### PR TITLE
remove SessionVar blanket impl, replace with type impls

### DIFF
--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -762,6 +762,12 @@ impl core::fmt::Debug for vortex_array::aggregate_fn::session::AggregateFnSessio
 
 pub fn vortex_array::aggregate_fn::session::AggregateFnSession::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
+impl vortex_session::SessionVar for vortex_array::aggregate_fn::session::AggregateFnSession
+
+pub fn vortex_array::aggregate_fn::session::AggregateFnSession::as_any(&self) -> &dyn core::any::Any
+
+pub fn vortex_array::aggregate_fn::session::AggregateFnSession::as_any_mut(&mut self) -> &mut dyn core::any::Any
+
 pub trait vortex_array::aggregate_fn::session::AggregateFnSessionExt: vortex_session::SessionExt
 
 pub fn vortex_array::aggregate_fn::session::AggregateFnSessionExt::aggregate_fns(&self) -> vortex_session::Ref<'_, vortex_array::aggregate_fn::session::AggregateFnSession>
@@ -9044,6 +9050,12 @@ impl core::fmt::Debug for vortex_array::dtype::session::DTypeSession
 
 pub fn vortex_array::dtype::session::DTypeSession::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
+impl vortex_session::SessionVar for vortex_array::dtype::session::DTypeSession
+
+pub fn vortex_array::dtype::session::DTypeSession::as_any(&self) -> &dyn core::any::Any
+
+pub fn vortex_array::dtype::session::DTypeSession::as_any_mut(&mut self) -> &mut dyn core::any::Any
+
 pub trait vortex_array::dtype::session::DTypeSessionExt: vortex_session::SessionExt
 
 pub fn vortex_array::dtype::session::DTypeSessionExt::dtypes(&self) -> vortex_session::Ref<'_, vortex_array::dtype::session::DTypeSession>
@@ -13374,6 +13386,12 @@ impl core::fmt::Debug for vortex_array::memory::MemorySession
 
 pub fn vortex_array::memory::MemorySession::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
+impl vortex_session::SessionVar for vortex_array::memory::MemorySession
+
+pub fn vortex_array::memory::MemorySession::as_any(&self) -> &dyn core::any::Any
+
+pub fn vortex_array::memory::MemorySession::as_any_mut(&mut self) -> &mut dyn core::any::Any
+
 pub struct vortex_array::memory::WritableHostBuffer
 
 impl vortex_array::memory::WritableHostBuffer
@@ -13479,6 +13497,12 @@ pub fn vortex_array::optimizer::kernels::ArrayKernels::default() -> vortex_array
 impl core::fmt::Debug for vortex_array::optimizer::kernels::ArrayKernels
 
 pub fn vortex_array::optimizer::kernels::ArrayKernels::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_session::SessionVar for vortex_array::optimizer::kernels::ArrayKernels
+
+pub fn vortex_array::optimizer::kernels::ArrayKernels::as_any(&self) -> &dyn core::any::Any
+
+pub fn vortex_array::optimizer::kernels::ArrayKernels::as_any_mut(&mut self) -> &mut dyn core::any::Any
 
 pub trait vortex_array::optimizer::kernels::ArrayKernelsExt: vortex_session::SessionExt
 
@@ -17602,6 +17626,12 @@ impl core::fmt::Debug for vortex_array::scalar_fn::session::ScalarFnSession
 
 pub fn vortex_array::scalar_fn::session::ScalarFnSession::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
+impl vortex_session::SessionVar for vortex_array::scalar_fn::session::ScalarFnSession
+
+pub fn vortex_array::scalar_fn::session::ScalarFnSession::as_any(&self) -> &dyn core::any::Any
+
+pub fn vortex_array::scalar_fn::session::ScalarFnSession::as_any_mut(&mut self) -> &mut dyn core::any::Any
+
 pub trait vortex_array::scalar_fn::session::ScalarFnSessionExt: vortex_session::SessionExt
 
 pub fn vortex_array::scalar_fn::session::ScalarFnSessionExt::scalar_fns(&self) -> vortex_session::Ref<'_, vortex_array::scalar_fn::session::ScalarFnSession>
