### PR TITLE
Update Claude Code action to v1.0.123

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -242,7 +242,7 @@ jobs:
 
       - name: Run Claude Code in review-only mode
         id: claude
-        uses: anthropics/claude-code-action@6cad158a175744eb2e76f7f5fd108ec63145598c
+        uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e  # v1.0.123
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # This workflow deliberately uses the built-in token because it only needs

--- a/.github/workflows/claude-write.yml
+++ b/.github/workflows/claude-write.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@6cad158a175744eb2e76f7f5fd108ec63145598c
+        uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e  # v1.0.123
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Updates the `anthropics/claude-code-action` dependency to version 1.0.123 in both the `claude-review` and `claude-write` GitHub workflows.

This change updates the action commit hash from `6cad158a175744eb2e76f7f5fd108ec63145598c` to `51ea8ea73a139f2a74ff649e3092c25a904aed7e` and adds a version tag comment for clarity.
