### PR TITLE
feat(cuda): prefer standalone kernels in `auto` mode

### DIFF
--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -43,6 +43,7 @@ use vortex::error::VortexResult;
 use vortex::error::vortex_err;
 use vortex::session::VortexSession;
 use vortex_cuda::CudaDeviceBuffer;
+use vortex_cuda::CudaDispatchMode;
 use vortex_cuda::CudaExecutionCtx;
 use vortex_cuda::CudaSession;
 use vortex_cuda::dynamic_dispatch::CudaDispatchPlan;
@@ -125,7 +126,9 @@ struct BenchRunner {
 
 impl BenchRunner {
     fn new(array: &vortex::array::ArrayRef, len: usize, cuda_ctx: &mut CudaExecutionCtx) -> Self {
-        let plan = match DispatchPlan::new(array).vortex_expect("build_dyn_dispatch_plan") {
+        let plan = match DispatchPlan::new(array, CudaDispatchMode::DynDispatchOnly)
+            .vortex_expect("build_dyn_dispatch_plan")
+        {
             DispatchPlan::Fused(plan) => plan,
             _ => unreachable!("encoding not fusable"),
         };

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -538,6 +538,7 @@ mod tests {
     use crate::CudaDeviceBuffer;
     use crate::CudaExecutionCtx;
     use crate::executor::CudaArrayExt;
+    use crate::executor::CudaDispatchMode;
     use crate::hybrid_dispatch::try_gpu_dispatch;
     use crate::session::CudaSession;
 
@@ -559,7 +560,7 @@ mod tests {
         array: &vortex::array::ArrayRef,
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<MaterializedPlan> {
-        match DispatchPlan::new(array)? {
+        match DispatchPlan::new(array, CudaDispatchMode::DynDispatchOnly)? {
             DispatchPlan::Fused(plan) => plan.materialize(ctx).await,
             _ => vortex_bail!("array encoding not fusable"),
         }
@@ -1100,7 +1101,7 @@ mod tests {
         // Mixed-width Dict (u8 codes, u32 values): both are Primitive, so
         // walk_mixed_width_child grabs the codes buffer directly as a LOAD
         // source. No pending subtrees → Fused.
-        let plan = DispatchPlan::new(&array)?;
+        let plan = DispatchPlan::new(&array, CudaDispatchMode::Auto)?;
         assert!(
             matches!(plan, DispatchPlan::Fused(..)),
             "expected Fused for mixed-width Dict with primitive codes"
@@ -1132,7 +1133,7 @@ mod tests {
         // Mixed-width Dict (u16 codes, u32 values): both are Primitive, so
         // walk_mixed_width_child grabs the codes buffer directly as a LOAD
         // source. No pending subtrees → Fused.
-        let plan = DispatchPlan::new(&array)?;
+        let plan = DispatchPlan::new(&array, CudaDispatchMode::Auto)?;
         assert!(
             matches!(plan, DispatchPlan::Fused(..)),
             "expected Fused for mixed-width Dict with primitive codes"
@@ -1164,7 +1165,7 @@ mod tests {
 
         // Ends (u64) are wider than values (u32), so the kernel would truncate
         // ends via load_element<T>. The plan builder rejects this as Unfused.
-        let plan = DispatchPlan::new(&array)?;
+        let plan = DispatchPlan::new(&array, CudaDispatchMode::Auto)?;
         assert!(
             matches!(plan, DispatchPlan::Unfused),
             "expected Unfused for RunEnd with wider ends"
@@ -1746,12 +1747,122 @@ mod tests {
         Ok(())
     }
 
+    // ---------------------------------------------------------------
+    // has_standalone_kernel classification tests
+    // ---------------------------------------------------------------
+
+    #[crate::test]
+    fn test_has_standalone_kernel_true_cases() -> VortexResult<()> {
+        // BitPacked — leaf encoding, no children.
+        let bp = bitpacked_array_u32(6, 2048);
+        let bp_arr = bp.into_array();
+        assert!(plan_builder::has_standalone_kernel(&bp_arr));
+
+        // Sequence — leaf encoding, no children.
+        use vortex::dtype::Nullability;
+        use vortex::encodings::sequence::Sequence;
+        let seq = Sequence::try_new_typed(0u32, 1u32, Nullability::NonNullable, 2048)?;
+        assert!(plan_builder::has_standalone_kernel(&seq.into_array()));
+
+        // FoR(BitPacked) — FFOR fusion, single launch.
+        let for_bp = FoR::try_new(bp_arr.clone(), 100u32.into())?;
+        assert!(plan_builder::has_standalone_kernel(&for_bp.into_array()));
+
+        // FoR(Slice(BitPacked)) — FFOR + slice fusion, single launch.
+        let sliced_bp = bp_arr.slice(100..1500)?;
+        let for_sliced_bp = FoR::try_new(sliced_bp, 100u32.into())?;
+        assert!(plan_builder::has_standalone_kernel(
+            &for_sliced_bp.into_array()
+        ));
+
+        Ok(())
+    }
+
+    #[crate::test]
+    fn test_has_standalone_kernel_false_cases() -> VortexResult<()> {
+        // ALP(Primitive) — ALP always calls execute_cuda on its encoded child.
+        let encoded =
+            PrimitiveArray::new(Buffer::from((0i32..2048).collect::<Vec<_>>()), NonNullable);
+        let alp = ALP::try_new(encoded.into_array(), Exponents { e: 2, f: 0 }, None)?;
+        assert!(!plan_builder::has_standalone_kernel(&alp.into_array()));
+
+        // FoR(Primitive) — FoR standalone would recurse for non-BP child.
+        let prim = PrimitiveArray::new(Buffer::from(vec![1u32, 2, 3]), NonNullable);
+        let for_prim = FoR::try_new(prim.into_array(), 100u32.into())?;
+        assert!(!plan_builder::has_standalone_kernel(&for_prim.into_array()));
+
+        // Dict and RunEnd always recurse into children.
+        let codes = PrimitiveArray::new(Buffer::from(vec![0u32, 1, 0, 1]), NonNullable);
+        let values = PrimitiveArray::new(Buffer::from(vec![100u32, 200]), NonNullable);
+        let dict = DictArray::try_new(codes.into_array(), values.into_array())?;
+        assert!(!plan_builder::has_standalone_kernel(&dict.into_array()));
+
+        Ok(())
+    }
+
+    /// Every encoding `has_standalone_kernel` returns `true` for must have
+    /// a kernel registered in the CUDA session.
+    #[crate::test]
+    fn test_has_standalone_kernel_implies_registered_kernel() -> VortexResult<()> {
+        use vortex::dtype::Nullability;
+        use vortex::encodings::sequence::Sequence;
+
+        let session = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let cuda_session = session.cuda_session();
+
+        // Leaf encodings.
+        let bp = bitpacked_array_u32(6, 2048);
+        let bp_arr = bp.into_array();
+        let seq = Sequence::try_new_typed(0u32, 1u32, Nullability::NonNullable, 2048)?;
+        let seq_arr = seq.into_array();
+
+        // FoR fusions.
+        let for_bp = FoR::try_new(bp_arr.clone(), 100u32.into())?;
+        let sliced_bp = bp_arr.slice(100..1500)?;
+        let for_sliced_bp = FoR::try_new(sliced_bp, 100u32.into())?;
+
+        // With patches: some values exceed 2^4-1, creating overflow exceptions.
+        let values: Vec<u32> = (0..2048)
+            .map(|i| if i % 100 == 0 { 1000 } else { (i as u32) % 16 })
+            .collect();
+        let patched_bp = BitPacked::encode(
+            &PrimitiveArray::new(Buffer::from(values), NonNullable).into_array(),
+            4,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
+        assert!(patched_bp.patches().is_some(), "expected patches");
+        let patched_bp_arr = patched_bp.into_array();
+        let for_patched_bp = FoR::try_new(patched_bp_arr.clone(), 100u32.into())?;
+
+        for array in [
+            &bp_arr,
+            &seq_arr,
+            &for_bp.into_array(),
+            &for_sliced_bp.into_array(),
+            &patched_bp_arr,
+            &for_patched_bp.into_array(),
+        ] {
+            assert!(
+                plan_builder::has_standalone_kernel(array),
+                "expected has_standalone_kernel=true for {:?}",
+                array.encoding_id()
+            );
+            assert!(
+                cuda_session.kernel(&array.encoding_id()).is_some(),
+                "has_standalone_kernel=true but no kernel registered for {:?}",
+                array.encoding_id()
+            );
+        }
+
+        Ok(())
+    }
+
     #[crate::test]
     fn test_f64_rejected() {
         // F64 arrays should be rejected by the plan builder, not silently accepted.
         let values: Vec<f64> = vec![1.0, 2.0, 3.0];
         let primitive = PrimitiveArray::new(Buffer::from(values), NonNullable);
-        let plan = DispatchPlan::new(&primitive.into_array())
+        let plan = DispatchPlan::new(&primitive.into_array(), CudaDispatchMode::Auto)
             .expect("DispatchPlan::new should not fail for f64");
         assert!(
             matches!(plan, DispatchPlan::Unfused),
@@ -1775,7 +1886,7 @@ mod tests {
 
         // Ends (u32) are wider than values (u16), so the kernel would truncate
         // ends via load_element<T>. The plan builder rejects this as Unfused.
-        let plan = DispatchPlan::new(&array)?;
+        let plan = DispatchPlan::new(&array, CudaDispatchMode::Auto)?;
         assert!(
             matches!(plan, DispatchPlan::Unfused),
             "expected Unfused for RunEnd with wider ends"
@@ -1824,7 +1935,7 @@ mod tests {
         let dict = DictArray::try_new(codes_bp.into_array(), values_prim.into_array())?;
         let array = dict.into_array();
 
-        let plan = DispatchPlan::new(&array)?;
+        let plan = DispatchPlan::new(&array, CudaDispatchMode::Auto)?;
         assert!(
             matches!(plan, DispatchPlan::Fused(..)),
             "expected Fused for mixed-width Dict with BitPacked codes"
@@ -1868,7 +1979,7 @@ mod tests {
         let dict = DictArray::try_new(codes_bp.into_array(), values_prim.into_array())?;
         let array = dict.into_array();
 
-        let plan = DispatchPlan::new(&array)?;
+        let plan = DispatchPlan::new(&array, CudaDispatchMode::Auto)?;
         assert!(
             matches!(plan, DispatchPlan::Fused(..)),
             "expected Fused for mixed-width Dict with BitPacked codes"
@@ -1912,7 +2023,7 @@ mod tests {
         let dict = DictArray::try_new(codes_for.into_array(), values_prim.into_array())?;
         let array = dict.into_array();
 
-        let plan = DispatchPlan::new(&array)?;
+        let plan = DispatchPlan::new(&array, CudaDispatchMode::Auto)?;
         assert!(
             matches!(plan, DispatchPlan::Fused(..)),
             "expected Fused for mixed-width Dict with FoR(BitPacked) codes"
@@ -1969,7 +2080,7 @@ mod tests {
         let re = RunEnd::new(ends_bp.into_array(), values_prim.into_array(), &mut ctx);
         let array = re.into_array();
 
-        let plan = DispatchPlan::new(&array)?;
+        let plan = DispatchPlan::new(&array, CudaDispatchMode::Auto)?;
         assert!(
             matches!(plan, DispatchPlan::Fused(..)),
             "expected Fused for mixed-width RunEnd with BitPacked ends"
@@ -2015,7 +2126,7 @@ mod tests {
         let re = RunEnd::new(ends_for.into_array(), values_prim.into_array(), &mut ctx);
         let array = re.into_array();
 
-        let plan = DispatchPlan::new(&array)?;
+        let plan = DispatchPlan::new(&array, CudaDispatchMode::Auto)?;
         assert!(
             matches!(plan, DispatchPlan::Fused(..)),
             "expected Fused for mixed-width RunEnd with FoR(BitPacked) ends"
@@ -2207,10 +2318,10 @@ mod tests {
         // Verify the plan actually fuses (not just a LOAD).
         assert!(
             matches!(
-                DispatchPlan::new(&for_arr.clone().into_array())?,
-                DispatchPlan::Fused(_)
+                DispatchPlan::new(&for_arr.clone().into_array(), CudaDispatchMode::Auto)?,
+                DispatchPlan::Standalone | DispatchPlan::Fused(_)
             ),
-            "FoR(BitPacked) with nullable validity should produce a Fused plan"
+            "FoR(BitPacked) with nullable validity should be fusable"
         );
 
         let gpu = try_gpu_dispatch(&for_arr.into_array(), &mut cuda_ctx)
@@ -2269,7 +2380,7 @@ mod tests {
         let values = PrimitiveArray::new(buffer![10u32, 20, 30], NonNullable);
         let dict = DictArray::try_new(codes.into_array(), values.into_array())?;
 
-        let plan = DispatchPlan::new(&dict.into_array())?;
+        let plan = DispatchPlan::new(&dict.into_array(), CudaDispatchMode::Auto)?;
         assert!(
             matches!(plan, DispatchPlan::Unfused),
             "Dict with nullable codes should fall back to Unfused"

--- a/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
+++ b/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
@@ -47,6 +47,7 @@ use super::ptype_to_tag;
 use super::tag_to_ptype;
 use crate::CudaBufferExt;
 use crate::CudaExecutionCtx;
+use crate::executor::CudaDispatchMode;
 use crate::kernel::load_patches_to_gpu;
 
 /// A plan whose source buffers have been copied to the device, ready for kernel launch.
@@ -121,6 +122,33 @@ fn is_dyn_dispatch_compatible(array: &ArrayRef) -> bool {
         || id == Sequence.id()
 }
 
+/// Returns `true` if a registered standalone kernel can decode the entire
+/// `array` tree in a single launch without recursing into `execute_cuda`
+/// for child encodings.
+pub fn has_standalone_kernel(array: &ArrayRef) -> bool {
+    let id = array.encoding_id();
+
+    // Leaf encodings: no children to recurse into.
+    if id == BitPacked.id() || id == Sequence.id() {
+        return true;
+    }
+
+    // FoR fuses with BitPacked (FFOR) and Slice(BitPacked) in one launch.
+    if id == FoR.id() {
+        let for_arr = array.as_::<FoR>();
+        let child = for_arr.encoded();
+        if child.encoding_id() == BitPacked.id() {
+            return true;
+        }
+        if let Some(slice) = child.as_opt::<Slice>() {
+            return slice.child().encoding_id() == BitPacked.id();
+        }
+        return false;
+    }
+
+    false
+}
+
 /// An unmaterialized stage: a source op, scalar ops, and optional source buffer reference.
 ///
 /// Patches are tied to their owning ops, mirroring the CUDA side where
@@ -160,6 +188,9 @@ type OutputLen = u32;
 /// Constructed by [`DispatchPlan::new`], which inspects the encoding tree
 /// and determines whether it can be fully fused, partially fused, or not fused at all.
 pub enum DispatchPlan {
+    /// A registered standalone kernel can decode the entire tree in a single
+    /// launch without recursing into child encodings.
+    Standalone,
     /// Entire encoding tree is fusable into a single kernel launch.
     Fused(FusedPlan),
     /// Some subtrees need separate execution before the fused plan can run.
@@ -227,7 +258,11 @@ impl DispatchPlan {
     ///   nullable ends are rejected to guard against out-of-bounds access.
     /// - `BitPackedArray` and `ALPArray` with patches are supported.
     /// - Only f32 ALP is supported (kernel stores multipliers as `float`).
-    pub fn new(array: &ArrayRef) -> VortexResult<Self> {
+    pub fn new(array: &ArrayRef, mode: CudaDispatchMode) -> VortexResult<Self> {
+        if mode == CudaDispatchMode::Auto && has_standalone_kernel(array) {
+            return Ok(Self::Standalone);
+        }
+
         if PType::try_from(array.dtype()).is_err() || !is_dyn_dispatch_compatible(array) {
             return Ok(Self::Unfused);
         }

--- a/vortex-cuda/src/hybrid_dispatch/mod.rs
+++ b/vortex-cuda/src/hybrid_dispatch/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Hybrid dispatch: fuses dynamic-dispatch plans with single-kernel fallbacks.
+//! Hybrid dispatch: routes arrays to standalone kernels or fused dynamic-dispatch plans.
 //!
 //! When an array is executed on the GPU, we fuse as much of its encoding
 //! tree as possible into a single kernel launch via [`DispatchPlan`].
@@ -18,10 +18,15 @@
 //!
 //! Strategies tried in order:
 //!
-//! 1. Fully fused — no unfusable nodes, entire tree compiles into one
+//! 1. Standalone — a registered kernel covers the entire tree in a single
+//!    launch without recursing into child encodings. Preferred when applicable
+//!    because the kernel is hand-tuned for that exact scenario. Detected by
+//!    `has_standalone_kernel`.
+//!
+//! 2. Fully fused — no unfusable nodes, entire tree compiles into one
 //!    [`DispatchPlan`] → `MaterializedPlan` → kernel launch.
 //!
-//! 2. Partial fusion — `pending_subtrees` from the `PartiallyFused`
+//! 3. Partial fusion — `pending_subtrees` from the `PartiallyFused`
 //!    variant are executed first (sequentially, same stream), their device buffers
 //!    become `LOAD` ops in a fused plan via `FusedPlan::materialize_with_subtrees`.
 //!    Each subtree re-enters [`try_gpu_dispatch`] and may itself fuse.
@@ -30,10 +35,10 @@
 //!    happens in-kernel via `load_element<T>()` in the LOAD source op — no
 //!    separate widen pass is needed.
 //!
-//! 3. Fallback — root is not fusable. Delegate to its registered
+//! 4. Fallback — root is not fusable. Delegate to its registered
 //!    `CudaExecute` kernel; its children re-enter [`try_gpu_dispatch`].
 //!
-//! All three compose recursively to arbitrary depth.
+//! All four compose recursively.
 //!
 //! Zone-map pruning is handled by ZonedReader before chunks reach the plan
 //! builder. Filtering within a chunk is done after decompression, not as push-down.
@@ -55,12 +60,14 @@ use crate::dynamic_dispatch::plan_builder::DispatchPlan;
 use crate::executor::CudaArrayExt;
 use crate::executor::CudaExecutionCtx;
 
-/// Try to execute `array` on the GPU, attempting three strategies in order:
+/// Try to execute `array` on the GPU, attempting four strategies in order:
 ///
-/// 1. Fully fused — [`DispatchPlan::new`] + `FusedPlan::materialize`.
-/// 2. Partially fused — pending subtrees executed first, then
+/// 1. Standalone — a registered kernel covers the entire tree without
+///    recursing into child encodings (e.g. FFOR, ALP(Primitive)).
+/// 2. Fully fused — [`DispatchPlan::new`] + `FusedPlan::materialize`.
+/// 3. Partially fused — pending subtrees executed first, then
 ///    `FusedPlan::materialize_with_subtrees`.
-/// 3. Fallback — root encoding's `CudaExecute` kernel; children
+/// 4. Fallback — root encoding's `CudaExecute` kernel; children
 ///    re-enter this function recursively.
 ///
 /// Returns `Ok(Canonical)` on success. Returns `Err` when the array
@@ -85,7 +92,17 @@ pub async fn try_gpu_dispatch(
             .await;
     }
 
-    match DispatchPlan::new(array)? {
+    match DispatchPlan::new(array, ctx.dispatch_mode())? {
+        DispatchPlan::Standalone => {
+            trace!(encoding = %array.encoding_id(), "standalone dispatch");
+            ctx.cuda_session()
+                .kernel(&array.encoding_id())
+                .ok_or_else(|| {
+                    vortex_err!("No CUDA kernel for encoding {:?}", array.encoding_id())
+                })?
+                .execute(array.clone(), ctx)
+                .await
+        }
         DispatchPlan::Fused(plan) => {
             let materialized = plan.materialize(ctx).await?;
             let num_stages = materialized.dispatch_plan.num_stages();


### PR DESCRIPTION
In `auto` dispatch mode, `try_gpu_dispatch` now checks `has_standalone_kernel` before the dynamic-dispatch plan builder.

Standalone kernels are preferred when they can decode the entire tree in a single launch without recursing into `execute_cuda` for child encodings.