### PR TITLE
fix: code coverage ci task

### DIFF
--- a/.github/workflows/fuzz-coverage.yml
+++ b/.github/workflows/fuzz-coverage.yml
@@ -40,11 +40,14 @@ jobs:
             rustup component add llvm-tools-preview --toolchain $NIGHTLY_TOOLCHAIN
 
           # Verify llvm-profdata is accessible (cargo-fuzz needs it for coverage merging)
-          LLVM_PROFDATA="$(rustc +$NIGHTLY_TOOLCHAIN --print sysroot)/lib/rustlib/$(rustc +$NIGHTLY_TOOLCHAIN -vV | sed -n 's|host: ||p')/bin/llvm-profdata"
+          RUST_SYSROOT="$(rustc +$NIGHTLY_TOOLCHAIN --print sysroot)"
+          RUST_HOST="$(rustc +$NIGHTLY_TOOLCHAIN --print host-tuple)"
+          LLVM_TOOLS_BIN="${RUST_SYSROOT}/lib/rustlib/${RUST_HOST}/bin"
+          LLVM_PROFDATA="${LLVM_TOOLS_BIN}/llvm-profdata"
           if [ ! -f "$LLVM_PROFDATA" ]; then
             echo "ERROR: llvm-profdata not found at $LLVM_PROFDATA"
             echo "Listing bin directory:"
-            ls -la "$(dirname "$LLVM_PROFDATA")" || echo "Directory does not exist"
+            ls -la "$LLVM_TOOLS_BIN" || echo "Directory does not exist"
             exit 1
           fi
           echo "Found llvm-profdata at $LLVM_PROFDATA"
@@ -84,13 +87,13 @@ jobs:
           COVERAGE_DIR="fuzz/coverage/${{ matrix.fuzz_target }}"
 
           # llvm tools are installed via rustup's llvm-tools component
-          LLVM_TOOLS_BIN="$(rustc +$NIGHTLY_TOOLCHAIN --print sysroot)/lib/rustlib/$(rustc +$NIGHTLY_TOOLCHAIN -vV | sed -n 's|host: ||p')/bin"
-
-          TARGET_TRIPLE=$(rustc +$NIGHTLY_TOOLCHAIN -vV | sed -n 's|host: ||p')
+          RUST_SYSROOT="$(rustc +$NIGHTLY_TOOLCHAIN --print sysroot)"
+          RUST_HOST="$(rustc +$NIGHTLY_TOOLCHAIN --print host-tuple)"
+          LLVM_TOOLS_BIN="${RUST_SYSROOT}/lib/rustlib/${RUST_HOST}/bin"
 
           # cargo-fuzz coverage places the binary at:
           #   target/<triple>/coverage/<triple>/release/<fuzz_target>
-          FUZZ_BIN="target/${TARGET_TRIPLE}/coverage/${TARGET_TRIPLE}/release/${{ matrix.fuzz_target }}"
+          FUZZ_BIN="target/${RUST_HOST}/coverage/${RUST_HOST}/release/${{ matrix.fuzz_target }}"
 
           if [ ! -f "$FUZZ_BIN" ]; then
             echo "ERROR: Could not find fuzz binary at $FUZZ_BIN"

--- a/.github/workflows/rust-instrumented.yml
+++ b/.github/workflows/rust-instrumented.yml
@@ -47,14 +47,33 @@ jobs:
           sccache: s3
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - uses: ./.github/actions/setup-prebuild
+      - name: Ensure llvm-tools are installed
+        run: |
+          rustup component add llvm-tools || \
+            rustup component add llvm-tools-preview
+
+          # Verify llvm-profdata is accessible (grcov needs it for coverage merging)
+          RUST_SYSROOT="$(rustc --print sysroot)"
+          RUST_HOST="$(rustc --print host-tuple)"
+          LLVM_TOOLS_BIN="${RUST_SYSROOT}/lib/rustlib/${RUST_HOST}/bin"
+          LLVM_PROFDATA="${LLVM_TOOLS_BIN}/llvm-profdata"
+          if [ ! -f "$LLVM_PROFDATA" ]; then
+            echo "ERROR: llvm-profdata not found at $LLVM_PROFDATA"
+            echo "Listing bin directory:"
+            ls -la "$LLVM_TOOLS_BIN" || echo "Directory does not exist"
+            exit 1
+          fi
+          echo "Found llvm-profdata at $LLVM_PROFDATA"
+
       - name: Rust Tests
         if: ${{ matrix.suite == 'tests' }}
         run: |
           cargo nextest run --locked --workspace --all-features --no-fail-fast
       - name: Generate coverage report
         run: |
-          set -euo pipefail
-          LLVM_TOOLS_BIN="$(dirname "$(rustup which llvm-profdata)")"
+          RUST_SYSROOT="$(rustc --print sysroot)"
+          RUST_HOST="$(rustc --print host-tuple)"
+          LLVM_TOOLS_BIN="${RUST_SYSROOT}/lib/rustlib/${RUST_HOST}/bin"
           grcov . --binary-path target/debug/ -s . -t lcov --llvm --ignore-not-existing \
             --llvm-path "${LLVM_TOOLS_BIN}" \
             --threads $(nproc) \


### PR DESCRIPTION
The installed LLVM tools reside under 
```
RUST_SYSROOT="$(rustc --print sysroot)"
RUST_HOST="$(rustc --print host-tuple)"
LLVM_TOOLS_BIN="${RUST_SYSROOT}/lib/rustlib/${RUST_HOST}/bin"
```
which is different from what we previously expected.

Further, splitting up the commands like
```
RUST_SYSROOT="$(rustc +$NIGHTLY_TOOLCHAIN --print sysroot)"
RUST_HOST="$(rustc +$NIGHTLY_TOOLCHAIN --print host-tuple)"
LLVM_TOOLS_BIN="${RUST_SYSROOT}/lib/rustlib/${RUST_HOST}/bin"
```
leads to non-zero exit code in case any of them fail. This is unlike the previous setup where only the outermost command `dirname` was checked for its exit code which is 0, even if `""` is passed as an argument.