### PR TITLE
Standardize DType match arms to follow variant declaration order

### DIFF
--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -114,14 +114,6 @@ pub(super) fn execute_sparse(parts: SparseParts, ctx: &mut ExecutionCtx) -> Vort
                 execute_sparse_primitives::<P>(&patches, &fill_value, ctx)?
             })
         }
-        DType::Struct(struct_fields, ..) => execute_sparse_struct(
-            struct_fields,
-            fill_value.as_struct(),
-            dtype.nullability(),
-            &patches,
-            len,
-            ctx,
-        )?,
         DType::Decimal(decimal_dtype, nullability) => {
             let canonical_decimal_value_type =
                 DecimalType::smallest_decimal_value_type(decimal_dtype);
@@ -157,8 +149,16 @@ pub(super) fn execute_sparse(parts: SparseParts, ctx: &mut ExecutionCtx) -> Vort
         DType::FixedSizeList(.., nullability) => {
             execute_sparse_fixed_size_list(&patches, &fill_value, len, *nullability, ctx)?
         }
-        DType::Extension(_ext_dtype) => todo!(),
+        DType::Struct(struct_fields, ..) => execute_sparse_struct(
+            struct_fields,
+            fill_value.as_struct(),
+            dtype.nullability(),
+            &patches,
+            len,
+            ctx,
+        )?,
         DType::Variant(_) => vortex_bail!("Sparse canonicalization does not support Variant"),
+        DType::Extension(_ext_dtype) => todo!(),
     })
 }
 

--- a/fuzz/src/array/compare.rs
+++ b/fuzz/src/array/compare.rs
@@ -161,7 +161,7 @@ pub fn compare_canonical_array(
                 )
             })
         }
-        DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => {
+        DType::List(..) | DType::FixedSizeList(..) | DType::Struct(..) => {
             let scalar_vals: Vec<Scalar> = (0..array.len())
                 .map(|i| array.execute_scalar(i, ctx).vortex_expect("scalar_at"))
                 .collect();
@@ -173,7 +173,7 @@ pub fn compare_canonical_array(
             }))
             .into_array()
         }
-        d @ (DType::Null | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Variant(_) | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/filter.rs
+++ b/fuzz/src/array/filter.rs
@@ -98,6 +98,15 @@ pub fn filter_canonical_array(
             });
             Ok(VarBinViewArray::from_iter(values, array.dtype().clone()).into_array())
         }
+        DType::List(..) | DType::FixedSizeList(..) => {
+            let mut indices = Vec::new();
+            for (idx, bool) in filter.iter().enumerate() {
+                if *bool {
+                    indices.push(idx);
+                }
+            }
+            take_canonical_array_non_nullable_indices(array, indices.as_slice(), ctx)
+        }
         DType::Struct(..) => {
             let struct_array = array.clone().execute::<StructArray>(ctx)?;
             let filtered_children = struct_array
@@ -113,16 +122,7 @@ pub fn filter_canonical_array(
             )
             .map(|a| a.into_array())
         }
