### PR TITLE
Inventory-based registry for downstream encoding kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11043,6 +11043,7 @@ dependencies = [
  "arrow-schema 58.2.0",
  "bytes",
  "codspeed-divan-compat",
+ "inventory",
  "mimalloc",
  "rand 0.10.1",
  "rstest",
@@ -11052,6 +11053,7 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-session",
+ "vortex-utils",
 ]
 
 [[package]]

--- a/vortex-row/Cargo.toml
+++ b/vortex-row/Cargo.toml
@@ -18,12 +18,14 @@ workspace = true
 
 [dependencies]
 bytes = { workspace = true }
+inventory = { workspace = true }
 smallvec = { workspace = true }
 vortex-array = { workspace = true }
 vortex-buffer = { workspace = true }
 vortex-error = { workspace = true }
 vortex-mask = { workspace = true }
 vortex-session = { workspace = true }
+vortex-utils = { workspace = true, features = ["dyn-traits"] }
 
 [dev-dependencies]
 arrow-array = { workspace = true }

--- a/vortex-row/public-api.lock
+++ b/vortex-row/public-api.lock
@@ -240,6 +240,24 @@ impl core::marker::StructuralPartialEq for vortex_row::options::SortField
 
 pub const vortex_row::options::FIELDS_INLINE: usize
 
