### PR TITLE
Improve stats reporting to DF

### DIFF
--- a/vortex-datafusion/src/convert/stats.rs
+++ b/vortex-datafusion/src/convert/stats.rs
@@ -9,6 +9,7 @@ use vortex::dtype::Nullability;
 use vortex::dtype::PType;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
+use vortex::expr::stats::Precision as VortexPrecision;
 use vortex::expr::stats::Stat;
 use vortex::scalar::Scalar;
 
@@ -83,10 +84,40 @@ pub(crate) fn stats_set_to_df(
         min_value: min.to_df(),
         max_value: max.to_df(),
         sum_value: sum.to_df(),
-        distinct_count: stats_set
-            .get_as::<bool>(Stat::IsConstant, &DType::Bool(Nullability::NonNullable))
-            .and_then(|is_constant| is_constant.as_exact().map(|_| Precision::Exact(1)))
-            .unwrap_or(Precision::Absent),
+        distinct_count: is_constant_to_distinct_count(
+            stats_set.get_as::<bool>(Stat::IsConstant, &DType::Bool(Nullability::NonNullable)),
+        ),
         byte_size: column_size.to_df(),
     })
+}
+
+pub(crate) fn is_constant_to_distinct_count(
+    is_constant: Option<VortexPrecision<bool>>,
+) -> Precision<usize> {
+    match is_constant.and_then(VortexPrecision::as_exact) {
+        Some(true) => Precision::Exact(1),
+        Some(false) | None => Precision::Absent,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex::expr::stats::Precision as VortexPrecision;
+
+    use super::*;
+
+    #[test]
+    fn is_constant_false_does_not_imply_one_distinct_value() -> VortexResult<()> {
+        let false_constant = StatsSet::of(Stat::IsConstant, VortexPrecision::exact(false));
+        let false_stats = stats_set_to_df(&false_constant, &DType::Bool(Nullability::NonNullable))?;
+
+        assert_eq!(false_stats.distinct_count, Precision::Absent);
+
+        let true_constant = StatsSet::of(Stat::IsConstant, VortexPrecision::exact(true));
+        let true_stats = stats_set_to_df(&true_constant, &DType::Bool(Nullability::NonNullable))?;
+
+        assert_eq!(true_stats.distinct_count, Precision::Exact(1));
+
+        Ok(())
+    }
 }

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -14,6 +14,7 @@ use datafusion_common::ColumnStatistics;
 use datafusion_common::DataFusionError;
 use datafusion_common::GetExt;
 use datafusion_common::Result as DFResult;
+use datafusion_common::ScalarValue as DFScalarValue;
 use datafusion_common::Statistics;
 use datafusion_common::config::ConfigField;
 use datafusion_common::config_namespace;
@@ -34,6 +35,7 @@ use datafusion_datasource::sink::DataSinkExec;
 use datafusion_datasource::source::DataSourceExec;
 use datafusion_execution::cache::cache_manager::CachedFileMetadataEntry;
 use datafusion_expr::dml::InsertOp;
+use datafusion_physical_expr::LexOrdering;
 use datafusion_physical_expr::LexRequirement;
 use datafusion_physical_plan::ExecutionPlan;
 use futures::FutureExt;
@@ -60,6 +62,7 @@ use vortex::file::VORTEX_FILE_EXTENSION;
 use vortex::io::object_store::ObjectStoreReadAt;
 use vortex::io::session::RuntimeSessionExt;
 use vortex::scalar::Scalar;
+use vortex::scalar::ScalarValue as VortexScalarValue;
 use vortex::session::VortexSession;
 
 use super::cache::CachedVortexMetadata;
@@ -518,55 +521,26 @@ impl FileFormat for VortexFormat {
                 let (stats_set, stats_dtype) = file_stats.get(col_idx);
 
                 // Update the total size in bytes.
-                let column_size = stats_set
-                    .get_as::<usize>(Stat::UncompressedSizeInBytes, &PType::U64.into())
-                    .unwrap_or_else(|| stats::Precision::inexact(0_usize));
+                let column_size =
+                    stats_set.get_as::<usize>(Stat::UncompressedSizeInBytes, &PType::U64.into());
+
                 sum_of_column_byte_sizes = sum_of_column_byte_sizes
-                    .zip(column_size)
+                    .zip(column_size.unwrap_or_else(|| stats::Precision::inexact(0_usize)))
                     .map(|(acc, size)| acc + size);
 
-                // TODO(connor): There's a lot that can go wrong here, should probably handle this
-                // more gracefully...
-                // Find the min statistic.
-                let min = stats_set.get(Stat::Min).and_then(|pstat_val| {
-                    pstat_val
-                        .map(|stat_val| {
-                            // Because of DataFusion's Schema evolution, it is possible that the
-                            // type of the min/max stat has changed. Thus we construct the stat as
-                            // the file datatype first and only then do we cast accordingly.
-                            Scalar::try_new(
-                                Stat::Min
-                                    .dtype(stats_dtype)
-                                    .vortex_expect("must have a valid dtype"),
-                                Some(stat_val),
-                            )
-                            .vortex_expect("`Stat::Min` somehow had an incompatible `DType`")
-                            .cast(&DType::from_arrow(field.as_ref()))
-                            .vortex_expect("Unable to cast to target type that DataFusion wants")
-                            .try_to_df()
-                            .ok()
-                        })
-                        .transpose()
-                });
-
-                // Find the max statistic.
-                let max = stats_set.get(Stat::Max).and_then(|pstat_val| {
-                    pstat_val
-                        .map(|stat_val| {
-                            Scalar::try_new(
-                                Stat::Max
-                                    .dtype(stats_dtype)
-                                    .vortex_expect("must have a valid dtype"),
-                                Some(stat_val),
-                            )
-                            .vortex_expect("`Stat::Max` somehow had an incompatible `DType`")
-                            .cast(&DType::from_arrow(field.as_ref()))
-                            .vortex_expect("Unable to cast to target type that DataFusion wants")
-                            .try_to_df()
-                            .ok()
-                        })
-                        .transpose()
-                });
+                let target_dtype = DType::from_arrow(field.as_ref());
+                let min = scalar_stat_to_df(
+                    Stat::Min,
+                    stats_set.get(Stat::Min),
+                    stats_dtype,
+                    &target_dtype,
+                );
+                let max = scalar_stat_to_df(
+                    Stat::Max,
+                    stats_set.get(Stat::Max),
+                    stats_dtype,
+                    &target_dtype,
+                );
 
                 let null_count = stats_set.get_as::<usize>(Stat::NullCount, &PType::U64.into());
 
@@ -649,6 +623,23 @@ impl FileFormat for VortexFormat {
 
         Arc::new(source) as _
     }
+}
+
+fn scalar_stat_to_df(
+    stat: Stat,
+    value: Option<stats::Precision<VortexScalarValue>>,
+    stats_dtype: &DType,
+    target_dtype: &DType,
+) -> Option<stats::Precision<DFScalarValue>> {
+    let stat_dtype = stat.dtype(stats_dtype)?;
+
+    value?
+        .try_map(|stat_value| {
+            Scalar::try_new(stat_dtype, Some(stat_value))?
+                .cast(target_dtype)?
+                .try_to_df()
+        })
+        .ok()
 }
 
 #[cfg(test)]

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -69,6 +69,7 @@ use super::sink::VortexSink;
 use super::source::VortexSource;
 use crate::PrecisionExt as _;
 use crate::convert::TryToDataFusion;
+use crate::convert::stats::is_constant_to_distinct_count;
 
 const DEFAULT_FOOTER_INITIAL_READ_SIZE_BYTES: usize = MAX_POSTSCRIPT_SIZE as usize + EOF_SIZE;
 
@@ -502,7 +503,10 @@ impl FileFormat for VortexFormat {
                             .vortex_expect("Row count overflow"),
                     ),
                     total_byte_size: Precision::Absent,
-                    column_statistics: vec![ColumnStatistics::default(); struct_dtype.nfields()],
+                    column_statistics: vec![
+                        ColumnStatistics::default();
+                        table_schema.fields().len()
+                    ],
                 });
             };
 
