### PR TITLE
skip[fuzz]: allow generation of longer arrays 

### DIFF
--- a/encodings/runend/src/arbitrary.rs
+++ b/encodings/runend/src/arbitrary.rs
@@ -9,6 +9,7 @@ use vortex_array::LEGACY_SESSION;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::arbitrary::ArbitraryArray;
+use vortex_array::arrays::arbitrary::ArbitraryArrayConfig;
 use vortex_array::arrays::arbitrary::ArbitraryWith;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
@@ -49,7 +50,7 @@ impl ArbitraryRunEndArray {
             let ends = PrimitiveArray::from_iter(Vec::<u64>::new()).into_array();
             let values = ArbitraryArray::arbitrary_with_config(
                 u,
-                &vortex_array::arrays::arbitrary::ArbitraryArrayConfig {
+                &ArbitraryArrayConfig {
                     dtype: Some(dtype.clone()),
                     len: 0..=0,
                 },
@@ -63,7 +64,7 @@ impl ArbitraryRunEndArray {
         // Generate arbitrary values for each run
         let values = ArbitraryArray::arbitrary_with_config(
             u,
-            &vortex_array::arrays::arbitrary::ArbitraryArrayConfig {
+            &ArbitraryArrayConfig {
                 dtype: Some(dtype.clone()),
                 len: num_runs..=num_runs,
             },

--- a/encodings/runend/src/arbitrary.rs
+++ b/encodings/runend/src/arbitrary.rs
@@ -9,6 +9,7 @@ use vortex_array::LEGACY_SESSION;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::arbitrary::ArbitraryArray;
+use vortex_array::arrays::arbitrary::ArbitraryWith;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
@@ -46,14 +47,28 @@ impl ArbitraryRunEndArray {
         if num_runs == 0 {
             // Empty RunEndArray
             let ends = PrimitiveArray::from_iter(Vec::<u64>::new()).into_array();
-            let values = ArbitraryArray::arbitrary_with(u, Some(0), dtype)?.0;
+            let values = ArbitraryArray::arbitrary_with_config(
+                u,
+                &vortex_array::arrays::arbitrary::ArbitraryArrayConfig {
+                    dtype: Some(dtype.clone()),
+                    len: 0..=0,
+                },
+            )?
+            .0;
             let runend_array = RunEnd::try_new(ends, values, &mut ctx)
                 .vortex_expect("Empty RunEndArray creation should succeed");
             return Ok(ArbitraryRunEndArray(runend_array));
         }
 
         // Generate arbitrary values for each run
-        let values = ArbitraryArray::arbitrary_with(u, Some(num_runs), dtype)?.0;
+        let values = ArbitraryArray::arbitrary_with_config(
+            u,
+            &vortex_array::arrays::arbitrary::ArbitraryArrayConfig {
+                dtype: Some(dtype.clone()),
+                len: num_runs..=num_runs,
+            },
+        )?
+        .0;
 
         // Generate strictly increasing ends
         // Each end must be > previous end, and first end must be >= 1

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -49,6 +49,8 @@ use vortex_array::aggregate_fn::fns::sum::sum;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::arbitrary::ArbitraryArray;
+use vortex_array::arrays::arbitrary::ArbitraryArrayConfig;
+use vortex_array::arrays::arbitrary::ArbitraryWith;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
@@ -67,6 +69,7 @@ use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 use vortex_utils::aliases::hash_set::HashSet;
 
+use crate::FUZZ_ARRAY_LEN_RANGE;
 use crate::SESSION;
 use crate::error::Backtrace;
 use crate::error::VortexFuzzError;
@@ -170,7 +173,14 @@ impl ExpectedValue {
 
 impl<'a> Arbitrary<'a> for FuzzArrayAction {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let array = ArbitraryArray::arbitrary(u)?.0;
+        let array = ArbitraryArray::arbitrary_with_config(
+            u,
+            &ArbitraryArrayConfig {
+                dtype: None,
+                len: FUZZ_ARRAY_LEN_RANGE,
+            },
+        )?
+        .0;
         let mut current_array = array.clone();
 
         let mut ctx = SESSION.create_execution_ctx();

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -69,7 +69,7 @@ use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 use vortex_utils::aliases::hash_set::HashSet;
 
-use crate::FUZZ_ARRAY_LEN_RANGE;
+use crate::FUZZ_ARRAY_MAX_LEN;
 use crate::SESSION;
 use crate::error::Backtrace;
 use crate::error::VortexFuzzError;
@@ -177,7 +177,7 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
             u,
             &ArbitraryArrayConfig {
                 dtype: None,
-                len: FUZZ_ARRAY_LEN_RANGE,
+                len: 0..=FUZZ_ARRAY_MAX_LEN,
             },
         )?
         .0;

--- a/fuzz/src/file/mod.rs
+++ b/fuzz/src/file/mod.rs
@@ -5,10 +5,13 @@ use arbitrary::Arbitrary;
 use arbitrary::Unstructured;
 use vortex_array::ArrayRef;
 use vortex_array::arrays::arbitrary::ArbitraryArray;
+use vortex_array::arrays::arbitrary::ArbitraryArrayConfig;
+use vortex_array::arrays::arbitrary::ArbitraryWith;
 use vortex_array::expr::Expression;
 use vortex_array::expr::arbitrary::filter_expr;
 use vortex_array::expr::arbitrary::projection_expr;
 
+use crate::FUZZ_ARRAY_LEN_RANGE;
 use crate::array::CompressorStrategy;
 
 #[derive(Debug)]
@@ -21,7 +24,14 @@ pub struct FuzzFileAction {
 
 impl<'a> Arbitrary<'a> for FuzzFileAction {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let array = ArbitraryArray::arbitrary(u)?.0;
+        let array = ArbitraryArray::arbitrary_with_config(
+            u,
+            &ArbitraryArrayConfig {
+                dtype: None,
+                len: FUZZ_ARRAY_LEN_RANGE,
+            },
+        )?
+        .0;
         let dtype = array.dtype().clone();
         Ok(FuzzFileAction {
             array,

--- a/fuzz/src/file/mod.rs
+++ b/fuzz/src/file/mod.rs
@@ -11,7 +11,7 @@ use vortex_array::expr::Expression;
 use vortex_array::expr::arbitrary::filter_expr;
 use vortex_array::expr::arbitrary::projection_expr;
 
-use crate::FUZZ_ARRAY_LEN_RANGE;
+use crate::FUZZ_ARRAY_MAX_LEN;
 use crate::array::CompressorStrategy;
 
 #[derive(Debug)]
@@ -28,7 +28,7 @@ impl<'a> Arbitrary<'a> for FuzzFileAction {
             u,
             &ArbitraryArrayConfig {
                 dtype: None,
-                len: FUZZ_ARRAY_LEN_RANGE,
+                len: 0..=FUZZ_ARRAY_MAX_LEN,
             },
         )?
         .0;

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -3,8 +3,6 @@
 
 #![expect(clippy::use_debug)]
 
-use std::ops::RangeInclusive;
-
 mod array;
 pub mod compress;
 pub mod error;

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -34,7 +34,7 @@ pub use gpu::FuzzCompressGpu;
 #[cfg(feature = "cuda")]
 pub use gpu::run_compress_gpu;
 
-pub const FUZZ_ARRAY_LEN_RANGE: RangeInclusive<usize> = 0..=16_384;
+pub const FUZZ_ARRAY_MAX_LEN: usize = 16_384;
 
 // Runtime initialization - platform-specific
 #[cfg(not(target_arch = "wasm32"))]

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![expect(clippy::use_debug)]
 
+use std::ops::RangeInclusive;
+
 mod array;
 pub mod compress;
 pub mod error;
@@ -31,6 +33,8 @@ pub use fsst_like::run_fsst_like_fuzz;
 pub use gpu::FuzzCompressGpu;
 #[cfg(feature = "cuda")]
 pub use gpu::run_compress_gpu;
+
+pub const FUZZ_ARRAY_LEN_RANGE: RangeInclusive<usize> = 0..=16_384;
 
 // Runtime initialization - platform-specific
 #[cfg(not(target_arch = "wasm32"))]

--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -2,9 +2,11 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::iter;
+use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use arbitrary::Arbitrary;
+use arbitrary::Error::IncorrectFormat;
 use arbitrary::Result;
 use arbitrary::Unstructured;
 use vortex_buffer::BitBuffer;
@@ -41,10 +43,44 @@ use crate::validity::Validity;
 #[derive(Clone, Debug)]
 pub struct ArbitraryArray(pub ArrayRef);
 
+/// Trait for generating arbitrary values with a caller-provided configuration.
+pub trait ArbitraryWith<'a, C>: Sized {
+    /// Generate an arbitrary value using the provided configuration.
+    fn arbitrary_with_config(u: &mut Unstructured<'a>, config: &C) -> Result<Self>;
+}
+
+/// Configuration for arbitrary array generation.
+#[derive(Clone, Debug)]
+pub struct ArbitraryArrayConfig {
+    /// Fixed dtype, or `None` to generate one from [`Unstructured`].
+    pub dtype: Option<DType>,
+    /// Inclusive range for the total array length.
+    pub len: RangeInclusive<usize>,
+}
+
 impl<'a> Arbitrary<'a> for ArbitraryArray {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         let dtype = u.arbitrary()?;
         Self::arbitrary_with(u, None, &dtype)
+    }
+}
+
+impl<'a> ArbitraryWith<'a, ArbitraryArrayConfig> for ArbitraryArray {
+    fn arbitrary_with_config(
+        u: &mut Unstructured<'a>,
+        config: &ArbitraryArrayConfig,
+    ) -> Result<Self> {
+        if config.len.is_empty() {
+            return Err(IncorrectFormat);
+        }
+
+        let dtype = match &config.dtype {
+            Some(dtype) => dtype.clone(),
+            None => u.arbitrary()?,
+        };
+        let len = u.int_in_range(config.len.clone())?;
+
+        random_array(u, &dtype, Some(len)).map(ArbitraryArray)
     }
 }
 

--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -58,18 +58,6 @@ pub struct ArbitraryArrayConfig {
     pub len: RangeInclusive<usize>,
 }
 
-// impl<'a> Arbitrary<'a> for ArbitraryArray {
-//     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-//         Self::arbitrary_with_config(
-//             u,
-//             &ArbitraryArrayConfig {
-//                 dtype: None,
-//                 len: 0..=FUZZ_ARRAY_MAX_LEN,
-//             },
-//         )
-//     }
-// }
-
 impl<'a> ArbitraryWith<'a, ArbitraryArrayConfig> for ArbitraryArray {
     fn arbitrary_with_config(
         u: &mut Unstructured<'a>,

--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -58,17 +58,17 @@ pub struct ArbitraryArrayConfig {
     pub len: RangeInclusive<usize>,
 }
 
-impl<'a> Arbitrary<'a> for ArbitraryArray {
-    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        Self::arbitrary_with_config(
-            u,
-            &ArbitraryArrayConfig {
-                dtype: None,
-                len: DEFAULT_ARRAY_LEN_RANGE,
-            },
-        )
-    }
-}
+// impl<'a> Arbitrary<'a> for ArbitraryArray {
+//     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+//         Self::arbitrary_with_config(
+//             u,
+//             &ArbitraryArrayConfig {
+//                 dtype: None,
+//                 len: 0..=FUZZ_ARRAY_MAX_LEN,
+//             },
+//         )
+//     }
+// }
 
 impl<'a> ArbitraryWith<'a, ArbitraryArrayConfig> for ArbitraryArray {
     fn arbitrary_with_config(

--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -60,8 +60,13 @@ pub struct ArbitraryArrayConfig {
 
 impl<'a> Arbitrary<'a> for ArbitraryArray {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        let dtype = u.arbitrary()?;
-        Self::arbitrary_with(u, None, &dtype)
+        Self::arbitrary_with_config(
+            u,
+            &ArbitraryArrayConfig {
+                dtype: None,
+                len: DEFAULT_ARRAY_LEN_RANGE,
+            },
+        )
     }
 }
 
@@ -81,12 +86,6 @@ impl<'a> ArbitraryWith<'a, ArbitraryArrayConfig> for ArbitraryArray {
         let len = u.int_in_range(config.len.clone())?;
 
         random_array(u, &dtype, Some(len)).map(ArbitraryArray)
-    }
-}
-
-impl ArbitraryArray {
-    pub fn arbitrary_with(u: &mut Unstructured, len: Option<usize>, dtype: &DType) -> Result<Self> {
-        random_array(u, dtype, len).map(ArbitraryArray)
     }
 }
 

--- a/vortex-array/src/arrays/dict/arbitrary.rs
+++ b/vortex-array/src/arrays/dict/arbitrary.rs
@@ -13,6 +13,7 @@ use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::arbitrary::ArbitraryArray;
+use crate::arrays::arbitrary::ArbitraryWith;
 use crate::arrays::arbitrary::random_validity;
 use crate::dtype::DType;
 use crate::dtype::NativePType;
@@ -36,7 +37,14 @@ impl ArbitraryDictArray {
         // Generate the number of unique values (dictionary size)
         let values_len = u.int_in_range(1..=20)?;
         // Generate values array with the given dtype
-        let values = ArbitraryArray::arbitrary_with(u, Some(values_len), dtype)?.0;
+        let values = ArbitraryArray::arbitrary_with_config(
+            u,
+            &crate::arrays::arbitrary::ArbitraryArrayConfig {
+                dtype: Some(dtype.clone()),
+                len: values_len..=values_len,
+            },
+        )?
+        .0;
 
         // Generate codes that index into the values
         let codes_len = len.unwrap_or(u.int_in_range(0..=100)?);

--- a/vortex-array/src/arrays/dict/arbitrary.rs
+++ b/vortex-array/src/arrays/dict/arbitrary.rs
@@ -13,6 +13,7 @@ use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::arbitrary::ArbitraryArray;
+use crate::arrays::arbitrary::ArbitraryArrayConfig;
 use crate::arrays::arbitrary::ArbitraryWith;
 use crate::arrays::arbitrary::random_validity;
 use crate::dtype::DType;
@@ -39,7 +40,7 @@ impl ArbitraryDictArray {
         // Generate values array with the given dtype
         let values = ArbitraryArray::arbitrary_with_config(
             u,
-            &crate::arrays::arbitrary::ArbitraryArrayConfig {
+            &ArbitraryArrayConfig {
                 dtype: Some(dtype.clone()),
                 len: values_len..=values_len,
             },


### PR DESCRIPTION
Allow the fuzzer to create longer arrays to exercise more file_io logic (e.g. zone_map partitions).

Adds a new trait `ArbitraryWith` and `ArbitraryArrayConfig` to express this.

```rust
/// Trait for generating arbitrary values with a caller-provided configuration.
pub trait ArbitraryWith<'a, C>: Sized {
    /// Generate an arbitrary value using the provided configuration.
    fn arbitrary_with_config(u: &mut Unstructured<'a>, config: &C) -> Result<Self>;
}

/// Configuration for arbitrary array generation.
#[derive(Clone, Debug)]
pub struct ArbitraryArrayConfig {
    /// Fixed dtype, or `None` to generate one from [`Unstructured`].
    pub dtype: Option<DType>,
    /// Inclusive range for the total array length.
    pub len: RangeInclusive<usize>,
}
```