### PR TITLE
ci: allow changelog/ci label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -40,6 +40,7 @@ version-resolver:
 
 exclude-labels:
   - "changelog/skip"
+  - "changelog/ci"
 
 template: |
   ## Changes

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -40,6 +40,7 @@ jobs:
             "changelog/fix"
             "changelog/docs"
             "changelog/chore"
+            "changelog/ci"
             "changelog/skip"
           )
           REQUIRED_LABELS_JSON=$(jq -n '$ARGS.positional' --args "${REQUIRED_LABELS[@]}")


### PR DESCRIPTION
Add `changelog/ci` to the accepted changelog labels so the Validate Changelog Label check passes for CI PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGpV4yB3TneBSGQYdu737C)_