### PR TITLE
Fix weird signature of with_slots functions

### DIFF
--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -472,7 +472,7 @@ impl ArrayRef {
 
         // SAFETY: ensured by the caller — the None slot is either put back or driven to completion
         // via the builder path before the parent escapes the executor.
-        let new_parent = unsafe { self.0.with_slots_unchecked(&self, new_slots) };
+        let new_parent = unsafe { self.0.with_slots_unchecked(new_slots) };
         Ok((new_parent, child))
     }
 
@@ -497,7 +497,7 @@ impl ArrayRef {
         let mut slots = self.slots().to_vec();
         slots[slot_idx] = Some(replacement);
         let inner = Arc::clone(&self.0);
-        inner.with_slots(self, slots)
+        inner.with_slots(slots)
     }
 
     /// Returns a new array with the provided slots.
@@ -536,7 +536,7 @@ impl ArrayRef {
             }
         }
         let inner = Arc::clone(&self.0);
-        inner.with_slots(self, slots)
+        inner.with_slots(slots)
     }
 
     pub fn reduce(&self) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -144,7 +144,7 @@ pub(crate) trait DynArray: 'static + private::Sealed + Send + Sync + Debug {
     fn dyn_array_eq(&self, other: &ArrayRef, precision: crate::Precision) -> bool;
 
     /// Returns a new array with the given slots.
-    fn with_slots(&self, this: ArrayRef, slots: Vec<Option<ArrayRef>>) -> VortexResult<ArrayRef>;
+    fn with_slots(&self, slots: Vec<Option<ArrayRef>>) -> VortexResult<ArrayRef>;
 
     /// Returns a new array with the given slots, bypassing encoding-level validation.
     ///
@@ -158,11 +158,7 @@ pub(crate) trait DynArray: 'static + private::Sealed + Send + Sync + Debug {
     /// The array returned may have slots whose content does not match the encoding's normal
     /// invariants. Callers must re-establish those invariants before handing the array to
     /// anything outside the executor.
-    unsafe fn with_slots_unchecked(
-        &self,
-        this: &ArrayRef,
-        slots: Vec<Option<ArrayRef>>,
-    ) -> ArrayRef;
+    unsafe fn with_slots_unchecked(&self, slots: Vec<Option<ArrayRef>>) -> ArrayRef;
 
     /// Attempt to reduce the array to a simpler representation.
     fn reduce(&self, this: &ArrayRef) -> VortexResult<Option<ArrayRef>>;
@@ -423,28 +419,28 @@ impl<V: VTable> DynArray for ArrayInner<V> {
             })
     }
 
-    fn with_slots(&self, this: ArrayRef, slots: Vec<Option<ArrayRef>>) -> VortexResult<ArrayRef> {
-        let data = self.data.clone();
-        let stats = this.statistics().to_owned();
+    fn with_slots(&self, slots: Vec<Option<ArrayRef>>) -> VortexResult<ArrayRef> {
+        let stats = self.stats.clone();
         Ok(Array::<V>::try_from_parts(
-            ArrayParts::new(self.vtable.clone(), this.dtype().clone(), this.len(), data)
-                .with_slots(slots),
+            ArrayParts::new(
+                self.vtable.clone(),
+                self.dtype.clone(),
+                self.len,
+                self.data.clone(),
+            )
+            .with_slots(slots),
         )?
-        .with_stats_set(stats)
+        .with_stats_set(stats.into())
         .into_array())
     }
 
-    unsafe fn with_slots_unchecked(
-        &self,
-        this: &ArrayRef,
-        slots: Vec<Option<ArrayRef>>,
-    ) -> ArrayRef {
+    unsafe fn with_slots_unchecked(&self, slots: Vec<Option<ArrayRef>>) -> ArrayRef {
         // SAFETY: we intentionally skip `V::validate` here. Caller guarantees that the resulting
         // array is either repaired or not externally observed.
         let inner = unsafe {
             ArrayInner::<V>::from_data_unchecked(
                 self.vtable.clone(),
-                this.dtype().clone(),
+                self.dtype.clone(),
                 self.len,
                 self.data.clone(),
                 slots,


### PR DESCRIPTION
with_slots doesn't need to pass the original ref to the arrayinner methods as
unique ownership arc is handled earlier

Signed-off-by: Robert Kruszewski <github@robertk.io>
