### PR TITLE
remove unused methods from duckdb vtab

### DIFF
--- a/vortex-duckdb/cpp/error.cpp
+++ b/vortex-duckdb/cpp/error.cpp
@@ -1,17 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-#include <cassert>
-#include <exception>
-
+#include <string>
+#include "duckdb_vx/error.h"
 #include "duckdb_vx/duckdb_diagnostics.h"
-DUCKDB_INCLUDES_BEGIN
-#include "duckdb/common/exception.hpp"
-#include "duckdb/common/types/vector_buffer.hpp"
-#include "duckdb/common/types/vector.hpp"
-DUCKDB_INCLUDES_END
 
-#include "duckdb_vx.h"
+DUCKDB_INCLUDES_BEGIN
+#include "duckdb.h"
+#include "duckdb/common/assert.hpp"
+DUCKDB_INCLUDES_END
 
 extern "C" duckdb_vx_error duckdb_vx_error_create(const char *message, size_t message_length) {
     return reinterpret_cast<duckdb_vx_error>(new std::string(message, message_length));
@@ -33,26 +30,15 @@ std::string IntoErrString(duckdb_vx_error error) {
     if (!error) {
         return {};
     }
-    return *reinterpret_cast<std::string *>(error);
+    std::string *const error_str = reinterpret_cast<std::string *>(error);
+    std::string out = std::move(*error_str);
+    duckdb_vx_error_free(error);
+    return out;
 }
 
 duckdb_state SetError(duckdb_vx_error *error_out, std::string_view message) {
-    assert(error_out != nullptr && "SetError called with null error_out");
+    D_ASSERT(error_out != nullptr && "SetError called with null error_out");
     *error_out = duckdb_vx_error_create(message.data(), message.size());
     return DuckDBError;
-}
-
-duckdb_state HandleException(std::exception_ptr ex, duckdb_vx_error *error_out) {
-    if (!ex) {
-        return SetError(error_out, "Unknown error");
-    }
-
-    try {
-        std::rethrow_exception(ex);
-    } catch (const std::exception &caught) {
-        return SetError(error_out, caught.what());
-    } catch (...) {
-        return SetError(error_out, "Unknown error");
-    }
 }
 } // namespace vortex

--- a/vortex-duckdb/cpp/file_system.cpp
+++ b/vortex-duckdb/cpp/file_system.cpp
@@ -12,12 +12,9 @@ DUCKDB_INCLUDES_BEGIN
 #include <duckdb/main/client_context.hpp>
 DUCKDB_INCLUDES_END
 
-#include <memory>
-#include <string>
 #include <utility>
 
 using namespace duckdb;
-using vortex::HandleException;
 using vortex::SetError;
 
 extern "C" duckdb_vx_file_handle

--- a/vortex-duckdb/cpp/include/duckdb_vx/error.hpp
+++ b/vortex-duckdb/cpp/include/duckdb_vx/error.hpp
@@ -17,5 +17,4 @@ DUCKDB_INCLUDES_END
 namespace vortex {
 std::string IntoErrString(duckdb_vx_error error);
 duckdb_state SetError(duckdb_vx_error *error_out, std::string_view message);
-duckdb_state HandleException(std::exception_ptr ex, duckdb_vx_error *error_out);
 } // namespace vortex

--- a/vortex-duckdb/cpp/include/duckdb_vx/table_function.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/table_function.h
@@ -12,9 +12,8 @@
 #include "error.h"
 #include "table_filter.h"
 #include "duckdb_vx/data.h"
-#include "duckdb_vx/client_context.h"
 
