### PR TITLE
Fuse validity-aware min/max with the value conversion in primitive cast

### DIFF
--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -24,6 +24,7 @@ internals/session
 internals/async-runtime
 internals/vtables
 internals/execution
+internals/validity-iteration
 internals/io
 internals/serialization
 internals/cuda

--- a/docs/developer-guide/internals/validity-iteration.md
+++ b/docs/developer-guide/internals/validity-iteration.md
@@ -136,25 +136,33 @@ Decomposing checked `i32 + i32` (N=65,536; ns/elem; ratios matter, absolute numb
 
 | variant | density 1.0 | density 0.5 |
 | --- | --- | --- |
-| bare add (no validity, no overflow check) | 0.165 | 0.166 |
-| + overflow check, no validity | 0.174 (+6%) | 0.177 |
-| + validity (nullable, branch-free) | 0.503 (~3×) | 0.505 |
+| bare add (no validity, no overflow check) | 0.20 | 0.21 |
+| + overflow check, no validity | 0.20 (+1%) | 0.21 |
+| **+ validity, arrow-style (flat dense values, separate word-level `a & b`)** | **0.21 (+4%)** | **0.21** |
+| + validity *fused per-lane into the value loop* (anti-pattern) | 0.97 (~5×) | 0.97 |
 
-Two conclusions:
+Three conclusions:
 
-- **The overflow/fault check is essentially free** (~6% over a bare add) — it rides alongside the
-  arithmetic (`vpaddd` + `vpternlogd` + OR-reduce). Never avoid checking to "save time"; it costs
-  almost nothing when done branch-free.
-- **Validity handling is the expensive part (~3×)** — and it's the *bitmap* work (per-lane mask
-  read + writing the result null buffer), not the values. Both guarded forms are
-  density-independent.
+- **The overflow/fault check is essentially free** (~1% over a bare add) — it rides alongside the
+  arithmetic (`vpaddd` + `vpternlogd` + OR-reduce). Never avoid checking to "save time".
+- **For an elementwise op, validity is also nearly free (~4%)** *if done right*: keep the value
+  computation a **flat dense loop** (it vectorizes exactly like the non-nullable case) and produce
+  the result validity as a **separate word-level bitwise AND** of the input bitmaps. This is arrow's
+  strategy and there is no meaningful penalty for nullability.
+- **The ~5× cost is an anti-pattern, not inherent.** Fusing the per-lane validity bit into the
+  value loop (`for word { for j in 0..64 { … bit j … } }`) breaks vectorization of the arithmetic.
+  An earlier prototype did this and measured ~3–5× — the cost was the broken value loop, not the
+  validity. Do **not** thread the bitmap through the elementwise value loop.
 
-**Best of both:** the validity-free path is ~3× faster, so do not pay for validity when there are
-no nulls — dispatch on `Mask::AllTrue` once and run the validity-free kernel, paying the validity
-cost only when nulls are actually present. Vortex's `AllTrue`/`AllFalse`/`Values` match already
-does this; the measurement confirms it is worth keeping. The residual ~3× (when nulls *are*
-present) is the per-lane bitmap handling — reducible toward free only with AVX-512 mask registers
-(`kmov`/`kand`) or nightly `core::simd::Mask::from_bitmask`.
+**Reductions are different.** `sum`/`min`/`max`/`nan_count` *cannot* compute densely and AND
+bitmaps — they must skip null lanes inside the fold — so they pay a real (but density-independent)
+cost to gate, which is exactly why the branch-free fold above matters for them. For elementwise
+maps, prefer the dense-values + separate-bitmap split; for reductions, use the branch-free gated
+fold.
+
+For a *fallible* elementwise op (checked add/cast) the overflow-anywhere flag is computed ungated in
+the dense pass; only if it trips do you correlate fault-with-validity (rare), so the common path
+stays at the ~4% figure.
 
 ### Caveats learned the hard way
 

--- a/docs/developer-guide/internals/validity-iteration.md
+++ b/docs/developer-guide/internals/validity-iteration.md
@@ -102,6 +102,34 @@ lanes is exact and preserves order); `nan_count` is an order-independent count. 
 per-kernel branch-misprediction penalty at 50% nulls was 3–8× (`nan_count` 8×, `sum` 3.9×,
 `min_max` 3×) — that penalty is what the branch-free form removes.
 
