### PR TITLE
fix(ffi): double-free in partition scan on error

### DIFF
--- a/vortex-ffi/src/scan.rs
+++ b/vortex-ffi/src/scan.rs
@@ -304,7 +304,7 @@ pub unsafe extern "C-unwind" fn vx_scan_next_partition(
             }
         };
 
-        let owned = ptr::read(ptr);
+        let owned = ptr::replace(ptr, VxScan::Finished);
         try_or_default(err, || match owned {
             VxScan::Pending(scan) => on_stream(scan.partitions()),
             VxScan::Started(stream) => on_stream(stream),
@@ -421,7 +421,7 @@ pub unsafe extern "C-unwind" fn vx_partition_next(
             }
         };
 
-        let owned = ptr::read(ptr);
+        let owned = ptr::replace(ptr, VxPartitionScan::Finished);
         try_or_default(err, || match owned {
             VxPartitionScan::Pending(partition) => on_stream(partition.execute()?),
             VxPartitionScan::Started(stream) => on_stream(stream),

--- a/vortex-ffi/test/scan.cpp
+++ b/vortex-ffi/test/scan.cpp
@@ -876,3 +876,72 @@ TEST_CASE("Scan to Arrow", "[scan]") {
     }
     compare_stream_with_sample(unique_stream);
 }
+
+TEST_CASE("Broken scan with DType mismatch in filter", "[filter]") {
+    vx_session *session = vx_session_new();
+    defer {
+        vx_session_free(session);
+    };
+    TempPath path = write_sample(session);
+    vx_error *error = nullptr;
+
+    vx_data_source_options ds_opts = {};
+    ds_opts.paths = path.c_str();
+    const vx_data_source *ds = vx_data_source_new(session, &ds_opts, &error);
+    require_no_error(error);
+    defer {
+        vx_data_source_free(ds);
+    };
+
+    vx_expression *root = vx_expression_root();
+    defer {
+        vx_expression_free(root);
+    };
+
+    vx_expression *age_col = vx_expression_get_item("age", root);
+    REQUIRE(age_col != nullptr);
+    defer {
+        vx_expression_free(age_col);
+    };
+
+    vx_scalar *lit = vx_scalar_new_i32(67, false);
+    defer {
+        vx_scalar_free(lit);
+    };
+
+    vx_expression *lit_expr = vx_expression_literal(lit, &error);
+    require_no_error(error);
+    defer {
+        vx_expression_free(lit_expr);
+    };
+
+    // DType mismatch between age_col (u8) and lit (i32)
+    vx_expression *filter = vx_expression_binary(VX_OPERATOR_EQ, age_col, lit_expr);
+    REQUIRE(filter != nullptr);
+    defer {
+        vx_expression_free(filter);
+    };
+
+    vx_scan_options scan_opts = {};
+    scan_opts.max_threads = 1;
+    scan_opts.filter = filter;
+
+    vx_scan *scan = vx_data_source_scan(ds, &scan_opts, nullptr, &error);
+    require_no_error(error);
+    defer {
+        vx_scan_free(scan);
+    };
+
+    vx_partition *partition = vx_scan_next_partition(scan, &error);
+    require_no_error(error);
+    REQUIRE(partition != nullptr);
+    defer {
+        vx_partition_free(partition);
+    };
+
+    // This call must set vx_error and return nullptr, not panic
+    const vx_array *array = vx_partition_next(partition, &error);
+    REQUIRE(array == nullptr);
+    REQUIRE(error != nullptr);
+    vx_error_free(error);
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! We appreciate your time and effort.

Please make sure to provide enough information so that we can review your pull
request. The Summary and Testing sections below contain guidance on what to
include.
-->

## Summary

Fix for the second part of: #7808 

```
(gdb) bt
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>)
    at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6)
    at ./nptl/pthread_kill.c:89
#3  0x000076a38cc4527e in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x000076a38cc288ff in __GI_abort () at ./stdlib/abort.c:79
#5  0x000076a38cc297b6 in __libc_message_impl (fmt=fmt@entry=0x76a38cdce8d7 "%s\n")
    at ../sysdeps/posix/libc_fatal.c:134
#6  0x000076a38cca8ff5 in malloc_printerr (
    str=str@entry=0x76a38cdd1bf0 "free(): double free detected in tcache 2")
    at ./malloc/malloc.c:5775
#7  0x000076a38ccab55f in _int_free (av=0x76a38ce03ac0 <main_arena>, p=<optimized out>, 
    have_lock=0) at ./malloc/malloc.c:4541
#8  0x000076a38ccaddce in __GI___libc_free (mem=0x5be5cd9632c0) at ./malloc/malloc.c:3398
#9  0x000076a38eb6807e in alloc::alloc::dealloc (ptr=0x5be5cd9632c0, layout=...)
    at /home/ubuntu/.rustup/toolchains/1.91.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:114
#10 alloc::alloc::{impl#1}::deallocate (self=0x5be5cd95f708, ptr=..., layout=...)
    at /home/ubuntu/.rustup/toolchains/1.91.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:271
#11 0x000076a38ead9a64 in alloc::boxed::{impl#8}::drop<dyn vortex_scan::Partition, alloc::alloc::Global> (self=0x5be5cd95f6f8)
    at /home/ubuntu/.rustup/toolchains/1.91.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1666
#12 0x000076a38ead349e in core::ptr::drop_in_place<alloc::boxed::Box<dyn vortex_scan::Partition, alloc::alloc::Global>> ()
    at /home/ubuntu/.rustup/toolchains/1.91.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:804
#13 0x000076a38e8764de in core::ptr::drop_in_place<vortex_ffi::scan::VxPartitionScan> ()
    at /home/ubuntu/.rustup/toolchains/1.91.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:804
#14 0x000076a38e876fb8 in core::ptr::drop_in_place<alloc::boxed::Box<vortex_ffi::scan::VxPartitionScan, alloc::alloc::Global>> ()
    at /home/ubuntu/.rustup/toolchains/1.91.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:804
#15 0x000076a38e87f2f5 in core::mem::drop<alloc::boxed::Box<vortex_ffi::scan::VxPartitionScan, alloc::alloc::Global>> (_x=0x5be5cd95f6f0)
    at /home/ubuntu/.rustup/toolchains/1.91.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/mem/mod.rs:961
#16 0x000076a38e84efa7 in vortex_ffi::scan::vx_partition_free (ptr=0x5be5cd95f6f0)
    at vortex-ffi/src/macros.rs:295
#17 0x00005be5b0c81126 in operator() (__closure=0x7fff2208a8b0)
    at /home/ubuntu/vortex/vortex-ffi/test/scan.cpp:940
```

<!--
If this PR is related to a tracked effort, please link to the relevant issue
here (e.g., `Closes: #123`). Otherwise, feel free to ignore / delete this.

In this section, please:

1. Explain the rationale for this change.
2. Summarize the changes included in this PR.

A general rule of thumb is that larger PRs should have larger summaries. If
there are a lot of changes, please help us review the code by explaining what
was changed and why.

If there is an issue or discussion attached, there is no need to duplicate all
the details, but clarity is always preferred over brevity.
-->

<!--
## API Changes

Uncomment this section if there are any user-facing changes.

Consider whether the change affects users in one of the following ways:

1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the engine integrations.
3. Should some documentation be updated to reflect this change?

If a public API is changed in a breaking manner, make sure to add the
appropriate label. You can run `./scripts/public-api.sh` locally to see if there
are any public API changes (and this also runs in our CI).
-->

## Testing

Verifying existing behavior is maintained.

<!--
Please describe how this change was tested. Here are some common categories for
testing in Vortex:

1. Verifying existing behavior is maintained.
2. Verifying new behavior and functionality works correctly.
3. Serialization compatibility (backwards and forwards) should be maintained or
   explicitly broken.
-->