-        DType::List(..) | DType::FixedSizeList(..) => {
-            let mut indices = Vec::new();
-            for (idx, bool) in filter.iter().enumerate() {
-                if *bool {
-                    indices.push(idx);
-                }
-            }
-            take_canonical_array_non_nullable_indices(array, indices.as_slice(), ctx)
-        }
-        d @ (DType::Null | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Variant(_) | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -464,20 +464,25 @@ fn actions_for_dtype(dtype: &DType) -> HashSet<ActionType> {
     use ActionType::*;
 
     match dtype {
-        DType::Struct(sdt, _) => {
-            // Struct supports: Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt
-            // Does NOT support: SearchSorted (requires scalar comparison), Compare, Cast, Sum, FillNull
-            let struct_actions = [Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt];
-            sdt.fields()
-                .map(|child| actions_for_dtype(&child))
-                .fold(struct_actions.into(), |acc, actions| {
-                    acc.intersection(&actions).copied().collect()
-                })
+        DType::Null => {
+            // Null arrays support most operations but not Sum or MinMax (return None for dtype)
+            [
+                Compress,
+                Slice,
+                Take,
+                SearchSorted,
+                Filter,
+                Compare,
+                Cast,
+                FillNull,
+                Mask,
+                ScalarAt,
+            ]
+            .into()
         }
-        DType::List(..) | DType::FixedSizeList(..) => {
-            // List supports: Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt
-            // Does NOT support: SearchSorted, Compare, Cast, Sum, FillNull
-            [Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt].into()
+        DType::Bool(_) | DType::Primitive(..) | DType::Decimal(..) => {
+            // These support all actions
+            ActionType::iter().collect()
         }
         DType::Utf8(_) | DType::Binary(_) => {
             // Utf8/Binary supports everything except Sum and FillNull
@@ -496,32 +501,27 @@ fn actions_for_dtype(dtype: &DType) -> HashSet<ActionType> {
             ]
             .into()
         }
-        DType::Bool(_) | DType::Primitive(..) | DType::Decimal(..) => {
-            // These support all actions
-            ActionType::iter().collect()
+        DType::List(..) | DType::FixedSizeList(..) => {
+            // List supports: Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt
+            // Does NOT support: SearchSorted, Compare, Cast, Sum, FillNull
+            [Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt].into()
         }
-        DType::Null => {
-            // Null arrays support most operations but not Sum or MinMax (return None for dtype)
-            [
-                Compress,
-                Slice,
-                Take,
-                SearchSorted,
-                Filter,
-                Compare,
-                Cast,
-                FillNull,
-                Mask,
-                ScalarAt,
-            ]
-            .into()
+        DType::Struct(sdt, _) => {
+            // Struct supports: Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt
+            // Does NOT support: SearchSorted (requires scalar comparison), Compare, Cast, Sum, FillNull
+            let struct_actions = [Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt];
+            sdt.fields()
+                .map(|child| actions_for_dtype(&child))
+                .fold(struct_actions.into(), |acc, actions| {
+                    acc.intersection(&actions).copied().collect()
+                })
         }
+        // Currently, no support at all
+        DType::Variant(_) => unreachable!("Variant dtype shouldn't be fuzzed"),
         DType::Extension(_) => {
             // Extension types delegate to storage dtype, support most operations
             ActionType::iter().collect()
         }
-        // Currently, no support at all
-        DType::Variant(_) => unreachable!("Variant dtype shouldn't be fuzzed"),
     }
 }
 

--- a/fuzz/src/array/search_sorted.rs
+++ b/fuzz/src/array/search_sorted.rs
@@ -142,13 +142,13 @@ pub fn search_sorted_canonical_array(
             };
             SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
         }
-        DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => {
+        DType::List(..) | DType::FixedSizeList(..) | DType::Struct(..) => {
             let scalar_vals = (0..array.len())
                 .map(|i| array.execute_scalar(i, ctx))
                 .collect::<VortexResult<Vec<_>>>()?;
             scalar_vals.search_sorted(&scalar.cast(array.dtype())?, side)
         }
-        d @ (DType::Null | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Variant(_) | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -54,6 +54,19 @@ pub fn slice_canonical_array(
                 .into_array())
             })
         }
+        DType::Decimal(decimal_dtype, _) => {
+            let decimal_array = array.clone().execute::<DecimalArray>(ctx)?;
+            Ok(
+                match_each_decimal_value_type!(decimal_array.values_type(), |D| {
+                    DecimalArray::new(
+                        decimal_array.buffer::<D>().slice(start..stop),
+                        *decimal_dtype,
+                        validity,
+                    )
+                })
+                .into_array(),
+            )
+        }
         DType::Utf8(_) | DType::Binary(_) => {
             let utf8 = array.clone().execute::<VarBinViewArray>(ctx)?;
             let values =
@@ -63,20 +76,6 @@ pub fn slice_canonical_array(
                 array.dtype().clone(),
             )
             .into_array())
-        }
-        DType::Struct(..) => {
-            let struct_array = array.clone().execute::<StructArray>(ctx)?;
-            let sliced_children = struct_array
-                .iter_unmasked_fields()
-                .map(|c| slice_canonical_array(c, start, stop, ctx))
-                .collect::<VortexResult<Vec<_>>>()?;
-            StructArray::try_new_with_dtype(
-                sliced_children,
-                struct_array.struct_fields().clone(),
-                stop - start,
-                validity,
-            )
-            .map(|a| a.into_array())
         }
         DType::List(..) => {
             let list_array = array.clone().execute::<ListViewArray>(ctx)?;
@@ -110,20 +109,21 @@ pub fn slice_canonical_array(
             FixedSizeListArray::try_new(elements, fsl_array.list_size(), validity, new_len)
                 .map(|a| a.into_array())
         }
-        DType::Decimal(decimal_dtype, _) => {
-            let decimal_array = array.clone().execute::<DecimalArray>(ctx)?;
-            Ok(
-                match_each_decimal_value_type!(decimal_array.values_type(), |D| {
-                    DecimalArray::new(
-                        decimal_array.buffer::<D>().slice(start..stop),
-                        *decimal_dtype,
-                        validity,
-                    )
-                })
-                .into_array(),
+        DType::Struct(..) => {
+            let struct_array = array.clone().execute::<StructArray>(ctx)?;
+            let sliced_children = struct_array
+                .iter_unmasked_fields()
+                .map(|c| slice_canonical_array(c, start, stop, ctx))
+                .collect::<VortexResult<Vec<_>>>()?;
+            StructArray::try_new_with_dtype(
+                sliced_children,
+                struct_array.struct_fields().clone(),
+                stop - start,
+                validity,
             )
+            .map(|a| a.into_array())
         }
-        d @ (DType::Null | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Variant(_) | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/sort.rs
+++ b/fuzz/src/array/sort.rs
@@ -91,7 +91,7 @@ pub fn sort_canonical_array(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexR
             opt_values.sort();
             Ok(VarBinViewArray::from_iter(opt_values, array.dtype().clone()).into_array())
         }
-        DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => {
+        DType::List(..) | DType::FixedSizeList(..) | DType::Struct(..) => {
             let mut sort_indices = (0..array.len()).collect::<Vec<_>>();
             sort_indices.sort_by(|a, b| {
                 let lhs = array.execute_scalar(*a, ctx).vortex_expect("scalar_at");
@@ -101,7 +101,7 @@ pub fn sort_canonical_array(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexR
             });
             take_canonical_array_non_nullable_indices(array, &sort_indices, ctx)
         }
-        d @ (DType::Null | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Variant(_) | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/take.rs
+++ b/fuzz/src/array/take.rs
@@ -113,21 +113,6 @@ pub fn take_canonical_array(
             )
             .into_array())
         }
-        DType::Struct(..) => {
-            let struct_array = array.clone().execute::<StructArray>(ctx)?;
-            let taken_children = struct_array
-                .iter_unmasked_fields()
-                .map(|c| take_canonical_array_non_nullable_indices(c, indices_slice_non_opt, ctx))
-                .collect::<VortexResult<Vec<_>>>()?;
-
-            StructArray::try_new(
-                struct_array.names().clone(),
-                taken_children,
-                indices_slice_non_opt.len(),
-                validity,
-            )
-            .map(|a| a.into_array())
-        }
         DType::List(..) | DType::FixedSizeList(..) => {
             let mut builder = builder_with_capacity(
                 &array.dtype().union_nullability(nullable),
@@ -147,7 +132,22 @@ pub fn take_canonical_array(
             }
             Ok(builder.finish())
         }
-        d @ (DType::Null | DType::Extension(_) | DType::Variant(_)) => {
+        DType::Struct(..) => {
+            let struct_array = array.clone().execute::<StructArray>(ctx)?;
+            let taken_children = struct_array
+                .iter_unmasked_fields()
+                .map(|c| take_canonical_array_non_nullable_indices(c, indices_slice_non_opt, ctx))
+                .collect::<VortexResult<Vec<_>>>()?;
+
+            StructArray::try_new(
+                struct_array.names().clone(),
+                taken_children,
+                indices_slice_non_opt.len(),
+                validity,
+            )
+            .map(|a| a.into_array())
+        }
+        d @ (DType::Null | DType::Variant(_) | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/vortex-array/src/aggregate_fn/fns/is_sorted/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/is_sorted/mod.rs
@@ -242,9 +242,9 @@ impl AggregateFnVTable for IsSorted {
     fn return_dtype(&self, _options: &Self::Options, input_dtype: &DType) -> Option<DType> {
         match input_dtype {
             DType::Null
-            | DType::Struct(..)
             | DType::List(..)
             | DType::FixedSizeList(..)
+            | DType::Struct(..)
             | DType::Variant(..) => None,
             _ => Some(DType::Bool(Nullability::NonNullable)),
         }
@@ -253,9 +253,9 @@ impl AggregateFnVTable for IsSorted {
     fn partial_dtype(&self, _options: &Self::Options, input_dtype: &DType) -> Option<DType> {
         match input_dtype {
             DType::Null
-            | DType::Struct(..)
             | DType::List(..)
             | DType::FixedSizeList(..)
+            | DType::Struct(..)
             | DType::Variant(..) => None,
             _ => Some(make_is_sorted_partial_dtype(input_dtype)),
         }

--- a/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
@@ -240,12 +240,12 @@ pub(crate) fn constant_uncompressed_size_in_bytes(
             array.len(),
             array.scalar().as_binary().value().map(|value| value.len()),
         )?,
-        DType::Variant(_) => {
-            vortex_bail!("UncompressedSizeInBytes is not supported for Variant arrays")
-        }
-        DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) | DType::Extension(_) => {
+        DType::List(..) | DType::FixedSizeList(..) | DType::Struct(..) | DType::Extension(_) => {
             let canonical = array.array().clone().execute::<Canonical>(ctx)?;
             return canonical_uncompressed_size_in_bytes(&canonical, ctx);
+        }
+        DType::Variant(_) => {
+            vortex_bail!("UncompressedSizeInBytes is not supported for Variant arrays")
         }
     };
 
@@ -293,10 +293,10 @@ fn supports_uncompressed_size_in_bytes(dtype: &DType) -> bool {
         DType::Struct(fields, _) => fields
             .fields()
             .all(|field| supports_uncompressed_size_in_bytes(&field)),
+        DType::Variant(_) => false,
         DType::Extension(ext_dtype) => {
             supports_uncompressed_size_in_bytes(ext_dtype.storage_dtype())
         }
-        DType::Variant(_) => false,
         DType::Null
         | DType::Bool(_)
         | DType::Primitive(..)

--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -155,6 +155,10 @@ fn random_array_chunk(
         }
         DType::Utf8(n) => random_string(u, *n, chunk_len),
         DType::Binary(n) => random_bytes(u, *n, chunk_len),
+        DType::List(elem_dtype, null) => random_list(u, elem_dtype, *null, chunk_len),
+        DType::FixedSizeList(elem_dtype, list_size, null) => {
+            random_fixed_size_list(u, elem_dtype, *list_size, *null, chunk_len)
+        }
         DType::Struct(sdt, n) => {
             let first_array = sdt
                 .fields()
@@ -185,15 +189,11 @@ fn random_array_chunk(
             .vortex_expect("operation should succeed in arbitrary impl")
             .into_array())
         }
-        DType::List(elem_dtype, null) => random_list(u, elem_dtype, *null, chunk_len),
-        DType::FixedSizeList(elem_dtype, list_size, null) => {
-            random_fixed_size_list(u, elem_dtype, *list_size, *null, chunk_len)
+        DType::Variant(_) => {
+            unimplemented!("Variant arrays are not implemented")
         }
         DType::Extension(..) => {
             unimplemented!("Extension arrays are not implemented")
-        }
-        DType::Variant(_) => {
-            unimplemented!("Variant arrays are not implemented")
         }
     }
 }

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -241,7 +241,7 @@ impl VTable for Chunked {
     fn execute(array: Array<Self>, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionResult> {
         match array.dtype() {
             // Struct and List need special swizzling logic, use the existing canonicalize path.
-            DType::Struct(..) | DType::List(..) => {
+            DType::List(..) | DType::Struct(..) => {
                 // TODO(joe)[#7674]: iterative execution here too
                 Ok(ExecutionResult::done(_canonicalize(array.as_view(), ctx)?))
             }

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -124,6 +124,18 @@ pub(crate) fn constant_canonicalize(
                 array.len(),
             ))
         }
+        DType::List(..) => Canonical::List(constant_canonical_list_array(scalar, array.len())),
+        DType::FixedSizeList(element_dtype, list_size, _) => {
+            let value = scalar.as_list();
+
+            Canonical::FixedSizeList(constant_canonical_fixed_size_list_array(
+                value.elements(),
+                element_dtype,
+                *list_size,
+                value.dtype().nullability(),
+                array.len(),
+            ))
+        }
         DType::Struct(struct_dtype, _) => {
             let value = scalar.as_struct();
             let fields: Vec<_> = match value.fields_iter() {
@@ -151,17 +163,10 @@ pub(crate) fn constant_canonicalize(
                 StructArray::new_unchecked(fields, struct_dtype.clone(), array.len(), validity)
             })
         }
-        DType::List(..) => Canonical::List(constant_canonical_list_array(scalar, array.len())),
-        DType::FixedSizeList(element_dtype, list_size, _) => {
-            let value = scalar.as_list();
-
-            Canonical::FixedSizeList(constant_canonical_fixed_size_list_array(
-                value.elements(),
-                element_dtype,
-                *list_size,
-                value.dtype().nullability(),
-                array.len(),
-            ))
+        DType::Variant(_) => {
+            unimplemented!(
+                "TODO(variant): canonicalization will use the child-array design in a follow-up"
+            )
         }
         DType::Extension(ext_dtype) => {
             let s = scalar.as_extension();
@@ -178,11 +183,6 @@ pub(crate) fn constant_canonicalize(
                 .into_array();
 
             Canonical::Extension(ExtensionArray::new(ext_dtype.clone(), storage_self))
-        }
-        DType::Variant(_) => {
-            unimplemented!(
-                "TODO(variant): canonicalization will use the child-array design in a follow-up"
-            )
         }
     })
 }

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -269,11 +269,6 @@ pub fn builder_with_capacity(dtype: &DType, capacity: usize) -> Box<dyn ArrayBui
             DType::Binary(*n),
             capacity,
         )),
-        DType::Struct(struct_dtype, n) => Box::new(StructBuilder::with_capacity(
-            struct_dtype.clone(),
-            *n,
-            capacity,
-        )),
         DType::List(dtype, n) => Box::new(ListViewBuilder::<u64, u64>::with_capacity(
             Arc::clone(dtype),
             *n,
@@ -288,11 +283,16 @@ pub fn builder_with_capacity(dtype: &DType, capacity: usize) -> Box<dyn ArrayBui
                 capacity,
             ))
         }
-        DType::Extension(ext_dtype) => {
-            Box::new(ExtensionBuilder::with_capacity(ext_dtype.clone(), capacity))
-        }
+        DType::Struct(struct_dtype, n) => Box::new(StructBuilder::with_capacity(
+            struct_dtype.clone(),
+            *n,
+            capacity,
+        )),
         DType::Variant(_) => {
             unimplemented!()
+        }
+        DType::Extension(ext_dtype) => {
+            Box::new(ExtensionBuilder::with_capacity(ext_dtype.clone(), capacity))
         }
     }
 }

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -194,17 +194,6 @@ impl Canonical {
                     Validity::from(n),
                 )
             }),
-            DType::Struct(struct_dtype, n) => Canonical::Struct(unsafe {
-                StructArray::new_unchecked(
-                    struct_dtype
-                        .fields()
-                        .map(|f| Canonical::empty(&f).into_array())
-                        .collect::<Arc<[_]>>(),
-                    struct_dtype.clone(),
-                    0,
-                    Validity::from(n),
-                )
-            }),
             DType::List(dtype, n) => Canonical::List(unsafe {
                 ListViewArray::new_unchecked(
                     Canonical::empty(dtype).into_array(),
@@ -225,13 +214,24 @@ impl Canonical {
                     0,
                 )
             }),
+            DType::Struct(struct_dtype, n) => Canonical::Struct(unsafe {
+                StructArray::new_unchecked(
+                    struct_dtype
+                        .fields()
+                        .map(|f| Canonical::empty(&f).into_array())
+                        .collect::<Arc<[_]>>(),
+                    struct_dtype.clone(),
+                    0,
+                    Validity::from(n),
+                )
+            }),
+            DType::Variant(_) => {
+                vortex_panic!(InvalidArgument: "Canonical empty is not supported for Variant")
+            }
             DType::Extension(ext_dtype) => Canonical::Extension(ExtensionArray::new(
                 ext_dtype.clone(),
                 Canonical::empty(ext_dtype.storage_dtype()).into_array(),
             )),
-            DType::Variant(_) => {
-                vortex_panic!(InvalidArgument: "Canonical empty is not supported for Variant")
-            }
         }
     }
 

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -705,7 +705,7 @@ fn test_comparison_inverse_consistency(array: &ArrayRef) {
 
     // Skip non-comparable types.
     match array.dtype() {
-        DType::Null | DType::Extension(_) | DType::Struct(..) | DType::List(..) => return,
+        DType::Null | DType::List(..) | DType::Struct(..) | DType::Extension(_) => return,
         _ => {}
     }
 
@@ -833,7 +833,7 @@ fn test_comparison_symmetry_consistency(array: &ArrayRef) {
 
     // Skip non-comparable types.
     match array.dtype() {
-        DType::Null | DType::Extension(_) | DType::Struct(..) | DType::List(..) => return,
+        DType::Null | DType::List(..) | DType::Struct(..) | DType::Extension(_) => return,
         _ => {}
     }
 
@@ -1195,6 +1195,13 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
             }
             targets
         }
+        DType::Decimal(decimal_type, nullability) => {
+            let opposite = match nullability {
+                Nullability::NonNullable => Nullability::Nullable,
+                Nullability::Nullable => Nullability::NonNullable,
+            };
+            vec![DType::Decimal(*decimal_type, opposite)]
+        }
         DType::Utf8(nullability) => {
             let opposite = match nullability {
                 Nullability::NonNullable => Nullability::Nullable,
@@ -1211,20 +1218,6 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
                 DType::Binary(opposite),
                 DType::Utf8(*nullability), // May fail if not valid UTF-8
             ]
-        }
-        DType::Decimal(decimal_type, nullability) => {
-            let opposite = match nullability {
-                Nullability::NonNullable => Nullability::Nullable,
-                Nullability::Nullable => Nullability::NonNullable,
-            };
-            vec![DType::Decimal(*decimal_type, opposite)]
-        }
-        DType::Struct(fields, nullability) => {
-            let opposite = match nullability {
-                Nullability::NonNullable => Nullability::Nullable,
-                Nullability::Nullable => Nullability::NonNullable,
-            };
-            vec![DType::Struct(fields.clone(), opposite)]
         }
         DType::List(element_type, nullability) => {
             let opposite = match nullability {
@@ -1244,8 +1237,15 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
                 opposite,
             )]
         }
-        DType::Extension(_) => vec![], // Extension types typically only cast to themselves
+        DType::Struct(fields, nullability) => {
+            let opposite = match nullability {
+                Nullability::NonNullable => Nullability::Nullable,
+                Nullability::Nullable => Nullability::NonNullable,
+            };
+            vec![DType::Struct(fields.clone(), opposite)]
+        }
         DType::Variant(_) => unimplemented!(),
+        DType::Extension(_) => vec![], // Extension types typically only cast to themselves
     };
 
     // Test each target dtype

--- a/vortex-array/src/dtype/dtype_impl.rs
+++ b/vortex-array/src/dtype/dtype_impl.rs
@@ -55,16 +55,16 @@ impl DType {
     pub fn is_nullable(&self) -> bool {
         match self {
             Null => true,
-            Extension(ext_dtype) => ext_dtype.storage_dtype().is_nullable(),
             Bool(null)
             | Primitive(_, null)
             | Decimal(_, null)
             | Utf8(null)
             | Binary(null)
-            | Struct(_, null)
             | List(_, null)
             | FixedSizeList(_, _, null)
+            | Struct(_, null)
             | Variant(null) => matches!(null, Nullability::Nullable),
+            Extension(ext_dtype) => ext_dtype.storage_dtype().is_nullable(),
         }
     }
 
@@ -87,11 +87,11 @@ impl DType {
             Decimal(ddt, _) => Decimal(*ddt, nullability),
             Utf8(_) => Utf8(nullability),
             Binary(_) => Binary(nullability),
-            Struct(sf, _) => Struct(sf.clone(), nullability),
             List(edt, _) => List(Arc::clone(edt), nullability),
             FixedSizeList(edt, size, _) => FixedSizeList(Arc::clone(edt), *size, nullability),
-            Extension(ext) => Extension(ext.with_nullability(nullability)),
+            Struct(sf, _) => Struct(sf.clone(), nullability),
             Variant(_) => Variant(nullability),
+            Extension(ext) => Extension(ext.with_nullability(nullability)),
         }
     }
 
@@ -121,10 +121,10 @@ impl DType {
                         .zip_eq(rhs_dtype.fields())
                         .all(|(l, r)| l.eq_ignore_nullability(&r)))
             }
+            (Variant(_), Variant(_)) => true,
             (Extension(lhs_extdtype), Extension(rhs_extdtype)) => {
                 lhs_extdtype.eq_ignore_nullability(rhs_extdtype)
             }
-            (Variant(_), Variant(_)) => true,
             _ => false,
         }
     }
@@ -244,14 +244,14 @@ impl DType {
         matches!(self, Struct(_, _))
     }
 
-    /// Check if `self` is a [`DType::Extension`] type
-    pub fn is_extension(&self) -> bool {
-        matches!(self, Extension(_))
-    }
-
     /// Check if `self` is a [`DType::Variant`] type
     pub fn is_variant(&self) -> bool {
         matches!(self, Variant(_))
+    }
+
+    /// Check if `self` is a [`DType::Extension`] type
+    pub fn is_extension(&self) -> bool {
+        matches!(self, Extension(_))
     }
 
     /// Check if `self` is a nested type, i.e. list, fixed size list, struct, or extension of a
@@ -291,8 +291,8 @@ impl DType {
                 }
                 Some(sum)
             }
-            Extension(ext) => ext.storage_dtype().element_size(),
             Variant(_) => None,
+            Extension(ext) => ext.storage_dtype().element_size(),
         }
     }
 
