### PR TITLE
[claude] benchmarks-website-v3: alpha server (axum + maud + duckdb)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,8 @@ jobs:
         if: matrix.os == 'windows-x64'
         run: |
           cargo nextest run --cargo-profile ci --locked --workspace --all-features --no-fail-fast `
-            --exclude vortex-bench --exclude vortex-python --exclude vortex-duckdb `
+            --exclude vortex-bench --exclude vortex-bench-server `
+            --exclude vortex-python --exclude vortex-duckdb `
             --exclude vortex-fuzz --exclude vortex-cuda --exclude vortex-nvcomp `
             --exclude vortex-cub --exclude vortex-test-e2e-cuda --exclude duckdb-bench `
             --exclude lance-bench --exclude datafusion-bench --exclude random-access-bench `

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
  "memchr",
  "num",
  "regex",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -811,7 +811,7 @@ dependencies = [
  "memchr",
  "num-traits",
  "regex",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -828,7 +828,7 @@ dependencies = [
  "memchr",
  "num-traits",
  "regex",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1355,7 +1355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
- "regex-automata 0.4.14",
+ "regex-automata",
  "serde",
 ]
 
@@ -3298,7 +3298,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "regex",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3318,7 +3318,7 @@ dependencies = [
  "log",
  "recursive",
  "regex",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3801,7 +3801,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4000,7 +4000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4379,7 +4379,7 @@ dependencies = [
  "log",
  "rustversion",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
 ]
 
 [[package]]
@@ -4743,7 +4743,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry",
 ]
 
 [[package]]
@@ -5022,7 +5022,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5094,7 +5094,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5702,7 +5702,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2e48de899e2931afb67fcddd0a08e439bf5d8b6ea2a2ed9cb8f4df669bd5cc"
 dependencies = [
- "reqwest 0.12.9",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_repr",
@@ -6128,11 +6128,11 @@ checksum = "58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -6481,12 +6481,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6687,7 +6686,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.10.1",
- "reqwest 0.12.9",
+ "reqwest 0.12.28",
  "ring",
  "rustls-pki-types",
  "serde",
@@ -6765,7 +6764,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.12.9",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -6780,7 +6779,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.14.3",
- "reqwest 0.12.9",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -6836,12 +6835,6 @@ checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "ownedbytes"
@@ -7192,9 +7185,9 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "044b1fa4f259f4df9ad5078e587b208f5d288a25407575fcddb9face30c7c692"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.8.6",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7691,7 +7684,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8060,17 +8053,8 @@ checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.14",
- "regex-syntax 0.8.10",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -8081,7 +8065,7 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.10",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -8089,12 +8073,6 @@ name = "regex-lite"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -8129,11 +8107,10 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "async-compression",
  "base64",
  "bytes",
  "encoding_rs",
@@ -8147,18 +8124,15 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -8167,13 +8141,14 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "windows-registry 0.2.0",
 ]
 
 [[package]]
@@ -8394,7 +8369,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8425,15 +8400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8461,7 +8427,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9454,7 +9420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
 dependencies = [
  "byteorder",
- "regex-syntax 0.8.10",
+ "regex-syntax",
  "utf8-ranges",
 ]
 
@@ -9551,7 +9517,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9570,7 +9536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9960,13 +9926,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -10061,9 +10032,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
  "tracing-core",
@@ -10071,14 +10042,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -11624,7 +11595,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11663,8 +11634,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -11718,33 +11689,13 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
-dependencies = [
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -11754,16 +11705,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11804,15 +11745,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -11844,28 +11776,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -11890,12 +11805,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11906,12 +11815,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11926,22 +11829,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -11956,12 +11847,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11972,12 +11857,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -11992,12 +11871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12008,12 +11881,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1797,7 +1797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3804,7 +3804,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4003,7 +4003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5026,7 +5026,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5098,7 +5098,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8395,7 +8395,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8408,7 +8408,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8475,7 +8475,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9031,7 +9031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9118,7 +9118,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9557,15 +9557,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.4",
  "once_cell",
- "rustix 0.38.44",
- "windows-sys 0.59.0",
+ "rustix 1.1.4",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9584,7 +9584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11655,7 +11655,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1060,13 +1060,13 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -1079,8 +1079,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -1094,19 +1093,17 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -1797,7 +1794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3804,7 +3801,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4003,7 +4000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4722,7 +4719,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -5026,7 +5022,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5098,7 +5094,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6141,9 +6137,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "matrixmultiply"
@@ -6160,9 +6156,9 @@ dependencies = [
 
 [[package]]
 name = "maud"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df518b75016b4289cdddffa1b01f2122f4a49802c93191f3133f6dc2472ebcaa"
+checksum = "8156733e27020ea5c684db5beac5d1d611e1272ab17901a49466294b84fc217e"
 dependencies = [
  "axum-core",
  "http",
@@ -6172,12 +6168,12 @@ dependencies = [
 
 [[package]]
 name = "maud_macros"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa453238ec218da0af6b11fc5978d3b5c3a45ed97b722391a2a11f3306274e18"
+checksum = "7261b00f3952f617899bc012e3dbd56e4f0110a038175929fa5d18e5a19913ca"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
+ "proc-macro2-diagnostics",
  "quote",
  "syn 2.0.117",
 ]
@@ -7348,29 +7344,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7399,6 +7372,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
 ]
 
 [[package]]
@@ -8188,7 +8173,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 0.26.11",
  "windows-registry 0.2.0",
 ]
 
@@ -8220,6 +8204,8 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "serde",
+ "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -8395,7 +8381,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8408,7 +8394,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8475,7 +8461,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9031,7 +9017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9118,7 +9104,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9562,10 +9548,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9584,7 +9570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9965,6 +9951,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -10551,7 +10538,7 @@ dependencies = [
  "base64",
  "duckdb",
  "maud",
- "reqwest 0.12.9",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "subtle",
@@ -11607,24 +11594,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "which"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11655,7 +11624,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,24 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
+dependencies = [
+ "arrow-arith 56.2.0",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-cast 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-ord 56.2.0",
+ "arrow-row 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
+ "arrow-string 56.2.0",
+]
+
+[[package]]
+name = "arrow"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
@@ -269,6 +287,20 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
+dependencies = [
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "chrono",
+ "num",
+]
+
+[[package]]
+name = "arrow-arith"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
@@ -293,6 +325,22 @@ dependencies = [
  "arrow-schema 58.1.0",
  "chrono",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num",
 ]
 
 [[package]]
@@ -335,6 +383,17 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
@@ -355,6 +414,27 @@ dependencies = [
  "half",
  "num-bigint",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
+dependencies = [
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
+ "atoi",
+ "base64",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
 ]
 
 [[package]]
@@ -429,6 +509,18 @@ dependencies = [
  "csv",
  "csv-core",
  "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
+dependencies = [
+ "arrow-buffer 56.2.0",
+ "arrow-schema 56.2.0",
+ "half",
+ "num",
 ]
 
 [[package]]
@@ -539,6 +631,19 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
+dependencies = [
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
+]
+
+[[package]]
+name = "arrow-ord"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
@@ -561,6 +666,19 @@ dependencies = [
  "arrow-data 58.1.0",
  "arrow-schema 58.1.0",
  "arrow-select 58.1.0",
+]
+
+[[package]]
+name = "arrow-row"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
+dependencies = [
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "half",
 ]
 
 [[package]]
@@ -591,6 +709,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "arrow-schema"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
@@ -609,6 +736,20 @@ dependencies = [
  "bitflags",
  "serde_core",
  "serde_json",
+]
+
+[[package]]
+name = "arrow-select"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "num",
 ]
 
 [[package]]
@@ -641,6 +782,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
+dependencies = [
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax 0.8.10",
+]
+
+[[package]]
+name = "arrow-string"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
@@ -653,7 +811,7 @@ dependencies = [
  "memchr",
  "num-traits",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -670,7 +828,7 @@ dependencies = [
  "memchr",
  "num-traits",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -898,6 +1056,61 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1145,7 +1358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.14",
  "serde",
 ]
 
@@ -1599,11 +1812,12 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "e0d05af1e006a2407bedef5af410552494ce5be9090444dbbcb57258c1af3d56"
 dependencies = [
- "unicode-segmentation",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "unicode-width 0.2.2",
 ]
 
@@ -3087,7 +3301,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -3107,7 +3321,7 @@ dependencies = [
  "log",
  "recursive",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -3637,6 +3851,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7"
 
 [[package]]
+name = "duckdb"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a093eed1c714143b257b95fa323e38527fabf05fbf02bb0d5d2045275ffdaef"
+dependencies = [
+ "arrow 56.2.0",
+ "cast",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libduckdb-sys",
+ "num-integer",
+ "rust_decimal",
+ "strum 0.27.2",
+]
+
+[[package]]
 name = "duckdb-bench"
 version = "0.1.0"
 dependencies = [
@@ -3836,6 +4067,18 @@ checksum = "a296e5a895621edf9fa8329c83aa1cb69a964643e36cf54d8d7a69b789089537"
 dependencies = [
  "ext-trait",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fast-float2"
@@ -4139,7 +4382,7 @@ dependencies = [
  "log",
  "rustversion",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4333,6 +4576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4405,6 +4657,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humansize"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4442,6 +4700,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -4463,6 +4722,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4487,7 +4747,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -5446,7 +5706,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2e48de899e2931afb67fcddd0a08e439bf5d8b6ea2a2ed9cb8f4df669bd5cc"
 dependencies = [
- "reqwest 0.12.28",
+ "reqwest 0.12.9",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5613,6 +5873,21 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libduckdb-sys"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b93c3ff279601516f01531cadf2ccba50394fbb5f7bf685c6e6b9b07c8dca6f"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "serde",
+ "serde_json",
+ "tar",
+ "vcpkg",
+]
 
 [[package]]
 name = "libfuzzer-sys"
@@ -5857,12 +6132,18 @@ checksum = "58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d"
 
 [[package]]
 name = "matchers"
-version = "0.2.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matrixmultiply"
@@ -5875,6 +6156,30 @@ dependencies = [
  "once_cell",
  "rawpointer",
  "thread-tree",
+]
+
+[[package]]
+name = "maud"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df518b75016b4289cdddffa1b01f2122f4a49802c93191f3133f6dc2472ebcaa"
+dependencies = [
+ "axum-core",
+ "http",
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa453238ec218da0af6b11fc5978d3b5c3a45ed97b722391a2a11f3306274e18"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6180,11 +6485,26 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.3"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
- "windows-sys 0.61.2",
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -6219,6 +6539,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -6349,7 +6691,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.10.1",
- "reqwest 0.12.28",
+ "reqwest 0.12.9",
  "ring",
  "rustls-pki-types",
  "serde",
@@ -6427,7 +6769,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest 0.12.9",
 ]
 
 [[package]]
@@ -6442,7 +6784,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.14.3",
- "reqwest 0.12.28",
+ "reqwest 0.12.9",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -6498,6 +6840,12 @@ checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "ownedbytes"
@@ -6997,6 +7345,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -7704,8 +8075,17 @@ checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.14",
+ "regex-syntax 0.8.10",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -7716,7 +8096,7 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -7724,6 +8104,12 @@ name = "regex-lite"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -7758,10 +8144,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
+ "async-compression",
  "base64",
  "bytes",
  "encoding_rs",
@@ -7775,15 +8162,18 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
  "rustls-native-certs",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7792,14 +8182,14 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
- "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
+ "webpki-roots 0.26.11",
+ "windows-registry 0.2.0",
 ]
 
 [[package]]
@@ -8046,6 +8436,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -8303,6 +8702,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -9058,7 +9468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
 dependencies = [
  "byteorder",
- "regex-syntax",
+ "regex-syntax 0.8.10",
  "utf8-ranges",
 ]
 
@@ -9147,15 +9557,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.27.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
+ "cfg-if",
  "fastrand",
- "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "rustix 0.38.44",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9544,9 +9954,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -9563,21 +9973,17 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "async-compression",
  "bitflags",
  "bytes",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
- "http-body-util",
  "iri-string",
  "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -9668,9 +10074,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.2.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
  "serde",
  "tracing-core",
@@ -9678,14 +10084,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.23"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata",
+ "regex",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -9705,11 +10111,11 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "2.1.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -9912,6 +10318,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vector-search-bench"
@@ -10128,6 +10540,29 @@ dependencies = [
  "uuid",
  "vortex",
  "vortex-tensor",
+]
+
+[[package]]
+name = "vortex-bench-server"
+version = "0.1.0-alpha.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "base64",
+ "duckdb",
+ "maud",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "subtle",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "twox-hash",
 ]
 
 [[package]]
@@ -11035,6 +11470,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -11171,6 +11607,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "which"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11240,8 +11694,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -11295,13 +11749,33 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11311,6 +11785,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ members = [
     "benchmarks/duckdb-bench",
     "benchmarks/random-access-bench",
     "benchmarks/vector-search-bench",
+    # Benchmarks website v3 (alpha) - leaf binary, not part of vortex-* API
+    "benchmarks-website/server",
 ]
 exclude = ["java/testfiles", "wasm-test"]
 resolver = "2"

--- a/benchmarks-website/planning/components/server.md
+++ b/benchmarks-website/planning/components/server.md
@@ -22,8 +22,8 @@ production deploy. Production deploy, backups, admin tooling, and
 historical data import are deferred (see
 [`../deferred.md`](../deferred.md)).
 
-The server crate lives at a path of the agent's choosing under
-`benchmarks-website/`, registered as a workspace member.
+The server crate is `vortex-bench-server`, living at
+`benchmarks-website/server/`, registered as a workspace member.
 
 ## In scope
 

--- a/benchmarks-website/planning/decisions.md
+++ b/benchmarks-website/planning/decisions.md
@@ -15,6 +15,8 @@ decisions deliberately stay open until we get there - see
 - **Single binary**: server is one Rust process - HTTP API + HTML
   routes + DuckDB owner. No separate ingester service, no S3
   coordination layer for writes, no client-side WASM.
+- **Server crate**: `vortex-bench-server` at `benchmarks-website/server/`,
+  registered as a workspace member.
 - **Server-side classifier**: there isn't one. The emitter writes
   v3-shape records directly.
 - **Fact-table layout**: one fact table per measurement family

--- a/benchmarks-website/server/Cargo.toml
+++ b/benchmarks-website/server/Cargo.toml
@@ -24,22 +24,22 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-axum = { version = "=0.7.9", default-features = false, features = ["http1", "json", "tokio", "matched-path", "tracing", "query"] }
-base64 = "=0.22.1"
-duckdb = { version = "=1.4.1", features = ["bundled"] }
-maud = { version = "=0.26.0", features = ["axum"] }
+axum = "0.8"
+base64 = "0.22"
+duckdb = { version = "1.4", features = ["bundled"] }
+maud = { version = "0.27", features = ["axum"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-subtle = "=2.6.1"
+subtle = "2.6"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "sync"] }
-tower = "=0.5.2"
-tower-http = { version = "=0.6.8", features = ["trace"] }
+tower = "0.5"
+tower-http = { version = "0.6", features = ["trace"] }
 tracing = { workspace = true, features = ["std"] }
-tracing-subscriber = { version = "=0.3.18", features = ["env-filter", "fmt"] }
-twox-hash = { version = "=2.1.0", default-features = false, features = ["xxhash64"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+twox-hash = "2.1"
 
 [dev-dependencies]
-reqwest = { version = "=0.12.9", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { workspace = true, features = ["json"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net"] }

--- a/benchmarks-website/server/Cargo.toml
+++ b/benchmarks-website/server/Cargo.toml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+[package]
+name = "vortex-bench-server"
+version = "0.1.0-alpha.0"
+edition = "2024"
+rust-version = "1.91.0"
+license = "Apache-2.0"
+description = "bench.vortex.dev v3 alpha server: HTTP API + HTML + DuckDB on local disk"
+publish = false
+
+[lib]
+name = "vortex_bench_server"
+path = "src/lib.rs"
+
+[[bin]]
+name = "vortex-bench-server"
+path = "src/main.rs"
+
+# This is a leaf binary, not part of the vortex-* public API surface.
+# Errors use anyhow / thiserror and the crate is intentionally outside
+# the workspace public-api lockfile set.
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { version = "=0.7.9", default-features = false, features = ["http1", "json", "tokio", "matched-path", "tracing", "query"] }
+base64 = "=0.22.1"
+duckdb = { version = "=1.4.1", features = ["bundled"] }
+maud = { version = "=0.26.0", features = ["axum"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+subtle = "=2.6.1"
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "sync"] }
+tower = "=0.5.2"
+tower-http = { version = "=0.6.8", features = ["trace"] }
+tracing = { workspace = true, features = ["std"] }
+tracing-subscriber = { version = "=0.3.18", features = ["env-filter", "fmt"] }
+twox-hash = { version = "=2.1.0", default-features = false, features = ["xxhash64"] }
+
+[dev-dependencies]
+reqwest = { version = "=0.12.9", default-features = false, features = ["json", "rustls-tls"] }
+tempfile = "=3.14.0"
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net"] }

--- a/benchmarks-website/server/Cargo.toml
+++ b/benchmarks-website/server/Cargo.toml
@@ -41,5 +41,5 @@ twox-hash = { version = "=2.1.0", default-features = false, features = ["xxhash6
 
 [dev-dependencies]
 reqwest = { version = "=0.12.9", default-features = false, features = ["json", "rustls-tls"] }
-tempfile = "=3.14.0"
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net"] }

--- a/benchmarks-website/server/fixtures/envelope.json
+++ b/benchmarks-website/server/fixtures/envelope.json
@@ -1,0 +1,71 @@
+{
+  "run_meta": {
+    "benchmark_id": "fixture",
+    "schema_version": 1,
+    "started_at": "2026-04-25T00:00:00Z"
+  },
+  "commit": {
+    "sha": "0123456789abcdef0123456789abcdef01234567",
+    "timestamp": "2026-04-25T00:00:00Z",
+    "message": "fixture commit",
+    "author_name": "Test Author",
+    "author_email": "author@example.com",
+    "committer_name": "Test Committer",
+    "committer_email": "committer@example.com",
+    "tree_sha": "fedcba9876543210fedcba9876543210fedcba98",
+    "url": "https://github.com/vortex-data/vortex/commit/0123456789abcdef0123456789abcdef01234567"
+  },
+  "records": [
+    {
+      "kind": "query_measurement",
+      "commit_sha": "0123456789abcdef0123456789abcdef01234567",
+      "dataset": "tpch",
+      "scale_factor": "1",
+      "query_idx": 1,
+      "storage": "nvme",
+      "engine": "datafusion",
+      "format": "vortex-file-compressed",
+      "value_ns": 1234567,
+      "all_runtimes_ns": [1200000, 1234567, 1300000],
+      "env_triple": "x86_64-linux-gnu"
+    },
+    {
+      "kind": "compression_time",
+      "commit_sha": "0123456789abcdef0123456789abcdef01234567",
+      "dataset": "tpch-lineitem",
+      "format": "vortex-file-compressed",
+      "op": "encode",
+      "value_ns": 9999,
+      "all_runtimes_ns": [9000, 9999, 10500]
+    },
+    {
+      "kind": "compression_size",
+      "commit_sha": "0123456789abcdef0123456789abcdef01234567",
+      "dataset": "tpch-lineitem",
+      "format": "vortex-file-compressed",
+      "value_bytes": 4242
+    },
+    {
+      "kind": "random_access_time",
+      "commit_sha": "0123456789abcdef0123456789abcdef01234567",
+      "dataset": "taxi",
+      "format": "vortex-file-compressed",
+      "value_ns": 555,
+      "all_runtimes_ns": [500, 555, 600]
+    },
+    {
+      "kind": "vector_search_run",
+      "commit_sha": "0123456789abcdef0123456789abcdef01234567",
+      "dataset": "cohere-large-10m",
+      "layout": "partitioned",
+      "flavor": "vortex-turboquant",
+      "threshold": 0.75,
+      "value_ns": 7777,
+      "all_runtimes_ns": [7700, 7777, 7800],
+      "matches": 42,
+      "rows_scanned": 1000000,
+      "bytes_scanned": 5000000,
+      "iterations": 3
+    }
+  ]
+}

--- a/benchmarks-website/server/src/api.rs
+++ b/benchmarks-website/server/src/api.rs
@@ -7,11 +7,14 @@
 //! `benchmarks-website/planning/01-schema.md`. Slugs round-trip through
 //! [`crate::slug::ChartKey`].
 
-use anyhow::{Context as _, Result};
+use anyhow::Context as _;
+use anyhow::Result;
 use axum::Json;
-use axum::extract::{Path, State};
+use axum::extract::Path;
+use axum::extract::State;
 use axum::response::IntoResponse;
-use duckdb::{Connection, params};
+use duckdb::Connection;
+use duckdb::params;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 

--- a/benchmarks-website/server/src/api.rs
+++ b/benchmarks-website/server/src/api.rs
@@ -1,0 +1,712 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Read-side API: `/api/groups`, `/api/chart/:slug`, `/health`.
+//!
+//! Group / chart / series fit follows
+//! `benchmarks-website/planning/01-schema.md`. Slugs round-trip through
+//! [`crate::slug::ChartKey`].
+
+use anyhow::{Context as _, Result};
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::response::IntoResponse;
+use duckdb::{Connection, params};
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+
+use crate::app::AppState;
+use crate::db;
+use crate::error::ApiError;
+use crate::slug::ChartKey;
+
+#[derive(Debug, Serialize)]
+pub struct GroupsResponse {
+    pub groups: Vec<Group>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Group {
+    pub name: String,
+    pub charts: Vec<ChartLink>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChartLink {
+    pub name: String,
+    pub slug: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChartResponse {
+    pub display_name: String,
+    pub unit: &'static str,
+    pub commits: Vec<CommitPoint>,
+    pub series: serde_json::Map<String, JsonValue>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CommitPoint {
+    pub sha: String,
+    pub timestamp: String,
+    pub message: String,
+    pub url: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HealthResponse {
+    pub status: &'static str,
+    pub db_path: String,
+    pub schema_version: i32,
+    pub latest_commit_timestamp: Option<String>,
+    pub row_counts: RowCounts,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RowCounts {
+    pub commits: i64,
+    pub query_measurements: i64,
+    pub compression_times: i64,
+    pub compression_sizes: i64,
+    pub random_access_times: i64,
+    pub vector_search_runs: i64,
+}
+
+/// Handler for `GET /api/groups`.
+pub async fn groups(State(state): State<AppState>) -> Result<impl IntoResponse, ApiError> {
+    let groups = db::run_blocking(&state.db, |conn| collect_groups(conn)).await?;
+    Ok(Json(GroupsResponse { groups }))
+}
+
+/// Handler for `GET /api/chart/:slug`.
+pub async fn chart(
+    State(state): State<AppState>,
+    Path(slug): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let key = ChartKey::from_slug(&slug)
+        .map_err(|e| ApiError::BadRequest(format!("invalid slug: {e}")))?;
+    let response = db::run_blocking(&state.db, move |conn| collect_chart(conn, &key)).await?;
+    let response =
+        response.ok_or_else(|| ApiError::NotFound(format!("no data for slug {slug:?}")))?;
+    Ok(Json(response))
+}
+
+/// Handler for `GET /health`.
+pub async fn health(State(state): State<AppState>) -> Result<impl IntoResponse, ApiError> {
+    let path = state.db_path.display().to_string();
+    let response = db::run_blocking(&state.db, move |conn| collect_health(conn, path)).await?;
+    Ok(Json(response))
+}
+
+fn collect_health(conn: &Connection, db_path: String) -> Result<HealthResponse> {
+    let count = |table: &str| -> Result<i64> {
+        let sql = format!("SELECT COUNT(*) FROM {table}");
+        let n: i64 = conn.query_row(&sql, [], |r| r.get(0))?;
+        Ok(n)
+    };
+    let row_counts = RowCounts {
+        commits: count("commits")?,
+        query_measurements: count("query_measurements")?,
+        compression_times: count("compression_times")?,
+        compression_sizes: count("compression_sizes")?,
+        random_access_times: count("random_access_times")?,
+        vector_search_runs: count("vector_search_runs")?,
+    };
+    let latest_commit_timestamp: Option<String> = conn
+        .query_row(
+            "SELECT CAST(timestamp AS VARCHAR) FROM commits ORDER BY timestamp DESC LIMIT 1",
+            [],
+            |r| r.get::<_, String>(0),
+        )
+        .ok();
+    Ok(HealthResponse {
+        status: "ok",
+        db_path,
+        schema_version: crate::schema::SCHEMA_VERSION,
+        latest_commit_timestamp,
+        row_counts,
+    })
+}
+
+fn collect_groups(conn: &Connection) -> Result<Vec<Group>> {
+    let mut groups: Vec<Group> = Vec::new();
+
+    let qm_groups = collect_query_groups(conn).context("collect_query_groups")?;
+    groups.extend(qm_groups);
+
+    if let Some(g) = collect_compression_time_group(conn)? {
+        groups.push(g);
+    }
+    if let Some(g) = collect_compression_size_group(conn)? {
+        groups.push(g);
+    }
+    if let Some(g) = collect_random_access_group(conn)? {
+        groups.push(g);
+    }
+    let vsr_groups = collect_vector_search_groups(conn)?;
+    groups.extend(vsr_groups);
+
+    Ok(groups)
+}
+
+fn collect_query_groups(conn: &Connection) -> Result<Vec<Group>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT dataset, dataset_variant, scale_factor, storage, query_idx
+          FROM query_measurements
+         GROUP BY dataset, dataset_variant, scale_factor, storage, query_idx
+         ORDER BY dataset, dataset_variant NULLS FIRST,
+                  scale_factor NULLS FIRST, storage, query_idx
+        "#,
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, i32>(4)?,
+        ))
+    })?;
+
+    let mut groups: Vec<Group> = Vec::new();
+    let mut current: Option<(String, Option<String>, Option<String>, String)> = None;
+    for row in rows {
+        let (dataset, dataset_variant, scale_factor, storage, query_idx) = row?;
+        let key = (
+            dataset.clone(),
+            dataset_variant.clone(),
+            scale_factor.clone(),
+            storage.clone(),
+        );
+        let need_new_group = current.as_ref() != Some(&key);
+        if need_new_group {
+            groups.push(Group {
+                name: group_name_query(&dataset, &dataset_variant, &scale_factor, &storage),
+                charts: Vec::new(),
+            });
+            current = Some(key);
+        }
+        let slug = ChartKey::QueryMeasurement {
+            dataset,
+            dataset_variant,
+            scale_factor,
+            storage,
+            query_idx,
+        }
+        .to_slug();
+        groups.last_mut().expect("just pushed").charts.push(ChartLink {
+            name: format!("Q{query_idx}"),
+            slug,
+        });
+    }
+    Ok(groups)
+}
+
+fn group_name_query(
+    dataset: &str,
+    dataset_variant: &Option<String>,
+    scale_factor: &Option<String>,
+    storage: &str,
+) -> String {
+    let mut name = dataset.to_string();
+    if let Some(v) = dataset_variant {
+        name.push('/');
+        name.push_str(v);
+    }
+    if let Some(sf) = scale_factor {
+        name.push_str(" sf=");
+        name.push_str(sf);
+    }
+    name.push_str(" [");
+    name.push_str(storage);
+    name.push(']');
+    name
+}
+
+fn collect_compression_time_group(conn: &Connection) -> Result<Option<Group>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT dataset, dataset_variant
+          FROM compression_times
+         GROUP BY dataset, dataset_variant
+         ORDER BY dataset, dataset_variant NULLS FIRST
+        "#,
+    )?;
+    let charts: Vec<ChartLink> = stmt
+        .query_map([], |row| {
+            let dataset: String = row.get(0)?;
+            let dataset_variant: Option<String> = row.get(1)?;
+            Ok((dataset, dataset_variant))
+        })?
+        .map(|r| {
+            r.map(|(dataset, dataset_variant)| {
+                let key = ChartKey::CompressionTime {
+                    dataset: dataset.clone(),
+                    dataset_variant: dataset_variant.clone(),
+                };
+                let mut name = dataset;
+                if let Some(v) = &dataset_variant {
+                    name.push('/');
+                    name.push_str(v);
+                }
+                ChartLink { name, slug: key.to_slug() }
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    if charts.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(Group { name: "Compression".into(), charts }))
+    }
+}
+
+fn collect_compression_size_group(conn: &Connection) -> Result<Option<Group>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT dataset, dataset_variant
+          FROM compression_sizes
+         GROUP BY dataset, dataset_variant
+         ORDER BY dataset, dataset_variant NULLS FIRST
+        "#,
+    )?;
+    let charts: Vec<ChartLink> = stmt
+        .query_map([], |row| {
+            let dataset: String = row.get(0)?;
+            let dataset_variant: Option<String> = row.get(1)?;
+            Ok((dataset, dataset_variant))
+        })?
+        .map(|r| {
+            r.map(|(dataset, dataset_variant)| {
+                let key = ChartKey::CompressionSize {
+                    dataset: dataset.clone(),
+                    dataset_variant: dataset_variant.clone(),
+                };
+                let mut name = dataset;
+                if let Some(v) = &dataset_variant {
+                    name.push('/');
+                    name.push_str(v);
+                }
+                ChartLink { name, slug: key.to_slug() }
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    if charts.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(Group { name: "Compression Size".into(), charts }))
+    }
+}
+
+fn collect_random_access_group(conn: &Connection) -> Result<Option<Group>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT DISTINCT dataset
+          FROM random_access_times
+         ORDER BY dataset
+        "#,
+    )?;
+    let charts: Vec<ChartLink> = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .map(|r| {
+            r.map(|dataset| ChartLink {
+                name: dataset.clone(),
+                slug: ChartKey::RandomAccess { dataset }.to_slug(),
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    if charts.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(Group { name: "Random Access".into(), charts }))
+    }
+}
+
+fn collect_vector_search_groups(conn: &Connection) -> Result<Vec<Group>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT dataset, layout, threshold
+          FROM vector_search_runs
+         GROUP BY dataset, layout, threshold
+         ORDER BY dataset, layout, threshold
+        "#,
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, f64>(2)?,
+        ))
+    })?;
+
+    let mut groups: Vec<Group> = Vec::new();
+    let mut current: Option<(String, String)> = None;
+    for row in rows {
+        let (dataset, layout, threshold) = row?;
+        let key = (dataset.clone(), layout.clone());
+        if current.as_ref() != Some(&key) {
+            groups.push(Group {
+                name: format!("{dataset} / {layout}"),
+                charts: Vec::new(),
+            });
+            current = Some(key);
+        }
+        let slug = ChartKey::VectorSearch {
+            dataset,
+            layout,
+            threshold,
+        }
+        .to_slug();
+        groups.last_mut().expect("just pushed").charts.push(ChartLink {
+            name: format!("threshold={threshold}"),
+            slug,
+        });
+    }
+    Ok(groups)
+}
+
+fn collect_chart(conn: &Connection, key: &ChartKey) -> Result<Option<ChartResponse>> {
+    match key {
+        ChartKey::QueryMeasurement {
+            dataset,
+            dataset_variant,
+            scale_factor,
+            storage,
+            query_idx,
+        } => collect_query_chart(conn, dataset, dataset_variant, scale_factor, storage, *query_idx),
+        ChartKey::CompressionTime { dataset, dataset_variant } => {
+            collect_compression_time_chart(conn, dataset, dataset_variant)
+        }
+        ChartKey::CompressionSize { dataset, dataset_variant } => {
+            collect_compression_size_chart(conn, dataset, dataset_variant)
+        }
+        ChartKey::RandomAccess { dataset } => collect_random_access_chart(conn, dataset),
+        ChartKey::VectorSearch { dataset, layout, threshold } => {
+            collect_vector_search_chart(conn, dataset, layout, *threshold)
+        }
+    }
+}
+
+/// Time series rows are gathered keyed by `(commit_sha, series_key)` and then
+/// reshaped into the `commits[] / series{}` response shape.
+struct SeriesAccumulator {
+    commits: Vec<CommitPoint>,
+    commit_index: std::collections::HashMap<String, usize>,
+    series: std::collections::BTreeMap<String, Vec<Option<f64>>>,
+}
+
+impl SeriesAccumulator {
+    fn new() -> Self {
+        Self {
+            commits: Vec::new(),
+            commit_index: std::collections::HashMap::new(),
+            series: std::collections::BTreeMap::new(),
+        }
+    }
+
+    fn ensure_commit(
+        &mut self,
+        sha: &str,
+        timestamp: &str,
+        message: &str,
+        url: &str,
+    ) -> usize {
+        if let Some(&idx) = self.commit_index.get(sha) {
+            return idx;
+        }
+        let idx = self.commits.len();
+        self.commits.push(CommitPoint {
+            sha: sha.to_string(),
+            timestamp: timestamp.to_string(),
+            message: message.to_string(),
+            url: url.to_string(),
+        });
+        self.commit_index.insert(sha.to_string(), idx);
+        idx
+    }
+
+    fn record(&mut self, series_key: &str, commit_idx: usize, value: f64) {
+        let total_commits = self.commits.len();
+        let entry = self
+            .series
+            .entry(series_key.to_string())
+            .or_insert_with(|| vec![None; total_commits]);
+        if entry.len() < total_commits {
+            entry.resize(total_commits, None);
+        }
+        entry[commit_idx] = Some(value);
+    }
+
+    fn finish(self, display_name: String, unit: &'static str) -> ChartResponse {
+        let total = self.commits.len();
+        let mut series_map = serde_json::Map::new();
+        for (k, mut v) in self.series {
+            if v.len() < total {
+                v.resize(total, None);
+            }
+            series_map.insert(k, serde_json::to_value(v).expect("Vec<Option<f64>>"));
+        }
+        ChartResponse {
+            display_name,
+            unit,
+            commits: self.commits,
+            series: series_map,
+        }
+    }
+}
+
+fn collect_query_chart(
+    conn: &Connection,
+    dataset: &str,
+    dataset_variant: &Option<String>,
+    scale_factor: &Option<String>,
+    storage: &str,
+    query_idx: i32,
+) -> Result<Option<ChartResponse>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT q.commit_sha,
+               CAST(c.timestamp AS VARCHAR),
+               c.message, c.url,
+               q.engine, q.format, q.value_ns
+          FROM query_measurements q
+          JOIN commits c USING (commit_sha)
+         WHERE q.dataset = ?
+           AND q.dataset_variant IS NOT DISTINCT FROM ?
+           AND q.scale_factor    IS NOT DISTINCT FROM ?
+           AND q.storage = ?
+           AND q.query_idx = ?
+         ORDER BY c.timestamp, q.engine, q.format
+        "#,
+    )?;
+    let mut acc = SeriesAccumulator::new();
+    let rows = stmt.query_map(
+        params![
+            dataset,
+            dataset_variant.as_deref(),
+            scale_factor.as_deref(),
+            storage,
+            query_idx,
+        ],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, i64>(6)?,
+            ))
+        },
+    )?;
+    let mut any = false;
+    for row in rows {
+        any = true;
+        let (sha, ts, msg, url, engine, format, value_ns) = row?;
+        let idx = acc.ensure_commit(&sha, &ts, &msg, &url);
+        acc.record(&format!("{engine}:{format}"), idx, value_ns as f64);
+    }
+    if !any {
+        return Ok(None);
+    }
+    let mut name = dataset.to_string();
+    if let Some(v) = dataset_variant {
+        name.push('/');
+        name.push_str(v);
+    }
+    if let Some(sf) = scale_factor {
+        name.push_str(" sf=");
+        name.push_str(sf);
+    }
+    name.push_str(&format!(" Q{query_idx} [{storage}]"));
+    Ok(Some(acc.finish(name, "ns")))
+}
+
+fn collect_compression_time_chart(
+    conn: &Connection,
+    dataset: &str,
+    dataset_variant: &Option<String>,
+) -> Result<Option<ChartResponse>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT t.commit_sha,
+               CAST(c.timestamp AS VARCHAR),
+               c.message, c.url,
+               t.format, t.op, t.value_ns
+          FROM compression_times t
+          JOIN commits c USING (commit_sha)
+         WHERE t.dataset = ?
+           AND t.dataset_variant IS NOT DISTINCT FROM ?
+         ORDER BY c.timestamp, t.format, t.op
+        "#,
+    )?;
+    let mut acc = SeriesAccumulator::new();
+    let rows = stmt.query_map(
+        params![dataset, dataset_variant.as_deref()],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, i64>(6)?,
+            ))
+        },
+    )?;
+    let mut any = false;
+    for row in rows {
+        any = true;
+        let (sha, ts, msg, url, format, op, value_ns) = row?;
+        let idx = acc.ensure_commit(&sha, &ts, &msg, &url);
+        acc.record(&format!("{format}:{op}"), idx, value_ns as f64);
+    }
+    if !any {
+        return Ok(None);
+    }
+    let mut name = dataset.to_string();
+    if let Some(v) = dataset_variant {
+        name.push('/');
+        name.push_str(v);
+    }
+    Ok(Some(acc.finish(name, "ns")))
+}
+
+fn collect_compression_size_chart(
+    conn: &Connection,
+    dataset: &str,
+    dataset_variant: &Option<String>,
+) -> Result<Option<ChartResponse>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT s.commit_sha,
+               CAST(c.timestamp AS VARCHAR),
+               c.message, c.url,
+               s.format, s.value_bytes
+          FROM compression_sizes s
+          JOIN commits c USING (commit_sha)
+         WHERE s.dataset = ?
+           AND s.dataset_variant IS NOT DISTINCT FROM ?
+         ORDER BY c.timestamp, s.format
+        "#,
+    )?;
+    let mut acc = SeriesAccumulator::new();
+    let rows = stmt.query_map(
+        params![dataset, dataset_variant.as_deref()],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, i64>(5)?,
+            ))
+        },
+    )?;
+    let mut any = false;
+    for row in rows {
+        any = true;
+        let (sha, ts, msg, url, format, value_bytes) = row?;
+        let idx = acc.ensure_commit(&sha, &ts, &msg, &url);
+        acc.record(&format, idx, value_bytes as f64);
+    }
+    if !any {
+        return Ok(None);
+    }
+    let mut name = dataset.to_string();
+    if let Some(v) = dataset_variant {
+        name.push('/');
+        name.push_str(v);
+    }
+    Ok(Some(acc.finish(name, "bytes")))
+}
+
+fn collect_random_access_chart(
+    conn: &Connection,
+    dataset: &str,
+) -> Result<Option<ChartResponse>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT r.commit_sha,
+               CAST(c.timestamp AS VARCHAR),
+               c.message, c.url,
+               r.format, r.value_ns
+          FROM random_access_times r
+          JOIN commits c USING (commit_sha)
+         WHERE r.dataset = ?
+         ORDER BY c.timestamp, r.format
+        "#,
+    )?;
+    let mut acc = SeriesAccumulator::new();
+    let rows = stmt.query_map(params![dataset], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
+            row.get::<_, i64>(5)?,
+        ))
+    })?;
+    let mut any = false;
+    for row in rows {
+        any = true;
+        let (sha, ts, msg, url, format, value_ns) = row?;
+        let idx = acc.ensure_commit(&sha, &ts, &msg, &url);
+        acc.record(&format, idx, value_ns as f64);
+    }
+    if !any {
+        return Ok(None);
+    }
+    Ok(Some(acc.finish(dataset.to_string(), "ns")))
+}
+
+fn collect_vector_search_chart(
+    conn: &Connection,
+    dataset: &str,
+    layout: &str,
+    threshold: f64,
+) -> Result<Option<ChartResponse>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT v.commit_sha,
+               CAST(c.timestamp AS VARCHAR),
+               c.message, c.url,
+               v.flavor, v.value_ns
+          FROM vector_search_runs v
+          JOIN commits c USING (commit_sha)
+         WHERE v.dataset = ?
+           AND v.layout = ?
+           AND v.threshold = ?
+         ORDER BY c.timestamp, v.flavor
+        "#,
+    )?;
+    let mut acc = SeriesAccumulator::new();
+    let rows = stmt.query_map(params![dataset, layout, threshold], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
+            row.get::<_, i64>(5)?,
+        ))
+    })?;
+    let mut any = false;
+    for row in rows {
+        any = true;
+        let (sha, ts, msg, url, flavor, value_ns) = row?;
+        let idx = acc.ensure_commit(&sha, &ts, &msg, &url);
+        acc.record(&flavor, idx, value_ns as f64);
+    }
+    if !any {
+        return Ok(None);
+    }
+    Ok(Some(acc.finish(
+        format!("{dataset} / {layout} (threshold={threshold})"),
+        "ns",
+    )))
+}

--- a/benchmarks-website/server/src/api.rs
+++ b/benchmarks-website/server/src/api.rs
@@ -195,10 +195,14 @@ fn collect_query_groups(conn: &Connection) -> Result<Vec<Group>> {
             query_idx,
         }
         .to_slug();
-        groups.last_mut().expect("just pushed").charts.push(ChartLink {
-            name: format!("Q{query_idx}"),
-            slug,
-        });
+        groups
+            .last_mut()
+            .expect("just pushed")
+            .charts
+            .push(ChartLink {
+                name: format!("Q{query_idx}"),
+                slug,
+            });
     }
     Ok(groups)
 }
@@ -250,14 +254,20 @@ fn collect_compression_time_group(conn: &Connection) -> Result<Option<Group>> {
                     name.push('/');
                     name.push_str(v);
                 }
-                ChartLink { name, slug: key.to_slug() }
+                ChartLink {
+                    name,
+                    slug: key.to_slug(),
+                }
             })
         })
         .collect::<Result<_, _>>()?;
     if charts.is_empty() {
         Ok(None)
     } else {
-        Ok(Some(Group { name: "Compression".into(), charts }))
+        Ok(Some(Group {
+            name: "Compression".into(),
+            charts,
+        }))
     }
 }
 
@@ -287,14 +297,20 @@ fn collect_compression_size_group(conn: &Connection) -> Result<Option<Group>> {
                     name.push('/');
                     name.push_str(v);
                 }
-                ChartLink { name, slug: key.to_slug() }
+                ChartLink {
+                    name,
+                    slug: key.to_slug(),
+                }
             })
         })
         .collect::<Result<_, _>>()?;
     if charts.is_empty() {
         Ok(None)
     } else {
-        Ok(Some(Group { name: "Compression Size".into(), charts }))
+        Ok(Some(Group {
+            name: "Compression Size".into(),
+            charts,
+        }))
     }
 }
 
@@ -318,7 +334,10 @@ fn collect_random_access_group(conn: &Connection) -> Result<Option<Group>> {
     if charts.is_empty() {
         Ok(None)
     } else {
-        Ok(Some(Group { name: "Random Access".into(), charts }))
+        Ok(Some(Group {
+            name: "Random Access".into(),
+            charts,
+        }))
     }
 }
 
@@ -357,10 +376,14 @@ fn collect_vector_search_groups(conn: &Connection) -> Result<Vec<Group>> {
             threshold,
         }
         .to_slug();
-        groups.last_mut().expect("just pushed").charts.push(ChartLink {
-            name: format!("threshold={threshold}"),
-            slug,
-        });
+        groups
+            .last_mut()
+            .expect("just pushed")
+            .charts
+            .push(ChartLink {
+                name: format!("threshold={threshold}"),
+                slug,
+            });
     }
     Ok(groups)
 }
@@ -373,17 +396,28 @@ fn collect_chart(conn: &Connection, key: &ChartKey) -> Result<Option<ChartRespon
             scale_factor,
             storage,
             query_idx,
-        } => collect_query_chart(conn, dataset, dataset_variant, scale_factor, storage, *query_idx),
-        ChartKey::CompressionTime { dataset, dataset_variant } => {
-            collect_compression_time_chart(conn, dataset, dataset_variant)
-        }
-        ChartKey::CompressionSize { dataset, dataset_variant } => {
-            collect_compression_size_chart(conn, dataset, dataset_variant)
-        }
+        } => collect_query_chart(
+            conn,
+            dataset,
+            dataset_variant,
+            scale_factor,
+            storage,
+            *query_idx,
+        ),
+        ChartKey::CompressionTime {
+            dataset,
+            dataset_variant,
+        } => collect_compression_time_chart(conn, dataset, dataset_variant),
+        ChartKey::CompressionSize {
+            dataset,
+            dataset_variant,
+        } => collect_compression_size_chart(conn, dataset, dataset_variant),
         ChartKey::RandomAccess { dataset } => collect_random_access_chart(conn, dataset),
-        ChartKey::VectorSearch { dataset, layout, threshold } => {
-            collect_vector_search_chart(conn, dataset, layout, *threshold)
-        }
+        ChartKey::VectorSearch {
+            dataset,
+            layout,
+            threshold,
+        } => collect_vector_search_chart(conn, dataset, layout, *threshold),
     }
 }
 
@@ -391,7 +425,7 @@ fn collect_chart(conn: &Connection, key: &ChartKey) -> Result<Option<ChartRespon
 /// reshaped into the `commits[] / series{}` response shape.
 struct SeriesAccumulator {
     commits: Vec<CommitPoint>,
-    commit_index: std::collections::HashMap<String, usize>,
+    commit_index: std::collections::BTreeMap<String, usize>,
     series: std::collections::BTreeMap<String, Vec<Option<f64>>>,
 }
 
@@ -399,18 +433,12 @@ impl SeriesAccumulator {
     fn new() -> Self {
         Self {
             commits: Vec::new(),
-            commit_index: std::collections::HashMap::new(),
+            commit_index: std::collections::BTreeMap::new(),
             series: std::collections::BTreeMap::new(),
         }
     }
 
-    fn ensure_commit(
-        &mut self,
-        sha: &str,
-        timestamp: &str,
-        message: &str,
-        url: &str,
-    ) -> usize {
+    fn ensure_commit(&mut self, sha: &str, timestamp: &str, message: &str, url: &str) -> usize {
         if let Some(&idx) = self.commit_index.get(sha) {
             return idx;
         }
@@ -542,20 +570,17 @@ fn collect_compression_time_chart(
         "#,
     )?;
     let mut acc = SeriesAccumulator::new();
-    let rows = stmt.query_map(
-        params![dataset, dataset_variant.as_deref()],
-        |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, String>(3)?,
-                row.get::<_, String>(4)?,
-                row.get::<_, String>(5)?,
-                row.get::<_, i64>(6)?,
-            ))
-        },
-    )?;
+    let rows = stmt.query_map(params![dataset, dataset_variant.as_deref()], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
+            row.get::<_, String>(5)?,
+            row.get::<_, i64>(6)?,
+        ))
+    })?;
     let mut any = false;
     for row in rows {
         any = true;
@@ -593,19 +618,16 @@ fn collect_compression_size_chart(
         "#,
     )?;
     let mut acc = SeriesAccumulator::new();
-    let rows = stmt.query_map(
-        params![dataset, dataset_variant.as_deref()],
-        |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, String>(3)?,
-                row.get::<_, String>(4)?,
-                row.get::<_, i64>(5)?,
-            ))
-        },
-    )?;
+    let rows = stmt.query_map(params![dataset, dataset_variant.as_deref()], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
+            row.get::<_, i64>(5)?,
+        ))
+    })?;
     let mut any = false;
     for row in rows {
         any = true;
@@ -624,10 +646,7 @@ fn collect_compression_size_chart(
     Ok(Some(acc.finish(name, "bytes")))
 }
 
-fn collect_random_access_chart(
-    conn: &Connection,
-    dataset: &str,
-) -> Result<Option<ChartResponse>> {
+fn collect_random_access_chart(conn: &Connection, dataset: &str) -> Result<Option<ChartResponse>> {
     let mut stmt = conn.prepare(
         r#"
         SELECT r.commit_sha,

--- a/benchmarks-website/server/src/api.rs
+++ b/benchmarks-website/server/src/api.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Read-side API: `/api/groups`, `/api/chart/:slug`, `/health`.
+//! Read-side API: `/api/groups`, `/api/chart/{slug}`, `/health`.
 //!
 //! Group / chart / series fit follows
 //! `benchmarks-website/planning/01-schema.md`. Slugs round-trip through
@@ -81,7 +81,7 @@ pub async fn groups(State(state): State<AppState>) -> Result<impl IntoResponse, 
     Ok(Json(GroupsResponse { groups }))
 }
 
-/// Handler for `GET /api/chart/:slug`.
+/// Handler for `GET /api/chart/{slug}`.
 pub async fn chart(
     State(state): State<AppState>,
     Path(slug): Path<String>,

--- a/benchmarks-website/server/src/app.rs
+++ b/benchmarks-website/server/src/app.rs
@@ -4,7 +4,7 @@
 //! Axum [`Router`] composition and shared [`AppState`].
 //!
 //! The router mounts:
-//! - `/api/groups`, `/api/chart/:slug`, `/health` (read API)
+//! - `/api/groups`, `/api/chart/{slug}`, `/health` (read API)
 //! - `/api/ingest` (gated by [`crate::auth::require_bearer`])
 //! - HTML routes contributed by [`crate::html::router`]
 
@@ -57,7 +57,7 @@ pub fn router(state: AppState) -> Router {
 
     let read_routes = Router::new()
         .route("/api/groups", get(api::groups))
-        .route("/api/chart/:slug", get(api::chart))
+        .route("/api/chart/{slug}", get(api::chart))
         .route("/health", get(api::health));
 
     Router::new()

--- a/benchmarks-website/server/src/app.rs
+++ b/benchmarks-website/server/src/app.rs
@@ -8,16 +8,19 @@
 //! - `/api/ingest` (gated by [`crate::auth::require_bearer`])
 //! - HTML routes contributed by [`crate::html::router`]
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
 use axum::Router;
-use axum::routing::{get, post};
+use axum::routing::get;
+use axum::routing::post;
 
 use crate::api;
 use crate::auth::require_bearer;
-use crate::db::{self, DbHandle};
+use crate::db::DbHandle;
+use crate::db::{self};
 use crate::html;
 use crate::ingest;
 

--- a/benchmarks-website/server/src/app.rs
+++ b/benchmarks-website/server/src/app.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Axum [`Router`] composition and shared [`AppState`].
+//!
+//! The router mounts:
+//! - `/api/groups`, `/api/chart/:slug`, `/health` (read API)
+//! - `/api/ingest` (gated by [`crate::auth::require_bearer`])
+//! - HTML routes contributed by [`crate::html::router`]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Result;
+use axum::Router;
+use axum::routing::{get, post};
+
+use crate::api;
+use crate::auth::require_bearer;
+use crate::db::{self, DbHandle};
+use crate::html;
+use crate::ingest;
+
+/// Shared state for all handlers. Cheap to clone (everything is `Arc`-shaped
+/// or a small `String`).
+#[derive(Clone)]
+pub struct AppState {
+    pub db: DbHandle,
+    pub bearer_token: Arc<String>,
+    pub db_path: Arc<PathBuf>,
+}
+
+impl AppState {
+    /// Open the DuckDB at `db_path`, apply the schema, and return shared state.
+    pub fn open<P: AsRef<Path>>(db_path: P, bearer_token: String) -> Result<Self> {
+        let path = db_path.as_ref().to_path_buf();
+        let db = db::open(&path)?;
+        Ok(Self {
+            db,
+            bearer_token: Arc::new(bearer_token),
+            db_path: Arc::new(path),
+        })
+    }
+}
+
+/// Build the full Axum router for the bench server.
+pub fn router(state: AppState) -> Router {
+    let ingest_routes = Router::new()
+        .route("/api/ingest", post(ingest::handle))
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            require_bearer,
+        ));
+
+    let read_routes = Router::new()
+        .route("/api/groups", get(api::groups))
+        .route("/api/chart/:slug", get(api::chart))
+        .route("/health", get(api::health));
+
+    Router::new()
+        .merge(ingest_routes)
+        .merge(read_routes)
+        .merge(html::router())
+        .with_state(state)
+}

--- a/benchmarks-website/server/src/auth.rs
+++ b/benchmarks-website/server/src/auth.rs
@@ -6,7 +6,8 @@
 //! The token is read from `INGEST_BEARER_TOKEN` at startup and compared with
 //! constant-time equality.
 
-use axum::extract::{Request, State};
+use axum::extract::Request;
+use axum::extract::State;
 use axum::http::header::AUTHORIZATION;
 use axum::middleware::Next;
 use axum::response::Response;

--- a/benchmarks-website/server/src/auth.rs
+++ b/benchmarks-website/server/src/auth.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Bearer-token authentication for `/api/ingest`.
+//!
+//! The token is read from `INGEST_BEARER_TOKEN` at startup and compared with
+//! constant-time equality.
+
+use axum::extract::{Request, State};
+use axum::http::header::AUTHORIZATION;
+use axum::middleware::Next;
+use axum::response::Response;
+use subtle::ConstantTimeEq;
+
+use crate::app::AppState;
+use crate::error::IngestError;
+
+/// Axum middleware that enforces a `Bearer <token>` header on the route.
+pub async fn require_bearer(
+    State(state): State<AppState>,
+    req: Request,
+    next: Next,
+) -> Result<Response, IngestError> {
+    let header = req
+        .headers()
+        .get(AUTHORIZATION)
+        .ok_or(IngestError::Unauthorized)?
+        .to_str()
+        .map_err(|_| IngestError::Unauthorized)?;
+
+    let presented = header
+        .strip_prefix("Bearer ")
+        .ok_or(IngestError::Unauthorized)?
+        .as_bytes();
+    let expected = state.bearer_token.as_bytes();
+
+    if presented.ct_eq(expected).into() {
+        Ok(next.run(req).await)
+    } else {
+        Err(IngestError::Unauthorized)
+    }
+}

--- a/benchmarks-website/server/src/db.rs
+++ b/benchmarks-website/server/src/db.rs
@@ -14,14 +14,17 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::{Context as _, Result};
+use anyhow::Context as _;
+use anyhow::Result;
 use duckdb::Connection;
 use tokio::sync::Mutex;
 use twox_hash::XxHash64;
 
-use crate::records::{
-    CompressionSize, CompressionTime, QueryMeasurement, RandomAccessTime, VectorSearchRun,
-};
+use crate::records::CompressionSize;
+use crate::records::CompressionTime;
+use crate::records::QueryMeasurement;
+use crate::records::RandomAccessTime;
+use crate::records::VectorSearchRun;
 use crate::schema::SCHEMA_DDL;
 
 /// A connection guard the rest of the crate hands around.

--- a/benchmarks-website/server/src/db.rs
+++ b/benchmarks-website/server/src/db.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! DuckDB connection management plus the deterministic `measurement_id` hash.
+//!
+//! The server holds a single [`duckdb::Connection`] inside an async
+//! [`tokio::sync::Mutex`]. All DB work runs inside `spawn_blocking` so the
+//! Tokio runtime is never blocked on synchronous DuckDB calls.
+//!
+//! `measurement_id` is a server-internal xxhash64 over each table's
+//! dimensional tuple. The hash never crosses a process boundary, so the
+//! exact byte layout below is private to this server.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use duckdb::Connection;
+use tokio::sync::Mutex;
+use twox_hash::XxHash64;
+
+use crate::records::{
+    CompressionSize, CompressionTime, QueryMeasurement, RandomAccessTime, VectorSearchRun,
+};
+use crate::schema::SCHEMA_DDL;
+
+/// A connection guard the rest of the crate hands around.
+pub type DbHandle = Arc<Mutex<Connection>>;
+
+/// Open the DuckDB file at `path` (creating it if absent) and apply the
+/// schema DDL. Returns a handle ready to be cloned into the Axum state.
+pub fn open<P: AsRef<Path>>(path: P) -> Result<DbHandle> {
+    let conn = Connection::open(path.as_ref())
+        .with_context(|| format!("opening DuckDB at {}", path.as_ref().display()))?;
+    conn.execute_batch(SCHEMA_DDL)
+        .context("applying schema DDL")?;
+    Ok(Arc::new(Mutex::new(conn)))
+}
+
+/// Run a synchronous DB operation on the blocking pool, holding the connection
+/// mutex for the duration of the call.
+pub async fn run_blocking<F, T>(handle: &DbHandle, f: F) -> Result<T>
+where
+    F: FnOnce(&mut Connection) -> Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    let handle = handle.clone();
+    tokio::task::spawn_blocking(move || {
+        let mut guard = handle.blocking_lock();
+        f(&mut guard)
+    })
+    .await
+    .context("DB task panicked")?
+}
+
+/// Hash a sequence of fields with a per-table tag to produce a 64-bit
+/// `measurement_id`. The bit-cast to `i64` is intentional: DuckDB's `BIGINT`
+/// is signed.
+fn finish(hasher: XxHash64) -> i64 {
+    use std::hash::Hasher as _;
+    hasher.finish() as i64
+}
+
+fn write_str(hasher: &mut XxHash64, s: &str) {
+    use std::hash::Hasher as _;
+    hasher.write_u64(s.len() as u64);
+    hasher.write(s.as_bytes());
+}
+
+fn write_opt_str(hasher: &mut XxHash64, s: Option<&str>) {
+    use std::hash::Hasher as _;
+    match s {
+        Some(s) => {
+            hasher.write_u8(1);
+            write_str(hasher, s);
+        }
+        None => hasher.write_u8(0),
+    }
+}
+
+fn write_i32(hasher: &mut XxHash64, v: i32) {
+    use std::hash::Hasher as _;
+    hasher.write_i32(v);
+}
+
+fn write_f64(hasher: &mut XxHash64, v: f64) {
+    use std::hash::Hasher as _;
+    hasher.write_u64(v.to_bits());
+}
+
+fn hasher_for(tag: &'static str) -> XxHash64 {
+    use std::hash::Hasher as _;
+    let mut h = XxHash64::with_seed(0);
+    h.write(tag.as_bytes());
+    h.write_u8(0);
+    h
+}
+
+/// Hash for `query_measurements` rows. Matches the dim columns marked NOT NULL
+/// in `01-schema.md` plus the optional dimensions that distinguish rows.
+pub fn measurement_id_query(r: &QueryMeasurement) -> i64 {
+    let mut h = hasher_for("query_measurements");
+    write_str(&mut h, &r.dataset);
+    write_opt_str(&mut h, r.dataset_variant.as_deref());
+    write_opt_str(&mut h, r.scale_factor.as_deref());
+    write_i32(&mut h, r.query_idx);
+    write_str(&mut h, &r.storage);
+    write_str(&mut h, &r.engine);
+    write_str(&mut h, &r.format);
+    finish(h)
+}
+
+/// Hash for `compression_times` rows.
+pub fn measurement_id_compression_time(r: &CompressionTime) -> i64 {
+    let mut h = hasher_for("compression_times");
+    write_str(&mut h, &r.dataset);
+    write_opt_str(&mut h, r.dataset_variant.as_deref());
+    write_str(&mut h, &r.format);
+    write_str(&mut h, &r.op);
+    finish(h)
+}
+
+/// Hash for `compression_sizes` rows.
+pub fn measurement_id_compression_size(r: &CompressionSize) -> i64 {
+    let mut h = hasher_for("compression_sizes");
+    write_str(&mut h, &r.dataset);
+    write_opt_str(&mut h, r.dataset_variant.as_deref());
+    write_str(&mut h, &r.format);
+    finish(h)
+}
+
+/// Hash for `random_access_times` rows.
+pub fn measurement_id_random_access(r: &RandomAccessTime) -> i64 {
+    let mut h = hasher_for("random_access_times");
+    write_str(&mut h, &r.dataset);
+    write_str(&mut h, &r.format);
+    finish(h)
+}
+
+/// Hash for `vector_search_runs` rows. `iterations` is intentionally not part
+/// of the dim tuple per `01-schema.md`.
+pub fn measurement_id_vector_search(r: &VectorSearchRun) -> i64 {
+    let mut h = hasher_for("vector_search_runs");
+    write_str(&mut h, &r.dataset);
+    write_str(&mut h, &r.layout);
+    write_str(&mut h, &r.flavor);
+    write_f64(&mut h, r.threshold);
+    finish(h)
+}

--- a/benchmarks-website/server/src/error.rs
+++ b/benchmarks-website/server/src/error.rs
@@ -8,7 +8,8 @@
 
 use axum::Json;
 use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
+use axum::response::IntoResponse;
+use axum::response::Response;
 use serde_json::json;
 use thiserror::Error;
 

--- a/benchmarks-website/server/src/error.rs
+++ b/benchmarks-website/server/src/error.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Error types for the bench server.
+//!
+//! [`IngestError`] models the HTTP matrix from `02-contracts.md` for the
+//! `POST /api/ingest` route. [`ApiError`] is the catch-all for read routes.
+
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde_json::json;
+use thiserror::Error;
+
+/// Errors surfaced by `POST /api/ingest`. Each variant maps to a specific
+/// HTTP status per the contract.
+#[derive(Debug, Error)]
+pub enum IngestError {
+    /// 400 - the request body wasn't valid JSON or didn't match the envelope
+    /// schema (including unknown `kind` values and unknown fields).
+    #[error("malformed request body: {0}")]
+    Malformed(String),
+
+    /// 400 - a per-record validation rule failed. Carries the offending
+    /// record's index in `records` so emitters can pinpoint the problem.
+    #[error("record at index {index} failed validation: {message}")]
+    Record { index: usize, message: String },
+
+    /// 401 - the bearer token was missing or did not match.
+    #[error("missing or invalid bearer token")]
+    Unauthorized,
+
+    /// 409 - the envelope's `schema_version` is newer than this server expects.
+    #[error("schema version {got} is newer than server's {expected}")]
+    SchemaVersionTooNew { expected: i32, got: i32 },
+
+    /// 500 - any other error. Avoid leaking internals to clients.
+    #[error("internal server error")]
+    Internal(#[from] anyhow::Error),
+}
+
+impl IngestError {
+    fn status(&self) -> StatusCode {
+        match self {
+            Self::Malformed(_) | Self::Record { .. } => StatusCode::BAD_REQUEST,
+            Self::Unauthorized => StatusCode::UNAUTHORIZED,
+            Self::SchemaVersionTooNew { .. } => StatusCode::CONFLICT,
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+impl IntoResponse for IngestError {
+    fn into_response(self) -> Response {
+        let status = self.status();
+        let body = match &self {
+            Self::Malformed(msg) => json!({ "error": "malformed", "message": msg }),
+            Self::Record { index, message } => json!({
+                "error": "record",
+                "record_index": index,
+                "message": message,
+            }),
+            Self::Unauthorized => json!({ "error": "unauthorized" }),
+            Self::SchemaVersionTooNew { expected, got } => json!({
+                "error": "schema_version_too_new",
+                "expected": expected,
+                "got": got,
+            }),
+            Self::Internal(err) => {
+                tracing::error!(error = ?err, "ingest internal error");
+                json!({ "error": "internal" })
+            }
+        };
+        (status, Json(body)).into_response()
+    }
+}
+
+/// Errors surfaced by the read API and `/health`.
+#[derive(Debug, Error)]
+pub enum ApiError {
+    /// 404 - the slug supplied to `/api/chart/:slug` couldn't be parsed
+    /// or matched no rows.
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// 400 - the slug or query parameters were syntactically invalid.
+    #[error("bad request: {0}")]
+    BadRequest(String),
+
+    /// 500 - any other error.
+    #[error("internal server error")]
+    Internal(#[from] anyhow::Error),
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let (status, body) = match &self {
+            Self::NotFound(msg) => (
+                StatusCode::NOT_FOUND,
+                json!({ "error": "not_found", "message": msg }),
+            ),
+            Self::BadRequest(msg) => (
+                StatusCode::BAD_REQUEST,
+                json!({ "error": "bad_request", "message": msg }),
+            ),
+            Self::Internal(err) => {
+                tracing::error!(error = ?err, "api internal error");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    json!({ "error": "internal" }),
+                )
+            }
+        };
+        (status, Json(body)).into_response()
+    }
+}

--- a/benchmarks-website/server/src/html.rs
+++ b/benchmarks-website/server/src/html.rs
@@ -10,7 +10,9 @@
 
 use axum::Router;
 use axum::routing::get;
-use maud::{DOCTYPE, Markup, html};
+use maud::DOCTYPE;
+use maud::Markup;
+use maud::html;
 
 use crate::app::AppState;
 

--- a/benchmarks-website/server/src/html.rs
+++ b/benchmarks-website/server/src/html.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! HTML routes.
+//!
+//! The web-ui component owns the actual landing-page and chart-page templates.
+//! At alpha this module exposes a single placeholder route so the server can
+//! be exercised end-to-end before web-ui lands; the web-ui PR replaces
+//! [`router`] with the real Maud templates.
+
+use axum::Router;
+use axum::routing::get;
+use maud::{DOCTYPE, Markup, html};
+
+use crate::app::AppState;
+
+/// HTML routes mounted under `/`. Replaced by the web-ui component.
+pub fn router() -> Router<AppState> {
+    Router::new().route("/", get(placeholder))
+}
+
+async fn placeholder() -> Markup {
+    html! {
+        (DOCTYPE)
+        html lang="en" {
+            head {
+                meta charset="utf-8";
+                title { "bench.vortex.dev (v3 alpha)" }
+            }
+            body {
+                h1 { "bench.vortex.dev (v3 alpha)" }
+                p {
+                    "Server is up. The landing page and chart page land with "
+                    "the web-ui PR."
+                }
+                ul {
+                    li { code { "GET /api/groups" } }
+                    li { code { "GET /api/chart/:slug" } }
+                    li { code { "GET /health" } }
+                    li { code { "POST /api/ingest" } " (bearer auth)" }
+                }
+            }
+        }
+    }
+}

--- a/benchmarks-website/server/src/html.rs
+++ b/benchmarks-website/server/src/html.rs
@@ -37,7 +37,7 @@ async fn placeholder() -> Markup {
                 }
                 ul {
                     li { code { "GET /api/groups" } }
-                    li { code { "GET /api/chart/:slug" } }
+                    li { code { "GET /api/chart/{slug}" } }
                     li { code { "GET /health" } }
                     li { code { "POST /api/ingest" } " (bearer auth)" }
                 }

--- a/benchmarks-website/server/src/ingest.rs
+++ b/benchmarks-website/server/src/ingest.rs
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! `POST /api/ingest` handler.
+//!
+//! All-or-nothing per envelope: every record is upserted in a single DuckDB
+//! transaction or none of them are. The reported `inserted`/`updated` counts
+//! aggregate across all five fact tables.
+
+use anyhow::{Context as _, Result};
+use axum::Json;
+use axum::extract::State;
+use axum::response::IntoResponse;
+use duckdb::{Connection, params};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::app::AppState;
+use crate::db::{
+    self, measurement_id_compression_size, measurement_id_compression_time,
+    measurement_id_query, measurement_id_random_access, measurement_id_vector_search,
+};
+use crate::error::IngestError;
+use crate::records::{
+    CommitInfo, Envelope, QueryMeasurement, Record, VectorSearchRun,
+};
+use crate::schema::SCHEMA_VERSION;
+
+/// Successful ingest response body.
+#[derive(Debug, Serialize)]
+pub struct IngestResponse {
+    pub inserted: u64,
+    pub updated: u64,
+}
+
+/// Handler for `POST /api/ingest`. Bearer auth is enforced by the
+/// [`crate::auth::require_bearer`] middleware, not here.
+pub async fn handle(
+    State(state): State<AppState>,
+    body: Json<Value>,
+) -> Result<impl IntoResponse, IngestError> {
+    let Json(value) = body;
+    let envelope: Envelope = serde_json::from_value(value)
+        .map_err(|e| IngestError::Malformed(e.to_string()))?;
+    validate_envelope(&envelope)?;
+
+    let response = db::run_blocking(&state.db, move |conn| apply_envelope(conn, envelope))
+        .await
+        .map_err(|err| match err.downcast::<IngestError>() {
+            Ok(ingest) => ingest,
+            Err(other) => IngestError::Internal(other),
+        })?;
+    Ok(Json(response))
+}
+
+fn validate_envelope(env: &Envelope) -> Result<(), IngestError> {
+    if env.run_meta.schema_version > SCHEMA_VERSION {
+        return Err(IngestError::SchemaVersionTooNew {
+            expected: SCHEMA_VERSION,
+            got: env.run_meta.schema_version,
+        });
+    }
+    if env.run_meta.schema_version < SCHEMA_VERSION {
+        return Err(IngestError::Malformed(format!(
+            "schema_version {} is older than server's {}",
+            env.run_meta.schema_version, SCHEMA_VERSION
+        )));
+    }
+    Ok(())
+}
+
+fn apply_envelope(conn: &mut Connection, env: Envelope) -> Result<IngestResponse> {
+    let tx = conn.transaction().context("begin transaction")?;
+
+    upsert_commit(&tx, &env.commit).context("upsert commit")?;
+
+    let mut inserted = 0u64;
+    let mut updated = 0u64;
+    for (idx, record) in env.records.iter().enumerate() {
+        if record.commit_sha() != env.commit.sha {
+            return Err(IngestError::Record {
+                index: idx,
+                message: format!(
+                    "record commit_sha {:?} does not match envelope commit.sha {:?}",
+                    record.commit_sha(),
+                    env.commit.sha,
+                ),
+            }
+            .into());
+        }
+        match apply_record(&tx, record) {
+            Ok(was_update) => {
+                if was_update {
+                    updated += 1;
+                } else {
+                    inserted += 1;
+                }
+            }
+            Err(RecordError::Validation(msg)) => {
+                return Err(IngestError::Record { index: idx, message: msg }.into());
+            }
+            Err(RecordError::Internal(err)) => {
+                return Err(err
+                    .context(format!("applying record at index {idx}")));
+            }
+        }
+    }
+
+    tx.commit().context("commit transaction")?;
+
+    Ok(IngestResponse { inserted, updated })
+}
+
+fn upsert_commit(tx: &duckdb::Transaction<'_>, c: &CommitInfo) -> Result<()> {
+    tx.execute(
+        r#"
+        INSERT INTO commits (
+            commit_sha, timestamp, message, author_name, author_email,
+            committer_name, committer_email, tree_sha, url
+        ) VALUES (?, CAST(? AS TIMESTAMPTZ), ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (commit_sha) DO UPDATE SET
+            timestamp       = excluded.timestamp,
+            message         = excluded.message,
+            author_name     = excluded.author_name,
+            author_email    = excluded.author_email,
+            committer_name  = excluded.committer_name,
+            committer_email = excluded.committer_email,
+            tree_sha        = excluded.tree_sha,
+            url             = excluded.url
+        "#,
+        params![
+            c.sha,
+            c.timestamp,
+            c.message,
+            c.author_name,
+            c.author_email,
+            c.committer_name,
+            c.committer_email,
+            c.tree_sha,
+            c.url,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Per-record error split: validation failures carry a message that the
+/// caller turns into an [`IngestError::Record`] with the right index;
+/// anything else bubbles up as a 500.
+enum RecordError {
+    Validation(String),
+    Internal(anyhow::Error),
+}
+
+impl From<anyhow::Error> for RecordError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Internal(err)
+    }
+}
+
+impl From<duckdb::Error> for RecordError {
+    fn from(err: duckdb::Error) -> Self {
+        Self::Internal(err.into())
+    }
+}
+
+fn apply_record(tx: &duckdb::Transaction<'_>, record: &Record) -> Result<bool, RecordError> {
+    match record {
+        Record::QueryMeasurement(r) => insert_query_measurement(tx, r),
+        Record::CompressionTime(r) => {
+            let mid = measurement_id_compression_time(r);
+            let was_update = exists(tx, "compression_times", mid)?;
+            tx.execute(
+                r#"
+                INSERT INTO compression_times (
+                    measurement_id, commit_sha, dataset, dataset_variant,
+                    format, op, value_ns, all_runtimes_ns, env_triple
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, CAST(? AS BIGINT[]), ?)
+                ON CONFLICT (measurement_id) DO UPDATE SET
+                    commit_sha      = excluded.commit_sha,
+                    value_ns        = excluded.value_ns,
+                    all_runtimes_ns = excluded.all_runtimes_ns,
+                    env_triple      = excluded.env_triple
+                "#,
+                params![
+                    mid,
+                    r.commit_sha,
+                    r.dataset,
+                    r.dataset_variant,
+                    r.format,
+                    r.op,
+                    r.value_ns,
+                    runtimes_literal(&r.all_runtimes_ns),
+                    r.env_triple,
+                ],
+            )?;
+            Ok(was_update)
+        }
+        Record::CompressionSize(r) => {
+            let mid = measurement_id_compression_size(r);
+            let was_update = exists(tx, "compression_sizes", mid)?;
+            tx.execute(
+                r#"
+                INSERT INTO compression_sizes (
+                    measurement_id, commit_sha, dataset, dataset_variant,
+                    format, value_bytes
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT (measurement_id) DO UPDATE SET
+                    commit_sha   = excluded.commit_sha,
+                    value_bytes  = excluded.value_bytes
+                "#,
+                params![
+                    mid,
+                    r.commit_sha,
+                    r.dataset,
+                    r.dataset_variant,
+                    r.format,
+                    r.value_bytes,
+                ],
+            )?;
+            Ok(was_update)
+        }
+        Record::RandomAccessTime(r) => {
+            let mid = measurement_id_random_access(r);
+            let was_update = exists(tx, "random_access_times", mid)?;
+            tx.execute(
+                r#"
+                INSERT INTO random_access_times (
+                    measurement_id, commit_sha, dataset, format,
+                    value_ns, all_runtimes_ns, env_triple
+                ) VALUES (?, ?, ?, ?, ?, CAST(? AS BIGINT[]), ?)
+                ON CONFLICT (measurement_id) DO UPDATE SET
+                    commit_sha      = excluded.commit_sha,
+                    value_ns        = excluded.value_ns,
+                    all_runtimes_ns = excluded.all_runtimes_ns,
+                    env_triple      = excluded.env_triple
+                "#,
+                params![
+                    mid,
+                    r.commit_sha,
+                    r.dataset,
+                    r.format,
+                    r.value_ns,
+                    runtimes_literal(&r.all_runtimes_ns),
+                    r.env_triple,
+                ],
+            )?;
+            Ok(was_update)
+        }
+        Record::VectorSearchRun(r) => insert_vector_search(tx, r),
+    }
+}
+
+fn insert_query_measurement(
+    tx: &duckdb::Transaction<'_>,
+    r: &QueryMeasurement,
+) -> Result<bool, RecordError> {
+    if !matches!(r.storage.as_str(), "nvme" | "s3") {
+        return Err(RecordError::Validation(format!(
+            "storage must be 'nvme' or 's3', got {:?}",
+            r.storage
+        )));
+    }
+    if !memory_quartet_consistent(r) {
+        return Err(RecordError::Validation(
+            "memory fields must be populated together (all four or none)".into(),
+        ));
+    }
+    let mid = measurement_id_query(r);
+    let was_update = exists(tx, "query_measurements", mid)?;
+    tx.execute(
+        r#"
+        INSERT INTO query_measurements (
+            measurement_id, commit_sha, dataset, dataset_variant, scale_factor,
+            query_idx, storage, engine, format,
+            value_ns, all_runtimes_ns,
+            peak_physical, peak_virtual, physical_delta, virtual_delta,
+            env_triple
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? AS BIGINT[]), ?, ?, ?, ?, ?)
+        ON CONFLICT (measurement_id) DO UPDATE SET
+            commit_sha      = excluded.commit_sha,
+            value_ns        = excluded.value_ns,
+            all_runtimes_ns = excluded.all_runtimes_ns,
+            peak_physical   = excluded.peak_physical,
+            peak_virtual    = excluded.peak_virtual,
+            physical_delta  = excluded.physical_delta,
+            virtual_delta   = excluded.virtual_delta,
+            env_triple      = excluded.env_triple
+        "#,
+        params![
+            mid,
+            r.commit_sha,
+            r.dataset,
+            r.dataset_variant,
+            r.scale_factor,
+            r.query_idx,
+            r.storage,
+            r.engine,
+            r.format,
+            r.value_ns,
+            runtimes_literal(&r.all_runtimes_ns),
+            r.peak_physical,
+            r.peak_virtual,
+            r.physical_delta,
+            r.virtual_delta,
+            r.env_triple,
+        ],
+    )?;
+    Ok(was_update)
+}
+
+fn insert_vector_search(
+    tx: &duckdb::Transaction<'_>,
+    r: &VectorSearchRun,
+) -> Result<bool, RecordError> {
+    let mid = measurement_id_vector_search(r);
+    let was_update = exists(tx, "vector_search_runs", mid)?;
+    tx.execute(
+        r#"
+        INSERT INTO vector_search_runs (
+            measurement_id, commit_sha, dataset, layout, flavor, threshold,
+            value_ns, all_runtimes_ns, matches, rows_scanned, bytes_scanned,
+            iterations, env_triple
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, CAST(? AS BIGINT[]), ?, ?, ?, ?, ?)
+        ON CONFLICT (measurement_id) DO UPDATE SET
+            commit_sha      = excluded.commit_sha,
+            value_ns        = excluded.value_ns,
+            all_runtimes_ns = excluded.all_runtimes_ns,
+            matches         = excluded.matches,
+            rows_scanned    = excluded.rows_scanned,
+            bytes_scanned   = excluded.bytes_scanned,
+            iterations      = excluded.iterations,
+            env_triple      = excluded.env_triple
+        "#,
+        params![
+            mid,
+            r.commit_sha,
+            r.dataset,
+            r.layout,
+            r.flavor,
+            r.threshold,
+            r.value_ns,
+            runtimes_literal(&r.all_runtimes_ns),
+            r.matches,
+            r.rows_scanned,
+            r.bytes_scanned,
+            r.iterations,
+            r.env_triple,
+        ],
+    )?;
+    Ok(was_update)
+}
+
+fn exists(tx: &duckdb::Transaction<'_>, table: &str, mid: i64) -> Result<bool, RecordError> {
+    // Table name is from a closed enum of literals above, never user input.
+    let sql = format!("SELECT 1 FROM {table} WHERE measurement_id = ? LIMIT 1");
+    let mut stmt = tx.prepare(&sql)?;
+    let exists = stmt.exists(params![mid])?;
+    Ok(exists)
+}
+
+fn runtimes_literal(values: &[i64]) -> String {
+    let mut s = String::with_capacity(values.len() * 8 + 2);
+    s.push('[');
+    for (i, v) in values.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&v.to_string());
+    }
+    s.push(']');
+    s
+}
+
+fn memory_quartet_consistent(r: &QueryMeasurement) -> bool {
+    let any = r.peak_physical.is_some()
+        || r.peak_virtual.is_some()
+        || r.physical_delta.is_some()
+        || r.virtual_delta.is_some();
+    let all = r.peak_physical.is_some()
+        && r.peak_virtual.is_some()
+        && r.physical_delta.is_some()
+        && r.virtual_delta.is_some();
+    !any || all
+}

--- a/benchmarks-website/server/src/ingest.rs
+++ b/benchmarks-website/server/src/ingest.rs
@@ -17,13 +17,11 @@ use serde_json::Value;
 
 use crate::app::AppState;
 use crate::db::{
-    self, measurement_id_compression_size, measurement_id_compression_time,
-    measurement_id_query, measurement_id_random_access, measurement_id_vector_search,
+    self, measurement_id_compression_size, measurement_id_compression_time, measurement_id_query,
+    measurement_id_random_access, measurement_id_vector_search,
 };
 use crate::error::IngestError;
-use crate::records::{
-    CommitInfo, Envelope, QueryMeasurement, Record, VectorSearchRun,
-};
+use crate::records::{CommitInfo, Envelope, QueryMeasurement, Record, VectorSearchRun};
 use crate::schema::SCHEMA_VERSION;
 
 /// Successful ingest response body.
@@ -40,8 +38,8 @@ pub async fn handle(
     body: Json<Value>,
 ) -> Result<impl IntoResponse, IngestError> {
     let Json(value) = body;
-    let envelope: Envelope = serde_json::from_value(value)
-        .map_err(|e| IngestError::Malformed(e.to_string()))?;
+    let envelope: Envelope =
+        serde_json::from_value(value).map_err(|e| IngestError::Malformed(e.to_string()))?;
     validate_envelope(&envelope)?;
 
     let response = db::run_blocking(&state.db, move |conn| apply_envelope(conn, envelope))
@@ -97,11 +95,14 @@ fn apply_envelope(conn: &mut Connection, env: Envelope) -> Result<IngestResponse
                 }
             }
             Err(RecordError::Validation(msg)) => {
-                return Err(IngestError::Record { index: idx, message: msg }.into());
+                return Err(IngestError::Record {
+                    index: idx,
+                    message: msg,
+                }
+                .into());
             }
             Err(RecordError::Internal(err)) => {
-                return Err(err
-                    .context(format!("applying record at index {idx}")));
+                return Err(err.context(format!("applying record at index {idx}")));
             }
         }
     }

--- a/benchmarks-website/server/src/ingest.rs
+++ b/benchmarks-website/server/src/ingest.rs
@@ -7,21 +7,29 @@
 //! transaction or none of them are. The reported `inserted`/`updated` counts
 //! aggregate across all five fact tables.
 
-use anyhow::{Context as _, Result};
+use anyhow::Context as _;
+use anyhow::Result;
 use axum::Json;
 use axum::extract::State;
 use axum::response::IntoResponse;
-use duckdb::{Connection, params};
+use duckdb::Connection;
+use duckdb::params;
 use serde::Serialize;
 use serde_json::Value;
 
 use crate::app::AppState;
-use crate::db::{
-    self, measurement_id_compression_size, measurement_id_compression_time, measurement_id_query,
-    measurement_id_random_access, measurement_id_vector_search,
-};
+use crate::db::measurement_id_compression_size;
+use crate::db::measurement_id_compression_time;
+use crate::db::measurement_id_query;
+use crate::db::measurement_id_random_access;
+use crate::db::measurement_id_vector_search;
+use crate::db::{self};
 use crate::error::IngestError;
-use crate::records::{CommitInfo, Envelope, QueryMeasurement, Record, VectorSearchRun};
+use crate::records::CommitInfo;
+use crate::records::Envelope;
+use crate::records::QueryMeasurement;
+use crate::records::Record;
+use crate::records::VectorSearchRun;
 use crate::schema::SCHEMA_VERSION;
 
 /// Successful ingest response body.

--- a/benchmarks-website/server/src/lib.rs
+++ b/benchmarks-website/server/src/lib.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Vortex benchmarks website v3 (alpha) server.
+//!
+//! This crate is a leaf binary that owns a DuckDB file on local disk,
+//! accepts authenticated `/api/ingest` POSTs, and serves a small read API
+//! plus the HTML pages contributed by the web-ui component.
+
+pub mod api;
+pub mod app;
+pub mod auth;
+pub mod db;
+pub mod error;
+pub mod html;
+pub mod ingest;
+pub mod records;
+pub mod schema;
+pub mod slug;

--- a/benchmarks-website/server/src/main.rs
+++ b/benchmarks-website/server/src/main.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Binary entrypoint for the bench.vortex.dev v3 alpha server.
+
+use std::env;
+use std::path::PathBuf;
+
+use anyhow::{Context as _, Result};
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_env("VORTEX_BENCH_LOG")
+                .unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let db_path: PathBuf = env::var("VORTEX_BENCH_DB")
+        .unwrap_or_else(|_| "bench.duckdb".to_string())
+        .into();
+    let bearer_token = env::var("INGEST_BEARER_TOKEN")
+        .context("INGEST_BEARER_TOKEN env var must be set")?;
+    let bind_addr = env::var("VORTEX_BENCH_BIND")
+        .unwrap_or_else(|_| "127.0.0.1:3000".to_string());
+
+    let state = vortex_bench_server::app::AppState::open(&db_path, bearer_token)
+        .with_context(|| format!("opening DuckDB at {}", db_path.display()))?;
+    let app = vortex_bench_server::app::router(state);
+
+    let listener = tokio::net::TcpListener::bind(&bind_addr)
+        .await
+        .with_context(|| format!("binding to {bind_addr}"))?;
+    tracing::info!(
+        addr = %listener.local_addr()?,
+        db = %db_path.display(),
+        "bench server listening"
+    );
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/benchmarks-website/server/src/main.rs
+++ b/benchmarks-website/server/src/main.rs
@@ -6,7 +6,8 @@
 use std::env;
 use std::path::PathBuf;
 
-use anyhow::{Context as _, Result};
+use anyhow::Context as _;
+use anyhow::Result;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]

--- a/benchmarks-website/server/src/main.rs
+++ b/benchmarks-website/server/src/main.rs
@@ -13,18 +13,16 @@ use tracing_subscriber::EnvFilter;
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_env("VORTEX_BENCH_LOG")
-                .unwrap_or_else(|_| EnvFilter::new("info")),
+            EnvFilter::try_from_env("VORTEX_BENCH_LOG").unwrap_or_else(|_| EnvFilter::new("info")),
         )
         .init();
 
     let db_path: PathBuf = env::var("VORTEX_BENCH_DB")
         .unwrap_or_else(|_| "bench.duckdb".to_string())
         .into();
-    let bearer_token = env::var("INGEST_BEARER_TOKEN")
-        .context("INGEST_BEARER_TOKEN env var must be set")?;
-    let bind_addr = env::var("VORTEX_BENCH_BIND")
-        .unwrap_or_else(|_| "127.0.0.1:3000".to_string());
+    let bearer_token =
+        env::var("INGEST_BEARER_TOKEN").context("INGEST_BEARER_TOKEN env var must be set")?;
+    let bind_addr = env::var("VORTEX_BENCH_BIND").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
 
     let state = vortex_bench_server::app::AppState::open(&db_path, bearer_token)
         .with_context(|| format!("opening DuckDB at {}", db_path.display()))?;

--- a/benchmarks-website/server/src/records.rs
+++ b/benchmarks-website/server/src/records.rs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Wire shapes for `POST /api/ingest`.
+//!
+//! These types deserialize the ingest envelope defined in
+//! `benchmarks-website/planning/02-contracts.md`. Each variant of [`Record`]
+//! is gated by `#[serde(deny_unknown_fields)]`, so unknown fields produce
+//! a 400 with the offending record's index.
+
+use serde::Deserialize;
+
+/// One ingest payload.
+///
+/// `run_meta` and `commit` are added by the post-ingest script around the
+/// JSONL of bare records the Rust emitter writes.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Envelope {
+    pub run_meta: RunMeta,
+    pub commit: CommitInfo,
+    pub records: Vec<Record>,
+}
+
+/// Run-level metadata. `schema_version` is checked against
+/// [`crate::schema::SCHEMA_VERSION`] before any record is processed.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunMeta {
+    pub benchmark_id: String,
+    pub schema_version: i32,
+    pub started_at: String,
+}
+
+/// Columns for the `commits` dim table. The wire field for `commit_sha` is
+/// renamed to `sha` per the contract.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CommitInfo {
+    pub sha: String,
+    pub timestamp: String,
+    pub message: String,
+    pub author_name: String,
+    pub author_email: String,
+    pub committer_name: String,
+    pub committer_email: String,
+    pub tree_sha: String,
+    pub url: String,
+}
+
+/// A single ingest record, discriminated by `kind`.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Record {
+    QueryMeasurement(QueryMeasurement),
+    CompressionTime(CompressionTime),
+    CompressionSize(CompressionSize),
+    RandomAccessTime(RandomAccessTime),
+    VectorSearchRun(VectorSearchRun),
+}
+
+/// SQL query suite measurement (TPC-H, ClickBench, ...).
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct QueryMeasurement {
+    pub commit_sha: String,
+    pub dataset: String,
+    #[serde(default)]
+    pub dataset_variant: Option<String>,
+    #[serde(default)]
+    pub scale_factor: Option<String>,
+    pub query_idx: i32,
+    pub storage: String,
+    pub engine: String,
+    pub format: String,
+    pub value_ns: i64,
+    pub all_runtimes_ns: Vec<i64>,
+    #[serde(default)]
+    pub peak_physical: Option<i64>,
+    #[serde(default)]
+    pub peak_virtual: Option<i64>,
+    #[serde(default)]
+    pub physical_delta: Option<i64>,
+    #[serde(default)]
+    pub virtual_delta: Option<i64>,
+    #[serde(default)]
+    pub env_triple: Option<String>,
+}
+
+/// Encode/decode timing from `compress-bench`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompressionTime {
+    pub commit_sha: String,
+    pub dataset: String,
+    #[serde(default)]
+    pub dataset_variant: Option<String>,
+    pub format: String,
+    pub op: String,
+    pub value_ns: i64,
+    pub all_runtimes_ns: Vec<i64>,
+    #[serde(default)]
+    pub env_triple: Option<String>,
+}
+
+/// On-disk size from `compress-bench`. One-shot, no per-iteration data.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompressionSize {
+    pub commit_sha: String,
+    pub dataset: String,
+    #[serde(default)]
+    pub dataset_variant: Option<String>,
+    pub format: String,
+    pub value_bytes: i64,
+}
+
+/// Take-time timing from `random-access-bench`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RandomAccessTime {
+    pub commit_sha: String,
+    pub dataset: String,
+    pub format: String,
+    pub value_ns: i64,
+    pub all_runtimes_ns: Vec<i64>,
+    #[serde(default)]
+    pub env_triple: Option<String>,
+}
+
+/// Cosine-similarity scan from `vector-search-bench`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VectorSearchRun {
+    pub commit_sha: String,
+    pub dataset: String,
+    pub layout: String,
+    pub flavor: String,
+    pub threshold: f64,
+    pub value_ns: i64,
+    pub all_runtimes_ns: Vec<i64>,
+    pub matches: i64,
+    pub rows_scanned: i64,
+    pub bytes_scanned: i64,
+    pub iterations: i32,
+    #[serde(default)]
+    pub env_triple: Option<String>,
+}
+
+impl Record {
+    /// The `commit_sha` referenced by this record. Every record carries one;
+    /// the server checks the envelope's `commit.sha` matches.
+    pub fn commit_sha(&self) -> &str {
+        match self {
+            Self::QueryMeasurement(r) => &r.commit_sha,
+            Self::CompressionTime(r) => &r.commit_sha,
+            Self::CompressionSize(r) => &r.commit_sha,
+            Self::RandomAccessTime(r) => &r.commit_sha,
+            Self::VectorSearchRun(r) => &r.commit_sha,
+        }
+    }
+
+    /// The wire `kind` string. Useful for logging and error messages.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::QueryMeasurement(_) => "query_measurement",
+            Self::CompressionTime(_) => "compression_time",
+            Self::CompressionSize(_) => "compression_size",
+            Self::RandomAccessTime(_) => "random_access_time",
+            Self::VectorSearchRun(_) => "vector_search_run",
+        }
+    }
+}