+pub mod vortex_row::registry
+
+pub struct vortex_row::registry::RowEncodeRegistration
+
+pub vortex_row::registry::RowEncodeRegistration::encode: vortex_row::registry::DynEncodeFn
+
+pub vortex_row::registry::RowEncodeRegistration::id: fn() -> vortex_array::array::ArrayId
+
+pub vortex_row::registry::RowEncodeRegistration::size: vortex_row::registry::DynSizeFn
+
+impl inventory::Collect for vortex_row::registry::RowEncodeRegistration
+
+pub fn vortex_row::registry::lookup(&vortex_array::array::ArrayId) -> core::option::Option<(vortex_row::registry::DynSizeFn, vortex_row::registry::DynEncodeFn)>
+
+pub type vortex_row::registry::DynEncodeFn = fn(&vortex_array::array::erased::ArrayRef, vortex_row::options::SortField, &[u32], &mut [u32], &mut [u8], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
+
+pub type vortex_row::registry::DynSizeFn = fn(&vortex_array::array::erased::ArrayRef, vortex_row::options::SortField, &mut [u32], &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<()>>
+
 pub mod vortex_row::size
 
 pub struct vortex_row::size::RowSize
@@ -355,6 +373,16 @@ impl core::hash::Hash for vortex_row::options::RowEncodeOptions
 pub fn vortex_row::options::RowEncodeOptions::hash<__H: core::hash::Hasher>(&self, &mut __H)
 
 impl core::marker::StructuralPartialEq for vortex_row::options::RowEncodeOptions
+
+pub struct vortex_row::RowEncodeRegistration
+
+pub vortex_row::RowEncodeRegistration::encode: vortex_row::registry::DynEncodeFn
+
+pub vortex_row::RowEncodeRegistration::id: fn() -> vortex_array::array::ArrayId
+
+pub vortex_row::RowEncodeRegistration::size: vortex_row::registry::DynSizeFn
+
+impl inventory::Collect for vortex_row::registry::RowEncodeRegistration
 
 pub struct vortex_row::RowSize
 

--- a/vortex-row/src/encode.rs
+++ b/vortex-row/src/encode.rs
@@ -48,6 +48,7 @@ use crate::options::RowEncodeOptions;
 use crate::options::SortField;
 use crate::options::deserialize_row_encode_options;
 use crate::options::serialize_row_encode_options;
+use crate::registry;
 use crate::size::ColKind;
 use crate::size::compute_sizes;
 
@@ -487,6 +488,11 @@ pub fn dispatch_encode(
     }
     if let Some(view) = col.as_opt::<Patched>()
         && Patched::row_encode_into(view, field, offsets, cursors, out, ctx)?.is_some()
+    {
+        return Ok(());
+    }
+    if let Some((_, encode_fn)) = registry::lookup(&col.encoding_id())
+        && encode_fn(col, field, offsets, cursors, out, ctx)?.is_some()
     {
         return Ok(());
     }

--- a/vortex-row/src/lib.rs
+++ b/vortex-row/src/lib.rs
@@ -30,6 +30,7 @@ pub mod convert;
 pub mod encode;
 mod kernels;
 pub mod options;
+pub mod registry;
 pub mod size;
 
 #[cfg(test)]
@@ -41,6 +42,7 @@ pub use encode::RowEncode;
 pub use encode::RowEncodeKernel;
 pub use options::RowEncodeOptions;
 pub use options::SortField;
+pub use registry::RowEncodeRegistration;
 pub use size::RowSize;
 pub use size::RowSizeKernel;
 use vortex_array::scalar_fn::session::ScalarFnSessionExt;

--- a/vortex-row/src/registry.rs
+++ b/vortex-row/src/registry.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Registry for per-encoding row-encode fast paths from downstream crates.
+//!
+//! Encodings that live outside `vortex-array` (such as `RunEnd` in `encodings/runend`) cannot
+//! be directly downcast from inside the variadic [`RowSize`] / [`RowEncode`] dispatch loops.
+//! Instead, they submit a [`RowEncodeRegistration`] via the `inventory` crate, and the
+//! dispatch loop looks them up by [`ArrayId`].
+//!
+//! [`RowSize`]: super::size::RowSize
+//! [`RowEncode`]: super::encode::RowEncode
+
+use std::sync::OnceLock;
+
+use vortex_array::ArrayId;
+use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
+use vortex_error::VortexResult;
+use vortex_utils::aliases::hash_map::HashMap;
+
+use crate::options::SortField;
+
+/// Function pointer signature for an encoding's per-row size contribution.
+pub type DynSizeFn =
+    fn(&ArrayRef, SortField, &mut [u32], &mut ExecutionCtx) -> VortexResult<Option<()>>;
+
+/// Function pointer signature for an encoding's per-row byte encoding.
+pub type DynEncodeFn = fn(
+    &ArrayRef,
+    SortField,
+    &[u32],
+    &mut [u32],
+    &mut [u8],
+    &mut ExecutionCtx,
+) -> VortexResult<Option<()>>;
+
+/// A registration submitted by an encoding crate to plug into the row encoder.
+///
+/// Because [`ArrayId`] requires runtime string interning, the encoding id is passed as a
+/// function pointer that is called once at registry initialization time.
+pub struct RowEncodeRegistration {
+    /// Returns the [`ArrayId`] of the encoding this registration applies to.
+    pub id: fn() -> ArrayId,
+    /// Per-row size contribution function.
+    pub size: DynSizeFn,
+    /// Per-row encoding function.
+    pub encode: DynEncodeFn,
+}
+
+inventory::collect!(RowEncodeRegistration);
+
+/// Look up a (size, encode) pair for the given encoding id.
+pub fn lookup(id: &ArrayId) -> Option<(DynSizeFn, DynEncodeFn)> {
+    static MAP: OnceLock<HashMap<ArrayId, (DynSizeFn, DynEncodeFn)>> = OnceLock::new();
+    let map = MAP.get_or_init(|| {
+        inventory::iter::<RowEncodeRegistration>
+            .into_iter()
+            .map(|r| ((r.id)(), (r.size, r.encode)))
+            .collect()
+    });
+    map.get(id).copied()
+}

--- a/vortex-row/src/size.rs
+++ b/vortex-row/src/size.rs
@@ -42,6 +42,7 @@ use crate::options::RowEncodeOptions;
 use crate::options::SortField;
 use crate::options::deserialize_row_encode_options;
 use crate::options::serialize_row_encode_options;
+use crate::registry;
 
 /// Classification of a single input column for the size pass.
 ///
@@ -280,6 +281,11 @@ pub fn dispatch_size(
     }
     if let Some(view) = col.as_opt::<Patched>()
         && Patched::row_size_contribution(view, field, sizes, ctx)?.is_some()
+    {
+        return Ok(());
+    }
+    if let Some((size_fn, _)) = registry::lookup(&col.encoding_id())
+        && size_fn(col, field, sizes, ctx)?.is_some()
     {
         return Ok(());
     }


### PR DESCRIPTION
Part 19 of 25 in the stacked PR series adding `vortex-row`.

This PR contains exactly one commit; review just that diff in isolation.

## What this commit does

Encodings that live outside `vortex-array` (e.g. RunEnd, BitPacked, FoR, Delta) can't be downcast from inside the variadic dispatch loops — vortex-array doesn't know about them, and reversing the dependency would create a cycle.

Adds a `RowEncodeRegistration` that downstream crates submit via the inventory crate. `lookup(&array_id)` lazily builds an `ArrayId → (size, encode)` HashMap on first call, behind a `OnceLock` so the build is single-threaded and the lookups are wait-free thereafter.

Wires the lookup into `dispatch_size` / `dispatch_encode` after the in-crate downcast attempts: in-crate kernels take precedence (constant-time downcast), then downstream registrations (HashMap lookup), then the canonicalization fallback.

## Stack

| # | PR | Title | Branch |
|---|---|---|---|
| 1 | #7986 | vortex-row: crate scaffolding | `claude/row-c01-crate-scaffolding` |
| 2 | #7987 | vortex-row: add SortField and RowEncodeOptions | `claude/row-c02-sortfield-options` |
| 3 | #7988 | vortex-row: codec for fixed-width canonical types | `claude/row-c03-codec-fixed-width` |
| 4 | #7989 | vortex-row: codec for varlen canonical types | `claude/row-c04-codec-varlen` |
| 5 | #7990 | vortex-row: codec for nested canonical types | `claude/row-c05-codec-nested` |
| 6 | #7991 | vortex-row: compute_sizes helper and RowSize ScalarFn | `claude/row-c06-rowsize-scalarfn` |
| 7 | #7992 | vortex-row: RowEncode ScalarFn | `claude/row-c07-rowencode-scalarfn` |
| 8 | #7993 | vortex-row: convert_columns + tests + bench scaffolding | `claude/row-c08-convert-columns-tests-bench` |
| 9 | #7994 | Skip ListView validation in row encoder output | `claude/row-c09-skip-listview-validation` |
| 10 | #7995 | Add validity fast-path helper for the four pattern-matching encoders | `claude/row-c10-validity-fast-path` |
| 11 | #7996 | Skip zero-init of output buffer | `claude/row-c11-skip-zero-init` |
| 12 | #7997 | Auto-vectorize pure-fixed offsets construction | `claude/row-c12-vectorize-pure-fixed-offsets` |
| 13 | #7998 | Auto-vectorize mixed-path offsets construction | `claude/row-c13-vectorize-mixed-offsets` |
| 14 | #7999 | Rewrite varlen 32-byte block encoder with copy_nonoverlapping | `claude/row-c14-varlen-block-copy-nonoverlapping` |
| 15 | #8000 | Walk VarBinView rows directly in row encoder hot loop | `claude/row-c15-walk-varbinview-directly` |
| 16 | #8001 | Add arithmetic-write fast path for fixed-before-varlen columns | `claude/row-c16-arith-write-fast-path` |
| 17 | #8002 | Specialize Constant for the arithmetic-write fast path | `claude/row-c17-specialize-constant-arith` |
| 18 | #8003 | RowSizeKernel and RowEncodeKernel dispatch helpers | `claude/row-c18-kernel-dispatch-helpers` |
| 19 | #8004 | Inventory-based registry for downstream encoding kernels | `claude/row-c19-inventory-registry` |
| 20 | #8005 | Constant row-encode kernel | `claude/row-c20-constant-kernel` |
| 21 | #8006 | Dict row-encode kernel | `claude/row-c21-dict-kernel` |
| 22 | #8007 | Patched row-encode kernel | `claude/row-c22-patched-kernel` |
| 23 | #8008 | RunEnd row-encode kernel (vortex-runend) | `claude/row-c23-runend-kernel` |
| 24 | #8009 | BitPacked row-encode kernel (vortex-fastlanes) | `claude/row-c24-bitpacked-kernel` |
| 25 | #7985 | FoR and Delta row-encode kernels (vortex-fastlanes) | `claude/row-pr3-kernels` |

Base of this PR: #8003 (`claude/row-c18-kernel-dispatch-helpers`)
Next in stack: #8005 (`claude/row-c20-constant-kernel`)

## Combined context

For the full design + rationale, see PR #7985 (top of stack).
