### PR TITLE
ci(fuzz): fix self-cancelling concurrency in fuzzer autofix

### DIFF
--- a/.github/workflows/fuzzer-fix-automation.yml
+++ b/.github/workflows/fuzzer-fix-automation.yml
@@ -1,7 +1,8 @@
 name: Fuzzer Fix Automation
 
+# Distinct from the caller's `fuzzer-fix-<issue>` group: this reusable workflow runs inside the caller's run, so sharing the name would make it cancel its own parent (cancel-in-progress).
 concurrency:
-  group: fuzzer-fix-${{ inputs.issue_number || github.run_id }}
+  group: fuzzer-fix-automation-${{ inputs.issue_number || github.run_id }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
## Problem

Filing/labeling a fuzzer issue triggers `fuzzer-issue-autofix.yml`, which calls the reusable `fuzzer-fix-automation.yml`. Both used the **same** concurrency group name, `fuzzer-fix-<issue>`:

- caller `fuzzer-issue-autofix.yml`: `group: fuzzer-fix-${{ github.event.issue.number }}`
- callee `fuzzer-fix-automation.yml`: `group: fuzzer-fix-${{ inputs.issue_number || github.run_id }}`

A reusable workflow runs **inside its caller's run**. When the caller's `autofix` job invoked the reusable workflow, the callee entered the identical group with `cancel-in-progress: true` and **cancelled its own parent run**.
