### PR TITLE
Skip ListView validation in row encoder output

### DIFF
--- a/vortex-row/src/encode.rs
+++ b/vortex-row/src/encode.rs
@@ -195,10 +195,19 @@ fn execute_row_encode(
         Validity::NonNullable,
     )
     .into_array();
-    Ok(
-        ListViewArray::try_new(elements, offsets_arr, sizes_arr, Validity::NonNullable)?
-            .into_array(),
-    )
+    // SAFETY: The encoder constructs `elements`, `offsets_arr`, and `sizes_arr` itself.
+    // - `elements` is a `PrimitiveArray<u8>` of length `total_bytes`.
+    // - `offsets[i]` is `i * fixed_per_row + var_prefix[i]`, monotonically increasing,
+    //   each value in `0..total_bytes`.
+    // - `sizes[i]` is the per-row size; `offsets[i] + sizes[i] <= total_bytes` by
+    //   construction of the buffer.
+    // - Each row's slice is disjoint from every other row's slice.
+    // The constructor's `validate` re-walks every row to verify these invariants; we know
+    // they hold by construction, so we skip that walk.
+    Ok(unsafe {
+        ListViewArray::new_unchecked(elements, offsets_arr, sizes_arr, Validity::NonNullable)
+    }
+    .into_array())
 }
 
 /// Dispatch a single column's encoding into the shared `out` buffer.


### PR DESCRIPTION
Part 9 of 25 in the stacked PR series adding `vortex-row`.

This PR contains exactly one commit; review just that diff in isolation.

## What this commit does

The encoder constructs the ListView's elements/offsets/sizes itself and maintains every invariant by construction: monotone offsets, each slice's `offsets[i] + sizes[i] <= total`, pairwise-disjoint slices. `ListViewArray::try_new` re-walks every row to validate those properties, which doubles as a memory pass over the just-built offsets/sizes arrays.

Switches to `unsafe { ListViewArray::new_unchecked(...) }` with an inline SAFETY comment justifying each invariant. primitive_i64_vortex throughput improves from ~1.80 GB/s to ~4.7 GB/s on isolated runs (the validate walk dominates for small per-row payloads; larger varlen rows show smaller % improvements).

## Stack

| # | PR | Title | Branch |
|---|---|---|---|
| 1 | #7986 | vortex-row: crate scaffolding | `claude/row-c01-crate-scaffolding` |
| 2 | #7987 | vortex-row: add SortField and RowEncodeOptions | `claude/row-c02-sortfield-options` |
| 3 | #7988 | vortex-row: codec for fixed-width canonical types | `claude/row-c03-codec-fixed-width` |
| 4 | #7989 | vortex-row: codec for varlen canonical types | `claude/row-c04-codec-varlen` |
| 5 | #7990 | vortex-row: codec for nested canonical types | `claude/row-c05-codec-nested` |
| 6 | #7991 | vortex-row: compute_sizes helper and RowSize ScalarFn | `claude/row-c06-rowsize-scalarfn` |
| 7 | #7992 | vortex-row: RowEncode ScalarFn | `claude/row-c07-rowencode-scalarfn` |
| 8 | #7993 | vortex-row: convert_columns + tests + bench scaffolding | `claude/row-c08-convert-columns-tests-bench` |
| 9 | #7994 | Skip ListView validation in row encoder output | `claude/row-c09-skip-listview-validation` |
| 10 | #7995 | Add validity fast-path helper for the four pattern-matching encoders | `claude/row-c10-validity-fast-path` |
| 11 | #7996 | Skip zero-init of output buffer | `claude/row-c11-skip-zero-init` |
| 12 | #7997 | Auto-vectorize pure-fixed offsets construction | `claude/row-c12-vectorize-pure-fixed-offsets` |
| 13 | #7998 | Auto-vectorize mixed-path offsets construction | `claude/row-c13-vectorize-mixed-offsets` |
| 14 | #7999 | Rewrite varlen 32-byte block encoder with copy_nonoverlapping | `claude/row-c14-varlen-block-copy-nonoverlapping` |
| 15 | #8000 | Walk VarBinView rows directly in row encoder hot loop | `claude/row-c15-walk-varbinview-directly` |
| 16 | #8001 | Add arithmetic-write fast path for fixed-before-varlen columns | `claude/row-c16-arith-write-fast-path` |
| 17 | #8002 | Specialize Constant for the arithmetic-write fast path | `claude/row-c17-specialize-constant-arith` |
| 18 | #8003 | RowSizeKernel and RowEncodeKernel dispatch helpers | `claude/row-c18-kernel-dispatch-helpers` |
| 19 | #8004 | Inventory-based registry for downstream encoding kernels | `claude/row-c19-inventory-registry` |
| 20 | #8005 | Constant row-encode kernel | `claude/row-c20-constant-kernel` |
| 21 | #8006 | Dict row-encode kernel | `claude/row-c21-dict-kernel` |
| 22 | #8007 | Patched row-encode kernel | `claude/row-c22-patched-kernel` |
| 23 | #8008 | RunEnd row-encode kernel (vortex-runend) | `claude/row-c23-runend-kernel` |
| 24 | #8009 | BitPacked row-encode kernel (vortex-fastlanes) | `claude/row-c24-bitpacked-kernel` |
| 25 | #7985 | FoR and Delta row-encode kernels (vortex-fastlanes) | `claude/row-pr3-kernels` |

Base of this PR: #7993 (`claude/row-c08-convert-columns-tests-bench`)
Next in stack: #7995 (`claude/row-c10-validity-fast-path`)

## Combined context

For the full design + rationale, see PR #7985 (top of stack).