@@ -19055,6 +19085,12 @@ pub fn vortex_array::session::ArraySession::default() -> Self
 impl core::fmt::Debug for vortex_array::session::ArraySession
 
 pub fn vortex_array::session::ArraySession::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_session::SessionVar for vortex_array::session::ArraySession
+
+pub fn vortex_array::session::ArraySession::as_any(&self) -> &dyn core::any::Any
+
+pub fn vortex_array::session::ArraySession::as_any_mut(&mut self) -> &mut dyn core::any::Any
 
 pub trait vortex_array::session::ArraySessionExt: vortex_session::SessionExt
 

--- a/vortex-array/src/aggregate_fn/session.rs
+++ b/vortex-array/src/aggregate_fn/session.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
 use vortex_session::Ref;
 use vortex_session::SessionExt;
+use vortex_session::SessionVar;
 use vortex_session::registry::Registry;
 use vortex_utils::aliases::hash_map::HashMap;
 
@@ -40,6 +42,16 @@ pub struct AggregateFnSession {
 
     pub(super) kernels: RwLock<HashMap<KernelKey, &'static dyn DynAggregateKernel>>,
     pub(super) grouped_kernels: RwLock<HashMap<KernelKey, &'static dyn DynGroupedAggregateKernel>>,
+}
+
+impl SessionVar for AggregateFnSession {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
 }
 
 type KernelKey = (ArrayId, Option<AggregateFnId>);

--- a/vortex-array/src/dtype/session.rs
+++ b/vortex-array/src/dtype/session.rs
@@ -3,10 +3,12 @@
 
 //! Module for managing extension dtypes in a Vortex session.
 
+use std::any::Any;
 use std::sync::Arc;
 
 use vortex_session::Ref;
 use vortex_session::SessionExt;
+use vortex_session::SessionVar;
 use vortex_session::registry::Registry;
 
 use crate::dtype::extension::ExtDTypePluginRef;
@@ -36,6 +38,16 @@ impl Default for DTypeSession {
         this.register(Timestamp);
 
         this
+    }
+}
+
+impl SessionVar for DTypeSession {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
     }
 }
 

--- a/vortex-array/src/memory.rs
+++ b/vortex-array/src/memory.rs
@@ -3,6 +3,7 @@
 
 //! Session-scoped memory allocation for host-side buffers.
 
+use std::any::Any;
 use std::fmt::Debug;
 use std::mem::size_of;
 use std::sync::Arc;
@@ -18,6 +19,7 @@ use vortex_error::vortex_err;
 use vortex_session::Ref;
 use vortex_session::RefMut;
 use vortex_session::SessionExt;
+use vortex_session::SessionVar;
 
 /// Mutable host buffer contract used by [`WritableHostBuffer`].
 pub trait HostBufferMut: Send + 'static {
@@ -196,6 +198,16 @@ impl MemorySession {
 impl Default for MemorySession {
     fn default() -> Self {
         Self::new(Arc::new(DefaultHostAllocator))
+    }
+}
+
+impl SessionVar for MemorySession {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
     }
 }
 

--- a/vortex-array/src/optimizer/kernels.rs
+++ b/vortex-array/src/optimizer/kernels.rs
@@ -17,6 +17,7 @@
 //! sessions can add it with [`VortexSession::with`](vortex_session::VortexSession::with) or rely
 //! on [`ArrayKernelsExt::kernels`] to insert the default value.
 
+use std::any::Any;
 use std::hash::BuildHasher;
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -25,6 +26,7 @@ use arc_swap::ArcSwap;
 use vortex_error::VortexResult;
 use vortex_session::Ref;
 use vortex_session::SessionExt;
+use vortex_session::SessionVar;
 use vortex_session::registry::Id;
 use vortex_utils::aliases::DefaultHashBuilder;
 use vortex_utils::aliases::hash_map::HashMap;