@@ -456,6 +456,8 @@ impl Display for DType {
             Decimal(ddt, null) => write!(f, "{ddt}{null}"),
             Utf8(null) => write!(f, "utf8{null}"),
             Binary(null) => write!(f, "binary{null}"),
+            List(edt, null) => write!(f, "list({edt}){null}"),
+            FixedSizeList(edt, size, null) => write!(f, "fixed_size_list({edt})[{size}]{null}"),
             Struct(sf, null) => write!(
                 f,
                 "{{{}}}{null}",
@@ -465,10 +467,8 @@ impl Display for DType {
                     .map(|(field_null, dt)| format!("{field_null}={dt}"))
                     .join(", "),
             ),
-            List(edt, null) => write!(f, "list({edt}){null}"),
-            FixedSizeList(edt, size, null) => write!(f, "fixed_size_list({edt})[{size}]{null}"),
-            Extension(ext) => write!(f, "{}", ext),
             Variant(null) => write!(f, "variant{null}"),
+            Extension(ext) => write!(f, "{}", ext),
         }
     }
 }

--- a/vortex-array/src/dtype/mod.rs
+++ b/vortex-array/src/dtype/mod.rs
@@ -98,13 +98,13 @@ pub enum DType {
     /// `DType`. See [`StructFields`] for more information.
     Struct(StructFields, Nullability),
 
+    /// Variant type.
+    Variant(Nullability),
+
     /// A user-defined extension type.
     ///
     /// See [`ExtDTypeRef`] for more information.
     Extension(ExtDTypeRef),
-
-    /// Variant type.
-    Variant(Nullability),
 }
 
 impl PartialEq for DType {
@@ -124,8 +124,8 @@ impl PartialEq for DType {
             }
             // StructFields handles its own Arc::ptr_eq in its PartialEq impl.
             (Self::Struct(a, na), Self::Struct(b, nb)) => na == nb && a == b,
-            (Self::Extension(a), Self::Extension(b)) => a == b,
             (Self::Variant(a), Self::Variant(b)) => a == b,
+            (Self::Extension(a), Self::Extension(b)) => a == b,
             // Every variant is listed in the first position so that adding a new
             // variant produces a non-exhaustive match compile error.
             (Self::Null, _)
@@ -137,8 +137,8 @@ impl PartialEq for DType {
             | (Self::List(..), _)
             | (Self::FixedSizeList(..), _)
             | (Self::Struct(..), _)
-            | (Self::Extension(_), _)
-            | (Self::Variant(_), _) => false,
+            | (Self::Variant(_), _)
+            | (Self::Extension(_), _) => false,
         }
     }
 }

