### PR TITLE
skip[array]: add a benchmark of the optimize loop

### DIFF
--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -197,3 +197,7 @@ harness = false
 [[bench]]
 name = "listview_builder_extend"
 harness = false
+
+[[bench]]
+name = "slice_dict_primitive"
+harness = false

--- a/vortex-array/benches/slice_dict_primitive.rs
+++ b/vortex-array/benches/slice_dict_primitive.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 #![expect(clippy::unwrap_used)]
+#![expect(clippy::cast_possible_truncation)]
 
 use divan::Bencher;
 use vortex_array::ArrayRef;

--- a/vortex-array/benches/slice_dict_primitive.rs
+++ b/vortex-array/benches/slice_dict_primitive.rs
@@ -14,7 +14,7 @@ fn main() {
     divan::main();
 }
 
-const ARRAY_LENGTHS: &[usize] = &[100_000];
+const ARRAY_LENGTHS: &[usize] = &[10_000];
 
 fn build_dict(len: usize) -> DictArray {
     let num_unique = 256;

--- a/vortex-array/benches/slice_dict_primitive.rs
+++ b/vortex-array/benches/slice_dict_primitive.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+#![expect(clippy::unwrap_used)]
+
+use divan::Bencher;
+use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
+use vortex_array::arrays::DictArray;
+use vortex_array::arrays::PrimitiveArray;
+
+fn main() {
+    divan::main();
+}
+
+const ARRAY_LENGTHS: &[usize] = &[100_000];
+
+fn build_dict(len: usize) -> DictArray {
+    let num_unique = 256;
+    let codes = PrimitiveArray::from_iter((0..len).map(|i| (i % num_unique) as u32));
+    let values = PrimitiveArray::from_iter(0..num_unique as u32);
+    DictArray::try_new(codes.into_array(), values.into_array()).unwrap()
+}
+
+fn build_primitive(len: usize) -> PrimitiveArray {
+    PrimitiveArray::from_iter(0..len as u32)
+}
+
+#[divan::bench(args = ARRAY_LENGTHS)]
+fn slice_primitive_tight_loop(bencher: Bencher, len: usize) {
+    let arr = build_primitive(len).into_array();
+    let slice_len = 64;
+
+    let num_slices = len / slice_len;
+
+    bencher
+        .with_inputs(|| (&arr, Vec::<ArrayRef>::with_capacity(num_slices)))
+        .bench_refs(|(arr, out)| {
+            out.clear();
+            let mut offset = 0;
+            while offset + slice_len <= len {
+                out.push(arr.slice(offset..offset + slice_len).unwrap());
+                offset += slice_len;
+            }
+        });
+}
+
+#[divan::bench(args = ARRAY_LENGTHS)]
+fn slice_dict_tight_loop(bencher: Bencher, len: usize) {
+    let dict = build_dict(len).into_array();
+    let slice_len = 64;
+    let num_slices = len / slice_len;
+
+    bencher
+        .with_inputs(|| (&dict, Vec::<ArrayRef>::with_capacity(num_slices)))
+        .bench_refs(|(dict, out)| {
+            out.clear();
+            let mut offset = 0;
+            while offset + slice_len <= len {
+                out.push(dict.slice(offset..offset + slice_len).unwrap());
+                offset += slice_len;
+            }
+        });
+}


### PR DESCRIPTION
Include a benchmark which uses the array optimize loop checking for the performance or this and lots of small array being created. 