### PR TITLE
`PrimitiveArrayExt::narrow` expose `ExecutionCtx` 

### DIFF
--- a/encodings/fastlanes/src/rle/array/mod.rs
+++ b/encodings/fastlanes/src/rle/array/mod.rs
@@ -473,7 +473,7 @@ mod tests {
             .indices()
             .clone()
             .execute::<PrimitiveArray>(&mut ctx)?
-            .narrow()?;
+            .narrow(&mut ctx)?;
         let re_encoded = RLEData::encode(indices_prim.as_view(), &mut ctx)?;
 
         // Reconstruct the outer RLE with re-encoded indices.

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -84,7 +84,9 @@ pub fn runend_encode(
         }
     };
 
-    let ends = ends.narrow().vortex_expect("Ends must succeed downcasting");
+    let ends = ends
+        .narrow(ctx)
+        .vortex_expect("Ends must succeed downcasting");
 
     ends.statistics()
         .set(Stat::IsStrictSorted, Precision::Exact(true.into()));

--- a/vortex-array/benches/dict_compare.rs
+++ b/vortex-array/benches/dict_compare.rs
@@ -7,6 +7,7 @@ use std::str::from_utf8;
 
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::accessor::ArrayAccessor;
@@ -48,7 +49,11 @@ const LENGTH_AND_UNIQUE_VALUES: &[(usize, usize)] = &[
 #[divan::bench(args = LENGTH_AND_UNIQUE_VALUES)]
 fn bench_compare_primitive(bencher: divan::Bencher, (len, uniqueness): (usize, usize)) {
     let primitive_arr = gen_primitive_for_dict::<i32>(len, uniqueness);
-    let dict = dict_encode(&primitive_arr.clone().into_array()).unwrap();
+    let dict = dict_encode(
+        &primitive_arr.clone().into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    )
+    .unwrap();
     let value = primitive_arr.as_slice::<i32>()[0];
     let session = VortexSession::empty();
 
@@ -67,7 +72,11 @@ fn bench_compare_primitive(bencher: divan::Bencher, (len, uniqueness): (usize, u
 #[divan::bench(args = LENGTH_AND_UNIQUE_VALUES)]
 fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usize)) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(len, uniqueness));
-    let dict = dict_encode(&varbin_arr.clone().into_array()).unwrap();
+    let dict = dict_encode(
+        &varbin_arr.clone().into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    )
+    .unwrap();
     let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
     let session = VortexSession::empty();
@@ -87,7 +96,11 @@ fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usiz
 #[divan::bench(args = LENGTH_AND_UNIQUE_VALUES)]
 fn bench_compare_varbinview(bencher: divan::Bencher, (len, uniqueness): (usize, usize)) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(len, uniqueness));
-    let dict = dict_encode(&varbinview_arr.clone().into_array()).unwrap();
+    let dict = dict_encode(
+        &varbinview_arr.clone().into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    )
+    .unwrap();
     let bytes = varbinview_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
     let session = VortexSession::empty();
@@ -122,7 +135,11 @@ fn bench_compare_sliced_dict_primitive(
     (codes_len, values_len): (usize, usize),
 ) {
     let primitive_arr = gen_primitive_for_dict::<i32>(codes_len.max(values_len), values_len);
-    let dict = dict_encode(&primitive_arr.clone().into_array()).unwrap();
+    let dict = dict_encode(
+        &primitive_arr.clone().into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    )
+    .unwrap();
     let dict = dict.into_array().slice(0..codes_len).unwrap();
     let value = primitive_arr.as_slice::<i32>()[0];
     let session = VortexSession::empty();
@@ -144,7 +161,11 @@ fn bench_compare_sliced_dict_varbinview(
     (codes_len, values_len): (usize, usize),
 ) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(codes_len.max(values_len), values_len));
-    let dict = dict_encode(&varbin_arr.clone().into_array()).unwrap();
+    let dict = dict_encode(
+        &varbin_arr.clone().into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    )
+    .unwrap();
     let dict = dict.into_array().slice(0..codes_len).unwrap();
     let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();

--- a/vortex-array/benches/dict_compress.rs
+++ b/vortex-array/benches/dict_compress.rs
@@ -43,27 +43,36 @@ where
 {
     let primitive_arr = gen_primitive_for_dict::<T>(len, unique_values);
 
-    bencher
-        .with_inputs(|| &primitive_arr)
-        .bench_refs(|arr| dict_encode(&arr.clone().into_array()));
+    bencher.with_inputs(|| &primitive_arr).bench_refs(|arr| {
+        dict_encode(
+            &arr.clone().into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+    });
 }
 
 #[divan::bench(args = BENCH_ARGS)]
 fn encode_varbin(bencher: Bencher, (len, unique_values): (usize, usize)) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(len, unique_values));
 
-    bencher
-        .with_inputs(|| &varbin_arr)
-        .bench_refs(|arr| dict_encode(&arr.clone().into_array()));
+    bencher.with_inputs(|| &varbin_arr).bench_refs(|arr| {
+        dict_encode(
+            &arr.clone().into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+    });
 }
 
 #[divan::bench(args = BENCH_ARGS)]
 fn encode_varbinview(bencher: Bencher, (len, unique_values): (usize, usize)) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(len, unique_values));
 
-    bencher
-        .with_inputs(|| &varbinview_arr)
-        .bench_refs(|arr| dict_encode(&arr.clone().into_array()));
+    bencher.with_inputs(|| &varbinview_arr).bench_refs(|arr| {
+        dict_encode(
+            &arr.clone().into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+    });
 }
 
 #[divan::bench(types = [u8, f32, i64], args = BENCH_ARGS)]
@@ -73,9 +82,12 @@ where
     StandardUniform: Distribution<T>,
 {
     let primitive_arr = gen_primitive_for_dict::<T>(len, unique_values);
-    let dict = dict_encode(&primitive_arr.into_array())
-        .unwrap()
-        .into_array();
+    let dict = dict_encode(
+        &primitive_arr.into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    )
+    .unwrap()
+    .into_array();
 
     bencher
         .with_inputs(|| (&dict, LEGACY_SESSION.create_execution_ctx()))
@@ -85,7 +97,12 @@ where
 #[divan::bench(args = BENCH_ARGS)]
 fn decode_varbin(bencher: Bencher, (len, unique_values): (usize, usize)) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(len, unique_values));
-    let dict = dict_encode(&varbin_arr.into_array()).unwrap().into_array();
+    let dict = dict_encode(
+        &varbin_arr.into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    )
+    .unwrap()
+    .into_array();
 
     bencher
         .with_inputs(|| (&dict, LEGACY_SESSION.create_execution_ctx()))
@@ -95,9 +112,12 @@ fn decode_varbin(bencher: Bencher, (len, unique_values): (usize, usize)) {
 #[divan::bench(args = BENCH_ARGS)]
 fn decode_varbinview(bencher: Bencher, (len, unique_values): (usize, usize)) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(len, unique_values));
-    let dict = dict_encode(&varbinview_arr.into_array())
-        .unwrap()
-        .into_array();
+    let dict = dict_encode(
+        &varbinview_arr.into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    )
+    .unwrap()
+    .into_array();
 
     bencher
         .with_inputs(|| (&dict, LEGACY_SESSION.create_execution_ctx()))

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -5200,7 +5200,7 @@ pub trait vortex_array::arrays::primitive::PrimitiveArrayExt: vortex_array::Type
 
 pub fn vortex_array::arrays::primitive::PrimitiveArrayExt::buffer_handle(&self) -> &vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::primitive::PrimitiveArrayExt::narrow(&self) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray>
