### PR TITLE
Revert "Remove type coercion"

### DIFF
--- a/docs/concepts/expressions.md
+++ b/docs/concepts/expressions.md
@@ -50,14 +50,14 @@ scalar_fn(struct.pack):
 Delaying the computation in this way allows for many more optimizations to be performed later, including fused 
 computation of several expressions at once, as is commonly done by the Vortex GPU compute context.
 
-## Type Checking
+## Type Coercion
 
 Vortex expressions are strictly typed. This means that the input data types to an expression must exactly match the
 expected data types of the expression's signature.
 
-For example, all binary functions require the same data type for both inputs. Any casts should be performed by the caller
-before constructing the expression. This allows Vortex to be agnostic to the type conversion rules of different compute
-engines.
+For example, all binary functions require the same data type for both inputs. Any coercion of types should be performed
+by the caller before constructing the expression. This allows Vortex to be agnostic to the type coercion rules of 
+different compute engines.
 
-The notable exception to this rule is nullability. For example, the equality comparison function allows comparing a
-`u32` and `u32?` array, but not a `u32` and `i32` array.
+The notable exception to this rule, is that many expressions permit null-coercion. For example, the equality comparison
+function allows comparing a `u32` and `u32?` array, but not a `u32` and `i32` array.

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -56,6 +56,8 @@ pub type vortex_array::aggregate_fn::combined::Combined<T>::Partial = (alloc::bo
 
 pub fn vortex_array::aggregate_fn::combined::Combined<T>::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::aggregate_fn::combined::Combined<T>::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::combined::Combined<T>::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::combined::Combined<T>::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
@@ -114,6 +116,8 @@ pub type vortex_array::aggregate_fn::combined::BinaryCombined::Left: vortex_arra
 
 pub type vortex_array::aggregate_fn::combined::BinaryCombined::Right: vortex_array::aggregate_fn::AggregateFnVTable
 
+pub fn vortex_array::aggregate_fn::combined::BinaryCombined::coerce_args(&self, &vortex_array::aggregate_fn::combined::CombinedOptions<Self>, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::combined::BinaryCombined::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_array::aggregate_fn::combined::CombinedOptions<Self>>
 
 pub fn vortex_array::aggregate_fn::combined::BinaryCombined::finalize(&self, vortex_array::ArrayRef, vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -141,6 +145,8 @@ impl vortex_array::aggregate_fn::combined::BinaryCombined for vortex_array::aggr
 pub type vortex_array::aggregate_fn::fns::mean::Mean::Left = vortex_array::aggregate_fn::fns::sum::Sum
 
 pub type vortex_array::aggregate_fn::fns::mean::Mean::Right = vortex_array::aggregate_fn::fns::count::Count
+
+pub fn vortex_array::aggregate_fn::fns::mean::Mean::coerce_args(&self, &vortex_array::aggregate_fn::combined::PairOptions<<vortex_array::aggregate_fn::fns::sum::Sum as vortex_array::aggregate_fn::AggregateFnVTable>::Options, <vortex_array::aggregate_fn::fns::count::Count as vortex_array::aggregate_fn::AggregateFnVTable>::Options>, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::mean::Mean::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_array::aggregate_fn::combined::CombinedOptions<Self>>
 
@@ -187,6 +193,8 @@ pub type vortex_array::aggregate_fn::fns::all_non_distinct::AllNonDistinct::Opti
 pub type vortex_array::aggregate_fn::fns::all_non_distinct::AllNonDistinct::Partial = vortex_array::aggregate_fn::fns::all_non_distinct::AllNonDistinctPartial
 
 pub fn vortex_array::aggregate_fn::fns::all_non_distinct::AllNonDistinct::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::all_non_distinct::AllNonDistinct::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::all_non_distinct::AllNonDistinct::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
@@ -238,6 +246,8 @@ pub type vortex_array::aggregate_fn::fns::count::Count::Partial = u64
 
 pub fn vortex_array::aggregate_fn::fns::count::Count::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::aggregate_fn::fns::count::Count::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::fns::count::Count::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::fns::count::Count::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
@@ -283,6 +293,8 @@ pub type vortex_array::aggregate_fn::fns::first::First::Options = vortex_array::
 pub type vortex_array::aggregate_fn::fns::first::First::Partial = vortex_array::aggregate_fn::fns::first::FirstPartial
 
 pub fn vortex_array::aggregate_fn::fns::first::First::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::first::First::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::first::First::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
@@ -344,6 +356,8 @@ pub type vortex_array::aggregate_fn::fns::is_constant::IsConstant::Partial = vor
 
 pub fn vortex_array::aggregate_fn::fns::is_constant::IsConstant::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::aggregate_fn::fns::is_constant::IsConstant::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::fns::is_constant::IsConstant::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::fns::is_constant::IsConstant::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
@@ -399,6 +413,8 @@ pub type vortex_array::aggregate_fn::fns::is_sorted::IsSorted::Options = vortex_
 pub type vortex_array::aggregate_fn::fns::is_sorted::IsSorted::Partial = vortex_array::aggregate_fn::fns::is_sorted::IsSortedPartial
 
 pub fn vortex_array::aggregate_fn::fns::is_sorted::IsSorted::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::is_sorted::IsSorted::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::is_sorted::IsSorted::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
@@ -490,6 +506,8 @@ pub type vortex_array::aggregate_fn::fns::last::Last::Partial = vortex_array::ag
 
 pub fn vortex_array::aggregate_fn::fns::last::Last::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::aggregate_fn::fns::last::Last::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::fns::last::Last::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::fns::last::Last::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
@@ -542,6 +560,8 @@ pub type vortex_array::aggregate_fn::fns::mean::Mean::Left = vortex_array::aggre
 
 pub type vortex_array::aggregate_fn::fns::mean::Mean::Right = vortex_array::aggregate_fn::fns::count::Count
 
+pub fn vortex_array::aggregate_fn::fns::mean::Mean::coerce_args(&self, &vortex_array::aggregate_fn::combined::PairOptions<<vortex_array::aggregate_fn::fns::sum::Sum as vortex_array::aggregate_fn::AggregateFnVTable>::Options, <vortex_array::aggregate_fn::fns::count::Count as vortex_array::aggregate_fn::AggregateFnVTable>::Options>, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::fns::mean::Mean::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_array::aggregate_fn::combined::CombinedOptions<Self>>
 
 pub fn vortex_array::aggregate_fn::fns::mean::Mean::finalize(&self, vortex_array::ArrayRef, vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -585,6 +605,8 @@ pub type vortex_array::aggregate_fn::fns::min_max::MinMax::Options = vortex_arra
 pub type vortex_array::aggregate_fn::fns::min_max::MinMax::Partial = vortex_array::aggregate_fn::fns::min_max::MinMaxPartial
 
 pub fn vortex_array::aggregate_fn::fns::min_max::MinMax::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::min_max::MinMax::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::min_max::MinMax::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
@@ -664,6 +686,8 @@ pub type vortex_array::aggregate_fn::fns::nan_count::NanCount::Partial = u64
 
 pub fn vortex_array::aggregate_fn::fns::nan_count::NanCount::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::aggregate_fn::fns::nan_count::NanCount::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::fns::nan_count::NanCount::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::fns::nan_count::NanCount::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
@@ -711,6 +735,8 @@ pub type vortex_array::aggregate_fn::fns::null_count::NullCount::Options = vorte
 pub type vortex_array::aggregate_fn::fns::null_count::NullCount::Partial = u64
 
 pub fn vortex_array::aggregate_fn::fns::null_count::NullCount::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::null_count::NullCount::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::null_count::NullCount::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
@@ -774,6 +800,8 @@ pub type vortex_array::aggregate_fn::fns::sum::Sum::Partial = vortex_array::aggr
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
@@ -823,6 +851,8 @@ pub type vortex_array::aggregate_fn::fns::uncompressed_size_in_bytes::Uncompress
 pub type vortex_array::aggregate_fn::fns::uncompressed_size_in_bytes::UncompressedSizeInBytes::Partial = u64
 
 pub fn vortex_array::aggregate_fn::fns::uncompressed_size_in_bytes::UncompressedSizeInBytes::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::uncompressed_size_in_bytes::UncompressedSizeInBytes::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::uncompressed_size_in_bytes::UncompressedSizeInBytes::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
@@ -978,6 +1008,8 @@ pub fn vortex_array::aggregate_fn::AggregateFnRef::as_<V: vortex_array::aggregat
 
 pub fn vortex_array::aggregate_fn::AggregateFnRef::as_opt<V: vortex_array::aggregate_fn::AggregateFnVTable>(&self) -> core::option::Option<&<V as vortex_array::aggregate_fn::AggregateFnVTable>::Options>
 
+pub fn vortex_array::aggregate_fn::AggregateFnRef::coerce_args(&self, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::AggregateFnRef::id(&self) -> vortex_array::aggregate_fn::AggregateFnId
 
 pub fn vortex_array::aggregate_fn::AggregateFnRef::is<V: vortex_array::aggregate_fn::AggregateFnVTable>(&self) -> bool
@@ -1078,6 +1110,8 @@ pub type vortex_array::aggregate_fn::AggregateFnVTable::Partial: 'static + core:
 
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::aggregate_fn::AggregateFnVTable::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
@@ -1111,6 +1145,8 @@ pub type vortex_array::aggregate_fn::fns::all_non_distinct::AllNonDistinct::Opti
 pub type vortex_array::aggregate_fn::fns::all_non_distinct::AllNonDistinct::Partial = vortex_array::aggregate_fn::fns::all_non_distinct::AllNonDistinctPartial
 
 pub fn vortex_array::aggregate_fn::fns::all_non_distinct::AllNonDistinct::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::all_non_distinct::AllNonDistinct::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::all_non_distinct::AllNonDistinct::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
@@ -1146,6 +1182,8 @@ pub type vortex_array::aggregate_fn::fns::count::Count::Partial = u64
 
 pub fn vortex_array::aggregate_fn::fns::count::Count::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::aggregate_fn::fns::count::Count::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::fns::count::Count::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::fns::count::Count::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
@@ -1179,6 +1217,8 @@ pub type vortex_array::aggregate_fn::fns::first::First::Options = vortex_array::
 pub type vortex_array::aggregate_fn::fns::first::First::Partial = vortex_array::aggregate_fn::fns::first::FirstPartial
 
 pub fn vortex_array::aggregate_fn::fns::first::First::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::first::First::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::first::First::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
@@ -1214,6 +1254,8 @@ pub type vortex_array::aggregate_fn::fns::is_constant::IsConstant::Partial = vor
 
 pub fn vortex_array::aggregate_fn::fns::is_constant::IsConstant::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::aggregate_fn::fns::is_constant::IsConstant::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::fns::is_constant::IsConstant::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::fns::is_constant::IsConstant::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
@@ -1247,6 +1289,8 @@ pub type vortex_array::aggregate_fn::fns::is_sorted::IsSorted::Options = vortex_
 pub type vortex_array::aggregate_fn::fns::is_sorted::IsSorted::Partial = vortex_array::aggregate_fn::fns::is_sorted::IsSortedPartial
 
 pub fn vortex_array::aggregate_fn::fns::is_sorted::IsSorted::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::is_sorted::IsSorted::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::is_sorted::IsSorted::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
@@ -1282,6 +1326,8 @@ pub type vortex_array::aggregate_fn::fns::last::Last::Partial = vortex_array::ag
 
 pub fn vortex_array::aggregate_fn::fns::last::Last::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::aggregate_fn::fns::last::Last::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::fns::last::Last::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::fns::last::Last::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
@@ -1315,6 +1361,8 @@ pub type vortex_array::aggregate_fn::fns::min_max::MinMax::Options = vortex_arra
 pub type vortex_array::aggregate_fn::fns::min_max::MinMax::Partial = vortex_array::aggregate_fn::fns::min_max::MinMaxPartial
 
 pub fn vortex_array::aggregate_fn::fns::min_max::MinMax::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::min_max::MinMax::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::min_max::MinMax::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
@@ -1350,6 +1398,8 @@ pub type vortex_array::aggregate_fn::fns::nan_count::NanCount::Partial = u64
 
 pub fn vortex_array::aggregate_fn::fns::nan_count::NanCount::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::aggregate_fn::fns::nan_count::NanCount::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::fns::nan_count::NanCount::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::fns::nan_count::NanCount::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
@@ -1383,6 +1433,8 @@ pub type vortex_array::aggregate_fn::fns::null_count::NullCount::Options = vorte
 pub type vortex_array::aggregate_fn::fns::null_count::NullCount::Partial = u64
 
 pub fn vortex_array::aggregate_fn::fns::null_count::NullCount::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::null_count::NullCount::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::null_count::NullCount::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
@@ -1418,6 +1470,8 @@ pub type vortex_array::aggregate_fn::fns::sum::Sum::Partial = vortex_array::aggr
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
@@ -1452,6 +1506,8 @@ pub type vortex_array::aggregate_fn::fns::uncompressed_size_in_bytes::Uncompress
 
 pub fn vortex_array::aggregate_fn::fns::uncompressed_size_in_bytes::UncompressedSizeInBytes::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::aggregate_fn::fns::uncompressed_size_in_bytes::UncompressedSizeInBytes::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
 pub fn vortex_array::aggregate_fn::fns::uncompressed_size_in_bytes::UncompressedSizeInBytes::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::fns::uncompressed_size_in_bytes::UncompressedSizeInBytes::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
@@ -1485,6 +1541,8 @@ pub type vortex_array::aggregate_fn::combined::Combined<T>::Options = vortex_arr
 pub type vortex_array::aggregate_fn::combined::Combined<T>::Partial = (alloc::boxed::Box<dyn vortex_array::aggregate_fn::DynAccumulator>, alloc::boxed::Box<dyn vortex_array::aggregate_fn::DynAccumulator>)
 
 pub fn vortex_array::aggregate_fn::combined::Combined<T>::accumulate(&self, &mut Self::Partial, &vortex_array::Columnar, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::combined::Combined<T>::coerce_args(&self, &Self::Options, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::combined::Combined<T>::combine_partials(&self, &mut Self::Partial, vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
@@ -9206,9 +9264,15 @@ pub fn vortex_array::dtype::extension::ExtDType<V>::try_new(<V as vortex_array::
 
 impl<V: vortex_array::dtype::extension::ExtVTable> vortex_array::dtype::extension::ExtDType<V>
 
+pub fn vortex_array::dtype::extension::ExtDType<V>::can_coerce_from(&self, &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::dtype::extension::ExtDType<V>::can_coerce_to(&self, &vortex_array::dtype::DType) -> bool
+
 pub fn vortex_array::dtype::extension::ExtDType<V>::erased(self) -> vortex_array::dtype::extension::ExtDTypeRef
 
 pub fn vortex_array::dtype::extension::ExtDType<V>::id(&self) -> vortex_array::dtype::extension::ExtId
+
+pub fn vortex_array::dtype::extension::ExtDType<V>::least_supertype(&self, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
 
 pub fn vortex_array::dtype::extension::ExtDType<V>::metadata(&self) -> &<V as vortex_array::dtype::extension::ExtVTable>::Metadata
 
@@ -9248,6 +9312,10 @@ pub struct vortex_array::dtype::extension::ExtDTypeRef(_)
 
 impl vortex_array::dtype::extension::ExtDTypeRef
 
+pub fn vortex_array::dtype::extension::ExtDTypeRef::can_coerce_from(&self, &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::dtype::extension::ExtDTypeRef::can_coerce_to(&self, &vortex_array::dtype::DType) -> bool
+
 pub fn vortex_array::dtype::extension::ExtDTypeRef::display_metadata(&self) -> impl core::fmt::Display + '_
 
 pub fn vortex_array::dtype::extension::ExtDTypeRef::eq_ignore_nullability(&self, &Self) -> bool
@@ -9255,6 +9323,8 @@ pub fn vortex_array::dtype::extension::ExtDTypeRef::eq_ignore_nullability(&self,
 pub fn vortex_array::dtype::extension::ExtDTypeRef::id(&self) -> vortex_array::dtype::extension::ExtId
 
 pub fn vortex_array::dtype::extension::ExtDTypeRef::is_nullable(&self) -> bool
+
+pub fn vortex_array::dtype::extension::ExtDTypeRef::least_supertype(&self, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
 
 pub fn vortex_array::dtype::extension::ExtDTypeRef::nullability(&self) -> vortex_array::dtype::Nullability
 
@@ -9316,9 +9386,15 @@ pub type vortex_array::dtype::extension::ExtVTable::Metadata: 'static + core::ma
 
 pub type vortex_array::dtype::extension::ExtVTable::NativeValue<'a>: core::fmt::Display
 
+pub fn vortex_array::dtype::extension::ExtVTable::can_coerce_from(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::dtype::extension::ExtVTable::can_coerce_to(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
 pub fn vortex_array::dtype::extension::ExtVTable::deserialize_metadata(&self, &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::dtype::extension::ExtVTable::id(&self) -> vortex_array::dtype::extension::ExtId
+
+pub fn vortex_array::dtype::extension::ExtVTable::least_supertype(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
 
 pub fn vortex_array::dtype::extension::ExtVTable::serialize_metadata(&self, &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -9334,9 +9410,15 @@ pub type vortex_array::extension::datetime::Date::Metadata = vortex_array::exten
 
 pub type vortex_array::extension::datetime::Date::NativeValue<'a> = vortex_array::extension::datetime::DateValue
 
+pub fn vortex_array::extension::datetime::Date::can_coerce_from(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::extension::datetime::Date::can_coerce_to(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
 pub fn vortex_array::extension::datetime::Date::deserialize_metadata(&self, &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::extension::datetime::Date::id(&self) -> vortex_array::dtype::extension::ExtId
+
+pub fn vortex_array::extension::datetime::Date::least_supertype(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
 
 pub fn vortex_array::extension::datetime::Date::serialize_metadata(&self, &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -9352,9 +9434,15 @@ pub type vortex_array::extension::datetime::Time::Metadata = vortex_array::exten
 
 pub type vortex_array::extension::datetime::Time::NativeValue<'a> = vortex_array::extension::datetime::TimeValue
 
+pub fn vortex_array::extension::datetime::Time::can_coerce_from(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::extension::datetime::Time::can_coerce_to(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
 pub fn vortex_array::extension::datetime::Time::deserialize_metadata(&self, &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::extension::datetime::Time::id(&self) -> vortex_array::dtype::extension::ExtId
+
+pub fn vortex_array::extension::datetime::Time::least_supertype(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
 
 pub fn vortex_array::extension::datetime::Time::serialize_metadata(&self, &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -9370,9 +9458,15 @@ pub type vortex_array::extension::datetime::Timestamp::Metadata = vortex_array::
 
 pub type vortex_array::extension::datetime::Timestamp::NativeValue<'a> = vortex_array::extension::datetime::TimestampValue<'a>
 
+pub fn vortex_array::extension::datetime::Timestamp::can_coerce_from(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::extension::datetime::Timestamp::can_coerce_to(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
 pub fn vortex_array::extension::datetime::Timestamp::deserialize_metadata(&self, &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::extension::datetime::Timestamp::id(&self) -> vortex_array::dtype::extension::ExtId
+
+pub fn vortex_array::extension::datetime::Timestamp::least_supertype(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
 
 pub fn vortex_array::extension::datetime::Timestamp::serialize_metadata(&self, &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -9388,9 +9482,15 @@ pub type vortex_array::extension::uuid::Uuid::Metadata = vortex_array::extension
 
 pub type vortex_array::extension::uuid::Uuid::NativeValue<'a> = uuid::Uuid
 
+pub fn vortex_array::extension::uuid::Uuid::can_coerce_from(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::extension::uuid::Uuid::can_coerce_to(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
 pub fn vortex_array::extension::uuid::Uuid::deserialize_metadata(&self, &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::extension::uuid::Uuid::id(&self) -> vortex_array::dtype::extension::ExtId
+
+pub fn vortex_array::extension::uuid::Uuid::least_supertype(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
 
 pub fn vortex_array::extension::uuid::Uuid::serialize_metadata(&self, &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -9564,15 +9664,11 @@ pub fn vortex_array::dtype::DType::is_nested(&self) -> bool
 
 pub fn vortex_array::dtype::DType::is_nullable(&self) -> bool
 
-pub fn vortex_array::dtype::DType::is_numeric(&self) -> bool
-
 pub fn vortex_array::dtype::DType::is_primitive(&self) -> bool
 
 pub fn vortex_array::dtype::DType::is_signed_int(&self) -> bool
 
 pub fn vortex_array::dtype::DType::is_struct(&self) -> bool
-
-pub fn vortex_array::dtype::DType::is_temporal(&self) -> bool
 
 pub fn vortex_array::dtype::DType::is_union(&self) -> bool
 
@@ -9591,6 +9687,28 @@ pub fn vortex_array::dtype::DType::struct_<I: core::iter::traits::collect::IntoI
 pub fn vortex_array::dtype::DType::union_nullability(&self, vortex_array::dtype::Nullability) -> Self
 
 pub fn vortex_array::dtype::DType::with_nullability(&self, vortex_array::dtype::Nullability) -> Self
+
+impl vortex_array::dtype::DType
+
+pub fn vortex_array::dtype::DType::all_coercible_to(&[vortex_array::dtype::DType], &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::dtype::DType::are_coercible(&[vortex_array::dtype::DType]) -> bool
+
+pub fn vortex_array::dtype::DType::can_coerce_from(&self, &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::dtype::DType::can_coerce_to(&self, &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::dtype::DType::coerce_all_to(&[vortex_array::dtype::DType], &vortex_array::dtype::DType) -> core::option::Option<alloc::vec::Vec<vortex_array::dtype::DType>>
+
+pub fn vortex_array::dtype::DType::coerce_to_supertype(&[vortex_array::dtype::DType]) -> core::option::Option<alloc::vec::Vec<vortex_array::dtype::DType>>
+
+pub fn vortex_array::dtype::DType::is_numeric(&self) -> bool
+
+pub fn vortex_array::dtype::DType::is_temporal(&self) -> bool
+
+pub fn vortex_array::dtype::DType::least_supertype(&self, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
+
+pub fn vortex_array::dtype::DType::least_supertype_of(&[vortex_array::dtype::DType]) -> core::option::Option<vortex_array::dtype::DType>
 
 impl vortex_array::dtype::DType
 
@@ -9983,6 +10101,10 @@ impl vortex_array::dtype::PType
 pub fn vortex_array::dtype::PType::from_i32(i32) -> core::option::Option<vortex_array::dtype::PType>
 
 pub fn vortex_array::dtype::PType::is_valid(i32) -> bool
+
+impl vortex_array::dtype::PType
+
+pub fn vortex_array::dtype::PType::least_supertype(self, vortex_array::dtype::PType) -> core::option::Option<vortex_array::dtype::PType>
 
 impl core::clone::Clone for vortex_array::dtype::PType
 
@@ -12498,6 +12620,8 @@ impl<A: core::fmt::Display> core::fmt::Display for vortex_array::expr::transform
 
 pub fn vortex_array::expr::transform::PartitionedExpr<A>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
+pub fn vortex_array::expr::transform::coerce_expression(vortex_array::expr::Expression, &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+
 pub fn vortex_array::expr::transform::partition<A: vortex_array::expr::AnnotationFn>(vortex_array::expr::Expression, &vortex_array::dtype::DType, A) -> vortex_error::VortexResult<vortex_array::expr::transform::PartitionedExpr<<A as vortex_array::expr::AnnotationFn>::Annotation>> where <A as vortex_array::expr::AnnotationFn>::Annotation: core::fmt::Display, vortex_array::dtype::FieldName: core::convert::From<<A as vortex_array::expr::AnnotationFn>::Annotation>
 
 pub fn vortex_array::expr::transform::replace(vortex_array::expr::Expression, &vortex_array::expr::Expression, vortex_array::expr::Expression) -> vortex_array::expr::Expression
@@ -13242,9 +13366,15 @@ pub type vortex_array::extension::datetime::Date::Metadata = vortex_array::exten
 
 pub type vortex_array::extension::datetime::Date::NativeValue<'a> = vortex_array::extension::datetime::DateValue
 
+pub fn vortex_array::extension::datetime::Date::can_coerce_from(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::extension::datetime::Date::can_coerce_to(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
 pub fn vortex_array::extension::datetime::Date::deserialize_metadata(&self, &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::extension::datetime::Date::id(&self) -> vortex_array::dtype::extension::ExtId
+
+pub fn vortex_array::extension::datetime::Date::least_supertype(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
 
 pub fn vortex_array::extension::datetime::Date::serialize_metadata(&self, &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -13292,9 +13422,15 @@ pub type vortex_array::extension::datetime::Time::Metadata = vortex_array::exten
 
 pub type vortex_array::extension::datetime::Time::NativeValue<'a> = vortex_array::extension::datetime::TimeValue
 
+pub fn vortex_array::extension::datetime::Time::can_coerce_from(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::extension::datetime::Time::can_coerce_to(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
 pub fn vortex_array::extension::datetime::Time::deserialize_metadata(&self, &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::extension::datetime::Time::id(&self) -> vortex_array::dtype::extension::ExtId
+
+pub fn vortex_array::extension::datetime::Time::least_supertype(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
 
 pub fn vortex_array::extension::datetime::Time::serialize_metadata(&self, &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -13344,9 +13480,15 @@ pub type vortex_array::extension::datetime::Timestamp::Metadata = vortex_array::
 
 pub type vortex_array::extension::datetime::Timestamp::NativeValue<'a> = vortex_array::extension::datetime::TimestampValue<'a>
 
+pub fn vortex_array::extension::datetime::Timestamp::can_coerce_from(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::extension::datetime::Timestamp::can_coerce_to(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
 pub fn vortex_array::extension::datetime::Timestamp::deserialize_metadata(&self, &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::extension::datetime::Timestamp::id(&self) -> vortex_array::dtype::extension::ExtId
+
+pub fn vortex_array::extension::datetime::Timestamp::least_supertype(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
 
 pub fn vortex_array::extension::datetime::Timestamp::serialize_metadata(&self, &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -13438,9 +13580,15 @@ pub type vortex_array::extension::uuid::Uuid::Metadata = vortex_array::extension
 
 pub type vortex_array::extension::uuid::Uuid::NativeValue<'a> = uuid::Uuid
 
+pub fn vortex_array::extension::uuid::Uuid::can_coerce_from(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::extension::uuid::Uuid::can_coerce_to(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> bool
+
 pub fn vortex_array::extension::uuid::Uuid::deserialize_metadata(&self, &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::extension::uuid::Uuid::id(&self) -> vortex_array::dtype::extension::ExtId
+
+pub fn vortex_array::extension::uuid::Uuid::least_supertype(&vortex_array::dtype::extension::ExtDType<Self>, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
 
 pub fn vortex_array::extension::uuid::Uuid::serialize_metadata(&self, &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -16202,6 +16350,8 @@ pub fn vortex_array::scalar_fn::fns::between::Between::arity(&self, &Self::Optio
 
 pub fn vortex_array::scalar_fn::fns::between::Between::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::between::Between::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::between::Between::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::between::Between::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -16328,6 +16478,8 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::arity(&self, &Self::Options
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::binary::Binary::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::binary::Binary::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, &vortex_array::scalar_fn::fns::operators::Operator, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -16416,6 +16568,8 @@ pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::arity(&self, &Self::Op
 
 pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -16495,6 +16649,8 @@ pub type vortex_array::scalar_fn::fns::cast::Cast::Options = vortex_array::dtype
 pub fn vortex_array::scalar_fn::fns::cast::Cast::arity(&self, &vortex_array::dtype::DType) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::child_name(&self, &vortex_array::dtype::DType, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::cast::Cast::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -16664,6 +16820,8 @@ pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::arity(&self, &S
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -16743,6 +16901,8 @@ pub type vortex_array::scalar_fn::fns::fill_null::FillNull::Options = vortex_arr
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -16852,6 +17012,8 @@ pub fn vortex_array::scalar_fn::fns::get_item::GetItem::arity(&self, &vortex_arr
 
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::get_item::GetItem::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::execute(&self, &vortex_array::dtype::FieldName, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -16895,6 +17057,8 @@ pub type vortex_array::scalar_fn::fns::is_not_null::IsNotNull::Options = vortex_
 pub fn vortex_array::scalar_fn::fns::is_not_null::IsNotNull::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::is_not_null::IsNotNull::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::is_not_null::IsNotNull::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::is_not_null::IsNotNull::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -16940,6 +17104,8 @@ pub fn vortex_array::scalar_fn::fns::is_null::IsNull::arity(&self, &Self::Option
 
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::is_null::IsNull::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -16983,6 +17149,8 @@ pub type vortex_array::scalar_fn::fns::like::Like::Options = vortex_array::scala
 pub fn vortex_array::scalar_fn::fns::like::Like::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::like::Like::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::like::Like::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::like::Like::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -17108,6 +17276,8 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::arity(&self, &
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -17192,6 +17362,8 @@ pub fn vortex_array::scalar_fn::fns::literal::Literal::arity(&self, &Self::Optio
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::literal::Literal::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::literal::Literal::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::execute(&self, &vortex_array::scalar::Scalar, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -17235,6 +17407,8 @@ pub type vortex_array::scalar_fn::fns::mask::Mask::Options = vortex_array::scala
 pub fn vortex_array::scalar_fn::fns::mask::Mask::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::mask::Mask::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -17412,6 +17586,8 @@ pub fn vortex_array::scalar_fn::fns::merge::Merge::arity(&self, &Self::Options) 
 
 pub fn vortex_array::scalar_fn::fns::merge::Merge::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::merge::Merge::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::merge::Merge::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::merge::Merge::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -17455,6 +17631,8 @@ pub type vortex_array::scalar_fn::fns::not::Not::Options = vortex_array::scalar_
 pub fn vortex_array::scalar_fn::fns::not::Not::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::not::Not::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::not::Not::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::not::Not::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -17706,6 +17884,8 @@ pub fn vortex_array::scalar_fn::fns::pack::Pack::arity(&self, &Self::Options) ->
 
 pub fn vortex_array::scalar_fn::fns::pack::Pack::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::pack::Pack::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::pack::Pack::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::pack::Pack::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -17779,6 +17959,8 @@ pub type vortex_array::scalar_fn::fns::root::Root::Options = vortex_array::scala
 pub fn vortex_array::scalar_fn::fns::root::Root::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::root::Root::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::root::Root::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::root::Root::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -17868,6 +18050,8 @@ pub fn vortex_array::scalar_fn::fns::select::Select::arity(&self, &vortex_array:
 
 pub fn vortex_array::scalar_fn::fns::select::Select::child_name(&self, &vortex_array::scalar_fn::fns::select::FieldSelection, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::select::Select::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::select::Select::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_array::scalar_fn::fns::select::FieldSelection>
 
 pub fn vortex_array::scalar_fn::fns::select::Select::execute(&self, &vortex_array::scalar_fn::fns::select::FieldSelection, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -17911,6 +18095,8 @@ pub type vortex_array::scalar_fn::fns::stat::StatFn::Options = vortex_array::sca
 pub fn vortex_array::scalar_fn::fns::stat::StatFn::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::stat::StatFn::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::stat::StatFn::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::stat::StatFn::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -18040,6 +18226,8 @@ pub fn vortex_array::scalar_fn::fns::variant_get::VariantGet::arity(&self, &Self
 
 pub fn vortex_array::scalar_fn::fns::variant_get::VariantGet::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::variant_get::VariantGet::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::variant_get::VariantGet::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::variant_get::VariantGet::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -18168,6 +18356,8 @@ pub fn vortex_array::scalar_fn::fns::zip::Zip::arity(&self, &Self::Options) -> v
 
 pub fn vortex_array::scalar_fn::fns::zip::Zip::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::zip::Zip::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::zip::Zip::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::zip::Zip::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -18265,6 +18455,8 @@ pub type vortex_array::scalar_fn::internal::row_count::RowCount::Options = vorte
 pub fn vortex_array::scalar_fn::internal::row_count::RowCount::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::internal::row_count::RowCount::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::internal::row_count::RowCount::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::internal::row_count::RowCount::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -18448,6 +18640,8 @@ pub fn vortex_array::scalar_fn::ForeignScalarFnVTable::arity(&self, &Self::Optio
 
 pub fn vortex_array::scalar_fn::ForeignScalarFnVTable::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::ForeignScalarFnVTable::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::ForeignScalarFnVTable::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::ForeignScalarFnVTable::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -18511,6 +18705,8 @@ impl vortex_array::scalar_fn::ScalarFnRef
 pub fn vortex_array::scalar_fn::ScalarFnRef::as_<V: vortex_array::scalar_fn::ScalarFnVTable>(&self) -> &<V as vortex_array::scalar_fn::ScalarFnVTable>::Options
 
 pub fn vortex_array::scalar_fn::ScalarFnRef::as_opt<V: vortex_array::scalar_fn::ScalarFnVTable>(&self) -> core::option::Option<&<V as vortex_array::scalar_fn::ScalarFnVTable>::Options>
+
+pub fn vortex_array::scalar_fn::ScalarFnRef::coerce_args(&self, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::ScalarFnRef::downcast<V: vortex_array::scalar_fn::ScalarFnVTable>(self) -> alloc::sync::Arc<vortex_array::scalar_fn::TypedScalarFnInstance<V>>
 
@@ -18658,6 +18854,8 @@ pub fn vortex_array::scalar_fn::ScalarFnVTable::arity(&self, &Self::Options) -> 
 
 pub fn vortex_array::scalar_fn::ScalarFnVTable::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::ScalarFnVTable::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::ScalarFnVTable::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::ScalarFnVTable::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -18693,6 +18891,8 @@ pub type vortex_array::scalar_fn::ForeignScalarFnVTable::Options = vortex_array:
 pub fn vortex_array::scalar_fn::ForeignScalarFnVTable::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::ForeignScalarFnVTable::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::ForeignScalarFnVTable::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::ForeignScalarFnVTable::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -18730,6 +18930,8 @@ pub fn vortex_array::scalar_fn::fns::between::Between::arity(&self, &Self::Optio
 
 pub fn vortex_array::scalar_fn::fns::between::Between::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::between::Between::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::between::Between::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::between::Between::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -18765,6 +18967,8 @@ pub type vortex_array::scalar_fn::fns::binary::Binary::Options = vortex_array::s
 pub fn vortex_array::scalar_fn::fns::binary::Binary::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::binary::Binary::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -18802,6 +19006,8 @@ pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::arity(&self, &Self::Op
 
 pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -18837,6 +19043,8 @@ pub type vortex_array::scalar_fn::fns::cast::Cast::Options = vortex_array::dtype
 pub fn vortex_array::scalar_fn::fns::cast::Cast::arity(&self, &vortex_array::dtype::DType) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::child_name(&self, &vortex_array::dtype::DType, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::cast::Cast::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -18874,6 +19082,8 @@ pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::arity(&self, &S
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -18909,6 +19119,8 @@ pub type vortex_array::scalar_fn::fns::fill_null::FillNull::Options = vortex_arr
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -18946,6 +19158,8 @@ pub fn vortex_array::scalar_fn::fns::get_item::GetItem::arity(&self, &vortex_arr
 
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::get_item::GetItem::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::execute(&self, &vortex_array::dtype::FieldName, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -18981,6 +19195,8 @@ pub type vortex_array::scalar_fn::fns::is_not_null::IsNotNull::Options = vortex_
 pub fn vortex_array::scalar_fn::fns::is_not_null::IsNotNull::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::is_not_null::IsNotNull::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::is_not_null::IsNotNull::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::is_not_null::IsNotNull::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -19018,6 +19234,8 @@ pub fn vortex_array::scalar_fn::fns::is_null::IsNull::arity(&self, &Self::Option
 
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::is_null::IsNull::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -19053,6 +19271,8 @@ pub type vortex_array::scalar_fn::fns::like::Like::Options = vortex_array::scala
 pub fn vortex_array::scalar_fn::fns::like::Like::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::like::Like::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::like::Like::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::like::Like::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -19090,6 +19310,8 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::arity(&self, &
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -19125,6 +19347,8 @@ pub type vortex_array::scalar_fn::fns::literal::Literal::Options = vortex_array:
 pub fn vortex_array::scalar_fn::fns::literal::Literal::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::literal::Literal::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -19162,6 +19386,8 @@ pub fn vortex_array::scalar_fn::fns::mask::Mask::arity(&self, &Self::Options) ->
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::mask::Mask::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::mask::Mask::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -19197,6 +19423,8 @@ pub type vortex_array::scalar_fn::fns::merge::Merge::Options = vortex_array::sca
 pub fn vortex_array::scalar_fn::fns::merge::Merge::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::merge::Merge::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::merge::Merge::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::merge::Merge::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -19234,6 +19462,8 @@ pub fn vortex_array::scalar_fn::fns::not::Not::arity(&self, &Self::Options) -> v
 
 pub fn vortex_array::scalar_fn::fns::not::Not::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::not::Not::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::not::Not::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::not::Not::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -19269,6 +19499,8 @@ pub type vortex_array::scalar_fn::fns::pack::Pack::Options = vortex_array::scala
 pub fn vortex_array::scalar_fn::fns::pack::Pack::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::pack::Pack::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::pack::Pack::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::pack::Pack::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -19306,6 +19538,8 @@ pub fn vortex_array::scalar_fn::fns::root::Root::arity(&self, &Self::Options) ->
 
 pub fn vortex_array::scalar_fn::fns::root::Root::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::root::Root::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::root::Root::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::root::Root::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -19341,6 +19575,8 @@ pub type vortex_array::scalar_fn::fns::select::Select::Options = vortex_array::s
 pub fn vortex_array::scalar_fn::fns::select::Select::arity(&self, &vortex_array::scalar_fn::fns::select::FieldSelection) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::select::Select::child_name(&self, &vortex_array::scalar_fn::fns::select::FieldSelection, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::select::Select::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::select::Select::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_array::scalar_fn::fns::select::FieldSelection>
 
@@ -19378,6 +19614,8 @@ pub fn vortex_array::scalar_fn::fns::stat::StatFn::arity(&self, &Self::Options) 
 
 pub fn vortex_array::scalar_fn::fns::stat::StatFn::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::stat::StatFn::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::stat::StatFn::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::stat::StatFn::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -19413,6 +19651,8 @@ pub type vortex_array::scalar_fn::fns::variant_get::VariantGet::Options = vortex
 pub fn vortex_array::scalar_fn::fns::variant_get::VariantGet::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::variant_get::VariantGet::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::variant_get::VariantGet::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::variant_get::VariantGet::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -19450,6 +19690,8 @@ pub fn vortex_array::scalar_fn::fns::zip::Zip::arity(&self, &Self::Options) -> v
 
 pub fn vortex_array::scalar_fn::fns::zip::Zip::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::zip::Zip::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
+
 pub fn vortex_array::scalar_fn::fns::zip::Zip::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
 pub fn vortex_array::scalar_fn::fns::zip::Zip::execute(&self, &Self::Options, &dyn vortex_array::scalar_fn::ExecutionArgs, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -19485,6 +19727,8 @@ pub type vortex_array::scalar_fn::internal::row_count::RowCount::Options = vorte
 pub fn vortex_array::scalar_fn::internal::row_count::RowCount::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::internal::row_count::RowCount::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::internal::row_count::RowCount::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::internal::row_count::RowCount::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
@@ -19837,6 +20081,8 @@ pub type vortex_array::scalar_fn::fns::stat::StatFn::Options = vortex_array::sca
 pub fn vortex_array::scalar_fn::fns::stat::StatFn::arity(&self, &Self::Options) -> vortex_array::scalar_fn::Arity
 
 pub fn vortex_array::scalar_fn::fns::stat::StatFn::child_name(&self, &Self::Options, usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::stat::StatFn::coerce_args(&self, &Self::Options, &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_array::dtype::DType>>
 
 pub fn vortex_array::scalar_fn::fns::stat::StatFn::deserialize(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 

--- a/vortex-array/src/aggregate_fn/combined.rs
+++ b/vortex-array/src/aggregate_fn/combined.rs
@@ -102,6 +102,16 @@ pub trait BinaryCombined: 'static + Send + Sync + Clone {
         );
     }
 
+    /// Coerce the input type. Default: chains `right.coerce_args(left.coerce_args(input))`.
+    fn coerce_args(
+        &self,
+        options: &CombinedOptions<Self>,
+        input_dtype: &DType,
+    ) -> VortexResult<DType> {
+        let left_coerced = self.left().coerce_args(&options.0, input_dtype)?;
+        self.right().coerce_args(&options.1, &left_coerced)
+    }
+
     /// Build the partial struct dtype that wraps the two child partials.
     fn partial_struct_dtype(&self, left: DType, right: DType) -> DType {
         DType::Struct(
@@ -145,6 +155,10 @@ impl<T: BinaryCombined> AggregateFnVTable for Combined<T> {
 
     fn deserialize(&self, metadata: &[u8], session: &VortexSession) -> VortexResult<Self::Options> {
         BinaryCombined::deserialize(&self.0, metadata, session)
+    }
+
+    fn coerce_args(&self, options: &Self::Options, input_dtype: &DType) -> VortexResult<DType> {
+        BinaryCombined::coerce_args(&self.0, options, input_dtype)
     }
 
     fn return_dtype(&self, _options: &Self::Options, input_dtype: &DType) -> Option<DType> {

--- a/vortex-array/src/aggregate_fn/erased.rs
+++ b/vortex-array/src/aggregate_fn/erased.rs
@@ -74,6 +74,11 @@ impl AggregateFnRef {
         AggregateFnOptions { inner: &*self.0 }
     }
 
+    /// Coerce the input type for this aggregate function.
+    pub fn coerce_args(&self, input_dtype: &DType) -> VortexResult<DType> {
+        self.0.coerce_args(input_dtype)
+    }
+
     /// Compute the return [`DType`] per group given the input element type.
     ///
     /// Returns `None` if the input dtype is not supported by the aggregate function.

--- a/vortex-array/src/aggregate_fn/fns/mean/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/mean/mod.rs
@@ -8,6 +8,7 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::aggregate_fn::Accumulator;
 use crate::aggregate_fn::AggregateFnId;
+use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::DynAccumulator;
 use crate::aggregate_fn::EmptyOptions;
 use crate::aggregate_fn::combined::BinaryCombined;
@@ -40,8 +41,10 @@ pub fn mean(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
 ///
 /// Implemented as `Sum / Count` via [`BinaryCombined`].
 ///
-/// Booleans and primitive numeric types produce nullable `f64` results.
-/// Decimals are kept as decimals but not implemented currently.
+/// Coercion / return type:
+/// - Booleans and primitive numeric types are coerced to `f64` and the result
+///   is a nullable `f64`.
+/// - Decimals are kept as decimals but not implemented currently
 #[derive(Clone, Debug)]
 pub struct Mean;
 
@@ -109,6 +112,35 @@ impl BinaryCombined for Mean {
 
     fn serialize(&self, _options: &CombinedOptions<Self>) -> VortexResult<Option<Vec<u8>>> {
         unimplemented!("mean is not yet serializable");
+    }
+
+    fn coerce_args(
+        &self,
+        _options: &PairOptions<
+            <Sum as AggregateFnVTable>::Options,
+            <Count as AggregateFnVTable>::Options,
+        >,
+        input_dtype: &DType,
+    ) -> VortexResult<DType> {
+        // Advisory hint for query planners: where possible, cast input to the
+        // type we're going to compute the mean in.
+        Ok(coerced_input_dtype(input_dtype).unwrap_or_else(|| input_dtype.clone()))
+    }
+}
+
+/// Hint for callers: what to cast the input to before accumulation.
+///
+/// - Bool stays as bool — `Sum` has a native bool path and bool → f64 isn't
+///   currently a direct cast in vortex.
+/// - Primitive numerics → `f64` so the sum and finalize work without overflow.
+fn coerced_input_dtype(input_dtype: &DType) -> Option<DType> {
+    match input_dtype {
+        DType::Bool(_) => Some(input_dtype.clone()),
+        DType::Primitive(_, n) => Some(DType::Primitive(PType::F64, *n)),
+        DType::Decimal(..) => {
+            unimplemented!("mean is not implemented for decimals yet")
+        }
+        _ => None,
     }
 }
 

--- a/vortex-array/src/aggregate_fn/typed.rs
+++ b/vortex-array/src/aggregate_fn/typed.rs
@@ -38,6 +38,7 @@ pub(super) trait DynAggregateFn: 'static + Send + Sync + super::sealed::Sealed {
     fn id(&self) -> AggregateFnId;
     fn options_any(&self) -> &dyn Any;
 
+    fn coerce_args(&self, input_dtype: &DType) -> VortexResult<DType>;
     fn return_dtype(&self, input_dtype: &DType) -> Option<DType>;
     fn state_dtype(&self, input_dtype: &DType) -> Option<DType>;
     fn accumulator(&self, input_dtype: &DType) -> VortexResult<AccumulatorRef>;
@@ -73,6 +74,10 @@ impl<V: AggregateFnVTable> DynAggregateFn for AggregateFnInner<V> {
 
     fn options_any(&self) -> &dyn Any {
         &self.options
+    }
+
+    fn coerce_args(&self, input_dtype: &DType) -> VortexResult<DType> {
+        V::coerce_args(&self.vtable, &self.options, input_dtype)
     }
 
     fn return_dtype(&self, input_dtype: &DType) -> Option<DType> {

--- a/vortex-array/src/aggregate_fn/vtable.rs
+++ b/vortex-array/src/aggregate_fn/vtable.rs
@@ -57,6 +57,15 @@ pub trait AggregateFnVTable: 'static + Sized + Clone + Send + Sync {
         vortex_bail!("Aggregate function {} is not deserializable", self.id());
     }
 
+    /// Coerce the input type for this aggregate function.
+    ///
+    /// This is optionally used by Vortex users when performing type coercion over a Vortex
+    /// expression. The default implementation returns the input type unchanged.
+    fn coerce_args(&self, options: &Self::Options, input_dtype: &DType) -> VortexResult<DType> {
+        let _ = options;
+        Ok(input_dtype.clone())
+    }
+
     /// The return [`DType`] of the aggregate.
     ///
     /// Returns `None` if the aggregate function cannot be applied to the input dtype.

--- a/vortex-array/src/dtype/coercion.rs
+++ b/vortex-array/src/dtype/coercion.rs
@@ -1,0 +1,756 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Utilities for performing type coercion.
+
+use std::sync::Arc;
+
+use crate::dtype::DType;
+use crate::dtype::PType;
+use crate::dtype::decimal::DecimalDType;
+
+impl PType {
+    /// Returns the least supertype (widest common type) of two primitive types,
+    /// or `None` if no lossless promotion exists.
+    pub fn least_supertype(self, other: PType) -> Option<PType> {
+        if self == other {
+            return Some(self);
+        }
+
+        // Same family — pick the wider.
+        if self.is_unsigned_int() && other.is_unsigned_int() {
+            return Some(self.max_unsigned_ptype(other));
+        }
+        if self.is_signed_int() && other.is_signed_int() {
+            return Some(self.max_signed_ptype(other));
+        }
+        if self.is_float() && other.is_float() {
+            return if self.byte_width() >= other.byte_width() {
+                Some(self)
+            } else {
+                Some(other)
+            };
+        }
+
+        // Unsigned + Signed crossover — promote to signed one width-step wider.
+        if self.is_unsigned_int() && other.is_signed_int() {
+            return Self::unsigned_signed_supertype(self, other);
+        }
+        if self.is_signed_int() && other.is_unsigned_int() {
+            return Self::unsigned_signed_supertype(other, self);
+        }
+
+        // Int + Float — pick the smallest float that losslessly represents the integer.
+        let (int, float) = if self.is_float() {
+            (other, self)
+        } else {
+            (self, other)
+        };
+        Self::int_float_supertype(int, float)
+    }
+
+    fn unsigned_signed_supertype(unsigned: PType, signed: PType) -> Option<PType> {
+        use PType::*;
+        match unsigned.byte_width().max(signed.byte_width()) {
+            1 => Some(I16),
+            2 => Some(I32),
+            4 => Some(I64),
+            _ => None, // U64 + I64 — no lossless 128-bit integer type
+        }
+    }
+
+    fn int_float_supertype(int: PType, float: PType) -> Option<PType> {
+        use PType::*;
+        let min_float = match int.byte_width() {
+            1 => F16,         // f16 has 11-bit mantissa, enough for 8-bit ints
+            2 => F32,         // f32 has 24-bit mantissa, enough for 16-bit ints
+            4 => F64,         // f64 has 53-bit mantissa, enough for 32-bit ints
+            _ => return None, // no standard float for 64-bit ints
+        };
+        if float.byte_width() >= min_float.byte_width() {
+            Some(float)
+        } else {
+            Some(min_float)
+        }
+    }
+}
+
+impl DType {
+    /// The core primitive — what type can hold both `self` and `other`?
+    /// Returns `None` if no common supertype exists.
+    pub fn least_supertype(&self, other: &DType) -> Option<DType> {
+        let union_null = self.nullability() | other.nullability();
+
+        if let (
+            DType::FixedSizeList(lhs_elem, lhs_size, _),
+            DType::FixedSizeList(rhs_elem, rhs_size, _),
+        ) = (self, other)
+            && lhs_size == rhs_size
+        {
+            let elem = lhs_elem.least_supertype(rhs_elem)?;
+            return Some(DType::FixedSizeList(Arc::new(elem), *lhs_size, union_null));
+        }
+
+        if let (DType::List(lhs_elem, _), DType::List(rhs_elem, _)) = (self, other) {
+            let elem = lhs_elem.least_supertype(rhs_elem)?;
+            return Some(DType::List(Arc::new(elem), union_null));
+        }
+
+        // Identity (ignoring nullability): return self with union nullability
+        if self.eq_ignore_nullability(other) {
+            return Some(self.with_nullability(union_null));
+        }
+
+        // Null + X: return X as nullable
+        if matches!(self, DType::Null) {
+            return Some(other.as_nullable());
+        }
+        if matches!(other, DType::Null) {
+            return Some(self.as_nullable());
+        }
+
+        // Bool + numeric: return the numeric type (with union nullability)
+        if self.is_boolean() && other.is_numeric() {
+            return Some(other.with_nullability(union_null));
+        }
+        if other.is_boolean() && self.is_numeric() {
+            return Some(self.with_nullability(union_null));
+        }
+
+        // Primitive + Primitive (different ptypes): delegate to PType::least_supertype
+        if let (DType::Primitive(lhs_p, _), DType::Primitive(rhs_p, _)) = (self, other) {
+            return lhs_p
+                .least_supertype(*rhs_p)
+                .map(|p| DType::Primitive(p, union_null));
+        }
+
+        // Decimal + Decimal: compute wider decimal
+        if let (DType::Decimal(lhs_d, _), DType::Decimal(rhs_d, _)) = (self, other) {
+            return decimal_least_supertype(*lhs_d, *rhs_d).map(|d| DType::Decimal(d, union_null));
+        }
+
+        // Decimal + integer Primitive: convert integer to Decimal, then widen
+        if let (DType::Decimal(dec, _), DType::Primitive(p, _)) = (self, other)
+            && p.is_int()
+        {
+            let int_dec = DecimalDType::new(integer_decimal_precision(*p), 0);
+            return decimal_least_supertype(*dec, int_dec).map(|d| DType::Decimal(d, union_null));
+        }
+        if let (DType::Primitive(p, _), DType::Decimal(dec, _)) = (self, other)
+            && p.is_int()
+        {
+            let int_dec = DecimalDType::new(integer_decimal_precision(*p), 0);
+            return decimal_least_supertype(int_dec, *dec).map(|d| DType::Decimal(d, union_null));
+        }
+
+        // Extension + anything: delegate to vtable
+        if let DType::Extension(ext) = self {
+            return ext
+                .least_supertype(other)
+                .map(|dt| dt.with_nullability(union_null));
+        }
+        if let DType::Extension(ext) = other {
+            return ext
+                .least_supertype(self)
+                .map(|dt| dt.with_nullability(union_null));
+        }
+
+        None
+    }
+
+    /// Fold over a slice — what type can hold all of these?
+    pub fn least_supertype_of(types: &[DType]) -> Option<DType> {
+        types
+            .iter()
+            .skip(1)
+            .try_fold(types[0].clone(), |acc, t| acc.least_supertype(t))
+    }
+
+    /// Is there any implicit coercion path from `other` to `self`?
+    pub fn can_coerce_from(&self, other: &DType) -> bool {
+        if let (
+            DType::FixedSizeList(target_elem, target_size, _),
+            DType::FixedSizeList(source_elem, source_size, _),
+        ) = (self, other)
+        {
+            return target_size == source_size
+                && (self.is_nullable() || !other.is_nullable())
+                && target_elem.can_coerce_from(source_elem);
+        }
+
+        if let (DType::List(target_elem, _), DType::List(source_elem, _)) = (self, other) {
+            return (self.is_nullable() || !other.is_nullable())
+                && target_elem.can_coerce_from(source_elem);
+        }
+
+        // Same type (ignoring nullability): check nullability compatibility
+        if self.eq_ignore_nullability(other) {
+            return self.is_nullable() || !other.is_nullable();
+        }
+
+        // Null → nullable target
+        if matches!(other, DType::Null) {
+            return self.is_nullable();
+        }
+
+        // Bool → numeric
+        if other.is_boolean() && self.is_numeric() {
+            return self.is_nullable() || !other.is_nullable();
+        }
+
+        // Primitive widening: true if least_supertype(source, target) == target
+        if let (DType::Primitive(..), DType::Primitive(..)) = (self, other) {
+            return other
+                .least_supertype(self)
+                .is_some_and(|st| st.eq_ignore_nullability(self))
+                && (self.is_nullable() || !other.is_nullable());
+        }
+
+        // Decimal widening
+        if let (DType::Decimal(target, _), DType::Decimal(source, _)) = (self, other) {
+            let target_integral = target.precision() as i16 - target.scale() as i16;
+            let source_integral = source.precision() as i16 - source.scale() as i16;
+            return target_integral >= source_integral
+                && target.scale() >= source.scale()
+                && (self.is_nullable() || !other.is_nullable());
+        }
+
+        // Integer → Decimal
+        if let (DType::Decimal(dec, _), DType::Primitive(p, _)) = (self, other)
+            && p.is_int()
+        {
+            let needed = integer_decimal_precision(*p);
+            let integral_digits = dec.precision() as i16 - dec.scale() as i16;
+            return integral_digits >= needed as i16
+                && (self.is_nullable() || !other.is_nullable());
+        }
+
+        // Extension: delegate to vtable
+        if let DType::Extension(ext) = self {
+            return ext.can_coerce_from(other);
+        }
+
+        false
+    }
+
+    /// Convenience — is there a path from `self` to `other`?
+    pub fn can_coerce_to(&self, other: &DType) -> bool {
+        other.can_coerce_from(self)
+    }
+
+    /// Are all types in the slice mutually coercible to a common type?
+    pub fn are_coercible(types: &[DType]) -> bool {
+        DType::least_supertype_of(types).is_some()
+    }
+
+    /// Can all types in the slice be coerced to a specific target?
+    pub fn all_coercible_to(types: &[DType], target: &DType) -> bool {
+        types.iter().all(|t| target.can_coerce_from(t))
+    }
+
+    /// Coerce a slice to a specific target — returns the vec of targets
+    /// if all are coercible, `None` if any are not.
+    pub fn coerce_all_to(types: &[DType], target: &DType) -> Option<Vec<DType>> {
+        types
+            .iter()
+            .all(|t| target.can_coerce_from(t))
+            .then(|| vec![target.clone(); types.len()])
+    }
+
+    /// Coerce a slice to their mutual least supertype.
+    pub fn coerce_to_supertype(types: &[DType]) -> Option<Vec<DType>> {
+        let supertype = DType::least_supertype_of(types)?;
+        Some(vec![supertype; types.len()])
+    }
+
+    /// Is this a numeric type (primitive int/float or decimal)?
+    pub fn is_numeric(&self) -> bool {
+        matches!(self, DType::Primitive(..) | DType::Decimal(..))
+    }
+
+    /// Is this a temporal type (date, time, timestamp, duration)?
+    pub fn is_temporal(&self) -> bool {
+        match self {
+            DType::Extension(ext) => {
+                use crate::dtype::extension::Matcher;
+                use crate::extension::datetime::AnyTemporal;
+                AnyTemporal::matches(ext)
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Maps integer PType widths to the minimum decimal precision needed.
+fn integer_decimal_precision(ptype: PType) -> u8 {
+    match ptype {
+        PType::U8 | PType::I8 => 3,
+        PType::U16 | PType::I16 => 5,
+        PType::U32 | PType::I32 => 10,
+        PType::U64 | PType::I64 => 19,
+        _ => 19,
+    }
+}
+
+/// Compute the least supertype of two decimal types using SQL-standard rules.
+fn decimal_least_supertype(a: DecimalDType, b: DecimalDType) -> Option<DecimalDType> {
+    let a_integral = a.precision() as i16 - a.scale() as i16;
+    let b_integral = b.precision() as i16 - b.scale() as i16;
+    let max_integral = a_integral.max(b_integral);
+    let max_scale = a.scale().max(b.scale());
+    let precision = u8::try_from(max_integral + max_scale as i16).ok()?;
+    DecimalDType::try_new(precision, max_scale).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::dtype::DType;
+    use crate::dtype::PType;
+    use crate::dtype::decimal::DecimalDType;
+    use crate::dtype::nullability::Nullability::NonNullable;
+    use crate::dtype::nullability::Nullability::Nullable;
+
+    #[test]
+    fn is_numeric() {
+        assert!(DType::Primitive(PType::I32, NonNullable).is_numeric());
+        assert!(DType::Primitive(PType::F64, NonNullable).is_numeric());
+        assert!(DType::Decimal(DecimalDType::new(10, 2), NonNullable).is_numeric());
+        assert!(!DType::Bool(NonNullable).is_numeric());
+        assert!(!DType::Utf8(NonNullable).is_numeric());
+        assert!(!DType::Null.is_numeric());
+    }
+
+    #[test]
+    fn least_supertype_identity() {
+        let i32_nn = DType::Primitive(PType::I32, NonNullable);
+        assert_eq!(i32_nn.least_supertype(&i32_nn).unwrap(), i32_nn);
+    }
+
+    #[test]
+    fn least_supertype_nullability_union() {
+        let i32_nn = DType::Primitive(PType::I32, NonNullable);
+        let i32_n = DType::Primitive(PType::I32, Nullable);
+        assert_eq!(i32_nn.least_supertype(&i32_n).unwrap(), i32_n);
+        assert_eq!(i32_n.least_supertype(&i32_nn).unwrap(), i32_n);
+    }
+
+    #[test]
+    fn least_supertype_null_absorption() {
+        let i32_nn = DType::Primitive(PType::I32, NonNullable);
+        assert_eq!(
+            DType::Null.least_supertype(&i32_nn).unwrap(),
+            DType::Primitive(PType::I32, Nullable)
+        );
+        assert_eq!(
+            i32_nn.least_supertype(&DType::Null).unwrap(),
+            DType::Primitive(PType::I32, Nullable)
+        );
+    }
+
+    #[test]
+    fn least_supertype_unsigned_widening() {
+        let u8_nn = DType::Primitive(PType::U8, NonNullable);
+        let u32_nn = DType::Primitive(PType::U32, NonNullable);
+        assert_eq!(u8_nn.least_supertype(&u32_nn).unwrap(), u32_nn);
+    }
+
+    #[test]
+    fn least_supertype_signed_widening() {
+        let i16_nn = DType::Primitive(PType::I16, NonNullable);
+        let i64_nn = DType::Primitive(PType::I64, NonNullable);
+        assert_eq!(i16_nn.least_supertype(&i64_nn).unwrap(), i64_nn);
+    }
+
+    #[test]
+    fn least_supertype_cross_family() {
+        let u8_nn = DType::Primitive(PType::U8, NonNullable);
+        let i8_nn = DType::Primitive(PType::I8, NonNullable);
+        assert_eq!(
+            u8_nn.least_supertype(&i8_nn).unwrap(),
+            DType::Primitive(PType::I16, NonNullable)
+        );
+    }
+
+    #[test]
+    fn least_supertype_u64_i64_none() {
+        let u64_nn = DType::Primitive(PType::U64, NonNullable);
+        let i64_nn = DType::Primitive(PType::I64, NonNullable);
+        assert!(u64_nn.least_supertype(&i64_nn).is_none());
+    }
+
+    #[test]
+    fn least_supertype_int_float_promotion() {
+        let u8_nn = DType::Primitive(PType::U8, NonNullable);
+        let f32_nn = DType::Primitive(PType::F32, NonNullable);
+        assert_eq!(u8_nn.least_supertype(&f32_nn).unwrap(), f32_nn);
+    }
+
+    #[test]
+    fn least_supertype_i32_f32_to_f64() {
+        let i32_nn = DType::Primitive(PType::I32, NonNullable);
+        let f32_nn = DType::Primitive(PType::F32, NonNullable);
+        assert_eq!(
+            i32_nn.least_supertype(&f32_nn).unwrap(),
+            DType::Primitive(PType::F64, NonNullable)
+        );
+    }
+
+    #[test]
+    fn least_supertype_bool_numeric() {
+        let bool_nn = DType::Bool(NonNullable);
+        let i32_nn = DType::Primitive(PType::I32, NonNullable);
+        assert_eq!(bool_nn.least_supertype(&i32_nn).unwrap(), i32_nn);
+        assert_eq!(i32_nn.least_supertype(&bool_nn).unwrap(), i32_nn);
+    }
+
+    #[test]
+    fn least_supertype_decimal_widening() {
+        let d1 = DType::Decimal(DecimalDType::new(10, 2), NonNullable);
+        let d2 = DType::Decimal(DecimalDType::new(15, 5), NonNullable);
+        let result = d1.least_supertype(&d2).unwrap();
+        // integral digits: max(8, 10) = 10, max scale = 5, precision = 15
+        assert_eq!(
+            result,
+            DType::Decimal(DecimalDType::new(15, 5), NonNullable)
+        );
+    }
+
+    #[test]
+    fn least_supertype_incompatible_none() {
+        let utf8 = DType::Utf8(NonNullable);
+        let i32_nn = DType::Primitive(PType::I32, NonNullable);
+        assert!(utf8.least_supertype(&i32_nn).is_none());
+    }
+
+    #[test]
+    fn can_coerce_from_widening() {
+        let i32_nn = DType::Primitive(PType::I32, NonNullable);
+        let i64_nn = DType::Primitive(PType::I64, NonNullable);
+        assert!(i64_nn.can_coerce_from(&i32_nn));
+    }
+
+    #[test]
+    fn can_coerce_from_narrowing_rejected() {
+        let i32_nn = DType::Primitive(PType::I32, NonNullable);
+        let i64_nn = DType::Primitive(PType::I64, NonNullable);
+        assert!(!i32_nn.can_coerce_from(&i64_nn));
+    }
+
+    #[test]
+    fn can_coerce_from_nullability_constraints() {
+        let i32_nn = DType::Primitive(PType::I32, NonNullable);
+        let i32_n = DType::Primitive(PType::I32, Nullable);
+        assert!(i32_n.can_coerce_from(&i32_nn));
+        assert!(!i32_nn.can_coerce_from(&i32_n));
+    }
+
+    #[test]
+    fn can_coerce_from_null() {
+        let i32_n = DType::Primitive(PType::I32, Nullable);
+        let i32_nn = DType::Primitive(PType::I32, NonNullable);
+        assert!(i32_n.can_coerce_from(&DType::Null));
+        assert!(!i32_nn.can_coerce_from(&DType::Null));
+    }
+
+    #[test]
+    fn are_coercible_mixed() {
+        let types = [
+            DType::Primitive(PType::I32, NonNullable),
+            DType::Primitive(PType::I64, NonNullable),
+        ];
+        assert!(DType::are_coercible(&types));
+    }
+
+    #[test]
+    fn all_coercible_to_target() {
+        let types = [
+            DType::Primitive(PType::I32, NonNullable),
+            DType::Primitive(PType::I16, NonNullable),
+        ];
+        let target = DType::Primitive(PType::I64, NonNullable);
+        assert!(DType::all_coercible_to(&types, &target));
+    }
+
+    #[test]
+    fn coerce_to_supertype_works() {
+        let types = [
+            DType::Primitive(PType::U8, NonNullable),
+            DType::Primitive(PType::I16, NonNullable),
+        ];
+        let result = DType::coerce_to_supertype(&types).unwrap();
+        // U8 + I16: unsigned_signed_supertype max_width=max(1,2)=2 => I32
+        assert_eq!(result, vec![DType::Primitive(PType::I32, NonNullable); 2]);
+    }
+
+    #[test]
+    fn fsl_widens_element_dtype_when_size_matches() {
+        let lhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            768,
+            NonNullable,
+        );
+        let rhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            768,
+            NonNullable,
+        );
+        let expected = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            768,
+            NonNullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+    }
+
+    #[test]
+    fn fsl_size_mismatch_returns_none() {
+        let lhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            768,
+            NonNullable,
+        );
+        let rhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            1024,
+            NonNullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), None);
+    }
+
+    #[test]
+    fn fsl_unions_outer_nullability() {
+        let lhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            4,
+            NonNullable,
+        );
+        let rhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            4,
+            Nullable,
+        );
+        let expected = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            4,
+            Nullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+    }
+
+    #[test]
+    fn fsl_widening_unions_element_nullability() {
+        let lhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            4,
+            NonNullable,
+        );
+        let rhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, Nullable)),
+            4,
+            NonNullable,
+        );
+        let expected = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, Nullable)),
+            4,
+            NonNullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+    }
+
+    #[test]
+    fn fsl_incompatible_elements_returns_none() {
+        let lhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            4,
+            NonNullable,
+        );
+        let rhs = DType::FixedSizeList(Arc::new(DType::Utf8(NonNullable)), 4, NonNullable);
+        assert_eq!(lhs.least_supertype(&rhs), None);
+    }
+
+    #[test]
+    fn fsl_can_coerce_from_widening() {
+        let target = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            4,
+            NonNullable,
+        );
+        let source = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            4,
+            NonNullable,
+        );
+        assert!(target.can_coerce_from(&source));
+        assert!(!source.can_coerce_from(&target));
+    }
+
+    #[test]
+    fn fsl_same_element_widening_unions_inner_nullability() {
+        let lhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::I32, NonNullable)),
+            4,
+            NonNullable,
+        );
+        let rhs = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::I32, Nullable)),
+            4,
+            NonNullable,
+        );
+        let expected = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::I32, Nullable)),
+            4,
+            NonNullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+    }
+
+    #[test]
+    fn list_widens_element_dtype() {
+        let lhs = DType::List(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            NonNullable,
+        );
+        let rhs = DType::List(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            NonNullable,
+        );
+        let expected = DType::List(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            NonNullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+    }
+
+    #[test]
+    fn list_unions_outer_nullability() {
+        let lhs = DType::List(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            NonNullable,
+        );
+        let rhs = DType::List(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            Nullable,
+        );
+        let expected = DType::List(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            Nullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+    }
+
+    #[test]
+    fn list_unions_inner_nullability() {
+        let lhs = DType::List(
+            Arc::new(DType::Primitive(PType::I32, NonNullable)),
+            NonNullable,
+        );
+        let rhs = DType::List(
+            Arc::new(DType::Primitive(PType::I32, Nullable)),
+            NonNullable,
+        );
+        let expected = DType::List(
+            Arc::new(DType::Primitive(PType::I32, Nullable)),
+            NonNullable,
+        );
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+    }
+
+    #[test]
+    fn list_incompatible_elements_returns_none() {
+        let lhs = DType::List(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            NonNullable,
+        );
+        let rhs = DType::List(Arc::new(DType::Utf8(NonNullable)), NonNullable);
+        assert_eq!(lhs.least_supertype(&rhs), None);
+    }
+
+    #[test]
+    fn list_can_coerce_from_widening() {
+        let target = DType::List(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            NonNullable,
+        );
+        let source = DType::List(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            NonNullable,
+        );
+        assert!(target.can_coerce_from(&source));
+        assert!(!source.can_coerce_from(&target));
+    }
+
+    #[test]
+    fn fsl_can_coerce_from_rejects_nullable_source_elements() {
+        let target = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            4,
+            NonNullable,
+        );
+        let source = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, Nullable)),
+            4,
+            NonNullable,
+        );
+        assert!(!target.can_coerce_from(&source));
+    }
+
+    #[test]
+    fn list_can_coerce_from_rejects_nullable_source_elements() {
+        let target = DType::List(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            NonNullable,
+        );
+        let source = DType::List(
+            Arc::new(DType::Primitive(PType::F32, Nullable)),
+            NonNullable,
+        );
+        assert!(!target.can_coerce_from(&source));
+    }
+
+    #[test]
+    fn fsl_can_coerce_from_allows_widening_nullable_target() {
+        let target = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::I32, Nullable)),
+            4,
+            NonNullable,
+        );
+        let source = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::I32, NonNullable)),
+            4,
+            NonNullable,
+        );
+        assert!(target.can_coerce_from(&source));
+    }
+
+    #[test]
+    fn fsl_can_coerce_from_size_mismatch_rejected() {
+        let a = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            4,
+            NonNullable,
+        );
+        let b = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F32, NonNullable)),
+            8,
+            NonNullable,
+        );
+        assert!(!a.can_coerce_from(&b));
+        assert!(!b.can_coerce_from(&a));
+    }
+
+    #[test]
+    fn least_supertype_integer_decimal() {
+        let i32_nn = DType::Primitive(PType::I32, NonNullable);
+        let dec = DType::Decimal(DecimalDType::new(15, 5), NonNullable);
+        let result = i32_nn.least_supertype(&dec).unwrap();
+        // int_dec for I32 = Decimal(10, 0). integral digits = 10.
+        // dec integral = 15 - 5 = 10.
+        // max_integral = 10, max_scale = 5, precision = 15
+        assert_eq!(
+            result,
+            DType::Decimal(DecimalDType::new(15, 5), NonNullable)
+        );
+    }
+}

--- a/vortex-array/src/dtype/dtype_impl.rs
+++ b/vortex-array/src/dtype/dtype_impl.rs
@@ -222,23 +222,6 @@ impl DType {
         matches!(self, Decimal(..))
     }
 
-    /// Check if `self` is numeric.
-    pub fn is_numeric(&self) -> bool {
-        matches!(self, Primitive(..) | Decimal(..))
-    }
-
-    /// Check if `self` is a temporal extension type.
-    pub fn is_temporal(&self) -> bool {
-        match self {
-            Extension(ext) => {
-                use crate::dtype::extension::Matcher;
-                use crate::extension::datetime::AnyTemporal;
-                AnyTemporal::matches(ext)
-            }
-            _ => false,
-        }
-    }
-
     /// Check if `self` is a [`DType::Utf8`]
     pub fn is_utf8(&self) -> bool {
         matches!(self, Utf8(_))
@@ -527,16 +510,6 @@ mod tests {
             Timestamp::new_with_tz(TimeUnit::Seconds, Some("ET".into()), Nullable).erased(),
         );
         assert!(!t1.eq_ignore_nullability(&t2));
-    }
-
-    #[test]
-    fn is_numeric() {
-        assert!(DType::Primitive(PType::I32, NonNullable).is_numeric());
-        assert!(DType::Primitive(PType::F64, NonNullable).is_numeric());
-        assert!(DType::Decimal(DecimalDType::new(10, 2), NonNullable).is_numeric());
-        assert!(!DType::Bool(NonNullable).is_numeric());
-        assert!(!DType::Utf8(NonNullable).is_numeric());
-        assert!(!DType::Null.is_numeric());
     }
 
     #[test]

--- a/vortex-array/src/dtype/extension/erased.rs
+++ b/vortex-array/src/dtype/extension/erased.rs
@@ -99,6 +99,21 @@ impl ExtDTypeRef {
     pub(crate) fn validate_storage_value(&self, storage_value: &ScalarValue) -> VortexResult<()> {
         self.0.validate_scalar_value(storage_value)
     }
+
+    /// Can a value of `other` be implicitly coerced into this extension type?
+    pub fn can_coerce_from(&self, other: &DType) -> bool {
+        self.0.can_coerce_from(other)
+    }
+
+    /// Can this extension type be implicitly coerced into `other`?
+    pub fn can_coerce_to(&self, other: &DType) -> bool {
+        self.0.can_coerce_to(other)
+    }
+
+    /// Compute the least supertype of this extension type and another type.
+    pub fn least_supertype(&self, other: &DType) -> Option<DType> {
+        self.0.least_supertype(other)
+    }
 }
 
 /// Methods for downcasting type-erased extension dtypes.

--- a/vortex-array/src/dtype/extension/typed.rs
+++ b/vortex-array/src/dtype/extension/typed.rs
@@ -108,6 +108,21 @@ impl<V: ExtVTable> ExtDType<V> {
         V::validate_scalar_value(self, storage_value)
     }
 
+    /// Can a value of `other` be implicitly coerced into this extension type?
+    pub fn can_coerce_from(&self, other: &DType) -> bool {
+        V::can_coerce_from(self, other)
+    }
+
+    /// Can this extension type be implicitly coerced into `other`?
+    pub fn can_coerce_to(&self, other: &DType) -> bool {
+        V::can_coerce_to(self, other)
+    }
+
+    /// Compute the least supertype of this extension type and another type.
+    pub fn least_supertype(&self, other: &DType) -> Option<DType> {
+        V::least_supertype(self, other)
+    }
+
     /// Erase the concrete type information, returning a type-erased extension dtype.
     pub fn erased(self) -> ExtDTypeRef {
         ExtDTypeRef(Arc::new(self))
@@ -133,6 +148,9 @@ pub(super) trait DynExtDType: 'static + Send + Sync + super::sealed::Sealed {
     fn validate_scalar_value(&self, storage_value: &ScalarValue) -> VortexResult<()>;
     fn value_display(&self, f: &mut fmt::Formatter<'_>, storage_value: &ScalarValue)
     -> fmt::Result;
+    fn can_coerce_from(&self, other: &DType) -> bool;
+    fn can_coerce_to(&self, other: &DType) -> bool;
+    fn least_supertype(&self, other: &DType) -> Option<DType>;
 }
 
 /// Blanket impl: thin forwarder to `ExtDType<V>` inherent methods.
@@ -201,5 +219,17 @@ impl<V: ExtVTable> DynExtDType for ExtDType<V> {
                 self.id()
             ),
         }
+    }
+
+    fn can_coerce_from(&self, other: &DType) -> bool {
+        self.can_coerce_from(other)
+    }
+
+    fn can_coerce_to(&self, other: &DType) -> bool {
+        self.can_coerce_to(other)
+    }
+
+    fn least_supertype(&self, other: &DType) -> Option<DType> {
+        self.least_supertype(other)
     }
 }

--- a/vortex-array/src/dtype/extension/vtable.rs
+++ b/vortex-array/src/dtype/extension/vtable.rs
@@ -7,6 +7,7 @@ use std::hash::Hash;
 
 use vortex_error::VortexResult;
 
+use crate::dtype::DType;
 use crate::dtype::extension::ExtDType;
 use crate::dtype::extension::ExtId;
 use crate::scalar::ScalarValue;
@@ -37,6 +38,33 @@ pub trait ExtVTable: 'static + Sized + Send + Sync + Clone + Debug + Eq + Hash {
 
     /// Validate that the given storage type is compatible with this extension type.
     fn validate_dtype(ext_dtype: &ExtDType<Self>) -> VortexResult<()>;
+
+    /// Can a value of `other` be implicitly widened into this type? (e.g. GeographyType might
+    /// accept Point, LineString, etc.)
+    ///
+    /// Implementors only need to override one of `can_coerce_from` or `can_coerce_to`. We have both
+    /// so that either side of the coercion can provide the logic.
+    fn can_coerce_from(ext_dtype: &ExtDType<Self>, other: &DType) -> bool {
+        let _ = (ext_dtype, other);
+        false
+    }
+
+    /// Can this type be implicitly widened into `other`?
+    ///
+    /// Implementors only need to override one of `can_coerce_from` or `can_coerce_to`. We have both
+    /// so that either side of the coercion can provide the logic.
+    fn can_coerce_to(ext_dtype: &ExtDType<Self>, other: &DType) -> bool {
+        let _ = (ext_dtype, other);
+        false
+    }
+
+    /// Given two types in a Uniform context, what is their least supertype?
+    ///
+    /// Return None if no supertype exists.
+    fn least_supertype(ext_dtype: &ExtDType<Self>, other: &DType) -> Option<DType> {
+        let _ = (ext_dtype, other);
+        None
+    }
 
     // Methods related to the extension scalar values.
 

--- a/vortex-array/src/dtype/mod.rs
+++ b/vortex-array/src/dtype/mod.rs
@@ -10,6 +10,7 @@
 mod arbitrary;
 pub mod arrow;
 mod bigint;
+mod coercion;
 mod decimal;
 mod dtype_impl;
 pub mod extension;

--- a/vortex-array/src/expr/transform/coerce.rs
+++ b/vortex-array/src/expr/transform/coerce.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Expression-level type coercion pass.
+
+use vortex_error::VortexResult;
+
+use crate::dtype::DType;
+use crate::expr::Expression;
+use crate::expr::cast;
+use crate::expr::traversal::NodeExt;
+use crate::expr::traversal::Transformed;
+use crate::scalar_fn::fns::literal::Literal;
+use crate::scalar_fn::fns::root::Root;
+
+/// Rewrite an expression tree to insert casts where a scalar function's `coerce_args` demands
+/// a different type than what the child currently produces.
+///
+/// The rewrite is bottom-up: children are coerced first, then each parent node checks whether
+/// its children match the coerced argument types.
+pub fn coerce_expression(expr: Expression, scope: &DType) -> VortexResult<Expression> {
+    // We capture scope by reference for the closure.
+    let scope = scope.clone();
+    expr.transform_up(|node| {
+        // Leaf nodes (Root, Literal) have no children to coerce.
+        if node.is::<Root>() || node.is::<Literal>() || node.children().is_empty() {
+            return Ok(Transformed::no(node));
+        }
+
+        // Compute the current child return types.
+        let child_dtypes: Vec<DType> = node
+            .children()
+            .iter()
+            .map(|c| c.return_dtype(&scope))
+            .collect::<VortexResult<_>>()?;
+
+        // Ask the scalar function what types it wants.
+        let coerced_dtypes = node.scalar_fn().coerce_args(&child_dtypes)?;
+
+        // If nothing changed, skip.
+        if child_dtypes == coerced_dtypes {
+            return Ok(Transformed::no(node));
+        }
+
+        // Build new children, inserting casts where needed.
+        let new_children: Vec<Expression> = node
+            .children()
+            .iter()
+            .zip(coerced_dtypes.iter())
+            .map(|(child, target)| {
+                let child_dtype = child.return_dtype(&scope)?;
+                if child_dtype.eq_ignore_nullability(target)
+                    && child_dtype.nullability() == target.nullability()
+                {
+                    Ok(child.clone())
+                } else {
+                    Ok(cast(child.clone(), target.clone()))
+                }
+            })
+            .collect::<VortexResult<_>>()?;
+
+        let new_expr = node.with_children(new_children)?;
+        Ok(Transformed::yes(new_expr))
+    })
+    .map(|t| t.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_error::VortexResult;
+
+    use crate::dtype::DType;
+    use crate::dtype::Nullability::NonNullable;
+    use crate::dtype::PType;
+    use crate::dtype::StructFields;
+    use crate::expr::col;
+    use crate::expr::lit;
+    use crate::expr::transform::coerce::coerce_expression;
+    use crate::scalar::Scalar;
+    use crate::scalar_fn::ScalarFnVTableExt;
+    use crate::scalar_fn::fns::binary::Binary;
+    use crate::scalar_fn::fns::cast::Cast;
+    use crate::scalar_fn::fns::operators::Operator;
+
+    fn test_scope() -> DType {
+        DType::Struct(
+            StructFields::new(
+                ["x", "y"].into(),
+                vec![
+                    DType::Primitive(PType::I32, NonNullable),
+                    DType::Primitive(PType::I64, NonNullable),
+                ],
+            ),
+            NonNullable,
+        )
+    }
+
+    #[test]
+    fn mixed_type_comparison_inserts_cast() -> VortexResult<()> {
+        let scope = test_scope();
+        // x (I32) < y (I64) => should cast x to I64
+        let expr = Binary.new_expr(Operator::Lt, [col("x"), col("y")]);
+        let coerced = coerce_expression(expr, &scope)?;
+
+        // The LHS child should now be a cast expression
+        assert!(coerced.child(0).is::<Cast>());
+        // The coerced LHS should return I64
+        assert_eq!(
+            coerced.child(0).return_dtype(&scope)?,
+            DType::Primitive(PType::I64, NonNullable)
+        );
+        // The RHS should be unchanged
+        assert!(!coerced.child(1).is::<Cast>());
+        Ok(())
+    }
+
+    #[test]
+    fn same_type_comparison_no_cast() -> VortexResult<()> {
+        let scope = test_scope();
+        // x (I32) < x (I32) => no cast needed
+        let expr = Binary.new_expr(Operator::Lt, [col("x"), col("x")]);
+        let coerced = coerce_expression(expr, &scope)?;
+
+        // Neither child should be a cast
+        assert!(!coerced.child(0).is::<Cast>());
+        assert!(!coerced.child(1).is::<Cast>());
+        Ok(())
+    }
+
+    #[test]
+    fn mixed_type_arithmetic_coerces_both() -> VortexResult<()> {
+        let scope = DType::Struct(
+            StructFields::new(
+                ["a", "b"].into(),
+                vec![
+                    DType::Primitive(PType::U8, NonNullable),
+                    DType::Primitive(PType::I32, NonNullable),
+                ],
+            ),
+            NonNullable,
+        );
+        // a (U8) + b (I32) => both should be coerced to I32
+        // U8 + I32: unsigned_signed_supertype(U8, I32) => max(1,4)=4 => I64
+        let expr = Binary.new_expr(Operator::Add, [col("a"), col("b")]);
+        let coerced = coerce_expression(expr, &scope)?;
+
+        // LHS (U8) should be cast
+        assert!(coerced.child(0).is::<Cast>());
+        // Both should return the same supertype
+        let lhs_dt = coerced.child(0).return_dtype(&scope)?;
+        let rhs_dt = coerced.child(1).return_dtype(&scope)?;
+        assert_eq!(lhs_dt, rhs_dt);
+        Ok(())
+    }
+
+    #[test]
+    fn boolean_operators_no_coercion() -> VortexResult<()> {
+        let scope = DType::Struct(
+            StructFields::new(
+                ["p", "q"].into(),
+                vec![DType::Bool(NonNullable), DType::Bool(NonNullable)],
+            ),
+            NonNullable,
+        );
+        let expr = Binary.new_expr(Operator::And, [col("p"), col("q")]);
+        let coerced = coerce_expression(expr, &scope)?;
+
+        assert!(!coerced.child(0).is::<Cast>());
+        assert!(!coerced.child(1).is::<Cast>());
+        Ok(())
+    }
+
+    #[test]
+    fn literal_coercion() -> VortexResult<()> {
+        let scope = DType::Struct(
+            StructFields::new(
+                ["x"].into(),
+                vec![DType::Primitive(PType::I64, NonNullable)],
+            ),
+            NonNullable,
+        );
+        // x (I64) + 1i32 => literal should be cast to I64
+        let expr = Binary.new_expr(Operator::Add, [col("x"), lit(Scalar::from(1i32))]);
+        let coerced = coerce_expression(expr, &scope)?;
+
+        // The RHS (literal) should be cast to I64
+        assert!(coerced.child(1).is::<Cast>());
+        assert_eq!(
+            coerced.child(1).return_dtype(&scope)?,
+            DType::Primitive(PType::I64, NonNullable)
+        );
+        Ok(())
+    }
+}

--- a/vortex-array/src/expr/transform/mod.rs
+++ b/vortex-array/src/expr/transform/mod.rs
@@ -2,9 +2,11 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 //! A collection of transformations that can be applied to a [`crate::expr::Expression`].
+mod coerce;
 pub(crate) mod match_between;
 mod partition;
 mod replace;
 
+pub use coerce::*;
 pub use partition::*;
 pub use replace::*;

--- a/vortex-array/src/extension/datetime/date.rs
+++ b/vortex-array/src/extension/datetime/date.rs
@@ -107,6 +107,29 @@ impl ExtVTable for Date {
         Ok(())
     }
 
+    fn can_coerce_from(ext_dtype: &ExtDType<Self>, other: &DType) -> bool {
+        let DType::Extension(other_ext) = other else {
+            return false;
+        };
+        let Some(other_unit) = other_ext.metadata_opt::<Date>() else {
+            return false;
+        };
+        let our_unit = ext_dtype.metadata();
+        // We can coerce from other if our unit is finer (<=) and nullability is compatible.
+        our_unit <= other_unit && (ext_dtype.storage_dtype().is_nullable() || !other.is_nullable())
+    }
+
+    fn least_supertype(ext_dtype: &ExtDType<Self>, other: &DType) -> Option<DType> {
+        let DType::Extension(other_ext) = other else {
+            return None;
+        };
+        let other_unit = other_ext.metadata_opt::<Date>()?;
+        let our_unit = ext_dtype.metadata();
+        let finest = (*our_unit).min(*other_unit);
+        let union_null = ext_dtype.storage_dtype().nullability() | other.nullability();
+        Some(DType::Extension(Date::new(finest, union_null).erased()))
+    }
+
     fn unpack_native<'a>(
         ext_dtype: &'a ExtDType<Self>,
         storage_value: &'a ScalarValue,
@@ -165,6 +188,27 @@ mod tests {
 
         let scalar = Scalar::new(dtype, Some(ScalarValue::Primitive(PValue::I32(365))));
         assert_eq!(format!("{}", scalar.as_extension()), "1971-01-01");
+    }
+
+    #[test]
+    fn least_supertype_date_units() {
+        use crate::dtype::Nullability::NonNullable;
+
+        let days = DType::Extension(Date::new(TimeUnit::Days, NonNullable).erased());
+        let ms = DType::Extension(Date::new(TimeUnit::Milliseconds, NonNullable).erased());
+        let expected = DType::Extension(Date::new(TimeUnit::Milliseconds, NonNullable).erased());
+        assert_eq!(days.least_supertype(&ms).unwrap(), expected);
+        assert_eq!(ms.least_supertype(&days).unwrap(), expected);
+    }
+
+    #[test]
+    fn can_coerce_from_date() {
+        use crate::dtype::Nullability::NonNullable;
+
+        let days = DType::Extension(Date::new(TimeUnit::Days, NonNullable).erased());
+        let ms = DType::Extension(Date::new(TimeUnit::Milliseconds, NonNullable).erased());
+        assert!(ms.can_coerce_from(&days));
+        assert!(!days.can_coerce_from(&ms));
     }
 
     #[test]

--- a/vortex-array/src/extension/datetime/time.rs
+++ b/vortex-array/src/extension/datetime/time.rs
@@ -108,6 +108,28 @@ impl ExtVTable for Time {
         Ok(())
     }
 
+    fn can_coerce_from(ext_dtype: &ExtDType<Self>, other: &DType) -> bool {
+        let DType::Extension(other_ext) = other else {
+            return false;
+        };
+        let Some(other_unit) = other_ext.metadata_opt::<Time>() else {
+            return false;
+        };
+        let our_unit = ext_dtype.metadata();
+        our_unit <= other_unit && (ext_dtype.storage_dtype().is_nullable() || !other.is_nullable())
+    }
+
+    fn least_supertype(ext_dtype: &ExtDType<Self>, other: &DType) -> Option<DType> {
+        let DType::Extension(other_ext) = other else {
+            return None;
+        };
+        let other_unit = other_ext.metadata_opt::<Time>()?;
+        let our_unit = ext_dtype.metadata();
+        let finest = (*our_unit).min(*other_unit);
+        let union_null = ext_dtype.storage_dtype().nullability() | other.nullability();
+        Some(DType::Extension(Time::new(finest, union_null).erased()))
+    }
+
     fn unpack_native<'a>(
         ext_dtype: &'a ExtDType<Self>,
         storage_value: &'a ScalarValue,
@@ -186,6 +208,17 @@ mod tests {
 
         let scalar = Scalar::new(dtype, Some(ScalarValue::Primitive(PValue::I32(0))));
         assert_eq!(format!("{}", scalar.as_extension()), "00:00:00");
+    }
+
+    #[test]
+    fn least_supertype_time_units() {
+        use crate::dtype::Nullability::NonNullable;
+
+        let secs = DType::Extension(Time::new(TimeUnit::Seconds, NonNullable).erased());
+        let ns = DType::Extension(Time::new(TimeUnit::Nanoseconds, NonNullable).erased());
+        let expected = DType::Extension(Time::new(TimeUnit::Nanoseconds, NonNullable).erased());
+        assert_eq!(secs.least_supertype(&ns).unwrap(), expected);
+        assert_eq!(ns.least_supertype(&secs).unwrap(), expected);
     }
 
     #[test]

--- a/vortex-array/src/extension/datetime/timestamp.rs
+++ b/vortex-array/src/extension/datetime/timestamp.rs
@@ -179,6 +179,35 @@ impl ExtVTable for Timestamp {
         })
     }
 
+    fn can_coerce_from(ext_dtype: &ExtDType<Self>, other: &DType) -> bool {
+        let DType::Extension(other_ext) = other else {
+            return false;
+        };
+        let Some(other_opts) = other_ext.metadata_opt::<Timestamp>() else {
+            return false;
+        };
+        let our_opts = ext_dtype.metadata();
+        our_opts.tz == other_opts.tz
+            && our_opts.unit <= other_opts.unit
+            && (ext_dtype.storage_dtype().is_nullable() || !other.is_nullable())
+    }
+
+    fn least_supertype(ext_dtype: &ExtDType<Self>, other: &DType) -> Option<DType> {
+        let DType::Extension(other_ext) = other else {
+            return None;
+        };
+        let other_opts = other_ext.metadata_opt::<Timestamp>()?;
+        let our_opts = ext_dtype.metadata();
+        if our_opts.tz != other_opts.tz {
+            return None;
+        }
+        let finest = our_opts.unit.min(other_opts.unit);
+        let union_null = ext_dtype.storage_dtype().nullability() | other.nullability();
+        Some(DType::Extension(
+            Timestamp::new_with_tz(finest, our_opts.tz.clone(), union_null).erased(),
+        ))
+    }
+
     fn validate_dtype(ext_dtype: &ExtDType<Self>) -> VortexResult<()> {
         vortex_ensure!(
             matches!(ext_dtype.storage_dtype(), DType::Primitive(PType::I64, _)),
@@ -288,6 +317,63 @@ mod tests {
             format!("{}", scalar.as_extension()),
             "1969-12-31T19:00:00-05:00[America/New_York]"
         );
+    }
+
+    #[test]
+    fn least_supertype_timestamp_units() {
+        use crate::dtype::Nullability::NonNullable;
+
+        let secs = DType::Extension(Timestamp::new(TimeUnit::Seconds, NonNullable).erased());
+        let ns = DType::Extension(Timestamp::new(TimeUnit::Nanoseconds, NonNullable).erased());
+        let expected =
+            DType::Extension(Timestamp::new(TimeUnit::Nanoseconds, NonNullable).erased());
+        assert_eq!(secs.least_supertype(&ns).unwrap(), expected);
+        assert_eq!(ns.least_supertype(&secs).unwrap(), expected);
+    }
+
+    #[test]
+    fn least_supertype_timestamp_tz_mismatch() {
+        use crate::dtype::Nullability::NonNullable;
+
+        let utc = DType::Extension(
+            Timestamp::new_with_tz(TimeUnit::Seconds, Some(Arc::from("UTC")), NonNullable).erased(),
+        );
+        let none = DType::Extension(Timestamp::new(TimeUnit::Seconds, NonNullable).erased());
+        assert!(utc.least_supertype(&none).is_none());
+    }
+
+    #[test]
+    fn least_supertype_timestamp_same_tz() {
+        use crate::dtype::Nullability::NonNullable;
+
+        let utc_s = DType::Extension(
+            Timestamp::new_with_tz(TimeUnit::Seconds, Some(Arc::from("UTC")), NonNullable).erased(),
+        );
+        let utc_ns = DType::Extension(
+            Timestamp::new_with_tz(TimeUnit::Nanoseconds, Some(Arc::from("UTC")), NonNullable)
+                .erased(),
+        );
+        let expected = DType::Extension(
+            Timestamp::new_with_tz(TimeUnit::Nanoseconds, Some(Arc::from("UTC")), NonNullable)
+                .erased(),
+        );
+        assert_eq!(utc_s.least_supertype(&utc_ns).unwrap(), expected);
+    }
+
+    #[test]
+    fn can_coerce_from_timestamp_tz() {
+        use crate::dtype::Nullability::NonNullable;
+
+        let utc = DType::Extension(
+            Timestamp::new_with_tz(TimeUnit::Nanoseconds, Some(Arc::from("UTC")), NonNullable)
+                .erased(),
+        );
+        let utc_s = DType::Extension(
+            Timestamp::new_with_tz(TimeUnit::Seconds, Some(Arc::from("UTC")), NonNullable).erased(),
+        );
+        let none = DType::Extension(Timestamp::new(TimeUnit::Nanoseconds, NonNullable).erased());
+        assert!(utc.can_coerce_from(&utc_s));
+        assert!(!utc.can_coerce_from(&none));
     }
 
     #[test]

--- a/vortex-array/src/scalar_fn/erased.rs
+++ b/vortex-array/src/scalar_fn/erased.rs
@@ -127,6 +127,11 @@ impl ScalarFnRef {
         self.0.return_dtype(arg_types)
     }
 
+    /// Coerce the argument types for this scalar function.
+    pub fn coerce_args(&self, arg_types: &[DType]) -> VortexResult<Vec<DType>> {
+        self.0.coerce_args(arg_types)
+    }
+
     /// Transforms the expression into one representing the validity of this expression.
     pub fn validity(&self, expr: &Expression) -> VortexResult<Expression> {
         Ok(self.0.validity(expr)?.unwrap_or_else(|| {

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -98,6 +98,20 @@ impl ScalarFnVTable for Binary {
         write!(f, ")")
     }
 
+    fn coerce_args(&self, operator: &Self::Options, args: &[DType]) -> VortexResult<Vec<DType>> {
+        let lhs = &args[0];
+        let rhs = &args[1];
+        if operator.is_arithmetic() || operator.is_comparison() {
+            let supertype = lhs.least_supertype(rhs).ok_or_else(|| {
+                vortex_error::vortex_err!("No common supertype for {} and {}", lhs, rhs)
+            })?;
+            Ok(vec![supertype.clone(), supertype])
+        } else {
+            // Boolean And/Or: no coercion
+            Ok(args.to_vec())
+        }
+    }
+
     fn return_dtype(&self, operator: &Operator, arg_dtypes: &[DType]) -> VortexResult<DType> {
         let lhs = &arg_dtypes[0];
         let rhs = &arg_dtypes[1];

--- a/vortex-array/src/scalar_fn/typed.rs
+++ b/vortex-array/src/scalar_fn/typed.rs
@@ -81,6 +81,7 @@ pub(super) trait DynScalarFn: 'static + Send + Sync + super::sealed::Sealed {
     // Bound methods — options accessed from self
     fn execute(&self, args: &dyn ExecutionArgs, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef>;
     fn return_dtype(&self, arg_types: &[DType]) -> VortexResult<DType>;
+    fn coerce_args(&self, arg_types: &[DType]) -> VortexResult<Vec<DType>>;
     fn reduce(
         &self,
         node: &dyn ReduceNode,
@@ -172,6 +173,10 @@ impl<V: ScalarFnVTable> DynScalarFn for TypedScalarFnInstance<V> {
 
     fn return_dtype(&self, arg_dtypes: &[DType]) -> VortexResult<DType> {
         V::return_dtype(&self.vtable, &self.options, arg_dtypes)
+    }
+
+    fn coerce_args(&self, arg_types: &[DType]) -> VortexResult<Vec<DType>> {
+        V::coerce_args(&self.vtable, &self.options, arg_types)
     }
 
     fn reduce(

--- a/vortex-array/src/scalar_fn/vtable.rs
+++ b/vortex-array/src/scalar_fn/vtable.rs
@@ -94,6 +94,19 @@ pub trait ScalarFnVTable: 'static + Sized + Clone + Send + Sync {
         write!(f, ")")
     }
 
+    /// Coerce the arguments of this function.
+    ///
+    /// This is optionally used by Vortex users when performing type coercion over a Vortex
+    /// expression. Note that direct Vortex query engine integrations (e.g. DuckDB, DataFusion,
+    /// etc.) do not perform type coercion and rely on the engine's own logical planner.
+    ///
+    /// Note that the default implementation simply returns the arguments without coercion, and it
+    /// is expected that the [`ScalarFnVTable::return_dtype`] call may still fail.
+    fn coerce_args(&self, options: &Self::Options, args: &[DType]) -> VortexResult<Vec<DType>> {
+        let _ = options;
+        Ok(args.to_vec())
+    }
+
     /// Compute the return [`DType`] of the expression if evaluated over the given input types.
     ///
     /// # Preconditions

--- a/vortex-tensor/public-api.lock
+++ b/vortex-tensor/public-api.lock
@@ -130,6 +130,8 @@ pub fn vortex_tensor::fixed_shape_tensor::FixedShapeTensor::deserialize_metadata
 
 pub fn vortex_tensor::fixed_shape_tensor::FixedShapeTensor::id(&self) -> vortex_array::dtype::extension::ExtId
 
+pub fn vortex_tensor::fixed_shape_tensor::FixedShapeTensor::least_supertype(&vortex_array::dtype::extension::typed::ExtDType<Self>, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
+
 pub fn vortex_tensor::fixed_shape_tensor::FixedShapeTensor::serialize_metadata(&self, &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
 pub fn vortex_tensor::fixed_shape_tensor::FixedShapeTensor::unpack_native<'a>(&'a vortex_array::dtype::extension::typed::ExtDType<Self>, &'a vortex_array::scalar::scalar_value::ScalarValue) -> vortex_error::VortexResult<Self::NativeValue>
@@ -571,6 +573,8 @@ pub type vortex_tensor::vector::Vector::NativeValue<'a> = &'a vortex_array::scal
 pub fn vortex_tensor::vector::Vector::deserialize_metadata(&self, &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_tensor::vector::Vector::id(&self) -> vortex_array::dtype::extension::ExtId
+
+pub fn vortex_tensor::vector::Vector::least_supertype(&vortex_array::dtype::extension::typed::ExtDType<Self>, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
 
 pub fn vortex_tensor::vector::Vector::serialize_metadata(&self, &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 

--- a/vortex-tensor/src/types/fixed_shape_tensor/vtable.rs
+++ b/vortex-tensor/src/types/fixed_shape_tensor/vtable.rs
@@ -33,6 +33,22 @@ impl ExtVTable for FixedShapeTensor {
         proto::deserialize(metadata)
     }
 
+    fn least_supertype(ext_dtype: &ExtDType<Self>, other: &DType) -> Option<DType> {
+        let DType::Extension(other_ext) = other else {
+            return None;
+        };
+        // Only element dtype may widen — shape, dim_names, and permutation must match exactly.
+        let other_metadata = other_ext.metadata_opt::<Self>()?;
+        if ext_dtype.metadata() != other_metadata {
+            return None;
+        }
+        let widened = ext_dtype
+            .storage_dtype()
+            .least_supertype(other_ext.storage_dtype())?;
+        let ext = ExtDType::<Self>::try_new(ext_dtype.metadata().clone(), widened).ok()?;
+        Some(DType::Extension(ext.erased()))
+    }
+
     fn validate_dtype(ext_dtype: &ExtDType<Self>) -> VortexResult<()> {
         let storage_dtype = ext_dtype.storage_dtype();
         let DType::FixedSizeList(element_dtype, list_size, _nullability) = storage_dtype else {
@@ -76,7 +92,13 @@ impl ExtVTable for FixedShapeTensor {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use rstest::rstest;
+    use vortex_array::dtype::DType;
+    use vortex_array::dtype::Nullability;
+    use vortex_array::dtype::PType;
+    use vortex_array::dtype::extension::ExtDType;
     use vortex_array::dtype::extension::ExtVTable;
     use vortex_error::VortexResult;
 
@@ -117,5 +139,71 @@ mod tests {
         #[case] metadata: VortexResult<FixedShapeTensorMetadata>,
     ) -> VortexResult<()> {
         assert_roundtrip(&metadata?)
+    }
+
+    /// Constructs a `FixedShapeTensor` ext dtype wrapped in `DType::Extension`.
+    fn tensor_dtype(
+        metadata: FixedShapeTensorMetadata,
+        element: PType,
+        list_size: u32,
+    ) -> VortexResult<DType> {
+        let storage = DType::FixedSizeList(
+            Arc::new(DType::Primitive(element, Nullability::NonNullable)),
+            list_size,
+            Nullability::NonNullable,
+        );
+        Ok(DType::Extension(
+            ExtDType::<FixedShapeTensor>::try_new(metadata, storage)?.erased(),
+        ))
+    }
+
+    #[test]
+    fn tensor_widens_element_when_metadata_matches() -> VortexResult<()> {
+        let metadata = FixedShapeTensorMetadata::new(vec![2, 3]);
+        let lhs = tensor_dtype(metadata.clone(), PType::F32, 6)?;
+        let rhs = tensor_dtype(metadata.clone(), PType::F64, 6)?;
+        let expected = tensor_dtype(metadata, PType::F64, 6)?;
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+        Ok(())
+    }
+
+    #[test]
+    fn tensor_different_shape_returns_none() -> VortexResult<()> {
+        let lhs = tensor_dtype(FixedShapeTensorMetadata::new(vec![2, 3]), PType::F32, 6)?;
+        let rhs = tensor_dtype(FixedShapeTensorMetadata::new(vec![3, 2]), PType::F32, 6)?;
+        assert_eq!(lhs.least_supertype(&rhs), None);
+        Ok(())
+    }
+
+    #[test]
+    fn tensor_different_permutation_returns_none() -> VortexResult<()> {
+        let lhs_metadata =
+            FixedShapeTensorMetadata::new(vec![2, 3]).with_permutation(vec![0, 1])?;
+        let rhs_metadata =
+            FixedShapeTensorMetadata::new(vec![2, 3]).with_permutation(vec![1, 0])?;
+        let lhs = tensor_dtype(lhs_metadata, PType::F32, 6)?;
+        let rhs = tensor_dtype(rhs_metadata, PType::F32, 6)?;
+        assert_eq!(lhs.least_supertype(&rhs), None);
+        Ok(())
+    }
+
+    #[test]
+    fn tensor_different_dim_names_returns_none() -> VortexResult<()> {
+        let lhs_metadata = FixedShapeTensorMetadata::new(vec![2, 3])
+            .with_dim_names(vec!["x".into(), "y".into()])?;
+        let rhs_metadata = FixedShapeTensorMetadata::new(vec![2, 3])
+            .with_dim_names(vec!["rows".into(), "cols".into()])?;
+        let lhs = tensor_dtype(lhs_metadata, PType::F32, 6)?;
+        let rhs = tensor_dtype(rhs_metadata, PType::F32, 6)?;
+        assert_eq!(lhs.least_supertype(&rhs), None);
+        Ok(())
+    }
+
+    #[test]
+    fn tensor_vs_non_extension_returns_none() -> VortexResult<()> {
+        let lhs = tensor_dtype(FixedShapeTensorMetadata::new(vec![2, 3]), PType::F32, 6)?;
+        let rhs = DType::Primitive(PType::F32, Nullability::NonNullable);
+        assert_eq!(lhs.least_supertype(&rhs), None);
+        Ok(())
     }
 }

--- a/vortex-tensor/src/types/vector/vtable.rs
+++ b/vortex-tensor/src/types/vector/vtable.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::dtype::DType;
 use vortex_array::dtype::extension::ExtDType;
 use vortex_array::dtype::extension::ExtId;
 use vortex_array::dtype::extension::ExtVTable;
@@ -27,6 +28,20 @@ impl ExtVTable for Vector {
 
     fn deserialize_metadata(&self, _metadata: &[u8]) -> VortexResult<Self::Metadata> {
         Ok(EmptyMetadata)
+    }
+
+    fn least_supertype(ext_dtype: &ExtDType<Self>, other: &DType) -> Option<DType> {
+        let DType::Extension(other_ext) = other else {
+            return None;
+        };
+        if !other_ext.is::<Self>() {
+            return None;
+        }
+        let widened = ext_dtype
+            .storage_dtype()
+            .least_supertype(other_ext.storage_dtype())?;
+        let ext = ExtDType::<Self>::try_new(EmptyMetadata, widened).ok()?;
+        Some(DType::Extension(ext.erased()))
     }
 
     fn validate_dtype(ext_dtype: &ExtDType<Self>) -> VortexResult<()> {
@@ -120,6 +135,63 @@ mod tests {
         assert!(bytes.is_empty());
         let deserialized = vtable.deserialize_metadata(&bytes)?;
         assert_eq!(deserialized, EmptyMetadata);
+        Ok(())
+    }
+
+    /// Constructs a `Vector` ext dtype wrapped in `DType::Extension`.
+    fn vector_dtype(ptype: PType, dims: u32) -> VortexResult<DType> {
+        vector_dtype_with_outer(ptype, dims, Nullability::NonNullable)
+    }
+
+    /// Constructs a `Vector` ext dtype with the given outer `Nullability`, wrapped in
+    /// `DType::Extension`.
+    fn vector_dtype_with_outer(ptype: PType, dims: u32, outer: Nullability) -> VortexResult<DType> {
+        let storage = vector_storage_dtype(ptype, dims, outer);
+        Ok(DType::Extension(
+            ExtDType::<Vector>::try_new(EmptyMetadata, storage)?.erased(),
+        ))
+    }
+
+    #[test]
+    fn vector_widens_float_precision() -> VortexResult<()> {
+        let lhs = vector_dtype(PType::F32, 768)?;
+        let rhs = vector_dtype(PType::F64, 768)?;
+        let expected = vector_dtype(PType::F64, 768)?;
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+        Ok(())
+    }
+
+    #[test]
+    fn vector_dim_mismatch_returns_none() -> VortexResult<()> {
+        let lhs = vector_dtype(PType::F32, 768)?;
+        let rhs = vector_dtype(PType::F32, 1024)?;
+        assert_eq!(lhs.least_supertype(&rhs), None);
+        Ok(())
+    }
+
+    #[test]
+    fn vector_vs_non_extension_returns_none() -> VortexResult<()> {
+        let lhs = vector_dtype(PType::F32, 768)?;
+        let rhs = DType::Primitive(PType::F32, Nullability::NonNullable);
+        assert_eq!(lhs.least_supertype(&rhs), None);
+        Ok(())
+    }
+
+    #[test]
+    fn vector_unions_outer_nullability_with_float_widening() -> VortexResult<()> {
+        let lhs = vector_dtype_with_outer(PType::F32, 4, Nullability::NonNullable)?;
+        let rhs = vector_dtype_with_outer(PType::F64, 4, Nullability::Nullable)?;
+        let expected = vector_dtype_with_outer(PType::F64, 4, Nullability::Nullable)?;
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
+        Ok(())
+    }
+
+    #[test]
+    fn vector_same_ptype_unions_outer_nullability() -> VortexResult<()> {
+        let lhs = vector_dtype_with_outer(PType::F32, 4, Nullability::NonNullable)?;
+        let rhs = vector_dtype_with_outer(PType::F32, 4, Nullability::Nullable)?;
+        let expected = vector_dtype_with_outer(PType::F32, 4, Nullability::Nullable)?;
+        assert_eq!(lhs.least_supertype(&rhs), Some(expected));
         Ok(())
     }
 }


### PR DESCRIPTION
Reverts vortex-data/vortex#8032

Actually I'm not so sure on this one! If we say that Vortex has a logical type system, and we allow users to define extension types, then we really ought to allow users to define the coercion rules of said extension types.