-#ifdef __cplusplus /* If compiled as C++, use C ABI */
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -22,15 +21,9 @@ extern "C" {
 typedef struct duckdb_vx_tfunc_bind_input_ *duckdb_vx_tfunc_bind_input;
 typedef struct duckdb_vx_tfunc_bind_result_ *duckdb_vx_tfunc_bind_result;
 
-// Fetch the parameter count from the bind info.
-size_t duckdb_vx_tfunc_bind_input_get_parameter_count(duckdb_vx_tfunc_bind_input ffi_input);
-
 // Fetch a parameter from the bind info.
 // The caller is responsible for freeing the value using duckdb_value_free.
 duckdb_value duckdb_vx_tfunc_bind_input_get_parameter(duckdb_vx_tfunc_bind_input ffi_input, size_t index);
-
-duckdb_value duckdb_vx_tfunc_bind_input_get_named_parameter(duckdb_vx_tfunc_bind_input ffi_input,
-                                                            const char *name_str);
 
 // Add a result column to the bind info.
 void duckdb_vx_tfunc_bind_result_add_column(duckdb_vx_tfunc_bind_result ffi_result,
@@ -90,22 +83,12 @@ typedef struct {
     bool has_null;
 } duckdb_column_statistics;
 
-typedef idx_t column_t;
-
-// A transparent DuckDB table function vtable, which can be used to configure a table function.
-// See duckdb/include/function/tfunc.hpp for details on each field.
+// vtable mimicking subset of TableFunction.
+// See duckdb/include/function/tfunc.hpp
 typedef struct {
-    // The name of the table function.
     const char *name;
-
-    // The parameters of the table function.
     const duckdb_logical_type *parameters;
     size_t parameter_count;
-
-    // The named parameters of the table function.
-    const duckdb_logical_type *named_parameter_types;
-    const char *const *named_parameter_names;
-    size_t named_parameter_count;
 
     duckdb_vx_data (*bind)(duckdb_client_context ctx,
                            duckdb_vx_tfunc_bind_input input,
@@ -113,9 +96,6 @@ typedef struct {
                            duckdb_vx_error *error_out);
 
     duckdb_vx_data (*bind_data_clone)(const void *bind_data, duckdb_vx_error *error_out);
-
-    // void *bind_replace;
-    // void *bind_operator;
 
     duckdb_vx_data (*init_global)(const duckdb_vx_tfunc_init_input *input, duckdb_vx_error *error_out);
 
@@ -130,21 +110,14 @@ typedef struct {
                      duckdb_data_chunk data_chunk_out,
                      duckdb_vx_error *error_out);
 
-    // void *in_out_function;
-    // void *in_out_function_final;
-
-    // false if statistics are not available
     bool (*statistics)(duckdb_client_context context,
                        const void *bind_data,
                        size_t column_index,
                        duckdb_column_statistics *stats_out);
 
-    // void *dependency;
     void (*cardinality)(void *bind_data, duckdb_vx_node_statistics *node_stats_out);
 
     bool (*pushdown_complex_filter)(void *bind_data, duckdb_vx_expr expr, duckdb_vx_error *error_out);
-
-    void *pushdown_expression;
 
     void (*to_string)(void *bind_data, duckdb_vx_string_map map);
 
@@ -154,25 +127,11 @@ typedef struct {
                                 void *init_global_data,
                                 void *init_local_data,
                                 duckdb_vx_error *error_out);
-    // void *get_bind_info;
-    // void *type_pushdown;
-    // void *get_multi_file_reader;
-    // void *supports_pushdown_type;
-    // void *get_partition_info;
-    // void *get_partition_stats;
-    // void *get_row_id_columns;
-
-    bool projection_pushdown;
-    bool filter_pushdown;
-    bool filter_prune;
-    bool sampling_pushdown;
-    bool late_materialization;
-    idx_t max_threads;
 } duckdb_vx_tfunc_vtab_t;
 
 // A single function for configuring the DuckDB table function vtable.
 duckdb_state duckdb_vx_tfunc_register(duckdb_database ffi_db, const duckdb_vx_tfunc_vtab_t *vtab);
 
-#ifdef __cplusplus /* End C ABI */
+#ifdef __cplusplus
 }
 #endif

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-#include "duckdb_vx/table_function.h"
+#include "duckdb_vx/data.hpp"
 #include "duckdb_vx/duckdb_diagnostics.h"
+#include "duckdb_vx/error.hpp"
+#include "duckdb_vx/table_function.h"
 
 DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
@@ -14,40 +16,36 @@ DUCKDB_INCLUDES_BEGIN
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 DUCKDB_INCLUDES_END
 
-#include "duckdb_vx.h"
-#include "duckdb_vx/data.hpp"
-#include "duckdb_vx/error.hpp"
-
 using namespace duckdb;
+using vortex::CData;
+using vortex::IntoErrString;
 
-namespace vortex {
 struct CTableFunctionInfo final : TableFunctionInfo {
-    explicit CTableFunctionInfo(const duckdb_vx_tfunc_vtab_t &vtab)
-        : vtab(vtab), max_threads(vtab.max_threads) {
+    explicit CTableFunctionInfo(const duckdb_vx_tfunc_vtab_t &vtab) : vtab(vtab) {
     }
 
     duckdb_vx_tfunc_vtab_t vtab;
-    idx_t max_threads;
 };
 
 struct CTableBindData final : TableFunctionData {
     CTableBindData(unique_ptr<CTableFunctionInfo> info_p,
-                   unique_ptr<vortex::CData> ffi_data_p,
+                   unique_ptr<CData> ffi_data_p,
                    const vector<LogicalType> &types)
         : info(std::move(info_p)), ffi_data(std::move(ffi_data_p)), types(types) {
     }
 
     unique_ptr<FunctionData> Copy() const override {
-        assert(info->vtab.bind_data_clone != nullptr);
+        D_ASSERT(info->vtab.bind_data_clone);
 
         duckdb_vx_error error_out = nullptr;
         const auto copied_ffi_data = info->vtab.bind_data_clone(ffi_data->DataPtr(), &error_out);
         if (error_out) {
             throw BinderException(IntoErrString(error_out));
         }
-        return make_uniq<CTableBindData>(make_uniq<CTableFunctionInfo>(info->vtab),
-                                         unique_ptr<CData>(reinterpret_cast<CData *>(copied_ffi_data)),
-                                         types);
+
+        auto info_p = make_uniq<CTableFunctionInfo>(info->vtab);
+        auto ffi_data_p = unique_ptr<CData>(reinterpret_cast<CData *>(copied_ffi_data));
+        return make_uniq<CTableBindData>(std::move(info_p), std::move(ffi_data_p), types);
     }
 
     unique_ptr<CTableFunctionInfo> info;
@@ -56,23 +54,21 @@ struct CTableBindData final : TableFunctionData {
 };
 
 struct CTableGlobalData final : GlobalTableFunctionState {
-    explicit CTableGlobalData(unique_ptr<vortex::CData> ffi_data_p, idx_t max_threads_p)
-        : ffi_data(std::move(ffi_data_p)), max_threads(max_threads_p) {
+    explicit CTableGlobalData(unique_ptr<CData> ffi_data_p) : ffi_data(std::move(ffi_data_p)) {
     }
-
-    unique_ptr<vortex::CData> ffi_data;
-    idx_t max_threads;
 
     idx_t MaxThreads() const override {
-        return max_threads;
+        return GlobalTableFunctionState::MAX_THREADS;
     }
+
+    unique_ptr<CData> ffi_data;
 };
 
 struct CTableLocalData final : LocalTableFunctionState {
-    explicit CTableLocalData(unique_ptr<vortex::CData> ffi_data_p) : ffi_data(std::move(ffi_data_p)) {
+    explicit CTableLocalData(unique_ptr<CData> ffi_data_p) : ffi_data(std::move(ffi_data_p)) {
     }
 
-    unique_ptr<vortex::CData> ffi_data;
+    unique_ptr<CData> ffi_data;
 };
 
 /**
@@ -236,9 +232,8 @@ unique_ptr<GlobalTableFunctionState> c_init_global(ClientContext &context, Table
         throw BinderException(IntoErrString(error_out));
     }
 
-    return make_uniq<CTableGlobalData>(
-        unique_ptr<vortex::CData>(reinterpret_cast<vortex::CData *>(ffi_global_data)),
-        bind.info->max_threads);
+    auto cdata = unique_ptr<CData>(reinterpret_cast<CData *>(ffi_global_data));
+    return make_uniq<CTableGlobalData>(std::move(cdata));
 }
 
 unique_ptr<LocalTableFunctionState> c_init_local(ExecutionContext &context,
@@ -263,8 +258,7 @@ unique_ptr<LocalTableFunctionState> c_init_local(ExecutionContext &context,
         throw BinderException(IntoErrString(error_out));
     }
 
-    return make_uniq<CTableLocalData>(
-        unique_ptr<vortex::CData>(reinterpret_cast<vortex::CData *>(ffi_local_data)));
+    return make_uniq<CTableLocalData>(unique_ptr<CData>(reinterpret_cast<CData *>(ffi_local_data)));
 }
 
 void c_function(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
@@ -275,34 +269,26 @@ void c_function(ClientContext &context, TableFunctionInput &input, DataChunk &ou
     auto global_data = input.global_state->Cast<CTableGlobalData>().ffi_data->DataPtr();
     auto local_data = input.local_state->Cast<CTableLocalData>().ffi_data->DataPtr();
 
+    duckdb_data_chunk chunk = reinterpret_cast<duckdb_data_chunk>(&output);
     duckdb_vx_error error_out = nullptr;
-    bind.info->vtab.function(ctx,
-                             bind_data,
-                             global_data,
-                             local_data,
-                             reinterpret_cast<duckdb_data_chunk>(&output),
-                             &error_out);
+    bind.info->vtab.function(ctx, bind_data, global_data, local_data, chunk, &error_out);
     if (error_out) {
         throw InvalidInputException(IntoErrString(error_out));
     }
 }
 
-void c_pushdown_complex_filter(ClientContext & /*context*/,
-                               LogicalGet & /*get*/,
+void c_pushdown_complex_filter(ClientContext &,
+                               LogicalGet &,
                                FunctionData *bind_data,
                                vector<unique_ptr<Expression>> &filters) {
-    if (filters.empty()) {
-        return;
-    }
-
     auto &bind = bind_data->Cast<CTableBindData>();
+    void *const ffi_bind = bind.ffi_data->DataPtr();
 
     for (auto iter = filters.begin(); iter != filters.end();) {
         duckdb_vx_error error_out = nullptr;
-        auto pushed =
-            bind.info->vtab.pushdown_complex_filter(bind_data->Cast<CTableBindData>().ffi_data->DataPtr(),
-                                                    reinterpret_cast<duckdb_vx_expr>(iter->get()),
-                                                    &error_out);
+        duckdb_vx_expr ffi_expr = reinterpret_cast<duckdb_vx_expr>(iter->get());
+
+        const bool pushed = bind.info->vtab.pushdown_complex_filter(ffi_bind, ffi_expr, &error_out);
         if (error_out) {
             throw BinderException(IntoErrString(error_out));
         }
@@ -312,55 +298,32 @@ void c_pushdown_complex_filter(ClientContext & /*context*/,
     }
 }
 
-unique_ptr<NodeStatistics> c_cardinality(ClientContext & /*context*/, const FunctionData *bind_data) {
+unique_ptr<NodeStatistics> c_cardinality(ClientContext &, const FunctionData *bind_data) {
     auto &bind = bind_data->Cast<CTableBindData>();
 
-    duckdb_vx_node_statistics node_stats_out = {
-        .estimated_cardinality = 0,
-        .max_cardinality = 0,
-        .has_estimated_cardinality = false,
-        .has_max_cardinality = false,
-    };
-    bind.info->vtab.cardinality(bind_data->Cast<CTableBindData>().ffi_data->DataPtr(), &node_stats_out);
+    duckdb_vx_node_statistics stats = {};
+    bind.info->vtab.cardinality(bind.ffi_data->DataPtr(), &stats);
 
-    auto stats = make_uniq<NodeStatistics>();
-    stats->has_estimated_cardinality = node_stats_out.has_estimated_cardinality;
-    stats->estimated_cardinality = node_stats_out.estimated_cardinality;
-    stats->has_max_cardinality = node_stats_out.has_max_cardinality;
-    stats->max_cardinality = node_stats_out.max_cardinality;
+    auto out = make_uniq<NodeStatistics>();
+    out->has_estimated_cardinality = stats.has_estimated_cardinality;
+    out->estimated_cardinality = stats.estimated_cardinality;
+    out->has_max_cardinality = stats.has_max_cardinality;
+    out->max_cardinality = stats.max_cardinality;
 
-    return stats;
-}
-
-extern "C" size_t duckdb_vx_tfunc_bind_input_get_parameter_count(duckdb_vx_tfunc_bind_input ffi_input) {
-    if (!ffi_input) {
-        return 0;
-    }
-    const auto input = reinterpret_cast<TableFunctionBindInput *>(ffi_input);
-    return input->inputs.size();
+    return out;
 }
 
 extern "C" duckdb_value duckdb_vx_tfunc_bind_input_get_parameter(duckdb_vx_tfunc_bind_input ffi_input,
                                                                  size_t index) {
-    if (!ffi_input || index >= duckdb_vx_tfunc_bind_input_get_parameter_count(ffi_input)) {
+    if (!ffi_input) {
         return nullptr;
     }
-    const auto info = reinterpret_cast<TableFunctionBindInput *>(ffi_input);
-    return reinterpret_cast<duckdb_value>(new Value(info->inputs[index]));
-}
 
-extern "C" duckdb_value duckdb_vx_tfunc_bind_input_get_named_parameter(duckdb_vx_tfunc_bind_input ffi_input,
-                                                                       const char *name) {
-    if (!ffi_input || !name) {
+    const TableFunctionBindInput &input = *reinterpret_cast<TableFunctionBindInput *>(ffi_input);
+    if (index >= input.inputs.size()) {
         return nullptr;
     }
-    const auto info = reinterpret_cast<TableFunctionBindInput *>(ffi_input);
-
-    if (!info->named_parameters.contains(name)) {
-        return nullptr;
-    }
-    auto value = duckdb::make_uniq<Value>(info->named_parameters.at(name));
-    return reinterpret_cast<duckdb_value>(value.release());
+    return reinterpret_cast<duckdb_value>(new Value(input.inputs[index]));
 }
 
 extern "C" void duckdb_vx_tfunc_bind_result_add_column(duckdb_vx_tfunc_bind_result ffi_result,
@@ -377,24 +340,21 @@ extern "C" void duckdb_vx_tfunc_bind_result_add_column(duckdb_vx_tfunc_bind_resu
     result->return_types.emplace_back(*logical_type);
 }
 
-OperatorPartitionData c_get_partition_data(ClientContext & /*context*/,
-                                           TableFunctionGetPartitionInput &input) {
+OperatorPartitionData c_get_partition_data(ClientContext &, TableFunctionGetPartitionInput &input) {
     if (input.partition_info.RequiresPartitionColumns()) {
         throw InternalException("TableScan::GetPartitionData: partition columns not supported");
     }
     auto &bind = input.bind_data->Cast<CTableBindData>();
-    auto &global = input.global_state->Cast<CTableGlobalData>();
-    auto &local = input.local_state->Cast<CTableLocalData>();
+    void *const ffi_bind = bind.ffi_data->DataPtr();
+    void *const ffi_global = input.global_state->Cast<CTableGlobalData>().ffi_data->DataPtr();
+    void *const ffi_local = input.local_state->Cast<CTableLocalData>().ffi_data->DataPtr();
 
     duckdb_vx_error error_out = nullptr;
-    auto index = bind.info->vtab.get_partition_data(bind.ffi_data->DataPtr(),
-                                                    global.ffi_data->DataPtr(),
-                                                    local.ffi_data->DataPtr(),
-                                                    &error_out);
+    const idx_t batch_index = bind.info->vtab.get_partition_data(ffi_bind, ffi_global, ffi_local, &error_out);
     if (error_out) {
         throw InvalidInputException(IntoErrString(error_out));
     }
-    return OperatorPartitionData(index);
+    return OperatorPartitionData(batch_index);
 }
 
 extern "C" void duckdb_vx_string_map_insert(duckdb_vx_string_map map, const char *key, const char *value) {
@@ -421,13 +381,15 @@ extern "C" duckdb_state duckdb_vx_tfunc_register(duckdb_database ffi_db, const d
     auto db = wrapper->database->instance;
     auto tf = TableFunction(vtab->name, {}, c_function, c_bind, c_init_global, c_init_local);
 
-    tf.pushdown_complex_filter = c_pushdown_complex_filter;
+    tf.projection_pushdown = true;
+    tf.filter_pushdown = true;
+    // We can prune out filter columns that are unused in the remainder of the query plan.
+    // e.g. in "SELECT i FROM tbl WHERE j = 42" j does not leave Vortex table function.
+    tf.filter_prune = true;
+    tf.sampling_pushdown = false;
+    tf.late_materialization = false;
 
-    tf.projection_pushdown = vtab->projection_pushdown;
-    tf.filter_pushdown = vtab->filter_pushdown;
-    tf.filter_prune = vtab->filter_prune;
-    tf.sampling_pushdown = vtab->sampling_pushdown;
-    tf.late_materialization = vtab->late_materialization;
+    tf.pushdown_complex_filter = c_pushdown_complex_filter;
     tf.cardinality = c_cardinality;
     tf.get_partition_data = c_get_partition_data;
     tf.to_string = c_to_string;
@@ -438,19 +400,12 @@ extern "C" duckdb_state duckdb_vx_tfunc_register(duckdb_database ffi_db, const d
         return {{COLUMN_IDENTIFIER_EMPTY, TableColumn("", LogicalTypeId::BOOLEAN)}};
     };
 
-    // Set up the parameters
     tf.arguments.reserve(vtab->parameter_count);
     for (size_t i = 0; i < vtab->parameter_count; i++) {
         auto logical_type = reinterpret_cast<LogicalType *>(vtab->parameters[i]);
         tf.arguments.emplace_back(*logical_type);
     }
-    // And the named parameters
-    for (size_t i = 0; i < vtab->named_parameter_count; i++) {
-        auto logical_type = reinterpret_cast<LogicalType *>(vtab->named_parameter_types[i]);
-        tf.named_parameters.emplace(vtab->named_parameter_names[i], *logical_type);
-    }
 
-    // Assign the VTable to the function info so we can access it later to invoke the callbacks.
     tf.function_info = make_shared_ptr<CTableFunctionInfo>(*vtab);
 
     try {
@@ -465,4 +420,3 @@ extern "C" duckdb_state duckdb_vx_tfunc_register(duckdb_database ffi_db, const d
     }
     return DuckDBSuccess;
 }
-} // namespace vortex

--- a/vortex-duckdb/src/datasource.rs
+++ b/vortex-duckdb/src/datasource.rs
@@ -7,7 +7,6 @@
 //! to get a blanket [`TableFunction`] implementation covering init, scan, progress, filter
 //! pushdown, cardinality, and partitioning.
 
-use std::ffi::CString;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
@@ -84,7 +83,7 @@ use crate::exporter::ConversionCache;
 /// first column. As we don't want to fill the output chunk and we can leave
 /// it uninitialized in this case, we define COLUMN_IDENTIFIER_EMPTY as a
 /// virtual column.
-/// See vortex-duckdb/cpp/table_function.cpp
+/// See virtual_columns in vortex-duckdb/cpp/table_function.cpp
 static EMPTY_COLUMN_IDX: u64 = 18446744073709551614;
 
 /// A trait for table functions that resolve to a [`DataSourceRef`].
@@ -93,15 +92,8 @@ static EMPTY_COLUMN_IDX: u64 = 18446744073709551614;
 /// data source. All other [`TableFunction`] methods (init, scan, progress, filter pushdown,
 /// cardinality, partitioning) are provided by a blanket implementation.
 pub(crate) trait DataSourceTableFunction: Sized + Debug {
-    /// Returns the positional parameters of the table function.
-    fn parameters() -> Vec<LogicalType> {
-        vec![]
-    }
-
-    /// Returns the named parameters of the table function, if any.
-    fn named_parameters() -> Vec<(CString, LogicalType)> {
-        vec![]
-    }
+    /// Positional parameters
+    fn parameters() -> Vec<LogicalType>;
 
     /// Bind the table function and return a [`DataSourceRef`].
     fn bind(ctx: &ClientContextRef, input: &BindInputRef) -> VortexResult<MultiLayoutDataSource>;
@@ -260,16 +252,8 @@ impl<T: DataSourceTableFunction> TableFunction for T {
     type GlobalState = DataSourceGlobal;
     type LocalState = DataSourceLocal;
 
-    const PROJECTION_PUSHDOWN: bool = true;
-    const FILTER_PUSHDOWN: bool = true;
-    const FILTER_PRUNE: bool = true;
-
     fn parameters() -> Vec<LogicalType> {
         T::parameters()
-    }
-
-    fn named_parameters() -> Vec<(CString, LogicalType)> {
-        T::named_parameters()
     }
 
     fn bind(
@@ -507,7 +491,7 @@ impl<T: DataSourceTableFunction> TableFunction for T {
         // Otherwise we'd have to open all files eagerly which is a performance
         // regression. Duckdb's Parquet reader only gets metadata for multiple
         // files with a UNION BY NAME and we don't support it (yet)
-        // https://github.com/duckdb/duckdb/blob/471de9f0e0e157ae672e56710e8c43b132a5ddc4/src/include/duckdb/common/multi_file/multi_file_function.hpp#L691
+        // See duckdb/common/multi_file/multi_file_function.hpp#L691
         if children.len() != 1 {
             return None;
         }
@@ -581,7 +565,7 @@ fn extract_projection_expr(
     column_fields: &[DuckdbField],
 ) -> Expression {
     // Projection ids may be empty, in which case you need to use projection_ids
-    // https://github.com/duckdb/duckdb/blob/6e211da91657a94803c465fd0ce585f4c6754b54/src/planner/operator/logical_get.cpp#L168
+    // See duckdb/src/planner/operator/logical_get.cpp#L168
     let (projection_ids, has_projection_ids) = match projection_ids {
         Some(ids) => (ids, true),
         None => (column_ids, false),

--- a/vortex-duckdb/src/duckdb/table_function/bind.rs
+++ b/vortex-duckdb/src/duckdb/table_function/bind.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::ffi::CStr;
-
 use vortex::error::vortex_err;
 
 use crate::cpp;
@@ -59,23 +57,6 @@ impl BindInputRef {
         } else {
             Some(unsafe { Value::own(value_ptr) })
         }
-    }
-
-    /// Returns the named parameter with the given name, if it exists.
-    pub fn get_named_parameter(&self, name: &CStr) -> Option<Value> {
-        let value_ptr = unsafe {
-            cpp::duckdb_vx_tfunc_bind_input_get_named_parameter(self.as_ptr(), name.as_ptr())
-        };
-        if value_ptr.is_null() {
-            None
-        } else {
-            Some(unsafe { Value::own(value_ptr) })
-        }
-    }
-
-    /// Returns the number of parameters bound to this function.
-    pub fn parameter_count(&self) -> usize {
-        unsafe { cpp::duckdb_vx_tfunc_bind_input_get_parameter_count(self.as_ptr()) }
     }
 }
 

--- a/vortex-duckdb/src/duckdb/table_function/mod.rs
+++ b/vortex-duckdb/src/duckdb/table_function/mod.rs
@@ -5,7 +5,6 @@ use std::ffi::CStr;
 use std::ffi::CString;
 use std::ffi::c_void;
 use std::fmt::Debug;
-use std::ptr;
 
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
@@ -65,33 +64,9 @@ pub trait TableFunction: Sized + Debug {
     type GlobalState: Send + Sync;
     type LocalState;
 
-    /// Whether the table function supports projection pushdown.
-    /// If not supported a projection will be added that filters out unused columns.
-    const PROJECTION_PUSHDOWN: bool = false;
-
-    /// Whether the table function supports filter pushdown.
-    /// If not supported a filter will be added that applies the table filter directly.
-    const FILTER_PUSHDOWN: bool = false;
-
-    /// Whether the table function can immediately prune out filter columns that are unused
-    /// in the remainder of the query plan.
-    /// e.g. "SELECT i FROM tbl WHERE j = 42;"
-    ///   - j does not need to leave the table function at all.
-    const FILTER_PRUNE: bool = false;
-
-    /// Maximum number of threads the table function can use.
-    /// If not specified, DuckDB will use its default (GlobalTableFunctionState::MAX_THREADS).
-    const MAX_THREADS: u64 = u64::MAX;
-
     /// Returns the parameters of the table function.
     fn parameters() -> Vec<LogicalType> {
         // By default, we don't have any parameters.
-        vec![]
-    }
-
-    /// Returns the named parameters of the table function, if any.
-    fn named_parameters() -> Vec<(CString, LogicalType)> {
-        // By default, we don't have any named parameters.
         vec![]
     }
 
@@ -103,6 +78,8 @@ pub trait TableFunction: Sized + Debug {
         result: &mut BindResultRef,
     ) -> VortexResult<Self::BindData>;
 
+    /// Report column statistics for a file or collections of files e.g.
+    /// registered as a VIEW.
     fn statistics(
         client_context: &ClientContextRef,
         bind_data: &Self::BindData,
@@ -167,8 +144,6 @@ pub trait TableFunction: Sized + Debug {
 
     /// Returns a vector of key-value pairs for EXPLAIN output
     fn to_string(bind_data: &Self::BindData, map: &mut DuckdbStringMapRef);
-
-    // TODO(ngates): there are many more callbacks that can be configured.
 }
 
 #[derive(Debug)]
@@ -190,19 +165,10 @@ impl DatabaseRef {
             .map(|logical_type| logical_type.as_ptr())
             .collect::<Vec<_>>();
 
-        let param_names = T::named_parameters();
-        let (param_names_ptrs, param_types_ptr) = param_names
-            .into_iter()
-            .map(|(name, logical_type)| (name.as_ptr(), logical_type.as_ptr()))
-            .unzip::<_, _, Vec<_>, Vec<_>>();
-
         let vtab = cpp::duckdb_vx_tfunc_vtab_t {
             name: name.as_ptr(),
             parameters: parameter_ptrs.as_ptr(),
             parameter_count: parameters.len() as _,
-            named_parameter_names: param_names_ptrs.as_ptr(),
-            named_parameter_types: param_types_ptr.as_ptr(),
-            named_parameter_count: param_names_ptrs.len() as _,
             bind: Some(bind_callback::<T>),
             bind_data_clone: Some(bind_data_clone_callback::<T>),
             init_global: Some(init_global_callback::<T>),
@@ -211,16 +177,9 @@ impl DatabaseRef {
             statistics: Some(statistics::<T>),
             cardinality: Some(cardinality_callback::<T>),
             pushdown_complex_filter: Some(pushdown_complex_filter_callback::<T>),
-            pushdown_expression: ptr::null_mut::<c_void>(),
             to_string: Some(to_string_callback::<T>),
             table_scan_progress: Some(table_scan_progress_callback::<T>),
             get_partition_data: Some(get_partition_data_callback::<T>),
-            projection_pushdown: T::PROJECTION_PUSHDOWN,
-            filter_pushdown: T::FILTER_PUSHDOWN,
-            filter_prune: T::FILTER_PRUNE,
-            sampling_pushdown: false,
-            late_materialization: false,
-            max_threads: T::MAX_THREADS,
         };
 
         duckdb_try!(


### PR DESCRIPTION
1. Remove unused and not set methods from duckdb vtab.
2. Correctly set MAX_THREADS for table function (was u64::MAX but duckdb uses
   another constant).
3. Move boolean definitions like filter pushdown to C++ part.
4. Remove named parameters since we don't support them.
5. Fix a memory leak when throwing errors.

