### PR TITLE
fix: nested block on, make `materialize` async

### DIFF
--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -17,6 +17,7 @@ use cudarc::driver::DevicePtr;
 use cudarc::driver::LaunchConfig;
 use cudarc::driver::PushKernelArg;
 use cudarc::driver::sys::CUevent_flags;
+use futures::executor::block_on;
 use vortex::array::IntoArray;
 use vortex::array::LEGACY_SESSION;
 use vortex::array::VortexSessionExecute;
@@ -133,7 +134,7 @@ impl BenchRunner {
             device_buffers,
             shared_mem_bytes,
             ..
-        } = plan.materialize(cuda_ctx).vortex_expect("materialize plan");
+        } = block_on(plan.materialize(cuda_ctx)).vortex_expect("materialize plan");
 
         let device_plan = Arc::new(
             cuda_ctx

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -555,12 +555,12 @@ mod tests {
         .vortex_expect("failed to create BitPacked array")
     }
 
-    fn dispatch_plan(
+    async fn dispatch_plan(
         array: &vortex::array::ArrayRef,
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<MaterializedPlan> {
         match DispatchPlan::new(array)? {
-            DispatchPlan::Fused(plan) => plan.materialize(ctx),
+            DispatchPlan::Fused(plan) => plan.materialize(ctx).await,
             _ => vortex_bail!("array encoding not fusable"),
         }
     }
@@ -786,7 +786,7 @@ mod tests {
     }
 
     #[crate::test]
-    fn test_bitpacked() -> VortexResult<()> {
+    async fn test_bitpacked() -> VortexResult<()> {
         let bit_width: u8 = 10;
         let len = 3000;
         let max_val = (1u64 << bit_width).saturating_sub(1);
@@ -796,7 +796,7 @@ mod tests {
 
         let bp = bitpacked_array_u32(bit_width, len);
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&bp.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&bp.into_array(), &mut cuda_ctx).await?;
 
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
@@ -806,7 +806,7 @@ mod tests {
     }
 
     #[crate::test]
-    fn test_for_bitpacked() -> VortexResult<()> {
+    async fn test_for_bitpacked() -> VortexResult<()> {
         let bit_width: u8 = 6;
         let len = 3000;
         let reference = 42u32;
@@ -821,7 +821,7 @@ mod tests {
         let for_arr = FoR::try_new(bp.into_array(), Scalar::from(reference))?;
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&for_arr.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&for_arr.into_array(), &mut cuda_ctx).await?;
 
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
@@ -831,7 +831,7 @@ mod tests {
     }
 
     #[crate::test]
-    fn test_runend() -> VortexResult<()> {
+    async fn test_runend() -> VortexResult<()> {
         let ends: Vec<u32> = vec![1000, 2000, 3000];
         let values: Vec<u32> = vec![10, 20, 30];
         let len = 3000;
@@ -847,7 +847,7 @@ mod tests {
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
         let re = RunEnd::new(ends_arr, values_arr, cuda_ctx.execution_ctx());
 
-        let plan = dispatch_plan(&re.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&re.into_array(), &mut cuda_ctx).await?;
 
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
@@ -857,7 +857,7 @@ mod tests {
     }
 
     #[crate::test]
-    fn test_dict_for_bp_values_bp_codes() -> VortexResult<()> {
+    async fn test_dict_for_bp_values_bp_codes() -> VortexResult<()> {
         // Dict where both codes and values are BitPacked+FoR.
         let dict_reference = 1_000_000u32;
         let dict_residuals: Vec<u32> = (0..64).collect();
@@ -888,7 +888,7 @@ mod tests {
         let dict = DictArray::try_new(codes_bp.into_array(), dict_for.into_array())?;
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&dict.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&dict.into_array(), &mut cuda_ctx).await?;
 
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
@@ -898,7 +898,7 @@ mod tests {
     }
 
     #[crate::test]
-    fn test_alp_for_bitpacked() -> VortexResult<()> {
+    async fn test_alp_for_bitpacked() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // ALP(FoR(BitPacked)): encode each layer, then reassemble the tree
         // bottom-up because encode() methods produce flat outputs.
@@ -925,7 +925,7 @@ mod tests {
         );
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&tree.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&tree.into_array(), &mut cuda_ctx).await?;
 
         let actual =
             run_dispatch_plan_f32(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
@@ -935,7 +935,7 @@ mod tests {
     }
 
     #[crate::test]
-    fn test_zigzag_bitpacked() -> VortexResult<()> {
+    async fn test_zigzag_bitpacked() -> VortexResult<()> {
         // ZigZag(BitPacked): unpack then zigzag-decode.
         let bit_width: u8 = 4;
         let len = 3000;
@@ -958,7 +958,7 @@ mod tests {
         let zz = ZigZag::try_new(bp.into_array())?;
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&zz.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&zz.into_array(), &mut cuda_ctx).await?;
 
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
@@ -968,7 +968,7 @@ mod tests {
     }
 
     #[crate::test]
-    fn test_for_runend() -> VortexResult<()> {
+    async fn test_for_runend() -> VortexResult<()> {
         // FoR(RunEnd): expand runs then add constant.
         let ends: Vec<u32> = vec![500, 1000, 1500, 2000, 2500, 3000];
         let values: Vec<u32> = vec![1, 2, 3, 4, 5, 6];
@@ -987,7 +987,7 @@ mod tests {
         let re = RunEnd::new(ends_arr, values_arr, cuda_ctx.execution_ctx());
         let for_arr = FoR::try_new(re.into_array(), Scalar::from(reference))?;
 
-        let plan = dispatch_plan(&for_arr.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&for_arr.into_array(), &mut cuda_ctx).await?;
 
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
@@ -997,7 +997,7 @@ mod tests {
     }
 
     #[crate::test]
-    fn test_for_dict() -> VortexResult<()> {
+    async fn test_for_dict() -> VortexResult<()> {
         // FoR(Dict(codes=Primitive, values=Primitive)): gather then add constant.
         let dict_values: Vec<u32> = vec![100, 200, 300, 400];
         let dict_size = dict_values.len();
@@ -1016,7 +1016,7 @@ mod tests {
         let for_arr = FoR::try_new(dict.into_array(), Scalar::from(reference))?;
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&for_arr.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&for_arr.into_array(), &mut cuda_ctx).await?;
 
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
@@ -1026,7 +1026,7 @@ mod tests {
     }
 
     #[crate::test]
-    fn test_dict_for_bp_codes() -> VortexResult<()> {
+    async fn test_dict_for_bp_codes() -> VortexResult<()> {
         // Dict(codes=FoR(BitPacked), values=primitive)
         let dict_values: Vec<u32> = (0..8).map(|i| i * 1000 + 7).collect();
         let dict_size = dict_values.len();
@@ -1048,7 +1048,7 @@ mod tests {
         let dict = DictArray::try_new(codes_for.into_array(), values_prim.into_array())?;
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&dict.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&dict.into_array(), &mut cuda_ctx).await?;
 
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
@@ -1058,7 +1058,7 @@ mod tests {
     }
 
     #[crate::test]
-    fn test_dict_primitive_values_bp_codes() -> VortexResult<()> {
+    async fn test_dict_primitive_values_bp_codes() -> VortexResult<()> {
         let dict_values: Vec<u32> = vec![100, 200, 300, 400];
         let dict_size = dict_values.len();
         let len = 3000;
@@ -1077,7 +1077,7 @@ mod tests {
         let dict = DictArray::try_new(codes_bp.into_array(), values_prim.into_array())?;
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&dict.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&dict.into_array(), &mut cuda_ctx).await?;
 
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
@@ -1207,7 +1207,7 @@ mod tests {
     #[case(2500, 4500)]
     #[case(3333, 4444)]
     #[crate::test]
-    fn test_sliced_primitive(
+    async fn test_sliced_primitive(
         #[case] slice_start: usize,
         #[case] slice_end: usize,
     ) -> VortexResult<()> {
@@ -1221,7 +1221,7 @@ mod tests {
         let expected: Vec<u32> = data[slice_start..slice_end].to_vec();
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&sliced, &mut cuda_ctx)?;
+        let plan = dispatch_plan(&sliced, &mut cuda_ctx).await?;
 
         let actual = run_dynamic_dispatch_plan(
             &cuda_ctx,
@@ -1250,7 +1250,7 @@ mod tests {
     #[case(2500, 4500)]
     #[case(3333, 4444)]
     #[crate::test]
-    fn test_sliced_zigzag_bitpacked(
+    async fn test_sliced_zigzag_bitpacked(
         #[case] slice_start: usize,
         #[case] slice_end: usize,
     ) -> VortexResult<()> {
@@ -1276,7 +1276,7 @@ mod tests {
         let expected: Vec<u32> = all_decoded[slice_start..slice_end].to_vec();
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&sliced, &mut cuda_ctx)?;
+        let plan = dispatch_plan(&sliced, &mut cuda_ctx).await?;
 
         let actual = run_dynamic_dispatch_plan(
             &cuda_ctx,
@@ -1305,7 +1305,7 @@ mod tests {
     #[case(2500, 4500)]
     #[case(3333, 4444)]
     #[crate::test]
-    fn test_sliced_dict_with_primitive_codes(
+    async fn test_sliced_dict_with_primitive_codes(
         #[case] slice_start: usize,
         #[case] slice_end: usize,
     ) -> VortexResult<()> {
@@ -1326,7 +1326,7 @@ mod tests {
             .collect();
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&sliced, &mut cuda_ctx)?;
+        let plan = dispatch_plan(&sliced, &mut cuda_ctx).await?;
 
         let actual = run_dynamic_dispatch_plan(
             &cuda_ctx,
@@ -1355,7 +1355,7 @@ mod tests {
     #[case(2500, 4500)]
     #[case(3333, 4444)]
     #[crate::test]
-    fn test_sliced_bitpacked(
+    async fn test_sliced_bitpacked(
         #[case] slice_start: usize,
         #[case] slice_end: usize,
     ) -> VortexResult<()> {
@@ -1375,7 +1375,7 @@ mod tests {
         let expected: Vec<u32> = data[slice_start..slice_end].to_vec();
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&sliced, &mut cuda_ctx)?;
+        let plan = dispatch_plan(&sliced, &mut cuda_ctx).await?;
 
         let actual = run_dynamic_dispatch_plan(
             &cuda_ctx,
@@ -1404,7 +1404,7 @@ mod tests {
     #[case(2500, 4500)]
     #[case(3333, 4444)]
     #[crate::test]
-    fn test_sliced_for_bitpacked(
+    async fn test_sliced_for_bitpacked(
         #[case] slice_start: usize,
         #[case] slice_end: usize,
     ) -> VortexResult<()> {
@@ -1428,7 +1428,7 @@ mod tests {
         let expected: Vec<u32> = all_decoded[slice_start..slice_end].to_vec();
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&sliced, &mut cuda_ctx)?;
+        let plan = dispatch_plan(&sliced, &mut cuda_ctx).await?;
 
         let actual = run_dynamic_dispatch_plan(
             &cuda_ctx,
@@ -1457,7 +1457,7 @@ mod tests {
     #[case(2500, 4500)]
     #[case(3333, 4444)]
     #[crate::test]
-    fn test_sliced_dict_for_bp_values_bp_codes(
+    async fn test_sliced_dict_for_bp_values_bp_codes(
         #[case] slice_start: usize,
         #[case] slice_end: usize,
     ) -> VortexResult<()> {
@@ -1493,7 +1493,7 @@ mod tests {
         let expected: Vec<u32> = all_decoded[slice_start..slice_end].to_vec();
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&sliced, &mut cuda_ctx)?;
+        let plan = dispatch_plan(&sliced, &mut cuda_ctx).await?;
 
         let actual = run_dynamic_dispatch_plan(
             &cuda_ctx,
@@ -1512,7 +1512,7 @@ mod tests {
     #[case(0u32, 1u32, 4096)]
     #[case(100u32, 7u32, 5000)]
     #[crate::test]
-    fn test_sequence_unsigned(
+    async fn test_sequence_unsigned(
         #[case] base: u32,
         #[case] multiplier: u32,
         #[case] len: usize,
@@ -1525,7 +1525,7 @@ mod tests {
         let seq = Sequence::try_new_typed(base, multiplier, Nullability::NonNullable, len)?;
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&seq.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&seq.into_array(), &mut cuda_ctx).await?;
 
         let actual = run_dynamic_dispatch_plan(
             &cuda_ctx,
@@ -1545,7 +1545,7 @@ mod tests {
     #[case(-500i32, -7i32, 50)]
     #[case(0i32, 1i32, 5000)]
     #[crate::test]
-    fn test_sequence_signed(
+    async fn test_sequence_signed(
         #[case] base: i32,
         #[case] multiplier: i32,
         #[case] len: usize,
@@ -1558,7 +1558,7 @@ mod tests {
         let seq = Sequence::try_new_typed(base, multiplier, Nullability::NonNullable, len)?;
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&seq.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&seq.into_array(), &mut cuda_ctx).await?;
 
         let actual_u32 = run_dynamic_dispatch_plan(
             &cuda_ctx,
@@ -2362,7 +2362,7 @@ mod tests {
     #[case::start_slice(5000, Some(0..1000))]
     #[case::chunk_aligned(5000, Some(1024..3000))]
     #[crate::test]
-    fn test_bitpacked_with_patches(
+    async fn test_bitpacked_with_patches(
         #[case] len: usize,
         #[case] slice_range: Option<Range<usize>>,
     ) -> VortexResult<()> {
@@ -2394,7 +2394,7 @@ mod tests {
         };
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&array, &mut cuda_ctx)?;
+        let plan = dispatch_plan(&array, &mut cuda_ctx).await?;
         let actual = run_dynamic_dispatch_plan(
             &cuda_ctx,
             expected.len(),
@@ -2409,7 +2409,7 @@ mod tests {
     #[case::unsliced(3000, None)]
     #[case::mid_slice(5000, Some(500..3500))]
     #[crate::test]
-    fn test_for_bitpacked_with_patches(
+    async fn test_for_bitpacked_with_patches(
         #[case] len: usize,
         #[case] slice_range: Option<Range<usize>>,
     ) -> VortexResult<()> {
@@ -2444,7 +2444,7 @@ mod tests {
         };
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&array, &mut cuda_ctx)?;
+        let plan = dispatch_plan(&array, &mut cuda_ctx).await?;
         let actual = run_dynamic_dispatch_plan(
             &cuda_ctx,
             expected.len(),
@@ -2460,7 +2460,7 @@ mod tests {
     #[case::mid_slice(5000, Some(100..4000))]
     #[case::large_offset(5000, Some(1500..4500))]
     #[crate::test]
-    fn test_alp_with_patches(
+    async fn test_alp_with_patches(
         #[case] len: usize,
         #[case] slice_range: Option<Range<usize>>,
     ) -> VortexResult<()> {
@@ -2497,7 +2497,7 @@ mod tests {
         let expected: Vec<f32> = cpu_decoded.as_slice::<f32>().to_vec();
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&array, &mut cuda_ctx)?;
+        let plan = dispatch_plan(&array, &mut cuda_ctx).await?;
         let actual = run_dispatch_plan_f32(
             &cuda_ctx,
             expected.len(),
@@ -2621,7 +2621,7 @@ mod tests {
 
     /// Dict where codes are BitPacked u32 with patches exceeding the bit width.
     #[crate::test]
-    fn test_dict_bitpacked_codes_with_patches() -> VortexResult<()> {
+    async fn test_dict_bitpacked_codes_with_patches() -> VortexResult<()> {
         let dict_values: Vec<u32> = (0..256).map(|i| i * 1000 + 42).collect();
         let len = 3000;
         let bit_width: u8 = 4;
@@ -2650,7 +2650,7 @@ mod tests {
         let dict = DictArray::try_new(codes_bp.into_array(), values_prim.into_array())?;
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&dict.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&dict.into_array(), &mut cuda_ctx).await?;
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
         assert_eq!(actual, expected);
@@ -2659,7 +2659,7 @@ mod tests {
 
     /// Patches placed exactly at FastLanes chunk boundaries (1024-element chunks).
     #[crate::test]
-    fn test_bitpacked_patches_at_chunk_boundaries() -> VortexResult<()> {
+    async fn test_bitpacked_patches_at_chunk_boundaries() -> VortexResult<()> {
         let len = 4096usize;
         let bit_width: u8 = 4;
         let max_val = (1u32 << bit_width) - 1;
@@ -2679,7 +2679,7 @@ mod tests {
         assert!(bp.patches().is_some(), "expected patches");
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&bp.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&bp.into_array(), &mut cuda_ctx).await?;
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
         assert_eq!(actual, values);
@@ -2688,7 +2688,7 @@ mod tests {
 
     /// Large array (100k elements) spanning many blocks with sparse patches.
     #[crate::test]
-    fn test_bitpacked_large_array_with_patches() -> VortexResult<()> {
+    async fn test_bitpacked_large_array_with_patches() -> VortexResult<()> {
         let len = 100_000usize;
         let bit_width: u8 = 6;
         let max_val = (1u32 << bit_width) - 1;
@@ -2711,7 +2711,7 @@ mod tests {
         assert!(bp.patches().is_some(), "expected patches");
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&bp.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&bp.into_array(), &mut cuda_ctx).await?;
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
         assert_eq!(actual, values);
@@ -2763,7 +2763,7 @@ mod tests {
 
     /// Extreme case: ALL values are patches (bit_width=1, every value > 1).
     #[crate::test]
-    fn test_bitpacked_all_patches() -> VortexResult<()> {
+    async fn test_bitpacked_all_patches() -> VortexResult<()> {
         let bit_width: u8 = 1;
         let len = 2000usize;
         // All values >= 2, so every single element exceeds max storable (1) and
@@ -2779,7 +2779,7 @@ mod tests {
         assert!(bp.patches().is_some(), "expected patches");
 
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&bp.into_array(), &mut cuda_ctx)?;
+        let plan = dispatch_plan(&bp.into_array(), &mut cuda_ctx).await?;
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
         assert_eq!(actual, values);

--- a/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
+++ b/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
@@ -47,7 +47,7 @@ use super::ptype_to_tag;
 use super::tag_to_ptype;
 use crate::CudaBufferExt;
 use crate::CudaExecutionCtx;
-use crate::kernel::load_patches_sync;
+use crate::kernel::load_patches_to_gpu;
 
 /// A plan whose source buffers have been copied to the device, ready for kernel launch.
 pub struct MaterializedPlan {
@@ -325,7 +325,7 @@ impl FusedPlan {
     }
 
     /// Copy source buffers to the device, producing a [`MaterializedPlan`].
-    pub fn materialize(self, ctx: &mut CudaExecutionCtx) -> VortexResult<MaterializedPlan> {
+    pub async fn materialize(self, ctx: &mut CudaExecutionCtx) -> VortexResult<MaterializedPlan> {
         let shared_mem_bytes = self.dynamic_shared_mem_bytes();
 
         let mut device_buffers = Vec::new();
@@ -358,7 +358,7 @@ impl FusedPlan {
 
             // Upload source patches (e.g. BitPacked exceptions).
             if let Some(patches) = &stage.source_patches {
-                let (ptr, bufs) = load_patches_sync(patches, ctx)?;
+                let (ptr, bufs) = load_patches_to_gpu(patches, ctx).await?;
                 source.params.bitunpack.patches_ptr = ptr;
                 device_buffers.extend(bufs);
             }
@@ -367,7 +367,7 @@ impl FusedPlan {
             let mut scalar_ops: Vec<ScalarOp> = Vec::with_capacity(stage.scalar_ops.len());
             for (mut op, patches) in stage.scalar_ops.clone() {
                 if let Some(patches) = &patches {
-                    let (ptr, bufs) = load_patches_sync(patches, ctx)?;
+                    let (ptr, bufs) = load_patches_to_gpu(patches, ctx).await?;
                     op.params.alp.patches_ptr = ptr;
                     device_buffers.extend(bufs);
                 }
@@ -397,7 +397,7 @@ impl FusedPlan {
     ///
     /// `subtree_buffers` must correspond 1:1 (in DFS order) to the
     /// `pending_subtrees` returned by `build`.
-    pub fn materialize_with_subtrees(
+    pub async fn materialize_with_subtrees(
         mut self,
         subtree_buffers: Vec<BufferHandle>,
         ctx: &mut CudaExecutionCtx,
@@ -408,7 +408,7 @@ impl FusedPlan {
         ) {
             *slot = Some(buf);
         }
-        self.materialize(ctx)
+        self.materialize(ctx).await
     }
 
     /// Walk the encoding tree, producing a [`Stage`] for the root.

--- a/vortex-cuda/src/hybrid_dispatch/mod.rs
+++ b/vortex-cuda/src/hybrid_dispatch/mod.rs
@@ -74,7 +74,7 @@ pub async fn try_gpu_dispatch(
 
     match DispatchPlan::new(array)? {
         DispatchPlan::Fused(plan) => {
-            let materialized = plan.materialize(ctx)?;
+            let materialized = plan.materialize(ctx).await?;
             let num_stages = materialized.dispatch_plan.num_stages();
             trace!(encoding = %array.encoding_id(), num_stages, "fully-fused dispatch");
             materialized.execute(array.len(), ctx)
@@ -93,7 +93,7 @@ pub async fn try_gpu_dispatch(
             }
 
             let num_subtrees = subtree_buffers.len();
-            let materialized = plan.materialize_with_subtrees(subtree_buffers, ctx)?;
+            let materialized = plan.materialize_with_subtrees(subtree_buffers, ctx).await?;
             let num_stages = materialized.dispatch_plan.num_stages();
             trace!(encoding = %array.encoding_id(), num_stages, num_subtrees, "partially-fused dispatch");
             materialized.execute(array.len(), ctx)

--- a/vortex-cuda/src/kernel/mod.rs
+++ b/vortex-cuda/src/kernel/mod.rs
@@ -34,7 +34,7 @@ pub use encodings::ZstdKernelPrep;
 pub use encodings::zstd_kernel_prepare;
 pub(crate) use encodings::*;
 pub(crate) use filter::FilterExecutor;
-pub(crate) use patches::types::load_patches_sync;
+pub(crate) use patches::types::load_patches_to_gpu;
 pub(crate) use slice::SliceExecutor;
 
 use crate::CudaKernelEvents;

--- a/vortex-cuda/src/kernel/patches/types.rs
+++ b/vortex-cuda/src/kernel/patches/types.rs
@@ -167,16 +167,16 @@ fn build_gpu_patches(
     Ok((gpu_buf, ptr))
 }
 
-/// Sync wrapper: load patches via [`load_patches`] (blocking), then build and
-/// upload a [`GPUPatches`] struct. Returns the device pointer and all buffer
-/// handles that must be kept alive for the kernel launch.
-pub(crate) fn load_patches_sync(
+/// Transfers patches to the GPU and builds a [`GPUPatches`] descriptor.
+///
+/// Returns the device pointer and all buffer handles that must be kept
+/// alive for the kernel launch.
+pub(crate) async fn load_patches_to_gpu(
     patches: &Patches,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<(u64, Vec<BufferHandle>)> {
-    let device_patches = futures::executor::block_on(load_patches(patches, ctx))?;
+    let device_patches = load_patches(patches, ctx).await?;
     let (gpu_buf, ptr) = build_gpu_patches(&device_patches, ctx)?;
-
     let DevicePatches {
         chunk_offsets,
         indices,


### PR DESCRIPTION
Calling `block_on` in `load_patches_to_gpu` caused a crash when running the benchmark, as the bench runner also calls block on which led to nested executors. Copies and async usage will be reworked holistically as part of the bigger work stream making data loading fast.