### PR TITLE
Add `UnionVariants` type and embed it in `DType::Union`

### DIFF
--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -9416,7 +9416,7 @@ pub vortex_array::dtype::DType::Primitive(vortex_array::dtype::PType, vortex_arr
 
 pub vortex_array::dtype::DType::Struct(vortex_array::dtype::StructFields, vortex_array::dtype::Nullability)
 
-pub vortex_array::dtype::DType::Union(vortex_array::dtype::Nullability)
+pub vortex_array::dtype::DType::Union(vortex_array::dtype::UnionVariants, vortex_array::dtype::Nullability)
 
 pub vortex_array::dtype::DType::Utf8(vortex_array::dtype::Nullability)
 
@@ -9448,6 +9448,8 @@ pub fn vortex_array::dtype::DType::as_struct_fields(&self) -> &vortex_array::dty
 
 pub fn vortex_array::dtype::DType::as_struct_fields_opt(&self) -> core::option::Option<&vortex_array::dtype::StructFields>
 
+pub fn vortex_array::dtype::DType::as_union_variants_opt(&self) -> core::option::Option<&vortex_array::dtype::UnionVariants>
+
 pub fn vortex_array::dtype::DType::element_size(&self) -> core::option::Option<usize>
 
 pub fn vortex_array::dtype::DType::eq_ignore_nullability(&self, &Self) -> bool
@@ -9467,6 +9469,8 @@ pub fn vortex_array::dtype::DType::into_list_element_opt(self) -> core::option::
 pub fn vortex_array::dtype::DType::into_struct_fields(self) -> vortex_array::dtype::StructFields
 
 pub fn vortex_array::dtype::DType::into_struct_fields_opt(self) -> core::option::Option<vortex_array::dtype::StructFields>
+
+pub fn vortex_array::dtype::DType::into_union_variants_opt(self) -> core::option::Option<vortex_array::dtype::UnionVariants>
 
 pub fn vortex_array::dtype::DType::is_binary(&self) -> bool
 
@@ -10579,6 +10583,66 @@ pub fn vortex_array::dtype::StructFields::from_arrow(&arrow_schema::fields::Fiel
 impl<T, V> core::iter::traits::collect::FromIterator<(T, V)> for vortex_array::dtype::StructFields where T: core::convert::Into<vortex_array::dtype::FieldName>, V: core::convert::Into<vortex_array::dtype::FieldDType>
 
 pub fn vortex_array::dtype::StructFields::from_iter<I: core::iter::traits::collect::IntoIterator<Item = (T, V)>>(I) -> Self
+
+pub struct vortex_array::dtype::UnionVariants(_)
+
+impl vortex_array::dtype::UnionVariants
+
+pub fn vortex_array::dtype::UnionVariants::child_index_to_tag(&self, usize) -> i8
+
+pub fn vortex_array::dtype::UnionVariants::empty() -> Self
+
+pub fn vortex_array::dtype::UnionVariants::find(&self, impl core::convert::AsRef<str>) -> core::option::Option<usize>
+
+pub fn vortex_array::dtype::UnionVariants::is_consecutive(&self) -> bool
+
+pub fn vortex_array::dtype::UnionVariants::is_empty(&self) -> bool
+
+pub fn vortex_array::dtype::UnionVariants::len(&self) -> usize
+
+pub fn vortex_array::dtype::UnionVariants::names(&self) -> &vortex_array::dtype::FieldNames
+
+pub fn vortex_array::dtype::UnionVariants::new_consecutive(vortex_array::dtype::FieldNames, alloc::vec::Vec<vortex_array::dtype::DType>) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::dtype::UnionVariants::nullability_constraints_satisfied(&self, vortex_array::dtype::Nullability) -> bool
+
+pub fn vortex_array::dtype::UnionVariants::tag_to_child_index(&self, i8) -> core::option::Option<usize>
+
+pub fn vortex_array::dtype::UnionVariants::try_new(vortex_array::dtype::FieldNames, alloc::vec::Vec<vortex_array::dtype::DType>, alloc::vec::Vec<i8>) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::dtype::UnionVariants::type_ids(&self) -> &[i8]
+
+pub fn vortex_array::dtype::UnionVariants::variant(&self, impl core::convert::AsRef<str>) -> core::option::Option<vortex_array::dtype::DType>
+
+pub fn vortex_array::dtype::UnionVariants::variant_by_index(&self, usize) -> core::option::Option<vortex_array::dtype::DType>
+
+pub fn vortex_array::dtype::UnionVariants::variants(&self) -> impl core::iter::traits::exact_size::ExactSizeIterator<Item = vortex_array::dtype::DType> + '_
+
+impl core::clone::Clone for vortex_array::dtype::UnionVariants
+
+pub fn vortex_array::dtype::UnionVariants::clone(&self) -> vortex_array::dtype::UnionVariants
+
+impl core::cmp::Eq for vortex_array::dtype::UnionVariants
+
+impl core::cmp::PartialEq for vortex_array::dtype::UnionVariants
+
+pub fn vortex_array::dtype::UnionVariants::eq(&self, &Self) -> bool
+
+impl core::default::Default for vortex_array::dtype::UnionVariants
+
+pub fn vortex_array::dtype::UnionVariants::default() -> Self
+
+impl core::fmt::Debug for vortex_array::dtype::UnionVariants
+
+pub fn vortex_array::dtype::UnionVariants::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::fmt::Display for vortex_array::dtype::UnionVariants
+
+pub fn vortex_array::dtype::UnionVariants::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_array::dtype::UnionVariants
+
+pub fn vortex_array::dtype::UnionVariants::hash<__H: core::hash::Hasher>(&self, &mut __H)
 
 #[repr(transparent)] pub struct vortex_array::dtype::i256(_)
 

--- a/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
@@ -285,7 +285,9 @@ fn supports_uncompressed_size_in_bytes(dtype: &DType) -> bool {
         DType::Struct(fields, _) => fields
             .fields()
             .all(|field| supports_uncompressed_size_in_bytes(&field)),
-        DType::Union(_) => todo!("TODO(connor)[Union]: unimplemented"),
+        DType::Union(variants, _) => variants
+            .variants()
+            .all(|variant| supports_uncompressed_size_in_bytes(&variant)),
         DType::Extension(ext_dtype) => {
             supports_uncompressed_size_in_bytes(ext_dtype.storage_dtype())
         }

--- a/vortex-array/src/dtype/dtype_impl.rs
+++ b/vortex-array/src/dtype/dtype_impl.rs
@@ -15,6 +15,7 @@ use crate::dtype::FieldDType;
 use crate::dtype::FieldName;
 use crate::dtype::PType;
 use crate::dtype::StructFields;
+use crate::dtype::UnionVariants;
 use crate::dtype::decimal::DecimalDType;
 use crate::dtype::decimal::DecimalType;
 use crate::dtype::extension::ExtDTypeRef;
@@ -62,7 +63,7 @@ impl DType {
             | Utf8(null)
             | Binary(null)
             | Struct(_, null)
-            | Union(null)
+            | Union(_, null)
             | List(_, null)
             | FixedSizeList(_, _, null)
             | Variant(null) => matches!(null, Nullability::Nullable),
@@ -89,7 +90,7 @@ impl DType {
             Utf8(_) => Utf8(nullability),
             Binary(_) => Binary(nullability),
             Struct(sf, _) => Struct(sf.clone(), nullability),
-            Union(_) => Union(nullability),
+            Union(vs, _) => Union(vs.clone(), nullability),
             List(edt, _) => List(Arc::clone(edt), nullability),
             FixedSizeList(edt, size, _) => FixedSizeList(Arc::clone(edt), *size, nullability),
             Extension(ext) => Extension(ext.with_nullability(nullability)),
@@ -123,7 +124,15 @@ impl DType {
                         .zip_eq(rhs_dtype.fields())
                         .all(|(l, r)| l.eq_ignore_nullability(&r)))
             }
-            (Union(_), Union(_)) => true,
+            (Union(lhs, _), Union(rhs, _)) => {
+                // Equal `names` implies equal length by FieldNames equality.
+                lhs.names() == rhs.names()
+                    && lhs.type_ids() == rhs.type_ids()
+                    && lhs
+                        .variants()
+                        .zip_eq(rhs.variants())
+                        .all(|(l, r)| l.eq_ignore_nullability(&r))
+            }
             (Extension(lhs_extdtype), Extension(rhs_extdtype)) => {
                 lhs_extdtype.eq_ignore_nullability(rhs_extdtype)
             }
@@ -425,6 +434,24 @@ impl DType {
         }
     }
 
+    /// Get the [`UnionVariants`] if `self` is a [`DType::Union`], otherwise `None`.
+    pub fn as_union_variants_opt(&self) -> Option<&UnionVariants> {
+        if let Union(uv, _) = self {
+            Some(uv)
+        } else {
+            None
+        }
+    }
+
+    /// Owned version of [Self::as_union_variants_opt].
+    pub fn into_union_variants_opt(self) -> Option<UnionVariants> {
+        if let Union(uv, _) = self {
+            Some(uv)
+        } else {
+            None
+        }
+    }
+
     /// Downcast a `DType` to an `ExtDType`
     pub fn as_extension(&self) -> &ExtDTypeRef {
         let Extension(ext) = self else {
@@ -474,7 +501,7 @@ impl Display for DType {
                     .map(|(field_null, dt)| format!("{field_null}={dt}"))
                     .join(", "),
             ),
-            Union(null) => write!(f, "union(){null}"),
+            Union(uv, null) => write!(f, "union({uv}){null}"),
             List(edt, null) => write!(f, "list({edt}){null}"),
             FixedSizeList(edt, size, null) => write!(f, "fixed_size_list({edt})[{size}]{null}"),
             Extension(ext) => write!(f, "{}", ext),

--- a/vortex-array/src/dtype/mod.rs
+++ b/vortex-array/src/dtype/mod.rs
@@ -24,6 +24,7 @@ mod ptype;
 pub mod serde;
 pub mod session;
 mod struct_;
+mod union;
 
 use std::sync::Arc;
 
@@ -100,10 +101,10 @@ pub enum DType {
 
     /// A logical union (sum) type.
     ///
-    /// A subsequent change will replace this single-field variant with
-    /// `Union(UnionVariants, Nullability)` so the type can carry its named variants, per-variant
-    /// `DType`s, and `i8` type tags.
-    Union(Nullability),
+    /// A `Union` is composed of one or more *variants*, each with a name and a `DType`. A
+    /// per-row `i8` tag selects which variant is live at that row. See [`UnionVariants`] for
+    /// the type-tag conventions and accessors.
+    Union(UnionVariants, Nullability),
 
     /// A user-defined extension type.
     ///
@@ -131,9 +132,11 @@ impl PartialEq for DType {
             }
             // StructFields handles its own Arc::ptr_eq in its PartialEq impl.
             (Self::Struct(a, na), Self::Struct(b, nb)) => na == nb && a == b,
-            (Self::Union(a), Self::Union(b)) => a == b,
+            // UnionVariants handles its own Arc::ptr_eq in its PartialEq impl.
+            (Self::Union(a, na), Self::Union(b, nb)) => na == nb && a == b,
             (Self::Extension(a), Self::Extension(b)) => a == b,
             (Self::Variant(a), Self::Variant(b)) => a == b,
+
             // Every variant is listed in the first position so that adding a new
             // variant produces a non-exhaustive match compile error.
             (Self::Null, _)
@@ -163,6 +166,7 @@ pub use half;
 pub use nullability::*;
 pub use ptype::*;
 pub use struct_::*;
+pub use union::*;
 
 use crate::dtype::extension::ExtDTypeRef;
 

--- a/vortex-array/src/dtype/serde/flatbuffers.rs
+++ b/vortex-array/src/dtype/serde/flatbuffers.rs
@@ -11,6 +11,7 @@ use itertools::Itertools;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 use vortex_flatbuffers::FlatBuffer;
 use vortex_flatbuffers::FlatBufferRoot;
@@ -21,8 +22,10 @@ use vortex_session::VortexSession;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
 use crate::dtype::FieldDType;
+use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::dtype::StructFields;
+use crate::dtype::UnionVariants;
 use crate::dtype::extension::ExtId;
 use crate::dtype::extension::ForeignExtDType;
 use crate::dtype::flatbuffers as fb;
@@ -87,6 +90,42 @@ impl StructFields {
             .collect::<Vec<_>>();
 
         Ok(StructFields::from_fields(names, dtypes))
+    }
+}
+
+impl UnionVariants {
+    /// Creates a new instance from a flatbuffer-defined object and its underlying buffer.
+    fn from_fb(
+        fb_union: fbd::Union<'_>,
+        buffer: FlatBuffer,
+        session: VortexSession,
+    ) -> VortexResult<Self> {
+        let names = fb_union
+            .names()
+            .ok_or_else(|| vortex_err!("failed to parse union names from flatbuffer"))?
+            .iter()
+            .collect();
+
+        let dtypes = fb_union
+            .dtypes()
+            .ok_or_else(|| vortex_err!("failed to parse union dtypes from flatbuffer"))?
+            .iter()
+            .map(|dt| {
+                FieldDType::from(ViewedDType::from_fb_loc(
+                    dt._tab.loc(),
+                    buffer.clone(),
+                    session.clone(),
+                ))
+            })
+            .collect::<Vec<_>>();
+
+        let type_ids: Vec<i8> = fb_union
+            .type_ids()
+            .ok_or_else(|| vortex_err!("failed to parse union type_ids from flatbuffer"))?
+            .iter()
+            .collect();
+
+        UnionVariants::try_from_fields(names, dtypes, type_ids)
     }
 }
 
@@ -195,7 +234,17 @@ impl TryFrom<ViewedDType> for DType {
                 let fb_union = fb
                     .type__as_union()
                     .ok_or_else(|| vortex_err!("failed to parse union from flatbuffer"))?;
-                Ok(Self::Union(fb_union.nullable().into()))
+                let variants =
+                    UnionVariants::from_fb(fb_union, vfdt.buffer().clone(), vfdt.session.clone())?;
+
+                let nullability: Nullability = fb_union.nullable().into();
+                vortex_ensure!(
+                    variants.nullability_constraints_satisfied(nullability),
+                    "Union nullability constraint not satisfied: nullability={:?}",
+                    nullability
+                );
+
+                Ok(Self::Union(variants, nullability))
             }
             fb::Type::Extension => {
                 let fb_ext = fb
@@ -317,13 +366,33 @@ impl WriteFlatBuffer for DType {
                 )
                 .as_union_value()
             }
-            Self::Union(n) => fb::Union::create(
-                fbb,
-                &fb::UnionArgs {
-                    nullable: (*n).into(),
-                },
-            )
-            .as_union_value(),
+            Self::Union(uv, n) => {
+                let names = uv
+                    .names()
+                    .iter()
+                    .map(|name| fbb.create_string(name.as_ref()))
+                    .collect_vec();
+                let names = Some(fbb.create_vector(&names));
+
+                let dtypes = uv
+                    .variants()
+                    .map(|dtype| dtype.write_flatbuffer(fbb))
+                    .collect::<VortexResult<Vec<_>>>()?;
+                let dtypes = Some(fbb.create_vector(&dtypes));
+
+                let type_ids = Some(fbb.create_vector(uv.type_ids()));
+
+                fb::Union::create(
+                    fbb,
+                    &fb::UnionArgs {
+                        names,
+                        dtypes,
+                        type_ids,
+                        nullable: (*n).into(),
+                    },
+                )
+                .as_union_value()
+            }
             Self::List(edt, n) => {
                 let element_type = Some(edt.as_ref().write_flatbuffer(fbb)?);
                 fb::List::create(
@@ -445,6 +514,7 @@ mod test {
     use crate::dtype::DType;
     use crate::dtype::PType;
     use crate::dtype::StructFields;
+    use crate::dtype::UnionVariants;
     use crate::dtype::flatbuffers as fb;
     use crate::dtype::nullability::Nullability;
     use crate::dtype::serde::flatbuffers::ViewedDType;
@@ -500,5 +570,166 @@ mod test {
             Nullability::NonNullable,
         ));
         roundtrip_dtype(DType::Variant(Nullability::Nullable));
+    }
+
+    fn make_basic_union() -> DType {
+        DType::Union(
+            UnionVariants::new_consecutive(
+                ["int", "str"].into(),
+                vec![
+                    DType::Primitive(PType::I32, Nullability::NonNullable),
+                    DType::Utf8(Nullability::NonNullable),
+                ],
+            )
+            .unwrap(),
+            Nullability::NonNullable,
+        )
+    }
+
+    #[test]
+    fn test_union_round_trip_flatbuffer() {
+        roundtrip_dtype(make_basic_union());
+    }
+
+    #[test]
+    fn test_union_round_trip_flatbuffer_with_nullability() {
+        let dtype = DType::Union(
+            UnionVariants::new_consecutive(
+                ["null_variant", "str"].into(),
+                vec![DType::Null, DType::Utf8(Nullability::NonNullable)],
+            )
+            .unwrap(),
+            Nullability::Nullable,
+        );
+        roundtrip_dtype(dtype);
+    }
+
+    #[test]
+    fn test_union_round_trip_flatbuffer_with_type_id_indirection() {
+        let dtype = DType::Union(
+            UnionVariants::try_new(
+                ["a", "b", "c"].into(),
+                vec![
+                    DType::Primitive(PType::I32, Nullability::NonNullable),
+                    DType::Utf8(Nullability::NonNullable),
+                    DType::Bool(Nullability::NonNullable),
+                ],
+                vec![0, 5, 7],
+            )
+            .unwrap(),
+            Nullability::NonNullable,
+        );
+
+        let bytes = dtype.write_flatbuffer_bytes().unwrap();
+        let root_fb = root::<fb::DType>(&bytes).unwrap();
+        let view = ViewedDType::from_fb_loc(
+            root_fb._tab.loc(),
+            FlatBuffer::from(bytes.clone()),
+            SESSION.clone(),
+        );
+
+        let deserialized = DType::try_from(view).unwrap();
+        assert_eq!(dtype, deserialized);
+        let DType::Union(uv, _) = &deserialized else {
+            panic!("Expected Union");
+        };
+        assert_eq!(uv.type_ids(), &[0, 5, 7]);
+    }
+
+    #[test]
+    fn test_nested_union_round_trip_flatbuffer() {
+        let inner_union = make_basic_union();
+        let struct_with_union = DType::Struct(
+            StructFields::from_iter([
+                ("id", DType::Primitive(PType::I64, Nullability::NonNullable)),
+                ("inner", inner_union),
+            ]),
+            Nullability::NonNullable,
+        );
+
+        let outer_union = DType::Union(
+            UnionVariants::new_consecutive(
+                ["plain", "nested"].into(),
+                vec![DType::Utf8(Nullability::NonNullable), struct_with_union],
+            )
+            .unwrap(),
+            Nullability::NonNullable,
+        );
+
+        roundtrip_dtype(outer_union);
+    }
+
+    /// A `UnionVariants` parsed lazily from a flatbuffer must compare equal to its eager
+    /// counterpart.
+    #[test]
+    fn test_union_viewed_dtype_equality() {
+        let eager = make_basic_union();
+
+        let bytes = eager.write_flatbuffer_bytes().unwrap();
+        let root_fb = root::<fb::DType>(&bytes).unwrap();
+        let view = ViewedDType::from_fb_loc(
+            root_fb._tab.loc(),
+            FlatBuffer::from(bytes.clone()),
+            SESSION.clone(),
+        );
+
+        let viewed = DType::try_from(view).unwrap();
+        assert_eq!(eager, viewed);
+        assert_eq!(viewed, eager);
+    }
+
+    /// A malformed flatbuffer (here, `dtypes.len() != type_ids.len()`) must round-trip
+    /// to `Err`, not panic.
+    #[test]
+    fn test_union_malformed_flatbuffer_errors() {
+        use flatbuffers::FlatBufferBuilder;
+        use vortex_buffer::ByteBuffer;
+        use vortex_flatbuffers::WriteFlatBuffer;
+
+        let mut fbb = FlatBufferBuilder::new();
+
+        // Build a Union with 2 names + 2 dtypes but only 1 type_id.
+        let name_a = fbb.create_string("a");
+        let name_b = fbb.create_string("b");
+        let names = fbb.create_vector(&[name_a, name_b]);
+
+        let dtype_a = DType::Primitive(PType::I32, Nullability::NonNullable)
+            .write_flatbuffer(&mut fbb)
+            .unwrap();
+        let dtype_b = DType::Utf8(Nullability::NonNullable)
+            .write_flatbuffer(&mut fbb)
+            .unwrap();
+        let dtypes = fbb.create_vector(&[dtype_a, dtype_b]);
+
+        let type_ids = fbb.create_vector::<i8>(&[0]);
+
+        let union_table = fb::Union::create(
+            &mut fbb,
+            &fb::UnionArgs {
+                names: Some(names),
+                dtypes: Some(dtypes),
+                type_ids: Some(type_ids),
+                nullable: false,
+            },
+        );
+
+        let dtype = fb::DType::create(
+            &mut fbb,
+            &fb::DTypeArgs {
+                type_type: fb::Type::Union,
+                type_: Some(union_table.as_union_value()),
+            },
+        );
+        fbb.finish_minimal(dtype);
+        let (vec, start) = fbb.collapse();
+        let end = vec.len();
+        let buffer = FlatBuffer::align_from(ByteBuffer::from(vec).slice(start..end));
+
+        let root_fb = root::<fb::DType>(&buffer).unwrap();
+        let view = ViewedDType::from_fb_loc(root_fb._tab.loc(), buffer, SESSION.clone());
+
+        let result = DType::try_from(view);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("length mismatch"));
     }
 }

--- a/vortex-array/src/dtype/serde/proto.rs
+++ b/vortex-array/src/dtype/serde/proto.rs
@@ -5,13 +5,16 @@ use std::sync::Arc;
 
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
+use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::dtype::StructFields;
+use crate::dtype::UnionVariants;
 use crate::dtype::extension::ExtId;
 use crate::dtype::extension::ForeignExtDType;
 use crate::dtype::field::Field;
@@ -55,7 +58,32 @@ impl DType {
                 ),
                 s.nullable.into(),
             )),
-            DtypeType::Union(u) => Ok(Self::Union(u.nullable.into())),
+            DtypeType::Union(u) => {
+                let names = u.names.iter().map(|s| s.as_str()).collect();
+                let dtypes = u
+                    .dtypes
+                    .iter()
+                    .map(|dt| DType::from_proto(dt, session))
+                    .collect::<VortexResult<Vec<_>>>()?;
+                let type_ids = u
+                    .type_ids
+                    .iter()
+                    .map(|t| {
+                        i8::try_from(*t)
+                            .map_err(|_| vortex_err!("Union type_id {t} does not fit in i8"))
+                    })
+                    .collect::<VortexResult<Vec<_>>>()?;
+                let variants = UnionVariants::try_new(names, dtypes, type_ids)?;
+
+                let nullability: Nullability = u.nullable.into();
+                vortex_ensure!(
+                    variants.nullability_constraints_satisfied(nullability),
+                    "Union nullability constraint not satisfied: nullability={:?}",
+                    nullability
+                );
+
+                Ok(Self::Union(variants, nullability))
+            }
             DtypeType::List(l) => {
                 let nullable = l.nullable.into();
                 Ok(Self::List(
@@ -142,7 +170,13 @@ impl TryFrom<&DType> for pb::DType {
                         .collect::<VortexResult<Vec<_>>>()?,
                     nullable: (*null).into(),
                 }),
-                DType::Union(null) => DtypeType::Union(pb::Union {
+                DType::Union(uv, null) => DtypeType::Union(pb::Union {
+                    names: uv.names().iter().map(|n| n.as_ref().to_string()).collect(),
+                    dtypes: uv
+                        .variants()
+                        .map(|d| Self::try_from(&d))
+                        .collect::<VortexResult<Vec<_>>>()?,
+                    type_ids: uv.type_ids().iter().map(|t| *t as i32).collect(),
                     nullable: (*null).into(),
                 }),
                 DType::List(edt, null) => DtypeType::List(Box::new(pb::List {
@@ -239,6 +273,7 @@ mod tests {
     use crate::dtype::Nullability;
     use crate::dtype::PType;
     use crate::dtype::StructFields;
+    use crate::dtype::UnionVariants;
     use crate::dtype::proto::dtype::d_type::DtypeType;
     use crate::dtype::proto::dtype::field::FieldType;
     use crate::dtype::test::SESSION;
@@ -379,6 +414,147 @@ mod tests {
     fn test_variant_round_trip() {
         let converted = round_trip_dtype(&DType::Variant(Nullability::Nullable));
         assert_eq!(DType::Variant(Nullability::Nullable), converted);
+    }
+
+    #[test]
+    fn test_union_round_trip_proto() {
+        let variants = UnionVariants::new_consecutive(
+            ["int", "str"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Utf8(Nullability::NonNullable),
+            ],
+        )
+        .unwrap();
+        let dtype = DType::Union(variants, Nullability::NonNullable);
+        let converted = round_trip_dtype(&dtype);
+        assert_eq!(dtype, converted);
+    }
+
+    #[test]
+    fn test_union_round_trip_proto_with_nullability() {
+        let variants = UnionVariants::new_consecutive(
+            ["null_variant", "str"].into(),
+            vec![DType::Null, DType::Utf8(Nullability::NonNullable)],
+        )
+        .unwrap();
+
+        assert!(variants.nullability_constraints_satisfied(Nullability::Nullable));
+        assert!(!variants.nullability_constraints_satisfied(Nullability::NonNullable));
+
+        let dtype = DType::Union(variants, Nullability::Nullable);
+        let converted = round_trip_dtype(&dtype);
+        assert_eq!(dtype, converted);
+    }
+
+    #[test]
+    fn test_union_round_trip_proto_with_type_id_indirection() {
+        let variants = UnionVariants::try_new(
+            ["a", "b", "c"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Utf8(Nullability::NonNullable),
+                DType::Bool(Nullability::NonNullable),
+            ],
+            vec![0, 5, 7],
+        )
+        .unwrap();
+
+        let dtype = DType::Union(variants, Nullability::NonNullable);
+        let converted = round_trip_dtype(&dtype);
+        assert_eq!(dtype, converted);
+
+        let DType::Union(uv, _) = &converted else {
+            panic!("Expected Union");
+        };
+        assert_eq!(uv.type_ids(), &[0, 5, 7]);
+        assert!(!uv.is_consecutive());
+    }
+
+    #[test]
+    fn test_union_proto_rejects_violating_nullability_constraint() {
+        // Nullable Union with no nullable or Null children must be rejected.
+        let proto = pb::DType {
+            dtype_type: Some(DtypeType::Union(pb::Union {
+                names: vec!["a".to_string(), "b".to_string()],
+                dtypes: vec![
+                    pb::DType::try_from(&DType::Primitive(PType::I32, Nullability::NonNullable))
+                        .unwrap(),
+                    pb::DType::try_from(&DType::Utf8(Nullability::NonNullable)).unwrap(),
+                ],
+                type_ids: vec![0, 1],
+                nullable: true,
+            })),
+        };
+
+        let result = DType::from_proto(&proto, &SESSION);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Union nullability constraint not satisfied")
+        );
+    }
+
+    #[test]
+    fn test_union_proto_rejects_out_of_range_type_id() {
+        let proto = pb::DType {
+            dtype_type: Some(DtypeType::Union(pb::Union {
+                names: vec!["a".to_string()],
+                dtypes: vec![
+                    pb::DType::try_from(&DType::Primitive(PType::I32, Nullability::NonNullable))
+                        .unwrap(),
+                ],
+                // 200 does not fit in i8.
+                type_ids: vec![200],
+                nullable: false,
+            })),
+        };
+
+        let result = DType::from_proto(&proto, &SESSION);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("does not fit in i8")
+        );
+    }
+
+    #[test]
+    fn test_nested_union_round_trip_proto() {
+        let inner_union = DType::Union(
+            UnionVariants::new_consecutive(
+                ["a", "b"].into(),
+                vec![
+                    DType::Primitive(PType::I32, Nullability::NonNullable),
+                    DType::Utf8(Nullability::NonNullable),
+                ],
+            )
+            .unwrap(),
+            Nullability::NonNullable,
+        );
+
+        let struct_with_union = DType::Struct(
+            StructFields::from_iter([
+                ("id", DType::Primitive(PType::I64, Nullability::NonNullable)),
+                ("inner", inner_union),
+            ]),
+            Nullability::NonNullable,
+        );
+
+        let outer_union = DType::Union(
+            UnionVariants::new_consecutive(
+                ["plain", "nested"].into(),
+                vec![DType::Utf8(Nullability::NonNullable), struct_with_union],
+            )
+            .unwrap(),
+            Nullability::NonNullable,
+        );
+
+        let converted = round_trip_dtype(&outer_union);
+        assert_eq!(outer_union, converted);
     }
 
     #[test]

--- a/vortex-array/src/dtype/serde/serde.rs
+++ b/vortex-array/src/dtype/serde/serde.rs
@@ -27,6 +27,7 @@ use crate::dtype::FieldNames;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::dtype::StructFields;
+use crate::dtype::UnionVariants;
 use crate::dtype::decimal::DecimalDType;
 use crate::dtype::extension::ExtDTypeRef;
 use crate::dtype::extension::ExtId;
@@ -115,7 +116,12 @@ impl Serialize for DType {
                 state.serialize_field(n)?;
                 state.end()
             }
-            DType::Union(n) => serializer.serialize_newtype_variant("DType", 11, "Union", n),
+            DType::Union(uv, n) => {
+                let mut state = serializer.serialize_tuple_variant("DType", 11, "Union", 2)?;
+                state.serialize_field(&uv)?;
+                state.serialize_field(n)?;
+                state.end()
+            }
             DType::Extension(ext) => {
                 serializer.serialize_newtype_variant("DType", 9, "Extension", ext)
             }
@@ -133,6 +139,20 @@ impl Serialize for StructFields {
         state.serialize_field("names", self.names())?;
         let dtypes: Vec<DType> = self.fields().collect();
         state.serialize_field("dtypes", &dtypes)?;
+        state.end()
+    }
+}
+
+impl Serialize for UnionVariants {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("UnionVariants", 3)?;
+        state.serialize_field("names", self.names())?;
+        let dtypes: Vec<DType> = self.variants().collect();
+        state.serialize_field("dtypes", &dtypes)?;
+        state.serialize_field("type_ids", self.type_ids())?;
         state.end()
     }
 }
@@ -217,10 +237,9 @@ impl<'de> DeserializeSeed<'de> for DTypeSerde<'_, DType> {
                     "Struct" => access.newtype_variant_seed(StructFieldsSeed {
                         session: self.session,
                     }),
-                    "Union" => {
-                        let n = access.newtype_variant()?;
-                        Ok(DType::Union(n))
-                    }
+                    "Union" => access.newtype_variant_seed(UnionVariantsSeed {
+                        session: self.session,
+                    }),
                     "Extension" => {
                         let ext = access
                             .newtype_variant_seed(DTypeSerde::<ExtDTypeRef>::new(self.session))?;
@@ -385,6 +404,132 @@ impl<'de> DeserializeSeed<'de> for StructFieldsSeed<'_> {
         deserializer.deserialize_tuple(
             2,
             StructVisitor {
+                session: self.session,
+            },
+        )
+    }
+}
+
+struct UnionVariantsSeed<'a> {
+    session: &'a VortexSession,
+}
+
+impl<'de> DeserializeSeed<'de> for UnionVariantsSeed<'_> {
+    type Value = DType;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct UnionVisitor<'a> {
+            session: &'a VortexSession,
+        }
+
+        impl<'de> Visitor<'de> for UnionVisitor<'_> {
+            type Value = DType;
+
+            fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                f.write_str("Union tuple (variants, nullability)")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let variants = seq
+                    .next_element_seed(DTypeSerde::<UnionVariants>::new(self.session))?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let nullability: Nullability = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                if !variants.nullability_constraints_satisfied(nullability) {
+                    return Err(de::Error::custom(format!(
+                        "Union nullability constraint not satisfied: nullability={:?}",
+                        nullability
+                    )));
+                }
+                Ok(DType::Union(variants, nullability))
+            }
+        }
+
+        deserializer.deserialize_tuple(
+            2,
+            UnionVisitor {
+                session: self.session,
+            },
+        )
+    }
+}
+
+impl<'de> DeserializeSeed<'de> for DTypeSerde<'_, UnionVariants> {
+    type Value = UnionVariants;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["names", "dtypes", "type_ids"];
+
+        struct UnionVariantsInnerVisitor<'a> {
+            session: &'a VortexSession,
+        }
+
+        impl<'de> Visitor<'de> for UnionVariantsInnerVisitor<'_> {
+            type Value = UnionVariants;
+
+            fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                f.write_str("struct UnionVariants")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut names: Option<FieldNames> = None;
+                let mut dtypes: Option<Vec<DType>> = None;
+                let mut type_ids: Option<Vec<i8>> = None;
+
+                while let Some(key) = map.next_key::<Cow<'_, str>>()? {
+                    match key.as_ref() {
+                        "names" => {
+                            if names.is_some() {
+                                return Err(de::Error::duplicate_field("names"));
+                            }
+                            names = Some(map.next_value()?);
+                        }
+                        "dtypes" => {
+                            if dtypes.is_some() {
+                                return Err(de::Error::duplicate_field("dtypes"));
+                            }
+                            dtypes = Some(
+                                map.next_value_seed(DTypeSerde::<Vec<DType>>::new(self.session))?,
+                            );
+                        }
+                        "type_ids" => {
+                            if type_ids.is_some() {
+                                return Err(de::Error::duplicate_field("type_ids"));
+                            }
+                            type_ids = Some(map.next_value()?);
+                        }
+                        _ => {
+                            let _ = map.next_value::<de::IgnoredAny>()?;
+                        }
+                    }
+                }
+
+                let names = names.ok_or_else(|| de::Error::missing_field("names"))?;
+                let dtypes = dtypes.ok_or_else(|| de::Error::missing_field("dtypes"))?;
+                let type_ids = type_ids.ok_or_else(|| de::Error::missing_field("type_ids"))?;
+
+                UnionVariants::try_new(names, dtypes, type_ids)
+                    .map_err(|e| de::Error::custom(e.to_string()))
+            }
+        }
+
+        deserializer.deserialize_struct(
+            "UnionVariants",
+            FIELDS,
+            UnionVariantsInnerVisitor {
                 session: self.session,
             },
         )

