### PR TITLE
like stat falsification respects escape characters

### DIFF
--- a/encodings/fsst/src/compute/like.rs
+++ b/encodings/fsst/src/compute/like.rs
@@ -291,6 +291,65 @@ mod tests {
     }
 
     #[test]
+    fn test_like_kernel_falls_back_for_escape_patterns() -> VortexResult<()> {
+        let fsst = make_fsst(
+            &[Some("\\front"), Some("\\\\front"), Some("%front")],
+            Nullability::NonNullable,
+        );
+        let mut ctx = SESSION.create_execution_ctx();
+        let fsst_v = fsst.as_view();
+
+        let pattern = ConstantArray::new(r"\\%", fsst.len()).into_array();
+        let result =
+            <FSST as LikeKernel>::like(fsst_v, &pattern, LikeOptions::default(), &mut ctx)?;
+        assert!(
+            result.is_none(),
+            "escaped backslash pattern should fall back"
+        );
+
+        let pattern = ConstantArray::new(r"\%%", fsst.len()).into_array();
+        let result =
+            <FSST as LikeKernel>::like(fsst_v, &pattern, LikeOptions::default(), &mut ctx)?;
+        assert!(result.is_none(), "escaped percent pattern should fall back");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_like_escape_patterns_fall_back_correctly() -> VortexResult<()> {
+        let fsst = make_fsst(
+            &[
+                Some("\\front"),
+                Some("\\\\front"),
+                Some("%front"),
+                Some("_front"),
+                Some("front"),
+            ],
+            Nullability::NonNullable,
+        );
+
+        let result = like(fsst.clone(), r"\\%")?;
+        assert_arrays_eq!(
+            &result,
+            &BoolArray::from_iter([true, true, false, false, false])
+        );
+
+        let result = like(fsst.clone(), r"\%%")?;
+        assert_arrays_eq!(
+            &result,
+            &BoolArray::from_iter([false, false, true, false, false])
+        );
+
+        let result = like(fsst, r"\_%")?;
+        assert_arrays_eq!(
+            &result,
+            &BoolArray::from_iter([false, false, false, true, false])
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn test_like_long_prefix_handled_by_flat_dfa() -> VortexResult<()> {
         let fsst = make_fsst(
             &[

--- a/encodings/fsst/src/compute/like.rs
+++ b/encodings/fsst/src/compute/like.rs
@@ -291,65 +291,6 @@ mod tests {
     }
 
     #[test]
-    fn test_like_kernel_falls_back_for_escape_patterns() -> VortexResult<()> {
-        let fsst = make_fsst(
-            &[Some("\\front"), Some("\\\\front"), Some("%front")],
-            Nullability::NonNullable,
-        );
-        let mut ctx = SESSION.create_execution_ctx();
-        let fsst_v = fsst.as_view();
-
-        let pattern = ConstantArray::new(r"\\%", fsst.len()).into_array();
-        let result =
-            <FSST as LikeKernel>::like(fsst_v, &pattern, LikeOptions::default(), &mut ctx)?;
-        assert!(
-            result.is_none(),
-            "escaped backslash pattern should fall back"
-        );
-
-        let pattern = ConstantArray::new(r"\%%", fsst.len()).into_array();
-        let result =
-            <FSST as LikeKernel>::like(fsst_v, &pattern, LikeOptions::default(), &mut ctx)?;
-        assert!(result.is_none(), "escaped percent pattern should fall back");
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_like_escape_patterns_fall_back_correctly() -> VortexResult<()> {
-        let fsst = make_fsst(
-            &[
-                Some("\\front"),
-                Some("\\\\front"),
-                Some("%front"),
-                Some("_front"),
-                Some("front"),
-            ],
-            Nullability::NonNullable,
-        );
-
-        let result = like(fsst.clone(), r"\\%")?;
-        assert_arrays_eq!(
-            &result,
-            &BoolArray::from_iter([true, true, false, false, false])
-        );
-
-        let result = like(fsst.clone(), r"\%%")?;
-        assert_arrays_eq!(
-            &result,
-            &BoolArray::from_iter([false, false, true, false, false])
-        );
-
-        let result = like(fsst, r"\_%")?;
-        assert_arrays_eq!(
-            &result,
-            &BoolArray::from_iter([false, false, false, true, false])
-        );
-
-        Ok(())
-    }
-
-    #[test]
     fn test_like_long_prefix_handled_by_flat_dfa() -> VortexResult<()> {
         let fsst = make_fsst(
             &[

--- a/vortex-array/src/scalar_fn/fns/like/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/like/mod.rs
@@ -3,6 +3,7 @@
 
 mod kernel;
 
+use std::borrow::Cow;
 use std::fmt::Display;
 use std::fmt::Formatter;
 
@@ -189,13 +190,19 @@ impl ScalarFnVTable for Like {
         match LikeVariant::from_str(pat_str)? {
             LikeVariant::Exact(text) => {
                 // col LIKE 'exact' ==>  col.min > 'exact' || col.max < 'exact'
-                Some(or(gt(src_min, lit(text)), lt(src_max, lit(text))))
+                Some(or(
+                    gt(src_min, lit(text.as_ref())),
+                    lt(src_max, lit(text.as_ref())),
+                ))
             }
             LikeVariant::Prefix(prefix) => {
                 // col LIKE 'prefix%' ==> col.max < 'prefix' || col.min >= 'prefiy'
                 let succ = prefix.to_string().increment().ok()?;
 
-                Some(or(gt_eq(src_min, lit(succ)), lt(src_max, lit(prefix))))
+                Some(or(
+                    gt_eq(src_min, lit(succ)),
+                    lt(src_max, lit(prefix.as_ref())),
+                ))
             }
         }
     }
@@ -234,29 +241,53 @@ pub(crate) fn arrow_like(
 /// Variants of the LIKE filter that we know how to turn into a stats pruning predicate.s
 #[derive(Debug, PartialEq)]
 enum LikeVariant<'a> {
-    Exact(&'a str),
-    Prefix(&'a str),
+    Exact(Cow<'a, str>),
+    Prefix(Cow<'a, str>),
 }
 
 impl<'a> LikeVariant<'a> {
     /// Parse a LIKE pattern string into its relevant variant
-    fn from_str(string: &str) -> Option<LikeVariant<'_>> {
-        let Some(wildcard_pos) = string.find(['%', '_']) else {
-            return Some(LikeVariant::Exact(string));
-        };
+    fn from_str(string: &'a str) -> Option<LikeVariant<'a>> {
+        let mut literal = None;
+        let mut chars = string.char_indices();
 
-        // Can't handle wildcard in the front.
-        if wildcard_pos == 0 {
-            return None;
+        while let Some((idx, c)) = chars.next() {
+            match c {
+                '\\' => {
+                    let literal = literal.get_or_insert_with(|| string[..idx].to_string());
+                    match chars.next() {
+                        Some((_, escaped)) => literal.push(escaped),
+                        None => literal.push('\\'),
+                    }
+                }
+                '%' | '_' => {
+                    return match literal {
+                        Some(literal) => (!literal.is_empty())
+                            .then_some(LikeVariant::Prefix(Cow::Owned(literal))),
+                        None => {
+                            (idx != 0).then_some(LikeVariant::Prefix(Cow::Borrowed(&string[..idx])))
+                        }
+                    };
+                }
+                c => {
+                    if let Some(literal) = &mut literal {
+                        literal.push(c);
+                    }
+                }
+            }
         }
 
-        let prefix = &string[..wildcard_pos];
-        Some(LikeVariant::Prefix(prefix))
+        Some(match literal {
+            Some(literal) => LikeVariant::Exact(Cow::Owned(literal)),
+            None => LikeVariant::Exact(Cow::Borrowed(string)),
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use crate::IntoArray;
     use crate::arrays::BoolArray;
     use crate::assert_arrays_eq;
@@ -306,21 +337,44 @@ mod tests {
     #[test]
     fn test_like_variant() {
         // Supported patterns
-        assert_eq!(
+        assert!(matches!(
             LikeVariant::from_str("simple"),
-            Some(LikeVariant::Exact("simple"))
-        );
-        assert_eq!(
+            Some(LikeVariant::Exact(Cow::Borrowed(text))) if text == "simple"
+        ));
+        assert!(matches!(
             LikeVariant::from_str("prefix%"),
-            Some(LikeVariant::Prefix("prefix"))
-        );
-        assert_eq!(
+            Some(LikeVariant::Prefix(Cow::Borrowed(text))) if text == "prefix"
+        ));
+        assert!(matches!(
             LikeVariant::from_str("first%rest_stuff"),
-            Some(LikeVariant::Prefix("first"))
-        );
+            Some(LikeVariant::Prefix(Cow::Borrowed(text))) if text == "first"
+        ));
+
+        // Escaped LIKE wildcards are literal prefix bytes, not wildcard boundaries.
+        assert!(matches!(
+            LikeVariant::from_str(r"\%%"),
+            Some(LikeVariant::Prefix(Cow::Owned(text))) if text == "%"
+        ));
+        assert!(matches!(
+            LikeVariant::from_str(r"\_%"),
+            Some(LikeVariant::Prefix(Cow::Owned(text))) if text == "_"
+        ));
+        assert!(matches!(
+            LikeVariant::from_str(r"\\%"),
+            Some(LikeVariant::Prefix(Cow::Owned(text))) if text == "\\"
+        ));
+        assert!(matches!(
+            LikeVariant::from_str(r"\%"),
+            Some(LikeVariant::Exact(Cow::Owned(text))) if text == "%"
+        ));
+        assert!(matches!(
+            LikeVariant::from_str("trailing\\"),
+            Some(LikeVariant::Exact(Cow::Owned(text))) if text == "trailing\\"
+        ));
 
         // Unsupported patterns
         assert_eq!(LikeVariant::from_str("%suffix"), None);
+        assert_eq!(LikeVariant::from_str(r"%\%%"), None);
         assert_eq!(LikeVariant::from_str("_pattern"), None);
     }
 
@@ -335,6 +389,11 @@ mod tests {
             .expect("LIKE stat falsification");
 
         insta::assert_snapshot!(pruning_expr, @r#"(($.a_min >= "prefiy") or ($.a_max < "prefix"))"#);
+
+        let pruning_expr = like(col("a"), lit(r"\%%"))
+            .stat_falsification(&catalog)
+            .expect("LIKE stat falsification");
+        insta::assert_snapshot!(pruning_expr, @r#"(($.a_min >= "&") or ($.a_max < "%"))"#);
 
         // Multiple wildcards
         let pruning_expr = like(col("a"), lit("pref%ix%"))

--- a/vortex-array/src/scalar_fn/fns/like/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/like/mod.rs
@@ -334,45 +334,56 @@ mod tests {
         assert_eq!(expr2.to_string(), "$ not ilike \"test*\"");
     }
 
+    fn assert_borrowed_exact(pattern: &str, expected: &str) {
+        let Some(LikeVariant::Exact(actual)) = LikeVariant::from_str(pattern) else {
+            panic!("expected borrowed exact pattern");
+        };
+        assert!(matches!(actual, Cow::Borrowed(_)));
+        assert_eq!(actual.as_ref(), expected);
+    }
+
+    fn assert_owned_exact(pattern: &str, expected: &str) {
+        let Some(LikeVariant::Exact(actual)) = LikeVariant::from_str(pattern) else {
+            panic!("expected owned exact pattern");
+        };
+        assert!(matches!(actual, Cow::Owned(_)));
+        assert_eq!(actual.as_ref(), expected);
+    }
+
+    fn assert_borrowed_prefix(pattern: &str, expected: &str) {
+        let Some(LikeVariant::Prefix(actual)) = LikeVariant::from_str(pattern) else {
+            panic!("expected borrowed prefix pattern");
+        };
+        assert!(matches!(actual, Cow::Borrowed(_)));
+        assert_eq!(actual.as_ref(), expected);
+    }
+
+    fn assert_owned_prefix(pattern: &str, expected: &str) {
+        let Some(LikeVariant::Prefix(actual)) = LikeVariant::from_str(pattern) else {
+            panic!("expected owned prefix pattern");
+        };
+        assert!(matches!(actual, Cow::Owned(_)));
+        assert_eq!(actual.as_ref(), expected);
+    }
+
     #[test]
-    fn test_like_variant() {
-        // Supported patterns
-        assert!(matches!(
-            LikeVariant::from_str("simple"),
-            Some(LikeVariant::Exact(Cow::Borrowed(text))) if text == "simple"
-        ));
-        assert!(matches!(
-            LikeVariant::from_str("prefix%"),
-            Some(LikeVariant::Prefix(Cow::Borrowed(text))) if text == "prefix"
-        ));
-        assert!(matches!(
-            LikeVariant::from_str("first%rest_stuff"),
-            Some(LikeVariant::Prefix(Cow::Borrowed(text))) if text == "first"
-        ));
+    fn test_like_variant_borrowed_patterns() {
+        assert_borrowed_exact("simple", "simple");
+        assert_borrowed_prefix("prefix%", "prefix");
+        assert_borrowed_prefix("first%rest_stuff", "first");
+    }
 
-        // Escaped LIKE wildcards are literal prefix bytes, not wildcard boundaries.
-        assert!(matches!(
-            LikeVariant::from_str(r"\%%"),
-            Some(LikeVariant::Prefix(Cow::Owned(text))) if text == "%"
-        ));
-        assert!(matches!(
-            LikeVariant::from_str(r"\_%"),
-            Some(LikeVariant::Prefix(Cow::Owned(text))) if text == "_"
-        ));
-        assert!(matches!(
-            LikeVariant::from_str(r"\\%"),
-            Some(LikeVariant::Prefix(Cow::Owned(text))) if text == "\\"
-        ));
-        assert!(matches!(
-            LikeVariant::from_str(r"\%"),
-            Some(LikeVariant::Exact(Cow::Owned(text))) if text == "%"
-        ));
-        assert!(matches!(
-            LikeVariant::from_str("trailing\\"),
-            Some(LikeVariant::Exact(Cow::Owned(text))) if text == "trailing\\"
-        ));
+    #[test]
+    fn test_like_variant_escaped_patterns() {
+        assert_owned_prefix(r"\%%", "%");
+        assert_owned_prefix(r"\_%", "_");
+        assert_owned_prefix(r"\\%", "\\");
+        assert_owned_exact(r"\%", "%");
+        assert_owned_exact("trailing\\", "trailing\\");
+    }
 
-        // Unsupported patterns
+    #[test]
+    fn test_like_variant_unsupported_patterns() {
         assert_eq!(LikeVariant::from_str("%suffix"), None);
         assert_eq!(LikeVariant::from_str(r"%\%%"), None);
         assert_eq!(LikeVariant::from_str("_pattern"), None);


### PR DESCRIPTION
## Summary

In pruning of like expressions. We didn't remove the escape characters in the pattern, so we were getting wrong prefixes and exact patterns forwarded to further stat falsification

## Testing

unit tests
