### PR TITLE
Explicit Precision::Absent variant instead of Option<Precision>

### DIFF
--- a/encodings/datetime-parts/src/compute/take.rs
+++ b/encodings/datetime-parts/src/compute/take.rs
@@ -65,7 +65,7 @@ fn take_datetime_parts(
         .seconds()
         .statistics()
         .get(Stat::Min)
-        .map(|s| s.into_inner())
+        .into_inner()
         .unwrap_or_else(|| Scalar::primitive(0i64, Nullability::NonNullable))
         .cast(array.seconds().dtype())?;
     let taken_seconds = taken_seconds.fill_null(seconds_fill)?;
@@ -74,7 +74,7 @@ fn take_datetime_parts(
         .subseconds()
         .statistics()
         .get(Stat::Min)
-        .map(|s| s.into_inner())
+        .into_inner()
         .unwrap_or_else(|| Scalar::primitive(0i64, Nullability::NonNullable))
         .cast(array.subseconds().dtype())?;
     let taken_subseconds = taken_subseconds.fill_null(subseconds_fill)?;

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -519,12 +519,12 @@ mod tests {
         let is_sorted = arr
             .statistics()
             .with_typed_stats_set(|s| s.get_as::<bool>(Stat::IsSorted));
-        assert_eq!(is_sorted, Some(StatPrecision::Exact(true)));
+        assert_eq!(is_sorted, StatPrecision::Exact(true));
 
         let is_strict_sorted = arr
             .statistics()
             .with_typed_stats_set(|s| s.get_as::<bool>(Stat::IsStrictSorted));
-        assert_eq!(is_strict_sorted, Some(StatPrecision::Exact(true)));
+        assert_eq!(is_strict_sorted, StatPrecision::Exact(true));
         Ok(())
     }
 
@@ -535,12 +535,12 @@ mod tests {
         let is_sorted = arr
             .statistics()
             .with_typed_stats_set(|s| s.get_as::<bool>(Stat::IsSorted));
-        assert_eq!(is_sorted, Some(StatPrecision::Exact(true)));
+        assert_eq!(is_sorted, StatPrecision::Exact(true));
 
         let is_strict_sorted = arr
             .statistics()
             .with_typed_stats_set(|s| s.get_as::<bool>(Stat::IsStrictSorted));
-        assert_eq!(is_strict_sorted, Some(StatPrecision::Exact(false)));
+        assert_eq!(is_strict_sorted, StatPrecision::Exact(false));
         Ok(())
     }
 
@@ -551,12 +551,12 @@ mod tests {
         let is_sorted = arr
             .statistics()
             .with_typed_stats_set(|s| s.get_as::<bool>(Stat::IsSorted));
-        assert_eq!(is_sorted, Some(StatPrecision::Exact(false)));
+        assert_eq!(is_sorted, StatPrecision::Exact(false));
 
         let is_strict_sorted = arr
             .statistics()
             .with_typed_stats_set(|s| s.get_as::<bool>(Stat::IsStrictSorted));
-        assert_eq!(is_strict_sorted, Some(StatPrecision::Exact(false)));
+        assert_eq!(is_strict_sorted, StatPrecision::Exact(false));
         Ok(())
     }
 
@@ -575,8 +575,8 @@ mod tests {
             .statistics()
             .with_typed_stats_set(|s| s.get_as::<bool>(Stat::IsStrictSorted));
 
-        assert_eq!(is_sorted, Some(StatPrecision::Exact(true)));
-        assert_eq!(is_strict_sorted, Some(StatPrecision::Exact(true)));
+        assert_eq!(is_sorted, StatPrecision::Exact(true));
+        assert_eq!(is_strict_sorted, StatPrecision::Exact(true));
 
         Ok(())
     }

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -563,7 +563,7 @@ mod tests {
 
         let compressed = ZstdBuffers::compress(&input, 3, &LEGACY_SESSION)?;
 
-        assert!(compressed.statistics().get(Stat::Min).is_some());
+        assert!(!compressed.statistics().get(Stat::Min).is_absent());
         Ok(())
     }
 

--- a/java/vortex-jni/src/main/java/dev/vortex/api/DataSource.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/DataSource.java
@@ -80,7 +80,7 @@ public final class DataSource {
     }
 
     /**
-     * Row count along with the precision of that estimate. Mirrors the Rust {@code Option<Precision<u64>>} returned by
+     * Row count along with the precision of that estimate. Mirrors the Rust {@code Precision<u64>} returned by
      * {@code DataSource::row_count}: {@link RowCount.Unknown} when no estimate is available, {@link RowCount.Estimate}
      * for an inexact hint, {@link RowCount.Exact} when the count is authoritative.
      */

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -12964,7 +12964,7 @@ pub mod vortex_array::expr::stats
 
 pub enum vortex_array::expr::stats::IntersectionResult<T>
 
-pub vortex_array::expr::stats::IntersectionResult::None
+pub vortex_array::expr::stats::IntersectionResult::Empty
 
 pub vortex_array::expr::stats::IntersectionResult::Value(T)
 
@@ -12990,6 +12990,8 @@ impl<T> core::marker::StructuralPartialEq for vortex_array::expr::stats::Interse
 
 pub enum vortex_array::expr::stats::Precision<T>
 
+pub vortex_array::expr::stats::Precision::Absent
+
 pub vortex_array::expr::stats::Precision::Exact(T)
 
 pub vortex_array::expr::stats::Precision::Inexact(T)
@@ -13001,6 +13003,10 @@ pub fn vortex_array::expr::stats::Precision<&vortex_array::scalar::ScalarValue>:
 impl vortex_array::expr::stats::Precision<vortex_array::scalar::ScalarValue>
 
 pub fn vortex_array::expr::stats::Precision<vortex_array::scalar::ScalarValue>::into_scalar(self, vortex_array::dtype::DType) -> vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>
+
+impl<T, E> vortex_array::expr::stats::Precision<core::result::Result<T, E>>
+
+pub fn vortex_array::expr::stats::Precision<core::result::Result<T, E>>::transpose(self) -> core::result::Result<vortex_array::expr::stats::Precision<T>, E>
 
 impl<T> vortex_array::expr::stats::Precision<T> where T: core::marker::Copy
 
@@ -13020,19 +13026,19 @@ pub fn vortex_array::expr::stats::Precision<T>::inexact<S: core::convert::Into<T
 
 pub fn vortex_array::expr::stats::Precision<T>::into_inexact(self) -> Self
 
-pub fn vortex_array::expr::stats::Precision<T>::into_inner(self) -> T
+pub fn vortex_array::expr::stats::Precision<T>::into_inner(self) -> core::option::Option<T>
+
+pub fn vortex_array::expr::stats::Precision<T>::is_absent(&self) -> bool
 
 pub fn vortex_array::expr::stats::Precision<T>::is_exact(&self) -> bool
 
 pub fn vortex_array::expr::stats::Precision<T>::map<U, F: core::ops::function::FnOnce(T) -> U>(self, F) -> vortex_array::expr::stats::Precision<U>
 
-pub fn vortex_array::expr::stats::Precision<T>::try_map<U, F: core::ops::function::FnOnce(T) -> vortex_error::VortexResult<U>>(self, F) -> vortex_error::VortexResult<vortex_array::expr::stats::Precision<U>>
-
 pub fn vortex_array::expr::stats::Precision<T>::zip<U>(self, vortex_array::expr::stats::Precision<U>) -> vortex_array::expr::stats::Precision<(T, U)>
 
 impl<T> vortex_array::expr::stats::Precision<T>
 
-pub fn vortex_array::expr::stats::Precision<T>::bound<S: vortex_array::expr::stats::StatType<T>>(self) -> <S as vortex_array::expr::stats::StatType>::Bound
+pub fn vortex_array::expr::stats::Precision<T>::bound<S: vortex_array::expr::stats::StatType<T>>(self) -> core::option::Option<<S as vortex_array::expr::stats::StatType>::Bound>
 
 impl<T> vortex_array::expr::stats::Precision<core::option::Option<T>>
 
@@ -13073,6 +13079,10 @@ impl<T: core::fmt::Display> core::fmt::Display for vortex_array::expr::stats::Pr
 pub fn vortex_array::expr::stats::Precision<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
 impl<T: core::marker::Copy> core::marker::Copy for vortex_array::expr::stats::Precision<T>
+
+impl<T> core::default::Default for vortex_array::expr::stats::Precision<T>
+
+pub fn vortex_array::expr::stats::Precision<T>::default() -> Self
 
 impl<T> core::marker::StructuralPartialEq for vortex_array::expr::stats::Precision<T>
 
@@ -13440,7 +13450,7 @@ pub const vortex_array::expr::stats::UncompressedSizeInBytes::STAT: vortex_array
 
 pub trait vortex_array::expr::stats::StatsProvider
 
-pub fn vortex_array::expr::stats::StatsProvider::get(&self, vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>>
+pub fn vortex_array::expr::stats::StatsProvider::get(&self, vortex_array::expr::stats::Stat) -> vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::expr::stats::StatsProvider::is_empty(&self) -> bool
 
@@ -13448,7 +13458,7 @@ pub fn vortex_array::expr::stats::StatsProvider::len(&self) -> usize
 
 impl vortex_array::expr::stats::StatsProvider for vortex_array::stats::MutTypedStatsSetRef<'_, '_>
 
-pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::get(&self, vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>>
+pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::get(&self, vortex_array::expr::stats::Stat) -> vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::is_empty(&self) -> bool
 
@@ -13456,7 +13466,7 @@ pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::len(&self) -> usize
 
 impl vortex_array::expr::stats::StatsProvider for vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::stats::StatsSetRef<'_>::get(&self, vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>>
+pub fn vortex_array::stats::StatsSetRef<'_>::get(&self, vortex_array::expr::stats::Stat) -> vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::stats::StatsSetRef<'_>::is_empty(&self) -> bool
 
@@ -13464,7 +13474,7 @@ pub fn vortex_array::stats::StatsSetRef<'_>::len(&self) -> usize
 
 impl vortex_array::expr::stats::StatsProvider for vortex_array::stats::TypedStatsSetRef<'_, '_>
 
-pub fn vortex_array::stats::TypedStatsSetRef<'_, '_>::get(&self, vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>>
+pub fn vortex_array::stats::TypedStatsSetRef<'_, '_>::get(&self, vortex_array::expr::stats::Stat) -> vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::stats::TypedStatsSetRef<'_, '_>::is_empty(&self) -> bool
 
@@ -13472,7 +13482,7 @@ pub fn vortex_array::stats::TypedStatsSetRef<'_, '_>::len(&self) -> usize
 
 pub trait vortex_array::expr::stats::StatsProviderExt: vortex_array::expr::stats::StatsProvider
 
-pub fn vortex_array::expr::stats::StatsProviderExt::get_as<T: for<'a> core::convert::TryFrom<&'a vortex_array::scalar::Scalar, Error = vortex_error::VortexError>>(&self, vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<T>>
+pub fn vortex_array::expr::stats::StatsProviderExt::get_as<T: for<'a> core::convert::TryFrom<&'a vortex_array::scalar::Scalar, Error = vortex_error::VortexError>>(&self, vortex_array::expr::stats::Stat) -> vortex_array::expr::stats::Precision<T>
 
 pub fn vortex_array::expr::stats::StatsProviderExt::get_as_bound<S, U>(&self) -> core::option::Option<<S as vortex_array::expr::stats::StatType>::Bound> where S: vortex_array::expr::stats::StatType<U>, U: for<'a> core::convert::TryFrom<&'a vortex_array::scalar::Scalar, Error = vortex_error::VortexError>
 
@@ -13480,7 +13490,7 @@ pub fn vortex_array::expr::stats::StatsProviderExt::get_scalar_bound<S: vortex_a
 
 impl<S> vortex_array::expr::stats::StatsProviderExt for S where S: vortex_array::expr::stats::StatsProvider
 
-pub fn S::get_as<T: for<'a> core::convert::TryFrom<&'a vortex_array::scalar::Scalar, Error = vortex_error::VortexError>>(&self, vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<T>>
+pub fn S::get_as<T: for<'a> core::convert::TryFrom<&'a vortex_array::scalar::Scalar, Error = vortex_error::VortexError>>(&self, vortex_array::expr::stats::Stat) -> vortex_array::expr::stats::Precision<T>
 
 pub fn S::get_as_bound<S, U>(&self) -> core::option::Option<<S as vortex_array::expr::stats::StatType>::Bound> where S: vortex_array::expr::stats::StatType<U>, U: for<'a> core::convert::TryFrom<&'a vortex_array::scalar::Scalar, Error = vortex_error::VortexError>
 
@@ -21130,7 +21140,7 @@ pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::merge_unordered(self, &
 
 impl vortex_array::expr::stats::StatsProvider for vortex_array::stats::MutTypedStatsSetRef<'_, '_>
 
-pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::get(&self, vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>>
+pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::get(&self, vortex_array::expr::stats::Stat) -> vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::is_empty(&self) -> bool
 
@@ -21168,9 +21178,9 @@ impl vortex_array::stats::StatsSet
 
 pub fn vortex_array::stats::StatsSet::clear(&mut self, vortex_array::expr::stats::Stat)
 
-pub fn vortex_array::stats::StatsSet::get(&self, vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<vortex_array::scalar::ScalarValue>>
+pub fn vortex_array::stats::StatsSet::get(&self, vortex_array::expr::stats::Stat) -> vortex_array::expr::stats::Precision<vortex_array::scalar::ScalarValue>
 
-pub fn vortex_array::stats::StatsSet::get_as<T: for<'a> core::convert::TryFrom<&'a vortex_array::scalar::Scalar, Error = vortex_error::VortexError>>(&self, vortex_array::expr::stats::Stat, &vortex_array::dtype::DType) -> core::option::Option<vortex_array::expr::stats::Precision<T>>
+pub fn vortex_array::stats::StatsSet::get_as<T: for<'a> core::convert::TryFrom<&'a vortex_array::scalar::Scalar, Error = vortex_error::VortexError>>(&self, vortex_array::expr::stats::Stat, &vortex_array::dtype::DType) -> vortex_array::expr::stats::Precision<T>
 
 pub fn vortex_array::stats::StatsSet::is_empty(&self) -> bool
 
@@ -21292,7 +21302,7 @@ pub fn vortex_array::stats::StatsSetRef<'_>::with_typed_stats_set<U, F: core::op
 
 impl vortex_array::expr::stats::StatsProvider for vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::stats::StatsSetRef<'_>::get(&self, vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>>
+pub fn vortex_array::stats::StatsSetRef<'_>::get(&self, vortex_array::expr::stats::Stat) -> vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::stats::StatsSetRef<'_>::is_empty(&self) -> bool
 
@@ -21312,7 +21322,7 @@ pub vortex_array::stats::TypedStatsSetRef::values: &'a vortex_array::stats::Stat
 
 impl vortex_array::expr::stats::StatsProvider for vortex_array::stats::TypedStatsSetRef<'_, '_>
 
-pub fn vortex_array::stats::TypedStatsSetRef<'_, '_>::get(&self, vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>>
+pub fn vortex_array::stats::TypedStatsSetRef<'_, '_>::get(&self, vortex_array::expr::stats::Stat) -> vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::stats::TypedStatsSetRef<'_, '_>::is_empty(&self) -> bool
 

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -13014,6 +13014,8 @@ pub fn vortex_array::expr::stats::Precision<T>::to_inexact(&self) -> Self
 
 impl<T> vortex_array::expr::stats::Precision<T>
 
+pub fn vortex_array::expr::stats::Precision<T>::and_then<U, F: core::ops::function::FnOnce(T) -> core::option::Option<U>>(self, F) -> vortex_array::expr::stats::Precision<U>
+
 pub fn vortex_array::expr::stats::Precision<T>::as_exact(self) -> core::option::Option<T>
 
 pub fn vortex_array::expr::stats::Precision<T>::as_inexact(self) -> core::option::Option<T>
@@ -13039,10 +13041,6 @@ pub fn vortex_array::expr::stats::Precision<T>::zip<U>(self, vortex_array::expr:
 impl<T> vortex_array::expr::stats::Precision<T>
 
 pub fn vortex_array::expr::stats::Precision<T>::bound<S: vortex_array::expr::stats::StatType<T>>(self) -> core::option::Option<<S as vortex_array::expr::stats::StatType>::Bound>
-
-impl<T> vortex_array::expr::stats::Precision<core::option::Option<T>>
-
-pub fn vortex_array::expr::stats::Precision<core::option::Option<T>>::transpose(self) -> core::option::Option<vortex_array::expr::stats::Precision<T>>
 
 impl<T: core::clone::Clone> core::clone::Clone for vortex_array::expr::stats::Precision<T>
 

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -13082,7 +13082,7 @@ impl<T: core::marker::Copy> core::marker::Copy for vortex_array::expr::stats::Pr
 
 impl<T> core::default::Default for vortex_array::expr::stats::Precision<T>
 
-pub fn vortex_array::expr::stats::Precision<T>::default() -> Self
+pub fn vortex_array::expr::stats::Precision<T>::default() -> vortex_array::expr::stats::Precision<T>
 
 impl<T> core::marker::StructuralPartialEq for vortex_array::expr::stats::Precision<T>
 

--- a/vortex-array/src/aggregate_fn/accumulator.rs
+++ b/vortex-array/src/aggregate_fn/accumulator.rs
@@ -122,7 +122,7 @@ impl<V: AggregateFnVTable> DynAccumulator for Accumulator<V> {
         // 0. Legacy stats bridge: if this aggregate is still cached under a legacy Stat slot,
         //    consume that exact stat before kernel dispatch or decode.
         if let Some(stat) = Stat::from_aggregate_fn(&self.aggregate_fn)
-            && let Some(Precision::Exact(partial)) = batch.statistics().get(stat)
+            && let Precision::Exact(partial) = batch.statistics().get(stat)
         {
             let partial = if partial.dtype() == &self.partial_dtype {
                 partial

--- a/vortex-array/src/aggregate_fn/fns/is_constant/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/is_constant/mod.rs
@@ -89,7 +89,7 @@ fn arrays_value_equal(a: &ArrayRef, b: &ArrayRef, ctx: &mut ExecutionCtx) -> Vor
 /// 5. Is all valid AND has minimum and maximum statistics that are equal.
 pub fn is_constant(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<bool> {
     // Short-circuit using cached array statistics.
-    if let Some(Precision::Exact(value)) = array.statistics().get_as::<bool>(Stat::IsConstant) {
+    if let Precision::Exact(value) = array.statistics().get_as::<bool>(Stat::IsConstant) {
         return Ok(value);
     }
 
@@ -133,14 +133,14 @@ pub fn is_constant(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<boo
     }
 
     // We already know here that the array is all valid, so we check for min/max stats.
-    let min = array.statistics().get(Stat::Min);
-    let max = array.statistics().get(Stat::Max);
+    let min_stat = array.statistics().get(Stat::Min);
+    let max_stat = array.statistics().get(Stat::Max);
 
-    if let Some((min, max)) = min.zip(max)
-        && min.is_exact()
+    if let Precision::Exact(min) = min_stat.as_ref()
+        && let Precision::Exact(max) = max_stat.as_ref()
         && min == max
         && (Stat::NaNCount.dtype(array.dtype()).is_none()
-            || array.statistics().get_as::<u64>(Stat::NaNCount) == Some(Precision::exact(0u64)))
+            || array.statistics().get_as::<u64>(Stat::NaNCount) == Precision::exact(0u64))
     {
         array
             .statistics()

--- a/vortex-array/src/aggregate_fn/fns/is_sorted/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/is_sorted/mod.rs
@@ -77,7 +77,7 @@ fn is_sorted_impl(array: &ArrayRef, strict: bool, ctx: &mut ExecutionCtx) -> Vor
     };
 
     // Short-circuit using cached array statistics.
-    if let Some(Precision::Exact(value)) = array.statistics().get_as::<bool>(stat) {
+    if let Precision::Exact(value) = array.statistics().get_as::<bool>(stat) {
         return Ok(value);
     }
 

--- a/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
@@ -46,14 +46,8 @@ static NAMES: LazyLock<FieldNames> = LazyLock::new(|| FieldNames::from(["min", "
 /// This will update the stats set of the array as a side effect.
 pub fn min_max(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Option<MinMaxResult>> {
     // Short-circuit using cached array statistics.
-    let cached_min = array
-        .statistics()
-        .get(Stat::Min)
-        .and_then(Precision::as_exact);
-    let cached_max = array
-        .statistics()
-        .get(Stat::Max)
-        .and_then(Precision::as_exact);
+    let cached_min = array.statistics().get(Stat::Min).as_exact();
+    let cached_max = array.statistics().get(Stat::Max).as_exact();
     if let Some((min, max)) = cached_min.zip(cached_max) {
         let non_nullable_dtype = array.dtype().as_nonnullable();
         return Ok(Some(MinMaxResult {

--- a/vortex-array/src/aggregate_fn/fns/nan_count/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/nan_count/mod.rs
@@ -34,7 +34,7 @@ use crate::scalar::ScalarValue;
 /// See [`NanCount`] for details.
 pub fn nan_count(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<usize> {
     // Short-circuit using cached array statistics.
-    if let Some(Precision::Exact(nan_count_scalar)) = array.statistics().get(Stat::NaNCount) {
+    if let Precision::Exact(nan_count_scalar) = array.statistics().get(Stat::NaNCount) {
         return usize::try_from(&nan_count_scalar)
             .map_err(|e| vortex_err!("Failed to convert NaN count stat to usize: {e}"));
     }

--- a/vortex-array/src/aggregate_fn/fns/null_count/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/null_count/mod.rs
@@ -25,7 +25,7 @@ use crate::scalar::ScalarValue;
 
 /// Return the number of null values in an array.
 pub fn null_count(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<usize> {
-    if let Some(Precision::Exact(null_count_scalar)) = array.statistics().get(Stat::NullCount) {
+    if let Precision::Exact(null_count_scalar) = array.statistics().get(Stat::NullCount) {
         return usize::try_from(&null_count_scalar)
             .map_err(|e| vortex_err!("Failed to convert null count stat to usize: {e}"));
     }
@@ -170,7 +170,7 @@ mod tests {
         assert_eq!(null_count(&array, &mut ctx)?, 2);
         assert_eq!(
             array.statistics().get_as::<u64>(Stat::NullCount),
-            Some(Precision::exact(2u64))
+            Precision::exact(2u64)
         );
         Ok(())
     }

--- a/vortex-array/src/aggregate_fn/fns/sum/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/mod.rs
@@ -41,7 +41,7 @@ use crate::scalar::Scalar;
 /// See [`Sum`] for details.
 pub fn sum(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
     // Short-circuit using cached array statistics.
-    if let Some(Precision::Exact(sum_scalar)) = array.statistics().get(Stat::Sum) {
+    if let Precision::Exact(sum_scalar) = array.statistics().get(Stat::Sum) {
         return Ok(sum_scalar);
     }
 
@@ -379,7 +379,7 @@ mod tests {
 
         // For non-float types, try statistics short-circuit with accumulator.
         if !matches!(&sum_dtype, DType::Primitive(p, _) if p.is_float())
-            && let Some(Precision::Exact(sum_scalar)) = array.statistics().get(Stat::Sum)
+            && let Precision::Exact(sum_scalar) = array.statistics().get(Stat::Sum)
         {
             return add_scalars(&sum_dtype, &sum_scalar, accumulator);
         }

--- a/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
@@ -63,9 +63,7 @@ pub fn uncompressed_size_in_bytes(array: &ArrayRef, ctx: &mut ExecutionCtx) -> V
 }
 
 fn uncompressed_size_in_bytes_u64(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<u64> {
-    if let Some(Precision::Exact(size_scalar)) =
-        array.statistics().get(Stat::UncompressedSizeInBytes)
-    {
+    if let Precision::Exact(size_scalar) = array.statistics().get(Stat::UncompressedSizeInBytes) {
         return u64::try_from(&size_scalar)
             .map_err(|e| vortex_err!("Failed to convert uncompressed size stat to u64: {e}"));
     }
@@ -597,7 +595,7 @@ mod tests {
 
         assert_eq!(
             array.statistics().get(Stat::UncompressedSizeInBytes),
-            Some(Precision::exact(u64::try_from(size)?))
+            Precision::exact(u64::try_from(size)?)
         );
         Ok(())
     }

--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -327,8 +327,7 @@ impl ArrayRef {
     /// Returns the number of valid elements in the array.
     pub fn valid_count(&self, ctx: &mut ExecutionCtx) -> VortexResult<usize> {
         let len = self.len();
-        if let Some(Precision::Exact(invalid_count)) =
-            self.statistics().get_as::<usize>(Stat::NullCount)
+        if let Precision::Exact(invalid_count) = self.statistics().get_as::<usize>(Stat::NullCount)
         {
             return Ok(len - invalid_count);
         }

--- a/vortex-array/src/arrays/dict/take.rs
+++ b/vortex-array/src/arrays/dict/take.rs
@@ -151,19 +151,18 @@ pub(crate) fn propagate_take_stats(
     target.statistics().with_mut_typed_stats_set(|mut st| {
         if indices_all_valid {
             let is_constant = source.statistics().get_as::<bool>(Stat::IsConstant);
-            if is_constant == Some(Precision::Exact(true)) {
+            if matches!(is_constant, Precision::Exact(true)) {
                 // Any combination of elements from a constant array is still const
                 st.set(Stat::IsConstant, Precision::exact(true));
             }
         }
         let inexact_min_max = [Stat::Min, Stat::Max]
             .into_iter()
-            .filter_map(|stat| {
-                source
-                    .statistics()
-                    .get(stat)
-                    .and_then(|v| v.map(|s| s.into_value()).into_inexact().transpose())
-                    .map(|sv| (stat, sv))
+            .filter_map(|stat| match source.statistics().get(stat).into_inexact() {
+                Precision::Exact(scalar) | Precision::Inexact(scalar) => {
+                    scalar.into_value().map(|sv| (stat, Precision::Inexact(sv)))
+                }
+                Precision::Absent => None,
             })
             .collect::<SmallVec<_>>();
         st.combine_sets(

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -22,7 +22,6 @@ use crate::dtype::DType;
 use crate::dtype::NativePType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
-use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
 use crate::expr::stats::StatsProvider;
 use crate::match_each_native_ptype;
@@ -224,8 +223,8 @@ fn values_fit_in(
 /// stats cache, otherwise `None`.
 fn cached_values_fit_in(array: ArrayView<'_, Primitive>, target_dtype: &DType) -> Option<bool> {
     let stats = array.array().statistics();
-    let min = stats.get(Stat::Min).and_then(Precision::as_exact)?;
-    let max = stats.get(Stat::Max).and_then(Precision::as_exact)?;
+    let min = stats.get(Stat::Min).as_exact()?;
+    let max = stats.get(Stat::Max).as_exact()?;
     Some(min.cast(target_dtype).is_ok() && max.cast(target_dtype).is_ok())
 }
 

--- a/vortex-array/src/arrays/varbin/builder.rs
+++ b/vortex-array/src/arrays/varbin/builder.rs
@@ -177,7 +177,7 @@ mod tests {
             .offsets()
             .statistics()
             .with_typed_stats_set(|s| s.get_as::<bool>(Stat::IsSorted));
-        assert_eq!(is_sorted, Some(Precision::Exact(true)));
+        assert_eq!(is_sorted, Precision::Exact(true));
         Ok(())
     }
 
@@ -190,7 +190,7 @@ mod tests {
             .offsets()
             .statistics()
             .with_typed_stats_set(|s| s.get_as::<bool>(Stat::IsSorted));
-        assert_eq!(is_sorted, Some(Precision::Exact(true)));
+        assert_eq!(is_sorted, Precision::Exact(true));
         Ok(())
     }
 }

--- a/vortex-array/src/display/extractors/stats.rs
+++ b/vortex-array/src/display/extractors/stats.rs
@@ -31,8 +31,8 @@ impl fmt::Display for StatsDisplay<'_> {
         };
 
         // Null count or validity fallback
-        if let Some(nc) = stats.get(Stat::NullCount) {
-            if let Ok(n) = usize::try_from(&nc.clone().into_inner()) {
+        if let Some(nc) = stats.get(Stat::NullCount).into_inner() {
+            if let Ok(n) = usize::try_from(&nc) {
                 sep(f)?;
                 write!(f, "nulls={}", n)?;
             } else {
@@ -61,8 +61,8 @@ impl fmt::Display for StatsDisplay<'_> {
         }
 
         // NaN count (only if > 0)
-        if let Some(nan) = stats.get(Stat::NaNCount)
-            && let Ok(n) = usize::try_from(&nan.into_inner())
+        if let Some(nan) = stats.get(Stat::NaNCount).into_inner()
+            && let Ok(n) = usize::try_from(&nan)
             && n > 0
         {
             sep(f)?;
@@ -70,35 +70,35 @@ impl fmt::Display for StatsDisplay<'_> {
         }
 
         // Min/Max
-        if let Some(min) = stats.get(Stat::Min) {
+        if let Some(min) = stats.get(Stat::Min).into_inner() {
             sep(f)?;
             write!(f, "min={}", min)?;
         }
-        if let Some(max) = stats.get(Stat::Max) {
+        if let Some(max) = stats.get(Stat::Max).into_inner() {
             sep(f)?;
             write!(f, "max={}", max)?;
         }
 
         // Sum
-        if let Some(sum) = stats.get(Stat::Sum) {
+        if let Some(sum) = stats.get(Stat::Sum).into_inner() {
             sep(f)?;
             write!(f, "sum={}", sum)?;
         }
 
         // Boolean flags (compact)
-        if let Some(c) = stats.get(Stat::IsConstant)
-            && bool::try_from(&c.into_inner()).unwrap_or(false)
+        if let Some(c) = stats.get(Stat::IsConstant).into_inner()
+            && bool::try_from(&c).unwrap_or(false)
         {
             sep(f)?;
             f.write_str("const")?;
         }
-        if let Some(s) = stats.get(Stat::IsStrictSorted) {
-            if bool::try_from(&s.into_inner()).unwrap_or(false) {
+        if let Some(s) = stats.get(Stat::IsStrictSorted).into_inner() {
+            if bool::try_from(&s).unwrap_or(false) {
                 sep(f)?;
                 f.write_str("strict")?;
             }
-        } else if let Some(s) = stats.get(Stat::IsSorted)
-            && bool::try_from(&s.into_inner()).unwrap_or(false)
+        } else if let Some(s) = stats.get(Stat::IsSorted).into_inner()
+            && bool::try_from(&s).unwrap_or(false)
         {
             sep(f)?;
             f.write_str("sorted")?;

--- a/vortex-array/src/expr/stats/bound.rs
+++ b/vortex-array/src/expr/stats/bound.rs
@@ -7,6 +7,7 @@ use vortex_error::VortexError;
 use vortex_error::VortexResult;
 
 use crate::expr::stats::Precision;
+use crate::expr::stats::Precision::Absent;
 use crate::expr::stats::Precision::Exact;
 use crate::expr::stats::Precision::Inexact;
 use crate::expr::stats::StatBound;
@@ -19,7 +20,7 @@ use crate::partial_ord::partial_min;
 pub struct LowerBound<T>(pub(crate) Precision<T>);
 
 impl<T> LowerBound<T> {
-    pub(crate) fn min_value(self) -> T {
+    pub(crate) fn min_value(self) -> Option<T> {
         self.0.into_inner()
     }
 }
@@ -37,7 +38,7 @@ pub enum IntersectionResult<T> {
     /// An intersection result was found
     Value(T),
     /// Values has no intersection.
-    None,
+    Empty,
 }
 
 impl<T> IntersectionResult<T> {
@@ -47,7 +48,7 @@ impl<T> IntersectionResult<T> {
     {
         match self {
             IntersectionResult::Value(v) => Ok(v),
-            IntersectionResult::None => Err(err()),
+            IntersectionResult::Empty => Err(err()),
         }
     }
 }
@@ -58,6 +59,8 @@ impl<T: PartialOrd + Clone> StatBound<T> for LowerBound<T> {
     }
 
     fn union(&self, other: &Self) -> Option<LowerBound<T>> {
+        use Precision::*;
+
         Some(LowerBound(match (&self.0, &other.0) {
             (Exact(lhs), Exact(rhs)) => Exact(partial_min(lhs, rhs)?.clone()),
             (Inexact(lhs), Inexact(rhs)) => Inexact(partial_min(lhs, rhs)?.clone()),
@@ -75,6 +78,7 @@ impl<T: PartialOrd + Clone> StatBound<T> for LowerBound<T> {
                     Inexact(rhs.clone())
                 }
             }
+            (Absent, _) | (_, Absent) => return None,
         }))
     }
 
@@ -86,7 +90,7 @@ impl<T: PartialOrd + Clone> StatBound<T> for LowerBound<T> {
                     IntersectionResult::Value(LowerBound(Exact(lhs.clone())))
                 } else {
                     // The two intervals do not overlap
-                    IntersectionResult::None
+                    IntersectionResult::Empty
                 }
             }
             (Inexact(lhs), Inexact(rhs)) => {
@@ -97,7 +101,7 @@ impl<T: PartialOrd + Clone> StatBound<T> for LowerBound<T> {
                     IntersectionResult::Value(LowerBound(Exact(rhs.clone())))
                 } else {
                     // The two intervals do not overlap
-                    IntersectionResult::None
+                    IntersectionResult::Empty
                 }
             }
             (Exact(lhs), Inexact(rhs)) => {
@@ -105,9 +109,10 @@ impl<T: PartialOrd + Clone> StatBound<T> for LowerBound<T> {
                     IntersectionResult::Value(LowerBound(Exact(lhs.clone())))
                 } else {
                     // The two intervals do not overlap
-                    IntersectionResult::None
+                    IntersectionResult::Empty
                 }
             }
+            (Absent, _) | (_, Absent) => return None,
         })
     }
 
@@ -137,6 +142,7 @@ impl<T: PartialOrd> PartialOrd<T> for LowerBound<T> {
             Inexact(lhs) => lhs
                 .partial_cmp(other)
                 .and_then(|o| if o == Ordering::Less { None } else { Some(o) }),
+            Absent => None,
         }
     }
 }
@@ -146,7 +152,7 @@ impl<T: PartialOrd> PartialOrd<T> for LowerBound<T> {
 pub struct UpperBound<T>(pub(crate) Precision<T>);
 
 impl<T> UpperBound<T> {
-    pub(crate) fn max_value(self) -> T {
+    pub(crate) fn max_value(self) -> Option<T> {
         self.0.into_inner()
     }
 }
@@ -175,6 +181,7 @@ impl<T: PartialOrd + Clone> StatBound<T> for UpperBound<T> {
                     Inexact(rhs.clone())
                 }
             }
+            (Absent, _) | (_, Absent) => return None,
         }))
     }
 
@@ -185,7 +192,7 @@ impl<T: PartialOrd + Clone> StatBound<T> for UpperBound<T> {
                     IntersectionResult::Value(UpperBound(Exact(lhs.clone())))
                 } else {
                     // The two intervals do not overlap
-                    IntersectionResult::None
+                    IntersectionResult::Empty
                 }
             }
             (Inexact(lhs), Inexact(rhs)) => {
@@ -196,7 +203,7 @@ impl<T: PartialOrd + Clone> StatBound<T> for UpperBound<T> {
                     IntersectionResult::Value(UpperBound(Exact(rhs.clone())))
                 } else {
                     // The two intervals do not overlap
-                    IntersectionResult::None
+                    IntersectionResult::Empty
                 }
             }
             (Exact(lhs), Inexact(rhs)) => {
@@ -204,9 +211,10 @@ impl<T: PartialOrd + Clone> StatBound<T> for UpperBound<T> {
                     IntersectionResult::Value(UpperBound(Exact(lhs.clone())))
                 } else {
                     // The two intervals do not overlap
-                    IntersectionResult::None
+                    IntersectionResult::Empty
                 }
             }
+            (Absent, _) | (_, Absent) => return None,
         })
     }
 
@@ -240,6 +248,7 @@ impl<T: PartialOrd> PartialOrd<T> for UpperBound<T> {
                     Some(o)
                 }
             }),
+            Absent => return None,
         }
     }
 }
@@ -305,7 +314,7 @@ mod tests {
         let ub1: UpperBound<i32> = UpperBound(Precision::exact(13i32));
         let ub2 = UpperBound(Precision::inexact(12i32));
 
-        assert_eq!(Some(IntersectionResult::None), ub1.intersection(&ub2));
+        assert_eq!(Some(IntersectionResult::Empty), ub1.intersection(&ub2));
     }
 
     #[test]
@@ -321,6 +330,6 @@ mod tests {
         let lb1: LowerBound<i32> = LowerBound(Precision::exact(12i32));
         let lb2 = LowerBound(Precision::inexact(13i32));
 
-        assert_eq!(Some(IntersectionResult::None), lb1.intersection(&lb2));
+        assert_eq!(Some(IntersectionResult::Empty), lb1.intersection(&lb2));
     }
 }

--- a/vortex-array/src/expr/stats/bound.rs
+++ b/vortex-array/src/expr/stats/bound.rs
@@ -248,7 +248,7 @@ impl<T: PartialOrd> PartialOrd<T> for UpperBound<T> {
                     Some(o)
                 }
             }),
-            Absent => return None,
+            Absent => None,
         }
     }
 }

--- a/vortex-array/src/expr/stats/precision.rs
+++ b/vortex-array/src/expr/stats/precision.rs
@@ -6,11 +6,12 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 
 use vortex_error::VortexExpect;
-use vortex_error::VortexResult;
 
 use crate::dtype::DType;
-use crate::expr::stats::precision::Precision::Exact;
-use crate::expr::stats::precision::Precision::Inexact;
+use crate::expr::stats::IntersectionResult;
+use crate::expr::stats::StatBound;
+use crate::expr::stats::StatType;
+use crate::partial_ord::partial_min;
 use crate::scalar::Scalar;
 use crate::scalar::ScalarValue;
 
@@ -21,22 +22,36 @@ use crate::scalar::ScalarValue;
 /// This is statistic specific, for max this will be an upper bound. Meaning that the actual max
 /// in an array is guaranteed to be less than or equal to the inexact value, but equal to the exact
 /// value.
-///
-// TODO(ngates): should we model Unknown as a variant of Precision? Or have Option<Precision<T>>?
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Precision<T> {
     Exact(T),
     Inexact(T),
+    Absent,
+}
+
+impl<T> Default for Precision<T> {
+    fn default() -> Self {
+        Self::Absent
+    }
 }
 
 impl<T> Precision<Option<T>> {
     /// Transpose the `Precision<Option<T>>` into `Option<Precision<T>>`.
     pub fn transpose(self) -> Option<Precision<T>> {
+        use Precision::*;
+
         match self {
             Exact(Some(x)) => Some(Exact(x)),
             Inexact(Some(x)) => Some(Inexact(x)),
+            Absent => Some(Absent),
             Exact(None) | Inexact(None) => None,
         }
+    }
+}
+
+impl<T, E> Precision<Result<T, E>> {
+    pub fn transpose(self) -> Result<Precision<T>, E> {
+        todo!()
     }
 }
 
@@ -45,9 +60,11 @@ where
     T: Copy,
 {
     pub fn to_inexact(&self) -> Self {
+        use Precision::*;
+
         match self {
-            Exact(v) => Exact(*v),
-            Inexact(v) => Inexact(*v),
+            Exact(v) | Inexact(v) => Inexact(*v),
+            Absent => Absent,
         }
     }
 }
@@ -55,34 +72,39 @@ where
 impl<T> Precision<T> {
     /// Creates an exact value
     pub fn exact<S: Into<T>>(s: S) -> Precision<T> {
-        Exact(s.into())
+        Self::Exact(s.into())
     }
 
     /// Creates an inexact value
     pub fn inexact<S: Into<T>>(s: S) -> Precision<T> {
-        Inexact(s.into())
+        Self::Inexact(s.into())
     }
 
     /// Pushed the ref into the Precision enum
     pub fn as_ref(&self) -> Precision<&T> {
+        use Precision::*;
+
         match self {
             Exact(val) => Exact(val),
             Inexact(val) => Inexact(val),
+            Absent => Absent,
         }
     }
 
     /// Converts `self` into an inexact bound
     pub fn into_inexact(self) -> Self {
+        use Precision::*;
+
         match self {
-            Exact(val) => Inexact(val),
-            Inexact(_) => self,
+            Exact(v) | Inexact(v) => Inexact(v),
+            Absent => Absent,
         }
     }
 
     /// Returns the exact value from the bound, if that value is inexact, otherwise `None`.
     pub fn as_exact(self) -> Option<T> {
         match self {
-            Exact(val) => Some(val),
+            Self::Exact(val) => Some(val),
             _ => None,
         }
     }
@@ -90,59 +112,69 @@ impl<T> Precision<T> {
     /// Returns the exact value from the bound, if that value is inexact, otherwise `None`.
     pub fn as_inexact(self) -> Option<T> {
         match self {
-            Inexact(val) => Some(val),
+            Self::Inexact(val) => Some(val),
             _ => None,
         }
     }
 
-    /// True iff self == Exact(_)
+    /// Returns true when representing an exact value.
     pub fn is_exact(&self) -> bool {
-        matches!(self, Exact(_))
+        matches!(self, Self::Exact(_))
+    }
+
+    /// Returns true when representing an absent value
+    pub fn is_absent(&self) -> bool {
+        matches!(self, Self::Absent)
     }
 
     /// Map the value of either precision value
     pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Precision<U> {
+        use Precision::*;
+
         match self {
             Exact(value) => Exact(f(value)),
             Inexact(value) => Inexact(f(value)),
+            Absent => Absent,
         }
     }
 
     /// Zip two `Precision` values into a tuple, keeping the inexactness if any.
     pub fn zip<U>(self, other: Precision<U>) -> Precision<(T, U)> {
+        use Precision::*;
+
         match (self, other) {
             (Exact(lhs), Exact(rhs)) => Exact((lhs, rhs)),
             (Inexact(lhs), Exact(rhs))
             | (Exact(lhs), Inexact(rhs))
             | (Inexact(lhs), Inexact(rhs)) => Inexact((lhs, rhs)),
+            (Absent, _) | (_, Absent) => Absent,
         }
     }
 
-    /// Similar to `map` but handles functions that can fail.
-    pub fn try_map<U, F: FnOnce(T) -> VortexResult<U>>(self, f: F) -> VortexResult<Precision<U>> {
-        let precision = match self {
-            Exact(value) => Exact(f(value)?),
-            Inexact(value) => Inexact(f(value)?),
-        };
-        Ok(precision)
-    }
-
     /// Unwrap the underlying value
-    pub fn into_inner(self) -> T {
+    pub fn into_inner(self) -> Option<T> {
+        use Precision::*;
+
         match self {
-            Exact(val) | Inexact(val) => val,
+            Exact(val) | Inexact(val) => Some(val),
+            Absent => None,
         }
     }
 }
 
 impl<T: Display> Display for Precision<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use Precision::*;
+
         match self {
             Exact(v) => {
                 write!(f, "{v}")
             }
             Inexact(v) => {
                 write!(f, "~{v}")
+            }
+            Absent => {
+                write!(f, "{{empty}}")
             }
         }
     }
@@ -151,7 +183,7 @@ impl<T: Display> Display for Precision<T> {
 impl<T: PartialEq> PartialEq<T> for Precision<T> {
     fn eq(&self, other: &T) -> bool {
         match self {
-            Exact(v) => v == other,
+            Self::Exact(v) => v == other,
             _ => false,
         }
     }
@@ -175,5 +207,65 @@ impl Precision<&ScalarValue> {
             Scalar::try_new(dtype, Some(v.clone()))
                 .vortex_expect("`Precision<ScalarValue>` was invalid")
         })
+    }
+}
+
+/// This allows a stat with a `Precision` to be interpreted as a bound.
+impl<T> Precision<T> {
+    /// Applied the stat associated bound to the precision value
+    pub fn bound<S: StatType<T>>(self) -> Option<S::Bound> {
+        if self.is_absent() {
+            None
+        } else {
+            Some(S::Bound::lift(self))
+        }
+    }
+}
+
+impl<T: PartialOrd + Clone> StatBound<T> for Precision<T> {
+    fn lift(value: Precision<T>) -> Self {
+        value
+    }
+
+    fn into_value(self) -> Precision<T> {
+        self
+    }
+
+    fn union(&self, other: &Self) -> Option<Self> {
+        self.clone()
+            .zip(other.clone())
+            .map(|(lhs, rhs)| partial_min(&lhs, &rhs).cloned())
+            .transpose()
+    }
+
+    fn intersection(&self, other: &Self) -> Option<IntersectionResult<Self>> {
+        Some(match (self, other) {
+            (Precision::Exact(lhs), Precision::Exact(rhs)) => {
+                if lhs.partial_cmp(rhs)?.is_eq() {
+                    IntersectionResult::Value(Precision::Exact(lhs.clone()))
+                } else {
+                    IntersectionResult::Empty
+                }
+            }
+            (Precision::Exact(exact), Precision::Inexact(inexact))
+            | (Precision::Inexact(inexact), Precision::Exact(exact)) => {
+                if exact.partial_cmp(inexact)?.is_lt() {
+                    IntersectionResult::Value(Precision::Inexact(exact.clone()))
+                } else {
+                    IntersectionResult::Value(Precision::Exact(exact.clone()))
+                }
+            }
+            (Precision::Inexact(lhs), Precision::Inexact(rhs)) => {
+                IntersectionResult::Value(Precision::Inexact(partial_min(lhs, rhs)?.clone()))
+            }
+            (_, Precision::Absent) | (Precision::Absent, _) => IntersectionResult::Empty,
+        })
+    }
+
+    fn to_exact(&self) -> Option<&T> {
+        match self {
+            Precision::Exact(val) => Some(val),
+            _ => None,
+        }
     }
 }

--- a/vortex-array/src/expr/stats/precision.rs
+++ b/vortex-array/src/expr/stats/precision.rs
@@ -22,17 +22,12 @@ use crate::scalar::ScalarValue;
 /// This is statistic specific, for max this will be an upper bound. Meaning that the actual max
 /// in an array is guaranteed to be less than or equal to the inexact value, but equal to the exact
 /// value.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Precision<T> {
     Exact(T),
     Inexact(T),
+    #[default]
     Absent,
-}
-
-impl<T> Default for Precision<T> {
-    fn default() -> Self {
-        Self::Absent
-    }
 }
 
 impl<T> Precision<Option<T>> {

--- a/vortex-array/src/expr/stats/precision.rs
+++ b/vortex-array/src/expr/stats/precision.rs
@@ -50,8 +50,13 @@ impl<T> Precision<Option<T>> {
 }
 
 impl<T, E> Precision<Result<T, E>> {
+    /// Transpose a `Precision<Result<T, E>>` into a `Result<Precision<T>, E>`.
     pub fn transpose(self) -> Result<Precision<T>, E> {
-        todo!()
+        match self {
+            Self::Exact(value) => value.map(Precision::Exact),
+            Self::Inexact(value) => value.map(Precision::Inexact),
+            Self::Absent => Ok(Precision::Absent),
+        }
     }
 }
 

--- a/vortex-array/src/expr/stats/precision.rs
+++ b/vortex-array/src/expr/stats/precision.rs
@@ -30,20 +30,6 @@ pub enum Precision<T> {
     Absent,
 }
 
-impl<T> Precision<Option<T>> {
-    /// Transpose the `Precision<Option<T>>` into `Option<Precision<T>>`.
-    pub fn transpose(self) -> Option<Precision<T>> {
-        use Precision::*;
-
-        match self {
-            Exact(Some(x)) => Some(Exact(x)),
-            Inexact(Some(x)) => Some(Inexact(x)),
-            Absent => Some(Absent),
-            Exact(None) | Inexact(None) => None,
-        }
-    }
-}
-
 impl<T, E> Precision<Result<T, E>> {
     /// Transpose a `Precision<Result<T, E>>` into a `Result<Precision<T>, E>`.
     pub fn transpose(self) -> Result<Precision<T>, E> {
@@ -134,6 +120,22 @@ impl<T> Precision<T> {
         match self {
             Exact(value) => Exact(f(value)),
             Inexact(value) => Inexact(f(value)),
+            Absent => Absent,
+        }
+    }
+
+    pub fn and_then<U, F: FnOnce(T) -> Option<U>>(self, f: F) -> Precision<U> {
+        use Precision::*;
+
+        match self {
+            Exact(value) => match f(value) {
+                Some(v) => Exact(v),
+                None => Absent,
+            },
+            Inexact(value) => match f(value) {
+                Some(v) => Inexact(v),
+                None => Absent,
+            },
             Absent => Absent,
         }
     }
@@ -232,10 +234,15 @@ impl<T: PartialOrd + Clone> StatBound<T> for Precision<T> {
     }
 
     fn union(&self, other: &Self) -> Option<Self> {
-        self.clone()
+        match self
+            .clone()
             .zip(other.clone())
             .map(|(lhs, rhs)| partial_min(&lhs, &rhs).cloned())
-            .transpose()
+        {
+            Precision::Exact(v) => Some(Precision::Exact(v?)),
+            Precision::Inexact(v) => Some(Precision::Inexact(v?)),
+            Precision::Absent => None,
+        }
     }
 
     fn intersection(&self, other: &Self) -> Option<IntersectionResult<Self>> {

--- a/vortex-array/src/expr/stats/provider.rs
+++ b/vortex-array/src/expr/stats/provider.rs
@@ -10,7 +10,7 @@ use crate::expr::stats::Stat;
 use crate::scalar::Scalar;
 
 pub trait StatsProvider {
-    fn get(&self, stat: Stat) -> Option<Precision<Scalar>>;
+    fn get(&self, stat: Stat) -> Precision<Scalar>;
 
     /// Count of stored stats with known values.
     fn len(&self) -> usize;
@@ -25,23 +25,21 @@ impl<S> StatsProviderExt for S where S: StatsProvider {}
 
 pub trait StatsProviderExt: StatsProvider {
     fn get_scalar_bound<S: StatType<Scalar>>(&self) -> Option<S::Bound> {
-        self.get(S::STAT).map(|v| v.bound::<S>())
+        self.get(S::STAT).bound::<S>()
     }
 
     fn get_as<T: for<'a> TryFrom<&'a Scalar, Error = VortexError>>(
         &self,
         stat: Stat,
-    ) -> Option<Precision<T>> {
+    ) -> Precision<T> {
         self.get(stat).map(|v| {
-            v.map(|v| {
-                T::try_from(&v).unwrap_or_else(|err| {
-                    vortex_panic!(
-                        err,
-                        "Failed to get stat {} as {}",
-                        stat,
-                        std::any::type_name::<T>()
-                    )
-                })
+            T::try_from(&v).unwrap_or_else(|err| {
+                vortex_panic!(
+                    err,
+                    "Failed to get stat {} as {}",
+                    stat,
+                    std::any::type_name::<T>()
+                )
             })
         })
     }
@@ -51,6 +49,6 @@ pub trait StatsProviderExt: StatsProvider {
         S: StatType<U>,
         U: for<'a> TryFrom<&'a Scalar, Error = VortexError>,
     {
-        self.get_as::<U>(S::STAT).map(|v| v.bound::<S>())
+        self.get_as::<U>(S::STAT).bound::<S>()
     }
 }

--- a/vortex-array/src/expr/stats/stat_bound.rs
+++ b/vortex-array/src/expr/stats/stat_bound.rs
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::cmp::Ordering;
-
 use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
 use crate::expr::stats::bound::IntersectionResult;
-use crate::partial_ord::partial_min;
 
 /// `StatType` define the bound of a given statistic. (e.g. `Max` is an upper bound),
 /// this is used to extract the bound from a `Precision` value, (e.g. `p::bound<Max>()`).
@@ -37,59 +34,4 @@ pub trait StatBound<T>: Sized {
 
     /// Returns the exact value from the bound if that value is exact, otherwise `None`.
     fn to_exact(&self) -> Option<&T>;
-}
-
-/// This allows a stat with a `Precision` to be interpreted as a bound.
-impl<T> Precision<T> {
-    /// Applied the stat associated bound to the precision value
-    pub fn bound<S: StatType<T>>(self) -> S::Bound {
-        S::Bound::lift(self)
-    }
-}
-
-impl<T: PartialOrd + Clone> StatBound<T> for Precision<T> {
-    fn lift(value: Precision<T>) -> Self {
-        value
-    }
-
-    fn into_value(self) -> Precision<T> {
-        self
-    }
-
-    fn union(&self, other: &Self) -> Option<Self> {
-        self.clone()
-            .zip(other.clone())
-            .map(|(lhs, rhs)| partial_min(&lhs, &rhs).cloned())
-            .transpose()
-    }
-
-    fn intersection(&self, other: &Self) -> Option<IntersectionResult<Self>> {
-        Some(match (self, other) {
-            (Precision::Exact(lhs), Precision::Exact(rhs)) => {
-                if lhs.partial_cmp(rhs)? == Ordering::Equal {
-                    IntersectionResult::Value(Precision::Exact(lhs.clone()))
-                } else {
-                    IntersectionResult::None
-                }
-            }
-            (Precision::Exact(exact), Precision::Inexact(inexact))
-            | (Precision::Inexact(inexact), Precision::Exact(exact)) => {
-                if exact.partial_cmp(inexact)? == Ordering::Less {
-                    IntersectionResult::Value(Precision::Inexact(exact.clone()))
-                } else {
-                    IntersectionResult::Value(Precision::Exact(exact.clone()))
-                }
-            }
-            (Precision::Inexact(lhs), Precision::Inexact(rhs)) => {
-                IntersectionResult::Value(Precision::Inexact(partial_min(lhs, rhs)?.clone()))
-            }
-        })
-    }
-
-    fn to_exact(&self) -> Option<&T> {
-        match self {
-            Precision::Exact(val) => Some(val),
-            _ => None,
-        }
-    }
 }

--- a/vortex-array/src/scalar_fn/fns/stat.rs
+++ b/vortex-array/src/scalar_fn/fns/stat.rs
@@ -142,44 +142,34 @@ fn stat_array(
 ) -> VortexResult<ArrayRef> {
     let value = if aggregate_fn.is::<AllNull>() {
         let len = u64::try_from(len)?;
-        array
-            .statistics()
-            .get_as::<u64>(Stat::NullCount)
-            .and_then(|null_count| match null_count {
-                Precision::Exact(count) => Some(count == len),
-                Precision::Inexact(count) => (count < len).then_some(false),
-            })
-            .map(ScalarValue::Bool)
+        match array.statistics().get_as::<u64>(Stat::NullCount) {
+            Precision::Exact(count) => Some(count == len),
+            Precision::Inexact(count) => (count < len).then_some(false),
+            Precision::Absent => None,
+        }
+        .map(ScalarValue::Bool)
     } else if aggregate_fn.is::<AllNonNull>() {
-        array
-            .statistics()
-            .get_as::<u64>(Stat::NullCount)
-            .and_then(|null_count| match null_count {
-                Precision::Exact(count) => Some(count == 0),
-                Precision::Inexact(0) => Some(true),
-                Precision::Inexact(_) => None,
-            })
-            .map(ScalarValue::Bool)
+        match array.statistics().get_as::<u64>(Stat::NullCount) {
+            Precision::Exact(count) => Some(count == 0),
+            Precision::Inexact(0) => Some(true),
+            Precision::Inexact(_) | Precision::Absent => None,
+        }
+        .map(ScalarValue::Bool)
     } else if aggregate_fn.is::<AllNan>() {
         let len = u64::try_from(len)?;
-        array
-            .statistics()
-            .get_as::<u64>(Stat::NaNCount)
-            .and_then(|nan_count| match nan_count {
-                Precision::Exact(count) => Some(count == len),
-                Precision::Inexact(count) => (count < len).then_some(false),
-            })
-            .map(ScalarValue::Bool)
+        match array.statistics().get_as::<u64>(Stat::NaNCount) {
+            Precision::Exact(count) => Some(count == len),
+            Precision::Inexact(count) => (count < len).then_some(false),
+            Precision::Absent => None,
+        }
+        .map(ScalarValue::Bool)
     } else if aggregate_fn.is::<AllNonNan>() {
-        array
-            .statistics()
-            .get_as::<u64>(Stat::NaNCount)
-            .and_then(|nan_count| match nan_count {
-                Precision::Exact(count) => Some(count == 0),
-                Precision::Inexact(0) => Some(true),
-                Precision::Inexact(_) => None,
-            })
-            .map(ScalarValue::Bool)
+        match array.statistics().get_as::<u64>(Stat::NaNCount) {
+            Precision::Exact(count) => Some(count == 0),
+            Precision::Inexact(0) => Some(true),
+            Precision::Inexact(_) | Precision::Absent => None,
+        }
+        .map(ScalarValue::Bool)
     } else if let Some(stat) = Stat::from_aggregate_fn(aggregate_fn) {
         array
             .statistics()

--- a/vortex-array/src/scalar_fn/fns/stat.rs
+++ b/vortex-array/src/scalar_fn/fns/stat.rs
@@ -185,7 +185,7 @@ fn stat_array(
             .statistics()
             .with_typed_stats_set(|stats| stats.get(stat))
             // We don't mind whether the stat is approxed or not, since these are row-wise bounds.
-            .map(|stat| stat.into_inner())
+            .into_inner()
             .and_then(Scalar::into_value)
     } else {
         tracing::trace!(

--- a/vortex-array/src/stats/array.rs
+++ b/vortex-array/src/stats/array.rs
@@ -104,7 +104,7 @@ impl StatsSetRef<'_> {
         let mut guard = self.array_stats.inner.write();
         for (stat, value) in iter {
             if !value.is_exact() {
-                if !guard.get(*stat).is_some_and(|v| v.is_exact()) {
+                if !guard.get(*stat).is_exact() {
                     guard.set(*stat, value.clone());
                 }
             } else {
@@ -155,7 +155,7 @@ impl StatsSetRef<'_> {
 
     pub fn compute_stat(&self, stat: Stat, ctx: &mut ExecutionCtx) -> VortexResult<Option<Scalar>> {
         // If it's already computed and exact, we can return it.
-        if let Some(Precision::Exact(s)) = self.get(stat) {
+        if let Precision::Exact(s) = self.get(stat) {
             return Ok(Some(s));
         }
 
@@ -281,7 +281,7 @@ impl StatsSetRef<'_> {
 }
 
 impl StatsProvider for StatsSetRef<'_> {
-    fn get(&self, stat: Stat) -> Option<Precision<Scalar>> {
+    fn get(&self, stat: Stat) -> Precision<Scalar> {
         self.array_stats
             .inner
             .read()

--- a/vortex-array/src/stats/flatbuffers.rs
+++ b/vortex-array/src/stats/flatbuffers.rs
@@ -38,45 +38,33 @@ impl WriteFlatBuffer for StatsSet {
         &self,
         fbb: &mut FlatBufferBuilder<'fb>,
     ) -> VortexResult<WIPOffset<Self::Target<'fb>>> {
-        let (min_precision, min) = self
-            .get(Stat::Min)
-            .map(|min| {
-                (
-                    if min.is_exact() {
-                        fba::Precision::Exact
-                    } else {
-                        fba::Precision::Inexact
-                    },
-                    Some(
-                        fbb.create_vector(&ScalarValue::to_proto_bytes::<Vec<u8>>(Some(
-                            &min.into_inner(),
-                        ))),
-                    ),
-                )
-            })
-            .unwrap_or_else(|| (fba::Precision::Inexact, None));
+        let (min_precision, min) = match self.get(Stat::Min) {
+            Precision::Exact(min) => (
+                fba::Precision::Exact,
+                Some(fbb.create_vector(&ScalarValue::to_proto_bytes::<Vec<u8>>(Some(&min)))),
+            ),
+            Precision::Inexact(min) => (
+                fba::Precision::Inexact,
+                Some(fbb.create_vector(&ScalarValue::to_proto_bytes::<Vec<u8>>(Some(&min)))),
+            ),
+            Precision::Absent => (fba::Precision::Absent, None),
+        };
 
-        let (max_precision, max) = self
-            .get(Stat::Max)
-            .map(|max| {
-                (
-                    if max.is_exact() {
-                        fba::Precision::Exact
-                    } else {
-                        fba::Precision::Inexact
-                    },
-                    Some(
-                        fbb.create_vector(&ScalarValue::to_proto_bytes::<Vec<u8>>(Some(
-                            &max.into_inner(),
-                        ))),
-                    ),
-                )
-            })
-            .unwrap_or_else(|| (fba::Precision::Inexact, None));
+        let (max_precision, max) = match self.get(Stat::Max) {
+            Precision::Exact(max) => (
+                fba::Precision::Exact,
+                Some(fbb.create_vector(&ScalarValue::to_proto_bytes::<Vec<u8>>(Some(&max)))),
+            ),
+            Precision::Inexact(max) => (
+                fba::Precision::Inexact,
+                Some(fbb.create_vector(&ScalarValue::to_proto_bytes::<Vec<u8>>(Some(&max)))),
+            ),
+            Precision::Absent => (fba::Precision::Absent, None),
+        };
 
         let sum = self
             .get(Stat::Sum)
-            .and_then(Precision::as_exact)
+            .as_exact()
             .map(|sum| fbb.create_vector(&ScalarValue::to_proto_bytes::<Vec<u8>>(Some(&sum))));
 
         let stat_args = &fba::ArrayStatsArgs {
@@ -87,22 +75,22 @@ impl WriteFlatBuffer for StatsSet {
             sum,
             is_sorted: self
                 .get_as::<bool>(Stat::IsSorted, &DType::Bool(Nullability::NonNullable))
-                .and_then(Precision::as_exact),
+                .as_exact(),
             is_strict_sorted: self
                 .get_as::<bool>(Stat::IsStrictSorted, &DType::Bool(Nullability::NonNullable))
-                .and_then(Precision::as_exact),
+                .as_exact(),
             is_constant: self
                 .get_as::<bool>(Stat::IsConstant, &DType::Bool(Nullability::NonNullable))
-                .and_then(Precision::as_exact),
+                .as_exact(),
             null_count: self
                 .get_as::<u64>(Stat::NullCount, &PType::U64.into())
-                .and_then(Precision::as_exact),
+                .as_exact(),
             uncompressed_size_in_bytes: self
                 .get_as::<u64>(Stat::UncompressedSizeInBytes, &PType::U64.into())
-                .and_then(Precision::as_exact),
+                .as_exact(),
             nan_count: self
                 .get_as::<u64>(Stat::NaNCount, &PType::U64.into())
-                .and_then(Precision::as_exact),
+                .as_exact(),
         };
 
         Ok(fba::ArrayStats::create(fbb, stat_args))
@@ -144,6 +132,11 @@ impl StatsSet {
                     if let Some(max) = fb.max()
                         && let Some(stat_dtype) = stat_dtype
                     {
+                        let max_precision = fb.max_precision();
+                        if max_precision == fba::Precision::Absent {
+                            vortex_bail!("Corrupted max stat: value present with absent precision");
+                        }
+
                         let value =
                             ScalarValue::from_proto_bytes(max.bytes(), &stat_dtype, session)?;
                         let Some(value) = value else {
@@ -152,7 +145,7 @@ impl StatsSet {
 
                         stats_set.set(
                             Stat::Max,
-                            match fb.max_precision() {
+                            match max_precision {
                                 fba::Precision::Exact => Precision::Exact(value),
                                 fba::Precision::Inexact => Precision::Inexact(value),
                                 other => vortex_bail!("Corrupted max_precision field: {other:?}"),
@@ -164,6 +157,11 @@ impl StatsSet {
                     if let Some(min) = fb.min()
                         && let Some(stat_dtype) = stat_dtype
                     {
+                        let min_precision = fb.min_precision();
+                        if min_precision == fba::Precision::Absent {
+                            vortex_bail!("Corrupted min stat: value present with absent precision");
+                        }
+
                         let value =
                             ScalarValue::from_proto_bytes(min.bytes(), &stat_dtype, session)?;
                         let Some(value) = value else {
@@ -172,7 +170,7 @@ impl StatsSet {
 
                         stats_set.set(
                             Stat::Min,
-                            match fb.min_precision() {
+                            match min_precision {
                                 fba::Precision::Exact => Precision::Exact(value),
                                 fba::Precision::Inexact => Precision::Inexact(value),
                                 other => vortex_bail!("Corrupted min_precision field: {other:?}"),

--- a/vortex-array/src/stats/flatbuffers.rs
+++ b/vortex-array/src/stats/flatbuffers.rs
@@ -47,7 +47,7 @@ impl WriteFlatBuffer for StatsSet {
                 fba::Precision::Inexact,
                 Some(fbb.create_vector(&ScalarValue::to_proto_bytes::<Vec<u8>>(Some(&min)))),
             ),
-            Precision::Absent => (fba::Precision::Absent, None),
+            Precision::Absent => (fba::Precision::Inexact, None),
         };
 
         let (max_precision, max) = match self.get(Stat::Max) {
@@ -59,7 +59,7 @@ impl WriteFlatBuffer for StatsSet {
                 fba::Precision::Inexact,
                 Some(fbb.create_vector(&ScalarValue::to_proto_bytes::<Vec<u8>>(Some(&max)))),
             ),
-            Precision::Absent => (fba::Precision::Absent, None),
+            Precision::Absent => (fba::Precision::Inexact, None),
         };
 
         let sum = self
@@ -132,11 +132,6 @@ impl StatsSet {
                     if let Some(max) = fb.max()
                         && let Some(stat_dtype) = stat_dtype
                     {
-                        let max_precision = fb.max_precision();
-                        if max_precision == fba::Precision::Absent {
-                            vortex_bail!("Corrupted max stat: value present with absent precision");
-                        }
-
                         let value =
                             ScalarValue::from_proto_bytes(max.bytes(), &stat_dtype, session)?;
                         let Some(value) = value else {
@@ -145,7 +140,7 @@ impl StatsSet {
 
                         stats_set.set(
                             Stat::Max,
-                            match max_precision {
+                            match fb.max_precision() {
                                 fba::Precision::Exact => Precision::Exact(value),
                                 fba::Precision::Inexact => Precision::Inexact(value),
                                 other => vortex_bail!("Corrupted max_precision field: {other:?}"),
@@ -157,11 +152,6 @@ impl StatsSet {
                     if let Some(min) = fb.min()
                         && let Some(stat_dtype) = stat_dtype
                     {
-                        let min_precision = fb.min_precision();
-                        if min_precision == fba::Precision::Absent {
-                            vortex_bail!("Corrupted min stat: value present with absent precision");
-                        }
-
                         let value =
                             ScalarValue::from_proto_bytes(min.bytes(), &stat_dtype, session)?;
                         let Some(value) = value else {
@@ -170,7 +160,7 @@ impl StatsSet {
 
                         stats_set.set(
                             Stat::Min,
-                            match min_precision {
+                            match fb.min_precision() {
                                 fba::Precision::Exact => Precision::Exact(value),
                                 fba::Precision::Inexact => Precision::Inexact(value),
                                 other => vortex_bail!("Corrupted min_precision field: {other:?}"),

--- a/vortex-array/src/stats/stats_set.rs
+++ b/vortex-array/src/stats/stats_set.rs
@@ -103,11 +103,12 @@ impl StatsSet {
     }
 
     /// Get value for a given stat
-    pub fn get(&self, stat: Stat) -> Option<Precision<ScalarValue>> {
+    pub fn get(&self, stat: Stat) -> Precision<ScalarValue> {
         self.values
             .iter()
             .find(|(s, _)| *s == stat)
             .map(|(_, v)| v.clone())
+            .unwrap_or(Precision::Absent)
     }
 
     /// Length of the stats set
@@ -125,21 +126,19 @@ impl StatsSet {
         &self,
         stat: Stat,
         dtype: &DType,
-    ) -> Option<Precision<T>> {
+    ) -> Precision<T> {
         self.get(stat).map(|v| {
-            v.map(|v| {
-                T::try_from(
-                    &Scalar::try_new(dtype.clone(), Some(v))
-                        .vortex_expect("failed to construct a scalar statistic"),
+            T::try_from(
+                &Scalar::try_new(dtype.clone(), Some(v))
+                    .vortex_expect("failed to construct a scalar statistic"),
+            )
+            .unwrap_or_else(|err| {
+                vortex_panic!(
+                    err,
+                    "Failed to get stat {} as {}",
+                    stat,
+                    std::any::type_name::<T>()
                 )
-                .unwrap_or_else(|err| {
-                    vortex_panic!(
-                        err,
-                        "Failed to get stat {} as {}",
-                        stat,
-                        std::any::type_name::<T>()
-                    )
-                })
             })
         })
     }
@@ -220,16 +219,14 @@ pub struct TypedStatsSetRef<'a, 'b> {
 }
 
 impl StatsProvider for TypedStatsSetRef<'_, '_> {
-    fn get(&self, stat: Stat) -> Option<Precision<Scalar>> {
-        self.values.get(stat).map(|p| {
-            p.map(|sv| {
-                Scalar::try_new(
-                    stat.dtype(self.dtype)
-                        .vortex_expect("Must have valid dtype if value is present"),
-                    Some(sv),
-                )
-                .vortex_expect("failed to construct a scalar statistic")
-            })
+    fn get(&self, stat: Stat) -> Precision<Scalar> {
+        self.values.get(stat).map(|sv| {
+            Scalar::try_new(
+                stat.dtype(self.dtype)
+                    .vortex_expect("Must have valid dtype if value is present"),
+                Some(sv),
+            )
+            .vortex_expect("failed to construct a scalar statistic")
         })
     }
 
@@ -256,16 +253,14 @@ impl MutTypedStatsSetRef<'_, '_> {
 }
 
 impl StatsProvider for MutTypedStatsSetRef<'_, '_> {
-    fn get(&self, stat: Stat) -> Option<Precision<Scalar>> {
-        self.values.get(stat).map(|p| {
-            p.map(|sv| {
-                Scalar::try_new(
-                    stat.dtype(self.dtype)
-                        .vortex_expect("Must have valid dtype if value is present"),
-                    Some(sv),
-                )
-                .vortex_expect("failed to construct a scalar statistic")
-            })
+    fn get(&self, stat: Stat) -> Precision<Scalar> {
+        self.values.get(stat).map(|sv| {
+            Scalar::try_new(
+                stat.dtype(self.dtype)
+                    .vortex_expect("Must have valid dtype if value is present"),
+                Some(sv),
+            )
+            .vortex_expect("failed to construct a scalar statistic")
         })
     }
 
@@ -488,13 +483,12 @@ impl MutTypedStatsSetRef<'_, '_> {
         let self_min = self.get(Stat::Min);
         let other_min = other.get(Stat::Min);
 
-        if let (
-            Some(Precision::Exact(self_const)),
-            Some(Precision::Exact(other_const)),
-            Some(Precision::Exact(self_min)),
-            Some(Precision::Exact(other_min)),
-        ) = (self_const, other_const, self_min, other_min)
-        {
+        if let (Some(self_const), Some(other_const), Some(self_min), Some(other_min)) = (
+            self_const.as_exact(),
+            other_const.as_exact(),
+            self_min.as_exact(),
+            other_min.as_exact(),
+        ) {
             if self_const && other_const && self_min == other_min {
                 self.set(Stat::IsConstant, Precision::exact(true));
             } else {
@@ -518,7 +512,7 @@ impl MutTypedStatsSetRef<'_, '_> {
         stat: Stat,
         cmp: F,
     ) {
-        if (Some(Precision::Exact(true)), Some(Precision::Exact(true)))
+        if (Precision::Exact(true), Precision::Exact(true))
             == (self.get_as(stat), other.get_as(stat))
         {
             // There might be no stat because it was dropped, or it doesn't exist
@@ -526,10 +520,10 @@ impl MutTypedStatsSetRef<'_, '_> {
             // We assume that it was the dropped case since the doesn't exist might imply sorted,
             // but this in-precision is correct.
             if let (Some(self_max), Some(other_min)) = (
-                self.get_scalar_bound::<Max>(),
-                other.get_scalar_bound::<Min>(),
+                self.get_scalar_bound::<Max>().and_then(|v| v.max_value()),
+                other.get_scalar_bound::<Min>().and_then(|v| v.min_value()),
             ) {
-                return if cmp(&self_max.max_value(), &other_min.min_value()) {
+                return if cmp(&self_max, &other_min) {
                     // keep value
                 } else {
                     self.set(stat, Precision::inexact(false));
@@ -552,14 +546,15 @@ impl MutTypedStatsSetRef<'_, '_> {
     }
 
     fn merge_sum_stat(&mut self, stat: Stat, other: &TypedStatsSetRef) {
-        match (self.get_as::<usize>(stat), other.get_as::<usize>(stat)) {
-            (Some(nc1), Some(nc2)) => {
-                self.set(
-                    stat,
-                    nc1.zip(nc2).map(|(nc1, nc2)| ScalarValue::from(nc1 + nc2)),
-                );
-            }
-            _ => self.clear(stat),
+        let merged = self
+            .get_as::<usize>(stat)
+            .zip(other.get_as::<usize>(stat))
+            .map(|(l, r)| ScalarValue::from(l + r));
+
+        if merged.is_absent() {
+            self.clear(stat);
+        } else {
+            self.set(stat, merged);
         }
     }
 }
@@ -657,12 +652,9 @@ mod test {
         let first_ref = first.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
         assert_eq!(
             first_ref.get_as::<bool>(Stat::IsConstant),
-            Some(Precision::exact(false))
+            Precision::exact(false)
         );
-        assert_eq!(
-            first_ref.get_as::<i32>(Stat::Min),
-            Some(Precision::exact(42))
-        );
+        assert_eq!(first_ref.get_as::<i32>(Stat::Min), Precision::exact(42));
     }
 
     #[test]
@@ -673,7 +665,7 @@ mod test {
         );
 
         let first_ref = first.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
-        assert!(first_ref.get(Stat::Min).is_none());
+        assert!(first_ref.get(Stat::Min).is_absent());
     }
 
     #[test]
@@ -684,7 +676,7 @@ mod test {
         );
 
         let first_ref = first.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
-        assert!(first_ref.get(Stat::Min).is_none());
+        assert!(first_ref.get(Stat::Min).is_absent());
     }
 
     #[test]
@@ -695,10 +687,7 @@ mod test {
         );
 
         let first_ref = first.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
-        assert_eq!(
-            first_ref.get_as::<i32>(Stat::Min),
-            Some(Precision::exact(37))
-        );
+        assert_eq!(first_ref.get_as::<i32>(Stat::Min), Precision::exact(37));
     }
 
     #[test]
@@ -707,7 +696,7 @@ mod test {
             &StatsSet::default(),
             &DType::Primitive(PType::I32, Nullability::NonNullable),
         );
-        assert!(first.get(Stat::Max).is_none());
+        assert!(first.get(Stat::Max).is_absent());
     }
 
     #[test]
@@ -716,7 +705,7 @@ mod test {
             &StatsSet::of(Stat::Max, Precision::exact(42)),
             &DType::Primitive(PType::I32, Nullability::NonNullable),
         );
-        assert!(first.get(Stat::Max).is_none());
+        assert!(first.get(Stat::Max).is_absent());
     }
 
     #[test]
@@ -726,10 +715,7 @@ mod test {
             &DType::Primitive(PType::I32, Nullability::NonNullable),
         );
         let first_ref = first.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
-        assert_eq!(
-            first_ref.get_as::<i32>(Stat::Max),
-            Some(Precision::exact(42))
-        );
+        assert_eq!(first_ref.get_as::<i32>(Stat::Max), Precision::exact(42));
     }
 
     #[test]
@@ -738,10 +724,7 @@ mod test {
         let first = StatsSet::of(Stat::Max, Precision::exact(42i32))
             .merge_ordered(&StatsSet::of(Stat::Max, Precision::inexact(43i32)), &dtype);
         let first_ref = first.as_typed_ref(&dtype);
-        assert_eq!(
-            first_ref.get_as::<i32>(Stat::Max),
-            Some(Precision::inexact(43))
-        );
+        assert_eq!(first_ref.get_as::<i32>(Stat::Max), Precision::inexact(43));
     }
 
     #[test]
@@ -753,7 +736,7 @@ mod test {
             &DType::Primitive(PType::I32, Nullability::NonNullable),
         );
         let first_ref = first.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
-        assert!(first_ref.get(Stat::Sum).is_none());
+        assert!(first_ref.get(Stat::Sum).is_absent());
     }
 
     #[test]
@@ -765,7 +748,7 @@ mod test {
             &DType::Primitive(PType::I32, Nullability::NonNullable),
         );
         let first_ref = first.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
-        assert!(first_ref.get(Stat::Sum).is_none());
+        assert!(first_ref.get(Stat::Sum).is_absent());
     }
 
     #[test]
@@ -777,10 +760,7 @@ mod test {
             &DType::Primitive(PType::I32, Nullability::NonNullable),
         );
         let first_ref = first.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
-        assert_eq!(
-            first_ref.get_as::<i64>(Stat::Sum),
-            Some(Precision::exact(79i64))
-        );
+        assert_eq!(first_ref.get_as::<i64>(Stat::Sum), Precision::exact(79i64));
     }
 
     #[test]
@@ -789,7 +769,7 @@ mod test {
             &StatsSet::default(),
             &DType::Primitive(PType::I32, Nullability::NonNullable),
         );
-        assert!(first.get(Stat::IsStrictSorted).is_none());
+        assert!(first.get(Stat::IsStrictSorted).is_absent());
     }
 
     #[test]
@@ -798,7 +778,7 @@ mod test {
             &StatsSet::of(Stat::IsStrictSorted, Precision::exact(true)),
             &DType::Primitive(PType::I32, Nullability::NonNullable),
         );
-        assert!(first.get(Stat::IsStrictSorted).is_none());
+        assert!(first.get(Stat::IsStrictSorted).is_absent());
     }
 
     #[test]
@@ -815,7 +795,7 @@ mod test {
         let first_ref = first.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
         assert_eq!(
             first_ref.get_as::<bool>(Stat::IsStrictSorted),
-            Some(Precision::exact(true))
+            Precision::exact(true)
         );
     }
 
@@ -834,7 +814,7 @@ mod test {
             second.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
         assert_eq!(
             second_ref.get_as::<bool>(Stat::IsStrictSorted),
-            Some(Precision::inexact(false))
+            Precision::inexact(false)
         );
     }
 
@@ -853,7 +833,7 @@ mod test {
             second.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
         assert_eq!(
             second_ref.get_as::<bool>(Stat::IsStrictSorted),
-            Some(Precision::exact(false))
+            Precision::exact(false)
         );
     }
 
@@ -866,7 +846,7 @@ mod test {
             &second,
             &DType::Primitive(PType::I32, Nullability::NonNullable),
         );
-        assert!(first.get(Stat::IsStrictSorted).is_none());
+        assert!(first.get(Stat::IsStrictSorted).is_absent());
     }
 
     #[test]
@@ -883,7 +863,7 @@ mod test {
         let first_ref = first.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
         assert_eq!(
             first_ref.get_as::<bool>(Stat::IsStrictSorted),
-            Some(Precision::exact(true))
+            Precision::exact(true)
         );
     }
 
@@ -902,7 +882,7 @@ mod test {
 
         let stats = array.statistics().to_owned();
         for stat in &all_stats {
-            assert!(stats.get(*stat).is_some(), "Stat {stat} is missing");
+            assert!(!stats.get(*stat).is_absent(), "Stat {stat} is missing");
         }
 
         let merged = stats.clone().merge_unordered(
@@ -911,7 +891,7 @@ mod test {
         );
         for stat in &all_stats {
             assert_eq!(
-                merged.get(*stat).is_some(),
+                !merged.get(*stat).is_absent(),
                 stat.is_commutative(),
                 "Stat {stat} remains after merge_unordered despite not being commutative, or was removed despite being commutative"
             )
@@ -929,11 +909,8 @@ mod test {
             stats_ref.get_as::<i32>(Stat::Max)
         );
         assert_eq!(
-            merged_ref.get_as::<u64>(Stat::NullCount).unwrap(),
-            stats_ref
-                .get_as::<u64>(Stat::NullCount)
-                .unwrap()
-                .map(|s| s * 2)
+            merged_ref.get_as::<u64>(Stat::NullCount),
+            stats_ref.get_as::<u64>(Stat::NullCount).map(|s| s * 2)
         );
     }
 
@@ -947,10 +924,7 @@ mod test {
         );
         let merged_ref =
             merged.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
-        assert_eq!(
-            merged_ref.get_as::<i32>(Stat::Min),
-            Some(Precision::exact(5))
-        );
+        assert_eq!(merged_ref.get_as::<i32>(Stat::Min), Precision::exact(5));
     }
 
     #[test]
@@ -961,10 +935,7 @@ mod test {
         );
         let merged_ref =
             merged.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
-        assert_eq!(
-            merged_ref.get_as::<i32>(Stat::Min),
-            Some(Precision::inexact(4))
-        );
+        assert_eq!(merged_ref.get_as::<i32>(Stat::Min), Precision::inexact(4));
     }
 
     #[test]
@@ -981,7 +952,7 @@ mod test {
                 .unwrap();
             assert_eq!(
                 stats_ref.get_as::<bool>(Stat::IsConstant),
-                Some(Precision::exact(true))
+                Precision::exact(true)
             );
         }
 
@@ -997,7 +968,7 @@ mod test {
                 .unwrap();
             assert_eq!(
                 stats_ref.get_as::<bool>(Stat::IsConstant),
-                Some(Precision::exact(true))
+                Precision::exact(true)
             );
         }
 
@@ -1013,7 +984,7 @@ mod test {
                 .unwrap();
             assert_eq!(
                 stats_ref.get_as::<bool>(Stat::IsConstant),
-                Some(Precision::exact(false))
+                Precision::exact(false)
             );
         }
     }
@@ -1060,19 +1031,13 @@ mod test {
             stats1.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
 
         // Min should remain unchanged
-        assert_eq!(
-            stats_ref.get_as::<i32>(Stat::Min),
-            Some(Precision::exact(42))
-        );
+        assert_eq!(stats_ref.get_as::<i32>(Stat::Min), Precision::exact(42));
         // Max should be added
-        assert_eq!(
-            stats_ref.get_as::<i32>(Stat::Max),
-            Some(Precision::exact(100))
-        );
+        assert_eq!(stats_ref.get_as::<i32>(Stat::Max), Precision::exact(100));
         // IsStrictSorted should be added
         assert_eq!(
             stats_ref.get_as::<bool>(Stat::IsStrictSorted),
-            Some(Precision::exact(true))
+            Precision::exact(true)
         );
     }
 
@@ -1102,19 +1067,13 @@ mod test {
             stats1.as_typed_ref(&DType::Primitive(PType::I32, Nullability::NonNullable));
 
         // Min should remain unchanged since it's more restrictive than the inexact value
-        assert_eq!(
-            stats_ref.get_as::<i32>(Stat::Min),
-            Some(Precision::exact(42))
-        );
+        assert_eq!(stats_ref.get_as::<i32>(Stat::Min), Precision::exact(42));
         // Check that max was updated with the exact value
-        assert_eq!(
-            stats_ref.get_as::<i32>(Stat::Max),
-            Some(Precision::exact(90))
-        );
+        assert_eq!(stats_ref.get_as::<i32>(Stat::Max), Precision::exact(90));
         // Check that IsSorted was added
         assert_eq!(
             stats_ref.get_as::<bool>(Stat::IsSorted),
-            Some(Precision::exact(true))
+            Precision::exact(true)
         );
     }
 }

--- a/vortex-btrblocks/src/schemes/integer.rs
+++ b/vortex-btrblocks/src/schemes/integer.rs
@@ -1193,15 +1193,15 @@ mod scheme_selection_tests {
         assert!(compressed.is::<BitPacked>());
         assert_eq!(
             compressed.statistics().get_as::<u64>(Stat::NullCount),
-            Some(Precision::exact(0u64))
+            Precision::exact(0u64)
         );
         assert_eq!(
             compressed.statistics().get_as::<u32>(Stat::Min),
-            Some(Precision::exact(0u32))
+            Precision::exact(0u32)
         );
         assert_eq!(
             compressed.statistics().get_as::<u32>(Stat::Max),
-            Some(Precision::exact(15u32))
+            Precision::exact(15u32)
         );
         Ok(())
     }

--- a/vortex-cuda/src/layout.rs
+++ b/vortex-cuda/src/layout.rs
@@ -434,8 +434,8 @@ fn truncate_scalar_stat<F: Fn(Scalar) -> Option<(Scalar, bool)>>(
     stat: Stat,
     truncation: F,
 ) {
-    if let Some(sv) = statistics.get(stat) {
-        if let Some((truncated_value, truncated)) = truncation(sv.into_inner()) {
+    if let Some(sv) = statistics.get(stat).into_inner() {
+        if let Some((truncated_value, truncated)) = truncation(sv) {
             if truncated && let Some(v) = truncated_value.into_value() {
                 statistics.set(stat, Precision::Inexact(v));
             }

--- a/vortex-datafusion/src/convert/stats.rs
+++ b/vortex-datafusion/src/convert/stats.rs
@@ -27,55 +27,52 @@ pub(crate) fn stats_set_to_df(
     // TODO(connor): There's a lot that can go wrong here, should probably handle this
     // more gracefully...
     // Find the min statistic.
-    let min = stats_set.get(Stat::Min).and_then(|pstat_val| {
-        pstat_val
-            .map(|stat_val| {
-                Scalar::try_new(
-                    Stat::Min
-                        .dtype(dtype)
-                        .vortex_expect("must have a valid dtype"),
-                    Some(stat_val),
-                )
-                .vortex_expect("`Stat::Min` somehow had an incompatible `DType`")
-                .try_to_df()
-                .ok()
-            })
-            .transpose()
-    });
+    let min = stats_set
+        .get(Stat::Min)
+        .map(|stat_val| {
+            Scalar::try_new(
+                Stat::Min
+                    .dtype(dtype)
+                    .vortex_expect("must have a valid dtype"),
+                Some(stat_val),
+            )
+            .vortex_expect("`Stat::Min` somehow had an incompatible `DType`")
+            .try_to_df()
+            .ok()
+        })
+        .transpose();
 
     // Find the max statistic.
-    let max = stats_set.get(Stat::Max).and_then(|pstat_val| {
-        pstat_val
-            .map(|stat_val| {
-                Scalar::try_new(
-                    Stat::Max
-                        .dtype(dtype)
-                        .vortex_expect("must have a valid dtype"),
-                    Some(stat_val),
-                )
-                .vortex_expect("`Stat::Max` somehow had an incompatible `DType`")
-                .try_to_df()
-                .ok()
-            })
-            .transpose()
-    });
+    let max = stats_set
+        .get(Stat::Max)
+        .map(|stat_val| {
+            Scalar::try_new(
+                Stat::Max
+                    .dtype(dtype)
+                    .vortex_expect("must have a valid dtype"),
+                Some(stat_val),
+            )
+            .vortex_expect("`Stat::Max` somehow had an incompatible `DType`")
+            .try_to_df()
+            .ok()
+        })
+        .transpose();
 
     // Find the sum statistic
-    let sum = stats_set.get(Stat::Sum).and_then(|pstat_val| {
-        pstat_val
-            .map(|stat_val| {
-                Scalar::try_new(
-                    Stat::Sum
-                        .dtype(dtype)
-                        .vortex_expect("must have a valid dtype"),
-                    Some(stat_val),
-                )
-                .vortex_expect("`Stat::Sum` somehow had an incompatible `DType`")
-                .try_to_df()
-                .ok()
-            })
-            .transpose()
-    });
+    let sum = stats_set
+        .get(Stat::Sum)
+        .map(|stat_val| {
+            Scalar::try_new(
+                Stat::Sum
+                    .dtype(dtype)
+                    .vortex_expect("must have a valid dtype"),
+                Some(stat_val),
+            )
+            .vortex_expect("`Stat::Sum` somehow had an incompatible `DType`")
+            .try_to_df()
+            .ok()
+        })
+        .transpose();
 
     let null_count = stats_set.get_as::<usize>(Stat::NullCount, &PType::U64.into());
 
@@ -92,9 +89,9 @@ pub(crate) fn stats_set_to_df(
 }
 
 pub(crate) fn is_constant_to_distinct_count(
-    is_constant: Option<VortexPrecision<bool>>,
+    is_constant: VortexPrecision<bool>,
 ) -> Precision<usize> {
-    match is_constant.and_then(VortexPrecision::as_exact) {
+    match is_constant.as_exact() {
         Some(true) => Precision::Exact(1),
         Some(false) | None => Precision::Absent,
     }

--- a/vortex-datafusion/src/convert/stats.rs
+++ b/vortex-datafusion/src/convert/stats.rs
@@ -27,52 +27,43 @@ pub(crate) fn stats_set_to_df(
     // TODO(connor): There's a lot that can go wrong here, should probably handle this
     // more gracefully...
     // Find the min statistic.
-    let min = stats_set
-        .get(Stat::Min)
-        .map(|stat_val| {
-            Scalar::try_new(
-                Stat::Min
-                    .dtype(dtype)
-                    .vortex_expect("must have a valid dtype"),
-                Some(stat_val),
-            )
-            .vortex_expect("`Stat::Min` somehow had an incompatible `DType`")
-            .try_to_df()
-            .ok()
-        })
-        .transpose();
+    let min = stats_set.get(Stat::Min).and_then(|stat_val| {
+        Scalar::try_new(
+            Stat::Min
+                .dtype(dtype)
+                .vortex_expect("must have a valid dtype"),
+            Some(stat_val),
+        )
+        .vortex_expect("`Stat::Min` somehow had an incompatible `DType`")
+        .try_to_df()
+        .ok()
+    });
 
     // Find the max statistic.
-    let max = stats_set
-        .get(Stat::Max)
-        .map(|stat_val| {
-            Scalar::try_new(
-                Stat::Max
-                    .dtype(dtype)
-                    .vortex_expect("must have a valid dtype"),
-                Some(stat_val),
-            )
-            .vortex_expect("`Stat::Max` somehow had an incompatible `DType`")
-            .try_to_df()
-            .ok()
-        })
-        .transpose();
+    let max = stats_set.get(Stat::Max).and_then(|stat_val| {
+        Scalar::try_new(
+            Stat::Max
+                .dtype(dtype)
+                .vortex_expect("must have a valid dtype"),
+            Some(stat_val),
+        )
+        .vortex_expect("`Stat::Max` somehow had an incompatible `DType`")
+        .try_to_df()
+        .ok()
+    });
 
     // Find the sum statistic
-    let sum = stats_set
-        .get(Stat::Sum)
-        .map(|stat_val| {
-            Scalar::try_new(
-                Stat::Sum
-                    .dtype(dtype)
-                    .vortex_expect("must have a valid dtype"),
-                Some(stat_val),
-            )
-            .vortex_expect("`Stat::Sum` somehow had an incompatible `DType`")
-            .try_to_df()
-            .ok()
-        })
-        .transpose();
+    let sum = stats_set.get(Stat::Sum).and_then(|stat_val| {
+        Scalar::try_new(
+            Stat::Sum
+                .dtype(dtype)
+                .vortex_expect("must have a valid dtype"),
+            Some(stat_val),
+        )
+        .vortex_expect("`Stat::Sum` somehow had an incompatible `DType`")
+        .try_to_df()
+        .ok()
+    });
 
     let null_count = stats_set.get_as::<usize>(Stat::NullCount, &PType::U64.into());
 

--- a/vortex-datafusion/src/lib.rs
+++ b/vortex-datafusion/src/lib.rs
@@ -119,6 +119,7 @@ where
         match self {
             Precision::Exact(v) => DFPrecision::Exact(v),
             Precision::Inexact(v) => DFPrecision::Inexact(v),
+            Precision::Absent => DFPrecision::Absent,
         }
     }
 }

--- a/vortex-datafusion/src/lib.rs
+++ b/vortex-datafusion/src/lib.rs
@@ -124,18 +124,6 @@ where
     }
 }
 
-impl<T> PrecisionExt<T> for Option<Precision<T>>
-where
-    T: Debug + Clone + PartialEq + Eq + PartialOrd,
-{
-    fn to_df(self) -> DFPrecision<T> {
-        match self {
-            Some(v) => v.to_df(),
-            None => DFPrecision::Absent,
-        }
-    }
-}
-
 #[cfg(test)]
 mod common_tests {
     use std::sync::Arc;

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -21,7 +21,7 @@ use datafusion_common::config_namespace;
 use datafusion_common::internal_datafusion_err;
 use datafusion_common::not_impl_err;
 use datafusion_common::parsers::CompressionTypeVariant;
-use datafusion_common::stats::Precision;
+use datafusion_common::stats::Precision as DFPrecision;
 use datafusion_common_runtime::SpawnedTask;
 use datafusion_datasource::TableSchema;
 use datafusion_datasource::file::FileSource;
@@ -52,7 +52,7 @@ use vortex::dtype::PType;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
-use vortex::expr::stats;
+use vortex::expr::stats::Precision;
 use vortex::expr::stats::Stat;
 use vortex::file::EOF_SIZE;
 use vortex::file::MAX_POSTSCRIPT_SIZE;
@@ -499,12 +499,12 @@ impl FileFormat for VortexFormat {
             let Some(file_stats) = file_stats else {
                 // If the file has no column stats, the best we can do is return a row count.
                 return Ok(Statistics {
-                    num_rows: Precision::Exact(
+                    num_rows: DFPrecision::Exact(
                         usize::try_from(row_count)
                             .map_err(|_| vortex_err!("Row count overflow"))
                             .vortex_expect("Row count overflow"),
                     ),
-                    total_byte_size: Precision::Absent,
+                    total_byte_size: DFPrecision::Absent,
                     column_statistics: vec![
                         ColumnStatistics::default();
                         table_schema.fields().len()
@@ -544,6 +544,7 @@ impl FileFormat for VortexFormat {
                     stats_dtype,
                     &target_dtype,
                 );
+
                 let max = scalar_stat_to_df(
                     Stat::Max,
                     stats_set.get(Stat::Max),
@@ -557,7 +558,7 @@ impl FileFormat for VortexFormat {
                     null_count: null_count.to_df(),
                     min_value: min.to_df(),
                     max_value: max.to_df(),
-                    sum_value: Precision::Absent,
+                    sum_value: DFPrecision::Absent,
                     distinct_count: is_constant_to_distinct_count(
                         stats_set.get_as::<bool>(
                             Stat::IsConstant,
@@ -570,10 +571,10 @@ impl FileFormat for VortexFormat {
 
             let total_byte_size = column_statistics
                 .iter()
-                .fold(Precision::Exact(0), |acc, cs| acc.add(&cs.byte_size));
+                .fold(DFPrecision::Exact(0), |acc, cs| acc.add(&cs.byte_size));
 
             Ok(Statistics {
-                num_rows: Precision::Exact(
+                num_rows: DFPrecision::Exact(
                     usize::try_from(row_count)
                         .map_err(|_| vortex_err!("Row count overflow"))
                         .vortex_expect("Row count overflow"),
@@ -639,11 +640,13 @@ impl FileFormat for VortexFormat {
 
 fn scalar_stat_to_df(
     stat: Stat,
-    value: stats::Precision<VortexScalarValue>,
+    value: Precision<VortexScalarValue>,
     stats_dtype: &DType,
     target_dtype: &DType,
-) -> Option<stats::Precision<DFScalarValue>> {
-    let stat_dtype = stat.dtype(stats_dtype)?;
+) -> Precision<DFScalarValue> {
+    let Some(stat_dtype) = stat.dtype(stats_dtype) else {
+        return Precision::Absent;
+    };
 
     value
         .map(|stat_value| {
@@ -652,7 +655,7 @@ fn scalar_stat_to_df(
                 .try_to_df()
         })
         .transpose()
-        .ok()
+        .unwrap_or(Precision::Absent)
 }
 
 #[cfg(test)]

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -639,18 +639,19 @@ impl FileFormat for VortexFormat {
 
 fn scalar_stat_to_df(
     stat: Stat,
-    value: Option<stats::Precision<VortexScalarValue>>,
+    value: stats::Precision<VortexScalarValue>,
     stats_dtype: &DType,
     target_dtype: &DType,
 ) -> Option<stats::Precision<DFScalarValue>> {
     let stat_dtype = stat.dtype(stats_dtype)?;
 
-    value?
-        .try_map(|stat_value| {
+    value
+        .map(|stat_value| {
             Scalar::try_new(stat_dtype, Some(stat_value))?
                 .cast(target_dtype)?
                 .try_to_df()
         })
+        .transpose()
         .ok()
 }
 

--- a/vortex-datafusion/src/v2/source.rs
+++ b/vortex-datafusion/src/v2/source.rs
@@ -512,10 +512,10 @@ impl DataSource for VortexDataSource {
     fn partition_statistics(&self, _partition: Option<usize>) -> DFResult<Statistics> {
         // FIXME(ngates): this should be adjusted based on filters. See DuckDB for heuristics,
         //  and in the future, store the selectivity stats in the session.
-        let num_rows = estimate_to_df_precision(self.data_source.row_count().as_ref());
+        let num_rows = estimate_to_df_precision(&self.data_source.row_count());
 
         // FIXME(ngates): byte size should be adjusted for the initial projection...
-        let total_byte_size = estimate_to_df_precision(self.data_source.byte_size().as_ref());
+        let total_byte_size = estimate_to_df_precision(&self.data_source.byte_size());
 
         // Column statistics must match the output schema (leftover_schema), which may differ
         // from the initial schema after try_swapping_with_projection adds computed columns.
@@ -663,12 +663,10 @@ impl DataSource for VortexDataSource {
 /// [`DataFusionPrecision`].
 ///
 /// [`DataFusionPrecision`]: datafusion_common::stats::Precision
-fn estimate_to_df_precision(est: Option<&Precision<u64>>) -> DFPrecision<usize> {
+fn estimate_to_df_precision(est: &Precision<u64>) -> DFPrecision<usize> {
     match est {
-        Some(Precision::Exact(v)) => DFPrecision::Exact(usize::try_from(*v).unwrap_or(usize::MAX)),
-        Some(Precision::Inexact(v)) => {
-            DFPrecision::Inexact(usize::try_from(*v).unwrap_or(usize::MAX))
-        }
-        Some(Precision::Absent) | None => DFPrecision::Absent,
+        Precision::Exact(v) => DFPrecision::Exact(usize::try_from(*v).unwrap_or(usize::MAX)),
+        Precision::Inexact(v) => DFPrecision::Inexact(usize::try_from(*v).unwrap_or(usize::MAX)),
+        Precision::Absent => DFPrecision::Absent,
     }
 }

--- a/vortex-datafusion/src/v2/source.rs
+++ b/vortex-datafusion/src/v2/source.rs
@@ -669,6 +669,6 @@ fn estimate_to_df_precision(est: Option<&Precision<u64>>) -> DFPrecision<usize> 
         Some(Precision::Inexact(v)) => {
             DFPrecision::Inexact(usize::try_from(*v).unwrap_or(usize::MAX))
         }
-        None => DFPrecision::Absent,
+        Some(Precision::Absent) | None => DFPrecision::Absent,
     }
 }

--- a/vortex-datafusion/src/v2/table.rs
+++ b/vortex-datafusion/src/v2/table.rs
@@ -157,14 +157,14 @@ impl TableProvider for VortexTable {
     //  planning over stats from the physical plan?
     fn statistics(&self) -> Option<Statistics> {
         let num_rows = match self.data_source.row_count() {
-            Some(VortexPrecision::Exact(v)) => {
+            VortexPrecision::Exact(v) => {
                 usize::try_from(v).map(Precision::Exact).unwrap_or_default()
             }
             _ => Precision::Absent,
         };
 
         let total_byte_size = match self.data_source.byte_size() {
-            Some(VortexPrecision::Exact(v)) => {
+            VortexPrecision::Exact(v) => {
                 usize::try_from(v).map(Precision::Exact).unwrap_or_default()
             }
             _ => Precision::Absent,

--- a/vortex-duckdb/src/datasource.rs
+++ b/vortex-duckdb/src/datasource.rs
@@ -230,16 +230,16 @@ pub struct ColumnStatisticsAggregate {
 impl ColumnStatisticsAggregate {
     pub fn new(stats: &StatsSet) -> Self {
         let min = match stats.get(Stat::Min) {
-            Some(Precision::Exact(min)) => Some(min),
+            Precision::Exact(min) => Some(min),
             _ => None,
         };
         let max = match stats.get(Stat::Max) {
-            Some(Precision::Exact(max)) => Some(max),
+            Precision::Exact(max) => Some(max),
             _ => None,
         };
 
         let max_string_length =
-            if let Some(Precision::Exact(value)) = stats.get(Stat::UncompressedSizeInBytes) {
+            if let Precision::Exact(value) = stats.get(Stat::UncompressedSizeInBytes) {
                 // DuckDB's string length is u32
                 #[allow(clippy::cast_possible_truncation)]
                 Some(value.as_primitive().as_u64().vortex_expect("not a u64") as u32)
@@ -248,9 +248,7 @@ impl ColumnStatisticsAggregate {
             };
 
         let has_null = match stats.get(Stat::NullCount) {
-            Some(Precision::Exact(cnt)) => {
-                cnt.as_primitive().as_u64().vortex_expect("not a u64") > 0
-            }
+            Precision::Exact(cnt) => cnt.as_primitive().as_u64().vortex_expect("not a u64") > 0,
             _ => true,
         };
 

--- a/vortex-duckdb/src/datasource.rs
+++ b/vortex-duckdb/src/datasource.rs
@@ -608,7 +608,7 @@ impl<T: DataSourceTableFunction> TableFunction for T {
                 // Post-filter estimate is always a heuristic.
                 Cardinality::Estimate(postfilter_cardinality(v, has_non_optional_filter))
             }
-            None => Cardinality::Unknown,
+            Some(Precision::Absent) | None => Cardinality::Unknown,
         }
     }
 

--- a/vortex-duckdb/src/datasource.rs
+++ b/vortex-duckdb/src/datasource.rs
@@ -602,13 +602,13 @@ impl<T: DataSourceTableFunction> TableFunction for T {
 
     fn cardinality(bind_data: &Self::BindData) -> Cardinality {
         match bind_data.data_source.row_count() {
-            Some(Precision::Exact(v) | Precision::Inexact(v)) => {
+            Precision::Exact(v) | Precision::Inexact(v) => {
                 let has_non_optional_filter =
                     bind_data.has_non_optional_filter.load(Ordering::Relaxed);
                 // Post-filter estimate is always a heuristic.
                 Cardinality::Estimate(postfilter_cardinality(v, has_non_optional_filter))
             }
-            Some(Precision::Absent) | None => Cardinality::Unknown,
+            Precision::Absent => Cardinality::Unknown,
         }
     }
 

--- a/vortex-ffi/src/data_source.rs
+++ b/vortex-ffi/src/data_source.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use vortex::error::VortexResult;
 use vortex::error::vortex_ensure;
+use vortex::expr::stats::Precision::Absent;
 use vortex::expr::stats::Precision::Exact;
 use vortex::expr::stats::Precision::Inexact;
 use vortex::file::multi::MultiFileDataSource;
@@ -124,7 +125,7 @@ pub unsafe extern "C-unwind" fn vx_data_source_get_row_count(
             rc.r#type = vx_estimate_type::VX_ESTIMATE_INEXACT;
             rc.estimate = rows;
         }
-        None => {
+        Some(Absent) | None => {
             rc.r#type = vx_estimate_type::VX_ESTIMATE_UNKNOWN;
         }
     }

--- a/vortex-ffi/src/data_source.rs
+++ b/vortex-ffi/src/data_source.rs
@@ -117,15 +117,15 @@ pub unsafe extern "C-unwind" fn vx_data_source_get_row_count(
 ) {
     let rc = unsafe { &mut *row_count };
     match vx_data_source::as_ref(ds).row_count() {
-        Some(Exact(rows)) => {
+        Exact(rows) => {
             rc.r#type = vx_estimate_type::VX_ESTIMATE_EXACT;
             rc.estimate = rows;
         }
-        Some(Inexact(rows)) => {
+        Inexact(rows) => {
             rc.r#type = vx_estimate_type::VX_ESTIMATE_INEXACT;
             rc.estimate = rows;
         }
-        Some(Absent) | None => {
+        Absent => {
             rc.r#type = vx_estimate_type::VX_ESTIMATE_UNKNOWN;
         }
     }

--- a/vortex-ffi/src/scan.rs
+++ b/vortex-ffi/src/scan.rs
@@ -238,6 +238,7 @@ pub unsafe extern "C-unwind" fn vx_data_source_scan(
                     scan.partition_count().map(|x| match x {
                         Precision::Exact(v) => Precision::Exact(v as u64),
                         Precision::Inexact(v) => Precision::Inexact(v as u64),
+                        Precision::Absent => Precision::Absent,
                     }),
                     unsafe { &mut *estimate },
                 );

--- a/vortex-ffi/src/scan.rs
+++ b/vortex-ffi/src/scan.rs
@@ -194,17 +194,17 @@ fn scan_request(opts: *const vx_scan_options) -> VortexResult<ScanRequest> {
     })
 }
 
-fn write_estimate<T: Into<u64>>(estimate: Option<Precision<T>>, out: &mut vx_estimate) {
+fn write_estimate<T: Into<u64>>(estimate: Precision<T>, out: &mut vx_estimate) {
     match estimate {
-        Some(Precision::Exact(value)) => {
+        Precision::Exact(value) => {
             out.r#type = vx_estimate_type::VX_ESTIMATE_EXACT;
             out.estimate = value.into();
         }
-        Some(Precision::Inexact(value)) => {
+        Precision::Inexact(value) => {
             out.r#type = vx_estimate_type::VX_ESTIMATE_INEXACT;
             out.estimate = value.into();
         }
-        Some(Precision::Absent) | None => {
+        Precision::Absent => {
             out.r#type = vx_estimate_type::VX_ESTIMATE_UNKNOWN;
         }
     }
@@ -234,14 +234,9 @@ pub unsafe extern "C-unwind" fn vx_data_source_scan(
         RUNTIME.block_on(async {
             let scan = vx_data_source::as_ref(data_source).scan(request).await?;
             if !estimate.is_null() {
-                write_estimate(
-                    scan.partition_count().map(|x| match x {
-                        Precision::Exact(v) => Precision::Exact(v as u64),
-                        Precision::Inexact(v) => Precision::Inexact(v as u64),
-                        Precision::Absent => Precision::Absent,
-                    }),
-                    unsafe { &mut *estimate },
-                );
+                write_estimate(scan.partition_count().map(|v| v as u64), unsafe {
+                    &mut *estimate
+                });
             }
             Ok(vx_scan::new(VxScan::Pending(scan)))
         })

--- a/vortex-ffi/src/scan.rs
+++ b/vortex-ffi/src/scan.rs
@@ -204,7 +204,7 @@ fn write_estimate<T: Into<u64>>(estimate: Option<Precision<T>>, out: &mut vx_est
             out.r#type = vx_estimate_type::VX_ESTIMATE_INEXACT;
             out.estimate = value.into();
         }
-        None => {
+        Some(Precision::Absent) | None => {
             out.r#type = vx_estimate_type::VX_ESTIMATE_UNKNOWN;
         }
     }

--- a/vortex-file/src/pruning.rs
+++ b/vortex-file/src/pruning.rs
@@ -60,7 +60,7 @@ pub fn extract_relevant_file_stats_as_struct_row(
                 stat,
                 Stat::Max | Stat::Min | Stat::NaNCount | Stat::NullCount
             ) {
-                let Some(stat_value) = typed_stats.get(*stat).and_then(|p| p.as_exact()) else {
+                let Some(stat_value) = typed_stats.get(*stat).as_exact() else {
                     vortex_bail!("missing stat {}, {} from stats set", field, stat)
                 };
                 columns.push((

--- a/vortex-file/src/v2/file_stats_reader.rs
+++ b/vortex-file/src/v2/file_stats_reader.rs
@@ -132,7 +132,7 @@ impl StatsCatalog for FileStatsLayoutReader {
         let field_idx = self.struct_fields.find(field_name)?;
         let field_stats = self.file_stats.stats_sets().get(field_idx)?;
 
-        let stat_value = field_stats.get(stat)?.as_exact()?;
+        let stat_value = field_stats.get(stat).as_exact()?;
         let field_dtype = self.struct_fields.field_by_index(field_idx)?;
         let stat_dtype = stat.dtype(&field_dtype)?;
         let stat_scalar = Scalar::try_new(stat_dtype, Some(stat_value)).ok()?;

--- a/vortex-flatbuffers/flatbuffers/vortex-array/array.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-array/array.fbs
@@ -40,7 +40,6 @@ table ArrayNode {
 enum Precision: uint8 {
     Inexact = 0,
     Exact = 1,
-    Absent = 2,
 }
 
 table ArrayStats {

--- a/vortex-flatbuffers/flatbuffers/vortex-array/array.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-array/array.fbs
@@ -40,6 +40,7 @@ table ArrayNode {
 enum Precision: uint8 {
     Inexact = 0,
     Exact = 1,
+    Absent = 2,
 }
 
 table ArrayStats {

--- a/vortex-flatbuffers/public-api.lock
+++ b/vortex-flatbuffers/public-api.lock
@@ -450,8 +450,6 @@ pub fn vortex_flatbuffers::array::Compression::run_verifier(&mut flatbuffers::ve
 
 impl vortex_flatbuffers::array::Precision
 
-pub const vortex_flatbuffers::array::Precision::Absent: Self
-
 pub const vortex_flatbuffers::array::Precision::ENUM_MAX: u8
 
 pub const vortex_flatbuffers::array::Precision::ENUM_MIN: u8
@@ -534,7 +532,7 @@ pub const vortex_flatbuffers::array::ENUM_MIN_PRECISION: u8
 
 pub const vortex_flatbuffers::array::ENUM_VALUES_COMPRESSION: [vortex_flatbuffers::array::Compression; 2]
 
-pub const vortex_flatbuffers::array::ENUM_VALUES_PRECISION: [vortex_flatbuffers::array::Precision; 3]
+pub const vortex_flatbuffers::array::ENUM_VALUES_PRECISION: [vortex_flatbuffers::array::Precision; 2]
 
 pub fn vortex_flatbuffers::array::finish_array_buffer<'a, 'b, A: flatbuffers::builder::Allocator + 'a>(&'b mut flatbuffers::builder::FlatBufferBuilder<'a, A>, flatbuffers::primitives::WIPOffset<vortex_flatbuffers::array::Array<'a>>)
 

--- a/vortex-flatbuffers/public-api.lock
+++ b/vortex-flatbuffers/public-api.lock
@@ -450,6 +450,8 @@ pub fn vortex_flatbuffers::array::Compression::run_verifier(&mut flatbuffers::ve
 
 impl vortex_flatbuffers::array::Precision
 
+pub const vortex_flatbuffers::array::Precision::Absent: Self
+
 pub const vortex_flatbuffers::array::Precision::ENUM_MAX: u8
 
 pub const vortex_flatbuffers::array::Precision::ENUM_MIN: u8
@@ -532,7 +534,7 @@ pub const vortex_flatbuffers::array::ENUM_MIN_PRECISION: u8
 
 pub const vortex_flatbuffers::array::ENUM_VALUES_COMPRESSION: [vortex_flatbuffers::array::Compression; 2]
 
-pub const vortex_flatbuffers::array::ENUM_VALUES_PRECISION: [vortex_flatbuffers::array::Precision; 2]
+pub const vortex_flatbuffers::array::ENUM_VALUES_PRECISION: [vortex_flatbuffers::array::Precision; 3]
 
 pub fn vortex_flatbuffers::array::finish_array_buffer<'a, 'b, A: flatbuffers::builder::Allocator + 'a>(&'b mut flatbuffers::builder::FlatBufferBuilder<'a, A>, flatbuffers::primitives::WIPOffset<vortex_flatbuffers::array::Array<'a>>)
 

--- a/vortex-flatbuffers/src/generated/array.rs
+++ b/vortex-flatbuffers/src/generated/array.rs
@@ -91,13 +91,12 @@ impl ::flatbuffers::SimpleToVerifyInSlice for Compression {}
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 pub const ENUM_MIN_PRECISION: u8 = 0;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
-pub const ENUM_MAX_PRECISION: u8 = 2;
+pub const ENUM_MAX_PRECISION: u8 = 1;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_PRECISION: [Precision; 3] = [
+pub const ENUM_VALUES_PRECISION: [Precision; 2] = [
   Precision::Inexact,
   Precision::Exact,
-  Precision::Absent,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -107,21 +106,18 @@ pub struct Precision(pub u8);
 impl Precision {
   pub const Inexact: Self = Self(0);
   pub const Exact: Self = Self(1);
-  pub const Absent: Self = Self(2);
 
   pub const ENUM_MIN: u8 = 0;
-  pub const ENUM_MAX: u8 = 2;
+  pub const ENUM_MAX: u8 = 1;
   pub const ENUM_VALUES: &'static [Self] = &[
     Self::Inexact,
     Self::Exact,
-    Self::Absent,
   ];
   /// Returns the variant's name or "" if unknown.
   pub fn variant_name(self) -> Option<&'static str> {
     match self {
       Self::Inexact => Some("Inexact"),
       Self::Exact => Some("Exact"),
-      Self::Absent => Some("Absent"),
       _ => None,
     }
   }

--- a/vortex-flatbuffers/src/generated/array.rs
+++ b/vortex-flatbuffers/src/generated/array.rs
@@ -91,12 +91,13 @@ impl ::flatbuffers::SimpleToVerifyInSlice for Compression {}
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 pub const ENUM_MIN_PRECISION: u8 = 0;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
-pub const ENUM_MAX_PRECISION: u8 = 1;
+pub const ENUM_MAX_PRECISION: u8 = 2;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_PRECISION: [Precision; 2] = [
+pub const ENUM_VALUES_PRECISION: [Precision; 3] = [
   Precision::Inexact,
   Precision::Exact,
+  Precision::Absent,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -106,18 +107,21 @@ pub struct Precision(pub u8);
 impl Precision {
   pub const Inexact: Self = Self(0);
   pub const Exact: Self = Self(1);
+  pub const Absent: Self = Self(2);
 
   pub const ENUM_MIN: u8 = 0;
-  pub const ENUM_MAX: u8 = 1;
+  pub const ENUM_MAX: u8 = 2;
   pub const ENUM_VALUES: &'static [Self] = &[
     Self::Inexact,
     Self::Exact,
+    Self::Absent,
   ];
   /// Returns the variant's name or "" if unknown.
   pub fn variant_name(self) -> Option<&'static str> {
     match self {
       Self::Inexact => Some("Inexact"),
       Self::Exact => Some("Exact"),
+      Self::Absent => Some("Absent"),
       _ => None,
     }
   }

--- a/vortex-jni/src/data_source.rs
+++ b/vortex-jni/src/data_source.rs
@@ -204,7 +204,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDataSource_rowCount(
         let (rows, cardinality) = match ds.inner.row_count() {
             Some(Precision::Exact(r)) => (r as jlong, 2),
             Some(Precision::Inexact(r)) => (r as jlong, 1),
-            None => (0, 0),
+            Some(Precision::Absent) | None => (0, 0),
         };
         out.set_region(env, 0, &[rows, cardinality])?;
         Ok(())

--- a/vortex-jni/src/data_source.rs
+++ b/vortex-jni/src/data_source.rs
@@ -202,9 +202,9 @@ pub extern "system" fn Java_dev_vortex_jni_NativeDataSource_rowCount(
     try_or_throw(&mut env, |env| {
         let ds = unsafe { NativeDataSource::from_ptr(pointer) };
         let (rows, cardinality) = match ds.inner.row_count() {
-            Some(Precision::Exact(r)) => (r as jlong, 2),
-            Some(Precision::Inexact(r)) => (r as jlong, 1),
-            Some(Precision::Absent) | None => (0, 0),
+            Precision::Exact(r) => (r as jlong, 2),
+            Precision::Inexact(r) => (r as jlong, 1),
+            Precision::Absent => (0, 0),
         };
         out.set_region(env, 0, &[rows, cardinality])?;
         Ok(())

--- a/vortex-jni/src/scan.rs
+++ b/vortex-jni/src/scan.rs
@@ -216,7 +216,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeScan_partitionCount(
         let (rows, cardinality) = match scan.partition_count() {
             Some(Precision::Exact(v)) => (v as jlong, 2),
             Some(Precision::Inexact(v)) => (v as jlong, 1),
-            None => (0, 0),
+            Some(Precision::Absent) | None => (0, 0),
         };
         out.set_region(env, 0, &[rows, cardinality])?;
         Ok(())
@@ -286,7 +286,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativePartition_rowCount(
         let (rows, cardinality) = match partition.row_count() {
             Some(Precision::Exact(v)) => (v as jlong, 2),
             Some(Precision::Inexact(v)) => (v as jlong, 1),
-            None => (0, 0),
+            Some(Precision::Absent) | None => (0, 0),
         };
         out.set_region(env, 0, &[rows, cardinality])?;
         Ok(())

--- a/vortex-jni/src/scan.rs
+++ b/vortex-jni/src/scan.rs
@@ -214,9 +214,9 @@ pub extern "system" fn Java_dev_vortex_jni_NativeScan_partitionCount(
             throw_runtime!("partition count unavailable: scan already started");
         };
         let (rows, cardinality) = match scan.partition_count() {
-            Some(Precision::Exact(v)) => (v as jlong, 2),
-            Some(Precision::Inexact(v)) => (v as jlong, 1),
-            Some(Precision::Absent) | None => (0, 0),
+            Precision::Exact(v) => (v as jlong, 2),
+            Precision::Inexact(v) => (v as jlong, 1),
+            Precision::Absent => (0, 0),
         };
         out.set_region(env, 0, &[rows, cardinality])?;
         Ok(())
@@ -284,9 +284,9 @@ pub extern "system" fn Java_dev_vortex_jni_NativePartition_rowCount(
             throw_runtime!("row count unavailable: partition already started");
         };
         let (rows, cardinality) = match partition.row_count() {
-            Some(Precision::Exact(v)) => (v as jlong, 2),
-            Some(Precision::Inexact(v)) => (v as jlong, 1),
-            Some(Precision::Absent) | None => (0, 0),
+            Precision::Exact(v) => (v as jlong, 2),
+            Precision::Inexact(v) => (v as jlong, 1),
+            Precision::Absent => (0, 0),
         };
         out.set_region(env, 0, &[rows, cardinality])?;
         Ok(())

--- a/vortex-layout/public-api.lock
+++ b/vortex-layout/public-api.lock
@@ -974,7 +974,7 @@ pub fn vortex_layout::scan::layout::LayoutReaderDataSource::with_split_max_row_c
 
 impl vortex_scan::DataSource for vortex_layout::scan::layout::LayoutReaderDataSource
 
-pub fn vortex_layout::scan::layout::LayoutReaderDataSource::byte_size(&self) -> core::option::Option<vortex_array::expr::stats::precision::Precision<u64>>
+pub fn vortex_layout::scan::layout::LayoutReaderDataSource::byte_size(&self) -> vortex_array::expr::stats::precision::Precision<u64>
 
 pub fn vortex_layout::scan::layout::LayoutReaderDataSource::deserialize_partition(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_scan::PartitionRef>
 
@@ -982,7 +982,7 @@ pub fn vortex_layout::scan::layout::LayoutReaderDataSource::dtype(&self) -> &vor
 
 pub fn vortex_layout::scan::layout::LayoutReaderDataSource::field_statistics<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 vortex_array::dtype::field::FieldPath) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_array::stats::stats_set::StatsSet>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
 
-pub fn vortex_layout::scan::layout::LayoutReaderDataSource::row_count(&self) -> core::option::Option<vortex_array::expr::stats::precision::Precision<u64>>
+pub fn vortex_layout::scan::layout::LayoutReaderDataSource::row_count(&self) -> vortex_array::expr::stats::precision::Precision<u64>
 
 pub fn vortex_layout::scan::layout::LayoutReaderDataSource::scan<'life0, 'async_trait>(&'life0 self, vortex_scan::ScanRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_scan::DataSourceScanRef>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 
@@ -1014,7 +1014,7 @@ pub fn vortex_layout::scan::multi::MultiLayoutDataSource::dtype(&self) -> &vorte
 
 pub fn vortex_layout::scan::multi::MultiLayoutDataSource::field_statistics<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 vortex_array::dtype::field::FieldPath) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_array::stats::stats_set::StatsSet>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
 
-pub fn vortex_layout::scan::multi::MultiLayoutDataSource::row_count(&self) -> core::option::Option<vortex_array::expr::stats::precision::Precision<u64>>
+pub fn vortex_layout::scan::multi::MultiLayoutDataSource::row_count(&self) -> vortex_array::expr::stats::precision::Precision<u64>
 
 pub fn vortex_layout::scan::multi::MultiLayoutDataSource::scan<'life0, 'async_trait>(&'life0 self, vortex_scan::ScanRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_scan::DataSourceScanRef>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 

--- a/vortex-layout/src/display.rs
+++ b/vortex-layout/src/display.rs
@@ -334,8 +334,8 @@ mod tests {
                     let expected = "\
 vortex.struct, dtype: {numbers=i64?, strings=utf8}, children: 2, rows: 5
 ├── numbers: vortex.chunked, dtype: i64?, children: 1, rows: 5
-│   └── [0]: vortex.flat, dtype: i64?, metadata: 187 bytes, rows: 5, segment 0, buffers=[40B, 1B], total=41B
-└── strings: vortex.flat, dtype: utf8, metadata: 122 bytes, rows: 5, segment 1, buffers=[43B, 80B], total=123B
+│   └── [0]: vortex.flat, dtype: i64?, metadata: 171 bytes, rows: 5, segment 0, buffers=[40B, 1B], total=41B
+└── strings: vortex.flat, dtype: utf8, metadata: 110 bytes, rows: 5, segment 1, buffers=[43B, 80B], total=123B
 ";
                     assert_eq!(output, expected);
                 })

--- a/vortex-layout/src/display.rs
+++ b/vortex-layout/src/display.rs
@@ -334,8 +334,8 @@ mod tests {
                     let expected = "\
 vortex.struct, dtype: {numbers=i64?, strings=utf8}, children: 2, rows: 5
 ├── numbers: vortex.chunked, dtype: i64?, children: 1, rows: 5
-│   └── [0]: vortex.flat, dtype: i64?, metadata: 171 bytes, rows: 5, segment 0, buffers=[40B, 1B], total=41B
-└── strings: vortex.flat, dtype: utf8, metadata: 110 bytes, rows: 5, segment 1, buffers=[43B, 80B], total=123B
+│   └── [0]: vortex.flat, dtype: i64?, metadata: 187 bytes, rows: 5, segment 0, buffers=[40B, 1B], total=41B
+└── strings: vortex.flat, dtype: utf8, metadata: 122 bytes, rows: 5, segment 1, buffers=[43B, 80B], total=123B
 ";
                     assert_eq!(output, expected);
                 })

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -273,7 +273,7 @@ mod tests {
 
             assert_eq!(
                 result.statistics().get_as::<bool>(Stat::IsSorted),
-                Some(Precision::Exact(true))
+                Precision::Exact(true)
             );
         })
     }
@@ -325,16 +325,16 @@ mod tests {
             assert_eq!(
                 result.statistics().get_as::<String>(Stat::Min),
                 // The typo is correct, we need this to be truncated.
-                Some(Precision::Inexact(
+                Precision::Inexact(
                     // spellchecker:ignore-next-line
                     "Another string that's meant to be smaller than the previous valu".to_string()
-                ))
+                )
             );
             assert_eq!(
                 result.statistics().get_as::<String>(Stat::Max),
-                Some(Precision::Inexact(
+                Precision::Inexact(
                     "Long value to test that the statistics are actually truncated, j".to_string()
-                ))
+                )
             );
         })
     }

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -81,8 +81,8 @@ fn truncate_scalar_stat<F: Fn(Scalar) -> Option<(Scalar, bool)>>(
     stat: Stat,
     truncation: F,
 ) {
-    if let Some(sv) = statistics.get(stat) {
-        if let Some((truncated_value, truncated)) = truncation(sv.into_inner()) {
+    if let Some(sv) = statistics.get(stat).into_inner() {
+        if let Some((truncated_value, truncated)) = truncation(sv) {
             if truncated && let Some(v) = truncated_value.into_value() {
                 statistics.set(stat, Precision::Inexact(v));
             }

--- a/vortex-layout/src/layouts/zoned/builder.rs
+++ b/vortex-layout/src/layouts/zoned/builder.rs
@@ -76,7 +76,7 @@ impl StatsAccumulator {
 
     pub fn push_chunk_without_compute(&mut self, array: &ArrayRef) -> VortexResult<()> {
         for builder in &mut self.builders {
-            if let Some(Precision::Exact(value)) = array.statistics().get(builder.stat()) {
+            if let Precision::Exact(value) = array.statistics().get(builder.stat()) {
                 builder.append_scalar(value.cast(&value.dtype().as_nullable())?)?;
             } else {
                 builder.append_null();

--- a/vortex-layout/src/scan/layout.rs
+++ b/vortex-layout/src/scan/layout.rs
@@ -95,12 +95,12 @@ impl DataSource for LayoutReaderDataSource {
         self.reader.dtype()
     }
 
-    fn row_count(&self) -> Option<Precision<u64>> {
-        Some(Precision::exact(self.reader.row_count()))
+    fn row_count(&self) -> Precision<u64> {
+        Precision::exact(self.reader.row_count())
     }
 
-    fn byte_size(&self) -> Option<Precision<u64>> {
-        None
+    fn byte_size(&self) -> Precision<u64> {
+        Precision::Absent
     }
 
     fn deserialize_partition(
@@ -198,12 +198,12 @@ impl DataSourceScan for LayoutReaderScan {
         &self.dtype
     }
 
-    fn partition_count(&self) -> Option<Precision<usize>> {
+    fn partition_count(&self) -> Precision<usize> {
         let (lower, upper) = self.size_hint();
         match upper {
-            Some(u) if u == lower => Some(Precision::exact(lower)),
-            Some(u) => Some(Precision::inexact(u)),
-            None => Some(Precision::inexact(lower)),
+            Some(u) if u == lower => Precision::exact(lower),
+            Some(u) => Precision::inexact(u),
+            None => Precision::inexact(lower),
         }
     }
 
@@ -295,20 +295,20 @@ impl Partition for LayoutReaderSplit {
         self.row_range.start as usize
     }
 
-    fn row_count(&self) -> Option<Precision<u64>> {
+    fn row_count(&self) -> Precision<u64> {
         let row_count = self.row_range.end - self.row_range.start;
         let row_count = self.selection.row_count(row_count);
         let row_count = self.limit.map_or(row_count, |limit| row_count.min(limit));
 
-        Some(if self.filter.is_some() {
+        if self.filter.is_some() {
             Precision::inexact(row_count)
         } else {
             Precision::exact(row_count)
-        })
+        }
     }
 
-    fn byte_size(&self) -> Option<Precision<u64>> {
-        None
+    fn byte_size(&self) -> Precision<u64> {
+        Precision::Absent
     }
 
     fn execute(self: Box<Self>) -> VortexResult<SendableArrayStream> {
@@ -343,8 +343,8 @@ impl DataSourceScan for Empty {
         &self.dtype
     }
 
-    fn partition_count(&self) -> Option<Precision<usize>> {
-        Some(Precision::exact(1usize))
+    fn partition_count(&self) -> Precision<usize> {
+        Precision::exact(1usize)
     }
 
     fn partitions(self: Box<Self>) -> PartitionStream {
@@ -361,12 +361,12 @@ impl Partition for Empty {
         0
     }
 
-    fn row_count(&self) -> Option<Precision<u64>> {
-        Some(Precision::exact(self.row_count))
+    fn row_count(&self) -> Precision<u64> {
+        Precision::exact(self.row_count)
     }
 
-    fn byte_size(&self) -> Option<Precision<u64>> {
-        Some(Precision::exact(0u64))
+    fn byte_size(&self) -> Precision<u64> {
+        Precision::exact(0u64)
     }
 
     fn execute(mut self: Box<Self>) -> VortexResult<SendableArrayStream> {

--- a/vortex-layout/src/scan/multi.rs
+++ b/vortex-layout/src/scan/multi.rs
@@ -159,7 +159,7 @@ impl DataSource for MultiLayoutDataSource {
         &self.dtype
     }
 
-    fn row_count(&self) -> Option<Precision<u64>> {
+    fn row_count(&self) -> Precision<u64> {
         let mut sum: u64 = 0;
         let mut opened_count: u64 = 0;
         let mut deferred_count: u64 = 0;
@@ -178,17 +178,17 @@ impl DataSource for MultiLayoutDataSource {
 
         let total_count = opened_count + deferred_count;
         if total_count == 0 {
-            return Some(Precision::exact(0u64));
+            return Precision::exact(0u64);
         }
 
         if deferred_count == 0 {
-            Some(Precision::exact(sum))
+            Precision::exact(sum)
         } else if opened_count > 0 {
             let avg = sum / opened_count;
             let extrapolated = avg.saturating_mul(total_count);
-            Some(Precision::inexact(extrapolated))
+            Precision::inexact(extrapolated)
         } else {
-            None
+            Precision::Absent
         }
     }
 
@@ -244,12 +244,12 @@ impl DataSourceScan for MultiLayoutScan {
         &self.dtype
     }
 
-    fn partition_count(&self) -> Option<Precision<usize>> {
+    fn partition_count(&self) -> Precision<usize> {
         let count = self.ready.len() + self.deferred.len();
         if self.deferred.is_empty() {
-            Some(Precision::exact(count))
+            Precision::exact(count)
         } else {
-            Some(Precision::inexact(count))
+            Precision::inexact(count)
         }
     }
 
@@ -400,8 +400,10 @@ impl Partition for MultiLayoutPartition {
         self.index
     }
 
-    fn row_count(&self) -> Option<Precision<u64>> {
-        let row_range = self.request.row_range.as_ref()?;
+    fn row_count(&self) -> Precision<u64> {
+        let Some(row_range) = self.request.row_range.as_ref() else {
+            return Precision::Absent;
+        };
         let row_count = row_range.end - row_range.start;
         let row_count = self.request.selection.row_count(row_count);
         let row_count = self
@@ -409,15 +411,15 @@ impl Partition for MultiLayoutPartition {
             .limit
             .map_or(row_count, |limit| row_count.min(limit));
 
-        Some(if self.request.filter.is_some() {
+        if self.request.filter.is_some() {
             Precision::inexact(row_count)
         } else {
             Precision::exact(row_count)
-        })
+        }
     }
 
-    fn byte_size(&self) -> Option<Precision<u64>> {
-        None
+    fn byte_size(&self) -> Precision<u64> {
+        Precision::Absent
     }
 
     fn execute(self: Box<Self>) -> VortexResult<SendableArrayStream> {

--- a/vortex-scan/public-api.lock
+++ b/vortex-scan/public-api.lock
@@ -84,7 +84,7 @@ pub fn vortex_scan::ScanRequest::fmt(&self, &mut core::fmt::Formatter<'_>) -> co
 
 pub trait vortex_scan::DataSource: 'static + core::marker::Send + core::marker::Sync
 
-pub fn vortex_scan::DataSource::byte_size(&self) -> core::option::Option<vortex_array::expr::stats::precision::Precision<u64>>
+pub fn vortex_scan::DataSource::byte_size(&self) -> vortex_array::expr::stats::precision::Precision<u64>
 
 pub fn vortex_scan::DataSource::deserialize_partition(&self, &[u8], &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_scan::PartitionRef>
 
@@ -92,7 +92,7 @@ pub fn vortex_scan::DataSource::dtype(&self) -> &vortex_array::dtype::DType
 
 pub fn vortex_scan::DataSource::field_statistics<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 vortex_array::dtype::field::FieldPath) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_array::stats::stats_set::StatsSet>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
 
-pub fn vortex_scan::DataSource::row_count(&self) -> core::option::Option<vortex_array::expr::stats::precision::Precision<u64>>
+pub fn vortex_scan::DataSource::row_count(&self) -> vortex_array::expr::stats::precision::Precision<u64>
 
 pub fn vortex_scan::DataSource::scan<'life0, 'async_trait>(&'life0 self, vortex_scan::ScanRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_scan::DataSourceScanRef>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 
@@ -110,7 +110,7 @@ pub trait vortex_scan::DataSourceScan: 'static + core::marker::Send
 
 pub fn vortex_scan::DataSourceScan::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_scan::DataSourceScan::partition_count(&self) -> core::option::Option<vortex_array::expr::stats::precision::Precision<usize>>
+pub fn vortex_scan::DataSourceScan::partition_count(&self) -> vortex_array::expr::stats::precision::Precision<usize>
 
 pub fn vortex_scan::DataSourceScan::partitions(alloc::boxed::Box<Self>) -> vortex_scan::PartitionStream
 
@@ -118,13 +118,13 @@ pub trait vortex_scan::Partition: 'static + core::marker::Send
 
 pub fn vortex_scan::Partition::as_any(&self) -> &dyn core::any::Any
 
-pub fn vortex_scan::Partition::byte_size(&self) -> core::option::Option<vortex_array::expr::stats::precision::Precision<u64>>
+pub fn vortex_scan::Partition::byte_size(&self) -> vortex_array::expr::stats::precision::Precision<u64>
 
 pub fn vortex_scan::Partition::execute(alloc::boxed::Box<Self>) -> vortex_error::VortexResult<vortex_array::stream::SendableArrayStream>
 
 pub fn vortex_scan::Partition::index(&self) -> usize
 
-pub fn vortex_scan::Partition::row_count(&self) -> core::option::Option<vortex_array::expr::stats::precision::Precision<u64>>
+pub fn vortex_scan::Partition::row_count(&self) -> vortex_array::expr::stats::precision::Precision<u64>
 
 pub fn vortex_scan::Partition::serialize(&self) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 

--- a/vortex-scan/src/lib.rs
+++ b/vortex-scan/src/lib.rs
@@ -90,13 +90,13 @@ pub trait DataSource: 'static + Send + Sync {
     fn dtype(&self) -> &DType;
 
     /// Returns an estimate of the row count of the un-filtered source.
-    fn row_count(&self) -> Option<Precision<u64>> {
-        None
+    fn row_count(&self) -> Precision<u64> {
+        Precision::Absent
     }
 
     /// Returns an estimate of the byte size of the un-filtered source.
-    fn byte_size(&self) -> Option<Precision<u64>> {
-        None
+    fn byte_size(&self) -> Precision<u64> {
+        Precision::Absent
     }
 
     /// Serialize the [`DataSource`] to pass to a remote worker.
@@ -170,7 +170,7 @@ pub trait DataSourceScan: 'static + Send {
     fn dtype(&self) -> &DType;
 
     /// Returns an estimate of the total number of partitions the scan will produce.
-    fn partition_count(&self) -> Option<Precision<usize>>;
+    fn partition_count(&self) -> Precision<usize>;
 
     /// Returns a stream of partitions to be processed.
     fn partitions(self: Box<Self>) -> PartitionStream;
@@ -190,10 +190,10 @@ pub trait Partition: 'static + Send {
     fn index(&self) -> usize;
 
     /// Returns an estimate of the row count for this partition.
-    fn row_count(&self) -> Option<Precision<u64>>;
+    fn row_count(&self) -> Precision<u64>;
 
     /// Returns an estimate of the byte size for this partition.
-    fn byte_size(&self) -> Option<Precision<u64>>;
+    fn byte_size(&self) -> Precision<u64>;
 
     /// Serialize this partition for a remote worker.
     fn serialize(&self) -> VortexResult<Option<Vec<u8>>> {


### PR DESCRIPTION
This PR adds a new `Precision::Absent` variant **only after serialization** because its a more idiomatic API. The serialization format is unchanged.