### PR TITLE
perf: remove implicit `ListViewArray` rebuild during `take` and `filter` operations

### DIFF
--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -4446,7 +4446,13 @@ pub vortex_array::arrays::listview::ListViewDataParts::validity: vortex_array::v
 
 pub trait vortex_array::arrays::listview::ListViewArrayExt: vortex_array::TypedArrayRef<vortex_array::arrays::ListView>
 
+pub fn vortex_array::arrays::listview::ListViewArrayExt::compute_density(&self) -> core::option::Option<f32>
+
+pub fn vortex_array::arrays::listview::ListViewArrayExt::compute_referenced_elements_mask(&self) -> core::option::Option<vortex_mask::Mask>
+
 pub fn vortex_array::arrays::listview::ListViewArrayExt::elements(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::listview::ListViewArrayExt::estimate_density(&self) -> vortex_error::VortexResult<core::option::Option<f32>>
 
 pub fn vortex_array::arrays::listview::ListViewArrayExt::list_elements_at(&self, usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
@@ -4466,7 +4472,13 @@ pub fn vortex_array::arrays::listview::ListViewArrayExt::verify_is_zero_copy_to_
 
 impl<T: vortex_array::TypedArrayRef<vortex_array::arrays::ListView>> vortex_array::arrays::listview::ListViewArrayExt for T
 
+pub fn T::compute_density(&self) -> core::option::Option<f32>
+
+pub fn T::compute_referenced_elements_mask(&self) -> core::option::Option<vortex_mask::Mask>
+
 pub fn T::elements(&self) -> &vortex_array::ArrayRef
+
+pub fn T::estimate_density(&self) -> vortex_error::VortexResult<core::option::Option<f32>>
 
 pub fn T::list_elements_at(&self, usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -23966,6 +23966,8 @@ impl vortex_array::Array<vortex_array::arrays::ListView>
 
 pub fn vortex_array::Array<vortex_array::arrays::ListView>::rebuild(&self, vortex_array::arrays::listview::ListViewRebuildMode) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
 
+pub fn vortex_array::Array<vortex_array::arrays::ListView>::should_rebuild(&self, bool) -> bool
+
 impl vortex_array::Array<vortex_array::arrays::Masked>
 
 pub fn vortex_array::Array<vortex_array::arrays::Masked>::try_new(vortex_array::ArrayRef, vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -4446,13 +4446,13 @@ pub vortex_array::arrays::listview::ListViewDataParts::validity: vortex_array::v
 
 pub trait vortex_array::arrays::listview::ListViewArrayExt: vortex_array::TypedArrayRef<vortex_array::arrays::ListView>
 
-pub fn vortex_array::arrays::listview::ListViewArrayExt::compute_density(&self) -> core::option::Option<f32>
+pub fn vortex_array::arrays::listview::ListViewArrayExt::compute_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<f32>>
 
-pub fn vortex_array::arrays::listview::ListViewArrayExt::compute_referenced_elements_mask(&self) -> core::option::Option<vortex_mask::Mask>
+pub fn vortex_array::arrays::listview::ListViewArrayExt::compute_referenced_elements_mask(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_mask::Mask>>
 
 pub fn vortex_array::arrays::listview::ListViewArrayExt::elements(&self) -> &vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::listview::ListViewArrayExt::estimate_density(&self) -> vortex_error::VortexResult<core::option::Option<f32>>
+pub fn vortex_array::arrays::listview::ListViewArrayExt::estimate_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<f32>>
 
 pub fn vortex_array::arrays::listview::ListViewArrayExt::list_elements_at(&self, usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
@@ -4472,13 +4472,13 @@ pub fn vortex_array::arrays::listview::ListViewArrayExt::verify_is_zero_copy_to_
 
 impl<T: vortex_array::TypedArrayRef<vortex_array::arrays::ListView>> vortex_array::arrays::listview::ListViewArrayExt for T
 
-pub fn T::compute_density(&self) -> core::option::Option<f32>
+pub fn T::compute_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<f32>>
 
-pub fn T::compute_referenced_elements_mask(&self) -> core::option::Option<vortex_mask::Mask>
+pub fn T::compute_referenced_elements_mask(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_mask::Mask>>
 
 pub fn T::elements(&self) -> &vortex_array::ArrayRef
 
-pub fn T::estimate_density(&self) -> vortex_error::VortexResult<core::option::Option<f32>>
+pub fn T::estimate_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<f32>>
 
 pub fn T::list_elements_at(&self, usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
@@ -23966,7 +23966,7 @@ impl vortex_array::Array<vortex_array::arrays::ListView>
 
 pub fn vortex_array::Array<vortex_array::arrays::ListView>::rebuild(&self, vortex_array::arrays::listview::ListViewRebuildMode) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
 
-pub fn vortex_array::Array<vortex_array::arrays::ListView>::should_rebuild(&self, bool) -> bool
+pub fn vortex_array::Array<vortex_array::arrays::ListView>::should_rebuild(&self, bool, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<bool>
 
 impl vortex_array::Array<vortex_array::arrays::Masked>
 

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -4444,15 +4444,17 @@ pub vortex_array::arrays::listview::ListViewDataParts::sizes: vortex_array::Arra
 
 pub vortex_array::arrays::listview::ListViewDataParts::validity: vortex_array::validity::Validity
 
+pub const vortex_array::arrays::listview::DEFAULT_REBUILD_DENSITY_THRESHOLD: f32
+
 pub trait vortex_array::arrays::listview::ListViewArrayExt: vortex_array::TypedArrayRef<vortex_array::arrays::ListView>
 
-pub fn vortex_array::arrays::listview::ListViewArrayExt::compute_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<f32>>
+pub fn vortex_array::arrays::listview::ListViewArrayExt::compute_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<f32>
 
-pub fn vortex_array::arrays::listview::ListViewArrayExt::compute_referenced_elements_mask(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_mask::Mask>>
+pub fn vortex_array::arrays::listview::ListViewArrayExt::compute_referenced_elements_mask(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_mask::Mask>
 
 pub fn vortex_array::arrays::listview::ListViewArrayExt::elements(&self) -> &vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::listview::ListViewArrayExt::estimate_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<f32>>
+pub fn vortex_array::arrays::listview::ListViewArrayExt::estimate_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<f32>
 
 pub fn vortex_array::arrays::listview::ListViewArrayExt::list_elements_at(&self, usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
@@ -4472,13 +4474,13 @@ pub fn vortex_array::arrays::listview::ListViewArrayExt::verify_is_zero_copy_to_
 
 impl<T: vortex_array::TypedArrayRef<vortex_array::arrays::ListView>> vortex_array::arrays::listview::ListViewArrayExt for T
 
-pub fn T::compute_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<f32>>
+pub fn T::compute_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<f32>
 
-pub fn T::compute_referenced_elements_mask(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_mask::Mask>>
+pub fn T::compute_referenced_elements_mask(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_mask::Mask>
 
 pub fn T::elements(&self) -> &vortex_array::ArrayRef
 
-pub fn T::estimate_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<f32>>
+pub fn T::estimate_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<f32>
 
 pub fn T::list_elements_at(&self, usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
@@ -23965,8 +23967,6 @@ pub unsafe fn vortex_array::Array<vortex_array::arrays::ListView>::with_zero_cop
 impl vortex_array::Array<vortex_array::arrays::ListView>
 
 pub fn vortex_array::Array<vortex_array::arrays::ListView>::rebuild(&self, vortex_array::arrays::listview::ListViewRebuildMode) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
-
-pub fn vortex_array::Array<vortex_array::arrays::ListView>::should_rebuild(&self, bool, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<bool>
 
 impl vortex_array::Array<vortex_array::arrays::Masked>
 

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -4454,8 +4454,6 @@ pub fn vortex_array::arrays::listview::ListViewArrayExt::compute_referenced_elem
 
 pub fn vortex_array::arrays::listview::ListViewArrayExt::elements(&self) -> &vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::listview::ListViewArrayExt::estimate_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<f32>
-
 pub fn vortex_array::arrays::listview::ListViewArrayExt::list_elements_at(&self, usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::arrays::listview::ListViewArrayExt::listview_validity(&self) -> vortex_array::validity::Validity
@@ -4470,6 +4468,8 @@ pub fn vortex_array::arrays::listview::ListViewArrayExt::size_at(&self, usize) -
 
 pub fn vortex_array::arrays::listview::ListViewArrayExt::sizes(&self) -> &vortex_array::ArrayRef
 
+pub fn vortex_array::arrays::listview::ListViewArrayExt::upper_bound_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<f32>
+
 pub fn vortex_array::arrays::listview::ListViewArrayExt::verify_is_zero_copy_to_list(&self) -> bool
 
 impl<T: vortex_array::TypedArrayRef<vortex_array::arrays::ListView>> vortex_array::arrays::listview::ListViewArrayExt for T
@@ -4479,8 +4479,6 @@ pub fn T::compute_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_erro
 pub fn T::compute_referenced_elements_mask(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_mask::Mask>
 
 pub fn T::elements(&self) -> &vortex_array::ArrayRef
-
-pub fn T::estimate_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<f32>
 
 pub fn T::list_elements_at(&self, usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
@@ -4495,6 +4493,8 @@ pub fn T::offsets(&self) -> &vortex_array::ArrayRef
 pub fn T::size_at(&self, usize) -> usize
 
 pub fn T::sizes(&self) -> &vortex_array::ArrayRef
+
+pub fn T::upper_bound_density(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<f32>
 
 pub fn T::verify_is_zero_copy_to_list(&self) -> bool
 

--- a/vortex-array/src/arrays/filter/execute/listview.rs
+++ b/vortex-array/src/arrays/filter/execute/listview.rs
@@ -55,18 +55,7 @@ pub fn filter_listview(array: &ListViewArray, selection_mask: &Arc<MaskValues>) 
     // - Offsets and sizes are derived from existing valid child arrays.
     // - Offsets and sizes have the same length (both filtered by `selection_mask`).
     // - Validity matches the filtered array's nullability.
-    let new_array = unsafe {
-        ListViewArray::new_unchecked(elements.clone(), new_offsets, new_sizes, new_validity)
-    };
-
-    let kept_row_fraction = selection_mask.true_count() as f32 / array.sizes().len() as f32;
-    if kept_row_fraction < listview::compute::REBUILD_DENSITY_THRESHOLD {
-        new_array
-            .rebuild(ListViewRebuildMode::MakeZeroCopyToList)
-            .vortex_expect("ListViewArray rebuild to zero-copy List should always succeed")
-    } else {
-        new_array
-    }
+    unsafe { ListViewArray::new_unchecked(elements.clone(), new_offsets, new_sizes, new_validity) }
 }
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/filter/execute/listview.rs
+++ b/vortex-array/src/arrays/filter/execute/listview.rs
@@ -9,9 +9,7 @@ use vortex_mask::MaskValues;
 
 use crate::arrays::ListViewArray;
 use crate::arrays::filter::execute::filter_validity;
-use crate::arrays::listview;
 use crate::arrays::listview::ListViewArrayExt;
-use crate::arrays::listview::ListViewRebuildMode;
 
 /// [`ListViewArray`] filter implementation.
 ///

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -17,11 +17,11 @@ use vortex_mask::Mask;
 
 use crate::ArrayRef;
 use crate::ArraySlots;
+use crate::ExecutionCtx;
 use crate::LEGACY_SESSION;
 #[expect(deprecated)]
 use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
-use crate::aggregate_fn::fns::sum::sum;
 use crate::array::Array;
 use crate::array::ArrayParts;
 use crate::array::TypedArrayRef;
@@ -33,9 +33,7 @@ use crate::arrays::PrimitiveArray;
 use crate::arrays::bool;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
-use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
-use crate::expr::stats::StatsProvider;
 use crate::match_each_integer_ptype;
 use crate::validity::Validity;
 
@@ -409,52 +407,51 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
     /// Walks every `(offset, size)` pair, canonicalizes both `offsets` and `sizes`,
     /// and allocates a `BitBuffer` of length `elements.len()`, so it is extremely costly.
     ///
-    /// Returns `None` when `elements` is empty.
-    fn compute_referenced_elements_mask(&self) -> Option<Mask> {
+    /// Returns `Ok(None)` when `elements` is empty.
+    fn compute_referenced_elements_mask(
+        &self,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<Mask>> {
         let len = self.elements().len();
         if len == 0 {
-            return None;
+            return Ok(None);
         }
 
-        let offsets_dtype = self.offsets().dtype();
-        let sizes_dtype = self.sizes().dtype();
-
-        #[expect(deprecated)]
-        let offsets_primitive = self.offsets().to_primitive();
-        #[expect(deprecated)]
-        let sizes_primitive = self.sizes().to_primitive();
+        let offsets_primitive = self.offsets().clone().execute::<PrimitiveArray>(ctx)?;
+        let sizes_primitive = self.sizes().clone().execute::<PrimitiveArray>(ctx)?;
 
         let mut buf = BitBufferMut::new_unset(len);
         let offset_len = self.as_ref().len();
 
-        match_each_integer_ptype!(offsets_dtype.as_ptype(), |O| {
-            match_each_integer_ptype!(sizes_dtype.as_ptype(), |S| {
+        match_each_integer_ptype!(offsets_primitive.ptype(), |O| {
+            match_each_integer_ptype!(sizes_primitive.ptype(), |S| {
                 let offsets_slice = offsets_primitive.as_slice::<O>();
                 let sizes_slice = sizes_primitive.as_slice::<S>();
 
-                (0..offset_len).for_each(|i| {
-                    #[allow(clippy::cast_possible_truncation)]
-                    let start = offsets_slice[i] as usize;
-                    #[allow(clippy::cast_possible_truncation)]
-                    let size = sizes_slice[i] as usize;
+                for i in 0..offset_len {
+                    let start =
+                        usize::try_from(offsets_slice[i]).vortex_expect("offset must fit in usize");
+                    let size =
+                        usize::try_from(sizes_slice[i]).vortex_expect("size must fit in usize");
                     buf.fill_range(start, start + size, true);
-                });
+                }
             })
         });
 
-        Some(Mask::from_buffer(buf.freeze()))
+        Ok(Some(Mask::from_buffer(buf.freeze())))
     }
 
     /// Exact fraction of `elements` referenced by some view, in `[0.0, 1.0]`. Extremely costly.
     ///
-    /// Returns `None` when `elements` is empty.
-    fn compute_density(&self) -> Option<f32> {
-        self.compute_referenced_elements_mask()
+    /// Returns `Ok(None)` when `elements` is empty.
+    fn compute_density(&self, ctx: &mut ExecutionCtx) -> VortexResult<Option<f32>> {
+        Ok(self
+            .compute_referenced_elements_mask(ctx)?
             .map(|mask| match mask {
                 Mask::AllTrue(_) => 1.0,
                 Mask::AllFalse(_) => 0.0,
                 Mask::Values(values) => values.true_count() as f32 / self.elements().len() as f32,
-            })
+            }))
     }
 
     /// Upper-bound estimate of [`compute_density`](Self::compute_density) via
@@ -462,8 +459,8 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
     ///
     /// Exact for non-overlapping views, but overcounts when multiple views share the same elements.
     ///
-    /// Returns `Ok(None)` when `elements` is empty
-    fn estimate_density(&self) -> VortexResult<Option<f32>> {
+    /// Returns `Ok(None)` when `elements` is empty.
+    fn estimate_density(&self, ctx: &mut ExecutionCtx) -> VortexResult<Option<f32>> {
         let n_elts = self.elements().len();
         if n_elts == 0 {
             return Ok(None);
@@ -474,17 +471,14 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
             return Ok(Some(0.0));
         }
 
-        // Try to fetch the cached sum stat, otherwise fall back to calculating it on the spot
-        let sizes_sum = if let Some(Precision::Exact(scalar)) = sizes.statistics().get(Stat::Sum)
-            && let Some(sum) = scalar.as_primitive().as_::<u64>()
-        {
-            sum
-        } else {
-            sum(sizes, &mut LEGACY_SESSION.create_execution_ctx())?
-                .as_primitive()
-                .as_::<u64>()
-                .ok_or_else(|| vortex_err!("could not cast sum of sizes to u64"))?
-        };
+        // compute_stat short-circuits on a cached exact Sum and otherwise computes-and-caches.
+        let sizes_sum = sizes
+            .statistics()
+            .compute_stat(Stat::Sum, ctx)?
+            .ok_or_else(|| vortex_err!("Sum stat unavailable for sizes"))?
+            .as_primitive()
+            .as_::<u64>()
+            .ok_or_else(|| vortex_err!("could not cast sum of sizes to u64"))?;
 
         let estimate = (sizes_sum as f32 / n_elts as f32).clamp(0.0, 1.0);
 

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -408,6 +408,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
     /// and allocates a `BitBuffer` of length `elements.len()`, so it is extremely costly.
     ///
     /// Returns `Ok(None)` when `elements` is empty.
+    #[allow(clippy::cognitive_complexity, clippy::unnecessary_fallible_conversions)]
     fn compute_referenced_elements_mask(
         &self,
         ctx: &mut ExecutionCtx,

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -407,16 +407,13 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
     /// Walks every `(offset, size)` pair, canonicalizes both `offsets` and `sizes`,
     /// and allocates a `BitBuffer` of length `elements.len()`, so it is extremely costly.
     ///
-    /// Returns `Ok(None)` when `elements` is empty.
-    #[allow(clippy::cognitive_complexity, clippy::unnecessary_fallible_conversions)]
-    fn compute_referenced_elements_mask(
-        &self,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Mask>> {
+    /// **Preconditions**
+    ///
+    /// Assumes that `self.elements()` is non-empty.
+    #[allow(clippy::cognitive_complexity)]
+    fn compute_referenced_elements_mask(&self, ctx: &mut ExecutionCtx) -> VortexResult<Mask> {
+        debug_assert!(!self.elements().is_empty());
         let len = self.elements().len();
-        if len == 0 {
-            return Ok(None);
-        }
 
         let offsets_primitive = self.offsets().clone().execute::<PrimitiveArray>(ctx)?;
         let sizes_primitive = self.sizes().clone().execute::<PrimitiveArray>(ctx)?;
@@ -430,29 +427,35 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
                 let sizes_slice = sizes_primitive.as_slice::<S>();
 
                 for i in 0..offset_len {
-                    let start =
-                        usize::try_from(offsets_slice[i]).vortex_expect("offset must fit in usize");
-                    let size =
-                        usize::try_from(sizes_slice[i]).vortex_expect("size must fit in usize");
+                    let start: usize = offsets_slice[i].as_();
+                    let size: usize = sizes_slice[i].as_();
                     buf.fill_range(start, start + size, true);
                 }
             })
         });
 
-        Ok(Some(Mask::from_buffer(buf.freeze())))
+        Ok(Mask::from_buffer(buf.freeze()))
     }
 
     /// Exact fraction of `elements` referenced by some view, in `[0.0, 1.0]`. Extremely costly.
     ///
-    /// Returns `Ok(None)` when `elements` is empty.
-    fn compute_density(&self, ctx: &mut ExecutionCtx) -> VortexResult<Option<f32>> {
-        Ok(self
-            .compute_referenced_elements_mask(ctx)?
-            .map(|mask| match mask {
-                Mask::AllTrue(_) => 1.0,
-                Mask::AllFalse(_) => 0.0,
-                Mask::Values(values) => values.true_count() as f32 / self.elements().len() as f32,
-            }))
+    /// Returns `Ok(1.0)` when `elements` is empty.
+    fn compute_density(&self, ctx: &mut ExecutionCtx) -> VortexResult<f32> {
+        if self.elements().is_empty() {
+            return Ok(1.0);
+        }
+
+        if self.sizes().is_empty() {
+            return Ok(0.0);
+        }
+
+        let density = match self.compute_referenced_elements_mask(ctx)? {
+            Mask::AllTrue(_) => 1.0,
+            Mask::AllFalse(_) => 0.0,
+            Mask::Values(values) => values.true_count() as f32 / self.elements().len() as f32,
+        };
+
+        Ok(density)
     }
 
     /// Upper-bound estimate of [`compute_density`](Self::compute_density) via
@@ -460,19 +463,19 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
     ///
     /// Exact for non-overlapping views, but overcounts when multiple views share the same elements.
     ///
-    /// Returns `Ok(None)` when `elements` is empty.
-    fn estimate_density(&self, ctx: &mut ExecutionCtx) -> VortexResult<Option<f32>> {
+    /// Returns `Ok(1.0)` when `elements` is empty.
+    fn estimate_density(&self, ctx: &mut ExecutionCtx) -> VortexResult<f32> {
         let n_elts = self.elements().len();
-        if n_elts == 0 {
-            return Ok(None);
+        if self.elements().is_empty() {
+            return Ok(1.0);
         }
 
         let sizes = self.sizes();
         if sizes.is_empty() {
-            return Ok(Some(0.0));
+            return Ok(0.0);
         }
 
-        // compute_stat short-circuits on a cached exact Sum and otherwise computes-and-caches.
+        // compute_stat short-circuits on a cached exact Sum and otherwise computes
         let sizes_sum = sizes
             .statistics()
             .compute_stat(Stat::Sum, ctx)?
@@ -481,9 +484,11 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
             .as_::<u64>()
             .ok_or_else(|| vortex_err!("could not cast sum of sizes to u64"))?;
 
-        let estimate = (sizes_sum as f32 / n_elts as f32).clamp(0.0, 1.0);
+        let estimate = (sizes_sum as f32 / n_elts as f32).min(1.0);
 
-        Ok(Some(estimate))
+        debug_assert!(estimate >= 0.0);
+
+        Ok(estimate)
     }
 }
 impl<T: TypedArrayRef<ListView>> ListViewArrayExt for T {}

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -466,7 +466,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
     /// Returns `Ok(1.0)` when `elements` is empty.
     fn estimate_density(&self, ctx: &mut ExecutionCtx) -> VortexResult<f32> {
         let n_elts = self.elements().len();
-        if self.elements().is_empty() {
+        if n_elts == 0 {
             return Ok(1.0);
         }
 

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -7,11 +7,13 @@ use std::sync::Arc;
 
 use num_traits::AsPrimitive;
 use smallvec::smallvec;
+use vortex_buffer::BitBufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
+use vortex_mask::Mask;
 
 use crate::ArrayRef;
 use crate::ArraySlots;
@@ -19,6 +21,7 @@ use crate::LEGACY_SESSION;
 #[expect(deprecated)]
 use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
+use crate::aggregate_fn::fns::sum::sum;
 use crate::array::Array;
 use crate::array::ArrayParts;
 use crate::array::TypedArrayRef;
@@ -30,6 +33,9 @@ use crate::arrays::PrimitiveArray;
 use crate::arrays::bool;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
+use crate::expr::stats::Precision;
+use crate::expr::stats::Stat;
+use crate::expr::stats::StatsProvider;
 use crate::match_each_integer_ptype;
 use crate::validity::Validity;
 
@@ -395,6 +401,92 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
         #[expect(deprecated)]
         let sizes_primitive = self.sizes().to_primitive();
         validate_zctl(self.elements(), offsets_primitive, sizes_primitive).is_ok()
+    }
+
+    /// Returns a [`Mask`] of length `elements.len()` where each bit is set iff that
+    /// position in `elements` is referenced by at least one view.
+    ///
+    /// Walks every `(offset, size)` pair, canonicalizes both `offsets` and `sizes`,
+    /// and allocates a `BitBuffer` of length `elements.len()`, so it is extremely costly.
+    ///
+    /// Returns `None` when `elements` is empty.
+    fn compute_referenced_elements_mask(&self) -> Option<Mask> {
+        let len = self.elements().len();
+        if len == 0 {
+            return None;
+        }
+
+        let offsets_dtype = self.offsets().dtype();
+        let sizes_dtype = self.sizes().dtype();
+
+        #[expect(deprecated)]
+        let offsets_primitive = self.offsets().to_primitive();
+        #[expect(deprecated)]
+        let sizes_primitive = self.sizes().to_primitive();
+
+        let mut buf = BitBufferMut::new_unset(len);
+        let offset_len = self.as_ref().len();
+
+        match_each_integer_ptype!(offsets_dtype.as_ptype(), |O| {
+            match_each_integer_ptype!(sizes_dtype.as_ptype(), |S| {
+                let offsets_slice = offsets_primitive.as_slice::<O>();
+                let sizes_slice = sizes_primitive.as_slice::<S>();
+
+                (0..offset_len).for_each(|i| {
+                    let start = offsets_slice[i] as usize;
+                    let size = sizes_slice[i] as usize;
+                    buf.fill_range(start, start + size, true);
+                });
+            })
+        });
+
+        Some(Mask::from_buffer(buf.freeze()))
+    }
+
+    /// Exact fraction of `elements` referenced by some view, in `[0.0, 1.0]`. Extremely costly.
+    ///
+    /// Returns `None` when `elements` is empty.
+    fn compute_density(&self) -> Option<f32> {
+        self.compute_referenced_elements_mask()
+            .map(|mask| match mask {
+                Mask::AllTrue(_) => 1.0,
+                Mask::AllFalse(_) => 0.0,
+                Mask::Values(values) => values.true_count() as f32 / self.elements().len() as f32,
+            })
+    }
+
+    /// Upper-bound estimate of [`compute_density`](Self::compute_density) via
+    /// `sum(sizes) / elements.len()`, clamped to `[0.0, 1.0]`.
+    ///
+    /// Exact for non-overlapping views, but overcounts when multiple views share the same elements.
+    ///
+    /// Returns `Ok(None)` when `elements` is empty
+    fn estimate_density(&self) -> VortexResult<Option<f32>> {
+        let n_elts = self.elements().len();
+        if n_elts == 0 {
+            return Ok(None);
+        }
+
+        let sizes = self.sizes();
+        if sizes.is_empty() {
+            return Ok(Some(0.0));
+        }
+
+        // Try to fetch the cached sum stat, otherwise fall back to calculating it on the spot
+        let sizes_sum = if let Some(Precision::Exact(scalar)) = sizes.statistics().get(Stat::Sum)
+            && let Some(sum) = scalar.as_primitive().as_::<u64>()
+        {
+            sum
+        } else {
+            sum(sizes, &mut LEGACY_SESSION.create_execution_ctx())?
+                .as_primitive()
+                .as_::<u64>()
+                .unwrap()
+        };
+
+        let estimate = (sizes_sum as f32 / n_elts as f32).clamp(0.0, 1.0);
+
+        Ok(Some(estimate))
     }
 }
 impl<T: TypedArrayRef<ListView>> ListViewArrayExt for T {}

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -484,6 +484,8 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
             .as_::<u64>()
             .ok_or_else(|| vortex_err!("could not cast sum of sizes to u64"))?;
 
+        // if the same elements are referenced more than once the estimate may be
+        // greater than 1.0, so clamp
         let estimate = (sizes_sum as f32 / n_elts as f32).min(1.0);
 
         debug_assert!(estimate >= 0.0);

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -315,9 +315,9 @@ impl Default for ListViewData {
     }
 }
 
-/// Walks parallel `(offset, size)` slices and marks every referenced position in `buf`.
+/// Walks parallel `(offset, size)` slices and sets each range `[offset, offset + size]` in `buf`.
 ///
-/// **Precondition**
+/// **Preconditions**
 ///
 /// `offsets` and `sizes` must be the same length (which is always the case in valid `ListViewArray`s).
 fn fill_referenced_mask<O: IntegerPType, S: IntegerPType>(
@@ -460,7 +460,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
 
     /// Exact fraction of `elements` referenced by some view, in `[0.0, 1.0]`. Extremely costly.
     ///
-    /// Returns `Ok(1.0)` when `elements` is empty.
+    /// Returns `Ok(1.0)` when `elements` is empty instead of dividing by 0.
     fn compute_density(&self, ctx: &mut ExecutionCtx) -> VortexResult<f32> {
         if self.elements().is_empty() {
             return Ok(1.0);
@@ -484,7 +484,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
     ///
     /// Exact for non-overlapping views, but overcounts when multiple views share the same elements.
     ///
-    /// Returns `Ok(1.0)` when `elements` is empty.
+    /// Returns `Ok(1.0)` when `elements` is empty instead of dividing by 0.
     fn upper_bound_density(&self, ctx: &mut ExecutionCtx) -> VortexResult<f32> {
         let n_elts = self.elements().len();
         if n_elts == 0 {

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -483,7 +483,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
             sum(sizes, &mut LEGACY_SESSION.create_execution_ctx())?
                 .as_primitive()
                 .as_::<u64>()
-                .expect("sum should cast to u64")
+                .ok_or_else(|| vortex_err!("could not cast sum of sizes to u64"))?
         };
 
         let estimate = (sizes_sum as f32 / n_elts as f32).clamp(0.0, 1.0);

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -315,6 +315,31 @@ impl Default for ListViewData {
     }
 }
 
+/// Walks parallel `(offset, size)` slices and marks every referenced position in `buf`.
+///
+/// **Precondition**
+///
+/// `offsets` and `sizes` must be the same length (which is always the case in valid `ListViewArray`s).
+fn fill_referenced_mask<O: IntegerPType, S: IntegerPType>(
+    buf: &mut BitBufferMut,
+    offsets: &[O],
+    sizes: &[S],
+) {
+    let len = offsets.len();
+
+    assert_eq!(
+        len,
+        sizes.len(),
+        "offsets and sizes must be the same length"
+    );
+
+    for i in 0..len {
+        let start: usize = offsets[i].as_();
+        let size: usize = sizes[i].as_();
+        buf.fill_range(start, start + size, true);
+    }
+}
+
 pub trait ListViewArrayExt: TypedArrayRef<ListView> {
     fn nullability(&self) -> crate::dtype::Nullability {
         match self.as_ref().dtype() {
@@ -402,35 +427,31 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
     }
 
     /// Returns a [`Mask`] of length `elements.len()` where each bit is set iff that
-    /// position in `elements` is referenced by at least one view.
+    /// position in `elements` is referenced by at least one view. Caller must ensure `elements`
+    /// is non-empty.
     ///
     /// Walks every `(offset, size)` pair, canonicalizes both `offsets` and `sizes`,
     /// and allocates a `BitBuffer` of length `elements.len()`, so it is extremely costly.
     ///
     /// **Preconditions**
     ///
-    /// Assumes that `self.elements()` is non-empty.
-    #[allow(clippy::cognitive_complexity)]
+    /// `self.elements()` must be non-empty.
     fn compute_referenced_elements_mask(&self, ctx: &mut ExecutionCtx) -> VortexResult<Mask> {
-        debug_assert!(!self.elements().is_empty());
+        assert!(!self.elements().is_empty());
         let len = self.elements().len();
 
         let offsets_primitive = self.offsets().clone().execute::<PrimitiveArray>(ctx)?;
         let sizes_primitive = self.sizes().clone().execute::<PrimitiveArray>(ctx)?;
 
         let mut buf = BitBufferMut::new_unset(len);
-        let offset_len = self.as_ref().len();
 
         match_each_integer_ptype!(offsets_primitive.ptype(), |O| {
             match_each_integer_ptype!(sizes_primitive.ptype(), |S| {
-                let offsets_slice = offsets_primitive.as_slice::<O>();
-                let sizes_slice = sizes_primitive.as_slice::<S>();
-
-                for i in 0..offset_len {
-                    let start: usize = offsets_slice[i].as_();
-                    let size: usize = sizes_slice[i].as_();
-                    buf.fill_range(start, start + size, true);
-                }
+                fill_referenced_mask::<O, S>(
+                    &mut buf,
+                    offsets_primitive.as_slice::<O>(),
+                    sizes_primitive.as_slice::<S>(),
+                );
             })
         });
 
@@ -464,7 +485,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
     /// Exact for non-overlapping views, but overcounts when multiple views share the same elements.
     ///
     /// Returns `Ok(1.0)` when `elements` is empty.
-    fn estimate_density(&self, ctx: &mut ExecutionCtx) -> VortexResult<f32> {
+    fn upper_bound_density(&self, ctx: &mut ExecutionCtx) -> VortexResult<f32> {
         let n_elts = self.elements().len();
         if n_elts == 0 {
             return Ok(1.0);
@@ -479,10 +500,10 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
         let sizes_sum = sizes
             .statistics()
             .compute_stat(Stat::Sum, ctx)?
-            .ok_or_else(|| vortex_err!("Sum stat unavailable for sizes"))?
+            .vortex_expect("sizes array has integer ptype elements")
             .as_primitive()
             .as_::<u64>()
-            .ok_or_else(|| vortex_err!("could not cast sum of sizes to u64"))?;
+            .vortex_expect("integer ptypes can be upcast to u64");
 
         // if the same elements are referenced more than once the estimate may be
         // greater than 1.0, so clamp

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -433,7 +433,9 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
                 let sizes_slice = sizes_primitive.as_slice::<S>();
 
                 (0..offset_len).for_each(|i| {
+                    #[allow(clippy::cast_possible_truncation)]
                     let start = offsets_slice[i] as usize;
+                    #[allow(clippy::cast_possible_truncation)]
                     let size = sizes_slice[i] as usize;
                     buf.fill_range(start, start + size, true);
                 });
@@ -481,7 +483,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
             sum(sizes, &mut LEGACY_SESSION.create_execution_ctx())?
                 .as_primitive()
                 .as_::<u64>()
-                .unwrap()
+                .expect("sum should cast to u64")
         };
 
         let estimate = (sizes_sum as f32 / n_elts as f32).clamp(0.0, 1.0);

--- a/vortex-array/src/arrays/listview/compute/mod.rs
+++ b/vortex-array/src/arrays/listview/compute/mod.rs
@@ -6,15 +6,3 @@ mod mask;
 pub(crate) mod rules;
 mod slice;
 mod take;
-
-/// The threshold below which we rebuild the elements of a listview.
-///
-/// We don't touch `elements` on the metadata-only path since reorganizing it can be expensive.
-/// However, we also don't want to drag around a large amount of garbage data when the selection
-/// is sparse. Below this fraction of list rows retained, the rebuild is worth it.
-/// Rebuilding is needed when exporting the ListView's elements.
-///
-// TODO(connor)[ListView]: Ideally, we would only rebuild after all `take`s and `filter`
-//  compute functions have run, at the "top" of the operator tree. However, we cannot do this
-//  right now, so we will just rebuild every time (similar to [`ListArray`]).
-pub(crate) const REBUILD_DENSITY_THRESHOLD: f32 = 0.1;

--- a/vortex-array/src/arrays/listview/compute/take.rs
+++ b/vortex-array/src/arrays/listview/compute/take.rs
@@ -26,9 +26,6 @@ impl TakeReduce for ListView {
 }
 
 /// Execution-path take for [`ListViewArray`].
-///
-/// This does the same metadata-only take as [`TakeReduce`], but also rebuilds the array if the
-/// resulting array will be less dense than `REBUILD_DENSITY_THRESHOLD`.
 impl TakeExecute for ListView {
     fn take(
         array: ArrayView<'_, ListView>,

--- a/vortex-array/src/arrays/listview/compute/take.rs
+++ b/vortex-array/src/arrays/listview/compute/take.rs
@@ -4,7 +4,6 @@
 use num_traits::Zero;
 use vortex_error::VortexResult;
 
-use super::REBUILD_DENSITY_THRESHOLD;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
@@ -14,7 +13,6 @@ use crate::arrays::ListViewArray;
 use crate::arrays::dict::TakeExecute;
 use crate::arrays::dict::TakeReduce;
 use crate::arrays::listview::ListViewArrayExt;
-use crate::arrays::listview::ListViewRebuildMode;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::Nullability;
 use crate::match_each_integer_ptype;
@@ -23,14 +21,6 @@ use crate::scalar::Scalar;
 /// Metadata-only take for [`ListViewArray`].
 impl TakeReduce for ListView {
     fn take(array: ArrayView<'_, ListView>, indices: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
-        // Approximate element density by the fraction of list rows retained. Assumes roughly
-        // uniform list sizes; good enough to decide whether dragging along the full `elements`
-        // buffer is worth avoiding a rebuild.
-        let kept_row_fraction = indices.len() as f32 / array.sizes().len() as f32;
-        if kept_row_fraction < REBUILD_DENSITY_THRESHOLD {
-            return Ok(None);
-        }
-
         Ok(Some(apply_take(array, indices)?.into_array()))
     }
 }
@@ -45,21 +35,7 @@ impl TakeExecute for ListView {
         indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        let kept_row_fraction = indices.len() as f32 / array.sizes().len() as f32;
-        let taken = apply_take(array, indices)?;
-
-        if kept_row_fraction < REBUILD_DENSITY_THRESHOLD {
-            // TODO(connor)[ListView]: Ideally, we would only rebuild after all `take`s and `filter`
-            // compute functions have run, at the "top" of the operator tree. However, we cannot do
-            // this right now, so we will just rebuild every time (similar to `ListArray`).
-            Ok(Some(
-                taken
-                    .rebuild(ListViewRebuildMode::MakeZeroCopyToList)?
-                    .into_array(),
-            ))
-        } else {
-            Ok(Some(taken.into_array()))
-        }
+        Ok(Some(apply_take(array, indices)?.into_array()))
     }
 }
 

--- a/vortex-array/src/arrays/listview/mod.rs
+++ b/vortex-array/src/arrays/listview/mod.rs
@@ -18,6 +18,7 @@ pub use conversion::list_view_from_list;
 pub use conversion::recursive_list_from_list_view;
 
 mod rebuild;
+pub use rebuild::DEFAULT_REBUILD_DENSITY_THRESHOLD;
 pub use rebuild::ListViewRebuildMode;
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -6,7 +6,6 @@ use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 #[expect(deprecated)]
@@ -31,7 +30,10 @@ use crate::scalar_fn::fns::operators::Operator;
 /// A `ListViewArray` can accumulate unreferenced bytes in its `elements` buffer after
 /// metadata-only operations like `take` and `filter`. When density (referenced fraction of `elements`)
 /// falls below this threshold, the benefits of a rebuild may outweigh its cost.
-const REBUILD_DENSITY_THRESHOLD: f32 = 0.1;
+///
+/// This is a somewhat arbitrary rule-of-thumb and may be suboptimal depending on different use cases and
+/// list element dtypes.
+pub const DEFAULT_REBUILD_DENSITY_THRESHOLD: f32 = 0.1;
 
 /// Modes for rebuilding a [`ListViewArray`].
 pub enum ListViewRebuildMode {
@@ -383,16 +385,6 @@ impl ListViewArray {
             // any leading and trailing garbage data.
             self.rebuild_zero_copy_to_list()
         }
-    }
-
-    pub fn should_rebuild(&self, exact: bool, ctx: &mut ExecutionCtx) -> VortexResult<bool> {
-        let density = if exact {
-            self.compute_density(ctx)?
-        } else {
-            self.estimate_density(ctx)?
-        };
-
-        Ok(density.unwrap_or(1.0) < REBUILD_DENSITY_THRESHOLD)
     }
 }
 

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -389,7 +389,7 @@ impl ListViewArray {
         }
     }
 
-    fn should_rebuild(&self, exact: bool) -> bool {
+    pub fn should_rebuild(&self, exact: bool) -> bool {
         let density = if exact {
             self.compute_density()
         } else {

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -6,6 +6,7 @@ use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 #[expect(deprecated)]
@@ -25,16 +26,11 @@ use crate::match_each_integer_ptype;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::operators::Operator;
 
-/// The threshold below which we rebuild the elements of a listview.
+/// Density threshold to decide whether to rebuild a sparse `ListViewArray`.
 ///
-/// We don't touch `elements` on the metadata-only path since reorganizing it can be expensive.
-/// However, we also don't want to drag around a large amount of garbage data when the selection
-/// is sparse. Below this fraction of list rows retained, the rebuild is worth it.
-/// Rebuilding is needed when exporting the ListView's elements.
-///
-// TODO(connor)[ListView]: Ideally, we would only rebuild after all `take`s and `filter`
-//  compute functions have run, at the "top" of the operator tree. However, we cannot do this
-//  right now, so we will just rebuild every time (similar to [`ListArray`]).
+/// A `ListViewArray` can accumulate unreferenced bytes in its `elements` buffer after
+/// metadata-only operations like `take` and `filter`. When density (referenced fraction of `elements`)
+/// falls below this threshold, the benefits of a rebuild may outweigh its cost.
 const REBUILD_DENSITY_THRESHOLD: f32 = 0.1;
 
 /// Modes for rebuilding a [`ListViewArray`].
@@ -389,14 +385,14 @@ impl ListViewArray {
         }
     }
 
-    pub fn should_rebuild(&self, exact: bool) -> bool {
+    pub fn should_rebuild(&self, exact: bool, ctx: &mut ExecutionCtx) -> VortexResult<bool> {
         let density = if exact {
-            self.compute_density()
+            self.compute_density(ctx)?
         } else {
-            self.estimate_density().ok().flatten()
+            self.estimate_density(ctx)?
         };
 
-        density.unwrap_or(1.0) < REBUILD_DENSITY_THRESHOLD
+        Ok(density.unwrap_or(1.0) < REBUILD_DENSITY_THRESHOLD)
     }
 }
 

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -15,6 +15,7 @@ use crate::aggregate_fn::fns::min_max::min_max;
 use crate::arrays::ConstantArray;
 use crate::arrays::ListViewArray;
 use crate::arrays::listview::ListViewArrayExt;
+use crate::arrays::listview::compute::REBUILD_DENSITY_THRESHOLD;
 use crate::builders::builder_with_capacity;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
@@ -375,6 +376,16 @@ impl ListViewArray {
             // any leading and trailing garbage data.
             self.rebuild_zero_copy_to_list()
         }
+    }
+
+    fn should_rebuild(&self, exact: bool) -> bool {
+        let density = if exact {
+            self.compute_density()
+        } else {
+            self.estimate_density().ok().flatten()
+        };
+
+        density.unwrap_or(1.0) < REBUILD_DENSITY_THRESHOLD
     }
 }
 

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -15,7 +15,6 @@ use crate::aggregate_fn::fns::min_max::min_max;
 use crate::arrays::ConstantArray;
 use crate::arrays::ListViewArray;
 use crate::arrays::listview::ListViewArrayExt;
-use crate::arrays::listview::compute::REBUILD_DENSITY_THRESHOLD;
 use crate::builders::builder_with_capacity;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
@@ -25,6 +24,18 @@ use crate::dtype::PType;
 use crate::match_each_integer_ptype;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::operators::Operator;
+
+/// The threshold below which we rebuild the elements of a listview.
+///
+/// We don't touch `elements` on the metadata-only path since reorganizing it can be expensive.
+/// However, we also don't want to drag around a large amount of garbage data when the selection
+/// is sparse. Below this fraction of list rows retained, the rebuild is worth it.
+/// Rebuilding is needed when exporting the ListView's elements.
+///
+// TODO(connor)[ListView]: Ideally, we would only rebuild after all `take`s and `filter`
+//  compute functions have run, at the "top" of the operator tree. However, we cannot do this
+//  right now, so we will just rebuild every time (similar to [`ListArray`]).
+const REBUILD_DENSITY_THRESHOLD: f32 = 0.1;
 
 /// Modes for rebuilding a [`ListViewArray`].
 pub enum ListViewRebuildMode {

--- a/vortex-array/src/arrays/listview/tests/common.rs
+++ b/vortex-array/src/arrays/listview/tests/common.rs
@@ -22,6 +22,15 @@ pub fn create_basic_listview() -> ListViewArray {
     }
 }
 
+/// Creates a sparse ListView with two overlap regions
+/// `[[0,1,2], [1,2], [18, 19], [19]]` over 20 elements.
+pub fn create_sparse_overlapping_listview() -> ListViewArray {
+    let elements = buffer![0i32..20].into_array();
+    let offsets = buffer![0u32, 1, 18, 19].into_array();
+    let sizes = buffer![3u32, 2, 2, 1].into_array();
+    ListViewArray::new(elements, offsets, sizes, Validity::NonNullable)
+}
+
 /// Creates a nullable ListView: [[10,20], null, [50]]
 pub fn create_nullable_listview() -> ListViewArray {
     let elements = buffer![10i32, 20, 30, 40, 50].into_array();
@@ -39,6 +48,17 @@ pub fn create_empty_lists_listview() -> ListViewArray {
     let elements = buffer![99i32].into_array();
     let offsets = buffer![0u32, 0, 0, 0].into_array();
     let sizes = buffer![0u32, 0, 0, 0].into_array();
+    unsafe {
+        ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
+            .with_zero_copy_to_list(true)
+    }
+}
+
+/// Creates a ListView with empty lists and elements: [[]]
+pub fn create_empty_elements_listview() -> ListViewArray {
+    let elements = PrimitiveArray::from_iter::<[i32; 0]>([]).into_array();
+    let offsets = buffer![0u32; 0].into_array();
+    let sizes = buffer![0u32; 0].into_array();
     unsafe {
         ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
             .with_zero_copy_to_list(true)

--- a/vortex-array/src/arrays/listview/tests/density.rs
+++ b/vortex-array/src/arrays/listview/tests/density.rs
@@ -33,8 +33,8 @@ fn test_execution_ctx() -> ExecutionCtx {
 fn full_density_no_overlap() -> VortexResult<()> {
     let mut ctx = test_execution_ctx();
     let lv = create_basic_listview();
-    let exact = lv.compute_density(&mut ctx)?.expect("non-empty elements");
-    let est = lv.estimate_density(&mut ctx)?.expect("non-empty elements");
+    let exact = lv.compute_density(&mut ctx)?;
+    let est = lv.estimate_density(&mut ctx)?;
 
     assert!((exact - 1.0).abs() < EPS);
     assert!((est - 1.0).abs() < EPS);
@@ -45,8 +45,8 @@ fn full_density_no_overlap() -> VortexResult<()> {
 fn sparse_no_overlap_matches_exact() -> VortexResult<()> {
     let mut ctx = test_execution_ctx();
     let lv = create_large_listview();
-    let exact = lv.compute_density(&mut ctx)?.expect("non-empty");
-    let est = lv.estimate_density(&mut ctx)?.expect("non-empty");
+    let exact = lv.compute_density(&mut ctx)?;
+    let est = lv.estimate_density(&mut ctx)?;
 
     assert!((exact - 0.5).abs() < EPS);
     assert!((est - 0.5).abs() < EPS);
@@ -57,12 +57,8 @@ fn sparse_no_overlap_matches_exact() -> VortexResult<()> {
 fn all_empty_lists_is_zero_density() -> VortexResult<()> {
     let mut ctx = test_execution_ctx();
     let lv = create_empty_lists_listview();
-    let exact = lv
-        .compute_density(&mut ctx)?
-        .expect("elements has length 1");
-    let est = lv
-        .estimate_density(&mut ctx)?
-        .expect("elements has length 1");
+    let exact = lv.compute_density(&mut ctx)?;
+    let est = lv.estimate_density(&mut ctx)?;
 
     assert_eq!(exact, 0.0);
     assert_eq!(est, 0.0);
@@ -73,8 +69,8 @@ fn all_empty_lists_is_zero_density() -> VortexResult<()> {
 fn overlap_full_coverage_clamps_estimate() -> VortexResult<()> {
     let mut ctx = test_execution_ctx();
     let lv = create_overlapping_listview();
-    let exact = lv.compute_density(&mut ctx)?.expect("non-empty");
-    let est = lv.estimate_density(&mut ctx)?.expect("non-empty");
+    let exact = lv.compute_density(&mut ctx)?;
+    let est = lv.estimate_density(&mut ctx)?;
 
     assert!((exact - 1.0).abs() < EPS);
     assert!((est - 1.0).abs() < EPS);
@@ -86,8 +82,8 @@ fn overlap_differential_exact_lower_than_estimate() -> VortexResult<()> {
     let mut ctx = test_execution_ctx();
     let lv = create_sparse_overlapping_listview();
 
-    let exact = lv.compute_density(&mut ctx)?.expect("non-empty");
-    let est = lv.estimate_density(&mut ctx)?.expect("non-empty");
+    let exact = lv.compute_density(&mut ctx)?;
+    let est = lv.estimate_density(&mut ctx)?;
 
     assert!((exact - 0.25).abs() < EPS);
     assert!((est - 0.40).abs() < EPS);
@@ -95,12 +91,15 @@ fn overlap_differential_exact_lower_than_estimate() -> VortexResult<()> {
 }
 
 #[test]
-fn empty_elements_returns_none() -> VortexResult<()> {
+fn empty_elements_returns_zero() -> VortexResult<()> {
     let mut ctx = test_execution_ctx();
     let lv = create_empty_elements_listview();
 
-    assert!(lv.compute_density(&mut ctx)?.is_none());
-    assert!(lv.estimate_density(&mut ctx)?.is_none());
+    let exact = lv.compute_density(&mut ctx)?;
+    let est = lv.estimate_density(&mut ctx)?;
+
+    assert!(exact.abs() < EPS);
+    assert!(est.abs() < EPS);
     Ok(())
 }
 
@@ -114,7 +113,7 @@ fn estimate_uses_cached_sum_stat() -> VortexResult<()> {
         .statistics()
         .set(Stat::Sum, Precision::Exact(ScalarValue::from(5u64)));
 
-    let est = lv.estimate_density(&mut ctx)?.expect("non-empty");
+    let est = lv.estimate_density(&mut ctx)?;
     assert!((est - 0.5).abs() < EPS);
     Ok(())
 }
@@ -123,9 +122,7 @@ fn estimate_uses_cached_sum_stat() -> VortexResult<()> {
 fn referenced_mask_set_bits_match_views() -> VortexResult<()> {
     let mut ctx = test_execution_ctx();
     let lv = create_sparse_overlapping_listview();
-    let mask = lv
-        .compute_referenced_elements_mask(&mut ctx)?
-        .expect("non-empty elements");
+    let mask = lv.compute_referenced_elements_mask(&mut ctx)?;
     let bits = match mask {
         Mask::Values(v) => v,
         _ => panic!("expected Values mask"),

--- a/vortex-array/src/arrays/listview/tests/density.rs
+++ b/vortex-array/src/arrays/listview/tests/density.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Tests for `compute_referenced_elements_mask`, `compute_density`, and
+//! `estimate_density` on `ListViewArray`.
+
+use vortex_buffer::buffer;
+use vortex_error::VortexResult;
+use vortex_mask::Mask;
+
+use super::common::create_basic_listview;
+use super::common::create_empty_lists_listview;
+use super::common::create_large_listview;
+use super::common::create_overlapping_listview;
+use crate::IntoArray;
+use crate::arrays::ListViewArray;
+use crate::arrays::PrimitiveArray;
+use crate::arrays::listview::ListViewArrayExt;
+use crate::expr::stats::Precision;
+use crate::expr::stats::Stat;
+use crate::scalar::ScalarValue;
+use crate::validity::Validity;
+
+const EPS: f32 = 1e-6;
+
+#[test]
+fn full_density_no_overlap() -> VortexResult<()> {
+    let lv = create_basic_listview();
+    let exact = lv.compute_density().expect("non-empty elements");
+    let est = lv.estimate_density()?.expect("non-empty elements");
+
+    assert!((exact - 1.0).abs() < EPS, "exact density {exact}");
+    assert!((est - 1.0).abs() < EPS, "estimate density {est}");
+    Ok(())
+}
+
+#[test]
+fn sparse_no_overlap_matches_exact() -> VortexResult<()> {
+    let lv = create_large_listview();
+    let exact = lv.compute_density().expect("non-empty");
+    let est = lv.estimate_density()?.expect("non-empty");
+
+    assert!((exact - 0.5).abs() < EPS, "exact density {exact}");
+    assert!((est - 0.5).abs() < EPS, "estimate density {est}");
+    Ok(())
+}
+
+#[test]
+fn all_empty_lists_is_zero_density() -> VortexResult<()> {
+    let lv = create_empty_lists_listview();
+    let exact = lv.compute_density().expect("elements has length 1");
+    let est = lv.estimate_density()?.expect("elements has length 1");
+
+    assert_eq!(exact, 0.0);
+    assert_eq!(est, 0.0);
+    Ok(())
+}
+
+#[test]
+fn overlap_full_coverage_clamps_estimate() -> VortexResult<()> {
+    let lv = create_overlapping_listview();
+    let exact = lv.compute_density().expect("non-empty");
+    let est = lv.estimate_density()?.expect("non-empty");
+
+    assert!((exact - 1.0).abs() < EPS, "exact density {exact}");
+    assert!((est - 1.0).abs() < EPS, "estimate density {est}");
+    Ok(())
+}
+
+#[test]
+fn overlap_differential_exact_lower_than_estimate() -> VortexResult<()> {
+    // Two rows both pointing at elements[0..5) over a 20-element buffer.
+    // Unique referenced = 5  → exact = 0.25
+    // sum(sizes) = 10        → estimate = 0.50
+    let elements = PrimitiveArray::from_iter(0i32..20).into_array();
+    let offsets = buffer![0u32, 0].into_array();
+    let sizes = buffer![5u32, 5].into_array();
+    let lv = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)?;
+
+    let exact = lv.compute_density().expect("non-empty");
+    let est = lv.estimate_density()?.expect("non-empty");
+
+    assert!((exact - 0.25).abs() < EPS, "exact density {exact}");
+    assert!((est - 0.50).abs() < EPS, "estimate density {est}");
+    assert!(est > exact, "estimate must overcount overlapping views");
+    Ok(())
+}
+
+#[test]
+fn empty_elements_returns_none() -> VortexResult<()> {
+    let elements = PrimitiveArray::from_iter::<[i32; 0]>([]).into_array();
+    let offsets = buffer![0u32; 0].into_array();
+    let sizes = buffer![0u32; 0].into_array();
+    let lv = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)?;
+
+    assert!(lv.compute_density().is_none());
+    assert!(lv.estimate_density()?.is_none());
+    Ok(())
+}
+
+#[test]
+fn estimate_uses_cached_sum_stat() -> VortexResult<()> {
+    let lv = create_basic_listview();
+    // Pre-populate Stat::Sum with a deliberately-wrong 5 so we can prove
+    // estimate_density reads from the cache instead of computing fresh.
+    lv.sizes()
+        .statistics()
+        .set(Stat::Sum, Precision::Exact(ScalarValue::from(5u64)));
+
+    let est = lv.estimate_density()?.expect("non-empty");
+    assert!(
+        (est - 0.5).abs() < EPS,
+        "estimate {est} should reflect cached Sum=5, not computed Sum=10",
+    );
+    Ok(())
+}
+
+#[test]
+fn referenced_mask_set_bits_match_views() -> VortexResult<()> {
+    // create_large_listview: 10 lists of size 50 at offsets [0,100,200,...,900].
+    // Bits [i*100 .. i*100+50) set, the rest unset.
+    let lv = create_large_listview();
+    let mask = lv
+        .compute_referenced_elements_mask()
+        .expect("non-empty elements");
+    let bits = match mask {
+        Mask::Values(v) => v,
+        other => panic!("expected Values mask for partial coverage, got {other:?}"),
+    };
+
+    assert_eq!(bits.true_count(), 500);
+    // Spot-check the boundaries of the first and last views.
+    let bb = bits.bit_buffer();
+    assert!(bb.value(0));
+    assert!(bb.value(49));
+    assert!(!bb.value(50));
+    assert!(!bb.value(99));
+    assert!(bb.value(100));
+    assert!(bb.value(949));
+    assert!(!bb.value(950));
+    Ok(())
+}

--- a/vortex-array/src/arrays/listview/tests/density.rs
+++ b/vortex-array/src/arrays/listview/tests/density.rs
@@ -91,15 +91,15 @@ fn overlap_differential_exact_lower_than_estimate() -> VortexResult<()> {
 }
 
 #[test]
-fn empty_elements_returns_zero() -> VortexResult<()> {
+fn empty_elements_returns_one() -> VortexResult<()> {
     let mut ctx = test_execution_ctx();
     let lv = create_empty_elements_listview();
 
     let exact = lv.compute_density(&mut ctx)?;
     let est = lv.estimate_density(&mut ctx)?;
 
-    assert!(exact.abs() < EPS);
-    assert!(est.abs() < EPS);
+    assert!((exact - 1.0).abs() < EPS);
+    assert!((est - 1.0).abs() < EPS);
     Ok(())
 }
 

--- a/vortex-array/src/arrays/listview/tests/density.rs
+++ b/vortex-array/src/arrays/listview/tests/density.rs
@@ -34,7 +34,7 @@ fn full_density_no_overlap() -> VortexResult<()> {
     let mut ctx = test_execution_ctx();
     let lv = create_basic_listview();
     let exact = lv.compute_density(&mut ctx)?;
-    let est = lv.estimate_density(&mut ctx)?;
+    let est = lv.upper_bound_density(&mut ctx)?;
 
     assert!((exact - 1.0).abs() < EPS);
     assert!((est - 1.0).abs() < EPS);
@@ -46,7 +46,7 @@ fn sparse_no_overlap_matches_exact() -> VortexResult<()> {
     let mut ctx = test_execution_ctx();
     let lv = create_large_listview();
     let exact = lv.compute_density(&mut ctx)?;
-    let est = lv.estimate_density(&mut ctx)?;
+    let est = lv.upper_bound_density(&mut ctx)?;
 
     assert!((exact - 0.5).abs() < EPS);
     assert!((est - 0.5).abs() < EPS);
@@ -58,7 +58,7 @@ fn all_empty_lists_is_zero_density() -> VortexResult<()> {
     let mut ctx = test_execution_ctx();
     let lv = create_empty_lists_listview();
     let exact = lv.compute_density(&mut ctx)?;
-    let est = lv.estimate_density(&mut ctx)?;
+    let est = lv.upper_bound_density(&mut ctx)?;
 
     assert_eq!(exact, 0.0);
     assert_eq!(est, 0.0);
@@ -70,7 +70,7 @@ fn overlap_full_coverage_clamps_estimate() -> VortexResult<()> {
     let mut ctx = test_execution_ctx();
     let lv = create_overlapping_listview();
     let exact = lv.compute_density(&mut ctx)?;
-    let est = lv.estimate_density(&mut ctx)?;
+    let est = lv.upper_bound_density(&mut ctx)?;
 
     assert!((exact - 1.0).abs() < EPS);
     assert!((est - 1.0).abs() < EPS);
@@ -83,7 +83,7 @@ fn overlap_differential_exact_lower_than_estimate() -> VortexResult<()> {
     let lv = create_sparse_overlapping_listview();
 
     let exact = lv.compute_density(&mut ctx)?;
-    let est = lv.estimate_density(&mut ctx)?;
+    let est = lv.upper_bound_density(&mut ctx)?;
 
     assert!((exact - 0.25).abs() < EPS);
     assert!((est - 0.40).abs() < EPS);
@@ -96,7 +96,7 @@ fn empty_elements_returns_one() -> VortexResult<()> {
     let lv = create_empty_elements_listview();
 
     let exact = lv.compute_density(&mut ctx)?;
-    let est = lv.estimate_density(&mut ctx)?;
+    let est = lv.upper_bound_density(&mut ctx)?;
 
     assert!((exact - 1.0).abs() < EPS);
     assert!((est - 1.0).abs() < EPS);
@@ -113,7 +113,7 @@ fn estimate_uses_cached_sum_stat() -> VortexResult<()> {
         .statistics()
         .set(Stat::Sum, Precision::Exact(ScalarValue::from(5u64)));
 
-    let est = lv.estimate_density(&mut ctx)?;
+    let est = lv.upper_bound_density(&mut ctx)?;
     assert!((est - 0.5).abs() < EPS);
     Ok(())
 }

--- a/vortex-array/src/arrays/listview/tests/density.rs
+++ b/vortex-array/src/arrays/listview/tests/density.rs
@@ -4,7 +4,6 @@
 //! Tests for `compute_referenced_elements_mask`, `compute_density`, and
 //! `estimate_density` on `ListViewArray`.
 
-use vortex_buffer::buffer;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
@@ -12,14 +11,12 @@ use super::common::create_basic_listview;
 use super::common::create_empty_lists_listview;
 use super::common::create_large_listview;
 use super::common::create_overlapping_listview;
-use crate::IntoArray;
-use crate::arrays::ListViewArray;
-use crate::arrays::PrimitiveArray;
+use super::common::create_sparse_overlapping_listview;
 use crate::arrays::listview::ListViewArrayExt;
+use crate::arrays::listview::tests::common::create_empty_elements_listview;
 use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
 use crate::scalar::ScalarValue;
-use crate::validity::Validity;
 
 const EPS: f32 = 1e-6;
 
@@ -29,8 +26,8 @@ fn full_density_no_overlap() -> VortexResult<()> {
     let exact = lv.compute_density().expect("non-empty elements");
     let est = lv.estimate_density()?.expect("non-empty elements");
 
-    assert!((exact - 1.0).abs() < EPS, "exact density {exact}");
-    assert!((est - 1.0).abs() < EPS, "estimate density {est}");
+    assert!((exact - 1.0).abs() < EPS);
+    assert!((est - 1.0).abs() < EPS);
     Ok(())
 }
 
@@ -40,8 +37,8 @@ fn sparse_no_overlap_matches_exact() -> VortexResult<()> {
     let exact = lv.compute_density().expect("non-empty");
     let est = lv.estimate_density()?.expect("non-empty");
 
-    assert!((exact - 0.5).abs() < EPS, "exact density {exact}");
-    assert!((est - 0.5).abs() < EPS, "estimate density {est}");
+    assert!((exact - 0.5).abs() < EPS);
+    assert!((est - 0.5).abs() < EPS);
     Ok(())
 }
 
@@ -62,36 +59,26 @@ fn overlap_full_coverage_clamps_estimate() -> VortexResult<()> {
     let exact = lv.compute_density().expect("non-empty");
     let est = lv.estimate_density()?.expect("non-empty");
 
-    assert!((exact - 1.0).abs() < EPS, "exact density {exact}");
-    assert!((est - 1.0).abs() < EPS, "estimate density {est}");
+    assert!((exact - 1.0).abs() < EPS);
+    assert!((est - 1.0).abs() < EPS);
     Ok(())
 }
 
 #[test]
 fn overlap_differential_exact_lower_than_estimate() -> VortexResult<()> {
-    // Two rows both pointing at elements[0..5) over a 20-element buffer.
-    // Unique referenced = 5  → exact = 0.25
-    // sum(sizes) = 10        → estimate = 0.50
-    let elements = PrimitiveArray::from_iter(0i32..20).into_array();
-    let offsets = buffer![0u32, 0].into_array();
-    let sizes = buffer![5u32, 5].into_array();
-    let lv = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)?;
+    let lv = create_sparse_overlapping_listview();
 
     let exact = lv.compute_density().expect("non-empty");
     let est = lv.estimate_density()?.expect("non-empty");
 
-    assert!((exact - 0.25).abs() < EPS, "exact density {exact}");
-    assert!((est - 0.50).abs() < EPS, "estimate density {est}");
-    assert!(est > exact, "estimate must overcount overlapping views");
+    assert!((exact - 0.25).abs() < EPS);
+    assert!((est - 0.40).abs() < EPS);
     Ok(())
 }
 
 #[test]
 fn empty_elements_returns_none() -> VortexResult<()> {
-    let elements = PrimitiveArray::from_iter::<[i32; 0]>([]).into_array();
-    let offsets = buffer![0u32; 0].into_array();
-    let sizes = buffer![0u32; 0].into_array();
-    let lv = ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)?;
+    let lv = create_empty_elements_listview();
 
     assert!(lv.compute_density().is_none());
     assert!(lv.estimate_density()?.is_none());
@@ -108,35 +95,27 @@ fn estimate_uses_cached_sum_stat() -> VortexResult<()> {
         .set(Stat::Sum, Precision::Exact(ScalarValue::from(5u64)));
 
     let est = lv.estimate_density()?.expect("non-empty");
-    assert!(
-        (est - 0.5).abs() < EPS,
-        "estimate {est} should reflect cached Sum=5, not computed Sum=10",
-    );
+    assert!((est - 0.5).abs() < EPS);
     Ok(())
 }
 
 #[test]
 fn referenced_mask_set_bits_match_views() -> VortexResult<()> {
-    // create_large_listview: 10 lists of size 50 at offsets [0,100,200,...,900].
-    // Bits [i*100 .. i*100+50) set, the rest unset.
-    let lv = create_large_listview();
+    let lv = create_sparse_overlapping_listview();
     let mask = lv
         .compute_referenced_elements_mask()
         .expect("non-empty elements");
     let bits = match mask {
         Mask::Values(v) => v,
-        other => panic!("expected Values mask for partial coverage, got {other:?}"),
+        _ => panic!("expected Values mask"),
     };
 
-    assert_eq!(bits.true_count(), 500);
-    // Spot-check the boundaries of the first and last views.
+    assert_eq!(bits.true_count(), 5);
     let bb = bits.bit_buffer();
-    assert!(bb.value(0));
-    assert!(bb.value(49));
-    assert!(!bb.value(50));
-    assert!(!bb.value(99));
-    assert!(bb.value(100));
-    assert!(bb.value(949));
-    assert!(!bb.value(950));
+    for i in 0..3 {
+        assert!(bb.value(i));
+    }
+    assert!(bb.value(18));
+    assert!(bb.value(19));
     Ok(())
 }

--- a/vortex-array/src/arrays/listview/tests/density.rs
+++ b/vortex-array/src/arrays/listview/tests/density.rs
@@ -6,25 +6,35 @@
 
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
+use vortex_session::VortexSession;
 
 use super::common::create_basic_listview;
 use super::common::create_empty_lists_listview;
 use super::common::create_large_listview;
 use super::common::create_overlapping_listview;
 use super::common::create_sparse_overlapping_listview;
+use crate::ExecutionCtx;
+use crate::VortexSessionExecute;
 use crate::arrays::listview::ListViewArrayExt;
 use crate::arrays::listview::tests::common::create_empty_elements_listview;
 use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
 use crate::scalar::ScalarValue;
+use crate::session::ArraySession;
 
 const EPS: f32 = 1e-6;
 
+fn test_execution_ctx() -> ExecutionCtx {
+    let session = VortexSession::empty().with::<ArraySession>();
+    session.create_execution_ctx()
+}
+
 #[test]
 fn full_density_no_overlap() -> VortexResult<()> {
+    let mut ctx = test_execution_ctx();
     let lv = create_basic_listview();
-    let exact = lv.compute_density().expect("non-empty elements");
-    let est = lv.estimate_density()?.expect("non-empty elements");
+    let exact = lv.compute_density(&mut ctx)?.expect("non-empty elements");
+    let est = lv.estimate_density(&mut ctx)?.expect("non-empty elements");
 
     assert!((exact - 1.0).abs() < EPS);
     assert!((est - 1.0).abs() < EPS);
@@ -33,9 +43,10 @@ fn full_density_no_overlap() -> VortexResult<()> {
 
 #[test]
 fn sparse_no_overlap_matches_exact() -> VortexResult<()> {
+    let mut ctx = test_execution_ctx();
     let lv = create_large_listview();
-    let exact = lv.compute_density().expect("non-empty");
-    let est = lv.estimate_density()?.expect("non-empty");
+    let exact = lv.compute_density(&mut ctx)?.expect("non-empty");
+    let est = lv.estimate_density(&mut ctx)?.expect("non-empty");
 
     assert!((exact - 0.5).abs() < EPS);
     assert!((est - 0.5).abs() < EPS);
@@ -44,9 +55,14 @@ fn sparse_no_overlap_matches_exact() -> VortexResult<()> {
 
 #[test]
 fn all_empty_lists_is_zero_density() -> VortexResult<()> {
+    let mut ctx = test_execution_ctx();
     let lv = create_empty_lists_listview();
-    let exact = lv.compute_density().expect("elements has length 1");
-    let est = lv.estimate_density()?.expect("elements has length 1");
+    let exact = lv
+        .compute_density(&mut ctx)?
+        .expect("elements has length 1");
+    let est = lv
+        .estimate_density(&mut ctx)?
+        .expect("elements has length 1");
 
     assert_eq!(exact, 0.0);
     assert_eq!(est, 0.0);
@@ -55,9 +71,10 @@ fn all_empty_lists_is_zero_density() -> VortexResult<()> {
 
 #[test]
 fn overlap_full_coverage_clamps_estimate() -> VortexResult<()> {
+    let mut ctx = test_execution_ctx();
     let lv = create_overlapping_listview();
-    let exact = lv.compute_density().expect("non-empty");
-    let est = lv.estimate_density()?.expect("non-empty");
+    let exact = lv.compute_density(&mut ctx)?.expect("non-empty");
+    let est = lv.estimate_density(&mut ctx)?.expect("non-empty");
 
     assert!((exact - 1.0).abs() < EPS);
     assert!((est - 1.0).abs() < EPS);
@@ -66,10 +83,11 @@ fn overlap_full_coverage_clamps_estimate() -> VortexResult<()> {
 
 #[test]
 fn overlap_differential_exact_lower_than_estimate() -> VortexResult<()> {
+    let mut ctx = test_execution_ctx();
     let lv = create_sparse_overlapping_listview();
 
-    let exact = lv.compute_density().expect("non-empty");
-    let est = lv.estimate_density()?.expect("non-empty");
+    let exact = lv.compute_density(&mut ctx)?.expect("non-empty");
+    let est = lv.estimate_density(&mut ctx)?.expect("non-empty");
 
     assert!((exact - 0.25).abs() < EPS);
     assert!((est - 0.40).abs() < EPS);
@@ -78,15 +96,17 @@ fn overlap_differential_exact_lower_than_estimate() -> VortexResult<()> {
 
 #[test]
 fn empty_elements_returns_none() -> VortexResult<()> {
+    let mut ctx = test_execution_ctx();
     let lv = create_empty_elements_listview();
 
-    assert!(lv.compute_density().is_none());
-    assert!(lv.estimate_density()?.is_none());
+    assert!(lv.compute_density(&mut ctx)?.is_none());
+    assert!(lv.estimate_density(&mut ctx)?.is_none());
     Ok(())
 }
 
 #[test]
 fn estimate_uses_cached_sum_stat() -> VortexResult<()> {
+    let mut ctx = test_execution_ctx();
     let lv = create_basic_listview();
     // Pre-populate Stat::Sum with a deliberately-wrong 5 so we can prove
     // estimate_density reads from the cache instead of computing fresh.
@@ -94,16 +114,17 @@ fn estimate_uses_cached_sum_stat() -> VortexResult<()> {
         .statistics()
         .set(Stat::Sum, Precision::Exact(ScalarValue::from(5u64)));
 
-    let est = lv.estimate_density()?.expect("non-empty");
+    let est = lv.estimate_density(&mut ctx)?.expect("non-empty");
     assert!((est - 0.5).abs() < EPS);
     Ok(())
 }
 
 #[test]
 fn referenced_mask_set_bits_match_views() -> VortexResult<()> {
+    let mut ctx = test_execution_ctx();
     let lv = create_sparse_overlapping_listview();
     let mask = lv
-        .compute_referenced_elements_mask()
+        .compute_referenced_elements_mask(&mut ctx)?
         .expect("non-empty elements");
     let bits = match mask {
         Mask::Values(v) => v,

--- a/vortex-array/src/arrays/listview/tests/mod.rs
+++ b/vortex-array/src/arrays/listview/tests/mod.rs
@@ -4,6 +4,7 @@
 pub(super) mod common;
 
 mod basic;
+mod density;
 mod filter;
 mod nested;
 mod nullability;

--- a/vortex-array/src/arrow/executor/list_view.rs
+++ b/vortex-array/src/arrow/executor/list_view.rs
@@ -34,7 +34,7 @@ pub(super) fn to_arrow_list_view<O: OffsetSizeTrait + IntegerPType>(
     // If the array is sufficiently sparse, rebuild before handing it to Arrow. Otherwise downstream
     // consumers hold an elements buffer containing unreferenced data in memory indefinitely,
     // and any compute pass over that buffer wastes work on data nothing references.
-    let density = array.estimate_density(ctx)?;
+    let density = array.upper_bound_density(ctx)?;
     let array = if density < DEFAULT_REBUILD_DENSITY_THRESHOLD {
         array.rebuild(ListViewRebuildMode::MakeZeroCopyToList)?
     } else {

--- a/vortex-array/src/arrow/executor/list_view.rs
+++ b/vortex-array/src/arrow/executor/list_view.rs
@@ -13,6 +13,8 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::arrays::ListViewArray;
 use crate::arrays::PrimitiveArray;
+use crate::arrays::listview::DEFAULT_REBUILD_DENSITY_THRESHOLD;
+use crate::arrays::listview::ListViewArrayExt;
 use crate::arrays::listview::ListViewDataParts;
 use crate::arrays::listview::ListViewRebuildMode;
 use crate::arrow::executor::validity::to_arrow_null_buffer;
@@ -29,8 +31,11 @@ pub(super) fn to_arrow_list_view<O: OffsetSizeTrait + IntegerPType>(
 ) -> VortexResult<arrow_array::ArrayRef> {
     let array = array.execute::<ListViewArray>(ctx)?;
 
-    // If array is sparse, rebuild before handing it to Arrow
-    let array = if array.should_rebuild(false, ctx)? {
+    // If the array is sufficiently sparse, rebuild before handing it to Arrow. Otherwise downstream
+    // consumers hold an elements buffer containing unreferenced data in memory indefinitely,
+    // and any compute pass over that buffer wastes work on data nothing references.
+    let density = array.estimate_density(ctx)?;
+    let array = if density < DEFAULT_REBUILD_DENSITY_THRESHOLD {
         array.rebuild(ListViewRebuildMode::MakeZeroCopyToList)?
     } else {
         array

--- a/vortex-array/src/arrow/executor/list_view.rs
+++ b/vortex-array/src/arrow/executor/list_view.rs
@@ -11,10 +11,10 @@ use vortex_error::vortex_ensure;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
-use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::listview::ListViewDataParts;
+use crate::arrays::listview::ListViewRebuildMode;
 use crate::arrow::executor::validity::to_arrow_null_buffer;
 use crate::arrow::session::ArrowSessionExt;
 use crate::builtins::ArrayBuiltins;
@@ -27,15 +27,16 @@ pub(super) fn to_arrow_list_view<O: OffsetSizeTrait + IntegerPType>(
     elements_field: &FieldRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<arrow_array::ArrayRef> {
-    // Check for Vortex ListViewArray and convert directly.
-    let array = match array.try_downcast::<ListView>() {
-        Ok(array) => return list_view_to_list_view::<O>(array, elements_field, ctx),
-        Err(array) => array,
+    let array = array.execute::<ListViewArray>(ctx)?;
+
+    // If array is sparse, rebuild before handing it to Arrow
+    let array = if array.should_rebuild(false, ctx)? {
+        array.rebuild(ListViewRebuildMode::MakeZeroCopyToList)?
+    } else {
+        array
     };
 
-    // Otherwise, we execute to ListViewArray and convert.
-    let list_view_array = array.execute::<ListViewArray>(ctx)?;
-    list_view_to_list_view::<O>(list_view_array, elements_field, ctx)
+    list_view_to_list_view::<O>(array, elements_field, ctx)
 }
 
 fn list_view_to_list_view<O: OffsetSizeTrait + IntegerPType>(

--- a/vortex-array/src/stats/array.rs
+++ b/vortex-array/src/stats/array.rs
@@ -153,6 +153,8 @@ impl StatsSetRef<'_> {
         f(&mut lock.iter())
     }
 
+    /// Returns the value of `stat` by either fetching it from cache if it exists and is [`Precision::Exact`], or falling back to
+    /// computation.
     pub fn compute_stat(&self, stat: Stat, ctx: &mut ExecutionCtx) -> VortexResult<Option<Scalar>> {
         // If it's already computed and exact, we can return it.
         if let Some(Precision::Exact(s)) = self.get(stat) {

--- a/vortex-array/src/stats/array.rs
+++ b/vortex-array/src/stats/array.rs
@@ -154,7 +154,7 @@ impl StatsSetRef<'_> {
     }
 
     /// Returns the value of `stat` by either fetching it from cache if it exists and is [`Precision::Exact`], or falling back to
-    /// computation.
+    /// computation. The underlying compute kernels will cache the computed stat in the latter case.
     pub fn compute_stat(&self, stat: Stat, ctx: &mut ExecutionCtx) -> VortexResult<Option<Scalar>> {
         // If it's already computed and exact, we can return it.
         if let Some(Precision::Exact(s)) = self.get(stat) {

--- a/vortex-duckdb/src/exporter/list_view.rs
+++ b/vortex-duckdb/src/exporter/list_view.rs
@@ -11,6 +11,7 @@ use vortex::array::ExecutionCtx;
 use vortex::array::arrays::ListViewArray;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::listview::ListViewDataParts;
+use vortex::array::arrays::listview::ListViewRebuildMode;
 use vortex::array::match_each_integer_ptype;
 use vortex::array::validity::Validity;
 use vortex::dtype::IntegerPType;
@@ -50,13 +51,20 @@ pub(crate) fn new_exporter(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Box<dyn ColumnExporter>> {
     let len = array.len();
+
+    let compact_array = if array.should_rebuild(false) {
+        array.rebuild(ListViewRebuildMode::MakeZeroCopyToList)?
+    } else {
+        array
+    };
+
     let ListViewDataParts {
         elements_dtype,
         elements,
         offsets,
         sizes,
         validity,
-    } = array.into_data_parts();
+    } = compact_array.into_data_parts();
     // Cache an `elements` vector up front so that future exports can reference it.
     let num_elements = elements.len();
 

--- a/vortex-duckdb/src/exporter/list_view.rs
+++ b/vortex-duckdb/src/exporter/list_view.rs
@@ -52,7 +52,7 @@ pub(crate) fn new_exporter(
 ) -> VortexResult<Box<dyn ColumnExporter>> {
     let len = array.len();
 
-    let compact_array = if array.should_rebuild(false) {
+    let compact_array = if array.should_rebuild(false, ctx)? {
         array.rebuild(ListViewRebuildMode::MakeZeroCopyToList)?
     } else {
         array

--- a/vortex-duckdb/src/exporter/list_view.rs
+++ b/vortex-duckdb/src/exporter/list_view.rs
@@ -10,6 +10,8 @@ use parking_lot::Mutex;
 use vortex::array::ExecutionCtx;
 use vortex::array::arrays::ListViewArray;
 use vortex::array::arrays::PrimitiveArray;
+use vortex::array::arrays::listview::DEFAULT_REBUILD_DENSITY_THRESHOLD;
+use vortex::array::arrays::listview::ListViewArrayExt;
 use vortex::array::arrays::listview::ListViewDataParts;
 use vortex::array::arrays::listview::ListViewRebuildMode;
 use vortex::array::match_each_integer_ptype;
@@ -50,13 +52,17 @@ pub(crate) fn new_exporter(
     cache: &ConversionCache,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Box<dyn ColumnExporter>> {
-    let len = array.len();
-
-    let compact_array = if array.should_rebuild(false, ctx)? {
+    // If the array is sufficiently sparse, rebuild. Otherwise the DuckDB vector will
+    // hold an elements buffer containing unreferenced data in memory indefinitely,
+    // and any compute pass over that buffer wastes work on data nothing references.
+    let density = array.estimate_density(ctx)?;
+    let array = if density < DEFAULT_REBUILD_DENSITY_THRESHOLD {
         array.rebuild(ListViewRebuildMode::MakeZeroCopyToList)?
     } else {
         array
     };
+
+    let len = array.len();
 
     let ListViewDataParts {
         elements_dtype,
@@ -64,7 +70,7 @@ pub(crate) fn new_exporter(
         offsets,
         sizes,
         validity,
-    } = compact_array.into_data_parts();
+    } = array.into_data_parts();
     // Cache an `elements` vector up front so that future exports can reference it.
     let num_elements = elements.len();
 

--- a/vortex-duckdb/src/exporter/list_view.rs
+++ b/vortex-duckdb/src/exporter/list_view.rs
@@ -55,7 +55,7 @@ pub(crate) fn new_exporter(
     // If the array is sufficiently sparse, rebuild. Otherwise the DuckDB vector will
     // hold an elements buffer containing unreferenced data in memory indefinitely,
     // and any compute pass over that buffer wastes work on data nothing references.
-    let density = array.estimate_density(ctx)?;
+    let density = array.upper_bound_density(ctx)?;
     let array = if density < DEFAULT_REBUILD_DENSITY_THRESHOLD {
         array.rebuild(ListViewRebuildMode::MakeZeroCopyToList)?
     } else {


### PR DESCRIPTION
## Summary

Removes implicit rebuilds from `ListViewArray` `take` and `filter` compute kernels, adds density-introspection methods to support deciding when to rebuild explicitly at materialization boundaries, and defers rebuilding until array export to duckdb and arrow.

**Motivation.** The previous code rebuilt the elements buffer eagerly on every `take` or `filter` whose row-fraction dropped below `REBUILD_DENSITY_THRESHOLD`. In an execution tree like `take → take → ...`, an eager mid-pipeline rebuild costs an allocation and a full copy of referenced ranges that the next operator may immediately sparsify away.

The row-fraction heuristic was also inaccurate. It doesn't account for per-row size variance, unreferenced elements, and duplicate references. Instead, `ListViewArray::estimate_density` uses sum of `sizes` instead of row-fraction. This will overestimate density when there are overlapping references, but it is typically preferable to not compact.

**Changes:**

- **Drop implicit rebuild from `TakeReduce::take` and `TakeExecute::take`**
- **Drop implicit rebuild from `filter_listview`**
- **Add methods to calculate reference density**: `compute_referenced_elements_mask`, `compute_density`, and `estimate_density`
- **Estimate density and conditionally rebuild on export boundaries for duckdb and arrow**

## API Changes

Adds `ListViewArray::estimate_density`, `ListViewArray::compute_density`, and `ListViewArray::compute_referenced_elements_mask`.

## Testing

- New `vortex-array/src/arrays/listview/tests/density.rs` 