### PR TITLE
Support for importing Arrow extension arrays into core vortex arrays and ParquetVariant support.

### DIFF
--- a/encodings/parquet-variant/src/arrow.rs
+++ b/encodings/parquet-variant/src/arrow.rs
@@ -48,6 +48,8 @@ impl ArrowExportVTable for ParquetVariant {
         dtype: &DType,
         _session: &ArrowSession,
     ) -> VortexResult<Option<Field>> {
+        // TODO(#8135): This is wrong and won't work for shredded arrays.
+        // We need to be able to access array metadata to accurately provide Arrow schemas.
         if !dtype.is_variant() {
             return Ok(None);
         }

--- a/encodings/parquet-variant/src/arrow.rs
+++ b/encodings/parquet-variant/src/arrow.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::sync::Arc;
+
+use arrow_array::Array as _;
+use arrow_array::ArrayRef as ArrowArrayRef;
+use arrow_array::cast::AsArray;
+use arrow_schema::DataType;
+use arrow_schema::Field;
+use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
+use parquet_variant_compute::VariantArray as ArrowVariantArray;
+use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::VTable;
+use vortex_array::arrow::ArrowExport;
+use vortex_array::arrow::ArrowExportVTable;
+use vortex_array::arrow::ArrowImport;
+use vortex_array::arrow::ArrowImportVTable;
+use vortex_array::arrow::ArrowSession;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::extension::ExtDTypeRef;
+use vortex_error::VortexResult;
+use vortex_error::vortex_err;
+use vortex_session::registry::CachedId;
+use vortex_session::registry::Id;
+
+use crate::ParquetVariant;
+use crate::ParquetVariantArrayExt;
+
+/// Arrow canonical extension name for Parquet Variant storage.
+pub const PARQUET_VARIANT_ARROW_EXTENSION_NAME: &str = "arrow.parquet.variant";
+
+static ARROW_PARQUET_VARIANT: CachedId = CachedId::new(PARQUET_VARIANT_ARROW_EXTENSION_NAME);
+
+impl ArrowExportVTable for ParquetVariant {
+    fn arrow_ext_id(&self) -> Id {
+        *ARROW_PARQUET_VARIANT
+    }
+
+    fn vortex_ext_id(&self) -> Id {
+        ParquetVariant.id()
+    }
+
+    fn to_arrow_field(
+        &self,
+        _name: &str,
+        _dtype: &ExtDTypeRef,
+        _session: &ArrowSession,
+    ) -> VortexResult<Option<Field>> {
+        Ok(None)
+    }
+
+    fn execute_arrow(
+        &self,
+        array: ArrayRef,
+        target: &Field,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrowExport> {
+        if target
+            .metadata()
+            .get(EXTENSION_TYPE_NAME_KEY)
+            .map(String::as_str)
+            != Some(PARQUET_VARIANT_ARROW_EXTENSION_NAME)
+            || !array.dtype().is_variant()
+        {
+            return Ok(ArrowExport::Unsupported(array));
+        }
+
+        let executed = array.execute_until::<ParquetVariant>(ctx)?;
+        let parquet_array = executed
+            .as_opt::<ParquetVariant>()
+            .ok_or_else(|| vortex_err!("cannot export Variant without ParquetVariant storage"))?;
+        let arrow_variant = parquet_array.to_arrow(ctx)?;
+        Ok(ArrowExport::Exported(Arc::new(arrow_variant.into_inner())))
+    }
+}
+
+impl ArrowImportVTable for ParquetVariant {
+    fn arrow_ext_id(&self) -> Id {
+        *ARROW_PARQUET_VARIANT
+    }
+
+    fn from_arrow_field(&self, field: &Field) -> VortexResult<Option<DType>> {
+        if field
+            .metadata()
+            .get(EXTENSION_TYPE_NAME_KEY)
+            .map(String::as_str)
+            != Some(PARQUET_VARIANT_ARROW_EXTENSION_NAME)
+        {
+            return Ok(None);
+        }
+
+        Ok(Some(DType::Variant(field.is_nullable().into())))
+    }
+
+    fn from_arrow_array(
+        &self,
+        array: ArrowArrayRef,
+        field: &Field,
+        dtype: &DType,
+    ) -> VortexResult<ArrowImport> {
+        if !matches!(dtype, DType::Variant(_))
+            || field
+                .metadata()
+                .get(EXTENSION_TYPE_NAME_KEY)
+                .map(String::as_str)
+                != Some(PARQUET_VARIANT_ARROW_EXTENSION_NAME)
+            || !matches!(array.data_type(), DataType::Struct(_))
+        {
+            return Ok(ArrowImport::Unsupported(array));
+        }
+
+        let arrow_variant = ArrowVariantArray::try_new(array.as_struct())?;
+        let imported = if dtype.is_nullable() {
+            ParquetVariant::from_arrow_variant_nullable(&arrow_variant)?
+        } else {
+            ParquetVariant::from_arrow_variant(&arrow_variant)?
+        };
+        Ok(ArrowImport::Imported(imported.into_array()))
+    }
+}

--- a/encodings/parquet-variant/src/arrow.rs
+++ b/encodings/parquet-variant/src/arrow.rs
@@ -5,10 +5,13 @@ use std::sync::Arc;
 
 use arrow_array::Array as _;
 use arrow_array::ArrayRef as ArrowArrayRef;
+use arrow_array::StructArray;
 use arrow_array::cast::AsArray;
 use arrow_schema::DataType;
 use arrow_schema::Field;
+use arrow_schema::Fields;
 use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
+use parquet_variant_compute::GetOptions;
 use parquet_variant_compute::VariantArray as ArrowVariantArray;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
@@ -19,9 +22,10 @@ use vortex_array::arrow::ArrowExportVTable;
 use vortex_array::arrow::ArrowImport;
 use vortex_array::arrow::ArrowImportVTable;
 use vortex_array::arrow::ArrowSession;
+use vortex_array::arrow::ArrowSessionExt;
+use vortex_array::arrow::to_arrow_null_buffer;
 use vortex_array::dtype::DType;
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_session::registry::CachedId;
 use vortex_session::registry::Id;
@@ -32,6 +36,58 @@ use crate::ParquetVariantArrayExt;
 /// Arrow canonical extension name for Parquet Variant storage.
 const PARQUET_VARIANT_ARROW_EXTENSION_NAME: &str = "arrow.parquet.variant";
 static ARROW_PARQUET_VARIANT: CachedId = CachedId::new(PARQUET_VARIANT_ARROW_EXTENSION_NAME);
+
+fn is_parquet_variant_storage_fields(fields: &Fields) -> bool {
+    let mut has_metadata = false;
+    let mut has_value_or_typed = false;
+
+    for field in fields {
+        match field.name().as_str() {
+            "metadata" => has_metadata = true,
+            "value" | "typed_value" => has_value_or_typed = true,
+            _ => return false,
+        }
+    }
+
+    has_metadata && has_value_or_typed
+}
+
+fn try_export_storage_to_target<T: ParquetVariantArrayExt>(
+    parquet_array: &T,
+    target_fields: &Fields,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Option<ArrowArrayRef>> {
+    let mut arrays = Vec::with_capacity(target_fields.len());
+
+    for field in target_fields {
+        let child = match field.name().as_str() {
+            "metadata" => Some(parquet_array.metadata_array().clone()),
+            "value" => parquet_array.value_array().cloned(),
+            "typed_value" => parquet_array.typed_value_array().cloned(),
+            _ => return Ok(None),
+        };
+        let Some(child) = child else {
+            return Ok(None);
+        };
+
+        arrays.push(ctx.session().clone().arrow().execute_arrow(
+            child,
+            Some(field.as_ref()),
+            ctx,
+        )?);
+    }
+
+    let nulls = to_arrow_null_buffer(
+        ParquetVariantArrayExt::validity(parquet_array),
+        parquet_array.as_ref().len(),
+        ctx,
+    )?;
+    Ok(Some(Arc::new(StructArray::try_new(
+        target_fields.clone(),
+        arrays,
+        nulls,
+    )?)))
+}
 
 impl ArrowExportVTable for ParquetVariant {
     fn arrow_ext_id(&self) -> Id {
@@ -45,16 +101,12 @@ impl ArrowExportVTable for ParquetVariant {
     fn to_arrow_field(
         &self,
         _name: &str,
-        dtype: &DType,
+        _dtype: &DType,
         _session: &ArrowSession,
     ) -> VortexResult<Option<Field>> {
-        // TODO(#8135): This is wrong and won't work for shredded arrays.
-        // We need to be able to access array metadata to accurately provide Arrow schemas.
-        if !dtype.is_variant() {
-            return Ok(None);
-        }
-
-        vortex_bail!(InvalidArgument: "ParquetVariant array can't infer its Arrow storage schema from dtype");
+        // Variant field inference is handled by `ArrowSession::to_arrow_field` directly; this
+        // plugin hook is only consulted for `DType::Extension`, never for `DType::Variant`.
+        Ok(None)
     }
 
     fn execute_arrow(
@@ -76,8 +128,32 @@ impl ArrowExportVTable for ParquetVariant {
         let parquet_array = executed
             .as_opt::<ParquetVariant>()
             .ok_or_else(|| vortex_err!("cannot export Variant without ParquetVariant storage"))?;
-        let arrow_variant = parquet_array.to_arrow(ctx)?;
-        Ok(ArrowExport::Exported(Arc::new(arrow_variant.into_inner())))
+
+        if let DataType::Struct(fields) = target.data_type()
+            && is_parquet_variant_storage_fields(fields)
+        {
+            if let Some(storage) = try_export_storage_to_target(&parquet_array, fields, ctx)? {
+                return Ok(ArrowExport::Exported(storage));
+            }
+
+            // The target is a Parquet Variant physical storage schema, not a logical variant
+            // projection. Return preferred storage rather than passing storage field names through
+            // `variant_get` as object keys.
+            return Ok(ArrowExport::Exported(
+                Arc::new(parquet_array.to_arrow(ctx)?.into_inner()) as ArrowArrayRef,
+            ));
+        }
+
+        let arrow_variant = Arc::new(parquet_array.to_arrow(ctx)?.into_inner()) as ArrowArrayRef;
+
+        if arrow_variant.data_type() == target.data_type() {
+            Ok(ArrowExport::Exported(arrow_variant))
+        } else {
+            Ok(ArrowExport::Exported(parquet_variant_compute::variant_get(
+                &arrow_variant,
+                GetOptions::new().with_as_type(Some(target.clone().into())),
+            )?))
+        }
     }
 }
 
@@ -242,16 +318,15 @@ mod tests {
             .into_array();
         let expected = array.clone();
 
+        let mut ctx = session.create_execution_ctx();
+        let exported = session
+            .arrow()
+            .execute_arrow(array.clone(), None, &mut ctx)?;
+
         let field = Field::new(
-            "variant",
-            DataType::Struct(
-                vec![
-                    Field::new("metadata", DataType::Binary, false),
-                    Field::new("value", DataType::Binary, false),
-                ]
-                .into(),
-            ),
-            false,
+            "",
+            exported.data_type().clone(),
+            array.dtype().is_nullable(),
         )
         .with_metadata(
             [(
@@ -260,10 +335,7 @@ mod tests {
             )]
             .into(),
         );
-        let mut ctx = session.create_execution_ctx();
-        let exported = session
-            .arrow()
-            .execute_arrow(array, Some(&field), &mut ctx)?;
+
         let actual = session
             .arrow()
             .from_arrow_array(Arc::clone(&exported), &field)?;
@@ -313,10 +385,10 @@ mod tests {
         let exported = session
             .arrow()
             .execute_arrow(array, Some(&field), &mut ctx)?;
-        assert_ne!(
+        assert_eq!(
             exported.data_type(),
             field.data_type(),
-            "The current arrow field isn't fully validated to the full storage type"
+            "Parquet Variant export should honor the requested storage schema"
         );
 
         let actual = session.arrow().from_arrow_array(exported, &field)?;

--- a/encodings/parquet-variant/src/arrow.rs
+++ b/encodings/parquet-variant/src/arrow.rs
@@ -13,6 +13,7 @@ use arrow_schema::Fields;
 use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
 use parquet_variant_compute::GetOptions;
 use parquet_variant_compute::VariantArray as ArrowVariantArray;
+use parquet_variant_compute::unshred_variant;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
@@ -26,6 +27,7 @@ use vortex_array::arrow::ArrowSessionExt;
 use vortex_array::arrow::to_arrow_null_buffer;
 use vortex_array::dtype::DType;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_session::registry::CachedId;
 use vortex_session::registry::Id;
@@ -37,26 +39,28 @@ use crate::ParquetVariantArrayExt;
 const PARQUET_VARIANT_ARROW_EXTENSION_NAME: &str = "arrow.parquet.variant";
 static ARROW_PARQUET_VARIANT: CachedId = CachedId::new(PARQUET_VARIANT_ARROW_EXTENSION_NAME);
 
-fn is_parquet_variant_storage_fields(fields: &Fields) -> bool {
+fn parquet_variant_storage_request(fields: &Fields) -> Option<(bool, bool)> {
     let mut has_metadata = false;
-    let mut has_value_or_typed = false;
+    let mut has_value = false;
+    let mut has_typed_value = false;
 
     for field in fields {
         match field.name().as_str() {
-            "metadata" => has_metadata = true,
-            "value" | "typed_value" => has_value_or_typed = true,
-            _ => return false,
+            "metadata" if !has_metadata => has_metadata = true,
+            "value" if !has_value => has_value = true,
+            "typed_value" if !has_typed_value => has_typed_value = true,
+            _ => return None,
         }
     }
 
-    has_metadata && has_value_or_typed
+    (has_metadata && (has_value || has_typed_value)).then_some((has_value, has_typed_value))
 }
 
-fn try_export_storage_to_target<T: ParquetVariantArrayExt>(
+fn export_storage_to_target<T: ParquetVariantArrayExt>(
     parquet_array: &T,
     target_fields: &Fields,
     ctx: &mut ExecutionCtx,
-) -> VortexResult<Option<ArrowArrayRef>> {
+) -> VortexResult<ArrowArrayRef> {
     let mut arrays = Vec::with_capacity(target_fields.len());
 
     for field in target_fields {
@@ -64,10 +68,14 @@ fn try_export_storage_to_target<T: ParquetVariantArrayExt>(
             "metadata" => Some(parquet_array.metadata_array().clone()),
             "value" => parquet_array.value_array().cloned(),
             "typed_value" => parquet_array.typed_value_array().cloned(),
-            _ => return Ok(None),
+            _ => unreachable!("storage fields were validated before export"),
         };
         let Some(child) = child else {
-            return Ok(None);
+            vortex_bail!(
+                InvalidArgument: "cannot export Parquet Variant storage field '{}' because source has no {} child",
+                field.name(),
+                field.name()
+            );
         };
 
         arrays.push(ctx.session().clone().arrow().execute_arrow(
@@ -82,11 +90,27 @@ fn try_export_storage_to_target<T: ParquetVariantArrayExt>(
         parquet_array.as_ref().len(),
         ctx,
     )?;
-    Ok(Some(Arc::new(StructArray::try_new(
+    Ok(Arc::new(StructArray::try_new(
         target_fields.clone(),
         arrays,
         nulls,
-    )?)))
+    )?))
+}
+
+fn export_unshredded_storage_to_target<T: ParquetVariantArrayExt>(
+    parquet_array: &T,
+    target_fields: &Fields,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrowArrayRef> {
+    let arrow_variant = parquet_array.to_arrow(ctx)?;
+    let unshredded = unshred_variant(&arrow_variant)?;
+    let unshredded_array = if parquet_array.as_ref().dtype().is_nullable() {
+        ParquetVariant::from_arrow_variant_nullable(&unshredded)?
+    } else {
+        ParquetVariant::from_arrow_variant(&unshredded)?
+    };
+    let unshredded_parquet = unshredded_array.as_::<ParquetVariant>();
+    export_storage_to_target(&unshredded_parquet, target_fields, ctx)
 }
 
 impl ArrowExportVTable for ParquetVariant {
@@ -130,18 +154,35 @@ impl ArrowExportVTable for ParquetVariant {
             .ok_or_else(|| vortex_err!("cannot export Variant without ParquetVariant storage"))?;
 
         if let DataType::Struct(fields) = target.data_type()
-            && is_parquet_variant_storage_fields(fields)
+            && let Some((request_has_value, request_has_typed_value)) =
+                parquet_variant_storage_request(fields)
         {
-            if let Some(storage) = try_export_storage_to_target(&parquet_array, fields, ctx)? {
-                return Ok(ArrowExport::Exported(storage));
+            let has_value = parquet_array.value_array().is_some();
+            let has_typed_value = parquet_array.typed_value_array().is_some();
+
+            if request_has_value && !request_has_typed_value && has_typed_value {
+                return Ok(ArrowExport::Exported(export_unshredded_storage_to_target(
+                    &parquet_array,
+                    fields,
+                    ctx,
+                )?));
+            }
+            if has_value && !request_has_value {
+                vortex_bail!(
+                    InvalidArgument: "cannot export Parquet Variant storage without losing value child"
+                );
+            }
+            if has_typed_value && !request_has_typed_value {
+                vortex_bail!(
+                    InvalidArgument: "cannot export Parquet Variant storage without losing typed_value child"
+                );
             }
 
-            // The target is a Parquet Variant physical storage schema, not a logical variant
-            // projection. Return preferred storage rather than passing storage field names through
-            // `variant_get` as object keys.
-            return Ok(ArrowExport::Exported(
-                Arc::new(parquet_array.to_arrow(ctx)?.into_inner()) as ArrowArrayRef,
-            ));
+            return Ok(ArrowExport::Exported(export_storage_to_target(
+                &parquet_array,
+                fields,
+                ctx,
+            )?));
         }
 
         let arrow_variant = Arc::new(parquet_array.to_arrow(ctx)?.into_inner()) as ArrowArrayRef;
@@ -218,6 +259,7 @@ mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::VarBinViewArray;
     use vortex_array::arrow::ArrowSessionExt;
     use vortex_array::assert_arrays_eq;
@@ -265,6 +307,23 @@ mod tests {
         for (actual, expected) in actual.columns().iter().zip(expected.columns()) {
             assert_eq!(actual.to_data(), expected.to_data());
         }
+    }
+
+    fn assert_variant_scalars_eq(
+        actual: &vortex_array::ArrayRef,
+        expected: &vortex_array::ArrayRef,
+        session: &VortexSession,
+    ) -> VortexResult<()> {
+        assert_eq!(actual.len(), expected.len());
+        let mut actual_ctx = session.create_execution_ctx();
+        let mut expected_ctx = session.create_execution_ctx();
+        for index in 0..actual.len() {
+            assert_eq!(
+                actual.execute_scalar(index, &mut actual_ctx)?,
+                expected.execute_scalar(index, &mut expected_ctx)?
+            );
+        }
+        Ok(())
     }
 
     #[rstest]
@@ -341,6 +400,154 @@ mod tests {
             .from_arrow_array(Arc::clone(&exported), &field)?;
 
         assert_arrays_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[rstest]
+    fn export_fully_shredded_to_inferred_storage_unshreds_value(
+        session: VortexSession,
+    ) -> VortexResult<()> {
+        let rows = [
+            VariantBuilder::new().with_value(10i32).finish(),
+            VariantBuilder::new().with_value(20i32).finish(),
+            VariantBuilder::new().with_value(30i32).finish(),
+        ];
+        let metadata =
+            VarBinViewArray::from_iter_bin(rows.iter().map(|(metadata, _)| metadata.as_slice()))
+                .into_array();
+        let typed_value = buffer![10i32, 20, 30].into_array();
+        let expected =
+            ParquetVariant::try_new(Validity::NonNullable, metadata, None, Some(typed_value))?
+                .into_array();
+
+        let mut ctx = session.create_execution_ctx();
+        let exported = session
+            .arrow()
+            .execute_arrow(expected.clone(), None, &mut ctx)?;
+
+        assert_eq!(
+            exported.data_type(),
+            &DataType::Struct(
+                vec![
+                    Field::new("metadata", DataType::BinaryView, false),
+                    Field::new("value", DataType::BinaryView, false),
+                ]
+                .into()
+            )
+        );
+
+        let field = Field::new("", exported.data_type().clone(), false).with_metadata(
+            [(
+                EXTENSION_TYPE_NAME_KEY.to_string(),
+                PARQUET_VARIANT_ARROW_EXTENSION_NAME.to_string(),
+            )]
+            .into(),
+        );
+        let actual = session.arrow().from_arrow_array(exported, &field)?;
+        assert_variant_scalars_eq(&actual, &expected, &session)
+    }
+
+    #[rstest]
+    fn export_partially_shredded_to_metadata_value_preserves_typed_rows(
+        session: VortexSession,
+    ) -> VortexResult<()> {
+        let (metadata0, value0) = VariantBuilder::new().with_value("fallback-0").finish();
+        let (metadata1, _value1) = VariantBuilder::new().with_value(20i32).finish();
+        let (metadata2, value2) = VariantBuilder::new().with_value("fallback-2").finish();
+        let metadata = VarBinViewArray::from_iter_bin([
+            metadata0.as_slice(),
+            metadata1.as_slice(),
+            metadata2.as_slice(),
+        ])
+        .into_array();
+        let value = VarBinViewArray::from_iter_nullable_bin([
+            Some(value0.as_slice()),
+            None,
+            Some(value2.as_slice()),
+        ])
+        .into_array();
+        let typed_value = PrimitiveArray::from_option_iter([None, Some(20i32), None]).into_array();
+        let expected = ParquetVariant::try_new(
+            Validity::NonNullable,
+            metadata,
+            Some(value),
+            Some(typed_value),
+        )?
+        .into_array();
+        let field = Field::new(
+            "variant",
+            DataType::Struct(
+                vec![
+                    Field::new("metadata", DataType::BinaryView, false),
+                    Field::new("value", DataType::BinaryView, true),
+                ]
+                .into(),
+            ),
+            false,
+        )
+        .with_metadata(
+            [(
+                EXTENSION_TYPE_NAME_KEY.to_string(),
+                PARQUET_VARIANT_ARROW_EXTENSION_NAME.to_string(),
+            )]
+            .into(),
+        );
+
+        let mut ctx = session.create_execution_ctx();
+        let exported = session
+            .arrow()
+            .execute_arrow(expected.clone(), Some(&field), &mut ctx)?;
+        assert_eq!(exported.data_type(), field.data_type());
+
+        let actual = session.arrow().from_arrow_array(exported, &field)?;
+        assert_variant_scalars_eq(&actual, &expected, &session)
+    }
+
+    #[rstest]
+    fn export_partial_storage_target_rejects_data_loss(session: VortexSession) -> VortexResult<()> {
+        let (metadata0, value0) = VariantBuilder::new().with_value("fallback-0").finish();
+        let (metadata1, _value1) = VariantBuilder::new().with_value(20i32).finish();
+        let metadata = VarBinViewArray::from_iter_bin([metadata0.as_slice(), metadata1.as_slice()])
+            .into_array();
+        let value =
+            VarBinViewArray::from_iter_nullable_bin([Some(value0.as_slice()), None]).into_array();
+        let typed_value = PrimitiveArray::from_option_iter([None, Some(20i32)]).into_array();
+        let array = ParquetVariant::try_new(
+            Validity::NonNullable,
+            metadata,
+            Some(value),
+            Some(typed_value),
+        )?
+        .into_array();
+        let field = Field::new(
+            "variant",
+            DataType::Struct(
+                vec![
+                    Field::new("metadata", DataType::BinaryView, false),
+                    Field::new("typed_value", DataType::Int32, true),
+                ]
+                .into(),
+            ),
+            false,
+        )
+        .with_metadata(
+            [(
+                EXTENSION_TYPE_NAME_KEY.to_string(),
+                PARQUET_VARIANT_ARROW_EXTENSION_NAME.to_string(),
+            )]
+            .into(),
+        );
+
+        let mut ctx = session.create_execution_ctx();
+        let err = session
+            .arrow()
+            .execute_arrow(array, Some(&field), &mut ctx)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("cannot export Parquet Variant storage without losing value child"),
+            "unexpected error: {err}"
+        );
         Ok(())
     }
 

--- a/encodings/parquet-variant/src/arrow.rs
+++ b/encodings/parquet-variant/src/arrow.rs
@@ -20,7 +20,6 @@ use vortex_array::arrow::ArrowImport;
 use vortex_array::arrow::ArrowImportVTable;
 use vortex_array::arrow::ArrowSession;
 use vortex_array::dtype::DType;
-use vortex_array::dtype::extension::ExtDTypeRef;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 use vortex_session::registry::CachedId;
@@ -39,14 +38,14 @@ impl ArrowExportVTable for ParquetVariant {
         *ARROW_PARQUET_VARIANT
     }
 
-    fn vortex_ext_id(&self) -> Id {
+    fn vortex_id(&self) -> Id {
         ParquetVariant.id()
     }
 
     fn to_arrow_field(
         &self,
         _name: &str,
-        _dtype: &ExtDTypeRef,
+        _dtype: &DType,
         _session: &ArrowSession,
     ) -> VortexResult<Option<Field>> {
         Ok(None)

--- a/encodings/parquet-variant/src/arrow.rs
+++ b/encodings/parquet-variant/src/arrow.rs
@@ -8,7 +8,6 @@ use arrow_array::ArrayRef as ArrowArrayRef;
 use arrow_array::cast::AsArray;
 use arrow_schema::DataType;
 use arrow_schema::Field;
-use arrow_schema::Fields;
 use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
 use parquet_variant_compute::VariantArray as ArrowVariantArray;
 use vortex_array::ArrayRef;
@@ -22,6 +21,7 @@ use vortex_array::arrow::ArrowImportVTable;
 use vortex_array::arrow::ArrowSession;
 use vortex_array::dtype::DType;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_session::registry::CachedId;
 use vortex_session::registry::Id;
@@ -42,12 +42,9 @@ impl ArrowExportVTable for ParquetVariant {
         ParquetVariant.id()
     }
 
-    // The current API doesn't see the array at this point.
-    // which is what we actually need to know exactly what the arrow
-    // storage type is.
     fn to_arrow_field(
         &self,
-        name: &str,
+        _name: &str,
         dtype: &DType,
         _session: &ArrowSession,
     ) -> VortexResult<Option<Field>> {
@@ -55,23 +52,7 @@ impl ArrowExportVTable for ParquetVariant {
             return Ok(None);
         }
 
-        Ok(Some(
-            Field::new(
-                name,
-                DataType::Struct(Fields::from(vec![
-                    Arc::new(Field::new("metadata", DataType::BinaryView, false)),
-                    Arc::new(Field::new("value", DataType::BinaryView, false)),
-                ])),
-                dtype.is_nullable(),
-            )
-            .with_metadata(
-                [(
-                    EXTENSION_TYPE_NAME_KEY.to_string(),
-                    PARQUET_VARIANT_ARROW_EXTENSION_NAME.to_string(),
-                )]
-                .into(),
-            ),
-        ))
+        vortex_bail!(InvalidArgument: "ParquetVariant array can't infer its Arrow storage schema from dtype");
     }
 
     fn execute_arrow(
@@ -149,6 +130,7 @@ mod tests {
     use arrow_array::ArrayRef as ArrowArrayRef;
     use arrow_array::StructArray;
     use arrow_array::cast::AsArray;
+    use arrow_schema::DataType;
     use arrow_schema::Field;
     use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
     use parquet_variant::Variant as PqVariant;
@@ -159,7 +141,6 @@ mod tests {
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::VarBinViewArray;
-    use vortex_array::arrow::ArrowExportVTable;
     use vortex_array::arrow::ArrowSessionExt;
     use vortex_array::assert_arrays_eq;
     use vortex_array::dtype::DType;
@@ -168,7 +149,6 @@ mod tests {
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
-    use vortex_error::vortex_err;
     use vortex_session::VortexSession;
 
     use super::PARQUET_VARIANT_ARROW_EXTENSION_NAME;
@@ -260,9 +240,24 @@ mod tests {
             .into_array();
         let expected = array.clone();
 
-        let field = ParquetVariant
-            .to_arrow_field("variant", array.dtype(), &session.arrow())?
-            .ok_or_else(|| vortex_err!("expected ParquetVariant Arrow field"))?;
+        let field = Field::new(
+            "variant",
+            DataType::Struct(
+                vec![
+                    Field::new("metadata", DataType::Binary, false),
+                    Field::new("value", DataType::Binary, false),
+                ]
+                .into(),
+            ),
+            false,
+        )
+        .with_metadata(
+            [(
+                EXTENSION_TYPE_NAME_KEY.to_string(),
+                PARQUET_VARIANT_ARROW_EXTENSION_NAME.to_string(),
+            )]
+            .into(),
+        );
         let mut ctx = session.create_execution_ctx();
         let exported = session
             .arrow()
@@ -294,9 +289,24 @@ mod tests {
                 .into_array();
         let expected = array.clone();
 
-        let field = ParquetVariant
-            .to_arrow_field("variant", array.dtype(), &session.arrow())?
-            .ok_or_else(|| vortex_err!("expected ParquetVariant Arrow field"))?;
+        let field = Field::new(
+            "variant",
+            DataType::Struct(
+                vec![
+                    Field::new("metadata", DataType::Binary, false),
+                    Field::new("typed_value", DataType::Int32, false),
+                ]
+                .into(),
+            ),
+            false,
+        )
+        .with_metadata(
+            [(
+                EXTENSION_TYPE_NAME_KEY.to_string(),
+                PARQUET_VARIANT_ARROW_EXTENSION_NAME.to_string(),
+            )]
+            .into(),
+        );
         let mut ctx = session.create_execution_ctx();
         let exported = session
             .arrow()

--- a/encodings/parquet-variant/src/arrow.rs
+++ b/encodings/parquet-variant/src/arrow.rs
@@ -8,6 +8,7 @@ use arrow_array::ArrayRef as ArrowArrayRef;
 use arrow_array::cast::AsArray;
 use arrow_schema::DataType;
 use arrow_schema::Field;
+use arrow_schema::Fields;
 use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
 use parquet_variant_compute::VariantArray as ArrowVariantArray;
 use vortex_array::ArrayRef;
@@ -29,8 +30,7 @@ use crate::ParquetVariant;
 use crate::ParquetVariantArrayExt;
 
 /// Arrow canonical extension name for Parquet Variant storage.
-pub const PARQUET_VARIANT_ARROW_EXTENSION_NAME: &str = "arrow.parquet.variant";
-
+const PARQUET_VARIANT_ARROW_EXTENSION_NAME: &str = "arrow.parquet.variant";
 static ARROW_PARQUET_VARIANT: CachedId = CachedId::new(PARQUET_VARIANT_ARROW_EXTENSION_NAME);
 
 impl ArrowExportVTable for ParquetVariant {
@@ -42,13 +42,36 @@ impl ArrowExportVTable for ParquetVariant {
         ParquetVariant.id()
     }
 
+    // The current API doesn't see the array at this point.
+    // which is what we actually need to know exactly what the arrow
+    // storage type is.
     fn to_arrow_field(
         &self,
-        _name: &str,
-        _dtype: &DType,
+        name: &str,
+        dtype: &DType,
         _session: &ArrowSession,
     ) -> VortexResult<Option<Field>> {
-        Ok(None)
+        if !dtype.is_variant() {
+            return Ok(None);
+        }
+
+        Ok(Some(
+            Field::new(
+                name,
+                DataType::Struct(Fields::from(vec![
+                    Arc::new(Field::new("metadata", DataType::BinaryView, false)),
+                    Arc::new(Field::new("value", DataType::BinaryView, false)),
+                ])),
+                dtype.is_nullable(),
+            )
+            .with_metadata(
+                [(
+                    EXTENSION_TYPE_NAME_KEY.to_string(),
+                    PARQUET_VARIANT_ARROW_EXTENSION_NAME.to_string(),
+                )]
+                .into(),
+            ),
+        ))
     }
 
     fn execute_arrow(
@@ -60,8 +83,7 @@ impl ArrowExportVTable for ParquetVariant {
         if target
             .metadata()
             .get(EXTENSION_TYPE_NAME_KEY)
-            .map(String::as_str)
-            != Some(PARQUET_VARIANT_ARROW_EXTENSION_NAME)
+            .is_some_and(|ext| ext != PARQUET_VARIANT_ARROW_EXTENSION_NAME)
             || !array.dtype().is_variant()
         {
             return Ok(ArrowExport::Unsupported(array));
@@ -85,8 +107,7 @@ impl ArrowImportVTable for ParquetVariant {
         if field
             .metadata()
             .get(EXTENSION_TYPE_NAME_KEY)
-            .map(String::as_str)
-            != Some(PARQUET_VARIANT_ARROW_EXTENSION_NAME)
+            .is_some_and(|ext| ext != PARQUET_VARIANT_ARROW_EXTENSION_NAME)
         {
             return Ok(None);
         }
@@ -104,8 +125,7 @@ impl ArrowImportVTable for ParquetVariant {
             || field
                 .metadata()
                 .get(EXTENSION_TYPE_NAME_KEY)
-                .map(String::as_str)
-                != Some(PARQUET_VARIANT_ARROW_EXTENSION_NAME)
+                .is_some_and(|ext| ext != PARQUET_VARIANT_ARROW_EXTENSION_NAME)
             || !matches!(array.data_type(), DataType::Struct(_))
         {
             return Ok(ArrowImport::Unsupported(array));
@@ -118,5 +138,178 @@ impl ArrowImportVTable for ParquetVariant {
             ParquetVariant::from_arrow_variant(&arrow_variant)?
         };
         Ok(ArrowImport::Imported(imported.into_array()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::Array as _;
+    use arrow_array::ArrayRef as ArrowArrayRef;
+    use arrow_array::StructArray;
+    use arrow_array::cast::AsArray;
+    use arrow_schema::Field;
+    use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
+    use parquet_variant::Variant as PqVariant;
+    use parquet_variant::VariantBuilder;
+    use parquet_variant_compute::VariantArrayBuilder;
+    use rstest::fixture;
+    use rstest::rstest;
+    use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::VarBinViewArray;
+    use vortex_array::arrow::ArrowExportVTable;
+    use vortex_array::arrow::ArrowSessionExt;
+    use vortex_array::assert_arrays_eq;
+    use vortex_array::dtype::DType;
+    use vortex_array::dtype::Nullability;
+    use vortex_array::session::ArraySession;
+    use vortex_array::validity::Validity;
+    use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
+    use vortex_error::vortex_err;
+    use vortex_session::VortexSession;
+
+    use super::PARQUET_VARIANT_ARROW_EXTENSION_NAME;
+    use crate::ParquetVariant;
+
+    #[fixture]
+    fn session() -> VortexSession {
+        let session = VortexSession::empty().with::<ArraySession>();
+        crate::initialize(&session);
+        session
+    }
+
+    fn arrow_variant_storage() -> StructArray {
+        let mut builder = VariantArrayBuilder::new(3);
+        builder.append_variant(PqVariant::from(42i8));
+        builder.append_variant(PqVariant::from(true));
+        builder.append_variant(PqVariant::from("vortex"));
+        builder.build().into_inner()
+    }
+
+    fn arrow_variant_field(storage: &StructArray) -> Field {
+        Field::new("variant", storage.data_type().clone(), false).with_metadata(
+            [(
+                EXTENSION_TYPE_NAME_KEY.to_string(),
+                PARQUET_VARIANT_ARROW_EXTENSION_NAME.to_string(),
+            )]
+            .into(),
+        )
+    }
+
+    fn assert_struct_arrays_eq(actual: &StructArray, expected: &StructArray) {
+        assert_eq!(actual.len(), expected.len());
+        assert_eq!(actual.column_names(), expected.column_names());
+        assert_eq!(actual.fields(), expected.fields());
+        assert_eq!(actual.nulls(), expected.nulls());
+        for (actual, expected) in actual.columns().iter().zip(expected.columns()) {
+            assert_eq!(actual.to_data(), expected.to_data());
+        }
+    }
+
+    #[rstest]
+    fn import_parquet_variant_extension_array(session: VortexSession) -> VortexResult<()> {
+        let storage = arrow_variant_storage();
+        let field = arrow_variant_field(&storage);
+        let imported = session
+            .arrow()
+            .from_arrow_array(Arc::new(storage) as ArrowArrayRef, &field)?;
+
+        assert_eq!(imported.dtype(), &DType::Variant(Nullability::NonNullable));
+        assert!(imported.as_opt::<ParquetVariant>().is_some());
+        Ok(())
+    }
+
+    #[rstest]
+    fn roundtrip_parquet_variant_extension_array_from_arrow(
+        session: VortexSession,
+    ) -> VortexResult<()> {
+        let storage = arrow_variant_storage();
+        let field = arrow_variant_field(&storage);
+        let imported = session
+            .arrow()
+            .from_arrow_array(Arc::new(storage.clone()) as ArrowArrayRef, &field)?;
+
+        let mut ctx = session.create_execution_ctx();
+        let exported = session
+            .arrow()
+            .execute_arrow(imported, Some(&field), &mut ctx)?;
+        let exported = exported.as_struct();
+
+        assert_struct_arrays_eq(exported, &storage);
+        Ok(())
+    }
+
+    #[rstest]
+    fn roundtrip_parquet_variant_extension_array_from_vortex(
+        session: VortexSession,
+    ) -> VortexResult<()> {
+        let rows = [
+            VariantBuilder::new().with_value(42i32).finish(),
+            VariantBuilder::new().with_value(true).finish(),
+            VariantBuilder::new().with_value("vortex").finish(),
+        ];
+        let metadata =
+            VarBinViewArray::from_iter_bin(rows.iter().map(|(metadata, _)| metadata.as_slice()))
+                .into_array();
+        let value = VarBinViewArray::from_iter_bin(rows.iter().map(|(_, value)| value.as_slice()))
+            .into_array();
+        let array = ParquetVariant::try_new(Validity::NonNullable, metadata, Some(value), None)?
+            .into_array();
+        let expected = array.clone();
+
+        let field = ParquetVariant
+            .to_arrow_field("variant", array.dtype(), &session.arrow())?
+            .ok_or_else(|| vortex_err!("expected ParquetVariant Arrow field"))?;
+        let mut ctx = session.create_execution_ctx();
+        let exported = session
+            .arrow()
+            .execute_arrow(array, Some(&field), &mut ctx)?;
+        let actual = session
+            .arrow()
+            .from_arrow_array(Arc::clone(&exported), &field)?;
+
+        assert_arrays_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[rstest]
+    fn roundtrip_shredded_parquet_variant_extension_array_from_vortex(
+        session: VortexSession,
+    ) -> VortexResult<()> {
+        let rows = [
+            VariantBuilder::new().with_value(10i32).finish(),
+            VariantBuilder::new().with_value(20i32).finish(),
+            VariantBuilder::new().with_value(30i32).finish(),
+        ];
+        let metadata =
+            VarBinViewArray::from_iter_bin(rows.iter().map(|(metadata, _)| metadata.as_slice()))
+                .into_array();
+
+        let typed_value = buffer![10i32, 20, 30].into_array();
+        let array =
+            ParquetVariant::try_new(Validity::NonNullable, metadata, None, Some(typed_value))?
+                .into_array();
+        let expected = array.clone();
+
+        let field = ParquetVariant
+            .to_arrow_field("variant", array.dtype(), &session.arrow())?
+            .ok_or_else(|| vortex_err!("expected ParquetVariant Arrow field"))?;
+        let mut ctx = session.create_execution_ctx();
+        let exported = session
+            .arrow()
+            .execute_arrow(array, Some(&field), &mut ctx)?;
+        assert_ne!(
+            exported.data_type(),
+            field.data_type(),
+            "The current arrow field isn't fully validated to the full storage type"
+        );
+
+        let actual = session.arrow().from_arrow_array(exported, &field)?;
+
+        assert_arrays_eq!(actual, expected);
+        Ok(())
     }
 }

--- a/encodings/parquet-variant/src/lib.rs
+++ b/encodings/parquet-variant/src/lib.rs
@@ -25,11 +25,110 @@
 //! [Arrow canonical extension type]: https://arrow.apache.org/docs/format/CanonicalExtensions.html#parquet-variant
 
 mod array;
+mod arrow;
 mod kernel;
 mod operations;
 mod validity;
 mod vtable;
 
+use std::sync::Arc;
+
 pub use array::ParquetVariantArrayExt;
+pub use arrow::PARQUET_VARIANT_ARROW_EXTENSION_NAME;
+use vortex_array::arrow::ArrowSessionExt;
+use vortex_array::session::ArraySessionExt;
+use vortex_session::VortexSession;
 pub use vtable::ParquetVariant;
 pub use vtable::ParquetVariantArray;
+
+/// Register Parquet Variant array and Arrow extension support with a session.
+pub fn initialize(session: &VortexSession) {
+    session.arrays().register(ParquetVariant);
+    session.arrow().register_exporter(Arc::new(ParquetVariant));
+    session.arrow().register_importer(Arc::new(ParquetVariant));
+}
+
+#[cfg(test)]
+mod arrow_session_tests {
+    use std::sync::Arc;
+
+    use arrow_array::Array as _;
+    use arrow_array::ArrayRef as ArrowArrayRef;
+    use arrow_array::StructArray;
+    use arrow_array::cast::AsArray;
+    use arrow_schema::Field;
+    use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
+    use parquet_variant::Variant as PqVariant;
+    use parquet_variant_compute::VariantArrayBuilder;
+    use vortex_array::VortexSessionExecute;
+    use vortex_array::arrow::ArrowSessionExt;
+    use vortex_array::dtype::DType;
+    use vortex_array::dtype::Nullability;
+    use vortex_array::session::ArraySession;
+    use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
+
+    use crate::ParquetVariant;
+
+    fn session() -> VortexSession {
+        let session = VortexSession::empty().with::<ArraySession>();
+        crate::initialize(&session);
+        session
+    }
+
+    fn arrow_variant_storage() -> StructArray {
+        let mut builder = VariantArrayBuilder::new(3);
+        builder.append_variant(PqVariant::from(42i8));
+        builder.append_variant(PqVariant::from(true));
+        builder.append_variant(PqVariant::from("vortex"));
+        builder.build().into_inner()
+    }
+
+    fn arrow_variant_field(storage: &StructArray) -> Field {
+        Field::new("variant", storage.data_type().clone(), false).with_metadata(
+            [(
+                EXTENSION_TYPE_NAME_KEY.to_string(),
+                "arrow.parquet.variant".to_string(),
+            )]
+            .into(),
+        )
+    }
+
+    #[test]
+    fn arrow_session_imports_parquet_variant_extension_array() -> VortexResult<()> {
+        let session = session();
+        let storage = arrow_variant_storage();
+        let field = arrow_variant_field(&storage);
+        let imported = session
+            .arrow()
+            .from_arrow_array(Arc::new(storage) as ArrowArrayRef, &field)?;
+
+        assert_eq!(imported.dtype(), &DType::Variant(Nullability::NonNullable));
+        assert!(imported.as_opt::<ParquetVariant>().is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn arrow_session_exports_parquet_variant_extension_array() -> VortexResult<()> {
+        let session = session();
+        let storage = arrow_variant_storage();
+        let field = arrow_variant_field(&storage);
+        let imported = session
+            .arrow()
+            .from_arrow_array(Arc::new(storage.clone()) as ArrowArrayRef, &field)?;
+
+        let mut ctx = session.create_execution_ctx();
+        let exported = session
+            .arrow()
+            .execute_arrow(imported, Some(&field), &mut ctx)?;
+        let exported = exported.as_struct();
+
+        assert_eq!(exported.len(), storage.len());
+        assert_eq!(exported.column_names(), storage.column_names());
+        assert_eq!(exported.fields(), storage.fields());
+        for (actual, expected) in exported.columns().iter().zip(storage.columns()) {
+            assert_eq!(actual.to_data(), expected.to_data());
+        }
+        Ok(())
+    }
+}

--- a/encodings/parquet-variant/src/lib.rs
+++ b/encodings/parquet-variant/src/lib.rs
@@ -34,7 +34,6 @@ mod vtable;
 use std::sync::Arc;
 
 pub use array::ParquetVariantArrayExt;
-pub use arrow::PARQUET_VARIANT_ARROW_EXTENSION_NAME;
 use vortex_array::arrow::ArrowSessionExt;
 use vortex_array::session::ArraySessionExt;
 use vortex_session::VortexSession;
@@ -46,89 +45,4 @@ pub fn initialize(session: &VortexSession) {
     session.arrays().register(ParquetVariant);
     session.arrow().register_exporter(Arc::new(ParquetVariant));
     session.arrow().register_importer(Arc::new(ParquetVariant));
-}
-
-#[cfg(test)]
-mod arrow_session_tests {
-    use std::sync::Arc;
-
-    use arrow_array::Array as _;
-    use arrow_array::ArrayRef as ArrowArrayRef;
-    use arrow_array::StructArray;
-    use arrow_array::cast::AsArray;
-    use arrow_schema::Field;
-    use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
-    use parquet_variant::Variant as PqVariant;
-    use parquet_variant_compute::VariantArrayBuilder;
-    use vortex_array::VortexSessionExecute;
-    use vortex_array::arrow::ArrowSessionExt;
-    use vortex_array::dtype::DType;
-    use vortex_array::dtype::Nullability;
-    use vortex_array::session::ArraySession;
-    use vortex_error::VortexResult;
-    use vortex_session::VortexSession;
-
-    use crate::ParquetVariant;
-
-    fn session() -> VortexSession {
-        let session = VortexSession::empty().with::<ArraySession>();
-        crate::initialize(&session);
-        session
-    }
-
-    fn arrow_variant_storage() -> StructArray {
-        let mut builder = VariantArrayBuilder::new(3);
-        builder.append_variant(PqVariant::from(42i8));
-        builder.append_variant(PqVariant::from(true));
-        builder.append_variant(PqVariant::from("vortex"));
-        builder.build().into_inner()
-    }
-
-    fn arrow_variant_field(storage: &StructArray) -> Field {
-        Field::new("variant", storage.data_type().clone(), false).with_metadata(
-            [(
-                EXTENSION_TYPE_NAME_KEY.to_string(),
-                "arrow.parquet.variant".to_string(),
-            )]
-            .into(),
-        )
-    }
-
-    #[test]
-    fn arrow_session_imports_parquet_variant_extension_array() -> VortexResult<()> {
-        let session = session();
-        let storage = arrow_variant_storage();
-        let field = arrow_variant_field(&storage);
-        let imported = session
-            .arrow()
-            .from_arrow_array(Arc::new(storage) as ArrowArrayRef, &field)?;
-
-        assert_eq!(imported.dtype(), &DType::Variant(Nullability::NonNullable));
-        assert!(imported.as_opt::<ParquetVariant>().is_some());
-        Ok(())
-    }
-
-    #[test]
-    fn arrow_session_exports_parquet_variant_extension_array() -> VortexResult<()> {
-        let session = session();
-        let storage = arrow_variant_storage();
-        let field = arrow_variant_field(&storage);
-        let imported = session
-            .arrow()
-            .from_arrow_array(Arc::new(storage.clone()) as ArrowArrayRef, &field)?;
-
-        let mut ctx = session.create_execution_ctx();
-        let exported = session
-            .arrow()
-            .execute_arrow(imported, Some(&field), &mut ctx)?;
-        let exported = exported.as_struct();
-
-        assert_eq!(exported.len(), storage.len());
-        assert_eq!(exported.column_names(), storage.column_names());
-        assert_eq!(exported.fields(), storage.fields());
-        for (actual, expected) in exported.columns().iter().zip(storage.columns()) {
-            assert_eq!(actual.to_data(), expected.to_data());
-        }
-        Ok(())
-    }
 }

--- a/vortex-array/src/arrow/session.rs
+++ b/vortex-array/src/arrow/session.rs
@@ -290,7 +290,27 @@ impl ArrowSession {
                 vortex_bail!("extension type cannot be converted to Arrow without a plugin: {ext}");
             }
             DType::Variant(_) => {
-                vortex_bail!("Arrow does not have a raw/transparent Variant encoding");
+                // TODO(Adam): This currently encodes information about parquet-variant
+                // at this level. Variant's complexity with being an essentially logical type
+                // with multiple physical layout complicates handling this correctly.
+                Ok(Field::new(
+                    name,
+                    DataType::Struct(
+                        vec![
+                            Field::new("metadata", DataType::BinaryView, dtype.is_nullable()),
+                            Field::new("value", DataType::BinaryView, dtype.is_nullable()),
+                        ]
+                        .into(),
+                    ),
+                    dtype.is_nullable(),
+                )
+                .with_metadata(
+                    [(
+                        EXTENSION_TYPE_NAME_KEY.to_string(),
+                        "arrow.parquet.variant".to_string(),
+                    )]
+                    .into(),
+                ))
             }
             _ => Ok(Field::new(
                 name,

--- a/vortex-array/src/arrow/session.rs
+++ b/vortex-array/src/arrow/session.rs
@@ -61,8 +61,6 @@ use crate::dtype::Nullability;
 use crate::dtype::StructFields;
 use crate::dtype::arrow::FromArrowType;
 use crate::dtype::arrow::to_data_type_naive;
-use crate::dtype::extension::ExtDTypeRef;
-use crate::dtype::extension::ExtId;
 use crate::extension::datetime::AnyTemporal;
 use crate::extension::uuid::Uuid;
 use crate::validity::Validity;
@@ -99,17 +97,17 @@ pub trait ArrowExportVTable: 'static + Send + Sync + Debug {
     /// The Arrow extension ID this plugin produces.
     fn arrow_ext_id(&self) -> Id;
 
-    /// The Vortex extension ID this plugin maps from. Used only for inference by
+    /// The Vortex array or extension ID this plugin maps from. Used only for inference by
     /// [`ArrowSession::to_arrow_field`] / [`ArrowSession::to_arrow_schema`]; never as a
     /// dispatch key for [`execute_arrow`][Self::execute_arrow].
-    fn vortex_ext_id(&self) -> ExtId;
+    fn vortex_id(&self) -> Id;
 
     /// Build the Arrow [`Field`] this plugin produces for the given Vortex extension
     /// `dtype`. Used during schema inference.
     fn to_arrow_field(
         &self,
         name: &str,
-        dtype: &ExtDTypeRef,
+        dtype: &DType,
         session: &ArrowSession,
     ) -> VortexResult<Option<Field>>;
 
@@ -158,7 +156,7 @@ pub type ArrowImportVTableRef = Arc<dyn ArrowImportVTable>;
 
 type ExportMap = HashMap<Id, Arc<[ArrowExportVTableRef]>>;
 type ImportMap = HashMap<Id, Arc<[ArrowImportVTableRef]>>;
-type ExportDTypeMap = HashMap<ExtId, Arc<[ArrowExportVTableRef]>>;
+type ExportDTypeMap = HashMap<Id, Arc<[ArrowExportVTableRef]>>;
 
 /// Session-scoped registry of Arrow extension plugins.
 ///
@@ -200,11 +198,7 @@ impl ArrowSession {
             exporter.arrow_ext_id(),
             ArrowExportVTableRef::clone(&exporter),
         );
-        Self::insert(
-            &self.exporters_by_vortex,
-            exporter.vortex_ext_id(),
-            exporter,
-        );
+        Self::insert(&self.exporters_by_vortex, exporter.vortex_id(), exporter);
     }
 
     /// Register an [`ArrowImportVTable`] under its source Arrow extension name.
@@ -235,7 +229,7 @@ impl ArrowSession {
             .unwrap_or_else(|| Arc::from([]))
     }
 
-    fn exporters_by_vortex(&self, id: &ExtId) -> Arc<[ArrowExportVTableRef]> {
+    fn exporters_by_vortex(&self, id: &Id) -> Arc<[ArrowExportVTableRef]> {
         self.exporters_by_vortex
             .load()
             .get(id)
@@ -287,7 +281,9 @@ impl ArrowSession {
             }
             DType::Extension(ext) if !ext.is::<AnyTemporal>() => {
                 for plugin in self.exporters_by_vortex(&ext.id()).iter() {
-                    if let Some(field) = plugin.to_arrow_field(name, ext, self)? {
+                    if let Some(field) =
+                        plugin.to_arrow_field(name, &DType::Extension(ext.clone()), self)?
+                    {
                         return Ok(field);
                     }
                 }

--- a/vortex-array/src/arrow/session.rs
+++ b/vortex-array/src/arrow/session.rs
@@ -125,7 +125,7 @@ pub trait ArrowExportVTable: 'static + Send + Sync + Debug {
     ) -> VortexResult<ArrowExport>;
 }
 
-/// Plugin layer for importing an Arrow extension-typed array into a Vortex extension array.
+/// Plugin layer for importing an Arrow extension-typed array into a Vortex array.
 ///
 /// Plugins are dispatched by `arrow_ext_id`.
 ///
@@ -140,7 +140,7 @@ pub trait ArrowImportVTable: 'static + Send + Sync + Debug {
     #[allow(clippy::wrong_self_convention)]
     fn from_arrow_field(&self, field: &Field) -> VortexResult<Option<DType>>;
 
-    /// Convert an Arrow array into a Vortex extension array of `dtype`.
+    /// Convert an Arrow array into a Vortex array of `dtype`.
     ///
     /// Returns ownership of `array` via [`ArrowImport::Unsupported`] when the plugin cannot
     /// handle the input.
@@ -148,7 +148,8 @@ pub trait ArrowImportVTable: 'static + Send + Sync + Debug {
     fn from_arrow_array(
         &self,
         array: ArrowArrayRef,
-        dtype: &ExtDTypeRef,
+        field: &Field,
+        dtype: &DType,
     ) -> VortexResult<ArrowImport>;
 }
 
@@ -490,16 +491,14 @@ impl ArrowSession {
             let importers = self.importers(&Id::new(extension_name));
             if !importers.is_empty() {
                 let dtype = self.from_arrow_field(field)?;
-                if let DType::Extension(ext_dtype) = dtype {
-                    let mut current = array;
-                    for plugin in importers.iter() {
-                        match plugin.from_arrow_array(current, &ext_dtype)? {
-                            ArrowImport::Imported(arr) => return Ok(arr),
-                            ArrowImport::Unsupported(arr) => current = arr,
-                        }
+                let mut current = array;
+                for plugin in importers.iter() {
+                    match plugin.from_arrow_array(current, field, &dtype)? {
+                        ArrowImport::Imported(arr) => return Ok(arr),
+                        ArrowImport::Unsupported(arr) => current = arr,
                     }
-                    return ArrayRef::from_arrow(current.as_ref(), field.is_nullable());
                 }
+                return ArrayRef::from_arrow(current.as_ref(), field.is_nullable());
             }
         }
         self.from_arrow_array_canonical(array, field)

--- a/vortex-array/src/extension/uuid/arrow.rs
+++ b/vortex-array/src/extension/uuid/arrow.rs
@@ -125,8 +125,12 @@ impl ArrowImportVTable for Uuid {
     fn from_arrow_array(
         &self,
         array: ArrowArrayRef,
-        dtype: &ExtDTypeRef,
+        _field: &Field,
+        dtype: &DType,
     ) -> VortexResult<ArrowImport> {
+        let DType::Extension(dtype) = dtype else {
+            return Ok(ArrowImport::Unsupported(array));
+        };
         if !matches!(array.data_type(), DataType::FixedSizeBinary(UUID_BYTE_LEN))
             || !dtype.is::<Uuid>()
         {

--- a/vortex-array/src/extension/uuid/arrow.rs
+++ b/vortex-array/src/extension/uuid/arrow.rs
@@ -45,8 +45,6 @@ use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::dtype::extension::ExtDType;
-use crate::dtype::extension::ExtDTypeRef;
-use crate::dtype::extension::ExtId;
 use crate::dtype::extension::ExtVTable;
 use crate::extension::uuid::Uuid;
 use crate::extension::uuid::UuidMetadata;
@@ -61,7 +59,7 @@ impl ArrowExportVTable for Uuid {
         *ARROW_UUID
     }
 
-    fn vortex_ext_id(&self) -> ExtId {
+    fn vortex_id(&self) -> Id {
         Uuid.id()
     }
 
@@ -69,7 +67,7 @@ impl ArrowExportVTable for Uuid {
     fn to_arrow_field(
         &self,
         name: &str,
-        dtype: &ExtDTypeRef,
+        dtype: &DType,
         _session: &ArrowSession,
     ) -> VortexResult<Option<Field>> {
         let mut field = Field::new(

--- a/vortex-tensor/src/types/vector/arrow.rs
+++ b/vortex-tensor/src/types/vector/arrow.rs
@@ -29,8 +29,6 @@ use vortex_array::arrow::FromArrowArray;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::arrow::FromArrowType;
 use vortex_array::dtype::extension::ExtDType;
-use vortex_array::dtype::extension::ExtDTypeRef;
-use vortex_array::dtype::extension::ExtId;
 use vortex_array::dtype::extension::ExtVTable;
 use vortex_array::extension::EmptyMetadata;
 use vortex_error::VortexResult;
@@ -68,16 +66,20 @@ impl ArrowExportVTable for Vector {
         *ARROW_VECTOR
     }
 
-    fn vortex_ext_id(&self) -> ExtId {
+    fn vortex_id(&self) -> Id {
         Vector.id()
     }
 
     fn to_arrow_field(
         &self,
         name: &str,
-        dtype: &ExtDTypeRef,
+        dtype: &DType,
         session: &ArrowSession,
     ) -> VortexResult<Option<Field>> {
+        let DType::Extension(dtype) = dtype else {
+            return Ok(None);
+        };
+
         if !dtype.is::<Vector>() {
             return Ok(None);
         }

--- a/vortex-tensor/src/types/vector/arrow.rs
+++ b/vortex-tensor/src/types/vector/arrow.rs
@@ -141,8 +141,12 @@ impl ArrowImportVTable for Vector {
     fn from_arrow_array(
         &self,
         array: ArrowArrayRef,
-        dtype: &ExtDTypeRef,
+        _field: &Field,
+        dtype: &DType,
     ) -> VortexResult<ArrowImport> {
+        let DType::Extension(dtype) = dtype else {
+            return Ok(ArrowImport::Unsupported(array));
+        };
         if !dtype.is::<Vector>() {
             return Ok(ArrowImport::Unsupported(array));
         }
@@ -362,13 +366,11 @@ mod tests {
     #[test]
     fn from_arrow_array_returns_unsupported_for_non_fsl() -> VortexResult<()> {
         let dtype = vector_dtype(false);
-        let ext = dtype
-            .as_extension_opt()
-            .expect("vector dtype should be an extension dtype")
-            .clone();
+        let field = Field::new("embedding", DataType::Int32, false);
 
         let int_array: ArrowArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
-        let result = <Vector as ArrowImportVTable>::from_arrow_array(&Vector, int_array, &ext)?;
+        let result =
+            <Vector as ArrowImportVTable>::from_arrow_array(&Vector, int_array, &field, &dtype)?;
         assert!(matches!(result, ArrowImport::Unsupported(_)));
         Ok(())
     }
@@ -386,8 +388,13 @@ mod tests {
             ExtDType::try_with_vtable(Uuid, UuidMetadata::default(), uuid_storage)?.erased();
 
         let fsl_arrow = arrow_fsl_f32(vec![1.0, 2.0, 3.0], DIM as i32);
-        let result =
-            <Vector as ArrowImportVTable>::from_arrow_array(&Vector, fsl_arrow, &uuid_ext)?;
+        let field = Field::new("embedding", fsl_arrow.data_type().clone(), false);
+        let result = <Vector as ArrowImportVTable>::from_arrow_array(
+            &Vector,
+            fsl_arrow,
+            &field,
+            &DType::Extension(uuid_ext),
+        )?;
         assert!(matches!(result, ArrowImport::Unsupported(_)));
         Ok(())
     }


### PR DESCRIPTION
## Summary

Allows importing/exporting vortex and arrow arrays in the case where the arrow side is an extension but Vortex isn't.

This PR also includes the motivating change - support for ParquetVariant import/export.


## API Changes

Changes the signature of `ArrowImportVTable::from_arrow_array` to include both the `Field` (which has the full arrow-side type info) and a full  vortex `DType`.