--- a/vortex-array/src/dtype/serde/flatbuffers.rs
+++ b/vortex-array/src/dtype/serde/flatbuffers.rs
@@ -133,15 +133,15 @@ impl TryFrom<ViewedDType> for DType {
                     fb_decimal.nullable().into(),
                 ))
             }
-            fb::Type::Binary => Ok(Self::Binary(
-                fb.type__as_binary()
-                    .ok_or_else(|| vortex_err!("failed to parse binary from flatbuffer"))?
-                    .nullable()
-                    .into(),
-            )),
             fb::Type::Utf8 => Ok(Self::Utf8(
                 fb.type__as_utf_8()
                     .ok_or_else(|| vortex_err!("failed to parse utf-8 from flatbuffer"))?
+                    .nullable()
+                    .into(),
+            )),
+            fb::Type::Binary => Ok(Self::Binary(
+                fb.type__as_binary()
+                    .ok_or_else(|| vortex_err!("failed to parse binary from flatbuffer"))?
                     .nullable()
                     .into(),
             )),
@@ -191,6 +191,12 @@ impl TryFrom<ViewedDType> for DType {
 
                 Ok(Self::Struct(struct_dtype, fb_struct.nullable().into()))
             }
+            fb::Type::Variant => {
+                let fb_variant = fb
+                    .type__as_variant()
+                    .ok_or_else(|| vortex_err!("failed to parse variant from flatbuffer"))?;
+                Ok(Self::Variant(fb_variant.nullable().into()))
+            }
             fb::Type::Extension => {
                 let fb_ext = fb
                     .type__as_extension()
@@ -226,12 +232,6 @@ impl TryFrom<ViewedDType> for DType {
                 };
 
                 Ok(Self::Extension(ext_dtype))
-            }
-            fb::Type::Variant => {
-                let fb_variant = fb
-                    .type__as_variant()
-                    .ok_or_else(|| vortex_err!("failed to parse variant from flatbuffer"))?;
-                Ok(Self::Variant(fb_variant.nullable().into()))
             }
             _ => Err(vortex_err!("Unknown DType variant")),
         }
