### PR TITLE
Always use `FileStatsLayoutReader` if available for `VortexFile` reader

### DIFF
--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -46,14 +46,27 @@ use crate::v2::FileStatsLayoutReader;
 #[derive(Clone)]
 pub struct VortexFile {
     /// The footer of the Vortex file, containing metadata and layout information.
-    pub(crate) footer: Footer,
+    footer: Footer,
     /// The segment source used to read segments from this file.
-    pub(crate) segment_source: Arc<dyn SegmentSource>,
-    /// The Vortex session used to open this file
-    pub(crate) session: VortexSession,
+    segment_source: Arc<dyn SegmentSource>,
+    /// The Vortex session used to open this file.
+    session: VortexSession,
 }
 
 impl VortexFile {
+    /// Creates a new `VortexFile` from the given footer, segment source, and session.
+    pub fn new(
+        footer: Footer,
+        segment_source: Arc<dyn SegmentSource>,
+        session: VortexSession,
+    ) -> Self {
+        Self {
+            footer,
+            segment_source,
+            session,
+        }
+    }
+
     /// Returns a reference to the file's footer, which contains metadata and layout information.
     pub fn footer(&self) -> &Footer {
         &self.footer
@@ -82,6 +95,11 @@ impl VortexFile {
     /// is dropped.
     pub fn segment_source(&self) -> Arc<dyn SegmentSource> {
         Arc::clone(&self.segment_source)
+    }
+
+    /// Returns a reference to the Vortex session used to open this file.
+    pub fn session(&self) -> &VortexSession {
+        &self.session
     }
 
     /// Create a new layout reader for the file.

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -103,12 +103,26 @@ impl VortexFile {
     }
 
     /// Create a new layout reader for the file.
+    ///
+    /// Wraps the root layout in a [`FileStatsLayoutReader`] if file stats are available.
     pub fn layout_reader(&self) -> VortexResult<Arc<dyn LayoutReader>> {
         let segment_source = self.segment_source();
-        self.footer
+
+        let root_reader = self
+            .footer
             .layout()
             // TODO(ngates): we may want to allow the user pass in a name here?
-            .new_reader("".into(), segment_source, &self.session)
+            .new_reader("".into(), segment_source, &self.session)?;
+
+        Ok(if let Some(stats) = self.file_stats().cloned() {
+            Arc::new(FileStatsLayoutReader::new(
+                root_reader,
+                stats,
+                self.session.clone(),
+            ))
+        } else {
+            root_reader
+        })
     }
 
     /// Create a [`DataSource`](vortex_scan::DataSource) from this file for scanning.
@@ -116,14 +130,8 @@ impl VortexFile {
     /// Wraps the file's layout reader with [`FileStatsLayoutReader`] (when file-level
     /// statistics are available) and [`LayoutReaderDataSource`].
     pub fn data_source(&self) -> VortexResult<DataSourceRef> {
-        let mut reader = self.layout_reader()?;
-        if let Some(stats) = self.file_stats().cloned() {
-            reader = Arc::new(FileStatsLayoutReader::new(
-                reader,
-                stats,
-                self.session.clone(),
-            ));
-        }
+        let reader = self.layout_reader()?;
+
         Ok(Arc::new(LayoutReaderDataSource::new(
             reader,
             self.session.clone(),

--- a/vortex-file/src/multi/mod.rs
+++ b/vortex-file/src/multi/mod.rs
@@ -24,7 +24,6 @@ use vortex_session::VortexSession;
 use crate::OpenOptionsSessionExt;
 use crate::VortexFile;
 use crate::VortexOpenOptions;
-use crate::v2::FileStatsLayoutReader;
 
 /// A builder that discovers multiple Vortex files from glob patterns and constructs a
 /// [`MultiLayoutDataSource`] to scan them as a single data source.
@@ -154,7 +153,7 @@ impl MultiFileDataSource {
         let (first_file_listing, first_fs) = &all_files[0];
         let open_fn = self.open_options_fn.as_ref();
         let first_file = open_file(first_fs, first_file_listing, &self.session, open_fn).await?;
-        let first_reader = layout_reader_with_stats(&first_file)?;
+        let first_reader = first_file.layout_reader()?;
 
         let factories: Vec<Arc<dyn LayoutReaderFactory>> = all_files[1..]
             .iter()
@@ -238,20 +237,6 @@ async fn open_file(
     Ok(vortex_file)
 }
 
-/// Creates a layout reader from a VortexFile, wrapping with `FileStatsLayoutReader` when
-/// file-level statistics are available.
-fn layout_reader_with_stats(file: &VortexFile) -> VortexResult<LayoutReaderRef> {
-    let mut reader = file.layout_reader()?;
-    if let Some(stats) = file.file_stats().cloned() {
-        reader = Arc::new(FileStatsLayoutReader::new(
-            reader,
-            stats,
-            file.session().clone(),
-        ));
-    }
-    Ok(reader)
-}
-
 /// A [`LayoutReaderFactory`] that lazily opens a single Vortex file and returns its layout reader.
 struct VortexFileReaderFactory {
     fs: FileSystemRef,
@@ -270,6 +255,7 @@ impl LayoutReaderFactory for VortexFileReaderFactory {
             self.open_options_fn.as_ref(),
         )
         .await?;
-        Ok(Some(layout_reader_with_stats(&file)?))
+
+        Ok(Some(file.layout_reader()?))
     }
 }

--- a/vortex-file/src/multi/mod.rs
+++ b/vortex-file/src/multi/mod.rs
@@ -22,6 +22,7 @@ use vortex_scan::DataSource;
 use vortex_session::VortexSession;
 
 use crate::OpenOptionsSessionExt;
+use crate::VortexFile;
 use crate::VortexOpenOptions;
 use crate::v2::FileStatsLayoutReader;
 
@@ -203,7 +204,7 @@ async fn open_file(
     file: &FileListing,
     session: &VortexSession,
     open_options_fn: &(dyn Fn(VortexOpenOptions) -> VortexOpenOptions + Send + Sync),
-) -> VortexResult<crate::VortexFile> {
+) -> VortexResult<VortexFile> {
     tracing::trace!(path = %file.path, "opening vortex file");
 
     // Open the reader first so we can use its URI as the cache key.
@@ -239,13 +240,13 @@ async fn open_file(
 
 /// Creates a layout reader from a VortexFile, wrapping with `FileStatsLayoutReader` when
 /// file-level statistics are available.
-fn layout_reader_with_stats(file: &crate::VortexFile) -> VortexResult<LayoutReaderRef> {
+fn layout_reader_with_stats(file: &VortexFile) -> VortexResult<LayoutReaderRef> {
     let mut reader = file.layout_reader()?;
     if let Some(stats) = file.file_stats().cloned() {
         reader = Arc::new(FileStatsLayoutReader::new(
             reader,
             stats,
-            file.session.clone(),
+            file.session().clone(),
         ));
     }
     Ok(reader)

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -194,11 +194,7 @@ impl VortexOpenOptions {
             Arc::clone(footer.segment_map()),
         ));
 
-        Ok(VortexFile {
-            footer,
-            segment_source,
-            session: opts.session,
-        })
+        Ok(VortexFile::new(footer, segment_source, opts.session))
     }
 
     /// An API for opening a [`VortexFile`] using any [`VortexReadAt`] implementation.
@@ -244,11 +240,11 @@ impl VortexOpenOptions {
             segment_source,
         ));
 
-        Ok(VortexFile {
+        Ok(VortexFile::new(
             footer,
             segment_source,
-            session: self.session.clone(),
-        })
+            self.session.clone(),
+        ))
     }
 
     async fn read_footer(&self, read: &dyn VortexReadAt) -> VortexResult<Footer> {


### PR DESCRIPTION
## Summary

We use the file statistics when constructing a data source, but we do always do that for the layout reader.

Question: do we want to cache the layout reader in the vortex file instead of constructing it in every other method? (this was why I added a constructor)

## Testing

We'll see what happens in benchmarks.