### PR TITLE
remove gcs dead code from vortex-bench

### DIFF
--- a/vortex-bench/src/measurements.rs
+++ b/vortex-bench/src/measurements.rs
@@ -244,7 +244,7 @@ pub struct QueryMeasurement {
     pub target: Target,
     pub benchmark_dataset: BenchmarkDataset,
     pub benchmark_runner: String,
-    /// The storage backend against which this test was run. One of: s3, gcs, nvme.
+    /// The storage backend against which this test was run. One of: s3, nvme.
     pub storage: String,
     pub runs: Vec<Duration>,
 }

--- a/vortex-bench/src/utils/constants.rs
+++ b/vortex-bench/src/utils/constants.rs
@@ -4,4 +4,3 @@
 /// Storage type constants
 pub const STORAGE_NVME: &str = "nvme";
 pub const STORAGE_S3: &str = "s3";
-pub const STORAGE_GCS: &str = "gcs";

--- a/vortex-bench/src/utils/file.rs
+++ b/vortex-bench/src/utils/file.rs
@@ -154,20 +154,18 @@ pub fn resolve_data_url(remote_data_dir: Option<&str>, local_subdir: &str) -> Re
 
 /// Convert a URL scheme to a storage type string
 ///
-/// Maps URL schemes (s3, gcs, file) to storage type identifiers
+/// Maps URL schemes (s3, file) to storage type identifiers
 /// for benchmark reporting.
 ///
 /// # Returns
-/// - A storage type string ("s3", "gcs", "nvme")
+/// - A storage type string ("s3", "nvme")
 /// - Or an error if the scheme is unknown
 pub fn url_scheme_to_storage(url: &Url) -> Result<String> {
-    use super::constants::STORAGE_GCS;
     use super::constants::STORAGE_NVME;
     use super::constants::STORAGE_S3;
 
     match url.scheme() {
         STORAGE_S3 => Ok(STORAGE_S3.to_owned()),
-        STORAGE_GCS => Ok(STORAGE_GCS.to_owned()),
         "file" => Ok(STORAGE_NVME.to_owned()),
         otherwise => {
             bail!("unknown URL scheme: {}", otherwise)


### PR DESCRIPTION
## Summary

AFAIK we do not use gcs as a storage backend. I'm guessing this is a historical artifact?

## Testing

N/A