### PR TITLE
array tree layouts

### DIFF
--- a/vortex-file/public-api.lock
+++ b/vortex-file/public-api.lock
@@ -1,0 +1,421 @@
+pub mod vortex_file
+
+pub mod vortex_file::multi
+
+pub struct vortex_file::multi::MultiFileDataSource
+
+impl vortex_file::multi::MultiFileDataSource
+
+pub async fn vortex_file::multi::MultiFileDataSource::build(self) -> vortex_error::VortexResult<vortex_layout::scan::multi::MultiLayoutDataSource>
+
+pub fn vortex_file::multi::MultiFileDataSource::new(vortex_session::VortexSession) -> Self
+
+pub fn vortex_file::multi::MultiFileDataSource::with_glob(self, impl core::convert::Into<alloc::string::String>, core::option::Option<vortex_io::filesystem::FileSystemRef>) -> Self
+
+pub fn vortex_file::multi::MultiFileDataSource::with_open_options(self, impl core::ops::function::Fn(vortex_file::VortexOpenOptions) -> vortex_file::VortexOpenOptions + core::marker::Send + core::marker::Sync + 'static) -> Self
+
+pub mod vortex_file::segments
+
+pub enum vortex_file::segments::ReadEvent
+
+pub vortex_file::segments::ReadEvent::Dropped(usize)
+
+pub vortex_file::segments::ReadEvent::Polled(usize)
+
+pub vortex_file::segments::ReadEvent::Request(vortex_file::read::request::ReadRequest)
+
+impl core::fmt::Debug for vortex_file::segments::ReadEvent
+
+pub fn vortex_file::segments::ReadEvent::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub struct vortex_file::segments::FileSegmentSource
+
+impl vortex_file::segments::FileSegmentSource
+
+pub fn vortex_file::segments::FileSegmentSource::open<R: vortex_io::read_at::VortexReadAt + core::clone::Clone>(alloc::sync::Arc<[vortex_file::SegmentSpec]>, R, vortex_io::runtime::handle::Handle, vortex_file::segments::RequestMetrics) -> Self
+
+impl vortex_layout::segments::source::SegmentSource for vortex_file::segments::FileSegmentSource
+
+pub fn vortex_file::segments::FileSegmentSource::request(&self, vortex_layout::segments::SegmentId) -> vortex_layout::segments::source::SegmentFuture
+
+pub struct vortex_file::segments::InitialReadSegmentCache
+
+pub vortex_file::segments::InitialReadSegmentCache::fallback: alloc::sync::Arc<dyn vortex_layout::segments::cache::SegmentCache>
+
+pub vortex_file::segments::InitialReadSegmentCache::initial: parking_lot::rwlock::RwLock<vortex_utils::aliases::hash_map::HashMap<vortex_layout::segments::SegmentId, vortex_buffer::ByteBuffer>>
+
+impl vortex_layout::segments::cache::SegmentCache for vortex_file::segments::InitialReadSegmentCache
+
+pub fn vortex_file::segments::InitialReadSegmentCache::get<'life0, 'async_trait>(&'life0 self, vortex_layout::segments::SegmentId) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<core::option::Option<vortex_buffer::ByteBuffer>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+
+pub fn vortex_file::segments::InitialReadSegmentCache::put<'life0, 'async_trait>(&'life0 self, vortex_layout::segments::SegmentId, vortex_buffer::ByteBuffer) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+
+pub struct vortex_file::segments::RequestMetrics
+
+pub vortex_file::segments::RequestMetrics::coalesced_requests: vortex_metrics::counter::Counter
+
+pub vortex_file::segments::RequestMetrics::individual_requests: vortex_metrics::counter::Counter
+
+pub vortex_file::segments::RequestMetrics::num_requests_coalesced: vortex_metrics::histogram::Histogram
+
+impl vortex_file::segments::RequestMetrics
+
+pub fn vortex_file::segments::RequestMetrics::new(&dyn vortex_metrics::MetricsRegistry, alloc::vec::Vec<vortex_metrics::Label>) -> Self
+
+pub mod vortex_file::v2
+
+pub struct vortex_file::v2::FileStatsLayoutReader
+
+impl vortex_file::v2::FileStatsLayoutReader
+
+pub fn vortex_file::v2::FileStatsLayoutReader::file_stats(&self) -> &vortex_file::FileStatistics
+
+pub fn vortex_file::v2::FileStatsLayoutReader::new(vortex_layout::reader::LayoutReaderRef, vortex_file::FileStatistics, vortex_session::VortexSession) -> Self
+
+impl vortex_array::expr::pruning::StatsCatalog for vortex_file::v2::FileStatsLayoutReader
+
+pub fn vortex_file::v2::FileStatsLayoutReader::stats_ref(&self, &vortex_array::dtype::field::FieldPath, vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::expression::Expression>
+
+impl vortex_layout::reader::LayoutReader for vortex_file::v2::FileStatsLayoutReader
+
+pub fn vortex_file::v2::FileStatsLayoutReader::as_any(&self) -> &dyn core::any::Any
+
+pub fn vortex_file::v2::FileStatsLayoutReader::dtype(&self) -> &vortex_array::dtype::DType
+
+pub fn vortex_file::v2::FileStatsLayoutReader::filter_evaluation(&self, &core::ops::range::Range<u64>, &vortex_array::expr::expression::Expression, vortex_array::mask_future::MaskFuture) -> vortex_error::VortexResult<vortex_array::mask_future::MaskFuture>
+
+pub fn vortex_file::v2::FileStatsLayoutReader::name(&self) -> &alloc::sync::Arc<str>
+
+pub fn vortex_file::v2::FileStatsLayoutReader::projection_evaluation(&self, &core::ops::range::Range<u64>, &vortex_array::expr::expression::Expression, vortex_array::mask_future::MaskFuture) -> vortex_error::VortexResult<vortex_layout::reader::ArrayFuture>
+
+pub fn vortex_file::v2::FileStatsLayoutReader::pruning_evaluation(&self, &core::ops::range::Range<u64>, &vortex_array::expr::expression::Expression, vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::mask_future::MaskFuture>
+
+pub fn vortex_file::v2::FileStatsLayoutReader::register_splits(&self, &[vortex_array::dtype::field_mask::FieldMask], &vortex_layout::reader::SplitRange, &mut alloc::collections::btree::set::BTreeSet<u64>) -> vortex_error::VortexResult<()>
+
+pub fn vortex_file::v2::FileStatsLayoutReader::row_count(&self) -> u64
+
+pub enum vortex_file::DeserializeStep
+
+pub vortex_file::DeserializeStep::Done(vortex_file::Footer)
+
+pub vortex_file::DeserializeStep::NeedFileSize
+
+pub vortex_file::DeserializeStep::NeedMoreData
+
+pub vortex_file::DeserializeStep::NeedMoreData::len: usize
+
+pub vortex_file::DeserializeStep::NeedMoreData::offset: u64
+
+impl core::fmt::Debug for vortex_file::DeserializeStep
+
+pub fn vortex_file::DeserializeStep::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub struct vortex_file::BlockingWrite<'rt, B: vortex_io::runtime::blocking::BlockingRuntime>
+
+impl<'rt, B: vortex_io::runtime::blocking::BlockingRuntime> vortex_file::BlockingWrite<'rt, B>
+
+pub fn vortex_file::BlockingWrite<'rt, B>::write<W: std::io::Write + core::marker::Unpin>(self, W, impl vortex_array::iter::ArrayIterator + core::marker::Send + 'static) -> vortex_error::VortexResult<vortex_file::WriteSummary>
+
+pub fn vortex_file::BlockingWrite<'rt, B>::writer<'w, W: std::io::Write + core::marker::Unpin + 'w>(self, W, vortex_array::dtype::DType) -> vortex_file::BlockingWriter<'rt, 'w, B>
+
+pub struct vortex_file::BlockingWriter<'rt, 'w, B: vortex_io::runtime::blocking::BlockingRuntime>
+
+impl<B: vortex_io::runtime::blocking::BlockingRuntime> vortex_file::BlockingWriter<'_, '_, B>
+
+pub fn vortex_file::BlockingWriter<'_, '_, B>::buffered_bytes(&self) -> u64
+
+pub fn vortex_file::BlockingWriter<'_, '_, B>::bytes_written(&self) -> u64
+
+pub fn vortex_file::BlockingWriter<'_, '_, B>::finish(self) -> vortex_error::VortexResult<vortex_file::WriteSummary>
+
+pub fn vortex_file::BlockingWriter<'_, '_, B>::push(&mut self, vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<()>
+
+pub struct vortex_file::FileStatistics
+
+impl vortex_file::FileStatistics
+
+pub fn vortex_file::FileStatistics::dtypes(&self) -> &alloc::sync::Arc<[vortex_array::dtype::DType]>
+
+pub fn vortex_file::FileStatistics::from_flatbuffer<'a>(&vortex_flatbuffers::footer::FileStatistics<'a>, &vortex_array::dtype::DType, &vortex_session::VortexSession) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_file::FileStatistics::get(&self, usize) -> (&vortex_array::stats::stats_set::StatsSet, &vortex_array::dtype::DType)
+
+pub fn vortex_file::FileStatistics::new(alloc::sync::Arc<[vortex_array::stats::stats_set::StatsSet]>, alloc::sync::Arc<[vortex_array::dtype::DType]>) -> Self
+
+pub fn vortex_file::FileStatistics::new_with_dtype(alloc::sync::Arc<[vortex_array::stats::stats_set::StatsSet]>, &vortex_array::dtype::DType) -> Self
+
+pub fn vortex_file::FileStatistics::stats_sets(&self) -> &alloc::sync::Arc<[vortex_array::stats::stats_set::StatsSet]>
+
+impl core::clone::Clone for vortex_file::FileStatistics
+
+pub fn vortex_file::FileStatistics::clone(&self) -> vortex_file::FileStatistics
+
+impl core::fmt::Debug for vortex_file::FileStatistics
+
+pub fn vortex_file::FileStatistics::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_flatbuffers::FlatBufferRoot for vortex_file::FileStatistics
+
+impl vortex_flatbuffers::WriteFlatBuffer for vortex_file::FileStatistics
+
+pub type vortex_file::FileStatistics::Target<'a> = vortex_flatbuffers::footer::FileStatistics<'a>
+
+pub fn vortex_file::FileStatistics::write_flatbuffer<'fb>(&self, &mut flatbuffers::builder::FlatBufferBuilder<'fb>) -> vortex_error::VortexResult<flatbuffers::primitives::WIPOffset<Self::Target>>
+
+impl<'a> core::iter::traits::collect::IntoIterator for &'a vortex_file::FileStatistics
+
+pub type &'a vortex_file::FileStatistics::IntoIter = core::iter::adapters::zip::Zip<core::slice::iter::Iter<'a, vortex_array::stats::stats_set::StatsSet>, core::slice::iter::Iter<'a, vortex_array::dtype::DType>>
+
+pub type &'a vortex_file::FileStatistics::Item = (&'a vortex_array::stats::stats_set::StatsSet, &'a vortex_array::dtype::DType)
+
+pub fn &'a vortex_file::FileStatistics::into_iter(self) -> Self::IntoIter
+
+pub struct vortex_file::Footer
+
+impl vortex_file::Footer
+
+pub fn vortex_file::Footer::approx_byte_size(&self) -> core::option::Option<usize>
+
+pub fn vortex_file::Footer::deserializer(vortex_buffer::ByteBuffer, vortex_session::VortexSession) -> vortex_file::FooterDeserializer
+
+pub fn vortex_file::Footer::dtype(&self) -> &vortex_array::dtype::DType
+
+pub fn vortex_file::Footer::into_serializer(self) -> vortex_file::FooterSerializer
+
+pub fn vortex_file::Footer::layout(&self) -> &vortex_layout::layout::LayoutRef
+
+pub fn vortex_file::Footer::row_count(&self) -> u64
+
+pub fn vortex_file::Footer::segment_map(&self) -> &alloc::sync::Arc<[vortex_file::SegmentSpec]>
+
+pub fn vortex_file::Footer::statistics(&self) -> core::option::Option<&vortex_file::FileStatistics>
+
+impl core::clone::Clone for vortex_file::Footer
+
+pub fn vortex_file::Footer::clone(&self) -> vortex_file::Footer
+
+impl core::fmt::Debug for vortex_file::Footer
+
+pub fn vortex_file::Footer::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub struct vortex_file::FooterDeserializer
+
+impl vortex_file::FooterDeserializer
+
+pub fn vortex_file::FooterDeserializer::buffer(&self) -> &vortex_buffer::ByteBuffer
+
+pub fn vortex_file::FooterDeserializer::deserialize(&mut self) -> vortex_error::VortexResult<vortex_file::DeserializeStep>
+
+pub fn vortex_file::FooterDeserializer::prefix_data(&mut self, vortex_buffer::ByteBuffer)
+
+pub fn vortex_file::FooterDeserializer::with_dtype(self, vortex_array::dtype::DType) -> Self
+
+pub fn vortex_file::FooterDeserializer::with_size(self, u64) -> Self
+
+pub fn vortex_file::FooterDeserializer::with_some_dtype(self, core::option::Option<vortex_array::dtype::DType>) -> Self
+
+pub fn vortex_file::FooterDeserializer::with_some_size(self, core::option::Option<u64>) -> Self
+
+pub struct vortex_file::FooterSerializer
+
+impl vortex_file::FooterSerializer
+
+pub fn vortex_file::FooterSerializer::exclude_dtype(self) -> Self
+
+pub fn vortex_file::FooterSerializer::serialize(self) -> vortex_error::VortexResult<alloc::vec::Vec<vortex_buffer::ByteBuffer>>
+
+pub fn vortex_file::FooterSerializer::with_exclude_dtype(self, bool) -> Self
+
+pub fn vortex_file::FooterSerializer::with_offset(self, u64) -> Self
+
+pub struct vortex_file::SegmentSpec
+
+pub vortex_file::SegmentSpec::alignment: vortex_buffer::alignment::Alignment
+
+pub vortex_file::SegmentSpec::length: u32
+
+pub vortex_file::SegmentSpec::offset: u64
+
+impl vortex_file::SegmentSpec
+
+pub fn vortex_file::SegmentSpec::byte_range(&self) -> core::ops::range::Range<u64>
+
+impl core::clone::Clone for vortex_file::SegmentSpec
+
+pub fn vortex_file::SegmentSpec::clone(&self) -> vortex_file::SegmentSpec
+
+impl core::convert::From<&vortex_file::SegmentSpec> for vortex_flatbuffers::footer::SegmentSpec
+
+pub fn vortex_flatbuffers::footer::SegmentSpec::from(&vortex_file::SegmentSpec) -> Self
+
+impl core::convert::TryFrom<&vortex_flatbuffers::footer::SegmentSpec> for vortex_file::SegmentSpec
+
+pub type vortex_file::SegmentSpec::Error = vortex_error::VortexError
+
+pub fn vortex_file::SegmentSpec::try_from(&vortex_flatbuffers::footer::SegmentSpec) -> core::result::Result<Self, Self::Error>
+
+impl core::fmt::Debug for vortex_file::SegmentSpec
+
+pub fn vortex_file::SegmentSpec::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::marker::Copy for vortex_file::SegmentSpec
+
+pub struct vortex_file::VortexFile
+
+impl vortex_file::VortexFile
+
+pub fn vortex_file::VortexFile::can_prune(&self, &vortex_array::expr::expression::Expression) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_file::VortexFile::data_source(&self) -> vortex_error::VortexResult<vortex_scan::DataSourceRef>
+
+pub fn vortex_file::VortexFile::dtype(&self) -> &vortex_array::dtype::DType
+
+pub fn vortex_file::VortexFile::file_stats(&self) -> core::option::Option<&vortex_file::FileStatistics>
+
+pub fn vortex_file::VortexFile::footer(&self) -> &vortex_file::Footer
+
+pub fn vortex_file::VortexFile::layout_reader(&self) -> vortex_error::VortexResult<alloc::sync::Arc<dyn vortex_layout::reader::LayoutReader>>
+
+pub fn vortex_file::VortexFile::row_count(&self) -> u64
+
+pub fn vortex_file::VortexFile::scan(&self) -> vortex_error::VortexResult<vortex_layout::scan::scan_builder::ScanBuilder<vortex_array::array::erased::ArrayRef>>
+
+pub fn vortex_file::VortexFile::segment_source(&self) -> alloc::sync::Arc<dyn vortex_layout::segments::source::SegmentSource>
+
+pub fn vortex_file::VortexFile::splits(&self) -> vortex_error::VortexResult<alloc::vec::Vec<core::ops::range::Range<u64>>>
+
+impl core::clone::Clone for vortex_file::VortexFile
+
+pub fn vortex_file::VortexFile::clone(&self) -> vortex_file::VortexFile
+
+pub struct vortex_file::VortexOpenOptions
+
+impl vortex_file::VortexOpenOptions
+
+pub async fn vortex_file::VortexOpenOptions::open(self, alloc::sync::Arc<dyn vortex_io::read_at::VortexReadAt>) -> vortex_error::VortexResult<vortex_file::VortexFile>
+
+pub fn vortex_file::VortexOpenOptions::open_buffer<B: core::convert::Into<vortex_buffer::ByteBuffer>>(self, B) -> vortex_error::VortexResult<vortex_file::VortexFile>
+
+pub async fn vortex_file::VortexOpenOptions::open_path(self, impl core::convert::AsRef<std::path::Path>) -> vortex_error::VortexResult<vortex_file::VortexFile>
+
+pub async fn vortex_file::VortexOpenOptions::open_read<R: vortex_io::read_at::VortexReadAt + core::clone::Clone>(self, R) -> vortex_error::VortexResult<vortex_file::VortexFile>
+
+pub fn vortex_file::VortexOpenOptions::with_dtype(self, vortex_array::dtype::DType) -> Self
+
+pub fn vortex_file::VortexOpenOptions::with_file_size(self, u64) -> Self
+
+pub fn vortex_file::VortexOpenOptions::with_footer(self, vortex_file::Footer) -> Self
+
+pub fn vortex_file::VortexOpenOptions::with_initial_read_size(self, usize) -> Self
+
+pub fn vortex_file::VortexOpenOptions::with_labels(self, alloc::vec::Vec<vortex_metrics::Label>) -> Self
+
+pub fn vortex_file::VortexOpenOptions::with_metrics_registry(self, alloc::sync::Arc<dyn vortex_metrics::MetricsRegistry>) -> Self
+
+pub fn vortex_file::VortexOpenOptions::with_segment_cache(self, alloc::sync::Arc<dyn vortex_layout::segments::cache::SegmentCache>) -> Self
+
+pub fn vortex_file::VortexOpenOptions::with_some_file_size(self, core::option::Option<u64>) -> Self
+
+impl vortex_file::VortexOpenOptions
+
+pub async fn vortex_file::VortexOpenOptions::open_object_store(self, &alloc::sync::Arc<dyn object_store::ObjectStore>, &str) -> vortex_error::VortexResult<vortex_file::VortexFile>
+
+pub struct vortex_file::VortexWriteOptions
+
+impl vortex_file::VortexWriteOptions
+
+pub fn vortex_file::VortexWriteOptions::blocking<B: vortex_io::runtime::blocking::BlockingRuntime>(self, &B) -> vortex_file::BlockingWrite<'_, B>
+
+pub async fn vortex_file::VortexWriteOptions::write<W: vortex_io::write::VortexWrite + core::marker::Unpin, S: vortex_array::stream::ArrayStream + core::marker::Send + 'static>(self, W, S) -> vortex_error::VortexResult<vortex_file::WriteSummary>
+
+pub fn vortex_file::VortexWriteOptions::writer<'w, W: vortex_io::write::VortexWrite + core::marker::Unpin + 'w>(self, W, vortex_array::dtype::DType) -> vortex_file::Writer<'w>
+
+impl vortex_file::VortexWriteOptions
+
+pub fn vortex_file::VortexWriteOptions::exclude_dtype(self) -> Self
+
+pub fn vortex_file::VortexWriteOptions::new(vortex_session::VortexSession) -> Self
+
+pub fn vortex_file::VortexWriteOptions::with_file_statistics(self, alloc::vec::Vec<vortex_array::expr::stats::Stat>) -> Self
+
+pub fn vortex_file::VortexWriteOptions::with_strategy(self, alloc::sync::Arc<dyn vortex_layout::strategy::LayoutStrategy>) -> Self
+
+pub struct vortex_file::WriteStrategyBuilder
+
+impl vortex_file::WriteStrategyBuilder
+
+pub fn vortex_file::WriteStrategyBuilder::build(self) -> alloc::sync::Arc<dyn vortex_layout::strategy::LayoutStrategy>
+
+pub fn vortex_file::WriteStrategyBuilder::with_allow_encodings(self, vortex_utils::aliases::hash_set::HashSet<vortex_array::array::ArrayId>) -> Self
+
+pub fn vortex_file::WriteStrategyBuilder::with_array_tree(self, bool) -> Self
+
+pub fn vortex_file::WriteStrategyBuilder::with_btrblocks_builder(self, vortex_btrblocks::builder::BtrBlocksCompressorBuilder) -> Self
+
+pub fn vortex_file::WriteStrategyBuilder::with_compressor<C: vortex_layout::layouts::compressed::CompressorPlugin>(self, C) -> Self
+
+pub fn vortex_file::WriteStrategyBuilder::with_field_writer(self, impl core::convert::Into<vortex_array::dtype::field::FieldPath>, alloc::sync::Arc<dyn vortex_layout::strategy::LayoutStrategy>) -> Self
+
+pub fn vortex_file::WriteStrategyBuilder::with_flat_strategy(self, alloc::sync::Arc<dyn vortex_layout::strategy::LayoutStrategy>) -> Self
+
+pub fn vortex_file::WriteStrategyBuilder::with_row_block_size(self, usize) -> Self
+
+impl core::default::Default for vortex_file::WriteStrategyBuilder
+
+pub fn vortex_file::WriteStrategyBuilder::default() -> Self
+
+pub struct vortex_file::WriteSummary
+
+impl vortex_file::WriteSummary
+
+pub fn vortex_file::WriteSummary::footer(&self) -> &vortex_file::Footer
+
+pub fn vortex_file::WriteSummary::row_count(&self) -> u64
+
+pub fn vortex_file::WriteSummary::size(&self) -> u64
+
+pub struct vortex_file::Writer<'w>
+
+impl vortex_file::Writer<'_>
+
+pub fn vortex_file::Writer<'_>::buffered_bytes(&self) -> u64
+
+pub fn vortex_file::Writer<'_>::bytes_written(&self) -> u64
+
+pub async fn vortex_file::Writer<'_>::finish(self) -> vortex_error::VortexResult<vortex_file::WriteSummary>
+
+pub async fn vortex_file::Writer<'_>::push(&mut self, vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<()>
+
+pub async fn vortex_file::Writer<'_>::push_stream(&mut self, vortex_array::stream::SendableArrayStream) -> vortex_error::VortexResult<()>
+
+pub const vortex_file::EOF_SIZE: usize
+
+pub const vortex_file::MAGIC_BYTES: [u8; 4]
+
+pub const vortex_file::MAX_POSTSCRIPT_SIZE: u16
+
+pub const vortex_file::V1_FOOTER_FBS_SIZE: usize
+
+pub const vortex_file::VERSION: u16
+
+pub const vortex_file::VORTEX_FILE_EXTENSION: &str
+
+pub static vortex_file::ALLOWED_ENCODINGS: std::sync::lazy_lock::LazyLock<vortex_utils::aliases::hash_set::HashSet<vortex_array::array::ArrayId>>
+
+pub trait vortex_file::OpenOptionsSessionExt: vortex_array::session::ArraySessionExt + vortex_layout::session::LayoutSessionExt + vortex_io::session::RuntimeSessionExt + vortex_array::memory::MemorySessionExt
+
+pub fn vortex_file::OpenOptionsSessionExt::open_options(&self) -> vortex_file::VortexOpenOptions
+
+impl<S: vortex_array::session::ArraySessionExt + vortex_layout::session::LayoutSessionExt + vortex_io::session::RuntimeSessionExt + vortex_array::memory::MemorySessionExt> vortex_file::OpenOptionsSessionExt for S
+
+pub fn S::open_options(&self) -> vortex_file::VortexOpenOptions
+
+pub trait vortex_file::WriteOptionsSessionExt: vortex_session::SessionExt
+
+pub fn vortex_file::WriteOptionsSessionExt::write_options(&self) -> vortex_file::VortexWriteOptions
+
+impl<S: vortex_session::SessionExt> vortex_file::WriteOptionsSessionExt for S
+
+pub fn S::write_options(&self) -> vortex_file::VortexWriteOptions
+
+pub fn vortex_file::register_default_encodings(&vortex_session::VortexSession)

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -41,6 +41,7 @@ use vortex_fastlanes::FoR;
 use vortex_fastlanes::RLE;
 use vortex_fsst::FSST;
 use vortex_layout::LayoutStrategy;
+use vortex_layout::layouts::array_tree::writer as array_tree_writer;
 use vortex_layout::layouts::buffered::BufferedStrategy;
 use vortex_layout::layouts::chunked::writer::ChunkedLayoutStrategy;
 use vortex_layout::layouts::collect::CollectStrategy;
@@ -149,6 +150,7 @@ pub struct WriteStrategyBuilder {
     field_writers: HashMap<FieldPath, Arc<dyn LayoutStrategy>>,
     allow_encodings: Option<HashSet<ArrayId>>,
     flat_strategy: Option<Arc<dyn LayoutStrategy>>,
+    array_tree: bool,
 }
 
 impl Default for WriteStrategyBuilder {
@@ -161,6 +163,7 @@ impl Default for WriteStrategyBuilder {
             field_writers: HashMap::new(),
             allow_encodings: Some(ALLOWED_ENCODINGS.clone()),
             flat_strategy: None,
+            array_tree: false,
         }
     }
 }
@@ -193,8 +196,29 @@ impl WriteStrategyBuilder {
     ///
     /// By default, this uses [`FlatLayoutStrategy`]. This can be used to substitute a custom
     /// layout strategy, e.g. one that inlines constant array buffers for GPU reads.
+    ///
+    /// Passing a custom flat strategy implicitly disables the array-tree outlining feature
+    /// (see [`Self::with_array_tree`]), since the custom strategy owns the leaf format.
     pub fn with_flat_strategy(mut self, flat: Arc<dyn LayoutStrategy>) -> Self {
         self.flat_strategy = Some(flat);
+        self
+    }
+
+    /// Enable array-tree outlining: each chunk's encoding tree (without per-chunk statistics)
+    /// is collected into a single auxiliary segment per column rather than being inlined
+    /// alongside the chunk's data.
+    ///
+    /// Disabled by default. When enabled, the written file uses two encodings that older
+    /// readers will not understand:
+    /// [`vortex_layout::layouts::array_tree::ArrayTreeFlatLayout`] at the data leaves, and a
+    /// wrapping [`vortex_layout::layouts::array_tree::ArrayTreeLayout`] that owns the
+    /// consolidated auxiliary segment. Files written by this builder with the feature on
+    /// require a reader that recognizes both encodings.
+    ///
+    /// Has no effect if a custom flat strategy is provided via
+    /// [`Self::with_flat_strategy`] — the user-supplied leaf format wins.
+    pub fn with_array_tree(mut self, array_tree: bool) -> Self {
+        self.array_tree = array_tree;
         self
     }
 
@@ -218,23 +242,17 @@ impl WriteStrategyBuilder {
     /// Builds the canonical [`LayoutStrategy`] implementation, with the configured overrides
     /// applied.
     pub fn build(self) -> Arc<dyn LayoutStrategy> {
-        let flat: Arc<dyn LayoutStrategy> = if let Some(flat) = self.flat_strategy {
-            flat
-        } else if let Some(allow_encodings) = self.allow_encodings {
-            Arc::new(FlatLayoutStrategy::default().with_allow_encodings(allow_encodings))
+        let flat: Arc<dyn LayoutStrategy> = if let Some(flat) = &self.flat_strategy {
+            Arc::clone(flat)
+        } else if let Some(allow_encodings) = &self.allow_encodings {
+            Arc::new(FlatLayoutStrategy::default().with_allow_encodings(allow_encodings.clone()))
         } else {
             Arc::new(FlatLayoutStrategy::default())
         };
 
-        // 7. for each chunk create a flat layout
-        let chunked = ChunkedLayoutStrategy::new(Arc::clone(&flat));
-        // 6. buffer chunks so they end up with closer segment ids physically
-        let buffered = BufferedStrategy::new(chunked, 2 * ONE_MEG); // 2MB
-
-        // 5. compress each chunk.
-        // Exclude IntDictScheme from the data compressor because DictStrategy (step 3) already
-        // dictionary-encodes columns. Allowing IntDictScheme here would redundantly
-        // dictionary-encode the integer codes produced by that earlier step.
+        // Data compressor: excludes IntDictScheme because DictStrategy (step 3 below) already
+        // dictionary-encodes columns; allowing it here would redundantly dictionary-encode the
+        // integer codes produced by that earlier step.
         let data_compressor: Arc<dyn CompressorPlugin> = match &self.compressor {
             CompressorConfig::BtrBlocks(builder) => Arc::new(
                 builder
@@ -244,6 +262,37 @@ impl WriteStrategyBuilder {
             ),
             CompressorConfig::Opaque(compressor) => Arc::clone(compressor),
         };
+        // Stats compressor: used for zone-map tables, dict values, and (when enabled) the
+        // consolidated array-trees segment.
+        let stats_compressor: Arc<dyn CompressorPlugin> = match &self.compressor {
+            CompressorConfig::BtrBlocks(builder) => Arc::new(builder.clone().build()),
+            CompressorConfig::Opaque(compressor) => Arc::clone(compressor),
+        };
+        let compress_then_flat =
+            CompressingStrategy::new(Arc::clone(&flat), Arc::clone(&stats_compressor));
+        let compress_then_flat_arc: Arc<dyn LayoutStrategy> = Arc::new(compress_then_flat.clone());
+
+        let array_tree_enabled = self.array_tree && self.flat_strategy.is_none();
+        let (data_leaf, array_tree_collector): (Arc<dyn LayoutStrategy>, _) = if !array_tree_enabled
+        {
+            (Arc::clone(&flat), None)
+        } else {
+            let data_flat = if let Some(allow_encodings) = &self.allow_encodings {
+                FlatLayoutStrategy::default().with_allow_encodings(allow_encodings.clone())
+            } else {
+                FlatLayoutStrategy::default()
+            };
+            let (collector, leaf) =
+                array_tree_writer::writer(data_flat, Arc::clone(&compress_then_flat_arc));
+            (Arc::new(leaf), Some(collector))
+        };
+
+        // 7. for each chunk create a flat layout
+        let chunked = ChunkedLayoutStrategy::new(data_leaf);
+        // 6. buffer chunks so they end up with closer segment ids physically
+        let buffered = BufferedStrategy::new(chunked, 2 * ONE_MEG); // 2MB
+
+        // 5. compress each chunk.
         let compressing = CompressingStrategy::new(buffered, data_compressor);
 
         // 4. prior to compression, coalesce up to a minimum size
@@ -263,13 +312,6 @@ impl WriteStrategyBuilder {
             },
         );
 
-        // 2.1. | 3.1. compress stats tables and dict values.
-        let stats_compressor: Arc<dyn CompressorPlugin> = match self.compressor {
-            CompressorConfig::BtrBlocks(builder) => Arc::new(builder.build()),
-            CompressorConfig::Opaque(compressor) => compressor,
-        };
-        let compress_then_flat = CompressingStrategy::new(flat, stats_compressor);
-
         // 3. apply dict encoding or fallback
         let dict = DictStrategy::new(
             coalescing.clone(),
@@ -278,9 +320,16 @@ impl WriteStrategyBuilder {
             Default::default(),
         );
 
+        // 2.5. wrap dict in the array-tree collector if outlining is enabled.
+        let data_pipeline: Arc<dyn LayoutStrategy> = if let Some(collector) = array_tree_collector {
+            Arc::new(collector.wrap(dict))
+        } else {
+            Arc::new(dict)
+        };
+
         // 2. calculate stats for each row group
         let stats = ZonedStrategy::new(
-            dict,
+            data_pipeline,
             compress_then_flat.clone(),
             ZonedLayoutOptions {
                 block_size: self.row_block_size,

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1990,3 +1990,233 @@ async fn test_can_prune_composite_predicates() -> VortexResult<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_segment_ordering_array_trees_consolidated_and_after_data() -> VortexResult<()> {
+    // Multi-column struct large enough to produce chunked data, so each column will have
+    // many ArrayTreeFlat leaves. The collector should consolidate their compact trees into a
+    // single segment per ArrayTreeLayout.
+    let n = 100_000;
+    let values: Vec<&str> = (0..n).map(|i| ["alpha", "beta", "gamma"][i % 3]).collect();
+    let strings = VarBinArray::from(values).into_array();
+    let numbers = PrimitiveArray::from_iter(0..n as i32).into_array();
+    let floats = PrimitiveArray::from_iter((0..n).map(|i| i as f64 * 0.1)).into_array();
+
+    let st = StructArray::from_fields(&[
+        ("strings", strings),
+        ("numbers", numbers),
+        ("floats", floats),
+    ])
+    .unwrap();
+
+    let mut buf = ByteBufferMut::empty();
+    let strategy = crate::WriteStrategyBuilder::default()
+        .with_array_tree(true)
+        .build();
+    let summary = SESSION
+        .write_options()
+        .with_strategy(strategy)
+        .write(&mut buf, st.into_array().to_array_stream())
+        .await?;
+
+    let footer = summary.footer();
+    let segment_specs = footer.segment_map();
+    let root = footer.layout();
+
+    // For each ArrayTreeLayout in the tree, assert:
+    //   1. **Consolidation:** the auxiliary `array_trees` child writes exactly one segment.
+    //   2. **Per-column ordering:** every data segment under child 0 appears before the
+    //      array_trees segment under child 1.
+    fn check_array_tree_layouts(
+        layout: &dyn Layout,
+        segment_specs: &[SegmentSpec],
+        found_any: &mut bool,
+    ) {
+        if layout.encoding_id().as_ref() == "vortex.array_tree" {
+            *found_any = true;
+
+            let data_child = layout.child(0).unwrap();
+            let array_trees_child = layout.child(1).unwrap();
+
+            let data_offsets = collect_segment_offsets(data_child.as_ref(), segment_specs);
+            let array_trees_offsets =
+                collect_segment_offsets(array_trees_child.as_ref(), segment_specs);
+
+            assert_eq!(
+                array_trees_offsets.len(),
+                1,
+                "array_tree: auxiliary child must consolidate to exactly 1 segment, got {} segments at offsets {:?}",
+                array_trees_offsets.len(),
+                array_trees_offsets,
+            );
+
+            assert!(
+                !data_offsets.is_empty(),
+                "array_tree: data child must have at least one segment"
+            );
+
+            assert_offsets_ordered(
+                &data_offsets,
+                &array_trees_offsets,
+                "array_tree: all data segments should come before the array_trees segment",
+            );
+        }
+
+        for child in layout.children().unwrap() {
+            check_array_tree_layouts(child.as_ref(), segment_specs, found_any);
+        }
+    }
+
+    let mut found_any = false;
+    check_array_tree_layouts(root.as_ref(), segment_specs, &mut found_any);
+    assert!(
+        found_any,
+        "test setup expected the default write strategy to produce at least one ArrayTreeLayout"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_segment_ordering_array_trees_before_zones() -> VortexResult<()> {
+    // The write strategy wraps every column in `ZonedStrategy { data: ArrayTree, zones }`.
+    // Assert per-Zoned-layout that the array_trees segment (inside the data child) appears
+    // before every zone-map segment in the same column.
+    let n = 100_000;
+    let values: Vec<&str> = (0..n).map(|i| ["alpha", "beta", "gamma"][i % 3]).collect();
+    let strings = VarBinArray::from(values).into_array();
+    let numbers = PrimitiveArray::from_iter(0..n as i32).into_array();
+    let floats = PrimitiveArray::from_iter((0..n).map(|i| i as f64 * 0.1)).into_array();
+
+    let st = StructArray::from_fields(&[
+        ("strings", strings),
+        ("numbers", numbers),
+        ("floats", floats),
+    ])
+    .unwrap();
+
+    let mut buf = ByteBufferMut::empty();
+    let strategy = crate::WriteStrategyBuilder::default()
+        .with_array_tree(true)
+        .build();
+    let summary = SESSION
+        .write_options()
+        .with_strategy(strategy)
+        .write(&mut buf, st.into_array().to_array_stream())
+        .await?;
+
+    let footer = summary.footer();
+    let segment_specs = footer.segment_map();
+    let root = footer.layout();
+
+    fn check_zoned_with_array_tree(
+        layout: &dyn Layout,
+        segment_specs: &[SegmentSpec],
+        found_any: &mut bool,
+    ) {
+        if layout.encoding_id().as_ref() == "vortex.stats" {
+            let data_child = layout.child(0).unwrap();
+            let zones_child = layout.child(1).unwrap();
+
+            if data_child.encoding_id().as_ref() == "vortex.array_tree" {
+                *found_any = true;
+                let array_trees_offsets =
+                    collect_segment_offsets(data_child.child(1).unwrap().as_ref(), segment_specs);
+                let zones_offsets = collect_segment_offsets(zones_child.as_ref(), segment_specs);
+
+                assert_offsets_ordered(
+                    &array_trees_offsets,
+                    &zones_offsets,
+                    "zoned wrapping array_tree: the array_trees segment should come before zone-map segments",
+                );
+            }
+        }
+
+        for child in layout.children().unwrap() {
+            check_zoned_with_array_tree(child.as_ref(), segment_specs, found_any);
+        }
+    }
+
+    let mut found_any = false;
+    check_zoned_with_array_tree(root.as_ref(), segment_specs, &mut found_any);
+    assert!(
+        found_any,
+        "test setup expected the default write strategy to produce at least one Zoned wrapping an ArrayTree"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_roundtrip_array_tree_layout() -> VortexResult<()> {
+    // End-to-end coverage: write with `with_array_tree(true)`, then read back through the
+    // source-publishing reader-ctx path and assert the data matches. Exercises:
+    //   - ArrayTreeCollectorStrategy collecting compact trees from leaf transient state
+    //   - ArrayTreeLayout::new_reader publishing the ArrayTreesSource into the reader ctx
+    //   - ArrayTreeFlatReader pulling the source and resolving its tree by segment_id
+    //   - ColumnarSerializedArray::from_segment_and_tree decoding the data segment
+    let mut ctx = SESSION.create_execution_ctx();
+
+    let n = 10_000;
+    let strings_in: Vec<&str> = (0..n).map(|i| ["alpha", "beta", "gamma"][i % 3]).collect();
+    let strings = VarBinArray::from(strings_in.clone()).into_array();
+    let numbers_in: Vec<i32> = (0..n as i32).collect();
+    let numbers = PrimitiveArray::from_iter(numbers_in.iter().copied()).into_array();
+
+    let st = StructArray::from_fields(&[("strings", strings), ("numbers", numbers)])?.into_array();
+    let dtype = st.dtype().clone();
+
+    let mut buf = ByteBufferMut::empty();
+    let strategy = crate::WriteStrategyBuilder::default()
+        .with_array_tree(true)
+        .build();
+    SESSION
+        .write_options()
+        .with_strategy(strategy)
+        .write(&mut buf, st.to_array_stream())
+        .await?;
+
+    // Sanity-check we actually wrote ArrayTreeLayout nodes — otherwise the test would
+    // silently pass on the default code path.
+    let file = SESSION.open_options().open_buffer(buf)?;
+    fn has_array_tree(layout: &dyn Layout) -> bool {
+        if layout.encoding_id().as_ref() == "vortex.array_tree" {
+            return true;
+        }
+        layout
+            .children()
+            .map(|cs| cs.iter().any(|c| has_array_tree(c.as_ref())))
+            .unwrap_or(false)
+    }
+    assert!(
+        has_array_tree(file.footer().layout().as_ref()),
+        "test expected ArrayTreeLayout in the written file"
+    );
+
+    let result = file.scan()?.into_array_stream()?.read_all().await?;
+    assert_eq!(result.len(), n);
+    assert_eq!(result.dtype(), &dtype);
+
+    let struct_array = result.execute::<StructArray>(&mut ctx)?;
+
+    let read_numbers = struct_array.unmasked_field_by_name("numbers").cloned()?;
+    let expected_numbers = PrimitiveArray::from_iter(numbers_in.iter().copied()).into_array();
+    assert_arrays_eq!(read_numbers, expected_numbers);
+
+    let read_strings = struct_array
+        .unmasked_field_by_name("strings")
+        .cloned()?
+        .execute::<VarBinViewArray>(&mut ctx)?
+        .with_iterator(|iter| {
+            iter.map(|s| s.map(|st| unsafe { String::from_utf8_unchecked(st.to_vec()) }))
+                .collect::<Vec<_>>()
+        });
+    let expected_strings: Vec<Option<String>> =
+        strings_in.iter().map(|s| Some((*s).to_string())).collect();
+    assert_eq!(read_strings, expected_strings);
+
+    Ok(())
+}

--- a/vortex-layout/src/layouts/array_tree/flat.rs
+++ b/vortex-layout/src/layouts/array_tree/flat.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use vortex_array::EmptyMetadata;
+use vortex_array::dtype::DType;
+use vortex_array::serde::ColumnarArrayTree;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_panic;
+use vortex_session::VortexSession;
+use vortex_session::registry::ReadContext;
+
+use crate::LayoutChildType;
+use crate::LayoutEncodingRef;
+use crate::LayoutId;
+use crate::LayoutReaderContext;
+use crate::LayoutReaderRef;
+use crate::LayoutRef;
+use crate::VTable;
+use crate::children::LayoutChildren;
+use crate::layouts::array_tree::ARRAY_TREES_SOURCE_ID;
+use crate::layouts::array_tree::ArrayTreesSource;
+use crate::layouts::array_tree::reader::ArrayTreeFlatReader;
+use crate::layouts::flat::FlatLayout;
+use crate::segments::SegmentId;
+use crate::segments::SegmentSource;
+use crate::vtable;
+
+vtable!(ArrayTreeFlat);
+
+/// Encoding marker for [`ArrayTreeFlatLayout`].
+#[derive(Debug)]
+pub struct ArrayTreeFlatLayoutEncoding;
+
+/// Flat-layout variant that retrieves its encoding tree from a sibling consolidated array
+/// rather than from a per-segment trailing flatbuffer.
+///
+/// At write time, the leaf strategy attaches the chunk's [`ColumnarArrayTree`] as transient
+/// state (consumed by the collector strategy in its post-write subtree walk).
+///
+/// At read time, the reader pulls a shared [`ArrayTreesSource`] from the
+/// [`LayoutReaderContext`] and resolves its tree by segment id. The source must be
+/// published by an ancestor [`super::ArrayTreeLayout`]; constructing a reader without one
+/// fails with a clear error.
+#[derive(Clone, Debug)]
+pub struct ArrayTreeFlatLayout {
+    inner: FlatLayout,
+    /// Transient write-time state: the leaf strategy attaches its [`ColumnarArrayTree`] for
+    /// the collector to pluck via [`Self::take_tree`]. `Mutex<Option<_>>` so the collector
+    /// can take ownership cheaply during its post-write walk. Read-path construction (via
+    /// `build`) leaves this `None`; the field is never serialized to disk.
+    tree: Arc<Mutex<Option<ColumnarArrayTree>>>,
+}
+
+impl ArrayTreeFlatLayout {
+    /// Creates a new layout from the inner flat layout without any attached tree.
+    pub fn new(inner: FlatLayout) -> Self {
+        Self {
+            inner,
+            tree: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Creates a new layout with an attached transient [`ColumnarArrayTree`]. Used only by
+    /// the array-tree writer; the tree is consumed by the collector and never serialized.
+    pub fn with_tree(inner: FlatLayout, tree: ColumnarArrayTree) -> Self {
+        Self {
+            inner,
+            tree: Arc::new(Mutex::new(Some(tree))),
+        }
+    }
+
+    /// Returns the inner flat layout.
+    pub fn inner(&self) -> &FlatLayout {
+        &self.inner
+    }
+
+    /// Take ownership of any attached transient tree, leaving `None` behind.
+    pub fn take_tree(&self) -> Option<ColumnarArrayTree> {
+        self.tree.lock().take()
+    }
+}
+
+impl VTable for ArrayTreeFlat {
+    type Layout = ArrayTreeFlatLayout;
+    type Encoding = ArrayTreeFlatLayoutEncoding;
+    type Metadata = EmptyMetadata;
+
+    fn id(_encoding: &Self::Encoding) -> LayoutId {
+        LayoutId::new_static("vortex.array_tree_flat")
+    }
+
+    fn encoding(_layout: &Self::Layout) -> LayoutEncodingRef {
+        LayoutEncodingRef::new_ref(ArrayTreeFlatLayoutEncoding.as_ref())
+    }
+
+    fn row_count(layout: &Self::Layout) -> u64 {
+        layout.inner.row_count()
+    }
+
+    fn dtype(layout: &Self::Layout) -> &DType {
+        layout.inner.dtype()
+    }
+
+    fn metadata(_layout: &Self::Layout) -> Self::Metadata {
+        EmptyMetadata
+    }
+
+    fn segment_ids(layout: &Self::Layout) -> Vec<SegmentId> {
+        vec![layout.inner.segment_id()]
+    }
+
+    fn nchildren(_layout: &Self::Layout) -> usize {
+        0
+    }
+
+    fn child(_layout: &Self::Layout, idx: usize) -> VortexResult<LayoutRef> {
+        vortex_bail!("ArrayTreeFlatLayout has no children, got index {}", idx)
+    }
+
+    fn child_type(_layout: &Self::Layout, idx: usize) -> LayoutChildType {
+        vortex_panic!("ArrayTreeFlatLayout has no children, got index {}", idx)
+    }
+
+    fn new_reader(
+        layout: &Self::Layout,
+        name: Arc<str>,
+        segment_source: Arc<dyn SegmentSource>,
+        session: &VortexSession,
+        ctx: &LayoutReaderContext,
+    ) -> VortexResult<LayoutReaderRef> {
+        let source = ctx.get::<ArrayTreesSource>(*ARRAY_TREES_SOURCE_ID).ok_or_else(|| {
+            vortex_error::vortex_err!(
+                "ArrayTreeFlatLayout requires an ancestor ArrayTreeLayout to publish an \
+                 ArrayTreesSource into the reader context; call \
+                 ArrayTreeLayout::derive_reader_ctx on each ArrayTreeLayout ancestor before \
+                 constructing a reader for this layout"
+            )
+        })?;
+        Ok(Arc::new(ArrayTreeFlatReader::new(
+            layout.clone(),
+            name,
+            segment_source,
+            session.clone(),
+            source,
+        )))
+    }
+
+    fn build(
+        _encoding: &Self::Encoding,
+        dtype: &DType,
+        row_count: u64,
+        _metadata: &EmptyMetadata,
+        segment_ids: Vec<SegmentId>,
+        _children: &dyn LayoutChildren,
+        ctx: &ReadContext,
+    ) -> VortexResult<Self::Layout> {
+        if segment_ids.len() != 1 {
+            vortex_bail!("ArrayTreeFlatLayout must have exactly one segment ID");
+        }
+        Ok(ArrayTreeFlatLayout::new(FlatLayout::new(
+            row_count,
+            dtype.clone(),
+            segment_ids[0],
+            ctx.clone(),
+        )))
+    }
+}

--- a/vortex-layout/src/layouts/array_tree/mod.rs
+++ b/vortex-layout/src/layouts/array_tree/mod.rs
@@ -123,10 +123,15 @@ impl ArrayTreeLayout {
     /// }
     /// ```
     ///
-    /// The List<> element types are exactly the canonical per-tree schemas defined by
-    /// [`vortex_array::serde::NODES_COLUMNS_DTYPE`] / [`vortex_array::serde::BUFFER_COLUMNS_DTYPE`],
-    /// so slicing one row's nodes (resp. buffers) yields a [`StructArray`] matching the inner
+    /// The List<> element types are produced by
+    /// [`vortex_array::serde::nodes_columns_dtype`] / [`vortex_array::serde::BUFFER_COLUMNS_DTYPE`].
+    /// Slicing one row's nodes (resp. buffers) yields a [`StructArray`] matching the inner
     /// shape of a [`ColumnarArrayTree`].
+    ///
+    /// The `nodes` schema is parameterized by the stat menu the layout tracks; today this
+    /// defaults to [`vortex_array::serde::DEFAULT_STATS`] (the historical 11-stat set), but
+    /// future writers can pick a different menu and the schema field names carry that menu
+    /// across the wire.
     pub fn array_trees_dtype() -> DType {
         let nn = Nullability::NonNullable;
         DType::Struct(
@@ -148,8 +153,9 @@ impl ArrayTreeLayout {
     }
 
     /// Derive a [`LayoutReaderContext`] that publishes an [`ArrayTreesSource`] backed by this
-    /// layout's auxiliary `array_trees` child. Descendant [`ArrayTreeFlatLayout`] readers
-    /// pull the source via `ctx.get::<ArrayTreesSource>()` to resolve their compact trees.
+    /// layout's auxiliary `array_trees` child under [`ARRAY_TREES_SOURCE_ID`]. Descendant
+    /// [`ArrayTreeFlatLayout`] readers pull the source by the same id to resolve their
+    /// compact trees.
     ///
     /// Used by:
     /// - The normal [`crate::VTable::new_reader`] dispatch on `ArrayTreeLayout` (production path).
@@ -273,8 +279,8 @@ impl VTable for ArrayTree {
 /// the cached map.
 ///
 /// Published by [`ArrayTreeLayout::derive_reader_ctx`] into the [`LayoutReaderContext`]
-/// passed to descendants; pulled by [`ArrayTreeFlatLayout`]'s reader via
-/// `ctx.get::<ArrayTreesSource>()`.
+/// passed to descendants under [`ARRAY_TREES_SOURCE_ID`]; pulled by
+/// [`ArrayTreeFlatLayout`]'s reader by the same id.
 pub struct ArrayTreesSource {
     reader: LayoutReaderRef,
     /// Session used to create execution contexts when canonicalizing the consolidated array

--- a/vortex-layout/src/layouts/array_tree/mod.rs
+++ b/vortex-layout/src/layouts/array_tree/mod.rs
@@ -1,0 +1,512 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Array tree layout: stores per-chunk encoding trees as one consolidated columnar struct
+//! array (one row per data segment), alongside the data layout itself. The leaves write only
+//! data buffers — their encoding-tree metadata (plus per-node stats and buffer descriptors)
+//! lives in the auxiliary `array_trees` child, which is BtrBlocks-compressed end-to-end. At
+//! read time, the source published by [`ArrayTreeLayout::new_reader`] resolves a segment id
+//! to its [`ColumnarArrayTree`] in one lookup, then [`ArrayTreeFlatReader`] pairs it with
+//! the fetched data segment for decode.
+
+mod flat;
+mod reader;
+pub mod writer;
+
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::sync::OnceLock;
+
+use futures::FutureExt;
+use vortex_array::EmptyMetadata;
+use vortex_array::Executable;
+use vortex_array::MaskFuture;
+use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::ListViewArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::Struct;
+use vortex_array::arrays::StructArray;
+use vortex_array::arrays::VarBinView;
+use vortex_array::arrays::VarBinViewArray;
+use vortex_array::arrays::list::ListArrayExt;
+use vortex_array::arrays::listview::list_from_list_view;
+use vortex_array::arrays::struct_::StructArrayExt;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::FieldName;
+use vortex_array::dtype::Nullability;
+use vortex_array::dtype::PType;
+use vortex_array::dtype::StructFields;
+use vortex_array::expr::root;
+use vortex_array::serde::BUFFER_COLUMNS_DTYPE;
+use vortex_array::serde::ColumnarArrayTree;
+use vortex_array::serde::DEFAULT_STATS;
+use vortex_array::serde::StatsColumns;
+use vortex_array::serde::nodes_columns_dtype;
+use vortex_error::SharedVortexResult;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
+use vortex_error::vortex_panic;
+use vortex_session::VortexSession;
+use vortex_session::registry::Id;
+use vortex_session::registry::ReadContext;
+use vortex_utils::aliases::hash_map::HashMap;
+
+pub use self::flat::ArrayTreeFlat;
+pub use self::flat::ArrayTreeFlatLayout;
+pub use self::flat::ArrayTreeFlatLayoutEncoding;
+use crate::LayoutChildType;
+use crate::LayoutEncodingRef;
+use crate::LayoutId;
+use crate::LayoutReaderContext;
+use crate::LayoutReaderRef;
+use crate::LayoutRef;
+use crate::VTable;
+use crate::children::LayoutChildren;
+use crate::children::OwnedLayoutChildren;
+use crate::layouts::array_tree::reader::ArrayTreeReader;
+use crate::segments::SegmentId;
+use crate::segments::SegmentSource;
+use crate::vtable;
+
+vtable!(ArrayTree);
+
+/// Well-known [`LayoutReaderContext`] key under which [`ArrayTreeLayout::derive_reader_ctx`]
+/// publishes its [`ArrayTreesSource`].
+///
+/// Both the publisher (parent [`ArrayTreeLayout`]) and the consumer
+/// ([`ArrayTreeFlatLayout`]'s `new_reader`) hardcode this id, so no metadata persistence is
+/// needed to bind them. Two stacked `ArrayTreeLayouts` both publish under this id; the
+/// inner one overrides the outer in the descendant's view — exactly the "nearest ancestor
+/// wins" semantic each `ArrayTreeFlat` leaf wants.
+pub static ARRAY_TREES_SOURCE_ID: LazyLock<Id> =
+    LazyLock::new(|| Id::new_static("vortex.array_tree.source"));
+
+/// Encoding marker for [`ArrayTreeLayout`].
+#[derive(Debug)]
+pub struct ArrayTreeLayoutEncoding;
+
+/// Stores per-chunk [`ColumnarArrayTree`]s as a consolidated columnar struct array, sharing
+/// schema (and compression) across all chunks.
+///
+/// # Children
+///
+/// - Child 0 (`Transparent "data"`): The actual data layout tree, with [`ArrayTreeFlatLayout`]
+///   at the leaves.
+/// - Child 1 (`Auxiliary "array_trees"`): A struct array (`{segment_id, nodes, buffers}`) with
+///   one row per data leaf; see [`Self::array_trees_dtype`] for the schema.
+#[derive(Clone, Debug)]
+pub struct ArrayTreeLayout {
+    dtype: DType,
+    children: Arc<dyn LayoutChildren>,
+}
+
+impl ArrayTreeLayout {
+    /// Creates a new `ArrayTreeLayout` from the data and array_trees children.
+    pub fn new(data: LayoutRef, array_trees: LayoutRef) -> Self {
+        Self {
+            dtype: data.dtype().clone(),
+            children: OwnedLayoutChildren::layout_children(vec![data, array_trees]),
+        }
+    }
+
+    /// Returns the dtype of the auxiliary `array_trees` child.
+    ///
+    /// The consolidated form is a struct array with one row per data-segment chunk:
+    ///
+    /// ```text
+    /// Struct {
+    ///   segment_id: u32,
+    ///   nodes: List<NODES_COLUMNS_DTYPE>,    // one element per ArrayNode in the chunk's tree
+    ///   buffers: List<BUFFER_COLUMNS_DTYPE>, // one element per data buffer for the chunk
+    /// }
+    /// ```
+    ///
+    /// The List<> element types are exactly the canonical per-tree schemas defined by
+    /// [`vortex_array::serde::NODES_COLUMNS_DTYPE`] / [`vortex_array::serde::BUFFER_COLUMNS_DTYPE`],
+    /// so slicing one row's nodes (resp. buffers) yields a [`StructArray`] matching the inner
+    /// shape of a [`ColumnarArrayTree`].
+    pub fn array_trees_dtype() -> DType {
+        let nn = Nullability::NonNullable;
+        DType::Struct(
+            StructFields::new(
+                vec![
+                    FieldName::from("segment_id"),
+                    FieldName::from("nodes"),
+                    FieldName::from("buffers"),
+                ]
+                .into(),
+                vec![
+                    DType::Primitive(PType::U32, nn),
+                    DType::List(Arc::new(nodes_columns_dtype(DEFAULT_STATS)), nn),
+                    DType::List(Arc::new(BUFFER_COLUMNS_DTYPE.clone()), nn),
+                ],
+            ),
+            nn,
+        )
+    }
+
+    /// Derive a [`LayoutReaderContext`] that publishes an [`ArrayTreesSource`] backed by this
+    /// layout's auxiliary `array_trees` child. Descendant [`ArrayTreeFlatLayout`] readers
+    /// pull the source via `ctx.get::<ArrayTreesSource>()` to resolve their compact trees.
+    ///
+    /// Used by:
+    /// - The normal [`crate::VTable::new_reader`] dispatch on `ArrayTreeLayout` (production path).
+    /// - Tools that construct readers at arbitrary points in the layout tree (explorers,
+    ///   debuggers): walk from the root to the target node, calling this method for each
+    ///   `ArrayTreeLayout` ancestor on the path so the accumulated ctx carries the right
+    ///   source when the leaf is finally constructed.
+    pub fn derive_reader_ctx(
+        &self,
+        name: &str,
+        segment_source: Arc<dyn SegmentSource>,
+        session: &VortexSession,
+        ctx: &LayoutReaderContext,
+    ) -> VortexResult<LayoutReaderContext> {
+        let array_trees_child = self.children.child(1, &Self::array_trees_dtype())?;
+        let trees_reader = array_trees_child.new_reader(
+            Arc::from(format!("{name}/array_trees")),
+            segment_source,
+            session,
+            ctx,
+        )?;
+        let source = Arc::new(ArrayTreesSource::new(trees_reader, session.clone()));
+        Ok(ctx.with(*ARRAY_TREES_SOURCE_ID, source))
+    }
+}
+
+impl VTable for ArrayTree {
+    type Layout = ArrayTreeLayout;
+    type Encoding = ArrayTreeLayoutEncoding;
+    type Metadata = EmptyMetadata;
+
+    fn id(_encoding: &Self::Encoding) -> LayoutId {
+        LayoutId::new_static("vortex.array_tree")
+    }
+
+    fn encoding(_layout: &Self::Layout) -> LayoutEncodingRef {
+        LayoutEncodingRef::new_ref(ArrayTreeLayoutEncoding.as_ref())
+    }
+
+    fn row_count(layout: &Self::Layout) -> u64 {
+        layout.children.child_row_count(0)
+    }
+
+    fn dtype(layout: &Self::Layout) -> &DType {
+        &layout.dtype
+    }
+
+    fn metadata(_layout: &Self::Layout) -> Self::Metadata {
+        EmptyMetadata
+    }
+
+    fn segment_ids(_layout: &Self::Layout) -> Vec<SegmentId> {
+        vec![]
+    }
+
+    fn nchildren(_layout: &Self::Layout) -> usize {
+        2
+    }
+
+    fn child(layout: &Self::Layout, idx: usize) -> VortexResult<LayoutRef> {
+        match idx {
+            0 => layout.children.child(0, &layout.dtype),
+            1 => layout.children.child(1, &Self::Layout::array_trees_dtype()),
+            _ => vortex_bail!("ArrayTreeLayout has 2 children, got index {}", idx),
+        }
+    }
+
+    fn child_type(_layout: &Self::Layout, idx: usize) -> LayoutChildType {
+        match idx {
+            0 => LayoutChildType::Transparent("data".into()),
+            1 => LayoutChildType::Auxiliary("array_trees".into()),
+            _ => vortex_panic!("ArrayTreeLayout has 2 children, got index {}", idx),
+        }
+    }
+
+    fn new_reader(
+        layout: &Self::Layout,
+        name: Arc<str>,
+        segment_source: Arc<dyn SegmentSource>,
+        session: &VortexSession,
+        ctx: &LayoutReaderContext,
+    ) -> VortexResult<LayoutReaderRef> {
+        let derived_ctx =
+            layout.derive_reader_ctx(&name, Arc::clone(&segment_source), session, ctx)?;
+        let data_child = Self::child(layout, 0)?;
+        let data_reader =
+            data_child.new_reader(Arc::clone(&name), segment_source, session, &derived_ctx)?;
+        Ok(Arc::new(ArrayTreeReader::new(name, data_reader)))
+    }
+
+    fn build(
+        _encoding: &Self::Encoding,
+        dtype: &DType,
+        _row_count: u64,
+        _metadata: &EmptyMetadata,
+        _segment_ids: Vec<SegmentId>,
+        children: &dyn LayoutChildren,
+        _ctx: &ReadContext,
+    ) -> VortexResult<Self::Layout> {
+        Ok(ArrayTreeLayout {
+            dtype: dtype.clone(),
+            children: children.to_arc(),
+        })
+    }
+
+    fn with_children(layout: &mut Self::Layout, children: Vec<LayoutRef>) -> VortexResult<()> {
+        if children.len() != 2 {
+            vortex_bail!(
+                "ArrayTreeLayout expects 2 children (data, array_trees), got {}",
+                children.len()
+            );
+        }
+        layout.children = OwnedLayoutChildren::layout_children(children);
+        Ok(())
+    }
+}
+
+/// Shared source for per-segment [`ColumnarArrayTree`]s. Holds a reader for the auxiliary
+/// `array_trees` child; on first lookup materializes the consolidated array and builds a
+/// `HashMap<SegmentId, Arc<ColumnarArrayTree>>`, then serves all subsequent lookups from
+/// the cached map.
+///
+/// Published by [`ArrayTreeLayout::derive_reader_ctx`] into the [`LayoutReaderContext`]
+/// passed to descendants; pulled by [`ArrayTreeFlatLayout`]'s reader via
+/// `ctx.get::<ArrayTreesSource>()`.
+pub struct ArrayTreesSource {
+    reader: LayoutReaderRef,
+    /// Session used to create execution contexts when canonicalizing the consolidated array
+    /// (its fields may be compressed, depending on the writer's `array_trees_strategy`).
+    session: VortexSession,
+    /// Lazily initialized shared future for the segment-keyed lookup map.
+    map: OnceLock<SharedSegmentMapFuture>,
+}
+
+type SharedSegmentMapFuture = futures::future::Shared<
+    futures::future::BoxFuture<
+        'static,
+        SharedVortexResult<Arc<HashMap<SegmentId, Arc<ColumnarArrayTree>>>>,
+    >,
+>;
+
+/// Future returned by [`ArrayTreesSource::get_for_segment`].
+pub type SharedSegmentTreeFuture = futures::future::Shared<
+    futures::future::BoxFuture<'static, SharedVortexResult<Arc<ColumnarArrayTree>>>,
+>;
+
+impl std::fmt::Debug for ArrayTreesSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ArrayTreesSource").finish_non_exhaustive()
+    }
+}
+
+impl ArrayTreesSource {
+    /// Creates a new source backed by the given array_trees reader and session.
+    pub fn new(reader: LayoutReaderRef, session: VortexSession) -> Self {
+        Self {
+            reader,
+            session,
+            map: OnceLock::new(),
+        }
+    }
+
+    /// Future resolving to the per-chunk [`ColumnarArrayTree`] for the given data-leaf segment.
+    ///
+    /// First call triggers materialization of the entire consolidated struct + lookup map;
+    /// subsequent calls reuse the cached map.
+    pub fn get_for_segment(&self, segment_id: SegmentId) -> SharedSegmentTreeFuture {
+        let map_fut = self.map_future();
+        async move {
+            let map = map_fut.await?;
+            map.get(&segment_id).cloned().ok_or_else(|| {
+                Arc::new(vortex_err!(
+                    "no columnar array tree found for segment id {}",
+                    *segment_id
+                ))
+            })
+        }
+        .boxed()
+        .shared()
+    }
+
+    fn map_future(&self) -> SharedSegmentMapFuture {
+        self.map
+            .get_or_init(|| {
+                let row_count = self.reader.row_count();
+                let reader = Arc::clone(&self.reader);
+                let session = self.session.clone();
+                async move {
+                    let array = reader
+                        .projection_evaluation(
+                            &(0..row_count),
+                            &root(),
+                            MaskFuture::new_true(
+                                usize::try_from(row_count)
+                                    .vortex_expect("row count must fit in usize"),
+                            ),
+                        )
+                        .map_err(Arc::new)?
+                        .await
+                        .map_err(Arc::new)?;
+                    let mut ctx = session.create_execution_ctx();
+                    build_segment_map(array, &mut ctx)
+                        .map(Arc::new)
+                        .map_err(Arc::new)
+                }
+                .boxed()
+                .shared()
+            })
+            .clone()
+    }
+}
+
+/// Decode the consolidated `array_trees` struct array into a per-segment lookup of
+/// [`ColumnarArrayTree`].
+///
+/// Canonicalizes each field once (it may be in a compressed encoding), then slices the
+/// per-row List<> ranges into typed columns and feeds them to
+/// [`ColumnarArrayTree::try_new`].
+fn build_segment_map(
+    array: vortex_array::ArrayRef,
+    ctx: &mut vortex_array::ExecutionCtx,
+) -> VortexResult<HashMap<SegmentId, Arc<ColumnarArrayTree>>> {
+    let outer = StructArray::execute(array, ctx)?;
+
+    let segment_ids = PrimitiveArray::execute(field_clone(&outer, "segment_id")?, ctx)?;
+    let segment_ids = segment_ids.as_slice::<u32>();
+
+    let nodes_view = field_clone(&outer, "nodes")?.execute::<ListViewArray>(ctx)?;
+    let nodes_list = list_from_list_view(nodes_view, ctx)?;
+    let nodes_inner = StructArray::execute(nodes_list.elements().clone(), ctx)?;
+    let nodes_cols = NodesColumns::extract(&nodes_inner, ctx)?;
+
+    let buffers_view = field_clone(&outer, "buffers")?.execute::<ListViewArray>(ctx)?;
+    let buffers_list = list_from_list_view(buffers_view, ctx)?;
+    let buffers_inner = StructArray::execute(buffers_list.elements().clone(), ctx)?;
+    let buffers_cols = BuffersColumns::extract(&buffers_inner, ctx)?;
+
+    let mut map = HashMap::with_capacity(segment_ids.len());
+    for (row, &seg) in segment_ids.iter().enumerate() {
+        let n_start = nodes_list.offset_at(row)?;
+        let n_end = nodes_list.offset_at(row + 1)?;
+        let b_start = buffers_list.offset_at(row)?;
+        let b_end = buffers_list.offset_at(row + 1)?;
+
+        let tree = nodes_cols.tree_at(&buffers_cols, n_start..n_end, b_start..b_end)?;
+        map.insert(SegmentId::from(seg), Arc::new(tree));
+    }
+    Ok(map)
+}
+
+fn field_clone(s: &StructArray, name: &str) -> VortexResult<vortex_array::ArrayRef> {
+    Ok(s.unmasked_field_by_name_opt(name)
+        .ok_or_else(|| vortex_err!("array_trees struct missing field '{}'", name))?
+        .clone())
+}
+
+/// Canonical typed handles into the nodes inner struct, plus a `tree_at` row-slice helper.
+struct NodesColumns {
+    encoding_ids: PrimitiveArray,
+    child_counts: PrimitiveArray,
+    metadata: VarBinViewArray,
+    buffers_per_node: PrimitiveArray,
+    subtree_sizes: PrimitiveArray,
+    buffer_offsets: PrimitiveArray,
+    stats: StructArray,
+}
+
+impl NodesColumns {
+    fn extract(inner: &StructArray, ctx: &mut vortex_array::ExecutionCtx) -> VortexResult<Self> {
+        Ok(Self {
+            encoding_ids: PrimitiveArray::execute(field_clone(inner, "encoding_id")?, ctx)?,
+            child_counts: PrimitiveArray::execute(field_clone(inner, "child_count")?, ctx)?,
+            metadata: VarBinViewArray::execute(field_clone(inner, "metadata")?, ctx)?,
+            buffers_per_node: PrimitiveArray::execute(
+                field_clone(inner, "buffers_per_node")?,
+                ctx,
+            )?,
+            subtree_sizes: PrimitiveArray::execute(field_clone(inner, "subtree_size")?, ctx)?,
+            buffer_offsets: PrimitiveArray::execute(field_clone(inner, "buffer_offset")?, ctx)?,
+            stats: StructArray::execute(field_clone(inner, "stats")?, ctx)?,
+        })
+    }
+
+    fn tree_at(
+        &self,
+        buffers: &BuffersColumns,
+        node_range: std::ops::Range<usize>,
+        buffer_range: std::ops::Range<usize>,
+    ) -> VortexResult<ColumnarArrayTree> {
+        let n_len = node_range.end - node_range.start;
+        let b_len = buffer_range.end - buffer_range.start;
+        ColumnarArrayTree::try_new(
+            slice_primitive(&self.encoding_ids, node_range.clone(), n_len)?,
+            slice_primitive(&self.child_counts, node_range.clone(), n_len)?,
+            slice_varbinview(&self.metadata, node_range.clone(), n_len)?,
+            slice_primitive(&self.buffers_per_node, node_range.clone(), n_len)?,
+            slice_primitive(&self.subtree_sizes, node_range.clone(), n_len)?,
+            slice_primitive(&self.buffer_offsets, node_range.clone(), n_len)?,
+            StatsColumns::new(slice_struct(&self.stats, node_range, n_len)?)?,
+            slice_primitive(&buffers.padding, buffer_range.clone(), b_len)?,
+            slice_primitive(&buffers.alignment_exponent, buffer_range.clone(), b_len)?,
+            slice_primitive(&buffers.length, buffer_range, b_len)?,
+        )
+    }
+}
+
+struct BuffersColumns {
+    padding: PrimitiveArray,
+    alignment_exponent: PrimitiveArray,
+    length: PrimitiveArray,
+}
+
+impl BuffersColumns {
+    fn extract(inner: &StructArray, ctx: &mut vortex_array::ExecutionCtx) -> VortexResult<Self> {
+        Ok(Self {
+            padding: PrimitiveArray::execute(field_clone(inner, "padding")?, ctx)?,
+            alignment_exponent: PrimitiveArray::execute(
+                field_clone(inner, "alignment_exponent")?,
+                ctx,
+            )?,
+            length: PrimitiveArray::execute(field_clone(inner, "length")?, ctx)?,
+        })
+    }
+}
+
+fn slice_primitive(
+    arr: &PrimitiveArray,
+    range: std::ops::Range<usize>,
+    expected_len: usize,
+) -> VortexResult<PrimitiveArray> {
+    let sliced = arr.as_ref().slice(range)?;
+    debug_assert_eq!(sliced.len(), expected_len);
+    sliced
+        .try_downcast::<vortex_array::arrays::Primitive>()
+        .map_err(|_| vortex_err!("sliced array_trees field is not a canonical PrimitiveArray"))
+}
+
+fn slice_varbinview(
+    arr: &VarBinViewArray,
+    range: std::ops::Range<usize>,
+    expected_len: usize,
+) -> VortexResult<VarBinViewArray> {
+    let sliced = arr.as_ref().slice(range)?;
+    debug_assert_eq!(sliced.len(), expected_len);
+    sliced
+        .try_downcast::<VarBinView>()
+        .map_err(|_| vortex_err!("sliced array_trees field is not a canonical VarBinViewArray"))
+}
+
+fn slice_struct(
+    arr: &StructArray,
+    range: std::ops::Range<usize>,
+    expected_len: usize,
+) -> VortexResult<StructArray> {
+    let sliced = arr.as_ref().slice(range)?;
+    debug_assert_eq!(sliced.len(), expected_len);
+    sliced
+        .try_downcast::<Struct>()
+        .map_err(|_| vortex_err!("sliced array_trees stats field is not a canonical StructArray"))
+}

--- a/vortex-layout/src/layouts/array_tree/reader.rs
+++ b/vortex-layout/src/layouts/array_tree/reader.rs
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::ops::BitAnd;
+use std::ops::Range;
+use std::sync::Arc;
+
+use futures::FutureExt;
+use vortex_array::MaskFuture;
+use vortex_array::VortexSessionExecute;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::FieldMask;
+use vortex_array::expr::Expression;
+use vortex_array::serde::ColumnarSerializedArray;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_mask::Mask;
+use vortex_session::VortexSession;
+
+use crate::LayoutReader;
+use crate::LayoutReaderRef;
+use crate::layouts::SharedArrayFuture;
+use crate::layouts::array_tree::ArrayTreesSource;
+use crate::layouts::array_tree::flat::ArrayTreeFlatLayout;
+use crate::reader::ArrayFuture;
+use crate::reader::RowSplits;
+use crate::reader::SplitRange;
+use crate::segments::SegmentSource;
+
+/// Transparent reader for [`super::ArrayTreeLayout`]. Delegates all operations to the data
+/// child reader; the auxiliary `array_trees` child is consumed at construction time (via
+/// [`super::ArrayTreeLayout::derive_reader_ctx`]) to publish the source descendants need.
+pub struct ArrayTreeReader {
+    name: Arc<str>,
+    data_reader: LayoutReaderRef,
+}
+
+impl ArrayTreeReader {
+    pub fn new(name: Arc<str>, data_reader: LayoutReaderRef) -> Self {
+        Self { name, data_reader }
+    }
+}
+
+impl LayoutReader for ArrayTreeReader {
+    fn name(&self) -> &Arc<str> {
+        &self.name
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn dtype(&self) -> &DType {
+        self.data_reader.dtype()
+    }
+
+    fn row_count(&self) -> u64 {
+        self.data_reader.row_count()
+    }
+
+    fn register_splits(
+        &self,
+        field_mask: &[FieldMask],
+        split_range: &SplitRange,
+        splits: &mut RowSplits,
+    ) -> VortexResult<()> {
+        self.data_reader
+            .register_splits(field_mask, split_range, splits)
+    }
+
+    fn pruning_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: Mask,
+    ) -> VortexResult<MaskFuture> {
+        self.data_reader.pruning_evaluation(row_range, expr, mask)
+    }
+
+    fn filter_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: MaskFuture,
+    ) -> VortexResult<MaskFuture> {
+        self.data_reader.filter_evaluation(row_range, expr, mask)
+    }
+
+    fn projection_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: MaskFuture,
+    ) -> VortexResult<ArrayFuture> {
+        self.data_reader
+            .projection_evaluation(row_range, expr, mask)
+    }
+}
+
+/// Mask-density threshold below which we evaluate expressions over the filtered subset and
+/// above which we evaluate over all rows then filter.
+const EXPR_EVAL_THRESHOLD: f64 = 0.2;
+
+/// Reader for [`ArrayTreeFlatLayout`]. Pulls its compact tree from the shared
+/// [`ArrayTreesSource`] (keyed by its own segment id) and pairs it with the fetched data
+/// segment for decode.
+pub struct ArrayTreeFlatReader {
+    layout: ArrayTreeFlatLayout,
+    name: Arc<str>,
+    segment_source: Arc<dyn SegmentSource>,
+    session: VortexSession,
+    source: Arc<ArrayTreesSource>,
+}
+
+impl ArrayTreeFlatReader {
+    pub(crate) fn new(
+        layout: ArrayTreeFlatLayout,
+        name: Arc<str>,
+        segment_source: Arc<dyn SegmentSource>,
+        session: VortexSession,
+        source: Arc<ArrayTreesSource>,
+    ) -> Self {
+        Self {
+            layout,
+            name,
+            segment_source,
+            session,
+            source,
+        }
+    }
+
+    /// Resolve the columnar array tree from the shared source and the data segment from the
+    /// segment source concurrently, then combine them into a decoded array.
+    fn array_future(&self) -> SharedArrayFuture {
+        let row_count = usize::try_from(self.layout.inner().row_count())
+            .vortex_expect("row count must fit in usize");
+
+        let segment_id = self.layout.inner().segment_id();
+        let segment_fut = self.segment_source.request(segment_id);
+        let tree_fut = self.source.get_for_segment(segment_id);
+
+        let ctx = self.layout.inner().array_ctx().clone();
+        let session = self.session.clone();
+        let dtype = self.layout.inner().dtype().clone();
+
+        async move {
+            let segment_fut = async move { segment_fut.await.map_err(Arc::new) };
+            let (segment, tree) = futures::try_join!(segment_fut, tree_fut)?;
+            let parts =
+                ColumnarSerializedArray::from_segment_and_tree(segment, tree).map_err(Arc::new)?;
+            parts
+                .decode(&dtype, row_count, &ctx, &session)
+                .map_err(Arc::new)
+        }
+        .boxed()
+        .shared()
+    }
+}
+
+impl LayoutReader for ArrayTreeFlatReader {
+    fn name(&self) -> &Arc<str> {
+        &self.name
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn dtype(&self) -> &DType {
+        self.layout.inner().dtype()
+    }
+
+    fn row_count(&self) -> u64 {
+        self.layout.inner().row_count()
+    }
+
+    fn register_splits(
+        &self,
+        _field_mask: &[FieldMask],
+        split_range: &SplitRange,
+        splits: &mut RowSplits,
+    ) -> VortexResult<()> {
+        split_range.check_bounds(self.layout.inner().row_count())?;
+        splits.push(split_range.root_row_range().end);
+        Ok(())
+    }
+
+    fn pruning_evaluation(
+        &self,
+        _row_range: &Range<u64>,
+        _expr: &Expression,
+        mask: Mask,
+    ) -> VortexResult<MaskFuture> {
+        Ok(MaskFuture::ready(mask))
+    }
+
+    fn filter_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: MaskFuture,
+    ) -> VortexResult<MaskFuture> {
+        let row_range = usize::try_from(row_range.start)
+            .vortex_expect("Row range begin must fit within layout size")
+            ..usize::try_from(row_range.end)
+                .vortex_expect("Row range end must fit within layout size");
+        let name = Arc::clone(&self.name);
+        let array = self.array_future();
+        let expr = expr.clone();
+        let session = self.session.clone();
+
+        Ok(MaskFuture::new(mask.len(), async move {
+            let mut array = array.clone().await?;
+            let mask = mask.await?;
+
+            if row_range.start > 0 || row_range.end < array.len() {
+                array = array.slice(row_range.clone())?;
+            }
+
+            let array_mask = if mask.density() < EXPR_EVAL_THRESHOLD {
+                let array = array.apply(&expr)?;
+                let array = array.filter(mask.clone())?;
+                let mut ctx = session.create_execution_ctx();
+                let array_mask = array.execute::<Mask>(&mut ctx)?;
+                mask.clone().intersect_by_rank(&array_mask)
+            } else {
+                let array = array.apply(&expr)?;
+                let mut ctx = session.create_execution_ctx();
+                let array_mask = array.execute::<Mask>(&mut ctx)?;
+                mask.clone().bitand(&array_mask)
+            };
+
+            tracing::debug!(
+                "ArrayTreeFlat mask evaluation {} - {} (mask = {}) => {}",
+                name,
+                expr,
+                mask.density(),
+                array_mask.density(),
+            );
+
+            Ok(array_mask)
+        }))
+    }
+
+    fn projection_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: MaskFuture,
+    ) -> VortexResult<ArrayFuture> {
+        let row_range = usize::try_from(row_range.start)
+            .vortex_expect("Row range begin must fit within layout size")
+            ..usize::try_from(row_range.end)
+                .vortex_expect("Row range end must fit within layout size");
+        let name = Arc::clone(&self.name);
+        let array = self.array_future();
+        let expr = expr.clone();
+
+        Ok(async move {
+            tracing::debug!("ArrayTreeFlat array evaluation {} - {}", name, expr);
+
+            let mut array = array.clone().await?;
+            let mask = mask.await?;
+
+            if row_range.start > 0 || row_range.end < array.len() {
+                array = array.slice(row_range.clone())?;
+            }
+
+            if !mask.all_true() {
+                array = array.filter(mask)?;
+            }
+
+            array = array.apply(&expr)?;
+            Ok(array)
+        }
+        .boxed())
+    }
+}

--- a/vortex-layout/src/layouts/array_tree/writer.rs
+++ b/vortex-layout/src/layouts/array_tree/writer.rs
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::StreamExt as _;
+use vortex_array::ArrayContext;
+use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::StructArray;
+use vortex_array::arrays::list::ListArray;
+use vortex_array::dtype::FieldName;
+use vortex_array::serde::ColumnarArrayTree;
+use vortex_array::serde::SerializeOptions;
+use vortex_array::serde::serialize_to_columnar_tree;
+use vortex_array::validity::Validity;
+use vortex_buffer::Buffer;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
+use vortex_session::VortexSession;
+use vortex_session::registry::ReadContext;
+
+use crate::IntoLayout;
+use crate::LayoutRef;
+use crate::LayoutStrategy;
+use crate::layouts::array_tree::ArrayTreeLayout;
+use crate::layouts::array_tree::flat::ArrayTreeFlat;
+use crate::layouts::array_tree::flat::ArrayTreeFlatLayout;
+use crate::layouts::flat::FlatLayout;
+use crate::layouts::flat::writer::FlatLayoutStrategy;
+use crate::segments::SegmentId;
+use crate::segments::SegmentSinkRef;
+use crate::sequence::SendableSequentialStream;
+use crate::sequence::SequencePointer;
+use crate::sequence::SequentialArrayStreamExt;
+
+/// Returns a `(collector, leaf)` pair of cooperating strategies for array-tree collection.
+///
+/// The leaf strategy replaces [`FlatLayoutStrategy`] in the data pipeline and attaches each
+/// chunk's [`ColumnarArrayTree`] to the resulting [`ArrayTreeFlatLayout`]. The collector
+/// wraps the data pipeline and, after it completes, walks the data subtree to extract those
+/// attached trees and writes them as a consolidated columnar struct array via the
+/// `array_trees_strategy` (typically the same compress-then-flat strategy used for data).
+///
+/// Why attach trees to the leaf layout rather than push to a shared sink: column writers in
+/// [`crate::layouts::table::TableStrategy`] run concurrently, and a shared sink would mix
+/// leaves across collector invocations. The leaf-attached design keeps every collector
+/// scoped to its own subtree.
+pub fn writer(
+    flat: FlatLayoutStrategy,
+    array_trees_strategy: Arc<dyn LayoutStrategy>,
+) -> (ArrayTreeCollectorStrategy, ArrayTreeFlatStrategy) {
+    let leaf = ArrayTreeFlatStrategy { flat };
+    let collector = ArrayTreeCollectorStrategy {
+        child: None,
+        array_trees_strategy,
+    };
+    (collector, leaf)
+}
+
+/// Leaf strategy (TX) that replaces [`FlatLayoutStrategy`].
+///
+/// Walks the chunk's array tree once via [`serialize_to_columnar_tree`] to produce data
+/// buffers and a [`ColumnarArrayTree`], writes the buffers as a data-only segment (no
+/// trailing flatbuffer), then attaches the tree to the returned layout for the collector to
+/// extract.
+#[derive(Clone)]
+pub struct ArrayTreeFlatStrategy {
+    flat: FlatLayoutStrategy,
+}
+
+#[async_trait]
+impl LayoutStrategy for ArrayTreeFlatStrategy {
+    async fn write_stream(
+        &self,
+        ctx: ArrayContext,
+        segment_sink: SegmentSinkRef,
+        mut stream: SendableSequentialStream,
+        _eof: SequencePointer,
+        session: &VortexSession,
+    ) -> VortexResult<LayoutRef> {
+        let ctx = ctx.clone();
+        let Some(chunk) = stream.next().await else {
+            vortex_bail!("array tree flat layout needs a single chunk");
+        };
+        let (sequence_id, chunk) = chunk?;
+
+        let row_count = chunk.len() as u64;
+
+        // Normalize if the flat strategy restricts encodings.
+        let chunk = if let Some(allowed) = &self.flat.allowed_encodings {
+            use vortex_array::normalize::NormalizeOptions;
+            use vortex_array::normalize::Operation;
+            chunk.normalize(&mut NormalizeOptions {
+                allowed,
+                operation: Operation::Error,
+            })?
+        } else {
+            chunk
+        };
+
+        // Single walk: data buffers + ColumnarArrayTree. No trailing flatbuffer in the
+        // segment — the consolidated array_trees segment is the sole source of encoding
+        // metadata for this leaf.
+        let (buffers, tree) = serialize_to_columnar_tree(
+            &chunk,
+            &ctx,
+            session,
+            &SerializeOptions {
+                offset: 0,
+                include_padding: self.flat.include_padding,
+            },
+        )?;
+
+        // IMPORTANT ORDERING CONSTRAINT: write the segment first, then advance past the
+        // sequence id. `segment_sink.write` consumes the SequenceId and only drops it on
+        // return; doing more work while holding it would let later leaves wait on
+        // SequenceId::collapse.
+        let segment_id = segment_sink.write(sequence_id, buffers).await?;
+
+        let None = stream.next().await else {
+            vortex_bail!("array tree flat layout received stream with more than a single chunk");
+        };
+
+        Ok(ArrayTreeFlatLayout::with_tree(
+            FlatLayout::new(
+                row_count,
+                stream.dtype().clone(),
+                segment_id,
+                ReadContext::new(ctx.to_ids()),
+            ),
+            tree,
+        )
+        .into_layout())
+    }
+
+    fn buffered_bytes(&self) -> u64 {
+        0
+    }
+}
+
+/// Collector strategy (RX) that wraps the data pipeline.
+///
+/// After the data child completes, walks the resulting subtree to extract each
+/// [`ArrayTreeFlatLayout`]'s attached [`ColumnarArrayTree`], builds the consolidated
+/// `{segment_id, nodes, buffers}` struct array (see [`ArrayTreeLayout::array_trees_dtype`]),
+/// and writes it via the configured `array_trees_strategy`.
+pub struct ArrayTreeCollectorStrategy {
+    child: Option<Arc<dyn LayoutStrategy>>,
+    array_trees_strategy: Arc<dyn LayoutStrategy>,
+}
+
+impl ArrayTreeCollectorStrategy {
+    /// Sets the data child pipeline that this collector wraps.
+    pub fn wrap(mut self, child: impl LayoutStrategy) -> Self {
+        self.child = Some(Arc::new(child));
+        self
+    }
+}
+
+#[async_trait]
+impl LayoutStrategy for ArrayTreeCollectorStrategy {
+    async fn write_stream(
+        &self,
+        ctx: ArrayContext,
+        segment_sink: SegmentSinkRef,
+        stream: SendableSequentialStream,
+        mut eof: SequencePointer,
+        session: &VortexSession,
+    ) -> VortexResult<LayoutRef> {
+        let Some(child) = self.child.as_ref() else {
+            vortex_bail!("ArrayTreeCollectorStrategy must have a child set via wrap()")
+        };
+
+        // Data segments get earlier sequence IDs than the consolidated array_trees segment.
+        let data_eof = eof.split_off();
+
+        let data_layout = child
+            .write_stream(
+                ctx.clone(),
+                Arc::clone(&segment_sink),
+                stream,
+                data_eof,
+                session,
+            )
+            .await?;
+
+        // Walk the data subtree to extract per-leaf trees. Each ArrayTreeFlatLayout leaf
+        // carries its tree attached as transient write-time state (not serialized to disk).
+        let mut entries: Vec<(SegmentId, ColumnarArrayTree)> = Vec::new();
+        for layout_ref in data_layout.depth_first_traversal() {
+            let layout_ref = layout_ref?;
+            if let Some(atf) = layout_ref.as_opt::<ArrayTreeFlat>()
+                && let Some(tree) = atf.take_tree()
+            {
+                entries.push((atf.inner().segment_id(), tree));
+            }
+        }
+
+        // Sort by segment ID so on-disk row order matches segment-write order.
+        entries.sort_by_key(|(seg, _)| *seg);
+
+        let array_trees_array = build_consolidated_array(&entries)?;
+
+        // Write the consolidated array via the array_trees strategy.
+        let trees_stream = array_trees_array
+            .to_array_stream()
+            .sequenced(eof.split_off());
+        let array_trees_layout = self
+            .array_trees_strategy
+            .write_stream(ctx, segment_sink, trees_stream, eof, session)
+            .await?;
+
+        Ok(ArrayTreeLayout::new(data_layout, array_trees_layout).into_layout())
+    }
+
+    fn buffered_bytes(&self) -> u64 {
+        self.child.as_ref().map(|c| c.buffered_bytes()).unwrap_or(0)
+            + self.array_trees_strategy.buffered_bytes()
+    }
+}
+
+/// Build the consolidated `{segment_id, nodes, buffers}` struct array from a sorted list of
+/// per-chunk entries. Each List<>'s elements are the concatenated per-chunk nodes (resp.
+/// buffers) struct arrays, with offsets recorded per row.
+fn build_consolidated_array(entries: &[(SegmentId, ColumnarArrayTree)]) -> VortexResult<ArrayRef> {
+    let nrows = entries.len();
+
+    let segment_ids: Buffer<u32> = entries.iter().map(|(seg, _)| **seg).collect();
+    let segment_ids_array = PrimitiveArray::new(segment_ids, Validity::NonNullable).into_array();
+
+    // Build the nodes list: concatenate every chunk's `tree.nodes` and record per-row offsets.
+    let mut nodes_offsets: Vec<i32> = Vec::with_capacity(nrows + 1);
+    nodes_offsets.push(0);
+    let mut cum: i32 = 0;
+    for (_, tree) in entries {
+        cum += i32::try_from(tree.nodes.as_ref().len())
+            .map_err(|_| vortex_err!("array tree node count overflows i32 offsets"))?;
+        nodes_offsets.push(cum);
+    }
+    let nodes_inner = StructArray::try_concat(entries.iter().map(|(_, t)| &t.nodes))?.into_array();
+    let nodes_list = ListArray::try_new(
+        nodes_inner,
+        PrimitiveArray::new(Buffer::from(nodes_offsets), Validity::NonNullable).into_array(),
+        Validity::NonNullable,
+    )?
+    .into_array();
+
+    // Build the buffers list: same pattern.
+    let mut buffers_offsets: Vec<i32> = Vec::with_capacity(nrows + 1);
+    buffers_offsets.push(0);
+    let mut cum: i32 = 0;
+    for (_, tree) in entries {
+        cum += i32::try_from(tree.buffers.as_ref().len())
+            .map_err(|_| vortex_err!("array tree buffer count overflows i32 offsets"))?;
+        buffers_offsets.push(cum);
+    }
+    let buffers_inner =
+        StructArray::try_concat(entries.iter().map(|(_, t)| &t.buffers))?.into_array();
+    let buffers_list = ListArray::try_new(
+        buffers_inner,
+        PrimitiveArray::new(Buffer::from(buffers_offsets), Validity::NonNullable).into_array(),
+        Validity::NonNullable,
+    )?
+    .into_array();
+
+    Ok(StructArray::try_new(
+        vec![
+            FieldName::from("segment_id"),
+            FieldName::from("nodes"),
+            FieldName::from("buffers"),
+        ]
+        .into(),
+        vec![segment_ids_array, nodes_list, buffers_list],
+        nrows,
+        Validity::NonNullable,
+    )?
+    .into_array())
+}

--- a/vortex-layout/src/layouts/mod.rs
+++ b/vortex-layout/src/layouts/mod.rs
@@ -8,6 +8,7 @@ use futures::future::Shared;
 use vortex_array::ArrayRef;
 use vortex_error::SharedVortexResult;
 
+pub mod array_tree;
 pub mod buffered;
 pub mod chunked;
 pub mod collect;

--- a/vortex-layout/src/session.rs
+++ b/vortex-layout/src/session.rs
@@ -9,6 +9,8 @@ use vortex_session::SessionVar;
 use vortex_session::registry::Registry;
 
 use crate::LayoutEncodingRef;
+use crate::layouts::array_tree::ArrayTreeFlatLayoutEncoding;
+use crate::layouts::array_tree::ArrayTreeLayoutEncoding;
 use crate::layouts::chunked::ChunkedLayoutEncoding;
 use crate::layouts::dict::DictLayoutEncoding;
 use crate::layouts::flat::FlatLayoutEncoding;
@@ -52,6 +54,14 @@ impl Default for LayoutSession {
         layouts.register(StructLayoutEncoding.id(), StructLayoutEncoding.as_ref());
         layouts.register(ZonedLayoutEncoding.id(), ZonedLayoutEncoding.as_ref());
         layouts.register(DictLayoutEncoding.id(), DictLayoutEncoding.as_ref());
+        layouts.register(
+            ArrayTreeLayoutEncoding.id(),
+            ArrayTreeLayoutEncoding.as_ref(),
+        );
+        layouts.register(
+            ArrayTreeFlatLayoutEncoding.id(),
+            ArrayTreeFlatLayoutEncoding.as_ref(),
+        );
 
         Self { registry: layouts }
     }


### PR DESCRIPTION
## Summary

Adds two new layouts, array tree layout and array tree flat layout. Latter writes the array node into a vortex array instead of serialising it into a flatbuffer, and the former collects all these columnar array nodes and creates one segment from them and writes at the end of the file, before the zone maps.

This replaces inlining the array nodes as flatbuffers to the footer