+pub fn vortex_array::arrays::primitive::PrimitiveArrayExt::narrow(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray>
 
 pub fn vortex_array::arrays::primitive::PrimitiveArrayExt::nullability(&self) -> vortex_array::dtype::Nullability
 
@@ -5216,7 +5216,7 @@ impl<T: vortex_array::TypedArrayRef<vortex_array::arrays::Primitive>> vortex_arr
 
 pub fn T::buffer_handle(&self) -> &vortex_array::buffer::BufferHandle
 
-pub fn T::narrow(&self) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray>
+pub fn T::narrow(&self, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray>
 
 pub fn T::nullability(&self) -> vortex_array::dtype::Nullability
 
@@ -8718,9 +8718,9 @@ pub fn vortex_array::builders::dict::DictEncoder::encode(&mut self, &vortex_arra
 
 pub fn vortex_array::builders::dict::DictEncoder::reset(&mut self) -> vortex_array::ArrayRef
 
-pub fn vortex_array::builders::dict::dict_encode(&vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
+pub fn vortex_array::builders::dict::dict_encode(&vortex_array::ArrayRef, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
 
-pub fn vortex_array::builders::dict::dict_encode_with_constraints(&vortex_array::ArrayRef, &vortex_array::builders::dict::DictConstraints) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
+pub fn vortex_array::builders::dict::dict_encode_with_constraints(&vortex_array::ArrayRef, &vortex_array::builders::dict::DictConstraints, &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
 
 pub fn vortex_array::builders::dict::dict_encoder(&vortex_array::ArrayRef, &vortex_array::builders::dict::DictConstraints) -> alloc::boxed::Box<dyn vortex_array::builders::dict::DictEncoder>
 

--- a/vortex-array/src/arrays/dict/compute/cast.rs
+++ b/vortex-array/src/arrays/dict/compute/cast.rs
@@ -46,11 +46,13 @@ impl CastReduce for Dict {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::LazyLock;
+
     use rstest::rstest;
     use vortex_buffer::buffer;
+    use vortex_session::VortexSession;
 
     use crate::IntoArray;
-    use crate::LEGACY_SESSION;
     #[expect(deprecated)]
     use crate::ToCanonical as _;
     use crate::VortexSessionExecute;
@@ -64,11 +66,15 @@ mod tests {
     use crate::dtype::DType;
     use crate::dtype::Nullability;
     use crate::dtype::PType;
+    use crate::session::ArraySession;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     #[test]
     fn test_cast_dict_to_wider_type() {
         let values = buffer![1i32, 2, 3, 2, 1].into_array();
-        let dict = dict_encode(&values, &mut LEGACY_SESSION.create_execution_ctx()).unwrap();
+        let dict = dict_encode(&values, &mut SESSION.create_execution_ctx()).unwrap();
 
         let casted = dict
             .into_array()
@@ -88,11 +94,7 @@ mod tests {
     fn test_cast_dict_nullable() {
         let values =
             PrimitiveArray::from_option_iter([Some(10i32), None, Some(20), Some(10), None]);
-        let dict = dict_encode(
-            &values.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let dict = dict_encode(&values.into_array(), &mut SESSION.create_execution_ctx()).unwrap();
 
         let casted = dict
             .into_array()
@@ -108,7 +110,7 @@ mod tests {
     fn test_cast_dict_allvalid_to_nonnullable_and_back() {
         // Create an AllValid dict array (no nulls)
         let values = buffer![10i32, 20, 30, 40].into_array();
-        let dict = dict_encode(&values, &mut LEGACY_SESSION.create_execution_ctx()).unwrap();
+        let dict = dict_encode(&values, &mut SESSION.create_execution_ctx()).unwrap();
 
         // Verify initial state - codes should be NonNullable, values should be NonNullable
         assert_eq!(dict.codes().dtype().nullability(), Nullability::NonNullable);
@@ -177,10 +179,10 @@ mod tests {
     }
 
     #[rstest]
-    #[case(dict_encode(&buffer![1i32, 2, 3, 2, 1, 3].into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap().into_array())]
-    #[case(dict_encode(&buffer![100u32, 200, 100, 300, 200].into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap().into_array())]
-    #[case(dict_encode(&PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap().into_array())]
-    #[case(dict_encode(&buffer![1.5f32, 2.5, 1.5, 3.5].into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap().into_array())]
+    #[case(dict_encode(&buffer![1i32, 2, 3, 2, 1, 3].into_array(), &mut SESSION.create_execution_ctx()).unwrap().into_array())]
+    #[case(dict_encode(&buffer![100u32, 200, 100, 300, 200].into_array(), &mut SESSION.create_execution_ctx()).unwrap().into_array())]
+    #[case(dict_encode(&PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).into_array(), &mut SESSION.create_execution_ctx()).unwrap().into_array())]
+    #[case(dict_encode(&buffer![1.5f32, 2.5, 1.5, 3.5].into_array(), &mut SESSION.create_execution_ctx()).unwrap().into_array())]
     fn test_cast_dict_conformance(#[case] array: crate::ArrayRef) {
         test_cast_conformance(&array);
     }

--- a/vortex-array/src/arrays/dict/compute/cast.rs
+++ b/vortex-array/src/arrays/dict/compute/cast.rs
@@ -50,8 +50,10 @@ mod tests {
     use vortex_buffer::buffer;
 
     use crate::IntoArray;
+    use crate::LEGACY_SESSION;
     #[expect(deprecated)]
     use crate::ToCanonical as _;
+    use crate::VortexSessionExecute;
     use crate::arrays::Dict;
     use crate::arrays::PrimitiveArray;
     use crate::arrays::dict::DictArraySlotsExt;
@@ -66,7 +68,7 @@ mod tests {
     #[test]
     fn test_cast_dict_to_wider_type() {
         let values = buffer![1i32, 2, 3, 2, 1].into_array();
-        let dict = dict_encode(&values).unwrap();
+        let dict = dict_encode(&values, &mut LEGACY_SESSION.create_execution_ctx()).unwrap();
 
         let casted = dict
             .into_array()
@@ -86,7 +88,11 @@ mod tests {
     fn test_cast_dict_nullable() {
         let values =
             PrimitiveArray::from_option_iter([Some(10i32), None, Some(20), Some(10), None]);
-        let dict = dict_encode(&values.into_array()).unwrap();
+        let dict = dict_encode(
+            &values.into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap();
 
         let casted = dict
             .into_array()
@@ -102,7 +108,7 @@ mod tests {
     fn test_cast_dict_allvalid_to_nonnullable_and_back() {
         // Create an AllValid dict array (no nulls)
         let values = buffer![10i32, 20, 30, 40].into_array();
-        let dict = dict_encode(&values).unwrap();
+        let dict = dict_encode(&values, &mut LEGACY_SESSION.create_execution_ctx()).unwrap();
 
         // Verify initial state - codes should be NonNullable, values should be NonNullable
         assert_eq!(dict.codes().dtype().nullability(), Nullability::NonNullable);
@@ -171,10 +177,10 @@ mod tests {
     }
 
     #[rstest]
-    #[case(dict_encode(&buffer![1i32, 2, 3, 2, 1, 3].into_array()).unwrap().into_array())]
-    #[case(dict_encode(&buffer![100u32, 200, 100, 300, 200].into_array()).unwrap().into_array())]
-    #[case(dict_encode(&PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).into_array()).unwrap().into_array())]
-    #[case(dict_encode(&buffer![1.5f32, 2.5, 1.5, 3.5].into_array()).unwrap().into_array())]
+    #[case(dict_encode(&buffer![1i32, 2, 3, 2, 1, 3].into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap().into_array())]
+    #[case(dict_encode(&buffer![100u32, 200, 100, 300, 200].into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap().into_array())]
+    #[case(dict_encode(&PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap().into_array())]
+    #[case(dict_encode(&buffer![1.5f32, 2.5, 1.5, 3.5].into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap().into_array())]
     fn test_cast_dict_conformance(#[case] array: crate::ArrayRef) {
         test_cast_conformance(&array);
     }

--- a/vortex-array/src/arrays/dict/compute/min_max.rs
+++ b/vortex-array/src/arrays/dict/compute/min_max.rs
@@ -117,7 +117,11 @@ mod tests {
     }
 
     fn dict_single() -> DictArray {
-        dict_encode(&buffer![42i32].into_array()).expect("valid single-value dictionary")
+        dict_encode(
+            &buffer![42i32].into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .expect("valid single-value dictionary")
     }
 
     fn dict_nullable_codes() -> DictArray {
@@ -132,6 +136,7 @@ mod tests {
         dict_encode(
             &PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None])
                 .into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
         )
         .expect("valid nullable-value dictionary")
     }
@@ -166,7 +171,10 @@ mod tests {
     #[test]
     fn test_sliced_dict() -> VortexResult<()> {
         let reference = PrimitiveArray::from_iter([1, 5, 10, 50, 100]);
-        let dict = dict_encode(&reference.into_array())?;
+        let dict = dict_encode(
+            &reference.into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         let sliced = dict.slice(1..3)?;
         assert_min_max(&sliced, Some((5, 10)))
     }

--- a/vortex-array/src/arrays/dict/compute/min_max.rs
+++ b/vortex-array/src/arrays/dict/compute/min_max.rs
@@ -60,21 +60,27 @@ impl DynAggregateKernel for DictMinMaxKernel {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::LazyLock;
+
     use rstest::rstest;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
 
     use crate::ArrayRef;
     use crate::IntoArray;
-    use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::fns::min_max::min_max;
     use crate::arrays::DictArray;
     use crate::arrays::PrimitiveArray;
     use crate::builders::dict::dict_encode;
+    use crate::session::ArraySession;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     fn assert_min_max(array: &ArrayRef, expected: Option<(i32, i32)>) -> VortexResult<()> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         match (min_max(array, &mut ctx)?, expected) {
             (Some(result), Some((expected_min, expected_max))) => {
                 assert_eq!(i32::try_from(&result.min)?, expected_min);
@@ -119,7 +125,7 @@ mod tests {
     fn dict_single() -> DictArray {
         dict_encode(
             &buffer![42i32].into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .expect("valid single-value dictionary")
     }
@@ -136,7 +142,7 @@ mod tests {
         dict_encode(
             &PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None])
                 .into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .expect("valid nullable-value dictionary")
     }
@@ -171,10 +177,7 @@ mod tests {
     #[test]
     fn test_sliced_dict() -> VortexResult<()> {
         let reference = PrimitiveArray::from_iter([1, 5, 10, 50, 100]);
-        let dict = dict_encode(
-            &reference.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )?;
+        let dict = dict_encode(&reference.into_array(), &mut SESSION.create_execution_ctx())?;
         let sliced = dict.slice(1..3)?;
         assert_min_max(&sliced, Some((5, 10)))
     }

--- a/vortex-array/src/arrays/dict/compute/mod.rs
+++ b/vortex-array/src/arrays/dict/compute/mod.rs
@@ -60,8 +60,10 @@ mod test {
 
     use crate::ArrayRef;
     use crate::IntoArray;
+    use crate::LEGACY_SESSION;
     #[expect(deprecated)]
     use crate::ToCanonical as _;
+    use crate::VortexSessionExecute;
     use crate::accessor::ArrayAccessor;
     use crate::arrays::ConstantArray;
     use crate::arrays::PrimitiveArray;
@@ -88,8 +90,11 @@ mod test {
             })
             .collect();
 
-        let dict =
-            dict_encode(&PrimitiveArray::from_option_iter(values.clone()).into_array()).unwrap();
+        let dict = dict_encode(
+            &PrimitiveArray::from_option_iter(values.clone()).into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap();
         #[expect(deprecated)]
         let actual = dict.as_array().to_primitive();
 
@@ -103,7 +108,11 @@ mod test {
         let unique_values: Vec<i32> = (0..32).collect();
         let expected = PrimitiveArray::from_iter((0..1000).map(|i| unique_values[i % 32]));
 
-        let dict = dict_encode(&expected.clone().into_array()).unwrap();
+        let dict = dict_encode(
+            &expected.clone().into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap();
         #[expect(deprecated)]
         let actual = dict.as_array().to_primitive();
 
@@ -115,7 +124,11 @@ mod test {
         let unique_values: Vec<i32> = (0..100).collect();
         let expected = PrimitiveArray::from_iter((0..1000).map(|i| unique_values[i % 100]));
 
-        let dict = dict_encode(&expected.clone().into_array()).unwrap();
+        let dict = dict_encode(
+            &expected.clone().into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap();
         #[expect(deprecated)]
         let actual = dict.as_array().to_primitive();
 
@@ -129,7 +142,11 @@ mod test {
             DType::Utf8(Nullability::Nullable),
         );
         assert_eq!(reference.len(), 6);
-        let dict = dict_encode(&reference.clone().into_array()).unwrap();
+        let dict = dict_encode(
+            &reference.clone().into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap();
         #[expect(deprecated)]
         let flattened_dict = dict.as_array().to_varbinview();
         assert_eq!(
@@ -151,7 +168,11 @@ mod test {
             Some(1),
             Some(5),
         ]);
-        let dict = dict_encode(&reference.into_array()).unwrap();
+        let dict = dict_encode(
+            &reference.into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap();
         dict.slice(1..4).unwrap()
     }
 
@@ -169,12 +190,17 @@ mod test {
 
     #[test]
     fn test_mask_dict_array() {
-        let array = dict_encode(&buffer![2, 0, 2, 0, 10].into_array()).unwrap();
+        let array = dict_encode(
+            &buffer![2, 0, 2, 0, 10].into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap();
         test_mask_conformance(&array.into_array());
 
         let array = dict_encode(
             &PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)])
                 .into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_mask_conformance(&array.into_array());
@@ -191,6 +217,7 @@ mod test {
                 DType::Utf8(Nullability::Nullable),
             )
             .into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_mask_conformance(&array.into_array());
@@ -198,12 +225,17 @@ mod test {
 
     #[test]
     fn test_filter_dict_array() {
-        let array = dict_encode(&buffer![2, 0, 2, 0, 10].into_array()).unwrap();
+        let array = dict_encode(
+            &buffer![2, 0, 2, 0, 10].into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap();
         test_filter_conformance(&array.into_array());
 
         let array = dict_encode(
             &PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)])
                 .into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_filter_conformance(&array.into_array());
@@ -220,6 +252,7 @@ mod test {
                 DType::Utf8(Nullability::Nullable),
             )
             .into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_filter_conformance(&array.into_array());
@@ -227,7 +260,11 @@ mod test {
 
     #[test]
     fn test_take_dict() {
-        let array = dict_encode(&buffer![1, 2].into_array()).unwrap();
+        let array = dict_encode(
+            &buffer![1, 2].into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap();
 
         assert_eq!(
             array
@@ -240,12 +277,17 @@ mod test {
 
     #[test]
     fn test_take_dict_conformance() {
-        let array = dict_encode(&buffer![2, 0, 2, 0, 10].into_array()).unwrap();
+        let array = dict_encode(
+            &buffer![2, 0, 2, 0, 10].into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap();
         test_take_conformance(&array.into_array());
 
         let array = dict_encode(
             &PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)])
                 .into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_take_conformance(&array.into_array());
@@ -262,6 +304,7 @@ mod test {
                 DType::Utf8(Nullability::Nullable),
             )
             .into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_take_conformance(&array.into_array());
@@ -274,6 +317,8 @@ mod tests {
     use vortex_buffer::buffer;
 
     use crate::IntoArray;
+    use crate::LEGACY_SESSION;
+    use crate::VortexSessionExecute;
     use crate::arrays::DictArray;
     use crate::arrays::PrimitiveArray;
     use crate::arrays::VarBinArray;
@@ -284,32 +329,32 @@ mod tests {
 
     #[rstest]
     // Primitive arrays
-    #[case::dict_i32(dict_encode(&buffer![1i32, 2, 3, 2, 1].into_array()).unwrap())]
+    #[case::dict_i32(dict_encode(&buffer![1i32, 2, 3, 2, 1].into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
     #[case::dict_nullable_codes(DictArray::try_new(
         buffer![0u32, 1, 2, 2, 0].into_array(),
         PrimitiveArray::from_option_iter([Some(10), Some(20), None]).into_array(),
     ).unwrap())]
     #[case::dict_nullable_values(dict_encode(
         &PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).into_array()
-    ).unwrap())]
-    #[case::dict_u64(dict_encode(&buffer![100u64, 200, 100, 300, 200].into_array()).unwrap())]
+    , &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
+    #[case::dict_u64(dict_encode(&buffer![100u64, 200, 100, 300, 200].into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
     // String arrays
     #[case::dict_str(dict_encode(
         &VarBinArray::from_iter(
             ["hello", "world", "hello", "test", "world"].map(Some),
             DType::Utf8(Nullability::NonNullable),
         ).into_array()
-    ).unwrap())]
+    , &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
     #[case::dict_nullable_str(dict_encode(
         &VarBinArray::from_iter(
             [Some("hello"), None, Some("world"), Some("hello"), None],
             DType::Utf8(Nullability::Nullable),
         ).into_array()
-    ).unwrap())]
+    , &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
     // Edge cases
-    #[case::dict_single(dict_encode(&buffer![42i32].into_array()).unwrap())]
-    #[case::dict_all_same(dict_encode(&buffer![5i32, 5, 5, 5, 5].into_array()).unwrap())]
-    #[case::dict_large(dict_encode(&PrimitiveArray::from_iter((0..1000).map(|i| i % 10)).into_array()).unwrap())]
+    #[case::dict_single(dict_encode(&buffer![42i32].into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
+    #[case::dict_all_same(dict_encode(&buffer![5i32, 5, 5, 5, 5].into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
+    #[case::dict_large(dict_encode(&PrimitiveArray::from_iter((0..1000).map(|i| i % 10)).into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
     fn test_dict_consistency(#[case] array: DictArray) {
         test_array_consistency(&array.into_array());
     }

--- a/vortex-array/src/arrays/dict/compute/mod.rs
+++ b/vortex-array/src/arrays/dict/compute/mod.rs
@@ -54,13 +54,15 @@ impl FilterReduce for Dict {
 
 #[cfg(test)]
 mod test {
+    use std::sync::LazyLock;
+
     #[expect(unused_imports)]
     use itertools::Itertools;
     use vortex_buffer::buffer;
+    use vortex_session::VortexSession;
 
     use crate::ArrayRef;
     use crate::IntoArray;
-    use crate::LEGACY_SESSION;
     #[expect(deprecated)]
     use crate::ToCanonical as _;
     use crate::VortexSessionExecute;
@@ -79,6 +81,11 @@ mod test {
     use crate::dtype::Nullability;
     use crate::dtype::PType::I32;
     use crate::scalar_fn::fns::operators::Operator;
+    use crate::session::ArraySession;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+
     #[test]
     fn canonicalise_nullable_primitive() {
         let values: Vec<Option<i32>> = (0..65)
@@ -92,7 +99,7 @@ mod test {
 
         let dict = dict_encode(
             &PrimitiveArray::from_option_iter(values.clone()).into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         #[expect(deprecated)]
@@ -110,7 +117,7 @@ mod test {
 
         let dict = dict_encode(
             &expected.clone().into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         #[expect(deprecated)]
@@ -126,7 +133,7 @@ mod test {
 
         let dict = dict_encode(
             &expected.clone().into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         #[expect(deprecated)]
@@ -144,7 +151,7 @@ mod test {
         assert_eq!(reference.len(), 6);
         let dict = dict_encode(
             &reference.clone().into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         #[expect(deprecated)]
@@ -168,11 +175,8 @@ mod test {
             Some(1),
             Some(5),
         ]);
-        let dict = dict_encode(
-            &reference.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let dict =
+            dict_encode(&reference.into_array(), &mut SESSION.create_execution_ctx()).unwrap();
         dict.slice(1..4).unwrap()
     }
 
@@ -192,7 +196,7 @@ mod test {
     fn test_mask_dict_array() {
         let array = dict_encode(
             &buffer![2, 0, 2, 0, 10].into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_mask_conformance(&array.into_array());
@@ -200,7 +204,7 @@ mod test {
         let array = dict_encode(
             &PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)])
                 .into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_mask_conformance(&array.into_array());
@@ -217,7 +221,7 @@ mod test {
                 DType::Utf8(Nullability::Nullable),
             )
             .into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_mask_conformance(&array.into_array());
@@ -227,7 +231,7 @@ mod test {
     fn test_filter_dict_array() {
         let array = dict_encode(
             &buffer![2, 0, 2, 0, 10].into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_filter_conformance(&array.into_array());
@@ -235,7 +239,7 @@ mod test {
         let array = dict_encode(
             &PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)])
                 .into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_filter_conformance(&array.into_array());
@@ -252,7 +256,7 @@ mod test {
                 DType::Utf8(Nullability::Nullable),
             )
             .into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_filter_conformance(&array.into_array());
@@ -262,7 +266,7 @@ mod test {
     fn test_take_dict() {
         let array = dict_encode(
             &buffer![1, 2].into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
 
@@ -279,7 +283,7 @@ mod test {
     fn test_take_dict_conformance() {
         let array = dict_encode(
             &buffer![2, 0, 2, 0, 10].into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_take_conformance(&array.into_array());
@@ -287,7 +291,7 @@ mod test {
         let array = dict_encode(
             &PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)])
                 .into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_take_conformance(&array.into_array());
@@ -304,7 +308,7 @@ mod test {
                 DType::Utf8(Nullability::Nullable),
             )
             .into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut SESSION.create_execution_ctx(),
         )
         .unwrap();
         test_take_conformance(&array.into_array());
@@ -313,11 +317,13 @@ mod test {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::LazyLock;
+
     use rstest::rstest;
     use vortex_buffer::buffer;
+    use vortex_session::VortexSession;
 
     use crate::IntoArray;
-    use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::arrays::DictArray;
     use crate::arrays::PrimitiveArray;
@@ -326,35 +332,39 @@ mod tests {
     use crate::compute::conformance::consistency::test_array_consistency;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
+    use crate::session::ArraySession;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     #[rstest]
     // Primitive arrays
-    #[case::dict_i32(dict_encode(&buffer![1i32, 2, 3, 2, 1].into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
+    #[case::dict_i32(dict_encode(&buffer![1i32, 2, 3, 2, 1].into_array(), &mut SESSION.create_execution_ctx()).unwrap())]
     #[case::dict_nullable_codes(DictArray::try_new(
         buffer![0u32, 1, 2, 2, 0].into_array(),
         PrimitiveArray::from_option_iter([Some(10), Some(20), None]).into_array(),
     ).unwrap())]
     #[case::dict_nullable_values(dict_encode(
         &PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).into_array()
-    , &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
-    #[case::dict_u64(dict_encode(&buffer![100u64, 200, 100, 300, 200].into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
+    , &mut SESSION.create_execution_ctx()).unwrap())]
+    #[case::dict_u64(dict_encode(&buffer![100u64, 200, 100, 300, 200].into_array(), &mut SESSION.create_execution_ctx()).unwrap())]
     // String arrays
     #[case::dict_str(dict_encode(
         &VarBinArray::from_iter(
             ["hello", "world", "hello", "test", "world"].map(Some),
             DType::Utf8(Nullability::NonNullable),
         ).into_array()
-    , &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
+    , &mut SESSION.create_execution_ctx()).unwrap())]
     #[case::dict_nullable_str(dict_encode(
         &VarBinArray::from_iter(
             [Some("hello"), None, Some("world"), Some("hello"), None],
             DType::Utf8(Nullability::Nullable),
         ).into_array()
-    , &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
+    , &mut SESSION.create_execution_ctx()).unwrap())]
     // Edge cases
-    #[case::dict_single(dict_encode(&buffer![42i32].into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
-    #[case::dict_all_same(dict_encode(&buffer![5i32, 5, 5, 5, 5].into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
-    #[case::dict_large(dict_encode(&PrimitiveArray::from_iter((0..1000).map(|i| i % 10)).into_array(), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
+    #[case::dict_single(dict_encode(&buffer![42i32].into_array(), &mut SESSION.create_execution_ctx()).unwrap())]
+    #[case::dict_all_same(dict_encode(&buffer![5i32, 5, 5, 5, 5].into_array(), &mut SESSION.create_execution_ctx()).unwrap())]
+    #[case::dict_large(dict_encode(&PrimitiveArray::from_iter((0..1000).map(|i| i % 10)).into_array(), &mut SESSION.create_execution_ctx()).unwrap())]
     fn test_dict_consistency(#[case] array: DictArray) {
         test_array_consistency(&array.into_array());
     }

--- a/vortex-array/src/arrays/primitive/array/cast.rs
+++ b/vortex-array/src/arrays/primitive/array/cast.rs
@@ -37,18 +37,24 @@ impl PrimitiveData {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::LazyLock;
+
     use rstest::rstest;
     use vortex_buffer::Buffer;
     use vortex_buffer::buffer;
+    use vortex_session::VortexSession;
 
-    use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::arrays::PrimitiveArray;
     use crate::arrays::primitive::PrimitiveArrayExt;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
     use crate::dtype::PType;
+    use crate::session::ArraySession;
     use crate::validity::Validity;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     #[test]
     fn test_downcast_all_invalid() {
@@ -57,9 +63,7 @@ mod tests {
             Validity::AllInvalid,
         );
 
-        let result = array
-            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap();
+        let result = array.narrow(&mut SESSION.create_execution_ctx()).unwrap();
         assert_eq!(
             result.dtype(),
             &DType::Primitive(PType::U8, Nullability::Nullable)
@@ -78,9 +82,7 @@ mod tests {
     #[case(vec![i32::MIN as i64, i32::MAX as i64], PType::I32)]
     fn test_downcast_signed(#[case] values: Vec<i64>, #[case] expected_ptype: PType) {
         let array = PrimitiveArray::from_iter(values);
-        let result = array
-            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap();
+        let result = array.narrow(&mut SESSION.create_execution_ctx()).unwrap();
         assert_eq!(result.ptype(), expected_ptype);
     }
 
@@ -92,27 +94,21 @@ mod tests {
     #[case(vec![0_u64, u32::MAX as u64], PType::U32)]
     fn test_downcast_unsigned(#[case] values: Vec<u64>, #[case] expected_ptype: PType) {
         let array = PrimitiveArray::from_iter(values);
-        let result = array
-            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap();
+        let result = array.narrow(&mut SESSION.create_execution_ctx()).unwrap();
         assert_eq!(result.ptype(), expected_ptype);
     }
 
     #[test]
     fn test_downcast_keeps_original_if_too_large() {
         let array = PrimitiveArray::from_iter(vec![0_u64, u64::MAX]);
-        let result = array
-            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap();
+        let result = array.narrow(&mut SESSION.create_execution_ctx()).unwrap();
         assert_eq!(result.ptype(), PType::U64);
     }
 
     #[test]
     fn test_downcast_preserves_nullability() {
         let array = PrimitiveArray::from_option_iter([Some(0_i32), None, Some(127)]);
-        let result = array
-            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap();
+        let result = array.narrow(&mut SESSION.create_execution_ctx()).unwrap();
         assert_eq!(
             result.dtype(),
             &DType::Primitive(PType::U8, Nullability::Nullable)
@@ -125,9 +121,7 @@ mod tests {
     fn test_downcast_preserves_values() {
         let values = vec![-100_i16, 0, 100];
         let array = PrimitiveArray::from_iter(values);
-        let result = array
-            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap();
+        let result = array.narrow(&mut SESSION.create_execution_ctx()).unwrap();
 
         assert_eq!(result.ptype(), PType::I8);
         // Check that the values were properly downscaled
@@ -138,18 +132,14 @@ mod tests {
     #[test]
     fn test_downcast_with_mixed_signs_chooses_signed() {
         let array = PrimitiveArray::from_iter(vec![-1_i32, 200]);
-        let result = array
-            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap();
+        let result = array.narrow(&mut SESSION.create_execution_ctx()).unwrap();
         assert_eq!(result.ptype(), PType::I16);
     }
 
     #[test]
     fn test_downcast_floats() {
         let array = PrimitiveArray::from_iter(vec![1.0_f32, 2.0, 3.0]);
-        let result = array
-            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap();
+        let result = array.narrow(&mut SESSION.create_execution_ctx()).unwrap();
         // Floats should remain unchanged since they can't be downscaled to integers
         assert_eq!(result.ptype(), PType::F32);
     }
@@ -157,13 +147,9 @@ mod tests {
     #[test]
     fn test_downcast_empty_array() {
         let array = PrimitiveArray::new(Buffer::<i32>::empty(), Validity::AllInvalid);
-        let result = array
-            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap();
+        let result = array.narrow(&mut SESSION.create_execution_ctx()).unwrap();
         let array2 = PrimitiveArray::new(Buffer::<i64>::empty(), Validity::NonNullable);
-        let result2 = array2
-            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap();
+        let result2 = array2.narrow(&mut SESSION.create_execution_ctx()).unwrap();
         // Empty arrays should not have their validity changed
         assert!(matches!(result.validity(), Ok(Validity::AllInvalid)));
         assert!(matches!(result2.validity(), Ok(Validity::NonNullable)));

--- a/vortex-array/src/arrays/primitive/array/cast.rs
+++ b/vortex-array/src/arrays/primitive/array/cast.rs
@@ -41,6 +41,8 @@ mod tests {
     use vortex_buffer::Buffer;
     use vortex_buffer::buffer;
 
+    use crate::LEGACY_SESSION;
+    use crate::VortexSessionExecute;
     use crate::arrays::PrimitiveArray;
     use crate::arrays::primitive::PrimitiveArrayExt;
     use crate::dtype::DType;
@@ -55,7 +57,9 @@ mod tests {
             Validity::AllInvalid,
         );
 
-        let result = array.narrow().unwrap();
+        let result = array
+            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
         assert_eq!(
             result.dtype(),
             &DType::Primitive(PType::U8, Nullability::Nullable)
@@ -74,7 +78,9 @@ mod tests {
     #[case(vec![i32::MIN as i64, i32::MAX as i64], PType::I32)]
     fn test_downcast_signed(#[case] values: Vec<i64>, #[case] expected_ptype: PType) {
         let array = PrimitiveArray::from_iter(values);
-        let result = array.narrow().unwrap();
+        let result = array
+            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
         assert_eq!(result.ptype(), expected_ptype);
     }
 
@@ -86,21 +92,27 @@ mod tests {
     #[case(vec![0_u64, u32::MAX as u64], PType::U32)]
     fn test_downcast_unsigned(#[case] values: Vec<u64>, #[case] expected_ptype: PType) {
         let array = PrimitiveArray::from_iter(values);
-        let result = array.narrow().unwrap();
+        let result = array
+            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
         assert_eq!(result.ptype(), expected_ptype);
     }
 
     #[test]
     fn test_downcast_keeps_original_if_too_large() {
         let array = PrimitiveArray::from_iter(vec![0_u64, u64::MAX]);
-        let result = array.narrow().unwrap();
+        let result = array
+            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
         assert_eq!(result.ptype(), PType::U64);
     }
 
     #[test]
     fn test_downcast_preserves_nullability() {
         let array = PrimitiveArray::from_option_iter([Some(0_i32), None, Some(127)]);
-        let result = array.narrow().unwrap();
+        let result = array
+            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
         assert_eq!(
             result.dtype(),
             &DType::Primitive(PType::U8, Nullability::Nullable)
@@ -113,7 +125,9 @@ mod tests {
     fn test_downcast_preserves_values() {
         let values = vec![-100_i16, 0, 100];
         let array = PrimitiveArray::from_iter(values);
-        let result = array.narrow().unwrap();
+        let result = array
+            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
 
         assert_eq!(result.ptype(), PType::I8);
         // Check that the values were properly downscaled
@@ -124,14 +138,18 @@ mod tests {
     #[test]
     fn test_downcast_with_mixed_signs_chooses_signed() {
         let array = PrimitiveArray::from_iter(vec![-1_i32, 200]);
-        let result = array.narrow().unwrap();
+        let result = array
+            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
         assert_eq!(result.ptype(), PType::I16);
     }
 
     #[test]
     fn test_downcast_floats() {
         let array = PrimitiveArray::from_iter(vec![1.0_f32, 2.0, 3.0]);
-        let result = array.narrow().unwrap();
+        let result = array
+            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
         // Floats should remain unchanged since they can't be downscaled to integers
         assert_eq!(result.ptype(), PType::F32);
     }
@@ -139,9 +157,13 @@ mod tests {
     #[test]
     fn test_downcast_empty_array() {
         let array = PrimitiveArray::new(Buffer::<i32>::empty(), Validity::AllInvalid);
-        let result = array.narrow().unwrap();
+        let result = array
+            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
         let array2 = PrimitiveArray::new(Buffer::<i64>::empty(), Validity::NonNullable);
-        let result2 = array2.narrow().unwrap();
+        let result2 = array2
+            .narrow(&mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
         // Empty arrays should not have their validity changed
         assert!(matches!(result.validity(), Ok(Validity::AllInvalid)));
         assert!(matches!(result2.validity(), Ok(Validity::NonNullable)));

--- a/vortex-array/src/arrays/primitive/array/mod.rs
+++ b/vortex-array/src/arrays/primitive/array/mod.rs
@@ -17,10 +17,9 @@ use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 
 use crate::ArraySlots;
-use crate::LEGACY_SESSION;
+use crate::ExecutionCtx;
 #[expect(deprecated)]
 use crate::ToCanonical as _;
-use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayParts;
 use crate::array::TypedArrayRef;
@@ -150,13 +149,12 @@ pub trait PrimitiveArrayExt: TypedArrayRef<Primitive> {
     }
 
     /// Narrow the array to the smallest possible integer type that can represent all values.
-    fn narrow(&self) -> VortexResult<PrimitiveArray> {
+    fn narrow(&self, ctx: &mut ExecutionCtx) -> VortexResult<PrimitiveArray> {
         if !self.ptype().is_int() {
             return Ok(self.to_owned());
         }
 
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let Some(min_max) = min_max(self.as_ref(), &mut ctx)? else {
+        let Some(min_max) = min_max(self.as_ref(), ctx)? else {
             return Ok(PrimitiveArray::new(
                 Buffer::<u8>::zeroed(self.len()),
                 self.validity(),
@@ -185,57 +183,51 @@ pub trait PrimitiveArrayExt: TypedArrayRef<Primitive> {
         if min < 0 || max < 0 {
             // Signed
             if min >= i8::MIN as i64 && max <= i8::MAX as i64 {
-                #[expect(deprecated)]
                 let result = self
                     .as_ref()
                     .cast(DType::Primitive(PType::I8, nullability))?
-                    .to_primitive();
+                    .execute::<PrimitiveArray>(ctx)?;
                 return Ok(result);
             }
 
             if min >= i16::MIN as i64 && max <= i16::MAX as i64 {
-                #[expect(deprecated)]
                 let result = self
                     .as_ref()
                     .cast(DType::Primitive(PType::I16, nullability))?
-                    .to_primitive();
+                    .execute::<PrimitiveArray>(ctx)?;
                 return Ok(result);
             }
 
             if min >= i32::MIN as i64 && max <= i32::MAX as i64 {
-                #[expect(deprecated)]
                 let result = self
                     .as_ref()
                     .cast(DType::Primitive(PType::I32, nullability))?
-                    .to_primitive();
+                    .execute::<PrimitiveArray>(ctx)?;
                 return Ok(result);
             }
         } else {
             // Unsigned
             if max <= u8::MAX as i64 {
-                #[expect(deprecated)]
                 let result = self
                     .as_ref()
                     .cast(DType::Primitive(PType::U8, nullability))?
-                    .to_primitive();
+                    .execute::<PrimitiveArray>(ctx)?;
                 return Ok(result);
             }
 
             if max <= u16::MAX as i64 {
-                #[expect(deprecated)]
                 let result = self
                     .as_ref()
                     .cast(DType::Primitive(PType::U16, nullability))?
-                    .to_primitive();
+                    .execute::<PrimitiveArray>(ctx)?;
                 return Ok(result);
             }
 
             if max <= u32::MAX as i64 {
-                #[expect(deprecated)]
                 let result = self
                     .as_ref()
                     .cast(DType::Primitive(PType::U32, nullability))?
-                    .to_primitive();
+                    .execute::<PrimitiveArray>(ctx)?;
                 return Ok(result);
             }
         }

--- a/vortex-array/src/builders/dict/bytes.rs
+++ b/vortex-array/src/builders/dict/bytes.rs
@@ -207,8 +207,10 @@ mod test {
     use std::str;
 
     use crate::IntoArray;
+    use crate::LEGACY_SESSION;
     #[expect(deprecated)]
     use crate::ToCanonical as _;
+    use crate::VortexSessionExecute;
     use crate::accessor::ArrayAccessor;
     use crate::arrays::VarBinArray;
     use crate::arrays::dict::DictArraySlotsExt;
@@ -217,7 +219,11 @@ mod test {
     #[test]
     fn encode_varbin() {
         let arr = VarBinArray::from(vec!["hello", "world", "hello", "again", "world"]);
-        let dict = dict_encode(&arr.into_array()).unwrap();
+        let dict = dict_encode(
+            &arr.into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap();
         #[expect(deprecated)]
         let codes = dict.codes().to_primitive();
         assert_eq!(codes.as_slice::<u8>(), &[0, 1, 0, 2, 1]);
@@ -247,7 +253,11 @@ mod test {
         ]
         .into_iter()
         .collect();
-        let dict = dict_encode(&arr.into_array()).unwrap();
+        let dict = dict_encode(
+            &arr.into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap();
         #[expect(deprecated)]
         let codes = dict.codes().to_primitive();
         assert_eq!(codes.as_slice::<u8>(), &[0, 1, 2, 0, 1, 3, 2, 1]);
@@ -265,7 +275,11 @@ mod test {
     #[test]
     fn repeated_values() {
         let arr = VarBinArray::from(vec!["a", "a", "b", "b", "a", "b", "a", "b"]);
-        let dict = dict_encode(&arr.into_array()).unwrap();
+        let dict = dict_encode(
+            &arr.into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap();
         #[expect(deprecated)]
         let values = dict.values().to_varbinview();
         values.with_iterator(|iter| {

--- a/vortex-array/src/builders/dict/bytes.rs
+++ b/vortex-array/src/builders/dict/bytes.rs
@@ -205,9 +205,11 @@ impl<Code: UnsignedPType> DictEncoder for BytesDictBuilder<Code> {
 #[cfg(test)]
 mod test {
     use std::str;
+    use std::sync::LazyLock;
+
+    use vortex_session::VortexSession;
 
     use crate::IntoArray;
-    use crate::LEGACY_SESSION;
     #[expect(deprecated)]
     use crate::ToCanonical as _;
     use crate::VortexSessionExecute;
@@ -215,15 +217,15 @@ mod test {
     use crate::arrays::VarBinArray;
     use crate::arrays::dict::DictArraySlotsExt;
     use crate::builders::dict::dict_encode;
+    use crate::session::ArraySession;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     #[test]
     fn encode_varbin() {
         let arr = VarBinArray::from(vec!["hello", "world", "hello", "again", "world"]);
-        let dict = dict_encode(
-            &arr.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let dict = dict_encode(&arr.into_array(), &mut SESSION.create_execution_ctx()).unwrap();
         #[expect(deprecated)]
         let codes = dict.codes().to_primitive();
         assert_eq!(codes.as_slice::<u8>(), &[0, 1, 0, 2, 1]);
@@ -253,11 +255,7 @@ mod test {
         ]
         .into_iter()
         .collect();
-        let dict = dict_encode(
-            &arr.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let dict = dict_encode(&arr.into_array(), &mut SESSION.create_execution_ctx()).unwrap();
         #[expect(deprecated)]
         let codes = dict.codes().to_primitive();
         assert_eq!(codes.as_slice::<u8>(), &[0, 1, 2, 0, 1, 3, 2, 1]);
@@ -275,11 +273,7 @@ mod test {
     #[test]
     fn repeated_values() {
         let arr = VarBinArray::from(vec!["a", "a", "b", "b", "a", "b", "a", "b"]);
-        let dict = dict_encode(
-            &arr.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let dict = dict_encode(&arr.into_array(), &mut SESSION.create_execution_ctx()).unwrap();
         #[expect(deprecated)]
         let values = dict.values().to_varbinview();
         values.with_iterator(|iter| {

--- a/vortex-array/src/builders/dict/mod.rs
+++ b/vortex-array/src/builders/dict/mod.rs
@@ -8,11 +8,11 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_panic;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::arrays::DictArray;
 use crate::arrays::Primitive;
+use crate::arrays::PrimitiveArray;
 use crate::arrays::VarBin;
 use crate::arrays::VarBinView;
 use crate::arrays::primitive::PrimitiveArrayExt;
@@ -65,11 +65,11 @@ pub fn dict_encoder(array: &ArrayRef, constraints: &DictConstraints) -> Box<dyn 
 pub fn dict_encode_with_constraints(
     array: &ArrayRef,
     constraints: &DictConstraints,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<DictArray> {
     let mut encoder = dict_encoder(array, constraints);
     let encoded = encoder.encode(array);
-    #[expect(deprecated)]
-    let codes = encoded.to_primitive().narrow()?;
+    let codes = encoded.execute::<PrimitiveArray>(ctx)?.narrow(ctx)?;
     // SAFETY: The encoding process will produce a value set of codes and values
     // All values in the dictionary are guaranteed to be referenced by at least one code
     // since we build the dictionary from the codes we observe during encoding
@@ -81,8 +81,8 @@ pub fn dict_encode_with_constraints(
     }
 }
 
-pub fn dict_encode(array: &ArrayRef) -> VortexResult<DictArray> {
-    let dict_array = dict_encode_with_constraints(array, &UNCONSTRAINED)?;
+pub fn dict_encode(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<DictArray> {
+    let dict_array = dict_encode_with_constraints(array, &UNCONSTRAINED, ctx)?;
     if dict_array.len() != array.len() {
         vortex_bail!(
             "must have encoded all {} elements, but only encoded {}",

--- a/vortex-array/src/builders/dict/primitive.rs
+++ b/vortex-array/src/builders/dict/primitive.rs
@@ -160,6 +160,8 @@ mod test {
     use vortex_buffer::buffer;
 
     use crate::IntoArray as _;
+    use crate::LEGACY_SESSION;
+    use crate::VortexSessionExecute;
     use crate::arrays::dict::DictArraySlotsExt;
     use crate::assert_arrays_eq;
     use crate::builders::dict::dict_encode;
@@ -168,7 +170,7 @@ mod test {
     #[test]
     fn encode_primitive() {
         let arr = buffer![1, 1, 3, 3, 3].into_array();
-        let dict = dict_encode(&arr).unwrap();
+        let dict = dict_encode(&arr, &mut LEGACY_SESSION.create_execution_ctx()).unwrap();
 
         let expected_codes = buffer![0u8, 0, 1, 1, 1].into_array();
         assert_arrays_eq!(dict.codes(), expected_codes);
@@ -189,7 +191,11 @@ mod test {
             Some(3),
             None,
         ]);
-        let dict = dict_encode(&arr.into_array()).unwrap();
+        let dict = dict_encode(
+            &arr.into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap();
 
         let expected_codes = buffer![0u8, 0, 1, 2, 2, 1, 2, 1].into_array();
         assert_arrays_eq!(dict.codes(), expected_codes);

--- a/vortex-array/src/builders/dict/primitive.rs
+++ b/vortex-array/src/builders/dict/primitive.rs
@@ -155,22 +155,28 @@ where
 
 #[cfg(test)]
 mod test {
+    use std::sync::LazyLock;
+
     #[expect(unused_imports)]
     use itertools::Itertools;
     use vortex_buffer::buffer;
+    use vortex_session::VortexSession;
 
     use crate::IntoArray as _;
-    use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::arrays::dict::DictArraySlotsExt;
     use crate::assert_arrays_eq;
     use crate::builders::dict::dict_encode;
     use crate::builders::dict::primitive::PrimitiveArray;
+    use crate::session::ArraySession;
+
+    static SESSION: LazyLock<VortexSession> =
+        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     #[test]
     fn encode_primitive() {
         let arr = buffer![1, 1, 3, 3, 3].into_array();
-        let dict = dict_encode(&arr, &mut LEGACY_SESSION.create_execution_ctx()).unwrap();
+        let dict = dict_encode(&arr, &mut SESSION.create_execution_ctx()).unwrap();
 
         let expected_codes = buffer![0u8, 0, 1, 1, 1].into_array();
         assert_arrays_eq!(dict.codes(), expected_codes);
@@ -191,11 +197,7 @@ mod test {
             Some(3),
             None,
         ]);
-        let dict = dict_encode(
-            &arr.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let dict = dict_encode(&arr.into_array(), &mut SESSION.create_execution_ctx()).unwrap();
 
         let expected_codes = buffer![0u8, 0, 1, 2, 2, 1, 2, 1].into_array();
         assert_arrays_eq!(dict.codes(), expected_codes);

--- a/vortex-btrblocks/src/schemes/float.rs
+++ b/vortex-btrblocks/src/schemes/float.rs
@@ -268,7 +268,7 @@ impl Scheme for NullDominatedSparseScheme {
                 .indices()
                 .clone()
                 .execute::<PrimitiveArray>(exec_ctx)?
-                .narrow()?;
+                .narrow(exec_ctx)?;
             let compressed_indices = compressor.compress_child(
                 &indices.into_array(),
                 &compress_ctx,

--- a/vortex-btrblocks/src/schemes/integer.rs
+++ b/vortex-btrblocks/src/schemes/integer.rs
@@ -554,7 +554,7 @@ impl Scheme for SparseScheme {
                 .indices()
                 .clone()
                 .execute::<PrimitiveArray>(exec_ctx)?
-                .narrow()?;
+                .narrow(exec_ctx)?;
 
             let compressed_indices = compressor.compress_child(
                 &indices.into_array(),
@@ -849,7 +849,7 @@ pub(crate) fn rle_compress(
             .indices()
             .clone()
             .execute::<PrimitiveArray>(exec_ctx)?
-            .narrow()?;
+            .narrow(exec_ctx)?;
         try_compress_delta(
             compressor,
             &rle_indices_primitive.into_array(),
@@ -866,7 +866,7 @@ pub(crate) fn rle_compress(
             .indices()
             .clone()
             .execute::<PrimitiveArray>(exec_ctx)?
-            .narrow()?;
+            .narrow(exec_ctx)?;
         compressor.compress_child(
             &rle_indices_primitive.into_array(),
             &compress_ctx,
@@ -880,7 +880,7 @@ pub(crate) fn rle_compress(
         .values_idx_offsets()
         .clone()
         .execute::<PrimitiveArray>(exec_ctx)?
-        .narrow()?;
+        .narrow(exec_ctx)?;
     let compressed_offsets = compressor.compress_child(
         &rle_offsets_primitive.into_array(),
         &compress_ctx,

--- a/vortex-btrblocks/src/schemes/patches.rs
+++ b/vortex-btrblocks/src/schemes/patches.rs
@@ -18,7 +18,7 @@ pub fn compress_patches(patches: Patches, ctx: &mut ExecutionCtx) -> VortexResul
         .indices()
         .clone()
         .execute::<PrimitiveArray>(ctx)?
-        .narrow()?
+        .narrow(ctx)?
         .into_array();
 
     // Check if the values are constant.
@@ -39,7 +39,7 @@ pub fn compress_patches(patches: Patches, ctx: &mut ExecutionCtx) -> VortexResul
             let offsets_primitive = offsets
                 .clone()
                 .execute::<PrimitiveArray>(ctx)?
-                .narrow()?
+                .narrow(ctx)?
                 .into_array();
             Ok::<ArrayRef, VortexError>(offsets_primitive)
         })

--- a/vortex-btrblocks/src/schemes/string.rs
+++ b/vortex-btrblocks/src/schemes/string.rs
@@ -96,7 +96,7 @@ impl Scheme for FSSTScheme {
             .uncompressed_lengths()
             .clone()
             .execute::<PrimitiveArray>(exec_ctx)?
-            .narrow()?;
+            .narrow(exec_ctx)?;
         let compressed_original_lengths = compressor.compress_child(
             &uncompressed_lengths_primitive.into_array(),
             &compress_ctx,
@@ -110,7 +110,7 @@ impl Scheme for FSSTScheme {
             .offsets()
             .clone()
             .execute::<PrimitiveArray>(exec_ctx)?
-            .narrow()?;
+            .narrow(exec_ctx)?;
         let compressed_codes_offsets = compressor.compress_child(
             &codes_offsets_primitive.into_array(),
             &compress_ctx,
@@ -207,7 +207,7 @@ impl Scheme for NullDominatedSparseScheme {
                 .indices()
                 .clone()
                 .execute::<PrimitiveArray>(exec_ctx)?
-                .narrow()?;
+                .narrow(exec_ctx)?;
             let compressed_indices = compressor.compress_child(
                 &indices.into_array(),
                 &compress_ctx,

--- a/vortex-btrblocks/src/schemes/temporal.rs
+++ b/vortex-btrblocks/src/schemes/temporal.rs
@@ -98,7 +98,7 @@ impl Scheme for TemporalScheme {
             subseconds,
         } = split_temporal(temporal_array, exec_ctx)?;
 
-        let days_primitive = days.execute::<PrimitiveArray>(exec_ctx)?.narrow()?;
+        let days_primitive = days.execute::<PrimitiveArray>(exec_ctx)?.narrow(exec_ctx)?;
         let days = compressor.compress_child(
             &days_primitive.into_array(),
             &compress_ctx,
@@ -106,7 +106,9 @@ impl Scheme for TemporalScheme {
             0,
             exec_ctx,
         )?;
-        let seconds_primitive = seconds.execute::<PrimitiveArray>(exec_ctx)?.narrow()?;
+        let seconds_primitive = seconds
+            .execute::<PrimitiveArray>(exec_ctx)?
+            .narrow(exec_ctx)?;
         let seconds = compressor.compress_child(
             &seconds_primitive.into_array(),
             &compress_ctx,
@@ -114,7 +116,9 @@ impl Scheme for TemporalScheme {
             1,
             exec_ctx,
         )?;
-        let subseconds_primitive = subseconds.execute::<PrimitiveArray>(exec_ctx)?.narrow()?;
+        let subseconds_primitive = subseconds
+            .execute::<PrimitiveArray>(exec_ctx)?
+            .narrow(exec_ctx)?;
         let subseconds = compressor.compress_child(
             &subseconds_primitive.into_array(),
             &compress_ctx,

--- a/vortex-compressor/benches/dict_encode.rs
+++ b/vortex-compressor/benches/dict_encode.rs
@@ -33,9 +33,9 @@ fn make_array() -> PrimitiveArray {
 #[divan::bench]
 fn encode_generic(bencher: Bencher) {
     let array = make_array().into_array();
-    bencher
-        .with_inputs(|| &array)
-        .bench_refs(|array| dict_encode(array).unwrap());
+    bencher.with_inputs(|| &array).bench_refs(|array| {
+        dict_encode(array, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
+    });
 }
 
 #[cfg(not(codspeed))]

--- a/vortex-compressor/src/builtins/dict/float.rs
+++ b/vortex-compressor/src/builtins/dict/float.rs
@@ -127,7 +127,7 @@ impl Scheme for FloatDictScheme {
             .codes()
             .clone()
             .execute::<PrimitiveArray>(exec_ctx)?
-            .narrow()?
+            .narrow(exec_ctx)?
             .into_array();
         let compressed_codes =
             compressor.compress_child(&narrowed_codes, &compress_ctx, self.id(), 1, exec_ctx)?;

--- a/vortex-compressor/src/builtins/dict/integer.rs
+++ b/vortex-compressor/src/builtins/dict/integer.rs
@@ -119,7 +119,7 @@ impl Scheme for IntDictScheme {
             .codes()
             .clone()
             .execute::<PrimitiveArray>(exec_ctx)?
-            .narrow()?
+            .narrow(exec_ctx)?
             .into_array();
         let compressed_codes =
             compressor.compress_child(&narrowed_codes, &compress_ctx, self.id(), 1, exec_ctx)?;

--- a/vortex-compressor/src/builtins/dict/string.rs
+++ b/vortex-compressor/src/builtins/dict/string.rs
@@ -98,7 +98,7 @@ impl Scheme for StringDictScheme {
         compress_ctx: CompressorContext,
         exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let dict = dict_encode(data.array())?;
+        let dict = dict_encode(data.array(), exec_ctx)?;
 
         // Values = child 0.
         let compressed_values =
@@ -109,7 +109,7 @@ impl Scheme for StringDictScheme {
             .codes()
             .clone()
             .execute::<PrimitiveArray>(exec_ctx)?
-            .narrow()?
+            .narrow(exec_ctx)?
             .into_array();
         let compressed_codes =
             compressor.compress_child(&narrowed_codes, &compress_ctx, self.id(), 1, exec_ctx)?;

--- a/vortex-compressor/src/compressor.rs
+++ b/vortex-compressor/src/compressor.rs
@@ -517,7 +517,7 @@ impl CascadingCompressor {
             .offsets()
             .clone()
             .execute::<PrimitiveArray>(exec_ctx)?
-            .narrow()?;
+            .narrow(exec_ctx)?;
         let compressed_offsets = self.compress_canonical(
             Canonical::Primitive(list_offsets_primitive),
             offset_ctx,
@@ -547,7 +547,7 @@ impl CascadingCompressor {
             .offsets()
             .clone()
             .execute::<PrimitiveArray>(exec_ctx)?
-            .narrow()?;
+            .narrow(exec_ctx)?;
         let compressed_offsets = self.compress_canonical(
             Canonical::Primitive(list_view_offsets_primitive),
             offset_ctx,
@@ -559,7 +559,7 @@ impl CascadingCompressor {
             .sizes()
             .clone()
             .execute::<PrimitiveArray>(exec_ctx)?
-            .narrow()?;
+            .narrow(exec_ctx)?;
         let compressed_sizes = self.compress_canonical(
             Canonical::Primitive(list_view_sizes_primitive),
             sizes_ctx,

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/dict.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/dict.rs
@@ -5,6 +5,8 @@ use vortex::array::ArrayId;
 use vortex::array::ArrayRef;
 use vortex::array::ArrayVTable;
 use vortex::array::IntoArray;
+use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::Dict;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;
@@ -100,18 +102,66 @@ impl FlatLayoutFixture for DictFixture {
                 "insertion_ordered",
             ]),
             vec![
-                dict_encode(&str_col.into_array())?.into_array(),
-                dict_encode(&int_col.into_array())?.into_array(),
-                dict_encode(&nullable_col.into_array())?.into_array(),
-                dict_encode(&single_col.into_array())?.into_array(),
-                dict_encode(&bool_cat_col.into_array())?.into_array(),
-                dict_encode(&all_null_col.into_array())?.into_array(),
-                dict_encode(&single_non_null_col.into_array())?.into_array(),
-                dict_encode(&threshold_255_col.into_array())?.into_array(),
-                dict_encode(&threshold_256_col.into_array())?.into_array(),
-                dict_encode(&threshold_257_col.into_array())?.into_array(),
-                dict_encode(&long_col.into_array())?.into_array(),
-                dict_encode(&insertion_ordered_col.into_array())?.into_array(),
+                dict_encode(
+                    &str_col.into_array(),
+                    &mut LEGACY_SESSION.create_execution_ctx(),
+                )?
+                .into_array(),
+                dict_encode(
+                    &int_col.into_array(),
+                    &mut LEGACY_SESSION.create_execution_ctx(),
+                )?
+                .into_array(),
+                dict_encode(
+                    &nullable_col.into_array(),
+                    &mut LEGACY_SESSION.create_execution_ctx(),
+                )?
+                .into_array(),
+                dict_encode(
+                    &single_col.into_array(),
+                    &mut LEGACY_SESSION.create_execution_ctx(),
+                )?
+                .into_array(),
+                dict_encode(
+                    &bool_cat_col.into_array(),
+                    &mut LEGACY_SESSION.create_execution_ctx(),
+                )?
+                .into_array(),
+                dict_encode(
+                    &all_null_col.into_array(),
+                    &mut LEGACY_SESSION.create_execution_ctx(),
+                )?
+                .into_array(),
+                dict_encode(
+                    &single_non_null_col.into_array(),
+                    &mut LEGACY_SESSION.create_execution_ctx(),
+                )?
+                .into_array(),
+                dict_encode(
+                    &threshold_255_col.into_array(),
+                    &mut LEGACY_SESSION.create_execution_ctx(),
+                )?
+                .into_array(),
+                dict_encode(
+                    &threshold_256_col.into_array(),
+                    &mut LEGACY_SESSION.create_execution_ctx(),
+                )?
+                .into_array(),
+                dict_encode(
+                    &threshold_257_col.into_array(),
+                    &mut LEGACY_SESSION.create_execution_ctx(),
+                )?
+                .into_array(),
+                dict_encode(
+                    &long_col.into_array(),
+                    &mut LEGACY_SESSION.create_execution_ctx(),
+                )?
+                .into_array(),
+                dict_encode(
+                    &insertion_ordered_col.into_array(),
+                    &mut LEGACY_SESSION.create_execution_ctx(),
+                )?
+                .into_array(),
             ],
             N,
             Validity::NonNullable,

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -216,13 +216,23 @@ fn bench_dict_compress_u32(bencher: Bencher) {
 
     with_byte_counter(bencher, NUM_VALUES * 4)
         .with_inputs(|| &uint_array)
-        .bench_refs(|a| dict_encode(&a.clone().into_array()).unwrap());
+        .bench_refs(|a| {
+            dict_encode(
+                &a.clone().into_array(),
+                &mut LEGACY_SESSION.create_execution_ctx(),
+            )
+            .unwrap()
+        });
 }
 
 #[divan::bench(name = "dict_decompress_u32")]
 fn bench_dict_decompress_u32(bencher: Bencher) {
     let (uint_array, ..) = setup_primitive_arrays();
-    let compressed = dict_encode(&uint_array.into_array()).unwrap();
+    let compressed = dict_encode(
+        &uint_array.into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    )
+    .unwrap();
 
     with_byte_counter(bencher, NUM_VALUES * 4)
         .with_inputs(|| (&compressed, SESSION.create_execution_ctx()))
@@ -396,14 +406,24 @@ fn bench_dict_compress_string(bencher: Bencher) {
 
     with_byte_counter(bencher, nbytes)
         .with_inputs(|| &varbinview_arr)
-        .bench_refs(|a| dict_encode(&a.clone().into_array()).unwrap());
+        .bench_refs(|a| {
+            dict_encode(
+                &a.clone().into_array(),
+                &mut LEGACY_SESSION.create_execution_ctx(),
+            )
+            .unwrap()
+        });
 }
 
 #[divan::bench(name = "dict_decompress_string")]
 fn bench_dict_decompress_string(bencher: Bencher) {
     let varbinview_arr =
         VarBinViewArray::from_iter_str(gen_varbin_words(NUM_VALUES as usize, 0.00005));
-    let dict = dict_encode(&varbinview_arr.clone().into_array()).unwrap();
+    let dict = dict_encode(
+        &varbinview_arr.clone().into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    )
+    .unwrap();
     let nbytes = varbinview_arr.into_array().nbytes() as u64;
 
     with_byte_counter(bencher, nbytes)


### PR DESCRIPTION
Narrow requires an exe ctx so pass one