--- a/vortex-array/src/dtype/union.rs
+++ b/vortex-array/src/dtype/union.rs
@@ -1,0 +1,623 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::fmt;
+use std::hash::Hash;
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+use itertools::Itertools;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
+use vortex_error::vortex_ensure_eq;
+use vortex_utils::aliases::hash_map::HashMap;
+
+use crate::dtype::DType;
+use crate::dtype::FieldDType;
+use crate::dtype::FieldName;
+use crate::dtype::FieldNames;
+use crate::dtype::Nullability;
+
+/// Type information for a union array.
+///
+/// A `UnionVariants` describes the possible alternative types for each row of a union, along with a
+/// per-variant `i8` type tag. We use the term **variants** (rather than "fields") because a union
+/// is a sum type: each row chooses exactly one alternative.
+///
+/// Per Arrow's spec, the per-row type tag is an `int8`. By default, tag `i` selects the child at
+/// offset `i` (`type_ids = [0, 1, ..., N-1]`). Schemas may also use non-consecutive tags (e.g.
+/// `[0, 5, 7]`), in which case the value of `type_ids[i]` is the tag used in the data to select the
+/// child at offset `i`. Supporting non-consecutive tags from v1 lets the schema remove children
+/// without renumbering the remaining tags.
+///
+/// Variant names must be distinct. Unlike [`StructFields`](crate::dtype::StructFields), which
+/// permits duplicate field names for Arrow/Parquet round-trip fidelity, duplicates have no
+/// meaningful semantics in a sum type and are rejected at construction.
+///
+/// ```
+/// use vortex_array::dtype::{DType, Nullability, PType, UnionVariants};
+///
+/// let variants = UnionVariants::new_consecutive(
+///     ["a", "b"].into(),
+///     vec![
+///         DType::Primitive(PType::I32, Nullability::NonNullable),
+///         DType::Utf8(Nullability::NonNullable),
+///     ],
+/// )
+/// .unwrap();
+///
+/// assert_eq!(variants.len(), 2);
+/// assert_eq!(variants.type_ids(), &[0, 1]);
+/// ```
+#[allow(
+    clippy::derived_hash_with_manual_eq,
+    reason = "manual PartialEq adds Arc::ptr_eq fast path only"
+)]
+#[derive(Clone, Eq, Hash)]
+pub struct UnionVariants(Arc<UnionVariantsInner>);
+
+impl PartialEq for UnionVariants {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0) || self.0 == other.0
+    }
+}
+
+impl fmt::Debug for UnionVariants {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnionVariants")
+            .field("names", &self.0.names)
+            .field("dtypes", &self.0.dtypes)
+            .field("type_ids", &self.0.type_ids)
+            .finish()
+    }
+}
+
+impl fmt::Display for UnionVariants {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Surface non-consecutive type tags so they aren't hidden by the format. Consecutive
+        // `[0, 1, ..., N-1]` is the common case and is left implicit.
+        let show_tags = !self.is_consecutive();
+        write!(
+            f,
+            "{}",
+            self.names()
+                .iter()
+                .zip(self.variants())
+                .zip(self.type_ids().iter())
+                .map(|((name, dt), tag)| {
+                    if show_tags {
+                        format!("{name}@{tag}={dt}")
+                    } else {
+                        format!("{name}={dt}")
+                    }
+                })
+                .join(", ")
+        )
+    }
+}
+
+struct UnionVariantsInner {
+    /// The names of the variants. This is called `FieldNames` because it is shared with the
+    /// [`StructFields`](crate::dtype::StructFields) implementation.
+    names: FieldNames,
+
+    /// The types of each of the variants.
+    dtypes: Arc<[FieldDType]>,
+
+    /// One tag per variant, in variant order. The common case where children are referenced by
+    /// consecutive offsets is `[0, 1, ..., N-1]`.
+    ///
+    /// For schemas with explicit `typeIds` indirection (e.g. `[0, 5, 7]`), this stores those tags.
+    type_ids: Arc<[i8]>,
+
+    /// Derived from `names`, maps from variant name to index.
+    /// This is excluded from the `PartialEq`, `Eq`, `Hash`, and serde serialization.
+    indices: OnceLock<HashMap<FieldName, usize>>,
+}
+
+impl UnionVariantsInner {
+    fn from_fields(names: FieldNames, dtypes: Arc<[FieldDType]>, type_ids: Arc<[i8]>) -> Self {
+        Self {
+            names,
+            dtypes,
+            type_ids,
+            indices: OnceLock::new(),
+        }
+    }
+
+    fn indices(&self) -> &HashMap<FieldName, usize> {
+        self.indices.get_or_init(|| {
+            // Uniqueness is enforced by `validate_shape`, so a plain `insert` is safe.
+            let mut map = HashMap::with_capacity(self.names.len());
+            for (idx, name) in self.names.iter().enumerate() {
+                map.insert(name.clone(), idx);
+            }
+            map
+        })
+    }
+}
+
+impl PartialEq for UnionVariantsInner {
+    fn eq(&self, other: &Self) -> bool {
+        self.names == other.names && self.dtypes == other.dtypes && self.type_ids == other.type_ids
+    }
+}
+
+impl Eq for UnionVariantsInner {}
+
+impl Hash for UnionVariantsInner {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.names.hash(state);
+        self.dtypes.hash(state);
+        self.type_ids.hash(state);
+    }
+}
+
+impl Default for UnionVariants {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl UnionVariants {
+    /// The variants of the empty union.
+    pub fn empty() -> Self {
+        Self(Arc::new(UnionVariantsInner::from_fields(
+            FieldNames::default(),
+            Arc::from([]),
+            Arc::from([]),
+        )))
+    }
+
+    /// Validate that `names`, `dtypes`, and `type_ids` are mutually consistent.
+    fn validate_shape(names: &FieldNames, n_dtypes: usize, type_ids: &[i8]) -> VortexResult<()> {
+        vortex_ensure_eq!(
+            names.len(),
+            n_dtypes,
+            "length mismatch between names ({}) and dtypes ({})",
+            names.len(),
+            n_dtypes
+        );
+        vortex_ensure_eq!(
+            names.len(),
+            type_ids.len(),
+            "length mismatch between names ({}) and type_ids ({})",
+            names.len(),
+            type_ids.len()
+        );
+
+        vortex_ensure!(
+            type_ids.iter().all_unique(),
+            "type_ids must be distinct, got {:?}",
+            type_ids
+        );
+        vortex_ensure!(
+            names.iter().all_unique(),
+            "union variant names must be distinct, got {:?}",
+            names
+        );
+
+        Ok(())
+    }
+
+    /// Create a new [`UnionVariants`] with explicit `type_ids`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if names, dtypes, or type IDs do not all have the same length, or if there
+    /// are any duplicate names or type ids.
+    pub fn try_new(names: FieldNames, dtypes: Vec<DType>, type_ids: Vec<i8>) -> VortexResult<Self> {
+        Self::validate_shape(&names, dtypes.len(), &type_ids)?;
+
+        let dtypes: Arc<[FieldDType]> = dtypes.into_iter().map(FieldDType::from).collect();
+        let type_ids: Arc<[i8]> = Arc::from(type_ids);
+
+        Ok(Self(Arc::new(UnionVariantsInner::from_fields(
+            names, dtypes, type_ids,
+        ))))
+    }
+
+    /// Create a new [`UnionVariants`] with consecutive `type_ids = [0, 1, ..., N-1]`.
+    ///
+    /// # Errors
+    ///
+    /// `names` and `dtypes` must have the same length, and `names.len()` cannot be more than
+    /// `i8::MAX as usize + 1` (128).
+    pub fn new_consecutive(names: FieldNames, dtypes: Vec<DType>) -> VortexResult<Self> {
+        const MAX_CONSECUTIVE: usize = i8::MAX as usize + 1;
+        vortex_ensure!(
+            names.len() <= MAX_CONSECUTIVE,
+            "union supports at most {} consecutive variants, got {}",
+            MAX_CONSECUTIVE,
+            names.len()
+        );
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "the MAX_CONSECUTIVE bound above guarantees `i as i8` is in range"
+        )]
+        let type_ids: Vec<i8> = (0..names.len()).map(|i| i as i8).collect();
+
+        Self::try_new(names, dtypes, type_ids)
+    }
+
+    /// Create a new [`UnionVariants`] from pre-constructed [`FieldDType`]s, which may be owned or
+    /// backed by a flatbuffer view.
+    ///
+    /// Used by deserialization paths where the children may be lazily backed by a flatbuffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if names, dtypes, or type IDs do not all have the same length, or if there
+    /// are any duplicate names or type ids.
+    pub(crate) fn try_from_fields(
+        names: FieldNames,
+        dtypes: Vec<FieldDType>,
+        type_ids: Vec<i8>,
+    ) -> VortexResult<Self> {
+        Self::validate_shape(&names, dtypes.len(), &type_ids)?;
+
+        Ok(Self(Arc::new(UnionVariantsInner::from_fields(
+            names,
+            dtypes.into(),
+            Arc::from(type_ids),
+        ))))
+    }
+
+    /// Get the names of the variants in the union.
+    pub fn names(&self) -> &FieldNames {
+        &self.0.names
+    }
+
+    /// Returns the number of variants in the union.
+    pub fn len(&self) -> usize {
+        self.0.names.len()
+    }
+
+    /// Returns true if the union has no variants.
+    pub fn is_empty(&self) -> bool {
+        self.0.names.is_empty()
+    }
+
+    /// Returns the per-variant type tag vector. Entry `i` is the tag that the data uses to
+    /// select the variant at offset `i`.
+    pub fn type_ids(&self) -> &[i8] {
+        &self.0.type_ids
+    }
+
+    /// Returns `true` if the type tags are the consecutive sequence `[0, 1, ..., N-1]`.
+    pub fn is_consecutive(&self) -> bool {
+        self.0
+            .type_ids
+            .iter()
+            .enumerate()
+            .all(|(i, &tag)| i8::try_from(i).is_ok_and(|i| i == tag))
+    }
+
+    /// Find the offset of a variant by name. Returns `None` if no variant has the name.
+    pub fn find(&self, name: impl AsRef<str>) -> Option<usize> {
+        self.0.indices().get(name.as_ref()).copied()
+    }
+
+    /// Get the [`DType`] of a variant by name. Returns `None` if no variant has the name.
+    pub fn variant(&self, name: impl AsRef<str>) -> Option<DType> {
+        let index = self.find(name)?;
+        Some(
+            self.0.dtypes[index]
+                .value()
+                .vortex_expect("variant DType must be valid"),
+        )
+    }
+
+    /// Get the [`DType`] of a variant by offset.
+    pub fn variant_by_index(&self, index: usize) -> Option<DType> {
+        Some(
+            self.0
+                .dtypes
+                .get(index)?
+                .value()
+                .vortex_expect("variant DType must be valid"),
+        )
+    }
+
+    /// Returns an ordered iterator over the variants.
+    pub fn variants(&self) -> impl ExactSizeIterator<Item = DType> + '_ {
+        self.0
+            .dtypes
+            .iter()
+            .map(|dt| dt.value().vortex_expect("variant DType must be valid"))
+    }
+
+    /// Convert a data-level type tag to a child offset. Returns `None` if the tag is not in
+    /// `type_ids`.
+    ///
+    /// This is a linear scan over [`Self::type_ids`]. The number of variants is bounded by
+    /// `i8::MAX + 1 = 128`, which fits in two cache lines, so a linear scan is faster than a
+    /// `HashMap` lookup in practice.
+    pub fn tag_to_child_index(&self, tag: i8) -> Option<usize> {
+        self.0.type_ids.iter().position(|&t| t == tag)
+    }
+
+    /// Convert a child offset to its data-level type tag.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index >= self.len()`.
+    pub fn child_index_to_tag(&self, index: usize) -> i8 {
+        self.0.type_ids[index]
+    }
+
+    /// Checks whether this set of variants satisfies the constraint imposed by a union-level
+    /// `Nullability`:
+    ///
+    /// - `Nullable`: at least one variant is `DType::Null` or has nullable nullability.
+    /// - `NonNullable`: no `DType::Null` variants and no nullable variants.
+    ///
+    /// The check materializes each [`FieldDType`] (so it may be expensive if some are still
+    /// flatbuffer-backed views).
+    ///
+    /// It is intentionally not part of `UnionVariants` construction since `Nullability` lives on
+    /// the `DType::Union(_, Nullability)` enum variant, not on `UnionVariants` itself.
+    pub fn nullability_constraints_satisfied(&self, union_nullability: Nullability) -> bool {
+        let has_null_or_nullable = self
+            .variants()
+            .any(|dt| matches!(dt, DType::Null) || dt.is_nullable());
+
+        match union_nullability {
+            Nullability::Nullable => has_null_or_nullable,
+            Nullability::NonNullable => !has_null_or_nullable,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::dtype::DType;
+    use crate::dtype::FieldNames;
+    use crate::dtype::Nullability;
+    use crate::dtype::PType;
+    use crate::dtype::UnionVariants;
+
+    fn i32_variants() -> UnionVariants {
+        UnionVariants::new_consecutive(
+            ["int", "str"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Utf8(Nullability::NonNullable),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_consecutive_type_ids() {
+        let variants = i32_variants();
+        assert_eq!(variants.type_ids(), &[0, 1]);
+        assert!(variants.is_consecutive());
+        assert_eq!(variants.tag_to_child_index(0), Some(0));
+        assert_eq!(variants.tag_to_child_index(1), Some(1));
+        assert_eq!(variants.tag_to_child_index(2), None);
+        assert_eq!(variants.child_index_to_tag(0), 0);
+        assert_eq!(variants.child_index_to_tag(1), 1);
+    }
+
+    #[test]
+    fn test_type_id_indirection() {
+        let variants = UnionVariants::try_new(
+            ["a", "b", "c"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Utf8(Nullability::NonNullable),
+                DType::Bool(Nullability::NonNullable),
+            ],
+            vec![0, 5, 7],
+        )
+        .unwrap();
+
+        assert_eq!(variants.type_ids(), &[0, 5, 7]);
+        assert!(!variants.is_consecutive());
+        assert_eq!(variants.tag_to_child_index(0), Some(0));
+        assert_eq!(variants.tag_to_child_index(5), Some(1));
+        assert_eq!(variants.tag_to_child_index(7), Some(2));
+        assert_eq!(variants.tag_to_child_index(1), None);
+    }
+
+    #[test]
+    fn test_find() {
+        let variants = i32_variants();
+        assert_eq!(variants.find("int"), Some(0));
+        assert_eq!(variants.find("str"), Some(1));
+        assert!(variants.find("missing").is_none());
+
+        let value = variants.variant("int").unwrap();
+        assert_eq!(
+            value,
+            DType::Primitive(PType::I32, Nullability::NonNullable)
+        );
+    }
+
+    #[test]
+    fn test_duplicate_names_rejected() {
+        let result = UnionVariants::new_consecutive(
+            ["dup", "dup"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Primitive(PType::I64, Nullability::NonNullable),
+            ],
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("distinct"));
+    }
+
+    #[test]
+    fn test_length_mismatch_rejected() {
+        let result = UnionVariants::try_new(
+            ["a", "b"].into(),
+            vec![DType::Primitive(PType::I32, Nullability::NonNullable)],
+            vec![0, 1],
+        );
+        assert!(result.is_err());
+
+        let result = UnionVariants::try_new(
+            ["a"].into(),
+            vec![DType::Primitive(PType::I32, Nullability::NonNullable)],
+            vec![0, 1],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_duplicate_type_ids_rejected() {
+        let result = UnionVariants::try_new(
+            ["a", "b"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Utf8(Nullability::NonNullable),
+            ],
+            vec![3, 3],
+        );
+        assert!(result.is_err());
+    }
+
+    #[rstest]
+    #[case::nullable_with_null_child(
+        vec![
+            DType::Null,
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+        ],
+        Nullability::Nullable,
+        true,
+    )]
+    #[case::nullable_with_nullable_child(
+        vec![
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+            DType::Utf8(Nullability::Nullable),
+        ],
+        Nullability::Nullable,
+        true,
+    )]
+    #[case::nullable_with_no_null_or_nullable(
+        vec![
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+            DType::Utf8(Nullability::NonNullable),
+        ],
+        Nullability::Nullable,
+        false,
+    )]
+    #[case::nonnullable_with_null_child(
+        vec![
+            DType::Null,
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+        ],
+        Nullability::NonNullable,
+        false,
+    )]
+    #[case::nonnullable_with_nullable_child(
+        vec![
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+            DType::Utf8(Nullability::Nullable),
+        ],
+        Nullability::NonNullable,
+        false,
+    )]
+    #[case::nonnullable_clean(
+        vec![
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+            DType::Utf8(Nullability::NonNullable),
+        ],
+        Nullability::NonNullable,
+        true,
+    )]
+    fn test_nullability_constraints(
+        #[case] dtypes: Vec<DType>,
+        #[case] nullability: Nullability,
+        #[case] expected: bool,
+    ) {
+        let names: Vec<&str> = (0..dtypes.len()).map(|i| ["a", "b", "c", "d"][i]).collect();
+        let variants = UnionVariants::new_consecutive(names.as_slice().into(), dtypes).unwrap();
+        assert_eq!(
+            variants.nullability_constraints_satisfied(nullability),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_display() {
+        let variants = i32_variants();
+        let dtype = DType::Union(variants, Nullability::NonNullable);
+        assert_eq!(dtype.to_string(), "union(int=i32, str=utf8)");
+
+        let nullable = DType::Union(
+            UnionVariants::new_consecutive(
+                ["int", "maybe_str"].into(),
+                vec![
+                    DType::Primitive(PType::I32, Nullability::NonNullable),
+                    DType::Utf8(Nullability::Nullable),
+                ],
+            )
+            .unwrap(),
+            Nullability::Nullable,
+        );
+        assert_eq!(nullable.to_string(), "union(int=i32, maybe_str=utf8?)?");
+    }
+
+    #[test]
+    fn test_display_with_type_id_indirection() {
+        let variants = UnionVariants::try_new(
+            ["a", "b", "c"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Utf8(Nullability::NonNullable),
+                DType::Bool(Nullability::NonNullable),
+            ],
+            vec![0, 5, 7],
+        )
+        .unwrap();
+        let dtype = DType::Union(variants, Nullability::NonNullable);
+        assert_eq!(dtype.to_string(), "union(a@0=i32, b@5=utf8, c@7=bool)");
+    }
+
+    #[test]
+    fn test_new_consecutive_max_size() {
+        // 128 variants is the maximum for consecutive type_ids: tags 0..=127 all fit in i8.
+        let names: Vec<String> = (0..128).map(|i| format!("v{i}")).collect();
+        let dtypes: Vec<DType> = (0..128)
+            .map(|_| DType::Primitive(PType::I32, Nullability::NonNullable))
+            .collect();
+        let names: FieldNames = names.into_iter().collect();
+        let variants = UnionVariants::new_consecutive(names, dtypes).unwrap();
+        assert_eq!(variants.len(), 128);
+        assert_eq!(variants.type_ids()[127], 127);
+        assert!(variants.is_consecutive());
+    }
+
+    #[test]
+    fn test_new_consecutive_too_large_rejected() {
+        // 129 variants exceeds i8::MAX + 1 = 128.
+        let names: Vec<String> = (0..129).map(|i| format!("v{i}")).collect();
+        let dtypes: Vec<DType> = (0..129)
+            .map(|_| DType::Primitive(PType::I32, Nullability::NonNullable))
+            .collect();
+        let names: FieldNames = names.into_iter().collect();
+        let result = UnionVariants::new_consecutive(names, dtypes);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("at most 128 consecutive variants")
+        );
+    }
+
+    #[test]
+    fn test_empty() {
+        let v = UnionVariants::empty();
+        assert!(v.is_empty());
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.type_ids(), &[] as &[i8]);
+        assert!(v.is_consecutive());
+    }
+}

