### PR TITLE
Add FSSTView encoding: a ListView-style FSST array

### DIFF
--- a/encodings/fsst/Cargo.toml
+++ b/encodings/fsst/Cargo.toml
@@ -56,5 +56,9 @@ name = "chunked_dict_fsst_builder"
 harness = false
 required-features = ["_test-harness"]
 
+[[bench]]
+name = "fsst_view_compute"
+harness = false
+
 [package.metadata.cargo-machete]
 ignored = ["fsst-rs"]

--- a/encodings/fsst/benches/fsst_view_compute.rs
+++ b/encodings/fsst/benches/fsst_view_compute.rs
@@ -155,6 +155,7 @@ fn compaction_name(strategy: FsstViewCompaction) -> &'static str {
         FsstViewCompaction::Direct => "direct",
         FsstViewCompaction::GatherBulk => "gather_bulk",
         FsstViewCompaction::PerElement => "per_element",
+        FsstViewCompaction::RunCoalesce => "run_coalesce",
     }
 }
 
@@ -549,6 +550,7 @@ const COMPACTIONS: &[FsstViewCompaction] = &[
     FsstViewCompaction::Auto,
     FsstViewCompaction::GatherBulk,
     FsstViewCompaction::PerElement,
+    FsstViewCompaction::RunCoalesce,
 ];
 
 fn take_view_pipeline_args() -> Vec<TakeViewArg> {

--- a/encodings/fsst/benches/fsst_view_compute.rs
+++ b/encodings/fsst/benches/fsst_view_compute.rs
@@ -1,0 +1,501 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Compares the two ways to run a `filter`/`take` pipeline that ends in a `VarBinViewArray`:
+//!
+//! 1. **fsst pipeline**: stay in [`FSSTArray`] at every step, compacting the codes into a fresh
+//!    [`FSSTArray`] each time (the kernels delegate to `VarBin`, rewriting the byte heap), then
+//!    canonicalize to a [`VarBinViewArray`] at the end.
+//! 2. **fsstview pipeline**: convert to [`FSSTViewArray`] and apply the metadata-only kernels
+//!    (offsets/sizes only — the byte heap is never touched), then canonicalize to a
+//!    [`VarBinViewArray`] at the end.
+//!
+//! Kernels are invoked directly (no Vortex execution/dispatch) so each part is measured in
+//! isolation: the `_step` benches measure just the filter/take hop; the `_pipeline` benches
+//! measure the hop plus the final canonicalization. For the fsstview pipeline the final
+//! canonicalization is measured under each [`FsstViewCompaction`] strategy so the compaction
+//! trade-off is visible directly.
+//!
+//! Two ~2 MiB (uncompressed) inputs are used: one with **many short** strings and one with
+//! **fewer long** strings. The expectation: the fsstview hop is far cheaper in both cases (no
+//! heap rewrite); for the final canonicalization, `GatherBulk` (compact) wins on the short-string
+//! input while `PerElement` (no compact) wins on the long-string input.
+
+#![expect(clippy::unwrap_used)]
+
+use divan::Bencher;
+use divan::black_box;
+use rand::RngExt;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::VarBinArray;
+use vortex_array::arrays::VarBinViewArray;
+use vortex_array::arrays::dict::TakeExecute;
+use vortex_array::arrays::filter::FilterKernel;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::Nullability;
+use vortex_fsst::FSST;
+use vortex_fsst::FSSTArray;
+use vortex_fsst::FSSTView;
+use vortex_fsst::FsstViewCompaction;
+use vortex_fsst::canonicalize_fsstview_with;
+use vortex_fsst::fsst_compress;
+use vortex_fsst::fsst_train_compressor;
+use vortex_fsst::fsstview_from_fsst;
+use vortex_mask::Mask;
+
+fn main() {
+    divan::main();
+}
+
+/// ~2 MiB of uncompressed string data, in two shapes.
+const TARGET_UNCOMPRESSED: usize = 2 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug)]
+enum Shape {
+    /// Many short strings (~12 bytes each) — small per-element work.
+    ManyShort,
+    /// Fewer long strings (~256 bytes each) — large per-element work.
+    FewLong,
+}
+
+impl Shape {
+    fn avg_len(self) -> usize {
+        match self {
+            Shape::ManyShort => 12,
+            Shape::FewLong => 256,
+        }
+    }
+
+    fn count(self) -> usize {
+        TARGET_UNCOMPRESSED / self.avg_len()
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Shape::ManyShort => "many_short",
+            Shape::FewLong => "few_long",
+        }
+    }
+}
+
+/// Build a ~2 MiB input. We use a small alphabet so FSST finds good symbols (realistic
+/// compression), with some shared substrings to mimic real string columns.
+fn generate(shape: Shape) -> VarBinArray {
+    let mut rng = StdRng::seed_from_u64(42);
+    let count = shape.count();
+    let avg_len = shape.avg_len();
+    let mut strings: Vec<Box<[u8]>> = Vec::with_capacity(count);
+
+    const WORDS: &[&str] = &[
+        "https://", "example", "vortex", ".com/", "path", "query=", "value", "data", "alpha",
+        "bravo", "charlie", "delta", "_", "-", "/", "0123",
+    ];
+
+    for _ in 0..count {
+        let target = avg_len * rng.random_range(70..=130) / 100;
+        let mut s = String::with_capacity(target + 8);
+        while s.len() < target {
+            s.push_str(WORDS[rng.random_range(0..WORDS.len())]);
+        }
+        s.truncate(target.max(1));
+        strings.push(s.into_bytes().into_boxed_slice());
+    }
+
+    VarBinArray::from_iter(
+        strings.into_iter().map(Some),
+        DType::Utf8(Nullability::NonNullable),
+    )
+}
+
+fn compress(varbin: &VarBinArray, ctx: &mut ExecutionCtx) -> FSSTArray {
+    let compressor = fsst_train_compressor(varbin);
+    fsst_compress(varbin, varbin.len(), varbin.dtype(), &compressor, ctx)
+}
+
+/// A selective mask keeps ~10% of rows; a non-selective mask keeps ~90%.
+fn make_mask(len: usize, keep_fraction: f64) -> Mask {
+    let mut rng = StdRng::seed_from_u64(7);
+    Mask::from_iter((0..len).map(|_| rng.random_bool(keep_fraction)))
+}
+
+#[derive(Clone, Copy, Debug)]
+enum TakeKind {
+    /// A full shuffle (permutation of all rows) — same length, reordered.
+    Shuffle,
+    /// Very selective — pick ~5% of rows at random (with possible repeats).
+    Selective,
+    /// Not selective — pick ~150% of rows at random (duplicates, output grows).
+    Dense,
+}
+
+impl TakeKind {
+    fn name(self) -> &'static str {
+        match self {
+            TakeKind::Shuffle => "shuffle",
+            TakeKind::Selective => "selective",
+            TakeKind::Dense => "dense",
+        }
+    }
+}
+
+fn compaction_name(strategy: FsstViewCompaction) -> &'static str {
+    match strategy {
+        FsstViewCompaction::Auto => "auto",
+        FsstViewCompaction::Direct => "direct",
+        FsstViewCompaction::GatherBulk => "gather_bulk",
+        FsstViewCompaction::PerElement => "per_element",
+    }
+}
+
+fn make_indices(len: usize, kind: TakeKind) -> ArrayRef {
+    let mut rng = StdRng::seed_from_u64(11);
+    let indices: Vec<u64> = match kind {
+        TakeKind::Shuffle => {
+            let mut v: Vec<u64> = (0..len as u64).collect();
+            // Fisher-Yates.
+            for i in (1..v.len()).rev() {
+                v.swap(i, rng.random_range(0..=i));
+            }
+            v
+        }
+        TakeKind::Selective => (0..(len / 20).max(1))
+            .map(|_| rng.random_range(0..len as u64))
+            .collect(),
+        TakeKind::Dense => (0..(len * 3 / 2))
+            .map(|_| rng.random_range(0..len as u64))
+            .collect(),
+    };
+    PrimitiveArray::from_iter(indices).into_array()
+}
+
+// ----- direct kernel wrappers (no Vortex dispatch) ---------------------------------------------
+
+fn fsst_filter(array: &FSSTArray, mask: &Mask, ctx: &mut ExecutionCtx) -> FSSTArray {
+    <FSST as FilterKernel>::filter(array.as_view(), mask, ctx)
+        .unwrap()
+        .unwrap()
+        .try_downcast::<FSST>()
+        .ok()
+        .unwrap()
+}
+
+fn fsst_take(array: &FSSTArray, indices: &ArrayRef, ctx: &mut ExecutionCtx) -> FSSTArray {
+    <FSST as TakeExecute>::take(array.as_view(), indices, ctx)
+        .unwrap()
+        .unwrap()
+        .try_downcast::<FSST>()
+        .ok()
+        .unwrap()
+}
+
+fn view_filter(array: &FSSTArray, mask: &Mask, ctx: &mut ExecutionCtx) -> ArrayRef {
+    let view = fsstview_from_fsst(array, ctx).unwrap();
+    <FSSTView as FilterKernel>::filter(view.as_view(), mask, ctx)
+        .unwrap()
+        .unwrap()
+}
+
+fn view_take(array: &FSSTArray, indices: &ArrayRef, ctx: &mut ExecutionCtx) -> ArrayRef {
+    let view = fsstview_from_fsst(array, ctx).unwrap();
+    <FSSTView as TakeExecute>::take(view.as_view(), indices, ctx)
+        .unwrap()
+        .unwrap()
+}
+
+fn fsst_to_canonical(array: &FSSTArray, ctx: &mut ExecutionCtx) -> ArrayRef {
+    // Decompress straight to a VarBinView via the VarBin codes (the FSST canonical path).
+    array
+        .clone()
+        .into_array()
+        .execute::<VarBinViewArray>(ctx)
+        .unwrap()
+        .into_array()
+}
+
+const SHAPES: &[Shape] = &[Shape::ManyShort, Shape::FewLong];
+
+// =============================== FILTER ========================================================
+
+/// Filter masks to exercise: selective (~10% kept) and non-selective (~90% kept).
+const FILTER_KEEP: &[(&str, f64)] = &[("selective_10pct", 0.10), ("nonselective_90pct", 0.90)];
+
+#[divan::bench(args = filter_args())]
+fn filter_step_fsst(bencher: Bencher, args: FilterArg) {
+    let varbin = generate(args.shape);
+    let fsst = compress(&varbin, &mut LEGACY_SESSION.create_execution_ctx());
+    let mask = make_mask(fsst.len(), args.keep);
+    bencher
+        .with_inputs(|| (&fsst, &mask, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(fsst, mask, ctx)| black_box(fsst_filter(fsst, mask, ctx)));
+}
+
+#[divan::bench(args = filter_args())]
+fn filter_step_view(bencher: Bencher, args: FilterArg) {
+    let varbin = generate(args.shape);
+    let fsst = compress(&varbin, &mut LEGACY_SESSION.create_execution_ctx());
+    let mask = make_mask(fsst.len(), args.keep);
+    bencher
+        .with_inputs(|| (&fsst, &mask, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(fsst, mask, ctx)| black_box(view_filter(fsst, mask, ctx)));
+}
+
+/// Full pipeline: filter (compacting into another FSSTArray) then canonicalize to VarBinView.
+#[divan::bench(args = filter_args())]
+fn filter_pipeline_fsst(bencher: Bencher, args: FilterArg) {
+    let varbin = generate(args.shape);
+    let fsst = compress(&varbin, &mut LEGACY_SESSION.create_execution_ctx());
+    let mask = make_mask(fsst.len(), args.keep);
+    bencher
+        .with_inputs(|| (&fsst, &mask, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(fsst, mask, ctx)| {
+            let filtered = fsst_filter(fsst, mask, ctx);
+            black_box(fsst_to_canonical(&filtered, ctx))
+        });
+}
+
+/// Full pipeline: filter to FSSTView then canonicalize, once per compaction strategy.
+#[divan::bench(args = filter_view_pipeline_args())]
+fn filter_pipeline_view(bencher: Bencher, args: FilterViewArg) {
+    let varbin = generate(args.shape);
+    let fsst = compress(&varbin, &mut LEGACY_SESSION.create_execution_ctx());
+    let mask = make_mask(fsst.len(), args.keep);
+    bencher
+        .with_inputs(|| (&fsst, &mask, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(fsst, mask, ctx)| {
+            let view = view_filter(fsst, mask, ctx)
+                .try_downcast::<FSSTView>()
+                .ok()
+                .unwrap();
+            black_box(canonicalize_fsstview_with(view.as_view(), args.strategy, ctx).unwrap())
+        });
+}
+
+// =============================== TAKE ==========================================================
+
+const TAKE_KINDS: &[TakeKind] = &[TakeKind::Shuffle, TakeKind::Selective, TakeKind::Dense];
+
+#[divan::bench(args = take_args())]
+fn take_step_fsst(bencher: Bencher, args: TakeArg) {
+    let varbin = generate(args.shape);
+    let fsst = compress(&varbin, &mut LEGACY_SESSION.create_execution_ctx());
+    let indices = make_indices(fsst.len(), args.kind);
+    bencher
+        .with_inputs(|| (&fsst, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(fsst, indices, ctx)| black_box(fsst_take(fsst, indices, ctx)));
+}
+
+#[divan::bench(args = take_args())]
+fn take_step_view(bencher: Bencher, args: TakeArg) {
+    let varbin = generate(args.shape);
+    let fsst = compress(&varbin, &mut LEGACY_SESSION.create_execution_ctx());
+    let indices = make_indices(fsst.len(), args.kind);
+    bencher
+        .with_inputs(|| (&fsst, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(fsst, indices, ctx)| black_box(view_take(fsst, indices, ctx)));
+}
+
+#[divan::bench(args = take_args())]
+fn take_pipeline_fsst(bencher: Bencher, args: TakeArg) {
+    let varbin = generate(args.shape);
+    let fsst = compress(&varbin, &mut LEGACY_SESSION.create_execution_ctx());
+    let indices = make_indices(fsst.len(), args.kind);
+    bencher
+        .with_inputs(|| (&fsst, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(fsst, indices, ctx)| {
+            let taken = fsst_take(fsst, indices, ctx);
+            black_box(fsst_to_canonical(&taken, ctx))
+        });
+}
+
+#[divan::bench(args = take_view_pipeline_args())]
+fn take_pipeline_view(bencher: Bencher, args: TakeViewArg) {
+    let varbin = generate(args.shape);
+    let fsst = compress(&varbin, &mut LEGACY_SESSION.create_execution_ctx());
+    let indices = make_indices(fsst.len(), args.kind);
+    bencher
+        .with_inputs(|| (&fsst, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(fsst, indices, ctx)| {
+            let view = view_take(fsst, indices, ctx)
+                .try_downcast::<FSSTView>()
+                .ok()
+                .unwrap();
+            black_box(canonicalize_fsstview_with(view.as_view(), args.strategy, ctx).unwrap())
+        });
+}
+
+// =============================== COMBINATION ===================================================
+
+/// A filter (selective) followed by a take (shuffle) — the realistic "scan then reorder" shape.
+/// fsst path compacts twice; fsstview path stays metadata-only until the final canonicalize.
+#[divan::bench(args = SHAPES)]
+fn combo_pipeline_fsst(bencher: Bencher, shape: Shape) {
+    let varbin = generate(shape);
+    let fsst = compress(&varbin, &mut LEGACY_SESSION.create_execution_ctx());
+    let mask = make_mask(fsst.len(), 0.10);
+    bencher
+        .with_inputs(|| (&fsst, &mask, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(fsst, mask, ctx)| {
+            let filtered = fsst_filter(fsst, mask, ctx);
+            let indices = make_indices(filtered.len(), TakeKind::Shuffle);
+            let taken = fsst_take(&filtered, &indices, ctx);
+            black_box(fsst_to_canonical(&taken, ctx))
+        });
+}
+
+#[divan::bench(args = SHAPES)]
+fn combo_pipeline_view(bencher: Bencher, shape: Shape) {
+    let varbin = generate(shape);
+    let fsst = compress(&varbin, &mut LEGACY_SESSION.create_execution_ctx());
+    let mask = make_mask(fsst.len(), 0.10);
+    bencher
+        .with_inputs(|| (&fsst, &mask, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(fsst, mask, ctx)| {
+            // filter -> view, then take on the view (both metadata-only), then canonicalize.
+            let filtered = view_filter(fsst, mask, ctx)
+                .try_downcast::<FSSTView>()
+                .ok()
+                .unwrap();
+            let indices = make_indices(filtered.len(), TakeKind::Shuffle);
+            let taken = <FSSTView as TakeExecute>::take(filtered.as_view(), &indices, ctx)
+                .unwrap()
+                .unwrap()
+                .try_downcast::<FSSTView>()
+                .ok()
+                .unwrap();
+            black_box(
+                canonicalize_fsstview_with(taken.as_view(), FsstViewCompaction::Auto, ctx).unwrap(),
+            )
+        });
+}
+
+// =============================== arg plumbing ==================================================
+
+#[derive(Clone, Copy)]
+struct FilterArg {
+    shape: Shape,
+    keep: f64,
+    label: &'static str,
+}
+
+impl std::fmt::Display for FilterArg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.shape.name(), self.label)
+    }
+}
+
+fn filter_args() -> Vec<FilterArg> {
+    let mut v = Vec::new();
+    for &shape in SHAPES {
+        for &(label, keep) in FILTER_KEEP {
+            v.push(FilterArg { shape, keep, label });
+        }
+    }
+    v
+}
+
+#[derive(Clone, Copy)]
+struct FilterViewArg {
+    shape: Shape,
+    keep: f64,
+    label: &'static str,
+    strategy: FsstViewCompaction,
+}
+
+impl std::fmt::Display for FilterViewArg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}/{}/{}",
+            self.shape.name(),
+            self.label,
+            compaction_name(self.strategy)
+        )
+    }
+}
+
+fn filter_view_pipeline_args() -> Vec<FilterViewArg> {
+    let mut v = Vec::new();
+    for &shape in SHAPES {
+        for &(label, keep) in FILTER_KEEP {
+            for &strategy in COMPACTIONS {
+                v.push(FilterViewArg {
+                    shape,
+                    keep,
+                    label,
+                    strategy,
+                });
+            }
+        }
+    }
+    v
+}
+
+#[derive(Clone, Copy)]
+struct TakeArg {
+    shape: Shape,
+    kind: TakeKind,
+}
+
+impl std::fmt::Display for TakeArg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.shape.name(), self.kind.name())
+    }
+}
+
+fn take_args() -> Vec<TakeArg> {
+    let mut v = Vec::new();
+    for &shape in SHAPES {
+        for &kind in TAKE_KINDS {
+            v.push(TakeArg { shape, kind });
+        }
+    }
+    v
+}
+
+#[derive(Clone, Copy)]
+struct TakeViewArg {
+    shape: Shape,
+    kind: TakeKind,
+    strategy: FsstViewCompaction,
+}
+
+impl std::fmt::Display for TakeViewArg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}/{}/{}",
+            self.shape.name(),
+            self.kind.name(),
+            compaction_name(self.strategy)
+        )
+    }
+}
+
+const COMPACTIONS: &[FsstViewCompaction] = &[
+    FsstViewCompaction::Auto,
+    FsstViewCompaction::GatherBulk,
+    FsstViewCompaction::PerElement,
+];
+
+fn take_view_pipeline_args() -> Vec<TakeViewArg> {
+    let mut v = Vec::new();
+    for &shape in SHAPES {
+        for &kind in TAKE_KINDS {
+            for &strategy in COMPACTIONS {
+                v.push(TakeViewArg {
+                    shape,
+                    kind,
+                    strategy,
+                });
+            }
+        }
+    }
+    v
+}

