### PR TITLE
Bump msrv and rust-toolchain to 1.91 (and lance for benchmarks)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1881,6 +1881,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,39 +2104,39 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba7cb113e9c0bedf9e9765926031e132fa05a1b09ba6e93a6d1a4d7044457b8"
+checksum = "7541353e77dc7262b71ca27be07d8393661737e3a73b5d1b1c6f7d814c64fa2a"
 dependencies = [
  "arrow 57.3.0",
  "arrow-schema 57.3.0",
  "async-trait",
  "bytes",
  "chrono",
- "datafusion-catalog 51.0.0",
- "datafusion-catalog-listing 51.0.0",
- "datafusion-common 51.0.0",
- "datafusion-common-runtime 51.0.0",
- "datafusion-datasource 51.0.0",
- "datafusion-datasource-arrow 51.0.0",
- "datafusion-datasource-csv 51.0.0",
- "datafusion-datasource-json 51.0.0",
- "datafusion-execution 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-expr-common 51.0.0",
- "datafusion-functions 51.0.0",
- "datafusion-functions-aggregate 51.0.0",
- "datafusion-functions-nested 51.0.0",
- "datafusion-functions-table 51.0.0",
- "datafusion-functions-window 51.0.0",
- "datafusion-optimizer 51.0.0",
- "datafusion-physical-expr 51.0.0",
- "datafusion-physical-expr-adapter 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
- "datafusion-physical-optimizer 51.0.0",
- "datafusion-physical-plan 51.0.0",
- "datafusion-session 51.0.0",
- "datafusion-sql 51.0.0",
+ "datafusion-catalog 52.5.0",
+ "datafusion-catalog-listing 52.5.0",
+ "datafusion-common 52.5.0",
+ "datafusion-common-runtime 52.5.0",
+ "datafusion-datasource 52.5.0",
+ "datafusion-datasource-arrow 52.5.0",
+ "datafusion-datasource-csv 52.5.0",
+ "datafusion-datasource-json 52.5.0",
+ "datafusion-execution 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-expr-common 52.5.0",
+ "datafusion-functions 52.5.0",
+ "datafusion-functions-aggregate 52.5.0",
+ "datafusion-functions-nested 52.5.0",
+ "datafusion-functions-table 52.5.0",
+ "datafusion-functions-window 52.5.0",
+ "datafusion-optimizer 52.5.0",
+ "datafusion-physical-expr 52.5.0",
+ "datafusion-physical-expr-adapter 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
+ "datafusion-physical-optimizer 52.5.0",
+ "datafusion-physical-plan 52.5.0",
+ "datafusion-session 52.5.0",
+ "datafusion-sql 52.5.0",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -2134,7 +2144,6 @@ dependencies = [
  "parking_lot",
  "rand 0.9.2",
  "regex",
- "rstest",
  "sqlparser 0.59.0",
  "tempfile",
  "tokio",
@@ -2226,21 +2235,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a3a799f914a59b1ea343906a0486f17061f39509af74e874a866428951130d"
+checksum = "9997731f90fa5398ef831ad0e69600f92c861b79c0d38bd1a29b6f0e3a0ce4c8"
 dependencies = [
  "arrow 57.3.0",
  "async-trait",
  "dashmap",
- "datafusion-common 51.0.0",
- "datafusion-common-runtime 51.0.0",
- "datafusion-datasource 51.0.0",
- "datafusion-execution 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-physical-expr 51.0.0",
- "datafusion-physical-plan 51.0.0",
- "datafusion-session 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-common-runtime 52.5.0",
+ "datafusion-datasource 52.5.0",
+ "datafusion-execution 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-physical-expr 52.5.0",
+ "datafusion-physical-plan 52.5.0",
+ "datafusion-session 52.5.0",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -2276,26 +2285,25 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db1b113c80d7a0febcd901476a57aef378e717c54517a163ed51417d87621b0"
+checksum = "2b30a3dd50dec860c9559275c8d97d9de602e611237a6ecfbda0b3b63b872352"
 dependencies = [
  "arrow 57.3.0",
  "async-trait",
- "datafusion-catalog 51.0.0",
- "datafusion-common 51.0.0",
- "datafusion-datasource 51.0.0",
- "datafusion-execution 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-physical-expr 51.0.0",
- "datafusion-physical-expr-adapter 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
- "datafusion-physical-plan 51.0.0",
+ "datafusion-catalog 52.5.0",
+ "datafusion-common 52.5.0",
+ "datafusion-datasource 52.5.0",
+ "datafusion-execution 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-physical-expr 52.5.0",
+ "datafusion-physical-expr-adapter 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
+ "datafusion-physical-plan 52.5.0",
  "futures",
  "itertools 0.14.0",
  "log",
  "object_store 0.12.5",
- "tokio",
 ]
 
 [[package]]
@@ -2323,16 +2331,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c10f7659e96127d25e8366be7c8be4109595d6a2c3eac70421f380a7006a1b0"
+checksum = "d551054acec0398ca604512310b77ce05c46f66e54b54d48200a686e385cca4e"
 dependencies = [
  "ahash 0.8.12",
  "arrow 57.3.0",
  "arrow-ipc 57.3.0",
  "chrono",
  "half",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "libc",
  "log",
@@ -2371,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92065bbc6532c6651e2f7dd30b55cba0c7a14f860c7e1d15f165c41a1868d95"
+checksum = "567d40e285f5b79f8737b576605721cd6c1133b5d2b00bdbd5d9838d90d0812f"
 dependencies = [
  "futures",
  "log",
@@ -2393,23 +2401,23 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde13794244bc7581cd82f6fff217068ed79cdc344cafe4ab2c3a1c3510b38d6"
+checksum = "27d2668f51b3b30befae2207472569e37807fdedd1d14da58acc6f8ca6257eae"
 dependencies = [
  "arrow 57.3.0",
  "async-trait",
  "bytes",
  "chrono",
- "datafusion-common 51.0.0",
- "datafusion-common-runtime 51.0.0",
- "datafusion-execution 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-physical-expr 51.0.0",
- "datafusion-physical-expr-adapter 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
- "datafusion-physical-plan 51.0.0",
- "datafusion-session 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-common-runtime 52.5.0",
+ "datafusion-execution 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-physical-expr 52.5.0",
+ "datafusion-physical-expr-adapter 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
+ "datafusion-physical-plan 52.5.0",
+ "datafusion-session 52.5.0",
  "futures",
  "glob",
  "itertools 0.14.0",
@@ -2457,22 +2465,22 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804fa9b4ecf3157982021770617200ef7c1b2979d57bec9044748314775a9aea"
+checksum = "e02e1b3e3a8ec55f1f62de4252b0407c8567363d056078769a197e24fc834a0f"
 dependencies = [
  "arrow 57.3.0",
  "arrow-ipc 57.3.0",
  "async-trait",
  "bytes",
- "datafusion-common 51.0.0",
- "datafusion-common-runtime 51.0.0",
- "datafusion-datasource 51.0.0",
- "datafusion-execution 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
- "datafusion-physical-plan 51.0.0",
- "datafusion-session 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-common-runtime 52.5.0",
+ "datafusion-datasource 52.5.0",
+ "datafusion-execution 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
+ "datafusion-physical-plan 52.5.0",
+ "datafusion-session 52.5.0",
  "futures",
  "itertools 0.14.0",
  "object_store 0.12.5",
@@ -2525,21 +2533,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a1641a40b259bab38131c5e6f48fac0717bedb7dc93690e604142a849e0568"
+checksum = "b559d7bf87d4f900f847baba8509634f838d9718695389e903604cdcccdb01f3"
 dependencies = [
  "arrow 57.3.0",
  "async-trait",
  "bytes",
- "datafusion-common 51.0.0",
- "datafusion-common-runtime 51.0.0",
- "datafusion-datasource 51.0.0",
- "datafusion-execution 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
- "datafusion-physical-plan 51.0.0",
- "datafusion-session 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-common-runtime 52.5.0",
+ "datafusion-datasource 52.5.0",
+ "datafusion-execution 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
+ "datafusion-physical-plan 52.5.0",
+ "datafusion-session 52.5.0",
  "futures",
  "object_store 0.12.5",
  "regex",
@@ -2571,21 +2579,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adeacdb00c1d37271176f8fb6a1d8ce096baba16ea7a4b2671840c5c9c64fe85"
+checksum = "250e2d7591ba8b638f063854650faa40bca4e8bd4059b2ece8836f6388d02db4"
 dependencies = [
  "arrow 57.3.0",
  "async-trait",
  "bytes",
- "datafusion-common 51.0.0",
- "datafusion-common-runtime 51.0.0",
- "datafusion-datasource 51.0.0",
- "datafusion-execution 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
- "datafusion-physical-plan 51.0.0",
- "datafusion-session 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-common-runtime 52.5.0",
+ "datafusion-datasource 52.5.0",
+ "datafusion-execution 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
+ "datafusion-physical-plan 52.5.0",
+ "datafusion-session 52.5.0",
  "futures",
  "object_store 0.12.5",
  "tokio",
@@ -2647,9 +2655,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b99e13947667b36ad713549237362afb054b2d8f8cc447751e23ec61202db07"
+checksum = "b9496cb0db222dbb9a3735760ceca7fc56f35e1d5502c38d0caa77a81e9c1f6a"
 
 [[package]]
 name = "datafusion-doc"
@@ -2659,15 +2667,16 @@ checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
 
 [[package]]
 name = "datafusion-execution"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63695643190679037bc946ad46a263b62016931547bf119859c511f7ff2f5178"
+checksum = "dc45d23c516ed8d3637751e44e09e21b45b3f58b473c802dddd1f1ad4fe435ff"
 dependencies = [
  "arrow 57.3.0",
  "async-trait",
+ "chrono",
  "dashmap",
- "datafusion-common 51.0.0",
- "datafusion-expr 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-expr 52.5.0",
  "futures",
  "log",
  "object_store 0.12.5",
@@ -2702,19 +2711,19 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a4787cbf5feb1ab351f789063398f67654a6df75c4d37d7f637dc96f951a91"
+checksum = "63dd30526d2db4fda6440806a41e4676334a94bc0596cc9cc2a0efed20ef2c44"
 dependencies = [
  "arrow 57.3.0",
  "async-trait",
  "chrono",
- "datafusion-common 51.0.0",
- "datafusion-doc 51.0.0",
- "datafusion-expr-common 51.0.0",
- "datafusion-functions-aggregate-common 51.0.0",
- "datafusion-functions-window-common 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-doc 52.5.0",
+ "datafusion-expr-common 52.5.0",
+ "datafusion-functions-aggregate-common 52.5.0",
+ "datafusion-functions-window-common 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
  "indexmap",
  "itertools 0.14.0",
  "paste",
@@ -2747,12 +2756,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce2fb1b8c15c9ac45b0863c30b268c69dc9ee7a1ee13ecf5d067738338173dc"
+checksum = "1b486b5f6255d40976b88bb83813b0d035a8333e0ec39864824e78068cf42fa6"
 dependencies = [
  "arrow 57.3.0",
- "datafusion-common 51.0.0",
+ "datafusion-common 52.5.0",
  "indexmap",
  "itertools 0.14.0",
  "paste",
@@ -2773,9 +2782,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794a9db7f7b96b3346fc007ff25e994f09b8f0511b4cf7dff651fadfe3ebb28f"
+checksum = "07356c94118d881130dd0ffbff127540407d969c8978736e324edcd6c41cd48f"
 dependencies = [
  "arrow 57.3.0",
  "arrow-buffer 57.3.0",
@@ -2783,12 +2792,13 @@ dependencies = [
  "blake2",
  "blake3",
  "chrono",
- "datafusion-common 51.0.0",
- "datafusion-doc 51.0.0",
- "datafusion-execution 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-expr-common 51.0.0",
- "datafusion-macros 51.0.0",
+ "chrono-tz",
+ "datafusion-common 52.5.0",
+ "datafusion-doc 52.5.0",
+ "datafusion-execution 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-expr-common 52.5.0",
+ "datafusion-macros 52.5.0",
  "hex",
  "itertools 0.14.0",
  "log",
@@ -2835,20 +2845,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c25210520a9dcf9c2b2cbbce31ebd4131ef5af7fc60ee92b266dc7d159cb305"
+checksum = "b644f9cf696df9233ce6958b9807666d78563b56f923267474dd6c07795f1f8f"
 dependencies = [
  "ahash 0.8.12",
  "arrow 57.3.0",
- "datafusion-common 51.0.0",
- "datafusion-doc 51.0.0",
- "datafusion-execution 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-functions-aggregate-common 51.0.0",
- "datafusion-macros 51.0.0",
- "datafusion-physical-expr 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-doc 52.5.0",
+ "datafusion-execution 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-functions-aggregate-common 52.5.0",
+ "datafusion-macros 52.5.0",
+ "datafusion-physical-expr 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
  "half",
  "log",
  "paste",
@@ -2878,15 +2888,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f4a66f3b87300bb70f4124b55434d2ae3fe80455f3574701d0348da040b55d"
+checksum = "c1de2deaaabe8923ce9ea9f29c47bbb4ee14f67ea2fe1ab5398d9bbebcf86e56"
 dependencies = [
  "ahash 0.8.12",
  "arrow 57.3.0",
- "datafusion-common 51.0.0",
- "datafusion-expr-common 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-expr-common 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
 ]
 
 [[package]]
@@ -2904,22 +2914,22 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5c06eed03918dc7fe7a9f082a284050f0e9ecf95d72f57712d1496da03b8c4"
+checksum = "552f8d92e4331ee91d23c02d12bb6acf32cbfd5215117e01c0fb63cd4b15af1a"
 dependencies = [
  "arrow 57.3.0",
  "arrow-ord 57.3.0",
- "datafusion-common 51.0.0",
- "datafusion-doc 51.0.0",
- "datafusion-execution 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-expr-common 51.0.0",
- "datafusion-functions 51.0.0",
- "datafusion-functions-aggregate 51.0.0",
- "datafusion-functions-aggregate-common 51.0.0",
- "datafusion-macros 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-doc 52.5.0",
+ "datafusion-execution 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-expr-common 52.5.0",
+ "datafusion-functions 52.5.0",
+ "datafusion-functions-aggregate 52.5.0",
+ "datafusion-functions-aggregate-common 52.5.0",
+ "datafusion-macros 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
  "itertools 0.14.0",
  "log",
  "paste",
@@ -2952,16 +2962,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4fed1d71738fbe22e2712d71396db04c25de4111f1ec252b8f4c6d3b25d7f5"
+checksum = "970fd0cdd3df8802b9a9975ff600998289ba9d46682a4f7285cba4820c9ada78"
 dependencies = [
  "arrow 57.3.0",
  "async-trait",
- "datafusion-catalog 51.0.0",
- "datafusion-common 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-physical-plan 51.0.0",
+ "datafusion-catalog 52.5.0",
+ "datafusion-common 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-physical-plan 52.5.0",
  "parking_lot",
  "paste",
 ]
@@ -2984,18 +2994,18 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d92206aa5ae21892f1552b4d61758a862a70956e6fd7a95cb85db1de74bc6d1"
+checksum = "40b4c21a7c8a986a1866c0a87ab756d0bbf7b5f41f306009fa2d9af79c52ed31"
 dependencies = [
  "arrow 57.3.0",
- "datafusion-common 51.0.0",
- "datafusion-doc 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-functions-window-common 51.0.0",
- "datafusion-macros 51.0.0",
- "datafusion-physical-expr 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-doc 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-functions-window-common 52.5.0",
+ "datafusion-macros 52.5.0",
+ "datafusion-physical-expr 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
  "log",
  "paste",
 ]
@@ -3020,12 +3030,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ae9bcc39800820d53a22d758b3b8726ff84a5a3e24cecef04ef4e5fdf1c7cc"
+checksum = "b1210ad73b8b3211aeaf4a42bef9bd7a2b7fce3ec119a478831f18c6ff7f7b93"
 dependencies = [
- "datafusion-common 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
 ]
 
 [[package]]
@@ -3040,11 +3050,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1063ad4c9e094b3f798acee16d9a47bd7372d9699be2de21b05c3bd3f34ab848"
+checksum = "aaa566a963013a38681ad82a727a654bc7feb19632426aea8c3412d415d200c5"
 dependencies = [
- "datafusion-doc 51.0.0",
+ "datafusion-doc 52.5.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -3062,16 +3072,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35f9ec5d08b87fd1893a30c2929f2559c2f9806ca072d8fefca5009dc0f06a"
+checksum = "ff9aa82b240252a88dee118372f9b9757c545ab9e53c0736bebab2e7da0ef1f2"
 dependencies = [
  "arrow 57.3.0",
  "chrono",
- "datafusion-common 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-expr-common 51.0.0",
- "datafusion-physical-expr 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-expr-common 52.5.0",
+ "datafusion-physical-expr 52.5.0",
  "indexmap",
  "itertools 0.14.0",
  "log",
@@ -3101,24 +3111,25 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30cc8012e9eedcb48bbe112c6eff4ae5ed19cf3003cb0f505662e88b7014c5d"
+checksum = "7d48022b8af9988c1d852644f9e8b5584c490659769a550c5e8d39457a1da0a5"
 dependencies = [
  "ahash 0.8.12",
  "arrow 57.3.0",
- "datafusion-common 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-expr-common 51.0.0",
- "datafusion-functions-aggregate-common 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-expr-common 52.5.0",
+ "datafusion-functions-aggregate-common 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
  "half",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "itertools 0.14.0",
  "parking_lot",
  "paste",
  "petgraph",
+ "tokio",
 ]
 
 [[package]]
@@ -3147,16 +3158,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9ff2dbd476221b1f67337699eff432781c4e6e1713d2aefdaa517dfbf79768"
+checksum = "ae7a8abc0b4fe624000972a9b145b30b7f1b680bffaa950ea53f78d9b21c27c3"
 dependencies = [
  "arrow 57.3.0",
- "datafusion-common 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-functions 51.0.0",
- "datafusion-physical-expr 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-functions 52.5.0",
+ "datafusion-physical-expr 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
  "itertools 0.14.0",
 ]
 
@@ -3177,16 +3188,19 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90da43e1ec550b172f34c87ec68161986ced70fd05c8d2a2add66eef9c276f03"
+checksum = "147253ca3e6b9d59c162de64c02800973018660e13340dd1886dd038d17ac429"
 dependencies = [
  "ahash 0.8.12",
  "arrow 57.3.0",
- "datafusion-common 51.0.0",
- "datafusion-expr-common 51.0.0",
- "hashbrown 0.14.5",
+ "chrono",
+ "datafusion-common 52.5.0",
+ "datafusion-expr-common 52.5.0",
+ "hashbrown 0.16.1",
+ "indexmap",
  "itertools 0.14.0",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3208,19 +3222,19 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9804f799acd7daef3be7aaffe77c0033768ed8fdbf5fb82fc4c5f2e6bc14e6"
+checksum = "689156bb2282107b6239db8d7ef44b4dab10a9b33d3491a0c74acac5e4fedd72"
 dependencies = [
  "arrow 57.3.0",
- "datafusion-common 51.0.0",
- "datafusion-execution 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-expr-common 51.0.0",
- "datafusion-physical-expr 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
- "datafusion-physical-plan 51.0.0",
- "datafusion-pruning 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-execution 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-expr-common 52.5.0",
+ "datafusion-physical-expr 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
+ "datafusion-physical-plan 52.5.0",
+ "datafusion-pruning 52.5.0",
  "itertools 0.14.0",
 ]
 
@@ -3245,27 +3259,27 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0acf0ad6b6924c6b1aa7d213b181e012e2d3ec0a64ff5b10ee6282ab0f8532ac"
+checksum = "68253dc0ee5330aa558b2549c9b0da5af9fc17d753ae73022939014ad616fc28"
 dependencies = [
  "ahash 0.8.12",
  "arrow 57.3.0",
  "arrow-ord 57.3.0",
  "arrow-schema 57.3.0",
  "async-trait",
- "chrono",
- "datafusion-common 51.0.0",
- "datafusion-common-runtime 51.0.0",
- "datafusion-execution 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-functions-aggregate-common 51.0.0",
- "datafusion-functions-window-common 51.0.0",
- "datafusion-physical-expr 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-common-runtime 52.5.0",
+ "datafusion-execution 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-functions 52.5.0",
+ "datafusion-functions-aggregate-common 52.5.0",
+ "datafusion-functions-window-common 52.5.0",
+ "datafusion-physical-expr 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
  "futures",
  "half",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "itertools 0.14.0",
  "log",
@@ -3308,17 +3322,17 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2c2498a1f134a9e11a9f5ed202a2a7d7e9774bd9249295593053ea3be999db"
+checksum = "0fcad240a54d0b1d3e8f668398900260a53122d522b2102ab57218590decacd6"
 dependencies = [
  "arrow 57.3.0",
- "datafusion-common 51.0.0",
- "datafusion-datasource 51.0.0",
- "datafusion-expr-common 51.0.0",
- "datafusion-physical-expr 51.0.0",
- "datafusion-physical-expr-common 51.0.0",
- "datafusion-physical-plan 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-datasource 52.5.0",
+ "datafusion-expr-common 52.5.0",
+ "datafusion-physical-expr 52.5.0",
+ "datafusion-physical-expr-common 52.5.0",
+ "datafusion-physical-plan 52.5.0",
  "itertools 0.14.0",
  "log",
 ]
@@ -3342,15 +3356,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f96eebd17555386f459037c65ab73aae8df09f464524c709d6a3134ad4f4776"
+checksum = "f58e83a68bb67007a8fcbf005c44cefe441270c7ee7f6dee10c0e0109b556f6d"
 dependencies = [
  "async-trait",
- "datafusion-common 51.0.0",
- "datafusion-execution 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-physical-plan 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-execution 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-physical-plan 52.5.0",
  "parking_lot",
 ]
 
@@ -3397,15 +3411,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "51.0.0"
+version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc195fe60634b2c6ccfd131b487de46dc30eccae8a3c35a13f136e7f440414f"
+checksum = "be53e9eb55db0fbb8980bb6d87f2435b0524acf4c718ed54a57cabbb299b2ab3"
 dependencies = [
  "arrow 57.3.0",
  "bigdecimal",
  "chrono",
- "datafusion-common 51.0.0",
- "datafusion-expr 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-expr 52.5.0",
  "indexmap",
  "log",
  "regex",
@@ -3647,16 +3661,6 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
-name = "earcutr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
-dependencies = [
- "itertools 0.11.0",
- "num-traits",
-]
 
 [[package]]
 name = "educe"
@@ -3921,12 +3925,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float_next_after"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3980,9 +3978,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9e5c0b1c67a38cb92b41535d44623483beb9511592ae23a3bf42ddec758690"
+checksum = "2195cc7f87e84bd695586137de99605e7e9579b26ec5e01b82960ddb4d0922f2"
 dependencies = [
  "arrow-array 57.3.0",
  "rand 0.9.2",
@@ -4154,128 +4152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "geo"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
-dependencies = [
- "earcutr",
- "float_next_after",
- "geo-types",
- "geographiclib-rs",
- "i_overlay",
- "log",
- "num-traits",
- "robust",
- "rstar",
- "spade",
-]
-
-[[package]]
-name = "geo-traits"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7c353d12a704ccfab1ba8bfb1a7fe6cb18b665bf89d37f4f7890edcd260206"
-dependencies = [
- "geo-types",
-]
-
-[[package]]
-name = "geo-types"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
-dependencies = [
- "approx",
- "num-traits",
- "rayon",
- "rstar",
- "serde",
-]
-
-[[package]]
-name = "geoarrow-array"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1cc4106ac0a0a512c398961ce95d8150475c84a84e17c4511c3643fa120a17"
-dependencies = [
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
- "arrow-schema 57.3.0",
- "geo-traits",
- "geoarrow-schema",
- "num-traits",
- "wkb",
- "wkt",
-]
-
-[[package]]
-name = "geoarrow-expr-geo"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa84300361ce57fb875bcaa6e32b95b0aff5c6b1af692b936bdd58ff343f4394"
-dependencies = [
- "arrow-array 57.3.0",
- "arrow-buffer 57.3.0",
- "geo",
- "geo-traits",
- "geoarrow-array",
- "geoarrow-schema",
-]
-
-[[package]]
-name = "geoarrow-schema"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97be4e9f523f92bd6a0e0458323f4b783d073d011664decd8dbf05651704f34"
-dependencies = [
- "arrow-schema 57.3.0",
- "geo-traits",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "geodatafusion"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773cfa1fb0d7f7661b76b3fde00f3ffd8e0ff7b3635096f0ff6294fe5ca62a2b"
-dependencies = [
- "arrow-arith 57.3.0",
- "arrow-array 57.3.0",
- "arrow-schema 57.3.0",
- "datafusion 51.0.0",
- "geo",
- "geo-traits",
- "geoarrow-array",
- "geoarrow-expr-geo",
- "geoarrow-schema",
- "geohash",
- "thiserror 1.0.69",
- "wkt",
-]
-
-[[package]]
-name = "geographiclib-rs"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
-dependencies = [
- "libm",
-]
-
-[[package]]
-name = "geohash"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb94b1a65401d6cbf22958a9040aa364812c26674f841bee538b12c135db1e6"
-dependencies = [
- "geo-types",
- "libm",
-]
-
-[[package]]
 name = "get_dir"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4404,15 +4280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ed72152641d513a6084a3907bfcba3f35ae2d3335c22ce2242969c25ff8e46"
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbag"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4468,16 +4335,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
-]
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -4648,49 +4505,6 @@ checksum = "621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "i_float"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010025c2c532c8d82e42d0b8bb5184afa449fa6f06c709ea9adcb16c49ae405b"
-dependencies = [
- "libm",
-]
-
-[[package]]
-name = "i_key_sort"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9190f86706ca38ac8add223b2aed8b1330002b5cdbbce28fb58b10914d38fc27"
-
-[[package]]
-name = "i_overlay"
-version = "4.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413183068e6e0289e18d7d0a1f661b81546e6918d5453a44570b9ab30cbed1b3"
-dependencies = [
- "i_float",
- "i_key_sort",
- "i_shape",
- "i_tree",
- "rayon",
-]
-
-[[package]]
-name = "i_shape"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea154b742f7d43dae2897fcd5ead86bc7b5eefcedd305a7ebf9f69d44d61082"
-dependencies = [
- "i_float",
-]
-
-[[package]]
-name = "i_tree"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
 
 [[package]]
 name = "iana-time-zone"
@@ -4978,15 +4792,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -5179,9 +4984,9 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7f07b905df393a5554eba19055c620f9ea25a3e40a013bda4bd8dc4ca66f01"
+checksum = "efe6c3ddd79cdfd2b7e1c23cafae52806906bc40fbd97de9e8cf2f8c7a75fc04"
 dependencies = [
  "arrow 57.3.0",
  "arrow-arith 57.3.0",
@@ -5198,12 +5003,13 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
+ "crossbeam-skiplist",
  "dashmap",
- "datafusion 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-functions 51.0.0",
- "datafusion-physical-expr 51.0.0",
- "datafusion-physical-plan 51.0.0",
+ "datafusion 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-functions 52.5.0",
+ "datafusion-physical-expr 52.5.0",
+ "datafusion-physical-plan 52.5.0",
  "deepsize",
  "either",
  "futures",
@@ -5215,7 +5021,6 @@ dependencies = [
  "lance-datafusion",
  "lance-encoding",
  "lance-file",
- "lance-geo",
  "lance-index",
  "lance-io",
  "lance-linalg",
@@ -5229,7 +5034,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-types",
  "rand 0.9.2",
- "roaring 0.10.12",
+ "roaring",
  "semver",
  "serde",
  "serde_json",
@@ -5237,6 +5042,7 @@ dependencies = [
  "tantivy",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "url",
  "uuid",
@@ -5244,9 +5050,9 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100e076cb81c8f0c24cd2881c706fc53e037c7d6e81eb320e929e265d157effb"
+checksum = "5d9f5d95bdda2a2b790f1fb8028b5b6dcf661abeb3133a8bca0f3d24b054af87"
 dependencies = [
  "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
@@ -5256,6 +5062,7 @@ dependencies = [
  "arrow-schema 57.3.0",
  "arrow-select 57.3.0",
  "bytes",
+ "futures",
  "getrandom 0.2.17",
  "half",
  "jsonb",
@@ -5283,9 +5090,9 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588318d3d1ba0f97162fab39a323a0a49866bb35b32af42572c6b6a12296fa27"
+checksum = "f827d6ab9f8f337a9509d5ad66a12f3314db8713868260521c344ef6135eb4e4"
 dependencies = [
  "arrayref",
  "paste",
@@ -5294,9 +5101,9 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa01d1cf490ccfd3b8eaeee2781415d0419e6be8366040e57e43677abf2644e"
+checksum = "0f1e25df6a79bf72ee6bcde0851f19b1cd36c5848c1b7db83340882d3c9fdecb"
 dependencies = [
  "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
@@ -5305,8 +5112,8 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "datafusion-common 51.0.0",
- "datafusion-sql 51.0.0",
+ "datafusion-common 52.5.0",
+ "datafusion-sql 52.5.0",
  "deepsize",
  "futures",
  "itertools 0.13.0",
@@ -5320,7 +5127,7 @@ dependencies = [
  "pin-project",
  "prost 0.14.3",
  "rand 0.9.2",
- "roaring 0.10.12",
+ "roaring",
  "serde_json",
  "snafu",
  "tempfile",
@@ -5333,9 +5140,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef89a39e3284eef76f79e63f23de8881a0583ad6feb20ed39f47eadd847a2b88"
+checksum = "93146de8ae720cb90edef81c2f2d0a1b065fc2f23ecff2419546f389b0fa70a4"
 dependencies = [
  "arrow 57.3.0",
  "arrow-array 57.3.0",
@@ -5345,19 +5152,19 @@ dependencies = [
  "arrow-select 57.3.0",
  "async-trait",
  "chrono",
- "datafusion 51.0.0",
- "datafusion-common 51.0.0",
- "datafusion-functions 51.0.0",
- "datafusion-physical-expr 51.0.0",
+ "datafusion 52.5.0",
+ "datafusion-common 52.5.0",
+ "datafusion-functions 52.5.0",
+ "datafusion-physical-expr 52.5.0",
  "futures",
  "jsonb",
  "lance-arrow",
  "lance-core",
  "lance-datagen",
- "lance-geo",
  "log",
  "pin-project",
  "prost 0.14.3",
+ "prost-build",
  "snafu",
  "tokio",
  "tracing",
@@ -5365,9 +5172,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2a60eef5c47e65d91e2ffa8e7e1629c52e7190c8b88a371a1a60601dc49371"
+checksum = "ccec8ce4d8e0a87a99c431dab2364398029f2ffb649c1a693c60c79e05ed30dd"
 dependencies = [
  "arrow 57.3.0",
  "arrow-array 57.3.0",
@@ -5385,9 +5192,9 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce4a6631308aa681b2671af8f2a845ff781f8d4e755a2a7ccd012379467094"
+checksum = "5c1aec0bbbac6bce829bc10f1ba066258126100596c375fb71908ecf11c2c2a5"
 dependencies = [
  "arrow-arith 57.3.0",
  "arrow-array 57.3.0",
@@ -5424,9 +5231,9 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d4d82357cbfaa1a18494226c15b1cb3c8ed0b6c84b91146323c82047ede419"
+checksum = "14a8c548804f5b17486dc2d3282356ed1957095a852780283bc401fdd69e9075"
 dependencies = [
  "arrow-arith 57.3.0",
  "arrow-array 57.3.0",
@@ -5438,7 +5245,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
- "datafusion-common 51.0.0",
+ "datafusion-common 52.5.0",
  "deepsize",
  "futures",
  "lance-arrow",
@@ -5457,26 +5264,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lance-geo"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7183fc870da62826f0f97df8007b634da053eb310157856efe1dc74f446951c"
-dependencies = [
- "datafusion 51.0.0",
- "geo-traits",
- "geo-types",
- "geoarrow-array",
- "geoarrow-schema",
- "geodatafusion",
- "lance-core",
- "serde",
-]
-
-[[package]]
 name = "lance-index"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20e9c5aa7024a63af9ae89ee8c0f23c8421b7896742e5cd4a271a60f9956cb80"
+checksum = "2da212f0090ea59f79ac3686660f596520c167fe1cb5f408900cf71d215f0e03"
 dependencies = [
  "arrow 57.3.0",
  "arrow-arith 57.3.0",
@@ -5490,19 +5281,17 @@ dependencies = [
  "bitpacking",
  "bitvec",
  "bytes",
+ "chrono",
  "crossbeam-queue",
- "datafusion 51.0.0",
- "datafusion-common 51.0.0",
- "datafusion-expr 51.0.0",
- "datafusion-physical-expr 51.0.0",
- "datafusion-sql 51.0.0",
+ "datafusion 52.5.0",
+ "datafusion-common 52.5.0",
+ "datafusion-expr 52.5.0",
+ "datafusion-physical-expr 52.5.0",
+ "datafusion-sql 52.5.0",
  "deepsize",
  "dirs",
  "fst",
  "futures",
- "geo-types",
- "geoarrow-array",
- "geoarrow-schema",
  "half",
  "itertools 0.13.0",
  "jsonb",
@@ -5512,7 +5301,6 @@ dependencies = [
  "lance-datagen",
  "lance-encoding",
  "lance-file",
- "lance-geo",
  "lance-io",
  "lance-linalg",
  "lance-table",
@@ -5528,7 +5316,7 @@ dependencies = [
  "rand_distr 0.5.1",
  "rangemap",
  "rayon",
- "roaring 0.10.12",
+ "roaring",
  "serde",
  "serde_json",
  "smallvec",
@@ -5543,9 +5331,9 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d2af0b17fb374a8181bcf1a10bce5703ae3ee4373c1587ce4bba23e15e45c8"
+checksum = "41d958eb4b56f03bbe0f5f85eb2b4e9657882812297b6f711f201ffc995f259f"
 dependencies = [
  "arrow 57.3.0",
  "arrow-arith 57.3.0",
@@ -5562,6 +5350,7 @@ dependencies = [
  "chrono",
  "deepsize",
  "futures",
+ "http",
  "lance-arrow",
  "lance-core",
  "lance-namespace",
@@ -5572,8 +5361,8 @@ dependencies = [
  "prost 0.14.3",
  "rand 0.9.2",
  "serde",
- "shellexpand",
  "snafu",
+ "tempfile",
  "tokio",
  "tracing",
  "url",
@@ -5581,9 +5370,9 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5125aa62696e75a7475807564b4921f252d8815be606b84bc00e6def0f5c24bb"
+checksum = "0285b70da35def7ed95e150fae1d5308089554e1290470403ed3c50cb235bc5e"
 dependencies = [
  "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
@@ -5599,23 +5388,24 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70545c2676ce954dfd801da5c6a631a70bba967826cd3a8f31b47d1f04bbfed3"
+checksum = "5f78e2a828b654e062a495462c6e3eb4fcf0e7e907d761b8f217fc09ccd3ceac"
 dependencies = [
  "arrow 57.3.0",
  "async-trait",
  "bytes",
  "lance-core",
  "lance-namespace-reqwest-client",
+ "serde",
  "snafu",
 ]
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.4.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2acdba67f84190067532fce07b51a435dd390d7cdc1129a05003e5cb3274cf0"
+checksum = "ee2e48de899e2931afb67fcddd0a08e439bf5d8b6ea2a2ed9cb8f4df669bd5cc"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -5626,9 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06ad37bd90045de8ef533df170c6098e6ff6ecb427aade47d7db8e2c86f2678"
+checksum = "3df9c4adca3eb2074b3850432a9fb34248a3d90c3d6427d158b13ff9355664ee"
 dependencies = [
  "arrow 57.3.0",
  "arrow-array 57.3.0",
@@ -5652,7 +5442,7 @@ dependencies = [
  "prost-types",
  "rand 0.9.2",
  "rangemap",
- "roaring 0.10.12",
+ "roaring",
  "semver",
  "serde",
  "serde_json",
@@ -6439,7 +6229,6 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8077,39 +7866,12 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
-dependencies = [
- "bytemuck",
- "byteorder",
-]
-
-[[package]]
-name = "roaring"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
 dependencies = [
  "bytemuck",
  "byteorder",
-]
-
-[[package]]
-name = "robust"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
-
-[[package]]
-name = "rstar"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
-dependencies = [
- "heapless",
- "num-traits",
- "smallvec",
 ]
 
 [[package]]
@@ -8655,15 +8417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shellexpand"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
-dependencies = [
- "dirs",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8793,18 +8546,18 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+checksum = "d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -8836,18 +8589,6 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "spade"
-version = "2.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb313e1c8afee5b5647e00ee0fe6855e3d529eb863a0fdae1d60006c4d1e9990"
-dependencies = [
- "hashbrown 0.15.5",
- "num-traits",
- "robust",
- "smallvec",
 ]
 
 [[package]]
@@ -11015,7 +10756,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures",
- "roaring 0.11.3",
+ "roaring",
  "tracing",
  "vortex-array",
  "vortex-buffer",
@@ -11818,31 +11559,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
-]
-
-[[package]]
-name = "wkb"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a120b336c7ad17749026d50427c23d838ecb50cd64aaea6254b5030152f890a9"
-dependencies = [
- "byteorder",
- "geo-traits",
- "num_enum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "wkt"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb2b923ccc882312e559ffaa832a055ba9d1ac0cc8e86b3e25453247e4b81d7"
-dependencies = [
- "geo-traits",
- "geo-types",
- "log",
- "num-traits",
- "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ keywords = ["vortex"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/spiraldb/vortex"
-rust-version = "1.90.0"
+rust-version = "1.91.0"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/benchmarks/lance-bench/Cargo.toml
+++ b/benchmarks/lance-bench/Cargo.toml
@@ -15,8 +15,8 @@ version.workspace = true
 publish = false
 
 [dependencies]
-lance = { version = "2.0.0", default-features = false }
-lance-encoding = { version = "2.0.0" }
+lance = { version = "4", default-features = false }
+lance-encoding = { version = "4" }
 
 anyhow = { workspace = true }
 arrow-cast = { version = "57" }

--- a/benchmarks/vector-search-bench/src/ingest.rs
+++ b/benchmarks/vector-search-bench/src/ingest.rs
@@ -169,8 +169,13 @@ mod tests {
         let chunk =
             StructArray::from_fields(&[("id", id_array(&[0, 1])), ("emb", emb)])?.into_array();
         let out = transform_chunk(chunk, &mut ctx)?;
-        let out_struct = out.as_opt::<Struct>().expect("returns Struct");
-        let out_emb = out_struct.unmasked_field_by_name("emb").unwrap().clone();
+        let out_struct = out
+            .as_opt::<Struct>()
+            .context("transform_chunk should return a Struct array")?;
+        let out_emb = out_struct
+            .unmasked_field_by_name("emb")
+            .context("transform_chunk output should contain an emb field")?
+            .clone();
         let DType::Extension(ext) = out_emb.dtype() else {
             panic!("expected extension dtype, got {}", out_emb.dtype());
         };

--- a/encodings/datetime-parts/src/canonical.rs
+++ b/encodings/datetime-parts/src/canonical.rs
@@ -158,12 +158,7 @@ mod test {
             .execute::<PrimitiveArray>(&mut ctx)?;
 
         assert_arrays_eq!(primitive_values, milliseconds);
-        assert!(
-            primitive_values
-                .validity()
-                .unwrap()
-                .mask_eq(&validity, &mut ctx)?
-        );
+        assert!(primitive_values.validity()?.mask_eq(&validity, &mut ctx)?);
         Ok(())
     }
 }

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
@@ -540,13 +540,15 @@ mod test {
             .for_each(|&idx| values[idx] = patch_value);
 
         let array = PrimitiveArray::from_iter(values);
-        let bitpacked = bitpack_encode(&array, 4, None, &mut ctx).unwrap();
+        let bitpacked = bitpack_encode(&array, 4, None, &mut ctx)?;
 
-        let patches = bitpacked.patches().unwrap();
+        let patches = bitpacked
+            .patches()
+            .ok_or_else(|| vortex_error::vortex_err!("expected patches"))?;
         let chunk_offsets = patches
             .chunk_offsets()
             .as_ref()
-            .unwrap()
+            .ok_or_else(|| vortex_error::vortex_err!("expected chunk offsets"))?
             .clone()
             .execute::<PrimitiveArray>(&mut ctx)?;
 
@@ -570,13 +572,15 @@ mod test {
             .for_each(|&idx| values[idx] = patch_value);
 
         let array = PrimitiveArray::from_iter(values);
-        let bitpacked = bitpack_encode(&array, 4, None, &mut ctx).unwrap();
+        let bitpacked = bitpack_encode(&array, 4, None, &mut ctx)?;
 
-        let patches = bitpacked.patches().unwrap();
+        let patches = bitpacked
+            .patches()
+            .ok_or_else(|| vortex_error::vortex_err!("expected patches"))?;
         let chunk_offsets = patches
             .chunk_offsets()
             .as_ref()
-            .unwrap()
+            .ok_or_else(|| vortex_error::vortex_err!("expected chunk offsets"))?
             .clone()
             .execute::<PrimitiveArray>(&mut ctx)?;
 
@@ -596,13 +600,15 @@ mod test {
             .for_each(|&idx| values[idx] = patch_value);
 
         let array = PrimitiveArray::from_iter(values);
-        let bitpacked = bitpack_encode(&array, 4, None, &mut ctx).unwrap();
+        let bitpacked = bitpack_encode(&array, 4, None, &mut ctx)?;
 
-        let patches = bitpacked.patches().unwrap();
+        let patches = bitpacked
+            .patches()
+            .ok_or_else(|| vortex_error::vortex_err!("expected patches"))?;
         let chunk_offsets = patches
             .chunk_offsets()
             .as_ref()
-            .unwrap()
+            .ok_or_else(|| vortex_error::vortex_err!("expected chunk offsets"))?
             .clone()
             .execute::<PrimitiveArray>(&mut ctx)?;
 
@@ -627,13 +633,15 @@ mod test {
             .for_each(|&idx| values[idx] = patch_value);
 
         let array = PrimitiveArray::from_iter(values);
-        let bitpacked = bitpack_encode(&array, 4, None, &mut ctx).unwrap();
+        let bitpacked = bitpack_encode(&array, 4, None, &mut ctx)?;
 
-        let patches = bitpacked.patches().unwrap();
+        let patches = bitpacked
+            .patches()
+            .ok_or_else(|| vortex_error::vortex_err!("expected patches"))?;
         let chunk_offsets = patches
             .chunk_offsets()
             .as_ref()
-            .unwrap()
+            .ok_or_else(|| vortex_error::vortex_err!("expected chunk offsets"))?
             .clone()
             .execute::<PrimitiveArray>(&mut ctx)?;
 

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
@@ -442,6 +442,7 @@ mod test {
     use vortex_array::session::ArraySession;
     use vortex_buffer::Buffer;
     use vortex_error::VortexError;
+    use vortex_error::vortex_err;
     use vortex_session::VortexSession;
 
     use super::*;
@@ -544,11 +545,11 @@ mod test {
 
         let patches = bitpacked
             .patches()
-            .ok_or_else(|| vortex_error::vortex_err!("expected patches"))?;
+            .ok_or_else(|| vortex_err!("expected patches"))?;
         let chunk_offsets = patches
             .chunk_offsets()
             .as_ref()
-            .ok_or_else(|| vortex_error::vortex_err!("expected chunk offsets"))?
+            .ok_or_else(|| vortex_err!("expected chunk offsets"))?
             .clone()
             .execute::<PrimitiveArray>(&mut ctx)?;
 
@@ -576,11 +577,11 @@ mod test {
 
         let patches = bitpacked
             .patches()
-            .ok_or_else(|| vortex_error::vortex_err!("expected patches"))?;
+            .ok_or_else(|| vortex_err!("expected patches"))?;
         let chunk_offsets = patches
             .chunk_offsets()
             .as_ref()
-            .ok_or_else(|| vortex_error::vortex_err!("expected chunk offsets"))?
+            .ok_or_else(|| vortex_err!("expected chunk offsets"))?
             .clone()
             .execute::<PrimitiveArray>(&mut ctx)?;
 
@@ -604,11 +605,11 @@ mod test {
 
         let patches = bitpacked
             .patches()
-            .ok_or_else(|| vortex_error::vortex_err!("expected patches"))?;
+            .ok_or_else(|| vortex_err!("expected patches"))?;
         let chunk_offsets = patches
             .chunk_offsets()
             .as_ref()
-            .ok_or_else(|| vortex_error::vortex_err!("expected chunk offsets"))?
+            .ok_or_else(|| vortex_err!("expected chunk offsets"))?
             .clone()
             .execute::<PrimitiveArray>(&mut ctx)?;
 
@@ -637,11 +638,11 @@ mod test {
 
         let patches = bitpacked
             .patches()
-            .ok_or_else(|| vortex_error::vortex_err!("expected patches"))?;
+            .ok_or_else(|| vortex_err!("expected patches"))?;
         let chunk_offsets = patches
             .chunk_offsets()
             .as_ref()
-            .ok_or_else(|| vortex_error::vortex_err!("expected chunk offsets"))?
+            .ok_or_else(|| vortex_err!("expected chunk offsets"))?
             .clone()
             .execute::<PrimitiveArray>(&mut ctx)?;
 

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -305,11 +305,8 @@ mod tests {
         let bitpacked = encode(&zeros, 10);
         assert_eq!(bitpacked.len(), 1025);
         assert!(bitpacked.patches().is_some());
-        let slice_ref = bitpacked.into_array().slice(1023..1025).unwrap();
-        let actual = slice_ref
-            .execute::<Canonical>(&mut ctx)
-            .unwrap()
-            .into_primitive();
+        let slice_ref = bitpacked.into_array().slice(1023..1025)?;
+        let actual = slice_ref.execute::<Canonical>(&mut ctx)?.into_primitive();
         assert_arrays_eq!(actual, PrimitiveArray::from_iter([1535u16, 1536]));
         Ok(())
     }
@@ -323,11 +320,8 @@ mod tests {
         let bitpacked = encode(&zeros, 10);
         assert_eq!(bitpacked.len(), 2229);
         assert!(bitpacked.patches().is_some());
-        let slice_ref = bitpacked.into_array().slice(1023..2049).unwrap();
-        let actual = slice_ref
-            .execute::<Canonical>(&mut ctx)
-            .unwrap()
-            .into_primitive();
+        let slice_ref = bitpacked.into_array().slice(1023..2049)?;
+        let actual = slice_ref.execute::<Canonical>(&mut ctx)?.into_primitive();
         assert_arrays_eq!(
             actual,
             PrimitiveArray::from_iter((1023u16..2049).map(|x| x + 512))
@@ -380,11 +374,11 @@ mod tests {
         // Verify the validity mask was correctly applied.
         assert_eq!(result.len(), 5);
         let mut ctx = SESSION.create_execution_ctx();
-        assert!(!result.execute_scalar(0, &mut ctx).unwrap().is_null());
-        assert!(result.execute_scalar(1, &mut ctx).unwrap().is_null());
-        assert!(!result.execute_scalar(2, &mut ctx).unwrap().is_null());
-        assert!(!result.execute_scalar(3, &mut ctx).unwrap().is_null());
-        assert!(result.execute_scalar(4, &mut ctx).unwrap().is_null());
+        assert!(!result.execute_scalar(0, &mut ctx)?.is_null());
+        assert!(result.execute_scalar(1, &mut ctx)?.is_null());
+        assert!(!result.execute_scalar(2, &mut ctx)?.is_null());
+        assert!(!result.execute_scalar(3, &mut ctx)?.is_null());
+        assert!(result.execute_scalar(4, &mut ctx)?.is_null());
         Ok(())
     }
 
@@ -504,10 +498,7 @@ mod tests {
 
             let executed = {
                 let mut ctx = SESSION.create_execution_ctx();
-                bitpacked
-                    .into_array()
-                    .execute::<Canonical>(&mut ctx)
-                    .unwrap()
+                bitpacked.into_array().execute::<Canonical>(&mut ctx)?
             };
 
             assert_eq!(
@@ -530,8 +521,7 @@ mod tests {
                 let mut ctx = SESSION.create_execution_ctx();
                 unpacked_array
                     .into_array()
-                    .execute::<Canonical>(&mut ctx)
-                    .unwrap()
+                    .execute::<Canonical>(&mut ctx)?
                     .into_primitive()
             };
             assert_eq!(
@@ -560,13 +550,12 @@ mod tests {
         // Test with sliced array (offset > 0).
         let values = PrimitiveArray::from_iter(0u32..2048);
         let bitpacked = encode(&values, 11);
-        let slice_ref = bitpacked.into_array().slice(500..1500).unwrap();
+        let slice_ref = bitpacked.into_array().slice(500..1500)?;
         let sliced = {
             let mut ctx = SESSION.create_execution_ctx();
             slice_ref
                 .clone()
-                .execute::<Canonical>(&mut ctx)
-                .unwrap()
+                .execute::<Canonical>(&mut ctx)?
                 .into_primitive()
         };
 
@@ -575,7 +564,7 @@ mod tests {
         let unpacked_array = sliced;
         let executed = {
             let mut ctx = SESSION.create_execution_ctx();
-            slice_ref.execute::<Canonical>(&mut ctx).unwrap()
+            slice_ref.execute::<Canonical>(&mut ctx)?
         };
 
         assert_eq!(

--- a/encodings/fastlanes/src/delta/array/delta_compress.rs
+++ b/encodings/fastlanes/src/delta/array/delta_compress.rs
@@ -135,8 +135,8 @@ mod tests {
         let array = PrimitiveArray::from_option_iter(
             (0u8..200).map(|i| (!(50..100).contains(&i)).then_some(i)),
         );
-        let (bases, deltas) = delta_compress(&array, &mut ctx).unwrap();
-        let bitpacked_deltas = bitpack_encode(&deltas, 1, None, &mut ctx).unwrap();
+        let (bases, deltas) = delta_compress(&array, &mut ctx)?;
+        let bitpacked_deltas = bitpack_encode(&deltas, 1, None, &mut ctx)?;
         let packed_delta = Delta::try_new(
             bases.into_array(),
             bitpacked_deltas.into_array(),

--- a/encodings/fastlanes/src/for/array/for_compress.rs
+++ b/encodings/fastlanes/src/for/array/for_compress.rs
@@ -143,7 +143,7 @@ mod test {
         // Create a range offset by a million.
         let expect = PrimitiveArray::from_iter((0u32..1024).map(|x| x % 7 + 10));
         let array = PrimitiveArray::from_iter((0u32..1024).map(|x| x % 7));
-        let bp = BitPackedData::encode(&array.into_array(), 2, &mut ctx).unwrap();
+        let bp = BitPackedData::encode(&array.into_array(), 2, &mut ctx)?;
         let compressed = FoR::try_new(bp.clone().into_array(), 10u32.into())?;
         let decompressed = fused_decompress::<u32>(&compressed, bp.as_view(), &mut ctx)?;
         assert_arrays_eq!(decompressed, expect);
@@ -154,7 +154,7 @@ mod test {
     fn test_overflow() -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter(i8::MIN..=i8::MAX);
-        let compressed = FoRData::encode(array.clone()).unwrap();
+        let compressed = FoRData::encode(array.clone())?;
         assert_eq!(
             i8::MIN,
             compressed

--- a/encodings/fastlanes/src/rle/array/mod.rs
+++ b/encodings/fastlanes/src/rle/array/mod.rs
@@ -365,7 +365,7 @@ mod tests {
     fn test_rle_serialization() -> VortexResult<()> {
         let mut exec_ctx = SESSION.create_execution_ctx();
         let primitive = PrimitiveArray::from_iter((0..2048).map(|i| (i / 100) as u32));
-        let rle_array = RLEData::encode(primitive.as_view(), &mut exec_ctx).unwrap();
+        let rle_array = RLEData::encode(primitive.as_view(), &mut exec_ctx)?;
         assert_eq!(rle_array.len(), 2048);
 
         let original_data = rle_array
@@ -374,10 +374,10 @@ mod tests {
             .execute::<PrimitiveArray>(&mut exec_ctx)?;
 
         let ctx = ArrayContext::empty();
-        let serialized = rle_array
-            .into_array()
-            .serialize(&ctx, &SESSION, &SerializeOptions::default())
-            .unwrap();
+        let serialized =
+            rle_array
+                .into_array()
+                .serialize(&ctx, &SESSION, &SerializeOptions::default())?;
 
         let mut concat = ByteBufferMut::empty();
         for buf in serialized {
@@ -385,15 +385,13 @@ mod tests {
         }
         let concat = concat.freeze();
 
-        let parts = SerializedArray::try_from(concat).unwrap();
-        let decoded = parts
-            .decode(
-                &DType::Primitive(PType::U32, Nullability::NonNullable),
-                2048,
-                &ReadContext::new(ctx.to_ids()),
-                &SESSION,
-            )
-            .unwrap();
+        let parts = SerializedArray::try_from(concat)?;
+        let decoded = parts.decode(
+            &DType::Primitive(PType::U32, Nullability::NonNullable),
+            2048,
+            &ReadContext::new(ctx.to_ids()),
+            &SESSION,
+        )?;
 
         let decoded_data = decoded.execute::<PrimitiveArray>(&mut exec_ctx)?;
 
@@ -405,7 +403,7 @@ mod tests {
     fn test_rle_serialization_slice() -> VortexResult<()> {
         let mut exec_ctx = SESSION.create_execution_ctx();
         let primitive = PrimitiveArray::from_iter((0..2048).map(|i| (i / 100) as u32));
-        let rle_array = RLEData::encode(primitive.as_view(), &mut exec_ctx).unwrap();
+        let rle_array = RLEData::encode(primitive.as_view(), &mut exec_ctx)?;
 
         let sliced = RLE::try_new(
             rle_array.values().clone(),
@@ -418,11 +416,11 @@ mod tests {
         assert_eq!(sliced.len(), 100);
 
         let ctx = ArrayContext::empty();
-        let serialized = sliced
-            .clone()
-            .into_array()
-            .serialize(&ctx, &SESSION, &SerializeOptions::default())
-            .unwrap();
+        let serialized =
+            sliced
+                .clone()
+                .into_array()
+                .serialize(&ctx, &SESSION, &SerializeOptions::default())?;
 
         let mut concat = ByteBufferMut::empty();
         for buf in serialized {
@@ -430,15 +428,13 @@ mod tests {
         }
         let concat = concat.freeze();
 
-        let parts = SerializedArray::try_from(concat).unwrap();
-        let decoded = parts
-            .decode(
-                sliced.dtype(),
-                sliced.len(),
-                &ReadContext::new(ctx.to_ids()),
-                &SESSION,
-            )
-            .unwrap();
+        let parts = SerializedArray::try_from(concat)?;
+        let decoded = parts.decode(
+            sliced.dtype(),
+            sliced.len(),
+            &ReadContext::new(ctx.to_ids()),
+            &SESSION,
+        )?;
 
         let original_data = sliced
             .as_array()

--- a/encodings/fastlanes/src/rle/array/rle_compress.rs
+++ b/encodings/fastlanes/src/rle/array/rle_compress.rs
@@ -178,8 +178,7 @@ mod tests {
         let encoded_u8 = RLEData::encode(
             PrimitiveArray::new(array_u8, Validity::NonNullable).as_view(),
             &mut ctx,
-        )
-        .unwrap();
+        )?;
         let decoded_u8 = encoded_u8
             .as_array()
             .clone()
@@ -192,8 +191,7 @@ mod tests {
         let encoded_u16 = RLEData::encode(
             PrimitiveArray::new(array_u16, Validity::NonNullable).as_view(),
             &mut ctx,
-        )
-        .unwrap();
+        )?;
         let decoded_u16 = encoded_u16
             .as_array()
             .clone()
@@ -206,8 +204,7 @@ mod tests {
         let encoded_u64 = RLEData::encode(
             PrimitiveArray::new(array_u64, Validity::NonNullable).as_view(),
             &mut ctx,
-        )
-        .unwrap();
+        )?;
         let decoded_u64 = encoded_u64
             .as_array()
             .clone()
@@ -251,8 +248,7 @@ mod tests {
         let encoded = RLEData::encode(
             PrimitiveArray::new(values, Validity::NonNullable).as_view(),
             &mut ctx,
-        )
-        .unwrap();
+        )?;
         assert_eq!(encoded.values().len(), 2); // 2 chunks, each storing value 42
 
         let decoded = encoded
@@ -272,8 +268,7 @@ mod tests {
         let encoded = RLEData::encode(
             PrimitiveArray::new(values, Validity::NonNullable).as_view(),
             &mut ctx,
-        )
-        .unwrap();
+        )?;
         assert_eq!(encoded.values().len(), 256);
 
         let decoded = encoded
@@ -334,17 +329,12 @@ mod tests {
             .clone()
             .into_array()
             .execute::<PrimitiveArray>(&mut ctx)?;
-        let result = RLEData::encode(primitive.as_view(), &mut ctx).unwrap();
+        let result = RLEData::encode(primitive.as_view(), &mut ctx)?;
         let decoded = result
             .as_array()
             .clone()
             .execute::<PrimitiveArray>(&mut ctx)?;
-        let expected = PrimitiveArray::new(
-            values,
-            primitive
-                .validity()
-                .vortex_expect("primitive validity should be derivable"),
-        );
+        let expected = PrimitiveArray::new(values, primitive.validity()?);
         assert_arrays_eq!(decoded, expected);
         Ok(())
     }
@@ -555,7 +545,7 @@ mod tests {
     ) -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let primitive = PrimitiveArray::from_iter(values);
-        let rle = RLEData::encode(primitive.as_view(), &mut ctx).unwrap();
+        let rle = RLEData::encode(primitive.as_view(), &mut ctx)?;
         let decoded = rle.as_array().clone().execute::<PrimitiveArray>(&mut ctx)?;
         assert_arrays_eq!(primitive, decoded);
         Ok(())

--- a/encodings/parquet-variant/src/array.rs
+++ b/encodings/parquet-variant/src/array.rs
@@ -304,6 +304,7 @@ mod tests {
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
+    use vortex_error::vortex_err;
 
     use crate::ParquetVariant;
     use crate::ParquetVariantData;
@@ -314,11 +315,11 @@ mod tests {
         let vortex_arr = ParquetVariantData::from_arrow_variant(&arrow_variant)?;
         let variant_view = vortex_arr
             .as_opt::<Variant>()
-            .ok_or_else(|| vortex_error::vortex_err!("expected variant array"))?;
+            .ok_or_else(|| vortex_err!("expected variant array"))?;
         let child = variant_view.child();
         let inner = child
             .as_opt::<ParquetVariant>()
-            .ok_or_else(|| vortex_error::vortex_err!("expected parquet variant child"))?;
+            .ok_or_else(|| vortex_err!("expected parquet variant child"))?;
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let roundtripped = inner.to_arrow(&mut ctx)?;
@@ -407,11 +408,11 @@ mod tests {
 
         let variant_arr = vortex_arr
             .as_opt::<Variant>()
-            .ok_or_else(|| vortex_error::vortex_err!("expected variant array"))?;
+            .ok_or_else(|| vortex_err!("expected variant array"))?;
         let inner = variant_arr
             .child()
             .as_opt::<ParquetVariant>()
-            .ok_or_else(|| vortex_error::vortex_err!("expected parquet variant child"))?;
+            .ok_or_else(|| vortex_err!("expected parquet variant child"))?;
         assert!(inner.typed_value_array().is_some());
 
         Ok(())

--- a/encodings/parquet-variant/src/array.rs
+++ b/encodings/parquet-variant/src/array.rs
@@ -310,11 +310,15 @@ mod tests {
     use crate::array::ParquetVariantArrayExt;
 
     fn assert_arrow_variant_storage_roundtrip(struct_array: StructArray) -> VortexResult<()> {
-        let arrow_variant = ArrowVariantArray::try_new(&struct_array).unwrap();
+        let arrow_variant = ArrowVariantArray::try_new(&struct_array)?;
         let vortex_arr = ParquetVariantData::from_arrow_variant(&arrow_variant)?;
-        let variant_view = vortex_arr.as_opt::<Variant>().unwrap();
+        let variant_view = vortex_arr
+            .as_opt::<Variant>()
+            .ok_or_else(|| vortex_error::vortex_err!("expected variant array"))?;
         let child = variant_view.child();
-        let inner = child.as_opt::<ParquetVariant>().unwrap();
+        let inner = child
+            .as_opt::<ParquetVariant>()
+            .ok_or_else(|| vortex_error::vortex_err!("expected parquet variant child"))?;
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let roundtripped = inner.to_arrow(&mut ctx)?;
@@ -390,10 +394,9 @@ mod tests {
         ]
         .into();
         let struct_array =
-            StructArray::try_new(struct_fields, vec![Arc::new(metadata), typed_value], None)
-                .unwrap();
+            StructArray::try_new(struct_fields, vec![Arc::new(metadata), typed_value], None)?;
 
-        let arrow_variant = ArrowVariantArray::try_new(&struct_array).unwrap();
+        let arrow_variant = ArrowVariantArray::try_new(&struct_array)?;
 
         let vortex_arr = ParquetVariantData::from_arrow_variant(&arrow_variant)?;
         assert_eq!(vortex_arr.len(), 3);
@@ -402,8 +405,13 @@ mod tests {
             &DType::Variant(Nullability::NonNullable)
         );
 
-        let variant_arr = vortex_arr.as_opt::<Variant>().unwrap();
-        let inner = variant_arr.child().as_opt::<ParquetVariant>().unwrap();
+        let variant_arr = vortex_arr
+            .as_opt::<Variant>()
+            .ok_or_else(|| vortex_error::vortex_err!("expected variant array"))?;
+        let inner = variant_arr
+            .child()
+            .as_opt::<ParquetVariant>()
+            .ok_or_else(|| vortex_error::vortex_err!("expected parquet variant child"))?;
         assert!(inner.typed_value_array().is_some());
 
         Ok(())
@@ -473,8 +481,7 @@ mod tests {
             .into(),
             vec![metadata, typed_value],
             None,
-        )
-        .unwrap();
+        )?;
 
         assert_arrow_variant_storage_roundtrip(struct_array)
     }
@@ -494,8 +501,7 @@ mod tests {
             .into(),
             vec![metadata, value, typed_value],
             None,
-        )
-        .unwrap();
+        )?;
 
         assert_arrow_variant_storage_roundtrip(struct_array)
     }
@@ -512,8 +518,7 @@ mod tests {
             .into(),
             vec![metadata, value],
             Some(NullBuffer::from(vec![true, false, true])),
-        )
-        .unwrap();
+        )?;
 
         assert_arrow_variant_storage_roundtrip(struct_array)
     }

--- a/encodings/parquet-variant/src/kernel.rs
+++ b/encodings/parquet-variant/src/kernel.rs
@@ -135,9 +135,8 @@ mod tests {
             inner.fields().clone(),
             inner.columns().to_vec(),
             Some(NullBuffer::from(vec![true, false, true, false])),
-        )
-        .unwrap();
-        let arrow_variant = ArrowVariantArray::try_new(&null_struct).unwrap();
+        )?;
+        let arrow_variant = ArrowVariantArray::try_new(&null_struct)?;
         ParquetVariantData::from_arrow_variant(&arrow_variant)
     }
 
@@ -306,9 +305,8 @@ mod tests {
             .into(),
             vec![metadata, typed_value],
             None,
-        )
-        .unwrap();
-        let arrow_variant = ArrowVariantArray::try_new(&struct_array).unwrap();
+        )?;
+        let arrow_variant = ArrowVariantArray::try_new(&struct_array)?;
         let arr = ParquetVariantData::from_arrow_variant(&arrow_variant)?;
 
         let sliced = arr.slice(1..3)?;

--- a/encodings/parquet-variant/src/operations.rs
+++ b/encodings/parquet-variant/src/operations.rs
@@ -384,13 +384,11 @@ mod tests {
         let vortex_arr = ParquetVariantData::from_arrow_variant(arrow_variant)?;
 
         for index in rows {
-            let expected_inner =
-                parquet_variant_to_scalar(arrow_variant.try_value(index).unwrap())?;
+            let expected_inner = parquet_variant_to_scalar(arrow_variant.try_value(index)?)?;
             let expected = Scalar::try_new(
                 vortex_arr.dtype().clone(),
                 Some(ScalarValue::Variant(Box::new(expected_inner))),
-            )
-            .unwrap();
+            )?;
             assert_eq!(
                 vortex_arr.execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())?,
                 expected
@@ -412,10 +410,9 @@ mod tests {
             inner.fields().clone(),
             inner.columns().to_vec(),
             Some(NullBuffer::from(vec![true, false, true])),
-        )
-        .unwrap();
+        )?;
 
-        let arrow_variant = ArrowVariantArray::try_new(&null_struct).unwrap();
+        let arrow_variant = ArrowVariantArray::try_new(&null_struct)?;
         let vortex_arr = ParquetVariantData::from_arrow_variant(&arrow_variant)?;
 
         assert_eq!(vortex_arr.dtype(), &DType::Variant(Nullability::Nullable));
@@ -453,10 +450,9 @@ mod tests {
             inner.fields().clone(),
             inner.columns().to_vec(),
             Some(NullBuffer::from(vec![false, false])),
-        )
-        .unwrap();
+        )?;
 
-        let arrow_variant = ArrowVariantArray::try_new(&null_struct).unwrap();
+        let arrow_variant = ArrowVariantArray::try_new(&null_struct)?;
         let vortex_arr = ParquetVariantData::from_arrow_variant(&arrow_variant)?;
 
         assert_eq!(vortex_arr.dtype(), &DType::Variant(Nullability::Nullable));
@@ -533,10 +529,9 @@ mod tests {
                 Arc::new(Int32Array::from(vec![10, 20, 30])),
             ],
             None,
-        )
-        .unwrap();
+        )?;
 
-        let arrow_variant = ArrowVariantArray::try_new(&struct_array).unwrap();
+        let arrow_variant = ArrowVariantArray::try_new(&struct_array)?;
         assert_scalar_at_matches_arrow_try_value(&arrow_variant, [0, 1, 2])
     }
 
@@ -567,10 +562,9 @@ mod tests {
             .into(),
             vec![metadata, value, typed_value],
             None,
-        )
-        .unwrap();
+        )?;
 
-        let arrow_variant = ArrowVariantArray::try_new(&struct_array).unwrap();
+        let arrow_variant = ArrowVariantArray::try_new(&struct_array)?;
         assert_scalar_at_matches_arrow_try_value(&arrow_variant, [0, 1, 2])
     }
 
@@ -583,22 +577,18 @@ mod tests {
             vec![Arc::new(Field::new("typed_value", DataType::Int32, false))].into(),
             vec![Arc::new(Int32Array::from(vec![10, 20, 30]))],
             None,
-        )
-        .unwrap();
+        )?;
 
-        let typed_value: ArrowArrayRef = Arc::new(
-            ListArray::try_new(
-                Arc::new(Field::new(
-                    "element",
-                    element_struct.data_type().clone(),
-                    false,
-                )),
-                OffsetBuffer::from_lengths([2, 1]),
-                Arc::new(element_struct),
-                None,
-            )
-            .unwrap(),
-        );
+        let typed_value: ArrowArrayRef = Arc::new(ListArray::try_new(
+            Arc::new(Field::new(
+                "element",
+                element_struct.data_type().clone(),
+                false,
+            )),
+            OffsetBuffer::from_lengths([2, 1]),
+            Arc::new(element_struct),
+            None,
+        )?);
 
         let struct_array = StructArray::try_new(
             vec![
@@ -612,10 +602,9 @@ mod tests {
             .into(),
             vec![binary_view_array(&[b"\x01\x00", b"\x01\x00"]), typed_value],
             None,
-        )
-        .unwrap();
+        )?;
 
-        let arrow_variant = ArrowVariantArray::try_new(&struct_array).unwrap();
+        let arrow_variant = ArrowVariantArray::try_new(&struct_array)?;
         let vortex_arr = ParquetVariantData::from_arrow_variant(&arrow_variant)?;
 
         let row0 = vortex_arr.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())?;
@@ -676,21 +665,17 @@ mod tests {
             vec![Arc::new(Field::new("typed_value", DataType::Int32, false))].into(),
             vec![Arc::new(Int32Array::from(vec![7]))],
             None,
-        )
-        .unwrap();
-        let typed_value: ArrowArrayRef = Arc::new(
-            StructArray::try_new(
-                vec![Arc::new(Field::new(
-                    "a",
-                    shredded_a.data_type().clone(),
-                    false,
-                ))]
-                .into(),
-                vec![Arc::new(shredded_a)],
-                None,
-            )
-            .unwrap(),
-        );
+        )?;
+        let typed_value: ArrowArrayRef = Arc::new(StructArray::try_new(
+            vec![Arc::new(Field::new(
+                "a",
+                shredded_a.data_type().clone(),
+                false,
+            ))]
+            .into(),
+            vec![Arc::new(shredded_a)],
+            None,
+        )?);
 
         let struct_array = StructArray::try_new(
             vec![
@@ -709,10 +694,9 @@ mod tests {
                 typed_value,
             ],
             None,
-        )
-        .unwrap();
+        )?;
 
-        let arrow_variant = ArrowVariantArray::try_new(&struct_array).unwrap();
+        let arrow_variant = ArrowVariantArray::try_new(&struct_array)?;
         let vortex_arr = ParquetVariantData::from_arrow_variant(&arrow_variant)?;
         let object = vortex_arr.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())?;
         let object = object.as_variant().value().unwrap().as_struct();

--- a/encodings/runend/src/arrow.rs
+++ b/encodings/runend/src/arrow.rs
@@ -157,7 +157,7 @@ mod tests {
         // Values: [10, 20, 30] means values 10, 10, 10, 20, 20, 30, 30, 30
         let run_ends = Int32Array::from(vec![3i32, 5, 8]);
         let values = Int32Array::from(vec![10, 20, 30]);
-        let arrow_run_array = RunArray::<Int32Type>::try_new(&run_ends, &values).unwrap();
+        let arrow_run_array = RunArray::<Int32Type>::try_new(&run_ends, &values)?;
 
         // Convert to Vortex
         let vortex_array = decode_run_array(&arrow_run_array, false)?;
@@ -174,7 +174,7 @@ mod tests {
         // Create an Arrow RunArray with nullable values
         let run_ends = Int32Array::from(vec![2i32, 4, 6]);
         let values = Int32Array::from(vec![Some(100), None, Some(300)]);
-        let arrow_run_array = RunArray::<Int32Type>::try_new(&run_ends, &values).unwrap();
+        let arrow_run_array = RunArray::<Int32Type>::try_new(&run_ends, &values)?;
 
         // Convert to Vortex with nullable=true
         let vortex_array = decode_run_array(&arrow_run_array, true)?;
@@ -198,7 +198,7 @@ mod tests {
         // Test with UInt64 run ends and Float64 values
         let run_ends = Int64Array::from(vec![1i64, 3, 4]);
         let values = Float64Array::from(vec![1.5, 2.5, 3.5]);
-        let arrow_run_array = RunArray::<Int64Type>::try_new(&run_ends, &values).unwrap();
+        let arrow_run_array = RunArray::<Int64Type>::try_new(&run_ends, &values)?;
 
         // Convert to Vortex
         let vortex_array = decode_run_array(&arrow_run_array, false)?;
@@ -214,7 +214,7 @@ mod tests {
         // Values: [100, 200, 300, 400] means: 100, 100, 200, 200, 200, 300, 300, 300, 400, 400
         let run_ends = Int32Array::from(vec![2i32, 5, 8, 10]);
         let values = Int32Array::from(vec![100, 200, 300, 400]);
-        let arrow_run_array = RunArray::<Int32Type>::try_new(&run_ends, &values).unwrap();
+        let arrow_run_array = RunArray::<Int32Type>::try_new(&run_ends, &values)?;
 
         // Slice the array from index 1 to 7 (length 6)
         // This should give us: 100, 200, 200, 200, 300, 300
@@ -236,7 +236,7 @@ mod tests {
         // Values: [Some(10), None, Some(30), Some(40)]
         let run_ends = Int64Array::from(vec![3i64, 6, 9, 12]);
         let values = Int64Array::from(vec![Some(10), None, Some(30), Some(40)]);
-        let arrow_run_array = RunArray::<Int64Type>::try_new(&run_ends, &values).unwrap();
+        let arrow_run_array = RunArray::<Int64Type>::try_new(&run_ends, &values)?;
 
         // Slice from index 4 to 10 (length 6)
         // Original: 10, 10, 10, null, null, null, 30, 30, 30, 40, 40, 40
@@ -267,7 +267,7 @@ mod tests {
         // Values: [Some(10), None, Some(30), Some(40)]
         let run_ends = Int64Array::from(vec![3i64, 6, 9, 12]);
         let values = Int64Array::from(vec![Some(10), None, Some(30), Some(40)]);
-        let arrow_run_array = RunArray::<Int64Type>::try_new(&run_ends, &values).unwrap();
+        let arrow_run_array = RunArray::<Int64Type>::try_new(&run_ends, &values)?;
 
         // Slice from index 4 to 4 (length 0)
         // Original: 10, 10, 10, null, null, null, 30, 30, 30, 40, 40, 40

--- a/encodings/runend/src/compute/filter.rs
+++ b/encodings/runend/src/compute/filter.rs
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn filter_sliced_run_end() -> VortexResult<()> {
-        let arr = ree_array().slice(2..7).unwrap();
+        let arr = ree_array().slice(2..7)?;
         let filtered = arr.filter(Mask::from_iter([true, false, false, true, true]))?;
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();

--- a/encodings/runend/src/decompress_bool.rs
+++ b/encodings/runend/src/decompress_bool.rs
@@ -390,8 +390,7 @@ mod tests {
             decoded
                 .as_ref()
                 .validity()?
-                .execute_mask(decoded.as_ref().len(), &mut ctx)
-                .unwrap()
+                .execute_mask(decoded.as_ref().len(), &mut ctx)?
                 .value(0)
         );
         assert!(decoded.to_bit_buffer().value(0));
@@ -400,8 +399,7 @@ mod tests {
             !decoded
                 .as_ref()
                 .validity()?
-                .execute_mask(decoded.as_ref().len(), &mut ctx)
-                .unwrap()
+                .execute_mask(decoded.as_ref().len(), &mut ctx)?
                 .value(2000)
         );
         // Third run: valid true
@@ -409,8 +407,7 @@ mod tests {
             decoded
                 .as_ref()
                 .validity()?
-                .execute_mask(decoded.as_ref().len(), &mut ctx)
-                .unwrap()
+                .execute_mask(decoded.as_ref().len(), &mut ctx)?
                 .value(4000)
         );
         assert!(decoded.to_bit_buffer().value(4000));

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -1082,9 +1082,7 @@ mod test {
 
         let indices = buffer![0u8, 3u8, 4u8, 5u8].into_array();
         let fill_value = Scalar::null(lists.dtype().clone());
-        let sparse = Sparse::try_new(indices, lists, 6, fill_value)
-            .unwrap()
-            .into_array();
+        let sparse = Sparse::try_new(indices, lists, 6, fill_value)?.into_array();
 
         let actual = sparse.execute::<Canonical>(&mut ctx)?.into_array();
         let result_listview = actual.execute::<ListViewArray>(&mut ctx)?;
@@ -1193,9 +1191,7 @@ mod test {
 
         let indices = buffer![0u8, 3u8, 4u8, 5u8].into_array();
         let fill_value = Scalar::from(Some(vec![5i32, 6, 7, 8]));
-        let sparse = Sparse::try_new(indices, lists, 6, fill_value)
-            .unwrap()
-            .into_array();
+        let sparse = Sparse::try_new(indices, lists, 6, fill_value)?.into_array();
 
         let actual = sparse.execute::<Canonical>(&mut ctx)?.into_array();
         let result_listview = actual.execute::<ListViewArray>(&mut ctx)?;
@@ -1303,9 +1299,7 @@ mod test {
     fn test_sparse_fixed_size_list_null_fill() -> VortexResult<()> {
         // Create a FixedSizeListArray with 3 lists of size 3.
         let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
-        let fsl = FixedSizeListArray::try_new(elements, 3, Validity::AllValid, 3)
-            .unwrap()
-            .into_array();
+        let fsl = FixedSizeListArray::try_new(elements, 3, Validity::AllValid, 3)?.into_array();
 
         let indices = buffer![0u8, 2u8, 3u8].into_array();
         let fill_value = Scalar::null(DType::FixedSizeList(
@@ -1313,9 +1307,7 @@ mod test {
             3,
             Nullable,
         ));
-        let sparse = Sparse::try_new(indices, fsl, 5, fill_value)
-            .unwrap()
-            .into_array();
+        let sparse = Sparse::try_new(indices, fsl, 5, fill_value)?.into_array();
 
         let actual = sparse
             .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
@@ -1329,8 +1321,7 @@ mod test {
             3,
             Validity::Array(BoolArray::from_iter([true, false, true, true, false]).into_array()),
             5,
-        )
-        .unwrap()
+        )?
         .into_array();
 
         assert_arrays_eq!(actual, expected);
@@ -1340,9 +1331,7 @@ mod test {
     #[test]
     fn test_sparse_fixed_size_list_non_null_fill() -> VortexResult<()> {
         let elements = buffer![1i32, 2, 3, 4, 5, 6].into_array();
-        let fsl = FixedSizeListArray::try_new(elements, 2, Validity::AllValid, 3)
-            .unwrap()
-            .into_array();
+        let fsl = FixedSizeListArray::try_new(elements, 2, Validity::AllValid, 3)?.into_array();
 
         let indices = buffer![0u8, 2u8, 4u8].into_array();
         let fill_value = Scalar::fixed_size_list(
@@ -1353,9 +1342,7 @@ mod test {
             ],
             NonNullable,
         );
-        let sparse = Sparse::try_new(indices, fsl, 6, fill_value)
-            .unwrap()
-            .into_array();
+        let sparse = Sparse::try_new(indices, fsl, 6, fill_value)?.into_array();
 
         let actual = sparse
             .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
@@ -1363,8 +1350,7 @@ mod test {
 
         // Expected: [1,2], [99,88], [3,4], [99,88], [5,6], [99,88].
         let expected_elements = buffer![1i32, 2, 99, 88, 3, 4, 99, 88, 5, 6, 99, 88].into_array();
-        let expected = FixedSizeListArray::try_new(expected_elements, 2, Validity::NonNullable, 6)
-            .unwrap()
+        let expected = FixedSizeListArray::try_new(expected_elements, 2, Validity::NonNullable, 6)?
             .into_array();
 
         assert_arrays_eq!(actual, expected);
@@ -1380,8 +1366,7 @@ mod test {
             2,
             Validity::Array(BoolArray::from_iter([true, false, true]).into_array()),
             3,
-        )
-        .unwrap()
+        )?
         .into_array();
 
         let indices = buffer![1u16, 3u16, 4u16].into_array();
@@ -1393,9 +1378,7 @@ mod test {
             ],
             Nullable,
         );
-        let sparse = Sparse::try_new(indices, fsl, 6, fill_value)
-            .unwrap()
-            .into_array();
+        let sparse = Sparse::try_new(indices, fsl, 6, fill_value)?.into_array();
 
         let actual = sparse
             .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
@@ -1411,8 +1394,7 @@ mod test {
                 BoolArray::from_iter([true, true, true, false, true, true]).into_array(),
             ),
             6,
-        )
-        .unwrap()
+        )?
         .into_array();
 
         assert_arrays_eq!(actual, expected);
@@ -1426,9 +1408,7 @@ mod test {
 
         // Create patch values: only 3 distinct lists out of 100 total positions.
         let elements = buffer![10i32, 11, 20, 21, 30, 31].into_array();
-        let fsl = FixedSizeListArray::try_new(elements, 2, Validity::AllValid, 3)
-            .unwrap()
-            .into_array();
+        let fsl = FixedSizeListArray::try_new(elements, 2, Validity::AllValid, 3)?.into_array();
 
         // Patches at positions 5, 50, and 95 out of 100.
         let indices = buffer![5u32, 50, 95].into_array();
@@ -1443,9 +1423,7 @@ mod test {
             NonNullable,
         );
 
-        let sparse = Sparse::try_new(indices, fsl, 100, fill_value)
-            .unwrap()
-            .into_array();
+        let sparse = Sparse::try_new(indices, fsl, 100, fill_value)?.into_array();
 
         let actual = sparse
             .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
@@ -1477,8 +1455,7 @@ mod test {
         }
         let expected_elements = PrimitiveArray::from_iter(expected_elements_vec).into_array();
         let expected =
-            FixedSizeListArray::try_new(expected_elements, 2, Validity::NonNullable, 100)
-                .unwrap()
+            FixedSizeListArray::try_new(expected_elements, 2, Validity::NonNullable, 100)?
                 .into_array();
 
         assert_arrays_eq!(actual, expected);
@@ -1489,9 +1466,7 @@ mod test {
     fn test_sparse_fixed_size_list_single_element() -> VortexResult<()> {
         // Test with a single element FSL array.
         let elements = buffer![42i32, 43].into_array();
-        let fsl = FixedSizeListArray::try_new(elements, 2, Validity::AllValid, 1)
-            .unwrap()
-            .into_array();
+        let fsl = FixedSizeListArray::try_new(elements, 2, Validity::AllValid, 1)?.into_array();
 
         let indices = buffer![0u32].into_array();
         let fill_value = Scalar::fixed_size_list(
@@ -1502,9 +1477,7 @@ mod test {
             ],
             NonNullable,
         );
-        let sparse = Sparse::try_new(indices, fsl, 1, fill_value)
-            .unwrap()
-            .into_array();
+        let sparse = Sparse::try_new(indices, fsl, 1, fill_value)?.into_array();
 
         let actual = sparse
             .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
@@ -1512,8 +1485,7 @@ mod test {
 
         // Expected: just [42, 43].
         let expected_elements = buffer![42i32, 43].into_array();
-        let expected = FixedSizeListArray::try_new(expected_elements, 2, Validity::NonNullable, 1)
-            .unwrap()
+        let expected = FixedSizeListArray::try_new(expected_elements, 2, Validity::NonNullable, 1)?
             .into_array();
 
         assert_arrays_eq!(actual, expected);
@@ -1525,15 +1497,11 @@ mod test {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let elements = buffer![1i32, 2, 1, 2].into_array();
         let offsets = buffer![0u8, 1, 2, 3, 4].into_array();
-        let lists = ListArray::try_new(elements, offsets, Validity::AllValid)
-            .unwrap()
-            .into_array();
+        let lists = ListArray::try_new(elements, offsets, Validity::AllValid)?.into_array();
 
         let indices = buffer![0u8, 1u8, 2u8, 3u8].into_array();
         let fill_value = Scalar::from(Some(vec![42i32; 252])); // 252 + 4 elements = 256 > u8::MAX
-        let sparse = Sparse::try_new(indices, lists, 5, fill_value)
-            .unwrap()
-            .into_array();
+        let sparse = Sparse::try_new(indices, lists, 5, fill_value)?.into_array();
 
         let actual = sparse.execute::<Canonical>(&mut ctx)?.into_array();
         let mut expected_elements = buffer_mut![1, 2, 1, 2];
@@ -1542,8 +1510,7 @@ mod test {
             expected_elements.freeze().into_array(),
             buffer![0u16, 1, 2, 3, 4, 256].into_array(),
             Validity::AllValid,
-        )
-        .unwrap()
+        )?
         .into_array();
 
         let actual_listview = actual.clone().execute::<ListViewArray>(&mut ctx)?;
@@ -1554,11 +1521,9 @@ mod test {
         assert_arrays_eq!(&actual, &expected);
 
         // Note that the preferred arrow list representation is `List` (not `ListView`).
-        let arrow_dtype = expected.dtype().to_arrow_dtype().unwrap();
-        let actual = actual.execute_arrow(Some(&arrow_dtype), &mut ctx).unwrap();
-        let expected = expected
-            .execute_arrow(Some(&arrow_dtype), &mut ctx)
-            .unwrap();
+        let arrow_dtype = expected.dtype().to_arrow_dtype()?;
+        let actual = actual.execute_arrow(Some(&arrow_dtype), &mut ctx)?;
+        let expected = expected.execute_arrow(Some(&arrow_dtype), &mut ctx)?;
 
         assert_eq!(actual.data_type(), expected.data_type());
         Ok(())
@@ -1602,8 +1567,7 @@ mod test {
             list_view.into_array(),
             10,
             Scalar::null(list_dtype),
-        )
-        .unwrap();
+        )?;
 
         // Convert to canonical form - this triggers the function we're testing
         let canonical = sparse
@@ -1677,7 +1641,7 @@ mod test {
         // - Index 0: [2, 3, 4] (original list 1)
         // - Index 1: [5] (original list 2)
         // - Index 2: [6, 7] (original list 3)
-        let sliced = full_listview.slice(1..4).unwrap();
+        let sliced = full_listview.slice(1..4)?;
 
         // Create sparse array with indices [0, 1] and length 5
         // Expected result:
@@ -1688,9 +1652,8 @@ mod test {
         // - Index 4: null
         let indices = buffer![0u8, 1].into_array();
         // Extract only the values we need from the sliced array
-        let values = sliced.slice(0..2).unwrap();
-        let sparse =
-            Sparse::try_new(indices, values, 5, Scalar::null(sliced.dtype().clone())).unwrap();
+        let values = sliced.slice(0..2)?;
+        let sparse = Sparse::try_new(indices, values, 5, Scalar::null(sliced.dtype().clone()))?;
 
         let canonical = sparse
             .into_array()

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -300,13 +300,10 @@ mod test {
             array.statistics().compute_is_constant(&mut ctx)
         );
 
-        let sliced = zigzag.slice(0..2).unwrap();
+        let sliced = zigzag.slice(0..2)?;
         let sliced = sliced.as_::<ZigZag>();
         assert_eq!(
-            sliced
-                .array()
-                .execute_scalar(sliced.len() - 1, &mut ctx,)
-                .unwrap(),
+            sliced.array().execute_scalar(sliced.len() - 1, &mut ctx,)?,
             Scalar::from(-5i32)
         );
 

--- a/encodings/zigzag/src/compute/mod.rs
+++ b/encodings/zigzag/src/compute/mod.rs
@@ -108,7 +108,7 @@ mod tests {
         )?;
 
         let indices = buffer![0, 2].into_array();
-        let actual = zigzag.take(indices).unwrap();
+        let actual = zigzag.take(indices)?;
         let expected =
             zigzag_encode(PrimitiveArray::new(buffer![-189, 1], Validity::AllValid).as_view())?
                 .into_array();
@@ -123,7 +123,7 @@ mod tests {
         )?;
 
         let filter_mask = BitBuffer::from(vec![true, false, true]).into();
-        let actual = zigzag.filter(filter_mask).unwrap();
+        let actual = zigzag.filter(filter_mask)?;
         let expected =
             zigzag_encode(PrimitiveArray::new(buffer![-189, 1], Validity::AllValid).as_view())?
                 .into_array();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.91.0"
 components = ["rust-src", "rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/vortex-array/src/aggregate_fn/fns/is_sorted/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/is_sorted/mod.rs
@@ -662,10 +662,8 @@ mod tests {
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DecimalDType::new(19, 2);
-        let i100 =
-            parse_decimal::<Decimal128Type>("100.00", dtype.precision(), dtype.scale()).unwrap();
-        let i200 =
-            parse_decimal::<Decimal128Type>("200.00", dtype.precision(), dtype.scale()).unwrap();
+        let i100 = parse_decimal::<Decimal128Type>("100.00", dtype.precision(), dtype.scale())?;
+        let i200 = parse_decimal::<Decimal128Type>("200.00", dtype.precision(), dtype.scale())?;
 
         let sorted = buffer![i100, i200, i200];
         let unsorted = buffer![i200, i100, i200];
@@ -689,12 +687,9 @@ mod tests {
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DecimalDType::new(19, 2);
-        let i100 =
-            parse_decimal::<Decimal128Type>("100.00", dtype.precision(), dtype.scale()).unwrap();
-        let i200 =
-            parse_decimal::<Decimal128Type>("200.00", dtype.precision(), dtype.scale()).unwrap();
-        let i300 =
-            parse_decimal::<Decimal128Type>("300.00", dtype.precision(), dtype.scale()).unwrap();
+        let i100 = parse_decimal::<Decimal128Type>("100.00", dtype.precision(), dtype.scale())?;
+        let i200 = parse_decimal::<Decimal128Type>("200.00", dtype.precision(), dtype.scale())?;
+        let i300 = parse_decimal::<Decimal128Type>("300.00", dtype.precision(), dtype.scale())?;
 
         let strict_sorted = buffer![i100, i200, i300];
         let sorted = buffer![i100, i200, i200];

--- a/vortex-array/src/arrays/chunked/array.rs
+++ b/vortex-array/src/arrays/chunked/array.rs
@@ -361,16 +361,11 @@ mod test {
             ChunkedArray::try_new(chunks, DType::Primitive(PType::U64, Nullability::Nullable))?;
 
         // Should be all_valid since all non-empty chunks are all_valid
-        assert!(
-            chunked
-                .all_valid(&mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
+        assert!(chunked.all_valid(&mut LEGACY_SESSION.create_execution_ctx())?);
         assert!(
             !chunked
                 .into_array()
-                .all_invalid(&mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
+                .all_invalid(&mut LEGACY_SESSION.create_execution_ctx())?
         );
 
         Ok(())
@@ -390,16 +385,11 @@ mod test {
             ChunkedArray::try_new(chunks, DType::Primitive(PType::U64, Nullability::Nullable))?;
 
         // Should be all_invalid since all non-empty chunks are all_invalid
-        assert!(
-            !chunked
-                .all_valid(&mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
+        assert!(!chunked.all_valid(&mut LEGACY_SESSION.create_execution_ctx())?);
         assert!(
             chunked
                 .into_array()
-                .all_invalid(&mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
+                .all_invalid(&mut LEGACY_SESSION.create_execution_ctx())?
         );
 
         Ok(())
@@ -419,16 +409,11 @@ mod test {
             ChunkedArray::try_new(chunks, DType::Primitive(PType::U64, Nullability::Nullable))?;
 
         // Should be neither all_valid nor all_invalid
-        assert!(
-            !chunked
-                .all_valid(&mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
+        assert!(!chunked.all_valid(&mut LEGACY_SESSION.create_execution_ctx())?);
         assert!(
             !chunked
                 .into_array()
-                .all_invalid(&mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
+                .all_invalid(&mut LEGACY_SESSION.create_execution_ctx())?
         );
 
         Ok(())

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -383,13 +383,10 @@ mod tests {
     fn test_canonicalize_propagates_stats() -> VortexResult<()> {
         let scalar = Scalar::bool(true, Nullability::NonNullable);
         let const_array = ConstantArray::new(scalar, 4).into_array();
-        let stats = const_array
-            .statistics()
-            .compute_all(
-                &all::<Stat>().collect_vec(),
-                &mut LEGACY_SESSION.create_execution_ctx(),
-            )
-            .unwrap();
+        let stats = const_array.statistics().compute_all(
+            &all::<Stat>().collect_vec(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         #[expect(deprecated)]
         let canonical = const_array.to_canonical()?.into_array();
         let canonical_stats = canonical.statistics();

--- a/vortex-array/src/arrays/dict/compute/min_max.rs
+++ b/vortex-array/src/arrays/dict/compute/min_max.rs
@@ -92,42 +92,73 @@ mod tests {
         Ok(())
     }
 
-    #[rstest]
-    #[case::covering(
+    fn dict_covering() -> DictArray {
         DictArray::try_new(
             buffer![0u32, 1, 2, 3, 0, 1].into_array(),
             buffer![10i32, 20, 30, 40].into_array(),
-        ).unwrap(),
-        (10, 40)
-    )]
-    #[case::non_covering_duplicates(
+        )
+        .expect("valid test dictionary")
+    }
+
+    fn dict_non_covering_duplicates() -> DictArray {
         DictArray::try_new(
             buffer![1u32, 1, 1, 3, 3].into_array(),
             buffer![1i32, 2, 3, 4, 5].into_array(),
-        ).unwrap(),
-        (2, 4)
-    )]
-    #[case::non_covering_gaps(
+        )
+        .expect("valid test dictionary")
+    }
+
+    fn dict_non_covering_gaps() -> DictArray {
         DictArray::try_new(
             buffer![0u32, 2, 4].into_array(),
             buffer![1i32, 2, 3, 4, 5].into_array(),
-        ).unwrap(),
-        (1, 5)
-    )]
-    #[case::single(dict_encode(&buffer![42i32].into_array()).unwrap(), (42, 42))]
-    #[case::nullable_codes(
+        )
+        .expect("valid test dictionary")
+    }
+
+    fn dict_single() -> DictArray {
+        dict_encode(&buffer![42i32].into_array()).expect("valid single-value dictionary")
+    }
+
+    fn dict_nullable_codes() -> DictArray {
         DictArray::try_new(
             PrimitiveArray::from_option_iter([Some(0u32), None, Some(1), Some(2)]).into_array(),
             buffer![10i32, 20, 30].into_array(),
-        ).unwrap(),
-        (10, 30)
-    )]
-    #[case::nullable_values(
+        )
+        .expect("valid nullable-code dictionary")
+    }
+
+    fn dict_nullable_values() -> DictArray {
         dict_encode(
-            &PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).into_array()
-        ).unwrap(),
-        (1, 2)
-    )]
+            &PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None])
+                .into_array(),
+        )
+        .expect("valid nullable-value dictionary")
+    }
+
+    fn dict_empty() -> DictArray {
+        DictArray::try_new(
+            PrimitiveArray::from_iter(Vec::<u32>::new()).into_array(),
+            buffer![10i32, 20, 30].into_array(),
+        )
+        .expect("valid empty dictionary")
+    }
+
+    fn dict_all_null_codes() -> DictArray {
+        DictArray::try_new(
+            PrimitiveArray::from_option_iter([Option::<u32>::None, None, None]).into_array(),
+            buffer![10i32, 20, 30].into_array(),
+        )
+        .expect("valid all-null-code dictionary")
+    }
+
+    #[rstest]
+    #[case::covering(dict_covering(), (10, 40))]
+    #[case::non_covering_duplicates(dict_non_covering_duplicates(), (2, 4))]
+    #[case::non_covering_gaps(dict_non_covering_gaps(), (1, 5))]
+    #[case::single(dict_single(), (42, 42))]
+    #[case::nullable_codes(dict_nullable_codes(), (10, 30))]
+    #[case::nullable_values(dict_nullable_values(), (1, 2))]
     fn test_min_max(#[case] dict: DictArray, #[case] expected: (i32, i32)) -> VortexResult<()> {
         assert_min_max(&dict.into_array(), Some(expected))
     }
@@ -141,18 +172,8 @@ mod tests {
     }
 
     #[rstest]
-    #[case::empty(
-        DictArray::try_new(
-            PrimitiveArray::from_iter(Vec::<u32>::new()).into_array(),
-            buffer![10i32, 20, 30].into_array(),
-        ).unwrap()
-    )]
-    #[case::all_null_codes(
-        DictArray::try_new(
-            PrimitiveArray::from_option_iter([Option::<u32>::None, None, None]).into_array(),
-            buffer![10i32, 20, 30].into_array(),
-        ).unwrap()
-    )]
+    #[case::empty(dict_empty())]
+    #[case::all_null_codes(dict_all_null_codes())]
     fn test_min_max_none(#[case] dict: DictArray) -> VortexResult<()> {
         assert_min_max(&dict.into_array(), None)
     }

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -421,12 +421,12 @@ mod tests {
 
         // Verify the data is correct
         assert_arrays_eq!(
-            flattened.list_elements_at(0).unwrap(),
+            flattened.list_elements_at(0)?,
             PrimitiveArray::from_iter([1i32, 2, 3])
         );
 
         assert_arrays_eq!(
-            flattened.list_elements_at(1).unwrap(),
+            flattened.list_elements_at(1)?,
             PrimitiveArray::from_iter([2i32, 3])
         );
         Ok(())
@@ -454,18 +454,18 @@ mod tests {
 
         // Verify nullability is preserved
         assert_eq!(flattened.dtype().nullability(), Nullability::Nullable);
-        assert!(flattened.validity()?.is_valid(0).unwrap());
-        assert!(!flattened.validity()?.is_valid(1).unwrap());
-        assert!(flattened.validity()?.is_valid(2).unwrap());
+        assert!(flattened.validity()?.is_valid(0)?);
+        assert!(!flattened.validity()?.is_valid(1)?);
+        assert!(flattened.validity()?.is_valid(2)?);
 
         // Verify valid lists contain correct data
         assert_arrays_eq!(
-            flattened.list_elements_at(0).unwrap(),
+            flattened.list_elements_at(0)?,
             PrimitiveArray::from_iter([1i32, 2])
         );
 
         assert_arrays_eq!(
-            flattened.list_elements_at(2).unwrap(),
+            flattened.list_elements_at(2)?,
             PrimitiveArray::from_iter([3i32])
         );
         Ok(())
@@ -500,12 +500,12 @@ mod tests {
 
         // Verify the data is correct.
         assert_arrays_eq!(
-            trimmed.list_elements_at(0).unwrap(),
+            trimmed.list_elements_at(0)?,
             PrimitiveArray::from_iter([1i32, 2])
         );
 
         assert_arrays_eq!(
-            trimmed.list_elements_at(1).unwrap(),
+            trimmed.list_elements_at(1)?,
             PrimitiveArray::from_iter([3i32, 4])
         );
 
@@ -513,9 +513,7 @@ mod tests {
         #[expect(deprecated)]
         let all_elements = trimmed.elements().to_primitive();
         assert_eq!(
-            all_elements
-                .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap(),
+            all_elements.execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())?,
             97i32.into()
         );
         Ok(())
@@ -557,35 +555,19 @@ mod tests {
         let exact = rebuilt.rebuild(ListViewRebuildMode::MakeExact)?;
 
         // Verify the result is still valid
-        assert!(
-            exact
-                .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
-        assert!(
-            exact
-                .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
-        assert!(
-            !exact
-                .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
-        assert!(
-            !exact
-                .is_valid(3, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
+        assert!(exact.is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())?);
+        assert!(exact.is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())?);
+        assert!(!exact.is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())?);
+        assert!(!exact.is_valid(3, &mut LEGACY_SESSION.create_execution_ctx())?);
 
         // Verify data is preserved
         assert_arrays_eq!(
-            exact.list_elements_at(0).unwrap(),
+            exact.list_elements_at(0)?,
             PrimitiveArray::from_iter([1i32, 2])
         );
 
         assert_arrays_eq!(
-            exact.list_elements_at(1).unwrap(),
+            exact.list_elements_at(1)?,
             PrimitiveArray::from_iter([3i32, 4])
         );
         Ok(())
@@ -607,7 +589,7 @@ mod tests {
         let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable);
         let trimmed = listview.rebuild(ListViewRebuildMode::TrimElements)?;
         assert_arrays_eq!(
-            trimmed.list_elements_at(1).unwrap(),
+            trimmed.list_elements_at(1)?,
             PrimitiveArray::from_iter([30i32, 40])
         );
         Ok(())
@@ -627,7 +609,7 @@ mod tests {
         let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable);
         let trimmed = listview.rebuild(ListViewRebuildMode::TrimElements)?;
         assert_arrays_eq!(
-            trimmed.list_elements_at(1).unwrap(),
+            trimmed.list_elements_at(1)?,
             PrimitiveArray::from_iter([30i32, 40])
         );
         Ok(())

--- a/vortex-array/src/arrays/listview/tests/basic.rs
+++ b/vortex-array/src/arrays/listview/tests/basic.rs
@@ -127,7 +127,7 @@ fn test_from_list_array() -> VortexResult<()> {
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7].into_array();
     let validity = Validity::from_iter([true, false, true]);
 
-    let list_array = ListArray::try_new(elements, offsets, validity).unwrap();
+    let list_array = ListArray::try_new(elements, offsets, validity)?;
     let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let list_view = list_view_from_list(list_array, &mut ctx)?;
 
@@ -135,26 +135,14 @@ fn test_from_list_array() -> VortexResult<()> {
 
     // Check first list.
     assert_arrays_eq!(
-        list_view.list_elements_at(0).unwrap(),
+        list_view.list_elements_at(0)?,
         PrimitiveArray::from_iter([1i32, 2])
     );
 
     // Check validity is preserved.
-    assert!(
-        list_view
-            .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap()
-    );
-    assert!(
-        list_view
-            .is_invalid(1, &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap()
-    );
-    assert!(
-        list_view
-            .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap()
-    );
+    assert!(list_view.is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())?);
+    assert!(list_view.is_invalid(1, &mut LEGACY_SESSION.create_execution_ctx())?);
+    assert!(list_view.is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())?);
 
     // Check third list.
     assert_arrays_eq!(

--- a/vortex-array/src/arrays/masked/tests.rs
+++ b/vortex-array/src/arrays/masked/tests.rs
@@ -46,7 +46,7 @@ fn test_dtype_nullability_with_nullable_child() {
 fn test_canonical_dtype_matches_array_dtype() -> VortexResult<()> {
     // The canonical form should have the same nullability as the array's dtype.
     let child = PrimitiveArray::from_iter([1i32, 2, 3]).into_array();
-    let array = MaskedArray::try_new(child, Validity::AllValid).unwrap();
+    let array = MaskedArray::try_new(child, Validity::AllValid)?;
 
     let canonical = array
         .clone()

--- a/vortex-array/src/arrays/masked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/masked/vtable/canonical.rs
@@ -15,21 +15,25 @@ mod tests {
     use crate::dtype::Nullability;
     use crate::validity::Validity;
 
+    fn masked_all_valid() -> MaskedArray {
+        MaskedArray::try_new(
+            PrimitiveArray::from_iter([1i32, 2, 3]).into_array(),
+            Validity::AllValid,
+        )
+        .expect("valid masked array")
+    }
+
+    fn masked_with_nulls() -> MaskedArray {
+        MaskedArray::try_new(
+            PrimitiveArray::from_iter([1i32, 2, 3]).into_array(),
+            Validity::from_iter([true, false, true]),
+        )
+        .expect("valid masked array")
+    }
+
     #[rstest]
-    #[case(
-        MaskedArray::try_new(
-            PrimitiveArray::from_iter([1i32, 2, 3]).into_array(),
-            Validity::AllValid
-        ).unwrap(),
-        Nullability::Nullable
-    )]
-    #[case(
-        MaskedArray::try_new(
-            PrimitiveArray::from_iter([1i32, 2, 3]).into_array(),
-            Validity::from_iter([true, false, true])
-        ).unwrap(),
-        Nullability::Nullable
-    )]
+    #[case(masked_all_valid(), Nullability::Nullable)]
+    #[case(masked_with_nulls(), Nullability::Nullable)]
     fn test_canonical_nullability(
         #[case] array: MaskedArray,
         #[case] expected_nullability: Nullability,
@@ -48,8 +52,7 @@ mod tests {
         let array = MaskedArray::try_new(
             PrimitiveArray::from_iter([1i32, 2, 3, 4, 5]).into_array(),
             Validity::from_iter([true, false, true, false, true]),
-        )
-        .unwrap();
+        )?;
 
         let canonical = array
             .into_array()
@@ -58,29 +61,12 @@ mod tests {
 
         // Check that null positions match validity.
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        assert_eq!(prim.valid_count(&mut ctx).unwrap(), 3);
-        assert!(
-            prim.is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
-        assert!(
-            !prim
-                .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
-        assert!(
-            prim.is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
-        assert!(
-            !prim
-                .is_valid(3, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
-        assert!(
-            prim.is_valid(4, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
+        assert_eq!(prim.valid_count(&mut ctx)?, 3);
+        assert!(prim.is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())?);
+        assert!(!prim.is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())?);
+        assert!(prim.is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())?);
+        assert!(!prim.is_valid(3, &mut LEGACY_SESSION.create_execution_ctx())?);
+        assert!(prim.is_valid(4, &mut LEGACY_SESSION.create_execution_ctx())?);
         Ok(())
     }
 
@@ -89,8 +75,7 @@ mod tests {
         let array = MaskedArray::try_new(
             PrimitiveArray::from_iter([10i32, 20, 30]).into_array(),
             Validity::AllValid,
-        )
-        .unwrap();
+        )?;
 
         let canonical = array
             .into_array()
@@ -99,8 +84,7 @@ mod tests {
         assert_eq!(
             canonical
                 .into_array()
-                .valid_count(&mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap(),
+                .valid_count(&mut LEGACY_SESSION.create_execution_ctx())?,
             3
         );
         Ok(())

--- a/vortex-array/src/arrays/patched/compute/compare.rs
+++ b/vortex-array/src/arrays/patched/compute/compare.rs
@@ -160,6 +160,7 @@ impl<V: NativePType> ApplyPatches<'_, V> {
 mod tests {
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
+    use vortex_error::vortex_err;
 
     use crate::ExecutionCtx;
     use crate::IntoArray;
@@ -261,7 +262,7 @@ mod tests {
         let lhs = Patched::from_array_and_patches(lhs, &patches, &mut ctx)?
             .into_array()
             .try_downcast::<Patched>()
-            .map_err(|_| vortex_error::vortex_err!("expected patched array"))?;
+            .map_err(|_| vortex_err!("expected patched array"))?;
 
         let rhs = ConstantArray::new(subnormal, 512).into_array();
 
@@ -271,7 +272,7 @@ mod tests {
             CompareOperator::Eq,
             &mut ctx,
         )?
-        .ok_or_else(|| vortex_error::vortex_err!("expected compare result"))?;
+        .ok_or_else(|| vortex_err!("expected compare result"))?;
 
         let expected = BoolArray::from_indices(512, [510], Validity::NonNullable).into_array();
 
@@ -295,7 +296,7 @@ mod tests {
         let lhs = Patched::from_array_and_patches(lhs, &patches, &mut ctx)?
             .into_array()
             .try_downcast::<Patched>()
-            .map_err(|_| vortex_error::vortex_err!("expected patched array"))?;
+            .map_err(|_| vortex_err!("expected patched array"))?;
 
         let rhs = ConstantArray::new(0.0f32, 10).into_array();
 
@@ -305,7 +306,7 @@ mod tests {
             CompareOperator::Eq,
             &mut ctx,
         )?
-        .ok_or_else(|| vortex_error::vortex_err!("expected compare result"))?;
+        .ok_or_else(|| vortex_err!("expected compare result"))?;
 
         let expected = BoolArray::from_indices(10, [7], Validity::NonNullable).into_array();
 

--- a/vortex-array/src/arrays/patched/compute/compare.rs
+++ b/vortex-array/src/arrays/patched/compute/compare.rs
@@ -261,7 +261,7 @@ mod tests {
         let lhs = Patched::from_array_and_patches(lhs, &patches, &mut ctx)?
             .into_array()
             .try_downcast::<Patched>()
-            .unwrap();
+            .map_err(|_| vortex_error::vortex_err!("expected patched array"))?;
 
         let rhs = ConstantArray::new(subnormal, 512).into_array();
 
@@ -271,7 +271,7 @@ mod tests {
             CompareOperator::Eq,
             &mut ctx,
         )?
-        .unwrap();
+        .ok_or_else(|| vortex_error::vortex_err!("expected compare result"))?;
 
         let expected = BoolArray::from_indices(512, [510], Validity::NonNullable).into_array();
 
@@ -295,7 +295,7 @@ mod tests {
         let lhs = Patched::from_array_and_patches(lhs, &patches, &mut ctx)?
             .into_array()
             .try_downcast::<Patched>()
-            .unwrap();
+            .map_err(|_| vortex_error::vortex_err!("expected patched array"))?;
 
         let rhs = ConstantArray::new(0.0f32, 10).into_array();
 
@@ -305,7 +305,7 @@ mod tests {
             CompareOperator::Eq,
             &mut ctx,
         )?
-        .unwrap();
+        .ok_or_else(|| vortex_error::vortex_err!("expected compare result"))?;
 
         let expected = BoolArray::from_indices(10, [7], Validity::NonNullable).into_array();
 

--- a/vortex-array/src/arrow/executor/dictionary.rs
+++ b/vortex-array/src/arrow/executor/dictionary.rs
@@ -168,6 +168,24 @@ mod tests {
         array.execute_arrow(Some(dt), &mut LEGACY_SESSION.create_execution_ctx())
     }
 
+    fn dict_basic_input() -> crate::ArrayRef {
+        DictArray::try_new(
+            buffer![0u8, 1, 0].into_array(),
+            VarBinViewArray::from_iter_str(["a", "b"]).into_array(),
+        )
+        .expect("valid dictionary input")
+        .into_array()
+    }
+
+    fn dict_with_null_codes_input() -> crate::ArrayRef {
+        DictArray::try_new(
+            PrimitiveArray::from_option_iter(vec![Some(0u8), None, Some(1)]).into_array(),
+            VarBinViewArray::from_iter_str(["a", "b"]).into_array(),
+        )
+        .expect("valid dictionary input with null codes")
+        .into_array()
+    }
+
     #[rstest]
     #[case::constant_null(
         ConstantArray::new(Scalar::null(DType::Utf8(Nullable)), 4).into_array(),
@@ -180,18 +198,12 @@ mod tests {
         Arc::new(vec![Some("hello"); 5].into_iter().collect::<ArrowDictArray<UInt32Type>>()) as arrow_array::ArrayRef,
     )]
     #[case::dict_basic(
-        DictArray::try_new(
-            buffer![0u8, 1, 0].into_array(),
-            VarBinViewArray::from_iter_str(["a", "b"]).into_array(),
-        ).unwrap().into_array(),
+        dict_basic_input(),
         dict_type(DataType::UInt8, DataType::Utf8),
         Arc::new(vec![Some("a"), Some("b"), Some("a")].into_iter().collect::<ArrowDictArray<UInt8Type>>()) as arrow_array::ArrayRef,
     )]
     #[case::dict_with_null_codes(
-        DictArray::try_new(
-            PrimitiveArray::from_option_iter(vec![Some(0u8), None, Some(1)]).into_array(),
-            VarBinViewArray::from_iter_str(["a", "b"]).into_array(),
-        ).unwrap().into_array(),
+        dict_with_null_codes_input(),
         dict_type(DataType::UInt8, DataType::Utf8),
         Arc::new(vec![Some("a"), None, Some("b")].into_iter().collect::<ArrowDictArray<UInt8Type>>()) as arrow_array::ArrayRef,
     )]

--- a/vortex-array/src/arrow/executor/run_end.rs
+++ b/vortex-array/src/arrow/executor/run_end.rs
@@ -232,22 +232,36 @@ mod tests {
         array.execute_arrow(Some(dt), &mut SESSION.create_execution_ctx())
     }
 
+    fn constant_i32_with_i16_ends() -> arrow_array::ArrayRef {
+        Arc::new(
+            RunArray::<Int16Type>::try_new(
+                &Int16Array::from(vec![5i16]),
+                &Int32Array::from(vec![42]),
+            )
+            .expect("valid run-end test array"),
+        ) as arrow_array::ArrayRef
+    }
+
+    fn constant_f64_with_i64_ends() -> arrow_array::ArrayRef {
+        Arc::new(
+            RunArray::<Int64Type>::try_new(
+                &Int64Array::from(vec![7i64]),
+                &arrow_array::Float64Array::from(vec![1.5]),
+            )
+            .expect("valid run-end test array"),
+        ) as arrow_array::ArrayRef
+    }
+
     #[rstest]
     #[case::i32_with_i16_ends(
         ConstantArray::new(Scalar::from(42i32), 5).into_array(),
         ree_type(DataType::Int16, DataType::Int32),
-        Arc::new(RunArray::<Int16Type>::try_new(
-            &Int16Array::from(vec![5i16]),
-            &Int32Array::from(vec![42]),
-        ).unwrap()) as arrow_array::ArrayRef,
+        constant_i32_with_i16_ends(),
     )]
     #[case::f64_with_i64_ends(
         ConstantArray::new(Scalar::from(1.5f64), 7).into_array(),
         ree_type(DataType::Int64, DataType::Float64),
-        Arc::new(RunArray::<Int64Type>::try_new(
-            &Int64Array::from(vec![7i64]),
-            &arrow_array::Float64Array::from(vec![1.5]),
-        ).unwrap()) as arrow_array::ArrayRef,
+        constant_f64_with_i64_ends(),
     )]
     #[case::null(
         ConstantArray::new(Scalar::null(DType::Primitive(PType::I32, Nullable)), 4).into_array(),
@@ -312,9 +326,13 @@ mod tests {
         let ree = result
             .as_any()
             .downcast_ref::<RunArray<Int32Type>>()
-            .unwrap();
+            .ok_or_else(|| vortex_error::vortex_err!("expected Int32 run-end array"))?;
         assert_eq!(ree.run_ends().values(), expected_ends);
-        let values = ree.values().as_any().downcast_ref::<Int64Array>().unwrap();
+        let values = ree
+            .values()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or_else(|| vortex_error::vortex_err!("expected Int64 values"))?;
         assert_eq!(values.values(), expected_values);
         Ok(())
     }

--- a/vortex-array/src/arrow/executor/run_end.rs
+++ b/vortex-array/src/arrow/executor/run_end.rs
@@ -205,6 +205,7 @@ mod tests {
     use arrow_schema::Field;
     use rstest::rstest;
     use vortex_error::VortexResult;
+    use vortex_error::vortex_err;
     use vortex_session::VortexSession;
 
     use crate::IntoArray;
@@ -326,13 +327,13 @@ mod tests {
         let ree = result
             .as_any()
             .downcast_ref::<RunArray<Int32Type>>()
-            .ok_or_else(|| vortex_error::vortex_err!("expected Int32 run-end array"))?;
+            .ok_or_else(|| vortex_err!("expected Int32 run-end array"))?;
         assert_eq!(ree.run_ends().values(), expected_ends);
         let values = ree
             .values()
             .as_any()
             .downcast_ref::<Int64Array>()
-            .ok_or_else(|| vortex_error::vortex_err!("expected Int64 values"))?;
+            .ok_or_else(|| vortex_err!("expected Int64 values"))?;
         assert_eq!(values.values(), expected_values);
         Ok(())
     }

--- a/vortex-array/src/extension/uuid/vtable.rs
+++ b/vortex-array/src/extension/uuid/vtable.rs
@@ -312,8 +312,7 @@ mod tests {
                 version: Some(Version::Random),
             },
             uuid_storage_dtype(Nullability::NonNullable),
-        )
-        .unwrap();
+        )?;
         let storage_value = uuid_storage_scalar(&v4_uuid);
 
         let result = Uuid::unpack_native(&ext_dtype, &storage_value)?;
@@ -330,8 +329,7 @@ mod tests {
         let ext_dtype = ExtDType::try_new(
             UuidMetadata::default(),
             uuid_storage_dtype(Nullability::NonNullable),
-        )
-        .unwrap();
+        )?;
         let storage_value = uuid_storage_scalar(&v4_uuid);
 
         let result = Uuid::unpack_native(&ext_dtype, &storage_value)?;

--- a/vortex-array/src/scalar/typed_view/utf8.rs
+++ b/vortex-array/src/scalar/typed_view/utf8.rs
@@ -159,7 +159,7 @@ mod private {
     impl Sealed for BufferString {}
 
     impl StringLike for BufferString {
-        #[expect(clippy::unwrap_in_result, clippy::expect_used)]
+        #[expect(clippy::expect_used)]
         fn increment(self) -> Result<BufferString, BufferString> {
             if self.is_empty() {
                 return Err(self);

--- a/vortex-array/src/scalar_fn/fns/case_when.rs
+++ b/vortex-array/src/scalar_fn/fns/case_when.rs
@@ -858,9 +858,8 @@ mod tests {
         //      WHEN value = 1 THEN nullable(20) -- Nullable
         //      ELSE 0                           -- NonNullable
         // → result must be Nullable(i32)
-        let test_array = StructArray::from_fields(&[("value", buffer![0i32, 1, 2].into_array())])
-            .unwrap()
-            .into_array();
+        let test_array =
+            StructArray::from_fields(&[("value", buffer![0i32, 1, 2].into_array())])?.into_array();
 
         let nullable_20 =
             Scalar::from(20i32).cast(&DType::Primitive(PType::I32, Nullability::Nullable))?;
@@ -1117,8 +1116,7 @@ mod tests {
     fn test_evaluate_nary_string_output() -> VortexResult<()> {
         // Exercises merge_case_branches with a non-primitive (Utf8) builder.
         let test_array =
-            StructArray::from_fields(&[("value", buffer![1i32, 2, 3, 4].into_array())])
-                .unwrap()
+            StructArray::from_fields(&[("value", buffer![1i32, 2, 3, 4].into_array())])?
                 .into_array();
 
         // CASE WHEN value > 2 THEN 'high' WHEN value > 0 THEN 'low' ELSE 'none' END

--- a/vortex-bench/src/polarsignals/benchmark.rs
+++ b/vortex-bench/src/polarsignals/benchmark.rs
@@ -119,7 +119,7 @@ impl Benchmark for PolarSignalsBenchmark {
         )]
     }
 
-    #[expect(clippy::expect_used, clippy::unwrap_in_result)]
+    #[expect(clippy::expect_used)]
     fn pattern(&self, _table_name: &str, format: Format) -> Option<glob::Pattern> {
         Some(
             format!("{FILE_NAME}.{}", format.ext())

--- a/vortex-bench/src/statpopgen/statpopgen_benchmark.rs
+++ b/vortex-bench/src/statpopgen/statpopgen_benchmark.rs
@@ -168,7 +168,7 @@ impl Benchmark for StatPopGenBenchmark {
         vec![TableSpec::new("statpopgen", None)]
     }
 
-    #[expect(clippy::expect_used, clippy::unwrap_in_result)]
+    #[expect(clippy::expect_used)]
     fn pattern(&self, _table_name: &str, format: Format) -> Option<glob::Pattern> {
         Some(
             format!("{}.{}", Self::FILE_NAME, format.ext())

--- a/vortex-bench/src/tpcds/tpcds_benchmark.rs
+++ b/vortex-bench/src/tpcds/tpcds_benchmark.rs
@@ -124,7 +124,7 @@ impl Benchmark for TpcDsBenchmark {
         ]
     }
 
-    #[expect(clippy::expect_used, clippy::unwrap_in_result)]
+    #[expect(clippy::expect_used)]
     fn pattern(&self, table_name: &str, format: Format) -> Option<Pattern> {
         Some(
             format!("{}.{}", table_name, format.ext())

--- a/vortex-bench/src/tpch/benchmark.rs
+++ b/vortex-bench/src/tpch/benchmark.rs
@@ -139,7 +139,7 @@ impl Benchmark for TpcHBenchmark {
         ]
     }
 
-    #[expect(clippy::expect_used, clippy::unwrap_in_result)]
+    #[expect(clippy::expect_used)]
     fn pattern(&self, table_name: &str, format: Format) -> Option<Pattern> {
         Some(
             format!("{}_*.{}", table_name, format.ext())

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -664,7 +664,12 @@ mod tests {
         cuda_ctx: &CudaExecutionCtx,
         data: &[u32],
     ) -> VortexResult<(u64, Arc<cudarc::driver::CudaSlice<u32>>)> {
-        let device_buf = Arc::new(cuda_ctx.stream().clone_htod(data).expect("htod"));
+        let device_buf = Arc::new(
+            cuda_ctx
+                .stream()
+                .clone_htod(data)
+                .map_err(|e| vortex_err!("htod: {e}"))?,
+        );
         let (ptr, _) = device_buf.device_ptr(cuda_ctx.stream());
         Ok((ptr, device_buf))
     }
@@ -732,12 +737,15 @@ mod tests {
             cuda_ctx
                 .stream()
                 .clone_htod(plan.as_bytes())
-                .expect("copy plan to device"),
+                .map_err(|e| vortex_err!("copy plan to device: {e}"))?,
         );
         let (plan_ptr, record_plan) = device_plan.device_ptr(cuda_ctx.stream());
         let array_len_u64 = output_len as u64;
 
-        cuda_ctx.stream().synchronize().expect("sync");
+        cuda_ctx
+            .stream()
+            .synchronize()
+            .map_err(|e| vortex_err!("sync: {e}"))?;
 
         let cuda_function = cuda_ctx
             .load_function("dynamic_dispatch", &[PType::U32])
@@ -754,14 +762,16 @@ mod tests {
             shared_mem_bytes,
         };
         unsafe {
-            launch_builder.launch(config).expect("kernel launch");
+            launch_builder
+                .launch(config)
+                .map_err(|e| vortex_err!("kernel launch: {e}"))?;
         }
         drop((record_output, record_plan));
 
-        Ok(cuda_ctx
+        cuda_ctx
             .stream()
             .clone_dtoh(&output_buf.as_view::<u32>())
-            .expect("copy back"))
+            .map_err(|e| vortex_err!("copy back: {e}"))
     }
 
     fn run_dispatch_plan_f32(
@@ -1869,7 +1879,12 @@ mod tests {
 
         let i8_values: Vec<i8> = vec![-1, -2, -3, 127, -128, 0, 1, 42];
         let len = i8_values.len();
-        let device_buf = Arc::new(cuda_ctx.stream().clone_htod(&i8_values).expect("htod"));
+        let device_buf = Arc::new(
+            cuda_ctx
+                .stream()
+                .clone_htod(&i8_values)
+                .map_err(|e| vortex_err!("htod: {e}"))?,
+        );
         let (input_ptr, _) = device_buf.device_ptr(cuda_ctx.stream());
 
         // Build a single-stage LOAD plan: source ptype = I8, output ptype = U32.
@@ -1902,7 +1917,12 @@ mod tests {
 
         let i16_values: Vec<i16> = vec![-1, -256, -32768, 32767, 0, 1, -100, 12345];
         let len = i16_values.len();
-        let device_buf = Arc::new(cuda_ctx.stream().clone_htod(&i16_values).expect("htod"));
+        let device_buf = Arc::new(
+            cuda_ctx
+                .stream()
+                .clone_htod(&i16_values)
+                .map_err(|e| vortex_err!("htod: {e}"))?,
+        );
         let (input_ptr, _) = device_buf.device_ptr(cuda_ctx.stream());
 
         let plan = CudaDispatchPlan::new(

--- a/vortex-duckdb/src/exporter/dict.rs
+++ b/vortex-duckdb/src/exporter/dict.rs
@@ -192,15 +192,12 @@ mod tests {
 
         let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_INTEGER)]);
 
-        new_exporter(&arr, &ConversionCache::default())
-            .unwrap()
-            .export(
-                0,
-                2,
-                chunk.get_vector_mut(0),
-                &mut SESSION.create_execution_ctx(),
-            )
-            .unwrap();
+        new_exporter(&arr, &ConversionCache::default())?.export(
+            0,
+            2,
+            chunk.get_vector_mut(0),
+            &mut SESSION.create_execution_ctx(),
+        )?;
         chunk.set_len(2);
 
         assert_eq!(
@@ -223,10 +220,12 @@ mod tests {
         let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_INTEGER)]);
 
         let mut ctx = ExecutionCtx::new(VortexSession::default());
-        new_exporter_with_flatten(&arr, &ConversionCache::default(), &mut ctx, false)
-            .unwrap()
-            .export(0, 2, chunk.get_vector_mut(0), &mut ctx)
-            .unwrap();
+        new_exporter_with_flatten(&arr, &ConversionCache::default(), &mut ctx, false)?.export(
+            0,
+            2,
+            chunk.get_vector_mut(0),
+            &mut ctx,
+        )?;
         chunk.set_len(2);
 
         assert_eq!(
@@ -248,15 +247,12 @@ mod tests {
 
         let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_INTEGER)]);
 
-        new_exporter(&arr, &ConversionCache::default())
-            .unwrap()
-            .export(
-                0,
-                3,
-                chunk.get_vector_mut(0),
-                &mut SESSION.create_execution_ctx(),
-            )
-            .unwrap();
+        new_exporter(&arr, &ConversionCache::default())?.export(
+            0,
+            3,
+            chunk.get_vector_mut(0),
+            &mut SESSION.create_execution_ctx(),
+        )?;
         chunk.set_len(3);
 
         // some-invalid codes cannot be exported as a dictionary.
@@ -271,10 +267,12 @@ mod tests {
             DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_INTEGER)]);
         let mut ctx = SESSION.create_execution_ctx();
 
-        new_array_exporter(arr.into_array(), &ConversionCache::default(), &mut ctx)
-            .unwrap()
-            .export(0, 3, flat_chunk.get_vector_mut(0), &mut ctx)
-            .unwrap();
+        new_array_exporter(arr.into_array(), &ConversionCache::default(), &mut ctx)?.export(
+            0,
+            3,
+            flat_chunk.get_vector_mut(0),
+            &mut ctx,
+        )?;
         flat_chunk.set_len(3);
 
         assert_eq!(
@@ -297,15 +295,12 @@ mod tests {
 
         let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_INTEGER)]);
 
-        new_exporter(&arr, &ConversionCache::default())
-            .unwrap()
-            .export(
-                0,
-                0,
-                chunk.get_vector_mut(0),
-                &mut SESSION.create_execution_ctx(),
-            )
-            .unwrap();
+        new_exporter(&arr, &ConversionCache::default())?.export(
+            0,
+            0,
+            chunk.get_vector_mut(0),
+            &mut SESSION.create_execution_ctx(),
+        )?;
         chunk.set_len(0);
 
         assert_eq!(

--- a/vortex-duckdb/src/exporter/varbinview.rs
+++ b/vortex-duckdb/src/exporter/varbinview.rs
@@ -161,7 +161,7 @@ mod tests {
         chunk.set_len(3);
 
         assert_eq!(
-            format!("{}", String::try_from(&*chunk).unwrap()),
+            format!("{}", String::try_from(&*chunk)?),
             r#"Chunk - [1 Columns]
 - CONSTANT VARCHAR: 3 = [ NULL]
 "#
@@ -181,7 +181,7 @@ mod tests {
         chunk.set_len(3);
 
         assert_eq!(
-            format!("{}", String::try_from(&*chunk).unwrap()),
+            format!("{}", String::try_from(&*chunk)?),
             r#"Chunk - [1 Columns]
 - CONSTANT VARCHAR: 3 = [ NULL]
 "#
@@ -203,7 +203,7 @@ mod tests {
         chunk.set_len(3);
 
         assert_eq!(
-            format!("{}", String::try_from(&*chunk).unwrap()),
+            format!("{}", String::try_from(&*chunk)?),
             r#"Chunk - [1 Columns]
 - FLAT VARCHAR: 3 = [ NULL, NULL, Hi]
 "#

--- a/vortex-duckdb/src/multi_file.rs
+++ b/vortex-duckdb/src/multi_file.rs
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_parse_glob_url_absolute_glob_path() -> VortexResult<()> {
-        let tmpdir = tempfile::tempdir().unwrap();
+        let tmpdir = tempfile::tempdir()?;
         let glob = format!("{}/*.vortex", tmpdir.path().display());
         let url = parse_glob_url(&glob)?;
         assert_eq!(url.scheme(), "file");
@@ -190,9 +190,11 @@ mod tests {
 
     #[test]
     fn test_parse_glob_url_absolute_existing_path() -> VortexResult<()> {
-        let tmpfile = tempfile::NamedTempFile::new().unwrap();
-        let canonical = std::fs::canonicalize(tmpfile.path()).unwrap();
-        let path_str = canonical.to_str().unwrap();
+        let tmpfile = tempfile::NamedTempFile::new()?;
+        let canonical = std::fs::canonicalize(tmpfile.path())?;
+        let path_str = canonical
+            .to_str()
+            .ok_or_else(|| vortex_err!("canonical path is not valid UTF-8"))?;
         let url = parse_glob_url(path_str)?;
         assert_eq!(url.scheme(), "file");
         assert_eq!(url.path(), path_str);
@@ -203,8 +205,13 @@ mod tests {
     fn test_parse_glob_url_relative_path() -> VortexResult<()> {
         // Create a tempfile in the current working directory so we can refer to it
         // by a relative name (just the filename, without any directory component).
-        let tmpfile = tempfile::NamedTempFile::new_in(".").unwrap();
-        let filename = tmpfile.path().file_name().unwrap().to_str().unwrap();
+        let tmpfile = tempfile::NamedTempFile::new_in(".")?;
+        let filename = tmpfile
+            .path()
+            .file_name()
+            .ok_or_else(|| vortex_err!("temp file missing file name"))?
+            .to_str()
+            .ok_or_else(|| vortex_err!("temp file name is not valid UTF-8"))?;
 
         let url = parse_glob_url(filename)?;
         assert_eq!(url.scheme(), "file");
@@ -218,8 +225,13 @@ mod tests {
     fn test_parse_glob_url_relative_glob_path() -> VortexResult<()> {
         // A relative path with a glob character (e.g. `./data/*.vortex`) must also resolve
         // correctly.
-        let tmpdir = tempfile::tempdir_in(".").unwrap();
-        let dir_name = tmpdir.path().file_name().unwrap().to_str().unwrap();
+        let tmpdir = tempfile::tempdir_in(".")?;
+        let dir_name = tmpdir
+            .path()
+            .file_name()
+            .ok_or_else(|| vortex_err!("temp dir missing file name"))?
+            .to_str()
+            .ok_or_else(|| vortex_err!("temp dir name is not valid UTF-8"))?;
         let glob = format!("./{dir_name}/*.vortex");
         let url = parse_glob_url(&glob)?;
         assert_eq!(url.scheme(), "file");
@@ -241,8 +253,13 @@ mod tests {
     fn test_parse_glob_url_parent_relative_path() -> VortexResult<()> {
         // A path starting with `..` must be resolved to an absolute path without
         // percent-encoding the `..` component in the resulting URL.
-        let tmpfile = tempfile::NamedTempFile::new_in("..").unwrap();
-        let filename = tmpfile.path().file_name().unwrap().to_str().unwrap();
+        let tmpfile = tempfile::NamedTempFile::new_in("..")?;
+        let filename = tmpfile
+            .path()
+            .file_name()
+            .ok_or_else(|| vortex_err!("temp file missing file name"))?
+            .to_str()
+            .ok_or_else(|| vortex_err!("temp file name is not valid UTF-8"))?;
         let relative = format!("../{filename}");
 
         let url = parse_glob_url(&relative)?;

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -669,7 +669,7 @@ mod test {
         let runtime = SingleThreadRuntime::default();
         let session = crate::scan::test::session_with_handle(runtime.handle());
 
-        let stream = ScanBuilder::new(session, reader).into_stream().unwrap();
+        let stream = ScanBuilder::new(session, reader).into_stream()?;
         let mut iter = runtime.block_on_stream(stream);
 
         let mut values = Vec::new();

--- a/vortex-metrics/src/histogram.rs
+++ b/vortex-metrics/src/histogram.rs
@@ -32,7 +32,6 @@ impl Histogram {
     /// Returns the estimated quantile value, which must be in the [0.0, 1.0] range, will panic otherwise.
     /// Returns `None` if the histogram is empty.
     #[expect(clippy::expect_used)]
-    #[expect(clippy::unwrap_in_result)]
     pub fn quantile(&self, quantile: f64) -> Option<f64> {
         assert!(
             (0.0..=1.0).contains(&quantile),

--- a/vortex-metrics/src/timer.rs
+++ b/vortex-metrics/src/timer.rs
@@ -43,7 +43,6 @@ impl Timer {
     /// Returns the estimated quantile value, which must be in the [0.0, 1.0] range, will panic otherwise.
     /// Returns `None` if the timer is empty.
     #[expect(clippy::expect_used)]
-    #[expect(clippy::unwrap_in_result)]
     pub fn quantile(&self, quantile: f64) -> Option<Duration> {
         assert!(
             (0.0..=1.0).contains(&quantile),

--- a/vortex-tensor/src/encodings/turboquant/tests/roundtrip.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests/roundtrip.rs
@@ -11,6 +11,7 @@ use vortex_array::arrays::PrimitiveArray;
 use vortex_array::validity::Validity;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
+use vortex_error::vortex_err;
 
 use super::*;
 use crate::encodings::turboquant::turboquant_encode_unchecked;
@@ -195,8 +196,7 @@ fn all_zero_vectors_roundtrip() -> VortexResult<()> {
     let elements = PrimitiveArray::new::<f32>(buf.freeze(), Validity::NonNullable);
     let fsl = FixedSizeListArray::try_new(
         elements.into_array(),
-        dim.try_into()
-            .map_err(|e| vortex_error::vortex_err!("{e}"))?,
+        dim.try_into().map_err(|e| vortex_err!("{e}"))?,
         Validity::NonNullable,
         num_rows,
     )?;
@@ -245,7 +245,7 @@ fn f64_input_encodes_successfully() -> VortexResult<()> {
     let num_rows = 10;
     let dim = 128;
     let mut rng = StdRng::seed_from_u64(99);
-    let normal = Normal::new(0.0f64, 1.0).map_err(|e| vortex_error::vortex_err!("{e}"))?;
+    let normal = Normal::new(0.0f64, 1.0).map_err(|e| vortex_err!("{e}"))?;
 
     let mut buf = BufferMut::<f64>::with_capacity(num_rows * dim);
     for _ in 0..(num_rows * dim) {
@@ -254,8 +254,7 @@ fn f64_input_encodes_successfully() -> VortexResult<()> {
     let elements = PrimitiveArray::new::<f64>(buf.freeze(), Validity::NonNullable);
     let fsl = FixedSizeListArray::try_new(
         elements.into_array(),
-        dim.try_into()
-            .map_err(|e| vortex_error::vortex_err!("{e}"))?,
+        dim.try_into().map_err(|e| vortex_err!("{e}"))?,
         Validity::NonNullable,
         num_rows,
     )?;
@@ -279,7 +278,7 @@ fn f16_input_encodes_successfully() -> VortexResult<()> {
     let num_rows = 10;
     let dim = 128;
     let mut rng = StdRng::seed_from_u64(99);
-    let normal = Normal::new(0.0f32, 1.0).map_err(|e| vortex_error::vortex_err!("{e}"))?;
+    let normal = Normal::new(0.0f32, 1.0).map_err(|e| vortex_err!("{e}"))?;
 
     let mut buf = BufferMut::<half::f16>::with_capacity(num_rows * dim);
     for _ in 0..(num_rows * dim) {
@@ -288,8 +287,7 @@ fn f16_input_encodes_successfully() -> VortexResult<()> {
     let elements = PrimitiveArray::new::<half::f16>(buf.freeze(), Validity::NonNullable);
     let fsl = FixedSizeListArray::try_new(
         elements.into_array(),
-        dim.try_into()
-            .map_err(|e| vortex_error::vortex_err!("{e}"))?,
+        dim.try_into().map_err(|e| vortex_err!("{e}"))?,
         Validity::NonNullable,
         num_rows,
     )?;

--- a/vortex-tensor/src/encodings/turboquant/tests/roundtrip.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests/roundtrip.rs
@@ -196,7 +196,7 @@ fn all_zero_vectors_roundtrip() -> VortexResult<()> {
     let fsl = FixedSizeListArray::try_new(
         elements.into_array(),
         dim.try_into()
-            .expect("somehow got dimension greater than u32::MAX"),
+            .map_err(|e| vortex_error::vortex_err!("{e}"))?,
         Validity::NonNullable,
         num_rows,
     )?;
@@ -245,7 +245,7 @@ fn f64_input_encodes_successfully() -> VortexResult<()> {
     let num_rows = 10;
     let dim = 128;
     let mut rng = StdRng::seed_from_u64(99);
-    let normal = Normal::new(0.0f64, 1.0).unwrap();
+    let normal = Normal::new(0.0f64, 1.0).map_err(|e| vortex_error::vortex_err!("{e}"))?;
 
     let mut buf = BufferMut::<f64>::with_capacity(num_rows * dim);
     for _ in 0..(num_rows * dim) {
@@ -254,7 +254,8 @@ fn f64_input_encodes_successfully() -> VortexResult<()> {
     let elements = PrimitiveArray::new::<f64>(buf.freeze(), Validity::NonNullable);
     let fsl = FixedSizeListArray::try_new(
         elements.into_array(),
-        dim.try_into().unwrap(),
+        dim.try_into()
+            .map_err(|e| vortex_error::vortex_err!("{e}"))?,
         Validity::NonNullable,
         num_rows,
     )?;
@@ -278,7 +279,7 @@ fn f16_input_encodes_successfully() -> VortexResult<()> {
     let num_rows = 10;
     let dim = 128;
     let mut rng = StdRng::seed_from_u64(99);
-    let normal = Normal::new(0.0f32, 1.0).unwrap();
+    let normal = Normal::new(0.0f32, 1.0).map_err(|e| vortex_error::vortex_err!("{e}"))?;
 
     let mut buf = BufferMut::<half::f16>::with_capacity(num_rows * dim);
     for _ in 0..(num_rows * dim) {
@@ -287,7 +288,8 @@ fn f16_input_encodes_successfully() -> VortexResult<()> {
     let elements = PrimitiveArray::new::<half::f16>(buf.freeze(), Validity::NonNullable);
     let fsl = FixedSizeListArray::try_new(
         elements.into_array(),
-        dim.try_into().unwrap(),
+        dim.try_into()
+            .map_err(|e| vortex_error::vortex_err!("{e}"))?,
         Validity::NonNullable,
         num_rows,
     )?;

--- a/vortex-tensor/src/scalar_fns/cosine_similarity.rs
+++ b/vortex-tensor/src/scalar_fns/cosine_similarity.rs
@@ -704,16 +704,8 @@ mod tests {
     }
 
     #[rstest]
-    #[case::vector(
-        vector_array(3, &[1.0, 0.0, 0.0, 3.0, 4.0, 0.0]).unwrap(),
-        vector_array(3, &[0.0, 1.0, 0.0, 3.0, 4.0, 0.0]).unwrap(),
-        2,
-    )]
-    #[case::fixed_shape_tensor(
-        tensor_array(&[2], &[1.0, 0.0, 3.0, 4.0]).unwrap(),
-        tensor_array(&[2], &[0.0, 1.0, 3.0, 4.0]).unwrap(),
-        2,
-    )]
+    #[case::vector(cosine_vector_lhs(), cosine_vector_rhs(), 2)]
+    #[case::fixed_shape_tensor(cosine_tensor_lhs(), cosine_tensor_rhs(), 2)]
     fn serde_round_trip(
         #[case] lhs: ArrayRef,
         #[case] rhs: ArrayRef,
@@ -740,5 +732,21 @@ mod tests {
         assert_eq!(recovered.len(), original.len());
         assert_eq!(recovered.encoding_id(), original.encoding_id());
         Ok(())
+    }
+
+    fn cosine_vector_lhs() -> ArrayRef {
+        vector_array(3, &[1.0, 0.0, 0.0, 3.0, 4.0, 0.0]).expect("valid vector array")
+    }
+
+    fn cosine_vector_rhs() -> ArrayRef {
+        vector_array(3, &[0.0, 1.0, 0.0, 3.0, 4.0, 0.0]).expect("valid vector array")
+    }
+
+    fn cosine_tensor_lhs() -> ArrayRef {
+        tensor_array(&[2], &[1.0, 0.0, 3.0, 4.0]).expect("valid tensor array")
+    }
+
+    fn cosine_tensor_rhs() -> ArrayRef {
+        tensor_array(&[2], &[0.0, 1.0, 3.0, 4.0]).expect("valid tensor array")
     }
 }

--- a/vortex-tensor/src/scalar_fns/inner_product.rs
+++ b/vortex-tensor/src/scalar_fns/inner_product.rs
@@ -839,16 +839,8 @@ mod tests {
     }
 
     #[rstest]
-    #[case::vector(
-        vector_array(3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
-        vector_array(3, &[7.0, 8.0, 9.0, 10.0, 11.0, 12.0]).unwrap(),
-        2,
-    )]
-    #[case::fixed_shape_tensor(
-        tensor_array(&[2], &[1.0, 2.0, 3.0, 4.0]).unwrap(),
-        tensor_array(&[2], &[5.0, 6.0, 7.0, 8.0]).unwrap(),
-        2,
-    )]
+    #[case::vector(inner_product_vector_lhs(), inner_product_vector_rhs(), 2)]
+    #[case::fixed_shape_tensor(inner_product_tensor_lhs(), inner_product_tensor_rhs(), 2)]
     fn serde_round_trip(
         #[case] lhs: ArrayRef,
         #[case] rhs: ArrayRef,
@@ -875,6 +867,22 @@ mod tests {
         assert_eq!(recovered.len(), original.len());
         assert_eq!(recovered.encoding_id(), original.encoding_id());
         Ok(())
+    }
+
+    fn inner_product_vector_lhs() -> ArrayRef {
+        vector_array(3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).expect("valid vector array")
+    }
+
+    fn inner_product_vector_rhs() -> ArrayRef {
+        vector_array(3, &[7.0, 8.0, 9.0, 10.0, 11.0, 12.0]).expect("valid vector array")
+    }
+
+    fn inner_product_tensor_lhs() -> ArrayRef {
+        tensor_array(&[2], &[1.0, 2.0, 3.0, 4.0]).expect("valid tensor array")
+    }
+
+    fn inner_product_tensor_rhs() -> ArrayRef {
+        tensor_array(&[2], &[5.0, 6.0, 7.0, 8.0]).expect("valid tensor array")
     }
 
     // ---- Tests for the `SorfTransform + constant` and `Dict + constant` fast paths ----

--- a/vortex-tensor/src/scalar_fns/l2_denorm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_denorm.rs
@@ -1113,8 +1113,8 @@ mod tests {
     /// inherits the input's nullability, giving us two different per-child nullabilities to
     /// round-trip.
     #[rstest]
-    #[case::vector(vector_array(3, &[3.0, 4.0, 0.0, 0.0, 0.0, 0.0]).unwrap())]
-    #[case::fixed_shape_tensor(tensor_array(&[2, 2], &[1.0, 2.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0]).unwrap())]
+    #[case::vector(l2_denorm_vector_input())]
+    #[case::fixed_shape_tensor(l2_denorm_tensor_input())]
     fn serde_round_trip(#[case] input: ArrayRef) -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         let original = normalize_as_l2_denorm(input, &mut ctx)?.into_array();
@@ -1140,5 +1140,14 @@ mod tests {
         assert_eq!(recovered.len(), original.len());
         assert_eq!(recovered.encoding_id(), original.encoding_id());
         Ok(())
+    }
+
+    fn l2_denorm_vector_input() -> ArrayRef {
+        vector_array(3, &[3.0, 4.0, 0.0, 0.0, 0.0, 0.0]).expect("valid vector array")
+    }
+
+    fn l2_denorm_tensor_input() -> ArrayRef {
+        tensor_array(&[2, 2], &[1.0, 2.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0])
+            .expect("valid tensor array")
     }
 }

--- a/vortex-tensor/src/scalar_fns/l2_norm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_norm.rs
@@ -418,8 +418,8 @@ mod tests {
     }
 
     #[rstest]
-    #[case::fixed_shape_tensor(tensor_array(&[3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(), 2)]
-    #[case::vector(vector_array(3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(), 2)]
+    #[case::fixed_shape_tensor(l2_norm_tensor_child(), 2)]
+    #[case::vector(l2_norm_vector_child(), 2)]
     fn serde_round_trip(#[case] child: ArrayRef, #[case] len: usize) -> VortexResult<()> {
         let original = L2Norm::try_new_array(child.clone(), len)?.into_array();
 
@@ -442,5 +442,13 @@ mod tests {
         assert_eq!(recovered.len(), original.len());
         assert_eq!(recovered.encoding_id(), original.encoding_id());
         Ok(())
+    }
+
+    fn l2_norm_tensor_child() -> ArrayRef {
+        tensor_array(&[3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).expect("valid tensor array")
+    }
+
+    fn l2_norm_vector_child() -> ArrayRef {
+        vector_array(3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).expect("valid vector array")
     }
 }

--- a/vortex-tensor/src/utils.rs
+++ b/vortex-tensor/src/utils.rs
@@ -270,7 +270,12 @@ pub mod test_helpers {
     /// The number of rows is inferred from the total element count divided by the product of the
     /// shape dimensions. For 0-dimensional tensors (scalar), each element is one row.
     pub fn tensor_array<T: NativePType>(shape: &[usize], elements: &[T]) -> VortexResult<ArrayRef> {
-        let list_size: u32 = shape.iter().product::<usize>().max(1).try_into().unwrap();
+        let list_size: u32 = shape
+            .iter()
+            .product::<usize>()
+            .max(1)
+            .try_into()
+            .map_err(|e| vortex_error::vortex_err!("{e}"))?;
         let storage = flat_fsl(elements, list_size);
         let metadata = FixedShapeTensorMetadata::new(shape.to_vec());
         let ext_dtype =

--- a/vortex-tensor/src/utils.rs
+++ b/vortex-tensor/src/utils.rs
@@ -241,6 +241,7 @@ pub mod test_helpers {
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
     use vortex_error::VortexResult;
+    use vortex_error::vortex_err;
 
     use crate::scalar_fns::l2_denorm::L2Denorm;
     use crate::types::fixed_shape::FixedShapeTensor;
@@ -275,7 +276,7 @@ pub mod test_helpers {
             .product::<usize>()
             .max(1)
             .try_into()
-            .map_err(|e| vortex_error::vortex_err!("{e}"))?;
+            .map_err(|e| vortex_err!("{e}"))?;
         let storage = flat_fsl(elements, list_size);
         let metadata = FixedShapeTensorMetadata::new(shape.to_vec());
         let ext_dtype =

--- a/vortex-web/crate/Cargo.toml
+++ b/vortex-web/crate/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vortex-web-wasm"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.91.0"
 license = "Apache-2.0"
 description = "WASM bindings for the Vortex web explorer"
 publish = false


### PR DESCRIPTION
We're two major version back on our lance comparison (which is about 2 months of changes), but it also seems like more and more dependencies break because we're on 1.90.

libs.rs says 68% of crates.io requests ask for this stable version or newer, not sure what was our bar in the past but I figured its worth at least checking it out.

I've reviewed the changes and none of them seem substantial, they are all tests and some lints that were improved and don't warn anymore.