### PR TITLE
fix: reduce CUDA benchmark noise on codspeed

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -73,8 +73,7 @@ jobs:
         include:
           - { shard: 1, name: "Bitpacked", benches: "bitpacked_cuda" }
           - { shard: 2, name: "Dynamic dispatch", benches: "dynamic_dispatch_cuda" }
-          - { shard: 3, name: "Standalone kernels", benches: "alp_cuda date_time_parts_cuda dict_cuda for_cuda runend_cuda throughput_cuda" }
-          - { shard: 4, name: "NVIDIA kernels", benches: "filter_cuda zstd_cuda" }
+          - { shard: 3, name: "Standalone kernels", benches: "alp_cuda date_time_parts_cuda dict_cuda runend_cuda" }
     name: "Benchmark with Codspeed (CUDA Shard #${{ matrix.shard }} - ${{ matrix.name }})"
     timeout-minutes: 30
     runs-on: runs-on=${{ github.run_id }}/family=g5/image=ubuntu24-gpu-x64/tag=bench-codspeed-cuda-${{ matrix.shard }}
@@ -96,7 +95,7 @@ jobs:
         with:
           tool: cargo-codspeed
       - name: Build benchmarks
-        run: cargo codspeed build -m walltime -p vortex-cuda --profile bench
+        run: cargo codspeed build -m walltime $(printf -- '--bench %s ' ${{ matrix.benches }}) --profile bench
       - name: Run benchmarks
         uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2
         env:

--- a/vortex-cuda/benches/alp_cuda.rs
+++ b/vortex-cuda/benches/alp_cuda.rs
@@ -38,9 +38,8 @@ use vortex_cuda::executor::CudaArrayExt;
 use vortex_cuda_macros::cuda_available;
 use vortex_cuda_macros::cuda_not_available;
 
+use crate::bench_config::BENCH_SIZES;
 use crate::timed_launch_strategy::TimedLaunchStrategy;
-
-const N_ROWS: usize = 100_000_000;
 
 /// Patch frequencies to benchmark (as fractions).
 const PATCH_FREQUENCIES: &[(f64, &str)] = &[(0.0, "0%"), (0.01, "1%"), (0.10, "10%")];