+### Fallible elementwise: checked add with validity (prototype, N=65,536)
+
+A standalone prototype of `i32 + i32` with per-operand validity compared three strategies:
+
+| strategy | 100% valid | 50% valid |
+| --- | --- | --- |
+| naive per-lane zip + branch + early return | 1.61 ns/elem | 7.58 ns/elem |
+| arrow-style scalar valid-index gather (`try_for_each_valid_idx`) | 1.17 | 0.52 |
+| **dense branch-free (compute all, AND fault with validity, bail once)** | **0.27** | **0.28** |
+
+The dense form vectorizes to `vpaddd` + `vpternlogd` (the branch-free signed-overflow test
+`((x^s) & (y^s)) < 0` in one op) + `vpsrld` + `vporq`, and is **4.3× faster than arrow's approach**
+and density-independent. Note arrow-rs *cannot* do this for checked arithmetic: its `op` is a
+generic fallible closure that would trap on the garbage at null slots, so it gathers valid indices
+instead. Rust's non-trapping `i32::overflowing_add` (or the explicit sign test) lets us stay dense
+and branch-free — overflow at a *null* lane is computed but its fault bit is masked out by the
+`& validity` before the final bail. Result validity is the cheap word-wise `a_nulls & b_nulls`.
+
+### `take` / gather with validity
+
+Per arrow-rs (`arrow-select`) and confirmed by inspection, `take` is **gather-bound, not bitmap- or
+branch-bound**: gather the values (`out[i] = values[indices[i]]`) and build the result validity in
+a separate pass (gather the source validity bits at the indices, AND with the indices' own
+validity; when the source has no nulls, just propagate the indices' null buffer). No mainstream
+crate uses SIMD here — the random gather dominates — so the validity-iteration pattern above buys
+little; the win, if any, is a hardware gather (Vortex already has an AVX2 `take`). The "checked"
+part is an index bounds-check, which vectorizes trivially (`indices < len`, OR-reduced).
+
 ### Caveats learned the hard way
 
 - **Benchmark on the real build, not just a microbenchmark.** A "byte per 8 lanes" traversal that

--- a/docs/developer-guide/internals/validity-iteration.md
+++ b/docs/developer-guide/internals/validity-iteration.md
@@ -57,6 +57,25 @@ The rules, in order of impact:
 
 See the [`vortex_buffer::BitBuffer`] docs for the same guidance from the bitmap side.
 
+## Two shapes of kernel
+
+The right strategy depends on whether the kernel is a reduction or an elementwise map.
+
+- **Reductions** (`sum`, `min`/`max`, `nan_count`, the cast's range check) *must* consult validity
+  to skip null lanes. Use the word-chunked branch-free fold above: fold invalid lanes against a
+  neutral, accumulate, decide once.
+- **Elementwise maps** (`a + b`, `cast`, `take`) should **not** gate the value computation by
+  validity at all. Compute the result for *every* lane at full SIMD width — null-position values
+  are arbitrary but masked — and produce the result validity as a cheap, separate **bitwise op on
+  the input bitmaps** (e.g. `result_nulls = a_nulls & b_nulls`, a vectorized word-wise AND). This is
+  the approach arrow-rs uses for arithmetic (`arrow-arith`'s `binary`/`try_binary`), and it keeps
+  the hot value loop completely branch- and validity-free.
+
+  The only wrinkle is a **fallible** elementwise op (checked add, checked cast): an overflow at a
+  *null* lane must not error. Handle it exactly as the cast does — compute on all lanes, detect the
+  fault branch-free per lane, **AND the fault mask with validity**, and bail once at the end if any
+  *valid* lane faulted. Never branch on validity in the per-lane body.
+
 ## Evidence
 
 This pattern was validated while tuning the primitive cast kernel
@@ -70,6 +89,19 @@ idiom to the branch-free word-chunk form:
   from making the loop *branch-free* (the scalar convert was unchanged), so it is
   density-independent where the old branchy version got worse as nulls increased.
 
+The same rewrite on the nullable aggregate kernels (`aggregate_fn/fns/...`), benchmarked at N=100k,
+50% nulls, before → after:
+
+| kernel | before | after | speedup |
+| --- | --- | --- | --- |
+| `nan_count` (f64) | 140.7 µs | 79.3 µs | 1.77× |
+| `sum` (f64) | 720.9 µs | 430.5 µs | 1.67× |
+
+The branch-free `sum` is *bit-identical* to the old scalar version (adding `0.0` for invalid/NaN
+lanes is exact and preserves order); `nan_count` is an order-independent count. The measured
+per-kernel branch-misprediction penalty at 50% nulls was 3–8× (`nan_count` 8×, `sum` 3.9×,
+`min_max` 3×) — that penalty is what the branch-free form removes.
+
 ### Caveats learned the hard way
 
 - **Benchmark on the real build, not just a microbenchmark.** A "byte per 8 lanes" traversal that
@@ -81,6 +113,10 @@ idiom to the branch-free word-chunk form:
 - **End-to-end overhead can mask a kernel win.** `cast_u32_to_u8_nullable` barely moved end-to-end
   even though the kernel went scalar → SIMD, because that path is dominated by mask materialization
   and array construction, not the cast loop. Profile to confirm the kernel is the bottleneck.
+- **Beware the statistics cache when benchmarking aggregates.** Calling `sum`/`min_max`/`nan_count`
+  on a cloned array measures a cached-stat lookup (~100 ns for 100k elements), not the kernel.
+  Construct a fresh `PrimitiveArray` (cheap buffer/validity `clone`s) per timed iteration so the
+  stats cache is empty and the kernel actually runs.
 
 ## Rollout plan
 

--- a/docs/developer-guide/internals/validity-iteration.md
+++ b/docs/developer-guide/internals/validity-iteration.md
@@ -130,6 +130,32 @@ crate uses SIMD here — the random gather dominates — so the validity-iterati
 little; the win, if any, is a hardware gather (Vortex already has an AVX2 `take`). The "checked"
 part is an index bounds-check, which vectorizes trivially (`indices < len`, OR-reduced).
 
+### What does the validity guard actually cost?
+
+Decomposing checked `i32 + i32` (N=65,536; ns/elem; ratios matter, absolute numbers are machine-relative):
+
+| variant | density 1.0 | density 0.5 |
+| --- | --- | --- |
+| bare add (no validity, no overflow check) | 0.165 | 0.166 |
+| + overflow check, no validity | 0.174 (+6%) | 0.177 |
+| + validity (nullable, branch-free) | 0.503 (~3×) | 0.505 |
+
+Two conclusions:
+
+- **The overflow/fault check is essentially free** (~6% over a bare add) — it rides alongside the
+  arithmetic (`vpaddd` + `vpternlogd` + OR-reduce). Never avoid checking to "save time"; it costs
+  almost nothing when done branch-free.
+- **Validity handling is the expensive part (~3×)** — and it's the *bitmap* work (per-lane mask
+  read + writing the result null buffer), not the values. Both guarded forms are
+  density-independent.
+
+**Best of both:** the validity-free path is ~3× faster, so do not pay for validity when there are
+no nulls — dispatch on `Mask::AllTrue` once and run the validity-free kernel, paying the validity
+cost only when nulls are actually present. Vortex's `AllTrue`/`AllFalse`/`Values` match already
+does this; the measurement confirms it is worth keeping. The residual ~3× (when nulls *are*
+present) is the per-lane bitmap handling — reducible toward free only with AVX-512 mask registers
+(`kmov`/`kand`) or nightly `core::simd::Mask::from_bitmask`.
+
 ### Caveats learned the hard way
 
 - **Benchmark on the real build, not just a microbenchmark.** A "byte per 8 lanes" traversal that

--- a/docs/developer-guide/internals/validity-iteration.md
+++ b/docs/developer-guide/internals/validity-iteration.md
@@ -1,0 +1,111 @@
+# Validity-aware iteration
+
+Many compute and aggregate kernels walk a value buffer alongside a validity bitmap (a
+`vortex_mask::Mask` / `vortex_buffer::BitBuffer`, one bit per element). How the bitmap is
+traversed dominates the throughput of these kernels, and the naive idiom is several times slower
+than it needs to be. This page describes the fast pattern, the evidence behind it, and a plan to
+roll it out across the codebase.
+
+## The pattern
+
+**Slow (avoid):** zipping a per-bit `bool` iterator with the values and branching per lane.
+
+```rust
+// ❌ scalar, branchy — does not vectorize, degrades further as nulls appear
+for (v, valid) in values.iter().zip(mask.bit_buffer().iter()) {
+    if valid {
+        out.push(checked(v)?);   // per-element fallible op + early return
+    }
+}
+```
+
+This loses on three independent counts, each of which alone defeats the autovectorizer:
+
+1. a per-element fallible op with an early `return`/`?` inside the loop;
+2. a per-bit `bool` iterator (`bit_buffer().iter()`, `iter_bits`, `BitIterator`, `threshold_iter`);
+3. a data-dependent `if valid { … }` branch on the bit.
+
+**Fast (prefer):** consume the bitmap in 64-bit words via [`BitBuffer::chunks`], gate each lane
+branch-free, and decide once at the end.
+
+```rust
+// ✅ branch-free; vectorizes; cost is independent of null density
+for word in mask.bit_buffer().chunks().iter() {     // offset-normalized u64 words
+    for (j, &v) in block.iter().enumerate() {
+        let valid = (word >> j) & 1 != 0;
+        // gate with a SELECT, not a branch: fold invalid lanes against a neutral value
+        let folded = if valid { v } else { NEUTRAL };
+        acc = combine(acc, folded);                 // e.g. min/max/sum
+    }
+}
+// one check after the loop, never inside it
+```
+
+The rules, in order of impact:
+
+- **Never early-return / bail per element.** Accumulate a flag (or running min/max) and check once
+  after the loop. Early exits serialize the reduction.
+- **Walk the bitmap in word chunks, read the chunk once.** Use [`BitBuffer::chunks`] — it yields
+  offset-normalized `u64` words, so the same code is correct for sliced (bit-offset) buffers. Never
+  index `bits[i / 64] >> (i % 64)` inside the value loop.
+- **Gate with a select, not a branch.** Fold invalid lanes against a neutral that can't affect the
+  result (e.g. `+∞`/`T::MAX` for a running min, `T::MIN` for a max, `0` for a sum), or pre-zero the
+  invalid inputs. A branch on the validity word reintroduces misprediction on null-bearing data.
+- **Leave invalid output lanes as garbage when you can.** The result validity already hides them, so
+  masking/zeroing them is wasted work. (Zeroing the output is near-free only when the output type is
+  at least as wide as the validity granularity; for narrow outputs prefer zeroing the *input*.)
+
+See the [`vortex_buffer::BitBuffer`] docs for the same guidance from the bitmap side.
+
+## Evidence
+
+This pattern was validated while tuning the primitive cast kernel
+(`vortex-array/src/arrays/primitive/compute/cast.rs`). Rewriting the fallible path from the slow
+idiom to the branch-free word-chunk form:
+
+- **int → int (e.g. `u32 → u8`): scalar → SIMD.** The old kernel emitted a scalar byte loop with an
+  early-return branch (no vector instructions). The new kernel emits packed `vpmovdb` +
+  `vpminud`/`vpmaxud` + a mask-register select — pure safe Rust, no `std::arch`.
+- **nullable `f64 → i32`: ~493 µs → ~200 µs (≈2.4×)** at N=100k, 50% nulls. Notably this win came
+  from making the loop *branch-free* (the scalar convert was unchanged), so it is
+  density-independent where the old branchy version got worse as nulls increased.
+
+### Caveats learned the hard way
+
+- **Benchmark on the real build, not just a microbenchmark.** A "byte per 8 lanes" traversal that
+  read a flat `&[u8]` was faster in isolation, but re-deriving the byte from a `u64` chunk word
+  (`(word >> b*8) as u8`) *regressed* the real cast kernel (201 µs → 269 µs). It was reverted.
+- **Saturating `as` does not vectorize for float → int.** `v as i32` lowers to scalar
+  `vcvttsd2si` + clamp. Getting SIMD there needs `to_int_unchecked` after a branchless clamp (pure
+  Rust, vectorizes to `vcvttpd2dq`) or an `std::arch` backend — a separate, reviewed change.
+- **End-to-end overhead can mask a kernel win.** `cast_u32_to_u8_nullable` barely moved end-to-end
+  even though the kernel went scalar → SIMD, because that path is dominated by mask materialization
+  and array construction, not the cast loop. Profile to confirm the kernel is the bottleneck.
+
+## Rollout plan
+
+The goal is one shared, branch-free `(values, validity)` reducer/mapper rather than rewriting each
+kernel by hand — the same "avoid N bespoke kernels" principle the cast work demonstrated.
+
+1. **Extract a shared helper** (in `vortex-array`, near the aggregate plumbing, building on
+   [`BitBuffer::chunks`]) that drives a word-chunked, branch-free fold over `(values, validity)`
+   with a caller-supplied combine + neutral. Aggregates and simple masked maps route through it.
+2. **Retrofit the hottest sites first, each behind a benchmark.** For every site: add/keep a divan
+   bench, confirm scalar → SIMD in the emitted asm, and measure before/after on the real build.
+
+   Priority order (hottest first; these run on every scan batch):
+
+   | tier | sites |
+   | --- | --- |
+   | 1 — aggregates | `aggregate_fn/fns/sum/{primitive,decimal}.rs`, `aggregate_fn/fns/min_max/{primitive,decimal}.rs`, `aggregate_fn/fns/nan_count/primitive.rs` |
+   | 2 — metadata / strings / bridges | `aggregate_fn/fns/is_sorted/{primitive,bool,decimal}.rs`, `arrays/varbinview/compact.rs`, `vortex-duckdb/src/convert/vector.rs` |
+   | 3 — decompression | `encodings/runend/src/compress.rs`, `encodings/fastlanes/src/lib.rs` (`fill_null_forward`) |
+
+   `sum` and `min_max` (primitive + decimal) are the highest leverage; `min_max` is also the exact
+   reduction the cast kernel already does well, so it is the natural first consumer of the helper.
+3. **Don't trust unbenchmarked estimates.** Treat per-site projections as "worth measuring," not
+   promises — the cast work produced at least one change that looked good on paper and regressed in
+   practice.
+
+[`BitBuffer::chunks`]: https://docs.rs/vortex-buffer/latest/vortex_buffer/struct.BitBuffer.html
+[`vortex_buffer::BitBuffer`]: https://docs.rs/vortex-buffer/latest/vortex_buffer/struct.BitBuffer.html

--- a/encodings/fastlanes/src/lib.rs
+++ b/encodings/fastlanes/src/lib.rs
@@ -92,6 +92,11 @@ pub(crate) fn fill_forward_nulls<T: Copy + Default>(
             let mut last_valid = T::default();
             match values.try_into_mut() {
                 Ok(mut to_fill_mut) => {
+                    // TODO(perf): per-bit `zip` over validity is scalar. Forward-fill carries a
+                    // sequential dependency so it won't fully vectorize, but reading the bitmap a
+                    // word at a time (and skipping all-valid words, which need no fill) avoids the
+                    // per-lane bit extraction. See vortex-array
+                    // docs/developer-guide/internals/validity-iteration.md.
                     for (i, (v, is_valid)) in
                         to_fill_mut.iter_mut().zip(bit_buffer.iter()).enumerate()
                     {

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -233,6 +233,9 @@ fn runend_decode_slice<T: Copy + Default>(
         Mask::Values(mask) => {
             let mut decoded = BufferMut::with_capacity(length);
             let mut decoded_validity = BitBufferMut::with_capacity(length);
+            // TODO(perf): per-bit `zip` over the validity bitmap is scalar; this is on the
+            // decompression path. A word-chunked validity walk would vectorize the value handling.
+            // See vortex-array docs/developer-guide/internals/validity-iteration.md.
             for (end, value) in run_ends.zip_eq(
                 values
                     .iter()

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -102,6 +102,10 @@ name = "cast_primitive"
 harness = false
 
 [[bench]]
+name = "aggregate"
+harness = false
+
+[[bench]]
 name = "search_sorted"
 harness = false
 

--- a/vortex-array/benches/aggregate.rs
+++ b/vortex-array/benches/aggregate.rs
@@ -46,7 +46,9 @@ fn bench_agg<R>(bencher: Bencher, valid_pct: u32, f: impl Fn(&vortex_array::Arra
 
 fn inputs_i64(valid_frac: f64) -> (Buffer<i64>, Validity) {
     let mut rng = StdRng::seed_from_u64(7);
-    let values: Buffer<i64> = (0..N).map(|_| rng.random_range(-1_000_000i64..1_000_000)).collect();
+    let values: Buffer<i64> = (0..N)
+        .map(|_| rng.random_range(-1_000_000i64..1_000_000))
+        .collect();
     let validity = Validity::from_iter((0..N).map(|_| rng.random_bool(valid_frac)));
     (values, validity)
 }

--- a/vortex-array/benches/aggregate.rs
+++ b/vortex-array/benches/aggregate.rs
@@ -44,6 +44,24 @@ fn bench_agg<R>(bencher: Bencher, valid_pct: u32, f: impl Fn(&vortex_array::Arra
         .bench_refs(|a| f(a));
 }
 
+fn inputs_i64(valid_frac: f64) -> (Buffer<i64>, Validity) {
+    let mut rng = StdRng::seed_from_u64(7);
+    let values: Buffer<i64> = (0..N).map(|_| rng.random_range(-1_000_000i64..1_000_000)).collect();
+    let validity = Validity::from_iter((0..N).map(|_| rng.random_bool(valid_frac)));
+    (values, validity)
+}
+
+#[divan::bench(args = [100u32, 50])]
+fn sum_i64_nullable(bencher: Bencher, valid_pct: u32) {
+    let (values, validity) = inputs_i64(valid_pct as f64 / 100.0);
+    bencher
+        .with_inputs(|| PrimitiveArray::new(values.clone(), validity.clone()).into_array())
+        .bench_refs(|a| {
+            #[expect(clippy::unwrap_used)]
+            sum(a, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
+        });
+}
+
 #[divan::bench(args = [100u32, 50])]
 fn sum_f64_nullable(bencher: Bencher, valid_pct: u32) {
     bench_agg(bencher, valid_pct, |a| {

--- a/vortex-array/benches/aggregate.rs
+++ b/vortex-array/benches/aggregate.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use divan::Bencher;
+use rand::prelude::*;
+use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
+use vortex_array::aggregate_fn::fns::min_max::min_max;
+use vortex_array::aggregate_fn::fns::nan_count::nan_count;
+use vortex_array::aggregate_fn::fns::sum::sum;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::validity::Validity;
+use vortex_buffer::Buffer;
+
+fn main() {
+    divan::main();
+}
+
+const N: usize = 100_000;
+
+// Pre-build the value buffer and validity once; each timed iteration constructs a *fresh*
+// `PrimitiveArray` (cheap Arc clones) so the statistics cache is empty and the real kernel runs
+// instead of a cached-stat lookup.
+fn inputs(valid_frac: f64) -> (Buffer<f64>, Validity) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let values: Buffer<f64> = (0..N)
+        .map(|_| {
+            if rng.random_bool(0.01) {
+                f64::NAN
+            } else {
+                rng.random_range(-1e6..1e6)
+            }
+        })
+        .collect();
+    let validity = Validity::from_iter((0..N).map(|_| rng.random_bool(valid_frac)));
+    (values, validity)
+}
+
+fn bench_agg<R>(bencher: Bencher, valid_pct: u32, f: impl Fn(&vortex_array::ArrayRef) -> R + Sync) {
+    let (values, validity) = inputs(valid_pct as f64 / 100.0);
+    bencher
+        .with_inputs(|| PrimitiveArray::new(values.clone(), validity.clone()).into_array())
+        .bench_refs(|a| f(a));
+}
+
+#[divan::bench(args = [100u32, 50])]
+fn sum_f64_nullable(bencher: Bencher, valid_pct: u32) {
+    bench_agg(bencher, valid_pct, |a| {
+        #[expect(clippy::unwrap_used)]
+        sum(a, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
+    });
+}
+
+#[divan::bench(args = [100u32, 50])]
+fn nan_count_f64_nullable(bencher: Bencher, valid_pct: u32) {
+    bench_agg(bencher, valid_pct, |a| {
+        #[expect(clippy::unwrap_used)]
+        nan_count(a, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
+    });
+}
+
+#[divan::bench(args = [100u32, 50])]
+fn min_max_f64_nullable(bencher: Bencher, valid_pct: u32) {
+    bench_agg(bencher, valid_pct, |a| {
+        #[expect(clippy::unwrap_used)]
+        min_max(a, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
+    });
+}

--- a/vortex-array/benches/cast_primitive.rs
+++ b/vortex-array/benches/cast_primitive.rs
@@ -46,3 +46,58 @@ fn cast_u16_to_u32(bencher: Bencher) {
             .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
     });
 }
+
+/// Narrowing cast on nullable data with *no* precomputed stats: exercises the fused fallible
+/// kernel (validity-aware min/max + cast in one pass).
+#[divan::bench]
+fn cast_u32_to_u8_nullable(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let arr = PrimitiveArray::from_option_iter((0..N).map(|_| {
+        if rng.random_bool(0.5) {
+            None
+        } else {
+            Some(rng.random_range(0u32..=255))
+        }
+    }))
+    .into_array();
+    bencher.with_inputs(|| arr.clone()).bench_refs(|a| {
+        #[expect(clippy::unwrap_used)]
+        a.cast(DType::Primitive(PType::U8, Nullability::Nullable))
+            .unwrap()
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+    });
+}
+
+/// Float-to-int narrowing on nullable data with no precomputed stats.
+#[divan::bench]
+fn cast_f64_to_i32_nullable(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let arr = PrimitiveArray::from_option_iter((0..N).map(|_| {
+        if rng.random_bool(0.5) {
+            None
+        } else {
+            Some(rng.random_range(-1000.0f64..=1000.0))
+        }
+    }))
+    .into_array();
+    bencher.with_inputs(|| arr.clone()).bench_refs(|a| {
+        #[expect(clippy::unwrap_used)]
+        a.cast(DType::Primitive(PType::I32, Nullability::Nullable))
+            .unwrap()
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+    });
+}
+
+/// Float-to-int narrowing on dense (all-valid) data with no precomputed stats.
+#[divan::bench]
+fn cast_f64_to_i32_dense(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let arr = PrimitiveArray::from_iter((0..N).map(|_| rng.random_range(-1000.0f64..=1000.0)))
+        .into_array();
+    bencher.with_inputs(|| arr.clone()).bench_refs(|a| {
+        #[expect(clippy::unwrap_used)]
+        a.cast(DType::Primitive(PType::I32, Nullability::Nullable))
+            .unwrap()
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+    });
+}

--- a/vortex-array/src/aggregate_fn/fns/is_sorted/bool.rs
+++ b/vortex-array/src/aggregate_fn/fns/is_sorted/bool.rs
@@ -32,6 +32,8 @@ pub(super) fn check_bool_sorted(
             if strict {
                 let validity_buffer = mask_values.bit_buffer();
                 let values = array.to_bit_buffer();
+                // TODO(perf): per-bit `zip` of two bitmaps is scalar; a word-at-a-time scan over
+                // both bitmaps would vectorize. See docs/developer-guide/internals/validity-iteration.md.
                 Ok(validity_buffer
                     .iter()
                     .zip(values.iter())

--- a/vortex-array/src/aggregate_fn/fns/is_sorted/decimal.rs
+++ b/vortex-array/src/aggregate_fn/fns/is_sorted/decimal.rs
@@ -47,6 +47,9 @@ where
         }
         Mask::Values(mask_values) => {
             let values = array.buffer::<T>();
+            // TODO(perf): per-bit `zip` over the validity bitmap is scalar. Prefer a word-chunked
+            // walk (compare adjacent valid values branch-free). See
+            // docs/developer-guide/internals/validity-iteration.md.
             let iter = mask_values
                 .bit_buffer()
                 .iter()

--- a/vortex-array/src/aggregate_fn/fns/is_sorted/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/is_sorted/primitive.rs
@@ -44,6 +44,9 @@ fn compute_is_sorted<T: NativePType>(
             })
         }
         Mask::Values(mask_values) => {
+            // TODO(perf): per-bit `zip` over the validity bitmap is scalar and mispredicts on
+            // nulls. Prefer a word-chunked branch-free walk. See
+            // docs/developer-guide/internals/validity-iteration.md.
             let iter = mask_values
                 .bit_buffer()
                 .iter()

--- a/vortex-array/src/aggregate_fn/fns/min_max/decimal.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/decimal.rs
@@ -43,6 +43,10 @@ where
         {
             Mask::AllTrue(_) => compute_min_max(array.buffer::<D>().iter(), array.decimal_dtype()),
             Mask::AllFalse(_) => None,
+            // TODO(perf): the per-bit `zip + filter_map` is scalar and mispredicts on nulls. Port
+            // the branch-free neutral-replacement word-chunked min/max from the primitive `min_max`
+            // (vortex-array/src/aggregate_fn/fns/min_max/primitive.rs). See
+            // docs/developer-guide/internals/validity-iteration.md.
             Mask::Values(v) => compute_min_max(
                 array
                     .buffer::<D>()

--- a/vortex-array/src/aggregate_fn/fns/min_max/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/primitive.rs
@@ -73,7 +73,8 @@ fn minmax_all<T: NativePType + PartialOrd + Bounded>(values: &[T]) -> (T, T) {
 }
 
 /// Validity-gated min/max, branch-free: invalid lanes fold against neutral bounds (never winning),
-/// NaN is skipped. Word-chunked so it vectorizes regardless of null density.
+/// NaN is skipped. Uses the shared [`BitBuffer::zip_lanes`] word-chunked walk, so it vectorizes
+/// regardless of null density.
 #[multiversion::multiversion(targets("x86_64+avx512f", "x86_64+avx2", "aarch64+neon"))]
 fn minmax_masked<T: NativePType + PartialOrd + Bounded>(
     values: &[T],
@@ -83,25 +84,7 @@ fn minmax_masked<T: NativePType + PartialOrd + Bounded>(
     let lo = T::min_value();
     let mut vmin = hi;
     let mut vmax = lo;
-    let chunks = validity.chunks();
-    let mut base = 0usize;
-    for word in chunks.iter() {
-        for (j, &v) in values[base..base + 64].iter().enumerate() {
-            let valid = (word >> j) & 1 != 0;
-            let for_min = if valid { v } else { hi };
-            let for_max = if valid { v } else { lo };
-            if for_min < vmin {
-                vmin = for_min;
-            }
-            if for_max > vmax {
-                vmax = for_max;
-            }
-        }
-        base += 64;
-    }
-    let remainder = chunks.remainder_bits();
-    for (j, &v) in values[base..].iter().enumerate() {
-        let valid = (remainder >> j) & 1 != 0;
+    validity.zip_lanes(values, |v, valid| {
         let for_min = if valid { v } else { hi };
         let for_max = if valid { v } else { lo };
         if for_min < vmin {
@@ -110,6 +93,6 @@ fn minmax_masked<T: NativePType + PartialOrd + Bounded>(
         if for_max > vmax {
             vmax = for_max;
         }
-    }
+    });
     (vmin, vmax)
 }

--- a/vortex-array/src/aggregate_fn/fns/min_max/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/primitive.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use itertools::Itertools;
+use num_traits::Bounded;
+use vortex_buffer::BitBuffer;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
@@ -32,48 +33,83 @@ fn compute_min_max_with_validity<T>(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<MinMaxResult>>
 where
-    T: NativePType,
+    T: NativePType + PartialOrd + Bounded,
     PValue: From<T>,
 {
-    Ok(
-        match array
-            .as_ref()
-            .validity()?
-            .execute_mask(array.as_ref().len(), ctx)?
-        {
-            Mask::AllTrue(_) => compute_min_max(array.as_slice::<T>().iter()),
-            Mask::AllFalse(_) => None,
-            Mask::Values(v) => compute_min_max(
-                array
-                    .as_slice::<T>()
-                    .iter()
-                    .zip(v.bit_buffer().iter())
-                    .filter_map(|(v, m)| m.then_some(v)),
-            ),
-        },
-    )
+    let values = array.as_slice::<T>();
+    let (vmin, vmax) = match array
+        .as_ref()
+        .validity()?
+        .execute_mask(array.as_ref().len(), ctx)?
+    {
+        Mask::AllTrue(_) => minmax_all(values),
+        Mask::AllFalse(_) => return Ok(None),
+        Mask::Values(v) => minmax_masked(values, v.bit_buffer()),
+    };
+    // Neutral seeds invert (`vmin > vmax`) exactly when no non-NaN value was folded, so this both
+    // detects the empty/all-NaN case and produces the result otherwise.
+    Ok((vmin <= vmax).then(|| MinMaxResult {
+        min: Scalar::primitive(vmin, NonNullable),
+        max: Scalar::primitive(vmax, NonNullable),
+    }))
 }
 
-fn compute_min_max<'a, T>(iter: impl Iterator<Item = &'a T>) -> Option<MinMaxResult>
-where
-    T: NativePType,
-    PValue: From<T>,
-{
-    match iter
-        .filter(|v| !v.is_nan())
-        .minmax_by(|a, b| a.total_compare(**b))
-    {
-        itertools::MinMaxResult::NoElements => None,
-        itertools::MinMaxResult::OneElement(&x) => {
-            let scalar = Scalar::primitive(x, NonNullable);
-            Some(MinMaxResult {
-                min: scalar.clone(),
-                max: scalar,
-            })
+/// Plain-comparison min/max over all values, skipping NaN (NaN fails both comparisons). For every
+/// non-NaN input this matches the previous `total_compare`-based result; `±0.0` ties are
+/// numerically equal and not distinguished, which is irrelevant to callers (range pruning, casts).
+#[multiversion::multiversion(targets("x86_64+avx512f", "x86_64+avx2", "aarch64+neon"))]
+fn minmax_all<T: NativePType + PartialOrd + Bounded>(values: &[T]) -> (T, T) {
+    let mut vmin = T::max_value();
+    let mut vmax = T::min_value();
+    for &v in values {
+        if v < vmin {
+            vmin = v;
         }
-        itertools::MinMaxResult::MinMax(&min, &max) => Some(MinMaxResult {
-            min: Scalar::primitive(min, NonNullable),
-            max: Scalar::primitive(max, NonNullable),
-        }),
+        if v > vmax {
+            vmax = v;
+        }
     }
+    (vmin, vmax)
+}
+
+/// Validity-gated min/max, branch-free: invalid lanes fold against neutral bounds (never winning),
+/// NaN is skipped. Word-chunked so it vectorizes regardless of null density.
+#[multiversion::multiversion(targets("x86_64+avx512f", "x86_64+avx2", "aarch64+neon"))]
+fn minmax_masked<T: NativePType + PartialOrd + Bounded>(
+    values: &[T],
+    validity: &BitBuffer,
+) -> (T, T) {
+    let hi = T::max_value();
+    let lo = T::min_value();
+    let mut vmin = hi;
+    let mut vmax = lo;
+    let chunks = validity.chunks();
+    let mut base = 0usize;
+    for word in chunks.iter() {
+        for (j, &v) in values[base..base + 64].iter().enumerate() {
+            let valid = (word >> j) & 1 != 0;
+            let for_min = if valid { v } else { hi };
+            let for_max = if valid { v } else { lo };
+            if for_min < vmin {
+                vmin = for_min;
+            }
+            if for_max > vmax {
+                vmax = for_max;
+            }
+        }
+        base += 64;
+    }
+    let remainder = chunks.remainder_bits();
+    for (j, &v) in values[base..].iter().enumerate() {
+        let valid = (remainder >> j) & 1 != 0;
+        let for_min = if valid { v } else { hi };
+        let for_max = if valid { v } else { lo };
+        if for_min < vmin {
+            vmin = for_min;
+        }
+        if for_max > vmax {
+            vmax = for_max;
+        }
+    }
+    (vmin, vmax)
 }

--- a/vortex-array/src/aggregate_fn/fns/nan_count/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/nan_count/primitive.rs
@@ -27,12 +27,29 @@ fn compute_nan_count_with_validity<T: NativePType>(values: &[T], validity: Mask)
     match validity {
         Mask::AllTrue(_) => values.iter().filter(|v| v.is_nan()).count(),
         Mask::AllFalse(_) => 0,
-        Mask::Values(v) => values
-            .iter()
-            .zip(v.bit_buffer().iter())
-            .filter_map(|(v, m)| m.then_some(v))
-            .filter(|v| v.is_nan())
-            .count(),
+        // Branch-free, word-chunked: `count += valid_bit & is_nan` accumulates an order-independent
+        // count with no per-lane branch, so it does not mispredict on null-bearing data. See the
+        // `BitBuffer` docs for the general pattern.
+        Mask::Values(v) => {
+            let bits = v.bit_buffer();
+            let chunks = bits.chunks();
+            let mut count = 0usize;
+            let mut base = 0usize;
+            for word in chunks.iter() {
+                let block = &values[base..base + 64];
+                let mut c = 0u32;
+                for (j, x) in block.iter().enumerate() {
+                    c += (((word >> j) & 1) as u32) & (x.is_nan() as u32);
+                }
+                count += c as usize;
+                base += 64;
+            }
+            let remainder = chunks.remainder_bits();
+            for (j, x) in values[base..].iter().enumerate() {
+                count += ((((remainder >> j) & 1) as u32) & (x.is_nan() as u32)) as usize;
+            }
+            count
+        }
     }
 }
 

--- a/vortex-array/src/aggregate_fn/fns/nan_count/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/nan_count/primitive.rs
@@ -27,27 +27,13 @@ fn compute_nan_count_with_validity<T: NativePType>(values: &[T], validity: Mask)
     match validity {
         Mask::AllTrue(_) => values.iter().filter(|v| v.is_nan()).count(),
         Mask::AllFalse(_) => 0,
-        // Branch-free, word-chunked: `count += valid_bit & is_nan` accumulates an order-independent
-        // count with no per-lane branch, so it does not mispredict on null-bearing data. See the
-        // `BitBuffer` docs for the general pattern.
+        // Branch-free: `count += valid & is_nan` is an order-independent count with no per-lane
+        // branch, so it does not mispredict on null-bearing data. See the `BitBuffer` docs.
         Mask::Values(v) => {
-            let bits = v.bit_buffer();
-            let chunks = bits.chunks();
             let mut count = 0usize;
-            let mut base = 0usize;
-            for word in chunks.iter() {
-                let block = &values[base..base + 64];
-                let mut c = 0u32;
-                for (j, x) in block.iter().enumerate() {
-                    c += (((word >> j) & 1) as u32) & (x.is_nan() as u32);
-                }
-                count += c as usize;
-                base += 64;
-            }
-            let remainder = chunks.remainder_bits();
-            for (j, x) in values[base..].iter().enumerate() {
-                count += ((((remainder >> j) & 1) as u32) & (x.is_nan() as u32)) as usize;
-            }
+            v.bit_buffer().zip_lanes(values, |x, valid| {
+                count += (valid & x.is_nan()) as usize;
+            });
             count
         }
     }

--- a/vortex-array/src/aggregate_fn/fns/sum/decimal.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/decimal.rs
@@ -97,6 +97,10 @@ where
     bool: AsPrimitive<I>,
 {
     let mut sum = initial;
+    // TODO(perf): per-bit `zip(validity)` does not vectorize and mispredicts on null-bearing data.
+    // Apply the branch-free word-chunked validity walk (read the bitmap a u64/byte at a time, fold
+    // invalid lanes against 0) like the primitive `sum`. See
+    // docs/developer-guide/internals/validity-iteration.md.
     for (v, valid) in values.iter().zip_eq(validity) {
         let v: I = v.as_() * valid.as_();
 

--- a/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use itertools::Itertools;
 use num_traits::ToPrimitive;
 use vortex_buffer::BitBuffer;
 use vortex_error::VortexExpect;
@@ -79,27 +78,13 @@ fn accumulate_primitive_valid(
 ) -> VortexResult<bool> {
     match inner {
         SumState::Unsigned(acc) => match_each_native_ptype!(p.ptype(),
-            unsigned: |T| {
-                for (&v, valid) in p.as_slice::<T>().iter().zip_eq(validity.iter()) {
-                    if valid && checked_add_u64(acc, v.to_u64().vortex_expect("unsigned to u64")) {
-                        return Ok(true);
-                    }
-                }
-                Ok(false)
-            },
+            unsigned: |T| { accumulate_unsigned_valid(acc, p.as_slice::<T>(), validity) },
             signed: |_T| { vortex_panic!("unsigned sum state with signed input") },
             floating: |_T| { vortex_panic!("unsigned sum state with float input") }
         ),
         SumState::Signed(acc) => match_each_native_ptype!(p.ptype(),
             unsigned: |_T| { vortex_panic!("signed sum state with unsigned input") },
-            signed: |T| {
-                for (&v, valid) in p.as_slice::<T>().iter().zip_eq(validity.iter()) {
-                    if valid && checked_add_i64(acc, v.to_i64().vortex_expect("signed to i64")) {
-                        return Ok(true);
-                    }
-                }
-                Ok(false)
-            },
+            signed: |T| { accumulate_signed_valid(acc, p.as_slice::<T>(), validity) },
             floating: |_T| { vortex_panic!("signed sum state with float input") }
         ),
         SumState::Float(acc) => match_each_native_ptype!(p.ptype(),
@@ -135,6 +120,67 @@ fn accumulate_float_valid<T: NativePType>(acc: &mut f64, values: &[T], validity:
         let wide = ToPrimitive::to_f64(&value).vortex_expect("float to f64");
         *acc += if keep { wide } else { 0.0 };
     }
+}
+
+/// Branch-free validity-gated unsigned sum: invalid lanes add 0 (a select, not a branch), so the
+/// per-lane validity branch — which mispredicts badly on null-bearing data — is removed. The only
+/// remaining branch is the effectively-never-taken checked-overflow bail. Result is identical to
+/// the scalar `if valid { checked_add(v) }` loop (adding 0 cannot overflow).
+fn accumulate_unsigned_valid<T: NativePType>(
+    acc: &mut u64,
+    values: &[T],
+    validity: &BitBuffer,
+) -> VortexResult<bool> {
+    let chunks = validity.chunks();
+    let mut base = 0usize;
+    for word in chunks.iter() {
+        for (lane, &v) in values[base..base + 64].iter().enumerate() {
+            let raw = v.to_u64().vortex_expect("unsigned to u64");
+            let add = if (word >> lane) & 1 != 0 { raw } else { 0 };
+            if checked_add_u64(acc, add) {
+                return Ok(true);
+            }
+        }
+        base += 64;
+    }
+    let remainder = chunks.remainder_bits();
+    for (lane, &v) in values[base..].iter().enumerate() {
+        let raw = v.to_u64().vortex_expect("unsigned to u64");
+        let add = if (remainder >> lane) & 1 != 0 { raw } else { 0 };
+        if checked_add_u64(acc, add) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Branch-free validity-gated signed sum; see [`accumulate_unsigned_valid`].
+fn accumulate_signed_valid<T: NativePType>(
+    acc: &mut i64,
+    values: &[T],
+    validity: &BitBuffer,
+) -> VortexResult<bool> {
+    let chunks = validity.chunks();
+    let mut base = 0usize;
+    for word in chunks.iter() {
+        for (lane, &v) in values[base..base + 64].iter().enumerate() {
+            let raw = v.to_i64().vortex_expect("signed to i64");
+            let add = if (word >> lane) & 1 != 0 { raw } else { 0 };
+            if checked_add_i64(acc, add) {
+                return Ok(true);
+            }
+        }
+        base += 64;
+    }
+    let remainder = chunks.remainder_bits();
+    for (lane, &v) in values[base..].iter().enumerate() {
+        let raw = v.to_i64().vortex_expect("signed to i64");
+        let add = if (remainder >> lane) & 1 != 0 { raw } else { 0 };
+        if checked_add_i64(acc, add) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 #[cfg(test)]

--- a/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
@@ -3,6 +3,7 @@
 
 use itertools::Itertools;
 use num_traits::ToPrimitive;
+use vortex_buffer::BitBuffer;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
@@ -13,6 +14,7 @@ use super::checked_add_i64;
 use super::checked_add_u64;
 use crate::ExecutionCtx;
 use crate::arrays::PrimitiveArray;
+use crate::dtype::NativePType;
 use crate::match_each_native_ptype;
 
 pub(super) fn accumulate_primitive(
@@ -73,7 +75,7 @@ fn accumulate_primitive_all(inner: &mut SumState, p: &PrimitiveArray) -> VortexR
 fn accumulate_primitive_valid(
     inner: &mut SumState,
     p: &PrimitiveArray,
-    validity: &vortex_buffer::BitBuffer,
+    validity: &BitBuffer,
 ) -> VortexResult<bool> {
     match inner {
         SumState::Unsigned(acc) => match_each_native_ptype!(p.ptype(),
@@ -104,15 +106,34 @@ fn accumulate_primitive_valid(
             unsigned: |_T| { vortex_panic!("float sum state with unsigned input") },
             signed: |_T| { vortex_panic!("float sum state with signed input") },
             floating: |T| {
-                for (&v, valid) in p.as_slice::<T>().iter().zip_eq(validity.iter()) {
-                    if valid && !v.is_nan() {
-                        *acc += ToPrimitive::to_f64(&v).vortex_expect("float to f64");
-                    }
-                }
+                accumulate_float_valid(acc, p.as_slice::<T>(), validity);
                 Ok(false)
             }
         ),
         SumState::Decimal { .. } => vortex_panic!("decimal sum state with primitive input"),
+    }
+}
+
+/// Branch-free, word-chunked float sum over valid lanes. Invalid or NaN lanes contribute `0.0`,
+/// which is exact and preserves the left-to-right summation order, so the result is bit-identical
+/// to a scalar `if valid && !nan { acc += v }` loop — but without a per-lane branch that
+/// mispredicts on null-bearing data. See the `BitBuffer` docs for the general pattern.
+fn accumulate_float_valid<T: NativePType>(acc: &mut f64, values: &[T], validity: &BitBuffer) {
+    let chunks = validity.chunks();
+    let mut base = 0usize;
+    for word in chunks.iter() {
+        for (lane, &value) in values[base..base + 64].iter().enumerate() {
+            let keep = (((word >> lane) & 1) != 0) & !value.is_nan();
+            let wide = ToPrimitive::to_f64(&value).vortex_expect("float to f64");
+            *acc += if keep { wide } else { 0.0 };
+        }
+        base += 64;
+    }
+    let remainder = chunks.remainder_bits();
+    for (lane, &value) in values[base..].iter().enumerate() {
+        let keep = (((remainder >> lane) & 1) != 0) & !value.is_nan();
+        let wide = ToPrimitive::to_f64(&value).vortex_expect("float to f64");
+        *acc += if keep { wide } else { 0.0 };
     }
 }
 

--- a/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
@@ -99,27 +99,16 @@ fn accumulate_primitive_valid(
     }
 }
 
-/// Branch-free, word-chunked float sum over valid lanes. Invalid or NaN lanes contribute `0.0`,
-/// which is exact and preserves the left-to-right summation order, so the result is bit-identical
-/// to a scalar `if valid && !nan { acc += v }` loop — but without a per-lane branch that
-/// mispredicts on null-bearing data. See the `BitBuffer` docs for the general pattern.
+/// Branch-free float sum over valid lanes. Invalid or NaN lanes contribute `0.0`, which is exact
+/// and preserves the left-to-right summation order, so the result is bit-identical to a scalar
+/// `if valid && !nan { acc += v }` loop — but without a per-lane branch that mispredicts on
+/// null-bearing data. Uses the shared [`BitBuffer::zip_lanes`] walk.
 fn accumulate_float_valid<T: NativePType>(acc: &mut f64, values: &[T], validity: &BitBuffer) {
-    let chunks = validity.chunks();
-    let mut base = 0usize;
-    for word in chunks.iter() {
-        for (lane, &value) in values[base..base + 64].iter().enumerate() {
-            let keep = (((word >> lane) & 1) != 0) & !value.is_nan();
-            let wide = ToPrimitive::to_f64(&value).vortex_expect("float to f64");
-            *acc += if keep { wide } else { 0.0 };
-        }
-        base += 64;
-    }
-    let remainder = chunks.remainder_bits();
-    for (lane, &value) in values[base..].iter().enumerate() {
-        let keep = (((remainder >> lane) & 1) != 0) & !value.is_nan();
+    validity.zip_lanes(values, |value, valid| {
+        let keep = valid & !value.is_nan();
         let wide = ToPrimitive::to_f64(&value).vortex_expect("float to f64");
         *acc += if keep { wide } else { 0.0 };
-    }
+    });
 }
 
 /// Branch-free validity-gated unsigned sum: invalid lanes add 0 (a select, not a branch), so the

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -198,44 +198,38 @@ where
 /// Fused cast + validity-aware min/max. Writes `values as T` into `dst` for every lane, but folds
 /// only lanes whose validity bit is set into the returned min/max (NaN excluded). Invalid lanes
 /// may hold out-of-range values; those are masked out and never affect the bounds.
+///
+/// The lane gating is branch-free (invalid lanes are folded against neutral bounds rather than
+/// skipped) so the loop vectorizes regardless of null density — a data-dependent branch on the
+/// validity word would otherwise serialize the reduction whenever nulls are present.
 #[multiversion::multiversion(targets("x86_64+avx512f", "x86_64+avx2", "aarch64+neon"))]
 fn cast_and_bounds_masked<F, T>(values: &[F], validity: &BitBuffer, dst: &mut [T]) -> Option<(F, F)>
 where
     F: NativePType + AsPrimitive<T> + PartialOrd + Bounded,
     T: NativePType,
 {
-    let mut vmin = F::max_value();
-    let mut vmax = F::min_value();
+    // Invalid lanes fold against these neutrals, which can never win the min/max. A valid NaN
+    // fails both comparisons and is skipped, matching `min_max`'s NaN filtering.
+    let hi_neutral = F::max_value();
+    let lo_neutral = F::min_value();
+    let mut vmin = hi_neutral;
+    let mut vmax = lo_neutral;
 
     let chunks = validity.chunks();
     let mut base = 0usize;
     for word in chunks.iter() {
         let vblk = &values[base..base + 64];
         let oblk = &mut dst[base..base + 64];
-        // Cast all 64 lanes unconditionally; this vectorizes regardless of validity.
-        for (out, &v) in oblk.iter_mut().zip(vblk) {
+        for (j, (out, &v)) in oblk.iter_mut().zip(vblk).enumerate() {
             *out = v.as_();
-        }
-        if word == u64::MAX {
-            // Whole chunk valid: a plain branch-free min/max that the compiler can vectorize.
-            for &v in vblk {
-                if v < vmin {
-                    vmin = v;
-                }
-                if v > vmax {
-                    vmax = v;
-                }
+            let valid = (word >> j) & 1 != 0;
+            let for_min = if valid { v } else { hi_neutral };
+            let for_max = if valid { v } else { lo_neutral };
+            if for_min < vmin {
+                vmin = for_min;
             }
-        } else if word != 0 {
-            for (j, &v) in vblk.iter().enumerate() {
-                if (word >> j) & 1 != 0 {
-                    if v < vmin {
-                        vmin = v;
-                    }
-                    if v > vmax {
-                        vmax = v;
-                    }
-                }
+            if for_max > vmax {
+                vmax = for_max;
             }
         }
         base += 64;
@@ -249,13 +243,14 @@ where
         .enumerate()
     {
         *out = v.as_();
-        if (remainder >> j) & 1 != 0 {
-            if v < vmin {
-                vmin = v;
-            }
-            if v > vmax {
-                vmax = v;
-            }
+        let valid = (remainder >> j) & 1 != 0;
+        let for_min = if valid { v } else { hi_neutral };
+        let for_max = if valid { v } else { lo_neutral };
+        if for_min < vmin {
+            vmin = for_min;
+        }
+        if for_max > vmax {
+            vmax = for_max;
         }
     }
 

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -161,6 +161,13 @@ where
     unsafe { out.set_len(len) };
     let dst = out.as_mut_slice();
 
+    // TODO(perf): the `Mask::Values` arm runs a validity-gated min/max reduction. A prototype
+    // showed a faster "split" form (measured ~2x for nullable f64->i32, see
+    // docs/developer-guide/internals/validity-iteration.md): compute the DENSE min/max ignoring
+    // validity (`cast_and_bounds_all`) first — if it fits `T`, every valid value fits too, so skip
+    // the gated pass entirely; only fall back to the gated `cast_and_bounds_masked` when the dense
+    // bounds don't fit. A further ~7x for float->int needs a vectorized convert (clamp +
+    // `to_int_unchecked` -> `vcvttpd2dq`) with per-pair NaN->0 handling (separate, `unsafe`).
     let bounds = match &mask {
         Mask::AllTrue(_) => cast_and_bounds_all::<F, T>(values, dst),
         Mask::AllFalse(_) => {

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -2,12 +2,12 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use num_traits::AsPrimitive;
-use num_traits::NumCast;
+use num_traits::Bounded;
+use vortex_buffer::BitBuffer;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
-use vortex_error::vortex_err;
 use vortex_mask::Mask;
 
 use crate::ArrayRef;
@@ -25,6 +25,8 @@ use crate::dtype::PType;
 use crate::expr::stats::Stat;
 use crate::expr::stats::StatsProvider;
 use crate::match_each_native_ptype;
+use crate::scalar::PValue;
+use crate::scalar::Scalar;
 use crate::scalar_fn::fns::cast::CastKernel;
 use crate::scalar_fn::fns::cast::CastReduce;
 use crate::validity::Validity;
@@ -102,23 +104,23 @@ impl CastKernel for Primitive {
     }
 }
 
-/// Cast values from `F` to `T`. For infallible casts this is a pure pass; for fallible casts
-/// each valid value goes through a checked `NumCast::from` and the kernel bails if any of them
-/// overflow `T`. Invalid positions use the wrapping `as` cast since their values are masked out.
+/// Cast values from `F` to `T`. For infallible casts this is a pure pass; for fallible casts the
+/// kernel fuses the conversion with a validity-aware min/max reduction over the source and bails
+/// if those bounds don't fit `T`.
 fn cast_values<F, T>(
     array: ArrayView<'_, Primitive>,
     new_validity: Validity,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef>
 where
-    F: NativePType + AsPrimitive<T>,
+    F: NativePType + AsPrimitive<T> + PartialOrd + Bounded + Into<PValue>,
     T: NativePType,
 {
     let values = array.as_slice::<F>();
 
     // Fast path: statically infallible, or cached min/max prove every valid value fits in `T`.
     // The cached check never triggers a stats computation — if the bounds aren't already known
-    // we fall through to the per-lane loop below.
+    // we fall through to the fused kernel below.
     if values_always_fit(F::PTYPE, T::PTYPE) || values_fit_in(array, T::PTYPE, ctx, false) {
         return Ok(PrimitiveArray::new(cast::<F, T>(values), new_validity).into_array());
     }
@@ -126,33 +128,138 @@ where
     // TODO(joe): if the values source and target have the same bit-width we can
     // mutate in place.
 
-    // Fallible: invalid lanes are pre-multiplied to zero so the checked cast always succeeds for
-    // them; valid lanes go through `NumCast::from` and the whole cast bails on the first overflow.
-    let mask = array.validity()?.execute_mask(array.len(), ctx)?;
-    let overflow = || {
-        vortex_err!(
-            Compute: "Cannot cast {} to {} — value exceeds target range",
-            F::PTYPE, T::PTYPE,
-        )
-    };
-    let buffer: Buffer<T> = match &mask {
-        Mask::AllTrue(_) => BufferMut::try_from_trusted_len_iter(
-            values
-                .iter()
-                .map(|&v| <T as NumCast>::from(v).ok_or_else(overflow)),
-        )?
-        .freeze(),
-        Mask::AllFalse(_) => BufferMut::<T>::zeroed(values.len()).freeze(),
-        Mask::Values(m) => BufferMut::try_from_trusted_len_iter(
-            values.iter().zip(m.bit_buffer().iter()).map(|(&v, valid)| {
-                let factor = if valid { F::one() } else { F::zero() };
-                <T as NumCast>::from(v * factor).ok_or_else(overflow)
-            }),
-        )?
-        .freeze(),
+    // Fallible path. A value can only exceed `T`'s range if it is strictly below the smallest or
+    // above the largest *valid* value, so a single validity-aware min/max over the source fully
+    // decides whether the cast can overflow. We fuse that reduction with the value conversion in
+    // one SIMD-friendly pass: every lane is cast unconditionally (out-of-range values at invalid
+    // positions wrap/saturate harmlessly under `as` and are masked out), while the running min/max
+    // folds only valid, non-NaN lanes. If the resulting bounds don't fit `T`, the cast bails.
+    let len = values.len();
+    let mask = array.validity()?.execute_mask(len, ctx)?;
+
+    let mut out = BufferMut::<T>::with_capacity(len);
+    // SAFETY: `T` is a primitive numeric type for which every bit pattern is valid, and every
+    // element of `dst` is written exactly once below before the buffer is frozen and read.
+    unsafe { out.set_len(len) };
+    let dst = out.as_mut_slice();
+
+    let bounds = match &mask {
+        Mask::AllTrue(_) => cast_and_bounds_all::<F, T>(values, dst),
+        Mask::AllFalse(_) => {
+            dst.fill(T::default());
+            None
+        }
+        Mask::Values(m) => cast_and_bounds_masked::<F, T>(values, m.bit_buffer(), dst),
     };
 
-    Ok(PrimitiveArray::new(buffer, new_validity).into_array())
+    if let Some((min, max)) = bounds {
+        let target = DType::Primitive(T::PTYPE, Nullability::NonNullable);
+        let fits = |v: F| {
+            Scalar::primitive(v, Nullability::NonNullable)
+                .cast(&target)
+                .is_ok()
+        };
+        if !fits(min) || !fits(max) {
+            vortex_bail!(
+                Compute: "Cannot cast {} to {} — value exceeds target range",
+                F::PTYPE, T::PTYPE,
+            );
+        }
+    }
+
+    Ok(PrimitiveArray::new(out.freeze(), new_validity).into_array())
+}
+
+/// Fused cast + min/max for an all-valid run. Writes `values as T` into `dst` and returns the
+/// numeric min/max of `values`, ignoring NaN. Returns `None` when there is no non-NaN value (so
+/// the caller skips the range check, since nothing can be out of range).
+#[multiversion::multiversion(targets("x86_64+avx512f", "x86_64+avx2", "aarch64+neon"))]
+fn cast_and_bounds_all<F, T>(values: &[F], dst: &mut [T]) -> Option<(F, F)>
+where
+    F: NativePType + AsPrimitive<T> + PartialOrd + Bounded,
+    T: NativePType,
+{
+    let mut vmin = F::max_value();
+    let mut vmax = F::min_value();
+    for (out, &v) in dst.iter_mut().zip(values) {
+        *out = v.as_();
+        // NaN fails both comparisons and is therefore skipped, matching `min_max` semantics.
+        if v < vmin {
+            vmin = v;
+        }
+        if v > vmax {
+            vmax = v;
+        }
+    }
+    // `vmin <= vmax` holds exactly when at least one non-NaN value was folded.
+    (vmin <= vmax).then_some((vmin, vmax))
+}
+
+/// Fused cast + validity-aware min/max. Writes `values as T` into `dst` for every lane, but folds
+/// only lanes whose validity bit is set into the returned min/max (NaN excluded). Invalid lanes
+/// may hold out-of-range values; those are masked out and never affect the bounds.
+#[multiversion::multiversion(targets("x86_64+avx512f", "x86_64+avx2", "aarch64+neon"))]
+fn cast_and_bounds_masked<F, T>(values: &[F], validity: &BitBuffer, dst: &mut [T]) -> Option<(F, F)>
+where
+    F: NativePType + AsPrimitive<T> + PartialOrd + Bounded,
+    T: NativePType,
+{
+    let mut vmin = F::max_value();
+    let mut vmax = F::min_value();
+
+    let chunks = validity.chunks();
+    let mut base = 0usize;
+    for word in chunks.iter() {
+        let vblk = &values[base..base + 64];
+        let oblk = &mut dst[base..base + 64];
+        // Cast all 64 lanes unconditionally; this vectorizes regardless of validity.
+        for (out, &v) in oblk.iter_mut().zip(vblk) {
+            *out = v.as_();
+        }
+        if word == u64::MAX {
+            // Whole chunk valid: a plain branch-free min/max that the compiler can vectorize.
+            for &v in vblk {
+                if v < vmin {
+                    vmin = v;
+                }
+                if v > vmax {
+                    vmax = v;
+                }
+            }
+        } else if word != 0 {
+            for (j, &v) in vblk.iter().enumerate() {
+                if (word >> j) & 1 != 0 {
+                    if v < vmin {
+                        vmin = v;
+                    }
+                    if v > vmax {
+                        vmax = v;
+                    }
+                }
+            }
+        }
+        base += 64;
+    }
+
+    // Trailing lanes that don't fill a 64-bit chunk.
+    let remainder = chunks.remainder_bits();
+    for (j, (&v, out)) in values[base..]
+        .iter()
+        .zip(dst[base..].iter_mut())
+        .enumerate()
+    {
+        *out = v.as_();
+        if (remainder >> j) & 1 != 0 {
+            if v < vmin {
+                vmin = v;
+            }
+            if v > vmax {
+                vmax = v;
+            }
+        }
+    }
+
+    (vmin <= vmax).then_some((vmin, vmax))
 }
 
 /// Out-of-range values at invalid positions are truncated/wrapped by `as`, which is fine because
@@ -452,6 +559,70 @@ mod test {
             casted,
             PrimitiveArray::from_option_iter([None, Some(10u8), Some(42)])
         );
+        Ok(())
+    }
+
+    /// Fused fallible path: a *valid* out-of-range value must make the cast fail, even when an
+    /// invalid lane also holds an out-of-range value.
+    #[test]
+    fn cast_masked_valid_out_of_range_errors() {
+        let arr = PrimitiveArray::new(
+            buffer![1000u32, 300u32, 42u32],
+            Validity::from_iter([false, true, true]),
+        );
+        #[expect(deprecated)]
+        let err = arr
+            .into_array()
+            .cast(DType::Primitive(PType::U8, Nullability::Nullable))
+            .and_then(|a| a.to_canonical().map(|c| c.into_array()))
+            .unwrap_err();
+        assert!(matches!(err, VortexError::Compute(..)));
+        assert!(err.to_string().contains("exceeds target range"));
+    }
+
+    /// Fused fallible path with no nulls: an out-of-range value must fail.
+    #[test]
+    fn cast_all_valid_out_of_range_errors() {
+        let arr = buffer![10u32, 1000u32, 42u32].into_array();
+        #[expect(deprecated)]
+        let err = arr
+            .cast(PType::U8.into())
+            .and_then(|a| a.to_canonical().map(|c| c.into_array()))
+            .unwrap_err();
+        assert!(matches!(err, VortexError::Compute(..)));
+    }
+
+    /// Float-to-int through the fused path: out-of-range and non-finite *valid* values fail,
+    /// while the same garbage at invalid positions is harmless.
+    #[test]
+    fn cast_f64_to_i32_masked() -> vortex_error::VortexResult<()> {
+        // The invalid lane holds a value far outside i32 range; it must not trigger an error.
+        let arr = PrimitiveArray::new(
+            buffer![1e18f64, -5.0, 7.0],
+            Validity::from_iter([false, true, true]),
+        );
+        #[expect(deprecated)]
+        let casted = arr
+            .into_array()
+            .cast(DType::Primitive(PType::I32, Nullability::Nullable))?
+            .to_primitive();
+        assert_arrays_eq!(
+            casted,
+            PrimitiveArray::from_option_iter([None, Some(-5i32), Some(7)])
+        );
+
+        // A valid out-of-range float must fail.
+        let arr = PrimitiveArray::new(
+            buffer![1.0f64, 1e18, 7.0],
+            Validity::from_iter([true, true, true]),
+        );
+        #[expect(deprecated)]
+        let err = arr
+            .into_array()
+            .cast(DType::Primitive(PType::I32, Nullability::Nullable))
+            .and_then(|a| a.to_canonical().map(|c| c.into_array()))
+            .unwrap_err();
+        assert!(matches!(err, VortexError::Compute(..)));
         Ok(())
     }
 

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -107,6 +107,24 @@ impl CastKernel for Primitive {
 /// Cast values from `F` to `T`. For infallible casts this is a pure pass; for fallible casts the
 /// kernel fuses the conversion with a validity-aware min/max reduction over the source and bails
 /// if those bounds don't fit `T`.
+///
+/// Performance notes learned while tuning this path:
+/// * **The convert dominates; the overflow check is nearly free.** A branch-free range/`min-max`
+///   reduction folded into the same pass costs only a few ALU ops on top of the bare cast, so it
+///   is never worth a separate pass over the data.
+/// * **Invalid lanes are left as garbage on purpose.** We convert every lane unconditionally —
+///   out-of-range values at invalid positions wrap/saturate harmlessly and are hidden by the
+///   result validity, so masking or zeroing them would only add work. (Zeroing the *output* is
+///   close to free when `T` is at least as wide as the validity granularity, but costs extra when
+///   `T` is a narrow type because the masked store can't fold into the narrowing pack; prefer
+///   gating the *input* if zeroed nulls are ever required.)
+/// * **Decide overflow from the valid min/max, not per element.** A value can only exceed `T`'s
+///   range if it is below the smallest or above the largest valid value, so two `Scalar::cast`
+///   boundary checks at the end suffice and stay consistent with the cached fast path.
+/// * **Never bail per element / never early-return inside the loop** — that serializes the
+///   reduction. Accumulate and check once at the end.
+///
+/// See [`vortex_buffer::BitBuffer`] for the bitmap-traversal guidance the masked kernel relies on.
 fn cast_values<F, T>(
     array: ArrayView<'_, Primitive>,
     new_validity: Validity,
@@ -199,9 +217,13 @@ where
 /// only lanes whose validity bit is set into the returned min/max (NaN excluded). Invalid lanes
 /// may hold out-of-range values; those are masked out and never affect the bounds.
 ///
-/// The lane gating is branch-free (invalid lanes are folded against neutral bounds rather than
-/// skipped) so the loop vectorizes regardless of null density — a data-dependent branch on the
-/// validity word would otherwise serialize the reduction whenever nulls are present.
+/// Two structural choices keep this vectorizing regardless of null density:
+/// * The lane gating is branch-free — invalid lanes fold against neutral bounds rather than being
+///   skipped — so a data-dependent branch on the validity word never serializes the reduction.
+/// * Validity is consumed one byte (8 lanes) at a time rather than shifting the 64-bit word per
+///   lane. Reading the byte once lets the backend materialize the lane predicate from a broadcast
+///   plus a constant bit selector (or a mask register) instead of a per-lane variable shift, which
+///   is markedly faster on null-bearing data. See `BitBuffer` docs for the general pattern.
 #[multiversion::multiversion(targets("x86_64+avx512f", "x86_64+avx2", "aarch64+neon"))]
 fn cast_and_bounds_masked<F, T>(values: &[F], validity: &BitBuffer, dst: &mut [T]) -> Option<(F, F)>
 where
@@ -215,21 +237,26 @@ where
     let mut vmin = hi_neutral;
     let mut vmax = lo_neutral;
 
+    // `BitChunks` yields offset-normalized 64-bit words, so byte `b` of `word` holds the validity
+    // for the 8 lanes starting at `base + b * 8` — correct even for sliced (bit-offset) buffers.
     let chunks = validity.chunks();
     let mut base = 0usize;
     for word in chunks.iter() {
-        let vblk = &values[base..base + 64];
-        let oblk = &mut dst[base..base + 64];
-        for (j, (out, &v)) in oblk.iter_mut().zip(vblk).enumerate() {
-            *out = v.as_();
-            let valid = (word >> j) & 1 != 0;
-            let for_min = if valid { v } else { hi_neutral };
-            let for_max = if valid { v } else { lo_neutral };
-            if for_min < vmin {
-                vmin = for_min;
-            }
-            if for_max > vmax {
-                vmax = for_max;
+        for b in 0..8usize {
+            let byte = (word >> (b * 8)) as u8;
+            let blk = base + b * 8;
+            for j in 0..8usize {
+                let v = values[blk + j];
+                dst[blk + j] = v.as_();
+                let valid = (byte >> j) & 1 != 0;
+                let for_min = if valid { v } else { hi_neutral };
+                let for_max = if valid { v } else { lo_neutral };
+                if for_min < vmin {
+                    vmin = for_min;
+                }
+                if for_max > vmax {
+                    vmax = for_max;
+                }
             }
         }
         base += 64;

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -217,13 +217,13 @@ where
 /// only lanes whose validity bit is set into the returned min/max (NaN excluded). Invalid lanes
 /// may hold out-of-range values; those are masked out and never affect the bounds.
 ///
-/// Two structural choices keep this vectorizing regardless of null density:
-/// * The lane gating is branch-free — invalid lanes fold against neutral bounds rather than being
-///   skipped — so a data-dependent branch on the validity word never serializes the reduction.
-/// * Validity is consumed one byte (8 lanes) at a time rather than shifting the 64-bit word per
-///   lane. Reading the byte once lets the backend materialize the lane predicate from a broadcast
-///   plus a constant bit selector (or a mask register) instead of a per-lane variable shift, which
-///   is markedly faster on null-bearing data. See `BitBuffer` docs for the general pattern.
+/// The lane gating is branch-free — invalid lanes fold against neutral bounds rather than being
+/// skipped — so a data-dependent branch on the validity word never serializes the reduction, and
+/// the loop vectorizes at any null density. Validity is consumed a 64-bit word at a time via
+/// [`BitChunks`], which is the fastest traversal measured here. (A byte-per-8-lane variant that
+/// reads each byte out of the word looks appealing on paper, and helps when validity is a real
+/// `&[u8]` slice, but extracting the byte from the offset-normalized word regressed this kernel —
+/// see `BitBuffer` docs for the general guidance and that caveat.)
 #[multiversion::multiversion(targets("x86_64+avx512f", "x86_64+avx2", "aarch64+neon"))]
 fn cast_and_bounds_masked<F, T>(values: &[F], validity: &BitBuffer, dst: &mut [T]) -> Option<(F, F)>
 where
@@ -237,26 +237,21 @@ where
     let mut vmin = hi_neutral;
     let mut vmax = lo_neutral;
 
-    // `BitChunks` yields offset-normalized 64-bit words, so byte `b` of `word` holds the validity
-    // for the 8 lanes starting at `base + b * 8` — correct even for sliced (bit-offset) buffers.
     let chunks = validity.chunks();
     let mut base = 0usize;
     for word in chunks.iter() {
-        for b in 0..8usize {
-            let byte = (word >> (b * 8)) as u8;
-            let blk = base + b * 8;
-            for j in 0..8usize {
-                let v = values[blk + j];
-                dst[blk + j] = v.as_();
-                let valid = (byte >> j) & 1 != 0;
-                let for_min = if valid { v } else { hi_neutral };
-                let for_max = if valid { v } else { lo_neutral };
-                if for_min < vmin {
-                    vmin = for_min;
-                }
-                if for_max > vmax {
-                    vmax = for_max;
-                }
+        let vblk = &values[base..base + 64];
+        let oblk = &mut dst[base..base + 64];
+        for (j, (out, &v)) in oblk.iter_mut().zip(vblk).enumerate() {
+            *out = v.as_();
+            let valid = (word >> j) & 1 != 0;
+            let for_min = if valid { v } else { hi_neutral };
+            let for_max = if valid { v } else { lo_neutral };
+            if for_min < vmin {
+                vmin = for_min;
+            }
+            if for_max > vmax {
+                vmax = for_max;
             }
         }
         base += 64;

--- a/vortex-array/src/arrays/varbinview/compact.rs
+++ b/vortex-array/src/arrays/varbinview/compact.rs
@@ -78,6 +78,9 @@ impl VarBinViewArray {
             }
             Mask::AllFalse(_) => {}
             Mask::Values(v) => {
+                // TODO(perf): per-bit `zip` over validity is scalar. A word-chunked walk (or
+                // iterating only set bits via `set_indices()` when sparse) avoids the per-lane
+                // branch. See docs/developer-guide/internals/validity-iteration.md.
                 for (&view, is_valid) in self.views().iter().zip(v.bit_buffer().iter()) {
                     if is_valid && !view.is_inlined() {
                         f(view.as_view());

--- a/vortex-array/src/scalar_fn/fns/binary/numeric.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric.rs
@@ -16,6 +16,13 @@ use crate::scalar::NumericOperator;
 ///
 /// This is the entry point for numeric operations from the binary expression.
 /// Handles constant-constant directly, otherwise falls back to Arrow.
+///
+// TODO(perf): the array-array path falls back to Arrow. A native primitive kernel using the
+// "split" form would be a measured win (and beats Arrow's checked path): compute values densely
+// with `overflowing_add`/wrapping arithmetic over ALL lanes (vectorizes to e.g. `vpaddd`), produce
+// result validity as a separate word-level `lhs_nulls & rhs_nulls`, detect overflow branch-free
+// (`vpternlogd`) and only bail if a *valid* lane overflowed. A prototype measured ~4.3x over
+// Arrow's scalar valid-index gather. See docs/developer-guide/internals/validity-iteration.md.
 pub(crate) fn execute_numeric(
     lhs: &ArrayRef,
     rhs: &ArrayRef,

--- a/vortex-buffer/public-api.lock
+++ b/vortex-buffer/public-api.lock
@@ -300,6 +300,8 @@ pub fn vortex_buffer::BitBuffer::value(&self, usize) -> bool
 
 pub unsafe fn vortex_buffer::BitBuffer::value_unchecked(&self, usize) -> bool
 
+pub fn vortex_buffer::BitBuffer::zip_lanes<T: core::marker::Copy>(&self, &[T], impl core::ops::function::FnMut(T, bool))
+
 impl vortex_buffer::BitBuffer
 
 pub fn vortex_buffer::BitBuffer::into_inner(self) -> (usize, usize, vortex_buffer::ByteBuffer)

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -29,6 +29,31 @@ use crate::bit::select::bit_select;
 use crate::buffer;
 
 /// An immutable bitset stored as a packed byte buffer.
+///
+/// # Iterating values alongside a bitmap (validity, selection, …)
+///
+/// A very common pattern is walking a value slice while consulting a `BitBuffer` of the same
+/// length — e.g. a primitive array and its validity. How you traverse the bitmap dominates the
+/// performance of these kernels, so prefer the following (measured) guidance:
+///
+/// * **Do not** zip a per-bit `bool` iterator ([`BitBuffer::iter`]) with the values in a hot loop.
+///   It forces a scalar, bit-at-a-time traversal that the autovectorizer cannot lift, and it is
+///   several times slower on null-bearing data than the alternatives below.
+/// * **Do** consume the bitmap in word- or byte-sized groups via [`BitBuffer::chunks`], which
+///   yields offset-normalized `u64` words (so the same code is correct for sliced/bit-offset
+///   buffers). For maximum throughput, peel each word into **bytes and process 8 value lanes per
+///   byte**: reading the byte once lets the backend materialize the per-lane predicate from a
+///   broadcast plus a constant power-of-two selector (or a mask register), instead of emitting a
+///   per-lane variable shift (`(word >> j) & 1`), which is the usual bottleneck.
+/// * **Keep the per-lane work branch-free.** Gate with a select (e.g. fold invalid lanes against a
+///   neutral value, or zero them) rather than a data-dependent `if valid { … }` branch on the bit;
+///   a branch on the bitmap word serializes otherwise-vectorizable loops as soon as nulls appear.
+/// * Indexing the bitmap as `bits[i / 64] >> (i % 64)` inside the value loop defeats the
+///   vectorizer entirely — read the chunk/byte *once* outside the inner 8-lane loop.
+///
+/// On nightly, `core::simd::Mask::from_bitmask` turns a validity byte directly into a lane mask
+/// (a single `kmov` on AVX-512) and is the ideal primitive for this; on stable, the byte-per-8
+/// pattern above is the closest the compiler will get without `std::arch` intrinsics.
 #[derive(Debug, Clone, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BitBuffer {

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -366,6 +366,35 @@ impl BitBuffer {
         BitIterator::new(self.buffer.as_slice(), self.offset, self.len)
     }
 
+    /// Branch-free, word-chunked iteration over `values` paired with this bitmap's bits.
+    ///
+    /// Calls `f(value, is_valid)` for every lane, reading the bitmap one 64-bit word at a time
+    /// (offset-normalized, so it is correct for sliced buffers). This is the fast way to walk a
+    /// value slice alongside a validity mask: the closure **must** consume `is_valid` branch-free
+    /// (e.g. a select / fold against a neutral) so the loop vectorizes — see the type-level docs.
+    ///
+    /// Zero-cost: `#[inline(always)]`, so it folds into the (possibly multiversioned) caller and
+    /// compiles to the same code as the hand-written word loop.
+    ///
+    /// # Panics
+    /// Panics (in debug) if `values.len() != self.len()`.
+    #[inline(always)]
+    pub fn zip_lanes<T: Copy>(&self, values: &[T], mut f: impl FnMut(T, bool)) {
+        debug_assert_eq!(values.len(), self.len);
+        let chunks = self.chunks();
+        let mut base = 0usize;
+        for word in chunks.iter() {
+            for (j, &v) in values[base..base + 64].iter().enumerate() {
+                f(v, (word >> j) & 1 != 0);
+            }
+            base += 64;
+        }
+        let remainder = chunks.remainder_bits();
+        for (j, &v) in values[base..].iter().enumerate() {
+            f(v, (remainder >> j) & 1 != 0);
+        }
+    }
+
     /// Iterator over set indices of the underlying buffer
     pub fn set_indices(&self) -> BitIndexIterator<'_> {
         BitIndexIterator::new(self.buffer.as_slice(), self.offset, self.len)

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -39,21 +39,22 @@ use crate::buffer;
 /// * **Do not** zip a per-bit `bool` iterator ([`BitBuffer::iter`]) with the values in a hot loop.
 ///   It forces a scalar, bit-at-a-time traversal that the autovectorizer cannot lift, and it is
 ///   several times slower on null-bearing data than the alternatives below.
-/// * **Do** consume the bitmap in word- or byte-sized groups via [`BitBuffer::chunks`], which
-///   yields offset-normalized `u64` words (so the same code is correct for sliced/bit-offset
-///   buffers). For maximum throughput, peel each word into **bytes and process 8 value lanes per
-///   byte**: reading the byte once lets the backend materialize the per-lane predicate from a
-///   broadcast plus a constant power-of-two selector (or a mask register), instead of emitting a
-///   per-lane variable shift (`(word >> j) & 1`), which is the usual bottleneck.
+/// * **Do** consume the bitmap in word-sized groups via [`BitBuffer::chunks`], which yields
+///   offset-normalized `u64` words (so the same code is correct for sliced/bit-offset buffers).
+///   Process one word's worth of lanes per outer iteration and read the word *once*.
 /// * **Keep the per-lane work branch-free.** Gate with a select (e.g. fold invalid lanes against a
 ///   neutral value, or zero them) rather than a data-dependent `if valid { … }` branch on the bit;
 ///   a branch on the bitmap word serializes otherwise-vectorizable loops as soon as nulls appear.
 /// * Indexing the bitmap as `bits[i / 64] >> (i % 64)` inside the value loop defeats the
-///   vectorizer entirely — read the chunk/byte *once* outside the inner 8-lane loop.
+///   vectorizer entirely — read the chunk *once* outside the inner lane loop.
 ///
-/// On nightly, `core::simd::Mask::from_bitmask` turns a validity byte directly into a lane mask
-/// (a single `kmov` on AVX-512) and is the ideal primitive for this; on stable, the byte-per-8
-/// pattern above is the closest the compiler will get without `std::arch` intrinsics.
+/// A finer "one validity byte per 8 lanes" traversal can let the backend build the lane predicate
+/// from a broadcast + constant selector instead of a per-lane variable shift, and is a clear win
+/// when validity is already a flat `&[u8]`. Beware: re-deriving the byte from a `u64` chunk word
+/// (`(word >> b*8) as u8`) does *not* reliably reproduce that win and has measured *slower* than
+/// the plain word traversal in at least one kernel — benchmark before adopting it. On nightly,
+/// `core::simd::Mask::from_bitmask` turns a validity byte directly into a lane mask (a single
+/// `kmov` on AVX-512) and is the ideal primitive; stable Rust cannot match it without `std::arch`.
 #[derive(Debug, Clone, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BitBuffer {

--- a/vortex-duckdb/src/convert/vector.rs
+++ b/vortex-duckdb/src/convert/vector.rs
@@ -187,6 +187,9 @@ fn process_duckdb_lists(
             let mut child_min_length = 0;
             let mut previous_end = 0;
 
+            // TODO(perf): per-bit `zip` over validity is scalar; runs on every DuckDB->Vortex list
+            // import with nulls. A word-chunked validity walk would avoid the per-lane branch. See
+            // vortex-array docs/developer-guide/internals/validity-iteration.md.
             for (entry, is_valid) in entries.iter().zip(values.bit_buffer().iter()) {
                 let (offset, size) = if is_valid {
                     convert_valid_list_entry(entry, &mut child_min_length, &mut previous_end)


### PR DESCRIPTION
The fallible primitive cast previously checked each lane with an opaque
`NumCast::from` behind an early-return, which defeats vectorization, plus a
per-lane multiply-by-zero trick to keep invalid lanes from erroring.

A value can only exceed the target range if it is below the smallest or above
the largest valid value, so a single validity-aware min/max over the source
fully decides whether the cast can overflow. Fuse that reduction with the
conversion in one SIMD-friendly pass: every lane is cast unconditionally (out-
of-range values at invalid positions wrap/saturate harmlessly and are masked
out), while the running min/max folds only valid, non-NaN lanes. Validity is
consumed in 64-bit words so the common all-valid chunk is a branch-free,
vectorizable reduction. The kernels are multiversioned for AVX-512/AVX2/NEON.

The bounds are checked with the same `Scalar::cast` oracle the cast conformance
suite uses, so the error decision is now consistent with the cached fast path.

Signed-off-by: Joe Isaacs <joe.isaacs@live.co.uk>