### PR TITLE
Extend DType::least_supertype to cover FixedSizeList, List, and tensor extensions

### DIFF
--- a/vortex-array/src/dtype/coercion.rs
+++ b/vortex-array/src/dtype/coercion.rs
@@ -79,13 +79,27 @@ impl DType {
     /// The core primitive — what type can hold both `self` and `other`?
     /// Returns `None` if no common supertype exists.
     pub fn least_supertype(&self, other: &DType) -> Option<DType> {
-        // 1. Same type modulo outer nullability: union outer and return. Nested types
-        //    whose only difference is inner nullability fall through to their own arms.
-        if self.with_nullability(other.nullability()) == *other {
-            return Some(self.with_nullability(self.nullability() | other.nullability()));
+        let union_null = self.nullability() | other.nullability();
+
+        if let (
+            DType::FixedSizeList(lhs_elem, lhs_size, _),
+            DType::FixedSizeList(rhs_elem, rhs_size, _),
+        ) = (self, other)
+            && lhs_size == rhs_size
+        {
+            let elem = lhs_elem.least_supertype(rhs_elem)?;
+            return Some(DType::FixedSizeList(Arc::new(elem), *lhs_size, union_null));
         }
 
-        let union_null = self.nullability() | other.nullability();
+        if let (DType::List(lhs_elem, _), DType::List(rhs_elem, _)) = (self, other) {
+            let elem = lhs_elem.least_supertype(rhs_elem)?;
+            return Some(DType::List(Arc::new(elem), union_null));
+        }
+
+        // 1. Identity (ignoring nullability): return self with union nullability
+        if self.eq_ignore_nullability(other) {
+            return Some(self.with_nullability(union_null));
+        }
 
         // 2. Null + X: return X as nullable
         if matches!(self, DType::Null) {
@@ -129,24 +143,7 @@ impl DType {
             return decimal_least_supertype(int_dec, *dec).map(|d| DType::Decimal(d, union_null));
         }
 
-        // 7. FixedSizeList + FixedSizeList: same size, recurse on element dtype.
-        if let (
-            DType::FixedSizeList(lhs_elem, lhs_size, _),
-            DType::FixedSizeList(rhs_elem, rhs_size, _),
-        ) = (self, other)
-            && lhs_size == rhs_size
-        {
-            let elem = lhs_elem.least_supertype(rhs_elem)?;
-            return Some(DType::FixedSizeList(Arc::new(elem), *lhs_size, union_null));
-        }
-
-        // 8. List + List: recurse on element dtype.
-        if let (DType::List(lhs_elem, _), DType::List(rhs_elem, _)) = (self, other) {
-            let elem = lhs_elem.least_supertype(rhs_elem)?;
-            return Some(DType::List(Arc::new(elem), union_null));
-        }
-
-        // 9. Extension + anything: delegate to vtable
+        // 7. Extension + anything: delegate to vtable
         if let DType::Extension(ext) = self {
             return ext
                 .least_supertype(other)
@@ -158,7 +155,7 @@ impl DType {
                 .map(|dt| dt.with_nullability(union_null));
         }
 
-        // 10. Everything else: no common supertype
+        // 8. Everything else: no common supertype
         None
     }
 
@@ -172,6 +169,21 @@ impl DType {
 
     /// Is there any implicit coercion path from `other` to `self`?
     pub fn can_coerce_from(&self, other: &DType) -> bool {
+        if let (
+            DType::FixedSizeList(target_elem, target_size, _),
+            DType::FixedSizeList(source_elem, source_size, _),
+        ) = (self, other)
+        {
+            return target_size == source_size
+                && (self.is_nullable() || !other.is_nullable())
+                && target_elem.can_coerce_from(source_elem);
+        }
+
+        if let (DType::List(target_elem, _), DType::List(source_elem, _)) = (self, other) {
+            return (self.is_nullable() || !other.is_nullable())
+                && target_elem.can_coerce_from(source_elem);
+        }
+
         // 1. Same type (ignoring nullability): check nullability compatibility
         if self.eq_ignore_nullability(other) {
             return self.is_nullable() || !other.is_nullable();
@@ -214,24 +226,12 @@ impl DType {
                 && (self.is_nullable() || !other.is_nullable());
         }
 
-        // 7. FixedSizeList / List widening: defer to least_supertype + identity check
-        if matches!(
-            (self, other),
-            (DType::FixedSizeList(..), DType::FixedSizeList(..))
-                | (DType::List(..), DType::List(..))
-        ) {
-            return other
-                .least_supertype(self)
-                .is_some_and(|st| st.eq_ignore_nullability(self))
-                && (self.is_nullable() || !other.is_nullable());
-        }
-
-        // 8. Extension: delegate to vtable
+        // 7. Extension: delegate to vtable
         if let DType::Extension(ext) = self {
             return ext.can_coerce_from(other);
         }
 
-        // 9. Everything else: false
+        // 8. Everything else: false
         false
     }
 
@@ -681,6 +681,49 @@ mod tests {
         );
         assert!(target.can_coerce_from(&source));
         assert!(!source.can_coerce_from(&target));
+    }
+
+    #[test]
+    fn fsl_can_coerce_from_rejects_nullable_source_elements() {
+        let target = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            4,
+            NonNullable,
+        );
+        let source = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, Nullable)),
+            4,
+            NonNullable,
+        );
+        assert!(!target.can_coerce_from(&source));
+    }
+
+    #[test]
+    fn list_can_coerce_from_rejects_nullable_source_elements() {
+        let target = DType::List(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            NonNullable,
+        );
+        let source = DType::List(
+            Arc::new(DType::Primitive(PType::F32, Nullable)),
+            NonNullable,
+        );
+        assert!(!target.can_coerce_from(&source));
+    }
+
+    #[test]
+    fn fsl_can_coerce_from_allows_widening_nullable_target() {
+        let target = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::I32, Nullable)),
+            4,
+            NonNullable,
+        );
+        let source = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::I32, NonNullable)),
+            4,
+            NonNullable,
+        );
+        assert!(target.can_coerce_from(&source));
     }
 
     #[test]

