### PR TITLE
Fix native library publish for non amd64 platforms

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,6 +80,10 @@ jobs:
     env:
       # Picked up by gradle-git-version
       GIT_VERSION: ${{ github.event.release.tag_name }}
+      # The cross-compiled release JNI libs are copied into resources/native/
+      # before any gradle task runs; skip the host-arch rebuild that would
+      # otherwise overwrite them with a debug amd64 .so on the publish runner.
+      VORTEX_SKIP_MAKE_TEST_FILES: "true"
     defaults:
       run:
         working-directory: ./java

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -10,25 +10,40 @@ permissions:
 jobs:
   build:
     name: Build ${{ matrix.target }}
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: >-
+      ${{ github.repository == 'vortex-data/vortex'
+          && matrix.runner
+          || matrix.fallback_runner }}
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: aarch64-apple-darwin
-            runs-on: macos-latest
+            runner: macos-latest
+            fallback_runner: macos-latest
             archive: tgz
           - target: x86_64-apple-darwin
-            runs-on: macos-15-intel
+            runner: macos-15-intel
+            fallback_runner: macos-15-intel
             archive: tgz
+          # Linux targets cross-compile from an amd64 runs-on runner via
+          # cargo-zigbuild with glibc 2.31 pinning, matching the Python wheel
+          # and JNI builds.
           - target: aarch64-unknown-linux-gnu
-            runs-on: ubuntu-24.04-arm
+            runner: runs-on=${{ github.run_id }}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/tag=release-vx-aarch64-linux
+            fallback_runner: ubuntu-24.04
             archive: tgz
           - target: x86_64-unknown-linux-gnu
-            runs-on: ubuntu-24.04
+            runner: runs-on=${{ github.run_id }}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/tag=release-vx-amd64-linux
+            fallback_runner: ubuntu-24.04
             archive: tgz
     steps:
+      - uses: runs-on/action@v2
+        if: github.repository == 'vortex-data/vortex' && contains(matrix.target, 'linux')
+        with:
+          sccache: s3
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
@@ -37,9 +52,24 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           targets: ${{ matrix.target }}
-          enable-sccache: "false"
+          enable-sccache: ${{ contains(matrix.target, 'linux') && 'true' || 'false' }}
 
-      - name: Build release binary
+      - name: Setup Zig
+        if: contains(matrix.target, 'linux')
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29  # v2.2.1
+
+      - name: Install cargo-zigbuild
+        if: contains(matrix.target, 'linux')
+        uses: taiki-e/cache-cargo-install-action@66c9585ef5ca780ee69399975a5e911f47905995
+        with:
+          tool: cargo-zigbuild
+
+      - name: Build release binary (Linux, zigbuild)
+        if: contains(matrix.target, 'linux')
+        run: cargo zigbuild --release --package vortex-tui --bin vx --target ${{ matrix.target }}.2.31
+
+      - name: Build release binary (macOS)
+        if: contains(matrix.target, 'apple-darwin')
         run: cargo build --release --package vortex-tui --bin vx --target ${{ matrix.target }}
 
       - name: Create archive (tgz)

--- a/java/vortex-jni/build.gradle.kts
+++ b/java/vortex-jni/build.gradle.kts
@@ -112,31 +112,43 @@ tasks.register("makeTestFiles") {
     description = "Generate files used by unit tests"
     group = "verification"
 
+    // The publish workflow places release, cross-compiled libs for every supported
+    // architecture before invoking shadowJar; rebuilding the host-arch debug lib
+    // here would overwrite them (linux-aarch64 ends up holding a linux-amd64 .so).
+    onlyIf { System.getenv("VORTEX_SKIP_MAKE_TEST_FILES") != "true" }
+
     doLast {
         println("makeTestFiles executed")
 
         val execOps = serviceOf<ExecOperations>()
 
-        // Build the JNI lib
+        // Build the JNI lib for the host architecture only.
         execOps.exec {
             workingDir = rootProject.projectDir.absoluteFile.parentFile
             executable = "cargo"
             args("build", "--package", "vortex-jni")
         }
 
-        copy {
-            from("${rootProject.projectDir.absoluteFile.parentFile}/target/debug/libvortex_jni.so")
-            into("$projectDir/src/main/resources/native/linux-amd64")
+        val osName = System.getProperty("os.name").lowercase()
+        val osArch = System.getProperty("os.arch").lowercase()
+        val osShortName = when {
+            osName.contains("mac") -> "darwin"
+            osName.contains("nix") || osName.contains("nux") -> "linux"
+            osName.contains("win") -> "win"
+            else -> throw GradleException("Unsupported OS for makeTestFiles: $osName")
+        }
+        val libExt = when (osShortName) {
+            "darwin" -> ".dylib"
+            "linux" -> ".so"
+            "win" -> ".dll"
+            else -> throw GradleException("Unsupported OS short name: $osShortName")
         }
 
+        // Only populate the host-arch directory so cross-compiled libs for other
+        // architectures (placed by the publish workflow) are preserved.
         copy {
-            from("${rootProject.projectDir.absoluteFile.parentFile}/target/debug/libvortex_jni.so")
-            into("$projectDir/src/main/resources/native/linux-aarch64")
-        }
-
-        copy {
-            from("${rootProject.projectDir.absoluteFile.parentFile}/target/debug/libvortex_jni.dylib")
-            into("$projectDir/src/main/resources/native/darwin-aarch64")
+            from("${rootProject.projectDir.absoluteFile.parentFile}/target/debug/libvortex_jni$libExt")
+            into("$projectDir/src/main/resources/native/$osShortName-$osArch")
         }
     }
 }


### PR DESCRIPTION
When publishing native packages make sure different architectures don't override
each other

