### PR TITLE
bench: CUDA sync load-to-device benchmark

### DIFF
--- a/vortex-cuda/Cargo.toml
+++ b/vortex-cuda/Cargo.toml
@@ -94,3 +94,7 @@ harness = false
 [[bench]]
 name = "throughput_cuda"
 harness = false
+
+[[bench]]
+name = "load_to_device_cuda"
+harness = false

--- a/vortex-cuda/benches/load_to_device_cuda.rs
+++ b/vortex-cuda/benches/load_to_device_cuda.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+#![expect(clippy::expect_used)]
+
+mod bench_config;
+// Unused here but suppresses dead_code warning for the shared module.
+const _: &[(usize, &str)] = bench_config::BENCH_SIZES;
+
+use criterion::BatchSize;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use vortex::array::buffer::BufferHandle;
+use vortex::buffer::ByteBuffer;
+use vortex::error::VortexExpect;
+use vortex::session::VortexSession;
+use vortex_cuda::CudaSession;
+use vortex_cuda_macros::cuda_available;
+use vortex_cuda_macros::cuda_not_available;
+
+const LOAD_SIZES: &[(usize, &str)] = &[
+    (16 * 1024 * 1024, "16MiB"),
+    (64 * 1024 * 1024, "64MiB"),
+    (256 * 1024 * 1024, "256MiB"),
+    (1024 * 1024 * 1024, "1GiB"),
+];
+
+fn benchmark_load_to_device(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cuda");
+
+    for &(size, size_name) in LOAD_SIZES {
+        group.throughput(Throughput::Bytes(size as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("cuda/load_to_device/ensure_on_device_sync", size_name),
+            &size,
+            |b, &size| {
+                let session = VortexSession::empty();
+                let cuda_ctx =
+                    CudaSession::create_execution_ctx(&session).vortex_expect("cuda ctx");
+
+                b.iter_batched(
+                    || BufferHandle::new_host(ByteBuffer::from(vec![0xA5; size])),
+                    |source| {
+                        let handle = cuda_ctx
+                            .ensure_on_device_sync(source)
+                            .vortex_expect("ensure_on_device_sync");
+                        assert!(handle.is_on_device());
+                        // Keep the explicit sync here to ensure that we measure a sync copy. In
+                        // case the default buffer allocation strategy in the future changes to use
+                        // `cuMemHostAlloc`, the htod copy would change to being async, making the
+                        // function return immediately.
+                        cuda_ctx.stream().synchronize().expect("synchronize stream");
+                    },
+                    BatchSize::PerIteration,
+                );
+
+                drop(cuda_ctx);
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion::criterion_group! {
+    name = benches;
+    config = bench_config::cuda_bench_config();
+    targets = benchmark_load_to_device
+}
+
+#[cuda_available]
+criterion::criterion_main!(benches);
+
+#[cuda_not_available]
+fn main() {}


### PR DESCRIPTION
This benchmark provides the baseline for GPU data loading exercising our synchronous logic. In this naive case, the data is copied to the GPU from host memory. This does not include loading the buffer from a file. This change will be followed up by benchmarks for different copy strategies / paths.

Benchmarks for a GH200:
```
cuda/cuda/load_to_device/ensure_on_device_sync/16MiB
                        time:   [1.1733 ms 1.1966 ms 1.2282 ms]
                        thrpt:  [12.722 GiB/s 13.058 GiB/s 13.317 GiB/s]
                 change:
                        time:   [-2.3933% +0.2367% +3.1250%] (p = 0.88 > 0.05)
                        thrpt:  [-3.0303% -0.2362% +2.4520%]

cuda/cuda/load_to_device/ensure_on_device_sync/64MiB
                        time:   [3.0456 ms 3.0634 ms 3.0819 ms]
                        thrpt:  [20.280 GiB/s 20.402 GiB/s 20.522 GiB/s]
                 change:
                        time:   [+0.0301% +1.0798% +2.0330%] (p = 0.06 > 0.05)
                        thrpt:  [-1.9925% -1.0682% -0.0301%]

cuda/cuda/load_to_device/ensure_on_device_sync/256MiB
                        time:   [11.363 ms 11.399 ms 11.434 ms]
                        thrpt:  [21.864 GiB/s 21.932 GiB/s 22.000 GiB/s]
                 change:
                        time:   [-0.1484% +0.1656% +0.4805%] (p = 0.37 > 0.05)
                        thrpt:  [-0.4782% -0.1653% +0.1486%]

cuda/cuda/load_to_device/ensure_on_device_sync/1GiB
                        time:   [42.364 ms 42.832 ms 43.712 ms]
                        thrpt:  [22.877 GiB/s 23.347 GiB/s 23.605 GiB/s]
                 change:
                        time:   [-6.7679% -0.1064% +4.4406%] (p = 0.98 > 0.05)
                        thrpt:  [-4.2518% +0.1065% +7.2592%]
```