### PR TITLE
feat(cuda): fuse narrower-than-output Dict codes and RunEnd ends

### DIFF
--- a/vortex-cuda/kernels/src/dynamic_dispatch.cu
+++ b/vortex-cuda/kernels/src/dynamic_dispatch.cu
@@ -39,9 +39,16 @@
 //
 // ## Mixed-width support
 //
-// LOAD sources from pending subtrees may have a narrower type than the
-// output (e.g. u8 dict codes in a u32 plan). load_element() widens
-// to T via static_cast — no separate widen kernel or smem intermediate.
+// Dict codes, RunEnd ends, and other child arrays may have a narrower
+// element type than the output T. Two mechanisms handle this:
+//
+// LOAD       load_element() dispatches on the per-stage PTypeTag to
+//            read at the source's native width and static_cast to T.
+// BITUNPACK  bitunpack_typed() unpacks at the source's native width,
+//            then widens to T in-place via a backward scan
+//            (widen_inplace). The smem region is pre-allocated at
+//            max(source_width, T) bytes per element by the Rust plan
+//            builder, so the widen never overflows.
 
 #include <assert.h>
 #include <cuda.h>
@@ -203,6 +210,22 @@ scatter_patches_chunk(const GPUPatches &patches, T *__restrict out, uint32_t chu
 // Source ops
 // ═══════════════════════════════════════════════════════════════════════════
 
+/// Widen U-sized elements in shared memory to T-sized, in-place.
+/// Backward scan ensures no unread element is overwritten since
+/// sizeof(T) >= sizeof(U) guarantees the write at index i touches
+/// only bytes beyond those of src[i].
+template <typename T, typename U>
+__device__ inline void widen_inplace(T *dst, uint32_t len) {
+    if constexpr (sizeof(T) <= sizeof(U)) {
+        return;
+    }
+    const U *src = reinterpret_cast<const U *>(dst);
+    for (int32_t i = static_cast<int32_t>(len) - 1 - threadIdx.x; i >= 0; i -= blockDim.x) {
+        dst[i] = static_cast<T>(src[i]);
+    }
+    __syncthreads();
+}
+
 /// FastLanes cooperative unpack — all threads in the block scatter-write
 /// decoded elements into `dst`. Caller must issue __syncthreads() before
 /// any thread reads from `dst`.
@@ -233,6 +256,68 @@ __device__ inline void bitunpack(const T *__restrict packed,
             const auto &patches = *reinterpret_cast<const GPUPatches *>(src.params.bitunpack.patches_ptr);
             scatter_patches_chunk<T>(patches, chunk_dst, first_block + c);
         }
+    }
+}
+
+/// Dispatch bitunpack at the source's native element width, then widen
+/// to T in-place so all downstream scalar ops and smem consumers see
+/// T-sized elements. Falls back to the direct `bitunpack<T>` path when
+/// the source ptype already matches T. Issues __syncthreads() before
+/// returning on all paths.
+///
+/// Accepts explicit chunk_start / chunk_len so it works for both input
+/// stages (full decode with chunk_start=0, chunk_len=stage.len) and
+/// the output stage (tiled with varying chunk_start / chunk_len).
+template <typename T>
+__device__ inline void bitunpack_typed(T *__restrict dst,
+                                       const void *__restrict packed,
+                                       uint64_t chunk_start,
+                                       uint32_t chunk_len,
+                                       const struct SourceOp &src,
+                                       PTypeTag source_ptype) {
+    // Fast path: source width matches T — no widening needed.
+    if (ptype_byte_width(source_ptype) == sizeof(T)) {
+        bitunpack<T>(reinterpret_cast<const T *>(packed), dst, chunk_start, chunk_len, src);
+        __syncthreads();
+        return;
+    }
+
+    // Compute total elements written by bitunpack (including alignment
+    // padding) so widen_inplace covers the full scratch region.
+    const uint32_t elem_off = src.params.bitunpack.element_offset;
+    const uint32_t dst_off = (chunk_start + elem_off) % FL_CHUNK;
+    const uint32_t n_chunks = (chunk_len + dst_off + FL_CHUNK - 1) / FL_CHUNK;
+    const uint32_t total_elems = n_chunks * FL_CHUNK;
+
+    // Narrow source: unpack at native width, then widen to T.
+    switch (source_ptype) {
+    case PTYPE_U8:
+    case PTYPE_I8: {
+        auto *narrow = reinterpret_cast<uint8_t *>(dst);
+        bitunpack<uint8_t>(reinterpret_cast<const uint8_t *>(packed), narrow, chunk_start, chunk_len, src);
+        __syncthreads();
+        widen_inplace<T, uint8_t>(dst, total_elems);
+        break;
+    }
+    case PTYPE_U16:
+    case PTYPE_I16: {
+        auto *narrow = reinterpret_cast<uint16_t *>(dst);
+        bitunpack<uint16_t>(reinterpret_cast<const uint16_t *>(packed), narrow, chunk_start, chunk_len, src);
+        __syncthreads();
+        widen_inplace<T, uint16_t>(dst, total_elems);
+        break;
+    }
+    case PTYPE_U32:
+    case PTYPE_I32:
+    case PTYPE_F32: {
+        auto *narrow = reinterpret_cast<uint32_t *>(dst);
+        bitunpack<uint32_t>(reinterpret_cast<const uint32_t *>(packed), narrow, chunk_start, chunk_len, src);
+        __syncthreads();
+        widen_inplace<T, uint32_t>(dst, total_elems);
+        break;
+    }
+    default:
+        __builtin_unreachable();
     }
 }
 
