### PR TITLE
Try to fix benchmakrs-website tests on windows

### DIFF
--- a/benchmarks-website/migrate/tests/end_to_end.rs
+++ b/benchmarks-website/migrate/tests/end_to_end.rs
@@ -277,7 +277,9 @@ fn open_target_db_removes_orphan_wal() {
     assert!(wal.exists(), "precondition: orphan wal staged");
     assert!(!target.exists(), "precondition: no main db file");
 
-    let _conn = migrate::open_target_db(&target).unwrap();
+    {
+        let _conn = migrate::open_target_db(&target).unwrap();
+    }
 
     // The migrator opens the DB after sweeping the WAL; DuckDB may
     // recreate its own wal under load, but our pre-existing orphan


### PR DESCRIPTION
If we drop the db before we open we should avoid the double open problem

Signed-off-by: Robert Kruszewski <github@robertk.io>
