### PR TITLE
Phase 1: partition zoned stats internally

### DIFF
--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -272,7 +272,7 @@ impl WriteStrategyBuilder {
             Default::default(),
         );
 
-        // 2. calculate stats for each row group
+        // 2. calculate fixed-size zone stats while leaving data chunking to the child strategy.
         let stats = ZonedStrategy::new(
             dict,
             compress_then_flat.clone(),
@@ -282,24 +282,11 @@ impl WriteStrategyBuilder {
             },
         );
 
-        // 1. repartition each column to fixed row counts
-        let repartition = RepartitionStrategy::new(
-            stats,
-            RepartitionWriterOptions {
-                // No minimum block size in bytes
-                block_size_minimum: 0,
-                // Always repartition into 8K row blocks
-                block_len_multiple: self.row_block_size,
-                block_size_target: None,
-                canonicalize: false,
-            },
-        );
-
         // 0. start with splitting columns
         let validity_strategy = CollectStrategy::new(compress_then_flat);
 
         // Take any field overrides from the builder and apply them to the final strategy.
-        let table_strategy = TableStrategy::new(Arc::new(validity_strategy), Arc::new(repartition))
+        let table_strategy = TableStrategy::new(Arc::new(validity_strategy), Arc::new(stats))
             .with_field_writers(self.field_writers);
 
         Arc::new(table_strategy)

--- a/vortex-layout/src/layouts/zoned/builder.rs
+++ b/vortex-layout/src/layouts/zoned/builder.rs
@@ -25,7 +25,6 @@ use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::expr::stats::Precision;
 use vortex_array::expr::stats::Stat;
-use vortex_array::expr::stats::StatsProvider;
 use vortex_array::scalar::Scalar;
 use vortex_array::scalar::ScalarTruncation;
 use vortex_array::scalar::lower_bound;
@@ -65,18 +64,6 @@ impl StatsAccumulator {
             builders,
             length: 0,
         }
-    }
-
-    pub fn push_chunk_without_compute(&mut self, array: &ArrayRef) -> VortexResult<()> {
-        for builder in &mut self.builders {
-            if let Some(Precision::Exact(value)) = array.statistics().get(builder.stat()) {
-                builder.append_scalar(value.cast(&value.dtype().as_nullable())?)?;
-            } else {
-                builder.append_null();
-            }
-        }
-        self.length += 1;
-        Ok(())
     }
 
     pub fn push_chunk(&mut self, array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<()> {

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -224,6 +224,7 @@ mod test {
     use vortex_array::IntoArray;
     use vortex_array::MaskFuture;
     use vortex_array::arrays::ChunkedArray;
+    use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::expr::gt;
     use vortex_array::expr::lit;
@@ -245,6 +246,7 @@ mod test {
     use crate::LayoutStrategy;
     use crate::VTable;
     use crate::children::OwnedLayoutChildren;
+    use crate::layouts::chunked::Chunked;
     use crate::layouts::chunked::writer::ChunkedLayoutStrategy;
     use crate::layouts::flat::writer::FlatLayoutStrategy;
     use crate::layouts::zoned::Zoned;
@@ -267,9 +269,10 @@ mod test {
             .with_handle(handle)
     }
 
-    #[fixture]
-    /// Create a stats layout with three chunks of primitive arrays.
-    fn stats_layout() -> (Arc<dyn SegmentSource>, LayoutRef) {
+    fn write_stats_layout(
+        chunks: Vec<Vec<i32>>,
+        block_size: usize,
+    ) -> (Arc<dyn SegmentSource>, LayoutRef) {
         let ctx = ArrayContext::empty();
         let segments = Arc::new(TestSegments::default());
         let (ptr, eof) = SequenceId::root().split();
@@ -277,15 +280,15 @@ mod test {
             ChunkedLayoutStrategy::new(FlatLayoutStrategy::default()),
             FlatLayoutStrategy::default(),
             ZonedLayoutOptions {
-                block_size: 3,
+                block_size,
                 ..Default::default()
             },
         );
-        let array_stream = ChunkedArray::from_iter([
-            buffer![1, 2, 3].into_array(),
-            buffer![4, 5, 6].into_array(),
-            buffer![7, 8, 9].into_array(),
-        ])
+        let array_stream = ChunkedArray::from_iter(
+            chunks
+                .into_iter()
+                .map(|chunk| PrimitiveArray::from_iter(chunk).into_array()),
+        )
         .into_array()
         .to_array_stream()
         .sequenced(ptr);
@@ -298,6 +301,12 @@ mod test {
         })
         .unwrap();
         (segments, layout)
+    }
+
+    #[fixture]
+    /// Create a stats layout with three chunks of primitive arrays.
+    fn stats_layout() -> (Arc<dyn SegmentSource>, LayoutRef) {
+        write_stats_layout(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]], 3)
     }
 
     #[rstest]
@@ -349,6 +358,52 @@ mod test {
                 result,
                 Mask::from_iter([false, false, false, false, false, false, true, true, true])
             );
+        })
+    }
+
+    #[rstest]
+    #[case::smaller_chunks(vec![vec![1, 2], vec![3, 4], vec![5, 6], vec![7, 8], vec![9]])]
+    #[case::larger_chunks(vec![vec![1, 2, 3, 4, 5], vec![6, 7, 8, 9]])]
+    #[case::unaligned_chunks(vec![vec![1, 2, 3, 4], vec![5, 6], vec![7, 8, 9]])]
+    fn test_writer_partitions_fixed_zones_independent_of_input_chunks(
+        #[case] chunks: Vec<Vec<i32>>,
+    ) -> VortexResult<()> {
+        let chunk_lengths = chunks.iter().map(Vec::len).collect::<Vec<_>>();
+        let (segments, layout) = write_stats_layout(chunks, 3);
+
+        let zoned_layout = layout.as_::<Zoned>();
+        assert_eq!(zoned_layout.zone_len(), 3);
+        assert_eq!(zoned_layout.nzones(), 3);
+
+        let data_layout = layout.child(0)?;
+        assert!(data_layout.is::<Chunked>());
+        assert_eq!(data_layout.nchildren(), chunk_lengths.len());
+
+        let mut offset = 0;
+        for (idx, chunk_len) in chunk_lengths.into_iter().enumerate() {
+            assert_eq!(data_layout.child_type(idx).row_offset(), Some(offset));
+            assert_eq!(data_layout.child(idx)?.row_count(), chunk_len as u64);
+            offset += chunk_len as u64;
+        }
+
+        block_on(|handle| async {
+            let row_count = layout.row_count();
+            let session = session_with_handle(handle);
+            let reader = layout.new_reader("".into(), segments, &session)?;
+
+            let result = reader
+                .pruning_evaluation(
+                    &(0..row_count),
+                    &gt(root(), lit(7)),
+                    Mask::new_true(row_count.try_into().unwrap()),
+                )?
+                .await?;
+
+            assert_eq!(
+                result,
+                Mask::from_iter([false, false, false, false, false, false, true, true, true])
+            );
+            Ok(())
         })
     }
 

