### PR TITLE
Add Vortex file metadata segments

### DIFF
--- a/vortex-file/public-api.lock
+++ b/vortex-file/public-api.lock
@@ -186,7 +186,7 @@ pub fn vortex_file::Footer::layout(&self) -> &vortex_layout::layout::LayoutRef
 
 pub fn vortex_file::Footer::metadata_segment(&self, &str) -> core::option::Option<&vortex_buffer::ByteBuffer>
 
-pub fn vortex_file::Footer::metadata_segments(&self) -> &[(alloc::string::String, vortex_buffer::ByteBuffer)]
+pub fn vortex_file::Footer::metadata_segments(&self) -> impl core::iter::traits::iterator::Iterator<Item = (&str, &vortex_buffer::ByteBuffer)>
 
 pub fn vortex_file::Footer::row_count(&self) -> u64
 
@@ -210,9 +210,13 @@ pub fn vortex_file::FooterDeserializer::buffer(&self) -> &vortex_buffer::ByteBuf
 
 pub fn vortex_file::FooterDeserializer::deserialize(&mut self) -> vortex_error::VortexResult<vortex_file::DeserializeStep>
 
+pub fn vortex_file::FooterDeserializer::include_metadata(self) -> Self
+
 pub fn vortex_file::FooterDeserializer::prefix_data(&mut self, vortex_buffer::ByteBuffer)
 
 pub fn vortex_file::FooterDeserializer::with_dtype(self, vortex_array::dtype::DType) -> Self
+
+pub fn vortex_file::FooterDeserializer::with_include_metadata(self, bool) -> Self
 
 pub fn vortex_file::FooterDeserializer::with_size(self, u64) -> Self
 
@@ -282,7 +286,7 @@ pub fn vortex_file::VortexFile::layout_reader(&self) -> vortex_error::VortexResu
 
 pub fn vortex_file::VortexFile::metadata_segment(&self, &str) -> core::option::Option<&vortex_buffer::ByteBuffer>
 
-pub fn vortex_file::VortexFile::metadata_segments(&self) -> &[(alloc::string::String, vortex_buffer::ByteBuffer)]
+pub fn vortex_file::VortexFile::metadata_segments(&self) -> impl core::iter::traits::iterator::Iterator<Item = (&str, &vortex_buffer::ByteBuffer)>
 
 pub fn vortex_file::VortexFile::row_count(&self) -> u64
 
@@ -300,6 +304,8 @@ pub struct vortex_file::VortexOpenOptions
 
 impl vortex_file::VortexOpenOptions
 
+pub fn vortex_file::VortexOpenOptions::include_metadata(self) -> Self
+
 pub async fn vortex_file::VortexOpenOptions::open(self, alloc::sync::Arc<dyn vortex_io::read_at::VortexReadAt>) -> vortex_error::VortexResult<vortex_file::VortexFile>
 
 pub fn vortex_file::VortexOpenOptions::open_buffer<B: core::convert::Into<vortex_buffer::ByteBuffer>>(self, B) -> vortex_error::VortexResult<vortex_file::VortexFile>
