### PR TITLE
fix[gpu]: CUDA sliced patch views with device patches

### DIFF
--- a/vortex-cuda/kernels/src/dynamic_dispatch.cu
+++ b/vortex-cuda/kernels/src/dynamic_dispatch.cu
@@ -171,9 +171,6 @@ scalar_op(T *values, const struct ScalarOp &op, char *__restrict smem, uint64_t 
         // straddle two FL chunks, so each value needs its own lookup.
         if (op.params.alp.patches_ptr != 0) {
             const auto &patches = *reinterpret_cast<const GPUPatches *>(op.params.alp.patches_ptr);
-            // The sliced chunk_offsets array starts at original chunk
-            // (offset / FL_CHUNK). PatchesCursor indexes from 0, so
-            // subtract that base to get the index into chunk_offsets.
             const uint32_t chunk_start = patches.offset / FL_CHUNK;
 #pragma unroll
             for (uint32_t i = 0; i < N; ++i) {

--- a/vortex-cuda/kernels/src/patches.cuh
+++ b/vortex-cuda/kernels/src/patches.cuh
@@ -56,23 +56,33 @@ public:
             return;
         }
 
-        // mirrors the logic from vortex-array/src/arrays/primitive/array/patch.rs
+        if (chunk >= patches.n_chunks) {
+            indices = nullptr;
+            values = nullptr;
+            remaining = 0;
+            return;
+        }
 
-        // Compute base_offset from the first chunk offset.
-        uint32_t base_offset = load_chunk_offset(patches, 0);
+        const uint32_t indices_base = patches.indices_base == PATCH_DERIVE_INDICES_BASE
+                                          ? load_chunk_offset(patches, 0) + patches.offset_within_chunk
+                                          : patches.indices_base;
 
-        uint32_t patches_start_idx = load_chunk_offset(patches, chunk) - base_offset;
-        patches_start_idx -= min(patches_start_idx, patches.offset_within_chunk);
+        // Convert chunk_offsets entries into offsets within indices/values.
+        // Ordinary sliced patches derive the base from the first chunk offset;
+        // chunk-offset-only sliced views provide it explicitly.
+        uint32_t patches_start_idx = load_chunk_offset(patches, chunk);
+        patches_start_idx = (patches_start_idx > indices_base) ? patches_start_idx - indices_base : 0;
 
         // calculate the ending index.
         uint32_t patches_end_idx;
         if ((chunk + 1) < patches.n_chunks) {
-            patches_end_idx = load_chunk_offset(patches, chunk + 1) - base_offset;
-            // if this is the end of times, we should drop it out here...
-            patches_end_idx -= min(patches_end_idx, patches.offset_within_chunk);
+            patches_end_idx = load_chunk_offset(patches, chunk + 1);
+            patches_end_idx = (patches_end_idx > indices_base) ? patches_end_idx - indices_base : 0;
         } else {
             patches_end_idx = patches.num_patches;
         }
+        patches_end_idx = min(patches_end_idx, patches.num_patches);
+        patches_end_idx = max(patches_end_idx, patches_start_idx);
 
         // calculate how many patches are in the chunk
         uint32_t num_patches = patches_end_idx - patches_start_idx;

--- a/vortex-cuda/kernels/src/patches.h
+++ b/vortex-cuda/kernels/src/patches.h
@@ -12,6 +12,8 @@ extern "C" {
 /// Type tag for chunk_offsets pointer.
 typedef enum { CO_U8 = 0, CO_U16 = 1, CO_U32 = 2, CO_U64 = 3 } ChunkOffsetType;
 
+static const uint32_t PATCH_DERIVE_INDICES_BASE = UINT32_MAX;
+
 /// GPU-resident patches for fused exception patching during bit-unpacking.
 ///
 /// Patches are stored in sorted order within each chunk. The chunk_offsets
@@ -29,6 +31,10 @@ typedef struct {
     uint32_t offset_within_chunk;
     uint32_t num_patches;
     uint32_t n_chunks;
+    // PATCH_DERIVE_INDICES_BASE means derive from chunk_offsets[0] +
+    // offset_within_chunk. Chunk-offset-only sliced views need an explicit
+    // base because their indices/values buffers still start at patch 0.
+    uint32_t indices_base;
 } GPUPatches;
 
 #ifdef __cplusplus

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -509,6 +509,7 @@ mod tests {
     use cudarc::driver::LaunchConfig;
     use cudarc::driver::PushKernelArg;
     use rstest::rstest;
+    use vortex::array::ArrayRef;
     use vortex::array::IntoArray;
     use vortex::array::arrays::DictArray;
     use vortex::array::arrays::PrimitiveArray;
@@ -516,7 +517,7 @@ mod tests {
     use vortex::array::validity::Validity;
     use vortex::array::validity::Validity::NonNullable;
     use vortex::buffer::Buffer;
-    use vortex::dtype::PType;
+    use vortex::dtype::NativePType;
     use vortex::encodings::alp::ALP;
     use vortex::encodings::alp::ALPArrayExt;
     use vortex::encodings::alp::ALPArraySlotsExt;
@@ -535,6 +536,7 @@ mod tests {
     use vortex::session::VortexSession;
     use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute;
+    use vortex_array::patches::Patches;
 
     use super::*;
     use crate::CanonicalCudaExt;
@@ -561,7 +563,7 @@ mod tests {
     }
 
     async fn dispatch_plan(
-        array: &vortex::array::ArrayRef,
+        array: &ArrayRef,
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<MaterializedPlan> {
         match DispatchPlan::new(array, CudaDispatchMode::DynDispatchOnly)? {
@@ -1976,6 +1978,68 @@ mod tests {
     }
 
     #[crate::test]
+    async fn alp_slice_device_patches() -> VortexResult<()> {
+        // Regression test for https://github.com/vortex-data/vortex/issues/7838.
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let len = 4096;
+        let exponents = Exponents { e: 0, f: 0 };
+
+        async fn device_primitive<T: NativePType>(
+            cuda_ctx: &mut CudaExecutionCtx,
+            values: Vec<T>,
+        ) -> VortexResult<ArrayRef> {
+            let array = PrimitiveArray::new(Buffer::from(values), NonNullable);
+            Ok(PrimitiveArray::from_buffer_handle(
+                cuda_ctx
+                    .ensure_on_device(array.buffer_handle().clone())
+                    .await?,
+                T::PTYPE,
+                NonNullable,
+            )
+            .into_array())
+        }
+
+        let encoded = PrimitiveArray::new(Buffer::from(vec![0i64; len]), NonNullable).into_array();
+        let device_indices = device_primitive(&mut cuda_ctx, vec![500u32, 1024, 2048]).await?;
+        let device_values = device_primitive(
+            &mut cuda_ctx,
+            vec![
+                std::f64::consts::PI,
+                std::f64::consts::E,
+                std::f64::consts::LN_2,
+            ],
+        )
+        .await?;
+        let device_chunk_offsets = device_primitive(&mut cuda_ctx, vec![0u32, 1, 2, 3]).await?;
+
+        let patches = unsafe {
+            Patches::new_unchecked(
+                len,
+                0,
+                device_indices,
+                device_values,
+                Some(device_chunk_offsets),
+                Some(0),
+            )
+        };
+        let alp = ALP::try_new(encoded, exponents, Some(patches))?.into_array();
+        let sliced = alp.slice(100..3000)?;
+
+        let canonical = try_gpu_dispatch(&sliced, &mut cuda_ctx).await?;
+        let gpu = CanonicalCudaExt::into_host(canonical).await?.into_array();
+
+        let mut expected = vec![0.0f64; sliced.len()];
+        expected[500 - 100] = std::f64::consts::PI;
+        expected[1024 - 100] = std::f64::consts::E;
+        expected[2048 - 100] = std::f64::consts::LN_2;
+        let expected = PrimitiveArray::new(Buffer::from(expected), NonNullable).into_array();
+
+        vortex::array::assert_arrays_eq!(expected, gpu);
+
+        Ok(())
+    }
+
+    #[crate::test]
     async fn test_runend_u32_ends_u16_values() -> VortexResult<()> {
         // RunEnd with u32 ends, u16 values. Output type = u16.
         // Ends (u32) differ from output (u16) → pending subtree.
@@ -2065,7 +2129,7 @@ mod tests {
     #[case::bp_u8_codes_u32_values(2u8, 3000usize, vec![100_000u32, 200_000, 300_000, 400_000])]
     #[case::bp_u16_codes_u32_values(4u8, 2048usize, vec![1_000_000u32, 2_000_000, 3_000_000, 4_000_000, 5_000_000, 6_000_000, 7_000_000, 8_000_000])]
     #[crate::test]
-    async fn test_dict_mixed_width_bitpacked_codes<V: vortex::dtype::NativePType>(
+    async fn test_dict_mixed_width_bitpacked_codes<V: NativePType>(
         #[case] bit_width: u8,
         #[case] len: usize,
         #[case] dict_values: Vec<V>,
@@ -2108,7 +2172,7 @@ mod tests {
     #[case::for_bp_u8_codes_u32_values(3u8, 3000usize, vec![100u32, 200, 300, 400, 500, 600, 700, 800])]
     #[case::for_bp_u16_codes_u32_values(4u8, 2048usize, vec![10_000u32, 20_000, 30_000, 40_000, 50_000, 60_000, 70_000, 80_000])]
     #[crate::test]
-    async fn test_dict_mixed_width_for_bp_codes<V: vortex::dtype::NativePType>(
+    async fn test_dict_mixed_width_for_bp_codes<V: NativePType>(
         #[case] bit_width: u8,
         #[case] len: usize,
         #[case] dict_values: Vec<V>,
@@ -2162,10 +2226,7 @@ mod tests {
         vec![100_000u32, 200_000, 300_000, 400_000],
     )]
     #[crate::test]
-    async fn test_runend_mixed_width_bitpacked_ends<
-        E: vortex::dtype::NativePType + Into<u64>,
-        V: vortex::dtype::NativePType,
-    >(
+    async fn test_runend_mixed_width_bitpacked_ends<E: NativePType + Into<u64>, V: NativePType>(
         #[case] ends: Vec<E>,
         #[case] values: Vec<V>,
     ) -> VortexResult<()> {

--- a/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
+++ b/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
@@ -6,6 +6,8 @@
 //! subtrees and computing shared memory requirements upfront — before any
 //! device allocation or kernel work.
 
+use std::ops::Range;
+
 use itertools::zip_eq;
 use tracing::trace;
 use vortex::array::ArrayRef;
@@ -150,18 +152,28 @@ pub fn has_standalone_kernel(array: &ArrayRef) -> bool {
     false
 }
 
+/// Patch payload attached to the op that consumes it.
+///
+/// `slice` is a logical output range to apply when materializing the patch descriptor on the GPU.
+/// This lets the planner avoid calling `Patches::slice` when patch metadata may already be device-resident.
+#[derive(Clone)]
+struct PlanPatches {
+    patches: Patches,
+    slice: Option<Range<usize>>,
+}
+
 /// An unmaterialized stage: a source op, scalar ops, and optional source buffer reference.
 ///
-/// Patches are tied to their owning ops, mirroring the CUDA side where
-/// `patches_ptr` lives on `BitunpackParams` / `AlpParams`:
-/// - `source_patches` for the source op (BitPacked exceptions)
-/// - Each scalar op carries its own `Option<Patches>` (ALP exceptions)
+/// Patch descriptors are tied to the op that consumes them, matching the CUDA parameter layout:
+/// source patches live on `BitunpackParams`, while scalar-op patches live on `AlpParams`.
+/// Patches may also carry a logical slice range when planning has sliced the values but patch
+/// metadata must remain device-resident until materialization.
 struct Stage {
     source: SourceOp,
     /// Patches from the source op (e.g. BitPacked overflow exceptions).
-    source_patches: Option<Patches>,
+    source_patches: Option<PlanPatches>,
     /// Scalar ops with optional per-op patches (e.g. ALP float exceptions).
-    scalar_ops: Vec<(ScalarOp, Option<Patches>)>,
+    scalar_ops: Vec<(ScalarOp, Option<PlanPatches>)>,
     /// Index into `FusedPlan::source_buffers`, or `None`
     /// for sources that don't read from a device buffer.
     source_buffer_index: Option<usize>,
@@ -396,7 +408,8 @@ impl FusedPlan {
 
             // Upload source patches (e.g. BitPacked exceptions).
             if let Some(patches) = &stage.source_patches {
-                let (ptr, bufs) = load_patches_to_gpu(patches, ctx).await?;
+                let (ptr, bufs) =
+                    load_patches_to_gpu(&patches.patches, patches.slice.clone(), ctx).await?;
                 source.params.bitunpack.patches_ptr = ptr;
                 device_buffers.extend(bufs);
             }
@@ -405,7 +418,8 @@ impl FusedPlan {
             let mut scalar_ops: Vec<ScalarOp> = Vec::with_capacity(stage.scalar_ops.len());
             for (mut op, patches) in stage.scalar_ops.clone() {
                 if let Some(patches) = &patches {
-                    let (ptr, bufs) = load_patches_to_gpu(patches, ctx).await?;
+                    let (ptr, bufs) =
+                        load_patches_to_gpu(&patches.patches, patches.slice.clone(), ctx).await?;
                     op.params.alp.patches_ptr = ptr;
                     device_buffers.extend(bufs);
                 }
@@ -504,21 +518,20 @@ impl FusedPlan {
             return self.walk(reduced, pending_subtrees);
         }
 
-        // ALP doesn't implement reduce_parent — slice encoded child and
-        // patches manually (Patches::slice adjusts offsets for the range).
+        // ALP doesn't implement reduce_parent. Slice the encoded child here,
+        // and defer patch slicing to CUDA materialization so device-resident
+        // patch buffers stay on device.
         if child.encoding_id() == ALP.id() {
             let alp = child.as_::<ALP>();
             let offset = slice_arr.data().slice_range().start;
             let len = array.len();
             let sliced_encoded = alp.encoded().clone().slice(offset..offset + len)?;
-            let sliced_patches = alp
-                .patches()
-                .map(|p| p.slice(offset..offset + len))
-                .transpose()?
-                .flatten();
             return self.walk_alp_inner(
                 sliced_encoded,
-                sliced_patches,
+                alp.patches().map(|patches| PlanPatches {
+                    patches,
+                    slice: Some(offset..offset + len),
+                }),
                 alp.exponents(),
                 pending_subtrees,
             );
@@ -554,7 +567,10 @@ impl FusedPlan {
             Some(buf_index),
             source_ptype,
         );
-        stage.source_patches = bp.patches();
+        stage.source_patches = bp.patches().map(|patches| PlanPatches {
+            patches,
+            slice: None,
+        });
         Ok(stage)
     }
 
@@ -611,7 +627,10 @@ impl FusedPlan {
         let alp = array.as_::<ALP>();
         self.walk_alp_inner(
             alp.encoded().clone(),
-            alp.patches(),
+            alp.patches().map(|patches| PlanPatches {
+                patches,
+                slice: None,
+            }),
             alp.exponents(),
             pending_subtrees,
         )
@@ -621,7 +640,7 @@ impl FusedPlan {
     fn walk_alp_inner(
         &mut self,
         encoded: ArrayRef,
-        patches: Option<Patches>,
+        patches: Option<PlanPatches>,
         exponents: Exponents,
         pending_subtrees: &mut Vec<ArrayRef>,
     ) -> VortexResult<Stage> {

--- a/vortex-cuda/src/kernel/encodings/alp.rs
+++ b/vortex-cuda/src/kernel/encodings/alp.rs
@@ -31,7 +31,7 @@ use crate::executor::CudaArrayExt;
 use crate::executor::CudaExecute;
 use crate::executor::CudaExecutionCtx;
 use crate::kernel::patches::build_gpu_patches;
-use crate::kernel::patches::types::load_patches;
+use crate::kernel::patches::types::load_device_patches;
 
 /// CUDA decoder for ALP (Adaptive Lossless floating-Point) decompression.
 #[derive(Debug)]
@@ -91,10 +91,10 @@ where
 
     // Patch validity does not need to be scattered: the ALP encoder strips null
     // positions from the exception list, so patches only exist at valid
-    // positions. load_patches additionally rejects patches without
+    // positions. load_device_patches additionally rejects patches without
     // chunk_offsets (required by the fused kernel's PatchesCursor).
     let device_patches = if let Some(patches) = array.patches() {
-        Some(load_patches(&patches, ctx).await?)
+        Some(load_device_patches(&patches, ctx).await?)
     } else {
         None
     };

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -29,7 +29,7 @@ use crate::CudaDeviceBuffer;
 use crate::executor::CudaExecute;
 use crate::executor::CudaExecutionCtx;
 use crate::kernel::patches::build_gpu_patches;
-use crate::kernel::patches::types::load_patches;
+use crate::kernel::patches::types::load_device_patches;
 
 /// CUDA decoder for bit-packed arrays.
 #[derive(Debug)]
@@ -122,7 +122,7 @@ where
 
     // We hold this here to keep the device buffers alive.
     let device_patches = if let Some(patches) = patches {
-        Some(load_patches(&patches, ctx).await?)
+        Some(load_device_patches(&patches, ctx).await?)
     } else {
         None
     };

--- a/vortex-cuda/src/kernel/patches/mod.rs
+++ b/vortex-cuda/src/kernel/patches/mod.rs
@@ -31,6 +31,7 @@ use crate::kernel::patches::gpu::ChunkOffsetType_CO_U16;
 use crate::kernel::patches::gpu::ChunkOffsetType_CO_U32;
 use crate::kernel::patches::gpu::ChunkOffsetType_CO_U64;
 use crate::kernel::patches::gpu::GPUPatches;
+use crate::kernel::patches::gpu::PATCH_DERIVE_INDICES_BASE;
 use crate::kernel::patches::types::DevicePatches;
 
 // Safe because `GPUPatches` contains only raw pointers, POD integers, and an enum.
@@ -48,6 +49,7 @@ impl GPUPatches {
         offset_within_chunk: 0,
         num_patches: 0,
         n_chunks: 0,
+        indices_base: 0,
     };
 }
 
@@ -80,6 +82,9 @@ pub(crate) fn build_gpu_patches(
             offset_within_chunk: p.offset_within_chunk as u32,
             num_patches: p.num_patches as u32,
             n_chunks: p.n_chunks as u32,
+            indices_base: p
+                .indices_base
+                .map_or(PATCH_DERIVE_INDICES_BASE, |base| base as u32),
         }),
         None => Ok(GPUPatches::NULL_PATCHES),
     }

--- a/vortex-cuda/src/kernel/patches/types.rs
+++ b/vortex-cuda/src/kernel/patches/types.rs
@@ -4,6 +4,7 @@
 //! GPU patches loading for fused exception patching during bit-unpacking.
 
 use std::mem::size_of;
+use std::ops::Range;
 
 use num_traits::ToPrimitive;
 use vortex::array::buffer::BufferHandle;
@@ -13,6 +14,7 @@ use vortex::buffer::BufferMut;
 use vortex::buffer::ByteBufferMut;
 use vortex::dtype::PType;
 use vortex_array::match_each_unsigned_integer_ptype;
+use vortex_array::patches::PATCH_CHUNK_SIZE;
 use vortex_array::patches::Patches;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -26,6 +28,7 @@ use crate::kernel::patches::gpu::ChunkOffsetType_CO_U16;
 use crate::kernel::patches::gpu::ChunkOffsetType_CO_U32;
 use crate::kernel::patches::gpu::ChunkOffsetType_CO_U64;
 use crate::kernel::patches::gpu::GPUPatches;
+use crate::kernel::patches::gpu::PATCH_DERIVE_INDICES_BASE;
 
 /// A set of device-resident patches.
 pub struct DevicePatches {
@@ -37,15 +40,21 @@ pub struct DevicePatches {
     pub(crate) offset_within_chunk: usize,
     pub(crate) num_patches: usize,
     pub(crate) n_chunks: usize,
+    /// Base patch index for chunk offsets when indices/values remain unsliced.
+    /// `None` means derive it in the kernel via `PATCH_DERIVE_INDICES_BASE`.
+    pub(crate) indices_base: Option<usize>,
 }
 
-/// Load patches for GPU use (async).
+/// Build [`DevicePatches`] from patches by ensuring their buffers are on GPU.
+///
+/// This prepares `chunk_offsets`, `indices`, and `values` as device buffers and collects the
+/// metadata needed to build a [`GPUPatches`] descriptor. It does not upload the descriptor itself.
 ///
 /// # Errors
 ///
 /// If the patches do not have `chunk_offsets`. They have been written by
 /// default in new Vortex files since 0.54.0.
-pub(crate) async fn load_patches(
+pub(crate) async fn load_device_patches(
     patches: &Patches,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<DevicePatches> {
@@ -113,6 +122,7 @@ pub(crate) async fn load_patches(
         offset_within_chunk,
         num_patches,
         n_chunks,
+        indices_base: None,
     })
 }
 
@@ -127,9 +137,10 @@ pub(crate) fn ptype_to_chunk_offset_type(ptype: PType) -> VortexResult<ChunkOffs
     }
 }
 
-/// Build a [`GPUPatches`] struct from [`DevicePatches`], serialize it to
-/// bytes, and upload to the device. Returns the device pointer and a buffer
-/// handle that must be kept alive for the kernel launch.
+/// Build a [`GPUPatches`] struct from [`DevicePatches`], serialize it to bytes, and upload to the
+/// device. Returns the device pointer and a buffer handle that must be kept alive for the kernel
+/// launch.
+#[expect(clippy::cast_possible_truncation)]
 fn build_gpu_patches(
     dp: &DevicePatches,
     ctx: &CudaExecutionCtx,
@@ -141,17 +152,17 @@ fn build_gpu_patches(
     gpu_patches.chunk_offset_type = ptype_to_chunk_offset_type(dp.chunk_offset_ptype)?;
     gpu_patches.indices = dp.indices.cuda_device_ptr()? as _;
     gpu_patches.values = dp.values.cuda_device_ptr()? as _;
-    #[expect(clippy::cast_possible_truncation)]
-    {
-        gpu_patches.offset = dp.offset as u32;
-        gpu_patches.offset_within_chunk = dp.offset_within_chunk as u32;
-        gpu_patches.num_patches = dp.num_patches as u32;
-        // n_chunks must match the chunk_offsets array length, not array_len / 1024.
-        // When patches are sliced, chunk_offsets is sliced to only include chunks
-        // overlapping the slice range — matching the CPU's patch_chunk which uses
-        // chunk_offsets_slice.len().
-        gpu_patches.n_chunks = dp.n_chunks as u32;
-    }
+    gpu_patches.offset = dp.offset as u32;
+    gpu_patches.offset_within_chunk = dp.offset_within_chunk as u32;
+    gpu_patches.num_patches = dp.num_patches as u32;
+    // n_chunks must match the chunk_offsets array length, not array_len / 1024.
+    // When patches are sliced, chunk_offsets is sliced to only include chunks
+    // overlapping the slice range — matching the CPU's patch_chunk which uses
+    // chunk_offsets_slice.len().
+    gpu_patches.n_chunks = dp.n_chunks as u32;
+    gpu_patches.indices_base = dp
+        .indices_base
+        .map_or(PATCH_DERIVE_INDICES_BASE, |base| base as u32);
 
     let bytes = unsafe {
         std::slice::from_raw_parts(
@@ -169,13 +180,23 @@ fn build_gpu_patches(
 
 /// Transfers patches to the GPU and builds a [`GPUPatches`] descriptor.
 ///
-/// Returns the device pointer and all buffer handles that must be kept
-/// alive for the kernel launch.
+/// When `range` is set, this builds a sliced patch view without reading patch metadata on the
+/// host. It slices `chunk_offsets` by chunk boundaries, keeps `indices` and `values` unsliced, and
+/// records an explicit `indices_base` so the kernel can interpret the sliced chunk offsets against
+/// the original patch arrays.
+///
+/// Returns the device pointer and all buffer handles that must be kept alive for the kernel launch.
 pub(crate) async fn load_patches_to_gpu(
     patches: &Patches,
+    range: Option<Range<usize>>,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<(u64, Vec<BufferHandle>)> {
-    let device_patches = load_patches(patches, ctx).await?;
+    let mut device_patches = load_device_patches(patches, ctx).await?;
+
+    if let Some(range) = range {
+        slice_device_patches(patches, range, &mut device_patches);
+    }
+
     let (gpu_buf, ptr) = build_gpu_patches(&device_patches, ctx)?;
     let DevicePatches {
         chunk_offsets,
@@ -186,12 +207,46 @@ pub(crate) async fn load_patches_to_gpu(
     Ok((ptr, vec![chunk_offsets, indices, values, gpu_buf]))
 }
 
+fn slice_device_patches(
+    patches: &Patches,
+    range: Range<usize>,
+    device_patches: &mut DevicePatches,
+) {
+    let offset = patches.offset() + range.start;
+    let len = range.len();
+    let chunk_start = offset / PATCH_CHUNK_SIZE;
+    let chunk_end = offset.saturating_add(len).div_ceil(PATCH_CHUNK_SIZE);
+    let first_chunk = patches.offset() / PATCH_CHUNK_SIZE;
+    let start = chunk_start.saturating_sub(first_chunk);
+    let end = (chunk_end.saturating_sub(first_chunk) + 1).min(device_patches.n_chunks);
+    if start < end {
+        let width = device_patches.chunk_offset_ptype.byte_width();
+        device_patches.chunk_offsets = device_patches
+            .chunk_offsets
+            .slice(start * width..end * width);
+        device_patches.n_chunks = end - start;
+    }
+
+    // Keep indices/values unsliced. This is a conservative chunk-aligned
+    // patch view for lookup-style consumers: patches outside `range` may be
+    // scanned, but their indices cannot match positions inside the range.
+    device_patches.offset = offset;
+    device_patches.offset_within_chunk = 0;
+    device_patches.indices_base = Some(0);
+}
+
 #[cfg(test)]
 mod tests {
+    use vortex::buffer::Buffer;
+    use vortex::session::VortexSession;
     use vortex_array::IntoArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::patches::Patches;
     use vortex_error::VortexResult;
+
+    use super::load_device_patches;
+    use super::slice_device_patches;
+    use crate::CudaSession;
 
     #[test]
     fn test_patches_with_chunk_offsets() -> VortexResult<()> {
@@ -212,6 +267,81 @@ mod tests {
         assert_eq!(patches.chunk_offset_at(0)?, 0);
         assert_eq!(patches.chunk_offset_at(1)?, 2);
         assert_eq!(patches.chunk_offset_at(2)?, 3);
+
+        Ok(())
+    }
+
+    #[rstest::rstest]
+    #[case::full_range(0..5120, 0, vec![0, 1, 2, 3, 4, 5])]
+    #[case::single_first_chunk(0..1024, 0, vec![0, 1])]
+    #[case::partial_first_chunk(100..3000, 100, vec![0, 1, 2, 3])]
+    #[case::chunk_aligned_start(1024..3000, 1024, vec![1, 2, 3])]
+    #[case::single_middle_chunk(2048..3072, 2048, vec![2, 3])]
+    #[case::middle_of_chunks(1500..2800, 1500, vec![1, 2, 3])]
+    #[case::skip_first_chunks(3072..4500, 3072, vec![3, 4, 5])]
+    #[case::tail_chunk(4500..5000, 4500, vec![4, 5])]
+    #[crate::test]
+    async fn test_slice_device_patches(
+        #[case] range: std::ops::Range<usize>,
+        #[case] expected_offset: usize,
+        #[case] expected_chunk_offsets: Vec<u32>,
+    ) -> VortexResult<()> {
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let indices = PrimitiveArray::from_iter([100u32, 1100, 2100, 3100, 4100]);
+        let values = PrimitiveArray::from_iter([10u32, 11, 12, 13, 14]);
+        let chunk_offsets = PrimitiveArray::from_iter([0u32, 1, 2, 3, 4, 5]);
+        let patches = Patches::new(
+            5120,
+            0,
+            indices.into_array(),
+            values.into_array(),
+            Some(chunk_offsets.into_array()),
+        )?;
+
+        let mut device_patches = load_device_patches(&patches, &mut cuda_ctx).await?;
+        slice_device_patches(&patches, range, &mut device_patches);
+
+        let chunk_offsets =
+            Buffer::<u32>::from_byte_buffer(device_patches.chunk_offsets.to_host().await);
+        assert_eq!(chunk_offsets.as_slice(), expected_chunk_offsets.as_slice());
+        assert_eq!(device_patches.n_chunks, expected_chunk_offsets.len());
+        assert_eq!(device_patches.offset, expected_offset);
+        assert_eq!(device_patches.offset_within_chunk, 0);
+        assert_eq!(device_patches.indices_base, Some(0));
+
+        Ok(())
+    }
+
+    #[rstest::rstest]
+    #[case::u8(PrimitiveArray::from_iter([0u8, 1, 2, 3, 4, 5]).into_array())]
+    #[case::u16(PrimitiveArray::from_iter([0u16, 1, 2, 3, 4, 5]).into_array())]
+    #[case::u64(PrimitiveArray::from_iter([0u64, 1, 2, 3, 4, 5]).into_array())]
+    #[crate::test]
+    async fn test_slice_device_patches_chunk_offset_widths(
+        #[case] chunk_offsets: vortex_array::ArrayRef,
+    ) -> VortexResult<()> {
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let indices = PrimitiveArray::from_iter([100u32, 1100, 2100, 3100, 4100]);
+        let values = PrimitiveArray::from_iter([10u32, 11, 12, 13, 14]);
+        let patches = Patches::new(
+            5120,
+            0,
+            indices.into_array(),
+            values.into_array(),
+            Some(chunk_offsets),
+        )?;
+
+        let mut device_patches = load_device_patches(&patches, &mut cuda_ctx).await?;
+        slice_device_patches(&patches, 1024..3000, &mut device_patches);
+
+        assert_eq!(
+            device_patches.chunk_offsets.len(),
+            3 * device_patches.chunk_offset_ptype.byte_width()
+        );
+        assert_eq!(device_patches.n_chunks, 3);
+        assert_eq!(device_patches.offset, 1024);
+        assert_eq!(device_patches.offset_within_chunk, 0);
+        assert_eq!(device_patches.indices_base, Some(0));
 
         Ok(())
     }

--- a/vortex-io/public-api.lock
+++ b/vortex-io/public-api.lock
@@ -866,13 +866,13 @@ pub async fn vortex_io::object_store::ObjectStoreWrite::shutdown(&mut self) -> s
 
 pub async fn vortex_io::object_store::ObjectStoreWrite::write_all<B: vortex_io::IoBuf>(&mut self, B) -> std::io::error::Result<B>
 
-impl<T> vortex_io::VortexWrite for std::io::cursor::Cursor<T> where std::io::cursor::Cursor<T>: std::io::Write
+impl<T> vortex_io::VortexWrite for core::io::cursor::Cursor<T> where core::io::cursor::Cursor<T>: std::io::Write
 
-pub fn std::io::cursor::Cursor<T>::flush(&mut self) -> impl core::future::future::Future<Output = std::io::error::Result<()>>
+pub fn core::io::cursor::Cursor<T>::flush(&mut self) -> impl core::future::future::Future<Output = std::io::error::Result<()>>
 
-pub fn std::io::cursor::Cursor<T>::shutdown(&mut self) -> impl core::future::future::Future<Output = std::io::error::Result<()>>
+pub fn core::io::cursor::Cursor<T>::shutdown(&mut self) -> impl core::future::future::Future<Output = std::io::error::Result<()>>
 
-pub fn std::io::cursor::Cursor<T>::write_all<B: vortex_io::IoBuf>(&mut self, B) -> impl core::future::future::Future<Output = std::io::error::Result<B>>
+pub fn core::io::cursor::Cursor<T>::write_all<B: vortex_io::IoBuf>(&mut self, B) -> impl core::future::future::Future<Output = std::io::error::Result<B>>
 
 impl<W: futures_io::if_std::AsyncWrite + core::marker::Unpin> vortex_io::VortexWrite for vortex_io::AsyncWriteAdapter<W>
 


### PR DESCRIPTION
### Summary

For `Slice(ALP)` the GPU plan builder was calling `Patches::slice` for device resident patch metadata. Within slice scalar access panicked when the patch buffers are device resident.

This change adds a CUDA materialization path for sliced patch views. The planner keeps the original Patches plus an optional slice range; materialization slices only chunk_offsets, leaves indices/values on device, and records indices_base when the sliced chunk_offsets still refer into unsliced patch arrays.

### Fixed Issue

https://github.com/vortex-data/vortex/issues/7838