### PR TITLE
Simplify some of the buffer impl

### DIFF
--- a/vortex-buffer/public-api.lock
+++ b/vortex-buffer/public-api.lock
@@ -634,13 +634,9 @@ pub type vortex_buffer::ConstBuffer<T, A>::Error = vortex_error::VortexError
 
 pub fn vortex_buffer::ConstBuffer<T, A>::try_from(vortex_buffer::Buffer<T>) -> core::result::Result<Self, Self::Error>
 
-impl<T: core::cmp::PartialEq> core::cmp::PartialEq<alloc::vec::Vec<T>> for vortex_buffer::Buffer<T>
+impl<T: core::clone::Clone> core::clone::Clone for vortex_buffer::Buffer<T>
 
-pub fn vortex_buffer::Buffer<T>::eq(&self, &alloc::vec::Vec<T>) -> bool
-
-impl<T: core::cmp::PartialEq> core::cmp::PartialEq<vortex_buffer::Buffer<T>> for alloc::vec::Vec<T>
-
-pub fn alloc::vec::Vec<T>::eq(&self, &vortex_buffer::Buffer<T>) -> bool
+pub fn vortex_buffer::Buffer<T>::clone(&self) -> vortex_buffer::Buffer<T>
 
 impl<T: core::fmt::Debug> core::fmt::Debug for vortex_buffer::Buffer<T>
 
@@ -653,10 +649,6 @@ pub type vortex_buffer::Buffer<T>::IntoIter = vortex_buffer::BufferIterator<T>
 pub type vortex_buffer::Buffer<T>::Item = T
 
 pub fn vortex_buffer::Buffer<T>::into_iter(self) -> Self::IntoIter
-
-impl<T> core::clone::Clone for vortex_buffer::Buffer<T>
-
-pub fn vortex_buffer::Buffer<T>::clone(&self) -> Self
 
 impl<T> core::cmp::Eq for vortex_buffer::Buffer<T>
 

--- a/vortex-buffer/src/buffer.rs
+++ b/vortex-buffer/src/buffer.rs
@@ -24,23 +24,12 @@ use crate::debug::TruncatedDebug;
 use crate::trusted_len::TrustedLen;
 
 /// An immutable buffer of items of `T`.
+#[derive(Clone)]
 pub struct Buffer<T> {
     pub(crate) bytes: Bytes,
     pub(crate) length: usize,
     pub(crate) alignment: Alignment,
     pub(crate) _marker: PhantomData<T>,
-}
-
-impl<T> Clone for Buffer<T> {
-    #[inline]
-    fn clone(&self) -> Self {
-        Self {
-            bytes: self.bytes.clone(),
-            length: self.length,
-            alignment: self.alignment,
-            _marker: PhantomData,
-        }
-    }
 }
 
 impl<T> Default for Buffer<T> {
@@ -58,18 +47,6 @@ impl<T> PartialEq for Buffer<T> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.bytes == other.bytes
-    }
-}
-
-impl<T: PartialEq> PartialEq<Vec<T>> for Buffer<T> {
-    fn eq(&self, other: &Vec<T>) -> bool {
-        self.as_ref() == other.as_slice()
-    }
-}
-
-impl<T: PartialEq> PartialEq<Buffer<T>> for Vec<T> {
-    fn eq(&self, other: &Buffer<T>) -> bool {
-        self.as_slice() == other.as_ref()
     }
 }
 
@@ -806,7 +783,7 @@ mod test {
         let vec = vec![1, 2, 3, 4, 5];
         let buff = Buffer::from(vec.clone());
         assert!(buff.is_aligned(Alignment::of::<i32>()));
-        assert_eq!(vec, buff);
+        assert_eq!(vec, buff.as_ref());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Remove a PartialEq impl we don't use and can be expressed with `as_ref` + derive `Clone` which generates identical code.


## API Changes

None

## Testing

Existing tests
