### PR TITLE
ci: always run all lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,15 +214,51 @@ jobs:
       - name: Install nightly for fmt
         run: rustup toolchain install $NIGHTLY_TOOLCHAIN --component rustfmt
       - name: Rust Lint - Format
+        id: fmt
+        continue-on-error: true
         run: cargo +$NIGHTLY_TOOLCHAIN fmt --all --check
       - name: Rustc check
+        id: check
+        continue-on-error: true
         run: RUSTFLAGS="-D warnings" cargo check --profile ci --locked --all-features --all-targets
       - name: Rustc check (release)
+        id: check-release
+        continue-on-error: true
         run: RUSTFLAGS="-D warnings" cargo check --locked --all-features --all-targets --release
       - name: Rust Lint - Clippy All Features
+        id: clippy-all
+        continue-on-error: true
         run: cargo clippy --profile ci --locked --all-features --all-targets -- -D warnings
       - name: Rust Lint - Clippy Default Features
+        id: clippy-default
+        continue-on-error: true
         run: cargo clippy --profile ci --locked --all-targets -- -D warnings
+      - name: Check lint results
+        if: always()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        with:
+          script: |
+            const failed = Object.entries({
+              fmt: '${{ steps.fmt.outcome }}',
+              check: '${{ steps.check.outcome }}',
+              'check-release': '${{ steps.check-release.outcome }}',
+              'clippy-all': '${{ steps.clippy-all.outcome }}',
+              'clippy-default': '${{ steps.clippy-default.outcome }}',
+            }).filter(([, o]) => o === 'failure').map(([n]) => n);
+            if (!failed.length) return;
+
+            const { data: { jobs } } = await github.rest.actions.listJobsForWorkflowRun({
+              ...context.repo, run_id: context.runId,
+            });
+            const url = jobs.find(j => j.name === context.job)?.check_run_url;
+            if (url) {
+              await github.rest.checks.update({
+                ...context.repo,
+                check_run_id: Number(url.split('/').pop()),
+                output: { title: `${failed.join(', ')} — failing`, summary: '' },
+              });
+            }
+            core.setFailed(`Lint failed: ${failed.join(', ')}`);
 
   cpp-lint:
     name: "C/C++ (lint)"


### PR DESCRIPTION
<img width="635" height="142" alt="Zen Browser 2026-04-21 13 20 20" src="https://github.com/user-attachments/assets/872e521d-aa11-444c-9af6-d8379f64a5f1" />

always run all checks and display their results right in the CI box