--- a/vortex-flatbuffers/flatbuffers/vortex-dtype/dtype.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-dtype/dtype.fbs
@@ -68,6 +68,9 @@ table Variant {
 }
 
 table Union {
+    names: [string];
+    dtypes: [DType];
+    type_ids: [byte]; // length must equal dtypes.len()
     nullable: bool;
 }
 

--- a/vortex-flatbuffers/public-api.lock
+++ b/vortex-flatbuffers/public-api.lock
@@ -1462,13 +1462,25 @@ pub vortex_flatbuffers::dtype::Union::_tab: flatbuffers::table::Table<'a>
 
 impl<'a> vortex_flatbuffers::dtype::Union<'a>
 
+pub const vortex_flatbuffers::dtype::Union<'a>::VT_DTYPES: flatbuffers::primitives::VOffsetT
+
+pub const vortex_flatbuffers::dtype::Union<'a>::VT_NAMES: flatbuffers::primitives::VOffsetT
+
 pub const vortex_flatbuffers::dtype::Union<'a>::VT_NULLABLE: flatbuffers::primitives::VOffsetT
 
-pub fn vortex_flatbuffers::dtype::Union<'a>::create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::builder::Allocator + 'bldr>(&'mut_bldr mut flatbuffers::builder::FlatBufferBuilder<'bldr, A>, &'args vortex_flatbuffers::dtype::UnionArgs) -> flatbuffers::primitives::WIPOffset<vortex_flatbuffers::dtype::Union<'bldr>>
+pub const vortex_flatbuffers::dtype::Union<'a>::VT_TYPE_IDS: flatbuffers::primitives::VOffsetT
+
+pub fn vortex_flatbuffers::dtype::Union<'a>::create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::builder::Allocator + 'bldr>(&'mut_bldr mut flatbuffers::builder::FlatBufferBuilder<'bldr, A>, &'args vortex_flatbuffers::dtype::UnionArgs<'args>) -> flatbuffers::primitives::WIPOffset<vortex_flatbuffers::dtype::Union<'bldr>>
+
+pub fn vortex_flatbuffers::dtype::Union<'a>::dtypes(&self) -> core::option::Option<flatbuffers::vector::Vector<'a, flatbuffers::primitives::ForwardsUOffset<vortex_flatbuffers::dtype::DType<'a>>>>
 
 pub unsafe fn vortex_flatbuffers::dtype::Union<'a>::init_from_table(flatbuffers::table::Table<'a>) -> Self
 
