### PR TITLE
Remove chunked special case from stat execution

### DIFF
--- a/vortex-array/src/scalar_fn/fns/stat.rs
+++ b/vortex-array/src/scalar_fn/fns/stat.rs
@@ -13,10 +13,7 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::aggregate_fn::AggregateFnRef;
-use crate::arrays::Chunked;
-use crate::arrays::ChunkedArray;
 use crate::arrays::ConstantArray;
-use crate::arrays::chunked::ChunkedArrayExt;
 use crate::dtype::DType;
 use crate::expr::Expression;
 use crate::expr::stats::StatsProvider;
@@ -115,26 +112,6 @@ impl ScalarFnVTable for StatFn {
     ) -> VortexResult<ArrayRef> {
         let input = args.get(0)?;
         let dtype = stat_dtype(options.aggregate_fn(), input.dtype())?;
-
-        // Recurse into each chunk so the output keeps per-chunk granularity (one constant
-        // per chunk) instead of collapsing to a single combined stat across the whole array.
-        // Per-chunk granularity is what makes the result useful for pruning: predicates can
-        // drop whole chunks at a time. Without this, we'd lose every chunk boundary as a
-        // pruning opportunity. Other encodings (zone maps, etc.) will need similar
-        // structure-preserving handling once they land.
-        if let Some(chunked) = input.as_opt::<Chunked>() {
-            tracing::trace!(
-                "stat({}) descending into ChunkedArray with {} chunks",
-                options.aggregate_fn(),
-                chunked.nchunks()
-            );
-            let chunks = chunked
-                .iter_chunks()
-                .map(|chunk| stat_array(chunk, options.aggregate_fn(), dtype.clone(), chunk.len()))
-                .collect::<VortexResult<Vec<_>>>()?;
-            return Ok(ChunkedArray::try_new(chunks, dtype)?.into_array());
-        }
-
         stat_array(&input, options.aggregate_fn(), dtype, args.row_count())
     }
 }


### PR DESCRIPTION
Part of #7707.

Stack: 1/3

Base: `develop`
Next: #7929

## Summary

- Remove the explicit chunked-array special case from `StatFn::execute`.
- Rely on the existing chunked scalar-function pushdown path to preserve per-chunk stat results.
- Keep the existing chunked stats regression test covering the behavior.

## Checks

- `cargo test -p vortex-array stat_expr_reads_cached_sum_per_chunk`
