### PR TITLE
fix deadlock on unknown policy request

### DIFF
--- a/vortex-session/src/lib.rs
+++ b/vortex-session/src/lib.rs
@@ -72,7 +72,9 @@ impl VortexSession {
 
     /// Returns whether unknown plugins should deserialize as foreign placeholders.
     pub fn allows_unknown(&self) -> bool {
-        <Self as SessionExt>::get::<UnknownPluginPolicy>(self).allow_unknown
+        <Self as SessionExt>::get_opt::<UnknownPluginPolicy>(self)
+            .map(|p| p.allow_unknown)
+            .unwrap_or(false)
     }
 }
 


### PR DESCRIPTION
Querying allows_unknown + allow_unknown leads to a deadlock in FFI tests.