### PR TITLE
Skip empty chunks when aggregating over chunked arrays

### DIFF
--- a/vortex-array/src/aggregate_fn/fns/min_max/bool.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/bool.rs
@@ -19,10 +19,6 @@ pub(super) fn accumulate_bool(
     array: &BoolArray,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()> {
-    if array.is_empty() {
-        return Ok(());
-    }
-
     let mask = array
         .as_ref()
         .validity()?

--- a/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
@@ -660,6 +660,35 @@ mod tests {
         Ok(())
     }
 
+    /// Regression test for <https://github.com/vortex-data/vortex/issues/8145>.
+    ///
+    /// A chunked array whose first chunk is an *empty* constant array — as produced by
+    /// `fill_null` on an empty all-null chunk — returned `max = u32::MAX` because
+    /// `ChunkedArrayAggregate` accumulated the empty chunk, folding its fill scalar into the
+    /// running min/max. Empty chunks are now skipped during chunked aggregation.
+    #[test]
+    fn test_chunked_with_empty_constant_chunk() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+
+        let empty = ConstantArray::new(Scalar::primitive(u32::MAX, Nullability::NonNullable), 0)
+            .into_array();
+        let chunk1 = PrimitiveArray::new(buffer![7631471u32], Validity::NonNullable).into_array();
+        let chunk2 = PrimitiveArray::new(buffer![0u32], Validity::NonNullable).into_array();
+        let chunked = ChunkedArray::try_new(
+            vec![empty, chunk1, chunk2],
+            DType::Primitive(PType::U32, Nullability::NonNullable),
+        )?;
+
+        assert_eq!(
+            min_max(&chunked.into_array(), &mut ctx)?,
+            Some(MinMaxResult {
+                min: Scalar::primitive(0u32, Nullability::NonNullable),
+                max: Scalar::primitive(7631471u32, Nullability::NonNullable),
+            })
+        );
+        Ok(())
+    }
+
     #[test]
     fn test_varbin_all_nulls() -> VortexResult<()> {
         let array = VarBinArray::from_iter(

--- a/vortex-array/src/arrays/chunked/compute/aggregate.rs
+++ b/vortex-array/src/arrays/chunked/compute/aggregate.rs
@@ -26,7 +26,8 @@ impl DynAggregateKernel for ChunkedArrayAggregate {
         };
 
         let mut acc = aggregate_fn.accumulator(chunked.dtype())?;
-        for chunk in chunked.iter_chunks() {
+        // Skip empty chunks: they contribute no elements.
+        for chunk in chunked.non_empty_chunks() {
             acc.accumulate(chunk, ctx)?;
         }
         // Return the partial (not finalized) result, since the outer accumulator


### PR DESCRIPTION
This was previously special cased for bool but it applies to all chunked array
types

this covers #8145 
