### PR TITLE
Rename `ScalarValue::List` to `ScalarValue::Tuple`

### DIFF
--- a/encodings/parquet-variant/src/operations.rs
+++ b/encodings/parquet-variant/src/operations.rs
@@ -214,7 +214,7 @@ fn scalar_from_shredded_object_scalar(
     let fields = StructFields::new(FieldNames::from(names), dtypes);
     Scalar::try_new(
         DType::Struct(fields, Nullability::NonNullable),
-        Some(ScalarValue::List(field_values)),
+        Some(ScalarValue::Tuple(field_values)),
     )
 }
 
@@ -330,7 +330,7 @@ fn parquet_variant_to_scalar(variant: PqVariant<'_, '_>) -> VortexResult<Scalar>
             let fields = StructFields::new(FieldNames::from(names), dtypes);
             Scalar::try_new(
                 DType::Struct(fields, nn),
-                Some(ScalarValue::List(field_values)),
+                Some(ScalarValue::Tuple(field_values)),
             )?
         }
     })

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -13960,9 +13960,9 @@ pub vortex_array::scalar::ScalarValue::Bool(bool)
 
 pub vortex_array::scalar::ScalarValue::Decimal(vortex_array::scalar::DecimalValue)
 
-pub vortex_array::scalar::ScalarValue::List(alloc::vec::Vec<core::option::Option<vortex_array::scalar::ScalarValue>>)
-
 pub vortex_array::scalar::ScalarValue::Primitive(vortex_array::scalar::PValue)
+
+pub vortex_array::scalar::ScalarValue::Tuple(alloc::vec::Vec<core::option::Option<vortex_array::scalar::ScalarValue>>)
 
 pub vortex_array::scalar::ScalarValue::Utf8(vortex_buffer::string::BufferString)
 