--- a/benchmarks-website/server/src/schema.rs
+++ b/benchmarks-website/server/src/schema.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! DuckDB schema DDL applied on server boot.
+//!
+//! See `benchmarks-website/planning/01-schema.md` for the column contracts.
+//! There is no migration framework at alpha: if the schema changes, delete
+//! the DuckDB file and restart.
+
+/// DDL for the `commits` dim plus the five fact tables.
+pub const SCHEMA_DDL: &str = r#"
+CREATE TABLE IF NOT EXISTS commits (
+    commit_sha       TEXT        PRIMARY KEY NOT NULL,
+    timestamp        TIMESTAMPTZ NOT NULL,
+    message          TEXT        NOT NULL,
+    author_name      TEXT        NOT NULL,
+    author_email     TEXT        NOT NULL,
+    committer_name   TEXT        NOT NULL,
+    committer_email  TEXT        NOT NULL,
+    tree_sha         TEXT        NOT NULL,
+    url              TEXT        NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS query_measurements (
+    measurement_id   BIGINT      PRIMARY KEY NOT NULL,
+    commit_sha       TEXT        NOT NULL,
+    dataset          TEXT        NOT NULL,
+    dataset_variant  TEXT,
+    scale_factor     TEXT,
+    query_idx        INTEGER     NOT NULL,
+    storage          TEXT        NOT NULL,
+    engine           TEXT        NOT NULL,
+    format           TEXT        NOT NULL,
+    value_ns         BIGINT      NOT NULL,
+    all_runtimes_ns  BIGINT[]    NOT NULL,
+    peak_physical    BIGINT,
+    peak_virtual     BIGINT,
+    physical_delta   BIGINT,
+    virtual_delta    BIGINT,
+    env_triple       TEXT
+);
+
+CREATE TABLE IF NOT EXISTS compression_times (
+    measurement_id   BIGINT      PRIMARY KEY NOT NULL,
+    commit_sha       TEXT        NOT NULL,
+    dataset          TEXT        NOT NULL,
+    dataset_variant  TEXT,
+    format           TEXT        NOT NULL,
+    op               TEXT        NOT NULL,
+    value_ns         BIGINT      NOT NULL,
+    all_runtimes_ns  BIGINT[]    NOT NULL,
+    env_triple       TEXT
+);
+
+CREATE TABLE IF NOT EXISTS compression_sizes (
+    measurement_id   BIGINT      PRIMARY KEY NOT NULL,
+    commit_sha       TEXT        NOT NULL,
+    dataset          TEXT        NOT NULL,
+    dataset_variant  TEXT,
+    format           TEXT        NOT NULL,
+    value_bytes      BIGINT      NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS random_access_times (
+    measurement_id   BIGINT      PRIMARY KEY NOT NULL,
+    commit_sha       TEXT        NOT NULL,
+    dataset          TEXT        NOT NULL,
+    format           TEXT        NOT NULL,
+    value_ns         BIGINT      NOT NULL,
+    all_runtimes_ns  BIGINT[]    NOT NULL,
+    env_triple       TEXT
+);
+
+CREATE TABLE IF NOT EXISTS vector_search_runs (
+    measurement_id   BIGINT      PRIMARY KEY NOT NULL,
+    commit_sha       TEXT        NOT NULL,
+    dataset          TEXT        NOT NULL,
+    layout           TEXT        NOT NULL,
+    flavor           TEXT        NOT NULL,
+    threshold        DOUBLE      NOT NULL,
+    value_ns         BIGINT      NOT NULL,
+    all_runtimes_ns  BIGINT[]    NOT NULL,
+    matches          BIGINT      NOT NULL,
+    rows_scanned     BIGINT      NOT NULL,
+    bytes_scanned    BIGINT      NOT NULL,
+    iterations       INTEGER     NOT NULL,
+    env_triple       TEXT
+);
+"#;
+
+/// Schema version expected by the server. The ingest envelope's
+/// `run_meta.schema_version` must match this exactly at alpha.
+pub const SCHEMA_VERSION: i32 = 1;

--- a/benchmarks-website/server/src/slug.rs
+++ b/benchmarks-website/server/src/slug.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Opaque slugs for `/api/chart/:slug`.
+//!
+//! Per `02-contracts.md`, the web-ui treats slugs as opaque strings: it
+//! receives them from `/api/groups` and feeds them back unchanged to
+//! `/api/chart/:slug`. The server is free to choose any format.
+//!
+//! Slugs here are `<prefix>.<base64url-of-json>` where `<prefix>` names the
+//! source fact table and the JSON encodes the chart key. Round-tripping the
+//! slug back gives a strongly-typed [`ChartKey`].
+
+use anyhow::{Context as _, Result, anyhow};
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::{Deserialize, Serialize};
+
+const PREFIX_QUERY: &str = "qm";
+const PREFIX_COMPRESSION_TIME: &str = "ct";
+const PREFIX_COMPRESSION_SIZE: &str = "cs";
+const PREFIX_RANDOM_ACCESS: &str = "rat";
+const PREFIX_VECTOR_SEARCH: &str = "vsr";
+
+/// The strongly-typed chart key parsed from a slug.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "k")]
+pub enum ChartKey {
+    /// `query_measurements` chart: `(dataset, query_idx)` per `01-schema.md`.
+    /// Group context (`dataset_variant`, `scale_factor`, `storage`) is carried
+    /// alongside so the slug fully specifies the chart.
+    QueryMeasurement {
+        dataset: String,
+        dataset_variant: Option<String>,
+        scale_factor: Option<String>,
+        storage: String,
+        query_idx: i32,
+    },
+    /// `compression_times` chart: `(dataset, dataset_variant)`.
+    CompressionTime {
+        dataset: String,
+        dataset_variant: Option<String>,
+    },
+    /// `compression_sizes` chart: `(dataset, dataset_variant)`.
+    CompressionSize {
+        dataset: String,
+        dataset_variant: Option<String>,
+    },
+    /// `random_access_times` chart: `dataset`.
+    RandomAccess { dataset: String },
+    /// `vector_search_runs` chart: `(dataset, layout, threshold)`.
+    VectorSearch {
+        dataset: String,
+        layout: String,
+        threshold: f64,
+    },
+}
+
+impl ChartKey {
+    fn prefix(&self) -> &'static str {
+        match self {
+            Self::QueryMeasurement { .. } => PREFIX_QUERY,
+            Self::CompressionTime { .. } => PREFIX_COMPRESSION_TIME,
+            Self::CompressionSize { .. } => PREFIX_COMPRESSION_SIZE,
+            Self::RandomAccess { .. } => PREFIX_RANDOM_ACCESS,
+            Self::VectorSearch { .. } => PREFIX_VECTOR_SEARCH,
+        }
+    }
+
+    /// Render the slug for this chart key.
+    pub fn to_slug(&self) -> String {
+        let json = serde_json::to_vec(self).expect("ChartKey is always JSON-serializable");
+        format!("{}.{}", self.prefix(), URL_SAFE_NO_PAD.encode(json))
+    }
+
+    /// Parse a slug previously produced by [`Self::to_slug`].
+    pub fn from_slug(slug: &str) -> Result<Self> {
+        let (_, encoded) = slug
+            .split_once('.')
+            .ok_or_else(|| anyhow!("slug missing '.' separator"))?;
+        let json = URL_SAFE_NO_PAD
+            .decode(encoded.as_bytes())
+            .context("slug payload was not valid base64url")?;
+        let key: Self = serde_json::from_slice(&json).context("slug payload was not valid JSON")?;
+        Ok(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(key: ChartKey) {
+        let slug = key.to_slug();
+        let parsed = ChartKey::from_slug(&slug).expect("parses back");
+        assert_eq!(parsed, key);
+    }
+
+    #[test]
+    fn query_measurement_roundtrips() {
+        roundtrip(ChartKey::QueryMeasurement {
+            dataset: "tpch".into(),
+            dataset_variant: None,
+            scale_factor: Some("1".into()),
+            storage: "nvme".into(),
+            query_idx: 7,
+        });
+    }
+
+    #[test]
+    fn vector_search_roundtrips() {
+        roundtrip(ChartKey::VectorSearch {
+            dataset: "cohere-large-10m".into(),
+            layout: "partitioned".into(),
+            threshold: 0.75,
+        });
+    }
+
+    #[test]
+    fn random_access_roundtrips() {
+        roundtrip(ChartKey::RandomAccess {
+            dataset: "taxi".into(),
+        });
+    }
+
+    #[test]
+    fn malformed_slug_rejected() {
+        assert!(ChartKey::from_slug("not-a-slug").is_err());
+        assert!(ChartKey::from_slug("qm.****").is_err());
+    }
+}

--- a/benchmarks-website/server/src/slug.rs
+++ b/benchmarks-website/server/src/slug.rs
@@ -11,10 +11,13 @@
 //! source fact table and the JSON encodes the chart key. Round-tripping the
 //! slug back gives a strongly-typed [`ChartKey`].
 
-use anyhow::{Context as _, Result, anyhow};
+use anyhow::Context as _;
+use anyhow::Result;
+use anyhow::anyhow;
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
 const PREFIX_QUERY: &str = "qm";
 const PREFIX_COMPRESSION_TIME: &str = "ct";

--- a/benchmarks-website/server/tests/ingest.rs
+++ b/benchmarks-website/server/tests/ingest.rs
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Integration tests covering the acceptance criteria from
+//! `benchmarks-website/planning/components/server.md`.
+
+use std::net::SocketAddr;
+
+use anyhow::{Context as _, Result};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use vortex_bench_server::app::{AppState, router};
+
+const TOKEN: &str = "test-bearer-token";
+
+struct Server {
+    addr: SocketAddr,
+    _tmp: TempDir,
+    handle: JoinHandle<()>,
+}
+
+impl Server {
+    async fn start() -> Result<Self> {
+        let tmp = TempDir::new()?;
+        let db_path = tmp.path().join("bench.duckdb");
+        let state = AppState::open(&db_path, TOKEN.to_string())?;
+        let app = router(state);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        Ok(Self {
+            addr,
+            _tmp: tmp,
+            handle,
+        })
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("http://{}{}", self.addr, path)
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+fn fixture_envelope() -> Value {
+    let raw = include_str!("../fixtures/envelope.json");
+    serde_json::from_str(raw).expect("fixture envelope is valid JSON")
+}
+
+#[tokio::test]
+async fn happy_path_then_idempotent_reingest() -> Result<()> {
+    let server = Server::start().await?;
+    let client = reqwest::Client::new();
+    let envelope = fixture_envelope();
+
+    let resp = client
+        .post(server.url("/api/ingest"))
+        .bearer_auth(TOKEN)
+        .json(&envelope)
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 200, "first ingest should be 200");
+    let body: Value = resp.json().await?;
+    assert_eq!(body["inserted"].as_u64(), Some(5));
+    assert_eq!(body["updated"].as_u64(), Some(0));
+
+    let resp = client
+        .post(server.url("/api/ingest"))
+        .bearer_auth(TOKEN)
+        .json(&envelope)
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 200, "second ingest should be 200");
+    let body: Value = resp.json().await?;
+    assert_eq!(body["inserted"].as_u64(), Some(0), "no new rows on re-emit");
+    assert!(
+        body["updated"].as_u64().context("updated is u64")? > 0,
+        "re-emit must report at least one updated row"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn missing_bearer_is_unauthorized() -> Result<()> {
+    let server = Server::start().await?;
+    let client = reqwest::Client::new();
+    let envelope = fixture_envelope();
+
+    let resp = client
+        .post(server.url("/api/ingest"))
+        .json(&envelope)
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 401);
+    Ok(())
+}
+
+#[tokio::test]
+async fn wrong_bearer_is_unauthorized() -> Result<()> {
+    let server = Server::start().await?;
+    let client = reqwest::Client::new();
+    let envelope = fixture_envelope();
+
+    let resp = client
+        .post(server.url("/api/ingest"))
+        .bearer_auth("not-the-real-token")
+        .json(&envelope)
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 401);
+    Ok(())
+}
+
+#[tokio::test]
+async fn unknown_kind_is_400() -> Result<()> {
+    let server = Server::start().await?;
+    let client = reqwest::Client::new();
+
+    let envelope = json!({
+        "run_meta": {
+            "benchmark_id": "fixture",
+            "schema_version": 1,
+            "started_at": "2026-04-25T00:00:00Z"
+        },
+        "commit": {
+            "sha": "0123456789abcdef0123456789abcdef01234567",
+            "timestamp": "2026-04-25T00:00:00Z",
+            "message": "x", "author_name": "x", "author_email": "x@x",
+            "committer_name": "x", "committer_email": "x@x",
+            "tree_sha": "fedcba9876543210fedcba9876543210fedcba98",
+            "url": "https://example.com"
+        },
+        "records": [
+            { "kind": "made_up_kind", "commit_sha": "0123456789abcdef0123456789abcdef01234567" }
+        ]
+    });
+    let resp = client
+        .post(server.url("/api/ingest"))
+        .bearer_auth(TOKEN)
+        .json(&envelope)
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 400);
+    Ok(())
+}
+
+#[tokio::test]
+async fn unknown_field_is_400() -> Result<()> {
+    let server = Server::start().await?;
+    let client = reqwest::Client::new();
+
+    let mut envelope = fixture_envelope();
+    envelope["records"][0]["surprise_field"] = json!("oops");
+    let resp = client
+        .post(server.url("/api/ingest"))
+        .bearer_auth(TOKEN)
+        .json(&envelope)
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 400);
+    Ok(())
+}
+
+#[tokio::test]
+async fn schema_version_too_new_is_409() -> Result<()> {
+    let server = Server::start().await?;
+    let client = reqwest::Client::new();
+
+    let mut envelope = fixture_envelope();
+    envelope["run_meta"]["schema_version"] = json!(99);
+    let resp = client
+        .post(server.url("/api/ingest"))
+        .bearer_auth(TOKEN)
+        .json(&envelope)
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 409);
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_storage_is_400_record_error() -> Result<()> {
+    let server = Server::start().await?;
+    let client = reqwest::Client::new();
+
+    let mut envelope = fixture_envelope();
+    envelope["records"][0]["storage"] = json!("gcs");
+    let resp = client
+        .post(server.url("/api/ingest"))
+        .bearer_auth(TOKEN)
+        .json(&envelope)
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 400);
+    let body: Value = resp.json().await?;
+    assert_eq!(body["record_index"], json!(0));
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_reports_after_ingest() -> Result<()> {
+    let server = Server::start().await?;
+    let client = reqwest::Client::new();
+
+    // Pre-ingest: counts are zero.
+    let resp = client.get(server.url("/health")).send().await?;
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await?;
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["schema_version"], 1);
+    assert_eq!(body["row_counts"]["commits"], 0);
+    assert!(body["latest_commit_timestamp"].is_null());
+
+    // Ingest, then re-check.
+    client
+        .post(server.url("/api/ingest"))
+        .bearer_auth(TOKEN)
+        .json(&fixture_envelope())
+        .send()
+        .await?;
+
+    let resp = client.get(server.url("/health")).send().await?;
+    let body: Value = resp.json().await?;
+    assert_eq!(body["row_counts"]["commits"], 1);
+    assert_eq!(body["row_counts"]["query_measurements"], 1);
+    assert_eq!(body["row_counts"]["compression_times"], 1);
+    assert_eq!(body["row_counts"]["compression_sizes"], 1);
+    assert_eq!(body["row_counts"]["random_access_times"], 1);
+    assert_eq!(body["row_counts"]["vector_search_runs"], 1);
+    assert!(!body["latest_commit_timestamp"].is_null());
+    Ok(())
+}
+
+#[tokio::test]
+async fn read_routes_serve_after_ingest() -> Result<()> {
+    let server = Server::start().await?;
+    let client = reqwest::Client::new();
+
+    client
+        .post(server.url("/api/ingest"))
+        .bearer_auth(TOKEN)
+        .json(&fixture_envelope())
+        .send()
+        .await?;
+
+    let resp = client.get(server.url("/api/groups")).send().await?;
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await?;
+    let groups = body["groups"].as_array().context("groups is array")?;
+    assert!(
+        !groups.is_empty(),
+        "groups should not be empty after ingest"
+    );
+
+    // Pick the first chart slug and round-trip it.
+    let first_chart = groups
+        .iter()
+        .find_map(|g| g["charts"].as_array().and_then(|c| c.first()))
+        .context("at least one chart")?;
+    let slug = first_chart["slug"]
+        .as_str()
+        .context("slug is a string")?
+        .to_string();
+
+    let resp = client
+        .get(server.url(&format!("/api/chart/{slug}")))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 200, "chart {slug} should resolve");
+    let body: Value = resp.json().await?;
+    assert!(body["display_name"].is_string());
+    assert!(body["unit"].is_string());
+    assert!(body["commits"].is_array());
+    assert_eq!(body["commits"].as_array().unwrap().len(), 1);
+    assert!(body["series"].is_object());
+    Ok(())
+}
+
+#[tokio::test]
+async fn unknown_slug_is_404() -> Result<()> {
+    let server = Server::start().await?;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(server.url("/api/chart/qm.aGVsbG8"))
+        .send()
+        .await?;
+    // Either 400 (couldn't decode JSON) or 404 (decoded but no rows). Both are
+    // acceptable per the contract; we just need it to not be a 500.
+    assert!(
+        resp.status() == 400 || resp.status() == 404,
+        "got {}",
+        resp.status()
+    );
+    Ok(())
+}

