### PR TITLE
add export to cdata to vortex-ffi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10116,6 +10116,7 @@ dependencies = [
 name = "vortex-ffi"
 version = "0.1.0"
 dependencies = [
+ "arrow-array",
  "async-fs",
  "cbindgen",
  "futures",

--- a/vortex-ffi/Cargo.toml
+++ b/vortex-ffi/Cargo.toml
@@ -20,6 +20,7 @@ categories = { workspace = true }
 all-features = true
 
 [dependencies]
+arrow-array = { workspace = true, features = ["ffi"] }
 async-fs = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }

--- a/vortex-ffi/cbindgen.toml
+++ b/vortex-ffi/cbindgen.toml
@@ -13,13 +13,15 @@ header = """
 // THIS FILE IS AUTO-GENERATED, DO NOT MAKE EDITS DIRECTLY
 //
 """
+#[export]
+#include = ["FFI_ArrowArray", "FFI_ArrowSchema"]
 
 [export.rename]
 "f16" = "uint16_t"
 
 [parse]
 parse_deps = true
-include = ["vortex", "vortex-array"]
+include = ["vortex", "vortex-array", "arrow-schema", "arrow-data"]
 
 [parse.expand]
 crates = ["vortex-ffi"]

--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -5,6 +5,7 @@
 // THIS FILE IS AUTO-GENERATED, DO NOT MAKE EDITS DIRECTLY
 //
 
+
 #pragma once
 
 #include <stdarg.h>
@@ -22,126 +23,126 @@
  * Variant enum for Vortex primitive types.
  */
 typedef enum {
-    /**
-     * Unsigned 8-bit integer
-     */
-    PTYPE_U8 = 0,
-    /**
-     * Unsigned 16-bit integer
-     */
-    PTYPE_U16 = 1,
-    /**
-     * Unsigned 32-bit integer
-     */
-    PTYPE_U32 = 2,
-    /**
-     * Unsigned 64-bit integer
-     */
-    PTYPE_U64 = 3,
-    /**
-     * Signed 8-bit integer
-     */
-    PTYPE_I8 = 4,
-    /**
-     * Signed 16-bit integer
-     */
-    PTYPE_I16 = 5,
-    /**
-     * Signed 32-bit integer
-     */
-    PTYPE_I32 = 6,
-    /**
-     * Signed 64-bit integer
-     */
-    PTYPE_I64 = 7,
-    /**
-     * 16-bit floating point number
-     */
-    PTYPE_F16 = 8,
-    /**
-     * 32-bit floating point number
-     */
-    PTYPE_F32 = 9,
-    /**
-     * 64-bit floating point number
-     */
-    PTYPE_F64 = 10,
+  /**
+   * Unsigned 8-bit integer
+   */
+  PTYPE_U8 = 0,
+  /**
+   * Unsigned 16-bit integer
+   */
+  PTYPE_U16 = 1,
+  /**
+   * Unsigned 32-bit integer
+   */
+  PTYPE_U32 = 2,
+  /**
+   * Unsigned 64-bit integer
+   */
+  PTYPE_U64 = 3,
+  /**
+   * Signed 8-bit integer
+   */
+  PTYPE_I8 = 4,
+  /**
+   * Signed 16-bit integer
+   */
+  PTYPE_I16 = 5,
+  /**
+   * Signed 32-bit integer
+   */
+  PTYPE_I32 = 6,
+  /**
+   * Signed 64-bit integer
+   */
+  PTYPE_I64 = 7,
+  /**
+   * 16-bit floating point number
+   */
+  PTYPE_F16 = 8,
+  /**
+   * 32-bit floating point number
+   */
+  PTYPE_F32 = 9,
+  /**
+   * 64-bit floating point number
+   */
+  PTYPE_F64 = 10,
 } vx_ptype;
 
 /**
  * The variant tag for a Vortex data type.
  */
 typedef enum {
-    /**
-     * Null type.
-     */
-    DTYPE_NULL = 0,
-    /**
-     * Boolean type.
-     */
-    DTYPE_BOOL = 1,
-    /**
-     * Primitive types (e.g., u8, i16, f32, etc.).
-     */
-    DTYPE_PRIMITIVE = 2,
-    /**
-     * Variable-length UTF-8 string type.
-     */
-    DTYPE_UTF8 = 3,
-    /**
-     * Variable-length binary data type.
-     */
-    DTYPE_BINARY = 4,
-    /**
-     * Nested struct type.
-     */
-    DTYPE_STRUCT = 5,
-    /**
-     * Nested list type.
-     */
-    DTYPE_LIST = 6,
-    /**
-     * User-defined extension type.
-     */
-    DTYPE_EXTENSION = 7,
-    /**
-     * Decimal type with fixed precision and scale.
-     */
-    DTYPE_DECIMAL = 8,
-    /**
-     * Nested fixed-size list type.
-     */
-    DTYPE_FIXED_SIZE_LIST = 9,
+  /**
+   * Null type.
+   */
+  DTYPE_NULL = 0,
+  /**
+   * Boolean type.
+   */
+  DTYPE_BOOL = 1,
+  /**
+   * Primitive types (e.g., u8, i16, f32, etc.).
+   */
+  DTYPE_PRIMITIVE = 2,
+  /**
+   * Variable-length UTF-8 string type.
+   */
+  DTYPE_UTF8 = 3,
+  /**
+   * Variable-length binary data type.
+   */
+  DTYPE_BINARY = 4,
+  /**
+   * Nested struct type.
+   */
+  DTYPE_STRUCT = 5,
+  /**
+   * Nested list type.
+   */
+  DTYPE_LIST = 6,
+  /**
+   * User-defined extension type.
+   */
+  DTYPE_EXTENSION = 7,
+  /**
+   * Decimal type with fixed precision and scale.
+   */
+  DTYPE_DECIMAL = 8,
+  /**
+   * Nested fixed-size list type.
+   */
+  DTYPE_FIXED_SIZE_LIST = 9,
 } vx_dtype_variant;
 
 /**
  * Log levels for the Vortex library.
  */
 typedef enum {
-    /**
-     * No logging will be performed.
-     */
-    LOG_LEVEL_OFF = 0,
-    /**
-     * Only error messages will be logged.
-     */
-    LOG_LEVEL_ERROR = 1,
-    /**
-     * Warnings and error messages will be logged.
-     */
-    LOG_LEVEL_WARN = 2,
-    /**
-     * Informational messages, warnings, and error messages will be logged.
-     */
-    LOG_LEVEL_INFO = 3,
-    /**
-     * Debug messages, informational messages, warnings, and error messages will be logged.
-     */
-    LOG_LEVEL_DEBUG = 4,
-    /**
-     * All messages, including trace messages, will be logged.
-     */
-    LOG_LEVEL_TRACE = 5,
+  /**
+   * No logging will be performed.
+   */
+  LOG_LEVEL_OFF = 0,
+  /**
+   * Only error messages will be logged.
+   */
+  LOG_LEVEL_ERROR = 1,
+  /**
+   * Warnings and error messages will be logged.
+   */
+  LOG_LEVEL_WARN = 2,
+  /**
+   * Informational messages, warnings, and error messages will be logged.
+   */
+  LOG_LEVEL_INFO = 3,
+  /**
+   * Debug messages, informational messages, warnings, and error messages will be logged.
+   */
+  LOG_LEVEL_DEBUG = 4,
+  /**
+   * All messages, including trace messages, will be logged.
+   */
+  LOG_LEVEL_TRACE = 5,
 } vx_log_level;
 
 /**
@@ -149,53 +150,53 @@ typedef enum {
  */
 enum PType
 #ifdef __cplusplus
-    : uint8_t
+  : uint8_t
 #endif // __cplusplus
-{
-    /**
-     * An 8-bit unsigned integer
-     */
-    U8 = 0,
-    /**
-     * A 16-bit unsigned integer
-     */
-    U16 = 1,
-    /**
-     * A 32-bit unsigned integer
-     */
-    U32 = 2,
-    /**
-     * A 64-bit unsigned integer
-     */
-    U64 = 3,
-    /**
-     * An 8-bit signed integer
-     */
-    I8 = 4,
-    /**
-     * A 16-bit signed integer
-     */
-    I16 = 5,
-    /**
-     * A 32-bit signed integer
-     */
-    I32 = 6,
-    /**
-     * A 64-bit signed integer
-     */
-    I64 = 7,
-    /**
-     * A 16-bit floating point number
-     */
-    F16 = 8,
-    /**
-     * A 32-bit floating point number
-     */
-    F32 = 9,
-    /**
-     * A 64-bit floating point number
-     */
-    F64 = 10,
+ {
+  /**
+   * An 8-bit unsigned integer
+   */
+  U8 = 0,
+  /**
+   * A 16-bit unsigned integer
+   */
+  U16 = 1,
+  /**
+   * A 32-bit unsigned integer
+   */
+  U32 = 2,
+  /**
+   * A 64-bit unsigned integer
+   */
+  U64 = 3,
+  /**
+   * An 8-bit signed integer
+   */
+  I8 = 4,
+  /**
+   * A 16-bit signed integer
+   */
+  I16 = 5,
+  /**
+   * A 32-bit signed integer
+   */
+  I32 = 6,
+  /**
+   * A 64-bit signed integer
+   */
+  I64 = 7,
+  /**
+   * A 16-bit floating point number
+   */
+  F16 = 8,
+  /**
+   * A 32-bit floating point number
+   */
+  F32 = 9,
+  /**
+   * A 64-bit floating point number
+   */
+  F64 = 10,
 };
 #ifndef __cplusplus
 typedef uint8_t PType;
@@ -326,63 +327,118 @@ typedef struct vx_struct_fields_builder vx_struct_fields_builder;
  * Options supplied for opening a file.
  */
 typedef struct {
-    /**
-     * URI for opening the file.
-     * This must be a valid URI, even for files (file:///path/to/file)
-     */
-    const char *uri;
-    /**
-     * Additional configuration for the file source (e.g. "s3.accessKey").
-     * This may be null, in which case it is treated as empty.
-     */
-    const char *const *property_keys;
-    /**
-     * Additional configuration values for the file source (e.g. S3 credentials).
-     */
-    const char *const *property_vals;
-    /**
-     * Number of properties in `property_keys` and `property_vals`.
-     */
-    int property_len;
+  /**
+   * URI for opening the file.
+   * This must be a valid URI, even for files (file:///path/to/file)
+   */
+  const char *uri;
+  /**
+   * Additional configuration for the file source (e.g. "s3.accessKey").
+   * This may be null, in which case it is treated as empty.
+   */
+  const char *const *property_keys;
+  /**
+   * Additional configuration values for the file source (e.g. S3 credentials).
+   */
+  const char *const *property_vals;
+  /**
+   * Number of properties in `property_keys` and `property_vals`.
+   */
+  int property_len;
 } vx_file_open_options;
 
 /**
  * Scan options provided by an FFI client calling the `vx_file_scan` function.
  */
 typedef struct {
-    /**
-     * Column names to project out in the scan. These must be null-terminated C strings.
-     */
-    const char *projection_expression;
-    /**
-     * Number of columns in `projection`.
-     */
-    unsigned int projection_expr_len;
-    /**
-     * Serialized expressions for pushdown
-     */
-    const char *filter_expression;
-    /**
-     * The len in bytes of the filter expression
-     */
-    unsigned int filter_expression_len;
-    /**
-     * Splits the file into chunks of this size, if zero then we use the write layout.
-     */
-    int split_by_row_count;
-    /**
-     * First row of a range to scan.
-     */
-    unsigned long row_range_start;
-    /**
-     * Last row of a range to scan.
-     */
-    unsigned long row_range_end;
-    /**
-     * The row offset of the file in a multi-file scan.
-     */
-    unsigned long row_offset;
+  /**
+   * Column names to project out in the scan. These must be null-terminated C strings.
+   */
+  const char *projection_expression;
+  /**
+   * Number of columns in `projection`.
+   */
+  unsigned int projection_expr_len;
+  /**
+   * Serialized expressions for pushdown
+   */
+  const char *filter_expression;
+  /**
+   * The len in bytes of the filter expression
+   */
+  unsigned int filter_expression_len;
+  /**
+   * Splits the file into chunks of this size, if zero then we use the write layout.
+   */
+  int split_by_row_count;
+  /**
+   * First row of a range to scan.
+   */
+  unsigned long row_range_start;
+  /**
+   * Last row of a range to scan.
+   */
+  unsigned long row_range_end;
+  /**
+   * The row offset of the file in a multi-file scan.
+   */
+  unsigned long row_offset;
 } vx_file_scan_options;
+
+/**
+ * ABI-compatible struct for ArrowArray from C Data Interface
+ * See <https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions>
+ *
+ * ```
+ * # use arrow_data::ArrayData;
+ * # use arrow_data::ffi::FFI_ArrowArray;
+ * fn export_array(array: &ArrayData) -> FFI_ArrowArray {
+ *     FFI_ArrowArray::new(array)
+ * }
+ * ```
+ */
+typedef struct {
+  int64_t length;
+  int64_t null_count;
+  int64_t offset;
+  int64_t n_buffers;
+  int64_t n_children;
+  const void **buffers;
+  FFI_ArrowArray **children;
+  FFI_ArrowArray *dictionary;
+  void (*release)(FFI_ArrowArray *arg1);
+  void *private_data;
+} FFI_ArrowArray;
+
+/**
+ * ABI-compatible struct for `ArrowSchema` from C Data Interface
+ * See <https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions>
+ *
+ * ```
+ * # use arrow_schema::DataType;
+ * # use arrow_schema::ffi::FFI_ArrowSchema;
+ * fn array_schema(data_type: &DataType) -> FFI_ArrowSchema {
+ *     FFI_ArrowSchema::try_from(data_type).unwrap()
+ * }
+ * ```
+ *
+ */
+typedef struct {
+  const char *format;
+  const char *name;
+  const char *metadata;
+  /**
+   * Refer to [Arrow Flags](https://arrow.apache.org/docs/format/CDataInterface.html#c.ArrowSchema.flags)
+   */
+  int64_t flags;
+  int64_t n_children;
+  FFI_ArrowSchema **children;
+  FFI_ArrowSchema *dictionary;
+  void (*release)(FFI_ArrowSchema *arg1);
+  void *private_data;
+} FFI_ArrowSchema;
+
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -416,7 +472,10 @@ const vx_dtype *vx_array_dtype(const vx_array *array);
 
 const vx_array *vx_array_get_field(const vx_array *array, uint32_t index, vx_error **error_out);
 
-const vx_array *vx_array_slice(const vx_array *array, uint32_t start, uint32_t stop, vx_error **error_out);
+const vx_array *vx_array_slice(const vx_array *array,
+                               uint32_t start,
+                               uint32_t stop,
+                               vx_error **error_out);
 
 bool vx_array_is_null(const vx_array *array, uint32_t index, vx_error **_error_out);
 
@@ -470,13 +529,15 @@ double vx_array_get_storage_f64(const vx_array *array, uint32_t index);
  * Return the utf-8 string at `index` in the array. The pointer will be null if the value at `index` is null.
  * The caller must free the returned pointer.
  */
-const vx_string *vx_array_get_utf8(const vx_array *array, uint32_t index);
+const vx_string *vx_array_get_utf8(const vx_array *array,
+                                   uint32_t index);
 
 /**
  * Return the binary at `index` in the array. The pointer will be null if the value at `index` is null.
  * The caller must free the returned pointer.
  */
-const vx_binary *vx_array_get_binary(const vx_array *array, uint32_t index);
+const vx_binary *vx_array_get_binary(const vx_array *array,
+                                     uint32_t index);
 
 /**
  * Free an owned [`vx_array_iterator`] object.
@@ -491,7 +552,8 @@ void vx_array_iterator_free(vx_array_iterator *ptr);
  *
  * It is an error to call this function again after the iterator is finished.
  */
-const vx_array *vx_array_iterator_next(vx_array_iterator *iter, vx_error **error_out);
+const vx_array *vx_array_iterator_next(vx_array_iterator *iter,
+                                       vx_error **error_out);
 
 /**
  * Clone a borrowed [`vx_binary`], returning an owned [`vx_binary`].
@@ -571,7 +633,9 @@ const vx_dtype *vx_dtype_new_list(const vx_dtype *element, bool is_nullable);
  *
  * Takes ownership of the `element` pointer.
  */
-const vx_dtype *vx_dtype_new_fixed_size_list(const vx_dtype *element, uint32_t size, bool is_nullable);
+const vx_dtype *vx_dtype_new_fixed_size_list(const vx_dtype *element,
+                                             uint32_t size,
+                                             bool is_nullable);
 
 /**
  * Create a new struct data type.
@@ -693,8 +757,9 @@ void vx_file_free(const vx_file *ptr);
 /**
  * Open a file at the given path on the file system.
  */
-const vx_file *
-vx_file_open_reader(const vx_session *session, const vx_file_open_options *options, vx_error **error_out);
+const vx_file *vx_file_open_reader(const vx_session *session,
+                                   const vx_file_open_options *options,
+                                   vx_error **error_out);
 
 void vx_file_write_array(const vx_session *session,
                          const char *path,
@@ -864,6 +929,15 @@ void vx_struct_fields_builder_add_field(vx_struct_fields_builder *builder,
  */
 const vx_struct_fields *vx_struct_fields_builder_finalize(vx_struct_fields_builder *builder);
 
+/**
+ * Exports a Vortex Array into pre-allocated Arrow FFI C Data structures.
+ *
+ * # Safety
+ * The caller must ensure that `out_array` and `out_schema` point to valid,
+ * uninitialized or safely overwritable memory locations allocated by the host.
+ */
+int vx_array_export(const vx_array *array, FFI_ArrowArray *out_array, FFI_ArrowSchema *out_schema);
+
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/vortex-ffi/src/arrow.rs
+++ b/vortex-ffi/src/arrow.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::ffi::c_int;
+use arrow_array::{Array as ArrowArrayTrait, StructArray};
+use arrow_array::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
+use arrow_array::RecordBatch;
+use crate::array::vx_array;
+
+/// Exports a Vortex Array into pre-allocated Arrow FFI C Data structures.
+///
+/// # Safety
+/// The caller must ensure that `out_array` and `out_schema` point to valid,
+/// uninitialized or safely overwritable memory locations allocated by the host.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vx_array_export(
+    array: *const vx_array,
+    out_array: *mut FFI_ArrowArray,
+    out_schema: *mut FFI_ArrowSchema,
+) -> c_int {
+
+    // Reference the incoming Vortex array
+    let array = vx_array::as_ref(array);
+    //let sarray = StructArray::from(array.as_ref());
+    let record_batch = RecordBatch::try_from(array.as_ref());
+    let struct_array = StructArray::from(record_batch.unwrap().clone());
+
+    // Export schema + array
+    let schema = FFI_ArrowSchema::try_from(struct_array.data_type()).unwrap();
+    let array = FFI_ArrowArray::new(&struct_array.to_data());
+    unsafe {
+        std::ptr::write(out_array, array);
+        std::ptr::write(out_schema, schema);
+    }
+
+    0
+}

--- a/vortex-ffi/src/lib.rs
+++ b/vortex-ffi/src/lib.rs
@@ -19,6 +19,7 @@ mod session;
 mod sink;
 mod string;
 mod struct_fields;
+mod arrow;
 
 use std::ffi::CStr;
 use std::ffi::c_char;


### PR DESCRIPTION
Signed-off-by: Igor Vagulin <igor.vagulin@gmail.com>

<!--
Thank you for submitting a pull request! We appreciate your time and effort.

Please make sure to provide enough information so that we can review your pull
request. The Summary and Testing sections below contain guidance on what to
include.
-->

## Summary

Closes: #7924

## API Changes

PR add vx_array_export function to vortex-ffi to be able to get results in arrow-ffi format

## Testing

Tested from golang though cgo using following function

```
func ReadFileVortexFFI(sess *C.struct_vx_session, fileName string, b testing.TB) {
	vxf := C.vx_file_open_reader(sess, &opts, &openErr)
	it := C.vx_file_scan(sess, vxf, nil, &scanErr)
	for {
		arr := C.vx_array_iterator_next(it, &nextErr)
		var carr C.FFI_ArrowArray
		var cschema C.FFI_ArrowSchema
		C.vx_array_export(arr, &carr, &cschema)
		rec, err := cdata.ImportCRecordBatch(
			(*cdata.CArrowArray)(unsafe.Pointer(&carr)),
			(*cdata.CArrowSchema)(unsafe.Pointer(&cschema)),
		)
		require.NoError(b, err)
		rec.Release()
	}
}
```