--- a/vortex-layout/src/layouts/zoned/writer.rs
+++ b/vortex-layout/src/layouts/zoned/writer.rs
@@ -9,13 +9,18 @@ use async_trait::async_trait;
 use futures::StreamExt as _;
 use parking_lot::Mutex;
 use vortex_array::ArrayContext;
+use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::ChunkedArray;
+use vortex_array::arrays::StructArray;
+use vortex_array::dtype::DType;
 use vortex_array::expr::stats::Stat;
 use vortex_array::stats::PRUNING_STATS;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
-use vortex_io::session::RuntimeSessionExt;
 use vortex_session::VortexSession;
 use vortex_utils::parallelism::get_available_parallelism;
 
@@ -32,17 +37,14 @@ use crate::sequence::SequentialStreamAdapter;
 use crate::sequence::SequentialStreamExt;
 
 /// Configuration for building zoned layouts.
-///
-/// The input stream is assumed to already be partitioned into one chunk per zone, except
-/// possibly the final partial zone.
 pub struct ZonedLayoutOptions {
-    /// The size of a statistics block
+    /// The fixed number of rows covered by each zone map entry.
     pub block_size: usize,
     /// The statistics to collect for each block.
     pub stats: Arc<[Stat]>,
     /// Maximum length of a variable length statistics
     pub max_variable_length_statistics_size: usize,
-    /// Number of chunks to compute in parallel.
+    /// Reserved for future parallel zone-statistics computation.
     pub concurrency: usize,
 }
 
@@ -78,6 +80,82 @@ impl ZonedStrategy {
     }
 }
 