@@ -354,16 +439,14 @@ __device__ void execute_output_stage(T *__restrict output,
         if (src.op_code == SourceOp::BITUNPACK) {
             chunk_len = bitunpack_tile_len(stage, block_len, elem_idx);
             T *scratch = reinterpret_cast<T *>(smem + stage.smem_byte_offset);
-            bitunpack<T>(reinterpret_cast<const T *>(stage.input_ptr),
-                         scratch,
-                         block_start + elem_idx,
-                         chunk_len,
-                         src);
+            bitunpack_typed<T>(scratch,
+                               reinterpret_cast<const void *>(stage.input_ptr),
+                               block_start + elem_idx,
+                               chunk_len,
+                               src,
+                               ptype);
             const uint32_t align = (block_start + elem_idx + src.params.bitunpack.element_offset) % FL_CHUNK;
             smem_src = scratch + align;
-            // Write barrier: all threads finished bitunpack (and any
-            // patches), safe to read from scratch.
-            __syncthreads();
         } else {
             chunk_len = block_len;
         }
@@ -438,11 +521,12 @@ __device__ void execute_input_stage(const Stage &stage, char *__restrict smem) {
     const auto &src = stage.source;
 
     if (src.op_code == SourceOp::BITUNPACK) {
-        T *raw_smem = smem_out;
-        bitunpack<T>(reinterpret_cast<const T *>(stage.input_ptr), smem_out, 0, stage.len, src);
-        // Write barrier: cooperative bitunpack finished, safe to read
-        // decoded elements below.
-        __syncthreads();
+        bitunpack_typed<T>(smem_out,
+                           reinterpret_cast<const void *>(stage.input_ptr),
+                           0,
+                           stage.len,
+                           src,
+                           stage.source_ptype);
 
         smem_out += src.params.bitunpack.element_offset % SMEM_TILE_SIZE;
 

--- a/vortex-cuda/kernels/src/dynamic_dispatch.h
+++ b/vortex-cuda/kernels/src/dynamic_dispatch.h
@@ -78,6 +78,27 @@ PTYPE_HOST_DEVICE constexpr PTypeTag ptype_to_unsigned(PTypeTag tag) {
         return tag;
     }
 }
+
+PTYPE_HOST_DEVICE constexpr uint8_t ptype_byte_width(PTypeTag tag) {
+    switch (tag) {
+    case PTYPE_U8:
+    case PTYPE_I8:
+        return 1;
+    case PTYPE_U16:
+    case PTYPE_I16:
+        return 2;
+    case PTYPE_U32:
+    case PTYPE_I32:
+    case PTYPE_F32:
+        return 4;
+    case PTYPE_U64:
+    case PTYPE_I64:
+    case PTYPE_F64:
+        return 8;
+    default:
+        return 0;
+    }
+}
 #endif
 
 /// Number of threads per CUDA block.

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -1806,7 +1806,8 @@ mod tests {
     #[crate::test]
     async fn test_dict_bitpacked_u8_codes_u32_values() -> VortexResult<()> {
         // Dict with BitPacked u8 codes (narrower than u32 output) and u32 values.
-        // Codes become a pending subtree, values fuse.
+        // The kernel's bitunpack_typed decodes at the source's native width and
+        // widens to T, so this fuses into a single kernel launch.
         let dict_values: Vec<u32> = vec![100, 200, 300, 400];
         let len = 2048;
         let codes: Vec<u8> = (0..len).map(|i| (i % dict_values.len()) as u8).collect();
@@ -1825,8 +1826,8 @@ mod tests {
 
         let plan = DispatchPlan::new(&array)?;
         assert!(
-            matches!(plan, DispatchPlan::PartiallyFused { .. }),
-            "expected PartiallyFused for mixed-width Dict with BitPacked codes"
+            matches!(plan, DispatchPlan::Fused(..)),
+            "expected Fused for mixed-width Dict with BitPacked codes"
         );
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
@@ -1834,6 +1835,216 @@ mod tests {
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
         let expected: Vec<u32> = codes.iter().map(|&c| dict_values[c as usize]).collect();
+        let expected_arr = PrimitiveArray::new(Buffer::from(expected), NonNullable).into_array();
+        vortex::array::assert_arrays_eq!(expected_arr, result);
+
+        Ok(())
+    }
+
+    /// Dict with non-Primitive narrower codes (BitPacked) at various
+    /// code/value widths. These fuse into a single kernel because
+    /// bitunpack_typed decodes at the source's native width and widens to T.
+    #[rstest]
+    #[case::bp_u8_codes_u16_values(2u8, 3000usize, vec![100u16, 200, 300, 400])]
+    #[case::bp_u8_codes_u32_values(2u8, 3000usize, vec![100_000u32, 200_000, 300_000, 400_000])]
+    #[case::bp_u16_codes_u32_values(4u8, 2048usize, vec![1_000_000u32, 2_000_000, 3_000_000, 4_000_000, 5_000_000, 6_000_000, 7_000_000, 8_000_000])]
+    #[crate::test]
+    async fn test_dict_mixed_width_bitpacked_codes<V: vortex::dtype::NativePType + Into<u64>>(
+        #[case] bit_width: u8,
+        #[case] len: usize,
+        #[case] dict_values: Vec<V>,
+    ) -> VortexResult<()> {
+        let dict_size = dict_values.len();
+        let codes: Vec<u8> = (0..len).map(|i| (i % dict_size) as u8).collect();
+
+        let codes_prim = PrimitiveArray::new(Buffer::from(codes.clone()), NonNullable);
+        let codes_bp = BitPacked::encode(
+            &codes_prim.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("bitpack codes");
+        let values_prim = PrimitiveArray::new(Buffer::from(dict_values.clone()), NonNullable);
+        let dict = DictArray::try_new(codes_bp.into_array(), values_prim.into_array())?;
+        let array = dict.into_array();
+
+        let plan = DispatchPlan::new(&array)?;
+        assert!(
+            matches!(plan, DispatchPlan::Fused(..)),
+            "expected Fused for mixed-width Dict with BitPacked codes"
+        );
+
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
+        let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
+
+        let expected: Vec<V> = codes.iter().map(|&c| dict_values[c as usize]).collect();
+        let expected_arr = PrimitiveArray::new(Buffer::from(expected), NonNullable).into_array();
+        vortex::array::assert_arrays_eq!(expected_arr, result);
+
+        Ok(())
+    }
+
+    /// Dict with FoR(BitPacked) codes narrower than the value type.
+    /// The entire codes decode chain runs at the narrower width; the kernel
+    /// decodes at native width and widens to T, fusing everything.
+    #[rstest]
+    #[case::for_bp_u8_codes_u32_values(3u8, 3000usize, vec![100u32, 200, 300, 400, 500, 600, 700, 800])]
+    #[case::for_bp_u16_codes_u32_values(4u8, 2048usize, vec![10_000u32, 20_000, 30_000, 40_000, 50_000, 60_000, 70_000, 80_000])]
+    #[crate::test]
+    async fn test_dict_mixed_width_for_bp_codes<V: vortex::dtype::NativePType>(
+        #[case] bit_width: u8,
+        #[case] len: usize,
+        #[case] dict_values: Vec<V>,
+    ) -> VortexResult<()> {
+        let dict_size = dict_values.len();
+        let codes: Vec<u8> = (0..len).map(|i| (i % dict_size) as u8).collect();
+
+        let codes_prim = PrimitiveArray::new(Buffer::from(codes.clone()), NonNullable);
+        let codes_bp = BitPacked::encode(
+            &codes_prim.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("bitpack codes");
+        let codes_for = FoR::try_new(codes_bp.into_array(), Scalar::from(0u8))?;
+        let values_prim = PrimitiveArray::new(Buffer::from(dict_values.clone()), NonNullable);
+        let dict = DictArray::try_new(codes_for.into_array(), values_prim.into_array())?;
+        let array = dict.into_array();
+
+        let plan = DispatchPlan::new(&array)?;
+        assert!(
+            matches!(plan, DispatchPlan::Fused(..)),
+            "expected Fused for mixed-width Dict with FoR(BitPacked) codes"
+        );
+
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
+        let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
+
+        let expected: Vec<V> = codes.iter().map(|&c| dict_values[c as usize]).collect();
+        let expected_arr = PrimitiveArray::new(Buffer::from(expected), NonNullable).into_array();
+        vortex::array::assert_arrays_eq!(expected_arr, result);
+
+        Ok(())
+    }
+
+    /// RunEnd with non-Primitive narrower ends (BitPacked) and wider output
+    /// values. The kernel decodes at the source's native width and widens
+    /// to T in shared memory, fusing everything into one launch.
+    #[rstest]
+    #[case::bp_u8_ends_u16_values(
+        vec![25u8, 50, 75, 100],
+        vec![10u16, 20, 30, 40],
+        100usize,
+    )]
+    #[case::bp_u8_ends_u32_values(
+        vec![40u8, 80, 120],
+        vec![1000u32, 2000, 3000],
+        120usize,
+    )]
+    #[case::bp_u16_ends_u32_values(
+        vec![500u16, 1000, 1500, 2000],
+        vec![100_000u32, 200_000, 300_000, 400_000],
+        2000usize,
+    )]
+    #[crate::test]
+    async fn test_runend_mixed_width_bitpacked_ends<
+        E: vortex::dtype::NativePType + Into<u64> + TryInto<usize>,
+        V: vortex::dtype::NativePType + Copy,
+    >(
+        #[case] ends: Vec<E>,
+        #[case] values: Vec<V>,
+        #[case] len: usize,
+    ) -> VortexResult<()>
+    where
+        <E as TryInto<usize>>::Error: std::fmt::Debug,
+    {
+        let ends_u64: Vec<u64> = ends.iter().map(|e| (*e).into()).collect();
+
+        let bit_width = 64 - ends_u64.iter().max().unwrap().leading_zeros() as u8;
+        let ends_prim = PrimitiveArray::new(Buffer::from(ends.clone()), NonNullable);
+        let ends_bp = BitPacked::encode(
+            &ends_prim.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("bitpack ends");
+
+        let values_prim = PrimitiveArray::new(Buffer::from(values.clone()), NonNullable);
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let re = RunEnd::new(ends_bp.into_array(), values_prim.into_array(), &mut ctx);
+        let array = re.into_array();
+
+        let plan = DispatchPlan::new(&array)?;
+        assert!(
+            matches!(plan, DispatchPlan::Fused(..)),
+            "expected Fused for mixed-width RunEnd with BitPacked ends"
+        );
+
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
+        let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
+
+        let mut expected: Vec<V> = Vec::with_capacity(len);
+        let mut prev: u64 = 0;
+        for (end, val) in ends_u64.iter().zip(values.iter()) {
+            let run_len = (*end - prev) as usize;
+            expected.extend(std::iter::repeat_n(*val, run_len));
+            prev = *end;
+        }
+        let expected_arr = PrimitiveArray::new(Buffer::from(expected), NonNullable).into_array();
+        vortex::array::assert_arrays_eq!(expected_arr, result);
+
+        Ok(())
+    }
+
+    /// RunEnd with FoR(BitPacked) narrower ends: the full decode chain for
+    /// ends runs at a narrower width; the kernel's bitunpack_typed decodes
+    /// at native width and widens to T, fusing everything.
+    #[crate::test]
+    async fn test_runend_mixed_width_for_bp_u16_ends_u32_values() -> VortexResult<()> {
+        let ends: Vec<u16> = vec![500, 1000, 1500, 2000];
+        let values: Vec<u32> = vec![100, 200, 300, 400];
+        let len = 2000usize;
+
+        let ends_prim = PrimitiveArray::new(Buffer::from(ends.clone()), NonNullable);
+        let ends_bp = BitPacked::encode(
+            &ends_prim.into_array(),
+            11,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("bitpack ends");
+        let ends_for = FoR::try_new(ends_bp.into_array(), Scalar::from(0u16))?;
+
+        let values_prim = PrimitiveArray::new(Buffer::from(values.clone()), NonNullable);
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let re = RunEnd::new(ends_for.into_array(), values_prim.into_array(), &mut ctx);
+        let array = re.into_array();
+
+        let plan = DispatchPlan::new(&array)?;
+        assert!(
+            matches!(plan, DispatchPlan::Fused(..)),
+            "expected Fused for mixed-width RunEnd with FoR(BitPacked) ends"
+        );
+
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
+        let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
+
+        let expected: Vec<u32> = (0..len as u64)
+            .map(|i| {
+                if i < 500 {
+                    100
+                } else if i < 1000 {
+                    200
+                } else if i < 1500 {
+                    300
+                } else {
+                    400
+                }
+            })
+            .collect();
         let expected_arr = PrimitiveArray::new(Buffer::from(expected), NonNullable).into_array();
         vortex::array::assert_arrays_eq!(expected_arr, result);
 

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -1849,7 +1849,7 @@ mod tests {
     #[case::bp_u8_codes_u32_values(2u8, 3000usize, vec![100_000u32, 200_000, 300_000, 400_000])]
     #[case::bp_u16_codes_u32_values(4u8, 2048usize, vec![1_000_000u32, 2_000_000, 3_000_000, 4_000_000, 5_000_000, 6_000_000, 7_000_000, 8_000_000])]
     #[crate::test]
-    async fn test_dict_mixed_width_bitpacked_codes<V: vortex::dtype::NativePType + Into<u64>>(
+    async fn test_dict_mixed_width_bitpacked_codes<V: vortex::dtype::NativePType>(
         #[case] bit_width: u8,
         #[case] len: usize,
         #[case] dict_values: Vec<V>,
@@ -1936,32 +1936,25 @@ mod tests {
     #[case::bp_u8_ends_u16_values(
         vec![25u8, 50, 75, 100],
         vec![10u16, 20, 30, 40],
-        100usize,
     )]
     #[case::bp_u8_ends_u32_values(
         vec![40u8, 80, 120],
         vec![1000u32, 2000, 3000],
-        120usize,
     )]
     #[case::bp_u16_ends_u32_values(
         vec![500u16, 1000, 1500, 2000],
         vec![100_000u32, 200_000, 300_000, 400_000],
-        2000usize,
     )]
     #[crate::test]
     async fn test_runend_mixed_width_bitpacked_ends<
-        E: vortex::dtype::NativePType + Into<u64> + TryInto<usize>,
-        V: vortex::dtype::NativePType + Copy,
+        E: vortex::dtype::NativePType + Into<u64>,
+        V: vortex::dtype::NativePType,
     >(
         #[case] ends: Vec<E>,
         #[case] values: Vec<V>,
-        #[case] len: usize,
-    ) -> VortexResult<()>
-    where
-        <E as TryInto<usize>>::Error: std::fmt::Debug,
-    {
+    ) -> VortexResult<()> {
         let ends_u64: Vec<u64> = ends.iter().map(|e| (*e).into()).collect();
-
+        let len = *ends_u64.last().unwrap() as usize;
         let bit_width = 64 - ends_u64.iter().max().unwrap().leading_zeros() as u8;
         let ends_prim = PrimitiveArray::new(Buffer::from(ends.clone()), NonNullable);
         let ends_bp = BitPacked::encode(
@@ -2032,19 +2025,12 @@ mod tests {
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
-        let expected: Vec<u32> = (0..len as u64)
-            .map(|i| {
-                if i < 500 {
-                    100
-                } else if i < 1000 {
-                    200
-                } else if i < 1500 {
-                    300
-                } else {
-                    400
-                }
-            })
-            .collect();
+        let mut expected: Vec<u32> = Vec::with_capacity(len);
+        let mut prev = 0u16;
+        for (&end, &val) in ends.iter().zip(values.iter()) {
+            expected.extend(std::iter::repeat_n(val, (end - prev) as usize));
+            prev = end;
+        }
         let expected_arr = PrimitiveArray::new(Buffer::from(expected), NonNullable).into_array();
         vortex::array::assert_arrays_eq!(expected_arr, result);
 

--- a/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
+++ b/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
@@ -178,55 +178,28 @@ pub enum DispatchPlan {
 ///
 /// Stages are stored in kernel execution order. There are two phases:
 ///
-/// 1. All stages except the last run first and decode their output
-///    into shared memory (e.g. all dict values, all run-end endpoints).
-///    This data stays resident for the output stage to index into.
+/// 1. All stages except the last decode into shared memory (dict values,
+///    run-end endpoints). The kernel writes `T`-wide elements even when
+///    a stage's source ptype is narrower, widening in-place as needed.
 ///
-/// 2. The last stage (the output stage) iterates over the input in tiles
-///    of `SMEM_TILE_SIZE` (1024) elements, decoding each tile into a
-///    scratch region of shared memory, applying scalar ops (which may
-///    reference data from the earlier stages), and writing the result to
-///    global memory.
-///
-/// # Per-stage PType tracking
-///
-/// Each stage carries a `source_ptype` (`PTypeTag`) that identifies the
-/// primitive type produced by its source op (LOAD, BITUNPACK, etc.).
-/// Scalar ops may change the type (e.g. DICT transforms codes → values,
-/// ALP transforms encoded ints → floats); each `ScalarOp` declares its
-/// `output_ptype`. The kernel uses these tags to dispatch typed memory
-/// operations and cross-stage references at the correct element width.
+/// 2. The last stage (the output stage) tiles at `SMEM_TILE_SIZE` (1024)
+///    elements, decoding each tile into a scratch region, applying scalar
+///    ops (which may reference earlier stages), and streaming to global
+///    memory.
 ///
 /// # Shared memory allocation
 ///
-/// Total shared memory = `smem_byte_cursor` + `SMEM_TILE_SIZE` × `output_elem_bytes`.
+/// Total = `smem_byte_cursor` + `SMEM_TILE_SIZE × output_elem_bytes`.
 ///
-/// `smem_byte_cursor` is tracked in bytes and covers the preceding
-/// fully-decoded stages (dict values, run-end endpoints). Each stage's
-/// shared memory footprint is `len × final_ptype_byte_width`, where the
-/// final ptype is determined by the last scalar op's `output_ptype` (or
-/// `source_ptype` if there are no scalar ops).
+/// Each input stage occupies `len × max(final_width, output_elem_bytes)`
+/// bytes, where `final_width` is the byte width of the last scalar op's
+/// `output_ptype` (or `source_ptype` if none). The `max` is necessary
+/// because `execute_input_stage<T>` writes `T`-wide elements even when
+/// the stage's logical type is narrower.
 ///
-/// All shared memory offsets are byte offsets — the C ABI uses byte
-/// offsets and per-field `PTypeTag` values so that stages with different
-/// element widths can coexist in the same shared memory pool.
-///
-/// This is sufficient because:
-///
-/// - Earlier stages only originate from dict (values) and run-end (ends,
-///   values). `push_smem_stage` reserves the appropriate number of bytes
-///   in `smem_byte_cursor`, so each stage's source op has room to decode
-///   the complete input.
-///
-/// - The output stage (last) tiles at `SMEM_TILE_SIZE` (1024 elements),
-///   so its source op never writes more than 1024 elements into the
-///   scratch region, even though each block is responsible for
-///   `ELEMENTS_PER_BLOCK` (2048) output elements — it processes them in
-///   two passes through the scratch.
-///
-/// Note: `BITUNPACK` writes full FastLanes blocks (1024 elements), which can
-/// exceed `stage.len` by up to 1023 elements. This overflow is absorbed by
-/// the scratch region (`SMEM_TILE_SIZE` ≥ `FL_CHUNK_SIZE`).
+/// `BITUNPACK` writes full FastLanes blocks (1024 elements) which may
+/// exceed `stage.len` by up to 1023 elements; this overflow is absorbed
+/// by the scratch region (`SMEM_TILE_SIZE` ≥ `FL_CHUNK_SIZE`).
 pub struct FusedPlan {
     /// Stages in kernel execution order; all but the last decode into
     /// shared memory, the last decodes into global memory.
@@ -746,13 +719,10 @@ impl FusedPlan {
     }
 
     /// Add a stage that decodes fully into shared memory before the output
-    /// stage runs. Returns the shared memory byte offset where the data starts.
-    ///
-    /// The smem region is sized at the stage's output ptype width — i.e.
-    /// the ptype after all scalar ops have run. For stages that go through
-    /// type-changing scalar ops (e.g. dict values with FoR→ALP), the final
-    /// smem footprint is `len × final_ptype_byte_width`. If there are no
-    /// scalar ops, the source_ptype determines the width.
+    /// stage runs. Returns the shared memory byte offset where the data
+    /// starts. Allocates `len × max(final_width, output_elem_bytes)` bytes
+    /// so that narrower stages widened to `T` by `bitunpack_typed` never
+    /// overflow.
     fn push_smem_stage(&mut self, spec: Stage, len: u32) -> u32 {
         let smem_byte_offset = self.smem_byte_cursor;
         // The kernel's execute_input_stage<T> always writes T-wide elements

--- a/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
+++ b/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
@@ -445,22 +445,7 @@ impl FusedPlan {
         pending_subtrees: &mut Vec<ArrayRef>,
     ) -> VortexResult<Stage> {
         if !is_dyn_dispatch_compatible(&array) {
-            // Subtree can't be fused — record it as a deferred LOAD source.
-            // Bail if dtype is non-primitive (can't become a LOAD stage).
-            let ptype = PType::try_from(array.dtype()).map_err(|_| {
-                vortex_err!(
-                    "unfusable subtree has non-primitive dtype {:?}, cannot partially fuse",
-                    array.dtype()
-                )
-            })?;
-            let buf_idx = self.source_buffers.len();
-            self.source_buffers.push(None); // placeholder, filled at materialize time
-            pending_subtrees.push(array);
-            return Ok(Stage::new(
-                SourceOp::load(),
-                Some(buf_idx),
-                ptype_to_tag(ptype),
-            ));
+            return self.push_subtree(array, pending_subtrees);
         }
 
         let id = array.encoding_id();
@@ -639,24 +624,53 @@ impl FusedPlan {
         Ok(pipeline)
     }
 
-    /// Handle a child array whose element width differs from the output type.
+    /// Walk a child that may have a different element width than the output.
     ///
-    /// If the child is a `Primitive`, its buffer is grabbed directly as a LOAD
-    /// source — no separate kernel launch needed, since `load_element<T>()`
-    /// handles the widening in-kernel. Otherwise, the child is recorded as a
-    /// pending subtree for separate execution.
-    fn walk_mixed_width_child(
+    /// Primitives are always handled directly (`load_element<T>()` widens
+    /// in-kernel). Non-primitive children are recursively walked; the kernel's
+    /// `bitunpack_typed` decodes at the source's native width and widens to
+    /// `T` in shared memory, and `push_smem_stage` allocates accordingly.
+    fn walk_child(
         &mut self,
-        child: ArrayRef,
+        array: ArrayRef,
         pending_subtrees: &mut Vec<ArrayRef>,
     ) -> VortexResult<Stage> {
-        let ptype = PType::try_from(child.dtype())?;
-        if child.encoding_id() == Primitive.id() {
-            return self.walk_primitive(child);
+        if array.encoding_id() == Primitive.id() {
+            return self.walk_primitive(array);
         }
+        self.walk(array, pending_subtrees)
+    }
+
+    /// Reserve a placeholder buffer slot and record the array as a pending subtree.
+    ///
+    /// Called from [`walk`] when [`is_dyn_dispatch_compatible`] rejects a child.
+    /// Cases that require a separate kernel dispatch:
+    ///
+    /// - **F16 / F64 primitives** — no reinterpret path in the kernel.
+    /// - **ALP with non-F32 dtype** — only F32 ALP is supported.
+    /// - **Dict with nullable codes** — garbage at null positions could OOB
+    ///   the DICT gather in shared memory.
+    /// - **Dict with codes wider than values** — `load_element<T>()` would
+    ///   truncate the code indices.
+    /// - **RunEnd with nullable ends** — garbage values break the binary
+    ///   search / forward-scan.
+    /// - **RunEnd with ends wider than values** — same truncation issue.
+    /// - **Unrecognized encoding** — anything outside the kernel's allow-list
+    ///   (e.g. FSST, Pco, Zstd).
+    fn push_subtree(
+        &mut self,
+        array: ArrayRef,
+        pending_subtrees: &mut Vec<ArrayRef>,
+    ) -> VortexResult<Stage> {
+        let ptype = PType::try_from(array.dtype()).map_err(|_| {
+            vortex_err!(
+                "unfusable subtree has non-primitive dtype {:?}, cannot partially fuse",
+                array.dtype()
+            )
+        })?;
         let buf_idx = self.source_buffers.len();
         self.source_buffers.push(None);
-        pending_subtrees.push(child);
+        pending_subtrees.push(array);
         Ok(Stage::new(
             SourceOp::load(),
             Some(buf_idx),
@@ -674,28 +688,12 @@ impl FusedPlan {
         let codes = dict.codes().clone();
 
         let values_ptype = PType::try_from(values.dtype())?;
-        let values_elem_bytes = values_ptype.byte_width() as u32;
-        let codes_ptype = PType::try_from(codes.dtype())?;
-        let codes_elem_bytes = codes_ptype.byte_width() as u32;
 
-        // If values have a different width than the output type, they
-        // can't be fused into the same kernel instantiation. Primitives
-        // are handled directly (just grab the buffer); other encodings
-        // become pending subtrees executed by a separate kernel.
         let values_len = values.len() as u32;
-        let values_spec = if values_elem_bytes != self.output_elem_bytes {
-            self.walk_mixed_width_child(values, pending_subtrees)?
-        } else {
-            self.walk(values, pending_subtrees)?
-        };
+        let values_spec = self.walk_child(values, pending_subtrees)?;
         let values_smem_byte_offset = self.push_smem_stage(values_spec, values_len);
 
-        // Same for codes.
-        let mut pipeline = if codes_elem_bytes != self.output_elem_bytes {
-            self.walk_mixed_width_child(codes, pending_subtrees)?
-        } else {
-            self.walk(codes, pending_subtrees)?
-        };
+        let mut pipeline = self.walk_child(codes, pending_subtrees)?;
         // DICT scalar op: pass byte offset directly (C ABI uses byte offsets).
         // output_ptype is the values' ptype — DICT transforms codes → values.
         pipeline.scalar_ops.push((
@@ -727,26 +725,10 @@ impl FusedPlan {
         let num_runs = ends.len() as u32;
         let num_values = values.len() as u32;
 
-        let ends_ptype = PType::try_from(ends.dtype())?;
-        let ends_elem_bytes = ends_ptype.byte_width() as u32;
-        let values_ptype = PType::try_from(values.dtype())?;
-        let values_elem_bytes = values_ptype.byte_width() as u32;
-
-        // If ends or values have a different width than the output type,
-        // they can't be fused into the same kernel instantiation.
-        // Primitives are handled directly; others become pending subtrees.
-        let ends_spec = if ends_elem_bytes != self.output_elem_bytes {
-            self.walk_mixed_width_child(ends, pending_subtrees)?
-        } else {
-            self.walk(ends, pending_subtrees)?
-        };
+        let ends_spec = self.walk_child(ends, pending_subtrees)?;
         let ends_smem_byte_offset = self.push_smem_stage(ends_spec, num_runs);
 
-        let values_spec = if values_elem_bytes != self.output_elem_bytes {
-            self.walk_mixed_width_child(values, pending_subtrees)?
-        } else {
-            self.walk(values, pending_subtrees)?
-        };
+        let values_spec = self.walk_child(values, pending_subtrees)?;
         let values_smem_byte_offset = self.push_smem_stage(values_spec, num_values);
 
         // Pass byte offsets and PTypeTags directly — the C ABI now uses


### PR DESCRIPTION
Dict codes and RunEnd ends that are narrower than the output type (e.g. u8 BitPacked codes in a u32 Dict) previously required a separate kernel launch. They are now fused by decoding at the source's native width and widening to T in shared memory.