### PR TITLE
Consistent `DType` match

### DIFF
--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -114,15 +114,6 @@ pub(super) fn execute_sparse(parts: SparseParts, ctx: &mut ExecutionCtx) -> Vort
                 execute_sparse_primitives::<P>(&patches, &fill_value, ctx)?
             })
         }
-        DType::Struct(struct_fields, ..) => execute_sparse_struct(
-            struct_fields,
-            fill_value.as_struct(),
-            dtype.nullability(),
-            &patches,
-            len,
-            ctx,
-        )?,
-        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::Decimal(decimal_dtype, nullability) => {
             let canonical_decimal_value_type =
                 DecimalType::smallest_decimal_value_type(decimal_dtype);
@@ -158,6 +149,15 @@ pub(super) fn execute_sparse(parts: SparseParts, ctx: &mut ExecutionCtx) -> Vort
         DType::FixedSizeList(.., nullability) => {
             execute_sparse_fixed_size_list(&patches, &fill_value, len, *nullability, ctx)?
         }
+        DType::Struct(struct_fields, ..) => execute_sparse_struct(
+            struct_fields,
+            fill_value.as_struct(),
+            dtype.nullability(),
+            &patches,
+            len,
+            ctx,
+        )?,
+        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::Extension(_ext_dtype) => todo!(),
         DType::Variant(_) => vortex_bail!("Sparse canonicalization does not support Variant"),
     })

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -158,8 +158,8 @@ pub(super) fn execute_sparse(parts: SparseParts, ctx: &mut ExecutionCtx) -> Vort
             ctx,
         )?,
         DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-        DType::Extension(_ext_dtype) => todo!(),
         DType::Variant(_) => vortex_bail!("Sparse canonicalization does not support Variant"),
+        DType::Extension(_ext_dtype) => todo!(),
     })
 }
 

--- a/fuzz/src/array/compare.rs
+++ b/fuzz/src/array/compare.rs
@@ -161,7 +161,7 @@ pub fn compare_canonical_array(
                 )
             })
         }
-        DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => {
+        DType::List(..) | DType::FixedSizeList(..) | DType::Struct(..) => {
             let scalar_vals: Vec<Scalar> = (0..array.len())
                 .map(|i| array.execute_scalar(i, ctx).vortex_expect("scalar_at"))
                 .collect();

--- a/fuzz/src/array/compare.rs
+++ b/fuzz/src/array/compare.rs
@@ -173,7 +173,7 @@ pub fn compare_canonical_array(
             }))
             .into_array()
         }
-        d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Union(..) | DType::Variant(_) | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/filter.rs
+++ b/fuzz/src/array/filter.rs
@@ -98,6 +98,15 @@ pub fn filter_canonical_array(
             });
             Ok(VarBinViewArray::from_iter(values, array.dtype().clone()).into_array())
         }
+        DType::List(..) | DType::FixedSizeList(..) => {
+            let mut indices = Vec::new();
+            for (idx, bool) in filter.iter().enumerate() {
+                if *bool {
+                    indices.push(idx);
+                }
+            }
+            take_canonical_array_non_nullable_indices(array, indices.as_slice(), ctx)
+        }
         DType::Struct(..) => {
             let struct_array = array.clone().execute::<StructArray>(ctx)?;
             let filtered_children = struct_array
@@ -112,15 +121,6 @@ pub fn filter_canonical_array(
                 validity,
             )
             .map(|a| a.into_array())
-        }
-        DType::List(..) | DType::FixedSizeList(..) => {
-            let mut indices = Vec::new();
-            for (idx, bool) in filter.iter().enumerate() {
-                if *bool {
-                    indices.push(idx);
-                }
-            }
-            take_canonical_array_non_nullable_indices(array, indices.as_slice(), ctx)
         }
         d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
             unreachable!("DType {d} not supported for fuzzing")

--- a/fuzz/src/array/filter.rs
+++ b/fuzz/src/array/filter.rs
@@ -122,7 +122,7 @@ pub fn filter_canonical_array(
             )
             .map(|a| a.into_array())
         }
-        d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Union(..) | DType::Variant(_) | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -464,21 +464,25 @@ fn actions_for_dtype(dtype: &DType) -> HashSet<ActionType> {
     use ActionType::*;
 
     match dtype {
-        DType::Struct(sdt, _) => {
-            // Struct supports: Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt
-            // Does NOT support: SearchSorted (requires scalar comparison), Compare, Cast, Sum, FillNull
-            let struct_actions = [Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt];
-            sdt.fields()
-                .map(|child| actions_for_dtype(&child))
-                .fold(struct_actions.into(), |acc, actions| {
-                    acc.intersection(&actions).copied().collect()
-                })
+        DType::Null => {
+            // Null arrays support most operations but not Sum or MinMax (return None for dtype)
+            [
+                Compress,
+                Slice,
+                Take,
+                SearchSorted,
+                Filter,
+                Compare,
+                Cast,
+                FillNull,
+                Mask,
+                ScalarAt,
+            ]
+            .into()
         }
-        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-        DType::List(..) | DType::FixedSizeList(..) => {
-            // List supports: Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt
-            // Does NOT support: SearchSorted, Compare, Cast, Sum, FillNull
-            [Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt].into()
+        DType::Bool(_) | DType::Primitive(..) | DType::Decimal(..) => {
+            // These support all actions
+            ActionType::iter().collect()
         }
         DType::Utf8(_) | DType::Binary(_) => {
             // Utf8/Binary supports everything except Sum and FillNull
@@ -497,26 +501,22 @@ fn actions_for_dtype(dtype: &DType) -> HashSet<ActionType> {
             ]
             .into()
         }
-        DType::Bool(_) | DType::Primitive(..) | DType::Decimal(..) => {
-            // These support all actions
-            ActionType::iter().collect()
+        DType::List(..) | DType::FixedSizeList(..) => {
+            // List supports: Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt
+            // Does NOT support: SearchSorted, Compare, Cast, Sum, FillNull
+            [Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt].into()
         }
-        DType::Null => {
-            // Null arrays support most operations but not Sum or MinMax (return None for dtype)
-            [
-                Compress,
-                Slice,
-                Take,
-                SearchSorted,
-                Filter,
-                Compare,
-                Cast,
-                FillNull,
-                Mask,
-                ScalarAt,
-            ]
-            .into()
+        DType::Struct(sdt, _) => {
+            // Struct supports: Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt
+            // Does NOT support: SearchSorted (requires scalar comparison), Compare, Cast, Sum, FillNull
+            let struct_actions = [Compress, Slice, Take, Filter, MinMax, Mask, ScalarAt];
+            sdt.fields()
+                .map(|child| actions_for_dtype(&child))
+                .fold(struct_actions.into(), |acc, actions| {
+                    acc.intersection(&actions).copied().collect()
+                })
         }
+        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::Extension(_) => {
             // Extension types delegate to storage dtype, support most operations
             ActionType::iter().collect()

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -517,12 +517,12 @@ fn actions_for_dtype(dtype: &DType) -> HashSet<ActionType> {
                 })
         }
         DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
+        // Currently, no support at all
+        DType::Variant(_) => unreachable!("Variant dtype shouldn't be fuzzed"),
         DType::Extension(_) => {
             // Extension types delegate to storage dtype, support most operations
             ActionType::iter().collect()
         }
-        // Currently, no support at all
-        DType::Variant(_) => unreachable!("Variant dtype shouldn't be fuzzed"),
     }
 }
 

--- a/fuzz/src/array/search_sorted.rs
+++ b/fuzz/src/array/search_sorted.rs
@@ -148,7 +148,7 @@ pub fn search_sorted_canonical_array(
                 .collect::<VortexResult<Vec<_>>>()?;
             scalar_vals.search_sorted(&scalar.cast(array.dtype())?, side)
         }
-        d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Union(..) | DType::Variant(_) | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/search_sorted.rs
+++ b/fuzz/src/array/search_sorted.rs
@@ -142,7 +142,7 @@ pub fn search_sorted_canonical_array(
             };
             SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
         }
-        DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => {
+        DType::List(..) | DType::FixedSizeList(..) | DType::Struct(..) => {
             let scalar_vals = (0..array.len())
                 .map(|i| array.execute_scalar(i, ctx))
                 .collect::<VortexResult<Vec<_>>>()?;

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -54,6 +54,19 @@ pub fn slice_canonical_array(
                 .into_array())
             })
         }
+        DType::Decimal(decimal_dtype, _) => {
+            let decimal_array = array.clone().execute::<DecimalArray>(ctx)?;
+            Ok(
+                match_each_decimal_value_type!(decimal_array.values_type(), |D| {
+                    DecimalArray::new(
+                        decimal_array.buffer::<D>().slice(start..stop),
+                        *decimal_dtype,
+                        validity,
+                    )
+                })
+                .into_array(),
+            )
+        }
         DType::Utf8(_) | DType::Binary(_) => {
             let utf8 = array.clone().execute::<VarBinViewArray>(ctx)?;
             let values =
@@ -63,20 +76,6 @@ pub fn slice_canonical_array(
                 array.dtype().clone(),
             )
             .into_array())
-        }
-        DType::Struct(..) => {
-            let struct_array = array.clone().execute::<StructArray>(ctx)?;
-            let sliced_children = struct_array
-                .iter_unmasked_fields()
-                .map(|c| slice_canonical_array(c, start, stop, ctx))
-                .collect::<VortexResult<Vec<_>>>()?;
-            StructArray::try_new_with_dtype(
-                sliced_children,
-                struct_array.struct_fields().clone(),
-                stop - start,
-                validity,
-            )
-            .map(|a| a.into_array())
         }
         DType::List(..) => {
             let list_array = array.clone().execute::<ListViewArray>(ctx)?;
@@ -110,18 +109,19 @@ pub fn slice_canonical_array(
             FixedSizeListArray::try_new(elements, fsl_array.list_size(), validity, new_len)
                 .map(|a| a.into_array())
         }
-        DType::Decimal(decimal_dtype, _) => {
-            let decimal_array = array.clone().execute::<DecimalArray>(ctx)?;
-            Ok(
-                match_each_decimal_value_type!(decimal_array.values_type(), |D| {
-                    DecimalArray::new(
-                        decimal_array.buffer::<D>().slice(start..stop),
-                        *decimal_dtype,
-                        validity,
-                    )
-                })
-                .into_array(),
+        DType::Struct(..) => {
+            let struct_array = array.clone().execute::<StructArray>(ctx)?;
+            let sliced_children = struct_array
+                .iter_unmasked_fields()
+                .map(|c| slice_canonical_array(c, start, stop, ctx))
+                .collect::<VortexResult<Vec<_>>>()?;
+            StructArray::try_new_with_dtype(
+                sliced_children,
+                struct_array.struct_fields().clone(),
+                stop - start,
+                validity,
             )
+            .map(|a| a.into_array())
         }
         d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
             unreachable!("DType {d} not supported for fuzzing")

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -123,7 +123,7 @@ pub fn slice_canonical_array(
             )
             .map(|a| a.into_array())
         }
-        d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Union(..) | DType::Variant(_) | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/sort.rs
+++ b/fuzz/src/array/sort.rs
@@ -101,7 +101,7 @@ pub fn sort_canonical_array(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexR
             });
             take_canonical_array_non_nullable_indices(array, &sort_indices, ctx)
         }
