### PR TITLE
Fix segfault when calling vx CLI from Python bindings

### DIFF
--- a/vortex-tui/src/lib.rs
+++ b/vortex-tui/src/lib.rs
@@ -123,11 +123,15 @@ mod native_cli {
     ) -> anyhow::Result<()> {
         let _ = env_logger::try_init();
 
-        let cli = Cli::parse_from(args);
+        // Use `try_parse_from` rather than `parse_from` so we never call
+        // `std::process::exit` from library code — that segfaults when
+        // `launch_from` runs inside a Python-loaded dylib.
+        // See https://github.com/vortex-data/vortex/issues/7910.
+        let cli = Cli::try_parse_from(args)?;
 
         let path = cli.command.file_path();
         if !std::fs::exists(path)? {
-            Cli::command()
+            return Err(Cli::command()
                 .error(
                     clap::error::ErrorKind::Io,
                     format!(
@@ -135,7 +139,7 @@ mod native_cli {
                         path.to_str().vortex_expect("file path")
                     ),
                 )
-                .exit()
+                .into());
         }
 
         match cli.command {
@@ -148,6 +152,27 @@ mod native_cli {
         };
 
         Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use vortex::VortexSessionDefault;
+        use vortex::session::VortexSession;
+
+        /// Regression test for https://github.com/vortex-data/vortex/issues/7910:
+        /// `vx --help` must surface as a `clap::Error` rather than calling
+        /// `std::process::exit`, which segfaults when invoked via the Python
+        /// binding.
+        #[tokio::test]
+        async fn help_flag_surfaces_clap_error() {
+            let err = super::launch_from(&VortexSession::default(), ["vx", "--help"])
+                .await
+                .expect_err("--help must surface as a clap::Error");
+            assert_eq!(
+                err.downcast_ref::<clap::Error>().map(clap::Error::kind),
+                Some(clap::error::ErrorKind::DisplayHelp),
+            );
+        }
     }
 }
 

--- a/vortex-tui/src/main.rs
+++ b/vortex-tui/src/main.rs
@@ -9,5 +9,13 @@ use vortex_tui::launch;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let session = VortexSession::default().with_tokio().allow_unknown();
-    launch(&session).await
+    if let Err(err) = launch(&session).await {
+        // Defer help/version/usage errors back to clap so their formatting
+        // and exit codes match the standalone-binary convention exactly.
+        if let Some(clap_err) = err.downcast_ref::<clap::Error>() {
+            clap_err.exit();
+        }
+        return Err(err);
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary

Closes: #7910

The `launch_from` function in the native CLI module was calling `Cli::parse_from()`, which internally calls `std::process::exit()` on parse errors (including `--help` and `--version`). When `launch_from` is invoked from Python bindings via a dynamically loaded dylib, calling `std::process::exit()` from library code causes a segfault.

This PR changes the implementation to:

1. Use `Cli::try_parse_from()` instead of `parse_from()` to surface parse errors as `clap::Error` values rather than calling `exit()`
2. Convert file-not-found errors to return `Err()` instead of calling `.exit()`
3. Update `main.rs` to handle `clap::Error` specially by calling `exit()` only from the binary entry point, not from library code
4. Add a regression test verifying that `--help` surfaces as a `clap::Error` rather than exiting

The changes preserve the exact behavior of the standalone binary (same exit codes and formatting) while allowing the library function to be safely called from Python without segfaulting.

## Testing

Added a regression test `help_flag_surfaces_clap_error()` that verifies `vx --help` returns a `clap::Error` with `DisplayHelp` kind rather than calling `std::process::exit()`. The test uses the async test harness and confirms the error can be downcast to `clap::Error`.

Existing behavior is preserved: the standalone binary still exits with the same codes and formatting as before, since `main.rs` now explicitly calls `clap_err.exit()` for clap errors.

https://claude.ai/code/session_0177K9Q4KzUyxKUPu5xokEDZ