### PR TITLE
perf[array]: cast to prim faster

### DIFF
--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -103,6 +103,62 @@ impl CastKernel for Primitive {
     }
 }
 
+/// Cast values from `F` to `T`. For infallible casts this is a pure pass; for fallible casts
+/// each valid value goes through a checked `NumCast::from` and the kernel bails if any of them
+/// overflow `T`. Invalid positions use the wrapping `as` cast since their values are masked out.
+fn cast_values<F, T>(
+    array: ArrayView<'_, Primitive>,
+    new_validity: Validity,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef>
+where
+    F: NativePType + AsPrimitive<T>,
+    T: NativePType,
+{
+    let values = array.as_slice::<F>();
+
+    // Fast path: statically infallible, or cached min/max prove every valid value fits in `T`.
+    // The cached check never triggers a stats computation — if the bounds aren't already known
+    // we fall through to the per-lane loop below.
+    if values_always_fit(F::PTYPE, T::PTYPE) || values_fit_in(array, T::PTYPE, ctx, false) {
+        return Ok(PrimitiveArray::new(cast::<F, T>(values), new_validity).into_array());
+    }
+
+    // Fallible: invalid lanes are pre-multiplied to zero so the checked cast always succeeds for
+    // them; valid lanes go through `NumCast::from` and the whole cast bails on the first overflow.
+    let mask = array.validity()?.execute_mask(array.len(), ctx)?;
+    let overflow = || {
+        vortex_err!(
+            Compute: "Cannot cast {} to {} — value exceeds target range",
+            F::PTYPE, T::PTYPE,
+        )
+    };
+    let buffer: Buffer<T> = match &mask {
+        Mask::AllTrue(_) => BufferMut::try_from_trusted_len_iter(
+            values
+                .iter()
+                .map(|&v| <T as NumCast>::from(v).ok_or_else(overflow)),
+        )?
+        .freeze(),
+        Mask::AllFalse(_) => BufferMut::<T>::zeroed(values.len()).freeze(),
+        Mask::Values(m) => BufferMut::try_from_trusted_len_iter(
+            values.iter().zip(m.bit_buffer().iter()).map(|(&v, valid)| {
+                let factor = if valid { F::one() } else { F::zero() };
+                <T as NumCast>::from(v * factor).ok_or_else(overflow)
+            }),
+        )?
+        .freeze(),
+    };
+
+    Ok(PrimitiveArray::new(buffer, new_validity).into_array())
+}
+
+/// Out-of-range values at invalid positions are truncated/wrapped by `as`, which is fine because
+/// they are masked out by validity.
+fn cast<F: NativePType + AsPrimitive<T>, T: NativePType>(array: &[F]) -> Buffer<T> {
+    BufferMut::from_trusted_len_iter(array.iter().map(|&src| src.as_())).freeze()
+}
+
 fn reinterpret(
     array: ArrayView<'_, Primitive>,
     new_ptype: PType,
@@ -168,62 +224,6 @@ fn cached_values_fit_in(array: ArrayView<'_, Primitive>, target_dtype: &DType) -
     let min = stats.get(Stat::Min).and_then(Precision::as_exact)?;
     let max = stats.get(Stat::Max).and_then(Precision::as_exact)?;
     Some(min.cast(target_dtype).is_ok() && max.cast(target_dtype).is_ok())
-}
-
-/// Cast values from `F` to `T`. For infallible casts this is a pure pass; for fallible casts
-/// each valid value goes through a checked `NumCast::from` and the kernel bails if any of them
-/// overflow `T`. Invalid positions use the wrapping `as` cast since their values are masked out.
-fn cast_values<F, T>(
-    array: ArrayView<'_, Primitive>,
-    new_validity: Validity,
-    ctx: &mut ExecutionCtx,
-) -> VortexResult<ArrayRef>
-where
-    F: NativePType + AsPrimitive<T>,
-    T: NativePType,
-{
-    let values = array.as_slice::<F>();
-
-    // Fast path: statically infallible, or cached min/max prove every valid value fits in `T`.
-    // The cached check never triggers a stats computation — if the bounds aren't already known
-    // we fall through to the per-lane loop below.
-    if values_always_fit(F::PTYPE, T::PTYPE) || values_fit_in(array, T::PTYPE, ctx, false) {
-        return Ok(PrimitiveArray::new(cast::<F, T>(values), new_validity).into_array());
-    }
-
-    // Fallible: invalid lanes are pre-multiplied to zero so the checked cast always succeeds for
-    // them; valid lanes go through `NumCast::from` and the whole cast bails on the first overflow.
-    let mask = array.validity()?.execute_mask(array.len(), ctx)?;
-    let overflow = || {
-        vortex_err!(
-            Compute: "Cannot cast {} to {} — value exceeds target range",
-            F::PTYPE, T::PTYPE,
-        )
-    };
-    let buffer: Buffer<T> = match &mask {
-        Mask::AllTrue(_) => BufferMut::try_from_trusted_len_iter(
-            values
-                .iter()
-                .map(|&v| <T as NumCast>::from(v).ok_or_else(overflow)),
-        )?
-        .freeze(),
-        Mask::AllFalse(_) => BufferMut::<T>::zeroed(values.len()).freeze(),
-        Mask::Values(m) => BufferMut::try_from_trusted_len_iter(
-            values.iter().zip(m.bit_buffer().iter()).map(|(&v, valid)| {
-                let factor = if valid { F::one() } else { F::zero() };
-                <T as NumCast>::from(v * factor).ok_or_else(overflow)
-            }),
-        )?
-        .freeze(),
-    };
-
-    Ok(PrimitiveArray::new(buffer, new_validity).into_array())
-}
-
-/// Out-of-range values at invalid positions are truncated/wrapped by `as`, which is fine because
-/// they are masked out by validity.
-fn cast<F: NativePType + AsPrimitive<T>, T: NativePType>(array: &[F]) -> Buffer<T> {
-    BufferMut::from_trusted_len_iter(array.iter().map(|&src| src.as_())).freeze()
 }
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -2,10 +2,12 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use num_traits::AsPrimitive;
+use num_traits::NumCast;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
 use vortex_mask::Mask;
 
 use crate::ArrayRef;
@@ -24,8 +26,6 @@ use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
 use crate::expr::stats::StatsProvider;
 use crate::match_each_native_ptype;
-use crate::scalar::PValue;
-use crate::scalar::ScalarValue;
 use crate::scalar_fn::fns::cast::CastKernel;
 use crate::scalar_fn::fns::cast::CastReduce;
 use crate::validity::Validity;
@@ -76,19 +76,15 @@ impl CastKernel for Primitive {
             .validity()?
             .cast_nullability(new_nullability, array.len(), ctx)?;
 
-        // Same ptype: zero-copy, just update validity.
-        if src_ptype == new_ptype {
-            return Ok(Some(reinterpret(array, src_ptype, new_validity)));
-        }
-
-        let same_width = src_ptype.byte_width() == new_ptype.byte_width();
-        let same_int_rep = same_width && src_ptype.is_int() && new_ptype.is_int();
-        let infallible = values_always_fit(src_ptype, new_ptype);
-
-        // Same-width int↔int: bit patterns are identical under 2's complement, so once we have
-        // verified the values fit we can just reinterpret the buffer with no per-element work.
-        if same_int_rep {
-            if !infallible && !values_fit_in(array, new_ptype, ctx) {
+        // Same bit representation: either the same ptype (only the nullability changed) or two
+        // same-width integers (identical layout under 2's complement). The only non-trivial case
+        // is the sign change between same-width ints, which still needs a value-range check.
+        let same_rep = src_ptype == new_ptype
+            || (src_ptype.is_int()
+                && new_ptype.is_int()
+                && src_ptype.byte_width() == new_ptype.byte_width());
+        if same_rep {
+            if !values_fit_in(array, new_ptype, ctx, true) {
                 vortex_bail!(
                     Compute: "Cannot cast {} to {} — values exceed target range",
                     src_ptype, new_ptype,
@@ -97,21 +93,11 @@ impl CastKernel for Primitive {
             return Ok(Some(reinterpret(array, new_ptype, new_validity)));
         }
 
-        // Infallible casts (e.g. int → wider int, int → float): no min/max needed. Same-width
-        // casts try to reuse the source allocation when uniquely owned; otherwise allocate.
-        if infallible {
-            return Ok(Some(match_each_native_ptype!(new_ptype, |T| {
-                match_each_native_ptype!(src_ptype, |F| {
-                    PrimitiveArray::new(cast_or_reuse::<F, T>(array), new_validity).into_array()
-                })
-            })));
-        }
-
-        // Fallible cast (e.g. float → int, narrowing int, narrowing float): cast and min/max
-        // validation happen in a single pass over the source values.
+        // Different bit rep: cast each element. `cast_values` picks a pure or checked loop based
+        // on whether the conversion is statically infallible.
         Ok(Some(match_each_native_ptype!(new_ptype, |T| {
             match_each_native_ptype!(src_ptype, |F| {
-                cast_with_check::<F, T>(array, new_validity, ctx)?
+                cast_values::<F, T>(array, new_validity, ctx)?
             })
         })))
     }
@@ -134,8 +120,9 @@ fn reinterpret(
     .into_array()
 }
 
-/// Whether every valid value of `src` is guaranteed representable in `target` without inspecting
-/// the values themselves.
+/// Returns `true` if every value of `src` is guaranteed representable in `target` without
+/// overflow. Precision may be lost (e.g. large integers cast to `f32`), but the cast can never
+/// produce an out-of-range result.
 fn values_always_fit(src: PType, target: PType) -> bool {
     if src == target {
         return true;
@@ -150,40 +137,43 @@ fn values_always_fit(src: PType, target: PType) -> bool {
     src.is_int() && matches!(target, PType::F32 | PType::F64)
 }
 
-/// Returns `true` if all valid values in `array` are representable as `target_ptype`. Uses cached
-/// min/max statistics when available and otherwise computes them with a single pass.
+/// Returns `true` if all valid values in `array` are representable as `target_ptype`.
+///
+/// Cached min/max statistics are consulted first. If either bound is missing, the function either
+/// computes them with a single pass (when `compute` is `true`) or returns `false` so the caller
+/// can fall back to a slower path (when `compute` is `false`).
 fn values_fit_in(
     array: ArrayView<'_, Primitive>,
     target_ptype: PType,
     ctx: &mut ExecutionCtx,
+    compute: bool,
 ) -> bool {
     let target_dtype = DType::Primitive(target_ptype, Nullability::NonNullable);
+    if let Some(fits) = cached_values_fit_in(array, &target_dtype) {
+        return fits;
+    }
+    if !compute {
+        return false;
+    }
     aggregate_fn::fns::min_max::min_max(array.array(), ctx)
         .ok()
         .flatten()
         .is_none_or(|mm| mm.min.cast(&target_dtype).is_ok() && mm.max.cast(&target_dtype).is_ok())
 }
 
-/// Cast values from `F` to `T`, reusing the source buffer in-place when the widths match and the
-/// underlying allocation is uniquely owned. Falls back to a fresh allocation otherwise.
-fn cast_or_reuse<F, T>(array: ArrayView<'_, Primitive>) -> Buffer<T>
-where
-    F: NativePType + AsPrimitive<T>,
-    T: NativePType,
-{
-    if size_of::<F>() == size_of::<T>() {
-        let source = Buffer::<F>::from_byte_buffer(array.buffer_handle().to_host_sync());
-        source
-            .map_each_in_place(<F as AsPrimitive<T>>::as_)
-            .freeze()
-    } else {
-        cast::<F, T>(array.as_slice())
-    }
+/// Cached-only check: returns `Some(fits)` if both `Min` and `Max` are present as `Exact` in the
+/// stats cache, otherwise `None`.
+fn cached_values_fit_in(array: ArrayView<'_, Primitive>, target_dtype: &DType) -> Option<bool> {
+    let stats = array.array().statistics();
+    let min = stats.get(Stat::Min).and_then(Precision::as_exact)?;
+    let max = stats.get(Stat::Max).and_then(Precision::as_exact)?;
+    Some(min.cast(target_dtype).is_ok() && max.cast(target_dtype).is_ok())
 }
 
-/// Fallible cast: writes target values to a new buffer and tracks the source min/max in the same
-/// pass, then bails if the min/max indicate values overflow the target type.
-fn cast_with_check<F, T>(
+/// Cast values from `F` to `T`. For infallible casts this is a pure pass; for fallible casts
+/// each valid value goes through a checked `NumCast::from` and the kernel bails if any of them
+/// overflow `T`. Invalid positions use the wrapping `as` cast since their values are masked out.
+fn cast_values<F, T>(
     array: ArrayView<'_, Primitive>,
     new_validity: Validity,
     ctx: &mut ExecutionCtx,
@@ -191,88 +181,43 @@ fn cast_with_check<F, T>(
 where
     F: NativePType + AsPrimitive<T>,
     T: NativePType,
-    PValue: From<F>,
 {
-    let target_dtype = DType::Primitive(T::PTYPE, Nullability::NonNullable);
+    let values = array.as_slice::<F>();
 
-    // If min/max stats are already cached we can decide the fit without revisiting the values.
-    if let Some(fits) = cached_min_max_fits(array, &target_dtype) {
-        if !fits {
-            vortex_bail!(
-                Compute: "Cannot cast {} to {} — values exceed target range",
-                F::PTYPE, T::PTYPE,
-            );
-        }
-        return Ok(PrimitiveArray::new(cast_or_reuse::<F, T>(array), new_validity).into_array());
+    // Fast path: statically infallible, or cached min/max prove every valid value fits in `T`.
+    // The cached check never triggers a stats computation — if the bounds aren't already known
+    // we fall through to the per-lane loop below.
+    if values_always_fit(F::PTYPE, T::PTYPE) || values_fit_in(array, T::PTYPE, ctx, false) {
+        return Ok(PrimitiveArray::new(cast::<F, T>(values), new_validity).into_array());
     }
 
-    let values = array.as_slice::<F>();
+    // Fallible: invalid lanes are pre-multiplied to zero so the checked cast always succeeds for
+    // them; valid lanes go through `NumCast::from` and the whole cast bails on the first overflow.
     let mask = array.validity()?.execute_mask(array.len(), ctx)?;
-    let mut min_max: Option<(F, F)> = None;
-
-    let buffer: Buffer<T> = match &mask {
-        Mask::AllTrue(_) => BufferMut::from_trusted_len_iter(values.iter().map(|&v| {
-            track_min_max(&mut min_max, v);
-            v.as_()
-        }))
-        .freeze(),
-        Mask::AllFalse(_) => cast::<F, T>(values),
-        Mask::Values(m) => BufferMut::from_trusted_len_iter(
-            values.iter().zip(m.bit_buffer().iter()).map(|(&v, valid)| {
-                if valid {
-                    track_min_max(&mut min_max, v);
-                }
-                v.as_()
-            }),
+    let overflow = || {
+        vortex_err!(
+            Compute: "Cannot cast {} to {} — value exceeds target range",
+            F::PTYPE, T::PTYPE,
         )
+    };
+    let buffer: Buffer<T> = match &mask {
+        Mask::AllTrue(_) => BufferMut::try_from_trusted_len_iter(
+            values
+                .iter()
+                .map(|&v| <T as NumCast>::from(v).ok_or_else(overflow)),
+        )?
+        .freeze(),
+        Mask::AllFalse(_) => BufferMut::<T>::zeroed(values.len()).freeze(),
+        Mask::Values(m) => BufferMut::try_from_trusted_len_iter(
+            values.iter().zip(m.bit_buffer().iter()).map(|(&v, valid)| {
+                let factor = if valid { F::one() } else { F::zero() };
+                <T as NumCast>::from(v * factor).ok_or_else(overflow)
+            }),
+        )?
         .freeze(),
     };
 
-    if let Some((min, max)) = min_max {
-        let stats = array.array().statistics();
-        stats.set(
-            Stat::Min,
-            Precision::Exact(ScalarValue::Primitive(PValue::from(min))),
-        );
-        stats.set(
-            Stat::Max,
-            Precision::Exact(ScalarValue::Primitive(PValue::from(max))),
-        );
-
-        if PValue::from(min).cast::<T>().is_err() || PValue::from(max).cast::<T>().is_err() {
-            vortex_bail!(
-                Compute: "Cannot cast {} to {} — values exceed target range",
-                F::PTYPE, T::PTYPE,
-            );
-        }
-    }
-
     Ok(PrimitiveArray::new(buffer, new_validity).into_array())
-}
-
-fn track_min_max<F: NativePType>(min_max: &mut Option<(F, F)>, value: F) {
-    if value.is_nan() {
-        return;
-    }
-    match min_max {
-        None => *min_max = Some((value, value)),
-        Some((min, max)) => {
-            if value.total_compare(*min).is_lt() {
-                *min = value;
-            } else if value.total_compare(*max).is_gt() {
-                *max = value;
-            }
-        }
-    }
-}
-
-/// Returns `Some(true)` if cached min/max prove every valid value fits in `target_dtype`,
-/// `Some(false)` if cached min/max prove the cast must fail, and `None` if stats are unavailable.
-fn cached_min_max_fits(array: ArrayView<'_, Primitive>, target_dtype: &DType) -> Option<bool> {
-    let stats = array.array().statistics();
-    let min = stats.get(Stat::Min).and_then(Precision::as_exact)?;
-    let max = stats.get(Stat::Max).and_then(Precision::as_exact)?;
-    Some(min.cast(target_dtype).is_ok() && max.cast(target_dtype).is_ok())
 }
 
 /// Out-of-range values at invalid positions are truncated/wrapped by `as`, which is fine because

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -6,6 +6,7 @@ use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_mask::Mask;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
@@ -19,9 +20,15 @@ use crate::dtype::DType;
 use crate::dtype::NativePType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
+use crate::expr::stats::Precision;
+use crate::expr::stats::Stat;
+use crate::expr::stats::StatsProvider;
 use crate::match_each_native_ptype;
+use crate::scalar::PValue;
+use crate::scalar::ScalarValue;
 use crate::scalar_fn::fns::cast::CastKernel;
 use crate::scalar_fn::fns::cast::CastReduce;
+use crate::validity::Validity;
 
 impl CastReduce for Primitive {
     fn cast(array: ArrayView<'_, Primitive>, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
@@ -63,62 +70,88 @@ impl CastKernel for Primitive {
             return Ok(None);
         };
         let (new_ptype, new_nullability) = (*new_ptype, *new_nullability);
+        let src_ptype = array.ptype();
 
-        // First, check that the cast is compatible with the source array's validity
         let new_validity = array
             .validity()?
             .cast_nullability(new_nullability, array.len(), ctx)?;
 
         // Same ptype: zero-copy, just update validity.
-        if array.ptype() == new_ptype {
-            // SAFETY: validity and data buffer still have same length
-            return Ok(Some(unsafe {
-                PrimitiveArray::new_unchecked_from_handle(
-                    array.buffer_handle().clone(),
-                    array.ptype(),
-                    new_validity,
-                )
-                .into_array()
-            }));
+        if src_ptype == new_ptype {
+            return Ok(Some(reinterpret(array, src_ptype, new_validity)));
         }
 
-        if !values_fit_in(array, new_ptype, ctx) {
-            vortex_bail!(
-                Compute: "Cannot cast {} to {} — values exceed target range",
-                array.ptype(),
-                new_ptype,
-            );
+        let same_width = src_ptype.byte_width() == new_ptype.byte_width();
+        let same_int_rep = same_width && src_ptype.is_int() && new_ptype.is_int();
+        let infallible = values_always_fit(src_ptype, new_ptype);
+
+        // Same-width int↔int: bit patterns are identical under 2's complement, so once we have
+        // verified the values fit we can just reinterpret the buffer with no per-element work.
+        if same_int_rep {
+            if !infallible && !values_fit_in(array, new_ptype, ctx) {
+                vortex_bail!(
+                    Compute: "Cannot cast {} to {} — values exceed target range",
+                    src_ptype, new_ptype,
+                );
+            }
+            return Ok(Some(reinterpret(array, new_ptype, new_validity)));
         }
 
-        // Same-width integers have identical bit representations due to 2's
-        // complement. If all values fit in the target range, reinterpret with
-        // no allocation.
-        if array.ptype().is_int()
-            && new_ptype.is_int()
-            && array.ptype().byte_width() == new_ptype.byte_width()
-        {
-            // SAFETY: both types are integers with the same size and alignment, and
-            // min/max confirm all valid values are representable in the target type.
-            return Ok(Some(unsafe {
-                PrimitiveArray::new_unchecked_from_handle(
-                    array.buffer_handle().clone(),
-                    new_ptype,
-                    new_validity,
-                )
-                .into_array()
-            }));
+        // Infallible casts (e.g. int → wider int, int → float): no min/max needed. Same-width
+        // casts try to reuse the source allocation when uniquely owned; otherwise allocate.
+        if infallible {
+            return Ok(Some(match_each_native_ptype!(new_ptype, |T| {
+                match_each_native_ptype!(src_ptype, |F| {
+                    PrimitiveArray::new(cast_or_reuse::<F, T>(array), new_validity).into_array()
+                })
+            })));
         }
 
-        // Otherwise, we need to cast the values one-by-one.
+        // Fallible cast (e.g. float → int, narrowing int, narrowing float): cast and min/max
+        // validation happen in a single pass over the source values.
         Ok(Some(match_each_native_ptype!(new_ptype, |T| {
-            match_each_native_ptype!(array.ptype(), |F| {
-                PrimitiveArray::new(cast::<F, T>(array.as_slice()), new_validity).into_array()
+            match_each_native_ptype!(src_ptype, |F| {
+                cast_with_check::<F, T>(array, new_validity, ctx)?
             })
         })))
     }
 }
 
-/// Returns `true` if all valid values in `array` are representable as `target_ptype`.
+fn reinterpret(
+    array: ArrayView<'_, Primitive>,
+    new_ptype: PType,
+    new_validity: Validity,
+) -> ArrayRef {
+    // SAFETY: caller has verified the bit representation is compatible and that validity length
+    // still matches the buffer length.
+    unsafe {
+        PrimitiveArray::new_unchecked_from_handle(
+            array.buffer_handle().clone(),
+            new_ptype,
+            new_validity,
+        )
+    }
+    .into_array()
+}
+
+/// Whether every valid value of `src` is guaranteed representable in `target` without inspecting
+/// the values themselves.
+fn values_always_fit(src: PType, target: PType) -> bool {
+    if src == target {
+        return true;
+    }
+    if src.is_int() && target.is_int() {
+        return target.byte_width() > src.byte_width()
+            && (src.is_unsigned_int() || target.is_signed_int());
+    }
+    if src.is_float() && target.is_float() {
+        return target.byte_width() > src.byte_width();
+    }
+    src.is_int() && matches!(target, PType::F32 | PType::F64)
+}
+
+/// Returns `true` if all valid values in `array` are representable as `target_ptype`. Uses cached
+/// min/max statistics when available and otherwise computes them with a single pass.
 fn values_fit_in(
     array: ArrayView<'_, Primitive>,
     target_ptype: PType,
@@ -131,9 +164,119 @@ fn values_fit_in(
         .is_none_or(|mm| mm.min.cast(&target_dtype).is_ok() && mm.max.cast(&target_dtype).is_ok())
 }
 
-/// Caller must ensure all valid values are representable via `values_fit_in`.
-/// Out-of-range values at invalid positions are truncated/wrapped by `as`,
-/// which is fine because they are masked out by validity.
+/// Cast values from `F` to `T`, reusing the source buffer in-place when the widths match and the
+/// underlying allocation is uniquely owned. Falls back to a fresh allocation otherwise.
+fn cast_or_reuse<F, T>(array: ArrayView<'_, Primitive>) -> Buffer<T>
+where
+    F: NativePType + AsPrimitive<T>,
+    T: NativePType,
+{
+    if size_of::<F>() == size_of::<T>() {
+        let source = Buffer::<F>::from_byte_buffer(array.buffer_handle().to_host_sync());
+        source
+            .map_each_in_place(<F as AsPrimitive<T>>::as_)
+            .freeze()
+    } else {
+        cast::<F, T>(array.as_slice())
+    }
+}
+
+/// Fallible cast: writes target values to a new buffer and tracks the source min/max in the same
+/// pass, then bails if the min/max indicate values overflow the target type.
+fn cast_with_check<F, T>(
+    array: ArrayView<'_, Primitive>,
+    new_validity: Validity,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef>
+where
+    F: NativePType + AsPrimitive<T>,
+    T: NativePType,
+    PValue: From<F>,
+{
+    let target_dtype = DType::Primitive(T::PTYPE, Nullability::NonNullable);
+
+    // If min/max stats are already cached we can decide the fit without revisiting the values.
+    if let Some(fits) = cached_min_max_fits(array, &target_dtype) {
+        if !fits {
+            vortex_bail!(
+                Compute: "Cannot cast {} to {} — values exceed target range",
+                F::PTYPE, T::PTYPE,
+            );
+        }
+        return Ok(PrimitiveArray::new(cast_or_reuse::<F, T>(array), new_validity).into_array());
+    }
+
+    let values = array.as_slice::<F>();
+    let mask = array.validity()?.execute_mask(array.len(), ctx)?;
+    let mut min_max: Option<(F, F)> = None;
+
+    let buffer: Buffer<T> = match &mask {
+        Mask::AllTrue(_) => BufferMut::from_trusted_len_iter(values.iter().map(|&v| {
+            track_min_max(&mut min_max, v);
+            v.as_()
+        }))
+        .freeze(),
+        Mask::AllFalse(_) => cast::<F, T>(values),
+        Mask::Values(m) => BufferMut::from_trusted_len_iter(
+            values.iter().zip(m.bit_buffer().iter()).map(|(&v, valid)| {
+                if valid {
+                    track_min_max(&mut min_max, v);
+                }
+                v.as_()
+            }),
+        )
+        .freeze(),
+    };
+
+    if let Some((min, max)) = min_max {
+        let stats = array.array().statistics();
+        stats.set(
+            Stat::Min,
+            Precision::Exact(ScalarValue::Primitive(PValue::from(min))),
+        );
+        stats.set(
+            Stat::Max,
+            Precision::Exact(ScalarValue::Primitive(PValue::from(max))),
+        );
+
+        if PValue::from(min).cast::<T>().is_err() || PValue::from(max).cast::<T>().is_err() {
+            vortex_bail!(
+                Compute: "Cannot cast {} to {} — values exceed target range",
+                F::PTYPE, T::PTYPE,
+            );
+        }
+    }
+
+    Ok(PrimitiveArray::new(buffer, new_validity).into_array())
+}
+
+fn track_min_max<F: NativePType>(min_max: &mut Option<(F, F)>, value: F) {
+    if value.is_nan() {
+        return;
+    }
+    match min_max {
+        None => *min_max = Some((value, value)),
+        Some((min, max)) => {
+            if value.total_compare(*min).is_lt() {
+                *min = value;
+            } else if value.total_compare(*max).is_gt() {
+                *max = value;
+            }
+        }
+    }
+}
+
+/// Returns `Some(true)` if cached min/max prove every valid value fits in `target_dtype`,
+/// `Some(false)` if cached min/max prove the cast must fail, and `None` if stats are unavailable.
+fn cached_min_max_fits(array: ArrayView<'_, Primitive>, target_dtype: &DType) -> Option<bool> {
+    let stats = array.array().statistics();
+    let min = stats.get(Stat::Min).and_then(Precision::as_exact)?;
+    let max = stats.get(Stat::Max).and_then(Precision::as_exact)?;
+    Some(min.cast(target_dtype).is_ok() && max.cast(target_dtype).is_ok())
+}
+
+/// Out-of-range values at invalid positions are truncated/wrapped by `as`, which is fine because
+/// they are masked out by validity.
 fn cast<F: NativePType + AsPrimitive<T>, T: NativePType>(array: &[F]) -> Buffer<T> {
     BufferMut::from_trusted_len_iter(array.iter().map(|&src| src.as_())).freeze()
 }

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -124,6 +124,9 @@ where
         return Ok(PrimitiveArray::new(cast::<F, T>(values), new_validity).into_array());
     }
 
+    // TODO(joe): if the values source and target have the same bit-width we can
+    // mutate in place.
+
     // Fallible: invalid lanes are pre-multiplied to zero so the checked cast always succeeds for
     // them; valid lanes go through `NumCast::from` and the whole cast bails on the first overflow.
     let mask = array.validity()?.execute_mask(array.len(), ctx)?;

--- a/vortex-buffer/public-api.lock
+++ b/vortex-buffer/public-api.lock
@@ -788,6 +788,10 @@ pub fn vortex_buffer::BufferMut<T>::extend_trusted<I: vortex_buffer::trusted_len
 
 pub fn vortex_buffer::BufferMut<T>::from_trusted_len_iter<I>(I) -> Self where I: vortex_buffer::trusted_len::TrustedLen<Item = T>
 
+pub fn vortex_buffer::BufferMut<T>::try_extend_trusted<E, I>(&mut self, I) -> core::result::Result<(), E> where I: vortex_buffer::trusted_len::TrustedLen<Item = core::result::Result<T, E>>
+
+pub fn vortex_buffer::BufferMut<T>::try_from_trusted_len_iter<E, I>(I) -> core::result::Result<Self, E> where I: vortex_buffer::trusted_len::TrustedLen<Item = core::result::Result<T, E>>
+
 impl<'a, T> core::iter::traits::collect::Extend<&'a T> for vortex_buffer::BufferMut<T> where T: core::marker::Copy + 'a
 
 pub fn vortex_buffer::BufferMut<T>::extend<I: core::iter::traits::collect::IntoIterator<Item = &'a T>>(&mut self, I)

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -644,6 +644,66 @@ impl<T> BufferMut<T> {
         buffer.extend_trusted(iter);
         buffer
     }
+
+    /// Like [`extend_trusted()`](Self::extend_trusted), but the iterator yields `Result<T, E>`
+    /// and the extension short-circuits on the first `Err`.
+    ///
+    /// On error, items written before the failure remain in the buffer.
+    pub fn try_extend_trusted<E, I>(&mut self, iter: I) -> Result<(), E>
+    where
+        I: TrustedLen<Item = Result<T, E>>,
+    {
+        let (_, upper_bound) = iter.size_hint();
+        self.reserve(
+            upper_bound
+                .vortex_expect("`TrustedLen` iterator somehow didn't have valid upper bound"),
+        );
+
+        let begin: *const T = self.bytes.spare_capacity_mut().as_mut_ptr().cast();
+        let mut dst: *mut T = begin.cast_mut();
+        let mut result: Result<(), E> = Ok(());
+
+        for item in iter {
+            match item {
+                Ok(value) => {
+                    // SAFETY: We reserved enough capacity to hold this item, and `dst` is a
+                    // pointer derived from a valid reference to byte data.
+                    unsafe { dst.write(value) };
+                    // SAFETY: The offset fits in `isize` because we reserved that much capacity.
+                    unsafe { dst = dst.add(1) };
+                }
+                Err(e) => {
+                    result = Err(e);
+                    break;
+                }
+            }
+        }
+
+        // SAFETY: `dst` was derived from `begin`, both valid references to byte data, and
+        // `dst >= begin` since the only operation on `dst` is `add`.
+        let items_written = unsafe { dst.offset_from_unsigned(begin) };
+        let length = self.len() + items_written;
+        // SAFETY: We have written valid items between the old length and the new length.
+        unsafe { self.set_len(length) };
+
+        result
+    }
+
+    /// Like [`from_trusted_len_iter()`](Self::from_trusted_len_iter), but the iterator yields
+    /// `Result<T, E>` and construction short-circuits on the first `Err`.
+    pub fn try_from_trusted_len_iter<E, I>(iter: I) -> Result<Self, E>
+    where
+        I: TrustedLen<Item = Result<T, E>>,
+    {
+        let (_, upper_bound) = iter.size_hint();
+        let mut buffer = Self::with_capacity(
+            upper_bound
+                .vortex_expect("`TrustedLen` iterator somehow didn't have valid upper bound"),
+        );
+
+        buffer.try_extend_trusted(iter)?;
+        Ok(buffer)
+    }
 }
 
 impl<T> Extend<T> for BufferMut<T> {
@@ -812,6 +872,25 @@ mod test {
     fn from_iter() {
         let buf = BufferMut::from_iter([0, 10, 20, 30]);
         assert_eq!(buf.as_slice(), &[0, 10, 20, 30]);
+    }
+
+    #[test]
+    fn try_from_trusted_len_iter_ok() {
+        let buf = BufferMut::<i32>::try_from_trusted_len_iter(
+            [0, 10, 20, 30].iter().map(|&v| Ok::<_, ()>(v)),
+        )
+        .unwrap();
+        assert_eq!(buf.as_slice(), &[0, 10, 20, 30]);
+    }
+
+    #[test]
+    fn try_from_trusted_len_iter_err() {
+        let result: Result<BufferMut<i32>, &'static str> = BufferMut::try_from_trusted_len_iter(
+            [0, 10, 20, 30]
+                .iter()
+                .map(|&v| if v == 20 { Err("bad") } else { Ok(v) }),
+        );
+        assert_eq!(result.err(), Some("bad"));
     }
 
     #[test]


### PR DESCRIPTION
Remove a double pass of the array, once for min/max another to cast.

Can try to reinterpret the same buffer.