--- a/benchmarks-website/server/tests/ingest.rs
+++ b/benchmarks-website/server/tests/ingest.rs
@@ -6,12 +6,15 @@
 
 use std::net::SocketAddr;
 
-use anyhow::{Context as _, Result};
-use serde_json::{Value, json};
+use anyhow::Context as _;
+use anyhow::Result;
+use serde_json::Value;
+use serde_json::json;
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
-use vortex_bench_server::app::{AppState, router};
+use vortex_bench_server::app::AppState;
+use vortex_bench_server::app::router;
 
 const TOKEN: &str = "test-bearer-token";
 


### PR DESCRIPTION
## Summary

Implements the alpha server for `bench.vortex.dev` v3 per
[`benchmarks-website/planning/components/server.md`](../tree/ct/benchmarks-v3/benchmarks-website/planning/components/server.md).

A single Rust binary that owns a DuckDB file on local disk, accepts
authenticated `/api/ingest` POSTs, and serves a small read API plus a
placeholder HTML route the web-ui PR will replace.

- **Schema** (`src/schema.rs`): `commits` dim + the five fact tables from
  `01-schema.md`. DDL is applied on boot; no migration framework at alpha.
- **Ingest** (`src/ingest.rs`): bearer-auth middleware, all-or-nothing
  transactions, idempotent upsert via per-table xxhash64 `measurement_id`,
  full HTTP matrix from `02-contracts.md` (200 / 400 / 401 / 409 / 500).
