### PR TITLE
Type pushdown for duckdb

### DIFF
--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -23,7 +23,7 @@ const DEFAULT_DUCKDB_VERSION: &str = "1.5.3";
 
 const BUILD_ARTIFACTS: [&str; 3] = ["libduckdb.dylib", "libduckdb.so", "libduckdb_static.a"];
 
-const SOURCE_FILES: [&str; 17] = [
+const SOURCE_FILES: [&str; 18] = [
     "cpp/client_context.cpp",
     "cpp/config.cpp",
     "cpp/copy_function.cpp",
@@ -33,6 +33,7 @@ const SOURCE_FILES: [&str; 17] = [
     "cpp/expr.cpp",
     "cpp/file_system.cpp",
     "cpp/logical_type.cpp",
+    "cpp/optimizer.cpp",
     "cpp/replacement_scan.cpp",
     "cpp/reusable_dict.cpp",
     "cpp/scalar_function.cpp",

--- a/vortex-duckdb/cpp/include/duckdb_vx.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "duckdb_vx/client_context.h"
+#include "duckdb_vx/optimizer.h"
 #include "duckdb_vx/config.h"
 #include "duckdb_vx/copy_function.h"
 #include "duckdb_vx/data.h"

--- a/vortex-duckdb/cpp/include/duckdb_vx/optimizer.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/optimizer.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+#pragma once
+
+#include "duckdb_vx/duckdb_diagnostics.h"
+DUCKDB_INCLUDES_BEGIN
+#include "duckdb.h"
+DUCKDB_INCLUDES_END
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+duckdb_state duckdb_vx_optimizer_extension_register(duckdb_database ffi_db);
+
+#ifdef __cplusplus
+}
+#endif

--- a/vortex-duckdb/cpp/include/duckdb_vx/table_function.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/table_function.h
@@ -125,6 +125,7 @@ typedef struct {
 
     void (*cardinality)(void *bind_data, duckdb_vx_node_statistics *node_stats_out);
 
+    void (*pushdown_column_type)(void *bind_data, idx_t id, duckdb_logical_type type);
     bool (*pushdown_complex_filter)(void *bind_data, duckdb_vx_expr expr, duckdb_vx_error *error_out);
 
     void (*to_string)(void *bind_data, duckdb_vx_string_map map);

--- a/vortex-duckdb/cpp/optimizer.cpp
+++ b/vortex-duckdb/cpp/optimizer.cpp
@@ -18,135 +18,181 @@ using namespace duckdb;
  */
 
 // Collect CAST(bound_column, T) patterns where bound_column binds into given GET's index.
-void CollectCastTypes(const Expression &expr, idx_t index, const vector<ColumnIndex> &column_ids,
-                      unordered_map<column_t, LogicalType> &cast_map, unordered_set<column_t> &conflicts) {
-	auto collect_children = [&] {
-		ExpressionIterator::EnumerateChildren(
-		    expr, [&](const Expression &child) { CollectCastTypes(child, index, column_ids, cast_map, conflicts); });
-	};
+// A bare bound_column ref (outside any CAST) is recorded as a conflict: the column is
+// consumed at its original type and its scan type must not change.
+static void CollectCastTypes(const Expression &expr,
+                             idx_t index,
+                             const vector<ColumnIndex> &column_ids,
+                             unordered_map<column_t, LogicalType> &cast_map,
+                             unordered_set<column_t> &conflicts) {
+    auto collect_children = [&] {
+        ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
+            CollectCastTypes(child, index, column_ids, cast_map, conflicts);
+        });
+    };
 
-	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CAST) {
-		return collect_children();
-	}
-	auto &bound_cast = expr.Cast<BoundCastExpression>();
+    // Bare column ref pointing to this GET: the column is used at its original type.
+    if (expr.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+        auto &colref = expr.Cast<BoundColumnRefExpression>();
+        if (colref.depth == 0 && colref.binding.table_index == index) {
+            const column_t proj_id = colref.binding.column_index;
+            if (!IsVirtualColumn(proj_id) && proj_id < column_ids.size()) {
+                conflicts.insert(column_ids[proj_id].GetPrimaryIndex());
+            }
+        }
+        return;
+    }
 
-	if (bound_cast.child->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
-		return collect_children();
-	}
-	auto &bound_column = bound_cast.child->Cast<BoundColumnRefExpression>();
+    if (expr.GetExpressionClass() != ExpressionClass::BOUND_CAST) {
+        return collect_children();
+    }
+    auto &bound_cast = expr.Cast<BoundCastExpression>();
 
-	if (bound_column.depth > 0 || bound_column.binding.table_index != index) {
-		return collect_children();
-	}
+    if (bound_cast.child->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+        return collect_children();
+    }
+    auto &bound_column = bound_cast.child->Cast<BoundColumnRefExpression>();
 
-	// We are in a leaf
-	const column_t projection_id = bound_column.binding.column_index;
-	if (IsVirtualColumn(projection_id)) {
-		return;
-	}
-	D_ASSERT(projection_id < column_ids.size());
-	const column_t column_id = column_ids[projection_id].GetPrimaryIndex();
-	if (auto it = cast_map.find(column_id); it == cast_map.end()) {
-		cast_map.emplace(column_id, bound_cast.return_type);
-	} else if (it->second != bound_cast.return_type) {
-		conflicts.insert(column_id);
-	}
+    if (bound_column.depth > 0 || bound_column.binding.table_index != index) {
+        return collect_children();
+    }
+
+    // We are in a leaf: CAST(colref, T) where colref binds into this GET.
+    const column_t projection_id = bound_column.binding.column_index;
+    if (IsVirtualColumn(projection_id)) {
+        return;
+    }
+    D_ASSERT(projection_id < column_ids.size());
+    const column_t column_id = column_ids[projection_id].GetPrimaryIndex();
+    if (auto it = cast_map.find(column_id); it == cast_map.end()) {
+        cast_map.emplace(column_id, bound_cast.return_type);
+    } else if (it->second != bound_cast.return_type) {
+        conflicts.insert(column_id);
+    }
 }
 
 // Replace every CAST(bound_column, T) with a bare bound_column at type T when T
 // is listed in projection_cast.
-static void ReplaceCastTypes(unique_ptr<Expression> &expr, idx_t index,
+static void ReplaceCastTypes(unique_ptr<Expression> &expr,
+                             idx_t index,
                              const unordered_map<column_t, LogicalType> &projection_cast) {
-	auto replace_children = [&] {
-		ExpressionIterator::EnumerateChildren(
-		    *expr, [&](unique_ptr<Expression> &child) { ReplaceCastTypes(child, index, projection_cast); });
-	};
+    auto replace_children = [&] {
+        ExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<Expression> &child) {
+            ReplaceCastTypes(child, index, projection_cast);
+        });
+    };
 
-	if (expr->GetExpressionClass() != ExpressionClass::BOUND_CAST) {
-		return replace_children();
-	}
-	auto &bound_cast = expr->Cast<BoundCastExpression>();
+    if (expr->GetExpressionClass() != ExpressionClass::BOUND_CAST) {
+        return replace_children();
+    }
+    auto &bound_cast = expr->Cast<BoundCastExpression>();
 
-	if (bound_cast.child->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
-		return replace_children();
-	}
-	auto &bound_column = bound_cast.child->Cast<BoundColumnRefExpression>();
+    if (bound_cast.child->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+        return replace_children();
+    }
+    auto &bound_column = bound_cast.child->Cast<BoundColumnRefExpression>();
 
-	if (bound_column.depth > 0 || bound_column.binding.table_index != index) {
-		return replace_children();
-	}
+    if (bound_column.depth > 0 || bound_column.binding.table_index != index) {
+        return replace_children();
+    }
 
-	const column_t projection_id = bound_column.binding.column_index;
-	auto it = projection_cast.find(projection_id);
-	if (it == projection_cast.end() || it->second != bound_cast.return_type) {
-		return replace_children();
-	}
+    const column_t projection_id = bound_column.binding.column_index;
+    auto it = projection_cast.find(projection_id);
+    if (it == projection_cast.end() || it->second != bound_cast.return_type) {
+        return replace_children();
+    }
 
-	expr = make_uniq<BoundColumnRefExpression>(it->second, bound_column.binding);
+    expr = make_uniq<BoundColumnRefExpression>(it->second, bound_column.binding);
 }
 
