### PR TITLE
[claude] Add vortex-bench-migrate: v2→v3 historical data migrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10502,6 +10502,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "vortex-bench-migrate"
+version = "0.1.0-alpha.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "duckdb",
+ "flate2",
+ "reqwest 0.13.2",
+ "rstest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "vortex-bench-server",
+]
+
+[[package]]
 name = "vortex-bench-server"
 version = "0.1.0-alpha.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
     "benchmarks/vector-search-bench",
     # Benchmarks website v3 (alpha) - leaf binary, not part of vortex-* API
     "benchmarks-website/server",
+    "benchmarks-website/migrate",
 ]
 exclude = ["java/testfiles", "wasm-test"]
 resolver = "2"

--- a/benchmarks-website/migrate/Cargo.toml
+++ b/benchmarks-website/migrate/Cargo.toml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+[package]
+name = "vortex-bench-migrate"
+version = "0.1.0-alpha.0"
+edition = "2024"
+rust-version = "1.91.0"
+license = "Apache-2.0"
+description = "One-shot historical migrator from the v2 benchmarks S3 dataset to a v3 DuckDB file"
+publish = false
+
+[[bin]]
+name = "vortex-bench-migrate"
+path = "src/main.rs"
+
+# Throwaway binary, not part of the vortex-* public API surface.
+# Errors use anyhow, and the crate is intentionally outside the
+# workspace public-api lockfile set.
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+duckdb = { version = "1.4", features = ["bundled"] }
+flate2 = "1.1"
+reqwest = { workspace = true, features = ["json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tracing = { workspace = true, features = ["std"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+vortex-bench-server = { path = "../server" }
+
+[dev-dependencies]
+rstest = { workspace = true }
+tempfile = { workspace = true }

--- a/benchmarks-website/migrate/src/classifier.rs
+++ b/benchmarks-website/migrate/src/classifier.rs
@@ -1,0 +1,605 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Bug-for-bug port of v2's `getGroup`, `formatQuery`, and
+//! `normalizeChartName` from `benchmarks-website/server.js`, plus the
+//! mapping from v2 group + name pattern to a v3 fact-table bin.
+//!
+//! The v2 classifier was the source of truth for what historical
+//! records mean. It groups records by name prefix into one of:
+//! "Random Access", "Compression", "Compression Size", or one of the
+//! SQL query suites (with optional fan-out by storage and scale
+//! factor for TPC-H/TPC-DS). This module reproduces that logic and
+//! then hops to a v3 fact-table bin, since v3 stores dim values as
+//! columns instead of name fragments.
+
+use crate::v2::V2Record;
+use crate::v2::dataset_scale_factor;
+
+/// Static port of v2's `QUERY_SUITES`.
+pub const QUERY_SUITES: &[QuerySuite] = &[
+    QuerySuite {
+        prefix: "clickbench",
+        display_name: "Clickbench",
+        query_prefix: "CLICKBENCH",
+        dataset_key: None,
+        fan_out: false,
+        skip: false,
+    },
+    QuerySuite {
+        prefix: "statpopgen",
+        display_name: "Statistical and Population Genetics",
+        query_prefix: "STATPOPGEN",
+        dataset_key: None,
+        fan_out: false,
+        skip: false,
+    },
+    QuerySuite {
+        prefix: "polarsignals",
+        display_name: "PolarSignals Profiling",
+        query_prefix: "POLARSIGNALS",
+        dataset_key: None,
+        fan_out: false,
+        skip: false,
+    },
+    QuerySuite {
+        prefix: "tpch",
+        display_name: "TPC-H",
+        query_prefix: "TPC-H",
+        dataset_key: Some("tpch"),
+        fan_out: true,
+        skip: false,
+    },
+    QuerySuite {
+        prefix: "tpcds",
+        display_name: "TPC-DS",
+        query_prefix: "TPC-DS",
+        dataset_key: Some("tpcds"),
+        fan_out: true,
+        skip: false,
+    },
+    QuerySuite {
+        prefix: "fineweb",
+        display_name: "Fineweb",
+        query_prefix: "FINEWEB",
+        dataset_key: None,
+        fan_out: false,
+        skip: true,
+    },
+];
+
+/// Static port of v2's `ENGINE_RENAMES`. Applied to the "series" half
+/// of a benchmark name (the part after the first `/`) before splitting
+/// on `:` into engine/format. Order doesn't matter — keys are unique.
+const ENGINE_RENAMES: &[(&str, &str)] = &[
+    ("datafusion:vortex-file-compressed", "datafusion:vortex"),
+    ("datafusion:parquet", "datafusion:parquet"),
+    ("datafusion:arrow", "datafusion:in-memory-arrow"),
+    ("datafusion:lance", "datafusion:lance"),
+    ("datafusion:vortex-compact", "datafusion:vortex-compact"),
+    ("duckdb:vortex-file-compressed", "duckdb:vortex"),
+    ("duckdb:parquet", "duckdb:parquet"),
+    ("duckdb:duckdb", "duckdb:duckdb"),
+    ("duckdb:vortex-compact", "duckdb:vortex-compact"),
+    ("vortex-tokio-local-disk", "vortex-nvme"),
+    ("vortex-compact-tokio-local-disk", "vortex-compact-nvme"),
+    ("lance-tokio-local-disk", "lance-nvme"),
+    ("parquet-tokio-local-disk", "parquet-nvme"),
+    ("lance", "lance"),
+];
+
+/// One entry of `QUERY_SUITES`.
+#[derive(Debug, Clone, Copy)]
+pub struct QuerySuite {
+    pub prefix: &'static str,
+    pub display_name: &'static str,
+    pub query_prefix: &'static str,
+    pub dataset_key: Option<&'static str>,
+    pub fan_out: bool,
+    pub skip: bool,
+}
+
+/// Group a v2 record falls into. Mirrors `getGroup` in `server.js`,
+/// including the fan-out group naming for TPC-H/TPC-DS.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum V2Group {
+    RandomAccess,
+    Compression,
+    CompressionSize,
+    Query {
+        suite_index: usize,
+        /// `Some` for fan-out suites only.
+        storage: Option<String>,
+        /// `Some` for fan-out suites only.
+        scale_factor: Option<String>,
+    },
+}
+
+impl V2Group {
+    /// Display name as v2 served it from `/api/metadata`.
+    pub fn display_name(&self) -> String {
+        match self {
+            V2Group::RandomAccess => "Random Access".into(),
+            V2Group::Compression => "Compression".into(),
+            V2Group::CompressionSize => "Compression Size".into(),
+            V2Group::Query {
+                suite_index,
+                storage,
+                scale_factor,
+            } => {
+                let suite = &QUERY_SUITES[*suite_index];
+                if let (Some(storage), Some(sf)) = (storage, scale_factor) {
+                    format!("{} ({}) (SF={})", suite.display_name, storage, sf)
+                } else {
+                    suite.display_name.to_string()
+                }
+            }
+        }
+    }
+}
+
+/// Apply v2's `ENGINE_RENAMES`. Reproduces the JS `rename`:
+/// `RENAMES[s.toLowerCase()] || RENAMES[s] || s`.
+pub fn rename_engine(s: &str) -> String {
+    let lower = s.to_lowercase();
+    for (k, v) in ENGINE_RENAMES {
+        if *k == lower {
+            return (*v).to_string();
+        }
+    }
+    for (k, v) in ENGINE_RENAMES {
+        if *k == s {
+            return (*v).to_string();
+        }
+    }
+    s.to_string()
+}
+
+/// Faithful port of v2's `formatQuery`: maps `clickbench_q07` →
+/// `"CLICKBENCH Q7"`. Returns the original (uppercased,
+/// `-` and `_` replaced with spaces) when no suite matches.
+pub fn format_query(q: &str) -> String {
+    let lower = q.to_lowercase();
+    for suite in QUERY_SUITES {
+        if suite.skip {
+            continue;
+        }
+        let prefix = suite.prefix;
+        if let Some(rest) = lower.strip_prefix(prefix)
+            && let Some(idx) = parse_query_index(rest)
+        {
+            return format!("{} Q{}", suite.query_prefix, idx);
+        }
+    }
+    let mut out = q.to_uppercase();
+    out = out.replace(['_', '-'], " ");
+    out
+}
+
+/// Parse the `_q07` / ` q7` / `q42` tail used by `format_query`.
+/// Returns the integer query index if the tail matches the v2 regex
+/// `^[_ ]?q(\d+)`.
+fn parse_query_index(rest: &str) -> Option<u32> {
+    let after_sep = rest
+        .strip_prefix('_')
+        .or_else(|| rest.strip_prefix(' '))
+        .unwrap_or(rest);
+    let after_q = after_sep
+        .strip_prefix('q')
+        .or_else(|| after_sep.strip_prefix('Q'))?;
+    let digits: String = after_q.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if digits.is_empty() {
+        return None;
+    }
+    digits.parse().ok()
+}
+
+/// Faithful port of v2's `normalizeChartName`.
+pub fn normalize_chart_name(group: &V2Group, chart_name: &str) -> String {
+    if matches!(group, V2Group::CompressionSize) && chart_name == "VORTEX FILE COMPRESSED SIZE" {
+        return "VORTEX SIZE".into();
+    }
+    chart_name.to_string()
+}
+
+/// Port of v2's `getGroup`. Returns `None` for skipped suites
+/// (e.g. `fineweb`) or names that match nothing.
+pub fn get_group(record: &V2Record) -> Option<V2Group> {
+    let lower = record.name.to_lowercase();
+
+    if lower.starts_with("random-access/") || lower.starts_with("random access/") {
+        return Some(V2Group::RandomAccess);
+    }
+
+    if lower.starts_with("vortex size/")
+        || lower.starts_with("vortex-file-compressed size/")
+        || lower.starts_with("parquet size/")
+        || lower.starts_with("lance size/")
+        || lower.contains(":raw size/")
+        || lower.contains(":parquet-zstd size/")
+        || lower.contains(":lance size/")
+    {
+        return Some(V2Group::CompressionSize);
+    }
+
+    if lower.starts_with("compress time/")
+        || lower.starts_with("decompress time/")
+        || lower.starts_with("parquet_rs-zstd compress")
+        || lower.starts_with("parquet_rs-zstd decompress")
+        || lower.starts_with("lance compress")
+        || lower.starts_with("lance decompress")
+        || lower.starts_with("vortex:lance ratio")
+        || lower.starts_with("vortex:parquet-zstd ratio")
+        || lower.starts_with("vortex:raw ratio")
+    {
+        return Some(V2Group::Compression);
+    }
+
+    for (i, suite) in QUERY_SUITES.iter().enumerate() {
+        let prefix_q = format!("{}_q", suite.prefix);
+        let prefix_slash = format!("{}/", suite.prefix);
+        if !lower.starts_with(&prefix_q) && !lower.starts_with(&prefix_slash) {
+            continue;
+        }
+        if suite.skip {
+            return None;
+        }
+        if !suite.fan_out {
+            return Some(V2Group::Query {
+                suite_index: i,
+                storage: None,
+                scale_factor: None,
+            });
+        }
+        let storage = match record.storage.as_deref().map(str::to_uppercase).as_deref() {
+            Some("S3") => "S3",
+            _ => "NVMe",
+        };
+        let dataset_key = suite.dataset_key.unwrap_or(suite.prefix);
+        let raw_sf = record
+            .dataset
+            .as_ref()
+            .and_then(|d| dataset_scale_factor(d, dataset_key));
+        let sf = raw_sf
+            .as_deref()
+            .and_then(|s| s.parse::<f64>().ok())
+            .map(|f| f.round() as i64)
+            .unwrap_or(1);
+        return Some(V2Group::Query {
+            suite_index: i,
+            storage: Some(storage.into()),
+            scale_factor: Some(sf.to_string()),
+        });
+    }
+
+    None
+}
+
+/// Group + chart + series breakdown for a v2 record, using the same
+/// rules `server.js` applies in `refresh()`. Equivalent to v2's
+/// `(group, chartName, seriesName)` triple after rename / skip rules.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct V2Classification {
+    pub group: V2Group,
+    pub chart: String,
+    pub series: String,
+}
+
+/// Apply the same chart / series naming v2's `refresh()` does, plus
+/// the throughput / `PARQUET-UNC` skip rules.
+pub fn classify_v2(record: &V2Record) -> Option<V2Classification> {
+    if record.name.contains(" throughput") {
+        return None;
+    }
+    let group = get_group(record)?;
+    let parts: Vec<&str> = record.name.split('/').collect();
+    let (chart, series) = match (&group, parts.len()) {
+        (V2Group::RandomAccess, 4) => {
+            let chart = format!("{}/{}", parts[1], parts[2])
+                .to_uppercase()
+                .replace(['_', '-'], " ");
+            let series = rename_engine(if parts[3].is_empty() {
+                "default"
+            } else {
+                parts[3]
+            });
+            (chart, series)
+        }
+        (V2Group::RandomAccess, 2) => (
+            "RANDOM ACCESS".to_string(),
+            rename_engine(if parts[1].is_empty() {
+                "default"
+            } else {
+                parts[1]
+            }),
+        ),
+        (V2Group::RandomAccess, _) => return None,
+        _ => {
+            let series_raw = if parts.len() >= 2 && !parts[1].is_empty() {
+                parts[1]
+            } else {
+                "default"
+            };
+            let series = rename_engine(series_raw);
+            let chart = format_query(parts[0]);
+            (chart, series)
+        }
+    };
+    let chart = normalize_chart_name(&group, &chart);
+    if chart.contains("PARQUET-UNC") {
+        return None;
+    }
+    Some(V2Classification {
+        group,
+        chart,
+        series,
+    })
+}
+
+/// Mapping target: which v3 fact table a v2 record lands in, plus the
+/// dim values that table needs.
+#[derive(Debug, Clone, PartialEq)]
+pub enum V3Bin {
+    Query {
+        dataset: String,
+        dataset_variant: Option<String>,
+        scale_factor: Option<String>,
+        query_idx: i32,
+        storage: String,
+        engine: String,
+        format: String,
+    },
+    CompressionTime {
+        dataset: String,
+        dataset_variant: Option<String>,
+        format: String,
+        op: String,
+    },
+    CompressionSize {
+        dataset: String,
+        dataset_variant: Option<String>,
+        format: String,
+    },
+    RandomAccess {
+        dataset: String,
+        format: String,
+    },
+}
+
+/// Top-level entry point. Combines `classify_v2` with the v3 fact-table
+/// mapping. Returns `None` for records that:
+///
+/// - Don't match any v2 group (uncategorized prefix).
+/// - Are explicitly skipped by v2 (throughput, PARQUET-UNC, fineweb).
+/// - Are computed-at-read-time ratios that v3 derives from
+///   `compression_sizes` (`vortex:parquet-zstd ratio …`,
+///   `vortex:lance ratio …`, `vortex:raw ratio …`,
+///   `vortex:* size/…`).
+pub fn classify(record: &V2Record) -> Option<V3Bin> {
+    let cls = classify_v2(record)?;
+    match &cls.group {
+        V2Group::RandomAccess => bin_random_access(&cls, record),
+        V2Group::Compression => bin_compression_time(&cls, record),
+        V2Group::CompressionSize => bin_compression_size(&cls, record),
+        V2Group::Query { .. } => bin_query(&cls, record),
+    }
+}
+
+fn bin_random_access(cls: &V2Classification, record: &V2Record) -> Option<V3Bin> {
+    // v2 chart name shape: "RANDOM ACCESS" or "DATASET/PATTERN" (uppercase).
+    // We store it as the v3 dataset value verbatim, lowercased so
+    // `/api/groups` returns canonical lowercase names.
+    let dataset = cls.chart.to_lowercase();
+    if dataset.is_empty() {
+        return None;
+    }
+    let mut format = cls.series.clone();
+    if format.is_empty() {
+        return None;
+    }
+    // v2 emits a "default" placeholder when parts[1] is empty; treat
+    // that as missing and skip the row instead of inserting "default"
+    // as a format.
+    if format == "default" {
+        return None;
+    }
+    // The v2 random-access bench used to emit `parquet`-suffixed names;
+    // strip an "ns" unit guard later.
+    let _ = record; // record is unused here; kept for parity with siblings.
+    // Lower-case the format too so v3 series names are canonical.
+    format = format.to_lowercase();
+    Some(V3Bin::RandomAccess { dataset, format })
+}
+
+fn bin_compression_time(cls: &V2Classification, _record: &V2Record) -> Option<V3Bin> {
+    // v2 compression chart names look like (after format_query):
+    //   "COMPRESS TIME"                                       [vortex/encode]
+    //   "DECOMPRESS TIME"                                     [vortex/decode]
+    //   "PARQUET RS ZSTD COMPRESS TIME"                       [parquet/encode]
+    //   "PARQUET RS ZSTD DECOMPRESS TIME"                     [parquet/decode]
+    //   "LANCE COMPRESS TIME"                                 [lance/encode]
+    //   "LANCE DECOMPRESS TIME"                               [lance/decode]
+    //   "VORTEX:LANCE RATIO COMPRESS TIME"                    [drop]
+    //   "VORTEX:PARQUET-ZSTD RATIO COMPRESS TIME"             [drop]
+    //   "VORTEX:RAW RATIO COMPRESS TIME"                      [drop]
+    let lc = cls.chart.to_lowercase();
+    if lc.contains("ratio") || lc.contains(':') {
+        // Ratios are computed at read time from compression_sizes.
+        return None;
+    }
+    let (format, op) = if lc.starts_with("compress time") {
+        ("vortex-file-compressed", "encode")
+    } else if lc.starts_with("decompress time") {
+        ("vortex-file-compressed", "decode")
+    } else if lc.starts_with("parquet rs zstd compress time") {
+        ("parquet", "encode")
+    } else if lc.starts_with("parquet rs zstd decompress time") {
+        ("parquet", "decode")
+    } else if lc.starts_with("lance compress time") {
+        ("lance", "encode")
+    } else if lc.starts_with("lance decompress time") {
+        ("lance", "decode")
+    } else {
+        return None;
+    };
+    let dataset = cls.series.to_lowercase();
+    if dataset.is_empty() || dataset == "default" {
+        return None;
+    }
+    Some(V3Bin::CompressionTime {
+        dataset,
+        dataset_variant: None,
+        format: format.to_string(),
+        op: op.to_string(),
+    })
+}
+
+fn bin_compression_size(cls: &V2Classification, _record: &V2Record) -> Option<V3Bin> {
+    let lc = cls.chart.to_lowercase();
+    // Ratios like "VORTEX:PARQUET ZSTD SIZE" / "VORTEX:LANCE SIZE" /
+    // "VORTEX:RAW SIZE" are derived from compression_sizes at read
+    // time, not stored.
+    if lc.contains(':') {
+        return None;
+    }
+    let format = if lc.starts_with("vortex size") {
+        "vortex-file-compressed"
+    } else if lc.starts_with("parquet size") {
+        "parquet"
+    } else if lc.starts_with("lance size") {
+        "lance"
+    } else {
+        return None;
+    };
+    let dataset = cls.series.to_lowercase();
+    if dataset.is_empty() || dataset == "default" {
+        return None;
+    }
+    Some(V3Bin::CompressionSize {
+        dataset,
+        dataset_variant: None,
+        format: format.to_string(),
+    })
+}
+
+fn bin_query(cls: &V2Classification, record: &V2Record) -> Option<V3Bin> {
+    let V2Group::Query {
+        suite_index,
+        storage,
+        scale_factor,
+    } = &cls.group
+    else {
+        return None;
+    };
+    let suite = &QUERY_SUITES[*suite_index];
+
+    // Pull the query index from the *raw* name's first part instead of
+    // the formatted chart, so we don't have to round-trip "Q07".
+    let raw_first = record.name.split('/').next().unwrap_or("");
+    let query_idx = parse_query_index_from_first(raw_first)?;
+
+    // Series for non-RA records is "engine:format" after rename.
+    let (engine, format) = split_engine_format(&cls.series)?;
+
+    let storage_v3 = match storage.as_deref() {
+        Some("S3") => "s3".to_string(),
+        Some("NVMe") => "nvme".to_string(),
+        _ => "nvme".to_string(),
+    };
+
+    // ClickBench's "flavor" lives in dataset_variant per benchmark-mapping.md
+    // - we don't have it from a v2 name string, so we leave it None.
+    Some(V3Bin::Query {
+        dataset: suite.prefix.to_string(),
+        dataset_variant: None,
+        scale_factor: scale_factor.clone(),
+        query_idx,
+        storage: storage_v3,
+        engine,
+        format,
+    })
+}
+
+/// Pull the integer query index out of the leading name part, which is
+/// always `<prefix>_q<NN>` or `<prefix> q<NN>` for SQL query records.
+fn parse_query_index_from_first(first: &str) -> Option<i32> {
+    let lower = first.to_lowercase();
+    for suite in QUERY_SUITES {
+        if let Some(rest) = lower.strip_prefix(suite.prefix)
+            && let Some(idx) = parse_query_index(rest)
+        {
+            return Some(idx as i32);
+        }
+    }
+    None
+}
+
+/// Split a renamed series like `datafusion:parquet` into
+/// `(engine, format)`. Returns `None` for series with no `:` since
+/// v3 requires both columns.
+fn split_engine_format(series: &str) -> Option<(String, String)> {
+    let mut split = series.splitn(2, ':');
+    let engine = split.next()?.trim().to_string();
+    let format = split.next()?.trim().to_string();
+    if engine.is_empty() || format.is_empty() {
+        return None;
+    }
+    Some((engine, format))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(name: &str) -> V2Record {
+        V2Record {
+            name: name.to_string(),
+            commit_id: Some("deadbeef".into()),
+            unit: None,
+            value: None,
+            storage: None,
+            dataset: None,
+            all_runtimes: None,
+            env_triple: None,
+        }
+    }
+
+    #[test]
+    fn format_query_round_trips() {
+        assert_eq!(format_query("clickbench_q07"), "CLICKBENCH Q7");
+        assert_eq!(format_query("tpch_q01"), "TPC-H Q1");
+        assert_eq!(format_query("tpcds_q42"), "TPC-DS Q42");
+        assert_eq!(format_query("statpopgen_q3"), "STATPOPGEN Q3");
+        assert_eq!(format_query("foo bar"), "FOO BAR");
+    }
+
+    #[test]
+    fn rename_engine_canonicalizes_disk_names() {
+        assert_eq!(rename_engine("vortex-tokio-local-disk"), "vortex-nvme");
+        assert_eq!(
+            rename_engine("datafusion:vortex-file-compressed"),
+            "datafusion:vortex"
+        );
+        assert_eq!(rename_engine("unknown-engine"), "unknown-engine");
+    }
+
+    #[test]
+    fn parse_query_index_handles_separators() {
+        assert_eq!(parse_query_index("_q07"), Some(7));
+        assert_eq!(parse_query_index(" q7"), Some(7));
+        assert_eq!(parse_query_index("q42"), Some(42));
+        assert_eq!(parse_query_index("xq7"), None);
+    }
+
+    #[test]
+    fn random_access_bins_dataset_pattern() {
+        let bin = classify(&record("random-access/taxi/take/parquet")).unwrap();
+        assert_eq!(
+            bin,
+            V3Bin::RandomAccess {
+                dataset: "taxi/take".into(),
+                format: "parquet".into(),
+            }
+        );
+    }
+}