-        d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Union(..) | DType::Variant(_) | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/sort.rs
+++ b/fuzz/src/array/sort.rs
@@ -91,7 +91,7 @@ pub fn sort_canonical_array(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexR
             opt_values.sort();
             Ok(VarBinViewArray::from_iter(opt_values, array.dtype().clone()).into_array())
         }
-        DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => {
+        DType::List(..) | DType::FixedSizeList(..) | DType::Struct(..) => {
             let mut sort_indices = (0..array.len()).collect::<Vec<_>>();
             sort_indices.sort_by(|a, b| {
                 let lhs = array.execute_scalar(*a, ctx).vortex_expect("scalar_at");

--- a/fuzz/src/array/take.rs
+++ b/fuzz/src/array/take.rs
@@ -147,7 +147,7 @@ pub fn take_canonical_array(
             )
             .map(|a| a.into_array())
         }
-        d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
+        d @ (DType::Null | DType::Union(..) | DType::Variant(_) | DType::Extension(_)) => {
             unreachable!("DType {d} not supported for fuzzing")
         }
     }

--- a/fuzz/src/array/take.rs
+++ b/fuzz/src/array/take.rs
@@ -113,21 +113,6 @@ pub fn take_canonical_array(
             )
             .into_array())
         }
-        DType::Struct(..) => {
-            let struct_array = array.clone().execute::<StructArray>(ctx)?;
-            let taken_children = struct_array
-                .iter_unmasked_fields()
-                .map(|c| take_canonical_array_non_nullable_indices(c, indices_slice_non_opt, ctx))
-                .collect::<VortexResult<Vec<_>>>()?;
-
-            StructArray::try_new(
-                struct_array.names().clone(),
-                taken_children,
-                indices_slice_non_opt.len(),
-                validity,
-            )
-            .map(|a| a.into_array())
-        }
         DType::List(..) | DType::FixedSizeList(..) => {
             let mut builder = builder_with_capacity(
                 &array.dtype().union_nullability(nullable),
@@ -146,6 +131,21 @@ pub fn take_canonical_array(
                 }
             }
             Ok(builder.finish())
+        }
+        DType::Struct(..) => {
+            let struct_array = array.clone().execute::<StructArray>(ctx)?;
+            let taken_children = struct_array
+                .iter_unmasked_fields()
+                .map(|c| take_canonical_array_non_nullable_indices(c, indices_slice_non_opt, ctx))
+                .collect::<VortexResult<Vec<_>>>()?;
+
+            StructArray::try_new(
+                struct_array.names().clone(),
+                taken_children,
+                indices_slice_non_opt.len(),
+                validity,
+            )
+            .map(|a| a.into_array())
         }
         d @ (DType::Null | DType::Union(..) | DType::Extension(_) | DType::Variant(_)) => {
             unreachable!("DType {d} not supported for fuzzing")

--- a/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
@@ -292,10 +292,10 @@ fn supports_uncompressed_size_in_bytes(dtype: &DType) -> bool {
             .fields()
             .all(|field| supports_uncompressed_size_in_bytes(&field)),
         DType::Union(_) => todo!("TODO(connor)[Union]: unimplemented"),
+        DType::Variant(_) => false,
         DType::Extension(ext_dtype) => {
             supports_uncompressed_size_in_bytes(ext_dtype.storage_dtype())
         }
-        DType::Variant(_) => false,
     }
 }
 

--- a/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
@@ -231,14 +231,14 @@ pub(crate) fn constant_uncompressed_size_in_bytes(
             array.len(),
             array.scalar().as_binary().value().map(|value| value.len()),
         )?,
-        DType::Variant(_) => {
-            vortex_bail!("UncompressedSizeInBytes is not supported for Variant arrays")
-        }
-        DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) | DType::Extension(_) => {
+        DType::List(..) | DType::FixedSizeList(..) | DType::Struct(..) | DType::Extension(_) => {
             let canonical = array.array().clone().execute::<Canonical>(ctx)?;
             return canonical_uncompressed_size_in_bytes(&canonical, ctx);
         }
         DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
+        DType::Variant(_) => {
+            vortex_bail!("UncompressedSizeInBytes is not supported for Variant arrays")
+        }
     };
 
     value_size
@@ -279,6 +279,12 @@ fn checked_len_mul(len: usize, width: usize, name: &str) -> VortexResult<u64> {
 
 fn supports_uncompressed_size_in_bytes(dtype: &DType) -> bool {
     match dtype {
+        DType::Null
+        | DType::Bool(_)
+        | DType::Primitive(..)
+        | DType::Decimal(..)
+        | DType::Utf8(_)
+        | DType::Binary(_) => true,
         DType::List(element_dtype, _) | DType::FixedSizeList(element_dtype, ..) => {
             supports_uncompressed_size_in_bytes(element_dtype)
         }
@@ -290,12 +296,6 @@ fn supports_uncompressed_size_in_bytes(dtype: &DType) -> bool {
             supports_uncompressed_size_in_bytes(ext_dtype.storage_dtype())
         }
         DType::Variant(_) => false,
-        DType::Null
-        | DType::Bool(_)
-        | DType::Primitive(..)
-        | DType::Decimal(..)
-        | DType::Utf8(_)
-        | DType::Binary(_) => true,
     }
 }
 

--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -155,6 +155,10 @@ fn random_array_chunk(
         }
         DType::Utf8(n) => random_string(u, *n, chunk_len),
         DType::Binary(n) => random_bytes(u, *n, chunk_len),
+        DType::List(elem_dtype, null) => random_list(u, elem_dtype, *null, chunk_len),
+        DType::FixedSizeList(elem_dtype, list_size, null) => {
+            random_fixed_size_list(u, elem_dtype, *list_size, *null, chunk_len)
+        }
         DType::Struct(sdt, n) => {
             let first_array = sdt
                 .fields()
@@ -186,10 +190,6 @@ fn random_array_chunk(
             .into_array())
         }
         DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-        DType::List(elem_dtype, null) => random_list(u, elem_dtype, *null, chunk_len),
-        DType::FixedSizeList(elem_dtype, list_size, null) => {
-            random_fixed_size_list(u, elem_dtype, *list_size, *null, chunk_len)
-        }
         DType::Extension(..) => {
             unimplemented!("Extension arrays are not implemented")
         }

--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -190,11 +190,11 @@ fn random_array_chunk(
             .into_array())
         }
         DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-        DType::Extension(..) => {
-            unimplemented!("Extension arrays are not implemented")
-        }
         DType::Variant(_) => {
             unimplemented!("Variant arrays are not implemented")
+        }
+        DType::Extension(..) => {
+            unimplemented!("Extension arrays are not implemented")
         }
     }
 }

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -241,7 +241,7 @@ impl VTable for Chunked {
     fn execute(array: Array<Self>, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionResult> {
         match array.dtype() {
             // Struct and List need special swizzling logic, use the existing canonicalize path.
-            DType::Struct(..) | DType::List(..) => {
+            DType::List(..) | DType::Struct(..) => {
                 // TODO(joe)[#7674]: iterative execution here too
                 Ok(ExecutionResult::done(_canonicalize(array.as_view(), ctx)?))
             }

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -164,6 +164,11 @@ pub(crate) fn constant_canonicalize(
             })
         }
         DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
+        DType::Variant(_) => {
+            unimplemented!(
+                "TODO(variant): canonicalization will use the child-array design in a follow-up"
+            )
+        }
         DType::Extension(ext_dtype) => {
             let s = scalar.as_extension();
 
@@ -179,11 +184,6 @@ pub(crate) fn constant_canonicalize(
                 .into_array();
 
             Canonical::Extension(ExtensionArray::new(ext_dtype.clone(), storage_self))
-        }
-        DType::Variant(_) => {
-            unimplemented!(
-                "TODO(variant): canonicalization will use the child-array design in a follow-up"
-            )
         }
     })
 }

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -124,6 +124,18 @@ pub(crate) fn constant_canonicalize(
                 array.len(),
             ))
         }
+        DType::List(..) => Canonical::List(constant_canonical_list_array(scalar, array.len())),
+        DType::FixedSizeList(element_dtype, list_size, _) => {
+            let value = scalar.as_list();
+
+            Canonical::FixedSizeList(constant_canonical_fixed_size_list_array(
+                value.elements(),
+                element_dtype,
+                *list_size,
+                value.dtype().nullability(),
+                array.len(),
+            ))
+        }
         DType::Struct(struct_dtype, _) => {
             let value = scalar.as_struct();
             let fields: Vec<_> = match value.fields_iter() {
@@ -152,18 +164,6 @@ pub(crate) fn constant_canonicalize(
             })
         }
         DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-        DType::List(..) => Canonical::List(constant_canonical_list_array(scalar, array.len())),
