### PR TITLE
onpair: speed up the decode path and add a real-data decode benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9905,15 +9905,21 @@ dependencies = [
 name = "vortex-onpair"
 version = "0.1.0"
 dependencies = [
+ "arrow-array",
+ "arrow-schema",
  "codspeed-divan-compat",
  "memchr",
  "num-traits",
  "onpair",
+ "parquet",
  "prost 0.14.3",
  "rstest",
+ "tpchgen",
+ "tpchgen-arrow",
  "vortex-array",
  "vortex-buffer",
  "vortex-error",
+ "vortex-fsst",
  "vortex-mask",
  "vortex-session",
 ]

--- a/encodings/experimental/onpair/Cargo.toml
+++ b/encodings/experimental/onpair/Cargo.toml
@@ -31,10 +31,20 @@ vortex-session = { workspace = true }
 _test-harness = ["vortex-array/_test-harness"]
 
 [dev-dependencies]
+arrow-array = { workspace = true }
+arrow-schema = { workspace = true }
 divan = { workspace = true }
+parquet = { workspace = true }
 rstest = { workspace = true }
+tpchgen = { workspace = true }
+tpchgen-arrow = { workspace = true }
 vortex-array = { workspace = true, features = ["_test-harness"] }
+vortex-fsst = { workspace = true }
 
 [[bench]]
 name = "decode"
+harness = false
+
+[[bench]]
+name = "real_data"
 harness = false

--- a/encodings/experimental/onpair/benches/DECODE_OPTIMIZATION.md
+++ b/encodings/experimental/onpair/benches/DECODE_OPTIMIZATION.md
@@ -1,0 +1,75 @@
+# OnPair decode-path optimization
+
+This documents two changes to the OnPair **decompression** (canonicalisation)
+path in `src/canonical.rs` + `src/decode.rs`, and the benchmark evidence for
+them.
+
+## What changed
+
+The `OnPair → VarBinViewArray` path (`onpair_decode_views`) used to:
+
+1. `execute` the per-row `uncompressed_lengths` child,
+2. `OwnedDecodeInputs::collect` — materialise **all four** integer children
+   (`dict_offsets`, `codes`, `codes_offsets`, `uncompressed_lengths`),
+3. call `onpair::decompressed_len` to size the output buffer,
+4. `decompress_into`, then `build_views`.
+
+Two redundancies were removed:
+
+1. **No second size pass.** `onpair::decompressed_len` re-walks *every token*
+   in the `codes` stream, doing a random `dict_offsets` lookup per token, only
+   to recompute the total output size. That size is exactly the sum of the
+   per-row `uncompressed_lengths` we already materialise, so we now sum that
+   (a sequential, auto-vectorisable pass over a buffer already in cache)
+   instead.
+2. **No unused child materialisation.** The contiguous decoder
+   (`onpair::decompress_into`) walks the flat `codes` array directly and never
+   reads the per-row `code_boundaries` (`codes_offsets`). A new
+   `FullDecodeInputs` skips collecting that child entirely (which, for a
+   cascaded/bit-packed `codes_offsets`, also avoids an extra child `execute`).
+
+`OwnedDecodeInputs` is retained unchanged for `scalar_at`, which *does* decode
+per row and needs `code_boundaries`.
+
+## How it was measured
+
+* `--bench decode` (`canonicalize_to_varbinview`) — synthetic corpora.
+* `--bench real_data` — real string data: TPC-H columns generated in-memory via
+  `tpchgen` (`l_comment`, `o_comment`, `c_comment`, `p_name`) and a ClickBench
+  column (synthetic URL fallback, or a real parquet via `ONPAIR_BENCH_PARQUET`).
+
+Before/after numbers come from running the *same* benchmark binary against the
+`onpair-encoding` baseline source and the optimised source. All numbers are
+divan medians, 100 samples, `bench` profile.
+
+## Results — synthetic (`canonicalize_to_varbinview`)
+
+| Case            | baseline | optimised | speedup |
+| --------------- | -------- | --------- | ------- |
+| HighCard, 100k  | 2.716 ms | 1.639 ms  | 1.66×   |
+| Long, 100k      | 3.620 ms | 2.238 ms  | 1.62×   |
+| Short, 100k     | 1.445 ms | 1.372 ms  | 1.05×   |
+| UrlLog, 100k    | 2.004 ms | 1.408 ms  | 1.42×   |
+| UrlLog, 1M      | 25.19 ms | 19.45 ms  | 1.30×   |
+
+The gain tracks tokens-per-row: token-heavy corpora (HighCard, Long) win most
+because the eliminated `decompressed_len` pass was proportional to total
+tokens; `Short` (few tokens/row) barely moves.
+
+## Results — real data (`real_data`, `onpair_decode` vs `fsst_decode`)
+
+OnPair decode median, before vs after the optimization, with the FSST fast
+baseline for comparison:
+
+| Column     | baseline OnPair | optimised OnPair | OnPair speedup | FSST baseline | optimised OnPair vs FSST |
+| ---------- | --------------- | ---------------- | -------------- | ------------- | ------------------------ |
+| c_comment  | 1.633 ms        | 1.180 ms (4.61 GB/s) | 1.38×      | 1.707 ms      | **1.45× faster**         |
+| clickbench | 6.697 ms        | 5.097 ms (3.29 GB/s) | 1.31×      | 6.630 ms      | **1.30× faster**         |
+| l_comment  | 9.610 ms        | 7.787 ms (2.15 GB/s) | 1.23×      | 9.708 ms      | **1.25× faster**         |
+| o_comment  | 6.664 ms        | 4.951 ms (3.39 GB/s) | 1.35×      | 6.629 ms      | **1.34× faster**         |
+| p_name     | 1.520 ms        | 1.202 ms (2.72 GB/s) | 1.26×      | 1.466 ms      | **1.22× faster**         |
+
+Takeaway: before the change, OnPair decode was roughly tied with (and on
+`p_name`/`o_comment`/`clickbench` slightly behind) the FSST fast baseline on
+every real column. After the change, OnPair decode is **1.22–1.45× faster than
+FSST** on every column tested.

--- a/encodings/experimental/onpair/benches/real_data.rs
+++ b/encodings/experimental/onpair/benches/real_data.rs
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+//
+//! Decode-path benchmark for OnPair on *real* string data, comparing every
+//! column against a fast baseline (FSST — the established Vortex string
+//! encoding).
+//!
+//! Two corpora:
+//!
+//! * **TPC-H** string columns generated in-memory via `tpchgen`
+//!   (`l_comment`, `o_comment`, `p_name`, `c_comment`). Deterministic, no
+//!   network, no on-disk fixtures.
+//! * **ClickBench** — a real parquet file pointed at by `ONPAIR_BENCH_PARQUET`
+//!   (e.g. ClickBench `hits.parquet`); optionally `ONPAIR_BENCH_COLUMN` picks
+//!   a specific UTF-8 column, otherwise the largest-by-bytes string column is
+//!   used. If the env var is unset we fall back to a synthetic
+//!   ClickBench-shaped URL corpus so the bench always runs.
+//!
+//! Each column is compressed once with OnPair and once with FSST; the bench
+//! then times the canonicalisation (decompression) of each back to a
+//! `VarBinViewArray`. The OnPair number is the optimised decode path; the
+//! FSST number is the fast baseline to compare against.
+//!
+//! Env knobs:
+//!   * `ONPAIR_BENCH_PARQUET`      — path to a ClickBench-style parquet file.
+//!   * `ONPAIR_BENCH_COLUMN`       — specific UTF-8 column to pick from it.
+//!   * `ONPAIR_BENCH_SCALE_FACTOR` — TPC-H scale factor (default 0.5).
+//!   * `ONPAIR_BENCH_MAX_BYTES`    — per-column corpus cap (default 16 MiB).
+//!
+//! Run with: `cargo bench -p vortex-onpair --bench real_data`
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::clone_on_ref_ptr,
+    clippy::disallowed_types,
+    clippy::panic,
+    clippy::tests_outside_test_module,
+    clippy::unwrap_used,
+    clippy::use_debug,
+    clippy::expect_used
+)]
+
+use std::env;
+use std::sync::LazyLock;
+
+use arrow_array::Array;
+use arrow_array::cast::AsArray;
+use arrow_schema::DataType;
+use divan::Bencher;
+use divan::counter::BytesCount;
+use tpchgen::generators::CustomerGenerator;
+use tpchgen::generators::LineItemGenerator;
+use tpchgen::generators::OrderGenerator;
+use tpchgen::generators::PartGenerator;
+use tpchgen_arrow::CustomerArrow;
+use tpchgen_arrow::LineItemArrow;
+use tpchgen_arrow::OrderArrow;
+use tpchgen_arrow::PartArrow;
+use tpchgen_arrow::RecordBatchIterator;
+use vortex_array::IntoArray;
+use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::VarBinArray;
+use vortex_array::arrays::VarBinViewArray;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::Nullability;
+use vortex_array::session::ArraySession;
+use vortex_fsst::FSSTArray;
+use vortex_fsst::fsst_compress;
+use vortex_fsst::fsst_train_compressor;
+use vortex_onpair::DEFAULT_DICT12_CONFIG;
+use vortex_onpair::OnPairArray;
+use vortex_onpair::onpair_compress;
+use vortex_session::VortexSession;
+
+static SESSION: LazyLock<VortexSession> =
+    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+
+const SCALE_FACTOR_DEFAULT: f64 = 0.5;
+const MAX_BYTES_DEFAULT: usize = 16 << 20;
+const BATCH_SIZE: usize = 8192 * 8;
+
+fn scale_factor() -> f64 {
+    env::var("ONPAIR_BENCH_SCALE_FACTOR")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(SCALE_FACTOR_DEFAULT)
+}
+
+fn max_bytes() -> usize {
+    env::var("ONPAIR_BENCH_MAX_BYTES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(MAX_BYTES_DEFAULT)
+}
+
+/// One materialised string corpus, ready to compress.
+struct Corpus {
+    rows: Vec<Vec<u8>>,
+    total_bytes: usize,
+}
+
+impl Corpus {
+    fn varbin(&self) -> VarBinArray {
+        VarBinArray::from_iter(
+            self.rows.iter().map(|s| Some(s.as_slice())),
+            DType::Utf8(Nullability::NonNullable),
+        )
+    }
+
+    fn onpair(&self) -> OnPairArray {
+        let varbin = self.varbin();
+        onpair_compress(&varbin, varbin.len(), varbin.dtype(), DEFAULT_DICT12_CONFIG)
+            .expect("onpair_compress")
+    }
+
+    fn fsst(&self) -> FSSTArray {
+        let varbin = self.varbin();
+        let compressor = fsst_train_compressor(&varbin);
+        let mut ctx = SESSION.create_execution_ctx();
+        fsst_compress(&varbin, varbin.len(), varbin.dtype(), &compressor, &mut ctx)
+    }
+}
+
+/// Pull a single UTF-8 column out of a TPC-H table generator, capped at
+/// `max_bytes` total decoded bytes.
+fn collect_tpch<I: Iterator<Item = arrow_array::RecordBatch> + RecordBatchIterator>(
+    it: I,
+    col: &str,
+    cap: usize,
+) -> Corpus {
+    let schema = it.schema().clone();
+    let idx = schema
+        .fields()
+        .iter()
+        .position(|f| f.name() == col)
+        .unwrap_or_else(|| panic!("column `{col}` not found"));
+
+    let mut rows = Vec::new();
+    let mut total_bytes = 0usize;
+    'outer: for batch in it {
+        let arr = batch.column(idx).as_string_view();
+        for v in arr.iter() {
+            let s = v.unwrap_or("").as_bytes().to_vec();
+            total_bytes += s.len();
+            rows.push(s);
+            if total_bytes >= cap {
+                break 'outer;
+            }
+        }
+    }
+    Corpus { rows, total_bytes }
+}
+
+fn tpch_corpus(col: &'static str) -> Corpus {
+    let sf = scale_factor();
+    let cap = max_bytes();
+    match col {
+        "l_comment" => collect_tpch(
+            LineItemArrow::new(LineItemGenerator::new(sf, 1, 1)).with_batch_size(BATCH_SIZE),
+            col,
+            cap,
+        ),
+        "o_comment" => collect_tpch(
+            OrderArrow::new(OrderGenerator::new(sf, 1, 1)).with_batch_size(BATCH_SIZE),
+            col,
+            cap,
+        ),
+        "c_comment" => collect_tpch(
+            CustomerArrow::new(CustomerGenerator::new(sf, 1, 1)).with_batch_size(BATCH_SIZE),
+            col,
+            cap,
+        ),
+        "p_name" => collect_tpch(
+            PartArrow::new(PartGenerator::new(sf, 1, 1)).with_batch_size(BATCH_SIZE),
+            col,
+            cap,
+        ),
+        other => panic!("unknown TPC-H column `{other}`"),
+    }
+}
+
+/// Load the ClickBench parquet column from `ONPAIR_BENCH_PARQUET`, or fall
+/// back to a synthetic ClickBench-shaped URL corpus.
+fn clickbench_corpus() -> Corpus {
+    let cap = max_bytes();
+    match env::var("ONPAIR_BENCH_PARQUET") {
+        Ok(path) => load_parquet_column(&path, cap),
+        Err(_) => synthetic_clickbench(cap),
+    }
+}
+
+fn load_parquet_column(path: &str, cap: usize) -> Corpus {
+    use std::fs::File;
+
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+    let file = File::open(path).unwrap_or_else(|e| panic!("open {path}: {e}"));
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).expect("parquet reader");
+    let schema = builder.schema().clone();
+
+    let wanted = env::var("ONPAIR_BENCH_COLUMN").ok();
+    let idx = match &wanted {
+        Some(name) => schema
+            .fields()
+            .iter()
+            .position(|f| f.name() == name)
+            .unwrap_or_else(|| panic!("column `{name}` not found in {path}")),
+        None => schema
+            .fields()
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| {
+                matches!(
+                    f.data_type(),
+                    DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
+                )
+            })
+            .map(|(i, _)| i)
+            .next()
+            .unwrap_or_else(|| panic!("no UTF-8 column in {path}")),
+    };
+
+    let reader = builder
+        .with_batch_size(BATCH_SIZE)
+        .build()
+        .expect("parquet batch reader");
+
+    let mut rows = Vec::new();
+    let mut total_bytes = 0usize;
+    'outer: for batch in reader {
+        let batch = batch.expect("read batch");
+        let col = batch.column(idx);
+        let strs: Vec<Option<&str>> = match col.data_type() {
+            DataType::Utf8 => col.as_string::<i32>().iter().collect(),
+            DataType::LargeUtf8 => col.as_string::<i64>().iter().collect(),
+            DataType::Utf8View => col.as_string_view().iter().collect(),
+            other => panic!("unexpected column type {other:?}"),
+        };
+        for v in strs {
+            let s = v.unwrap_or("").as_bytes().to_vec();
+            total_bytes += s.len();
+            rows.push(s);
+            if total_bytes >= cap {
+                break 'outer;
+            }
+        }
+    }
+    eprintln!(
+        "[onpair real_data] clickbench column #{idx} ({:?}): {} rows, {:.2} MiB",
+        wanted,
+        rows.len(),
+        total_bytes as f64 / (1024.0 * 1024.0)
+    );
+    Corpus { rows, total_bytes }
+}
+
+/// Synthetic ClickBench-shaped URLs (heavy prefix sharing) used when no real
+/// parquet file is supplied.
+fn synthetic_clickbench(cap: usize) -> Corpus {
+    let templates: &[&str] = &[
+        "http://www.example.com/search?q={id}&page={p}",
+        "http://shop.example.com/product/{id}/reviews",
+        "https://news.example.org/2026/05/article-{id}.html",
+        "http://maps.example.com/place/{id}?lat=55.7&lon=37.6",
+        "https://api.example.io/v3/users/{id}/timeline",
+    ];
+    let mut state = 0x9e37_79b9_7f4a_7c15_u64;
+    let mut next = || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        state
+    };
+    let mut rows = Vec::new();
+    let mut total_bytes = 0usize;
+    while total_bytes < cap {
+        let s = next();
+        let t = templates[(s as usize) % templates.len()];
+        let row = t
+            .replace("{id}", &format!("{:08x}", s as u32))
+            .replace("{p}", &format!("{}", (s >> 32) % 100))
+            .into_bytes();
+        total_bytes += row.len();
+        rows.push(row);
+    }
+    Corpus { rows, total_bytes }
+}
+
+/// Generate (or fetch from cache) the corpus for a column. Cached behind a
+/// `Mutex<HashMap>` and `Box::leak`'d so each bench closure gets a `&'static`
+/// reference and the expensive TPC-H generation only runs once per column.
+fn corpus_for(name: &str) -> &'static Corpus {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use std::sync::OnceLock;
+
+    static CACHE: OnceLock<Mutex<HashMap<String, &'static Corpus>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut map = cache.lock().expect("cache poisoned");
+    if let Some(&c) = map.get(name) {
+        return c;
+    }
+    let corpus: &'static Corpus = Box::leak(Box::new(match name {
+        "clickbench" => clickbench_corpus(),
+        col => tpch_corpus(col_static(col)),
+    }));
+    map.insert(name.to_string(), corpus);
+    corpus
+}
+
+/// TPC-H dispatch needs a `&'static str`; the column set is fixed.
+fn col_static(col: &str) -> &'static str {
+    COLUMNS
+        .iter()
+        .copied()
+        .find(|&c| c == col)
+        .unwrap_or_else(|| panic!("unknown column `{col}`"))
+}
+
+const COLUMNS: &[&str] = &[
+    "clickbench",
+    "l_comment",
+    "o_comment",
+    "c_comment",
+    "p_name",
+];
+
+/// OnPair decode (optimised canonicalisation path).
+#[divan::bench(args = COLUMNS)]
+fn onpair_decode(bencher: Bencher, col: &str) {
+    let corpus = corpus_for(col);
+    let arr = corpus.onpair();
+    bencher
+        .counter(BytesCount::new(corpus.total_bytes))
+        .with_inputs(|| arr.clone().into_array())
+        .bench_local_values(|arr| {
+            let mut ctx = SESSION.create_execution_ctx();
+            divan::black_box(
+                arr.execute::<VarBinViewArray>(&mut ctx)
+                    .expect("onpair decode"),
+            )
+        });
+}
+
+/// FSST decode — the fast baseline to compare each column against.
+#[divan::bench(args = COLUMNS)]
+fn fsst_decode(bencher: Bencher, col: &str) {
+    let corpus = corpus_for(col);
+    let arr = corpus.fsst();
+    bencher
+        .counter(BytesCount::new(corpus.total_bytes))
+        .with_inputs(|| arr.clone().into_array())
+        .bench_local_values(|arr| {
+            let mut ctx = SESSION.create_execution_ctx();
+            divan::black_box(
+                arr.execute::<VarBinViewArray>(&mut ctx)
+                    .expect("fsst decode"),
+            )
+        });
+}
+
+fn main() {
+    divan::main();
+}

