### PR TITLE
ci: update Claude actions to use Opus 4.8 model

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -254,5 +254,6 @@ jobs:
             actions: read
 
           claude_args: |
+            --model claude-opus-4-8
             --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git show:*),Bash(git log:*),Bash(head:*),Bash(jq:*),Bash(rg:*)"
             --system-prompt "You are the repository's read-only Claude review workflow. Review the current same-repo pull request and respond in GitHub. Never modify files, never create commits, never push branches, and never open or update pull requests. Fork pull requests are blocked before this job starts."

--- a/.github/workflows/claude-write.yml
+++ b/.github/workflows/claude-write.yml
@@ -208,6 +208,7 @@ jobs:
             actions: read
 
           claude_args: |
+            --model claude-opus-4-8
             --allowedTools "Bash(cargo nextest:*),Bash(cargo check:*),Bash(cargo clippy:*),Bash(cargo fmt:*),Bash(uv run:*)"
             --system-prompt "You are the repository's write-capable Claude workflow. You run only from trusted issue traffic and from trusted PR conversation comments on same-repo pull requests that were previously opened by the repository's Claude GitHub App. Create or update branches and pull requests using the provided GitHub App token. Do not use fork pull request content because those runs are blocked before this job starts."
 

--- a/.github/workflows/fuzzer-fix-automation.yml
+++ b/.github/workflows/fuzzer-fix-automation.yml
@@ -357,7 +357,7 @@ jobs:
             **Suggested Approach**: [Recommendation with code snippets if possible]
             ```
           claude_args: |
-            --model claude-opus-4-20250514
+            --model claude-opus-4-8
             --max-turns 120
             --allowedTools "Read,Write,Edit,Glob,Grep,Bash(cargo:*),Bash(gh issue comment:*),Bash(gh run download:*),Bash(curl:*),Bash(find:*),Bash(ls:*),Bash(cat:*),Bash(RUST_BACKTRACE=* cargo:*)"
 


### PR DESCRIPTION
Update the model ID across all three Claude-powered workflows to the newer claude-opus-4-8 (Claude Opus 4.8):

- fuzzer-fix-automation.yml: bump from claude-opus-4-20250514
- claude-review.yml: pin model explicitly (was action default)
- claude-write.yml: pin model explicitly (was action default)