-        DType::FixedSizeList(element_dtype, list_size, _) => {
-            let value = scalar.as_list();
-
-            Canonical::FixedSizeList(constant_canonical_fixed_size_list_array(
-                value.elements(),
-                element_dtype,
-                *list_size,
-                value.dtype().nullability(),
-                array.len(),
-            ))
-        }
         DType::Extension(ext_dtype) => {
             let s = scalar.as_extension();
 

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -269,12 +269,6 @@ pub fn builder_with_capacity(dtype: &DType, capacity: usize) -> Box<dyn ArrayBui
             DType::Binary(*n),
             capacity,
         )),
-        DType::Struct(struct_dtype, n) => Box::new(StructBuilder::with_capacity(
-            struct_dtype.clone(),
-            *n,
-            capacity,
-        )),
-        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::List(dtype, n) => Box::new(ListViewBuilder::<u64, u64>::with_capacity(
             Arc::clone(dtype),
             *n,
@@ -289,6 +283,12 @@ pub fn builder_with_capacity(dtype: &DType, capacity: usize) -> Box<dyn ArrayBui
                 capacity,
             ))
         }
+        DType::Struct(struct_dtype, n) => Box::new(StructBuilder::with_capacity(
+            struct_dtype.clone(),
+            *n,
+            capacity,
+        )),
+        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::Extension(ext_dtype) => {
             Box::new(ExtensionBuilder::with_capacity(ext_dtype.clone(), capacity))
         }

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -289,11 +289,11 @@ pub fn builder_with_capacity(dtype: &DType, capacity: usize) -> Box<dyn ArrayBui
             capacity,
         )),
         DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-        DType::Extension(ext_dtype) => {
-            Box::new(ExtensionBuilder::with_capacity(ext_dtype.clone(), capacity))
-        }
         DType::Variant(_) => {
             unimplemented!()
+        }
+        DType::Extension(ext_dtype) => {
+            Box::new(ExtensionBuilder::with_capacity(ext_dtype.clone(), capacity))
         }
     }
 }

--- a/vortex-array/src/builders/tests.rs
+++ b/vortex-array/src/builders/tests.rs
@@ -586,36 +586,14 @@ fn create_test_scalars_for_dtype(dtype: &DType, count: usize) -> Vec<Scalar> {
                 PType::F32 => Scalar::primitive(i as f32 * 1.5, *n),
                 PType::F64 => Scalar::primitive(i as f64 * 1.5, *n),
             },
-            DType::Utf8(n) => Scalar::utf8(format!("test_string_{}", i), *n),
-            DType::Binary(n) => Scalar::binary(format!("bytes_{}", i).into_bytes(), *n),
             DType::Decimal(dec_dtype, n) => {
                 // Create decimal scalars based on the decimal dtype.
                 use crate::scalar::DecimalValue;
                 let value = DecimalValue::I128((i as i128 + 1) * 100); // Simple decimal values.
                 Scalar::decimal(value, *dec_dtype, *n)
             }
-            DType::Struct(fields, n) => {
-                // Create struct scalars with field values.
-                let field_values: Vec<Scalar> = fields
-                    .fields()
-                    .enumerate()
-                    .map(|(j, field_dtype)| {
-                        // Create simple values for each field.
-                        match &field_dtype {
-                            DType::Primitive(PType::I32, n) => {
-                                Scalar::primitive((i as i32).saturating_add(j as i32), *n)
-                            }
-                            DType::Primitive(PType::F64, n) => {
-                                Scalar::primitive((i + j) as f64, *n)
-                            }
-                            DType::Utf8(n) => Scalar::utf8(format!("field_{}", i + j), *n),
-                            _ => Scalar::default_value(&field_dtype),
-                        }
-                    })
-                    .collect();
-                Scalar::struct_(DType::Struct(fields.clone(), *n), field_values)
-            }
-            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
+            DType::Utf8(n) => Scalar::utf8(format!("test_string_{}", i), *n),
+            DType::Binary(n) => Scalar::binary(format!("bytes_{}", i).into_bytes(), *n),
             DType::List(element_dtype, n) => {
                 // Create list scalars with a few elements.
                 let elements: Vec<Scalar> = (0..=i)
@@ -640,6 +618,28 @@ fn create_test_scalars_for_dtype(dtype: &DType, count: usize) -> Vec<Scalar> {
                     .collect();
                 Scalar::fixed_size_list(Arc::clone(element_dtype), elements, *n)
             }
+            DType::Struct(fields, n) => {
+                // Create struct scalars with field values.
+                let field_values: Vec<Scalar> = fields
+                    .fields()
+                    .enumerate()
+                    .map(|(j, field_dtype)| {
+                        // Create simple values for each field.
+                        match &field_dtype {
+                            DType::Primitive(PType::I32, n) => {
+                                Scalar::primitive((i as i32).saturating_add(j as i32), *n)
+                            }
+                            DType::Primitive(PType::F64, n) => {
+                                Scalar::primitive((i + j) as f64, *n)
+                            }
+                            DType::Utf8(n) => Scalar::utf8(format!("field_{}", i + j), *n),
+                            _ => Scalar::default_value(&field_dtype),
+                        }
+                    })
+                    .collect();
+                Scalar::struct_(DType::Struct(fields.clone(), *n), field_values)
+            }
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Extension(ext_dtype) => {
                 // Create extension scalars with storage values.
                 let storage_scalar = match ext_dtype.storage_dtype() {

--- a/vortex-array/src/builders/tests.rs
+++ b/vortex-array/src/builders/tests.rs
@@ -640,6 +640,7 @@ fn create_test_scalars_for_dtype(dtype: &DType, count: usize) -> Vec<Scalar> {
                 Scalar::struct_(DType::Struct(fields.clone(), *n), field_values)
             }
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
+            DType::Variant(_) => continue,
             DType::Extension(ext_dtype) => {
                 // Create extension scalars with storage values.
                 let storage_scalar = match ext_dtype.storage_dtype() {
@@ -648,7 +649,6 @@ fn create_test_scalars_for_dtype(dtype: &DType, count: usize) -> Vec<Scalar> {
                 };
                 Scalar::extension_ref(ext_dtype.clone(), storage_scalar)
             }
-            DType::Variant(_) => continue,
         };
         scalars.push(scalar);
     }

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -226,13 +226,13 @@ impl Canonical {
                 )
             }),
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
+            DType::Variant(_) => {
+                vortex_panic!(InvalidArgument: "Canonical empty is not supported for Variant")
+            }
             DType::Extension(ext_dtype) => Canonical::Extension(ExtensionArray::new(
                 ext_dtype.clone(),
                 Canonical::empty(ext_dtype.storage_dtype()).into_array(),
             )),
-            DType::Variant(_) => {
-                vortex_panic!(InvalidArgument: "Canonical empty is not supported for Variant")
-            }
         }
     }
 

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -194,18 +194,6 @@ impl Canonical {
                     Validity::from(n),
                 )
             }),
-            DType::Struct(struct_dtype, n) => Canonical::Struct(unsafe {
-                StructArray::new_unchecked(
-                    struct_dtype
-                        .fields()
-                        .map(|f| Canonical::empty(&f).into_array())
-                        .collect::<Arc<[_]>>(),
-                    struct_dtype.clone(),
-                    0,
-                    Validity::from(n),
-                )
-            }),
-            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(dtype, n) => Canonical::List(unsafe {
                 ListViewArray::new_unchecked(
                     Canonical::empty(dtype).into_array(),
@@ -226,6 +214,18 @@ impl Canonical {
                     0,
                 )
             }),
+            DType::Struct(struct_dtype, n) => Canonical::Struct(unsafe {
+                StructArray::new_unchecked(
+                    struct_dtype
+                        .fields()
+                        .map(|f| Canonical::empty(&f).into_array())
+                        .collect::<Arc<[_]>>(),
+                    struct_dtype.clone(),
+                    0,
+                    Validity::from(n),
+                )
+            }),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Extension(ext_dtype) => Canonical::Extension(ExtensionArray::new(
                 ext_dtype.clone(),
                 Canonical::empty(ext_dtype.storage_dtype()).into_array(),

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -1253,8 +1253,8 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
             vec![DType::Struct(fields.clone(), opposite)]
         }
         DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-        DType::Extension(_) => vec![], // Extension types typically only cast to themselves
         DType::Variant(_) => unimplemented!(),
+        DType::Extension(_) => vec![], // Extension types typically only cast to themselves
     };
 
     // Test each target dtype

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -706,10 +706,10 @@ fn test_comparison_inverse_consistency(array: &ArrayRef) {
     // Skip non-comparable types.
     match array.dtype() {
         DType::Null
-        | DType::Extension(_)
+        | DType::List(..)
         | DType::Struct(..)
         | DType::Union(..)
-        | DType::List(..) => return,
+        | DType::Extension(_) => return,
         _ => {}
     }
 
@@ -838,10 +838,10 @@ fn test_comparison_symmetry_consistency(array: &ArrayRef) {
     // Skip non-comparable types.
     match array.dtype() {
         DType::Null
-        | DType::Extension(_)
+        | DType::List(..)
         | DType::Struct(..)
         | DType::Union(..)
-        | DType::List(..) => return,
+        | DType::Extension(_) => return,
         _ => {}
     }
 
@@ -1203,6 +1203,13 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
             }
             targets
         }
+        DType::Decimal(decimal_type, nullability) => {
+            let opposite = match nullability {
+                Nullability::NonNullable => Nullability::Nullable,
+                Nullability::Nullable => Nullability::NonNullable,
+            };
+            vec![DType::Decimal(*decimal_type, opposite)]
+        }
         DType::Utf8(nullability) => {
             let opposite = match nullability {
                 Nullability::NonNullable => Nullability::Nullable,
@@ -1220,21 +1227,6 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
                 DType::Utf8(*nullability), // May fail if not valid UTF-8
             ]
         }
-        DType::Decimal(decimal_type, nullability) => {
-            let opposite = match nullability {
-                Nullability::NonNullable => Nullability::Nullable,
-                Nullability::Nullable => Nullability::NonNullable,
-            };
-            vec![DType::Decimal(*decimal_type, opposite)]
-        }
-        DType::Struct(fields, nullability) => {
-            let opposite = match nullability {
-                Nullability::NonNullable => Nullability::Nullable,
-                Nullability::Nullable => Nullability::NonNullable,
-            };
-            vec![DType::Struct(fields.clone(), opposite)]
-        }
-        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::List(element_type, nullability) => {
             let opposite = match nullability {
                 Nullability::NonNullable => Nullability::Nullable,
@@ -1253,6 +1245,14 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
                 opposite,
             )]
         }
