### PR TITLE
feat(ffi): add literal expression support

### DIFF
--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -1106,6 +1106,44 @@ void vx_expression_free(vx_expression *ptr);
 vx_expression *vx_expression_root(void);
 
 /**
+ * Create a literal boolean expression.
+ */
+vx_expression *vx_expression_literal_bool(bool value, bool is_nullable);
+
+/**
+ * Create a literal primitive expression.
+ *
+ * `value` must point to one value of the C type corresponding to `ptype`.
+ * For `PTYPE_F16`, the value is represented as `uint16_t`.
+ * If `value` is NULL, returns NULL.
+ */
+vx_expression *vx_expression_literal_primitive(vx_ptype ptype, const void *value, bool is_nullable);
+
+/**
+ * Create a literal UTF-8 expression.
+ *
+ * The input string is borrowed and copied into the returned expression.
+ * If `value` is NULL, returns NULL.
+ */
+vx_expression *vx_expression_literal_utf8(const vx_string *value, bool is_nullable);
+
+/**
+ * Create a literal binary expression.
+ *
+ * The input bytes are borrowed and copied into the returned expression.
+ * If `value` is NULL, returns NULL.
+ */
+vx_expression *vx_expression_literal_binary(const vx_binary *value, bool is_nullable);
+
+/**
+ * Create a typed null literal expression.
+ *
+ * The null literal uses a nullable version of `dtype`.
+ * If `dtype` is NULL, returns NULL.
+ */
+vx_expression *vx_expression_literal_null(const vx_dtype *dtype);
+
+/**
  * Create an expression that selects (includes) specific fields from a child
  * expression. Child expression must have a DTYPE_STRUCT dtype. Errors in
  * vx_array_apply if the child expression doesn't have a specified field.

--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -490,13 +490,12 @@ typedef struct vx_file vx_file;
 typedef struct vx_partition vx_partition;
 
 /**
- * A `vx_scalar` stores a logical `DType` with an optional `ScalarValue`.
- * The `ScalarValue` is absent for a null scalar. Otherwise, the `DType`
- * gives the `ScalarValue` its meaning; for example, a tuple value can
- * represent a list, fixed-size list, or struct scalar depending on the
- * `DType`.
+ * A typed scalar value.
  *
- * The C API exposes only the complete pair as `vx_scalar`.
+ * A `vx_scalar` represents a single value with an associated `DType`.
+ * Its value is either null or a `ScalarValue`. Null values are allowed only
+ * when the associated `DType` allows nulls. Non-null values are represented
+ * by `ScalarValue` and interpreted using the `DType`.
  */
 typedef struct vx_scalar vx_scalar;
 

--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -490,6 +490,16 @@ typedef struct vx_file vx_file;
 typedef struct vx_partition vx_partition;
 
 /**
+ * Opaque handle to a `Scalar` struct: a pair of a logical `DType` and an optional
+ * `ScalarValue` payload.
+ *
+ * The C API exposes only the complete pair as `vx_scalar`, so
+ * callers do not need to know enum layouts or maintain the `DType`/`ScalarValue`
+ * invariants themselves.
+ */
+typedef struct vx_scalar vx_scalar;
+
+/**
  * A scan is a single traversal of a data source with projections and
  * filters. A scan can be consumed only once.
  */
@@ -1106,42 +1116,38 @@ void vx_expression_free(vx_expression *ptr);
 vx_expression *vx_expression_root(void);
 
 /**
- * Create a literal boolean expression.
- */
-vx_expression *vx_expression_literal_bool(bool value, bool is_nullable);
-
-/**
- * Create a literal primitive expression.
+ * Create a literal expression from a scalar.
  *
- * `value` must point to one value of the C type corresponding to `ptype`.
- * For `PTYPE_F16`, the value is represented as `uint16_t`.
- * If `value` is NULL, returns NULL.
- */
-vx_expression *vx_expression_literal_primitive(vx_ptype ptype, const void *value, bool is_nullable);
-
-/**
- * Create a literal UTF-8 expression.
+ * Literal expressions are useful for constants in expression trees, especially scan
+ * predicates. For example, a caller can compare a column expression to a scalar
+ * threshold and pass the resulting predicate to `vx_data_source_scan`.
  *
- * The input string is borrowed and copied into the returned expression.
- * If `value` is NULL, returns NULL.
- */
-vx_expression *vx_expression_literal_utf8(const vx_string *value, bool is_nullable);
-
-/**
- * Create a literal binary expression.
+ * Example:
  *
- * The input bytes are borrowed and copied into the returned expression.
- * If `value` is NULL, returns NULL.
- */
-vx_expression *vx_expression_literal_binary(const vx_binary *value, bool is_nullable);
-
-/**
- * Create a typed null literal expression.
+ * vx_error* error = NULL;
+ * const vx_data_source* data_source = ...;
  *
- * The null literal uses a nullable version of `dtype`.
- * If `dtype` is NULL, returns NULL.
+ * vx_expression* root = vx_expression_root();
+ * vx_expression* age = vx_expression_get_item("age", root);
+ *
+ * vx_scalar* threshold_scalar = vx_scalar_new_u8(50, false);
+ * vx_expression* threshold = vx_expression_literal(threshold_scalar, &error);
+ * vx_scalar_free(threshold_scalar);
+ *
+ * vx_expression* predicate = vx_expression_binary(VX_OPERATOR_GTE, age, threshold);
+ * vx_scan_options options = {};
+ * options.filter = predicate;
+ *
+ * vx_scan* scan = vx_data_source_scan(data_source, &options, NULL, &error);
+ *
+ * vx_scan_free(scan);
+ * vx_expression_free(predicate);
+ * vx_expression_free(threshold);
+ * vx_expression_free(age);
+ * vx_expression_free(root);
+ *
  */
-vx_expression *vx_expression_literal_null(const vx_dtype *dtype);
+vx_expression *vx_expression_literal(const vx_scalar *scalar, vx_error **err);
 
 /**
  * Create an expression that selects (includes) specific fields from a child
@@ -1289,6 +1295,236 @@ vx_array_iterator *vx_file_scan(const vx_session *session,
  * The logger will only be installed on the first call.
  */
 void vx_set_log_level(vx_log_level level);
+
+/**
+ * Free an owned [`vx_scalar`] object.
+ */
+void vx_scalar_free(vx_scalar *ptr);
+
+/**
+ * Clone a borrowed scalar handle.
+ *
+ * The input scalar handle is not consumed. The returned scalar handle must be
+ * released with vx_scalar_free. Returns NULL when given a NULL scalar handle.
+ */
+vx_scalar *vx_scalar_clone(const vx_scalar *scalar);
+
+/**
+ * Return the data type of a scalar.
+ *
+ * The returned data type handle borrows storage from the scalar handle and must
+ * not be freed separately. Returns NULL when given a NULL scalar handle.
+ */
+const vx_dtype *vx_scalar_dtype(const vx_scalar *scalar);
+
+/**
+ * Return whether the scalar is a typed null value.
+ *
+ * Returns false when given a NULL scalar handle.
+ */
+bool vx_scalar_is_null(const vx_scalar *scalar);
+
+/**
+ * Create a boolean scalar.
+ */
+vx_scalar *vx_scalar_new_bool(bool value, bool is_nullable);
+
+/**
+ * Create an unsigned 8-bit integer scalar.
+ */
+vx_scalar *vx_scalar_new_u8(uint8_t value, bool is_nullable);
+
+/**
+ * Create an unsigned 16-bit integer scalar.
+ */
+vx_scalar *vx_scalar_new_u16(uint16_t value, bool is_nullable);
+
+/**
+ * Create an unsigned 32-bit integer scalar.
+ */
+vx_scalar *vx_scalar_new_u32(uint32_t value, bool is_nullable);
+
+/**
+ * Create an unsigned 64-bit integer scalar.
+ */
+vx_scalar *vx_scalar_new_u64(uint64_t value, bool is_nullable);
+
+/**
+ * Create a signed 8-bit integer scalar.
+ */
+vx_scalar *vx_scalar_new_i8(int8_t value, bool is_nullable);
+
+/**
+ * Create a signed 16-bit integer scalar.
+ */
+vx_scalar *vx_scalar_new_i16(int16_t value, bool is_nullable);
+
+/**
+ * Create a signed 32-bit integer scalar.
+ */
+vx_scalar *vx_scalar_new_i32(int32_t value, bool is_nullable);
+
+/**
+ * Create a signed 64-bit integer scalar.
+ */
+vx_scalar *vx_scalar_new_i64(int64_t value, bool is_nullable);
+
+/**
+ * Create a 32-bit floating point scalar.
+ */
+vx_scalar *vx_scalar_new_f32(float value, bool is_nullable);
+
+/**
+ * Create a 64-bit floating point scalar.
+ */
+vx_scalar *vx_scalar_new_f64(double value, bool is_nullable);
+
+/**
+ * Create a 16-bit floating point scalar.
+ *
+ * The value is read from raw half-precision bits because C has no portable
+ * half-precision floating point ABI.
+ */
+vx_scalar *vx_scalar_new_f16_bits(uint16_t bits, bool is_nullable);
+
+/**
+ * Create a UTF-8 scalar.
+ *
+ * The byte range is copied into the scalar. A NULL data pointer is allowed only
+ * for an empty byte range. Invalid UTF-8 returns NULL and writes the error
+ * output.
+ */
+vx_scalar *vx_scalar_new_utf8(const char *ptr, size_t len, bool is_nullable, vx_error **err);
+
+/**
+ * Create a binary scalar.
+ *
+ * The byte range is copied into the scalar. A NULL data pointer is allowed only
+ * for an empty byte range. Passing a NULL data pointer for a non-empty byte
+ * range returns NULL and writes the error output.
+ */
+vx_scalar *vx_scalar_new_binary(const uint8_t *ptr, size_t len, bool is_nullable, vx_error **err);
+
+/**
+ * Create a typed null scalar.
+ *
+ * The data type handle is borrowed, not consumed. The returned scalar uses a
+ * nullable copy of that logical type, regardless of the input type's top-level
+ * nullability. A NULL data type handle returns NULL and writes the error output.
+ */
+vx_scalar *vx_scalar_new_null(const vx_dtype *dtype, vx_error **err);
+
+/**
+ * Create a decimal scalar.
+ *
+ * The unscaled value is provided as a signed 8-bit integer. Decimal precision
+ * and scale define the logical decimal type. Invalid decimal metadata or value
+ * overflow returns NULL and writes the error output.
+ */
+vx_scalar *
+vx_scalar_new_decimal_i8(int8_t value, uint8_t precision, int8_t scale, bool is_nullable, vx_error **err);
+
+/**
+ * Create a decimal scalar.
+ *
+ * The unscaled value is provided as a signed 16-bit integer. Decimal precision
+ * and scale define the logical decimal type. Invalid decimal metadata or value
+ * overflow returns NULL and writes the error output.
+ */
+vx_scalar *
+vx_scalar_new_decimal_i16(int16_t value, uint8_t precision, int8_t scale, bool is_nullable, vx_error **err);
+
+/**
+ * Create a decimal scalar.
+ *
+ * The unscaled value is provided as a signed 32-bit integer. Decimal precision
+ * and scale define the logical decimal type. Invalid decimal metadata or value
+ * overflow returns NULL and writes the error output.
+ */
+vx_scalar *
+vx_scalar_new_decimal_i32(int32_t value, uint8_t precision, int8_t scale, bool is_nullable, vx_error **err);
+
+/**
+ * Create a decimal scalar.
+ *
+ * The unscaled value is provided as a signed 64-bit integer. Decimal precision
+ * and scale define the logical decimal type. Invalid decimal metadata or value
+ * overflow returns NULL and writes the error output.
+ */
+vx_scalar *
+vx_scalar_new_decimal_i64(int64_t value, uint8_t precision, int8_t scale, bool is_nullable, vx_error **err);
+
+/**
+ * Create a decimal scalar.
+ *
+ * The unscaled value is read from a 16-byte little-endian signed integer
+ * buffer. Decimal precision and scale define the logical decimal type.
+ * Invalid decimal metadata or value overflow returns NULL and writes the error
+ * output.
+ */
+vx_scalar *vx_scalar_new_decimal_i128_le(const uint8_t *bytes16,
+                                         uint8_t precision,
+                                         int8_t scale,
+                                         bool is_nullable,
+                                         vx_error **err);
+
+/**
+ * Create a decimal scalar.
+ *
+ * The unscaled value is read from a 32-byte little-endian signed integer
+ * buffer. Decimal precision and scale define the logical decimal type.
+ * Invalid decimal metadata or value overflow returns NULL and writes the error
+ * output.
+ */
+vx_scalar *vx_scalar_new_decimal_i256_le(const uint8_t *bytes32,
+                                         uint8_t precision,
+                                         int8_t scale,
+                                         bool is_nullable,
+                                         vx_error **err);
+
+/**
+ * Create a list scalar.
+ *
+ * The element data type handle is borrowed, not consumed. Child scalar handles
+ * are cloned into the list value, so the caller keeps ownership of the handle
+ * array and each scalar in it. A NULL child handle array is allowed only for an
+ * empty list. Child values are validated against the element logical type.
+ */
+vx_scalar *vx_scalar_new_list(const vx_dtype *element_dtype,
+                              const vx_scalar *const *elements,
+                              size_t len,
+                              bool is_nullable,
+                              vx_error **err);
+
+/**
+ * Create a fixed-size list scalar.
+ *
+ * The element data type handle is borrowed, not consumed. The number of child
+ * scalars becomes the fixed-size list width and must fit in a 32-bit unsigned
+ * integer. Child scalar handles are cloned into the list value, so the caller
+ * keeps ownership of the handle array and each scalar in it. A NULL child
+ * handle array is allowed only for an empty list. Child values are validated
+ * against the element logical type.
+ */
+vx_scalar *vx_scalar_new_fixed_size_list(const vx_dtype *element_dtype,
+                                         const vx_scalar *const *elements,
+                                         size_t len,
+                                         bool is_nullable,
+                                         vx_error **err);
+
+/**
+ * Create a struct scalar.
+ *
+ * The struct data type handle is borrowed, not consumed. Field scalar handles
+ * are cloned into the struct value, so the caller keeps ownership of the handle
+ * array and each scalar in it. Field count and field logical types are validated
+ * against the struct logical type. A NULL field handle array is allowed only for
+ * an empty struct value.
+ */
+vx_scalar *vx_scalar_new_struct(const vx_dtype *struct_dtype,
+                                const vx_scalar *const *fields,
+                                size_t len,
+                                vx_error **err);
 
 /**
  * Free an owned [`vx_scan`] object.

--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -490,12 +490,13 @@ typedef struct vx_file vx_file;
 typedef struct vx_partition vx_partition;
 
 /**
- * Opaque handle to a `Scalar` struct: a pair of a logical `DType` and an optional
- * `ScalarValue` payload.
+ * A `vx_scalar` stores a logical `DType` with an optional `ScalarValue`.
+ * The `ScalarValue` is absent for a null scalar. Otherwise, the `DType`
+ * gives the `ScalarValue` its meaning; for example, a tuple value can
+ * represent a list, fixed-size list, or struct scalar depending on the
+ * `DType`.
  *
- * The C API exposes only the complete pair as `vx_scalar`, so
- * callers do not need to know enum layouts or maintain the `DType`/`ScalarValue`
- * invariants themselves.
+ * The C API exposes only the complete pair as `vx_scalar`.
  */
 typedef struct vx_scalar vx_scalar;
 