--- a/vortex-array/src/dtype/coercion.rs
+++ b/vortex-array/src/dtype/coercion.rs
@@ -96,12 +96,12 @@ impl DType {
             return Some(DType::List(Arc::new(elem), union_null));
         }
 
-        // 1. Identity (ignoring nullability): return self with union nullability
+        // Identity (ignoring nullability): return self with union nullability
         if self.eq_ignore_nullability(other) {
             return Some(self.with_nullability(union_null));
         }
 
-        // 2. Null + X: return X as nullable
+        // Null + X: return X as nullable
         if matches!(self, DType::Null) {
             return Some(other.as_nullable());
         }
@@ -109,7 +109,7 @@ impl DType {
             return Some(self.as_nullable());
         }
 
-        // 3. Bool + numeric: return the numeric type (with union nullability)
+        // Bool + numeric: return the numeric type (with union nullability)
         if self.is_boolean() && other.is_numeric() {
             return Some(other.with_nullability(union_null));
         }
@@ -117,19 +117,19 @@ impl DType {
             return Some(self.with_nullability(union_null));
         }
 
-        // 4. Primitive + Primitive (different ptypes): delegate to PType::least_supertype
+        // Primitive + Primitive (different ptypes): delegate to PType::least_supertype
         if let (DType::Primitive(lhs_p, _), DType::Primitive(rhs_p, _)) = (self, other) {
             return lhs_p
                 .least_supertype(*rhs_p)
                 .map(|p| DType::Primitive(p, union_null));
         }
 
-        // 5. Decimal + Decimal: compute wider decimal
+        // Decimal + Decimal: compute wider decimal
         if let (DType::Decimal(lhs_d, _), DType::Decimal(rhs_d, _)) = (self, other) {
             return decimal_least_supertype(*lhs_d, *rhs_d).map(|d| DType::Decimal(d, union_null));
         }
 