+        DType::Struct(fields, nullability) => {
+            let opposite = match nullability {
+                Nullability::NonNullable => Nullability::Nullable,
+                Nullability::Nullable => Nullability::NonNullable,
+            };
+            vec![DType::Struct(fields.clone(), opposite)]
+        }
+        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::Extension(_) => vec![], // Extension types typically only cast to themselves
         DType::Variant(_) => unimplemented!(),
     };

--- a/vortex-array/src/dtype/dtype_impl.rs
+++ b/vortex-array/src/dtype/dtype_impl.rs
@@ -63,9 +63,9 @@ impl DType {
             | List(_, null)
             | FixedSizeList(_, _, null)
             | Struct(_, null)
-            | Union(null) => matches!(null, Nullability::Nullable),
+            | Union(null)
+            | Variant(null) => matches!(null, Nullability::Nullable),
             Extension(ext_dtype) => ext_dtype.storage_dtype().is_nullable(),
-            Variant(null) => matches!(null, Nullability::Nullable),
         }
     }
 
@@ -92,8 +92,8 @@ impl DType {
             FixedSizeList(edt, size, _) => FixedSizeList(Arc::clone(edt), *size, nullability),
             Struct(sf, _) => Struct(sf.clone(), nullability),
             Union(_) => Union(nullability),
-            Extension(ext) => Extension(ext.with_nullability(nullability)),
             Variant(_) => Variant(nullability),
+            Extension(ext) => Extension(ext.with_nullability(nullability)),
         }
     }
 
@@ -124,10 +124,10 @@ impl DType {
                         .all(|(l, r)| l.eq_ignore_nullability(&r)))
             }
             (Union(_), Union(_)) => true,
+            (Variant(_), Variant(_)) => true,
             (Extension(lhs_extdtype), Extension(rhs_extdtype)) => {
                 lhs_extdtype.eq_ignore_nullability(rhs_extdtype)
             }
-            (Variant(_), Variant(_)) => true,
             _ => false,
         }
     }
@@ -252,23 +252,22 @@ impl DType {
         matches!(self, Union(..))
     }
 
-    /// Check if `self` is a [`DType::Extension`] type
-    pub fn is_extension(&self) -> bool {
-        matches!(self, Extension(_))
-    }
-
     /// Check if `self` is a [`DType::Variant`] type
     pub fn is_variant(&self) -> bool {
         matches!(self, Variant(_))
+    }
+
+    /// Check if `self` is a [`DType::Extension`] type
+    pub fn is_extension(&self) -> bool {
+        matches!(self, Extension(_))
     }
 
     /// Check if `self` is a nested type, i.e. list, fixed size list, struct, or extension of a
     /// recursive type.
     pub fn is_nested(&self) -> bool {
         match self {
-            List(..) | FixedSizeList(..) | Struct(..) | Union(..) => true,
+            List(..) | FixedSizeList(..) | Struct(..) | Union(..) | Variant(..) => true,
             Extension(ext) => ext.storage_dtype().is_nested(),
-            Variant(..) => true,
             _ => false,
         }
     }
@@ -301,8 +300,8 @@ impl DType {
                 Some(sum)
             }
             Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            Extension(ext) => ext.storage_dtype().element_size(),
             Variant(_) => None,
+            Extension(ext) => ext.storage_dtype().element_size(),
         }
     }
 
@@ -478,8 +477,8 @@ impl Display for DType {
                     .join(", "),
             ),
             Union(null) => write!(f, "union(){null}"),
-            Extension(ext) => write!(f, "{}", ext),
             Variant(null) => write!(f, "variant{null}"),
+            Extension(ext) => write!(f, "{}", ext),
         }
     }
 }

--- a/vortex-array/src/dtype/dtype_impl.rs
+++ b/vortex-array/src/dtype/dtype_impl.rs
@@ -55,17 +55,17 @@ impl DType {
     pub fn is_nullable(&self) -> bool {
         match self {
             Null => true,
-            Extension(ext_dtype) => ext_dtype.storage_dtype().is_nullable(),
             Bool(null)
             | Primitive(_, null)
             | Decimal(_, null)
             | Utf8(null)
             | Binary(null)
-            | Struct(_, null)
-            | Union(null)
             | List(_, null)
             | FixedSizeList(_, _, null)
-            | Variant(null) => matches!(null, Nullability::Nullable),
+            | Struct(_, null)
+            | Union(null) => matches!(null, Nullability::Nullable),
+            Extension(ext_dtype) => ext_dtype.storage_dtype().is_nullable(),
+            Variant(null) => matches!(null, Nullability::Nullable),
         }
     }
 
@@ -88,10 +88,10 @@ impl DType {
             Decimal(ddt, _) => Decimal(*ddt, nullability),
             Utf8(_) => Utf8(nullability),
             Binary(_) => Binary(nullability),
-            Struct(sf, _) => Struct(sf.clone(), nullability),
-            Union(_) => Union(nullability),
             List(edt, _) => List(Arc::clone(edt), nullability),
             FixedSizeList(edt, size, _) => FixedSizeList(Arc::clone(edt), *size, nullability),
+            Struct(sf, _) => Struct(sf.clone(), nullability),
+            Union(_) => Union(nullability),
             Extension(ext) => Extension(ext.with_nullability(nullability)),
             Variant(_) => Variant(nullability),
         }
@@ -266,8 +266,9 @@ impl DType {
     /// recursive type.
     pub fn is_nested(&self) -> bool {
         match self {
-            List(..) | FixedSizeList(..) | Struct(..) | Union(..) | Variant(..) => true,
+            List(..) | FixedSizeList(..) | Struct(..) | Union(..) => true,
             Extension(ext) => ext.storage_dtype().is_nested(),
+            Variant(..) => true,
             _ => false,
         }
     }
@@ -465,6 +466,8 @@ impl Display for DType {
             Decimal(ddt, null) => write!(f, "{ddt}{null}"),
             Utf8(null) => write!(f, "utf8{null}"),
             Binary(null) => write!(f, "binary{null}"),
+            List(edt, null) => write!(f, "list({edt}){null}"),
+            FixedSizeList(edt, size, null) => write!(f, "fixed_size_list({edt})[{size}]{null}"),
             Struct(sf, null) => write!(
                 f,
                 "{{{}}}{null}",
@@ -475,8 +478,6 @@ impl Display for DType {
                     .join(", "),
             ),
             Union(null) => write!(f, "union(){null}"),
-            List(edt, null) => write!(f, "list({edt}){null}"),
-            FixedSizeList(edt, size, null) => write!(f, "fixed_size_list({edt})[{size}]{null}"),
             Extension(ext) => write!(f, "{}", ext),
             Variant(null) => write!(f, "variant{null}"),
         }

--- a/vortex-array/src/dtype/mod.rs
+++ b/vortex-array/src/dtype/mod.rs
@@ -98,20 +98,17 @@ pub enum DType {
     /// `DType`. See [`StructFields`] for more information.
     Struct(StructFields, Nullability),
 
+    // TODO(connor)[Union]: Add more info here!
     /// A logical union (sum) type.
-    ///
-    /// A subsequent change will replace this single-field variant with
-    /// `Union(UnionVariants, Nullability)` so the type can carry its named variants, per-variant
-    /// `DType`s, and `i8` type tags.
     Union(Nullability),
+
+    /// Variant type.
+    Variant(Nullability),
 
     /// A user-defined extension type.
     ///
     /// See [`ExtDTypeRef`] for more information.
     Extension(ExtDTypeRef),
-
-    /// Variant type.
-    Variant(Nullability),
 }
 
 impl PartialEq for DType {
@@ -132,8 +129,8 @@ impl PartialEq for DType {
             // StructFields handles its own Arc::ptr_eq in its PartialEq impl.
             (Self::Struct(a, na), Self::Struct(b, nb)) => na == nb && a == b,
             (Self::Union(a), Self::Union(b)) => a == b,
-            (Self::Extension(a), Self::Extension(b)) => a == b,
             (Self::Variant(a), Self::Variant(b)) => a == b,
+            (Self::Extension(a), Self::Extension(b)) => a == b,
             // Every variant is listed in the first position so that adding a new
             // variant produces a non-exhaustive match compile error.
             (Self::Null, _)
@@ -146,8 +143,8 @@ impl PartialEq for DType {
             | (Self::FixedSizeList(..), _)
             | (Self::Struct(..), _)
             | (Self::Union(..), _)
-            | (Self::Extension(_), _)
-            | (Self::Variant(_), _) => false,
+            | (Self::Variant(_), _)
+            | (Self::Extension(_), _) => false,
         }
     }
 }

--- a/vortex-array/src/dtype/mod.rs
+++ b/vortex-array/src/dtype/mod.rs
@@ -50,8 +50,11 @@ use std::sync::Arc;
 ///
 /// [`I32`]: PType::I32
 /// [`NonNullable`]: Nullability::NonNullable
+#[allow(
+    clippy::derived_hash_with_manual_eq,
+    reason = "manual PartialEq adds Arc::ptr_eq fast path only"
+)]
 #[derive(Debug, Clone, Eq, Hash)]
-#[allow(clippy::derived_hash_with_manual_eq)] // manual PartialEq adds Arc::ptr_eq fast path only
 pub enum DType {
     /// A logical null type.
     ///

--- a/vortex-array/src/dtype/serde/flatbuffers.rs
+++ b/vortex-array/src/dtype/serde/flatbuffers.rs
@@ -133,15 +133,15 @@ impl TryFrom<ViewedDType> for DType {
                     fb_decimal.nullable().into(),
                 ))
             }
