### PR TITLE
Pass `ExecutionCtx` through the compressor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10382,6 +10382,7 @@ dependencies = [
  "vortex-pco",
  "vortex-runend",
  "vortex-sequence",
+ "vortex-session",
  "vortex-sparse",
  "vortex-tensor",
  "vortex-utils",
@@ -10463,6 +10464,7 @@ dependencies = [
  "vortex-buffer",
  "vortex-error",
  "vortex-mask",
+ "vortex-session",
  "vortex-utils",
 ]
 

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -237,7 +237,7 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     };
 
                     let compressed = BtrBlocksCompressor::default()
-                        .compress(&indices_array)
+                        .compress(&indices_array, &mut ctx)
                         .vortex_expect("BtrBlocksCompressor compress should succeed in fuzz test");
                     (
                         Action::Take(compressed),
@@ -541,14 +541,15 @@ fn random_action_from_list(
 /// Compress an array using the given strategy.
 #[cfg(feature = "zstd")]
 pub fn compress_array(array: &ArrayRef, strategy: CompressorStrategy) -> ArrayRef {
+    let mut ctx = SESSION.create_execution_ctx();
     match strategy {
         CompressorStrategy::Default => BtrBlocksCompressor::default()
-            .compress(array)
+            .compress(array, &mut ctx)
             .vortex_expect("BtrBlocksCompressor compress should succeed in fuzz test"),
         CompressorStrategy::Compact => BtrBlocksCompressorBuilder::default()
             .with_compact()
             .build()
-            .compress(array)
+            .compress(array, &mut ctx)
             .vortex_expect("Compact compress should succeed in fuzz test"),
     }
 }
@@ -557,7 +558,7 @@ pub fn compress_array(array: &ArrayRef, strategy: CompressorStrategy) -> ArrayRe
 #[cfg(not(feature = "zstd"))]
 pub fn compress_array(array: &ArrayRef, _strategy: CompressorStrategy) -> ArrayRef {
     BtrBlocksCompressor::default()
-        .compress(array)
+        .compress(array, &mut SESSION.create_execution_ctx())
         .vortex_expect("BtrBlocksCompressor compress should succeed in fuzz test")
 }
 

--- a/vortex-btrblocks/Cargo.toml
+++ b/vortex-btrblocks/Cargo.toml
@@ -44,6 +44,7 @@ divan = { workspace = true }
 rstest = { workspace = true }
 test-with = { workspace = true }
 vortex-array = { workspace = true, features = ["_test-harness"] }
+vortex-session = { workspace = true }
 
 [features]
 # This feature enabled unstable encodings for which we don't guarantee stability.

--- a/vortex-btrblocks/benches/compress.rs
+++ b/vortex-btrblocks/benches/compress.rs
@@ -5,6 +5,8 @@
 
 #[cfg(not(codspeed))]
 mod benchmarks {
+    use std::sync::LazyLock;
+
     use divan::Bencher;
     use divan::counter::BytesCount;
     use divan::counter::ItemsCount;
@@ -13,12 +15,16 @@ mod benchmarks {
     use rand::prelude::StdRng;
     use vortex_array::ArrayRef;
     use vortex_array::IntoArray;
-    use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::session::ArraySession;
     use vortex_btrblocks::BtrBlocksCompressor;
     use vortex_buffer::buffer_mut;
+    use vortex_session::VortexSession;
     use vortex_utils::aliases::hash_set::HashSet;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     fn make_clickbench_window_name() -> ArrayRef {
         // A test that's meant to mirror the WindowName column from ClickBench.
@@ -41,7 +47,7 @@ mod benchmarks {
 
     #[divan::bench]
     fn btrblocks(bencher: Bencher) {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         let array = make_clickbench_window_name()
             .execute::<PrimitiveArray>(&mut ctx)
             .unwrap();
@@ -50,7 +56,14 @@ mod benchmarks {
             .with_inputs(|| &array)
             .input_counter(|array| ItemsCount::new(array.len()))
             .input_counter(|array| BytesCount::of_many::<i32>(array.len()))
-            .bench_refs(|array| compressor.compress(&array.clone().into_array()).unwrap());
+            .bench_refs(|array| {
+                compressor
+                    .compress(
+                        &array.clone().into_array(),
+                        &mut SESSION.create_execution_ctx(),
+                    )
+                    .unwrap()
+            });
     }
 }
 

--- a/vortex-btrblocks/benches/compress.rs
+++ b/vortex-btrblocks/benches/compress.rs
@@ -53,15 +53,12 @@ mod benchmarks {
             .unwrap();
         let compressor = BtrBlocksCompressor::default();
         bencher
-            .with_inputs(|| &array)
-            .input_counter(|array| ItemsCount::new(array.len()))
-            .input_counter(|array| BytesCount::of_many::<i32>(array.len()))
-            .bench_refs(|array| {
+            .with_inputs(|| (&array, SESSION.create_execution_ctx()))
+            .input_counter(|(array, _)| ItemsCount::new(array.len()))
+            .input_counter(|(array, _)| BytesCount::of_many::<i32>(array.len()))
+            .bench_refs(|(array, ctx)| {
                 compressor
-                    .compress(
-                        &array.clone().into_array(),
-                        &mut SESSION.create_execution_ctx(),
-                    )
+                    .compress(&array.clone().into_array(), ctx)
                     .unwrap()
             });
     }

--- a/vortex-btrblocks/benches/compress_listview.rs
+++ b/vortex-btrblocks/benches/compress_listview.rs
@@ -6,6 +6,8 @@
 
 #[cfg(not(codspeed))]
 mod benchmarks {
+    use std::sync::LazyLock;
+
     use divan::Bencher;
     use divan::counter::BytesCount;
     use divan::counter::ItemsCount;
@@ -14,16 +16,22 @@ mod benchmarks {
     use rand::prelude::StdRng;
     use vortex_array::ArrayRef;
     use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::ListViewArray;
     use vortex_array::arrays::StructArray;
     use vortex_array::arrays::VarBinViewArray;
     use vortex_array::dtype::FieldNames;
+    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_btrblocks::BtrBlocksCompressor;
     use vortex_buffer::buffer_mut;
+    use vortex_session::VortexSession;
 
     const NUM_ROWS: usize = 8192;
     const SEED: u64 = 42;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     const SHORT_STRINGS: &[&str] = &[
         "alpha_one",
@@ -180,7 +188,11 @@ mod benchmarks {
             .with_inputs(|| &array)
             .input_counter(|_| ItemsCount::new(NUM_ROWS))
             .input_counter(move |_| BytesCount::new(nbytes as usize))
-            .bench_refs(|array| compressor.compress(array).unwrap());
+            .bench_refs(|array| {
+                compressor
+                    .compress(array, &mut SESSION.create_execution_ctx())
+                    .unwrap()
+            });
     }
 }
 

--- a/vortex-btrblocks/benches/compress_listview.rs
+++ b/vortex-btrblocks/benches/compress_listview.rs
@@ -185,14 +185,10 @@ mod benchmarks {
         let nbytes = array.nbytes();
         let compressor = BtrBlocksCompressor::default();
         bencher
-            .with_inputs(|| &array)
+            .with_inputs(|| (&array, SESSION.create_execution_ctx()))
             .input_counter(|_| ItemsCount::new(NUM_ROWS))
             .input_counter(move |_| BytesCount::new(nbytes as usize))
-            .bench_refs(|array| {
-                compressor
-                    .compress(array, &mut SESSION.create_execution_ctx())
-                    .unwrap()
-            });
+            .bench_refs(|(array, ctx)| compressor.compress(array, ctx).unwrap());
     }
 }
 

--- a/vortex-btrblocks/public-api.lock
+++ b/vortex-btrblocks/public-api.lock
@@ -56,9 +56,9 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::decimal::D
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::decimal::DecimalScheme
 
-pub fn vortex_btrblocks::schemes::decimal::DecimalScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::decimal::DecimalScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_btrblocks::schemes::decimal::DecimalScheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::decimal::DecimalScheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, _exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::decimal::DecimalScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -98,9 +98,9 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::float::ALP
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::float::ALPRDScheme
 
-pub fn vortex_btrblocks::schemes::float::ALPRDScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::float::ALPRDScheme::compress(&self, _compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_btrblocks::schemes::float::ALPRDScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::float::ALPRDScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, _exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::float::ALPRDScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -128,9 +128,9 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::float::ALP
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::float::ALPScheme
 
-pub fn vortex_btrblocks::schemes::float::ALPScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::float::ALPScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_btrblocks::schemes::float::ALPScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::float::ALPScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, _exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::float::ALPScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -162,11 +162,11 @@ impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::float::Flo
 
 pub fn vortex_btrblocks::schemes::float::FloatRLEScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_btrblocks::schemes::float::FloatRLEScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::float::FloatRLEScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_btrblocks::schemes::float::FloatRLEScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_btrblocks::schemes::float::FloatRLEScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::float::FloatRLEScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::float::FloatRLEScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -196,11 +196,11 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::float::Nul
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::float::NullDominatedSparseScheme
 
-pub fn vortex_btrblocks::schemes::float::NullDominatedSparseScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::float::NullDominatedSparseScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_btrblocks::schemes::float::NullDominatedSparseScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_btrblocks::schemes::float::NullDominatedSparseScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::float::NullDominatedSparseScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::float::NullDominatedSparseScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -230,9 +230,9 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::float::Pco
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::float::PcoScheme
 
-pub fn vortex_btrblocks::schemes::float::PcoScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::float::PcoScheme::compress(&self, _compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_btrblocks::schemes::float::PcoScheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::float::PcoScheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, _exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::float::PcoScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -270,9 +270,9 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::integer::B
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::integer::BitPackingScheme
 
-pub fn vortex_btrblocks::schemes::integer::BitPackingScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::integer::BitPackingScheme::compress(&self, _compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_btrblocks::schemes::integer::BitPackingScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::integer::BitPackingScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::integer::BitPackingScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -302,9 +302,9 @@ impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::integer::F
 
 pub fn vortex_btrblocks::schemes::integer::FoRScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_btrblocks::schemes::integer::FoRScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::integer::FoRScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_btrblocks::schemes::integer::FoRScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::integer::FoRScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::integer::FoRScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -334,11 +334,11 @@ impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::integer::I
 
 pub fn vortex_btrblocks::schemes::integer::IntRLEScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_btrblocks::schemes::integer::IntRLEScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::integer::IntRLEScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_btrblocks::schemes::integer::IntRLEScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_btrblocks::schemes::integer::IntRLEScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::integer::IntRLEScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::integer::IntRLEScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -368,9 +368,9 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::integer::P
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::integer::PcoScheme
 
-pub fn vortex_btrblocks::schemes::integer::PcoScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::integer::PcoScheme::compress(&self, _compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_btrblocks::schemes::integer::PcoScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::integer::PcoScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, _exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::integer::PcoScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -400,11 +400,11 @@ impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::integer::R
 
 pub fn vortex_btrblocks::schemes::integer::RunEndScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_btrblocks::schemes::integer::RunEndScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::integer::RunEndScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_btrblocks::schemes::integer::RunEndScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_btrblocks::schemes::integer::RunEndScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::integer::RunEndScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::integer::RunEndScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -436,9 +436,9 @@ impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::integer::S
 
 pub fn vortex_btrblocks::schemes::integer::SequenceScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_btrblocks::schemes::integer::SequenceScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::integer::SequenceScheme::compress(&self, _compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_btrblocks::schemes::integer::SequenceScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::integer::SequenceScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::integer::SequenceScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -466,11 +466,11 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::integer::S
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::integer::SparseScheme
 
-pub fn vortex_btrblocks::schemes::integer::SparseScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::integer::SparseScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_btrblocks::schemes::integer::SparseScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_btrblocks::schemes::integer::SparseScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::integer::SparseScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::integer::SparseScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -504,11 +504,11 @@ impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::integer::Z
 
 pub fn vortex_btrblocks::schemes::integer::ZigZagScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_btrblocks::schemes::integer::ZigZagScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::integer::ZigZagScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_btrblocks::schemes::integer::ZigZagScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_btrblocks::schemes::integer::ZigZagScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::integer::ZigZagScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::integer::ZigZagScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -548,9 +548,9 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::string::FS
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::string::FSSTScheme
 
-pub fn vortex_btrblocks::schemes::string::FSSTScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::string::FSSTScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_btrblocks::schemes::string::FSSTScheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::string::FSSTScheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, _exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::string::FSSTScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -580,11 +580,11 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::string::Nu
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::string::NullDominatedSparseScheme
 
-pub fn vortex_btrblocks::schemes::string::NullDominatedSparseScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::string::NullDominatedSparseScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_btrblocks::schemes::string::NullDominatedSparseScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_btrblocks::schemes::string::NullDominatedSparseScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::string::NullDominatedSparseScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::string::NullDominatedSparseScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -614,9 +614,9 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::string::Zs
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::string::ZstdScheme
 
-pub fn vortex_btrblocks::schemes::string::ZstdScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::string::ZstdScheme::compress(&self, _compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_btrblocks::schemes::string::ZstdScheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::string::ZstdScheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, _exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::string::ZstdScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -646,9 +646,9 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::temporal::
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::temporal::TemporalScheme
 
-pub fn vortex_btrblocks::schemes::temporal::TemporalScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::temporal::TemporalScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_btrblocks::schemes::temporal::TemporalScheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_btrblocks::schemes::temporal::TemporalScheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, _exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_btrblocks::schemes::temporal::TemporalScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -660,7 +660,7 @@ pub struct vortex_btrblocks::BtrBlocksCompressor(pub vortex_compressor::compress
 
 impl vortex_btrblocks::BtrBlocksCompressor
 
-pub fn vortex_btrblocks::BtrBlocksCompressor::compress(&self, array: &vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::BtrBlocksCompressor::compress(&self, array: &vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 impl core::clone::Clone for vortex_btrblocks::BtrBlocksCompressor
 

--- a/vortex-btrblocks/src/canonical_compressor.rs
+++ b/vortex-btrblocks/src/canonical_compressor.rs
@@ -6,6 +6,7 @@
 use std::ops::Deref;
 
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_error::VortexResult;
 
 use crate::BtrBlocksCompressorBuilder;
@@ -38,8 +39,8 @@ pub struct BtrBlocksCompressor(
 
 impl BtrBlocksCompressor {
     /// Compresses an array using BtrBlocks-inspired compression.
-    pub fn compress(&self, array: &ArrayRef) -> VortexResult<ArrayRef> {
-        self.0.compress(array)
+    pub fn compress(&self, array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+        self.0.compress(array, ctx)
     }
 }
 
@@ -59,20 +60,28 @@ impl Default for BtrBlocksCompressor {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::LazyLock;
+
     use rstest::rstest;
     use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::Constant;
     use vortex_array::arrays::List;
     use vortex_array::arrays::ListView;
     use vortex_array::arrays::ListViewArray;
     use vortex_array::assert_arrays_eq;
+    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::BitBuffer;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
 
     use crate::BtrBlocksCompressor;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     #[rstest]
     #[case::zctl(
@@ -100,7 +109,8 @@ mod tests {
         #[case] expect_list: bool,
     ) -> VortexResult<()> {
         let array_ref = input.clone().into_array();
-        let result = BtrBlocksCompressor::default().compress(&array_ref)?;
+        let result = BtrBlocksCompressor::default()
+            .compress(&array_ref, &mut SESSION.create_execution_ctx())?;
         if expect_list {
             assert!(result.as_opt::<List>().is_some());
         } else {
@@ -114,7 +124,10 @@ mod tests {
     fn test_constant_all_true() -> VortexResult<()> {
         let array = BoolArray::new(BitBuffer::from(vec![true; 100]), Validity::NonNullable);
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.clone().into_array())?;
+        let compressed = btr.compress(
+            &array.clone().into_array(),
+            &mut SESSION.create_execution_ctx(),
+        )?;
         assert!(compressed.is::<Constant>());
         assert_arrays_eq!(compressed, array);
         Ok(())
@@ -124,7 +137,10 @@ mod tests {
     fn test_constant_all_false() -> VortexResult<()> {
         let array = BoolArray::new(BitBuffer::from(vec![false; 100]), Validity::NonNullable);
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.clone().into_array())?;
+        let compressed = btr.compress(
+            &array.clone().into_array(),
+            &mut SESSION.create_execution_ctx(),
+        )?;
         assert!(compressed.is::<Constant>());
         assert_arrays_eq!(compressed, array);
         Ok(())
@@ -137,7 +153,10 @@ mod tests {
             Validity::from(BitBuffer::from(vec![true; 100])),
         );
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.clone().into_array())?;
+        let compressed = btr.compress(
+            &array.clone().into_array(),
+            &mut SESSION.create_execution_ctx(),
+        )?;
         assert!(compressed.is::<Constant>());
         assert_arrays_eq!(compressed, array);
         Ok(())
@@ -148,7 +167,10 @@ mod tests {
         let validity = Validity::from(BitBuffer::from_iter((0..100).map(|i| i % 3 != 0)));
         let array = BoolArray::new(BitBuffer::from(vec![true; 100]), validity);
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.clone().into_array())?;
+        let compressed = btr.compress(
+            &array.clone().into_array(),
+            &mut SESSION.create_execution_ctx(),
+        )?;
         assert!(!compressed.is::<Constant>());
         assert_arrays_eq!(compressed, array);
         Ok(())
@@ -161,7 +183,10 @@ mod tests {
             Validity::NonNullable,
         );
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.clone().into_array())?;
+        let compressed = btr.compress(
+            &array.clone().into_array(),
+            &mut SESSION.create_execution_ctx(),
+        )?;
         assert!(!compressed.is::<Constant>());
         assert_arrays_eq!(compressed, array);
         Ok(())

--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -22,8 +22,8 @@
 //!
 //! # How It Works
 //!
-//! [`BtrBlocksCompressor::compress()`] takes an `&ArrayRef` and returns an `ArrayRef` that may
-//! use a different encoding. It first canonicalizes the input, then dispatches by type.
+//! [`BtrBlocksCompressor::compress()`] takes an `&ArrayRef` plus a mutable execution context and
+//! returns an `ArrayRef` that may use a different encoding. It first canonicalizes the input, then dispatches by type.
 //! Primitives and strings go through `choose_and_compress`, which evaluates every enabled
 //! [`Scheme`] and picks the one with the best compression ratio. Compound types like structs
 //! and lists recurse into their fields and elements.

--- a/vortex-btrblocks/src/schemes/decimal.rs
+++ b/vortex-btrblocks/src/schemes/decimal.rs
@@ -5,6 +5,7 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::DecimalArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -45,7 +46,8 @@ impl Scheme for DecimalScheme {
     fn expected_compression_ratio(
         &self,
         _data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        _exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         // Decimal compression is almost always beneficial (narrowing + primitive compression).
         CompressionEstimate::Verdict(EstimateVerdict::AlwaysUse)
@@ -55,14 +57,12 @@ impl Scheme for DecimalScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         // TODO(joe): add support splitting i128/256 buffers into chunks of primitive values
         // for compression. 2 for i128 and 4 for i256.
-        let decimal = data
-            .array()
-            .clone()
-            .execute::<DecimalArray>(&mut compressor.execution_ctx())?;
+        let decimal = data.array().clone().execute::<DecimalArray>(exec_ctx)?;
         let decimal = narrowed_decimal(decimal);
         let validity = decimal.validity()?;
         let prim = match decimal.values_type() {
@@ -73,7 +73,8 @@ impl Scheme for DecimalScheme {
             _ => return Ok(decimal.into_array()),
         };
 
-        let compressed = compressor.compress_child(&prim.into_array(), &ctx, self.id(), 0)?;
+        let compressed =
+            compressor.compress_child(&prim.into_array(), &compress_ctx, self.id(), 0, exec_ctx)?;
 
         DecimalByteParts::try_new(compressed, decimal.decimal_dtype()).map(|d| d.into_array())
     }

--- a/vortex-btrblocks/src/schemes/float.rs
+++ b/vortex-btrblocks/src/schemes/float.rs
@@ -12,9 +12,8 @@ use vortex_alp::RDEncoder;
 use vortex_alp::alp_encode;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::Patched;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::patched::use_experimental_patches;
@@ -85,11 +84,12 @@ impl Scheme for ALPScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        _exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         // ALP encodes floats as integers. Without integer compression afterward, the encoded ints
         // are the same size.
-        if ctx.finished_cascading() {
+        if compress_ctx.finished_cascading() {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
@@ -105,17 +105,19 @@ impl Scheme for ALPScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let alp_encoded = alp_encode(
-            data.array_as_primitive(),
-            None,
-            &mut compressor.execution_ctx(),
-        )?;
+        let alp_encoded = alp_encode(data.array_as_primitive(), None, exec_ctx)?;
 
         // Compress the ALP ints.
-        let compressed_alp_ints =
-            compressor.compress_child(alp_encoded.encoded(), &ctx, self.id(), 0)?;
+        let compressed_alp_ints = compressor.compress_child(
+            alp_encoded.encoded(),
+            &compress_ctx,
+            self.id(),
+            0,
+            exec_ctx,
+        )?;
 
         let alp_stats = alp_encoded.as_array().statistics().to_owned();
         let exponents = alp_encoded.exponents();
@@ -128,18 +130,14 @@ impl Scheme for ALPScheme {
 
             match patches {
                 None => Ok(alp_array),
-                Some(p) => Ok(Patched::from_array_and_patches(
-                    alp_array,
-                    &p,
-                    &mut compressor.execution_ctx(),
-                )?
-                .with_stats_set(alp_stats)
-                .into_array()),
+                Some(p) => Ok(Patched::from_array_and_patches(alp_array, &p, exec_ctx)?
+                    .with_stats_set(alp_stats)
+                    .into_array()),
             }
         } else {
             let patches = alp_encoded
                 .patches()
-                .map(|p| compress_patches(p, &mut compressor.execution_ctx()))
+                .map(|p| compress_patches(p, exec_ctx))
                 .transpose()?;
 
             Ok(ALP::new(compressed_alp_ints, exponents, patches).into_array())
@@ -159,7 +157,8 @@ impl Scheme for ALPRDScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        _exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         // We don't support ALPRD for f16.
         if data.array_as_primitive().ptype() == PType::F16 {
@@ -171,9 +170,10 @@ impl Scheme for ALPRDScheme {
 
     fn compress(
         &self,
-        compressor: &CascadingCompressor,
+        _compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         let primitive_array = data.array_as_primitive();
 
@@ -183,13 +183,13 @@ impl Scheme for ALPRDScheme {
             ptype => vortex_panic!("cannot ALPRD compress ptype {ptype}"),
         };
 
-        let alp_rd = encoder.encode(primitive_array, &mut compressor.execution_ctx());
+        let alp_rd = encoder.encode(primitive_array, exec_ctx);
         let dtype = alp_rd.dtype().clone();
         let right_bit_width = alp_rd.right_bit_width();
         let mut parts = ALPRDArrayOwnedExt::into_data_parts(alp_rd);
         parts.left_parts_patches = parts
             .left_parts_patches
-            .map(|p| compress_patches(p, &mut compressor.execution_ctx()))
+            .map(|p| compress_patches(p, exec_ctx))
             .transpose()?;
 
         Ok(vortex_alp::ALPRD::try_new(
@@ -199,7 +199,7 @@ impl Scheme for ALPRDScheme {
             parts.right_parts,
             right_bit_width,
             parts.left_parts_patches,
-            &mut compressor.execution_ctx(),
+            exec_ctx,
         )?
         .into_array())
     }
@@ -230,13 +230,11 @@ impl Scheme for NullDominatedSparseScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         let len = data.array_len() as f64;
-        // TRAIT-IMPL BOUNDARY: `Scheme::expected_compression_ratio` has a fixed signature
-        // and does not receive an `ExecutionCtx`, so we fall back to the legacy session here.
-        let mut exec_ctx = LEGACY_SESSION.create_execution_ctx();
-        let stats = data.float_stats(&mut exec_ctx);
+        let stats = data.float_stats(exec_ctx);
         let value_count = stats.value_count();
 
         // All-null arrays should be compressed as constant instead anyways.
@@ -257,20 +255,26 @@ impl Scheme for NullDominatedSparseScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         // We pass None as we only run this pathway for NULL-dominated float arrays.
-        let sparse_encoded = Sparse::encode(data.array(), None, &mut compressor.execution_ctx())?;
+        let sparse_encoded = Sparse::encode(data.array(), None, exec_ctx)?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<Sparse>() {
             let indices = sparse
                 .patches()
                 .indices()
                 .clone()
-                .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+                .execute::<PrimitiveArray>(exec_ctx)?
                 .narrow()?;
-            let compressed_indices =
-                compressor.compress_child(&indices.into_array(), &ctx, self.id(), 0)?;
+            let compressed_indices = compressor.compress_child(
+                &indices.into_array(),
+                &compress_ctx,
+                self.id(),
+                0,
+                exec_ctx,
+            )?;
 
             Sparse::try_new(
                 compressed_indices,
@@ -298,22 +302,24 @@ impl Scheme for PcoScheme {
     fn expected_compression_ratio(
         &self,
         _data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        _exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         CompressionEstimate::Deferred(DeferredEstimate::Sample)
     }
 
     fn compress(
         &self,
-        compressor: &CascadingCompressor,
+        _compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         Ok(vortex_pco::Pco::from_primitive(
             data.array_as_primitive(),
             pco::DEFAULT_COMPRESSION_LEVEL,
             8192,
-            &mut compressor.execution_ctx(),
+            exec_ctx,
         )?
         .into_array())
     }
@@ -344,19 +350,15 @@ impl Scheme for FloatRLEScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         // RLE is only useful when we cascade it with another encoding.
-        if ctx.finished_cascading() {
+        if compress_ctx.finished_cascading() {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
-        // TRAIT-IMPL BOUNDARY: `Scheme::expected_compression_ratio` has a fixed signature
-        // and does not receive an `ExecutionCtx`, so we fall back to the legacy session here.
-        let mut exec_ctx = LEGACY_SESSION.create_execution_ctx();
-        if data.float_stats(&mut exec_ctx).average_run_length()
-            < super::integer::RUN_LENGTH_THRESHOLD
-        {
+        if data.float_stats(exec_ctx).average_run_length() < super::integer::RUN_LENGTH_THRESHOLD {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
@@ -367,38 +369,46 @@ impl Scheme for FloatRLEScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        super::integer::rle_compress(self, compressor, data, ctx)
+        super::integer::rle_compress(self, compressor, data, compress_ctx, exec_ctx)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::iter;
+    use std::sync::LazyLock;
 
     use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::builders::ArrayBuilder;
     use vortex_array::builders::PrimitiveBuilder;
     use vortex_array::display::DisplayOptions;
     use vortex_array::dtype::Nullability;
+    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
     use vortex_buffer::buffer_mut;
     use vortex_compressor::CascadingCompressor;
     use vortex_error::VortexResult;
     use vortex_fastlanes::RLE;
+    use vortex_session::VortexSession;
 
     use crate::BtrBlocksCompressor;
     use crate::schemes::float::FloatRLEScheme;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     #[test]
     fn test_empty() -> VortexResult<()> {
         let btr = BtrBlocksCompressor::default();
         let array = PrimitiveArray::new(Buffer::<f32>::empty(), Validity::NonNullable).into_array();
-        let result = btr.compress(&array)?;
+        let result = btr.compress(&array, &mut SESSION.create_execution_ctx())?;
 
         assert!(result.is_empty());
         Ok(())
@@ -413,7 +423,7 @@ mod tests {
 
         let array = values.into_array();
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array)?;
+        let compressed = btr.compress(&array, &mut SESSION.create_execution_ctx())?;
         assert_eq!(compressed.len(), 1024);
 
         let display = compressed
@@ -435,7 +445,8 @@ mod tests {
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
 
         let compressor = CascadingCompressor::new(vec![&FloatRLEScheme]);
-        let compressed = compressor.compress(&array.into_array())?;
+        let compressed =
+            compressor.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<RLE>());
 
         let expected = Buffer::copy_from(&values).into_array();
@@ -456,7 +467,7 @@ mod tests {
 
         let array = array.finish_into_primitive().into_array();
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array)?;
+        let compressed = btr.compress(&array, &mut SESSION.create_execution_ctx())?;
         assert_eq!(compressed.len(), 96);
 
         let display = compressed
@@ -472,26 +483,34 @@ mod tests {
 /// Tests to verify that each float compression scheme produces the expected encoding.
 #[cfg(test)]
 mod scheme_selection_tests {
+    use std::sync::LazyLock;
+
     use vortex_alp::ALP;
     use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::Constant;
     use vortex_array::arrays::Dict;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::builders::ArrayBuilder;
     use vortex_array::builders::PrimitiveBuilder;
     use vortex_array::dtype::Nullability;
+    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
     use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
 
     use crate::BtrBlocksCompressor;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     #[test]
     fn test_constant_compressed() -> VortexResult<()> {
         let values: Vec<f64> = vec![42.5; 100];
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.into_array())?;
+        let compressed = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<Constant>());
         Ok(())
     }
@@ -501,7 +520,7 @@ mod scheme_selection_tests {
         let values: Vec<f64> = (0..1000).map(|i| (i as f64) * 0.01).collect();
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.into_array())?;
+        let compressed = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<ALP>());
         Ok(())
     }
@@ -514,7 +533,7 @@ mod scheme_selection_tests {
             .collect();
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.into_array())?;
+        let compressed = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<ALP>());
         assert!(compressed.children()[0].is::<Dict>());
         Ok(())
@@ -529,7 +548,7 @@ mod scheme_selection_tests {
         builder.append_nulls(95);
         let array = builder.finish_into_primitive();
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.into_array())?;
+        let compressed = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         // Verify the compressed array preserves values.
         assert_eq!(compressed.len(), 100);
         Ok(())

--- a/vortex-btrblocks/src/schemes/integer.rs
+++ b/vortex-btrblocks/src/schemes/integer.rs
@@ -5,9 +5,8 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::Patched;
 use vortex_array::arrays::PrimitiveArray;
@@ -131,17 +130,15 @@ impl Scheme for FoRScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         // FoR only subtracts the min. Without further compression (e.g. BitPacking), the output is
         // the same size.
-        if ctx.finished_cascading() {
+        if compress_ctx.finished_cascading() {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
-
-        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
-        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
-        let stats = data.integer_stats(&mut local_ctx);
+        let stats = data.integer_stats(exec_ctx);
 
         // Only apply when the min is not already zero.
         if stats.erased().min_is_zero() {
@@ -186,25 +183,25 @@ impl Scheme for FoRScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let primitive = data
-            .array()
-            .clone()
-            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
+        let primitive = data.array().clone().execute::<PrimitiveArray>(exec_ctx)?;
         let for_array = FoR::encode(primitive)?;
         let biased = for_array
             .encoded()
             .clone()
-            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
+            .execute::<PrimitiveArray>(exec_ctx)?;
 
         // Immediately bitpack. If any other scheme was preferable, it would be chosen instead
         // of bitpacking.
         // NOTE: we could delegate in the future if we had another downstream codec that performs
         //  as well.
-        let leaf_ctx = ctx.clone().as_leaf();
-        let mut biased_data = ArrayAndStats::new(biased.into_array(), ctx.merged_stats_options());
-        let compressed = BitPackingScheme.compress(compressor, &mut biased_data, leaf_ctx)?;
+        let leaf_ctx = compress_ctx.clone().as_leaf();
+        let mut biased_data =
+            ArrayAndStats::new(biased.into_array(), compress_ctx.merged_stats_options());
+        let compressed =
+            BitPackingScheme.compress(compressor, &mut biased_data, leaf_ctx, exec_ctx)?;
 
         // TODO(connor): This should really be `new_unchecked`.
         let for_compressed = FoR::try_new(compressed, for_array.reference_scalar().clone())?;
@@ -272,17 +269,15 @@ impl Scheme for ZigZagScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         // ZigZag only transforms negative values to positive. Without further compression,
         // the output is the same size.
-        if ctx.finished_cascading() {
+        if compress_ctx.finished_cascading() {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
-
-        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
-        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
-        let stats = data.integer_stats(&mut local_ctx);
+        let stats = data.integer_stats(exec_ctx);
 
         // ZigZag is only useful when there are negative values.
         if !stats.erased().min_is_negative() {
@@ -296,16 +291,20 @@ impl Scheme for ZigZagScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         // Zigzag encode the values, then recursively compress the inner values.
         let zag = zigzag_encode(data.array_as_primitive())?;
-        let encoded = zag
-            .encoded()
-            .clone()
-            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
+        let encoded = zag.encoded().clone().execute::<PrimitiveArray>(exec_ctx)?;
 
-        let compressed = compressor.compress_child(&encoded.into_array(), &ctx, self.id(), 0)?;
+        let compressed = compressor.compress_child(
+            &encoded.into_array(),
+            &compress_ctx,
+            self.id(),
+            0,
+            exec_ctx,
+        )?;
 
         Ok(ZigZag::try_new(compressed)?.into_array())
     }
@@ -323,11 +322,10 @@ impl Scheme for BitPackingScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
-        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
-        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
-        let stats = data.integer_stats(&mut local_ctx);
+        let stats = data.integer_stats(exec_ctx);
 
         // BitPacking only works for non-negative values.
         if stats.erased().min_is_negative() {
@@ -339,13 +337,14 @@ impl Scheme for BitPackingScheme {
 
     fn compress(
         &self,
-        compressor: &CascadingCompressor,
+        _compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         let primitive_array = data.array_as_primitive();
 
-        let histogram = bit_width_histogram(primitive_array, &mut compressor.execution_ctx())?;
+        let histogram = bit_width_histogram(primitive_array, exec_ctx)?;
         let bw = find_best_bit_width(primitive_array.ptype(), &histogram)?;
 
         // If best bw is determined to be the current bit-width, return the original array.
@@ -355,12 +354,7 @@ impl Scheme for BitPackingScheme {
 
         // Otherwise we can bitpack the array.
         let primitive_array = primitive_array.into_owned();
-        let packed = bitpack_encode(
-            &primitive_array,
-            bw,
-            Some(&histogram),
-            &mut compressor.execution_ctx(),
-        )?;
+        let packed = bitpack_encode(&primitive_array, bw, Some(&histogram), exec_ctx)?;
 
         let packed_stats = packed.statistics().to_owned();
         let ptype = packed.dtype().as_ptype();
@@ -382,18 +376,16 @@ impl Scheme for BitPackingScheme {
 
             match patches {
                 None => array,
-                Some(p) => {
-                    Patched::from_array_and_patches(array, &p, &mut compressor.execution_ctx())?
-                        .with_stats_set(packed_stats)
-                        .into_array()
-                }
+                Some(p) => Patched::from_array_and_patches(array, &p, exec_ctx)?
+                    .with_stats_set(packed_stats)
+                    .into_array(),
             }
         } else {
             // Compress patches and place back into BitPackedArray.
             let patches = parts
                 .patches
                 .take()
-                .map(|p| compress_patches(p, &mut compressor.execution_ctx()))
+                .map(|p| compress_patches(p, exec_ctx))
                 .transpose()?;
             parts.patches = patches;
             BitPacked::try_new(
@@ -459,12 +451,11 @@ impl Scheme for SparseScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         let len = data.array_len() as f64;
-        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
-        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
-        let stats = data.integer_stats(&mut local_ctx);
+        let stats = data.integer_stats(exec_ctx);
         let value_count = stats.value_count();
 
         // All-null arrays should be compressed as constant instead anyways.
@@ -506,11 +497,12 @@ impl Scheme for SparseScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         let len = data.array_len();
         // TODO(connor): Fight the borrow checker (needs interior mutability)!
-        let stats = data.integer_stats(&mut compressor.execution_ctx()).clone();
+        let stats = data.integer_stats(exec_ctx).clone();
         let array = data.array();
 
         let (most_frequent_value, most_frequent_count) = stats
@@ -540,7 +532,7 @@ impl Scheme for SparseScheme {
                 most_frequent_value.ptype(),
                 array.dtype().nullability(),
             )),
-            &mut compressor.execution_ctx(),
+            exec_ctx,
         )?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<Sparse>() {
@@ -548,23 +540,29 @@ impl Scheme for SparseScheme {
                 .patches()
                 .values()
                 .clone()
-                .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
+                .execute::<PrimitiveArray>(exec_ctx)?;
             let compressed_values = compressor.compress_child(
                 &sparse_values_primitive.into_array(),
-                &ctx,
+                &compress_ctx,
                 self.id(),
                 0,
+                exec_ctx,
             )?;
 
             let indices = sparse
                 .patches()
                 .indices()
                 .clone()
-                .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+                .execute::<PrimitiveArray>(exec_ctx)?
                 .narrow()?;
 
-            let compressed_indices =
-                compressor.compress_child(&indices.into_array(), &ctx, self.id(), 1)?;
+            let compressed_indices = compressor.compress_child(
+                &indices.into_array(),
+                &compress_ctx,
+                self.id(),
+                1,
+                exec_ctx,
+            )?;
 
             Sparse::try_new(
                 compressed_indices,
@@ -638,12 +636,11 @@ impl Scheme for RunEndScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         // If the run length is below the threshold, drop it.
-        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
-        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
-        if data.integer_stats(&mut local_ctx).average_run_length() < RUN_END_THRESHOLD {
+        if data.integer_stats(exec_ctx).average_run_length() < RUN_END_THRESHOLD {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
@@ -654,17 +651,23 @@ impl Scheme for RunEndScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         // Run-end encode the ends.
-        let (ends, values) =
-            runend_encode(data.array_as_primitive(), &mut compressor.execution_ctx());
+        let (ends, values) = runend_encode(data.array_as_primitive(), exec_ctx);
 
-        let values_primitive = values.execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
-        let compressed_values =
-            compressor.compress_child(&values_primitive.into_array(), &ctx, self.id(), 0)?;
+        let values_primitive = values.execute::<PrimitiveArray>(exec_ctx)?;
+        let compressed_values = compressor.compress_child(
+            &values_primitive.into_array(),
+            &compress_ctx,
+            self.id(),
+            0,
+            exec_ctx,
+        )?;
 
-        let compressed_ends = compressor.compress_child(&ends.into_array(), &ctx, self.id(), 1)?;
+        let compressed_ends =
+            compressor.compress_child(&ends.into_array(), &compress_ctx, self.id(), 1, exec_ctx)?;
 
         // SAFETY: compression doesn't affect invariants.
         Ok(unsafe {
@@ -673,7 +676,7 @@ impl Scheme for RunEndScheme {
                 compressed_values,
                 0,
                 data.array_len(),
-                &mut compressor.execution_ctx(),
+                exec_ctx,
             )
             .into_array()
         })
@@ -712,17 +715,15 @@ impl Scheme for SequenceScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         // It is pointless checking if a sample is a sequence since it will not correspond to the
         // entire array.
-        if ctx.is_sample() {
+        if compress_ctx.is_sample() {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
-
-        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
-        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
-        let stats = data.integer_stats(&mut local_ctx);
+        let stats = data.integer_stats(exec_ctx);
 
         // `SequenceArray` does not support nulls.
         if stats.null_count() > 0 {
@@ -742,10 +743,8 @@ impl Scheme for SequenceScheme {
         // why do we divide the ratio by 2???
 
         CompressionEstimate::Deferred(DeferredEstimate::Callback(Box::new(
-            |compressor, data, _ctx| {
-                let Some(encoded) =
-                    sequence_encode(data.array_as_primitive(), &mut compressor.execution_ctx())?
-                else {
+            |_compressor, data, _ctx, exec_ctx| {
+                let Some(encoded) = sequence_encode(data.array_as_primitive(), exec_ctx)? else {
                     // If we are unable to sequence encode this array, make sure we skip.
                     return Ok(EstimateVerdict::Skip);
                 };
@@ -760,16 +759,17 @@ impl Scheme for SequenceScheme {
 
     fn compress(
         &self,
-        compressor: &CascadingCompressor,
+        _compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let stats = data.integer_stats(&mut compressor.execution_ctx());
+        let stats = data.integer_stats(exec_ctx);
 
         if stats.null_count() > 0 {
             vortex_bail!("sequence encoding does not support nulls");
         }
-        sequence_encode(data.array_as_primitive(), &mut compressor.execution_ctx())?
+        sequence_encode(data.array_as_primitive(), exec_ctx)?
             .ok_or_else(|| vortex_err!("cannot sequence encode array"))
     }
 }
@@ -787,7 +787,8 @@ impl Scheme for PcoScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        _exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         use vortex_array::dtype::PType;
 
@@ -801,15 +802,16 @@ impl Scheme for PcoScheme {
 
     fn compress(
         &self,
-        compressor: &CascadingCompressor,
+        _compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         Ok(vortex_pco::Pco::from_primitive(
             data.array_as_primitive(),
             pco::DEFAULT_COMPRESSION_LEVEL,
             8192,
-            &mut compressor.execution_ctx(),
+            exec_ctx,
         )?
         .into_array())
     }
@@ -820,16 +822,22 @@ pub(crate) fn rle_compress(
     scheme: &dyn Scheme,
     compressor: &CascadingCompressor,
     data: &mut ArrayAndStats,
-    ctx: CompressorContext,
+    compress_ctx: CompressorContext,
+    exec_ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    let rle_array = RLE::encode(data.array_as_primitive(), &mut compressor.execution_ctx())?;
+    let rle_array = RLE::encode(data.array_as_primitive(), exec_ctx)?;
 
     let rle_values_primitive = rle_array
         .values()
         .clone()
-        .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
-    let compressed_values =
-        compressor.compress_child(&rle_values_primitive.into_array(), &ctx, scheme.id(), 0)?;
+        .execute::<PrimitiveArray>(exec_ctx)?;
+    let compressed_values = compressor.compress_child(
+        &rle_values_primitive.into_array(),
+        &compress_ctx,
+        scheme.id(),
+        0,
+        exec_ctx,
+    )?;
 
     // Delta is an unstable encoding, once we deem it stable we can switch over to this always.
     #[cfg(feature = "unstable_encodings")]
@@ -837,14 +845,15 @@ pub(crate) fn rle_compress(
         let rle_indices_primitive = rle_array
             .indices()
             .clone()
-            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+            .execute::<PrimitiveArray>(exec_ctx)?
             .narrow()?;
         try_compress_delta(
             compressor,
             &rle_indices_primitive.into_array(),
-            &ctx,
+            &compress_ctx,
             scheme.id(),
             1,
+            exec_ctx,
         )?
     };
 
@@ -853,18 +862,29 @@ pub(crate) fn rle_compress(
         let rle_indices_primitive = rle_array
             .indices()
             .clone()
-            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+            .execute::<PrimitiveArray>(exec_ctx)?
             .narrow()?;
-        compressor.compress_child(&rle_indices_primitive.into_array(), &ctx, scheme.id(), 1)?
+        compressor.compress_child(
+            &rle_indices_primitive.into_array(),
+            &compress_ctx,
+            scheme.id(),
+            1,
+            exec_ctx,
+        )?
     };
 
     let rle_offsets_primitive = rle_array
         .values_idx_offsets()
         .clone()
-        .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+        .execute::<PrimitiveArray>(exec_ctx)?
         .narrow()?;
-    let compressed_offsets =
-        compressor.compress_child(&rle_offsets_primitive.into_array(), &ctx, scheme.id(), 2)?;
+    let compressed_offsets = compressor.compress_child(
+        &rle_offsets_primitive.into_array(),
+        &compress_ctx,
+        scheme.id(),
+        2,
+        exec_ctx,
+    )?;
 
     // SAFETY: Recursive compression doesn't affect the invariants.
     unsafe {
@@ -886,17 +906,25 @@ fn try_compress_delta(
     parent_ctx: &CompressorContext,
     parent_id: SchemeId,
     child_index: usize,
+    exec_ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    let child_primitive = child
-        .clone()
-        .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
-    let (bases, deltas) =
-        vortex_fastlanes::delta_compress(&child_primitive, &mut compressor.execution_ctx())?;
+    let child_primitive = child.clone().execute::<PrimitiveArray>(exec_ctx)?;
+    let (bases, deltas) = vortex_fastlanes::delta_compress(&child_primitive, exec_ctx)?;
 
-    let compressed_bases =
-        compressor.compress_child(&bases.into_array(), parent_ctx, parent_id, child_index)?;
-    let compressed_deltas =
-        compressor.compress_child(&deltas.into_array(), parent_ctx, parent_id, child_index)?;
+    let compressed_bases = compressor.compress_child(
+        &bases.into_array(),
+        parent_ctx,
+        parent_id,
+        child_index,
+        exec_ctx,
+    )?;
+    let compressed_deltas = compressor.compress_child(
+        &deltas.into_array(),
+        parent_ctx,
+        parent_id,
+        child_index,
+        exec_ctx,
+    )?;
 
     Delta::try_new(compressed_bases, compressed_deltas, 0, child.len()).map(IntoArray::into_array)
 }
@@ -926,16 +954,14 @@ impl Scheme for IntRLEScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         // RLE is only useful when we cascade it with another encoding.
-        if ctx.finished_cascading() {
+        if compress_ctx.finished_cascading() {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
-
-        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
-        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
-        if data.integer_stats(&mut local_ctx).average_run_length() < RUN_LENGTH_THRESHOLD {
+        if data.integer_stats(exec_ctx).average_run_length() < RUN_LENGTH_THRESHOLD {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
@@ -946,26 +972,30 @@ impl Scheme for IntRLEScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        rle_compress(self, compressor, data, ctx)
+        rle_compress(self, compressor, data, compress_ctx, exec_ctx)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::iter;
+    use std::sync::LazyLock;
 
     use itertools::Itertools;
     use rand::Rng;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
     use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::Constant;
     use vortex_array::arrays::Dict;
     use vortex_array::arrays::Masked;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
+    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
     use vortex_buffer::BufferMut;
@@ -974,16 +1004,20 @@ mod tests {
     use vortex_error::VortexResult;
     use vortex_fastlanes::RLE;
     use vortex_sequence::Sequence;
+    use vortex_session::VortexSession;
 
     use crate::BtrBlocksCompressor;
     use crate::schemes::integer::IntRLEScheme;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     #[test]
     fn test_empty() -> VortexResult<()> {
         // Make sure empty array compression does not fail.
         let btr = BtrBlocksCompressor::default();
         let array = PrimitiveArray::new(Buffer::<i32>::empty(), Validity::NonNullable);
-        let result = btr.compress(&array.into_array())?;
+        let result = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
 
         assert!(result.is_empty());
         Ok(())
@@ -1010,7 +1044,10 @@ mod tests {
         }
 
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&codes.freeze().into_array())?;
+        let compressed = btr.compress(
+            &codes.freeze().into_array(),
+            &mut SESSION.create_execution_ctx(),
+        )?;
         assert!(compressed.is::<Dict>());
         Ok(())
     }
@@ -1026,7 +1063,7 @@ mod tests {
         let validity = array.validity()?;
 
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.into_array())?;
+        let compressed = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
 
         assert!(compressed.is::<Masked>());
         assert!(compressed.children()[0].is::<Constant>());
@@ -1044,7 +1081,7 @@ mod tests {
         let array = PrimitiveArray::from_option_iter(values.clone().into_iter().map(Some));
 
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.into_array())?;
+        let compressed = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<Sequence>());
 
         let decoded = compressed;
@@ -1062,7 +1099,8 @@ mod tests {
 
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
         let compressor = CascadingCompressor::new(vec![&IntRLEScheme]);
-        let compressed = compressor.compress(&array.into_array())?;
+        let compressed =
+            compressor.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<RLE>());
 
         let expected = Buffer::copy_from(&values).into_array();
@@ -1084,7 +1122,7 @@ mod tests {
             .into_array();
 
         let btr = BtrBlocksCompressor::default();
-        btr.compress(&prim)?;
+        btr.compress(&prim, &mut SESSION.create_execution_ctx())?;
 
         Ok(())
     }
@@ -1094,17 +1132,20 @@ mod tests {
 #[cfg(test)]
 mod scheme_selection_tests {
     use std::iter;
+    use std::sync::LazyLock;
 
     use rand::Rng;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
     use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::Constant;
     use vortex_array::arrays::Dict;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::expr::stats::Precision;
     use vortex_array::expr::stats::Stat;
     use vortex_array::expr::stats::StatsProviderExt;
+    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
     use vortex_error::VortexResult;
@@ -1112,16 +1153,20 @@ mod scheme_selection_tests {
     use vortex_fastlanes::FoR;
     use vortex_runend::RunEnd;
     use vortex_sequence::Sequence;
+    use vortex_session::VortexSession;
     use vortex_sparse::Sparse;
 
     use crate::BtrBlocksCompressor;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     #[test]
     fn test_constant_compressed() -> VortexResult<()> {
         let values: Vec<i32> = iter::repeat_n(42, 100).collect();
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.into_array())?;
+        let compressed = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<Constant>());
         Ok(())
     }
@@ -1131,7 +1176,7 @@ mod scheme_selection_tests {
         let values: Vec<i32> = (0..1000).map(|i| 1_000_000 + ((i * 37) % 100)).collect();
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.into_array())?;
+        let compressed = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<FoR>());
         Ok(())
     }
@@ -1141,7 +1186,7 @@ mod scheme_selection_tests {
         let values: Vec<u32> = (0..1000).map(|i| i % 16).collect();
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.into_array())?;
+        let compressed = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<BitPacked>());
         assert_eq!(
             compressed.statistics().get_as::<u64>(Stat::NullCount),
@@ -1170,7 +1215,7 @@ mod scheme_selection_tests {
         }
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.into_array())?;
+        let compressed = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<Sparse>());
         Ok(())
     }
@@ -1194,7 +1239,7 @@ mod scheme_selection_tests {
 
         let array = PrimitiveArray::new(Buffer::copy_from(&codes), Validity::NonNullable);
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.into_array())?;
+        let compressed = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<Dict>());
         Ok(())
     }
@@ -1207,7 +1252,7 @@ mod scheme_selection_tests {
         }
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.into_array())?;
+        let compressed = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<RunEnd>());
         Ok(())
     }
@@ -1217,7 +1262,7 @@ mod scheme_selection_tests {
         let values: Vec<i32> = (0..1000).map(|i| i * 7).collect();
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.into_array())?;
+        let compressed = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<Sequence>());
         Ok(())
     }
@@ -1230,7 +1275,7 @@ mod scheme_selection_tests {
         }
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array.into_array())?;
+        let compressed = btr.compress(&array.into_array(), &mut SESSION.create_execution_ctx())?;
         eprintln!("{}", compressed.display_tree());
         assert!(compressed.is::<RunEnd>());
         Ok(())

--- a/vortex-btrblocks/src/schemes/string.rs
+++ b/vortex-btrblocks/src/schemes/string.rs
@@ -5,9 +5,8 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::VarBinArray;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
@@ -75,7 +74,8 @@ impl Scheme for FSSTScheme {
     fn expected_compression_ratio(
         &self,
         _data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        _exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         CompressionEstimate::Deferred(DeferredEstimate::Sample)
     }
@@ -84,38 +84,39 @@ impl Scheme for FSSTScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         let utf8 = data.array_as_utf8().into_owned();
         let compressor_fsst = fsst_train_compressor(&utf8);
-        let fsst = fsst_compress(
-            &utf8,
-            utf8.len(),
-            utf8.dtype(),
-            &compressor_fsst,
-            &mut compressor.execution_ctx(),
-        );
+        let fsst = fsst_compress(&utf8, utf8.len(), utf8.dtype(), &compressor_fsst, exec_ctx);
 
         let uncompressed_lengths_primitive = fsst
             .uncompressed_lengths()
             .clone()
-            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+            .execute::<PrimitiveArray>(exec_ctx)?
             .narrow()?;
         let compressed_original_lengths = compressor.compress_child(
             &uncompressed_lengths_primitive.into_array(),
-            &ctx,
+            &compress_ctx,
             self.id(),
             0,
+            exec_ctx,
         )?;
 
         let codes_offsets_primitive = fsst
             .codes()
             .offsets()
             .clone()
-            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+            .execute::<PrimitiveArray>(exec_ctx)?
             .narrow()?;
-        let compressed_codes_offsets =
-            compressor.compress_child(&codes_offsets_primitive.into_array(), &ctx, self.id(), 1)?;
+        let compressed_codes_offsets = compressor.compress_child(
+            &codes_offsets_primitive.into_array(),
+            &compress_ctx,
+            self.id(),
+            1,
+            exec_ctx,
+        )?;
         let compressed_codes = VarBinArray::try_new(
             compressed_codes_offsets,
             fsst.codes().bytes().clone(),
@@ -129,7 +130,7 @@ impl Scheme for FSSTScheme {
             fsst.symbol_lengths().clone(),
             compressed_codes,
             compressed_original_lengths,
-            &mut compressor.execution_ctx(),
+            exec_ctx,
         )?;
 
         Ok(fsst.into_array())
@@ -167,12 +168,11 @@ impl Scheme for NullDominatedSparseScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         let len = data.array_len() as f64;
-        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
-        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
-        let stats = data.string_stats(&mut local_ctx);
+        let stats = data.string_stats(exec_ctx);
         let value_count = stats.value_count();
 
         // All-null arrays should be compressed as constant instead anyways.
@@ -193,10 +193,11 @@ impl Scheme for NullDominatedSparseScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         // We pass None as we only run this pathway for NULL-dominated string arrays.
-        let sparse_encoded = Sparse::encode(data.array(), None, &mut compressor.execution_ctx())?;
+        let sparse_encoded = Sparse::encode(data.array(), None, exec_ctx)?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<Sparse>() {
             // Compress the indices only (not the values for strings).
@@ -204,10 +205,15 @@ impl Scheme for NullDominatedSparseScheme {
                 .patches()
                 .indices()
                 .clone()
-                .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+                .execute::<PrimitiveArray>(exec_ctx)?
                 .narrow()?;
-            let compressed_indices =
-                compressor.compress_child(&indices.into_array(), &ctx, self.id(), 0)?;
+            let compressed_indices = compressor.compress_child(
+                &indices.into_array(),
+                &compress_ctx,
+                self.id(),
+                0,
+                exec_ctx,
+            )?;
 
             Sparse::try_new(
                 compressed_indices,
@@ -235,25 +241,24 @@ impl Scheme for ZstdScheme {
     fn expected_compression_ratio(
         &self,
         _data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        _exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         CompressionEstimate::Deferred(DeferredEstimate::Sample)
     }
 
     fn compress(
         &self,
-        compressor: &CascadingCompressor,
+        _compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         let compacted = data.array_as_utf8().into_owned().compact_buffers()?;
-        Ok(vortex_zstd::Zstd::from_var_bin_view_without_dict(
-            &compacted,
-            3,
-            8192,
-            &mut compressor.execution_ctx(),
-        )?
-        .into_array())
+        Ok(
+            vortex_zstd::Zstd::from_var_bin_view_without_dict(&compacted, 3, 8192, exec_ctx)?
+                .into_array(),
+        )
     }
 }
 
@@ -270,7 +275,8 @@ impl Scheme for ZstdBuffersScheme {
     fn expected_compression_ratio(
         &self,
         _data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        _exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         CompressionEstimate::Deferred(DeferredEstimate::Sample)
     }
@@ -279,24 +285,33 @@ impl Scheme for ZstdBuffersScheme {
         &self,
         _compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        Ok(vortex_zstd::ZstdBuffers::compress(data.array(), 3, &LEGACY_SESSION)?.into_array())
+        Ok(vortex_zstd::ZstdBuffers::compress(data.array(), 3, exec_ctx.session())?.into_array())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::LazyLock;
+
     use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::VarBinViewArray;
     use vortex_array::builders::ArrayBuilder;
     use vortex_array::builders::VarBinViewBuilder;
     use vortex_array::display::DisplayOptions;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
+    use vortex_array::session::ArraySession;
     use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
 
     use crate::BtrBlocksCompressor;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     #[test]
     fn test_strings() -> VortexResult<()> {
@@ -311,7 +326,7 @@ mod tests {
 
         let array_ref = strings.into_array();
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array_ref)?;
+        let compressed = btr.compress(&array_ref, &mut SESSION.create_execution_ctx())?;
         assert_eq!(compressed.len(), 2048);
 
         let display = compressed
@@ -334,7 +349,7 @@ mod tests {
 
         let array_ref = strings.into_array();
         let btr = BtrBlocksCompressor::default();
-        let compressed = btr.compress(&array_ref)?;
+        let compressed = btr.compress(&array_ref, &mut SESSION.create_execution_ctx())?;
         assert_eq!(compressed.len(), 100);
 
         let display = compressed
@@ -350,23 +365,32 @@ mod tests {
 /// Tests to verify that each string compression scheme produces the expected encoding.
 #[cfg(test)]
 mod scheme_selection_tests {
+    use std::sync::LazyLock;
+
     use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::Constant;
     use vortex_array::arrays::Dict;
     use vortex_array::arrays::VarBinViewArray;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
+    use vortex_array::session::ArraySession;
     use vortex_error::VortexResult;
     use vortex_fsst::FSST;
+    use vortex_session::VortexSession;
 
     use crate::BtrBlocksCompressor;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     #[test]
     fn test_constant_compressed() -> VortexResult<()> {
         let strings: Vec<Option<&str>> = vec![Some("constant_value"); 100];
         let array = VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
         let array_ref = array.into_array();
-        let compressed = BtrBlocksCompressor::default().compress(&array_ref)?;
+        let compressed = BtrBlocksCompressor::default()
+            .compress(&array_ref, &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<Constant>());
         Ok(())
     }
@@ -380,7 +404,8 @@ mod scheme_selection_tests {
         }
         let array = VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
         let array_ref = array.into_array();
-        let compressed = BtrBlocksCompressor::default().compress(&array_ref)?;
+        let compressed = BtrBlocksCompressor::default()
+            .compress(&array_ref, &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<Dict>());
         Ok(())
     }
@@ -395,7 +420,8 @@ mod scheme_selection_tests {
         }
         let array = VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
         let array_ref = array.into_array();
-        let compressed = BtrBlocksCompressor::default().compress(&array_ref)?;
+        let compressed = BtrBlocksCompressor::default()
+            .compress(&array_ref, &mut SESSION.create_execution_ctx())?;
         assert!(compressed.is::<FSST>());
         Ok(())
     }

--- a/vortex-btrblocks/src/schemes/temporal.rs
+++ b/vortex-btrblocks/src/schemes/temporal.rs
@@ -5,6 +5,7 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::aggregate_fn::fns::is_constant::is_constant;
 use vortex_array::arrays::ConstantArray;
@@ -61,7 +62,8 @@ impl Scheme for TemporalScheme {
     fn expected_compression_ratio(
         &self,
         _data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        _exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         // Temporal compression (splitting into parts) is almost always beneficial.
         CompressionEstimate::Verdict(EstimateVerdict::AlwaysUse)
@@ -71,24 +73,21 @@ impl Scheme for TemporalScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         let array = data.array().clone();
-        let ext_array = array.execute::<ExtensionArray>(&mut compressor.execution_ctx())?;
+        let ext_array = array.execute::<ExtensionArray>(exec_ctx)?;
         let temporal_array = TemporalArray::try_from(ext_array.clone().into_array())?;
 
         // Check for constant array and return early if so.
-        let is_constant = is_constant(
-            &ext_array.clone().into_array(),
-            &mut compressor.execution_ctx(),
-        )?;
+        let is_constant = is_constant(&ext_array.clone().into_array(), exec_ctx)?;
 
         if is_constant {
-            return Ok(ConstantArray::new(
-                ext_array.execute_scalar(0, &mut compressor.execution_ctx())?,
-                ext_array.len(),
-            )
-            .into_array());
+            return Ok(
+                ConstantArray::new(ext_array.execute_scalar(0, exec_ctx)?, ext_array.len())
+                    .into_array(),
+            );
         }
 
         let dtype = temporal_array.dtype().clone();
@@ -96,22 +95,32 @@ impl Scheme for TemporalScheme {
             days,
             seconds,
             subseconds,
-        } = split_temporal(temporal_array, &mut compressor.execution_ctx())?;
+        } = split_temporal(temporal_array, exec_ctx)?;
 
-        let days_primitive = days
-            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
-            .narrow()?;
-        let days = compressor.compress_child(&days_primitive.into_array(), &ctx, self.id(), 0)?;
-        let seconds_primitive = seconds
-            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
-            .narrow()?;
-        let seconds =
-            compressor.compress_child(&seconds_primitive.into_array(), &ctx, self.id(), 1)?;
-        let subseconds_primitive = subseconds
-            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
-            .narrow()?;
-        let subseconds =
-            compressor.compress_child(&subseconds_primitive.into_array(), &ctx, self.id(), 2)?;
+        let days_primitive = days.execute::<PrimitiveArray>(exec_ctx)?.narrow()?;
+        let days = compressor.compress_child(
+            &days_primitive.into_array(),
+            &compress_ctx,
+            self.id(),
+            0,
+            exec_ctx,
+        )?;
+        let seconds_primitive = seconds.execute::<PrimitiveArray>(exec_ctx)?.narrow()?;
+        let seconds = compressor.compress_child(
+            &seconds_primitive.into_array(),
+            &compress_ctx,
+            self.id(),
+            1,
+            exec_ctx,
+        )?;
+        let subseconds_primitive = subseconds.execute::<PrimitiveArray>(exec_ctx)?.narrow()?;
+        let subseconds = compressor.compress_child(
+            &subseconds_primitive.into_array(),
+            &compress_ctx,
+            self.id(),
+            2,
+            exec_ctx,
+        )?;
 
         Ok(DateTimeParts::try_new(dtype, days, seconds, subseconds)?.into_array())
     }

--- a/vortex-compressor/Cargo.toml
+++ b/vortex-compressor/Cargo.toml
@@ -31,6 +31,7 @@ divan = { workspace = true }
 rstest = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 vortex-array = { workspace = true, features = ["_test-harness"] }
+vortex-session = { workspace = true }
 
 [lints]
 workspace = true

--- a/vortex-compressor/public-api.lock
+++ b/vortex-compressor/public-api.lock
@@ -26,11 +26,11 @@ impl vortex_compressor::scheme::Scheme for vortex_compressor::builtins::BoolCons
 
 pub fn vortex_compressor::builtins::BoolConstantScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::builtins::BoolConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::builtins::BoolConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::builtins::BoolConstantScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::builtins::BoolConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::builtins::BoolConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::builtins::BoolConstantScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -64,11 +64,11 @@ impl vortex_compressor::scheme::Scheme for vortex_compressor::builtins::FloatCon
 
 pub fn vortex_compressor::builtins::FloatConstantScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::builtins::FloatConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::builtins::FloatConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::builtins::FloatConstantScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::builtins::FloatConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::builtins::FloatConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::builtins::FloatConstantScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -102,11 +102,11 @@ impl vortex_compressor::scheme::Scheme for vortex_compressor::builtins::FloatDic
 
 pub fn vortex_compressor::builtins::FloatDictScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::builtins::FloatDictScheme::compress(&self, compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::builtins::FloatDictScheme::compress(&self, compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::builtins::FloatDictScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::builtins::FloatDictScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::builtins::FloatDictScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::builtins::FloatDictScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -140,11 +140,11 @@ impl vortex_compressor::scheme::Scheme for vortex_compressor::builtins::IntConst
 
 pub fn vortex_compressor::builtins::IntConstantScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::builtins::IntConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::builtins::IntConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::builtins::IntConstantScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::builtins::IntConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::builtins::IntConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::builtins::IntConstantScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -178,11 +178,11 @@ impl vortex_compressor::scheme::Scheme for vortex_compressor::builtins::IntDictS
 
 pub fn vortex_compressor::builtins::IntDictScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::builtins::IntDictScheme::compress(&self, compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::builtins::IntDictScheme::compress(&self, compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::builtins::IntDictScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::builtins::IntDictScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::builtins::IntDictScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::builtins::IntDictScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -216,11 +216,11 @@ impl vortex_compressor::scheme::Scheme for vortex_compressor::builtins::StringCo
 
 pub fn vortex_compressor::builtins::StringConstantScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::builtins::StringConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::builtins::StringConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::builtins::StringConstantScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::builtins::StringConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::builtins::StringConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::builtins::StringConstantScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -254,11 +254,11 @@ impl vortex_compressor::scheme::Scheme for vortex_compressor::builtins::StringDi
 
 pub fn vortex_compressor::builtins::StringDictScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::builtins::StringDictScheme::compress(&self, compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::builtins::StringDictScheme::compress(&self, compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::builtins::StringDictScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::builtins::StringDictScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::builtins::StringDictScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::builtins::StringDictScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -338,7 +338,7 @@ impl core::fmt::Debug for vortex_compressor::estimate::EstimateVerdict
 
 pub fn vortex_compressor::estimate::EstimateVerdict::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-pub type vortex_compressor::estimate::EstimateFn = (dyn core::ops::function::FnOnce(&vortex_compressor::CascadingCompressor, &mut vortex_compressor::stats::ArrayAndStats, vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_compressor::estimate::EstimateVerdict> + core::marker::Send + core::marker::Sync)
+pub type vortex_compressor::estimate::EstimateFn = (dyn core::ops::function::FnOnce(&vortex_compressor::CascadingCompressor, &mut vortex_compressor::stats::ArrayAndStats, vortex_compressor::ctx::CompressorContext, &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_compressor::estimate::EstimateVerdict> + core::marker::Send + core::marker::Sync)
 
 pub mod vortex_compressor::scheme
 
@@ -428,11 +428,11 @@ pub trait vortex_compressor::scheme::Scheme: core::fmt::Debug + core::marker::Se
 
 pub fn vortex_compressor::scheme::Scheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::scheme::Scheme::compress(&self, compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::scheme::Scheme::compress(&self, compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::scheme::Scheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::scheme::Scheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::scheme::Scheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, _exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::scheme::Scheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -446,11 +446,11 @@ impl vortex_compressor::scheme::Scheme for vortex_compressor::builtins::BoolCons
 
 pub fn vortex_compressor::builtins::BoolConstantScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::builtins::BoolConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::builtins::BoolConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::builtins::BoolConstantScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::builtins::BoolConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::builtins::BoolConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::builtins::BoolConstantScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -464,11 +464,11 @@ impl vortex_compressor::scheme::Scheme for vortex_compressor::builtins::FloatCon
 
 pub fn vortex_compressor::builtins::FloatConstantScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::builtins::FloatConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::builtins::FloatConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::builtins::FloatConstantScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::builtins::FloatConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::builtins::FloatConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::builtins::FloatConstantScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -482,11 +482,11 @@ impl vortex_compressor::scheme::Scheme for vortex_compressor::builtins::FloatDic
 
 pub fn vortex_compressor::builtins::FloatDictScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::builtins::FloatDictScheme::compress(&self, compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::builtins::FloatDictScheme::compress(&self, compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::builtins::FloatDictScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::builtins::FloatDictScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::builtins::FloatDictScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::builtins::FloatDictScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -500,11 +500,11 @@ impl vortex_compressor::scheme::Scheme for vortex_compressor::builtins::IntConst
 
 pub fn vortex_compressor::builtins::IntConstantScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::builtins::IntConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::builtins::IntConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::builtins::IntConstantScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::builtins::IntConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::builtins::IntConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::builtins::IntConstantScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -518,11 +518,11 @@ impl vortex_compressor::scheme::Scheme for vortex_compressor::builtins::IntDictS
 
 pub fn vortex_compressor::builtins::IntDictScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::builtins::IntDictScheme::compress(&self, compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::builtins::IntDictScheme::compress(&self, compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::builtins::IntDictScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::builtins::IntDictScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::builtins::IntDictScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::builtins::IntDictScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -536,11 +536,11 @@ impl vortex_compressor::scheme::Scheme for vortex_compressor::builtins::StringCo
 
 pub fn vortex_compressor::builtins::StringConstantScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::builtins::StringConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::builtins::StringConstantScheme::compress(&self, _compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::builtins::StringConstantScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::builtins::StringConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::builtins::StringConstantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::builtins::StringConstantScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -554,11 +554,11 @@ impl vortex_compressor::scheme::Scheme for vortex_compressor::builtins::StringDi
 
 pub fn vortex_compressor::builtins::StringDictScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_compressor::builtins::StringDictScheme::compress(&self, compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::builtins::StringDictScheme::compress(&self, compressor: &vortex_compressor::CascadingCompressor, data: &mut vortex_compressor::stats::ArrayAndStats, compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::builtins::StringDictScheme::descendant_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::DescendantExclusion>
 
-pub fn vortex_compressor::builtins::StringDictScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_compressor::builtins::StringDictScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_compressor::builtins::StringDictScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -932,11 +932,9 @@ pub struct vortex_compressor::CascadingCompressor
 
 impl vortex_compressor::CascadingCompressor
 
-pub fn vortex_compressor::CascadingCompressor::compress(&self, array: &vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_compressor::CascadingCompressor::compress(&self, array: &vortex_array::array::erased::ArrayRef, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_compressor::CascadingCompressor::compress_child(&self, child: &vortex_array::array::erased::ArrayRef, parent_ctx: &vortex_compressor::ctx::CompressorContext, parent_id: vortex_compressor::scheme::SchemeId, child_index: usize) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
-
-pub fn vortex_compressor::CascadingCompressor::execution_ctx(&self) -> parking_lot::mutex::MutexGuard<'_, vortex_array::executor::ExecutionCtx>
+pub fn vortex_compressor::CascadingCompressor::compress_child(&self, child: &vortex_array::array::erased::ArrayRef, parent_ctx: &vortex_compressor::ctx::CompressorContext, parent_id: vortex_compressor::scheme::SchemeId, child_index: usize, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_compressor::CascadingCompressor::new(schemes: alloc::vec::Vec<&'static dyn vortex_compressor::scheme::Scheme>) -> Self
 

--- a/vortex-compressor/src/builtins/constant/bool.rs
+++ b/vortex-compressor/src/builtins/constant/bool.rs
@@ -5,8 +5,7 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
+use vortex_array::ExecutionCtx;
 use vortex_error::VortexResult;
 
 use crate::CascadingCompressor;
@@ -30,18 +29,17 @@ impl Scheme for BoolConstantScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         // Constant detection on a sample is a false positive, since the sample being constant does
         // not mean the full array is constant.
-        if ctx.is_sample() {
+        if compress_ctx.is_sample() {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
         let array_len = data.array().len();
-        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let stats = data.bool_stats(&mut ctx);
+        let stats = data.bool_stats(exec_ctx);
 
         // We want to use `Constant` if there are only nulls in the array.
         if stats.value_count() == 0 {
@@ -60,8 +58,9 @@ impl Scheme for BoolConstantScheme {
         &self,
         _compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        compress_constant_array_with_validity(data.array())
+        compress_constant_array_with_validity(data.array(), exec_ctx)
     }
 }

--- a/vortex-compressor/src/builtins/constant/float.rs
+++ b/vortex-compressor/src/builtins/constant/float.rs
@@ -5,8 +5,7 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
+use vortex_array::ExecutionCtx;
 use vortex_array::aggregate_fn::fns::is_constant::is_constant;
 use vortex_error::VortexResult;
 
@@ -33,19 +32,17 @@ impl Scheme for FloatConstantScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         // Constant detection on a sample is a false positive, since the sample being constant does
         // not mean the full array is constant.
-        if ctx.is_sample() {
+        if compress_ctx.is_sample() {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
         let array_len = data.array().len();
-        // TRAIT-IMPL BOUNDARY: `Scheme::expected_compression_ratio` has a fixed signature
-        // and does not receive an `ExecutionCtx`, so we fall back to the legacy session here.
-        let mut exec_ctx = LEGACY_SESSION.create_execution_ctx();
-        let stats = data.float_stats(&mut exec_ctx);
+        let stats = data.float_stats(exec_ctx);
 
         // Note that we only compute distinct counts if other schemes have requested it.
         if let Some(distinct_count) = stats.distinct_count() {
@@ -69,8 +66,8 @@ impl Scheme for FloatConstantScheme {
         // This is an expensive check, but in practice the distinct count is known because we often
         // include dictionary encoding in our set of schemes, so we rarely call this.
         CompressionEstimate::Deferred(DeferredEstimate::Callback(Box::new(
-            |compressor, data, _ctx| {
-                if is_constant(data.array(), &mut compressor.execution_ctx())? {
+            |_compressor, data, _ctx, exec_ctx| {
+                if is_constant(data.array(), exec_ctx)? {
                     Ok(EstimateVerdict::AlwaysUse)
                 } else {
                     Ok(EstimateVerdict::Skip)
@@ -83,8 +80,9 @@ impl Scheme for FloatConstantScheme {
         &self,
         _compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        compress_constant_array_with_validity(data.array())
+        compress_constant_array_with_validity(data.array(), exec_ctx)
     }
 }

--- a/vortex-compressor/src/builtins/constant/integer.rs
+++ b/vortex-compressor/src/builtins/constant/integer.rs
@@ -5,8 +5,7 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
+use vortex_array::ExecutionCtx;
 use vortex_error::VortexResult;
 
 use super::is_integer_primitive;
@@ -31,18 +30,17 @@ impl Scheme for IntConstantScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         // Constant detection on a sample is a false positive, since the sample being constant does
         // not mean the full array is constant.
-        if ctx.is_sample() {
+        if compress_ctx.is_sample() {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
         let array_len = data.array().len();
-        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let stats = data.integer_stats(&mut ctx);
+        let stats = data.integer_stats(exec_ctx);
 
         // Note that we only compute distinct counts if other schemes have requested it.
         if let Some(distinct_count) = stats.distinct_count() {
@@ -72,8 +70,9 @@ impl Scheme for IntConstantScheme {
         &self,
         _compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        compress_constant_array_with_validity(data.array())
+        compress_constant_array_with_validity(data.array(), exec_ctx)
     }
 }

--- a/vortex-compressor/src/builtins/constant/mod.rs
+++ b/vortex-compressor/src/builtins/constant/mod.rs
@@ -4,9 +4,8 @@
 //! Constant encoding schemes for bool, float, integer, and string arrays.
 
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::MaskedArray;
 use vortex_array::scalar::Scalar;
@@ -44,22 +43,24 @@ mod string;
 /// Assumes that the source array has constant valid scalars.
 ///
 /// If the array has any nulls, returns a [`MaskedArray`] with a [`ConstantArray`] child.`
-fn compress_constant_array_with_validity(source: &ArrayRef) -> VortexResult<ArrayRef> {
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
-    if source.all_invalid(&mut ctx)? {
+fn compress_constant_array_with_validity(
+    source: &ArrayRef,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    if source.all_invalid(ctx)? {
         return Ok(
             ConstantArray::new(Scalar::null(source.dtype().clone()), source.len()).into_array(),
         );
     }
 
     let scalar_idx = (0..source.len())
-        .position(|idx| source.is_valid(idx, &mut ctx).unwrap_or(false))
+        .position(|idx| source.is_valid(idx, ctx).unwrap_or(false))
         .vortex_expect("We checked that there exists a scalar that is not invalid");
 
-    let scalar = source.execute_scalar(scalar_idx, &mut ctx)?;
+    let scalar = source.execute_scalar(scalar_idx, ctx)?;
     let const_arr = ConstantArray::new(scalar, source.len()).into_array();
 
-    if !source.all_valid(&mut ctx)? {
+    if !source.all_valid(ctx)? {
         Ok(MaskedArray::try_new(const_arr, source.validity()?)?.into_array())
     } else {
         Ok(const_arr)

--- a/vortex-compressor/src/builtins/constant/string.rs
+++ b/vortex-compressor/src/builtins/constant/string.rs
@@ -5,8 +5,7 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
+use vortex_array::ExecutionCtx;
 use vortex_array::aggregate_fn::fns::is_constant::is_constant;
 use vortex_error::VortexResult;
 
@@ -33,18 +32,17 @@ impl Scheme for StringConstantScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         // Constant detection on a sample is a false positive, since the sample being constant does
         // not mean the full array is constant.
-        if ctx.is_sample() {
+        if compress_ctx.is_sample() {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
         let array_len = data.array().len();
-        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
-        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
-        let stats = data.string_stats(&mut local_ctx);
+        let stats = data.string_stats(exec_ctx);
 
         // We want to use `Constant` if there are only nulls in the array.
         if stats.value_count() == 0 {
@@ -62,8 +60,8 @@ impl Scheme for StringConstantScheme {
         // This is an expensive check, but the alternative of not compressing a constant array is
         // far less preferable.
         CompressionEstimate::Deferred(DeferredEstimate::Callback(Box::new(
-            |compressor, data, _ctx| {
-                if is_constant(data.array(), &mut compressor.execution_ctx())? {
+            |_compressor, data, _ctx, exec_ctx| {
+                if is_constant(data.array(), exec_ctx)? {
                     Ok(EstimateVerdict::AlwaysUse)
                 } else {
                     Ok(EstimateVerdict::Skip)
@@ -76,8 +74,9 @@ impl Scheme for StringConstantScheme {
         &self,
         _compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        compress_constant_array_with_validity(data.array())
+        compress_constant_array_with_validity(data.array(), exec_ctx)
     }
 }

--- a/vortex-compressor/src/builtins/dict/float.rs
+++ b/vortex-compressor/src/builtins/dict/float.rs
@@ -9,9 +9,8 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
@@ -85,12 +84,10 @@ impl Scheme for FloatDictScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
-        // TRAIT-IMPL BOUNDARY: `Scheme::expected_compression_ratio` has a fixed signature
-        // and does not receive an `ExecutionCtx`, so we fall back to the legacy session here.
-        let mut exec_ctx = LEGACY_SESSION.create_execution_ctx();
-        let stats = data.float_stats(&mut exec_ctx);
+        let stats = data.float_stats(exec_ctx);
 
         if stats.value_count() == 0 {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
@@ -113,28 +110,28 @@ impl Scheme for FloatDictScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         // TODO(connor): Fight the borrow checker (needs interior mutability)!
-        let stats = {
-            let mut exec_ctx = compressor.execution_ctx();
-            data.float_stats(&mut exec_ctx).clone()
-        };
+        let stats = data.float_stats(exec_ctx).clone();
         let dict = dictionary_encode(data.array_as_primitive(), &stats)?;
 
         let has_all_values_referenced = dict.has_all_values_referenced();
 
         // Values = child 0.
-        let compressed_values = compressor.compress_child(dict.values(), &ctx, self.id(), 0)?;
+        let compressed_values =
+            compressor.compress_child(dict.values(), &compress_ctx, self.id(), 0, exec_ctx)?;
 
         // Codes = child 1.
         let narrowed_codes = dict
             .codes()
             .clone()
-            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+            .execute::<PrimitiveArray>(exec_ctx)?
             .narrow()?
             .into_array();
-        let compressed_codes = compressor.compress_child(&narrowed_codes, &ctx, self.id(), 1)?;
+        let compressed_codes =
+            compressor.compress_child(&narrowed_codes, &compress_ctx, self.id(), 1, exec_ctx)?;
 
         // SAFETY: compressing codes or values does not alter the invariants.
         unsafe {
@@ -250,15 +247,16 @@ impl_encode!(f64, u64);
 #[cfg(test)]
 mod tests {
     use vortex_array::IntoArray;
-    use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::dict::DictArraySlotsExt;
     use vortex_array::assert_arrays_eq;
+    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
 
     use super::dictionary_encode;
     use crate::stats::FloatStats;
@@ -266,7 +264,9 @@ mod tests {
 
     #[test]
     fn test_float_dict_encode() -> VortexResult<()> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = VortexSession::empty()
+            .with::<ArraySession>()
+            .create_execution_ctx();
         let values = buffer![1f32, 2f32, 2f32, 0f32, 1f32];
         let validity =
             Validity::Array(BoolArray::from_iter([true, true, true, false, true]).into_array());

--- a/vortex-compressor/src/builtins/dict/integer.rs
+++ b/vortex-compressor/src/builtins/dict/integer.rs
@@ -9,9 +9,8 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
@@ -59,12 +58,11 @@ impl Scheme for IntDictScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         let bit_width = data.array_as_primitive().ptype().bit_width();
-        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let stats = data.integer_stats(&mut ctx);
+        let stats = data.integer_stats(exec_ctx);
 
         if stats.value_count() == 0 {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
@@ -106,23 +104,26 @@ impl Scheme for IntDictScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         // TODO(connor): Fight the borrow checker (needs interior mutability)!
-        let stats = data.integer_stats(&mut compressor.execution_ctx()).clone();
+        let stats = data.integer_stats(exec_ctx).clone();
         let dict = dictionary_encode(data.array_as_primitive(), &stats)?;
 
         // Values = child 0.
-        let compressed_values = compressor.compress_child(dict.values(), &ctx, self.id(), 0)?;
+        let compressed_values =
+            compressor.compress_child(dict.values(), &compress_ctx, self.id(), 0, exec_ctx)?;
 
         // Codes = child 1.
         let narrowed_codes = dict
             .codes()
             .clone()
-            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+            .execute::<PrimitiveArray>(exec_ctx)?
             .narrow()?
             .into_array();
-        let compressed_codes = compressor.compress_child(&narrowed_codes, &ctx, self.id(), 1)?;
+        let compressed_codes =
+            compressor.compress_child(&narrowed_codes, &compress_ctx, self.id(), 1, exec_ctx)?;
 
         // SAFETY: compressing codes does not change their values.
         unsafe {
@@ -253,22 +254,25 @@ impl_encode!(i64);
 #[cfg(test)]
 mod tests {
     use vortex_array::IntoArray;
-    use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::dict::DictArraySlotsExt;
     use vortex_array::assert_arrays_eq;
+    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
 
     use super::dictionary_encode;
     use crate::stats::IntegerStats;
 
     #[test]
     fn test_dict_encode_integer_stats() -> VortexResult<()> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = VortexSession::empty()
+            .with::<ArraySession>()
+            .create_execution_ctx();
         let data = buffer![100i32, 200, 100, 0, 100];
         let validity =
             Validity::Array(BoolArray::from_iter([true, true, true, false, true]).into_array());

--- a/vortex-compressor/src/builtins/dict/string.rs
+++ b/vortex-compressor/src/builtins/dict/string.rs
@@ -8,9 +8,8 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::dict::DictArrayExt;
@@ -70,11 +69,10 @@ impl Scheme for StringDictScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
-        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
-        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
-        let stats = data.string_stats(&mut local_ctx);
+        let stats = data.string_stats(exec_ctx);
 
         if stats.value_count() == 0 {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
@@ -97,21 +95,24 @@ impl Scheme for StringDictScheme {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         let dict = dict_encode(data.array())?;
 
         // Values = child 0.
-        let compressed_values = compressor.compress_child(dict.values(), &ctx, self.id(), 0)?;
+        let compressed_values =
+            compressor.compress_child(dict.values(), &compress_ctx, self.id(), 0, exec_ctx)?;
 
         // Codes = child 1.
         let narrowed_codes = dict
             .codes()
             .clone()
-            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+            .execute::<PrimitiveArray>(exec_ctx)?
             .narrow()?
             .into_array();
-        let compressed_codes = compressor.compress_child(&narrowed_codes, &ctx, self.id(), 1)?;
+        let compressed_codes =
+            compressor.compress_child(&narrowed_codes, &compress_ctx, self.id(), 1, exec_ctx)?;
 
         // SAFETY: compressing codes or values does not alter the invariants.
         unsafe {

--- a/vortex-compressor/src/compressor.rs
+++ b/vortex-compressor/src/compressor.rs
@@ -3,17 +3,11 @@
 
 //! Cascading array compression implementation.
 
-use std::sync::Arc;
-
-use parking_lot::Mutex;
-use parking_lot::MutexGuard;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::CanonicalValidity;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::FixedSizeListArray;
@@ -88,11 +82,6 @@ pub struct CascadingCompressor {
     /// Descendant exclusion rules for the compressor's own cascading (e.g. excluding Dict from
     /// list offsets).
     root_exclusions: Vec<DescendantExclusion>,
-
-    /// Shared execution context for array operations during compression.
-    ///
-    /// This should have low contention as we only execute arrays one at a time during compression.
-    ctx: Arc<Mutex<ExecutionCtx>>,
 }
 
 impl CascadingCompressor {
@@ -110,14 +99,7 @@ impl CascadingCompressor {
         Self {
             schemes,
             root_exclusions,
-            // TODO(connor): The caller should probably pass this in.
-            ctx: Arc::new(Mutex::new(LEGACY_SESSION.create_execution_ctx())),
         }
-    }
-
-    /// Returns a mutable borrow of the execution context.
-    pub fn execution_ctx(&self) -> MutexGuard<'_, ExecutionCtx> {
-        self.ctx.lock()
     }
 
     /// Compresses an array using cascading adaptive compression.
@@ -127,17 +109,18 @@ impl CascadingCompressor {
     /// # Errors
     ///
     /// Returns an error if canonicalization or compression fails.
-    pub fn compress(&self, array: &ArrayRef) -> VortexResult<ArrayRef> {
+    pub fn compress(
+        &self,
+        array: &ArrayRef,
+        exec_ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
         let before_nbytes = array.nbytes();
         let span = trace::compress_span(array.len(), array.dtype(), before_nbytes);
         let _enter = span.enter();
 
-        let canonical = array
-            .clone()
-            .execute::<CanonicalValidity>(&mut self.execution_ctx())?
-            .0;
+        let canonical = array.clone().execute::<CanonicalValidity>(exec_ctx)?.0;
         let compact = canonical.compact()?;
-        let compressed = self.compress_canonical(compact, CompressorContext::new())?;
+        let compressed = self.compress_canonical(compact, CompressorContext::new(), exec_ctx)?;
 
         trace::record_compress_outcome(&span, before_nbytes, compressed.nbytes());
 
@@ -159,22 +142,20 @@ impl CascadingCompressor {
         parent_ctx: &CompressorContext,
         parent_id: SchemeId,
         child_index: usize,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         if parent_ctx.finished_cascading() {
             trace::cascade_exhausted(parent_id, child_index);
             return Ok(child.clone());
         }
 
-        let canonical = child
-            .clone()
-            .execute::<CanonicalValidity>(&mut self.execution_ctx())?
-            .0;
+        let canonical = child.clone().execute::<CanonicalValidity>(exec_ctx)?.0;
         let compact = canonical.compact()?;
 
         let child_ctx = parent_ctx
             .clone()
             .descend_with_scheme(parent_id, child_index);
-        self.compress_canonical(compact, child_ctx)
+        self.compress_canonical(compact, child_ctx, exec_ctx)
     }
 
     /// Compresses a canonical array by dispatching to type-specific logic.
@@ -185,23 +166,24 @@ impl CascadingCompressor {
     fn compress_canonical(
         &self,
         array: Canonical,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         match array {
             Canonical::Null(null_array) => Ok(null_array.into_array()),
             Canonical::Bool(bool_array) => {
-                self.choose_and_compress(Canonical::Bool(bool_array), ctx)
+                self.choose_and_compress(Canonical::Bool(bool_array), compress_ctx, exec_ctx)
             }
             Canonical::Primitive(primitive) => {
-                self.choose_and_compress(Canonical::Primitive(primitive), ctx)
+                self.choose_and_compress(Canonical::Primitive(primitive), compress_ctx, exec_ctx)
             }
             Canonical::Decimal(decimal) => {
-                self.choose_and_compress(Canonical::Decimal(decimal), ctx)
+                self.choose_and_compress(Canonical::Decimal(decimal), compress_ctx, exec_ctx)
             }
             Canonical::Struct(struct_array) => {
                 let fields = struct_array
                     .iter_unmasked_fields()
-                    .map(|field| self.compress(field))
+                    .map(|field| self.compress(field, exec_ctx))
                     .collect::<Result<Vec<_>, _>>()?;
 
                 Ok(StructArray::try_new(
@@ -215,13 +197,13 @@ impl CascadingCompressor {
             Canonical::List(list_view_array) => {
                 if list_view_array.is_zero_copy_to_list() || list_view_array.elements().is_empty() {
                     let list_array = list_from_list_view(list_view_array)?;
-                    self.compress_list_array(list_array, ctx)
+                    self.compress_list_array(list_array, compress_ctx, exec_ctx)
                 } else {
-                    self.compress_list_view_array(list_view_array, ctx)
+                    self.compress_list_view_array(list_view_array, compress_ctx, exec_ctx)
                 }
             }
             Canonical::FixedSizeList(fsl_array) => {
-                let compressed_elems = self.compress(fsl_array.elements())?;
+                let compressed_elems = self.compress(fsl_array.elements(), exec_ctx)?;
 
                 Ok(FixedSizeListArray::try_new(
                     compressed_elems,
@@ -236,7 +218,7 @@ impl CascadingCompressor {
                     .dtype()
                     .eq_ignore_nullability(&DType::Utf8(Nullability::NonNullable))
                 {
-                    self.choose_and_compress(Canonical::VarBinView(strings), ctx)
+                    self.choose_and_compress(Canonical::VarBinView(strings), compress_ctx, exec_ctx)
                 } else {
                     // We do not compress binary arrays.
                     Ok(strings.into_array())
@@ -246,8 +228,11 @@ impl CascadingCompressor {
                 let before_nbytes = ext_array.as_ref().nbytes();
 
                 // Try scheme-based compression first.
-                let result =
-                    self.choose_and_compress(Canonical::Extension(ext_array.clone()), ctx)?;
+                let result = self.choose_and_compress(
+                    Canonical::Extension(ext_array.clone()),
+                    compress_ctx,
+                    exec_ctx,
+                )?;
                 if result.nbytes() < before_nbytes {
                     return Ok(result);
                 }
@@ -258,7 +243,7 @@ impl CascadingCompressor {
                 }
 
                 // Otherwise, fall back to compressing the underlying storage array.
-                let compressed_storage = self.compress(ext_array.storage_array())?;
+                let compressed_storage = self.compress(ext_array.storage_array(), exec_ctx)?;
 
                 Ok(
                     ExtensionArray::new(ext_array.ext_dtype().clone(), compressed_storage)
@@ -287,13 +272,14 @@ impl CascadingCompressor {
     fn choose_and_compress(
         &self,
         canonical: Canonical,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         let eligible_schemes: Vec<&'static dyn Scheme> = self
             .schemes
             .iter()
             .copied()
-            .filter(|s| s.matches(&canonical) && !self.is_excluded(*s, &ctx))
+            .filter(|s| s.matches(&canonical) && !self.is_excluded(*s, &compress_ctx))
             .collect();
 
         let array: ArrayRef = canonical.into();
@@ -302,7 +288,7 @@ impl CascadingCompressor {
             return Ok(array);
         }
 
-        if array.all_invalid(&mut self.execution_ctx())? {
+        if array.all_invalid(exec_ctx)? {
             return Ok(
                 ConstantArray::new(Scalar::null(array.dtype().clone()), array.len()).into_array(),
             );
@@ -315,20 +301,20 @@ impl CascadingCompressor {
             .fold(GenerateStatsOptions::default(), |acc, s| {
                 acc.merge(s.stats_options())
             });
-        let ctx = ctx.with_merged_stats_options(merged_opts);
+        let compress_ctx = compress_ctx.with_merged_stats_options(merged_opts);
 
         let mut data = ArrayAndStats::new(array, merged_opts);
 
         let Some((winner, winner_estimate)) =
-            self.choose_best_scheme(&eligible_schemes, &mut data, ctx.clone())?
+            self.choose_best_scheme(&eligible_schemes, &mut data, compress_ctx.clone(), exec_ctx)?
         else {
             return Ok(data.into_array());
         };
 
         // Run the winning scheme's `compress`. On failure, emit an ERROR event carrying the
         // scheme name and cascade history before propagating.
-        let error_ctx = trace::enabled_error_context(&ctx);
-        let compressed = match winner.compress(self, &mut data, ctx) {
+        let error_ctx = trace::enabled_error_context(&compress_ctx);
+        let compressed = match winner.compress(self, &mut data, compress_ctx, exec_ctx) {
             Ok(compressed) => compressed,
             Err(err) => {
                 // NB: this is the only way we can tell which scheme panicked / bailed on their
@@ -370,31 +356,34 @@ impl CascadingCompressor {
         &self,
         schemes: &[&'static dyn Scheme],
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<(&'static dyn Scheme, WinnerEstimate)>> {
         let mut best: Option<(&'static dyn Scheme, EstimateScore)> = None;
 
         // TODO(connor): Rather than computing the deferred estimates eagerly, it would be better to
         // look at all quick estimates and see if it makes sense to sample at all.
         for &scheme in schemes {
-            let verdict = match scheme.expected_compression_ratio(data, ctx.clone()) {
-                CompressionEstimate::Verdict(verdict) => verdict,
-                CompressionEstimate::Deferred(DeferredEstimate::Sample) => {
-                    let score = estimate_compression_ratio_with_sampling(
-                        scheme,
-                        self,
-                        data.array(),
-                        ctx.clone(),
-                    )?;
-                    if is_better_score(score, &best) {
-                        best = Some((scheme, score));
+            let verdict =
+                match scheme.expected_compression_ratio(data, compress_ctx.clone(), exec_ctx) {
+                    CompressionEstimate::Verdict(verdict) => verdict,
+                    CompressionEstimate::Deferred(DeferredEstimate::Sample) => {
+                        let score = estimate_compression_ratio_with_sampling(
+                            scheme,
+                            self,
+                            data.array(),
+                            compress_ctx.clone(),
+                            exec_ctx,
+                        )?;
+                        if is_better_score(score, &best) {
+                            best = Some((scheme, score));
+                        }
+                        continue;
                     }
-                    continue;
-                }
-                CompressionEstimate::Deferred(DeferredEstimate::Callback(callback)) => {
-                    callback(self, data, ctx.clone())?
-                }
-            };
+                    CompressionEstimate::Deferred(DeferredEstimate::Callback(callback)) => {
+                        callback(self, data, compress_ctx.clone(), exec_ctx)?
+                    }
+                };
 
             match verdict {
                 EstimateVerdict::Skip => {}
@@ -465,21 +454,26 @@ impl CascadingCompressor {
     fn compress_list_array(
         &self,
         list_array: ListArray,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         let list_array = list_array.reset_offsets(true)?;
 
-        let compressed_elems = self.compress(list_array.elements())?;
+        let compressed_elems = self.compress(list_array.elements(), exec_ctx)?;
 
         // Record the root scheme with the offsets child index so root exclusion rules apply.
-        let offset_ctx = ctx.descend_with_scheme(ROOT_SCHEME_ID, root_list_children::OFFSETS);
+        let offset_ctx =
+            compress_ctx.descend_with_scheme(ROOT_SCHEME_ID, root_list_children::OFFSETS);
         let list_offsets_primitive = list_array
             .offsets()
             .clone()
-            .execute::<PrimitiveArray>(&mut self.execution_ctx())?
+            .execute::<PrimitiveArray>(exec_ctx)?
             .narrow()?;
-        let compressed_offsets =
-            self.compress_canonical(Canonical::Primitive(list_offsets_primitive), offset_ctx)?;
+        let compressed_offsets = self.compress_canonical(
+            Canonical::Primitive(list_offsets_primitive),
+            offset_ctx,
+            exec_ctx,
+        )?;
 
         Ok(
             ListArray::try_new(compressed_elems, compressed_offsets, list_array.validity()?)?
@@ -492,31 +486,36 @@ impl CascadingCompressor {
     fn compress_list_view_array(
         &self,
         list_view: ListViewArray,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let compressed_elems = self.compress(list_view.elements())?;
+        let compressed_elems = self.compress(list_view.elements(), exec_ctx)?;
 
-        let offset_ctx = ctx
+        let offset_ctx = compress_ctx
             .clone()
             .descend_with_scheme(ROOT_SCHEME_ID, root_list_children::OFFSETS);
         let list_view_offsets_primitive = list_view
             .offsets()
             .clone()
-            .execute::<PrimitiveArray>(&mut self.execution_ctx())?
+            .execute::<PrimitiveArray>(exec_ctx)?
             .narrow()?;
         let compressed_offsets = self.compress_canonical(
             Canonical::Primitive(list_view_offsets_primitive),
             offset_ctx,
+            exec_ctx,
         )?;
 
-        let sizes_ctx = ctx.descend_with_scheme(ROOT_SCHEME_ID, root_list_children::SIZES);
+        let sizes_ctx = compress_ctx.descend_with_scheme(ROOT_SCHEME_ID, root_list_children::SIZES);
         let list_view_sizes_primitive = list_view
             .sizes()
             .clone()
-            .execute::<PrimitiveArray>(&mut self.execution_ctx())?
+            .execute::<PrimitiveArray>(exec_ctx)?
             .narrow()?;
-        let compressed_sizes =
-            self.compress_canonical(Canonical::Primitive(list_view_sizes_primitive), sizes_ctx)?;
+        let compressed_sizes = self.compress_canonical(
+            Canonical::Primitive(list_view_sizes_primitive),
+            sizes_ctx,
+            exec_ctx,
+        )?;
 
         Ok(ListViewArray::try_new(
             compressed_elems,
@@ -532,7 +531,9 @@ impl CascadingCompressor {
 mod tests {
     use std::collections::BTreeMap;
     use std::sync::Arc;
+    use std::sync::LazyLock;
 
+    use parking_lot::Mutex;
     use tracing::Event;
     use tracing::Subscriber;
     use tracing::field::Field;
@@ -542,12 +543,15 @@ mod tests {
     use tracing_subscriber::prelude::*;
     use vortex_array::ArrayRef;
     use vortex_array::Canonical;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::Constant;
     use vortex_array::arrays::NullArray;
     use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
+    use vortex_session::VortexSession;
 
     use super::*;
     use crate::builtins::FloatDictScheme;
@@ -561,6 +565,9 @@ mod tests {
     use crate::estimate::WinnerEstimate;
     use crate::scheme::SchemeExt;
     use crate::trace::TARGET_TRACE;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     fn compressor() -> CascadingCompressor {
         CascadingCompressor::new(vec![&IntDictScheme, &FloatDictScheme, &StringDictScheme])
@@ -682,7 +689,8 @@ mod tests {
         fn expected_compression_ratio(
             &self,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> CompressionEstimate {
             CompressionEstimate::Verdict(EstimateVerdict::Ratio(2.0))
         }
@@ -691,7 +699,8 @@ mod tests {
             &self,
             _compressor: &CascadingCompressor,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> VortexResult<ArrayRef> {
             unreachable!("test helper should never be selected for compression")
         }
@@ -712,7 +721,8 @@ mod tests {
         fn expected_compression_ratio(
             &self,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> CompressionEstimate {
             CompressionEstimate::Verdict(EstimateVerdict::AlwaysUse)
         }
@@ -721,7 +731,8 @@ mod tests {
             &self,
             _compressor: &CascadingCompressor,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> VortexResult<ArrayRef> {
             unreachable!("test helper should never be selected for compression")
         }
@@ -742,10 +753,11 @@ mod tests {
         fn expected_compression_ratio(
             &self,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> CompressionEstimate {
             CompressionEstimate::Deferred(DeferredEstimate::Callback(Box::new(
-                |_compressor, _data, _ctx| Ok(EstimateVerdict::AlwaysUse),
+                |_compressor, _data, _ctx, _exec_ctx| Ok(EstimateVerdict::AlwaysUse),
             )))
         }
 
@@ -753,7 +765,8 @@ mod tests {
             &self,
             _compressor: &CascadingCompressor,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> VortexResult<ArrayRef> {
             unreachable!("test helper should never be selected for compression")
         }
@@ -774,10 +787,11 @@ mod tests {
         fn expected_compression_ratio(
             &self,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> CompressionEstimate {
             CompressionEstimate::Deferred(DeferredEstimate::Callback(Box::new(
-                |_compressor, _data, _ctx| Ok(EstimateVerdict::Skip),
+                |_compressor, _data, _ctx, _exec_ctx| Ok(EstimateVerdict::Skip),
             )))
         }
 
@@ -785,7 +799,8 @@ mod tests {
             &self,
             _compressor: &CascadingCompressor,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> VortexResult<ArrayRef> {
             unreachable!("test helper should never be selected for compression")
         }
@@ -806,10 +821,11 @@ mod tests {
         fn expected_compression_ratio(
             &self,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> CompressionEstimate {
             CompressionEstimate::Deferred(DeferredEstimate::Callback(Box::new(
-                |_compressor, _data, _ctx| Ok(EstimateVerdict::Ratio(3.0)),
+                |_compressor, _data, _ctx, _exec_ctx| Ok(EstimateVerdict::Ratio(3.0)),
             )))
         }
 
@@ -817,7 +833,8 @@ mod tests {
             &self,
             _compressor: &CascadingCompressor,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> VortexResult<ArrayRef> {
             unreachable!("test helper should never be selected for compression")
         }
@@ -838,7 +855,8 @@ mod tests {
         fn expected_compression_ratio(
             &self,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> CompressionEstimate {
             CompressionEstimate::Verdict(EstimateVerdict::Ratio(100.0))
         }
@@ -847,7 +865,8 @@ mod tests {
             &self,
             _compressor: &CascadingCompressor,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> VortexResult<ArrayRef> {
             unreachable!("test helper should never be selected for compression")
         }
@@ -868,7 +887,8 @@ mod tests {
         fn expected_compression_ratio(
             &self,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> CompressionEstimate {
             CompressionEstimate::Deferred(DeferredEstimate::Sample)
         }
@@ -877,7 +897,8 @@ mod tests {
             &self,
             _compressor: &CascadingCompressor,
             data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> VortexResult<ArrayRef> {
             Ok(NullArray::new(data.array().len()).into_array())
         }
@@ -898,7 +919,8 @@ mod tests {
         fn expected_compression_ratio(
             &self,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> CompressionEstimate {
             CompressionEstimate::Verdict(EstimateVerdict::AlwaysUse)
         }
@@ -907,9 +929,10 @@ mod tests {
             &self,
             compressor: &CascadingCompressor,
             data: &mut ArrayAndStats,
-            ctx: CompressorContext,
+            compress_ctx: CompressorContext,
+            exec_ctx: &mut ExecutionCtx,
         ) -> VortexResult<ArrayRef> {
-            compressor.compress_child(data.array(), &ctx, self.id(), 1)
+            compressor.compress_child(data.array(), &compress_ctx, self.id(), 1, exec_ctx)
         }
     }
 
@@ -928,7 +951,8 @@ mod tests {
         fn expected_compression_ratio(
             &self,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> CompressionEstimate {
             CompressionEstimate::Verdict(EstimateVerdict::AlwaysUse)
         }
@@ -937,7 +961,8 @@ mod tests {
             &self,
             _compressor: &CascadingCompressor,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> VortexResult<ArrayRef> {
             vortex_error::vortex_bail!("nested failure")
         }
@@ -958,7 +983,8 @@ mod tests {
         fn expected_compression_ratio(
             &self,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> CompressionEstimate {
             CompressionEstimate::Deferred(DeferredEstimate::Sample)
         }
@@ -967,7 +993,8 @@ mod tests {
             &self,
             _compressor: &CascadingCompressor,
             _data: &mut ArrayAndStats,
-            _ctx: CompressorContext,
+            _compress_ctx: CompressorContext,
+            _exec_ctx: &mut ExecutionCtx,
         ) -> VortexResult<ArrayRef> {
             vortex_error::vortex_bail!("sample failure")
         }
@@ -1028,9 +1055,14 @@ mod tests {
             CascadingCompressor::new(vec![&DirectRatioScheme, &ImmediateAlwaysUseScheme]);
         let schemes: [&'static dyn Scheme; 2] = [&DirectRatioScheme, &ImmediateAlwaysUseScheme];
         let mut data = estimate_test_data();
+        let mut exec_ctx = SESSION.create_execution_ctx();
 
-        let winner =
-            compressor.choose_best_scheme(&schemes, &mut data, CompressorContext::new())?;
+        let winner = compressor.choose_best_scheme(
+            &schemes,
+            &mut data,
+            CompressorContext::new(),
+            &mut exec_ctx,
+        )?;
 
         assert!(matches!(
             winner,
@@ -1046,9 +1078,14 @@ mod tests {
             CascadingCompressor::new(vec![&DirectRatioScheme, &CallbackAlwaysUseScheme]);
         let schemes: [&'static dyn Scheme; 2] = [&DirectRatioScheme, &CallbackAlwaysUseScheme];
         let mut data = estimate_test_data();
+        let mut exec_ctx = SESSION.create_execution_ctx();
 
-        let winner =
-            compressor.choose_best_scheme(&schemes, &mut data, CompressorContext::new())?;
+        let winner = compressor.choose_best_scheme(
+            &schemes,
+            &mut data,
+            CompressorContext::new(),
+            &mut exec_ctx,
+        )?;
 
         assert!(matches!(
             winner,
@@ -1063,9 +1100,14 @@ mod tests {
         let compressor = CascadingCompressor::new(vec![&CallbackSkipScheme, &DirectRatioScheme]);
         let schemes: [&'static dyn Scheme; 2] = [&CallbackSkipScheme, &DirectRatioScheme];
         let mut data = estimate_test_data();
+        let mut exec_ctx = SESSION.create_execution_ctx();
 
-        let winner =
-            compressor.choose_best_scheme(&schemes, &mut data, CompressorContext::new())?;
+        let winner = compressor.choose_best_scheme(
+            &schemes,
+            &mut data,
+            CompressorContext::new(),
+            &mut exec_ctx,
+        )?;
 
         assert!(matches!(
             winner,
@@ -1080,9 +1122,14 @@ mod tests {
         let compressor = CascadingCompressor::new(vec![&DirectRatioScheme, &CallbackRatioScheme]);
         let schemes: [&'static dyn Scheme; 2] = [&DirectRatioScheme, &CallbackRatioScheme];
         let mut data = estimate_test_data();
+        let mut exec_ctx = SESSION.create_execution_ctx();
 
-        let winner =
-            compressor.choose_best_scheme(&schemes, &mut data, CompressorContext::new())?;
+        let winner = compressor.choose_best_scheme(
+            &schemes,
+            &mut data,
+            CompressorContext::new(),
+            &mut exec_ctx,
+        )?;
 
         assert!(matches!(
             winner,
@@ -1097,9 +1144,14 @@ mod tests {
         let compressor = CascadingCompressor::new(vec![&HugeRatioScheme, &ZeroBytesSamplingScheme]);
         let schemes: [&'static dyn Scheme; 2] = [&HugeRatioScheme, &ZeroBytesSamplingScheme];
         let mut data = estimate_test_data();
+        let mut exec_ctx = SESSION.create_execution_ctx();
 
-        let winner =
-            compressor.choose_best_scheme(&schemes, &mut data, CompressorContext::new())?;
+        let winner = compressor.choose_best_scheme(
+            &schemes,
+            &mut data,
+            CompressorContext::new(),
+            &mut exec_ctx,
+        )?;
 
         assert!(matches!(
             winner,
@@ -1114,9 +1166,14 @@ mod tests {
         let compressor = CascadingCompressor::new(vec![&ZeroBytesSamplingScheme, &HugeRatioScheme]);
         let schemes: [&'static dyn Scheme; 2] = [&ZeroBytesSamplingScheme, &HugeRatioScheme];
         let mut data = estimate_test_data();
+        let mut exec_ctx = SESSION.create_execution_ctx();
 
-        let winner =
-            compressor.choose_best_scheme(&schemes, &mut data, CompressorContext::new())?;
+        let winner = compressor.choose_best_scheme(
+            &schemes,
+            &mut data,
+            CompressorContext::new(),
+            &mut exec_ctx,
+        )?;
 
         assert!(matches!(
             winner,
@@ -1131,9 +1188,14 @@ mod tests {
         let compressor = CascadingCompressor::new(vec![&ZeroBytesSamplingScheme]);
         let schemes: [&'static dyn Scheme; 1] = [&ZeroBytesSamplingScheme];
         let mut data = estimate_test_data();
+        let mut exec_ctx = SESSION.create_execution_ctx();
 
-        let winner =
-            compressor.choose_best_scheme(&schemes, &mut data, CompressorContext::new())?;
+        let winner = compressor.choose_best_scheme(
+            &schemes,
+            &mut data,
+            CompressorContext::new(),
+            &mut exec_ctx,
+        )?;
 
         assert!(winner.is_none());
         Ok(())
@@ -1150,7 +1212,8 @@ mod tests {
         // The compressor should produce a `ConstantArray` for an all-null array regardless of
         // which schemes are registered.
         let compressor = CascadingCompressor::new(vec![&IntDictScheme]);
-        let compressed = compressor.compress(&array)?;
+        let mut exec_ctx = SESSION.create_execution_ctx();
+        let compressed = compressor.compress(&array, &mut exec_ctx)?;
         assert!(compressed.is::<Constant>());
         Ok(())
     }
@@ -1179,8 +1242,14 @@ mod tests {
 
         // Before the fix this panicked with:
         //   "this must be present since `DictScheme` declared that we need distinct values"
-        let score =
-            estimate_compression_ratio_with_sampling(&FloatDictScheme, &compressor, &array, ctx)?;
+        let mut exec_ctx = SESSION.create_execution_ctx();
+        let score = estimate_compression_ratio_with_sampling(
+            &FloatDictScheme,
+            &compressor,
+            &array,
+            ctx,
+            &mut exec_ctx,
+        )?;
         assert!(matches!(score, EstimateScore::FiniteCompression(ratio) if ratio.is_finite()));
         Ok(())
     }
@@ -1191,7 +1260,10 @@ mod tests {
             CascadingCompressor::new(vec![&NestedFailureParentScheme, &NestedFailureLeafScheme]);
         let array = test_integer_array();
 
-        let (result, events) = record_events(|| compressor.compress(&array));
+        let (result, events) = record_events(|| {
+            let mut exec_ctx = SESSION.create_execution_ctx();
+            compressor.compress(&array, &mut exec_ctx)
+        });
 
         assert!(result.is_err());
         let event = find_event(&events, TARGET_TRACE, "scheme.compress_failed");
@@ -1214,7 +1286,10 @@ mod tests {
         let compressor = CascadingCompressor::new(vec![&SamplingFailureScheme]);
         let array = test_integer_array();
 
-        let (result, events) = record_events(|| compressor.compress(&array));
+        let (result, events) = record_events(|| {
+            let mut exec_ctx = SESSION.create_execution_ctx();
+            compressor.compress(&array, &mut exec_ctx)
+        });
 
         assert!(result.is_err());
         let event = find_event(&events, TARGET_TRACE, "sample.compress_failed");
@@ -1237,7 +1312,10 @@ mod tests {
         let compressor = CascadingCompressor::new(vec![&ZeroBytesSamplingScheme]);
         let array = test_integer_array();
 
-        let (result, events) = record_events(|| compressor.compress(&array));
+        let (result, events) = record_events(|| {
+            let mut exec_ctx = SESSION.create_execution_ctx();
+            compressor.compress(&array, &mut exec_ctx)
+        });
 
         assert!(result.is_ok());
 

--- a/vortex-compressor/src/estimate.rs
+++ b/vortex-compressor/src/estimate.rs
@@ -7,6 +7,7 @@ use std::fmt;
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_error::VortexResult;
 
@@ -29,6 +30,7 @@ pub type EstimateFn = dyn FnOnce(
         &CascadingCompressor,
         &mut ArrayAndStats,
         CompressorContext,
+        &mut ExecutionCtx,
     ) -> VortexResult<EstimateVerdict>
     + Send
     + Sync;
@@ -179,23 +181,23 @@ pub(super) fn estimate_compression_ratio_with_sampling<S: Scheme + ?Sized>(
     scheme: &S,
     compressor: &CascadingCompressor,
     array: &ArrayRef,
-    ctx: CompressorContext,
+    compress_ctx: CompressorContext,
+    exec_ctx: &mut ExecutionCtx,
 ) -> VortexResult<EstimateScore> {
-    let sample_array = if ctx.is_sample() {
+    let sample_array = if compress_ctx.is_sample() {
         array.clone()
     } else {
         let sample_count = sample_count_approx_one_percent(array.len());
         // `ArrayAndStats` expects a canonical array (so that it can easily compute lazy stats).
-        let canonical: Canonical =
-            sample(array, SAMPLE_SIZE, sample_count).execute(&mut compressor.execution_ctx())?;
+        let canonical: Canonical = sample(array, SAMPLE_SIZE, sample_count).execute(exec_ctx)?;
         canonical.into_array()
     };
 
     let mut sample_data = ArrayAndStats::new(sample_array, scheme.stats_options());
-    let error_ctx = trace::enabled_error_context(&ctx);
-    let sample_ctx = ctx.with_sampling();
+    let error_ctx = trace::enabled_error_context(&compress_ctx);
+    let sample_ctx = compress_ctx.with_sampling();
 
-    let compressed = match scheme.compress(compressor, &mut sample_data, sample_ctx) {
+    let compressed = match scheme.compress(compressor, &mut sample_data, sample_ctx, exec_ctx) {
         Ok(compressed) => compressed,
         Err(err) => {
             trace::sample_compress_failed(scheme.id(), error_ctx.as_ref(), &err);

--- a/vortex-compressor/src/scheme.rs
+++ b/vortex-compressor/src/scheme.rs
@@ -10,6 +10,7 @@ use std::hash::Hasher;
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_error::VortexResult;
 
 use crate::CascadingCompressor;
@@ -211,7 +212,8 @@ pub trait Scheme: Debug + Send + Sync {
     fn expected_compression_ratio(
         &self,
         _data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        _exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate;
 
     /// Compress the array using this scheme.
@@ -223,7 +225,8 @@ pub trait Scheme: Debug + Send + Sync {
         &self,
         compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        ctx: CompressorContext,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef>;
 }
 

--- a/vortex-layout/public-api.lock
+++ b/vortex-layout/public-api.lock
@@ -186,19 +186,19 @@ pub fn vortex_layout::layouts::compressed::CompressingStrategy::write_stream<'li
 
 pub trait vortex_layout::layouts::compressed::CompressorPlugin: core::marker::Send + core::marker::Sync + 'static
 
-pub fn vortex_layout::layouts::compressed::CompressorPlugin::compress_chunk(&self, chunk: &vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_layout::layouts::compressed::CompressorPlugin::compress_chunk(&self, chunk: &vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 impl vortex_layout::layouts::compressed::CompressorPlugin for alloc::sync::Arc<dyn vortex_layout::layouts::compressed::CompressorPlugin>
 
-pub fn alloc::sync::Arc<dyn vortex_layout::layouts::compressed::CompressorPlugin>::compress_chunk(&self, chunk: &vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn alloc::sync::Arc<dyn vortex_layout::layouts::compressed::CompressorPlugin>::compress_chunk(&self, chunk: &vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 impl vortex_layout::layouts::compressed::CompressorPlugin for vortex_btrblocks::canonical_compressor::BtrBlocksCompressor
 
-pub fn vortex_btrblocks::canonical_compressor::BtrBlocksCompressor::compress_chunk(&self, chunk: &vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::canonical_compressor::BtrBlocksCompressor::compress_chunk(&self, chunk: &vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-impl<F> vortex_layout::layouts::compressed::CompressorPlugin for F where F: core::ops::function::Fn(&vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef> + core::marker::Send + core::marker::Sync + 'static
+impl<F> vortex_layout::layouts::compressed::CompressorPlugin for F where F: core::ops::function::Fn(&vortex_array::array::erased::ArrayRef, &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef> + core::marker::Send + core::marker::Sync + 'static
 
-pub fn F::compress_chunk(&self, chunk: &vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn F::compress_chunk(&self, chunk: &vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub mod vortex_layout::layouts::dict
 

--- a/vortex-layout/src/layouts/compressed.rs
+++ b/vortex-layout/src/layouts/compressed.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use futures::StreamExt as _;
 use vortex_array::ArrayContext;
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::VortexSessionExecute;
 use vortex_array::expr::stats::Stat;
 use vortex_btrblocks::BtrBlocksCompressor;
@@ -26,27 +27,27 @@ use crate::sequence::SequentialStreamExt;
 ///
 /// API consumers are free to implement this trait to provide new plugin compressors.
 pub trait CompressorPlugin: Send + Sync + 'static {
-    fn compress_chunk(&self, chunk: &ArrayRef) -> VortexResult<ArrayRef>;
+    fn compress_chunk(&self, chunk: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef>;
 }
 
 impl CompressorPlugin for Arc<dyn CompressorPlugin> {
-    fn compress_chunk(&self, chunk: &ArrayRef) -> VortexResult<ArrayRef> {
-        self.as_ref().compress_chunk(chunk)
+    fn compress_chunk(&self, chunk: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+        self.as_ref().compress_chunk(chunk, ctx)
     }
 }
 
 impl<F> CompressorPlugin for F
 where
-    F: Fn(&ArrayRef) -> VortexResult<ArrayRef> + Send + Sync + 'static,
+    F: Fn(&ArrayRef, &mut ExecutionCtx) -> VortexResult<ArrayRef> + Send + Sync + 'static,
 {
-    fn compress_chunk(&self, chunk: &ArrayRef) -> VortexResult<ArrayRef> {
-        self(chunk)
+    fn compress_chunk(&self, chunk: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+        self(chunk, ctx)
     }
 }
 
 impl CompressorPlugin for BtrBlocksCompressor {
-    fn compress_chunk(&self, chunk: &ArrayRef) -> VortexResult<ArrayRef> {
-        self.compress(chunk)
+    fn compress_chunk(&self, chunk: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+        self.compress(chunk, ctx)
     }
 }
 
@@ -109,11 +110,10 @@ impl LayoutStrategy for CompressingStrategy {
                 let session = compute_session.clone();
                 handle.spawn_cpu(move || {
                     let (sequence_id, chunk) = chunk?;
+                    let mut ctx = session.create_execution_ctx();
                     // Compute the stats for the chunk prior to compression
-                    chunk
-                        .statistics()
-                        .compute_all(&stats, &mut session.create_execution_ctx())?;
-                    Ok((sequence_id, compressor.compress_chunk(&chunk)?))
+                    chunk.statistics().compute_all(&stats, &mut ctx)?;
+                    Ok((sequence_id, compressor.compress_chunk(&chunk, &mut ctx)?))
                 })
             })
             .buffered(self.concurrency);

--- a/vortex-layout/src/layouts/dict/writer.rs
+++ b/vortex-layout/src/layouts/dict/writer.rs
@@ -20,6 +20,7 @@ use futures::stream::once;
 use futures::try_join;
 use vortex_array::ArrayContext;
 use vortex_array::ArrayRef;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::Dict;
 use vortex_array::builders::dict::DictConstraints;
 use vortex_array::builders::dict::DictEncoder;
@@ -151,7 +152,8 @@ impl LayoutStrategy for DictStrategy {
         let should_fallback = match first_chunk {
             None => true, // empty stream
             Some(chunk) => {
-                let compressed = BtrBlocksCompressor::default().compress(&chunk)?;
+                let mut exec_ctx = session.create_execution_ctx();
+                let compressed = BtrBlocksCompressor::default().compress(&chunk, &mut exec_ctx)?;
                 !compressed.is::<Dict>()
             }
         };

--- a/vortex-python/src/compress.rs
+++ b/vortex-python/src/compress.rs
@@ -2,8 +2,10 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use pyo3::prelude::*;
+use vortex::array::VortexSessionExecute;
 use vortex::compressor::BtrBlocksCompressor;
 
+use crate::SESSION;
 use crate::arrays::PyArrayRef;
 use crate::error::PyVortexResult;
 use crate::install_module;
@@ -51,6 +53,7 @@ pub(crate) fn init(py: Python, parent: &Bound<PyModule>) -> PyResult<()> {
 ///    'vortex.alp(f64?, len=1000)'
 #[pyfunction]
 pub fn compress(array: PyArrayRef) -> PyVortexResult<PyArrayRef> {
-    let compressed = BtrBlocksCompressor::default().compress(array.inner())?;
+    let compressed = BtrBlocksCompressor::default()
+        .compress(array.inner(), &mut SESSION.create_execution_ctx())?;
     Ok(PyArrayRef::from(compressed))
 }

--- a/vortex-tensor/public-api.lock
+++ b/vortex-tensor/public-api.lock
@@ -12,9 +12,9 @@ pub fn vortex_tensor::encodings::l2_denorm::L2DenormScheme::fmt(&self, f: &mut c
 
 impl vortex_compressor::scheme::Scheme for vortex_tensor::encodings::l2_denorm::L2DenormScheme
 
-pub fn vortex_tensor::encodings::l2_denorm::L2DenormScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_tensor::encodings::l2_denorm::L2DenormScheme::compress(&self, _compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_tensor::encodings::l2_denorm::L2DenormScheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_tensor::encodings::l2_denorm::L2DenormScheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, _exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_tensor::encodings::l2_denorm::L2DenormScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 
@@ -64,9 +64,9 @@ impl core::marker::StructuralPartialEq for vortex_tensor::encodings::turboquant:
 
 impl vortex_compressor::scheme::Scheme for vortex_tensor::encodings::turboquant::TurboQuantScheme
 
-pub fn vortex_tensor::encodings::turboquant::TurboQuantScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_tensor::encodings::turboquant::TurboQuantScheme::compress(&self, _compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_tensor::encodings::turboquant::TurboQuantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
+pub fn vortex_tensor::encodings::turboquant::TurboQuantScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _compress_ctx: vortex_compressor::ctx::CompressorContext, _exec_ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_compressor::estimate::CompressionEstimate
 
 pub fn vortex_tensor::encodings::turboquant::TurboQuantScheme::matches(&self, canonical: &vortex_array::canonical::Canonical) -> bool
 

--- a/vortex-tensor/src/encodings/l2_denorm.rs
+++ b/vortex-tensor/src/encodings/l2_denorm.rs
@@ -3,6 +3,7 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_compressor::CascadingCompressor;
 use vortex_compressor::ctx::CompressorContext;
@@ -33,19 +34,20 @@ impl Scheme for L2DenormScheme {
     fn expected_compression_ratio(
         &self,
         _data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        _exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         CompressionEstimate::Verdict(EstimateVerdict::AlwaysUse)
     }
 
     fn compress(
         &self,
-        compressor: &CascadingCompressor,
+        _compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let l2_denorm =
-            normalize_as_l2_denorm(data.array().clone(), &mut compressor.execution_ctx())?;
+        let l2_denorm = normalize_as_l2_denorm(data.array().clone(), exec_ctx)?;
         Ok(l2_denorm.into_array())
     }
 }

--- a/vortex-tensor/src/encodings/turboquant/scheme.rs
+++ b/vortex-tensor/src/encodings/turboquant/scheme.rs
@@ -21,6 +21,7 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_compressor::CascadingCompressor;
 use vortex_compressor::ctx::CompressorContext;
 use vortex_compressor::estimate::CompressionEstimate;
@@ -71,7 +72,8 @@ impl Scheme for TurboQuantScheme {
     fn expected_compression_ratio(
         &self,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        _exec_ctx: &mut ExecutionCtx,
     ) -> CompressionEstimate {
         let len = data.array().len();
         let dtype = data.array().dtype();
@@ -94,12 +96,12 @@ impl Scheme for TurboQuantScheme {
 
     fn compress(
         &self,
-        compressor: &CascadingCompressor,
+        _compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
-        _ctx: CompressorContext,
+        _compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let mut ctx = compressor.execution_ctx();
-        turboquant_encode(data.array().clone(), &TurboQuantConfig::default(), &mut ctx)
+        turboquant_encode(data.array().clone(), &TurboQuantConfig::default(), exec_ctx)
     }
 }
 

--- a/vortex/examples/compression_showcase.rs
+++ b/vortex/examples/compression_showcase.rs
@@ -28,35 +28,37 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("This example demonstrates how Vortex automatically selects");
     println!("optimal compression strategies for different data patterns.\n");
 
+    let session = VortexSession::default();
+
     // 1. Compress sequential/monotonic data
     println!("1. Sequential Data Compression:");
-    compress_sequential_data()?;
+    compress_sequential_data(&session)?;
 
     // 2. Compress repetitive data
     println!("\n2. Repetitive Data Compression:");
-    compress_repetitive_data()?;
+    compress_repetitive_data(&session)?;
 
     // 3. Compress string data
     println!("\n3. String Data Compression:");
-    compress_string_data()?;
+    compress_string_data(&session)?;
 
     // 4. Compress floating-point data
     println!("\n4. Floating-Point Data Compression:");
-    compress_float_data()?;
+    compress_float_data(&session)?;
 
     // 5. Compress sparse data
     println!("\n5. Sparse Data Compression:");
-    compress_sparse_data()?;
+    compress_sparse_data(&session)?;
 
     // 6. Compress structured data
     println!("\n6. Structured Data Compression:");
-    compress_structured_data()?;
+    compress_structured_data(&session)?;
 
     println!("\n=== Compression showcase completed! ===");
     Ok(())
 }
 
-fn compress_sequential_data() -> Result<(), Box<dyn std::error::Error>> {
+fn compress_sequential_data(session: &VortexSession) -> Result<(), Box<dyn std::error::Error>> {
     // Create sequential data (e.g., timestamps, IDs)
     let sequential: PrimitiveArray = (1000..11000).map(|i| i as u64).collect();
 
@@ -66,7 +68,6 @@ fn compress_sequential_data() -> Result<(), Box<dyn std::error::Error>> {
 
     // Compress using default strategy
     let compressor = BtrBlocksCompressor::default();
-    let session = VortexSession::default();
     let compressed = compressor.compress(
         &sequential.into_array(),
         &mut session.create_execution_ctx(),
@@ -83,7 +84,7 @@ fn compress_sequential_data() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn compress_repetitive_data() -> Result<(), Box<dyn std::error::Error>> {
+fn compress_repetitive_data(session: &VortexSession) -> Result<(), Box<dyn std::error::Error>> {
     // Create highly repetitive data (run-length encoding opportunity)
     let mut repetitive = Vec::new();
     for i in 0..100 {
@@ -98,7 +99,6 @@ fn compress_repetitive_data() -> Result<(), Box<dyn std::error::Error>> {
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let session = VortexSession::default();
     let compressed =
         compressor.compress(&array.into_array(), &mut session.create_execution_ctx())?;
 
@@ -113,7 +113,7 @@ fn compress_repetitive_data() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn compress_string_data() -> Result<(), Box<dyn std::error::Error>> {
+fn compress_string_data(session: &VortexSession) -> Result<(), Box<dyn std::error::Error>> {
     // Create string data with patterns
     let categories = vec!["Electronics", "Clothing", "Food", "Books"];
     let mut strings = Vec::new();
@@ -132,7 +132,6 @@ fn compress_string_data() -> Result<(), Box<dyn std::error::Error>> {
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let session = VortexSession::default();
     let compressed =
         compressor.compress(&array.into_array(), &mut session.create_execution_ctx())?;
 
@@ -147,7 +146,7 @@ fn compress_string_data() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn compress_float_data() -> Result<(), Box<dyn std::error::Error>> {
+fn compress_float_data(session: &VortexSession) -> Result<(), Box<dyn std::error::Error>> {
     // Create floating-point data with patterns
     let floats: Buffer<f64> = (0..10000).map(|i| (i as f64) * 0.1 + 100.0).collect();
     let array = floats.into_array();
@@ -157,7 +156,6 @@ fn compress_float_data() -> Result<(), Box<dyn std::error::Error>> {
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let session = VortexSession::default();
     let compressed = compressor.compress(&array, &mut session.create_execution_ctx())?;
 
     let compressed_size = compressed.nbytes();
@@ -171,7 +169,7 @@ fn compress_float_data() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn compress_sparse_data() -> Result<(), Box<dyn std::error::Error>> {
+fn compress_sparse_data(session: &VortexSession) -> Result<(), Box<dyn std::error::Error>> {
     // Create sparse data (mostly zeros with few non-zero values)
     let mut sparse = vec![0i64; 10000];
     for i in (0..10000).step_by(100) {
@@ -184,7 +182,6 @@ fn compress_sparse_data() -> Result<(), Box<dyn std::error::Error>> {
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let session = VortexSession::default();
     let compressed =
         compressor.compress(&array.into_array(), &mut session.create_execution_ctx())?;
 
@@ -199,7 +196,7 @@ fn compress_sparse_data() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn compress_structured_data() -> Result<(), Box<dyn std::error::Error>> {
+fn compress_structured_data(session: &VortexSession) -> Result<(), Box<dyn std::error::Error>> {
     // Create a struct array with multiple columns
     let size = 5000;
 
@@ -236,7 +233,6 @@ fn compress_structured_data() -> Result<(), Box<dyn std::error::Error>> {
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let session = VortexSession::default();
     let compressed = compressor.compress(
         &struct_array.into_array(),
         &mut session.create_execution_ctx(),

--- a/vortex/examples/compression_showcase.rs
+++ b/vortex/examples/compression_showcase.rs
@@ -8,8 +8,10 @@
 //!
 //! Run with: cargo run --example compression_showcase
 
+use vortex::VortexSessionDefault;
 use vortex::array::ArrayRef;
 use vortex::array::IntoArray;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;
 use vortex::array::arrays::VarBinArray;
@@ -17,6 +19,7 @@ use vortex::array::validity::Validity;
 use vortex::compressor::BtrBlocksCompressor;
 use vortex::dtype::DType;
 use vortex::dtype::Nullability;
+use vortex::session::VortexSession;
 use vortex_buffer::Buffer;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -63,7 +66,11 @@ fn compress_sequential_data() -> Result<(), Box<dyn std::error::Error>> {
 
     // Compress using default strategy
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(&sequential.into_array())?;
+    let session = VortexSession::default();
+    let compressed = compressor.compress(
+        &sequential.into_array(),
+        &mut session.create_execution_ctx(),
+    )?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -91,7 +98,9 @@ fn compress_repetitive_data() -> Result<(), Box<dyn std::error::Error>> {
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(&array.into_array())?;
+    let session = VortexSession::default();
+    let compressed =
+        compressor.compress(&array.into_array(), &mut session.create_execution_ctx())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -123,7 +132,9 @@ fn compress_string_data() -> Result<(), Box<dyn std::error::Error>> {
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(&array.into_array())?;
+    let session = VortexSession::default();
+    let compressed =
+        compressor.compress(&array.into_array(), &mut session.create_execution_ctx())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -146,7 +157,8 @@ fn compress_float_data() -> Result<(), Box<dyn std::error::Error>> {
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(&array)?;
+    let session = VortexSession::default();
+    let compressed = compressor.compress(&array, &mut session.create_execution_ctx())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -172,7 +184,9 @@ fn compress_sparse_data() -> Result<(), Box<dyn std::error::Error>> {
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(&array.into_array())?;
+    let session = VortexSession::default();
+    let compressed =
+        compressor.compress(&array.into_array(), &mut session.create_execution_ctx())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -222,7 +236,11 @@ fn compress_structured_data() -> Result<(), Box<dyn std::error::Error>> {
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(&struct_array.into_array())?;
+    let session = VortexSession::default();
+    let compressed = compressor.compress(
+        &struct_array.into_array(),
+        &mut session.create_execution_ctx(),
+    )?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -246,7 +246,11 @@ mod test {
         let array = PrimitiveArray::new(buffer![42u64; 100_000], Validity::NonNullable);
 
         // You can compress an array in-memory with the BtrBlocks compressor
-        let compressed = BtrBlocksCompressor::default().compress(&array.clone().into_array())?;
+        let session = VortexSession::default();
+        let compressed = BtrBlocksCompressor::default().compress(
+            &array.clone().into_array(),
+            &mut session.create_execution_ctx(),
+        )?;
         println!(
             "BtrBlocks size: {} / {}",
             compressed.nbytes(),

--- a/wasm-test/src/main.rs
+++ b/wasm-test/src/main.rs
@@ -2,10 +2,13 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex::array::IntoArray;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::validity::Validity;
 use vortex::buffer::buffer;
 use vortex::compressor::BtrBlocksCompressor;
+use vortex::session::VortexSession;
+use vortex::VortexSessionDefault;
 
 //use wasm_bindgen::prelude::*;
 
@@ -13,7 +16,10 @@ pub fn main() {
     // Extremely simple test of compression/decompression and a few compute functions.
     let array = PrimitiveArray::new(buffer![1i32; 1024], Validity::AllValid).into_array();
 
-    let compressed = BtrBlocksCompressor::default().compress(&array).unwrap();
+    let session = VortexSession::default();
+    let compressed = BtrBlocksCompressor::default()
+        .compress(&array, &mut session.create_execution_ctx())
+        .unwrap();
     println!("Compressed size: {}", compressed.len());
     println!("Tree view: {}", compressed.display_tree());
 }


### PR DESCRIPTION
## Summary

Tracking issue: https://github.com/vortex-data/vortex/issues/7216

In order to have a "less breaking change" before, I just put an execution context in an arc'd mutex in the compressor itself. This is really stupid, and the caller should pass an execution context whenever they want to compress something (because we need to look at buffers to canonicalize and do compute in the compressor).

## Testing

N/A since this is just moving where things are coming from.