--- a/benchmarks-website/migrate/src/commits.rs
+++ b/benchmarks-website/migrate/src/commits.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Commit upserts. Adapts a [`crate::v2::V2Commit`] into the v3
+//! `commits` row shape (a [`vortex_bench_server::records::CommitInfo`]).
+
+use anyhow::Context as _;
+use anyhow::Result;
+use duckdb::Transaction;
+use duckdb::params;
+
+use crate::v2::V2Commit;
+
+/// Insert a v3 `commits` row for one v2 commit. Missing fields are
+/// filled with the empty string, matching the v3 schema's `NOT NULL`
+/// constraints; the call site logs a warning for each fallback so
+/// the operator can spot bad inputs.
+pub fn upsert_commit(tx: &Transaction<'_>, commit: &V2Commit) -> Result<UpsertOutcome> {
+    let mut warnings = Vec::new();
+    let timestamp = require_field(&commit.timestamp, "timestamp", &commit.id, &mut warnings);
+    let message = require_field(&commit.message, "message", &commit.id, &mut warnings);
+    let author_name = require_field(
+        &commit.author.as_ref().and_then(|p| p.name.clone()),
+        "author.name",
+        &commit.id,
+        &mut warnings,
+    );
+    let author_email = require_field(
+        &commit.author.as_ref().and_then(|p| p.email.clone()),
+        "author.email",
+        &commit.id,
+        &mut warnings,
+    );
+    let committer_name = require_field(
+        &commit.committer.as_ref().and_then(|p| p.name.clone()),
+        "committer.name",
+        &commit.id,
+        &mut warnings,
+    );
+    let committer_email = require_field(
+        &commit.committer.as_ref().and_then(|p| p.email.clone()),
+        "committer.email",
+        &commit.id,
+        &mut warnings,
+    );
+    let tree_sha = require_field(&commit.tree_id, "tree_id", &commit.id, &mut warnings);
+    let url = require_field(&commit.url, "url", &commit.id, &mut warnings);
+
+    tx.execute(
+        r#"
+        INSERT INTO commits (
+            commit_sha, timestamp, message, author_name, author_email,
+            committer_name, committer_email, tree_sha, url
+        ) VALUES (?, CAST(? AS TIMESTAMPTZ), ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (commit_sha) DO UPDATE SET
+            timestamp       = excluded.timestamp,
+            message         = excluded.message,
+            author_name     = excluded.author_name,
+            author_email    = excluded.author_email,
+            committer_name  = excluded.committer_name,
+            committer_email = excluded.committer_email,
+            tree_sha        = excluded.tree_sha,
+            url             = excluded.url
+        "#,
+        params![
+            commit.id,
+            timestamp,
+            message,
+            author_name,
+            author_email,
+            committer_name,
+            committer_email,
+            tree_sha,
+            url,
+        ],
+    )
+    .with_context(|| format!("upserting commit {}", commit.id))?;
+    Ok(UpsertOutcome { warnings })
+}
+
+fn require_field(
+    field: &Option<String>,
+    name: &str,
+    sha: &str,
+    warnings: &mut Vec<String>,
+) -> String {
+    match field {
+        Some(s) => s.clone(),
+        None => {
+            warnings.push(format!("commit {sha} missing {name}"));
+            String::new()
+        }
+    }
+}
+
+/// Per-call warning bag returned to the caller for logging.
+#[derive(Debug, Default)]
+pub struct UpsertOutcome {
+    pub warnings: Vec<String>,
+}

--- a/benchmarks-website/migrate/src/lib.rs
+++ b/benchmarks-website/migrate/src/lib.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! One-shot historical migrator from v2's S3-hosted benchmark dataset
+//! to a v3 DuckDB file.
+//!
+//! The v2 dataset is JSONL of bare benchmark records keyed by name string.
+//! v3 uses five typed fact tables with explicit dim columns. This crate
+//! ports v2's `getGroup` classifier (in `benchmarks-website/server.js`)
+//! bug-for-bug so that historical rows survive the migration with the
+//! same group / chart / series structure as the live v2 server.
+//!
+//! The migrator is throwaway: once v3 cuts over, both the binary and
+//! the classifier go away.
+
+pub mod classifier;
+pub mod commits;
+pub mod migrate;
+pub mod source;
+pub mod v2;
+pub mod verify;

--- a/benchmarks-website/migrate/src/main.rs
+++ b/benchmarks-website/migrate/src/main.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! `vortex-bench-migrate` CLI: a one-shot historical migrator from
+//! v2's S3 dataset into a v3 DuckDB file, plus a structural diff
+//! against the live v2 `/api/metadata` endpoint for spotting
+//! classifier regressions.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use anyhow::Context as _;
+use anyhow::Result;
+use clap::Parser;
+use clap::Subcommand;
+use clap::ValueEnum;
+use tracing_subscriber::EnvFilter;
+use vortex_bench_migrate::migrate;
+use vortex_bench_migrate::source::Source;
+use vortex_bench_migrate::verify;
+
+/// One-shot historical migrator from v2's S3 dataset to v3 DuckDB.
+#[derive(Debug, Parser)]
+#[command(name = "vortex-bench-migrate", version, about)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Read v2's data.json.gz / commits.json / file-sizes-*.json.gz
+    /// and write a fully populated v3 DuckDB at `--output`.
+    Run {
+        /// Path to write the v3 DuckDB to. Created if absent.
+        #[arg(long)]
+        output: PathBuf,
+        /// Where to fetch v2 dumps from.
+        #[arg(long, value_enum, default_value_t = SourceKind::PublicS3)]
+        source: SourceKind,
+        /// For `--source=local`, the directory containing
+        /// `data.json.gz`, `commits.json`, and `file-sizes-*.json.gz`.
+        #[arg(long, required_if_eq("source", "local"))]
+        source_dir: Option<PathBuf>,
+    },
+    /// Diff a migrated DuckDB against the live v2 `/api/metadata`
+    /// endpoint. Exits 0 if every v2 group is present in v3, 1
+    /// otherwise so this can gate a CI step.
+    Verify {
+        /// HTTPS root of a running v2 server (e.g. `https://bench.vortex.dev`).
+        #[arg(long)]
+        against: String,
+        /// Path to the migrated v3 DuckDB.
+        #[arg(long)]
+        duckdb: PathBuf,
+    },
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum SourceKind {
+    PublicS3,
+    Local,
+}
+
+fn main() -> ExitCode {
+    if let Err(err) = run() {
+        eprintln!("error: {err:#}");
+        return ExitCode::from(2);
+    }
+    ExitCode::SUCCESS
+}
+
+fn run() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_env("VORTEX_BENCH_LOG").unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Run {
+            output,
+            source,
+            source_dir,
+        } => {
+            let source = match source {
+                SourceKind::PublicS3 => Source::PublicS3,
+                SourceKind::Local => {
+                    Source::Local(source_dir.context("--source=local requires --source-dir")?)
+                }
+            };
+            let summary = migrate::run(&source, &output)?;
+            print!("{summary}");
+            if summary.uncategorized_fraction() > 0.05 {
+                anyhow::bail!(
+                    "uncategorized records ({:.2}%) exceed the 5% gate; \
+                     stop and report unmatched prefixes (see summary above) \
+                     before proceeding",
+                    100.0 * summary.uncategorized_fraction()
+                );
+            }
+            Ok(())
+        }
+        Command::Verify { against, duckdb } => {
+            let report = verify::run(&against, &duckdb)?;
+            print!("{report}");
+            if !report.v2_groups_covered() {
+                std::process::exit(1);
+            }
+            Ok(())
+        }
+    }
+}

