### PR TITLE
RowSizeKernel and RowEncodeKernel dispatch helpers

### DIFF
--- a/vortex-row/public-api.lock
+++ b/vortex-row/public-api.lock
@@ -146,6 +146,18 @@ pub trait vortex_row::encode::RowEncodeKernel: vortex_array::array::vtable::VTab
 
 pub fn vortex_row::encode::RowEncodeKernel::row_encode_into(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &[u32], &mut [u32], &mut [u8], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
 
+impl vortex_row::encode::RowEncodeKernel for vortex_array::arrays::constant::vtable::Constant
+
+pub fn vortex_array::arrays::constant::vtable::Constant::row_encode_into(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &[u32], &mut [u32], &mut [u8], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
+
+impl vortex_row::encode::RowEncodeKernel for vortex_array::arrays::dict::vtable::Dict
+
+pub fn vortex_array::arrays::dict::vtable::Dict::row_encode_into(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &[u32], &mut [u32], &mut [u8], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
+
+impl vortex_row::encode::RowEncodeKernel for vortex_array::arrays::patched::vtable::Patched
+
+pub fn vortex_array::arrays::patched::vtable::Patched::row_encode_into(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &[u32], &mut [u32], &mut [u8], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
+
 pub fn vortex_row::encode::dispatch_encode(&vortex_array::array::erased::ArrayRef, vortex_row::options::SortField, &[u32], &mut [u32], &mut [u8], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<()>
 
 pub mod vortex_row::options
@@ -265,6 +277,18 @@ pub fn vortex_row::size::RowSize::serialize(&self, &Self::Options) -> vortex_err
 pub trait vortex_row::size::RowSizeKernel: vortex_array::array::vtable::VTable
 
 pub fn vortex_row::size::RowSizeKernel::row_size_contribution(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &mut [u32], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
+
+impl vortex_row::size::RowSizeKernel for vortex_array::arrays::constant::vtable::Constant
+
+pub fn vortex_array::arrays::constant::vtable::Constant::row_size_contribution(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &mut [u32], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
+
+impl vortex_row::size::RowSizeKernel for vortex_array::arrays::dict::vtable::Dict
+
+pub fn vortex_array::arrays::dict::vtable::Dict::row_size_contribution(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &mut [u32], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
+
+impl vortex_row::size::RowSizeKernel for vortex_array::arrays::patched::vtable::Patched
+
+pub fn vortex_array::arrays::patched::vtable::Patched::row_size_contribution(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &mut [u32], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
 
 pub fn vortex_row::size::dispatch_size(&vortex_array::array::erased::ArrayRef, vortex_row::options::SortField, &mut [u32], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<()>
 
@@ -412,9 +436,33 @@ pub trait vortex_row::RowEncodeKernel: vortex_array::array::vtable::VTable
 
 pub fn vortex_row::RowEncodeKernel::row_encode_into(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &[u32], &mut [u32], &mut [u8], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
 
+impl vortex_row::encode::RowEncodeKernel for vortex_array::arrays::constant::vtable::Constant
+
+pub fn vortex_array::arrays::constant::vtable::Constant::row_encode_into(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &[u32], &mut [u32], &mut [u8], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
+
+impl vortex_row::encode::RowEncodeKernel for vortex_array::arrays::dict::vtable::Dict
+
+pub fn vortex_array::arrays::dict::vtable::Dict::row_encode_into(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &[u32], &mut [u32], &mut [u8], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
+
+impl vortex_row::encode::RowEncodeKernel for vortex_array::arrays::patched::vtable::Patched
+
+pub fn vortex_array::arrays::patched::vtable::Patched::row_encode_into(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &[u32], &mut [u32], &mut [u8], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
+
 pub trait vortex_row::RowSizeKernel: vortex_array::array::vtable::VTable
 
 pub fn vortex_row::RowSizeKernel::row_size_contribution(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &mut [u32], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
+
+impl vortex_row::size::RowSizeKernel for vortex_array::arrays::constant::vtable::Constant
+
+pub fn vortex_array::arrays::constant::vtable::Constant::row_size_contribution(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &mut [u32], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
+
+impl vortex_row::size::RowSizeKernel for vortex_array::arrays::dict::vtable::Dict
+
+pub fn vortex_array::arrays::dict::vtable::Dict::row_size_contribution(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &mut [u32], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
+
+impl vortex_row::size::RowSizeKernel for vortex_array::arrays::patched::vtable::Patched
+
+pub fn vortex_array::arrays::patched::vtable::Patched::row_size_contribution(vortex_array::array::view::ArrayView<'_, Self>, vortex_row::options::SortField, &mut [u32], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
 
 pub fn vortex_row::compute_row_sizes(&[vortex_array::array::erased::ArrayRef], &[vortex_row::options::SortField], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 

--- a/vortex-row/src/encode.rs
+++ b/vortex-row/src/encode.rs
@@ -25,6 +25,8 @@ use vortex_array::arrays::Constant;
 use vortex_array::arrays::ListViewArray;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::dict::Dict;
+use vortex_array::arrays::patched::Patched;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
@@ -462,9 +464,9 @@ fn encode_constant_arith(
 
 /// Dispatch a single column's encoding into the shared `out` buffer.
 ///
-/// For PR 1 this is just the canonicalize-then-`codec::field_encode` fallback path.
-/// In-crate fast paths for `Constant`/`Dict`/`Patched` and the inventory-based registry
-/// for downstream encodings are added in PR 3.
+/// Tries the in-crate per-encoding fast paths first, then falls back to canonicalization.
+/// Per-encoding kernels currently return `Ok(None)` (stubs added alongside the trait); the
+/// real impls land in follow-up commits. The downstream-encoding registry is added next.
 pub fn dispatch_encode(
     col: &ArrayRef,
     field: SortField,
@@ -473,6 +475,21 @@ pub fn dispatch_encode(
     out: &mut [u8],
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()> {
+    if let Some(view) = col.as_opt::<Constant>()
+        && Constant::row_encode_into(view, field, offsets, cursors, out, ctx)?.is_some()
+    {
+        return Ok(());
+    }
+    if let Some(view) = col.as_opt::<Dict>()
+        && Dict::row_encode_into(view, field, offsets, cursors, out, ctx)?.is_some()
+    {
+        return Ok(());
+    }
+    if let Some(view) = col.as_opt::<Patched>()
+        && Patched::row_encode_into(view, field, offsets, cursors, out, ctx)?.is_some()
+    {
+        return Ok(());
+    }
     let canonical = col.clone().execute::<Canonical>(ctx)?;
     codec::field_encode(&canonical, field, offsets, cursors, out, ctx)
 }

--- a/vortex-row/src/kernels/constant.rs
+++ b/vortex-row/src/kernels/constant.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Row-encode kernels for `ConstantArray`.
+//!
+//! Stubs in this commit return `Ok(None)` so the dispatch loop falls back to
+//! canonicalization. The real impls land in a follow-up commit.
+
+use vortex_array::ArrayView;
+use vortex_array::ExecutionCtx;
+use vortex_array::arrays::Constant;
+use vortex_error::VortexResult;
+
+use crate::encode::RowEncodeKernel;
+use crate::options::SortField;
+use crate::size::RowSizeKernel;
+
+impl RowSizeKernel for Constant {
+    fn row_size_contribution(
+        _column: ArrayView<'_, Self>,
+        _field: SortField,
+        _sizes: &mut [u32],
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<()>> {
+        Ok(None)
+    }
+}
+
+impl RowEncodeKernel for Constant {
+    fn row_encode_into(
+        _column: ArrayView<'_, Self>,
+        _field: SortField,
+        _offsets: &[u32],
+        _cursors: &mut [u32],
+        _out: &mut [u8],
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<()>> {
+        Ok(None)
+    }
+}

--- a/vortex-row/src/kernels/dict.rs
+++ b/vortex-row/src/kernels/dict.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Row-encode kernels for `DictArray`.
+//!
+//! Stubs in this commit return `Ok(None)` so the dispatch loop falls back to
+//! canonicalization. The real impls land in a follow-up commit.
+
+use vortex_array::ArrayView;
+use vortex_array::ExecutionCtx;
+use vortex_array::arrays::dict::Dict;
+use vortex_error::VortexResult;
+
+use crate::encode::RowEncodeKernel;
+use crate::options::SortField;
+use crate::size::RowSizeKernel;
+
+impl RowSizeKernel for Dict {
+    fn row_size_contribution(
+        _column: ArrayView<'_, Self>,
+        _field: SortField,
+        _sizes: &mut [u32],
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<()>> {
+        Ok(None)
+    }
+}
+
+impl RowEncodeKernel for Dict {
+    fn row_encode_into(
+        _column: ArrayView<'_, Self>,
+        _field: SortField,
+        _offsets: &[u32],
+        _cursors: &mut [u32],
+        _out: &mut [u8],
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<()>> {
+        Ok(None)
+    }
+}

--- a/vortex-row/src/kernels/mod.rs
+++ b/vortex-row/src/kernels/mod.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Per-encoding fast-path implementations of [`RowSizeKernel`] and [`RowEncodeKernel`] for
+//! encodings defined in `vortex-array`.
+//!
+//! Each impl in this module lives here (rather than under the corresponding encoding's
+//! `compute` module in `vortex-array`) so the orphan rule is satisfied: the trait is
+//! defined in `vortex-row` and the impl is also in `vortex-row`, while the array type
+//! (`Constant`, `Dict`, `Patched`) remains in `vortex-array`.
+//!
+//! [`RowSizeKernel`]: crate::size::RowSizeKernel
+//! [`RowEncodeKernel`]: crate::encode::RowEncodeKernel
+
+mod constant;
+mod dict;
+mod patched;

--- a/vortex-row/src/kernels/patched.rs
+++ b/vortex-row/src/kernels/patched.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Row-encode kernels for `Patched`.
+//!
+//! Stubs in this commit return `Ok(None)` so the dispatch loop falls back to
+//! canonicalization. The real impls land in a follow-up commit.
+
+use vortex_array::ArrayView;
+use vortex_array::ExecutionCtx;
+use vortex_array::arrays::patched::Patched;
+use vortex_error::VortexResult;
+
+use crate::encode::RowEncodeKernel;
+use crate::options::SortField;
+use crate::size::RowSizeKernel;
+
+impl RowSizeKernel for Patched {
+    fn row_size_contribution(
+        _column: ArrayView<'_, Self>,
+        _field: SortField,
+        _sizes: &mut [u32],
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<()>> {
+        Ok(None)
+    }
+}
+
+impl RowEncodeKernel for Patched {
+    fn row_encode_into(
+        _column: ArrayView<'_, Self>,
+        _field: SortField,
+        _offsets: &[u32],
+        _cursors: &mut [u32],
+        _out: &mut [u8],
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<()>> {
+        Ok(None)
+    }
+}

--- a/vortex-row/src/lib.rs
+++ b/vortex-row/src/lib.rs
@@ -28,6 +28,7 @@
 pub mod codec;
 pub mod convert;
 pub mod encode;
+mod kernels;
 pub mod options;
 pub mod size;
 

--- a/vortex-row/src/size.rs
+++ b/vortex-row/src/size.rs
@@ -11,9 +11,12 @@ use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::VTable;
+use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::StructArray;
+use vortex_array::arrays::dict::Dict;
+use vortex_array::arrays::patched::Patched;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldName;
 use vortex_array::dtype::FieldNames;
@@ -256,15 +259,30 @@ impl ScalarFnVTable for RowSize {
 
 /// Dispatch a single column's per-row size contribution.
 ///
-/// For PR 1 this is just the canonicalize-then-`codec::field_size` fallback path. In-crate
-/// fast paths for `Constant`/`Dict`/`Patched` and the inventory-based registry for
-/// downstream encodings are added in PR 3.
+/// Tries the in-crate per-encoding fast paths first, then falls back to canonicalization.
+/// Per-encoding kernels currently return `Ok(None)` (stubs added alongside the trait); the
+/// real impls land in follow-up commits. The downstream-encoding registry is added next.
 pub fn dispatch_size(
     col: &ArrayRef,
     field: SortField,
     sizes: &mut [u32],
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()> {
+    if let Some(view) = col.as_opt::<Constant>()
+        && Constant::row_size_contribution(view, field, sizes, ctx)?.is_some()
+    {
+        return Ok(());
+    }
+    if let Some(view) = col.as_opt::<Dict>()
+        && Dict::row_size_contribution(view, field, sizes, ctx)?.is_some()
+    {
+        return Ok(());
+    }
+    if let Some(view) = col.as_opt::<Patched>()
+        && Patched::row_size_contribution(view, field, sizes, ctx)?.is_some()
+    {
+        return Ok(());
+    }
     let canonical = col.clone().execute::<Canonical>(ctx)?;
     codec::field_size(&canonical, field, sizes, ctx)
 }


### PR DESCRIPTION
Part 18 of 25 in the stacked PR series adding `vortex-row`.

This PR contains exactly one commit; review just that diff in isolation.

## What this commit does

Wires per-encoding fast-path traits into `dispatch_size` and `dispatch_encode`. Both helpers now try the in-crate downcast arms (Constant, Dict, Patched) before falling back to canonicalization.

This commit adds stub impls returning `Ok(None)` so the existing behavior is preserved bit-for-bit; subsequent commits replace each stub with its real impl. Keeping the wiring change separate from the algorithm work makes the kernel impl commits trivially reviewable in isolation (they only touch one file each).

The kernel module is `mod kernels` (crate-private) so the impls satisfy the orphan rule (trait defined in `vortex-row`, types from `vortex-array`) without leaking the impls into the crate's public surface.

## Stack

| # | PR | Title | Branch |
|---|---|---|---|
| 1 | #7986 | vortex-row: crate scaffolding | `claude/row-c01-crate-scaffolding` |
| 2 | #7987 | vortex-row: add SortField and RowEncodeOptions | `claude/row-c02-sortfield-options` |
| 3 | #7988 | vortex-row: codec for fixed-width canonical types | `claude/row-c03-codec-fixed-width` |
| 4 | #7989 | vortex-row: codec for varlen canonical types | `claude/row-c04-codec-varlen` |
| 5 | #7990 | vortex-row: codec for nested canonical types | `claude/row-c05-codec-nested` |
| 6 | #7991 | vortex-row: compute_sizes helper and RowSize ScalarFn | `claude/row-c06-rowsize-scalarfn` |
| 7 | #7992 | vortex-row: RowEncode ScalarFn | `claude/row-c07-rowencode-scalarfn` |
| 8 | #7993 | vortex-row: convert_columns + tests + bench scaffolding | `claude/row-c08-convert-columns-tests-bench` |
| 9 | #7994 | Skip ListView validation in row encoder output | `claude/row-c09-skip-listview-validation` |
| 10 | #7995 | Add validity fast-path helper for the four pattern-matching encoders | `claude/row-c10-validity-fast-path` |
| 11 | #7996 | Skip zero-init of output buffer | `claude/row-c11-skip-zero-init` |
| 12 | #7997 | Auto-vectorize pure-fixed offsets construction | `claude/row-c12-vectorize-pure-fixed-offsets` |
| 13 | #7998 | Auto-vectorize mixed-path offsets construction | `claude/row-c13-vectorize-mixed-offsets` |
| 14 | #7999 | Rewrite varlen 32-byte block encoder with copy_nonoverlapping | `claude/row-c14-varlen-block-copy-nonoverlapping` |
| 15 | #8000 | Walk VarBinView rows directly in row encoder hot loop | `claude/row-c15-walk-varbinview-directly` |
| 16 | #8001 | Add arithmetic-write fast path for fixed-before-varlen columns | `claude/row-c16-arith-write-fast-path` |
| 17 | #8002 | Specialize Constant for the arithmetic-write fast path | `claude/row-c17-specialize-constant-arith` |
| 18 | #8003 | RowSizeKernel and RowEncodeKernel dispatch helpers | `claude/row-c18-kernel-dispatch-helpers` |
| 19 | #8004 | Inventory-based registry for downstream encoding kernels | `claude/row-c19-inventory-registry` |
| 20 | #8005 | Constant row-encode kernel | `claude/row-c20-constant-kernel` |
| 21 | #8006 | Dict row-encode kernel | `claude/row-c21-dict-kernel` |
| 22 | #8007 | Patched row-encode kernel | `claude/row-c22-patched-kernel` |
| 23 | #8008 | RunEnd row-encode kernel (vortex-runend) | `claude/row-c23-runend-kernel` |
| 24 | #8009 | BitPacked row-encode kernel (vortex-fastlanes) | `claude/row-c24-bitpacked-kernel` |
| 25 | #7985 | FoR and Delta row-encode kernels (vortex-fastlanes) | `claude/row-pr3-kernels` |

Base of this PR: #8002 (`claude/row-c17-specialize-constant-arith`)
Next in stack: #8004 (`claude/row-c19-inventory-registry`)

## Combined context

For the full design + rationale, see PR #7985 (top of stack).
