### PR TITLE
[claude] fsst: ignored regression test for i32 offset overflow

### DIFF
--- a/encodings/fsst/src/tests.rs
+++ b/encodings/fsst/src/tests.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand::seq::IndexedRandom;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::LEGACY_SESSION;
@@ -106,4 +109,50 @@ fn test_fsst_array_ops() {
         .into_array();
 
     assert_arrays_eq!(fsst_array, canonical_array);
+}
+
+/// Regression for #7833: `fsst_compress` must accept inputs whose cumulative
+/// compressed bytes exceed `i32::MAX`. Pre-fix, `fsst_compress_iter` hardcoded
+/// `VarBinBuilder::<i32>` for the FSST output buffer regardless of input size,
+/// which panicked in `VarBinBuilder::<i32>::append_value` once cumulative
+/// compressed bytes passed `i32::MAX`.
+///
+/// Allocates ~2.5 GiB for the input plus ~2.5 GiB for the FSST output, so the
+/// test is `#[ignore]`-d by default. Run explicitly with:
+/// `cargo test --release -p vortex-fsst -- --ignored fsst_compress_offsets`.
+#[test]
+#[ignore = "allocates ~5 GiB; run with --ignored"]
+fn fsst_compress_offsets_overflow_i32() {
+    // High-entropy ASCII strings sliced from a random pool. FSST is a
+    // symbol-table compressor; pseudo-random data with no recurring byte
+    // sequences resists compression, so the compressed output stays close
+    // to input size and crosses the i32 boundary.
+    const STRING_LEN: usize = 64 * 1024;
+    const TOTAL_BYTES: usize = (1usize << 31) + (512 << 20); // ~2.5 GiB
+    const N: usize = TOTAL_BYTES / STRING_LEN;
+    const POOL_LEN: usize = 64 * 1024 * 1024;
+
+    // Printable ASCII alphabet so the result is valid UTF-8.
+    const ALPHABET: &[u8; 95] =
+        b" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+
+    let mut rng = StdRng::seed_from_u64(0xC0DE_C011_B711);
+    let pool: Vec<u8> = (0..POOL_LEN)
+        .map(|_| *ALPHABET.choose(&mut rng).unwrap())
+        .collect();
+
+    let mut builder = VarBinBuilder::<i64>::with_capacity(N);
+    for i in 0..N {
+        let off = (i.wrapping_mul(31337)) % (POOL_LEN - STRING_LEN);
+        builder.append_value(&pool[off..off + STRING_LEN]);
+    }
+    let array = builder.finish(DType::Utf8(Nullability::NonNullable));
+
+    let compressor = fsst_train_compressor(&array);
+    let len = array.len();
+    let dtype = array.dtype().clone();
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+
+    let compressed = fsst_compress(array, len, &dtype, &compressor, &mut ctx);
+    assert_eq!(compressed.len(), len);
 }


### PR DESCRIPTION
Alternative to #7832 — same regression test for #7833, but placed in the existing `encodings/fsst/src/tests.rs` module instead of a new `tests_large.rs`, and gated with `#[ignore]` rather than the `test_with` CI env attributes.

The test allocates ~2.5 GiB for the input plus ~2.5 GiB for the compressed output, so it's too expensive to run by default even in CI. With `#[ignore]` it's skipped on every normal `cargo test` / `cargo nextest` run and can be invoked explicitly when needed:

```
cargo test --release -p vortex-fsst -- --ignored fsst_compress_offsets
```

When the underlying overflow in `fsst_compress_iter` (`encodings/fsst/src/compress.rs:72`, hardcoded `VarBinBuilder::<i32>`) is fixed, the trailing `assert_eq!(compressed.len(), len)` becomes the live regression assertion — just drop the `#[ignore]` (or leave it, since the run cost is unchanged).

Compared to #7832 this drops the `test-with` dev-dependency, the `tests_large.rs` module, and the corresponding `mod tests_large;` in `lib.rs`.

Tracks #7833.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLY1CDvucwUD995mmPepea)_