### PR TITLE
use mimalloc only on MacOS

### DIFF
--- a/vortex-bench/Cargo.toml
+++ b/vortex-bench/Cargo.toml
@@ -39,7 +39,6 @@ glob = { workspace = true }
 humansize = { workspace = true }
 indicatif = { workspace = true, features = ["futures"] }
 itertools = { workspace = true }
-mimalloc = { workspace = true }
 noodles-bgzf = { workspace = true, features = ["async"] }
 noodles-vcf = { workspace = true, features = ["async"] }
 parking_lot = { workspace = true }
@@ -66,6 +65,9 @@ tracing-subscriber = { workspace = true, features = [
 ] }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+mimalloc = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/vortex-bench/src/lib.rs
+++ b/vortex-bench/src/lib.rs
@@ -68,7 +68,8 @@ pub use vortex::error::vortex_panic;
 use vortex::io::session::RuntimeSessionExt;
 use vortex::session::VortexSession;
 
-// All benchmarks run with mimalloc for consistency.
+// All benchmarks run with mimalloc for consistency on macOS.
+#[cfg(target_os = "macos")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/vortex-ffi/src/lib.rs
+++ b/vortex-ffi/src/lib.rs
@@ -36,7 +36,7 @@ use vortex::error::VortexResult;
 use vortex::error::vortex_err;
 use vortex::io::runtime::current::CurrentThreadRuntime;
 
-#[cfg(all(feature = "mimalloc", not(miri)))]
+#[cfg(all(target_os = "macos", feature = "mimalloc", not(miri)))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/vortex-tensor/Cargo.toml
+++ b/vortex-tensor/Cargo.toml
@@ -34,9 +34,11 @@ prost = { workspace = true }
 
 [dev-dependencies]
 divan = { workspace = true }
-mimalloc = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 rstest = { workspace = true }
 vortex-array = { workspace = true, features = ["_test-harness"] }
 vortex-btrblocks = { path = "../vortex-btrblocks" }
+
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+mimalloc = { workspace = true }

--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -55,7 +55,6 @@ arrow-array = { workspace = true }
 divan = { workspace = true }
 fastlanes = { workspace = true }
 futures = { workspace = true }
-mimalloc = { workspace = true }
 parquet = { workspace = true }
 paste = { workspace = true }
 rand = { workspace = true }
@@ -67,6 +66,9 @@ tracing-subscriber = { workspace = true }
 vortex = { path = ".", features = ["tokio"] }
 vortex-bench = { workspace = true, features = ["unstable_encodings"] }
 vortex-tensor = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+mimalloc = { workspace = true }
 
 [features]
 default = ["files", "zstd"]

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -9,6 +9,7 @@ use std::ops::Deref;
 use divan::Bencher;
 #[cfg(not(codspeed))]
 use divan::counter::BytesCount;
+#[cfg(target_os = "macos")]
 use mimalloc::MiMalloc;
 use rand::RngExt;
 use rand::SeedableRng;
@@ -44,6 +45,7 @@ use vortex::encodings::runend::RunEndArrayExt;
 use vortex::error::VortexExpect;
 use vortex::extension::datetime::TimeUnit;
 
+#[cfg(target_os = "macos")]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -9,6 +9,7 @@ use std::sync::LazyLock;
 use divan::Bencher;
 #[cfg(not(codspeed))]
 use divan::counter::BytesCount;
+#[cfg(target_os = "macos")]
 use mimalloc::MiMalloc;
 use rand::RngExt;
 use rand::SeedableRng;
@@ -44,6 +45,7 @@ use vortex_error::VortexResult;
 use vortex_sequence::Sequence;
 use vortex_session::VortexSession;
 
+#[cfg(target_os = "macos")]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 


### PR DESCRIPTION
Vortex being an application plugin shouldn't bring our own allocator.
MacOS has a bad default allocator so on MacOS we still use mimalloc for
local benchmarks
