### PR TITLE
Allow running reduce_parent operations on stack allocated parents

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -20,6 +20,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::TypedArrayRef;
 use vortex_array::array_slots;
 use vortex_array::arrays::Primitive;
@@ -191,7 +192,7 @@ impl VTable for ALP {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)
@@ -427,8 +428,8 @@ pub trait ALPArrayExt: ALPArraySlotsExt {
     fn patches(&self) -> Option<Patches> {
         PatchesData::patches_from_slots(
             self.patches_data.as_ref(),
-            self.as_ref().len(),
-            self.as_ref().slots(),
+            self.len(),
+            self.slots(),
             PATCH_SLOTS,
         )
     }

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -21,6 +21,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::TypedArrayRef;
 use vortex_array::array_slots;
 use vortex_array::arrays::Primitive;
@@ -303,7 +304,7 @@ impl VTable for ALPRD {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)
@@ -537,11 +538,7 @@ pub trait ALPRDArrayExt: ALPRDArraySlotsExt {
     }
 
     fn left_parts_patches(&self) -> Option<Patches> {
-        patches_from_slots(
-            self.as_ref().slots(),
-            self.patches_data.as_ref(),
-            self.as_ref().len(),
-        )
+        patches_from_slots(self.slots(), self.patches_data.as_ref(), self.len())
     }
 
     fn left_parts_dictionary(&self) -> &Buffer<u16> {

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -18,6 +18,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::TypedArrayRef;
 use vortex_array::array_slots;
 use vortex_array::arrays::BoolArray;
@@ -160,7 +161,7 @@ impl VTable for ByteBool {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         crate::rules::RULES.evaluate(array, parent, child_idx)
@@ -198,8 +199,8 @@ pub trait ByteBoolArrayExt: TypedArrayRef<ByteBool> + ByteBoolArraySlotsExt {
     /// Returns the [`Validity`] derived from the validity slot.
     fn bytebool_validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[ByteBoolSlots::VALIDITY].as_ref(),
-            self.as_ref().dtype().nullability(),
+            self.slots()[ByteBoolSlots::VALIDITY].as_ref(),
+            self.dtype().nullability(),
         )
     }
 }

--- a/encodings/bytebool/src/compute.rs
+++ b/encodings/bytebool/src/compute.rs
@@ -139,7 +139,7 @@ impl BooleanKernel for ByteBool {
             .map(Some);
         }
 
-        let Some(rhs) = rhs.as_opt::<ByteBool>() else {
+        let Some(rhs) = rhs.as_typed::<ByteBool>() else {
             return Ok(None);
         };
 

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -19,6 +19,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::array_slots;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::TemporalArray;
@@ -202,7 +203,7 @@ impl VTable for DateTimeParts {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/encodings/datetime-parts/src/canonical.rs
+++ b/encodings/datetime-parts/src/canonical.rs
@@ -42,7 +42,10 @@ pub fn decode_to_temporal(
     };
 
     // Days is guaranteed Primitive by require_child.
-    let days = parts.days.as_::<Primitive>();
+    let days = parts
+        .days
+        .as_typed::<Primitive>()
+        .vortex_expect("days child must be Primitive");
     let validity = days.validity()?;
 
     let mut values: BufferMut<i64> = match_each_integer_ptype!(days.ptype(), |D| {

--- a/encodings/datetime-parts/src/compute/rules.rs
+++ b/encodings/datetime-parts/src/compute/rules.rs
@@ -4,6 +4,7 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::IntoArray;
+use vortex_array::ParentView;
 use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::Filter;
@@ -16,7 +17,6 @@ use vortex_array::arrays::slice::SliceReduceAdaptor;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::extension::datetime::Timestamp;
-use vortex_array::optimizer::ArrayOptimizer;
 use vortex_array::optimizer::rules::ArrayParentReduceRule;
 use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::between::Between;
@@ -49,7 +49,7 @@ impl ArrayParentReduceRule<DateTimeParts> for DTPFilterPushDownRule {
     fn reduce_parent(
         &self,
         child: ArrayView<'_, DateTimeParts>,
-        parent: ArrayView<'_, Filter>,
+        parent: ParentView<'_, Filter>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         debug_assert_eq!(child_idx, 0);
@@ -95,7 +95,7 @@ impl ArrayParentReduceRule<DateTimeParts> for DTPComparisonPushDownRule {
     fn reduce_parent(
         &self,
         child: ArrayView<'_, DateTimeParts>,
-        parent: ArrayView<'_, ScalarFn>,
+        parent: ParentView<'_, ScalarFn>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         // Only handle comparison operations (Binary comparisons or Between)
@@ -133,9 +133,9 @@ impl ArrayParentReduceRule<DateTimeParts> for DTPComparisonPushDownRule {
             }
         }
 
-        let result = ScalarFnArray::try_new(parent.scalar_fn().clone(), new_children)?
-            .into_array()
-            .optimize()?;
+        let parts =
+            ScalarFnArray::try_new_parts(parent.scalar_fn().clone(), new_children, parent.len())?;
+        let result = parts.optimize()?;
 
         Ok(Some(result))
     }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -21,6 +21,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::array_slots;
 use vortex_array::arrays::DecimalArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -161,7 +162,7 @@ impl VTable for DecimalByteParts {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/rules.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/rules.rs
@@ -4,6 +4,7 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::IntoArray;
+use vortex_array::ParentView;
 use vortex_array::arrays::Filter;
 use vortex_array::arrays::filter::FilterReduceAdaptor;
 use vortex_array::arrays::slice::SliceReduceAdaptor;
@@ -34,7 +35,7 @@ impl ArrayParentReduceRule<DecimalByteParts> for DecimalBytePartsFilterPushDownR
     fn reduce_parent(
         &self,
         child: ArrayView<'_, DecimalByteParts>,
-        parent: ArrayView<'_, Filter>,
+        parent: ParentView<'_, Filter>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         // TODO(ngates): we should benchmark whether to push-down filters with "lower parts".

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -302,15 +302,15 @@ pub trait BitPackedArrayExt: BitPackedArraySlotsExt {
     fn patches(&self) -> Option<Patches> {
         PatchesData::patches_from_slots(
             self.patches_data.as_ref(),
-            self.as_ref().len(),
-            self.as_ref().slots(),
+            self.len(),
+            self.slots(),
             PATCH_SLOTS,
         )
     }
 
     #[inline]
     fn validity(&self) -> Validity {
-        child_to_validity(self.validity_child(), self.as_ref().dtype().nullability())
+        child_to_validity(self.validity_child(), self.dtype().nullability())
     }
 
     #[inline]
@@ -323,12 +323,7 @@ pub trait BitPackedArrayExt: BitPackedArraySlotsExt {
         &'a self,
         scratch: &'a mut [MaybeUninit<T>; FL_CHUNK_SIZE],
     ) -> VortexResult<BitUnpackedChunks<'a, T>> {
-        BitPackedData::unpacked_chunks::<T>(
-            self,
-            self.as_ref().dtype(),
-            self.as_ref().len(),
-            scratch,
-        )
+        BitPackedData::unpacked_chunks::<T>(self, self.dtype(), self.len(), scratch)
     }
 }
 

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -299,15 +299,15 @@ pub trait BitPackedArrayExt: BitPackedArraySlotsExt {
     fn patches(&self) -> Option<Patches> {
         PatchesData::patches_from_slots(
             self.patches_data.as_ref(),
-            self.as_ref().len(),
-            self.as_ref().slots(),
+            self.len(),
+            self.slots(),
             PATCH_SLOTS,
         )
     }
 
     #[inline]
     fn validity(&self) -> Validity {
-        child_to_validity(self.validity_child(), self.as_ref().dtype().nullability())
+        child_to_validity(self.validity_child(), self.dtype().nullability())
     }
 
     #[inline]
@@ -317,7 +317,7 @@ pub trait BitPackedArrayExt: BitPackedArraySlotsExt {
 
     #[inline]
     fn unpacked_chunks<T: BitPackedIter>(&self) -> VortexResult<BitUnpackedChunks<T>> {
-        BitPackedData::unpacked_chunks::<T>(self, self.as_ref().dtype(), self.as_ref().len())
+        BitPackedData::unpacked_chunks::<T>(self, self.dtype(), self.len())
     }
 }
 

--- a/encodings/fastlanes/src/bitpacking/compute/compare.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/compare.rs
@@ -250,7 +250,7 @@ mod tests {
             CompareOperator::Gte,
         ] {
             let got = <BitPacked as CompareKernel>::compare(
-                sliced.as_::<BitPacked>(),
+                sliced.as_::<BitPacked>().materialize_view(),
                 &rhs,
                 op,
                 &mut ctx,
@@ -288,7 +288,7 @@ mod tests {
             .expect("slice kernel produces a sliced bitpacked array");
         let rhs = ConstantArray::new(50i32, end - start).into_array();
         let got = <BitPacked as CompareKernel>::compare(
-            sliced.as_::<BitPacked>(),
+            sliced.as_::<BitPacked>().materialize_view(),
             &rhs,
             CompareOperator::Eq,
             &mut ctx,

--- a/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
@@ -39,7 +39,7 @@ impl DynAggregateKernel for BitPackedIsConstantKernel {
             return Ok(None);
         }
 
-        let Some(array) = batch.as_opt::<BitPacked>() else {
+        let Some(array) = batch.as_typed::<BitPacked>() else {
             return Ok(None);
         };
 

--- a/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
@@ -40,7 +40,7 @@ impl DynAggregateKernel for BitPackedIsConstantKernel {
             return Ok(None);
         }
 
-        let Some(array) = batch.as_opt::<BitPacked>() else {
+        let Some(array) = batch.as_typed::<BitPacked>() else {
             return Ok(None);
         };
 

--- a/encodings/fastlanes/src/bitpacking/compute/slice.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/slice.rs
@@ -72,6 +72,7 @@ fn slice_bitpacked(
 #[cfg(test)]
 mod tests {
     use vortex_array::IntoArray;
+    use vortex_array::ParentRef;
     use vortex_array::VortexSessionExecute;
     use vortex_array::array_session;
     use vortex_array::arrays::PrimitiveArray;
@@ -87,11 +88,11 @@ mod tests {
         let values = PrimitiveArray::from_iter(0u32..2048);
         let bitpacked = bitpack_encode(&values, 11, None, &mut ctx)?;
 
-        let slice_array = SliceArray::new(bitpacked.clone().into_array(), 500..1500);
+        let slice_array = SliceArray::new(bitpacked.clone().into_array(), 500..1500).into_array();
 
         let bitpacked_ref = bitpacked.into_array();
         let reduced = bitpacked_ref
-            .reduce_parent(&slice_array.into_array(), 0)?
+            .reduce_parent(&ParentRef::from_array_ref(&slice_array), 0)?
             .expect("expected slice kernel to execute");
 
         assert!(reduced.is::<BitPacked>());

--- a/encodings/fastlanes/src/bitpacking/compute/slice.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/slice.rs
@@ -88,11 +88,11 @@ mod tests {
         let values = PrimitiveArray::from_iter(0u32..2048);
         let bitpacked = bitpack_encode(&values, 11, None, &mut ctx)?;
 
-        let slice_array = SliceArray::new(bitpacked.clone().into_array(), 500..1500).into_array();
+        let slice_array = SliceArray::new(bitpacked.clone().into_array(), 500..1500);
 
         let bitpacked_ref = bitpacked.into_array();
         let reduced = bitpacked_ref
-            .reduce_parent(&ParentRef::from_array_ref(&slice_array), 0)?
+            .reduce_parent(&ParentRef::from_array(&slice_array), 0)?
             .expect("expected slice kernel to execute");
 
         assert!(reduced.is::<BitPacked>());

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -17,6 +17,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::builders::ArrayBuilder;
 use vortex_array::dtype::DType;
@@ -292,7 +293,7 @@ impl VTable for BitPacked {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)

--- a/encodings/fastlanes/src/bitpacking/vtable/operations.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/operations.rs
@@ -34,6 +34,7 @@ mod test {
 
     use vortex_array::ArrayRef;
     use vortex_array::IntoArray;
+    use vortex_array::ParentRef;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::SliceArray;
@@ -63,9 +64,9 @@ mod test {
 
     fn slice_via_reduce(array: &BitPackedArray, range: Range<usize>) -> BitPackedArray {
         let array_ref = array.clone().into_array();
-        let slice_array = SliceArray::new(array_ref.clone(), range);
+        let slice_array = SliceArray::new(array_ref.clone(), range).into_array();
         let sliced = array_ref
-            .reduce_parent(&slice_array.into_array(), 0)
+            .reduce_parent(&ParentRef::from_array_ref(&slice_array), 0)
             .expect("execute_parent failed")
             .expect("expected slice kernel to execute");
         sliced.as_::<BitPacked>().into_owned()

--- a/encodings/fastlanes/src/bitpacking/vtable/operations.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/operations.rs
@@ -64,9 +64,9 @@ mod test {
 
     fn slice_via_reduce(array: &BitPackedArray, range: Range<usize>) -> BitPackedArray {
         let array_ref = array.clone().into_array();
-        let slice_array = SliceArray::new(array_ref.clone(), range).into_array();
+        let slice_array = SliceArray::new(array_ref.clone(), range);
         let sliced = array_ref
-            .reduce_parent(&ParentRef::from_array_ref(&slice_array), 0)
+            .reduce_parent(&ParentRef::from_array(&slice_array), 0)
             .expect("execute_parent failed")
             .expect("expected slice kernel to execute");
         sliced.as_::<BitPacked>().into_owned()

--- a/encodings/fastlanes/src/delta/vtable/mod.rs
+++ b/encodings/fastlanes/src/delta/vtable/mod.rs
@@ -16,6 +16,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
@@ -117,7 +118,7 @@ impl VTable for Delta {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         rules::RULES.evaluate(array, parent, child_idx)

--- a/encodings/fastlanes/src/for/array/for_decompress.rs
+++ b/encodings/fastlanes/src/for/array/for_decompress.rs
@@ -51,7 +51,7 @@ pub fn decompress(array: &FoRArray, ctx: &mut ExecutionCtx) -> VortexResult<Prim
 
     // Try to do fused unpack.
     if array.reference_scalar().dtype().is_unsigned_int()
-        && let Some(bp) = array.encoded().as_opt::<BitPacked>()
+        && let Some(bp) = array.encoded().as_typed::<BitPacked>()
     {
         return match_each_unsigned_integer_ptype!(array.ptype(), |T| {
             fused_decompress::<T>(array, bp, ctx)

--- a/encodings/fastlanes/src/for/array/for_decompress.rs
+++ b/encodings/fastlanes/src/for/array/for_decompress.rs
@@ -55,7 +55,7 @@ pub fn decompress(array: &FoRArray, ctx: &mut ExecutionCtx) -> VortexResult<Prim
 
     // Try to do fused unpack.
     if array.reference_scalar().dtype().is_unsigned_int()
-        && let Some(bp) = array.encoded().as_opt::<BitPacked>()
+        && let Some(bp) = array.encoded().as_typed::<BitPacked>()
     {
         return match_each_unsigned_integer_ptype!(array.ptype(), |T| {
             fused_decompress::<T>(array, bp, ctx)

--- a/encodings/fastlanes/src/for/vtable/mod.rs
+++ b/encodings/fastlanes/src/for/vtable/mod.rs
@@ -16,6 +16,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
@@ -152,7 +153,7 @@ impl VTable for FoR {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/encodings/fastlanes/src/for/vtable/rules.rs
+++ b/encodings/fastlanes/src/for/vtable/rules.rs
@@ -4,6 +4,7 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::IntoArray;
+use vortex_array::ParentView;
 use vortex_array::arrays::Filter;
 use vortex_array::arrays::filter::FilterReduceAdaptor;
 use vortex_array::arrays::slice::SliceReduceAdaptor;
@@ -33,7 +34,7 @@ impl ArrayParentReduceRule<FoR> for FoRFilterPushDownRule {
     fn reduce_parent(
         &self,
         child: ArrayView<'_, FoR>,
-        parent: ArrayView<'_, Filter>,
+        parent: ParentView<'_, Filter>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -16,6 +16,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::arrays::Primitive;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
@@ -123,7 +124,7 @@ impl VTable for RLE {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)

--- a/encodings/fastlanes/src/transposed_bool.rs
+++ b/encodings/fastlanes/src/transposed_bool.rs
@@ -18,6 +18,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::TypedArrayRef;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::slice::SliceReduce;
@@ -88,7 +89,7 @@ pub trait TransposedBoolArrayExt: TypedArrayRef<TransposedBool> {
 
     /// Returns the backing bitmap in FastLanes-transposed order.
     fn transposed(&self) -> &ArrayRef {
-        self.as_ref().slots()[TRANSPOSED_SLOT]
+        self.slots()[TRANSPOSED_SLOT]
             .as_ref()
             .vortex_expect("TransposedBoolArray transposed slot")
     }
@@ -248,7 +249,7 @@ impl VTable for TransposedBool {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -25,6 +25,7 @@ use vortex_array::ArrayView;
 use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
+use vortex_array::ParentRef;
 use vortex_array::TypedArrayRef;
 use vortex_array::VortexSessionExecute;
 use vortex_array::array_slots;
@@ -356,7 +357,7 @@ impl VTable for FSST {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)
@@ -997,15 +998,14 @@ pub trait FSSTArrayExt: FSSTArraySlotsExt {
     /// from [`FSSTData`] with the offsets and validity stored in the array's slots.
     fn codes(&self) -> VarBinArray {
         let offsets = self.codes_offsets().clone();
-        let validity =
-            child_to_validity(self.codes_validity(), self.as_ref().dtype().nullability());
+        let validity = child_to_validity(self.codes_validity(), self.dtype().nullability());
         let codes_bytes = self.codes_bytes_handle().clone();
         // SAFETY: components were validated at construction time.
         unsafe {
             VarBinArray::new_unchecked_from_handle(
                 offsets,
                 codes_bytes,
-                DType::Binary(self.as_ref().dtype().nullability()),
+                DType::Binary(self.dtype().nullability()),
                 validity,
             )
         }
@@ -1013,7 +1013,7 @@ pub trait FSSTArrayExt: FSSTArraySlotsExt {
 
     /// Get the DType of the codes array.
     fn codes_dtype(&self) -> DType {
-        DType::Binary(self.as_ref().dtype().nullability())
+        DType::Binary(self.dtype().nullability())
     }
 }
 

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -26,6 +26,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::TypedArrayRef;
 use vortex_array::VortexSessionExecute;
 use vortex_array::array_slots;
@@ -354,7 +355,7 @@ impl VTable for FSST {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)
@@ -828,15 +829,14 @@ pub trait FSSTArrayExt: FSSTArraySlotsExt {
     /// from [`FSSTData`] with the offsets and validity stored in the array's slots.
     fn codes(&self) -> VarBinArray {
         let offsets = self.codes_offsets().clone();
-        let validity =
-            child_to_validity(self.codes_validity(), self.as_ref().dtype().nullability());
+        let validity = child_to_validity(self.codes_validity(), self.dtype().nullability());
         let codes_bytes = self.codes_bytes_handle().clone();
         // SAFETY: components were validated at construction time.
         unsafe {
             VarBinArray::new_unchecked_from_handle(
                 offsets,
                 codes_bytes,
-                DType::Binary(self.as_ref().dtype().nullability()),
+                DType::Binary(self.dtype().nullability()),
                 validity,
             )
         }
@@ -844,7 +844,7 @@ pub trait FSSTArrayExt: FSSTArraySlotsExt {
 
     /// Get the DType of the codes array.
     fn codes_dtype(&self) -> DType {
-        DType::Binary(self.as_ref().dtype().nullability())
+        DType::Binary(self.dtype().nullability())
     }
 }
 

--- a/encodings/fsst/src/compress.rs
+++ b/encodings/fsst/src/compress.rs
@@ -53,9 +53,9 @@ pub fn fsst_compress(
     compressor: &Compressor,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<FSSTArray> {
-    if let Some(view) = array.as_opt::<VarBinView>() {
+    if let Some(view) = array.as_typed::<VarBinView>() {
         compress_varbinview(view, compressor, ctx)
-    } else if let Some(varbin) = array.as_opt::<VarBin>() {
+    } else if let Some(varbin) = array.as_typed::<VarBin>() {
         compress_varbin_array(varbin, compressor, ctx)
     } else {
         vortex_bail!(
@@ -69,9 +69,9 @@ pub fn fsst_compress(
 ///
 /// Accepts any [`VarBinView`] or [`VarBin`]-encoded array; other encodings error.
 pub fn fsst_train_compressor(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Compressor> {
-    if let Some(view) = array.as_opt::<VarBinView>() {
+    if let Some(view) = array.as_typed::<VarBinView>() {
         train_varbinview(view, ctx)
-    } else if let Some(varbin) = array.as_opt::<VarBin>() {
+    } else if let Some(varbin) = array.as_typed::<VarBin>() {
         train_varbin_array(varbin, ctx)
     } else {
         vortex_bail!(

--- a/encodings/fsst/src/compress.rs
+++ b/encodings/fsst/src/compress.rs
@@ -50,9 +50,9 @@ pub fn fsst_compress(
     compressor: &Compressor,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<FSSTArray> {
-    if let Some(view) = array.as_opt::<VarBinView>() {
+    if let Some(view) = array.as_typed::<VarBinView>() {
         compress_varbinview(view, compressor, ctx)
-    } else if let Some(varbin) = array.as_opt::<VarBin>() {
+    } else if let Some(varbin) = array.as_typed::<VarBin>() {
         compress_varbin_array(varbin, compressor, ctx)
     } else {
         vortex_bail!(
@@ -66,9 +66,9 @@ pub fn fsst_compress(
 ///
 /// Accepts any [`VarBinView`] or [`VarBin`]-encoded array; other encodings error.
 pub fn fsst_train_compressor(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Compressor> {
-    if let Some(view) = array.as_opt::<VarBinView>() {
+    if let Some(view) = array.as_typed::<VarBinView>() {
         train_varbinview(view, ctx)
-    } else if let Some(varbin) = array.as_opt::<VarBin>() {
+    } else if let Some(varbin) = array.as_typed::<VarBin>() {
         train_varbin_array(varbin, ctx)
     } else {
         vortex_bail!(

--- a/encodings/onpair/src/array.rs
+++ b/encodings/onpair/src/array.rs
@@ -25,6 +25,7 @@ use vortex_array::ArrayView;
 use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
+use vortex_array::ParentRef;
 use vortex_array::array_slots;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::builders::ArrayBuilder;
@@ -645,7 +646,7 @@ impl VTable for OnPair {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)
@@ -702,8 +703,8 @@ pub trait OnPairArrayExt: OnPairArraySlotsExt {
     /// the outer dtype's nullability.
     fn array_validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[OnPairSlots::VALIDITY].as_ref(),
-            self.as_ref().dtype().nullability(),
+            self.slots()[OnPairSlots::VALIDITY].as_ref(),
+            self.dtype().nullability(),
         )
     }
 }

--- a/encodings/onpair/src/array.rs
+++ b/encodings/onpair/src/array.rs
@@ -23,6 +23,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::array_slots;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::builders::ArrayBuilder;
@@ -596,7 +597,7 @@ impl VTable for OnPair {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)
@@ -618,8 +619,8 @@ pub trait OnPairArrayExt: OnPairArraySlotsExt {
     /// the outer dtype's nullability.
     fn array_validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[OnPairSlots::VALIDITY].as_ref(),
-            self.as_ref().dtype().nullability(),
+            self.slots()[OnPairSlots::VALIDITY].as_ref(),
+            self.dtype().nullability(),
         )
     }
 }

--- a/encodings/parquet-variant/src/array.rs
+++ b/encodings/parquet-variant/src/array.rs
@@ -198,7 +198,7 @@ pub(crate) fn logical_shredded_from_parquet_typed_value(
         .into_array());
     }
 
-    let Some(struct_array) = typed_value.as_opt::<Struct>() else {
+    let Some(struct_array) = typed_value.as_typed::<Struct>() else {
         return Ok(typed_value);
     };
 
@@ -237,7 +237,7 @@ fn logical_shredded_from_parquet_field(
     field: ArrayRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ArrayRef>> {
-    let Some(field_struct) = field.as_opt::<Struct>() else {
+    let Some(field_struct) = field.as_typed::<Struct>() else {
         return Ok(Some(field));
     };
 
@@ -364,7 +364,7 @@ pub(crate) fn parquet_typed_value_from_logical_shredded(
         FieldNames::from_iter(names),
         fields,
         struct_array.len(),
-        struct_array.validity()?,
+        struct_array.struct_validity(),
     )?
     .into_array())
 }
@@ -430,8 +430,8 @@ pub trait ParquetVariantArrayExt:
     /// Returns the outer row validity for the Variant values.
     fn parquet_variant_validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[ParquetVariantSlots::VALIDITY].as_ref(),
-            self.as_ref().dtype().nullability(),
+            self.slots()[ParquetVariantSlots::VALIDITY].as_ref(),
+            self.dtype().nullability(),
         )
     }
 

--- a/encodings/parquet-variant/src/array.rs
+++ b/encodings/parquet-variant/src/array.rs
@@ -192,7 +192,7 @@ pub(crate) fn logical_shredded_from_parquet_typed_value(
         .into_array());
     }
 
-    let Some(struct_array) = typed_value.as_opt::<Struct>() else {
+    let Some(struct_array) = typed_value.as_typed::<Struct>() else {
         return Ok(typed_value);
     };
 
@@ -231,7 +231,7 @@ fn logical_shredded_from_parquet_field(
     field: ArrayRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ArrayRef>> {
-    let Some(field_struct) = field.as_opt::<Struct>() else {
+    let Some(field_struct) = field.as_typed::<Struct>() else {
         return Ok(Some(field));
     };
 
@@ -358,7 +358,7 @@ pub(crate) fn parquet_typed_value_from_logical_shredded(
         FieldNames::from_iter(names),
         fields,
         struct_array.len(),
-        struct_array.validity()?,
+        struct_array.struct_validity(),
     )?
     .into_array())
 }
@@ -424,8 +424,8 @@ pub trait ParquetVariantArrayExt:
     /// Returns the outer row validity for the Variant values.
     fn parquet_variant_validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[ParquetVariantSlots::VALIDITY].as_ref(),
-            self.as_ref().dtype().nullability(),
+            self.slots()[ParquetVariantSlots::VALIDITY].as_ref(),
+            self.dtype().nullability(),
         )
     }
 

--- a/encodings/parquet-variant/src/arrow.rs
+++ b/encodings/parquet-variant/src/arrow.rs
@@ -91,7 +91,7 @@ pub(crate) fn export_storage_to_target<T: ParquetVariantArrayExt>(
 
     let nulls = to_arrow_null_buffer(
         ParquetVariantArrayExt::parquet_variant_validity(parquet_array),
-        parquet_array.as_ref().len(),
+        parquet_array.len(),
         ctx,
     )?;
     Ok(Arc::new(StructArray::try_new(
@@ -108,7 +108,7 @@ pub(crate) fn export_unshredded_storage_to_target<T: ParquetVariantArrayExt>(
 ) -> VortexResult<ArrowArrayRef> {
     let arrow_variant = parquet_array.to_arrow(ctx)?;
     let unshredded = unshred_variant(&arrow_variant)?;
-    let unshredded_array = if parquet_array.as_ref().dtype().is_nullable() {
+    let unshredded_array = if parquet_array.dtype().is_nullable() {
         ParquetVariant::from_arrow_variant_nullable(&unshredded, &ctx.session().arrow())?
     } else {
         ParquetVariant::from_arrow_variant(&unshredded, &ctx.session().arrow())?

--- a/encodings/parquet-variant/src/arrow.rs
+++ b/encodings/parquet-variant/src/arrow.rs
@@ -91,7 +91,7 @@ pub(crate) fn export_storage_to_target<T: ParquetVariantArrayExt>(
 
     let nulls = to_arrow_null_buffer(
         ParquetVariantArrayExt::parquet_variant_validity(parquet_array),
-        parquet_array.as_ref().len(),
+        parquet_array.len(),
         ctx,
     )?;
     Ok(Arc::new(StructArray::try_new(
@@ -108,7 +108,7 @@ pub(crate) fn export_unshredded_storage_to_target<T: ParquetVariantArrayExt>(
 ) -> VortexResult<ArrowArrayRef> {
     let arrow_variant = parquet_array.to_arrow(ctx)?;
     let unshredded = unshred_variant(&arrow_variant)?;
-    let unshredded_array = if parquet_array.as_ref().dtype().is_nullable() {
+    let unshredded_array = if parquet_array.dtype().is_nullable() {
         ParquetVariant::from_arrow_variant_nullable(&unshredded)?
     } else {
         ParquetVariant::from_arrow_variant(&unshredded)?

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -29,6 +29,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::TypedArrayRef;
 use vortex_array::array_slots;
 use vortex_array::arrays::Primitive;
@@ -257,7 +258,7 @@ impl VTable for Pco {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         crate::rules::RULES.evaluate(array, parent, child_idx)
@@ -354,8 +355,8 @@ pub trait PcoArrayExt: PcoArraySlotsExt {
     /// Reconstruct the unsliced [`Validity`] from the validity slot.
     fn unsliced_validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[PcoSlots::VALIDITY].as_ref(),
-            self.as_ref().dtype().nullability(),
+            self.slots()[PcoSlots::VALIDITY].as_ref(),
+            self.dtype().nullability(),
         )
     }
 }

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -29,6 +29,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::TypedArrayRef;
 use vortex_array::array_slots;
 use vortex_array::arrays::Primitive;
@@ -259,7 +260,7 @@ impl VTable for Pco {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         crate::rules::RULES.evaluate(array, parent, child_idx)
@@ -365,8 +366,8 @@ pub trait PcoArrayExt: PcoArraySlotsExt {
     /// Reconstruct the unsliced [`Validity`] from the validity slot.
     fn unsliced_validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[PcoSlots::VALIDITY].as_ref(),
-            self.as_ref().dtype().nullability(),
+            self.slots()[PcoSlots::VALIDITY].as_ref(),
+            self.dtype().nullability(),
         )
     }
 }

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -19,6 +19,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::TypedArrayRef;
 use vortex_array::VortexSessionExecute;
 use vortex_array::array_slots;
@@ -175,7 +176,7 @@ impl VTable for RunEnd {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)
@@ -293,7 +294,7 @@ impl RunEnd {
 
     /// Run the array through run-end encoding.
     pub fn encode(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<RunEndArray> {
-        if let Some(parray) = array.as_opt::<Primitive>() {
+        if let Some(parray) = array.as_typed::<Primitive>() {
             let (ends, values) = runend_encode(parray, ctx);
             let ends = ends.into_array();
             let len = array.len();
@@ -440,7 +441,7 @@ impl RunEndData {
 
     /// Run the array through run-end encoding.
     pub fn encode(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        if let Some(parray) = array.as_opt::<Primitive>() {
+        if let Some(parray) = array.as_typed::<Primitive>() {
             let (_ends, _values) = runend_encode(parray, ctx);
             // SAFETY: runend_encode handles this
             unsafe { Ok(Self::new_unchecked(0)) }

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -19,6 +19,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::TypedArrayRef;
 use vortex_array::VortexSessionExecute;
 use vortex_array::array_slots;
@@ -170,7 +171,7 @@ impl VTable for RunEnd {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)
@@ -288,7 +289,7 @@ impl RunEnd {
 
     /// Run the array through run-end encoding.
     pub fn encode(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<RunEndArray> {
-        if let Some(parray) = array.as_opt::<Primitive>() {
+        if let Some(parray) = array.as_typed::<Primitive>() {
             let (ends, values) = runend_encode(parray, ctx);
             let ends = ends.into_array();
             let len = array.len();
@@ -435,7 +436,7 @@ impl RunEndData {
 
     /// Run the array through run-end encoding.
     pub fn encode(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        if let Some(parray) = array.as_opt::<Primitive>() {
+        if let Some(parray) = array.as_typed::<Primitive>() {
             let (_ends, _values) = runend_encode(parray, ctx);
             // SAFETY: runend_encode handles this
             unsafe { Ok(Self::new_unchecked(0)) }

--- a/encodings/runend/src/compute/is_sorted.rs
+++ b/encodings/runend/src/compute/is_sorted.rs
@@ -34,7 +34,7 @@ impl DynAggregateKernel for RunEndIsSortedKernel {
             return Ok(None);
         };
 
-        let Some(array) = batch.as_opt::<RunEnd>() else {
+        let Some(array) = batch.as_typed::<RunEnd>() else {
             return Ok(None);
         };
 

--- a/encodings/runend/src/compute/take_from.rs
+++ b/encodings/runend/src/compute/take_from.rs
@@ -5,6 +5,7 @@ use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::ParentView;
 use vortex_array::arrays::Dict;
 use vortex_array::arrays::dict::DictArraySlotsExt;
 use vortex_array::dtype::DType;
@@ -24,7 +25,7 @@ impl ExecuteParentKernel<RunEnd> for RunEndTakeFrom {
     fn execute_parent(
         &self,
         array: ArrayView<'_, RunEnd>,
-        dict: ArrayView<'_, Dict>,
+        dict: ParentView<'_, Dict>,
         child_idx: usize,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
@@ -97,7 +98,7 @@ mod tests {
         let (codes, dict) = make_dict_with_runend_codes(&mut ctx);
 
         let result = RunEndTakeFrom
-            .execute_parent(codes.as_view(), dict.as_view(), 0, &mut ctx)?
+            .execute_parent(codes.as_view(), dict.as_parent_view(), 0, &mut ctx)?
             .expect("kernel should return Some");
 
         let expected = PrimitiveArray::from_iter([2i32, 2, 2, 3, 3, 2, 2]);
@@ -121,7 +122,7 @@ mod tests {
         };
 
         let result = RunEndTakeFrom
-            .execute_parent(sliced_codes.as_view(), dict.as_view(), 0, &mut ctx)?
+            .execute_parent(sliced_codes.as_view(), dict.as_parent_view(), 0, &mut ctx)?
             .expect("kernel should return Some");
 
         let expected = PrimitiveArray::from_iter([2i32, 3, 3]);
@@ -145,7 +146,7 @@ mod tests {
         };
 
         let result = RunEndTakeFrom
-            .execute_parent(sliced_codes.as_view(), dict.as_view(), 0, &mut ctx)?
+            .execute_parent(sliced_codes.as_view(), dict.as_parent_view(), 0, &mut ctx)?
             .expect("kernel should return Some");
 
         let expected = PrimitiveArray::from_iter([3i32, 3, 2, 2]);
@@ -169,7 +170,7 @@ mod tests {
         };
 
         let result = RunEndTakeFrom
-            .execute_parent(sliced_codes.as_view(), dict.as_view(), 0, &mut ctx)?
+            .execute_parent(sliced_codes.as_view(), dict.as_parent_view(), 0, &mut ctx)?
             .expect("kernel should return Some");
 
         let expected = PrimitiveArray::from_iter([3i32]);
@@ -183,7 +184,8 @@ mod tests {
         let mut ctx = SESSION.create_execution_ctx();
         let (codes, dict) = make_dict_with_runend_codes(&mut ctx);
 
-        let result = RunEndTakeFrom.execute_parent(codes.as_view(), dict.as_view(), 1, &mut ctx)?;
+        let result =
+            RunEndTakeFrom.execute_parent(codes.as_view(), dict.as_parent_view(), 1, &mut ctx)?;
         assert!(result.is_none());
         Ok(())
     }

--- a/encodings/runend/src/kernel.rs
+++ b/encodings/runend/src/kernel.rs
@@ -8,6 +8,7 @@ use vortex_array::ArrayVTable;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::ParentView;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::Dict;
 use vortex_array::arrays::Filter;
@@ -49,7 +50,7 @@ impl ExecuteParentKernel<RunEnd> for RunEndSliceKernel {
     fn execute_parent(
         &self,
         array: ArrayView<'_, RunEnd>,
-        parent: ArrayView<'_, Slice>,
+        parent: ParentView<'_, Slice>,
         _child_idx: usize,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/encodings/runend/src/rules.rs
+++ b/encodings/runend/src/rules.rs
@@ -4,6 +4,7 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::IntoArray;
+use vortex_array::ParentView;
 use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::ScalarFnArray;
@@ -42,7 +43,7 @@ impl ArrayParentReduceRule<RunEnd> for RunEndScalarFnRule {
     fn reduce_parent(
         &self,
         run_end: ArrayView<'_, RunEnd>,
-        parent: ArrayView<'_, ScalarFn>,
+        parent: ParentView<'_, ScalarFn>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         for (idx, child) in parent.iter_children().enumerate() {

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -19,6 +19,7 @@ use vortex_array::ArrayView;
 use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
+use vortex_array::ParentRef;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
@@ -418,7 +419,7 @@ impl VTable for Sequence {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -19,6 +19,7 @@ use vortex_array::ArrayView;
 use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
+use vortex_array::ParentRef;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
@@ -340,7 +341,7 @@ impl VTable for Sequence {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -22,6 +22,8 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
+use vortex_array::ParentView;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::Primitive;
@@ -146,13 +148,13 @@ impl SparseOwnedExt for Array<Sparse> {
         let patches = Patches::new(
             self.len(),
             self.patches().offset(),
-            self.as_ref().slots()[SparseSlots::PATCH_INDICES]
+            self.slots()[SparseSlots::PATCH_INDICES]
                 .clone()
                 .vortex_expect("indices"),
-            self.as_ref().slots()[SparseSlots::PATCH_VALUES]
+            self.slots()[SparseSlots::PATCH_VALUES]
                 .clone()
                 .vortex_expect("values"),
-            self.as_ref().slots()[SparseSlots::PATCH_CHUNK_OFFSETS].clone(),
+            self.slots()[SparseSlots::PATCH_CHUNK_OFFSETS].clone(),
         )?;
         Ok(SparseParts {
             patches,
@@ -302,7 +304,7 @@ impl VTable for Sparse {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)
@@ -687,6 +689,12 @@ pub trait SparseExt {
 }
 
 impl SparseExt for ArrayView<'_, Sparse> {
+    fn patches(&self) -> Patches {
+        SparseData::patches_from_slots(self.data(), self.len(), self.slots())
+    }
+}
+
+impl SparseExt for ParentView<'_, Sparse> {
     fn patches(&self) -> Patches {
         SparseData::patches_from_slots(self.data(), self.len(), self.slots())
     }

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -22,6 +22,8 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
+use vortex_array::ParentView;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::Primitive;
@@ -142,13 +144,13 @@ impl SparseOwnedExt for Array<Sparse> {
         let patches = Patches::new(
             self.len(),
             self.patches().offset(),
-            self.as_ref().slots()[SparseSlots::PATCH_INDICES]
+            self.slots()[SparseSlots::PATCH_INDICES]
                 .clone()
                 .vortex_expect("indices"),
-            self.as_ref().slots()[SparseSlots::PATCH_VALUES]
+            self.slots()[SparseSlots::PATCH_VALUES]
                 .clone()
                 .vortex_expect("values"),
-            self.as_ref().slots()[SparseSlots::PATCH_CHUNK_OFFSETS].clone(),
+            self.slots()[SparseSlots::PATCH_CHUNK_OFFSETS].clone(),
         )?;
         Ok(SparseParts {
             patches,
@@ -298,7 +300,7 @@ impl VTable for Sparse {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)
@@ -656,6 +658,12 @@ pub trait SparseExt {
 }
 
 impl SparseExt for ArrayView<'_, Sparse> {
+    fn patches(&self) -> Patches {
+        SparseData::patches_from_slots(self.data(), self.len(), self.slots())
+    }
+}
+
+impl SparseExt for ParentView<'_, Sparse> {
     fn patches(&self) -> Patches {
         SparseData::patches_from_slots(self.data(), self.len(), self.slots())
     }

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -16,6 +16,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::TypedArrayRef;
 use vortex_array::array_slots;
 use vortex_array::buffer::BufferHandle;
@@ -144,7 +145,7 @@ impl VTable for ZigZag {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)
@@ -295,7 +296,7 @@ mod test {
         );
 
         let sliced = zigzag.slice(0..2)?;
-        let sliced = sliced.as_::<ZigZag>();
+        let sliced = sliced.as_::<ZigZag>().materialize_view();
         assert_eq!(
             sliced.array().execute_scalar(sliced.len() - 1, &mut ctx,)?,
             Scalar::from(-5i32)

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -25,6 +25,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::array_slots;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -301,7 +302,7 @@ impl VTable for Zstd {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         crate::rules::RULES.evaluate(array, parent, child_idx)

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -22,6 +22,7 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::array_slots;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -323,7 +324,7 @@ impl VTable for Zstd {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         crate::rules::RULES.evaluate(array, parent, child_idx)

--- a/vortex-array-macros/src/lib.rs
+++ b/vortex-array-macros/src/lib.rs
@@ -283,7 +283,7 @@ fn expand_array_slots(
 
             #[doc = "Returns a borrowed view of all slots."]
             fn slots_view(&self) -> #view_ident<'_> {
-                #view_ident::from_slots(self.as_ref().slots())
+                #view_ident::from_slots(self.slots())
             }
         }
 
@@ -661,7 +661,7 @@ impl SlotField {
                 #[inline]
                 fn #field_ident(&self) -> &::vortex_array::ArrayRef {
                     ::vortex_error::VortexExpect::vortex_expect(
-                        self.as_ref().slots()[#struct_ident::#const_ident].as_ref(),
+                        self.slots()[#struct_ident::#const_ident].as_ref(),
                         #expect_message,
                     )
                 }
@@ -669,14 +669,14 @@ impl SlotField {
             SlotFieldType::Optional => quote! {
                 #[inline]
                 fn #field_ident(&self) -> Option<&::vortex_array::ArrayRef> {
-                    self.as_ref().slots()[#struct_ident::#const_ident].as_ref()
+                    self.slots()[#struct_ident::#const_ident].as_ref()
                 }
             },
             SlotFieldType::VariadicTail => quote! {
                 #[inline]
                 fn #field_ident(&self) -> ::vortex_array::SlotSlice<'_> {
                     ::vortex_array::SlotSlice::new(
-                        &self.as_ref().slots()[#struct_ident::#const_ident..],
+                        &self.slots()[#struct_ident::#const_ident..],
                         #expect_message,
                     )
                 }

--- a/vortex-array/src/aggregate_fn/fns/sum_v2/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum_v2/mod.rs
@@ -249,7 +249,7 @@ impl AggregateFnVTable for SumV2 {
 
     fn finalize(&self, partials: ArrayRef) -> VortexResult<ArrayRef> {
         if let Some(partials) = partials.as_opt::<Struct>() {
-            return finalize_struct(partials);
+            return finalize_struct(partials.materialize_view());
         }
 
         let sum = partials.get_item(SUM_FIELD)?;

--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -92,6 +92,7 @@ impl ArrayRef {
         &self.0.data
     }
 
+    #[allow(clippy::inline_always)]
     #[inline(always)]
     pub(crate) fn inner(&self) -> &ArrayInner<dyn DynArrayData> {
         &self.0

--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -21,6 +21,7 @@ use crate::AnyCanonical;
 use crate::Array;
 use crate::ArrayEq;
 use crate::ArrayHash;
+use crate::ArraySlots;
 use crate::ArrayView;
 use crate::Canonical;
 use crate::ExecutionCtx;
@@ -32,8 +33,10 @@ use crate::aggregate_fn::fns::sum::sum;
 use crate::array::ArrayData;
 use crate::array::ArrayId;
 use crate::array::ArrayInner;
-use crate::array::ArraySlots;
 use crate::array::DynArrayData;
+use crate::array::ParentMaterializer;
+use crate::array::ParentRef;
+use crate::array::ParentView;
 use crate::arrays::Constant;
 use crate::arrays::DictArray;
 use crate::arrays::FilterArray;
@@ -45,10 +48,9 @@ use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
 use crate::expr::stats::StatsProviderExt;
 use crate::legacy_session;
+use crate::matcher::AsParent;
 use crate::matcher::Matcher;
-use crate::optimizer::ArrayOptimizer;
 use crate::scalar::Scalar;
-use crate::scalar::ScalarValue;
 use crate::stats::StatsSetRef;
 use crate::validity::Validity;
 
@@ -87,6 +89,11 @@ impl ArrayRef {
     #[inline(always)]
     pub(crate) fn dyn_array(&self) -> &dyn DynArrayData {
         &self.0.data
+    }
+
+    #[inline(always)]
+    pub(crate) fn inner(&self) -> &ArrayInner<dyn DynArrayData> {
+        &self.0
     }
 
     /// Returns a mutable reference to the inner if this is the sole owner.
@@ -182,24 +189,28 @@ impl ArrayEq for ArrayRef {
 impl ArrayRef {
     /// Returns the length of the array.
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn len(&self) -> usize {
         self.0.len
     }
 
     /// Returns whether the array is empty (has zero rows).
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn is_empty(&self) -> bool {
         self.0.len == 0
     }
 
     /// Returns the logical Vortex [`DType`] of the array.
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn dtype(&self) -> &DType {
         &self.0.dtype
     }
 
     /// Returns the encoding ID of the array.
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn encoding_id(&self) -> ArrayId {
         self.0.encoding_id
     }
@@ -223,23 +234,24 @@ impl ArrayRef {
             return Ok(Canonical::empty(self.dtype()).into_array());
         }
 
-        let sliced = SliceArray::try_new(self.clone(), range)?
-            .into_array()
-            .optimize()?;
+        let sliced = SliceArray::try_new_parts(self.clone(), range)?;
+        let sliced = sliced.optimize()?;
 
         // Propagate some stats from the original array to the sliced array.
-        if !sliced.is::<Constant>() {
-            self.statistics().with_iter(|iter| {
-                sliced.statistics().inherit(iter.filter(|(stat, value)| {
-                    matches!(
-                        stat,
-                        Stat::IsConstant | Stat::IsSorted | Stat::IsStrictSorted
-                    ) && value
-                        .as_ref()
-                        .as_exact()
-                        .is_some_and(|v| matches!(v, ScalarValue::Bool(true)))
-                }));
+        if sliced.encoding_id() != Constant.id() {
+            let inherited = self.statistics().with_typed_stats_set(|s| {
+                [Stat::IsConstant, Stat::IsSorted, Stat::IsStrictSorted]
+                    .into_iter()
+                    .filter_map(|stat| s.values.get(stat).as_exact().map(|ex| (stat, ex)))
+                    .collect::<Vec<_>>()
             });
+            if !inherited.is_empty() {
+                sliced.statistics().with_mut_typed_stats_set(|mut t| {
+                    for (stat, ex) in inherited {
+                        t.set(stat, Precision::Exact(ex));
+                    }
+                });
+            }
         }
 
         Ok(sliced)
@@ -247,16 +259,14 @@ impl ArrayRef {
 
     /// Wraps the array in a [`FilterArray`] such that it is logically filtered by the given mask.
     pub fn filter(&self, mask: Mask) -> VortexResult<ArrayRef> {
-        FilterArray::try_new(self.clone(), mask)?
-            .into_array()
-            .optimize()
+        let parts = FilterArray::try_new_parts(self.clone(), mask)?;
+        parts.optimize()
     }
 
     /// Wraps the array in a [`DictArray`] such that it is logically taken by the given indices.
     pub fn take(&self, indices: ArrayRef) -> VortexResult<ArrayRef> {
-        DictArray::try_new(indices, self.clone())?
-            .into_array()
-            .optimize()
+        let parts = DictArray::try_new_parts(indices, self.clone())?;
+        parts.optimize()
     }
 
     /// Fetch the scalar at the given index.
@@ -385,18 +395,26 @@ impl ArrayRef {
 
     /// Does the array match the given matcher.
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn is<M: Matcher>(&self) -> bool {
         M::matches(self)
     }
 
     /// Returns the array downcast by the given matcher.
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn as_<M: Matcher>(&self) -> M::Match<'_> {
         self.as_opt::<M>().vortex_expect("Failed to downcast")
     }
 
     /// Returns the array downcast by the given matcher.
+    ///
+    /// The returned match never hides a materialization: heap-backed arrays are
+    /// already materialized, so [`ParentView::materialize_array_ref`]-style hooks
+    /// on the match are free. Use [`Self::as_typed`] for a direct [`ArrayView`]
+    /// downcast when heap-only APIs like [`ArrayView::array`] are needed.
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn as_opt<M: Matcher>(&self) -> Option<M::Match<'_>> {
         M::try_match(self)
     }
@@ -641,7 +659,7 @@ impl ArrayRef {
 
     pub fn reduce_parent(
         &self,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         self.0.data.reduce_parent(self, parent, child_idx)
@@ -689,8 +707,8 @@ impl ArrayRef {
     /// Returns the nth child of the array without allocating a Vec.
     ///
     /// Returns `None` if the index is out of bounds.
-    pub fn nth_child(&self, idx: usize) -> Option<ArrayRef> {
-        self.children_iter().nth(idx).cloned()
+    pub fn nth_child(&self, idx: usize) -> Option<&ArrayRef> {
+        self.children_iter().nth(idx)
     }
 
     /// Returns the names of the children of the array: the slot names of the non-None slots
@@ -739,6 +757,7 @@ impl ArrayRef {
     }
 
     /// Returns the slots of the array.
+    #[allow(clippy::same_name_method)]
     pub fn slots(&self) -> &[Option<ArrayRef>] {
         &self.0.slots
     }
@@ -789,18 +808,79 @@ impl IntoArray for ArrayRef {
     }
 }
 
-impl<V: VTable> Matcher for V {
-    type Match<'a> = ArrayView<'a, V>;
-
+impl ParentMaterializer for ArrayRef {
     #[inline]
-    fn matches(array: &ArrayRef) -> bool {
-        array.0.data.as_any().is::<ArrayData<V>>()
+    fn materialize_array_ref(&self) -> &ArrayRef {
+        self
+    }
+}
+
+#[allow(clippy::same_name_method)]
+impl AsParent for ArrayRef {
+    #[inline]
+    fn encoding_id(&self) -> ArrayId {
+        ArrayRef::encoding_id(self)
     }
 
     #[inline]
-    fn try_match(array: &'_ ArrayRef) -> Option<ArrayView<'_, V>> {
-        let inner = array.0.data.as_any().downcast_ref::<ArrayData<V>>()?;
-        // # Safety checked by `downcast_ref`.
-        Some(unsafe { ArrayView::new_unchecked(array, &inner.data) })
+    fn dtype(&self) -> &DType {
+        ArrayRef::dtype(self)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        ArrayRef::len(self)
+    }
+
+    #[inline]
+    fn slots(&self) -> &[Option<ArrayRef>] {
+        ArrayRef::slots(self)
+    }
+
+    /// Direct downcast on the heap array. The hot `ArrayRef::is::<V>()` path goes
+    /// through here, so any extra work shows up in downstream micro-benchmarks
+    /// (`patches_lookup`, `chunk_array_builder`, ...).
+    #[inline]
+    fn is_encoding<V: VTable>(&self) -> bool {
+        self.0.data.as_any().is::<ArrayData<V>>()
+    }
+
+    #[inline]
+    fn typed_data<V: VTable>(&self) -> Option<&V::TypedArrayData> {
+        self.0
+            .data
+            .as_any()
+            .downcast_ref::<ArrayData<V>>()
+            .map(|data| &data.data)
+    }
+
+    #[inline]
+    fn as_parent_view<V: VTable>(&self) -> Option<ParentView<'_, V>> {
+        let data = AsParent::typed_data::<V>(self)?;
+        // SAFETY: `typed_data::<V>()` returned Some, so the array's encoding is
+        // `V` and `data` is the `V::TypedArrayData` stored inside `self`.
+        Some(unsafe { ParentView::new_unchecked(self, data) })
+    }
+}
+
+impl<V: VTable> Matcher for V {
+    type Match<'a> = ParentView<'a, V>;
+
+    /// Match by encoding id (no materialization). Equivalent to
+    /// [`Matcher::try_match`].is_some() but avoids constructing a
+    /// [`ParentView`] for parents that do not need one.
+    #[inline]
+    fn matches<P: AsParent>(parent: &P) -> bool {
+        parent.is_encoding::<V>()
+    }
+
+    /// Returns a [`ParentView`] for the parent if its encoding is `V`.
+    ///
+    /// The returned [`ParentView`] is stack-backed when the parent is stack-backed,
+    /// so no `Arc<ArrayInner<_>>` is allocated until a downstream consumer reaches
+    /// for [`ParentView::materialize_array_ref`].
+    #[inline]
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        parent.as_parent_view::<V>()
     }
 }

--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -21,6 +21,7 @@ use crate::AnyCanonical;
 use crate::Array;
 use crate::ArrayEq;
 use crate::ArrayHash;
+use crate::ArraySlots;
 use crate::ArrayView;
 use crate::Canonical;
 use crate::ExecutionCtx;
@@ -32,8 +33,10 @@ use crate::aggregate_fn::fns::sum::sum;
 use crate::array::ArrayData;
 use crate::array::ArrayId;
 use crate::array::ArrayInner;
-use crate::array::ArraySlots;
 use crate::array::DynArrayData;
+use crate::array::ParentMaterializer;
+use crate::array::ParentRef;
+use crate::array::ParentView;
 use crate::arrays::Constant;
 use crate::arrays::DictArray;
 use crate::arrays::FilterArray;
@@ -45,10 +48,9 @@ use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
 use crate::expr::stats::StatsProviderExt;
 use crate::legacy_session;
+use crate::matcher::AsParent;
 use crate::matcher::Matcher;
-use crate::optimizer::ArrayOptimizer;
 use crate::scalar::Scalar;
-use crate::scalar::ScalarValue;
 use crate::stats::StatsSetRef;
 use crate::validity::Validity;
 
@@ -88,6 +90,11 @@ impl ArrayRef {
     #[inline(always)]
     pub(crate) fn dyn_array(&self) -> &dyn DynArrayData {
         &self.0.data
+    }
+
+    #[inline(always)]
+    pub(crate) fn inner(&self) -> &ArrayInner<dyn DynArrayData> {
+        &self.0
     }
 
     /// Returns a mutable reference to the inner if this is the sole owner.
@@ -185,24 +192,28 @@ impl ArrayEq for ArrayRef {
 impl ArrayRef {
     /// Returns the length of the array.
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn len(&self) -> usize {
         self.0.len
     }
 
     /// Returns whether the array is empty (has zero rows).
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn is_empty(&self) -> bool {
         self.0.len == 0
     }
 
     /// Returns the logical Vortex [`DType`] of the array.
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn dtype(&self) -> &DType {
         &self.0.dtype
     }
 
     /// Returns the encoding ID of the array.
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn encoding_id(&self) -> ArrayId {
         self.0.encoding_id
     }
@@ -226,23 +237,24 @@ impl ArrayRef {
             return Ok(Canonical::empty(self.dtype()).into_array());
         }
 
-        let sliced = SliceArray::try_new(self.clone(), range)?
-            .into_array()
-            .optimize()?;
+        let sliced = SliceArray::try_new_parts(self.clone(), range)?;
+        let sliced = sliced.optimize()?;
 
         // Propagate some stats from the original array to the sliced array.
-        if !sliced.is::<Constant>() {
-            self.statistics().with_iter(|iter| {
-                sliced.statistics().inherit(iter.filter(|(stat, value)| {
-                    matches!(
-                        stat,
-                        Stat::IsConstant | Stat::IsSorted | Stat::IsStrictSorted
-                    ) && value
-                        .as_ref()
-                        .as_exact()
-                        .is_some_and(|v| matches!(v, ScalarValue::Bool(true)))
-                }));
+        if sliced.encoding_id() != Constant.id() {
+            let inherited = self.statistics().with_typed_stats_set(|s| {
+                [Stat::IsConstant, Stat::IsSorted, Stat::IsStrictSorted]
+                    .into_iter()
+                    .filter_map(|stat| s.values.get(stat).as_exact().map(|ex| (stat, ex)))
+                    .collect::<Vec<_>>()
             });
+            if !inherited.is_empty() {
+                sliced.statistics().with_mut_typed_stats_set(|mut t| {
+                    for (stat, ex) in inherited {
+                        t.set(stat, Precision::Exact(ex));
+                    }
+                });
+            }
         }
 
         Ok(sliced)
@@ -250,16 +262,14 @@ impl ArrayRef {
 
     /// Wraps the array in a [`FilterArray`] such that it is logically filtered by the given mask.
     pub fn filter(&self, mask: Mask) -> VortexResult<ArrayRef> {
-        FilterArray::try_new(self.clone(), mask)?
-            .into_array()
-            .optimize()
+        let parts = FilterArray::try_new_parts(self.clone(), mask)?;
+        parts.optimize()
     }
 
     /// Wraps the array in a [`DictArray`] such that it is logically taken by the given indices.
     pub fn take(&self, indices: ArrayRef) -> VortexResult<ArrayRef> {
-        DictArray::try_new(indices, self.clone())?
-            .into_array()
-            .optimize()
+        let parts = DictArray::try_new_parts(indices, self.clone())?;
+        parts.optimize()
     }
 
     /// Fetch the scalar at the given index.
@@ -396,18 +406,26 @@ impl ArrayRef {
 
     /// Does the array match the given matcher.
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn is<M: Matcher>(&self) -> bool {
         M::matches(self)
     }
 
     /// Returns the array downcast by the given matcher.
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn as_<M: Matcher>(&self) -> M::Match<'_> {
         self.as_opt::<M>().vortex_expect("Failed to downcast")
     }
 
     /// Returns the array downcast by the given matcher.
+    ///
+    /// The returned match never hides a materialization: heap-backed arrays are
+    /// already materialized, so [`ParentView::materialize_array_ref`]-style hooks
+    /// on the match are free. Use [`Self::as_typed`] for a direct [`ArrayView`]
+    /// downcast when heap-only APIs like [`ArrayView::array`] are needed.
     #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn as_opt<M: Matcher>(&self) -> Option<M::Match<'_>> {
         M::try_match(self)
     }
@@ -652,7 +670,7 @@ impl ArrayRef {
 
     pub fn reduce_parent(
         &self,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         self.0.data.reduce_parent(self, parent, child_idx)
@@ -700,8 +718,8 @@ impl ArrayRef {
     /// Returns the nth child of the array without allocating a Vec.
     ///
     /// Returns `None` if the index is out of bounds.
-    pub fn nth_child(&self, idx: usize) -> Option<ArrayRef> {
-        self.children_iter().nth(idx).cloned()
+    pub fn nth_child(&self, idx: usize) -> Option<&ArrayRef> {
+        self.children_iter().nth(idx)
     }
 
     /// Returns the names of the children of the array: the slot names of the non-None slots
@@ -750,6 +768,7 @@ impl ArrayRef {
     }
 
     /// Returns the slots of the array.
+    #[allow(clippy::same_name_method)]
     pub fn slots(&self) -> &[Option<ArrayRef>] {
         &self.0.slots
     }
@@ -801,18 +820,79 @@ impl IntoArray for ArrayRef {
     }
 }
 
-impl<V: VTable> Matcher for V {
-    type Match<'a> = ArrayView<'a, V>;
-
+impl ParentMaterializer for ArrayRef {
     #[inline]
-    fn matches(array: &ArrayRef) -> bool {
-        array.0.data.as_any().is::<ArrayData<V>>()
+    fn materialize_array_ref(&self) -> &ArrayRef {
+        self
+    }
+}
+
+#[allow(clippy::same_name_method)]
+impl AsParent for ArrayRef {
+    #[inline]
+    fn encoding_id(&self) -> ArrayId {
+        ArrayRef::encoding_id(self)
     }
 
     #[inline]
-    fn try_match(array: &'_ ArrayRef) -> Option<ArrayView<'_, V>> {
-        let inner = array.0.data.as_any().downcast_ref::<ArrayData<V>>()?;
-        // # Safety checked by `downcast_ref`.
-        Some(unsafe { ArrayView::new_unchecked(array, &inner.data) })
+    fn dtype(&self) -> &DType {
+        ArrayRef::dtype(self)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        ArrayRef::len(self)
+    }
+
+    #[inline]
+    fn slots(&self) -> &[Option<ArrayRef>] {
+        ArrayRef::slots(self)
+    }
+
+    /// Direct downcast on the heap array. The hot `ArrayRef::is::<V>()` path goes
+    /// through here, so any extra work shows up in downstream micro-benchmarks
+    /// (`patches_lookup`, `chunk_array_builder`, ...).
+    #[inline]
+    fn is_encoding<V: VTable>(&self) -> bool {
+        self.0.data.as_any().is::<ArrayData<V>>()
+    }
+
+    #[inline]
+    fn typed_data<V: VTable>(&self) -> Option<&V::TypedArrayData> {
+        self.0
+            .data
+            .as_any()
+            .downcast_ref::<ArrayData<V>>()
+            .map(|data| &data.data)
+    }
+
+    #[inline]
+    fn as_parent_view<V: VTable>(&self) -> Option<ParentView<'_, V>> {
+        let data = AsParent::typed_data::<V>(self)?;
+        // SAFETY: `typed_data::<V>()` returned Some, so the array's encoding is
+        // `V` and `data` is the `V::TypedArrayData` stored inside `self`.
+        Some(unsafe { ParentView::new_unchecked(self, data) })
+    }
+}
+
+impl<V: VTable> Matcher for V {
+    type Match<'a> = ParentView<'a, V>;
+
+    /// Match by encoding id (no materialization). Equivalent to
+    /// [`Matcher::try_match`].is_some() but avoids constructing a
+    /// [`ParentView`] for parents that do not need one.
+    #[inline]
+    fn matches<P: AsParent>(parent: &P) -> bool {
+        parent.is_encoding::<V>()
+    }
+
+    /// Returns a [`ParentView`] for the parent if its encoding is `V`.
+    ///
+    /// The returned [`ParentView`] is stack-backed when the parent is stack-backed,
+    /// so no `Arc<ArrayInner<_>>` is allocated until a downstream consumer reaches
+    /// for [`ParentView::materialize_array_ref`].
+    #[inline]
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        parent.as_parent_view::<V>()
     }
 }

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -34,6 +34,9 @@ pub use plugin::*;
 mod foreign;
 pub(crate) use foreign::*;
 
+mod parent;
+pub use parent::*;
+
 mod typed;
 pub use typed::*;
 
@@ -117,7 +120,11 @@ impl std::ops::Index<usize> for SlotSlice<'_> {
 #[doc(hidden)]
 pub(crate) trait DynArrayData: 'static + private::Sealed + Send + Sync + Debug {
     /// Returns the array as a reference to a generic [`Any`] trait object.
-    fn as_any(&self) -> &dyn Any;
+    ///
+    /// The `+ Send + Sync` bound is preserved so [`ParentRef`] — which carries
+    /// this reference as `&dyn Any` to stay type-erased over `V` — stays
+    /// `Send + Sync` for use across `.await` boundaries.
+    fn as_any(&self) -> &(dyn Any + Send + Sync);
 
     /// Returns the array as a mutable reference to a generic [`Any`] trait object.
     fn as_any_mut(&mut self) -> &mut dyn Any;
@@ -191,7 +198,7 @@ pub(crate) trait DynArrayData: 'static + private::Sealed + Send + Sync + Debug {
     fn reduce_parent(
         &self,
         this: &ArrayRef,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>>;
 
@@ -254,7 +261,7 @@ mod private {
 /// This is self-contained: identity methods use `ArrayData<V>`'s own fields (dtype, len, stats),
 /// while data-access methods delegate to VTable methods on the inner `V::TypedArrayData`.
 impl<V: VTable> DynArrayData for ArrayData<V> {
-    fn as_any(&self) -> &dyn Any {
+    fn as_any(&self) -> &(dyn Any + Send + Sync) {
         self
     }
 
@@ -404,7 +411,10 @@ impl<V: VTable> DynArrayData for ArrayData<V> {
     }
 
     fn reduce(&self, this: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
-        let view = unsafe { ArrayView::new_unchecked(this, &self.data) };
+        let parent = ParentRef::from_array_ref(this);
+        let view = parent
+            .as_parent_view::<V>()
+            .vortex_expect("ArrayRef reduce: encoding mismatch");
         let Some(reduced) = V::reduce(view)? else {
             return Ok(None);
         };
@@ -426,7 +436,7 @@ impl<V: VTable> DynArrayData for ArrayData<V> {
     fn reduce_parent(
         &self,
         this: &ArrayRef,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         let view = unsafe { ArrayView::new_unchecked(this, &self.data) };

--- a/vortex-array/src/array/parent.rs
+++ b/vortex-array/src/array/parent.rs
@@ -30,7 +30,7 @@ use crate::array::VTable;
 use crate::dtype::DType;
 use crate::matcher::AsParent;
 use crate::matcher::Matcher;
-use crate::optimizer::ArrayOptimizer;
+use crate::optimizer::optimize_owned;
 
 /// A parent array, possibly stack-allocated, used by the `reduce_parent` dispatch chain.
 ///
@@ -325,14 +325,14 @@ impl<V: VTable> ArrayParts<V> {
     pub fn optimize(self) -> VortexResult<ArrayRef> {
         let parent = ParentRef::from_parts(&self);
         if let Some(reduced) = parent.reduce()? {
-            return reduced.optimize();
+            return Ok(optimize_owned(reduced, None)?.0);
         }
 
         for (slot_idx, slot) in parent.slots.iter().enumerate() {
             let Some(child) = slot else { continue };
 
             if let Some(reduced) = child.reduce_parent(&parent, slot_idx)? {
-                return reduced.optimize();
+                return Ok(optimize_owned(reduced, None)?.0);
             }
         }
 

--- a/vortex-array/src/array/parent.rs
+++ b/vortex-array/src/array/parent.rs
@@ -21,6 +21,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 
 use crate::ArrayRef;
+use crate::array::Array;
 use crate::array::ArrayData;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
@@ -109,6 +110,15 @@ impl<'a> ParentRef<'a> {
             },
             cache: OnceLock::new(),
         }
+    }
+
+    /// Build a [`ParentRef`] borrowing a typed [`Array<V>`] handle.
+    ///
+    /// Equivalent to [`ParentRef::from_array_ref`] on the handle's inner [`ArrayRef`],
+    /// so callers holding a typed array don't need to `into_array()` first.
+    #[inline]
+    pub fn from_array<V: VTable>(array: &'a Array<V>) -> Self {
+        Self::from_array_ref(array.as_ref())
     }
 
     /// Build a [`ParentRef`] borrowing construction parts before materialization.

--- a/vortex-array/src/array/parent.rs
+++ b/vortex-array/src/array/parent.rs
@@ -1,0 +1,525 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Stack-allocatable parent representation used by the `reduce_parent` dispatch chain.
+//!
+//! [`ParentRef`] either borrows an existing heap-allocated [`ArrayRef`], or borrows
+//! stack-allocated construction state. The construction-side optimizer can borrow
+//! `ArrayParts` before materializing an `ArrayInner`, so matchers and parent-reduce
+//! rules can attempt reduction without first allocating an `Arc<ArrayInner<_>>`.
+//!
+//! Stack-backed parents lazily materialize an `ArrayRef` into an internal [`OnceLock`]
+//! only when a downstream consumer explicitly asks a [`ParentView`] to materialize.
+
+use std::any::Any;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::sync::OnceLock;
+
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
+
+use crate::ArrayRef;
+use crate::array::ArrayData;
+use crate::array::ArrayId;
+use crate::array::ArrayParts;
+use crate::array::ArraySlots;
+use crate::array::ParentView;
+use crate::array::VTable;
+use crate::dtype::DType;
+use crate::matcher::AsParent;
+use crate::matcher::Matcher;
+use crate::optimizer::ArrayOptimizer;
+
+/// A parent array, possibly stack-allocated, used by the `reduce_parent` dispatch chain.
+///
+/// Carries the metadata needed to dispatch parent-reduce rules (encoding id, dtype,
+/// length, encoding-specific data, slots) regardless of whether the parent is backed
+/// by an existing [`ArrayRef`] or by borrowed [`ArrayParts`]. Stack-backed parents
+/// materialize an [`ArrayRef`] into an internal cache on first explicit materialization.
+pub struct ParentRef<'a> {
+    encoding_id: ArrayId,
+    dtype: &'a DType,
+    len: usize,
+    slots: &'a [Option<ArrayRef>],
+    data: ParentData<'a>,
+    /// Lazily-populated materialization slot used by stack-backed parents.
+    /// Heap-backed parents return their borrowed [`ArrayRef`] directly and never
+    /// touch this cache.
+    cache: OnceLock<ArrayRef>,
+}
+
+/// Type-erased payload for [`ParentRef`].
+///
+/// Carries `&dyn Any` rather than `&V`/`&V::TypedArrayData` so [`ParentRef`] is not
+/// itself generic over `V`. The `+ Send + Sync` bound mirrors the bounds on
+/// [`VTable`] and `V::TypedArrayData`, keeping [`ParentRef`]
+/// and the [`ParentView`] built on top of it `Send + Sync`.
+type AnyRef<'a> = &'a (dyn Any + Send + Sync);
+
+enum ParentData<'a> {
+    Heap {
+        array: &'a ArrayRef,
+        data: AnyRef<'a>,
+    },
+    Parts {
+        vtable: AnyRef<'a>,
+        data: AnyRef<'a>,
+        materialize: MaterializeFn,
+        reduce: ReduceFn,
+    },
+}
+
+/// Function pointer that materializes stack-borrowed parts into an owned [`ArrayRef`].
+///
+/// The `vtable` and `data` arguments are the borrowed `&V` and `&V::TypedArrayData`
+/// previously stashed as `&dyn Any` in [`ParentData::Parts`]. The implementation
+/// downcasts them, clones into owned values, and produces an `ArrayRef`.
+type MaterializeFn = fn(
+    vtable: &(dyn Any + Send + Sync),
+    data: &(dyn Any + Send + Sync),
+    dtype: &DType,
+    len: usize,
+    slots: &[Option<ArrayRef>],
+) -> ArrayRef;
+
+/// Function pointer that runs encoding `V`'s self-reduce rules against a (possibly
+/// stack-borrowed) parent.
+///
+/// Stored alongside [`MaterializeFn`] in [`ParentData::Parts`] so [`ArrayParts::optimize`](crate::array::ArrayParts::optimize)
+/// can dispatch `V::reduce` without being generic over `V`. The implementation builds a
+/// [`ParentView`] over the borrowed parts, so a rule that only inspects metadata never
+/// forces a materialization.
+type ReduceFn = fn(parent: &ParentRef<'_>) -> VortexResult<Option<ArrayRef>>;
+
+impl<'a> ParentRef<'a> {
+    /// Build a [`ParentRef`] borrowing a heap-allocated [`ArrayRef`].
+    #[inline]
+    pub fn from_array_ref(array: &'a ArrayRef) -> Self {
+        let inner = array.inner();
+        Self {
+            encoding_id: inner.encoding_id,
+            dtype: &inner.dtype,
+            len: inner.len,
+            slots: &inner.slots,
+            data: ParentData::Heap {
+                array,
+                data: inner.data.as_any(),
+            },
+            cache: OnceLock::new(),
+        }
+    }
+
+    /// Build a [`ParentRef`] borrowing construction parts before materialization.
+    ///
+    /// The returned [`ParentRef`] owns the cache slot for the lazily materialized
+    /// [`ArrayRef`], so callers don't need to thread an external scratch through.
+    #[inline]
+    pub fn from_parts<V: VTable>(parts: &'a ArrayParts<V>) -> Self {
+        Self {
+            encoding_id: parts.vtable.id(),
+            dtype: &parts.dtype,
+            len: parts.len,
+            slots: &parts.slots,
+            data: ParentData::Parts {
+                vtable: &parts.vtable,
+                data: &parts.data,
+                materialize: materialize_parts::<V>,
+                reduce: reduce_parts::<V>,
+            },
+            cache: OnceLock::new(),
+        }
+    }
+
+    /// Run the parent encoding's self-reduce rules against the parent.
+    ///
+    /// Mirrors [`ArrayRef::reduce`](crate::ArrayRef::reduce) for the `ParentRef` dispatch
+    /// chain. Heap-backed parents delegate to the existing array; stack-backed parents
+    /// dispatch through the stored [`ReduceFn`] so the borrowed parts only materialize if a
+    /// rule reaches for an [`ArrayRef`]. The reduced array is validated to preserve the
+    /// parent's len and dtype, matching the heap path.
+    fn reduce(&self) -> VortexResult<Option<ArrayRef>> {
+        let reduced = match self.data {
+            ParentData::Heap { array, .. } => return array.reduce(),
+            ParentData::Parts { reduce, .. } => reduce(self)?,
+        };
+        let Some(reduced) = reduced else {
+            return Ok(None);
+        };
+        vortex_ensure!(
+            reduced.len() == self.len,
+            "Reduced array length mismatch from {} to {}",
+            self.encoding_id,
+            reduced.encoding_id()
+        );
+        vortex_ensure!(
+            reduced.dtype() == self.dtype,
+            "Reduced array dtype mismatch from {} to {}",
+            self.encoding_id,
+            reduced.encoding_id()
+        );
+        Ok(Some(reduced))
+    }
+
+    /// Returns the encoding id of the parent.
+    #[inline]
+    #[allow(clippy::same_name_method)]
+    pub fn encoding_id(&self) -> ArrayId {
+        self.encoding_id
+    }
+
+    /// Returns the dtype of the parent.
+    #[inline]
+    #[allow(clippy::same_name_method)]
+    pub fn dtype(&self) -> &DType {
+        self.dtype
+    }
+
+    /// Returns the length of the parent.
+    #[inline]
+    #[allow(clippy::same_name_method)]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns whether the parent is empty.
+    #[inline]
+    #[allow(clippy::same_name_method)]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns the slots of the parent.
+    #[inline]
+    #[allow(clippy::same_name_method)]
+    pub fn slots(&self) -> &[Option<ArrayRef>] {
+        self.slots
+    }
+
+    /// Consume this `ParentRef` and return the cached materialization, if one exists.
+    ///
+    /// This is used by owned [`ArrayParts::optimize`] to avoid materializing twice when
+    /// a stack-backed parent was forced into an [`ArrayRef`] by a rule that did not fire.
+    fn into_cached_array_ref(self) -> Option<ArrayRef> {
+        self.cache.into_inner()
+    }
+
+    /// Returns `true` if this parent's encoding matches `V`.
+    ///
+    /// Cheap encoding-id check that works for both heap- and stack-backed parents
+    /// without forcing materialization.
+    #[inline]
+    #[allow(clippy::same_name_method)]
+    pub(crate) fn is_encoding<V: VTable>(&self) -> bool {
+        match self.data {
+            ParentData::Heap { data, .. } => data.is::<ArrayData<V>>(),
+            ParentData::Parts { vtable, .. } => vtable.is::<V>(),
+        }
+    }
+
+    #[inline]
+    #[allow(clippy::same_name_method)]
+    pub(crate) fn typed_data<V: VTable>(&self) -> Option<&V::TypedArrayData> {
+        match self.data {
+            ParentData::Heap { data, .. } => data
+                .downcast_ref::<ArrayData<V>>()
+                .map(|array_data| &array_data.data),
+            ParentData::Parts { data, .. } => data.downcast_ref::<V::TypedArrayData>(),
+        }
+    }
+
+    /// Try to extract a [`ParentView`] for the parent's encoding `V`.
+    ///
+    /// Returns `None` if the parent's encoding is not `V`. No materialization happens
+    /// up front. Materialization is only available through
+    /// [`ParentView::materialize_array_ref`].
+    ///
+    /// This is the low-level entry point used by the blanket `VTable` matcher
+    /// implementation. Prefer [`AsParent::as_opt`] for matcher-based downcasts.
+    #[allow(clippy::same_name_method)]
+    pub fn as_parent_view<V: VTable>(&self) -> Option<ParentView<'_, V>> {
+        let data = self.typed_data::<V>()?;
+        // SAFETY: `typed_data::<V>()` returned Some, so the parent's encoding is
+        // `V` and `data` is the `V::TypedArrayData` reachable through `self`.
+        Some(unsafe { ParentView::new_unchecked(self, data) })
+    }
+
+    /// Does the parent match the given matcher.
+    ///
+    /// Mirrors [`ArrayRef::is`](ArrayRef::is) for the parent-side dispatch
+    /// chain. Routes through [`Matcher::matches`] so matchers that can answer with
+    /// a cheap encoding-id check don't force a downcast.
+    #[allow(clippy::same_name_method)]
+    pub fn is<M: Matcher>(&self) -> bool {
+        M::matches(self)
+    }
+
+    /// Returns the parent downcast by the given matcher, or `None` if it doesn't match.
+    ///
+    /// Mirrors [`ArrayRef::as_opt`](ArrayRef::as_opt) for the parent-side
+    /// dispatch chain. The returned match borrows from `self`, so stack-backed
+    /// parents stay on the stack until a consumer explicitly materializes a
+    /// [`ParentView`].
+    #[allow(clippy::same_name_method)]
+    pub fn as_opt<M: Matcher>(&self) -> Option<M::Match<'_>> {
+        M::try_match(self)
+    }
+
+    /// Returns the parent downcast by the given matcher, panicking if it doesn't match.
+    ///
+    /// Mirrors [`ArrayRef::as_`](ArrayRef::as_).
+    #[allow(clippy::same_name_method)]
+    pub fn as_<M: Matcher>(&self) -> M::Match<'_> {
+        self.as_opt::<M>().vortex_expect("Failed to downcast")
+    }
+}
+
+#[allow(clippy::same_name_method)]
+impl AsParent for ParentRef<'_> {
+    #[inline]
+    fn encoding_id(&self) -> ArrayId {
+        ParentRef::encoding_id(self)
+    }
+
+    #[inline]
+    fn dtype(&self) -> &DType {
+        ParentRef::dtype(self)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        ParentRef::len(self)
+    }
+
+    #[inline]
+    fn slots(&self) -> &[Option<ArrayRef>] {
+        ParentRef::slots(self)
+    }
+
+    #[inline]
+    fn is_encoding<V: VTable>(&self) -> bool {
+        ParentRef::is_encoding::<V>(self)
+    }
+
+    #[inline]
+    fn typed_data<V: VTable>(&self) -> Option<&V::TypedArrayData> {
+        ParentRef::typed_data::<V>(self)
+    }
+
+    #[inline]
+    fn as_parent_view<V: VTable>(&self) -> Option<ParentView<'_, V>> {
+        ParentRef::as_parent_view::<V>(self)
+    }
+}
+
+impl<V: VTable> ArrayParts<V> {
+    /// Optimize already-valid construction parts, consuming the original parts on a miss.
+    ///
+    /// This mirrors one iteration of [`ArrayRef::optimize`](crate::optimizer::ArrayOptimizer):
+    /// the parent's own `reduce` rules are tried first, then `reduce_parent` on each child
+    /// slot. Both run against the stack-borrowed parent, so a reduction that only inspects
+    /// metadata never allocates an `Arc<ArrayInner<_>>`. If no rule applies and the
+    /// stack-backed parent was not materialized by a rule, the result is built with
+    /// [`ArrayParts::into_array`] directly without cloning the parts.
+    pub fn optimize(self) -> VortexResult<ArrayRef> {
+        let parent = ParentRef::from_parts(&self);
+        if let Some(reduced) = parent.reduce()? {
+            return reduced.optimize();
+        }
+
+        for (slot_idx, slot) in parent.slots.iter().enumerate() {
+            let Some(child) = slot else { continue };
+
+            if let Some(reduced) = child.reduce_parent(&parent, slot_idx)? {
+                return reduced.optimize();
+            }
+        }
+
+        if let Some(cached) = parent.into_cached_array_ref() {
+            return Ok(cached);
+        }
+
+        Ok(self.into_array())
+    }
+}
+
+impl Debug for ParentRef<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let heap_backed = matches!(self.data, ParentData::Heap { .. });
+        f.debug_struct("ParentRef")
+            .field("encoding", &self.encoding_id())
+            .field("dtype", self.dtype())
+            .field("len", &self.len())
+            .field("heap_backed", &heap_backed)
+            .finish()
+    }
+}
+
+impl<'a> From<&'a ArrayRef> for ParentRef<'a> {
+    fn from(array: &'a ArrayRef) -> Self {
+        Self::from_array_ref(array)
+    }
+}
+
+/// Explicit materialization hook used by [`ParentView`].
+pub(crate) trait ParentMaterializer: Send + Sync {
+    /// Returns a materialized [`ArrayRef`].
+    ///
+    /// For heap-backed parents this is a cheap reference return. For stack-backed parents this
+    /// triggers materialization on first call and caches the result.
+    fn materialize_array_ref(&self) -> &ArrayRef;
+}
+
+impl ParentMaterializer for ParentRef<'_> {
+    #[inline]
+    fn materialize_array_ref(&self) -> &ArrayRef {
+        match self.data {
+            ParentData::Heap { array, .. } => array,
+            ParentData::Parts {
+                vtable,
+                data,
+                materialize,
+                ..
+            } => self
+                .cache
+                .get_or_init(|| materialize(vtable, data, self.dtype, self.len, self.slots)),
+        }
+    }
+}
+
+/// Materializes stack-borrowed parts of encoding `V` into an owned [`ArrayRef`].
+///
+/// Used as the function pointer stored inside [`ParentData::Parts`]. The
+/// `vtable`/`data` arguments are `&V` and `&V::TypedArrayData` erased to `&dyn Any`;
+/// they are downcast and cloned into a fresh `ArrayParts<V>` which is then turned
+/// into an `ArrayRef`. Validation is skipped: stack-borrowed parts were validated
+/// when the originating `ArrayParts<V>` was constructed.
+fn materialize_parts<V: VTable>(
+    vtable: &(dyn Any + Send + Sync),
+    data: &(dyn Any + Send + Sync),
+    dtype: &DType,
+    len: usize,
+    slots: &[Option<ArrayRef>],
+) -> ArrayRef {
+    let vtable = vtable
+        .downcast_ref::<V>()
+        .vortex_expect("ParentRef materialize: vtable type mismatch");
+    let data = data
+        .downcast_ref::<V::TypedArrayData>()
+        .vortex_expect("ParentRef materialize: data type mismatch");
+    let slots: ArraySlots = slots.iter().cloned().collect();
+    ArrayParts::new(vtable.clone(), dtype.clone(), len, data.clone())
+        .with_slots(slots)
+        .into_array()
+}
+
+/// Runs encoding `V`'s self-reduce rules against a (possibly stack-borrowed) parent.
+///
+/// Used as the [`ReduceFn`] stored inside [`ParentData::Parts`]. Builds a
+/// [`ParentView`] over the borrowed parts and dispatches to [`VTable::reduce`]; the view
+/// only materializes if a rule explicitly asks for an [`ArrayRef`].
+fn reduce_parts<V: VTable>(parent: &ParentRef<'_>) -> VortexResult<Option<ArrayRef>> {
+    let view = parent
+        .as_parent_view::<V>()
+        .vortex_expect("ParentRef reduce: encoding mismatch");
+    V::reduce(view)
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_error::VortexResult;
+
+    use super::ParentRef;
+    use crate::IntoArray;
+    use crate::VortexSessionExecute;
+    use crate::arrays::BoolArray;
+    use crate::arrays::PrimitiveArray;
+    use crate::arrays::ScalarFnArray;
+    use crate::arrays::Slice;
+    use crate::arrays::SliceArray;
+    use crate::arrays::Struct;
+    use crate::assert_arrays_eq;
+    use crate::dtype::Nullability;
+    use crate::optimizer::ArrayOptimizer;
+    use crate::scalar_fn::ScalarFnVTableExt;
+    use crate::scalar_fn::fns::pack::Pack;
+    use crate::scalar_fn::fns::pack::PackOptions;
+
+    #[test]
+    fn parts_parent_ref_exposes_array_view() -> VortexResult<()> {
+        let child = BoolArray::from_iter([true, false, true]).into_array();
+        let parts = SliceArray::try_new_parts(child, 1..3)?;
+        let parent = ParentRef::from_parts(&parts);
+
+        let view = parent
+            .as_opt::<Slice>()
+            .expect("Slice parts should match a Slice array view");
+
+        assert_eq!(view.slice_range(), &(1..3));
+        assert_eq!(view.len(), 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn parts_parent_ref_explicit_materialize() -> VortexResult<()> {
+        let child = BoolArray::from_iter([true, false, true]).into_array();
+        let parts = SliceArray::try_new_parts(child, 1..3)?;
+        let parent = ParentRef::from_parts(&parts);
+
+        let view = parent
+            .as_opt::<Slice>()
+            .expect("Slice parts should match a Slice array view");
+
+        // Reading metadata through the view does NOT force materialization.
+        assert_eq!(view.slice_range(), &(1..3));
+        assert_eq!(view.len(), 2);
+
+        // Explicit materialization produces an ArrayRef.
+        let array_ref = view.materialize_array_ref();
+        assert_eq!(array_ref.len(), 2);
+
+        Ok(())
+    }
+
+    /// Optimizing borrowed parts must produce the same array as materializing them and
+    /// calling [`ArrayRef::optimize`](crate::optimizer::ArrayOptimizer) — the two paths
+    /// differ only in whether the wrapper is heap-allocated.
+    ///
+    /// Regression test for [`ArrayParts::optimize`] skipping the parent's own `reduce`
+    /// rules. A `Pack` scalar function collapses to a `StructArray` via the `ScalarFn`
+    /// encoding's self-`reduce`. No `reduce_parent` rule mirrors this, so the reduction is
+    /// only reachable through self-`reduce`: before `optimize` ran `reduce` first the stack
+    /// path returned the `ScalarFn` wrapper while materialize-then-optimize returned the
+    /// struct.
+    #[test]
+    fn optimize_matches_heap_path() -> VortexResult<()> {
+        let mut ctx = crate::array_session().create_execution_ctx();
+        let a = PrimitiveArray::from_iter([1i32, 2, 3]).into_array();
+        let b = PrimitiveArray::from_iter([4i32, 5, 6]).into_array();
+        let len = a.len();
+        let pack = Pack.bind(PackOptions {
+            names: ["a", "b"].into(),
+            nullability: Nullability::NonNullable,
+        });
+
+        let heap = ScalarFnArray::try_new_with_len(pack.clone(), vec![a.clone(), b.clone()], len)?
+            .into_array()
+            .optimize()?;
+        let parts = ScalarFnArray::try_new_parts(pack, vec![a, b], len)?;
+        let stack = parts.optimize()?;
+
+        assert!(
+            heap.is::<Struct>(),
+            "heap path should collapse Pack to a struct"
+        );
+        assert!(
+            stack.is::<Struct>(),
+            "stack path should collapse Pack to a struct"
+        );
+        assert_arrays_eq!(stack, heap, &mut ctx);
+
+        Ok(())
+    }
+}

--- a/vortex-array/src/array/parent.rs
+++ b/vortex-array/src/array/parent.rs
@@ -13,6 +13,7 @@
 
 use std::any::Any;
 use std::fmt::Debug;
+use std::fmt::Display;
 use std::fmt::Formatter;
 use std::sync::OnceLock;
 
@@ -28,10 +29,12 @@ use crate::array::ArrayParts;
 use crate::array::ArraySlots;
 use crate::array::ParentView;
 use crate::array::VTable;
+use crate::display::EncodingSummaryExtractor;
 use crate::dtype::DType;
 use crate::matcher::AsParent;
 use crate::matcher::Matcher;
 use crate::optimizer::optimize_owned;
+use crate::trace_op;
 
 /// A parent array, possibly stack-allocated, used by the `reduce_parent` dispatch chain.
 ///
@@ -332,25 +335,47 @@ impl<V: VTable> ArrayParts<V> {
     /// metadata never allocates an `Arc<ArrayInner<_>>`. If no rule applies and the
     /// stack-backed parent was not materialized by a rule, the result is built with
     /// [`ArrayParts::into_array`] directly without cloning the parts.
+    ///
+    /// The same trace events as the heap path are emitted, so a construction-time optimization
+    /// appears in a [`trace_op`](crate::test_harness::trace::trace_op) capture as an `optimize`
+    /// block rather than as rule events with no enclosing pass. Recording those events reads only
+    /// the parent's metadata and never forces the borrowed parts to materialize.
     pub fn optimize(self) -> VortexResult<ArrayRef> {
         let parent = ParentRef::from_parts(&self);
+        trace_op!(record_optimize_start(&parent, false));
+        trace_op!(record_optimize_loop_start(&parent));
+
         if let Some(reduced) = parent.reduce()? {
-            return Ok(optimize_owned(reduced, None)?.0);
+            trace_op!(record_optimize_loop_end());
+            let output = optimize_owned(reduced, None)?.0;
+            trace_op!(record_optimize_done(&output, true));
+            return Ok(output);
         }
+        trace_op!(record_optimize_reduce_none(&parent));
 
         for (slot_idx, slot) in parent.slots.iter().enumerate() {
             let Some(child) = slot else { continue };
 
             if let Some(reduced) = child.reduce_parent(&parent, slot_idx)? {
-                return Ok(optimize_owned(reduced, None)?.0);
+                trace_op!(record_optimize_loop_end());
+                let output = optimize_owned(reduced, None)?.0;
+                trace_op!(record_optimize_done(&output, true));
+                return Ok(output);
             }
         }
+        trace_op!(record_optimize_parent_reduce_none(&parent));
+        trace_op!(record_optimize_loop_end());
 
+        // A rule that declined may still have materialized the parent; reuse that allocation
+        // rather than building the parts a second time.
         if let Some(cached) = parent.into_cached_array_ref() {
+            trace_op!(record_optimize_done(&cached, false));
             return Ok(cached);
         }
 
-        Ok(self.into_array())
+        let output = self.into_array();
+        trace_op!(record_optimize_done(&output, false));
+        Ok(output)
     }
 }
 
@@ -363,6 +388,14 @@ impl Debug for ParentRef<'_> {
             .field("len", &self.len())
             .field("heap_backed", &heap_backed)
             .finish()
+    }
+}
+
+/// Renders the same encoding summary as [`ArrayRef`] (`vortex.primitive(i32, len=4)`) without
+/// materializing a stack-backed parent.
+impl Display for ParentRef<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        EncodingSummaryExtractor::write_parts(self.encoding_id, self.dtype, self.len, f)
     }
 }
 

--- a/vortex-array/src/array/parent.rs
+++ b/vortex-array/src/array/parent.rs
@@ -486,6 +486,7 @@ mod tests {
     use crate::dtype::Nullability;
     use crate::optimizer::ArrayOptimizer;
     use crate::scalar_fn::ScalarFnVTableExt;
+    use crate::scalar_fn::fns::cast::Cast;
     use crate::scalar_fn::fns::pack::Pack;
     use crate::scalar_fn::fns::pack::PackOptions;
 
@@ -562,6 +563,27 @@ mod tests {
             "stack path should collapse Pack to a struct"
         );
         assert_arrays_eq!(stack, heap, &mut ctx);
+
+        Ok(())
+    }
+
+    /// Abstract reduce rules run against the borrowed parts. A cast to the child's own dtype
+    /// collapses to the child, and doing so must not allocate the `ScalarFn` wrapper.
+    #[test]
+    fn abstract_reduce_keeps_parts_on_stack() -> VortexResult<()> {
+        let mut ctx = crate::array_session().create_execution_ctx();
+        let child = PrimitiveArray::from_iter([1i32, 2, 3]).into_array();
+        let cast = Cast.bind(child.dtype().clone());
+        let parts = ScalarFnArray::try_new_parts(cast, vec![child.clone()], child.len())?;
+        let parent = ParentRef::from_parts(&parts);
+
+        let reduced = parent.reduce()?.expect("same-dtype cast should reduce");
+
+        assert!(
+            parent.into_cached_array_ref().is_none(),
+            "reducing borrowed parts must not materialize the parent"
+        );
+        assert_arrays_eq!(reduced, child, &mut ctx);
 
         Ok(())
     }

--- a/vortex-array/src/array/plugin.rs
+++ b/vortex-array/src/array/plugin.rs
@@ -6,6 +6,7 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
 
@@ -86,7 +87,12 @@ impl<V: VTable> ArrayPlugin for V {
             array.encoding_id(),
             "Invoked for incorrect array ID"
         );
-        V::serialize(array.as_::<V>(), session)
+        V::serialize(
+            array
+                .as_typed::<V>()
+                .vortex_expect("Invoked for incorrect array type"),
+            session,
+        )
     }
 
     fn deserialize(

--- a/vortex-array/src/array/plugin.rs
+++ b/vortex-array/src/array/plugin.rs
@@ -7,6 +7,7 @@ use std::fmt::Formatter;
 use std::sync::Arc;
 
 use vortex_buffer::ByteBuffer;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_session::VortexSession;
@@ -178,7 +179,10 @@ impl<V: VTable> ArrayPlugin for V {
             self.id(),
             array.encoding_id(),
         );
-        Ok(V::serialize(array.as_::<V>(), session)?
+        let typed = array
+            .as_typed::<V>()
+            .vortex_expect("Invoked for incorrect array type");
+        Ok(V::serialize(typed, session)?
             .map(|metadata| ArraySerialization::from_array(self.id(), array, metadata)))
     }
 

--- a/vortex-array/src/array/typed.rs
+++ b/vortex-array/src/array/typed.rs
@@ -26,6 +26,7 @@ use crate::IntoArray;
 use crate::VortexSessionExecute;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::array::VTable;
 use crate::dtype::DType;
 use crate::legacy_session;
@@ -86,23 +87,118 @@ impl<V: VTable> ArrayParts<V> {
         self.slots = slots;
         self
     }
-}
 
-/// Shared bound for helpers that should work over both owned [`Array<V>`] and borrowed
-/// [`ArrayView<V>`].
-///
-/// Extension traits use this to share typed array logic while still exposing the backing
-/// [`ArrayRef`] and the encoding-specific [`VTable::TypedArrayData`].
-pub trait TypedArrayRef<V: VTable>: AsRef<ArrayRef> + Deref<Target = V::TypedArrayData> {
-    /// Returns an owned [`Array<V>`] from the reference.
-    fn to_owned(&self) -> Array<V> {
-        self.as_ref().clone().downcast()
+    /// Materialize already-valid parts into an [`ArrayRef`] without attempting reduction.
+    ///
+    /// This intentionally skips vtable validation. Use
+    /// `Array::<V>::try_from_parts(parts)?.into_array()` when constructing parts from unchecked
+    /// inputs.
+    pub fn into_array(self) -> ArrayRef {
+        unsafe { Array::<V>::from_parts_unchecked(self).into_array() }
     }
 }
 
-impl<V: VTable> TypedArrayRef<V> for Array<V> {}
+/// Shared bound for helpers that should work over owned [`Array<V>`], heap-backed
+/// [`ArrayView<V>`], and stack-aware [`ParentView<V>`].
+///
+/// Extension traits use this to share typed array logic while still exposing the backing
+/// encoding-specific [`VTable::TypedArrayData`].
+///
+/// This trait deliberately does not require [`AsRef<ArrayRef>`]. [`ParentView`] is allowed to
+/// stay non-materialized, so any code that needs an [`ArrayRef`] must opt into ownership through
+/// [`Self::to_owned`] or call [`ParentView::materialize_array_ref`] explicitly.
+pub trait TypedArrayRef<V: VTable>: Deref<Target = V::TypedArrayData> {
+    /// Returns an owned [`Array<V>`] from the reference.
+    ///
+    /// For [`ParentView`], this explicitly materializes stack-backed construction parts.
+    fn to_owned(&self) -> Array<V>;
 
-impl<V: VTable> TypedArrayRef<V> for ArrayView<'_, V> {}
+    fn is_empty(&self) -> bool;
+
+    fn slots(&self) -> &[Option<ArrayRef>];
+
+    fn len(&self) -> usize;
+
+    fn dtype(&self) -> &DType;
+}
+
+impl<V: VTable> TypedArrayRef<V> for Array<V> {
+    fn to_owned(&self) -> Array<V> {
+        self.clone()
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn slots(&self) -> &[Option<ArrayRef>] {
+        Array::<V>::slots(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn len(&self) -> usize {
+        Array::<V>::len(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn dtype(&self) -> &DType {
+        Array::<V>::dtype(self)
+    }
+}
+
+impl<V: VTable> TypedArrayRef<V> for ArrayView<'_, V> {
+    fn to_owned(&self) -> Array<V> {
+        self.into_owned()
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn is_empty(&self) -> bool {
+        ArrayView::is_empty(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn slots(&self) -> &[Option<ArrayRef>] {
+        ArrayView::slots(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn len(&self) -> usize {
+        ArrayView::len(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn dtype(&self) -> &DType {
+        ArrayView::dtype(self)
+    }
+}
+
+impl<V: VTable> TypedArrayRef<V> for ParentView<'_, V> {
+    fn to_owned(&self) -> Array<V> {
+        (*self).into_owned()
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn is_empty(&self) -> bool {
+        ParentView::is_empty(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn slots(&self) -> &[Option<ArrayRef>] {
+        ParentView::slots(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn len(&self) -> usize {
+        ParentView::len(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn dtype(&self) -> &DType {
+        ParentView::dtype(self)
+    }
+}
 // =============================================================================
 // ArrayData<V> — the concrete type stored inside Arc<dyn DynArrayData>
 // =============================================================================
@@ -272,16 +368,19 @@ impl<V: VTable> Array<V> {
     }
 
     /// Returns the logical dtype.
+    #[allow(clippy::same_name_method)]
     pub fn dtype(&self) -> &DType {
         self.inner.dtype()
     }
 
     /// Returns the length.
+    #[allow(clippy::same_name_method)]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
     /// Returns whether this array is empty.
+    #[allow(clippy::same_name_method)]
     pub fn is_empty(&self) -> bool {
         self.inner.len() == 0
     }
@@ -343,6 +442,7 @@ impl<V: VTable> Array<V> {
     }
 
     /// Returns the array slots.
+    #[allow(clippy::same_name_method)]
     pub fn slots(&self) -> &[Option<ArrayRef>] {
         self.inner.slots()
     }
@@ -358,6 +458,14 @@ impl<V: VTable> Array<V> {
         let inner = self.downcast_inner();
         // SAFETY: `inner.data` is the `V::TypedArrayData` stored inside `self.inner`.
         unsafe { ArrayView::new_unchecked(&self.inner, &inner.data) }
+    }
+
+    /// Returns a [`ParentView`] borrowing this array's data, for APIs that accept
+    /// both heap- and stack-backed parents.
+    pub fn as_parent_view(&self) -> ParentView<'_, V> {
+        let inner = self.downcast_inner();
+        // SAFETY: `inner.data` is the `V::TypedArrayData` stored inside `self.inner`.
+        unsafe { ParentView::new_unchecked(&self.inner, &inner.data) }
     }
 
     /// Downcast the inner `ArrayRef` to `&ArrayData<V>`.
@@ -408,6 +516,7 @@ impl<V: VTable> Array<V> {
     }
 
     /// Returns the array's validity representation.
+    #[allow(clippy::same_name_method)]
     pub fn validity(&self) -> VortexResult<Validity> {
         self.inner.validity()
     }

--- a/vortex-array/src/array/typed.rs
+++ b/vortex-array/src/array/typed.rs
@@ -26,6 +26,7 @@ use crate::IntoArray;
 use crate::VortexSessionExecute;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::array::VTable;
 use crate::dtype::DType;
 use crate::legacy_session;
@@ -86,23 +87,118 @@ impl<V: VTable> ArrayParts<V> {
         self.slots = slots;
         self
     }
-}
 
-/// Shared bound for helpers that should work over both owned [`Array<V>`] and borrowed
-/// [`ArrayView<V>`].
-///
-/// Extension traits use this to share typed array logic while still exposing the backing
-/// [`ArrayRef`] and the encoding-specific [`VTable::TypedArrayData`].
-pub trait TypedArrayRef<V: VTable>: AsRef<ArrayRef> + Deref<Target = V::TypedArrayData> {
-    /// Returns an owned [`Array<V>`] from the reference.
-    fn to_owned(&self) -> Array<V> {
-        self.as_ref().clone().downcast()
+    /// Materialize already-valid parts into an [`ArrayRef`] without attempting reduction.
+    ///
+    /// This intentionally skips vtable validation. Use
+    /// `Array::<V>::try_from_parts(parts)?.into_array()` when constructing parts from unchecked
+    /// inputs.
+    pub fn into_array(self) -> ArrayRef {
+        unsafe { Array::<V>::from_parts_unchecked(self).into_array() }
     }
 }
 
-impl<V: VTable> TypedArrayRef<V> for Array<V> {}
+/// Shared bound for helpers that should work over owned [`Array<V>`], heap-backed
+/// [`ArrayView<V>`], and stack-aware [`ParentView<V>`].
+///
+/// Extension traits use this to share typed array logic while still exposing the backing
+/// encoding-specific [`VTable::TypedArrayData`].
+///
+/// This trait deliberately does not require [`AsRef<ArrayRef>`]. [`ParentView`] is allowed to
+/// stay non-materialized, so any code that needs an [`ArrayRef`] must opt into ownership through
+/// [`Self::to_owned`] or call [`ParentView::materialize_array_ref`] explicitly.
+pub trait TypedArrayRef<V: VTable>: Deref<Target = V::TypedArrayData> {
+    /// Returns an owned [`Array<V>`] from the reference.
+    ///
+    /// For [`ParentView`], this explicitly materializes stack-backed construction parts.
+    fn to_owned(&self) -> Array<V>;
 
-impl<V: VTable> TypedArrayRef<V> for ArrayView<'_, V> {}
+    fn is_empty(&self) -> bool;
+
+    fn slots(&self) -> &[Option<ArrayRef>];
+
+    fn len(&self) -> usize;
+
+    fn dtype(&self) -> &DType;
+}
+
+impl<V: VTable> TypedArrayRef<V> for Array<V> {
+    fn to_owned(&self) -> Array<V> {
+        self.clone()
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn slots(&self) -> &[Option<ArrayRef>] {
+        Array::<V>::slots(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn len(&self) -> usize {
+        Array::<V>::len(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn dtype(&self) -> &DType {
+        Array::<V>::dtype(self)
+    }
+}
+
+impl<V: VTable> TypedArrayRef<V> for ArrayView<'_, V> {
+    fn to_owned(&self) -> Array<V> {
+        self.into_owned()
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn is_empty(&self) -> bool {
+        ArrayView::is_empty(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn slots(&self) -> &[Option<ArrayRef>] {
+        ArrayView::slots(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn len(&self) -> usize {
+        ArrayView::len(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn dtype(&self) -> &DType {
+        ArrayView::dtype(self)
+    }
+}
+
+impl<V: VTable> TypedArrayRef<V> for ParentView<'_, V> {
+    fn to_owned(&self) -> Array<V> {
+        (*self).into_owned()
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn is_empty(&self) -> bool {
+        ParentView::is_empty(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn slots(&self) -> &[Option<ArrayRef>] {
+        ParentView::slots(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn len(&self) -> usize {
+        ParentView::len(self)
+    }
+
+    #[allow(clippy::same_name_method)]
+    fn dtype(&self) -> &DType {
+        ParentView::dtype(self)
+    }
+}
 // =============================================================================
 // ArrayData<V> — the concrete type stored inside Arc<dyn DynArrayData>
 // =============================================================================
@@ -272,16 +368,19 @@ impl<V: VTable> Array<V> {
     }
 
     /// Returns the logical dtype.
+    #[allow(clippy::same_name_method)]
     pub fn dtype(&self) -> &DType {
         self.inner.dtype()
     }
 
     /// Returns the length.
+    #[allow(clippy::same_name_method)]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
     /// Returns whether this array is empty.
+    #[allow(clippy::same_name_method)]
     pub fn is_empty(&self) -> bool {
         self.inner.len() == 0
     }
@@ -343,6 +442,7 @@ impl<V: VTable> Array<V> {
     }
 
     /// Returns the array slots.
+    #[allow(clippy::same_name_method)]
     pub fn slots(&self) -> &[Option<ArrayRef>] {
         self.inner.slots()
     }
@@ -359,6 +459,14 @@ impl<V: VTable> Array<V> {
         let inner = self.downcast_inner();
         // SAFETY: `inner.data` is the `V::TypedArrayData` stored inside `self.inner`.
         unsafe { ArrayView::new_unchecked(&self.inner, &inner.data) }
+    }
+
+    /// Returns a [`ParentView`] borrowing this array's data, for APIs that accept
+    /// both heap- and stack-backed parents.
+    pub fn as_parent_view(&self) -> ParentView<'_, V> {
+        let inner = self.downcast_inner();
+        // SAFETY: `inner.data` is the `V::TypedArrayData` stored inside `self.inner`.
+        unsafe { ParentView::new_unchecked(&self.inner, &inner.data) }
     }
 
     /// Downcast the inner `ArrayRef` to `&ArrayData<V>`.
@@ -410,6 +518,7 @@ impl<V: VTable> Array<V> {
     }
 
     /// Returns the array's validity representation.
+    #[allow(clippy::same_name_method)]
     pub fn validity(&self) -> VortexResult<Validity> {
         self.inner.validity()
     }

--- a/vortex-array/src/array/view.rs
+++ b/vortex-array/src/array/view.rs
@@ -5,21 +5,24 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::ops::Deref;
 
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::array::Array;
 use crate::array::ArrayId;
+use crate::array::ParentMaterializer;
 use crate::array::VTable;
 use crate::dtype::DType;
+use crate::matcher::AsParent;
 use crate::stats::StatsSetRef;
 use crate::validity::Validity;
 
-/// A lightweight, `Copy`-able typed view into an [`ArrayRef`].
+/// A lightweight, `Copy`-able typed view of an array.
 ///
-/// Vtable methods receive `ArrayView<V>` so they can inspect common array metadata and
-/// encoding-specific data without cloning or downcasting an [`ArrayRef`]. The view is only valid for
-/// the lifetime of the borrowed array.
+/// `ArrayView` is heap-backed: it always borrows an existing [`ArrayRef`]. Parent
+/// reduction over stack-borrowed construction parts uses [`ParentView`] instead, so
+/// APIs like [`Self::array`] and [`AsRef<ArrayRef>`] never hide a stack materialization.
 pub struct ArrayView<'a, V: VTable> {
     array: &'a ArrayRef,
     data: &'a V::TypedArrayData,
@@ -34,6 +37,8 @@ impl<V: VTable> Clone for ArrayView<'_, V> {
 }
 
 impl<'a, V: VTable> ArrayView<'a, V> {
+    /// Construct a heap-backed view.
+    ///
     /// # Safety
     /// Caller must ensure `data` is the `V::TypedArrayData` stored inside `array`.
     pub(crate) unsafe fn new_unchecked(array: &'a ArrayRef, data: &'a V::TypedArrayData) -> Self {
@@ -41,61 +46,198 @@ impl<'a, V: VTable> ArrayView<'a, V> {
         Self { array, data }
     }
 
-    /// Returns the erased array handle that owns this view.
+    /// Returns the underlying heap-allocated [`ArrayRef`].
+    #[inline]
     pub fn array(&self) -> &'a ArrayRef {
         self.array
     }
 
     /// Returns the encoding-specific data stored by this array.
+    #[inline]
     pub fn data(&self) -> &'a V::TypedArrayData {
         self.data
     }
 
     /// Returns this array's child slots.
+    #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn slots(&self) -> &'a [Option<ArrayRef>] {
         self.array.slots()
     }
 
     /// Returns the logical dtype.
-    pub fn dtype(&self) -> &DType {
+    #[inline]
+    #[allow(clippy::same_name_method)]
+    pub fn dtype(&self) -> &'a DType {
         self.array.dtype()
     }
 
     /// Returns the number of rows.
+    #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn len(&self) -> usize {
         self.array.len()
     }
 
     /// Returns `true` when the array has no rows.
+    #[inline]
+    #[allow(clippy::same_name_method)]
     pub fn is_empty(&self) -> bool {
-        self.array.len() == 0
+        self.array.is_empty()
     }
 
     /// Returns the encoding ID.
+    #[inline]
     pub fn encoding_id(&self) -> ArrayId {
         self.array.encoding_id()
     }
 
     /// Returns the array's statistics set.
     pub fn statistics(&self) -> StatsSetRef<'_> {
-        self.array.statistics()
+        self.array().statistics()
     }
 
     /// Returns the array's validity representation.
+    #[allow(clippy::same_name_method)]
     pub fn validity(&self) -> VortexResult<Validity> {
-        self.array.validity()
+        self.array().validity()
     }
 
     /// Clone the underlying [`ArrayRef`] and return it as an owned typed handle.
     pub fn into_owned(self) -> Array<V> {
         // SAFETY: we are ourselves type checked as 'V'
-        unsafe { Array::<V>::from_array_ref_unchecked(self.array.clone()) }
+        unsafe { Array::<V>::from_array_ref_unchecked(self.array().clone()) }
+    }
+}
+
+/// A typed view over a parent array during metadata-only reduction.
+///
+/// `ParentView` can borrow either a heap-backed parent or stack-allocated construction
+/// parts via [`ParentRef`](crate::array::ParentRef). It intentionally does not implement [`AsRef<ArrayRef>`] and
+/// does not expose an `array()` method: callers that truly need an [`ArrayRef`] must call
+/// [`Self::materialize_array_ref`] so the allocation boundary is visible in code review.
+pub struct ParentView<'a, V: VTable> {
+    data: &'a V::TypedArrayData,
+    dtype: &'a DType,
+    len: usize,
+    slots: &'a [Option<ArrayRef>],
+    encoding_id: ArrayId,
+    materializer: &'a dyn ParentMaterializer,
+}
+
+impl<V: VTable> Copy for ParentView<'_, V> {}
+
+impl<V: VTable> Clone for ParentView<'_, V> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, V: VTable> ParentView<'a, V> {
+    /// Construct a parent view borrowing any [`AsParent`].
+    ///
+    /// # Safety
+    /// Caller must ensure `parent.is_encoding::<V>()` and that `data` is the
+    /// `V::TypedArrayData` borrowed inside `parent`.
+    pub(crate) unsafe fn new_unchecked<P: AsParent + ParentMaterializer>(
+        parent: &'a P,
+        data: &'a V::TypedArrayData,
+    ) -> Self {
+        debug_assert!(parent.is_encoding::<V>());
+        Self {
+            data,
+            dtype: parent.dtype(),
+            len: parent.len(),
+            slots: parent.slots(),
+            encoding_id: parent.encoding_id(),
+            materializer: parent,
+        }
+    }
+
+    /// Explicitly materialize the parent as an [`ArrayRef`].
+    ///
+    /// For heap-backed parents this returns the existing array. For stack-backed parents this
+    /// allocates an `ArrayRef` on first call and reuses the parent's cache after that.
+    #[inline]
+    pub fn materialize_array_ref(&self) -> &'a ArrayRef {
+        self.materializer.materialize_array_ref()
+    }
+
+    /// Explicitly materialize the parent as a heap-backed [`ArrayView`].
+    ///
+    /// For heap-backed parents this is free; stack-backed parents allocate an
+    /// `ArrayRef` on first call and reuse the parent's cache after that.
+    pub fn materialize_view(&self) -> ArrayView<'a, V> {
+        self.materialize_array_ref()
+            .as_typed::<V>()
+            .vortex_expect("materialized parent must keep its encoding")
+    }
+
+    #[inline]
+    pub fn data(&self) -> &'a V::TypedArrayData {
+        self.data
+    }
+
+    #[inline]
+    #[allow(clippy::same_name_method)]
+    pub fn slots(&self) -> &'a [Option<ArrayRef>] {
+        self.slots
+    }
+
+    #[inline]
+    #[allow(clippy::same_name_method)]
+    pub fn dtype(&self) -> &'a DType {
+        self.dtype
+    }
+
+    #[inline]
+    #[allow(clippy::same_name_method)]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    #[inline]
+    #[allow(clippy::same_name_method)]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    #[inline]
+    pub fn encoding_id(&self) -> ArrayId {
+        self.encoding_id
+    }
+
+    /// Returns an owned typed handle, explicitly materializing stack-backed parents.
+    pub fn into_owned(self) -> Array<V> {
+        // SAFETY: we are ourselves type checked as 'V'
+        unsafe { Array::<V>::from_array_ref_unchecked(self.materialize_array_ref().clone()) }
+    }
+}
+
+impl<V: VTable> Deref for ParentView<'_, V> {
+    type Target = V::TypedArrayData;
+
+    fn deref(&self) -> &V::TypedArrayData {
+        self.data
+    }
+}
+
+impl<V: VTable> Debug for ParentView<'_, V> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ParentView")
+            .field("encoding", &self.encoding_id())
+            .field("dtype", self.dtype())
+            .field("len", &self.len())
+            .finish()
     }
 }
 
 impl<V: VTable> AsRef<ArrayRef> for ArrayView<'_, V> {
     fn as_ref(&self) -> &ArrayRef {
-        self.array
+        // For heap-backed views this returns the borrowed `ArrayRef` directly. For
+        // stack-backed views, materialization runs once and the cached `ArrayRef`
+        // lives as long as the parent.
+        self.array()
     }
 }
 
@@ -110,9 +252,9 @@ impl<V: VTable> Deref for ArrayView<'_, V> {
 impl<V: VTable> Debug for ArrayView<'_, V> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ArrayView")
-            .field("encoding", &self.array.encoding_id())
-            .field("dtype", self.array.dtype())
-            .field("len", &self.array.len())
+            .field("encoding", &self.encoding_id())
+            .field("dtype", self.dtype())
+            .field("len", &self.len())
             .finish()
     }
 }

--- a/vortex-array/src/array/vtable/mod.rs
+++ b/vortex-array/src/array/vtable/mod.rs
@@ -35,6 +35,8 @@ use crate::Canonical;
 use crate::EqMode;
 use crate::ExecutionResult;
 use crate::IntoArray;
+use crate::array::ParentRef;
+use crate::array::ParentView;
 pub use crate::array::plugin::*;
 use crate::arrays::ConstantArray;
 use crate::arrays::constant::Constant;
@@ -191,7 +193,7 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
     ///
     /// Reductions are opportunistic and may return `Ok(None)` when no cheaper representation is
     /// known.
-    fn reduce(array: ArrayView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
+    fn reduce(array: ParentView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
         _ = array;
         Ok(None)
     }
@@ -201,7 +203,7 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
     /// This is used by lazy arrays to let child execution unlock parent simplifications.
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         _ = (array, parent, child_idx);

--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -89,7 +89,7 @@ pub struct BoolDataParts {
 
 pub trait BoolArrayExt: TypedArrayRef<Bool> {
     fn nullability(&self) -> crate::dtype::Nullability {
-        match self.as_ref().dtype() {
+        match self.dtype() {
             DType::Bool(nullability) => *nullability,
             _ => unreachable!("BoolArrayExt requires a bool dtype"),
         }
@@ -97,7 +97,7 @@ pub trait BoolArrayExt: TypedArrayRef<Bool> {
 
     fn validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[BoolSlots::VALIDITY].as_ref(),
+            self.slots()[BoolSlots::VALIDITY].as_ref(),
             self.nullability(),
         )
     }
@@ -129,11 +129,11 @@ pub trait BoolArrayExt: TypedArrayRef<Bool> {
 
     fn to_mask_fill_null_false(&self, ctx: &mut ExecutionCtx) -> Mask {
         let validity_mask = BoolArrayExt::validity(self)
-            .execute_mask(self.as_ref().len(), ctx)
+            .execute_mask(self.len(), ctx)
             .vortex_expect("Failed to compute validity mask");
         let buffer = match validity_mask {
             Mask::AllTrue(_) => self.to_bit_buffer(),
-            Mask::AllFalse(_) => return Mask::new_false(self.as_ref().len()),
+            Mask::AllFalse(_) => return Mask::new_false(self.len()),
             Mask::Values(validity) => validity.bit_buffer() & self.to_bit_buffer(),
         };
         Mask::from_buffer(buffer)

--- a/vortex-array/src/arrays/bool/compute/boolean.rs
+++ b/vortex-array/src/arrays/bool/compute/boolean.rs
@@ -40,7 +40,7 @@ impl BooleanKernel for Bool {
             .map(Some);
         }
 
-        let Some(rhs) = rhs.as_opt::<Bool>() else {
+        let Some(rhs) = rhs.as_typed::<Bool>() else {
             return Ok(None);
         };
 

--- a/vortex-array/src/arrays/bool/compute/rules.rs
+++ b/vortex-array/src/arrays/bool/compute/rules.rs
@@ -6,11 +6,13 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::arrays::Bool;
 use crate::arrays::BoolArray;
 use crate::arrays::Masked;
 use crate::arrays::bool::BoolArrayExt;
 use crate::arrays::filter::FilterReduceAdaptor;
+use crate::arrays::masked::MaskedArrayExt;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::optimizer::rules::ParentRuleSet;
@@ -38,7 +40,7 @@ impl ArrayParentReduceRule<Bool> for BoolMaskedValidityRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, Bool>,
-        parent: ArrayView<'_, Masked>,
+        parent: ParentView<'_, Masked>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         if child_idx > 0 {
@@ -48,7 +50,7 @@ impl ArrayParentReduceRule<Bool> for BoolMaskedValidityRule {
         let bit_buffer = array.to_bit_buffer();
         // Merge the parent's validity mask into the child's validity
         // TODO(joe): make this lazy
-        let validity = array.validity()?.and(parent.validity()?)?;
+        let validity = array.validity()?.and(parent.masked_validity())?;
 
         // Safety:
         // we know all elements are valid, the AND operation will fail if mismatched.

--- a/vortex-array/src/arrays/bool/compute/take.rs
+++ b/vortex-array/src/arrays/bool/compute/take.rs
@@ -39,7 +39,8 @@ impl TakeExecute for Bool {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         if let Some(piecewise_indices) = indices.as_opt::<PiecewiseSequence>()
-            && let Some(taken) = take_contiguous_ranges(array, piecewise_indices, indices, ctx)?
+            && let Some(taken) =
+                take_contiguous_ranges(array, piecewise_indices.materialize_view(), indices, ctx)?
         {
             return Ok(Some(taken));
         }

--- a/vortex-array/src/arrays/bool/compute/zip.rs
+++ b/vortex-array/src/arrays/bool/compute/zip.rs
@@ -29,7 +29,7 @@ impl ZipKernel for Bool {
         mask: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        let Some(if_false) = if_false.as_opt::<Bool>() else {
+        let Some(if_false) = if_false.as_typed::<Bool>() else {
             return Ok(None);
         };
 

--- a/vortex-array/src/arrays/bool/test_harness.rs
+++ b/vortex-array/src/arrays/bool/test_harness.rs
@@ -12,7 +12,7 @@ impl BoolArray {
     pub fn opt_bool_vec(&self, ctx: &mut ExecutionCtx) -> Vec<Option<bool>> {
         self.validity()
             .vortex_expect("failed to get validity")
-            .execute_mask(self.as_ref().len(), ctx)
+            .execute_mask(self.len(), ctx)
             .vortex_expect("Failed to compute validity mask")
             .to_bit_buffer()
             .iter()
@@ -24,7 +24,7 @@ impl BoolArray {
     pub fn bool_vec(&self, ctx: &mut ExecutionCtx) -> Vec<bool> {
         self.validity()
             .vortex_expect("failed to get validity")
-            .execute_mask(self.as_ref().len(), ctx)
+            .execute_mask(self.len(), ctx)
             .vortex_expect("Failed to compute validity mask")
             .to_bit_buffer()
             .iter()

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -18,6 +18,7 @@ use crate::ExecutionResult;
 use crate::array::Array;
 use crate::array::ArrayParts;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::child_to_validity;
 use crate::arrays::bool::BoolData;
@@ -209,7 +210,7 @@ impl VTable for Bool {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/chunked/array.rs
+++ b/vortex-array/src/arrays/chunked/array.rs
@@ -61,27 +61,26 @@ impl Display for ChunkedData {
 
 pub trait ChunkedArrayExt: TypedArrayRef<Chunked> {
     fn chunk_offsets_array(&self) -> &ArrayRef {
-        self.as_ref().slots()[ChunkedSlots::CHUNK_OFFSETS]
+        self.slots()[ChunkedSlots::CHUNK_OFFSETS]
             .as_ref()
             .vortex_expect("validated chunk offsets slot")
     }
 
     fn nchunks(&self) -> usize {
-        self.as_ref()
-            .slots()
+        self.slots()
             .len()
             .saturating_sub(ChunkedSlots::CHUNKS_OFFSET)
     }
 
     fn chunk(&self, idx: usize) -> &ArrayRef {
-        self.as_ref().slots()[ChunkedSlots::CHUNKS_OFFSET + idx]
+        self.slots()[ChunkedSlots::CHUNKS_OFFSET + idx]
             .as_ref()
             .vortex_expect("validated chunk slot")
     }
 
     fn iter_chunks<'a>(&'a self) -> Box<dyn Iterator<Item = &'a ArrayRef> + 'a> {
         Box::new(
-            self.as_ref().slots()[ChunkedSlots::CHUNKS_OFFSET..]
+            self.slots()[ChunkedSlots::CHUNKS_OFFSET..]
                 .iter()
                 .map(|slot| slot.as_ref().vortex_expect("validated chunk slot")),
         )
@@ -101,10 +100,7 @@ pub trait ChunkedArrayExt: TypedArrayRef<Chunked> {
     }
 
     fn find_chunk_idx(&self, index: usize) -> VortexResult<(usize, usize)> {
-        assert!(
-            index <= self.as_ref().len(),
-            "Index out of bounds of the array"
-        );
+        assert!(index <= self.len(), "Index out of bounds of the array");
         let chunk_offset_values = self.chunk_offset_values();
         let index_chunk = chunk_offset_values
             .search_sorted(&index, SearchSortedSide::Right)?
@@ -117,14 +113,14 @@ pub trait ChunkedArrayExt: TypedArrayRef<Chunked> {
 
     fn array_iterator(&self) -> impl ArrayIterator + '_ {
         ArrayIteratorAdapter::new(
-            self.as_ref().dtype().clone(),
+            self.dtype().clone(),
             self.iter_chunks().map(|chunk| Ok(chunk.clone())),
         )
     }
 
     fn array_stream(&self) -> impl ArrayStream + '_ {
         ArrayStreamAdapter::new(
-            self.as_ref().dtype().clone(),
+            self.dtype().clone(),
             stream::iter(self.iter_chunks().map(|chunk| Ok(chunk.clone()))),
         )
     }

--- a/vortex-array/src/arrays/chunked/compute/rules.rs
+++ b/vortex-array/src/arrays/chunked/compute/rules.rs
@@ -7,6 +7,7 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
 use crate::arrays::Constant;
@@ -16,7 +17,6 @@ use crate::arrays::ScalarFnArray;
 use crate::arrays::chunked::ChunkedArrayExt;
 use crate::arrays::scalar_fn::AnyScalarFn;
 use crate::arrays::scalar_fn::ScalarFnArrayExt;
-use crate::optimizer::ArrayOptimizer;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar_fn::fns::cast::CastReduceAdaptor;
@@ -38,7 +38,7 @@ impl ArrayParentReduceRule<Chunked> for ChunkedUnaryScalarFnPushDownRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, Chunked>,
-        parent: ArrayView<'_, ScalarFn>,
+        parent: ParentView<'_, ScalarFn>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         if parent.nchildren() != 1 {
@@ -48,9 +48,12 @@ impl ArrayParentReduceRule<Chunked> for ChunkedUnaryScalarFnPushDownRule {
         let new_chunks: Vec<_> = array
             .iter_chunks()
             .map(|chunk| {
-                ScalarFnArray::try_new(parent.scalar_fn().clone(), vec![chunk.clone()])?
-                    .into_array()
-                    .optimize()
+                let parts = ScalarFnArray::try_new_parts(
+                    parent.scalar_fn().clone(),
+                    vec![chunk.clone()],
+                    chunk.len(),
+                )?;
+                parts.optimize()
             })
             .try_collect()?;
 
@@ -69,7 +72,7 @@ impl ArrayParentReduceRule<Chunked> for ChunkedConstantScalarFnPushDownRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, Chunked>,
-        parent: ArrayView<'_, ScalarFn>,
+        parent: ParentView<'_, ScalarFn>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         for (idx, child) in parent.iter_children().enumerate() {
@@ -100,9 +103,12 @@ impl ArrayParentReduceRule<Chunked> for ChunkedConstantScalarFnPushDownRule {
                     })
                     .collect();
 
-                ScalarFnArray::try_new(parent.scalar_fn().clone(), new_children)?
-                    .into_array()
-                    .optimize()
+                let parts = ScalarFnArray::try_new_parts(
+                    parent.scalar_fn().clone(),
+                    new_children,
+                    chunk.len(),
+                )?;
+                parts.optimize()
             })
             .try_collect()?;
 

--- a/vortex-array/src/arrays/chunked/compute/take.rs
+++ b/vortex-array/src/arrays/chunked/compute/take.rs
@@ -339,7 +339,8 @@ impl TakeExecute for Chunked {
         }
 
         if let Some(piecewise_indices) = indices.as_opt::<PiecewiseSequence>()
-            && let Some(taken) = take_piecewise_chunked(array, piecewise_indices, ctx)?
+            && let Some(taken) =
+                take_piecewise_chunked(array, piecewise_indices.materialize_view(), ctx)?
         {
             return Ok(Some(taken));
         }

--- a/vortex-array/src/arrays/chunked/paired_chunks.rs
+++ b/vortex-array/src/arrays/chunked/paired_chunks.rs
@@ -70,15 +70,15 @@ pub(crate) struct PairedChunks {
 pub(crate) trait PairedChunksExt: ChunkedArrayExt {
     fn paired_chunks<T: ChunkedArrayExt>(&self, other: &T) -> PairedChunks {
         assert_eq!(
-            self.as_ref().len(),
-            other.as_ref().len(),
+            self.len(),
+            other.len(),
             "paired_chunks requires arrays of equal length"
         );
         PairedChunks {
             left: ChunkCursor::new(self.chunks()),
             right: ChunkCursor::new(other.chunks()),
             pos: 0,
-            total_len: self.as_ref().len(),
+            total_len: self.len(),
         }
     }
 }

--- a/vortex-array/src/arrays/chunked/tests.rs
+++ b/vortex-array/src/arrays/chunked/tests.rs
@@ -220,7 +220,7 @@ fn with_slot_rewrites_chunk_and_offsets() {
         &mut ctx
     );
     assert_arrays_eq!(
-        array.array().clone(),
+        array.materialize_array_ref().clone(),
         PrimitiveArray::from_iter([1u64, 2, 3, 4, 5, 6, 7, 8, 9]),
         &mut ctx
     );

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -27,6 +27,8 @@ use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
+use crate::array::ParentView;
 use crate::array::VTable;
 use crate::array::with_empty_buffers;
 use crate::arrays::PrimitiveArray;
@@ -71,6 +73,7 @@ impl VTable for Chunked {
 
     type OperationsVTable = Self;
     type ValidityVTable = Self;
+
     fn id(&self) -> ArrayId {
         static ID: CachedId = CachedId::new("vortex.chunked");
         *ID
@@ -283,7 +286,7 @@ impl VTable for Chunked {
         }
     }
 
-    fn reduce(array: ArrayView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
+    fn reduce(array: ParentView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
         Ok(match array.nchunks() {
             0 => Some(Canonical::empty(array.dtype()).into_array()),
             1 => Some(array.chunk(0).clone()),
@@ -293,7 +296,7 @@ impl VTable for Chunked {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/constant/compute/rules.rs
+++ b/vortex-array/src/arrays/constant/compute/rules.rs
@@ -6,6 +6,7 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrays::Filter;
@@ -39,7 +40,7 @@ impl ArrayParentReduceRule<Constant> for ConstantFilterRule {
     fn reduce_parent(
         &self,
         child: ArrayView<'_, Constant>,
-        parent: ArrayView<'_, Filter>,
+        parent: ParentView<'_, Filter>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -24,6 +24,7 @@ use crate::IntoArray;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::unsupported_buffer_replacement;
 use crate::arrays::ExtensionArray;
@@ -172,7 +173,7 @@ impl VTable for Constant {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -24,6 +24,7 @@ use crate::IntoArray;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::unsupported_buffer_replacement;
 use crate::arrays::constant::ConstantData;
@@ -165,7 +166,7 @@ impl VTable for Constant {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/decimal/array.rs
+++ b/vortex-array/src/arrays/decimal/array.rs
@@ -133,26 +133,26 @@ pub struct DecimalDataParts {
 
 pub trait DecimalArrayExt: TypedArrayRef<Decimal> {
     fn decimal_dtype(&self) -> DecimalDType {
-        match self.as_ref().dtype() {
+        match self.dtype() {
             DType::Decimal(decimal_dtype, _) => *decimal_dtype,
             _ => unreachable!("DecimalArrayExt requires a decimal dtype"),
         }
     }
 
     fn nullability(&self) -> Nullability {
-        match self.as_ref().dtype() {
+        match self.dtype() {
             DType::Decimal(_, nullability) => *nullability,
             _ => unreachable!("DecimalArrayExt requires a decimal dtype"),
         }
     }
 
     fn validity_child(&self) -> Option<&ArrayRef> {
-        self.as_ref().slots()[DecimalSlots::VALIDITY].as_ref()
+        self.slots()[DecimalSlots::VALIDITY].as_ref()
     }
 
     fn validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[DecimalSlots::VALIDITY].as_ref(),
+            self.slots()[DecimalSlots::VALIDITY].as_ref(),
             self.nullability(),
         )
     }

--- a/vortex-array/src/arrays/decimal/compute/rules.rs
+++ b/vortex-array/src/arrays/decimal/compute/rules.rs
@@ -8,9 +8,11 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::arrays::Decimal;
 use crate::arrays::DecimalArray;
 use crate::arrays::Masked;
+use crate::arrays::masked::MaskedArrayExt;
 use crate::arrays::slice::SliceReduce;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::match_each_decimal_value_type;
@@ -39,7 +41,7 @@ impl ArrayParentReduceRule<Decimal> for DecimalMaskedValidityRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, Decimal>,
-        parent: ArrayView<'_, Masked>,
+        parent: ParentView<'_, Masked>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         // Merge the parent's validity mask into the child's validity
@@ -51,7 +53,7 @@ impl ArrayParentReduceRule<Decimal> for DecimalMaskedValidityRule {
                 DecimalArray::new_unchecked(
                     array.buffer::<D>(),
                     array.decimal_dtype(),
-                    array.validity()?.and(parent.validity()?)?,
+                    array.validity()?.and(parent.masked_validity())?,
                 )
             }
             .into_array()

--- a/vortex-array/src/arrays/decimal/compute/take.rs
+++ b/vortex-array/src/arrays/decimal/compute/take.rs
@@ -37,7 +37,8 @@ impl TakeExecute for Decimal {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         if let Some(piecewise_indices) = indices.as_opt::<PiecewiseSequence>()
-            && let Some(taken) = take_contiguous_ranges(array, piecewise_indices, indices, ctx)?
+            && let Some(taken) =
+                take_contiguous_ranges(array, piecewise_indices.materialize_view(), indices, ctx)?
         {
             return Ok(Some(taken));
         }

--- a/vortex-array/src/arrays/decimal/vtable/mod.rs
+++ b/vortex-array/src/arrays/decimal/vtable/mod.rs
@@ -16,6 +16,7 @@ use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::array::Array;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::arrays::decimal::DecimalData;
 use crate::arrays::fixed_width::vtable as fixed_width;
@@ -200,7 +201,7 @@ impl VTable for Decimal {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/decimal/vtable/mod.rs
+++ b/vortex-array/src/arrays/decimal/vtable/mod.rs
@@ -17,6 +17,7 @@ use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::array::Array;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::arrays::decimal::DecimalData;
 use crate::buffer::BufferHandle;
@@ -222,7 +223,7 @@ impl VTable for Decimal {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/dict/array.rs
+++ b/vortex-array/src/arrays/dict/array.rs
@@ -226,15 +226,49 @@ impl Array<Dict> {
 
     /// Build a new `DictArray` from its components, `codes` and `values`.
     pub fn try_new(codes: ArrayRef, values: ArrayRef) -> VortexResult<Self> {
+        Array::try_from_parts(Self::try_new_parts(codes, values)?)
+    }
+
+    /// Build the [`ArrayParts<Dict>`]. The parts can then be optimized through
+    /// [`ArrayParts::optimize`](crate::array::ArrayParts::optimize) or materialized
+    /// directly with [`ArrayParts::into_array`].
+    pub fn try_new_parts(codes: ArrayRef, values: ArrayRef) -> VortexResult<ArrayParts<Dict>> {
         let dtype = values
             .dtype()
             .union_nullability(codes.dtype().nullability());
         let len = codes.len();
         let data = DictData::try_new(codes.dtype())?;
-        Array::try_from_parts(
+        Ok(
             ArrayParts::new(Dict, dtype, len, data)
                 .with_slots(smallvec![Some(codes), Some(values)]),
         )
+    }
+
+    /// Build the [`ArrayParts<Dict>`] without validating codes or values, recording whether
+    /// all values are referenced by at least one code.
+    ///
+    /// The parts can then be optimized through
+    /// [`ArrayParts::optimize`](crate::array::ArrayParts::optimize) or materialized directly
+    /// with [`ArrayParts::into_array`]. Unlike
+    /// [`set_all_values_referenced`](Self::set_all_values_referenced), this does not run the
+    /// debug-only `all_values_referenced` validation, so it is intended for callers that
+    /// have externally guaranteed the flag (for example a layout validated at write time).
+    ///
+    /// # Safety
+    ///
+    /// See [`DictData::new_unchecked`] and [`DictData::set_all_values_referenced`].
+    pub unsafe fn new_unchecked_parts(
+        codes: ArrayRef,
+        values: ArrayRef,
+        all_values_referenced: bool,
+    ) -> ArrayParts<Dict> {
+        let dtype = values
+            .dtype()
+            .union_nullability(codes.dtype().nullability());
+        let len = codes.len();
+        let data =
+            unsafe { DictData::new_unchecked().set_all_values_referenced(all_values_referenced) };
+        ArrayParts::new(Dict, dtype, len, data).with_slots(smallvec![Some(codes), Some(values)])
     }
 
     /// Build a new `DictArray` without validating the codes or values.

--- a/vortex-array/src/arrays/dict/compute/like.rs
+++ b/vortex-array/src/arrays/dict/compute/like.rs
@@ -12,7 +12,6 @@ use crate::arrays::ConstantArray;
 use crate::arrays::dict::DictArrayExt;
 use crate::arrays::dict::DictArraySlotsExt;
 use crate::arrays::scalar_fn::ScalarFnFactoryExt;
-use crate::optimizer::ArrayOptimizer;
 use crate::scalar_fn::fns::like::Like;
 use crate::scalar_fn::fns::like::LikeOptions;
 use crate::scalar_fn::fns::like::LikeReduce;
@@ -30,9 +29,12 @@ impl LikeReduce for Dict {
         if let Some(pattern) = pattern.as_constant() {
             let pattern = ConstantArray::new(pattern, array.values().len()).into_array();
 
-            let values = Like
-                .try_new_array(pattern.len(), options, [array.values().clone(), pattern])?
-                .optimize()?;
+            let parts = Like.try_new_array_parts(
+                pattern.len(),
+                options,
+                [array.values().clone(), pattern],
+            )?;
+            let values = parts.optimize()?;
 
             // SAFETY: LIKE preserves the len of the values, so codes are still pointing at
             //  valid positions.

--- a/vortex-array/src/arrays/dict/compute/like.rs
+++ b/vortex-array/src/arrays/dict/compute/like.rs
@@ -11,7 +11,7 @@ use crate::array::ArrayView;
 use crate::arrays::ConstantArray;
 use crate::arrays::dict::DictArrayExt;
 use crate::arrays::dict::DictArraySlotsExt;
-use crate::optimizer::ArrayOptimizer;
+use crate::arrays::scalar_fn::ScalarFnFactoryExt;
 use crate::scalar_fn::fns::like::Like;
 use crate::scalar_fn::fns::like::LikeOptions;
 use crate::scalar_fn::fns::like::LikeReduce;
@@ -29,9 +29,12 @@ impl LikeReduce for Dict {
         if let Some(pattern) = pattern.as_constant() {
             let pattern = ConstantArray::new(pattern, array.values().len()).into_array();
 
-            let values = Like::try_new(array.values().clone(), pattern, options)?
-                .into_array()
-                .optimize()?;
+            let parts = Like.try_new_array_parts(
+                pattern.len(),
+                options,
+                [array.values().clone(), pattern],
+            )?;
+            let values = parts.optimize()?;
 
             // SAFETY: LIKE preserves the len of the values, so codes are still pointing at
             //  valid positions.

--- a/vortex-array/src/arrays/dict/compute/rules.rs
+++ b/vortex-array/src/arrays/dict/compute/rules.rs
@@ -8,6 +8,7 @@ use crate::ArrayRef;
 use crate::EqMode;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::array::VTable;
 use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
@@ -25,7 +26,6 @@ use crate::arrays::scalar_fn::AnyScalarFn;
 use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::builtins::ArrayBuiltins;
-use crate::optimizer::ArrayOptimizer;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar_fn::fns::cast::Cast;
@@ -59,7 +59,7 @@ impl ArrayParentReduceRule<Dict> for DictionaryChunkedValuesPullUpRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, Dict>,
-        parent: ArrayView<'_, Chunked>,
+        parent: ParentView<'_, Chunked>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         let values = array.values();
@@ -103,7 +103,7 @@ impl ArrayParentReduceRule<Dict> for DictionaryScalarFnValuesPushDownRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, Dict>,
-        parent: ArrayView<'_, ScalarFn>,
+        parent: ParentView<'_, ScalarFn>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         let scalar_fn = parent.scalar_fn();
@@ -174,9 +174,9 @@ impl ArrayParentReduceRule<Dict> for DictionaryScalarFnValuesPushDownRule {
             }
         }
 
-        let transformed_values = ScalarFnArray::try_new(scalar_fn.clone(), value_children)?
-            .into_array()
-            .optimize()?;
+        let transformed_values =
+            ScalarFnArray::try_new_parts(scalar_fn.clone(), value_children, values_len)?
+                .optimize()?;
 
         // A non-strict function reaches this point only when the codes are all valid, but their
         // dtype may still be nullable. Remove that declared nullability while rebuilding the
@@ -216,7 +216,7 @@ impl ArrayParentReduceRule<Dict> for DictionaryScalarFnCodesPullUpRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, Dict>,
-        parent: ArrayView<'_, ScalarFn>,
+        parent: ParentView<'_, ScalarFn>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         // Don't attempt to pull up if there are less than 2 siblings.
@@ -252,9 +252,12 @@ impl ArrayParentReduceRule<Dict> for DictionaryScalarFnCodesPullUpRule {
             }
         }
 
-        let new_values = ScalarFnArray::try_new(parent.scalar_fn().clone(), new_children)?
-            .into_array()
-            .optimize()?;
+        let parts = ScalarFnArray::try_new_parts(
+            parent.scalar_fn().clone(),
+            new_children,
+            array.values().len(),
+        )?;
+        let new_values = parts.optimize()?;
 
         let new_dict =
             unsafe { DictArray::new_unchecked(array.codes().clone(), new_values) }.into_array();

--- a/vortex-array/src/arrays/dict/compute/rules.rs
+++ b/vortex-array/src/arrays/dict/compute/rules.rs
@@ -8,6 +8,7 @@ use crate::ArrayRef;
 use crate::EqMode;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::array::VTable;
 use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
@@ -25,7 +26,6 @@ use crate::arrays::scalar_fn::AnyScalarFn;
 use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::builtins::ArrayBuiltins;
-use crate::optimizer::ArrayOptimizer;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar_fn::fns::cast::Cast;
@@ -59,7 +59,7 @@ impl ArrayParentReduceRule<Dict> for DictionaryChunkedValuesPullUpRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, Dict>,
-        parent: ArrayView<'_, Chunked>,
+        parent: ParentView<'_, Chunked>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         let values = array.values();
@@ -103,7 +103,7 @@ impl ArrayParentReduceRule<Dict> for DictionaryScalarFnValuesPushDownRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, Dict>,
-        parent: ArrayView<'_, ScalarFn>,
+        parent: ParentView<'_, ScalarFn>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         // Check that the scalar function can actually be pushed down.
@@ -179,9 +179,9 @@ impl ArrayParentReduceRule<Dict> for DictionaryScalarFnValuesPushDownRule {
             }
         }
 
-        let new_values = ScalarFnArray::try_new(parent.scalar_fn().clone(), new_children)?
-            .into_array()
-            .optimize()?;
+        let parts =
+            ScalarFnArray::try_new_parts(parent.scalar_fn().clone(), new_children, values_len)?;
+        let new_values = parts.optimize()?;
 
         // A non-strict function reaches this point only when the codes are all valid, but their
         // dtype may still be nullable. Remove that declared nullability while rebuilding the
@@ -213,7 +213,7 @@ impl ArrayParentReduceRule<Dict> for DictionaryScalarFnCodesPullUpRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, Dict>,
-        parent: ArrayView<'_, ScalarFn>,
+        parent: ParentView<'_, ScalarFn>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         // Don't attempt to pull up if there are less than 2 siblings.
@@ -249,9 +249,12 @@ impl ArrayParentReduceRule<Dict> for DictionaryScalarFnCodesPullUpRule {
             }
         }
 
-        let new_values = ScalarFnArray::try_new(parent.scalar_fn().clone(), new_children)?
-            .into_array()
-            .optimize()?;
+        let parts = ScalarFnArray::try_new_parts(
+            parent.scalar_fn().clone(),
+            new_children,
+            array.values().len(),
+        )?;
+        let new_values = parts.optimize()?;
 
         let new_dict =
             unsafe { DictArray::new_unchecked(array.codes().clone(), new_values) }.into_array();

--- a/vortex-array/src/arrays/dict/execute.rs
+++ b/vortex-array/src/arrays/dict/execute.rs
@@ -47,19 +47,27 @@ pub(crate) fn take_canonical(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Canonical> {
     Ok(match values {
-        CanonicalView::Null(a) => Canonical::Null(take_null(a, codes)),
-        CanonicalView::Bool(a) => Canonical::Bool(take_bool(a, codes, ctx)?),
-        CanonicalView::Primitive(a) => Canonical::Primitive(take_primitive(a, codes, ctx)),
-        CanonicalView::Decimal(a) => Canonical::Decimal(take_decimal(a, codes, ctx)),
-        CanonicalView::VarBinView(a) => Canonical::VarBinView(take_varbinview(a, codes, ctx)),
-        CanonicalView::List(a) => Canonical::List(take_listview(a, codes, ctx)),
-        CanonicalView::Map(a) => Canonical::Map(take_map(a, codes, ctx)),
-        CanonicalView::FixedSizeList(a) => {
-            Canonical::FixedSizeList(take_fixed_size_list(a, codes, ctx))
+        CanonicalView::Null(a) => Canonical::Null(take_null(a.materialize_view(), codes)),
+        CanonicalView::Bool(a) => Canonical::Bool(take_bool(a.materialize_view(), codes, ctx)?),
+        CanonicalView::Primitive(a) => {
+            Canonical::Primitive(take_primitive(a.materialize_view(), codes, ctx))
         }
-        CanonicalView::Struct(a) => Canonical::Struct(take_struct(a, codes)),
-        CanonicalView::Union(a) => Canonical::Union(take_union(a, codes)),
-        CanonicalView::Extension(a) => Canonical::Extension(take_extension(a, codes, ctx)),
+        CanonicalView::Decimal(a) => {
+            Canonical::Decimal(take_decimal(a.materialize_view(), codes, ctx))
+        }
+        CanonicalView::VarBinView(a) => {
+            Canonical::VarBinView(take_varbinview(a.materialize_view(), codes, ctx))
+        }
+        CanonicalView::List(a) => Canonical::List(take_listview(a.materialize_view(), codes, ctx)),
+        CanonicalView::Map(a) => Canonical::Map(take_map(a.materialize_view(), codes, ctx)),
+        CanonicalView::FixedSizeList(a) => {
+            Canonical::FixedSizeList(take_fixed_size_list(a.materialize_view(), codes, ctx))
+        }
+        CanonicalView::Struct(a) => Canonical::Struct(take_struct(a.materialize_view(), codes)),
+        CanonicalView::Union(a) => Canonical::Union(take_union(a.materialize_view(), codes)),
+        CanonicalView::Extension(a) => {
+            Canonical::Extension(take_extension(a.materialize_view(), codes, ctx))
+        }
         CanonicalView::Variant(a) => {
             let indices = codes.array().clone();
             let taken_core_storage = a.core_storage().take(indices.clone())?;

--- a/vortex-array/src/arrays/dict/take.rs
+++ b/vortex-array/src/arrays/dict/take.rs
@@ -10,6 +10,7 @@ use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::array::VTable;
 use crate::arrays::ConstantArray;
 use crate::arrays::dict::DictArraySlotsExt;
@@ -90,7 +91,7 @@ where
     fn reduce_parent(
         &self,
         array: ArrayView<'_, V>,
-        parent: ArrayView<'_, Dict>,
+        parent: ParentView<'_, Dict>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         // Only handle the values child (index 1), not the codes child (index 0).
@@ -169,4 +170,28 @@ pub(crate) fn propagate_take_stats(
             &(unsafe { StatsSet::new_unchecked(inexact_min_max) }).as_typed_ref(source.dtype()),
         )
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_error::VortexResult;
+
+    use crate::IntoArray;
+    use crate::arrays::Constant;
+    use crate::arrays::ConstantArray;
+    use crate::arrays::DictArray;
+    use crate::arrays::PrimitiveArray;
+
+    #[test]
+    fn reduce_adaptor_handles_stack_backed_dict_parent() -> VortexResult<()> {
+        let indices = PrimitiveArray::from_iter([0u32, 0, 0]).into_array();
+        let values = ConstantArray::new(7i32, 1).into_array();
+        let parts = DictArray::try_new_parts(indices, values)?;
+
+        let reduced = parts.optimize()?;
+
+        assert!(reduced.is::<Constant>());
+        assert_eq!(reduced.len(), 3);
+        Ok(())
+    }
 }

--- a/vortex-array/src/arrays/dict/vtable/mod.rs
+++ b/vortex-array/src/arrays/dict/vtable/mod.rs
@@ -216,7 +216,7 @@ impl VTable for Dict {
 
         Ok(ExecutionResult::done(take_canonical(
             values.as_::<AnyCanonical>(),
-            codes.as_::<Primitive>(),
+            codes.as_::<Primitive>().materialize_view(),
             ctx,
         )?))
     }
@@ -236,7 +236,7 @@ impl VTable for Dict {
             if let CanonicalView::VarBinView(values) = values
                 && let Some(result) = match_each_varbin_builder!(builder, |builder| {
                     let validity = array.validity()?.execute_mask(array.len(), ctx)?;
-                    append_dict_to_varbin(codes, values, validity, builder)
+                    append_dict_to_varbin(codes, values.materialize_view(), validity, builder)
                 })
             {
                 return result;
@@ -245,7 +245,12 @@ impl VTable for Dict {
                 && let Some(builder) = builder.as_any_mut().downcast_mut::<VarBinViewBuilder>()
             {
                 let validity = array.validity()?.execute_mask(array.len(), ctx)?;
-                return append_dict_to_varbinview(codes, values, validity, builder);
+                return append_dict_to_varbinview(
+                    codes,
+                    values.materialize_view(),
+                    validity,
+                    builder,
+                );
             }
             let canonical = take_canonical(values, codes, ctx)?.into_array();
             canonical.append_to_builder(builder, ctx)?;

--- a/vortex-array/src/arrays/dict/vtable/mod.rs
+++ b/vortex-array/src/arrays/dict/vtable/mod.rs
@@ -34,6 +34,7 @@ use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::with_empty_buffers;
 use crate::arrays::ConstantArray;
@@ -227,7 +228,7 @@ impl VTable for Dict {
     ) -> VortexResult<()> {
         if !array.is_empty()
             && let (Some(codes), Some(values)) = (
-                array.codes().as_opt::<Primitive>(),
+                array.codes().as_typed::<Primitive>(),
                 array.values().as_opt::<AnyCanonical>(),
             )
             && !codes.validity()?.definitely_all_null()
@@ -262,7 +263,7 @@ impl VTable for Dict {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/dict/vtable/mod.rs
+++ b/vortex-array/src/arrays/dict/vtable/mod.rs
@@ -30,6 +30,7 @@ use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::with_empty_buffers;
 use crate::arrays::ConstantArray;
@@ -217,7 +218,7 @@ impl VTable for Dict {
     ) -> VortexResult<()> {
         if !array.is_empty()
             && let (Some(codes), Some(values)) = (
-                array.codes().as_opt::<Primitive>(),
+                array.codes().as_typed::<Primitive>(),
                 array.values().as_opt::<AnyCanonical>(),
             )
             && !codes.validity()?.definitely_all_null()
@@ -239,7 +240,7 @@ impl VTable for Dict {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/extension/array.rs
+++ b/vortex-array/src/arrays/extension/array.rs
@@ -26,8 +26,7 @@ pub struct ExtensionSlots {
 
 pub trait ExtensionArrayExt: TypedArrayRef<Extension> + ExtensionArraySlotsExt {
     fn ext_dtype(&self) -> &ExtDTypeRef {
-        self.as_ref()
-            .dtype()
+        self.dtype()
             .as_extension_opt()
             .vortex_expect("extension array somehow did not have an extension dtype")
     }

--- a/vortex-array/src/arrays/extension/compute/rules.rs
+++ b/vortex-array/src/arrays/extension/compute/rules.rs
@@ -6,6 +6,7 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrays::Extension;
@@ -30,7 +31,7 @@ pub(crate) const RULES: ReduceRuleSet<Extension> = ReduceRuleSet::new(&[&Extensi
 struct ExtensionConstantRule;
 
 impl ArrayReduceRule<Extension> for ExtensionConstantRule {
-    fn reduce(&self, array: ArrayView<'_, Extension>) -> VortexResult<Option<ArrayRef>> {
+    fn reduce(&self, array: ParentView<'_, Extension>) -> VortexResult<Option<ArrayRef>> {
         let Some(const_array) = array.storage_array().as_opt::<Constant>() else {
             return Ok(None);
         };
@@ -64,7 +65,7 @@ impl ArrayParentReduceRule<Extension> for ExtensionFilterPushDownRule {
     fn reduce_parent(
         &self,
         child: ArrayView<'_, Extension>,
-        parent: ArrayView<'_, Filter>,
+        parent: ParentView<'_, Filter>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         debug_assert_eq!(child_idx, 0);

--- a/vortex-array/src/arrays/extension/vtable/mod.rs
+++ b/vortex-array/src/arrays/extension/vtable/mod.rs
@@ -18,6 +18,8 @@ use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
+use crate::array::ParentView;
 use crate::array::VTable;
 use crate::array::ValidityVTableFromChild;
 use crate::array::with_empty_buffers;
@@ -199,13 +201,13 @@ impl VTable for Extension {
         builder.append_extension_array(&array.into_owned(), ctx)
     }
 
-    fn reduce(array: ArrayView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
+    fn reduce(array: ParentView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array)
     }
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/filter/array.rs
+++ b/vortex-array/src/arrays/filter/array.rs
@@ -43,7 +43,7 @@ pub struct FilterDataParts {
 }
 
 impl FilterData {
-    pub fn new(mask: Mask) -> Self {
+    fn new(mask: Mask) -> Self {
         Self { mask }
     }
 
@@ -95,14 +95,17 @@ impl Array<Filter> {
 
     /// Constructs a new `FilterArray`.
     pub fn try_new(array: ArrayRef, mask: Mask) -> VortexResult<Self> {
+        Ok(unsafe { Array::from_parts_unchecked(Self::try_new_parts(array, mask)?) })
+    }
+
+    /// Builds the [`ArrayParts<Filter>`]. The parts can then be optimized through
+    /// [`ArrayParts::optimize`](crate::array::ArrayParts::optimize) or materialized
+    /// directly with [`ArrayParts::into_array`].
+    pub fn try_new_parts(array: ArrayRef, mask: Mask) -> VortexResult<ArrayParts<Filter>> {
         let dtype = array.dtype().clone();
         let len = mask.true_count();
         let data = FilterData::try_new(array.len(), mask)?;
-        Ok(unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(Filter, dtype, len, data)
-                    .with_slots(FilterSlots { child: array }.into_slots()),
-            )
-        })
+        Ok(ArrayParts::new(Filter, dtype, len, data)
+            .with_slots(FilterSlots { child: array }.into_slots()))
     }
 }

--- a/vortex-array/src/arrays/filter/execute/take/tests.rs
+++ b/vortex-array/src/arrays/filter/execute/take/tests.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_buffer::buffer;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
@@ -35,7 +36,7 @@ fn execute_parent(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<crate::ArrayRef>> {
     TakeExecuteAdaptor(Filter).execute_parent(
-        child.as_::<Filter>(),
+        child.as_typed::<Filter>().vortex_expect("Filter child"),
         parent.as_::<Dict>(),
         child_idx,
         ctx,

--- a/vortex-array/src/arrays/filter/kernel.rs
+++ b/vortex-array/src/arrays/filter/kernel.rs
@@ -18,6 +18,7 @@ use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::array::VTable;
 use crate::arrays::Dict;
 use crate::arrays::Filter;
@@ -100,7 +101,7 @@ where
     fn reduce_parent(
         &self,
         array: ArrayView<'_, V>,
-        parent: ArrayView<'_, Filter>,
+        parent: ParentView<'_, Filter>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         assert_eq!(child_idx, 0);
@@ -133,5 +134,28 @@ where
             return Ok(Some(result));
         }
         <V as FilterKernel>::filter(array, parent.filter_mask(), ctx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_error::VortexResult;
+    use vortex_mask::Mask;
+
+    use crate::IntoArray;
+    use crate::arrays::Constant;
+    use crate::arrays::ConstantArray;
+    use crate::arrays::FilterArray;
+
+    #[test]
+    fn reduce_adaptor_handles_stack_backed_filter_parent() -> VortexResult<()> {
+        let child = ConstantArray::new(7i32, 4).into_array();
+        let parts = FilterArray::try_new_parts(child, Mask::from_iter([true, false, true, false]))?;
+
+        let reduced = parts.optimize()?;
+
+        assert!(reduced.is::<Constant>());
+        assert_eq!(reduced.len(), 2);
+        Ok(())
     }
 }

--- a/vortex-array/src/arrays/filter/rules.rs
+++ b/vortex-array/src/arrays/filter/rules.rs
@@ -8,6 +8,7 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::arrays::Filter;
 use crate::arrays::Struct;
 use crate::arrays::StructArray;
@@ -38,7 +39,7 @@ impl FilterReduce for Filter {
 struct TrivialFilterRule;
 
 impl ArrayReduceRule<Filter> for TrivialFilterRule {
-    fn reduce(&self, array: ArrayView<'_, Filter>) -> VortexResult<Option<ArrayRef>> {
+    fn reduce(&self, array: ParentView<'_, Filter>) -> VortexResult<Option<ArrayRef>> {
         match array.filter_mask() {
             Mask::AllTrue(_) => Ok(Some(array.child().clone())),
             Mask::AllFalse(_) => Ok(Some(Canonical::empty(array.dtype()).into_array())),
@@ -52,7 +53,7 @@ impl ArrayReduceRule<Filter> for TrivialFilterRule {
 struct FilterStructRule;
 
 impl ArrayReduceRule<Filter> for FilterStructRule {
-    fn reduce(&self, array: ArrayView<'_, Filter>) -> VortexResult<Option<ArrayRef>> {
+    fn reduce(&self, array: ParentView<'_, Filter>) -> VortexResult<Option<ArrayRef>> {
         let mask = array.filter_mask();
         let Some(struct_array) = array.child().as_opt::<Struct>() else {
             return Ok(None);

--- a/vortex-array/src/arrays/filter/rules.rs
+++ b/vortex-array/src/arrays/filter/rules.rs
@@ -8,6 +8,7 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::arrays::Filter;
 use crate::arrays::Struct;
 use crate::arrays::StructArray;
@@ -63,7 +64,7 @@ impl ArrayParentReduceRule<Filter> for FilterGetItemRule {
 struct TrivialFilterRule;
 
 impl ArrayReduceRule<Filter> for TrivialFilterRule {
-    fn reduce(&self, array: ArrayView<'_, Filter>) -> VortexResult<Option<ArrayRef>> {
+    fn reduce(&self, array: ParentView<'_, Filter>) -> VortexResult<Option<ArrayRef>> {
         match array.filter_mask() {
             Mask::AllTrue(_) => Ok(Some(array.child().clone())),
             Mask::AllFalse(_) => Ok(Some(Canonical::empty(array.dtype()).into_array())),
@@ -77,7 +78,7 @@ impl ArrayReduceRule<Filter> for TrivialFilterRule {
 struct FilterStructRule;
 
 impl ArrayReduceRule<Filter> for FilterStructRule {
-    fn reduce(&self, array: ArrayView<'_, Filter>) -> VortexResult<Option<ArrayRef>> {
+    fn reduce(&self, array: ParentView<'_, Filter>) -> VortexResult<Option<ArrayRef>> {
         let mask = array.filter_mask();
         let Some(struct_array) = array.child().as_opt::<Struct>() else {
             return Ok(None);

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -25,6 +25,8 @@ use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
+use crate::array::ParentRef;
+use crate::array::ParentView;
 use crate::array::VTable;
 use crate::array::ValidityVTable;
 use crate::array::with_empty_buffers;
@@ -66,6 +68,7 @@ impl VTable for Filter {
     type TypedArrayData = FilterData;
     type OperationsVTable = Self;
     type ValidityVTable = Self;
+
     fn id(&self) -> ArrayId {
         static ID: CachedId = CachedId::new("vortex.filter");
         *ID
@@ -173,13 +176,13 @@ impl VTable for Filter {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)
     }
 
-    fn reduce(array: ArrayView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
+    fn reduce(array: ParentView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array)
     }
 }

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -25,6 +25,8 @@ use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
+use crate::array::ParentRef;
+use crate::array::ParentView;
 use crate::array::VTable;
 use crate::array::ValidityVTable;
 use crate::array::with_empty_buffers;
@@ -67,6 +69,7 @@ impl VTable for Filter {
     type TypedArrayData = FilterData;
     type OperationsVTable = Self;
     type ValidityVTable = Self;
+
     fn id(&self) -> ArrayId {
         static ID: CachedId = CachedId::new("vortex.filter");
         *ID
@@ -189,13 +192,13 @@ impl VTable for Filter {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)
     }
 
-    fn reduce(array: ArrayView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
+    fn reduce(array: ParentView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array)
     }
 }

--- a/vortex-array/src/arrays/fixed_size_list/array.rs
+++ b/vortex-array/src/arrays/fixed_size_list/array.rs
@@ -212,7 +212,7 @@ impl FixedSizeListData {
 
 pub trait FixedSizeListArrayExt: FixedSizeListArraySlotsExt {
     fn dtype_parts(&self) -> (&DType, u32, crate::dtype::Nullability) {
-        match self.as_ref().dtype() {
+        match self.dtype() {
             DType::FixedSizeList(element_dtype, list_size, nullability) => {
                 (element_dtype.as_ref(), *list_size, *nullability)
             }
@@ -228,7 +228,7 @@ pub trait FixedSizeListArrayExt: FixedSizeListArraySlotsExt {
     fn fixed_size_list_validity(&self) -> Validity {
         let (_, _, nullability) = self.dtype_parts();
         child_to_validity(
-            self.as_ref().slots()[FixedSizeListSlots::VALIDITY].as_ref(),
+            self.slots()[FixedSizeListSlots::VALIDITY].as_ref(),
             nullability,
         )
     }
@@ -236,10 +236,10 @@ pub trait FixedSizeListArrayExt: FixedSizeListArraySlotsExt {
     #[allow(clippy::disallowed_methods)]
     fn fixed_size_list_elements_at(&self, index: usize) -> VortexResult<ArrayRef> {
         debug_assert!(
-            index < self.as_ref().len(),
+            index < self.len(),
             "index {} out of bounds: the len is {}",
             index,
-            self.as_ref().len(),
+            self.len(),
         );
 
         let start = self.list_size() as usize * index;

--- a/vortex-array/src/arrays/fixed_size_list/compute/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/take.rs
@@ -112,7 +112,7 @@ fn take_non_empty_fsl(
     }
 
     if let Some(piecewise_indices) = indices.as_opt::<PiecewiseSequence>()
-        && let Some(taken) = take_piecewise_fsl(array, piecewise_indices, ctx)?
+        && let Some(taken) = take_piecewise_fsl(array, piecewise_indices.materialize_view(), ctx)?
     {
         return Ok(taken);
     }

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -23,6 +23,7 @@ use crate::ExecutionResult;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::with_empty_buffers;
 use crate::arrays::fixed_size_list::FixedSizeListData;
@@ -65,6 +66,7 @@ impl VTable for FixedSizeList {
 
     type OperationsVTable = Self;
     type ValidityVTable = Self;
+
     fn id(&self) -> ArrayId {
         static ID: CachedId = CachedId::new("vortex.fixed_size_list");
         *ID
@@ -92,7 +94,7 @@ impl VTable for FixedSizeList {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/fixed_width/take/mod.rs
+++ b/vortex-array/src/arrays/fixed_width/take/mod.rs
@@ -97,7 +97,8 @@ pub(crate) fn take<V: FixedWidthArray>(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ArrayRef>> {
     if let Some(piecewise_indices) = indices.as_opt::<PiecewiseSequence>()
-        && let Some(taken) = take_contiguous_ranges(array, piecewise_indices, indices, ctx)?
+        && let Some(taken) =
+            take_contiguous_ranges(array, piecewise_indices.materialize_view(), indices, ctx)?
     {
         return Ok(Some(taken));
     }

--- a/vortex-array/src/arrays/interleave/mod.rs
+++ b/vortex-array/src/arrays/interleave/mod.rs
@@ -121,21 +121,21 @@ pub trait InterleaveArrayExt: TypedArrayRef<Interleave> {
 
     /// The `idx`-th value array (holding the rows that `array_indices` routes to it).
     fn value(&self, idx: usize) -> &ArrayRef {
-        self.as_ref().slots()[idx + 2]
+        self.slots()[idx + 2]
             .as_ref()
             .vortex_expect("validated interleave value slot")
     }
 
     /// The selector routing each output row to a value array.
     fn array_indices(&self) -> &ArrayRef {
-        self.as_ref().slots()[0]
+        self.slots()[0]
             .as_ref()
             .vortex_expect("validated interleave array_indices slot")
     }
 
     /// The selector naming each output row's position within its value array.
     fn row_indices(&self) -> &ArrayRef {
-        self.as_ref().slots()[1]
+        self.slots()[1]
             .as_ref()
             .vortex_expect("validated interleave row_indices slot")
     }

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -278,7 +278,7 @@ impl ListData {
 
 pub trait ListArrayExt: ListArraySlotsExt {
     fn nullability(&self) -> crate::dtype::Nullability {
-        match self.as_ref().dtype() {
+        match self.dtype() {
             DType::List(_, nullability) => *nullability,
             _ => unreachable!("ListArrayExt requires a list dtype"),
         }
@@ -286,7 +286,7 @@ pub trait ListArrayExt: ListArraySlotsExt {
 
     fn list_validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[ListSlots::VALIDITY].as_ref(),
+            self.slots()[ListSlots::VALIDITY].as_ref(),
             self.nullability(),
         )
     }
@@ -294,9 +294,9 @@ pub trait ListArrayExt: ListArraySlotsExt {
     #[allow(clippy::disallowed_methods)]
     fn offset_at(&self, index: usize) -> VortexResult<usize> {
         vortex_ensure!(
-            index <= self.as_ref().len(),
+            index <= self.len(),
             "Index {index} out of bounds 0..={}",
-            self.as_ref().len()
+            self.len()
         );
 
         if let Some(p) = self.offsets().as_opt::<Primitive>() {
@@ -320,7 +320,7 @@ pub trait ListArrayExt: ListArraySlotsExt {
 
     fn sliced_elements(&self) -> VortexResult<ArrayRef> {
         let start = self.offset_at(0)?;
-        let end = self.offset_at(self.as_ref().len())?;
+        let end = self.offset_at(self.len())?;
         self.elements().slice(start..end)
     }
 

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -49,7 +49,8 @@ impl TakeExecute for List {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         if let Some(piecewise_indices) = indices.as_opt::<PiecewiseSequence>()
-            && let Some(taken) = take_slices(array, piecewise_indices, indices, ctx)?
+            && let Some(taken) =
+                take_slices(array, piecewise_indices.materialize_view(), indices, ctx)?
         {
             return Ok(Some(taken));
         }

--- a/vortex-array/src/arrays/list/tests.rs
+++ b/vortex-array/src/arrays/list/tests.rs
@@ -747,7 +747,7 @@ fn test_list_of_lists_nullable_inner() {
 
     // Check that second inner list is null.
     let second_inner = first_list
-        .array()
+        .materialize_array_ref()
         .execute_scalar(1, &mut SESSION.create_execution_ctx())
         .unwrap();
     assert!(second_inner.is_null());
@@ -789,7 +789,10 @@ fn test_list_of_lists_both_nullable() {
     assert_eq!(first_inner.len(), 2);
 
     // Second inner list should be null.
-    let second_inner = first_list.array().execute_scalar(1, &mut ctx).unwrap();
+    let second_inner = first_list
+        .materialize_array_ref()
+        .execute_scalar(1, &mut ctx)
+        .unwrap();
     assert!(second_inner.is_null());
 
     // Second outer list should be null.
@@ -807,7 +810,10 @@ fn test_list_of_lists_both_nullable() {
     let fourth_outer = list_of_lists.list_elements_at(3).unwrap();
     let fourth_list = fourth_outer.as_::<List>();
     assert_eq!(fourth_list.len(), 1);
-    let inner = fourth_list.array().execute_scalar(0, &mut ctx).unwrap();
+    let inner = fourth_list
+        .materialize_array_ref()
+        .execute_scalar(0, &mut ctx)
+        .unwrap();
     assert!(inner.is_null());
 }
 

--- a/vortex-array/src/arrays/list/vtable/mod.rs
+++ b/vortex-array/src/arrays/list/vtable/mod.rs
@@ -24,6 +24,7 @@ use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::with_empty_buffers;
 use crate::arrays::list::ListArraySlotsExt;
@@ -67,6 +68,7 @@ impl VTable for List {
 
     type OperationsVTable = Self;
     type ValidityVTable = Self;
+
     fn id(&self) -> ArrayId {
         static ID: CachedId = CachedId::new("vortex.list");
         *ID
@@ -94,7 +96,7 @@ impl VTable for List {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -355,7 +355,7 @@ fn fill_referenced_mask<O: IntegerPType, S: IntegerPType>(
 
 pub trait ListViewArrayExt: ListViewArraySlotsExt {
     fn nullability(&self) -> crate::dtype::Nullability {
-        match self.as_ref().dtype() {
+        match self.dtype() {
             DType::List(_, nullability) => *nullability,
             _ => unreachable!("ListViewArrayExt requires a list dtype"),
         }
@@ -363,7 +363,7 @@ pub trait ListViewArrayExt: ListViewArraySlotsExt {
 
     fn listview_validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[ListViewSlots::VALIDITY].as_ref(),
+            self.slots()[ListViewSlots::VALIDITY].as_ref(),
             self.nullability(),
         )
     }
@@ -371,9 +371,9 @@ pub trait ListViewArrayExt: ListViewArraySlotsExt {
     #[allow(clippy::disallowed_methods)]
     fn offset_at(&self, index: usize) -> usize {
         assert!(
-            index < self.as_ref().len(),
+            index < self.len(),
             "Index {index} out of bounds 0..{}",
-            self.as_ref().len()
+            self.len()
         );
         self.offsets()
             .as_opt::<Primitive>()
@@ -391,10 +391,10 @@ pub trait ListViewArrayExt: ListViewArraySlotsExt {
     #[allow(clippy::disallowed_methods)]
     fn size_at(&self, index: usize) -> usize {
         assert!(
-            index < self.as_ref().len(),
+            index < self.len(),
             "Index {} out of bounds 0..{}",
             index,
-            self.as_ref().len()
+            self.len()
         );
         self.sizes()
             .as_opt::<Primitive>()
@@ -521,7 +521,7 @@ pub trait ListViewArrayExt: ListViewArraySlotsExt {
     ///
     /// The array must contain at least one list (`len() > 0`).
     fn referenced_element_bounds(&self, ctx: &mut ExecutionCtx) -> VortexResult<(usize, usize)> {
-        let n_lists = self.as_ref().len();
+        let n_lists = self.len();
         vortex_ensure!(
             n_lists > 0,
             "referenced_element_bounds requires a non-empty array"

--- a/vortex-array/src/arrays/listview/compute/rules.rs
+++ b/vortex-array/src/arrays/listview/compute/rules.rs
@@ -6,6 +6,7 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::arrays::Filter;
 use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
@@ -34,7 +35,7 @@ impl ArrayParentReduceRule<ListView> for ListViewFilterPushDown {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, ListView>,
-        parent: ArrayView<'_, Filter>,
+        parent: ParentView<'_, Filter>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         // NOTE(ngates): if the filter is super selective, we maybe ought to consider masking

--- a/vortex-array/src/arrays/listview/compute/zip.rs
+++ b/vortex-array/src/arrays/listview/compute/zip.rs
@@ -45,7 +45,7 @@ impl ZipKernel for ListView {
         mask: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        let Some(if_false) = if_false.as_opt::<ListView>() else {
+        let Some(if_false) = if_false.as_typed::<ListView>() else {
             return Ok(None);
         };
 

--- a/vortex-array/src/arrays/listview/tests/operations.rs
+++ b/vortex-array/src/arrays/listview/tests/operations.rs
@@ -62,7 +62,7 @@ fn test_slice_comprehensive() {
         // Compare the sliced elements
         assert_eq!(
             full_list
-                .array()
+                .materialize_array_ref()
                 .execute_scalar(i, &mut array_session().create_execution_ctx())
                 .unwrap(),
             listview
@@ -161,13 +161,13 @@ fn test_slice_with_nulls() {
     assert_eq!(sliced_list.len(), 2);
     assert!(
         sliced_list
-            .array()
+            .materialize_array_ref()
             .is_invalid(0, &mut array_session().create_execution_ctx())
             .unwrap()
     ); // Original index 1 was null.
     assert!(
         sliced_list
-            .array()
+            .materialize_array_ref()
             .is_valid(1, &mut array_session().create_execution_ctx())
             .unwrap()
     ); // Original index 2 was valid.

--- a/vortex-array/src/arrays/listview/vtable/mod.rs
+++ b/vortex-array/src/arrays/listview/vtable/mod.rs
@@ -24,6 +24,7 @@ use crate::ExecutionResult;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::with_empty_buffers;
 use crate::arrays::listview::ListViewArraySlotsExt;
@@ -78,6 +79,7 @@ impl VTable for ListView {
 
     type OperationsVTable = Self;
     type ValidityVTable = Self;
+
     fn id(&self) -> ArrayId {
         static ID: CachedId = CachedId::new("vortex.listview");
         *ID
@@ -243,7 +245,7 @@ impl VTable for ListView {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/map/array.rs
+++ b/vortex-array/src/arrays/map/array.rs
@@ -91,8 +91,7 @@ pub trait MapArrayExt: MapArraySlotsExt {
 
     /// Returns this map's key/value type information.
     fn map_dtype(&self) -> &MapDType {
-        self.as_ref()
-            .dtype()
+        self.dtype()
             .as_map_opt()
             .vortex_expect("MapArray requires a map dtype")
     }

--- a/vortex-array/src/arrays/map/compute/cast.rs
+++ b/vortex-array/src/arrays/map/compute/cast.rs
@@ -49,7 +49,7 @@ impl CastReduce for Map {
         };
 
         let Some(entries) = <ListView as CastReduce>::cast(
-            array.entries().as_::<ListView>(),
+            array.entries().as_::<ListView>().materialize_view(),
             &target_entries_dtype,
         )?
         else {
@@ -72,7 +72,7 @@ impl CastKernel for Map {
         };
 
         let Some(entries) = <ListView as CastKernel>::cast(
-            array.entries().as_::<ListView>(),
+            array.entries().as_::<ListView>().materialize_view(),
             &target_entries_dtype,
             ctx,
         )?

--- a/vortex-array/src/arrays/map/compute/filter.rs
+++ b/vortex-array/src/arrays/map/compute/filter.rs
@@ -20,7 +20,7 @@ use crate::executor::ExecutionCtx;
 
 impl FilterReduce for Map {
     fn filter(array: ArrayView<'_, Self>, mask: &Mask) -> VortexResult<Option<ArrayRef>> {
-        let entries = array.entries().as_::<ListView>();
+        let entries = array.entries().as_::<ListView>().materialize_view();
 
         // SAFETY: filtering row metadata keeps offsets and sizes paired, preserves the original
         // elements, and filters validity to the same output length. The zero-copy-to-list flag is

--- a/vortex-array/src/arrays/map/compute/mask.rs
+++ b/vortex-array/src/arrays/map/compute/mask.rs
@@ -16,8 +16,10 @@ use crate::scalar_fn::fns::mask::MaskReduce;
 
 impl MaskReduce for Map {
     fn mask(array: ArrayView<'_, Self>, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
-        let Some(entries) =
-            <ListView as MaskReduce>::mask(array.entries().as_::<ListView>(), mask)?
+        let Some(entries) = <ListView as MaskReduce>::mask(
+            array.entries().as_::<ListView>().materialize_view(),
+            mask,
+        )?
         else {
             return Ok(None);
         };

--- a/vortex-array/src/arrays/map/compute/slice.rs
+++ b/vortex-array/src/arrays/map/compute/slice.rs
@@ -18,8 +18,10 @@ use crate::executor::ExecutionCtx;
 
 impl SliceReduce for Map {
     fn slice(array: ArrayView<'_, Self>, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
-        let Some(sliced_entries) =
-            <ListView as SliceReduce>::slice(array.entries().as_::<ListView>(), range)?
+        let Some(sliced_entries) = <ListView as SliceReduce>::slice(
+            array.entries().as_::<ListView>().materialize_view(),
+            range,
+        )?
         else {
             return Ok(None);
         };

--- a/vortex-array/src/arrays/map/compute/take.rs
+++ b/vortex-array/src/arrays/map/compute/take.rs
@@ -16,8 +16,10 @@ use crate::executor::ExecutionCtx;
 
 impl TakeReduce for Map {
     fn take(array: ArrayView<'_, Self>, indices: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
-        let Some(entries) =
-            <ListView as TakeReduce>::take(array.entries().as_::<ListView>(), indices)?
+        let Some(entries) = <ListView as TakeReduce>::take(
+            array.entries().as_::<ListView>().materialize_view(),
+            indices,
+        )?
         else {
             return Ok(None);
         };
@@ -32,8 +34,11 @@ impl TakeExecute for Map {
         indices: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        let Some(entries) =
-            <ListView as TakeExecute>::take(array.entries().as_::<ListView>(), indices, ctx)?
+        let Some(entries) = <ListView as TakeExecute>::take(
+            array.entries().as_::<ListView>().materialize_view(),
+            indices,
+            ctx,
+        )?
         else {
             return Ok(None);
         };

--- a/vortex-array/src/arrays/map/vtable/mod.rs
+++ b/vortex-array/src/arrays/map/vtable/mod.rs
@@ -12,6 +12,7 @@ use crate::ArrayParts;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
+use crate::ParentRef;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
@@ -172,7 +173,7 @@ impl VTable for Map {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/masked/array.rs
+++ b/vortex-array/src/arrays/masked/array.rs
@@ -42,8 +42,8 @@ impl Display for MaskedData {
 pub trait MaskedArrayExt: TypedArrayRef<Masked> + MaskedArraySlotsExt {
     fn masked_validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[MaskedSlots::VALIDITY].as_ref(),
-            self.as_ref().dtype().nullability(),
+            self.slots()[MaskedSlots::VALIDITY].as_ref(),
+            self.dtype().nullability(),
         )
     }
 }

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -27,6 +27,7 @@ use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::validity_to_child;
 use crate::array::with_empty_buffers;
@@ -200,7 +201,7 @@ impl VTable for Masked {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -27,6 +27,7 @@ use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::validity_to_child;
 use crate::array::with_empty_buffers;
@@ -195,7 +196,7 @@ impl VTable for Masked {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -17,6 +17,7 @@ use crate::array::ArrayParts;
 use crate::array::ArrayView;
 use crate::array::EmptyArrayData;
 use crate::array::OperationsVTable;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::ValidityVTable;
 use crate::array::with_empty_buffers;
@@ -112,7 +113,7 @@ impl VTable for Null {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/patched/array.rs
+++ b/vortex-array/src/arrays/patched/array.rs
@@ -116,7 +116,7 @@ pub trait PatchedArrayExt: PatchedArraySlotsExt {
     #[inline]
     #[allow(clippy::disallowed_methods)]
     fn lane_range(&self, chunk: usize, lane: usize) -> VortexResult<Range<usize>> {
-        assert!(chunk * 1024 <= self.as_ref().len() + self.offset());
+        assert!(chunk * 1024 <= self.len() + self.offset());
         assert!(lane < self.n_lanes());
 
         let start = self.lane_offsets().execute_scalar(
@@ -154,12 +154,12 @@ pub trait PatchedArrayExt: PatchedArraySlotsExt {
         let begin = (chunks.start * 1024).saturating_sub(self.offset());
         let end = (chunks.end * 1024)
             .saturating_sub(self.offset())
-            .min(self.as_ref().len());
+            .min(self.len());
 
         let offset = if chunks.start == 0 { self.offset() } else { 0 };
         let inner = self.inner().slice(begin..end)?;
         let len = inner.len();
-        let dtype = self.as_ref().dtype().clone();
+        let dtype = self.dtype().clone();
         let slots = PatchedSlots {
             inner,
             lane_offsets: sliced_lane_offsets,

--- a/vortex-array/src/arrays/patched/vtable/mod.rs
+++ b/vortex-array/src/arrays/patched/vtable/mod.rs
@@ -29,6 +29,7 @@ use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::ValidityChild;
 use crate::array::ValidityVTableFromChild;
@@ -304,7 +305,7 @@ impl VTable for Patched {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/primitive/array/mod.rs
+++ b/vortex-array/src/arrays/primitive/array/mod.rs
@@ -108,26 +108,26 @@ pub struct PrimitiveDataParts {
 
 pub trait PrimitiveArrayExt: TypedArrayRef<Primitive> {
     fn ptype(&self) -> PType {
-        match self.as_ref().dtype() {
+        match self.dtype() {
             DType::Primitive(ptype, _) => *ptype,
             _ => unreachable!("PrimitiveArrayExt requires a primitive dtype"),
         }
     }
 
     fn nullability(&self) -> Nullability {
-        match self.as_ref().dtype() {
+        match self.dtype() {
             DType::Primitive(_, nullability) => *nullability,
             _ => unreachable!("PrimitiveArrayExt requires a primitive dtype"),
         }
     }
 
     fn validity_child(&self) -> Option<&ArrayRef> {
-        self.as_ref().slots()[PrimitiveSlots::VALIDITY].as_ref()
+        self.slots()[PrimitiveSlots::VALIDITY].as_ref()
     }
 
     fn validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[PrimitiveSlots::VALIDITY].as_ref(),
+            self.slots()[PrimitiveSlots::VALIDITY].as_ref(),
             self.nullability(),
         )
     }
@@ -160,7 +160,8 @@ pub trait PrimitiveArrayExt: TypedArrayRef<Primitive> {
             return Ok(self.to_owned());
         }
 
-        let Some(min_max) = min_max(self.as_ref(), ctx, NumericalAggregateOpts::default())? else {
+        let array = self.to_owned().as_array().clone();
+        let Some(min_max) = min_max(&array, ctx, NumericalAggregateOpts::default())? else {
             return Ok(PrimitiveArray::new(
                 Buffer::<u8>::zeroed(self.len()),
                 PrimitiveArrayExt::validity(self),
@@ -184,29 +185,26 @@ pub trait PrimitiveArrayExt: TypedArrayRef<Primitive> {
             return Ok(self.to_owned());
         };
 
-        let nullability = self.as_ref().dtype().nullability();
+        let nullability = self.dtype().nullability();
 
         if min < 0 || max < 0 {
             // Signed
             if min >= i8::MIN as i64 && max <= i8::MAX as i64 {
-                let result = self
-                    .as_ref()
+                let result = array
                     .cast(DType::Primitive(PType::I8, nullability))?
                     .execute::<PrimitiveArray>(ctx)?;
                 return Ok(result);
             }
 
             if min >= i16::MIN as i64 && max <= i16::MAX as i64 {
-                let result = self
-                    .as_ref()
+                let result = array
                     .cast(DType::Primitive(PType::I16, nullability))?
                     .execute::<PrimitiveArray>(ctx)?;
                 return Ok(result);
             }
 
             if min >= i32::MIN as i64 && max <= i32::MAX as i64 {
-                let result = self
-                    .as_ref()
+                let result = array
                     .cast(DType::Primitive(PType::I32, nullability))?
                     .execute::<PrimitiveArray>(ctx)?;
                 return Ok(result);
@@ -214,24 +212,21 @@ pub trait PrimitiveArrayExt: TypedArrayRef<Primitive> {
         } else {
             // Unsigned
             if max <= u8::MAX as i64 {
-                let result = self
-                    .as_ref()
+                let result = array
                     .cast(DType::Primitive(PType::U8, nullability))?
                     .execute::<PrimitiveArray>(ctx)?;
                 return Ok(result);
             }
 
             if max <= u16::MAX as i64 {
-                let result = self
-                    .as_ref()
+                let result = array
                     .cast(DType::Primitive(PType::U16, nullability))?
                     .execute::<PrimitiveArray>(ctx)?;
                 return Ok(result);
             }
 
             if max <= u32::MAX as i64 {
-                let result = self
-                    .as_ref()
+                let result = array
                     .cast(DType::Primitive(PType::U32, nullability))?
                     .execute::<PrimitiveArray>(ctx)?;
                 return Ok(result);

--- a/vortex-array/src/arrays/primitive/array/top_value.rs
+++ b/vortex-array/src/arrays/primitive/array/top_value.rs
@@ -31,9 +31,7 @@ impl PrimitiveArray {
         match_each_native_ptype!(self.ptype(), |P| {
             let (top, count) = typed_top_value(
                 self.as_slice::<P>(),
-                self.as_ref()
-                    .validity()?
-                    .execute_mask(self.as_ref().len(), ctx)?,
+                self.validity()?.execute_mask(self.len(), ctx)?,
             );
             Ok(Some((top.into(), count)))
         })

--- a/vortex-array/src/arrays/primitive/compute/rules.rs
+++ b/vortex-array/src/arrays/primitive/compute/rules.rs
@@ -6,9 +6,11 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::arrays::Masked;
 use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
+use crate::arrays::masked::MaskedArrayExt;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::optimizer::rules::ParentRuleSet;
@@ -35,12 +37,12 @@ impl ArrayParentReduceRule<Primitive> for PrimitiveMaskedValidityRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, Primitive>,
-        parent: ArrayView<'_, Masked>,
+        parent: ParentView<'_, Masked>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         // TODO(joe): make this lazy
         // Merge the parent's validity mask into the child's validity
-        let new_validity = array.validity()?.and(parent.validity()?)?;
+        let new_validity = array.validity()?.and(parent.masked_validity())?;
 
         // SAFETY: masking validity does not change PrimitiveArray invariants
         let masked_array = unsafe {

--- a/vortex-array/src/arrays/primitive/compute/take/mod.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/mod.rs
@@ -91,7 +91,8 @@ impl TakeExecute for Primitive {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         if let Some(piecewise_indices) = indices.as_opt::<PiecewiseSequence>()
-            && let Some(taken) = take_contiguous_ranges(array, piecewise_indices, indices, ctx)?
+            && let Some(taken) =
+                take_contiguous_ranges(array, piecewise_indices.materialize_view(), indices, ctx)?
         {
             return Ok(Some(taken));
         }

--- a/vortex-array/src/arrays/primitive/compute/zip.rs
+++ b/vortex-array/src/arrays/primitive/compute/zip.rs
@@ -33,7 +33,7 @@ impl ZipKernel for Primitive {
         mask: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        let Some(if_false) = if_false.as_opt::<Primitive>() else {
+        let Some(if_false) = if_false.as_typed::<Primitive>() else {
             return Ok(None);
         };
 

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -11,6 +11,7 @@ use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::array::Array;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::arrays::fixed_width::vtable as fixed_width;
 use crate::arrays::primitive::PrimitiveData;
@@ -197,7 +198,7 @@ impl VTable for Primitive {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -12,6 +12,7 @@ use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::array::Array;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::arrays::primitive::PrimitiveData;
 use crate::buffer::BufferHandle;
@@ -226,7 +227,7 @@ impl VTable for Primitive {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/scalar_fn/array.rs
+++ b/vortex-array/src/arrays/scalar_fn/array.rs
@@ -31,6 +31,11 @@ impl Display for ScalarFnData {
 }
 
 impl ScalarFnData {
+    /// Create a new ScalarFnArray from a scalar function and its children.
+    fn build(scalar_fn: ScalarFnRef) -> Self {
+        Self { scalar_fn }
+    }
+
     /// Get the scalar function bound to this array.
     #[inline(always)]
     pub fn scalar_fn(&self) -> &ScalarFnRef {
@@ -44,13 +49,13 @@ pub trait ScalarFnArrayExt: TypedArrayRef<ScalarFn> {
     }
 
     fn child_at(&self, idx: usize) -> &ArrayRef {
-        self.as_ref().slots()[idx]
+        self.slots()[idx]
             .as_ref()
             .vortex_expect("ScalarFnArray child slot")
     }
 
     fn child_count(&self) -> usize {
-        self.as_ref().slots().len()
+        self.slots().len()
     }
 
     fn nchildren(&self) -> usize {
@@ -87,19 +92,28 @@ impl Array<ScalarFn> {
         children: Vec<ArrayRef>,
         len: usize,
     ) -> VortexResult<Self> {
+        Ok(unsafe { Array::from_parts_unchecked(Self::try_new_parts(scalar_fn, children, len)?) })
+    }
+
+    /// Build the [`ArrayParts`] for a ScalarFnArray without materializing it.
+    ///
+    /// Mirrors [`try_new`](Self::try_new) but stops short of allocating the backing
+    /// `ArrayRef`, so callers can drive the parts through [`ArrayParts::optimize`] and
+    /// only pay the wrapper allocation when no reduction fires.
+    #[inline]
+    pub fn try_new_parts(
+        scalar_fn: ScalarFnRef,
+        children: Vec<ArrayRef>,
+        len: usize,
+    ) -> VortexResult<ArrayParts<ScalarFn>> {
         Self::validate_children_len(&children, len)?;
         let arg_dtypes: Vec<_> = children.iter().map(|c| c.dtype().clone()).collect();
         let dtype = scalar_fn.return_dtype(&arg_dtypes)?;
-        let data = ScalarFnData {
-            scalar_fn: scalar_fn.clone(),
-        };
-        let vtable = ScalarFn { id: scalar_fn.id() };
-        Ok(unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(vtable, dtype, len, data)
-                    .with_slots(children.into_iter().map(Some).collect::<ArraySlots>()),
-            )
-        })
+        let id = scalar_fn.id();
+        let data = ScalarFnData::build(scalar_fn);
+        let vtable = ScalarFn { id };
+        Ok(ArrayParts::new(vtable, dtype, len, data)
+            .with_slots(children.into_iter().map(Some).collect::<ArraySlots>()))
     }
 
     fn infer_len(children: &[ArrayRef]) -> VortexResult<usize> {

--- a/vortex-array/src/arrays/scalar_fn/array.rs
+++ b/vortex-array/src/arrays/scalar_fn/array.rs
@@ -31,6 +31,11 @@ impl Display for ScalarFnData {
 }
 
 impl ScalarFnData {
+    /// Create a new ScalarFnArray from a scalar function and its children.
+    fn build(scalar_fn: ScalarFnRef) -> Self {
+        Self { scalar_fn }
+    }
+
     /// Get the scalar function bound to this array.
     #[allow(clippy::inline_always)]
     #[inline(always)]
@@ -45,13 +50,13 @@ pub trait ScalarFnArrayExt: TypedArrayRef<ScalarFn> {
     }
 
     fn child_at(&self, idx: usize) -> &ArrayRef {
-        self.as_ref().slots()[idx]
+        self.slots()[idx]
             .as_ref()
             .vortex_expect("ScalarFnArray child slot")
     }
 
     fn child_count(&self) -> usize {
-        self.as_ref().slots().len()
+        self.slots().len()
     }
 
     fn nchildren(&self) -> usize {
@@ -88,22 +93,30 @@ impl Array<ScalarFn> {
         children: Vec<ArrayRef>,
         len: usize,
     ) -> VortexResult<Self> {
+        Ok(unsafe { Array::from_parts_unchecked(Self::try_new_parts(scalar_fn, children, len)?) })
+    }
+
+    /// Build the [`ArrayParts`] for a ScalarFnArray without materializing it.
+    ///
+    /// Mirrors [`try_new`](Self::try_new) but stops short of allocating the backing
+    /// `ArrayRef`, so callers can drive the parts through [`ArrayParts::optimize`] and
+    /// only pay the wrapper allocation when no reduction fires.
+    #[inline]
+    pub fn try_new_parts(
+        scalar_fn: ScalarFnRef,
+        children: Vec<ArrayRef>,
+        len: usize,
+    ) -> VortexResult<ArrayParts<ScalarFn>> {
         Self::validate_arity(&scalar_fn, children.len())?;
         Self::validate_children_len(&children, len)?;
 
         let arg_dtypes: Vec<_> = children.iter().map(|c| c.dtype().clone()).collect();
         let dtype = scalar_fn.return_dtype(&arg_dtypes)?;
-        let data = ScalarFnData {
-            scalar_fn: scalar_fn.clone(),
-        };
-        let vtable = ScalarFn { id: scalar_fn.id() };
-
-        Ok(unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(vtable, dtype, len, data)
-                    .with_slots(children.into_iter().map(Some).collect::<ArraySlots>()),
-            )
-        })
+        let id = scalar_fn.id();
+        let data = ScalarFnData::build(scalar_fn);
+        let vtable = ScalarFn { id };
+        Ok(ArrayParts::new(vtable, dtype, len, data)
+            .with_slots(children.into_iter().map(Some).collect::<ArraySlots>()))
     }
 
     fn infer_len(children: &[ArrayRef]) -> VortexResult<usize> {

--- a/vortex-array/src/arrays/scalar_fn/rules.rs
+++ b/vortex-array/src/arrays/scalar_fn/rules.rs
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
 use std::sync::Arc;
 
 use itertools::Itertools;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_error::vortex_panic;
 
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrays::Filter;
@@ -20,6 +21,7 @@ use crate::arrays::Slice;
 use crate::arrays::StructArray;
 use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::dtype::DType;
+use crate::expr::ExpressionReduceNode;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::optimizer::rules::ArrayReduceRule;
 use crate::optimizer::rules::ParentRuleSet;
@@ -43,8 +45,8 @@ pub(super) const PARENT_RULES: ParentRuleSet<ScalarFn> = ParentRuleSet::new(&[
 #[derive(Debug)]
 struct ScalarFnPackToStructRule;
 impl ArrayReduceRule<ScalarFn> for ScalarFnPackToStructRule {
-    fn reduce(&self, array: ArrayView<'_, ScalarFn>) -> VortexResult<Option<ArrayRef>> {
-        let Some(pack_options) = array.scalar_fn().as_opt::<Pack>() else {
+    fn reduce(&self, array: ParentView<'_, ScalarFn>) -> VortexResult<Option<ArrayRef>> {
+        let Some(pack_options) = ScalarFnArrayExt::scalar_fn(&array).as_opt::<Pack>() else {
             return Ok(None);
         };
 
@@ -73,7 +75,7 @@ impl ArrayParentReduceRule<ScalarFn> for ScalarFnSliceReduceRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, ScalarFn>,
-        parent: ArrayView<'_, Slice>,
+        parent: ParentView<'_, Slice>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         let range = parent.slice_range();
@@ -84,8 +86,12 @@ impl ArrayParentReduceRule<ScalarFn> for ScalarFnSliceReduceRule {
             .collect::<VortexResult<_>>()?;
 
         Ok(Some(
-            ScalarFnArray::try_new_with_len(array.scalar_fn().clone(), children, range.len())?
-                .into_array(),
+            ScalarFnArray::try_new_with_len(
+                ScalarFnArrayExt::scalar_fn(&array).clone(),
+                children,
+                range.len(),
+            )?
+            .into_array(),
         ))
     }
 }
@@ -93,26 +99,49 @@ impl ArrayParentReduceRule<ScalarFn> for ScalarFnSliceReduceRule {
 #[derive(Debug)]
 struct ScalarFnAbstractReduceRule;
 impl ArrayReduceRule<ScalarFn> for ScalarFnAbstractReduceRule {
-    fn reduce(&self, array: ArrayView<'_, ScalarFn>) -> VortexResult<Option<ArrayRef>> {
-        if let Some(reduced) = array
-            .scalar_fn()
-            .reduce(array.as_ref(), &ArrayReduceCtx { len: array.len() })?
+    fn reduce(&self, array: ParentView<'_, ScalarFn>) -> VortexResult<Option<ArrayRef>> {
+        if let Some(reduced) = ScalarFnArrayExt::scalar_fn(&array)
+            .reduce(&array, &ArrayReduceCtx { len: array.len() })?
         {
-            return Ok(Some(
-                reduced
-                    .as_any()
-                    .downcast_ref::<ArrayRef>()
-                    .vortex_expect("ReduceNode is not an ArrayRef")
-                    .clone(),
-            ));
+            return Ok(Some(reduced.as_array()));
         }
         Ok(None)
     }
 }
 
+impl ReduceNode for ParentView<'_, ScalarFn> {
+    fn as_array(&self) -> ArrayRef {
+        self.materialize_array_ref().clone()
+    }
+
+    fn as_expression(&self) -> ExpressionReduceNode {
+        vortex_panic!("Cannot convert ArrayView to ExpressionReduceNode")
+    }
+
+    fn node_dtype(&self) -> VortexResult<DType> {
+        Ok(self.dtype().clone())
+    }
+
+    fn scalar_fn(&self) -> Option<&ScalarFnRef> {
+        Some(ScalarFnArrayExt::scalar_fn(self))
+    }
+
+    fn child(&self, idx: usize) -> ReduceNodeRef {
+        Arc::new(self.child_at(idx).clone())
+    }
+
+    fn child_count(&self) -> usize {
+        ScalarFnArrayExt::nchildren(self)
+    }
+}
+
 impl ReduceNode for ArrayRef {
-    fn as_any(&self) -> &dyn Any {
-        self
+    fn as_array(&self) -> ArrayRef {
+        self.clone()
+    }
+
+    fn as_expression(&self) -> ExpressionReduceNode {
+        vortex_panic!("Cannot convert ArrayRef to ExpressionReduceNode")
     }
 
     fn node_dtype(&self) -> VortexResult<DType> {
@@ -124,7 +153,11 @@ impl ReduceNode for ArrayRef {
     }
 
     fn child(&self, idx: usize) -> ReduceNodeRef {
-        Arc::new(self.nth_child(idx).vortex_expect("child idx out of bounds"))
+        Arc::new(
+            self.nth_child(idx)
+                .vortex_expect("child idx out of bounds")
+                .clone(),
+        )
     }
 
     fn child_count(&self) -> usize {
@@ -145,15 +178,7 @@ impl ReduceCtx for ArrayReduceCtx {
         Ok(Arc::new(
             ScalarFnArray::try_new_with_len(
                 scalar_fn,
-                children
-                    .iter()
-                    .map(|c| {
-                        c.as_any()
-                            .downcast_ref::<ArrayRef>()
-                            .vortex_expect("ReduceNode is not an ArrayRef")
-                            .clone()
-                    })
-                    .collect(),
+                children.iter().map(|c| c.as_array()).collect(),
                 self.len,
             )?
             .into_array(),
@@ -170,7 +195,7 @@ impl ArrayParentReduceRule<ScalarFn> for ScalarFnUnaryFilterPushDownRule {
     fn reduce_parent(
         &self,
         child: ArrayView<'_, ScalarFn>,
-        parent: ArrayView<'_, Filter>,
+        parent: ParentView<'_, Filter>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         // If we only have one non-constant child, then it is _always_ cheaper to push down the
@@ -191,8 +216,12 @@ impl ArrayParentReduceRule<ScalarFn> for ScalarFnUnaryFilterPushDownRule {
                 })
                 .try_collect()?;
 
-            let new_array =
-                ScalarFnArray::try_new(child.scalar_fn().clone(), new_children)?.into_array();
+            let new_array = ScalarFnArray::try_new_with_len(
+                ScalarFnArrayExt::scalar_fn(&child).clone(),
+                new_children,
+                parent.len(),
+            )?
+            .into_array();
 
             return Ok(Some(new_array));
         }

--- a/vortex-array/src/arrays/scalar_fn/rules.rs
+++ b/vortex-array/src/arrays/scalar_fn/rules.rs
@@ -91,7 +91,7 @@ impl ArrayParentReduceRule<ScalarFn> for ScalarFnSliceReduceRule {
 struct ScalarFnAbstractReduceRule;
 impl ArrayReduceRule<ScalarFn> for ScalarFnAbstractReduceRule {
     fn reduce(&self, array: ParentView<'_, ScalarFn>) -> VortexResult<Option<ArrayRef>> {
-        let node = ArrayReduceNode::new(array.materialize_array_ref());
+        let node = ArrayReduceNode::from_parent(array);
         if let Some(reduced) = array.scalar_fn().reduce_array(&node)? {
             return Ok(Some(reduced.into_array()));
         }

--- a/vortex-array/src/arrays/scalar_fn/rules.rs
+++ b/vortex-array/src/arrays/scalar_fn/rules.rs
@@ -7,6 +7,7 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrays::Filter;
@@ -35,8 +36,8 @@ pub(super) const PARENT_RULES: ParentRuleSet<ScalarFn> = ParentRuleSet::new(&[
 #[derive(Debug)]
 struct ScalarFnPackToStructRule;
 impl ArrayReduceRule<ScalarFn> for ScalarFnPackToStructRule {
-    fn reduce(&self, array: ArrayView<'_, ScalarFn>) -> VortexResult<Option<ArrayRef>> {
-        let Some(pack_options) = array.scalar_fn().as_opt::<Pack>() else {
+    fn reduce(&self, array: ParentView<'_, ScalarFn>) -> VortexResult<Option<ArrayRef>> {
+        let Some(pack_options) = ScalarFnArrayExt::scalar_fn(&array).as_opt::<Pack>() else {
             return Ok(None);
         };
 
@@ -65,7 +66,7 @@ impl ArrayParentReduceRule<ScalarFn> for ScalarFnSliceReduceRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, ScalarFn>,
-        parent: ArrayView<'_, Slice>,
+        parent: ParentView<'_, Slice>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         let range = parent.slice_range();
@@ -76,8 +77,12 @@ impl ArrayParentReduceRule<ScalarFn> for ScalarFnSliceReduceRule {
             .collect::<VortexResult<_>>()?;
 
         Ok(Some(
-            ScalarFnArray::try_new_with_len(array.scalar_fn().clone(), children, range.len())?
-                .into_array(),
+            ScalarFnArray::try_new_with_len(
+                ScalarFnArrayExt::scalar_fn(&array).clone(),
+                children,
+                range.len(),
+            )?
+            .into_array(),
         ))
     }
 }
@@ -85,8 +90,8 @@ impl ArrayParentReduceRule<ScalarFn> for ScalarFnSliceReduceRule {
 #[derive(Debug)]
 struct ScalarFnAbstractReduceRule;
 impl ArrayReduceRule<ScalarFn> for ScalarFnAbstractReduceRule {
-    fn reduce(&self, array: ArrayView<'_, ScalarFn>) -> VortexResult<Option<ArrayRef>> {
-        let node = ArrayReduceNode::new(array.as_ref());
+    fn reduce(&self, array: ParentView<'_, ScalarFn>) -> VortexResult<Option<ArrayRef>> {
+        let node = ArrayReduceNode::new(array.materialize_array_ref());
         if let Some(reduced) = array.scalar_fn().reduce_array(&node)? {
             return Ok(Some(reduced.into_array()));
         }
@@ -103,7 +108,7 @@ impl ArrayParentReduceRule<ScalarFn> for ScalarFnUnaryFilterPushDownRule {
     fn reduce_parent(
         &self,
         child: ArrayView<'_, ScalarFn>,
-        parent: ArrayView<'_, Filter>,
+        parent: ParentView<'_, Filter>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         // If we only have one non-constant child, then it is _always_ cheaper to push down the
@@ -124,8 +129,12 @@ impl ArrayParentReduceRule<ScalarFn> for ScalarFnUnaryFilterPushDownRule {
                 })
                 .try_collect()?;
 
-            let new_array =
-                ScalarFnArray::try_new(child.scalar_fn().clone(), new_children)?.into_array();
+            let new_array = ScalarFnArray::try_new_with_len(
+                ScalarFnArrayExt::scalar_fn(&child).clone(),
+                new_children,
+                parent.len(),
+            )?
+            .into_array();
 
             return Ok(Some(new_array));
         }

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -10,6 +10,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 
 use itertools::Itertools;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
@@ -25,6 +26,8 @@ use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
+use crate::array::ParentView;
 use crate::array::VTable;
 use crate::array::with_empty_buffers;
 use crate::arrays::scalar_fn::array::ScalarFnArrayExt;
@@ -37,6 +40,7 @@ use crate::executor::ExecutionCtx;
 use crate::executor::ExecutionResult;
 use crate::expr::Expression;
 use crate::expr::display::ExprDisplay;
+use crate::matcher::AsParent;
 use crate::matcher::Matcher;
 use crate::scalar_fn;
 use crate::scalar_fn::Arity;
@@ -175,31 +179,61 @@ impl VTable for ScalarFn {
             .map(ExecutionResult::done)
     }
 
-    fn reduce(array: ArrayView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
+    fn reduce(array: ParentView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array)
     }
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)
     }
 }
 
+/// Array factory functions for scalar functions.
+pub trait ScalarFnFactoryExt: scalar_fn::ScalarFnVTable {
+    /// Build the [`ArrayParts<ScalarFn>`] for this scalar function applied to `children`.
+    ///
+    /// Stops short of allocating the backing `ArrayRef`, so callers can drive the parts
+    /// through [`ArrayParts::optimize`] and only pay the wrapper allocation when no
+    /// reduction fires.
+    #[inline]
+    fn try_new_array_parts(
+        &self,
+        len: usize,
+        options: Self::Options,
+        children: impl Into<Vec<ArrayRef>>,
+    ) -> VortexResult<ArrayParts<ScalarFn>> {
+        let scalar_fn = scalar_fn::TypedScalarFnInstance::new(self.clone(), options).erased();
+        Array::<ScalarFn>::try_new_parts(scalar_fn, children.into(), len)
+    }
+
+    /// Build a materialized scalar-function array for this scalar function applied to
+    /// `children`. Equivalent to [`try_new_array_parts`](Self::try_new_array_parts) followed
+    /// by [`ArrayParts::into_array`].
+    fn try_new_array(
+        &self,
+        len: usize,
+        options: Self::Options,
+        children: impl Into<Vec<ArrayRef>>,
+    ) -> VortexResult<ArrayRef> {
+        Ok(self
+            .try_new_array_parts(len, options, children)?
+            .into_array())
+    }
+}
+impl<V: scalar_fn::ScalarFnVTable> ScalarFnFactoryExt for V {}
+
 /// A matcher that matches any scalar function expression.
 #[derive(Debug)]
 pub struct AnyScalarFn;
 impl Matcher for AnyScalarFn {
-    type Match<'a> = ArrayView<'a, ScalarFn>;
+    type Match<'a> = ParentView<'a, ScalarFn>;
 
-    fn matches(array: &ArrayRef) -> bool {
-        array.is::<ScalarFn>()
-    }
-
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        array.as_opt::<ScalarFn>()
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        parent.as_opt::<ScalarFn>()
     }
 }
 
@@ -207,40 +241,102 @@ impl Matcher for AnyScalarFn {
 #[derive(Debug, Default)]
 pub struct ExactScalarFn<F: scalar_fn::ScalarFnVTable>(PhantomData<F>);
 
-impl<F: scalar_fn::ScalarFnVTable> Matcher for ExactScalarFn<F> {
-    type Match<'a> = ScalarFnArrayView<'a, F>;
-
-    fn matches(array: &ArrayRef) -> bool {
-        if let Some(scalar_fn_array) = array.as_opt::<ScalarFn>() {
-            scalar_fn_array.data().scalar_fn().is::<F>()
-        } else {
-            false
-        }
-    }
-
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        let scalar_fn_array = array.as_opt::<ScalarFn>()?;
-        let scalar_fn_data = scalar_fn_array.data();
-        let scalar_fn = scalar_fn_data.scalar_fn().downcast_ref::<F>()?;
+impl<F: scalar_fn::ScalarFnVTable> ExactScalarFn<F> {
+    #[inline]
+    fn from_view(view: ParentView<'_, ScalarFn>) -> Option<ScalarFnArrayView<'_, F>> {
+        let scalar_fn = view.data().scalar_fn().downcast_ref::<F>()?;
         Some(ScalarFnArrayView {
-            array,
+            view,
             vtable: scalar_fn.vtable(),
             options: scalar_fn.options(),
         })
     }
 }
 
+impl<F: scalar_fn::ScalarFnVTable> Matcher for ExactScalarFn<F> {
+    type Match<'a> = ScalarFnArrayView<'a, F>;
+
+    /// Skip the `ParentView` + `ScalarFnArrayView` construction that the default
+    /// `try_match(...).is_some()` would do. Two cheap downcasts suffice: encoding
+    /// id, then scalar function id.
+    fn matches<P: AsParent>(parent: &P) -> bool {
+        parent
+            .typed_data::<ScalarFn>()
+            .is_some_and(|data| data.scalar_fn().is::<F>())
+    }
+
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        Self::from_view(parent.as_opt::<ScalarFn>()?)
+    }
+}
+
+/// A typed view over a [`ScalarFn`] array exposing the concrete `F`-typed `vtable`
+/// and `options`.
+///
+/// Wraps a [`ParentView<'_, ScalarFn>`], so the view works for heap arrays and
+/// stack-allocated construction parts alike. It does not expose implicit `ArrayRef`
+/// access; callers must explicitly materialize the underlying parent view if they
+/// need an owned array.
 pub struct ScalarFnArrayView<'a, F: scalar_fn::ScalarFnVTable> {
-    array: &'a ArrayRef,
+    view: ParentView<'a, ScalarFn>,
     pub vtable: &'a F,
     pub options: &'a F::Options,
 }
 
-impl<F: scalar_fn::ScalarFnVTable> Deref for ScalarFnArrayView<'_, F> {
-    type Target = ArrayRef;
+impl<'a, F: scalar_fn::ScalarFnVTable> ScalarFnArrayView<'a, F> {
+    /// Returns the underlying [`ScalarFn`]-typed parent view.
+    #[inline]
+    pub fn view(&self) -> ParentView<'a, ScalarFn> {
+        self.view
+    }
 
-    fn deref(&self) -> &Self::Target {
-        self.array
+    /// Returns the child array at the given slot.
+    ///
+    /// Reads from `slots()` directly without forcing stack-backed parents to
+    /// materialize.
+    pub fn child_at(&self, idx: usize) -> &ArrayRef {
+        self.view.slots()[idx]
+            .as_ref()
+            .vortex_expect("ScalarFnArray child slot")
+    }
+
+    /// Alias for [`Self::child_at`].
+    #[inline]
+    pub fn get_child(&self, idx: usize) -> &ArrayRef {
+        self.child_at(idx)
+    }
+
+    /// Returns the number of child slots.
+    #[inline]
+    pub fn child_count(&self) -> usize {
+        self.view.slots().len()
+    }
+
+    /// Iterates over the array's children.
+    pub fn iter_children(&self) -> impl Iterator<Item = &ArrayRef> + '_ {
+        (0..self.child_count()).map(|idx| self.child_at(idx))
+    }
+
+    /// Collects the children into a `Vec` of cloned `ArrayRef`s.
+    pub fn children(&self) -> Vec<ArrayRef> {
+        self.iter_children().cloned().collect()
+    }
+}
+
+impl<F: scalar_fn::ScalarFnVTable> Copy for ScalarFnArrayView<'_, F> {}
+
+impl<F: scalar_fn::ScalarFnVTable> Clone for ScalarFnArrayView<'_, F> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, F: scalar_fn::ScalarFnVTable> Deref for ScalarFnArrayView<'a, F> {
+    type Target = ParentView<'a, ScalarFn>;
+
+    #[inline]
+    fn deref(&self) -> &ParentView<'a, ScalarFn> {
+        &self.view
     }
 }
 

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -10,6 +10,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 
 use itertools::Itertools;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
@@ -20,13 +21,13 @@ use vortex_session::registry::CachedId;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
-use crate::ArraySlots;
 use crate::EqMode;
-use crate::IntoArray;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
+use crate::array::ParentView;
 use crate::array::VTable;
 use crate::array::with_empty_buffers;
 use crate::arrays::scalar_fn::array::ScalarFnArrayExt;
@@ -38,6 +39,7 @@ use crate::dtype::DType;
 use crate::executor::ExecutionCtx;
 use crate::executor::ExecutionResult;
 use crate::expr::Expression;
+use crate::matcher::AsParent;
 use crate::matcher::Matcher;
 use crate::scalar_fn;
 use crate::scalar_fn::Arity;
@@ -162,13 +164,13 @@ impl VTable for ScalarFn {
             .map(ExecutionResult::done)
     }
 
-    fn reduce(array: ArrayView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
+    fn reduce(array: ParentView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array)
     }
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)
@@ -177,34 +179,34 @@ impl VTable for ScalarFn {
 
 /// Array factory functions for scalar functions.
 pub trait ScalarFnFactoryExt: scalar_fn::ScalarFnVTable {
+    /// Build the [`ArrayParts<ScalarFn>`] for this scalar function applied to `children`.
+    ///
+    /// Stops short of allocating the backing `ArrayRef`, so callers can drive the parts
+    /// through [`ArrayParts::optimize`] and only pay the wrapper allocation when no
+    /// reduction fires.
+    #[inline]
+    fn try_new_array_parts(
+        &self,
+        len: usize,
+        options: Self::Options,
+        children: impl Into<Vec<ArrayRef>>,
+    ) -> VortexResult<ArrayParts<ScalarFn>> {
+        let scalar_fn = scalar_fn::TypedScalarFnInstance::new(self.clone(), options).erased();
+        Array::<ScalarFn>::try_new_parts(scalar_fn, children.into(), len)
+    }
+
+    /// Build a materialized scalar-function array for this scalar function applied to
+    /// `children`. Equivalent to [`try_new_array_parts`](Self::try_new_array_parts) followed
+    /// by [`ArrayParts::into_array`].
     fn try_new_array(
         &self,
         len: usize,
         options: Self::Options,
         children: impl Into<Vec<ArrayRef>>,
     ) -> VortexResult<ArrayRef> {
-        let scalar_fn = scalar_fn::TypedScalarFnInstance::new(self.clone(), options).erased();
-
-        let children = children.into();
-        vortex_ensure!(
-            children.iter().all(|c| c.len() == len),
-            "All child arrays must have the same length as the scalar function array"
-        );
-
-        let child_dtypes = children.iter().map(|c| c.dtype().clone()).collect_vec();
-        let dtype = scalar_fn.return_dtype(&child_dtypes)?;
-
-        let data = ScalarFnData {
-            scalar_fn: scalar_fn.clone(),
-        };
-        let vtable = ScalarFn { id: scalar_fn.id() };
-        Ok(unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(vtable, dtype, len, data)
-                    .with_slots(children.into_iter().map(Some).collect::<ArraySlots>()),
-            )
-        }
-        .into_array())
+        Ok(self
+            .try_new_array_parts(len, options, children)?
+            .into_array())
     }
 }
 impl<V: scalar_fn::ScalarFnVTable> ScalarFnFactoryExt for V {}
@@ -213,14 +215,10 @@ impl<V: scalar_fn::ScalarFnVTable> ScalarFnFactoryExt for V {}
 #[derive(Debug)]
 pub struct AnyScalarFn;
 impl Matcher for AnyScalarFn {
-    type Match<'a> = ArrayView<'a, ScalarFn>;
+    type Match<'a> = ParentView<'a, ScalarFn>;
 
-    fn matches(array: &ArrayRef) -> bool {
-        array.is::<ScalarFn>()
-    }
-
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        array.as_opt::<ScalarFn>()
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        parent.as_opt::<ScalarFn>()
     }
 }
 
@@ -228,40 +226,102 @@ impl Matcher for AnyScalarFn {
 #[derive(Debug, Default)]
 pub struct ExactScalarFn<F: scalar_fn::ScalarFnVTable>(PhantomData<F>);
 
-impl<F: scalar_fn::ScalarFnVTable> Matcher for ExactScalarFn<F> {
-    type Match<'a> = ScalarFnArrayView<'a, F>;
-
-    fn matches(array: &ArrayRef) -> bool {
-        if let Some(scalar_fn_array) = array.as_opt::<ScalarFn>() {
-            scalar_fn_array.data().scalar_fn().is::<F>()
-        } else {
-            false
-        }
-    }
-
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        let scalar_fn_array = array.as_opt::<ScalarFn>()?;
-        let scalar_fn_data = scalar_fn_array.data();
-        let scalar_fn = scalar_fn_data.scalar_fn().downcast_ref::<F>()?;
+impl<F: scalar_fn::ScalarFnVTable> ExactScalarFn<F> {
+    #[inline]
+    fn from_view(view: ParentView<'_, ScalarFn>) -> Option<ScalarFnArrayView<'_, F>> {
+        let scalar_fn = view.data().scalar_fn().downcast_ref::<F>()?;
         Some(ScalarFnArrayView {
-            array,
+            view,
             vtable: scalar_fn.vtable(),
             options: scalar_fn.options(),
         })
     }
 }
 
+impl<F: scalar_fn::ScalarFnVTable> Matcher for ExactScalarFn<F> {
+    type Match<'a> = ScalarFnArrayView<'a, F>;
+
+    /// Skip the `ParentView` + `ScalarFnArrayView` construction that the default
+    /// `try_match(...).is_some()` would do. Two cheap downcasts suffice: encoding
+    /// id, then scalar function id.
+    fn matches<P: AsParent>(parent: &P) -> bool {
+        parent
+            .typed_data::<ScalarFn>()
+            .is_some_and(|data| data.scalar_fn().is::<F>())
+    }
+
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        Self::from_view(parent.as_opt::<ScalarFn>()?)
+    }
+}
+
+/// A typed view over a [`ScalarFn`] array exposing the concrete `F`-typed `vtable`
+/// and `options`.
+///
+/// Wraps a [`ParentView<'_, ScalarFn>`], so the view works for heap arrays and
+/// stack-allocated construction parts alike. It does not expose implicit `ArrayRef`
+/// access; callers must explicitly materialize the underlying parent view if they
+/// need an owned array.
 pub struct ScalarFnArrayView<'a, F: scalar_fn::ScalarFnVTable> {
-    array: &'a ArrayRef,
+    view: ParentView<'a, ScalarFn>,
     pub vtable: &'a F,
     pub options: &'a F::Options,
 }
 
-impl<F: scalar_fn::ScalarFnVTable> Deref for ScalarFnArrayView<'_, F> {
-    type Target = ArrayRef;
+impl<'a, F: scalar_fn::ScalarFnVTable> ScalarFnArrayView<'a, F> {
+    /// Returns the underlying [`ScalarFn`]-typed parent view.
+    #[inline]
+    pub fn view(&self) -> ParentView<'a, ScalarFn> {
+        self.view
+    }
 
-    fn deref(&self) -> &Self::Target {
-        self.array
+    /// Returns the child array at the given slot.
+    ///
+    /// Reads from `slots()` directly without forcing stack-backed parents to
+    /// materialize.
+    pub fn child_at(&self, idx: usize) -> &ArrayRef {
+        self.view.slots()[idx]
+            .as_ref()
+            .vortex_expect("ScalarFnArray child slot")
+    }
+
+    /// Alias for [`Self::child_at`].
+    #[inline]
+    pub fn get_child(&self, idx: usize) -> &ArrayRef {
+        self.child_at(idx)
+    }
+
+    /// Returns the number of child slots.
+    #[inline]
+    pub fn child_count(&self) -> usize {
+        self.view.slots().len()
+    }
+
+    /// Iterates over the array's children.
+    pub fn iter_children(&self) -> impl Iterator<Item = &ArrayRef> + '_ {
+        (0..self.child_count()).map(|idx| self.child_at(idx))
+    }
+
+    /// Collects the children into a `Vec` of cloned `ArrayRef`s.
+    pub fn children(&self) -> Vec<ArrayRef> {
+        self.iter_children().cloned().collect()
+    }
+}
+
+impl<F: scalar_fn::ScalarFnVTable> Copy for ScalarFnArrayView<'_, F> {}
+
+impl<F: scalar_fn::ScalarFnVTable> Clone for ScalarFnArrayView<'_, F> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, F: scalar_fn::ScalarFnVTable> Deref for ScalarFnArrayView<'a, F> {
+    type Target = ParentView<'a, ScalarFn>;
+
+    #[inline]
+    fn deref(&self) -> &ParentView<'a, ScalarFn> {
+        &self.view
     }
 }
 

--- a/vortex-array/src/arrays/shared/vtable.rs
+++ b/vortex-array/src/arrays/shared/vtable.rs
@@ -54,6 +54,7 @@ impl VTable for Shared {
     type TypedArrayData = SharedData;
     type OperationsVTable = Self;
     type ValidityVTable = Self;
+
     fn id(&self) -> ArrayId {
         static ID: CachedId = CachedId::new("vortex.shared");
         *ID

--- a/vortex-array/src/arrays/slice/array.rs
+++ b/vortex-array/src/arrays/slice/array.rs
@@ -75,15 +75,7 @@ impl SliceData {
 impl Array<Slice> {
     /// Constructs a new `SliceArray`.
     pub fn try_new(child: ArrayRef, range: Range<usize>) -> VortexResult<Self> {
-        let len = range.len();
-        let dtype = child.dtype().clone();
-        let data = SliceData::try_new(child.len(), range)?;
-        Ok(unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(Slice, dtype, len, data)
-                    .with_slots(SliceSlots { child }.into_slots()),
-            )
-        })
+        Ok(unsafe { Array::from_parts_unchecked(Self::try_new_parts(child, range)?) })
     }
 
     /// Constructs a new `SliceArray`.
@@ -97,5 +89,15 @@ impl Array<Slice> {
                     .with_slots(SliceSlots { child }.into_slots()),
             )
         }
+    }
+
+    /// Builds the [`ArrayParts<Slice>`] for a slice. The parts can then be
+    /// optimized through [`ArrayParts::optimize`](crate::array::ArrayParts::optimize)
+    /// or materialized directly with [`ArrayParts::into_array`].
+    pub fn try_new_parts(child: ArrayRef, range: Range<usize>) -> VortexResult<ArrayParts<Slice>> {
+        let len = range.len();
+        let dtype = child.dtype().clone();
+        let data = SliceData::try_new(child.len(), range)?;
+        Ok(ArrayParts::new(Slice, dtype, len, data).with_slots(SliceSlots { child }.into_slots()))
     }
 }

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -25,6 +25,7 @@ use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::ValidityVTable;
 use crate::array::with_empty_buffers;
@@ -64,6 +65,7 @@ impl VTable for Slice {
     type TypedArrayData = SliceData;
     type OperationsVTable = Self;
     type ValidityVTable = Self;
+
     fn id(&self) -> ArrayId {
         static ID: CachedId = CachedId::new("vortex.slice");
         *ID
@@ -162,7 +164,7 @@ impl VTable for Slice {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -203,14 +203,14 @@ pub(super) fn make_struct_slots(
 /// [`StructArraySlotsExt`] supertrait; this trait layers struct-specific lookups on top.
 pub trait StructArrayExt: StructArraySlotsExt {
     fn nullability(&self) -> crate::dtype::Nullability {
-        match self.as_ref().dtype() {
+        match self.dtype() {
             DType::Struct(_, nullability) => *nullability,
             _ => unreachable!("StructArrayExt requires a struct dtype"),
         }
     }
 
     fn names(&self) -> &FieldNames {
-        self.as_ref().dtype().as_struct_fields().names()
+        self.dtype().as_struct_fields().names()
     }
 
     fn struct_validity(&self) -> Validity {
@@ -258,7 +258,7 @@ pub trait StructArrayExt: StructArraySlotsExt {
     }
 
     fn struct_fields(&self) -> &StructFields {
-        self.as_ref().dtype().as_struct_fields()
+        self.dtype().as_struct_fields()
     }
 }
 impl<T: TypedArrayRef<Struct>> StructArrayExt for T {}
@@ -409,7 +409,7 @@ impl Array<Struct> {
             FieldNames::from(names.as_slice()),
             children,
             self.len(),
-            self.validity()?,
+            self.struct_validity(),
         )
     }
 
@@ -479,7 +479,7 @@ impl Array<Struct> {
 
         let children = self.iter_unmasked_fields().cloned().chain(once(array));
 
-        Self::try_new_with_dtype(children, new_fields, self.len(), self.validity()?)
+        Self::try_new_with_dtype(children, new_fields, self.len(), self.struct_validity())
     }
 
     pub fn remove_column_owned(&self, name: impl Into<FieldName>) -> Option<(Self, ArrayRef)> {

--- a/vortex-array/src/arrays/struct_/compute/rules.rs
+++ b/vortex-array/src/arrays/struct_/compute/rules.rs
@@ -6,6 +6,7 @@ use vortex_error::vortex_err;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::ParentRef;
 use crate::array::ArrayView;
 use crate::arrays::ConstantArray;
 use crate::arrays::Struct;
@@ -17,7 +18,6 @@ use crate::arrays::slice::SliceReduceAdaptor;
 use crate::arrays::struct_::StructArrayExt;
 use crate::arrays::struct_::compute::cast::struct_cast_fields;
 use crate::builtins::ArrayBuiltins;
-use crate::matcher::Matcher;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar::Scalar;
@@ -35,13 +35,13 @@ pub(crate) const PARENT_RULES: ParentRuleSet<Struct> = ParentRuleSet::new(&[
 
 pub(crate) fn struct_cast_reduce_parent(
     child: &ArrayRef,
-    parent: &ArrayRef,
+    parent: &ParentRef<'_>,
     _child_idx: usize,
 ) -> VortexResult<Option<ArrayRef>> {
-    let Some(array) = child.as_opt::<Struct>() else {
+    let Some(array) = child.as_typed::<Struct>() else {
         return Ok(None);
     };
-    let Some(parent) = ExactScalarFn::<Cast>::try_match(parent) else {
+    let Some(parent) = parent.as_opt::<ExactScalarFn<Cast>>() else {
         return Ok(None);
     };
 
@@ -135,6 +135,7 @@ mod tests {
 
     use crate::ArrayRef;
     use crate::IntoArray;
+    use crate::ParentRef;
     use crate::array::ArrayPlugin;
     use crate::arrays::ScalarFn;
     use crate::arrays::Struct;
@@ -157,11 +158,12 @@ mod tests {
     use crate::scalar_fn::ScalarFnVTable;
     use crate::scalar_fn::fns::cast::Cast;
     use crate::validity::Validity;
+
     static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     fn no_struct_cast_plugin(
         _child: &ArrayRef,
-        _parent: &ArrayRef,
+        _parent: &ParentRef<'_>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         Ok(None)

--- a/vortex-array/src/arrays/struct_/compute/zip.rs
+++ b/vortex-array/src/arrays/struct_/compute/zip.rs
@@ -25,7 +25,7 @@ impl ZipKernel for Struct {
         mask: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        let Some(if_false) = if_false.as_opt::<Struct>() else {
+        let Some(if_false) = if_false.as_typed::<Struct>() else {
             return Ok(None);
         };
         assert_eq!(

--- a/vortex-array/src/arrays/struct_/vtable/mod.rs
+++ b/vortex-array/src/arrays/struct_/vtable/mod.rs
@@ -14,6 +14,7 @@ use crate::array::Array;
 use crate::array::ArrayParts;
 use crate::array::ArrayView;
 use crate::array::EmptyArrayData;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::child_to_validity;
 use crate::array::with_empty_buffers;
@@ -46,6 +47,7 @@ impl VTable for Struct {
 
     type OperationsVTable = Self;
     type ValidityVTable = Self;
+
     fn id(&self) -> ArrayId {
         static ID: CachedId = CachedId::new("vortex.struct");
         *ID
@@ -212,7 +214,7 @@ impl VTable for Struct {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/union/array.rs
+++ b/vortex-array/src/arrays/union/array.rs
@@ -74,7 +74,7 @@ pub struct UnionDataParts {
 pub trait UnionArrayExt: UnionArraySlotsExt {
     /// The union's variant schema.
     fn variants(&self) -> &UnionVariants {
-        match self.as_ref().dtype() {
+        match self.dtype() {
             DType::Union(variants, _) => variants,
             _ => unreachable!("UnionArrayExt requires a union dtype"),
         }

--- a/vortex-array/src/arrays/union/array.rs
+++ b/vortex-array/src/arrays/union/array.rs
@@ -71,7 +71,7 @@ pub struct UnionDataParts {
 pub trait UnionArrayExt: UnionArraySlotsExt {
     /// The union's variant schema.
     fn variants(&self) -> &UnionVariants {
-        match self.as_ref().dtype() {
+        match self.dtype() {
             DType::Union(variants, _) => variants,
             _ => unreachable!("UnionArrayExt requires a union dtype"),
         }

--- a/vortex-array/src/arrays/union/tests.rs
+++ b/vortex-array/src/arrays/union/tests.rs
@@ -262,7 +262,9 @@ fn serde_roundtrip() -> VortexResult<()> {
         assert_eq!(decoded.variants(), array.variants());
         for index in 0..len {
             assert_eq!(
-                decoded.array().execute_scalar(index, &mut execution_ctx)?,
+                decoded
+                    .materialize_array_ref()
+                    .execute_scalar(index, &mut execution_ctx)?,
                 array.execute_scalar(index, &mut execution_ctx)?
             );
         }

--- a/vortex-array/src/arrays/union/tests/mod.rs
+++ b/vortex-array/src/arrays/union/tests/mod.rs
@@ -330,7 +330,9 @@ fn serde_roundtrip() -> VortexResult<()> {
         assert_eq!(decoded.variants(), array.variants());
         for index in 0..len {
             assert_eq!(
-                decoded.array().execute_scalar(index, &mut execution_ctx)?,
+                decoded
+                    .materialize_array_ref()
+                    .execute_scalar(index, &mut execution_ctx)?,
                 array.execute_scalar(index, &mut execution_ctx)?
             );
         }

--- a/vortex-array/src/arrays/union/tests/take.rs
+++ b/vortex-array/src/arrays/union/tests/take.rs
@@ -147,10 +147,11 @@ fn take_from_empty_union_is_all_null() -> VortexResult<()> {
         .take(indices.clone())?
         .execute::<Canonical>(&mut array_session().create_execution_ctx())?
         .into_union();
-    let via_reduce = <Union as TakeReduce>::take(empty.as_::<Union>(), &indices)?
-        .ok_or_else(|| vortex_err!("Union take must never decline"))?
-        .as_::<Union>()
-        .into_owned();
+    let via_reduce =
+        <Union as TakeReduce>::take(empty.as_::<Union>().materialize_view(), &indices)?
+            .ok_or_else(|| vortex_err!("Union take must never decline"))?
+            .as_::<Union>()
+            .into_owned();
 
     let expected = || vec![Scalar::null(DType::Union(variants.clone(), nullability)); 2];
 

--- a/vortex-array/src/arrays/union/vtable/mod.rs
+++ b/vortex-array/src/arrays/union/vtable/mod.rs
@@ -18,6 +18,7 @@ use crate::array::ArrayId;
 use crate::array::ArrayParts;
 use crate::array::ArrayView;
 use crate::array::EmptyArrayData;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::with_empty_buffers;
 use crate::arrays::union::UnionArrayExt;
@@ -169,7 +170,7 @@ impl VTable for Union {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/varbin/array.rs
+++ b/vortex-array/src/arrays/varbin/array.rs
@@ -311,7 +311,7 @@ impl VarBinData {
 
 pub trait VarBinArrayExt: VarBinArraySlotsExt {
     fn dtype_parts(&self) -> (bool, Nullability) {
-        match self.as_ref().dtype() {
+        match self.dtype() {
             DType::Utf8(nullability) => (true, *nullability),
             DType::Binary(nullability) => (false, *nullability),
             _ => unreachable!("VarBinArrayExt requires a utf8 or binary dtype"),
@@ -328,7 +328,7 @@ pub trait VarBinArrayExt: VarBinArraySlotsExt {
 
     fn varbin_validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[VarBinSlots::VALIDITY].as_ref(),
+            self.slots()[VarBinSlots::VALIDITY].as_ref(),
             self.nullability(),
         )
     }
@@ -336,9 +336,9 @@ pub trait VarBinArrayExt: VarBinArraySlotsExt {
     #[allow(clippy::disallowed_methods)]
     fn offset_at(&self, index: usize) -> usize {
         assert!(
-            index <= self.as_ref().len(),
+            index <= self.len(),
             "Index {index} out of bounds 0..={}",
-            self.as_ref().len()
+            self.len()
         );
 
         (&self
@@ -357,7 +357,7 @@ pub trait VarBinArrayExt: VarBinArraySlotsExt {
 
     fn sliced_bytes(&self) -> ByteBuffer {
         let first_offset: usize = self.offset_at(0);
-        let last_offset = self.offset_at(self.as_ref().len());
+        let last_offset = self.offset_at(self.len());
         self.bytes().slice(first_offset..last_offset)
     }
 }

--- a/vortex-array/src/arrays/varbin/compute/take.rs
+++ b/vortex-array/src/arrays/varbin/compute/take.rs
@@ -241,7 +241,8 @@ pub fn take_varbin(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<VarBinArray> {
     if let Some(piecewise_indices) = indices.as_opt::<PiecewiseSequence>()
-        && let Some(taken) = take_contiguous_ranges(array, piecewise_indices, indices, ctx)?
+        && let Some(taken) =
+            take_contiguous_ranges(array, piecewise_indices.materialize_view(), indices, ctx)?
     {
         return Ok(taken);
     }

--- a/vortex-array/src/arrays/varbin/compute/take.rs
+++ b/vortex-array/src/arrays/varbin/compute/take.rs
@@ -55,7 +55,8 @@ impl TakeExecute for VarBin {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         if let Some(piecewise_indices) = indices.as_opt::<PiecewiseSequence>()
-            && let Some(taken) = take_contiguous_ranges(array, piecewise_indices, indices, ctx)?
+            && let Some(taken) =
+                take_contiguous_ranges(array, piecewise_indices.materialize_view(), indices, ctx)?
         {
             return Ok(Some(taken));
         }

--- a/vortex-array/src/arrays/varbin/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbin/vtable/mod.rs
@@ -19,6 +19,7 @@ use crate::IntoArray;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::varbin::VarBinArrayExt;
@@ -78,6 +79,7 @@ impl VTable for VarBin {
 
     type OperationsVTable = Self;
     type ValidityVTable = Self;
+
     fn id(&self) -> ArrayId {
         static ID: CachedId = CachedId::new("vortex.varbin");
         *ID
@@ -202,7 +204,7 @@ impl VTable for VarBin {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/varbin/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbin/vtable/mod.rs
@@ -19,6 +19,7 @@ use crate::IntoArray;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::arrays::varbin::VarBinArraySlotsExt;
 use crate::arrays::varbin::VarBinData;
@@ -74,6 +75,7 @@ impl VTable for VarBin {
 
     type OperationsVTable = Self;
     type ValidityVTable = Self;
+
     fn id(&self) -> ArrayId {
         static ID: CachedId = CachedId::new("vortex.varbin");
         *ID
@@ -198,7 +200,7 @@ impl VTable for VarBin {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/varbinview/array.rs
+++ b/vortex-array/src/arrays/varbinview/array.rs
@@ -561,7 +561,7 @@ impl VarBinViewData {
 
 pub trait VarBinViewArrayExt: TypedArrayRef<VarBinView> {
     fn dtype_parts(&self) -> (bool, Nullability) {
-        match self.as_ref().dtype() {
+        match self.dtype() {
             DType::Utf8(nullability) => (true, *nullability),
             DType::Binary(nullability) => (false, *nullability),
             _ => unreachable!("VarBinViewArrayExt requires a utf8 or binary dtype"),
@@ -570,7 +570,7 @@ pub trait VarBinViewArrayExt: TypedArrayRef<VarBinView> {
 
     fn varbinview_validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[VarBinViewSlots::VALIDITY].as_ref(),
+            self.slots()[VarBinViewSlots::VALIDITY].as_ref(),
             self.dtype_parts().1,
         )
     }

--- a/vortex-array/src/arrays/varbinview/array.rs
+++ b/vortex-array/src/arrays/varbinview/array.rs
@@ -656,7 +656,7 @@ impl VarBinViewData {
 
 pub trait VarBinViewArrayExt: TypedArrayRef<VarBinView> {
     fn dtype_parts(&self) -> (bool, Nullability) {
-        match self.as_ref().dtype() {
+        match self.dtype() {
             DType::Utf8(nullability) => (true, *nullability),
             DType::Binary(nullability) => (false, *nullability),
             _ => unreachable!("VarBinViewArrayExt requires a utf8 or binary dtype"),
@@ -665,7 +665,7 @@ pub trait VarBinViewArrayExt: TypedArrayRef<VarBinView> {
 
     fn varbinview_validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[VarBinViewSlots::VALIDITY].as_ref(),
+            self.slots()[VarBinViewSlots::VALIDITY].as_ref(),
             self.dtype_parts().1,
         )
     }

--- a/vortex-array/src/arrays/varbinview/compact.rs
+++ b/vortex-array/src/arrays/varbinview/compact.rs
@@ -71,11 +71,7 @@ impl VarBinViewArray {
     where
         F: FnMut(&Ref),
     {
-        match self
-            .as_ref()
-            .validity()?
-            .execute_mask(self.as_ref().len(), ctx)?
-        {
+        match self.validity()?.execute_mask(self.len(), ctx)? {
             Mask::AllTrue(_) => {
                 for &view in self.views().iter() {
                     if !view.is_inlined() {

--- a/vortex-array/src/arrays/varbinview/compact.rs
+++ b/vortex-array/src/arrays/varbinview/compact.rs
@@ -70,11 +70,7 @@ impl VarBinViewArray {
     where
         F: FnMut(&Ref),
     {
-        match self
-            .as_ref()
-            .validity()?
-            .execute_mask(self.as_ref().len(), ctx)?
-        {
+        match self.validity()?.execute_mask(self.len(), ctx)? {
             Mask::AllTrue(_) => {
                 for &view in self.views().iter() {
                     if !view.is_inlined() {

--- a/vortex-array/src/arrays/varbinview/compute/take.rs
+++ b/vortex-array/src/arrays/varbinview/compute/take.rs
@@ -41,7 +41,8 @@ impl TakeExecute for VarBinView {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         if let Some(piecewise_indices) = indices.as_opt::<PiecewiseSequence>()
-            && let Some(taken) = take_contiguous_ranges(array, piecewise_indices, indices, ctx)?
+            && let Some(taken) =
+                take_contiguous_ranges(array, piecewise_indices.materialize_view(), indices, ctx)?
         {
             return Ok(Some(taken));
         }

--- a/vortex-array/src/arrays/varbinview/compute/zip.rs
+++ b/vortex-array/src/arrays/varbinview/compute/zip.rs
@@ -30,7 +30,7 @@ impl ZipKernel for VarBinView {
         mask: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        let Some(if_false) = if_false.as_opt::<VarBinView>() else {
+        let Some(if_false) = if_false.as_typed::<VarBinView>() else {
             return Ok(None);
         };
 

--- a/vortex-array/src/arrays/varbinview/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/mod.rs
@@ -23,6 +23,7 @@ use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::arrays::varbinview::BinaryView;
 use crate::arrays::varbinview::VarBinViewData;
@@ -237,7 +238,7 @@ impl VTable for VarBinView {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/varbinview/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/mod.rs
@@ -22,6 +22,7 @@ use crate::ExecutionResult;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::arrays::varbinview::BinaryView;
 use crate::arrays::varbinview::VarBinViewData;
@@ -235,7 +236,7 @@ impl VTable for VarBinView {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/arrays/variant/vtable/mod.rs
+++ b/vortex-array/src/arrays/variant/vtable/mod.rs
@@ -23,6 +23,7 @@ use crate::array::ArrayId;
 use crate::array::ArrayParts;
 use crate::array::ArrayView;
 use crate::array::EmptyArrayData;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::array::with_empty_buffers;
 use crate::arrays::variant::VariantSlots;
@@ -201,7 +202,7 @@ impl VTable for Variant {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)

--- a/vortex-array/src/builders/dict/bytes.rs
+++ b/vortex-array/src/builders/dict/bytes.rs
@@ -273,9 +273,9 @@ impl<Code: UnsignedPType> DictEncoder for BytesDictBuilder<Code> {
             self.dtype
         );
 
-        if let Some(varbinview) = array.as_opt::<VarBinView>() {
+        if let Some(varbinview) = array.as_typed::<VarBinView>() {
             self.encode_varbinview(varbinview, ctx)
-        } else if let Some(varbin) = array.as_opt::<VarBin>() {
+        } else if let Some(varbin) = array.as_typed::<VarBin>() {
             self.encode_varbin(varbin, ctx)
         } else {
             // NOTE(aduffy): it is very rare that this path would be taken, only e.g.

--- a/vortex-array/src/builders/map.rs
+++ b/vortex-array/src/builders/map.rs
@@ -103,7 +103,7 @@ impl<O: OffsetBuilderPType, S: OffsetBuilderPType> MapBuilder<O, S> {
             array.dtype()
         );
         self.entries_builder
-            .append_listview_array(array.entries().as_::<ListView>(), ctx)
+            .append_listview_array(array.entries().as_::<ListView>().materialize_view(), ctx)
     }
 }
 

--- a/vortex-array/src/builtins.rs
+++ b/vortex-array/src/builtins.rs
@@ -19,7 +19,6 @@ use crate::arrays::scalar_fn::ScalarFnFactoryExt;
 use crate::dtype::DType;
 use crate::dtype::FieldName;
 use crate::expr::Expression;
-use crate::optimizer::ArrayOptimizer;
 use crate::scalar::Scalar;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ScalarFnVTableExt;
@@ -173,8 +172,8 @@ impl ArrayBuiltins for ArrayRef {
         if self.dtype() == &dtype {
             return Ok(self.clone());
         }
-        Cast.try_new_array(self.len(), dtype, [self.clone()])?
-            .optimize()
+        let parts = Cast.try_new_array_parts(self.len(), dtype, [self.clone()])?;
+        parts.optimize()
     }
 
     fn fill_null(&self, fill_value: impl Into<Scalar>) -> VortexResult<ArrayRef> {
@@ -182,48 +181,46 @@ impl ArrayBuiltins for ArrayRef {
         if !self.dtype().is_nullable() {
             return self.cast(fill_value.dtype().clone());
         }
-        FillNull
-            .try_new_array(
-                self.len(),
-                EmptyOptions,
-                [
-                    self.clone(),
-                    ConstantArray::new(fill_value, self.len()).into_array(),
-                ],
-            )?
-            .optimize()
+        let parts = FillNull.try_new_array_parts(
+            self.len(),
+            EmptyOptions,
+            [
+                self.clone(),
+                ConstantArray::new(fill_value, self.len()).into_array(),
+            ],
+        )?;
+        parts.optimize()
     }
 
     fn get_item(&self, field_name: impl Into<FieldName>) -> VortexResult<ArrayRef> {
-        GetItem
-            .try_new_array(self.len(), field_name.into(), [self.clone()])?
-            .optimize()
+        let parts = GetItem.try_new_array_parts(self.len(), field_name.into(), [self.clone()])?;
+        parts.optimize()
     }
 
     fn is_null(&self) -> VortexResult<ArrayRef> {
-        IsNull
-            .try_new_array(self.len(), EmptyOptions, [self.clone()])?
-            .optimize()
+        let parts = IsNull.try_new_array_parts(self.len(), EmptyOptions, [self.clone()])?;
+        parts.optimize()
     }
 
     fn is_not_null(&self) -> VortexResult<ArrayRef> {
-        IsNotNull
-            .try_new_array(self.len(), EmptyOptions, [self.clone()])?
-            .optimize()
+        let parts = IsNotNull.try_new_array_parts(self.len(), EmptyOptions, [self.clone()])?;
+        parts.optimize()
     }
 
     fn mask(self, mask: ArrayRef) -> VortexResult<ArrayRef> {
-        Mask.try_new_array(self.len(), EmptyOptions, [self, mask])?
-            .optimize()
+        let parts = Mask.try_new_array_parts(self.len(), EmptyOptions, [self, mask])?;
+        parts.optimize()
     }
 
     fn not(&self) -> VortexResult<ArrayRef> {
-        Not.try_new_array(self.len(), EmptyOptions, [self.clone()])?
-            .optimize()
+        let parts = Not.try_new_array_parts(self.len(), EmptyOptions, [self.clone()])?;
+        parts.optimize()
     }
 
     fn zip(&self, if_true: ArrayRef, if_false: ArrayRef) -> VortexResult<ArrayRef> {
-        Zip.try_new_array(self.len(), EmptyOptions, [if_true, if_false, self.clone()])
+        let parts =
+            Zip.try_new_array_parts(self.len(), EmptyOptions, [if_true, if_false, self.clone()])?;
+        parts.optimize()
     }
 
     fn interleave(
@@ -238,15 +235,14 @@ impl ArrayBuiltins for ArrayRef {
     }
 
     fn list_contains(&self, value: ArrayRef) -> VortexResult<ArrayRef> {
-        ListContains
-            .try_new_array(self.len(), EmptyOptions, [self.clone(), value])?
-            .optimize()
+        let parts =
+            ListContains.try_new_array_parts(self.len(), EmptyOptions, [self.clone(), value])?;
+        parts.optimize()
     }
 
     fn binary(&self, rhs: ArrayRef, op: Operator) -> VortexResult<ArrayRef> {
-        Binary
-            .try_new_array(self.len(), op, [self.clone(), rhs])?
-            .optimize()
+        let parts = Binary.try_new_array_parts(self.len(), op, [self.clone(), rhs])?;
+        parts.optimize()
     }
 
     fn between(
@@ -255,8 +251,7 @@ impl ArrayBuiltins for ArrayRef {
         upper: ArrayRef,
         options: BetweenOptions,
     ) -> VortexResult<ArrayRef> {
-        Between
-            .try_new_array(self.len(), options, [self, lower, upper])?
-            .optimize()
+        let parts = Between.try_new_array_parts(self.len(), options, [self, lower, upper])?;
+        parts.optimize()
     }
 }

--- a/vortex-array/src/builtins.rs
+++ b/vortex-array/src/builtins.rs
@@ -15,10 +15,10 @@ use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::InterleaveArray;
+use crate::arrays::scalar_fn::ScalarFnFactoryExt;
 use crate::dtype::DType;
 use crate::dtype::FieldName;
 use crate::expr::Expression;
-use crate::optimizer::ArrayOptimizer;
 use crate::scalar::Scalar;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ScalarFnVTableExt;
@@ -172,7 +172,8 @@ impl ArrayBuiltins for ArrayRef {
         if self.dtype() == &dtype {
             return Ok(self.clone());
         }
-        Cast::new(self.clone(), dtype).into_array().optimize()
+        let parts = Cast.try_new_array_parts(self.len(), dtype, [self.clone()])?;
+        parts.optimize()
     }
 
     fn fill_null(&self, fill_value: impl Into<Scalar>) -> VortexResult<ArrayRef> {
@@ -180,38 +181,46 @@ impl ArrayBuiltins for ArrayRef {
         if !self.dtype().is_nullable() {
             return self.cast(fill_value.dtype().clone());
         }
-        FillNull::try_new(
-            self.clone(),
-            ConstantArray::new(fill_value, self.len()).into_array(),
-        )?
-        .into_array()
-        .optimize()
+        let parts = FillNull.try_new_array_parts(
+            self.len(),
+            EmptyOptions,
+            [
+                self.clone(),
+                ConstantArray::new(fill_value, self.len()).into_array(),
+            ],
+        )?;
+        parts.optimize()
     }
 
     fn get_item(&self, field_name: impl Into<FieldName>) -> VortexResult<ArrayRef> {
-        GetItem::try_new(self.clone(), field_name)?
-            .into_array()
-            .optimize()
+        let parts = GetItem.try_new_array_parts(self.len(), field_name.into(), [self.clone()])?;
+        parts.optimize()
     }
 
     fn is_null(&self) -> VortexResult<ArrayRef> {
-        IsNull::new(self.clone()).into_array().optimize()
+        let parts = IsNull.try_new_array_parts(self.len(), EmptyOptions, [self.clone()])?;
+        parts.optimize()
     }
 
     fn is_not_null(&self) -> VortexResult<ArrayRef> {
-        IsNotNull::new(self.clone()).into_array().optimize()
+        let parts = IsNotNull.try_new_array_parts(self.len(), EmptyOptions, [self.clone()])?;
+        parts.optimize()
     }
 
     fn mask(self, mask: ArrayRef) -> VortexResult<ArrayRef> {
-        Mask::try_new(self, mask)?.into_array().optimize()
+        let parts = Mask.try_new_array_parts(self.len(), EmptyOptions, [self, mask])?;
+        parts.optimize()
     }
 
     fn not(&self) -> VortexResult<ArrayRef> {
-        Not::try_new(self.clone())?.into_array().optimize()
+        let parts = Not.try_new_array_parts(self.len(), EmptyOptions, [self.clone()])?;
+        parts.optimize()
     }
 
     fn zip(&self, if_true: ArrayRef, if_false: ArrayRef) -> VortexResult<ArrayRef> {
-        Ok(Zip::try_new(if_true, if_false, self.clone())?.into_array())
+        let parts =
+            Zip.try_new_array_parts(self.len(), EmptyOptions, [if_true, if_false, self.clone()])?;
+        parts.optimize()
     }
 
     fn interleave(
@@ -226,15 +235,14 @@ impl ArrayBuiltins for ArrayRef {
     }
 
     fn list_contains(&self, value: ArrayRef) -> VortexResult<ArrayRef> {
-        ListContains::try_new(self.clone(), value)?
-            .into_array()
-            .optimize()
+        let parts =
+            ListContains.try_new_array_parts(self.len(), EmptyOptions, [self.clone(), value])?;
+        parts.optimize()
     }
 
     fn binary(&self, rhs: ArrayRef, op: Operator) -> VortexResult<ArrayRef> {
-        Binary::try_new(self.clone(), rhs, op)?
-            .into_array()
-            .optimize()
+        let parts = Binary.try_new_array_parts(self.len(), op, [self.clone(), rhs])?;
+        parts.optimize()
     }
 
     fn between(
@@ -243,8 +251,7 @@ impl ArrayBuiltins for ArrayRef {
         upper: ArrayRef,
         options: BetweenOptions,
     ) -> VortexResult<ArrayRef> {
-        Between::try_new(self, lower, upper, options)?
-            .into_array()
-            .optimize()
+        let parts = Between.try_new_array_parts(self.len(), options, [self, lower, upper])?;
+        parts.optimize()
     }
 }

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -17,7 +17,7 @@ use crate::ArraySlots;
 use crate::Executable;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::array::child_to_validity;
 use crate::arrays::Bool;
 use crate::arrays::BoolArray;
@@ -62,6 +62,7 @@ use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::match_each_decimal_value_type;
 use crate::match_each_native_ptype;
+use crate::matcher::AsParent;
 use crate::matcher::Matcher;
 use crate::validity::Validity;
 
@@ -1172,22 +1173,22 @@ impl Executable for VariantArray {
 
 /// A view into a canonical array type.
 ///
-/// Uses `ArrayView<V>` because these are obtained by
-/// downcasting through the `Matcher` trait which returns `ArrayView<V>`.
+/// Arms are [`ParentView`]s: matches borrow from the parent — a heap array or
+/// stack-allocated construction parts — and never hide a materialization.
 #[derive(Debug, Clone, Copy)]
 pub enum CanonicalView<'a> {
-    Null(ArrayView<'a, Null>),
-    Bool(ArrayView<'a, Bool>),
-    Primitive(ArrayView<'a, Primitive>),
-    Decimal(ArrayView<'a, Decimal>),
-    VarBinView(ArrayView<'a, VarBinView>),
-    List(ArrayView<'a, ListView>),
-    Map(ArrayView<'a, Map>),
-    FixedSizeList(ArrayView<'a, FixedSizeList>),
-    Struct(ArrayView<'a, Struct>),
-    Union(ArrayView<'a, Union>),
-    Extension(ArrayView<'a, Extension>),
-    Variant(ArrayView<'a, Variant>),
+    Null(ParentView<'a, Null>),
+    Bool(ParentView<'a, Bool>),
+    Primitive(ParentView<'a, Primitive>),
+    Decimal(ParentView<'a, Decimal>),
+    VarBinView(ParentView<'a, VarBinView>),
+    List(ParentView<'a, ListView>),
+    Map(ParentView<'a, Map>),
+    FixedSizeList(ParentView<'a, FixedSizeList>),
+    Struct(ParentView<'a, Struct>),
+    Union(ParentView<'a, Union>),
+    Extension(ParentView<'a, Extension>),
+    Variant(ParentView<'a, Variant>),
 }
 
 impl From<CanonicalView<'_>> for Canonical {
@@ -1210,21 +1211,22 @@ impl From<CanonicalView<'_>> for Canonical {
 }
 
 impl CanonicalView<'_> {
-    /// Convert to a type-erased [`ArrayRef`].
+    /// Convert to a type-erased [`ArrayRef`], explicitly materializing stack-backed
+    /// parents.
     pub fn to_array_ref(&self) -> ArrayRef {
         match self {
-            CanonicalView::Null(a) => a.array().clone(),
-            CanonicalView::Bool(a) => a.array().clone(),
-            CanonicalView::Primitive(a) => a.array().clone(),
-            CanonicalView::Decimal(a) => a.array().clone(),
-            CanonicalView::VarBinView(a) => a.array().clone(),
-            CanonicalView::List(a) => a.array().clone(),
-            CanonicalView::Map(a) => a.array().clone(),
-            CanonicalView::FixedSizeList(a) => a.array().clone(),
-            CanonicalView::Struct(a) => a.array().clone(),
-            CanonicalView::Union(a) => a.array().clone(),
-            CanonicalView::Extension(a) => a.array().clone(),
-            CanonicalView::Variant(a) => a.array().clone(),
+            CanonicalView::Null(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Bool(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Primitive(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Decimal(a) => a.materialize_array_ref().clone(),
+            CanonicalView::VarBinView(a) => a.materialize_array_ref().clone(),
+            CanonicalView::List(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Map(a) => a.materialize_array_ref().clone(),
+            CanonicalView::FixedSizeList(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Struct(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Union(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Extension(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Variant(a) => a.materialize_array_ref().clone(),
         }
     }
 }
@@ -1234,48 +1236,50 @@ pub struct AnyCanonical;
 impl Matcher for AnyCanonical {
     type Match<'a> = CanonicalView<'a>;
 
+    /// Fast encoding-id checks. This is the hot path for
+    /// [`ArrayRef::is_canonical`](crate::ArrayRef::is_canonical), so each canonical
+    /// encoding is checked via the cheap [`AsParent::is_encoding`] direct downcast.
     #[inline]
-    fn matches(array: &ArrayRef) -> bool {
-        array.is::<Null>()
-            || array.is::<Bool>()
-            || array.is::<Primitive>()
-            || array.is::<Decimal>()
-            || array.is::<Struct>()
-            || array.is::<Union>()
-            || array.is::<ListView>()
-            || array.is::<Map>()
-            || array.is::<FixedSizeList>()
-            || array.is::<VarBinView>()
-            || array.is::<Variant>()
-            || array.is::<Extension>()
+    fn matches<P: AsParent>(parent: &P) -> bool {
+        parent.is::<Null>()
+            || parent.is::<Bool>()
+            || parent.is::<Primitive>()
+            || parent.is::<Decimal>()
+            || parent.is::<Struct>()
+            || parent.is::<Union>()
+            || parent.is::<ListView>()
+            || parent.is::<Map>()
+            || parent.is::<FixedSizeList>()
+            || parent.is::<VarBinView>()
+            || parent.is::<Variant>()
+            || parent.is::<Extension>()
     }
 
-    #[inline]
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        if let Some(a) = array.as_opt::<Null>() {
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        if let Some(a) = parent.as_opt::<Null>() {
             Some(CanonicalView::Null(a))
-        } else if let Some(a) = array.as_opt::<Bool>() {
+        } else if let Some(a) = parent.as_opt::<Bool>() {
             Some(CanonicalView::Bool(a))
-        } else if let Some(a) = array.as_opt::<Primitive>() {
+        } else if let Some(a) = parent.as_opt::<Primitive>() {
             Some(CanonicalView::Primitive(a))
-        } else if let Some(a) = array.as_opt::<Decimal>() {
+        } else if let Some(a) = parent.as_opt::<Decimal>() {
             Some(CanonicalView::Decimal(a))
-        } else if let Some(a) = array.as_opt::<Struct>() {
+        } else if let Some(a) = parent.as_opt::<Struct>() {
             Some(CanonicalView::Struct(a))
-        } else if let Some(a) = array.as_opt::<Union>() {
+        } else if let Some(a) = parent.as_opt::<Union>() {
             Some(CanonicalView::Union(a))
-        } else if let Some(a) = array.as_opt::<ListView>() {
+        } else if let Some(a) = parent.as_opt::<ListView>() {
             Some(CanonicalView::List(a))
-        } else if let Some(a) = array.as_opt::<Map>() {
+        } else if let Some(a) = parent.as_opt::<Map>() {
             Some(CanonicalView::Map(a))
-        } else if let Some(a) = array.as_opt::<FixedSizeList>() {
+        } else if let Some(a) = parent.as_opt::<FixedSizeList>() {
             Some(CanonicalView::FixedSizeList(a))
-        } else if let Some(a) = array.as_opt::<VarBinView>() {
+        } else if let Some(a) = parent.as_opt::<VarBinView>() {
             Some(CanonicalView::VarBinView(a))
-        } else if let Some(a) = array.as_opt::<Variant>() {
+        } else if let Some(a) = parent.as_opt::<Variant>() {
             Some(CanonicalView::Variant(a))
         } else {
-            array.as_opt::<Extension>().map(CanonicalView::Extension)
+            parent.as_opt::<Extension>().map(CanonicalView::Extension)
         }
     }
 }

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -17,7 +17,7 @@ use crate::ArraySlots;
 use crate::Executable;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::array::child_to_validity;
 use crate::arrays::Bool;
 use crate::arrays::BoolArray;
@@ -58,6 +58,7 @@ use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::match_each_decimal_value_type;
 use crate::match_each_native_ptype;
+use crate::matcher::AsParent;
 use crate::matcher::Matcher;
 use crate::validity::Validity;
 
@@ -1091,21 +1092,21 @@ impl Executable for VariantArray {
 
 /// A view into a canonical array type.
 ///
-/// Uses `ArrayView<V>` because these are obtained by
-/// downcasting through the `Matcher` trait which returns `ArrayView<V>`.
+/// Arms are [`ParentView`]s: matches borrow from the parent — a heap array or
+/// stack-allocated construction parts — and never hide a materialization.
 #[derive(Debug, Clone, Copy)]
 pub enum CanonicalView<'a> {
-    Null(ArrayView<'a, Null>),
-    Bool(ArrayView<'a, Bool>),
-    Primitive(ArrayView<'a, Primitive>),
-    Decimal(ArrayView<'a, Decimal>),
-    VarBinView(ArrayView<'a, VarBinView>),
-    List(ArrayView<'a, ListView>),
-    FixedSizeList(ArrayView<'a, FixedSizeList>),
-    Struct(ArrayView<'a, Struct>),
-    Union(ArrayView<'a, Union>),
-    Extension(ArrayView<'a, Extension>),
-    Variant(ArrayView<'a, Variant>),
+    Null(ParentView<'a, Null>),
+    Bool(ParentView<'a, Bool>),
+    Primitive(ParentView<'a, Primitive>),
+    Decimal(ParentView<'a, Decimal>),
+    VarBinView(ParentView<'a, VarBinView>),
+    List(ParentView<'a, ListView>),
+    FixedSizeList(ParentView<'a, FixedSizeList>),
+    Struct(ParentView<'a, Struct>),
+    Union(ParentView<'a, Union>),
+    Extension(ParentView<'a, Extension>),
+    Variant(ParentView<'a, Variant>),
 }
 
 impl From<CanonicalView<'_>> for Canonical {
@@ -1127,20 +1128,21 @@ impl From<CanonicalView<'_>> for Canonical {
 }
 
 impl CanonicalView<'_> {
-    /// Convert to a type-erased [`ArrayRef`].
+    /// Convert to a type-erased [`ArrayRef`], explicitly materializing stack-backed
+    /// parents.
     pub fn to_array_ref(&self) -> ArrayRef {
         match self {
-            CanonicalView::Null(a) => a.array().clone(),
-            CanonicalView::Bool(a) => a.array().clone(),
-            CanonicalView::Primitive(a) => a.array().clone(),
-            CanonicalView::Decimal(a) => a.array().clone(),
-            CanonicalView::VarBinView(a) => a.array().clone(),
-            CanonicalView::List(a) => a.array().clone(),
-            CanonicalView::FixedSizeList(a) => a.array().clone(),
-            CanonicalView::Struct(a) => a.array().clone(),
-            CanonicalView::Union(a) => a.array().clone(),
-            CanonicalView::Extension(a) => a.array().clone(),
-            CanonicalView::Variant(a) => a.array().clone(),
+            CanonicalView::Null(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Bool(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Primitive(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Decimal(a) => a.materialize_array_ref().clone(),
+            CanonicalView::VarBinView(a) => a.materialize_array_ref().clone(),
+            CanonicalView::List(a) => a.materialize_array_ref().clone(),
+            CanonicalView::FixedSizeList(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Struct(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Union(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Extension(a) => a.materialize_array_ref().clone(),
+            CanonicalView::Variant(a) => a.materialize_array_ref().clone(),
         }
     }
 }
@@ -1150,45 +1152,47 @@ pub struct AnyCanonical;
 impl Matcher for AnyCanonical {
     type Match<'a> = CanonicalView<'a>;
 
+    /// Fast encoding-id checks. This is the hot path for
+    /// [`ArrayRef::is_canonical`](crate::ArrayRef::is_canonical), so each canonical
+    /// encoding is checked via the cheap [`AsParent::is_encoding`] direct downcast.
     #[inline]
-    fn matches(array: &ArrayRef) -> bool {
-        array.is::<Null>()
-            || array.is::<Bool>()
-            || array.is::<Primitive>()
-            || array.is::<Decimal>()
-            || array.is::<Struct>()
-            || array.is::<Union>()
-            || array.is::<ListView>()
-            || array.is::<FixedSizeList>()
-            || array.is::<VarBinView>()
-            || array.is::<Variant>()
-            || array.is::<Extension>()
+    fn matches<P: AsParent>(parent: &P) -> bool {
+        parent.is::<Null>()
+            || parent.is::<Bool>()
+            || parent.is::<Primitive>()
+            || parent.is::<Decimal>()
+            || parent.is::<Struct>()
+            || parent.is::<Union>()
+            || parent.is::<ListView>()
+            || parent.is::<FixedSizeList>()
+            || parent.is::<VarBinView>()
+            || parent.is::<Variant>()
+            || parent.is::<Extension>()
     }
 
-    #[inline]
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        if let Some(a) = array.as_opt::<Null>() {
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        if let Some(a) = parent.as_opt::<Null>() {
             Some(CanonicalView::Null(a))
-        } else if let Some(a) = array.as_opt::<Bool>() {
+        } else if let Some(a) = parent.as_opt::<Bool>() {
             Some(CanonicalView::Bool(a))
-        } else if let Some(a) = array.as_opt::<Primitive>() {
+        } else if let Some(a) = parent.as_opt::<Primitive>() {
             Some(CanonicalView::Primitive(a))
-        } else if let Some(a) = array.as_opt::<Decimal>() {
+        } else if let Some(a) = parent.as_opt::<Decimal>() {
             Some(CanonicalView::Decimal(a))
-        } else if let Some(a) = array.as_opt::<Struct>() {
+        } else if let Some(a) = parent.as_opt::<Struct>() {
             Some(CanonicalView::Struct(a))
-        } else if let Some(a) = array.as_opt::<Union>() {
+        } else if let Some(a) = parent.as_opt::<Union>() {
             Some(CanonicalView::Union(a))
-        } else if let Some(a) = array.as_opt::<ListView>() {
+        } else if let Some(a) = parent.as_opt::<ListView>() {
             Some(CanonicalView::List(a))
-        } else if let Some(a) = array.as_opt::<FixedSizeList>() {
+        } else if let Some(a) = parent.as_opt::<FixedSizeList>() {
             Some(CanonicalView::FixedSizeList(a))
-        } else if let Some(a) = array.as_opt::<VarBinView>() {
+        } else if let Some(a) = parent.as_opt::<VarBinView>() {
             Some(CanonicalView::VarBinView(a))
-        } else if let Some(a) = array.as_opt::<Variant>() {
+        } else if let Some(a) = parent.as_opt::<Variant>() {
             Some(CanonicalView::Variant(a))
         } else {
-            array.as_opt::<Extension>().map(CanonicalView::Extension)
+            parent.as_opt::<Extension>().map(CanonicalView::Extension)
         }
     }
 }

--- a/vortex-array/src/columnar.rs
+++ b/vortex-array/src/columnar.rs
@@ -11,10 +11,11 @@ use crate::CanonicalView;
 use crate::Executable;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::array::ArrayView;
+use crate::array::ParentView;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::dtype::DType;
+use crate::matcher::AsParent;
 use crate::matcher::Matcher;
 use crate::scalar::Scalar;
 
@@ -86,18 +87,25 @@ impl Executable for Columnar {
 
 pub enum ColumnarView<'a> {
     Canonical(CanonicalView<'a>),
-    Constant(ArrayView<'a, Constant>),
+    Constant(ParentView<'a, Constant>),
 }
 
 pub struct AnyColumnar;
 impl Matcher for AnyColumnar {
     type Match<'a> = ColumnarView<'a>;
 
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        if let Some(constant) = array.as_opt::<Constant>() {
+    /// Fast encoding-id checks. Mirror of
+    /// [`AnyCanonical::matches`](crate::AnyCanonical) for the same reason.
+    #[inline]
+    fn matches<P: AsParent>(parent: &P) -> bool {
+        parent.is::<Constant>() || parent.is::<AnyCanonical>()
+    }
+
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        if let Some(constant) = parent.as_opt::<Constant>() {
             Some(ColumnarView::Constant(constant))
         } else {
-            array.as_opt::<AnyCanonical>().map(ColumnarView::Canonical)
+            parent.as_opt::<AnyCanonical>().map(ColumnarView::Canonical)
         }
     }
 }

--- a/vortex-array/src/display/extractors/encoding_summary.rs
+++ b/vortex-array/src/display/extractors/encoding_summary.rs
@@ -4,8 +4,10 @@
 use std::fmt;
 
 use crate::ArrayRef;
+use crate::array::ArrayId;
 use crate::display::extractor::TreeContext;
 use crate::display::extractor::TreeExtractor;
+use crate::dtype::DType;
 
 /// Extractor that adds the encoding summary (e.g. `vortex.primitive(i16, len=5)`) to the header.
 pub struct EncodingSummaryExtractor;
@@ -13,13 +15,22 @@ pub struct EncodingSummaryExtractor;
 impl EncodingSummaryExtractor {
     /// Write the encoding summary for an array directly to a formatter.
     pub fn write(array: &ArrayRef, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}({}, len={})",
-            array.encoding_id(),
-            array.dtype(),
-            array.len()
-        )
+        Self::write_parts(array.encoding_id(), array.dtype(), array.len(), f)
+    }
+
+    /// Write the encoding summary from its constituent parts.
+    ///
+    /// Callers that hold a parent's metadata without an [`ArrayRef`] — a
+    /// [`ParentRef`](crate::array::ParentRef) borrowing construction parts, or a captured
+    /// summary — use this to render the same `vortex.primitive(i16, len=5)` form as every
+    /// other array print.
+    pub fn write_parts(
+        encoding_id: ArrayId,
+        dtype: &DType,
+        len: usize,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        write!(f, "{encoding_id}({dtype}, len={len})")
     }
 }
 

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -35,6 +35,7 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::IntoArray;
 use crate::array::ArrayId;
+use crate::array::ParentRef;
 use crate::builders::ArrayBuilder;
 use crate::builders::builder_with_capacity_in;
 use crate::dtype::DType;
@@ -188,10 +189,10 @@ impl ArrayRef {
 
             let is_done = stack
                 .last()
-                .map_or(M::matches as DonePredicate, |frame| frame.done);
+                .map_or(M::matches::<ArrayRef> as DonePredicate, |frame| frame.done);
 
             let done_target = is_done(&current_array);
-            let done_canonical = AnyCanonical::matches(&current_array);
+            let done_canonical = current_array.is::<AnyCanonical>();
             trace_op!(record_execute_until_done_check(done_target, done_canonical));
 
             if done_target || done_canonical {
@@ -476,9 +477,17 @@ impl Executable for ArrayRef {
         }
         trace_op!(record_single_step_phase_none("reduce", &array));
 
+        let parent_ref = ParentRef::from_array_ref(&array);
         for (slot_idx, slot) in array.slots().iter().enumerate() {
             let Some(child) = slot else { continue };
-            if let Some(reduced_parent) = child.reduce_parent(&array, slot_idx)? {
+            if let Some(reduced_parent) = child.reduce_parent(&parent_ref, slot_idx)? {
+                ctx.log(format_args!(
+                    "reduce_parent: slot[{}]({}) rewrote {} -> {}",
+                    slot_idx,
+                    child.encoding_id(),
+                    array,
+                    reduced_parent
+                ));
                 reduced_parent.statistics().inherit_from(array.statistics());
                 trace_op!(record_single_step_applied(
                     "reduce_parent",
@@ -788,8 +797,8 @@ impl ExecutionResult {
     pub fn execute_slot<M: Matcher>(array: impl IntoArray, slot_idx: usize) -> Self {
         let array = array.into_array();
         Self {
-            array,
-            step: ExecutionStep::ExecuteSlot(slot_idx, M::matches),
+            array: array.into_array(),
+            step: ExecutionStep::ExecuteSlot(slot_idx, M::matches::<ArrayRef>),
         }
     }
 

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -481,13 +481,14 @@ impl Executable for ArrayRef {
         for (slot_idx, slot) in array.slots().iter().enumerate() {
             let Some(child) = slot else { continue };
             if let Some(reduced_parent) = child.reduce_parent(&parent_ref, slot_idx)? {
-                ctx.log(format_args!(
-                    "reduce_parent: slot[{}]({}) rewrote {} -> {}",
+                log_parent_rewrite(
+                    ctx,
+                    "reduce_parent",
                     slot_idx,
-                    child.encoding_id(),
-                    array,
-                    reduced_parent
-                ));
+                    &parent_ref,
+                    child,
+                    &reduced_parent,
+                );
                 reduced_parent.statistics().inherit_from(array.statistics());
                 trace_op!(record_single_step_applied(
                     "reduce_parent",
@@ -512,13 +513,6 @@ impl Executable for ArrayRef {
                 kernels,
                 ctx,
             )? {
-                ctx.log(format_args!(
-                    "execute_parent: slot[{}]({}) rewrote {} -> {}",
-                    slot_idx,
-                    child.encoding_id(),
-                    array,
-                    executed_parent
-                ));
                 executed_parent
                     .statistics()
                     .inherit_from(array.statistics());
@@ -631,7 +625,7 @@ fn finalize_done(
 }
 
 fn execute_parent_for_child(
-    _phase: &'static str,
+    phase: &'static str,
     parent: &ArrayRef,
     child: &ArrayRef,
     slot_idx: usize,
@@ -653,8 +647,9 @@ fn execute_parent_for_child(
                         "Executed parent canonical dtype mismatch"
                     );
                 }
+                log_parent_rewrite(ctx, phase, slot_idx, parent, child, &result);
                 trace_op!(record_session_execute_parent_applied(
-                    _phase,
+                    phase,
                     parent,
                     child,
                     slot_idx,
@@ -664,7 +659,7 @@ fn execute_parent_for_child(
                 return Ok(Some(result));
             }
             trace_op!(record_session_execute_parent_declined(
-                _phase,
+                phase,
                 parent,
                 child,
                 slot_idx,
@@ -674,6 +669,24 @@ fn execute_parent_for_child(
     }
 
     Ok(None)
+}
+
+/// Log a parent rewrite to the execution log.
+///
+/// `parent` is taken as `impl Display` so a rewrite driven from a [`ParentRef`] logs its
+/// encoding summary without materializing the borrowed construction parts.
+fn log_parent_rewrite(
+    ctx: &mut ExecutionCtx,
+    phase: &'static str,
+    slot_idx: usize,
+    parent: &impl Display,
+    child: &ArrayRef,
+    output: &ArrayRef,
+) {
+    ctx.log(format_args!(
+        "{phase}: slot[{slot_idx}]({}) rewrote {parent} -> {output}",
+        child.encoding_id(),
+    ));
 }
 
 /// Try execute_parent on each occupied slot of the array.
@@ -687,13 +700,6 @@ fn try_execute_parent(
         if let Some(executed_parent) =
             execute_parent_for_child("child_execute_parent", array, child, slot_idx, kernels, ctx)?
         {
-            ctx.log(format_args!(
-                "execute_parent: slot[{}]({}) rewrote {} -> {}",
-                slot_idx,
-                child.encoding_id(),
-                array,
-                executed_parent
-            ));
             executed_parent
                 .statistics()
                 .inherit_from(array.statistics());
@@ -795,7 +801,6 @@ impl ExecutionResult {
     ///
     /// The provided array is the (possibly modified) parent that still needs its slot executed.
     pub fn execute_slot<M: Matcher>(array: impl IntoArray, slot_idx: usize) -> Self {
-        let array = array.into_array();
         Self {
             array: array.into_array(),
             step: ExecutionStep::ExecuteSlot(slot_idx, M::matches::<ArrayRef>),

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -471,13 +471,14 @@ impl Executable for ArrayRef {
         for (slot_idx, slot) in array.slots().iter().enumerate() {
             let Some(child) = slot else { continue };
             if let Some(reduced_parent) = child.reduce_parent(&parent_ref, slot_idx)? {
-                ctx.log(format_args!(
-                    "reduce_parent: slot[{}]({}) rewrote {} -> {}",
+                log_parent_rewrite(
+                    ctx,
+                    "reduce_parent",
                     slot_idx,
-                    child.encoding_id(),
-                    array,
-                    reduced_parent
-                ));
+                    &parent_ref,
+                    child,
+                    &reduced_parent,
+                );
                 reduced_parent.statistics().inherit_from(array.statistics());
                 trace_op!(record_single_step_applied(
                     "reduce_parent",
@@ -502,13 +503,6 @@ impl Executable for ArrayRef {
                 kernels,
                 ctx,
             )? {
-                ctx.log(format_args!(
-                    "execute_parent: slot[{}]({}) rewrote {} -> {}",
-                    slot_idx,
-                    child.encoding_id(),
-                    array,
-                    executed_parent
-                ));
                 executed_parent
                     .statistics()
                     .inherit_from(array.statistics());
@@ -620,7 +614,7 @@ fn finalize_done(
 }
 
 fn execute_parent_for_child(
-    _phase: &'static str,
+    phase: &'static str,
     parent: &ArrayRef,
     child: &ArrayRef,
     slot_idx: usize,
@@ -642,8 +636,9 @@ fn execute_parent_for_child(
                         "Executed parent canonical dtype mismatch"
                     );
                 }
+                log_parent_rewrite(ctx, phase, slot_idx, parent, child, &result);
                 trace_op!(record_session_execute_parent_applied(
-                    _phase,
+                    phase,
                     parent,
                     child,
                     slot_idx,
@@ -653,7 +648,7 @@ fn execute_parent_for_child(
                 return Ok(Some(result));
             }
             trace_op!(record_session_execute_parent_declined(
-                _phase,
+                phase,
                 parent,
                 child,
                 slot_idx,
@@ -663,6 +658,24 @@ fn execute_parent_for_child(
     }
 
     Ok(None)
+}
+
+/// Log a parent rewrite to the execution log.
+///
+/// `parent` is taken as `impl Display` so a rewrite driven from a [`ParentRef`] logs its
+/// encoding summary without materializing the borrowed construction parts.
+fn log_parent_rewrite(
+    ctx: &mut ExecutionCtx,
+    phase: &'static str,
+    slot_idx: usize,
+    parent: &impl Display,
+    child: &ArrayRef,
+    output: &ArrayRef,
+) {
+    ctx.log(format_args!(
+        "{phase}: slot[{slot_idx}]({}) rewrote {parent} -> {output}",
+        child.encoding_id(),
+    ));
 }
 
 /// Try execute_parent on each occupied slot of the array.
@@ -676,13 +689,6 @@ fn try_execute_parent(
         if let Some(executed_parent) =
             execute_parent_for_child("child_execute_parent", array, child, slot_idx, kernels, ctx)?
         {
-            ctx.log(format_args!(
-                "execute_parent: slot[{}]({}) rewrote {} -> {}",
-                slot_idx,
-                child.encoding_id(),
-                array,
-                executed_parent
-            ));
             executed_parent
                 .statistics()
                 .inherit_from(array.statistics());
@@ -784,7 +790,6 @@ impl ExecutionResult {
     ///
     /// The provided array is the (possibly modified) parent that still needs its slot executed.
     pub fn execute_slot<M: Matcher>(array: impl IntoArray, slot_idx: usize) -> Self {
-        let array = array.into_array();
         Self {
             array: array.into_array(),
             step: ExecutionStep::ExecuteSlot(slot_idx, M::matches::<ArrayRef>),

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -34,6 +34,7 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::IntoArray;
 use crate::array::ArrayId;
+use crate::array::ParentRef;
 use crate::builders::ArrayBuilder;
 use crate::builders::builder_with_capacity_in;
 use crate::dtype::DType;
@@ -187,10 +188,10 @@ impl ArrayRef {
 
             let is_done = stack
                 .last()
-                .map_or(M::matches as DonePredicate, |frame| frame.done);
+                .map_or(M::matches::<ArrayRef> as DonePredicate, |frame| frame.done);
 
             let done_target = is_done(&current_array);
-            let done_canonical = AnyCanonical::matches(&current_array);
+            let done_canonical = current_array.is::<AnyCanonical>();
             trace_op!(record_execute_until_done_check(done_target, done_canonical));
 
             if done_target || done_canonical {
@@ -466,9 +467,17 @@ impl Executable for ArrayRef {
         }
         trace_op!(record_single_step_phase_none("reduce", &array));
 
+        let parent_ref = ParentRef::from_array_ref(&array);
         for (slot_idx, slot) in array.slots().iter().enumerate() {
             let Some(child) = slot else { continue };
-            if let Some(reduced_parent) = child.reduce_parent(&array, slot_idx)? {
+            if let Some(reduced_parent) = child.reduce_parent(&parent_ref, slot_idx)? {
+                ctx.log(format_args!(
+                    "reduce_parent: slot[{}]({}) rewrote {} -> {}",
+                    slot_idx,
+                    child.encoding_id(),
+                    array,
+                    reduced_parent
+                ));
                 reduced_parent.statistics().inherit_from(array.statistics());
                 trace_op!(record_single_step_applied(
                     "reduce_parent",
@@ -777,8 +786,8 @@ impl ExecutionResult {
     pub fn execute_slot<M: Matcher>(array: impl IntoArray, slot_idx: usize) -> Self {
         let array = array.into_array();
         Self {
-            array,
-            step: ExecutionStep::ExecuteSlot(slot_idx, M::matches),
+            array: array.into_array(),
+            step: ExecutionStep::ExecuteSlot(slot_idx, M::matches::<ArrayRef>),
         }
     }
 

--- a/vortex-array/src/expr/mod.rs
+++ b/vortex-array/src/expr/mod.rs
@@ -74,6 +74,7 @@ pub use bound_expression::*;
 pub use expression::*;
 pub use exprs::*;
 pub use scope::*;
+pub use optimize::ExpressionReduceNode;
 
 pub trait VortexExprExt {
     /// Accumulate all field references from this expression and its children in a set

--- a/vortex-array/src/expr/mod.rs
+++ b/vortex-array/src/expr/mod.rs
@@ -73,8 +73,8 @@ pub use analysis::*;
 pub use bound_expression::*;
 pub use expression::*;
 pub use exprs::*;
-pub use scope::*;
 pub use optimize::ExpressionReduceNode;
+pub use scope::*;
 
 pub trait VortexExprExt {
     /// Accumulate all field references from this expression and its children in a set

--- a/vortex-array/src/expr/optimize.rs
+++ b/vortex-array/src/expr/optimize.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
 use std::cell::RefCell;
 use std::ops::Deref;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_error::vortex_panic;
 use vortex_utils::aliases::hash_map::HashMap;
 
+use crate::ArrayRef;
 use crate::dtype::DType;
 use crate::expr::Expression;
 use crate::expr::transform::match_between::find_between;
@@ -83,12 +83,7 @@ impl Expression {
                 scope: scope.clone(),
             };
             if let Some(reduced) = current.scalar_fn().reduce(&reduce_node, &reduce_ctx)? {
-                let reduced_expr = reduced
-                    .as_any()
-                    .downcast_ref::<ExpressionReduceNode>()
-                    .vortex_expect("ReduceNode not an ExpressionReduceNode")
-                    .expression
-                    .clone();
+                let reduced_expr = reduced.as_expression().expression;
                 current = reduced_expr;
                 changed = true;
                 any_optimizations = true;
@@ -252,14 +247,19 @@ impl SimplifyCtx for SimplifyCache<'_> {
     }
 }
 
-struct ExpressionReduceNode {
+#[derive(Clone)]
+pub struct ExpressionReduceNode {
     expression: Expression,
     scope: DType,
 }
 
 impl ReduceNode for ExpressionReduceNode {
-    fn as_any(&self) -> &dyn Any {
-        self
+    fn as_array(&self) -> ArrayRef {
+        vortex_panic!("Cannot produce ArrayRef out of Expression node")
+    }
+
+    fn as_expression(&self) -> ExpressionReduceNode {
+        self.clone()
     }
 
     fn node_dtype(&self) -> VortexResult<DType> {
@@ -285,6 +285,7 @@ impl ReduceNode for ExpressionReduceNode {
 struct ExpressionReduceCtx {
     scope: DType,
 }
+
 impl ReduceCtx for ExpressionReduceCtx {
     fn new_node(
         &self,
@@ -295,13 +296,7 @@ impl ReduceCtx for ExpressionReduceCtx {
             scalar_fn,
             children
                 .iter()
-                .map(|c| {
-                    c.as_any()
-                        .downcast_ref::<ExpressionReduceNode>()
-                        .vortex_expect("ReduceNode not an ExpressionReduceNode")
-                        .expression
-                        .clone()
-                })
+                .map(|c| c.as_expression().expression)
                 .collect::<Vec<_>>(),
         )?;
 

--- a/vortex-array/src/matcher.rs
+++ b/vortex-array/src/matcher.rs
@@ -109,5 +109,5 @@ pub trait Matcher {
     /// The returned match borrows from `parent`, so matchers can return a
     /// [`ParentView`] without forcing the parent to materialize. Implementations
     /// typically delegate to [`AsParent::as_parent_view`] or [`AsParent::as_opt`].
-    fn try_match<P: AsParent>(parent: &P) -> Option<Self::Match>;
+    fn try_match<P: AsParent>(parent: &P) -> Option<Self::Match<'_>>;
 }

--- a/vortex-array/src/matcher.rs
+++ b/vortex-array/src/matcher.rs
@@ -1,36 +1,113 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexExpect;
+
 use crate::ArrayRef;
+use crate::array::ArrayId;
+use crate::array::ParentRef;
+use crate::array::ParentView;
+use crate::array::VTable;
+use crate::dtype::DType;
 
-/// Trait for matching array types.
-pub trait Matcher {
-    type Match<'a>;
-
-    /// Check if the given array matches this matcher type
-    #[inline]
-    fn matches(array: &ArrayRef) -> bool {
-        Self::try_match(array).is_some()
-    }
-
-    /// Try to match the given array, returning the matched view type if successful.
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>>;
+mod private {
+    pub trait Sealed {}
 }
 
-/// Matches any array type (wildcard matcher)
-#[derive(Debug)]
-pub struct AnyArray;
+impl private::Sealed for ArrayRef {}
+impl private::Sealed for ParentRef<'_> {}
 
-impl Matcher for AnyArray {
-    type Match<'a> = &'a ArrayRef;
+/// A parent array that matchers can inspect without forcing materialization.
+///
+/// Implemented by [`ArrayRef`] (always heap-backed) and [`ParentRef`] (heap- or
+/// stack-backed), so a single [`Matcher`] implementation serves both the execute
+/// dispatch chain (heap arrays) and the parent-reduce dispatch chain
+/// (stack-allocated construction parts).
+///
+/// This trait is sealed: matcher code can rely on materialization being free for
+/// heap-backed parents and explicit for stack-backed ones.
+pub trait AsParent: private::Sealed {
+    /// Returns the encoding id of the parent.
+    fn encoding_id(&self) -> ArrayId;
 
-    #[inline(always)]
-    fn matches(_array: &ArrayRef) -> bool {
-        true
+    /// Returns the dtype of the parent.
+    fn dtype(&self) -> &DType;
+
+    /// Returns the length of the parent.
+    fn len(&self) -> usize;
+
+    /// Returns whether the parent is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
-    #[inline(always)]
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        Some(array)
+    /// Returns the child slots of the parent.
+    fn slots(&self) -> &[Option<ArrayRef>];
+
+    /// Returns `true` if the parent's encoding is `V`.
+    ///
+    /// Cheap encoding-id check that never constructs a view or materializes
+    /// stack-backed parents.
+    fn is_encoding<V: VTable>(&self) -> bool;
+
+    /// Returns the `V`-typed encoding data if the parent's encoding is `V`.
+    fn typed_data<V: VTable>(&self) -> Option<&V::TypedArrayData>;
+
+    /// Returns a typed [`ParentView`] if the parent's encoding is `V`.
+    ///
+    /// The returned view borrows from `self`; stack-backed parents stay on the
+    /// stack until a consumer explicitly calls
+    /// [`ParentView::materialize_array_ref`].
+    fn as_parent_view<V: VTable>(&self) -> Option<ParentView<'_, V>>;
+
+    /// Does the parent match the given matcher.
+    fn is<M: Matcher>(&self) -> bool
+    where
+        Self: Sized,
+    {
+        M::matches(self)
     }
+
+    /// Returns the parent downcast by the given matcher, or `None` if it doesn't match.
+    fn as_opt<M: Matcher>(&self) -> Option<M::Match<'_>>
+    where
+        Self: Sized,
+    {
+        M::try_match(self)
+    }
+
+    /// Returns the parent downcast by the given matcher, panicking if it doesn't match.
+    fn as_<M: Matcher>(&self) -> M::Match<'_>
+    where
+        Self: Sized,
+    {
+        self.as_opt::<M>().vortex_expect("Failed to downcast")
+    }
+}
+
+/// Trait for matching array types.
+///
+/// Matchers take any [`AsParent`] — a heap-allocated [`ArrayRef`] or a possibly
+/// stack-allocated [`ParentRef`] — so one implementation serves both dispatch
+/// chains. The returned match borrows from the parent and must not hide stack
+/// materialization: matches expose an explicit
+/// [`ParentView::materialize_array_ref`]-style hook instead of `AsRef<ArrayRef>`.
+pub trait Matcher {
+    /// The view type produced by a successful match, borrowing from the parent.
+    type Match<'a>;
+
+    /// Check if the given parent matches this matcher type.
+    ///
+    /// The default implementation delegates through [`try_match`](Self::try_match).
+    /// Override when a cheaper check (e.g. an encoding-id comparison) suffices.
+    fn matches<P: AsParent>(parent: &P) -> bool {
+        Self::try_match(parent).is_some()
+    }
+
+    /// Try to match the parent, returning the matched view type if successful.
+    ///
+    /// The returned match borrows from `parent`, so matchers can return a
+    /// [`ParentView`] without forcing the parent to materialize. Implementations
+    /// typically delegate to [`AsParent::as_parent_view`] or [`AsParent::as_opt`].
+    fn try_match<P: AsParent>(parent: &P) -> Option<Self::Match>;
 }

--- a/vortex-array/src/matcher.rs
+++ b/vortex-array/src/matcher.rs
@@ -1,38 +1,113 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexExpect;
+
 use crate::ArrayRef;
+use crate::array::ArrayId;
+use crate::array::ParentRef;
+use crate::array::ParentView;
+use crate::array::VTable;
+use crate::dtype::DType;
 
-/// Trait for matching array types.
-pub trait Matcher {
-    type Match<'a>;
-
-    /// Check if the given array matches this matcher type
-    #[inline]
-    fn matches(array: &ArrayRef) -> bool {
-        Self::try_match(array).is_some()
-    }
-
-    /// Try to match the given array, returning the matched view type if successful.
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>>;
+mod private {
+    pub trait Sealed {}
 }
 
-/// Matches any array type (wildcard matcher)
-#[derive(Debug)]
-pub struct AnyArray;
+impl private::Sealed for ArrayRef {}
+impl private::Sealed for ParentRef<'_> {}
 
-impl Matcher for AnyArray {
-    type Match<'a> = &'a ArrayRef;
+/// A parent array that matchers can inspect without forcing materialization.
+///
+/// Implemented by [`ArrayRef`] (always heap-backed) and [`ParentRef`] (heap- or
+/// stack-backed), so a single [`Matcher`] implementation serves both the execute
+/// dispatch chain (heap arrays) and the parent-reduce dispatch chain
+/// (stack-allocated construction parts).
+///
+/// This trait is sealed: matcher code can rely on materialization being free for
+/// heap-backed parents and explicit for stack-backed ones.
+pub trait AsParent: private::Sealed {
+    /// Returns the encoding id of the parent.
+    fn encoding_id(&self) -> ArrayId;
 
-    #[allow(clippy::inline_always)]
-    #[inline(always)]
-    fn matches(_array: &ArrayRef) -> bool {
-        true
+    /// Returns the dtype of the parent.
+    fn dtype(&self) -> &DType;
+
+    /// Returns the length of the parent.
+    fn len(&self) -> usize;
+
+    /// Returns whether the parent is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
-    #[allow(clippy::inline_always)]
-    #[inline(always)]
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        Some(array)
+    /// Returns the child slots of the parent.
+    fn slots(&self) -> &[Option<ArrayRef>];
+
+    /// Returns `true` if the parent's encoding is `V`.
+    ///
+    /// Cheap encoding-id check that never constructs a view or materializes
+    /// stack-backed parents.
+    fn is_encoding<V: VTable>(&self) -> bool;
+
+    /// Returns the `V`-typed encoding data if the parent's encoding is `V`.
+    fn typed_data<V: VTable>(&self) -> Option<&V::TypedArrayData>;
+
+    /// Returns a typed [`ParentView`] if the parent's encoding is `V`.
+    ///
+    /// The returned view borrows from `self`; stack-backed parents stay on the
+    /// stack until a consumer explicitly calls
+    /// [`ParentView::materialize_array_ref`].
+    fn as_parent_view<V: VTable>(&self) -> Option<ParentView<'_, V>>;
+
+    /// Does the parent match the given matcher.
+    fn is<M: Matcher>(&self) -> bool
+    where
+        Self: Sized,
+    {
+        M::matches(self)
     }
+
+    /// Returns the parent downcast by the given matcher, or `None` if it doesn't match.
+    fn as_opt<M: Matcher>(&self) -> Option<M::Match<'_>>
+    where
+        Self: Sized,
+    {
+        M::try_match(self)
+    }
+
+    /// Returns the parent downcast by the given matcher, panicking if it doesn't match.
+    fn as_<M: Matcher>(&self) -> M::Match<'_>
+    where
+        Self: Sized,
+    {
+        self.as_opt::<M>().vortex_expect("Failed to downcast")
+    }
+}
+
+/// Trait for matching array types.
+///
+/// Matchers take any [`AsParent`] — a heap-allocated [`ArrayRef`] or a possibly
+/// stack-allocated [`ParentRef`] — so one implementation serves both dispatch
+/// chains. The returned match borrows from the parent and must not hide stack
+/// materialization: matches expose an explicit
+/// [`ParentView::materialize_array_ref`]-style hook instead of `AsRef<ArrayRef>`.
+pub trait Matcher {
+    /// The view type produced by a successful match, borrowing from the parent.
+    type Match<'a>;
+
+    /// Check if the given parent matches this matcher type.
+    ///
+    /// The default implementation delegates through [`try_match`](Self::try_match).
+    /// Override when a cheaper check (e.g. an encoding-id comparison) suffices.
+    fn matches<P: AsParent>(parent: &P) -> bool {
+        Self::try_match(parent).is_some()
+    }
+
+    /// Try to match the parent, returning the matched view type if successful.
+    ///
+    /// The returned match borrows from `parent`, so matchers can return a
+    /// [`ParentView`] without forcing the parent to materialize. Implementations
+    /// typically delegate to [`AsParent::as_parent_view`] or [`AsParent::as_opt`].
+    fn try_match<P: AsParent>(parent: &P) -> Option<Self::Match>;
 }

--- a/vortex-array/src/optimizer/kernels.rs
+++ b/vortex-array/src/optimizer/kernels.rs
@@ -43,6 +43,7 @@ use vortex_utils::aliases::hash_map::HashMap;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::array::ParentRef;
 use crate::array::VTable;
 use crate::arrays::Struct;
 use crate::arrays::struct_::compute::rules::struct_cast_reduce_parent;
@@ -62,8 +63,11 @@ static FN_HASHER: LazyLock<DefaultHashBuilder> = LazyLock::new(DefaultHashBuilde
 ///
 /// Implementations must preserve the parent's logical length and dtype, matching the invariant
 /// required of static parent-reduce rules.
-pub type ReduceParentFn =
-    fn(child: &ArrayRef, parent: &ArrayRef, child_idx: usize) -> VortexResult<Option<ArrayRef>>;
+pub type ReduceParentFn = fn(
+    child: &ArrayRef,
+    parent: &ParentRef<'_>,
+    child_idx: usize,
+) -> VortexResult<Option<ArrayRef>>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[repr(transparent)]
@@ -145,7 +149,7 @@ where
         child_idx: usize,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        let Some(child) = child.as_opt::<V>() else {
+        let Some(child) = child.as_typed::<V>() else {
             return Ok(None);
         };
         let Some(parent) = K::Parent::try_match(parent) else {
@@ -207,7 +211,7 @@ impl ArrayKernels {
     fn register_builtin_reduce_parent(&self) {
         self.register_reduce_parent(
             Cast.id(),
-            Struct.id(),
+            VTable::id(&Struct),
             &[struct_cast_reduce_parent as ReduceParentFn],
         );
     }

--- a/vortex-array/src/optimizer/mod.rs
+++ b/vortex-array/src/optimizer/mod.rs
@@ -55,27 +55,26 @@ pub trait ArrayOptimizer {
 
 impl ArrayOptimizer for ArrayRef {
     fn optimize(&self) -> VortexResult<ArrayRef> {
-        Ok(try_optimize(self, None)?.unwrap_or_else(|| self.clone()))
+        Ok(optimize_owned(self.clone(), None)?.0)
     }
 
     fn optimize_ctx(&self, session: &VortexSession) -> VortexResult<ArrayRef> {
-        Ok(try_optimize(self, Some(session))?.unwrap_or_else(|| self.clone()))
+        Ok(optimize_owned(self.clone(), Some(session))?.0)
     }
 
     fn optimize_recursive(&self, session: &VortexSession) -> VortexResult<ArrayRef> {
-        Ok(try_optimize_recursive(self, session)?.unwrap_or_else(|| self.clone()))
+        Ok(try_optimize_recursive(self.clone(), session)?.0)
     }
 }
 
-fn try_optimize(
-    array: &ArrayRef,
+pub(crate) fn optimize_owned(
+    mut current_array: ArrayRef,
     session: Option<&VortexSession>,
-) -> VortexResult<Option<ArrayRef>> {
-    let mut current_array = array.clone();
+) -> VortexResult<(ArrayRef, bool)> {
     let mut any_optimizations = false;
     let array_ref = session.map(|s| s.kernels());
 
-    trace_op!(record_optimize_start(array, session.is_some()));
+    trace_op!(record_optimize_start(&current_array, session.is_some()));
 
     // Apply reduction rules to the current array until no more rules apply.
     for _ in 0..=100 {
@@ -147,46 +146,35 @@ fn try_optimize(
         // No more optimizations can be applied
         trace_op!(record_optimize_done(&current_array, any_optimizations));
 
-        if any_optimizations {
-            return Ok(Some(current_array));
+        return if any_optimizations {
+            Ok((current_array, any_optimizations))
         } else {
-            return Ok(None);
-        }
+            Ok((current_array, false))
+        };
     }
 
     vortex_bail!("Exceeded maximum optimization iterations (possible infinite loop)");
 }
 
 fn try_optimize_recursive(
-    array: &ArrayRef,
+    current_array: ArrayRef,
     session: &VortexSession,
-) -> VortexResult<Option<ArrayRef>> {
-    let mut current_array = array.clone();
-    let mut any_optimizations = false;
-
-    trace_op!(record_optimize_recursive_start(array));
-
-    if let Some(new_array) = try_optimize(&current_array, Some(session))? {
-        current_array = new_array;
-        any_optimizations = true;
-    }
+) -> VortexResult<(ArrayRef, bool)> {
+    let (mut current_array, mut any_optimizations) = optimize_owned(current_array, Some(session))?;
 
     let mut new_slots = SmallVec::with_capacity(current_array.slots().len());
     let mut any_slot_optimized = false;
     for slot in current_array.slots() {
         match slot {
             Some(child) => {
-                if let Some(new_child) = try_optimize_recursive(child, session)? {
-                    trace_op!(record_optimize_recursive_slot(
-                        new_slots.len(),
-                        child,
-                        &new_child,
-                    ));
-                    new_slots.push(Some(new_child));
-                    any_slot_optimized = true;
-                } else {
-                    new_slots.push(Some(child.clone()));
-                }
+                let (new_child, new_slot_optimized) = try_optimize_recursive(child.clone(), session)?;
+                trace_op!(record_optimize_recursive_slot(
+                    new_slots.len(),
+                    child,
+                    &new_child,
+                ));
+                new_slots.push(Some(new_child));
+                any_slot_optimized |= new_slot_optimized;
             }
             None => new_slots.push(None),
         }
@@ -199,9 +187,5 @@ fn try_optimize_recursive(
         any_optimizations = true;
     }
 
-    if any_optimizations {
-        Ok(Some(current_array))
-    } else {
-        Ok(None)
-    }
+    Ok((current_array, any_optimizations))
 }

--- a/vortex-array/src/optimizer/mod.rs
+++ b/vortex-array/src/optimizer/mod.rs
@@ -22,6 +22,7 @@ use vortex_error::vortex_bail;
 use vortex_session::VortexSession;
 
 use crate::ArrayRef;
+use crate::array::ParentRef;
 use crate::optimizer::kernels::ArrayKernelsExt;
 use crate::trace_op;
 
@@ -92,6 +93,7 @@ fn try_optimize(
         // Apply parent reduction rules to each slot in the context of the current array.
         // Its important to take all slots here, as `current_array` can change inside the loop.
         let mut parent_reduced = None;
+        let parent_ref = ParentRef::from_array_ref(&current_array);
         for (slot_idx, slot) in current_array.slots().iter().enumerate() {
             let Some(child) = slot else { continue };
 
@@ -102,7 +104,7 @@ fn try_optimize(
             {
                 #[allow(clippy::unused_enumerate_index)]
                 for (_plugin_idx, plugin) in plugins.as_ref().iter().enumerate() {
-                    if let Some(new_array) = plugin(child, &current_array, slot_idx)? {
+                    if let Some(new_array) = plugin(child, &parent_ref, slot_idx)? {
                         trace_op!(record_session_parent_reduce_applied(
                             &current_array,
                             child,
@@ -125,7 +127,7 @@ fn try_optimize(
                 }
             }
 
-            if let Some(new_array) = child.reduce_parent(&current_array, slot_idx)? {
+            if let Some(new_array) = child.reduce_parent(&parent_ref, slot_idx)? {
                 parent_reduced = Some(new_array);
                 break;
             }

--- a/vortex-array/src/optimizer/mod.rs
+++ b/vortex-array/src/optimizer/mod.rs
@@ -60,27 +60,26 @@ pub trait ArrayOptimizer {
 
 impl ArrayOptimizer for ArrayRef {
     fn optimize(&self) -> VortexResult<ArrayRef> {
-        Ok(try_optimize(self, None)?.unwrap_or_else(|| self.clone()))
+        Ok(optimize_owned(self.clone(), None)?.0)
     }
 
     fn optimize_ctx(&self, session: &VortexSession) -> VortexResult<ArrayRef> {
-        Ok(try_optimize(self, Some(session))?.unwrap_or_else(|| self.clone()))
+        Ok(optimize_owned(self.clone(), Some(session))?.0)
     }
 
     fn optimize_recursive(&self, session: &VortexSession) -> VortexResult<ArrayRef> {
-        Ok(try_optimize_recursive(self, session)?.unwrap_or_else(|| self.clone()))
+        Ok(try_optimize_recursive(self.clone(), session)?.0)
     }
 }
 
-fn try_optimize(
-    array: &ArrayRef,
+pub(crate) fn optimize_owned(
+    mut current_array: ArrayRef,
     session: Option<&VortexSession>,
-) -> VortexResult<Option<ArrayRef>> {
-    let mut current_array = array.clone();
+) -> VortexResult<(ArrayRef, bool)> {
     let mut any_optimizations = false;
     let session_kernels = session.map(|session| session.kernels());
 
-    trace_op!(record_optimize_start(array, session.is_some()));
+    trace_op!(record_optimize_start(&current_array, session.is_some()));
 
     for _ in 0..=MAX_OPTIMIZER_REWRITE_PASS {
         trace_op!(record_optimize_loop_start(&current_array));
@@ -129,7 +128,7 @@ fn try_optimize(
 
         trace_op!(record_optimize_done(&current_array, any_optimizations));
 
-        return Ok(any_optimizations.then_some(current_array));
+        return Ok((current_array, any_optimizations));
     }
 
     vortex_bail!("Exceeded maximum optimization iterations (possible infinite loop)");
@@ -175,35 +174,24 @@ fn try_session_parent_reduce(
 }
 
 fn try_optimize_recursive(
-    array: &ArrayRef,
+    current_array: ArrayRef,
     session: &VortexSession,
-) -> VortexResult<Option<ArrayRef>> {
-    let mut current_array = array.clone();
-    let mut any_optimizations = false;
-
-    trace_op!(record_optimize_recursive_start(array));
-
-    if let Some(new_array) = try_optimize(&current_array, Some(session))? {
-        current_array = new_array;
-        any_optimizations = true;
-    }
+) -> VortexResult<(ArrayRef, bool)> {
+    let (mut current_array, mut any_optimizations) = optimize_owned(current_array, Some(session))?;
 
     let mut new_slots = SmallVec::with_capacity(current_array.slots().len());
     let mut any_slot_optimized = false;
     for slot in current_array.slots() {
         match slot {
             Some(child) => {
-                if let Some(new_child) = try_optimize_recursive(child, session)? {
-                    trace_op!(record_optimize_recursive_slot(
-                        new_slots.len(),
-                        child,
-                        &new_child,
-                    ));
-                    new_slots.push(Some(new_child));
-                    any_slot_optimized = true;
-                } else {
-                    new_slots.push(Some(child.clone()));
-                }
+                let (new_child, new_slot_optimized) = try_optimize_recursive(child.clone(), session)?;
+                trace_op!(record_optimize_recursive_slot(
+                    new_slots.len(),
+                    child,
+                    &new_child,
+                ));
+                new_slots.push(Some(new_child));
+                any_slot_optimized |= new_slot_optimized;
             }
             None => new_slots.push(None),
         }
@@ -216,9 +204,5 @@ fn try_optimize_recursive(
         any_optimizations = true;
     }
 
-    if any_optimizations {
-        Ok(Some(current_array))
-    } else {
-        Ok(None)
-    }
+    Ok((current_array, any_optimizations))
 }

--- a/vortex-array/src/optimizer/mod.rs
+++ b/vortex-array/src/optimizer/mod.rs
@@ -22,6 +22,7 @@ use vortex_error::vortex_bail;
 use vortex_session::VortexSession;
 
 use crate::ArrayRef;
+use crate::array::ParentRef;
 use crate::optimizer::kernels::ArrayKernels;
 use crate::optimizer::kernels::ArrayKernelsExt;
 use crate::trace_op;
@@ -95,6 +96,7 @@ fn try_optimize(
 
         // Try children in order; the first parent rewrite restarts the fixpoint loop.
         let mut reduced_parent = None;
+        let parent_ref = ParentRef::from_array_ref(&current_array);
         for (slot_idx, slot) in current_array.slots().iter().enumerate() {
             let Some(child) = slot else {
                 continue;
@@ -109,7 +111,7 @@ fn try_optimize(
                 break;
             }
 
-            if let Some(new_array) = child.reduce_parent(&current_array, slot_idx)? {
+            if let Some(new_array) = child.reduce_parent(&parent_ref, slot_idx)? {
                 reduced_parent = Some(new_array);
                 break;
             }
@@ -145,9 +147,11 @@ fn try_session_parent_reduce(
         return Ok(None);
     };
 
+    let parent_ref = ParentRef::from_array_ref(parent);
+
     #[allow(clippy::unused_enumerate_index)]
     for (_kernel_idx, reduce_parent) in reduce_parent_fns.iter().enumerate() {
-        if let Some(new_array) = reduce_parent(child, parent, slot_idx)? {
+        if let Some(new_array) = reduce_parent(child, &parent_ref, slot_idx)? {
             trace_op!(record_session_parent_reduce_applied(
                 parent,
                 child,

--- a/vortex-array/src/optimizer/mod.rs
+++ b/vortex-array/src/optimizer/mod.rs
@@ -105,7 +105,7 @@ pub(crate) fn optimize_owned(
                 for (_plugin_idx, plugin) in plugins.as_ref().iter().enumerate() {
                     if let Some(new_array) = plugin(child, &parent_ref, slot_idx)? {
                         trace_op!(record_session_parent_reduce_applied(
-                            &current_array,
+                            &parent_ref,
                             child,
                             slot_idx,
                             _plugin_idx,
@@ -115,7 +115,7 @@ pub(crate) fn optimize_owned(
                         break;
                     }
                     trace_op!(record_session_parent_reduce_declined(
-                        &current_array,
+                        &parent_ref,
                         child,
                         slot_idx,
                         _plugin_idx,
@@ -160,6 +160,8 @@ fn try_optimize_recursive(
     current_array: ArrayRef,
     session: &VortexSession,
 ) -> VortexResult<(ArrayRef, bool)> {
+    trace_op!(record_optimize_recursive_start(&current_array));
+
     let (mut current_array, mut any_optimizations) = optimize_owned(current_array, Some(session))?;
 
     let mut new_slots = SmallVec::with_capacity(current_array.slots().len());
@@ -167,12 +169,15 @@ fn try_optimize_recursive(
     for slot in current_array.slots() {
         match slot {
             Some(child) => {
-                let (new_child, new_slot_optimized) = try_optimize_recursive(child.clone(), session)?;
-                trace_op!(record_optimize_recursive_slot(
-                    new_slots.len(),
-                    child,
-                    &new_child,
-                ));
+                let (new_child, new_slot_optimized) =
+                    try_optimize_recursive(child.clone(), session)?;
+                if new_slot_optimized {
+                    trace_op!(record_optimize_recursive_slot(
+                        new_slots.len(),
+                        child,
+                        &new_child,
+                    ));
+                }
                 new_slots.push(Some(new_child));
                 any_slot_optimized |= new_slot_optimized;
             }

--- a/vortex-array/src/optimizer/mod.rs
+++ b/vortex-array/src/optimizer/mod.rs
@@ -152,7 +152,7 @@ fn try_session_parent_reduce(
     for (_kernel_idx, reduce_parent) in reduce_parent_fns.iter().enumerate() {
         if let Some(new_array) = reduce_parent(child, &parent_ref, slot_idx)? {
             trace_op!(record_session_parent_reduce_applied(
-                parent,
+                &parent_ref,
                 child,
                 slot_idx,
                 _kernel_idx,
@@ -163,7 +163,7 @@ fn try_session_parent_reduce(
         }
 
         trace_op!(record_session_parent_reduce_declined(
-            parent,
+            &parent_ref,
             child,
             slot_idx,
             _kernel_idx,
@@ -177,6 +177,8 @@ fn try_optimize_recursive(
     current_array: ArrayRef,
     session: &VortexSession,
 ) -> VortexResult<(ArrayRef, bool)> {
+    trace_op!(record_optimize_recursive_start(&current_array));
+
     let (mut current_array, mut any_optimizations) = optimize_owned(current_array, Some(session))?;
 
     let mut new_slots = SmallVec::with_capacity(current_array.slots().len());
@@ -184,12 +186,15 @@ fn try_optimize_recursive(
     for slot in current_array.slots() {
         match slot {
             Some(child) => {
-                let (new_child, new_slot_optimized) = try_optimize_recursive(child.clone(), session)?;
-                trace_op!(record_optimize_recursive_slot(
-                    new_slots.len(),
-                    child,
-                    &new_child,
-                ));
+                let (new_child, new_slot_optimized) =
+                    try_optimize_recursive(child.clone(), session)?;
+                if new_slot_optimized {
+                    trace_op!(record_optimize_recursive_slot(
+                        new_slots.len(),
+                        child,
+                        &new_child,
+                    ));
+                }
                 new_slots.push(Some(new_child));
                 any_slot_optimized |= new_slot_optimized;
             }

--- a/vortex-array/src/optimizer/rules.rs
+++ b/vortex-array/src/optimizer/rules.rs
@@ -26,6 +26,8 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::array::ArrayView;
+use crate::array::ParentRef;
+use crate::array::ParentView;
 use crate::array::VTable;
 use crate::matcher::Matcher;
 use crate::trace_op;
@@ -41,7 +43,7 @@ pub trait ArrayReduceRule<V: VTable>: Debug + Send + Sync + 'static {
     /// - `Ok(Some(new_array))` if the rule applied successfully
     /// - `Ok(None)` if the rule doesn't apply
     /// - `Err(e)` if an error occurred
-    fn reduce(&self, array: ArrayView<'_, V>) -> VortexResult<Option<ArrayRef>>;
+    fn reduce(&self, array: ParentView<'_, V>) -> VortexResult<Option<ArrayRef>>;
 }
 
 /// A metadata-only rewrite rule where a child encoding rewrites its parent (Layer 2).
@@ -49,6 +51,13 @@ pub trait ArrayReduceRule<V: VTable>: Debug + Send + Sync + 'static {
 /// The child sees the parent's type via the associated `Parent` [`Matcher`] and can return
 /// a replacement for the parent. This enables optimizations like pushing operations through
 /// compression layers (e.g., pushing a scalar function into dictionary values).
+///
+/// # Stack-backed parents
+///
+/// Construction-side callers borrow `ArrayParts` as a [`ParentRef`] via
+/// [`ArrayParts::optimize`](crate::array::ArrayParts::optimize). [`Matcher::try_match`]
+/// returns a [`ParentView`] without materializing an `Arc<ArrayInner<_>>`, so rules that
+/// consume only typed metadata can fire without forcing a heap allocation.
 pub trait ArrayParentReduceRule<V: VTable>: Debug + Send + Sync + 'static {
     /// The parent array type this rule matches against.
     type Parent: Matcher;
@@ -59,6 +68,13 @@ pub trait ArrayParentReduceRule<V: VTable>: Debug + Send + Sync + 'static {
     /// - `Ok(Some(new_array))` if the rule applied successfully
     /// - `Ok(None)` if the rule doesn't apply
     /// - `Err(e)` if an error occurred
+    ///
+    /// # Stack-backed parents
+    ///
+    /// The parent is received through [`Matcher::Match`]. For the blanket
+    /// `impl<V: VTable> Matcher for V`, that is a [`ParentView`] borrowed from the
+    /// parent — no `Arc<ArrayInner<_>>` is allocated unless the rule explicitly
+    /// materializes it.
     fn reduce_parent(
         &self,
         array: ArrayView<'_, V>,
@@ -70,12 +86,12 @@ pub trait ArrayParentReduceRule<V: VTable>: Debug + Send + Sync + 'static {
 /// Type-erased version of [`ArrayParentReduceRule`] used for dynamic dispatch within
 /// [`ParentRuleSet`].
 pub trait DynArrayParentReduceRule<V: VTable>: Debug + Send + Sync {
-    fn matches(&self, parent: &ArrayRef) -> bool;
+    fn matches(&self, parent: &ParentRef<'_>) -> bool;
 
     fn reduce_parent(
         &self,
         array: ArrayView<'_, V>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>>;
 }
@@ -99,17 +115,17 @@ impl<V: VTable, R: ArrayParentReduceRule<V>> Debug for ParentReduceRuleAdapter<V
 impl<V: VTable, K: ArrayParentReduceRule<V>> DynArrayParentReduceRule<V>
     for ParentReduceRuleAdapter<V, K>
 {
-    fn matches(&self, parent: &ArrayRef) -> bool {
-        K::Parent::matches(parent)
+    fn matches(&self, parent: &ParentRef<'_>) -> bool {
+        parent.is::<K::Parent>()
     }
 
     fn reduce_parent(
         &self,
         child: ArrayView<'_, V>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
-        let Some(parent_view) = K::Parent::try_match(parent) else {
+        let Some(parent_view) = parent.as_opt::<K::Parent>() else {
             return Ok(None);
         };
         self.rule.reduce_parent(child, parent_view, child_idx)
@@ -131,7 +147,7 @@ impl<V: VTable> ReduceRuleSet<V> {
     }
 
     /// Evaluate the reduction rules on the given array.
-    pub fn evaluate(&self, array: ArrayView<'_, V>) -> VortexResult<Option<ArrayRef>> {
+    pub fn evaluate(&self, array: ParentView<'_, V>) -> VortexResult<Option<ArrayRef>> {
         for rule in self.rules.iter() {
             if let Some(reduced) = rule.reduce(array)? {
                 trace_op!(record_reduce_applied(array.array(), *rule, &reduced));
@@ -174,7 +190,7 @@ impl<V: VTable> ParentRuleSet<V> {
     pub fn evaluate(
         &self,
         child: ArrayView<'_, V>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         for rule in self.rules.iter() {

--- a/vortex-array/src/optimizer/rules.rs
+++ b/vortex-array/src/optimizer/rules.rs
@@ -150,10 +150,10 @@ impl<V: VTable> ReduceRuleSet<V> {
     pub fn evaluate(&self, array: ParentView<'_, V>) -> VortexResult<Option<ArrayRef>> {
         for rule in self.rules.iter() {
             if let Some(reduced) = rule.reduce(array)? {
-                trace_op!(record_reduce_applied(array.array(), *rule, &reduced));
+                trace_op!(record_reduce_applied(&array, *rule, &reduced));
                 return Ok(Some(reduced));
             }
-            trace_op!(record_reduce_declined(array.array(), *rule));
+            trace_op!(record_reduce_declined(&array, *rule));
         }
         Ok(None)
     }

--- a/vortex-array/src/scalar_fn/fns/between/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/between/kernel.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use super::Between;
@@ -11,9 +10,7 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::VTable;
-use crate::arrays::ScalarFn;
 use crate::arrays::scalar_fn::ExactScalarFn;
-use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
 use crate::kernel::ExecuteParentKernel;
 use crate::optimizer::rules::ArrayParentReduceRule;
@@ -63,12 +60,8 @@ where
         if child_idx != 0 {
             return Ok(None);
         }
-        let scalar_fn_array = parent
-            .as_opt::<ScalarFn>()
-            .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
-        let children = scalar_fn_array.children();
-        let lower = &children[1];
-        let upper = &children[2];
+        let lower = parent.get_child(1);
+        let upper = parent.get_child(2);
         let arr = array.array().clone();
         if let Some(result) = precondition(&arr, lower, upper)? {
             return Ok(Some(result));
@@ -98,12 +91,8 @@ where
         if child_idx != 0 {
             return Ok(None);
         }
-        let scalar_fn_array = parent
-            .as_opt::<ScalarFn>()
-            .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
-        let children = scalar_fn_array.children();
-        let lower = &children[1];
-        let upper = &children[2];
+        let lower = parent.get_child(1);
+        let upper = parent.get_child(2);
         let arr = array.array().clone();
         if let Some(result) = precondition(&arr, lower, upper)? {
             return Ok(Some(result));

--- a/vortex-array/src/scalar_fn/fns/between/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/between/kernel.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use super::Between;
@@ -11,9 +10,7 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::VTable;
-use crate::arrays::ScalarFn;
 use crate::arrays::scalar_fn::ExactScalarFn;
-use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
 use crate::kernel::ExecuteParentKernel;
 use crate::optimizer::rules::ArrayParentReduceRule;
@@ -63,12 +60,8 @@ where
         if child_idx != 0 {
             return Ok(None);
         }
-        let scalar_fn_array = parent
-            .as_opt::<ScalarFn>()
-            .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
-        let children = scalar_fn_array.children();
-        let lower = &children[1];
-        let upper = &children[2];
+        let lower = parent.get_child(1);
+        let upper = parent.get_child(2);
         let arr = array.array().clone();
         if let Some(result) = short_circuit(&arr, lower, upper, parent.options)? {
             return Ok(Some(result));
@@ -98,12 +91,8 @@ where
         if child_idx != 0 {
             return Ok(None);
         }
-        let scalar_fn_array = parent
-            .as_opt::<ScalarFn>()
-            .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
-        let children = scalar_fn_array.children();
-        let lower = &children[1];
-        let upper = &children[2];
+        let lower = parent.get_child(1);
+        let upper = parent.get_child(2);
         let arr = array.array().clone();
         if let Some(result) = short_circuit(&arr, lower, upper, parent.options)? {
             // TODO(joe): return the lazy array directly, blocked on the same executor support as

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -131,13 +131,13 @@ fn between_canonical(
     }
 
     // Try type-specific kernels
-    if let Some(prim) = arr.as_opt::<Primitive>()
+    if let Some(prim) = arr.as_typed::<Primitive>()
         && let Some(result) =
             <Primitive as BetweenKernel>::between(prim, lower, upper, options, ctx)?
     {
         return Ok(result);
     }
-    if let Some(dec) = arr.as_opt::<Decimal>()
+    if let Some(dec) = arr.as_typed::<Decimal>()
         && let Some(result) = <Decimal as BetweenKernel>::between(dec, lower, upper, options, ctx)?
     {
         return Ok(result);

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -155,13 +155,13 @@ fn between_canonical(
     }
 
     // Try type-specific kernels
-    if let Some(prim) = arr.as_opt::<Primitive>()
+    if let Some(prim) = arr.as_typed::<Primitive>()
         && let Some(result) =
             <Primitive as BetweenKernel>::between(prim, lower, upper, options, ctx)?
     {
         return Ok(result);
     }
-    if let Some(dec) = arr.as_opt::<Decimal>()
+    if let Some(dec) = arr.as_typed::<Decimal>()
         && let Some(result) = <Decimal as BetweenKernel>::between(dec, lower, upper, options, ctx)?
     {
         return Ok(result);

--- a/vortex-array/src/scalar_fn/fns/binary/boolean.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/boolean.rs
@@ -22,9 +22,7 @@ use crate::arrays::Bool;
 use crate::arrays::BoolArray;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ScalarFn;
 use crate::arrays::scalar_fn::ExactScalarFn;
-use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
@@ -80,12 +78,9 @@ where
             return Ok(None);
         }
 
-        let Some(scalar_fn_array) = parent.as_opt::<ScalarFn>() else {
-            return Ok(None);
-        };
         let other = match child_idx {
-            0 => scalar_fn_array.get_child(1),
-            1 => scalar_fn_array.get_child(0),
+            0 => parent.get_child(1),
+            1 => parent.get_child(0),
             _ => return Ok(None),
         };
 

--- a/vortex-array/src/scalar_fn/fns/binary/compare/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare/mod.rs
@@ -30,10 +30,8 @@ use crate::array::VTable;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ScalarFn;
 use crate::arrays::extension::ExtensionArrayExt;
 use crate::arrays::scalar_fn::ExactScalarFn;
-use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -91,15 +89,11 @@ where
             return Ok(None);
         };
 
-        // Get the ScalarFnArray to access children
-        let Some(scalar_fn_array) = parent.as_opt::<ScalarFn>() else {
-            return Ok(None);
-        };
         // Normalize so `array` is always LHS, swapping the operator if needed
         // TODO(joe): should be go this here or in the Rule/Kernel
         let (cmp_op, other) = match child_idx {
-            0 => (cmp_op, scalar_fn_array.get_child(1)),
-            1 => (cmp_op.swap(), scalar_fn_array.get_child(0)),
+            0 => (cmp_op, parent.get_child(1)),
+            1 => (cmp_op.swap(), parent.get_child(0)),
             _ => return Ok(None),
         };
 

--- a/vortex-array/src/scalar_fn/fns/cast/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/cast/mod.rs
@@ -143,14 +143,16 @@ impl ScalarFnVTable for Cast {
                     ),
                 }
             }
-            ColumnarView::Constant(constant) => match cast_constant(constant, target_dtype)? {
-                Some(result) => Ok(result),
-                None => vortex_bail!(
-                    "No CastReduce to cast constant array from {} to {}",
-                    constant.dtype(),
-                    target_dtype,
-                ),
-            },
+            ColumnarView::Constant(constant) => {
+                match cast_constant(constant.materialize_view(), target_dtype)? {
+                    Some(result) => Ok(result),
+                    None => vortex_bail!(
+                        "No CastReduce to cast constant array from {} to {}",
+                        constant.dtype(),
+                        target_dtype,
+                    ),
+                }
+            }
         }
     }
 
@@ -204,22 +206,30 @@ fn cast_canonical(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ArrayRef>> {
     match canonical {
-        CanonicalView::Null(a) => <Null as CastReduce>::cast(a, dtype),
-        CanonicalView::Bool(a) => <Bool as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::Primitive(a) => <Primitive as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::Decimal(a) => <Decimal as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::VarBinView(a) => <VarBinView as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::List(a) => <ListView as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::Map(a) => <Map as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::FixedSizeList(a) => <FixedSizeList as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::Struct(a) => struct_cast(a, dtype, ctx),
+        CanonicalView::Null(a) => <Null as CastReduce>::cast(a.materialize_view(), dtype),
+        CanonicalView::Bool(a) => <Bool as CastKernel>::cast(a.materialize_view(), dtype, ctx),
+        CanonicalView::Primitive(a) => {
+            <Primitive as CastKernel>::cast(a.materialize_view(), dtype, ctx)
+        }
+        CanonicalView::Decimal(a) => {
+            <Decimal as CastKernel>::cast(a.materialize_view(), dtype, ctx)
+        }
+        CanonicalView::VarBinView(a) => {
+            <VarBinView as CastKernel>::cast(a.materialize_view(), dtype, ctx)
+        }
+        CanonicalView::List(a) => <ListView as CastKernel>::cast(a.materialize_view(), dtype, ctx),
+        CanonicalView::Map(a) => <Map as CastKernel>::cast(a.materialize_view(), dtype, ctx),
+        CanonicalView::FixedSizeList(a) => {
+            <FixedSizeList as CastKernel>::cast(a.materialize_view(), dtype, ctx)
+        }
+        CanonicalView::Struct(a) => struct_cast(a.materialize_view(), dtype, ctx),
         CanonicalView::Union(_) => {
             todo!(
                 "TODO(connor)[Union]: implement Union casting with conformance coverage for outer \
                  nullability changes, including validation of nullable-to-nonnullable casts"
             )
         }
-        CanonicalView::Extension(a) => <Extension as CastReduce>::cast(a, dtype),
+        CanonicalView::Extension(a) => <Extension as CastReduce>::cast(a.materialize_view(), dtype),
         CanonicalView::Variant(_) => {
             vortex_bail!("Variant arrays don't support casting")
         }

--- a/vortex-array/src/scalar_fn/fns/cast/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/cast/mod.rs
@@ -125,14 +125,16 @@ impl ScalarFnVTable for Cast {
                     ),
                 }
             }
-            ColumnarView::Constant(constant) => match cast_constant(constant, target_dtype)? {
-                Some(result) => Ok(result),
-                None => vortex_bail!(
-                    "No CastReduce to cast constant array from {} to {}",
-                    constant.dtype(),
-                    target_dtype,
-                ),
-            },
+            ColumnarView::Constant(constant) => {
+                match cast_constant(constant.materialize_view(), target_dtype)? {
+                    Some(result) => Ok(result),
+                    None => vortex_bail!(
+                        "No CastReduce to cast constant array from {} to {}",
+                        constant.dtype(),
+                        target_dtype,
+                    ),
+                }
+            }
         }
     }
 
@@ -191,21 +193,29 @@ fn cast_canonical(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ArrayRef>> {
     match canonical {
-        CanonicalView::Null(a) => <Null as CastReduce>::cast(a, dtype),
-        CanonicalView::Bool(a) => <Bool as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::Primitive(a) => <Primitive as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::Decimal(a) => <Decimal as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::VarBinView(a) => <VarBinView as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::List(a) => <ListView as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::FixedSizeList(a) => <FixedSizeList as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::Struct(a) => struct_cast(a, dtype, ctx),
+        CanonicalView::Null(a) => <Null as CastReduce>::cast(a.materialize_view(), dtype),
+        CanonicalView::Bool(a) => <Bool as CastKernel>::cast(a.materialize_view(), dtype, ctx),
+        CanonicalView::Primitive(a) => {
+            <Primitive as CastKernel>::cast(a.materialize_view(), dtype, ctx)
+        }
+        CanonicalView::Decimal(a) => {
+            <Decimal as CastKernel>::cast(a.materialize_view(), dtype, ctx)
+        }
+        CanonicalView::VarBinView(a) => {
+            <VarBinView as CastKernel>::cast(a.materialize_view(), dtype, ctx)
+        }
+        CanonicalView::List(a) => <ListView as CastKernel>::cast(a.materialize_view(), dtype, ctx),
+        CanonicalView::FixedSizeList(a) => {
+            <FixedSizeList as CastKernel>::cast(a.materialize_view(), dtype, ctx)
+        }
+        CanonicalView::Struct(a) => struct_cast(a.materialize_view(), dtype, ctx),
         CanonicalView::Union(_) => {
             todo!(
                 "TODO(connor)[Union]: implement Union casting with conformance coverage for outer \
                  nullability changes, including validation of nullable-to-nonnullable casts"
             )
         }
-        CanonicalView::Extension(a) => <Extension as CastReduce>::cast(a, dtype),
+        CanonicalView::Extension(a) => <Extension as CastReduce>::cast(a.materialize_view(), dtype),
         CanonicalView::Variant(_) => {
             vortex_bail!("Variant arrays don't support casting")
         }

--- a/vortex-array/src/scalar_fn/fns/fill_null/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/fill_null/kernel.rs
@@ -9,12 +9,11 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::TypedArrayRef;
 use crate::array::VTable;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ScalarFn;
 use crate::arrays::scalar_fn::ExactScalarFn;
-use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
 use crate::builtins::ArrayBuiltins;
 use crate::kernel::ExecuteParentKernel;
@@ -91,7 +90,7 @@ pub(super) fn precondition(
 /// Fill null on a [`ConstantArray`] by replacing null scalars with the fill value,
 /// or casting non-null scalars to the fill value's dtype.
 pub(crate) fn fill_null_constant(
-    array: ArrayView<Constant>,
+    array: impl TypedArrayRef<Constant>,
     fill_value: &Scalar,
 ) -> VortexResult<ArrayRef> {
     let scalar = if array.scalar().is_null() {
@@ -122,10 +121,7 @@ where
         if child_idx != 0 {
             return Ok(None);
         }
-        let scalar_fn_array = parent
-            .as_opt::<ScalarFn>()
-            .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
-        let fill_value = scalar_fn_array
+        let fill_value = parent
             .get_child(1)
             .as_constant()
             .vortex_expect("fill_null fill_value must be constant");
@@ -158,10 +154,7 @@ where
         if child_idx != 0 {
             return Ok(None);
         }
-        let scalar_fn_array = parent
-            .as_opt::<ScalarFn>()
-            .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
-        let fill_value = scalar_fn_array
+        let fill_value = parent
             .get_child(1)
             .as_constant()
             .vortex_expect("fill_null fill_value must be constant");

--- a/vortex-array/src/scalar_fn/fns/fill_null/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/fill_null/kernel.rs
@@ -9,12 +9,11 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::array::ArrayView;
+use crate::array::TypedArrayRef;
 use crate::array::VTable;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ScalarFn;
 use crate::arrays::scalar_fn::ExactScalarFn;
-use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
 use crate::builtins::ArrayBuiltins;
 use crate::kernel::ExecuteParentKernel;
@@ -96,7 +95,7 @@ pub(super) fn short_circuit(
 /// Fill null on a [`ConstantArray`] by replacing null scalars with the fill value,
 /// or casting non-null scalars to the fill value's dtype.
 pub(crate) fn fill_null_constant(
-    array: ArrayView<Constant>,
+    array: impl TypedArrayRef<Constant>,
     fill_value: &Scalar,
 ) -> VortexResult<ArrayRef> {
     let scalar = if array.scalar().is_null() {
@@ -127,10 +126,7 @@ where
         if child_idx != 0 {
             return Ok(None);
         }
-        let scalar_fn_array = parent
-            .as_opt::<ScalarFn>()
-            .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
-        let fill_value = scalar_fn_array
+        let fill_value = parent
             .get_child(1)
             .as_constant()
             .vortex_expect("fill_null fill_value must be constant");
@@ -163,10 +159,7 @@ where
         if child_idx != 0 {
             return Ok(None);
         }
-        let scalar_fn_array = parent
-            .as_opt::<ScalarFn>()
-            .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
-        let fill_value = scalar_fn_array
+        let fill_value = parent
             .get_child(1)
             .as_constant()
             .vortex_expect("fill_null fill_value must be constant");

--- a/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
@@ -171,14 +171,18 @@ fn fill_null_canonical(
         return result.execute::<ArrayRef>(ctx);
     }
     match canonical {
-        CanonicalView::Bool(a) => <Bool as FillNullKernel>::fill_null(a, fill_value, ctx)?
-            .ok_or_else(|| vortex_err!("FillNullKernel for BoolArray returned None")),
+        CanonicalView::Bool(a) => {
+            <Bool as FillNullKernel>::fill_null(a.materialize_view(), fill_value, ctx)?
+                .ok_or_else(|| vortex_err!("FillNullKernel for BoolArray returned None"))
+        }
         CanonicalView::Primitive(a) => {
-            <Primitive as FillNullKernel>::fill_null(a, fill_value, ctx)?
+            <Primitive as FillNullKernel>::fill_null(a.materialize_view(), fill_value, ctx)?
                 .ok_or_else(|| vortex_err!("FillNullKernel for PrimitiveArray returned None"))
         }
-        CanonicalView::Decimal(a) => <Decimal as FillNullKernel>::fill_null(a, fill_value, ctx)?
-            .ok_or_else(|| vortex_err!("FillNullKernel for DecimalArray returned None")),
+        CanonicalView::Decimal(a) => {
+            <Decimal as FillNullKernel>::fill_null(a.materialize_view(), fill_value, ctx)?
+                .ok_or_else(|| vortex_err!("FillNullKernel for DecimalArray returned None"))
+        }
         other => vortex_bail!(
             "No FillNullKernel for canonical array {}",
             other.to_array_ref().encoding_id()

--- a/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
@@ -159,14 +159,18 @@ fn fill_null_canonical(
         return result.execute::<ArrayRef>(ctx);
     }
     match canonical {
-        CanonicalView::Bool(a) => <Bool as FillNullKernel>::fill_null(a, fill_value, ctx)?
-            .ok_or_else(|| vortex_err!("FillNullKernel for BoolArray returned None")),
+        CanonicalView::Bool(a) => {
+            <Bool as FillNullKernel>::fill_null(a.materialize_view(), fill_value, ctx)?
+                .ok_or_else(|| vortex_err!("FillNullKernel for BoolArray returned None"))
+        }
         CanonicalView::Primitive(a) => {
-            <Primitive as FillNullKernel>::fill_null(a, fill_value, ctx)?
+            <Primitive as FillNullKernel>::fill_null(a.materialize_view(), fill_value, ctx)?
                 .ok_or_else(|| vortex_err!("FillNullKernel for PrimitiveArray returned None"))
         }
-        CanonicalView::Decimal(a) => <Decimal as FillNullKernel>::fill_null(a, fill_value, ctx)?
-            .ok_or_else(|| vortex_err!("FillNullKernel for DecimalArray returned None")),
+        CanonicalView::Decimal(a) => {
+            <Decimal as FillNullKernel>::fill_null(a.materialize_view(), fill_value, ctx)?
+                .ok_or_else(|| vortex_err!("FillNullKernel for DecimalArray returned None"))
+        }
         other => vortex_bail!(
             "No FillNullKernel for canonical array {}",
             other.to_array_ref().encoding_id()

--- a/vortex-array/src/scalar_fn/fns/like/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/like/kernel.rs
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::VTable;
-use crate::arrays::ScalarFn;
 use crate::arrays::scalar_fn::ExactScalarFn;
-use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
 use crate::kernel::ExecuteParentKernel;
 use crate::optimizer::rules::ArrayParentReduceRule;
@@ -68,10 +65,7 @@ where
         if child_idx != 0 {
             return Ok(None);
         }
-        let scalar_fn_array = parent
-            .as_opt::<ScalarFn>()
-            .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
-        let pattern = scalar_fn_array.get_child(1);
+        let pattern = parent.get_child(1);
         let options = *parent.options;
         <V as LikeReduce>::like(array, pattern, options)
     }
@@ -97,10 +91,7 @@ where
         if child_idx != 0 {
             return Ok(None);
         }
-        let scalar_fn_array = parent
-            .as_opt::<ScalarFn>()
-            .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
-        let pattern = scalar_fn_array.get_child(1);
+        let pattern = parent.get_child(1);
         let options = *parent.options;
         <V as LikeKernel>::like(array, pattern, options, ctx)
     }

--- a/vortex-array/src/scalar_fn/fns/list_contains/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/kernel.rs
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::VTable;
-use crate::arrays::ScalarFn;
 use crate::arrays::scalar_fn::ExactScalarFn;
-use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
 use crate::kernel::ExecuteParentKernel;
 use crate::optimizer::rules::ArrayParentReduceRule;
@@ -66,10 +63,7 @@ where
         if child_idx != 1 {
             return Ok(None);
         }
-        let scalar_fn_array = parent
-            .as_opt::<ScalarFn>()
-            .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
-        let list = scalar_fn_array.get_child(0);
+        let list = parent.get_child(0);
         <V as ListContainsElementReduce>::list_contains(list, array)
     }
 }
@@ -95,10 +89,7 @@ where
         if child_idx != 1 {
             return Ok(None);
         }
-        let scalar_fn_array = parent
-            .as_opt::<ScalarFn>()
-            .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
-        let list = scalar_fn_array.get_child(0);
+        let list = parent.get_child(0);
         <V as ListContainsElementKernel>::list_contains(list, array, ctx)
     }
 }

--- a/vortex-array/src/scalar_fn/fns/list_length.rs
+++ b/vortex-array/src/scalar_fn/fns/list_length.rs
@@ -10,7 +10,7 @@ use vortex_session::registry::CachedId;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::array::ArrayView;
+use crate::TypedArrayRef;
 use crate::arrays::ConstantArray;
 use crate::arrays::FixedSizeList;
 use crate::arrays::List;
@@ -25,6 +25,7 @@ use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::expr::Expression;
+use crate::matcher::AsParent;
 use crate::matcher::Matcher;
 use crate::scalar::Scalar;
 use crate::scalar_fn::Arity;
@@ -141,7 +142,7 @@ pub(crate) fn list_length(
         let lengths =
             ConstantArray::new(Scalar::primitive(size, Nullability::NonNullable), fsl.len())
                 .into_array();
-        (lengths, fsl.validity()?)
+        (lengths, fsl.fixed_size_list_validity())
     } else if let Some(lv) = any_list.as_opt::<ListView>() {
         // Length array is exactly the sizes child
         (lv.sizes().clone(), lv.listview_validity())
@@ -167,7 +168,7 @@ pub(crate) fn list_length(
 
 /// Calculate the lengths of `ListArray` elements via the `offsets` child:
 /// `length[i] = offsets[i + 1] - offsets[i]`.
-fn list_length_from_offsets(list: ArrayView<'_, List>) -> VortexResult<ArrayRef> {
+fn list_length_from_offsets(list: impl TypedArrayRef<List>) -> VortexResult<ArrayRef> {
     let offsets = list.offsets();
     let n = offsets.len().saturating_sub(1);
 
@@ -182,10 +183,10 @@ struct AnyList;
 impl Matcher for AnyList {
     type Match<'a> = ();
 
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        (array.as_opt::<List>().is_some()
-            || array.as_opt::<ListView>().is_some()
-            || array.as_opt::<FixedSizeList>().is_some())
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        (parent.is_encoding::<List>()
+            || parent.is_encoding::<ListView>()
+            || parent.is_encoding::<FixedSizeList>())
         .then_some(())
     }
 }

--- a/vortex-array/src/scalar_fn/fns/mask/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/mask/kernel.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_error::VortexResult;
-use vortex_error::vortex_err;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
@@ -75,14 +74,11 @@ where
         // `Constant`. `Mask::return_dtype` guarantees the mask is `Bool(NonNullable)`, so a
         // `Constant` here is a non-nullable Boolean. Other encodings may need execution, so leave
         // them to the kernel.
-        let parent_ref: ArrayRef = (*parent).clone();
-        let mask_child = parent_ref
-            .nth_child(1)
-            .ok_or_else(|| vortex_err!("Mask expression must have 2 children"))?;
+        let mask_child = parent.get_child(1);
         if mask_child.as_opt::<Bool>().is_none() && mask_child.as_opt::<Constant>().is_none() {
             return Ok(None);
         }
-        <V as MaskReduce>::mask(array, &mask_child)
+        <V as MaskReduce>::mask(array, mask_child)
     }
 }
 
@@ -107,10 +103,8 @@ where
         if child_idx != 0 {
             return Ok(None);
         }
-        let mask_child = parent
-            .nth_child(1)
-            .ok_or_else(|| vortex_err!("Mask expression must have 2 children"))?;
-        <V as MaskKernel>::mask(array, &mask_child, ctx)
+        let mask_child = parent.get_child(1);
+        <V as MaskKernel>::mask(array, mask_child, ctx)
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/merge.rs
+++ b/vortex-array/src/scalar_fn/fns/merge.rs
@@ -7,9 +7,9 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use itertools::Itertools as _;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 use vortex_utils::aliases::hash_set::HashSet;
@@ -187,16 +187,13 @@ impl ScalarFnVTable for Merge {
 
         for child in (0..node.child_count()).map(|i| node.child(i)) {
             let child_dtype = child.node_dtype()?;
-            if !child_dtype.is_struct() {
-                vortex_bail!(
+
+            let child_dtype = child_dtype.as_struct_fields_opt().ok_or_else(|| {
+                vortex_err!(
                     "Merge child must return a non-nullable struct dtype, got {}",
                     child_dtype
                 )
-            }
-
-            let child_dtype = child_dtype
-                .as_struct_fields_opt()
-                .vortex_expect("expected struct");
+            })?;
 
             for name in child_dtype.names().iter() {
                 if let Some(idx) = names.iter().position(|n| n == name) {

--- a/vortex-array/src/scalar_fn/fns/merge.rs
+++ b/vortex-array/src/scalar_fn/fns/merge.rs
@@ -7,9 +7,9 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use itertools::Itertools as _;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 use vortex_utils::aliases::hash_set::HashSet;
@@ -180,16 +180,13 @@ impl ScalarFnVTable for Merge {
 
         for child in (0..node.child_count()).map(|i| node.child(i)) {
             let child_dtype = child.node_dtype()?;
-            if !child_dtype.is_struct() {
-                vortex_bail!(
+
+            let child_dtype = child_dtype.as_struct_fields_opt().ok_or_else(|| {
+                vortex_err!(
                     "Merge child must return a non-nullable struct dtype, got {}",
                     child_dtype
                 )
-            }
-
-            let child_dtype = child_dtype
-                .as_struct_fields_opt()
-                .vortex_expect("expected struct");
+            })?;
 
             for name in child_dtype.names().iter() {
                 if let Some(idx) = names.iter().position(|n| n == name) {

--- a/vortex-array/src/scalar_fn/fns/not/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/not/mod.rs
@@ -90,7 +90,7 @@ impl ScalarFnVTable for Not {
         }
 
         // For boolean array
-        if let Some(bool) = child.as_opt::<Bool>() {
+        if let Some(bool) = child.as_typed::<Bool>() {
             return Ok(BoolArray::new(!bool.to_bit_buffer(), bool.validity()?).into_array());
         }
 

--- a/vortex-array/src/scalar_fn/fns/not/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/not/mod.rs
@@ -103,7 +103,7 @@ impl ScalarFnVTable for Not {
         }
 
         // For boolean array
-        if let Some(bool) = child.as_opt::<Bool>() {
+        if let Some(bool) = child.as_typed::<Bool>() {
             return Ok(BoolArray::new(!bool.to_bit_buffer(), bool.validity()?).into_array());
         }
 

--- a/vortex-array/src/scalar_fn/fns/zip/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/zip/kernel.rs
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::VTable;
-use crate::arrays::ScalarFn;
 use crate::arrays::scalar_fn::ExactScalarFn;
-use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
 use crate::kernel::ExecuteParentKernel;
 use crate::optimizer::rules::ArrayParentReduceRule;
@@ -67,11 +64,8 @@ where
         if child_idx != 0 {
             return Ok(None);
         }
-        let scalar_fn_array = parent
-            .as_opt::<ScalarFn>()
-            .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
-        let if_false = scalar_fn_array.get_child(1);
-        let mask_array = scalar_fn_array.get_child(2);
+        let if_false = parent.get_child(1);
+        let mask_array = parent.get_child(2);
         <V as ZipReduce>::zip(array, if_false, mask_array)
     }
 }
@@ -96,11 +90,8 @@ where
         if child_idx != 0 {
             return Ok(None);
         }
-        let scalar_fn_array = parent
-            .as_opt::<ScalarFn>()
-            .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
-        let if_false = scalar_fn_array.get_child(1);
-        let mask_array = scalar_fn_array.get_child(2);
+        let if_false = parent.get_child(1);
+        let mask_array = parent.get_child(2);
         <V as ZipKernel>::zip(array, if_false, mask_array, ctx)
     }
 }

--- a/vortex-array/src/scalar_fn/fns/zip/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/zip/mod.rs
@@ -584,6 +584,6 @@ mod tests {
                 false_value(i)
             }
         }));
-        assert_arrays_eq!(zipped.array().clone(), expected, &mut ctx);
+        assert_arrays_eq!(zipped.materialize_array_ref().clone(), expected, &mut ctx);
     }
 }

--- a/vortex-array/src/scalar_fn/fns/zip/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/zip/mod.rs
@@ -560,8 +560,7 @@ mod tests {
             .unwrap()
             .execute::<ArrayRef>(&mut ctx)
             .unwrap();
-        let zipped = zipped.as_opt::<VarBinView>().unwrap();
-        assert_eq!(zipped.data_buffers().len(), 2);
+        assert_eq!(zipped.as_::<VarBinView>().data_buffers().len(), 2);
 
         let true_value = |i: usize| {
             if i.is_multiple_of(2) {
@@ -584,6 +583,6 @@ mod tests {
                 false_value(i)
             }
         }));
-        assert_arrays_eq!(zipped.materialize_array_ref().clone(), expected, &mut ctx);
+        assert_arrays_eq!(zipped, expected, &mut ctx);
     }
 }

--- a/vortex-array/src/scalar_fn/fns/zip/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/zip/mod.rs
@@ -516,6 +516,6 @@ mod tests {
                 false_value(i)
             }
         }));
-        assert_arrays_eq!(zipped.array().clone(), expected, &mut ctx);
+        assert_arrays_eq!(zipped.materialize_array_ref().clone(), expected, &mut ctx);
     }
 }

--- a/vortex-array/src/scalar_fn/fns/zip/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/zip/mod.rs
@@ -492,8 +492,7 @@ mod tests {
             .unwrap()
             .execute::<ArrayRef>(&mut ctx)
             .unwrap();
-        let zipped = zipped.as_opt::<VarBinView>().unwrap();
-        assert_eq!(zipped.data_buffers().len(), 2);
+        assert_eq!(zipped.as_::<VarBinView>().data_buffers().len(), 2);
 
         let true_value = |i: usize| {
             if i.is_multiple_of(2) {
@@ -516,6 +515,6 @@ mod tests {
                 false_value(i)
             }
         }));
-        assert_arrays_eq!(zipped.materialize_array_ref().clone(), expected, &mut ctx);
+        assert_arrays_eq!(zipped, expected, &mut ctx);
     }
 }

--- a/vortex-array/src/scalar_fn/vtable.rs
+++ b/vortex-array/src/scalar_fn/vtable.rs
@@ -18,8 +18,10 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::array::ParentView;
 use crate::arrays::ScalarFn;
 use crate::arrays::ScalarFnArray;
+use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::dtype::DType;
 use crate::expr::BoundExpression;
 use crate::expr::Expression;
@@ -314,72 +316,104 @@ impl ReduceNode for ExpressionReduceNode<'_> {
 }
 
 /// A [`ReduceNode`] over an array tree.
+///
+/// The root may be a [`ParentView`] over stack-allocated construction parts. Rules read its
+/// dtype, length, scalar function, and children without materializing it; only
+/// [`Self::into_array`] on the root itself allocates. Children are always heap-backed
+/// [`ArrayRef`]s, so descending borrows them directly.
 #[derive(Clone)]
-pub struct ArrayReduceNode<'a> {
-    array: Cow<'a, ArrayRef>,
+pub struct ArrayReduceNode<'a>(NodeRef<'a>);
+
+#[derive(Clone)]
+enum NodeRef<'a> {
+    /// The root of a reduction, possibly stack-backed.
+    Parent(ParentView<'a, ScalarFn>),
+    /// A child borrowed from the tree being reduced.
+    Borrowed(&'a ArrayRef),
+    /// A freshly-built subtree produced by [`ReduceNode::new_node`].
+    Owned(ArrayRef),
 }
 
 impl<'a> ArrayReduceNode<'a> {
     /// Creates a node borrowing the given array.
     pub fn new(array: &'a ArrayRef) -> Self {
-        Self {
-            array: Cow::Borrowed(array),
+        Self(NodeRef::Borrowed(array))
+    }
+
+    /// Creates a root node over a parent view, leaving stack-backed parents unmaterialized.
+    pub fn from_parent(parent: ParentView<'a, ScalarFn>) -> Self {
+        Self(NodeRef::Parent(parent))
+    }
+
+    /// Consumes this node and returns the backing array, materializing a stack-backed root.
+    pub fn into_array(self) -> ArrayRef {
+        match self.0 {
+            NodeRef::Parent(parent) => parent.materialize_array_ref().clone(),
+            NodeRef::Borrowed(array) => array.clone(),
+            NodeRef::Owned(array) => array,
         }
     }
 
-    /// Returns the array backing this node.
-    pub fn array(&self) -> &ArrayRef {
-        &self.array
-    }
-
-    /// Consumes this node and returns the backing array.
-    pub fn into_array(self) -> ArrayRef {
-        self.array.into_owned()
+    fn len(&self) -> usize {
+        match &self.0 {
+            NodeRef::Parent(parent) => parent.len(),
+            NodeRef::Borrowed(array) => array.len(),
+            NodeRef::Owned(array) => array.len(),
+        }
     }
 }
 
 impl ReduceNode for ArrayReduceNode<'_> {
     fn node_dtype(&self) -> VortexResult<DType> {
-        Ok(self.array.dtype().clone())
+        Ok(match &self.0 {
+            NodeRef::Parent(parent) => parent.dtype().clone(),
+            NodeRef::Borrowed(array) => array.dtype().clone(),
+            NodeRef::Owned(array) => array.dtype().clone(),
+        })
     }
 
     fn scalar_fn(&self) -> Option<&ScalarFnRef> {
-        self.array
-            .as_opt::<ScalarFn>()
-            .map(|a| a.data().scalar_fn())
+        match &self.0 {
+            NodeRef::Parent(parent) => Some(ScalarFnArrayExt::scalar_fn(parent)),
+            NodeRef::Borrowed(array) => array.as_opt::<ScalarFn>().map(|a| a.data().scalar_fn()),
+            NodeRef::Owned(array) => array.as_opt::<ScalarFn>().map(|a| a.data().scalar_fn()),
+        }
     }
 
     fn child(&self, idx: usize) -> Self {
-        let array = match &self.array {
-            Cow::Borrowed(array) => Cow::Borrowed(
+        Self(match &self.0 {
+            // Slots borrow from the parent for `'a`, so children stay borrowed.
+            NodeRef::Parent(parent) => NodeRef::Borrowed(
+                parent.slots()[idx]
+                    .as_ref()
+                    .vortex_expect("ScalarFnArray child slot"),
+            ),
+            NodeRef::Borrowed(array) => NodeRef::Borrowed(
                 array
-                    .children_iter()
-                    .nth(idx)
+                    .nth_child(idx)
                     .vortex_expect("child idx out of bounds"),
             ),
-            Cow::Owned(array) => Cow::Owned(
+            NodeRef::Owned(array) => NodeRef::Owned(
                 array
                     .nth_child(idx)
                     .vortex_expect("child idx out of bounds")
                     .clone(),
             ),
-        };
-        Self { array }
+        })
     }
 
     fn child_count(&self) -> usize {
-        self.array.nchildren()
+        match &self.0 {
+            NodeRef::Parent(parent) => parent.slots().len(),
+            NodeRef::Borrowed(array) => array.nchildren(),
+            NodeRef::Owned(array) => array.nchildren(),
+        }
     }
 
     fn new_node(&self, scalar_fn: ScalarFnRef, children: &[Self]) -> VortexResult<Self> {
-        let array = ScalarFnArray::try_new_with_len(
-            scalar_fn,
-            children.iter().map(|c| c.array.as_ref().clone()).collect(),
-            self.array.len(),
-        )?;
-        Ok(Self {
-            array: Cow::Owned(array.into_array()),
-        })
+        let children = children.iter().map(|c| c.clone().into_array()).collect();
+        let array = ScalarFnArray::try_new_with_len(scalar_fn, children, self.len())?;
+        Ok(Self(NodeRef::Owned(array.into_array())))
     }
 }
 

--- a/vortex-array/src/scalar_fn/vtable.rs
+++ b/vortex-array/src/scalar_fn/vtable.rs
@@ -104,7 +104,7 @@ pub trait ScalarFnVTable: 'static + Sized + Clone + Send + Sync {
     /// Implementations may assume correct arity and will panic or return nonsensical results if
     /// violated.
     ///
-    /// [`Expression::try_new`]: crate::expr::Expression::try_new
+    /// [`Expression::try_new`]: Expression::try_new
     fn return_dtype(&self, options: &Self::Options, args: &[DType]) -> VortexResult<DType>;
 
     /// Execute the expression over the input arguments.

--- a/vortex-array/src/scalar_fn/vtable.rs
+++ b/vortex-array/src/scalar_fn/vtable.rs
@@ -360,7 +360,8 @@ impl ReduceNode for ArrayReduceNode<'_> {
             Cow::Owned(array) => Cow::Owned(
                 array
                     .nth_child(idx)
-                    .vortex_expect("child idx out of bounds"),
+                    .vortex_expect("child idx out of bounds")
+                    .clone(),
             ),
         };
         Self { array }

--- a/vortex-array/src/scalar_fn/vtable.rs
+++ b/vortex-array/src/scalar_fn/vtable.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
 use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Display;
@@ -20,6 +19,7 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::dtype::DType;
 use crate::expr::Expression;
+use crate::expr::ExpressionReduceNode;
 use crate::expr::traversal::Node;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnRef;
@@ -114,7 +114,7 @@ pub trait ScalarFnVTable: 'static + Sized + Clone + Send + Sync {
     /// Implementations may assume correct arity and will panic or return nonsensical results if
     /// violated.
     ///
-    /// [`Expression::try_new`]: crate::expr::Expression::try_new
+    /// [`Expression::try_new`]: Expression::try_new
     fn return_dtype(&self, options: &Self::Options, args: &[DType]) -> VortexResult<DType>;
 
     /// Execute the expression over the input arguments.
@@ -276,8 +276,9 @@ pub type ReduceNodeRef = Arc<dyn ReduceNode>;
 
 /// A node used for implementing abstract reduction rules.
 pub trait ReduceNode {
-    /// Downcast to Any.
-    fn as_any(&self) -> &dyn Any;
+    fn as_array(&self) -> ArrayRef;
+
+    fn as_expression(&self) -> ExpressionReduceNode;
 
     /// Return the data type of this node.
     fn node_dtype(&self) -> VortexResult<DType>;

--- a/vortex-array/src/test_harness/trace/mod.rs
+++ b/vortex-array/src/test_harness/trace/mod.rs
@@ -17,6 +17,11 @@
 //! - **Execution**: `execute_until` iterations, single-step entries, parent kernel attempts and
 //!   matches, slot transitions, builder start/append/finish, and the eventual canonical output.
 //!
+//! Both parent dispatch chains are covered. An optimization of a heap array and one of borrowed
+//! construction parts ([`ArrayParts::optimize`](crate::array::ArrayParts::optimize)) record the
+//! same events, and a parent is summarized from its metadata via [`TraceArray`], so recording a
+//! trace never forces a stack-allocated parent to materialize.
+//!
 //! Despite the name `trace_op`, the harness is *not* a generic logging facility: it is closely
 //! coupled to the optimizer/executor state machines so that the resulting trace is stable enough
 //! to commit as a snapshot.
@@ -75,6 +80,13 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 
 use crate::ArrayRef;
+use crate::array::ArrayId;
+use crate::array::ArrayView;
+use crate::array::ParentRef;
+use crate::array::ParentView;
+use crate::array::VTable;
+use crate::display::EncodingSummaryExtractor;
+use crate::dtype::DType;
 
 /// Controls how much rule and kernel resolution detail is captured.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -334,40 +346,86 @@ impl From<TraceResolution> for TraceInterest {
     }
 }
 
-/// Snapshot-friendly wrapper around [`ArrayRef`] that renders the encoding, dtype, and length
-/// using the canonical [`Display`] format (`vortex.primitive(i32, len=4)`).
+/// Snapshot-friendly summary of an array that renders the encoding, dtype, and length using the
+/// canonical [`Display`] format (`vortex.primitive(i32, len=4)`).
 ///
-/// Carries a clone of the [`ArrayRef`] instead of duplicating fields,
-/// so trace events stay small and share the same rendering as every other `{array}` print in
-/// the codebase.
+/// Carries the three summary fields rather than a cloned [`ArrayRef`] because the parent side of
+/// the dispatch chain is a [`ParentRef`], which may borrow construction parts that have not been
+/// heap-allocated yet. Recording a trace event must never be the reason a parent materializes, so
+/// the summary is captured from metadata alone. Rendering goes through
+/// [`EncodingSummaryExtractor`] so a traced array prints exactly like every other `{array}` print
+/// in the codebase.
 #[derive(Clone, Debug)]
-pub(crate) struct ArraySummary(ArrayRef);
+pub(crate) struct ArraySummary {
+    encoding_id: ArrayId,
+    dtype: DType,
+    len: usize,
+}
 
 impl ArraySummary {
-    pub(crate) fn new(array: &ArrayRef) -> Self {
-        Self(array.clone())
+    fn new(encoding_id: ArrayId, dtype: &DType, len: usize) -> Self {
+        Self {
+            encoding_id,
+            dtype: dtype.clone(),
+            len,
+        }
     }
 }
 
 impl Display for ArraySummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Display::fmt(&self.0, f)
+        EncodingSummaryExtractor::write_parts(self.encoding_id, &self.dtype, self.len, f)
     }
 }
 
-pub(crate) fn record_optimize_start(root: &ArrayRef, session: bool) {
+/// An array the trace harness can summarize without materializing it.
+///
+/// Implemented for both dispatch chains: the heap-backed [`ArrayRef`] and [`ArrayView`], and the
+/// possibly stack-backed [`ParentRef`] and [`ParentView`]. The `record_*` functions take
+/// `&impl TraceArray` for subject and parent arguments, so a single signature serves an optimizer
+/// pass over a heap array and a parent-reduce over borrowed [`ArrayParts`](crate::array::ArrayParts).
+pub(crate) trait TraceArray {
+    /// Capture this array's encoding, dtype, and length.
+    fn trace_summary(&self) -> ArraySummary;
+}
+
+impl TraceArray for ArrayRef {
+    fn trace_summary(&self) -> ArraySummary {
+        ArraySummary::new(self.encoding_id(), self.dtype(), self.len())
+    }
+}
+
+impl TraceArray for ParentRef<'_> {
+    fn trace_summary(&self) -> ArraySummary {
+        ArraySummary::new(self.encoding_id(), self.dtype(), self.len())
+    }
+}
+
+impl<V: VTable> TraceArray for ArrayView<'_, V> {
+    fn trace_summary(&self) -> ArraySummary {
+        ArraySummary::new(self.encoding_id(), self.dtype(), self.len())
+    }
+}
+
+impl<V: VTable> TraceArray for ParentView<'_, V> {
+    fn trace_summary(&self) -> ArraySummary {
+        ArraySummary::new(self.encoding_id(), self.dtype(), self.len())
+    }
+}
+
+pub(crate) fn record_optimize_start(root: &impl TraceArray, session: bool) {
     record(TraceEvent::OptimizeStart {
-        root: ArraySummary::new(root),
+        root: root.trace_summary(),
         session,
     });
 }
 
-pub(crate) fn record_optimize_loop_start(array: &ArrayRef) {
+pub(crate) fn record_optimize_loop_start(array: &impl TraceArray) {
     if !attempts_enabled() {
         return;
     }
     record(TraceEvent::OptimizeLoopStart {
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
@@ -378,7 +436,7 @@ pub(crate) fn record_optimize_loop_end() {
     record(TraceEvent::OptimizeLoopEnd);
 }
 
-pub(crate) fn record_optimize_reduce_none(array: &ArrayRef) {
+pub(crate) fn record_optimize_reduce_none(array: &impl TraceArray) {
     if !attempts_enabled() {
         return;
     }
@@ -386,11 +444,11 @@ pub(crate) fn record_optimize_reduce_none(array: &ArrayRef) {
         indent: 0,
         phase: "reduce",
         subject: "array",
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
-pub(crate) fn record_optimize_parent_reduce_none(array: &ArrayRef) {
+pub(crate) fn record_optimize_parent_reduce_none(array: &impl TraceArray) {
     if !attempts_enabled() {
         return;
     }
@@ -398,52 +456,52 @@ pub(crate) fn record_optimize_parent_reduce_none(array: &ArrayRef) {
         indent: 0,
         phase: "reduce_parent",
         subject: "array",
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
 pub(crate) fn record_optimize_done(output: &ArrayRef, changed: bool) {
     record(TraceEvent::OptimizeDone {
-        output: ArraySummary::new(output),
+        output: output.trace_summary(),
         changed,
     });
 }
 
-pub(crate) fn record_optimize_recursive_start(root: &ArrayRef) {
+pub(crate) fn record_optimize_recursive_start(root: &impl TraceArray) {
     record(TraceEvent::OptimizeRecursiveStart {
-        root: ArraySummary::new(root),
+        root: root.trace_summary(),
     });
 }
 
 pub(crate) fn record_optimize_recursive_slot(slot_idx: usize, input: &ArrayRef, output: &ArrayRef) {
     record(TraceEvent::OptimizeRecursiveSlot {
         slot_idx,
-        input: ArraySummary::new(input),
-        output: ArraySummary::new(output),
+        input: input.trace_summary(),
+        output: output.trace_summary(),
     });
 }
 
-pub(crate) fn record_reduce_applied(array: &ArrayRef, rule: &dyn Debug, output: &ArrayRef) {
+pub(crate) fn record_reduce_applied(array: &impl TraceArray, rule: &dyn Debug, output: &ArrayRef) {
     record(TraceEvent::ReduceApplied {
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
         rule: compact_label(rule),
-        output: ArraySummary::new(output),
+        output: output.trace_summary(),
     });
 }
 
-pub(crate) fn record_reduce_declined(array: &ArrayRef, rule: &dyn Debug) {
+pub(crate) fn record_reduce_declined(array: &impl TraceArray, rule: &dyn Debug) {
     if !attempts_enabled() {
         return;
     }
     record(TraceEvent::ReduceAttempt {
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
         rule: compact_label(rule),
         outcome: AttemptOutcome::Declined,
     });
 }
 
 pub(crate) fn record_session_parent_reduce_applied(
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     plugin_idx: usize,
@@ -460,7 +518,7 @@ pub(crate) fn record_session_parent_reduce_applied(
 }
 
 pub(crate) fn record_session_parent_reduce_declined(
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     plugin_idx: usize,
@@ -476,7 +534,7 @@ pub(crate) fn record_session_parent_reduce_declined(
 }
 
 pub(crate) fn record_static_parent_reduce_no_match(
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     rule: &dyn Debug,
@@ -492,7 +550,7 @@ pub(crate) fn record_static_parent_reduce_no_match(
 }
 
 pub(crate) fn record_static_parent_reduce_applied(
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     rule: &dyn Debug,
@@ -509,7 +567,7 @@ pub(crate) fn record_static_parent_reduce_applied(
 }
 
 pub(crate) fn record_static_parent_reduce_declined(
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     rule: &dyn Debug,
@@ -525,7 +583,7 @@ pub(crate) fn record_static_parent_reduce_declined(
 }
 
 fn record_parent_reduce_attempt(
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     source: TraceSource,
@@ -536,8 +594,8 @@ fn record_parent_reduce_attempt(
         return;
     }
     record(TraceEvent::ParentReduceAttempt {
-        parent: ArraySummary::new(parent),
-        child: ArraySummary::new(child),
+        parent: parent.trace_summary(),
+        child: child.trace_summary(),
         slot_idx,
         source,
         rule: rule.into(),
@@ -546,7 +604,7 @@ fn record_parent_reduce_attempt(
 }
 
 fn record_parent_reduce_applied(
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     source: TraceSource,
@@ -554,19 +612,19 @@ fn record_parent_reduce_applied(
     output: &ArrayRef,
 ) {
     record(TraceEvent::ParentReduceApplied {
-        parent: ArraySummary::new(parent),
-        child: ArraySummary::new(child),
+        parent: parent.trace_summary(),
+        child: child.trace_summary(),
         slot_idx,
         source,
         rule: rule.into(),
-        output: ArraySummary::new(output),
+        output: output.trace_summary(),
     });
 }
 
 pub(crate) fn record_execute_until_start<M>(root: &ArrayRef) {
     record(TraceEvent::ExecuteUntilStart {
         target: short_type_name::<M>(),
-        root: ArraySummary::new(root),
+        root: root.trace_summary(),
     });
 }
 
@@ -578,8 +636,8 @@ pub(crate) fn record_execute_until_iteration(
 ) {
     record(TraceEvent::ExecuteUntilIteration {
         iteration,
-        current: ArraySummary::new(current),
-        stack_parent: stack_parent.map(|(array, slot_idx)| (ArraySummary::new(array), slot_idx)),
+        current: current.trace_summary(),
+        stack_parent: stack_parent.map(|(array, slot_idx)| (array.trace_summary(), slot_idx)),
         builder_active,
     });
 }
@@ -593,20 +651,20 @@ pub(crate) fn record_execute_until_done_check(target: bool, canonical: bool) {
 
 pub(crate) fn record_execute_until_return(output: &ArrayRef) {
     record(TraceEvent::ExecuteUntilReturn {
-        output: ArraySummary::new(output),
+        output: output.trace_summary(),
     });
 }
 
 pub(crate) fn record_execute_until_pop_frame(slot_idx: usize, output: &ArrayRef) {
     record(TraceEvent::ExecuteUntilPopFrame {
         slot_idx,
-        output: ArraySummary::new(output),
+        output: output.trace_summary(),
     });
 }
 
 pub(crate) fn record_session_execute_parent_applied(
     phase: &'static str,
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     plugin_idx: usize,
@@ -625,7 +683,7 @@ pub(crate) fn record_session_execute_parent_applied(
 
 pub(crate) fn record_session_execute_parent_declined(
     phase: &'static str,
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     plugin_idx: usize,
@@ -643,7 +701,7 @@ pub(crate) fn record_session_execute_parent_declined(
 
 fn record_execute_parent_attempt(
     phase: &'static str,
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     source: TraceSource,
@@ -655,8 +713,8 @@ fn record_execute_parent_attempt(
     }
     record(TraceEvent::ExecuteParentAttempt {
         phase,
-        parent: ArraySummary::new(parent),
-        child: ArraySummary::new(child),
+        parent: parent.trace_summary(),
+        child: child.trace_summary(),
         slot_idx,
         source,
         kernel: kernel.into(),
@@ -666,7 +724,7 @@ fn record_execute_parent_attempt(
 
 fn record_execute_parent_applied(
     phase: &'static str,
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     source: TraceSource,
@@ -675,16 +733,16 @@ fn record_execute_parent_applied(
 ) {
     record(TraceEvent::ExecuteParentApplied {
         phase,
-        parent: ArraySummary::new(parent),
-        child: ArraySummary::new(child),
+        parent: parent.trace_summary(),
+        child: child.trace_summary(),
         slot_idx,
         source,
         kernel: kernel.into(),
-        output: ArraySummary::new(output),
+        output: output.trace_summary(),
     });
 }
 
-pub(crate) fn record_execute_parent_none(phase: &'static str, current: &ArrayRef) {
+pub(crate) fn record_execute_parent_none(phase: &'static str, current: &impl TraceArray) {
     if !attempts_enabled() {
         return;
     }
@@ -692,7 +750,7 @@ pub(crate) fn record_execute_parent_none(phase: &'static str, current: &ArrayRef
         indent: 2,
         phase,
         subject: "current",
-        array: ArraySummary::new(current),
+        array: current.trace_summary(),
     });
 }
 
@@ -702,27 +760,27 @@ pub(crate) fn record_execute_optimized(input: &ArrayRef, output: &ArrayRef) {
         return;
     }
     record(TraceEvent::ExecuteOptimized {
-        input: ArraySummary::new(input),
-        output: ArraySummary::new(output),
+        input: input.trace_summary(),
+        output: output.trace_summary(),
         changed,
     });
 }
 
-pub(crate) fn record_execute_encoding(array: &ArrayRef) {
+pub(crate) fn record_execute_encoding(array: &impl TraceArray) {
     if !attempts_enabled() {
         return;
     }
     record(TraceEvent::ExecuteEncoding {
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
-pub(crate) fn record_execute_slot(slot_idx: usize, parent: &ArrayRef, child: &ArrayRef) {
+pub(crate) fn record_execute_slot(slot_idx: usize, parent: &impl TraceArray, child: &ArrayRef) {
     record(TraceEvent::SlotTransition {
         step: "ExecuteSlot",
         slot_idx,
-        parent: ArraySummary::new(parent),
-        child: ArraySummary::new(child),
+        parent: parent.trace_summary(),
+        child: child.trace_summary(),
     });
 }
 
@@ -730,16 +788,16 @@ pub(crate) fn record_builder_start(array: &ArrayRef) {
     record(TraceEvent::BuilderEvent {
         action: "start",
         subject: "array",
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
-pub(crate) fn record_append_child(slot_idx: usize, parent: &ArrayRef, child: &ArrayRef) {
+pub(crate) fn record_append_child(slot_idx: usize, parent: &impl TraceArray, child: &ArrayRef) {
     record(TraceEvent::SlotTransition {
         step: "AppendChild",
         slot_idx,
-        parent: ArraySummary::new(parent),
-        child: ArraySummary::new(child),
+        parent: parent.trace_summary(),
+        child: child.trace_summary(),
     });
 }
 
@@ -747,13 +805,13 @@ pub(crate) fn record_builder_append(child: &ArrayRef) {
     record(TraceEvent::BuilderEvent {
         action: "append",
         subject: "child",
-        array: ArraySummary::new(child),
+        array: child.trace_summary(),
     });
 }
 
 pub(crate) fn record_execute_done(array: &ArrayRef) {
     record(TraceEvent::ExecuteDone {
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
@@ -761,17 +819,17 @@ pub(crate) fn record_builder_finish(output: &ArrayRef) {
     record(TraceEvent::BuilderEvent {
         action: "finish",
         subject: "output",
-        array: ArraySummary::new(output),
+        array: output.trace_summary(),
     });
 }
 
-pub(crate) fn record_single_step_start(array: &ArrayRef) {
+pub(crate) fn record_single_step_start(array: &impl TraceArray) {
     record(TraceEvent::SingleStepStart {
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
-pub(crate) fn record_single_step_phase_none(phase: &'static str, array: &ArrayRef) {
+pub(crate) fn record_single_step_phase_none(phase: &'static str, array: &impl TraceArray) {
     if !attempts_enabled() {
         return;
     }
@@ -779,15 +837,15 @@ pub(crate) fn record_single_step_phase_none(phase: &'static str, array: &ArrayRe
         indent: 1,
         phase,
         subject: "array",
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
 pub(crate) fn record_single_step_applied(phase: &'static str, input: &ArrayRef, output: &ArrayRef) {
     record(TraceEvent::SingleStepApplied {
         phase,
-        input: ArraySummary::new(input),
-        output: ArraySummary::new(output),
+        input: input.trace_summary(),
+        output: output.trace_summary(),
     });
 }
 

--- a/vortex-array/src/test_harness/trace/mod.rs
+++ b/vortex-array/src/test_harness/trace/mod.rs
@@ -17,6 +17,11 @@
 //! - **Execution**: `execute_until` iterations, single-step entries, parent kernel attempts and
 //!   matches, slot transitions, builder start/append/finish, and the eventual canonical output.
 //!
+//! Both parent dispatch chains are covered. An optimization of a heap array and one of borrowed
+//! construction parts ([`ArrayParts::optimize`](crate::array::ArrayParts::optimize)) record the
+//! same events, and a parent is summarized from its metadata via [`TraceArray`], so recording a
+//! trace never forces a stack-allocated parent to materialize.
+//!
 //! Despite the name `trace_op`, the harness is *not* a generic logging facility: it is closely
 //! coupled to the optimizer/executor state machines so that the resulting trace is stable enough
 //! to commit as a snapshot.
@@ -75,6 +80,13 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 
 use crate::ArrayRef;
+use crate::array::ArrayId;
+use crate::array::ArrayView;
+use crate::array::ParentRef;
+use crate::array::ParentView;
+use crate::array::VTable;
+use crate::display::EncodingSummaryExtractor;
+use crate::dtype::DType;
 
 /// Controls how much rule and kernel resolution detail is captured.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -332,40 +344,86 @@ impl From<TraceResolution> for TraceInterest {
     }
 }
 
-/// Snapshot-friendly wrapper around [`ArrayRef`] that renders the encoding, dtype, and length
-/// using the canonical [`Display`] format (`vortex.primitive(i32, len=4)`).
+/// Snapshot-friendly summary of an array that renders the encoding, dtype, and length using the
+/// canonical [`Display`] format (`vortex.primitive(i32, len=4)`).
 ///
-/// Carries a clone of the [`ArrayRef`] instead of duplicating fields,
-/// so trace events stay small and share the same rendering as every other `{array}` print in
-/// the codebase.
+/// Carries the three summary fields rather than a cloned [`ArrayRef`] because the parent side of
+/// the dispatch chain is a [`ParentRef`], which may borrow construction parts that have not been
+/// heap-allocated yet. Recording a trace event must never be the reason a parent materializes, so
+/// the summary is captured from metadata alone. Rendering goes through
+/// [`EncodingSummaryExtractor`] so a traced array prints exactly like every other `{array}` print
+/// in the codebase.
 #[derive(Clone, Debug)]
-pub(crate) struct ArraySummary(ArrayRef);
+pub(crate) struct ArraySummary {
+    encoding_id: ArrayId,
+    dtype: DType,
+    len: usize,
+}
 
 impl ArraySummary {
-    pub(crate) fn new(array: &ArrayRef) -> Self {
-        Self(array.clone())
+    fn new(encoding_id: ArrayId, dtype: &DType, len: usize) -> Self {
+        Self {
+            encoding_id,
+            dtype: dtype.clone(),
+            len,
+        }
     }
 }
 
 impl Display for ArraySummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Display::fmt(&self.0, f)
+        EncodingSummaryExtractor::write_parts(self.encoding_id, &self.dtype, self.len, f)
     }
 }
 
-pub(crate) fn record_optimize_start(root: &ArrayRef, session: bool) {
+/// An array the trace harness can summarize without materializing it.
+///
+/// Implemented for both dispatch chains: the heap-backed [`ArrayRef`] and [`ArrayView`], and the
+/// possibly stack-backed [`ParentRef`] and [`ParentView`]. The `record_*` functions take
+/// `&impl TraceArray` for subject and parent arguments, so a single signature serves an optimizer
+/// pass over a heap array and a parent-reduce over borrowed [`ArrayParts`](crate::array::ArrayParts).
+pub(crate) trait TraceArray {
+    /// Capture this array's encoding, dtype, and length.
+    fn trace_summary(&self) -> ArraySummary;
+}
+
+impl TraceArray for ArrayRef {
+    fn trace_summary(&self) -> ArraySummary {
+        ArraySummary::new(self.encoding_id(), self.dtype(), self.len())
+    }
+}
+
+impl TraceArray for ParentRef<'_> {
+    fn trace_summary(&self) -> ArraySummary {
+        ArraySummary::new(self.encoding_id(), self.dtype(), self.len())
+    }
+}
+
+impl<V: VTable> TraceArray for ArrayView<'_, V> {
+    fn trace_summary(&self) -> ArraySummary {
+        ArraySummary::new(self.encoding_id(), self.dtype(), self.len())
+    }
+}
+
+impl<V: VTable> TraceArray for ParentView<'_, V> {
+    fn trace_summary(&self) -> ArraySummary {
+        ArraySummary::new(self.encoding_id(), self.dtype(), self.len())
+    }
+}
+
+pub(crate) fn record_optimize_start(root: &impl TraceArray, session: bool) {
     record(TraceEvent::OptimizeStart {
-        root: ArraySummary::new(root),
+        root: root.trace_summary(),
         session,
     });
 }
 
-pub(crate) fn record_optimize_loop_start(array: &ArrayRef) {
+pub(crate) fn record_optimize_loop_start(array: &impl TraceArray) {
     if !attempts_enabled() {
         return;
     }
     record(TraceEvent::OptimizeLoopStart {
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
@@ -376,7 +434,7 @@ pub(crate) fn record_optimize_loop_end() {
     record(TraceEvent::OptimizeLoopEnd);
 }
 
-pub(crate) fn record_optimize_reduce_none(array: &ArrayRef) {
+pub(crate) fn record_optimize_reduce_none(array: &impl TraceArray) {
     if !attempts_enabled() {
         return;
     }
@@ -384,11 +442,11 @@ pub(crate) fn record_optimize_reduce_none(array: &ArrayRef) {
         indent: 0,
         phase: "reduce",
         subject: "array",
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
-pub(crate) fn record_optimize_parent_reduce_none(array: &ArrayRef) {
+pub(crate) fn record_optimize_parent_reduce_none(array: &impl TraceArray) {
     if !attempts_enabled() {
         return;
     }
@@ -396,52 +454,52 @@ pub(crate) fn record_optimize_parent_reduce_none(array: &ArrayRef) {
         indent: 0,
         phase: "reduce_parent",
         subject: "array",
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
 pub(crate) fn record_optimize_done(output: &ArrayRef, changed: bool) {
     record(TraceEvent::OptimizeDone {
-        output: ArraySummary::new(output),
+        output: output.trace_summary(),
         changed,
     });
 }
 
-pub(crate) fn record_optimize_recursive_start(root: &ArrayRef) {
+pub(crate) fn record_optimize_recursive_start(root: &impl TraceArray) {
     record(TraceEvent::OptimizeRecursiveStart {
-        root: ArraySummary::new(root),
+        root: root.trace_summary(),
     });
 }
 
 pub(crate) fn record_optimize_recursive_slot(slot_idx: usize, input: &ArrayRef, output: &ArrayRef) {
     record(TraceEvent::OptimizeRecursiveSlot {
         slot_idx,
-        input: ArraySummary::new(input),
-        output: ArraySummary::new(output),
+        input: input.trace_summary(),
+        output: output.trace_summary(),
     });
 }
 
-pub(crate) fn record_reduce_applied(array: &ArrayRef, rule: &dyn Debug, output: &ArrayRef) {
+pub(crate) fn record_reduce_applied(array: &impl TraceArray, rule: &dyn Debug, output: &ArrayRef) {
     record(TraceEvent::ReduceApplied {
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
         rule: compact_label(rule),
-        output: ArraySummary::new(output),
+        output: output.trace_summary(),
     });
 }
 
-pub(crate) fn record_reduce_declined(array: &ArrayRef, rule: &dyn Debug) {
+pub(crate) fn record_reduce_declined(array: &impl TraceArray, rule: &dyn Debug) {
     if !attempts_enabled() {
         return;
     }
     record(TraceEvent::ReduceAttempt {
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
         rule: compact_label(rule),
         outcome: AttemptOutcome::Declined,
     });
 }
 
 pub(crate) fn record_session_parent_reduce_applied(
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     plugin_idx: usize,
@@ -458,7 +516,7 @@ pub(crate) fn record_session_parent_reduce_applied(
 }
 
 pub(crate) fn record_session_parent_reduce_declined(
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     plugin_idx: usize,
@@ -474,7 +532,7 @@ pub(crate) fn record_session_parent_reduce_declined(
 }
 
 pub(crate) fn record_static_parent_reduce_no_match(
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     rule: &dyn Debug,
@@ -490,7 +548,7 @@ pub(crate) fn record_static_parent_reduce_no_match(
 }
 
 pub(crate) fn record_static_parent_reduce_applied(
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     rule: &dyn Debug,
@@ -507,7 +565,7 @@ pub(crate) fn record_static_parent_reduce_applied(
 }
 
 pub(crate) fn record_static_parent_reduce_declined(
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     rule: &dyn Debug,
@@ -523,7 +581,7 @@ pub(crate) fn record_static_parent_reduce_declined(
 }
 
 fn record_parent_reduce_attempt(
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     source: TraceSource,
@@ -534,8 +592,8 @@ fn record_parent_reduce_attempt(
         return;
     }
     record(TraceEvent::ParentReduceAttempt {
-        parent: ArraySummary::new(parent),
-        child: ArraySummary::new(child),
+        parent: parent.trace_summary(),
+        child: child.trace_summary(),
         slot_idx,
         source,
         rule: rule.into(),
@@ -544,7 +602,7 @@ fn record_parent_reduce_attempt(
 }
 
 fn record_parent_reduce_applied(
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     source: TraceSource,
@@ -552,19 +610,19 @@ fn record_parent_reduce_applied(
     output: &ArrayRef,
 ) {
     record(TraceEvent::ParentReduceApplied {
-        parent: ArraySummary::new(parent),
-        child: ArraySummary::new(child),
+        parent: parent.trace_summary(),
+        child: child.trace_summary(),
         slot_idx,
         source,
         rule: rule.into(),
-        output: ArraySummary::new(output),
+        output: output.trace_summary(),
     });
 }
 
 pub(crate) fn record_execute_until_start<M>(root: &ArrayRef) {
     record(TraceEvent::ExecuteUntilStart {
         target: short_type_name::<M>(),
-        root: ArraySummary::new(root),
+        root: root.trace_summary(),
     });
 }
 
@@ -576,8 +634,8 @@ pub(crate) fn record_execute_until_iteration(
 ) {
     record(TraceEvent::ExecuteUntilIteration {
         iteration,
-        current: ArraySummary::new(current),
-        stack_parent: stack_parent.map(|(array, slot_idx)| (ArraySummary::new(array), slot_idx)),
+        current: current.trace_summary(),
+        stack_parent: stack_parent.map(|(array, slot_idx)| (array.trace_summary(), slot_idx)),
         builder_active,
     });
 }
@@ -591,20 +649,20 @@ pub(crate) fn record_execute_until_done_check(target: bool, canonical: bool) {
 
 pub(crate) fn record_execute_until_return(output: &ArrayRef) {
     record(TraceEvent::ExecuteUntilReturn {
-        output: ArraySummary::new(output),
+        output: output.trace_summary(),
     });
 }
 
 pub(crate) fn record_execute_until_pop_frame(slot_idx: usize, output: &ArrayRef) {
     record(TraceEvent::ExecuteUntilPopFrame {
         slot_idx,
-        output: ArraySummary::new(output),
+        output: output.trace_summary(),
     });
 }
 
 pub(crate) fn record_session_execute_parent_applied(
     phase: &'static str,
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     plugin_idx: usize,
@@ -623,7 +681,7 @@ pub(crate) fn record_session_execute_parent_applied(
 
 pub(crate) fn record_session_execute_parent_declined(
     phase: &'static str,
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     plugin_idx: usize,
@@ -641,7 +699,7 @@ pub(crate) fn record_session_execute_parent_declined(
 
 fn record_execute_parent_attempt(
     phase: &'static str,
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     source: TraceSource,
@@ -653,8 +711,8 @@ fn record_execute_parent_attempt(
     }
     record(TraceEvent::ExecuteParentAttempt {
         phase,
-        parent: ArraySummary::new(parent),
-        child: ArraySummary::new(child),
+        parent: parent.trace_summary(),
+        child: child.trace_summary(),
         slot_idx,
         source,
         kernel: kernel.into(),
@@ -664,7 +722,7 @@ fn record_execute_parent_attempt(
 
 fn record_execute_parent_applied(
     phase: &'static str,
-    parent: &ArrayRef,
+    parent: &impl TraceArray,
     child: &ArrayRef,
     slot_idx: usize,
     source: TraceSource,
@@ -673,16 +731,16 @@ fn record_execute_parent_applied(
 ) {
     record(TraceEvent::ExecuteParentApplied {
         phase,
-        parent: ArraySummary::new(parent),
-        child: ArraySummary::new(child),
+        parent: parent.trace_summary(),
+        child: child.trace_summary(),
         slot_idx,
         source,
         kernel: kernel.into(),
-        output: ArraySummary::new(output),
+        output: output.trace_summary(),
     });
 }
 
-pub(crate) fn record_execute_parent_none(phase: &'static str, current: &ArrayRef) {
+pub(crate) fn record_execute_parent_none(phase: &'static str, current: &impl TraceArray) {
     if !attempts_enabled() {
         return;
     }
@@ -690,7 +748,7 @@ pub(crate) fn record_execute_parent_none(phase: &'static str, current: &ArrayRef
         indent: 2,
         phase,
         subject: "current",
-        array: ArraySummary::new(current),
+        array: current.trace_summary(),
     });
 }
 
@@ -700,27 +758,27 @@ pub(crate) fn record_execute_optimized(input: &ArrayRef, output: &ArrayRef) {
         return;
     }
     record(TraceEvent::ExecuteOptimized {
-        input: ArraySummary::new(input),
-        output: ArraySummary::new(output),
+        input: input.trace_summary(),
+        output: output.trace_summary(),
         changed,
     });
 }
 
-pub(crate) fn record_execute_encoding(array: &ArrayRef) {
+pub(crate) fn record_execute_encoding(array: &impl TraceArray) {
     if !attempts_enabled() {
         return;
     }
     record(TraceEvent::ExecuteEncoding {
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
-pub(crate) fn record_execute_slot(slot_idx: usize, parent: &ArrayRef, child: &ArrayRef) {
+pub(crate) fn record_execute_slot(slot_idx: usize, parent: &impl TraceArray, child: &ArrayRef) {
     record(TraceEvent::SlotTransition {
         step: "ExecuteSlot",
         slot_idx,
-        parent: ArraySummary::new(parent),
-        child: ArraySummary::new(child),
+        parent: parent.trace_summary(),
+        child: child.trace_summary(),
     });
 }
 
@@ -728,16 +786,16 @@ pub(crate) fn record_builder_start(array: &ArrayRef) {
     record(TraceEvent::BuilderEvent {
         action: "start",
         subject: "array",
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
-pub(crate) fn record_append_child(slot_idx: usize, parent: &ArrayRef, child: &ArrayRef) {
+pub(crate) fn record_append_child(slot_idx: usize, parent: &impl TraceArray, child: &ArrayRef) {
     record(TraceEvent::SlotTransition {
         step: "AppendChild",
         slot_idx,
-        parent: ArraySummary::new(parent),
-        child: ArraySummary::new(child),
+        parent: parent.trace_summary(),
+        child: child.trace_summary(),
     });
 }
 
@@ -745,13 +803,13 @@ pub(crate) fn record_builder_append(child: &ArrayRef) {
     record(TraceEvent::BuilderEvent {
         action: "append",
         subject: "child",
-        array: ArraySummary::new(child),
+        array: child.trace_summary(),
     });
 }
 
 pub(crate) fn record_execute_done(array: &ArrayRef) {
     record(TraceEvent::ExecuteDone {
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
@@ -759,17 +817,17 @@ pub(crate) fn record_builder_finish(output: &ArrayRef) {
     record(TraceEvent::BuilderEvent {
         action: "finish",
         subject: "output",
-        array: ArraySummary::new(output),
+        array: output.trace_summary(),
     });
 }
 
-pub(crate) fn record_single_step_start(array: &ArrayRef) {
+pub(crate) fn record_single_step_start(array: &impl TraceArray) {
     record(TraceEvent::SingleStepStart {
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
-pub(crate) fn record_single_step_phase_none(phase: &'static str, array: &ArrayRef) {
+pub(crate) fn record_single_step_phase_none(phase: &'static str, array: &impl TraceArray) {
     if !attempts_enabled() {
         return;
     }
@@ -777,15 +835,15 @@ pub(crate) fn record_single_step_phase_none(phase: &'static str, array: &ArrayRe
         indent: 1,
         phase,
         subject: "array",
-        array: ArraySummary::new(array),
+        array: array.trace_summary(),
     });
 }
 
 pub(crate) fn record_single_step_applied(phase: &'static str, input: &ArrayRef, output: &ArrayRef) {
     record(TraceEvent::SingleStepApplied {
         phase,
-        input: ArraySummary::new(input),
-        output: ArraySummary::new(output),
+        input: input.trace_summary(),
+        output: output.trace_summary(),
     });
 }
 

--- a/vortex-array/src/test_harness/trace/mod.rs
+++ b/vortex-array/src/test_harness/trace/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! Both parent dispatch chains are covered. An optimization of a heap array and one of borrowed
 //! construction parts ([`ArrayParts::optimize`](crate::array::ArrayParts::optimize)) record the
-//! same events, and a parent is summarized from its metadata via [`TraceArray`], so recording a
+//! same events, and a parent is summarized from its metadata via `TraceArray`, so recording a
 //! trace never forces a stack-allocated parent to materialize.
 //!
 //! Despite the name `trace_op`, the harness is *not* a generic logging facility: it is closely

--- a/vortex-array/src/test_harness/trace/tests.rs
+++ b/vortex-array/src/test_harness/trace/tests.rs
@@ -40,6 +40,8 @@ use crate::arrays::Filter;
 use crate::arrays::FilterArray;
 use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
+use crate::arrays::ScalarFnArray;
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::filter::FilterArraySlotsExt;
@@ -53,10 +55,13 @@ use crate::matcher::Matcher;
 use crate::optimizer::ArrayOptimizer;
 use crate::optimizer::kernels::ArrayKernelsExt;
 use crate::scalar::Scalar;
+use crate::scalar_fn::ScalarFnVTableExt;
 use crate::scalar_fn::fns::binary::Binary;
 use crate::scalar_fn::fns::like::Like;
 use crate::scalar_fn::fns::like::LikeOptions;
 use crate::scalar_fn::fns::operators::Operator;
+use crate::scalar_fn::fns::pack::Pack;
+use crate::scalar_fn::fns::pack::PackOptions;
 use crate::serde::ArrayChildren;
 use crate::session::ArraySession;
 use crate::test_harness::trace::TraceOptions;
@@ -710,6 +715,41 @@ fn trace_filter_on_struct_with_complex_children() -> VortexResult<()> {
     execute_until target=AnyCanonical root=vortex.struct({name=utf8, score=i64}, len=3)
       iter 0 current=vortex.struct({name=utf8, score=i64}, len=3) builder_active=false
       return output=vortex.struct({name=utf8, score=i64}, len=3)
+    ");
+
+    Ok(())
+}
+
+/// Optimizing borrowed construction parts must trace identically to materialize-then-optimize.
+///
+/// [`ArrayParts::optimize`] runs the same reduce and reduce_parent rules as
+/// [`ArrayOptimizer::optimize`], only against a parent borrowed from the stack, so both paths
+/// belong in a trace as the same `optimize` block. Before the two were unified, the stack path
+/// emitted its rule events with no enclosing `optimize`/`done` pass.
+#[test]
+fn trace_stack_parts_optimize_matches_heap_optimize() -> VortexResult<()> {
+    let a = PrimitiveArray::from_iter([1i32, 2, 3]).into_array();
+    let b = PrimitiveArray::from_iter([4i32, 5, 6]).into_array();
+    let len = a.len();
+    let pack = Pack.bind(PackOptions {
+        names: ["a", "b"].into(),
+        nullability: Nullability::NonNullable,
+    });
+
+    let heap = trace_op(|| {
+        ScalarFnArray::try_new_with_len(pack.clone(), vec![a.clone(), b.clone()], len)?
+            .into_array()
+            .optimize()
+    })?;
+    let stack = trace_op(|| ScalarFnArray::try_new_parts(pack, vec![a, b], len)?.optimize())?;
+
+    assert!(heap.output.is::<Struct>());
+    assert!(stack.output.is::<Struct>());
+    assert_eq!(stack.trace.to_string(), heap.trace.to_string());
+    insta::assert_snapshot!(stack.trace.to_string(), @"
+    optimize root=vortex.pack({a=i32, b=i32}, len=3) session=false
+      reduce ScalarFnPackToStructRule: vortex.pack({a=i32, b=i32}, len=3) -> vortex.struct({a=i32, b=i32}, len=3)
+      done output=vortex.struct({a=i32, b=i32}, len=3)
     ");
 
     Ok(())

--- a/vortex-array/src/test_harness/trace/tests.rs
+++ b/vortex-array/src/test_harness/trace/tests.rs
@@ -40,6 +40,8 @@ use crate::arrays::Filter;
 use crate::arrays::FilterArray;
 use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
+use crate::arrays::ScalarFnArray;
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::filter::FilterArraySlotsExt;
@@ -54,10 +56,13 @@ use crate::matcher::Matcher;
 use crate::optimizer::ArrayOptimizer;
 use crate::optimizer::kernels::ArrayKernelsExt;
 use crate::scalar::Scalar;
+use crate::scalar_fn::ScalarFnVTableExt;
 use crate::scalar_fn::fns::binary::Binary;
 use crate::scalar_fn::fns::like::Like;
 use crate::scalar_fn::fns::like::LikeOptions;
 use crate::scalar_fn::fns::operators::Operator;
+use crate::scalar_fn::fns::pack::Pack;
+use crate::scalar_fn::fns::pack::PackOptions;
 use crate::serde::ArrayChildren;
 use crate::session::ArraySession;
 use crate::test_harness::trace::TraceOptions;
@@ -668,6 +673,41 @@ fn trace_filter_on_struct_with_complex_children() -> VortexResult<()> {
     execute_until target=AnyCanonical root=vortex.struct({name=utf8, score=i64}, len=3)
       iter 0 current=vortex.struct({name=utf8, score=i64}, len=3) builder_active=false
       return output=vortex.struct({name=utf8, score=i64}, len=3)
+    ");
+
+    Ok(())
+}
+
+/// Optimizing borrowed construction parts must trace identically to materialize-then-optimize.
+///
+/// [`ArrayParts::optimize`] runs the same reduce and reduce_parent rules as
+/// [`ArrayOptimizer::optimize`], only against a parent borrowed from the stack, so both paths
+/// belong in a trace as the same `optimize` block. Before the two were unified, the stack path
+/// emitted its rule events with no enclosing `optimize`/`done` pass.
+#[test]
+fn trace_stack_parts_optimize_matches_heap_optimize() -> VortexResult<()> {
+    let a = PrimitiveArray::from_iter([1i32, 2, 3]).into_array();
+    let b = PrimitiveArray::from_iter([4i32, 5, 6]).into_array();
+    let len = a.len();
+    let pack = Pack.bind(PackOptions {
+        names: ["a", "b"].into(),
+        nullability: Nullability::NonNullable,
+    });
+
+    let heap = trace_op(|| {
+        ScalarFnArray::try_new_with_len(pack.clone(), vec![a.clone(), b.clone()], len)?
+            .into_array()
+            .optimize()
+    })?;
+    let stack = trace_op(|| ScalarFnArray::try_new_parts(pack, vec![a, b], len)?.optimize())?;
+
+    assert!(heap.output.is::<Struct>());
+    assert!(stack.output.is::<Struct>());
+    assert_eq!(stack.trace.to_string(), heap.trace.to_string());
+    insta::assert_snapshot!(stack.trace.to_string(), @"
+    optimize root=vortex.pack({a=i32, b=i32}, len=3) session=false
+      reduce ScalarFnPackToStructRule: vortex.pack({a=i32, b=i32}, len=3) -> vortex.struct({a=i32, b=i32}, len=3)
+      done output=vortex.struct({a=i32, b=i32}, len=3)
     ");
 
     Ok(())

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -28,6 +28,7 @@ use crate::VortexSessionExecute;
 use crate::arrays::BoolArray;
 use crate::arrays::ChunkedArray;
 use crate::arrays::ConstantArray;
+use crate::arrays::scalar_fn::ScalarFnFactoryExt;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -33,7 +33,6 @@ use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::legacy_session;
-use crate::optimizer::ArrayOptimizer;
 use crate::patches::Patches;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::binary::Binary;
@@ -321,11 +320,10 @@ impl Validity {
             | (Validity::AllValid, Validity::NonNullable)
             | (Validity::AllValid, Validity::AllValid) => Validity::AllValid,
             // Here we actually have to do some work
-            (Validity::Array(lhs), Validity::Array(rhs)) => Validity::Array(
-                Binary
-                    .try_new_array(lhs.len(), Operator::And, [lhs, rhs])?
-                    .optimize()?,
-            ),
+            (Validity::Array(lhs), Validity::Array(rhs)) => {
+                let parts = Binary.try_new_array_parts(lhs.len(), Operator::And, [lhs, rhs])?;
+                Validity::Array(parts.optimize()?)
+            }
         })
     }
 

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -32,7 +32,6 @@ use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::legacy_session;
-use crate::optimizer::ArrayOptimizer;
 use crate::patches::Patches;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::binary::Binary;
@@ -325,11 +324,10 @@ impl Validity {
             | (Validity::AllValid, Validity::NonNullable)
             | (Validity::AllValid, Validity::AllValid) => Validity::AllValid,
             // Here we actually have to do some work
-            (Validity::Array(lhs), Validity::Array(rhs)) => Validity::Array(
-                Binary::try_new(lhs, rhs, Operator::And)?
-                    .into_array()
-                    .optimize()?,
-            ),
+            (Validity::Array(lhs), Validity::Array(rhs)) => {
+                let parts = Binary.try_new_array_parts(lhs.len(), Operator::And, [lhs, rhs])?;
+                Validity::Array(parts.optimize()?)
+            }
         })
     }
 

--- a/vortex-arrow/src/executor/byte.rs
+++ b/vortex-arrow/src/executor/byte.rs
@@ -26,6 +26,7 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::OffsetBuilderPType;
+use vortex_array::matcher::AsParent;
 use vortex_array::matcher::Matcher;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -42,10 +43,10 @@ use crate::executor::validity::to_arrow_null_buffer;
 struct ArrowByteExportable;
 
 impl Matcher for ArrowByteExportable {
-    type Match<'a> = &'a ArrayRef;
+    type Match<'a> = ();
 
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        (array.is::<VarBin>() || array.is::<Chunked>() || array.is::<Constant>()).then_some(array)
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        (parent.is::<VarBin>() || parent.is::<Chunked>() || parent.is::<Constant>()).then_some(())
     }
 }
 
@@ -76,7 +77,7 @@ where
 
     // If the Vortex array is in VarBin format, we can directly convert it.
     if let Some(array) = array.as_opt::<VarBin>() {
-        return varbin_to_byte_array::<T>(array, validate_utf8, ctx);
+        return varbin_to_byte_array::<T>(array.materialize_view(), validate_utf8, ctx);
     }
 
     // The builder's offset type matches the Arrow target, so `varbin_to_byte_array` hands the

--- a/vortex-arrow/src/executor/byte.rs
+++ b/vortex-arrow/src/executor/byte.rs
@@ -24,6 +24,7 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
+use vortex_array::matcher::AsParent;
 use vortex_array::matcher::Matcher;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
@@ -40,10 +41,10 @@ use crate::executor::validity::to_arrow_null_buffer;
 struct ArrowByteExportable;
 
 impl Matcher for ArrowByteExportable {
-    type Match<'a> = &'a ArrayRef;
+    type Match<'a> = ();
 
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        (array.is::<VarBin>() || array.is::<Chunked>() || array.is::<Constant>()).then_some(array)
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        (parent.is::<VarBin>() || parent.is::<Chunked>() || parent.is::<Constant>()).then_some(())
     }
 }
 
@@ -79,7 +80,7 @@ where
 
     // If the Vortex array is in VarBin format, we can directly convert it.
     if let Some(array) = array.as_opt::<VarBin>() {
-        return varbin_to_byte_array::<T>(array, ctx);
+        return varbin_to_byte_array::<T>(array.materialize_view(), ctx);
     }
 
     let mut builder = DynVarBinBuilder::with_capacity(

--- a/vortex-arrow/src/executor/dictionary.rs
+++ b/vortex-arrow/src/executor/dictionary.rs
@@ -18,6 +18,7 @@ use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::Dict;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::dict::DictArraySlotsExt;
+use vortex_array::matcher::AsParent;
 use vortex_array::matcher::Matcher;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
@@ -29,10 +30,10 @@ use crate::ArrowArrayExecutor;
 struct ArrowDictExportable;
 
 impl Matcher for ArrowDictExportable {
-    type Match<'a> = &'a ArrayRef;
+    type Match<'a> = ();
 
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        (array.is::<Dict>() || array.is::<Constant>()).then_some(array)
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        (parent.is::<Dict>() || parent.is::<Constant>()).then_some(())
     }
 }
 

--- a/vortex-arrow/src/executor/list.rs
+++ b/vortex-arrow/src/executor/list.rs
@@ -25,6 +25,7 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
+use vortex_array::matcher::AsParent;
 use vortex_array::matcher::Matcher;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
@@ -38,10 +39,10 @@ use crate::session::ArrowSessionExt;
 struct ArrowListExportable;
 
 impl Matcher for ArrowListExportable {
-    type Match<'a> = &'a ArrayRef;
+    type Match<'a> = ();
 
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        (array.is::<List>() || array.is::<Chunked>() || array.is::<ListView>()).then_some(array)
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        (parent.is::<List>() || parent.is::<Chunked>() || parent.is::<ListView>()).then_some(())
     }
 }
 

--- a/vortex-arrow/src/executor/run_end.rs
+++ b/vortex-arrow/src/executor/run_end.rs
@@ -16,6 +16,7 @@ use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
+use vortex_array::matcher::AsParent;
 use vortex_array::matcher::Matcher;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
@@ -32,10 +33,10 @@ use crate::ArrowArrayExecutor;
 struct ArrowRunEndExportable;
 
 impl Matcher for ArrowRunEndExportable {
-    type Match<'a> = &'a ArrayRef;
+    type Match<'a> = ();
 
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        (array.is::<RunEnd>() || array.is::<Constant>()).then_some(array)
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        (parent.is::<RunEnd>() || parent.is::<Constant>()).then_some(())
     }
 }
 

--- a/vortex-arrow/src/executor/run_end.rs
+++ b/vortex-arrow/src/executor/run_end.rs
@@ -16,6 +16,7 @@ use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
+use vortex_array::matcher::AsParent;
 use vortex_array::matcher::Matcher;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
@@ -33,10 +34,10 @@ use crate::session::ArrowSessionExt;
 struct ArrowRunEndExportable;
 
 impl Matcher for ArrowRunEndExportable {
-    type Match<'a> = &'a ArrayRef;
+    type Match<'a> = ();
 
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        (array.is::<RunEnd>() || array.is::<Constant>()).then_some(array)
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        (parent.is::<RunEnd>() || parent.is::<Constant>()).then_some(())
     }
 }
 

--- a/vortex-arrow/src/executor/struct_.rs
+++ b/vortex-arrow/src/executor/struct_.rs
@@ -21,6 +21,7 @@ use vortex_array::arrays::struct_::StructDataParts;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldNames;
+use vortex_array::matcher::AsParent;
 use vortex_array::matcher::Matcher;
 use vortex_array::scalar_fn::fns::pack::Pack;
 use vortex_error::VortexResult;
@@ -35,15 +36,15 @@ use crate::session::ArrowSessionExt;
 struct ArrowStructExportable;
 
 impl Matcher for ArrowStructExportable {
-    type Match<'a> = &'a ArrayRef;
+    type Match<'a> = ();
 
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        (array.is::<Struct>()
-            || array.is::<Chunked>()
-            || array
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        (parent.is::<Struct>()
+            || parent.is::<Chunked>()
+            || parent
                 .as_opt::<ScalarFn>()
                 .is_some_and(|scalar_fn| scalar_fn.scalar_fn().as_opt::<Pack>().is_some()))
-        .then_some(array)
+        .then_some(())
     }
 }
 

--- a/vortex-arrow/src/executor/struct_.rs
+++ b/vortex-arrow/src/executor/struct_.rs
@@ -22,6 +22,7 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldNames;
 use vortex_array::dtype::StructFields;
+use vortex_array::matcher::AsParent;
 use vortex_array::matcher::Matcher;
 use vortex_array::scalar_fn::fns::pack::Pack;
 use vortex_error::VortexResult;
@@ -36,15 +37,15 @@ use crate::session::ArrowSessionExt;
 struct ArrowStructExportable;
 
 impl Matcher for ArrowStructExportable {
-    type Match<'a> = &'a ArrayRef;
+    type Match<'a> = ();
 
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        (array.is::<Struct>()
-            || array.is::<Chunked>()
-            || array
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        (parent.is::<Struct>()
+            || parent.is::<Chunked>()
+            || parent
                 .as_opt::<ScalarFn>()
                 .is_some_and(|scalar_fn| scalar_fn.scalar_fn().as_opt::<Pack>().is_some()))
-        .then_some(array)
+        .then_some(())
     }
 }
 

--- a/vortex-bench/src/vector_dataset/convert.rs
+++ b/vortex-bench/src/vector_dataset/convert.rs
@@ -175,7 +175,7 @@ pub fn list_to_vector_ext(input: ArrayRef) -> VortexResult<ArrayRef> {
     // losslessly convertible to a non-nullable FSL as long as the runtime validity is
     // `NonNullable`/`AllValid`; we must only reject when a real null is present.
     let elements = if elem_nullability.is_nullable() {
-        let primitive = raw_elements.as_opt::<Primitive>().ok_or_else(|| {
+        let primitive = raw_elements.as_typed::<Primitive>().ok_or_else(|| {
             vortex_err!(
                 "list_to_vector_ext: expected nullable-float elements to downcast to \
                  Primitive, got dtype {}",

--- a/vortex-compressor/src/stats/cache.rs
+++ b/vortex-compressor/src/stats/cache.rs
@@ -127,7 +127,7 @@ impl ArrayAndStats {
     /// Panics if the array is not a primitive array.
     pub fn array_as_primitive(&self) -> ArrayView<'_, Primitive> {
         self.array
-            .as_opt::<Primitive>()
+            .as_typed::<Primitive>()
             .vortex_expect("the array is guaranteed to already be canonical by construction")
     }
 
@@ -138,7 +138,7 @@ impl ArrayAndStats {
     /// Panics if the array is not a varbinview array.
     pub fn array_as_varbinview(&self) -> ArrayView<'_, VarBinView> {
         self.array
-            .as_opt::<VarBinView>()
+            .as_typed::<VarBinView>()
             .vortex_expect("the array is guaranteed to already be canonical by construction")
     }
 
@@ -170,7 +170,7 @@ impl ArrayAndStats {
         let opts = self.opts;
         self.cache.get_or_insert_with::<IntegerStats>(|| {
             let primitive = array
-                .as_opt::<Primitive>()
+                .as_typed::<Primitive>()
                 .vortex_expect("the array is guaranteed to already be canonical by construction")
                 .into_owned();
             IntegerStats::generate_opts(&primitive, opts, ctx)
@@ -183,7 +183,7 @@ impl ArrayAndStats {
         let opts = self.opts;
         self.cache.get_or_insert_with::<FloatStats>(|| {
             let primitive = array
-                .as_opt::<Primitive>()
+                .as_typed::<Primitive>()
                 .vortex_expect("the array is guaranteed to already be canonical by construction")
                 .into_owned();
             FloatStats::generate_opts(&primitive, opts, ctx)
@@ -196,7 +196,7 @@ impl ArrayAndStats {
         let opts = self.opts;
         self.cache.get_or_insert_with::<StringStats>(|| {
             let varbinview = array
-                .as_opt::<VarBinView>()
+                .as_typed::<VarBinView>()
                 .vortex_expect("the array is guaranteed to already be canonical by construction")
                 .into_owned();
             StringStats::generate_opts(&varbinview, opts, ctx)

--- a/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
+++ b/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
@@ -12,6 +12,7 @@ use itertools::zip_eq;
 use tracing::trace;
 use vortex::array::ArrayRef;
 use vortex::array::ArrayVTable;
+use vortex::array::ParentRef;
 use vortex::array::arrays::Dict;
 use vortex::array::arrays::Primitive;
 use vortex::array::arrays::ScalarFn;
@@ -549,14 +550,15 @@ impl FusedPlan {
         let slice_arr = array.as_::<Slice>();
         let child = slice_arr.child().clone();
 
-        if let Some(reduced) = child.reduce_parent(&array, 0)? {
+        let parent_ref = ParentRef::from_array_ref(&array);
+        if let Some(reduced) = child.reduce_parent(&parent_ref, 0)? {
             return self.walk(reduced, pending_subtrees);
         }
 
         // BitPacked with patches does not reduce through Slice. Slice the
         // packed buffer here, and defer patch slicing to CUDA materialization.
         if child.encoding_id() == BitPacked.id() {
-            let bp = child.as_::<BitPacked>();
+            let bp = child.as_::<BitPacked>().materialize_view();
             let offset = slice_arr.data().slice_range().start;
             let len = array.len();
             let (packed, bitpacked_offset, patch_range) = bitpacked_slice_view(bp, offset, len)?;

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -87,7 +87,7 @@ impl BitPackedExecutor {
             return Ok(None);
         }
 
-        let bp = child.as_::<BitPacked>();
+        let bp = child.as_::<BitPacked>().materialize_view();
         let offset = slice.data().slice_range().start;
         let len = array.len();
         let (packed, bitpacked_offset, patch_range) = bitpacked_slice_view(bp, offset, len)?;

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -26,7 +26,6 @@ use vortex_array::expr::direct_bound_annotations;
 use vortex_array::expr::label_bound_tree;
 use vortex_array::expr::root;
 use vortex_array::expr::transform::partition_bound_annotations;
-use vortex_array::optimizer::ArrayOptimizer;
 use vortex_array::scalar_fn::is_negative_cost;
 use vortex_error::VortexError;
 use vortex_error::VortexExpect;
@@ -332,12 +331,9 @@ impl LayoutReader for DictReader {
             //  * The codes child reader ensures the correct dtype.
             //  * The layout stores `all_values_referenced` and if this is malicious then it must
             //    only affect correctness not memory safety.
-            let array = unsafe {
-                DictArray::new_unchecked(codes, values)
-                    .set_all_values_referenced(all_values_referenced)
-            }
-            .into_array()
-            .optimize()?;
+            let parts =
+                unsafe { DictArray::new_unchecked_parts(codes, values, all_values_referenced) };
+            let array = parts.optimize()?;
 
             array.apply_bound(&expr_outer)
         }

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -26,7 +26,6 @@ use vortex_array::expr::label_tree;
 use vortex_array::expr::pack;
 use vortex_array::expr::root;
 use vortex_array::expr::transform::partition_annotations;
-use vortex_array::optimizer::ArrayOptimizer;
 use vortex_array::scalar_fn::is_negative_cost;
 use vortex_error::VortexError;
 use vortex_error::VortexExpect;
@@ -317,12 +316,9 @@ impl LayoutReader for DictReader {
             //  * The codes child reader ensures the correct dtype.
             //  * The layout stores `all_values_referenced` and if this is malicious then it must
             //    only affect correctness not memory safety.
-            let array = unsafe {
-                DictArray::new_unchecked(codes, values)
-                    .set_all_values_referenced(all_values_referenced)
-            }
-            .into_array()
-            .optimize()?;
+            let parts =
+                unsafe { DictArray::new_unchecked_parts(codes, values, all_values_referenced) };
+            let array = parts.optimize()?;
 
             array.apply(&expr_outer)
         }

--- a/vortex-layout/src/layouts/list/writer.rs
+++ b/vortex-layout/src/layouts/list/writer.rs
@@ -21,6 +21,7 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
+use vortex_array::matcher::AsParent;
 use vortex_array::matcher::Matcher;
 use vortex_array::scalar_fn::fns::operators::Operator;
 use vortex_error::VortexExpect;
@@ -314,8 +315,8 @@ struct AnyList;
 impl Matcher for AnyList {
     type Match<'a> = ();
 
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        (array.as_opt::<List>().is_some() || array.as_opt::<ListView>().is_some()).then_some(())
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        (parent.is::<List>() || parent.is::<ListView>()).then_some(())
     }
 }
 

--- a/vortex-layout/src/layouts/list/writer.rs
+++ b/vortex-layout/src/layouts/list/writer.rs
@@ -21,6 +21,7 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
+use vortex_array::matcher::AsParent;
 use vortex_array::matcher::Matcher;
 use vortex_array::scalar_fn::fns::operators::Operator;
 use vortex_error::VortexExpect;
@@ -315,8 +316,8 @@ struct AnyList;
 impl Matcher for AnyList {
     type Match<'a> = ();
 
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        (array.as_opt::<List>().is_some() || array.as_opt::<ListView>().is_some()).then_some(())
+    fn try_match<'a, P: AsParent>(parent: &'a P) -> Option<Self::Match<'a>> {
+        (parent.is::<List>() || parent.is::<ListView>()).then_some(())
     }
 }
 

--- a/vortex-tensor/src/encodings/normalized/array.rs
+++ b/vortex-tensor/src/encodings/normalized/array.rs
@@ -10,6 +10,7 @@ use vortex_array::EmptyArrayData;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
+use vortex_array::ParentRef;
 use vortex_array::array_slots;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::buffer::BufferHandle;
@@ -266,7 +267,7 @@ impl VTable for Normalized {
 
     fn reduce_parent(
         array: ArrayView<'_, Self>,
-        parent: &ArrayRef,
+        parent: &ParentRef<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)

--- a/vortex-tensor/src/encodings/normalized/rules.rs
+++ b/vortex-tensor/src/encodings/normalized/rules.rs
@@ -4,6 +4,7 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::IntoArray;
+use vortex_array::ParentView;
 use vortex_array::arrays::Filter;
 use vortex_array::arrays::Slice;
 use vortex_array::optimizer::rules::ArrayParentReduceRule;
@@ -27,7 +28,7 @@ impl ArrayParentReduceRule<Normalized> for NormalizedSliceRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, Normalized>,
-        parent: ArrayView<'_, Slice>,
+        parent: ParentView<'_, Slice>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         let range = parent.slice_range();
@@ -55,7 +56,7 @@ impl ArrayParentReduceRule<Normalized> for NormalizedFilterRule {
     fn reduce_parent(
         &self,
         array: ArrayView<'_, Normalized>,
-        parent: ArrayView<'_, Filter>,
+        parent: ParentView<'_, Filter>,
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         let mask = parent.filter_mask();

--- a/vortex-tensor/src/scalar_fns/l2_denorm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_denorm.rs
@@ -16,13 +16,11 @@ use vortex_array::arrays::Extension;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::arrays::ScalarFn as ScalarFnArrayEncoding;
 use vortex_array::arrays::ScalarFnArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArraySlotsExt;
 use vortex_array::arrays::scalar_fn::ExactScalarFn;
-use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex_array::arrays::scalar_fn::ScalarFnArrayView;
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayParts;
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayVTable;
@@ -286,9 +284,8 @@ impl ScalarFnArrayVTable for L2Denorm {
         view: &ScalarFnArrayView<Self>,
         _session: &VortexSession,
     ) -> VortexResult<Option<Vec<u8>>> {
-        let scalar_fn_array = view.as_::<ScalarFnArrayEncoding>();
-        let normalized_dtype = Some(scalar_fn_array.child_at(0).dtype().try_into()?);
-        let norms_dtype = Some(scalar_fn_array.child_at(1).dtype().try_into()?);
+        let normalized_dtype = Some(view.child_at(0).dtype().try_into()?);
+        let norms_dtype = Some(view.child_at(1).dtype().try_into()?);
         Ok(Some(
             L2DenormMetadata {
                 normalized_dtype,

--- a/vortex-tensor/src/scalar_fns/l2_norm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_norm.rs
@@ -12,10 +12,8 @@ use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::arrays::ScalarFn as ScalarFnArrayEncoding;
 use vortex_array::arrays::ScalarFnArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
-use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex_array::arrays::scalar_fn::ScalarFnArrayView;
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayParts;
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayVTable;
@@ -209,8 +207,7 @@ impl ScalarFnArrayVTable for L2Norm {
         view: &ScalarFnArrayView<Self>,
         _session: &VortexSession,
     ) -> VortexResult<Option<Vec<u8>>> {
-        let scalar_fn_array = view.as_::<ScalarFnArrayEncoding>();
-        let input_dtype = Some(scalar_fn_array.child_at(0).dtype().try_into()?);
+        let input_dtype = Some(view.child_at(0).dtype().try_into()?);
         Ok(Some(L2NormMetadata { input_dtype }.encode_to_vec()))
     }
 

--- a/vortex-tensor/src/scalar_fns/l2_norm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_norm.rs
@@ -12,11 +12,9 @@ use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::arrays::ScalarFn as ScalarFnArrayEncoding;
 use vortex_array::arrays::ScalarFnArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::scalar_fn::ExactScalarFn;
-use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex_array::arrays::scalar_fn::ScalarFnArrayView;
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayParts;
 use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayVTable;
@@ -212,8 +210,7 @@ impl ScalarFnArrayVTable for L2Norm {
         view: &ScalarFnArrayView<Self>,
         _session: &VortexSession,
     ) -> VortexResult<Option<Vec<u8>>> {
-        let scalar_fn_array = view.as_::<ScalarFnArrayEncoding>();
-        let input_dtype = Some(scalar_fn_array.child_at(0).dtype().try_into()?);
+        let input_dtype = Some(view.child_at(0).dtype().try_into()?);
         Ok(Some(L2NormMetadata { input_dtype }.encode_to_vec()))
     }
 

--- a/vortex-tensor/src/utils.rs
+++ b/vortex-tensor/src/utils.rs
@@ -11,10 +11,8 @@ use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::MaskedArray;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::arrays::ScalarFn;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArraySlotsExt;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
-use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex_array::arrays::scalar_fn::ScalarFnArrayView;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
@@ -254,9 +252,8 @@ impl BinaryTensorOpMetadata {
     pub(crate) fn encode_from_view<V: ScalarFnVTable>(
         view: &ScalarFnArrayView<V>,
     ) -> VortexResult<Vec<u8>> {
-        let scalar_fn_array = view.as_::<ScalarFn>();
-        let lhs_dtype = Some(scalar_fn_array.child_at(0).dtype().try_into()?);
-        let rhs_dtype = Some(scalar_fn_array.child_at(1).dtype().try_into()?);
+        let lhs_dtype = Some(view.child_at(0).dtype().try_into()?);
+        let rhs_dtype = Some(view.child_at(1).dtype().try_into()?);
         Ok(Self {
             lhs_dtype,
             rhs_dtype,

--- a/vortex-tensor/src/utils.rs
+++ b/vortex-tensor/src/utils.rs
@@ -10,11 +10,9 @@ use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::arrays::ScalarFn;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArraySlotsExt;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_array::arrays::scalar_fn::ExactScalarFn;
-use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex_array::arrays::scalar_fn::ScalarFnArrayView;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
@@ -65,11 +63,7 @@ pub fn extract_l2_denorm_children(array: &ArrayRef) -> (ArrayRef, ArrayRef) {
     let sfn = array
         .as_opt::<ExactScalarFn<L2Denorm>>()
         .vortex_expect("expected ScalarFnArray wrapping L2Denorm");
-    (
-        sfn.nth_child(0)
-            .vortex_expect("L2Denorm missing normalized array"),
-        sfn.nth_child(1).vortex_expect("L2Denorm missing norms"),
-    )
+    (sfn.get_child(0).clone(), sfn.get_child(1).clone())
 }
 
 /// Validates that `input_dtype` is a float-valued tensor-like extension dtype.
@@ -238,9 +232,8 @@ impl BinaryTensorOpMetadata {
     pub(crate) fn encode_from_view<V: ScalarFnVTable>(
         view: &ScalarFnArrayView<V>,
     ) -> VortexResult<Vec<u8>> {
-        let scalar_fn_array = view.as_::<ScalarFn>();
-        let lhs_dtype = Some(scalar_fn_array.child_at(0).dtype().try_into()?);
-        let rhs_dtype = Some(scalar_fn_array.child_at(1).dtype().try_into()?);
+        let lhs_dtype = Some(view.child_at(0).dtype().try_into()?);
+        let rhs_dtype = Some(view.child_at(1).dtype().try_into()?);
         Ok(Self {
             lhs_dtype,
             rhs_dtype,


### PR DESCRIPTION
Add indirection logic to support stack allocated array parents in reduce rules.

This lets us avoid heap allocation for commonly used operations that are often
immediately optimised away