+pub fn vortex_flatbuffers::dtype::Union<'a>::names(&self) -> core::option::Option<flatbuffers::vector::Vector<'a, flatbuffers::primitives::ForwardsUOffset<&'a str>>>
+
 pub fn vortex_flatbuffers::dtype::Union<'a>::nullable(&self) -> bool
+
+pub fn vortex_flatbuffers::dtype::Union<'a>::type_ids(&self) -> core::option::Option<flatbuffers::vector::Vector<'a, i8>>
 
 impl core::fmt::Debug for vortex_flatbuffers::dtype::Union<'_>
 
@@ -1496,19 +1508,31 @@ pub type vortex_flatbuffers::dtype::Union<'a>::Inner = vortex_flatbuffers::dtype
 
 pub unsafe fn vortex_flatbuffers::dtype::Union<'a>::follow(&'a [u8], usize) -> Self::Inner
 
-pub struct vortex_flatbuffers::dtype::UnionArgs
+pub struct vortex_flatbuffers::dtype::UnionArgs<'a>
+
+pub vortex_flatbuffers::dtype::UnionArgs::dtypes: core::option::Option<flatbuffers::primitives::WIPOffset<flatbuffers::vector::Vector<'a, flatbuffers::primitives::ForwardsUOffset<vortex_flatbuffers::dtype::DType<'a>>>>>
+
+pub vortex_flatbuffers::dtype::UnionArgs::names: core::option::Option<flatbuffers::primitives::WIPOffset<flatbuffers::vector::Vector<'a, flatbuffers::primitives::ForwardsUOffset<&'a str>>>>
 
 pub vortex_flatbuffers::dtype::UnionArgs::nullable: bool
 
