### PR TITLE
Add validity fast-path helper for the four pattern-matching encoders

### DIFF
--- a/vortex-row/src/codec.rs
+++ b/vortex-row/src/codec.rs
@@ -45,6 +45,7 @@ use vortex_array::dtype::NativePType;
 use vortex_array::dtype::PType;
 use vortex_array::dtype::half::f16;
 use vortex_array::match_each_native_ptype;
+use vortex_array::validity::Validity;
 use vortex_buffer::ByteBufferMut;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -75,6 +76,33 @@ fn encoded_size_for_varlen(len: usize) -> u32 {
 #[inline]
 const fn encoded_size_for_fixed(value_bytes: u32) -> u32 {
     1 + value_bytes
+}
+
+/// Pre-resolved per-row validity for the row encoders.
+///
+/// Encoders pattern-match on this once before their inner loop so the
+/// no-nulls fast path avoids per-row `mask.value(i)` branches entirely,
+/// and the nullable path holds the materialized mask exactly once.
+pub(crate) enum ValidityKind {
+    /// Column statically has no nulls (`Validity::NonNullable` or `AllValid`); no mask
+    /// allocation needed.
+    AllValid,
+    /// Column may have nulls; the materialized per-row mask is included.
+    Mask(vortex_mask::Mask),
+}
+
+/// Resolve a [`Validity`] into a [`ValidityKind`], materializing the mask only when
+/// the column may actually have nulls.
+#[inline]
+pub(crate) fn resolve_validity(
+    validity: Validity,
+    len: usize,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ValidityKind> {
+    Ok(match validity {
+        Validity::NonNullable | Validity::AllValid => ValidityKind::AllValid,
+        other => ValidityKind::Mask(other.execute_mask(len, ctx)?),
+    })
 }
 
 /// Per-row width classification for a column.
@@ -245,15 +273,21 @@ fn add_size_varbinview(
     sizes: &mut [u32],
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()> {
-    let mask = arr.as_ref().validity()?.execute_mask(arr.len(), ctx)?;
     let views = arr.views();
-    for (i, view) in views.iter().enumerate() {
-        let valid = mask.value(i);
-        if !valid {
-            sizes[i] += 1; // sentinel only
-        } else {
-            let len = view.len() as usize;
-            sizes[i] += encoded_size_for_varlen(len);
+    match resolve_validity(arr.as_ref().validity()?, arr.len(), ctx)? {
+        ValidityKind::AllValid => {
+            for (i, view) in views.iter().enumerate() {
+                sizes[i] += encoded_size_for_varlen(view.len() as usize);
+            }
+        }
+        ValidityKind::Mask(mask) => {
+            for (i, view) in views.iter().enumerate() {
+                if mask.value(i) {
+                    sizes[i] += encoded_size_for_varlen(view.len() as usize);
+                } else {
+                    sizes[i] += 1; // sentinel only
+                }
+            }
         }
     }
     Ok(())
@@ -336,23 +370,35 @@ fn encode_bool(
     out: &mut [u8],
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()> {
-    let mask = arr.as_ref().validity()?.execute_mask(arr.len(), ctx)?;
     let bits = arr.clone().into_bit_buffer();
     let non_null = field.non_null_sentinel();
-    let null = field.null_sentinel();
     let xor = if field.descending { 0xFF } else { 0x00 };
-    for i in 0..bits.len() {
-        let pos = (row_offsets[i] + col_offset[i]) as usize;
-        if mask.value(i) {
-            out[pos] = non_null;
-            // false=0x01, true=0x02 so false < true; XOR for descending
-            let raw = if bits.value(i) { 0x02u8 } else { 0x01u8 };
-            out[pos + 1] = raw ^ xor;
-        } else {
-            out[pos] = null;
-            out[pos + 1] = 0;
+    match resolve_validity(arr.as_ref().validity()?, arr.len(), ctx)? {
+        ValidityKind::AllValid => {
+            for i in 0..bits.len() {
+                let pos = (row_offsets[i] + col_offset[i]) as usize;
+                out[pos] = non_null;
+                let raw = if bits.value(i) { 0x02u8 } else { 0x01u8 };
+                out[pos + 1] = raw ^ xor;
+                col_offset[i] += BOOL_ENCODED_SIZE;
+            }
         }
-        col_offset[i] += BOOL_ENCODED_SIZE;
+        ValidityKind::Mask(mask) => {
+            let null = field.null_sentinel();
+            for i in 0..bits.len() {
+                let pos = (row_offsets[i] + col_offset[i]) as usize;
+                if mask.value(i) {
+                    out[pos] = non_null;
+                    // false=0x01, true=0x02 so false < true; XOR for descending
+                    let raw = if bits.value(i) { 0x02u8 } else { 0x01u8 };
+                    out[pos + 1] = raw ^ xor;
+                } else {
+                    out[pos] = null;
+                    out[pos + 1] = 0;
+                }
+                col_offset[i] += BOOL_ENCODED_SIZE;
+            }
+        }
     }
     Ok(())
 }
@@ -379,24 +425,35 @@ fn encode_primitive_typed<T: NativePType + RowEncode>(
     out: &mut [u8],
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()> {
-    let mask = arr.as_ref().validity()?.execute_mask(arr.len(), ctx)?;
     let slice: &[T] = arr.as_slice();
     let non_null = field.non_null_sentinel();
-    let null = field.null_sentinel();
     let value_bytes = size_of::<T>();
-    for (i, &v) in slice.iter().enumerate() {
-        let pos = (row_offsets[i] + col_offset[i]) as usize;
-        if mask.value(i) {
-            out[pos] = non_null;
-            v.encode_to(&mut out[pos + 1..pos + 1 + value_bytes], field.descending);
-        } else {
-            out[pos] = null;
-            // Zero-fill the value bytes.
-            for b in &mut out[pos + 1..pos + 1 + value_bytes] {
-                *b = 0;
+    let stride = encoded_size_for_fixed(value_bytes as u32);
+    match resolve_validity(arr.as_ref().validity()?, arr.len(), ctx)? {
+        ValidityKind::AllValid => {
+            for (i, &v) in slice.iter().enumerate() {
+                let pos = (row_offsets[i] + col_offset[i]) as usize;
+                out[pos] = non_null;
+                v.encode_to(&mut out[pos + 1..pos + 1 + value_bytes], field.descending);
+                col_offset[i] += stride;
             }
         }
-        col_offset[i] += encoded_size_for_fixed(value_bytes as u32);
+        ValidityKind::Mask(mask) => {
+            let null = field.null_sentinel();
+            for (i, &v) in slice.iter().enumerate() {
+                let pos = (row_offsets[i] + col_offset[i]) as usize;
+                if mask.value(i) {
+                    out[pos] = non_null;
+                    v.encode_to(&mut out[pos + 1..pos + 1 + value_bytes], field.descending);
+                } else {
+                    out[pos] = null;
+                    for b in &mut out[pos + 1..pos + 1 + value_bytes] {
+                        *b = 0;
+                    }
+                }
+                col_offset[i] += stride;
+            }
+        }
     }
     Ok(())
 }
@@ -471,24 +528,38 @@ fn encode_varbinview(
     out: &mut [u8],
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()> {
-    let mask = arr.as_ref().validity()?.execute_mask(arr.len(), ctx)?;
     let non_null = field.non_null_sentinel();
-    let null = field.null_sentinel();
-
-    arr.with_iterator(|iter| {
-        for (i, maybe) in iter.enumerate() {
-            let pos = (row_offsets[i] + col_offset[i]) as usize;
-            if !mask.value(i) {
-                out[pos] = null;
-                col_offset[i] += 1;
-                continue;
-            }
-            let bytes: &[u8] = maybe.unwrap_or(&[]);
-            out[pos] = non_null;
-            let written = encode_varlen_value(bytes, &mut out[pos + 1..], field.descending);
-            col_offset[i] += 1 + written;
+    let descending = field.descending;
+    match resolve_validity(arr.as_ref().validity()?, arr.len(), ctx)? {
+        ValidityKind::AllValid => {
+            arr.with_iterator(|iter| {
+                for (i, maybe) in iter.enumerate() {
+                    let pos = (row_offsets[i] + col_offset[i]) as usize;
+                    let bytes: &[u8] = maybe.unwrap_or(&[]);
+                    out[pos] = non_null;
+                    let written = encode_varlen_value(bytes, &mut out[pos + 1..], descending);
+                    col_offset[i] += 1 + written;
+                }
+            });
         }
-    });
+        ValidityKind::Mask(mask) => {
+            let null = field.null_sentinel();
+            arr.with_iterator(|iter| {
+                for (i, maybe) in iter.enumerate() {
+                    let pos = (row_offsets[i] + col_offset[i]) as usize;
+                    if !mask.value(i) {
+                        out[pos] = null;
+                        col_offset[i] += 1;
+                        continue;
+                    }
+                    let bytes: &[u8] = maybe.unwrap_or(&[]);
+                    out[pos] = non_null;
+                    let written = encode_varlen_value(bytes, &mut out[pos + 1..], descending);
+                    col_offset[i] += 1 + written;
+                }
+            });
+        }
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Part 10 of 25 in the stacked PR series adding `vortex-row`.

This PR contains exactly one commit; review just that diff in isolation.

Note: the PR title is a shortened version of the original commit title (which is 73 chars: "Add validity fast-path helper for the four encoders that pattern-match it"). The commit message itself is unchanged.

## What this commit does

Most production columns are non-nullable or `AllValid`, in which case the per-row `mask.value(i)` branch is dead weight. Introduces a `ValidityKind { AllValid, Mask(...) }` helper resolved exactly once per column, and pattern-matches on it in the four encoders that loop over rows: `encode_primitive_typed`, `encode_bool`, `encode_varbinview`, `add_size_varbinview`.

For NonNullable / AllValid columns this skips the mask materialization entirely, and the inner loop has no validity branch. For nullable columns the materialized mask is held once instead of re-resolved per row.

Yields ~10% across canonical paths on isolated runs; combines with the later auto-vectorization commit because removing the per-row branch makes the inner loop a candidate for the compiler's vectorizer.

## Stack

| # | PR | Title | Branch |
|---|---|---|---|
| 1 | #7986 | vortex-row: crate scaffolding | `claude/row-c01-crate-scaffolding` |
| 2 | #7987 | vortex-row: add SortField and RowEncodeOptions | `claude/row-c02-sortfield-options` |
| 3 | #7988 | vortex-row: codec for fixed-width canonical types | `claude/row-c03-codec-fixed-width` |
| 4 | #7989 | vortex-row: codec for varlen canonical types | `claude/row-c04-codec-varlen` |
| 5 | #7990 | vortex-row: codec for nested canonical types | `claude/row-c05-codec-nested` |
| 6 | #7991 | vortex-row: compute_sizes helper and RowSize ScalarFn | `claude/row-c06-rowsize-scalarfn` |
| 7 | #7992 | vortex-row: RowEncode ScalarFn | `claude/row-c07-rowencode-scalarfn` |
| 8 | #7993 | vortex-row: convert_columns + tests + bench scaffolding | `claude/row-c08-convert-columns-tests-bench` |
| 9 | #7994 | Skip ListView validation in row encoder output | `claude/row-c09-skip-listview-validation` |
| 10 | #7995 | Add validity fast-path helper for the four pattern-matching encoders | `claude/row-c10-validity-fast-path` |
| 11 | #7996 | Skip zero-init of output buffer | `claude/row-c11-skip-zero-init` |
| 12 | #7997 | Auto-vectorize pure-fixed offsets construction | `claude/row-c12-vectorize-pure-fixed-offsets` |
| 13 | #7998 | Auto-vectorize mixed-path offsets construction | `claude/row-c13-vectorize-mixed-offsets` |
| 14 | #7999 | Rewrite varlen 32-byte block encoder with copy_nonoverlapping | `claude/row-c14-varlen-block-copy-nonoverlapping` |
| 15 | #8000 | Walk VarBinView rows directly in row encoder hot loop | `claude/row-c15-walk-varbinview-directly` |
| 16 | #8001 | Add arithmetic-write fast path for fixed-before-varlen columns | `claude/row-c16-arith-write-fast-path` |
| 17 | #8002 | Specialize Constant for the arithmetic-write fast path | `claude/row-c17-specialize-constant-arith` |
| 18 | #8003 | RowSizeKernel and RowEncodeKernel dispatch helpers | `claude/row-c18-kernel-dispatch-helpers` |
| 19 | #8004 | Inventory-based registry for downstream encoding kernels | `claude/row-c19-inventory-registry` |
| 20 | #8005 | Constant row-encode kernel | `claude/row-c20-constant-kernel` |
| 21 | #8006 | Dict row-encode kernel | `claude/row-c21-dict-kernel` |
| 22 | #8007 | Patched row-encode kernel | `claude/row-c22-patched-kernel` |
| 23 | #8008 | RunEnd row-encode kernel (vortex-runend) | `claude/row-c23-runend-kernel` |
| 24 | #8009 | BitPacked row-encode kernel (vortex-fastlanes) | `claude/row-c24-bitpacked-kernel` |
| 25 | #7985 | FoR and Delta row-encode kernels (vortex-fastlanes) | `claude/row-pr3-kernels` |

Base of this PR: #7994 (`claude/row-c09-skip-listview-validation`)
Next in stack: #7996 (`claude/row-c11-skip-zero-init`)

## Combined context

For the full design + rationale, see PR #7985 (top of stack).