-        // 6. Decimal + integer Primitive: convert integer to Decimal, then widen
+        // Decimal + integer Primitive: convert integer to Decimal, then widen
         if let (DType::Decimal(dec, _), DType::Primitive(p, _)) = (self, other)
             && p.is_int()
         {
@@ -143,7 +143,7 @@ impl DType {
             return decimal_least_supertype(int_dec, *dec).map(|d| DType::Decimal(d, union_null));
         }
 
-        // 7. Extension + anything: delegate to vtable
+        // Extension + anything: delegate to vtable
         if let DType::Extension(ext) = self {
             return ext
                 .least_supertype(other)
@@ -155,7 +155,6 @@ impl DType {
                 .map(|dt| dt.with_nullability(union_null));
         }
 
-        // 8. Everything else: no common supertype
         None
     }
 
@@ -184,22 +183,22 @@ impl DType {
                 && target_elem.can_coerce_from(source_elem);
         }
 
-        // 1. Same type (ignoring nullability): check nullability compatibility
+        // Same type (ignoring nullability): check nullability compatibility
         if self.eq_ignore_nullability(other) {
             return self.is_nullable() || !other.is_nullable();
         }
 
-        // 2. Null → nullable target
+        // Null → nullable target
         if matches!(other, DType::Null) {
             return self.is_nullable();
         }
 
-        // 3. Bool → numeric
+        // Bool → numeric
         if other.is_boolean() && self.is_numeric() {
             return self.is_nullable() || !other.is_nullable();
         }
 
-        // 4. Primitive widening: true if least_supertype(source, target) == target
+        // Primitive widening: true if least_supertype(source, target) == target
         if let (DType::Primitive(..), DType::Primitive(..)) = (self, other) {
             return other
                 .least_supertype(self)
@@ -207,7 +206,7 @@ impl DType {
                 && (self.is_nullable() || !other.is_nullable());
         }
 
-        // 5. Decimal widening
+        // Decimal widening
         if let (DType::Decimal(target, _), DType::Decimal(source, _)) = (self, other) {
             let target_integral = target.precision() as i16 - target.scale() as i16;
             let source_integral = source.precision() as i16 - source.scale() as i16;
@@ -216,7 +215,7 @@ impl DType {
                 && (self.is_nullable() || !other.is_nullable());
         }
 
-        // 6. Integer → Decimal
+        // Integer → Decimal
         if let (DType::Decimal(dec, _), DType::Primitive(p, _)) = (self, other)
             && p.is_int()
         {
@@ -226,12 +225,11 @@ impl DType {
                 && (self.is_nullable() || !other.is_nullable());
         }
 
-        // 7. Extension: delegate to vtable
+        // Extension: delegate to vtable
         if let DType::Extension(ext) = self {
             return ext.can_coerce_from(other);
         }
 
-        // 8. Everything else: false
         false
     }
 

--- a/vortex-array/src/dtype/coercion.rs
+++ b/vortex-array/src/dtype/coercion.rs
@@ -3,6 +3,8 @@
 
 //! Utilities for performing type coercion.
 
+use std::sync::Arc;
+
 use crate::dtype::DType;
 use crate::dtype::PType;
 use crate::dtype::decimal::DecimalDType;
@@ -77,8 +79,9 @@ impl DType {
     /// The core primitive — what type can hold both `self` and `other`?
     /// Returns `None` if no common supertype exists.
     pub fn least_supertype(&self, other: &DType) -> Option<DType> {
-        // 1. Identity (ignoring nullability): return self with union nullability
-        if self.eq_ignore_nullability(other) {
+        // 1. Same type modulo outer nullability: union outer and return. Nested types
+        //    whose only difference is inner nullability fall through to their own arms.
+        if self.with_nullability(other.nullability()) == *other {
             return Some(self.with_nullability(self.nullability() | other.nullability()));
         }
 
@@ -126,7 +129,24 @@ impl DType {
             return decimal_least_supertype(int_dec, *dec).map(|d| DType::Decimal(d, union_null));
         }
 
-        // 7. Extension + anything: delegate to vtable
+        // 7. FixedSizeList + FixedSizeList: same size, recurse on element dtype.
+        if let (
+            DType::FixedSizeList(lhs_elem, lhs_size, _),
+            DType::FixedSizeList(rhs_elem, rhs_size, _),
+        ) = (self, other)
+            && lhs_size == rhs_size
+        {
+            let elem = lhs_elem.least_supertype(rhs_elem)?;
+            return Some(DType::FixedSizeList(Arc::new(elem), *lhs_size, union_null));
+        }
+
+        // 8. List + List: recurse on element dtype.
+        if let (DType::List(lhs_elem, _), DType::List(rhs_elem, _)) = (self, other) {
+            let elem = lhs_elem.least_supertype(rhs_elem)?;
+            return Some(DType::List(Arc::new(elem), union_null));
+        }
+
+        // 9. Extension + anything: delegate to vtable
         if let DType::Extension(ext) = self {
             return ext
                 .least_supertype(other)
@@ -138,7 +158,7 @@ impl DType {
                 .map(|dt| dt.with_nullability(union_null));
         }
 
-        // 8. Everything else: no common supertype
+        // 10. Everything else: no common supertype
         None
     }
 
@@ -194,12 +214,24 @@ impl DType {
                 && (self.is_nullable() || !other.is_nullable());
         }
 
-        // 7. Extension: delegate to vtable
+        // 7. FixedSizeList / List widening: defer to least_supertype + identity check
+        if matches!(
+            (self, other),
+            (DType::FixedSizeList(..), DType::FixedSizeList(..))
+                | (DType::List(..), DType::List(..))
+        ) {
+            return other
+                .least_supertype(self)
+                .is_some_and(|st| st.eq_ignore_nullability(self))
+                && (self.is_nullable() || !other.is_nullable());
+        }
+
+        // 8. Extension: delegate to vtable
         if let DType::Extension(ext) = self {
             return ext.can_coerce_from(other);
         }
 
-        // 8. Everything else: false
+        // 9. Everything else: false
         false
     }
 
@@ -274,6 +306,8 @@ fn decimal_least_supertype(a: DecimalDType, b: DecimalDType) -> Option<DecimalDT
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use crate::dtype::DType;
     use crate::dtype::PType;
     use crate::dtype::decimal::DecimalDType;
@@ -450,6 +484,219 @@ mod tests {
         let result = DType::coerce_to_supertype(&types).unwrap();
         // U8 + I16: unsigned_signed_supertype max_width=max(1,2)=2 => I32
         assert_eq!(result, vec![DType::Primitive(PType::I32, NonNullable); 2]);
+    }
+
+    #[test]
+    fn fsl_widens_element_dtype_when_size_matches() {
+        let lhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            768,
+            NonNullable,
+        );
+        let rhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            768,
+            NonNullable,
+        );
+        let expected = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            768,
+            NonNullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+    }
+
+    #[test]
+    fn fsl_size_mismatch_returns_none() {
+        let lhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            768,
+            NonNullable,
+        );
+        let rhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            1024,
+            NonNullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), None);
+    }
+
+    #[test]
+    fn fsl_unions_outer_nullability() {
+        let lhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            4,
+            NonNullable,
+        );
+        let rhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            4,
+            Nullable,
+        );
+        let expected = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            4,
+            Nullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+    }
+
+    #[test]
+    fn fsl_widening_unions_element_nullability() {
+        let lhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            4,
+            NonNullable,
+        );
+        let rhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, Nullable)),
+            4,
+            NonNullable,
+        );
+        let expected = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, Nullable)),
+            4,
+            NonNullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+    }
+
+    #[test]
+    fn fsl_incompatible_elements_returns_none() {
+        let lhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            4,
+            NonNullable,
+        );
+        let rhs = DType::FixedSizeList(Arc::new(DType::Utf8(NonNullable)), 4, NonNullable);
+        assert_eq!(lhs.least_supertype(&rhs), None);
+    }
+
+    #[test]
+    fn fsl_can_coerce_from_widening() {
+        let target = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            4,
+            NonNullable,
+        );
+        let source = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            4,
+            NonNullable,
+        );
+        assert!(target.can_coerce_from(&source));
+        assert!(!source.can_coerce_from(&target));
+    }
+
+    #[test]
+    fn fsl_same_element_widening_unions_inner_nullability() {
+        let lhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::I32, NonNullable)),
+            4,
+            NonNullable,
+        );
+        let rhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::I32, Nullable)),
+            4,
+            NonNullable,
+        );
+        let expected = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::I32, Nullable)),
+            4,
+            NonNullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+    }
+
+    #[test]
+    fn list_widens_element_dtype() {
+        let lhs = DType::List(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            NonNullable,
+        );
+        let rhs = DType::List(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            NonNullable,
+        );
+        let expected = DType::List(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            NonNullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+    }
+
+    #[test]
+    fn list_unions_outer_nullability() {
+        let lhs = DType::List(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            NonNullable,
+        );
+        let rhs = DType::List(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            Nullable,
+        );
+        let expected = DType::List(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            Nullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+    }
+
+    #[test]
+    fn list_unions_inner_nullability() {
+        let lhs = DType::List(
+            Arc::new(DType::Primitive(PType::I32, NonNullable)),
+            NonNullable,
+        );
+        let rhs = DType::List(
+            Arc::new(DType::Primitive(PType::I32, Nullable)),
+            NonNullable,
+        );
+        let expected = DType::List(
+            Arc::new(DType::Primitive(PType::I32, Nullable)),
+            NonNullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+    }
+
+    #[test]
+    fn list_incompatible_elements_returns_none() {
+        let lhs = DType::List(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            NonNullable,
+        );
+        let rhs = DType::List(Arc::new(DType::Utf8(NonNullable)), NonNullable);
+        assert_eq!(lhs.least_supertype(&rhs), None);
+    }
+
+    #[test]
+    fn list_can_coerce_from_widening() {
+        let target = DType::List(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            NonNullable,
+        );
+        let source = DType::List(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            NonNullable,
+        );
+        assert!(target.can_coerce_from(&source));
+        assert!(!source.can_coerce_from(&target));
+    }
+
+    #[test]
+    fn fsl_can_coerce_from_size_mismatch_rejected() {
+        let a = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            4,
+            NonNullable,
+        );
+        let b = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            8,
+            NonNullable,
+        );
+        assert!(!a.can_coerce_from(&b));
+        assert!(!b.can_coerce_from(&a));
     }
 
     #[test]

--- a/vortex-tensor/public-api.lock
+++ b/vortex-tensor/public-api.lock
@@ -130,6 +130,8 @@ pub fn vortex_tensor::fixed_shape::FixedShapeTensor::deserialize_metadata(&self,
 
 pub fn vortex_tensor::fixed_shape::FixedShapeTensor::id(&self) -> vortex_array::dtype::extension::ExtId
 
+pub fn vortex_tensor::fixed_shape::FixedShapeTensor::least_supertype(ext_dtype: &vortex_array::dtype::extension::typed::ExtDType<Self>, other: &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
+
 pub fn vortex_tensor::fixed_shape::FixedShapeTensor::serialize_metadata(&self, metadata: &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
 pub fn vortex_tensor::fixed_shape::FixedShapeTensor::unpack_native<'a>(_ext_dtype: &'a vortex_array::dtype::extension::typed::ExtDType<Self>, storage_value: &'a vortex_array::scalar::scalar_value::ScalarValue) -> vortex_error::VortexResult<Self::NativeValue>
@@ -559,6 +561,8 @@ pub type vortex_tensor::vector::Vector::NativeValue<'a> = &'a vortex_array::scal
 pub fn vortex_tensor::vector::Vector::deserialize_metadata(&self, _metadata: &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_tensor::vector::Vector::id(&self) -> vortex_array::dtype::extension::ExtId
+
+pub fn vortex_tensor::vector::Vector::least_supertype(ext_dtype: &vortex_array::dtype::extension::typed::ExtDType<Self>, other: &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
 
 pub fn vortex_tensor::vector::Vector::serialize_metadata(&self, _metadata: &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 

--- a/vortex-tensor/src/types/fixed_shape/vtable.rs
+++ b/vortex-tensor/src/types/fixed_shape/vtable.rs
@@ -33,6 +33,22 @@ impl ExtVTable for FixedShapeTensor {
         proto::deserialize(metadata)
     }
 
+    fn least_supertype(ext_dtype: &ExtDType<Self>, other: &DType) -> Option<DType> {
+        let DType::Extension(other_ext) = other else {
+            return None;
+        };
+        // Only element dtype may widen — shape, dim_names, and permutation must match exactly.
+        let other_metadata = other_ext.metadata_opt::<Self>()?;
+        if ext_dtype.metadata() != other_metadata {
+            return None;
+        }
+        let widened = ext_dtype
+            .storage_dtype()
+            .least_supertype(other_ext.storage_dtype())?;
+        let ext = ExtDType::<Self>::try_new(ext_dtype.metadata().clone(), widened).ok()?;
+        Some(DType::Extension(ext.erased()))
+    }
+
     fn validate_dtype(ext_dtype: &ExtDType<Self>) -> VortexResult<()> {
         let storage_dtype = ext_dtype.storage_dtype();
         let DType::FixedSizeList(element_dtype, list_size, _nullability) = storage_dtype else {
@@ -76,7 +92,13 @@ impl ExtVTable for FixedShapeTensor {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use rstest::rstest;
+    use vortex_array::dtype::DType;
+    use vortex_array::dtype::Nullability;
+    use vortex_array::dtype::PType;
+    use vortex_array::dtype::extension::ExtDType;
     use vortex_array::dtype::extension::ExtVTable;
     use vortex_error::VortexResult;
 
@@ -117,5 +139,71 @@ mod tests {
         #[case] metadata: VortexResult<FixedShapeTensorMetadata>,
     ) -> VortexResult<()> {
         assert_roundtrip(&metadata?)
+    }
+
+    /// Constructs a `FixedShapeTensor` ext dtype wrapped in `DType::Extension`.
+    fn tensor_dtype(
+        metadata: FixedShapeTensorMetadata,
+        element: PType,
+        list_size: u32,
+    ) -> VortexResult<DType> {
+        let storage = DType::FixedSizeList(
+            Arc::new(DType::Primitive(element, Nullability::NonNullable)),
+            list_size,
+            Nullability::NonNullable,
+        );
+        Ok(DType::Extension(
+            ExtDType::<FixedShapeTensor>::try_new(metadata, storage)?.erased(),
+        ))
+    }
+
+    #[test]
+    fn tensor_widens_element_when_metadata_matches() -> VortexResult<()> {
+        let metadata = FixedShapeTensorMetadata::new(vec![2, 3]);
+        let lhs = tensor_dtype(metadata.clone(), PType::F32, 6)?;
+        let rhs = tensor_dtype(metadata.clone(), PType::F64, 6)?;
+        let expected = tensor_dtype(metadata, PType::F64, 6)?;
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+        Ok(())
+    }
+
+    #[test]
+    fn tensor_different_shape_returns_none() -> VortexResult<()> {
+        let lhs = tensor_dtype(FixedShapeTensorMetadata::new(vec![2, 3]), PType::F32, 6)?;
+        let rhs = tensor_dtype(FixedShapeTensorMetadata::new(vec![3, 2]), PType::F32, 6)?;
+        assert_eq!(lhs.least_supertype(&rhs), None);
+        Ok(())
+    }
+
+    #[test]
+    fn tensor_different_permutation_returns_none() -> VortexResult<()> {
+        let lhs_metadata =
+            FixedShapeTensorMetadata::new(vec![2, 3]).with_permutation(vec![0, 1])?;
+        let rhs_metadata =
+            FixedShapeTensorMetadata::new(vec![2, 3]).with_permutation(vec![1, 0])?;
+        let lhs = tensor_dtype(lhs_metadata, PType::F32, 6)?;
+        let rhs = tensor_dtype(rhs_metadata, PType::F32, 6)?;
+        assert_eq!(lhs.least_supertype(&rhs), None);
+        Ok(())
+    }
+
+    #[test]
+    fn tensor_different_dim_names_returns_none() -> VortexResult<()> {
+        let lhs_metadata = FixedShapeTensorMetadata::new(vec![2, 3])
+            .with_dim_names(vec!["x".into(), "y".into()])?;
+        let rhs_metadata = FixedShapeTensorMetadata::new(vec![2, 3])
+            .with_dim_names(vec!["rows".into(), "cols".into()])?;
+        let lhs = tensor_dtype(lhs_metadata, PType::F32, 6)?;
+        let rhs = tensor_dtype(rhs_metadata, PType::F32, 6)?;
+        assert_eq!(lhs.least_supertype(&rhs), None);
+        Ok(())
+    }
+
+    #[test]
+    fn tensor_vs_non_extension_returns_none() -> VortexResult<()> {
+        let lhs = tensor_dtype(FixedShapeTensorMetadata::new(vec![2, 3]), PType::F32, 6)?;
+        let rhs = DType::Primitive(PType::F32, Nullability::NonNullable);
+        assert_eq!(lhs.least_supertype(&rhs), None);
+        Ok(())
     }
 }

--- a/vortex-tensor/src/types/vector/vtable.rs
+++ b/vortex-tensor/src/types/vector/vtable.rs
@@ -31,6 +31,20 @@ impl ExtVTable for Vector {
         Ok(EmptyMetadata)
     }
 
+    fn least_supertype(ext_dtype: &ExtDType<Self>, other: &DType) -> Option<DType> {
+        let DType::Extension(other_ext) = other else {
+            return None;
+        };
+        if !other_ext.is::<Self>() {
+            return None;
+        }
+        let widened = ext_dtype
+            .storage_dtype()
+            .least_supertype(other_ext.storage_dtype())?;
+        let ext = ExtDType::<Self>::try_new(EmptyMetadata, widened).ok()?;
+        Some(DType::Extension(ext.erased()))
+    }
+
     fn validate_dtype(ext_dtype: &ExtDType<Self>) -> VortexResult<()> {
         let storage_dtype = ext_dtype.storage_dtype();
         let DType::FixedSizeList(element_dtype, _list_size, _nullability) = storage_dtype else {
@@ -136,6 +150,64 @@ mod tests {
         assert!(bytes.is_empty());
         let deserialized = vtable.deserialize_metadata(&bytes)?;
         assert_eq!(deserialized, EmptyMetadata);
+        Ok(())
+    }
+
+    /// Constructs a `Vector` ext dtype wrapped in `DType::Extension`.
+    fn vector_dtype(ptype: PType, dims: u32) -> VortexResult<DType> {
+        vector_dtype_with_outer(ptype, dims, Nullability::NonNullable)
+    }
+
+    /// Constructs a `Vector` ext dtype with the given outer `Nullability`, wrapped in
+    /// `DType::Extension`.
+    fn vector_dtype_with_outer(ptype: PType, dims: u32, outer: Nullability) -> VortexResult<DType> {
+        let storage = vector_storage_dtype(ptype, dims, outer);
+        Ok(DType::Extension(
+            ExtDType::<Vector>::try_new(EmptyMetadata, storage)?.erased(),
+        ))
+    }
+
+    #[test]
+    fn vector_widens_float_precision() -> VortexResult<()> {
+        let lhs = vector_dtype(PType::F32, 768)?;
+        let rhs = vector_dtype(PType::F64, 768)?;
+        let expected = vector_dtype(PType::F64, 768)?;
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+        Ok(())
+    }
+
+    #[test]
+    fn vector_dim_mismatch_returns_none() -> VortexResult<()> {
+        let lhs = vector_dtype(PType::F32, 768)?;
+        let rhs = vector_dtype(PType::F32, 1024)?;
+        assert_eq!(lhs.least_supertype(&rhs), None);
+        Ok(())
+    }
+
+    #[test]
+    fn vector_vs_non_extension_returns_none() -> VortexResult<()> {
+        let lhs = vector_dtype(PType::F32, 768)?;
+        let rhs = DType::Primitive(PType::F32, Nullability::NonNullable);
+        assert_eq!(lhs.least_supertype(&rhs), None);
+        Ok(())
+    }
+
+    #[test]
+    fn vector_unions_outer_nullability_with_float_widening() -> VortexResult<()> {
+        // Regression: widened result must re-validate — element non-nullable invariant preserved.
+        let lhs = vector_dtype_with_outer(PType::F32, 4, Nullability::NonNullable)?;
+        let rhs = vector_dtype_with_outer(PType::F64, 4, Nullability::Nullable)?;
+        let expected = vector_dtype_with_outer(PType::F64, 4, Nullability::Nullable)?;
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+        Ok(())
+    }
+
+    #[test]
+    fn vector_same_ptype_unions_outer_nullability() -> VortexResult<()> {
+        let lhs = vector_dtype_with_outer(PType::F32, 4, Nullability::NonNullable)?;
+        let rhs = vector_dtype_with_outer(PType::F32, 4, Nullability::Nullable)?;
+        let expected = vector_dtype_with_outer(PType::F32, 4, Nullability::Nullable)?;
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
         Ok(())
     }
 }

--- a/vortex-tensor/src/types/vector/vtable.rs
+++ b/vortex-tensor/src/types/vector/vtable.rs
@@ -194,7 +194,6 @@ mod tests {
 
     #[test]
     fn vector_unions_outer_nullability_with_float_widening() -> VortexResult<()> {
-        // Regression: widened result must re-validate — element non-nullable invariant preserved.
         let lhs = vector_dtype_with_outer(PType::F32, 4, Nullability::NonNullable)?;
         let rhs = vector_dtype_with_outer(PType::F64, 4, Nullability::Nullable)?;
         let expected = vector_dtype_with_outer(PType::F64, 4, Nullability::Nullable)?;


### PR DESCRIPTION
Widening Vector<f32, 768> and Vector<f64, 768> now returns Vector<f64, 768> instead of None.