-            fb::Type::Binary => Ok(Self::Binary(
-                fb.type__as_binary()
-                    .ok_or_else(|| vortex_err!("failed to parse binary from flatbuffer"))?
-                    .nullable()
-                    .into(),
-            )),
             fb::Type::Utf8 => Ok(Self::Utf8(
                 fb.type__as_utf_8()
                     .ok_or_else(|| vortex_err!("failed to parse utf-8 from flatbuffer"))?
+                    .nullable()
+                    .into(),
+            )),
+            fb::Type::Binary => Ok(Self::Binary(
+                fb.type__as_binary()
+                    .ok_or_else(|| vortex_err!("failed to parse binary from flatbuffer"))?
                     .nullable()
                     .into(),
             )),
@@ -293,6 +293,29 @@ impl WriteFlatBuffer for DType {
                 },
             )
             .as_union_value(),
+            Self::List(edt, n) => {
+                let element_type = Some(edt.as_ref().write_flatbuffer(fbb)?);
+                fb::List::create(
+                    fbb,
+                    &fb::ListArgs {
+                        element_type,
+                        nullable: (*n).into(),
+                    },
+                )
+                .as_union_value()
+            }
+            Self::FixedSizeList(edt, size, n) => {
+                let element_type = Some(edt.as_ref().write_flatbuffer(fbb)?);
+                fb::FixedSizeList::create(
+                    fbb,
+                    &fb::FixedSizeListArgs {
+                        element_type,
+                        size: *size,
+                        nullable: (*n).into(),
+                    },
+                )
+                .as_union_value()
+            }
             Self::Struct(st, n) => {
                 let names = st
                     .names()
@@ -324,29 +347,6 @@ impl WriteFlatBuffer for DType {
                 },
             )
             .as_union_value(),
-            Self::List(edt, n) => {
-                let element_type = Some(edt.as_ref().write_flatbuffer(fbb)?);
-                fb::List::create(
-                    fbb,
-                    &fb::ListArgs {
-                        element_type,
-                        nullable: (*n).into(),
-                    },
-                )
-                .as_union_value()
-            }
-            Self::FixedSizeList(edt, size, n) => {
-                let element_type = Some(edt.as_ref().write_flatbuffer(fbb)?);
-                fb::FixedSizeList::create(
-                    fbb,
-                    &fb::FixedSizeListArgs {
-                        element_type,
-                        size: *size,
-                        nullable: (*n).into(),
-                    },
-                )
-                .as_union_value()
-            }
             Self::Extension(ext) => {
                 let id = Some(fbb.create_string(ext.id().as_ref()));
                 let storage_dtype = Some(ext.storage_dtype().write_flatbuffer(fbb)?);
@@ -377,10 +377,10 @@ impl WriteFlatBuffer for DType {
             Self::Decimal(..) => fb::Type::Decimal,
             Self::Utf8(_) => fb::Type::Utf8,
             Self::Binary(_) => fb::Type::Binary,
-            Self::Struct(..) => fb::Type::Struct_,
-            Self::Union(..) => fb::Type::Union,
             Self::List(..) => fb::Type::List,
             Self::FixedSizeList(..) => fb::Type::FixedSizeList,
+            Self::Struct(..) => fb::Type::Struct_,
+            Self::Union(..) => fb::Type::Union,
             Self::Extension { .. } => fb::Type::Extension,
             Self::Variant(_) => fb::Type::Variant,
         };

--- a/vortex-array/src/dtype/serde/flatbuffers.rs
+++ b/vortex-array/src/dtype/serde/flatbuffers.rs
@@ -197,6 +197,12 @@ impl TryFrom<ViewedDType> for DType {
                     .ok_or_else(|| vortex_err!("failed to parse union from flatbuffer"))?;
                 Ok(Self::Union(fb_union.nullable().into()))
             }
+            fb::Type::Variant => {
+                let fb_variant = fb
+                    .type__as_variant()
+                    .ok_or_else(|| vortex_err!("failed to parse variant from flatbuffer"))?;
+                Ok(Self::Variant(fb_variant.nullable().into()))
+            }
             fb::Type::Extension => {
                 let fb_ext = fb
                     .type__as_extension()
@@ -232,12 +238,6 @@ impl TryFrom<ViewedDType> for DType {
                 };
 
                 Ok(Self::Extension(ext_dtype))
-            }
-            fb::Type::Variant => {
-                let fb_variant = fb
-                    .type__as_variant()
-                    .ok_or_else(|| vortex_err!("failed to parse variant from flatbuffer"))?;
-                Ok(Self::Variant(fb_variant.nullable().into()))
             }
             _ => Err(vortex_err!("Unknown DType variant")),
         }
@@ -347,6 +347,13 @@ impl WriteFlatBuffer for DType {
                 },
             )
             .as_union_value(),
+            Self::Variant(n) => fb::Variant::create(
+                fbb,
+                &fb::VariantArgs {
+                    nullable: (*n).into(),
+                },
+            )
+            .as_union_value(),
             Self::Extension(ext) => {
                 let id = Some(fbb.create_string(ext.id().as_ref()));
                 let storage_dtype = Some(ext.storage_dtype().write_flatbuffer(fbb)?);
@@ -361,13 +368,6 @@ impl WriteFlatBuffer for DType {
                 )
                 .as_union_value()
             }
-            Self::Variant(n) => fb::Variant::create(
-                fbb,
-                &fb::VariantArgs {
-                    nullable: (*n).into(),
-                },
-            )
-            .as_union_value(),
         };
 
         let dtype_type = match self {
@@ -381,8 +381,8 @@ impl WriteFlatBuffer for DType {
             Self::FixedSizeList(..) => fb::Type::FixedSizeList,
             Self::Struct(..) => fb::Type::Struct_,
             Self::Union(..) => fb::Type::Union,
-            Self::Extension { .. } => fb::Type::Extension,
             Self::Variant(_) => fb::Type::Variant,
+            Self::Extension { .. } => fb::Type::Extension,
         };
 
         Ok(fb::DType::create(

--- a/vortex-array/src/dtype/serde/proto.rs
+++ b/vortex-array/src/dtype/serde/proto.rs
@@ -87,6 +87,7 @@ impl DType {
                 s.nullable.into(),
             )),
             DtypeType::Union(u) => Ok(Self::Union(u.nullable.into())),
+            DtypeType::Variant(v) => Ok(Self::Variant(v.nullable.into())),
             DtypeType::Extension(e) => {
                 let id = ExtId::new(e.id.as_str());
                 let storage_dtype = DType::from_proto(
@@ -104,7 +105,6 @@ impl DType {
                 };
                 Ok(Self::Extension(ext_dtype))
             }
-            DtypeType::Variant(v) => Ok(Self::Variant(v.nullable.into())),
         }
     }
 }
@@ -156,14 +156,14 @@ impl TryFrom<&DType> for pb::DType {
                 DType::Union(null) => DtypeType::Union(pb::Union {
                     nullable: (*null).into(),
                 }),
+                DType::Variant(null) => DtypeType::Variant(pb::Variant {
+                    nullable: (*null).into(),
+                }),
                 DType::Extension(e) => DtypeType::Extension(Box::new(pb::Extension {
                     id: e.id().as_ref().into(),
                     storage_dtype: Some(Box::new(e.storage_dtype().try_into()?)),
                     metadata: Some(e.serialize_metadata()?),
                 })),
-                DType::Variant(null) => DtypeType::Variant(pb::Variant {
-                    nullable: (*null).into(),
-                }),
             }),
         })
     }

--- a/vortex-array/src/dtype/serde/proto.rs
+++ b/vortex-array/src/dtype/serde/proto.rs
@@ -45,17 +45,6 @@ impl DType {
             )),
             DtypeType::Utf8(u) => Ok(Self::Utf8(u.nullable.into())),
             DtypeType::Binary(b) => Ok(Self::Binary(b.nullable.into())),