--- a/vortex-array/src/scalar/arbitrary.rs
+++ b/vortex-array/src/scalar/arbitrary.rs
@@ -66,7 +66,7 @@ pub fn random_scalar(u: &mut Unstructured, dtype: &DType) -> Result<Scalar> {
         .vortex_expect("unable to construct random `Scalar`_"),
         DType::Struct(sdt, _) => Scalar::try_new(
             dtype.clone(),
-            Some(ScalarValue::List(
+            Some(ScalarValue::Tuple(
                 sdt.fields()
                     .map(|d| random_scalar(u, &d).map(|s| s.into_value()))
                     .collect::<Result<Vec<_>>>()?,
@@ -75,7 +75,7 @@ pub fn random_scalar(u: &mut Unstructured, dtype: &DType) -> Result<Scalar> {
         .vortex_expect("unable to construct random `Scalar`_"),
         DType::List(edt, _) => Scalar::try_new(
             dtype.clone(),
-            Some(ScalarValue::List(
+            Some(ScalarValue::Tuple(
                 iter::from_fn(|| {
                     // Generate elements with 1/4 probability.
                     u.arbitrary()
@@ -88,7 +88,7 @@ pub fn random_scalar(u: &mut Unstructured, dtype: &DType) -> Result<Scalar> {
         .vortex_expect("unable to construct random `Scalar`_"),
         DType::FixedSizeList(edt, size, _) => Scalar::try_new(
             dtype.clone(),
-            Some(ScalarValue::List(
+            Some(ScalarValue::Tuple(
                 (0..*size)
                     .map(|_| random_scalar(u, edt).map(|s| s.into_value()))
                     .collect::<Result<Vec<_>>>()?,

--- a/vortex-array/src/scalar/constructor.rs
+++ b/vortex-array/src/scalar/constructor.rs
@@ -166,7 +166,7 @@ impl Scalar {
             ListKind::FixedSize => DType::FixedSizeList(element_dtype, size, nullability),
         };
 
-        Self::try_new(dtype, Some(ScalarValue::List(children)))
+        Self::try_new(dtype, Some(ScalarValue::Tuple(children)))
             .vortex_expect("unable to construct a list `Scalar`")
     }
 

--- a/vortex-array/src/scalar/convert/into_scalar.rs
+++ b/vortex-array/src/scalar/convert/into_scalar.rs
@@ -82,7 +82,7 @@ where
     Scalar: From<T>,
 {
     fn from(vec: Vec<T>) -> Self {
-        ScalarValue::List(
+        ScalarValue::Tuple(
             vec.into_iter()
                 .map(|elem| Scalar::from(elem).into_value())
                 .collect(),

--- a/vortex-array/src/scalar/downcast.rs
+++ b/vortex-array/src/scalar/downcast.rs
@@ -115,12 +115,13 @@ impl Scalar {
 
     /// Returns a view of the scalar as a list scalar.
     ///
-    /// Note that we use [`ListScalar`] to represent **both** [`List`](crate::dtype::DType::List) and
-    /// [`FixedSizeList`](crate::dtype::DType::FixedSizeList).
+    /// Note that we use [`ListScalar`] to represent **both** [`List`](crate::dtype::DType::List)
+    /// and [`FixedSizeList`](crate::dtype::DType::FixedSizeList).
     ///
     /// # Panics
     ///
-    /// Panics if the scalar does not have a [`List`](crate::dtype::DType::List) or [`FixedSizeList`](crate::dtype::DType::FixedSizeList) type.
+    /// Panics if the scalar does not have a [`List`](crate::dtype::DType::List) or
+    /// [`FixedSizeList`](crate::dtype::DType::FixedSizeList) type.
     pub fn as_list(&self) -> ListScalar<'_> {
         self.as_list_opt()
             .vortex_expect("Failed to convert scalar to list")
@@ -128,8 +129,8 @@ impl Scalar {
 
     /// Returns a view of the scalar as a list scalar if it has a list type.
     ///
-    /// Note that we use [`ListScalar`] to represent **both** [`List`](crate::dtype::DType::List) and
-    /// [`FixedSizeList`](crate::dtype::DType::FixedSizeList).
+    /// Note that we use [`ListScalar`] to represent **both** [`List`](crate::dtype::DType::List)
+    /// and [`FixedSizeList`](crate::dtype::DType::FixedSizeList).
     pub fn as_list_opt(&self) -> Option<ListScalar<'_>> {
         ListScalar::try_new(self.dtype(), self.value()).ok()
     }
@@ -172,7 +173,7 @@ impl Scalar {
 }
 
 impl ScalarValue {
-    /// Returns the boolean value, panicking if the value is not a [`Bool`][ScalarValue::Bool].
+    /// Returns the boolean value, panicking if the value is not a [`Bool`](ScalarValue::Bool).
     pub fn as_bool(&self) -> bool {
         match self {
             ScalarValue::Bool(b) => *b,
@@ -181,7 +182,7 @@ impl ScalarValue {
     }
 
     /// Returns the primitive value, panicking if the value is not a
-    /// [`Primitive`][ScalarValue::Primitive].
+    /// [`Primitive`](ScalarValue::Primitive).
     pub fn as_primitive(&self) -> &PValue {
         match self {
             ScalarValue::Primitive(p) => p,
@@ -190,7 +191,7 @@ impl ScalarValue {
     }
 
     /// Returns the decimal value, panicking if the value is not a
-    /// [`Decimal`][ScalarValue::Decimal].
+    /// [`Decimal`](ScalarValue::Decimal).
     pub fn as_decimal(&self) -> &DecimalValue {
         match self {
             ScalarValue::Decimal(d) => d,
@@ -198,7 +199,7 @@ impl ScalarValue {
         }
     }
 
-    /// Returns the UTF-8 string value, panicking if the value is not a [`Utf8`][ScalarValue::Utf8].
+    /// Returns the UTF-8 string value, panicking if the value is not a [`Utf8`](ScalarValue::Utf8).
     pub fn as_utf8(&self) -> &BufferString {
         match self {
             ScalarValue::Utf8(s) => s,
@@ -206,7 +207,7 @@ impl ScalarValue {
         }
     }
 
-    /// Returns the binary value, panicking if the value is not a [`Binary`][ScalarValue::Binary].
+    /// Returns the binary value, panicking if the value is not a [`Binary`](ScalarValue::Binary).
     pub fn as_binary(&self) -> &ByteBuffer {
         match self {
             ScalarValue::Binary(b) => b,
@@ -214,15 +215,15 @@ impl ScalarValue {
         }
     }
 
-    /// Returns the list elements, panicking if the value is not a [`List`][ScalarValue::List].
+    /// Returns the tuple elements, panicking if the value is not a [`Tuple`](ScalarValue::Tuple).
     pub fn as_list(&self) -> &[Option<ScalarValue>] {
         match self {
-            ScalarValue::List(elements) => elements,
-            _ => vortex_panic!("ScalarValue is not a List"),
+            ScalarValue::Tuple(elements) => elements,
+            _ => vortex_panic!("ScalarValue is not a Tuple"),
         }
     }
 
-    /// Returns the boolean value, panicking if the value is not a [`Bool`][ScalarValue::Bool].
+    /// Returns the boolean value, panicking if the value is not a [`Bool`](ScalarValue::Bool).
     pub fn into_bool(self) -> bool {
         match self {
             ScalarValue::Bool(b) => b,
@@ -231,7 +232,7 @@ impl ScalarValue {
     }
 
     /// Returns the primitive value, panicking if the value is not a
-    /// [`Primitive`][ScalarValue::Primitive].
+    /// [`Primitive`](ScalarValue::Primitive).
     pub fn into_primitive(self) -> PValue {
         match self {
             ScalarValue::Primitive(p) => p,
@@ -240,7 +241,7 @@ impl ScalarValue {
     }
 
     /// Returns the decimal value, panicking if the value is not a
-    /// [`Decimal`][ScalarValue::Decimal].
+    /// [`Decimal`](ScalarValue::Decimal).
     pub fn into_decimal(self) -> DecimalValue {
         match self {
             ScalarValue::Decimal(d) => d,
@@ -248,7 +249,7 @@ impl ScalarValue {
         }
     }
 
-    /// Returns the UTF-8 string value, panicking if the value is not a [`Utf8`][ScalarValue::Utf8].
+    /// Returns the UTF-8 string value, panicking if the value is not a [`Utf8`](ScalarValue::Utf8).
     pub fn into_utf8(self) -> BufferString {
         match self {
             ScalarValue::Utf8(s) => s,
@@ -256,7 +257,7 @@ impl ScalarValue {
         }
     }
 
-    /// Returns the binary value, panicking if the value is not a [`Binary`][ScalarValue::Binary].
+    /// Returns the binary value, panicking if the value is not a [`Binary`](ScalarValue::Binary).
     pub fn into_binary(self) -> ByteBuffer {
         match self {
             ScalarValue::Binary(b) => b,
@@ -264,11 +265,11 @@ impl ScalarValue {
         }
     }
 
-    /// Returns the list elements, panicking if the value is not a [`List`][ScalarValue::List].
+    /// Returns the tuple elements, panicking if the value is not a [`Tuple`](ScalarValue::Tuple).
     pub fn into_list(self) -> Vec<Option<ScalarValue>> {
         match self {
-            ScalarValue::List(elements) => elements,
-            _ => vortex_panic!("ScalarValue is not a List"),
+            ScalarValue::Tuple(elements) => elements,
+            _ => vortex_panic!("ScalarValue is not a Tuple"),
         }
     }
 

--- a/vortex-array/src/scalar/proto.rs
+++ b/vortex-array/src/scalar/proto.rs
@@ -101,7 +101,7 @@ impl From<&ScalarValue> for pb::ScalarValue {
             ScalarValue::Binary(v) => pb::ScalarValue {
                 kind: Some(Kind::BytesValue(v.to_vec())),
             },
-            ScalarValue::List(v) => {
+            ScalarValue::Tuple(v) => {
                 let mut values = Vec::with_capacity(v.len());
                 for elem in v.iter() {
                     values.push(ScalarValue::to_proto(elem.as_ref()));
@@ -435,7 +435,7 @@ fn bytes_from_proto(bytes: &[u8], dtype: &DType) -> VortexResult<ScalarValue> {
     }
 }
 
-/// Deserialize a [`ScalarValue::List`] from a protobuf `ListValue`.
+/// Deserialize a [`ScalarValue::Tuple`] from a protobuf `ListValue`.
 fn list_from_proto(
     v: &ListValue,
     dtype: &DType,
@@ -454,7 +454,7 @@ fn list_from_proto(
         )?);
     }
 
-    Ok(ScalarValue::List(values))
+    Ok(ScalarValue::Tuple(values))
 }
 
 #[cfg(test)]
@@ -531,7 +531,7 @@ mod tests {
                 Arc::new(DType::Primitive(PType::I32, Nullability::Nullable)),
                 Nullability::Nullable,
             ),
-            Some(ScalarValue::List(vec![
+            Some(ScalarValue::Tuple(vec![
                 Some(ScalarValue::Primitive(42i32.into())),
                 Some(ScalarValue::Primitive(43i32.into())),
             ])),

--- a/vortex-array/src/scalar/scalar_value.rs
+++ b/vortex-array/src/scalar/scalar_value.rs
@@ -33,8 +33,10 @@ pub enum ScalarValue {
     Utf8(BufferString),
     /// A binary (byte array) value.
     Binary(ByteBuffer),
-    /// A list of potentially null scalar values.
-    List(Vec<Option<ScalarValue>>),
+    /// A tuple of potentially null scalar values.
+    ///
+    /// Used as the underlying representation for list, fixed-size list, and struct scalars.
+    Tuple(Vec<Option<ScalarValue>>),
     /// A row-specific scalar wrapped by `DType::Variant`.
     Variant(Box<Scalar>),
 }
@@ -49,17 +51,17 @@ impl ScalarValue {
             DType::Decimal(dt, ..) => Self::Decimal(DecimalValue::zero(dt)),
             DType::Utf8(_) => Self::Utf8(BufferString::empty()),
             DType::Binary(_) => Self::Binary(ByteBuffer::empty()),
-            DType::List(..) => Self::List(vec![]),
+            DType::List(..) => Self::Tuple(vec![]),
             DType::FixedSizeList(edt, size, _) => {
                 let elements = (0..*size).map(|_| Some(Self::zero_value(edt))).collect();
-                Self::List(elements)
+                Self::Tuple(elements)
             }
             DType::Struct(fields, _) => {
                 let field_values = fields
                     .fields()
                     .map(|f| Some(Self::zero_value(&f)))
                     .collect();
-                Self::List(field_values)
+                Self::Tuple(field_values)
             }
             DType::Extension(ext_dtype) => {
                 // Since we have no way to define a "zero" extension value (since we have no idea
@@ -89,14 +91,14 @@ impl ScalarValue {
             DType::Decimal(dt, ..) => Self::Decimal(DecimalValue::zero(dt)),
             DType::Utf8(_) => Self::Utf8(BufferString::empty()),
             DType::Binary(_) => Self::Binary(ByteBuffer::empty()),
-            DType::List(..) => Self::List(vec![]),
+            DType::List(..) => Self::Tuple(vec![]),
             DType::FixedSizeList(edt, size, _) => {
                 let elements = (0..*size).map(|_| Self::default_value(edt)).collect();
-                Self::List(elements)
+                Self::Tuple(elements)
             }
             DType::Struct(fields, _) => {
                 let field_values = fields.fields().map(|f| Self::default_value(&f)).collect();
-                Self::List(field_values)
+                Self::Tuple(field_values)
             }
             DType::Extension(ext_dtype) => {
                 // Since we have no way to define a "default" extension value (since we have no idea
@@ -117,7 +119,7 @@ impl PartialOrd for ScalarValue {
             (ScalarValue::Decimal(a), ScalarValue::Decimal(b)) => a.partial_cmp(b),
             (ScalarValue::Utf8(a), ScalarValue::Utf8(b)) => a.partial_cmp(b),
             (ScalarValue::Binary(a), ScalarValue::Binary(b)) => a.partial_cmp(b),
-            (ScalarValue::List(a), ScalarValue::List(b)) => a.partial_cmp(b),
+            (ScalarValue::Tuple(a), ScalarValue::Tuple(b)) => a.partial_cmp(b),
             (ScalarValue::Variant(a), ScalarValue::Variant(b)) => a.partial_cmp(b),
             // (ScalarValue::Extension(a), ScalarValue::Extension(b)) => a.partial_cmp(b),
             _ => None,
@@ -156,7 +158,7 @@ impl Display for ScalarValue {
                     write!(f, "{}", to_hex(b))
                 }
             }
-            ScalarValue::List(elements) => {
+            ScalarValue::Tuple(elements) => {
                 write!(f, "[")?;
                 for (i, element) in elements.iter().enumerate() {
                     if i > 0 {

--- a/vortex-array/src/scalar/tests/casting.rs
+++ b/vortex-array/src/scalar/tests/casting.rs
@@ -152,7 +152,7 @@ mod tests {
             Some(ScalarValue::Primitive(PValue::F32(f32_value))),
         ];
 
-        let scalar = Scalar::new(struct_dtype, Some(ScalarValue::List(field_values)));
+        let scalar = Scalar::new(struct_dtype, Some(ScalarValue::Tuple(field_values)));
 
         let struct_scalar = scalar.as_struct();
         let fields: Vec<_> = (0..3)
@@ -209,7 +209,7 @@ mod tests {
             ))),
         ];
 
-        let scalar = Scalar::new(list_dtype, Some(ScalarValue::List(elements)));
+        let scalar = Scalar::new(list_dtype, Some(ScalarValue::Tuple(elements)));
 
         let list_scalar = scalar.as_list();
         let elements = list_scalar.elements().unwrap();
@@ -353,7 +353,7 @@ mod tests {
 
         let scalar = Scalar::new(
             DType::Extension(ext_dtype.erased()),
-            Some(ScalarValue::List(field_values)),
+            Some(ScalarValue::Tuple(field_values)),
         );
 
         // Verify the struct field was coerced

--- a/vortex-array/src/scalar/tests/nested.rs
+++ b/vortex-array/src/scalar/tests/nested.rs
@@ -311,7 +311,7 @@ mod tests {
                 Arc::from(DType::Primitive(PType::U16, Nullability::Nullable)),
                 Nullability::Nullable,
             ),
-            Some(ScalarValue::List(vec![
+            Some(ScalarValue::Tuple(vec![
                 Some(ScalarValue::Primitive(PValue::U16(6))),
                 Some(ScalarValue::Primitive(PValue::U16(100))),
             ])),
@@ -350,7 +350,7 @@ mod tests {
                 Arc::from(DType::Primitive(PType::U16, Nullability::Nullable)),
                 Nullability::Nullable,
             ),
-            Some(ScalarValue::List(vec![
+            Some(ScalarValue::Tuple(vec![
                 Some(ScalarValue::Primitive(PValue::U16(100))),
                 Some(ScalarValue::Primitive(PValue::U16(256))), // Too large for U8
                 Some(ScalarValue::Primitive(PValue::U16(1000))), // Too large for U8

--- a/vortex-array/src/scalar/tests/nullability.rs
+++ b/vortex-array/src/scalar/tests/nullability.rs
@@ -54,7 +54,7 @@ mod tests {
                 Arc::from(DType::Primitive(PType::U16, Nullability::Nullable)),
                 Nullability::Nullable,
             ),
-            Some(ScalarValue::List(vec![Some(ScalarValue::Primitive(
+            Some(ScalarValue::Tuple(vec![Some(ScalarValue::Primitive(
                 PValue::U16(6),
             ))])),
         );
@@ -97,7 +97,7 @@ mod tests {
                 Arc::from(DType::Primitive(PType::U16, Nullability::Nullable)),
                 Nullability::Nullable,
             ),
-            Some(ScalarValue::List(vec![
+            Some(ScalarValue::Tuple(vec![
                 Some(ScalarValue::Primitive(PValue::U16(6))),
                 None,
                 Some(ScalarValue::Primitive(PValue::U16(10))),
@@ -200,7 +200,7 @@ mod tests {
                 Arc::from(DType::Primitive(PType::U16, Nullability::Nullable)),
                 Nullability::Nullable,
             ),
-            Some(ScalarValue::List(vec![
+            Some(ScalarValue::Tuple(vec![
                 Some(ScalarValue::Primitive(PValue::U16(6))),
                 None,
             ])),

--- a/vortex-array/src/scalar/typed_view/list.rs
+++ b/vortex-array/src/scalar/typed_view/list.rs
@@ -207,7 +207,7 @@ impl<'a> ListScalar<'a> {
 
         Scalar::try_new(
             dtype.clone(),
-            Some(ScalarValue::List(
+            Some(ScalarValue::Tuple(
                 self.elements
                     .ok_or_else(|| vortex_err!("nullness should be handled in Scalar::cast"))?
                     .iter()

--- a/vortex-array/src/scalar/typed_view/struct_.rs
+++ b/vortex-array/src/scalar/typed_view/struct_.rs
@@ -236,7 +236,7 @@ impl<'a> StructScalar<'a> {
                     .map(|s| s.into_value())
                 })
                 .collect::<VortexResult<Vec<_>>>()?;
-            Scalar::try_new(dtype.clone(), Some(ScalarValue::List(fields)))
+            Scalar::try_new(dtype.clone(), Some(ScalarValue::Tuple(fields)))
         } else {
             Ok(Scalar::null(dtype.clone()))
         }
@@ -261,7 +261,7 @@ impl<'a> StructScalar<'a> {
             return Ok(Scalar::null(projected_dtype));
         };
 
-        let new_fields = ScalarValue::List(
+        let new_fields = ScalarValue::Tuple(
             projection
                 .iter()
                 .map(|name| {
@@ -306,7 +306,7 @@ impl Scalar {
         }
 
         let value_children: Vec<_> = children.into_iter().map(|x| x.into_value()).collect();
-        Self::try_new(dtype, Some(ScalarValue::List(value_children)))
+        Self::try_new(dtype, Some(ScalarValue::Tuple(value_children)))
             .vortex_expect("unable to construct a struct `Scalar`")
     }
 
@@ -323,7 +323,7 @@ impl Scalar {
         children: impl IntoIterator<Item = Scalar>,
     ) -> Self {
         let value_children: Vec<_> = children.into_iter().map(|s| s.into_value()).collect();
-        unsafe { Self::new_unchecked(dtype, Some(ScalarValue::List(value_children))) }
+        unsafe { Self::new_unchecked(dtype, Some(ScalarValue::Tuple(value_children))) }
     }
 }
 

--- a/vortex-array/src/scalar/validate.rs
+++ b/vortex-array/src/scalar/validate.rs
@@ -74,8 +74,8 @@ impl Scalar {
                 );
             }
             DType::List(elem_dtype, _) => {
-                let ScalarValue::List(elements) = value else {
-                    vortex_bail!("list dtype expected List value, got {value}");
+                let ScalarValue::Tuple(elements) = value else {
+                    vortex_bail!("list dtype expected Tuple value, got {value}");
                 };
 
                 for (i, element) in elements.iter().enumerate() {
@@ -84,8 +84,8 @@ impl Scalar {
                 }
             }
             DType::FixedSizeList(elem_dtype, size, _) => {
-                let ScalarValue::List(elements) = value else {
-                    vortex_bail!("fixed-size list dtype expected List value, got {value}",);
+                let ScalarValue::Tuple(elements) = value else {
+                    vortex_bail!("fixed-size list dtype expected Tuple value, got {value}",);
                 };
 
                 let len = elements.len();
@@ -102,8 +102,8 @@ impl Scalar {
                 }
             }
             DType::Struct(fields, _) => {
-                let ScalarValue::List(values) = value else {
-                    vortex_bail!("struct dtype expected List value, got {value}");
+                let ScalarValue::Tuple(values) = value else {
+                    vortex_bail!("struct dtype expected Tuple value, got {value}");
                 };
 
                 let nfields = fields.nfields();


### PR DESCRIPTION
## Summary

This is a better name for what it actually is, where every value can have a different type. And given that we want `ScalarValue::Array` for list scalars soon this makes more sense.

## API Changes

Renames the variant.

## Testing

N/A since this is a rename.