### PR TITLE
BufferMut::zeroed_aligned stores actually allocated length instead of passed length

### DIFF
--- a/vortex-buffer/src/buffer.rs
+++ b/vortex-buffer/src/buffer.rs
@@ -781,23 +781,23 @@ mod test {
     }
 
     #[test]
-    fn byte_buffer_zeroed() {
+    fn buffer_zeroed() {
         const LEN: usize = 17;
 
-        let buf = ByteBuffer::zeroed(LEN);
+        let buf = Buffer::<u32>::zeroed(LEN);
 
         assert_eq!(buf.len(), LEN);
-        assert_eq!(buf.alignment(), Alignment::of::<u8>());
-        assert!(buf.is_aligned(Alignment::of::<u8>()));
+        assert_eq!(buf.alignment(), Alignment::of::<u32>());
+        assert!(buf.is_aligned(Alignment::of::<u32>()));
         assert_eq!(buf.as_slice(), &[0; LEN]);
     }
 
     #[test]
-    fn byte_buffer_zeroed_aligned() {
+    fn buffer_zeroed_aligned() {
         const LEN: usize = 17;
         let alignment = Alignment::new(64);
 
-        let buf = ByteBuffer::zeroed_aligned(LEN, alignment);
+        let buf = Buffer::<u32>::zeroed_aligned(LEN, alignment);
 
         assert_eq!(buf.len(), LEN);
         assert_eq!(buf.alignment(), alignment);

--- a/vortex-buffer/src/buffer.rs
+++ b/vortex-buffer/src/buffer.rs
@@ -781,6 +781,31 @@ mod test {
     }
 
     #[test]
+    fn byte_buffer_zeroed() {
+        const LEN: usize = 17;
+
+        let buf = ByteBuffer::zeroed(LEN);
+
+        assert_eq!(buf.len(), LEN);
+        assert_eq!(buf.alignment(), Alignment::of::<u8>());
+        assert!(buf.is_aligned(Alignment::of::<u8>()));
+        assert_eq!(buf.as_slice(), &[0; LEN]);
+    }
+
+    #[test]
+    fn byte_buffer_zeroed_aligned() {
+        const LEN: usize = 17;
+        let alignment = Alignment::new(64);
+
+        let buf = ByteBuffer::zeroed_aligned(LEN, alignment);
+
+        assert_eq!(buf.len(), LEN);
+        assert_eq!(buf.alignment(), alignment);
+        assert!(buf.is_aligned(alignment));
+        assert_eq!(buf.as_slice(), &[0; LEN]);
+    }
+
+    #[test]
     fn from_vec() {
         let vec = vec![1, 2, 3, 4, 5];
         let buff = Buffer::from(vec.clone());

--- a/vortex-buffer/src/buffer.rs
+++ b/vortex-buffer/src/buffer.rs
@@ -774,7 +774,7 @@ mod test {
         assert_eq!(buf.remaining(), 10);
         assert_eq!(buf.chunk(), b"helloworld");
 
-        Buf::advance(&mut buf, 5);
+        buf.advance(5);
         assert_eq!(buf.remaining(), 5);
         assert_eq!(buf.as_slice(), b"world");
         assert_eq!(buf.chunk(), b"world");
@@ -786,8 +786,6 @@ mod test {
 
         let buf = Buffer::<u32>::zeroed(LEN);
 
-        assert_eq!(buf.len(), LEN);
-        assert_eq!(buf.alignment(), Alignment::of::<u32>());
         assert!(buf.is_aligned(Alignment::of::<u32>()));
         assert_eq!(buf.as_slice(), &[0; LEN]);
     }
@@ -799,8 +797,6 @@ mod test {
 
         let buf = Buffer::<u32>::zeroed_aligned(LEN, alignment);
 
-        assert_eq!(buf.len(), LEN);
-        assert_eq!(buf.alignment(), alignment);
         assert!(buf.is_aligned(alignment));
         assert_eq!(buf.as_slice(), &[0; LEN]);
     }

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -68,7 +68,11 @@ impl<T> BufferMut<T> {
         let mut bytes = BytesMut::zeroed((len * size_of::<T>()) + *alignment);
         bytes.advance(bytes.as_ptr().align_offset(*alignment));
         unsafe { bytes.set_len(len * size_of::<T>()) };
-        let actual_len = if size_of::<T>() == 0 { 0 } else { bytes.len() / size_of::<T>() };
+        let actual_len = if size_of::<T>() == 0 {
+            0
+        } else {
+            bytes.len() / size_of::<T>()
+        };
         Self {
             bytes,
             length: actual_len,

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -65,12 +65,14 @@ impl<T> BufferMut<T> {
 
     /// Create a new zeroed `BufferMut`.
     pub fn zeroed_aligned(len: usize, alignment: Alignment) -> Self {
-        let mut bytes = BytesMut::zeroed((len * size_of::<T>()) + *alignment);
+        let size_t = size_of::<T>();
+        let mut bytes = BytesMut::zeroed((len * size_t) + *alignment);
         bytes.advance(bytes.as_ptr().align_offset(*alignment));
-        unsafe { bytes.set_len(len * size_of::<T>()) };
+        unsafe { bytes.set_len(len * size_t) };
+        let actual_len = if size_t == 0 { 0 } else { bytes.len() / size_t };
         Self {
             bytes,
-            length: len,
+            length: actual_len,
             alignment,
             _marker: Default::default(),
         }
@@ -874,5 +876,36 @@ mod test {
 
         BufMut::put_slice(&mut buf, b"world");
         assert_eq!(buf.as_slice(), b"helloworld");
+    }
+
+    #[test]
+    fn byte_buffer_mut_zeroed() {
+        const LEN: usize = 17;
+
+        let mut buf = ByteBufferMut::zeroed(LEN);
+
+        assert_eq!(buf.len(), LEN);
+        assert_eq!(buf.alignment(), Alignment::of::<u8>());
+        assert_eq!(buf.as_ptr().align_offset(*Alignment::of::<u8>()), 0);
+        assert_eq!(buf.as_slice(), &[0; LEN]);
+
+        buf[3] = 7;
+        assert_eq!(buf.as_slice()[3], 7);
+    }
+
+    #[test]
+    fn byte_buffer_mut_zeroed_aligned() {
+        const LEN: usize = 17;
+        let alignment = Alignment::new(64);
+
+        let mut buf = ByteBufferMut::zeroed_aligned(LEN, alignment);
+
+        assert_eq!(buf.len(), LEN);
+        assert_eq!(buf.alignment(), alignment);
+        assert_eq!(buf.as_ptr().align_offset(*alignment), 0);
+        assert_eq!(buf.as_slice(), &[0; LEN]);
+
+        buf[3] = 7;
+        assert_eq!(buf.as_slice()[3], 7);
     }
 }

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -863,7 +863,7 @@ mod test {
         assert_eq!(buf.remaining(), 10);
         assert_eq!(buf.chunk(), b"helloworld");
 
-        Buf::advance(&mut buf, 5);
+        buf.advance(5);
         assert_eq!(buf.remaining(), 5);
         assert_eq!(buf.as_slice(), b"world");
         assert_eq!(buf.chunk(), b"world");
@@ -874,7 +874,7 @@ mod test {
         let mut buf = ByteBufferMut::copy_from("hello".as_bytes());
         assert_eq!(BufMut::remaining_mut(&buf), usize::MAX - 5);
 
-        BufMut::put_slice(&mut buf, b"world");
+        buf.put_slice(b"world");
         assert_eq!(buf.as_slice(), b"helloworld");
     }
 

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -884,8 +884,6 @@ mod test {
 
         let mut buf = BufferMut::<u32>::zeroed(LEN);
 
-        assert_eq!(buf.len(), LEN);
-        assert_eq!(buf.alignment(), Alignment::of::<u32>());
         assert_eq!(buf.as_ptr().align_offset(*Alignment::of::<u32>()), 0);
         assert_eq!(buf.as_slice(), &[0; LEN]);
 
@@ -900,8 +898,6 @@ mod test {
 
         let mut buf = BufferMut::<u32>::zeroed_aligned(LEN, alignment);
 
-        assert_eq!(buf.len(), LEN);
-        assert_eq!(buf.alignment(), alignment);
         assert_eq!(buf.as_ptr().align_offset(*alignment), 0);
         assert_eq!(buf.as_slice(), &[0; LEN]);
 

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -65,11 +65,10 @@ impl<T> BufferMut<T> {
 
     /// Create a new zeroed `BufferMut`.
     pub fn zeroed_aligned(len: usize, alignment: Alignment) -> Self {
-        let size_t = size_of::<T>();
-        let mut bytes = BytesMut::zeroed((len * size_t) + *alignment);
+        let mut bytes = BytesMut::zeroed((len * size_of::<T>()) + *alignment);
         bytes.advance(bytes.as_ptr().align_offset(*alignment));
-        unsafe { bytes.set_len(len * size_t) };
-        let actual_len = if size_t == 0 { 0 } else { bytes.len() / size_t };
+        unsafe { bytes.set_len(len * size_of::<T>()) };
+        let actual_len = if size_of::<T>() == 0 { 0 } else { bytes.len() / size_of::<T>() };
         Self {
             bytes,
             length: actual_len,

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -879,14 +879,14 @@ mod test {
     }
 
     #[test]
-    fn byte_buffer_mut_zeroed() {
+    fn buffer_mut_zeroed() {
         const LEN: usize = 17;
 
-        let mut buf = ByteBufferMut::zeroed(LEN);
+        let mut buf = BufferMut::<u32>::zeroed(LEN);
 
         assert_eq!(buf.len(), LEN);
-        assert_eq!(buf.alignment(), Alignment::of::<u8>());
-        assert_eq!(buf.as_ptr().align_offset(*Alignment::of::<u8>()), 0);
+        assert_eq!(buf.alignment(), Alignment::of::<u32>());
+        assert_eq!(buf.as_ptr().align_offset(*Alignment::of::<u32>()), 0);
         assert_eq!(buf.as_slice(), &[0; LEN]);
 
         buf[3] = 7;
@@ -894,11 +894,11 @@ mod test {
     }
 
     #[test]
-    fn byte_buffer_mut_zeroed_aligned() {
+    fn buffer_mut_zeroed_aligned() {
         const LEN: usize = 17;
         let alignment = Alignment::new(64);
 
-        let mut buf = ByteBufferMut::zeroed_aligned(LEN, alignment);
+        let mut buf = BufferMut::<u32>::zeroed_aligned(LEN, alignment);
 
         assert_eq!(buf.len(), LEN);
         assert_eq!(buf.alignment(), alignment);

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -68,11 +68,7 @@ impl<T> BufferMut<T> {
         let mut bytes = BytesMut::zeroed((len * size_of::<T>()) + *alignment);
         bytes.advance(bytes.as_ptr().align_offset(*alignment));
         unsafe { bytes.set_len(len * size_of::<T>()) };
-        let actual_len = if size_of::<T>() == 0 {
-            0
-        } else {
-            bytes.len() / size_of::<T>()
-        };
+        let actual_len = bytes.len().checked_div(size_of::<T>()).unwrap_or(0);
         Self {
             bytes,
             length: actual_len,


### PR DESCRIPTION
If `length * size_of::<T>` overflows the length of the buffer is wrong