@@ -1312,8 +1313,9 @@ vx_scalar *vx_scalar_clone(const vx_scalar *scalar);
 /**
  * Return the data type of a scalar.
  *
- * The returned data type handle borrows storage from the scalar handle and must
- * not be freed separately. Returns NULL when given a NULL scalar handle.
+ * The returned data type handle borrows storage from the scalar handle, so its
+ * lifetime is bound to the scalar handle. It MUST NOT be freed separately.
+ * Returns NULL when given a NULL scalar handle.
  */
 const vx_dtype *vx_scalar_dtype(const vx_scalar *scalar);
 

--- a/vortex-ffi/src/expression.rs
+++ b/vortex-ffi/src/expression.rs
@@ -4,16 +4,13 @@
 
 use std::ffi::CStr;
 use std::ffi::c_char;
-use std::ffi::c_void;
 use std::ptr;
 use std::slice;
 use std::sync::Arc;
 
 use vortex::dtype::FieldName;
-use vortex::dtype::NativePType;
-use vortex::dtype::Nullability;
-use vortex::dtype::half::f16;
 use vortex::error::VortexExpect;
+use vortex::error::vortex_ensure;
 use vortex::expr::Expression;
 use vortex::expr::and_collect;
 use vortex::expr::get_item;
@@ -24,16 +21,13 @@ use vortex::expr::not;
 use vortex::expr::or_collect;
 use vortex::expr::root;
 use vortex::expr::select;
-use vortex::scalar::PValue;
-use vortex::scalar::Scalar;
 use vortex::scalar_fn::ScalarFnVTableExt;
 use vortex::scalar_fn::fns::binary::Binary;
 use vortex::scalar_fn::fns::operators::Operator;
 
-use crate::binary::vx_binary;
-use crate::dtype::vx_dtype;
-use crate::ptype::vx_ptype;
-use crate::string::vx_string;
+use crate::error::try_or;
+use crate::error::vx_error;
+use crate::scalar::vx_scalar;
 use crate::to_field_names;
 
 // Expressions are Arc'ed inside
@@ -73,102 +67,45 @@ pub unsafe extern "C" fn vx_expression_root() -> *mut vx_expression {
     vx_expression::new(root())
 }
 
-/// Create a literal boolean expression.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn vx_expression_literal_bool(
-    value: bool,
-    is_nullable: bool,
-) -> *mut vx_expression {
-    vx_expression::new(lit(Scalar::bool(value, Nullability::from(is_nullable))))
-}
-
-/// Create a literal primitive expression.
+/// Create a literal expression from a scalar.
 ///
-/// `value` must point to one value of the C type corresponding to `ptype`.
-/// For `PTYPE_F16`, the value is represented as `uint16_t`.
-/// If `value` is NULL, returns NULL.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn vx_expression_literal_primitive(
-    ptype: vx_ptype,
-    value: *const c_void,
-    is_nullable: bool,
-) -> *mut vx_expression {
-    let nullability = Nullability::from(is_nullable);
-    match ptype {
-        vx_ptype::PTYPE_U8 => unsafe { primitive_literal_from_raw::<u8>(value, nullability) },
-        vx_ptype::PTYPE_U16 => unsafe { primitive_literal_from_raw::<u16>(value, nullability) },
-        vx_ptype::PTYPE_U32 => unsafe { primitive_literal_from_raw::<u32>(value, nullability) },
-        vx_ptype::PTYPE_U64 => unsafe { primitive_literal_from_raw::<u64>(value, nullability) },
-        vx_ptype::PTYPE_I8 => unsafe { primitive_literal_from_raw::<i8>(value, nullability) },
-        vx_ptype::PTYPE_I16 => unsafe { primitive_literal_from_raw::<i16>(value, nullability) },
-        vx_ptype::PTYPE_I32 => unsafe { primitive_literal_from_raw::<i32>(value, nullability) },
-        vx_ptype::PTYPE_I64 => unsafe { primitive_literal_from_raw::<i64>(value, nullability) },
-        vx_ptype::PTYPE_F16 => unsafe { primitive_literal_from_raw::<f16>(value, nullability) },
-        vx_ptype::PTYPE_F32 => unsafe { primitive_literal_from_raw::<f32>(value, nullability) },
-        vx_ptype::PTYPE_F64 => unsafe { primitive_literal_from_raw::<f64>(value, nullability) },
-    }
-}
-
-unsafe fn primitive_literal_from_raw<T>(
-    value: *const c_void,
-    nullability: Nullability,
-) -> *mut vx_expression
-where
-    T: NativePType + Into<PValue> + Copy,
-{
-    if value.is_null() {
-        return ptr::null_mut();
-    }
-    let value = unsafe { *value.cast::<T>() };
-    vx_expression::new(lit(Scalar::primitive(value, nullability)))
-}
-
-/// Create a literal UTF-8 expression.
+/// Literal expressions are useful for constants in expression trees, especially scan
+/// predicates. For example, a caller can compare a column expression to a scalar
+/// threshold and pass the resulting predicate to `vx_data_source_scan`.
 ///
-/// The input string is borrowed and copied into the returned expression.
-/// If `value` is NULL, returns NULL.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn vx_expression_literal_utf8(
-    value: *const vx_string,
-    is_nullable: bool,
-) -> *mut vx_expression {
-    if value.is_null() {
-        return ptr::null_mut();
-    }
-    vx_expression::new(lit(Scalar::utf8(
-        vx_string::as_str(value).to_owned(),
-        Nullability::from(is_nullable),
-    )))
-}
-
-/// Create a literal binary expression.
+/// Example:
 ///
-/// The input bytes are borrowed and copied into the returned expression.
-/// If `value` is NULL, returns NULL.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn vx_expression_literal_binary(
-    value: *const vx_binary,
-    is_nullable: bool,
-) -> *mut vx_expression {
-    if value.is_null() {
-        return ptr::null_mut();
-    }
-    vx_expression::new(lit(Scalar::binary(
-        vx_binary::as_slice(value).to_vec(),
-        Nullability::from(is_nullable),
-    )))
-}
-
-/// Create a typed null literal expression.
+/// vx_error* error = NULL;
+/// const vx_data_source* data_source = ...;
 ///
