### PR TITLE
Expression pushdown for duckdb

### DIFF
--- a/vortex-bench/src/runner.rs
+++ b/vortex-bench/src/runner.rs
@@ -184,10 +184,11 @@ impl SqlBenchmarkRunner {
         if let Some(expected_counts) = &self.expected_row_counts
             && query_idx < expected_counts.len()
         {
+            let expected = expected_counts[query_idx];
             assert_eq!(
                 row_count,
-                expected_counts[query_idx],
-                "Row count mismatch for query {query_idx} - {engine}:{format}",
+                expected,
+                "Row count mismatch for query {query_idx} - {engine}:{format}, expected {expected}, got {row_count}",
                 engine = self.engine,
             );
         }

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -15,6 +15,11 @@ DUCKDB_INCLUDES_BEGIN
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_between_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 DUCKDB_INCLUDES_END
 
 using namespace duckdb;
@@ -263,11 +268,22 @@ void function(ClientContext &, TableFunctionInput &input, DataChunk &output) {
     }
 }
 
-void c_pushdown_complex_filter(ClientContext &,
-                               LogicalGet &,
-                               FunctionData *bind_data,
-                               vector<unique_ptr<Expression>> &filters) {
-    auto &bind = bind_data->Cast<CTableBindData>();
+using FilterVec = vector<unique_ptr<Expression>>;
+
+/*
+ * Table filter pushdown is used for two tasks in duckdb:
+ *
+ * 1. Prune files based on filename or hive partitioning, see Parquet
+ * filter pushdown. We don't use this because we do own file-level pruning in
+ * FileStatsLayoutReader, and we don't support hive partitioning yet.
+ *
+ * 2. Avoid reading unused file data. Filter expressions are pushed to Vortex,
+ * converted to Vortex expressions and used during the scan.
+ * Duckdb pushes a subset of expressions i.e. equality operators, and also
+ * expressions which return true in pushdown_expression.
+ */
+void pushdown_complex_filter(const FunctionData &bind_data, FilterVec &filters) {
+    const auto &bind = bind_data.Cast<CTableBindData>();
     void *const ffi_bind = bind.ffi_data->DataPtr();
     duckdb_vx_error error_out = nullptr;
 
@@ -278,8 +294,6 @@ void c_pushdown_complex_filter(ClientContext &,
         if (error_out) {
             throw BinderException(IntoErrString(error_out));
         }
-
-        // If the pushdown complex filter returns true, we can remove the filter from the list.
         iter = pushed ? filters.erase(iter) : std::next(iter);
     }
 }
@@ -381,6 +395,9 @@ InsertionOrderPreservingMap<string> c_to_string(TableFunctionToStringInput &inpu
     return result;
 }
 
+// pushdown_expression misses FunctionData so we can't place it in vtab
+extern "C" bool duckdb_vx_pushdown_expression(duckdb_vx_expr expr);
+
 extern "C" duckdb_state duckdb_vx_tfunc_register(duckdb_database ffi_db, const duckdb_vx_tfunc_vtab_t *vtab) {
     D_ASSERT(ffi_db);
     D_ASSERT(vtab);
@@ -394,7 +411,12 @@ extern "C" duckdb_state duckdb_vx_tfunc_register(duckdb_database ffi_db, const d
     tf.filter_prune = true;
     tf.sampling_pushdown = false;
 
-    tf.pushdown_complex_filter = c_pushdown_complex_filter;
+    tf.pushdown_expression = [](auto &, const auto &, Expression &expression) {
+        return duckdb_vx_pushdown_expression(reinterpret_cast<duckdb_vx_expr>(&expression));
+    };
+    tf.pushdown_complex_filter = [](auto &, auto &, FunctionData *bind_data, FilterVec &filters) {
+        pushdown_complex_filter(*bind_data, filters);
+    };
     tf.cardinality = c_cardinality;
     tf.get_partition_info = get_partition_info;
     tf.get_partition_data = get_partition_data;

--- a/vortex-duckdb/include/vortex.h
+++ b/vortex-duckdb/include/vortex.h
@@ -38,6 +38,8 @@ const char *vortex_version_rust(void);
  */
 const char *vortex_extension_version_rust(void);
 
+bool duckdb_vx_pushdown_expression(duckdb_vx_expr expr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/vortex-duckdb/src/convert/expr.rs
+++ b/vortex-duckdb/src/convert/expr.rs
@@ -14,6 +14,7 @@ use vortex::error::vortex_err;
 use vortex::expr::Expression;
 use vortex::expr::and_collect;
 use vortex::expr::col;
+use vortex::expr::get_item;
 use vortex::expr::is_not_null;
 use vortex::expr::is_null;
 use vortex::expr::list_contains;
@@ -33,20 +34,134 @@ use vortex::scalar_fn::fns::operators::Operator;
 
 use crate::cpp::DUCKDB_VX_EXPR_TYPE;
 use crate::duckdb;
+use crate::duckdb::BoundFunction;
+use crate::duckdb::BoundOperator;
+use crate::duckdb::ExpressionClass;
+use crate::duckdb::ExpressionClass::BoundBetween;
+use crate::duckdb::ExpressionClass::BoundColumnRef;
+use crate::duckdb::ExpressionClass::BoundComparison;
+use crate::duckdb::ExpressionClass::BoundConjunction;
+use crate::duckdb::ExpressionClass::BoundConstant;
+use crate::duckdb::ExpressionClass::BoundRef;
 
-const DUCKDB_FUNCTION_NAME_CONTAINS: &str = "contains";
-
-fn like_pattern_str(value: &duckdb::ExpressionRef) -> VortexResult<Option<String>> {
+fn from_bound_str(value: &duckdb::ExpressionRef) -> VortexResult<String> {
     match value.as_class().vortex_expect("unknown class") {
-        duckdb::ExpressionClass::BoundConstant(constant) => {
-            Ok(Some(format!("%{}%", constant.value.as_string().as_str())))
-        }
-        _ => Ok(None),
+        BoundConstant(constant) => Ok(constant.value.as_string().as_str().to_owned()),
+        _ => vortex_bail!("Expected string expression, got {:?}", value.as_class_id()),
     }
+}
+
+fn try_from_bound_function(
+    func: &BoundFunction,
+    col_sub: Option<&Expression>,
+) -> VortexResult<Option<Expression>> {
+    let expr = match func.scalar_function.name() {
+        "struct_extract" => {
+            let children: Vec<_> = func.children().collect();
+            vortex_ensure!(children.len() == 2);
+            let Some(child) = try_from_expression_inner(children[0], col_sub)? else {
+                return Ok(None);
+            };
+            let field = from_bound_str(children[1])?;
+            get_item(field, child)
+        }
+        like @ ("~~" | "!~~") => {
+            let children: Vec<_> = func.children().collect();
+            vortex_ensure!(children.len() == 2);
+            let Some(string) = try_from_expression_inner(children[0], col_sub)? else {
+                return Ok(None);
+            };
+            let Some(target) = try_from_expression_inner(children[1], col_sub)? else {
+                return Ok(None);
+            };
+            let opts = LikeOptions {
+                negated: like == "!~~",
+                case_insensitive: false,
+            };
+            Like.new_expr(opts, [string, target])
+        }
+        matchers @ ("contains" | "prefix" | "suffix") => {
+            let children: Vec<_> = func.children().collect();
+            vortex_ensure!(children.len() == 2);
+            let Some(value) = try_from_expression_inner(children[0], col_sub)? else {
+                return Ok(None);
+            };
+            let pattern = from_bound_str(children[1])?;
+            let pattern = match matchers {
+                "contains" => format!("%{pattern}%"),
+                "prefix" => format!("{pattern}%"),
+                "suffix" => format!("%{pattern}"),
+                _ => unreachable!(),
+            };
+            Like.new_expr(LikeOptions::default(), [value, lit(pattern)])
+        }
+        _ => {
+            debug!("bound function {}", func.scalar_function.name());
+            return Ok(None);
+        }
+    };
+
+    Ok(Some(expr))
 }
 
 pub fn try_from_bound_expression(
     value: &duckdb::ExpressionRef,
+) -> VortexResult<Option<Expression>> {
+    try_from_expression_inner(value, None)
+}
+
+pub(super) fn try_from_bound_expression_with_col_sub(
+    value: &duckdb::ExpressionRef,
+    col_sub: &Expression,
+) -> VortexResult<Option<Expression>> {
+    try_from_expression_inner(value, Some(col_sub))
+}
+
+pub fn can_push_expression(value: &duckdb::ExpressionRef) -> bool {
+    let Some(value) = value.as_class() else {
+        return false;
+    };
+    match value {
+        BoundColumnRef(_) => true,
+        BoundConstant(_) => true,
+        BoundRef => true,
+        BoundComparison(comp) => can_push_expression(comp.left) && can_push_expression(comp.right),
+        BoundBetween(between) => {
+            can_push_expression(between.input)
+                && can_push_expression(between.lower)
+                && can_push_expression(between.upper)
+        }
+        BoundConjunction(conj) => conj.children().all(can_push_expression),
+        ExpressionClass::BoundFunction(func) => {
+            let name = func.scalar_function.name();
+            name == "struct_extract"
+                || name == "contains"
+                || name == "prefix"
+                || name == "suffix"
+                || name == "~~"
+                || name == "!~~"
+        }
+        ExpressionClass::BoundOperator(op) => {
+            if !matches!(
+                op.op,
+                DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_OPERATOR_NOT
+                    | DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_OPERATOR_IS_NULL
+                    | DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_OPERATOR_IS_NOT_NULL
+                    | DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_COMPARE_IN
+                    | DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_COMPARE_NOT_IN
+            ) {
+                return false;
+            }
+            op.children().all(can_push_expression)
+        }
+    }
+}
+
+// If you want to add support for other expressions, also change
+// can_push_expression
+fn try_from_expression_inner(
+    value: &duckdb::ExpressionRef,
+    col_sub: Option<&Expression>,
 ) -> VortexResult<Option<Expression>> {
     let Some(value) = value.as_class() else {
         debug!(
@@ -56,28 +171,34 @@ pub fn try_from_bound_expression(
         return Ok(None);
     };
     Ok(Some(match value {
-        duckdb::ExpressionClass::BoundColumnRef(col_ref) => col(col_ref.name.as_ref()),
-        duckdb::ExpressionClass::BoundConstant(const_) => lit(Scalar::try_from(const_.value)?),
-        duckdb::ExpressionClass::BoundComparison(compare) => {
+        BoundRef => {
+            let Some(col) = col_sub else {
+                vortex_bail!("BoundRef requested but no column supplied");
+            };
+            col.clone()
+        }
+        BoundColumnRef(col_ref) => col(col_ref.name.as_ref()),
+        BoundConstant(const_) => lit(Scalar::try_from(const_.value)?),
+        BoundComparison(compare) => {
             let operator: Operator = compare.op.try_into()?;
 
-            let Some(left) = try_from_bound_expression(compare.left)? else {
+            let Some(left) = try_from_expression_inner(compare.left, col_sub)? else {
                 return Ok(None);
             };
-            let Some(right) = try_from_bound_expression(compare.right)? else {
+            let Some(right) = try_from_expression_inner(compare.right, col_sub)? else {
                 return Ok(None);
             };
 
             Binary.new_expr(operator, [left, right])
         }
-        duckdb::ExpressionClass::BoundBetween(between) => {
-            let Some(array) = try_from_bound_expression(between.input)? else {
+        BoundBetween(between) => {
+            let Some(array) = try_from_expression_inner(between.input, col_sub)? else {
                 return Ok(None);
             };
-            let Some(lower) = try_from_bound_expression(between.lower)? else {
+            let Some(lower) = try_from_expression_inner(between.lower, col_sub)? else {
                 return Ok(None);
             };
-            let Some(upper) = try_from_bound_expression(between.upper)? else {
+            let Some(upper) = try_from_expression_inner(between.upper, col_sub)? else {
                 return Ok(None);
             };
             Between.new_expr(
@@ -96,13 +217,13 @@ pub fn try_from_bound_expression(
                 [array, lower, upper],
             )
         }
-        duckdb::ExpressionClass::BoundOperator(operator) => match operator.op {
+        ExpressionClass::BoundOperator(operator) => match operator.op {
             DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_OPERATOR_NOT
             | DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_OPERATOR_IS_NULL
             | DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_OPERATOR_IS_NOT_NULL => {
                 let children: Vec<_> = operator.children().collect();
                 vortex_ensure!(children.len() == 1);
-                let Some(child) = try_from_bound_expression(children[0])? else {
+                let Some(child) = try_from_expression_inner(children[0], col_sub)? else {
                     return Ok(None);
                 };
                 match operator.op {
@@ -115,70 +236,23 @@ pub fn try_from_bound_expression(
                 }
             }
             DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_COMPARE_IN => {
-                // First child is element, rest form the list.
-                let children: Vec<_> = operator.children().collect();
-                vortex_ensure!(children.len() >= 2);
-                let Some(element) = try_from_bound_expression(children[0])? else {
-                    return Ok(None);
-                };
-
-                let Some(list_elements) = children
-                    .iter()
-                    .skip(1)
-                    .map(|c| {
-                        let Some(value) = try_from_bound_expression(c)? else {
-                            return Ok(None);
-                        };
-                        Ok(Some(
-                            value
-                                .as_opt::<Literal>()
-                                .ok_or_else(|| {
-                                    vortex_err!("cannot have a non literal in a in_list")
-                                })?
-                                .clone(),
-                        ))
-                    })
-                    .collect::<VortexResult<Option<Vec<_>>>>()?
-                else {
-                    return Ok(None);
-                };
-                let list = Scalar::list(
-                    Arc::new(list_elements[0].dtype().clone()),
-                    list_elements,
-                    Nullability::Nullable,
-                );
-                list_contains(lit(list), element)
+                return try_from_compare_in(operator, col_sub, false);
+            }
+            DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_COMPARE_NOT_IN => {
+                return try_from_compare_in(operator, col_sub, true);
             }
             _ => {
                 debug!(op=?operator.op, "cannot push down operator");
                 return Ok(None);
             }
         },
-        duckdb::ExpressionClass::BoundFunction(func) => match func.scalar_function.name() {
-            DUCKDB_FUNCTION_NAME_CONTAINS => {
-                let children: Vec<_> = func.children().collect();
-                assert_eq!(children.len(), 2);
-                let Some(value) = try_from_bound_expression(children[0])? else {
-                    return Ok(None);
-                };
-                let Some(pattern_lit) = like_pattern_str(children[1])? else {
-                    vortex_bail!("expected pattern to be bound string")
-                };
-                let pattern = lit(pattern_lit);
-                Like.new_expr(LikeOptions::default(), [value, pattern])
-            }
-            _ => {
-                debug!(
-                    name = func.scalar_function.name(),
-                    "cannot push down function"
-                );
-                return Ok(None);
-            }
-        },
-        duckdb::ExpressionClass::BoundConjunction(conj) => {
+        ExpressionClass::BoundFunction(func) => {
+            return try_from_bound_function(&func, col_sub);
+        }
+        BoundConjunction(conj) => {
             let Some(children) = conj
                 .children()
-                .map(try_from_bound_expression)
+                .map(|c| try_from_expression_inner(c, col_sub))
                 .collect::<VortexResult<Option<Vec<_>>>>()?
             else {
                 return Ok(None);
@@ -194,6 +268,46 @@ pub fn try_from_bound_expression(
             }
         }
     }))
+}
+
+fn try_from_compare_in(
+    operator: BoundOperator,
+    col_sub: Option<&Expression>,
+    not_in: bool,
+) -> VortexResult<Option<Expression>> {
+    // First child is element, rest form the list.
+    let children: Vec<_> = operator.children().collect();
+    assert!(children.len() >= 2);
+    let Some(element) = try_from_expression_inner(children[0], col_sub)? else {
+        return Ok(None);
+    };
+
+    let Some(list_elements) = children
+        .iter()
+        .skip(1)
+        .map(|c| {
+            let Some(value) = try_from_expression_inner(c, col_sub)? else {
+                return Ok(None);
+            };
+            Ok(Some(
+                value
+                    .as_opt::<Literal>()
+                    .ok_or_else(|| vortex_err!("cannot have a non literal in a in_list"))?
+                    .clone(),
+            ))
+        })
+        .collect::<VortexResult<Option<Vec<_>>>>()?
+    else {
+        return Ok(None);
+    };
+    let list = Scalar::list(
+        Arc::new(list_elements[0].dtype().clone()),
+        list_elements,
+        Nullability::Nullable,
+    );
+
+    let expr = list_contains(lit(list), element);
+    Ok(Some(if not_in { not(expr) } else { expr }))
 }
 
 impl TryFrom<DUCKDB_VX_EXPR_TYPE> for Operator {

--- a/vortex-duckdb/src/convert/mod.rs
+++ b/vortex-duckdb/src/convert/mod.rs
@@ -10,6 +10,7 @@ mod vector;
 #[cfg(test)]
 pub use dtype::FromLogicalType;
 pub use dtype::from_duckdb_table;
+pub use expr::can_push_expression;
 pub use expr::try_from_bound_expression;
 pub use scalar::*;
 pub use table_filter::try_from_table_filter;

--- a/vortex-duckdb/src/convert/table_filter.rs
+++ b/vortex-duckdb/src/convert/table_filter.rs
@@ -26,6 +26,7 @@ use vortex::scalar_fn::fns::binary::Binary;
 use vortex::scalar_fn::fns::operators::CompareOperator;
 use vortex::scan::selection::Selection;
 
+use super::expr::try_from_bound_expression_with_col_sub;
 use crate::cpp::DUCKDB_VX_EXPR_TYPE;
 use crate::duckdb::ExtractedValue;
 use crate::duckdb::TableFilterClass;
@@ -123,8 +124,10 @@ pub fn try_from_table_filter(
             )
         }
         TableFilterClass::ExpressionRef(expr) => {
-            // TODO(ngates): figure out which column ID DuckDB is using for the expression.
-            vortex_bail!("expression table filter is not supported: {}", expr);
+            match try_from_bound_expression_with_col_sub(expr, col)? {
+                Some(expression) => expression,
+                None => return Ok(None),
+            }
         }
         TableFilterClass::Bloom => {
             vortex_bail!("bloom filter table filter is not supported")

--- a/vortex-duckdb/src/duckdb/expr.rs
+++ b/vortex-duckdb/src/duckdb/expr.rs
@@ -139,6 +139,9 @@ impl ExpressionRef {
                         bind_info: out.bind_info,
                     })
                 }
+                cpp::DUCKDB_VX_EXPR_CLASS::DUCKDB_VX_EXPR_CLASS_BOUND_REF => {
+                    ExpressionClass::BoundRef
+                }
                 _ => {
                     return None;
                 }
@@ -155,6 +158,8 @@ pub enum ExpressionClass<'a> {
     BoundBetween(BoundBetween<'a>),
     BoundOperator(BoundOperator<'a>),
     BoundFunction(BoundFunction<'a>),
+    /// Column inside ExpressionFilter for expression pushed down to Vortex.
+    BoundRef,
 }
 
 pub struct BoundColumnRef {

--- a/vortex-duckdb/src/duckdb/table_function/mod.rs
+++ b/vortex-duckdb/src/duckdb/table_function/mod.rs
@@ -16,6 +16,7 @@ mod init;
 pub use bind::*;
 pub use init::*;
 
+use crate::convert::can_push_expression;
 use crate::cpp;
 use crate::duckdb::DataChunk;
 use crate::duckdb::DatabaseRef;
@@ -171,6 +172,26 @@ impl DatabaseRef {
 
         Ok(())
     }
+}
+
+/*
+ * Called before pushdown_complex_filter or a table filter expression call.
+ * As we support complex filter pushdown, Duckdb pushes expressions to Vortex.
+ * However, it doesn't know what type of expressions we can handle. Here we list
+ * all expressions that are quaranteed to be converted to Vortex expressions.
+ *
+ * If we return true here, and expression is in the list for
+ * pushdown_complex_filter, we must handle it, or query engine will break.
+ *
+ * Example: we don't support substr() expression so we tell Duckdb we can't
+ * push it.
+ * Example: optional filters may fail to parse on our side (we return
+ * Ok(None)), so we don't allow pushing these.
+ */
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn duckdb_vx_pushdown_expression(expr: cpp::duckdb_vx_expr) -> bool {
+    let expr = unsafe { Expression::borrow(expr) };
+    can_push_expression(expr)
 }
 
 unsafe extern "C-unwind" fn to_string_callback<T: TableFunction>(

--- a/vortex-sqllogictest/slt/strings.slt
+++ b/vortex-sqllogictest/slt/strings.slt
@@ -22,3 +22,20 @@ query T
 SELECT string_agg(str, ',') FROM '$__TEST_DIR__/strings.vortex' WHERE str LIKE '%He%';
 ----
 Hello,Hey
+
+query T
+SELECT string_agg(str, ',') FROM '$__TEST_DIR__/strings.vortex' WHERE contains(str, 'e');
+----
+Hello,Hey
+
+onlyif duckdb
+query T
+SELECT string_agg(str, ',') FROM '$__TEST_DIR__/strings.vortex' WHERE prefix(str, 'He');
+----
+Hello,Hey
+
+onlyif duckdb
+query T
+SELECT string_agg(str, ',') FROM '$__TEST_DIR__/strings.vortex' WHERE suffix(str, 'lo');
+----
+Hello


### PR DESCRIPTION
- Support expression pushdown similarly to how it's done for
filter pushdown.
- Support pushing down constants, comparisons, IN/NOT in, struct_extract, contains, prefix, suffix, and LIKE/NOT LIKE.