--- a/encodings/fsst/benches/fsst_view_compute.rs
+++ b/encodings/fsst/benches/fsst_view_compute.rs
@@ -379,6 +379,69 @@ fn combo_pipeline_view(bencher: Bencher, shape: Shape) {
         });
 }
 
+// =============================== CHAIN =========================================================
+
+/// Number of ops in the chain benchmark.
+const CHAIN_LEN: usize = 5;
+
+/// A chain of `CHAIN_LEN` alternating filter/take ops ending in a canonicalization.
+///
+/// This is where the view model is meant to dominate: each fsst op re-compacts the byte heap,
+/// so the cost compounds with chain length, whereas the view converts to offsets+sizes *once*
+/// and every subsequent op is metadata-only, deferring the single gather+decode to the final
+/// canonicalize. We keep every op only mildly selective (filter keeps 80%, take is a shuffle)
+/// so there's still substantial data at the end — i.e. the heap rewrites the fsst path pays are
+/// real work, not optimized away to nothing.
+#[divan::bench(args = SHAPES)]
+fn chain_pipeline_fsst(bencher: Bencher, shape: Shape) {
+    let varbin = generate(shape);
+    let fsst = compress(&varbin, &mut LEGACY_SESSION.create_execution_ctx());
+    bencher
+        .with_inputs(|| (&fsst, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(fsst, ctx)| {
+            let mut cur = (*fsst).clone();
+            for op in 0..CHAIN_LEN {
+                if op % 2 == 0 {
+                    let mask = make_mask(cur.len(), 0.80);
+                    cur = fsst_filter(&cur, &mask, ctx);
+                } else {
+                    let indices = make_indices(cur.len(), TakeKind::Shuffle);
+                    cur = fsst_take(&cur, &indices, ctx);
+                }
+            }
+            black_box(fsst_to_canonical(&cur, ctx))
+        });
+}
+
+#[divan::bench(args = SHAPES)]
+fn chain_pipeline_view(bencher: Bencher, shape: Shape) {
+    let varbin = generate(shape);
+    let fsst = compress(&varbin, &mut LEGACY_SESSION.create_execution_ctx());
+    bencher
+        .with_inputs(|| (&fsst, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(fsst, ctx)| {
+            // Convert to the view once, then chain metadata-only ops, canonicalize once at the end.
+            let mut cur = fsstview_from_fsst(fsst, ctx).unwrap();
+            for op in 0..CHAIN_LEN {
+                let next = if op % 2 == 0 {
+                    let mask = make_mask(cur.len(), 0.80);
+                    <FSSTView as FilterKernel>::filter(cur.as_view(), &mask, ctx)
+                        .unwrap()
+                        .unwrap()
+                } else {
+                    let indices = make_indices(cur.len(), TakeKind::Shuffle);
+                    <FSSTView as TakeExecute>::take(cur.as_view(), &indices, ctx)
+                        .unwrap()
+                        .unwrap()
+                };
+                cur = next.try_downcast::<FSSTView>().ok().unwrap();
+            }
+            black_box(
+                canonicalize_fsstview_with(cur.as_view(), FsstViewCompaction::Auto, ctx).unwrap(),
+            )
+        });
+}
+
 // =============================== arg plumbing ==================================================
 
 #[derive(Clone, Copy)]

--- a/encodings/fsst/benches/fsst_view_compute.rs
+++ b/encodings/fsst/benches/fsst_view_compute.rs
@@ -251,6 +251,24 @@ fn filter_step_view(bencher: Bencher, args: FilterArg) {
         .bench_refs(|(fsst, mask, ctx)| black_box(view_filter(fsst, mask, ctx)));
 }
 
+/// Metadata-only filter measured in isolation (conversion hoisted out). See `take_op_only_view`.
+#[divan::bench(args = filter_args())]
+fn filter_op_only_view(bencher: Bencher, args: FilterArg) {
+    let varbin = generate(args.shape);
+    let fsst = compress(&varbin, &mut LEGACY_SESSION.create_execution_ctx());
+    let view = fsstview_from_fsst(&fsst, &mut LEGACY_SESSION.create_execution_ctx()).unwrap();
+    let mask = make_mask(view.len(), args.keep);
+    bencher
+        .with_inputs(|| (&view, &mask, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(view, mask, ctx)| {
+            black_box(
+                <FSSTView as FilterKernel>::filter(view.as_view(), mask, ctx)
+                    .unwrap()
+                    .unwrap(),
+            )
+        });
+}
+
 /// Full pipeline: filter (compacting into another FSSTArray) then canonicalize to VarBinView.
 #[divan::bench(args = filter_args())]
 fn filter_pipeline_fsst(bencher: Bencher, args: FilterArg) {
@@ -304,6 +322,27 @@ fn take_step_view(bencher: Bencher, args: TakeArg) {
     bencher
         .with_inputs(|| (&fsst, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(fsst, indices, ctx)| black_box(view_take(fsst, indices, ctx)));
+}
+
+/// The metadata-only take measured *in isolation*: the FSST→view conversion is hoisted out of the
+/// timed loop (a chain converts once), so this is the apples-to-apples "is the view op itself as
+/// cheap as a ListView op" comparison. The `*_step_view` bench above instead folds the one-time
+/// conversion into every op, which only the first op of a chain actually pays.
+#[divan::bench(args = take_args())]
+fn take_op_only_view(bencher: Bencher, args: TakeArg) {
+    let varbin = generate(args.shape);
+    let fsst = compress(&varbin, &mut LEGACY_SESSION.create_execution_ctx());
+    let view = fsstview_from_fsst(&fsst, &mut LEGACY_SESSION.create_execution_ctx()).unwrap();
+    let indices = make_indices(view.len(), args.kind);
+    bencher
+        .with_inputs(|| (&view, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(view, indices, ctx)| {
+            black_box(
+                <FSSTView as TakeExecute>::take(view.as_view(), indices, ctx)
+                    .unwrap()
+                    .unwrap(),
+            )
+        });
 }
 
 #[divan::bench(args = take_args())]

--- a/encodings/fsst/benches/fsst_view_compute.rs
+++ b/encodings/fsst/benches/fsst_view_compute.rs
@@ -17,9 +17,13 @@
 //! trade-off is visible directly.
 //!
 //! Two ~2 MiB (uncompressed) inputs are used: one with **many short** strings and one with
-//! **fewer long** strings. The expectation: the fsstview hop is far cheaper in both cases (no
-//! heap rewrite); for the final canonicalization, `GatherBulk` (compact) wins on the short-string
-//! input while `PerElement` (no compact) wins on the long-string input.
+//! **fewer long** strings.
+//!
+//! Observed (medians): the fsstview hop is far cheaper in both cases (no heap rewrite) — e.g.
+//! `take many_short/shuffle` is ~650 µs vs ~2.84 ms for fsst. For the final canonicalization,
+//! `GatherBulk` (compact) beats `PerElement` (no compact) across the whole range, short *and*
+//! long strings, because it pays FSST's slow decode-tail once instead of once per element; that's
+//! why `Auto` compacts whenever the codes aren't contiguous.
 
 #![expect(clippy::unwrap_used)]
 

--- a/encodings/fsst/src/fsstview/array.rs
+++ b/encodings/fsst/src/fsstview/array.rs
@@ -29,6 +29,7 @@ use vortex_array::vtable::ValidityVTable;
 use vortex_array::vtable::child_to_validity;
 use vortex_array::vtable::validity_to_child;
 use vortex_buffer::Buffer;
+use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
@@ -178,25 +179,25 @@ impl FSSTView {
 
 /// Convert a plain [`FSSTArray`] into an [`FSSTViewArray`], sharing the symbol table and the
 /// compressed byte heap (zero-copy) and deriving `sizes[i] = offsets[i + 1] - offsets[i]`.
+///
+/// The `offsets` (length `len + 1`) are reused for the view's `codes_offsets` by a zero-copy
+/// slice of their first `len` elements; only the `sizes` array is freshly allocated.
 pub fn fsstview_from_fsst(fsst: &FSSTArray, ctx: &mut ExecutionCtx) -> VortexResult<FSSTViewArray> {
     let codes = fsst.codes();
     let validity = codes.validity()?;
     let offsets = codes.offsets().clone().execute::<PrimitiveArray>(ctx)?;
+    let len = offsets.len().saturating_sub(1);
 
-    let (codes_offsets, codes_sizes) = match_each_integer_ptype!(offsets.ptype(), |O| {
+    let codes_sizes = match_each_integer_ptype!(offsets.ptype(), |O| {
         let offsets = offsets.as_slice::<O>();
-        let len = offsets.len().saturating_sub(1);
-        let mut starts = Vec::with_capacity(len);
-        let mut sizes = Vec::with_capacity(len);
+        let mut sizes = BufferMut::<O>::with_capacity(len);
         for i in 0..len {
-            starts.push(offsets[i]);
             sizes.push(offsets[i + 1] - offsets[i]);
         }
-        (
-            PrimitiveArray::from_iter(starts).into_array(),
-            PrimitiveArray::from_iter(sizes).into_array(),
-        )
+        sizes.into_array()
     });
+    // `codes_offsets` is the first `len` offsets — a zero-copy slice of the existing buffer.
+    let codes_offsets = offsets.into_array().slice(0..len)?;
 
     FSSTView::try_new(
         fsst.dtype().clone(),

--- a/encodings/fsst/src/fsstview/array.rs
+++ b/encodings/fsst/src/fsstview/array.rs
@@ -1,0 +1,459 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use fsst::Symbol;
+use prost::Message as _;
+use vortex_array::Array;
+use vortex_array::ArrayId;
+use vortex_array::ArrayParts;
+use vortex_array::ArrayRef;
+use vortex_array::ArraySlots;
+use vortex_array::ArrayView;
+use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionResult;
+use vortex_array::IntoArray;
+use vortex_array::TypedArrayRef;
+use vortex_array::array_slots;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::varbin::VarBinArrayExt;
+use vortex_array::buffer::BufferHandle;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::Nullability;
+use vortex_array::dtype::PType;
+use vortex_array::match_each_integer_ptype;
+use vortex_array::serde::ArrayChildren;
+use vortex_array::smallvec::smallvec;
+use vortex_array::validity::Validity;
+use vortex_array::vtable::VTable;
+use vortex_array::vtable::ValidityVTable;
+use vortex_array::vtable::child_to_validity;
+use vortex_array::vtable::validity_to_child;
+use vortex_buffer::Buffer;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_ensure;
+use vortex_error::vortex_err;
+use vortex_error::vortex_panic;
+use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
+
+use crate::FSSTArray;
+use crate::FSSTArrayExt;
+// `FSSTView` reuses the exact same inner data representation as `FSST`: the symbol table plus
+// the raw compressed byte heap. Only the *addressing* of that heap differs (offsets + sizes
+// instead of monotonic offsets), and that addressing lives entirely in the array's slots.
+use crate::array::FSSTData;
+use crate::fsstview::canonical::canonicalize_fsstview;
+use crate::fsstview::kernel::PARENT_KERNELS;
+use crate::fsstview::rules::RULES;
+
+/// An [`FSSTView`]-encoded Vortex array.
+pub type FSSTViewArray = Array<FSSTView>;
+
+/// The [`FSSTView`] encoding: a ListView-style FSST array.
+#[derive(Clone, Debug)]
+pub struct FSSTView;
+
+/// The child slots of an [`FSSTView`] array.
+///
+/// Declared with the [`array_slots`] proc macro, which generates the slot-index constants
+/// (`FSSTViewSlots::CODES_OFFSETS`, ...), the borrowed [`FSSTViewSlotsView`] struct, and the
+/// typed accessor trait [`FSSTViewArraySlotsExt`] (`.uncompressed_lengths()`,
+/// `.codes_offsets()`, `.codes_sizes()`, `.codes_validity()`).
+#[array_slots(FSSTView)]
+pub struct FSSTViewSlots {
+    /// Length of each original (uncompressed) value. Non-nullable integer.
+    pub uncompressed_lengths: ArrayRef,
+    /// Start offset of each element's compressed bytecodes within the code heap. Non-nullable
+    /// integer. Unlike `FSST`, these are **not** required to be monotonic or contiguous.
+    pub codes_offsets: ArrayRef,
+    /// Length in bytes of each element's compressed bytecodes within the code heap. Non-nullable
+    /// integer.
+    pub codes_sizes: ArrayRef,
+    /// Optional validity bitmap for the codes. Absent when the array is non-nullable.
+    pub codes_validity: Option<ArrayRef>,
+}
+
+#[derive(Clone, prost::Message)]
+pub struct FSSTViewMetadata {
+    #[prost(enumeration = "PType", tag = "1")]
+    uncompressed_lengths_ptype: i32,
+    #[prost(enumeration = "PType", tag = "2")]
+    codes_offsets_ptype: i32,
+    #[prost(enumeration = "PType", tag = "3")]
+    codes_sizes_ptype: i32,
+}
+
+impl FSSTViewMetadata {
+    fn get_uncompressed_lengths_ptype(&self) -> VortexResult<PType> {
+        PType::try_from(self.uncompressed_lengths_ptype)
+            .map_err(|_| vortex_err!("Invalid PType {}", self.uncompressed_lengths_ptype))
+    }
+
+    fn get_codes_offsets_ptype(&self) -> VortexResult<PType> {
+        PType::try_from(self.codes_offsets_ptype)
+            .map_err(|_| vortex_err!("Invalid PType {}", self.codes_offsets_ptype))
+    }
+
+    fn get_codes_sizes_ptype(&self) -> VortexResult<PType> {
+        PType::try_from(self.codes_sizes_ptype)
+            .map_err(|_| vortex_err!("Invalid PType {}", self.codes_sizes_ptype))
+    }
+}
+
+impl FSSTView {
+    /// Build an [`FSSTViewArray`] from its decomposed components.
+    ///
+    /// `codes_offsets[i]` and `codes_sizes[i]` address element `i`'s compressed bytecodes inside
+    /// `codes_bytes`. The offsets do not need to be sorted, contiguous, or non-overlapping.
+    #[allow(clippy::too_many_arguments)]
+    pub fn try_new(
+        dtype: DType,
+        symbols: Buffer<Symbol>,
+        symbol_lengths: Buffer<u8>,
+        codes_bytes: BufferHandle,
+        codes_offsets: ArrayRef,
+        codes_sizes: ArrayRef,
+        uncompressed_lengths: ArrayRef,
+        validity: Validity,
+    ) -> VortexResult<FSSTViewArray> {
+        let len = codes_offsets.len();
+        validate_fsstview(
+            &symbols,
+            &symbol_lengths,
+            &codes_offsets,
+            &codes_sizes,
+            &uncompressed_lengths,
+            &validity,
+            &dtype,
+            len,
+        )?;
+        let data = FSSTData::try_new(symbols, symbol_lengths, codes_bytes, len)?;
+        let slots = make_slots(
+            uncompressed_lengths,
+            codes_offsets,
+            codes_sizes,
+            &validity,
+            len,
+        );
+        Ok(unsafe {
+            Array::from_parts_unchecked(
+                ArrayParts::new(FSSTView, dtype, len, data).with_slots(slots),
+            )
+        })
+    }
+
+    /// Build an [`FSSTViewArray`] without validation.
+    ///
+    /// # Safety
+    ///
+    /// The caller must uphold the same invariants validated by [`FSSTView::try_new`].
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) unsafe fn new_unchecked(
+        dtype: DType,
+        symbols: Buffer<Symbol>,
+        symbol_lengths: Buffer<u8>,
+        codes_bytes: BufferHandle,
+        codes_offsets: ArrayRef,
+        codes_sizes: ArrayRef,
+        uncompressed_lengths: ArrayRef,
+        validity: Validity,
+    ) -> FSSTViewArray {
+        let len = codes_offsets.len();
+        let data = unsafe { FSSTData::new_unchecked(symbols, symbol_lengths, codes_bytes, len) };
+        let slots = make_slots(
+            uncompressed_lengths,
+            codes_offsets,
+            codes_sizes,
+            &validity,
+            len,
+        );
+        unsafe {
+            Array::from_parts_unchecked(
+                ArrayParts::new(FSSTView, dtype, len, data).with_slots(slots),
+            )
+        }
+    }
+}
+
+/// Convert a plain [`FSSTArray`] into an [`FSSTViewArray`], sharing the symbol table and the
+/// compressed byte heap (zero-copy) and deriving `sizes[i] = offsets[i + 1] - offsets[i]`.
+pub fn fsstview_from_fsst(fsst: &FSSTArray, ctx: &mut ExecutionCtx) -> VortexResult<FSSTViewArray> {
+    let codes = fsst.codes();
+    let validity = codes.validity()?;
+    let offsets = codes.offsets().clone().execute::<PrimitiveArray>(ctx)?;
+
+    let (codes_offsets, codes_sizes) = match_each_integer_ptype!(offsets.ptype(), |O| {
+        let offsets = offsets.as_slice::<O>();
+        let len = offsets.len().saturating_sub(1);
+        let mut starts = Vec::with_capacity(len);
+        let mut sizes = Vec::with_capacity(len);
+        for i in 0..len {
+            starts.push(offsets[i]);
+            sizes.push(offsets[i + 1] - offsets[i]);
+        }
+        (
+            PrimitiveArray::from_iter(starts).into_array(),
+            PrimitiveArray::from_iter(sizes).into_array(),
+        )
+    });
+
+    FSSTView::try_new(
+        fsst.dtype().clone(),
+        fsst.symbols().clone(),
+        fsst.symbol_lengths().clone(),
+        fsst.codes_bytes_handle().clone(),
+        codes_offsets,
+        codes_sizes,
+        fsst.uncompressed_lengths().clone(),
+        validity,
+    )
+}
+
+fn make_slots(
+    uncompressed_lengths: ArrayRef,
+    codes_offsets: ArrayRef,
+    codes_sizes: ArrayRef,
+    validity: &Validity,
+    len: usize,
+) -> ArraySlots {
+    smallvec![
+        Some(uncompressed_lengths),
+        Some(codes_offsets),
+        Some(codes_sizes),
+        validity_to_child(validity, len),
+    ]
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_fsstview(
+    symbols: &Buffer<Symbol>,
+    symbol_lengths: &Buffer<u8>,
+    codes_offsets: &ArrayRef,
+    codes_sizes: &ArrayRef,
+    uncompressed_lengths: &ArrayRef,
+    validity: &Validity,
+    dtype: &DType,
+    len: usize,
+) -> VortexResult<()> {
+    vortex_ensure!(
+        matches!(dtype, DType::Binary(_) | DType::Utf8(_)),
+        "FSSTView arrays must be Binary or Utf8, found {dtype}"
+    );
+    if symbols.len() > 255 {
+        vortex_bail!(InvalidArgument: "symbols array must have length <= 255");
+    }
+    if symbols.len() != symbol_lengths.len() {
+        vortex_bail!(InvalidArgument: "symbols and symbol_lengths arrays must have same length");
+    }
+    if codes_offsets.len() != len {
+        vortex_bail!(InvalidArgument: "codes_offsets must have same len as outer array");
+    }
+    if codes_sizes.len() != len {
+        vortex_bail!(InvalidArgument: "codes_sizes must have same len as outer array");
+    }
+    if uncompressed_lengths.len() != len {
+        vortex_bail!(InvalidArgument: "uncompressed_lengths must have same len as outer array");
+    }
+    if !codes_offsets.dtype().is_int() || codes_offsets.dtype().is_nullable() {
+        vortex_bail!(InvalidArgument: "codes_offsets must be non-nullable integer, found {}", codes_offsets.dtype());
+    }
+    if !codes_sizes.dtype().is_int() || codes_sizes.dtype().is_nullable() {
+        vortex_bail!(InvalidArgument: "codes_sizes must be non-nullable integer, found {}", codes_sizes.dtype());
+    }
+    if !uncompressed_lengths.dtype().is_int() || uncompressed_lengths.dtype().is_nullable() {
+        vortex_bail!(InvalidArgument: "uncompressed_lengths must be non-nullable integer, found {}", uncompressed_lengths.dtype());
+    }
+    if validity.nullability() != dtype.nullability() {
+        vortex_bail!(InvalidArgument: "validity nullability must match outer dtype nullability");
+    }
+    Ok(())
+}
+
+/// Typed accessors for [`FSSTViewArray`] that aren't covered by the [`array_slots`] macro.
+pub trait FSSTViewArrayExt: TypedArrayRef<FSSTView> {
+    /// The validity of the array, derived from the `codes_validity` slot.
+    fn fsstview_validity(&self) -> Validity {
+        child_to_validity(
+            self.as_ref().slots()[FSSTViewSlots::CODES_VALIDITY].as_ref(),
+            self.as_ref().dtype().nullability(),
+        )
+    }
+}
+
+impl<T: TypedArrayRef<FSSTView>> FSSTViewArrayExt for T {}
+
+impl VTable for FSSTView {
+    type TypedArrayData = FSSTData;
+    type OperationsVTable = Self;
+    type ValidityVTable = Self;
+
+    fn id(&self) -> ArrayId {
+        static ID: CachedId = CachedId::new("vortex.fsstview");
+        *ID
+    }
+
+    fn validate(
+        &self,
+        data: &Self::TypedArrayData,
+        dtype: &DType,
+        len: usize,
+        slots: &[Option<ArrayRef>],
+    ) -> VortexResult<()> {
+        let view = FSSTViewSlotsView::from_slots(slots);
+        let validity = child_to_validity(view.codes_validity, dtype.nullability());
+        validate_fsstview(
+            data.symbols(),
+            data.symbol_lengths(),
+            view.codes_offsets,
+            view.codes_sizes,
+            view.uncompressed_lengths,
+            &validity,
+            dtype,
+            len,
+        )
+    }
+
+    fn nbuffers(_array: ArrayView<'_, Self>) -> usize {
+        3
+    }
+
+    fn buffer(array: ArrayView<'_, Self>, idx: usize) -> BufferHandle {
+        match idx {
+            0 => BufferHandle::new_host(array.symbols().clone().into_byte_buffer()),
+            1 => BufferHandle::new_host(array.symbol_lengths().clone().into_byte_buffer()),
+            2 => array.codes_bytes_handle().clone(),
+            _ => vortex_panic!("FSSTViewArray buffer index {idx} out of bounds"),
+        }
+    }
+
+    fn buffer_name(_array: ArrayView<'_, Self>, idx: usize) -> Option<String> {
+        match idx {
+            0 => Some("symbols".to_string()),
+            1 => Some("symbol_lengths".to_string()),
+            2 => Some("compressed_codes".to_string()),
+            _ => vortex_panic!("FSSTViewArray buffer_name index {idx} out of bounds"),
+        }
+    }
+
+    fn serialize(
+        array: ArrayView<'_, Self>,
+        _session: &VortexSession,
+    ) -> VortexResult<Option<Vec<u8>>> {
+        Ok(Some(
+            FSSTViewMetadata {
+                uncompressed_lengths_ptype: PType::try_from(array.uncompressed_lengths().dtype())?
+                    as i32,
+                codes_offsets_ptype: PType::try_from(array.codes_offsets().dtype())? as i32,
+                codes_sizes_ptype: PType::try_from(array.codes_sizes().dtype())? as i32,
+            }
+            .encode_to_vec(),
+        ))
+    }
+
+    fn deserialize(
+        &self,
+        dtype: &DType,
+        len: usize,
+        metadata: &[u8],
+        buffers: &[BufferHandle],
+        children: &dyn ArrayChildren,
+        _session: &VortexSession,
+    ) -> VortexResult<ArrayParts<Self>> {
+        let metadata = FSSTViewMetadata::decode(metadata)?;
+        if buffers.len() != 3 {
+            vortex_bail!(
+                InvalidArgument: "Expected 3 buffers for fsstview, got {}",
+                buffers.len()
+            );
+        }
+        let symbols = Buffer::<Symbol>::from_byte_buffer(buffers[0].clone().try_to_host_sync()?);
+        let symbol_lengths = Buffer::<u8>::from_byte_buffer(buffers[1].clone().try_to_host_sync()?);
+        let codes_bytes = buffers[2].clone();
+
+        let uncompressed_lengths = children.get(
+            0,
+            &DType::Primitive(
+                metadata.get_uncompressed_lengths_ptype()?,
+                Nullability::NonNullable,
+            ),
+            len,
+        )?;
+        let codes_offsets = children.get(
+            1,
+            &DType::Primitive(
+                metadata.get_codes_offsets_ptype()?,
+                Nullability::NonNullable,
+            ),
+            len,
+        )?;
+        let codes_sizes = children.get(
+            2,
+            &DType::Primitive(metadata.get_codes_sizes_ptype()?, Nullability::NonNullable),
+            len,
+        )?;
+
+        let validity = if children.len() == 3 {
+            Validity::from(dtype.nullability())
+        } else if children.len() == 4 {
+            Validity::Array(children.get(3, &Validity::DTYPE, len)?)
+        } else {
+            vortex_bail!("Expected 3 or 4 children, got {}", children.len());
+        };
+
+        validate_fsstview(
+            &symbols,
+            &symbol_lengths,
+            &codes_offsets,
+            &codes_sizes,
+            &uncompressed_lengths,
+            &validity,
+            dtype,
+            len,
+        )?;
+
+        let data = FSSTData::try_new(symbols, symbol_lengths, codes_bytes, len)?;
+        let slots = make_slots(
+            uncompressed_lengths,
+            codes_offsets,
+            codes_sizes,
+            &validity,
+            len,
+        );
+        Ok(ArrayParts::new(self.clone(), dtype.clone(), len, data).with_slots(slots))
+    }
+
+    fn slot_name(_array: ArrayView<'_, Self>, idx: usize) -> String {
+        FSSTViewSlots::NAMES[idx].to_string()
+    }
+
+    fn execute(array: Array<Self>, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionResult> {
+        canonicalize_fsstview(array.as_view(), ctx).map(ExecutionResult::done)
+    }
+
+    fn execute_parent(
+        array: ArrayView<'_, Self>,
+        parent: &ArrayRef,
+        child_idx: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        PARENT_KERNELS.execute(array, parent, child_idx, ctx)
+    }
+
+    fn reduce_parent(
+        array: ArrayView<'_, Self>,
+        parent: &ArrayRef,
+        child_idx: usize,
+    ) -> VortexResult<Option<ArrayRef>> {
+        RULES.evaluate(array, parent, child_idx)
+    }
+}
+
+impl ValidityVTable<FSSTView> for FSSTView {
+    fn validity(array: ArrayView<'_, FSSTView>) -> VortexResult<Validity> {
+        Ok(child_to_validity(
+            array.slots()[FSSTViewSlots::CODES_VALIDITY].as_ref(),
+            array.dtype().nullability(),
+        ))
+    }
+}

--- a/encodings/fsst/src/fsstview/canonical.rs
+++ b/encodings/fsst/src/fsstview/canonical.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::sync::Arc;
+
+use vortex_array::ArrayRef;
+use vortex_array::ArrayView;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::VarBinViewArray;
+use vortex_array::arrays::varbinview::build_views::MAX_BUFFER_LEN;
+use vortex_array::arrays::varbinview::build_views::build_views;
+use vortex_array::match_each_integer_ptype;
+use vortex_buffer::ByteBufferMut;
+use vortex_error::VortexResult;
+
+use super::array::FSSTView;
+use super::array::FSSTViewArrayExt;
+use super::array::FSSTViewArraySlotsExt;
+
+/// Canonicalize an [`FSSTView`] array into a [`VarBinViewArray`].
+///
+/// Because `filter`/`take`/`slice` leave the compressed byte heap untouched, the live codes of
+/// element `i` are the (possibly out-of-order, possibly overlapping) slice
+/// `codes_bytes[offset_i .. offset_i + size_i]`. We first gather them into element order, then
+/// bulk-decompress in a single pass and build the binary views from the uncompressed lengths.
+pub(super) fn canonicalize_fsstview(
+    array: ArrayView<'_, FSSTView>,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let len = array.len();
+    let bytes = array.codes_bytes();
+
+    let offsets = array
+        .codes_offsets()
+        .clone()
+        .execute::<PrimitiveArray>(ctx)?;
+    let sizes = array.codes_sizes().clone().execute::<PrimitiveArray>(ctx)?;
+    let uncompressed_lengths = array
+        .uncompressed_lengths()
+        .clone()
+        .execute::<PrimitiveArray>(ctx)?;
+
+    #[expect(clippy::cast_possible_truncation)]
+    let offsets: Vec<usize> = match_each_integer_ptype!(offsets.ptype(), |O| {
+        offsets
+            .as_slice::<O>()
+            .iter()
+            .map(|o| *o as usize)
+            .collect()
+    });
+    #[expect(clippy::cast_possible_truncation)]
+    let sizes: Vec<usize> = match_each_integer_ptype!(sizes.ptype(), |S| {
+        sizes.as_slice::<S>().iter().map(|s| *s as usize).collect()
+    });
+
+    // Gather the live compressed bytes into element order.
+    let total_compressed: usize = sizes.iter().sum();
+    let mut compressed = ByteBufferMut::with_capacity(total_compressed);
+    for i in 0..len {
+        compressed.extend_from_slice(&bytes[offsets[i]..offsets[i] + sizes[i]]);
+    }
+
+    #[expect(clippy::cast_possible_truncation)]
+    let total_size: usize = match_each_integer_ptype!(uncompressed_lengths.ptype(), |P| {
+        uncompressed_lengths
+            .as_slice::<P>()
+            .iter()
+            .map(|x| *x as usize)
+            .sum()
+    });
+
+    // Bulk-decompress the gathered heap. We reserve 7 extra bytes because the FSST decoder may
+    // overrun the output by up to a word.
+    let decompressor = array.decompressor();
+    let mut uncompressed_bytes = ByteBufferMut::with_capacity(total_size + 7);
+    let written = decompressor.decompress_into(
+        compressed.as_slice(),
+        uncompressed_bytes.spare_capacity_mut(),
+    );
+    unsafe { uncompressed_bytes.set_len(written) };
+
+    let (buffers, views) = match_each_integer_ptype!(uncompressed_lengths.ptype(), |P| {
+        build_views(
+            0,
+            MAX_BUFFER_LEN,
+            uncompressed_bytes,
+            uncompressed_lengths.as_slice::<P>(),
+        )
+    });
+
+    // SAFETY: FSST validates the bytes for binary/UTF-8; the views point at valid ranges.
+    Ok(unsafe {
+        VarBinViewArray::new_unchecked(
+            views,
+            Arc::from(buffers),
+            array.dtype().clone(),
+            array.fsstview_validity(),
+        )
+        .into_array()
+    })
+}

--- a/encodings/fsst/src/fsstview/canonical.rs
+++ b/encodings/fsst/src/fsstview/canonical.rs
@@ -17,21 +17,29 @@
 //!   element boundaries.
 //! - [`PerElement`][FsstViewCompaction::PerElement] ("no compact"): decompress each element's
 //!   slice directly into its place in the output. No copy, but one decompress call per element.
+//! - [`RunCoalesce`][FsstViewCompaction::RunCoalesce] ("export paired slices"): decode contiguous
+//!   heap runs straight into a *heap-ordered* output and point `VarBinView`s back into it, out of
+//!   order — no gather copy, dedups duplicates.
 //!
 //! The compaction question, concretely. The `fsst_view_compute` benchmark (two ~2 MiB inputs,
-//! ~12-byte and ~256-byte strings) shows **`GatherBulk` beats `PerElement` across the whole
-//! tested range, for both short and long strings**. The reason: FSST's decoder has a fast 8-wide
-//! body and a slow byte-by-byte tail. `PerElement` pays that tail *once per element* (N tails),
-//! while `GatherBulk` decodes the whole heap in one call and pays the tail *once*. That saving
-//! dominates the cost of the gather memcpy even at 256-byte strings (with ~8 K elements). For
-//! example `take few_long/shuffle` canonicalizes in ~459 µs with `GatherBulk` vs ~623 µs with
-//! `PerElement`.
+//! ~12-byte and ~256-byte strings) shows **`GatherBulk` is the best non-contiguous strategy across
+//! the whole tested range**, for both short and long strings. The reason FSST decode is shaped
+//! this way: a fast 8-wide body and a slow byte-by-byte tail. `PerElement` pays that tail *once
+//! per element* (N tails); `GatherBulk` decodes the whole heap in one call and pays it *once*,
+//! which dominates the gather memcpy even at 256-byte strings.
 //!
-//! `PerElement` only wins in the opposite extreme — *very few, very long* strings — where N is
-//! tiny (few tails saved) but the gather memcpy of the entire live heap is large. That regime is
-//! outside what real string columns hit, so [`FsstViewCompaction::Auto`] never picks it: it uses
-//! `Direct` when the live codes are still contiguous (untouched/sliced view) and `GatherBulk`
-//! otherwise. `PerElement` is kept selectable so the trade-off stays measurable.
+//! `RunCoalesce` was the appealing idea of skipping the gather entirely — decode runs in place and
+//! let the `VarBinView` reference them out of order. It loses anyway, badly for short strings
+//! (`take many_short/shuffle`: ~18 ms vs ~5.6 ms for `GatherBulk`). The reason is subtle: the
+//! random access you avoid at *decode* time reappears at *view-build* time. Views are built in
+//! element order, so over a heap-ordered output the per-element `make_view` does N cache-missing
+//! random reads (and, for ≤12-byte strings, random-access *inlining* copies), plus an
+//! O(N log N) sort. `GatherBulk`'s output is element-ordered, so its view-build is sequential. The
+//! cheap sequential gather memcpy beats the expensive scattered view construction.
+//!
+//! So [`FsstViewCompaction::Auto`] uses `Direct` when the live codes are contiguous
+//! (untouched/sliced view) and `GatherBulk` otherwise. `PerElement` and `RunCoalesce` are kept
+//! selectable so the trade-off stays measurable, but `Auto` never picks them.
 
 use std::sync::Arc;
 
@@ -42,9 +50,13 @@ use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::VarBinViewArray;
+use vortex_array::arrays::varbinview::BinaryView;
 use vortex_array::arrays::varbinview::build_views::MAX_BUFFER_LEN;
 use vortex_array::arrays::varbinview::build_views::build_views;
 use vortex_array::match_each_integer_ptype;
+use vortex_buffer::Buffer;
+use vortex_buffer::BufferMut;
+use vortex_buffer::ByteBuffer;
 use vortex_buffer::ByteBufferMut;
 use vortex_error::VortexResult;
 
@@ -58,7 +70,7 @@ use super::array::FSSTViewArraySlotsExt;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FsstViewCompaction {
     /// Pick a strategy automatically: `Direct` when the live codes are contiguous, else
-    /// `GatherBulk`. Never picks `PerElement` (see module docs).
+    /// `GatherBulk`. Never picks `PerElement` or `RunCoalesce` (both lose; see module docs).
     Auto,
     /// Bulk-decompress the contiguous live range with no copy. Falls back to `GatherBulk` if the
     /// view's codes are not contiguous and in order.
@@ -67,6 +79,16 @@ pub enum FsstViewCompaction {
     GatherBulk,
     /// Decompress each element's code slice directly into place, without compacting.
     PerElement,
+    /// Coalesce survivors into contiguous heap runs and decompress each run with a *single* call
+    /// directly into a heap-ordered output (no gather copy), emitting `VarBinView` views — possibly
+    /// out of order — that point back into it. Decodes distinct codes once (duplicates share a
+    /// view).
+    ///
+    /// This is the "export paired slices into a `VarBinView`" approach. In theory it skips the
+    /// gather copy entirely; in practice it loses to `GatherBulk` (see module docs) because the
+    /// random access just moves to view-build time, where it's more expensive. Retained for
+    /// measurement only — `Auto` never selects it.
+    RunCoalesce,
 }
 
 pub(super) fn canonicalize_fsstview(
@@ -110,8 +132,8 @@ pub fn canonicalize_fsstview_with(
     let contiguous = is_contiguous(&offsets, &sizes);
     let chosen = match strategy {
         // Direct when the live codes are still one contiguous run, else compact-and-bulk.
-        // `GatherBulk` beats `PerElement` across the whole practical range (see module docs), so
-        // `Auto` never selects `PerElement`.
+        // `GatherBulk` beats both `PerElement` and `RunCoalesce` across the whole practical range
+        // (see module docs), so `Auto` picks neither.
         FsstViewCompaction::Auto => {
             if contiguous {
                 FsstViewCompaction::Direct
@@ -124,6 +146,23 @@ pub fn canonicalize_fsstview_with(
         other => other,
     };
 
+    // RunCoalesce builds its own (buffers, views) — decompression order is decoupled from element
+    // order, so it can't go through `build_views` (which assumes element-order contiguous output).
+    if chosen == FsstViewCompaction::RunCoalesce {
+        let (buffers, views) =
+            decompress_run_coalesce(&decompressor, heap, &offsets, &sizes, &ulens, total_size);
+        // SAFETY: FSST validates the bytes for binary/UTF-8; the views point at valid ranges.
+        return Ok(unsafe {
+            VarBinViewArray::new_unchecked(
+                views,
+                Arc::from(buffers),
+                array.dtype().clone(),
+                array.fsstview_validity(),
+            )
+            .into_array()
+        });
+    }
+
     let uncompressed = match chosen {
         FsstViewCompaction::Direct => {
             let start = offsets.first().copied().unwrap_or(0);
@@ -132,10 +171,8 @@ pub fn canonicalize_fsstview_with(
         FsstViewCompaction::GatherBulk => {
             decompress_gather(&decompressor, heap, &offsets, &sizes, live, total_size)
         }
-        // `Auto` is always resolved to a concrete strategy above.
-        FsstViewCompaction::PerElement | FsstViewCompaction::Auto => {
-            decompress_per_element(&decompressor, heap, &offsets, &sizes, &ulens, total_size)
-        }
+        // `Auto`/`RunCoalesce` are resolved above.
+        _ => decompress_per_element(&decompressor, heap, &offsets, &sizes, &ulens, total_size),
     };
 
     let (buffers, views) = match_each_integer_ptype!(ulen_prim.ptype(), |P| {
@@ -210,6 +247,92 @@ fn decompress_gather(
     let written = decompressor.decompress_into(compressed.as_slice(), out.spare_capacity_mut());
     unsafe { out.set_len(written) };
     out
+}
+
+/// Coalesce survivors into contiguous heap runs, decompress each run once directly into the
+/// output, and build `VarBinView`s (in element order) pointing back into that output.
+///
+/// Distinct elements are keyed by their `(offset, size)` heap span: duplicates (from a `take`
+/// with repeats) are decoded once and share a view. Adjacent distinct spans (`offset == prev end`)
+/// are decompressed in a single FSST call, so a shuffle take of the whole array is one decode.
+fn decompress_run_coalesce(
+    decompressor: &Decompressor<'_>,
+    heap: &[u8],
+    offsets: &[usize],
+    sizes: &[usize],
+    ulens: &[usize],
+    total_size: usize,
+) -> (Vec<ByteBuffer>, Buffer<BinaryView>) {
+    let count = offsets.len();
+
+    // Visit elements in heap order. Sorting by `(offset, size)` groups duplicates (same span)
+    // together and, at a shared offset, orders the zero-size span (null/empty) before the
+    // non-zero one — keeping the run extension below well-defined. `size` is part of the key
+    // because a zero-size element shares an offset with its heap neighbour.
+    let mut order: Vec<usize> = (0..count).collect();
+    order.sort_unstable_by_key(|&i| (offsets[i], sizes[i]));
+
+    // Output position of each element's decoded bytes, filled below.
+    let mut out_pos = vec![0usize; count];
+    let mut out = ByteBufferMut::with_capacity(total_size + 7);
+    let spare = out.spare_capacity_mut();
+
+    let mut written = 0usize;
+    let mut cursor = 0usize;
+    while cursor < count {
+        let head = order[cursor];
+        // Zero-size spans (empty/null) decode to nothing; share the current position.
+        if sizes[head] == 0 {
+            out_pos[head] = written;
+            cursor += 1;
+            continue;
+        }
+        // Start a run at this span and extend it while the next *distinct* span is heap-adjacent.
+        // Duplicate spans (identical offset+size) reuse the position already assigned for the run.
+        let run_out_base = written;
+        let run_heap_start = offsets[head];
+        let mut run_heap_end = run_heap_start;
+        let mut elem_out = written;
+        while cursor < count {
+            let elem = order[cursor];
+            if sizes[elem] == 0 {
+                break;
+            }
+            if offsets[elem] == run_heap_end {
+                // A new distinct span that continues the run.
+                out_pos[elem] = elem_out;
+                elem_out += ulens[elem];
+                run_heap_end += sizes[elem];
+                cursor += 1;
+            } else if offsets[elem] < run_heap_end {
+                // A duplicate of a span already decoded in this run: reuse its position. Duplicates
+                // are contiguous in the sorted order, so the previous entry shares this span.
+                out_pos[elem] = out_pos[order[cursor - 1]];
+                cursor += 1;
+            } else {
+                break;
+            }
+        }
+        // One decode for the whole run, straight into the output at `run_out_base`.
+        decompressor.decompress_into(
+            &heap[run_heap_start..run_heap_end],
+            &mut spare[run_out_base..],
+        );
+        written = elem_out;
+    }
+    unsafe { out.set_len(written) };
+    let bytes = out.freeze();
+
+    // Build views in element order, each pointing at its decoded output position.
+    let mut views = BufferMut::<BinaryView>::with_capacity(count);
+    for (i, &ulen) in ulens.iter().enumerate() {
+        let pos = out_pos[i];
+        #[expect(clippy::cast_possible_truncation)]
+        let view = BinaryView::make_view(&bytes[pos..pos + ulen], 0, pos as u32);
+        views.push(view);
+    }
+
+    (vec![bytes], views.freeze())
 }
 
 /// Decompress each element's code slice directly into its place in the output (no compaction).

--- a/encodings/fsst/src/fsstview/canonical.rs
+++ b/encodings/fsst/src/fsstview/canonical.rs
@@ -1,8 +1,32 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+//! Canonicalization of [`FSSTView`] into a [`VarBinViewArray`].
+//!
+//! After metadata-only `filter`/`take`, an [`FSSTView`]'s byte heap is the *original* heap and
+//! the live codes are scattered (gaps after a filter, reordering/duplication after a take). To
+//! canonicalize we must produce one contiguous decompressed buffer in element order. There are
+//! three ways to get there, with different cost profiles — see [`FsstViewCompaction`]:
+//!
+//! - [`Direct`][FsstViewCompaction::Direct]: the live codes are still contiguous and in order
+//!   (e.g. an untouched view or one that was only sliced). We bulk-decompress that single
+//!   contiguous range with no copy. Fastest, but only valid when contiguous.
+//! - [`GatherBulk`][FsstViewCompaction::GatherBulk] ("compact"): copy the scattered live codes
+//!   into a contiguous buffer, then a *single* bulk decompress. Pays a copy of the live
+//!   compressed bytes but the one bulk call amortizes the FSST 8-wide fast path across all
+//!   element boundaries.
+//! - [`PerElement`][FsstViewCompaction::PerElement] ("no compact"): decompress each element's
+//!   slice directly into its place in the output. No copy, but one decompress call per element.
+//!
+//! The compaction question, concretely: **compacting (`GatherBulk`) beats `PerElement` when the
+//! strings are short and numerous** — per-call overhead then dominates `PerElement` while the
+//! gather copy is cheap and unlocks bulk SIMD. **`PerElement` wins when the strings are long and
+//! few** — the gather copy dominates and per-call overhead is negligible. Density decides whether
+//! `Direct` is even available; average element size decides `GatherBulk` vs `PerElement`.
+
 use std::sync::Arc;
 
+use fsst::Decompressor;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
@@ -19,75 +43,95 @@ use super::array::FSSTView;
 use super::array::FSSTViewArrayExt;
 use super::array::FSSTViewArraySlotsExt;
 
-/// Canonicalize an [`FSSTView`] array into a [`VarBinViewArray`].
+/// Strategy for materializing the decompressed bytes when canonicalizing an [`FSSTView`].
 ///
-/// Because `filter`/`take`/`slice` leave the compressed byte heap untouched, the live codes of
-/// element `i` are the (possibly out-of-order, possibly overlapping) slice
-/// `codes_bytes[offset_i .. offset_i + size_i]`. We first gather them into element order, then
-/// bulk-decompress in a single pass and build the binary views from the uncompressed lengths.
+/// See the [module docs][self] for the full trade-off analysis.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FsstViewCompaction {
+    /// Pick a strategy automatically based on contiguity and average element size.
+    Auto,
+    /// Bulk-decompress the contiguous live range with no copy. Falls back to `GatherBulk` if the
+    /// view's codes are not contiguous and in order.
+    Direct,
+    /// Compact the scattered live codes into a contiguous buffer, then a single bulk decompress.
+    GatherBulk,
+    /// Decompress each element's code slice directly into place, without compacting.
+    PerElement,
+}
+
+/// Average compressed bytes/element below which compaction (`GatherBulk`) is preferred over
+/// `PerElement`. Heuristic; see module docs. Validated by the `fsst_view_compute` benchmark.
+const SHORT_STRING_THRESHOLD: usize = 32;
+
 pub(super) fn canonicalize_fsstview(
     array: ArrayView<'_, FSSTView>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    let len = array.len();
-    let bytes = array.codes_bytes();
+    canonicalize_fsstview_with(array, FsstViewCompaction::Auto, ctx)
+}
 
-    let offsets = array
-        .codes_offsets()
-        .clone()
-        .execute::<PrimitiveArray>(ctx)?;
-    let sizes = array.codes_sizes().clone().execute::<PrimitiveArray>(ctx)?;
-    let uncompressed_lengths = array
+/// Canonicalize an [`FSSTView`] to a [`VarBinViewArray`] using an explicit compaction strategy.
+///
+/// Exposed (rather than only the dispatch-driven [`canonicalize_fsstview`]) so benchmarks can
+/// measure each strategy directly. Production code goes through [`FsstViewCompaction::Auto`].
+pub fn canonicalize_fsstview_with(
+    array: ArrayView<'_, FSSTView>,
+    strategy: FsstViewCompaction,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let offsets = load_usize(array.codes_offsets(), ctx)?;
+    let sizes = load_usize(array.codes_sizes(), ctx)?;
+
+    let ulen_prim = array
         .uncompressed_lengths()
         .clone()
         .execute::<PrimitiveArray>(ctx)?;
-
     #[expect(clippy::cast_possible_truncation)]
-    let offsets: Vec<usize> = match_each_integer_ptype!(offsets.ptype(), |O| {
-        offsets
-            .as_slice::<O>()
-            .iter()
-            .map(|o| *o as usize)
-            .collect()
-    });
-    #[expect(clippy::cast_possible_truncation)]
-    let sizes: Vec<usize> = match_each_integer_ptype!(sizes.ptype(), |S| {
-        sizes.as_slice::<S>().iter().map(|s| *s as usize).collect()
-    });
-
-    // Gather the live compressed bytes into element order.
-    let total_compressed: usize = sizes.iter().sum();
-    let mut compressed = ByteBufferMut::with_capacity(total_compressed);
-    for i in 0..len {
-        compressed.extend_from_slice(&bytes[offsets[i]..offsets[i] + sizes[i]]);
-    }
-
-    #[expect(clippy::cast_possible_truncation)]
-    let total_size: usize = match_each_integer_ptype!(uncompressed_lengths.ptype(), |P| {
-        uncompressed_lengths
+    let ulens: Vec<usize> = match_each_integer_ptype!(ulen_prim.ptype(), |P| {
+        ulen_prim
             .as_slice::<P>()
             .iter()
             .map(|x| *x as usize)
-            .sum()
+            .collect()
     });
+    let total_size: usize = ulens.iter().sum();
+    let live: usize = sizes.iter().sum();
 
-    // Bulk-decompress the gathered heap. We reserve 7 extra bytes because the FSST decoder may
-    // overrun the output by up to a word.
+    let heap_buffer = array.codes_bytes();
+    let heap = heap_buffer.as_slice();
     let decompressor = array.decompressor();
-    let mut uncompressed_bytes = ByteBufferMut::with_capacity(total_size + 7);
-    let written = decompressor.decompress_into(
-        compressed.as_slice(),
-        uncompressed_bytes.spare_capacity_mut(),
-    );
-    unsafe { uncompressed_bytes.set_len(written) };
 
-    let (buffers, views) = match_each_integer_ptype!(uncompressed_lengths.ptype(), |P| {
-        build_views(
-            0,
-            MAX_BUFFER_LEN,
-            uncompressed_bytes,
-            uncompressed_lengths.as_slice::<P>(),
-        )
+    let contiguous = is_contiguous(&offsets, &sizes);
+    let chosen = match strategy {
+        FsstViewCompaction::Auto => {
+            if contiguous {
+                FsstViewCompaction::Direct
+            } else if !offsets.is_empty() && live / offsets.len() < SHORT_STRING_THRESHOLD {
+                FsstViewCompaction::GatherBulk
+            } else {
+                FsstViewCompaction::PerElement
+            }
+        }
+        // `Direct` is only valid for a contiguous layout; fall back to a compacting decode.
+        FsstViewCompaction::Direct if !contiguous => FsstViewCompaction::GatherBulk,
+        other => other,
+    };
+
+    let uncompressed = match chosen {
+        FsstViewCompaction::Direct => {
+            let start = offsets.first().copied().unwrap_or(0);
+            decompress_direct(&decompressor, heap, start, live, total_size)
+        }
+        FsstViewCompaction::GatherBulk => {
+            decompress_gather(&decompressor, heap, &offsets, &sizes, live, total_size)
+        }
+        FsstViewCompaction::PerElement | FsstViewCompaction::Auto => {
+            decompress_per_element(&decompressor, heap, &offsets, &sizes, &ulens, total_size)
+        }
+    };
+
+    let (buffers, views) = match_each_integer_ptype!(ulen_prim.ptype(), |P| {
+        build_views(0, MAX_BUFFER_LEN, uncompressed, ulen_prim.as_slice::<P>())
     });
 
     // SAFETY: FSST validates the bytes for binary/UTF-8; the views point at valid ranges.
@@ -100,4 +144,86 @@ pub(super) fn canonicalize_fsstview(
         )
         .into_array()
     })
+}
+
+fn load_usize(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Vec<usize>> {
+    let prim = array.clone().execute::<PrimitiveArray>(ctx)?;
+    #[expect(clippy::cast_possible_truncation)]
+    let out: Vec<usize> = match_each_integer_ptype!(prim.ptype(), |P| {
+        prim.as_slice::<P>().iter().map(|x| *x as usize).collect()
+    });
+    Ok(out)
+}
+
+/// Returns true if the live codes occupy a single contiguous, in-order run of the heap.
+fn is_contiguous(offsets: &[usize], sizes: &[usize]) -> bool {
+    let Some(&first) = offsets.first() else {
+        return true;
+    };
+    let mut pos = first;
+    for (&offset, &size) in offsets.iter().zip(sizes) {
+        if offset != pos {
+            return false;
+        }
+        pos += size;
+    }
+    true
+}
+
+/// Decompress a single contiguous run of the heap in one bulk call (no copy).
+fn decompress_direct(
+    decompressor: &Decompressor<'_>,
+    heap: &[u8],
+    start: usize,
+    live: usize,
+    total_size: usize,
+) -> ByteBufferMut {
+    let mut out = ByteBufferMut::with_capacity(total_size + 7);
+    let written =
+        decompressor.decompress_into(&heap[start..start + live], out.spare_capacity_mut());
+    unsafe { out.set_len(written) };
+    out
+}
+
+/// Compact the scattered live codes into a contiguous buffer, then a single bulk decompress.
+fn decompress_gather(
+    decompressor: &Decompressor<'_>,
+    heap: &[u8],
+    offsets: &[usize],
+    sizes: &[usize],
+    live: usize,
+    total_size: usize,
+) -> ByteBufferMut {
+    let mut compressed = ByteBufferMut::with_capacity(live);
+    for (&offset, &size) in offsets.iter().zip(sizes) {
+        compressed.extend_from_slice(&heap[offset..offset + size]);
+    }
+    let mut out = ByteBufferMut::with_capacity(total_size + 7);
+    let written = decompressor.decompress_into(compressed.as_slice(), out.spare_capacity_mut());
+    unsafe { out.set_len(written) };
+    out
+}
+
+/// Decompress each element's code slice directly into its place in the output (no compaction).
+fn decompress_per_element(
+    decompressor: &Decompressor<'_>,
+    heap: &[u8],
+    offsets: &[usize],
+    sizes: &[usize],
+    ulens: &[usize],
+    total_size: usize,
+) -> ByteBufferMut {
+    let mut out = ByteBufferMut::with_capacity(total_size + 7);
+    {
+        let spare = out.spare_capacity_mut();
+        let mut uoff = 0;
+        for ((&offset, &size), &ulen) in offsets.iter().zip(sizes).zip(ulens) {
+            if size > 0 {
+                decompressor.decompress_into(&heap[offset..offset + size], &mut spare[uoff..]);
+            }
+            uoff += ulen;
+        }
+    }
+    unsafe { out.set_len(total_size) };
+    out
 }

--- a/encodings/fsst/src/fsstview/canonical.rs
+++ b/encodings/fsst/src/fsstview/canonical.rs
@@ -98,6 +98,127 @@ pub(super) fn canonicalize_fsstview(
     canonicalize_fsstview_with(array, FsstViewCompaction::Auto, ctx)
 }
 
+/// Byte accounting for an [`FSSTView`], in **both compressed (code) space and uncompressed
+/// (decoded) space**, for reasoning about gather/coalesce trade-offs and dead-byte waste.
+///
+/// All figures are in bytes. The "span" figures describe what a *gap-merged* decode (decoding each
+/// run's full heap extent, dead bytes included) would touch; the difference from the live figures
+/// is the waste such a strategy would carry.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct FsstViewByteStats {
+    /// Number of (logical) elements in the view.
+    pub elements: usize,
+    /// Distinct heap runs the live elements form (maximal heap-adjacent groups of distinct spans).
+    pub runs: usize,
+    /// Distinct (deduplicated) live code spans referenced by the view.
+    pub distinct_spans: usize,
+    /// Compressed bytes the live distinct spans occupy (what `GatherBulk` copies / decodes).
+    pub live_compressed: usize,
+    /// Compressed bytes spanned by the runs *including* dead gaps between survivors (what a
+    /// gap-merged decode would feed the decoder). `span_compressed - live_compressed` is the
+    /// compressed waste of merging across gaps.
+    pub span_compressed: usize,
+    /// Uncompressed bytes the live elements decode to (the canonical output size; deduped spans
+    /// counted once).
+    pub live_uncompressed: usize,
+    /// Total uncompressed output size with duplicates expanded (the `VarBinView`'s logical size).
+    pub logical_uncompressed: usize,
+    /// Total compressed heap size backing the view (the original, shared code buffer).
+    pub heap_compressed: usize,
+}
+
+impl FsstViewByteStats {
+    /// Fraction of the spanned compressed bytes that are dead (would be wasted by a gap-merged
+    /// decode). `0.0` means the live spans are perfectly contiguous within each run.
+    pub fn compressed_waste_ratio(&self) -> f64 {
+        if self.span_compressed == 0 {
+            0.0
+        } else {
+            (self.span_compressed - self.live_compressed) as f64 / self.span_compressed as f64
+        }
+    }
+}
+
+/// Compute [`FsstViewByteStats`] for a view (diagnostics; not on the hot path).
+pub fn fsstview_byte_stats(
+    array: ArrayView<'_, FSSTView>,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<FsstViewByteStats> {
+    let offsets = load_usize(array.codes_offsets(), ctx)?;
+    let sizes = load_usize(array.codes_sizes(), ctx)?;
+    let ulen_prim = array
+        .uncompressed_lengths()
+        .clone()
+        .execute::<PrimitiveArray>(ctx)?;
+    #[expect(clippy::cast_possible_truncation)]
+    let ulens: Vec<usize> = match_each_integer_ptype!(ulen_prim.ptype(), |P| {
+        ulen_prim
+            .as_slice::<P>()
+            .iter()
+            .map(|x| *x as usize)
+            .collect()
+    });
+
+    let elements = offsets.len();
+    let logical_uncompressed: usize = ulens.iter().sum();
+    let heap_compressed = array.codes_bytes().len();
+
+    // Walk distinct spans in heap order, accumulating live/run/span figures.
+    let mut order: Vec<usize> = (0..elements).filter(|&i| sizes[i] > 0).collect();
+    order.sort_unstable_by_key(|&i| (offsets[i], sizes[i]));
+
+    let mut runs = 0usize;
+    let mut distinct_spans = 0usize;
+    let mut live_compressed = 0usize;
+    let mut live_uncompressed = 0usize;
+    let mut span_compressed = 0usize;
+    let mut run_end: Option<usize> = None;
+    let mut run_start = 0usize;
+    let mut prev_span: Option<(usize, usize)> = None;
+    for &i in &order {
+        let span = (offsets[i], sizes[i]);
+        let is_dup = prev_span == Some(span);
+        prev_span = Some(span);
+        if is_dup {
+            continue; // duplicate of the previous distinct span
+        }
+        distinct_spans += 1;
+        live_compressed += sizes[i];
+        live_uncompressed += ulens[i];
+        match run_end {
+            Some(end) if offsets[i] == end => {
+                run_end = Some(end + sizes[i]);
+            }
+            Some(end) => {
+                // Close the previous run, open a new one.
+                span_compressed += end - run_start;
+                runs += 1;
+                run_start = offsets[i];
+                run_end = Some(offsets[i] + sizes[i]);
+            }
+            None => {
+                run_start = offsets[i];
+                run_end = Some(offsets[i] + sizes[i]);
+            }
+        }
+    }
+    if let Some(end) = run_end {
+        span_compressed += end - run_start;
+        runs += 1;
+    }
+
+    Ok(FsstViewByteStats {
+        elements,
+        runs,
+        distinct_spans,
+        live_compressed,
+        span_compressed,
+        live_uncompressed,
+        logical_uncompressed,
+        heap_compressed,
+    })
+}
+
 /// Canonicalize an [`FSSTView`] to a [`VarBinViewArray`] using an explicit compaction strategy.
 ///
 /// Exposed (rather than only the dispatch-driven [`canonicalize_fsstview`]) so benchmarks can

--- a/encodings/fsst/src/fsstview/canonical.rs
+++ b/encodings/fsst/src/fsstview/canonical.rs
@@ -18,11 +18,20 @@
 //! - [`PerElement`][FsstViewCompaction::PerElement] ("no compact"): decompress each element's
 //!   slice directly into its place in the output. No copy, but one decompress call per element.
 //!
-//! The compaction question, concretely: **compacting (`GatherBulk`) beats `PerElement` when the
-//! strings are short and numerous** — per-call overhead then dominates `PerElement` while the
-//! gather copy is cheap and unlocks bulk SIMD. **`PerElement` wins when the strings are long and
-//! few** — the gather copy dominates and per-call overhead is negligible. Density decides whether
-//! `Direct` is even available; average element size decides `GatherBulk` vs `PerElement`.
+//! The compaction question, concretely. The `fsst_view_compute` benchmark (two ~2 MiB inputs,
+//! ~12-byte and ~256-byte strings) shows **`GatherBulk` beats `PerElement` across the whole
+//! tested range, for both short and long strings**. The reason: FSST's decoder has a fast 8-wide
+//! body and a slow byte-by-byte tail. `PerElement` pays that tail *once per element* (N tails),
+//! while `GatherBulk` decodes the whole heap in one call and pays the tail *once*. That saving
+//! dominates the cost of the gather memcpy even at 256-byte strings (with ~8 K elements). For
+//! example `take few_long/shuffle` canonicalizes in ~459 µs with `GatherBulk` vs ~623 µs with
+//! `PerElement`.
+//!
+//! `PerElement` only wins in the opposite extreme — *very few, very long* strings — where N is
+//! tiny (few tails saved) but the gather memcpy of the entire live heap is large. That regime is
+//! outside what real string columns hit, so [`FsstViewCompaction::Auto`] never picks it: it uses
+//! `Direct` when the live codes are still contiguous (untouched/sliced view) and `GatherBulk`
+//! otherwise. `PerElement` is kept selectable so the trade-off stays measurable.
 
 use std::sync::Arc;
 
@@ -48,7 +57,8 @@ use super::array::FSSTViewArraySlotsExt;
 /// See the [module docs][self] for the full trade-off analysis.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FsstViewCompaction {
-    /// Pick a strategy automatically based on contiguity and average element size.
+    /// Pick a strategy automatically: `Direct` when the live codes are contiguous, else
+    /// `GatherBulk`. Never picks `PerElement` (see module docs).
     Auto,
     /// Bulk-decompress the contiguous live range with no copy. Falls back to `GatherBulk` if the
     /// view's codes are not contiguous and in order.
@@ -58,10 +68,6 @@ pub enum FsstViewCompaction {
     /// Decompress each element's code slice directly into place, without compacting.
     PerElement,
 }
-
-/// Average compressed bytes/element below which compaction (`GatherBulk`) is preferred over
-/// `PerElement`. Heuristic; see module docs. Validated by the `fsst_view_compute` benchmark.
-const SHORT_STRING_THRESHOLD: usize = 32;
 
 pub(super) fn canonicalize_fsstview(
     array: ArrayView<'_, FSSTView>,
@@ -103,13 +109,14 @@ pub fn canonicalize_fsstview_with(
 
     let contiguous = is_contiguous(&offsets, &sizes);
     let chosen = match strategy {
+        // Direct when the live codes are still one contiguous run, else compact-and-bulk.
+        // `GatherBulk` beats `PerElement` across the whole practical range (see module docs), so
+        // `Auto` never selects `PerElement`.
         FsstViewCompaction::Auto => {
             if contiguous {
                 FsstViewCompaction::Direct
-            } else if !offsets.is_empty() && live / offsets.len() < SHORT_STRING_THRESHOLD {
-                FsstViewCompaction::GatherBulk
             } else {
-                FsstViewCompaction::PerElement
+                FsstViewCompaction::GatherBulk
             }
         }
         // `Direct` is only valid for a contiguous layout; fall back to a compacting decode.
@@ -125,6 +132,7 @@ pub fn canonicalize_fsstview_with(
         FsstViewCompaction::GatherBulk => {
             decompress_gather(&decompressor, heap, &offsets, &sizes, live, total_size)
         }
+        // `Auto` is always resolved to a concrete strategy above.
         FsstViewCompaction::PerElement | FsstViewCompaction::Auto => {
             decompress_per_element(&decompressor, heap, &offsets, &sizes, &ulens, total_size)
         }

--- a/encodings/fsst/src/fsstview/canonical.rs
+++ b/encodings/fsst/src/fsstview/canonical.rs
@@ -352,6 +352,11 @@ fn decompress_direct(
 }
 
 /// Compact the scattered live codes into a contiguous buffer, then a single bulk decompress.
+///
+/// The gather coalesces consecutive heap-adjacent spans into a single `extend_from_slice`: for an
+/// order-preserving `filter`, surviving neighbours are still contiguous in the heap, so a run of
+/// `k` survivors is copied in one memcpy instead of `k`. This collapses the per-span copy overhead
+/// (which dominates for short codes) to per-run, while a shuffle (no adjacency) is unaffected.
 fn decompress_gather(
     decompressor: &Decompressor<'_>,
     heap: &[u8],
@@ -361,8 +366,25 @@ fn decompress_gather(
     total_size: usize,
 ) -> ByteBufferMut {
     let mut compressed = ByteBufferMut::with_capacity(live);
+    // Accumulate a contiguous `[run_start, run_end)` heap range and flush it as one copy.
+    let mut run_start = 0usize;
+    let mut run_end = 0usize;
     for (&offset, &size) in offsets.iter().zip(sizes) {
-        compressed.extend_from_slice(&heap[offset..offset + size]);
+        if size == 0 {
+            continue;
+        }
+        if offset == run_end && run_end != run_start {
+            run_end += size; // extend the current run (heap-adjacent)
+        } else {
+            if run_end != run_start {
+                compressed.extend_from_slice(&heap[run_start..run_end]);
+            }
+            run_start = offset;
+            run_end = offset + size;
+        }
+    }
+    if run_end != run_start {
+        compressed.extend_from_slice(&heap[run_start..run_end]);
     }
     let mut out = ByteBufferMut::with_capacity(total_size + 7);
     let written = decompressor.decompress_into(compressed.as_slice(), out.spare_capacity_mut());

--- a/encodings/fsst/src/fsstview/compute.rs
+++ b/encodings/fsst/src/fsstview/compute.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Metadata-only `filter` and `take` for [`FSSTView`].
+//!
+//! Both operations rewrite only the small `offsets`/`sizes`/`uncompressed_lengths`/`validity`
+//! arrays and reuse the compressed byte heap (and symbol table) untouched. This is the core
+//! "ListView speed" win over plain [`FSST`][crate::FSST], whose `filter`/`take` delegate to
+//! `VarBin` and therefore rewrite the entire compressed heap.
+
+use vortex_array::ArrayRef;
+use vortex_array::ArrayView;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::arrays::dict::TakeExecute;
+use vortex_array::arrays::filter::FilterKernel;
+use vortex_array::builtins::ArrayBuiltins;
+use vortex_array::scalar::Scalar;
+use vortex_error::VortexResult;
+use vortex_mask::Mask;
+
+use super::array::FSSTView;
+use super::array::FSSTViewArrayExt;
+use super::array::FSSTViewArraySlotsExt;
+
+impl FilterKernel for FSSTView {
+    fn filter(
+        array: ArrayView<'_, Self>,
+        mask: &Mask,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        // Filter only the addressing arrays; the byte heap and symbol table are reused as-is.
+        let validity = array.fsstview_validity().filter(mask)?;
+        let codes_offsets = array.codes_offsets().filter(mask.clone())?;
+        let codes_sizes = array.codes_sizes().filter(mask.clone())?;
+        let uncompressed_lengths = array.uncompressed_lengths().filter(mask.clone())?;
+
+        // SAFETY: filter preserves all `FSSTView` invariants — offsets/sizes/lengths stay
+        // non-nullable and equal-length, and validity tracks nullness separately.
+        Ok(Some(
+            unsafe {
+                FSSTView::new_unchecked(
+                    array.dtype().clone(),
+                    array.symbols().clone(),
+                    array.symbol_lengths().clone(),
+                    array.codes_bytes_handle().clone(),
+                    codes_offsets,
+                    codes_sizes,
+                    uncompressed_lengths,
+                    validity,
+                )
+            }
+            .into_array(),
+        ))
+    }
+}
+
+impl TakeExecute for FSSTView {
+    fn take(
+        array: ArrayView<'_, Self>,
+        indices: &ArrayRef,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        let dtype = array
+            .dtype()
+            .clone()
+            .union_nullability(indices.dtype().nullability());
+
+        let validity = array.fsstview_validity().take(indices)?;
+
+        // `take` may reorder, duplicate, or skip elements, which is fine for `FSSTView` since
+        // offsets need not be monotonic. `take` yields nullable arrays (null index -> null),
+        // so we fill nulls with zero and rely on `validity` to track nullness.
+        let codes_offsets = array
+            .codes_offsets()
+            .take(indices.clone())?
+            .fill_null(Scalar::zero_value(array.codes_offsets().dtype()))?;
+        let codes_sizes = array
+            .codes_sizes()
+            .take(indices.clone())?
+            .fill_null(Scalar::zero_value(array.codes_sizes().dtype()))?;
+        let uncompressed_lengths = array
+            .uncompressed_lengths()
+            .take(indices.clone())?
+            .fill_null(Scalar::zero_value(array.uncompressed_lengths().dtype()))?;
+
+        // SAFETY: take preserves all `FSSTView` invariants (see `filter`).
+        Ok(Some(
+            unsafe {
+                FSSTView::new_unchecked(
+                    dtype,
+                    array.symbols().clone(),
+                    array.symbol_lengths().clone(),
+                    array.codes_bytes_handle().clone(),
+                    codes_offsets,
+                    codes_sizes,
+                    uncompressed_lengths,
+                    validity,
+                )
+            }
+            .into_array(),
+        ))
+    }
+}

--- a/encodings/fsst/src/fsstview/compute.rs
+++ b/encodings/fsst/src/fsstview/compute.rs
@@ -68,21 +68,14 @@ impl TakeExecute for FSSTView {
 
         let validity = array.fsstview_validity().take(indices)?;
 
-        // `take` may reorder, duplicate, or skip elements, which is fine for `FSSTView` since
-        // offsets need not be monotonic. `take` yields nullable arrays (null index -> null),
-        // so we fill nulls with zero and rely on `validity` to track nullness.
-        let codes_offsets = array
-            .codes_offsets()
-            .take(indices.clone())?
-            .fill_null(Scalar::zero_value(array.codes_offsets().dtype()))?;
-        let codes_sizes = array
-            .codes_sizes()
-            .take(indices.clone())?
-            .fill_null(Scalar::zero_value(array.codes_sizes().dtype()))?;
-        let uncompressed_lengths = array
-            .uncompressed_lengths()
-            .take(indices.clone())?
-            .fill_null(Scalar::zero_value(array.uncompressed_lengths().dtype()))?;
+        // `take` of a non-nullable child with non-nullable indices stays non-nullable, so the
+        // `fill_null` (and the `cast`/`optimize` it pulls in) is pure overhead in the common case.
+        // Only when the indices are nullable can a null index introduce a null we must fill with
+        // zero — nullness itself is tracked separately by `validity`.
+        let fill = indices.dtype().is_nullable();
+        let codes_offsets = take_child(array.codes_offsets(), indices, fill)?;
+        let codes_sizes = take_child(array.codes_sizes(), indices, fill)?;
+        let uncompressed_lengths = take_child(array.uncompressed_lengths(), indices, fill)?;
 
         // SAFETY: take preserves all `FSSTView` invariants (see `filter`).
         Ok(Some(
@@ -100,5 +93,16 @@ impl TakeExecute for FSSTView {
             }
             .into_array(),
         ))
+    }
+}
+
+/// Take a non-nullable integer child by `indices`, only filling nulls with zero when the indices
+/// are nullable (and so could have introduced nulls). The child is always non-nullable on input.
+fn take_child(child: &ArrayRef, indices: &ArrayRef, fill: bool) -> VortexResult<ArrayRef> {
+    let taken = child.take(indices.clone())?;
+    if fill {
+        taken.fill_null(Scalar::zero_value(child.dtype()))
+    } else {
+        Ok(taken)
     }
 }

--- a/encodings/fsst/src/fsstview/from_fsst.rs
+++ b/encodings/fsst/src/fsstview/from_fsst.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Metadata-only `filter`/`take` that go straight from an [`FSSTArray`] to an [`FSSTViewArray`].
+//!
+//! These are the "first hop" of the view pipeline. They never touch the compressed byte heap:
+//! the [`FSSTArray`] is reinterpreted as an [`FSSTViewArray`] (sharing symbols + codes bytes,
+//! deriving `sizes` from the consecutive offsets) and then the selection is applied to the small
+//! `offsets`/`sizes`/`lengths`/`validity` arrays only.
+
+use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
+use vortex_array::arrays::dict::TakeExecute;
+use vortex_array::arrays::filter::FilterKernel;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_error::vortex_err;
+use vortex_mask::Mask;
+
+use super::array::FSSTView;
+use super::array::FSSTViewArray;
+use super::array::fsstview_from_fsst;
+use crate::FSSTArray;
+
+/// Filter an [`FSSTArray`], producing an [`FSSTViewArray`] without touching the codes.
+pub fn fsst_filter_to_view(
+    array: &FSSTArray,
+    mask: &Mask,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<FSSTViewArray> {
+    let view = fsstview_from_fsst(array, ctx)?;
+    let filtered: ArrayRef = <FSSTView as FilterKernel>::filter(view.as_view(), mask, ctx)?
+        .vortex_expect("FSSTView filter always returns Some");
+    filtered
+        .try_downcast::<FSSTView>()
+        .map_err(|_| vortex_err!("FSSTView filter must return an FSSTView"))
+}
+
+/// Take from an [`FSSTArray`], producing an [`FSSTViewArray`] without touching the codes.
+pub fn fsst_take_to_view(
+    array: &FSSTArray,
+    indices: &ArrayRef,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<FSSTViewArray> {
+    let view = fsstview_from_fsst(array, ctx)?;
+    let taken: ArrayRef = <FSSTView as TakeExecute>::take(view.as_view(), indices, ctx)?
+        .vortex_expect("FSSTView take always returns Some");
+    taken
+        .try_downcast::<FSSTView>()
+        .map_err(|_| vortex_err!("FSSTView take must return an FSSTView"))
+}

--- a/encodings/fsst/src/fsstview/kernel.rs
+++ b/encodings/fsst/src/fsstview/kernel.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::arrays::dict::TakeExecuteAdaptor;
+use vortex_array::arrays::filter::FilterExecuteAdaptor;
+use vortex_array::kernel::ParentKernelSet;
+
+use super::array::FSSTView;
+
+pub(super) const PARENT_KERNELS: ParentKernelSet<FSSTView> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&FilterExecuteAdaptor(FSSTView)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(FSSTView)),
+]);

--- a/encodings/fsst/src/fsstview/mod.rs
+++ b/encodings/fsst/src/fsstview/mod.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! A "ListView"-style variant of the [`FSST`][crate::FSST] encoding.
+//!
+//! Where [`FSST`][crate::FSST] addresses its compressed codes with a single monotonic
+//! offsets array (`len + 1` offsets, exactly like `VarBin`/`List`), [`FSSTView`] addresses
+//! them with a pair of `offsets` **and** `sizes` arrays (exactly like
+//! [`ListView`][vortex_array::arrays::ListView]). Element `i`'s compressed bytecodes live in
+//! `codes_bytes[offsets[i] .. offsets[i] + sizes[i]]`.
+//!
+//! Decoupling the start (`offset`) from the length (`size`) means the offsets are no longer
+//! required to be monotonic or contiguous, so `filter`, `take`, and `slice` become
+//! metadata-only operations: they rewrite only the (small) `offsets`/`sizes`/lengths/validity
+//! arrays and **reuse the compressed byte heap untouched**. The plain [`FSST`][crate::FSST]
+//! encoding has to rewrite the entire compressed heap for `filter`/`take` because it delegates
+//! to `VarBin`. This is the same trade-off `ListView` makes over `List`.
+
+mod array;
+mod canonical;
+mod compute;
+mod kernel;
+mod ops;
+mod rules;
+mod slice;
+#[cfg(test)]
+mod tests;
+
+pub use array::*;

--- a/encodings/fsst/src/fsstview/mod.rs
+++ b/encodings/fsst/src/fsstview/mod.rs
@@ -28,7 +28,9 @@ mod slice;
 mod tests;
 
 pub use array::*;
+pub use canonical::FsstViewByteStats;
 pub use canonical::FsstViewCompaction;
 pub use canonical::canonicalize_fsstview_with;
+pub use canonical::fsstview_byte_stats;
 pub use from_fsst::fsst_filter_to_view;
 pub use from_fsst::fsst_take_to_view;

--- a/encodings/fsst/src/fsstview/mod.rs
+++ b/encodings/fsst/src/fsstview/mod.rs
@@ -19,6 +19,7 @@
 mod array;
 mod canonical;
 mod compute;
+mod from_fsst;
 mod kernel;
 mod ops;
 mod rules;
@@ -27,3 +28,7 @@ mod slice;
 mod tests;
 
 pub use array::*;
+pub use canonical::FsstViewCompaction;
+pub use canonical::canonicalize_fsstview_with;
+pub use from_fsst::fsst_filter_to_view;
+pub use from_fsst::fsst_take_to_view;

--- a/encodings/fsst/src/fsstview/ops.rs
+++ b/encodings/fsst/src/fsstview/ops.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::ArrayView;
+use vortex_array::ExecutionCtx;
+use vortex_array::arrays::varbin::varbin_scalar;
+use vortex_array::scalar::Scalar;
+use vortex_array::vtable::OperationsVTable;
+use vortex_buffer::ByteBuffer;
+use vortex_error::VortexResult;
+
+use super::array::FSSTView;
+use super::array::FSSTViewArraySlotsExt;
+
+impl OperationsVTable<FSSTView> for FSSTView {
+    fn scalar_at(
+        array: ArrayView<'_, FSSTView>,
+        index: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
+        // Preconditions (see `OperationsVTable`): `index` is in bounds and non-null.
+        let offset: usize = (&array.codes_offsets().execute_scalar(index, ctx)?).try_into()?;
+        let size: usize = (&array.codes_sizes().execute_scalar(index, ctx)?).try_into()?;
+
+        let compressed = &array.codes_bytes()[offset..offset + size];
+        let decoded = ByteBuffer::from(array.decompressor().decompress(compressed));
+        Ok(varbin_scalar(decoded, array.dtype()))
+    }
+}

--- a/encodings/fsst/src/fsstview/rules.rs
+++ b/encodings/fsst/src/fsstview/rules.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::arrays::slice::SliceReduceAdaptor;
+use vortex_array::optimizer::rules::ParentRuleSet;
+
+use super::array::FSSTView;
+
+pub(crate) static RULES: ParentRuleSet<FSSTView> =
+    ParentRuleSet::new(&[ParentRuleSet::lift(&SliceReduceAdaptor(FSSTView))]);

--- a/encodings/fsst/src/fsstview/slice.rs
+++ b/encodings/fsst/src/fsstview/slice.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::ops::Range;
+
+use vortex_array::ArrayRef;
+use vortex_array::ArrayView;
+use vortex_array::IntoArray;
+use vortex_array::arrays::slice::SliceReduce;
+use vortex_error::VortexResult;
+
+use super::array::FSSTView;
+use super::array::FSSTViewArrayExt;
+use super::array::FSSTViewArraySlotsExt;
+
+impl SliceReduce for FSSTView {
+    fn slice(array: ArrayView<'_, Self>, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
+        // Slicing leaves the symbol table and compressed byte heap intact; we only slice the
+        // addressing arrays.
+        Ok(Some(
+            unsafe {
+                FSSTView::new_unchecked(
+                    array.dtype().clone(),
+                    array.symbols().clone(),
+                    array.symbol_lengths().clone(),
+                    array.codes_bytes_handle().clone(),
+                    array.codes_offsets().slice(range.clone())?,
+                    array.codes_sizes().slice(range.clone())?,
+                    array.uncompressed_lengths().slice(range.clone())?,
+                    array.fsstview_validity().slice(range)?,
+                )
+            }
+            .into_array(),
+        ))
+    }
+}

--- a/encodings/fsst/src/fsstview/tests.rs
+++ b/encodings/fsst/src/fsstview/tests.rs
@@ -10,6 +10,7 @@ use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::VarBinArray;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::arrays::dict::TakeExecute;
+use vortex_array::arrays::filter::FilterKernel;
 use vortex_array::assert_arrays_eq;
 use vortex_array::compute::conformance::consistency::test_array_consistency;
 use vortex_array::compute::conformance::filter::test_filter_conformance;
@@ -28,6 +29,7 @@ use crate::fsst_compress;
 use crate::fsst_filter_to_view;
 use crate::fsst_take_to_view;
 use crate::fsst_train_compressor;
+use crate::fsstview_byte_stats;
 use crate::fsstview_from_fsst;
 
 fn make_fsstview(
@@ -325,5 +327,106 @@ fn run_coalesce_gaps_and_shuffle(#[case] strategy: FsstViewCompaction) -> Vortex
             .take(indices)?
             .execute::<VarBinViewArray>(&mut ctx)?;
     assert_arrays_eq!(got, expected.into_array());
+    Ok(())
+}
+
+/// Build a ~`target`-uncompressed-byte FSSTView of random short URL-ish strings.
+fn make_big_view(target: usize, avg_len: usize, ctx: &mut ExecutionCtx) -> FSSTViewArray {
+    use rand::RngExt;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+    let mut rng = StdRng::seed_from_u64(1);
+    let words = [
+        "https://", "example", "vortex", ".com/", "path", "value", "data", "alpha",
+    ];
+    let count = target / avg_len;
+    let strings: Vec<Box<[u8]>> = (0..count)
+        .map(|_| {
+            let mut s = String::new();
+            while s.len() < avg_len {
+                s.push_str(words[rng.random_range(0..words.len())]);
+            }
+            s.truncate(avg_len);
+            s.into_bytes().into_boxed_slice()
+        })
+        .collect();
+    let varbin = VarBinArray::from_iter(
+        strings.into_iter().map(Some),
+        DType::Utf8(Nullability::NonNullable),
+    );
+    let compressor = fsst_train_compressor(&varbin);
+    let fsst = fsst_compress(&varbin, varbin.len(), varbin.dtype(), &compressor, ctx);
+    fsstview_from_fsst(&fsst, ctx).expect("fsstview_from_fsst")
+}
+
+/// Reports the byte accounting (compressed and uncompressed) and the dead-byte waste a gap-merged
+/// decode would carry, for representative selective filter / shuffle take / dense take. Run with
+/// `cargo test -p vortex-fsst byte_stats_report -- --nocapture` to see the numbers.
+#[test]
+fn byte_stats_report() -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let base = make_big_view(1 << 20, 16, &mut ctx);
+    let n = base.len();
+
+    // Selective filter (keep ~10%): many small gaps -> high compressed waste if merged.
+    let mut rng_keep = {
+        use rand::SeedableRng;
+        rand::rngs::StdRng::seed_from_u64(3)
+    };
+    let mask = {
+        use rand::RngExt;
+        Mask::from_iter((0..n).map(|_| rng_keep.random_bool(0.10)))
+    };
+    let filtered = <FSSTView as FilterKernel>::filter(base.as_view(), &mask, &mut ctx)?
+        .unwrap()
+        .try_downcast::<FSSTView>()
+        .ok()
+        .unwrap();
+
+    // Shuffle take: same elements, reordered -> one run, zero waste.
+    let mut perm: Vec<u64> = (0..n as u64).collect();
+    {
+        use rand::RngExt;
+        use rand::SeedableRng;
+        let mut r = rand::rngs::StdRng::seed_from_u64(4);
+        for i in (1..perm.len()).rev() {
+            perm.swap(i, r.random_range(0..=i));
+        }
+    }
+    let shuffled = <FSSTView as TakeExecute>::take(
+        base.as_view(),
+        &PrimitiveArray::from_iter(perm).into_array(),
+        &mut ctx,
+    )?
+    .unwrap()
+    .try_downcast::<FSSTView>()
+    .ok()
+    .unwrap();
+
+    for (label, view) in [("filter_10pct", &filtered), ("shuffle_take", &shuffled)] {
+        let s = fsstview_byte_stats(view.as_view(), &mut ctx)?;
+        // Waste if we instead merged *everything* into a single decode of the whole heap extent
+        // (the most aggressive gap-merge): all heap bytes minus the live ones are dead.
+        let full_merge_waste = if s.heap_compressed == 0 {
+            0.0
+        } else {
+            (s.heap_compressed - s.live_compressed) as f64 / s.heap_compressed as f64
+        };
+        println!(
+            "{label}: elements={} runs={} distinct={} \
+             | compressed: live={}B span={}B heap={}B run_waste={:.1}% full_merge_waste={:.1}% \
+             | uncompressed: live={}B logical={}B",
+            s.elements,
+            s.runs,
+            s.distinct_spans,
+            s.live_compressed,
+            s.span_compressed,
+            s.heap_compressed,
+            s.compressed_waste_ratio() * 100.0,
+            full_merge_waste * 100.0,
+            s.live_uncompressed,
+            s.logical_uncompressed,
+        );
+    }
     Ok(())
 }

--- a/encodings/fsst/src/fsstview/tests.rs
+++ b/encodings/fsst/src/fsstview/tests.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use rstest::rstest;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::VarBinArray;
+use vortex_array::arrays::VarBinViewArray;
+use vortex_array::assert_arrays_eq;
+use vortex_array::compute::conformance::consistency::test_array_consistency;
+use vortex_array::compute::conformance::filter::test_filter_conformance;
+use vortex_array::compute::conformance::take::test_take_conformance;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::Nullability;
+use vortex_error::VortexResult;
+use vortex_mask::Mask;
+
+use crate::FSSTView;
+use crate::FSSTViewArray;
+use crate::fsst_compress;
+use crate::fsst_train_compressor;
+use crate::fsstview_from_fsst;
+
+fn make_fsstview(
+    strings: &[Option<&str>],
+    nullability: Nullability,
+    ctx: &mut ExecutionCtx,
+) -> FSSTViewArray {
+    let varbin = VarBinArray::from_iter(strings.iter().copied(), DType::Utf8(nullability));
+    let compressor = fsst_train_compressor(&varbin);
+    let fsst = fsst_compress(&varbin, varbin.len(), varbin.dtype(), &compressor, ctx);
+    fsstview_from_fsst(&fsst, ctx).expect("fsstview_from_fsst")
+}
+
+const SAMPLE: [Option<&str>; 6] = [
+    Some("hello world"),
+    Some("testing fsst compression"),
+    Some("hello world"),
+    Some("another string here"),
+    Some("the quick brown fox"),
+    Some("hello world"),
+];
+
+const SAMPLE_NULLABLE: [Option<&str>; 6] = [
+    Some("hello world"),
+    None,
+    Some("testing fsst compression"),
+    Some("another string here"),
+    None,
+    Some("the quick brown fox"),
+];
+
+#[test]
+fn canonicalizes_to_same_values() -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let view = make_fsstview(&SAMPLE, Nullability::NonNullable, &mut ctx);
+    let array = view.into_array();
+    assert!(array.is::<FSSTView>());
+
+    let canonical = array.execute::<VarBinViewArray>(&mut ctx)?;
+    let expected = VarBinArray::from_iter(
+        SAMPLE.iter().copied(),
+        DType::Utf8(Nullability::NonNullable),
+    )
+    .into_array()
+    .execute::<VarBinViewArray>(&mut ctx)?;
+    assert_arrays_eq!(canonical.into_array(), expected.into_array());
+    Ok(())
+}
+
+#[test]
+fn filter_matches_canonical() -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let view = make_fsstview(&SAMPLE_NULLABLE, Nullability::Nullable, &mut ctx);
+
+    let mask = Mask::from_iter([true, false, true, false, true, true]);
+
+    // The filtered FSSTView reuses the original byte heap untouched.
+    let filtered = view.into_array().filter(mask.clone())?;
+    let result = filtered.execute::<VarBinViewArray>(&mut ctx)?;
+
+    let expected = VarBinArray::from_iter(
+        SAMPLE_NULLABLE.iter().copied(),
+        DType::Utf8(Nullability::Nullable),
+    )
+    .into_array()
+    .filter(mask)?
+    .execute::<VarBinViewArray>(&mut ctx)?;
+
+    assert_arrays_eq!(result.into_array(), expected.into_array());
+    Ok(())
+}
+
+#[test]
+fn take_matches_canonical() -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let view = make_fsstview(&SAMPLE, Nullability::NonNullable, &mut ctx);
+
+    // Reorders and duplicates, which is fine for offsets+sizes addressing.
+    let indices = vortex_array::arrays::PrimitiveArray::from_iter([5u64, 0, 0, 3, 1]).into_array();
+
+    let taken = view.into_array().take(indices.clone())?;
+    let result = taken.execute::<VarBinViewArray>(&mut ctx)?;
+
+    let expected = VarBinArray::from_iter(
+        SAMPLE.iter().copied(),
+        DType::Utf8(Nullability::NonNullable),
+    )
+    .into_array()
+    .take(indices)?
+    .execute::<VarBinViewArray>(&mut ctx)?;
+
+    assert_arrays_eq!(result.into_array(), expected.into_array());
+    Ok(())
+}
+
+#[test]
+fn slice_matches_canonical() -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let view = make_fsstview(&SAMPLE, Nullability::NonNullable, &mut ctx);
+
+    let sliced = view.into_array().slice(1..4)?;
+    let result = sliced.execute::<VarBinViewArray>(&mut ctx)?;
+
+    let expected = VarBinArray::from_iter(
+        SAMPLE.iter().copied(),
+        DType::Utf8(Nullability::NonNullable),
+    )
+    .into_array()
+    .slice(1..4)?
+    .execute::<VarBinViewArray>(&mut ctx)?;
+
+    assert_arrays_eq!(result.into_array(), expected.into_array());
+    Ok(())
+}
+
+#[test]
+fn scalar_at_decodes_each_element() -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let view = make_fsstview(&SAMPLE, Nullability::NonNullable, &mut ctx);
+    let array = view.into_array();
+
+    for (i, expected) in SAMPLE.iter().enumerate() {
+        let scalar = array.execute_scalar(i, &mut ctx)?;
+        let value = scalar.as_utf8().value().expect("non-null");
+        assert_eq!(value.as_str(), expected.unwrap());
+    }
+    Ok(())
+}
+
+#[rstest]
+#[case(&SAMPLE, Nullability::NonNullable)]
+#[case(&SAMPLE_NULLABLE, Nullability::Nullable)]
+fn filter_conformance(#[case] strings: &[Option<&str>], #[case] nullability: Nullability) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let view = make_fsstview(strings, nullability, &mut ctx);
+    test_filter_conformance(&view.into_array());
+}
+
+#[rstest]
+#[case(&SAMPLE, Nullability::NonNullable)]
+#[case(&SAMPLE_NULLABLE, Nullability::Nullable)]
+fn take_conformance(#[case] strings: &[Option<&str>], #[case] nullability: Nullability) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let view = make_fsstview(strings, nullability, &mut ctx);
+    test_take_conformance(&view.into_array());
+}
+
+#[rstest]
+#[case(&SAMPLE, Nullability::NonNullable)]
+#[case(&SAMPLE_NULLABLE, Nullability::Nullable)]
+fn consistency(#[case] strings: &[Option<&str>], #[case] nullability: Nullability) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let view = make_fsstview(strings, nullability, &mut ctx);
+    test_array_consistency(&view.into_array());
+}

--- a/encodings/fsst/src/fsstview/tests.rs
+++ b/encodings/fsst/src/fsstview/tests.rs
@@ -9,6 +9,7 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::VarBinArray;
 use vortex_array::arrays::VarBinViewArray;
+use vortex_array::arrays::dict::TakeExecute;
 use vortex_array::assert_arrays_eq;
 use vortex_array::compute::conformance::consistency::test_array_consistency;
 use vortex_array::compute::conformance::filter::test_filter_conformance;
@@ -235,13 +236,14 @@ fn fsst_take_to_view_matches_canonical() -> VortexResult<()> {
     Ok(())
 }
 
-/// All three explicit compaction strategies must produce identical canonical output, both for a
+/// All explicit compaction strategies must produce identical canonical output, both for a
 /// contiguous (sliced) view and a scattered (taken) one.
 #[rstest]
 #[case(FsstViewCompaction::Auto)]
 #[case(FsstViewCompaction::Direct)]
 #[case(FsstViewCompaction::GatherBulk)]
 #[case(FsstViewCompaction::PerElement)]
+#[case(FsstViewCompaction::RunCoalesce)]
 fn compaction_strategies_agree(#[case] strategy: FsstViewCompaction) -> VortexResult<()> {
     let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let fsst = make_fsst(&SAMPLE, Nullability::NonNullable, &mut ctx);
@@ -268,6 +270,60 @@ fn compaction_strategies_agree(#[case] strategy: FsstViewCompaction) -> VortexRe
     )
     .into_array()
     .execute::<VarBinViewArray>(&mut ctx)?;
+    assert_arrays_eq!(got, expected.into_array());
+    Ok(())
+}
+
+/// Adversarial coverage for `RunCoalesce`: a filter that punches gaps into the heap (so survivors
+/// form multiple runs), then a shuffle take (reorders runs), over nullable data. Every strategy
+/// must still agree with the canonical VarBin result.
+#[rstest]
+#[case(FsstViewCompaction::Auto)]
+#[case(FsstViewCompaction::GatherBulk)]
+#[case(FsstViewCompaction::RunCoalesce)]
+#[case(FsstViewCompaction::PerElement)]
+fn run_coalesce_gaps_and_shuffle(#[case] strategy: FsstViewCompaction) -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    // 12 distinct-ish strings, nullable.
+    let strings: Vec<Option<&str>> = vec![
+        Some("alpha"),
+        None,
+        Some("bravo bravo"),
+        Some("charlie"),
+        Some("delta delta delta"),
+        None,
+        Some("echo"),
+        Some("foxtrot foxtrot"),
+        Some("golf"),
+        Some("hotel hotel hotel"),
+        None,
+        Some("india"),
+    ];
+    let fsst = make_fsst(&strings, Nullability::Nullable, &mut ctx);
+
+    // Filter to keep a gapped subset (drops 1,2,5,8,10 -> remaining survivors aren't all adjacent).
+    let keep = [
+        true, false, false, true, true, false, true, true, false, true, false, true,
+    ];
+    let mask = Mask::from_iter(keep);
+    let filtered = fsst_filter_to_view(&fsst, &mask, &mut ctx)?;
+
+    // Then a shuffle+dup take over the filtered length (7 survivors).
+    let indices = PrimitiveArray::from_iter([6u64, 0, 3, 3, 5, 1, 2, 4]).into_array();
+    let view = <FSSTView as TakeExecute>::take(filtered.as_view(), &indices, &mut ctx)?
+        .unwrap()
+        .try_downcast::<FSSTView>()
+        .ok()
+        .unwrap();
+
+    let got = canonicalize_fsstview_with(view.as_view(), strategy, &mut ctx)?;
+
+    let expected =
+        VarBinArray::from_iter(strings.iter().copied(), DType::Utf8(Nullability::Nullable))
+            .into_array()
+            .filter(mask)?
+            .take(indices)?
+            .execute::<VarBinViewArray>(&mut ctx)?;
     assert_arrays_eq!(got, expected.into_array());
     Ok(())
 }

--- a/encodings/fsst/src/fsstview/tests.rs
+++ b/encodings/fsst/src/fsstview/tests.rs
@@ -6,6 +6,7 @@ use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::LEGACY_SESSION;
 use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::VarBinArray;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::assert_arrays_eq;
@@ -17,9 +18,14 @@ use vortex_array::dtype::Nullability;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::FSSTArray;
 use crate::FSSTView;
 use crate::FSSTViewArray;
+use crate::FsstViewCompaction;
+use crate::canonicalize_fsstview_with;
 use crate::fsst_compress;
+use crate::fsst_filter_to_view;
+use crate::fsst_take_to_view;
 use crate::fsst_train_compressor;
 use crate::fsstview_from_fsst;
 
@@ -99,7 +105,7 @@ fn take_matches_canonical() -> VortexResult<()> {
     let view = make_fsstview(&SAMPLE, Nullability::NonNullable, &mut ctx);
 
     // Reorders and duplicates, which is fine for offsets+sizes addressing.
-    let indices = vortex_array::arrays::PrimitiveArray::from_iter([5u64, 0, 0, 3, 1]).into_array();
+    let indices = PrimitiveArray::from_iter([5u64, 0, 0, 3, 1]).into_array();
 
     let taken = view.into_array().take(indices.clone())?;
     let result = taken.execute::<VarBinViewArray>(&mut ctx)?;
@@ -175,4 +181,93 @@ fn consistency(#[case] strings: &[Option<&str>], #[case] nullability: Nullabilit
     let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let view = make_fsstview(strings, nullability, &mut ctx);
     test_array_consistency(&view.into_array());
+}
+
+fn make_fsst(
+    strings: &[Option<&str>],
+    nullability: Nullability,
+    ctx: &mut ExecutionCtx,
+) -> FSSTArray {
+    let varbin = VarBinArray::from_iter(strings.iter().copied(), DType::Utf8(nullability));
+    let compressor = fsst_train_compressor(&varbin);
+    fsst_compress(&varbin, varbin.len(), varbin.dtype(), &compressor, ctx)
+}
+
+/// `fsst_filter_to_view` must agree with filtering the canonical VarBin, and must not touch the
+/// codes bytes (the produced view shares the original heap).
+#[test]
+fn fsst_filter_to_view_matches_canonical() -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let fsst = make_fsst(&SAMPLE_NULLABLE, Nullability::Nullable, &mut ctx);
+    let mask = Mask::from_iter([true, false, true, false, true, true]);
+
+    let view = fsst_filter_to_view(&fsst, &mask, &mut ctx)?;
+    let result = view.into_array().execute::<VarBinViewArray>(&mut ctx)?;
+
+    let expected = VarBinArray::from_iter(
+        SAMPLE_NULLABLE.iter().copied(),
+        DType::Utf8(Nullability::Nullable),
+    )
+    .into_array()
+    .filter(mask)?
+    .execute::<VarBinViewArray>(&mut ctx)?;
+    assert_arrays_eq!(result.into_array(), expected.into_array());
+    Ok(())
+}
+
+#[test]
+fn fsst_take_to_view_matches_canonical() -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let fsst = make_fsst(&SAMPLE, Nullability::NonNullable, &mut ctx);
+    let indices = PrimitiveArray::from_iter([5u64, 0, 0, 3, 1]).into_array();
+
+    let view = fsst_take_to_view(&fsst, &indices, &mut ctx)?;
+    let result = view.into_array().execute::<VarBinViewArray>(&mut ctx)?;
+
+    let expected = VarBinArray::from_iter(
+        SAMPLE.iter().copied(),
+        DType::Utf8(Nullability::NonNullable),
+    )
+    .into_array()
+    .take(indices)?
+    .execute::<VarBinViewArray>(&mut ctx)?;
+    assert_arrays_eq!(result.into_array(), expected.into_array());
+    Ok(())
+}
+
+/// All three explicit compaction strategies must produce identical canonical output, both for a
+/// contiguous (sliced) view and a scattered (taken) one.
+#[rstest]
+#[case(FsstViewCompaction::Auto)]
+#[case(FsstViewCompaction::Direct)]
+#[case(FsstViewCompaction::GatherBulk)]
+#[case(FsstViewCompaction::PerElement)]
+fn compaction_strategies_agree(#[case] strategy: FsstViewCompaction) -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let fsst = make_fsst(&SAMPLE, Nullability::NonNullable, &mut ctx);
+
+    // Scattered view via a take (reorders + duplicates -> non-contiguous codes).
+    let indices = PrimitiveArray::from_iter([5u64, 0, 0, 3, 1, 2]).into_array();
+    let scattered = fsst_take_to_view(&fsst, &indices, &mut ctx)?;
+    let got = canonicalize_fsstview_with(scattered.as_view(), strategy, &mut ctx)?;
+    let expected = VarBinArray::from_iter(
+        SAMPLE.iter().copied(),
+        DType::Utf8(Nullability::NonNullable),
+    )
+    .into_array()
+    .take(indices)?
+    .execute::<VarBinViewArray>(&mut ctx)?;
+    assert_arrays_eq!(got, expected.into_array());
+
+    // Contiguous view (untouched) — exercises the Direct fast path.
+    let contiguous = fsstview_from_fsst(&fsst, &mut ctx)?;
+    let got = canonicalize_fsstview_with(contiguous.as_view(), strategy, &mut ctx)?;
+    let expected = VarBinArray::from_iter(
+        SAMPLE.iter().copied(),
+        DType::Utf8(Nullability::NonNullable),
+    )
+    .into_array()
+    .execute::<VarBinViewArray>(&mut ctx)?;
+    assert_arrays_eq!(got, expected.into_array());
+    Ok(())
 }

--- a/encodings/fsst/src/lib.rs
+++ b/encodings/fsst/src/lib.rs
@@ -16,6 +16,7 @@ mod canonical;
 mod compress;
 mod compute;
 mod dfa;
+mod fsstview;
 mod kernel;
 mod ops;
 mod rules;
@@ -27,3 +28,4 @@ mod tests;
 
 pub use array::*;
 pub use compress::*;
+pub use fsstview::*;

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -115,6 +115,7 @@ use vortex_array::arrays::patched::use_experimental_patches;
 use vortex_array::session::ArraySessionExt;
 use vortex_bytebool::ByteBool;
 use vortex_fsst::FSST;
+use vortex_fsst::FSSTView;
 use vortex_pco::Pco;
 use vortex_session::VortexSession;
 use vortex_zigzag::ZigZag;
@@ -162,6 +163,7 @@ pub fn register_default_encodings(session: &VortexSession) {
         arrays.register(ByteBool);
         arrays.register(Dict);
         arrays.register(FSST);
+        arrays.register(FSSTView);
         arrays.register(Pco);
         arrays.register(ZigZag);
         #[cfg(feature = "zstd")]


### PR DESCRIPTION
FSSTView addresses its FSST-compressed codes with separate `offsets` and
`sizes` arrays (like ListView) instead of FSST's single monotonic offsets
array (like List/VarBin). Decoupling start from length means offsets need
not be monotonic or contiguous, so filter/take/slice become metadata-only:
they rewrite only the small offsets/sizes/lengths/validity arrays and reuse
the compressed byte heap and symbol table untouched.

This avoids the heap rewrite that plain FSST incurs on filter/take (which
delegate to VarBin), giving the same speed win ListView has over List.

- New `vortex.fsstview` encoding in the fsst crate, reusing FSSTData for the
  symbol table + compressed byte heap. Children are declared with the
  `#[array_slots(FSSTView)]` proc macro (uncompressed_lengths, codes_offsets,
  codes_sizes, codes_validity).
- Metadata-only FilterKernel, TakeExecute, and SliceReduce.
- scalar_at decodes a single element via its offset+size slice.
- Canonicalization gathers the live codes (possibly out-of-order) and
  bulk-decompresses into a VarBinView.
- `fsstview_from_fsst` zero-copy conversion from an FSST array.
- Registered in `register_default_encodings`.
- Tests: canonical/filter/take/slice equivalence vs FSST, scalar_at, and
  filter/take/consistency conformance for nullable and non-nullable data.

Signed-off-by: Joe Isaacs <joe.isaacs@live.co.uk>