-impl<'a> core::default::Default for vortex_flatbuffers::dtype::UnionArgs
+pub vortex_flatbuffers::dtype::UnionArgs::type_ids: core::option::Option<flatbuffers::primitives::WIPOffset<flatbuffers::vector::Vector<'a, i8>>>
 
-pub fn vortex_flatbuffers::dtype::UnionArgs::default() -> Self
+impl<'a> core::default::Default for vortex_flatbuffers::dtype::UnionArgs<'a>
+
+pub fn vortex_flatbuffers::dtype::UnionArgs<'a>::default() -> Self
 
 pub struct vortex_flatbuffers::dtype::UnionBuilder<'a: 'b, 'b, A: flatbuffers::builder::Allocator + 'a>
 
 impl<'a: 'b, 'b, A: flatbuffers::builder::Allocator + 'a> vortex_flatbuffers::dtype::UnionBuilder<'a, 'b, A>
 
+pub fn vortex_flatbuffers::dtype::UnionBuilder<'a, 'b, A>::add_dtypes(&mut self, flatbuffers::primitives::WIPOffset<flatbuffers::vector::Vector<'b, flatbuffers::primitives::ForwardsUOffset<vortex_flatbuffers::dtype::DType<'b>>>>)
+
+pub fn vortex_flatbuffers::dtype::UnionBuilder<'a, 'b, A>::add_names(&mut self, flatbuffers::primitives::WIPOffset<flatbuffers::vector::Vector<'b, flatbuffers::primitives::ForwardsUOffset<&'b str>>>)
+
 pub fn vortex_flatbuffers::dtype::UnionBuilder<'a, 'b, A>::add_nullable(&mut self, bool)
