### PR TITLE
Clean up `vortex-tensor` even more

### DIFF
--- a/vortex-tensor/public-api.lock
+++ b/vortex-tensor/public-api.lock
@@ -28,7 +28,7 @@ pub vortex_tensor::encodings::turboquant::TurboQuantConfig::bit_width: u8
 
 pub vortex_tensor::encodings::turboquant::TurboQuantConfig::num_rounds: u8
 
-pub vortex_tensor::encodings::turboquant::TurboQuantConfig::seed: core::option::Option<u64>
+pub vortex_tensor::encodings::turboquant::TurboQuantConfig::seed: u64
 
 impl core::clone::Clone for vortex_tensor::encodings::turboquant::TurboQuantConfig
 
@@ -440,11 +440,11 @@ pub fn vortex_tensor::scalar_fns::sorf_transform::SorfMatrix::padded_dim(&self) 
 
 pub fn vortex_tensor::scalar_fns::sorf_transform::SorfMatrix::rotate(&self, input: &[f32], output: &mut [f32])
 
-pub fn vortex_tensor::scalar_fns::sorf_transform::SorfMatrix::try_new(seed: u64, dimension: usize, num_rounds: usize) -> vortex_error::VortexResult<Self>
+pub fn vortex_tensor::scalar_fns::sorf_transform::SorfMatrix::try_new(seed: u64, dimensions: usize, num_rounds: usize) -> vortex_error::VortexResult<Self>
 
 pub struct vortex_tensor::scalar_fns::sorf_transform::SorfOptions
 
-pub vortex_tensor::scalar_fns::sorf_transform::SorfOptions::dimension: u32
+pub vortex_tensor::scalar_fns::sorf_transform::SorfOptions::dimensions: u32
 
 pub vortex_tensor::scalar_fns::sorf_transform::SorfOptions::element_ptype: vortex_array::dtype::ptype::PType
 
@@ -490,7 +490,7 @@ pub fn vortex_tensor::scalar_fns::sorf_transform::SorfTransform::clone(&self) ->
 
 impl vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayVTable for vortex_tensor::scalar_fns::sorf_transform::SorfTransform
 
