### PR TITLE
tracing logger for duckdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10652,6 +10652,7 @@ dependencies = [
  "rstest",
  "tempfile",
  "tracing",
+ "tracing-subscriber",
  "url",
  "vortex",
  "vortex-array",

--- a/vortex-array/src/scalar_fn/fns/dynamic.rs
+++ b/vortex-array/src/scalar_fn/fns/dynamic.rs
@@ -67,10 +67,10 @@ impl ScalarFnVTable for DynamicComparison {
         f: &mut Formatter<'_>,
     ) -> std::fmt::Result {
         expr.child(0).fmt_sql(f)?;
-        write!(f, " {} dynamic(", dynamic)?;
+        write!(f, " {} dynamic(", dynamic.operator)?;
         match dynamic.scalar() {
-            None => write!(f, "<none>")?,
-            Some(scalar) => write!(f, "{}", scalar)?,
+            None => write!(f, "scalar=<none>")?,
+            Some(scalar) => write!(f, "scalar={scalar}")?,
         }
         write!(f, ")")
     }

--- a/vortex-duckdb/Cargo.toml
+++ b/vortex-duckdb/Cargo.toml
@@ -36,6 +36,7 @@ object_store = { workspace = true, features = ["aws"] }
 parking_lot = { workspace = true }
 paste = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
 vortex = { workspace = true, features = ["files", "tokio", "object_store"] }
 vortex-utils = { workspace = true, features = ["dashmap"] }

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -413,7 +413,10 @@ extern "C" duckdb_state duckdb_vx_tfunc_register(duckdb_database ffi_db, const d
         return {
             {COLUMN_IDENTIFIER_EMPTY, {"", LogicalTypeId::BOOLEAN}},
             {COLUMN_IDENTIFIER_FILE_INDEX, {"file_index", LogicalType::UBIGINT}},
-            {COLUMN_IDENTIFIER_FILE_ROW_NUMBER, {"file_row_number", LogicalType::BIGINT}},
+            // MultiFileReader's file_row_number column is BIGINT.
+            // row_idx() is UBIGINT. Use UBIGINT since there's no difference to
+            // Duckdb what to compare.
+            {COLUMN_IDENTIFIER_FILE_ROW_NUMBER, {"file_row_number", LogicalType::UBIGINT}},
         };
     };
 

--- a/vortex-duckdb/src/convert/expr.rs
+++ b/vortex-duckdb/src/convert/expr.rs
@@ -9,6 +9,7 @@ use vortex::error::VortexError;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
+use vortex::error::vortex_ensure;
 use vortex::error::vortex_err;
 use vortex::expr::Expression;
 use vortex::expr::and_collect;
@@ -48,7 +49,10 @@ pub fn try_from_bound_expression(
     value: &duckdb::ExpressionRef,
 ) -> VortexResult<Option<Expression>> {
     let Some(value) = value.as_class() else {
-        debug!("no expression class id {:?}", value.as_class_id());
+        debug!(
+            class_id = ?value.as_class_id(),
+            "unknown expression class id"
+        );
         return Ok(None);
     };
     Ok(Some(match value {
@@ -97,7 +101,7 @@ pub fn try_from_bound_expression(
             | DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_OPERATOR_IS_NULL
             | DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_OPERATOR_IS_NOT_NULL => {
                 let children: Vec<_> = operator.children().collect();
-                assert_eq!(children.len(), 1);
+                vortex_ensure!(children.len() == 1);
                 let Some(child) = try_from_bound_expression(children[0])? else {
                     return Ok(None);
                 };
@@ -113,7 +117,7 @@ pub fn try_from_bound_expression(
             DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_COMPARE_IN => {
                 // First child is element, rest form the list.
                 let children: Vec<_> = operator.children().collect();
-                assert!(children.len() >= 2);
+                vortex_ensure!(children.len() >= 2);
                 let Some(element) = try_from_bound_expression(children[0])? else {
                     return Ok(None);
                 };
@@ -146,7 +150,7 @@ pub fn try_from_bound_expression(
                 list_contains(lit(list), element)
             }
             _ => {
-                debug!(op=?operator.op, "cannot be pushed down");
+                debug!(op=?operator.op, "cannot push down operator");
                 return Ok(None);
             }
         },
@@ -164,7 +168,10 @@ pub fn try_from_bound_expression(
                 Like.new_expr(LikeOptions::default(), [value, pattern])
             }
             _ => {
-                debug!("bound function {}", func.scalar_function.name());
+                debug!(
+                    name = func.scalar_function.name(),
+                    "cannot push down function"
+                );
                 return Ok(None);
             }
         },

--- a/vortex-duckdb/src/datasource.rs
+++ b/vortex-duckdb/src/datasource.rs
@@ -29,13 +29,11 @@ use vortex::array::optimizer::ArrayOptimizer;
 use vortex::array::stats::StatsSet;
 use vortex::dtype::DType;
 use vortex::dtype::FieldNames;
-use vortex::dtype::PType;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
 use vortex::expr::Expression;
 use vortex::expr::and_collect;
-use vortex::expr::cast;
 use vortex::expr::col;
 use vortex::expr::merge;
 use vortex::expr::pack;
@@ -281,7 +279,7 @@ impl<T: DataSourceTableFunction> TableFunction for T {
     }
 
     fn init_global(init_input: &TableInitInput<Self>) -> VortexResult<Self::GlobalState> {
-        debug!("table init input: {init_input:?}");
+        debug!(input=?init_input, "table function global input");
 
         let bind_data = init_input.bind_data();
         let column_ids = init_input.column_ids();
@@ -307,13 +305,16 @@ impl<T: DataSourceTableFunction> TableFunction for T {
             bind_data.data_source.dtype(),
         )?;
 
-        let filter_expr_str = filter
-            .as_ref()
-            .map_or_else(|| "true".to_string(), |f| f.to_string());
         debug!(
-            "Global init Vortex scan SELECT {projection} WHERE {filter_expr_str}\n
-                 row selection: {row_selection:?}, row range: {row_range:?},
-                 file selection: {file_selection:?}, file range: {file_range:?}"
+            %projection,
+            filter = filter
+                .as_ref()
+                .map_or_else(|| "true".to_string(), |f| f.to_string()),
+            ?row_selection,
+            ?row_range,
+            ?file_selection,
+            ?file_range,
+            "table function scan input"
         );
 
         let request = ScanRequest {
@@ -500,10 +501,12 @@ impl<T: DataSourceTableFunction> TableFunction for T {
         bind_data: &mut Self::BindData,
         expr: &ExpressionRef,
     ) -> VortexResult<bool> {
-        tracing::debug!("Attempting to push down filter expression: {expr}");
+        debug!(%expr, "pushing down expression");
         let Some(expr) = try_from_bound_expression(expr)? else {
+            debug!(%expr, "failed to push down expression");
             return Ok(false);
         };
+        debug!(%expr, "pushed down expression");
         bind_data.filter_exprs.push(expr);
 
         // NOTE(ngates): Vortex does indeed run exact filters, so in theory we should return `true`
@@ -663,12 +666,9 @@ fn extract_projection_expr(
     };
 
     // file_index column will be filled later when exporting the chunk.
-
     let projection = if file_row_number_column_pos.is_some() {
-        // row_idx will be rearranged to correct position in scan(), prepend
-        // here
-        let row_idx = cast(row_idx(), DType::Primitive(PType::I64, false.into()));
-        let row_idx_struct = pack([("file_row_number", row_idx)], false.into());
+        // row_idx will be moved to correct position in scan(), prepend here
+        let row_idx_struct = pack([("file_row_number", row_idx())], false.into());
         merge([row_idx_struct, select])
     } else {
         select
@@ -751,8 +751,6 @@ mod tests {
     use std::sync::atomic::Ordering::Relaxed;
 
     use vortex::dtype::DType;
-    use vortex::dtype::PType;
-    use vortex::expr::cast;
     use vortex::expr::merge;
     use vortex::expr::pack;
     use vortex::expr::root;
@@ -807,8 +805,7 @@ mod tests {
 
         let ids = [FILE_ROW_NUMBER_COLUMN_IDX, 0, 1, FILE_INDEX_COLUMN_IDX, 2];
         let exprs = extract_projection_expr(None, &ids, &fields);
-        let row_idx = cast(row_idx(), DType::Primitive(PType::I64, false.into()));
-        let row_idx_struct = pack([("file_row_number", row_idx)], false.into());
+        let row_idx_struct = pack([("file_row_number", row_idx())], false.into());
         let root_with_virtual_cols = merge([row_idx_struct, root()]);
 
         assert_eq!(exprs.projection, root_with_virtual_cols);

--- a/vortex-duckdb/src/lib.rs
+++ b/vortex-duckdb/src/lib.rs
@@ -6,6 +6,7 @@
 use std::ffi::CStr;
 use std::ffi::c_char;
 use std::sync::LazyLock;
+use std::sync::OnceLock;
 
 use vortex::VortexSessionDefault;
 use vortex::error::VortexExpect;
@@ -45,6 +46,20 @@ static RUNTIME: LazyLock<CurrentThreadRuntime> = LazyLock::new(CurrentThreadRunt
 static SESSION: LazyLock<VortexSession> =
     LazyLock::new(|| VortexSession::default().with_handle(RUNTIME.handle()));
 
+// Duckdb's logger requires a *Context as first argument which
+// would be hard to integrate with tracing::. We use logging for
+// debugging only anyway, so that's good enough.
+fn init_tracing() {
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        drop(
+            tracing_subscriber::fmt()
+                .with_writer(std::io::stdout)
+                .try_init(),
+        );
+    });
+}
+
 /// Initialize the Vortex extension by registering the extension functions.
 /// Note: This also registers extension options. If you want to register options
 /// separately (e.g., before creating connections), call `register_extension_options` first.
@@ -74,6 +89,7 @@ pub fn initialize(db: &DatabaseRef) -> VortexResult<()> {
 /// The DuckDB extension ABI initialization function.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn vortex_init_rust(db: cpp::duckdb_database) {
+    init_tracing();
     let database = unsafe { Database::borrow(db) };
 
     database

--- a/vortex-file/src/footer/deserializer.rs
+++ b/vortex-file/src/footer/deserializer.rs
@@ -124,7 +124,7 @@ impl FooterDeserializer {
 
         // Read more bytes if necessary.
         if read_more_offset < initial_offset {
-            tracing::debug!(
+            tracing::trace!(
                 "Initial read from {initial_offset} did not cover all footer segments, reading from {read_more_offset}"
             );
             return Ok(DeserializeStep::NeedMoreData {

--- a/vortex-file/src/multi/mod.rs
+++ b/vortex-file/src/multi/mod.rs
@@ -204,7 +204,7 @@ async fn open_file(
     session: &VortexSession,
     open_options_fn: &(dyn Fn(VortexOpenOptions) -> VortexOpenOptions + Send + Sync),
 ) -> VortexResult<crate::VortexFile> {
-    debug!(path = %file.path, "opening vortex file");
+    tracing::trace!(path = %file.path, "opening vortex file");
 
     // Open the reader first so we can use its URI as the cache key.
     // The URI includes the full path (with any filesystem prefix), making it unique

--- a/vortex-file/src/read/driver.rs
+++ b/vortex-file/src/read/driver.rs
@@ -9,6 +9,7 @@ use std::task::Poll;
 
 use futures::Stream;
 use pin_project_lite::pin_project;
+use tracing::trace;
 use vortex_buffer::Alignment;
 use vortex_error::VortexExpect;
 use vortex_io::CoalesceConfig;
@@ -133,11 +134,11 @@ impl State {
 
     #[allow(clippy::cognitive_complexity)]
     fn on_event(&mut self, event: ReadEvent) {
-        tracing::debug!(?event, "Received ReadEvent");
+        trace!(?event, "Received ReadEvent");
         match event {
             ReadEvent::Request(req) => {
                 if req.callback.is_closed() {
-                    tracing::debug!(?req, "ReadRequest dropped before registration");
+                    trace!(?req, "ReadRequest dropped before registration");
                     return;
                 }
                 self.requests_by_offset.insert((req.offset, req.id));
@@ -147,7 +148,7 @@ impl State {
                 if let Some(req) = self.requests.remove(&req_id) {
                     if req.callback.is_closed() {
                         self.requests_by_offset.remove(&(req.offset, req_id));
-                        tracing::debug!(?req, "ReadRequest dropped before poll");
+                        trace!(?req, "ReadRequest dropped before poll");
                     } else {
                         self.polled_requests.insert(req_id, req);
                     }
@@ -156,11 +157,11 @@ impl State {
             ReadEvent::Dropped(req_id) => {
                 if let Some(req) = self.requests.remove(&req_id) {
                     self.requests_by_offset.remove(&(req.offset, req_id));
-                    tracing::debug!(?req, "ReadRequest dropped before poll");
+                    trace!(?req, "ReadRequest dropped before poll");
                 }
                 if let Some(req) = self.polled_requests.remove(&req_id) {
                     self.requests_by_offset.remove(&(req.offset, req_id));
-                    tracing::debug!(?req, "ReadRequest dropped after poll");
+                    trace!(?req, "ReadRequest dropped after poll");
                 }
             }
         }
@@ -193,7 +194,7 @@ impl State {
         while let Some((req_id, req)) = self.polled_requests.pop_first() {
             self.requests_by_offset.remove(&(req.offset, req_id));
             if req.callback.is_closed() {
-                tracing::debug!("Dropping canceled request");
+                trace!("Dropping canceled request");
                 continue;
             }
             return Some(req);
@@ -303,7 +304,7 @@ impl State {
 
         let aligned_start = current_start - (current_start % align);
 
-        tracing::debug!(
+        trace!(
             "Coalesced {} requests into range {}..{} (len={})",
             requests.len(),
             aligned_start,

--- a/vortex-file/src/read/request.rs
+++ b/vortex-file/src/read/request.rs
@@ -7,6 +7,7 @@ use std::fmt::Formatter;
 use std::ops::Range;
 use std::sync::Arc;
 
+use tracing::trace;
 use vortex_array::buffer::BufferHandle;
 use vortex_buffer::Alignment;
 use vortex_error::VortexError;
@@ -113,7 +114,7 @@ impl Debug for ReadRequest {
 impl ReadRequest {
     pub(crate) fn resolve(self, result: VortexResult<BufferHandle>) {
         if let Err(e) = self.callback.send(result) {
-            tracing::debug!("ReadRequest {} dropped before resolving: {e}", self.id);
+            trace!("ReadRequest {} dropped before resolving: {e}", self.id);
         }
     }
 }

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -11,6 +11,7 @@ use futures::TryStreamExt;
 use futures::future::BoxFuture;
 use futures::stream::FuturesOrdered;
 use itertools::Itertools;
+use tracing::trace;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
@@ -229,7 +230,7 @@ impl LayoutReader for ChunkedReader {
 
         let name = Arc::clone(&self.name);
         Ok(MaskFuture::new(mask.len(), async move {
-            tracing::debug!(
+            trace!(
                 "Chunked pruning evaluation {} (mask = {})",
                 name,
                 mask.density()
@@ -272,7 +273,7 @@ impl LayoutReader for ChunkedReader {
 
         let name = Arc::clone(&self.name);
         Ok(MaskFuture::new(mask.len(), async move {
-            tracing::debug!("Chunked mask evaluation {}", name);
+            trace!("Chunked mask evaluation {}", name);
 
             // Split the mask over each chunk.
             let masks: Vec<_> = FuturesOrdered::from_iter(chunk_evals).try_collect().await?;

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use futures::FutureExt;
 use futures::future::BoxFuture;
+use tracing::trace;
 use vortex_array::ArrayRef;
 use vortex_array::MaskFuture;
 use vortex_array::VortexSessionExecute;
@@ -164,7 +165,7 @@ impl LayoutReader for FlatReader {
                 mask.bitand(&array_mask)
             };
 
-            tracing::debug!(
+            trace!(
                 "Flat mask evaluation {} - {} (mask = {}) => {}",
                 name,
                 expr,
@@ -191,7 +192,7 @@ impl LayoutReader for FlatReader {
         let expr = expr.clone();
 
         Ok(async move {
-            tracing::debug!("Flat array evaluation {} - {}", name, expr);
+            trace!("Flat array evaluation {} - {}", name, expr);
 
             let mut array = array.clone().await?;
             let mask = mask.await?;

--- a/vortex-layout/src/layouts/zoned/pruning.rs
+++ b/vortex-layout/src/layouts/zoned/pruning.rs
@@ -12,6 +12,7 @@ use futures::TryFutureExt;
 use futures::future::BoxFuture;
 use futures::future::Shared;
 use parking_lot::RwLock;
+use tracing::trace;
 use vortex_array::MaskFuture;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::StructArray;
@@ -79,13 +80,11 @@ impl PruningState {
             .entry(expr.clone())
             .or_insert_with(|| match self.pruning_predicate(expr.clone()) {
                 None => {
-                    tracing::debug!("No pruning predicate for expr: {expr}");
+                    trace!(%expr, "no pruning predicate");
                     None
                 }
                 Some(predicate) => {
-                    tracing::debug!(
-                        "Constructed pruning predicate for expr: {expr}: {predicate:?}"
-                    );
+                    trace!(%expr, ?predicate, "constructed pruning predicate");
                     let zone_map = self.zone_map();
                     let dynamic_updates = DynamicExprUpdates::new(&expr);
                     let session = self.session.clone();
@@ -192,9 +191,10 @@ impl PruningResult {
             return Ok(guard.1.clone());
         }
 
-        tracing::debug!(
-            "Re-computing pruning mask for version {version} on {}",
-            self.predicate
+        trace!(
+            version,
+            predicate = %self.predicate,
+            "recomputing pruning mask"
         );
 
         let next_mask = self

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use futures::future::BoxFuture;
 use itertools::Itertools;
+use tracing::trace;
 use vortex_array::ArrayRef;
 use vortex_array::MaskFuture;
 use vortex_array::dtype::DType;
@@ -119,20 +120,18 @@ impl LayoutReader for ZonedReader {
         expr: &Expression,
         mask: Mask,
     ) -> VortexResult<MaskFuture> {
-        tracing::debug!("Stats pruning evaluation: {} - {}", &self.name, expr);
+        trace!("Stats pruning evaluation: {} - {}", &self.name, expr);
         let data_eval = self
             .data_child()?
             .pruning_evaluation(row_range, expr, mask.clone())?;
 
         if self.layout.zone_len == 0 {
-            tracing::debug!(
-                "Stats pruning evaluation: skipping zoned pruning for legacy zero-length zones"
-            );
+            trace!("Stats pruning evaluation: skipping zoned pruning for legacy zero-length zones");
             return Ok(data_eval);
         }
 
         let Some(pruning_mask_future) = self.pruning.pruning_mask_future(expr.clone()) else {
-            tracing::debug!("Stats pruning evaluation: not prune-able {expr}");
+            trace!("Stats pruning evaluation: not prune-able {expr}");
             return Ok(data_eval);
         };
 
@@ -159,7 +158,7 @@ impl LayoutReader for ZonedReader {
         let expr = expr.clone();
 
         Ok(MaskFuture::new(mask.len(), async move {
-            tracing::debug!("Invoking stats pruning evaluation {}: {}", name, expr);
+            trace!("Invoking stats pruning evaluation {}: {}", name, expr);
 
             let pruning_mask = pruning_mask_future.await?.mask()?;
 
@@ -180,7 +179,7 @@ impl LayoutReader for ZonedReader {
                 stats_mask = stats_mask.bitand(&data_mask);
             }
 
-            tracing::debug!(
+            trace!(
                 "Stats evaluation approx {} - {} (mask = {}) => {}",
                 name,
                 expr,

--- a/vortex-layout/src/scan/filter.rs
+++ b/vortex-layout/src/scan/filter.rs
@@ -123,7 +123,7 @@ impl FilterExpr {
                 .vortex_expect("Can't compare selectivity values")
         });
 
-        tracing::debug!(
+        tracing::trace!(
             "Reordered conjuncts based on new selectivity {:?}",
             ordering
                 .iter()


### PR DESCRIPTION
- Add stdout logger for Vortex in duckdb (we use it only for debugging anyway).
- Move some log messages from debug to trace
- Don't cast file_row_number to i64, use u64 as target column.
- Fix dynamic filter printing

Resolves #6820