@@ -313,6 +319,8 @@ pub fn vortex_file::VortexOpenOptions::with_dtype(self, vortex_array::dtype::DTy
 pub fn vortex_file::VortexOpenOptions::with_file_size(self, u64) -> Self
 
 pub fn vortex_file::VortexOpenOptions::with_footer(self, vortex_file::Footer) -> Self
+
+pub fn vortex_file::VortexOpenOptions::with_include_metadata(self, bool) -> Self
 
 pub fn vortex_file::VortexOpenOptions::with_initial_read_size(self, usize) -> Self
 

--- a/vortex-file/public-api.lock
+++ b/vortex-file/public-api.lock
@@ -184,6 +184,10 @@ pub fn vortex_file::Footer::into_serializer(self) -> vortex_file::FooterSerializ
 
 pub fn vortex_file::Footer::layout(&self) -> &vortex_layout::layout::LayoutRef
 
+pub fn vortex_file::Footer::metadata_segment(&self, &str) -> core::option::Option<&vortex_buffer::ByteBuffer>
+
+pub fn vortex_file::Footer::metadata_segments(&self) -> &[(alloc::string::String, vortex_buffer::ByteBuffer)]
+
 pub fn vortex_file::Footer::row_count(&self) -> u64
 
 pub fn vortex_file::Footer::segment_map(&self) -> &alloc::sync::Arc<[vortex_file::SegmentSpec]>
@@ -276,6 +280,10 @@ pub fn vortex_file::VortexFile::footer(&self) -> &vortex_file::Footer
 
 pub fn vortex_file::VortexFile::layout_reader(&self) -> vortex_error::VortexResult<alloc::sync::Arc<dyn vortex_layout::reader::LayoutReader>>
 
+pub fn vortex_file::VortexFile::metadata_segment(&self, &str) -> core::option::Option<&vortex_buffer::ByteBuffer>
+
+pub fn vortex_file::VortexFile::metadata_segments(&self) -> &[(alloc::string::String, vortex_buffer::ByteBuffer)]
+
 pub fn vortex_file::VortexFile::row_count(&self) -> u64
 
 pub fn vortex_file::VortexFile::scan(&self) -> vortex_error::VortexResult<vortex_layout::scan::scan_builder::ScanBuilder<vortex_array::array::erased::ArrayRef>>
@@ -337,6 +345,10 @@ pub fn vortex_file::VortexWriteOptions::exclude_dtype(self) -> Self
 pub fn vortex_file::VortexWriteOptions::new(vortex_session::VortexSession) -> Self
 
 pub fn vortex_file::VortexWriteOptions::with_file_statistics(self, alloc::vec::Vec<vortex_array::expr::stats::Stat>) -> Self
+
+pub fn vortex_file::VortexWriteOptions::with_metadata_segment(self, impl core::convert::Into<alloc::string::String>, impl core::convert::Into<vortex_buffer::ByteBuffer>) -> Self
+
+pub fn vortex_file::VortexWriteOptions::with_metadata_segments<I, K, B>(self, I) -> Self where I: core::iter::traits::collect::IntoIterator<Item = (K, B)>, K: core::convert::Into<alloc::string::String>, B: core::convert::Into<vortex_buffer::ByteBuffer>
 
 pub fn vortex_file::VortexWriteOptions::with_strategy(self, alloc::sync::Arc<dyn vortex_layout::strategy::LayoutStrategy>) -> Self
 

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -78,11 +78,15 @@ impl VortexFile {
     }
 
     /// Returns the user-defined metadata segments loaded for this file.
+    ///
+    /// Metadata is only loaded when requested during open. Iteration order is unspecified.
     pub fn metadata_segments(&self) -> impl Iterator<Item = (&str, &ByteBuffer)> {
         self.footer.metadata_segments()
     }
 
     /// Returns the loaded user-defined metadata segment for the given key.
+    ///
+    /// Returns `None` when the key is absent or metadata was not loaded.
     pub fn metadata_segment(&self, key: &str) -> Option<&ByteBuffer> {
         self.footer.metadata_segment(key)
     }

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -77,12 +77,12 @@ impl VortexFile {
         self.footer.statistics()
     }
 
-    /// Returns the user-defined metadata segments stored in this file.
-    pub fn metadata_segments(&self) -> &[(String, ByteBuffer)] {
+    /// Returns the user-defined metadata segments loaded for this file.
+    pub fn metadata_segments(&self) -> impl Iterator<Item = (&str, &ByteBuffer)> {
         self.footer.metadata_segments()
     }
 
-    /// Returns the user-defined metadata segment for the given key.
+    /// Returns the loaded user-defined metadata segment for the given key.
     pub fn metadata_segment(&self, key: &str) -> Option<&ByteBuffer> {
         self.footer.metadata_segment(key)
     }

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -23,6 +23,7 @@ use vortex_array::dtype::FieldPathSet;
 use vortex_array::expr::Expression;
 use vortex_array::expr::pruning::checked_pruning_expr;
 use vortex_array::scalar_fn::internal::row_count::substitute_row_count;
+use vortex_buffer::ByteBuffer;
 use vortex_error::VortexResult;
 use vortex_layout::LayoutReader;
 use vortex_layout::scan::layout::LayoutReaderDataSource;
@@ -74,6 +75,16 @@ impl VortexFile {
     /// Statistics can be used for query optimization and data exploration.
     pub fn file_stats(&self) -> Option<&FileStatistics> {
         self.footer.statistics()
+    }
+
+    /// Returns the user-defined metadata segments stored in this file.
+    pub fn metadata_segments(&self) -> &[(String, ByteBuffer)] {
+        self.footer.metadata_segments()
+    }
+
+    /// Returns the user-defined metadata segment for the given key.
+    pub fn metadata_segment(&self, key: &str) -> Option<&ByteBuffer> {
+        self.footer.metadata_segment(key)
     }
 
     /// Create a new segment source for reading from the file.

--- a/vortex-file/src/footer/deserializer.rs
+++ b/vortex-file/src/footer/deserializer.rs
@@ -14,6 +14,7 @@ use vortex_error::vortex_err;
 use vortex_flatbuffers::FlatBuffer;
 use vortex_flatbuffers::ReadFlatBuffer;
 use vortex_session::VortexSession;
+use vortex_utils::aliases::hash_map::HashMap;
 
 use crate::EOF_SIZE;
 use crate::Footer;
@@ -40,6 +41,8 @@ pub struct FooterDeserializer {
 
     // The file size, possibly provided externally.
     file_size: Option<u64>,
+    // Whether to include user-defined metadata segments in the footer read.
+    include_metadata: bool,
     // The postscript, once we've parsed it.
     postscript: Option<Postscript>,
 }
@@ -51,6 +54,7 @@ impl FooterDeserializer {
             session,
             dtype: None,
             file_size: None,
+            include_metadata: false,
             postscript: None,
         }
     }
@@ -72,6 +76,18 @@ impl FooterDeserializer {
 
     pub fn with_some_size(mut self, file_size: Option<u64>) -> Self {
         self.file_size = file_size;
+        self
+    }
+
+    /// Include user-defined metadata segments in footer deserialization.
+    pub fn include_metadata(mut self) -> Self {
+        self.include_metadata = true;
+        self
+    }
+
+    /// Whether to include user-defined metadata segments in footer deserialization.
+    pub fn with_include_metadata(mut self, include_metadata: bool) -> Self {
+        self.include_metadata = include_metadata;
         self
     }
 
@@ -122,8 +138,10 @@ impl FooterDeserializer {
         if let Some(stats_segment) = &postscript.statistics {
             read_more_offset = read_more_offset.min(stats_segment.offset);
         }
-        for metadata in &postscript.metadata {
-            read_more_offset = read_more_offset.min(metadata.segment.offset);
+        if self.include_metadata {
+            for metadata in &postscript.metadata {
+                read_more_offset = read_more_offset.min(metadata.segment.offset);
+            }
         }
         read_more_offset = read_more_offset.min(postscript.layout.offset);
         read_more_offset = read_more_offset.min(postscript.footer.offset);
@@ -157,12 +175,19 @@ impl FooterDeserializer {
                 )
             })
             .transpose()?;
-        let metadata: Arc<[(String, ByteBuffer)]> = postscript
-            .metadata
-            .iter()
-            .map(|metadata| self.parse_metadata_segment(initial_offset, &self.buffer, metadata))
-            .collect::<VortexResult<Vec<_>>>()?
-            .into();
+        let metadata = if self.include_metadata {
+            Arc::new(
+                postscript
+                    .metadata
+                    .iter()
+                    .map(|metadata| {
+                        self.parse_metadata_segment(initial_offset, &self.buffer, metadata)
+                    })
+                    .collect::<VortexResult<HashMap<_, _>>>()?,
+            )
+        } else {
+            Arc::new(HashMap::default())
+        };
 
         Ok(DeserializeStep::Done(self.parse_footer(
             initial_offset,
@@ -287,7 +312,7 @@ impl FooterDeserializer {
         postscript: &Postscript,
         dtype: DType,
         file_stats: Option<FileStatistics>,
-        metadata: Arc<[(String, ByteBuffer)]>,
+        metadata: Arc<HashMap<String, ByteBuffer>>,
     ) -> VortexResult<Footer> {
         let footer_segment = &postscript.footer;
         let footer_offset = usize::try_from(footer_segment.offset - initial_offset)?;

--- a/vortex-file/src/footer/deserializer.rs
+++ b/vortex-file/src/footer/deserializer.rs
@@ -80,12 +80,18 @@ impl FooterDeserializer {
     }
 
     /// Include user-defined metadata segments in footer deserialization.
+    ///
+    /// When enabled, deserialization may request additional bytes so the read buffer covers all
+    /// metadata segments named by the postscript.
     pub fn include_metadata(mut self) -> Self {
         self.include_metadata = true;
         self
     }
 
     /// Whether to include user-defined metadata segments in footer deserialization.
+    ///
+    /// When enabled, deserialization may request additional bytes so the read buffer covers all
+    /// metadata segments named by the postscript.
     pub fn with_include_metadata(mut self, include_metadata: bool) -> Self {
         self.include_metadata = include_metadata;
         self
@@ -283,7 +289,7 @@ impl FooterDeserializer {
         metadata: &PostscriptMetadata,
     ) -> VortexResult<(String, ByteBuffer)> {
         let offset = usize::try_from(metadata.segment.offset - initial_offset)?;
-        let length = metadata.segment.length as usize;
+        let length = usize::try_from(metadata.segment.length)?;
         let end = offset
             .checked_add(length)
             .ok_or_else(|| vortex_err!("Metadata segment range overflowed usize"))?;

--- a/vortex-file/src/footer/deserializer.rs
+++ b/vortex-file/src/footer/deserializer.rs
@@ -279,7 +279,7 @@ impl FooterDeserializer {
     fn parse_metadata_segment(
         &self,
         initial_offset: u64,
-        initial_read: &[u8],
+        initial_read: &ByteBuffer,
         metadata: &PostscriptMetadata,
     ) -> VortexResult<(String, ByteBuffer)> {
         let offset = usize::try_from(metadata.segment.offset - initial_offset)?;
@@ -300,7 +300,9 @@ impl FooterDeserializer {
 
         Ok((
             metadata.key.clone(),
-            ByteBuffer::copy_from(&initial_read[offset..end]).aligned(metadata.segment.alignment),
+            initial_read
+                .slice_unaligned(offset..end)
+                .aligned(metadata.segment.alignment),
         ))
     }
 

--- a/vortex-file/src/footer/deserializer.rs
+++ b/vortex-file/src/footer/deserializer.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::sync::Arc;
+
 use flatbuffers::root;
 use vortex_array::dtype::DType;
 use vortex_buffer::ByteBuffer;
@@ -19,6 +21,7 @@ use crate::MAGIC_BYTES;
 use crate::VERSION;
 use crate::footer::FileStatistics;
 use crate::footer::postscript::Postscript;
+use crate::footer::postscript::PostscriptMetadata;
 use crate::footer::postscript::PostscriptSegment;
 
 /// Deserialize a footer from the end of a Vortex file or created from a
@@ -119,6 +122,9 @@ impl FooterDeserializer {
         if let Some(stats_segment) = &postscript.statistics {
             read_more_offset = read_more_offset.min(stats_segment.offset);
         }
+        for metadata in &postscript.metadata {
+            read_more_offset = read_more_offset.min(metadata.segment.offset);
+        }
         read_more_offset = read_more_offset.min(postscript.layout.offset);
         read_more_offset = read_more_offset.min(postscript.footer.offset);
 
@@ -151,14 +157,20 @@ impl FooterDeserializer {
                 )
             })
             .transpose()?;
+        let metadata: Arc<[(String, ByteBuffer)]> = postscript
+            .metadata
+            .iter()
+            .map(|metadata| self.parse_metadata_segment(initial_offset, &self.buffer, metadata))
+            .collect::<VortexResult<Vec<_>>>()?
+            .into();
 
         Ok(DeserializeStep::Done(self.parse_footer(
             initial_offset,
             &self.buffer,
-            &postscript.footer,
-            &postscript.layout,
+            postscript,
             dtype,
             file_stats,
+            metadata,
         )?))
     }
 
@@ -238,27 +250,65 @@ impl FooterDeserializer {
         FileStatistics::from_flatbuffer(&fb, dtype, session)
     }
 
+    /// Parse a user-defined metadata segment from the initial read buffer.
+    fn parse_metadata_segment(
+        &self,
+        initial_offset: u64,
+        initial_read: &[u8],
+        metadata: &PostscriptMetadata,
+    ) -> VortexResult<(String, ByteBuffer)> {
+        let offset = usize::try_from(metadata.segment.offset - initial_offset)?;
+        let length = metadata.segment.length as usize;
+        let end = offset
+            .checked_add(length)
+            .ok_or_else(|| vortex_err!("Metadata segment range overflowed usize"))?;
+
+        if end > initial_read.len() {
+            vortex_bail!(
+                "Metadata segment {} range {}..{} out of bounds for initial read of length {}",
+                metadata.key,
+                offset,
+                end,
+                initial_read.len()
+            );
+        }
+
+        Ok((
+            metadata.key.clone(),
+            ByteBuffer::copy_from(&initial_read[offset..end]).aligned(metadata.segment.alignment),
+        ))
+    }
+
     /// Parse the rest of the footer from the initial read.
     fn parse_footer(
         &self,
         initial_offset: u64,
         initial_read: &[u8],
-        footer_segment: &PostscriptSegment,
-        layout_segment: &PostscriptSegment,
+        postscript: &Postscript,
         dtype: DType,
         file_stats: Option<FileStatistics>,
+        metadata: Arc<[(String, ByteBuffer)]>,
     ) -> VortexResult<Footer> {
+        let footer_segment = &postscript.footer;
         let footer_offset = usize::try_from(footer_segment.offset - initial_offset)?;
         let footer_bytes = FlatBuffer::copy_from(
             &initial_read[footer_offset..footer_offset + (footer_segment.length as usize)],
         );
 
+        let layout_segment = &postscript.layout;
         let layout_offset = usize::try_from(layout_segment.offset - initial_offset)?;
         let layout_bytes = FlatBuffer::copy_from(
             &initial_read[layout_offset..layout_offset + (layout_segment.length as usize)],
         );
 
-        Footer::from_flatbuffer(footer_bytes, layout_bytes, dtype, file_stats, &self.session)
+        Footer::from_flatbuffer(
+            footer_bytes,
+            layout_bytes,
+            dtype,
+            file_stats,
+            metadata,
+            &self.session,
+        )
     }
 }
 

--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -38,6 +38,7 @@ use vortex_layout::layout_from_flatbuffer_with_options;
 use vortex_layout::session::LayoutSessionExt;
 use vortex_session::VortexSession;
 use vortex_session::registry::ReadContext;
+use vortex_utils::aliases::hash_map::HashMap;
 
 /// Captures the layout information of a Vortex file.
 #[derive(Debug, Clone)]
@@ -45,7 +46,7 @@ pub struct Footer {
     root_layout: LayoutRef,
     segments: Arc<[SegmentSpec]>,
     statistics: Option<FileStatistics>,
-    metadata: Arc<[(String, ByteBuffer)]>,
+    metadata: Arc<HashMap<String, ByteBuffer>>,
     // The specific arrays used within the file, in the order they were registered.
     array_read_ctx: ReadContext,
     // The approximate size of the footer in bytes, used for caching and memory management.
@@ -57,7 +58,7 @@ impl Footer {
         root_layout: LayoutRef,
         segments: Arc<[SegmentSpec]>,
         statistics: Option<FileStatistics>,
-        metadata: Arc<[(String, ByteBuffer)]>,
+        metadata: Arc<HashMap<String, ByteBuffer>>,
         array_read_ctx: ReadContext,
     ) -> Self {
         Self {
@@ -81,7 +82,7 @@ impl Footer {
         layout_bytes: FlatBuffer,
         dtype: DType,
         statistics: Option<FileStatistics>,
-        metadata: Arc<[(String, ByteBuffer)]>,
+        metadata: Arc<HashMap<String, ByteBuffer>>,
         session: &VortexSession,
     ) -> VortexResult<Self> {
         let approx_byte_size = footer_bytes.len() + layout_bytes.len();
@@ -151,17 +152,16 @@ impl Footer {
         self.statistics.as_ref()
     }
 
-    /// Returns the user-defined metadata segments stored in this file.
-    pub fn metadata_segments(&self) -> &[(String, ByteBuffer)] {
-        self.metadata.as_ref()
-    }
-
-    /// Returns the user-defined metadata segment for the given key.
-    pub fn metadata_segment(&self, key: &str) -> Option<&ByteBuffer> {
+    /// Returns the user-defined metadata segments loaded for this file.
+    pub fn metadata_segments(&self) -> impl Iterator<Item = (&str, &ByteBuffer)> {
         self.metadata
             .iter()
-            .find(|(metadata_key, _)| metadata_key == key)
-            .map(|(_, metadata)| metadata)
+            .map(|(key, metadata)| (key.as_str(), metadata))
+    }
+
+    /// Returns the loaded user-defined metadata segment for the given key.
+    pub fn metadata_segment(&self, key: &str) -> Option<&ByteBuffer> {
+        self.metadata.get(key)
     }
 
     /// Returns the [`DType`] of the file.

--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -40,6 +40,20 @@ use vortex_session::VortexSession;
 use vortex_session::registry::ReadContext;
 use vortex_utils::aliases::hash_map::HashMap;
 
+/// Maximum number of user-defined metadata segments stored in the postscript.
+///
+/// The postscript has a fixed 64 KiB budget and must remain small enough for readers to discover
+/// the footer and required segment locations from the initial read. Sixteen entries keeps metadata
+/// bookkeeping well under 2 KiB for typical key lengths while leaving almost all of the postscript
+/// budget available for the required file segments.
+pub(crate) const MAX_METADATA_SEGMENTS: usize = 16;
+
+/// Maximum length, in Unicode scalar values, of a user-defined metadata key.
+///
+/// Metadata keys are stored directly in the fixed-size postscript. Keeping keys short prevents
+/// user-defined labels from consuming a disproportionate share of the postscript budget.
+pub(crate) const MAX_METADATA_KEY_CHARS: usize = 32;
+
 /// Captures the layout information of a Vortex file.
 #[derive(Debug, Clone)]
 pub struct Footer {

--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -48,11 +48,11 @@ use vortex_utils::aliases::hash_map::HashMap;
 /// budget available for the required file segments.
 pub(crate) const MAX_METADATA_SEGMENTS: usize = 16;
 
-/// Maximum length, in Unicode scalar values, of a user-defined metadata key.
+/// Maximum length, in UTF-8 bytes, of a user-defined metadata key.
 ///
 /// Metadata keys are stored directly in the fixed-size postscript. Keeping keys short prevents
 /// user-defined labels from consuming a disproportionate share of the postscript budget.
-pub(crate) const MAX_METADATA_KEY_CHARS: usize = 32;
+pub(crate) const MAX_METADATA_KEY_BYTES: usize = 32;
 
 /// Captures the layout information of a Vortex file.
 #[derive(Debug, Clone)]

--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -167,6 +167,9 @@ impl Footer {
     }
 
     /// Returns the user-defined metadata segments loaded for this file.
+    ///
+    /// Metadata is only loaded when requested during open or footer deserialization. Iteration order
+    /// is unspecified.
     pub fn metadata_segments(&self) -> impl Iterator<Item = (&str, &ByteBuffer)> {
         self.metadata
             .iter()
@@ -174,6 +177,8 @@ impl Footer {
     }
 
     /// Returns the loaded user-defined metadata segment for the given key.
+    ///
+    /// Returns `None` when the key is absent or metadata was not loaded.
     pub fn metadata_segment(&self, key: &str) -> Option<&ByteBuffer> {
         self.metadata.get(key)
     }

--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -45,6 +45,7 @@ pub struct Footer {
     root_layout: LayoutRef,
     segments: Arc<[SegmentSpec]>,
     statistics: Option<FileStatistics>,
+    metadata: Arc<[(String, ByteBuffer)]>,
     // The specific arrays used within the file, in the order they were registered.
     array_read_ctx: ReadContext,
     // The approximate size of the footer in bytes, used for caching and memory management.
@@ -56,12 +57,14 @@ impl Footer {
         root_layout: LayoutRef,
         segments: Arc<[SegmentSpec]>,
         statistics: Option<FileStatistics>,
+        metadata: Arc<[(String, ByteBuffer)]>,
         array_read_ctx: ReadContext,
     ) -> Self {
         Self {
             root_layout,
             segments,
             statistics,
+            metadata,
             array_read_ctx,
             approx_byte_size: None,
         }
@@ -78,6 +81,7 @@ impl Footer {
         layout_bytes: FlatBuffer,
         dtype: DType,
         statistics: Option<FileStatistics>,
+        metadata: Arc<[(String, ByteBuffer)]>,
         session: &VortexSession,
     ) -> VortexResult<Self> {
         let approx_byte_size = footer_bytes.len() + layout_bytes.len();
@@ -126,6 +130,7 @@ impl Footer {
             root_layout,
             segments,
             statistics,
+            metadata,
             array_read_ctx,
             approx_byte_size: Some(approx_byte_size),
         })
@@ -144,6 +149,19 @@ impl Footer {
     /// Returns the statistics of the file.
     pub fn statistics(&self) -> Option<&FileStatistics> {
         self.statistics.as_ref()
+    }
+
+    /// Returns the user-defined metadata segments stored in this file.
+    pub fn metadata_segments(&self) -> &[(String, ByteBuffer)] {
+        self.metadata.as_ref()
+    }
+
+    /// Returns the user-defined metadata segment for the given key.
+    pub fn metadata_segment(&self, key: &str) -> Option<&ByteBuffer> {
+        self.metadata
+            .iter()
+            .find(|(metadata_key, _)| metadata_key == key)
+            .map(|(_, metadata)| metadata)
     }
 
     /// Returns the [`DType`] of the file.

--- a/vortex-file/src/footer/postscript.rs
+++ b/vortex-file/src/footer/postscript.rs
@@ -20,6 +20,7 @@ pub(crate) struct Postscript {
     pub(crate) layout: PostscriptSegment,
     pub(crate) statistics: Option<PostscriptSegment>,
     pub(crate) footer: PostscriptSegment,
+    pub(crate) metadata: Vec<PostscriptMetadata>,
 }
 
 impl FlatBufferRoot for Postscript {}
@@ -43,6 +44,15 @@ impl WriteFlatBuffer for Postscript {
             .map(|ps| ps.write_flatbuffer(fbb))
             .transpose()?;
         let footer = self.footer.write_flatbuffer(fbb)?;
+        let metadata = if self.metadata.is_empty() {
+            None
+        } else {
+            let mut metadata = Vec::with_capacity(self.metadata.len());
+            for entry in &self.metadata {
+                metadata.push(entry.write_flatbuffer(fbb)?);
+            }
+            Some(fbb.create_vector(metadata.as_slice()))
+        };
         Ok(fb::Postscript::create(
             fbb,
             &fb::PostscriptArgs {
@@ -50,6 +60,7 @@ impl WriteFlatBuffer for Postscript {
                 layout: Some(layout),
                 statistics,
                 footer: Some(footer),
+                metadata,
             },
         ))
     }
@@ -62,6 +73,26 @@ impl ReadFlatBuffer for Postscript {
     fn read_flatbuffer<'buf>(
         fb: &<Self::Source<'buf> as Follow<'buf>>::Inner,
     ) -> Result<Self, Self::Error> {
+        let metadata = fb
+            .metadata()
+            .map(|metadata| {
+                metadata
+                    .iter()
+                    .map(|entry| PostscriptMetadata::read_flatbuffer(&entry))
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .transpose()?
+            .unwrap_or_default();
+
+        for (idx, entry) in metadata.iter().enumerate() {
+            if metadata[..idx].iter().any(|prev| prev.key == entry.key) {
+                return Err(vortex_err!(
+                    "Postscript contains duplicate metadata key {}",
+                    entry.key
+                ));
+            }
+        }
+
         Ok(Self {
             dtype: fb
                 .dtype()
@@ -79,6 +110,47 @@ impl ReadFlatBuffer for Postscript {
                 &fb.footer()
                     .ok_or_else(|| vortex_err!("Postscript missing footer segment"))?,
             )?,
+            metadata,
+        })
+    }
+}
+
+pub(crate) struct PostscriptMetadata {
+    pub(crate) key: String,
+    pub(crate) segment: PostscriptSegment,
+}
+
+impl FlatBufferRoot for PostscriptMetadata {}
+
+impl WriteFlatBuffer for PostscriptMetadata {
+    type Target<'a> = fb::PostscriptMetadata<'a>;
+
+    fn write_flatbuffer<'fb>(
+        &self,
+        fbb: &mut FlatBufferBuilder<'fb>,
+    ) -> VortexResult<WIPOffset<Self::Target<'fb>>> {
+        let key = fbb.create_string(&self.key);
+        let segment = self.segment.write_flatbuffer(fbb)?;
+        Ok(fb::PostscriptMetadata::create(
+            fbb,
+            &fb::PostscriptMetadataArgs {
+                key: Some(key),
+                segment: Some(segment),
+            },
+        ))
+    }
+}
+
+impl ReadFlatBuffer for PostscriptMetadata {
+    type Source<'a> = fb::PostscriptMetadata<'a>;
+    type Error = VortexError;
+
+    fn read_flatbuffer<'buf>(
+        fb: &<Self::Source<'buf> as Follow<'buf>>::Inner,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            key: fb.key().to_string(),
+            segment: PostscriptSegment::read_flatbuffer(&fb.segment())?,
         })
     }
 }

--- a/vortex-file/src/footer/postscript.rs
+++ b/vortex-file/src/footer/postscript.rs
@@ -12,6 +12,7 @@ use vortex_flatbuffers::FlatBufferRoot;
 use vortex_flatbuffers::ReadFlatBuffer;
 use vortex_flatbuffers::WriteFlatBuffer;
 use vortex_flatbuffers::footer as fb;
+use vortex_utils::aliases::hash_set::HashSet;
 
 /// The postscript captures the locations and compression for the initial segments required for
 /// reading a Vortex file.
@@ -84,12 +85,18 @@ impl ReadFlatBuffer for Postscript {
             .transpose()?
             .unwrap_or_default();
 
-        for (idx, entry) in metadata.iter().enumerate() {
-            if metadata[..idx].iter().any(|prev| prev.key == entry.key) {
-                return Err(vortex_err!(
-                    "Postscript contains duplicate metadata key {}",
-                    entry.key
-                ));
+        {
+            let mut seen_keys = HashSet::with_capacity(metadata.len());
+            for entry in &metadata {
+                if entry.key.is_empty() {
+                    return Err(vortex_err!("Postscript metadata key must not be empty"));
+                }
+                if !seen_keys.insert(&entry.key) {
+                    return Err(vortex_err!(
+                        "Postscript contains duplicate metadata key {}",
+                        entry.key
+                    ));
+                }
             }
         }
 
@@ -148,6 +155,8 @@ impl ReadFlatBuffer for PostscriptMetadata {
     fn read_flatbuffer<'buf>(
         fb: &<Self::Source<'buf> as Follow<'buf>>::Inner,
     ) -> Result<Self, Self::Error> {
+        // The FlatBuffers verifier enforces that `key` and `segment` are present before this
+        // accessor can panic on a malformed required field.
         Ok(Self {
             key: fb.key().to_string(),
             segment: PostscriptSegment::read_flatbuffer(&fb.segment())?,
@@ -195,5 +204,67 @@ impl ReadFlatBuffer for PostscriptSegment {
             length: fb.length(),
             alignment: Alignment::from_exponent(fb.alignment_exponent()),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_flatbuffers::ReadFlatBuffer;
+    use vortex_flatbuffers::WriteFlatBufferExt;
+
+    use super::*;
+
+    fn segment(offset: u64) -> PostscriptSegment {
+        PostscriptSegment {
+            offset,
+            length: 1,
+            alignment: Alignment::none(),
+        }
+    }
+
+    fn read_postscript_error(postscript: &Postscript) -> String {
+        let bytes = postscript.write_flatbuffer_bytes().unwrap();
+        match Postscript::read_flatbuffer_bytes(&bytes) {
+            Ok(_) => panic!("expected postscript read to fail"),
+            Err(err) => err.to_string(),
+        }
+    }
+
+    #[test]
+    fn duplicate_metadata_keys_are_rejected() {
+        let err = read_postscript_error(&Postscript {
+            dtype: None,
+            layout: segment(0),
+            statistics: None,
+            footer: segment(1),
+            metadata: vec![
+                PostscriptMetadata {
+                    key: "metadata".to_string(),
+                    segment: segment(2),
+                },
+                PostscriptMetadata {
+                    key: "metadata".to_string(),
+                    segment: segment(3),
+                },
+            ],
+        });
+
+        assert!(err.contains("duplicate metadata key"));
+    }
+
+    #[test]
+    fn empty_metadata_keys_are_rejected() {
+        let err = read_postscript_error(&Postscript {
+            dtype: None,
+            layout: segment(0),
+            statistics: None,
+            footer: segment(1),
+            metadata: vec![PostscriptMetadata {
+                key: String::new(),
+                segment: segment(2),
+            }],
+        });
+
+        assert!(err.contains("metadata key must not be empty"));
     }
 }

--- a/vortex-file/src/footer/postscript.rs
+++ b/vortex-file/src/footer/postscript.rs
@@ -36,6 +36,16 @@ impl WriteFlatBuffer for Postscript {
         &self,
         fbb: &mut FlatBufferBuilder<'fb>,
     ) -> VortexResult<WIPOffset<Self::Target<'fb>>> {
+        validate_metadata_entries(&self.metadata)?;
+        self.write_flatbuffer_unchecked(fbb)
+    }
+}
+
+impl Postscript {
+    fn write_flatbuffer_unchecked<'fb>(
+        &self,
+        fbb: &mut FlatBufferBuilder<'fb>,
+    ) -> VortexResult<WIPOffset<fb::Postscript<'fb>>> {
         let dtype = self
             .dtype
             .as_ref()
@@ -77,18 +87,27 @@ impl ReadFlatBuffer for Postscript {
     fn read_flatbuffer<'buf>(
         fb: &<Self::Source<'buf> as Follow<'buf>>::Inner,
     ) -> Result<Self, Self::Error> {
-        let metadata = fb
-            .metadata()
-            .map(|metadata| {
-                metadata
-                    .iter()
-                    .map(|entry| PostscriptMetadata::read_flatbuffer(&entry))
-                    .collect::<Result<Vec<_>, _>>()
-            })
-            .transpose()?
-            .unwrap_or_default();
+        let metadata = match fb.metadata() {
+            Some(metadata) => {
+                let metadata_len = metadata.len();
+                if metadata_len > MAX_METADATA_SEGMENTS {
+                    return Err(metadata_count_error(metadata_len));
+                }
 
-        validate_metadata_entries(&metadata)?;
+                let mut seen_keys = HashSet::with_capacity(metadata_len);
+                let mut entries = Vec::with_capacity(metadata_len);
+                for entry in metadata.iter() {
+                    let entry = PostscriptMetadata::read_flatbuffer(&entry)?;
+                    validate_metadata_key(&entry.key)?;
+                    if !seen_keys.insert(entry.key.clone()) {
+                        return Err(duplicate_metadata_key_error(&entry.key));
+                    }
+                    entries.push(entry);
+                }
+                entries
+            }
+            None => Vec::new(),
+        };
 
         Ok(Self {
             dtype: fb
@@ -114,43 +133,52 @@ impl ReadFlatBuffer for Postscript {
 
 fn validate_metadata_entries(metadata: &[PostscriptMetadata]) -> VortexResult<()> {
     if metadata.len() > MAX_METADATA_SEGMENTS {
-        return Err(vortex_err!(
-            "Postscript contains {} metadata segments, but Vortex supports at most {} metadata segments and at most {} bytes per metadata key",
-            metadata.len(),
-            MAX_METADATA_SEGMENTS,
-            MAX_METADATA_KEY_BYTES
-        ));
+        return Err(metadata_count_error(metadata.len()));
     }
 
     let mut seen_keys = HashSet::with_capacity(metadata.len());
     for entry in metadata {
         validate_metadata_key(&entry.key)?;
         if !seen_keys.insert(&entry.key) {
-            return Err(vortex_err!(
-                "Postscript contains duplicate metadata key {}",
-                entry.key
-            ));
+            return Err(duplicate_metadata_key_error(&entry.key));
         }
     }
 
     Ok(())
 }
 
+fn metadata_count_error(metadata_len: usize) -> VortexError {
+    vortex_err!(
+        "Postscript contains {} metadata segments, but Vortex supports at most {} metadata segments; metadata keys must be non-empty and at most {} bytes",
+        metadata_len,
+        MAX_METADATA_SEGMENTS,
+        MAX_METADATA_KEY_BYTES
+    )
+}
+
+fn duplicate_metadata_key_error(key: &str) -> VortexError {
+    vortex_err!(
+        "Postscript contains duplicate metadata key {key}; metadata keys must be unique, non-empty, and at most {} bytes, and files may contain at most {} metadata segments",
+        MAX_METADATA_KEY_BYTES,
+        MAX_METADATA_SEGMENTS
+    )
+}
+
 fn validate_metadata_key(key: &str) -> VortexResult<()> {
     if key.is_empty() {
         return Err(vortex_err!(
-            "Postscript metadata key must not be empty; Vortex supports at most {} metadata segments and metadata keys must be at most {} bytes",
-            MAX_METADATA_SEGMENTS,
-            MAX_METADATA_KEY_BYTES
+            "Postscript metadata key must not be empty; metadata keys must be at most {} bytes and files may contain at most {} metadata segments",
+            MAX_METADATA_KEY_BYTES,
+            MAX_METADATA_SEGMENTS
         ));
     }
 
     let key_bytes = key.len();
     if key_bytes > MAX_METADATA_KEY_BYTES {
         return Err(vortex_err!(
-            "Postscript metadata key {key:?} is {key_bytes} bytes, but Vortex supports at most {} metadata segments and metadata keys must be at most {} bytes",
-            MAX_METADATA_SEGMENTS,
-            MAX_METADATA_KEY_BYTES
+            "Postscript metadata key {key:?} is {key_bytes} bytes, but metadata keys must be at most {} bytes and files may contain at most {} metadata segments",
+            MAX_METADATA_KEY_BYTES,
+            MAX_METADATA_SEGMENTS
         ));
     }
 
@@ -244,6 +272,8 @@ impl ReadFlatBuffer for PostscriptSegment {
 
 #[cfg(test)]
 mod tests {
+    use vortex_buffer::ByteBuffer;
+    use vortex_flatbuffers::FlatBuffer;
     use vortex_flatbuffers::ReadFlatBuffer;
     use vortex_flatbuffers::WriteFlatBufferExt;
 
@@ -257,17 +287,71 @@ mod tests {
         }
     }
 
+    fn write_postscript_bytes_unchecked(postscript: &Postscript) -> FlatBuffer {
+        let mut fbb = FlatBufferBuilder::new();
+        let root_offset = postscript.write_flatbuffer_unchecked(&mut fbb).unwrap();
+        fbb.finish_minimal(root_offset);
+        let (vec, start) = fbb.collapse();
+        let end = vec.len();
+        FlatBuffer::align_from(ByteBuffer::from(vec).slice(start..end))
+    }
+
     fn read_postscript_error(postscript: &Postscript) -> String {
-        let bytes = postscript.write_flatbuffer_bytes().unwrap();
+        let bytes = write_postscript_bytes_unchecked(postscript);
         match Postscript::read_flatbuffer_bytes(&bytes) {
             Ok(_) => panic!("expected postscript read to fail"),
             Err(err) => err.to_string(),
         }
     }
 
+    fn write_postscript_error(postscript: &Postscript) -> String {
+        match postscript.write_flatbuffer_bytes() {
+            Ok(_) => panic!("expected postscript write to fail"),
+            Err(err) => err.to_string(),
+        }
+    }
+
+    fn key_limit_message() -> String {
+        format!("at most {MAX_METADATA_KEY_BYTES} bytes")
+    }
+
+    fn segment_limit_message() -> String {
+        format!("at most {MAX_METADATA_SEGMENTS} metadata segments")
+    }
+
+    #[test]
+    fn metadata_limit_boundaries_roundtrip() {
+        let metadata = (0..MAX_METADATA_SEGMENTS)
+            .map(|idx| PostscriptMetadata {
+                key: if idx == 0 {
+                    "é".repeat(MAX_METADATA_KEY_BYTES / "é".len())
+                } else {
+                    format!("metadata-{idx}")
+                },
+                segment: segment(2 + idx as u64),
+            })
+            .collect::<Vec<_>>();
+        let expected_boundary_key = metadata[0].key.clone();
+
+        let bytes = Postscript {
+            dtype: None,
+            layout: segment(0),
+            statistics: None,
+            footer: segment(1),
+            metadata,
+        }
+        .write_flatbuffer_bytes()
+        .unwrap();
+
+        let postscript = Postscript::read_flatbuffer_bytes(&bytes).unwrap();
+        assert_eq!(postscript.metadata.len(), MAX_METADATA_SEGMENTS);
+        assert_eq!(postscript.metadata[0].key, expected_boundary_key);
+        assert_eq!(postscript.metadata[0].key.len(), MAX_METADATA_KEY_BYTES);
+    }
+
     #[test]
     fn duplicate_metadata_keys_are_rejected() {
-        let err = read_postscript_error(&Postscript {
+        let postscript = Postscript {
             dtype: None,
             layout: segment(0),
             statistics: None,
@@ -282,14 +366,21 @@ mod tests {
                     segment: segment(3),
                 },
             ],
-        });
+        };
 
-        assert!(err.contains("duplicate metadata key"));
+        let read_err = read_postscript_error(&postscript);
+        assert!(read_err.contains("duplicate metadata key"));
+        assert!(read_err.contains(&key_limit_message()));
+        assert!(read_err.contains(&segment_limit_message()));
+        let write_err = write_postscript_error(&postscript);
+        assert!(write_err.contains("duplicate metadata key"));
+        assert!(write_err.contains(&key_limit_message()));
+        assert!(write_err.contains(&segment_limit_message()));
     }
 
     #[test]
     fn empty_metadata_keys_are_rejected() {
-        let err = read_postscript_error(&Postscript {
+        let postscript = Postscript {
             dtype: None,
             layout: segment(0),
             statistics: None,
@@ -298,32 +389,42 @@ mod tests {
                 key: String::new(),
                 segment: segment(2),
             }],
-        });
+        };
 
-        assert!(err.contains("metadata key must not be empty"));
+        let read_err = read_postscript_error(&postscript);
+        assert!(read_err.contains("metadata key must not be empty"));
+        let write_err = write_postscript_error(&postscript);
+        assert!(write_err.contains("metadata key must not be empty"));
     }
 
     #[test]
     fn long_metadata_keys_are_rejected() {
-        let err = read_postscript_error(&Postscript {
+        let key = "é".repeat((MAX_METADATA_KEY_BYTES / "é".len()) + 1);
+        let key_len = key.len();
+        let postscript = Postscript {
             dtype: None,
             layout: segment(0),
             statistics: None,
             footer: segment(1),
             metadata: vec![PostscriptMetadata {
-                key: "é".repeat((MAX_METADATA_KEY_BYTES / "é".len()) + 1),
+                key,
                 segment: segment(2),
             }],
-        });
+        };
 
-        assert!(err.contains("34 bytes"));
-        assert!(err.contains("at most 32 bytes"));
-        assert!(err.contains("at most 16 metadata segments"));
+        for err in [
+            read_postscript_error(&postscript),
+            write_postscript_error(&postscript),
+        ] {
+            assert!(err.contains(&format!("{key_len} bytes")));
+            assert!(err.contains(&key_limit_message()));
+            assert!(err.contains(&segment_limit_message()));
+        }
     }
 
     #[test]
     fn too_many_metadata_segments_are_rejected() {
-        let err = read_postscript_error(&Postscript {
+        let postscript = Postscript {
             dtype: None,
             layout: segment(0),
             statistics: None,
@@ -334,9 +435,14 @@ mod tests {
                     segment: segment(2 + idx as u64),
                 })
                 .collect(),
-        });
+        };
 
-        assert!(err.contains("at most 16 metadata segments"));
-        assert!(err.contains("at most 32 bytes"));
+        for err in [
+            read_postscript_error(&postscript),
+            write_postscript_error(&postscript),
+        ] {
+            assert!(err.contains(&segment_limit_message()));
+            assert!(err.contains(&key_limit_message()));
+        }
     }
 }

--- a/vortex-file/src/footer/postscript.rs
+++ b/vortex-file/src/footer/postscript.rs
@@ -14,6 +14,9 @@ use vortex_flatbuffers::WriteFlatBuffer;
 use vortex_flatbuffers::footer as fb;
 use vortex_utils::aliases::hash_set::HashSet;
 
+use super::MAX_METADATA_KEY_CHARS;
+use super::MAX_METADATA_SEGMENTS;
+
 /// The postscript captures the locations and compression for the initial segments required for
 /// reading a Vortex file.
 pub(crate) struct Postscript {
@@ -85,20 +88,7 @@ impl ReadFlatBuffer for Postscript {
             .transpose()?
             .unwrap_or_default();
 
-        {
-            let mut seen_keys = HashSet::with_capacity(metadata.len());
-            for entry in &metadata {
-                if entry.key.is_empty() {
-                    return Err(vortex_err!("Postscript metadata key must not be empty"));
-                }
-                if !seen_keys.insert(&entry.key) {
-                    return Err(vortex_err!(
-                        "Postscript contains duplicate metadata key {}",
-                        entry.key
-                    ));
-                }
-            }
-        }
+        validate_metadata_entries(&metadata)?;
 
         Ok(Self {
             dtype: fb
@@ -120,6 +110,51 @@ impl ReadFlatBuffer for Postscript {
             metadata,
         })
     }
+}
+
+fn validate_metadata_entries(metadata: &[PostscriptMetadata]) -> VortexResult<()> {
+    if metadata.len() > MAX_METADATA_SEGMENTS {
+        return Err(vortex_err!(
+            "Postscript contains {} metadata segments, but Vortex supports at most {} metadata segments and at most {} characters per metadata key",
+            metadata.len(),
+            MAX_METADATA_SEGMENTS,
+            MAX_METADATA_KEY_CHARS
+        ));
+    }
+
+    let mut seen_keys = HashSet::with_capacity(metadata.len());
+    for entry in metadata {
+        validate_metadata_key(&entry.key)?;
+        if !seen_keys.insert(&entry.key) {
+            return Err(vortex_err!(
+                "Postscript contains duplicate metadata key {}",
+                entry.key
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_metadata_key(key: &str) -> VortexResult<()> {
+    if key.is_empty() {
+        return Err(vortex_err!(
+            "Postscript metadata key must not be empty; Vortex supports at most {} metadata segments and metadata keys must be at most {} characters",
+            MAX_METADATA_SEGMENTS,
+            MAX_METADATA_KEY_CHARS
+        ));
+    }
+
+    let key_chars = key.chars().count();
+    if key_chars > MAX_METADATA_KEY_CHARS {
+        return Err(vortex_err!(
+            "Postscript metadata key {key:?} is {key_chars} characters, but Vortex supports at most {} metadata segments and metadata keys must be at most {} characters",
+            MAX_METADATA_SEGMENTS,
+            MAX_METADATA_KEY_CHARS
+        ));
+    }
+
+    Ok(())
 }
 
 pub(crate) struct PostscriptMetadata {
@@ -266,5 +301,41 @@ mod tests {
         });
 
         assert!(err.contains("metadata key must not be empty"));
+    }
+
+    #[test]
+    fn long_metadata_keys_are_rejected() {
+        let err = read_postscript_error(&Postscript {
+            dtype: None,
+            layout: segment(0),
+            statistics: None,
+            footer: segment(1),
+            metadata: vec![PostscriptMetadata {
+                key: "a".repeat(MAX_METADATA_KEY_CHARS + 1),
+                segment: segment(2),
+            }],
+        });
+
+        assert!(err.contains("at most 32 characters"));
+        assert!(err.contains("at most 16 metadata segments"));
+    }
+
+    #[test]
+    fn too_many_metadata_segments_are_rejected() {
+        let err = read_postscript_error(&Postscript {
+            dtype: None,
+            layout: segment(0),
+            statistics: None,
+            footer: segment(1),
+            metadata: (0..=MAX_METADATA_SEGMENTS)
+                .map(|idx| PostscriptMetadata {
+                    key: format!("metadata-{idx}"),
+                    segment: segment(2 + idx as u64),
+                })
+                .collect(),
+        });
+
+        assert!(err.contains("at most 16 metadata segments"));
+        assert!(err.contains("at most 32 characters"));
     }
 }

--- a/vortex-file/src/footer/postscript.rs
+++ b/vortex-file/src/footer/postscript.rs
@@ -14,7 +14,7 @@ use vortex_flatbuffers::WriteFlatBuffer;
 use vortex_flatbuffers::footer as fb;
 use vortex_utils::aliases::hash_set::HashSet;
 
-use super::MAX_METADATA_KEY_CHARS;
+use super::MAX_METADATA_KEY_BYTES;
 use super::MAX_METADATA_SEGMENTS;
 
 /// The postscript captures the locations and compression for the initial segments required for
@@ -115,10 +115,10 @@ impl ReadFlatBuffer for Postscript {
 fn validate_metadata_entries(metadata: &[PostscriptMetadata]) -> VortexResult<()> {
     if metadata.len() > MAX_METADATA_SEGMENTS {
         return Err(vortex_err!(
-            "Postscript contains {} metadata segments, but Vortex supports at most {} metadata segments and at most {} characters per metadata key",
+            "Postscript contains {} metadata segments, but Vortex supports at most {} metadata segments and at most {} bytes per metadata key",
             metadata.len(),
             MAX_METADATA_SEGMENTS,
-            MAX_METADATA_KEY_CHARS
+            MAX_METADATA_KEY_BYTES
         ));
     }
 
@@ -139,18 +139,18 @@ fn validate_metadata_entries(metadata: &[PostscriptMetadata]) -> VortexResult<()
 fn validate_metadata_key(key: &str) -> VortexResult<()> {
     if key.is_empty() {
         return Err(vortex_err!(
-            "Postscript metadata key must not be empty; Vortex supports at most {} metadata segments and metadata keys must be at most {} characters",
+            "Postscript metadata key must not be empty; Vortex supports at most {} metadata segments and metadata keys must be at most {} bytes",
             MAX_METADATA_SEGMENTS,
-            MAX_METADATA_KEY_CHARS
+            MAX_METADATA_KEY_BYTES
         ));
     }
 
-    let key_chars = key.chars().count();
-    if key_chars > MAX_METADATA_KEY_CHARS {
+    let key_bytes = key.len();
+    if key_bytes > MAX_METADATA_KEY_BYTES {
         return Err(vortex_err!(
-            "Postscript metadata key {key:?} is {key_chars} characters, but Vortex supports at most {} metadata segments and metadata keys must be at most {} characters",
+            "Postscript metadata key {key:?} is {key_bytes} bytes, but Vortex supports at most {} metadata segments and metadata keys must be at most {} bytes",
             MAX_METADATA_SEGMENTS,
-            MAX_METADATA_KEY_CHARS
+            MAX_METADATA_KEY_BYTES
         ));
     }
 
@@ -311,12 +311,13 @@ mod tests {
             statistics: None,
             footer: segment(1),
             metadata: vec![PostscriptMetadata {
-                key: "a".repeat(MAX_METADATA_KEY_CHARS + 1),
+                key: "é".repeat((MAX_METADATA_KEY_BYTES / "é".len()) + 1),
                 segment: segment(2),
             }],
         });
 
-        assert!(err.contains("at most 32 characters"));
+        assert!(err.contains("34 bytes"));
+        assert!(err.contains("at most 32 bytes"));
         assert!(err.contains("at most 16 metadata segments"));
     }
 
@@ -336,6 +337,6 @@ mod tests {
         });
 
         assert!(err.contains("at most 16 metadata segments"));
-        assert!(err.contains("at most 32 characters"));
+        assert!(err.contains("at most 32 bytes"));
     }
 }

--- a/vortex-file/src/footer/serializer.rs
+++ b/vortex-file/src/footer/serializer.rs
@@ -68,6 +68,7 @@ impl FooterSerializer {
         let mut buffers = vec![];
 
         let mut metadata = self.footer.metadata_segments().collect::<Vec<_>>();
+        // Metadata is stored in a HashMap, so sort keys before assigning segment offsets.
         metadata.sort_unstable_by_key(|(key, _)| *key);
 
         let mut metadata_segments = Vec::with_capacity(metadata.len());

--- a/vortex-file/src/footer/serializer.rs
+++ b/vortex-file/src/footer/serializer.rs
@@ -21,6 +21,7 @@ use crate::MAX_POSTSCRIPT_SIZE;
 use crate::VERSION;
 use crate::footer::file_layout::FooterFlatBufferWriter;
 use crate::footer::postscript::Postscript;
+use crate::footer::postscript::PostscriptMetadata;
 use crate::footer::postscript::PostscriptSegment;
 
 pub struct FooterSerializer {
@@ -66,6 +67,16 @@ impl FooterSerializer {
     pub fn serialize(mut self) -> VortexResult<Vec<ByteBuffer>> {
         let mut buffers = vec![];
 
+        let mut metadata_segments = Vec::with_capacity(self.footer.metadata_segments().len());
+        for (key, metadata) in self.footer.metadata_segments() {
+            let (metadata_buffers, segment) = write_buffer(&mut self.offset, metadata.clone())?;
+            buffers.extend(metadata_buffers);
+            metadata_segments.push(PostscriptMetadata {
+                key: key.clone(),
+                segment,
+            });
+        }
+
         let dtype_segment = if self.exclude_dtype {
             None
         } else {
@@ -110,6 +121,7 @@ impl FooterSerializer {
             layout: layout_segment,
             statistics: statistics_segment,
             footer: footer_segment,
+            metadata: metadata_segments,
         };
         let postscript_buffer = postscript.write_flatbuffer_bytes()?;
         if postscript_buffer.len() > MAX_POSTSCRIPT_SIZE as usize {
@@ -152,4 +164,32 @@ fn write_flatbuffer<F: FlatBufferRoot + WriteFlatBuffer>(
     *offset += u64::from(length);
 
     Ok((buffer.into_inner(), segment))
+}
+
+fn write_buffer(
+    offset: &mut u64,
+    buffer: ByteBuffer,
+) -> VortexResult<(Vec<ByteBuffer>, PostscriptSegment)> {
+    let length = u32::try_from(buffer.len())
+        .map_err(|_| vortex_err!("metadata segment length exceeds maximum u32"))?;
+    let alignment = buffer.alignment();
+
+    let padding = offset.next_multiple_of(*alignment as u64) - *offset;
+    let segment_offset = *offset + padding;
+
+    let segment = PostscriptSegment {
+        offset: segment_offset,
+        length,
+        alignment,
+    };
+
+    *offset += padding + u64::from(length);
+
+    let mut buffers = Vec::with_capacity(if padding == 0 { 1 } else { 2 });
+    if padding > 0 {
+        buffers.push(ByteBuffer::zeroed(padding as usize));
+    }
+    buffers.push(buffer);
+
+    Ok((buffers, segment))
 }

--- a/vortex-file/src/footer/serializer.rs
+++ b/vortex-file/src/footer/serializer.rs
@@ -67,12 +67,15 @@ impl FooterSerializer {
     pub fn serialize(mut self) -> VortexResult<Vec<ByteBuffer>> {
         let mut buffers = vec![];
 
-        let mut metadata_segments = Vec::with_capacity(self.footer.metadata_segments().len());
-        for (key, metadata) in self.footer.metadata_segments() {
+        let mut metadata = self.footer.metadata_segments().collect::<Vec<_>>();
+        metadata.sort_unstable_by_key(|(key, _)| *key);
+
+        let mut metadata_segments = Vec::with_capacity(metadata.len());
+        for (key, metadata) in metadata {
             let (metadata_buffers, segment) = write_buffer(&mut self.offset, metadata.clone())?;
             buffers.extend(metadata_buffers);
             metadata_segments.push(PostscriptMetadata {
-                key: key.clone(),
+                key: key.to_string(),
                 segment,
             });
         }

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -42,13 +42,15 @@
 //!    1. To allow for more efficient IO & pruning, our writer implementation first writes the "data" arrays,
 //!       and then writes the "metadata" arrays (i.e., per-column statistics)
 //! 2. We write what is collectively referred to as the "Footer", which contains:
-//!    1. An optional Schema, which if present is a valid flatbuffer representing a message::Schema
-//!    2. The Layout, which is a valid footer::Layout flatbuffer, and describes the physical byte ranges & relationships amongst
+//!    1. Optional user-defined metadata segments, keyed by strings in the Postscript.
+//!    2. An optional Schema, which if present is a valid flatbuffer representing a message::Schema
+//!    3. The Layout, which is a valid footer::Layout flatbuffer, and describes the physical byte ranges & relationships amongst
 //!       the those byte ranges that we wrote in part 1.
-//!    3. Optional user-defined metadata segments, keyed by strings in the Postscript.
-//!    4. The Postscript, which is a valid footer::Postscript flatbuffer, containing the absolute start offsets of the Schema,
+//!    4. Optional file-level Statistics, stored as a valid footer::FileStatistics flatbuffer.
+//!    5. The Footer flatbuffer, which stores the segment map and registered array/layout specs.
+//!    6. The Postscript, which is a valid footer::Postscript flatbuffer, containing the absolute start offsets of the Schema,
 //!       Layout, Footer, Statistics, and user-defined metadata segments within the file.
-//!    5. The End-of-File marker, which is 8 bytes, and contains the u16 version, u16 postscript length, and 4 magic bytes.
+//!    7. The End-of-File marker, which is 8 bytes, and contains the u16 version, u16 postscript length, and 4 magic bytes.
 //!
 //! ## Illustrated File Format
 //! ```text

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -45,9 +45,10 @@
 //!    1. An optional Schema, which if present is a valid flatbuffer representing a message::Schema
 //!    2. The Layout, which is a valid footer::Layout flatbuffer, and describes the physical byte ranges & relationships amongst
 //!       the those byte ranges that we wrote in part 1.
-//!    3. The Postscript, which is a valid footer::Postscript flatbuffer, containing the absolute start offsets of the Schema & Layout
-//!       flatbuffers within the file.
-//!    4. The End-of-File marker, which is 8 bytes, and contains the u16 version, u16 postscript length, and 4 magic bytes.
+//!    3. Optional user-defined metadata segments, keyed by strings in the Postscript.
+//!    4. The Postscript, which is a valid footer::Postscript flatbuffer, containing the absolute start offsets of the Schema,
+//!       Layout, Footer, Statistics, and user-defined metadata segments within the file.
+//!    5. The End-of-File marker, which is 8 bytes, and contains the u16 version, u16 postscript length, and 4 magic bytes.
 //!
 //! ## Illustrated File Format
 //! ```text
@@ -62,6 +63,10 @@
 //! │                            │
 //! ├────────────────────────────┤
 //! │                            │
+//! │  User Metadata Segments    │
+//! │                            │
+//! ├────────────────────────────┤
+//! │                            │
 //! │     Schema Flatbuffer      │
 //! │                            │
 //! ├────────────────────────────┤
@@ -71,7 +76,7 @@
 //! ├────────────────────────────┤
 //! │                            │
 //! │    Postscript Flatbuffer   │
-//! │  (Schema & Layout Offsets) │
+//! │  (Footer Segment Offsets)  │
 //! │                            │
 //! ├────────────────────────────┤
 //! │     8-byte End of File     │

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -75,6 +75,14 @@
 //! │                            │
 //! ├────────────────────────────┤
 //! │                            │
+//! │ File Statistics Flatbuffer │
+//! │                            │
+//! ├────────────────────────────┤
+//! │                            │
+//! │     Footer Flatbuffer      │
+//! │                            │
+//! ├────────────────────────────┤
+//! │                            │
 //! │    Postscript Flatbuffer   │
 //! │  (Footer Segment Offsets)  │
 //! │                            │

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -54,6 +54,8 @@ pub struct VortexOpenOptions {
     dtype: Option<DType>,
     /// An optional, externally provided, file layout.
     footer: Option<Footer>,
+    /// Whether to include user-defined metadata segments when opening the file.
+    include_metadata: bool,
     /// The segments read during the initial read.
     initial_read_segments: RwLock<HashMap<SegmentId, ByteBuffer>>,
     /// A metrics registry for the file.
@@ -74,6 +76,7 @@ pub trait OpenOptionsSessionExt:
             file_size: None,
             dtype: None,
             footer: None,
+            include_metadata: false,
             initial_read_segments: Default::default(),
             metrics_registry: None,
             labels: Vec::default(),
@@ -133,6 +136,21 @@ impl VortexOpenOptions {
     pub fn with_footer(mut self, footer: Footer) -> Self {
         self.dtype = Some(footer.layout().dtype().clone());
         self.footer = Some(footer);
+        self
+    }
+
+    /// Include user-defined metadata segments when opening the file.
+    ///
+    /// By default, opening a file reads only the metadata required to interpret the layout.
+    /// Enabling this option includes all postscript metadata segments in the footer read.
+    pub fn include_metadata(mut self) -> Self {
+        self.include_metadata = true;
+        self
+    }
+
+    /// Configure whether user-defined metadata segments are included when opening the file.
+    pub fn with_include_metadata(mut self, include_metadata: bool) -> Self {
+        self.include_metadata = include_metadata;
         self
     }
 
@@ -274,7 +292,8 @@ impl VortexOpenOptions {
 
         let mut deserializer = Footer::deserializer(initial_read, self.session.clone())
             .with_size(file_size)
-            .with_some_dtype(self.dtype.clone());
+            .with_some_dtype(self.dtype.clone())
+            .with_include_metadata(self.include_metadata);
 
         let footer = loop {
             match deserializer.deserialize()? {

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -142,13 +142,17 @@ impl VortexOpenOptions {
     /// Include user-defined metadata segments when opening the file.
     ///
     /// By default, opening a file reads only the metadata required to interpret the layout.
-    /// Enabling this option includes all postscript metadata segments in the footer read.
+    /// Enabling this option loads all metadata segments named by the postscript, which may require
+    /// additional reads before the footer is returned.
     pub fn include_metadata(mut self) -> Self {
         self.include_metadata = true;
         self
     }
 
     /// Configure whether user-defined metadata segments are included when opening the file.
+    ///
+    /// Enabling this option loads all metadata segments named by the postscript, which may require
+    /// additional reads before the footer is returned.
     pub fn with_include_metadata(mut self, include_metadata: bool) -> Self {
         self.include_metadata = include_metadata;
         self

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1703,6 +1703,17 @@ where
     }
 }
 
+fn metadata_key_limit_message() -> String {
+    format!("at most {} bytes", crate::footer::MAX_METADATA_KEY_BYTES)
+}
+
+fn metadata_segment_limit_message() -> String {
+    format!(
+        "at most {} metadata segments",
+        crate::footer::MAX_METADATA_SEGMENTS
+    )
+}
+
 #[tokio::test]
 async fn test_file_metadata_segments_roundtrip() -> VortexResult<()> {
     let array =
@@ -1714,6 +1725,7 @@ async fn test_file_metadata_segments_roundtrip() -> VortexResult<()> {
     let summary = SESSION
         .write_options()
         .with_metadata_segment("application/json", ByteBuffer::copy_from(b"old"))
+        // Re-using a key intentionally exercises last-write-wins replacement.
         .with_metadata_segment("application/json", small.clone())
         .with_metadata_segment("large", large.clone())
         .write(&mut buf, array.to_array_stream())
@@ -1730,6 +1742,7 @@ async fn test_file_metadata_segments_roundtrip() -> VortexResult<()> {
 
     let bytes = ByteBuffer::from(buf);
     let file_without_metadata = SESSION.open_options().open_buffer(bytes.clone())?;
+    assert_eq!(file_without_metadata.row_count(), 3);
     assert_eq!(file_without_metadata.metadata_segments().count(), 0);
     assert!(
         file_without_metadata
@@ -1781,23 +1794,21 @@ async fn test_file_metadata_empty_key_rejected() -> VortexResult<()> {
     let err = metadata_write_error([(String::new(), ByteBuffer::empty())]).await?;
 
     assert!(err.contains("non-empty"));
-    assert!(err.contains("at most 32 bytes"));
-    assert!(err.contains("at most 16 metadata segments"));
+    assert!(err.contains(&metadata_key_limit_message()));
+    assert!(err.contains(&metadata_segment_limit_message()));
 
     Ok(())
 }
 
 #[tokio::test]
 async fn test_file_metadata_long_key_rejected() -> VortexResult<()> {
-    let err = metadata_write_error([(
-        "é".repeat((crate::footer::MAX_METADATA_KEY_BYTES / "é".len()) + 1),
-        ByteBuffer::empty(),
-    )])
-    .await?;
+    let key = "é".repeat((crate::footer::MAX_METADATA_KEY_BYTES / "é".len()) + 1);
+    let key_len = key.len();
+    let err = metadata_write_error([(key, ByteBuffer::empty())]).await?;
 
-    assert!(err.contains("34 bytes"));
-    assert!(err.contains("at most 32 bytes"));
-    assert!(err.contains("at most 16 metadata segments"));
+    assert!(err.contains(&format!("{key_len} bytes")));
+    assert!(err.contains(&metadata_key_limit_message()));
+    assert!(err.contains(&metadata_segment_limit_message()));
 
     Ok(())
 }
@@ -1811,9 +1822,12 @@ async fn test_file_metadata_too_many_segments_rejected() -> VortexResult<()> {
     )
     .await?;
 
-    assert!(err.contains("got 17 metadata segments"));
-    assert!(err.contains("at most 16 metadata segments"));
-    assert!(err.contains("at most 32 bytes"));
+    assert!(err.contains(&format!(
+        "got {} metadata segments",
+        crate::footer::MAX_METADATA_SEGMENTS + 1
+    )));
+    assert!(err.contains(&metadata_segment_limit_message()));
+    assert!(err.contains(&metadata_key_limit_message()));
 
     Ok(())
 }

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -62,6 +62,7 @@ use vortex_buffer::Buffer;
 use vortex_buffer::ByteBuffer;
 use vortex_buffer::ByteBufferMut;
 use vortex_buffer::buffer;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_io::session::RuntimeSession;
 use vortex_layout::Layout;
@@ -69,6 +70,7 @@ use vortex_layout::scan::scan_builder::ScanBuilder;
 use vortex_layout::session::LayoutSession;
 use vortex_session::VortexSession;
 
+use crate::DeserializeStep;
 use crate::MAX_POSTSCRIPT_SIZE;
 use crate::OpenOptionsSessionExt;
 use crate::V1_FOOTER_FBS_SIZE;
@@ -1719,7 +1721,7 @@ async fn test_file_metadata_segments_roundtrip() -> VortexResult<()> {
     let file = SESSION
         .open_options()
         .include_metadata()
-        .open_buffer(bytes)?;
+        .open_buffer(bytes.clone())?;
 
     assert_eq!(file.metadata_segments().count(), 2);
     assert_eq!(
@@ -1734,6 +1736,23 @@ async fn test_file_metadata_segments_roundtrip() -> VortexResult<()> {
         Some(large.as_slice())
     );
     assert!(file.metadata_segment("missing").is_none());
+
+    let mut deserializer = crate::Footer::deserializer(bytes.clone(), SESSION.clone())
+        .with_size(bytes.len() as u64)
+        .include_metadata();
+    let footer = match deserializer.deserialize()? {
+        DeserializeStep::Done(footer) => footer,
+        _ => panic!("full file buffer should include all footer segments"),
+    };
+    let json_metadata = footer
+        .metadata_segment("application/json")
+        .vortex_expect("metadata segment");
+    let file_start = bytes.as_slice().as_ptr() as usize;
+    let file_end = file_start + bytes.len();
+    let metadata_start = json_metadata.as_slice().as_ptr() as usize;
+    let metadata_end = metadata_start + json_metadata.len();
+    assert!(metadata_start >= file_start);
+    assert!(metadata_end <= file_end);
 
     Ok(())
 }

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -59,6 +59,7 @@ use vortex_array::stream::ArrayStreamAdapter;
 use vortex_array::stream::ArrayStreamExt;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
+use vortex_buffer::ByteBuffer;
 use vortex_buffer::ByteBufferMut;
 use vortex_buffer::buffer;
 use vortex_error::VortexResult;
@@ -68,6 +69,7 @@ use vortex_layout::scan::scan_builder::ScanBuilder;
 use vortex_layout::session::LayoutSession;
 use vortex_session::VortexSession;
 
+use crate::MAX_POSTSCRIPT_SIZE;
 use crate::OpenOptionsSessionExt;
 use crate::V1_FOOTER_FBS_SIZE;
 use crate::VERSION;
@@ -1676,6 +1678,50 @@ async fn test_writer_with_statistics() -> VortexResult<()> {
 
     assert!(summary.footer().statistics().is_some());
     assert_eq!(summary.row_count(), 5);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_file_metadata_segments_roundtrip() -> VortexResult<()> {
+    let array =
+        StructArray::from_fields(&[("numbers", buffer![1u32, 2, 3].into_array())])?.into_array();
+    let small = ByteBuffer::copy_from(b"{\"source\":\"test\"}");
+    let large = ByteBuffer::copy_from(vec![7u8; usize::from(MAX_POSTSCRIPT_SIZE) + 1024]);
+
+    let mut buf = ByteBufferMut::empty();
+    let summary = SESSION
+        .write_options()
+        .with_metadata_segment("application/json", ByteBuffer::copy_from(b"old"))
+        .with_metadata_segment("application/json", small.clone())
+        .with_metadata_segment("large", large.clone())
+        .write(&mut buf, array.to_array_stream())
+        .await?;
+
+    assert_eq!(summary.footer().metadata_segments().len(), 2);
+    assert_eq!(
+        summary
+            .footer()
+            .metadata_segment("application/json")
+            .map(ByteBuffer::as_slice),
+        Some(small.as_slice())
+    );
+
+    let file = SESSION.open_options().open_buffer(buf)?;
+
+    assert_eq!(file.metadata_segments().len(), 2);
+    assert_eq!(
+        file.metadata_segment("application/json")
+            .map(ByteBuffer::as_slice),
+        Some(small.as_slice())
+    );
+    assert_eq!(
+        file.footer()
+            .metadata_segment("large")
+            .map(ByteBuffer::as_slice),
+        Some(large.as_slice())
+    );
+    assert!(file.metadata_segment("missing").is_none());
 
     Ok(())
 }

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1781,7 +1781,7 @@ async fn test_file_metadata_empty_key_rejected() -> VortexResult<()> {
     let err = metadata_write_error([(String::new(), ByteBuffer::empty())]).await?;
 
     assert!(err.contains("non-empty"));
-    assert!(err.contains("at most 32 characters"));
+    assert!(err.contains("at most 32 bytes"));
     assert!(err.contains("at most 16 metadata segments"));
 
     Ok(())
@@ -1790,13 +1790,13 @@ async fn test_file_metadata_empty_key_rejected() -> VortexResult<()> {
 #[tokio::test]
 async fn test_file_metadata_long_key_rejected() -> VortexResult<()> {
     let err = metadata_write_error([(
-        "a".repeat(crate::footer::MAX_METADATA_KEY_CHARS + 1),
+        "é".repeat((crate::footer::MAX_METADATA_KEY_BYTES / "é".len()) + 1),
         ByteBuffer::empty(),
     )])
     .await?;
 
-    assert!(err.contains("33 characters"));
-    assert!(err.contains("at most 32 characters"));
+    assert!(err.contains("34 bytes"));
+    assert!(err.contains("at most 32 bytes"));
     assert!(err.contains("at most 16 metadata segments"));
 
     Ok(())
@@ -1813,7 +1813,7 @@ async fn test_file_metadata_too_many_segments_rejected() -> VortexResult<()> {
 
     assert!(err.contains("got 17 metadata segments"));
     assert!(err.contains("at most 16 metadata segments"));
-    assert!(err.contains("at most 32 characters"));
+    assert!(err.contains("at most 32 bytes"));
 
     Ok(())
 }

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1698,7 +1698,7 @@ async fn test_file_metadata_segments_roundtrip() -> VortexResult<()> {
         .write(&mut buf, array.to_array_stream())
         .await?;
 
-    assert_eq!(summary.footer().metadata_segments().len(), 2);
+    assert_eq!(summary.footer().metadata_segments().count(), 2);
     assert_eq!(
         summary
             .footer()
@@ -1707,9 +1707,21 @@ async fn test_file_metadata_segments_roundtrip() -> VortexResult<()> {
         Some(small.as_slice())
     );
 
-    let file = SESSION.open_options().open_buffer(buf)?;
+    let bytes = ByteBuffer::from(buf);
+    let file_without_metadata = SESSION.open_options().open_buffer(bytes.clone())?;
+    assert_eq!(file_without_metadata.metadata_segments().count(), 0);
+    assert!(
+        file_without_metadata
+            .metadata_segment("application/json")
+            .is_none()
+    );
 
-    assert_eq!(file.metadata_segments().len(), 2);
+    let file = SESSION
+        .open_options()
+        .include_metadata()
+        .open_buffer(bytes)?;
+
+    assert_eq!(file.metadata_segments().count(), 2);
     assert_eq!(
         file.metadata_segment("application/json")
             .map(ByteBuffer::as_slice),
@@ -1724,6 +1736,15 @@ async fn test_file_metadata_segments_roundtrip() -> VortexResult<()> {
     assert!(file.metadata_segment("missing").is_none());
 
     Ok(())
+}
+
+#[test]
+#[should_panic(expected = "metadata key must not be empty")]
+fn test_file_metadata_empty_key_rejected() {
+    drop(
+        crate::VortexWriteOptions::new(VortexSession::empty())
+            .with_metadata_segment("", ByteBuffer::empty()),
+    );
 }
 
 #[tokio::test]

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1684,6 +1684,25 @@ async fn test_writer_with_statistics() -> VortexResult<()> {
     Ok(())
 }
 
+async fn metadata_write_error<I>(metadata: I) -> VortexResult<String>
+where
+    I: IntoIterator<Item = (String, ByteBuffer)>,
+{
+    let array =
+        StructArray::from_fields(&[("numbers", buffer![1u32, 2, 3].into_array())])?.into_array();
+    let mut buf = ByteBufferMut::empty();
+
+    match SESSION
+        .write_options()
+        .with_metadata_segments(metadata)
+        .write(&mut buf, array.to_array_stream())
+        .await
+    {
+        Ok(_) => panic!("expected metadata write to fail"),
+        Err(err) => Ok(err.to_string()),
+    }
+}
+
 #[tokio::test]
 async fn test_file_metadata_segments_roundtrip() -> VortexResult<()> {
     let array =
@@ -1757,13 +1776,46 @@ async fn test_file_metadata_segments_roundtrip() -> VortexResult<()> {
     Ok(())
 }
 
-#[test]
-#[should_panic(expected = "metadata key must not be empty")]
-fn test_file_metadata_empty_key_rejected() {
-    drop(
-        crate::VortexWriteOptions::new(VortexSession::empty())
-            .with_metadata_segment("", ByteBuffer::empty()),
-    );
+#[tokio::test]
+async fn test_file_metadata_empty_key_rejected() -> VortexResult<()> {
+    let err = metadata_write_error([(String::new(), ByteBuffer::empty())]).await?;
+
+    assert!(err.contains("non-empty"));
+    assert!(err.contains("at most 32 characters"));
+    assert!(err.contains("at most 16 metadata segments"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_file_metadata_long_key_rejected() -> VortexResult<()> {
+    let err = metadata_write_error([(
+        "a".repeat(crate::footer::MAX_METADATA_KEY_CHARS + 1),
+        ByteBuffer::empty(),
+    )])
+    .await?;
+
+    assert!(err.contains("33 characters"));
+    assert!(err.contains("at most 32 characters"));
+    assert!(err.contains("at most 16 metadata segments"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_file_metadata_too_many_segments_rejected() -> VortexResult<()> {
+    let err = metadata_write_error(
+        (0..=crate::footer::MAX_METADATA_SEGMENTS)
+            .map(|idx| (format!("metadata-{idx}"), ByteBuffer::empty()))
+            .collect::<Vec<_>>(),
+    )
+    .await?;
+
+    assert!(err.contains("got 17 metadata segments"));
+    assert!(err.contains("at most 16 metadata segments"));
+    assert!(err.contains("at most 32 characters"));
+
+    Ok(())
 }
 
 #[tokio::test]

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -54,7 +54,7 @@ use crate::MAGIC_BYTES;
 use crate::WriteStrategyBuilder;
 use crate::counting::CountingVortexWrite;
 use crate::footer::FileStatistics;
-use crate::footer::MAX_METADATA_KEY_CHARS;
+use crate::footer::MAX_METADATA_KEY_BYTES;
 use crate::footer::MAX_METADATA_SEGMENTS;
 use crate::segments::writer::BufferedSegmentSink;
 
@@ -125,10 +125,10 @@ impl VortexWriteOptions {
     ///
     /// If the key already exists, the previous segment for that key is replaced.
     ///
-    /// Metadata limits are validated when writing: keys must be non-empty and at most
-    /// 32 characters, and a file may contain at most 16 user-defined metadata segments. These
-    /// limits keep metadata bookkeeping small because keys and segment locations are stored in the
-    /// fixed-size postscript.
+    /// Metadata limits are validated when writing: keys must be non-empty and at most 32 UTF-8
+    /// bytes, and a file may contain at most 16 user-defined metadata segments. These limits keep
+    /// metadata bookkeeping small because keys and segment locations are stored in the fixed-size
+    /// postscript.
     pub fn with_metadata_segment(
         mut self,
         key: impl Into<String>,
@@ -321,9 +321,9 @@ impl VortexWriteOptions {
 fn validate_metadata_segments(metadata: &HashMap<String, ByteBuffer>) -> VortexResult<()> {
     if metadata.len() > MAX_METADATA_SEGMENTS {
         vortex_bail!(
-            "Vortex files may contain at most {} metadata segments with keys at most {} characters; got {} metadata segments",
+            "Vortex files may contain at most {} metadata segments with keys at most {} bytes; got {} metadata segments",
             MAX_METADATA_SEGMENTS,
-            MAX_METADATA_KEY_CHARS,
+            MAX_METADATA_KEY_BYTES,
             metadata.len()
         );
     }
@@ -331,17 +331,17 @@ fn validate_metadata_segments(metadata: &HashMap<String, ByteBuffer>) -> VortexR
     for key in metadata.keys() {
         if key.is_empty() {
             vortex_bail!(
-                "Vortex metadata keys must be non-empty and at most {} characters, and files may contain at most {} metadata segments",
-                MAX_METADATA_KEY_CHARS,
+                "Vortex metadata keys must be non-empty and at most {} bytes, and files may contain at most {} metadata segments",
+                MAX_METADATA_KEY_BYTES,
                 MAX_METADATA_SEGMENTS
             );
         }
 
-        let key_chars = key.chars().count();
-        if key_chars > MAX_METADATA_KEY_CHARS {
+        let key_bytes = key.len();
+        if key_bytes > MAX_METADATA_KEY_BYTES {
             vortex_bail!(
-                "Vortex metadata key {key:?} is {key_chars} characters, but keys must be at most {} characters and files may contain at most {} metadata segments",
-                MAX_METADATA_KEY_CHARS,
+                "Vortex metadata key {key:?} is {key_bytes} bytes, but keys must be at most {} bytes and files may contain at most {} metadata segments",
+                MAX_METADATA_KEY_BYTES,
                 MAX_METADATA_SEGMENTS
             );
         }

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -46,6 +46,7 @@ use vortex_layout::sequence::SequentialStreamExt;
 use vortex_session::SessionExt;
 use vortex_session::VortexSession;
 use vortex_session::registry::ReadContext;
+use vortex_utils::aliases::hash_map::HashMap;
 
 use crate::ALLOWED_ENCODINGS;
 use crate::Footer;
@@ -66,7 +67,7 @@ pub struct VortexWriteOptions {
     exclude_dtype: bool,
     max_variable_length_statistics_size: usize,
     file_statistics: Vec<Stat>,
-    metadata: Vec<(String, ByteBuffer)>,
+    metadata: HashMap<String, ByteBuffer>,
 }
 
 pub trait WriteOptionsSessionExt: SessionExt {
@@ -79,7 +80,7 @@ pub trait WriteOptionsSessionExt: SessionExt {
             exclude_dtype: false,
             file_statistics: PRUNING_STATS.to_vec(),
             max_variable_length_statistics_size: 64,
-            metadata: Vec::new(),
+            metadata: HashMap::default(),
         }
     }
 }
@@ -94,7 +95,7 @@ impl VortexWriteOptions {
             exclude_dtype: false,
             file_statistics: PRUNING_STATS.to_vec(),
             max_variable_length_statistics_size: 64,
-            metadata: Vec::new(),
+            metadata: HashMap::default(),
         }
     }
 
@@ -121,22 +122,19 @@ impl VortexWriteOptions {
     /// Add a user-defined metadata segment to the file.
     ///
     /// If the key already exists, the previous segment for that key is replaced.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the key is empty.
     pub fn with_metadata_segment(
         mut self,
         key: impl Into<String>,
         metadata: impl Into<ByteBuffer>,
     ) -> Self {
         let key = key.into();
+        assert!(!key.is_empty(), "metadata key must not be empty");
         let metadata = metadata.into();
-        if let Some((_, existing)) = self
-            .metadata
-            .iter_mut()
-            .find(|(existing_key, _)| existing_key == &key)
-        {
-            *existing = metadata;
-        } else {
-            self.metadata.push((key, metadata));
-        }
+        self.metadata.insert(key, metadata);
         self
     }
 
@@ -259,7 +257,7 @@ impl VortexWriteOptions {
                 &dtype,
             ))
         };
-        let metadata = self.metadata.into();
+        let metadata = Arc::new(self.metadata);
 
         let mut footer = Footer::new(
             Arc::clone(&layout),

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -54,6 +54,8 @@ use crate::MAGIC_BYTES;
 use crate::WriteStrategyBuilder;
 use crate::counting::CountingVortexWrite;
 use crate::footer::FileStatistics;
+use crate::footer::MAX_METADATA_KEY_CHARS;
+use crate::footer::MAX_METADATA_SEGMENTS;
 use crate::segments::writer::BufferedSegmentSink;
 
 /// Configure a new writer, which can eventually be used to write an [`ArrayStream`] into a sink
@@ -123,16 +125,16 @@ impl VortexWriteOptions {
     ///
     /// If the key already exists, the previous segment for that key is replaced.
     ///
-    /// ## Panics
-    ///
-    /// Panics if the key is empty.
+    /// Metadata limits are validated when writing: keys must be non-empty and at most
+    /// 32 characters, and a file may contain at most 16 user-defined metadata segments. These
+    /// limits keep metadata bookkeeping small because keys and segment locations are stored in the
+    /// fixed-size postscript.
     pub fn with_metadata_segment(
         mut self,
         key: impl Into<String>,
         metadata: impl Into<ByteBuffer>,
     ) -> Self {
         let key = key.into();
-        assert!(!key.is_empty(), "metadata key must not be empty");
         let metadata = metadata.into();
         self.metadata.insert(key, metadata);
         self
@@ -181,6 +183,8 @@ impl VortexWriteOptions {
         mut write: W,
         stream: SendableArrayStream,
     ) -> VortexResult<WriteSummary> {
+        validate_metadata_segments(&self.metadata)?;
+
         // NOTE(os): Setup an array context that already has all known encodings pre-populated.
         // This is preferred for now over having an empty context here, because only the
         // serialised array order is deterministic. The serialisation of arrays are done
@@ -312,6 +316,38 @@ impl VortexWriteOptions {
             strategy,
         }
     }
+}
+
+fn validate_metadata_segments(metadata: &HashMap<String, ByteBuffer>) -> VortexResult<()> {
+    if metadata.len() > MAX_METADATA_SEGMENTS {
+        vortex_bail!(
+            "Vortex files may contain at most {} metadata segments with keys at most {} characters; got {} metadata segments",
+            MAX_METADATA_SEGMENTS,
+            MAX_METADATA_KEY_CHARS,
+            metadata.len()
+        );
+    }
+
+    for key in metadata.keys() {
+        if key.is_empty() {
+            vortex_bail!(
+                "Vortex metadata keys must be non-empty and at most {} characters, and files may contain at most {} metadata segments",
+                MAX_METADATA_KEY_CHARS,
+                MAX_METADATA_SEGMENTS
+            );
+        }
+
+        let key_chars = key.chars().count();
+        if key_chars > MAX_METADATA_KEY_CHARS {
+            vortex_bail!(
+                "Vortex metadata key {key:?} is {key_chars} characters, but keys must be at most {} characters and files may contain at most {} metadata segments",
+                MAX_METADATA_KEY_CHARS,
+                MAX_METADATA_SEGMENTS
+            );
+        }
+    }
+
+    Ok(())
 }
 
 /// An async API for writing Vortex files.

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -66,6 +66,7 @@ pub struct VortexWriteOptions {
     exclude_dtype: bool,
     max_variable_length_statistics_size: usize,
     file_statistics: Vec<Stat>,
+    metadata: Vec<(String, ByteBuffer)>,
 }
 
 pub trait WriteOptionsSessionExt: SessionExt {
@@ -78,6 +79,7 @@ pub trait WriteOptionsSessionExt: SessionExt {
             exclude_dtype: false,
             file_statistics: PRUNING_STATS.to_vec(),
             max_variable_length_statistics_size: 64,
+            metadata: Vec::new(),
         }
     }
 }
@@ -92,6 +94,7 @@ impl VortexWriteOptions {
             exclude_dtype: false,
             file_statistics: PRUNING_STATS.to_vec(),
             max_variable_length_statistics_size: 64,
+            metadata: Vec::new(),
         }
     }
 
@@ -112,6 +115,43 @@ impl VortexWriteOptions {
     /// Configure which statistics to compute at the file-level.
     pub fn with_file_statistics(mut self, file_statistics: Vec<Stat>) -> Self {
         self.file_statistics = file_statistics;
+        self
+    }
+
+    /// Add a user-defined metadata segment to the file.
+    ///
+    /// If the key already exists, the previous segment for that key is replaced.
+    pub fn with_metadata_segment(
+        mut self,
+        key: impl Into<String>,
+        metadata: impl Into<ByteBuffer>,
+    ) -> Self {
+        let key = key.into();
+        let metadata = metadata.into();
+        if let Some((_, existing)) = self
+            .metadata
+            .iter_mut()
+            .find(|(existing_key, _)| existing_key == &key)
+        {
+            *existing = metadata;
+        } else {
+            self.metadata.push((key, metadata));
+        }
+        self
+    }
+
+    /// Add user-defined metadata segments to the file.
+    ///
+    /// If a key already exists, the previous segment for that key is replaced.
+    pub fn with_metadata_segments<I, K, B>(mut self, metadata: I) -> Self
+    where
+        I: IntoIterator<Item = (K, B)>,
+        K: Into<String>,
+        B: Into<ByteBuffer>,
+    {
+        for (key, metadata) in metadata {
+            self = self.with_metadata_segment(key, metadata);
+        }
         self
     }
 }
@@ -211,17 +251,21 @@ impl VortexWriteOptions {
         let (layout, segment_specs) = layout_fut.await?;
 
         // Assemble the Footer object now that we have all the segments.
+        let statistics = if self.file_statistics.is_empty() {
+            None
+        } else {
+            Some(FileStatistics::new_with_dtype(
+                file_stats.stats_sets().into(),
+                &dtype,
+            ))
+        };
+        let metadata = self.metadata.into();
+
         let mut footer = Footer::new(
             Arc::clone(&layout),
             segment_specs,
-            if self.file_statistics.is_empty() {
-                None
-            } else {
-                Some(FileStatistics::new_with_dtype(
-                    file_stats.stats_sets().into(),
-                    &dtype,
-                ))
-            },
+            statistics,
+            metadata,
             ReadContext::new(ctx.to_ids()),
         );
 

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -321,17 +321,17 @@ impl VortexWriteOptions {
 fn validate_metadata_segments(metadata: &HashMap<String, ByteBuffer>) -> VortexResult<()> {
     if metadata.len() > MAX_METADATA_SEGMENTS {
         vortex_bail!(
-            "Vortex files may contain at most {} metadata segments with keys at most {} bytes; got {} metadata segments",
+            "Vortex files may contain at most {} metadata segments; got {} metadata segments. Metadata keys must be non-empty and at most {} bytes",
             MAX_METADATA_SEGMENTS,
-            MAX_METADATA_KEY_BYTES,
-            metadata.len()
+            metadata.len(),
+            MAX_METADATA_KEY_BYTES
         );
     }
 
     for key in metadata.keys() {
         if key.is_empty() {
             vortex_bail!(
-                "Vortex metadata keys must be non-empty and at most {} bytes, and files may contain at most {} metadata segments",
+                "Vortex metadata keys must be non-empty and at most {} bytes; files may contain at most {} metadata segments",
                 MAX_METADATA_KEY_BYTES,
                 MAX_METADATA_SEGMENTS
             );
@@ -340,7 +340,7 @@ fn validate_metadata_segments(metadata: &HashMap<String, ByteBuffer>) -> VortexR
         let key_bytes = key.len();
         if key_bytes > MAX_METADATA_KEY_BYTES {
             vortex_bail!(
-                "Vortex metadata key {key:?} is {key_bytes} bytes, but keys must be at most {} bytes and files may contain at most {} metadata segments",
+                "Vortex metadata key {key:?} is {key_bytes} bytes, but keys must be at most {} bytes; files may contain at most {} metadata segments",
                 MAX_METADATA_KEY_BYTES,
                 MAX_METADATA_SEGMENTS
             );

--- a/vortex-flatbuffers/flatbuffers/vortex-file/footer.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-file/footer.fbs
@@ -29,6 +29,14 @@ table Postscript {
     statistics: PostscriptSegment;
     /// Segment containing the 'Footer' flatbuffer (required)
     footer: PostscriptSegment;
+    /// User-defined metadata segments keyed by string.
+    metadata: [PostscriptMetadata];
+}
+
+/// A keyed user-defined metadata segment.
+table PostscriptMetadata {
+    key: string (required);
+    segment: PostscriptSegment (required);
 }
 
 /// A `PostscriptSegment` describes the location of a segment in the file without referencing any

--- a/vortex-flatbuffers/flatbuffers/vortex-file/footer.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-file/footer.fbs
@@ -20,6 +20,8 @@ include "vortex-layout/layout.fbs";
 ///
 /// The segments pointed to by the postscript have inline compression and encryption specs to avoid
 /// the need to fetch encryption schemes up-front.
+///
+/// New fields must be appended to preserve FlatBuffers field-order compatibility with old readers.
 table Postscript {
     /// Segment containing the root `DType` flatbuffer.
     dtype: PostscriptSegment;
@@ -29,7 +31,8 @@ table Postscript {
     statistics: PostscriptSegment;
     /// Segment containing the 'Footer' flatbuffer (required)
     footer: PostscriptSegment;
-    /// User-defined metadata segments keyed by string.
+    /// User-defined metadata segments keyed by string. Keys must be unique, non-empty, and at most
+    /// 32 UTF-8 bytes; readers reject postscripts that violate these limits.
     metadata: [PostscriptMetadata];
 }
 

--- a/vortex-flatbuffers/public-api.lock
+++ b/vortex-flatbuffers/public-api.lock
@@ -1672,6 +1672,8 @@ pub enum vortex_flatbuffers::footer::FooterOffset
 
 pub enum vortex_flatbuffers::footer::LayoutSpecOffset
 
+pub enum vortex_flatbuffers::footer::PostscriptMetadataOffset
+
 pub enum vortex_flatbuffers::footer::PostscriptOffset
 
 pub enum vortex_flatbuffers::footer::PostscriptSegmentOffset
@@ -2140,6 +2142,8 @@ pub const vortex_flatbuffers::footer::Postscript<'a>::VT_FOOTER: flatbuffers::pr
 
 pub const vortex_flatbuffers::footer::Postscript<'a>::VT_LAYOUT: flatbuffers::primitives::VOffsetT
 
+pub const vortex_flatbuffers::footer::Postscript<'a>::VT_METADATA: flatbuffers::primitives::VOffsetT
+
 pub const vortex_flatbuffers::footer::Postscript<'a>::VT_STATISTICS: flatbuffers::primitives::VOffsetT
 
 pub fn vortex_flatbuffers::footer::Postscript<'a>::create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::builder::Allocator + 'bldr>(&'mut_bldr mut flatbuffers::builder::FlatBufferBuilder<'bldr, A>, &'args vortex_flatbuffers::footer::PostscriptArgs<'args>) -> flatbuffers::primitives::WIPOffset<vortex_flatbuffers::footer::Postscript<'bldr>>
@@ -2151,6 +2155,8 @@ pub fn vortex_flatbuffers::footer::Postscript<'a>::footer(&self) -> core::option
 pub unsafe fn vortex_flatbuffers::footer::Postscript<'a>::init_from_table(flatbuffers::table::Table<'a>) -> Self
 
 pub fn vortex_flatbuffers::footer::Postscript<'a>::layout(&self) -> core::option::Option<vortex_flatbuffers::footer::PostscriptSegment<'a>>
+
+pub fn vortex_flatbuffers::footer::Postscript<'a>::metadata(&self) -> core::option::Option<flatbuffers::vector::Vector<'a, flatbuffers::primitives::ForwardsUOffset<vortex_flatbuffers::footer::PostscriptMetadata<'a>>>>
 
 pub fn vortex_flatbuffers::footer::Postscript<'a>::statistics(&self) -> core::option::Option<vortex_flatbuffers::footer::PostscriptSegment<'a>>
 
@@ -2188,6 +2194,8 @@ pub vortex_flatbuffers::footer::PostscriptArgs::footer: core::option::Option<fla
 
 pub vortex_flatbuffers::footer::PostscriptArgs::layout: core::option::Option<flatbuffers::primitives::WIPOffset<vortex_flatbuffers::footer::PostscriptSegment<'a>>>
 
+pub vortex_flatbuffers::footer::PostscriptArgs::metadata: core::option::Option<flatbuffers::primitives::WIPOffset<flatbuffers::vector::Vector<'a, flatbuffers::primitives::ForwardsUOffset<vortex_flatbuffers::footer::PostscriptMetadata<'a>>>>>
+
 pub vortex_flatbuffers::footer::PostscriptArgs::statistics: core::option::Option<flatbuffers::primitives::WIPOffset<vortex_flatbuffers::footer::PostscriptSegment<'a>>>
 
 impl<'a> core::default::Default for vortex_flatbuffers::footer::PostscriptArgs<'a>
@@ -2204,11 +2212,79 @@ pub fn vortex_flatbuffers::footer::PostscriptBuilder<'a, 'b, A>::add_footer(&mut
 
 pub fn vortex_flatbuffers::footer::PostscriptBuilder<'a, 'b, A>::add_layout(&mut self, flatbuffers::primitives::WIPOffset<vortex_flatbuffers::footer::PostscriptSegment<'b>>)
 
+pub fn vortex_flatbuffers::footer::PostscriptBuilder<'a, 'b, A>::add_metadata(&mut self, flatbuffers::primitives::WIPOffset<flatbuffers::vector::Vector<'b, flatbuffers::primitives::ForwardsUOffset<vortex_flatbuffers::footer::PostscriptMetadata<'b>>>>)
+
 pub fn vortex_flatbuffers::footer::PostscriptBuilder<'a, 'b, A>::add_statistics(&mut self, flatbuffers::primitives::WIPOffset<vortex_flatbuffers::footer::PostscriptSegment<'b>>)
 
 pub fn vortex_flatbuffers::footer::PostscriptBuilder<'a, 'b, A>::finish(self) -> flatbuffers::primitives::WIPOffset<vortex_flatbuffers::footer::Postscript<'a>>
 
 pub fn vortex_flatbuffers::footer::PostscriptBuilder<'a, 'b, A>::new(&'b mut flatbuffers::builder::FlatBufferBuilder<'a, A>) -> vortex_flatbuffers::footer::PostscriptBuilder<'a, 'b, A>
+
+pub struct vortex_flatbuffers::footer::PostscriptMetadata<'a>
+
+pub vortex_flatbuffers::footer::PostscriptMetadata::_tab: flatbuffers::table::Table<'a>
+
+impl<'a> vortex_flatbuffers::footer::PostscriptMetadata<'a>
+
+pub const vortex_flatbuffers::footer::PostscriptMetadata<'a>::VT_KEY: flatbuffers::primitives::VOffsetT
+
+pub const vortex_flatbuffers::footer::PostscriptMetadata<'a>::VT_SEGMENT: flatbuffers::primitives::VOffsetT
+
+pub fn vortex_flatbuffers::footer::PostscriptMetadata<'a>::create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::builder::Allocator + 'bldr>(&'mut_bldr mut flatbuffers::builder::FlatBufferBuilder<'bldr, A>, &'args vortex_flatbuffers::footer::PostscriptMetadataArgs<'args>) -> flatbuffers::primitives::WIPOffset<vortex_flatbuffers::footer::PostscriptMetadata<'bldr>>
+
+pub unsafe fn vortex_flatbuffers::footer::PostscriptMetadata<'a>::init_from_table(flatbuffers::table::Table<'a>) -> Self
+
+pub fn vortex_flatbuffers::footer::PostscriptMetadata<'a>::key(&self) -> &'a str
+
+pub fn vortex_flatbuffers::footer::PostscriptMetadata<'a>::segment(&self) -> vortex_flatbuffers::footer::PostscriptSegment<'a>
+
+impl core::fmt::Debug for vortex_flatbuffers::footer::PostscriptMetadata<'_>
+
+pub fn vortex_flatbuffers::footer::PostscriptMetadata<'_>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl flatbuffers::verifier::Verifiable for vortex_flatbuffers::footer::PostscriptMetadata<'_>
+
+pub fn vortex_flatbuffers::footer::PostscriptMetadata<'_>::run_verifier(&mut flatbuffers::verifier::Verifier<'_, '_>, usize) -> core::result::Result<(), flatbuffers::verifier::InvalidFlatbuffer>
+
+impl<'a> core::clone::Clone for vortex_flatbuffers::footer::PostscriptMetadata<'a>
+
+pub fn vortex_flatbuffers::footer::PostscriptMetadata<'a>::clone(&self) -> vortex_flatbuffers::footer::PostscriptMetadata<'a>
+
+impl<'a> core::cmp::PartialEq for vortex_flatbuffers::footer::PostscriptMetadata<'a>
+
+pub fn vortex_flatbuffers::footer::PostscriptMetadata<'a>::eq(&self, &vortex_flatbuffers::footer::PostscriptMetadata<'a>) -> bool
+
+impl<'a> core::marker::Copy for vortex_flatbuffers::footer::PostscriptMetadata<'a>
+
+impl<'a> core::marker::StructuralPartialEq for vortex_flatbuffers::footer::PostscriptMetadata<'a>
+
+impl<'a> flatbuffers::follow::Follow<'a> for vortex_flatbuffers::footer::PostscriptMetadata<'a>
+
+pub type vortex_flatbuffers::footer::PostscriptMetadata<'a>::Inner = vortex_flatbuffers::footer::PostscriptMetadata<'a>
+
+pub unsafe fn vortex_flatbuffers::footer::PostscriptMetadata<'a>::follow(&'a [u8], usize) -> Self::Inner
+
+pub struct vortex_flatbuffers::footer::PostscriptMetadataArgs<'a>
+
+pub vortex_flatbuffers::footer::PostscriptMetadataArgs::key: core::option::Option<flatbuffers::primitives::WIPOffset<&'a str>>
+
+pub vortex_flatbuffers::footer::PostscriptMetadataArgs::segment: core::option::Option<flatbuffers::primitives::WIPOffset<vortex_flatbuffers::footer::PostscriptSegment<'a>>>
+
+impl<'a> core::default::Default for vortex_flatbuffers::footer::PostscriptMetadataArgs<'a>
+
+pub fn vortex_flatbuffers::footer::PostscriptMetadataArgs<'a>::default() -> Self
+
+pub struct vortex_flatbuffers::footer::PostscriptMetadataBuilder<'a: 'b, 'b, A: flatbuffers::builder::Allocator + 'a>
+
+impl<'a: 'b, 'b, A: flatbuffers::builder::Allocator + 'a> vortex_flatbuffers::footer::PostscriptMetadataBuilder<'a, 'b, A>
+
+pub fn vortex_flatbuffers::footer::PostscriptMetadataBuilder<'a, 'b, A>::add_key(&mut self, flatbuffers::primitives::WIPOffset<&'b str>)
+
+pub fn vortex_flatbuffers::footer::PostscriptMetadataBuilder<'a, 'b, A>::add_segment(&mut self, flatbuffers::primitives::WIPOffset<vortex_flatbuffers::footer::PostscriptSegment<'b>>)
+
+pub fn vortex_flatbuffers::footer::PostscriptMetadataBuilder<'a, 'b, A>::finish(self) -> flatbuffers::primitives::WIPOffset<vortex_flatbuffers::footer::PostscriptMetadata<'a>>
+
+pub fn vortex_flatbuffers::footer::PostscriptMetadataBuilder<'a, 'b, A>::new(&'b mut flatbuffers::builder::FlatBufferBuilder<'a, A>) -> vortex_flatbuffers::footer::PostscriptMetadataBuilder<'a, 'b, A>
 
 pub struct vortex_flatbuffers::footer::PostscriptSegment<'a>
 

--- a/vortex-flatbuffers/src/generated/footer.rs
+++ b/vortex-flatbuffers/src/generated/footer.rs
@@ -359,6 +359,7 @@ impl<'a> Postscript<'a> {
   pub const VT_LAYOUT: ::flatbuffers::VOffsetT = 6;
   pub const VT_STATISTICS: ::flatbuffers::VOffsetT = 8;
   pub const VT_FOOTER: ::flatbuffers::VOffsetT = 10;
+  pub const VT_METADATA: ::flatbuffers::VOffsetT = 12;
 
   #[inline]
   pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
@@ -370,6 +371,7 @@ impl<'a> Postscript<'a> {
     args: &'args PostscriptArgs<'args>
   ) -> ::flatbuffers::WIPOffset<Postscript<'bldr>> {
     let mut builder = PostscriptBuilder::new(_fbb);
+    if let Some(x) = args.metadata { builder.add_metadata(x); }
     if let Some(x) = args.footer { builder.add_footer(x); }
     if let Some(x) = args.statistics { builder.add_statistics(x); }
     if let Some(x) = args.layout { builder.add_layout(x); }
@@ -410,6 +412,14 @@ impl<'a> Postscript<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<::flatbuffers::ForwardsUOffset<PostscriptSegment>>(Postscript::VT_FOOTER, None)}
   }
+  /// User-defined metadata segments keyed by string.
+  #[inline]
+  pub fn metadata(&self) -> Option<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<PostscriptMetadata<'a>>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<PostscriptMetadata>>>>(Postscript::VT_METADATA, None)}
+  }
 }
 
 impl ::flatbuffers::Verifiable for Postscript<'_> {
@@ -422,6 +432,7 @@ impl ::flatbuffers::Verifiable for Postscript<'_> {
      .visit_field::<::flatbuffers::ForwardsUOffset<PostscriptSegment>>("layout", Self::VT_LAYOUT, false)?
      .visit_field::<::flatbuffers::ForwardsUOffset<PostscriptSegment>>("statistics", Self::VT_STATISTICS, false)?
      .visit_field::<::flatbuffers::ForwardsUOffset<PostscriptSegment>>("footer", Self::VT_FOOTER, false)?
+     .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, ::flatbuffers::ForwardsUOffset<PostscriptMetadata>>>>("metadata", Self::VT_METADATA, false)?
      .finish();
     Ok(())
   }
@@ -431,6 +442,7 @@ pub struct PostscriptArgs<'a> {
     pub layout: Option<::flatbuffers::WIPOffset<PostscriptSegment<'a>>>,
     pub statistics: Option<::flatbuffers::WIPOffset<PostscriptSegment<'a>>>,
     pub footer: Option<::flatbuffers::WIPOffset<PostscriptSegment<'a>>>,
+    pub metadata: Option<::flatbuffers::WIPOffset<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<PostscriptMetadata<'a>>>>>,
 }
 impl<'a> Default for PostscriptArgs<'a> {
   #[inline]
@@ -440,6 +452,7 @@ impl<'a> Default for PostscriptArgs<'a> {
       layout: None,
       statistics: None,
       footer: None,
+      metadata: None,
     }
   }
 }
@@ -466,6 +479,10 @@ impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> PostscriptBuilder<'a, 'b, A> 
     self.fbb_.push_slot_always::<::flatbuffers::WIPOffset<PostscriptSegment>>(Postscript::VT_FOOTER, footer);
   }
   #[inline]
+  pub fn add_metadata(&mut self, metadata: ::flatbuffers::WIPOffset<::flatbuffers::Vector<'b , ::flatbuffers::ForwardsUOffset<PostscriptMetadata<'b >>>>) {
+    self.fbb_.push_slot_always::<::flatbuffers::WIPOffset<_>>(Postscript::VT_METADATA, metadata);
+  }
+  #[inline]
   pub fn new(_fbb: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>) -> PostscriptBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     PostscriptBuilder {
@@ -487,6 +504,123 @@ impl ::core::fmt::Debug for Postscript<'_> {
       ds.field("layout", &self.layout());
       ds.field("statistics", &self.statistics());
       ds.field("footer", &self.footer());
+      ds.field("metadata", &self.metadata());
+      ds.finish()
+  }
+}
+pub enum PostscriptMetadataOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+/// A keyed user-defined metadata segment.
+pub struct PostscriptMetadata<'a> {
+  pub _tab: ::flatbuffers::Table<'a>,
+}
+
+impl<'a> ::flatbuffers::Follow<'a> for PostscriptMetadata<'a> {
+  type Inner = PostscriptMetadata<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: unsafe { ::flatbuffers::Table::new(buf, loc) } }
+  }
+}
+
+impl<'a> PostscriptMetadata<'a> {
+  pub const VT_KEY: ::flatbuffers::VOffsetT = 4;
+  pub const VT_SEGMENT: ::flatbuffers::VOffsetT = 6;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
+    PostscriptMetadata { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: ::flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut ::flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args PostscriptMetadataArgs<'args>
+  ) -> ::flatbuffers::WIPOffset<PostscriptMetadata<'bldr>> {
+    let mut builder = PostscriptMetadataBuilder::new(_fbb);
+    if let Some(x) = args.segment { builder.add_segment(x); }
+    if let Some(x) = args.key { builder.add_key(x); }
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn key(&self) -> &'a str {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<::flatbuffers::ForwardsUOffset<&str>>(PostscriptMetadata::VT_KEY, None).unwrap()}
+  }
+  #[inline]
+  pub fn segment(&self) -> PostscriptSegment<'a> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<::flatbuffers::ForwardsUOffset<PostscriptSegment>>(PostscriptMetadata::VT_SEGMENT, None).unwrap()}
+  }
+}
+
+impl ::flatbuffers::Verifiable for PostscriptMetadata<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut ::flatbuffers::Verifier, pos: usize
+  ) -> Result<(), ::flatbuffers::InvalidFlatbuffer> {
+    v.visit_table(pos)?
+     .visit_field::<::flatbuffers::ForwardsUOffset<&str>>("key", Self::VT_KEY, true)?
+     .visit_field::<::flatbuffers::ForwardsUOffset<PostscriptSegment>>("segment", Self::VT_SEGMENT, true)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct PostscriptMetadataArgs<'a> {
+    pub key: Option<::flatbuffers::WIPOffset<&'a str>>,
+    pub segment: Option<::flatbuffers::WIPOffset<PostscriptSegment<'a>>>,
+}
+impl<'a> Default for PostscriptMetadataArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    PostscriptMetadataArgs {
+      key: None, // required field
+      segment: None, // required field
+    }
+  }
+}
+
+pub struct PostscriptMetadataBuilder<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: ::flatbuffers::WIPOffset<::flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> PostscriptMetadataBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_key(&mut self, key: ::flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<::flatbuffers::WIPOffset<_>>(PostscriptMetadata::VT_KEY, key);
+  }
+  #[inline]
+  pub fn add_segment(&mut self, segment: ::flatbuffers::WIPOffset<PostscriptSegment<'b >>) {
+    self.fbb_.push_slot_always::<::flatbuffers::WIPOffset<PostscriptSegment>>(PostscriptMetadata::VT_SEGMENT, segment);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>) -> PostscriptMetadataBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    PostscriptMetadataBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> ::flatbuffers::WIPOffset<PostscriptMetadata<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    self.fbb_.required(o, PostscriptMetadata::VT_KEY,"key");
+    self.fbb_.required(o, PostscriptMetadata::VT_SEGMENT,"segment");
+    ::flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl ::core::fmt::Debug for PostscriptMetadata<'_> {
+  fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+    let mut ds = f.debug_struct("PostscriptMetadata");
+      ds.field("key", &self.key());
+      ds.field("segment", &self.segment());
       ds.finish()
   }
 }

--- a/vortex-flatbuffers/src/generated/footer.rs
+++ b/vortex-flatbuffers/src/generated/footer.rs
@@ -342,6 +342,8 @@ pub enum PostscriptOffset {}
 ///
 /// The segments pointed to by the postscript have inline compression and encryption specs to avoid
 /// the need to fetch encryption schemes up-front.
+///
+/// New fields must be appended to preserve FlatBuffers field-order compatibility with old readers.
 pub struct Postscript<'a> {
   pub _tab: ::flatbuffers::Table<'a>,
 }
@@ -412,7 +414,8 @@ impl<'a> Postscript<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<::flatbuffers::ForwardsUOffset<PostscriptSegment>>(Postscript::VT_FOOTER, None)}
   }
-  /// User-defined metadata segments keyed by string.
+  /// User-defined metadata segments keyed by string. Keys must be unique, non-empty, and at most
+  /// 32 UTF-8 bytes; readers reject postscripts that violate these limits.
   #[inline]
   pub fn metadata(&self) -> Option<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<PostscriptMetadata<'a>>>> {
     // Safety:


### PR DESCRIPTION
## Summary

Adds keyed user-defined metadata segments to Vortex files. Writers can attach `ByteBuffer` metadata by string key, and readers can retrieve those buffers from `VortexFile` or `Footer` after opening a file.

The segment locations are stored in the postscript alongside the existing dtype, layout, statistics, and footer segment specs. The footer deserializer includes metadata segments in its initial footer read window, so large metadata payloads are read back correctly even when they sit before the footer flatbuffers.

No existing issue was found for this change, so this PR does not use a `Fixes #...` trailer.

## Validation

- `cargo +nightly fmt --all`
- `./scripts/public-api.sh`
- `cargo clippy --all-targets --all-features`
- `cargo test -p vortex-file`
- `git diff --check`