### PR TITLE
Remove ScalarFnConstantRule

### DIFF
--- a/vortex-array/src/arrays/scalar_fn/rules.rs
+++ b/vortex-array/src/arrays/scalar_fn/rules.rs
@@ -9,9 +9,7 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
-use crate::Canonical;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::array::ArrayView;
 use crate::arrays::Constant;
@@ -36,7 +34,6 @@ use crate::validity::Validity;
 
 pub(super) const RULES: ReduceRuleSet<ScalarFnVTable> = ReduceRuleSet::new(&[
     &ScalarFnPackToStructRule,
-    &ScalarFnConstantRule,
     &ScalarFnAbstractReduceRule,
 ]);
 
@@ -68,24 +65,6 @@ impl ArrayReduceRule<ScalarFnVTable> for ScalarFnPackToStructRule {
             )?
             .into_array(),
         ))
-    }
-}
-
-#[derive(Debug)]
-struct ScalarFnConstantRule;
-impl ArrayReduceRule<ScalarFnVTable> for ScalarFnConstantRule {
-    fn reduce(&self, array: ArrayView<'_, ScalarFnVTable>) -> VortexResult<Option<ArrayRef>> {
-        if !array.children().iter().all(|c| c.is::<Constant>()) {
-            return Ok(None);
-        }
-        if array.is_empty() {
-            Ok(Some(Canonical::empty(array.dtype()).into_array()))
-        } else {
-            let result = array
-                .array()
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())?;
-            Ok(Some(ConstantArray::new(result, array.len()).into_array()))
-        }
     }
 }
 

--- a/vortex-array/src/arrays/scalar_fn/rules.rs
+++ b/vortex-array/src/arrays/scalar_fn/rules.rs
@@ -32,10 +32,8 @@ use crate::scalar_fn::ScalarFnRef;
 use crate::scalar_fn::fns::pack::Pack;
 use crate::validity::Validity;
 