--- a/benchmarks-website/migrate/src/migrate.rs
+++ b/benchmarks-website/migrate/src/migrate.rs
@@ -1,0 +1,562 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! End-to-end migration of one v2 dataset into a v3 DuckDB file.
+//!
+//! Streams `data.json.gz` line-by-line, runs each record through the
+//! [classifier][crate::classifier], and writes one row per record into
+//! the appropriate v3 fact table. Every row's `measurement_id` is
+//! computed via the server's `measurement_id_*` functions so the result
+//! is byte-compatible with what fresh `/api/ingest` would have produced.
+
+use std::collections::BTreeMap;
+use std::io::BufRead;
+use std::path::Path;
+
+use anyhow::Context as _;
+use anyhow::Result;
+use duckdb::Connection;
+use duckdb::Transaction;
+use duckdb::params;
+use tracing::warn;
+use vortex_bench_server::db::measurement_id_compression_size;
+use vortex_bench_server::db::measurement_id_compression_time;
+use vortex_bench_server::db::measurement_id_query;
+use vortex_bench_server::db::measurement_id_random_access;
+use vortex_bench_server::records::CompressionSize;
+use vortex_bench_server::records::CompressionTime;
+use vortex_bench_server::records::QueryMeasurement;
+use vortex_bench_server::records::RandomAccessTime;
+use vortex_bench_server::schema::SCHEMA_DDL;
+
+use crate::classifier::V3Bin;
+use crate::classifier::classify;
+use crate::commits::upsert_commit;
+use crate::source::Source;
+use crate::v2::V2Commit;
+use crate::v2::V2FileSize;
+use crate::v2::V2Record;
+use crate::v2::index_commits;
+use crate::v2::runtime_as_i64;
+use crate::v2::value_as_f64;
+
+/// Per-table insert counts, plus skip / missing counts.
+#[derive(Debug, Default, Clone)]
+pub struct MigrationSummary {
+    pub records_read: u64,
+    pub query_inserted: u64,
+    pub compression_time_inserted: u64,
+    pub compression_size_inserted: u64,
+    pub random_access_inserted: u64,
+    pub file_size_inserted: u64,
+    pub uncategorized: u64,
+    pub uncategorized_prefixes: BTreeMap<String, u64>,
+    pub missing_commit: u64,
+    pub commit_warnings: u64,
+    pub skipped_no_value: u64,
+    pub commits_inserted: u64,
+}
+
+impl MigrationSummary {
+    /// Total `data.json.gz` records that landed in some v3 fact table.
+    pub fn total_inserted(&self) -> u64 {
+        self.query_inserted
+            + self.compression_time_inserted
+            + self.compression_size_inserted
+            + self.random_access_inserted
+    }
+
+    /// Fraction of records that were uncategorized. The orchestrator
+    /// stops if this exceeds the documented 5% threshold.
+    pub fn uncategorized_fraction(&self) -> f64 {
+        if self.records_read == 0 {
+            return 0.0;
+        }
+        self.uncategorized as f64 / self.records_read as f64
+    }
+}
+
+/// Open or create a DuckDB at `path` and apply the v3 schema.
+pub fn open_target_db(path: &Path) -> Result<Connection> {
+    let conn =
+        Connection::open(path).with_context(|| format!("opening DuckDB at {}", path.display()))?;
+    conn.execute_batch(SCHEMA_DDL)
+        .context("applying v3 schema DDL")?;
+    Ok(conn)
+}
+
+/// Run the whole migration: commits, data.json.gz, and every
+/// file-sizes-*.json.gz under the source.
+pub fn run(source: &Source, target: &Path) -> Result<MigrationSummary> {
+    let mut conn = open_target_db(target)?;
+    let mut summary = MigrationSummary::default();
+
+    let commits = read_commits(source)?;
+    summary.commits_inserted = upsert_all_commits(&mut conn, &commits, &mut summary)?;
+
+    migrate_data_jsonl(&mut conn, source, &commits, &mut summary)?;
+
+    for name in source.list_file_sizes()? {
+        if let Err(e) = migrate_file_sizes(&mut conn, source, &name, &commits, &mut summary) {
+            warn!("file-sizes file {name} failed: {e:#}");
+        }
+    }
+
+    Ok(summary)
+}
+
+fn read_commits(source: &Source) -> Result<BTreeMap<String, V2Commit>> {
+    let reader = source.open_commits_jsonl()?;
+    let mut commits: Vec<V2Commit> = Vec::new();
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<V2Commit>(trimmed) {
+            Ok(c) => commits.push(c),
+            Err(e) => warn!("skipping malformed commits.json line: {e}"),
+        }
+    }
+    Ok(index_commits(commits))
+}
+
+fn upsert_all_commits(
+    conn: &mut Connection,
+    commits: &BTreeMap<String, V2Commit>,
+    summary: &mut MigrationSummary,
+) -> Result<u64> {
+    let tx = conn.transaction().context("begin commits transaction")?;
+    let mut count = 0u64;
+    for commit in commits.values() {
+        let outcome = upsert_commit(&tx, commit)?;
+        for w in outcome.warnings {
+            warn!("{w}");
+            summary.commit_warnings += 1;
+        }
+        count += 1;
+    }
+    tx.commit().context("commit commits transaction")?;
+    Ok(count)
+}
+
+fn migrate_data_jsonl(
+    conn: &mut Connection,
+    source: &Source,
+    commits: &BTreeMap<String, V2Commit>,
+    summary: &mut MigrationSummary,
+) -> Result<()> {
+    let reader = source.open_data_jsonl()?;
+    let mut tx = conn.transaction().context("begin data tx")?;
+    const BATCH: u64 = 10_000;
+    let mut in_batch = 0u64;
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        summary.records_read += 1;
+        let record: V2Record = match serde_json::from_str(trimmed) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("skipping malformed data.json line: {e}");
+                continue;
+            }
+        };
+        apply_v2_record(&tx, &record, commits, summary)?;
+        in_batch += 1;
+        if in_batch >= BATCH {
+            tx.commit().context("commit data batch")?;
+            tx = conn.transaction().context("begin data tx")?;
+            in_batch = 0;
+        }
+    }
+    tx.commit().context("commit final data batch")?;
+    Ok(())
+}
+
+fn apply_v2_record(
+    tx: &Transaction<'_>,
+    record: &V2Record,
+    commits: &BTreeMap<String, V2Commit>,
+    summary: &mut MigrationSummary,
+) -> Result<()> {
+    let Some(sha) = record.commit_id.clone() else {
+        summary.missing_commit += 1;
+        return Ok(());
+    };
+    if !commits.contains_key(&sha) {
+        summary.missing_commit += 1;
+        return Ok(());
+    }
+
+    let Some(bin) = classify(record) else {
+        summary.uncategorized += 1;
+        let prefix = record.name.split('/').next().unwrap_or("").to_string();
+        *summary.uncategorized_prefixes.entry(prefix).or_insert(0) += 1;
+        return Ok(());
+    };
+
+    let env_triple = record.env_triple.as_ref().and_then(|t| t.to_triple());
+    let runtimes = record
+        .all_runtimes
+        .as_ref()
+        .map(|v| v.iter().filter_map(runtime_as_i64).collect::<Vec<i64>>())
+        .unwrap_or_default();
+    let value_f64 = match record.value.as_ref().and_then(value_as_f64) {
+        Some(v) => v,
+        None => {
+            summary.skipped_no_value += 1;
+            return Ok(());
+        }
+    };
+
+    match bin {
+        V3Bin::Query {
+            dataset,
+            dataset_variant,
+            scale_factor,
+            query_idx,
+            storage,
+            engine,
+            format,
+        } => {
+            let qm = QueryMeasurement {
+                commit_sha: sha,
+                dataset,
+                dataset_variant,
+                scale_factor,
+                query_idx,
+                storage,
+                engine,
+                format,
+                value_ns: value_f64 as i64,
+                all_runtimes_ns: runtimes,
+                peak_physical: None,
+                peak_virtual: None,
+                physical_delta: None,
+                virtual_delta: None,
+                env_triple,
+            };
+            insert_query(tx, &qm)?;
+            summary.query_inserted += 1;
+        }
+        V3Bin::CompressionTime {
+            dataset,
+            dataset_variant,
+            format,
+            op,
+        } => {
+            let ct = CompressionTime {
+                commit_sha: sha,
+                dataset,
+                dataset_variant,
+                format,
+                op,
+                value_ns: value_f64 as i64,
+                all_runtimes_ns: runtimes,
+                env_triple,
+            };
+            insert_compression_time(tx, &ct)?;
+            summary.compression_time_inserted += 1;
+        }
+        V3Bin::CompressionSize {
+            dataset,
+            dataset_variant,
+            format,
+        } => {
+            let cs = CompressionSize {
+                commit_sha: sha,
+                dataset,
+                dataset_variant,
+                format,
+                value_bytes: value_f64 as i64,
+            };
+            insert_compression_size(tx, &cs)?;
+            summary.compression_size_inserted += 1;
+        }
+        V3Bin::RandomAccess { dataset, format } => {
+            let ra = RandomAccessTime {
+                commit_sha: sha,
+                dataset,
+                format,
+                value_ns: value_f64 as i64,
+                all_runtimes_ns: runtimes,
+                env_triple,
+            };
+            insert_random_access(tx, &ra)?;
+            summary.random_access_inserted += 1;
+        }
+    }
+    Ok(())
+}
+
+fn insert_query(tx: &Transaction<'_>, r: &QueryMeasurement) -> Result<()> {
+    let mid = measurement_id_query(r);
+    tx.execute(
+        r#"
+        INSERT INTO query_measurements (
+            measurement_id, commit_sha, dataset, dataset_variant, scale_factor,
+            query_idx, storage, engine, format,
+            value_ns, all_runtimes_ns,
+            peak_physical, peak_virtual, physical_delta, virtual_delta,
+            env_triple
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? AS BIGINT[]), ?, ?, ?, ?, ?)
+        ON CONFLICT (measurement_id) DO UPDATE SET
+            commit_sha      = excluded.commit_sha,
+            value_ns        = excluded.value_ns,
+            all_runtimes_ns = excluded.all_runtimes_ns,
+            env_triple      = excluded.env_triple
+        "#,
+        params![
+            mid,
+            r.commit_sha,
+            r.dataset,
+            r.dataset_variant,
+            r.scale_factor,
+            r.query_idx,
+            r.storage,
+            r.engine,
+            r.format,
+            r.value_ns,
+            runtimes_literal(&r.all_runtimes_ns),
+            r.peak_physical,
+            r.peak_virtual,
+            r.physical_delta,
+            r.virtual_delta,
+            r.env_triple,
+        ],
+    )?;
+    Ok(())
+}
+
+fn insert_compression_time(tx: &Transaction<'_>, r: &CompressionTime) -> Result<()> {
+    let mid = measurement_id_compression_time(r);
+    tx.execute(
+        r#"
+        INSERT INTO compression_times (
+            measurement_id, commit_sha, dataset, dataset_variant,
+            format, op, value_ns, all_runtimes_ns, env_triple
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, CAST(? AS BIGINT[]), ?)
+        ON CONFLICT (measurement_id) DO UPDATE SET
+            commit_sha      = excluded.commit_sha,
+            value_ns        = excluded.value_ns,
+            all_runtimes_ns = excluded.all_runtimes_ns,
+            env_triple      = excluded.env_triple
+        "#,
+        params![
+            mid,
+            r.commit_sha,
+            r.dataset,
+            r.dataset_variant,
+            r.format,
+            r.op,
+            r.value_ns,
+            runtimes_literal(&r.all_runtimes_ns),
+            r.env_triple,
+        ],
+    )?;
+    Ok(())
+}
+
+fn insert_compression_size(tx: &Transaction<'_>, r: &CompressionSize) -> Result<()> {
+    let mid = measurement_id_compression_size(r);
+    tx.execute(
+        r#"
+        INSERT INTO compression_sizes (
+            measurement_id, commit_sha, dataset, dataset_variant,
+            format, value_bytes
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT (measurement_id) DO UPDATE SET
+            commit_sha   = excluded.commit_sha,
+            value_bytes  = excluded.value_bytes
+        "#,
+        params![
+            mid,
+            r.commit_sha,
+            r.dataset,
+            r.dataset_variant,
+            r.format,
+            r.value_bytes,
+        ],
+    )?;
+    Ok(())
+}
+
+fn insert_random_access(tx: &Transaction<'_>, r: &RandomAccessTime) -> Result<()> {
+    let mid = measurement_id_random_access(r);
+    tx.execute(
+        r#"
+        INSERT INTO random_access_times (
+            measurement_id, commit_sha, dataset, format,
+            value_ns, all_runtimes_ns, env_triple
+        ) VALUES (?, ?, ?, ?, ?, CAST(? AS BIGINT[]), ?)
+        ON CONFLICT (measurement_id) DO UPDATE SET
+            commit_sha      = excluded.commit_sha,
+            value_ns        = excluded.value_ns,
+            all_runtimes_ns = excluded.all_runtimes_ns,
+            env_triple      = excluded.env_triple
+        "#,
+        params![
+            mid,
+            r.commit_sha,
+            r.dataset,
+            r.format,
+            r.value_ns,
+            runtimes_literal(&r.all_runtimes_ns),
+            r.env_triple,
+        ],
+    )?;
+    Ok(())
+}
+
+fn runtimes_literal(values: &[i64]) -> String {
+    let mut s = String::with_capacity(values.len() * 8 + 2);
+    s.push('[');
+    for (i, v) in values.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&v.to_string());
+    }
+    s.push(']');
+    s
+}
+
+fn migrate_file_sizes(
+    conn: &mut Connection,
+    source: &Source,
+    name: &str,
+    commits: &BTreeMap<String, V2Commit>,
+    summary: &mut MigrationSummary,
+) -> Result<()> {
+    let reader = source.open_file_sizes(name)?;
+    let dataset = name
+        .strip_prefix("file-sizes-")
+        .and_then(|s| s.strip_suffix(".json.gz"))
+        .unwrap_or(name)
+        .to_string();
+    let mut tx = conn.transaction().context("begin file-sizes tx")?;
+    const BATCH: u64 = 10_000;
+    let mut in_batch = 0u64;
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let sz: V2FileSize = match serde_json::from_str(trimmed) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("skipping malformed {name} line: {e}");
+                continue;
+            }
+        };
+        if !commits.contains_key(&sz.commit_id) {
+            summary.missing_commit += 1;
+            continue;
+        }
+        // file-sizes-*.json.gz captures per-file sizes inside one
+        // benchmark/format/scale_factor combo. We aggregate to one
+        // (commit, dataset, dataset_variant, format) row by summing,
+        // since v3's compression_sizes is a single bytes value per
+        // (dim) tuple. Use ON CONFLICT to accumulate.
+        upsert_file_size_row(&tx, &sz, &dataset)?;
+        summary.file_size_inserted += 1;
+        in_batch += 1;
+        if in_batch >= BATCH {
+            tx.commit().context("commit file-sizes batch")?;
+            tx = conn.transaction().context("begin file-sizes tx")?;
+            in_batch = 0;
+        }
+    }
+    tx.commit().context("commit final file-sizes batch")?;
+    Ok(())
+}
+
+fn upsert_file_size_row(
+    tx: &Transaction<'_>,
+    sz: &V2FileSize,
+    dataset_fallback: &str,
+) -> Result<()> {
+    let dataset = if sz.benchmark.is_empty() {
+        dataset_fallback.to_string()
+    } else {
+        sz.benchmark.clone()
+    };
+    let dataset_variant = sz
+        .scale_factor
+        .as_ref()
+        .filter(|s| !s.is_empty() && s.as_str() != "1.0")
+        .cloned();
+    let cs = CompressionSize {
+        commit_sha: sz.commit_id.clone(),
+        dataset,
+        dataset_variant,
+        format: sz.format.clone(),
+        value_bytes: sz.size_bytes,
+    };
+    let mid = measurement_id_compression_size(&cs);
+    // Multiple files within the same dataset/format/scale_factor sum
+    // into one row by adding to whatever is already there.
+    tx.execute(
+        r#"
+        INSERT INTO compression_sizes (
+            measurement_id, commit_sha, dataset, dataset_variant,
+            format, value_bytes
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT (measurement_id) DO UPDATE SET
+            value_bytes = compression_sizes.value_bytes + excluded.value_bytes
+        "#,
+        params![
+            mid,
+            cs.commit_sha,
+            cs.dataset,
+            cs.dataset_variant,
+            cs.format,
+            cs.value_bytes,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Print the summary in a human-readable form. Returned by the CLI.
+impl std::fmt::Display for MigrationSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Records read:           {}", self.records_read)?;
+        writeln!(f, "Commits upserted:       {}", self.commits_inserted)?;
+        writeln!(f, "Commit warnings:        {}", self.commit_warnings)?;
+        writeln!(f, "Inserted (query):       {}", self.query_inserted)?;
+        writeln!(
+            f,
+            "Inserted (compress t):  {}",
+            self.compression_time_inserted
+        )?;
+        writeln!(
+            f,
+            "Inserted (compress s):  {}",
+            self.compression_size_inserted
+        )?;
+        writeln!(f, "Inserted (random acc):  {}", self.random_access_inserted)?;
+        writeln!(f, "Inserted (file sizes):  {}", self.file_size_inserted)?;
+        writeln!(f, "Missing commit:         {}", self.missing_commit)?;
+        writeln!(f, "Skipped (no value):     {}", self.skipped_no_value)?;
+        writeln!(
+            f,
+            "Uncategorized:          {} ({:.2}%)",
+            self.uncategorized,
+            100.0 * self.uncategorized_fraction()
+        )?;
+        if !self.uncategorized_prefixes.is_empty() {
+            let mut top: Vec<_> = self.uncategorized_prefixes.iter().collect();
+            top.sort_by(|a, b| b.1.cmp(a.1));
+            writeln!(f, "Top uncategorized prefixes:")?;
+            for (prefix, n) in top.iter().take(20) {
+                writeln!(f, "  {prefix:>32} : {n}")?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/benchmarks-website/migrate/src/source.rs
+++ b/benchmarks-website/migrate/src/source.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Streaming readers for v2's public S3 bucket.
+//!
+//! The bucket is `--no-sign-request`, so we fetch the underlying
+//! HTTPS URL directly and stream-decompress with `flate2`. The
+//! downloads are wrapped in [`reqwest::blocking`] to keep the read
+//! path synchronous; the binary's hot path is single-threaded
+//! per-source already (DuckDB is a single-writer).
+//!
+//! For tests and offline runs, [`Source::Local`] accepts a local
+//! directory of dumps; the migrator's `--source` flag picks the
+//! variant.
+
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::io::Read;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context as _;
+use anyhow::Result;
+use flate2::read::GzDecoder;
+
+/// Public S3 bucket the live v2 server reads from.
+pub const PUBLIC_BUCKET_BASE: &str = "https://vortex-ci-benchmark-results.s3.amazonaws.com";
+
+/// Where to read the v2 dataset from. Either the public S3 bucket
+/// (the live deployment) or a local directory of dumps.
+#[derive(Debug, Clone)]
+pub enum Source {
+    /// HTTPS GETs against `s3.amazonaws.com`.
+    PublicS3,
+    /// A directory containing `data.json.gz`, `commits.json`, and
+    /// `file-sizes-*.json.gz` files.
+    Local(PathBuf),
+}
+
+impl Source {
+    /// Open `data.json.gz` for streaming, decompressing on the fly.
+    pub fn open_data_jsonl(&self) -> Result<Box<dyn BufRead>> {
+        let stream = self.open_raw("data.json.gz")?;
+        Ok(Box::new(BufReader::new(GzDecoder::new(stream))))
+    }
+
+    /// Open `commits.json` (uncompressed).
+    pub fn open_commits_jsonl(&self) -> Result<Box<dyn BufRead>> {
+        let stream = self.open_raw("commits.json")?;
+        Ok(Box::new(BufReader::new(stream)))
+    }
+
+    /// Enumerate `file-sizes-*.json.gz` files. For local sources this
+    /// is a directory glob; for the public bucket we hit the documented
+    /// suite ids.
+    pub fn list_file_sizes(&self) -> Result<Vec<String>> {
+        match self {
+            Source::Local(dir) => {
+                let mut out = Vec::new();
+                for entry in std::fs::read_dir(dir)? {
+                    let entry = entry?;
+                    let name = entry.file_name();
+                    let s = name.to_string_lossy();
+                    if s.starts_with("file-sizes-") && s.ends_with(".json.gz") {
+                        out.push(s.into_owned());
+                    }
+                }
+                out.sort();
+                Ok(out)
+            }
+            Source::PublicS3 => {
+                // The S3 bucket's ListObjects is denied for unsigned
+                // requests, so we hit the documented per-suite keys
+                // emitted by `.github/workflows/sql-benchmarks.yml`.
+                Ok(KNOWN_FILE_SIZES_SUITES
+                    .iter()
+                    .map(|id| format!("file-sizes-{id}.json.gz"))
+                    .collect())
+            }
+        }
+    }
+
+    /// Open one `file-sizes-*.json.gz` for streaming.
+    pub fn open_file_sizes(&self, name: &str) -> Result<Box<dyn BufRead>> {
+        let stream = self.open_raw(name)?;
+        Ok(Box::new(BufReader::new(GzDecoder::new(stream))))
+    }
+
+    fn open_raw(&self, name: &str) -> Result<Box<dyn Read + Send>> {
+        match self {
+            Source::Local(dir) => open_local(&dir.join(name)),
+            Source::PublicS3 => open_s3(name),
+        }
+    }
+}
+
+fn open_local(path: &Path) -> Result<Box<dyn Read + Send>> {
+    let f = File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    Ok(Box::new(f))
+}
+
+fn open_s3(name: &str) -> Result<Box<dyn Read + Send>> {
+    let url = format!("{PUBLIC_BUCKET_BASE}/{name}");
+    let resp = reqwest::blocking::get(&url).with_context(|| format!("GET {url}"))?;
+    if !resp.status().is_success() {
+        anyhow::bail!("GET {url} returned {}", resp.status());
+    }
+    Ok(Box::new(resp))
+}
+
+/// Suite IDs we know publish a `file-sizes-{id}.json.gz` to S3.
+/// Matches the `matrix.id` values in `.github/workflows/sql-benchmarks.yml`
+/// at the time of writing. New suites mean a new entry here.
+const KNOWN_FILE_SIZES_SUITES: &[&str] =
+    &["clickbench", "tpch", "tpcds", "statpopgen", "polarsignals"];

--- a/benchmarks-website/migrate/src/v2.rs
+++ b/benchmarks-website/migrate/src/v2.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Wire shapes of the v2 benchmark dataset on S3.
+//!
+//! These types capture only the fields the migrator reads. v2 records
+//! are serialized by `vortex-bench` (see `vortex-bench/src/measurements.rs`)
+//! and by older non-Rust scripts; the union of fields is loose, so we
+//! deserialize permissively (`serde(default)`, untyped `serde_json::Value`
+//! for the polymorphic `dataset` field).
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+/// One JSONL line of `data.json.gz`.
+///
+/// The shape is the union of every emitter's output. Most fields are
+/// optional because different benches emit different subsets.
+#[derive(Debug, Clone, Deserialize)]
+pub struct V2Record {
+    pub name: String,
+    #[serde(default)]
+    pub commit_id: Option<String>,
+    #[serde(default)]
+    pub unit: Option<String>,
+    #[serde(default)]
+    pub value: Option<serde_json::Value>,
+    #[serde(default)]
+    pub storage: Option<String>,
+    #[serde(default)]
+    pub dataset: Option<serde_json::Value>,
+    #[serde(default)]
+    pub all_runtimes: Option<Vec<serde_json::Value>>,
+    #[serde(default)]
+    pub env_triple: Option<V2EnvTriple>,
+}
+
+/// `dataset` in v2 records is sometimes a string, sometimes an object
+/// keyed by suite name (`{ "tpch": { "scale_factor": "10" } }`).
+/// This helper looks up the scale factor for a given suite without
+/// assuming a particular shape.
+pub fn dataset_scale_factor(dataset: &serde_json::Value, key: &str) -> Option<String> {
+    let obj = dataset.as_object()?;
+    let entry = obj.get(key)?;
+    let sf = entry.get("scale_factor")?;
+    match sf {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+/// Best-effort numeric coercion for the polymorphic `value` field.
+pub fn value_as_f64(value: &serde_json::Value) -> Option<f64> {
+    match value {
+        serde_json::Value::Number(n) => n.as_f64(),
+        serde_json::Value::String(s) => s.parse().ok(),
+        _ => None,
+    }
+}
+
+/// Best-effort coercion of a runtime entry to nanoseconds.
+pub fn runtime_as_i64(value: &serde_json::Value) -> Option<i64> {
+    match value {
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Some(i)
+            } else {
+                n.as_f64().map(|f| f as i64)
+            }
+        }
+        serde_json::Value::String(s) => s.parse().ok(),
+        _ => None,
+    }
+}
+
+/// Triple block as emitted by `vortex-bench`'s `--gh-json` path. v2
+/// stored it as an object; we serialize it back out as `arch-os-env`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct V2EnvTriple {
+    #[serde(default)]
+    pub architecture: Option<String>,
+    #[serde(default)]
+    pub operating_system: Option<String>,
+    #[serde(default)]
+    pub environment: Option<String>,
+}
+
+impl V2EnvTriple {
+    /// Format as the `arch-os-env` triple used by v3's `env_triple` column.
+    pub fn to_triple(&self) -> Option<String> {
+        let arch = self.architecture.as_deref()?;
+        let os = self.operating_system.as_deref()?;
+        let env = self.environment.as_deref()?;
+        Some(format!("{arch}-{os}-{env}"))
+    }
+}
+
+/// One JSONL line of `commits.json`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct V2Commit {
+    pub id: String,
+    #[serde(default)]
+    pub timestamp: Option<String>,
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(default)]
+    pub author: Option<V2Person>,
+    #[serde(default)]
+    pub committer: Option<V2Person>,
+    #[serde(default)]
+    pub tree_id: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct V2Person {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub email: Option<String>,
+}
+
+/// One JSONL line of `file-sizes-*.json.gz` produced by
+/// `scripts/capture-file-sizes.py`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct V2FileSize {
+    pub commit_id: String,
+    pub benchmark: String,
+    #[serde(default)]
+    pub scale_factor: Option<String>,
+    pub format: String,
+    pub file: String,
+    pub size_bytes: i64,
+}
+
+/// Build a sha-keyed map of commits.
+pub fn index_commits(commits: Vec<V2Commit>) -> BTreeMap<String, V2Commit> {
+    commits.into_iter().map(|c| (c.id.clone(), c)).collect()
+}

--- a/benchmarks-website/migrate/src/verify.rs
+++ b/benchmarks-website/migrate/src/verify.rs
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Structural diff between a migrated v3 DuckDB and the live v2
+//! `/api/metadata` endpoint.
+//!
+//! Compares group / chart structure only; values aren't compared
+//! because v2 converts ns → ms and bytes → MiB on read while v3
+//! stores raw and the chart query divides. Group/chart structural
+//! equivalence is enough to spot classifier regressions before
+//! cutover.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use anyhow::Context as _;
+use anyhow::Result;
+use duckdb::Connection;
+use serde::Deserialize;
+
+use crate::classifier::QUERY_SUITES;
+
+/// Result of one `verify` run.
+#[derive(Debug, Default)]
+pub struct VerifyReport {
+    pub matched_groups: Vec<String>,
+    pub only_in_v3: Vec<String>,
+    pub only_in_v2: Vec<String>,
+    pub chart_diffs: Vec<ChartDiff>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChartDiff {
+    pub group: String,
+    pub v2_count: usize,
+    pub v3_count: usize,
+}
+
+impl VerifyReport {
+    /// True if every v2 group is represented in v3. The CLI's exit
+    /// code reflects this.
+    pub fn v2_groups_covered(&self) -> bool {
+        self.only_in_v2.is_empty()
+    }
+}
+
+impl std::fmt::Display for VerifyReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Groups in both v2 and v3:")?;
+        for g in &self.matched_groups {
+            writeln!(f, "  + {g}")?;
+        }
+        if !self.only_in_v2.is_empty() {
+            writeln!(f, "Groups only in v2 (regression candidates):")?;
+            for g in &self.only_in_v2 {
+                writeln!(f, "  - {g}")?;
+            }
+        }
+        if !self.only_in_v3.is_empty() {
+            writeln!(f, "Groups only in v3:")?;
+            for g in &self.only_in_v3 {
+                writeln!(f, "  + {g}")?;
+            }
+        }
+        if !self.chart_diffs.is_empty() {
+            writeln!(f, "Chart count diffs:")?;
+            for d in &self.chart_diffs {
+                writeln!(
+                    f,
+                    "  {} : v2={} v3={} (delta={})",
+                    d.group,
+                    d.v2_count,
+                    d.v3_count,
+                    d.v3_count as i64 - d.v2_count as i64,
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// v2's `/api/metadata` reply — only the fields we need.
+#[derive(Debug, Deserialize)]
+struct V2Metadata {
+    groups: BTreeMap<String, V2GroupMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct V2GroupMeta {
+    #[serde(default)]
+    charts: Vec<V2ChartMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct V2ChartMeta {
+    #[serde(default)]
+    name: String,
+}
+
+/// Open the migrated DuckDB at `duckdb_path`, fetch `<v2_server>/api/metadata`,
+/// and produce a structural diff.
+pub fn run(v2_server: &str, duckdb_path: &Path) -> Result<VerifyReport> {
+    let v3 = collect_v3_groups(duckdb_path)?;
+    let v2 = fetch_v2_metadata(v2_server)?;
+    Ok(diff(&v2, &v3))
+}
+
+fn collect_v3_groups(duckdb_path: &Path) -> Result<BTreeMap<String, BTreeSet<String>>> {
+    let conn = Connection::open(duckdb_path)
+        .with_context(|| format!("opening DuckDB at {}", duckdb_path.display()))?;
+    let mut groups: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+
+    // query_measurements: chart per (dataset, query_idx); group per
+    // (dataset, dataset_variant, scale_factor, storage). We want v2
+    // group display names so the verifier can compare apples to
+    // apples, so we re-format them here using the same suite table.
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT dataset, dataset_variant, scale_factor, storage, query_idx
+          FROM query_measurements
+         GROUP BY dataset, dataset_variant, scale_factor, storage, query_idx
+        "#,
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, i32>(4)?,
+        ))
+    })?;
+    for row in rows {
+        let (dataset, _variant, sf, storage, query_idx) = row?;
+        let group_name = display_query_group(&dataset, sf.as_deref(), &storage);
+        let chart_name = chart_name_query(&dataset, query_idx);
+        groups
+            .entry(group_name)
+            .or_default()
+            .insert(normalize_chart(&chart_name));
+    }
+
+    // compression_times: group "Compression", charts per dataset.
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT dataset, format, op
+          FROM compression_times
+         GROUP BY dataset, format, op
+        "#,
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        ))
+    })?;
+    for row in rows {
+        let (dataset, format, op) = row?;
+        let chart = chart_name_compression_time(&format, &op, &dataset);
+        groups
+            .entry("Compression".to_string())
+            .or_default()
+            .insert(normalize_chart(&chart));
+    }
+
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT dataset, format
+          FROM compression_sizes
+         GROUP BY dataset, format
+        "#,
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    for row in rows {
+        let (_dataset, format) = row?;
+        let chart = chart_name_compression_size(&format);
+        groups
+            .entry("Compression Size".to_string())
+            .or_default()
+            .insert(normalize_chart(&chart));
+    }
+
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT DISTINCT dataset
+          FROM random_access_times
+        "#,
+    )?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+    for row in rows {
+        let dataset = row?;
+        groups
+            .entry("Random Access".to_string())
+            .or_default()
+            .insert(normalize_chart(&dataset));
+    }
+
+    Ok(groups)
+}
+
+fn fetch_v2_metadata(server: &str) -> Result<BTreeMap<String, BTreeSet<String>>> {
+    let url = format!("{}/api/metadata", server.trim_end_matches('/'));
+    let body = reqwest::blocking::get(&url)
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("non-2xx from {url}"))?
+        .json::<V2Metadata>()
+        .with_context(|| format!("parsing {url} as v2 /api/metadata"))?;
+    let mut out: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for (name, group) in body.groups {
+        let charts = group
+            .charts
+            .into_iter()
+            .map(|c| normalize_chart(&c.name))
+            .collect();
+        out.insert(name, charts);
+    }
+    Ok(out)
+}
+
+fn diff(
+    v2: &BTreeMap<String, BTreeSet<String>>,
+    v3: &BTreeMap<String, BTreeSet<String>>,
+) -> VerifyReport {
+    let mut report = VerifyReport::default();
+    let v2_keys: BTreeSet<&String> = v2.keys().collect();
+    let v3_keys: BTreeSet<&String> = v3.keys().collect();
+    for g in v2_keys.intersection(&v3_keys) {
+        report.matched_groups.push((**g).clone());
+        let v2_charts = &v2[*g];
+        let v3_charts = &v3[*g];
+        if v2_charts.len() != v3_charts.len() {
+            report.chart_diffs.push(ChartDiff {
+                group: (**g).clone(),
+                v2_count: v2_charts.len(),
+                v3_count: v3_charts.len(),
+            });
+        }
+    }
+    for g in v3_keys.difference(&v2_keys) {
+        report.only_in_v3.push((**g).clone());
+    }
+    for g in v2_keys.difference(&v3_keys) {
+        report.only_in_v2.push((**g).clone());
+    }
+    report.matched_groups.sort();
+    report.only_in_v3.sort();
+    report.only_in_v2.sort();
+    report
+}
+
+fn display_query_group(dataset: &str, scale_factor: Option<&str>, storage: &str) -> String {
+    let suite = QUERY_SUITES
+        .iter()
+        .find(|s| s.prefix.eq_ignore_ascii_case(dataset))
+        .copied();
+    match suite {
+        Some(suite) if suite.fan_out => {
+            let storage_disp = match storage {
+                "s3" | "S3" => "S3",
+                _ => "NVMe",
+            };
+            let sf = scale_factor.unwrap_or("1");
+            format!("{} ({}) (SF={})", suite.display_name, storage_disp, sf)
+        }
+        Some(suite) => suite.display_name.to_string(),
+        None => format!("{dataset} ({storage})"),
+    }
+}
+
+fn chart_name_query(dataset: &str, query_idx: i32) -> String {
+    let suite = QUERY_SUITES
+        .iter()
+        .find(|s| s.prefix.eq_ignore_ascii_case(dataset))
+        .copied();
+    match suite {
+        Some(suite) => format!("{} Q{}", suite.query_prefix, query_idx),
+        None => format!("{} Q{}", dataset.to_uppercase(), query_idx),
+    }
+}
+
+fn chart_name_compression_time(format: &str, op: &str, _dataset: &str) -> String {
+    // Re-derive the v2 chart name (the metric, not the dataset) so we
+    // can compare. v2's chart axis is the metric; series is the
+    // dataset. v3 inverts that. For structural comparison, we project
+    // back to v2's per-chart key.
+    match (format, op) {
+        ("vortex-file-compressed", "encode") => "COMPRESS TIME".into(),
+        ("vortex-file-compressed", "decode") => "DECOMPRESS TIME".into(),
+        ("parquet", "encode") => "PARQUET RS ZSTD COMPRESS TIME".into(),
+        ("parquet", "decode") => "PARQUET RS ZSTD DECOMPRESS TIME".into(),
+        ("lance", "encode") => "LANCE COMPRESS TIME".into(),
+        ("lance", "decode") => "LANCE DECOMPRESS TIME".into(),
+        _ => format!("{} {} TIME", format.to_uppercase(), op.to_uppercase()),
+    }
+}
+
+fn chart_name_compression_size(format: &str) -> String {
+    match format {
+        "vortex-file-compressed" => "VORTEX SIZE".into(),
+        "parquet" => "PARQUET SIZE".into(),
+        "lance" => "LANCE SIZE".into(),
+        _ => format!("{} SIZE", format.to_uppercase()),
+    }
+}
+
+/// Strip casing and `_-` differences between v2 and v3 chart names.
+/// v2 displays uppercase; v3 stores raw values. Comparing in this
+/// canonical form is enough for structural verification.
+fn normalize_chart(s: &str) -> String {
+    s.trim()
+        .to_uppercase()
+        .replace(['_', '-'], " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_chart_canonicalizes() {
+        assert_eq!(normalize_chart("taxi/take"), "TAXI/TAKE");
+        assert_eq!(normalize_chart("TAXI/TAKE"), "TAXI/TAKE");
+        assert_eq!(normalize_chart("tpc-h q1"), "TPC H Q1");
+        assert_eq!(normalize_chart("tpc h q1"), "TPC H Q1");
+    }
+
+    #[test]
+    fn display_query_group_handles_fan_out() {
+        assert_eq!(
+            display_query_group("tpch", Some("10"), "s3"),
+            "TPC-H (S3) (SF=10)"
+        );
+        assert_eq!(
+            display_query_group("tpch", Some("100"), "nvme"),
+            "TPC-H (NVMe) (SF=100)"
+        );
+        assert_eq!(
+            display_query_group("clickbench", None, "nvme"),
+            "Clickbench"
+        );
+    }
+}

