### PR TITLE
make all scalar view types `Copy`

### DIFF
--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -214,7 +214,7 @@ fn execute_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
         } else {
             // Set with the fill value.
             builder
-                .append_value(fill_value.clone())
+                .append_value(fill_value)
                 .vortex_expect("Failed to append fill value");
         }
     }

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -14248,6 +14248,8 @@ impl<'a> core::hash::Hash for vortex_array::scalar::BinaryScalar<'a>
 
 pub fn vortex_array::scalar::BinaryScalar<'a>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 
+impl<'a> core::marker::Copy for vortex_array::scalar::BinaryScalar<'a>
+
 pub struct vortex_array::scalar::BoolScalar<'a>
 
 impl<'a> vortex_array::scalar::BoolScalar<'a>
@@ -14297,6 +14299,8 @@ pub fn vortex_array::scalar::BoolScalar<'a>::fmt(&self, f: &mut core::fmt::Forma
 impl<'a> core::hash::Hash for vortex_array::scalar::BoolScalar<'a>
 
 pub fn vortex_array::scalar::BoolScalar<'a>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl<'a> core::marker::Copy for vortex_array::scalar::BoolScalar<'a>
 
 pub struct vortex_array::scalar::DecimalScalar<'a>
 
@@ -14464,6 +14468,8 @@ impl<'a> core::fmt::Debug for vortex_array::scalar::ExtScalar<'a>
 
 pub fn vortex_array::scalar::ExtScalar<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
+impl<'a> core::marker::Copy for vortex_array::scalar::ExtScalar<'a>
+
 pub struct vortex_array::scalar::ListScalar<'a>
 
 impl<'a> vortex_array::scalar::ListScalar<'a>
@@ -14515,6 +14521,8 @@ pub fn vortex_array::scalar::ListScalar<'a>::try_from(value: &'a vortex_array::s
 impl<'a> core::fmt::Debug for vortex_array::scalar::ListScalar<'a>
 
 pub fn vortex_array::scalar::ListScalar<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<'a> core::marker::Copy for vortex_array::scalar::ListScalar<'a>
 
 pub struct vortex_array::scalar::PrimitiveScalar<'a>
 
@@ -15310,6 +15318,8 @@ impl<'a> core::fmt::Debug for vortex_array::scalar::StructScalar<'a>
 
 pub fn vortex_array::scalar::StructScalar<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
+impl<'a> core::marker::Copy for vortex_array::scalar::StructScalar<'a>
+
 pub struct vortex_array::scalar::Utf8Scalar<'a>
 
 impl<'a> vortex_array::scalar::Utf8Scalar<'a>
@@ -15359,6 +15369,8 @@ pub fn vortex_array::scalar::Utf8Scalar<'a>::fmt(&self, f: &mut core::fmt::Forma
 impl<'a> core::hash::Hash for vortex_array::scalar::Utf8Scalar<'a>
 
 pub fn vortex_array::scalar::Utf8Scalar<'a>::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl<'a> core::marker::Copy for vortex_array::scalar::Utf8Scalar<'a>
 
 pub struct vortex_array::scalar::VariantScalar<'a>
 

--- a/vortex-array/src/scalar/typed_view/binary.rs
+++ b/vortex-array/src/scalar/typed_view/binary.rs
@@ -20,7 +20,7 @@ use crate::scalar::ScalarValue;
 ///
 /// This type provides a view into a binary scalar value, which can be either
 /// a valid byte buffer or null.
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Copy, Hash)]
 pub struct BinaryScalar<'a> {
     /// The data type of this scalar.
     dtype: &'a DType,

--- a/vortex-array/src/scalar/typed_view/bool.rs
+++ b/vortex-array/src/scalar/typed_view/bool.rs
@@ -19,7 +19,7 @@ use crate::scalar::ScalarValue;
 ///
 /// This type provides a view into a boolean scalar value, which can be either
 /// true, false, or null.
-#[derive(Debug, Clone, Hash, Eq)]
+#[derive(Debug, Clone, Copy, Hash, Eq)]
 pub struct BoolScalar<'a> {
     /// The data type of this scalar.
     dtype: &'a DType,

--- a/vortex-array/src/scalar/typed_view/extension/mod.rs
+++ b/vortex-array/src/scalar/typed_view/extension/mod.rs
@@ -19,7 +19,7 @@ use crate::scalar::ScalarValue;
 /// A scalar value representing an extension type.
 ///
 /// Extension types allow wrapping a storage type with custom semantics.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ExtScalar<'a> {
     /// A reference to the `DType` of the extension type. This **must** be the [`DType::Extension`]
     /// variant.

--- a/vortex-array/src/scalar/typed_view/list.rs
+++ b/vortex-array/src/scalar/typed_view/list.rs
@@ -29,7 +29,7 @@ use crate::scalar::ScalarValue;
 /// number of `elements` is equal to the `size` field of the [`FixedSizeList`].
 ///
 /// [`FixedSizeList`]: DType::FixedSizeList
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ListScalar<'a> {
     /// The data type of this scalar.
     dtype: &'a DType,

--- a/vortex-array/src/scalar/typed_view/struct_.rs
+++ b/vortex-array/src/scalar/typed_view/struct_.rs
@@ -27,7 +27,7 @@ use crate::scalar::ScalarValue;
 ///
 /// This type provides a view into a struct scalar value, which can contain
 /// named fields with different types, or be null.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct StructScalar<'a> {
     /// The data type of this scalar.
     dtype: &'a DType,

--- a/vortex-array/src/scalar/typed_view/utf8.rs
+++ b/vortex-array/src/scalar/typed_view/utf8.rs
@@ -22,7 +22,7 @@ use crate::scalar::ScalarValue;
 ///
 /// This type provides a view into a UTF-8 string scalar value, which can be either
 /// a valid UTF-8 string or null.
-#[derive(Debug, Clone, Hash, Eq)]
+#[derive(Debug, Clone, Copy, Hash, Eq)]
 pub struct Utf8Scalar<'a> {
     /// The data type of this scalar.
     dtype: &'a DType,


### PR DESCRIPTION
## Summary

Closes: https://github.com/vortex-data/vortex/issues/4844

## API Changes

Adds `Copy` impl for all scalar view types.

## Testing

N/A