+
+pub fn vortex_flatbuffers::dtype::UnionBuilder<'a, 'b, A>::add_type_ids(&mut self, flatbuffers::primitives::WIPOffset<flatbuffers::vector::Vector<'b, i8>>)
 
 pub fn vortex_flatbuffers::dtype::UnionBuilder<'a, 'b, A>::finish(self) -> flatbuffers::primitives::WIPOffset<vortex_flatbuffers::dtype::Union<'a>>
 

--- a/vortex-flatbuffers/src/generated/dtype.rs
+++ b/vortex-flatbuffers/src/generated/dtype.rs
@@ -1477,7 +1477,10 @@ impl<'a> ::flatbuffers::Follow<'a> for Union<'a> {
 }
 
 impl<'a> Union<'a> {
-  pub const VT_NULLABLE: ::flatbuffers::VOffsetT = 4;
+  pub const VT_NAMES: ::flatbuffers::VOffsetT = 4;
+  pub const VT_DTYPES: ::flatbuffers::VOffsetT = 6;
+  pub const VT_TYPE_IDS: ::flatbuffers::VOffsetT = 8;
+  pub const VT_NULLABLE: ::flatbuffers::VOffsetT = 10;
 
   #[inline]
   pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
@@ -1486,14 +1489,38 @@ impl<'a> Union<'a> {
   #[allow(unused_mut)]
   pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: ::flatbuffers::Allocator + 'bldr>(
     _fbb: &'mut_bldr mut ::flatbuffers::FlatBufferBuilder<'bldr, A>,
-    args: &'args UnionArgs
+    args: &'args UnionArgs<'args>
   ) -> ::flatbuffers::WIPOffset<Union<'bldr>> {
     let mut builder = UnionBuilder::new(_fbb);
+    if let Some(x) = args.type_ids { builder.add_type_ids(x); }
+    if let Some(x) = args.dtypes { builder.add_dtypes(x); }
+    if let Some(x) = args.names { builder.add_names(x); }
     builder.add_nullable(args.nullable);
     builder.finish()
   }
 
 