-/// The null literal uses a nullable version of `dtype`.
-/// If `dtype` is NULL, returns NULL.
+/// vx_expression* root = vx_expression_root();
+/// vx_expression* age = vx_expression_get_item("age", root);
+///
+/// vx_scalar* threshold_scalar = vx_scalar_new_u8(50, false);
+/// vx_expression* threshold = vx_expression_literal(threshold_scalar, &error);
+/// vx_scalar_free(threshold_scalar);
+///
+/// vx_expression* predicate = vx_expression_binary(VX_OPERATOR_GTE, age, threshold);
+/// vx_scan_options options = {};
+/// options.filter = predicate;
+///
+/// vx_scan* scan = vx_data_source_scan(data_source, &options, NULL, &error);
+///
+/// vx_scan_free(scan);
+/// vx_expression_free(predicate);
+/// vx_expression_free(threshold);
+/// vx_expression_free(age);
+/// vx_expression_free(root);
+///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn vx_expression_literal_null(dtype: *const vx_dtype) -> *mut vx_expression {
-    if dtype.is_null() {
-        return ptr::null_mut();
-    }
-    vx_expression::new(lit(Scalar::null(vx_dtype::as_ref(dtype).as_nullable())))
+pub unsafe extern "C-unwind" fn vx_expression_literal(
+    scalar: *const vx_scalar,
+    err: *mut *mut vx_error,
+) -> *mut vx_expression {
+    try_or(err, ptr::null_mut(), || {
+        vortex_ensure!(!scalar.is_null(), "scalar literal is null");
+        Ok(vx_expression::new(lit(vx_scalar::as_ref(scalar).clone())))
+    })
 }
 
 /// Create an expression that selects (includes) specific fields from a child