-// Walk the plan bottom-up and, for each node whose direct child is a GET that
-// supports type_pushdown, push every CAST(colref, T) found in that node's
-// expressions into the GET so the scan produces T directly.
-unique_ptr<LogicalOperator> TryPushdownCastTypes(ClientContext& context, unique_ptr<LogicalOperator> op) {
-	for (auto &child : op->children) {
-		child = TryPushdownCastTypes(context, std::move(child));
-	}
+// Collect cast-type candidates from every operator in the plan tree.
+static void CollectFromPlan(LogicalOperator &op,
+                            idx_t index,
+                            const vector<ColumnIndex> &column_ids,
+                            unordered_map<column_t, LogicalType> &cast_map,
+                            unordered_set<column_t> &conflicts) {
+    LogicalOperatorVisitor::EnumerateExpressions(op, [&](unique_ptr<Expression> *expr_ptr) {
+        CollectCastTypes(**expr_ptr, index, column_ids, cast_map, conflicts);
+    });
+    for (auto &child : op.children) {
+        CollectFromPlan(*child, index, column_ids, cast_map, conflicts);
+    }
+}
 
-	for (const auto &child : op->children) {
-		if (child->type != LogicalOperatorType::LOGICAL_GET) {
-			continue;
-		}
-		auto &get = child->Cast<LogicalGet>();
-		if (!get.function.type_pushdown) {
-			continue;
-		}
+// Replace cast expressions in every operator in the plan tree.
+static void
+ReplaceInPlan(LogicalOperator &op, idx_t index, const unordered_map<column_t, LogicalType> &proj_to_type) {
+    LogicalOperatorVisitor::EnumerateExpressions(op, [&](unique_ptr<Expression> *expr_ptr) {
+        ReplaceCastTypes(*expr_ptr, index, proj_to_type);
+    });
+    for (auto &child : op.children) {
+        ReplaceInPlan(*child, index, proj_to_type);
+    }
+}
 
-		const vector<ColumnIndex> &column_ids = get.GetColumnIds();
-		const idx_t index = get.table_index;
-		unordered_map<column_t, LogicalType> cast_map;
-		unordered_set<column_t> conflicts;
+static void FindGetWithTypePushdown(LogicalOperator &op, vector<LogicalGet *> &gets) {
+    if (op.type == LogicalOperatorType::LOGICAL_GET) {
+        auto &get = op.Cast<LogicalGet>();
+        if (get.function.type_pushdown) {
+            gets.push_back(&get);
+        }
+    }
+    for (auto &child : op.children) {
+        FindGetWithTypePushdown(*child, gets);
+    }
+}
 
-		LogicalOperatorVisitor::EnumerateExpressions(*op, [&](unique_ptr<Expression> *expr_ptr) {
-			CollectCastTypes(**expr_ptr, index, column_ids, cast_map, conflicts);
-		});
+// For each GET that supports type_pushdown, collect CAST(col, T) patterns from
+// the *entire* plan.  Columns that appear bare (outside any cast) or are cast to
+// multiple conflicting types are excluded.  The surviving types are pushed into
+// the GET's bind_data and returned_types, and the redundant CASTs are stripped
+// from all operator expressions throughout the plan.
+static unique_ptr<LogicalOperator> TryPushdownCastTypes(ClientContext &context,
+                                                        unique_ptr<LogicalOperator> plan) {
+    vector<LogicalGet *> gets;
+    FindGetWithTypePushdown(*plan, gets);
 
-		for (column_t col_id : conflicts) {
-			cast_map.erase(col_id);
-		}
-		if (cast_map.empty()) {
-			continue;
-		}
+    for (LogicalGet *get : gets) {
+        const vector<ColumnIndex> &column_ids = get->GetColumnIds();
+        const idx_t index = get->table_index;
+        unordered_map<column_t, LogicalType> cast_map;
+        unordered_set<column_t> conflicts;
 
-		get.function.type_pushdown(context, get.bind_data, cast_map);
-		for (const auto &[col_id, new_type] : cast_map) {
-			get.returned_types[col_id] = new_type;
-		}
+        CollectFromPlan(*plan, index, column_ids, cast_map, conflicts);
 
-		unordered_map<idx_t, LogicalType> proj_to_type;
-		for (idx_t i = 0; i < column_ids.size(); i++) {
-			const column_t col_idx = column_ids[i].GetPrimaryIndex();
-			if (auto it = cast_map.find(col_idx); it != cast_map.end()) {
-				proj_to_type[i] = it->second;
-			}
-		}
+        for (column_t col_id : conflicts) {
+            cast_map.erase(col_id);
+        }
+        if (cast_map.empty()) {
+            continue;
+        }
 
-		LogicalOperatorVisitor::EnumerateExpressions(
-		    *op, [&](unique_ptr<Expression> *expr_ptr) { ReplaceCastTypes(*expr_ptr, get.table_index, proj_to_type); });
-	}
+        get->function.type_pushdown(context, get->bind_data, cast_map);
+        for (const auto &[col_id, new_type] : cast_map) {
+            get->returned_types[col_id] = new_type;
+        }
 
-	return op;
+        unordered_map<idx_t, LogicalType> proj_to_type;
+        for (idx_t i = 0; i < column_ids.size(); i++) {
+            const column_t col_idx = column_ids[i].GetPrimaryIndex();
+            if (auto it = cast_map.find(col_idx); it != cast_map.end()) {
+                proj_to_type[i] = it->second;
+            }
+        }
+
+        ReplaceInPlan(*plan, index, proj_to_type);
+    }
+
+    return plan;
 }
 
 static void VortexOptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
     plan = TryPushdownCastTypes(input.context, std::move(plan));
 }
 
