### PR TITLE
bench: bit-packed compare-constant baseline

### DIFF
--- a/encodings/fastlanes/Cargo.toml
+++ b/encodings/fastlanes/Cargo.toml
@@ -59,3 +59,7 @@ required-features = ["_test-harness"]
 name = "bit_transpose"
 harness = false
 required-features = ["_test-harness"]
+
+[[bench]]
+name = "bitpack_compare"
+harness = false

--- a/encodings/fastlanes/benches/bitpack_compare.rs
+++ b/encodings/fastlanes/benches/bitpack_compare.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Compare an already-packed `BitPackedArray` against a constant value. Compares the
+//! out-of-range fast path (constant outside `[0, 2^bit_width - 1]`) against an explicit
+//! "decompress, then compare" baseline.
+//!
+//! Sized to finish quickly. Run with `cargo bench -p vortex-fastlanes --bench bitpack_compare`.
+
+#![expect(clippy::unwrap_used)]
+#![expect(clippy::cast_possible_truncation)]
+
+use divan::Bencher;
+use divan::counter::ItemsCount;
+use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::BoolArray;
+use vortex_array::arrays::ConstantArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::builtins::ArrayBuiltins;
+use vortex_array::scalar_fn::fns::operators::Operator;
+use vortex_array::validity::Validity;
+use vortex_buffer::BufferMut;
+use vortex_fastlanes::BitPackedData;
+
+fn main() {
+    divan::main();
+}
+
+const LENS: &[usize] = &[1024, 64 * 1024];
+const BIT_WIDTHS: &[u8] = &[4, 16];
+
+/// Build a packed array of varied in-range values, plus an out-of-range constant RHS for
+/// the fast-path benches.
+fn build_inputs<const BW: u8>(len: usize) -> (ArrayRef, ArrayRef, ExecutionCtx) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let buf: BufferMut<u32> = (0..len).map(|i| (i as u32) % (1 << BW)).collect();
+    let array = BitPackedData::encode(
+        &PrimitiveArray::new(buf.freeze(), Validity::NonNullable).into_array(),
+        BW,
+        &mut ctx,
+    )
+    .unwrap()
+    .into_array();
+    // 1 << BW is just past the packable range, so the out-of-range fast path fires.
+    let constant = 1u32 << BW;
+    let rhs = ConstantArray::new(constant, len).into_array();
+    (array, rhs, ctx)
+}
+
+#[divan::bench(args = LENS, consts = BIT_WIDTHS)]
+fn fast_eq_out_of_range<const BW: u8>(bencher: Bencher, len: usize) {
+    let (array, rhs, mut ctx) = build_inputs::<BW>(len);
+    bencher.counter(ItemsCount::new(len)).bench_local(|| {
+        array
+            .clone()
+            .binary(rhs.clone(), Operator::Eq)
+            .unwrap()
+            .execute::<BoolArray>(&mut ctx)
+            .unwrap()
+    });
+}
+
+#[divan::bench(args = LENS, consts = BIT_WIDTHS)]
+fn baseline_eq<const BW: u8>(bencher: Bencher, len: usize) {
+    let (array, rhs, mut ctx) = build_inputs::<BW>(len);
+    bencher.counter(ItemsCount::new(len)).bench_local(|| {
+        // What the fallback would do: materialize the unpacked primitive, then run Arrow
+        // compare on it.
+        let primitive = array.clone().execute::<PrimitiveArray>(&mut ctx).unwrap();
+        primitive
+            .into_array()
+            .binary(rhs.clone(), Operator::Eq)
+            .unwrap()
+            .execute::<BoolArray>(&mut ctx)
+            .unwrap()
+    });
+}
+
+#[divan::bench(args = LENS, consts = BIT_WIDTHS)]
+fn fast_lt_out_of_range<const BW: u8>(bencher: Bencher, len: usize) {
+    let (array, rhs, mut ctx) = build_inputs::<BW>(len);
+    bencher.counter(ItemsCount::new(len)).bench_local(|| {
+        array
+            .clone()
+            .binary(rhs.clone(), Operator::Lt)
+            .unwrap()
+            .execute::<BoolArray>(&mut ctx)
+            .unwrap()
+    });
+}
+
+#[divan::bench(args = LENS, consts = BIT_WIDTHS)]
+fn baseline_lt<const BW: u8>(bencher: Bencher, len: usize) {
+    let (array, rhs, mut ctx) = build_inputs::<BW>(len);
+    bencher.counter(ItemsCount::new(len)).bench_local(|| {
+        let primitive = array.clone().execute::<PrimitiveArray>(&mut ctx).unwrap();
+        primitive
+            .into_array()
+            .binary(rhs.clone(), Operator::Lt)
+            .unwrap()
+            .execute::<BoolArray>(&mut ctx)
+            .unwrap()
+    });
+}


### PR DESCRIPTION
## Summary

- Adds a divan benchmark `bitpack_compare` in `vortex-fastlanes` that compares an `Operator::Eq` / `Operator::Lt` against an out-of-range constant on a `BitPackedData` array vs. an explicit "decompress, then Arrow compare" baseline that materialises the unpacked `PrimitiveArray` first.
- The constant is chosen as `1 << BW`, just past the packable range, so a future compare-constant kernel can recognise it and short-circuit. Today both arms decompress; this PR establishes a baseline for that follow-up to land against.
- Grid sized for fast runs: `len ∈ {1024, 65536}`, `bit_width ∈ {4, 16}`, Eq + Lt.

The follow-up optimization (out-of-range fast path on `BitPacked`, plus the `bitpack_constant` analytical encoder) is in #PR2-PLACEHOLDER, stacked on this branch. Splitting the bench out lets the speedup PR show concrete numbers against this measured baseline.

## Test plan

- [x] `cargo check -p vortex-fastlanes --benches`
- [ ] `cargo bench -p vortex-fastlanes --bench bitpack_compare` records the slow baseline numbers prior to the follow-up landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)