@@ -414,19 +351,12 @@ mod tests {
     use vortex::array::validity::Validity;
     use vortex::buffer::Buffer;
     use vortex::buffer::buffer;
-    use vortex::dtype::DType;
     use vortex::dtype::Nullability;
-    use vortex::dtype::PType;
-    use vortex::dtype::half::f16;
     use vortex::scalar::Scalar;
 
     use crate::array::vx_array;
     use crate::array::vx_array_apply;
     use crate::array::vx_array_free;
-    use crate::binary::vx_binary_free;
-    use crate::binary::vx_binary_new;
-    use crate::dtype::vx_dtype_free;
-    use crate::dtype::vx_dtype_new_primitive;
     use crate::error::vx_error_free;
     use crate::expression::vx_binary_operator;
     use crate::expression::vx_expression;
@@ -435,17 +365,12 @@ mod tests {
     use crate::expression::vx_expression_free;
     use crate::expression::vx_expression_get_item;
     use crate::expression::vx_expression_list_contains;
-    use crate::expression::vx_expression_literal_binary;
-    use crate::expression::vx_expression_literal_bool;
-    use crate::expression::vx_expression_literal_null;
-    use crate::expression::vx_expression_literal_primitive;
-    use crate::expression::vx_expression_literal_utf8;
+    use crate::expression::vx_expression_literal;
     use crate::expression::vx_expression_or;
     use crate::expression::vx_expression_root;
     use crate::expression::vx_expression_select;
-    use crate::ptype::vx_ptype;
-    use crate::string::vx_string_free;
-    use crate::string::vx_string_new;
+    use crate::scalar::vx_scalar_free;
+    use crate::scalar::vx_scalar_new_i32;
 
     #[test]
     #[cfg_attr(miri, ignore)]
@@ -530,134 +455,36 @@ mod tests {
         unsafe {
             let array = vx_array::new(Arc::new(array));
 
-            let mut assert_literal = |expr: *mut vx_expression, expected: Scalar| {
-                assert!(!expr.is_null());
+            let value = 2i32;
+            let scalar = vx_scalar_new_i32(value, false);
+            assert!(!scalar.is_null());
 
+            let mut error = ptr::null_mut();
+            let expr = vx_expression_literal(scalar, &raw mut error);
+            assert!(error.is_null());
+            assert!(!expr.is_null());
+            vx_scalar_free(scalar);
+
+            let applied = vx_array_apply(array, expr, &raw mut error);
+            assert!(error.is_null());
+            assert!(!applied.is_null());
+
+            {
+                let applied = vx_array::as_ref(applied);
+                let expected = Scalar::primitive(value, Nullability::NonNullable);
+                assert_eq!(applied.len(), 3);
+                assert_eq!(applied.execute_scalar(0, &mut ctx).unwrap(), expected);
+                assert_eq!(applied.execute_scalar(2, &mut ctx).unwrap(), expected);
+            }
+
+            vx_array_free(applied);
+            vx_expression_free(expr);
+
+            {
                 let mut error = ptr::null_mut();
-                let applied = vx_array_apply(array, expr, &raw mut error);
-                assert!(error.is_null());
-                assert!(!applied.is_null());
-
-                {
-                    let applied = vx_array::as_ref(applied);
-                    assert_eq!(applied.len(), 3);
-                    assert_eq!(applied.execute_scalar(0, &mut ctx).unwrap(), expected);
-                    assert_eq!(applied.execute_scalar(2, &mut ctx).unwrap(), expected);
-                }
-
-                vx_array_free(applied);
-                vx_expression_free(expr);
-            };
-
-            {
-                let bool_expr = vx_expression_literal_bool(true, true);
-                assert_literal(bool_expr, Scalar::bool(true, Nullability::Nullable));
-            }
-
-            {
-                let bool_expr = vx_expression_literal_bool(false, false);
-                assert_literal(bool_expr, Scalar::bool(false, Nullability::NonNullable));
-            }
-
-            {
-                let primitive_value = 2i32;
-                let primitive_expr = vx_expression_literal_primitive(
-                    vx_ptype::PTYPE_I32,
-                    (&raw const primitive_value).cast(),
-                    false,
-                );
-                assert_literal(
-                    primitive_expr,
-                    Scalar::primitive(primitive_value, Nullability::NonNullable),
-                );
-            }
-
-            {
-                let f16_value = f16::from_f32(1.0);
-                let primitive_value = f16_value.to_bits();
-                let primitive_expr = vx_expression_literal_primitive(
-                    vx_ptype::PTYPE_F16,
-                    (&raw const primitive_value).cast(),
-                    false,
-                );
-                assert_literal(
-                    primitive_expr,
-                    Scalar::primitive(f16_value, Nullability::NonNullable),
-                );
-            }
-
-            {
-                let utf8_value = "literal";
-                let utf8 = vx_string_new(utf8_value.as_ptr().cast(), utf8_value.len());
-                let utf8_expr = vx_expression_literal_utf8(utf8, false);
-                vx_string_free(utf8);
-                assert_literal(
-                    utf8_expr,
-                    Scalar::utf8(utf8_value, Nullability::NonNullable),
-                );
-            }
-
-            {
-                let utf8_value = "";
-                let utf8 = vx_string_new(utf8_value.as_ptr().cast(), utf8_value.len());
-                let utf8_expr = vx_expression_literal_utf8(utf8, false);
-                vx_string_free(utf8);
-                assert_literal(
-                    utf8_expr,
-                    Scalar::utf8(utf8_value, Nullability::NonNullable),
-                );
-            }
-
-            {
-                let binary_value = b"\xde\xad\xbe\xef";
-                let binary = vx_binary_new(binary_value.as_ptr().cast(), binary_value.len());
-                let binary_expr = vx_expression_literal_binary(binary, true);
-                vx_binary_free(binary);
-                assert_literal(
-                    binary_expr,
-                    Scalar::binary(binary_value.to_vec(), Nullability::Nullable),
-                );
-            }
-
-            {
-                let binary_value = b"";
-                let binary = vx_binary_new(binary_value.as_ptr().cast(), binary_value.len());
-                let binary_expr = vx_expression_literal_binary(binary, false);
-                vx_binary_free(binary);
-                assert_literal(
-                    binary_expr,
-                    Scalar::binary(binary_value.to_vec(), Nullability::NonNullable),
-                );
-            }
-
-            {
-                let dtype = vx_dtype_new_primitive(vx_ptype::PTYPE_I32, false);
-                let null_expr = vx_expression_literal_null(dtype);
-                vx_dtype_free(dtype);
-                assert_literal(
-                    null_expr,
-                    Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable)),
-                );
-            }
-
-            {
-                let dtype = vx_dtype_new_primitive(vx_ptype::PTYPE_U8, true);
-                let null_expr = vx_expression_literal_null(dtype);
-                vx_dtype_free(dtype);
-                assert_literal(
-                    null_expr,
-                    Scalar::null(DType::Primitive(PType::U8, Nullability::Nullable)),
-                );
-            }
-
-            {
-                assert!(
-                    vx_expression_literal_primitive(vx_ptype::PTYPE_I32, ptr::null(), false)
-                        .is_null()
-                );
-                assert!(vx_expression_literal_utf8(ptr::null(), false).is_null());
-                assert!(vx_expression_literal_binary(ptr::null(), false).is_null());
-                assert!(vx_expression_literal_null(ptr::null()).is_null());
+                assert!(vx_expression_literal(ptr::null(), &raw mut error).is_null());
+                assert!(!error.is_null());
+                vx_error_free(error);
             }
 
             vx_array_free(array);
@@ -805,7 +632,11 @@ mod tests {
         unsafe {
             let root = vx_expression_root();
             let array = vx_array::new(Arc::new(array.into_array()));
-            let expression_value = vx_expression::new(lit(1));
+            let value = vx_scalar_new_i32(1, false);
+            let mut error = ptr::null_mut();
+            let expression_value = vx_expression_literal(value, &raw mut error);
+            assert!(error.is_null());
+            vx_scalar_free(value);
 
             let expression = vx_expression_list_contains(root, expression_value);
             assert!(!expression.is_null());

--- a/vortex-ffi/src/expression.rs
+++ b/vortex-ffi/src/expression.rs
@@ -4,25 +4,36 @@
 
 use std::ffi::CStr;
 use std::ffi::c_char;
+use std::ffi::c_void;
 use std::ptr;
 use std::slice;
 use std::sync::Arc;
 
 use vortex::dtype::FieldName;
+use vortex::dtype::NativePType;
+use vortex::dtype::Nullability;
+use vortex::dtype::half::f16;
 use vortex::error::VortexExpect;
 use vortex::expr::Expression;
 use vortex::expr::and_collect;
 use vortex::expr::get_item;
 use vortex::expr::is_null;
 use vortex::expr::list_contains;
+use vortex::expr::lit;
 use vortex::expr::not;
 use vortex::expr::or_collect;
 use vortex::expr::root;
 use vortex::expr::select;
+use vortex::scalar::PValue;
+use vortex::scalar::Scalar;
 use vortex::scalar_fn::ScalarFnVTableExt;
 use vortex::scalar_fn::fns::binary::Binary;
 use vortex::scalar_fn::fns::operators::Operator;
 
+use crate::binary::vx_binary;
+use crate::dtype::vx_dtype;
+use crate::ptype::vx_ptype;
+use crate::string::vx_string;
 use crate::to_field_names;
 
 // Expressions are Arc'ed inside
@@ -60,6 +71,104 @@ crate::box_wrapper!(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn vx_expression_root() -> *mut vx_expression {
     vx_expression::new(root())
+}
+
+/// Create a literal boolean expression.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vx_expression_literal_bool(
+    value: bool,
+    is_nullable: bool,
+) -> *mut vx_expression {
+    vx_expression::new(lit(Scalar::bool(value, Nullability::from(is_nullable))))
+}
+
+/// Create a literal primitive expression.
+///
+/// `value` must point to one value of the C type corresponding to `ptype`.
+/// For `PTYPE_F16`, the value is represented as `uint16_t`.
+/// If `value` is NULL, returns NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vx_expression_literal_primitive(
+    ptype: vx_ptype,
+    value: *const c_void,
+    is_nullable: bool,
+) -> *mut vx_expression {
+    let nullability = Nullability::from(is_nullable);
+    match ptype {
+        vx_ptype::PTYPE_U8 => unsafe { primitive_literal_from_raw::<u8>(value, nullability) },
+        vx_ptype::PTYPE_U16 => unsafe { primitive_literal_from_raw::<u16>(value, nullability) },
+        vx_ptype::PTYPE_U32 => unsafe { primitive_literal_from_raw::<u32>(value, nullability) },
+        vx_ptype::PTYPE_U64 => unsafe { primitive_literal_from_raw::<u64>(value, nullability) },
+        vx_ptype::PTYPE_I8 => unsafe { primitive_literal_from_raw::<i8>(value, nullability) },
+        vx_ptype::PTYPE_I16 => unsafe { primitive_literal_from_raw::<i16>(value, nullability) },
+        vx_ptype::PTYPE_I32 => unsafe { primitive_literal_from_raw::<i32>(value, nullability) },
+        vx_ptype::PTYPE_I64 => unsafe { primitive_literal_from_raw::<i64>(value, nullability) },
+        vx_ptype::PTYPE_F16 => unsafe { primitive_literal_from_raw::<f16>(value, nullability) },
+        vx_ptype::PTYPE_F32 => unsafe { primitive_literal_from_raw::<f32>(value, nullability) },
+        vx_ptype::PTYPE_F64 => unsafe { primitive_literal_from_raw::<f64>(value, nullability) },
+    }
+}
+
+unsafe fn primitive_literal_from_raw<T>(
+    value: *const c_void,
+    nullability: Nullability,
+) -> *mut vx_expression
+where
+    T: NativePType + Into<PValue> + Copy,
+{
+    if value.is_null() {
+        return ptr::null_mut();
+    }
+    let value = unsafe { *value.cast::<T>() };
+    vx_expression::new(lit(Scalar::primitive(value, nullability)))
+}
+
+/// Create a literal UTF-8 expression.
+///
+/// The input string is borrowed and copied into the returned expression.
+/// If `value` is NULL, returns NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vx_expression_literal_utf8(
+    value: *const vx_string,
+    is_nullable: bool,
+) -> *mut vx_expression {
+    if value.is_null() {
+        return ptr::null_mut();
+    }
+    vx_expression::new(lit(Scalar::utf8(
+        vx_string::as_str(value).to_owned(),
+        Nullability::from(is_nullable),
+    )))
+}
+
+/// Create a literal binary expression.
+///
+/// The input bytes are borrowed and copied into the returned expression.
+/// If `value` is NULL, returns NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vx_expression_literal_binary(
+    value: *const vx_binary,
+    is_nullable: bool,
+) -> *mut vx_expression {
+    if value.is_null() {
+        return ptr::null_mut();
+    }
+    vx_expression::new(lit(Scalar::binary(
+        vx_binary::as_slice(value).to_vec(),
+        Nullability::from(is_nullable),
+    )))
+}
+
+/// Create a typed null literal expression.
+///
+/// The null literal uses a nullable version of `dtype`.
+/// If `dtype` is NULL, returns NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vx_expression_literal_null(dtype: *const vx_dtype) -> *mut vx_expression {
+    if dtype.is_null() {
+        return ptr::null_mut();
+    }
+    vx_expression::new(lit(Scalar::null(vx_dtype::as_ref(dtype).as_nullable())))
 }
 
 /// Create an expression that selects (includes) specific fields from a child
@@ -305,11 +414,19 @@ mod tests {
     use vortex::array::validity::Validity;
     use vortex::buffer::Buffer;
     use vortex::buffer::buffer;
-    use vortex::expr::lit;
+    use vortex::dtype::DType;
+    use vortex::dtype::Nullability;
+    use vortex::dtype::PType;
+    use vortex::dtype::half::f16;
+    use vortex::scalar::Scalar;
 
     use crate::array::vx_array;
     use crate::array::vx_array_apply;
     use crate::array::vx_array_free;
+    use crate::binary::vx_binary_free;
+    use crate::binary::vx_binary_new;
+    use crate::dtype::vx_dtype_free;
+    use crate::dtype::vx_dtype_new_primitive;
     use crate::error::vx_error_free;
     use crate::expression::vx_binary_operator;
     use crate::expression::vx_expression;
@@ -318,9 +435,17 @@ mod tests {
     use crate::expression::vx_expression_free;
     use crate::expression::vx_expression_get_item;
     use crate::expression::vx_expression_list_contains;
+    use crate::expression::vx_expression_literal_binary;
+    use crate::expression::vx_expression_literal_bool;
+    use crate::expression::vx_expression_literal_null;
+    use crate::expression::vx_expression_literal_primitive;
+    use crate::expression::vx_expression_literal_utf8;
     use crate::expression::vx_expression_or;
     use crate::expression::vx_expression_root;
     use crate::expression::vx_expression_select;
+    use crate::ptype::vx_ptype;
+    use crate::string::vx_string_free;
+    use crate::string::vx_string_new;
 
     #[test]
     #[cfg_attr(miri, ignore)]
@@ -392,6 +517,150 @@ mod tests {
 
             vx_array_free(array);
             vx_expression_free(root);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_literal() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array =
+            PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable).into_array();
+
+        unsafe {
+            let array = vx_array::new(Arc::new(array));
+
+            let mut assert_literal = |expr: *mut vx_expression, expected: Scalar| {
+                assert!(!expr.is_null());
+
+                let mut error = ptr::null_mut();
+                let applied = vx_array_apply(array, expr, &raw mut error);
+                assert!(error.is_null());
+                assert!(!applied.is_null());
+
+                {
+                    let applied = vx_array::as_ref(applied);
+                    assert_eq!(applied.len(), 3);
+                    assert_eq!(applied.execute_scalar(0, &mut ctx).unwrap(), expected);
+                    assert_eq!(applied.execute_scalar(2, &mut ctx).unwrap(), expected);
+                }
+
+                vx_array_free(applied);
+                vx_expression_free(expr);
+            };
+
+            {
+                let bool_expr = vx_expression_literal_bool(true, true);
+                assert_literal(bool_expr, Scalar::bool(true, Nullability::Nullable));
+            }
+
+            {
+                let bool_expr = vx_expression_literal_bool(false, false);
+                assert_literal(bool_expr, Scalar::bool(false, Nullability::NonNullable));
+            }
+
+            {
+                let primitive_value = 2i32;
+                let primitive_expr = vx_expression_literal_primitive(
+                    vx_ptype::PTYPE_I32,
+                    (&raw const primitive_value).cast(),
+                    false,
+                );
+                assert_literal(
+                    primitive_expr,
+                    Scalar::primitive(primitive_value, Nullability::NonNullable),
+                );
+            }
+
+            {
+                let f16_value = f16::from_f32(1.0);
+                let primitive_value = f16_value.to_bits();
+                let primitive_expr = vx_expression_literal_primitive(
+                    vx_ptype::PTYPE_F16,
+                    (&raw const primitive_value).cast(),
+                    false,
+                );
+                assert_literal(
+                    primitive_expr,
+                    Scalar::primitive(f16_value, Nullability::NonNullable),
+                );
+            }
+
+            {
+                let utf8_value = "literal";
+                let utf8 = vx_string_new(utf8_value.as_ptr().cast(), utf8_value.len());
+                let utf8_expr = vx_expression_literal_utf8(utf8, false);
+                vx_string_free(utf8);
+                assert_literal(
+                    utf8_expr,
+                    Scalar::utf8(utf8_value, Nullability::NonNullable),
+                );
+            }
+
+            {
+                let utf8_value = "";
+                let utf8 = vx_string_new(utf8_value.as_ptr().cast(), utf8_value.len());
+                let utf8_expr = vx_expression_literal_utf8(utf8, false);
+                vx_string_free(utf8);
+                assert_literal(
+                    utf8_expr,
+                    Scalar::utf8(utf8_value, Nullability::NonNullable),
+                );
+            }
+
+            {
+                let binary_value = b"\xde\xad\xbe\xef";
+                let binary = vx_binary_new(binary_value.as_ptr().cast(), binary_value.len());
+                let binary_expr = vx_expression_literal_binary(binary, true);
+                vx_binary_free(binary);
+                assert_literal(
+                    binary_expr,
+                    Scalar::binary(binary_value.to_vec(), Nullability::Nullable),
+                );
+            }
+
+            {
+                let binary_value = b"";
+                let binary = vx_binary_new(binary_value.as_ptr().cast(), binary_value.len());
+                let binary_expr = vx_expression_literal_binary(binary, false);
+                vx_binary_free(binary);
+                assert_literal(
+                    binary_expr,
+                    Scalar::binary(binary_value.to_vec(), Nullability::NonNullable),
+                );
+            }
+
+            {
+                let dtype = vx_dtype_new_primitive(vx_ptype::PTYPE_I32, false);
+                let null_expr = vx_expression_literal_null(dtype);
+                vx_dtype_free(dtype);
+                assert_literal(
+                    null_expr,
+                    Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable)),
+                );
+            }
+
+            {
+                let dtype = vx_dtype_new_primitive(vx_ptype::PTYPE_U8, true);
+                let null_expr = vx_expression_literal_null(dtype);
+                vx_dtype_free(dtype);
+                assert_literal(
+                    null_expr,
+                    Scalar::null(DType::Primitive(PType::U8, Nullability::Nullable)),
+                );
+            }
+
+            {
+                assert!(
+                    vx_expression_literal_primitive(vx_ptype::PTYPE_I32, ptr::null(), false)
+                        .is_null()
+                );
+                assert!(vx_expression_literal_utf8(ptr::null(), false).is_null());
+                assert!(vx_expression_literal_binary(ptr::null(), false).is_null());
+                assert!(vx_expression_literal_null(ptr::null()).is_null());
+            }
+
+            vx_array_free(array);
         }
     }
 

--- a/vortex-ffi/src/lib.rs
+++ b/vortex-ffi/src/lib.rs
@@ -16,6 +16,7 @@ mod file;
 mod log;
 mod macros;
 mod ptype;
+mod scalar;
 mod scan;
 mod session;
 mod sink;

