### PR TITLE
Modify renovate config for better experience

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":automergePatch",
-    ":automergeMinor",
+    ":automergeStableNonMajor",
     ":automergePr",
     ":automergeRequireAllStatusChecks",
     ":combinePatchMinorReleases",
@@ -11,6 +10,7 @@
     ":separateMultipleMajorReleases",
     ":configMigration",
     "group:rust-futuresMonorepo",
+    "helpers:pinGitHubActionDigests",
     "schedule:earlyMondays",
     "docker:disable"
   ],
@@ -59,6 +59,36 @@
       "groupName": "tonic",
       "matchSourceUrls": [
         "https://github.com/hyperium/tonic"
+      ]
+    },
+    {
+      "groupName": "Rust lock file maintenance",
+      "groupSlug": "rust-lock-file-maintenance",
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ]
+    },
+    {
+      "groupName": "Python lock file maintenance",
+      "groupSlug": "python-lock-file-maintenance",
+      "matchManagers": [
+        "pep621"
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ]
+    },
+    {
+      "groupName": "JS lock file maintenance",
+      "groupSlug": "js-lock-file-maintenance",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

This PR includes 3 somewhat related changes, which should help maintain a better experience and keep the repo somewhat more secure:
1. Pin github actions to hashes instead of versions automatically, this is desirable because github-actions have mutable releases, and no guarantee the code and the release matches, a fact which has been repeatedly abused in recent years.
2. Split the lock file updates by ecosystem, so they don't get blocked on unrelated issues.
3. Instead of automerging patch/minor releases, only do that once a dependency is "stable" in semver terms (post 1.0) 