### PR TITLE
Specialize Constant for the arithmetic-write fast path

### DIFF
--- a/vortex-row/src/encode.rs
+++ b/vortex-row/src/encode.rs
@@ -21,6 +21,7 @@ use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::VTable;
+use vortex_array::arrays::Constant;
 use vortex_array::arrays::ListViewArray;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
@@ -317,12 +318,146 @@ fn dispatch_encode_fixed_arith(
             &canonical, field, col_prefix, row_stride, var_prefix, width, out, ctx,
         );
     }
-    // For other fixed columns route through canonicalization and the codec helpers. The
-    // Constant fast path is layered on in a follow-up commit.
+    // Constant fast path: write the same scalar bytes at each per-row position.
+    if let Some(view) = col.as_opt::<Constant>() {
+        return encode_constant_arith(view, field, col_prefix, row_stride, var_prefix, width, out);
+    }
+    // For other fixed columns route through canonicalization and the codec helpers.
     let canonical = col.clone().execute::<Canonical>(ctx)?;
     codec::field_encode_fixed_arithmetic(
         &canonical, field, col_prefix, row_stride, var_prefix, width, out, ctx,
     )
+}
+
+/// Constant-specific arithmetic writer. Encodes the scalar bytes once, then writes the same
+/// bytes into each per-row slot via direct register-sized stores for the common small
+/// lengths (2/5/9/17), or `copy_nonoverlapping` as a fallback.
+fn encode_constant_arith(
+    view: ArrayView<'_, Constant>,
+    field: SortField,
+    col_prefix: u32,
+    row_stride: u32,
+    var_prefix: Option<&[u32]>,
+    _width: u32,
+    out: &mut [u8],
+) -> VortexResult<()> {
+    let bytes = codec::encode_scalar(view.scalar(), field)?;
+    let len = bytes.len();
+    if len == 0 {
+        return Ok(());
+    }
+    let n = view.len();
+    // SAFETY: encoded scalar length matches the per-row width contributed to the size pass,
+    // so `pos + len <= out.len()` by buffer construction. For small fixed lengths (the
+    // common case: bool=2, i32=5, i64=9, i128=17) we hoist the encoded bytes into
+    // register-sized loads before the loop and emit direct write_unaligned stores per row.
+    // This is faster than copy_nonoverlapping for small `len` because the compiler emits a
+    // real memcpy call rather than inlining the 1- or 2-word store sequence.
+    unsafe {
+        let src = bytes.as_ptr();
+        let stride = row_stride as usize;
+        match (var_prefix, len) {
+            // i64-typical: 1 sentinel + 8 value bytes = 9 bytes, no varlen prefix.
+            (None, 9) => {
+                let v_lo = std::ptr::read_unaligned(src as *const u64);
+                let v_hi = *src.add(8);
+                let mut dst = out.as_mut_ptr().add(col_prefix as usize);
+                for _ in 0..n {
+                    std::ptr::write_unaligned(dst as *mut u64, v_lo);
+                    *dst.add(8) = v_hi;
+                    dst = dst.add(stride);
+                }
+            }
+            // i32-typical: 1 sentinel + 4 value bytes = 5 bytes, no varlen prefix.
+            (None, 5) => {
+                let v_lo = std::ptr::read_unaligned(src as *const u32);
+                let v_hi = *src.add(4);
+                let mut dst = out.as_mut_ptr().add(col_prefix as usize);
+                for _ in 0..n {
+                    std::ptr::write_unaligned(dst as *mut u32, v_lo);
+                    *dst.add(4) = v_hi;
+                    dst = dst.add(stride);
+                }
+            }
+            // bool / i8: 1 sentinel + 1 value byte = 2 bytes, no varlen prefix.
+            (None, 2) => {
+                let v = std::ptr::read_unaligned(src as *const u16);
+                let mut dst = out.as_mut_ptr().add(col_prefix as usize);
+                for _ in 0..n {
+                    std::ptr::write_unaligned(dst as *mut u16, v);
+                    dst = dst.add(stride);
+                }
+            }
+            // i128: 1 sentinel + 16 value bytes = 17 bytes, no varlen prefix.
+            (None, 17) => {
+                let v_lo = std::ptr::read_unaligned(src as *const u128);
+                let v_hi = *src.add(16);
+                let mut dst = out.as_mut_ptr().add(col_prefix as usize);
+                for _ in 0..n {
+                    std::ptr::write_unaligned(dst as *mut u128, v_lo);
+                    *dst.add(16) = v_hi;
+                    dst = dst.add(stride);
+                }
+            }
+            // General fallback for other lengths.
+            (None, _) => {
+                let mut dst = out.as_mut_ptr().add(col_prefix as usize);
+                for _ in 0..n {
+                    std::ptr::copy_nonoverlapping(src, dst, len);
+                    dst = dst.add(stride);
+                }
+            }
+            (Some(vp), 9) => {
+                let v_lo = std::ptr::read_unaligned(src as *const u64);
+                let v_hi = *src.add(8);
+                let base = out.as_mut_ptr();
+                for i in 0..n {
+                    let pos = (i as u32) * row_stride + col_prefix + vp[i];
+                    let dst = base.add(pos as usize);
+                    std::ptr::write_unaligned(dst as *mut u64, v_lo);
+                    *dst.add(8) = v_hi;
+                }
+            }
+            (Some(vp), 5) => {
+                let v_lo = std::ptr::read_unaligned(src as *const u32);
+                let v_hi = *src.add(4);
+                let base = out.as_mut_ptr();
+                for i in 0..n {
+                    let pos = (i as u32) * row_stride + col_prefix + vp[i];
+                    let dst = base.add(pos as usize);
+                    std::ptr::write_unaligned(dst as *mut u32, v_lo);
+                    *dst.add(4) = v_hi;
+                }
+            }
+            (Some(vp), 2) => {
+                let v = std::ptr::read_unaligned(src as *const u16);
+                let base = out.as_mut_ptr();
+                for i in 0..n {
+                    let pos = (i as u32) * row_stride + col_prefix + vp[i];
+                    std::ptr::write_unaligned(base.add(pos as usize) as *mut u16, v);
+                }
+            }
+            (Some(vp), 17) => {
+                let v_lo = std::ptr::read_unaligned(src as *const u128);
+                let v_hi = *src.add(16);
+                let base = out.as_mut_ptr();
+                for i in 0..n {
+                    let pos = (i as u32) * row_stride + col_prefix + vp[i];
+                    let dst = base.add(pos as usize);
+                    std::ptr::write_unaligned(dst as *mut u128, v_lo);
+                    *dst.add(16) = v_hi;
+                }
+            }
+            (Some(vp), _) => {
+                let base = out.as_mut_ptr();
+                for i in 0..n {
+                    let pos = (i as u32) * row_stride + col_prefix + vp[i];
+                    std::ptr::copy_nonoverlapping(src, base.add(pos as usize), len);
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Dispatch a single column's encoding into the shared `out` buffer.


### PR DESCRIPTION
Part 17 of 25 in the stacked PR series adding `vortex-row`.

This PR contains exactly one commit; review just that diff in isolation.

## What this commit does

When a ConstantArray feeds the fixed-before-varlen arithmetic path, the encoded scalar bytes are the same for every row. Hoists them into 1-2 register-sized loads outside the loop and emits direct `write_unaligned` stores per row. Specialized for encoded lengths 2 (bool/i8), 5 (i32), 9 (i64), 17 (i128). Other lengths fall back to `copy_nonoverlapping`. The var_prefix case (Constant after a varlen column) takes the same shape but computes per-row positions arithmetically rather than via a running cursor.

constant_i64_vortex_without_kernel 2.47 → ~6 GB/s (PR3 commit 3.3 adds the same specialization to the Constant kernel itself).

## Stack

| # | PR | Title | Branch |
|---|---|---|---|
| 1 | #7986 | vortex-row: crate scaffolding | `claude/row-c01-crate-scaffolding` |
| 2 | #7987 | vortex-row: add SortField and RowEncodeOptions | `claude/row-c02-sortfield-options` |
| 3 | #7988 | vortex-row: codec for fixed-width canonical types | `claude/row-c03-codec-fixed-width` |
| 4 | #7989 | vortex-row: codec for varlen canonical types | `claude/row-c04-codec-varlen` |
| 5 | #7990 | vortex-row: codec for nested canonical types | `claude/row-c05-codec-nested` |
| 6 | #7991 | vortex-row: compute_sizes helper and RowSize ScalarFn | `claude/row-c06-rowsize-scalarfn` |
| 7 | #7992 | vortex-row: RowEncode ScalarFn | `claude/row-c07-rowencode-scalarfn` |
| 8 | #7993 | vortex-row: convert_columns + tests + bench scaffolding | `claude/row-c08-convert-columns-tests-bench` |
| 9 | #7994 | Skip ListView validation in row encoder output | `claude/row-c09-skip-listview-validation` |
| 10 | #7995 | Add validity fast-path helper for the four pattern-matching encoders | `claude/row-c10-validity-fast-path` |
| 11 | #7996 | Skip zero-init of output buffer | `claude/row-c11-skip-zero-init` |
| 12 | #7997 | Auto-vectorize pure-fixed offsets construction | `claude/row-c12-vectorize-pure-fixed-offsets` |
| 13 | #7998 | Auto-vectorize mixed-path offsets construction | `claude/row-c13-vectorize-mixed-offsets` |
| 14 | #7999 | Rewrite varlen 32-byte block encoder with copy_nonoverlapping | `claude/row-c14-varlen-block-copy-nonoverlapping` |
| 15 | #8000 | Walk VarBinView rows directly in row encoder hot loop | `claude/row-c15-walk-varbinview-directly` |
| 16 | #8001 | Add arithmetic-write fast path for fixed-before-varlen columns | `claude/row-c16-arith-write-fast-path` |
| 17 | #8002 | Specialize Constant for the arithmetic-write fast path | `claude/row-c17-specialize-constant-arith` |
| 18 | #8003 | RowSizeKernel and RowEncodeKernel dispatch helpers | `claude/row-c18-kernel-dispatch-helpers` |
| 19 | #8004 | Inventory-based registry for downstream encoding kernels | `claude/row-c19-inventory-registry` |
| 20 | #8005 | Constant row-encode kernel | `claude/row-c20-constant-kernel` |
| 21 | #8006 | Dict row-encode kernel | `claude/row-c21-dict-kernel` |
| 22 | #8007 | Patched row-encode kernel | `claude/row-c22-patched-kernel` |
| 23 | #8008 | RunEnd row-encode kernel (vortex-runend) | `claude/row-c23-runend-kernel` |
| 24 | #8009 | BitPacked row-encode kernel (vortex-fastlanes) | `claude/row-c24-bitpacked-kernel` |
| 25 | #7985 | FoR and Delta row-encode kernels (vortex-fastlanes) | `claude/row-pr3-kernels` |

Base of this PR: #8001 (`claude/row-c16-arith-write-fast-path`)
Next in stack: #8003 (`claude/row-c18-kernel-dispatch-helpers`)

## Combined context

For the full design + rationale, see PR #7985 (top of stack).