@@ -93,35 +92,38 @@ fn benchmark_alp_decode_typed<T>(c: &mut Criterion, type_name: &str)
 where
     T: ALPFloat + NativePType + DeviceRepr,
 {
-    let mut group = c.benchmark_group(format!("alp_cuda_{}", type_name));
+    let mut group = c.benchmark_group(format!("cuda/alp_{}", type_name));
 
-    let nbytes = N_ROWS * size_of::<T>();
-    group.throughput(Throughput::Bytes(nbytes as u64));
+    for &(len, len_str) in BENCH_SIZES {
+        group.throughput(Throughput::Bytes((len * size_of::<T>()) as u64));
 
-    for &(patch_freq, patch_label) in PATCH_FREQUENCIES {
-        let array = make_alp_array::<T>(N_ROWS, patch_freq);
+        for &(patch_freq, patch_label) in PATCH_FREQUENCIES {
+            let array = make_alp_array::<T>(len, patch_freq);
 
-        group.bench_with_input(
-            BenchmarkId::new("alp_decode", patch_label),
-            &array,
-            |b, array| {
-                b.iter_custom(|iters| {
-                    let timed = TimedLaunchStrategy::default();
-                    let timer = timed.timer();
+            group.bench_with_input(
+                BenchmarkId::new(patch_label, len_str),
+                &array,
+                |b, array| {
+                    b.iter_custom(|iters| {
+                        let timed = TimedLaunchStrategy::default();
+                        let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
-                        .vortex_expect("failed to create execution context")
-                        .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
-                        .with_launch_strategy(Arc::new(timed));
+                        let mut cuda_ctx =
+                            CudaSession::create_execution_ctx(&VortexSession::empty())
+                                .vortex_expect("failed to create execution context")
+                                .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
+                                .with_launch_strategy(Arc::new(timed));
 
-                    for _ in 0..iters {
-                        block_on(array.clone().into_array().execute_cuda(&mut cuda_ctx)).unwrap();
-                    }
+                        for _ in 0..iters {
+                            block_on(array.clone().into_array().execute_cuda(&mut cuda_ctx))
+                                .unwrap();
+                        }
 
-                    Duration::from_nanos(timer.load(Ordering::Relaxed))
-                });
-            },
-        );
+                        Duration::from_nanos(timer.load(Ordering::Relaxed))
+                    });
+                },
+            );
+        }
     }
 
     group.finish();

--- a/vortex-cuda/benches/bench_config/mod.rs
+++ b/vortex-cuda/benches/bench_config/mod.rs
@@ -5,6 +5,16 @@ use std::time::Duration;
 
 use criterion::Criterion;
 
+/// Benchmark input sizes.
+///
+/// On codspeed, only the 100M variant runs — kernels under ~200 µs
+/// (i.e. the 10M cases) swing 15-45% across ephemeral GPU instances,
+/// drowning real regressions in noise. Locally both sizes run.
+#[cfg(not(codspeed))]
+pub const BENCH_SIZES: &[(usize, &str)] = &[(10_000_000, "10M"), (100_000_000, "100M")];
+#[cfg(codspeed)]
+pub const BENCH_SIZES: &[(usize, &str)] = &[(100_000_000, "100M")];
+
 /// Returns a [`Criterion`] configuration tuned for CUDA benchmarks.
 ///
 /// All benchmarks use `iter_custom` with precise CUDA event timing.
@@ -15,21 +25,21 @@ use criterion::Criterion;
 /// Stability comes from a high `sample_size` (many independent launches)
 /// rather than many iterations per sample.
 ///
-/// `warm_up_time` runs at least one full iteration before sampling, giving
-/// the GPU a chance to reach steady state (clock boost, cache warming).
-/// If a single launch exceeds the warm-up budget, criterion still completes
-/// it before moving on.
+/// `warm_up_time` is set to 500 ms — long enough to JIT-compile PTX,
+/// boost GPU clocks, and warm caches, while keeping total runtime under
+/// 2 minutes even for the largest benchmark binary (~18 benchmarks).
+///
+/// `sample_size` is 10: with 100M inputs the kernels are long enough
+/// (>500 µs) that within-run variance is low. Cross-run stability
+/// comes from the large input size, not from averaging many samples.
 pub(super) fn cuda_bench_config() -> Criterion {
-    // Number of independent kernel launches.
     let sample_size = 10;
 
     Criterion::default()
         .without_plots()
         .sample_size(sample_size)
-        // One ns is enough to JIT-compile kernels and warm GPU caches.
-        // Criterion always finishes the in-flight iteration even if this
-        // budget is exceeded.
-        .warm_up_time(Duration::from_nanos(1))
+        // Enough for PTX JIT, GPU clock boost, and cache warming.
+        .warm_up_time(Duration::from_millis(500))
         // Forces `iters = 1`: criterion's planner estimates iteration cost
         // from wall time (which includes GPU context setup), not the
         // GPU-timed duration returned by `iter_custom`. A real

--- a/vortex-cuda/benches/bitpacked_cuda.rs
+++ b/vortex-cuda/benches/bitpacked_cuda.rs
@@ -40,8 +40,6 @@ use vortex_cuda_macros::cuda_not_available;
 
 use crate::timed_launch_strategy::TimedLaunchStrategy;
 
-const N_ROWS: usize = 100_000_000;
-
 /// Patch frequencies to benchmark (as fractions)
 const PATCH_FREQUENCIES: &[(f64, &str)] = &[(0.01, "1%"), (0.10, "10%")];
 
@@ -112,61 +110,16 @@ where
     T: BitPacked + NativePType + DeviceRepr + Add<Output = T> + From<u8>,
     T::Physical: DeviceRepr,
 {
-    let mut group = c.benchmark_group(format!("bitunpack_cuda_{}", type_name));
+    let mut group = c.benchmark_group(format!("cuda/bitpacked_{}", type_name));
 
-    let array = make_bitpacked_array::<T>(bit_width, N_ROWS);
-    let nbytes = N_ROWS * size_of::<T>();
+    for &(n_rows, size_str) in bench_config::BENCH_SIZES {
+        let array = make_bitpacked_array::<T>(bit_width, n_rows);
+        let nbytes = n_rows * size_of::<T>();
 
-    group.throughput(Throughput::Bytes(nbytes as u64));
-
-    group.bench_with_input(
-        BenchmarkId::new("bitunpack", format!("{}bw", bit_width)),
-        &array,
-        |b, array| {
-            b.iter_custom(|iters| {
-                let timed = TimedLaunchStrategy::default();
-                let timer = timed.timer();
-
-                let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
-                    .vortex_expect("failed to create execution context")
-                    .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
-                    .with_launch_strategy(Arc::new(timed));
-
-                for _ in 0..iters {
-                    block_on(array.clone().into_array().execute_cuda(&mut cuda_ctx)).unwrap();
-                }
-
-                Duration::from_nanos(timer.load(Ordering::Relaxed))
-            });
-        },
-    );
-
-    group.finish();
-}
-
-fn benchmark_bitunpack(c: &mut Criterion) {
-    benchmark_bitunpack_typed::<u8>(c, 3, "u8");
-    benchmark_bitunpack_typed::<u16>(c, 5, "u16");
-    benchmark_bitunpack_typed::<u32>(c, 6, "u32");
-    benchmark_bitunpack_typed::<u64>(c, 8, "u64");
-}
-
-/// Benchmark function for unpacking with patches at various frequencies
-fn benchmark_bitunpack_with_patches_typed<T>(c: &mut Criterion, type_name: &str)
-where
-    T: BitPacked + NativePType + DeviceRepr + Add<Output = T> + From<u8>,
-    T::Physical: DeviceRepr,
-{
-    let mut group = c.benchmark_group(format!("bitunpack_cuda_patched_{}", type_name));
-
-    let nbytes = N_ROWS * size_of::<T>();
-    group.throughput(Throughput::Bytes(nbytes as u64));
-
-    for &(patch_freq, patch_label) in PATCH_FREQUENCIES {
-        let array = make_bitpacked_array_with_patches::<T>(N_ROWS, patch_freq);
+        group.throughput(Throughput::Bytes(nbytes as u64));
 
         group.bench_with_input(
-            BenchmarkId::new("bitunpack_patched", patch_label),
+            BenchmarkId::new(format!("unpack/{}bw", bit_width), size_str),
             &array,
             |b, array| {
                 b.iter_custom(|iters| {
@@ -186,6 +139,57 @@ where
                 });
             },
         );
+    }
+
+    group.finish();
+}
+
+fn benchmark_bitunpack(c: &mut Criterion) {
+    benchmark_bitunpack_typed::<u8>(c, 3, "u8");
+    benchmark_bitunpack_typed::<u16>(c, 5, "u16");
+    benchmark_bitunpack_typed::<u32>(c, 6, "u32");
+    benchmark_bitunpack_typed::<u64>(c, 8, "u64");
+}
+
+/// Benchmark function for unpacking with patches at various frequencies
+fn benchmark_bitunpack_with_patches_typed<T>(c: &mut Criterion, type_name: &str)
+where
+    T: BitPacked + NativePType + DeviceRepr + Add<Output = T> + From<u8>,
+    T::Physical: DeviceRepr,
+{
+    let mut group = c.benchmark_group(format!("cuda/bitpacked_patched_{}", type_name));
+
+    for &(n_rows, size_str) in bench_config::BENCH_SIZES {
+        let nbytes = n_rows * size_of::<T>();
+        group.throughput(Throughput::Bytes(nbytes as u64));
+
+        for &(patch_freq, patch_label) in PATCH_FREQUENCIES {
+            let array = make_bitpacked_array_with_patches::<T>(n_rows, patch_freq);
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("unpack/{}", patch_label), size_str),
+                &array,
+                |b, array| {
+                    b.iter_custom(|iters| {
+                        let timed = TimedLaunchStrategy::default();
+                        let timer = timed.timer();
+
+                        let mut cuda_ctx =
+                            CudaSession::create_execution_ctx(&VortexSession::empty())
+                                .vortex_expect("failed to create execution context")
+                                .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
+                                .with_launch_strategy(Arc::new(timed));
+
+                        for _ in 0..iters {
+                            block_on(array.clone().into_array().execute_cuda(&mut cuda_ctx))
+                                .unwrap();
+                        }
+
+                        Duration::from_nanos(timer.load(Ordering::Relaxed))
+                    });
+                },
+            );
+        }
     }
 
     group.finish();

--- a/vortex-cuda/benches/date_time_parts_cuda.rs
+++ b/vortex-cuda/benches/date_time_parts_cuda.rs
@@ -52,16 +52,16 @@ fn make_datetimeparts_array(len: usize, time_unit: TimeUnit) -> DateTimePartsArr
 }
 
 fn benchmark_datetimeparts(c: &mut Criterion) {
-    let mut group = c.benchmark_group("datetimeparts_cuda");
+    let mut group = c.benchmark_group("cuda/datetimeparts");
 
-    for (len, len_str) in [(10_000_000usize, "10M"), (100_000_000usize, "100M")] {
+    for &(len, len_str) in bench_config::BENCH_SIZES {
         group.throughput(Throughput::Bytes((len * size_of::<i64>()) as u64));
 
         let (time_unit, unit_str) = (TimeUnit::Milliseconds, "ms");
         let dtp_array = make_datetimeparts_array(len, time_unit);
 
         group.bench_with_input(
-            BenchmarkId::new("datetimeparts", format!("{len_str}_{unit_str}")),
+            BenchmarkId::new(unit_str, len_str),
             &dtp_array,
             |b, dtp_array| {
                 b.iter_custom(|iters| {

--- a/vortex-cuda/benches/dict_cuda.rs
+++ b/vortex-cuda/benches/dict_cuda.rs
@@ -34,9 +34,8 @@ use vortex_cuda::executor::CudaArrayExt;
 use vortex_cuda_macros::cuda_available;
 use vortex_cuda_macros::cuda_not_available;
 
+use crate::bench_config::BENCH_SIZES;
 use crate::timed_launch_strategy::TimedLaunchStrategy;
-
-const BENCH_ARGS: &[(usize, &str)] = &[(10_000_000, "10M")];
 
 /// Configuration for a dictionary benchmark specifying value and code types along with dictionary size.
 struct DictBenchConfig {
@@ -75,9 +74,9 @@ where
     C: NativePType + DeviceRepr + TryFrom<usize>,
     <C as TryFrom<usize>>::Error: Debug,
 {
-    let mut group = c.benchmark_group("dict_cuda");
+    let mut group = c.benchmark_group("cuda/dict");
 
-    for (len, len_str) in BENCH_ARGS {
+    for (len, len_str) in BENCH_SIZES {
         // Throughput is based on output size (values read from dictionary)
         group.throughput(Throughput::Bytes((len * size_of::<V>()) as u64));
 
@@ -85,11 +84,11 @@ where
 
         group.bench_with_input(
             BenchmarkId::new(
-                "dict",
                 format!(
-                    "{len_str}_{}_values_{}_codes",
+                    "{}_values_{}_codes",
                     config.value_type_name, config.code_type_name
                 ),
+                len_str,
             ),
             &dict_array,
             |b, dict_array| {

--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -58,7 +58,7 @@ use vortex_cuda::dynamic_dispatch::MaterializedPlan;
 use vortex_cuda_macros::cuda_available;
 use vortex_cuda_macros::cuda_not_available;
 
-const BENCH_ARGS: &[(usize, &str)] = &[(10_000_000, "10M"), (100_000_000, "100M")];
+use crate::bench_config::BENCH_SIZES;
 
 /// Launch the dynamic_dispatch kernel and return GPU-timed duration.
 ///
@@ -188,12 +188,12 @@ impl<T: DeviceRepr + NativePType> BenchRunner<T> {
 // Benchmark: FoR(BitPacked)
 // ---------------------------------------------------------------------------
 fn bench_for_bitpacked(c: &mut Criterion) {
-    let mut group = c.benchmark_group("for_bitpacked_6bw");
+    let mut group = c.benchmark_group("cuda/for_bitpacked_6bw");
 
     let bit_width: u8 = 6;
     let reference = 100_000u32;
 
-    for (len, len_str) in BENCH_ARGS {
+    for (len, len_str) in BENCH_SIZES {
         group.throughput(Throughput::Bytes((len * size_of::<u32>()) as u64));
 
         // FoR(BitPacked): residuals 0..max_val, reference adds 100_000
@@ -209,24 +209,20 @@ fn bench_for_bitpacked(c: &mut Criterion) {
             .vortex_expect("for")
             .into_array();
 
-        group.bench_with_input(
-            BenchmarkId::new("dynamic_dispatch_u32", len_str),
-            len,
-            |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+        group.bench_with_input(BenchmarkId::new("dispatch_u32", len_str), len, |b, &n| {
+            let mut cuda_ctx =
+                CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+            let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
-                b.iter_custom(|iters| {
-                    let mut total_time = Duration::ZERO;
-                    for _ in 0..iters {
-                        total_time += bench_runner.run(&mut cuda_ctx);
-                    }
-                    total_time
-                });
-            },
-        );
+            b.iter_custom(|iters| {
+                let mut total_time = Duration::ZERO;
+                for _ in 0..iters {
+                    total_time += bench_runner.run(&mut cuda_ctx);
+                }
+                total_time
+            });
+        });
     }
 
     group.finish();
@@ -236,13 +232,13 @@ fn bench_for_bitpacked(c: &mut Criterion) {
 // Benchmark: Dict(codes=BitPacked, values=Primitive)
 // ---------------------------------------------------------------------------
 fn bench_dict_bp_codes(c: &mut Criterion) {
-    let mut group = c.benchmark_group("dict_256vals_bp8bw_codes");
+    let mut group = c.benchmark_group("cuda/dict_256vals_bp8bw_codes");
 
     let dict_size: usize = 256;
     let dict_bit_width: u8 = 8;
     let dict_values: Vec<u32> = (0..dict_size as u32).map(|i| i * 1000 + 42).collect();
 
-    for (len, len_str) in BENCH_ARGS {
+    for (len, len_str) in BENCH_SIZES {
         group.throughput(Throughput::Bytes((len * size_of::<u32>()) as u64));
 
         let codes: Vec<u32> = (0..*len).map(|i| (i % dict_size) as u32).collect();
@@ -254,24 +250,20 @@ fn bench_dict_bp_codes(c: &mut Criterion) {
         let dict = DictArray::new(codes_bp.into_array(), values_prim.into_array());
         let array = dict.into_array();
 
-        group.bench_with_input(
-            BenchmarkId::new("dynamic_dispatch_u32", len_str),
-            len,
-            |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+        group.bench_with_input(BenchmarkId::new("dispatch_u32", len_str), len, |b, &n| {
+            let mut cuda_ctx =
+                CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+            let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
-                b.iter_custom(|iters| {
-                    let mut total_time = Duration::ZERO;
-                    for _ in 0..iters {
-                        total_time += bench_runner.run(&mut cuda_ctx);
-                    }
-                    total_time
-                });
-            },
-        );
+            b.iter_custom(|iters| {
+                let mut total_time = Duration::ZERO;
+                for _ in 0..iters {
+                    total_time += bench_runner.run(&mut cuda_ctx);
+                }
+                total_time
+            });
+        });
     }
 
     group.finish();
@@ -281,11 +273,11 @@ fn bench_dict_bp_codes(c: &mut Criterion) {
 // Benchmark: RunEnd(ends=Prim, values=Prim)
 // ---------------------------------------------------------------------------
 fn bench_runend(c: &mut Criterion) {
-    let mut group = c.benchmark_group("runend_100runs");
+    let mut group = c.benchmark_group("cuda/runend_100runs");
 
     let num_runs: usize = 100;
 
-    for (len, len_str) in BENCH_ARGS {
+    for (len, len_str) in BENCH_SIZES {
         group.throughput(Throughput::Bytes((len * size_of::<u32>()) as u64));
 
         let run_len = *len / num_runs;
@@ -298,24 +290,20 @@ fn bench_runend(c: &mut Criterion) {
         let re = RunEnd::new(ends_arr, values_arr, &mut ctx);
         let array = re.into_array();
 
-        group.bench_with_input(
-            BenchmarkId::new("dynamic_dispatch_u32", len_str),
-            len,
-            |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+        group.bench_with_input(BenchmarkId::new("dispatch_u32", len_str), len, |b, &n| {
+            let mut cuda_ctx =
+                CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+            let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
-                b.iter_custom(|iters| {
-                    let mut total_time = Duration::ZERO;
-                    for _ in 0..iters {
-                        total_time += bench_runner.run(&mut cuda_ctx);
-                    }
-                    total_time
-                });
-            },
-        );
+            b.iter_custom(|iters| {
+                let mut total_time = Duration::ZERO;
+                for _ in 0..iters {
+                    total_time += bench_runner.run(&mut cuda_ctx);
+                }
+                total_time
+            });
+        });
     }
 
     group.finish();
@@ -326,12 +314,12 @@ fn bench_runend(c: &mut Criterion) {
 // ---------------------------------------------------------------------------
 fn bench_alp_for_bitpacked_f64(c: &mut Criterion) {
     let mut ctx = LEGACY_SESSION.create_execution_ctx();
-    let mut group = c.benchmark_group("alp_for_bp_6bw_f64");
+    let mut group = c.benchmark_group("cuda/alp_for_bp_6bw_f64");
 
     let exponents = Exponents { e: 2, f: 0 };
     let bit_width: u8 = 6;
 
-    for (len, len_str) in BENCH_ARGS {
+    for (len, len_str) in BENCH_SIZES {
         group.throughput(Throughput::Bytes((len * size_of::<f64>()) as u64));
 
         // Generate f64 values that ALP-encode without patches.
@@ -363,24 +351,20 @@ fn bench_alp_for_bitpacked_f64(c: &mut Criterion) {
         );
         let array = tree.into_array();
 
-        group.bench_with_input(
-            BenchmarkId::new("dynamic_dispatch_f64", len_str),
-            len,
-            |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+        group.bench_with_input(BenchmarkId::new("dispatch_f64", len_str), len, |b, &n| {
+            let mut cuda_ctx =
+                CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u64>::new(&array, n, &mut cuda_ctx);
+            let bench_runner = BenchRunner::<u64>::new(&array, n, &mut cuda_ctx);
 
-                b.iter_custom(|iters| {
-                    let mut total_time = Duration::ZERO;
-                    for _ in 0..iters {
-                        total_time += bench_runner.run(&mut cuda_ctx);
-                    }
-                    total_time
-                });
-            },
-        );
+            b.iter_custom(|iters| {
+                let mut total_time = Duration::ZERO;
+                for _ in 0..iters {
+                    total_time += bench_runner.run(&mut cuda_ctx);
+                }
+                total_time
+            });
+        });
     }
 
     group.finish();
@@ -390,7 +374,7 @@ fn bench_alp_for_bitpacked_f64(c: &mut Criterion) {
 // Benchmark: Dict(codes=BitPacked, values=FoR(BitPacked))
 // ---------------------------------------------------------------------------
 fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
-    let mut group = c.benchmark_group("dict_64vals_bp6bw_codes_for_bp6bw_values");
+    let mut group = c.benchmark_group("cuda/dict_64vals_bp6bw_codes_for_bp6bw_values");
 
     let dict_size: usize = 64;
     let dict_bit_width: u8 = 6;
@@ -406,7 +390,7 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
     let dict_for =
         FoR::try_new(dict_bp.into_array(), Scalar::from(dict_reference)).vortex_expect("for dict");
 
-    for (len, len_str) in BENCH_ARGS {
+    for (len, len_str) in BENCH_SIZES {
         group.throughput(Throughput::Bytes((len * size_of::<u32>()) as u64));
 
         let codes: Vec<u32> = (0..*len).map(|i| (i % dict_size) as u32).collect();
@@ -417,24 +401,20 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
         let dict = DictArray::new(codes_bp.into_array(), dict_for.clone().into_array());
         let array = dict.into_array();
 
-        group.bench_with_input(
-            BenchmarkId::new("dynamic_dispatch_u32", len_str),
-            len,
-            |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+        group.bench_with_input(BenchmarkId::new("dispatch_u32", len_str), len, |b, &n| {
+            let mut cuda_ctx =
+                CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+            let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
-                b.iter_custom(|iters| {
-                    let mut total_time = Duration::ZERO;
-                    for _ in 0..iters {
-                        total_time += bench_runner.run(&mut cuda_ctx);
-                    }
-                    total_time
-                });
-            },
-        );
+            b.iter_custom(|iters| {
+                let mut total_time = Duration::ZERO;
+                for _ in 0..iters {
+                    total_time += bench_runner.run(&mut cuda_ctx);
+                }
+                total_time
+            });
+        });
     }
 
     group.finish();
@@ -445,12 +425,12 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
 // ---------------------------------------------------------------------------
 fn bench_alp_for_bitpacked(c: &mut Criterion) {
     let mut ctx = LEGACY_SESSION.create_execution_ctx();
-    let mut group = c.benchmark_group("alp_for_bp_6bw_f32");
+    let mut group = c.benchmark_group("cuda/alp_for_bp_6bw_f32");
 
     let exponents = Exponents { e: 2, f: 0 };
     let bit_width: u8 = 6;
 
-    for (len, len_str) in BENCH_ARGS {
+    for (len, len_str) in BENCH_SIZES {
         group.throughput(Throughput::Bytes((len * size_of::<f32>()) as u64));
 
         // Generate f32 values that ALP-encode without patches.
@@ -482,24 +462,20 @@ fn bench_alp_for_bitpacked(c: &mut Criterion) {
         );
         let array = tree.into_array();
 
-        group.bench_with_input(
-            BenchmarkId::new("dynamic_dispatch_f32", len_str),
-            len,
-            |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+        group.bench_with_input(BenchmarkId::new("dispatch_f32", len_str), len, |b, &n| {
+            let mut cuda_ctx =
+                CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+            let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
-                b.iter_custom(|iters| {
-                    let mut total_time = Duration::ZERO;
-                    for _ in 0..iters {
-                        total_time += bench_runner.run(&mut cuda_ctx);
-                    }
-                    total_time
-                });
-            },
-        );
+            b.iter_custom(|iters| {
+                let mut total_time = Duration::ZERO;
+                for _ in 0..iters {
+                    total_time += bench_runner.run(&mut cuda_ctx);
+                }
+                total_time
+            });
+        });
     }
 
     group.finish();
@@ -511,13 +487,13 @@ fn bench_alp_for_bitpacked(c: &mut Criterion) {
 
 /// Dict(codes=BitPacked<u8>, values=Prim<u32>) — widens u8 → u32 in smem.
 fn bench_dict_bp_u8_codes_u32_values(c: &mut Criterion) {
-    let mut group = c.benchmark_group("dict_widen_u8_to_u32");
+    let mut group = c.benchmark_group("cuda/dict_widen_u8_to_u32");
 
     let dict_size: usize = 4; // 2-bit codes
     let bit_width: u8 = 2;
     let dict_values: Vec<u32> = (0..dict_size as u32).map(|i| i * 1000 + 42).collect();
 
-    for (len, len_str) in BENCH_ARGS {
+    for (len, len_str) in BENCH_SIZES {
         group.throughput(Throughput::Bytes((len * size_of::<u32>()) as u64));
 
         let codes: Vec<u8> = (0..*len).map(|i| (i % dict_size) as u8).collect();
@@ -529,24 +505,20 @@ fn bench_dict_bp_u8_codes_u32_values(c: &mut Criterion) {
         let dict = DictArray::new(codes_bp.into_array(), values_prim.into_array());
         let array = dict.into_array();
 
-        group.bench_with_input(
-            BenchmarkId::new("dynamic_dispatch_u32", len_str),
-            len,
-            |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+        group.bench_with_input(BenchmarkId::new("dispatch_u32", len_str), len, |b, &n| {
+            let mut cuda_ctx =
+                CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+            let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
-                b.iter_custom(|iters| {
-                    let mut total_time = Duration::ZERO;
-                    for _ in 0..iters {
-                        total_time += bench_runner.run(&mut cuda_ctx);
-                    }
-                    total_time
-                });
-            },
-        );
+            b.iter_custom(|iters| {
+                let mut total_time = Duration::ZERO;
+                for _ in 0..iters {
+                    total_time += bench_runner.run(&mut cuda_ctx);
+                }
+                total_time
+            });
+        });
     }
 
     group.finish();
@@ -554,13 +526,13 @@ fn bench_dict_bp_u8_codes_u32_values(c: &mut Criterion) {
 
 /// Dict(codes=BitPacked<u16>, values=Prim<u32>) — widens u16 → u32 in smem.
 fn bench_dict_bp_u16_codes_u32_values(c: &mut Criterion) {
-    let mut group = c.benchmark_group("dict_widen_u16_to_u32");
+    let mut group = c.benchmark_group("cuda/dict_widen_u16_to_u32");
 
     let dict_size: usize = 8; // 3-bit codes
     let bit_width: u8 = 3;
     let dict_values: Vec<u32> = (0..dict_size as u32).map(|i| i * 5000 + 100).collect();
 
-    for (len, len_str) in BENCH_ARGS {
+    for (len, len_str) in BENCH_SIZES {
         group.throughput(Throughput::Bytes((len * size_of::<u32>()) as u64));
 
         let codes: Vec<u16> = (0..*len).map(|i| (i % dict_size) as u16).collect();
@@ -572,24 +544,20 @@ fn bench_dict_bp_u16_codes_u32_values(c: &mut Criterion) {
         let dict = DictArray::new(codes_bp.into_array(), values_prim.into_array());
         let array = dict.into_array();
 
-        group.bench_with_input(
-            BenchmarkId::new("dynamic_dispatch_u32", len_str),
-            len,
-            |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+        group.bench_with_input(BenchmarkId::new("dispatch_u32", len_str), len, |b, &n| {
+            let mut cuda_ctx =
+                CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+            let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
-                b.iter_custom(|iters| {
-                    let mut total_time = Duration::ZERO;
-                    for _ in 0..iters {
-                        total_time += bench_runner.run(&mut cuda_ctx);
-                    }
-                    total_time
-                });
-            },
-        );
+            b.iter_custom(|iters| {
+                let mut total_time = Duration::ZERO;
+                for _ in 0..iters {
+                    total_time += bench_runner.run(&mut cuda_ctx);
+                }
+                total_time
+            });
+        });
     }
 
     group.finish();
@@ -597,13 +565,13 @@ fn bench_dict_bp_u16_codes_u32_values(c: &mut Criterion) {
 
 /// Dict(codes=BitPacked<u32>, values=Prim<u32>) — same-width baseline, no widen.
 fn bench_dict_bp_u32_codes_u32_values(c: &mut Criterion) {
-    let mut group = c.benchmark_group("dict_nowiden_u32_to_u32");
+    let mut group = c.benchmark_group("cuda/dict_nowiden_u32_to_u32");
 
     let dict_size: usize = 8; // 3-bit codes
     let bit_width: u8 = 3;
     let dict_values: Vec<u32> = (0..dict_size as u32).map(|i| i * 5000 + 100).collect();
 
-    for (len, len_str) in BENCH_ARGS {
+    for (len, len_str) in BENCH_SIZES {
         group.throughput(Throughput::Bytes((len * size_of::<u32>()) as u64));
 
         let codes: Vec<u32> = (0..*len).map(|i| (i % dict_size) as u32).collect();
@@ -615,24 +583,20 @@ fn bench_dict_bp_u32_codes_u32_values(c: &mut Criterion) {
         let dict = DictArray::new(codes_bp.into_array(), values_prim.into_array());
         let array = dict.into_array();
 
-        group.bench_with_input(
-            BenchmarkId::new("dynamic_dispatch_u32", len_str),
-            len,
-            |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+        group.bench_with_input(BenchmarkId::new("dispatch_u32", len_str), len, |b, &n| {
+            let mut cuda_ctx =
+                CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+            let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
-                b.iter_custom(|iters| {
-                    let mut total_time = Duration::ZERO;
-                    for _ in 0..iters {
-                        total_time += bench_runner.run(&mut cuda_ctx);
-                    }
-                    total_time
-                });
-            },
-        );
+            b.iter_custom(|iters| {
+                let mut total_time = Duration::ZERO;
+                for _ in 0..iters {
+                    total_time += bench_runner.run(&mut cuda_ctx);
+                }
+                total_time
+            });
+        });
     }
 
     group.finish();

--- a/vortex-cuda/benches/filter_cuda.rs
+++ b/vortex-cuda/benches/filter_cuda.rs
@@ -35,7 +35,7 @@ use vortex_cuda::CudaSession;
 use vortex_cuda_macros::cuda_available;
 use vortex_cuda_macros::cuda_not_available;
 
-const BENCH_SIZES: &[(usize, &str)] = &[(10_000_000, "10M")];
+use crate::bench_config::BENCH_SIZES;
 const SELECTIVITIES: &[(f64, &str)] = &[(0.1, "10%"), (0.5, "50%"), (0.9, "90%")];
 
 /// Creates input data of the given length.
@@ -137,7 +137,7 @@ fn benchmark_filter_type<T>(c: &mut Criterion, type_name: &str)
 where
     T: CubFilterable + DeviceRepr + From<u8> + Debug + Clone + Send + Sync + 'static,
 {
-    let mut group = c.benchmark_group(format!("filter_cuda_{type_name}"));
+    let mut group = c.benchmark_group(format!("cuda/filter_{type_name}"));
 
     for (len, len_label) in BENCH_SIZES {
         for (selectivity, sel_label) in SELECTIVITIES {
@@ -148,7 +148,7 @@ where
             group.throughput(Throughput::Bytes((len * size_of::<T>()) as u64));
 
             group.bench_with_input(
-                BenchmarkId::new(format!("{len_label}_{sel_label}"), true_count),
+                BenchmarkId::new(format!("select/{sel_label}"), len_label),
                 &(input_data, bitmask, true_count),
                 |b, (input_data, bitmask, true_count)| {
                     b.iter_custom(|iters| {

--- a/vortex-cuda/benches/for_cuda.rs
+++ b/vortex-cuda/benches/for_cuda.rs
@@ -40,9 +40,8 @@ use vortex_cuda::executor::CudaArrayExt;
 use vortex_cuda_macros::cuda_available;
 use vortex_cuda_macros::cuda_not_available;
 
+use crate::bench_config::BENCH_SIZES;
 use crate::timed_launch_strategy::TimedLaunchStrategy;
-
-const BENCH_ARGS: &[(usize, &str)] = &[(10_000_000, "10M")];
 const REFERENCE_VALUE: u8 = 10;
 
 /// Creates a FoR array with the specified type and length.
@@ -76,15 +75,15 @@ where
     T: NativePType + DeviceRepr + From<u8> + Add<Output = T>,
     Scalar: From<T>,
 {
-    let mut group = c.benchmark_group("for_cuda");
+    let mut group = c.benchmark_group("cuda/for");
 
-    for &(len, len_str) in BENCH_ARGS {
+    for &(len, len_str) in BENCH_SIZES {
         group.throughput(Throughput::Bytes((len * size_of::<T>()) as u64));
 
         let for_array = make_for_array_typed::<T>(len, false);
 
         group.bench_with_input(
-            BenchmarkId::new("for", format!("{len_str}_{type_name}")),
+            BenchmarkId::new(type_name, len_str),
             &for_array,
             |b, for_array| {
                 b.iter_custom(|iters| {
@@ -115,15 +114,15 @@ where
     T: NativePType + DeviceRepr + From<u8> + Add<Output = T>,
     Scalar: From<T>,
 {
-    let mut group = c.benchmark_group("ffor_cuda");
+    let mut group = c.benchmark_group("cuda/ffor");
 
-    for &(len, len_str) in BENCH_ARGS {
+    for &(len, len_str) in BENCH_SIZES {
         group.throughput(Throughput::Bytes((len * size_of::<T>()) as u64));
 
         let for_array = make_for_array_typed::<T>(len, true);
 
         group.bench_with_input(
-            BenchmarkId::new("for", format!("{len_str}_{type_name}")),
+            BenchmarkId::new(type_name, len_str),
             &for_array,
             |b, for_array| {
                 b.iter_custom(|iters| {

--- a/vortex-cuda/benches/runend_cuda.rs
+++ b/vortex-cuda/benches/runend_cuda.rs
@@ -69,9 +69,9 @@ fn benchmark_runend_typed<T>(c: &mut Criterion, type_name: &str)
 where
     T: NativePType + DeviceRepr + From<u8>,
 {
-    let mut group = c.benchmark_group("runend_cuda");
+    let mut group = c.benchmark_group("cuda/runend");
 
-    for (len, len_str) in [(10_000_000usize, "10M"), (100_000_000usize, "100M")] {
+    for &(len, len_str) in bench_config::BENCH_SIZES {
         group.throughput(Throughput::Bytes((len * size_of::<T>()) as u64));
 
         for run_len in [10, 1000, 100000] {
@@ -79,7 +79,7 @@ where
             let runend_array = make_runend_array_typed::<T>(len, run_len, cuda_ctx.execution_ctx());
 
             group.bench_with_input(
-                BenchmarkId::new("runend", format!("{len_str}_{type_name}_runlen_{run_len}")),
+                BenchmarkId::new(format!("{type_name}_runlen_{run_len}"), len_str),
                 &runend_array,
                 |b, runend_array| {
                     b.iter_custom(|iters| {

--- a/vortex-cuda/benches/throughput_cuda.rs
+++ b/vortex-cuda/benches/throughput_cuda.rs
@@ -9,6 +9,8 @@
 #![expect(clippy::unwrap_used)]
 
 mod bench_config;
+// Unused here but suppresses dead_code warning for the shared module.
+const _: &[(usize, &str)] = bench_config::BENCH_SIZES;
 
 use std::time::Duration;
 
@@ -30,9 +32,9 @@ const TOTAL_BYTES: usize = 100 * 1024 * 1024;
 
 /// Benchmark configurations: (input_bytes, output_bytes, label).
 const MIXES: &[(usize, usize, &str)] = &[
-    (TOTAL_BYTES, 0, "100%_in/0%_out"),
-    (TOTAL_BYTES / 2, TOTAL_BYTES / 2, "50%_in/50%_out"),
-    (0, TOTAL_BYTES, "0%_in/100%_out"),
+    (TOTAL_BYTES, 0, "100%_in_0%_out"),
+    (TOTAL_BYTES / 2, TOTAL_BYTES / 2, "50%_in_50%_out"),
+    (0, TOTAL_BYTES, "0%_in_100%_out"),
 ];
 
 fn transfer_mix_timed(
@@ -95,13 +97,13 @@ fn transfer_mix_timed(
 }
 
 fn benchmark_transfer_throughput(c: &mut Criterion) {
-    let mut group = c.benchmark_group("transfer_throughput_cuda");
+    let mut group = c.benchmark_group("cuda/throughput");
     for &(input_bytes, output_bytes, label) in MIXES {
         let total_mem_bytes = input_bytes * 2 + output_bytes;
         group.throughput(Throughput::Bytes(total_mem_bytes as u64));
 
         group.bench_with_input(
-            BenchmarkId::new("mix", label),
+            BenchmarkId::new(format!("transfer/{label}"), "100MiB"),
             &(input_bytes, output_bytes),
             |b, &(in_bytes, out_bytes)| {
                 b.iter_custom(|iters| {

--- a/vortex-cuda/benches/zstd_cuda.rs
+++ b/vortex-cuda/benches/zstd_cuda.rs
@@ -27,11 +27,7 @@ use vortex_cuda::zstd_kernel_prepare;
 use vortex_cuda_macros::cuda_available;
 use vortex_cuda_macros::cuda_not_available;
 
-const BENCH_ARGS: &[(usize, &str)] = &[
-    (1_000_000, "1M"),
-    (10_000_000, "10M"),
-    (100_000_000, "100M"),
-];
+use crate::bench_config::BENCH_SIZES;
 
 /// Generate compressible string data by repeating patterns.
 fn generate_string_data(count: usize) -> Vec<&'static str> {
@@ -127,9 +123,9 @@ async fn execute_zstd_kernel(
 
 /// Benchmark ZSTD CUDA decompression kernel performance
 fn benchmark_zstd_cuda_decompress(c: &mut Criterion) {
-    let mut group = c.benchmark_group("ZSTD_cuda");
+    let mut group = c.benchmark_group("cuda/zstd");
 
-    for (num_strings, label) in BENCH_ARGS {
+    for (num_strings, label) in BENCH_SIZES {
         let mut setup_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
             .vortex_expect("failed to create execution context");
         let (zstd_array, uncompressed_size) = make_zstd_array(*num_strings, &mut setup_ctx)
@@ -137,7 +133,7 @@ fn benchmark_zstd_cuda_decompress(c: &mut Criterion) {
 
         group.throughput(Throughput::Bytes(uncompressed_size as u64));
         group.bench_with_input(
-            BenchmarkId::new("decompress_kernel", label),
+            BenchmarkId::new("decompress", label),
             &zstd_array,
             |b, zstd_array| {
                 b.iter_custom(|iters| {


### PR DESCRIPTION
- Remove noisy/synthetic benchmarks from codspeed CI:
  - throughput_cuda (pure memory bandwidth, not Vortex logic)
  - for_cuda (u8/u16 undersaturate the GPU)
  - filter_cuda + zstd_cuda (entire NVIDIA kernels shard, 10-25% cross-run swing)

- Only build benchmarks each shard needs
- Run only 100M element input sizes on codspeed
- Increase warm_up_time 1ns -> 500ms
- Consistent benchmark naming: cuda/{encoding}/{params}/{size} with size always the last path segment