### PR TITLE
Slice list/list_view elements in duckdb exporter

### DIFF
--- a/vortex-duckdb/cpp/include/duckdb_vx/vector.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector.h
@@ -17,6 +17,9 @@ DUCKDB_INCLUDES_END
 extern "C" {
 #endif
 
+// Create a vector that slices another vector between a pair of offsets [offset, end)
+duckdb_vector duckdb_vx_vector_slice(duckdb_vector ffi_vector, idx_t offset, idx_t end);
+
 /// Slice the vector to a new dictionary vector, using the current vector's values and
 /// the provided selection vector.
 ///

--- a/vortex-duckdb/cpp/vector.cpp
+++ b/vortex-duckdb/cpp/vector.cpp
@@ -10,10 +10,15 @@ DUCKDB_INCLUDES_BEGIN
 #include "duckdb/common/types/vector.hpp"
 DUCKDB_INCLUDES_END
 
-#include "duckdb_vx.h"
 #include "duckdb_vx/vector_buffer.hpp"
 
 using namespace duckdb;
+
+extern "C" duckdb_vector duckdb_vx_vector_slice(duckdb_vector ffi_vector, idx_t offset, idx_t end) {
+    const Vector &vector = *reinterpret_cast<Vector *>(ffi_vector);
+    Vector *const sliced = new Vector(vector, offset, end);
+    return reinterpret_cast<duckdb_vector>(sliced);
+}
 
 extern "C" void duckdb_vx_vector_slice_to_dictionary(duckdb_vector ffi_vector,
                                                      duckdb_selection_vector ffi_sel_vec,

--- a/vortex-duckdb/src/convert/mod.rs
+++ b/vortex-duckdb/src/convert/mod.rs
@@ -7,6 +7,8 @@ mod scalar;
 mod table_filter;
 mod vector;
 
+#[cfg(test)]
+pub use dtype::FromLogicalType;
 pub use dtype::from_duckdb_table;
 pub use expr::try_from_bound_expression;
 pub use scalar::*;

--- a/vortex-duckdb/src/duckdb/vector.rs
+++ b/vortex-duckdb/src/duckdb/vector.rs
@@ -3,6 +3,7 @@
 
 use std::ffi::CStr;
 use std::ffi::c_void;
+use std::ops::Range;
 use std::ptr;
 
 use bitvec::macros::internal::funty::Fundamental;
@@ -61,6 +62,18 @@ impl Vector {
     /// Create a new vector with the given type and capacity.
     pub fn with_capacity(logical_type: &LogicalTypeRef, len: usize) -> Self {
         unsafe { Self::own(cpp::duckdb_create_vector(logical_type.as_ptr(), len as _)) }
+    }
+
+    /// Create a new vector that references other's element range.
+    /// Both vectors share the same buffer.
+    pub fn slice(other: &VectorRef, range: Range<u64>) -> Self {
+        unsafe {
+            Self::own(cpp::duckdb_vx_vector_slice(
+                other.as_ptr(),
+                range.start,
+                range.end,
+            ))
+        }
     }
 }
 
@@ -305,6 +318,10 @@ impl VectorRef {
 
     pub fn array_vector_get_child_mut(&mut self) -> &mut Self {
         unsafe { Vector::borrow_mut(cpp::duckdb_array_vector_get_child(self.as_ptr())) }
+    }
+
+    pub fn list_vector_get_size(&self) -> u64 {
+        unsafe { cpp::duckdb_list_vector_get_size(self.as_ptr()) }
     }
 
     pub fn list_vector_set_size(&self, size: u64) -> VortexResult<()> {

--- a/vortex-duckdb/src/e2e_test/vortex_scan_test.rs
+++ b/vortex-duckdb/src/e2e_test/vortex_scan_test.rs
@@ -982,8 +982,10 @@ fn test_vortex_encodings_roundtrip() {
     assert_eq!(list_entries[4].offset, 10);
 
     // Get child vector and verify actual values
+    let list_child_len = list_vec.list_vector_get_size();
+    assert_eq!(list_child_len, 10);
     let list_child = list_vec.list_vector_get_child();
-    let child_values = list_child.as_slice_with_len::<i32>(10); // 10 total child elements
+    let child_values = list_child.as_slice_with_len::<i32>(list_child_len.as_());
     assert_eq!(child_values, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
     // Verify fixed-size list column (column 9)

--- a/vortex-duckdb/src/exporter/list.rs
+++ b/vortex-duckdb/src/exporter/list.rs
@@ -4,6 +4,7 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use num_traits::AsPrimitive;
 use parking_lot::Mutex;
 use vortex::array::ExecutionCtx;
 use vortex::array::arrays::ListArray;
@@ -13,7 +14,7 @@ use vortex::array::match_each_integer_ptype;
 use vortex::array::validity::Validity;
 use vortex::dtype::IntegerPType;
 use vortex::error::VortexResult;
-use vortex::error::vortex_err;
+use vortex::error::vortex_ensure;
 use vortex::mask::Mask;
 
 use super::ConversionCache;
@@ -110,40 +111,43 @@ impl<O: IntegerPType> ColumnExporter for ListExporter<O> {
         vector: &mut VectorRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
+        if len == 0 {
+            return vector.list_vector_set_size(0);
+        }
+
         // SAFETY: TODO(connor): Pretty sure that `export` needs to be `unsafe`.
         let duckdb_list_views: &mut [cpp::duckdb_list_entry] =
             unsafe { vector.as_slice_mut::<cpp::duckdb_list_entry>(len) };
-        debug_assert_eq!(duckdb_list_views.len(), len);
+        let offsets = &self.offsets.as_slice::<O>()[offset..offset + len + 1];
 
-        if len > 0 {
-            let offsets = &self.offsets.as_slice::<O>()[offset..offset + len + 1];
-            debug_assert_eq!(offsets.len(), len + 1);
+        let offset_start: u64 = offsets[0].as_().as_();
+        let offset_end = offsets[len].as_().as_();
+        vortex_ensure!(offset_end <= self.num_elements as u64);
 
-            for i in 0..len {
-                let offset = offsets[i]
-                    .to_u64()
-                    .ok_or_else(|| vortex_err!("somehow unable to convert an offset to u64"))?;
-                let length = (offsets[i + 1] - offsets[i])
-                    .to_u64()
-                    .ok_or_else(|| vortex_err!("somehow unable to convert an offset to u64"))?;
-
-                debug_assert!(offset + length <= self.num_elements as u64);
-
-                duckdb_list_views[i] = cpp::duckdb_list_entry { offset, length };
-            }
+        for i in 0..len {
+            let offset: u64 = offsets[i].as_().as_();
+            let next_offset: u64 = offsets[i + 1].as_().as_();
+            duckdb_list_views[i] = cpp::duckdb_list_entry {
+                offset: offset - offset_start,
+                length: next_offset - offset,
+            };
         }
 
-        let child = vector.list_vector_get_child_mut();
-        child.reference(&self.duckdb_elements.lock());
+        let sliced = {
+            let elements = &self.duckdb_elements.lock();
+            Vector::slice(elements, offset_start..offset_end)
+        };
 
-        vector.list_vector_set_size(self.num_elements as u64)?;
-
+        let child_len = offset_end - offset_start;
+        vector.list_vector_get_child_mut().reference(&sliced);
+        vector.list_vector_set_size(child_len)?;
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use num_traits::AsPrimitive;
     use vortex::array::IntoArray as _;
     use vortex::array::VortexSessionExecute;
     use vortex::array::arrays::VarBinArray;
@@ -153,52 +157,52 @@ mod tests {
     use vortex::dtype::DType;
     use vortex::dtype::PType;
     use vortex::encodings::runend::RunEnd;
-    use vortex::error::VortexExpect;
     use vortex::error::VortexResult;
 
     use super::*;
     use crate::SESSION;
+    use crate::convert::FromLogicalType;
     use crate::duckdb::DataChunk;
     use crate::duckdb::LogicalType;
     use crate::exporter::new_array_exporter;
 
     #[test]
-    fn test_export_empty_list() {
+    fn test_export_empty_list() -> VortexResult<()> {
         let list = ListArray::try_new(
             Buffer::<u32>::empty().into_array(),
             buffer![0u32].into_array(),
             Validity::AllValid,
-        )
-        .vortex_expect("list creation should succeed")
+        )?
         .into_array();
 
-        let list_type = LogicalType::list_type(LogicalType::uint32())
-            .vortex_expect("LogicalTypeRef creation should succeed for test data");
+        let list_type = LogicalType::list_type(LogicalType::uint32())?;
         let mut chunk = DataChunk::new([list_type]);
 
         let mut ctx = SESSION.create_execution_ctx();
-        new_array_exporter(list, &ConversionCache::default(), &mut ctx)
-            .unwrap()
-            .export(0, 0, chunk.get_vector_mut(0), &mut ctx)
-            .unwrap();
+        new_array_exporter(list, &ConversionCache::default(), &mut ctx)?.export(
+            0,
+            0,
+            chunk.get_vector_mut(0),
+            &mut ctx,
+        )?;
         chunk.set_len(0);
 
         assert_eq!(
-            format!("{}", String::try_from(&*chunk).unwrap()),
+            format!("{}", String::try_from(&*chunk)?),
             r#"Chunk - [1 Columns]
 - FLAT UINTEGER[]: 0 = [ ]
 "#
         );
+        Ok(())
     }
 
     #[test]
-    fn test_export_u64_list() {
+    fn test_export_u64_list() -> VortexResult<()> {
         let list = ListArray::try_new(
             buffer![1u64, 2, 3, 4, 5].into_array(),
             buffer![0u8, 1, 2, 3, 4, 5].into_array(),
             Validity::AllValid,
-        )
-        .vortex_expect("list creation should succeed")
+        )?
         .into_array();
         assert_eq!(
             list.dtype(),
@@ -208,41 +212,92 @@ mod tests {
             )
         );
 
-        let list_type = LogicalType::list_type(LogicalType::uint64())
-            .vortex_expect("LogicalTypeRef creation should succeed for test data");
+        let list_type = LogicalType::list_type(LogicalType::uint64())?;
         let mut chunk = DataChunk::new([list_type]);
 
         let mut ctx = SESSION.create_execution_ctx();
-        new_array_exporter(list, &ConversionCache::default(), &mut ctx)
-            .unwrap()
-            .export(0, 5, chunk.get_vector_mut(0), &mut ctx)
-            .unwrap();
+        new_array_exporter(list, &ConversionCache::default(), &mut ctx)?.export(
+            0,
+            5,
+            chunk.get_vector_mut(0),
+            &mut ctx,
+        )?;
         chunk.set_len(5);
 
         assert_eq!(
-            format!("{}", String::try_from(&*chunk).unwrap()),
+            format!("{}", String::try_from(&*chunk)?),
             r#"Chunk - [1 Columns]
 - FLAT UBIGINT[]: 5 = [ [1], [2], [3], [4], [5]]
 "#
         );
+        Ok(())
     }
 
-    // Ensure runend-compressed list is properly flattened
     #[test]
-    fn test_export_list_with_runend_elements() -> VortexResult<()> {
+    fn test_export_u64_list_two_pass() -> VortexResult<()> {
+        // [1], [2, 8], [3], [4], [5]
+        let elements = buffer![1u64, 2, 8, 3, 4, 5].into_array();
+        let offsets = buffer![0u8, 1, 3, 4, 5, 6].into_array();
+        let list = ListArray::try_new(elements, offsets, Validity::AllValid)?.into_array();
+
+        let u64_type = LogicalType::uint64();
+        let list_type = LogicalType::list_type(u64_type)?;
+        let mut chunk = DataChunk::new([list_type]);
+
         let mut ctx = SESSION.create_execution_ctx();
-        let elements = RunEnd::encode(buffer![100u32, 100, 200, 200, 200].into_array(), &mut ctx)?;
+        let exporter = new_array_exporter(list, &ConversionCache::default(), &mut ctx)?;
 
-        let list = ListArray::try_new(
-            elements.into_array(),
-            buffer![0u32, 2, 5].into_array(),
-            Validity::AllValid,
-        )
-        .vortex_expect("list creation should succeed")
-        .into_array();
+        exporter.export(0, 2, chunk.get_vector_mut(0), &mut ctx)?;
+        chunk.set_len(2);
 
-        let list_type = LogicalType::list_type(LogicalType::uint32())
-            .vortex_expect("LogicalTypeRef creation should succeed for test data");
+        assert_eq!(
+            format!("{}", String::try_from(&*chunk)?),
+            r#"Chunk - [1 Columns]
+- FLAT UBIGINT[]: 2 = [ [1], [2, 8]]
+"#
+        );
+
+        let u64_type = LogicalType::uint64();
+        let list_vec = chunk.get_vector(0);
+        let list_child = list_vec.list_vector_get_child();
+        assert_eq!(
+            DType::from_logical_type(&list_child.logical_type(), false.into())?,
+            DType::from_logical_type(&u64_type, false.into())?
+        );
+        let child_len: usize = list_vec.list_vector_get_size().as_();
+        assert_eq!(child_len, 3);
+        let child_values = list_child.as_slice_with_len::<u64>(child_len);
+        assert_eq!(child_values, [1, 2, 8]);
+
+        exporter.export(2, 3, chunk.get_vector_mut(0), &mut ctx)?;
+        chunk.set_len(3);
+
+        assert_eq!(
+            format!("{}", String::try_from(&*chunk)?),
+            r#"Chunk - [1 Columns]
+- FLAT UBIGINT[]: 3 = [ [3], [4], [5]]
+"#
+        );
+
+        let list_vec = chunk.get_vector(0);
+        let child_len: usize = list_vec.list_vector_get_size().as_();
+        assert_eq!(child_len, 3);
+        let list_child = list_vec.list_vector_get_child();
+        let child_values = list_child.as_slice_with_len::<u64>(child_len);
+        assert_eq!(child_values, [3, 4, 5]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_export_runend_list() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let elements_buffer = buffer![100f32, 100f32, 200f32, 200f32, 200f32].into_array();
+        let elements = RunEnd::encode(elements_buffer, &mut ctx)?.into_array();
+        let offsets = buffer![0u32, 2, 5].into_array();
+        let list = ListArray::try_new(elements, offsets, Validity::AllValid)?.into_array();
+
+        let list_type = LogicalType::list_type(LogicalType::float32())?;
         let mut chunk = DataChunk::new([list_type]);
 
         new_array_exporter(list, &ConversionCache::default(), &mut ctx)?.export(
@@ -256,7 +311,7 @@ mod tests {
         assert_eq!(
             format!("{}", String::try_from(&*chunk)?),
             r#"Chunk - [1 Columns]
-- FLAT UINTEGER[]: 2 = [ [100, 100], [200, 200, 200]]
+- FLAT FLOAT[]: 2 = [ [100.0, 100.0], [200.0, 200.0, 200.0]]
 "#
         );
 
@@ -264,7 +319,7 @@ mod tests {
     }
 
     #[test]
-    fn test_export_non_empty_list_of_strings() {
+    fn test_export_string_list() -> VortexResult<()> {
         let list = ListArray::try_new(
             <VarBinArray as FromIterator<_>>::from_iter([
                 Some("abc"),
@@ -275,26 +330,28 @@ mod tests {
             .into_array(),
             buffer![0u8, 1, 2, 3, 4].into_array(),
             Validity::from_iter([true, true, false, true]),
-        )
-        .vortex_expect("list creation should succeed")
+        )?
         .into_array();
 
-        let list_type = LogicalType::list_type(LogicalType::varchar())
-            .vortex_expect("LogicalTypeRef creation should succeed for test data");
+        let list_type = LogicalType::list_type(LogicalType::varchar())?;
         let mut chunk = DataChunk::new([list_type]);
 
         let mut ctx = SESSION.create_execution_ctx();
-        new_array_exporter(list, &ConversionCache::default(), &mut ctx)
-            .unwrap()
-            .export(0, 4, chunk.get_vector_mut(0), &mut ctx)
-            .unwrap();
+        new_array_exporter(list, &ConversionCache::default(), &mut ctx)?.export(
+            0,
+            4,
+            chunk.get_vector_mut(0),
+            &mut ctx,
+        )?;
         chunk.set_len(4);
 
         assert_eq!(
-            format!("{}", String::try_from(&*chunk).unwrap()),
+            format!("{}", String::try_from(&*chunk)?),
             r#"Chunk - [1 Columns]
 - FLAT VARCHAR[]: 4 = [ [abc], [def], NULL, [ghi]]
 "#
         );
+
+        Ok(())
     }
 }

--- a/vortex-duckdb/src/exporter/list_view.rs
+++ b/vortex-duckdb/src/exporter/list_view.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::cmp::max;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use num_traits::AsPrimitive;
 use parking_lot::Mutex;
 use vortex::array::ExecutionCtx;
 use vortex::array::arrays::ListViewArray;
@@ -12,8 +14,9 @@ use vortex::array::arrays::listview::ListViewDataParts;
 use vortex::array::match_each_integer_ptype;
 use vortex::array::validity::Validity;
 use vortex::dtype::IntegerPType;
+use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
-use vortex::error::vortex_err;
+use vortex::error::vortex_ensure;
 use vortex::mask::Mask;
 
 use super::ConversionCache;
@@ -118,34 +121,44 @@ impl<O: IntegerPType, S: IntegerPType> ColumnExporter for ListViewExporter<O, S>
         vector: &mut VectorRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
+        if len == 0 {
+            return vector.list_vector_set_size(0);
+        }
         let offsets = &self.offsets.as_slice::<O>()[offset..offset + len];
         let sizes = &self.sizes.as_slice::<S>()[offset..offset + len];
-        debug_assert_eq!(offsets.len(), len);
-        debug_assert_eq!(sizes.len(), len);
 
         // SAFETY: TODO(connor): Pretty sure that `export` needs to be `unsafe`.
         let duckdb_list_views: &mut [cpp::duckdb_list_entry] =
             unsafe { vector.as_slice_mut::<cpp::duckdb_list_entry>(len) };
-        debug_assert_eq!(duckdb_list_views.len(), len);
 
+        let offset_start: u64 = offsets
+            .iter()
+            .min()
+            .vortex_expect("offsets array is empty")
+            .as_()
+            .as_();
+
+        let mut offset_end: u64 = 0;
         for i in 0..len {
-            let offset = offsets[i]
-                .to_u64()
-                .ok_or_else(|| vortex_err!("somehow unable to convert an offset to u64"))?;
-            let length = sizes[i]
-                .to_u64()
-                .ok_or_else(|| vortex_err!("somehow unable to convert an offset to u64"))?;
-
-            debug_assert!(offset + length <= self.num_elements as u64);
-
-            duckdb_list_views[i] = cpp::duckdb_list_entry { offset, length };
+            let offset: u64 = offsets[i].as_().as_();
+            let length: u64 = sizes[i].as_().as_();
+            offset_end = max(offset_end, offset + length);
+            duckdb_list_views[i] = cpp::duckdb_list_entry {
+                offset: offset - offset_start,
+                length,
+            };
         }
+        vortex_ensure!(offset_start <= offset_end);
+        vortex_ensure!(offset_end <= self.num_elements as u64);
 
-        let child = vector.list_vector_get_child_mut();
-        child.reference(&self.duckdb_elements.lock());
+        let sliced = {
+            let elements = &self.duckdb_elements.lock();
+            Vector::slice(elements, offset_start..offset_end)
+        };
 
-        vector.list_vector_set_size(self.num_elements as u64)?;
-
+        let child_len = offset_end - offset_start;
+        vector.list_vector_get_child_mut().reference(&sliced);
+        vector.list_vector_set_size(child_len)?;
         Ok(())
     }
 }
@@ -158,7 +171,7 @@ mod tests {
     use vortex::array::validity::Validity;
     use vortex::buffer::Buffer;
     use vortex::buffer::buffer;
-    use vortex::error::VortexExpect;
+    use vortex_runend::RunEnd;
 
     use super::*;
     use crate::SESSION;
@@ -167,104 +180,164 @@ mod tests {
     use crate::exporter::new_array_exporter;
 
     #[test]
-    fn test_export_empty_list() {
-        let list = unsafe {
-            ListViewArray::new_unchecked(
-                Buffer::<u32>::empty().into_array(),
-                Buffer::<u32>::empty().into_array(),
-                Buffer::<u32>::empty().into_array(),
-                Validity::AllValid,
-            )
-            .with_zero_copy_to_list(true)
-        }
-        .into_array();
+    fn test_export_empty_list() -> VortexResult<()> {
+        let elements = Buffer::<u32>::empty().into_array();
+        let offsets = Buffer::<u32>::empty().into_array();
+        let sizes = Buffer::<u32>::empty().into_array();
+        let list = ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid)?;
+        let list = unsafe { list.with_zero_copy_to_list(true) };
+        let list = list.into_array();
 
-        let list_type = LogicalType::list_type(LogicalType::uint32())
-            .vortex_expect("LogicalTypeRef creation should succeed for test data");
+        let list_type = LogicalType::list_type(LogicalType::uint32())?;
         let mut chunk = DataChunk::new([list_type]);
 
         let mut ctx = SESSION.create_execution_ctx();
-        new_array_exporter(list, &ConversionCache::default(), &mut ctx)
-            .unwrap()
-            .export(0, 0, chunk.get_vector_mut(0), &mut ctx)
-            .unwrap();
+        new_array_exporter(list, &ConversionCache::default(), &mut ctx)?.export(
+            0,
+            0,
+            chunk.get_vector_mut(0),
+            &mut ctx,
+        )?;
         chunk.set_len(0);
 
         assert_eq!(
-            format!("{}", String::try_from(&*chunk).unwrap()),
+            format!("{}", String::try_from(&*chunk)?),
             r#"Chunk - [1 Columns]
 - FLAT UINTEGER[]: 0 = [ ]
 "#
         );
+
+        Ok(())
     }
 
     #[test]
-    fn test_export_non_empty_list_with_preceding_and_trailing_garbage() {
-        let list = unsafe {
-            ListViewArray::new_unchecked(
-                buffer![0, 1, 2, 3, 4, 5].into_array(),
-                buffer![1u8, 2, 3].into_array(),
-                buffer![1u8, 1, 1].into_array(),
-                Validity::AllValid,
-            )
-            .with_zero_copy_to_list(true)
-        }
-        .into_array();
+    fn test_export_list_non_ordered_elements() -> VortexResult<()> {
+        let elements = buffer![0, 1, 2, 3, 4, 5].into_array();
+        let offsets = buffer![1u8, 0, 3].into_array();
+        let sizes = buffer![1u8, 1, 1].into_array();
+        let list =
+            ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid)?.into_array();
 
-        let list_type = LogicalType::list_type(LogicalType::int32())
-            .vortex_expect("LogicalTypeRef creation should succeed for test data");
+        let list_type = LogicalType::list_type(LogicalType::int32())?;
         let mut chunk = DataChunk::new([list_type]);
 
         let mut ctx = SESSION.create_execution_ctx();
-        new_array_exporter(list, &ConversionCache::default(), &mut ctx)
-            .unwrap()
-            .export(0, 3, chunk.get_vector_mut(0), &mut ctx)
-            .unwrap();
+        new_array_exporter(list, &ConversionCache::default(), &mut ctx)?.export(
+            0,
+            3,
+            chunk.get_vector_mut(0),
+            &mut ctx,
+        )?;
         chunk.set_len(3);
 
         assert_eq!(
-            format!("{}", String::try_from(&*chunk).unwrap()),
+            format!("{}", String::try_from(&*chunk)?),
+            r#"Chunk - [1 Columns]
+- FLAT INTEGER[]: 3 = [ [1], [0], [3]]
+"#
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_export_non_empty_list_with_preceding_and_trailing_garbage() -> VortexResult<()> {
+        let elements = buffer![0, 1, 2, 3, 4, 5].into_array();
+        let offsets = buffer![1u8, 2, 3].into_array();
+        let sizes = buffer![1u8, 1, 1].into_array();
+        let list = ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid)?;
+        let list = unsafe { list.with_zero_copy_to_list(true) };
+        let list = list.into_array();
+
+        let list_type = LogicalType::list_type(LogicalType::int32())?;
+        let mut chunk = DataChunk::new([list_type]);
+
+        let mut ctx = SESSION.create_execution_ctx();
+        new_array_exporter(list, &ConversionCache::default(), &mut ctx)?.export(
+            0,
+            3,
+            chunk.get_vector_mut(0),
+            &mut ctx,
+        )?;
+        chunk.set_len(3);
+
+        assert_eq!(
+            format!("{}", String::try_from(&*chunk)?),
             r#"Chunk - [1 Columns]
 - FLAT INTEGER[]: 3 = [ [1], [2], [3]]
 "#
         );
+
+        Ok(())
     }
 
     #[test]
-    fn test_export_non_empty_list_of_strings() {
-        let list = unsafe {
-            ListViewArray::new_unchecked(
-                <VarBinArray as FromIterator<_>>::from_iter([
-                    Some("abc"),
-                    Some("def"),
-                    None,
-                    Some("ghi"),
-                ])
-                .into_array(),
-                buffer![0u8, 0, 3, 4].into_array(),
-                buffer![0u8, 3, 1, 0].into_array(),
-                Validity::from_iter([true, true, false, true]),
-            )
-            .with_zero_copy_to_list(true)
-        }
+    fn test_export_string_list() -> VortexResult<()> {
+        let elements = <VarBinArray as FromIterator<_>>::from_iter([
+            Some("abc"),
+            Some("def"),
+            None,
+            Some("ghi"),
+        ])
         .into_array();
+        let offsets = buffer![0u8, 0, 3, 4].into_array();
+        let sizes = buffer![0u8, 3, 1, 0].into_array();
+        let validities = Validity::from_iter([true, true, false, true]);
+        let list = ListViewArray::try_new(elements, offsets, sizes, validities)?;
+        let list = unsafe { list.with_zero_copy_to_list(true) };
+        let list = list.into_array();
 
-        let list_type = LogicalType::list_type(LogicalType::varchar())
-            .vortex_expect("LogicalTypeRef creation should succeed for test data");
+        let list_type = LogicalType::list_type(LogicalType::varchar())?;
         let mut chunk = DataChunk::new([list_type]);
 
         let mut ctx = SESSION.create_execution_ctx();
-        new_array_exporter(list, &ConversionCache::default(), &mut ctx)
-            .unwrap()
-            .export(0, 4, chunk.get_vector_mut(0), &mut ctx)
-            .unwrap();
+        new_array_exporter(list, &ConversionCache::default(), &mut ctx)?.export(
+            0,
+            4,
+            chunk.get_vector_mut(0),
+            &mut ctx,
+        )?;
         chunk.set_len(4);
 
         assert_eq!(
-            format!("{}", String::try_from(&*chunk).unwrap()),
+            format!("{}", String::try_from(&*chunk)?),
             r#"Chunk - [1 Columns]
 - FLAT VARCHAR[]: 4 = [ [], [abc, def, NULL], NULL, []]
 "#
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_export_runend_list() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let elements_buffer = buffer![100f32, 101f32, 200f32, 202f32, 203f32].into_array();
+        let elements = RunEnd::encode(elements_buffer, &mut ctx)?.into_array();
+
+        let offsets = buffer![1u32, 2, 4].into_array();
+        let sizes = buffer![1u8, 2, 1].into_array();
+        let list =
+            ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid)?.into_array();
+
+        let list_type = LogicalType::list_type(LogicalType::float32())?;
+        let mut chunk = DataChunk::new([list_type]);
+
+        new_array_exporter(list, &ConversionCache::default(), &mut ctx)?.export(
+            0,
+            3,
+            chunk.get_vector_mut(0),
+            &mut ctx,
+        )?;
+        chunk.set_len(3);
+
+        assert_eq!(
+            format!("{}", String::try_from(&*chunk)?),
+            r#"Chunk - [1 Columns]
+- FLAT FLOAT[]: 3 = [ [101.0], [200.0, 202.0], [203.0]]
+"#
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
We always reference the underlying vector for every list/list_view chunk
export. This means, for a 1M vector and export of first element, the underlying
vector would still be 1M.
This PR slices the underlying vector for list and list views exporter to only
contain requested elements by offsets.