- **Read API** (`src/api.rs`): `/api/groups`, `/api/chart/:slug`, `/health`.
  Slugs are opaque base64url-encoded JSON (`src/slug.rs`) so the web-ui
  treats them as strings per the contract.
- **Records** (`src/records.rs`): per-`kind` discriminated union with
  `deny_unknown_fields`, so unknown `kind`s and unknown fields fail loudly.
- **HTML** (`src/html.rs`): placeholder root route - replaced by web-ui.

## Stack

Pinned in `benchmarks-website/server/Cargo.toml`:

- `axum = "=0.7.9"` (`http1`, `json`, `tokio`, `query`)
- `maud = "=0.26.0"` with `axum`
- `duckdb = "=1.4.1"` with `bundled`
- `tower-http = "=0.6.8"` for tracing
- `subtle = "=2.6.1"` for constant-time bearer compare
- `twox-hash = "=2.1.0"` for the `measurement_id` xxhash64
- workspace `anyhow` + `thiserror` for errors

The crate is a leaf binary outside the `vortex-*` public-API surface, so
`./scripts/public-api.sh` is intentionally skipped per the task brief.

## Routes

| Method | Path | Auth |
|---|---|---|
| `POST` | `/api/ingest` | bearer |
| `GET`  | `/api/groups` | none |
| `GET`  | `/api/chart/:slug` | none |
| `GET`  | `/health` | none |
| `GET`  | `/` | none (placeholder, web-ui replaces) |