+  #[inline]
+  pub fn names(&self) -> Option<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<&'a str>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<&'a str>>>>(Union::VT_NAMES, None)}
+  }
+  #[inline]
+  pub fn dtypes(&self) -> Option<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<DType<'a>>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<DType>>>>(Union::VT_DTYPES, None)}
+  }
+  #[inline]
+  pub fn type_ids(&self) -> Option<::flatbuffers::Vector<'a, i8>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'a, i8>>>(Union::VT_TYPE_IDS, None)}
+  }
   #[inline]
   pub fn nullable(&self) -> bool {
     // Safety:
@@ -1509,18 +1536,27 @@ impl ::flatbuffers::Verifiable for Union<'_> {
     v: &mut ::flatbuffers::Verifier, pos: usize
   ) -> Result<(), ::flatbuffers::InvalidFlatbuffer> {
     v.visit_table(pos)?
+     .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, ::flatbuffers::ForwardsUOffset<&'_ str>>>>("names", Self::VT_NAMES, false)?
+     .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, ::flatbuffers::ForwardsUOffset<DType>>>>("dtypes", Self::VT_DTYPES, false)?
+     .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, i8>>>("type_ids", Self::VT_TYPE_IDS, false)?
      .visit_field::<bool>("nullable", Self::VT_NULLABLE, false)?
      .finish();
     Ok(())
   }
 }
