### PR TITLE
Fix unsound Delta unsigned-widening cast

### DIFF
--- a/encodings/fastlanes/src/delta/compute/cast.rs
+++ b/encodings/fastlanes/src/delta/compute/cast.rs
@@ -15,31 +15,22 @@ use crate::delta::array::DeltaArrayExt;
 
 impl CastReduce for Delta {
     fn cast(array: ArrayView<'_, Self>, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
-        let DType::Primitive(target_ptype, _) = dtype else {
+        let DType::Primitive(target_ptype, target_nullability) = dtype else {
             return Ok(None);
         };
 
-        let source_ptype = array.dtype().as_ptype();
-        // TODO(DK): narrows can be safe but we must decompress to compute the maximum value.
-        if target_ptype.is_signed_int() || source_ptype.bit_width() > target_ptype.bit_width() {
+        // Only a nullability change at the same primitive type can reuse the encoded
+        // components; everything else defers to the generic decompress path.
+        if array.dtype().as_ptype() != *target_ptype {
             return Ok(None);
         }
-        // Signed sources need a different cast policy than the lossless widening cast
-        // used here. The delta bytes are stored as the result of `wrapping_sub`, so e.g.
-        // a delta of -1i8 has the bit pattern 0xFF. Widening *as a value* (the cast op's
-        // semantics) sign-extends that to 0xFFFFFFFF, which means `wrapping_add(base, delta)`
-        // at the wider type produces a different result than at the source type — round-trip
-        // breaks. Cross-signedness widening has the same hazard for the same reason. Fall
-        // back to decompress-and-re-encode for both cases.
-        if source_ptype.is_signed_int() {
+        if *target_nullability == NonNullable && array.dtype().nullability() != NonNullable {
             return Ok(None);
         }
 
-        // Cast both bases and deltas to the target type
         let casted_bases = array.bases().cast(dtype.with_nullability(NonNullable))?;
         let casted_deltas = array.deltas().cast(dtype.clone())?;
 
-        // Create a new DeltaArray with the casted components, preserving offset and logical length
         Ok(Some(
             Delta::try_new(casted_bases, casted_deltas, array.offset(), array.len())?.into_array(),
         ))
@@ -62,11 +53,114 @@ mod tests {
     use vortex_array::dtype::PType;
     use vortex_array::session::ArraySession;
     use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
     use vortex_session::VortexSession;
 
     use crate::Delta;
     static SESSION: LazyLock<VortexSession> =
         LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+
+    #[test]
+    fn test_cast_delta_unsigned_widening_wraps() {
+        // A valid non-monotonic unsigned sequence whose deltas wrap at the source width.
+        // 200u8 -> 50u8 stores delta 0x6A (106); decode does 200 wrapping_add 106 = 306
+        // mod 256 = 50. Widening the delta to u32 preserves the value 106 but changes the
+        // reconstruction modulus to 2^32, so 200 + 106 = 306 instead of 50. Every index
+        // after a wrap is corrupted, so the widening cast must not reuse the components.
+        let primitive = PrimitiveArray::from_iter([200u8, 50, 75, 10, 255]);
+        let array =
+            Delta::try_from_primitive_array(&primitive, &mut SESSION.create_execution_ctx())
+                .unwrap();
+
+        let casted = array
+            .into_array()
+            .cast(DType::Primitive(PType::U32, Nullability::NonNullable))
+            .unwrap();
+
+        assert_arrays_eq!(casted, PrimitiveArray::from_iter([200u32, 50, 75, 10, 255]));
+    }
+
+    #[test]
+    fn test_cast_delta_same_width_float_target() {
+        // u32 and f32 share a bit width but are not interchangeable: the fast path must not
+        // reuse the integer components for a float target (that would error in `try_new`).
+        // The cast must succeed via the decompress-and-re-encode fallback.
+        let primitive = PrimitiveArray::from_iter([10u32, 20, 30, 40, 50]);
+        let array =
+            Delta::try_from_primitive_array(&primitive, &mut SESSION.create_execution_ctx())
+                .unwrap();
+
+        let casted = array
+            .into_array()
+            .cast(DType::Primitive(PType::F32, Nullability::NonNullable))
+            .unwrap();
+
+        assert_arrays_eq!(
+            casted,
+            PrimitiveArray::from_iter([10f32, 20.0, 30.0, 40.0, 50.0])
+        );
+    }
+
+    #[test]
+    fn test_cast_delta_add_nullability() -> VortexResult<()> {
+        // Same ptype, only adding nullability — handled by the kernel without decompressing.
+        let values = PrimitiveArray::from_iter([10u32, 20, 5, 30, 15]);
+        let array = Delta::try_from_primitive_array(&values, &mut SESSION.create_execution_ctx())?;
+
+        let casted = array
+            .into_array()
+            .cast(DType::Primitive(PType::U32, Nullability::Nullable))?;
+
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::U32, Nullability::Nullable)
+        );
+        assert_arrays_eq!(
+            casted,
+            PrimitiveArray::from_option_iter([Some(10u32), Some(20), Some(5), Some(30), Some(15)])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_delta_nullability_preserves_nulls() -> VortexResult<()> {
+        // A nullable Delta array carries its validity in the deltas child; a same-ptype
+        // nullability cast must round-trip the null positions.
+        let values =
+            PrimitiveArray::from_option_iter([Some(10u32), None, Some(30), Some(15), None]);
+        let array = Delta::try_from_primitive_array(&values, &mut SESSION.create_execution_ctx())?;
+
+        let casted = array
+            .into_array()
+            .cast(DType::Primitive(PType::U32, Nullability::Nullable))?;
+
+        assert_arrays_eq!(
+            casted,
+            PrimitiveArray::from_option_iter([Some(10u32), None, Some(30), Some(15), None])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_delta_drop_nullability_with_nulls_errors() -> VortexResult<()> {
+        // Dropping nullability when real nulls are present must error, matching the generic
+        // cast semantics rather than silently discarding the null mask.
+        let values = PrimitiveArray::from_option_iter([Some(10u32), None, Some(30)]);
+        let array = Delta::try_from_primitive_array(&values, &mut SESSION.create_execution_ctx())?;
+
+        // The cast is lazy; the nullability check fires when it is executed.
+        #[expect(deprecated)]
+        let result = array
+            .into_array()
+            .cast(DType::Primitive(PType::U32, Nullability::NonNullable))
+            .and_then(|a| a.to_canonical().map(|c| c.into_array()));
+
+        assert!(
+            result.is_err(),
+            "dropping nullability with real nulls must error, got {result:?}"
+        );
+        Ok(())
+    }
 
     #[test]
     fn test_cast_delta_u8_to_u32() {
@@ -90,8 +184,7 @@ mod tests {
 
     #[test]
     fn test_cast_delta_nullable() {
-        // DeltaArray doesn't support nullable arrays - the validity is handled at the DeltaArray level
-        // Create a non-nullable array and then add validity to the DeltaArray
+        // A combined ptype + nullability change goes through the generic decompress path.
         let values = PrimitiveArray::new(
             buffer![100u16, 0, 200, 300, 0],
             vortex_array::validity::Validity::NonNullable,


### PR DESCRIPTION
Fixes #8193.

## Problem

The Delta cast kernel reused the encoded `bases`/`deltas` across primitive-type changes, which is unsound. Delta stores deltas as `wrapping_sub` at the **source** bit width and decodes with `wrapping_add` at the **array's** bit width, so widening corrupted every value after a delta that wrapped at the source width:

```
[200u8, 50, 75, 10, 255] -> cast u32 -> [200, 306, 331, 522, 767]   (expected [200, 50, 75, 10, 255])
```

Two further latent bugs in the same kernel:
- `u32 -> f32` passed the guard, entered the reuse path, then **errored** in `Delta::try_new` (float dtype) instead of falling back.
- Casting a nullable Delta to non-nullable at the same ptype eagerly rebuilt a non-nullable DeltaArray, **silently discarding real nulls**.

## Fix

Reuse the encoded components only for a **nullability change at the same primitive type** (adding/keeping nullability, where validity lives in the deltas child). Every ptype change, and dropping nullability, defers to the generic decompress-and-re-encode path, which decodes correctly and validates nulls.

Nothing more is recoverable from metadata: widening would need a wrap/monotonicity flag (value range is insufficient — `[0,200]` and `[200,0]` share min/max but only one is safe to widen); narrowing/signedness need the value range, which can't be derived from the components.

## Tests

- `test_cast_delta_unsigned_widening_wraps` — widening corruption regression.
- `test_cast_delta_same_width_float_target` — `u32 -> f32` falls back instead of erroring.
- `test_cast_delta_add_nullability` — same-ptype add-nullability fast path.
- `test_cast_delta_nullability_preserves_nulls` — null positions round-trip.
- `test_cast_delta_drop_nullability_with_nulls_errors` — dropping nullability with real nulls errors.
- existing `test_cast_delta_conformance`, `test_cast_delta_u8_to_u32`, `test_cast_delta_nullable`.

## Checks

- `cargo test -p vortex-fastlanes` — 291 + 3 doctests pass (`delta::compute::cast` 11/11).
- `cargo clippy -p vortex-fastlanes --all-targets --all-features` — clean.
- `cargo +nightly fmt -p vortex-fastlanes -- --check` — clean.

Rebased onto the latest `develop` and squashed to a single commit.