-class VortexOptimizerExtension final : public OptimizerExtension {
-public:
-	VortexOptimizerExtension() {
-		optimize_function = VortexOptimizeFunction;
-	}
+struct VortexOptimizerExtension final : OptimizerExtension {
+    VortexOptimizerExtension() : OptimizerExtension(VortexOptimizeFunction, nullptr, {}) {
+    }
 };
 
 extern "C" duckdb_state duckdb_vx_optimizer_extension_register(duckdb_database ffi_db) {

--- a/vortex-duckdb/cpp/optimizer.cpp
+++ b/vortex-duckdb/cpp/optimizer.cpp
@@ -1,0 +1,164 @@
+#include "duckdb_vx/optimizer.h"
+#include "duckdb_vx/duckdb_diagnostics.h"
+DUCKDB_INCLUDES_BEGIN
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/main/capi/capi_internal.hpp"
+#include "duckdb/optimizer/optimizer_extension.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+DUCKDB_INCLUDES_END
+
+using namespace duckdb;
+
+/*
+ * Until https://github.com/duckdb/duckdb/pull/22788 is merged, and Duckdb
+ * version used in Vortex is bumped to include this, we'll have our separate
+ * optimizer pass pushing down types to Vortex.
+ */
+
+// Collect CAST(bound_column, T) patterns where bound_column binds into given GET's index.
+void CollectCastTypes(const Expression &expr, idx_t index, const vector<ColumnIndex> &column_ids,
+                      unordered_map<column_t, LogicalType> &cast_map, unordered_set<column_t> &conflicts) {
+	auto collect_children = [&] {
+		ExpressionIterator::EnumerateChildren(
+		    expr, [&](const Expression &child) { CollectCastTypes(child, index, column_ids, cast_map, conflicts); });
+	};
+
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CAST) {
+		return collect_children();
+	}
+	auto &bound_cast = expr.Cast<BoundCastExpression>();
+
+	if (bound_cast.child->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return collect_children();
+	}
+	auto &bound_column = bound_cast.child->Cast<BoundColumnRefExpression>();
+
+	if (bound_column.depth > 0 || bound_column.binding.table_index != index) {
+		return collect_children();
+	}
+
+	// We are in a leaf
+	const column_t projection_id = bound_column.binding.column_index;
+	if (IsVirtualColumn(projection_id)) {
+		return;
+	}
+	D_ASSERT(projection_id < column_ids.size());
+	const column_t column_id = column_ids[projection_id].GetPrimaryIndex();
+	if (auto it = cast_map.find(column_id); it == cast_map.end()) {
+		cast_map.emplace(column_id, bound_cast.return_type);
+	} else if (it->second != bound_cast.return_type) {
+		conflicts.insert(column_id);
+	}
+}
+
+// Replace every CAST(bound_column, T) with a bare bound_column at type T when T
+// is listed in projection_cast.
+static void ReplaceCastTypes(unique_ptr<Expression> &expr, idx_t index,
+                             const unordered_map<column_t, LogicalType> &projection_cast) {
+	auto replace_children = [&] {
+		ExpressionIterator::EnumerateChildren(
+		    *expr, [&](unique_ptr<Expression> &child) { ReplaceCastTypes(child, index, projection_cast); });
+	};
+
+	if (expr->GetExpressionClass() != ExpressionClass::BOUND_CAST) {
+		return replace_children();
+	}
+	auto &bound_cast = expr->Cast<BoundCastExpression>();
+
+	if (bound_cast.child->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+		return replace_children();
+	}
+	auto &bound_column = bound_cast.child->Cast<BoundColumnRefExpression>();
+
+	if (bound_column.depth > 0 || bound_column.binding.table_index != index) {
+		return replace_children();
+	}
+
+	const column_t projection_id = bound_column.binding.column_index;
+	auto it = projection_cast.find(projection_id);
+	if (it == projection_cast.end() || it->second != bound_cast.return_type) {
+		return replace_children();
+	}
+
+	expr = make_uniq<BoundColumnRefExpression>(it->second, bound_column.binding);
+}
+
+// Walk the plan bottom-up and, for each node whose direct child is a GET that
+// supports type_pushdown, push every CAST(colref, T) found in that node's
+// expressions into the GET so the scan produces T directly.
+unique_ptr<LogicalOperator> TryPushdownCastTypes(ClientContext& context, unique_ptr<LogicalOperator> op) {
+	for (auto &child : op->children) {
+		child = TryPushdownCastTypes(context, std::move(child));
+	}
+
+	for (const auto &child : op->children) {
+		if (child->type != LogicalOperatorType::LOGICAL_GET) {
+			continue;
+		}
+		auto &get = child->Cast<LogicalGet>();
+		if (!get.function.type_pushdown) {
+			continue;
+		}
+
+		const vector<ColumnIndex> &column_ids = get.GetColumnIds();
+		const idx_t index = get.table_index;
+		unordered_map<column_t, LogicalType> cast_map;
+		unordered_set<column_t> conflicts;
+
+		LogicalOperatorVisitor::EnumerateExpressions(*op, [&](unique_ptr<Expression> *expr_ptr) {
+			CollectCastTypes(**expr_ptr, index, column_ids, cast_map, conflicts);
+		});
+
+		for (column_t col_id : conflicts) {
+			cast_map.erase(col_id);
+		}
+		if (cast_map.empty()) {
+			continue;
+		}
+
+		get.function.type_pushdown(context, get.bind_data, cast_map);
+		for (const auto &[col_id, new_type] : cast_map) {
+			get.returned_types[col_id] = new_type;
+		}
+
+		unordered_map<idx_t, LogicalType> proj_to_type;
+		for (idx_t i = 0; i < column_ids.size(); i++) {
+			const column_t col_idx = column_ids[i].GetPrimaryIndex();
+			if (auto it = cast_map.find(col_idx); it != cast_map.end()) {
+				proj_to_type[i] = it->second;
+			}
+		}
+
+		LogicalOperatorVisitor::EnumerateExpressions(
+		    *op, [&](unique_ptr<Expression> *expr_ptr) { ReplaceCastTypes(*expr_ptr, get.table_index, proj_to_type); });
+	}
+
+	return op;
+}
+
+static void VortexOptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
+    plan = TryPushdownCastTypes(input.context, std::move(plan));
+}
+
+class VortexOptimizerExtension final : public OptimizerExtension {
+public:
+	VortexOptimizerExtension() {
+		optimize_function = VortexOptimizeFunction;
+	}
+};
+
+extern "C" duckdb_state duckdb_vx_optimizer_extension_register(duckdb_database ffi_db) {
+    D_ASSERT(ffi_db);
+    const DatabaseWrapper &wrapper = *reinterpret_cast<DatabaseWrapper *>(ffi_db);
+    DatabaseInstance &db = *wrapper.database->instance;
+    try {
+        DBConfig::GetConfig(db).GetCallbackManager().Register(VortexOptimizerExtension());
+    } catch (const std::exception &e) {
+        ErrorData data(e);
+        DUCKDB_LOG_ERROR(db, "Failed to create Vortex optimizer extension:\t" + data.Message());
+        return DuckDBError;
+    }
+    return DuckDBSuccess;
+}

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -263,6 +263,20 @@ void function(ClientContext &, TableFunctionInput &input, DataChunk &output) {
     }
 }
 