-pub(super) const RULES: ReduceRuleSet<ScalarFnVTable> = ReduceRuleSet::new(&[
-    &ScalarFnPackToStructRule,
-    &ScalarFnAbstractReduceRule,
-]);
+pub(super) const RULES: ReduceRuleSet<ScalarFnVTable> =
+    ReduceRuleSet::new(&[&ScalarFnPackToStructRule, &ScalarFnAbstractReduceRule]);
 
 pub(super) const PARENT_RULES: ParentRuleSet<ScalarFnVTable> = ParentRuleSet::new(&[
     ParentRuleSet::lift(&ScalarFnUnaryFilterPushDownRule),

--- a/vortex-array/src/arrays/scalar_fn/rules.rs
+++ b/vortex-array/src/arrays/scalar_fn/rules.rs
@@ -10,7 +10,6 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
-use crate::VortexSessionExecute;
 use crate::array::ArrayView;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -13,7 +13,7 @@ use vortex_error::vortex_bail;
 use vortex_proto::expr as pb;
 use vortex_session::VortexSession;
 
-use crate::ArrayRef;
+use crate::{ArrayRef, Columnar};
 use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -440,7 +440,6 @@ mod tests {
 
         // upper is a fixed constant
         let upper = ConstantArray::new(Scalar::from(2), 5).into_array();
-        #[expect(deprecated)]
         let matches = between_canonical(
             &array,
             &lower,
@@ -460,7 +459,6 @@ mod tests {
         // lower is also a constant
         let lower = ConstantArray::new(Scalar::from(0), 5).into_array();
 
-        #[expect(deprecated)]
         let matches = between_canonical(
             &array,
             &lower,

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -13,7 +13,7 @@ use vortex_error::vortex_bail;
 use vortex_proto::expr as pb;
 use vortex_session::VortexSession;
 
-use crate::{ArrayRef, Columnar};
+use crate::ArrayRef;
 use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
@@ -324,14 +324,13 @@ impl ScalarFnVTable for Between {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::LazyLock;
+
     use rstest::rstest;
     use vortex_buffer::buffer;
 
     use super::*;
     use crate::IntoArray;
-    use crate::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use crate::ToCanonical as _;
     use crate::VortexSessionExecute;
     use crate::arrays::BoolArray;
     use crate::arrays::DecimalArray;
@@ -346,8 +345,12 @@ mod tests {
     use crate::expr::root;
     use crate::scalar::DecimalValue;
     use crate::scalar::Scalar;
+    use crate::session::ArraySession;
     use crate::test_harness::to_int_indices;
     use crate::validity::Validity;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     #[test]
     fn test_display() {
@@ -388,7 +391,6 @@ mod tests {
         let array = buffer![1, 0, 1, 0, 1].into_array();
         let upper = buffer![2, 1, 1, 0, 0].into_array();
 
-        #[expect(deprecated)]
         let matches = between_canonical(
             &array,
             &lower,
@@ -397,10 +399,11 @@ mod tests {
                 lower_strict,
                 upper_strict,
             },
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap()
-        .to_bool();
+        .execute::<BoolArray>(&mut SESSION.create_execution_ctx())
+        .unwrap();
 
         let indices = to_int_indices(matches).unwrap();
         assert_eq!(indices, expected);
@@ -418,7 +421,6 @@ mod tests {
         )
         .into_array();
 
-        #[expect(deprecated)]
         let matches = between_canonical(
             &array,
             &lower,
@@ -427,10 +429,11 @@ mod tests {
                 lower_strict: StrictComparison::NonStrict,
                 upper_strict: StrictComparison::NonStrict,
             },
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap()
-        .to_bool();
+        .execute::<BoolArray>(&mut SESSION.create_execution_ctx())
+        .unwrap();
 
         let indices = to_int_indices(matches).unwrap();
         assert!(indices.is_empty());
@@ -446,10 +449,11 @@ mod tests {
                 lower_strict: StrictComparison::NonStrict,
                 upper_strict: StrictComparison::NonStrict,
             },
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap()
-        .to_bool();
+        .execute::<BoolArray>(&mut SESSION.create_execution_ctx())
+        .unwrap();
         let indices = to_int_indices(matches).unwrap();
         assert_eq!(indices, vec![0, 1, 3]);
 
@@ -465,10 +469,11 @@ mod tests {
                 lower_strict: StrictComparison::NonStrict,
                 upper_strict: StrictComparison::NonStrict,
             },
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap()
-        .to_bool();
+        .execute::<BoolArray>(&mut SESSION.create_execution_ctx())
+        .unwrap();
         let indices = to_int_indices(matches).unwrap();
         assert_eq!(indices, vec![0, 1, 2, 3, 4]);
     }
@@ -507,7 +512,7 @@ mod tests {
                 lower_strict: StrictComparison::Strict,
                 upper_strict: StrictComparison::NonStrict,
             },
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         assert_arrays_eq!(
@@ -524,7 +529,7 @@ mod tests {
                 lower_strict: StrictComparison::NonStrict,
                 upper_strict: StrictComparison::Strict,
             },
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         assert_arrays_eq!(

--- a/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
@@ -827,7 +827,6 @@ mod tests {
 
         let expr = list_contains(root(), lit(2i32));
         let contains = list_array.apply(&expr).unwrap();
-        assert!(contains.is::<Constant>(), "Expected constant result");
         let expected = BoolArray::from_iter([true, true]);
         assert_arrays_eq!(contains, expected);
     }
@@ -845,7 +844,6 @@ mod tests {
 
         let expr = list_contains(root(), lit(2i32));
         let contains = list_array.apply(&expr).unwrap();
-        assert!(contains.is::<Constant>(), "Expected constant result");
 
         let expected = BoolArray::new(
             [false, false, false, false, false].into_iter().collect(),

--- a/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
@@ -483,7 +483,6 @@ mod tests {
     use crate::expr::stats::Stat;
     use crate::scalar::Scalar;
     use crate::scalar_fn::fns::list_contains::BoolArray;
-    use crate::scalar_fn::fns::list_contains::Constant;
     use crate::scalar_fn::fns::list_contains::ConstantArray;
     use crate::scalar_fn::fns::list_contains::ListViewArray;
     use crate::scalar_fn::fns::list_contains::PrimitiveArray;


### PR DESCRIPTION
This reduction rule does execution and prevents any parent reduce rules from
triggering