@@ -287,6 +287,29 @@ impl WriteFlatBuffer for DType {
                 },
             )
             .as_union_value(),
+            Self::List(edt, n) => {
+                let element_type = Some(edt.as_ref().write_flatbuffer(fbb)?);
+                fb::List::create(
+                    fbb,
+                    &fb::ListArgs {
+                        element_type,
+                        nullable: (*n).into(),
+                    },
+                )
+                .as_union_value()
+            }
+            Self::FixedSizeList(edt, size, n) => {
+                let element_type = Some(edt.as_ref().write_flatbuffer(fbb)?);
+                fb::FixedSizeList::create(
+                    fbb,
+                    &fb::FixedSizeListArgs {
+                        element_type,
+                        size: *size,
+                        nullable: (*n).into(),
+                    },
+                )
+                .as_union_value()
+            }
             Self::Struct(st, n) => {
                 let names = st
                     .names()
@@ -311,29 +334,13 @@ impl WriteFlatBuffer for DType {
                 )
                 .as_union_value()
             }
-            Self::List(edt, n) => {
-                let element_type = Some(edt.as_ref().write_flatbuffer(fbb)?);
-                fb::List::create(
-                    fbb,
-                    &fb::ListArgs {
-                        element_type,
-                        nullable: (*n).into(),
-                    },
-                )
-                .as_union_value()
-            }
-            Self::FixedSizeList(edt, size, n) => {
-                let element_type = Some(edt.as_ref().write_flatbuffer(fbb)?);
-                fb::FixedSizeList::create(
-                    fbb,
-                    &fb::FixedSizeListArgs {
-                        element_type,
-                        size: *size,
-                        nullable: (*n).into(),
-                    },
-                )
-                .as_union_value()
-            }
+            Self::Variant(n) => fb::Variant::create(
+                fbb,
+                &fb::VariantArgs {
+                    nullable: (*n).into(),
+                },
+            )
+            .as_union_value(),
             Self::Extension(ext) => {
                 let id = Some(fbb.create_string(ext.id().as_ref()));
                 let storage_dtype = Some(ext.storage_dtype().write_flatbuffer(fbb)?);
@@ -348,13 +355,6 @@ impl WriteFlatBuffer for DType {
                 )
                 .as_union_value()
             }
-            Self::Variant(n) => fb::Variant::create(
-                fbb,
-                &fb::VariantArgs {
-                    nullable: (*n).into(),
-                },
-            )
-            .as_union_value(),
         };
 
         let dtype_type = match self {
@@ -364,11 +364,11 @@ impl WriteFlatBuffer for DType {
             Self::Decimal(..) => fb::Type::Decimal,
             Self::Utf8(_) => fb::Type::Utf8,
             Self::Binary(_) => fb::Type::Binary,
-            Self::Struct(..) => fb::Type::Struct_,
             Self::List(..) => fb::Type::List,
             Self::FixedSizeList(..) => fb::Type::FixedSizeList,
-            Self::Extension { .. } => fb::Type::Extension,
+            Self::Struct(..) => fb::Type::Struct_,
             Self::Variant(_) => fb::Type::Variant,
+            Self::Extension { .. } => fb::Type::Extension,
         };
 
         Ok(fb::DType::create(

--- a/vortex-array/src/dtype/serde/proto.rs
+++ b/vortex-array/src/dtype/serde/proto.rs
@@ -45,16 +45,6 @@ impl DType {
             )),
             DtypeType::Utf8(u) => Ok(Self::Utf8(u.nullable.into())),
             DtypeType::Binary(b) => Ok(Self::Binary(b.nullable.into())),
-            DtypeType::Struct(s) => Ok(Self::Struct(
-                StructFields::new(
-                    s.names.iter().map(|s| s.as_str()).collect(),
-                    s.dtypes
-                        .iter()
-                        .map(|dt| DType::from_proto(dt, session))
-                        .collect::<VortexResult<Vec<_>>>()?,
-                ),
-                s.nullable.into(),
-            )),
             DtypeType::List(l) => {
                 let nullable = l.nullable.into();
                 Ok(Self::List(
@@ -86,6 +76,17 @@ impl DType {
                     nullable,
                 ))
             }
+            DtypeType::Struct(s) => Ok(Self::Struct(
+                StructFields::new(
+                    s.names.iter().map(|s| s.as_str()).collect(),
+                    s.dtypes
+                        .iter()
+                        .map(|dt| DType::from_proto(dt, session))
+                        .collect::<VortexResult<Vec<_>>>()?,
+                ),
+                s.nullable.into(),
+            )),
+            DtypeType::Variant(v) => Ok(Self::Variant(v.nullable.into())),
             DtypeType::Extension(e) => {
                 let id = ExtId::new(e.id.as_str());
                 let storage_dtype = DType::from_proto(
@@ -103,7 +104,6 @@ impl DType {
                 };
                 Ok(Self::Extension(ext_dtype))
             }
-            DtypeType::Variant(v) => Ok(Self::Variant(v.nullable.into())),
         }
     }
 }
@@ -133,14 +133,6 @@ impl TryFrom<&DType> for pb::DType {
                 DType::Binary(null) => DtypeType::Binary(pb::Binary {
                     nullable: (*null).into(),
                 }),
-                DType::Struct(s, null) => DtypeType::Struct(pb::Struct {
-                    names: s.names().iter().map(|s| s.as_ref().to_string()).collect(),
-                    dtypes: s
-                        .fields()
-                        .map(|d| Self::try_from(&d))
-                        .collect::<VortexResult<Vec<_>>>()?,
-                    nullable: (*null).into(),
-                }),
                 DType::List(edt, null) => DtypeType::List(Box::new(pb::List {
                     element_type: Some(Box::new(edt.as_ref().try_into()?)),
                     nullable: (*null).into(),
@@ -152,14 +144,22 @@ impl TryFrom<&DType> for pb::DType {
                         nullable: (*null).into(),
                     }))
                 }
+                DType::Struct(s, null) => DtypeType::Struct(pb::Struct {
+                    names: s.names().iter().map(|s| s.as_ref().to_string()).collect(),
+                    dtypes: s
+                        .fields()
+                        .map(|d| Self::try_from(&d))
+                        .collect::<VortexResult<Vec<_>>>()?,
+                    nullable: (*null).into(),
+                }),
+                DType::Variant(null) => DtypeType::Variant(pb::Variant {
+                    nullable: (*null).into(),
+                }),
                 DType::Extension(e) => DtypeType::Extension(Box::new(pb::Extension {
                     id: e.id().as_ref().into(),
                     storage_dtype: Some(Box::new(e.storage_dtype().try_into()?)),
                     metadata: Some(e.serialize_metadata()?),
                 })),
-                DType::Variant(null) => DtypeType::Variant(pb::Variant {
-                    nullable: (*null).into(),
-                }),
             }),
         })
     }

