### PR TITLE
Avoid re-building vortex-duckdb twice

### DIFF
--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -14,6 +14,7 @@ use std::process::Command;
 use std::process::exit;
 
 use bindgen::Abi;
+use bindgen::callbacks::ParseCallbacks;
 
 const DUCKDB_RELEASES_URL: &str = "https://github.com/duckdb/duckdb/releases/download";
 const DUCKDB_SOURCE_RELEASE_URL: &str = "https://github.com/duckdb/duckdb/archive/refs/tags";
@@ -43,6 +44,26 @@ const SOURCE_FILES: [&str; 17] = [
 
 const DOWNLOAD_MAX_RETRIES: i32 = 3;
 const DOWNLOAD_TIMEOUT: u64 = 90;
+
+#[derive(Debug)]
+struct BindgenCargoCallbacks;
+
+impl ParseCallbacks for BindgenCargoCallbacks {
+    fn read_env_var(&self, key: &str) {
+        println!("cargo:rerun-if-env-changed={key}");
+    }
+
+    fn header_file(&self, filename: &str) {
+        println!("cargo:rerun-if-changed={filename}");
+    }
+
+    fn include_file(&self, _filename: &str) {
+        // We do not want to let bindgen add DuckDB headers from OUT_DIR to Cargo's fingerprint.
+        // Those files are extracted during this build script, so their mtimes are newer than
+        // Cargo's build-script output timestamp and would force one extra
+        // rebuild after a clean build.
+    }
+}
 
 #[derive(Debug, Clone)]
 enum DuckDBVersion {
@@ -305,9 +326,7 @@ fn c2rust(crate_dir: &Path, duckdb_include_dir: &Path) {
         .clang_arg(format!("-I{}", duckdb_include_dir.display()))
         .clang_arg(format!("-I{}", crate_dir.join("cpp/include").display()))
         .generate_comments(true)
-        // Tell cargo to invalidate the built crate whenever any of the
-        // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .parse_callbacks(Box::new(BindgenCargoCallbacks))
         .generate();
 
     let bindings = match bindings {
@@ -338,7 +357,6 @@ fn cpp(duckdb_include_dir: &Path) {
         .include("cpp/include")
         .files(SOURCE_FILES)
         .compile("vortex-duckdb-extras");
-    // bindgen generates rerun-if-changed for .h/.hpp files
     for e in SOURCE_FILES {
         println!("cargo:rerun-if-changed={e}");
     }
@@ -449,6 +467,7 @@ fn main() {
     };
 
     let duckdb_include_dir = inner_dir.join("src").join("include");
+    println!("cargo:rerun-if-changed=cpp/include");
     c2rust(&crate_dir, &duckdb_include_dir);
     cpp(&duckdb_include_dir);
     rust2c(&crate_dir);


### PR DESCRIPTION
## Summary

Currently, if you build something like `duckdb-bench` cargo will rebuild `vortex-duckdb` once before it'll be satisfied that it doesn't need to rebuild it. The root cause is that cargo's fingerprinting can't accurately track files that are created **during** the build.

This change is fine because we still track our own changes, the only external change will be something like a duckdb version upgrade which will change `build.rs` and re-trigger the build as expected.