### PR TITLE
Skip nightly lance benchmark

### DIFF
--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -39,7 +39,6 @@ jobs:
             "develop_targets": [
               {"engine": "datafusion", "format": "parquet"},
               {"engine": "datafusion", "format": "vortex"},
-              {"engine": "datafusion", "format": "lance"},
               {"engine": "duckdb", "format": "parquet"},
               {"engine": "duckdb", "format": "vortex"}
             ],


### PR DESCRIPTION
It seems like I've added `lance` accidentally, and it break the nightly TPC-H run on NVMe. From looking at the data I  don't think we ever ran Lance in that configuration.