--- a/vortex-array/src/dtype/serde/serde.rs
+++ b/vortex-array/src/dtype/serde/serde.rs
@@ -115,10 +115,10 @@ impl Serialize for DType {
                 state.serialize_field(n)?;
                 state.end()
             }
+            DType::Variant(n) => serializer.serialize_newtype_variant("DType", 10, "Variant", n),
             DType::Extension(ext) => {
                 serializer.serialize_newtype_variant("DType", 9, "Extension", ext)
             }
-            DType::Variant(n) => serializer.serialize_newtype_variant("DType", 10, "Variant", n),
         }
     }
 }
@@ -157,8 +157,8 @@ impl<'de> DeserializeSeed<'de> for DTypeSerde<'_, DType> {
             "List",
             "FixedSizeList",
             "Struct",
-            "Extension",
             "Variant",
+            "Extension",
         ];
 
         struct DTypeVisitor<'a> {
@@ -215,14 +215,14 @@ impl<'de> DeserializeSeed<'de> for DTypeSerde<'_, DType> {
                     "Struct" => access.newtype_variant_seed(StructFieldsSeed {
                         session: self.session,
                     }),
+                    "Variant" => {
+                        let n = access.newtype_variant()?;
+                        Ok(DType::Variant(n))
+                    }
                     "Extension" => {
                         let ext = access
                             .newtype_variant_seed(DTypeSerde::<ExtDTypeRef>::new(self.session))?;
                         Ok(DType::Extension(ext))
-                    }
-                    "Variant" => {
-                        let n = access.newtype_variant()?;
-                        Ok(DType::Variant(n))
                     }
                     _ => Err(de::Error::unknown_variant(&variant, VARIANTS)),
                 }

--- a/vortex-array/src/scalar/arbitrary.rs
+++ b/vortex-array/src/scalar/arbitrary.rs
@@ -64,15 +64,6 @@ pub fn random_scalar(u: &mut Unstructured, dtype: &DType) -> Result<Scalar> {
             ))),
         )
         .vortex_expect("unable to construct random `Scalar`_"),
-        DType::Struct(sdt, _) => Scalar::try_new(
-            dtype.clone(),
-            Some(ScalarValue::Tuple(
-                sdt.fields()
-                    .map(|d| random_scalar(u, &d).map(|s| s.into_value()))
-                    .collect::<Result<Vec<_>>>()?,
-            )),
-        )
-        .vortex_expect("unable to construct random `Scalar`_"),
         DType::List(edt, _) => Scalar::try_new(
             dtype.clone(),
             Some(ScalarValue::Tuple(
@@ -95,10 +86,19 @@ pub fn random_scalar(u: &mut Unstructured, dtype: &DType) -> Result<Scalar> {
             )),
         )
         .vortex_expect("unable to construct random `Scalar`_"),
+        DType::Struct(sdt, _) => Scalar::try_new(
+            dtype.clone(),
+            Some(ScalarValue::Tuple(
+                sdt.fields()
+                    .map(|d| random_scalar(u, &d).map(|s| s.into_value()))
+                    .collect::<Result<Vec<_>>>()?,
+            )),
+        )
+        .vortex_expect("unable to construct random `Scalar`_"),
+        DType::Variant(_) => todo!(),
         DType::Extension(..) => {
             unreachable!("Can't yet generate arbitrary scalars for ext dtype")
         }
-        DType::Variant(_) => todo!(),
     })
 }
 

--- a/vortex-array/src/scalar/arrow.rs
+++ b/vortex-array/src/scalar/arrow.rs
@@ -61,11 +61,11 @@ impl TryFrom<&Scalar> for Arc<dyn Datum> {
             DType::Decimal(..) => decimal_to_arrow(value.as_decimal()),
             DType::Utf8(_) => utf8_to_arrow(value.as_utf8()),
             DType::Binary(_) => binary_to_arrow(value.as_binary()),
-            DType::Struct(..) => unimplemented!("struct scalar conversion"),
             DType::List(..) => unimplemented!("list scalar conversion"),
             DType::FixedSizeList(..) => unimplemented!("fixed-size list scalar conversion"),
-            DType::Extension(..) => extension_to_arrow(value.as_extension()),
+            DType::Struct(..) => unimplemented!("struct scalar conversion"),
             DType::Variant(_) => unimplemented!("Variant scalar conversion"),
+            DType::Extension(..) => extension_to_arrow(value.as_extension()),
         }
     }
 }

--- a/vortex-array/src/scalar/cast.rs
+++ b/vortex-array/src/scalar/cast.rs
@@ -56,10 +56,10 @@ impl Scalar {
             DType::Decimal(..) => self.as_decimal().cast(target_dtype),
             DType::Utf8(_) => self.as_utf8().cast(target_dtype),
             DType::Binary(_) => self.as_binary().cast(target_dtype),
-            DType::Struct(..) => self.as_struct().cast(target_dtype),
             DType::List(..) | DType::FixedSizeList(..) => self.as_list().cast(target_dtype),
-            DType::Extension(..) => self.as_extension().cast(target_dtype),
+            DType::Struct(..) => self.as_struct().cast(target_dtype),
             DType::Variant(_) => vortex_bail!("Variant scalars can't be cast to {target_dtype}"),
+            DType::Extension(..) => self.as_extension().cast(target_dtype),
         }
     }
 

--- a/vortex-array/src/scalar/display.rs
+++ b/vortex-array/src/scalar/display.rs
@@ -18,10 +18,10 @@ impl Display for Scalar {
             DType::Decimal(..) => write!(f, "{}", self.as_decimal()),
             DType::Utf8(_) => write!(f, "{}", self.as_utf8()),
             DType::Binary(_) => write!(f, "{}", self.as_binary()),
-            DType::Struct(..) => write!(f, "{}", self.as_struct()),
             DType::List(..) | DType::FixedSizeList(..) => write!(f, "{}", self.as_list()),
-            DType::Extension(_) => write!(f, "{}", self.as_extension()),
+            DType::Struct(..) => write!(f, "{}", self.as_struct()),
             DType::Variant(_) => write!(f, "{}", self.as_variant()),
+            DType::Extension(_) => write!(f, "{}", self.as_extension()),
         }
     }
 }