+void type_pushdown(ClientContext &, optional_ptr<FunctionData> bind_data,
+                    const unordered_map<idx_t, LogicalType> &new_column_types) {
+    const auto &bind = bind_data->Cast<CTableBindData>();
+    void *const ffi_bind = bind.ffi_data->DataPtr();
+    for (const auto& [id, type] : new_column_types) {
+        const duckdb_logical_type casted_type = reinterpret_cast<duckdb_logical_type>(
+            // This is a flaw of duckdb api which doesn't allow passing const
+            // LogicalTypes. We guarantee this variable won't be mutated on
+            // Rust side
+            const_cast<LogicalType*>(&type));
+        bind.info.vtab.pushdown_column_type(ffi_bind, id, casted_type);
+    }
+}
+
 void c_pushdown_complex_filter(ClientContext &,
                                LogicalGet &,
                                FunctionData *bind_data,
@@ -394,6 +408,7 @@ extern "C" duckdb_state duckdb_vx_tfunc_register(duckdb_database ffi_db, const d
     tf.filter_prune = true;
     tf.sampling_pushdown = false;
 
+    tf.type_pushdown = type_pushdown;
     tf.pushdown_complex_filter = c_pushdown_complex_filter;
     tf.cardinality = c_cardinality;
     tf.get_partition_info = get_partition_info;

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -408,7 +408,7 @@ extern "C" duckdb_state duckdb_vx_tfunc_register(duckdb_database ffi_db, const d
     tf.filter_prune = true;
     tf.sampling_pushdown = false;
 
-    //tf.type_pushdown = type_pushdown;
+    tf.type_pushdown = type_pushdown;
     tf.pushdown_complex_filter = c_pushdown_complex_filter;
     tf.cardinality = c_cardinality;
     tf.get_partition_info = get_partition_info;

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -408,7 +408,7 @@ extern "C" duckdb_state duckdb_vx_tfunc_register(duckdb_database ffi_db, const d
     tf.filter_prune = true;
     tf.sampling_pushdown = false;
 
-    tf.type_pushdown = type_pushdown;
+    //tf.type_pushdown = type_pushdown;
     tf.pushdown_complex_filter = c_pushdown_complex_filter;
     tf.cardinality = c_cardinality;
     tf.get_partition_info = get_partition_info;

--- a/vortex-duckdb/src/convert/dtype.rs
+++ b/vortex-duckdb/src/convert/dtype.rs
@@ -284,6 +284,14 @@ impl TryFrom<&DType> for LogicalType {
     }
 }
 
+impl TryFrom<&LogicalTypeRef> for DType {
+    type Error = VortexError;
+
+    fn try_from(value: &LogicalTypeRef) -> Result<Self, Self::Error> {
+        DType::from_logical_type(value, Nullability::Nullable)
+    }
+}
+
 impl TryFrom<StructFields> for LogicalType {
     type Error = VortexError;
 

--- a/vortex-duckdb/src/datasource.rs
+++ b/vortex-duckdb/src/datasource.rs
@@ -31,7 +31,6 @@ use vortex::array::optimizer::ArrayOptimizer;
 use vortex::array::stats::StatsSet;
 use vortex::dtype::DType;
 use vortex::dtype::FieldName;
-use vortex::dtype::FieldNames;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
@@ -63,7 +62,6 @@ use vortex::scalar_fn::fns::pack::Pack;
 use vortex::scan::DataSource;
 use vortex::scan::ScanRequest;
 use vortex::scan::selection::Selection;
-use vortex_utils::aliases::hash_map::HashMap;
 use vortex_utils::aliases::hash_set::HashSet;
 use vortex_utils::parallelism::get_available_parallelism;
 
@@ -351,6 +349,7 @@ impl<T: DataSourceTableFunction> TableFunction for T {
                 .has_non_optional_filter
                 .store(true, Ordering::Relaxed);
         }
+        println!("{}", projection.display_tree());
 
         debug!(
             %projection,
@@ -718,7 +717,9 @@ fn extract_projection_expr(
     let mut real_column_count = 0;
 
     // DuckDB uses u64 as column indices but Rust uses usize
-    for (column_pos, (&column_id, column_field)) in ids.iter().zip(column_fields.as_ref()).enumerate() {
+    for (column_pos, (&column_id, column_field)) in
+        ids.iter().zip(column_fields.as_ref()).enumerate()
+    {
         let column_id = if has_projection_ids {
             let column_id: usize = column_id.as_();
             column_ids[column_id]
@@ -758,7 +759,7 @@ fn extract_projection_expr(
     let mut uncasted_fields = Vec::new();
     let mut casted_fields = Vec::new();
 
-    for (&column_id, column_field) in ids.iter().zip(column_fields.as_ref()) {
+    for &column_id in ids {
         let column_id = if has_projection_ids {
             let column_id: usize = column_id.as_();
             column_ids[column_id]
@@ -769,7 +770,9 @@ fn extract_projection_expr(
             continue;
         }
         let column_id: usize = column_id.as_();
+        let column_field = &column_fields[column_id];
         let field_name = FieldName::from(Arc::from(column_fields[column_id].name.as_str()));
+        println!("field: {column_field:?}");
         if column_field.casted {
             casted_fields.push((field_name, column_field.dtype.clone()));
         } else {
@@ -777,17 +780,22 @@ fn extract_projection_expr(
         }
     }
 
+    println!("casted fields: {casted_fields:?}");
+
     let projection = if casted_fields.is_empty() {
         select(uncasted_fields, root())
     } else {
         let mut fields = Vec::new();
-        for field in uncasted_fields {
-            fields.push(get_item(field, root()));
-        }
         for (field, dtype) in casted_fields {
-            fields.push(cast(get_item(field, root()), dtype));
+            println!("casted {field:?} to {dtype}");
+            fields.push((field.clone(), cast(get_item(field, root()), dtype)));
         }
-        merge(fields)
+        if uncasted_fields.is_empty() {
+            pack(fields, false.into())
+        } else {
+            let select = select(uncasted_fields, root());
+            merge([pack(fields, false.into()), select])
+        }
     };
 
     let projection = with_file_row_number(projection, file_row_number_column_pos.is_some());

--- a/vortex-duckdb/src/datasource.rs
+++ b/vortex-duckdb/src/datasource.rs
@@ -34,6 +34,7 @@ use vortex::dtype::FieldNames;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
+use vortex::error::vortex_panic;
 use vortex::expr::Expression;
 use vortex::expr::and_collect;
 use vortex::expr::col;
@@ -77,6 +78,7 @@ use crate::duckdb::DataChunkRef;
 use crate::duckdb::DuckdbStringMapRef;
 use crate::duckdb::ExpressionRef;
 use crate::duckdb::LogicalType;
+use crate::duckdb::LogicalTypeRef;
 use crate::duckdb::PartitionData;
 use crate::duckdb::TableFilterClass;
 use crate::duckdb::TableFilterSetRef;
@@ -126,6 +128,7 @@ pub struct DataSourceBindData {
     // There exists at least one non-optional table filter or at least one
     // complex filter is pushed down.
     has_non_optional_filter: AtomicBool,
+    //column_casts: Vec<(usize, DType)>,
 }
 
 impl Clone for DataSourceBindData {
@@ -631,6 +634,27 @@ impl<T: DataSourceTableFunction> TableFunction for T {
             let mut filters = bind_data.filter_exprs.iter().map(|f| format!("{f}"));
             map.push("Filters", &filters.join("\n"));
         }
+    }
+
+    fn pushdown_column_type(
+        bind_data: &mut Self::BindData,
+        column_id: u64,
+        new_type: &LogicalTypeRef,
+    ) {
+        // TODO virtual column count?
+        let column_id: usize = column_id.as_();
+        if column_id >= bind_data.column_fields.len() {
+            vortex_panic!("column_id {column_id} >= {}", bind_data.column_fields.len());
+        }
+        // TODO casting?
+        let field = &mut bind_data.column_fields[column_id];
+        let old_dtype = field.dtype.clone();
+        // TODO we don't need a copy?
+        field.logical_type = LogicalType::new(new_type.as_type_id());
+        field.dtype = new_type
+            .try_into()
+            .vortex_expect("logical type -> dtype conversion failed");
+        println!("Cast {} -> {}", old_dtype, field.dtype);
     }
 }
 

--- a/vortex-duckdb/src/datasource.rs
+++ b/vortex-duckdb/src/datasource.rs
@@ -30,6 +30,7 @@ use vortex::array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex::array::optimizer::ArrayOptimizer;
 use vortex::array::stats::StatsSet;
 use vortex::dtype::DType;
+use vortex::dtype::FieldName;
 use vortex::dtype::FieldNames;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
@@ -37,7 +38,9 @@ use vortex::error::vortex_err;
 use vortex::error::vortex_panic;
 use vortex::expr::Expression;
 use vortex::expr::and_collect;
+use vortex::expr::cast;
 use vortex::expr::col;
+use vortex::expr::get_item;
 use vortex::expr::merge;
 use vortex::expr::pack;
 use vortex::expr::root;
@@ -60,6 +63,7 @@ use vortex::scalar_fn::fns::pack::Pack;
 use vortex::scan::DataSource;
 use vortex::scan::ScanRequest;
 use vortex::scan::selection::Selection;
+use vortex_utils::aliases::hash_map::HashMap;
 use vortex_utils::aliases::hash_set::HashSet;
 use vortex_utils::parallelism::get_available_parallelism;
 
@@ -118,6 +122,7 @@ struct DuckdbField {
     name: String,
     logical_type: LogicalType,
     dtype: DType,
+    casted: bool,
 }
 
 /// Bind data produced by a [`DataSourceTableFunction`].
@@ -128,7 +133,6 @@ pub struct DataSourceBindData {
     // There exists at least one non-optional table filter or at least one
     // complex filter is pushed down.
     has_non_optional_filter: AtomicBool,
-    //column_casts: Vec<(usize, DType)>,
 }
 
 impl Clone for DataSourceBindData {
@@ -646,7 +650,6 @@ impl<T: DataSourceTableFunction> TableFunction for T {
         if column_id >= bind_data.column_fields.len() {
             vortex_panic!("column_id {column_id} >= {}", bind_data.column_fields.len());
         }
-        // TODO casting?
         let field = &mut bind_data.column_fields[column_id];
         let old_dtype = field.dtype.clone();
         // TODO we don't need a copy?
@@ -655,6 +658,7 @@ impl<T: DataSourceTableFunction> TableFunction for T {
             .try_into()
             .vortex_expect("logical type -> dtype conversion failed");
         println!("Cast {} -> {}", old_dtype, field.dtype);
+        field.casted = true;
     }
 }
 
@@ -673,6 +677,7 @@ fn extract_schema_from_dtype(dtype: &DType) -> VortexResult<Vec<DuckdbField>> {
             name: field_name.to_string(),
             logical_type,
             dtype: field_dtype,
+            casted: false,
         });
     }
     Ok(fields)
@@ -682,6 +687,17 @@ struct ProjectionWithVirtualColumns {
     projection: Expression,
     file_index_column_pos: Option<usize>,
     file_row_number_column_pos: Option<usize>,
+}
+
+fn with_file_row_number(select: Expression, has_file_row_number_column: bool) -> Expression {
+    // file_index column will be filled later when exporting the chunk.
+    if has_file_row_number_column {
+        // row_idx will be moved to correct position in scan(), prepend here
+        let row_idx_struct = pack([("file_row_number", row_idx())], false.into());
+        merge([row_idx_struct, select])
+    } else {
+        select
+    }
 }
 
 fn extract_projection_expr(
@@ -702,7 +718,7 @@ fn extract_projection_expr(
     let mut real_column_count = 0;
 
     // DuckDB uses u64 as column indices but Rust uses usize
-    for (column_pos, &column_id) in ids.iter().enumerate() {
+    for (column_pos, (&column_id, column_field)) in ids.iter().zip(column_fields.as_ref()).enumerate() {
         let column_id = if has_projection_ids {
             let column_id: usize = column_id.as_();
             column_ids[column_id]
@@ -719,6 +735,7 @@ fn extract_projection_expr(
             continue;
         }
 
+        is_star &= !column_field.casted;
         // In SELECT * DuckDB requests all columns from 0 to column_fields in
         // increasing order. After removing virtual columns, compare column_id
         // with (0..column_fields.len()) range.
@@ -729,37 +746,51 @@ fn extract_projection_expr(
     // 5 columns total.
     is_star &= real_column_count == column_fields.len() as u64;
 
-    let select = if is_star {
-        root()
-    } else {
-        let names = ids
-            .iter()
-            .map(|&column_id| {
-                if has_projection_ids {
-                    let column_id: usize = column_id.as_();
-                    column_ids[column_id]
-                } else {
-                    column_id
-                }
-            })
-            .filter(|&col_id| !is_virtual_column(col_id))
-            .map(|column_id| {
-                let column_id: usize = column_id.as_();
-                Arc::from(column_fields[column_id].name.as_str())
-            })
-            .collect::<FieldNames>();
+    if is_star {
+        let projection = with_file_row_number(root(), file_row_number_column_pos.is_some());
+        return ProjectionWithVirtualColumns {
+            projection,
+            file_index_column_pos,
+            file_row_number_column_pos,
+        };
+    }
 
-        select(names, root())
+    let mut uncasted_fields = Vec::new();
+    let mut casted_fields = Vec::new();
+
+    for (&column_id, column_field) in ids.iter().zip(column_fields.as_ref()) {
+        let column_id = if has_projection_ids {
+            let column_id: usize = column_id.as_();
+            column_ids[column_id]
+        } else {
+            column_id
+        };
+        if is_virtual_column(column_id) {
+            continue;
+        }
+        let column_id: usize = column_id.as_();
+        let field_name = FieldName::from(Arc::from(column_fields[column_id].name.as_str()));
+        if column_field.casted {
+            casted_fields.push((field_name, column_field.dtype.clone()));
+        } else {
+            uncasted_fields.push(field_name);
+        }
+    }
+
+    let projection = if casted_fields.is_empty() {
+        select(uncasted_fields, root())
+    } else {
+        let mut fields = Vec::new();
+        for field in uncasted_fields {
+            fields.push(get_item(field, root()));
+        }
+        for (field, dtype) in casted_fields {
+            fields.push(cast(get_item(field, root()), dtype));
+        }
+        merge(fields)
     };
 
-    // file_index column will be filled later when exporting the chunk.
-    let projection = if file_row_number_column_pos.is_some() {
-        // row_idx will be moved to correct position in scan(), prepend here
-        let row_idx_struct = pack([("file_row_number", row_idx())], false.into());
-        merge([row_idx_struct, select])
-    } else {
-        select
-    };
+    let projection = with_file_row_number(projection, file_row_number_column_pos.is_some());
 
     ProjectionWithVirtualColumns {
         projection,
@@ -873,21 +904,24 @@ mod tests {
     #[test]
     fn test_select_star() {
         let ids = [0, 1, 2];
-        let fields = [
+        let mut fields = [
             DuckdbField {
                 name: "".to_owned(),
                 logical_type: LogicalType::null(),
                 dtype: DType::Null,
+                casted: false,
             },
             DuckdbField {
                 name: "".to_owned(),
                 logical_type: LogicalType::null(),
                 dtype: DType::Null,
+                casted: false,
             },
             DuckdbField {
                 name: "".to_owned(),
                 logical_type: LogicalType::null(),
                 dtype: DType::Null,
+                casted: false,
             },
         ];
 
@@ -926,6 +960,12 @@ mod tests {
         let ids = [2, 1, 0];
         assert_ne!(
             extract_projection_expr(None, &ids, &fields).projection,
+            root()
+        );
+
+        fields[0].casted = true;
+        assert_ne!(
+            extract_projection_expr(None, &[0, 1, 2], &fields).projection,
             root()
         );
     }

--- a/vortex-duckdb/src/duckdb/table_function/mod.rs
+++ b/vortex-duckdb/src/duckdb/table_function/mod.rs
@@ -145,6 +145,14 @@ pub enum Cardinality {
 }
 
 impl DatabaseRef {
+    pub fn register_optimizer_extension(&self) -> VortexResult<()> {
+        duckdb_try!(
+            unsafe { cpp::duckdb_vx_optimizer_extension_register(self.as_ptr()) },
+            "Failed to register optimizer extension"
+        );
+        Ok(())
+    }
+
     pub fn register_table_function<T: TableFunction>(&self, name: &CStr) -> VortexResult<()> {
         // Set up the parameters.
         let parameters = T::parameters();

--- a/vortex-duckdb/src/duckdb/table_function/mod.rs
+++ b/vortex-duckdb/src/duckdb/table_function/mod.rs
@@ -21,6 +21,7 @@ use crate::duckdb::DataChunk;
 use crate::duckdb::DatabaseRef;
 use crate::duckdb::Expression;
 use crate::duckdb::LogicalType;
+use crate::duckdb::LogicalTypeRef;
 use crate::duckdb::Value;
 use crate::duckdb::client_context::ClientContextRef;
 use crate::duckdb::data_chunk::DataChunkRef;
@@ -103,6 +104,12 @@ pub trait TableFunction: Sized + Debug {
     /// Return table scanning progress from 0. to 100.
     fn table_scan_progress(global_state: &Self::GlobalState) -> f64;
 
+    fn pushdown_column_type(
+        bind_data: &mut Self::BindData,
+        column_id: u64,
+        new_type: &LogicalTypeRef
+    );
+
     /// Pushes down a filter expression to the table function.
     ///
     /// Returns `true` if the filter was successfully pushed down (and stored on the bind data),
@@ -157,6 +164,7 @@ impl DatabaseRef {
             function: Some(function::<T>),
             statistics: Some(statistics::<T>),
             cardinality: Some(cardinality_callback::<T>),
+            pushdown_column_type: Some(pushdown_column_type::<T>),
             pushdown_complex_filter: Some(pushdown_complex_filter_callback::<T>),
             to_string: Some(to_string_callback::<T>),
             table_scan_progress: Some(table_scan_progress_callback::<T>),
@@ -223,6 +231,17 @@ unsafe extern "C-unwind" fn get_partition_data_callback<T: TableFunction>(
     out.partition_index = data.partition_index;
     out.file_index_column_pos = data.file_index_column_pos.unwrap_or(usize::MAX);
     out.file_index = data.file_index;
+}
+
+unsafe extern "C-unwind" fn pushdown_column_type<T: TableFunction>(
+    bind_data: *mut c_void,
+    column_id: u64,
+    new_type: cpp::duckdb_logical_type
+) {
+    let bind_data =
+        unsafe { bind_data.cast::<T::BindData>().as_mut() }.vortex_expect("bind_data null pointer");
+    let new_type = unsafe { LogicalType::borrow(new_type) };
+    T::pushdown_column_type(bind_data, column_id, new_type);
 }
 
 unsafe extern "C-unwind" fn pushdown_complex_filter_callback<T: TableFunction>(

--- a/vortex-duckdb/src/lib.rs
+++ b/vortex-duckdb/src/lib.rs
@@ -70,6 +70,7 @@ pub fn initialize(db: &DatabaseRef) -> VortexResult<()> {
         LogicalType::varchar(),
         Value::from("vortex"),
     )?;
+    db.register_optimizer_extension()?;
     db.register_table_function::<VortexMultiFileScan>(c"vortex_scan")?;
     db.register_table_function::<VortexMultiFileScan>(c"read_vortex")?;
     // Register list overloads for multi-glob scanning (e.g., read_vortex(['a.vortex', 'b.vortex']))


### PR DESCRIPTION
Removes unnecessary casting of lists in statpopgen by propagating it to Vortex.
Requires https://github.com/duckdb/duckdb/pull/22788