### PR TITLE
Normalized Vector (logical refinement type)

### DIFF
--- a/vortex-array/src/arrays/extension/array.rs
+++ b/vortex-array/src/arrays/extension/array.rs
@@ -78,3 +78,93 @@ impl Array<Extension> {
         Self::try_new(ext_dtype, storage_array)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vortex_buffer::Buffer;
+
+    use super::*;
+    use crate::IntoArray;
+    use crate::arrays::ExtensionArray;
+    use crate::arrays::FixedSizeListArray;
+    use crate::arrays::PrimitiveArray;
+    use crate::dtype::Nullability;
+    use crate::dtype::PType;
+    use crate::dtype::extension::ExtId;
+    use crate::extension::EmptyMetadata;
+    use crate::scalar::ScalarValue;
+    use crate::validity::Validity;
+
+    #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+    struct TestExt;
+
+    impl ExtVTable for TestExt {
+        type Metadata = EmptyMetadata;
+        type NativeValue<'a> = &'a ScalarValue;
+
+        fn id(&self) -> ExtId {
+            ExtId::new("vortex.test.extension")
+        }
+
+        fn serialize_metadata(&self, _metadata: &Self::Metadata) -> VortexResult<Vec<u8>> {
+            Ok(Vec::new())
+        }
+
+        fn deserialize_metadata(&self, _metadata: &[u8]) -> VortexResult<Self::Metadata> {
+            Ok(EmptyMetadata)
+        }
+
+        fn validate_dtype(_ext_dtype: &ExtDType<Self>) -> VortexResult<()> {
+            Ok(())
+        }
+
+        fn unpack_native<'a>(
+            _ext_dtype: &'a ExtDType<Self>,
+            storage_value: &'a ScalarValue,
+        ) -> VortexResult<Self::NativeValue<'a>> {
+            Ok(storage_value)
+        }
+    }
+
+    fn fsl_dtype(element_nullability: Nullability, list_nullability: Nullability) -> DType {
+        DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, element_nullability)),
+            2,
+            list_nullability,
+        )
+    }
+
+    #[test]
+    fn extension_storage_allows_outer_nullability_mismatch() -> VortexResult<()> {
+        let ext_dtype = ExtDType::<TestExt>::try_new(
+            EmptyMetadata,
+            fsl_dtype(Nullability::NonNullable, Nullability::NonNullable),
+        )?
+        .erased();
+
+        let elements = PrimitiveArray::from_iter([1.0f32, 0.0]).into_array();
+        let storage = FixedSizeListArray::try_new(elements, 2, Validity::AllValid, 1)?.into_array();
+
+        ExtensionArray::try_new(ext_dtype, storage)?;
+        Ok(())
+    }
+
+    #[test]
+    fn extension_storage_rejects_nested_nullability_mismatch() -> VortexResult<()> {
+        let ext_dtype = ExtDType::<TestExt>::try_new(
+            EmptyMetadata,
+            fsl_dtype(Nullability::NonNullable, Nullability::NonNullable),
+        )?
+        .erased();
+
+        let elements =
+            PrimitiveArray::new(Buffer::copy_from([1.0f32, 0.0]), Validity::AllValid).into_array();
+        let storage =
+            FixedSizeListArray::try_new(elements, 2, Validity::NonNullable, 1)?.into_array();
+
+        assert!(ExtensionArray::try_new(ext_dtype, storage).is_err());
+        Ok(())
+    }
+}

--- a/vortex-tensor/public-api.lock
+++ b/vortex-tensor/public-api.lock
@@ -250,6 +250,64 @@ pub type vortex_tensor::matcher::AnyTensor::Match<'a> = vortex_tensor::matcher::
 
 pub fn vortex_tensor::matcher::AnyTensor::try_match<'a>(ext_dtype: &'a vortex_array::dtype::extension::erased::ExtDTypeRef) -> core::option::Option<Self::Match>
 