--- a/vortex-array/src/scalar/scalar_impl.rs
+++ b/vortex-array/src/scalar/scalar_impl.rs
@@ -190,8 +190,8 @@ impl Scalar {
             DType::List(..) => value.as_list().is_empty(),
             DType::FixedSizeList(_, list_size, _) => value.as_list().len() == *list_size as usize,
             DType::Struct(struct_fields, _) => value.as_list().len() == struct_fields.nfields(),
-            DType::Extension(_) => self.as_extension().to_storage_scalar().is_zero()?,
             DType::Variant(_) => self.as_variant().is_zero()?,
+            DType::Extension(_) => self.as_extension().to_storage_scalar().is_zero()?,
         };
 
         Some(is_zero)
@@ -248,18 +248,18 @@ impl Scalar {
             DType::Binary(_) => self
                 .value()
                 .map_or_else(|| 0, |value| value.as_binary().len()),
-            DType::Struct(..) => self
-                .as_struct()
-                .fields_iter()
-                .map(|fields| fields.into_iter().map(|f| f.approx_nbytes()).sum::<usize>())
-                .unwrap_or_default(),
             DType::List(..) | DType::FixedSizeList(..) => self
                 .as_list()
                 .elements()
                 .map(|fields| fields.into_iter().map(|f| f.approx_nbytes()).sum::<usize>())
                 .unwrap_or_default(),
-            DType::Extension(_) => self.as_extension().to_storage_scalar().approx_nbytes(),
+            DType::Struct(..) => self
+                .as_struct()
+                .fields_iter()
+                .map(|fields| fields.into_iter().map(|f| f.approx_nbytes()).sum::<usize>())
+                .unwrap_or_default(),
             DType::Variant(_) => self.as_variant().value().map_or(0, Scalar::approx_nbytes),
+            DType::Extension(_) => self.as_extension().to_storage_scalar().approx_nbytes(),
         }
     }
 }

--- a/vortex-array/src/scalar/scalar_value.rs
+++ b/vortex-array/src/scalar/scalar_value.rs
@@ -62,13 +62,13 @@ impl ScalarValue {
                     .collect();
                 Self::Tuple(field_values)
             }
+            DType::Variant(_) => Self::Variant(Box::new(Scalar::null(DType::Null))),
             DType::Extension(ext_dtype) => {
                 // Since we have no way to define a "zero" extension value (since we have no idea
                 // what the semantics of the extension is), a best effort attempt is to just use the
                 // zero storage value and try to make an extension scalar from that.
                 Self::zero_value(ext_dtype.storage_dtype())
             }
-            DType::Variant(_) => Self::Variant(Box::new(Scalar::null(DType::Null))),
         }
     }
 
@@ -99,13 +99,13 @@ impl ScalarValue {
                 let field_values = fields.fields().map(|f| Self::default_value(&f)).collect();
                 Self::Tuple(field_values)
             }
+            DType::Variant(_) => Self::Variant(Box::new(Scalar::null(DType::Null))),
             DType::Extension(ext_dtype) => {
                 // Since we have no way to define a "default" extension value (since we have no idea
                 // what the semantics of the extension is), a best effort attempt is to just use the
                 // default storage value and try to make an extension scalar from that.
                 Self::default_value(ext_dtype.storage_dtype())?
             }
-            DType::Variant(_) => Self::Variant(Box::new(Scalar::null(DType::Null))),
         })
     }
 }

--- a/vortex-array/src/scalar/validate.rs
+++ b/vortex-array/src/scalar/validate.rs
@@ -118,7 +118,6 @@ impl Scalar {
                     Self::validate(&field, field_value.as_ref())?;
                 }
             }
-            DType::Extension(ext_dtype) => ext_dtype.validate_storage_value(value)?,
             DType::Variant(_) => {
                 let ScalarValue::Variant(inner) = value else {
                     vortex_bail!("variant dtype expected Variant value, got {value}");
@@ -131,6 +130,7 @@ impl Scalar {
                     inner.dtype(),
                 );
             }
+            DType::Extension(ext_dtype) => ext_dtype.validate_storage_value(value)?,
         }
 
         Ok(())

--- a/vortex-datafusion/src/convert/scalars.rs
+++ b/vortex-datafusion/src/convert/scalars.rs
@@ -111,9 +111,10 @@ impl TryToDataFusion<ScalarValue> for Scalar {
                     .cloned()
                     .map(|b| Vec::<u8>::from(b.into_inner())),
             ),
-            DType::Struct(..) => todo!("struct scalar conversion"),
             DType::List(..) => todo!("list scalar conversion"),
             DType::FixedSizeList(..) => todo!("fixed-size list scalar conversion"),
+            DType::Struct(..) => todo!("struct scalar conversion"),
+            DType::Variant(_) => vortex_bail!("Variant scalars aren't supported with DF"),
             DType::Extension(ext) => {
                 let storage_scalar = self.as_extension().to_storage_scalar();
 
@@ -160,7 +161,6 @@ impl TryToDataFusion<ScalarValue> for Scalar {
                     },
                 }
             }
-            DType::Variant(_) => vortex_bail!("Variant scalars aren't supported with DF"),
         })
     }
 }

--- a/vortex-duckdb/src/convert/dtype.rs
+++ b/vortex-duckdb/src/convert/dtype.rs
@@ -218,17 +218,14 @@ impl TryFrom<&DType> for LogicalType {
             DType::Null => DUCKDB_TYPE::DUCKDB_TYPE_SQLNULL,
             DType::Bool(_) => DUCKDB_TYPE::DUCKDB_TYPE_BOOLEAN,
             DType::Primitive(ptype, _) => return LogicalType::try_from(*ptype),
-            DType::Utf8(_) => DUCKDB_TYPE::DUCKDB_TYPE_VARCHAR,
-            DType::Binary(_) => DUCKDB_TYPE::DUCKDB_TYPE_BLOB,
-            DType::Struct(struct_type, _) => {
-                return LogicalType::try_from(struct_type);
-            }
             DType::Decimal(decimal_dtype, _) => {
                 return LogicalType::decimal_type(
                     decimal_dtype.precision(),
                     decimal_dtype.scale().try_into()?,
                 );
             }
+            DType::Utf8(_) => DUCKDB_TYPE::DUCKDB_TYPE_VARCHAR,
+            DType::Binary(_) => DUCKDB_TYPE::DUCKDB_TYPE_BLOB,
             DType::List(element_dtype, _) => {
                 let element_logical_type = LogicalType::try_from(element_dtype.as_ref())?;
                 return LogicalType::list_type(element_logical_type);
@@ -236,6 +233,9 @@ impl TryFrom<&DType> for LogicalType {
             DType::FixedSizeList(element_dtype, list_size, _) => {
                 let element_logical_type = LogicalType::try_from(element_dtype.as_ref())?;
                 return LogicalType::array_type(element_logical_type, *list_size);
+            }
+            DType::Struct(struct_type, _) => {
+                return LogicalType::try_from(struct_type);
             }
             DType::Variant(_) => {
                 vortex_bail!("Vortex Variant array aren't supported in DuckDB")

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -75,13 +75,13 @@ impl ToDuckDBScalar for Scalar {
             DType::Bool(_) => self.as_bool().try_to_duckdb_scalar(),
             DType::Primitive(..) => self.as_primitive().try_to_duckdb_scalar(),
             DType::Decimal(..) => self.as_decimal().try_to_duckdb_scalar(),
-            DType::Extension(..) => self.as_extension().try_to_duckdb_scalar(),
             DType::Utf8(_) => self.as_utf8().try_to_duckdb_scalar(),
             DType::Binary(_) => self.as_binary().try_to_duckdb_scalar(),
-            DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => todo!(),
+            DType::List(..) | DType::FixedSizeList(..) | DType::Struct(..) => todo!(),
             DType::Variant(_) => {
                 vortex_bail!("Vortex Variant scalars aren't supported in DuckDB")
             }
+            DType::Extension(..) => self.as_extension().try_to_duckdb_scalar(),
         }
     }
 }

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -68,11 +68,11 @@ impl From<&DType> for vx_dtype_variant {
             DType::Decimal(..) => vx_dtype_variant::DTYPE_DECIMAL,
             DType::Utf8(_) => vx_dtype_variant::DTYPE_UTF8,
             DType::Binary(_) => vx_dtype_variant::DTYPE_BINARY,
-            DType::Struct(..) => vx_dtype_variant::DTYPE_STRUCT,
             DType::List(..) => vx_dtype_variant::DTYPE_LIST,
             DType::FixedSizeList(..) => vx_dtype_variant::DTYPE_FIXED_SIZE_LIST,
-            DType::Extension(_) => vx_dtype_variant::DTYPE_EXTENSION,
+            DType::Struct(..) => vx_dtype_variant::DTYPE_STRUCT,
             DType::Variant(_) => vortex_panic!("Variant DType is not supported in FFI yet"),
+            DType::Extension(_) => vx_dtype_variant::DTYPE_EXTENSION,
         }
     }
 }

