### PR TITLE
Walk VarBinView rows directly in row encoder hot loop

### DIFF
--- a/vortex-row/src/codec.rs
+++ b/vortex-row/src/codec.rs
@@ -530,17 +530,33 @@ fn encode_varbinview(
 ) -> VortexResult<()> {
     let non_null = field.non_null_sentinel();
     let descending = field.descending;
+    let views = arr.views();
+    let n_buffers = arr.data_buffers().len();
     match resolve_validity(arr.as_ref().validity()?, arr.len(), ctx)? {
         ValidityKind::AllValid => {
-            arr.with_iterator(|iter| {
-                for (i, maybe) in iter.enumerate() {
-                    let pos = (row_offsets[i] + col_offset[i]) as usize;
-                    let bytes: &[u8] = maybe.unwrap_or(&[]);
-                    out[pos] = non_null;
-                    let written = encode_varlen_value(bytes, &mut out[pos + 1..], descending);
-                    col_offset[i] += 1 + written;
-                }
-            });
+            // Cache data-buffer slices once. For inlined views (len <= 12), bytes live
+            // inside the view itself.
+            let buffers: smallvec::SmallVec<[&[u8]; 4]> =
+                (0..n_buffers).map(|i| arr.buffer(i).as_slice()).collect();
+            for (i, view) in views.iter().enumerate() {
+                let pos = (row_offsets[i] + col_offset[i]) as usize;
+                out[pos] = non_null;
+                let len = view.len() as usize;
+                // SAFETY: BinaryView's inlined-vs-ref discriminant is its `size` field
+                // (read by `view.len()`); for len <= 12 the bytes are inline in the view
+                // (we read from `as_inlined().value()`); for larger we index into the
+                // pre-validated buffer at `view_ref.offset..offset+size`. Both reads
+                // produce a slice of exactly `len` valid bytes.
+                let bytes: &[u8] = if view.is_inlined() {
+                    view.as_inlined().value()
+                } else {
+                    let r = view.as_view();
+                    let off = r.offset as usize;
+                    &buffers[r.buffer_index as usize][off..off + len]
+                };
+                let written = encode_varlen_value(bytes, &mut out[pos + 1..], descending);
+                col_offset[i] += 1 + written;
+            }
         }
         ValidityKind::Mask(mask) => {
             let null = field.null_sentinel();


### PR DESCRIPTION
Part 15 of 25 in the stacked PR series adding `vortex-row`.

This PR contains exactly one commit; review just that diff in isolation.

## What this commit does

`arr.with_iterator(...)` constructs an `Option<&[u8]>` per row through a trait-object dispatch and a branch-and-merge that hides the inline-vs-buffer view from the compiler. On the AllValid path we don't need the Option (no nulls) and we want the compiler to see the inline-vs-buffer branch directly so it can keep the inline arm in registers.

Walks `arr.views()` directly and resolves each view via `is_inlined() → as_inlined().value()` vs `as_view() → buffers[idx][offset..len]`. Caches data-buffer slices once before the loop (SmallVec for ≤4 buffers, the common case). Nullable path is unchanged because the Option<&[u8]> shape is already what we want when nulls are possible.

utf8 throughput: ~1.49 GB/s → ~1.84 GB/s.

## Stack

| # | PR | Title | Branch |
|---|---|---|---|
| 1 | #7986 | vortex-row: crate scaffolding | `claude/row-c01-crate-scaffolding` |
| 2 | #7987 | vortex-row: add SortField and RowEncodeOptions | `claude/row-c02-sortfield-options` |
| 3 | #7988 | vortex-row: codec for fixed-width canonical types | `claude/row-c03-codec-fixed-width` |
| 4 | #7989 | vortex-row: codec for varlen canonical types | `claude/row-c04-codec-varlen` |
| 5 | #7990 | vortex-row: codec for nested canonical types | `claude/row-c05-codec-nested` |
| 6 | #7991 | vortex-row: compute_sizes helper and RowSize ScalarFn | `claude/row-c06-rowsize-scalarfn` |
| 7 | #7992 | vortex-row: RowEncode ScalarFn | `claude/row-c07-rowencode-scalarfn` |
| 8 | #7993 | vortex-row: convert_columns + tests + bench scaffolding | `claude/row-c08-convert-columns-tests-bench` |
| 9 | #7994 | Skip ListView validation in row encoder output | `claude/row-c09-skip-listview-validation` |
| 10 | #7995 | Add validity fast-path helper for the four pattern-matching encoders | `claude/row-c10-validity-fast-path` |
| 11 | #7996 | Skip zero-init of output buffer | `claude/row-c11-skip-zero-init` |
| 12 | #7997 | Auto-vectorize pure-fixed offsets construction | `claude/row-c12-vectorize-pure-fixed-offsets` |
| 13 | #7998 | Auto-vectorize mixed-path offsets construction | `claude/row-c13-vectorize-mixed-offsets` |
| 14 | #7999 | Rewrite varlen 32-byte block encoder with copy_nonoverlapping | `claude/row-c14-varlen-block-copy-nonoverlapping` |
| 15 | #8000 | Walk VarBinView rows directly in row encoder hot loop | `claude/row-c15-walk-varbinview-directly` |
| 16 | #8001 | Add arithmetic-write fast path for fixed-before-varlen columns | `claude/row-c16-arith-write-fast-path` |
| 17 | #8002 | Specialize Constant for the arithmetic-write fast path | `claude/row-c17-specialize-constant-arith` |
| 18 | #8003 | RowSizeKernel and RowEncodeKernel dispatch helpers | `claude/row-c18-kernel-dispatch-helpers` |
| 19 | #8004 | Inventory-based registry for downstream encoding kernels | `claude/row-c19-inventory-registry` |
| 20 | #8005 | Constant row-encode kernel | `claude/row-c20-constant-kernel` |
| 21 | #8006 | Dict row-encode kernel | `claude/row-c21-dict-kernel` |
| 22 | #8007 | Patched row-encode kernel | `claude/row-c22-patched-kernel` |
| 23 | #8008 | RunEnd row-encode kernel (vortex-runend) | `claude/row-c23-runend-kernel` |
| 24 | #8009 | BitPacked row-encode kernel (vortex-fastlanes) | `claude/row-c24-bitpacked-kernel` |
| 25 | #7985 | FoR and Delta row-encode kernels (vortex-fastlanes) | `claude/row-pr3-kernels` |

Base of this PR: #7999 (`claude/row-c14-varlen-block-copy-nonoverlapping`)
Next in stack: #8001 (`claude/row-c16-arith-write-fast-path`)

## Combined context

For the full design + rationale, see PR #7985 (top of stack).
