### PR TITLE
Add `DType::Union` variant carrying just `Nullability`

### DIFF
--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -122,6 +122,7 @@ pub(super) fn execute_sparse(parts: SparseParts, ctx: &mut ExecutionCtx) -> Vort
             len,
             ctx,
         )?,
+        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::Decimal(decimal_dtype, nullability) => {
             let canonical_decimal_value_type =
                 DecimalType::smallest_decimal_value_type(decimal_dtype);

--- a/fuzz/src/array/compare.rs
+++ b/fuzz/src/array/compare.rs
@@ -173,7 +173,7 @@ pub fn compare_canonical_array(
             }))
             .into_array()
         }
-        d @ (DType::Null | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/filter.rs
+++ b/fuzz/src/array/filter.rs
@@ -122,7 +122,7 @@ pub fn filter_canonical_array(
             }
             take_canonical_array_non_nullable_indices(array, indices.as_slice(), ctx)
         }
-        d @ (DType::Null | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -474,6 +474,7 @@ fn actions_for_dtype(dtype: &DType) -> HashSet<ActionType> {
                     acc.intersection(&actions).copied().collect()
                 })
         }
+        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::List(..) | DType::FixedSizeList(..) => {
             // List supports: Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt
             // Does NOT support: SearchSorted, Compare, Cast, Sum, FillNull

--- a/fuzz/src/array/search_sorted.rs
+++ b/fuzz/src/array/search_sorted.rs
@@ -148,7 +148,7 @@ pub fn search_sorted_canonical_array(
                 .collect::<VortexResult<Vec<_>>>()?;
             scalar_vals.search_sorted(&scalar.cast(array.dtype())?, side)
         }
-        d @ (DType::Null | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -123,7 +123,7 @@ pub fn slice_canonical_array(
                 .into_array(),
             )
         }
-        d @ (DType::Null | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/sort.rs
+++ b/fuzz/src/array/sort.rs
@@ -101,7 +101,7 @@ pub fn sort_canonical_array(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexR
             });
             take_canonical_array_non_nullable_indices(array, &sort_indices, ctx)
         }
-        d @ (DType::Null | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/take.rs
+++ b/fuzz/src/array/take.rs
@@ -147,7 +147,7 @@ pub fn take_canonical_array(
             }
             Ok(builder.finish())
         }
-        d @ (DType::Null | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -9416,6 +9416,8 @@ pub vortex_array::dtype::DType::Primitive(vortex_array::dtype::PType, vortex_arr
 
 pub vortex_array::dtype::DType::Struct(vortex_array::dtype::StructFields, vortex_array::dtype::Nullability)
 
+pub vortex_array::dtype::DType::Union(vortex_array::dtype::Nullability)
+
 pub vortex_array::dtype::DType::Utf8(vortex_array::dtype::Nullability)
 
 pub vortex_array::dtype::DType::Variant(vortex_array::dtype::Nullability)
@@ -9491,6 +9493,8 @@ pub fn vortex_array::dtype::DType::is_primitive(&self) -> bool
 pub fn vortex_array::dtype::DType::is_signed_int(&self) -> bool
 
 pub fn vortex_array::dtype::DType::is_struct(&self) -> bool
+
+pub fn vortex_array::dtype::DType::is_union(&self) -> bool
 
 pub fn vortex_array::dtype::DType::is_unsigned_int(&self) -> bool
 

--- a/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
@@ -238,6 +238,7 @@ pub(crate) fn constant_uncompressed_size_in_bytes(
             let canonical = array.array().clone().execute::<Canonical>(ctx)?;
             return canonical_uncompressed_size_in_bytes(&canonical, ctx);
         }
+        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
     };
 
     value_size
@@ -284,6 +285,7 @@ fn supports_uncompressed_size_in_bytes(dtype: &DType) -> bool {
         DType::Struct(fields, _) => fields
             .fields()
             .all(|field| supports_uncompressed_size_in_bytes(&field)),
+        DType::Union(_) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::Extension(ext_dtype) => {
             supports_uncompressed_size_in_bytes(ext_dtype.storage_dtype())
         }

--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -185,6 +185,7 @@ fn random_array_chunk(
             .vortex_expect("operation should succeed in arbitrary impl")
             .into_array())
         }
+        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::List(elem_dtype, null) => random_list(u, elem_dtype, *null, chunk_len),
         DType::FixedSizeList(elem_dtype, list_size, null) => {
             random_fixed_size_list(u, elem_dtype, *list_size, *null, chunk_len)

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -151,6 +151,7 @@ pub(crate) fn constant_canonicalize(
                 StructArray::new_unchecked(fields, struct_dtype.clone(), array.len(), validity)
             })
         }
+        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::List(..) => Canonical::List(constant_canonical_list_array(scalar, array.len())),
         DType::FixedSizeList(element_dtype, list_size, _) => {
             let value = scalar.as_list();

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -274,6 +274,7 @@ pub fn builder_with_capacity(dtype: &DType, capacity: usize) -> Box<dyn ArrayBui
             *n,
             capacity,
         )),