+struct FixedZoneStatsAccumulator {
+    stats: StatsAccumulator,
+    dtype: DType,
+    zone_len: usize,
+    pending: Vec<ArrayRef>,
+    pending_len: usize,
+}
+
+impl FixedZoneStatsAccumulator {
+    fn new(
+        dtype: DType,
+        stats: &[Stat],
+        max_variable_length_statistics_size: usize,
+        zone_len: usize,
+    ) -> Self {
+        Self {
+            stats: StatsAccumulator::new(&dtype, stats, max_variable_length_statistics_size),
+            dtype,
+            zone_len,
+            pending: Vec::new(),
+            pending_len: 0,
+        }
+    }
+
+    fn push_chunk(&mut self, chunk: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<()> {
+        let mut offset = 0;
+        while offset < chunk.len() {
+            let zone_remaining = self.zone_len - self.pending_len;
+            let take = zone_remaining.min(chunk.len() - offset);
+            let end = offset + take;
+            let slice = chunk.slice(offset..end)?;
+
+            if self.pending.is_empty() && take == self.zone_len {
+                self.stats.push_chunk(&slice, ctx)?;
+            } else {
+                self.pending_len += slice.len();
+                self.pending.push(slice);
+
+                if self.pending_len == self.zone_len {
+                    self.flush_pending(ctx)?;
+                }
+            }
+
+            offset = end;
+        }
+
+        Ok(())
+    }
+
+    fn finish(&mut self, ctx: &mut ExecutionCtx) -> VortexResult<()> {
+        self.flush_pending(ctx)
+    }
+
+    fn as_array(&mut self) -> VortexResult<Option<(StructArray, Arc<[Stat]>)>> {
+        self.stats.as_array()
+    }
+
+    fn flush_pending(&mut self, ctx: &mut ExecutionCtx) -> VortexResult<()> {
+        if self.pending_len == 0 {
+            return Ok(());
+        }
+
+        let zone = if self.pending.len() == 1 {
+            self.pending
+                .pop()
+                .vortex_expect("pending zone is non-empty")
+        } else {
+            ChunkedArray::try_new(std::mem::take(&mut self.pending), self.dtype.clone())?
+                .into_array()
+        };
+
+        self.pending_len = 0;
+        self.stats.push_chunk(&zone, ctx)
+    }
+}
+
 #[async_trait]
 impl LayoutStrategy for ZonedStrategy {
     async fn write_stream(
@@ -95,46 +173,21 @@ impl LayoutStrategy for ZonedStrategy {
 
         let stats = Arc::clone(&self.options.stats);
         let session = session.clone();
-        let compute_session = session.clone();
-        let handle = session.handle();
-        let handle2 = handle.clone();
-
-        let stats_accumulator = Arc::new(Mutex::new(StatsAccumulator::new(
-            stream.dtype(),
+        let stats_session = session.clone();
+        let stats_accumulator = Arc::new(Mutex::new(FixedZoneStatsAccumulator::new(
+            stream.dtype().clone(),
             &stats,
             self.options.max_variable_length_statistics_size,
+            self.options.block_size,
         )));
 
-        // We can compute per-chunk statistics in parallel, so we spawn tasks for each chunk
-        let stream = SequentialStreamAdapter::new(
-            stream.dtype().clone(),
-            stream
-                .map(move |chunk| {
-                    let stats = Arc::clone(&stats);
-                    let session = compute_session.clone();
-                    handle2.spawn_cpu(move || {
-                        let (sequence_id, chunk) = chunk?;
-                        chunk
-                            .statistics()
-                            .compute_all(&stats, &mut session.create_execution_ctx())?;
-                        Ok((sequence_id, chunk))
-                    })
-                })
-                .buffered(self.options.concurrency),
-        )
-        .sendable();
-
-        // Now we accumulate the stats we computed above, this time we cannot spawn because we
-        // need to feed the accumulator an ordered stream.
         let stats_accumulator2 = Arc::clone(&stats_accumulator);
         let stream = SequentialStreamAdapter::new(
             stream.dtype().clone(),
             stream.map(move |item| {
                 let (sequence_id, chunk) = item?;
-                // We have already computed per-chunk statistics, so avoid trying again for any that failed.
-                stats_accumulator2
-                    .lock()
-                    .push_chunk_without_compute(&chunk)?;
+                let mut ctx = stats_session.create_execution_ctx();
+                stats_accumulator2.lock().push_chunk(&chunk, &mut ctx)?;
                 Ok((sequence_id, chunk))
             }),
         )
@@ -155,7 +208,12 @@ impl LayoutStrategy for ZonedStrategy {
             )
             .await?;
 
-        let Some((stats_array, stats)) = stats_accumulator.lock().as_array()? else {
+        let mut stats_ctx = session.create_execution_ctx();
+        let Some((stats_array, stats)) = ({
+            let mut stats_accumulator = stats_accumulator.lock();
+            stats_accumulator.finish(&mut stats_ctx)?;
+            stats_accumulator.as_array()?
+        }) else {
             // If we have no stats (e.g. the DType doesn't support them), then we just return the
             // child layout.
             return Ok(data_layout);


### PR DESCRIPTION
## Summary

Implements phase 1 of #7939 by moving fixed-size zone stats partitioning into `ZonedStrategy`.

- partitions zone stats internally from arbitrary input chunk boundaries
- keeps the data child write path independent from stats partitioning
- preserves the current single-zone-map metadata and reader pruning behavior
- adds regression coverage for input chunks smaller than, larger than, and unaligned with the configured zone size

## Validation

- `cargo +nightly fmt --all`
- `cargo test -p vortex-layout layouts::zoned`
- `cargo test -p vortex-file test_segment_ordering_zonemaps_after_data`
- `cargo check -p vortex-file`
- `cargo clippy --all-targets --all-features`