### PR TITLE
Faster BoolArray::min_max via true_count instead of set_slices

### DIFF
--- a/vortex-array/src/aggregate_fn/fns/min_max/bool.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/bool.rs
@@ -4,7 +4,7 @@
 use std::ops::BitAnd;
 
 use vortex_error::VortexResult;
-use vortex_mask::Mask;
+use vortex_mask::AllOr;
 
 use super::MinMaxPartial;
 use super::MinMaxResult;
@@ -27,53 +27,30 @@ pub(super) fn accumulate_bool(
         .as_ref()
         .validity()?
         .execute_mask(array.as_ref().len(), ctx)?;
-    let true_non_null = match &mask {
-        Mask::AllTrue(_) => array.to_bit_buffer(),
-        Mask::AllFalse(_) => return Ok(()),
-        Mask::Values(v) => array.to_bit_buffer().bitand(v.bit_buffer()),
+    let (true_count, valid_count) = match mask.bit_buffer() {
+        AllOr::None => return Ok(()),
+        AllOr::All => (array.to_bit_buffer().true_count(), array.as_ref().len()),
+        AllOr::Some(validity) => (
+            array.to_bit_buffer().bitand(validity).true_count(),
+            validity.true_count(),
+        ),
     };
 
-    let mut true_slices = true_non_null.set_slices();
-
-    let Some(slice) = true_slices.next() else {
-        // all false
-        partial.merge(Some(MinMaxResult {
-            min: Scalar::bool(false, NonNullable),
-            max: Scalar::bool(false, NonNullable),
-        }));
-        return Ok(());
-    };
-
-    if slice.0 == 0 && slice.1 == array.len() {
-        // all true
-        partial.merge(Some(MinMaxResult {
-            min: Scalar::bool(true, NonNullable),
-            max: Scalar::bool(true, NonNullable),
-        }));
+    if valid_count == 0 {
         return Ok(());
     }
 
-    // Check for valid false values when we have a partial validity mask
-    match &mask {
-        Mask::AllTrue(_) | Mask::AllFalse(_) => {}
-        Mask::Values(v) => {
-            let false_non_null = (!array.to_bit_buffer()).bitand(v.bit_buffer());
-            let mut false_slices = false_non_null.set_slices();
-
-            if false_slices.next().is_none() {
-                // No false values, so all valid values are true
-                partial.merge(Some(MinMaxResult {
-                    min: Scalar::bool(true, NonNullable),
-                    max: Scalar::bool(true, NonNullable),
-                }));
-                return Ok(());
-            }
-        }
-    }
+    let (min, max) = if true_count == 0 {
+        (false, false)
+    } else if true_count == valid_count {
+        (true, true)
+    } else {
+        (false, true)
+    };
 
     partial.merge(Some(MinMaxResult {
-        min: Scalar::bool(false, NonNullable),
-        max: Scalar::bool(true, NonNullable),
+        min: Scalar::bool(min, NonNullable),
+        max: Scalar::bool(max, NonNullable),
     }));
     Ok(())
 }


### PR DESCRIPTION
There's no need to compute valid slices, we can just use true_count

fix #7598 

Signed-off-by: Robert Kruszewski <github@robertk.io>
