### PR TITLE
Array operations fuzzer operates on smaller arrays

### DIFF
--- a/fuzz/src/file/mod.rs
+++ b/fuzz/src/file/mod.rs
@@ -11,7 +11,7 @@ use vortex_array::expr::Expression;
 use vortex_array::expr::arbitrary::filter_expr;
 use vortex_array::expr::arbitrary::projection_expr;
 
-use crate::FUZZ_ARRAY_MAX_LEN;
+use crate::{FUZZ_ARRAY_MAX_LEN, FUZZ_FILE_ARRAY_MAX_LEN};
 use crate::array::CompressorStrategy;
 
 #[derive(Debug)]
@@ -28,7 +28,7 @@ impl<'a> Arbitrary<'a> for FuzzFileAction {
             u,
             &ArbitraryArrayConfig {
                 dtype: None,
-                len: 0..=FUZZ_ARRAY_MAX_LEN,
+                len: 0..=FUZZ_FILE_ARRAY_MAX_LEN,
             },
         )?
         .0;

--- a/fuzz/src/file/mod.rs
+++ b/fuzz/src/file/mod.rs
@@ -11,7 +11,7 @@ use vortex_array::expr::Expression;
 use vortex_array::expr::arbitrary::filter_expr;
 use vortex_array::expr::arbitrary::projection_expr;
 
-use crate::{FUZZ_ARRAY_MAX_LEN, FUZZ_FILE_ARRAY_MAX_LEN};
+use crate::FUZZ_FILE_ARRAY_MAX_LEN;
 use crate::array::CompressorStrategy;
 
 #[derive(Debug)]

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -32,7 +32,8 @@ pub use gpu::FuzzCompressGpu;
 #[cfg(feature = "cuda")]
 pub use gpu::run_compress_gpu;
 
-pub const FUZZ_ARRAY_MAX_LEN: usize = 16_384;
+pub const FUZZ_ARRAY_MAX_LEN: usize = 2048;
+pub const FUZZ_FILE_ARRAY_MAX_LEN: usize = 16_384;
 
 // Runtime initialization - platform-specific
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
I believe some of the reference implementations are very slow so we can't
operate on bigger arrays

Signed-off-by: Robert Kruszewski <github@robertk.io>