--- a/benchmarks-website/migrate/tests/classifier.rs
+++ b/benchmarks-website/migrate/tests/classifier.rs
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Classifier behavior pinned by representative v2 names from each
+//! group in `benchmarks-website/server.js`'s `getGroup`.
+
+use rstest::rstest;
+use serde_json::json;
+use vortex_bench_migrate::classifier::V3Bin;
+use vortex_bench_migrate::classifier::classify;
+use vortex_bench_migrate::classifier::format_query;
+use vortex_bench_migrate::classifier::rename_engine;
+use vortex_bench_migrate::v2::V2Record;
+
+fn record(name: &str) -> V2Record {
+    V2Record {
+        name: name.to_string(),
+        commit_id: Some("deadbeef".into()),
+        unit: Some("ns".into()),
+        value: Some(json!(123)),
+        storage: None,
+        dataset: None,
+        all_runtimes: None,
+        env_triple: None,
+    }
+}
+
+fn record_with_storage_and_sf(name: &str, storage: &str, suite: &str, sf: &str) -> V2Record {
+    let mut r = record(name);
+    r.storage = Some(storage.into());
+    r.dataset = Some(json!({ suite: { "scale_factor": sf } }));
+    r
+}
+
+#[rstest]
+#[case::clickbench(
+    "clickbench_q07/datafusion:parquet",
+    V3Bin::Query {
+        dataset: "clickbench".into(),
+        dataset_variant: None,
+        scale_factor: None,
+        query_idx: 7,
+        storage: "nvme".into(),
+        engine: "datafusion".into(),
+        format: "parquet".into(),
+    },
+)]
+#[case::clickbench_vortex_renamed(
+    "clickbench_q12/datafusion:vortex-file-compressed",
+    V3Bin::Query {
+        dataset: "clickbench".into(),
+        dataset_variant: None,
+        scale_factor: None,
+        query_idx: 12,
+        storage: "nvme".into(),
+        engine: "datafusion".into(),
+        format: "vortex".into(),
+    },
+)]
+#[case::statpopgen(
+    "statpopgen_q3/datafusion:parquet",
+    V3Bin::Query {
+        dataset: "statpopgen".into(),
+        dataset_variant: None,
+        scale_factor: None,
+        query_idx: 3,
+        storage: "nvme".into(),
+        engine: "datafusion".into(),
+        format: "parquet".into(),
+    },
+)]
+#[case::polarsignals(
+    "polarsignals_q1/duckdb:parquet",
+    V3Bin::Query {
+        dataset: "polarsignals".into(),
+        dataset_variant: None,
+        scale_factor: None,
+        query_idx: 1,
+        storage: "nvme".into(),
+        engine: "duckdb".into(),
+        format: "parquet".into(),
+    },
+)]
+fn non_fan_out_query_records(#[case] name: &str, #[case] expected: V3Bin) {
+    let r = record(name);
+    assert_eq!(classify(&r), Some(expected));
+}
+
+#[rstest]
+#[case::tpch_s3_sf100(
+    "tpch_q01/datafusion:parquet",
+    "S3",
+    "tpch",
+    "100",
+    V3Bin::Query {
+        dataset: "tpch".into(),
+        dataset_variant: None,
+        scale_factor: Some("100".into()),
+        query_idx: 1,
+        storage: "s3".into(),
+        engine: "datafusion".into(),
+        format: "parquet".into(),
+    },
+)]
+#[case::tpch_nvme_sf1(
+    "tpch_q22/duckdb:vortex-file-compressed",
+    "NVMe",
+    "tpch",
+    "1",
+    V3Bin::Query {
+        dataset: "tpch".into(),
+        dataset_variant: None,
+        scale_factor: Some("1".into()),
+        query_idx: 22,
+        storage: "nvme".into(),
+        engine: "duckdb".into(),
+        format: "vortex".into(),
+    },
+)]
+#[case::tpcds_nvme_sf10(
+    "tpcds_q05/datafusion:vortex-file-compressed",
+    "NVMe",
+    "tpcds",
+    "10",
+    V3Bin::Query {
+        dataset: "tpcds".into(),
+        dataset_variant: None,
+        scale_factor: Some("10".into()),
+        query_idx: 5,
+        storage: "nvme".into(),
+        engine: "datafusion".into(),
+        format: "vortex".into(),
+    },
+)]
+fn fan_out_query_records(
+    #[case] name: &str,
+    #[case] storage: &str,
+    #[case] suite: &str,
+    #[case] sf: &str,
+    #[case] expected: V3Bin,
+) {
+    let r = record_with_storage_and_sf(name, storage, suite, sf);
+    assert_eq!(classify(&r), Some(expected));
+}
+
+#[rstest]
+#[case::random_access_4_part(
+    "random-access/taxi/take/parquet-tokio-local-disk",
+    V3Bin::RandomAccess {
+        dataset: "taxi/take".into(),
+        format: "parquet-nvme".into(),
+    },
+)]
+#[case::random_access_4_part_vortex(
+    "random-access/chimp/take/vortex-tokio-local-disk",
+    V3Bin::RandomAccess {
+        dataset: "chimp/take".into(),
+        format: "vortex-nvme".into(),
+    },
+)]
+#[case::random_access_2_part_legacy(
+    "random-access/parquet-tokio-local-disk",
+    V3Bin::RandomAccess {
+        dataset: "random access".into(),
+        format: "parquet-nvme".into(),
+    },
+)]
+fn random_access_records(#[case] name: &str, #[case] expected: V3Bin) {
+    let r = record(name);
+    assert_eq!(classify(&r), Some(expected));
+}
+
+#[rstest]
+#[case::compress_time_vortex(
+    "compress time/clickbench",
+    V3Bin::CompressionTime {
+        dataset: "clickbench".into(),
+        dataset_variant: None,
+        format: "vortex-file-compressed".into(),
+        op: "encode".into(),
+    },
+)]
+#[case::decompress_time_vortex(
+    "decompress time/tpch_lineitem",
+    V3Bin::CompressionTime {
+        dataset: "tpch_lineitem".into(),
+        dataset_variant: None,
+        format: "vortex-file-compressed".into(),
+        op: "decode".into(),
+    },
+)]
+#[case::parquet_compress(
+    "parquet_rs-zstd compress time/clickbench",
+    V3Bin::CompressionTime {
+        dataset: "clickbench".into(),
+        dataset_variant: None,
+        format: "parquet".into(),
+        op: "encode".into(),
+    },
+)]
+#[case::lance_decompress(
+    "lance decompress time/clickbench",
+    V3Bin::CompressionTime {
+        dataset: "clickbench".into(),
+        dataset_variant: None,
+        format: "lance".into(),
+        op: "decode".into(),
+    },
+)]
+fn compression_time_records(#[case] name: &str, #[case] expected: V3Bin) {
+    let r = record(name);
+    assert_eq!(classify(&r), Some(expected));
+}
+
+#[rstest]
+#[case::vortex_size(
+    "vortex size/clickbench",
+    V3Bin::CompressionSize {
+        dataset: "clickbench".into(),
+        dataset_variant: None,
+        format: "vortex-file-compressed".into(),
+    },
+)]
+#[case::vortex_file_compressed_size_normalizes(
+    "vortex-file-compressed size/clickbench",
+    V3Bin::CompressionSize {
+        dataset: "clickbench".into(),
+        dataset_variant: None,
+        format: "vortex-file-compressed".into(),
+    },
+)]
+#[case::parquet_size(
+    "parquet size/clickbench",
+    V3Bin::CompressionSize {
+        dataset: "clickbench".into(),
+        dataset_variant: None,
+        format: "parquet".into(),
+    },
+)]
+#[case::lance_size(
+    "lance size/tpch_lineitem",
+    V3Bin::CompressionSize {
+        dataset: "tpch_lineitem".into(),
+        dataset_variant: None,
+        format: "lance".into(),
+    },
+)]
+fn compression_size_records(#[case] name: &str, #[case] expected: V3Bin) {
+    let r = record(name);
+    assert_eq!(classify(&r), Some(expected));
+}
+
+#[rstest]
+#[case::ratio_vortex_parquet("vortex:parquet-zstd ratio compress time/clickbench")]
+#[case::ratio_vortex_lance("vortex:lance ratio decompress time/clickbench")]
+#[case::ratio_size_vortex_parquet("vortex:parquet-zstd size/clickbench")]
+#[case::ratio_size_vortex_raw("vortex:raw size/clickbench")]
+#[case::throughput("compress throughput/clickbench")]
+#[case::fineweb_skipped("fineweb_q01/datafusion:parquet")]
+#[case::nonsense_prefix("not-a-known-bench/series")]
+fn unmapped_records_yield_none(#[case] name: &str) {
+    let r = record(name);
+    assert_eq!(
+        classify(&r),
+        None,
+        "expected {name:?} to classify as None (drop)",
+    );
+}
+
+#[test]
+fn rename_engine_pins_canonical_outputs() {
+    assert_eq!(rename_engine("vortex-tokio-local-disk"), "vortex-nvme");
+    assert_eq!(
+        rename_engine("datafusion:vortex-file-compressed"),
+        "datafusion:vortex"
+    );
+    assert_eq!(rename_engine("LANCE"), "lance");
+}
+
+#[test]
+fn format_query_pins_v2_display() {
+    assert_eq!(format_query("clickbench_q00"), "CLICKBENCH Q0");
+    assert_eq!(format_query("tpch_q22"), "TPC-H Q22");
+    assert_eq!(format_query("tpcds_q42"), "TPC-DS Q42");
+    assert_eq!(format_query("polarsignals_q1"), "POLARSIGNALS Q1");
+    // Names that don't match a suite fall back to upper + " " replace.
+    assert_eq!(
+        format_query("vortex-file-compressed size"),
+        "VORTEX FILE COMPRESSED SIZE"
+    );
+}

