### PR TITLE
fix(sequence): fall back to canonical cast when params can't fit target

### DIFF
--- a/encodings/sequence/src/compute/cast.rs
+++ b/encodings/sequence/src/compute/cast.rs
@@ -54,10 +54,20 @@ impl CastReduce for Sequence {
                 Some(ScalarValue::Primitive(array.multiplier())),
             )?;
 
-            let new_base_scalar =
-                base_scalar.cast(&DType::Primitive(*target_ptype, Nullability::NonNullable))?;
-            let new_multiplier_scalar = multiplier_scalar
-                .cast(&DType::Primitive(*target_ptype, Nullability::NonNullable))?;
+            let target_scalar_dtype = DType::Primitive(*target_ptype, Nullability::NonNullable);
+
+            // If either the base or multiplier cannot be represented in the target
+            // type (e.g., a negative multiplier with an unsigned target), fall back
+            // to the canonical cast path by returning `Ok(None)`. That path decodes
+            // individual values and casts them one by one, which correctly succeeds
+            // whenever all produced values fit the target type even if the stored
+            // parameters do not.
+            let Ok(new_base_scalar) = base_scalar.cast(&target_scalar_dtype) else {
+                return Ok(None);
+            };
+            let Ok(new_multiplier_scalar) = multiplier_scalar.cast(&target_scalar_dtype) else {
+                return Ok(None);
+            };
 
             // Extract PValues from the casted scalars
             let new_base = new_base_scalar
@@ -186,11 +196,7 @@ mod tests {
     #[rstest]
     #[case::i32(Sequence::try_new_typed(0i32, 1i32, Nullability::NonNullable, 5).unwrap())]
     #[case::u64(Sequence::try_new_typed(1000u64, 100u64, Nullability::NonNullable, 4).unwrap())]
-    // TODO(DK): SequenceArray does not actually conform. You cannot cast this array to u8 even
-    // though all its values are representable therein.
-    //
-    // #[case::negative_step(Sequence::try_new_typed(100i32, -10i32, Nullability::NonNullable,
-    // 5).unwrap())]
+    #[case::negative_step(Sequence::try_new_typed(100i32, -10i32, Nullability::NonNullable, 5).unwrap())]
     #[case::single(Sequence::try_new_typed(42i64, 0i64, Nullability::NonNullable, 1).unwrap())]
     #[case::constant(Sequence::try_new_typed(
         100i32,


### PR DESCRIPTION
## Summary

Closes #5102.

`SequenceArray` represents arithmetic sequences as `(base, multiplier, len)`. When cast to a narrower or differently-signed target type, the current implementation tries to cast the stored `base` and `multiplier` to the target type directly. This fails when either parameter cannot be represented in the target type even if every produced value is representable.

Concrete failing case (matches the test file's `TODO(DK)` comment):

```
Sequence(base=100i32, multiplier=-10i32, len=5)
  → values [100, 90, 80, 70, 60]   (all fit in u8)
  → current: fails with "Cannot cast -10i32 to u8"
  → expected: succeed with [100u8, 90, 80, 70, 60]
```

## Fix

Return `Ok(None)` from `CastReduce::cast` when casting `base` or `multiplier` fails. This delegates to the canonical cast path, which decodes the sequence into individual values and casts them one by one — correctly succeeding whenever all produced values fit the target type.

This matches the existing behavior for float targets, which already returns `Ok(None)` in the same file. `CastReduce`'s `Ok(None)` contract is for "rule doesn't apply, use another approach" situations.

## What this PR does not do

The issue suggests a more invasive fix: separate `PType`s for calculation vs. return value. That would preserve Sequence's compact representation through the cast and avoid the canonical decode. This PR takes the narrower approach of using the existing canonical fallback to make the operation correct; a parameter-type redesign would be a separate PR with its own design discussion.

## Testing

- Reproduced the bug first: uncommented `#[case::negative_step(...)]` and confirmed `test_cast_sequence_conformance::case_3_negative_step` failed with `Cannot cast -10i32 to u8`.
- After fix: same case passes, and all 5 conformance cases pass.
- `cargo test -p vortex-sequence` — 57/57 pass.
- `cargo test -p vortex --lib` — 5/5 pass.
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo clippy -p vortex-sequence --all-targets --all-features` — no warnings.

No public API changes other than extending the set of casts that succeed.