-pub struct UnionArgs {
+pub struct UnionArgs<'a> {
+    pub names: Option<::flatbuffers::WIPOffset<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<&'a str>>>>,
+    pub dtypes: Option<::flatbuffers::WIPOffset<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<DType<'a>>>>>,
+    pub type_ids: Option<::flatbuffers::WIPOffset<::flatbuffers::Vector<'a, i8>>>,
     pub nullable: bool,
 }
-impl<'a> Default for UnionArgs {
+impl<'a> Default for UnionArgs<'a> {
   #[inline]
   fn default() -> Self {
     UnionArgs {
+      names: None,
+      dtypes: None,
+      type_ids: None,
       nullable: false,
     }
   }
@@ -1531,6 +1567,18 @@ pub struct UnionBuilder<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> {
   start_: ::flatbuffers::WIPOffset<::flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> UnionBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_names(&mut self, names: ::flatbuffers::WIPOffset<::flatbuffers::Vector<'b , ::flatbuffers::ForwardsUOffset<&'b  str>>>) {
+    self.fbb_.push_slot_always::<::flatbuffers::WIPOffset<_>>(Union::VT_NAMES, names);
+  }
+  #[inline]
+  pub fn add_dtypes(&mut self, dtypes: ::flatbuffers::WIPOffset<::flatbuffers::Vector<'b , ::flatbuffers::ForwardsUOffset<DType<'b >>>>) {
+    self.fbb_.push_slot_always::<::flatbuffers::WIPOffset<_>>(Union::VT_DTYPES, dtypes);
+  }
+  #[inline]
+  pub fn add_type_ids(&mut self, type_ids: ::flatbuffers::WIPOffset<::flatbuffers::Vector<'b , i8>>) {
+    self.fbb_.push_slot_always::<::flatbuffers::WIPOffset<_>>(Union::VT_TYPE_IDS, type_ids);
+  }
   #[inline]
   pub fn add_nullable(&mut self, nullable: bool) {
     self.fbb_.push_slot::<bool>(Union::VT_NULLABLE, nullable, false);
@@ -1553,6 +1601,9 @@ impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> UnionBuilder<'a, 'b, A> {
 impl ::core::fmt::Debug for Union<'_> {
   fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
     let mut ds = f.debug_struct("Union");
+      ds.field("names", &self.names());
+      ds.field("dtypes", &self.dtypes());
+      ds.field("type_ids", &self.type_ids());
       ds.field("nullable", &self.nullable());
       ds.finish()
   }

--- a/vortex-flatbuffers/src/generated/message.rs
+++ b/vortex-flatbuffers/src/generated/message.rs
@@ -2,8 +2,8 @@
 // @generated
 extern crate alloc;
 
-use crate::array::*;
 use crate::dtype::*;
+use crate::array::*;
 
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 pub const ENUM_MIN_MESSAGE_VERSION: u8 = 0;

--- a/vortex-proto/proto/dtype.proto
+++ b/vortex-proto/proto/dtype.proto
@@ -75,6 +75,9 @@ message Variant {
 }
 
 message Union {
+  repeated string names = 1;
+  repeated DType dtypes = 2;
+  repeated int32 type_ids = 3; // length must equal dtypes.len(); each value must fit in int8
   bool nullable = 4;
 }
 

--- a/vortex-proto/public-api.lock
+++ b/vortex-proto/public-api.lock
@@ -578,13 +578,17 @@ pub fn vortex_proto::dtype::Struct::encoded_len(&self) -> usize
 
 pub struct vortex_proto::dtype::Union
 
+pub vortex_proto::dtype::Union::dtypes: alloc::vec::Vec<vortex_proto::dtype::DType>
+
+pub vortex_proto::dtype::Union::names: alloc::vec::Vec<alloc::string::String>
+
 pub vortex_proto::dtype::Union::nullable: bool
+
+pub vortex_proto::dtype::Union::type_ids: alloc::vec::Vec<i32>
 
 impl core::clone::Clone for vortex_proto::dtype::Union
 
 pub fn vortex_proto::dtype::Union::clone(&self) -> vortex_proto::dtype::Union
-
-impl core::cmp::Eq for vortex_proto::dtype::Union
 
 impl core::cmp::PartialEq for vortex_proto::dtype::Union
 
@@ -597,12 +601,6 @@ pub fn vortex_proto::dtype::Union::default() -> Self
 impl core::fmt::Debug for vortex_proto::dtype::Union
 
 pub fn vortex_proto::dtype::Union::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::hash::Hash for vortex_proto::dtype::Union
-
-pub fn vortex_proto::dtype::Union::hash<__H: core::hash::Hasher>(&self, &mut __H)
-
-impl core::marker::Copy for vortex_proto::dtype::Union
 
 impl core::marker::StructuralPartialEq for vortex_proto::dtype::Union
 

--- a/vortex-proto/src/generated/vortex.dtype.rs
+++ b/vortex-proto/src/generated/vortex.dtype.rs
@@ -71,8 +71,15 @@ pub struct Variant {
     #[prost(bool, tag = "1")]
     pub nullable: bool,
 }
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Union {
+    #[prost(string, repeated, tag = "1")]
+    pub names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag = "2")]
+    pub dtypes: ::prost::alloc::vec::Vec<DType>,
+    /// length must equal dtypes.len(); each value must fit in int8
+    #[prost(int32, repeated, tag = "3")]
+    pub type_ids: ::prost::alloc::vec::Vec<i32>,
     #[prost(bool, tag = "4")]
     pub nullable: bool,
 }


### PR DESCRIPTION
## Summary

Tracking issue: https://github.com/vortex-data/vortex/issues/7882

Replaces `DType::Union(Nullability)` with `DType::Union(UnionVariants, Nullability)`. 

`UnionVariants` carries a `FieldNames` list, per-variant `FieldDType`s, and an `i8` type-id vector (supporting non-consecutive tags like `[0, 5, 7]` so children can be removed without renumbering). We use `i8` because that is what arrow uses, and because there is already a max of 128 different union variants for any given array.

A lot of the code is essentially duplicated from implementations of Struct. It could have been nice if we could reuse StructFields, but we need to additionally store a type IDs field that maps the different variant types to tag indexes (i.e. 0, 1, 2, 5), so we might as well have a new type for this that is named more appropriately.

Also note that the tags do not have to be consecutive (to support potential schema evolution, and also it does make things like casts easier).

I've also enforced that variant names are distinct. The Arrow spec does not make any guarantee about this, but I've chosen the sane path that DuckDB also [chooses](https://duckdb.org/docs/current/sql/data_types/union).

I'm going to guess that some of us will want to just allow duplicate variant names, so we should just discuss below.

## API Changes

Changes `DType::Union` to carry `UnionVariants`.

## Testing

Some basic roundtrip testing for the serialization formats.
