### PR TITLE
Use Uint8 for GT field in statpopgen instead of UInt64

### DIFF
--- a/vortex-bench/src/statpopgen/schema.rs
+++ b/vortex-bench/src/statpopgen/schema.rs
@@ -34,7 +34,8 @@ pub fn schema_from_vcf_header(header: &Header) -> SchemaRef {
         .into_iter()
         .chain(info_fields)
         .chain([
-            Arc::new(Field::new("GT", list(UInt64), true)),
+            // GT is NULL, 0, 1, or 2
+            Arc::new(Field::new("GT", list(UInt8), true)),
             Arc::new(Field::new("GQ", list(Int32), true)),
             Arc::new(Field::new("DP", list(Int32), true)),
             Arc::new(Field::new("AD", list(list(Int32)), true)),


### PR DESCRIPTION
With current U64 we're mostly measuring Duckdb upcast performance.
list_sum(GT) upcasts GT to u128 which takes most CPU time.
Since GT can fit in U8, use this to measure our performance.