-            DtypeType::Struct(s) => Ok(Self::Struct(
-                StructFields::new(
-                    s.names.iter().map(|s| s.as_str()).collect(),
-                    s.dtypes
-                        .iter()
-                        .map(|dt| DType::from_proto(dt, session))
-                        .collect::<VortexResult<Vec<_>>>()?,
-                ),
-                s.nullable.into(),
-            )),
-            DtypeType::Union(u) => Ok(Self::Union(u.nullable.into())),
             DtypeType::List(l) => {
                 let nullable = l.nullable.into();
                 Ok(Self::List(
@@ -87,6 +76,17 @@ impl DType {
                     nullable,
                 ))
             }
+            DtypeType::Struct(s) => Ok(Self::Struct(
+                StructFields::new(
+                    s.names.iter().map(|s| s.as_str()).collect(),
+                    s.dtypes
+                        .iter()
+                        .map(|dt| DType::from_proto(dt, session))
+                        .collect::<VortexResult<Vec<_>>>()?,
+                ),
+                s.nullable.into(),
+            )),
+            DtypeType::Union(u) => Ok(Self::Union(u.nullable.into())),
             DtypeType::Extension(e) => {
                 let id = ExtId::new(e.id.as_str());
                 let storage_dtype = DType::from_proto(
@@ -134,17 +134,6 @@ impl TryFrom<&DType> for pb::DType {
                 DType::Binary(null) => DtypeType::Binary(pb::Binary {
                     nullable: (*null).into(),
                 }),
-                DType::Struct(s, null) => DtypeType::Struct(pb::Struct {
-                    names: s.names().iter().map(|s| s.as_ref().to_string()).collect(),
-                    dtypes: s
-                        .fields()
-                        .map(|d| Self::try_from(&d))
-                        .collect::<VortexResult<Vec<_>>>()?,
-                    nullable: (*null).into(),
-                }),
-                DType::Union(null) => DtypeType::Union(pb::Union {
-                    nullable: (*null).into(),
-                }),
                 DType::List(edt, null) => DtypeType::List(Box::new(pb::List {
                     element_type: Some(Box::new(edt.as_ref().try_into()?)),
                     nullable: (*null).into(),
@@ -156,6 +145,17 @@ impl TryFrom<&DType> for pb::DType {
                         nullable: (*null).into(),
                     }))
                 }
+                DType::Struct(s, null) => DtypeType::Struct(pb::Struct {
+                    names: s.names().iter().map(|s| s.as_ref().to_string()).collect(),
+                    dtypes: s
+                        .fields()
+                        .map(|d| Self::try_from(&d))
+                        .collect::<VortexResult<Vec<_>>>()?,
+                    nullable: (*null).into(),
+                }),
+                DType::Union(null) => DtypeType::Union(pb::Union {
+                    nullable: (*null).into(),
+                }),
                 DType::Extension(e) => DtypeType::Extension(Box::new(pb::Extension {
                     id: e.id().as_ref().into(),
                     storage_dtype: Some(Box::new(e.storage_dtype().try_into()?)),

--- a/vortex-array/src/dtype/serde/serde.rs
+++ b/vortex-array/src/dtype/serde/serde.rs
@@ -116,10 +116,10 @@ impl Serialize for DType {
                 state.end()
             }
             DType::Union(n) => serializer.serialize_newtype_variant("DType", 11, "Union", n),
+            DType::Variant(n) => serializer.serialize_newtype_variant("DType", 10, "Variant", n),
             DType::Extension(ext) => {
                 serializer.serialize_newtype_variant("DType", 9, "Extension", ext)
             }
-            DType::Variant(n) => serializer.serialize_newtype_variant("DType", 10, "Variant", n),
         }
     }
 }
@@ -159,8 +159,8 @@ impl<'de> DeserializeSeed<'de> for DTypeSerde<'_, DType> {
             "FixedSizeList",
             "Struct",
             "Union",
-            "Extension",
             "Variant",
+            "Extension",
         ];
 
         struct DTypeVisitor<'a> {
@@ -221,14 +221,14 @@ impl<'de> DeserializeSeed<'de> for DTypeSerde<'_, DType> {
                         let n = access.newtype_variant()?;
                         Ok(DType::Union(n))
                     }
+                    "Variant" => {
+                        let n = access.newtype_variant()?;
+                        Ok(DType::Variant(n))
+                    }
                     "Extension" => {
                         let ext = access
                             .newtype_variant_seed(DTypeSerde::<ExtDTypeRef>::new(self.session))?;
                         Ok(DType::Extension(ext))
-                    }
-                    "Variant" => {
-                        let n = access.newtype_variant()?;
-                        Ok(DType::Variant(n))
                     }
                     _ => Err(de::Error::unknown_variant(&variant, VARIANTS)),
                 }

--- a/vortex-array/src/scalar/arbitrary.rs
+++ b/vortex-array/src/scalar/arbitrary.rs
@@ -64,16 +64,6 @@ pub fn random_scalar(u: &mut Unstructured, dtype: &DType) -> Result<Scalar> {
             ))),
         )
         .vortex_expect("unable to construct random `Scalar`_"),
-        DType::Struct(sdt, _) => Scalar::try_new(
-            dtype.clone(),
-            Some(ScalarValue::Tuple(
-                sdt.fields()
-                    .map(|d| random_scalar(u, &d).map(|s| s.into_value()))
-                    .collect::<Result<Vec<_>>>()?,
-            )),
-        )
-        .vortex_expect("unable to construct random `Scalar`_"),
-        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::List(edt, _) => Scalar::try_new(
             dtype.clone(),
             Some(ScalarValue::Tuple(
@@ -96,6 +86,16 @@ pub fn random_scalar(u: &mut Unstructured, dtype: &DType) -> Result<Scalar> {
             )),
         )
         .vortex_expect("unable to construct random `Scalar`_"),
+        DType::Struct(sdt, _) => Scalar::try_new(
+            dtype.clone(),
+            Some(ScalarValue::Tuple(
+                sdt.fields()
+                    .map(|d| random_scalar(u, &d).map(|s| s.into_value()))
+                    .collect::<Result<Vec<_>>>()?,
+            )),
+        )
+        .vortex_expect("unable to construct random `Scalar`_"),
+        DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
         DType::Extension(..) => {
             unreachable!("Can't yet generate arbitrary scalars for ext dtype")
         }

--- a/vortex-array/src/scalar/arbitrary.rs
+++ b/vortex-array/src/scalar/arbitrary.rs
@@ -96,10 +96,10 @@ pub fn random_scalar(u: &mut Unstructured, dtype: &DType) -> Result<Scalar> {
         )
         .vortex_expect("unable to construct random `Scalar`_"),
         DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
+        DType::Variant(_) => todo!(),
         DType::Extension(..) => {
             unreachable!("Can't yet generate arbitrary scalars for ext dtype")
         }
-        DType::Variant(_) => todo!(),
     })
 }
 

--- a/vortex-array/src/scalar/arrow.rs
+++ b/vortex-array/src/scalar/arrow.rs
@@ -61,10 +61,10 @@ impl TryFrom<&Scalar> for Arc<dyn Datum> {
             DType::Decimal(..) => decimal_to_arrow(value.as_decimal()),
             DType::Utf8(_) => utf8_to_arrow(value.as_utf8()),
             DType::Binary(_) => binary_to_arrow(value.as_binary()),
-            DType::Struct(..) => unimplemented!("struct scalar conversion"),
-            DType::Union(..) => unimplemented!("union scalar conversion"),
             DType::List(..) => unimplemented!("list scalar conversion"),
             DType::FixedSizeList(..) => unimplemented!("fixed-size list scalar conversion"),
+            DType::Struct(..) => unimplemented!("struct scalar conversion"),
+            DType::Union(..) => unimplemented!("union scalar conversion"),
             DType::Extension(..) => extension_to_arrow(value.as_extension()),
             DType::Variant(_) => unimplemented!("Variant scalar conversion"),
         }

--- a/vortex-array/src/scalar/arrow.rs
+++ b/vortex-array/src/scalar/arrow.rs
@@ -65,8 +65,8 @@ impl TryFrom<&Scalar> for Arc<dyn Datum> {
             DType::FixedSizeList(..) => unimplemented!("fixed-size list scalar conversion"),
             DType::Struct(..) => unimplemented!("struct scalar conversion"),
             DType::Union(..) => unimplemented!("union scalar conversion"),
-            DType::Extension(..) => extension_to_arrow(value.as_extension()),
             DType::Variant(_) => unimplemented!("Variant scalar conversion"),
+            DType::Extension(..) => extension_to_arrow(value.as_extension()),
         }
     }
 }

--- a/vortex-array/src/scalar/cast.rs
+++ b/vortex-array/src/scalar/cast.rs
@@ -59,8 +59,8 @@ impl Scalar {
             DType::List(..) | DType::FixedSizeList(..) => self.as_list().cast(target_dtype),
             DType::Struct(..) => self.as_struct().cast(target_dtype),
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::Extension(..) => self.as_extension().cast(target_dtype),
             DType::Variant(_) => vortex_bail!("Variant scalars can't be cast to {target_dtype}"),
+            DType::Extension(..) => self.as_extension().cast(target_dtype),
         }
     }
 

--- a/vortex-array/src/scalar/cast.rs
+++ b/vortex-array/src/scalar/cast.rs
@@ -56,9 +56,9 @@ impl Scalar {
             DType::Decimal(..) => self.as_decimal().cast(target_dtype),
             DType::Utf8(_) => self.as_utf8().cast(target_dtype),
             DType::Binary(_) => self.as_binary().cast(target_dtype),
+            DType::List(..) | DType::FixedSizeList(..) => self.as_list().cast(target_dtype),
             DType::Struct(..) => self.as_struct().cast(target_dtype),
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::List(..) | DType::FixedSizeList(..) => self.as_list().cast(target_dtype),
             DType::Extension(..) => self.as_extension().cast(target_dtype),
             DType::Variant(_) => vortex_bail!("Variant scalars can't be cast to {target_dtype}"),
         }

--- a/vortex-array/src/scalar/display.rs
+++ b/vortex-array/src/scalar/display.rs
@@ -21,8 +21,8 @@ impl Display for Scalar {
             DType::List(..) | DType::FixedSizeList(..) => write!(f, "{}", self.as_list()),
             DType::Struct(..) => write!(f, "{}", self.as_struct()),
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::Extension(_) => write!(f, "{}", self.as_extension()),
             DType::Variant(_) => write!(f, "{}", self.as_variant()),
+            DType::Extension(_) => write!(f, "{}", self.as_extension()),
         }
     }
 }

--- a/vortex-array/src/scalar/display.rs
+++ b/vortex-array/src/scalar/display.rs
@@ -18,9 +18,9 @@ impl Display for Scalar {
             DType::Decimal(..) => write!(f, "{}", self.as_decimal()),
             DType::Utf8(_) => write!(f, "{}", self.as_utf8()),
             DType::Binary(_) => write!(f, "{}", self.as_binary()),
+            DType::List(..) | DType::FixedSizeList(..) => write!(f, "{}", self.as_list()),
             DType::Struct(..) => write!(f, "{}", self.as_struct()),
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::List(..) | DType::FixedSizeList(..) => write!(f, "{}", self.as_list()),
             DType::Extension(_) => write!(f, "{}", self.as_extension()),
             DType::Variant(_) => write!(f, "{}", self.as_variant()),
         }

