### PR TITLE
Add epic and tracking issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,77 @@
+---
+name: Epic
+about: Public roadmap umbrella for a major Vortex initiative.
+title: "Epic: "
+labels: epic
+---
+
+<!--
+An Epic is a public roadmap umbrella for a major Vortex initiative. It should
+explain the goal, why it matters, what is out of scope, and where concrete work
+is tracked.
+
+Attach related tracking issues with GitHub's "Create sub-issue" or "Add
+existing sub-issue" button. The sub-issue panel tracks progress, so this issue
+does not need a checklist.
+
+Keep Epic issues readable. Route discussion elsewhere:
+
+- Open-ended scope or product questions: open a GitHub Discussion and link it
+  here.
+- Design debate scoped to one piece of work: open a tracking issue as a
+  sub-issue and discuss it there.
+- Bug reports: file a bug issue and reference this Epic.
+
+Short clarifying comments are fine. Long threads should be redirected.
+-->
+
+This Epic is for ...
+
+<!--
+One or two sentences. State the initiative and link any roadmap, design, or
+external context that helps readers understand the scope.
+-->
+
+## Status
+
+<!--
+Proposed / Active / Blocked / Complete. Briefly explain the current state.
+-->
+
+## Goal
+
+<!--
+One short paragraph covering both:
+
+- What "done" looks like for a user or downstream consumer. Name the concrete
+  API, format, encoding, or benchmark.
+- What people might reasonably expect this Epic to cover but it will not.
+  Non-goals stop scope creep.
+-->
+
+## Motivation
+
+<!--
+Why this, why now? Cover:
+
+- The concrete problem and who/what hits it. Examples: a downstream integration
+  (DataFusion, DuckDB, Python, Java), a benchmark gap (TPC-H, ClickBench,
+  vortex-bench), or a file format or encoding limitation.
+- What is currently blocked, slower, or larger than it should be. Link the
+  benchmark numbers, profile output, or related issues.
+
+If the answer is "it would be nice to have", the Epic is not ready.
+-->
+
+## Unresolved questions
+
+<!--
+Scope-level questions that must be answered before this Epic closes.
+Implementation questions belong in the relevant tracking issue.
+
+Each entry should be specific enough that a future reader can tell whether it
+has been answered. If a question grows large, please create a new tracking
+issue or Discussion and link it.
+-->
+
+- [ ] None yet.

--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -1,0 +1,86 @@
+---
+name: Tracking Issue
+about: Implementation context for work likely to span multiple PRs.
+title: "Tracking Issue: "
+labels: tracking-issue
+---
+
+<!--
+Tracking issues are for work that needs shared implementation context and is
+likely to span multiple PRs. Use this template when the issue should track
+planning, implementation, stabilization, and follow-through.
+
+Route discussion elsewhere:
+
+- New ideas, fit questions, or early design feedback: start with a GitHub
+  Discussion.
+- Bug reports surfaced while implementing: file a bug issue and reference this
+  tracking issue.
+- A design thread big enough to need its own page: spawn a tracking issue (as
+  a sub-issue of this one if it is narrow) and discuss it there.
+
+Tracking issues should be understandable a year from creation. Short clarifying
+comments are fine. Long threads should be redirected.
+-->
+
+This is a tracking issue for ...
+
+<!--
+One or two sentences. State what the feature is and where it lives in the
+codebase (crate, module, file format, encoding). Link the parent Epic, design
+doc, prototype PR, or external reference.
+-->
+
+## Design
+
+<!--
+Optional but recommended. Size to fit the work:
+
+- API additions: a stripped-down signature block. Rust traits or functions,
+  file-format struct, or wire-format message. Drop doc comments and bodies.
+- Behavioral changes: a short before / after description, ideally with a small
+  example.
+- Architectural changes: a paragraph explaining the new shape, or a link to a
+  design doc.
+
+Skip only if the change is fully obvious from the title. The Design section is
+what lets a reviewer judge whether the Steps below are the right ones.
+-->
+
+## Steps
+
+<!--
+Major checkpoints required to call this feature done. A handful of milestones,
+not every PR. Tick steps as they land; do not delete them.
+
+Steps are milestones, not PRs (initial implementation, documentation,
+stabilization). If a step is itself a separable shippable unit, promote it to
+a sub-issue.
+-->
+
+- [ ] Initial implementation
+- [ ] Documentation
+- [ ] Public API stabilization
+
+## Unresolved questions
+
+<!--
+Open design or implementation questions blocking progress. Link discussions
+and conclusions so a future reader can see how each question was settled.
+
+If a question is large enough to need its own thread, spawn a tracking issue
+or Discussion and link it.
+-->
+
+- [ ] None yet.
+
+## Implementation history
+
+<!--
+A running log of every PR that touched this feature: initial implementation,
+follow-ups, fixes, reverts. Grows continuously and is never ticked off. The
+archaeology trail for someone reading this issue a year later.
+
+Add PRs as they merge, in chronological order. A one-line description per PR
+is helpful but not required.
+-->


### PR DESCRIPTION
## Summary

Adds an epic and tracking issue template. We are moving writing down what things are being worked on / things we would like to work on, and this is a deliberate step in normalizing that behavior.

Obviously this is not something that we all need to follow exactly, but I think this is a generally helpful practice: forcing ourselves to write down this information will benefit us in the long-term.

Happy to make changes to some of the description wording, but I do feel quite strongly that each of the sections in here are important to write about.

## Unresolved Questions

- Should we name the labels `C-epic` and `C-tracking-issue` instead (C for category)? Probably not, but this is what the Rust project does. We probably don't need that until we have too many labels (we don't really have that many labels).

## Testing

N/A