### PR TITLE
benchmarks-website: duckdb conn pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3751,6 +3751,7 @@ dependencies = [
  "libduckdb-sys",
  "num",
  "num-integer",
+ "r2d2",
  "rust_decimal",
  "strum 0.27.2",
 ]
@@ -7589,6 +7590,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8366,6 +8378,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -10438,6 +10459,7 @@ dependencies = [
  "flate2",
  "insta",
  "maud",
+ "r2d2",
  "reqwest 0.13.3",
  "serde",
  "serde_json",

--- a/benchmarks-website/server/Cargo.toml
+++ b/benchmarks-website/server/Cargo.toml
@@ -27,8 +27,9 @@ anyhow = { workspace = true }
 axum = "0.8"
 base64 = "0.22"
 # track vortex-duckdb's bundled engine version (build.rs)
-duckdb = { version = "1.10502", features = ["bundled"] }
+duckdb = { version = "1.10502", features = ["bundled", "r2d2"] }
 maud = { version = "0.27", features = ["axum"] }
+r2d2 = "0.8"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 subtle = "2.6"

--- a/benchmarks-website/server/src/app.rs
+++ b/benchmarks-website/server/src/app.rs
@@ -22,6 +22,7 @@ use anyhow::Result;
 use axum::Router;
 use axum::routing::get;
 use axum::routing::post;
+use tokio::sync::Mutex;
 use tower_http::compression::CompressionLayer;
 
 use crate::api;
@@ -35,8 +36,11 @@ use crate::ingest;
 /// or a small `String`).
 #[derive(Clone)]
 pub struct AppState {
-    /// Mutex-guarded DuckDB connection. See [`crate::db`].
+    /// r2d2 pool of DuckDB connections. See [`crate::db`].
     pub db: DbHandle,
+    /// Serializes `/api/ingest` so concurrent ingests can't race on the same
+    /// rows and trigger a DuckDB write-write conflict. Reads are unaffected.
+    pub ingest_lock: Arc<Mutex<()>>,
     /// Bearer token expected on `/api/ingest`. Compared via constant-time eq.
     pub bearer_token: Arc<String>,
     /// On-disk path of the DuckDB file. Surfaced on `/health`.
@@ -50,6 +54,7 @@ impl AppState {
         let db = db::open(&path)?;
         Ok(Self {
             db,
+            ingest_lock: Arc::new(Mutex::new(())),
             bearer_token: Arc::new(bearer_token),
             db_path: Arc::new(path),
         })

--- a/benchmarks-website/server/src/db.rs
+++ b/benchmarks-website/server/src/db.rs
@@ -3,9 +3,11 @@
 
 //! DuckDB connection management plus the deterministic `measurement_id` hash.
 //!
-//! The server holds a single [`duckdb::Connection`] inside an async
-//! [`tokio::sync::Mutex`]. All DB work runs inside `spawn_blocking` so the
-//! Tokio runtime is never blocked on synchronous DuckDB calls.
+//! The server holds an [`r2d2::Pool`] of [`duckdb::Connection`]s. All DB
+//! work runs inside `spawn_blocking`, where a connection is checked out
+//! from the pool for the duration of the call. This lets Axum's concurrent
+//! requests run on independent DuckDB connections instead of serializing
+//! through a single mutex.
 //!
 //! `measurement_id` is a server-internal xxhash64 over `commit_sha` plus
 //! each table's dimensional tuple. Including `commit_sha` makes every
@@ -16,12 +18,12 @@
 
 use std::hash::Hasher as _;
 use std::path::Path;
-use std::sync::Arc;
 
 use anyhow::Context as _;
 use anyhow::Result;
 use duckdb::Connection;
-use tokio::sync::Mutex;
+use duckdb::DuckdbConnectionManager;
+use r2d2::Pool;
 use twox_hash::XxHash64;
 
 use crate::records::CompressionSize;
@@ -31,21 +33,30 @@ use crate::records::RandomAccessTime;
 use crate::records::VectorSearchRun;
 use crate::schema::SCHEMA_DDL;
 
-/// A connection guard the rest of the crate hands around.
-pub type DbHandle = Arc<Mutex<Connection>>;
+/// A pool of DuckDB connections shared across all handlers. Cheap to clone
+/// (internally an `Arc`).
+pub type DbHandle = Pool<DuckdbConnectionManager>;
 
-/// Open the DuckDB file at `path` (creating it if absent) and apply the
-/// schema DDL. Returns a handle ready to be cloned into the Axum state.
+/// Open the DuckDB file at `path` (creating it if absent), apply the schema
+/// DDL once, and return a connection pool ready to be cloned into the Axum
+/// state.
 pub fn open<P: AsRef<Path>>(path: P) -> Result<DbHandle> {
-    let conn = Connection::open(path.as_ref())
+    let manager = DuckdbConnectionManager::file(path.as_ref())
         .with_context(|| format!("opening DuckDB at {}", path.as_ref().display()))?;
+    let pool = Pool::builder()
+        .build(manager)
+        .context("building DuckDB connection pool")?;
+    let conn = pool
+        .get()
+        .context("acquiring DuckDB connection from pool")?;
     conn.execute_batch(SCHEMA_DDL)
         .context("applying schema DDL")?;
-    Ok(Arc::new(Mutex::new(conn)))
+    Ok(pool)
 }
 
-/// Run a synchronous DB operation on the blocking pool, holding the connection
-/// mutex for the duration of the call.
+/// Run a synchronous DB operation on the blocking pool. A connection is
+/// checked out from the r2d2 pool inside `spawn_blocking` (which may block
+/// if the pool is saturated) and released when the closure returns.
 pub async fn run_blocking<F, T>(handle: &DbHandle, f: F) -> Result<T>
 where
     F: FnOnce(&mut Connection) -> Result<T> + Send + 'static,
@@ -53,8 +64,10 @@ where
 {
     let handle = handle.clone();
     tokio::task::spawn_blocking(move || {
-        let mut guard = handle.blocking_lock();
-        f(&mut guard)
+        let mut conn = handle
+            .get()
+            .context("acquiring DuckDB connection from pool")?;
+        f(&mut conn)
     })
     .await
     .context("DB task panicked")?

--- a/benchmarks-website/server/src/ingest.rs
+++ b/benchmarks-website/server/src/ingest.rs
@@ -77,6 +77,7 @@ pub async fn handle(
         serde_json::from_value(value).map_err(|e| IngestError::Malformed(e.to_string()))?;
     validate_envelope(&envelope)?;
 
+    let _ingest_guard = state.ingest_lock.lock().await;
     let response = db::run_blocking(&state.db, move |conn| apply_envelope(conn, envelope))
         .await
         .map_err(|err| match err.downcast::<IngestError>() {

--- a/benchmarks-website/server/src/lib.rs
+++ b/benchmarks-website/server/src/lib.rs
@@ -35,7 +35,7 @@
 //! |---------------|---------------------------------------------------------------------------------------------|
 //! | [`app`]       | [`app::AppState`] (DB handle + bearer + path) and the Axum router composition.              |
 //! | [`auth`]      | Bearer-token middleware for `/api/ingest`.                                                  |
-//! | [`db`]        | [`db::DbHandle`] connection wrapper + the per-fact-table `measurement_id_*` hash functions. |
+//! | [`db`]        | [`db::DbHandle`] r2d2 connection pool + the per-fact-table `measurement_id_*` hash functions. |
 //! | [`schema`]    | DuckDB DDL ([`schema::SCHEMA_DDL`]) and the wire schema version.                            |
 //! | [`records`]   | Wire shapes for `POST /api/ingest`.                                                         |
 //! | [`ingest`]    | `POST /api/ingest` handler — envelope validation, transaction, upsert dispatch.             |
@@ -51,9 +51,9 @@
 //!    routes skip auth.
 //! 3. The handler parses body / path / query into typed inputs (e.g.
 //!    [`slug::ChartKey::from_slug`]).
-//! 4. The handler hands a closure to [`db::run_blocking`], which acquires
-//!    the connection mutex and runs the synchronous DuckDB call on
-//!    `tokio::task::spawn_blocking` so the runtime stays free.
+//! 4. The handler hands a closure to [`db::run_blocking`], which checks a
+//!    connection out of the r2d2 pool and runs the synchronous DuckDB call
+//!    on `tokio::task::spawn_blocking` so the runtime stays free.
 //! 5. The closure returns `Result<T, anyhow::Error>`. Errors are mapped
 //!    into [`error::IngestError`] / [`error::ApiError`] with the right
 //!    HTTP status.


### PR DESCRIPTION
A single visit to the benchmarks website makes ~360 concurrent API requests to this axum server.

The previous `Arc<Mutex<Connection>>` was causing all of these requests to serialize (multiply by however many concurrent tabs had the benchmarks open).

This creates a connection pool of DuckDB conns, and adds a mutex on the ingestion endpoint to avoid attempting to open two concurrent DB connections for writing (which DuckDB does not allow and would cause an error).