@@ -543,11 +547,12 @@ impl FileFormat for VortexFormat {
                     min_value: min.to_df(),
                     max_value: max.to_df(),
                     sum_value: Precision::Absent,
-                    distinct_count: stats_set
-                        .get_as::<bool>(Stat::IsConstant, &DType::Bool(Nullability::NonNullable))
-                        .and_then(|is_constant| is_constant.as_exact().map(|_| Precision::Exact(1)))
-                        .unwrap_or(Precision::Absent),
-                    // TODO(connor): Is this correct?
+                    distinct_count: is_constant_to_distinct_count(
+                        stats_set.get_as::<bool>(
+                            Stat::IsConstant,
+                            &DType::Bool(Nullability::NonNullable),
+                        ),
+                    ),
                     byte_size: column_size.to_df(),
                 })
             }

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -35,7 +35,6 @@ use datafusion_datasource::sink::DataSinkExec;
 use datafusion_datasource::source::DataSourceExec;
 use datafusion_execution::cache::cache_manager::CachedFileMetadataEntry;
 use datafusion_expr::dml::InsertOp;
-use datafusion_physical_expr::LexOrdering;
 use datafusion_physical_expr::LexRequirement;
 use datafusion_physical_plan::ExecutionPlan;
 use futures::FutureExt;
@@ -507,7 +506,6 @@ impl FileFormat for VortexFormat {
                 });
             };
 
-            let mut sum_of_column_byte_sizes = stats::Precision::exact(0_usize);
             let mut column_statistics = Vec::with_capacity(table_schema.fields().len());
 
             for field in table_schema.fields().iter() {
@@ -523,10 +521,6 @@ impl FileFormat for VortexFormat {
                 // Update the total size in bytes.
                 let column_size =
                     stats_set.get_as::<usize>(Stat::UncompressedSizeInBytes, &PType::U64.into());
-
-                sum_of_column_byte_sizes = sum_of_column_byte_sizes
-                    .zip(column_size.unwrap_or_else(|| stats::Precision::inexact(0_usize)))
-                    .map(|(acc, size)| acc + size);
 
                 let target_dtype = DType::from_arrow(field.as_ref());
                 let min = scalar_stat_to_df(
@@ -558,7 +552,9 @@ impl FileFormat for VortexFormat {
                 })
             }
 
-            let total_byte_size = sum_of_column_byte_sizes.to_df();
+            let total_byte_size = column_statistics
+                .iter()
+                .fold(Precision::Exact(0), |acc, cs| acc.add(&cs.byte_size));
 
             Ok(Statistics {
                 num_rows: Precision::Exact(


### PR DESCRIPTION
## Summary

By comparing the physical plans between Parquet and Vortex, I've found a few things we're doing that are either wrong or suboptimal:
1. Reporting inexact column and file byte sizes if they are missing (which they are), which at the very least leads DF down a suboptimal path which introduces an extra RepartitionExec which isn't necessary.
2. He have a cute trick to report cardinality estimation for constant columns, problem is if we said we had exactly one record even if `IsConstant` was false.

There are still a few stats things that could probably be improved here, especially which stats are calculated and stored where and how that's configured, but I think for now this is a very nice improvement.