### PR TITLE
Document why the Arrow exporter keeps Decimal128 as the default decimal width

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,35 +146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "apache-avro"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36fa98bc79671c7981272d91a8753a928ff6a1cd8e4f20a44c45bd5d313840bf"
-dependencies = [
- "bigdecimal",
- "bon",
- "bzip2",
- "crc32fast",
- "digest 0.10.7",
- "liblzma",
- "log",
- "miniz_oxide",
- "num-bigint",
- "quad-rand",
- "rand 0.9.4",
- "regex-lite",
- "serde",
- "serde_bytes",
- "serde_json",
- "snap",
- "strum 0.27.2",
- "strum_macros 0.27.2",
- "thiserror 2.0.18",
- "uuid",
- "zstd",
-]
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +251,30 @@ dependencies = [
  "num-complex",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-avro"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049230728cd6e093088c8d231b4beede184e35cad7777c1505c0d5a8571f4376"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "bytes",
+ "bzip2",
+ "crc",
+ "flate2",
+ "indexmap 2.14.0",
+ "liblzma",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "snap",
+ "strum_macros 0.28.0",
+ "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -787,7 +782,6 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -899,31 +893,6 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
-]
-
-[[package]]
-name = "bon"
-version = "3.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
-dependencies = [
- "bon-macros",
- "rustversion",
-]
-
-[[package]]
-name = "bon-macros"
-version = "3.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
-dependencies = [
- "darling",
- "ident_case",
- "prettyplease",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1670,6 +1639,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,13 +1956,11 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93db0e623840612f7f2cd757f7e8a8922064192363732c88692e0870016e141b"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "arrow-schema",
  "async-trait",
- "bytes",
  "bzip2",
  "chrono",
  "datafusion-catalog",
@@ -1993,10 +1975,10 @@ dependencies = [
  "datafusion-datasource-parquet",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-expr-common",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-functions",
- "datafusion-functions-aggregate",
- "datafusion-functions-nested",
+ "datafusion-functions-aggregate 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-nested 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-functions-table",
  "datafusion-functions-window",
  "datafusion-optimizer",
@@ -2006,18 +1988,17 @@ dependencies = [
  "datafusion-physical-optimizer",
  "datafusion-physical-plan",
  "datafusion-session",
- "datafusion-sql",
+ "datafusion-sql 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "flate2",
  "futures",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "liblzma",
  "log",
  "object_store 0.13.2",
  "parking_lot",
  "parquet",
- "rand 0.9.4",
- "regex",
- "sqlparser",
+ "sqlparser 0.62.0",
  "tempfile",
  "tokio",
  "url",
@@ -2054,8 +2035,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cefde60b26a7f4ff61e9d2ff2833322f91df2b568d7238afe67bde5bdffb66"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2079,8 +2059,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e112307715d6a7a331111a4c2330ff54bc237183511c319e3708a4cff431fb"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2102,34 +2081,32 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d72a11ca44a95e1081870d3abb80c717496e8a7acb467a1d3e932bb636af5cc2"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
- "ahash 0.8.12",
- "apache-avro",
  "arrow",
  "arrow-ipc",
+ "arrow-schema",
  "chrono",
+ "foldhash 0.2.0",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "libc",
  "log",
  "object_store 0.13.2",
  "parquet",
- "paste",
  "recursive",
- "sqlparser",
+ "sqlparser 0.62.0",
  "tokio",
+ "uuid",
  "web-time",
 ]
 
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f4afaed29670ec4fd6053643adc749fe3f4bc9d1ce1b8c5679b22c67d12def"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "futures",
  "log",
@@ -2139,8 +2116,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9fb386e1691355355a96419978a0022b7947b44d4a24a6ea99f00b6b485cbb6"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "async-compression",
@@ -2164,6 +2140,7 @@ dependencies = [
  "liblzma",
  "log",
  "object_store 0.13.2",
+ "parking_lot",
  "rand 0.9.4",
  "tokio",
  "tokio-util",
@@ -2174,8 +2151,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa6c52cfed0734c5f93754d1c0175f558175248bf686c944fb05c373e5fc096"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2198,28 +2174,25 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-avro"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a579c3bd290c66ea4b269493e75e8a3ed42c9c895a651f10210a29538aee50c4"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
- "apache-avro",
  "arrow",
+ "arrow-avro",
  "async-trait",
  "bytes",
  "datafusion-common",
  "datafusion-datasource",
- "datafusion-physical-expr-common",
+ "datafusion-physical-expr-adapter",
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "num-traits",
  "object_store 0.13.2",
 ]
 
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503f29e0582c1fc189578d665ff57d9300da1f80c282777d7eb67bb79fb8cdca"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2241,8 +2214,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33804749abc8d0c8cb7473228483cb8070e524c6f6086ee1b85a64debe2b3d2"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2257,7 +2229,6 @@ dependencies = [
  "datafusion-session",
  "futures",
  "object_store 0.13.2",
- "serde_json",
  "tokio",
  "tokio-stream",
 ]
@@ -2265,8 +2236,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a8e0365e0e08e8ff94d912f0ababcf9065a1a304018ba90b1fc83c855b4997"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2276,7 +2246,8 @@ dependencies = [
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-functions-aggregate-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-physical-expr",
  "datafusion-physical-expr-adapter",
  "datafusion-physical-expr-common",
@@ -2299,15 +2270,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
 
 [[package]]
+name = "datafusion-doc"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+
+[[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03c7fbdaefcca4ef6ffe425a5fc2325763bfb426599bb0bf4536466efabe709"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "arrow-buffer",
  "async-trait",
- "chrono",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
@@ -2324,24 +2298,23 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574b9b6977fedbd2a611cbff12e5caf90f31640ad9dc5870f152836d94bad0dd"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
- "datafusion-doc",
- "datafusion-expr-common",
- "datafusion-functions-aggregate-common",
+ "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
  "indexmap 2.14.0",
  "itertools 0.14.0",
- "paste",
  "recursive",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.62.0",
 ]
 
 [[package]]
@@ -2358,10 +2331,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-expr-common"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+]
+
+[[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28aa4e10384e782774b10e72aca4d93ef7b31aa653095d9d4536b0a3dbc51b6"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2371,21 +2354,21 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "datafusion-common",
- "datafusion-doc",
+ "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-macros",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common",
  "hex",
  "itertools 0.14.0",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "memchr",
  "num-traits",
  "rand 0.9.4",
  "regex",
- "sha2 0.10.9",
- "unicode-segmentation",
+ "sha2 0.11.0",
  "uuid",
 ]
 
@@ -2398,17 +2381,37 @@ dependencies = [
  "ahash 0.8.12",
  "arrow",
  "datafusion-common",
- "datafusion-doc",
+ "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-functions-aggregate-common",
- "datafusion-macros",
+ "datafusion-functions-aggregate-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-macros 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "half",
  "log",
  "num-traits",
  "paste",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "foldhash 0.2.0",
+ "half",
+ "log",
+ "num-traits",
 ]
 
 [[package]]
@@ -2420,7 +2423,18 @@ dependencies = [
  "ahash 0.8.12",
  "arrow",
  "datafusion-common",
- "datafusion-expr-common",
+ "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate-common"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-physical-expr-common",
 ]
 
@@ -2433,14 +2447,14 @@ dependencies = [
  "arrow",
  "arrow-ord",
  "datafusion-common",
- "datafusion-doc",
+ "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-expr-common",
+ "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "datafusion-functions",
- "datafusion-functions-aggregate",
- "datafusion-functions-aggregate-common",
- "datafusion-macros",
+ "datafusion-functions-aggregate 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-macros 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "datafusion-physical-expr-common",
  "hashbrown 0.16.1",
  "itertools 0.14.0",
@@ -2450,44 +2464,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-functions-nested"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+dependencies = [
+ "arrow",
+ "arrow-ord",
+ "datafusion-common",
+ "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions",
+ "datafusion-functions-aggregate 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
+ "itoa",
+ "log",
+ "memchr",
+]
+
+[[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b40d3f5bbb3905f9ccb1ce9485a9595c77b69758a7c24d3ba79e334ff51e7e"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-physical-expr",
  "datafusion-physical-plan",
  "parking_lot",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e88ec9d57c9b685d02f58bfee7be62d72610430ddcedb82a08e5d9925dbfb6"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "datafusion-common",
- "datafusion-doc",
+ "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-expr",
  "datafusion-functions-window-common",
- "datafusion-macros",
+ "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8307bb93519b1a91913723a1130cfafeee3f72200d870d88e91a6fc5470ede5c"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2499,7 +2533,17 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
 dependencies = [
- "datafusion-doc",
+ "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "datafusion-macros"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+dependencies = [
+ "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "quote",
  "syn 2.0.117",
 ]
@@ -2507,14 +2551,13 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e929015451a67f77d9d8b727b2bf3a40c4445fdef6cdc53281d7d97c76888ace"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
- "datafusion-expr-common",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-physical-expr",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -2527,22 +2570,19 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b1e68aba7a4b350401cfdf25a3d6f989ad898a7410164afe9ca52080244cb59"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
- "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-functions-aggregate-common",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-physical-expr-common",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
- "paste",
  "petgraph",
  "recursive",
  "tokio",
@@ -2551,8 +2591,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea22315f33cf2e0adc104e8ec42e285f6ed93998d565c65e82fec6a9ee9f9db4"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2566,31 +2605,29 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04b45ea8ad3ac2d78f2ea2a76053e06591c9629c7a603eda16c10649ecf4362"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
- "ahash 0.8.12",
  "arrow",
  "chrono",
  "datafusion-common",
- "datafusion-expr-common",
- "hashbrown 0.16.1",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
+ "pin-project",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb13397809a425918f608dfe8653f332015a3e330004ab191b4404187238b95"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-expr-common",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
@@ -2602,11 +2639,11 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edc023675791af9d5fb4cc4c24abf5f7bd3bd4dcf9e5bd90ea1eff6976dcc79"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
- "ahash 0.8.12",
  "arrow",
+ "arrow-data",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-schema",
  "async-trait",
@@ -2615,13 +2652,13 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions",
- "datafusion-functions-aggregate-common",
+ "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-functions-window-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "futures",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
@@ -2634,25 +2671,22 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8c76860e355616555081cab5968cec1af7a80701ff374510860bcd567e365a"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "datafusion-common",
  "datafusion-datasource",
- "datafusion-expr-common",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "itertools 0.14.0",
  "log",
 ]
 
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5412111aa48e2424ba926112e192f7a6b7e4ccb450145d25ce5ede9f19dc491e"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2665,8 +2699,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e059dcf8544da0d6598d0235be3cc29c209094a5976b2e4822e4a2cf91c2b5c5"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2678,14 +2711,17 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions",
- "datafusion-functions-aggregate",
- "datafusion-functions-nested",
+ "datafusion-functions-aggregate 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-nested 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "log",
+ "num-traits",
  "percent-encoding",
  "rand 0.9.4",
  "serde_json",
- "sha1 0.10.6",
- "sha2 0.10.9",
+ "sha1",
+ "sha2 0.11.0",
+ "twox-hash",
  "url",
 ]
 
@@ -2700,19 +2736,35 @@ dependencies = [
  "chrono",
  "datafusion-common",
  "datafusion-expr",
- "datafusion-functions-nested",
+ "datafusion-functions-nested 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 2.14.0",
+ "log",
+ "regex",
+ "sqlparser 0.61.0",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+dependencies = [
+ "arrow",
+ "bigdecimal",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions-nested 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "indexmap 2.14.0",
  "log",
  "recursive",
  "regex",
- "sqlparser",
+ "sqlparser 0.62.0",
 ]
 
 [[package]]
 name = "datafusion-sqllogictest"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e5a4a7a49143a68936992b6dbb0db44121c635e9992b2482817278f1e69c56"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2720,7 +2772,6 @@ dependencies = [
  "clap",
  "datafusion",
  "datafusion-spark",
- "datafusion-substrait",
  "futures",
  "half",
  "indicatif",
@@ -2728,30 +2779,10 @@ dependencies = [
  "log",
  "object_store 0.13.2",
  "sqllogictest",
- "sqlparser",
+ "sqlparser 0.62.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
-]
-
-[[package]]
-name = "datafusion-substrait"
-version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98494539a5468979cc42d86c7bc5f0f8cb71ee5c742694c26fc34efdd29dd2e5"
-dependencies = [
- "async-recursion",
- "async-trait",
- "chrono",
- "datafusion",
- "half",
- "itertools 0.14.0",
- "object_store 0.13.2",
- "pbjson-types",
- "prost 0.14.3",
- "substrait",
- "tokio",
- "url",
 ]
 
 [[package]]
@@ -4429,7 +4460,7 @@ dependencies = [
  "bytes",
  "chrono",
  "datafusion-common",
- "datafusion-sql",
+ "datafusion-sql 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deepsize",
  "futures",
  "itertools 0.13.0",
@@ -4604,7 +4635,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr",
- "datafusion-sql",
+ "datafusion-sql 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deepsize",
  "dirs",
  "fst",
@@ -5205,6 +5236,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5511,7 +5552,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -5682,7 +5722,7 @@ dependencies = [
  "humantime",
  "hyper",
  "itertools 0.14.0",
- "md-5",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
@@ -6002,43 +6042,6 @@ dependencies = [
  "serde_derive",
  "std_prelude",
  "stfu8",
-]
-
-[[package]]
-name = "pbjson"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898bac3fa00d0ba57a4e8289837e965baa2dee8c3749f3b11d45a64b4223d9c3"
-dependencies = [
- "base64",
- "serde",
-]
-
-[[package]]
-name = "pbjson-build"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af22d08a625a2213a78dbb0ffa253318c5c79ce3133d32d296655a7bdfb02095"
-dependencies = [
- "heck",
- "itertools 0.14.0",
- "prost 0.14.3",
- "prost-types",
-]
-
-[[package]]
-name = "pbjson-types"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e748e28374f10a330ee3bb9f29b828c0ac79831a32bab65015ad9b661ead526"
-dependencies = [
- "bytes",
- "chrono",
- "pbjson",
- "pbjson-build",
- "prost 0.14.3",
- "prost-build",
- "serde",
 ]
 
 [[package]]
@@ -6548,12 +6551,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quad-rand"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
-
-[[package]]
 name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6995,16 +6992,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "regress"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
-dependencies = [
- "hashbrown 0.16.1",
- "memchr",
-]
-
-[[package]]
 name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7385,18 +7372,6 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -7417,18 +7392,6 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -7505,16 +7468,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7528,17 +7481,6 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7599,18 +7541,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_tokenstream"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c49585c52c01f13c5c2ebb333f14f6885d76daa768d8a037d28017ec538c69"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7655,19 +7585,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "serial_test"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7690,17 +7607,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -7934,7 +7840,7 @@ dependencies = [
  "humantime",
  "itertools 0.13.0",
  "libtest-mimic",
- "md-5",
+ "md-5 0.10.6",
  "owo-colors",
  "rand 0.8.6",
  "regex",
@@ -7950,6 +7856,16 @@ name = "sqlparser"
 version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+dependencies = [
+ "log",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
 dependencies = [
  "log",
  "recursive",
@@ -8092,31 +8008,6 @@ checksum = "0a9a86e5144f63c2d18334698269a8bfae6eece345c70b64821ea5b35054ec99"
 dependencies = [
  "memchr",
  "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "substrait"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fc4b483a129b9772ccb9c3f7945a472112fdd9140da87f8a4e7f1d44e045d0"
-dependencies = [
- "heck",
- "pbjson",
- "pbjson-build",
- "pbjson-types",
- "prettyplease",
- "prost 0.14.3",
- "prost-build",
- "prost-types",
- "regress",
- "schemars 0.8.22",
- "semver",
- "serde",
- "serde_json",
- "serde_yaml",
- "syn 2.0.117",
- "typify",
- "walkdir",
 ]
 
 [[package]]
@@ -8824,53 +8715,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
-name = "typify"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5bcc6f62eb1fa8aa4098f39b29f93dcb914e17158b76c50360911257aa629"
-dependencies = [
- "typify-impl",
- "typify-macro",
-]
-
-[[package]]
-name = "typify-impl"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1eb359f7ffa4f9ebe947fa11a1b2da054564502968db5f317b7e37693cb2240"
-dependencies = [
- "heck",
- "log",
- "proc-macro2",
- "quote",
- "regress",
- "schemars 0.8.22",
- "semver",
- "serde",
- "serde_json",
- "syn 2.0.117",
- "thiserror 2.0.18",
- "unicode-ident",
-]
-
-[[package]]
-name = "typify-macro"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911c32f3c8514b048c1b228361bebb5e6d73aeec01696e8cc0e82e2ffef8ab7a"
-dependencies = [
- "proc-macro2",
- "quote",
- "schemars 0.8.22",
- "semver",
- "serde",
- "serde_json",
- "serde_tokenstream",
- "syn 2.0.117",
- "typify-impl",
-]
-
-[[package]]
 name = "uint"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8944,12 +8788,6 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -10958,7 +10796,7 @@ dependencies = [
  "memchr",
  "pbkdf2",
  "ppmd-rust",
- "sha1 0.11.0",
+ "sha1",
  "time",
  "typed-path",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1964,30 +1964,30 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "datafusion-catalog 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-catalog-listing 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-common-runtime 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-datasource 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-datasource-arrow 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-datasource-csv 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-datasource-json 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-aggregate 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-nested 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-table 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-window 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-optimizer 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-adapter 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-optimizer 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-session 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-sql 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-catalog 53.1.0",
+ "datafusion-catalog-listing 53.1.0",
+ "datafusion-common 53.1.0",
+ "datafusion-common-runtime 53.1.0",
+ "datafusion-datasource 53.1.0",
+ "datafusion-datasource-arrow 53.1.0",
+ "datafusion-datasource-csv 53.1.0",
+ "datafusion-datasource-json 53.1.0",
+ "datafusion-execution 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-expr-common 53.1.0",
+ "datafusion-functions 53.1.0",
+ "datafusion-functions-aggregate 53.1.0",
+ "datafusion-functions-nested 53.1.0",
+ "datafusion-functions-table 53.1.0",
+ "datafusion-functions-window 53.1.0",
+ "datafusion-optimizer 53.1.0",
+ "datafusion-physical-expr 53.1.0",
+ "datafusion-physical-expr-adapter 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
+ "datafusion-physical-optimizer 53.1.0",
+ "datafusion-physical-plan 53.1.0",
+ "datafusion-session 53.1.0",
+ "datafusion-sql 53.1.0",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -2004,40 +2004,40 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "arrow-schema",
  "async-trait",
  "bzip2",
  "chrono",
- "datafusion-catalog 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-catalog-listing 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-datasource-arrow 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-catalog 54.0.0",
+ "datafusion-catalog-listing 54.0.0",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-datasource-arrow 54.0.0",
  "datafusion-datasource-avro",
- "datafusion-datasource-csv 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-datasource-json 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-datasource-csv 54.0.0",
+ "datafusion-datasource-json 54.0.0",
  "datafusion-datasource-parquet",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-aggregate 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-nested 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-table 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-window 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-optimizer 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-adapter 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-optimizer 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-sql 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-functions 54.0.0",
+ "datafusion-functions-aggregate 54.0.0",
+ "datafusion-functions-nested 54.0.0",
+ "datafusion-functions-table 54.0.0",
+ "datafusion-functions-window 54.0.0",
+ "datafusion-optimizer 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-adapter 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-optimizer 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-session 54.0.0",
+ "datafusion-sql 54.0.0",
  "flate2",
  "futures",
  "indexmap 2.14.0",
@@ -2062,9 +2062,9 @@ dependencies = [
  "anyhow",
  "clap",
  "custom-labels",
- "datafusion 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion 54.0.0",
+ "datafusion-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
  "futures",
  "itertools 0.14.0",
  "object_store 0.13.2",
@@ -2090,14 +2090,14 @@ dependencies = [
  "arrow",
  "async-trait",
  "dashmap",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-common-runtime 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-datasource 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-session 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-common-runtime 53.1.0",
+ "datafusion-datasource 53.1.0",
+ "datafusion-execution 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-physical-expr 53.1.0",
+ "datafusion-physical-plan 53.1.0",
+ "datafusion-session 53.1.0",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -2108,20 +2108,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "async-trait",
  "dashmap",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-session 54.0.0",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -2138,15 +2138,15 @@ checksum = "17e112307715d6a7a331111a4c2330ff54bc237183511c319e3708a4cff431fb"
 dependencies = [
  "arrow",
  "async-trait",
- "datafusion-catalog 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-datasource 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-adapter 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-catalog 53.1.0",
+ "datafusion-common 53.1.0",
+ "datafusion-datasource 53.1.0",
+ "datafusion-execution 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-physical-expr 53.1.0",
+ "datafusion-physical-expr-adapter 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
+ "datafusion-physical-plan 53.1.0",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -2155,20 +2155,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "async-trait",
- "datafusion-catalog 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-adapter 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-catalog 54.0.0",
+ "datafusion-common 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-adapter 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -2200,8 +2200,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2236,8 +2236,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "futures",
  "log",
@@ -2254,15 +2254,15 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-common-runtime 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-adapter 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-session 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-common-runtime 53.1.0",
+ "datafusion-execution 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-physical-expr 53.1.0",
+ "datafusion-physical-expr-adapter 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
+ "datafusion-physical-plan 53.1.0",
+ "datafusion-session 53.1.0",
  "futures",
  "glob",
  "itertools 0.14.0",
@@ -2275,8 +2275,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "async-compression",
@@ -2284,15 +2284,15 @@ dependencies = [
  "bytes",
  "bzip2",
  "chrono",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-adapter 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-adapter 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-session 54.0.0",
  "flate2",
  "futures",
  "glob",
@@ -2318,14 +2318,14 @@ dependencies = [
  "arrow-ipc",
  "async-trait",
  "bytes",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-common-runtime 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-datasource 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-session 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-common-runtime 53.1.0",
+ "datafusion-datasource 53.1.0",
+ "datafusion-execution 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
+ "datafusion-physical-plan 53.1.0",
+ "datafusion-session 53.1.0",
  "futures",
  "itertools 0.14.0",
  "object_store 0.13.2",
@@ -2334,21 +2334,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "arrow-ipc",
  "async-trait",
  "bytes",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-session 54.0.0",
  "futures",
  "itertools 0.14.0",
  "object_store 0.13.2",
@@ -2357,18 +2357,18 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-avro"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "arrow-avro",
  "async-trait",
  "bytes",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-adapter 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-physical-expr-adapter 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-session 54.0.0",
  "futures",
  "object_store 0.13.2",
 ]
@@ -2382,14 +2382,14 @@ dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-common-runtime 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-datasource 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-session 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-common-runtime 53.1.0",
+ "datafusion-datasource 53.1.0",
+ "datafusion-execution 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
+ "datafusion-physical-plan 53.1.0",
+ "datafusion-session 53.1.0",
  "futures",
  "object_store 0.13.2",
  "regex",
@@ -2398,20 +2398,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-session 54.0.0",
  "futures",
  "object_store 0.13.2",
  "regex",
@@ -2427,14 +2427,14 @@ dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-common-runtime 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-datasource 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-session 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-common-runtime 53.1.0",
+ "datafusion-datasource 53.1.0",
+ "datafusion-execution 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
+ "datafusion-physical-plan 53.1.0",
+ "datafusion-session 53.1.0",
  "futures",
  "object_store 0.13.2",
  "serde_json",
@@ -2444,20 +2444,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-session 54.0.0",
  "futures",
  "object_store 0.13.2",
  "tokio",
@@ -2466,25 +2466,25 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-adapter 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-pruning 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions 54.0.0",
+ "datafusion-functions-aggregate-common 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-adapter 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-pruning 54.0.0",
+ "datafusion-session 54.0.0",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -2502,8 +2502,8 @@ checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
 
 [[package]]
 name = "datafusion-doc"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 
 [[package]]
 name = "datafusion-execution"
@@ -2516,9 +2516,9 @@ dependencies = [
  "async-trait",
  "chrono",
  "dashmap",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
  "futures",
  "log",
  "object_store 0.13.2",
@@ -2530,16 +2530,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-execution"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "arrow-buffer",
  "async-trait",
  "dashmap",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
  "futures",
  "log",
  "object_store 0.13.2",
@@ -2558,12 +2558,12 @@ dependencies = [
  "arrow",
  "async-trait",
  "chrono",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-aggregate-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-window-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-doc 53.1.0",
+ "datafusion-expr-common 53.1.0",
+ "datafusion-functions-aggregate-common 53.1.0",
+ "datafusion-functions-window-common 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "paste",
@@ -2573,19 +2573,19 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "arrow-schema",
  "async-trait",
  "chrono",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-window-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-doc 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-functions-aggregate-common 54.0.0",
+ "datafusion-functions-window-common 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "recursive",
@@ -2600,7 +2600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d7c3adf3db8bf61e92eb90cb659c8e8b734593a8f7c8e12a843c7ddba24b87e"
 dependencies = [
  "arrow",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "paste",
@@ -2608,11 +2608,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
  "indexmap 2.14.0",
  "itertools 0.14.0",
 ]
@@ -2630,12 +2630,12 @@ dependencies = [
  "blake3",
  "chrono",
  "chrono-tz",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-macros 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-doc 53.1.0",
+ "datafusion-execution 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-expr-common 53.1.0",
+ "datafusion-macros 53.1.0",
  "hex",
  "itertools 0.14.0",
  "log",
@@ -2651,8 +2651,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2661,13 +2661,13 @@ dependencies = [
  "blake3",
  "chrono",
  "chrono-tz",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-doc 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-macros 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
  "hex",
  "itertools 0.14.0",
  "log",
@@ -2688,14 +2688,14 @@ checksum = "00aa6217e56098ba84e0a338176fe52f0a84cca398021512c6c8c5eff806d0ad"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-aggregate-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-macros 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-doc 53.1.0",
+ "datafusion-execution 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-functions-aggregate-common 53.1.0",
+ "datafusion-macros 53.1.0",
+ "datafusion-physical-expr 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
  "half",
  "log",
  "num-traits",
@@ -2704,18 +2704,18 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-doc 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions-aggregate-common 54.0.0",
+ "datafusion-macros 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
  "foldhash 0.2.0",
  "half",
  "log",
@@ -2730,20 +2730,20 @@ checksum = "b511250349407db7c43832ab2de63f5557b19a20dfd236b39ca2c04468b50d47"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-expr-common 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
 ]
 
 [[package]]
@@ -2754,16 +2754,16 @@ checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
 dependencies = [
  "arrow",
  "arrow-ord",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-aggregate 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-aggregate-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-macros 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-doc 53.1.0",
+ "datafusion-execution 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-expr-common 53.1.0",
+ "datafusion-functions 53.1.0",
+ "datafusion-functions-aggregate 53.1.0",
+ "datafusion-functions-aggregate-common 53.1.0",
+ "datafusion-macros 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
  "hashbrown 0.16.1",
  "itertools 0.14.0",
  "itoa",
@@ -2773,21 +2773,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "arrow-ord",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-aggregate 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-doc 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-functions 54.0.0",
+ "datafusion-functions-aggregate 54.0.0",
+ "datafusion-functions-aggregate-common 54.0.0",
+ "datafusion-macros 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "itoa",
@@ -2803,26 +2803,26 @@ checksum = "72b40d3f5bbb3905f9ccb1ce9485a9595c77b69758a7c24d3ba79e334ff51e7e"
 dependencies = [
  "arrow",
  "async-trait",
- "datafusion-catalog 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-catalog 53.1.0",
+ "datafusion-common 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-physical-plan 53.1.0",
  "parking_lot",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-table"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "async-trait",
- "datafusion-catalog 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-catalog 54.0.0",
+ "datafusion-common 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-plan 54.0.0",
  "parking_lot",
 ]
 
@@ -2833,30 +2833,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e88ec9d57c9b685d02f58bfee7be62d72610430ddcedb82a08e5d9925dbfb6"
 dependencies = [
  "arrow",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-window-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-macros 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-doc 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-functions-window-common 53.1.0",
+ "datafusion-macros 53.1.0",
+ "datafusion-physical-expr 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
  "log",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-window-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-doc 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions-window-common 54.0.0",
+ "datafusion-macros 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
  "log",
 ]
 
@@ -2866,17 +2866,17 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8307bb93519b1a91913723a1130cfafeee3f72200d870d88e91a6fc5470ede5c"
 dependencies = [
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
 ]
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
 ]
 
 [[package]]
@@ -2885,17 +2885,17 @@ version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
 dependencies = [
- "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-doc 53.1.0",
  "quote",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "datafusion-macros"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
- "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-doc 54.0.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -2908,10 +2908,10 @@ checksum = "e929015451a67f77d9d8b727b2bf3a40c4445fdef6cdc53281d7d97c76888ace"
 dependencies = [
  "arrow",
  "chrono",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-expr-common 53.1.0",
+ "datafusion-physical-expr 53.1.0",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
@@ -2921,15 +2921,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "chrono",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-physical-expr 54.0.0",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
@@ -2946,11 +2946,11 @@ checksum = "4b1e68aba7a4b350401cfdf25a3d6f989ad898a7410164afe9ca52080244cb59"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-aggregate-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-expr-common 53.1.0",
+ "datafusion-functions-aggregate-common 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
  "half",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -2963,15 +2963,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-functions-aggregate-common 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
  "half",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -2989,25 +2989,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea22315f33cf2e0adc104e8ec42e285f6ed93998d565c65e82fec6a9ee9f9db4"
 dependencies = [
  "arrow",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-functions 53.1.0",
+ "datafusion-physical-expr 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
  "itertools 0.14.0",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
  "itertools 0.14.0",
 ]
 
@@ -3020,8 +3020,8 @@ dependencies = [
  "ahash 0.8.12",
  "arrow",
  "chrono",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-expr-common 53.1.0",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -3030,13 +3030,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "chrono",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-expr-common 54.0.0",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -3051,31 +3051,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cb13397809a425918f608dfe8653f332015a3e330004ab191b4404187238b95"
 dependencies = [
  "arrow",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-pruning 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-execution 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-expr-common 53.1.0",
+ "datafusion-physical-expr 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
+ "datafusion-physical-plan 53.1.0",
+ "datafusion-pruning 53.1.0",
  "itertools 0.14.0",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-pruning 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-pruning 54.0.0",
  "itertools 0.14.0",
  "recursive",
 ]
@@ -3091,15 +3091,15 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "async-trait",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-common-runtime 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-aggregate-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-window-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-common-runtime 53.1.0",
+ "datafusion-execution 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-functions 53.1.0",
+ "datafusion-functions-aggregate-common 53.1.0",
+ "datafusion-functions-window-common 53.1.0",
+ "datafusion-physical-expr 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
  "futures",
  "half",
  "hashbrown 0.16.1",
@@ -3114,8 +3114,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -3123,15 +3123,15 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "async-trait",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-window-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions 54.0.0",
+ "datafusion-functions-aggregate-common 54.0.0",
+ "datafusion-functions-window-common 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
  "futures",
  "half",
  "hashbrown 0.17.1",
@@ -3151,28 +3151,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac8c76860e355616555081cab5968cec1af7a80701ff374510860bcd567e365a"
 dependencies = [
  "arrow",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-datasource 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-datasource 53.1.0",
+ "datafusion-expr-common 53.1.0",
+ "datafusion-physical-expr 53.1.0",
+ "datafusion-physical-expr-common 53.1.0",
+ "datafusion-physical-plan 53.1.0",
  "itertools 0.14.0",
  "log",
 ]
 
 [[package]]
 name = "datafusion-pruning"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-expr-common 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
  "log",
 ]
 
@@ -3183,44 +3183,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5412111aa48e2424ba926112e192f7a6b7e4ccb450145d25ce5ede9f19dc491e"
 dependencies = [
  "async-trait",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-execution 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-physical-plan 53.1.0",
  "parking_lot",
 ]
 
 [[package]]
 name = "datafusion-session"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "async-trait",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-physical-plan 54.0.0",
  "parking_lot",
 ]
 
 [[package]]
 name = "datafusion-spark"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "bigdecimal",
  "chrono",
  "crc32fast",
- "datafusion 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-catalog 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-aggregate 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-nested 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion 54.0.0",
+ "datafusion-catalog 54.0.0",
+ "datafusion-common 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions 54.0.0",
+ "datafusion-functions-aggregate 54.0.0",
+ "datafusion-functions-aggregate-common 54.0.0",
+ "datafusion-functions-nested 54.0.0",
  "log",
  "num-traits",
  "percent-encoding",
@@ -3241,9 +3241,9 @@ dependencies = [
  "arrow",
  "bigdecimal",
  "chrono",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-nested 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-functions-nested 53.1.0",
  "indexmap 2.14.0",
  "log",
  "regex",
@@ -3252,15 +3252,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "bigdecimal",
  "chrono",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-nested 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions-nested 54.0.0",
  "indexmap 2.14.0",
  "log",
  "recursive",
@@ -3270,14 +3270,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sqllogictest"
-version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#50aa138564580ff7abaaf3d689fab831d0dd2ce2"
 dependencies = [
  "arrow",
  "async-trait",
  "bigdecimal",
  "clap",
- "datafusion 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion 54.0.0",
  "datafusion-spark",
  "futures",
  "half",
@@ -4857,11 +4857,11 @@ dependencies = [
  "chrono",
  "crossbeam-skiplist",
  "dashmap",
- "datafusion 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-functions 53.1.0",
+ "datafusion-physical-expr 53.1.0",
+ "datafusion-physical-plan 53.1.0",
  "deepsize",
  "either",
  "futures",
@@ -4966,8 +4966,8 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-sql 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
+ "datafusion-sql 53.1.0",
  "deepsize",
  "futures",
  "itertools 0.13.0",
@@ -5007,10 +5007,10 @@ dependencies = [
  "arrow-select",
  "async-trait",
  "chrono",
- "datafusion 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion 53.1.0",
+ "datafusion-common 53.1.0",
+ "datafusion-functions 53.1.0",
+ "datafusion-physical-expr 53.1.0",
  "futures",
  "jsonb",
  "lance-arrow",
@@ -5100,7 +5100,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0",
  "deepsize",
  "futures",
  "lance-arrow",
@@ -5138,11 +5138,11 @@ dependencies = [
  "bytes",
  "chrono",
  "crossbeam-queue",
- "datafusion 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-sql 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion 53.1.0",
+ "datafusion-common 53.1.0",
+ "datafusion-expr 53.1.0",
+ "datafusion-physical-expr 53.1.0",
+ "datafusion-sql 53.1.0",
  "deepsize",
  "dirs",
  "fst",
@@ -9832,19 +9832,19 @@ dependencies = [
  "anyhow",
  "arrow-schema",
  "async-trait",
- "datafusion 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-catalog 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-adapter 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-pruning 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion 54.0.0",
+ "datafusion-catalog 54.0.0",
+ "datafusion-common 54.0.0",
+ "datafusion-common-runtime 54.0.0",
+ "datafusion-datasource 54.0.0",
+ "datafusion-execution 54.0.0",
+ "datafusion-expr 54.0.0",
+ "datafusion-functions 54.0.0",
+ "datafusion-physical-expr 54.0.0",
+ "datafusion-physical-expr-adapter 54.0.0",
+ "datafusion-physical-expr-common 54.0.0",
+ "datafusion-physical-plan 54.0.0",
+ "datafusion-pruning 54.0.0",
  "futures",
  "insta",
  "itertools 0.14.0",
@@ -10376,7 +10376,7 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "clap",
- "datafusion 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion 54.0.0",
  "datafusion-sqllogictest",
  "futures",
  "indicatif",
@@ -10435,7 +10435,7 @@ dependencies = [
  "clap",
  "console_error_panic_hook",
  "crossterm 0.29.0",
- "datafusion 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion 54.0.0",
  "env_logger",
  "flatbuffers",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,10 +1975,10 @@ dependencies = [
  "datafusion-datasource-parquet",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common",
  "datafusion-functions",
- "datafusion-functions-aggregate 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-nested 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-nested",
  "datafusion-functions-table",
  "datafusion-functions-window",
  "datafusion-optimizer",
@@ -1988,7 +1988,7 @@ dependencies = [
  "datafusion-physical-optimizer",
  "datafusion-physical-plan",
  "datafusion-session",
- "datafusion-sql 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-sql",
  "flate2",
  "futures",
  "indexmap 2.14.0",
@@ -1998,7 +1998,7 @@ dependencies = [
  "object_store 0.13.2",
  "parking_lot",
  "parquet",
- "sqlparser 0.62.0",
+ "sqlparser",
  "tempfile",
  "tokio",
  "url",
@@ -2097,7 +2097,7 @@ dependencies = [
  "object_store 0.13.2",
  "parquet",
  "recursive",
- "sqlparser 0.62.0",
+ "sqlparser",
  "tokio",
  "uuid",
  "web-time",
@@ -2247,7 +2247,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions",
- "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-adapter",
  "datafusion-physical-expr-common",
@@ -2262,12 +2262,6 @@ dependencies = [
  "parquet",
  "tokio",
 ]
-
-[[package]]
-name = "datafusion-doc"
-version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
 
 [[package]]
 name = "datafusion-doc"
@@ -2305,29 +2299,16 @@ dependencies = [
  "async-trait",
  "chrono",
  "datafusion-common",
- "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-doc",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "recursive",
  "serde_json",
- "sqlparser 0.62.0",
-]
-
-[[package]]
-name = "datafusion-expr-common"
-version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7c3adf3db8bf61e92eb90cb659c8e8b734593a8f7c8e12a843c7ddba24b87e"
-dependencies = [
- "arrow",
- "datafusion-common",
- "indexmap 2.14.0",
- "itertools 0.14.0",
- "paste",
+ "sqlparser",
 ]
 
 [[package]]
@@ -2354,11 +2335,11 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "datafusion-common",
- "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-doc",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common",
+ "datafusion-macros",
  "datafusion-physical-expr-common",
  "hex",
  "itertools 0.14.0",
@@ -2375,37 +2356,15 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00aa6217e56098ba84e0a338176fe52f0a84cca398021512c6c8c5eff806d0ad"
-dependencies = [
- "ahash 0.8.12",
- "arrow",
- "datafusion-common",
- "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions-aggregate-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-macros 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
- "half",
- "log",
- "num-traits",
- "paste",
-]
-
-[[package]]
-name = "datafusion-functions-aggregate"
-version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "datafusion-common",
- "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-doc",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "foldhash 0.2.0",
@@ -2417,50 +2376,12 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b511250349407db7c43832ab2de63f5557b19a20dfd236b39ca2c04468b50d47"
-dependencies = [
- "ahash 0.8.12",
- "arrow",
- "datafusion-common",
- "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common",
-]
-
-[[package]]
-name = "datafusion-functions-aggregate-common"
-version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "datafusion-common",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common",
  "datafusion-physical-expr-common",
-]
-
-[[package]]
-name = "datafusion-functions-nested"
-version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
-dependencies = [
- "arrow",
- "arrow-ord",
- "datafusion-common",
- "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions",
- "datafusion-functions-aggregate 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-functions-aggregate-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-macros 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datafusion-physical-expr-common",
- "hashbrown 0.16.1",
- "itertools 0.14.0",
- "itoa",
- "log",
- "paste",
 ]
 
 [[package]]
@@ -2471,14 +2392,14 @@ dependencies = [
  "arrow",
  "arrow-ord",
  "datafusion-common",
- "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-doc",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common",
  "datafusion-functions",
- "datafusion-functions-aggregate 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
  "datafusion-physical-expr-common",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
@@ -2509,10 +2430,10 @@ source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a
 dependencies = [
  "arrow",
  "datafusion-common",
- "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-doc",
  "datafusion-expr",
  "datafusion-functions-window-common",
- "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-macros",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
@@ -2530,20 +2451,9 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
-dependencies = [
- "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "datafusion-macros"
-version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
- "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-doc",
  "quote",
  "syn 2.0.117",
 ]
@@ -2557,7 +2467,7 @@ dependencies = [
  "chrono",
  "datafusion-common",
  "datafusion-expr",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common",
  "datafusion-physical-expr",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -2575,8 +2485,8 @@ dependencies = [
  "arrow",
  "datafusion-common",
  "datafusion-expr",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.17.1",
@@ -2610,7 +2520,7 @@ dependencies = [
  "arrow",
  "chrono",
  "datafusion-common",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -2627,7 +2537,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
@@ -2652,7 +2562,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions",
- "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
@@ -2676,7 +2586,7 @@ dependencies = [
  "arrow",
  "datafusion-common",
  "datafusion-datasource",
- "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
@@ -2711,9 +2621,9 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions",
- "datafusion-functions-aggregate 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
- "datafusion-functions-nested 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-nested",
  "log",
  "num-traits",
  "percent-encoding",
@@ -2728,24 +2638,6 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
-dependencies = [
- "arrow",
- "bigdecimal",
- "chrono",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-functions-nested 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 2.14.0",
- "log",
- "regex",
- "sqlparser 0.61.0",
-]
-
-[[package]]
-name = "datafusion-sql"
-version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
@@ -2753,12 +2645,12 @@ dependencies = [
  "chrono",
  "datafusion-common",
  "datafusion-expr",
- "datafusion-functions-nested 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-nested",
  "indexmap 2.14.0",
  "log",
  "recursive",
  "regex",
- "sqlparser 0.62.0",
+ "sqlparser",
 ]
 
 [[package]]
@@ -2779,7 +2671,7 @@ dependencies = [
  "log",
  "object_store 0.13.2",
  "sqllogictest",
- "sqlparser 0.62.0",
+ "sqlparser",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -4460,7 +4352,7 @@ dependencies = [
  "bytes",
  "chrono",
  "datafusion-common",
- "datafusion-sql 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-sql",
  "deepsize",
  "futures",
  "itertools 0.13.0",
@@ -4635,7 +4527,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr",
- "datafusion-sql 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-sql",
  "deepsize",
  "dirs",
  "fst",
@@ -7849,16 +7741,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
-]
-
-[[package]]
-name = "sqlparser"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
-dependencies = [
- "log",
- "sqlparser_derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,6 +1956,55 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93db0e623840612f7f2cd757f7e8a8922064192363732c88692e0870016e141b"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion-catalog 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-catalog-listing 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource-arrow 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource-csv 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource-json 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-nested 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-table 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-window 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-optimizer 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-adapter 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-optimizer 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-session 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-sql 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
+ "parking_lot",
+ "rand 0.9.4",
+ "regex",
+ "sqlparser 0.61.0",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion"
+version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
@@ -1963,32 +2012,32 @@ dependencies = [
  "async-trait",
  "bzip2",
  "chrono",
- "datafusion-catalog",
- "datafusion-catalog-listing",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-datasource-arrow",
+ "datafusion-catalog 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-catalog-listing 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-datasource-arrow 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-datasource-avro",
- "datafusion-datasource-csv",
- "datafusion-datasource-json",
+ "datafusion-datasource-csv 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-datasource-json 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-datasource-parquet",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-functions",
- "datafusion-functions-aggregate",
- "datafusion-functions-nested",
- "datafusion-functions-table",
- "datafusion-functions-window",
- "datafusion-optimizer",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-optimizer",
- "datafusion-physical-plan",
- "datafusion-session",
- "datafusion-sql",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-nested 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-table 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-window 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-optimizer 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-adapter 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-optimizer 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-sql 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "flate2",
  "futures",
  "indexmap 2.14.0",
@@ -1998,7 +2047,7 @@ dependencies = [
  "object_store 0.13.2",
  "parking_lot",
  "parquet",
- "sqlparser",
+ "sqlparser 0.62.0",
  "tempfile",
  "tokio",
  "url",
@@ -2013,9 +2062,9 @@ dependencies = [
  "anyhow",
  "clap",
  "custom-labels",
- "datafusion",
- "datafusion-common",
- "datafusion-physical-plan",
+ "datafusion 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "futures",
  "itertools 0.14.0",
  "object_store 0.13.2",
@@ -2035,19 +2084,44 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37cefde60b26a7f4ff61e9d2ff2833322f91df2b568d7238afe67bde5bdffb66"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "dashmap",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-session 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-catalog"
+version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "async-trait",
  "dashmap",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -2059,23 +2133,69 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e112307715d6a7a331111a4c2330ff54bc237183511c319e3708a4cff431fb"
 dependencies = [
  "arrow",
  "async-trait",
- "datafusion-catalog",
- "datafusion-common",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
+ "datafusion-catalog 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-adapter 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "itertools 0.14.0",
  "log",
  "object_store 0.13.2",
+]
+
+[[package]]
+name = "datafusion-catalog-listing"
+version = "53.1.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "datafusion-catalog 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-adapter 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d72a11ca44a95e1081870d3abb80c717496e8a7acb467a1d3e932bb636af5cc2"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow",
+ "arrow-ipc",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "object_store 0.13.2",
+ "paste",
+ "sqlparser 0.61.0",
+ "tokio",
+ "web-time",
 ]
 
 [[package]]
@@ -2097,10 +2217,21 @@ dependencies = [
  "object_store 0.13.2",
  "parquet",
  "recursive",
- "sqlparser",
+ "sqlparser 0.62.0",
  "tokio",
  "uuid",
  "web-time",
+]
+
+[[package]]
+name = "datafusion-common-runtime"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f4afaed29670ec4fd6053643adc749fe3f4bc9d1ce1b8c5679b22c67d12def"
+dependencies = [
+ "futures",
+ "log",
+ "tokio",
 ]
 
 [[package]]
@@ -2116,6 +2247,35 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9fb386e1691355355a96419978a0022b7947b44d4a24a6ea99f00b6b485cbb6"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-adapter 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-session 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "glob",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
+ "rand 0.9.4",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "datafusion-datasource"
+version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
@@ -2124,15 +2284,15 @@ dependencies = [
  "bytes",
  "bzip2",
  "chrono",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-adapter 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "flate2",
  "futures",
  "glob",
@@ -2151,20 +2311,44 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffa6c52cfed0734c5f93754d1c0175f558175248bf686c944fb05c373e5fc096"
+dependencies = [
+ "arrow",
+ "arrow-ipc",
+ "async-trait",
+ "bytes",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-session 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "itertools 0.14.0",
+ "object_store 0.13.2",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-arrow"
+version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "arrow-ipc",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "futures",
  "itertools 0.14.0",
  "object_store 0.13.2",
@@ -2180,13 +2364,36 @@ dependencies = [
  "arrow-avro",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-datasource",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-adapter 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "futures",
  "object_store 0.13.2",
+]
+
+[[package]]
+name = "datafusion-datasource-csv"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503f29e0582c1fc189578d665ff57d9300da1f80c282777d7eb67bb79fb8cdca"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-session 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "object_store 0.13.2",
+ "regex",
+ "tokio",
 ]
 
 [[package]]
@@ -2197,18 +2404,42 @@ dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "futures",
  "object_store 0.13.2",
  "regex",
  "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-json"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33804749abc8d0c8cb7473228483cb8070e524c6f6086ee1b85a64debe2b3d2"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-session 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "object_store 0.13.2",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -2219,14 +2450,14 @@ dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "futures",
  "object_store 0.13.2",
  "tokio",
@@ -2241,19 +2472,19 @@ dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-functions-aggregate-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-pruning",
- "datafusion-session",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-adapter 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-pruning 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-session 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -2266,7 +2497,36 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
+
+[[package]]
+name = "datafusion-doc"
+version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
+
+[[package]]
+name = "datafusion-execution"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03c7fbdaefcca4ef6ffe425a5fc2325763bfb426599bb0bf4536466efabe709"
+dependencies = [
+ "arrow",
+ "arrow-buffer",
+ "async-trait",
+ "chrono",
+ "dashmap",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "log",
+ "object_store 0.13.2",
+ "parking_lot",
+ "rand 0.9.4",
+ "tempfile",
+ "url",
+]
 
 [[package]]
 name = "datafusion-execution"
@@ -2277,9 +2537,9 @@ dependencies = [
  "arrow-buffer",
  "async-trait",
  "dashmap",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "futures",
  "log",
  "object_store 0.13.2",
@@ -2292,23 +2552,58 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "574b9b6977fedbd2a611cbff12e5caf90f31640ad9dc5870f152836d94bad0dd"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "chrono",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-window-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "paste",
+ "serde_json",
+ "sqlparser 0.61.0",
+]
+
+[[package]]
+name = "datafusion-expr"
+version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "arrow-schema",
  "async-trait",
  "chrono",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-expr-common",
- "datafusion-functions-aggregate-common",
- "datafusion-functions-window-common",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-window-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "recursive",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.62.0",
+]
+
+[[package]]
+name = "datafusion-expr-common"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d7c3adf3db8bf61e92eb90cb659c8e8b734593a8f7c8e12a843c7ddba24b87e"
+dependencies = [
+ "arrow",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "paste",
 ]
 
 [[package]]
@@ -2317,9 +2612,41 @@ version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
- "datafusion-common",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "indexmap 2.14.0",
  "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-functions"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28aa4e10384e782774b10e72aca4d93ef7b31aa653095d9d4536b0a3dbc51b6"
+dependencies = [
+ "arrow",
+ "arrow-buffer",
+ "base64",
+ "blake2",
+ "blake3",
+ "chrono",
+ "chrono-tz",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-macros 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "md-5 0.10.6",
+ "memchr",
+ "num-traits",
+ "rand 0.9.4",
+ "regex",
+ "sha2 0.10.9",
+ "unicode-segmentation",
+ "uuid",
 ]
 
 [[package]]
@@ -2334,13 +2661,13 @@ dependencies = [
  "blake3",
  "chrono",
  "chrono-tz",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-macros",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "hex",
  "itertools 0.14.0",
  "log",
@@ -2356,17 +2683,39 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00aa6217e56098ba84e0a338176fe52f0a84cca398021512c6c8c5eff806d0ad"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-macros 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "half",
+ "log",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate"
+version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions-aggregate-common",
- "datafusion-macros",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "foldhash 0.2.0",
  "half",
  "log",
@@ -2376,12 +2725,50 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b511250349407db7c43832ab2de63f5557b19a20dfd236b39ca2c04468b50d47"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate-common"
+version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-expr-common",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+]
+
+[[package]]
+name = "datafusion-functions-nested"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
+dependencies = [
+ "arrow",
+ "arrow-ord",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-macros 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.16.1",
+ "itertools 0.14.0",
+ "itoa",
+ "log",
+ "paste",
 ]
 
 [[package]]
@@ -2391,16 +2778,16 @@ source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a
 dependencies = [
  "arrow",
  "arrow-ord",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-functions",
- "datafusion-functions-aggregate",
- "datafusion-functions-aggregate-common",
- "datafusion-macros",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "itoa",
@@ -2411,16 +2798,50 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b40d3f5bbb3905f9ccb1ce9485a9595c77b69758a7c24d3ba79e334ff51e7e"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "datafusion-catalog 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-table"
+version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "async-trait",
- "datafusion-catalog",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-plan",
+ "datafusion-catalog 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "parking_lot",
+]
+
+[[package]]
+name = "datafusion-functions-window"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e88ec9d57c9b685d02f58bfee7be62d72610430ddcedb82a08e5d9925dbfb6"
+dependencies = [
+ "arrow",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-window-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-macros 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
+ "paste",
 ]
 
 [[package]]
@@ -2429,14 +2850,24 @@ version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-expr",
- "datafusion-functions-window-common",
- "datafusion-macros",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-window-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-macros 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "log",
+]
+
+[[package]]
+name = "datafusion-functions-window-common"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8307bb93519b1a91913723a1130cfafeee3f72200d870d88e91a6fc5470ede5c"
+dependencies = [
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2444,8 +2875,19 @@ name = "datafusion-functions-window-common"
 version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
- "datafusion-common",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+]
+
+[[package]]
+name = "datafusion-macros"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
+dependencies = [
+ "datafusion-doc 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2453,9 +2895,28 @@ name = "datafusion-macros"
 version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
- "datafusion-doc",
+ "datafusion-doc 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e929015451a67f77d9d8b727b2bf3a40c4445fdef6cdc53281d7d97c76888ace"
+dependencies = [
+ "arrow",
+ "chrono",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "log",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2465,10 +2926,10 @@ source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a
 dependencies = [
  "arrow",
  "chrono",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-physical-expr",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
@@ -2480,14 +2941,37 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b1e68aba7a4b350401cfdf25a3d6f989ad898a7410164afe9ca52080244cb59"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "parking_lot",
+ "paste",
+ "petgraph",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-physical-expr"
+version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-functions-aggregate-common",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "half",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -2501,15 +2985,47 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea22315f33cf2e0adc104e8ec42e285f6ed93998d565c65e82fec6a9ee9f9db4"
+dependencies = [
+ "arrow",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-expr-adapter"
+version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-expr-common"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04b45ea8ad3ac2d78f2ea2a76053e06591c9629c7a603eda16c10649ecf4362"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow",
+ "chrono",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2519,8 +3035,8 @@ source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a
 dependencies = [
  "arrow",
  "chrono",
- "datafusion-common",
- "datafusion-expr-common",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -2531,19 +3047,69 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb13397809a425918f608dfe8653f332015a3e330004ab191b4404187238b95"
+dependencies = [
+ "arrow",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-pruning 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-optimizer"
+version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-pruning",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-pruning 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "itertools 0.14.0",
  "recursive",
+]
+
+[[package]]
+name = "datafusion-physical-plan"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5edc023675791af9d5fb4cc4c24abf5f7bd3bd4dcf9e5bd90ea1eff6976dcc79"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow",
+ "arrow-ord",
+ "arrow-schema",
+ "async-trait",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common-runtime 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-aggregate-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-window-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "log",
+ "num-traits",
+ "parking_lot",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2557,15 +3123,15 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "async-trait",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-functions-aggregate-common",
- "datafusion-functions-window-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-window-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "futures",
  "half",
  "hashbrown 0.17.1",
@@ -2581,16 +3147,47 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac8c76860e355616555081cab5968cec1af7a80701ff374510860bcd567e365a"
+dependencies = [
+ "arrow",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-datasource 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.14.0",
+ "log",
+]
+
+[[package]]
+name = "datafusion-pruning"
+version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
- "datafusion-common",
- "datafusion-datasource",
- "datafusion-expr-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "log",
+]
+
+[[package]]
+name = "datafusion-session"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5412111aa48e2424ba926112e192f7a6b7e4ccb450145d25ce5ede9f19dc491e"
+dependencies = [
+ "async-trait",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-execution 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2599,10 +3196,10 @@ version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "async-trait",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-plan",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "parking_lot",
 ]
 
@@ -2615,15 +3212,15 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "crc32fast",
- "datafusion",
- "datafusion-catalog",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-functions-aggregate",
- "datafusion-functions-aggregate-common",
- "datafusion-functions-nested",
+ "datafusion 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-catalog 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-aggregate-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-nested 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "log",
  "num-traits",
  "percent-encoding",
@@ -2638,19 +3235,37 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
+dependencies = [
+ "arrow",
+ "bigdecimal",
+ "chrono",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions-nested 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 2.14.0",
+ "log",
+ "regex",
+ "sqlparser 0.61.0",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "53.1.0"
 source = "git+https://github.com/apache/datafusion?branch=branch-54#70caf372a54a088b4bcfd3b4479490f3388971d8"
 dependencies = [
  "arrow",
  "bigdecimal",
  "chrono",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-functions-nested",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions-nested 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "indexmap 2.14.0",
  "log",
  "recursive",
  "regex",
- "sqlparser",
+ "sqlparser 0.62.0",
 ]
 
 [[package]]
@@ -2662,7 +3277,7 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "clap",
- "datafusion",
+ "datafusion 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-spark",
  "futures",
  "half",
@@ -2671,7 +3286,7 @@ dependencies = [
  "log",
  "object_store 0.13.2",
  "sqllogictest",
- "sqlparser",
+ "sqlparser 0.62.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -4242,11 +4857,11 @@ dependencies = [
  "chrono",
  "crossbeam-skiplist",
  "dashmap",
- "datafusion",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-physical-expr",
- "datafusion-physical-plan",
+ "datafusion 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-plan 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deepsize",
  "either",
  "futures",
@@ -4351,8 +4966,8 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "datafusion-common",
- "datafusion-sql",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-sql 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deepsize",
  "futures",
  "itertools 0.13.0",
@@ -4392,10 +5007,10 @@ dependencies = [
  "arrow-select",
  "async-trait",
  "chrono",
- "datafusion",
- "datafusion-common",
- "datafusion-functions",
- "datafusion-physical-expr",
+ "datafusion 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-functions 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "jsonb",
  "lance-arrow",
@@ -4485,7 +5100,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
- "datafusion-common",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deepsize",
  "futures",
  "lance-arrow",
@@ -4523,11 +5138,11 @@ dependencies = [
  "bytes",
  "chrono",
  "crossbeam-queue",
- "datafusion",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-sql",
+ "datafusion 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-common 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-physical-expr 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datafusion-sql 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deepsize",
  "dirs",
  "fst",
@@ -7745,6 +8360,16 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+dependencies = [
+ "log",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser"
 version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
@@ -9207,19 +9832,19 @@ dependencies = [
  "anyhow",
  "arrow-schema",
  "async-trait",
- "datafusion",
- "datafusion-catalog",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-pruning",
+ "datafusion 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-catalog 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-common-runtime 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-datasource 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-execution 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-functions 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-adapter 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-expr-common 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-physical-plan 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
+ "datafusion-pruning 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "futures",
  "insta",
  "itertools 0.14.0",
@@ -9751,7 +10376,7 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "clap",
- "datafusion",
+ "datafusion 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "datafusion-sqllogictest",
  "futures",
  "indicatif",
@@ -9810,7 +10435,7 @@ dependencies = [
  "clap",
  "console_error_panic_hook",
  "crossterm 0.29.0",
- "datafusion",
+ "datafusion 53.1.0 (git+https://github.com/apache/datafusion?branch=branch-54)",
  "env_logger",
  "flatbuffers",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -408,3 +408,19 @@ debug = false
 debug-assertions = false
 strip = "debuginfo"
 incremental = false
+
+[patch.crates-io]
+datafusion = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-catalog = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-common = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-common-runtime = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-datasource = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-execution = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-expr = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-functions = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-physical-expr = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-physical-expr-adapter = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-physical-expr-common = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-physical-plan = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-pruning = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-sqllogictest = { git = "https://github.com/apache/datafusion", branch = "branch-54" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,20 +132,22 @@ cudarc = { version = "0.19.0", features = [
 ] }
 custom-labels = "0.4.4"
 dashmap = "6.1.0"
-datafusion = { version = "53", default-features = false, features = ["sql"] }
-datafusion-catalog = { version = "53" }
-datafusion-common = { version = "53" }
-datafusion-common-runtime = { version = "53" }
-datafusion-datasource = { version = "53", default-features = false }
-datafusion-execution = { version = "53" }
-datafusion-expr = { version = "53" }
-datafusion-functions = { version = "53" }
-datafusion-physical-expr = { version = "53" }
-datafusion-physical-expr-adapter = { version = "53" }
-datafusion-physical-expr-common = { version = "53" }
-datafusion-physical-plan = { version = "53" }
-datafusion-pruning = { version = "53" }
-datafusion-sqllogictest = { version = "53" }
+datafusion = { git = "https://github.com/apache/datafusion", branch = "branch-54", default-features = false, features = [
+    "sql",
+] }
+datafusion-catalog = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-common = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-common-runtime = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-datasource = { git = "https://github.com/apache/datafusion", branch = "branch-54", default-features = false }
+datafusion-execution = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-expr = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-functions = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-physical-expr = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-physical-expr-adapter = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-physical-expr-common = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-physical-plan = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-pruning = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-sqllogictest = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
 dirs = "6.0.0"
 divan = { package = "codspeed-divan-compat", version = "4.0.4" }
 enum-iterator = "2.0.0"
@@ -408,27 +410,3 @@ debug = false
 debug-assertions = false
 strip = "debuginfo"
 incremental = false
-
-[patch.crates-io]
-datafusion = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-catalog = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-common = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-common-runtime = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-datasource = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-execution = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-expr = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-functions = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-physical-expr = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-physical-expr-adapter = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-physical-expr-common = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-physical-plan = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-pruning = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-sqllogictest = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-
-# Extra patches
-datafusion-sql = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-functions-nested = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-expr-common = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-functions-aggregate = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-functions-aggregate-common = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-doc = { git = "https://github.com/apache/datafusion", branch = "branch-54" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -424,3 +424,11 @@ datafusion-physical-expr-common = { git = "https://github.com/apache/datafusion"
 datafusion-physical-plan = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
 datafusion-pruning = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
 datafusion-sqllogictest = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+
+# Extra patches
+datafusion-sql = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-functions-nested = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-expr-common = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-functions-aggregate = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-functions-aggregate-common = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-doc = { git = "https://github.com/apache/datafusion", branch = "branch-54" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,22 +132,22 @@ cudarc = { version = "0.19.0", features = [
 ] }
 custom-labels = "0.4.4"
 dashmap = "6.1.0"
-datafusion = { git = "https://github.com/apache/datafusion", branch = "branch-54", default-features = false, features = [
+datafusion = { version = "54", git = "https://github.com/apache/datafusion", branch = "branch-54", default-features = false, features = [
     "sql",
 ] }
-datafusion-catalog = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-common = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-common-runtime = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-datasource = { git = "https://github.com/apache/datafusion", branch = "branch-54", default-features = false }
-datafusion-execution = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-expr = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-functions = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-physical-expr = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-physical-expr-adapter = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-physical-expr-common = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-physical-plan = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-pruning = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
-datafusion-sqllogictest = { git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-catalog = { version = "54", git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-common = { version = "54", git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-common-runtime = { version = "54", git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-datasource = { version = "54", git = "https://github.com/apache/datafusion", branch = "branch-54", default-features = false }
+datafusion-execution = { version = "54", git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-expr = { version = "54", git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-functions = { version = "54", git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-physical-expr = { version = "54", git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-physical-expr-adapter = { version = "54", git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-physical-expr-common = { version = "54", git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-physical-plan = { version = "54", git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-pruning = { version = "54", git = "https://github.com/apache/datafusion", branch = "branch-54" }
+datafusion-sqllogictest = { version = "54", git = "https://github.com/apache/datafusion", branch = "branch-54" }
 dirs = "6.0.0"
 divan = { package = "codspeed-divan-compat", version = "4.0.4" }
 enum-iterator = "2.0.0"

--- a/benchmarks/datafusion-bench/src/lib.rs
+++ b/benchmarks/datafusion-bench/src/lib.rs
@@ -14,7 +14,7 @@ use datafusion::datasource::provider::DefaultTableFactory;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::cache::DefaultListFilesCache;
 use datafusion::execution::cache::cache_manager::CacheManagerConfig;
-use datafusion::execution::cache::cache_unit::DefaultFileStatisticsCache;
+use datafusion::execution::cache::file_statistics_cache::DefaultFileStatisticsCache;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::prelude::SessionConfig;
 use datafusion::prelude::SessionContext;
@@ -37,7 +37,7 @@ pub fn get_session_context() -> SessionContext {
     let file_static_cache = Arc::new(DefaultFileStatisticsCache::default());
     let list_file_cache = Arc::new(DefaultListFilesCache::default());
     let cache_config = CacheManagerConfig::default()
-        .with_files_statistics_cache(Some(file_static_cache))
+        .with_file_statistics_cache(Some(file_static_cache))
         .with_list_files_cache(Some(list_file_cache));
     rt_builder = rt_builder.with_cache_manager(cache_config);
 

--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -15,7 +15,6 @@ use datafusion::datasource::listing::ListingOptions;
 use datafusion::datasource::listing::ListingTable;
 use datafusion::datasource::listing::ListingTableConfig;
 use datafusion::datasource::listing::ListingTableUrl;
-use datafusion::execution::cache::file_statistics_cache::DefaultFileStatisticsCache;
 use datafusion::parquet::arrow::ParquetRecordBatchStreamBuilder;
 use datafusion::prelude::SessionContext;
 use datafusion_bench::format_to_df_format;

--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -15,6 +15,7 @@ use datafusion::datasource::listing::ListingOptions;
 use datafusion::datasource::listing::ListingTable;
 use datafusion::datasource::listing::ListingTableConfig;
 use datafusion::datasource::listing::ListingTableUrl;
+use datafusion::execution::cache::file_statistics_cache::DefaultFileStatisticsCache;
 use datafusion::parquet::arrow::ParquetRecordBatchStreamBuilder;
 use datafusion::prelude::SessionContext;
 use datafusion_bench::format_to_df_format;
@@ -278,7 +279,14 @@ async fn register_benchmark_tables<B: Benchmark + ?Sized>(
                     None => config.infer_schema(&session.state()).await?,
                 };
 
-                let listing_table = Arc::new(ListingTable::try_new(config)?);
+                let listing_table = Arc::new(
+                    ListingTable::try_new(config)?.with_cache(
+                        session
+                            .runtime_env()
+                            .cache_manager
+                            .get_file_statistic_cache(),
+                    ),
+                );
 
                 session.register_table(table.name, listing_table)?;
             }

--- a/vortex-array/src/dtype/arrow.rs
+++ b/vortex-array/src/dtype/arrow.rs
@@ -298,13 +298,12 @@ pub(crate) fn to_data_type_naive(dtype: &DType) -> VortexResult<DataType> {
             let scale = dt.scale();
 
             match precision {
-                // This code is commented out until DataFusion improves its support for smaller decimals.
-                // // DECIMAL32_MAX_PRECISION
-                // 0..=9 => DataType::Decimal32(precision, scale),
-                // // DECIMAL64_MAX_PRECISION
-                // 10..=18 => DataType::Decimal64(precision, scale),
+                // DECIMAL32_MAX_PRECISION
+                0..=9 => DataType::Decimal32(precision, scale),
+                // DECIMAL64_MAX_PRECISION
+                10..=18 => DataType::Decimal64(precision, scale),
                 // DECIMAL128_MAX_PRECISION
-                0..=38 => DataType::Decimal128(precision, scale),
+                19..=38 => DataType::Decimal128(precision, scale),
                 // DECIMAL256_MAX_PRECISION
                 39.. => DataType::Decimal256(precision, scale),
             }
@@ -448,6 +447,25 @@ mod test {
                 FieldRef::from(Field::new("field_b", DataType::Utf8View, true)),
             ]))
         );
+    }
+
+    #[rstest]
+    #[case(1, DataType::Decimal32(1, 0))]
+    #[case(9, DataType::Decimal32(9, 0))]
+    #[case(10, DataType::Decimal64(10, 0))]
+    #[case(18, DataType::Decimal64(18, 0))]
+    #[case(19, DataType::Decimal128(19, 0))]
+    #[case(38, DataType::Decimal128(38, 0))]
+    #[case(39, DataType::Decimal256(39, 0))]
+    #[case(76, DataType::Decimal256(76, 0))]
+    fn test_decimal_dtype_to_arrow_smallest_width(
+        #[case] precision: u8,
+        #[case] expected: DataType,
+    ) {
+        use crate::dtype::DecimalDType;
+
+        let dtype = DType::Decimal(DecimalDType::new(precision, 0), Nullability::NonNullable);
+        assert_eq!(dtype.to_arrow_dtype().unwrap(), expected);
     }
 
     #[test]

--- a/vortex-datafusion/src/convert/exprs.rs
+++ b/vortex-datafusion/src/convert/exprs.rs
@@ -127,7 +127,6 @@ impl DefaultExpressionConvertor {
             let mut result = self.convert(source_expr.as_ref())?;
             for expr in field_names {
                 let field_name = expr
-                    .as_any()
                     .downcast_ref::<df_expr::Literal>()
                     .ok_or_else(|| exec_datafusion_err!("get_field field name must be a literal"))?
                     .value()
@@ -195,7 +194,7 @@ impl ExpressionConvertor for DefaultExpressionConvertor {
     fn convert(&self, df: &dyn PhysicalExpr) -> DFResult<Expression> {
         // TODO(joe): Don't return an error when we have an unsupported node, bubble up "TRUE" as in keep
         //  for that node, up to any `and` or `or` node.
-        if let Some(binary_expr) = df.as_any().downcast_ref::<df_expr::BinaryExpr>() {
+        if let Some(binary_expr) = df.downcast_ref::<df_expr::BinaryExpr>() {
             let left = self.convert(binary_expr.left().as_ref())?;
             let right = self.convert(binary_expr.right().as_ref())?;
             let operator = try_operator_from_df(binary_expr.op())?;
@@ -203,11 +202,11 @@ impl ExpressionConvertor for DefaultExpressionConvertor {
             return Ok(Binary.new_expr(operator, [left, right]));
         }
 
-        if let Some(col_expr) = df.as_any().downcast_ref::<df_expr::Column>() {
+        if let Some(col_expr) = df.downcast_ref::<df_expr::Column>() {
             return Ok(get_item(col_expr.name().to_owned(), root()));
         }
 
-        if let Some(like) = df.as_any().downcast_ref::<df_expr::LikeExpr>() {
+        if let Some(like) = df.downcast_ref::<df_expr::LikeExpr>() {
             let child = self.convert(like.expr().as_ref())?;
             let pattern = self.convert(like.pattern().as_ref())?;
             return Ok(Like.new_expr(
@@ -219,42 +218,34 @@ impl ExpressionConvertor for DefaultExpressionConvertor {
             ));
         }
 
-        if let Some(literal) = df.as_any().downcast_ref::<df_expr::Literal>() {
+        if let Some(literal) = df.downcast_ref::<df_expr::Literal>() {
             let value = Scalar::from_df(literal.value());
             return Ok(lit(value));
         }
 
-        if let Some(cast_expr) = df.as_any().downcast_ref::<df_expr::CastExpr>() {
-            let cast_dtype = DType::from_arrow((cast_expr.cast_type(), Nullability::Nullable));
+        if let Some(cast_expr) = df.downcast_ref::<df_expr::CastExpr>() {
+            let cast_dtype = DType::from_arrow(cast_expr.target_field().as_ref());
             let child = self.convert(cast_expr.expr().as_ref())?;
             return Ok(cast(child, cast_dtype));
         }
 
-        if let Some(cast_col_expr) = df.as_any().downcast_ref::<df_expr::CastColumnExpr>() {
-            let target = cast_col_expr.target_field();
-
-            let target_dtype = DType::from_arrow((target.data_type(), target.is_nullable().into()));
-            let child = self.convert(cast_col_expr.expr().as_ref())?;
-            return Ok(cast(child, target_dtype));
-        }
-
-        if let Some(is_null_expr) = df.as_any().downcast_ref::<df_expr::IsNullExpr>() {
+        if let Some(is_null_expr) = df.downcast_ref::<df_expr::IsNullExpr>() {
             let arg = self.convert(is_null_expr.arg().as_ref())?;
             return Ok(is_null(arg));
         }
 
-        if let Some(is_not_null_expr) = df.as_any().downcast_ref::<df_expr::IsNotNullExpr>() {
+        if let Some(is_not_null_expr) = df.downcast_ref::<df_expr::IsNotNullExpr>() {
             let arg = self.convert(is_not_null_expr.arg().as_ref())?;
             return Ok(is_not_null(arg));
         }
 
-        if let Some(in_list) = df.as_any().downcast_ref::<df_expr::InListExpr>() {
+        if let Some(in_list) = df.downcast_ref::<df_expr::InListExpr>() {
             let value = self.convert(in_list.expr().as_ref())?;
             let list_elements: Vec<_> = in_list
                 .list()
                 .iter()
                 .map(|e| {
-                    if let Some(lit) = e.as_any().downcast_ref::<df_expr::Literal>() {
+                    if let Some(lit) = e.downcast_ref::<df_expr::Literal>() {
                         Ok(Scalar::from_df(lit.value()))
                     } else {
                         Err(exec_datafusion_err!("Failed to cast sub-expression"))
@@ -272,11 +263,11 @@ impl ExpressionConvertor for DefaultExpressionConvertor {
             return Ok(if in_list.negated() { not(expr) } else { expr });
         }
 
-        if let Some(scalar_fn) = df.as_any().downcast_ref::<ScalarFunctionExpr>() {
+        if let Some(scalar_fn) = df.downcast_ref::<ScalarFunctionExpr>() {
             return self.try_convert_scalar_function(scalar_fn);
         }
 
-        if let Some(case_expr) = df.as_any().downcast_ref::<df_expr::CaseExpr>() {
+        if let Some(case_expr) = df.downcast_ref::<df_expr::CaseExpr>() {
             return self.try_convert_case_expr(case_expr);
         }
 
@@ -297,7 +288,7 @@ impl ExpressionConvertor for DefaultExpressionConvertor {
         for projection_expr in source_projection.iter() {
             let r = projection_expr.expr.apply(|node| {
                 // We only pull column children of scalar functions that we can't push into the scan.
-                if let Some(scalar_fn_expr) = node.as_any().downcast_ref::<ScalarFunctionExpr>()
+                if let Some(scalar_fn_expr) = node.downcast_ref::<ScalarFunctionExpr>()
                     && !can_scalar_fn_be_pushed_down(scalar_fn_expr)
                 {
                     scan_projection.extend(
@@ -312,7 +303,7 @@ impl ExpressionConvertor for DefaultExpressionConvertor {
 
                 // DataFusion assumes different decimal types can be coerced.
                 // Vortex expects a perfect match so we don't push it down.
-                if let Some(binary_expr) = node.as_any().downcast_ref::<df_expr::BinaryExpr>()
+                if let Some(binary_expr) = node.downcast_ref::<df_expr::BinaryExpr>()
                     && binary_expr.op().is_numerical_operators()
                     && (is_decimal(&binary_expr.left().data_type(input_schema)?)
                         && is_decimal(&binary_expr.right().data_type(input_schema)?))
@@ -406,14 +397,13 @@ fn try_operator_from_df(value: &DFOperator) -> DFResult<Operator> {
     }
 }
 
-fn can_be_pushed_down_impl(df_expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> bool {
+fn can_be_pushed_down_impl(expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> bool {
     // We currently do not support pushdown of dynamic expressions in DF.
     // See issue: https://github.com/vortex-data/vortex/issues/4034
-    if is_dynamic_physical_expr(df_expr) {
+    if is_dynamic_physical_expr(expr) {
         return false;
     }
 
-    let expr = df_expr.as_any();
     if let Some(binary) = expr.downcast_ref::<df_expr::BinaryExpr>() {
         can_binary_be_pushed_down(binary, schema)
     } else if let Some(col) = expr.downcast_ref::<df_expr::Column>() {
@@ -429,9 +419,6 @@ fn can_be_pushed_down_impl(df_expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> 
     } else if let Some(cast_expr) = expr.downcast_ref::<df_expr::CastExpr>() {
         // CastExpr child must be an expression type that convert() can handle
         is_convertible_expr(cast_expr.expr())
-    } else if let Some(cast_col_expr) = expr.downcast_ref::<df_expr::CastColumnExpr>() {
-        // CastColumnExpr child must be an expression type that convert() can handle
-        is_convertible_expr(cast_col_expr.expr())
     } else if let Some(is_null) = expr.downcast_ref::<df_expr::IsNullExpr>() {
         can_be_pushed_down_impl(is_null.arg(), schema)
     } else if let Some(is_not_null) = expr.downcast_ref::<df_expr::IsNotNullExpr>() {
@@ -447,7 +434,7 @@ fn can_be_pushed_down_impl(df_expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> 
     } else if let Some(case_expr) = expr.downcast_ref::<df_expr::CaseExpr>() {
         can_case_be_pushed_down(case_expr, schema)
     } else {
-        tracing::debug!(%df_expr, "DataFusion expression can't be pushed down");
+        tracing::debug!(%expr, "DataFusion expression can't be pushed down");
         false
     }
 }
@@ -455,9 +442,7 @@ fn can_be_pushed_down_impl(df_expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> 
 /// Checks if an expression type is one that convert() can handle.
 /// This is less restrictive than can_be_pushed_down since it only checks
 /// expression types, not data type support.
-fn is_convertible_expr(df_expr: &Arc<dyn PhysicalExpr>) -> bool {
-    let expr = df_expr.as_any();
-
+fn is_convertible_expr(expr: &Arc<dyn PhysicalExpr>) -> bool {
     // Expression types that convert() handles
     expr.downcast_ref::<df_expr::BinaryExpr>().is_some()
         || expr.downcast_ref::<df_expr::Column>().is_some()
@@ -465,9 +450,6 @@ fn is_convertible_expr(df_expr: &Arc<dyn PhysicalExpr>) -> bool {
         || expr.downcast_ref::<df_expr::Literal>().is_some()
         || expr
             .downcast_ref::<df_expr::CastExpr>()
-            .is_some_and(|e| is_convertible_expr(e.expr()))
-        || expr
-            .downcast_ref::<df_expr::CastColumnExpr>()
             .is_some_and(|e| is_convertible_expr(e.expr()))
         || expr.downcast_ref::<df_expr::IsNullExpr>().is_some()
         || expr.downcast_ref::<df_expr::IsNotNullExpr>().is_some()
@@ -568,6 +550,8 @@ mod tests {
     use arrow_schema::Field;
     use arrow_schema::Schema;
     use arrow_schema::TimeUnit as ArrowTimeUnit;
+    use datafusion::arrow::array::AsArray;
+    use datafusion::arrow::datatypes::Int32Type;
     use datafusion_common::ScalarValue;
     use datafusion_expr::Operator as DFOperator;
     use datafusion_physical_expr::PhysicalExpr;
@@ -988,12 +972,7 @@ mod tests {
         let vortex_as_arrow = vortex_result.into_primitive().as_slice::<i32>().to_vec();
 
         // Convert DataFusion result to Vec for comparison
-        let df_as_arrow: Vec<i32> = df_array
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .unwrap()
-            .values()
-            .to_vec();
+        let df_as_arrow: Vec<i32> = df_array.as_primitive::<Int32Type>().values().to_vec();
 
         // Compare results
         // Expected: [0, 0, 50, 100, 100] for values [1, 5, 10, 15, 20]

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -299,10 +298,6 @@ impl FileFormatFactory for VortexFormatFactory {
     fn default(&self) -> Arc<dyn FileFormat> {
         Arc::new(VortexFormat::new(self.session.clone()))
     }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 }
 
 impl VortexFormat {
@@ -330,10 +325,6 @@ impl VortexFormat {
 
 #[async_trait]
 impl FileFormat for VortexFormat {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn compression_type(&self) -> Option<FileCompressionType> {
         None
     }
@@ -594,7 +585,6 @@ impl FileFormat for VortexFormat {
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         let mut source = file_scan_config
             .file_source()
-            .as_any()
             .downcast_ref::<VortexSource>()
             .cloned()
             .ok_or_else(|| internal_datafusion_err!("Expected VortexSource"))?;

--- a/vortex-datafusion/src/persistent/metrics.rs
+++ b/vortex-datafusion/src/persistent/metrics.rs
@@ -73,16 +73,13 @@ impl VortexMetricsFinder {
 impl ExecutionPlanVisitor for VortexMetricsFinder {
     type Error = std::convert::Infallible;
     fn pre_visit(&mut self, plan: &dyn ExecutionPlan) -> Result<bool, Self::Error> {
-        if let Some(exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
+        if let Some(exec) = plan.downcast_ref::<DataSourceExec>() {
             // Start with exec metrics or create a new set
             let mut set = exec.metrics().unwrap_or_default();
 
             // Include our own metrics from VortexSource
-            if let Some(file_scan) = exec.data_source().as_any().downcast_ref::<FileScanConfig>()
-                && let Some(scan) = file_scan
-                    .file_source
-                    .as_any()
-                    .downcast_ref::<VortexSource>()
+            if let Some(file_scan) = exec.data_source().downcast_ref::<FileScanConfig>()
+                && let Some(scan) = file_scan.file_source.downcast_ref::<VortexSource>()
             {
                 for metric in scan
                     .metrics_registry()
@@ -240,7 +237,7 @@ mod tests {
             &mut self,
             plan: &dyn datafusion_physical_plan::ExecutionPlan,
         ) -> Result<bool, Self::Error> {
-            if plan.as_any().downcast_ref::<DataSourceExec>().is_some() {
+            if plan.downcast_ref::<DataSourceExec>().is_some() {
                 self.0 += 1;
                 Ok(false)
             } else {

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -314,9 +314,7 @@ impl FileOpener for VortexOpener {
 
             let mut scan_builder = ScanBuilder::new(session.clone(), Arc::clone(&layout_reader));
 
-            if let Some(extensions) = file.extensions
-                && let Some(vortex_plan) = extensions.downcast_ref::<VortexAccessPlan>()
-            {
+            if let Some(vortex_plan) = file.extensions.get::<VortexAccessPlan>() {
                 scan_builder = vortex_plan.apply_to_builder(scan_builder);
             }
 
@@ -1149,9 +1147,12 @@ mod tests {
 
         let schema = batch.schema();
         let mut file = PartitionedFile::new(file_path.to_string(), data_size);
-        file.extensions = Some(Arc::new(VortexAccessPlan::default().with_selection(
-            Selection::IncludeByIndex(Buffer::from_iter(vec![1, 3, 5, 7])),
-        )));
+        file.extensions
+            .insert(
+                VortexAccessPlan::default().with_selection(Selection::IncludeByIndex(
+                    Buffer::from_iter(vec![1, 3, 5, 7]),
+                )),
+            );
 
         let opener = make_test_opener(
             Arc::clone(&object_store),
@@ -1190,9 +1191,12 @@ mod tests {
 
         let schema = batch.schema();
         let mut file = PartitionedFile::new(file_path.to_string(), data_size);
-        file.extensions = Some(Arc::new(VortexAccessPlan::default().with_selection(
-            Selection::ExcludeByIndex(Buffer::from_iter(vec![0, 2, 4, 6, 8])),
-        )));
+        file.extensions
+            .insert(
+                VortexAccessPlan::default().with_selection(Selection::ExcludeByIndex(
+                    Buffer::from_iter(vec![0, 2, 4, 6, 8]),
+                )),
+            );
 
         let opener = make_test_opener(
             Arc::clone(&object_store),
@@ -1234,9 +1238,8 @@ mod tests {
 
         let schema = batch.schema();
         let mut file = PartitionedFile::new(file_path.to_string(), data_size);
-        file.extensions = Some(Arc::new(
-            VortexAccessPlan::default().with_selection(Selection::All),
-        ));
+        file.extensions
+            .insert(VortexAccessPlan::default().with_selection(Selection::All));
 
         let opener = make_test_opener(
             Arc::clone(&object_store),

--- a/vortex-datafusion/src/persistent/sink.rs
+++ b/vortex-datafusion/src/persistent/sink.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
 use std::sync::Arc;
 
 use arrow_schema::SchemaRef;
@@ -69,10 +68,6 @@ impl DisplayAs for VortexSink {
 
 #[async_trait]
 impl DataSink for VortexSink {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn metrics(&self) -> Option<MetricsSet> {
         None
     }

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -8,7 +8,6 @@ use std::sync::Weak;
 
 use datafusion_common::Result as DFResult;
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_datasource::TableSchema;
 use datafusion_datasource::file::FileSource;
 use datafusion_datasource::file_scan_config::FileScanConfig;
@@ -484,24 +483,6 @@ impl FileSource for VortexSource {
 
     fn table_schema(&self) -> &TableSchema {
         &self.table_schema
-    }
-
-    fn apply_expressions(
-        &self,
-        f: &mut dyn FnMut(&dyn PhysicalExpr) -> DFResult<TreeNodeRecursion>,
-    ) -> DFResult<TreeNodeRecursion> {
-        // Visit predicate (filter) expression if present
-        let mut tnr = TreeNodeRecursion::Continue;
-        if let Some(predicate) = &self.vortex_predicate {
-            tnr = tnr.visit_sibling(|| f(predicate.as_ref()))?;
-        }
-
-        // Visit projection expressions
-        for proj_expr in &self.projection {
-            tnr = tnr.visit_sibling(|| f(proj_expr.expr.as_ref()))?;
-        }
-
-        Ok(tnr)
     }
 }
 

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
 use std::fmt::Formatter;
 use std::ops::Range;
 use std::sync::Arc;
@@ -9,6 +8,7 @@ use std::sync::Weak;
 
 use datafusion_common::Result as DFResult;
 use datafusion_common::config::ConfigOptions;
+use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_datasource::TableSchema;
 use datafusion_datasource::file::FileSource;
 use datafusion_datasource::file_scan_config::FileScanConfig;
@@ -361,10 +361,6 @@ impl FileSource for VortexSource {
         )?))
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn with_batch_size(&self, batch_size: usize) -> Arc<dyn FileSource> {
         let mut source = self.clone();
         source.batch_size = Some(batch_size);
@@ -488,6 +484,24 @@ impl FileSource for VortexSource {
 
     fn table_schema(&self) -> &TableSchema {
         &self.table_schema
+    }
+
+    fn apply_expressions(
+        &self,
+        f: &mut dyn FnMut(&dyn PhysicalExpr) -> DFResult<TreeNodeRecursion>,
+    ) -> DFResult<TreeNodeRecursion> {
+        // Visit predicate (filter) expression if present
+        let mut tnr = TreeNodeRecursion::Continue;
+        if let Some(predicate) = &self.vortex_predicate {
+            tnr = tnr.visit_sibling(|| f(predicate.as_ref()))?;
+        }
+
+        // Visit projection expressions
+        for proj_expr in &self.projection {
+            tnr = tnr.visit_sibling(|| f(proj_expr.expr.as_ref()))?;
+        }
+
+        Ok(tnr)
     }
 }
 

--- a/vortex-datafusion/src/v2/source.rs
+++ b/vortex-datafusion/src/v2/source.rs
@@ -67,7 +67,6 @@
 //! [`DataSourceRef`]: vortex::scan::DataSourceRef
 //! [`ScanRequest`]: vortex::scan::ScanRequest
 
-use std::any::Any;
 use std::fmt;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -82,6 +81,7 @@ use datafusion_common::Statistics;
 use datafusion_common::arrow::array::AsArray;
 use datafusion_common::arrow::array::RecordBatch;
 use datafusion_common::stats::Precision as DFPrecision;
+use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_datasource::source::DataSource;
 use datafusion_execution::SendableRecordBatchStream;
 use datafusion_execution::TaskContext;
@@ -469,10 +469,6 @@ impl DataSource for VortexDataSource {
         )))
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
@@ -509,7 +505,7 @@ impl DataSource for VortexDataSource {
         EquivalenceProperties::new(Arc::clone(&self.leftover_schema))
     }
 
-    fn partition_statistics(&self, _partition: Option<usize>) -> DFResult<Statistics> {
+    fn partition_statistics(&self, _partition: Option<usize>) -> DFResult<Arc<Statistics>> {
         // FIXME(ngates): this should be adjusted based on filters. See DuckDB for heuristics,
         //  and in the future, store the selectivity stats in the session.
         let num_rows = estimate_to_df_precision(&self.data_source.row_count());
@@ -521,11 +517,11 @@ impl DataSource for VortexDataSource {
         // from the initial schema after try_swapping_with_projection adds computed columns.
         let column_statistics = self.leftover_statistics.clone();
 
-        Ok(Statistics {
+        Ok(Arc::new(Statistics {
             num_rows,
             total_byte_size,
             column_statistics,
-        })
+        }))
     }
 
     fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn DataSource>> {
@@ -656,6 +652,14 @@ impl DataSource for VortexDataSource {
             FilterPushdownPropagation::with_parent_pushdown_result(pushdown_results)
                 .with_updated_node(Arc::new(this) as _),
         )
+    }
+
+    fn apply_expressions(
+        &self,
+        _f: &mut dyn FnMut(&dyn PhysicalExpr) -> DFResult<TreeNodeRecursion>,
+    ) -> DFResult<TreeNodeRecursion> {
+        // Its unclear to me if this is the desired behavior here.
+        Ok(TreeNodeRecursion::Continue)
     }
 }
 

--- a/vortex-datafusion/src/v2/source.rs
+++ b/vortex-datafusion/src/v2/source.rs
@@ -81,7 +81,6 @@ use datafusion_common::Statistics;
 use datafusion_common::arrow::array::AsArray;
 use datafusion_common::arrow::array::RecordBatch;
 use datafusion_common::stats::Precision as DFPrecision;
-use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_datasource::source::DataSource;
 use datafusion_execution::SendableRecordBatchStream;
 use datafusion_execution::TaskContext;
@@ -652,14 +651,6 @@ impl DataSource for VortexDataSource {
             FilterPushdownPropagation::with_parent_pushdown_result(pushdown_results)
                 .with_updated_node(Arc::new(this) as _),
         )
-    }
-
-    fn apply_expressions(
-        &self,
-        _f: &mut dyn FnMut(&dyn PhysicalExpr) -> DFResult<TreeNodeRecursion>,
-    ) -> DFResult<TreeNodeRecursion> {
-        // Its unclear to me if this is the desired behavior here.
-        Ok(TreeNodeRecursion::Continue)
     }
 }
 

--- a/vortex-datafusion/src/v2/table.rs
+++ b/vortex-datafusion/src/v2/table.rs
@@ -7,7 +7,6 @@
 //! [`DataSourceRef`]: vortex::scan::DataSourceRef
 //! [`TableProvider`]: datafusion_catalog::TableProvider
 
-use std::any::Any;
 use std::fmt;
 use std::sync::Arc;
 
@@ -107,10 +106,6 @@ impl VortexTable {
 
 #[async_trait]
 impl TableProvider for VortexTable {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         Arc::clone(&self.arrow_schema)
     }


### PR DESCRIPTION
## Summary

Originally this PR enabled emitting narrower Arrow decimals (`Decimal32`/`Decimal64`) by default from `to_data_type_naive`. E2E verification against `datafusion-bench` with **real generated data** showed this is **not safe on the versions Vortex ships**, so the behavior change has been reverted; the net diff is now an explanatory comment documenting *why* the narrower widths stay gated.

## What the verification found

- **arrow-rs 58 / DataFusion 53** both have the `Decimal32`/`Decimal64` types (added in arrow-rs ~v56 and DataFusion 51.0.0), and Vortex's Arrow executor already produces all four widths on request. So the *types* exist.
- But **DataFusion 53 keeps decimal `SUM`/`AVG` within the same physical width family** — `Decimal32 → i32`, `Decimal64 → i64` — instead of widening the accumulator (`datafusion-functions-aggregate` `sum.rs` / `average.rs`). A `Decimal32` `SUM`/`AVG` is capped at precision 9 / `i32`, so it overflows once the running total exceeds ~1e9, regardless of row count.
  - **TPC-DS Q1** (`avg(sum(sr_return_amt))`, `sr_return_amt` = `decimal(7,2)`, inferred schema → `Decimal32`) fails with `Arithmetic Overflow in AvgAccumulator`. Tracked upstream in [apache/datafusion#17489](https://github.com/apache/datafusion/issues/17489).
  - **TPC-H Q1/Q6** pass — but only because TPC-H registers explicit `Decimal128(15,2)` schemas, so its plan never sees the narrow type.
- The **Spark/JNI bindings assume 128-bit decimals** (`SparkToArrowSchema` hard-codes `bitWidth = 128`; the JNI `TestMinimal` writes `Decimal128(9,2)` and asserts an exact round-trip), so any narrowing breaks the round-trip — confirmed by the `TestMinimal.testFullScan` failure.

There is no narrowing tier that's safe across all current consumers: `Decimal32` breaks DataFusion aggregation + JNI; `Decimal64` would break the Spark `decimal(10,2)` round-trip too. The original guard comment was correct.

## Change

Revert to the `Decimal128` default and replace the terse `// commented out until DataFusion improves...` note with a comment recording the concrete reasons (accumulator overflow + 128-bit binding assumption, with the upstream issue link). The Arrow executor still emits `Decimal32`/`Decimal64` when a consumer explicitly requests that target type — only the inferred default stays `Decimal128`.

## Follow-up option

If we want the storage/bandwidth win for narrow decimals without breaking these consumers, the path is to make narrowing **opt-in** (default stays `Decimal128`, enabled via a session/config flag). Happy to do that as a separate change.

## Checks

- `cargo test -p vortex-array --lib dtype::arrow` ✅
- `datafusion-bench tpch --formats parquet,vortex --queries 1,6` (SF=1, real data) ✅ — row counts validated
- Decimal mapping now byte-for-byte equivalent to `develop` (comment-only diff), restoring the green baseline for the TPC-DS bench and JNI jobs.

https://claude.ai/code/session_01RctLpues7aLnsxJ86XH9pC