--- a/vortex-ffi/src/scalar.rs
+++ b/vortex-ffi/src/scalar.rs
@@ -1,0 +1,844 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! FFI interface for working with Vortex scalar values.
+
+use std::ffi::c_char;
+use std::ptr;
+use std::slice;
+use std::str;
+use std::sync::Arc;
+
+use vortex::dtype::DType;
+use vortex::dtype::DecimalDType;
+use vortex::dtype::Nullability;
+use vortex::dtype::half::f16;
+use vortex::dtype::i256;
+use vortex::error::VortexResult;
+use vortex::error::vortex_bail;
+use vortex::error::vortex_ensure;
+use vortex::error::vortex_err;
+use vortex::scalar::DecimalValue;
+use vortex::scalar::Scalar;
+use vortex::scalar::ScalarValue;
+
+use crate::dtype::vx_dtype;
+use crate::error::try_or;
+use crate::error::vx_error;
+
+crate::box_wrapper!(
+    /// Opaque handle to a `Scalar` struct: a pair of a logical `DType` and an optional
+    /// `ScalarValue` payload.
+    ///
+    /// The C API exposes only the complete pair as `vx_scalar`, so
+    /// callers do not need to know enum layouts or maintain the `DType`/`ScalarValue`
+    /// invariants themselves.
+    Scalar,
+    vx_scalar
+);
+
+/// Clone a borrowed scalar handle.
+///
+/// The input scalar handle is not consumed. The returned scalar handle must be
+/// released with vx_scalar_free. Returns NULL when given a NULL scalar handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_clone(scalar: *const vx_scalar) -> *mut vx_scalar {
+    if scalar.is_null() {
+        return ptr::null_mut();
+    }
+    vx_scalar::new(vx_scalar::as_ref(scalar).clone())
+}
+
+/// Return the data type of a scalar.
+///
+/// The returned data type handle borrows storage from the scalar handle and must
+/// not be freed separately. Returns NULL when given a NULL scalar handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_dtype(scalar: *const vx_scalar) -> *const vx_dtype {
+    if scalar.is_null() {
+        return ptr::null();
+    }
+    vx_dtype::new_ref(vx_scalar::as_ref(scalar).dtype())
+}
+
+/// Return whether the scalar is a typed null value.
+///
+/// Returns false when given a NULL scalar handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_is_null(scalar: *const vx_scalar) -> bool {
+    if scalar.is_null() {
+        return false;
+    }
+    vx_scalar::as_ref(scalar).is_null()
+}
+
+/// Create a boolean scalar.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_bool(
+    value: bool,
+    is_nullable: bool,
+) -> *mut vx_scalar {
+    vx_scalar::new(Scalar::bool(value, Nullability::from(is_nullable)))
+}
+
+/// Create an unsigned 8-bit integer scalar.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_u8(value: u8, is_nullable: bool) -> *mut vx_scalar {
+    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
+}
+
+/// Create an unsigned 16-bit integer scalar.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_u16(value: u16, is_nullable: bool) -> *mut vx_scalar {
+    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
+}
+
+/// Create an unsigned 32-bit integer scalar.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_u32(value: u32, is_nullable: bool) -> *mut vx_scalar {
+    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
+}
+
+/// Create an unsigned 64-bit integer scalar.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_u64(value: u64, is_nullable: bool) -> *mut vx_scalar {
+    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
+}
+
+/// Create a signed 8-bit integer scalar.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_i8(value: i8, is_nullable: bool) -> *mut vx_scalar {
+    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
+}
+
+/// Create a signed 16-bit integer scalar.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_i16(value: i16, is_nullable: bool) -> *mut vx_scalar {
+    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
+}
+
+/// Create a signed 32-bit integer scalar.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_i32(value: i32, is_nullable: bool) -> *mut vx_scalar {
+    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
+}
+
+/// Create a signed 64-bit integer scalar.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_i64(value: i64, is_nullable: bool) -> *mut vx_scalar {
+    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
+}
+
+/// Create a 32-bit floating point scalar.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_f32(value: f32, is_nullable: bool) -> *mut vx_scalar {
+    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
+}
+
+/// Create a 64-bit floating point scalar.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_f64(value: f64, is_nullable: bool) -> *mut vx_scalar {
+    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
+}
+
+/// Create a 16-bit floating point scalar.
+///
+/// The value is read from raw half-precision bits because C has no portable
+/// half-precision floating point ABI.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_f16_bits(
+    bits: u16,
+    is_nullable: bool,
+) -> *mut vx_scalar {
+    vx_scalar::new(Scalar::primitive(
+        f16::from_bits(bits),
+        Nullability::from(is_nullable),
+    ))
+}
+
+/// Create a UTF-8 scalar.
+///
+/// The byte range is copied into the scalar. A NULL data pointer is allowed only
+/// for an empty byte range. Invalid UTF-8 returns NULL and writes the error
+/// output.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_utf8(
+    ptr: *const c_char,
+    len: usize,
+    is_nullable: bool,
+    err: *mut *mut vx_error,
+) -> *mut vx_scalar {
+    try_or(err, ptr::null_mut(), || {
+        let bytes = bytes_from_raw(ptr.cast(), len, "utf8")?;
+        let value = str::from_utf8(bytes).map_err(|e| vortex_err!("invalid utf-8: {e}"))?;
+        Ok(vx_scalar::new(Scalar::utf8(
+            value.to_owned(),
+            Nullability::from(is_nullable),
+        )))
+    })
+}
+
+/// Create a binary scalar.
+///
+/// The byte range is copied into the scalar. A NULL data pointer is allowed only
+/// for an empty byte range. Passing a NULL data pointer for a non-empty byte
+/// range returns NULL and writes the error output.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_binary(
+    ptr: *const u8,
+    len: usize,
+    is_nullable: bool,
+    err: *mut *mut vx_error,
+) -> *mut vx_scalar {
+    try_or(err, ptr::null_mut(), || {
+        let bytes = bytes_from_raw(ptr, len, "binary")?;
+        Ok(vx_scalar::new(Scalar::binary(
+            bytes.to_vec(),
+            Nullability::from(is_nullable),
+        )))
+    })
+}
+
+/// Create a typed null scalar.
+///
+/// The data type handle is borrowed, not consumed. The returned scalar uses a
+/// nullable copy of that logical type, regardless of the input type's top-level
+/// nullability. A NULL data type handle returns NULL and writes the error output.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_null(
+    dtype: *const vx_dtype,
+    err: *mut *mut vx_error,
+) -> *mut vx_scalar {
+    try_or(err, ptr::null_mut(), || {
+        vortex_ensure!(!dtype.is_null(), "dtype is null");
+        Ok(vx_scalar::new(Scalar::null(
+            vx_dtype::as_ref(dtype).as_nullable(),
+        )))
+    })
+}
+
+/// Create a decimal scalar.
+///
+/// The unscaled value is provided as a signed 8-bit integer. Decimal precision
+/// and scale define the logical decimal type. Invalid decimal metadata or value
+/// overflow returns NULL and writes the error output.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_decimal_i8(
+    value: i8,
+    precision: u8,
+    scale: i8,
+    is_nullable: bool,
+    err: *mut *mut vx_error,
+) -> *mut vx_scalar {
+    try_or(err, ptr::null_mut(), || {
+        decimal_scalar_from_value(DecimalValue::I8(value), precision, scale, is_nullable)
+    })
+}
+
+/// Create a decimal scalar.
+///
+/// The unscaled value is provided as a signed 16-bit integer. Decimal precision
+/// and scale define the logical decimal type. Invalid decimal metadata or value
+/// overflow returns NULL and writes the error output.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_decimal_i16(
+    value: i16,
+    precision: u8,
+    scale: i8,
+    is_nullable: bool,
+    err: *mut *mut vx_error,
+) -> *mut vx_scalar {
+    try_or(err, ptr::null_mut(), || {
+        decimal_scalar_from_value(DecimalValue::I16(value), precision, scale, is_nullable)
+    })
+}
+
+/// Create a decimal scalar.
+///
+/// The unscaled value is provided as a signed 32-bit integer. Decimal precision
+/// and scale define the logical decimal type. Invalid decimal metadata or value
+/// overflow returns NULL and writes the error output.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_decimal_i32(
+    value: i32,
+    precision: u8,
+    scale: i8,
+    is_nullable: bool,
+    err: *mut *mut vx_error,
+) -> *mut vx_scalar {
+    try_or(err, ptr::null_mut(), || {
+        decimal_scalar_from_value(DecimalValue::I32(value), precision, scale, is_nullable)
+    })
+}
+
+/// Create a decimal scalar.
+///
+/// The unscaled value is provided as a signed 64-bit integer. Decimal precision
+/// and scale define the logical decimal type. Invalid decimal metadata or value
+/// overflow returns NULL and writes the error output.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_decimal_i64(
+    value: i64,
+    precision: u8,
+    scale: i8,
+    is_nullable: bool,
+    err: *mut *mut vx_error,
+) -> *mut vx_scalar {
+    try_or(err, ptr::null_mut(), || {
+        decimal_scalar_from_value(DecimalValue::I64(value), precision, scale, is_nullable)
+    })
+}
+
+/// Create a decimal scalar.
+///
+/// The unscaled value is read from a 16-byte little-endian signed integer
+/// buffer. Decimal precision and scale define the logical decimal type.
+/// Invalid decimal metadata or value overflow returns NULL and writes the error
+/// output.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_decimal_i128_le(
+    bytes16: *const u8,
+    precision: u8,
+    scale: i8,
+    is_nullable: bool,
+    err: *mut *mut vx_error,
+) -> *mut vx_scalar {
+    try_or(err, ptr::null_mut(), || {
+        let bytes = fixed_bytes_from_raw::<16>(bytes16, "decimal i128")?;
+        decimal_scalar_from_value(
+            DecimalValue::I128(i128::from_le_bytes(bytes)),
+            precision,
+            scale,
+            is_nullable,
+        )
+    })
+}
+
+/// Create a decimal scalar.
+///
+/// The unscaled value is read from a 32-byte little-endian signed integer
+/// buffer. Decimal precision and scale define the logical decimal type.
+/// Invalid decimal metadata or value overflow returns NULL and writes the error
+/// output.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_decimal_i256_le(
+    bytes32: *const u8,
+    precision: u8,
+    scale: i8,
+    is_nullable: bool,
+    err: *mut *mut vx_error,
+) -> *mut vx_scalar {
+    try_or(err, ptr::null_mut(), || {
+        let bytes = fixed_bytes_from_raw::<32>(bytes32, "decimal i256")?;
+        decimal_scalar_from_value(
+            DecimalValue::I256(i256::from_le_bytes(bytes)),
+            precision,
+            scale,
+            is_nullable,
+        )
+    })
+}
+
+/// Create a list scalar.
+///
+/// The element data type handle is borrowed, not consumed. Child scalar handles
+/// are cloned into the list value, so the caller keeps ownership of the handle
+/// array and each scalar in it. A NULL child handle array is allowed only for an
+/// empty list. Child values are validated against the element logical type.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_list(
+    element_dtype: *const vx_dtype,
+    elements: *const *const vx_scalar,
+    len: usize,
+    is_nullable: bool,
+    err: *mut *mut vx_error,
+) -> *mut vx_scalar {
+    try_or(err, ptr::null_mut(), || {
+        vortex_ensure!(!element_dtype.is_null(), "element dtype is null");
+        let dtype = DType::List(
+            Arc::new(vx_dtype::as_ref(element_dtype).clone()),
+            Nullability::from(is_nullable),
+        );
+        let values = scalar_values_from_raw(elements, len)?;
+        Ok(vx_scalar::new(Scalar::try_new(
+            dtype,
+            Some(ScalarValue::Tuple(values)),
+        )?))
+    })
+}
+
+/// Create a fixed-size list scalar.
+///
+/// The element data type handle is borrowed, not consumed. The number of child
+/// scalars becomes the fixed-size list width and must fit in a 32-bit unsigned
+/// integer. Child scalar handles are cloned into the list value, so the caller
+/// keeps ownership of the handle array and each scalar in it. A NULL child
+/// handle array is allowed only for an empty list. Child values are validated
+/// against the element logical type.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_fixed_size_list(
+    element_dtype: *const vx_dtype,
+    elements: *const *const vx_scalar,
+    len: usize,
+    is_nullable: bool,
+    err: *mut *mut vx_error,
+) -> *mut vx_scalar {
+    try_or(err, ptr::null_mut(), || {
+        vortex_ensure!(!element_dtype.is_null(), "element dtype is null");
+        let size = u32::try_from(len)
+            .map_err(|_| vortex_err!("fixed-size list length {len} exceeds u32::MAX"))?;
+        let dtype = DType::FixedSizeList(
+            Arc::new(vx_dtype::as_ref(element_dtype).clone()),
+            size,
+            Nullability::from(is_nullable),
+        );
+        let values = scalar_values_from_raw(elements, len)?;
+        Ok(vx_scalar::new(Scalar::try_new(
+            dtype,
+            Some(ScalarValue::Tuple(values)),
+        )?))
+    })
+}
+
+/// Create a struct scalar.
+///
+/// The struct data type handle is borrowed, not consumed. Field scalar handles
+/// are cloned into the struct value, so the caller keeps ownership of the handle
+/// array and each scalar in it. Field count and field logical types are validated
+/// against the struct logical type. A NULL field handle array is allowed only for
+/// an empty struct value.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_new_struct(
+    struct_dtype: *const vx_dtype,
+    fields: *const *const vx_scalar,
+    len: usize,
+    err: *mut *mut vx_error,
+) -> *mut vx_scalar {
+    try_or(err, ptr::null_mut(), || {
+        vortex_ensure!(!struct_dtype.is_null(), "struct dtype is null");
+        let values = scalar_values_from_raw(fields, len)?;
+        Ok(vx_scalar::new(Scalar::try_new(
+            vx_dtype::as_ref(struct_dtype).clone(),
+            Some(ScalarValue::Tuple(values)),
+        )?))
+    })
+}
+
+fn decimal_scalar_from_value(
+    value: DecimalValue,
+    precision: u8,
+    scale: i8,
+    is_nullable: bool,
+) -> VortexResult<*mut vx_scalar> {
+    let decimal_dtype = DecimalDType::try_new(precision, scale)?;
+    Ok(vx_scalar::new(Scalar::try_new(
+        DType::Decimal(decimal_dtype, Nullability::from(is_nullable)),
+        Some(ScalarValue::Decimal(value)),
+    )?))
+}
+
+fn scalar_values_from_raw(
+    values: *const *const vx_scalar,
+    len: usize,
+) -> VortexResult<Vec<Option<ScalarValue>>> {
+    if len == 0 {
+        return Ok(Vec::new());
+    }
+    vortex_ensure!(!values.is_null(), "scalar pointer array is null");
+
+    unsafe { slice::from_raw_parts(values, len) }
+        .iter()
+        .enumerate()
+        .map(|(idx, value)| {
+            if value.is_null() {
+                vortex_bail!("scalar pointer at index {idx} is null");
+            }
+            Ok(vx_scalar::as_ref(*value).clone().into_value())
+        })
+        .collect()
+}
+
+fn bytes_from_raw<'a>(ptr: *const u8, len: usize, label: &str) -> VortexResult<&'a [u8]> {
+    if len == 0 {
+        return Ok(&[]);
+    }
+    vortex_ensure!(!ptr.is_null(), "{label} data pointer is null");
+    Ok(unsafe { slice::from_raw_parts(ptr, len) })
+}
+
+fn fixed_bytes_from_raw<const N: usize>(ptr: *const u8, label: &str) -> VortexResult<[u8; N]> {
+    vortex_ensure!(!ptr.is_null(), "{label} data pointer is null");
+    let mut bytes = [0u8; N];
+    bytes.copy_from_slice(unsafe { slice::from_raw_parts(ptr, N) });
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ptr;
+    use std::sync::Arc;
+
+    use vortex::dtype::DType;
+    use vortex::dtype::DecimalDType;
+    use vortex::dtype::Nullability;
+    use vortex::dtype::PType;
+    use vortex::dtype::StructFields;
+    use vortex::dtype::half::f16;
+    use vortex::scalar::DecimalValue;
+    use vortex::scalar::Scalar;
+
+    use crate::dtype::vx_dtype;
+    use crate::dtype::vx_dtype_free;
+    use crate::dtype::vx_dtype_new_bool;
+    use crate::dtype::vx_dtype_new_primitive;
+    use crate::ptype::vx_ptype;
+    use crate::scalar::vx_scalar;
+    use crate::scalar::vx_scalar_clone;
+    use crate::scalar::vx_scalar_dtype;
+    use crate::scalar::vx_scalar_free;
+    use crate::scalar::vx_scalar_is_null;
+    use crate::scalar::vx_scalar_new_binary;
+    use crate::scalar::vx_scalar_new_bool;
+    use crate::scalar::vx_scalar_new_decimal_i8;
+    use crate::scalar::vx_scalar_new_decimal_i16;
+    use crate::scalar::vx_scalar_new_decimal_i32;
+    use crate::scalar::vx_scalar_new_decimal_i64;
+    use crate::scalar::vx_scalar_new_decimal_i128_le;
+    use crate::scalar::vx_scalar_new_decimal_i256_le;
+    use crate::scalar::vx_scalar_new_f16_bits;
+    use crate::scalar::vx_scalar_new_f32;
+    use crate::scalar::vx_scalar_new_f64;
+    use crate::scalar::vx_scalar_new_fixed_size_list;
+    use crate::scalar::vx_scalar_new_i8;
+    use crate::scalar::vx_scalar_new_i16;
+    use crate::scalar::vx_scalar_new_i32;
+    use crate::scalar::vx_scalar_new_i64;
+    use crate::scalar::vx_scalar_new_list;
+    use crate::scalar::vx_scalar_new_null;
+    use crate::scalar::vx_scalar_new_struct;
+    use crate::scalar::vx_scalar_new_u8;
+    use crate::scalar::vx_scalar_new_u16;
+    use crate::scalar::vx_scalar_new_u32;
+    use crate::scalar::vx_scalar_new_u64;
+    use crate::scalar::vx_scalar_new_utf8;
+    use crate::tests::assert_error;
+    use crate::tests::assert_no_error;
+
+    fn assert_scalar(ptr: *mut vx_scalar, expected: Scalar) {
+        assert!(!ptr.is_null());
+        assert_eq!(vx_scalar::as_ref(ptr), &expected);
+        unsafe { vx_scalar_free(ptr) };
+    }
+
+    #[test]
+    fn test_primitive_scalar_constructors() {
+        unsafe {
+            assert_scalar(
+                vx_scalar_new_bool(true, true),
+                Scalar::bool(true, Nullability::Nullable),
+            );
+            assert_scalar(
+                vx_scalar_new_u8(42, false),
+                Scalar::primitive(42u8, Nullability::NonNullable),
+            );
+            assert_scalar(
+                vx_scalar_new_u16(42, true),
+                Scalar::primitive(42u16, Nullability::Nullable),
+            );
+            assert_scalar(
+                vx_scalar_new_u32(42, false),
+                Scalar::primitive(42u32, Nullability::NonNullable),
+            );
+            assert_scalar(
+                vx_scalar_new_u64(42, true),
+                Scalar::primitive(42u64, Nullability::Nullable),
+            );
+            assert_scalar(
+                vx_scalar_new_i8(-42, false),
+                Scalar::primitive(-42i8, Nullability::NonNullable),
+            );
+            assert_scalar(
+                vx_scalar_new_i16(-42, true),
+                Scalar::primitive(-42i16, Nullability::Nullable),
+            );
+            assert_scalar(
+                vx_scalar_new_i32(-42, true),
+                Scalar::primitive(-42i32, Nullability::Nullable),
+            );
+            assert_scalar(
+                vx_scalar_new_i64(-42, false),
+                Scalar::primitive(-42i64, Nullability::NonNullable),
+            );
+
+            let f16_value = f16::from_f32(1.5);
+            assert_scalar(
+                vx_scalar_new_f16_bits(f16_value.to_bits(), false),
+                Scalar::primitive(f16_value, Nullability::NonNullable),
+            );
+            assert_scalar(
+                vx_scalar_new_f32(1.5, true),
+                Scalar::primitive(1.5f32, Nullability::Nullable),
+            );
+            assert_scalar(
+                vx_scalar_new_f64(1.5, false),
+                Scalar::primitive(1.5f64, Nullability::NonNullable),
+            );
+        }
+    }
+
+    #[test]
+    fn test_utf8_binary_and_null_scalar_constructors() {
+        unsafe {
+            let mut error = ptr::null_mut();
+            let value = "literal";
+            assert_scalar(
+                vx_scalar_new_utf8(value.as_ptr().cast(), value.len(), false, &raw mut error),
+                Scalar::utf8(value, Nullability::NonNullable),
+            );
+            assert_no_error(error);
+
+            let invalid_utf8 = [0xffu8];
+            let scalar = vx_scalar_new_utf8(
+                invalid_utf8.as_ptr().cast(),
+                invalid_utf8.len(),
+                false,
+                &raw mut error,
+            );
+            assert!(scalar.is_null());
+            assert_error(error);
+
+            let bytes = b"\xde\xad\xbe\xef";
+            assert_scalar(
+                vx_scalar_new_binary(bytes.as_ptr(), bytes.len(), true, &raw mut error),
+                Scalar::binary(bytes.to_vec(), Nullability::Nullable),
+            );
+            assert_no_error(error);
+
+            let dtype = vx_dtype_new_primitive(vx_ptype::PTYPE_I32, false);
+            let null_scalar = vx_scalar_new_null(dtype, &raw mut error);
+            vx_dtype_free(dtype);
+            assert_no_error(error);
+            assert!(vx_scalar_is_null(null_scalar));
+            assert_eq!(
+                vx_dtype::as_ref(vx_scalar_dtype(null_scalar)),
+                &DType::Primitive(PType::I32, Nullability::Nullable)
+            );
+            vx_scalar_free(null_scalar);
+        }
+    }
+
+    #[test]
+    fn test_scalar_clone() {
+        unsafe {
+            let scalar = vx_scalar_new_u8(7, false);
+            let cloned = vx_scalar_clone(scalar);
+            assert_eq!(vx_scalar::as_ref(cloned), vx_scalar::as_ref(scalar));
+            vx_scalar_free(cloned);
+            vx_scalar_free(scalar);
+            assert!(vx_scalar_clone(ptr::null()).is_null());
+        }
+    }
+
+    #[test]
+    fn test_decimal_scalar_constructors() {
+        unsafe {
+            let mut error = ptr::null_mut();
+            assert_scalar(
+                vx_scalar_new_decimal_i16(999, 3, 0, false, &raw mut error),
+                Scalar::decimal(
+                    DecimalValue::I16(999),
+                    DecimalDType::new(3, 0),
+                    Nullability::NonNullable,
+                ),
+            );
+            assert_no_error(error);
+
+            assert_scalar(
+                vx_scalar_new_decimal_i32(999, 3, 0, true, &raw mut error),
+                Scalar::decimal(
+                    DecimalValue::I32(999),
+                    DecimalDType::new(3, 0),
+                    Nullability::Nullable,
+                ),
+            );
+            assert_no_error(error);
+
+            assert_scalar(
+                vx_scalar_new_decimal_i64(999, 3, 0, false, &raw mut error),
+                Scalar::decimal(
+                    DecimalValue::I64(999),
+                    DecimalDType::new(3, 0),
+                    Nullability::NonNullable,
+                ),
+            );
+            assert_no_error(error);
+
+            let scalar = vx_scalar_new_decimal_i8(100, 2, 0, false, &raw mut error);
+            assert!(scalar.is_null());
+            assert_error(error);
+
+            let i128_value = 12345i128;
+            assert_scalar(
+                vx_scalar_new_decimal_i128_le(
+                    i128_value.to_le_bytes().as_ptr(),
+                    10,
+                    2,
+                    true,
+                    &raw mut error,
+                ),
+                Scalar::decimal(
+                    DecimalValue::I128(i128_value),
+                    DecimalDType::new(10, 2),
+                    Nullability::Nullable,
+                ),
+            );
+            assert_no_error(error);
+
+            let i256_value = vortex::dtype::i256::from_i128(12345);
+            assert_scalar(
+                vx_scalar_new_decimal_i256_le(
+                    i256_value.to_le_bytes().as_ptr(),
+                    10,
+                    2,
+                    false,
+                    &raw mut error,
+                ),
+                Scalar::decimal(
+                    DecimalValue::I256(i256_value),
+                    DecimalDType::new(10, 2),
+                    Nullability::NonNullable,
+                ),
+            );
+            assert_no_error(error);
+        }
+    }
+
+    #[test]
+    fn test_nested_scalar_constructors() {
+        unsafe {
+            let mut error = ptr::null_mut();
+
+            let element_dtype = vx_dtype_new_primitive(vx_ptype::PTYPE_I32, false);
+            let child0 = vx_scalar_new_i32(1, false);
+            let child1 = vx_scalar_new_i32(2, false);
+            let children = [child0.cast_const(), child1.cast_const()];
+
+            assert_scalar(
+                vx_scalar_new_list(
+                    element_dtype,
+                    children.as_ptr(),
+                    children.len(),
+                    true,
+                    &raw mut error,
+                ),
+                Scalar::list(
+                    Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
+                    vec![
+                        Scalar::primitive(1i32, Nullability::NonNullable),
+                        Scalar::primitive(2i32, Nullability::NonNullable),
+                    ],
+                    Nullability::Nullable,
+                ),
+            );
+            assert_no_error(error);
+
+            assert_scalar(
+                vx_scalar_new_fixed_size_list(
+                    element_dtype,
+                    children.as_ptr(),
+                    children.len(),
+                    false,
+                    &raw mut error,
+                ),
+                Scalar::fixed_size_list(
+                    Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
+                    vec![
+                        Scalar::primitive(1i32, Nullability::NonNullable),
+                        Scalar::primitive(2i32, Nullability::NonNullable),
+                    ],
+                    Nullability::NonNullable,
+                ),
+            );
+            assert_no_error(error);
+
+            let wrong_child = vx_scalar_new_bool(true, false);
+            let wrong_children = [wrong_child.cast_const()];
+            let wrong = vx_scalar_new_list(
+                element_dtype,
+                wrong_children.as_ptr(),
+                wrong_children.len(),
+                false,
+                &raw mut error,
+            );
+            assert!(wrong.is_null());
+            assert_error(error);
+
+            let struct_dtype = vx_dtype::new(Arc::new(DType::Struct(
+                StructFields::new(
+                    ["flag", "value"].into(),
+                    vec![
+                        DType::Bool(Nullability::NonNullable),
+                        DType::Primitive(PType::I32, Nullability::NonNullable),
+                    ],
+                ),
+                Nullability::NonNullable,
+            )));
+            let flag = vx_scalar_new_bool(true, false);
+            let value = vx_scalar_new_i32(10, false);
+            let fields = [flag.cast_const(), value.cast_const()];
+            assert_scalar(
+                vx_scalar_new_struct(struct_dtype, fields.as_ptr(), fields.len(), &raw mut error),
+                Scalar::struct_(
+                    DType::Struct(
+                        StructFields::new(
+                            ["flag", "value"].into(),
+                            vec![
+                                DType::Bool(Nullability::NonNullable),
+                                DType::Primitive(PType::I32, Nullability::NonNullable),
+                            ],
+                        ),
+                        Nullability::NonNullable,
+                    ),
+                    vec![
+                        Scalar::bool(true, Nullability::NonNullable),
+                        Scalar::primitive(10i32, Nullability::NonNullable),
+                    ],
+                ),
+            );
+            assert_no_error(error);
+
+            let missing_field = vx_scalar_new_struct(
+                struct_dtype,
+                fields.as_ptr(),
+                fields.len() - 1,
+                &raw mut error,
+            );
+            assert!(missing_field.is_null());
+            assert_error(error);
+
+            vx_dtype_free(element_dtype);
+            vx_dtype_free(struct_dtype);
+            vx_scalar_free(child0);
+            vx_scalar_free(child1);
+            vx_scalar_free(wrong_child);
+            vx_scalar_free(flag);
+            vx_scalar_free(value);
+        }
+    }
+
+    #[test]
+    fn test_nested_null_inputs() {
+        unsafe {
+            let mut error = ptr::null_mut();
+            let dtype = vx_dtype_new_bool(false);
+            assert!(vx_scalar_new_list(dtype, ptr::null(), 1, false, &raw mut error).is_null());
+            assert_error(error);
+
+            let empty = vx_scalar_new_list(dtype, ptr::null(), 0, false, &raw mut error);
+            assert_no_error(error);
+            assert!(!empty.is_null());
+            vx_scalar_free(empty);
+            vx_dtype_free(dtype);
+        }
+    }
+}

