### PR TITLE
feat: check VortexReadAt::read_at results in the I/O driver

### DIFF
--- a/vortex-file/src/read/driver.rs
+++ b/vortex-file/src/read/driver.rs
@@ -174,7 +174,7 @@ impl State {
                 IoRequest::new_single(request)
             }),
             Some(window) => self.next_coalesced(window).map(|request| {
-                match request.requests.len() {
+                match request.requests().len() {
                     1 => self.metrics.individual_requests.add(1),
                     num_requests => {
                         self.metrics.coalesced_requests.add(1);
@@ -311,11 +311,14 @@ impl State {
             current_end - aligned_start,
         );
 
-        Some(CoalescedRequest {
-            range: aligned_start..current_end,
-            alignment: self.coalesced_buffer_alignment,
-            requests,
-        })
+        Some(
+            CoalescedRequest::try_new(
+                aligned_start..current_end,
+                self.coalesced_buffer_alignment,
+                requests,
+            )
+            .vortex_expect("each request is correctly constructed and range.start <= range.end"),
+        )
     }
 }
 

--- a/vortex-file/src/read/driver.rs
+++ b/vortex-file/src/read/driver.rs
@@ -441,8 +441,8 @@ mod tests {
 
         match outputs[0].inner() {
             IoRequestInner::Coalesced(coalesced) => {
-                assert_eq!(coalesced.range, 0..30);
-                assert_eq!(coalesced.requests.len(), 3);
+                assert_eq!(*coalesced.range(), 0..30);
+                assert_eq!(coalesced.requests().len(), 3);
             }
             _ => panic!("Expected coalesced request"),
         }
@@ -470,7 +470,7 @@ mod tests {
         .await;
         assert_eq!(outputs.len(), 1);
         match outputs[0].inner() {
-            IoRequestInner::Coalesced(c) => assert_eq!(c.requests.len(), 2),
+            IoRequestInner::Coalesced(c) => assert_eq!(c.requests().len(), 2),
             _ => panic!("Expected coalesced"),
         }
     }
@@ -515,10 +515,10 @@ mod tests {
         assert_eq!(outputs.len(), 1);
         match outputs[0].inner() {
             IoRequestInner::Coalesced(coalesced) => {
-                assert_eq!(coalesced.range.start, 4);
-                assert_eq!(coalesced.alignment, Alignment::new(4));
-                for req in &coalesced.requests {
-                    let rel = req.offset - coalesced.range.start;
+                assert_eq!(coalesced.range().start, 4);
+                assert_eq!(coalesced.alignment(), Alignment::new(4));
+                for req in coalesced.requests() {
+                    let rel = req.offset - coalesced.range().start;
                     assert_eq!(rel % *req.alignment as u64, 0);
                 }
             }
@@ -660,12 +660,12 @@ mod tests {
 
         match outputs[0].inner() {
             IoRequestInner::Coalesced(coalesced) => {
-                assert_eq!(coalesced.range, 0..110);
-                assert_eq!(coalesced.requests.len(), 3);
+                assert_eq!(*coalesced.range(), 0..110);
+                assert_eq!(coalesced.requests().len(), 3);
                 // Should be sorted by offset
-                assert_eq!(coalesced.requests[0].offset, 0);
-                assert_eq!(coalesced.requests[1].offset, 50);
-                assert_eq!(coalesced.requests[2].offset, 100);
+                assert_eq!(coalesced.requests()[0].offset, 0);
+                assert_eq!(coalesced.requests()[1].offset, 50);
+                assert_eq!(coalesced.requests()[2].offset, 100);
             }
             _ => panic!("Expected coalesced request"),
         }

--- a/vortex-file/src/read/request.rs
+++ b/vortex-file/src/read/request.rs
@@ -160,7 +160,7 @@ impl CoalescedRequest {
                     req,
                 )
             }
-            if req.offset.saturating_add(req.length as u64) <= range.end {
+            if req.offset.saturating_add(req.length as u64) > range.end {
                 vortex_bail!(
                     "CoalescedRequest: sub-request for length {} at file offset {} exceeds the coalesced range: {}..{}. {:?}",
                     req.length,

--- a/vortex-file/src/read/request.rs
+++ b/vortex-file/src/read/request.rs
@@ -175,6 +175,16 @@ impl CoalescedRequest {
         })
     }
 
+    #[allow_unused)]
+    pub fn range(&self) -> &Range<u64> {
+        &self.range
+    }
+
+    #[allow_unused)]
+    pub fn alignment(&self) -> Alignment {
+        self.alignment
+    }
+
     pub fn requests(&self) -> &[ReadRequest] {
         &self.requests
     }

--- a/vortex-file/src/read/request.rs
+++ b/vortex-file/src/read/request.rs
@@ -160,6 +160,16 @@ impl CoalescedRequest {
                     req,
                 )
             }
+            if req.offset.saturating_add(req.length as u64) <= range.end {
+                vortex_bail!(
+                    "CoalescedRequest: sub-request for length {} at file offset {} exceeds the coalesced range: {}..{}. {:?}",
+                    req.length,
+                    req.offset,
+                    range.start,
+                    range.end,
+                    req,
+                )
+            }
         }
         Ok(Self {
             range,
@@ -173,36 +183,6 @@ impl CoalescedRequest {
     }
 
     pub fn resolve(self, result: VortexResult<BufferHandle>) {
-        let result = result.and_then(|buffer| {
-            let buffer_len = buffer.len() as u64;
-
-            for req in self.requests.iter() {
-                // We check on construction that req.offset >= range.start.
-                let request_offset = req.offset - self.range.start;
-
-                if request_offset > buffer_len {
-                    vortex_bail!(
-                        "CoalescedRequest: sub-request for length {} at buffer offset {} (file offset {}) is unsatisfiable by buffer of length {}.",
-                        req.length,
-                        request_offset,
-                        req.offset,
-                        buffer_len
-                    )
-                }
-                let request_end = request_offset.saturating_add(req.length as u64);
-                if request_end > buffer_len {
-                    vortex_bail!(
-                        "CoalescedRequest: sub-request for length {} at buffer offset {} (file offset {}) is unsatisfiable by buffer of length {}.",
-                        req.length,
-                        request_offset,
-                        req.offset,
-                        buffer_len
-                    )
-                }
-            }
-            Ok(buffer)
-        });
-
         match result {
             Ok(buffer) => {
                 let base = match buffer.ensure_aligned(Alignment::none()) {

--- a/vortex-file/src/read/request.rs
+++ b/vortex-file/src/read/request.rs
@@ -175,12 +175,12 @@ impl CoalescedRequest {
         })
     }
 
-    #[allow_unused)]
+    #[allow(unused)]
     pub fn range(&self) -> &Range<u64> {
         &self.range
     }
 
-    #[allow_unused)]
+    #[allow(unused)]
     pub fn alignment(&self) -> Alignment {
         self.alignment
     }

--- a/vortex-file/src/read/request.rs
+++ b/vortex-file/src/read/request.rs
@@ -13,9 +13,9 @@ use vortex_error::VortexError;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
-use vortex_error::vortex_err;
 
 /// An I/O request, either a single read or a coalesced set of reads.
+#[derive(Debug)]
 pub(crate) struct IoRequest(IoRequestInner);
 
 impl IoRequest {
@@ -82,6 +82,7 @@ impl IoRequest {
     }
 }
 
+#[derive(Debug)]
 pub(crate) enum IoRequestInner {
     Single(ReadRequest),
     Coalesced(CoalescedRequest),
@@ -165,6 +166,10 @@ impl CoalescedRequest {
             alignment,
             requests,
         })
+    }
+
+    pub fn requests(&self) -> &[ReadRequest] {
+        &self.requests
     }
 
     pub fn resolve(self, result: VortexResult<BufferHandle>) {

--- a/vortex-file/src/read/request.rs
+++ b/vortex-file/src/read/request.rs
@@ -39,8 +39,10 @@ impl IoRequest {
     pub fn len(&self) -> usize {
         match &self.0 {
             IoRequestInner::Single(r) => r.length,
-            IoRequestInner::Coalesced(r) => usize::try_from(r.range.end - r.range.start)
-                .vortex_expect("range too big for usize"),
+            IoRequestInner::Coalesced(r) => {
+                usize::try_from(r.range.end.saturating_sub(r.range.start))
+                    .vortex_expect("range too big for usize")
+            }
         }
     }
 
@@ -109,17 +111,6 @@ impl Debug for ReadRequest {
 
 impl ReadRequest {
     pub(crate) fn resolve(self, result: VortexResult<BufferHandle>) {
-        let result = result.and_then(|buffer| {
-            if self.length != buffer.len() {
-                vortex_bail!(
-                    "ReadRequest: expected buffer of length {} but received {}.",
-                    self.length,
-                    buffer.len()
-                )
-            }
-            Ok(buffer)
-        });
-
         if let Err(e) = self.callback.send(result) {
             tracing::debug!("ReadRequest {} dropped before resolving: {e}", self.id);
         }
@@ -128,9 +119,9 @@ impl ReadRequest {
 
 /// A set of I/O requests that have been coalesced into a single larger request.
 pub(crate) struct CoalescedRequest {
-    pub(crate) range: Range<u64>,
-    pub(crate) alignment: Alignment, // Global max segment alignment used for the coalesced range.
-    pub(crate) requests: Vec<ReadRequest>, // TODO(ngates): we could have enum of Single/Many to avoid Vec.
+    range: Range<u64>,
+    alignment: Alignment, // Global max segment alignment used for the coalesced range.
+    requests: Vec<ReadRequest>, // TODO(ngates): we could have enum of Single/Many to avoid Vec.
 }
 
 impl Debug for CoalescedRequest {
@@ -145,28 +136,45 @@ impl Debug for CoalescedRequest {
 }
 
 impl CoalescedRequest {
-    pub fn resolve(self, result: VortexResult<BufferHandle>) {
-        let result = result.and_then(|buffer| {
-            let expected_length = self.range.end.saturating_sub(self.range.start);
-            let buffer_len = buffer.len() as u64;
-            if expected_length != buffer_len {
+    pub fn try_new(
+        range: Range<u64>,
+        alignment: Alignment,
+        requests: Vec<ReadRequest>,
+    ) -> VortexResult<Self> {
+        if range.start > range.end {
+            vortex_bail!(
+                "CoalescedRequest: range.start, {}, must be less than or equal to range.end, {}.",
+                range.start,
+                range.end,
+            )
+        }
+        for req in requests.iter() {
+            if req.offset < range.start {
                 vortex_bail!(
-                    "CoalescedRequest: expected buffer of length {} but received {}.",
-                    expected_length,
-                    buffer_len
+                    "CoalescedRequest: sub-request for length {} at file offset {} precedes coalesced range: {}..{}. {:?}",
+                    req.length,
+                    req.offset,
+                    range.start,
+                    range.end,
+                    req,
                 )
             }
+        }
+        Ok(Self {
+            range,
+            alignment,
+            requests,
+        })
+    }
+
+    pub fn resolve(self, result: VortexResult<BufferHandle>) {
+        let result = result.and_then(|buffer| {
+            let buffer_len = buffer.len() as u64;
 
             for req in self.requests.iter() {
-                let request_offset = req.offset.checked_sub(self.range.start).ok_or_else(|| {
-                    vortex_err!(
-                        "CoalescedRequest: sub-request for length {} at file offset {} preceeds coalesced range: {}..{}.",
-                        req.length,
-                        req.offset,
-                        self.range.start,
-                        self.range.end,
-                    )
-                })?;
+                // We check on construction that req.offset >= range.start.
+                let request_offset = req.offset - self.range.start;
+
                 if request_offset > buffer_len {
                     vortex_bail!(
                         "CoalescedRequest: sub-request for length {} at buffer offset {} (file offset {}) is unsatisfiable by buffer of length {}.",

--- a/vortex-file/src/read/request.rs
+++ b/vortex-file/src/read/request.rs
@@ -12,7 +12,7 @@ use vortex_buffer::Alignment;
 use vortex_error::VortexError;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
+use vortex_error::vortex_ensure;
 
 /// An I/O request, either a single read or a coalesced set of reads.
 #[derive(Debug)]
@@ -142,34 +142,31 @@ impl CoalescedRequest {
         alignment: Alignment,
         requests: Vec<ReadRequest>,
     ) -> VortexResult<Self> {
-        if range.start > range.end {
-            vortex_bail!(
-                "CoalescedRequest: range.start, {}, must be less than or equal to range.end, {}.",
+        vortex_ensure!(
+            range.start <= range.end,
+            "CoalescedRequest: range.start, {}, must be less than or equal to range.end, {}.",
+            range.start,
+            range.end,
+        );
+        for req in requests.iter() {
+            vortex_ensure!(
+                req.offset >= range.start,
+                "CoalescedRequest: sub-request for length {} at file offset {} precedes coalesced range: {}..{}. {:?}",
+                req.length,
+                req.offset,
                 range.start,
                 range.end,
-            )
-        }
-        for req in requests.iter() {
-            if req.offset < range.start {
-                vortex_bail!(
-                    "CoalescedRequest: sub-request for length {} at file offset {} precedes coalesced range: {}..{}. {:?}",
-                    req.length,
-                    req.offset,
-                    range.start,
-                    range.end,
-                    req,
-                )
-            }
-            if req.offset.saturating_add(req.length as u64) > range.end {
-                vortex_bail!(
-                    "CoalescedRequest: sub-request for length {} at file offset {} exceeds the coalesced range: {}..{}. {:?}",
-                    req.length,
-                    req.offset,
-                    range.start,
-                    range.end,
-                    req,
-                )
-            }
+                req,
+            );
+            vortex_ensure!(
+                req.offset.saturating_add(req.length as u64) <= range.end,
+                "CoalescedRequest: sub-request for length {} at file offset {} exceeds the coalesced range: {}..{}. {:?}",
+                req.length,
+                req.offset,
+                range.start,
+                range.end,
+                req,
+            );
         }
         Ok(Self {
             range,

--- a/vortex-file/src/read/request.rs
+++ b/vortex-file/src/read/request.rs
@@ -12,6 +12,8 @@ use vortex_buffer::Alignment;
 use vortex_error::VortexError;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
 
 /// An I/O request, either a single read or a coalesced set of reads.
 pub(crate) struct IoRequest(IoRequestInner);
@@ -107,6 +109,17 @@ impl Debug for ReadRequest {
 
 impl ReadRequest {
     pub(crate) fn resolve(self, result: VortexResult<BufferHandle>) {
+        let result = result.and_then(|buffer| {
+            if self.length != buffer.len() {
+                vortex_bail!(
+                    "ReadRequest: expected buffer of length {} but received {}.",
+                    self.length,
+                    buffer.len()
+                )
+            }
+            Ok(buffer)
+        });
+
         if let Err(e) = self.callback.send(result) {
             tracing::debug!("ReadRequest {} dropped before resolving: {e}", self.id);
         }
@@ -133,6 +146,50 @@ impl Debug for CoalescedRequest {
 
 impl CoalescedRequest {
     pub fn resolve(self, result: VortexResult<BufferHandle>) {
+        let result = result.and_then(|buffer| {
+            let expected_length = self.range.end.saturating_sub(self.range.start);
+            let buffer_len = buffer.len() as u64;
+            if expected_length != buffer_len {
+                vortex_bail!(
+                    "CoalescedRequest: expected buffer of length {} but received {}.",
+                    expected_length,
+                    buffer_len
+                )
+            }
+
+            for req in self.requests.iter() {
+                let request_offset = req.offset.checked_sub(self.range.start).ok_or_else(|| {
+                    vortex_err!(
+                        "CoalescedRequest: sub-request for length {} at file offset {} preceeds coalesced range: {}..{}.",
+                        req.length,
+                        req.offset,
+                        self.range.start,
+                        self.range.end,
+                    )
+                })?;
+                if request_offset > buffer_len {
+                    vortex_bail!(
+                        "CoalescedRequest: sub-request for length {} at buffer offset {} (file offset {}) is unsatisfiable by buffer of length {}.",
+                        req.length,
+                        request_offset,
+                        req.offset,
+                        buffer_len
+                    )
+                }
+                let request_end = request_offset.saturating_add(req.length as u64);
+                if request_end > buffer_len {
+                    vortex_bail!(
+                        "CoalescedRequest: sub-request for length {} at buffer offset {} (file offset {}) is unsatisfiable by buffer of length {}.",
+                        req.length,
+                        request_offset,
+                        req.offset,
+                        buffer_len
+                    )
+                }
+            }
+            Ok(buffer)
+        });
+
         match result {
             Ok(buffer) => {
                 let base = match buffer.ensure_aligned(Alignment::none()) {

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -16,6 +16,7 @@ use vortex_array::buffer::BufferHandle;
 use vortex_buffer::Alignment;
 use vortex_buffer::ByteBuffer;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 use vortex_io::VortexReadAt;
@@ -115,6 +116,17 @@ impl FileSegmentSource {
                         let result = reader
                             .read_at(req.offset(), req.len(), req.alignment())
                             .await;
+                        let result = result.and_then(|buffer| {
+                            if req.len() != buffer.len() {
+                                vortex_bail!(
+                                    "ReadRequest: expected buffer of length {} but received {}.",
+                                    req.len(),
+                                    buffer.len()
+                                )
+                            }
+                            Ok(buffer)
+                        });
+
                         req.resolve(result);
                     }
                 })

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -119,9 +119,10 @@ impl FileSegmentSource {
                         let result = result.and_then(|buffer| {
                             if req.len() != buffer.len() {
                                 vortex_bail!(
-                                    "ReadRequest: expected buffer of length {} but received {}.",
+                                    "FileSegmentSource: expected buffer of length {} but received {}. {:?}",
                                     req.len(),
-                                    buffer.len()
+                                    buffer.len(),
+                                    req
                                 )
                             }
                             Ok(buffer)


### PR DESCRIPTION
This ensures misbehaving VortexReadAt implementations cannot trigger later bad behavior by the I/O driver. Instead, the driver raises an error as close as possible to the badly behaving VortexReadAt implementation.