@@ -97,6 +99,16 @@ impl ArrayKernels {
     /// [`FnRegistry`]. All typed helpers use this path so registration and lookup agree.
     fn hash_fn_ids(&self, parent: Id, child: Id) -> u64 {
         FN_HASHER.hash_one((parent, child))
+    }
+}
+
+impl SessionVar for ArrayKernels {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
     }
 }
 

--- a/vortex-array/src/scalar_fn/session.rs
+++ b/vortex-array/src/scalar_fn/session.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
 use std::sync::Arc;
 
 use vortex_session::Ref;
 use vortex_session::SessionExt;
+use vortex_session::SessionVar;
 use vortex_session::registry::Registry;
 
 use crate::scalar_fn::ScalarFnPluginRef;
@@ -71,6 +73,16 @@ impl Default for ScalarFnSession {
         this.register(Select);
 
         this
+    }
+}
+
+impl SessionVar for ScalarFnSession {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
     }
 }
 

--- a/vortex-array/src/session/mod.rs
+++ b/vortex-array/src/session/mod.rs
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
 use std::sync::Arc;
 
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_session::Ref;
 use vortex_session::SessionExt;
+use vortex_session::SessionVar;
 use vortex_session::registry::Registry;
 
 use crate::ArrayRef;
@@ -82,6 +84,16 @@ impl Default for ArraySession {
         this.register(VarBin);
 
         this
+    }
+}
+
+impl SessionVar for ArraySession {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
     }
 }
 

--- a/vortex-cuda/src/session.rs
+++ b/vortex-cuda/src/session.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -10,6 +11,7 @@ use vortex::array::VortexSessionExecute;
 use vortex::error::VortexResult;
 use vortex::session::Ref;
 use vortex::session::SessionExt;
+use vortex::session::SessionVar;
 use vortex::utils::aliases::dash_map::DashMap;
 
 use crate::ExportDeviceArray;
@@ -144,6 +146,16 @@ impl Default for CudaSession {
         let this = Self::new(context);
         initialize_cuda(&this);
         this
+    }
+}
+
+impl SessionVar for CudaSession {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
     }
 }
 

--- a/vortex-file/src/multi/session.rs
+++ b/vortex-file/src/multi/session.rs
@@ -3,10 +3,12 @@
 
 //! Session extension for multi-file scanning, providing a shared footer cache.
 
+use std::any::Any;
 use std::fmt;
 use std::fmt::Debug;
 
 use vortex_session::SessionExt;
+use vortex_session::SessionVar;
 
 use crate::footer::Footer;
 
@@ -58,6 +60,16 @@ impl MultiFileSession {
     /// Store a footer under the given file path.
     pub fn put_footer(&self, path: &str, footer: Footer) {
         self.footer_cache.insert(path.to_string(), footer);
+    }
+}
+
+impl SessionVar for MultiFileSession {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
     }
 }
 

--- a/vortex-io/public-api.lock
+++ b/vortex-io/public-api.lock
@@ -488,6 +488,12 @@ impl core::fmt::Debug for vortex_io::session::RuntimeSession
 
 pub fn vortex_io::session::RuntimeSession::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
+impl vortex_session::SessionVar for vortex_io::session::RuntimeSession
+
+pub fn vortex_io::session::RuntimeSession::as_any(&self) -> &dyn core::any::Any
+
+pub fn vortex_io::session::RuntimeSession::as_any_mut(&mut self) -> &mut dyn core::any::Any
+
 pub trait vortex_io::session::RuntimeSessionExt: vortex_session::SessionExt
 
 pub fn vortex_io::session::RuntimeSessionExt::handle(&self) -> vortex_io::runtime::Handle

--- a/vortex-io/src/session.rs
+++ b/vortex-io/src/session.rs
@@ -1,16 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
 use std::fmt::Debug;
 
 use vortex_error::VortexExpect;
 use vortex_session::SessionExt;