--- a/vortex-ffi/src/scalar.rs
+++ b/vortex-ffi/src/scalar.rs
@@ -27,12 +27,13 @@ use crate::error::try_or;
 use crate::error::vx_error;
 
 crate::box_wrapper!(
-    /// Opaque handle to a `Scalar` struct: a pair of a logical `DType` and an optional
-    /// `ScalarValue` payload.
+    /// A `vx_scalar` stores a logical `DType` with an optional `ScalarValue`.
+    /// The `ScalarValue` is absent for a null scalar. Otherwise, the `DType`
+    /// gives the `ScalarValue` its meaning; for example, a tuple value can
+    /// represent a list, fixed-size list, or struct scalar depending on the
+    /// `DType`.
     ///
-    /// The C API exposes only the complete pair as `vx_scalar`, so
-    /// callers do not need to know enum layouts or maintain the `DType`/`ScalarValue`
-    /// invariants themselves.
+    /// The C API exposes only the complete pair as `vx_scalar`.
     Scalar,
     vx_scalar
 );
@@ -51,8 +52,9 @@ pub unsafe extern "C-unwind" fn vx_scalar_clone(scalar: *const vx_scalar) -> *mu
 
 /// Return the data type of a scalar.
 ///
-/// The returned data type handle borrows storage from the scalar handle and must
-/// not be freed separately. Returns NULL when given a NULL scalar handle.
+/// The returned data type handle borrows storage from the scalar handle, so its
+/// lifetime is bound to the scalar handle. It MUST NOT be freed separately.
+/// Returns NULL when given a NULL scalar handle.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_scalar_dtype(scalar: *const vx_scalar) -> *const vx_dtype {
     if scalar.is_null() {

--- a/vortex-ffi/src/scalar.rs
+++ b/vortex-ffi/src/scalar.rs
@@ -27,13 +27,12 @@ use crate::error::try_or;
 use crate::error::vx_error;
 
 crate::box_wrapper!(
-    /// A `vx_scalar` stores a logical `DType` with an optional `ScalarValue`.
-    /// The `ScalarValue` is absent for a null scalar. Otherwise, the `DType`
-    /// gives the `ScalarValue` its meaning; for example, a tuple value can
-    /// represent a list, fixed-size list, or struct scalar depending on the
-    /// `DType`.
+    /// A typed scalar value.
     ///
-    /// The C API exposes only the complete pair as `vx_scalar`.
+    /// A `vx_scalar` represents a single value with an associated `DType`.
+    /// Its value is either null or a `ScalarValue`. Null values are allowed only
+    /// when the associated `DType` allows nulls. Non-null values are represented
+    /// by `ScalarValue` and interpreted using the `DType`.
     Scalar,
     vx_scalar
 );

--- a/vortex-ffi/src/scan.rs
+++ b/vortex-ffi/src/scan.rs
@@ -439,7 +439,6 @@ mod tests {
 
     use vortex::VortexSessionDefault;
     use vortex::array::arrays::StructArray;
-    use vortex::expr::lit;
     use vortex::session::VortexSession;
     use vortex_array::ExecutionCtx;
     use vortex_array::arrays::struct_::StructArrayExt;
@@ -451,11 +450,12 @@ mod tests {
     use crate::data_source::vx_data_source_new;
     use crate::data_source::vx_data_source_options;
     use crate::expression::vx_binary_operator;
-    use crate::expression::vx_expression;
     use crate::expression::vx_expression_binary;
     use crate::expression::vx_expression_free;
     use crate::expression::vx_expression_get_item;
+    use crate::expression::vx_expression_literal_primitive;
     use crate::expression::vx_expression_root;
+    use crate::ptype::vx_ptype;
     use crate::scan::vx_data_source_scan;
     use crate::scan::vx_estimate;
     use crate::scan::vx_partition_free;
@@ -596,7 +596,12 @@ mod tests {
         unsafe {
             let root = vx_expression_root();
             let age_expr = vx_expression_get_item(c"age".as_ptr(), root);
-            let lit_100 = vx_expression::new(lit(100u64));
+            let value = 100u64;
+            let lit_100 = vx_expression_literal_primitive(
+                vx_ptype::PTYPE_U64,
+                (&raw const value).cast(),
+                false,
+            );
             let filter =
                 vx_expression_binary(vx_binary_operator::VX_OPERATOR_GTE, age_expr, lit_100);
 
@@ -621,7 +626,12 @@ mod tests {
         unsafe {
             let root = vx_expression_root();
             let age_expr = vx_expression_get_item(c"age".as_ptr(), root);
-            let lit_100 = vx_expression::new(lit(100u64));
+            let value = 100u64;
+            let lit_100 = vx_expression_literal_primitive(
+                vx_ptype::PTYPE_U64,
+                (&raw const value).cast(),
+                false,
+            );
             let filter =
                 vx_expression_binary(vx_binary_operator::VX_OPERATOR_GTE, age_expr, lit_100);
             let projection = vx_expression_get_item(c"age".as_ptr(), root);

--- a/vortex-ffi/src/scan.rs
+++ b/vortex-ffi/src/scan.rs
@@ -453,9 +453,10 @@ mod tests {
     use crate::expression::vx_expression_binary;
     use crate::expression::vx_expression_free;
     use crate::expression::vx_expression_get_item;
-    use crate::expression::vx_expression_literal_primitive;
+    use crate::expression::vx_expression_literal;
     use crate::expression::vx_expression_root;
-    use crate::ptype::vx_ptype;
+    use crate::scalar::vx_scalar_free;
+    use crate::scalar::vx_scalar_new_u64;
     use crate::scan::vx_data_source_scan;
     use crate::scan::vx_estimate;
     use crate::scan::vx_partition_free;
@@ -596,12 +597,11 @@ mod tests {
         unsafe {
             let root = vx_expression_root();
             let age_expr = vx_expression_get_item(c"age".as_ptr(), root);
-            let value = 100u64;
-            let lit_100 = vx_expression_literal_primitive(
-                vx_ptype::PTYPE_U64,
-                (&raw const value).cast(),
-                false,
-            );
+            let value = vx_scalar_new_u64(100, false);
+            let mut error = ptr::null_mut();
+            let lit_100 = vx_expression_literal(value, &raw mut error);
+            assert_no_error(error);
+            vx_scalar_free(value);
             let filter =
                 vx_expression_binary(vx_binary_operator::VX_OPERATOR_GTE, age_expr, lit_100);
 
@@ -626,12 +626,11 @@ mod tests {
         unsafe {
             let root = vx_expression_root();
             let age_expr = vx_expression_get_item(c"age".as_ptr(), root);
-            let value = 100u64;
-            let lit_100 = vx_expression_literal_primitive(
-                vx_ptype::PTYPE_U64,
-                (&raw const value).cast(),
-                false,
-            );
+            let value = vx_scalar_new_u64(100, false);
+            let mut error = ptr::null_mut();
+            let lit_100 = vx_expression_literal(value, &raw mut error);
+            assert_no_error(error);
+            vx_scalar_free(value);
             let filter =
                 vx_expression_binary(vx_binary_operator::VX_OPERATOR_GTE, age_expr, lit_100);
             let projection = vx_expression_get_item(c"age".as_ptr(), root);

--- a/vortex-ffi/test/scan.cpp
+++ b/vortex-ffi/test/scan.cpp
@@ -650,7 +650,15 @@ TEST_CASE("Filter with literal expression", "[filter]") {
     };
 
     uint8_t threshold = 50;
-    vx_expression *threshold_expr = vx_expression_literal_primitive(PTYPE_U8, &threshold, false);
+    vx_scalar *threshold_scalar = vx_scalar_new_u8(threshold, false);
+    REQUIRE(threshold_scalar != nullptr);
+    defer {
+        vx_scalar_free(threshold_scalar);
+    };
+
+    vx_error *literal_error = nullptr;
+    vx_expression *threshold_expr = vx_expression_literal(threshold_scalar, &literal_error);
+    require_no_error(literal_error);
     REQUIRE(threshold_expr != nullptr);
     defer {
         vx_expression_free(threshold_expr);
@@ -681,6 +689,44 @@ TEST_CASE("Filter with literal expression", "[filter]") {
 
     for (size_t i = 0; i < vx_array_len(filtered_age); ++i) {
         REQUIRE(vx_array_get_u8(filtered_age, i) == static_cast<uint8_t>(threshold + i));
+    }
+}
+
+TEST_CASE("Project UTF-8 literal expression", "[projection]") {
+    constexpr auto value = "constant"sv;
+    vx_error *scalar_error = nullptr;
+    vx_scalar *literal_scalar =
+        vx_scalar_new_utf8(value.data(), value.size(), false, &scalar_error);
+    require_no_error(scalar_error);
+    REQUIRE(literal_scalar != nullptr);
+    defer {
+        vx_scalar_free(literal_scalar);
+    };
+
+    vx_error *literal_error = nullptr;
+    vx_expression *literal_expr = vx_expression_literal(literal_scalar, &literal_error);
+    require_no_error(literal_error);
+    REQUIRE(literal_expr != nullptr);
+    defer {
+        vx_expression_free(literal_expr);
+    };
+
+    vx_scan_options opts = {};
+    opts.projection = literal_expr;
+    const vx_array *array = scan_with_options(opts);
+    defer {
+        vx_array_free(array);
+    };
+
+    REQUIRE(vx_array_len(array) == SAMPLE_ROWS);
+
+    for (size_t i : {size_t {0}, SAMPLE_ROWS - 1}) {
+        const vx_string *actual = vx_array_get_utf8(array, static_cast<uint32_t>(i));
+        REQUIRE(actual != nullptr);
+        defer {
+            vx_string_free(actual);
+        };
+        REQUIRE(to_string_view(actual) == value);
     }
 }
 

--- a/vortex-ffi/test/scan.cpp
+++ b/vortex-ffi/test/scan.cpp
@@ -695,8 +695,7 @@ TEST_CASE("Filter with literal expression", "[filter]") {
 TEST_CASE("Project UTF-8 literal expression", "[projection]") {
     constexpr auto value = "constant"sv;
     vx_error *scalar_error = nullptr;
-    vx_scalar *literal_scalar =
-        vx_scalar_new_utf8(value.data(), value.size(), false, &scalar_error);
+    vx_scalar *literal_scalar = vx_scalar_new_utf8(value.data(), value.size(), false, &scalar_error);
     require_no_error(scalar_error);
     REQUIRE(literal_scalar != nullptr);
     defer {

--- a/vortex-ffi/test/scan.cpp
+++ b/vortex-ffi/test/scan.cpp
@@ -637,6 +637,53 @@ TEST_CASE("Project single field", "[projection]") {
     }
 }
 
+TEST_CASE("Filter with literal expression", "[filter]") {
+    vx_expression *root = vx_expression_root();
+    defer {
+        vx_expression_free(root);
+    };
+
+    vx_expression *age_field = vx_expression_get_item("age", root);
+    REQUIRE(age_field != nullptr);
+    defer {
+        vx_expression_free(age_field);
+    };
+
+    uint8_t threshold = 50;
+    vx_expression *threshold_expr = vx_expression_literal_primitive(PTYPE_U8, &threshold, false);
+    REQUIRE(threshold_expr != nullptr);
+    defer {
+        vx_expression_free(threshold_expr);
+    };
+
+    vx_expression *filter = vx_expression_binary(VX_OPERATOR_GTE, age_field, threshold_expr);
+    REQUIRE(filter != nullptr);
+    defer {
+        vx_expression_free(filter);
+    };
+
+    vx_scan_options opts = {};
+    opts.filter = filter;
+    const vx_array *array = scan_with_options(opts);
+    defer {
+        vx_array_free(array);
+    };
+
+    REQUIRE(vx_array_len(array) == SAMPLE_ROWS - threshold);
+
+    vx_error *error = nullptr;
+    const vx_array *filtered_age = vx_array_get_field(array, 0, &error);
+    require_no_error(error);
+    REQUIRE(filtered_age != nullptr);
+    defer {
+        vx_array_free(filtered_age);
+    };
+
+    for (size_t i = 0; i < vx_array_len(filtered_age); ++i) {
+        REQUIRE(vx_array_get_u8(filtered_age, i) == static_cast<uint8_t>(threshold + i));
+    }
+}
+
 void compare_schemas(const UniqueSchema &left, const UniqueSchema &right) {
     REQUIRE(std::string_view {left->format} == std::string_view {right->format});
     REQUIRE(left->n_children == right->n_children);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! We appreciate your time and effort.

Please make sure to provide enough information so that we can review your pull
request. The Summary and Testing sections below contain guidance on what to
include.
-->

## Summary

Add support for literal expressions in `vortex-ffi`

Motivation example: 

Сallers need constants in expression trees to create scan predicates that can be pushed down, for example:

```sql
age >= 67
price >= decimal(1512.0)
```

Introduce `vx_scalar` as an opaque ffi handle that exposes a typed Vortex scalar (`DType` + `optional ScalarValue`) and `vx_expression_literal` that allows to create literal expression nodes from scalar handle

## API Changes

### Scalar:

`vx_scalar_new_*` creates a Rust `Scalar` and returns it as an owned opaque boxed handle (`vx_scalar *`). APIs that take `const vx_scalar *` borrow the handle; `vx_expression_literal` clones the underlying scalar into the expression, so the caller can free the original handle after construction

```c
vx_scalar *vx_scalar_new_u8(uint8_t value, bool is_nullable);
vx_scalar *vx_scalar_new_utf8(const char *ptr, size_t len, bool is_nullable, vx_error **err);
vx_scalar *vx_scalar_new_null(const vx_dtype *dtype, vx_error **err);

const vx_dtype *vx_scalar_dtype(const vx_scalar *scalar);
bool vx_scalar_is_null(const vx_scalar *scalar);
vx_scalar *vx_scalar_clone(const vx_scalar *scalar);
void vx_scalar_free(vx_scalar *scalar);
```

### Literal expression:

`vx_expression_literal` clones the scalar into the expression, so the original scalar can be freed immediately after expression creation:

```c
vx_expression *root = vx_expression_root();
vx_expression *age = vx_expression_get_item("age", root);

vx_scalar *threshold_scalar = vx_scalar_new_u8(67, false);
vx_expression *threshold = vx_expression_literal(threshold_scalar, &error);
vx_scalar_free(threshold_scalar);

vx_expression *filter = vx_expression_binary(VX_OPERATOR_GTE, age, threshold);

vx_scan_options options = {};
options.filter = filter;
```

## Testing

Verifying new behavior and functionality works correctly

AI disclosure: Claude was used to add tests

<!--
Please describe how this change was tested. Here are some common categories for
testing in Vortex:

1. Verifying existing behavior is maintained.
2. Verifying new behavior and functionality works correctly.
4. Serialization compatibility (backwards and forwards) should be maintained or
   explicitly broken.
-->