--- a/vortex-python/src/dtype/mod.rs
+++ b/vortex-python/src/dtype/mod.rs
@@ -129,13 +129,13 @@ impl PyDType {
             DType::Decimal(..) => Self::with_subclass(py, dtype, PyDecimalDType),
             DType::Utf8(..) => Self::with_subclass(py, dtype, PyUtf8DType),
             DType::Binary(..) => Self::with_subclass(py, dtype, PyBinaryDType),
-            DType::Struct(..) => Self::with_subclass(py, dtype, PyStructDType),
             DType::List(..) => Self::with_subclass(py, dtype, PyListDType),
             DType::FixedSizeList(..) => Self::with_subclass(py, dtype, PyFixedSizeListDType),
-            DType::Extension(..) => Self::with_subclass(py, dtype, PyExtensionDType),
+            DType::Struct(..) => Self::with_subclass(py, dtype, PyStructDType),
             DType::Variant(_) => Err(PyValueError::new_err(
                 "Variant DType is not supported in Python yet",
             )),
+            DType::Extension(..) => Self::with_subclass(py, dtype, PyExtensionDType),
         }
     }
 

--- a/vortex-python/src/python_repr.rs
+++ b/vortex-python/src/python_repr.rs
@@ -67,16 +67,6 @@ impl Display for DTypePythonRepr<'_> {
             }
             DType::Utf8(n) => write!(f, "utf8(nullable={})", n.python_repr()),
             DType::Binary(n) => write!(f, "binary(nullable={})", n.python_repr()),
-            DType::Struct(st, n) => write!(
-                f,
-                "struct({{{}}}, nullable={})",
-                st.names()
-                    .iter()
-                    .zip(st.fields())
-                    .map(|(n, dt)| format!("\"{}\": {}", n, dt.python_repr()))
-                    .join(", "),
-                n.python_repr()
-            ),
             DType::List(edt, n) => write!(
                 f,
                 "list({}, nullable={})",
@@ -90,6 +80,17 @@ impl Display for DTypePythonRepr<'_> {
                 size,
                 n.python_repr()
             ),
+            DType::Struct(st, n) => write!(
+                f,
+                "struct({{{}}}, nullable={})",
+                st.names()
+                    .iter()
+                    .zip(st.fields())
+                    .map(|(n, dt)| format!("\"{}\": {}", n, dt.python_repr()))
+                    .join(", "),
+                n.python_repr()
+            ),
+            DType::Variant(_) => write!(f, "variant()"),
             DType::Extension(ext) => {
                 write!(
                     f,
@@ -103,7 +104,6 @@ impl Display for DTypePythonRepr<'_> {
                 }
                 write!(f, ")")
             }
-            DType::Variant(_) => write!(f, "variant()"),
         }
     }
 }

--- a/vortex-python/src/scalar/into_py.rs
+++ b/vortex-python/src/scalar/into_py.rs
@@ -80,16 +80,16 @@ impl<'py> IntoPyObject<'py> for PyVortex<&'_ Scalar> {
                 .cloned()
                 .map(PyVortex)
                 .into_pyobject(py),
-            DType::Struct(..) => PyVortex(self.0.as_struct()).into_pyobject(py),
             DType::List(..) | DType::FixedSizeList(..) => {
                 PyVortex(self.0.as_list()).into_pyobject(py)
             }
-            DType::Extension(_) => {
-                PyVortex(&self.0.as_extension().to_storage_scalar()).into_pyobject(py)
-            }
+            DType::Struct(..) => PyVortex(self.0.as_struct()).into_pyobject(py),
             DType::Variant(_) => Err(PyValueError::new_err(
                 "Variant scalars are not supported in Python yet",
             )),
+            DType::Extension(_) => {
+                PyVortex(&self.0.as_extension().to_storage_scalar()).into_pyobject(py)
+            }
         }
     }
 }

--- a/vortex-python/src/scalar/mod.rs
+++ b/vortex-python/src/scalar/mod.rs
@@ -111,16 +111,16 @@ impl PyScalar {
             DType::Decimal(..) => Self::with_subclass(py, scalar, PyDecimalScalar),
             DType::Utf8(..) => Self::with_subclass(py, scalar, PyUtf8Scalar),
             DType::Binary(..) => Self::with_subclass(py, scalar, PyBinaryScalar),
-            DType::Struct(..) => Self::with_subclass(py, scalar, PyStructScalar),
             DType::List(..) | DType::FixedSizeList(..) => {
                 // We represent both lists and fixed-size lists with `PyListScalar` since the notion
                 // of "fixed-size" only applies to full arrays, not scalars.
                 Self::with_subclass(py, scalar, PyListScalar)
             }
-            DType::Extension(..) => Self::with_subclass(py, scalar, PyExtensionScalar),
+            DType::Struct(..) => Self::with_subclass(py, scalar, PyStructScalar),
             DType::Variant(_) => Err(PyValueError::new_err(
                 "Variant scalars are not supported in Python yet",
             )),
+            DType::Extension(..) => Self::with_subclass(py, scalar, PyExtensionScalar),
         }
     }
 


### PR DESCRIPTION
Reorder `DType` match arms across the codebase to match the order of the
`DType` enum declaration, and move `Extension` after `Variant` so that
`Extension` is the last variant in the enum (and in all match statements).

This is a purely cosmetic refactor with no functional changes:
- The protobuf, flatbuffer, and serde wire formats are preserved (only the
  source order of match arms is changed, not the discriminant/tag values).
- The public API surface is unchanged; `public-api.lock` files are
  alphabetical so they require no update.

Signed-off-by: Claude <noreply@anthropic.com>