+        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::List(dtype, n) => Box::new(ListViewBuilder::<u64, u64>::with_capacity(
             Arc::clone(dtype),
             *n,

--- a/vortex-array/src/builders/tests.rs
+++ b/vortex-array/src/builders/tests.rs
@@ -615,6 +615,7 @@ fn create_test_scalars_for_dtype(dtype: &DType, count: usize) -> Vec<Scalar> {
                     .collect();
                 Scalar::struct_(DType::Struct(fields.clone(), *n), field_values)
             }
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(element_dtype, n) => {
                 // Create list scalars with a few elements.
                 let elements: Vec<Scalar> = (0..=i)

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -205,6 +205,7 @@ impl Canonical {
                     Validity::from(n),
                 )
             }),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(dtype, n) => Canonical::List(unsafe {
                 ListViewArray::new_unchecked(
                     Canonical::empty(dtype).into_array(),

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -705,7 +705,11 @@ fn test_comparison_inverse_consistency(array: &ArrayRef) {
 
     // Skip non-comparable types.
     match array.dtype() {
-        DType::Null | DType::Extension(_) | DType::Struct(..) | DType::List(..) => return,
+        DType::Null
+        | DType::Extension(_)
+        | DType::Struct(..)
+        | DType::Union(..)
+        | DType::List(..) => return,
         _ => {}
     }
 
@@ -833,7 +837,11 @@ fn test_comparison_symmetry_consistency(array: &ArrayRef) {
 
     // Skip non-comparable types.
     match array.dtype() {
-        DType::Null | DType::Extension(_) | DType::Struct(..) | DType::List(..) => return,
+        DType::Null
+        | DType::Extension(_)
+        | DType::Struct(..)
+        | DType::Union(..)
+        | DType::List(..) => return,
         _ => {}
     }
 
@@ -1226,6 +1234,7 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
             };
             vec![DType::Struct(fields.clone(), opposite)]
         }
+        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::List(element_type, nullability) => {
             let opposite = match nullability {
                 Nullability::NonNullable => Nullability::Nullable,

--- a/vortex-array/src/dtype/arrow.rs
+++ b/vortex-array/src/dtype/arrow.rs
@@ -320,6 +320,7 @@ impl DType {
 
                 DataType::Struct(Fields::from(fields))
             }
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Variant(_) => vortex_bail!(
                 "DType::Variant requires Arrow Field metadata; use to_arrow_schema or a Field helper"
             ),

--- a/vortex-array/src/dtype/dtype_impl.rs
+++ b/vortex-array/src/dtype/dtype_impl.rs
@@ -62,6 +62,7 @@ impl DType {
             | Utf8(null)
             | Binary(null)
             | Struct(_, null)
+            | Union(null)
             | List(_, null)
             | FixedSizeList(_, _, null)
             | Variant(null) => matches!(null, Nullability::Nullable),
@@ -88,6 +89,7 @@ impl DType {
             Utf8(_) => Utf8(nullability),
             Binary(_) => Binary(nullability),
             Struct(sf, _) => Struct(sf.clone(), nullability),
+            Union(_) => Union(nullability),
             List(edt, _) => List(Arc::clone(edt), nullability),
             FixedSizeList(edt, size, _) => FixedSizeList(Arc::clone(edt), *size, nullability),
             Extension(ext) => Extension(ext.with_nullability(nullability)),
@@ -121,6 +123,7 @@ impl DType {
                         .zip_eq(rhs_dtype.fields())
                         .all(|(l, r)| l.eq_ignore_nullability(&r)))
             }
+            (Union(_), Union(_)) => true,
             (Extension(lhs_extdtype), Extension(rhs_extdtype)) => {
                 lhs_extdtype.eq_ignore_nullability(rhs_extdtype)
             }
@@ -244,6 +247,11 @@ impl DType {
         matches!(self, Struct(_, _))
     }
 
+    /// Check if `self` is a [`DType::Union`] type.
+    pub fn is_union(&self) -> bool {
+        matches!(self, Union(..))
+    }
+
     /// Check if `self` is a [`DType::Extension`] type
     pub fn is_extension(&self) -> bool {
         matches!(self, Extension(_))
@@ -258,7 +266,7 @@ impl DType {
     /// recursive type.
     pub fn is_nested(&self) -> bool {
         match self {
-            List(..) | FixedSizeList(..) | Struct(..) | Variant(..) => true,
+            List(..) | FixedSizeList(..) | Struct(..) | Union(..) | Variant(..) => true,
             Extension(ext) => ext.storage_dtype().is_nested(),
             _ => false,
         }
@@ -291,6 +299,7 @@ impl DType {
                 }
                 Some(sum)
             }
+            Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             Extension(ext) => ext.storage_dtype().element_size(),
             Variant(_) => None,
         }
@@ -465,6 +474,7 @@ impl Display for DType {
                     .map(|(field_null, dt)| format!("{field_null}={dt}"))
                     .join(", "),
             ),
+            Union(null) => write!(f, "union(){null}"),
             List(edt, null) => write!(f, "list({edt}){null}"),
             FixedSizeList(edt, size, null) => write!(f, "fixed_size_list({edt})[{size}]{null}"),
             Extension(ext) => write!(f, "{}", ext),

--- a/vortex-array/src/dtype/mod.rs
+++ b/vortex-array/src/dtype/mod.rs
@@ -98,6 +98,13 @@ pub enum DType {
     /// `DType`. See [`StructFields`] for more information.
     Struct(StructFields, Nullability),
 
+    /// A logical union (sum) type.
+    ///
+    /// A subsequent change will replace this single-field variant with
+    /// `Union(UnionVariants, Nullability)` so the type can carry its named variants, per-variant
+    /// `DType`s, and `i8` type tags.
+    Union(Nullability),
+
     /// A user-defined extension type.
     ///
     /// See [`ExtDTypeRef`] for more information.
@@ -124,6 +131,7 @@ impl PartialEq for DType {
             }
             // StructFields handles its own Arc::ptr_eq in its PartialEq impl.
             (Self::Struct(a, na), Self::Struct(b, nb)) => na == nb && a == b,
+            (Self::Union(a), Self::Union(b)) => a == b,
             (Self::Extension(a), Self::Extension(b)) => a == b,
             (Self::Variant(a), Self::Variant(b)) => a == b,
             // Every variant is listed in the first position so that adding a new
@@ -137,6 +145,7 @@ impl PartialEq for DType {
             | (Self::List(..), _)
             | (Self::FixedSizeList(..), _)
             | (Self::Struct(..), _)
+            | (Self::Union(..), _)
             | (Self::Extension(_), _)
             | (Self::Variant(_), _) => false,
         }

--- a/vortex-array/src/dtype/serde/flatbuffers.rs
+++ b/vortex-array/src/dtype/serde/flatbuffers.rs
@@ -191,6 +191,12 @@ impl TryFrom<ViewedDType> for DType {
 
                 Ok(Self::Struct(struct_dtype, fb_struct.nullable().into()))
             }
+            fb::Type::Union => {
+                let fb_union = fb
+                    .type__as_union()
+                    .ok_or_else(|| vortex_err!("failed to parse union from flatbuffer"))?;
+                Ok(Self::Union(fb_union.nullable().into()))
+            }
             fb::Type::Extension => {
                 let fb_ext = fb
                     .type__as_extension()
@@ -311,6 +317,13 @@ impl WriteFlatBuffer for DType {
                 )
                 .as_union_value()
             }
+            Self::Union(n) => fb::Union::create(
+                fbb,
+                &fb::UnionArgs {
+                    nullable: (*n).into(),
+                },
+            )
+            .as_union_value(),
             Self::List(edt, n) => {
                 let element_type = Some(edt.as_ref().write_flatbuffer(fbb)?);
                 fb::List::create(
@@ -365,6 +378,7 @@ impl WriteFlatBuffer for DType {
             Self::Utf8(_) => fb::Type::Utf8,
             Self::Binary(_) => fb::Type::Binary,
             Self::Struct(..) => fb::Type::Struct_,
+            Self::Union(..) => fb::Type::Union,
             Self::List(..) => fb::Type::List,
             Self::FixedSizeList(..) => fb::Type::FixedSizeList,
             Self::Extension { .. } => fb::Type::Extension,

--- a/vortex-array/src/dtype/serde/proto.rs
+++ b/vortex-array/src/dtype/serde/proto.rs
@@ -55,6 +55,7 @@ impl DType {
                 ),
                 s.nullable.into(),
             )),
+            DtypeType::Union(u) => Ok(Self::Union(u.nullable.into())),
             DtypeType::List(l) => {
                 let nullable = l.nullable.into();
                 Ok(Self::List(
@@ -139,6 +140,9 @@ impl TryFrom<&DType> for pb::DType {
                         .fields()
                         .map(|d| Self::try_from(&d))
                         .collect::<VortexResult<Vec<_>>>()?,
+                    nullable: (*null).into(),
+                }),
+                DType::Union(null) => DtypeType::Union(pb::Union {
                     nullable: (*null).into(),
                 }),
                 DType::List(edt, null) => DtypeType::List(Box::new(pb::List {

--- a/vortex-array/src/dtype/serde/serde.rs
+++ b/vortex-array/src/dtype/serde/serde.rs
@@ -115,6 +115,7 @@ impl Serialize for DType {
                 state.serialize_field(n)?;
                 state.end()
             }
+            DType::Union(n) => serializer.serialize_newtype_variant("DType", 11, "Union", n),
             DType::Extension(ext) => {
                 serializer.serialize_newtype_variant("DType", 9, "Extension", ext)
             }
@@ -157,6 +158,7 @@ impl<'de> DeserializeSeed<'de> for DTypeSerde<'_, DType> {
             "List",
             "FixedSizeList",
             "Struct",
+            "Union",
             "Extension",
             "Variant",
         ];
@@ -215,6 +217,10 @@ impl<'de> DeserializeSeed<'de> for DTypeSerde<'_, DType> {
                     "Struct" => access.newtype_variant_seed(StructFieldsSeed {
                         session: self.session,
                     }),
+                    "Union" => {
+                        let n = access.newtype_variant()?;
+                        Ok(DType::Union(n))
+                    }
                     "Extension" => {
                         let ext = access
                             .newtype_variant_seed(DTypeSerde::<ExtDTypeRef>::new(self.session))?;

--- a/vortex-array/src/dtype/struct_.rs
+++ b/vortex-array/src/dtype/struct_.rs
@@ -138,8 +138,11 @@ impl FieldDTypeInner {
 /// // Accessing a field by name will yield the first
 /// assert_eq!(fields.field("int_col").unwrap(), DType::Primitive(PType::I32, Nullability::Nullable));
 /// ```
+#[allow(
+    clippy::derived_hash_with_manual_eq,
+    reason = "manual PartialEq adds Arc::ptr_eq fast path only"
+)]
 #[derive(Clone, Eq, Hash)]
-#[allow(clippy::derived_hash_with_manual_eq)] // manual PartialEq adds Arc::ptr_eq fast path only
 pub struct StructFields(Arc<StructFieldsInner>);
 
 impl PartialEq for StructFields {

--- a/vortex-array/src/scalar/arbitrary.rs
+++ b/vortex-array/src/scalar/arbitrary.rs
@@ -73,6 +73,7 @@ pub fn random_scalar(u: &mut Unstructured, dtype: &DType) -> Result<Scalar> {
             )),
         )
         .vortex_expect("unable to construct random `Scalar`_"),
+        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::List(edt, _) => Scalar::try_new(
             dtype.clone(),
             Some(ScalarValue::Tuple(

--- a/vortex-array/src/scalar/arrow.rs
+++ b/vortex-array/src/scalar/arrow.rs
@@ -62,6 +62,7 @@ impl TryFrom<&Scalar> for Arc<dyn Datum> {
             DType::Utf8(_) => utf8_to_arrow(value.as_utf8()),
             DType::Binary(_) => binary_to_arrow(value.as_binary()),
             DType::Struct(..) => unimplemented!("struct scalar conversion"),
+            DType::Union(..) => unimplemented!("union scalar conversion"),
             DType::List(..) => unimplemented!("list scalar conversion"),
             DType::FixedSizeList(..) => unimplemented!("fixed-size list scalar conversion"),
             DType::Extension(..) => extension_to_arrow(value.as_extension()),

--- a/vortex-array/src/scalar/cast.rs
+++ b/vortex-array/src/scalar/cast.rs
@@ -57,6 +57,7 @@ impl Scalar {
             DType::Utf8(_) => self.as_utf8().cast(target_dtype),
             DType::Binary(_) => self.as_binary().cast(target_dtype),
             DType::Struct(..) => self.as_struct().cast(target_dtype),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(..) | DType::FixedSizeList(..) => self.as_list().cast(target_dtype),
             DType::Extension(..) => self.as_extension().cast(target_dtype),
             DType::Variant(_) => vortex_bail!("Variant scalars can't be cast to {target_dtype}"),

--- a/vortex-array/src/scalar/display.rs
+++ b/vortex-array/src/scalar/display.rs
@@ -19,6 +19,7 @@ impl Display for Scalar {
             DType::Utf8(_) => write!(f, "{}", self.as_utf8()),
             DType::Binary(_) => write!(f, "{}", self.as_binary()),
             DType::Struct(..) => write!(f, "{}", self.as_struct()),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(..) | DType::FixedSizeList(..) => write!(f, "{}", self.as_list()),
             DType::Extension(_) => write!(f, "{}", self.as_extension()),
             DType::Variant(_) => write!(f, "{}", self.as_variant()),

--- a/vortex-array/src/scalar/scalar_impl.rs
+++ b/vortex-array/src/scalar/scalar_impl.rs
@@ -188,8 +188,11 @@ impl Scalar {
             DType::Utf8(_) => value.as_utf8().is_empty(),
             DType::Binary(_) => value.as_binary().is_empty(),
             DType::List(..) => value.as_list().is_empty(),
+            // TODO(connor): This seems wrong...
             DType::FixedSizeList(_, list_size, _) => value.as_list().len() == *list_size as usize,
+            // TODO(connor): This also seems wrong...
             DType::Struct(struct_fields, _) => value.as_list().len() == struct_fields.nfields(),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Extension(_) => self.as_extension().to_storage_scalar().is_zero()?,
             DType::Variant(_) => self.as_variant().is_zero()?,
         };
@@ -253,6 +256,7 @@ impl Scalar {
                 .fields_iter()
                 .map(|fields| fields.into_iter().map(|f| f.approx_nbytes()).sum::<usize>())
                 .unwrap_or_default(),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(..) | DType::FixedSizeList(..) => self
                 .as_list()
                 .elements()

--- a/vortex-array/src/scalar/scalar_value.rs
+++ b/vortex-array/src/scalar/scalar_value.rs
@@ -62,6 +62,7 @@ impl ScalarValue {
                     .collect();
                 Self::Tuple(field_values)
             }
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Extension(ext_dtype) => {
                 // Since we have no way to define a "zero" extension value (since we have no idea
                 // what the semantics of the extension is), a best effort attempt is to just use the
@@ -99,6 +100,7 @@ impl ScalarValue {
                 let field_values = fields.fields().map(|f| Self::default_value(&f)).collect();
                 Self::Tuple(field_values)
             }
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Extension(ext_dtype) => {
                 // Since we have no way to define a "default" extension value (since we have no idea
                 // what the semantics of the extension is), a best effort attempt is to just use the

--- a/vortex-array/src/scalar/validate.rs
+++ b/vortex-array/src/scalar/validate.rs
@@ -118,6 +118,7 @@ impl Scalar {
                     Self::validate(&field, field_value.as_ref())?;
                 }
             }
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Extension(ext_dtype) => ext_dtype.validate_storage_value(value)?,
             DType::Variant(_) => {
                 let ScalarValue::Variant(inner) = value else {

--- a/vortex-datafusion/src/convert/scalars.rs
+++ b/vortex-datafusion/src/convert/scalars.rs
@@ -112,6 +112,7 @@ impl TryToDataFusion<ScalarValue> for Scalar {
                     .map(|b| Vec::<u8>::from(b.into_inner())),
             ),
             DType::Struct(..) => todo!("struct scalar conversion"),
+            DType::Union(..) => todo!("union scalar conversion"),
             DType::List(..) => todo!("list scalar conversion"),
             DType::FixedSizeList(..) => todo!("fixed-size list scalar conversion"),
             DType::Extension(ext) => {

--- a/vortex-duckdb/src/convert/dtype.rs
+++ b/vortex-duckdb/src/convert/dtype.rs
@@ -223,6 +223,7 @@ impl TryFrom<&DType> for LogicalType {
             DType::Struct(struct_type, _) => {
                 return LogicalType::try_from(struct_type);
             }
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Decimal(decimal_dtype, _) => {
                 return LogicalType::decimal_type(
                     decimal_dtype.precision(),

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -79,6 +79,7 @@ impl ToDuckDBScalar for Scalar {
             DType::Utf8(_) => self.as_utf8().try_to_duckdb_scalar(),
             DType::Binary(_) => self.as_binary().try_to_duckdb_scalar(),
             DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => todo!(),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Variant(_) => {
                 vortex_bail!("Vortex Variant scalars aren't supported in DuckDB")
             }

--- a/vortex-ffi/README.md
+++ b/vortex-ffi/README.md
@@ -1,4 +1,13 @@
 # Vortex C interface
+
+## Updating Headers
+
+If you're developing FFI and want to rebuild `cinclude/vortex.h`, run:
+
+```sh
+cargo +nightly build -p vortex-ffi
+```
+
 ## Usage from a CMake project
 
 ```
@@ -21,11 +30,6 @@ cmake --build build
 ./build/examples/scan_to_arrow
 ./build/examples/write_sample
 ```
-
-## Updating Headers
-
-If you're developing FFI and want to rebuild `cinclude/vortex.h`, run
-`cargo +nightly build -p vortex-ffi`.
 
 ## Testing C part
 
@@ -75,14 +79,11 @@ cargo +nightly test -Zbuild-std \
     -- --no-capture
 ```
 
-- `-Zbuild-std` is needed as memory and thread sanitizers report std errors
-  otherwise.
-- `--no-default-features` is needed as we use Mimalloc otherwise which interferes
-with sanitizers.
-- `allow-abi-mismatch` is safe because in our dependency graph only crates like
-  `compiler_builtins` unset sanitization, and they do it on purpose.
-- Make sure to use `cargo test` and not `cargo nextest` as nextest reports less
-  leaks.
+- `-Zbuild-std` is needed as memory and thread sanitizers report std errors otherwise.
+- `--no-default-features` is needed as we use Mimalloc otherwise which interferes with sanitizers.
+- `allow-abi-mismatch` is safe because in our dependency graph only crates like `compiler_builtins`
+  unset sanitization, and they do it on purpose.
+- Make sure to use `cargo test` and not `cargo nextest` as nextest reports less leaks.
 - If you want stack trace symbolization, install `llvm-symbolizer`.
 
 ## Testing Rust and C with sanitizers

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -59,6 +59,7 @@ pub enum vx_dtype_variant {
     DTYPE_FIXED_SIZE_LIST = 9,
 }
 
+// TODO(connor)[Union]: Do we need to add union and variant here?
 impl From<&DType> for vx_dtype_variant {
     fn from(value: &DType) -> Self {
         match value {
@@ -69,6 +70,7 @@ impl From<&DType> for vx_dtype_variant {
             DType::Utf8(_) => vx_dtype_variant::DTYPE_UTF8,
             DType::Binary(_) => vx_dtype_variant::DTYPE_BINARY,
             DType::Struct(..) => vx_dtype_variant::DTYPE_STRUCT,
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(..) => vx_dtype_variant::DTYPE_LIST,
             DType::FixedSizeList(..) => vx_dtype_variant::DTYPE_FIXED_SIZE_LIST,
             DType::Extension(_) => vx_dtype_variant::DTYPE_EXTENSION,

--- a/vortex-flatbuffers/flatbuffers/vortex-dtype/dtype.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-dtype/dtype.fbs
@@ -67,6 +67,10 @@ table Variant {
     nullable: bool;
 }
 
+table Union {
+    nullable: bool;
+}
+
 union Type {
     Null = 1,
     Bool = 2,
@@ -79,6 +83,7 @@ union Type {
     Extension = 9,
     FixedSizeList = 10, // This is after `Extension` for backwards compatibility.
     Variant = 11,
+    Union = 12,
 }
 
 table DType {

--- a/vortex-flatbuffers/public-api.lock
+++ b/vortex-flatbuffers/public-api.lock
@@ -572,6 +572,8 @@ pub enum vortex_flatbuffers::dtype::PrimitiveOffset
 
 pub enum vortex_flatbuffers::dtype::Struct_Offset
 
+pub enum vortex_flatbuffers::dtype::UnionOffset
+
 pub enum vortex_flatbuffers::dtype::Utf8Offset
 
 pub enum vortex_flatbuffers::dtype::VariantOffset
@@ -725,6 +727,8 @@ pub fn vortex_flatbuffers::dtype::DType<'a>::type__as_null(&self) -> core::optio
 pub fn vortex_flatbuffers::dtype::DType<'a>::type__as_primitive(&self) -> core::option::Option<vortex_flatbuffers::dtype::Primitive<'a>>
 
 pub fn vortex_flatbuffers::dtype::DType<'a>::type__as_struct_(&self) -> core::option::Option<vortex_flatbuffers::dtype::Struct_<'a>>
+
+pub fn vortex_flatbuffers::dtype::DType<'a>::type__as_union(&self) -> core::option::Option<vortex_flatbuffers::dtype::Union<'a>>
 
 pub fn vortex_flatbuffers::dtype::DType<'a>::type__as_utf_8(&self) -> core::option::Option<vortex_flatbuffers::dtype::Utf8<'a>>
 
@@ -1382,6 +1386,8 @@ pub const vortex_flatbuffers::dtype::Type::Primitive: Self
 
 pub const vortex_flatbuffers::dtype::Type::Struct_: Self
 
+pub const vortex_flatbuffers::dtype::Type::Union: Self
+
 pub const vortex_flatbuffers::dtype::Type::Utf8: Self
 
 pub const vortex_flatbuffers::dtype::Type::Variant: Self
@@ -1449,6 +1455,64 @@ impl<'a> flatbuffers::verifier::Verifiable for vortex_flatbuffers::dtype::Type
 pub fn vortex_flatbuffers::dtype::Type::run_verifier(&mut flatbuffers::verifier::Verifier<'_, '_>, usize) -> core::result::Result<(), flatbuffers::verifier::InvalidFlatbuffer>
 
 pub struct vortex_flatbuffers::dtype::TypeUnionTableOffset
+
+pub struct vortex_flatbuffers::dtype::Union<'a>
+
+pub vortex_flatbuffers::dtype::Union::_tab: flatbuffers::table::Table<'a>
+
+impl<'a> vortex_flatbuffers::dtype::Union<'a>
+
+pub const vortex_flatbuffers::dtype::Union<'a>::VT_NULLABLE: flatbuffers::primitives::VOffsetT
+
+pub fn vortex_flatbuffers::dtype::Union<'a>::create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::builder::Allocator + 'bldr>(&'mut_bldr mut flatbuffers::builder::FlatBufferBuilder<'bldr, A>, &'args vortex_flatbuffers::dtype::UnionArgs) -> flatbuffers::primitives::WIPOffset<vortex_flatbuffers::dtype::Union<'bldr>>
+
+pub unsafe fn vortex_flatbuffers::dtype::Union<'a>::init_from_table(flatbuffers::table::Table<'a>) -> Self
+
+pub fn vortex_flatbuffers::dtype::Union<'a>::nullable(&self) -> bool
+
+impl core::fmt::Debug for vortex_flatbuffers::dtype::Union<'_>
+
+pub fn vortex_flatbuffers::dtype::Union<'_>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl flatbuffers::verifier::Verifiable for vortex_flatbuffers::dtype::Union<'_>
+
+pub fn vortex_flatbuffers::dtype::Union<'_>::run_verifier(&mut flatbuffers::verifier::Verifier<'_, '_>, usize) -> core::result::Result<(), flatbuffers::verifier::InvalidFlatbuffer>
+
+impl<'a> core::clone::Clone for vortex_flatbuffers::dtype::Union<'a>
+
+pub fn vortex_flatbuffers::dtype::Union<'a>::clone(&self) -> vortex_flatbuffers::dtype::Union<'a>
+
+impl<'a> core::cmp::PartialEq for vortex_flatbuffers::dtype::Union<'a>
+
+pub fn vortex_flatbuffers::dtype::Union<'a>::eq(&self, &vortex_flatbuffers::dtype::Union<'a>) -> bool
+
+impl<'a> core::marker::Copy for vortex_flatbuffers::dtype::Union<'a>
+
+impl<'a> core::marker::StructuralPartialEq for vortex_flatbuffers::dtype::Union<'a>
+
+impl<'a> flatbuffers::follow::Follow<'a> for vortex_flatbuffers::dtype::Union<'a>
+
+pub type vortex_flatbuffers::dtype::Union<'a>::Inner = vortex_flatbuffers::dtype::Union<'a>
+
+pub unsafe fn vortex_flatbuffers::dtype::Union<'a>::follow(&'a [u8], usize) -> Self::Inner
+
+pub struct vortex_flatbuffers::dtype::UnionArgs
+
+pub vortex_flatbuffers::dtype::UnionArgs::nullable: bool
+
+impl<'a> core::default::Default for vortex_flatbuffers::dtype::UnionArgs
+
+pub fn vortex_flatbuffers::dtype::UnionArgs::default() -> Self
+
+pub struct vortex_flatbuffers::dtype::UnionBuilder<'a: 'b, 'b, A: flatbuffers::builder::Allocator + 'a>
+
+impl<'a: 'b, 'b, A: flatbuffers::builder::Allocator + 'a> vortex_flatbuffers::dtype::UnionBuilder<'a, 'b, A>
+
+pub fn vortex_flatbuffers::dtype::UnionBuilder<'a, 'b, A>::add_nullable(&mut self, bool)
+
+pub fn vortex_flatbuffers::dtype::UnionBuilder<'a, 'b, A>::finish(self) -> flatbuffers::primitives::WIPOffset<vortex_flatbuffers::dtype::Union<'a>>
+
+pub fn vortex_flatbuffers::dtype::UnionBuilder<'a, 'b, A>::new(&'b mut flatbuffers::builder::FlatBufferBuilder<'a, A>) -> vortex_flatbuffers::dtype::UnionBuilder<'a, 'b, A>
 
 pub struct vortex_flatbuffers::dtype::Utf8<'a>
 
@@ -1576,7 +1640,7 @@ pub const vortex_flatbuffers::dtype::ENUM_MIN_TYPE: u8
 
 pub const vortex_flatbuffers::dtype::ENUM_VALUES_PTYPE: [vortex_flatbuffers::dtype::PType; 11]
 
-pub const vortex_flatbuffers::dtype::ENUM_VALUES_TYPE: [vortex_flatbuffers::dtype::Type; 12]
+pub const vortex_flatbuffers::dtype::ENUM_VALUES_TYPE: [vortex_flatbuffers::dtype::Type; 13]
 
 pub fn vortex_flatbuffers::dtype::finish_dtype_buffer<'a, 'b, A: flatbuffers::builder::Allocator + 'a>(&'b mut flatbuffers::builder::FlatBufferBuilder<'a, A>, flatbuffers::primitives::WIPOffset<vortex_flatbuffers::dtype::DType<'a>>)
 

--- a/vortex-flatbuffers/src/generated/dtype.rs
+++ b/vortex-flatbuffers/src/generated/dtype.rs
@@ -126,10 +126,10 @@ impl ::flatbuffers::SimpleToVerifyInSlice for PType {}
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 pub const ENUM_MIN_TYPE: u8 = 0;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
-pub const ENUM_MAX_TYPE: u8 = 11;
+pub const ENUM_MAX_TYPE: u8 = 12;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_TYPE: [Type; 12] = [
+pub const ENUM_VALUES_TYPE: [Type; 13] = [
   Type::NONE,
   Type::Null,
   Type::Bool,
@@ -142,6 +142,7 @@ pub const ENUM_VALUES_TYPE: [Type; 12] = [
   Type::Extension,
   Type::FixedSizeList,
   Type::Variant,
+  Type::Union,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -161,9 +162,10 @@ impl Type {
   pub const Extension: Self = Self(9);
   pub const FixedSizeList: Self = Self(10);
   pub const Variant: Self = Self(11);
+  pub const Union: Self = Self(12);
 
   pub const ENUM_MIN: u8 = 0;
-  pub const ENUM_MAX: u8 = 11;
+  pub const ENUM_MAX: u8 = 12;
   pub const ENUM_VALUES: &'static [Self] = &[
     Self::NONE,
     Self::Null,
@@ -177,6 +179,7 @@ impl Type {
     Self::Extension,
     Self::FixedSizeList,
     Self::Variant,
+    Self::Union,
   ];
   /// Returns the variant's name or "" if unknown.
   pub fn variant_name(self) -> Option<&'static str> {
@@ -193,6 +196,7 @@ impl Type {
       Self::Extension => Some("Extension"),
       Self::FixedSizeList => Some("FixedSizeList"),
       Self::Variant => Some("Variant"),
+      Self::Union => Some("Union"),
       _ => None,
     }
   }
@@ -1457,6 +1461,102 @@ impl ::core::fmt::Debug for Variant<'_> {
       ds.finish()
   }
 }
+pub enum UnionOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct Union<'a> {
+  pub _tab: ::flatbuffers::Table<'a>,
+}
+
+impl<'a> ::flatbuffers::Follow<'a> for Union<'a> {
+  type Inner = Union<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: unsafe { ::flatbuffers::Table::new(buf, loc) } }
+  }
+}
+
+impl<'a> Union<'a> {
+  pub const VT_NULLABLE: ::flatbuffers::VOffsetT = 4;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
+    Union { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: ::flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut ::flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args UnionArgs
+  ) -> ::flatbuffers::WIPOffset<Union<'bldr>> {
+    let mut builder = UnionBuilder::new(_fbb);
+    builder.add_nullable(args.nullable);
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn nullable(&self) -> bool {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<bool>(Union::VT_NULLABLE, Some(false)).unwrap()}
+  }
+}
+
+impl ::flatbuffers::Verifiable for Union<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut ::flatbuffers::Verifier, pos: usize
+  ) -> Result<(), ::flatbuffers::InvalidFlatbuffer> {
+    v.visit_table(pos)?
+     .visit_field::<bool>("nullable", Self::VT_NULLABLE, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct UnionArgs {
+    pub nullable: bool,
+}
+impl<'a> Default for UnionArgs {
+  #[inline]
+  fn default() -> Self {
+    UnionArgs {
+      nullable: false,
+    }
+  }
+}
+
+pub struct UnionBuilder<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: ::flatbuffers::WIPOffset<::flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> UnionBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_nullable(&mut self, nullable: bool) {
+    self.fbb_.push_slot::<bool>(Union::VT_NULLABLE, nullable, false);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>) -> UnionBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    UnionBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> ::flatbuffers::WIPOffset<Union<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    ::flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl ::core::fmt::Debug for Union<'_> {
+  fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+    let mut ds = f.debug_struct("Union");
+      ds.field("nullable", &self.nullable());
+      ds.finish()
+  }
+}
 pub enum DTypeOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -1671,6 +1771,21 @@ impl<'a> DType<'a> {
     }
   }
 
+  #[inline]
+  #[allow(non_snake_case)]
+  pub fn type__as_union(&self) -> Option<Union<'a>> {
+    if self.type_type() == Type::Union {
+      self.type_().map(|t| {
+       // Safety:
+       // Created from a valid Table for this object
+       // Which contains a valid union in this slot
+       unsafe { Union::init_from_table(t) }
+     })
+    } else {
+      None
+    }
+  }
+
 }
 
 impl ::flatbuffers::Verifiable for DType<'_> {
@@ -1692,6 +1807,7 @@ impl ::flatbuffers::Verifiable for DType<'_> {
           Type::Extension => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<Extension>>("Type::Extension", pos),
           Type::FixedSizeList => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<FixedSizeList>>("Type::FixedSizeList", pos),
           Type::Variant => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<Variant>>("Type::Variant", pos),
+          Type::Union => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<Union>>("Type::Union", pos),
           _ => Ok(()),
         }
      })?
@@ -1818,6 +1934,13 @@ impl ::core::fmt::Debug for DType<'_> {
         },
         Type::Variant => {
           if let Some(x) = self.type__as_variant() {
+            ds.field("type_", &x)
+          } else {
+            ds.field("type_", &"InvalidFlatbuffer: Union discriminant does not match value.")
+          }
+        },
+        Type::Union => {
+          if let Some(x) = self.type__as_union() {
             ds.field("type_", &x)
           } else {
             ds.field("type_", &"InvalidFlatbuffer: Union discriminant does not match value.")

--- a/vortex-proto/proto/dtype.proto
+++ b/vortex-proto/proto/dtype.proto
@@ -74,6 +74,10 @@ message Variant {
   bool nullable = 1;
 }
 
+message Union {
+  bool nullable = 4;
+}
+
 message DType {
   oneof dtype_type {
     Null null = 1;
@@ -87,6 +91,7 @@ message DType {
     Extension extension = 9;
     FixedSizeList fixed_size_list = 10; // This is after `Extension` for backwards compatibility.
     Variant variant = 11;
+    Union union = 12;
   }
 }
 

--- a/vortex-proto/public-api.lock
+++ b/vortex-proto/public-api.lock
@@ -24,6 +24,8 @@ pub vortex_proto::dtype::d_type::DtypeType::Primitive(vortex_proto::dtype::Primi
 
 pub vortex_proto::dtype::d_type::DtypeType::Struct(vortex_proto::dtype::Struct)
 
+pub vortex_proto::dtype::d_type::DtypeType::Union(vortex_proto::dtype::Union)
+
 pub vortex_proto::dtype::d_type::DtypeType::Utf8(vortex_proto::dtype::Utf8)
 
 pub vortex_proto::dtype::d_type::DtypeType::Variant(vortex_proto::dtype::Variant)
@@ -573,6 +575,42 @@ impl prost::message::Message for vortex_proto::dtype::Struct
 pub fn vortex_proto::dtype::Struct::clear(&mut self)
 
 pub fn vortex_proto::dtype::Struct::encoded_len(&self) -> usize
+
+pub struct vortex_proto::dtype::Union
+
+pub vortex_proto::dtype::Union::nullable: bool
+
+impl core::clone::Clone for vortex_proto::dtype::Union
+
+pub fn vortex_proto::dtype::Union::clone(&self) -> vortex_proto::dtype::Union
+
+impl core::cmp::Eq for vortex_proto::dtype::Union
+
+impl core::cmp::PartialEq for vortex_proto::dtype::Union
+
+pub fn vortex_proto::dtype::Union::eq(&self, &vortex_proto::dtype::Union) -> bool
+
+impl core::default::Default for vortex_proto::dtype::Union
+
+pub fn vortex_proto::dtype::Union::default() -> Self
+
+impl core::fmt::Debug for vortex_proto::dtype::Union
+
+pub fn vortex_proto::dtype::Union::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_proto::dtype::Union
+
+pub fn vortex_proto::dtype::Union::hash<__H: core::hash::Hasher>(&self, &mut __H)
+
+impl core::marker::Copy for vortex_proto::dtype::Union
+
+impl core::marker::StructuralPartialEq for vortex_proto::dtype::Union
+
+impl prost::message::Message for vortex_proto::dtype::Union
+
+pub fn vortex_proto::dtype::Union::clear(&mut self)
+
+pub fn vortex_proto::dtype::Union::encoded_len(&self) -> usize
 
 pub struct vortex_proto::dtype::Utf8
 

--- a/vortex-proto/src/generated/vortex.dtype.rs
+++ b/vortex-proto/src/generated/vortex.dtype.rs
@@ -71,9 +71,14 @@ pub struct Variant {
     #[prost(bool, tag = "1")]
     pub nullable: bool,
 }
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct Union {
+    #[prost(bool, tag = "4")]
+    pub nullable: bool,
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DType {
-    #[prost(oneof = "d_type::DtypeType", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")]
+    #[prost(oneof = "d_type::DtypeType", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12")]
     pub dtype_type: ::core::option::Option<d_type::DtypeType>,
 }
 /// Nested message and enum types in `DType`.
@@ -103,6 +108,8 @@ pub mod d_type {
         FixedSizeList(::prost::alloc::boxed::Box<super::FixedSizeList>),
         #[prost(message, tag = "11")]
         Variant(super::Variant),
+        #[prost(message, tag = "12")]
+        Union(super::Union),
     }
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]

--- a/vortex-python/src/dtype/mod.rs
+++ b/vortex-python/src/dtype/mod.rs
@@ -130,6 +130,7 @@ impl PyDType {
             DType::Utf8(..) => Self::with_subclass(py, dtype, PyUtf8DType),
             DType::Binary(..) => Self::with_subclass(py, dtype, PyBinaryDType),
             DType::Struct(..) => Self::with_subclass(py, dtype, PyStructDType),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(..) => Self::with_subclass(py, dtype, PyListDType),
             DType::FixedSizeList(..) => Self::with_subclass(py, dtype, PyFixedSizeListDType),
             DType::Extension(..) => Self::with_subclass(py, dtype, PyExtensionDType),

--- a/vortex-python/src/python_repr.rs
+++ b/vortex-python/src/python_repr.rs
@@ -77,6 +77,7 @@ impl Display for DTypePythonRepr<'_> {
                     .join(", "),
                 n.python_repr()
             ),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(edt, n) => write!(
                 f,
                 "list({}, nullable={})",

--- a/vortex-python/src/scalar/into_py.rs
+++ b/vortex-python/src/scalar/into_py.rs
@@ -81,6 +81,7 @@ impl<'py> IntoPyObject<'py> for PyVortex<&'_ Scalar> {
                 .map(PyVortex)
                 .into_pyobject(py),
             DType::Struct(..) => PyVortex(self.0.as_struct()).into_pyobject(py),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(..) | DType::FixedSizeList(..) => {
                 PyVortex(self.0.as_list()).into_pyobject(py)
             }

--- a/vortex-python/src/scalar/mod.rs
+++ b/vortex-python/src/scalar/mod.rs
@@ -112,6 +112,7 @@ impl PyScalar {
             DType::Utf8(..) => Self::with_subclass(py, scalar, PyUtf8Scalar),
             DType::Binary(..) => Self::with_subclass(py, scalar, PyBinaryScalar),
             DType::Struct(..) => Self::with_subclass(py, scalar, PyStructScalar),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(..) | DType::FixedSizeList(..) => {
                 // We represent both lists and fixed-size lists with `PyListScalar` since the notion
                 // of "fixed-size" only applies to full arrays, not scalars.


### PR DESCRIPTION
## Summary

Tracking issue: https://github.com/vortex-data/vortex/issues/7882

Adds the `Union(Nullability)` enum variant, plumbs it through all existing match arms with `todo!("TODO(connor)[Union]: unimplemented")`, and reserves slot 12 in the flatbuffer and protobuf wire schemas.

A follow-up PR will replace `Union(Nullability)` with `Union(UnionVariants, Nullability)` and fill in the serde paths.

Note that this PR doesn't have any implementation logic, it is just boilerplate.

## API Changes

Adds a new `DType::Union` variant.

## Testing

Nothing to test.