+use vortex_session::SessionVar;
 
 use crate::runtime::Handle;
 
 /// Session state for Vortex async runtimes.
 pub struct RuntimeSession {
     handle: Option<Handle>,
+}
+
+impl SessionVar for RuntimeSession {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
 }
 
 impl Default for RuntimeSession {

--- a/vortex-layout/public-api.lock
+++ b/vortex-layout/public-api.lock
@@ -1414,6 +1414,12 @@ impl core::fmt::Debug for vortex_layout::session::LayoutSession
 
 pub fn vortex_layout::session::LayoutSession::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
+impl vortex_session::SessionVar for vortex_layout::session::LayoutSession
+
+pub fn vortex_layout::session::LayoutSession::as_any(&self) -> &dyn core::any::Any
+
+pub fn vortex_layout::session::LayoutSession::as_any_mut(&mut self) -> &mut dyn core::any::Any
+
 pub trait vortex_layout::session::LayoutSessionExt: vortex_session::SessionExt
 
 pub fn vortex_layout::session::LayoutSessionExt::layouts(&self) -> vortex_session::Ref<'_, vortex_layout::session::LayoutSession>

--- a/vortex-layout/src/session.rs
+++ b/vortex-layout/src/session.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
+
 use vortex_session::Ref;
 use vortex_session::SessionExt;
+use vortex_session::SessionVar;
 use vortex_session::registry::Registry;
 
 use crate::LayoutEncodingRef;
@@ -51,6 +54,15 @@ impl Default for LayoutSession {
         layouts.register(DictLayoutEncoding.id(), DictLayoutEncoding.as_ref());
 
         Self { registry: layouts }
+    }
+}
+
+impl SessionVar for LayoutSession {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
     }
 }
 

--- a/vortex-session/public-api.lock
+++ b/vortex-session/public-api.lock
@@ -239,9 +239,3 @@ pub trait vortex_session::SessionVar: core::any::Any + core::marker::Send + core
 pub fn vortex_session::SessionVar::as_any(&self) -> &dyn core::any::Any
 
 pub fn vortex_session::SessionVar::as_any_mut(&mut self) -> &mut dyn core::any::Any
-
-impl<T: core::marker::Send + core::marker::Sync + core::fmt::Debug + 'static> vortex_session::SessionVar for T
-
-pub fn T::as_any(&self) -> &dyn core::any::Any
-
-pub fn T::as_any_mut(&mut self) -> &mut dyn core::any::Any

--- a/vortex-session/src/lib.rs
+++ b/vortex-session/src/lib.rs
@@ -83,6 +83,16 @@ struct UnknownPluginPolicy {
     allow_unknown: bool,
 }
 
+impl SessionVar for UnknownPluginPolicy {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
 /// Trait for accessing and modifying the state of a Vortex session.
 pub trait SessionExt: Sized + private::Sealed {
     /// Returns the [`VortexSession`].
@@ -211,16 +221,6 @@ impl Hasher for IdHasher {
 pub trait SessionVar: Any + Send + Sync + Debug + 'static {
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
-}
-
-impl<T: Send + Sync + Debug + 'static> SessionVar for T {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
 }
 
 // NOTE(ngates): we don't want to expose that the internals of a session is a DashMap, so we have

--- a/vortex-session/src/lib.rs
+++ b/vortex-session/src/lib.rs
@@ -218,6 +218,8 @@ impl Hasher for IdHasher {
 }
 
 /// This trait defines variables that can be stored against a Vortex session.
+///
+/// Users should implement this trait for anything that you want to store on a `VortexSession`.
 pub trait SessionVar: Any + Send + Sync + Debug + 'static {
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;


### PR DESCRIPTION
The blanket impl is a bit of a footgun, replace with impls for each of the session extension types

See discussion in https://github.com/vortex-data/vortex/pull/7693#issuecomment-4335695797

Playground link that illustrates what the blanket impl is doing: https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=86edbba2a1f4d7e4fb46f281fb21a8c3