--- a/vortex-array/src/scalar/scalar_impl.rs
+++ b/vortex-array/src/scalar/scalar_impl.rs
@@ -251,17 +251,17 @@ impl Scalar {
             DType::Binary(_) => self
                 .value()
                 .map_or_else(|| 0, |value| value.as_binary().len()),
+            DType::List(..) | DType::FixedSizeList(..) => self
+                .as_list()
+                .elements()
+                .map(|fields| fields.into_iter().map(|f| f.approx_nbytes()).sum::<usize>())
+                .unwrap_or_default(),
             DType::Struct(..) => self
                 .as_struct()
                 .fields_iter()
                 .map(|fields| fields.into_iter().map(|f| f.approx_nbytes()).sum::<usize>())
                 .unwrap_or_default(),
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::List(..) | DType::FixedSizeList(..) => self
-                .as_list()
-                .elements()
-                .map(|fields| fields.into_iter().map(|f| f.approx_nbytes()).sum::<usize>())
-                .unwrap_or_default(),
             DType::Extension(_) => self.as_extension().to_storage_scalar().approx_nbytes(),
             DType::Variant(_) => self.as_variant().value().map_or(0, Scalar::approx_nbytes),
         }

--- a/vortex-array/src/scalar/scalar_impl.rs
+++ b/vortex-array/src/scalar/scalar_impl.rs
@@ -193,8 +193,8 @@ impl Scalar {
             // TODO(connor): This also seems wrong...
             DType::Struct(struct_fields, _) => value.as_list().len() == struct_fields.nfields(),
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::Extension(_) => self.as_extension().to_storage_scalar().is_zero()?,
             DType::Variant(_) => self.as_variant().is_zero()?,
+            DType::Extension(_) => self.as_extension().to_storage_scalar().is_zero()?,
         };
 
         Some(is_zero)
@@ -262,8 +262,8 @@ impl Scalar {
                 .map(|fields| fields.into_iter().map(|f| f.approx_nbytes()).sum::<usize>())
                 .unwrap_or_default(),
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::Extension(_) => self.as_extension().to_storage_scalar().approx_nbytes(),
             DType::Variant(_) => self.as_variant().value().map_or(0, Scalar::approx_nbytes),
+            DType::Extension(_) => self.as_extension().to_storage_scalar().approx_nbytes(),
         }
     }
 }

--- a/vortex-array/src/scalar/scalar_value.rs
+++ b/vortex-array/src/scalar/scalar_value.rs
@@ -63,13 +63,13 @@ impl ScalarValue {
                 Self::Tuple(field_values)
             }
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
+            DType::Variant(_) => Self::Variant(Box::new(Scalar::null(DType::Null))),
             DType::Extension(ext_dtype) => {
                 // Since we have no way to define a "zero" extension value (since we have no idea
                 // what the semantics of the extension is), a best effort attempt is to just use the
                 // zero storage value and try to make an extension scalar from that.
                 Self::zero_value(ext_dtype.storage_dtype())
             }
-            DType::Variant(_) => Self::Variant(Box::new(Scalar::null(DType::Null))),
         }
     }
 
@@ -101,13 +101,13 @@ impl ScalarValue {
                 Self::Tuple(field_values)
             }
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
+            DType::Variant(_) => Self::Variant(Box::new(Scalar::null(DType::Null))),
             DType::Extension(ext_dtype) => {
                 // Since we have no way to define a "default" extension value (since we have no idea
                 // what the semantics of the extension is), a best effort attempt is to just use the
                 // default storage value and try to make an extension scalar from that.
                 Self::default_value(ext_dtype.storage_dtype())?
             }
-            DType::Variant(_) => Self::Variant(Box::new(Scalar::null(DType::Null))),
         })
     }
 }

--- a/vortex-array/src/scalar/validate.rs
+++ b/vortex-array/src/scalar/validate.rs
@@ -119,7 +119,6 @@ impl Scalar {
                 }
             }
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::Extension(ext_dtype) => ext_dtype.validate_storage_value(value)?,
             DType::Variant(_) => {
                 let ScalarValue::Variant(inner) = value else {
                     vortex_bail!("variant dtype expected Variant value, got {value}");
@@ -132,6 +131,7 @@ impl Scalar {
                     inner.dtype(),
                 );
             }
+            DType::Extension(ext_dtype) => ext_dtype.validate_storage_value(value)?,
         }
 
         Ok(())

--- a/vortex-datafusion/src/convert/scalars.rs
+++ b/vortex-datafusion/src/convert/scalars.rs
@@ -115,6 +115,7 @@ impl TryToDataFusion<ScalarValue> for Scalar {
             DType::FixedSizeList(..) => todo!("fixed-size list scalar conversion"),
             DType::Struct(..) => todo!("struct scalar conversion"),
             DType::Union(..) => todo!("union scalar conversion"),
+            DType::Variant(_) => vortex_bail!("Variant scalars aren't supported with DF"),
             DType::Extension(ext) => {
                 let storage_scalar = self.as_extension().to_storage_scalar();
 
@@ -161,7 +162,6 @@ impl TryToDataFusion<ScalarValue> for Scalar {
                     },
                 }
             }
-            DType::Variant(_) => vortex_bail!("Variant scalars aren't supported with DF"),
         })
     }
 }

--- a/vortex-datafusion/src/convert/scalars.rs
+++ b/vortex-datafusion/src/convert/scalars.rs
@@ -111,10 +111,10 @@ impl TryToDataFusion<ScalarValue> for Scalar {
                     .cloned()
                     .map(|b| Vec::<u8>::from(b.into_inner())),
             ),
-            DType::Struct(..) => todo!("struct scalar conversion"),
-            DType::Union(..) => todo!("union scalar conversion"),
             DType::List(..) => todo!("list scalar conversion"),
             DType::FixedSizeList(..) => todo!("fixed-size list scalar conversion"),
+            DType::Struct(..) => todo!("struct scalar conversion"),
+            DType::Union(..) => todo!("union scalar conversion"),
             DType::Extension(ext) => {
                 let storage_scalar = self.as_extension().to_storage_scalar();
 

--- a/vortex-duckdb/src/convert/dtype.rs
+++ b/vortex-duckdb/src/convert/dtype.rs
@@ -218,18 +218,14 @@ impl TryFrom<&DType> for LogicalType {
             DType::Null => DUCKDB_TYPE::DUCKDB_TYPE_SQLNULL,
             DType::Bool(_) => DUCKDB_TYPE::DUCKDB_TYPE_BOOLEAN,
             DType::Primitive(ptype, _) => return LogicalType::try_from(*ptype),
-            DType::Utf8(_) => DUCKDB_TYPE::DUCKDB_TYPE_VARCHAR,
-            DType::Binary(_) => DUCKDB_TYPE::DUCKDB_TYPE_BLOB,
-            DType::Struct(struct_type, _) => {
-                return LogicalType::try_from(struct_type);
-            }
-            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Decimal(decimal_dtype, _) => {
                 return LogicalType::decimal_type(
                     decimal_dtype.precision(),
                     decimal_dtype.scale().try_into()?,
                 );
             }
+            DType::Utf8(_) => DUCKDB_TYPE::DUCKDB_TYPE_VARCHAR,
+            DType::Binary(_) => DUCKDB_TYPE::DUCKDB_TYPE_BLOB,
             DType::List(element_dtype, _) => {
                 let element_logical_type = LogicalType::try_from(element_dtype.as_ref())?;
                 return LogicalType::list_type(element_logical_type);
@@ -238,9 +234,10 @@ impl TryFrom<&DType> for LogicalType {
                 let element_logical_type = LogicalType::try_from(element_dtype.as_ref())?;
                 return LogicalType::array_type(element_logical_type, *list_size);
             }
-            DType::Variant(_) => {
-                vortex_bail!("Vortex Variant array aren't supported in DuckDB")
+            DType::Struct(struct_type, _) => {
+                return LogicalType::try_from(struct_type);
             }
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Extension(ext_dtype) => {
                 let Some(temporal) = ext_dtype.metadata_opt::<AnyTemporal>() else {
                     vortex_bail!("Unsupported extension type \"{}\"", ext_dtype.id());
@@ -276,6 +273,9 @@ impl TryFrom<&DType> for LogicalType {
                         _ => vortex_bail!("Invalid TimeUnit {} for time", unit),
                     },
                 }
+            }
+            DType::Variant(_) => {
+                vortex_bail!("Vortex Variant array aren't supported in DuckDB")
             }
         };
 

--- a/vortex-duckdb/src/convert/dtype.rs
+++ b/vortex-duckdb/src/convert/dtype.rs
@@ -238,6 +238,9 @@ impl TryFrom<&DType> for LogicalType {
                 return LogicalType::try_from(struct_type);
             }
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
+            DType::Variant(_) => {
+                vortex_bail!("Vortex Variant array aren't supported in DuckDB")
+            }
             DType::Extension(ext_dtype) => {
                 let Some(temporal) = ext_dtype.metadata_opt::<AnyTemporal>() else {
                     vortex_bail!("Unsupported extension type \"{}\"", ext_dtype.id());
@@ -273,9 +276,6 @@ impl TryFrom<&DType> for LogicalType {
                         _ => vortex_bail!("Invalid TimeUnit {} for time", unit),
                     },
                 }
-            }
-            DType::Variant(_) => {
-                vortex_bail!("Vortex Variant array aren't supported in DuckDB")
             }
         };
 

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -79,10 +79,10 @@ impl ToDuckDBScalar for Scalar {
             DType::Binary(_) => self.as_binary().try_to_duckdb_scalar(),
             DType::List(..) | DType::FixedSizeList(..) | DType::Struct(..) => todo!(),
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::Extension(..) => self.as_extension().try_to_duckdb_scalar(),
             DType::Variant(_) => {
                 vortex_bail!("Vortex Variant scalars aren't supported in DuckDB")
             }
+            DType::Extension(..) => self.as_extension().try_to_duckdb_scalar(),
         }
     }
 }

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -75,11 +75,11 @@ impl ToDuckDBScalar for Scalar {
             DType::Bool(_) => self.as_bool().try_to_duckdb_scalar(),
             DType::Primitive(..) => self.as_primitive().try_to_duckdb_scalar(),
             DType::Decimal(..) => self.as_decimal().try_to_duckdb_scalar(),
-            DType::Extension(..) => self.as_extension().try_to_duckdb_scalar(),
             DType::Utf8(_) => self.as_utf8().try_to_duckdb_scalar(),
             DType::Binary(_) => self.as_binary().try_to_duckdb_scalar(),
-            DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => todo!(),
+            DType::List(..) | DType::FixedSizeList(..) | DType::Struct(..) => todo!(),
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
+            DType::Extension(..) => self.as_extension().try_to_duckdb_scalar(),
             DType::Variant(_) => {
                 vortex_bail!("Vortex Variant scalars aren't supported in DuckDB")
             }

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -73,8 +73,8 @@ impl From<&DType> for vx_dtype_variant {
             DType::FixedSizeList(..) => vx_dtype_variant::DTYPE_FIXED_SIZE_LIST,
             DType::Struct(..) => vx_dtype_variant::DTYPE_STRUCT,
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::Extension(_) => vx_dtype_variant::DTYPE_EXTENSION,
             DType::Variant(_) => vortex_panic!("Variant DType is not supported in FFI yet"),
+            DType::Extension(_) => vx_dtype_variant::DTYPE_EXTENSION,
         }
     }
 }

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -69,10 +69,10 @@ impl From<&DType> for vx_dtype_variant {
             DType::Decimal(..) => vx_dtype_variant::DTYPE_DECIMAL,
             DType::Utf8(_) => vx_dtype_variant::DTYPE_UTF8,
             DType::Binary(_) => vx_dtype_variant::DTYPE_BINARY,
-            DType::Struct(..) => vx_dtype_variant::DTYPE_STRUCT,
-            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(..) => vx_dtype_variant::DTYPE_LIST,
             DType::FixedSizeList(..) => vx_dtype_variant::DTYPE_FIXED_SIZE_LIST,
+            DType::Struct(..) => vx_dtype_variant::DTYPE_STRUCT,
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Extension(_) => vx_dtype_variant::DTYPE_EXTENSION,
             DType::Variant(_) => vortex_panic!("Variant DType is not supported in FFI yet"),
         }

