### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,39 @@
+cff-version: 1.2.0
+title: Vortex
+abstract: >-
+  Vortex is an extensible framework for compressed columnar data, spanning
+  in-memory arrays, on-disk file formats, over-the-wire protocols, and query
+  engine integrations. It decouples a logical type system from physical layout
+  and provides a pluggable system of cascading compression encodings that
+  operate directly on compressed data with zero-copy Apache Arrow
+  compatibility. These components compose into a default file format, and
+  Vortex integrates with engines including DataFusion, DuckDB, and Spark.
+type: software
+version: 0.72.0
+date-released: 2026-05-20
+url: "https://github.com/vortex-data/vortex"
+repository-code: "https://github.com/vortex-data/vortex"
+license: Apache-2.0
+authors:
+  - given-names: Nicholas
+    family-names: Gates
+    email: "nick@spiraldb.com"
+    affiliation: Spiral
+  - given-names: Robert
+    family-names: Kruszewski
+    email: "robert@spiraldb.com"
+    affiliation: Spiral
+  - given-names: Will
+    family-names: Manning
+    email: "will@spiraldb.com"
+    affiliation: Spiral
+keywords:
+  - columnar
+  - file-format
+  - compression
+  - arrow
+  - encodings
+  - object-storage
+message: >-
+  If you use Vortex in academic work, please cite it using the metadata in this
+  file.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![PyPI - Version](https://img.shields.io/pypi/v/vortex-data)](https://pypi.org/project/vortex-data/)
 [![Maven - Version](https://img.shields.io/maven-central/v/dev.vortex/vortex-spark)](https://central.sonatype.com/artifact/dev.vortex/vortex-spark)
 [![codecov](https://codecov.io/github/vortex-data/vortex/graph/badge.svg)](https://codecov.io/github/vortex-data/vortex)
+[![Cite](https://img.shields.io/badge/cite-CITATION.cff-blue)](CITATION.cff)
 
 [Join the community on Slack!](https://vortex.dev/slack) | [Documentation](https://docs.vortex.dev/) | [Performance Benchmarks](https://bench.vortex.dev)
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -36,7 +36,7 @@ SPDX-FileCopyrightText = "Copyright the Vortex contributors"
 SPDX-License-Identifier = "CC-BY-4.0"
 
 [[annotations]]
-path = ["**/.gitignore", ".gitmodules", ".python-version", "**/*.lock", "**/*.lockfile", "**/*.toml", "**/*.json", ".idea/**", ".github/**", "codecov.yml", "java/gradle/wrapper/gradle-wrapper.properties", "**.duckdb*"]
+path = ["**/.gitignore", ".gitmodules", ".python-version", "**/*.lock", "**/*.lockfile", "**/*.toml", "**/*.json", "CITATION.cff", ".idea/**", ".github/**", "codecov.yml", "java/gradle/wrapper/gradle-wrapper.properties", "**.duckdb*"]
 precedence = "override"
 SPDX-FileCopyrightText = "Copyright the Vortex contributors"
 SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
Adds a `CITATION.cff` so GitHub shows a "Cite this repository" button and exposes machine-readable citation metadata, plus a cite badge in the README that links to it. Structure and author list follow Spiral's Raincloud file; fields are retargeted to Vortex — version 0.72.0, the `vortex-data/vortex` remote, and an abstract that frames Vortex as an extensible framework for compressed columnar data with a default file format, rather than a single format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
