### PR TITLE
Fix random-access benchmark console display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6789,6 +6789,7 @@ dependencies = [
  "lance-bench",
  "rand 0.10.1",
  "rand_distr 0.6.0",
+ "tabled",
  "tokio",
  "vortex-bench",
 ]

--- a/benchmarks/random-access-bench/Cargo.toml
+++ b/benchmarks/random-access-bench/Cargo.toml
@@ -21,6 +21,7 @@ indicatif = { workspace = true }
 lance-bench = { path = "../lance-bench", optional = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
+tabled = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 vortex-bench = { workspace = true }
 

--- a/benchmarks/random-access-bench/src/main.rs
+++ b/benchmarks/random-access-bench/src/main.rs
@@ -24,7 +24,6 @@ use vortex_bench::datasets::nested_structs::NestedStructsData;
 use vortex_bench::datasets::taxi_data::TaxiData;
 use vortex_bench::display::DisplayFormat;
 use vortex_bench::display::print_measurements_json;
-use vortex_bench::display::render_table;
 use vortex_bench::measurements::TimingMeasurement;
 use vortex_bench::random_access::BenchDataset;
 use vortex_bench::random_access::ParquetRandomAccessor;
@@ -34,13 +33,18 @@ use vortex_bench::setup_logging_and_tracing;
 use vortex_bench::utils::constants::STORAGE_NVME;
 use vortex_bench::v3;
 
+use crate::render::RandomAccessRun;
+use crate::render::render_random_access_table;
+
+mod render;
+
 // ---------------------------------------------------------------------------
 // Access patterns
 // ---------------------------------------------------------------------------
 
 /// Access pattern for random access benchmarks.
-#[derive(Clone, Copy, Debug)]
-enum AccessPattern {
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum AccessPattern {
     /// Multiple clusters of sequential indices scattered across the dataset,
     /// simulating workloads with spatial locality (e.g. scanning nearby records).
     Correlated,
@@ -225,15 +229,17 @@ async fn main() -> Result<()> {
 /// collecting timing for each run. When `reopen` is true, the accessor is
 /// recreated from scratch before each iteration so that file metadata
 /// parsing is included in the timing.
+#[expect(clippy::too_many_arguments)]
 async fn benchmark_random_access(
     dataset: &dyn BenchDataset,
     format: Format,
     measurement_name: &str,
+    pattern: Option<AccessPattern>,
     indices: &[u64],
     time_limit_secs: u64,
     storage: &str,
     reopen: bool,
-) -> Result<TimingMeasurement> {
+) -> Result<RandomAccessRun> {
     let time_limit = Duration::from_secs(time_limit_secs);
     let overall_start = Instant::now();
     let mut runs = Vec::new();
@@ -253,12 +259,29 @@ async fn benchmark_random_access(
         }
     }
 
-    Ok(TimingMeasurement {
+    let timing = TimingMeasurement {
         name: measurement_name.to_string(),
         storage: storage.to_string(),
         target: Target::new(format_to_engine(format), format),
         runs,
+    };
+    Ok(RandomAccessRun {
+        display_name: display_name(dataset.name(), pattern),
+        dataset: dataset.name().to_string(),
+        pattern,
+        reopen,
+        timing,
     })
+}
+
+/// Row label for the table view. Format is implied by the column header, so
+/// it is omitted from the row label even though it stays in the
+/// [`TimingMeasurement::name`] used for JSON back-compat.
+fn display_name(dataset: &str, pattern: Option<AccessPattern>) -> String {
+    match pattern {
+        Some(p) => format!("random-access/{}/{}", dataset, p.name()),
+        None => format!("random-access/{}", dataset),
+    }
 }
 
 /// Build a measurement name for a benchmark run.
@@ -287,19 +310,13 @@ fn v3_random_access_dataset_name(dataset: &str, pattern: Option<AccessPattern>) 
     }
 }
 
-fn push_v3_random_access_record(
-    records: &mut Vec<v3::V3Record>,
-    measurement: &TimingMeasurement,
-    dataset: &str,
-    pattern: Option<AccessPattern>,
-    reopen: bool,
-) {
-    if reopen {
+fn push_v3_random_access_record(records: &mut Vec<v3::V3Record>, run: &RandomAccessRun) {
+    if run.reopen {
         return;
     }
 
-    let dataset = v3_random_access_dataset_name(dataset, pattern);
-    records.push(v3::random_access_record(measurement, &dataset));
+    let dataset = v3_random_access_dataset_name(&run.dataset, run.pattern);
+    records.push(v3::random_access_record(&run.timing, &dataset));
 }
 
 /// Map format to the appropriate engine for random access benchmarks.
@@ -311,13 +328,6 @@ fn format_to_engine(format: Format) -> Engine {
         Format::Lance => Engine::Arrow, // Is this right here?
         _ => Engine::default(),
     }
-}
-
-fn table_targets(formats: &[Format]) -> Vec<Target> {
-    formats
-        .iter()
-        .map(|format| Target::new(format_to_engine(*format), *format))
-        .collect()
 }
 
 /// Open a random accessor for any supported format.
@@ -392,10 +402,11 @@ async fn run_random_access(
         .sum();
     let progress = ProgressBar::new(total_steps as u64);
 
-    let targets = table_targets(&formats);
-    let mut measurements = Vec::new();
+    let mut runs: Vec<RandomAccessRun> = Vec::new();
     let mut v3_records: Vec<v3::V3Record> = Vec::new();
 
+    // Iteration order matters for the table renderer: row order is set by the
+    // first time each `(dataset, pattern)` pair is observed.
     for dataset in datasets {
         for format in &formats {
             if dataset.name() == "taxi" {
@@ -406,10 +417,11 @@ async fn run_random_access(
                     } else {
                         name.clone()
                     };
-                    let measurement = benchmark_random_access(
+                    let run = benchmark_random_access(
                         dataset.as_ref(),
                         *format,
                         &bench_name,
+                        None,
                         &FIXED_TAXI_INDICES,
                         time_limit,
                         STORAGE_NVME,
@@ -417,14 +429,8 @@ async fn run_random_access(
                     )
                     .await?;
 
-                    push_v3_random_access_record(
-                        &mut v3_records,
-                        &measurement,
-                        dataset.name(),
-                        None,
-                        reopen,
-                    );
-                    measurements.push(measurement);
+                    push_v3_random_access_record(&mut v3_records, &run);
+                    runs.push(run);
                     progress.inc(1);
                 }
             }
@@ -438,10 +444,11 @@ async fn run_random_access(
                     } else {
                         name.clone()
                     };
-                    let measurement = benchmark_random_access(
+                    let run = benchmark_random_access(
                         dataset.as_ref(),
                         *format,
                         &bench_name,
+                        Some(*pattern),
                         &indices,
                         time_limit,
                         STORAGE_NVME,
@@ -449,14 +456,8 @@ async fn run_random_access(
                     )
                     .await?;
 
-                    push_v3_random_access_record(
-                        &mut v3_records,
-                        &measurement,
-                        dataset.name(),
-                        Some(*pattern),
-                        reopen,
-                    );
-                    measurements.push(measurement);
+                    push_v3_random_access_record(&mut v3_records, &run);
+                    runs.push(run);
                     progress.inc(1);
                 }
             }
@@ -473,10 +474,11 @@ async fn run_random_access(
 
     match display_format {
         DisplayFormat::Table => {
-            render_table(&mut writer, measurements, &targets)?;
+            render_random_access_table(&mut writer, &runs, &formats, reopen_variants)?;
         }
         DisplayFormat::GhJson => {
-            print_measurements_json(&mut writer, measurements)?;
+            let timings: Vec<TimingMeasurement> = runs.into_iter().map(|r| r.timing).collect();
+            print_measurements_json(&mut writer, timings)?;
         }
     }
 
@@ -500,30 +502,33 @@ mod tests {
         );
     }
 
+    fn fake_run(dataset: &str, pattern: Option<AccessPattern>, reopen: bool) -> RandomAccessRun {
+        RandomAccessRun {
+            timing: TimingMeasurement {
+                name: format!("random-access/{dataset}/parquet-tokio-local-disk"),
+                target: Target::new(Engine::Arrow, Format::Parquet),
+                storage: STORAGE_NVME.to_string(),
+                runs: vec![Duration::from_nanos(10)],
+            },
+            dataset: dataset.to_string(),
+            pattern,
+            reopen,
+            display_name: display_name(dataset, pattern),
+        }
+    }
+
     #[test]
     fn v3_random_access_records_skip_reopen_variants() {
-        let measurement = TimingMeasurement {
-            name: "random-access/taxi/uniform/parquet-tokio-local-disk".to_string(),
-            target: Target::new(Engine::Arrow, Format::Parquet),
-            storage: STORAGE_NVME.to_string(),
-            runs: vec![Duration::from_nanos(10)],
-        };
         let mut records = Vec::new();
 
-        push_v3_random_access_record(&mut records, &measurement, "taxi", None, false);
+        push_v3_random_access_record(&mut records, &fake_run("taxi", None, false));
         push_v3_random_access_record(
             &mut records,
-            &measurement,
-            "taxi",
-            Some(AccessPattern::Uniform),
-            false,
+            &fake_run("taxi", Some(AccessPattern::Uniform), false),
         );
         push_v3_random_access_record(
             &mut records,
-            &measurement,
-            "taxi",
-            Some(AccessPattern::Correlated),
-            true,
+            &fake_run("taxi", Some(AccessPattern::Correlated), true),
         );
 
         assert_eq!(records.len(), 2);
@@ -538,15 +543,15 @@ mod tests {
     }
 
     #[test]
-    fn table_targets_has_one_column_per_format() {
-        let targets = table_targets(&[Format::Parquet, Format::OnDiskVortex]);
-
+    fn display_name_drops_format_extension() {
+        assert_eq!(display_name("taxi", None), "random-access/taxi");
         assert_eq!(
-            targets,
-            vec![
-                Target::new(Engine::Arrow, Format::Parquet),
-                Target::new(Engine::Vortex, Format::OnDiskVortex),
-            ]
+            display_name("taxi", Some(AccessPattern::Uniform)),
+            "random-access/taxi/uniform"
+        );
+        assert_eq!(
+            display_name("feature-vectors", Some(AccessPattern::Correlated)),
+            "random-access/feature-vectors/correlated"
         );
     }
 }

--- a/benchmarks/random-access-bench/src/main.rs
+++ b/benchmarks/random-access-bench/src/main.rs
@@ -313,6 +313,13 @@ fn format_to_engine(format: Format) -> Engine {
     }
 }
 
+fn table_targets(formats: &[Format]) -> Vec<Target> {
+    formats
+        .iter()
+        .map(|format| Target::new(format_to_engine(*format), *format))
+        .collect()
+}
+
 /// Open a random accessor for any supported format.
 ///
 /// For Vortex and Parquet, the path comes from [`BenchDataset::path`].
@@ -385,7 +392,7 @@ async fn run_random_access(
         .sum();
     let progress = ProgressBar::new(total_steps as u64);
 
-    let mut targets = Vec::new();
+    let targets = table_targets(&formats);
     let mut measurements = Vec::new();
     let mut v3_records: Vec<v3::V3Record> = Vec::new();
 
@@ -417,7 +424,6 @@ async fn run_random_access(
                         None,
                         reopen,
                     );
-                    targets.push(measurement.target);
                     measurements.push(measurement);
                     progress.inc(1);
                 }
@@ -450,7 +456,6 @@ async fn run_random_access(
                         Some(*pattern),
                         reopen,
                     );
-                    targets.push(measurement.target);
                     measurements.push(measurement);
                     progress.inc(1);
                 }
@@ -530,5 +535,18 @@ mod tests {
             v3::V3Record::RandomAccessTime(record) => assert_eq!(record.dataset, "taxi/uniform"),
             other => panic!("expected random-access record, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn table_targets_has_one_column_per_format() {
+        let targets = table_targets(&[Format::Parquet, Format::OnDiskVortex]);
+
+        assert_eq!(
+            targets,
+            vec![
+                Target::new(Engine::Arrow, Format::Parquet),
+                Target::new(Engine::Vortex, Format::OnDiskVortex),
+            ]
+        );
     }
 }

--- a/benchmarks/random-access-bench/src/render.rs
+++ b/benchmarks/random-access-bench/src/render.rs
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Custom console-table rendering for random-access benchmark results.
+//!
+//! Random-access has two extra dimensions beyond what the shared
+//! [`vortex_bench::display::render_table`] handles: the access pattern (which
+//! we keep on the row) and the open mode (cached vs reopen), which becomes a
+//! second-level column header inlined into the format label (e.g.
+//! `parquet-cached`, `parquet-reopen`). Rather than push those concerns into
+//! the shared renderer, we keep this layout local.
+//!
+//! Rows are keyed by `(dataset, Option<AccessPattern>)` in the order they are
+//! first observed in `runs`; columns are the cartesian product of `formats`
+//! and `reopen_variants`.
+
+use std::io::Write;
+
+use anyhow::Result;
+use tabled::builder::Builder;
+use tabled::settings::Color;
+use tabled::settings::Style;
+use tabled::settings::themes::Colorization;
+use vortex_bench::Format;
+use vortex_bench::measurements::TimingMeasurement;
+use vortex_bench::utils::aliases::hash_map::HashMap;
+
+use crate::AccessPattern;
+
+/// One row of random-access timing for a `(dataset, pattern)` benchmark and a
+/// specific `(format, reopen)` combination. Carries the same
+/// [`TimingMeasurement`] used for JSON output so the two emitters stay in sync.
+pub struct RandomAccessRun {
+    pub timing: TimingMeasurement,
+    pub dataset: String,
+    pub pattern: Option<AccessPattern>,
+    pub reopen: bool,
+    /// Row label for this run (e.g. `random-access/taxi/uniform`). Format is
+    /// implied by the column header, so it is not part of the label.
+    pub display_name: String,
+}
+
+/// Render a random-access benchmark result table.
+///
+/// Columns are `formats × reopen_variants` with `{format-ext}-{open-mode}`
+/// headers (e.g. `vortex-cached`, `parquet-reopen`). Rows are unique
+/// `(dataset, pattern)` pairs in the order they were observed in `runs`.
+///
+/// The first column (the baseline) is the leftmost format / cached variant;
+/// each non-baseline cell is colored relative to the baseline value in its
+/// row.
+pub fn render_random_access_table<W: Write>(
+    writer: &mut W,
+    runs: &[RandomAccessRun],
+    formats: &[Format],
+    reopen_variants: &[bool],
+) -> Result<()> {
+    // Columns: cartesian product of (format, reopen) in the user-supplied
+    // ordering. Storing the cell key alongside its display label keeps the
+    // lookup loop straightforward.
+    let columns: Vec<(Format, bool, String)> = formats
+        .iter()
+        .flat_map(|format| {
+            reopen_variants
+                .iter()
+                .map(move |&reopen| (*format, reopen, column_label(*format, reopen)))
+        })
+        .collect();
+
+    // Rows: unique (dataset, pattern) keys in insertion order. Insertion
+    // order matches the outer iteration in `run_random_access`, so taxi/legacy
+    // rows appear before pattern rows.
+    let mut rows: Vec<(String, Option<AccessPattern>, String)> = Vec::new();
+    let mut row_index: HashMap<(String, Option<AccessPattern>), usize> = HashMap::new();
+    let mut cells: HashMap<(usize, Format, bool), u128> = HashMap::new();
+
+    for run in runs {
+        let key = (run.dataset.clone(), run.pattern);
+        let idx = match row_index.get(&key) {
+            Some(&idx) => idx,
+            None => {
+                let idx = rows.len();
+                row_index.insert(key.clone(), idx);
+                rows.push((run.dataset.clone(), run.pattern, run.display_name.clone()));
+                idx
+            }
+        };
+        let format = run.timing.target.format;
+        cells.insert(
+            (idx, format, run.reopen),
+            run.timing.median_time().as_micros(),
+        );
+    }
+
+    let mut table_builder = Builder::default();
+
+    // Single header row: `Benchmark | format-mode | format-mode | ...`.
+    let header: Vec<String> = std::iter::once("Benchmark".to_owned())
+        .chain(columns.iter().map(|(_, _, label)| label.clone()))
+        .collect();
+    table_builder.push_record(header);
+
+    // Baseline for each row is the leftmost column. We capture it before
+    // emitting the row so non-baseline cells can be colored relative to it.
+    let baseline_column = columns
+        .first()
+        .map(|(format, reopen, _)| (*format, *reopen));
+
+    let mut colors = Vec::new();
+    for (row_idx, (_, _, label)) in rows.iter().enumerate() {
+        let baseline_value = baseline_column
+            .and_then(|(format, reopen)| cells.get(&(row_idx, format, reopen)).copied());
+
+        let mut record = vec![label.clone()];
+        for (col_idx, (format, reopen, _)) in columns.iter().enumerate() {
+            let value = cells.get(&(row_idx, *format, *reopen)).copied();
+            record.push(match (value, baseline_value) {
+                (Some(v), Some(base)) if base > 0 => {
+                    let ratio = v as f64 / base as f64;
+                    if col_idx > 0 {
+                        colors.push(Colorization::exact(
+                            vec![color(base, v)],
+                            (row_idx + 1, col_idx + 1),
+                        ));
+                    }
+                    format!("{v} μs ({ratio:.2})")
+                }
+                (Some(v), _) => format!("{v} μs"),
+                (None, _) => "-".to_string(),
+            });
+        }
+        table_builder.push_record(record);
+    }
+
+    let mut table = table_builder.build();
+    table.with(Style::modern());
+    for c in colors {
+        table.with(c);
+    }
+
+    writeln!(writer, "{table}")?;
+    Ok(())
+}
+
+/// `{format-ext}-{mode}` (e.g. `vortex-cached`, `parquet-reopen`). Using
+/// `Format::ext()` keeps headers narrow (`vortex` rather than
+/// `vortex-file-compressed`).
+fn column_label(format: Format, reopen: bool) -> String {
+    let mode = if reopen { "reopen" } else { "cached" };
+    format!("{}-{}", format.ext(), mode)
+}
+
+/// Mirror of the coloring used by `vortex_bench::display::render_table`:
+/// green when within 10% of baseline, yellow when within 50%, red beyond.
+fn color(baseline: u128, value: u128) -> Color {
+    if value > baseline + baseline / 2 {
+        Color::BG_RED | Color::FG_BLACK
+    } else if value > baseline + baseline / 10 {
+        Color::BG_YELLOW | Color::FG_BLACK
+    } else {
+        Color::BG_BRIGHT_GREEN | Color::FG_BLACK
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use vortex_bench::Engine;
+    use vortex_bench::Target;
+
+    use super::*;
+
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\u{1b}' {
+                for c in chars.by_ref() {
+                    if c == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    fn run(
+        dataset: &str,
+        pattern: Option<AccessPattern>,
+        format: Format,
+        reopen: bool,
+        micros: u64,
+    ) -> RandomAccessRun {
+        RandomAccessRun {
+            timing: TimingMeasurement {
+                name: format!("random-access/{dataset}/{}-tokio-local-disk", format.ext()),
+                target: Target::new(Engine::Arrow, format),
+                storage: "nvme".to_string(),
+                runs: vec![Duration::from_micros(micros)],
+            },
+            dataset: dataset.to_string(),
+            pattern,
+            reopen,
+            display_name: match pattern {
+                Some(p) => format!("random-access/{dataset}/{}", p.name()),
+                None => format!("random-access/{dataset}"),
+            },
+        }
+    }
+
+    #[test]
+    fn column_label_uses_format_ext_and_mode() {
+        assert_eq!(column_label(Format::Parquet, false), "parquet-cached");
+        assert_eq!(column_label(Format::Parquet, true), "parquet-reopen");
+        assert_eq!(column_label(Format::OnDiskVortex, false), "vortex-cached");
+    }
+
+    #[test]
+    fn render_emits_single_header_row_with_format_mode_columns() -> Result<()> {
+        let runs = vec![
+            run("taxi", None, Format::Parquet, false, 100),
+            run("taxi", None, Format::Parquet, true, 200),
+            run("taxi", None, Format::OnDiskVortex, false, 50),
+            run("taxi", None, Format::OnDiskVortex, true, 110),
+            run(
+                "taxi",
+                Some(AccessPattern::Uniform),
+                Format::Parquet,
+                false,
+                300,
+            ),
+            run(
+                "taxi",
+                Some(AccessPattern::Uniform),
+                Format::Parquet,
+                true,
+                600,
+            ),
+            run(
+                "taxi",
+                Some(AccessPattern::Uniform),
+                Format::OnDiskVortex,
+                false,
+                150,
+            ),
+            run(
+                "taxi",
+                Some(AccessPattern::Uniform),
+                Format::OnDiskVortex,
+                true,
+                330,
+            ),
+        ];
+
+        let mut buf = Vec::new();
+        render_random_access_table(
+            &mut buf,
+            &runs,
+            &[Format::Parquet, Format::OnDiskVortex],
+            &[false, true],
+        )?;
+        let rendered = strip_ansi(&String::from_utf8(buf)?);
+
+        assert!(
+            rendered.contains("parquet-cached") && rendered.contains("parquet-reopen"),
+            "expected format-mode column headers, got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("vortex-cached") && rendered.contains("vortex-reopen"),
+            "expected ext-based column headers, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("arrow"),
+            "expected no engine header row, got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("random-access/taxi")
+                && rendered.contains("random-access/taxi/uniform"),
+            "expected display-name row labels, got:\n{rendered}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn render_renders_dash_for_missing_cells() -> Result<()> {
+        let runs = vec![
+            run("taxi", None, Format::Parquet, false, 100),
+            // No reopen variant supplied for taxi, but the column is still
+            // listed in `reopen_variants` — that cell should render as `-`.
+        ];
+
+        let mut buf = Vec::new();
+        render_random_access_table(&mut buf, &runs, &[Format::Parquet], &[false, true])?;
+        let rendered = strip_ansi(&String::from_utf8(buf)?);
+
+        assert!(
+            rendered.contains('-'),
+            "expected `-` placeholder for missing cell, got:\n{rendered}"
+        );
+        Ok(())
+    }
+}

--- a/vortex-bench/src/utils/mod.rs
+++ b/vortex-bench/src/utils/mod.rs
@@ -8,6 +8,11 @@ pub mod logging;
 use std::process::Command;
 use std::sync::LazyLock;
 
+/// Re-export of `vortex::utils::aliases` so downstream benchmark crates can
+/// reach the standard `HashMap`/`HashSet` aliases without pulling in `vortex`
+/// directly.
+pub use vortex::utils::aliases;
+
 pub static GIT_COMMIT_ID: LazyLock<String> = LazyLock::new(|| {
     String::from_utf8(
         Command::new("git")


### PR DESCRIPTION
Random access benchmark has more variants than regular ones.
The new state is 
```
  ┌────────────────────────────┬────────────────┬────────────────┬───────────────┬───────────────┐
  │ Benchmark                  │ parquet-cached │ parquet-reopen │ vortex-cached │ vortex-reopen │
  ├────────────────────────────┼────────────────┼────────────────┼───────────────┼───────────────┤
  │ random-access/taxi         │ 100 μs (1.00)  │ 200 μs (2.00)  │ 50 μs (0.50)  │ 110 μs (1.10) │
  │ random-access/taxi/uniform │ 300 μs (1.00)  │ 600 μs (2.00)  │ 150 μs (0.50) │ 330 μs (1.10) │
  └────────────────────────────┴────────────────┴────────────────┴───────────────┴───────────────┘
```