--- a/vortex-python/src/dtype/mod.rs
+++ b/vortex-python/src/dtype/mod.rs
@@ -129,10 +129,10 @@ impl PyDType {
             DType::Decimal(..) => Self::with_subclass(py, dtype, PyDecimalDType),
             DType::Utf8(..) => Self::with_subclass(py, dtype, PyUtf8DType),
             DType::Binary(..) => Self::with_subclass(py, dtype, PyBinaryDType),
-            DType::Struct(..) => Self::with_subclass(py, dtype, PyStructDType),
-            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(..) => Self::with_subclass(py, dtype, PyListDType),
             DType::FixedSizeList(..) => Self::with_subclass(py, dtype, PyFixedSizeListDType),
+            DType::Struct(..) => Self::with_subclass(py, dtype, PyStructDType),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Extension(..) => Self::with_subclass(py, dtype, PyExtensionDType),
             DType::Variant(_) => Err(PyValueError::new_err(
                 "Variant DType is not supported in Python yet",

--- a/vortex-python/src/dtype/mod.rs
+++ b/vortex-python/src/dtype/mod.rs
@@ -133,10 +133,10 @@ impl PyDType {
             DType::FixedSizeList(..) => Self::with_subclass(py, dtype, PyFixedSizeListDType),
             DType::Struct(..) => Self::with_subclass(py, dtype, PyStructDType),
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::Extension(..) => Self::with_subclass(py, dtype, PyExtensionDType),
             DType::Variant(_) => Err(PyValueError::new_err(
                 "Variant DType is not supported in Python yet",
             )),
+            DType::Extension(..) => Self::with_subclass(py, dtype, PyExtensionDType),
         }
     }
 

--- a/vortex-python/src/python_repr.rs
+++ b/vortex-python/src/python_repr.rs
@@ -67,17 +67,6 @@ impl Display for DTypePythonRepr<'_> {
             }
             DType::Utf8(n) => write!(f, "utf8(nullable={})", n.python_repr()),
             DType::Binary(n) => write!(f, "binary(nullable={})", n.python_repr()),
-            DType::Struct(st, n) => write!(
-                f,
-                "struct({{{}}}, nullable={})",
-                st.names()
-                    .iter()
-                    .zip(st.fields())
-                    .map(|(n, dt)| format!("\"{}\": {}", n, dt.python_repr()))
-                    .join(", "),
-                n.python_repr()
-            ),
-            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(edt, n) => write!(
                 f,
                 "list({}, nullable={})",
@@ -91,6 +80,17 @@ impl Display for DTypePythonRepr<'_> {
                 size,
                 n.python_repr()
             ),
+            DType::Struct(st, n) => write!(
+                f,
+                "struct({{{}}}, nullable={})",
+                st.names()
+                    .iter()
+                    .zip(st.fields())
+                    .map(|(n, dt)| format!("\"{}\": {}", n, dt.python_repr()))
+                    .join(", "),
+                n.python_repr()
+            ),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Extension(ext) => {
                 write!(
                     f,

--- a/vortex-python/src/python_repr.rs
+++ b/vortex-python/src/python_repr.rs
@@ -91,6 +91,7 @@ impl Display for DTypePythonRepr<'_> {
                 n.python_repr()
             ),
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
+            DType::Variant(_) => write!(f, "variant()"),
             DType::Extension(ext) => {
                 write!(
                     f,
@@ -104,7 +105,6 @@ impl Display for DTypePythonRepr<'_> {
                 }
                 write!(f, ")")
             }
-            DType::Variant(_) => write!(f, "variant()"),
         }
     }
 }

--- a/vortex-python/src/scalar/into_py.rs
+++ b/vortex-python/src/scalar/into_py.rs
@@ -85,12 +85,12 @@ impl<'py> IntoPyObject<'py> for PyVortex<&'_ Scalar> {
             }
             DType::Struct(..) => PyVortex(self.0.as_struct()).into_pyobject(py),
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::Extension(_) => {
-                PyVortex(&self.0.as_extension().to_storage_scalar()).into_pyobject(py)
-            }
             DType::Variant(_) => Err(PyValueError::new_err(
                 "Variant scalars are not supported in Python yet",
             )),
+            DType::Extension(_) => {
+                PyVortex(&self.0.as_extension().to_storage_scalar()).into_pyobject(py)
+            }
         }
     }
 }

--- a/vortex-python/src/scalar/into_py.rs
+++ b/vortex-python/src/scalar/into_py.rs
@@ -80,11 +80,11 @@ impl<'py> IntoPyObject<'py> for PyVortex<&'_ Scalar> {
                 .cloned()
                 .map(PyVortex)
                 .into_pyobject(py),
-            DType::Struct(..) => PyVortex(self.0.as_struct()).into_pyobject(py),
-            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(..) | DType::FixedSizeList(..) => {
                 PyVortex(self.0.as_list()).into_pyobject(py)
             }
+            DType::Struct(..) => PyVortex(self.0.as_struct()).into_pyobject(py),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Extension(_) => {
                 PyVortex(&self.0.as_extension().to_storage_scalar()).into_pyobject(py)
             }

--- a/vortex-python/src/scalar/mod.rs
+++ b/vortex-python/src/scalar/mod.rs
@@ -118,10 +118,10 @@ impl PyScalar {
             }
             DType::Struct(..) => Self::with_subclass(py, scalar, PyStructScalar),
             DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::Extension(..) => Self::with_subclass(py, scalar, PyExtensionScalar),
             DType::Variant(_) => Err(PyValueError::new_err(
                 "Variant scalars are not supported in Python yet",
             )),
+            DType::Extension(..) => Self::with_subclass(py, scalar, PyExtensionScalar),
         }
     }
 

--- a/vortex-python/src/scalar/mod.rs
+++ b/vortex-python/src/scalar/mod.rs
@@ -111,13 +111,13 @@ impl PyScalar {
             DType::Decimal(..) => Self::with_subclass(py, scalar, PyDecimalScalar),
             DType::Utf8(..) => Self::with_subclass(py, scalar, PyUtf8Scalar),
             DType::Binary(..) => Self::with_subclass(py, scalar, PyBinaryScalar),
-            DType::Struct(..) => Self::with_subclass(py, scalar, PyStructScalar),
-            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::List(..) | DType::FixedSizeList(..) => {
                 // We represent both lists and fixed-size lists with `PyListScalar` since the notion
                 // of "fixed-size" only applies to full arrays, not scalars.
                 Self::with_subclass(py, scalar, PyListScalar)
             }
+            DType::Struct(..) => Self::with_subclass(py, scalar, PyStructScalar),
+            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
             DType::Extension(..) => Self::with_subclass(py, scalar, PyExtensionScalar),
             DType::Variant(_) => Err(PyValueError::new_err(
                 "Variant scalars are not supported in Python yet",


### PR DESCRIPTION
## Summary

This is a purely cosmetic change.

Since we now have a whole 12 dtype enum variants (with the addition of `Union`), we might as well be more consistent with the ordering of match statements.

Also moves `Extension` to the end of the enum.

If you are strongly against this PR, then just close it for me.

## Testing

N/A