--- a/benchmarks-website/migrate/tests/end_to_end.rs
+++ b/benchmarks-website/migrate/tests/end_to_end.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Inline JSONL fixture exercising 1 record per kind through the full
+//! migration into a tempdir DuckDB. No live S3.
+
+use std::fs::File;
+use std::io::Write;
+
+use duckdb::Connection;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use tempfile::TempDir;
+use vortex_bench_migrate::migrate;
+use vortex_bench_migrate::source::Source;
+
+const COMMITS_JSONL: &str = r#"{"id":"deadbeef","timestamp":"2026-04-25T00:00:00Z","message":"fixture commit","author":{"name":"A","email":"a@example.com"},"committer":{"name":"C","email":"c@example.com"},"tree_id":"abcd0001","url":"https://example.com/commit/deadbeef"}
+"#;
+
+const DATA_JSONL: &str = r#"{"name":"clickbench_q07/datafusion:parquet","commit_id":"deadbeef","unit":"ns","value":42000,"all_runtimes":[41000,42000,43000]}
+{"name":"compress time/clickbench","commit_id":"deadbeef","unit":"ns","value":99}
+{"name":"vortex size/clickbench","commit_id":"deadbeef","unit":"bytes","value":1024}
+{"name":"random-access/taxi/take/parquet-tokio-local-disk","commit_id":"deadbeef","unit":"ns","value":777,"all_runtimes":[700,777,800]}
+"#;
+
+fn write_local_dir() -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    {
+        let mut f = File::create(dir.path().join("commits.json")).unwrap();
+        f.write_all(COMMITS_JSONL.as_bytes()).unwrap();
+    }
+    {
+        let f = File::create(dir.path().join("data.json.gz")).unwrap();
+        let mut gz = GzEncoder::new(f, Compression::default());
+        gz.write_all(DATA_JSONL.as_bytes()).unwrap();
+        gz.finish().unwrap();
+    }
+    // No file-sizes-*.json.gz to keep the fixture minimal.
+    dir
+}
+
+#[test]
+fn migrate_inline_fixture_populates_each_table() {
+    let src_dir = write_local_dir();
+    let target_dir = TempDir::new().unwrap();
+    let target = target_dir.path().join("v3.duckdb");
+
+    let summary = migrate::run(&Source::Local(src_dir.path().into()), &target).unwrap();
+
+    assert_eq!(summary.records_read, 4, "summary={summary}");
+    assert_eq!(summary.uncategorized, 0, "summary={summary}");
+    assert_eq!(summary.commits_inserted, 1);
+    assert_eq!(summary.query_inserted, 1);
+    assert_eq!(summary.compression_time_inserted, 1);
+    assert_eq!(summary.compression_size_inserted, 1);
+    assert_eq!(summary.random_access_inserted, 1);
+
+    let conn = Connection::open(&target).unwrap();
+    let count = |table: &str| -> i64 {
+        conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| r.get(0))
+            .unwrap()
+    };
+    assert_eq!(count("commits"), 1);
+    assert_eq!(count("query_measurements"), 1);
+    assert_eq!(count("compression_times"), 1);
+    assert_eq!(count("compression_sizes"), 1);
+    assert_eq!(count("random_access_times"), 1);
+
+    // Spot-check the v3 column values for each kind.
+    let (engine, format, query_idx, value_ns): (String, String, i32, i64) = conn
+        .query_row(
+            "SELECT engine, format, query_idx, value_ns FROM query_measurements",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(engine, "datafusion");
+    assert_eq!(format, "parquet");
+    assert_eq!(query_idx, 7);
+    assert_eq!(value_ns, 42000);
+
+    let (dataset, format, op): (String, String, String) = conn
+        .query_row(
+            "SELECT dataset, format, op FROM compression_times",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(dataset, "clickbench");
+    assert_eq!(format, "vortex-file-compressed");
+    assert_eq!(op, "encode");
+
+    let (dataset, format, value_bytes): (String, String, i64) = conn
+        .query_row(
+            "SELECT dataset, format, value_bytes FROM compression_sizes",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(dataset, "clickbench");
+    assert_eq!(format, "vortex-file-compressed");
+    assert_eq!(value_bytes, 1024);
+
+    let (dataset, format): (String, String) = conn
+        .query_row("SELECT dataset, format FROM random_access_times", [], |r| {
+            Ok((r.get(0)?, r.get(1)?))
+        })
+        .unwrap();
+    assert_eq!(dataset, "taxi/take");
+    assert_eq!(format, "parquet-nvme");
+}


### PR DESCRIPTION
## Summary

This PR introduces `vortex-bench-migrate`, a one-shot CLI tool for migrating historical benchmark data from the v2 S3-hosted dataset into a v3 DuckDB file. The v2 dataset uses untyped JSONL records with benchmark metadata encoded in name strings, while v3 uses five typed fact tables with explicit dimension columns. This migrator bridges that gap.

### Key Components

1. **Classifier** (`classifier.rs`): A faithful port of v2's `server.js` classification logic that:
   - Groups records by name prefix (Random Access, Compression, Compression Size, or Query suites)
   - Applies engine/format renames and query name formatting
   - Maps v2 group + chart + series triples to v3 fact-table bins with explicit dimensions
   - Handles fan-out logic for TPC-H/TPC-DS (storage and scale factor extraction)

2. **Migration Engine** (`migrate.rs`): Streams v2 data and writes to v3:
   - Reads `data.json.gz`, `commits.json`, and `file-sizes-*.json.gz` from S3 or local directory
   - Applies the classifier to each record
   - Computes `measurement_id` values using the same server functions for byte-compatibility
   - Batches inserts into DuckDB with transaction management
   - Tracks detailed migration statistics (inserted counts per table, uncategorized records, etc.)

3. **Verification** (`verify.rs`): Structural diff against live v2 `/api/metadata`:
   - Compares group/chart structure between migrated v3 and live v2
   - Identifies missing groups (regression candidates) and extra groups
   - Exits with appropriate code for CI gating

4. **Source Abstraction** (`source.rs`): Pluggable data source:
   - `PublicS3`: HTTPS streaming from the public S3 bucket
   - `Local`: Directory of gzipped dumps for testing/offline runs

5. **Supporting Types** (`v2.rs`, `commits.rs`): Wire format definitions and commit upserts

### Testing

- Unit tests in `tests/classifier.rs` pin classifier behavior for representative v2 names from each group
- End-to-end test in `tests/end_to_end.rs` exercises one record per kind through full migration into a tempdir DuckDB
- All tests pass with the inline fixture

The migrator is intentionally a leaf binary outside the workspace public-API surface (uses `anyhow` for errors, not part of vortex-* public API).

https://claude.ai/code/session_01EzqvFcTFBAw9SD7faMd2mS