-pub fn vortex_tensor::scalar_fns::sorf_transform::SorfTransform::deserialize(&self, dtype: &vortex_array::dtype::DType, len: usize, metadata: &[u8], children: &dyn vortex_array::serde::ArrayChildren, _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayParts<Self>>
+pub fn vortex_tensor::scalar_fns::sorf_transform::SorfTransform::deserialize(&self, dtype: &vortex_array::dtype::DType, len: usize, metadata: &[u8], children: &dyn vortex_array::serde::ArrayChildren, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayParts<Self>>
 
 pub fn vortex_tensor::scalar_fns::sorf_transform::SorfTransform::serialize(&self, view: &vortex_array::arrays::scalar_fn::vtable::ScalarFnArrayView<'_, Self>, _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 

--- a/vortex-tensor/src/encodings/turboquant/centroids.rs
+++ b/vortex-tensor/src/encodings/turboquant/centroids.rs
@@ -36,7 +36,7 @@ static CENTROID_CACHE: LazyLock<DashMap<(u32, u8), Buffer<f32>>> = LazyLock::new
 /// Returns `2^bit_width` centroids sorted in ascending order, representing optimal scalar
 /// quantization levels for the coordinate distribution after random rotation in
 /// `dimension`-dimensional space.
-pub fn get_centroids(dimension: u32, bit_width: u8) -> VortexResult<Buffer<f32>> {
+pub fn compute_or_get_centroids(dimension: u32, bit_width: u8) -> VortexResult<Buffer<f32>> {
     vortex_ensure!(
         (1..=MAX_BIT_WIDTH).contains(&bit_width),
         "TurboQuant bit_width must be 1-{}, got {bit_width}",
@@ -239,7 +239,7 @@ mod tests {
         #[case] bits: u8,
         #[case] expected: usize,
     ) -> VortexResult<()> {
-        let centroids = get_centroids(dim, bits)?;
+        let centroids = compute_or_get_centroids(dim, bits)?;
         assert_eq!(centroids.len(), expected);
         Ok(())
     }
@@ -251,7 +251,7 @@ mod tests {
     #[case(128, 4)]
     #[case(768, 2)]
     fn centroids_are_sorted(#[case] dim: u32, #[case] bits: u8) -> VortexResult<()> {
-        let centroids = get_centroids(dim, bits)?;
+        let centroids = compute_or_get_centroids(dim, bits)?;
         for window in centroids.windows(2) {
             assert!(
                 window[0] < window[1],
@@ -268,7 +268,7 @@ mod tests {
     #[case(256, 2)]
     #[case(768, 2)]
     fn centroids_are_symmetric(#[case] dim: u32, #[case] bits: u8) -> VortexResult<()> {
-        let centroids = get_centroids(dim, bits)?;
+        let centroids = compute_or_get_centroids(dim, bits)?;
         let count = centroids.len();
         for idx in 0..count / 2 {
             let diff = (centroids[idx] + centroids[count - 1 - idx]).abs();
@@ -287,7 +287,7 @@ mod tests {
     #[case(128, 1)]
     #[case(128, 4)]
     fn centroids_within_bounds(#[case] dim: u32, #[case] bits: u8) -> VortexResult<()> {
-        let centroids = get_centroids(dim, bits)?;
+        let centroids = compute_or_get_centroids(dim, bits)?;
         for &val in centroids.iter() {
             assert!(
                 (-1.0..=1.0).contains(&val),
@@ -299,15 +299,15 @@ mod tests {
 
     #[test]
     fn centroids_cached() -> VortexResult<()> {
-        let c1 = get_centroids(128, 2)?;
-        let c2 = get_centroids(128, 2)?;
+        let c1 = compute_or_get_centroids(128, 2)?;
+        let c2 = compute_or_get_centroids(128, 2)?;
         assert_eq!(c1, c2);
         Ok(())
     }
 
     #[test]
     fn find_nearest_basic() -> VortexResult<()> {
-        let centroids = get_centroids(128, 2)?;
+        let centroids = compute_or_get_centroids(128, 2)?;
         let boundaries = compute_centroid_boundaries(&centroids);
         assert_eq!(find_nearest_centroid(-1.0, &boundaries), 0);
 
@@ -324,9 +324,9 @@ mod tests {
 
     #[test]
     fn rejects_invalid_params() {
-        assert!(get_centroids(128, 0).is_err());
-        assert!(get_centroids(128, 9).is_err());
-        assert!(get_centroids(1, 2).is_err());
-        assert!(get_centroids(127, 2).is_err());
+        assert!(compute_or_get_centroids(128, 0).is_err());
+        assert!(compute_or_get_centroids(128, 9).is_err());
+        assert!(compute_or_get_centroids(1, 2).is_err());
+        assert!(compute_or_get_centroids(127, 2).is_err());
     }
 }

--- a/vortex-tensor/src/encodings/turboquant/compress.rs
+++ b/vortex-tensor/src/encodings/turboquant/compress.rs
@@ -32,8 +32,8 @@ use vortex_error::vortex_ensure;
 use crate::encodings::turboquant::MAX_BIT_WIDTH;
 use crate::encodings::turboquant::MIN_DIMENSION;
 use crate::encodings::turboquant::centroids::compute_centroid_boundaries;
+use crate::encodings::turboquant::centroids::compute_or_get_centroids;
 use crate::encodings::turboquant::centroids::find_nearest_centroid;
-use crate::encodings::turboquant::centroids::get_centroids;
 use crate::scalar_fns::l2_denorm::L2Denorm;
 use crate::scalar_fns::l2_denorm::normalize_as_l2_denorm;
 use crate::scalar_fns::sorf_transform::SorfMatrix;
@@ -48,8 +48,8 @@ use crate::utils::cast_to_f32;
 pub struct TurboQuantConfig {
     /// Bits per coordinate (1-8).
     pub bit_width: u8,
-    /// Optional seed for the rotation matrix. If None, the default seed is used.
-    pub seed: Option<u64>,
+    /// Seed for the rotation matrix.
+    pub seed: u64,
     /// Number of sign-diagonal + WHT rounds in the structured rotation (default 3).
     pub num_rounds: u8,
 }
@@ -58,7 +58,7 @@ impl Default for TurboQuantConfig {
     fn default() -> Self {
         Self {
             bit_width: MAX_BIT_WIDTH,
-            seed: Some(42),
+            seed: 42,
             num_rounds: 3,
         }
     }
@@ -141,7 +141,7 @@ pub unsafe fn turboquant_encode_unchecked(
     let vector_metadata = ext_dtype.as_extension().metadata::<AnyVector>();
     let element_ptype = vector_metadata.element_ptype();
 
-    let seed = config.seed.unwrap_or(42);
+    let seed = config.seed;
     let num_rows = fsl.len();
 
     if fsl.is_empty() {
@@ -161,7 +161,7 @@ pub unsafe fn turboquant_encode_unchecked(
         let sorf_options = SorfOptions {
             seed,
             num_rounds: config.num_rounds,
-            dimension,
+            dimensions: dimension,
             element_ptype,
         };
         return Ok(
@@ -177,7 +177,7 @@ pub unsafe fn turboquant_encode_unchecked(
     let sorf_options = SorfOptions {
         seed,
         num_rounds: config.num_rounds,
-        dimension,
+        dimensions: dimension,
         element_ptype,
     };
     Ok(SorfTransform::try_new_array(&sorf_options, padded_vector, num_rows)?.into_array())
@@ -213,7 +213,7 @@ fn turboquant_quantize_core(
     let elements_prim: PrimitiveArray = fsl.elements().clone().execute(ctx)?;
     let f32_elements = cast_to_f32(elements_prim)?;
 
-    let centroids = get_centroids(padded_dim_u32, bit_width)?;
+    let centroids = compute_or_get_centroids(padded_dim_u32, bit_width)?;
     let boundaries = compute_centroid_boundaries(&centroids);
 
     let mut all_indices = BufferMut::<u8>::with_capacity(num_rows * padded_dim);

--- a/vortex-tensor/src/encodings/turboquant/mod.rs
+++ b/vortex-tensor/src/encodings/turboquant/mod.rs
@@ -121,7 +121,7 @@
 //! // Normalize and quantize at 2 bits per coordinate in one pass.
 //! let session = VortexSession::empty().with::<ArraySession>();
 //! let mut ctx = session.create_execution_ctx();
-//! let config = TurboQuantConfig { bit_width: 2, seed: Some(42), num_rounds: 3 };
+//! let config = TurboQuantConfig { bit_width: 2, seed: 42, num_rounds: 3 };
 //! let tq = turboquant_encode(vector, &config, &mut ctx).unwrap();
 //!
 //! // Verify compression: 100 vectors x 128 dims x 4 bytes = 51200 bytes input.

--- a/vortex-tensor/src/encodings/turboquant/scheme.rs
+++ b/vortex-tensor/src/encodings/turboquant/scheme.rs
@@ -111,21 +111,25 @@ impl Scheme for TurboQuantScheme {
 fn estimate_compression_ratio(element_bit_width: u8, dimensions: u32, num_vectors: usize) -> f64 {
     let config = TurboQuantConfig::default();
     let padded_dim = dimensions.next_power_of_two() as usize;
+    let element_bits = usize::from(element_bit_width);
 
-    // Per-vector: MSE codes per padded coordinate, plus one stored norm in the input element
-    // float width.
-    let compressed_bits_per_vector =
-        usize::from(element_bit_width) + usize::from(config.bit_width) * padded_dim;
+    // Get the size of the fully uncompressed vector data.
+    let uncompressed_size_bits = element_bits * dimensions as usize * num_vectors;
+
+    // Per-vector: MSE codes per padded coordinate, plus one stored norm in the input element float
+    // width.
+    let norm_bits = element_bits;
+    let compressed_bits_per_vector = usize::from(config.bit_width) * padded_dim;
+    let total_bits_per_vector = norm_bits + compressed_bits_per_vector;
 
     // Shared overhead: codebook centroids (2^bit_width f32 values).
-    // Note: rotation signs are no longer stored — rotation is deterministic from seed.
     let num_centroids = 1usize << config.bit_width;
     debug_assert!(num_centroids <= MAX_CENTROIDS);
     let overhead_bits = num_centroids * 32; // centroids are always f32
 
-    let compressed_size_bits = compressed_bits_per_vector * num_vectors + overhead_bits;
+    // This includes the quantized vectors, norms, and centroid codebook.
+    let compressed_size_bits = total_bits_per_vector * num_vectors + overhead_bits;
 
-    let uncompressed_size_bits = usize::from(element_bit_width) * dimensions as usize * num_vectors;
     uncompressed_size_bits as f64 / compressed_size_bits as f64
 }
 

--- a/vortex-tensor/src/encodings/turboquant/tests/compute.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests/compute.rs
@@ -40,7 +40,7 @@ fn slice_preserves_data() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 4,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -85,7 +85,7 @@ fn scalar_at_matches_decompress() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 2,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -108,7 +108,7 @@ fn l2_norm_readthrough() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 5,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -146,7 +146,7 @@ fn l2_norm_readthrough_is_authoritative_for_lossy_storage() -> VortexResult<()> 
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 1,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -183,7 +183,7 @@ fn cosine_similarity_readthrough_is_authoritative_for_lossy_storage() -> VortexR
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 1,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();

--- a/vortex-tensor/src/encodings/turboquant/tests/nullable.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests/nullable.rs
@@ -23,7 +23,7 @@ fn nullable_vectors_roundtrip() -> VortexResult<()> {
 
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 4,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -84,7 +84,7 @@ fn nullable_norms_match_validity() -> VortexResult<()> {
 
     let config = TurboQuantConfig {
         bit_width: 2,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -114,7 +114,7 @@ fn nullable_l2_norm_readthrough() -> VortexResult<()> {
 
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -156,7 +156,7 @@ fn nullable_slice_preserves_validity() -> VortexResult<()> {
 
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 2,
     };
     let mut ctx = SESSION.create_execution_ctx();

--- a/vortex-tensor/src/encodings/turboquant/tests/roundtrip.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests/roundtrip.rs
@@ -29,7 +29,7 @@ fn roundtrip(#[case] dim: usize, #[case] bit_width: u8) -> VortexResult<()> {
     let fsl = make_fsl(10, dim, 42);
     let config = TurboQuantConfig {
         bit_width,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
@@ -49,7 +49,7 @@ fn mse_within_theoretical_bound(#[case] dim: usize, #[case] bit_width: u8) -> Vo
     let fsl = make_fsl(num_rows, dim, 42);
     let config = TurboQuantConfig {
         bit_width,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
@@ -76,7 +76,7 @@ fn high_bitwidth_mse_is_small(#[case] dim: usize, #[case] bit_width: u8) -> Vort
 
     let config_4bit = TurboQuantConfig {
         bit_width: 4,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let (original_4, decoded_4) = encode_decode(&fsl, &config_4bit)?;
@@ -84,7 +84,7 @@ fn high_bitwidth_mse_is_small(#[case] dim: usize, #[case] bit_width: u8) -> Vort
 
     let config = TurboQuantConfig {
         bit_width,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
@@ -108,7 +108,7 @@ fn mse_decreases_with_bits() -> VortexResult<()> {
     for bit_width in 1..=8u8 {
         let config = TurboQuantConfig {
             bit_width,
-            seed: Some(123),
+            seed: 123,
             num_rounds: 3,
         };
         let (original, decoded) = encode_decode(&fsl, &config)?;
@@ -130,7 +130,7 @@ fn roundtrip_edge_cases(#[case] num_rows: usize) -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 2,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -159,7 +159,7 @@ fn rejects_dimension_below_128(#[case] dim: usize) {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 2,
-        seed: Some(0),
+        seed: 0,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -174,7 +174,7 @@ fn rejects_invalid_bit_width(#[case] bit_width: u8) {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width,
-        seed: Some(0),
+        seed: 0,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -203,7 +203,7 @@ fn all_zero_vectors_roundtrip() -> VortexResult<()> {
 
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(42),
+        seed: 42,
         num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
@@ -223,7 +223,7 @@ fn large_dimension_roundtrip(#[case] dim: usize, #[case] bit_width: u8) -> Vorte
     let fsl = make_fsl(num_rows, dim, 42);
     let config = TurboQuantConfig {
         bit_width,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
@@ -262,7 +262,7 @@ fn f64_input_encodes_successfully() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(42),
+        seed: 42,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -295,7 +295,7 @@ fn f16_input_encodes_successfully() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(42),
+        seed: 42,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();

--- a/vortex-tensor/src/encodings/turboquant/tests/structural.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests/structural.rs
@@ -13,14 +13,14 @@ use vortex_error::VortexResult;
 
 use super::*;
 
-/// Verify that the centroids stored in the DictArray match what `get_centroids()` computes.
+/// Verify that the centroids stored in the DictArray match what `compute_or_get_centroids()` computes.
 #[test]
 fn stored_centroids_match_computed() -> VortexResult<()> {
     let fsl = make_fsl(10, 128, 42);
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -30,7 +30,7 @@ fn stored_centroids_match_computed() -> VortexResult<()> {
     let stored = centroids.as_slice::<f32>();
 
     // padded_dim for dim=128 is 128.
-    let computed = crate::encodings::turboquant::centroids::get_centroids(128, 3)?;
+    let computed = crate::encodings::turboquant::centroids::compute_or_get_centroids(128, 3)?;
 
     assert_eq!(stored.len(), computed.len());
     for i in 0..stored.len() {
@@ -46,7 +46,7 @@ fn seed_deterministic_rotation_produces_correct_decode() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 4,
     };
 
@@ -90,7 +90,7 @@ fn encoded_dtype_is_vector_extension() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 3,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 2,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -115,7 +115,7 @@ fn cosine_similarity_quantized_accuracy() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 4,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -172,7 +172,7 @@ fn dot_product_quantized_accuracy() -> VortexResult<()> {
     let ext = make_vector_ext(&fsl);
     let config = TurboQuantConfig {
         bit_width: 8,
-        seed: Some(123),
+        seed: 123,
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
@@ -231,8 +231,8 @@ fn sorf_transform_roundtrip_isolation() -> VortexResult<()> {
     use vortex_buffer::BufferMut;
 
     use crate::encodings::turboquant::centroids::compute_centroid_boundaries;
+    use crate::encodings::turboquant::centroids::compute_or_get_centroids;
     use crate::encodings::turboquant::centroids::find_nearest_centroid;
-    use crate::encodings::turboquant::centroids::get_centroids;
     use crate::scalar_fns::sorf_transform::SorfMatrix;
     use crate::scalar_fns::sorf_transform::SorfOptions;
     use crate::scalar_fns::sorf_transform::SorfTransform;
@@ -261,7 +261,7 @@ fn sorf_transform_roundtrip_isolation() -> VortexResult<()> {
     // Forward transform + quantize (mimicking what turboquant_quantize_core does).
     let rotation = SorfMatrix::try_new(seed, dim, num_rounds as usize)?;
     let padded_dim = rotation.padded_dim();
-    let centroids = get_centroids(padded_dim as u32, 8)?;
+    let centroids = compute_or_get_centroids(padded_dim as u32, 8)?;
     let boundaries = compute_centroid_boundaries(&centroids);
 
     let mut all_indices = BufferMut::<u8>::with_capacity(num_rows * padded_dim);
@@ -299,7 +299,7 @@ fn sorf_transform_roundtrip_isolation() -> VortexResult<()> {
     let sorf_options = SorfOptions {
         seed,
         num_rounds,
-        dimension: dim as u32,
+        dimensions: dim as u32,
         element_ptype: vortex_array::dtype::PType::F32,
     };
     let sorf_array =

--- a/vortex-tensor/src/lib.rs
+++ b/vortex-tensor/src/lib.rs
@@ -5,6 +5,11 @@
 //! including unit vectors, spherical coordinates, and similarity measures such as cosine
 //! similarity.
 
+#![cfg_attr(
+    test,
+    allow(clippy::unwrap_used, clippy::expect_used, clippy::unwrap_in_result)
+)]
+
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayPlugin;
 use vortex_array::dtype::session::DTypeSessionExt;
 use vortex_array::scalar_fn::session::ScalarFnSessionExt;

--- a/vortex-tensor/src/scalar_fns/cosine_similarity.rs
+++ b/vortex-tensor/src/scalar_fns/cosine_similarity.rs
@@ -33,11 +33,11 @@ use vortex_buffer::Buffer;
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
 
-use crate::scalar_fns::inner_product::BinaryTensorOpMetadata;
 use crate::scalar_fns::inner_product::InnerProduct;
 use crate::scalar_fns::l2_denorm::DenormOrientation;
 use crate::scalar_fns::l2_denorm::try_build_constant_l2_denorm;
 use crate::scalar_fns::l2_norm::L2Norm;
+use crate::utils::BinaryTensorOpMetadata;
 use crate::utils::extract_l2_denorm_children;
 use crate::utils::validate_binary_tensor_float_inputs;
 
@@ -115,7 +115,7 @@ impl ScalarFnVTable for CosineSimilarity {
         let lhs = &arg_dtypes[0];
         let rhs = &arg_dtypes[1];
 
-        let tensor_match = validate_binary_tensor_float_inputs("CosineSimilarity", lhs, rhs)?;
+        let tensor_match = validate_binary_tensor_float_inputs(lhs, rhs)?;
         let ptype = tensor_match.element_ptype();
         let nullability = Nullability::from(lhs.is_nullable() || rhs.is_nullable());
         Ok(DType::Primitive(ptype, nullability))
@@ -227,13 +227,8 @@ impl ScalarFnArrayVTable for CosineSimilarity {
         children: &dyn ArrayChildren,
         session: &VortexSession,
     ) -> VortexResult<ScalarFnArrayParts<Self>> {
-        let reconstructed = BinaryTensorOpMetadata::decode_children(
-            metadata,
-            len,
-            children,
-            session,
-            "CosineSimilarity",
-        )?;
+        let reconstructed =
+            BinaryTensorOpMetadata::decode_children(metadata, len, children, session)?;
         Ok(ScalarFnArrayParts {
             options: EmptyOptions,
             children: reconstructed,

--- a/vortex-tensor/src/scalar_fns/inner_product.rs
+++ b/vortex-tensor/src/scalar_fns/inner_product.rs
@@ -6,7 +6,6 @@
 use std::fmt::Formatter;
 
 use num_traits::Float;
-use prost::Message;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
@@ -17,13 +16,11 @@ use vortex_array::arrays::Extension;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::FixedSizeList;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::arrays::ScalarFn as ScalarFnArrayEncoding;
 use vortex_array::arrays::ScalarFnArray;
 use vortex_array::arrays::dict::DictArraySlotsExt;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
 use vortex_array::arrays::scalar_fn::ExactScalarFn;
-use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex_array::arrays::scalar_fn::ScalarFnArrayView;
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayParts;
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayVTable;
@@ -31,7 +28,6 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
-use vortex_array::dtype::proto::dtype as pb;
 use vortex_array::expr::Expression;
 use vortex_array::expr::and;
 use vortex_array::match_each_float_ptype;
@@ -47,8 +43,6 @@ use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
-use vortex_error::vortex_ensure;
-use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 
 use crate::matcher::AnyTensor;
@@ -56,6 +50,7 @@ use crate::scalar_fns::l2_denorm::DenormOrientation;
 use crate::scalar_fns::sorf_transform::SorfMatrix;
 use crate::scalar_fns::sorf_transform::SorfTransform;
 use crate::types::vector::Vector;
+use crate::utils::BinaryTensorOpMetadata;
 use crate::utils::extract_constant_flat_row;
 use crate::utils::extract_flat_elements;
 use crate::utils::extract_l2_denorm_children;
@@ -130,7 +125,7 @@ impl ScalarFnVTable for InnerProduct {
         let rhs = &arg_dtypes[1];
 
         // TODO(connor): relax the float-only gate once integer tensors are supported.
-        let tensor_match = validate_binary_tensor_float_inputs("InnerProduct", lhs, rhs)?;
+        let tensor_match = validate_binary_tensor_float_inputs(lhs, rhs)?;
         let ptype = tensor_match.element_ptype();
         let nullability = Nullability::from(lhs.is_nullable() || rhs.is_nullable());
         Ok(DType::Primitive(ptype, nullability))
@@ -225,66 +220,6 @@ impl ScalarFnVTable for InnerProduct {
     }
 }
 
-/// Metadata for a serialized binary tensor-op array (shared by [`InnerProduct`] and
-/// [`CosineSimilarity`]). Both operands share the same extension dtype up to nullability
-/// (enforced by their `return_dtype` checks), but their individual nullabilities are lost in the
-/// parent's unioned output, so both are persisted.
-///
-/// [`CosineSimilarity`]: crate::scalar_fns::cosine_similarity::CosineSimilarity
-#[derive(Clone, prost::Message)]
-pub(crate) struct BinaryTensorOpMetadata {
-    #[prost(message, optional, tag = "1")]
-    pub(crate) lhs_dtype: Option<pb::DType>,
-    #[prost(message, optional, tag = "2")]
-    pub(crate) rhs_dtype: Option<pb::DType>,
-}
-
-impl BinaryTensorOpMetadata {
-    /// Encodes the two children of `view` into a [`BinaryTensorOpMetadata`] byte blob.
-    pub(crate) fn encode_from_view<V: ScalarFnVTable>(
-        view: &ScalarFnArrayView<V>,
-    ) -> VortexResult<Vec<u8>> {
-        let scalar_fn_array = view.as_::<ScalarFnArrayEncoding>();
-        let lhs_dtype = Some(scalar_fn_array.child_at(0).dtype().try_into()?);
-        let rhs_dtype = Some(scalar_fn_array.child_at(1).dtype().try_into()?);
-        Ok(Self {
-            lhs_dtype,
-            rhs_dtype,
-        }
-        .encode_to_vec())
-    }
-
-    /// Decodes `metadata` and fetches both children from `children` using the decoded dtypes,
-    /// validating that `lhs` and `rhs` agree modulo nullability.
-    pub(crate) fn decode_children(
-        metadata: &[u8],
-        len: usize,
-        children: &dyn ArrayChildren,
-        session: &VortexSession,
-        scalar_fn_name: &str,
-    ) -> VortexResult<Vec<ArrayRef>> {
-        let metadata = Self::decode(metadata)
-            .map_err(|e| vortex_err!("Failed to decode BinaryTensorOpMetadata: {e}"))?;
-        let lhs_pb = metadata
-            .lhs_dtype
-            .as_ref()
-            .ok_or_else(|| vortex_err!("{scalar_fn_name} metadata missing lhs_dtype"))?;
-        let rhs_pb = metadata
-            .rhs_dtype
-            .as_ref()
-            .ok_or_else(|| vortex_err!("{scalar_fn_name} metadata missing rhs_dtype"))?;
-        let lhs_dtype = DType::from_proto(lhs_pb, session)?;
-        let rhs_dtype = DType::from_proto(rhs_pb, session)?;
-        vortex_ensure!(
-            lhs_dtype.eq_ignore_nullability(&rhs_dtype),
-            "{scalar_fn_name} operand dtype mismatch: {lhs_dtype} vs {rhs_dtype}"
-        );
-        let lhs = children.get(0, &lhs_dtype, len)?;
-        let rhs = children.get(1, &rhs_dtype, len)?;
-        Ok(vec![lhs, rhs])
-    }
-}
-
 impl ScalarFnArrayVTable for InnerProduct {
     fn serialize(
         &self,
@@ -302,13 +237,8 @@ impl ScalarFnArrayVTable for InnerProduct {
         children: &dyn ArrayChildren,
         session: &VortexSession,
     ) -> VortexResult<ScalarFnArrayParts<Self>> {
-        let reconstructed = BinaryTensorOpMetadata::decode_children(
-            metadata,
-            len,
-            children,
-            session,
-            "InnerProduct",
-        )?;
+        let reconstructed =
+            BinaryTensorOpMetadata::decode_children(metadata, len, children, session)?;
         Ok(ScalarFnArrayParts {
             options: EmptyOptions,
             children: reconstructed,
@@ -421,7 +351,7 @@ impl InnerProduct {
             return Ok(None);
         };
 
-        let dim = sorf_view.options.dimension as usize;
+        let dim = sorf_view.options.dimensions as usize;
         let num_rounds = sorf_view.options.num_rounds as usize;
         let seed = sorf_view.options.seed;
         let padded_dim = dim.next_power_of_two();
@@ -980,7 +910,7 @@ mod tests {
             let sorf_options = SorfOptions {
                 seed,
                 num_rounds,
-                dimension: dim,
+                dimensions: dim,
                 element_ptype: PType::F32,
             };
             let sorf =
@@ -1556,7 +1486,7 @@ mod tests {
             let sorf_options = SorfOptions {
                 seed,
                 num_rounds,
-                dimension: dim,
+                dimensions: dim,
                 element_ptype: PType::F32,
             };
             let sorf =

--- a/vortex-tensor/src/scalar_fns/l2_denorm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_denorm.rs
@@ -31,7 +31,6 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
-use vortex_array::dtype::PType;
 use vortex_array::dtype::proto::dtype as pb;
 use vortex_array::expr::Expression;
 use vortex_array::expr::and;
@@ -62,6 +61,7 @@ use crate::matcher::AnyTensor;
 use crate::scalar_fns::l2_norm::L2Norm;
 use crate::utils::extract_constant_flat_row;
 use crate::utils::extract_flat_elements;
+use crate::utils::unit_norm_tolerance;
 use crate::utils::validate_tensor_float_input;
 
 /// Re-applies authoritative L2 norms to a normalized tensor column.
@@ -360,7 +360,21 @@ fn execute_l2_denorm_constant_norms(
         .vortex_expect("we know that this is a float, so it must fit in f64")
         - 1.0f64;
 
-    let tolerance = unit_norm_tolerance(norm_scalar.dtype().as_ptype());
+    let tensor_match = normalized_ref
+        .dtype()
+        .as_extension_opt()
+        .and_then(|ext| ext.metadata_opt::<AnyTensor>())
+        .ok_or_else(|| {
+            vortex_err!(
+                "L2Denorm normalized child must be a tensor-like extension, got {}",
+                normalized_ref.dtype(),
+            )
+        })?;
+
+    let tolerance = unit_norm_tolerance(
+        norm_scalar.dtype().as_ptype(),
+        tensor_match.list_size() as usize,
+    );
     if err.abs() < tolerance {
         return Ok(normalized_ref);
     }
@@ -594,16 +608,6 @@ fn build_tensor_array<T: NativePType>(
     Ok(ExtensionArray::new(dtype.as_extension().clone(), storage.into_array()).into_array())
 }
 
-/// Returns the acceptable unit-norm drift for the given element precision.
-fn unit_norm_tolerance(element_ptype: PType) -> f64 {
-    match element_ptype {
-        PType::F16 => 2e-3,
-        PType::F32 => 2e-6,
-        PType::F64 => 1e-10,
-        _ => unreachable!("L2Denorm requires float elements, got {element_ptype:?}"),
-    }
-}
-
 /// Validates that `normalized` and (when supplied) the matching `norms` jointly satisfy the
 /// [`L2Denorm`] invariants:
 ///
@@ -623,8 +627,8 @@ pub fn validate_l2_normalized_rows_against_norms(
 
     let tensor_match = validate_tensor_float_input(normalized.dtype())?;
     let element_ptype = tensor_match.element_ptype();
-    let tolerance = unit_norm_tolerance(element_ptype);
     let tensor_flat_size = tensor_match.list_size() as usize;
+    let tolerance = unit_norm_tolerance(element_ptype, tensor_flat_size);
 
     if let Some(norms) = norms {
         vortex_ensure_eq!(

--- a/vortex-tensor/src/scalar_fns/sorf_transform/mod.rs
+++ b/vortex-tensor/src/scalar_fns/sorf_transform/mod.rs
@@ -81,7 +81,7 @@ pub struct SorfOptions {
     pub num_rounds: u8,
     /// Original vector dimension (before power-of-2 padding). The output
     /// [`Vector`](crate::vector::Vector) has this dimension.
-    pub dimension: u32,
+    pub dimensions: u32,
     /// Element type of the output [`Vector`](crate::vector::Vector). The child input must always
     /// be `f32`, but the output can be any float type (`F16`, `F32`, `F64`); the final
     /// `f32 -> element_ptype` cast happens while building the output.
@@ -137,7 +137,7 @@ impl fmt::Display for SorfOptions {
         write!(
             f,
             "SorfOptions(seed={}, rounds={}, dim={}, ptype={})",
-            self.seed, self.num_rounds, self.dimension, self.element_ptype
+            self.seed, self.num_rounds, self.dimensions, self.element_ptype
         )
     }
 }

--- a/vortex-tensor/src/scalar_fns/sorf_transform/rotation.rs
+++ b/vortex-tensor/src/scalar_fns/sorf_transform/rotation.rs
@@ -76,15 +76,15 @@ impl SorfMatrix {
     /// The seed is expanded using Vortex's frozen local SplitMix64 stream. Signs are generated in
     /// round-major, block-major order, with each `u64` contributing 64 sign bits in
     /// least-significant-bit-first order.
-    pub fn try_new(seed: u64, dimension: usize, num_rounds: usize) -> VortexResult<Self> {
+    pub fn try_new(seed: u64, dimensions: usize, num_rounds: usize) -> VortexResult<Self> {
         vortex_ensure!(num_rounds >= 1, "num_rounds must be >= 1, got {num_rounds}");
 
-        let padded_dim = dimension.next_power_of_two();
+        let padded_dim = dimensions.next_power_of_two();
         let sign_masks = gen_sign_masks_from_seed(seed, padded_dim, num_rounds);
 
         // Compute in f64 for precision, then store as f32 since the WHT operates on f32 buffers.
         // The result is always in (0, 1] for any valid padded_dim >= 2 and num_rounds >= 1, so
-        // the f64 -> f32 cast is a precision loss only -- it cannot overflow to infinity.
+        // the f64 -> f32 cast is a precision loss only (it cannot overflow to infinity).
         #[expect(
             clippy::cast_possible_truncation,
             reason = "the norm factor is in (0, 1] so the f64 -> f32 cast cannot overflow"

--- a/vortex-tensor/src/scalar_fns/sorf_transform/tests.rs
+++ b/vortex-tensor/src/scalar_fns/sorf_transform/tests.rs
@@ -33,8 +33,8 @@ use super::SorfOptions;
 use super::SorfTransform;
 use super::rotation::SorfMatrix;
 use crate::encodings::turboquant::centroids::compute_centroid_boundaries;
+use crate::encodings::turboquant::centroids::compute_or_get_centroids;
 use crate::encodings::turboquant::centroids::find_nearest_centroid;
-use crate::encodings::turboquant::centroids::get_centroids;
 use crate::tests::SESSION;
 use crate::types::vector::Vector;
 
@@ -67,7 +67,7 @@ fn forward_rotate_and_quantize(
 
     let rotation = SorfMatrix::try_new(seed, dim, num_rounds)?;
     let padded_dim = rotation.padded_dim();
-    let centroids = get_centroids(padded_dim as u32, bit_width)?;
+    let centroids = compute_or_get_centroids(padded_dim as u32, bit_width)?;
     let boundaries = compute_centroid_boundaries(&centroids);
 
     let mut all_indices = BufferMut::<u8>::with_capacity(num_rows * padded_dim);
@@ -115,7 +115,7 @@ fn default_options(dim: u32, seed: u64) -> SorfOptions {
     SorfOptions {
         seed,
         num_rounds: 3,
-        dimension: dim,
+        dimensions: dim,
         element_ptype: PType::F32,
     }
 }
@@ -319,7 +319,7 @@ fn rejects_zero_rounds_at_construction() {
     let options = SorfOptions {
         seed: 42,
         num_rounds: 0,
-        dimension: 128,
+        dimensions: 128,
         element_ptype: PType::F32,
     };
     let elements = PrimitiveArray::from_iter([0.0f32; 128]).into_array();
@@ -336,7 +336,7 @@ fn rejects_non_float_output_ptype_at_construction() {
     let options = SorfOptions {
         seed: 42,
         num_rounds: 3,
-        dimension: 128,
+        dimensions: 128,
         element_ptype: PType::U8,
     };
     let elements = PrimitiveArray::from_iter([0.0f32; 128]).into_array();
@@ -400,7 +400,7 @@ fn f16_output_type() -> VortexResult<()> {
     let options = SorfOptions {
         seed,
         num_rounds: 3,
-        dimension: dim as u32,
+        dimensions: dim as u32,
         element_ptype: PType::F16,
     };
     let sorf = SorfTransform::try_new_array(&options, padded_vector.into_array(), num_rows)?;
@@ -425,7 +425,7 @@ fn f64_output_type() -> VortexResult<()> {
     let options = SorfOptions {
         seed,
         num_rounds: 3,
-        dimension: dim as u32,
+        dimensions: dim as u32,
         element_ptype: PType::F64,
     };
     let sorf = SorfTransform::try_new_array(&options, padded_vector.into_array(), num_rows)?;
@@ -461,13 +461,13 @@ fn trivial_padded_vector(padded_dim: u32, num_rows: usize, validity: Validity) -
 #[case::non_power_of_two_dim(100, Validity::NonNullable)]
 // Nullable top-level Vector to verify child nullability is reconstructed from the parent output.
 #[case::nullable_child(100, Validity::AllValid)]
-fn serde_round_trip(#[case] dimension: u32, #[case] validity: Validity) -> VortexResult<()> {
-    let padded_dim = dimension.next_power_of_two();
+fn serde_round_trip(#[case] dimensions: u32, #[case] validity: Validity) -> VortexResult<()> {
+    let padded_dim = dimensions.next_power_of_two();
     let num_rows = 4;
     let options = SorfOptions {
         seed: 42,
         num_rounds: 3,
-        dimension,
+        dimensions,
         element_ptype: PType::F32,
     };
     let child = trivial_padded_vector(padded_dim, num_rows, validity);

--- a/vortex-tensor/src/scalar_fns/sorf_transform/vtable.rs
+++ b/vortex-tensor/src/scalar_fns/sorf_transform/vtable.rs
@@ -16,8 +16,10 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::ScalarFn as ScalarFnArrayEncoding;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
+use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex_array::arrays::scalar_fn::ScalarFnArrayView;
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayParts;
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayVTable;
@@ -26,6 +28,7 @@ use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::dtype::extension::ExtDType;
+use vortex_array::dtype::proto::dtype as pb;
 use vortex_array::expr::Expression;
 use vortex_array::extension::EmptyMetadata;
 use vortex_array::match_each_float_ptype;
@@ -90,13 +93,13 @@ impl ScalarFnVTable for SorfTransform {
                 vortex_err!("SorfTransform child must be a Vector extension, got {child_dtype}")
             })?;
 
-        let expected_padded = options.dimension.next_power_of_two();
+        let expected_padded = options.dimensions.next_power_of_two();
         vortex_ensure_eq!(
             vector_metadata.dimensions(),
             expected_padded,
             "SorfTransform child Vector must have dimension {expected_padded} (next power of two \
              for dimension {})",
-            options.dimension,
+            options.dimensions,
         );
 
         // For now, the child Vector storage must be f32. TurboQuant stores its centroids as f32,
@@ -113,11 +116,13 @@ impl ScalarFnVTable for SorfTransform {
         let output_elem_dtype = DType::Primitive(options.element_ptype, Nullability::NonNullable);
         let storage_dtype = DType::FixedSizeList(
             Arc::new(output_elem_dtype),
-            options.dimension,
+            options.dimensions,
             child_dtype.nullability(),
         );
 
+        let _ = vector_metadata;
         let ext_dtype = ExtDType::<Vector>::try_new(EmptyMetadata, storage_dtype)?.erased();
+
         Ok(DType::Extension(ext_dtype))
     }
 
@@ -127,19 +132,18 @@ impl ScalarFnVTable for SorfTransform {
         args: &dyn ExecutionArgs,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        validate_sorf_options(options)?;
-        let dim = options.dimension as usize;
+        let dim = options.dimensions as usize;
         let num_rows = args.row_count();
 
         if num_rows == 0 {
-            let child_nullability = args.get(0)?.dtype().nullability();
-            let validity = Validity::from(child_nullability);
+            let child_dtype = args.get(0)?.dtype().clone();
+            let validity = Validity::from(child_dtype.nullability());
 
             return match_each_float_ptype!(options.element_ptype, |T| {
                 let elements = PrimitiveArray::empty::<T>(Nullability::NonNullable);
                 let fsl = FixedSizeListArray::try_new(
                     elements.into_array(),
-                    options.dimension,
+                    options.dimensions,
                     validity,
                     0,
                 )?;
@@ -194,11 +198,9 @@ impl ScalarFnVTable for SorfTransform {
 
 /// Metadata for a serialized [`SorfTransform`] array.
 ///
-/// Stores the full [`SorfOptions`] inline. The child [`DType`] is not serialized because it is
-/// fully determined by the options: the child is always a [`Vector`] extension wrapping
-/// `FSL<f32, dimension.next_power_of_two()>`. The child's nullability is recovered from the
-/// parent output dtype at deserialize time, since `SorfTransform::return_dtype` propagates child
-/// nullability into the output FSL (see `return_dtype` above).
+/// Stores the full [`SorfOptions`] inline along with the child [`DType`]. Older metadata omitted
+/// this field; deserialization derives the legacy plain-`Vector` child dtype from the parent dtype
+/// in that case.
 #[derive(Clone, prost::Message)]
 pub(super) struct SorfTransformMetadata {
     #[prost(uint64, tag = "1")]
@@ -210,6 +212,8 @@ pub(super) struct SorfTransformMetadata {
     dimension: u32,
     #[prost(enumeration = "PType", tag = "4")]
     element_ptype: i32,
+    #[prost(message, optional, tag = "5")]
+    child_dtype: Option<pb::DType>,
 }
 
 impl ScalarFnArrayVTable for SorfTransform {
@@ -218,9 +222,13 @@ impl ScalarFnArrayVTable for SorfTransform {
         view: &ScalarFnArrayView<Self>,
         _session: &VortexSession,
     ) -> VortexResult<Option<Vec<u8>>> {
-        Ok(Some(
-            SorfTransformMetadata::from(view.options).encode_to_vec(),
-        ))
+        let scalar_fn_array = view.as_::<ScalarFnArrayEncoding>();
+        let child_dtype = Some(scalar_fn_array.child_at(0).dtype().try_into()?);
+        let metadata = SorfTransformMetadata {
+            child_dtype,
+            ..SorfTransformMetadata::from(view.options)
+        };
+        Ok(Some(metadata.encode_to_vec()))
     }
 
     fn deserialize(
@@ -229,11 +237,11 @@ impl ScalarFnArrayVTable for SorfTransform {
         len: usize,
         metadata: &[u8],
         children: &dyn ArrayChildren,
-        _session: &VortexSession,
+        session: &VortexSession,
     ) -> VortexResult<ScalarFnArrayParts<Self>> {
-        let options = SorfTransformMetadata::decode(metadata)
-            .map_err(|e| vortex_err!("Failed to decode SorfTransformMetadata: {e}"))?
-            .to_options()?;
+        let metadata = SorfTransformMetadata::decode(metadata)
+            .map_err(|e| vortex_err!("Failed to decode SorfTransformMetadata: {e}"))?;
+        let options = metadata.to_options()?;
 
         // `return_dtype` sets the output FSL's nullability to the child's nullability (see
         // `return_dtype` above), so we read the child nullability back from the parent dtype.
@@ -244,14 +252,19 @@ impl ScalarFnArrayVTable for SorfTransform {
             })?
             .storage_dtype()
             .nullability();
-        let padded_dim = options.dimension.next_power_of_two();
+        let padded_dim = options.dimensions.next_power_of_two();
         let child_storage = DType::FixedSizeList(
             Arc::new(DType::Primitive(PType::F32, Nullability::NonNullable)),
             padded_dim,
             child_nullability,
         );
-        let child_ext = ExtDType::<Vector>::try_new(EmptyMetadata, child_storage)?.erased();
-        let child_dtype = DType::Extension(child_ext);
+        let child_dtype = match metadata.child_dtype.as_ref() {
+            Some(dtype) => DType::from_proto(dtype, session)?,
+            None => {
+                let child_ext = ExtDType::<Vector>::try_new(EmptyMetadata, child_storage)?.erased();
+                DType::Extension(child_ext)
+            }
+        };
         let child = children.get(0, &child_dtype, len)?;
 
         Ok(ScalarFnArrayParts {
@@ -270,7 +283,7 @@ fn float_from_f32<T: Float + FromPrimitive>(v: f32) -> T {
 }
 
 /// Apply the inverse SORF transform on f32 data, truncate to the original dimension, cast each
-/// element to `T`, and build the output [`Vector`] extension array.
+/// element to `T`, and build a plain [`Vector`](crate::vector::Vector) extension array.
 fn inverse_rotate_typed<T: NativePType + Float + FromPrimitive>(
     f32_elements: &[f32],
     rotation: &SorfMatrix,
@@ -304,8 +317,9 @@ impl From<&SorfOptions> for SorfTransformMetadata {
         Self {
             seed: options.seed,
             num_rounds: u32::from(options.num_rounds),
-            dimension: options.dimension,
+            dimension: options.dimensions,
             element_ptype: options.element_ptype as i32,
+            child_dtype: None,
         }
     }
 }
@@ -323,7 +337,7 @@ impl SorfTransformMetadata {
         let options = SorfOptions {
             seed: self.seed,
             num_rounds,
-            dimension: self.dimension,
+            dimensions: self.dimension,
             element_ptype: self.element_ptype(),
         };
         validate_sorf_options(&options)?;

--- a/vortex-tensor/src/types/vector/mod.rs
+++ b/vortex-tensor/src/types/vector/mod.rs
@@ -14,6 +14,30 @@ use vortex_array::extension::EmptyMetadata;
 use vortex_array::scalar::PValue;
 use vortex_array::scalar::Scalar;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_ensure;
+
+/// Validates that `storage` is a valid storage dtype for a [`Vector`] or
+/// [`NormalizedVector`](crate::normalized_vector::NormalizedVector) extension type.
+///
+/// The storage must be a `FixedSizeList<float, dim, nullability>` with non-nullable float
+/// elements. The outer nullability is not constrained.
+pub(crate) fn validate_vector_storage_dtype(storage: &DType) -> VortexResult<()> {
+    let DType::FixedSizeList(element_dtype, _list_size, _nullability) = storage else {
+        vortex_bail!("Vector storage dtype must be a FixedSizeList, got {storage}");
+    };
+
+    vortex_ensure!(
+        element_dtype.is_float(),
+        "Vector element dtype must be a float, got {element_dtype}"
+    );
+    vortex_ensure!(
+        !element_dtype.is_nullable(),
+        "Vector element dtype must be non-nullable"
+    );
+
+    Ok(())
+}
 
 /// The Vector extension type.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]

--- a/vortex-tensor/src/types/vector/vtable.rs
+++ b/vortex-tensor/src/types/vector/vtable.rs
@@ -8,10 +8,9 @@ use vortex_array::dtype::extension::ExtVTable;
 use vortex_array::extension::EmptyMetadata;
 use vortex_array::scalar::ScalarValue;
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
-use vortex_error::vortex_ensure;
 
 use crate::types::vector::Vector;
+use crate::types::vector::validate_vector_storage_dtype;
 
 impl ExtVTable for Vector {
     type Metadata = EmptyMetadata;
@@ -46,21 +45,7 @@ impl ExtVTable for Vector {
     }
 
     fn validate_dtype(ext_dtype: &ExtDType<Self>) -> VortexResult<()> {
-        let storage_dtype = ext_dtype.storage_dtype();
-        let DType::FixedSizeList(element_dtype, _list_size, _nullability) = storage_dtype else {
-            vortex_bail!("Vector storage dtype must be a FixedSizeList, got {storage_dtype}");
-        };
-
-        vortex_ensure!(
-            element_dtype.is_float(),
-            "Vector element dtype must be a float, got {element_dtype}"
-        );
-        vortex_ensure!(
-            !element_dtype.is_nullable(),
-            "Vector element dtype must be non-nullable"
-        );
-
-        Ok(())
+        validate_vector_storage_dtype(ext_dtype.storage_dtype())
     }
 
     fn unpack_native<'a>(

--- a/vortex-tensor/src/utils.rs
+++ b/vortex-tensor/src/utils.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use half::f16;
+use prost::Message;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
@@ -8,22 +10,69 @@ use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::ScalarFn;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_array::arrays::scalar_fn::ExactScalarFn;
+use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
+use vortex_array::arrays::scalar_fn::ScalarFnArrayView;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::PType;
+use vortex_array::dtype::proto::dtype as pb;
+use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_buffer::Buffer;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
+use vortex_session::VortexSession;
 
 use crate::matcher::AnyTensor;
 use crate::matcher::TensorMatch;
 use crate::scalar_fns::l2_denorm::L2Denorm;
+
+/// Safety factor for unit-norm tolerance. Applied as a constant multiplier on the probabilistic
+/// `√d · ε` bound so that legitimate round-off noise clears the check with headroom.
+pub(crate) const SAFETY_FACTOR: usize = 10;
+
+/// Returns the acceptable unit-norm drift for the given element precision and dimension count.
+///
+/// Uses the `c · √d · ε` bound where ε is machine epsilon and d is the vector dimension. Under
+/// IEEE 754 round-to-nearest the probabilistic (RMS-case) forward error for computing ‖x‖₂ grows
+/// as `O(√d · ε)` rather than the worst-case `O(d · ε)` from the classical Wilkinson bound,
+/// assuming near-independent rounding errors across the d-term summation.
+///
+/// Reference: Croci, Fasi, Higham, Mary, Mikaitis (2022). "Stochastic rounding: implementation,
+/// error analysis and applications." Royal Society Open Science, 9: 211631, §6.1 "Probabilistic
+/// error analysis." https://doi.org/10.1098/rsos.211631
+pub fn unit_norm_tolerance(element_ptype: PType, dimensions: usize) -> f64 {
+    let machine_epsilon: f64 = match element_ptype {
+        PType::F64 => f64::EPSILON,
+        PType::F32 => f32::EPSILON as f64,
+        PType::F16 => f16::EPSILON.to_f64_const(),
+        _ => unreachable!("unit_norm_tolerance requires a float ptype, got {element_ptype:?}"),
+    };
+
+    let dimensions_root = (dimensions as f64).sqrt();
+
+    SAFETY_FACTOR as f64 * machine_epsilon * dimensions_root
+}
+
+/// Extracts the `(normalized, norms)` children from an [`L2Denorm`] scalar function array.
+///
+/// [`L2Denorm`]: crate::scalar_fns::l2_denorm::L2Denorm
+pub fn extract_l2_denorm_children(array: &ArrayRef) -> (ArrayRef, ArrayRef) {
+    let sfn = array
+        .as_opt::<ExactScalarFn<L2Denorm>>()
+        .vortex_expect("expected ScalarFnArray wrapping L2Denorm");
+    (
+        sfn.nth_child(0)
+            .vortex_expect("L2Denorm missing normalized array"),
+        sfn.nth_child(1).vortex_expect("L2Denorm missing norms"),
+    )
+}
 
 /// Validates that `input_dtype` is a float-valued tensor-like extension dtype.
 pub fn validate_tensor_float_input(input_dtype: &DType) -> VortexResult<TensorMatch<'_>> {
@@ -46,17 +95,13 @@ pub fn validate_tensor_float_input(input_dtype: &DType) -> VortexResult<TensorMa
 
 /// Validates that two arguments of a binary tensor-like operator share the same float tensor
 /// dtype (ignoring top-level nullability), returning the shared [`TensorMatch`].
-///
-/// `op_name` is interpolated into the shape-mismatch error message so callers get a
-/// self-identifying diagnostic (e.g. "InnerProduct requires both inputs ...").
 pub fn validate_binary_tensor_float_inputs<'a>(
-    op_name: &str,
     lhs: &'a DType,
     rhs: &DType,
 ) -> VortexResult<TensorMatch<'a>> {
     vortex_ensure!(
         lhs.eq_ignore_nullability(rhs),
-        "{op_name} requires both inputs to have the same dtype, got {lhs} and {rhs}"
+        "binary tensor expression expects inputs to have the same dtype, got {lhs} and {rhs}"
     );
     validate_tensor_float_input(lhs)
 }
@@ -73,7 +118,7 @@ pub fn validate_binary_tensor_float_inputs<'a>(
 pub fn cast_to_f32(prim: PrimitiveArray) -> VortexResult<Buffer<f32>> {
     match prim.ptype() {
         PType::F16 => Ok(prim
-            .as_slice::<half::f16>()
+            .as_slice::<f16>()
             .iter()
             .map(|&v| f32::from(v))
             .collect()),
@@ -209,18 +254,62 @@ pub fn extract_constant_flat_row(
     Ok(FlatRow { elems })
 }
 
-/// Extracts the `(normalized, norms)` children from an [`L2Denorm`] scalar function array.
+/// Metadata for a serialized binary tensor-op array (shared by [`InnerProduct`] and
+/// [`CosineSimilarity`]). Both operands share the same extension dtype up to nullability
+/// (enforced by their `return_dtype` checks), but their individual nullabilities are lost in the
+/// parent's unioned output, so both are persisted.
 ///
-/// [`L2Denorm`]: crate::scalar_fns::l2_denorm::L2Denorm
-pub fn extract_l2_denorm_children(array: &ArrayRef) -> (ArrayRef, ArrayRef) {
-    let sfn = array
-        .as_opt::<ExactScalarFn<L2Denorm>>()
-        .vortex_expect("expected ScalarFnArray wrapping L2Denorm");
-    (
-        sfn.nth_child(0)
-            .vortex_expect("L2Denorm missing normalized array"),
-        sfn.nth_child(1).vortex_expect("L2Denorm missing norms"),
-    )
+/// [`CosineSimilarity`]: crate::scalar_fns::cosine_similarity::CosineSimilarity
+#[derive(Clone, prost::Message)]
+pub(crate) struct BinaryTensorOpMetadata {
+    #[prost(message, optional, tag = "1")]
+    pub(crate) lhs_dtype: Option<pb::DType>,
+    #[prost(message, optional, tag = "2")]
+    pub(crate) rhs_dtype: Option<pb::DType>,
+}
+
+impl BinaryTensorOpMetadata {
+    /// Encodes the two children of `view` into a [`BinaryTensorOpMetadata`] byte blob.
+    pub(crate) fn encode_from_view<V: ScalarFnVTable>(
+        view: &ScalarFnArrayView<V>,
+    ) -> VortexResult<Vec<u8>> {
+        let scalar_fn_array = view.as_::<ScalarFn>();
+        let lhs_dtype = Some(scalar_fn_array.child_at(0).dtype().try_into()?);
+        let rhs_dtype = Some(scalar_fn_array.child_at(1).dtype().try_into()?);
+        Ok(Self {
+            lhs_dtype,
+            rhs_dtype,
+        }
+        .encode_to_vec())
+    }
+
+    /// Decodes `metadata` and fetches both children from `children` using the decoded dtypes,
+    /// validating that `lhs` and `rhs` are compatible tensor operands.
+    pub(crate) fn decode_children(
+        metadata: &[u8],
+        len: usize,
+        children: &dyn vortex_array::serde::ArrayChildren,
+        session: &VortexSession,
+    ) -> VortexResult<Vec<ArrayRef>> {
+        let metadata = Self::decode(metadata)
+            .map_err(|e| vortex_err!("Failed to decode BinaryTensorOpMetadata: {e}"))?;
+        let lhs_pb = metadata
+            .lhs_dtype
+            .as_ref()
+            .ok_or_else(|| vortex_err!("metadata missing lhs_dtype"))?;
+        let rhs_pb = metadata
+            .rhs_dtype
+            .as_ref()
+            .ok_or_else(|| vortex_err!("metadata missing rhs_dtype"))?;
+
+        let lhs_dtype = DType::from_proto(lhs_pb, session)?;
+        let rhs_dtype = DType::from_proto(rhs_pb, session)?;
+        validate_binary_tensor_float_inputs(&lhs_dtype, &rhs_dtype)?;
+
+        let lhs = children.get(0, &lhs_dtype, len)?;
+        let rhs = children.get(1, &rhs_dtype, len)?;
+        Ok(vec![lhs, rhs])
+    }
 }
 
 #[cfg(test)]
@@ -241,7 +330,6 @@ pub mod test_helpers {
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
     use vortex_error::VortexResult;
-    use vortex_error::vortex_err;
 
     use crate::scalar_fns::l2_denorm::L2Denorm;
     use crate::types::fixed_shape::FixedShapeTensor;
@@ -271,12 +359,7 @@ pub mod test_helpers {
     /// The number of rows is inferred from the total element count divided by the product of the
     /// shape dimensions. For 0-dimensional tensors (scalar), each element is one row.
     pub fn tensor_array<T: NativePType>(shape: &[usize], elements: &[T]) -> VortexResult<ArrayRef> {
-        let list_size: u32 = shape
-            .iter()
-            .product::<usize>()
-            .max(1)
-            .try_into()
-            .map_err(|e| vortex_err!("{e}"))?;
+        let list_size: u32 = shape.iter().product::<usize>().max(1).try_into().unwrap();
         let storage = flat_fsl(elements, list_size);
         let metadata = FixedShapeTensorMetadata::new(shape.to_vec());
         let ext_dtype =

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -544,7 +544,7 @@ mod turboquant_benches {
     fn turboquant_config(bit_width: u8) -> TurboQuantConfig {
         TurboQuantConfig {
             bit_width,
-            seed: Some(123),
+            seed: 123,
             num_rounds: 3,
         }
     }


### PR DESCRIPTION
## Summary

Tracking issue: https://github.com/vortex-data/vortex/issues/7297

This is mostly just cosmetic changes that will help with some future changes incoming.

- Extract validate_vector_storage_dtype from Vector::validate_dtype into types/vector/mod.rs.
- Move unit_norm_tolerance and BinaryTensorOpMetadata into utils.rs; switch unit_norm_tolerance to the c*sqrt(d)*epsilon bound with a dimensions parameter.
- Drop op_name from validate_binary_tensor_float_inputs.
- TurboQuantConfig::seed Option<u64> -> u64.
- SorfOptions::dimension -> SorfOptions::dimensions and matching SorfMatrix::try_new parameter.
- centroids::get_centroids -> compute_or_get_centroids.
- Crate-root #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::unwrap_in_result))].
- Extract validate_vector_storage_dtype from Vector::validate_dtype into types/vector/mod.rs.
- Move unit_norm_tolerance and BinaryTensorOpMetadata into utils.rs; switch unit_norm_tolerance to the c*sqrt(d)*epsilon bound with a dimensions parameter.
- Drop op_name from validate_binary_tensor_float_inputs.
- TurboQuantConfig::seed Option<u64> -> u64.
- SorfOptions::dimension -> SorfOptions::dimensions and matching SorfMatrix::try_new parameter.
- centroids::get_centroids -> compute_or_get_centroids.
- Crate-root #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::unwrap_in_result))].

## API Changes

Some renames

## Testing

N/A