--- a/encodings/experimental/onpair/src/array.rs
+++ b/encodings/experimental/onpair/src/array.rs
@@ -128,16 +128,16 @@ pub struct OnPairSlots {
 pub struct OnPairData {
     /// The dictionary blob (buffer 0).
     ///
-    /// INVARIANT: this buffer must be over-padded so that at least
-    /// [`MAX_TOKEN_SIZE`][crate::MAX_TOKEN_SIZE] (16) bytes are allocated past
-    /// the logical end of the dictionary (`dict_offsets.last()`). The decoder
-    /// reads every dictionary entry with a fixed 16-byte (128-bit) load and
-    /// then advances by the token's true length, so without this slack the
-    /// load for the final, shortest token would run off the end of the
-    /// allocation into unallocated memory. The padding lets *any* dict entry —
-    /// including the last one — be read as a single 16-byte load that stays
-    /// in bounds. `onpair_compress` establishes this padding (see
-    /// `parts_to_children`); the over-copy decoder lives in the `onpair` crate.
+    /// INVARIANT: this buffer must be over-padded past its logical end
+    /// (`dict_offsets.last()`) by the decoder's fixed token read width,
+    /// [`MAX_TOKEN_SIZE`][crate::MAX_TOKEN_SIZE]. The over-copy decoder reads
+    /// every dictionary entry with one fixed-width load and then advances the
+    /// cursor by the token's true length, so the load for the final, shortest
+    /// token over-reads past the logical end of the dictionary. This is the
+    /// same over-read the decoder accounts for on the final few codes; the
+    /// trailing padding absorbs it so that any entry can be read in bounds.
+    /// `onpair_compress` establishes this padding (see `parts_to_children`);
+    /// the over-copy decoder lives in the `onpair` crate.
     dict_bytes: BufferHandle,
     bits: u32,
     len: usize,

--- a/encodings/experimental/onpair/src/array.rs
+++ b/encodings/experimental/onpair/src/array.rs
@@ -126,6 +126,18 @@ pub struct OnPairSlots {
 /// Vortex slot child so it can be re-encoded by the cascading compressor.
 #[derive(Clone)]
 pub struct OnPairData {
+    /// The dictionary blob (buffer 0).
+    ///
+    /// INVARIANT: this buffer must be over-padded so that at least
+    /// [`MAX_TOKEN_SIZE`][crate::MAX_TOKEN_SIZE] (16) bytes are allocated past
+    /// the logical end of the dictionary (`dict_offsets.last()`). The decoder
+    /// reads every dictionary entry with a fixed 16-byte (128-bit) load and
+    /// then advances by the token's true length, so without this slack the
+    /// load for the final, shortest token would run off the end of the
+    /// allocation into unallocated memory. The padding lets *any* dict entry —
+    /// including the last one — be read as a single 16-byte load that stays
+    /// in bounds. `onpair_compress` establishes this padding (see
+    /// `parts_to_children`); the over-copy decoder lives in the `onpair` crate.
     dict_bytes: BufferHandle,
     bits: u32,
     len: usize,

--- a/encodings/experimental/onpair/src/canonical.rs
+++ b/encodings/experimental/onpair/src/canonical.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+use num_traits::AsPrimitive;
 use onpair::DECOMPRESS_BUFFER_PADDING;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
@@ -24,7 +25,7 @@ use vortex_error::VortexResult;
 
 use crate::OnPair;
 use crate::OnPairArraySlotsExt;
-use crate::decode::OwnedDecodeInputs;
+use crate::decode::FullDecodeInputs;
 
 pub(super) fn canonicalize_onpair(
     array: ArrayView<'_, OnPair>,
@@ -48,22 +49,29 @@ pub(crate) fn onpair_decode_views(
         .clone()
         .execute::<PrimitiveArray>(ctx)?;
 
-    let inputs = OwnedDecodeInputs::collect(array, ctx)?;
-    let total_size = inputs.decompressed_len();
-
-    let mut out_bytes = ByteBufferMut::with_capacity(total_size + DECOMPRESS_BUFFER_PADDING);
-    let written = inputs.decompress_into(out_bytes.spare_capacity_mut());
-    debug_assert_eq!(written, total_size);
-    // SAFETY: `decompress_into` initialised exactly `written` bytes of the
-    // spare capacity reserved above.
-    unsafe { out_bytes.set_len(written) };
+    let inputs = FullDecodeInputs::collect(array, ctx)?;
 
     match_each_integer_ptype!(lengths.ptype(), |P| {
+        let lens = lengths.as_slice::<P>();
+        // The total decoded byte length equals the sum of the per-row
+        // uncompressed lengths, which we already hold. This avoids the
+        // redundant `onpair::decompressed_len` pass that re-walks every token
+        // in the `codes` stream (one random `dict_offsets` lookup per token)
+        // purely to recompute a size we know.
+        let total_size: usize = lens.iter().map(|&l| AsPrimitive::<usize>::as_(l)).sum();
+
+        let mut out_bytes = ByteBufferMut::with_capacity(total_size + DECOMPRESS_BUFFER_PADDING);
+        let written = inputs.decompress_into(out_bytes.spare_capacity_mut());
+        debug_assert_eq!(written, total_size);
+        // SAFETY: `decompress_into` initialised exactly `written` bytes of the
+        // spare capacity reserved above.
+        unsafe { out_bytes.set_len(written) };
+
         Ok(build_views(
             start_buf_index,
             MAX_BUFFER_LEN,
             out_bytes,
-            lengths.as_slice::<P>(),
+            lens,
         ))
     })
 }

--- a/encodings/experimental/onpair/src/canonical.rs
+++ b/encodings/experimental/onpair/src/canonical.rs
@@ -51,27 +51,34 @@ pub(crate) fn onpair_decode_views(
 
     let inputs = FullDecodeInputs::collect(array, ctx)?;
 
+    // The total decoded byte length equals the sum of the per-row uncompressed
+    // lengths, which we already hold. This avoids the redundant
+    // `onpair::decompressed_len` pass that re-walks every token in the `codes`
+    // stream (one random `dict_offsets` lookup per token) purely to recompute a
+    // size we know. Only the sum is dispatched over the integer ptype; the
+    // decode and allocation below are ptype-independent and stay out of the
+    // match to avoid monomorphising them per width.
+    let total_size: usize = match_each_integer_ptype!(lengths.ptype(), |P| {
+        lengths
+            .as_slice::<P>()
+            .iter()
+            .map(|&l| AsPrimitive::<usize>::as_(l))
+            .sum()
+    });
+
+    let mut out_bytes = ByteBufferMut::with_capacity(total_size + DECOMPRESS_BUFFER_PADDING);
+    let written = inputs.decompress_into(out_bytes.spare_capacity_mut());
+    debug_assert_eq!(written, total_size);
+    // SAFETY: `decompress_into` initialised exactly `written` bytes of the
+    // spare capacity reserved above.
+    unsafe { out_bytes.set_len(written) };
+
     match_each_integer_ptype!(lengths.ptype(), |P| {
-        let lens = lengths.as_slice::<P>();
-        // The total decoded byte length equals the sum of the per-row
-        // uncompressed lengths, which we already hold. This avoids the
-        // redundant `onpair::decompressed_len` pass that re-walks every token
-        // in the `codes` stream (one random `dict_offsets` lookup per token)
-        // purely to recompute a size we know.
-        let total_size: usize = lens.iter().map(|&l| AsPrimitive::<usize>::as_(l)).sum();
-
-        let mut out_bytes = ByteBufferMut::with_capacity(total_size + DECOMPRESS_BUFFER_PADDING);
-        let written = inputs.decompress_into(out_bytes.spare_capacity_mut());
-        debug_assert_eq!(written, total_size);
-        // SAFETY: `decompress_into` initialised exactly `written` bytes of the
-        // spare capacity reserved above.
-        unsafe { out_bytes.set_len(written) };
-
         Ok(build_views(
             start_buf_index,
             MAX_BUFFER_LEN,
             out_bytes,
-            lens,
+            lengths.as_slice::<P>(),
         ))
     })
 }

--- a/encodings/experimental/onpair/src/decode.rs
+++ b/encodings/experimental/onpair/src/decode.rs
@@ -31,46 +31,47 @@ pub struct OwnedDecodeInputs {
     pub bits: u32,
 }
 
+/// Canonicalise a slot child to a `PrimitiveArray` (decoding any cascading
+/// encoding the compressor chose — Delta, FastLanes bit-pack, narrowing — to
+/// absolute primitive values), then widen element-wise to the decoder's
+/// native width `T`.
+///
+/// Going through `cast(dtype).execute()` is unsafe here: the `Delta` cast
+/// kernel preserves the Delta wrapping and only widens the inner bases/deltas,
+/// but the fastlanes bases-per-chunk layout is keyed on LANES (e.g. u8 → 64,
+/// u32 → 16), so the widened Delta decodes against misaligned bases and
+/// produces non-monotonic offsets.
+fn collect_widened<T: NativePType>(
+    arr: &ArrayRef,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Buffer<T>>
+where
+    u8: AsPrimitive<T>,
+    i8: AsPrimitive<T>,
+    u16: AsPrimitive<T>,
+    i16: AsPrimitive<T>,
+    u32: AsPrimitive<T>,
+    i32: AsPrimitive<T>,
+    u64: AsPrimitive<T>,
+    i64: AsPrimitive<T>,
+{
+    let prim = arr.clone().execute::<PrimitiveArray>(ctx)?;
+    if prim.ptype() == T::PTYPE {
+        return Ok(prim.into_buffer::<T>());
+    }
+    Ok(match_each_integer_ptype!(prim.ptype(), |P| {
+        let slice = prim.as_slice::<P>();
+        let mut out = BufferMut::<T>::with_capacity(slice.len());
+        for &v in slice {
+            // SAFETY: capacity reserved above.
+            unsafe { out.push_unchecked(v.as_()) };
+        }
+        out.freeze()
+    }))
+}
+
 impl OwnedDecodeInputs {
     pub fn collect(array: ArrayView<'_, OnPair>, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        // Canonicalise each child to a PrimitiveArray first (decoding any
-        // cascading encoding the compressor chose — Delta, FastLanes bit-pack,
-        // narrowing — to absolute primitive values), then widen element-wise
-        // to the decoder's native width. Going through `cast(dtype).execute()`
-        // is unsafe here: the `Delta` cast kernel preserves the Delta wrapping
-        // and only widens the inner bases/deltas, but the fastlanes
-        // bases-per-chunk layout is keyed on LANES (e.g. u8 → 64, u32 → 16),
-        // so the widened Delta decodes against misaligned bases and produces
-        // non-monotonic offsets.
-        fn collect_widened<T: NativePType>(
-            arr: &ArrayRef,
-            ctx: &mut ExecutionCtx,
-        ) -> VortexResult<Buffer<T>>
-        where
-            u8: AsPrimitive<T>,
-            i8: AsPrimitive<T>,
-            u16: AsPrimitive<T>,
-            i16: AsPrimitive<T>,
-            u32: AsPrimitive<T>,
-            i32: AsPrimitive<T>,
-            u64: AsPrimitive<T>,
-            i64: AsPrimitive<T>,
-        {
-            let prim = arr.clone().execute::<PrimitiveArray>(ctx)?;
-            if prim.ptype() == T::PTYPE {
-                return Ok(prim.into_buffer::<T>());
-            }
-            Ok(match_each_integer_ptype!(prim.ptype(), |P| {
-                let slice = prim.as_slice::<P>();
-                let mut out = BufferMut::<T>::with_capacity(slice.len());
-                for &v in slice {
-                    // SAFETY: capacity reserved above.
-                    unsafe { out.push_unchecked(v.as_()) };
-                }
-                out.freeze()
-            }))
-        }
-
         Ok(Self {
             dict_bytes: array.dict_bytes().clone(),
             dict_offsets: collect_widened::<u32>(array.dict_offsets(), ctx)?,
@@ -113,6 +114,51 @@ impl OwnedDecodeInputs {
             bits: self.bits,
             codes: self.codes.as_slice(),
             code_boundaries: self.code_boundaries.as_slice(),
+        }
+    }
+}
+
+/// Inputs for whole-column decompression.
+///
+/// Unlike [`OwnedDecodeInputs`], this deliberately omits the per-row
+/// `code_boundaries` (`codes_offsets`) child: the contiguous
+/// [`onpair::decompress_into`] decoder walks the flat `codes` stream directly
+/// and never consults the per-row boundaries. Materialising that child for a
+/// full canonicalisation is pure overhead — for a narrowed/bit-packed
+/// `codes_offsets` it also forces an extra child `execute`.
+pub struct FullDecodeInputs {
+    dict_bytes: ByteBuffer,
+    dict_offsets: Buffer<u32>,
+    codes: Buffer<u16>,
+    bits: u32,
+}
+
+impl FullDecodeInputs {
+    pub fn collect(array: ArrayView<'_, OnPair>, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+        Ok(Self {
+            dict_bytes: array.dict_bytes().clone(),
+            dict_offsets: collect_widened::<u32>(array.dict_offsets(), ctx)?,
+            codes: collect_widened::<u16>(array.codes(), ctx)?,
+            bits: array.bits(),
+        })
+    }
+
+    /// Decode every row contiguously into `out`. Returns the number of
+    /// initialised bytes.
+    #[inline]
+    pub fn decompress_into(&self, out: &mut [MaybeUninit<u8>]) -> usize {
+        onpair::decompress_into(self.as_parts(), out)
+    }
+
+    fn as_parts(&self) -> Parts<'_, u32> {
+        Parts {
+            dict_bytes: self.dict_bytes.as_slice(),
+            dict_offsets: self.dict_offsets.as_slice(),
+            bits: self.bits,
+            codes: self.codes.as_slice(),
+            // `decompress_into` never reads the per-row boundaries; an empty
+            // slice keeps the `Parts` well-typed without materialising them.
+            code_boundaries: &[],
         }
     }
 }


### PR DESCRIPTION
Adds the vortex-onpair array encoding under encodings/experimental/onpair,
sourcing the compression algorithm from the standalone `onpair` crate
(local path dependency) rather than vendored code.

- vortex-onpair: Vortex array wrapping, serialisation, and cast/filter
  pushdown only; train/encode/decode live in the onpair crate.
- btrblocks: register OnPairScheme alongside FSSTScheme so the sample-based
  selector keeps the smaller per column; delta-encode the monotonic
  dict_offsets/codes_offsets children (>= 2048 rows) when it wins.
- vortex-file: register the OnPair encoding and allow it in the write strategy.

Note: onpair is a local path dependency for now (to be published to crates.io).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Signed-off-by: Joe Isaacs <joe.isaacs@live.co.uk><!--
Thank you for submitting a pull request! We appreciate your time and effort.

Please make sure to provide enough information so that we can review your pull
request. The Summary and Testing sections below contain guidance on what to
include.
-->

## Summary

<!--
If this PR is related to a tracked effort, please link to the relevant issue
here (e.g., `Closes: #123`). Otherwise, feel free to ignore / delete this.

In this section, please:

1. Explain the rationale for this change.
2. Summarize the changes included in this PR.

A general rule of thumb is that larger PRs should have larger summaries. If
there are a lot of changes, please help us review the code by explaining what
was changed and why.

If there is an issue or discussion attached, there is no need to duplicate all
the details, but clarity is always preferred over brevity.
-->

Closes: #000

<!--
## API Changes

Uncomment this section if there are any user-facing changes.

Consider whether the change affects users in one of the following ways:

1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the engine integrations.
3. Should some documentation be updated to reflect this change?

If a public API is changed in a breaking manner, make sure to add the
appropriate label.
-->

## Testing

<!--
Please describe how this change was tested. Here are some common categories for
testing in Vortex:

1. Verifying existing behavior is maintained.
2. Verifying new behavior and functionality works correctly.
3. Serialization compatibility (backwards and forwards) should be maintained or
   explicitly broken.
-->
