### PR TITLE
Auto-vectorize mixed-path offsets construction

### DIFF
--- a/vortex-row/src/encode.rs
+++ b/vortex-row/src/encode.rs
@@ -165,14 +165,21 @@ fn execute_row_encode(
             }
         }
         Some(v) => {
-            let mut acc: u32 = 0;
-            for (i, &l) in v.iter().enumerate() {
-                let off = (i as u32)
-                    .checked_mul(fixed_per_row)
-                    .and_then(|t| t.checked_add(acc))
-                    .vortex_expect("row offset overflow");
-                listview_offsets.push(off);
-                acc = acc.checked_add(l).vortex_expect("varlen prefix overflow");
+            // Mixed path: offsets[i] = i * fixed_per_row + var_prefix[i] where
+            // var_prefix is the exclusive cumsum of varlen lengths. Same raw-pointer
+            // write loop as the pure-fixed branch (auto-vectorized); the total was
+            // validated to fit in u32 upstream so `wrapping_add` is sound here.
+            // SAFETY: we just reserved nrows; writes at indices [0, nrows) are valid.
+            unsafe {
+                let off_ptr = listview_offsets.as_mut_ptr();
+                let mut acc: u32 = 0;
+                for (i, &l) in v.iter().enumerate() {
+                    off_ptr
+                        .add(i)
+                        .write((i as u32).wrapping_mul(fixed_per_row).wrapping_add(acc));
+                    acc = acc.wrapping_add(l);
+                }
+                listview_offsets.set_len(nrows);
             }
         }
     }


### PR DESCRIPTION
Part 13 of 25 in the stacked PR series adding `vortex-row`.

This PR contains exactly one commit; review just that diff in isolation.

## What this commit does

Applies the same `Vec::push` → raw-pointer-write transformation to the mixed (fixed-plus-varlen) branch of Phase 3. We already validated the total fits in u32 upstream, so `wrapping_mul` / `wrapping_add` here are sound.

Mixed paths within the bench noise; this commit keeps the pure-fixed and mixed branches structurally identical so reviewers see the same shape regardless of whether varlen is present.

## Stack

| # | PR | Title | Branch |
|---|---|---|---|
| 1 | #7986 | vortex-row: crate scaffolding | `claude/row-c01-crate-scaffolding` |
| 2 | #7987 | vortex-row: add SortField and RowEncodeOptions | `claude/row-c02-sortfield-options` |
| 3 | #7988 | vortex-row: codec for fixed-width canonical types | `claude/row-c03-codec-fixed-width` |
| 4 | #7989 | vortex-row: codec for varlen canonical types | `claude/row-c04-codec-varlen` |
| 5 | #7990 | vortex-row: codec for nested canonical types | `claude/row-c05-codec-nested` |
| 6 | #7991 | vortex-row: compute_sizes helper and RowSize ScalarFn | `claude/row-c06-rowsize-scalarfn` |
| 7 | #7992 | vortex-row: RowEncode ScalarFn | `claude/row-c07-rowencode-scalarfn` |
| 8 | #7993 | vortex-row: convert_columns + tests + bench scaffolding | `claude/row-c08-convert-columns-tests-bench` |
| 9 | #7994 | Skip ListView validation in row encoder output | `claude/row-c09-skip-listview-validation` |
| 10 | #7995 | Add validity fast-path helper for the four pattern-matching encoders | `claude/row-c10-validity-fast-path` |
| 11 | #7996 | Skip zero-init of output buffer | `claude/row-c11-skip-zero-init` |
| 12 | #7997 | Auto-vectorize pure-fixed offsets construction | `claude/row-c12-vectorize-pure-fixed-offsets` |
| 13 | #7998 | Auto-vectorize mixed-path offsets construction | `claude/row-c13-vectorize-mixed-offsets` |
| 14 | #7999 | Rewrite varlen 32-byte block encoder with copy_nonoverlapping | `claude/row-c14-varlen-block-copy-nonoverlapping` |
| 15 | #8000 | Walk VarBinView rows directly in row encoder hot loop | `claude/row-c15-walk-varbinview-directly` |
| 16 | #8001 | Add arithmetic-write fast path for fixed-before-varlen columns | `claude/row-c16-arith-write-fast-path` |
| 17 | #8002 | Specialize Constant for the arithmetic-write fast path | `claude/row-c17-specialize-constant-arith` |
| 18 | #8003 | RowSizeKernel and RowEncodeKernel dispatch helpers | `claude/row-c18-kernel-dispatch-helpers` |
| 19 | #8004 | Inventory-based registry for downstream encoding kernels | `claude/row-c19-inventory-registry` |
| 20 | #8005 | Constant row-encode kernel | `claude/row-c20-constant-kernel` |
| 21 | #8006 | Dict row-encode kernel | `claude/row-c21-dict-kernel` |
| 22 | #8007 | Patched row-encode kernel | `claude/row-c22-patched-kernel` |
| 23 | #8008 | RunEnd row-encode kernel (vortex-runend) | `claude/row-c23-runend-kernel` |
| 24 | #8009 | BitPacked row-encode kernel (vortex-fastlanes) | `claude/row-c24-bitpacked-kernel` |
| 25 | #7985 | FoR and Delta row-encode kernels (vortex-fastlanes) | `claude/row-pr3-kernels` |

Base of this PR: #7997 (`claude/row-c12-vectorize-pure-fixed-offsets`)
Next in stack: #7999 (`claude/row-c14-varlen-block-copy-nonoverlapping`)

## Combined context

For the full design + rationale, see PR #7985 (top of stack).
