### PR TITLE
Skip zero-init of output buffer

### DIFF
--- a/vortex-row/src/encode.rs
+++ b/vortex-row/src/encode.rs
@@ -133,12 +133,17 @@ fn execute_row_encode(
     }
     let total_len = total as usize;
 
-    // Allocate the elements buffer (zero-initialized). The zero-init lets every encoder
-    // assume previously-untouched bytes are zero, simplifying the null-row fill paths.
-    // PR 2 skips this memset because every byte in the output range is written by some
-    // encoder.
     let mut out_buf: BufferMut<u8> = BufferMut::with_capacity(total_len);
-    out_buf.push_n(0u8, total_len);
+    // Every encoder writes every byte in its row range: non-null values are written
+    // directly; null fixed-width slots are sentinel + explicit zero-fill; varlen partial
+    // blocks zero-pad via the encoder's own loop; null struct/FSL bodies are zero-filled
+    // after the child encoders run. So the pre-zero-init of the buffer is redundant;
+    // skipping it saves a memset of `total_len` bytes per call (significant for
+    // varlen-heavy inputs where total_len reaches multiple MB).
+    //
+    // SAFETY: we just allocated `total_len` capacity. By the size-pass + encoder
+    // contract every byte in [0, total_len) is written before the buffer is read out.
+    unsafe { out_buf.set_len(total_len) };
 
     // ===== Phase 3: per-row offsets =====
     // listview_offsets[i] is the absolute byte offset where row `i` begins.


### PR DESCRIPTION
Part 11 of 25 in the stacked PR series adding `vortex-row`.

This PR contains exactly one commit; review just that diff in isolation.

## What this commit does

`BufferMut::with_capacity(total_len).push_n(0u8, total_len)` issues a memset of the entire output range, only to have every byte overwritten by the encoders. The encoders cover every byte by construction:

- Fixed-width non-null slots: sentinel + value bytes.
- Fixed-width null slots: sentinel + explicit per-byte zero-fill loop.
- Varlen blocks: full blocks are written by `encode_varlen_value`; the partial-block tail is zero-padded by that same function.
- Struct/FSL null bodies: zero-filled after the child encoders run.

Switches to `unsafe { out_buf.set_len(total_len) }` with a SAFETY comment recording the invariant. Reclaims a `total_len`-byte memset per call; for varlen-heavy inputs (multiple MB of output) this saves real time. dict_utf8 (varlen heavy) throughput: ~3.74 GB/s → ~4.55 GB/s.

## Stack

| # | PR | Title | Branch |
|---|---|---|---|
| 1 | #7986 | vortex-row: crate scaffolding | `claude/row-c01-crate-scaffolding` |
| 2 | #7987 | vortex-row: add SortField and RowEncodeOptions | `claude/row-c02-sortfield-options` |
| 3 | #7988 | vortex-row: codec for fixed-width canonical types | `claude/row-c03-codec-fixed-width` |
| 4 | #7989 | vortex-row: codec for varlen canonical types | `claude/row-c04-codec-varlen` |
| 5 | #7990 | vortex-row: codec for nested canonical types | `claude/row-c05-codec-nested` |
| 6 | #7991 | vortex-row: compute_sizes helper and RowSize ScalarFn | `claude/row-c06-rowsize-scalarfn` |
| 7 | #7992 | vortex-row: RowEncode ScalarFn | `claude/row-c07-rowencode-scalarfn` |
| 8 | #7993 | vortex-row: convert_columns + tests + bench scaffolding | `claude/row-c08-convert-columns-tests-bench` |
| 9 | #7994 | Skip ListView validation in row encoder output | `claude/row-c09-skip-listview-validation` |
| 10 | #7995 | Add validity fast-path helper for the four pattern-matching encoders | `claude/row-c10-validity-fast-path` |
| 11 | #7996 | Skip zero-init of output buffer | `claude/row-c11-skip-zero-init` |
| 12 | #7997 | Auto-vectorize pure-fixed offsets construction | `claude/row-c12-vectorize-pure-fixed-offsets` |
| 13 | #7998 | Auto-vectorize mixed-path offsets construction | `claude/row-c13-vectorize-mixed-offsets` |
| 14 | #7999 | Rewrite varlen 32-byte block encoder with copy_nonoverlapping | `claude/row-c14-varlen-block-copy-nonoverlapping` |
| 15 | #8000 | Walk VarBinView rows directly in row encoder hot loop | `claude/row-c15-walk-varbinview-directly` |
| 16 | #8001 | Add arithmetic-write fast path for fixed-before-varlen columns | `claude/row-c16-arith-write-fast-path` |
| 17 | #8002 | Specialize Constant for the arithmetic-write fast path | `claude/row-c17-specialize-constant-arith` |
| 18 | #8003 | RowSizeKernel and RowEncodeKernel dispatch helpers | `claude/row-c18-kernel-dispatch-helpers` |
| 19 | #8004 | Inventory-based registry for downstream encoding kernels | `claude/row-c19-inventory-registry` |
| 20 | #8005 | Constant row-encode kernel | `claude/row-c20-constant-kernel` |
| 21 | #8006 | Dict row-encode kernel | `claude/row-c21-dict-kernel` |
| 22 | #8007 | Patched row-encode kernel | `claude/row-c22-patched-kernel` |
| 23 | #8008 | RunEnd row-encode kernel (vortex-runend) | `claude/row-c23-runend-kernel` |
| 24 | #8009 | BitPacked row-encode kernel (vortex-fastlanes) | `claude/row-c24-bitpacked-kernel` |
| 25 | #7985 | FoR and Delta row-encode kernels (vortex-fastlanes) | `claude/row-pr3-kernels` |

Base of this PR: #7995 (`claude/row-c10-validity-fast-path`)
Next in stack: #7997 (`claude/row-c12-vectorize-pure-fixed-offsets`)

## Combined context

For the full design + rationale, see PR #7985 (top of stack).