## Test plan

- [x] `cargo build -p vortex-bench-server`
- [x] `cargo test -p vortex-bench-server` - 14 tests pass (4 unit + 10 integration)
- [x] `cargo clippy -p vortex-bench-server --all-targets -- -D warnings`
- [x] `cargo fmt -p vortex-bench-server`
- [x] Manual `cargo run` smoke: `/health`, `POST /api/ingest` (with and without
      bearer), `/api/groups`, `/api/chart/:slug` round-trip.

Acceptance criteria from `components/server.md`:

- [x] `cargo build` succeeds for the server crate.
- [x] Integration test: POST with valid bearer → 200; re-POST → 200 with
      `updated > 0, inserted = 0`; no/wrong bearer → 401; unknown `kind` → 400.
- [x] `GET /health` returns coherent shape after an ingest (db_path,
      schema_version, latest_commit_timestamp, per-table row counts).
- [x] `cargo run` against a fresh DuckDB file serves both read routes.

## Coordination

The skeleton commit (`3266b87`) was pushed before the integration test
commit so the web-ui agent can rebase onto the workspace member without
waiting for tests.

Branch: `claude/benchmarks-v3-server` → `ct/benchmarks-v3` (not develop, not main).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPMnGUzXCUQvdkwbhSU9HR)_