+pub mod vortex_tensor::normalized_vector
+
+pub struct vortex_tensor::normalized_vector::AnyNormalizedVector
+
+impl vortex_array::dtype::extension::matcher::Matcher for vortex_tensor::normalized_vector::AnyNormalizedVector
+
+pub type vortex_tensor::normalized_vector::AnyNormalizedVector::Match<'a> = vortex_tensor::vector::VectorMatcherMetadata
+
+pub fn vortex_tensor::normalized_vector::AnyNormalizedVector::try_match<'a>(ext_dtype: &'a vortex_array::dtype::extension::erased::ExtDTypeRef) -> core::option::Option<Self::Match>
+
+pub struct vortex_tensor::normalized_vector::NormalizedVector
+
+impl vortex_tensor::normalized_vector::NormalizedVector
+
+pub unsafe fn vortex_tensor::normalized_vector::NormalizedVector::new_unchecked(storage: vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+
+pub fn vortex_tensor::normalized_vector::NormalizedVector::try_new(storage: vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+
+impl core::clone::Clone for vortex_tensor::normalized_vector::NormalizedVector
+
+pub fn vortex_tensor::normalized_vector::NormalizedVector::clone(&self) -> vortex_tensor::normalized_vector::NormalizedVector
+
+impl core::cmp::Eq for vortex_tensor::normalized_vector::NormalizedVector
+
+impl core::cmp::PartialEq for vortex_tensor::normalized_vector::NormalizedVector
+
+pub fn vortex_tensor::normalized_vector::NormalizedVector::eq(&self, other: &vortex_tensor::normalized_vector::NormalizedVector) -> bool
+
+impl core::default::Default for vortex_tensor::normalized_vector::NormalizedVector
+
+pub fn vortex_tensor::normalized_vector::NormalizedVector::default() -> vortex_tensor::normalized_vector::NormalizedVector
+
+impl core::fmt::Debug for vortex_tensor::normalized_vector::NormalizedVector
+
+pub fn vortex_tensor::normalized_vector::NormalizedVector::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_tensor::normalized_vector::NormalizedVector
+
+pub fn vortex_tensor::normalized_vector::NormalizedVector::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::StructuralPartialEq for vortex_tensor::normalized_vector::NormalizedVector
+
+impl vortex_array::dtype::extension::vtable::ExtVTable for vortex_tensor::normalized_vector::NormalizedVector
+
+pub type vortex_tensor::normalized_vector::NormalizedVector::Metadata = vortex_array::extension::EmptyMetadata
+
+pub type vortex_tensor::normalized_vector::NormalizedVector::NativeValue<'a> = &'a vortex_array::scalar::scalar_value::ScalarValue
+
+pub fn vortex_tensor::normalized_vector::NormalizedVector::deserialize_metadata(&self, _metadata: &[u8]) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_tensor::normalized_vector::NormalizedVector::id(&self) -> vortex_array::dtype::extension::ExtId
+
+pub fn vortex_tensor::normalized_vector::NormalizedVector::serialize_metadata(&self, _metadata: &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
+
+pub fn vortex_tensor::normalized_vector::NormalizedVector::unpack_native<'a>(_ext_dtype: &'a vortex_array::dtype::extension::typed::ExtDType<Self>, storage_value: &'a vortex_array::scalar::scalar_value::ScalarValue) -> vortex_error::VortexResult<Self::NativeValue>
+
+pub fn vortex_tensor::normalized_vector::NormalizedVector::validate_dtype(ext_dtype: &vortex_array::dtype::extension::typed::ExtDType<Self>) -> vortex_error::VortexResult<()>
+
 pub mod vortex_tensor::scalar_fns
 
 pub mod vortex_tensor::scalar_fns::cosine_similarity
@@ -381,8 +439,6 @@ pub fn vortex_tensor::scalar_fns::l2_denorm::L2Denorm::return_dtype(&self, _opti
 pub fn vortex_tensor::scalar_fns::l2_denorm::L2Denorm::validity(&self, _options: &Self::Options, expression: &vortex_array::expr::expression::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::expression::Expression>>
 
 pub fn vortex_tensor::scalar_fns::l2_denorm::normalize_as_l2_denorm(input: vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::scalar_fn::vtable::ScalarFnArray>
-
-pub fn vortex_tensor::scalar_fns::l2_denorm::validate_l2_normalized_rows_against_norms(normalized: &vortex_array::array::erased::ArrayRef, norms: core::option::Option<&vortex_array::array::erased::ArrayRef>, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<()>
 
 pub mod vortex_tensor::scalar_fns::l2_norm
 
@@ -574,7 +630,9 @@ pub fn vortex_tensor::vector::VectorMatcherMetadata::dimensions(&self) -> u32
 
 pub fn vortex_tensor::vector::VectorMatcherMetadata::element_ptype(&self) -> vortex_array::dtype::ptype::PType
 
-pub fn vortex_tensor::vector::VectorMatcherMetadata::try_new(element_ptype: vortex_array::dtype::ptype::PType, dimensions: u32) -> vortex_error::VortexResult<Self>
+pub fn vortex_tensor::vector::VectorMatcherMetadata::is_normalized(&self) -> bool
+
+pub fn vortex_tensor::vector::VectorMatcherMetadata::try_new(element_ptype: vortex_array::dtype::ptype::PType, dimensions: u32, is_normalized: bool) -> vortex_error::VortexResult<Self>
 
 impl core::clone::Clone for vortex_tensor::vector::VectorMatcherMetadata
 

--- a/vortex-tensor/src/encodings/l2_denorm.rs
+++ b/vortex-tensor/src/encodings/l2_denorm.rs
@@ -14,8 +14,9 @@ use vortex_compressor::scheme::Scheme;
 use vortex_compressor::stats::ArrayAndStats;
 use vortex_error::VortexResult;
 
-use crate::matcher::AnyTensor;
+use crate::normalized_vector::AnyNormalizedVector;
 use crate::scalar_fns::l2_denorm::normalize_as_l2_denorm;
+use crate::types::vector::AnyVector;
 
 #[derive(Debug)]
 pub struct L2DenormScheme;
@@ -26,10 +27,11 @@ impl Scheme for L2DenormScheme {
     }
 
     fn matches(&self, canonical: &Canonical) -> bool {
-        matches!(
-            canonical,
-            Canonical::Extension(ext) if ext.ext_dtype().is::<AnyTensor>()
-        )
+        let Canonical::Extension(ext) = canonical else {
+            return false;
+        };
+
+        ext.ext_dtype().is::<AnyVector>() && !ext.ext_dtype().is::<AnyNormalizedVector>()
     }
 
     fn expected_compression_ratio(
@@ -38,6 +40,7 @@ impl Scheme for L2DenormScheme {
         _compress_ctx: CompressorContext,
         _exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
+        // We almost always want to pre-normalize our data if the vector is not already normalized.
         CompressionEstimate::Verdict(EstimateVerdict::AlwaysUse)
     }
 
@@ -50,5 +53,64 @@ impl Scheme for L2DenormScheme {
     ) -> VortexResult<ArrayRef> {
         let l2_denorm = normalize_as_l2_denorm(data.array().clone(), exec_ctx)?;
         Ok(l2_denorm.into_array())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vortex_array::Canonical;
+    use vortex_array::IntoArray;
+    use vortex_array::arrays::ExtensionArray;
+    use vortex_array::arrays::FixedSizeListArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::dtype::DType;
+    use vortex_array::dtype::Nullability;
+    use vortex_array::dtype::PType;
+    use vortex_array::dtype::extension::ExtDType;
+    use vortex_array::extension::EmptyMetadata;
+    use vortex_array::validity::Validity;
+    use vortex_compressor::scheme::Scheme;
+    use vortex_error::VortexResult;
+
+    use super::L2DenormScheme;
+    use crate::types::fixed_shape::FixedShapeTensor;
+    use crate::types::fixed_shape::FixedShapeTensorMetadata;
+    use crate::types::vector::Vector;
+
+    fn fsl_storage(elements: &[f32], list_size: u32) -> VortexResult<FixedSizeListArray> {
+        let len = elements.len() / list_size as usize;
+        let elements = PrimitiveArray::from_iter(elements.iter().copied()).into_array();
+        FixedSizeListArray::try_new(elements, list_size, Validity::NonNullable, len)
+    }
+
+    #[test]
+    fn matches_vector() -> VortexResult<()> {
+        let fsl = fsl_storage(&[1.0, 0.0], 2)?;
+        let ext_dtype = ExtDType::<Vector>::try_new(EmptyMetadata, fsl.dtype().clone())?.erased();
+        let canonical = Canonical::Extension(ExtensionArray::new(ext_dtype, fsl.into_array()));
+
+        assert!(L2DenormScheme.matches(&canonical));
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_fixed_shape_tensor() -> VortexResult<()> {
+        let fsl = fsl_storage(&[1.0, 0.0, 0.0, 1.0], 4)?;
+        let storage_dtype = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, Nullability::NonNullable)),
+            4,
+            Nullability::NonNullable,
+        );
+        let ext_dtype = ExtDType::<FixedShapeTensor>::try_new(
+            FixedShapeTensorMetadata::new(vec![2, 2]),
+            storage_dtype,
+        )?
+        .erased();
+        let canonical = Canonical::Extension(ExtensionArray::new(ext_dtype, fsl.into_array()));
+
+        assert!(!L2DenormScheme.matches(&canonical));
+        Ok(())
     }
 }

--- a/vortex-tensor/src/encodings/turboquant/centroids.rs
+++ b/vortex-tensor/src/encodings/turboquant/centroids.rs
@@ -36,7 +36,7 @@ static CENTROID_CACHE: LazyLock<DashMap<(u32, u8), Buffer<f32>>> = LazyLock::new
 /// Returns `2^bit_width` centroids sorted in ascending order, representing optimal scalar
 /// quantization levels for the coordinate distribution after random rotation in
 /// `dimension`-dimensional space.
-pub fn get_centroids(dimension: u32, bit_width: u8) -> VortexResult<Buffer<f32>> {
+pub fn compute_or_get_centroids(dimension: u32, bit_width: u8) -> VortexResult<Buffer<f32>> {
     vortex_ensure!(
         (1..=MAX_BIT_WIDTH).contains(&bit_width),
         "TurboQuant bit_width must be 1-{}, got {bit_width}",
@@ -239,7 +239,7 @@ mod tests {
         #[case] bits: u8,
         #[case] expected: usize,
     ) -> VortexResult<()> {
-        let centroids = get_centroids(dim, bits)?;
+        let centroids = compute_or_get_centroids(dim, bits)?;
         assert_eq!(centroids.len(), expected);
         Ok(())
     }
@@ -251,7 +251,7 @@ mod tests {
     #[case(128, 4)]
     #[case(768, 2)]
     fn centroids_are_sorted(#[case] dim: u32, #[case] bits: u8) -> VortexResult<()> {
-        let centroids = get_centroids(dim, bits)?;
+        let centroids = compute_or_get_centroids(dim, bits)?;
         for window in centroids.windows(2) {
             assert!(
                 window[0] < window[1],
@@ -268,7 +268,7 @@ mod tests {
     #[case(256, 2)]
     #[case(768, 2)]
     fn centroids_are_symmetric(#[case] dim: u32, #[case] bits: u8) -> VortexResult<()> {
-        let centroids = get_centroids(dim, bits)?;
+        let centroids = compute_or_get_centroids(dim, bits)?;
         let count = centroids.len();
         for idx in 0..count / 2 {
             let diff = (centroids[idx] + centroids[count - 1 - idx]).abs();
@@ -287,7 +287,7 @@ mod tests {
     #[case(128, 1)]
     #[case(128, 4)]
     fn centroids_within_bounds(#[case] dim: u32, #[case] bits: u8) -> VortexResult<()> {
-        let centroids = get_centroids(dim, bits)?;
+        let centroids = compute_or_get_centroids(dim, bits)?;
         for &val in centroids.iter() {
             assert!(
                 (-1.0..=1.0).contains(&val),
@@ -299,15 +299,15 @@ mod tests {
 
     #[test]
     fn centroids_cached() -> VortexResult<()> {
-        let c1 = get_centroids(128, 2)?;
-        let c2 = get_centroids(128, 2)?;
+        let c1 = compute_or_get_centroids(128, 2)?;
+        let c2 = compute_or_get_centroids(128, 2)?;
         assert_eq!(c1, c2);
         Ok(())
     }
 
     #[test]
     fn find_nearest_basic() -> VortexResult<()> {
-        let centroids = get_centroids(128, 2)?;
+        let centroids = compute_or_get_centroids(128, 2)?;
         let boundaries = compute_centroid_boundaries(&centroids);
         assert_eq!(find_nearest_centroid(-1.0, &boundaries), 0);
 
@@ -324,9 +324,9 @@ mod tests {
 
     #[test]
     fn rejects_invalid_params() {
-        assert!(get_centroids(128, 0).is_err());
-        assert!(get_centroids(128, 9).is_err());
-        assert!(get_centroids(1, 2).is_err());
-        assert!(get_centroids(127, 2).is_err());
+        assert!(compute_or_get_centroids(128, 0).is_err());
+        assert!(compute_or_get_centroids(128, 9).is_err());
+        assert!(compute_or_get_centroids(1, 2).is_err());
+        assert!(compute_or_get_centroids(127, 2).is_err());
     }
 }

--- a/vortex-tensor/src/encodings/turboquant/compress.rs
+++ b/vortex-tensor/src/encodings/turboquant/compress.rs
@@ -32,15 +32,15 @@ use vortex_error::vortex_ensure;
 use crate::encodings::turboquant::MAX_BIT_WIDTH;
 use crate::encodings::turboquant::MIN_DIMENSION;
 use crate::encodings::turboquant::centroids::compute_centroid_boundaries;
+use crate::encodings::turboquant::centroids::compute_or_get_centroids;
 use crate::encodings::turboquant::centroids::find_nearest_centroid;
-use crate::encodings::turboquant::centroids::get_centroids;
+use crate::normalized_vector::AnyNormalizedVector;
 use crate::scalar_fns::l2_denorm::L2Denorm;
 use crate::scalar_fns::l2_denorm::normalize_as_l2_denorm;
 use crate::scalar_fns::sorf_transform::SorfMatrix;
 use crate::scalar_fns::sorf_transform::SorfOptions;
 use crate::scalar_fns::sorf_transform::SorfTransform;
-use crate::types::vector::AnyVector;
-use crate::types::vector::Vector;
+use crate::types::normalized_vector::NormalizedVector;
 use crate::utils::cast_to_f32;
 
 /// Configuration for TurboQuant encoding.
@@ -48,8 +48,8 @@ use crate::utils::cast_to_f32;
 pub struct TurboQuantConfig {
     /// Bits per coordinate (1-8).
     pub bit_width: u8,
-    /// Optional seed for the rotation matrix. If None, the default seed is used.
-    pub seed: Option<u64>,
+    /// Seed for the rotation matrix.
+    pub seed: u64,
     /// Number of sign-diagonal + WHT rounds in the structured rotation (default 3).
     pub num_rounds: u8,
 }
@@ -58,7 +58,7 @@ impl Default for TurboQuantConfig {
     fn default() -> Self {
         Self {
             bit_width: MAX_BIT_WIDTH,
-            seed: Some(42),
+            seed: 42,
             num_rounds: 3,
         }
     }
@@ -80,8 +80,8 @@ impl Default for TurboQuantConfig {
 ///
 /// # Errors
 ///
-/// Returns an error if `input` is not a tensor-like extension array, if normalization fails, or
-/// if [`turboquant_encode_unchecked`] rejects the input shape.
+/// Returns an error if `input` is not a tensor-like extension array, if normalization fails, or if
+/// [`turboquant_encode_unchecked`] rejects the input shape.
 pub fn turboquant_encode(
     input: ArrayRef,
     config: &TurboQuantConfig,
@@ -89,6 +89,8 @@ pub fn turboquant_encode(
 ) -> VortexResult<ArrayRef> {
     // We must normalize the array before we can encode it with TurboQuant.
     let l2_denorm = normalize_as_l2_denorm(input, ctx)?;
+
+    // This is guaranteed to be a `NormalizedVector` extension type.
     let normalized = l2_denorm.child_at(0).clone();
     let norms = l2_denorm.child_at(1).clone();
     let num_rows = l2_denorm.len();
@@ -97,33 +99,30 @@ pub fn turboquant_encode(
         .as_opt::<Extension>()
         .vortex_expect("normalize_as_l2_denorm always produces an Extension array child");
 
-    // SAFETY: `normalize_as_l2_denorm` guarantees every row is unit-norm (or zero for null rows).
-    let tq = unsafe { turboquant_encode_unchecked(normalized_ext, config, ctx) }?;
+    let tq = turboquant_encode_normalized(normalized_ext, config, ctx)?;
 
     // SAFETY: TurboQuant is a lossy approximation of the normalized child, so we intentionally
-    // bypass the strict normalized-row validation when reattaching the stored norms.
+    // bypass the strict normalized-row and zero-row validation when reattaching the stored norms.
     Ok(unsafe { L2Denorm::new_array_unchecked(tq, norms, num_rows) }?.into_array())
 }
 
-/// Encode a non-nullable, L2-normalized [`Vector`](crate::vector::Vector) extension array into a
-/// `ScalarFnArray(SorfTransform, [FSL(Dict(codes, centroids))])`, without validating the unit-norm
-/// precondition.
-///
-/// # Safety
-///
-/// The caller must ensure:
-///
-/// - The input dtype is non-nullable.
-/// - Every row is L2-normalized (unit norm) or is a zero vector.
+/// Encode a non-nullable [`NormalizedVector`](crate::vector::NormalizedVector) extension array into
+/// a `ScalarFnArray(SorfTransform, [FSL(Dict(codes, centroids))])`, without validating the
+/// unit-norm precondition.
 ///
 /// Passing non-unit-norm vectors will not cause memory unsafety, but will produce silently
 /// incorrect quantization results.
-pub unsafe fn turboquant_encode_unchecked(
+pub fn turboquant_encode_normalized(
     ext: ArrayView<Extension>,
     config: &TurboQuantConfig,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let ext_dtype = ext.dtype().clone();
+
+    let vector_metadata = ext_dtype.as_extension().metadata::<AnyNormalizedVector>();
+    let element_ptype = vector_metadata.element_ptype();
+    let dimensions = vector_metadata.dimensions();
+
     let storage = ext.storage_array();
     let fsl = storage.clone().execute::<FixedSizeListArray>(ctx)?;
 
@@ -132,20 +131,21 @@ pub unsafe fn turboquant_encode_unchecked(
         "bit_width must be 1-{MAX_BIT_WIDTH}, got {}",
         config.bit_width
     );
-    let dimension = fsl.list_size();
     vortex_ensure!(
-        dimension >= MIN_DIMENSION,
-        "TurboQuant requires dimension >= {MIN_DIMENSION}, got {dimension}",
+        dimensions >= MIN_DIMENSION,
+        "TurboQuant requires dimension >= {MIN_DIMENSION}, got {dimensions}",
     );
 
-    let vector_metadata = ext_dtype.as_extension().metadata::<AnyVector>();
-    let element_ptype = vector_metadata.element_ptype();
-
-    let seed = config.seed.unwrap_or(42);
     let num_rows = fsl.len();
+    let sorf_options = SorfOptions {
+        seed: config.seed,
+        num_rounds: config.num_rounds,
+        dimensions,
+        element_ptype,
+    };
 
     if fsl.is_empty() {
-        let padded_dim = dimension.next_power_of_two();
+        let padded_dim = dimensions.next_power_of_two();
         let empty_codes = PrimitiveArray::empty::<u8>(Nullability::NonNullable);
         let empty_centroids = PrimitiveArray::empty::<f32>(Nullability::NonNullable);
         let empty_dict =
@@ -156,77 +156,128 @@ pub unsafe fn turboquant_encode_unchecked(
             Validity::NonNullable,
             0,
         )?;
-        let empty_padded_vector = Vector::try_new_vector_array(empty_fsl.into_array())?;
+        // SAFETY: An empty FSL contains no rows, so the unit-norm-or-zero invariant holds
+        // vacuously.
+        let empty_padded_vector =
+            unsafe { NormalizedVector::new_unchecked(empty_fsl.into_array()) }?;
 
-        let sorf_options = SorfOptions {
-            seed,
-            num_rounds: config.num_rounds,
-            dimension,
-            element_ptype,
-        };
         return Ok(
             SorfTransform::try_new_array(&sorf_options, empty_padded_vector, 0)?.into_array(),
         );
     }
 
-    let core = turboquant_quantize_core(&fsl, seed, config.bit_width, config.num_rounds, ctx)?;
-    let quantized_fsl =
-        build_quantized_fsl(num_rows, core.all_indices, core.centroids, core.padded_dim)?;
-    let padded_vector = Vector::try_new_vector_array(quantized_fsl)?;
+    let quantized_fsl = turboquant_quantize_fsl(&fsl, config.bit_width, &sorf_options, ctx)?;
 
-    let sorf_options = SorfOptions {
-        seed,
-        num_rounds: config.num_rounds,
-        dimension,
-        element_ptype,
-    };
+    // NB: The quantized rows are approximately unit-norm by construction; downstream callers
+    // (notably the enclosing `L2Denorm` wrapper) treat the stored-norm + NormalizedVector claim as
+    // authoritative rather than decode-verified.
+
+    // SAFETY: TurboQuant is a lossy approximation of the already-unit-norm input.
+    let padded_vector = unsafe { NormalizedVector::new_unchecked(quantized_fsl) }?;
+
     Ok(SorfTransform::try_new_array(&sorf_options, padded_vector, num_rows)?.into_array())
 }
 
-/// Shared intermediate results from the quantization loop.
-struct QuantizationResult {
-    centroids: Buffer<f32>,
-    all_indices: Buffer<u8>,
-    padded_dim: usize,
-}
-
-/// Core quantization: rotate and quantize already-normalized rows.
+/// Rotate and quantize already-normalized rows into a dict-encoded `FixedSizeList`.
 ///
-/// The input `fsl` must contain non-nullable, unit-norm vectors (already L2-normalized). Null
-/// vectors are not supported and must be zeroed out before reaching this function. The rotation
-/// and centroid lookup happen in f32.
-fn turboquant_quantize_core(
+/// The input `fsl` must contain non-nullable, unit-norm vectors of float values (already
+/// L2-normalized). Null vectors are not supported and must be zeroed out before reaching this
+/// function. The rotation and centroid lookup happen in f32.
+///
+/// The returned array is `FSL(DictArray(codes, centroids), padded_dim)`. The `FixedSizeList` has
+/// Dict-encoded elements, where each row of `padded_dim` u8 codes indexes into the centroid
+/// codebook.
+///
+/// This allows the FSL (via the Dict-encodede elements) to be independently sliced, taken, or
+/// executed (dequantized) without knowledge of the rotation.
+///
+/// Internally, this function will:
+///
+/// 1. Builds a [`SorfMatrix`] structured rotation from the seed/rounds in `sorf_options`.
+/// 2. For each row, zero-pads to the next power of 2, applies the rotation, and maps each rotated
+///    coordinate to its nearest centroid index via binary search on precomputed boundaries.
+/// 3. Packs the per-row centroid indices and the shared centroid codebook into a `DictArray`-backed
+///    `FixedSizeListArray`.
+fn turboquant_quantize_fsl(
     fsl: &FixedSizeListArray,
-    seed: u64,
     bit_width: u8,
-    num_rounds: u8,
+    sorf_options: &SorfOptions,
     ctx: &mut ExecutionCtx,
-) -> VortexResult<QuantizationResult> {
-    let dimension = fsl.list_size() as usize;
+) -> VortexResult<ArrayRef> {
+    let dimensions = fsl.list_size() as usize;
     let num_rows = fsl.len();
 
-    let rotation = SorfMatrix::try_new(seed, dimension, num_rounds as usize)?;
+    vortex_ensure!(!fsl.dtype().is_nullable());
+
+    let rotation = SorfMatrix::try_new(
+        sorf_options.seed,
+        dimensions,
+        sorf_options.num_rounds as usize,
+    )?;
     let padded_dim = rotation.padded_dim();
     let padded_dim_u32 =
         u32::try_from(padded_dim).vortex_expect("padded_dim stays representable as u32");
 
+    // Compute the centroids for the given (dimension, bit_width) combination (or retrieve it from a
+    // previous computation)
+    let centroids = compute_or_get_centroids(padded_dim_u32, bit_width)?;
+
+    // Extract out the elements of the FSL and cast to f32. In the f64 case, we intentionally lose
+    // information here because we are already going to be quantizing to a smaller set of centroids,
+    // so we are fine with this loss.
     let elements_prim: PrimitiveArray = fsl.elements().clone().execute(ctx)?;
     let f32_elements = cast_to_f32(elements_prim)?;
 
-    let centroids = get_centroids(padded_dim_u32, bit_width)?;
-    let boundaries = compute_centroid_boundaries(&centroids);
+    // Take the float values and quantize by finding the closest centroid in the codebook to each
+    // and recording the index of that centroid.
+    let all_indices = rotate_and_quantize(
+        f32_elements.as_slice(),
+        num_rows,
+        dimensions,
+        &rotation,
+        &centroids,
+    );
+
+    // Build the Dict-encoded FSL from the centroid indices and codebook. Everything is non-null
+    // since our input in non-null.
+    let codes = PrimitiveArray::new::<u8>(all_indices, Validity::NonNullable);
+    let values = PrimitiveArray::new::<f32>(centroids, Validity::NonNullable);
+    let dict = DictArray::try_new(codes.into_array(), values.into_array())?;
+
+    Ok(FixedSizeListArray::try_new(
+        dict.into_array(),
+        padded_dim_u32,
+        Validity::NonNullable,
+        num_rows,
+    )?
+    .into_array())
+}
+
+/// Rotate each row via the structured rotation and quantize every rotated coordinate to its nearest
+/// centroid index via binary search on precomputed boundaries.
+///
+/// Returns a flat [`Buffer<u8>`] of length `num_rows * padded_dim` containing the per-coordinate
+/// centroid indices.
+fn rotate_and_quantize(
+    f32_slice: &[f32],
+    num_rows: usize,
+    dimensions: usize,
+    rotation: &SorfMatrix,
+    centroids: &[f32],
+) -> Buffer<u8> {
+    let padded_dim = rotation.padded_dim();
+    let boundaries = compute_centroid_boundaries(centroids);
 
     let mut all_indices = BufferMut::<u8>::with_capacity(num_rows * padded_dim);
     let mut padded = vec![0.0f32; padded_dim];
     let mut rotated = vec![0.0f32; padded_dim];
 
-    let f32_slice = f32_elements.as_slice();
     for row in 0..num_rows {
-        let x = &f32_slice[row * dimension..(row + 1) * dimension];
+        let x = &f32_slice[row * dimensions..][..dimensions];
 
         // Zero-pad to the next power of 2.
-        padded[..dimension].copy_from_slice(x);
-        padded[dimension..].fill(0.0);
+        padded[..dimensions].copy_from_slice(x);
+        padded[dimensions..].fill(0.0);
 
         rotation.rotate(&padded, &mut rotated);
 
@@ -235,36 +286,5 @@ fn turboquant_quantize_core(
         }
     }
 
-    Ok(QuantizationResult {
-        centroids,
-        all_indices: all_indices.freeze(),
-        padded_dim,
-    })
-}
-
-/// Build a quantized representation: `FSL(DictArray(codes, centroids), padded_dim)`.
-///
-/// This is a Dict-encoded FixedSizeList where each row of `padded_dim` u8 codes indexes into the
-/// centroid codebook. The Dict can be independently sliced, taken, or executed (dequantized)
-/// without knowledge of the rotation.
-fn build_quantized_fsl(
-    num_rows: usize,
-    all_indices: Buffer<u8>,
-    centroids: Buffer<f32>,
-    padded_dim: usize,
-) -> VortexResult<ArrayRef> {
-    let codes = PrimitiveArray::new::<u8>(all_indices, Validity::NonNullable);
-    let centroids_array = PrimitiveArray::new::<f32>(centroids, Validity::NonNullable);
-
-    let dict = DictArray::try_new(codes.into_array(), centroids_array.into_array())?;
-
-    let padded_dim_u32 =
-        u32::try_from(padded_dim).vortex_expect("padded_dim stays representable as u32");
-    Ok(FixedSizeListArray::try_new(
-        dict.into_array(),
-        padded_dim_u32,
-        Validity::NonNullable,
-        num_rows,
-    )?
-    .into_array())
+    all_indices.freeze()
 }

--- a/vortex-tensor/src/encodings/turboquant/mod.rs
+++ b/vortex-tensor/src/encodings/turboquant/mod.rs
@@ -134,7 +134,7 @@ pub(crate) mod compress;
 mod scheme;
 pub use compress::TurboQuantConfig;
 pub use compress::turboquant_encode;
-pub use compress::turboquant_encode_unchecked;
+pub use compress::turboquant_encode_normalized;
 pub use scheme::TurboQuantScheme;
 
 /// Minimum vector dimension for TurboQuant encoding.

--- a/vortex-tensor/src/encodings/turboquant/scheme.rs
+++ b/vortex-tensor/src/encodings/turboquant/scheme.rs
@@ -111,21 +111,25 @@ impl Scheme for TurboQuantScheme {
 fn estimate_compression_ratio(element_bit_width: u8, dimensions: u32, num_vectors: usize) -> f64 {
     let config = TurboQuantConfig::default();
     let padded_dim = dimensions.next_power_of_two() as usize;
+    let element_bits = usize::from(element_bit_width);
 
-    // Per-vector: MSE codes per padded coordinate, plus one stored norm in the input element
-    // float width.
-    let compressed_bits_per_vector =
-        usize::from(element_bit_width) + usize::from(config.bit_width) * padded_dim;
+    // Get the size of the fully uncompressed vector data.
+    let uncompressed_size_bits = element_bits * dimensions as usize * num_vectors;
+
+    // Per-vector: MSE codes per padded coordinate, plus one stored norm in the input element float
+    // width.
+    let norm_bits = element_bits;
+    let compressed_bits_per_vector = usize::from(config.bit_width) * padded_dim;
+    let total_bits_per_vector = norm_bits + compressed_bits_per_vector;
 
     // Shared overhead: codebook centroids (2^bit_width f32 values).
-    // Note: rotation signs are no longer stored — rotation is deterministic from seed.
     let num_centroids = 1usize << config.bit_width;
     debug_assert!(num_centroids <= MAX_CENTROIDS);
     let overhead_bits = num_centroids * 32; // centroids are always f32
 
-    let compressed_size_bits = compressed_bits_per_vector * num_vectors + overhead_bits;
+    // This includes the quantized vectors, norms, and centroid codebook.
+    let compressed_size_bits = total_bits_per_vector * num_vectors + overhead_bits;
 
-    let uncompressed_size_bits = usize::from(element_bit_width) * dimensions as usize * num_vectors;
     uncompressed_size_bits as f64 / compressed_size_bits as f64
 }
 

--- a/vortex-tensor/src/encodings/turboquant/tests/compute.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests/compute.rs
@@ -40,7 +40,7 @@ fn slice_preserves_data() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 4,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -85,7 +85,7 @@ fn scalar_at_matches_decompress() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 2,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -108,7 +108,7 @@ fn l2_norm_readthrough() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 5,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -146,7 +146,7 @@ fn l2_norm_readthrough_is_authoritative_for_lossy_storage() -> VortexResult<()> 
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 1,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -183,7 +183,7 @@ fn cosine_similarity_readthrough_is_authoritative_for_lossy_storage() -> VortexR
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 1,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();

--- a/vortex-tensor/src/encodings/turboquant/tests/nullable.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests/nullable.rs
@@ -23,7 +23,7 @@ fn nullable_vectors_roundtrip() -> VortexResult<()> {
 
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 4,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -84,7 +84,7 @@ fn nullable_norms_match_validity() -> VortexResult<()> {
 
     let config = TurboQuantConfig {
         bit_width: 2,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -114,7 +114,7 @@ fn nullable_l2_norm_readthrough() -> VortexResult<()> {
 
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -156,7 +156,7 @@ fn nullable_slice_preserves_validity() -> VortexResult<()> {
 
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 2,
     };
     let mut ctx = SESSION.create_execution_ctx();

--- a/vortex-tensor/src/encodings/turboquant/tests/roundtrip.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests/roundtrip.rs
@@ -13,7 +13,7 @@ use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
 
 use super::*;
-use crate::encodings::turboquant::turboquant_encode_unchecked;
+use crate::encodings::turboquant::turboquant_encode_normalized;
 use crate::scalar_fns::l2_denorm::normalize_as_l2_denorm;
 
 #[rstest]
@@ -28,7 +28,7 @@ fn roundtrip(#[case] dim: usize, #[case] bit_width: u8) -> VortexResult<()> {
     let fsl = make_fsl(10, dim, 42);
     let config = TurboQuantConfig {
         bit_width,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
@@ -48,7 +48,7 @@ fn mse_within_theoretical_bound(#[case] dim: usize, #[case] bit_width: u8) -> Vo
     let fsl = make_fsl(num_rows, dim, 42);
     let config = TurboQuantConfig {
         bit_width,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
@@ -75,7 +75,7 @@ fn high_bitwidth_mse_is_small(#[case] dim: usize, #[case] bit_width: u8) -> Vort
 
     let config_4bit = TurboQuantConfig {
         bit_width: 4,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let (original_4, decoded_4) = encode_decode(&fsl, &config_4bit)?;
@@ -83,7 +83,7 @@ fn high_bitwidth_mse_is_small(#[case] dim: usize, #[case] bit_width: u8) -> Vort
 
     let config = TurboQuantConfig {
         bit_width,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
@@ -107,7 +107,7 @@ fn mse_decreases_with_bits() -> VortexResult<()> {
     for bit_width in 1..=8u8 {
         let config = TurboQuantConfig {
             bit_width,
-            seed: Some(123),
+            seed: 123,
             num_rounds: 3,
         };
         let (original, decoded) = encode_decode(&fsl, &config)?;
@@ -129,7 +129,7 @@ fn roundtrip_edge_cases(#[case] num_rows: usize) -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 2,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -158,7 +158,7 @@ fn rejects_dimension_below_128(#[case] dim: usize) {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 2,
-        seed: Some(0),
+        seed: 0,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -173,7 +173,7 @@ fn rejects_invalid_bit_width(#[case] bit_width: u8) {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width,
-        seed: Some(0),
+        seed: 0,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -184,7 +184,7 @@ fn rejects_invalid_bit_width(#[case] bit_width: u8) {
     let normalized_ext = normalized
         .as_opt::<Extension>()
         .expect("normalized child should be Extension");
-    assert!(unsafe { turboquant_encode_unchecked(normalized_ext, &config, &mut ctx) }.is_err());
+    assert!(turboquant_encode_normalized(normalized_ext, &config, &mut ctx).is_err());
 }
 
 #[test]
@@ -203,7 +203,7 @@ fn all_zero_vectors_roundtrip() -> VortexResult<()> {
 
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(42),
+        seed: 42,
         num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
@@ -223,7 +223,7 @@ fn large_dimension_roundtrip(#[case] dim: usize, #[case] bit_width: u8) -> Vorte
     let fsl = make_fsl(num_rows, dim, 42);
     let config = TurboQuantConfig {
         bit_width,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
@@ -262,7 +262,7 @@ fn f64_input_encodes_successfully() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(42),
+        seed: 42,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -295,7 +295,7 @@ fn f16_input_encodes_successfully() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(42),
+        seed: 42,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();

--- a/vortex-tensor/src/encodings/turboquant/tests/structural.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests/structural.rs
@@ -20,7 +20,7 @@ fn stored_centroids_match_computed() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -30,7 +30,7 @@ fn stored_centroids_match_computed() -> VortexResult<()> {
     let stored = centroids.as_slice::<f32>();
 
     // padded_dim for dim=128 is 128.
-    let computed = crate::encodings::turboquant::centroids::get_centroids(128, 3)?;
+    let computed = crate::encodings::turboquant::centroids::compute_or_get_centroids(128, 3)?;
 
     assert_eq!(stored.len(), computed.len());
     for i in 0..stored.len() {
@@ -46,7 +46,7 @@ fn seed_deterministic_rotation_produces_correct_decode() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 4,
     };
 
@@ -90,7 +90,7 @@ fn encoded_dtype_is_vector_extension() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 2,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -115,7 +115,7 @@ fn cosine_similarity_quantized_accuracy() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 4,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -172,7 +172,7 @@ fn dot_product_quantized_accuracy() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 8,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -231,8 +231,8 @@ fn sorf_transform_roundtrip_isolation() -> VortexResult<()> {
     use vortex_buffer::BufferMut;
 
     use crate::encodings::turboquant::centroids::compute_centroid_boundaries;
+    use crate::encodings::turboquant::centroids::compute_or_get_centroids;
     use crate::encodings::turboquant::centroids::find_nearest_centroid;
-    use crate::encodings::turboquant::centroids::get_centroids;
     use crate::scalar_fns::sorf_transform::SorfMatrix;
     use crate::scalar_fns::sorf_transform::SorfOptions;
     use crate::scalar_fns::sorf_transform::SorfTransform;
@@ -261,7 +261,7 @@ fn sorf_transform_roundtrip_isolation() -> VortexResult<()> {
     // Forward transform + quantize (mimicking what turboquant_quantize_core does).
     let rotation = SorfMatrix::try_new(seed, dim, num_rounds as usize)?;
     let padded_dim = rotation.padded_dim();
-    let centroids = get_centroids(padded_dim as u32, 8)?;
+    let centroids = compute_or_get_centroids(padded_dim as u32, 8)?;
     let boundaries = compute_centroid_boundaries(&centroids);
 
     let mut all_indices = BufferMut::<u8>::with_capacity(num_rows * padded_dim);
@@ -299,7 +299,7 @@ fn sorf_transform_roundtrip_isolation() -> VortexResult<()> {
     let sorf_options = SorfOptions {
         seed,
         num_rounds,
-        dimension: dim as u32,
+        dimensions: dim as u32,
         element_ptype: vortex_array::dtype::PType::F32,
     };
     let sorf_array =

--- a/vortex-tensor/src/lib.rs
+++ b/vortex-tensor/src/lib.rs
@@ -17,6 +17,7 @@ use crate::scalar_fns::l2_denorm::L2Denorm;
 use crate::scalar_fns::l2_norm::L2Norm;
 use crate::scalar_fns::sorf_transform::SorfTransform;
 use crate::types::fixed_shape::FixedShapeTensor;
+use crate::types::normalized_vector::NormalizedVector;
 use crate::types::vector::Vector;
 
 pub mod matcher;
@@ -25,6 +26,7 @@ pub mod scalar_fns;
 mod types;
 
 pub use types::fixed_shape;
+pub use types::normalized_vector;
 pub use types::vector;
 
 pub mod encodings;
@@ -43,6 +45,7 @@ pub const SCALAR_FN_ARRAY_TENSOR_PLUGIN_ENV: &str = "VX_SCALAR_FN_ARRAY_TENSOR_P
 /// Initialize the Vortex tensor library with a Vortex session.
 pub fn initialize(session: &VortexSession) {
     session.dtypes().register(Vector);
+    session.dtypes().register(NormalizedVector);
     session.dtypes().register(FixedShapeTensor);
 
     let session_fns = session.scalar_fns();

--- a/vortex-tensor/src/scalar_fns/cosine_similarity.rs
+++ b/vortex-tensor/src/scalar_fns/cosine_similarity.rs
@@ -33,12 +33,10 @@ use vortex_buffer::Buffer;
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
 
-use crate::scalar_fns::inner_product::BinaryTensorOpMetadata;
 use crate::scalar_fns::inner_product::InnerProduct;
-use crate::scalar_fns::l2_denorm::DenormOrientation;
+use crate::scalar_fns::l2_denorm::NormalForm;
 use crate::scalar_fns::l2_denorm::try_build_constant_l2_denorm;
 use crate::scalar_fns::l2_norm::L2Norm;
-use crate::utils::extract_l2_denorm_children;
 use crate::utils::validate_binary_tensor_float_inputs;
 
 /// Cosine similarity between two columns.
@@ -115,7 +113,7 @@ impl ScalarFnVTable for CosineSimilarity {
         let lhs = &arg_dtypes[0];
         let rhs = &arg_dtypes[1];
 
-        let tensor_match = validate_binary_tensor_float_inputs("CosineSimilarity", lhs, rhs)?;
+        let tensor_match = validate_binary_tensor_float_inputs(lhs, rhs)?;
         let ptype = tensor_match.element_ptype();
         let nullability = Nullability::from(lhs.is_nullable() || rhs.is_nullable());
         Ok(DType::Primitive(ptype, nullability))
@@ -141,15 +139,21 @@ impl ScalarFnVTable for CosineSimilarity {
             rhs_ref = sfn.into_array();
         }
 
-        // Take any L2Denorm-wrapped fast path that applies.
-        match DenormOrientation::classify(&lhs_ref, &rhs_ref) {
-            DenormOrientation::Both { lhs, rhs } => {
-                return self.execute_both_denorm(lhs, rhs, len);
+        // Classify each operand by its normal form. When both operands carry a known unit-norm
+        // representation, cosine similarity collapses to the dot product of the unit vectors.
+        let lhs_form = NormalForm::classify(&lhs_ref);
+        let rhs_form = NormalForm::classify(&rhs_ref);
+        match (lhs_form.normalized_array(), rhs_form.normalized_array()) {
+            (Some(unit_lhs), Some(unit_rhs)) => {
+                return self.execute_both_unit(unit_lhs, unit_rhs, &lhs_ref, &rhs_ref, len);
             }
-            DenormOrientation::One { denorm, plain } => {
-                return self.execute_one_denorm(denorm, plain, len, ctx);
+            (Some(unit_lhs), None) => {
+                return self.execute_one_unit(unit_lhs, &rhs_ref, &lhs_ref, len, ctx);
             }
-            DenormOrientation::Neither => {}
+            (None, Some(unit_rhs)) => {
+                return self.execute_one_unit(unit_rhs, &lhs_ref, &rhs_ref, len, ctx);
+            }
+            (None, None) => {}
         }
 
         // Compute combined validity.
@@ -227,13 +231,8 @@ impl ScalarFnArrayVTable for CosineSimilarity {
         children: &dyn ArrayChildren,
         session: &VortexSession,
     ) -> VortexResult<ScalarFnArrayParts<Self>> {
-        let reconstructed = BinaryTensorOpMetadata::decode_children(
-            metadata,
-            len,
-            children,
-            session,
-            "CosineSimilarity",
-        )?;
+        let reconstructed =
+            BinaryTensorOpMetadata::decode_children(metadata, len, children, session)?;
         Ok(ScalarFnArrayParts {
             options: EmptyOptions,
             children: reconstructed,
@@ -242,22 +241,20 @@ impl ScalarFnArrayVTable for CosineSimilarity {
 }
 
 impl CosineSimilarity {
-    /// Both sides are `L2Denorm`: treat the normalized children as authoritative, so
-    /// `cosine_similarity = dot(n_l, n_r)`.
-    fn execute_both_denorm(
+    /// Both sides carry a known unit-norm representation: cosine similarity collapses to the
+    /// dot product of the unit children.
+    fn execute_both_unit(
         &self,
+        unit_lhs: &ArrayRef,
+        unit_rhs: &ArrayRef,
         lhs_ref: &ArrayRef,
         rhs_ref: &ArrayRef,
         len: usize,
     ) -> VortexResult<ArrayRef> {
         let validity = lhs_ref.validity()?.and(rhs_ref.validity()?)?;
 
-        let (normalized_l, _) = extract_l2_denorm_children(lhs_ref);
-        let (normalized_r, _) = extract_l2_denorm_children(rhs_ref);
-
-        // `L2Denorm` makes the normalized children authoritative, so their dot product is the
-        // cosine similarity even for lossy storage wrappers.
-        let dot = InnerProduct::try_new_array(normalized_l, normalized_r, len)?.into_array();
+        let dot =
+            InnerProduct::try_new_array(unit_lhs.clone(), unit_rhs.clone(), len)?.into_array();
 
         if !matches!(validity, Validity::NonNullable) {
             // Masking always changes the nullability to nullable.
@@ -267,22 +264,21 @@ impl CosineSimilarity {
         }
     }
 
-    /// One side is `L2Denorm`: treat the normalized child as authoritative, so
-    /// `cosine_similarity = dot(n, b) / ||b||`.
-    ///
-    /// The caller must pass the denorm array as `denorm_ref` and the plain array as `plain_ref`.
-    fn execute_one_denorm(
+    /// Exactly one side carries a unit-norm representation: cosine similarity reduces to
+    /// `dot(unit, other) / ||other||`. The norms of the unit side are implicitly `1.0` (naked
+    /// `NormalizedVector`) or stored separately (the outer `L2Denorm` wrapper, which is not
+    /// needed here since cosine ignores magnitude).
+    fn execute_one_unit(
         &self,
-        denorm_ref: &ArrayRef,
+        unit: &ArrayRef,
         plain_ref: &ArrayRef,
+        unit_ref: &ArrayRef,
         len: usize,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let validity = denorm_ref.validity()?.and(plain_ref.validity()?)?;
+        let validity = unit_ref.validity()?.and(plain_ref.validity()?)?;
 
-        let (normalized, _) = extract_l2_denorm_children(denorm_ref);
-
-        let dot_arr = InnerProduct::try_new_array(normalized, plain_ref.clone(), len)?;
+        let dot_arr = InnerProduct::try_new_array(unit.clone(), plain_ref.clone(), len)?;
         let dot: PrimitiveArray = dot_arr.into_array().execute(ctx)?;
 
         let norm_arr = L2Norm::try_new_array(plain_ref.clone(), len)?;
@@ -331,6 +327,7 @@ mod tests {
     use crate::utils::test_helpers::assert_close;
     use crate::utils::test_helpers::constant_tensor_array;
     use crate::utils::test_helpers::l2_denorm_array;
+    use crate::utils::test_helpers::normalized_vector_array;
     use crate::utils::test_helpers::tensor_array;
     use crate::utils::test_helpers::vector_array;
 
@@ -519,13 +516,25 @@ mod tests {
         Ok(())
     }
 
+    /// Naked [`NormalizedVector`](crate::normalized_vector::NormalizedVector) operands take the
+    /// fast path: cosine similarity collapses to the dot product without computing norms.
+    #[test]
+    fn naked_normalized_vector_cosine() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let lhs = normalized_vector_array(2, &[0.6, 0.8, 1.0, 0.0], &mut ctx)?;
+        let rhs = normalized_vector_array(2, &[0.6, 0.8, 0.0, 1.0], &mut ctx)?;
+        // Row 0: identical -> 1.0, Row 1: orthogonal -> 0.0.
+        assert_close(&eval_cosine_similarity(lhs, rhs, 2)?, &[1.0, 0.0]);
+        Ok(())
+    }
+
     #[test]
     fn both_denorm_self_similarity() -> VortexResult<()> {
         // [3.0, 4.0] has norm 5.0, normalized [0.6, 0.8].
         // [1.0, 0.0] has norm 1.0, normalized [1.0, 0.0].
         let mut ctx = SESSION.create_execution_ctx();
-        let lhs = l2_denorm_array(&[2], &[0.6, 0.8, 1.0, 0.0], &[5.0, 1.0], &mut ctx)?;
-        let rhs = l2_denorm_array(&[2], &[0.6, 0.8, 1.0, 0.0], &[5.0, 1.0], &mut ctx)?;
+        let lhs = l2_denorm_array(2, &[0.6, 0.8, 1.0, 0.0], &[5.0, 1.0], &mut ctx)?;
+        let rhs = l2_denorm_array(2, &[0.6, 0.8, 1.0, 0.0], &[5.0, 1.0], &mut ctx)?;
 
         // Self-similarity should always be 1.0.
         assert_close(&eval_cosine_similarity(lhs, rhs, 2)?, &[1.0, 1.0]);
@@ -537,8 +546,8 @@ mod tests {
         // [3.0, 0.0] normalized [1.0, 0.0], norm 3.0.
         // [0.0, 4.0] normalized [0.0, 1.0], norm 4.0.
         let mut ctx = SESSION.create_execution_ctx();
-        let lhs = l2_denorm_array(&[2], &[1.0, 0.0], &[3.0], &mut ctx)?;
-        let rhs = l2_denorm_array(&[2], &[0.0, 1.0], &[4.0], &mut ctx)?;
+        let lhs = l2_denorm_array(2, &[1.0, 0.0], &[3.0], &mut ctx)?;
+        let rhs = l2_denorm_array(2, &[0.0, 1.0], &[4.0], &mut ctx)?;
 
         assert_close(&eval_cosine_similarity(lhs, rhs, 1)?, &[0.0]);
         Ok(())
@@ -548,8 +557,8 @@ mod tests {
     fn both_denorm_zero_norm() -> VortexResult<()> {
         // Zero-norm row: normalized is [0.0, 0.0], norm is 0.0.
         let mut ctx = SESSION.create_execution_ctx();
-        let lhs = l2_denorm_array(&[2], &[0.6, 0.8, 0.0, 0.0], &[5.0, 0.0], &mut ctx)?;
-        let rhs = l2_denorm_array(&[2], &[0.6, 0.8, 1.0, 0.0], &[5.0, 1.0], &mut ctx)?;
+        let lhs = l2_denorm_array(2, &[0.6, 0.8, 0.0, 0.0], &[5.0, 0.0], &mut ctx)?;
+        let rhs = l2_denorm_array(2, &[0.6, 0.8, 1.0, 0.0], &[5.0, 1.0], &mut ctx)?;
 
         // Row 0: dot([0.6, 0.8], [0.6, 0.8]) = 1.0, row 1: dot([0,0], [1,0]) = 0.0.
         assert_close(&eval_cosine_similarity(lhs, rhs, 2)?, &[1.0, 0.0]);
@@ -562,8 +571,8 @@ mod tests {
         // RHS is plain [3.0, 4.0].
         // cosine_similarity([3.0, 4.0], [3.0, 4.0]) = 1.0.
         let mut ctx = SESSION.create_execution_ctx();
-        let lhs = l2_denorm_array(&[2], &[0.6, 0.8], &[5.0], &mut ctx)?;
-        let rhs = tensor_array(&[2], &[3.0, 4.0])?;
+        let lhs = l2_denorm_array(2, &[0.6, 0.8], &[5.0], &mut ctx)?;
+        let rhs = vector_array(2, &[3.0, 4.0])?;
 
         assert_close(&eval_cosine_similarity(lhs, rhs, 1)?, &[1.0]);
         Ok(())
@@ -574,8 +583,8 @@ mod tests {
         // LHS is plain [1.0, 0.0], RHS is L2Denorm([0.6, 0.8], 5.0) representing [3.0, 4.0].
         // cosine_similarity([1.0, 0.0], [3.0, 4.0]) = 3.0 / (1.0 * 5.0) = 0.6.
         let mut ctx = SESSION.create_execution_ctx();
-        let lhs = tensor_array(&[2], &[1.0, 0.0])?;
-        let rhs = l2_denorm_array(&[2], &[0.6, 0.8], &[5.0], &mut ctx)?;
+        let lhs = vector_array(2, &[1.0, 0.0])?;
+        let rhs = l2_denorm_array(2, &[0.6, 0.8], &[5.0], &mut ctx)?;
 
         assert_close(&eval_cosine_similarity(lhs, rhs, 1)?, &[0.6]);
         Ok(())
@@ -585,9 +594,9 @@ mod tests {
     fn both_denorm_null_norms() -> VortexResult<()> {
         // Row 0: valid, row 1: null (via nullable norms on rhs).
         let mut ctx = SESSION.create_execution_ctx();
-        let lhs = l2_denorm_array(&[2], &[0.6, 0.8, 1.0, 0.0], &[5.0, 1.0], &mut ctx)?;
+        let lhs = l2_denorm_array(2, &[0.6, 0.8, 1.0, 0.0], &[5.0, 1.0], &mut ctx)?;
 
-        let normalized_r = tensor_array(&[2], &[0.6, 0.8, 1.0, 0.0])?;
+        let normalized_r = normalized_vector_array(2, &[0.6, 0.8, 1.0, 0.0], &mut ctx)?;
         let norms_r = PrimitiveArray::from_option_iter([Some(5.0f64), None]).into_array();
         let rhs = L2Denorm::try_new_array(normalized_r, norms_r, 2, &mut ctx)?.into_array();
 
@@ -700,6 +709,34 @@ mod tests {
             &eval_cosine_similarity(lhs, rhs, 4)?,
             &[1.0 / 3.0, 1.0, 2.0 / 3.0, 8.0 / 9.0],
         );
+        Ok(())
+    }
+
+    #[test]
+    fn serde_round_trip_mixed_vector_and_normalized_vector() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let lhs = normalized_vector_array(2, &[0.6, 0.8, 1.0, 0.0], &mut ctx)?;
+        let rhs = vector_array(2, &[3.0, 4.0, 0.0, 1.0])?;
+        let original = CosineSimilarity::try_new_array(lhs.clone(), rhs.clone(), 2)?.into_array();
+
+        let plugin = ScalarFnArrayPlugin::new(CosineSimilarity);
+        let metadata = plugin
+            .serialize(&original, &SESSION)?
+            .expect("CosineSimilarity serialize must produce metadata");
+
+        let children = vec![lhs, rhs];
+        let recovered = plugin.deserialize(
+            original.dtype(),
+            original.len(),
+            &metadata,
+            &[],
+            &children,
+            &SESSION,
+        )?;
+
+        assert_eq!(recovered.dtype(), original.dtype());
+        assert_eq!(recovered.len(), original.len());
+        assert_eq!(recovered.encoding_id(), original.encoding_id());
         Ok(())
     }
 

--- a/vortex-tensor/src/scalar_fns/inner_product.rs
+++ b/vortex-tensor/src/scalar_fns/inner_product.rs
@@ -31,7 +31,6 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
-use vortex_array::dtype::proto::dtype as pb;
 use vortex_array::expr::Expression;
 use vortex_array::expr::and;
 use vortex_array::match_each_float_ptype;
@@ -47,18 +46,17 @@ use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
-use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 
 use crate::matcher::AnyTensor;
-use crate::scalar_fns::l2_denorm::DenormOrientation;
+use crate::scalar_fns::l2_denorm::NormalForm;
 use crate::scalar_fns::sorf_transform::SorfMatrix;
 use crate::scalar_fns::sorf_transform::SorfTransform;
 use crate::types::vector::Vector;
+use crate::utils::BinaryTensorOpMetadata;
 use crate::utils::extract_constant_flat_row;
 use crate::utils::extract_flat_elements;
-use crate::utils::extract_l2_denorm_children;
 use crate::utils::validate_binary_tensor_float_inputs;
 
 /// Inner product (dot product) between two columns.
@@ -130,7 +128,7 @@ impl ScalarFnVTable for InnerProduct {
         let rhs = &arg_dtypes[1];
 
         // TODO(connor): relax the float-only gate once integer tensors are supported.
-        let tensor_match = validate_binary_tensor_float_inputs("InnerProduct", lhs, rhs)?;
+        let tensor_match = validate_binary_tensor_float_inputs(lhs, rhs)?;
         let ptype = tensor_match.element_ptype();
         let nullability = Nullability::from(lhs.is_nullable() || rhs.is_nullable());
         Ok(DType::Primitive(ptype, nullability))
@@ -146,15 +144,16 @@ impl ScalarFnVTable for InnerProduct {
         let rhs_ref = args.get(1)?;
         let len = args.row_count();
 
-        // Take any L2Denorm-wrapped fast path that applies.
-        match DenormOrientation::classify(&lhs_ref, &rhs_ref) {
-            DenormOrientation::Both { lhs, rhs } => {
-                return self.execute_both_denorm(lhs, rhs, len, ctx);
-            }
-            DenormOrientation::One { denorm, plain } => {
-                return self.execute_one_denorm(denorm, plain, len, ctx);
-            }
-            DenormOrientation::Neither => {}
+        // Take the unit-norm fast path only when at least one operand wraps stored norms (the
+        // `Denormalized` form). For naked `NormalizedVector` operands the fall-through dot
+        // product already computes the right thing (and short-circuiting here would recurse
+        // back into `InnerProduct`).
+        let lhs_form = NormalForm::classify(&lhs_ref);
+        let rhs_form = NormalForm::classify(&rhs_ref);
+        if matches!(lhs_form, NormalForm::Denormalized { .. })
+            || matches!(rhs_form, NormalForm::Denormalized { .. })
+        {
+            return self.execute_unit_form(&lhs_form, &rhs_form, &lhs_ref, &rhs_ref, len, ctx);
         }
 
         // Reduction case 1: `InnerProduct(SorfTransform(x), const)` rewrites to
@@ -225,66 +224,6 @@ impl ScalarFnVTable for InnerProduct {
     }
 }
 
-/// Metadata for a serialized binary tensor-op array (shared by [`InnerProduct`] and
-/// [`CosineSimilarity`]). Both operands share the same extension dtype up to nullability
-/// (enforced by their `return_dtype` checks), but their individual nullabilities are lost in the
-/// parent's unioned output, so both are persisted.
-///
-/// [`CosineSimilarity`]: crate::scalar_fns::cosine_similarity::CosineSimilarity
-#[derive(Clone, prost::Message)]
-pub(crate) struct BinaryTensorOpMetadata {
-    #[prost(message, optional, tag = "1")]
-    pub(crate) lhs_dtype: Option<pb::DType>,
-    #[prost(message, optional, tag = "2")]
-    pub(crate) rhs_dtype: Option<pb::DType>,
-}
-
-impl BinaryTensorOpMetadata {
-    /// Encodes the two children of `view` into a [`BinaryTensorOpMetadata`] byte blob.
-    pub(crate) fn encode_from_view<V: ScalarFnVTable>(
-        view: &ScalarFnArrayView<V>,
-    ) -> VortexResult<Vec<u8>> {
-        let scalar_fn_array = view.as_::<ScalarFnArrayEncoding>();
-        let lhs_dtype = Some(scalar_fn_array.child_at(0).dtype().try_into()?);
-        let rhs_dtype = Some(scalar_fn_array.child_at(1).dtype().try_into()?);
-        Ok(Self {
-            lhs_dtype,
-            rhs_dtype,
-        }
-        .encode_to_vec())
-    }
-
-    /// Decodes `metadata` and fetches both children from `children` using the decoded dtypes,
-    /// validating that `lhs` and `rhs` agree modulo nullability.
-    pub(crate) fn decode_children(
-        metadata: &[u8],
-        len: usize,
-        children: &dyn ArrayChildren,
-        session: &VortexSession,
-        scalar_fn_name: &str,
-    ) -> VortexResult<Vec<ArrayRef>> {
-        let metadata = Self::decode(metadata)
-            .map_err(|e| vortex_err!("Failed to decode BinaryTensorOpMetadata: {e}"))?;
-        let lhs_pb = metadata
-            .lhs_dtype
-            .as_ref()
-            .ok_or_else(|| vortex_err!("{scalar_fn_name} metadata missing lhs_dtype"))?;
-        let rhs_pb = metadata
-            .rhs_dtype
-            .as_ref()
-            .ok_or_else(|| vortex_err!("{scalar_fn_name} metadata missing rhs_dtype"))?;
-        let lhs_dtype = DType::from_proto(lhs_pb, session)?;
-        let rhs_dtype = DType::from_proto(rhs_pb, session)?;
-        vortex_ensure!(
-            lhs_dtype.eq_ignore_nullability(&rhs_dtype),
-            "{scalar_fn_name} operand dtype mismatch: {lhs_dtype} vs {rhs_dtype}"
-        );
-        let lhs = children.get(0, &lhs_dtype, len)?;
-        let rhs = children.get(1, &rhs_dtype, len)?;
-        Ok(vec![lhs, rhs])
-    }
-}
-
 impl ScalarFnArrayVTable for InnerProduct {
     fn serialize(
         &self,
@@ -302,13 +241,8 @@ impl ScalarFnArrayVTable for InnerProduct {
         children: &dyn ArrayChildren,
         session: &VortexSession,
     ) -> VortexResult<ScalarFnArrayParts<Self>> {
-        let reconstructed = BinaryTensorOpMetadata::decode_children(
-            metadata,
-            len,
-            children,
-            session,
-            "InnerProduct",
-        )?;
+        let reconstructed =
+            BinaryTensorOpMetadata::decode_children(metadata, len, children, session)?;
         Ok(ScalarFnArrayParts {
             options: EmptyOptions,
             children: reconstructed,
@@ -317,9 +251,14 @@ impl ScalarFnArrayVTable for InnerProduct {
 }
 
 impl InnerProduct {
-    /// Both sides are `L2Denorm`: `inner_product = s_l * s_r * dot(n_l, n_r)`.
-    fn execute_both_denorm(
+    /// Inner product over operands that may carry a unit-norm representation:
+    /// `inner_product = scale_l * scale_r * dot(unit_l, unit_r)`, where `scale = 1` for naked
+    /// `Normalized` operands, `scale = stored_norms` for `Denormalized` operands, and the
+    /// `unit_*` operands are the input itself for `Plain` operands.
+    fn execute_unit_form(
         &self,
+        lhs_form: &NormalForm<'_>,
+        rhs_form: &NormalForm<'_>,
         lhs_ref: &ArrayRef,
         rhs_ref: &ArrayRef,
         len: usize,
@@ -327,50 +266,42 @@ impl InnerProduct {
     ) -> VortexResult<ArrayRef> {
         let validity = lhs_ref.validity()?.and(rhs_ref.validity()?)?;
 
-        let (normalized_l, norms_l) = extract_l2_denorm_children(lhs_ref);
-        let (normalized_r, norms_r) = extract_l2_denorm_children(rhs_ref);
+        // For each operand, take its unit-norm representation if it has one; fall back to the
+        // operand itself (the `Plain` case feeds the regular dot path with no scaling).
+        let unit_lhs = lhs_form
+            .normalized_array()
+            .cloned()
+            .unwrap_or_else(|| lhs_ref.clone());
+        let unit_rhs = rhs_form
+            .normalized_array()
+            .cloned()
+            .unwrap_or_else(|| rhs_ref.clone());
 
-        let norms_l: PrimitiveArray = norms_l.execute(ctx)?;
-        let norms_r: PrimitiveArray = norms_r.execute(ctx)?;
-
-        let dot: PrimitiveArray = InnerProduct::try_new_array(normalized_l, normalized_r, len)?
+        let dot: PrimitiveArray = InnerProduct::try_new_array(unit_lhs, unit_rhs, len)?
             .into_array()
             .execute(ctx)?;
 
-        match_each_float_ptype!(dot.ptype(), |T| {
-            let dots = dot.as_slice::<T>();
-            let nl = norms_l.as_slice::<T>();
-            let nr = norms_r.as_slice::<T>();
-            let buffer: Buffer<T> = (0..len).map(|i| nl[i] * nr[i] * dots[i]).collect();
-
-            // SAFETY: The buffer length equals `len`, which matches the source validity length.
-            Ok(unsafe { PrimitiveArray::new_unchecked(buffer, validity) }.into_array())
-        })
-    }
-
-    /// One side is `L2Denorm`: `inner_product = s * dot(n, other)`.
-    ///
-    /// The caller must pass the denorm array as `denorm_ref` and the plain array as `plain_ref`.
-    fn execute_one_denorm(
-        &self,
-        denorm_ref: &ArrayRef,
-        plain_ref: &ArrayRef,
-        len: usize,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<ArrayRef> {
-        let validity = denorm_ref.validity()?.and(plain_ref.validity()?)?;
-
-        let (normalized, norms) = extract_l2_denorm_children(denorm_ref);
-        let denorm_norms: PrimitiveArray = norms.execute(ctx)?;
-
-        let dot: PrimitiveArray = InnerProduct::try_new_array(normalized, plain_ref.clone(), len)?
-            .into_array()
-            .execute(ctx)?;
+        let lhs_scale = norms_for_scaling(lhs_form, ctx)?;
+        let rhs_scale = norms_for_scaling(rhs_form, ctx)?;
 
         match_each_float_ptype!(dot.ptype(), |T| {
             let dots = dot.as_slice::<T>();
-            let ns = denorm_norms.as_slice::<T>();
-            let buffer: Buffer<T> = (0..len).map(|i| ns[i] * dots[i]).collect();
+            let buffer: Buffer<T> = match (lhs_scale.as_ref(), rhs_scale.as_ref()) {
+                (Some(nl), Some(nr)) => {
+                    let nl = nl.as_slice::<T>();
+                    let nr = nr.as_slice::<T>();
+                    (0..len).map(|i| nl[i] * nr[i] * dots[i]).collect()
+                }
+                (Some(nl), None) => {
+                    let nl = nl.as_slice::<T>();
+                    (0..len).map(|i| nl[i] * dots[i]).collect()
+                }
+                (None, Some(nr)) => {
+                    let nr = nr.as_slice::<T>();
+                    (0..len).map(|i| nr[i] * dots[i]).collect()
+                }
+                (None, None) => dots.iter().copied().collect(),
+            };
 
             // SAFETY: The buffer length equals `len`, which matches the source validity length.
             Ok(unsafe { PrimitiveArray::new_unchecked(buffer, validity) }.into_array())
@@ -421,7 +352,7 @@ impl InnerProduct {
             return Ok(None);
         };
 
-        let dim = sorf_view.options.dimension as usize;
+        let dim = sorf_view.options.dimensions as usize;
         let num_rounds = sorf_view.options.num_rounds as usize;
         let seed = sorf_view.options.seed;
         let padded_dim = dim.next_power_of_two();
@@ -568,6 +499,21 @@ impl InnerProduct {
     }
 }
 
+/// Materialize the per-row scaling factor for an operand classified by [`NormalForm`].
+///
+/// - `Plain`: no scaling needed (the operand itself enters the dot product).
+/// - `Normalized`: implicit scaling of `1.0`, returned as `None` so the caller skips the multiply.
+/// - `Denormalized`: returns the materialized stored norms.
+fn norms_for_scaling(
+    form: &NormalForm<'_>,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Option<PrimitiveArray>> {
+    match form {
+        NormalForm::Plain | NormalForm::Normalized { .. } => Ok(None),
+        NormalForm::Denormalized { norms, .. } => Ok(Some(norms.clone().execute(ctx)?)),
+    }
+}
+
 /// Return the storage constant for a canonical tensor-like constant query.
 fn constant_tensor_storage(array: &ArrayRef) -> Option<ArrayRef> {
     let constant = array.as_opt::<Constant>()?;
@@ -651,6 +597,7 @@ mod tests {
     use crate::tests::SESSION;
     use crate::utils::test_helpers::assert_close;
     use crate::utils::test_helpers::l2_denorm_array;
+    use crate::utils::test_helpers::normalized_vector_array;
     use crate::utils::test_helpers::tensor_array;
     use crate::utils::test_helpers::vector_array;
 
@@ -771,8 +718,8 @@ mod tests {
         // RHS: [1.0, 0.0] = L2Denorm([1.0, 0.0], 1.0).
         // dot([3.0, 4.0], [1.0, 0.0]) = 3.0.
         let mut ctx = SESSION.create_execution_ctx();
-        let lhs = l2_denorm_array(&[2], &[0.6, 0.8], &[5.0], &mut ctx)?;
-        let rhs = l2_denorm_array(&[2], &[1.0, 0.0], &[1.0], &mut ctx)?;
+        let lhs = l2_denorm_array(2, &[0.6, 0.8], &[5.0], &mut ctx)?;
+        let rhs = l2_denorm_array(2, &[1.0, 0.0], &[1.0], &mut ctx)?;
 
         // Expected: 5.0 * 1.0 * dot([0.6, 0.8], [1.0, 0.0]) = 5.0 * 0.6 = 3.0.
         assert_close(&eval_inner_product(lhs, rhs, 1)?, &[3.0]);
@@ -784,8 +731,8 @@ mod tests {
         // Row 0: [3.0, 4.0] dot [3.0, 4.0] = 25.0.
         // Row 1: [1.0, 0.0] dot [0.0, 1.0] = 0.0.
         let mut ctx = SESSION.create_execution_ctx();
-        let lhs = l2_denorm_array(&[2], &[0.6, 0.8, 1.0, 0.0], &[5.0, 1.0], &mut ctx)?;
-        let rhs = l2_denorm_array(&[2], &[0.6, 0.8, 0.0, 1.0], &[5.0, 1.0], &mut ctx)?;
+        let lhs = l2_denorm_array(2, &[0.6, 0.8, 1.0, 0.0], &[5.0, 1.0], &mut ctx)?;
+        let rhs = l2_denorm_array(2, &[0.6, 0.8, 0.0, 1.0], &[5.0, 1.0], &mut ctx)?;
 
         assert_close(&eval_inner_product(lhs, rhs, 2)?, &[25.0, 0.0]);
         Ok(())
@@ -797,8 +744,8 @@ mod tests {
         // RHS: plain [1.0, 2.0].
         // dot([3.0, 4.0], [1.0, 2.0]) = 3.0 + 8.0 = 11.0.
         let mut ctx = SESSION.create_execution_ctx();
-        let lhs = l2_denorm_array(&[2], &[0.6, 0.8], &[5.0], &mut ctx)?;
-        let rhs = tensor_array(&[2], &[1.0, 2.0])?;
+        let lhs = l2_denorm_array(2, &[0.6, 0.8], &[5.0], &mut ctx)?;
+        let rhs = vector_array(2, &[1.0, 2.0])?;
 
         assert_close(&eval_inner_product(lhs, rhs, 1)?, &[11.0]);
         Ok(())
@@ -810,8 +757,8 @@ mod tests {
         // RHS: L2Denorm([0.6, 0.8], 5.0) representing [3.0, 4.0].
         // dot([1.0, 2.0], [3.0, 4.0]) = 3.0 + 8.0 = 11.0.
         let mut ctx = SESSION.create_execution_ctx();
-        let lhs = tensor_array(&[2], &[1.0, 2.0])?;
-        let rhs = l2_denorm_array(&[2], &[0.6, 0.8], &[5.0], &mut ctx)?;
+        let lhs = vector_array(2, &[1.0, 2.0])?;
+        let rhs = l2_denorm_array(2, &[0.6, 0.8], &[5.0], &mut ctx)?;
 
         assert_close(&eval_inner_product(lhs, rhs, 1)?, &[11.0]);
         Ok(())
@@ -820,12 +767,16 @@ mod tests {
     #[test]
     fn both_denorm_null_norms() -> VortexResult<()> {
         // Row 0: valid, row 1: null (via nullable norms on lhs).
-        let normalized_l = tensor_array(&[2], &[0.6, 0.8, 1.0, 0.0])?;
+        let normalized_l = normalized_vector_array(
+            2,
+            &[0.6, 0.8, 1.0, 0.0],
+            &mut SESSION.create_execution_ctx(),
+        )?;
         let norms_l = PrimitiveArray::from_option_iter([Some(5.0f64), None]).into_array();
         let mut ctx = SESSION.create_execution_ctx();
 
         let lhs = L2Denorm::try_new_array(normalized_l, norms_l, 2, &mut ctx)?.into_array();
-        let rhs = l2_denorm_array(&[2], &[0.6, 0.8, 1.0, 0.0], &[5.0, 1.0], &mut ctx)?;
+        let rhs = l2_denorm_array(2, &[0.6, 0.8, 1.0, 0.0], &[5.0, 1.0], &mut ctx)?;
 
         let scalar_fn = InnerProduct::new().erased();
         let result = ScalarFnArray::try_new(scalar_fn, vec![lhs, rhs], 2)?;
@@ -835,6 +786,47 @@ mod tests {
         assert!(prim.is_valid(0, &mut ctx)?);
         assert!(!prim.is_valid(1, &mut ctx)?);
         assert_close(&[prim.as_slice::<f64>()[0]], &[25.0]);
+        Ok(())
+    }
+
+    /// Naked [`NormalizedVector`](crate::normalized_vector::NormalizedVector) operands fall
+    /// through to the regular dot path (no extra scaling). The result is just `dot(lhs, rhs)`.
+    #[test]
+    fn naked_normalized_vector_dot() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let lhs = normalized_vector_array(2, &[0.6, 0.8, 1.0, 0.0], &mut ctx)?;
+        let rhs = normalized_vector_array(2, &[0.6, 0.8, 0.0, 1.0], &mut ctx)?;
+
+        // Row 0: dot([0.6,0.8],[0.6,0.8]) = 1.0, Row 1: dot([1.0,0.0],[0.0,1.0]) = 0.0.
+        assert_close(&eval_inner_product(lhs, rhs, 2)?, &[1.0, 0.0]);
+        Ok(())
+    }
+
+    #[test]
+    fn serde_round_trip_mixed_vector_and_normalized_vector() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let lhs = normalized_vector_array(2, &[0.6, 0.8, 1.0, 0.0], &mut ctx)?;
+        let rhs = vector_array(2, &[3.0, 4.0, 0.0, 1.0])?;
+        let original = InnerProduct::try_new_array(lhs.clone(), rhs.clone(), 2)?.into_array();
+
+        let plugin = ScalarFnArrayPlugin::new(InnerProduct);
+        let metadata = plugin
+            .serialize(&original, &SESSION)?
+            .expect("InnerProduct serialize must produce metadata");
+
+        let children = vec![lhs, rhs];
+        let recovered = plugin.deserialize(
+            original.dtype(),
+            original.len(),
+            &metadata,
+            &[],
+            &children,
+            &SESSION,
+        )?;
+
+        assert_eq!(recovered.dtype(), original.dtype());
+        assert_eq!(recovered.len(), original.len());
+        assert_eq!(recovered.encoding_id(), original.encoding_id());
         Ok(())
     }
 
@@ -972,7 +964,7 @@ mod tests {
             let sorf_options = SorfOptions {
                 seed,
                 num_rounds,
-                dimension: dim,
+                dimensions: dim,
                 element_ptype: PType::F32,
             };
             let sorf =
@@ -1548,7 +1540,7 @@ mod tests {
             let sorf_options = SorfOptions {
                 seed,
                 num_rounds,
-                dimension: dim,
+                dimensions: dim,
                 element_ptype: PType::F32,
             };
             let sorf =

--- a/vortex-tensor/src/scalar_fns/l2_denorm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_denorm.rs
@@ -31,10 +31,11 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
-use vortex_array::dtype::PType;
+use vortex_array::dtype::extension::ExtDType;
 use vortex_array::dtype::proto::dtype as pb;
 use vortex_array::expr::Expression;
 use vortex_array::expr::and;
+use vortex_array::extension::EmptyMetadata;
 use vortex_array::match_each_float_ptype;
 use vortex_array::scalar::Scalar;
 use vortex_array::scalar::ScalarValue;
@@ -60,31 +61,33 @@ use vortex_session::VortexSession;
 
 use crate::matcher::AnyTensor;
 use crate::scalar_fns::l2_norm::L2Norm;
+use crate::types::normalized_vector::NormalizedVector;
+use crate::types::vector::AnyVector;
+use crate::types::vector::Vector;
 use crate::utils::extract_constant_flat_row;
 use crate::utils::extract_flat_elements;
-use crate::utils::validate_tensor_float_input;
+use crate::utils::extract_l2_denorm_children;
+use crate::utils::unit_norm_tolerance;
 
-/// Re-applies authoritative L2 norms to a normalized tensor column.
+/// Re-applies authoritative L2 norms to a normalized vector column.
 ///
-/// Computes `normalized * norm` on each row over the flat backing buffer of each tensor-like type.
+/// Computes `normalized * norm` on each row over the flat backing buffer of the vector-shaped
+/// child.
 ///
-/// The normalized input must be a tensor-like extension array with a float element type and each
-/// non-null row is semantically required to already be L2-normalized.
+/// The first child must be vector-shaped and semantically suitable for L2 denormalization. Exact
+/// callers should use [`try_new_array`](Self::try_new_array), which verifies that plain
+/// [`Vector`] inputs are row-wise unit-norm (or zero). Lossy encodings may use
+/// [`new_array_unchecked`](Self::new_array_unchecked) when the decoded child is only an
+/// approximation but the stored norms are still authoritative.
 ///
-/// The norms input must be a primitive float column with the same element type as the normalized
-/// tensor elements.
-///
-/// [`L2Denorm`] is the norm-splitting wrapper used throughout the tensor crate. Callers that build
-/// it through [`try_new_array`](Self::try_new_array) get an exact unit-norm invariant on the
-/// `normalized` child.
-///
-/// Advanced callers can also use [`new_array_unchecked`](Self::new_array_unchecked) to attach
-/// authoritative stored norms to a lossy approximation of that child, such as quantized normalized
-/// vectors.
+/// The norms input must be a primitive float column with the same element type as the
+/// normalized vector elements.
 ///
 /// Downstream readthrough rules intentionally treat the stored norms and normalized child as the
 /// encoding contract, even when that differs slightly from recomputing over fully decoded
 /// coordinates.
+///
+/// [`NormalizedVector`]: crate::normalized_vector::NormalizedVector
 #[derive(Clone)]
 pub struct L2Denorm;
 
@@ -99,45 +102,65 @@ impl L2Denorm {
 
     /// Constructs a validated [`ScalarFnArray`] that lazily re-applies `norms` to `normalized`.
     ///
-    /// This is the correct constructor for [`L2Denorm`] arrays. In addition to the structural
-    /// checks performed by [`ScalarFnArray::try_new`], it validates that every valid row of the
-    /// `normalized` child has L2 norm `1.0` (or `0.0` for zero rows), within the tolerance implied
-    /// by the child element precision. It also validates that stored norms are non-negative, and
-    /// that any row with stored norm `0.0` has an all-zero normalized row.
+    /// In addition to the structural checks performed by [`ScalarFnArray::try_new`], this
+    /// constructor verifies that plain [`Vector`] children are row-wise unit-norm (or zero), that
+    /// stored norms are non-negative, and that any row with stored norm `0.0` has an all-zero
+    /// normalized row.
+    ///
+    /// Plain [`Vector`] children are promoted to [`NormalizedVector`] after validation so that
+    /// downstream execution paths can rely on the unit-norm refinement.
     ///
     /// # Errors
     ///
     /// Returns an error if the [`ScalarFnArray`] cannot be constructed (e.g. due to dtype
-    /// mismatches) or if the `normalized` child is not row-wise L2-normalized.
+    /// mismatches), if a stored norm is negative, or if a zero-norm row is paired with a
+    /// non-zero normalized row.
     pub fn try_new_array(
         normalized: ArrayRef,
         norms: ArrayRef,
         len: usize,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ScalarFnArray> {
-        validate_l2_normalized_rows_against_norms(&normalized, Some(&norms), ctx)?;
+        validate_norms_against_normalized(&normalized, &norms, ctx)?;
 
-        // SAFETY: We just validated that it is normalized.
+        // Promote plain `Vector` children to `NormalizedVector`. The unit-norm invariant is
+        // verified by `validate_norms_against_normalized`, so the `new_unchecked` wrap is safe
+        // by construction.
+        let normalized = if normalized
+            .dtype()
+            .as_extension_opt()
+            .is_some_and(|ext| ext.is::<NormalizedVector>())
+        {
+            normalized
+        } else {
+            let ext: ExtensionArray = normalized.execute(ctx)?;
+
+            // SAFETY: row-wise unit-norm (or zero) was just verified for the plain `Vector` input
+            // above.
+            unsafe { NormalizedVector::new_unchecked(ext.storage_array().clone()) }?
+        };
+
+        // SAFETY: The validation above established the exact L2Denorm invariants.
         unsafe { Self::new_array_unchecked(normalized, norms, len) }
     }
 
-    /// Constructs an [`L2Denorm`] array without validating that the `normalized` child is actually
-    /// row-wise L2-normalized.
+    /// Constructs an [`L2Denorm`] array without validating the normalized-child invariant.
     ///
-    /// This escape hatch is intended for advanced callers that already established, or
-    /// intentionally relax, the normalized-child invariant. Structural validation still runs via
-    /// [`ScalarFnArray::try_new`].
+    /// Structural validation still runs via [`ScalarFnArray::try_new`]. Use this when the
+    /// normalized child is a lossy approximation whose rows may not be exactly unit-norm or may not
+    /// preserve exact zero-ness.
     ///
     /// # Safety
     ///
-    /// The caller must ensure the `normalized` child is semantically suitable for L2
-    /// denormalization. For exact wrappers, that means every valid row is unit-norm or zero.
+    /// The caller must ensure the first child is semantically suitable for L2 denormalization.
+    /// For exact wrappers, every valid row must be unit-norm or zero and stored norms must be
+    /// non-negative. Lossy encodings may deliberately relax the exact row invariant while still
+    /// treating the stored norms as authoritative.
     ///
-    /// Lossy encodings may deliberately relax that invariant while still treating the stored norms
-    /// as authoritative.
+    /// # Errors
     ///
-    /// Violating the intended contract will not cause memory unsafety, but may produce incorrect
-    /// results.
+    /// Returns an error if the [`ScalarFnArray`] cannot be constructed (e.g. due to dtype
+    /// mismatches).
     pub unsafe fn new_array_unchecked(
         normalized: ArrayRef,
         norms: ArrayRef,
@@ -183,8 +206,15 @@ impl ScalarFnVTable for L2Denorm {
         let normalized = &arg_dtypes[0];
         let norms = &arg_dtypes[1];
 
-        let tensor_match = validate_tensor_float_input(normalized)?;
-        let element_ptype = tensor_match.element_ptype();
+        let normalized_metadata = normalized
+            .as_extension_opt()
+            .and_then(|ext| ext.metadata_opt::<AnyVector>())
+            .ok_or_else(|| {
+                vortex_err!(
+                    "L2Denorm normalized child must be a Vector or NormalizedVector, got {normalized}",
+                )
+            })?;
+        let element_ptype = normalized_metadata.element_ptype();
 
         let DType::Primitive(norms_ptype, _) = norms else {
             vortex_bail!("L2Denorm norms must be a primitive float array, got {norms}");
@@ -196,7 +226,13 @@ impl ScalarFnVTable for L2Denorm {
                 got {norms_ptype}",
         );
 
-        Ok(normalized.union_nullability(norms.nullability()))
+        // The denormalized output has the same storage shape as the normalized child but is no
+        // longer guaranteed unit-norm, so it surfaces as a plain `Vector` extension type.
+        let normalized_storage_dtype = normalized.as_extension().storage_dtype().clone();
+        let plain_vector = DType::Extension(
+            ExtDType::<Vector>::try_new(EmptyMetadata, normalized_storage_dtype)?.erased(),
+        );
+        Ok(plain_vector.union_nullability(norms.nullability()))
     }
 
     fn execute(
@@ -207,9 +243,17 @@ impl ScalarFnVTable for L2Denorm {
     ) -> VortexResult<ArrayRef> {
         let normalized_ref = args.get(0)?;
         let norms_ref = args.get(1)?;
-        let output_dtype = normalized_ref
+        // Output is a plain `Vector` (not `NormalizedVector`) because denormalized values are no
+        // longer guaranteed unit-norm.
+        let normalized_storage_dtype = normalized_ref
             .dtype()
-            .union_nullability(norms_ref.dtype().nullability());
+            .as_extension()
+            .storage_dtype()
+            .clone();
+        let output_dtype = DType::Extension(
+            ExtDType::<Vector>::try_new(EmptyMetadata, normalized_storage_dtype)?.erased(),
+        )
+        .union_nullability(norms_ref.dtype().nullability());
         let validity = normalized_ref.validity()?.and(norms_ref.validity()?)?;
 
         if let Some(const_norms) = norms_ref.as_opt::<Constant>() {
@@ -360,9 +404,30 @@ fn execute_l2_denorm_constant_norms(
         .vortex_expect("we know that this is a float, so it must fit in f64")
         - 1.0f64;
 
-    let tolerance = unit_norm_tolerance(norm_scalar.dtype().as_ptype());
+    let vector_match = normalized_ref
+        .dtype()
+        .as_extension_opt()
+        .and_then(|ext| ext.metadata_opt::<AnyVector>())
+        .ok_or_else(|| {
+            vortex_err!(
+                "L2Denorm normalized child must be a Vector or NormalizedVector, got {}",
+                normalized_ref.dtype(),
+            )
+        })?;
+
+    let tolerance = unit_norm_tolerance(
+        norm_scalar.dtype().as_ptype(),
+        vector_match.dimensions() as usize,
+    );
     if err.abs() < tolerance {
-        return Ok(normalized_ref);
+        // The output dtype is the sibling plain `Vector`. Rewrap the vector storage so the
+        // executed array's dtype matches `output_dtype`.
+        let normalized: ExtensionArray = normalized_ref.execute(ctx)?;
+        return Ok(ExtensionArray::try_new(
+            output_dtype.as_extension().clone(),
+            normalized.storage_array().clone(),
+        )?
+        .into_array());
     }
 
     // Even if the norms are not all 1, if they are all the same then we can multiply
@@ -393,15 +458,19 @@ fn execute_l2_denorm_constant_norms(
     Ok(ExtensionArray::new(output_dtype.as_extension().clone(), new_fsl.into_array()).into_array())
 }
 
+// TODO(connor): Fast-path the case where the array is already `NormalizedVector`.
 /// Builds an unexecuted [`L2Denorm`] expression by normalizing `input` and reattaching the exact
-/// norms as the norms child.
+/// norms as the `norms` child.
 ///
 /// The returned array is a lazy `L2Denorm(normalized, norms)` scalar function array.
 ///
 /// # Normalized child
 ///
-/// The normalized child is always **non-nullable** with [`Validity::NonNullable`]. Every non-null
-/// row with a positive L2 norm is divided by its norm to produce a unit-norm vector.
+/// Every non-null row with a positive L2 norm is divided by its norm to produce a unit-norm vector.
+///
+/// IMPORTANT: The normalized child is always **non-nullable** with [`Validity::NonNullable`]. We do
+/// this because we do not want our optimized kernels over normalized vectors to worry about _both_
+/// zero vectors _and also_ null vectors.
 ///
 /// Rows that are null in the original input are **zeroed out** in the normalized output. This is
 /// necessary because null rows may have undefined (garbage) physical storage values, and we do not
@@ -409,20 +478,30 @@ fn execute_l2_denorm_constant_norms(
 ///
 /// # Nullability
 ///
-/// Nullability is tracked entirely by the norms child. Null input rows produce null norms via
-/// [`L2Norm`]'s validity propagation. When the [`L2Denorm`] wrapper is executed, its validity is
-/// `and(normalized_validity, norms_validity)`, which correctly identifies originally-null rows
-/// since the normalized child is all-valid and the norms child carries the original nulls.
+/// Nullability is tracked entirely by the `norms` child. Null input rows produce null `norms` via
+/// [`L2Norm`]'s validity propagation. When the [`L2Denorm`] wrapper is executed, the output
+/// validity is `and(normalized_validity, norms_validity)`, which correctly identifies
+/// originally-null rows since the normalized child is all-valid and the `norms` child carries the
+/// original nulls.
 ///
-/// Because this helper computes exact norms first and then divides by those norms, the returned
+/// Because this helper computes exact `norms` first and then divides by those `norms`, the returned
 /// `normalized` child satisfies the strict unit-norm invariant required by [`L2Denorm`].
 pub fn normalize_as_l2_denorm(
     input: ArrayRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ScalarFnArray> {
     let row_count = input.len();
-    let tensor_match = validate_tensor_float_input(input.dtype())?;
-    let tensor_flat_size = tensor_match.list_size() as usize;
+    let vector_metadata = input
+        .dtype()
+        .as_extension_opt()
+        .and_then(|ext| ext.metadata_opt::<AnyVector>())
+        .ok_or_else(|| {
+            vortex_err!(
+                "normalize_as_l2_denorm requires a Vector or NormalizedVector input, got {}",
+                input.dtype(),
+            )
+        })?;
+    let tensor_flat_size = vector_metadata.dimensions() as usize;
 
     // Constant fast path: if the input is a constant-backed extension, normalize the single
     // stored row once and return an `L2Denorm` whose children are both `ConstantArray`s.
@@ -437,11 +516,10 @@ pub fn normalize_as_l2_denorm(
     let norms_validity = primitive_norms.validity()?;
 
     let input: ExtensionArray = input.execute(ctx)?;
-    let normalized_dtype = input.dtype().as_nonnullable();
     let flat = extract_flat_elements(input.storage_array(), tensor_flat_size, ctx)?;
 
     // Normalize all of the vectors.
-    let normalized = match_each_float_ptype!(flat.ptype(), |T| {
+    let normalized_storage = match_each_float_ptype!(flat.ptype(), |T| {
         let norm_values = primitive_norms.as_slice::<T>();
 
         let total_elements = row_count * tensor_flat_size;
@@ -464,24 +542,19 @@ pub fn normalize_as_l2_denorm(
         }
 
         // Since L2Denorm's validity is the `and` of its child validities, we can make the
-        // normalized array non-nullable.
-        build_tensor_array(
-            normalized_dtype,
-            tensor_flat_size,
-            row_count,
-            Validity::NonNullable,
-            elements.freeze(),
-        )
+        // normalized child non-nullable.
+        build_normalized_storage(tensor_flat_size, row_count, elements.freeze())
     })?;
 
     // SAFETY:
     // - `norms_array` was produced by `L2Norm(input)`, so every stored norm is non-negative and
     //   null rows already carry null validity through that child.
     // - For every valid row, we either emit all zeros when the norm is zero or divide every
-    //   element by the exact stored norm, so the normalized child is unit-norm (or zero) by
+    //   element by the exact stored norm, so the normalized storage is unit-norm (or zero) by
     //   construction.
-    // - Null rows are zeroed out above to avoid propagating arbitrary physical storage values into
-    //   downstream lossy encodings.
+    // - Null rows are zeroed out above to avoid propagating arbitrary physical storage values
+    //   into downstream lossy encodings.
+    let normalized = unsafe { NormalizedVector::new_unchecked(normalized_storage) }?;
     unsafe { L2Denorm::new_array_unchecked(normalized, norms_array, row_count) }
 }
 
@@ -512,16 +585,15 @@ pub(crate) fn try_build_constant_l2_denorm(
         return Ok(None);
     }
 
-    // The caller is expected to have already validated that `input` is an `AnyTensor`
-    // extension dtype.
-    let tensor_match = input
+    let Some(vector_metadata) = input
         .dtype()
-        .as_extension()
-        .metadata_opt::<AnyTensor>()
-        .vortex_expect("caller validated input has AnyTensor metadata");
-    let list_size = tensor_match.list_size() as usize;
+        .as_extension_opt()
+        .and_then(|ext| ext.metadata_opt::<AnyVector>())
+    else {
+        return Ok(None);
+    };
+    let list_size = vector_metadata.dimensions() as usize;
     let original_nullability = input.dtype().nullability();
-    let ext_dtype = input.dtype().as_extension().clone();
     let storage_fsl_nullability = storage.dtype().nullability();
 
     // Materialize just the single stored row; this does not expand the constant to the full
@@ -537,8 +609,8 @@ pub(crate) fn try_build_constant_l2_denorm(
         }
         let norm_t: T = sum_sq.sqrt();
 
-        // Zero-norm rows must be stored as all-zeros so [`L2Denorm`]'s unit-norm-or-zero
-        // invariant holds. This mirrors the per-row logic in `normalize_as_l2_denorm`.
+        // Zero-norm rows must be stored as all-zeros so the `NormalizedVector` invariant holds.
+        // This mirrors the per-row logic in `normalize_as_l2_denorm`.
         let element_dtype = DType::Primitive(T::PTYPE, Nullability::NonNullable);
         let children: Vec<Scalar> = if norm_t == T::zero() {
             (0..list_size)
@@ -550,23 +622,23 @@ pub(crate) fn try_build_constant_l2_denorm(
                 .collect()
         };
 
-        // The rebuilt FSL scalar preserves the original storage FSL's nullability so the
-        // resulting `ExtensionArray::new` call accepts the same extension dtype.
         let fsl_scalar = Scalar::fixed_size_list(element_dtype, children, storage_fsl_nullability);
         let norms_scalar = Scalar::primitive(norm_t, original_nullability);
         (fsl_scalar, norms_scalar)
     });
 
     let normalized_storage = ConstantArray::new(normalized_fsl_scalar, len).into_array();
-    let normalized_ext = ExtensionArray::new(ext_dtype, normalized_storage).into_array();
+    // SAFETY: The single stored row is either `v / ||v||` (unit norm within floating-point
+    // tolerance) or all zeros when `||v|| == 0`. This is the invariant required by
+    // `NormalizedVector::new_unchecked`.
+    let normalized = unsafe { NormalizedVector::new_unchecked(normalized_storage) }?;
     let norms_array = ConstantArray::new(norms_scalar, len).into_array();
 
-    // SAFETY: Each row of `normalized_ext` is either `v / ||v||` (unit norm within floating
-    // point tolerance) or all zeros when `||v|| == 0`. Stored norms are non-negative by
-    // construction (`sqrt`). These are exactly the invariants required by
-    // [`L2Denorm::new_array_unchecked`].
-    let wrapped = unsafe { L2Denorm::new_array_unchecked(normalized_ext, norms_array, len)? };
-    Ok(Some(wrapped))
+    // SAFETY: The single stored row is exactly normalized above (or all zeros), and the norm was
+    // computed with `sqrt`, so it is non-negative.
+    Ok(Some(unsafe {
+        L2Denorm::new_array_unchecked(normalized, norms_array, len)?
+    }))
 }
 
 /// Rebuilds a tensor-like extension array from flat primitive elements.
@@ -582,107 +654,126 @@ fn build_tensor_array<T: NativePType>(
     validity: Validity,
     elements: Buffer<T>,
 ) -> VortexResult<ArrayRef> {
+    let storage = build_fsl_storage(tensor_flat_size, row_count, validity, elements)?.into_array();
+    Ok(ExtensionArray::new(dtype.as_extension().clone(), storage).into_array())
+}
+
+/// Build a non-nullable [`FixedSizeListArray`] suitable for wrapping as a
+/// [`NormalizedVector`] storage.
+fn build_normalized_storage<T: NativePType>(
+    tensor_flat_size: usize,
+    row_count: usize,
+    elements: Buffer<T>,
+) -> VortexResult<ArrayRef> {
+    Ok(
+        build_fsl_storage(tensor_flat_size, row_count, Validity::NonNullable, elements)?
+            .into_array(),
+    )
+}
+
+/// Build a [`FixedSizeListArray`] from a flat element buffer and a per-row validity.
+fn build_fsl_storage<T: NativePType>(
+    tensor_flat_size: usize,
+    row_count: usize,
+    validity: Validity,
+    elements: Buffer<T>,
+) -> VortexResult<FixedSizeListArray> {
     let list_size =
         u32::try_from(tensor_flat_size).vortex_expect("tensor flat size must fit into `u32`");
-
     // SAFETY: Validity has no length (because tensor elements are always non-nullable).
     let elements = unsafe { PrimitiveArray::new_unchecked(elements, Validity::NonNullable) };
-
-    let storage =
-        FixedSizeListArray::try_new(elements.into_array(), list_size, validity, row_count)?;
-
-    Ok(ExtensionArray::new(dtype.as_extension().clone(), storage.into_array()).into_array())
+    FixedSizeListArray::try_new(elements.into_array(), list_size, validity, row_count)
 }
 
-/// Returns the acceptable unit-norm drift for the given element precision.
-fn unit_norm_tolerance(element_ptype: PType) -> f64 {
-    match element_ptype {
-        PType::F16 => 2e-3,
-        PType::F32 => 2e-6,
-        PType::F64 => 1e-10,
-        _ => unreachable!("L2Denorm requires float elements, got {element_ptype:?}"),
-    }
-}
-
-/// Validates that `normalized` and (when supplied) the matching `norms` jointly satisfy the
-/// [`L2Denorm`] invariants:
-///
-/// - Every valid row of `normalized` has L2 norm `1.0` or `0.0` (within element-precision
-///   tolerance).
-/// - When `norms` is supplied, every stored norm is non-negative and any row whose stored norm is
-///   `0.0` is exactly the zero vector in `normalized`.
-pub fn validate_l2_normalized_rows_against_norms(
+// TODO(connor): Need better logic here to check against `NormalizedVector` vs `Vector`.
+/// Cross-check that `normalized` and `norms` agree on per-row zero-ness, and that stored norms
+/// are non-negative. Unit-norm enforcement on the rows lives on the
+/// [`NormalizedVector`](crate::normalized_vector::NormalizedVector) dtype itself.
+fn validate_norms_against_normalized(
     normalized: &ArrayRef,
-    norms: Option<&ArrayRef>,
+    norms: &ArrayRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()> {
+    let vector_match = normalized
+        .dtype()
+        .as_extension_opt()
+        .and_then(|ext| ext.metadata_opt::<AnyVector>())
+        .ok_or_else(|| {
+            vortex_err!(
+                "L2Denorm normalized child must be a Vector or NormalizedVector, got {}",
+                normalized.dtype(),
+            )
+        })?;
     let row_count = normalized.len();
+    let element_ptype = vector_match.element_ptype();
+    let tolerance = unit_norm_tolerance(element_ptype, vector_match.dimensions() as usize);
+    let tensor_flat_size = vector_match.dimensions() as usize;
+
+    vortex_ensure_eq!(
+        norms.len(),
+        row_count,
+        "L2Denorm normalized and norms children must have the same length"
+    );
+
+    let DType::Primitive(norms_ptype, _) = norms.dtype() else {
+        vortex_bail!(
+            "L2Denorm norms must be a primitive float array, got {}",
+            norms.dtype()
+        );
+    };
+    vortex_ensure_eq!(
+        *norms_ptype,
+        element_ptype,
+        "L2Denorm norms ptype must match normalized element ptype"
+    );
+
     if row_count == 0 {
         return Ok(());
-    }
-
-    let tensor_match = validate_tensor_float_input(normalized.dtype())?;
-    let element_ptype = tensor_match.element_ptype();
-    let tolerance = unit_norm_tolerance(element_ptype);
-    let tensor_flat_size = tensor_match.list_size() as usize;
-
-    if let Some(norms) = norms {
-        vortex_ensure_eq!(
-            norms.dtype().as_ptype(),
-            element_ptype,
-            "L2Denorm norms ptype must match normalized element ptype"
-        );
     }
 
     let normalized: ExtensionArray = normalized.clone().execute(ctx)?;
     let normalized_validity = normalized.as_ref().validity()?;
 
     let flat = extract_flat_elements(normalized.storage_array(), tensor_flat_size, ctx)?;
-    let norms = norms
-        .map(|norms| norms.clone().execute::<PrimitiveArray>(ctx))
-        .transpose()?;
-
-    let combined_validity = match &norms {
-        Some(norms) => normalized_validity.and(norms.validity()?)?,
-        None => normalized_validity,
-    };
+    let norms_prim: PrimitiveArray = norms.clone().execute(ctx)?;
+    let combined_validity = normalized_validity.and(norms_prim.validity()?)?;
 
     match_each_float_ptype!(element_ptype, |T| {
-        let stored_norms = norms.as_ref().map(|norms| norms.as_slice::<T>());
+        let stored_norms = norms_prim.as_slice::<T>();
 
         for i in 0..row_count {
             if !combined_validity.is_valid(i)? {
                 continue;
             }
 
+            let stored_norm_f64 = ToPrimitive::to_f64(&stored_norms[i]).unwrap_or(f64::NAN);
+            vortex_ensure!(
+                stored_norm_f64 >= 0.0,
+                "L2Denorm norms must be non-negative, but row {i} has {stored_norm_f64:.6}",
+            );
+
             let (row_norm_sq, is_zero_row) =
                 flat.row::<T>(i)
                     .iter()
-                    .fold((0.0f64, true), |(sum_sq, is_zero), x| {
+                    .fold((0.0f64, true), |(sum_sq, all_zero), x| {
                         let value = ToPrimitive::to_f64(x).unwrap_or(f64::NAN);
-                        (sum_sq + value * value, is_zero && value.abs() <= tolerance)
+                        (sum_sq + value * value, all_zero && value.abs() <= tolerance)
                     });
-            let row_norm = row_norm_sq.sqrt();
 
-            vortex_ensure!(
-                row_norm == 0.0 || (row_norm - 1.0).abs() <= tolerance,
-                "L2Denorm normalized child must have L2 norm 1.0 or 0.0, but row {i} has \
-                 {row_norm:.6}",
-            );
-
-            if let Some(stored_norms) = stored_norms {
-                let stored_norm_f64 = ToPrimitive::to_f64(&stored_norms[i]).unwrap_or(f64::NAN);
+            if !vector_match.is_normalized() {
+                let row_norm = row_norm_sq.sqrt();
                 vortex_ensure!(
-                    stored_norm_f64 >= 0.0,
-                    "L2Denorm norms must be non-negative, but row {i} has {stored_norm_f64:.6}",
+                    row_norm == 0.0 || (row_norm - 1.0).abs() <= tolerance,
+                    "L2Denorm normalized child row {i} has L2 norm {row_norm:.6}, \
+                     expected 1.0 or 0.0",
                 );
+            }
 
-                if stored_norm_f64 == 0.0 {
-                    vortex_ensure!(
-                        is_zero_row,
-                        "L2Denorm normalized child must be all zeros when norms row {i} is 0.0",
-                    );
-                }
+            if stored_norm_f64 == 0.0 {
+                vortex_ensure!(
+                    is_zero_row,
+                    "L2Denorm normalized child must be all zeros when norms row {i} is 0.0",
+                );
             }
         }
     });
@@ -690,47 +781,60 @@ pub fn validate_l2_normalized_rows_against_norms(
     Ok(())
 }
 
-/// Classification of a binary operand pair by which side (if any) is wrapped in [`L2Denorm`].
+/// Per-operand classification of a tensor argument by whether it carries an authoritative unit-norm
+/// representation, and whether stored norms accompany it.
 ///
-/// Symmetric binary tensor operators (e.g. [`CosineSimilarity`], [`InnerProduct`]) have identical
-/// fast paths for "only the lhs is denormalized" and "only the rhs is denormalized", and a separate
-/// fast path for "both are denormalized". Rather than hand-rolling the commutative swap at every
-/// call site, callers classify their operands with [`Self::classify`] and pattern-match on the
-/// returned variant.
+/// Symmetric binary tensor operators ([`CosineSimilarity`], [`InnerProduct`]) and unary ones
+/// ([`L2Norm`]) take a fast path whenever an operand carries a unit-norm representation. Callers
+/// classify each operand individually via [`Self::classify`] and pattern-match on the resulting
+/// variant.
 ///
 /// [`CosineSimilarity`]: crate::scalar_fns::cosine_similarity::CosineSimilarity
 /// [`InnerProduct`]: crate::scalar_fns::inner_product::InnerProduct
-pub(crate) enum DenormOrientation<'a> {
-    /// Both operands are [`ExactScalarFn<L2Denorm>`] arrays.
-    Both {
-        lhs: &'a ArrayRef,
-        rhs: &'a ArrayRef,
+pub(crate) enum NormalForm<'a> {
+    /// A plain `Vector`.
+    Plain,
+
+    /// An already-normalized `NormalizedVector`, which has implicit norms of `1.0`.
+    Normalized { array: &'a ArrayRef },
+
+    /// Decomposed `L2Denorm(normalized: NormalizedVector, norms)`.
+    ///
+    /// Note that `normalized` is _always_ non-null, and the validity is stored in `norms`.
+    Denormalized {
+        normalized: ArrayRef,
+        norms: ArrayRef,
     },
-    /// Exactly one operand is an [`ExactScalarFn<L2Denorm>`]; the other is plain.
-    One {
-        denorm: &'a ArrayRef,
-        plain: &'a ArrayRef,
-    },
-    /// Neither operand is an [`ExactScalarFn<L2Denorm>`].
-    Neither,
 }
 
-impl<'a> DenormOrientation<'a> {
-    /// Classify `(lhs, rhs)` by which side (if any) is wrapped in [`L2Denorm`].
-    pub(crate) fn classify(lhs: &'a ArrayRef, rhs: &'a ArrayRef) -> Self {
-        let lhs_denorm = lhs.is::<ExactScalarFn<L2Denorm>>();
-        let rhs_denorm = rhs.is::<ExactScalarFn<L2Denorm>>();
-        match (lhs_denorm, rhs_denorm) {
-            (true, true) => Self::Both { lhs, rhs },
-            (true, false) => Self::One {
-                denorm: lhs,
-                plain: rhs,
-            },
-            (false, true) => Self::One {
-                denorm: rhs,
-                plain: lhs,
-            },
-            (false, false) => Self::Neither,
+impl<'a> NormalForm<'a> {
+    /// Classify `array` by its tensor extension type and (if present) any wrapping `L2Denorm`.
+    pub(crate) fn classify(array: &'a ArrayRef) -> Self {
+        if array.is::<ExactScalarFn<L2Denorm>>() {
+            let (normalized, norms) = extract_l2_denorm_children(array);
+            return Self::Denormalized { normalized, norms };
+        }
+
+        let is_normalized = array
+            .dtype()
+            .as_extension_opt()
+            .and_then(|ext| ext.metadata_opt::<AnyVector>())
+            .is_some_and(|m| m.is_normalized());
+
+        if is_normalized {
+            Self::Normalized { array }
+        } else {
+            Self::Plain
+        }
+    }
+
+    /// Returns the unit-norm "shape" of the operand suitable for inner-product fast paths, if
+    /// one exists. For [`Self::Plain`] this returns `None`.
+    pub(crate) fn normalized_array(&self) -> Option<&ArrayRef> {
+        match self {
+            Self::Plain => None,
+            Self::Normalized { array } => Some(array),
+            Self::Denormalized { normalized, .. } => Some(normalized),
         }
     }
 }
@@ -765,17 +869,25 @@ mod tests {
 
     use crate::scalar_fns::l2_denorm::L2Denorm;
     use crate::scalar_fns::l2_denorm::normalize_as_l2_denorm;
-    use crate::scalar_fns::l2_denorm::validate_l2_normalized_rows_against_norms;
     use crate::tests::SESSION;
+    use crate::types::normalized_vector::NormalizedVector;
     use crate::types::vector::Vector;
     use crate::utils::test_helpers::assert_close;
-    use crate::utils::test_helpers::constant_tensor_array;
-    use crate::utils::test_helpers::tensor_array;
+    use crate::utils::test_helpers::normalized_vector_array;
     use crate::utils::test_helpers::vector_array;
 
-    /// Evaluates L2 denorm on a tensor/vector array and returns the executed array.
-    fn eval_l2_denorm(normalized: ArrayRef, norms: ArrayRef, len: usize) -> VortexResult<ArrayRef> {
+    /// Evaluates L2 denorm on a [`Vector`] (rewrapped as a [`NormalizedVector`]) and the matching
+    /// norms, returning the executed array. Convenience wrapper for tests that already hold a
+    /// pre-normalized [`Vector`] (possibly wrapped in another encoding such as `MaskedArray`).
+    fn eval_l2_denorm(
+        vector_input: ArrayRef,
+        norms: ArrayRef,
+        len: usize,
+    ) -> VortexResult<ArrayRef> {
         let mut ctx = SESSION.create_execution_ctx();
+        let canonical: ExtensionArray = vector_input.execute(&mut ctx)?;
+        let storage = canonical.storage_array().clone();
+        let normalized = NormalizedVector::try_new(storage, &mut ctx)?;
         let result = L2Denorm::try_new_array(normalized, norms, len, &mut ctx)?;
         result.into_array().execute(&mut ctx)
     }
@@ -824,17 +936,6 @@ mod tests {
     }
 
     #[test]
-    fn l2_denorm_fixed_shape_tensors() -> VortexResult<()> {
-        let lhs = tensor_array(&[2, 2], &[0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 0.0, 0.0])?;
-        let rhs = PrimitiveArray::from_iter([4.0f64, 2.0]).into_array();
-        let actual = eval_l2_denorm(lhs, rhs, 2)?;
-        let expected = tensor_array(&[2, 2], &[2.0, 2.0, 2.0, 2.0, 2.0, 0.0, 0.0, 0.0])?;
-
-        assert_tensor_arrays_eq(actual, expected)?;
-        Ok(())
-    }
-
-    #[test]
     fn l2_denorm_null_propagation() -> VortexResult<()> {
         let lhs = vector_array(2, &[0.6, 0.8, 1.0, 0.0, 0.0, 0.0])?;
         let lhs = MaskedArray::try_new(lhs, Validity::from_iter([true, false, true]))?.into_array();
@@ -874,9 +975,20 @@ mod tests {
     }
 
     #[test]
-    fn l2_denorm_rejects_integer_tensor_lhs() -> VortexResult<()> {
-        let lhs = tensor_array(&[2], &[1i32, 2, 3, 4])?;
+    fn l2_denorm_accepts_plain_unit_vector_lhs() -> VortexResult<()> {
+        let lhs = vector_array(2, &[1.0, 0.0, 0.0, 1.0])?;
         let rhs = PrimitiveArray::from_iter([1.0f64, 1.0]).into_array();
+
+        let mut ctx = SESSION.create_execution_ctx();
+        let result = L2Denorm::try_new_array(lhs, rhs, 2, &mut ctx);
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn l2_denorm_rejects_unnormalized_plain_vector_lhs() -> VortexResult<()> {
+        let lhs = vector_array(2, &[3.0, 4.0, 0.0, 1.0])?;
+        let rhs = PrimitiveArray::from_iter([5.0f64, 1.0]).into_array();
 
         let mut ctx = SESSION.create_execution_ctx();
         let result = L2Denorm::try_new_array(lhs, rhs, 2, &mut ctx);
@@ -886,49 +998,61 @@ mod tests {
 
     #[test]
     fn l2_denorm_rejects_mismatched_rhs_ptype() -> VortexResult<()> {
-        let lhs = vector_array(2, &[1.0, 0.0, 0.0, 1.0])?;
+        let mut ctx = SESSION.create_execution_ctx();
+        let lhs = normalized_vector_array(2, &[1.0, 0.0, 0.0, 1.0], &mut ctx)?;
         let rhs = PrimitiveArray::from_iter([1.0f32, 1.0]).into_array();
 
-        let mut ctx = SESSION.create_execution_ctx();
         let result = L2Denorm::try_new_array(lhs, rhs, 2, &mut ctx);
         assert!(result.is_err());
         Ok(())
     }
 
     #[test]
-    fn validate_l2_normalized_rows_accepts_normalized_f16_input() -> VortexResult<()> {
-        let input = vector_array(2, &[3.0f32, 4.0, 0.0, 0.0].map(half::f16::from_f32))?;
+    fn l2_denorm_rejects_non_primitive_rhs_without_panic() -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
-        let roundtrip = normalize_as_l2_denorm(input, &mut ctx)?;
-        validate_l2_normalized_rows_against_norms(&roundtrip.child_at(0).clone(), None, &mut ctx)?;
-        Ok(())
-    }
+        let lhs = normalized_vector_array(2, &[1.0, 0.0, 0.0, 1.0], &mut ctx)?;
+        let rhs = vector_array(2, &[1.0f64, 0.0, 0.0, 1.0])?;
 
-    #[test]
-    fn validate_l2_normalized_rows_rejects_unnormalized_input() -> VortexResult<()> {
-        let input = vector_array(2, &[3.0, 4.0, 1.0, 0.0])?;
-        let mut ctx = SESSION.create_execution_ctx();
-        let result = validate_l2_normalized_rows_against_norms(&input, None, &mut ctx);
+        let result = L2Denorm::try_new_array(lhs, rhs, 2, &mut ctx);
         assert!(result.is_err());
         Ok(())
     }
 
     #[test]
-    fn l2_denorm_try_new_array_rejects_unnormalized_child() -> VortexResult<()> {
-        let normalized = vector_array(2, &[3.0, 4.0, 1.0, 0.0])?;
-        let norms = PrimitiveArray::from_iter([5.0f64, 1.0]).into_array();
+    fn l2_denorm_rejects_length_mismatch_without_panic() -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
+        let lhs = normalized_vector_array(2, &[1.0, 0.0, 0.0, 1.0], &mut ctx)?;
+        let rhs = PrimitiveArray::from_iter([1.0f64]).into_array();
 
-        let result = L2Denorm::try_new_array(normalized, norms, 2, &mut ctx);
+        let result = L2Denorm::try_new_array(lhs, rhs, 2, &mut ctx);
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn normalized_vector_try_new_accepts_normalized_f16_input() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let elements = [3.0f32, 4.0, 0.0, 0.0].map(half::f16::from_f32);
+        let roundtrip = normalize_as_l2_denorm(vector_array(2, &elements)?, &mut ctx)?;
+        // The first child is already a `NormalizedVector` by construction.
+        let normalized = roundtrip.child_at(0).clone();
+        assert!(normalized.dtype().as_extension().is::<NormalizedVector>(),);
+        Ok(())
+    }
+
+    #[test]
+    fn normalized_vector_try_new_rejects_unnormalized_input() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let result = normalized_vector_array(2, &[3.0, 4.0, 1.0, 0.0], &mut ctx);
         assert!(result.is_err());
         Ok(())
     }
 
     #[test]
     fn l2_denorm_try_new_array_rejects_nonzero_row_with_zero_norm() -> VortexResult<()> {
-        let normalized = vector_array(2, &[1.0, 0.0, 0.0, 0.0])?;
-        let norms = PrimitiveArray::from_iter([0.0f64, 0.0]).into_array();
         let mut ctx = SESSION.create_execution_ctx();
+        let normalized = normalized_vector_array(2, &[1.0, 0.0, 0.0, 0.0], &mut ctx)?;
+        let norms = PrimitiveArray::from_iter([0.0f64, 0.0]).into_array();
 
         let result = L2Denorm::try_new_array(normalized, norms, 2, &mut ctx);
         assert!(result.is_err());
@@ -937,9 +1061,9 @@ mod tests {
 
     #[test]
     fn l2_denorm_try_new_array_rejects_negative_norms() -> VortexResult<()> {
-        let normalized = vector_array(2, &[1.0, 0.0, 0.0, 1.0])?;
-        let norms = PrimitiveArray::from_iter([1.0f64, -1.0]).into_array();
         let mut ctx = SESSION.create_execution_ctx();
+        let normalized = normalized_vector_array(2, &[1.0, 0.0, 0.0, 1.0], &mut ctx)?;
+        let norms = PrimitiveArray::from_iter([1.0f64, -1.0]).into_array();
 
         let result = L2Denorm::try_new_array(normalized, norms, 2, &mut ctx);
         assert!(result.is_err());
@@ -947,10 +1071,14 @@ mod tests {
     }
 
     #[test]
-    fn l2_denorm_new_array_unchecked_accepts_unnormalized_child() -> VortexResult<()> {
-        let normalized = vector_array(2, &[3.0, 4.0, 1.0, 0.0])?;
-        let norms = PrimitiveArray::from_iter([5.0f64, 1.0]).into_array();
+    fn l2_denorm_new_array_unchecked_skips_zero_row_cross_check() -> VortexResult<()> {
+        // `L2Denorm::new_array_unchecked` accepts a NormalizedVector + norms without the zero-norm
+        // cross-check; useful for lossy encodings (e.g. TurboQuant).
+        let mut ctx = SESSION.create_execution_ctx();
+        let normalized = normalized_vector_array(2, &[1.0, 0.0, 0.0, 1.0], &mut ctx)?;
+        let norms = PrimitiveArray::from_iter([0.0f64, 1.0]).into_array();
 
+        // SAFETY: This test intentionally exercises the lossy escape hatch.
         let result = unsafe { L2Denorm::new_array_unchecked(normalized, norms, 2) };
         assert!(result.is_ok());
         Ok(())
@@ -959,28 +1087,6 @@ mod tests {
     #[test]
     fn normalize_as_l2_denorm_roundtrips_vectors() -> VortexResult<()> {
         let input = vector_array(3, &[3.0, 4.0, 0.0, 0.0, 0.0, 0.0])?;
-        let mut ctx = SESSION.create_execution_ctx();
-        let roundtrip = normalize_as_l2_denorm(input.clone(), &mut ctx)?;
-        let actual = roundtrip.into_array().execute(&mut ctx)?;
-
-        assert_tensor_arrays_eq(actual, input)?;
-        Ok(())
-    }
-
-    #[test]
-    fn normalize_as_l2_denorm_roundtrips_fixed_shape_tensors() -> VortexResult<()> {
-        let input = tensor_array(&[2, 2], &[1.0, 2.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0])?;
-        let mut ctx = SESSION.create_execution_ctx();
-        let roundtrip = normalize_as_l2_denorm(input.clone(), &mut ctx)?;
-        let actual = roundtrip.into_array().execute(&mut ctx)?;
-
-        assert_tensor_arrays_eq(actual, input)?;
-        Ok(())
-    }
-
-    #[test]
-    fn normalize_as_l2_denorm_supports_constant_tensors() -> VortexResult<()> {
-        let input = constant_tensor_array(&[2], &[3.0, 4.0], 3)?;
         let mut ctx = SESSION.create_execution_ctx();
         let roundtrip = normalize_as_l2_denorm(input.clone(), &mut ctx)?;
         let actual = roundtrip.into_array().execute(&mut ctx)?;
@@ -1095,16 +1201,31 @@ mod tests {
         Ok(())
     }
 
+    /// Regression: a non-nullable [`NormalizedVector`] child paired with a nullable-dtype
+    /// constant norms array (whose value happens to be non-null `1.0`) used to panic in the
+    /// constant-unit fast path because the extension's declared storage nullability no longer
+    /// matched the storage array's own nullability. The fix is on the [`ExtensionArray`] side —
+    /// storage-dtype matching ignores outer nullability — and the operation now succeeds.
     #[test]
-    fn l2_denorm_constant_nonunit_norms_scales_fixed_shape_tensors() -> VortexResult<()> {
-        // The same constant-scaling fast path must also cover multi-dimensional fixed-shape
-        // tensors, where the backing elements buffer spans more than one slot per row.
-        let normalized = tensor_array(&[2, 2], &[0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 0.0, 0.0])?;
-        let norms = constant_f64_norms(4.0, 2);
+    fn l2_denorm_constant_unit_norms_nullable_scalar_nonnullable_normalized() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let normalized = normalized_vector_array(3, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0], &mut ctx)?;
+        let nullable_unit_norms =
+            ConstantArray::new(Scalar::primitive(1.0f64, Nullability::Nullable), 2).into_array();
 
-        let actual = eval_l2_denorm(normalized, norms, 2)?;
-        let expected = tensor_array(&[2, 2], &[2.0, 2.0, 2.0, 2.0, 4.0, 0.0, 0.0, 0.0])?;
-        assert_tensor_arrays_eq(actual, expected)?;
+        let result = L2Denorm::try_new_array(normalized, nullable_unit_norms, 2, &mut ctx)?;
+        let actual: ArrayRef = result.into_array().execute(&mut ctx)?;
+
+        // The output surfaces as a plain `Vector` whose outer nullability is the union of the
+        // two children (nullable here, since the norms child was nullable).
+        assert!(actual.dtype().as_extension().is::<Vector>());
+        assert!(actual.dtype().is_nullable());
+
+        // The element values round-trip: scaling unit vectors by `1.0` is a no-op.
+        let ext: ExtensionArray = actual.execute(&mut ctx)?;
+        let storage: FixedSizeListArray = ext.storage_array().clone().execute(&mut ctx)?;
+        let elements: PrimitiveArray = storage.elements().clone().execute(&mut ctx)?;
+        assert_close(elements.as_slice::<f64>(), &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
         Ok(())
     }
 
@@ -1114,7 +1235,6 @@ mod tests {
     /// round-trip.
     #[rstest]
     #[case::vector(vector_array(3, &[3.0, 4.0, 0.0, 0.0, 0.0, 0.0]).unwrap())]
-    #[case::fixed_shape_tensor(tensor_array(&[2, 2], &[1.0, 2.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0]).unwrap())]
     fn serde_round_trip(#[case] input: ArrayRef) -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         let original = normalize_as_l2_denorm(input, &mut ctx)?.into_array();

--- a/vortex-tensor/src/scalar_fns/l2_norm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_norm.rs
@@ -6,6 +6,8 @@
 use std::fmt::Formatter;
 
 use num_traits::Float;
+use num_traits::One;
+use num_traits::Zero;
 use prost::Message;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
@@ -17,7 +19,6 @@ use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::ScalarFn as ScalarFnArrayEncoding;
 use vortex_array::arrays::ScalarFnArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
-use vortex_array::arrays::scalar_fn::ExactScalarFn;
 use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex_array::arrays::scalar_fn::ScalarFnArrayView;
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayParts;
@@ -25,6 +26,7 @@ use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayVTable;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
+use vortex_array::dtype::PType;
 use vortex_array::dtype::proto::dtype as pb;
 use vortex_array::expr::Expression;
 use vortex_array::match_each_float_ptype;
@@ -40,14 +42,12 @@ use vortex_array::serde::ArrayChildren;
 use vortex_buffer::Buffer;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
-use vortex_error::vortex_ensure_eq;
 use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 
 use crate::matcher::AnyTensor;
-use crate::scalar_fns::l2_denorm::L2Denorm;
+use crate::scalar_fns::l2_denorm::NormalForm;
 use crate::utils::extract_flat_elements;
-use crate::utils::extract_l2_denorm_children;
 use crate::utils::validate_tensor_float_input;
 
 /// L2 norm (Euclidean norm) of a tensor or vector column.
@@ -57,10 +57,11 @@ use crate::utils::validate_tensor_float_input;
 /// The input must be a tensor-like extension array with a float element type. The output is a float
 /// column of the same float type.
 ///
-/// When the input is wrapped in [`L2Denorm`], this operator treats the stored norms as
-/// authoritative. For lossy encodings such as TurboQuant, that means `L2Norm` may intentionally
-/// read the stored norms instead of re-deriving them from fully decoded coordinates. That behavior
-/// is part of the lossy storage contract, not a separate lossy-compute mode.
+/// When the input is wrapped in [`L2Denorm`](crate::scalar_fns::l2_denorm::L2Denorm), this operator
+/// treats the stored norms as authoritative. For lossy encodings such as TurboQuant, that means
+/// `L2Norm` may intentionally read the stored norms instead of re-deriving them from fully decoded
+/// coordinates. That behavior is part of the lossy storage contract, not a separate lossy-compute
+/// mode.
 #[derive(Clone)]
 pub struct L2Norm;
 
@@ -115,6 +116,7 @@ impl ScalarFnVTable for L2Norm {
         let tensor_match = validate_tensor_float_input(input_dtype)?;
         let ptype = tensor_match.element_ptype();
 
+        // Inherit the nullability from the vectors themselves.
         let nullability = Nullability::from(input_dtype.is_nullable());
         Ok(DType::Primitive(ptype, nullability))
     }
@@ -137,13 +139,24 @@ impl ScalarFnVTable for L2Norm {
 
         let norm_dtype = DType::Primitive(element_ptype, ext.nullability());
 
-        // L2Norm(L2Denorm(normalized, norms)) is defined to read back the authoritative stored
-        // norms. Exact callers of lossy encodings like TurboQuant opt into that storage semantics
-        // instead of forcing a decode-and-recompute path here.
-        if input_ref.is::<ExactScalarFn<L2Denorm>>() {
-            let (_, norms) = extract_l2_denorm_children(&input_ref);
-            vortex_ensure_eq!(norms.dtype(), &norm_dtype);
-            return Ok(norms);
+        // TODO(connor): Need to write some tests for this.
+        // Short-circuit when the input carries a unit-norm representation already.
+        match NormalForm::classify(&input_ref) {
+            NormalForm::Denormalized { norms, .. } => {
+                return Ok(norms);
+            }
+            NormalForm::Normalized { .. } => {
+                // A naked `NormalizedVector` row is either unit norm or the zero vector by type.
+                // We still have to distinguish those two cases and preserve row validity.
+                return execute_normalized_vector_norms(
+                    &input_ref,
+                    element_ptype,
+                    tensor_flat_size,
+                    row_count,
+                    ctx,
+                );
+            }
+            NormalForm::Plain => {}
         }
 
         // Optimize for the constant array case.
@@ -261,6 +274,35 @@ fn l2_norm_row<T: Float + NativePType>(v: &[T]) -> T {
     sum_sq.sqrt()
 }
 
+/// Computes L2 norms for a [`NormalizedVector`](crate::normalized_vector::NormalizedVector)
+/// without taking square roots: valid rows are either all-zero (`0.0`) or unit-norm (`1.0`).
+fn execute_normalized_vector_norms(
+    input_ref: &ArrayRef,
+    element_ptype: PType,
+    tensor_flat_size: usize,
+    row_count: usize,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let input: ExtensionArray = input_ref.clone().execute(ctx)?;
+    let validity = input.as_ref().validity()?;
+    let flat = extract_flat_elements(input.storage_array(), tensor_flat_size, ctx)?;
+
+    match_each_float_ptype!(element_ptype, |T| {
+        let buffer: Buffer<T> = (0..row_count)
+            .map(|i| {
+                if flat.row::<T>(i).iter().all(|&x| x == T::zero()) {
+                    T::zero()
+                } else {
+                    T::one()
+                }
+            })
+            .collect();
+
+        // SAFETY: The buffer length equals `row_count`, which matches the source validity length.
+        Ok(unsafe { PrimitiveArray::new_unchecked(buffer, validity) }.into_array())
+    })
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -289,6 +331,7 @@ mod tests {
     use crate::types::vector::Vector;
     use crate::utils::test_helpers::assert_close;
     use crate::utils::test_helpers::literal_vector_array;
+    use crate::utils::test_helpers::normalized_vector_array;
     use crate::utils::test_helpers::tensor_array;
     use crate::utils::test_helpers::vector_array;
 
@@ -441,6 +484,31 @@ mod tests {
         assert_eq!(recovered.dtype(), original.dtype());
         assert_eq!(recovered.len(), original.len());
         assert_eq!(recovered.encoding_id(), original.encoding_id());
+        Ok(())
+    }
+
+    /// A naked [`NormalizedVector`](crate::normalized_vector::NormalizedVector) input must
+    /// short-circuit to `1.0` for unit rows and `0.0` for zero rows without taking square roots.
+    #[test]
+    fn naked_normalized_vector_returns_unit_norms() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let input = normalized_vector_array(2, &[1.0, 0.0, 0.6, 0.8, 0.0, 0.0], &mut ctx)?;
+        assert_close(&eval_l2_norm(input, 3)?, &[1.0, 1.0, 0.0]);
+        Ok(())
+    }
+
+    #[test]
+    fn naked_normalized_vector_preserves_nulls() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let input = normalized_vector_array(2, &[1.0, 0.0, 0.0, 0.0], &mut ctx)?;
+        let input = MaskedArray::try_new(input, Validity::from_iter([true, false]))?.into_array();
+
+        let result = L2Norm::try_new_array(input, 2)?;
+        let prim: PrimitiveArray = result.into_array().execute(&mut ctx)?;
+
+        assert!(prim.is_valid(0, &mut ctx)?);
+        assert!(!prim.is_valid(1, &mut ctx)?);
+        assert_close(&[prim.as_slice::<f64>()[0]], &[1.0]);
         Ok(())
     }
 }

--- a/vortex-tensor/src/scalar_fns/sorf_transform/mod.rs
+++ b/vortex-tensor/src/scalar_fns/sorf_transform/mod.rs
@@ -8,10 +8,10 @@
 //! Walsh-Hadamard transform to achieve O(d log d) matrix-vector products instead of the O(d^2) cost
 //! of a dense orthogonal matrix.
 //!
-//! This module wraps a [`Vector`] extension array whose dimension is the padded SORF dimension
-//! (e.g. a `Vector` wrapping `FSL(Dict(codes, centroids))`) and applies the inverse SORF transform
-//! at execution time, producing a [`Vector`] extension array with the original (pre-padding)
-//! dimensionality.
+//! This module wraps a [`Vector`] or [`NormalizedVector`] extension array whose dimension is the
+//! padded SORF dimension (e.g. a `Vector` wrapping `FSL(Dict(codes, centroids))`) and applies the
+//! inverse SORF transform at execution time, producing a plain [`Vector`] extension array with the
+//! original (pre-padding) dimensionality.
 //!
 //! The transform parameters are stored as a deterministic seed in [`SorfOptions`], so the
 //! [`SorfMatrix`] is reconstructed cheaply at decode time. Sign diagonals are defined by Vortex's
@@ -19,9 +19,9 @@
 //!
 //! # Input element type: `f32` only (TODO(connor): for now...)
 //!
-//! The child [`Vector`] **must** have `f32` storage elements. This is a hard constraint that is
-//! enforced by `SorfTransform`'s `return_dtype` check. Callers with `f16` or `f64` source data need
-//! to cast to `f32` before wrapping in a [`Vector`] and handing it to SorfTransform.
+//! The child vector extension **must** have `f32` storage elements. This is a hard constraint that
+//! is enforced by `SorfTransform`'s `return_dtype` check. Callers with `f16` or `f64` source data
+//! need to cast to `f32` before wrapping in a vector extension and handing it to SorfTransform.
 //!
 //! The reason for this constraint is that TurboQuant (the only production caller today) stores its
 //! dictionary centroids as `f32`, and the SORF transform itself operates internally in `f32`.
@@ -40,6 +40,7 @@
 //!
 //! [sorf-paper]: https://proceedings.neurips.cc/paper_files/paper/2016/file/53adaf494dc89ef7196d73636eb2451b-Paper.pdf
 //! [`Vector`]: crate::vector::Vector
+//! [`NormalizedVector`]: crate::normalized_vector::NormalizedVector
 
 use std::fmt;
 use std::fmt::Formatter;
@@ -59,10 +60,10 @@ mod vtable;
 
 /// Inverse SORF orthogonal transform scalar function.
 ///
-/// Takes a [`Vector`](crate::vector::Vector) extension child at the padded dimension with `f32`
-/// storage, applies the inverse structured Walsh-Hadamard orthogonal transform, truncates to the
-/// original (pre-padding) dimension, casts element-wise to [`SorfOptions::element_ptype`], and
-/// wraps the result in a new [`Vector`](crate::vector::Vector) extension array.
+/// Takes a vector extension child at the padded dimension with `f32` storage, applies the inverse
+/// structured Walsh-Hadamard orthogonal transform, truncates to the original (pre-padding)
+/// dimension, casts element-wise to [`SorfOptions::element_ptype`], and wraps the result in a new
+/// plain [`Vector`](crate::vector::Vector) extension array.
 ///
 /// See the [module-level docs](crate::scalar_fns::sorf_transform) for the rationale behind the
 /// `f32`-only input constraint.
@@ -81,7 +82,7 @@ pub struct SorfOptions {
     pub num_rounds: u8,
     /// Original vector dimension (before power-of-2 padding). The output
     /// [`Vector`](crate::vector::Vector) has this dimension.
-    pub dimension: u32,
+    pub dimensions: u32,
     /// Element type of the output [`Vector`](crate::vector::Vector). The child input must always
     /// be `f32`, but the output can be any float type (`F16`, `F32`, `F64`); the final
     /// `f32 -> element_ptype` cast happens while building the output.
@@ -96,16 +97,18 @@ impl SorfTransform {
 
     /// Constructs a validated [`ScalarFnArray`] that lazily applies the inverse SORF transform.
     ///
-    /// The `child` must be a [`Vector`] extension array (or an array that executes to one) with:
+    /// The `child` must be a [`Vector`] or [`NormalizedVector`] extension array (or an array that
+    /// executes to one) with:
     ///
     /// - dimension equal to `padded_dim` (i.e. `options.dimension.next_power_of_two()`), and
     /// - `f32` storage elements. This is a hard requirement today; see the
     ///   [module-level docs](crate::scalar_fns::sorf_transform) for the rationale.
     ///
-    /// The output [`Vector`] has dimension `options.dimension` and element type
+    /// The output plain [`Vector`] has dimension `options.dimension` and element type
     /// `options.element_ptype`.
     ///
     /// [`Vector`]: crate::vector::Vector
+    /// [`NormalizedVector`]: crate::normalized_vector::NormalizedVector
     pub fn try_new_array(
         options: &SorfOptions,
         child: ArrayRef,
@@ -137,7 +140,7 @@ impl fmt::Display for SorfOptions {
         write!(
             f,
             "SorfOptions(seed={}, rounds={}, dim={}, ptype={})",
-            self.seed, self.num_rounds, self.dimension, self.element_ptype
+            self.seed, self.num_rounds, self.dimensions, self.element_ptype
         )
     }
 }

--- a/vortex-tensor/src/scalar_fns/sorf_transform/rotation.rs
+++ b/vortex-tensor/src/scalar_fns/sorf_transform/rotation.rs
@@ -76,15 +76,15 @@ impl SorfMatrix {
     /// The seed is expanded using Vortex's frozen local SplitMix64 stream. Signs are generated in
     /// round-major, block-major order, with each `u64` contributing 64 sign bits in
     /// least-significant-bit-first order.
-    pub fn try_new(seed: u64, dimension: usize, num_rounds: usize) -> VortexResult<Self> {
+    pub fn try_new(seed: u64, dimensions: usize, num_rounds: usize) -> VortexResult<Self> {
         vortex_ensure!(num_rounds >= 1, "num_rounds must be >= 1, got {num_rounds}");
 
-        let padded_dim = dimension.next_power_of_two();
+        let padded_dim = dimensions.next_power_of_two();
         let sign_masks = gen_sign_masks_from_seed(seed, padded_dim, num_rounds);
 
         // Compute in f64 for precision, then store as f32 since the WHT operates on f32 buffers.
         // The result is always in (0, 1] for any valid padded_dim >= 2 and num_rounds >= 1, so
-        // the f64 -> f32 cast is a precision loss only -- it cannot overflow to infinity.
+        // the f64 -> f32 cast is a precision loss only (it cannot overflow to infinity).
         #[expect(
             clippy::cast_possible_truncation,
             reason = "the norm factor is in (0, 1] so the f64 -> f32 cast cannot overflow"

--- a/vortex-tensor/src/scalar_fns/sorf_transform/tests.rs
+++ b/vortex-tensor/src/scalar_fns/sorf_transform/tests.rs
@@ -7,6 +7,7 @@
 
 use std::sync::Arc;
 
+use prost::Message;
 use vortex_array::ArrayPlugin;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
@@ -14,9 +15,11 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::ScalarFn as ScalarFnArrayEncoding;
 use vortex_array::arrays::dict::DictArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
+use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayPlugin;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
@@ -33,9 +36,10 @@ use super::SorfOptions;
 use super::SorfTransform;
 use super::rotation::SorfMatrix;
 use crate::encodings::turboquant::centroids::compute_centroid_boundaries;
+use crate::encodings::turboquant::centroids::compute_or_get_centroids;
 use crate::encodings::turboquant::centroids::find_nearest_centroid;
-use crate::encodings::turboquant::centroids::get_centroids;
 use crate::tests::SESSION;
+use crate::types::normalized_vector::NormalizedVector;
 use crate::types::vector::Vector;
 
 /// Build a unit-normalized input vector array and forward-transform + quantize it, returning
@@ -67,7 +71,7 @@ fn forward_rotate_and_quantize(
 
     let rotation = SorfMatrix::try_new(seed, dim, num_rounds)?;
     let padded_dim = rotation.padded_dim();
-    let centroids = get_centroids(padded_dim as u32, bit_width)?;
+    let centroids = compute_or_get_centroids(padded_dim as u32, bit_width)?;
     let boundaries = compute_centroid_boundaries(&centroids);
 
     let mut all_indices = BufferMut::<u8>::with_capacity(num_rows * padded_dim);
@@ -115,7 +119,7 @@ fn default_options(dim: u32, seed: u64) -> SorfOptions {
     SorfOptions {
         seed,
         num_rounds: 3,
-        dimension: dim,
+        dimensions: dim,
         element_ptype: PType::F32,
     }
 }
@@ -319,7 +323,7 @@ fn rejects_zero_rounds_at_construction() {
     let options = SorfOptions {
         seed: 42,
         num_rounds: 0,
-        dimension: 128,
+        dimensions: 128,
         element_ptype: PType::F32,
     };
     let elements = PrimitiveArray::from_iter([0.0f32; 128]).into_array();
@@ -336,7 +340,7 @@ fn rejects_non_float_output_ptype_at_construction() {
     let options = SorfOptions {
         seed: 42,
         num_rounds: 3,
-        dimension: 128,
+        dimensions: 128,
         element_ptype: PType::U8,
     };
     let elements = PrimitiveArray::from_iter([0.0f32; 128]).into_array();
@@ -359,6 +363,24 @@ fn rejects_non_vector_extension_child_at_construction() {
     let err = SorfTransform::try_new_array(&options, child.into_array(), 1)
         .expect_err("non-Vector-extension children should be rejected at construction time");
     assert!(err.to_string().contains("Vector extension"));
+}
+
+#[test]
+fn accepts_normalized_vector_child_and_returns_plain_vector() -> VortexResult<()> {
+    let options = default_options(128, 42);
+    let mut values = vec![0.0f32; 128];
+    values[0] = 1.0;
+    let elements = PrimitiveArray::from_iter(values).into_array();
+    let fsl = FixedSizeListArray::try_new(elements, 128, Validity::NonNullable, 1)?;
+    let mut ctx = SESSION.create_execution_ctx();
+    let child = NormalizedVector::try_new(fsl.into_array(), &mut ctx)?;
+
+    let sorf = SorfTransform::try_new_array(&options, child, 1)?.into_array();
+    assert!(sorf.dtype().as_extension().is::<Vector>());
+
+    let result: ExtensionArray = sorf.execute(&mut ctx)?;
+    assert!(result.dtype().as_extension().is::<Vector>());
+    Ok(())
 }
 
 #[test]
@@ -400,7 +422,7 @@ fn f16_output_type() -> VortexResult<()> {
     let options = SorfOptions {
         seed,
         num_rounds: 3,
-        dimension: dim as u32,
+        dimensions: dim as u32,
         element_ptype: PType::F16,
     };
     let sorf = SorfTransform::try_new_array(&options, padded_vector.into_array(), num_rows)?;
@@ -425,7 +447,7 @@ fn f64_output_type() -> VortexResult<()> {
     let options = SorfOptions {
         seed,
         num_rounds: 3,
-        dimension: dim as u32,
+        dimensions: dim as u32,
         element_ptype: PType::F64,
     };
     let sorf = SorfTransform::try_new_array(&options, padded_vector.into_array(), num_rows)?;
@@ -455,19 +477,45 @@ fn trivial_padded_vector(padded_dim: u32, num_rows: usize, validity: Validity) -
     ExtensionArray::new(ext_dtype, fsl.into_array()).into_array()
 }
 
+fn trivial_padded_normalized_vector(
+    padded_dim: u32,
+    num_rows: usize,
+    validity: Validity,
+) -> VortexResult<ArrayRef> {
+    let elements = PrimitiveArray::new(
+        Buffer::<f32>::zeroed(num_rows * padded_dim as usize),
+        Validity::NonNullable,
+    );
+    let fsl = FixedSizeListArray::try_new(elements.into_array(), padded_dim, validity, num_rows)?;
+    let mut ctx = SESSION.create_execution_ctx();
+    NormalizedVector::try_new(fsl.into_array(), &mut ctx)
+}
+
+#[derive(Clone, prost::Message)]
+struct LegacySorfTransformMetadata {
+    #[prost(uint64, tag = "1")]
+    seed: u64,
+    #[prost(uint32, tag = "2")]
+    num_rounds: u32,
+    #[prost(uint32, tag = "3")]
+    dimension: u32,
+    #[prost(enumeration = "PType", tag = "4")]
+    element_ptype: i32,
+}
+
 #[rstest::rstest]
 // Non-power-of-two dimension to exercise `padded_dim = dim.next_power_of_two()`.
 #[case::power_of_two_dim(128, Validity::NonNullable)]
 #[case::non_power_of_two_dim(100, Validity::NonNullable)]
 // Nullable top-level Vector to verify child nullability is reconstructed from the parent output.
 #[case::nullable_child(100, Validity::AllValid)]
-fn serde_round_trip(#[case] dimension: u32, #[case] validity: Validity) -> VortexResult<()> {
-    let padded_dim = dimension.next_power_of_two();
+fn serde_round_trip(#[case] dimensions: u32, #[case] validity: Validity) -> VortexResult<()> {
+    let padded_dim = dimensions.next_power_of_two();
     let num_rows = 4;
     let options = SorfOptions {
         seed: 42,
         num_rounds: 3,
-        dimension,
+        dimensions,
         element_ptype: PType::F32,
     };
     let child = trivial_padded_vector(padded_dim, num_rows, validity);
@@ -491,5 +539,99 @@ fn serde_round_trip(#[case] dimension: u32, #[case] validity: Validity) -> Vorte
     assert_eq!(recovered.dtype(), original.dtype());
     assert_eq!(recovered.len(), original.len());
     assert_eq!(recovered.encoding_id(), original.encoding_id());
+    let recovered_scalar_fn = recovered.as_::<ScalarFnArrayEncoding>();
+    assert!(
+        recovered_scalar_fn
+            .child_at(0)
+            .dtype()
+            .as_extension()
+            .is::<Vector>()
+    );
+    Ok(())
+}
+
+#[test]
+fn serde_round_trip_preserves_normalized_vector_child_dtype() -> VortexResult<()> {
+    let dimension = 128;
+    let num_rows = 4;
+    let options = default_options(dimension, 42);
+    let child = trivial_padded_normalized_vector(
+        dimension.next_power_of_two(),
+        num_rows,
+        Validity::NonNullable,
+    )?;
+    let original = SorfTransform::try_new_array(&options, child.clone(), num_rows)?.into_array();
+
+    let plugin = ScalarFnArrayPlugin::new(SorfTransform);
+    let metadata = plugin
+        .serialize(&original, &SESSION)?
+        .expect("SorfTransform serialize must produce metadata");
+
+    let children = vec![child];
+    let recovered = plugin.deserialize(
+        original.dtype(),
+        original.len(),
+        &metadata,
+        &[],
+        &children,
+        &SESSION,
+    )?;
+
+    assert_eq!(recovered.dtype(), original.dtype());
+    assert_eq!(recovered.len(), original.len());
+    assert_eq!(recovered.encoding_id(), original.encoding_id());
+    let recovered_scalar_fn = recovered.as_::<ScalarFnArrayEncoding>();
+    assert!(
+        recovered_scalar_fn
+            .child_at(0)
+            .dtype()
+            .as_extension()
+            .is::<NormalizedVector>()
+    );
+    Ok(())
+}
+
+#[test]
+fn serde_legacy_metadata_derives_plain_vector_child_dtype() -> VortexResult<()> {
+    let dimension = 128;
+    let num_rows = 4;
+    let options = default_options(dimension, 42);
+    let child = trivial_padded_vector(
+        dimension.next_power_of_two(),
+        num_rows,
+        Validity::NonNullable,
+    );
+    let original = SorfTransform::try_new_array(&options, child.clone(), num_rows)?.into_array();
+
+    let legacy_metadata = LegacySorfTransformMetadata {
+        seed: options.seed,
+        num_rounds: u32::from(options.num_rounds),
+        dimension: options.dimensions,
+        element_ptype: options.element_ptype as i32,
+    }
+    .encode_to_vec();
+
+    let plugin = ScalarFnArrayPlugin::new(SorfTransform);
+    let children = vec![child];
+    let recovered = plugin.deserialize(
+        original.dtype(),
+        original.len(),
+        &legacy_metadata,
+        &[],
+        &children,
+        &SESSION,
+    )?;
+
+    assert_eq!(recovered.dtype(), original.dtype());
+    assert_eq!(recovered.len(), original.len());
+    assert_eq!(recovered.encoding_id(), original.encoding_id());
+    let recovered_scalar_fn = recovered.as_::<ScalarFnArrayEncoding>();
+    assert!(
+        recovered_scalar_fn
+            .child_at(0)
+            .dtype()
+            .as_extension()
+            .is::<Vector>()
+    );
     Ok(())
 }

--- a/vortex-tensor/src/scalar_fns/sorf_transform/vtable.rs
+++ b/vortex-tensor/src/scalar_fns/sorf_transform/vtable.rs
@@ -16,8 +16,10 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::ScalarFn as ScalarFnArrayEncoding;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
+use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex_array::arrays::scalar_fn::ScalarFnArrayView;
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayParts;
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayVTable;
@@ -26,6 +28,7 @@ use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::dtype::extension::ExtDType;
+use vortex_array::dtype::proto::dtype as pb;
 use vortex_array::expr::Expression;
 use vortex_array::extension::EmptyMetadata;
 use vortex_array::match_each_float_ptype;
@@ -47,6 +50,7 @@ use super::SorfOptions;
 use super::SorfTransform;
 use super::rotation::SorfMatrix;
 use super::validate_sorf_options;
+use crate::normalized_vector::NormalizedVector;
 use crate::types::vector::AnyVector;
 use crate::types::vector::Vector;
 
@@ -90,13 +94,13 @@ impl ScalarFnVTable for SorfTransform {
                 vortex_err!("SorfTransform child must be a Vector extension, got {child_dtype}")
             })?;
 
-        let expected_padded = options.dimension.next_power_of_two();
+        let expected_padded = options.dimensions.next_power_of_two();
         vortex_ensure_eq!(
             vector_metadata.dimensions(),
             expected_padded,
             "SorfTransform child Vector must have dimension {expected_padded} (next power of two \
              for dimension {})",
-            options.dimension,
+            options.dimensions,
         );
 
         // For now, the child Vector storage must be f32. TurboQuant stores its centroids as f32,
@@ -113,11 +117,16 @@ impl ScalarFnVTable for SorfTransform {
         let output_elem_dtype = DType::Primitive(options.element_ptype, Nullability::NonNullable);
         let storage_dtype = DType::FixedSizeList(
             Arc::new(output_elem_dtype),
-            options.dimension,
+            options.dimensions,
             child_dtype.nullability(),
         );
 
-        let ext_dtype = ExtDType::<Vector>::try_new(EmptyMetadata, storage_dtype)?.erased();
+        let ext_dtype = if vector_metadata.is_normalized() {
+            ExtDType::<NormalizedVector>::try_new(EmptyMetadata, storage_dtype)?.erased()
+        } else {
+            ExtDType::<Vector>::try_new(EmptyMetadata, storage_dtype)?.erased()
+        };
+
         Ok(DType::Extension(ext_dtype))
     }
 
@@ -127,19 +136,18 @@ impl ScalarFnVTable for SorfTransform {
         args: &dyn ExecutionArgs,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        validate_sorf_options(options)?;
-        let dim = options.dimension as usize;
+        let dim = options.dimensions as usize;
         let num_rows = args.row_count();
 
         if num_rows == 0 {
-            let child_nullability = args.get(0)?.dtype().nullability();
-            let validity = Validity::from(child_nullability);
+            let child_dtype = args.get(0)?.dtype().clone();
+            let validity = Validity::from(child_dtype.nullability());
 
             return match_each_float_ptype!(options.element_ptype, |T| {
                 let elements = PrimitiveArray::empty::<T>(Nullability::NonNullable);
                 let fsl = FixedSizeListArray::try_new(
                     elements.into_array(),
-                    options.dimension,
+                    options.dimensions,
                     validity,
                     0,
                 )?;
@@ -194,11 +202,10 @@ impl ScalarFnVTable for SorfTransform {
 
 /// Metadata for a serialized [`SorfTransform`] array.
 ///
-/// Stores the full [`SorfOptions`] inline. The child [`DType`] is not serialized because it is
-/// fully determined by the options: the child is always a [`Vector`] extension wrapping
-/// `FSL<f32, dimension.next_power_of_two()>`. The child's nullability is recovered from the
-/// parent output dtype at deserialize time, since `SorfTransform::return_dtype` propagates child
-/// nullability into the output FSL (see `return_dtype` above).
+/// Stores the full [`SorfOptions`] inline along with the child [`DType`]. The child dtype records
+/// whether the input was a plain [`Vector`] or [`NormalizedVector`](crate::normalized_vector::NormalizedVector).
+/// Older metadata omitted this field; deserialization derives the legacy plain-`Vector` child dtype
+/// from the parent dtype in that case.
 #[derive(Clone, prost::Message)]
 pub(super) struct SorfTransformMetadata {
     #[prost(uint64, tag = "1")]
@@ -210,6 +217,8 @@ pub(super) struct SorfTransformMetadata {
     dimension: u32,
     #[prost(enumeration = "PType", tag = "4")]
     element_ptype: i32,
+    #[prost(message, optional, tag = "5")]
+    child_dtype: Option<pb::DType>,
 }
 
 impl ScalarFnArrayVTable for SorfTransform {
@@ -218,9 +227,13 @@ impl ScalarFnArrayVTable for SorfTransform {
         view: &ScalarFnArrayView<Self>,
         _session: &VortexSession,
     ) -> VortexResult<Option<Vec<u8>>> {
-        Ok(Some(
-            SorfTransformMetadata::from(view.options).encode_to_vec(),
-        ))
+        let scalar_fn_array = view.as_::<ScalarFnArrayEncoding>();
+        let child_dtype = Some(scalar_fn_array.child_at(0).dtype().try_into()?);
+        let metadata = SorfTransformMetadata {
+            child_dtype,
+            ..SorfTransformMetadata::from(view.options)
+        };
+        Ok(Some(metadata.encode_to_vec()))
     }
 
     fn deserialize(
@@ -229,11 +242,11 @@ impl ScalarFnArrayVTable for SorfTransform {
         len: usize,
         metadata: &[u8],
         children: &dyn ArrayChildren,
-        _session: &VortexSession,
+        session: &VortexSession,
     ) -> VortexResult<ScalarFnArrayParts<Self>> {
-        let options = SorfTransformMetadata::decode(metadata)
-            .map_err(|e| vortex_err!("Failed to decode SorfTransformMetadata: {e}"))?
-            .to_options()?;
+        let metadata = SorfTransformMetadata::decode(metadata)
+            .map_err(|e| vortex_err!("Failed to decode SorfTransformMetadata: {e}"))?;
+        let options = metadata.to_options()?;
 
         // `return_dtype` sets the output FSL's nullability to the child's nullability (see
         // `return_dtype` above), so we read the child nullability back from the parent dtype.
@@ -244,14 +257,19 @@ impl ScalarFnArrayVTable for SorfTransform {
             })?
             .storage_dtype()
             .nullability();
-        let padded_dim = options.dimension.next_power_of_two();
+        let padded_dim = options.dimensions.next_power_of_two();
         let child_storage = DType::FixedSizeList(
             Arc::new(DType::Primitive(PType::F32, Nullability::NonNullable)),
             padded_dim,
             child_nullability,
         );
-        let child_ext = ExtDType::<Vector>::try_new(EmptyMetadata, child_storage)?.erased();
-        let child_dtype = DType::Extension(child_ext);
+        let child_dtype = match metadata.child_dtype.as_ref() {
+            Some(dtype) => DType::from_proto(dtype, session)?,
+            None => {
+                let child_ext = ExtDType::<Vector>::try_new(EmptyMetadata, child_storage)?.erased();
+                DType::Extension(child_ext)
+            }
+        };
         let child = children.get(0, &child_dtype, len)?;
 
         Ok(ScalarFnArrayParts {
@@ -270,7 +288,7 @@ fn float_from_f32<T: Float + FromPrimitive>(v: f32) -> T {
 }
 
 /// Apply the inverse SORF transform on f32 data, truncate to the original dimension, cast each
-/// element to `T`, and build the output [`Vector`] extension array.
+/// element to `T`, and build a plain [`Vector`](crate::vector::Vector) extension array.
 fn inverse_rotate_typed<T: NativePType + Float + FromPrimitive>(
     f32_elements: &[f32],
     rotation: &SorfMatrix,
@@ -304,8 +322,9 @@ impl From<&SorfOptions> for SorfTransformMetadata {
         Self {
             seed: options.seed,
             num_rounds: u32::from(options.num_rounds),
-            dimension: options.dimension,
+            dimension: options.dimensions,
             element_ptype: options.element_ptype as i32,
+            child_dtype: None,
         }
     }
 }
@@ -323,7 +342,7 @@ impl SorfTransformMetadata {
         let options = SorfOptions {
             seed: self.seed,
             num_rounds,
-            dimension: self.dimension,
+            dimensions: self.dimension,
             element_ptype: self.element_ptype(),
         };
         validate_sorf_options(&options)?;

--- a/vortex-tensor/src/types/mod.rs
+++ b/vortex-tensor/src/types/mod.rs
@@ -4,4 +4,5 @@
 //! Internal homes for tensor extension types.
 
 pub mod fixed_shape;
+pub mod normalized_vector;
 pub mod vector;

--- a/vortex-tensor/src/types/normalized_vector/matcher.rs
+++ b/vortex-tensor/src/types/normalized_vector/matcher.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::dtype::DType;
+use vortex_array::dtype::extension::ExtDTypeRef;
+use vortex_array::dtype::extension::Matcher;
+use vortex_error::VortexExpect;
+use vortex_error::vortex_panic;
+
+use crate::types::normalized_vector::NormalizedVector;
+use crate::types::vector::VectorMatcherMetadata;
+
+/// Matcher that accepts only the [`NormalizedVector`] extension type.
+///
+/// Use this when a consumer must reject plain [`Vector`](crate::vector::Vector) inputs. Callers
+/// that can accept either should use [`AnyVector`](crate::vector::AnyVector) instead.
+pub struct AnyNormalizedVector;
+
+impl Matcher for AnyNormalizedVector {
+    type Match<'a> = VectorMatcherMetadata;
+
+    fn try_match<'a>(ext_dtype: &'a ExtDTypeRef) -> Option<Self::Match<'a>> {
+        if !ext_dtype.is::<NormalizedVector>() {
+            return None;
+        }
+
+        let DType::FixedSizeList(element_dtype, list_size, _) = ext_dtype.storage_dtype() else {
+            vortex_panic!(
+                "`NormalizedVector` type somehow did not have a `FixedSizeList` storage type"
+            )
+        };
+        assert!(element_dtype.is_float(), "element dtype must be float");
+        assert!(
+            !element_dtype.is_nullable(),
+            "element dtype must be non-nullable"
+        );
+
+        let metadata = VectorMatcherMetadata::try_new(element_dtype.as_ptype(), *list_size, true)
+            .vortex_expect("`NormalizedVector` type somehow did not have float elements");
+
+        Some(metadata)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vortex_array::dtype::DType;
+    use vortex_array::dtype::Nullability;
+    use vortex_array::dtype::PType;
+    use vortex_array::dtype::extension::ExtDType;
+    use vortex_array::extension::EmptyMetadata;
+    use vortex_error::VortexResult;
+
+    use super::*;
+    use crate::types::vector::AnyVector;
+    use crate::types::vector::Vector;
+
+    fn storage_dtype(element_ptype: PType, dimensions: u32) -> DType {
+        DType::FixedSizeList(
+            Arc::new(DType::Primitive(element_ptype, Nullability::NonNullable)),
+            dimensions,
+            Nullability::NonNullable,
+        )
+    }
+
+    #[test]
+    fn matches_normalized_vector_dtype() -> VortexResult<()> {
+        let ext_dtype =
+            ExtDType::<NormalizedVector>::try_new(EmptyMetadata, storage_dtype(PType::F32, 128))?
+                .erased();
+
+        let metadata = ext_dtype.metadata::<AnyNormalizedVector>();
+        assert_eq!(metadata.element_ptype(), PType::F32);
+        assert_eq!(metadata.dimensions(), 128);
+        assert!(metadata.is_normalized());
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_plain_vector() -> VortexResult<()> {
+        let ext_dtype =
+            ExtDType::<Vector>::try_new(EmptyMetadata, storage_dtype(PType::F32, 128))?.erased();
+
+        assert!(ext_dtype.metadata_opt::<AnyNormalizedVector>().is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn any_vector_matches_normalized_vector() -> VortexResult<()> {
+        let ext_dtype =
+            ExtDType::<NormalizedVector>::try_new(EmptyMetadata, storage_dtype(PType::F32, 128))?
+                .erased();
+
+        let metadata = ext_dtype.metadata::<AnyVector>();
+        assert_eq!(metadata.element_ptype(), PType::F32);
+        assert_eq!(metadata.dimensions(), 128);
+        assert!(metadata.is_normalized());
+        Ok(())
+    }
+}

--- a/vortex-tensor/src/types/normalized_vector/mod.rs
+++ b/vortex-tensor/src/types/normalized_vector/mod.rs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Normalized vector extension type: a refinement of [`Vector`](crate::vector::Vector) whose
+//! rows are guaranteed (or asserted, for lossy encodings) to have unit L2 norm.
+
+use num_traits::ToPrimitive;
+use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::arrays::ExtensionArray;
+use vortex_array::arrays::extension::ExtensionArrayExt;
+use vortex_array::extension::EmptyMetadata;
+use vortex_array::match_each_float_ptype;
+use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
+
+use crate::utils::extract_flat_elements;
+use crate::utils::unit_norm_tolerance;
+use crate::utils::validate_tensor_float_input;
+
+/// Refinement of [`Vector`](crate::vector::Vector) that asserts every valid row is L2-normalized
+/// (unit-norm) or the zero vector.
+///
+/// The storage shape is identical to [`Vector`](crate::vector::Vector): a `FixedSizeList<float,
+/// dim, nullability>` with non-nullable float elements. Downstream operators such as
+/// [`L2Denorm`](crate::scalar_fns::l2_denorm::L2Denorm),
+/// [`L2Norm`](crate::scalar_fns::l2_norm::L2Norm),
+/// [`InnerProduct`](crate::scalar_fns::inner_product::InnerProduct), and
+/// [`CosineSimilarity`](crate::scalar_fns::cosine_similarity::CosineSimilarity) short-circuit
+/// arithmetic when they see this refinement.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct NormalizedVector;
+
+impl NormalizedVector {
+    /// Wraps `storage` as a [`NormalizedVector`] extension array after checking that every valid
+    /// row is unit-norm or the zero vector.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the extension dtype rejects `storage`, if `storage` is not a tensor
+    /// with float elements, or if any valid row's L2 norm is not `1.0` (or `0.0`) within the
+    /// tolerance implied by the element precision.
+    pub fn try_new(storage: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+        let ext = ExtensionArray::try_new_from_vtable(NormalizedVector, EmptyMetadata, storage)?
+            .into_array();
+        validate_unit_norm_rows(&ext, ctx)?;
+        Ok(ext)
+    }
+
+    /// Wraps `storage` as a [`NormalizedVector`] extension array **without** validating that
+    /// rows are unit-norm.
+    ///
+    /// # Safety
+    ///
+    /// Every valid row must be unit-norm or the zero vector. Lossy approximations (e.g.
+    /// TurboQuant) deliberately relax this, but still treat the claim as authoritative
+    /// downstream. Violating this does not cause memory unsafety but will produce silently
+    /// incorrect results.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the extension dtype rejects `storage` (e.g. non-FSL storage, wrong
+    /// element dtype, or nullable elements).
+    pub unsafe fn new_unchecked(storage: ArrayRef) -> VortexResult<ArrayRef> {
+        Ok(
+            ExtensionArray::try_new_from_vtable(NormalizedVector, EmptyMetadata, storage)?
+                .into_array(),
+        )
+    }
+}
+
+/// Validates that every valid row of a [`NormalizedVector`] extension array has L2 norm `1.0`
+/// or `0.0` within the element-precision tolerance.
+fn validate_unit_norm_rows(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<()> {
+    let row_count = array.len();
+    if row_count == 0 {
+        return Ok(());
+    }
+
+    let tensor_match = validate_tensor_float_input(array.dtype())?;
+    let element_ptype = tensor_match.element_ptype();
+    let tolerance = unit_norm_tolerance(element_ptype, tensor_match.list_size() as usize);
+    let tensor_flat_size = tensor_match.list_size() as usize;
+
+    let ext: ExtensionArray = array.clone().execute(ctx)?;
+    let validity = ext.as_ref().validity()?;
+    let flat = extract_flat_elements(ext.storage_array(), tensor_flat_size, ctx)?;
+
+    match_each_float_ptype!(element_ptype, |T| {
+        for i in 0..row_count {
+            if !validity.is_valid(i)? {
+                continue;
+            }
+
+            let row_norm_sq = flat.row::<T>(i).iter().fold(0.0f64, |sum_sq, x| {
+                let value = ToPrimitive::to_f64(x).unwrap_or(f64::NAN);
+                sum_sq + value * value
+            });
+            let row_norm = row_norm_sq.sqrt();
+
+            vortex_ensure!(
+                row_norm == 0.0 || (row_norm - 1.0).abs() <= tolerance,
+                "NormalizedVector row {i} has L2 norm {row_norm:.6}, expected 1.0 or 0.0",
+            );
+        }
+    });
+
+    Ok(())
+}
+
+mod matcher;
+mod vtable;
+
+pub use matcher::AnyNormalizedVector;

--- a/vortex-tensor/src/types/normalized_vector/vtable.rs
+++ b/vortex-tensor/src/types/normalized_vector/vtable.rs
@@ -8,17 +8,17 @@ use vortex_array::extension::EmptyMetadata;
 use vortex_array::scalar::ScalarValue;
 use vortex_error::VortexResult;
 
-use crate::types::vector::Vector;
+use crate::types::normalized_vector::NormalizedVector;
 use crate::types::vector::validate_vector_storage_dtype;
 
-impl ExtVTable for Vector {
+impl ExtVTable for NormalizedVector {
     type Metadata = EmptyMetadata;
 
     // TODO(connor): This is just a placeholder for now.
     type NativeValue<'a> = &'a ScalarValue;
 
     fn id(&self) -> ExtId {
-        ExtId::new("vortex.tensor.vector")
+        ExtId::new("vortex.tensor.normalized_vector")
     }
 
     fn serialize_metadata(&self, _metadata: &Self::Metadata) -> VortexResult<Vec<u8>> {
@@ -54,11 +54,9 @@ mod tests {
     use vortex_array::extension::EmptyMetadata;
     use vortex_error::VortexResult;
 
-    use crate::types::vector::Vector;
+    use crate::types::normalized_vector::NormalizedVector;
 
-    /// Constructs a `FixedSizeList` storage dtype with the given float [`PType`], list size, and
-    /// [`Nullability`].
-    fn vector_storage_dtype(ptype: PType, size: u32, nullability: Nullability) -> DType {
+    fn storage_dtype(ptype: PType, size: u32, nullability: Nullability) -> DType {
         DType::FixedSizeList(
             Arc::new(DType::Primitive(ptype, Nullability::NonNullable)),
             size,
@@ -71,8 +69,8 @@ mod tests {
     #[case::f32(PType::F32)]
     #[case::f64(PType::F64)]
     fn validate_accepts_float_types(#[case] ptype: PType) -> VortexResult<()> {
-        let storage = vector_storage_dtype(ptype, 128, Nullability::NonNullable);
-        ExtDType::<Vector>::try_new(EmptyMetadata, storage)?;
+        let storage = storage_dtype(ptype, 64, Nullability::NonNullable);
+        ExtDType::<NormalizedVector>::try_new(EmptyMetadata, storage)?;
         Ok(())
     }
 
@@ -82,40 +80,40 @@ mod tests {
     fn validate_accepts_any_outer_nullability(
         #[case] nullability: Nullability,
     ) -> VortexResult<()> {
-        let storage = vector_storage_dtype(PType::F32, 128, nullability);
-        ExtDType::<Vector>::try_new(EmptyMetadata, storage)?;
+        let storage = storage_dtype(PType::F32, 64, nullability);
+        ExtDType::<NormalizedVector>::try_new(EmptyMetadata, storage)?;
         Ok(())
     }
 
     #[test]
     fn validate_rejects_non_fsl() {
         let storage = DType::Primitive(PType::F32, Nullability::NonNullable);
-        assert!(ExtDType::<Vector>::try_new(EmptyMetadata, storage).is_err());
+        assert!(ExtDType::<NormalizedVector>::try_new(EmptyMetadata, storage).is_err());
     }
 
     #[test]
     fn validate_rejects_integer_elements() {
         let storage = DType::FixedSizeList(
             Arc::new(DType::Primitive(PType::U32, Nullability::NonNullable)),
-            128,
+            64,
             Nullability::NonNullable,
         );
-        assert!(ExtDType::<Vector>::try_new(EmptyMetadata, storage).is_err());
+        assert!(ExtDType::<NormalizedVector>::try_new(EmptyMetadata, storage).is_err());
     }
 
     #[test]
     fn validate_rejects_nullable_elements() {
         let storage = DType::FixedSizeList(
             Arc::new(DType::Primitive(PType::F32, Nullability::Nullable)),
-            128,
+            64,
             Nullability::NonNullable,
         );
-        assert!(ExtDType::<Vector>::try_new(EmptyMetadata, storage).is_err());
+        assert!(ExtDType::<NormalizedVector>::try_new(EmptyMetadata, storage).is_err());
     }
 
     #[test]
     fn roundtrip_metadata() -> VortexResult<()> {
-        let vtable = Vector;
+        let vtable = NormalizedVector;
         let bytes = vtable.serialize_metadata(&EmptyMetadata)?;
         assert!(bytes.is_empty());
         let deserialized = vtable.deserialize_metadata(&bytes)?;

--- a/vortex-tensor/src/types/vector/matcher.rs
+++ b/vortex-tensor/src/types/vector/matcher.rs
@@ -10,8 +10,16 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_panic;
 
+use crate::types::normalized_vector::NormalizedVector;
 use crate::types::vector::Vector;
 
+/// Matcher that accepts both the plain [`Vector`] extension type and the
+/// [`NormalizedVector`](crate::normalized_vector::NormalizedVector) refinement.
+///
+/// Callers that care only about the vector-shaped storage (element dtype and dimension) should
+/// use this matcher. Callers that must distinguish the refinement can check
+/// [`VectorMatcherMetadata::is_normalized`] or use
+/// [`AnyNormalizedVector`](crate::normalized_vector::AnyNormalizedVector).
 pub struct AnyVector;
 
 /// Convenience metadata for vectors.
@@ -33,15 +41,24 @@ pub struct VectorMatcherMetadata {
 
     /// The number of dimensions of the vector. This is always fixed.
     dimensions: u32,
+
+    /// Whether this vector is known to be L2-normalized (rows are unit-norm or zero).
+    ///
+    /// Set to `true` for `NormalizedVector` matches and `false` for plain `Vector` matches.
+    is_normalized: bool,
 }
 
 impl Matcher for AnyVector {
     type Match<'a> = VectorMatcherMetadata;
 
     fn try_match<'a>(ext_dtype: &'a ExtDTypeRef) -> Option<Self::Match<'a>> {
-        if !ext_dtype.is::<Vector>() {
+        let is_normalized = if ext_dtype.is::<Vector>() {
+            false
+        } else if ext_dtype.is::<NormalizedVector>() {
+            true
+        } else {
             return None;
-        }
+        };
 
         let DType::FixedSizeList(element_dtype, list_size, _) = ext_dtype.storage_dtype() else {
             vortex_panic!("`Vector` type somehow did not have a `FixedSizeList` storage type")
@@ -56,8 +73,9 @@ impl Matcher for AnyVector {
         );
         let element_ptype = element_dtype.as_ptype();
 
-        let vector_metadata = VectorMatcherMetadata::try_new(element_ptype, dimensions)
-            .vortex_expect("`Vector` type somehow did not have float elements");
+        let vector_metadata =
+            VectorMatcherMetadata::try_new(element_ptype, dimensions, is_normalized)
+                .vortex_expect("`Vector` type somehow did not have float elements");
 
         Some(vector_metadata)
     }
@@ -69,12 +87,17 @@ impl VectorMatcherMetadata {
     /// # Errors
     ///
     /// Returns an error if the element type is not a float.
-    pub fn try_new(element_ptype: PType, dimensions: u32) -> VortexResult<Self> {
+    pub fn try_new(
+        element_ptype: PType,
+        dimensions: u32,
+        is_normalized: bool,
+    ) -> VortexResult<Self> {
         vortex_ensure!(element_ptype.is_float());
 
         Ok(Self {
             element_ptype,
             dimensions,
+            is_normalized,
         })
     }
 
@@ -86,6 +109,12 @@ impl VectorMatcherMetadata {
     /// Returns the number of dimensions of the vector.
     pub fn dimensions(&self) -> u32 {
         self.dimensions
+    }
+
+    /// Returns `true` when the matched dtype is a
+    /// [`NormalizedVector`](crate::normalized_vector::NormalizedVector).
+    pub fn is_normalized(&self) -> bool {
+        self.is_normalized
     }
 }
 
@@ -121,6 +150,22 @@ mod tests {
         let metadata = ext_dtype.metadata::<AnyVector>();
         assert_eq!(metadata.element_ptype(), PType::F32);
         assert_eq!(metadata.dimensions(), 256);
+        assert!(!metadata.is_normalized());
+        Ok(())
+    }
+
+    #[test]
+    fn matches_normalized_vector_dtype_metadata() -> VortexResult<()> {
+        let ext_dtype = ExtDType::<NormalizedVector>::try_new(
+            EmptyMetadata,
+            vector_storage_dtype(PType::F32, 256),
+        )?
+        .erased();
+
+        let metadata = ext_dtype.metadata::<AnyVector>();
+        assert_eq!(metadata.element_ptype(), PType::F32);
+        assert_eq!(metadata.dimensions(), 256);
+        assert!(metadata.is_normalized());
         Ok(())
     }
 

--- a/vortex-tensor/src/types/vector/mod.rs
+++ b/vortex-tensor/src/types/vector/mod.rs
@@ -14,6 +14,30 @@ use vortex_array::extension::EmptyMetadata;
 use vortex_array::scalar::PValue;
 use vortex_array::scalar::Scalar;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_ensure;
+
+/// Validates that `storage` is a valid storage dtype for a [`Vector`] or
+/// [`NormalizedVector`](crate::normalized_vector::NormalizedVector) extension type.
+///
+/// The storage must be a `FixedSizeList<float, dim, nullability>` with non-nullable float
+/// elements. The outer nullability is not constrained.
+pub(crate) fn validate_vector_storage_dtype(storage: &DType) -> VortexResult<()> {
+    let DType::FixedSizeList(element_dtype, _list_size, _nullability) = storage else {
+        vortex_bail!("Vector storage dtype must be a FixedSizeList, got {storage}");
+    };
+
+    vortex_ensure!(
+        element_dtype.is_float(),
+        "Vector element dtype must be a float, got {element_dtype}"
+    );
+    vortex_ensure!(
+        !element_dtype.is_nullable(),
+        "Vector element dtype must be non-nullable"
+    );
+
+    Ok(())
+}
 
 /// The Vector extension type.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]

--- a/vortex-tensor/src/utils.rs
+++ b/vortex-tensor/src/utils.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use half::f16;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
@@ -8,22 +9,68 @@ use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::ScalarFn;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_array::arrays::scalar_fn::ExactScalarFn;
+use vortex_array::arrays::scalar_fn::ScalarFnArrayView;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::PType;
+use vortex_array::dtype::proto::dtype as pb;
+use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_buffer::Buffer;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
+use vortex_session::VortexSession;
 
 use crate::matcher::AnyTensor;
 use crate::matcher::TensorMatch;
 use crate::scalar_fns::l2_denorm::L2Denorm;
+
+/// Safety factor for unit-norm tolerance. Applied as a constant multiplier on the probabilistic
+/// `√d · ε` bound so that legitimate round-off noise clears the check with headroom.
+pub(crate) const SAFETY_FACTOR: usize = 10;
+
+/// Returns the acceptable unit-norm drift for the given element precision and dimension count.
+///
+/// Uses the `c · √d · ε` bound where ε is machine epsilon and d is the vector dimension. Under
+/// IEEE 754 round-to-nearest the probabilistic (RMS-case) forward error for computing ‖x‖₂ grows
+/// as `O(√d · ε)` rather than the worst-case `O(d · ε)` from the classical Wilkinson bound,
+/// assuming near-independent rounding errors across the d-term summation.
+///
+/// Reference: Croci, Fasi, Higham, Mary, Mikaitis (2022). "Stochastic rounding: implementation,
+/// error analysis and applications." Royal Society Open Science, 9: 211631, §6.1 "Probabilistic
+/// error analysis." https://doi.org/10.1098/rsos.211631
+pub fn unit_norm_tolerance(element_ptype: PType, dimensions: usize) -> f64 {
+    let machine_epsilon: f64 = match element_ptype {
+        PType::F64 => f64::EPSILON,
+        PType::F32 => f32::EPSILON as f64,
+        PType::F16 => f16::EPSILON.to_f64_const(),
+        _ => unreachable!("unit_norm_tolerance requires a float ptype, got {element_ptype:?}"),
+    };
+
+    let dimensions_root = (dimensions as f64).sqrt();
+
+    SAFETY_FACTOR as f64 * machine_epsilon * dimensions_root
+}
+
+/// Extracts the `(normalized, norms)` children from an [`L2Denorm`] scalar function array.
+///
+/// [`L2Denorm`]: crate::scalar_fns::l2_denorm::L2Denorm
+pub fn extract_l2_denorm_children(array: &ArrayRef) -> (ArrayRef, ArrayRef) {
+    let sfn = array
+        .as_opt::<ExactScalarFn<L2Denorm>>()
+        .vortex_expect("expected ScalarFnArray wrapping L2Denorm");
+    (
+        sfn.nth_child(0)
+            .vortex_expect("L2Denorm missing normalized array"),
+        sfn.nth_child(1).vortex_expect("L2Denorm missing norms"),
+    )
+}
 
 /// Validates that `input_dtype` is a float-valued tensor-like extension dtype.
 pub fn validate_tensor_float_input(input_dtype: &DType) -> VortexResult<TensorMatch<'_>> {
@@ -47,18 +94,39 @@ pub fn validate_tensor_float_input(input_dtype: &DType) -> VortexResult<TensorMa
 /// Validates that two arguments of a binary tensor-like operator share the same float tensor
 /// dtype (ignoring top-level nullability), returning the shared [`TensorMatch`].
 ///
+/// The plain [`Vector`](crate::vector::Vector) and the
+/// [`NormalizedVector`](crate::normalized_vector::NormalizedVector) refinement are treated as
+/// interchangeable for the purposes of this check, since both share the same storage shape
+/// and operators like inner product or cosine similarity ignore the unit-norm marker.
+///
 /// `op_name` is interpolated into the shape-mismatch error message so callers get a
 /// self-identifying diagnostic (e.g. "InnerProduct requires both inputs ...").
 pub fn validate_binary_tensor_float_inputs<'a>(
-    op_name: &str,
     lhs: &'a DType,
     rhs: &DType,
 ) -> VortexResult<TensorMatch<'a>> {
+    let dtypes_match = lhs.eq_ignore_nullability(rhs) || vector_shapes_match(lhs, rhs);
     vortex_ensure!(
-        lhs.eq_ignore_nullability(rhs),
-        "{op_name} requires both inputs to have the same dtype, got {lhs} and {rhs}"
+        dtypes_match,
+        "binary tensor expression expects inputs to have the same dtype, got {lhs} and {rhs}"
     );
     validate_tensor_float_input(lhs)
+}
+
+/// Returns `true` when `lhs` and `rhs` are both vector-shaped extension types (plain `Vector`
+/// or `NormalizedVector`) with the same float ptype and dimension.
+fn vector_shapes_match(lhs: &DType, rhs: &DType) -> bool {
+    let lhs_match = lhs
+        .as_extension_opt()
+        .and_then(|ext| ext.metadata_opt::<crate::types::vector::AnyVector>());
+    let rhs_match = rhs
+        .as_extension_opt()
+        .and_then(|ext| ext.metadata_opt::<crate::types::vector::AnyVector>());
+    matches!(
+        (lhs_match, rhs_match),
+        (Some(l), Some(r))
+            if l.element_ptype() == r.element_ptype() && l.dimensions() == r.dimensions()
+    )
 }
 
 /// Cast a float [`PrimitiveArray`] to a `Buffer<f32>`.
@@ -73,7 +141,7 @@ pub fn validate_binary_tensor_float_inputs<'a>(
 pub fn cast_to_f32(prim: PrimitiveArray) -> VortexResult<Buffer<f32>> {
     match prim.ptype() {
         PType::F16 => Ok(prim
-            .as_slice::<half::f16>()
+            .as_slice::<f16>()
             .iter()
             .map(|&v| f32::from(v))
             .collect()),
@@ -209,18 +277,62 @@ pub fn extract_constant_flat_row(
     Ok(FlatRow { elems })
 }
 
-/// Extracts the `(normalized, norms)` children from an [`L2Denorm`] scalar function array.
+/// Metadata for a serialized binary tensor-op array (shared by [`InnerProduct`] and
+/// [`CosineSimilarity`]). Both operands share the same extension dtype up to nullability
+/// (enforced by their `return_dtype` checks), but their individual nullabilities are lost in the
+/// parent's unioned output, so both are persisted.
 ///
-/// [`L2Denorm`]: crate::scalar_fns::l2_denorm::L2Denorm
-pub fn extract_l2_denorm_children(array: &ArrayRef) -> (ArrayRef, ArrayRef) {
-    let sfn = array
-        .as_opt::<ExactScalarFn<L2Denorm>>()
-        .vortex_expect("expected ScalarFnArray wrapping L2Denorm");
-    (
-        sfn.nth_child(0)
-            .vortex_expect("L2Denorm missing normalized array"),
-        sfn.nth_child(1).vortex_expect("L2Denorm missing norms"),
-    )
+/// [`CosineSimilarity`]: crate::scalar_fns::cosine_similarity::CosineSimilarity
+#[derive(Clone, prost::Message)]
+pub(crate) struct BinaryTensorOpMetadata {
+    #[prost(message, optional, tag = "1")]
+    pub(crate) lhs_dtype: Option<pb::DType>,
+    #[prost(message, optional, tag = "2")]
+    pub(crate) rhs_dtype: Option<pb::DType>,
+}
+
+impl BinaryTensorOpMetadata {
+    /// Encodes the two children of `view` into a [`BinaryTensorOpMetadata`] byte blob.
+    pub(crate) fn encode_from_view<V: ScalarFnVTable>(
+        view: &ScalarFnArrayView<V>,
+    ) -> VortexResult<Vec<u8>> {
+        let scalar_fn_array = view.as_::<ScalarFn>();
+        let lhs_dtype = Some(scalar_fn_array.child_at(0).dtype().try_into()?);
+        let rhs_dtype = Some(scalar_fn_array.child_at(1).dtype().try_into()?);
+        Ok(Self {
+            lhs_dtype,
+            rhs_dtype,
+        }
+        .encode_to_vec())
+    }
+
+    /// Decodes `metadata` and fetches both children from `children` using the decoded dtypes,
+    /// validating that `lhs` and `rhs` are compatible tensor operands.
+    pub(crate) fn decode_children(
+        metadata: &[u8],
+        len: usize,
+        children: &dyn vortex_array::serde::ArrayChildren,
+        session: &VortexSession,
+    ) -> VortexResult<Vec<ArrayRef>> {
+        let metadata = Self::decode(metadata)
+            .map_err(|e| vortex_err!("Failed to decode BinaryTensorOpMetadata: {e}"))?;
+        let lhs_pb = metadata
+            .lhs_dtype
+            .as_ref()
+            .ok_or_else(|| vortex_err!("metadata missing lhs_dtype"))?;
+        let rhs_pb = metadata
+            .rhs_dtype
+            .as_ref()
+            .ok_or_else(|| vortex_err!("metadata missing rhs_dtype"))?;
+
+        let lhs_dtype = DType::from_proto(lhs_pb, session)?;
+        let rhs_dtype = DType::from_proto(rhs_pb, session)?;
+        validate_binary_tensor_float_inputs(&lhs_dtype, &rhs_dtype)?;
+
+        let lhs = children.get(0, &lhs_dtype, len)?;
+        let rhs = children.get(1, &rhs_dtype, len)?;
+        Ok(vec![lhs, rhs])
+    }
 }
 
 #[cfg(test)]
@@ -245,6 +357,7 @@ pub mod test_helpers {
     use crate::scalar_fns::l2_denorm::L2Denorm;
     use crate::types::fixed_shape::FixedShapeTensor;
     use crate::types::fixed_shape::FixedShapeTensorMetadata;
+    use crate::types::normalized_vector::NormalizedVector;
     use crate::types::vector::Vector;
 
     /// Builds a `FixedSizeList<T, list_size>` storage array from flat `elements`. The row count is
@@ -283,6 +396,16 @@ pub mod test_helpers {
         Vector::try_new_vector_array(flat_fsl(elements, dim))
     }
 
+    /// Builds a [`NormalizedVector`] extension array from pre-normalized `elements` and a vector
+    /// dimension size. The caller must ensure each row is unit-norm or the zero vector.
+    pub fn normalized_vector_array<T: NativePType>(
+        dim: u32,
+        elements: &[T],
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        NormalizedVector::try_new(flat_fsl(elements, dim), ctx)
+    }
+
     /// Builds a [`FixedShapeTensor`] extension array whose storage is a [`ConstantArray`],
     /// representing a single query tensor broadcast to `len` rows.
     pub fn constant_tensor_array<T: NativePType + Into<PValue>>(
@@ -310,17 +433,21 @@ pub mod test_helpers {
         ConstantArray::new(ext_scalar, len).into_array()
     }
 
-    /// Creates an [`L2Denorm`] scalar function array from pre-normalized tensor elements and
+    /// Creates an [`L2Denorm`] scalar function array from pre-normalized vector elements and
     /// matching norms. The caller must ensure every row of `normalized_elements` is unit-norm or
     /// zero.
+    ///
+    /// `dim` is the vector dimension (the inner `FixedSizeList` width). The number of rows is
+    /// inferred from `normalized_elements.len() / dim`.
     pub fn l2_denorm_array<T: NativePType>(
-        shape: &[usize],
+        dim: u32,
         normalized_elements: &[T],
         norms: &[T],
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         let len = norms.len();
-        let normalized = tensor_array(shape, normalized_elements)?;
+        let storage = flat_fsl(normalized_elements, dim);
+        let normalized = NormalizedVector::try_new(storage, ctx)?;
         let norms =
             PrimitiveArray::new(Buffer::copy_from(norms), Validity::NonNullable).into_array();
         Ok(L2Denorm::try_new_array(normalized, norms, len, ctx)?.into_array())

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -504,7 +504,7 @@ mod turboquant_benches {
     use vortex_array::VortexSessionExecute;
     use vortex_buffer::BufferMut;
     use vortex_tensor::encodings::turboquant::TurboQuantConfig;
-    use vortex_tensor::encodings::turboquant::turboquant_encode_unchecked;
+    use vortex_tensor::encodings::turboquant::turboquant_encode_normalized;
     use vortex_tensor::scalar_fns::l2_denorm::normalize_as_l2_denorm;
     use vortex_tensor::vector::Vector;
 
@@ -544,7 +544,7 @@ mod turboquant_benches {
     fn turboquant_config(bit_width: u8) -> TurboQuantConfig {
         TurboQuantConfig {
             bit_width,
-            seed: Some(123),
+            seed: 123,
             num_rounds: 3,
         }
     }
@@ -575,7 +575,7 @@ mod turboquant_benches {
                                 .expect("normalized benchmark input should be an Extension array");
                             // SAFETY: Benchmark inputs are normalized once up front so the timed
                             // region measures only TurboQuant encoding.
-                            unsafe { turboquant_encode_unchecked(normalized, &config, ctx) }
+                            turboquant_encode_normalized(normalized, &config, ctx)
                                 .unwrap()
                         });
                 }
@@ -588,10 +588,9 @@ mod turboquant_benches {
                     let normalized_ext = setup_normalized_vector_ext($dim);
                     let config = turboquant_config($bits);
                     let mut ctx = SESSION.create_execution_ctx();
-                    let compressed = unsafe {
-                        turboquant_encode_unchecked(normalized_ext.as_view(), &config, &mut ctx)
-                    }
-                    .unwrap();
+                    let compressed =
+                        turboquant_encode_normalized(normalized_ext.as_view(), &config, &mut ctx)
+                            .unwrap();
                     with_byte_counter(bencher, (NUM_VECTORS * $dim * 4) as u64)
                         .with_inputs(|| (&compressed, SESSION.create_execution_ctx()))
                         .bench_refs(|(a, ctx)| {


### PR DESCRIPTION
## Summary

Tracking issue: https://github.com/vortex-data/vortex/issues/7297

Adds a new `NormalizedVector` logical extension type, which is a refinement type of `Vector` where all vectors are unit-normalized (with some tolerance).

Also generally cleans up the `vortex-tensor` crate because we are refining logic, and the rest of the crate needs to also be more refined.

It is unclear if there is a better way to represent refinement types in the [Vortex type system](https://productionresultssa0.blob.core.windows.net/actions-results/9fb512b7-d10c-4c02-b793-0b399388281b/workflow-job-run-1b8a5558-685a-5a30-b320-66cc49fc9487/artifacts/474c99a03c874a78c77ffb85b3b35e33e95c123cd1f3f8a3931add57f3a7fb6d.html?rscd=inline%3B+filename%3D%22preview.html%22&rsct=text%2Fhtml&se=2026-04-20T20%3A53%3A40Z&sig=sT0ScnMjlaOfamsMiht6bii1v7jOMiYyRjxnrK2xsNs%3D&ske=2026-04-20T23%3A35%3A01Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-04-20T19%3A35%3A01Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-04-20T20%3A43%3A35Z&sv=2025-11-05), as there is a lot of boilerplate code that we need to add just to support this relatively simple invariant.

## Testing

Basic testing.