### PR TITLE
move getrandom backend override to config.toml

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -58,9 +58,7 @@ jobs:
           cache: "npm"
           cache-dependency-path: vortex-web/package-lock.json
       - run: npm ci
-      - env:
-          RUSTFLAGS: --cfg getrandom_backend="unsupported"
-        run: npm run wasm
+      - run: npm run wasm
       - run: npm run format:check
       - run: npm run lint
       - run: npm run typecheck
@@ -87,9 +85,7 @@ jobs:
           cache: "npm"
           cache-dependency-path: vortex-web/package-lock.json
       - run: npm ci
-      - env:
-          RUSTFLAGS: --cfg getrandom_backend="unsupported"
-        run: npm run build
+      - run: npm run build
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:

--- a/vortex-web/crate/.cargo/config.toml
+++ b/vortex-web/crate/.cargo/config.toml
@@ -1,0 +1,7 @@
+# vortex-array dependency tree pulls in rand 0.10 → getrandom 0.4, which requires an explicit
+# backend opt-in for wasm32-unknown-unknown. The "unsupported" backend compiles fine and
+# panics only if random values are actually requested at runtime — nothing in the explorer
+# codepath does that, so this matches the CI build exactly without taking on the heavier
+# `wasm_js` browser-RNG dep.
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="unsupported"']


### PR DESCRIPTION
## Summary

to compile the wasm target we need to override the getrandom backend to be unsupported. We were previously doing this in CI, but for local builds that override was not picked up.