### PR TITLE
deprecate: into_arrow

### DIFF
--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -576,7 +576,7 @@ mod test {
     use vortex_array::arrays::VarBinArray;
     use vortex_array::arrays::VarBinViewArray;
     use vortex_array::arrays::listview::ListViewArrayExt;
-    use vortex_array::arrow::IntoArrowArray as _;
+    use vortex_array::arrow::ArrowArrayExecutor;
     use vortex_array::assert_arrays_eq;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::DecimalDType;
@@ -829,7 +829,7 @@ mod test {
             Validity::from_mask(Mask::from_excluded_indices(10, vec![8]), Nullable),
         )
         .into_array()
-        .into_arrow_preferred()
+        .execute_arrow(None, &mut ctx)
         .unwrap();
 
         let actual = sparse_struct
@@ -838,7 +838,7 @@ mod test {
             .execute::<DecimalArray>(&mut ctx)
             .unwrap()
             .into_array()
-            .into_arrow_preferred()
+            .execute_arrow(None, &mut ctx)
             .unwrap();
 
         assert_eq!(expected.data_type(), actual.data_type());
@@ -1555,8 +1555,10 @@ mod test {
 
         // Note that the preferred arrow list representation is `List` (not `ListView`).
         let arrow_dtype = expected.dtype().to_arrow_dtype().unwrap();
-        let actual = actual.into_arrow(&arrow_dtype).unwrap();
-        let expected = expected.into_arrow(&arrow_dtype).unwrap();
+        let actual = actual.execute_arrow(Some(&arrow_dtype), &mut ctx).unwrap();
+        let expected = expected
+            .execute_arrow(Some(&arrow_dtype), &mut ctx)
+            .unwrap();
 
         assert_eq!(actual.data_type(), expected.data_type());
         Ok(())

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -6798,11 +6798,11 @@ impl vortex_array::arrow::Datum
 
 pub fn vortex_array::arrow::Datum::data_type(&self) -> &arrow_schema::datatype::DataType
 
-pub fn vortex_array::arrow::Datum::try_new(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrow::Datum::try_new(array: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::arrow::Datum::try_new_array(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrow::Datum::try_new_array(array: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::arrow::Datum::try_new_with_target_datatype(array: &vortex_array::ArrayRef, target_datatype: &arrow_schema::datatype::DataType) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrow::Datum::try_new_with_target_datatype(array: &vortex_array::ArrayRef, target_datatype: &arrow_schema::datatype::DataType, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
 impl arrow_array::scalar::Datum for vortex_array::arrow::Datum
 
@@ -15608,7 +15608,7 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::coerce_args(&self, operator
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::fmt_sql(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -16252,7 +16252,7 @@ pub fn vortex_array::scalar_fn::fns::like::Like::coerce_args(&self, options: &Se
 
 pub fn vortex_array::scalar_fn::fns::like::Like::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::like::Like::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::like::Like::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::like::Like::fmt_sql(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -17752,7 +17752,7 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::coerce_args(&self, operator
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::fmt_sql(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -18056,7 +18056,7 @@ pub fn vortex_array::scalar_fn::fns::like::Like::coerce_args(&self, options: &Se
 
 pub fn vortex_array::scalar_fn::fns::like::Like::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::like::Like::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::like::Like::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::like::Like::fmt_sql(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 

--- a/vortex-array/src/arrays/constant/compute/fill_null.rs
+++ b/vortex-array/src/arrays/constant/compute/fill_null.rs
@@ -22,8 +22,10 @@ impl FillNullReduce for Constant {
 #[cfg(test)]
 mod test {
     use crate::IntoArray as _;
+    use crate::LEGACY_SESSION;
+    use crate::VortexSessionExecute;
     use crate::arrays::ConstantArray;
-    use crate::arrow::IntoArrowArray as _;
+    use crate::arrow::ArrowArrayExecutor;
     use crate::builtins::ArrayBuiltins;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
@@ -32,6 +34,7 @@ mod test {
 
     #[test]
     fn test_null() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let actual = ConstantArray::new(Scalar::null_native::<i32>(), 3)
             .into_array()
             .fill_null(Scalar::from(1))
@@ -40,8 +43,8 @@ mod test {
 
         assert!(!actual.dtype().is_nullable());
 
-        let actual_arrow = actual.clone().into_arrow_preferred().unwrap();
-        let expected_arrow = expected.clone().into_arrow_preferred().unwrap();
+        let actual_arrow = actual.clone().execute_arrow(None, &mut ctx).unwrap();
+        let expected_arrow = expected.clone().execute_arrow(None, &mut ctx).unwrap();
         assert_eq!(
             &actual_arrow,
             &expected_arrow,
@@ -53,6 +56,7 @@ mod test {
 
     #[test]
     fn test_non_null() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let actual = ConstantArray::new(Scalar::from(Some(1)), 3)
             .into_array()
             .fill_null(Scalar::from(1))
@@ -61,8 +65,8 @@ mod test {
 
         assert!(!actual.dtype().is_nullable());
 
-        let actual_arrow = actual.clone().into_arrow_preferred().unwrap();
-        let expected_arrow = expected.clone().into_arrow_preferred().unwrap();
+        let actual_arrow = actual.clone().execute_arrow(None, &mut ctx).unwrap();
+        let expected_arrow = expected.clone().execute_arrow(None, &mut ctx).unwrap();
         assert_eq!(
             &actual_arrow,
             &expected_arrow,
@@ -74,6 +78,7 @@ mod test {
 
     #[test]
     fn test_non_nullable_with_nullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let actual = ConstantArray::new(Scalar::from(1), 3)
             .into_array()
             .fill_null(Scalar::new(
@@ -87,8 +92,8 @@ mod test {
 
         assert!(actual.dtype().is_nullable());
 
-        let actual_arrow = actual.clone().into_arrow_preferred().unwrap();
-        let expected_arrow = expected.clone().into_arrow_preferred().unwrap();
+        let actual_arrow = actual.clone().execute_arrow(None, &mut ctx).unwrap();
+        let expected_arrow = expected.clone().execute_arrow(None, &mut ctx).unwrap();
         assert_eq!(
             &actual_arrow,
             &expected_arrow,

--- a/vortex-array/src/arrays/filter/execute/varbinview.rs
+++ b/vortex-array/src/arrays/filter/execute/varbinview.rs
@@ -10,11 +10,13 @@ use vortex_mask::MaskValues;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::LEGACY_SESSION;
+use crate::VortexSessionExecute;
 use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::filter::execute::values_to_mask;
+use crate::arrow::ArrowArrayExecutor;
 use crate::arrow::FromArrowArray;
-use crate::arrow::IntoArrowArray;
 
 pub fn filter_varbinview(array: &VarBinViewArray, mask: &Arc<MaskValues>) -> VarBinViewArray {
     // Delegate to the Arrow implementation of filter over `VarBinView`.
@@ -30,7 +32,9 @@ fn arrow_filter_fn(array: &ArrayRef, mask: &Mask) -> vortex_error::VortexResult<
         Mask::AllTrue(_) | Mask::AllFalse(_) => unreachable!("check in filter invoke"),
     };
 
-    let array_ref = array.clone().into_arrow_preferred()?;
+    let array_ref = array
+        .clone()
+        .execute_arrow(None, &mut LEGACY_SESSION.create_execution_ctx())?;
     let mask_array = BooleanArray::new(values.bit_buffer().clone().into(), None);
     let filtered = arrow_select::filter::filter(array_ref.as_ref(), &mask_array)?;
 

--- a/vortex-array/src/arrays/varbin/compute/compare.rs
+++ b/vortex-array/src/arrays/varbin/compute/compare.rs
@@ -80,10 +80,10 @@ impl CompareKernel for VarBin {
                 ));
             }
 
-            let lhs = Datum::try_new(lhs.array())?;
+            let lhs = Datum::try_new(lhs.array(), ctx)?;
 
             // Use StringViewArray/BinaryViewArray to match the Utf8View/BinaryView types
-            // produced by Datum::try_new (which uses into_arrow_preferred())
+            // produced by Datum::try_new (which uses execute_arrow(None, ctx))
             let arrow_rhs: &dyn arrow_array::Datum = match rhs_const.dtype() {
                 DType::Utf8(_) => &rhs_const
                     .as_utf8()

--- a/vortex-array/src/arrow/datum.rs
+++ b/vortex-array/src/arrow/datum.rs
@@ -15,8 +15,9 @@ use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
+use crate::arrow::ArrowArrayExecutor;
 use crate::arrow::FromArrowArray;
-use crate::arrow::IntoArrowArray;
+use crate::executor::ExecutionCtx;
 
 /// A wrapper around a generic Arrow array that can be used as a Datum in Arrow compute.
 #[derive(Debug)]
@@ -27,15 +28,15 @@ pub struct Datum {
 
 impl Datum {
     /// Create a new [`Datum`] from an [`ArrayRef`], which can then be passed to Arrow compute.
-    pub fn try_new(array: &ArrayRef) -> VortexResult<Self> {
+    pub fn try_new(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
         if array.is::<Constant>() {
             Ok(Self {
-                array: array.slice(0..1)?.into_arrow_preferred()?,
+                array: array.slice(0..1)?.execute_arrow(None, ctx)?,
                 is_scalar: true,
             })
         } else {
             Ok(Self {
-                array: array.clone().into_arrow_preferred()?,
+                array: array.clone().execute_arrow(None, ctx)?,
                 is_scalar: false,
             })
         }
@@ -43,9 +44,9 @@ impl Datum {
 
     /// Create a new [`Datum`] from an `DynArray`, which can then be passed to Arrow compute.
     /// This not try and convert the array to a scalar if it is constant.
-    pub fn try_new_array(array: &ArrayRef) -> VortexResult<Self> {
+    pub fn try_new_array(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
         Ok(Self {
-            array: array.clone().into_arrow_preferred()?,
+            array: array.clone().execute_arrow(None, ctx)?,
             is_scalar: false,
         })
     }
@@ -53,15 +54,18 @@ impl Datum {
     pub fn try_new_with_target_datatype(
         array: &ArrayRef,
         target_datatype: &DataType,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
         if array.is::<Constant>() {
             Ok(Self {
-                array: array.slice(0..1)?.into_arrow(target_datatype)?,
+                array: array
+                    .slice(0..1)?
+                    .execute_arrow(Some(target_datatype), ctx)?,
                 is_scalar: true,
             })
         } else {
             Ok(Self {
-                array: array.clone().into_arrow(target_datatype)?,
+                array: array.clone().execute_arrow(Some(target_datatype), ctx)?,
                 is_scalar: false,
             })
         }

--- a/vortex-array/src/arrow/executor/decimal.rs
+++ b/vortex-array/src/arrow/executor/decimal.rs
@@ -226,7 +226,6 @@ mod tests {
     use crate::VortexSessionExecute;
     use crate::array::IntoArray;
     use crate::arrow::ArrowArrayExecutor;
-    use crate::arrow::IntoArrowArray;
     use crate::arrow::executor::decimal::DecimalArray;
     use crate::builders::ArrayBuilder;
     use crate::builders::DecimalBuilder;
@@ -236,16 +235,16 @@ mod tests {
 
     #[test]
     fn decimal_to_arrow() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Make a very simple i128 and i256 array.
         let decimal_vortex = DecimalArray::new(
             buffer![1i128, 2i128, 3i128, 4i128, 5i128],
             DecimalDType::new(19, 2),
             Validity::NonNullable,
         );
-        let arrow = decimal_vortex.into_array().execute_arrow(
-            Some(&DataType::Decimal128(19, 2)),
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )?;
+        let arrow = decimal_vortex
+            .into_array()
+            .execute_arrow(Some(&DataType::Decimal128(19, 2)), &mut ctx)?;
         assert_eq!(arrow.data_type(), &DataType::Decimal128(19, 2));
         let decimal_array = arrow.as_any().downcast_ref::<Decimal128Array>().unwrap();
         assert_eq!(
@@ -265,13 +264,14 @@ mod tests {
     fn test_to_arrow_decimal128<T: NativeDecimalType>(
         #[case] _decimal_type: T,
     ) -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut decimal = DecimalBuilder::new::<T>(DecimalDType::new(2, 1), false.into());
         decimal.append_value(10);
         decimal.append_value(11);
         decimal.append_value(12);
         let decimal = decimal.finish();
 
-        let arrow_array = decimal.into_arrow(&DataType::Decimal128(2, 1))?;
+        let arrow_array = decimal.execute_arrow(Some(&DataType::Decimal128(2, 1)), &mut ctx)?;
         let arrow_decimal = arrow_array
             .as_any()
             .downcast_ref::<Decimal128Array>()
@@ -292,13 +292,14 @@ mod tests {
     fn test_to_arrow_decimal32<T: NativeDecimalType>(#[case] _decimal_type: T) -> VortexResult<()> {
         use arrow_array::Decimal32Array;
 
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut decimal = DecimalBuilder::new::<T>(DecimalDType::new(2, 1), false.into());
         decimal.append_value(10);
         decimal.append_value(11);
         decimal.append_value(12);
         let decimal = decimal.finish();
 
-        let arrow_array = decimal.into_arrow(&DataType::Decimal32(2, 1))?;
+        let arrow_array = decimal.execute_arrow(Some(&DataType::Decimal32(2, 1)), &mut ctx)?;
         let arrow_decimal = arrow_array
             .as_any()
             .downcast_ref::<Decimal32Array>()
@@ -319,13 +320,14 @@ mod tests {
     fn test_to_arrow_decimal64<T: NativeDecimalType>(#[case] _decimal_type: T) -> VortexResult<()> {
         use arrow_array::Decimal64Array;
 
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut decimal = DecimalBuilder::new::<T>(DecimalDType::new(2, 1), false.into());
         decimal.append_value(10);
         decimal.append_value(11);
         decimal.append_value(12);
         let decimal = decimal.finish();
 
-        let arrow_array = decimal.into_arrow(&DataType::Decimal64(2, 1))?;
+        let arrow_array = decimal.execute_arrow(Some(&DataType::Decimal64(2, 1)), &mut ctx)?;
         let arrow_decimal = arrow_array
             .as_any()
             .downcast_ref::<Decimal64Array>()
@@ -346,13 +348,14 @@ mod tests {
     fn test_to_arrow_decimal256<T: NativeDecimalType>(
         #[case] _decimal_type: T,
     ) -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut decimal = DecimalBuilder::new::<T>(DecimalDType::new(2, 1), false.into());
         decimal.append_value(10);
         decimal.append_value(11);
         decimal.append_value(12);
         let decimal = decimal.finish();
 
-        let arrow_array = decimal.into_arrow(&DataType::Decimal256(2, 1))?;
+        let arrow_array = decimal.execute_arrow(Some(&DataType::Decimal256(2, 1)), &mut ctx)?;
         let arrow_decimal = arrow_array
             .as_any()
             .downcast_ref::<Decimal256Array>()

--- a/vortex-array/src/arrow/executor/list.rs
+++ b/vortex-array/src/arrow/executor/list.rs
@@ -206,8 +206,10 @@ mod tests {
 
     use crate::Canonical;
     use crate::IntoArray;
+    use crate::LEGACY_SESSION;
+    use crate::VortexSessionExecute;
     use crate::arrays::PrimitiveArray;
-    use crate::arrow::IntoArrowArray;
+    use crate::arrow::ArrowArrayExecutor;
     use crate::arrow::executor::list::ListViewArray;
     use crate::dtype::DType;
     use crate::dtype::Nullability::NonNullable;
@@ -215,6 +217,7 @@ mod tests {
 
     #[test]
     fn test_to_arrow_list_i32() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create a ListViewArray with i32 elements: [[1, 2, 3], [4, 5]]
         let elements = PrimitiveArray::new(buffer![1i32, 2, 3, 4, 5], Validity::NonNullable);
         let offsets = PrimitiveArray::new(buffer![0i32, 3], Validity::NonNullable);
@@ -233,7 +236,9 @@ mod tests {
         // Convert to Arrow List with i32 offsets.
         let field = Field::new("item", DataType::Int32, false);
         let arrow_dt = DataType::List(field.into());
-        let arrow_array = list_array.into_array().into_arrow(&arrow_dt)?;
+        let arrow_array = list_array
+            .into_array()
+            .execute_arrow(Some(&arrow_dt), &mut ctx)?;
 
         // Verify the type is correct.
         assert_eq!(arrow_array.data_type(), &arrow_dt);
@@ -267,6 +272,7 @@ mod tests {
 
     #[test]
     fn test_to_arrow_list_i64() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create a ListViewArray with i64 offsets: [[10, 20], [30]]
         let elements = PrimitiveArray::new(buffer![10i64, 20, 30], Validity::NonNullable);
         let offsets = PrimitiveArray::new(buffer![0i64, 2], Validity::NonNullable);
@@ -285,7 +291,9 @@ mod tests {
         // Convert to Arrow LargeList with i64 offsets.
         let field = Field::new("item", DataType::Int64, false);
         let arrow_dt = DataType::LargeList(field.into());
-        let arrow_array = list_array.into_array().into_arrow(&arrow_dt)?;
+        let arrow_array = list_array
+            .into_array()
+            .execute_arrow(Some(&arrow_dt), &mut ctx)?;
 
         // Verify the type is correct.
         assert_eq!(arrow_array.data_type(), &arrow_dt);
@@ -304,6 +312,7 @@ mod tests {
 
     #[test]
     fn test_to_arrow_list_non_zctl() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Overlapping lists are NOT zero-copy-to-list, so this exercises the rebuild path.
         // Elements: [1, 2, 3, 4], List 0: [1,2,3], List 1: [2,3,4] (overlap at indices 1-2)
         let elements = PrimitiveArray::new(buffer![1i32, 2, 3, 4], Validity::NonNullable);
@@ -320,7 +329,9 @@ mod tests {
 
         let field = Field::new("item", DataType::Int32, false);
         let arrow_dt = DataType::List(field.into());
-        let arrow_array = list_array.into_array().into_arrow(&arrow_dt)?;
+        let arrow_array = list_array
+            .into_array()
+            .execute_arrow(Some(&arrow_dt), &mut ctx)?;
 
         let list = arrow_array
             .as_any()
@@ -343,6 +354,7 @@ mod tests {
 
     #[test]
     fn test_to_arrow_list_empty_zctl() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::List(
             Arc::new(DType::Primitive(crate::dtype::PType::I32, NonNullable)),
             NonNullable,
@@ -354,7 +366,9 @@ mod tests {
         };
 
         let arrow_dt = DataType::List(Field::new("item", DataType::Int32, false).into());
-        let arrow_array = list_array.into_array().into_arrow(&arrow_dt)?;
+        let arrow_array = list_array
+            .into_array()
+            .execute_arrow(Some(&arrow_dt), &mut ctx)?;
         assert_eq!(arrow_array.len(), 0);
         Ok(())
     }

--- a/vortex-array/src/arrow/executor/list_view.rs
+++ b/vortex-array/src/arrow/executor/list_view.rs
@@ -89,13 +89,16 @@ mod tests {
     use vortex_error::VortexResult;
 
     use crate::IntoArray;
-    use crate::arrow::IntoArrowArray;
+    use crate::LEGACY_SESSION;
+    use crate::VortexSessionExecute;
+    use crate::arrow::ArrowArrayExecutor;
     use crate::arrow::executor::list_view::ListViewArray;
     use crate::arrow::executor::list_view::PrimitiveArray;
     use crate::validity::Validity;
 
     #[test]
     fn test_to_arrow_listview_i32() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create a ListViewArray with overlapping views: [[1, 2], [2, 3], [3, 4]]
         let elements = PrimitiveArray::new(buffer![1i32, 2, 3, 4], Validity::NonNullable);
         let offsets = PrimitiveArray::new(buffer![0i32, 1, 2], Validity::NonNullable);
@@ -111,7 +114,9 @@ mod tests {
         // Convert to Arrow ListView with i32 offsets.
         let field = Field::new("item", DataType::Int32, false);
         let arrow_dt = DataType::ListView(field.into());
-        let arrow_array = list_array.into_array().into_arrow(&arrow_dt)?;
+        let arrow_array = list_array
+            .into_array()
+            .execute_arrow(Some(&arrow_dt), &mut ctx)?;
 
         // Verify the type is correct.
         assert_eq!(arrow_array.data_type(), &arrow_dt);
@@ -148,6 +153,7 @@ mod tests {
 
     #[test]
     fn test_to_arrow_listview_i64() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create a ListViewArray with nullable elements: [[100], null, [200, 300]]
         let elements = PrimitiveArray::new(buffer![100i64, 200, 300], Validity::NonNullable);
         let offsets = PrimitiveArray::new(buffer![0i64, 1, 1], Validity::NonNullable);
@@ -167,7 +173,9 @@ mod tests {
         // Convert to Arrow LargeListView with i64 offsets.
         let field = Field::new("item", DataType::Int64, false);
         let arrow_dt = DataType::LargeListView(field.into());
-        let arrow_array = list_array.into_array().into_arrow(&arrow_dt)?;
+        let arrow_array = list_array
+            .into_array()
+            .execute_arrow(Some(&arrow_dt), &mut ctx)?;
 
         // Verify the type is correct.
         assert_eq!(arrow_array.data_type(), &arrow_dt);

--- a/vortex-array/src/arrow/executor/struct_.rs
+++ b/vortex-array/src/arrow/executor/struct_.rs
@@ -190,6 +190,7 @@ fn create_from_fields(
 mod tests {
     use std::sync::Arc;
 
+    use arrays::varbinview::VarBinViewArray;
     use arrow_array::ArrayRef;
     use arrow_array::PrimitiveArray as ArrowPrimitiveArray;
     use arrow_array::StringViewArray;
@@ -210,12 +211,12 @@ mod tests {
     use crate::arrays::StructArray;
     use crate::arrow::ArrowArrayExecutor;
     use crate::arrow::FromArrowArray;
-    use crate::arrow::IntoArrowArray;
     use crate::dtype::FieldNames;
     use crate::validity::Validity;
 
     #[test]
     fn struct_nullable_non_null_to_arrow() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let xs = PrimitiveArray::new(buffer![0i64, 1, 2, 3, 4], Validity::AllValid);
 
         let struct_a = StructArray::try_new(
@@ -228,12 +229,15 @@ mod tests {
         let fields = vec![Field::new("xs", DataType::Int64, false)];
         let arrow_dt = DataType::Struct(fields.into());
 
-        struct_a.into_array().into_arrow(&arrow_dt)?;
+        struct_a
+            .into_array()
+            .execute_arrow(Some(&arrow_dt), &mut ctx)?;
         Ok(())
     }
 
     #[test]
     fn struct_nullable_with_nulls_to_arrow() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let xs =
             PrimitiveArray::from_option_iter(vec![Some(0_i64), Some(1), Some(2), None, Some(3)]);
 
@@ -247,12 +251,18 @@ mod tests {
         let fields = vec![Field::new("xs", DataType::Int64, false)];
         let arrow_dt = DataType::Struct(fields.into());
 
-        assert!(struct_a.into_array().into_arrow(&arrow_dt).is_err());
+        assert!(
+            struct_a
+                .into_array()
+                .execute_arrow(Some(&arrow_dt), &mut ctx)
+                .is_err()
+        );
         Ok(())
     }
 
     #[test]
     fn struct_to_arrow_with_schema_mismatch() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let xs = PrimitiveArray::new(buffer![0i64, 1, 2, 3, 4], Validity::AllValid);
 
         let struct_a = StructArray::try_new(
@@ -268,7 +278,11 @@ mod tests {
         ];
         let arrow_dt = DataType::Struct(fields.into());
 
-        let err = struct_a.into_array().into_arrow(&arrow_dt).err().unwrap();
+        let err = struct_a
+            .into_array()
+            .execute_arrow(Some(&arrow_dt), &mut ctx)
+            .err()
+            .unwrap();
         assert!(
             err.to_string()
                 .contains("StructArray has 1 fields, but target Arrow type has 2 fields")
@@ -278,6 +292,7 @@ mod tests {
 
     #[test]
     fn test_to_arrow() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = StructArray::from_fields(
             vec![
                 (
@@ -286,8 +301,7 @@ mod tests {
                 ),
                 (
                     "b",
-                    arrays::varbinview::VarBinViewArray::from_iter_str(vec!["a", "b", "c"])
-                        .into_array(),
+                    VarBinViewArray::from_iter_str(vec!["a", "b", "c"]).into_array(),
                 ),
             ]
             .as_slice(),
@@ -311,10 +325,9 @@ mod tests {
 
         let arrow_dtype = array.dtype().to_arrow_dtype()?;
         assert_eq!(
-            &array.into_array().execute_arrow(
-                Some(&arrow_dtype),
-                &mut LEGACY_SESSION.create_execution_ctx()
-            )?,
+            &array
+                .into_array()
+                .execute_arrow(Some(&arrow_dtype), &mut ctx)?,
             &arrow_array
         );
         Ok(())
@@ -322,6 +335,7 @@ mod tests {
 
     #[test]
     fn to_arrow_with_non_nullable_fields() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = StructArray::from_fields(
             vec![
                 (
@@ -330,14 +344,13 @@ mod tests {
                 ),
                 (
                     "b",
-                    arrays::varbinview::VarBinViewArray::from_iter_str(vec!["a", "b", "c"])
-                        .into_array(),
+                    VarBinViewArray::from_iter_str(vec!["a", "b", "c"]).into_array(),
                 ),
             ]
             .as_slice(),
         )?;
         let orig_dtype = array.dtype().clone();
-        let arrow_array = array.into_array().into_arrow_preferred()?;
+        let arrow_array = array.into_array().execute_arrow(None, &mut ctx)?;
         let from_arrow = array::ArrayRef::from_arrow(arrow_array.as_ref(), false)?;
         assert_eq!(&orig_dtype, from_arrow.dtype());
         Ok(())

--- a/vortex-array/src/arrow/mod.rs
+++ b/vortex-array/src/arrow/mod.rs
@@ -30,12 +30,16 @@ pub trait FromArrowArray<A> {
         Self: Sized;
 }
 
+#[deprecated(note = "Use `execute_arrow(None, ctx)` or `execute_arrow(Some(dt), ctx)` instead")]
 pub trait IntoArrowArray {
+    #[deprecated(note = "Use `execute_arrow(None, ctx)` instead")]
     fn into_arrow_preferred(self) -> VortexResult<ArrowArrayRef>;
 
+    #[deprecated(note = "Use `execute_arrow(Some(data_type), ctx)` instead")]
     fn into_arrow(self, data_type: &DataType) -> VortexResult<ArrowArrayRef>;
 }
 
+#[allow(deprecated)]
 impl IntoArrowArray for ArrayRef {
     /// Convert this [`crate::ArrayRef`] into an Arrow [`crate::ArrayRef`] by using the array's
     /// preferred (cheapest) Arrow [`DataType`].

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -1067,13 +1067,16 @@ mod test {
 
     use crate::ArrayRef;
     use crate::IntoArray;
+    use crate::LEGACY_SESSION;
+    use crate::VortexSessionExecute;
     use crate::arrays::ConstantArray;
+    use crate::arrow::ArrowArrayExecutor;
     use crate::arrow::FromArrowArray;
-    use crate::arrow::IntoArrowArray;
     use crate::canonical::StructArray;
 
     #[test]
     fn test_canonicalize_nested_struct() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create a struct array with multiple internal components.
         let nested_struct_array = StructArray::from_fields(&[
             ("a", buffer![1u64].into_array()),
@@ -1095,7 +1098,7 @@ mod test {
 
         let arrow_struct = nested_struct_array
             .into_array()
-            .into_arrow_preferred()
+            .execute_arrow(None, &mut ctx)
             .unwrap()
             .as_any()
             .downcast_ref::<ArrowStructArray>()
@@ -1130,6 +1133,7 @@ mod test {
 
     #[test]
     fn roundtrip_struct() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut nulls = NullBufferBuilder::new(6);
         nulls.append_n_non_nulls(4);
         nulls.append_null();
@@ -1165,12 +1169,16 @@ mod test {
 
         assert_eq!(
             &arrow_struct,
-            vortex_struct.into_arrow_preferred().unwrap().as_struct()
+            vortex_struct
+                .execute_arrow(None, &mut ctx)
+                .unwrap()
+                .as_struct()
         );
     }
 
     #[test]
     fn roundtrip_list() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let names = Arc::new(StringArray::from_iter(vec![
             Some("Joseph"),
             Some("Angela"),
@@ -1187,7 +1195,9 @@ mod test {
 
         let vortex_list = ArrayRef::from_arrow(&arrow_list, true).unwrap();
 
-        let rt_arrow_list = vortex_list.into_arrow(list_data_type).unwrap();
+        let rt_arrow_list = vortex_list
+            .execute_arrow(Some(list_data_type), &mut ctx)
+            .unwrap();
 
         assert_eq!(
             (Arc::new(arrow_list.clone()) as ArrowArrayRef).as_ref(),

--- a/vortex-array/src/expr/exprs.rs
+++ b/vortex-array/src/expr/exprs.rs
@@ -397,17 +397,19 @@ where
 ///
 /// ```
 /// # use vortex_array::IntoArray;
-/// # use vortex_array::arrow::IntoArrowArray as _;
+/// # use vortex_array::arrow::ArrowArrayExecutor;
+/// # use vortex_array::{LEGACY_SESSION, VortexSessionExecute};
 /// # use vortex_buffer::buffer;
 /// # use vortex_array::expr::{checked_add, lit, root};
 /// let xs = buffer![1, 2, 3].into_array();
 /// let result = xs.apply(&checked_add(root(), lit(5))).unwrap();
 ///
+/// let mut ctx = LEGACY_SESSION.create_execution_ctx();
 /// assert_eq!(
-///     &result.into_arrow_preferred().unwrap(),
+///     &result.execute_arrow(None, &mut ctx).unwrap(),
 ///     &buffer![6, 7, 8]
 ///         .into_array()
-///         .into_arrow_preferred()
+///         .execute_arrow(None, &mut ctx)
 ///         .unwrap()
 /// );
 /// ```

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -155,7 +155,7 @@ fn between_canonical(
         upper.clone(),
         Operator::from(options.upper_strict.to_compare_operator()),
     )?;
-    execute_boolean(&lower_cmp, &upper_cmp, Operator::And)
+    execute_boolean(&lower_cmp, &upper_cmp, Operator::And, ctx)
 }
 
 /// An optimized scalar expression to compute whether values fall between two bounds.

--- a/vortex-array/src/scalar_fn/fns/binary/boolean.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/boolean.rs
@@ -10,10 +10,11 @@ use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
+use crate::arrow::ArrowArrayExecutor;
 use crate::arrow::FromArrowArray;
-use crate::arrow::IntoArrowArray;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
+use crate::executor::ExecutionCtx;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::operators::Operator;
 
@@ -37,19 +38,31 @@ pub(crate) fn execute_boolean(
     lhs: &ArrayRef,
     rhs: &ArrayRef,
     op: Operator,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     if let Some(result) = constant_boolean(lhs, rhs, op)? {
         return Ok(result);
     }
-    arrow_execute_boolean(lhs.clone(), rhs.clone(), op)
+    arrow_execute_boolean(lhs.clone(), rhs.clone(), op, ctx)
 }
 
 /// Arrow implementation for Kleene boolean operations using [`Operator`].
-fn arrow_execute_boolean(lhs: ArrayRef, rhs: ArrayRef, op: Operator) -> VortexResult<ArrayRef> {
+fn arrow_execute_boolean(
+    lhs: ArrayRef,
+    rhs: ArrayRef,
+    op: Operator,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
     let nullable = lhs.dtype().is_nullable() || rhs.dtype().is_nullable();
 
-    let lhs = lhs.into_arrow(&DataType::Boolean)?.as_boolean().clone();
-    let rhs = rhs.into_arrow(&DataType::Boolean)?.as_boolean().clone();
+    let lhs = lhs
+        .execute_arrow(Some(&DataType::Boolean), ctx)?
+        .as_boolean()
+        .clone();
+    let rhs = rhs
+        .execute_arrow(Some(&DataType::Boolean), ctx)?
+        .as_boolean()
+        .clone();
 
     let array = match op {
         Operator::And => arrow_arith::boolean::and_kleene(&lhs, &rhs)?,

--- a/vortex-array/src/scalar_fn/fns/binary/compare.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare.rs
@@ -23,8 +23,8 @@ use crate::arrays::ScalarFnVTable;
 use crate::arrays::scalar_fn::ExactScalarFn;
 use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
+use crate::arrow::ArrowArrayExecutor;
 use crate::arrow::Datum;
-use crate::arrow::IntoArrowArray;
 use crate::arrow::from_arrow_array_with_len;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -114,6 +114,7 @@ pub(crate) fn execute_compare(
     lhs: &ArrayRef,
     rhs: &ArrayRef,
     op: CompareOperator,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let nullable = lhs.dtype().is_nullable() || rhs.dtype().is_nullable();
 
@@ -136,7 +137,7 @@ pub(crate) fn execute_compare(
         return Ok(ConstantArray::new(result, lhs.len()).into_array());
     }
 
-    arrow_compare_arrays(lhs, rhs, op)
+    arrow_compare_arrays(lhs, rhs, op, ctx)
 }
 
 /// Fall back to Arrow for comparison.
@@ -144,6 +145,7 @@ fn arrow_compare_arrays(
     left: &ArrayRef,
     right: &ArrayRef,
     operator: CompareOperator,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     assert_eq!(left.len(), right.len());
 
@@ -152,8 +154,8 @@ fn arrow_compare_arrays(
     // Arrow's vectorized comparison kernels don't support nested types.
     // For nested types, fall back to `make_comparator` which does element-wise comparison.
     let arrow_array: BooleanArray = if left.dtype().is_nested() || right.dtype().is_nested() {
-        let rhs = right.clone().into_arrow_preferred()?;
-        let lhs = left.clone().into_arrow(rhs.data_type())?;
+        let rhs = right.clone().execute_arrow(None, ctx)?;
+        let lhs = left.clone().execute_arrow(Some(rhs.data_type()), ctx)?;
 
         assert!(
             lhs.data_type().equals_datatype(rhs.data_type()),
@@ -165,8 +167,8 @@ fn arrow_compare_arrays(
         compare_nested_arrow_arrays(lhs.as_ref(), rhs.as_ref(), operator)?
     } else {
         // Fast path: use vectorized kernels for primitive types.
-        let lhs = Datum::try_new(left)?;
-        let rhs = Datum::try_new_with_target_datatype(right, lhs.data_type())?;
+        let lhs = Datum::try_new(left, ctx)?;
+        let rhs = Datum::try_new_with_target_datatype(right, lhs.data_type(), ctx)?;
 
         match operator {
             CompareOperator::Eq => cmp::eq(&lhs, &rhs)?,

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -142,24 +142,24 @@ impl ScalarFnVTable for Binary {
         &self,
         op: &Operator,
         args: &dyn ExecutionArgs,
-        _ctx: &mut ExecutionCtx,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         let lhs = args.get(0)?;
         let rhs = args.get(1)?;
 
         match op {
-            Operator::Eq => execute_compare(&lhs, &rhs, CompareOperator::Eq),
-            Operator::NotEq => execute_compare(&lhs, &rhs, CompareOperator::NotEq),
-            Operator::Lt => execute_compare(&lhs, &rhs, CompareOperator::Lt),
-            Operator::Lte => execute_compare(&lhs, &rhs, CompareOperator::Lte),
-            Operator::Gt => execute_compare(&lhs, &rhs, CompareOperator::Gt),
-            Operator::Gte => execute_compare(&lhs, &rhs, CompareOperator::Gte),
-            Operator::And => execute_boolean(&lhs, &rhs, Operator::And),
-            Operator::Or => execute_boolean(&lhs, &rhs, Operator::Or),
-            Operator::Add => execute_numeric(&lhs, &rhs, NumericOperator::Add),
-            Operator::Sub => execute_numeric(&lhs, &rhs, NumericOperator::Sub),
-            Operator::Mul => execute_numeric(&lhs, &rhs, NumericOperator::Mul),
-            Operator::Div => execute_numeric(&lhs, &rhs, NumericOperator::Div),
+            Operator::Eq => execute_compare(&lhs, &rhs, CompareOperator::Eq, ctx),
+            Operator::NotEq => execute_compare(&lhs, &rhs, CompareOperator::NotEq, ctx),
+            Operator::Lt => execute_compare(&lhs, &rhs, CompareOperator::Lt, ctx),
+            Operator::Lte => execute_compare(&lhs, &rhs, CompareOperator::Lte, ctx),
+            Operator::Gt => execute_compare(&lhs, &rhs, CompareOperator::Gt, ctx),
+            Operator::Gte => execute_compare(&lhs, &rhs, CompareOperator::Gte, ctx),
+            Operator::And => execute_boolean(&lhs, &rhs, Operator::And, ctx),
+            Operator::Or => execute_boolean(&lhs, &rhs, Operator::Or, ctx),
+            Operator::Add => execute_numeric(&lhs, &rhs, NumericOperator::Add, ctx),
+            Operator::Sub => execute_numeric(&lhs, &rhs, NumericOperator::Sub, ctx),
+            Operator::Mul => execute_numeric(&lhs, &rhs, NumericOperator::Mul, ctx),
+            Operator::Div => execute_numeric(&lhs, &rhs, NumericOperator::Div, ctx),
         }
     }
 

--- a/vortex-array/src/scalar_fn/fns/binary/numeric.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric.rs
@@ -9,6 +9,7 @@ use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrow::Datum;
 use crate::arrow::from_arrow_array_with_len;
+use crate::executor::ExecutionCtx;
 use crate::scalar::NumericOperator;
 
 /// Execute a numeric operation between two arrays.
@@ -19,11 +20,12 @@ pub(crate) fn execute_numeric(
     lhs: &ArrayRef,
     rhs: &ArrayRef,
     op: NumericOperator,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     if let Some(result) = constant_numeric(lhs, rhs, op)? {
         return Ok(result);
     }
-    arrow_numeric(lhs, rhs, op)
+    arrow_numeric(lhs, rhs, op, ctx)
 }
 
 /// Implementation of numeric operations using the Arrow crate.
@@ -31,12 +33,13 @@ pub(crate) fn arrow_numeric(
     lhs: &ArrayRef,
     rhs: &ArrayRef,
     operator: NumericOperator,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let nullable = lhs.dtype().is_nullable() || rhs.dtype().is_nullable();
     let len = lhs.len();
 
-    let left = Datum::try_new(lhs)?;
-    let right = Datum::try_new_with_target_datatype(rhs, left.data_type())?;
+    let left = Datum::try_new(lhs, ctx)?;
+    let right = Datum::try_new_with_target_datatype(rhs, left.data_type(), ctx)?;
 
     let array = match operator {
         NumericOperator::Add => arrow_arith::numeric::add(&left, &right)?,

--- a/vortex-array/src/scalar_fn/fns/like/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/like/mod.rs
@@ -140,12 +140,12 @@ impl ScalarFnVTable for Like {
         &self,
         options: &Self::Options,
         args: &dyn ExecutionArgs,
-        _ctx: &mut ExecutionCtx,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         let child = args.get(0)?;
         let pattern = args.get(1)?;
 
-        arrow_like(&child, &pattern, *options)
+        arrow_like(&child, &pattern, *options, ctx)
     }
 
     fn validity(
@@ -206,6 +206,7 @@ pub(crate) fn arrow_like(
     array: &ArrayRef,
     pattern: &ArrayRef,
     options: LikeOptions,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let nullable = array.dtype().is_nullable() | pattern.dtype().is_nullable();
     let len = array.len();
@@ -217,8 +218,8 @@ pub(crate) fn arrow_like(
     );
 
     // convert the pattern to the preferred array datatype
-    let lhs = Datum::try_new(array)?;
-    let rhs = Datum::try_new_with_target_datatype(pattern, lhs.data_type())?;
+    let lhs = Datum::try_new(array, ctx)?;
+    let rhs = Datum::try_new_with_target_datatype(pattern, lhs.data_type(), ctx)?;
 
     let result = match (options.negated, options.case_insensitive) {
         (false, false) => arrow_string::like::like(&lhs, &rhs)?,

--- a/vortex-array/src/scalar_fn/fns/zip/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/zip/mod.rs
@@ -238,7 +238,7 @@ mod tests {
     use crate::arrays::Struct;
     use crate::arrays::StructArray;
     use crate::arrays::VarBinView;
-    use crate::arrow::IntoArrowArray;
+    use crate::arrow::ArrowArrayExecutor;
     use crate::assert_arrays_eq;
     use crate::builders::ArrayBuilder;
     use crate::builders::BufferGrowthStrategy;
@@ -444,17 +444,22 @@ mod tests {
         let zipped = zipped.as_opt::<VarBinView>().unwrap();
         assert_eq!(zipped.data_buffers().len(), 2);
 
+        let mut arrow_ctx = LEGACY_SESSION.create_execution_ctx();
         let expected = arrow_zip(
             mask.into_array()
-                .into_arrow_preferred()
+                .execute_arrow(None, &mut arrow_ctx)
                 .unwrap()
                 .as_boolean(),
-            &if_true.into_arrow_preferred().unwrap(),
-            &if_false.into_arrow_preferred().unwrap(),
+            &if_true.execute_arrow(None, &mut arrow_ctx).unwrap(),
+            &if_false.execute_arrow(None, &mut arrow_ctx).unwrap(),
         )
         .unwrap();
 
-        let actual = zipped.array().clone().into_arrow_preferred().unwrap();
+        let actual = zipped
+            .array()
+            .clone()
+            .execute_arrow(None, &mut arrow_ctx)
+            .unwrap();
         assert_eq!(actual.as_ref(), expected.as_ref());
     }
 }

--- a/vortex-cxx/src/read.rs
+++ b/vortex-cxx/src/read.rs
@@ -15,7 +15,9 @@ use arrow_schema::Schema;
 use arrow_schema::SchemaRef;
 use futures::stream::TryStreamExt;
 use vortex::array::ArrayRef;
-use vortex::array::arrow::IntoArrowArray;
+use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
+use vortex::array::arrow::ArrowArrayExecutor;
 use vortex::buffer::Buffer;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::io::runtime::BlockingRuntime;
@@ -163,7 +165,7 @@ pub(crate) fn scan_builder_into_threadsafe_cloneable_reader(
     let stream = builder
         .inner
         .map(move |b| {
-            b.into_arrow(&data_type)
+            b.execute_arrow(Some(&data_type), &mut LEGACY_SESSION.create_execution_ctx())
                 .map(|struct_array| RecordBatch::from(struct_array.as_struct()))
         })
         .into_stream()?

--- a/vortex-jni/src/array.rs
+++ b/vortex-jni/src/array.rs
@@ -28,6 +28,7 @@ use jni::sys::jshort;
 use jni::sys::jstring;
 use vortex::array::ArrayRef;
 use vortex::array::ArrayView;
+use vortex::array::LEGACY_SESSION;
 use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::ExtensionArray;
 use vortex::array::arrays::StructArray;
@@ -36,7 +37,7 @@ use vortex::array::arrays::VarBinView;
 use vortex::array::arrays::extension::ExtensionArrayExt;
 use vortex::array::arrays::struct_::StructArrayExt;
 use vortex::array::arrays::varbin::VarBinArrayExt;
-use vortex::array::arrow::IntoArrowArray;
+use vortex::array::arrow::ArrowArrayExecutor;
 use vortex::dtype::DType;
 use vortex::dtype::i256;
 use vortex::error::VortexError;
@@ -117,7 +118,10 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_exportToArrow<'loc
         let preferred_arrow_type = array_ref.inner.dtype().to_arrow_dtype()?;
         let viewless_arrow_type = data_type_no_views(preferred_arrow_type);
 
-        let arrow_array = array_ref.inner.clone().into_arrow(&viewless_arrow_type)?;
+        let arrow_array = array_ref.inner.clone().execute_arrow(
+            Some(&viewless_arrow_type),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         let (ffi_array, ffi_schema) =
             arrow_array::ffi::to_ffi(&arrow_array.to_data()).map_err(VortexError::from)?;
 

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -31,7 +31,7 @@ use vortex::array::arrays::BoolArray;
 use vortex::array::arrays::Chunked;
 use vortex::array::arrays::bool::BoolArrayExt;
 use vortex::array::arrays::chunked::ChunkedArrayExt;
-use vortex::array::arrow::IntoArrowArray;
+use vortex::array::arrow::ArrowArrayExecutor;
 use vortex::array::builtins::ArrayBuiltins;
 use vortex::array::match_each_integer_ptype;
 use vortex::dtype::DType;
@@ -337,7 +337,12 @@ impl PyArray {
 
             let chunks = chunked_array
                 .iter_chunks()
-                .map(|chunk| -> PyVortexResult<_> { Ok(chunk.clone().into_arrow(&arrow_dtype)?) })
+                .map(|chunk| -> PyVortexResult<_> {
+                    Ok(chunk.clone().execute_arrow(
+                        Some(&arrow_dtype),
+                        &mut LEGACY_SESSION.create_execution_ctx(),
+                    )?)
+                })
                 .collect::<Result<Vec<ArrowArrayRef>, _>>()?;
 
             let pa_data_type = arrow_dtype.clone().to_pyarrow(py)?;
@@ -357,7 +362,7 @@ impl PyArray {
             )?)
         } else {
             Ok(array
-                .into_arrow_preferred()?
+                .execute_arrow(None, &mut LEGACY_SESSION.create_execution_ctx())?
                 .into_data()
                 .to_pyarrow(py)?
                 .into_bound(py))

--- a/vortex-python/src/iter/mod.rs
+++ b/vortex-python/src/iter/mod.rs
@@ -20,7 +20,9 @@ use pyo3::prelude::*;
 use pyo3::types::PyIterator;
 use vortex::array::Canonical;
 use vortex::array::IntoArray;
-use vortex::array::arrow::IntoArrowArray;
+use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
+use vortex::array::arrow::ArrowArrayExecutor;
 use vortex::array::iter::ArrayIterator;
 use vortex::array::iter::ArrayIteratorAdapter;
 use vortex::array::iter::ArrayIteratorExt;
@@ -126,7 +128,8 @@ impl PyArrayIterator {
             Box::new(RecordBatchIterator::new(
                 iter.map(move |chunk| {
                     let data_type = data_type.clone();
-                    chunk?.into_arrow(&data_type)
+                    chunk?
+                        .execute_arrow(Some(&data_type), &mut LEGACY_SESSION.create_execution_ctx())
                 })
                 .map(|chunk| chunk.map_err(|e| ArrowError::ExternalError(Box::new(e))))
                 .map(|array| array.map(|a| RecordBatch::from(a.as_struct().clone()))),


### PR DESCRIPTION
## deprecated
use `execute_arrow`