### PR TITLE
Expose row_idx in vortex-jni bindings

### DIFF
--- a/java/vortex-jni/src/main/java/dev/vortex/api/Expression.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/Expression.java
@@ -41,6 +41,14 @@ public final class Expression {
         return new Expression(NativeExpression.root());
     }
 
+    /**
+     * The row-index expression. When evaluated as part of a Vortex scan it yields the zero-based index of each row
+     * within the file as a non-nullable {@code u64}. It cannot be evaluated outside of a scan.
+     */
+    public static Expression rowIdx() {
+        return new Expression(NativeExpression.rowIdx());
+    }
+
     /** Access a named field from a struct expression. */
     public static Expression getItem(String fieldName, Expression child) {
         return new Expression(NativeExpression.getItem(fieldName, child.nativePointer()));

--- a/java/vortex-jni/src/main/java/dev/vortex/api/Expression.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/Expression.java
@@ -42,8 +42,10 @@ public final class Expression {
     }
 
     /**
-     * The row-index expression. When evaluated as part of a Vortex scan it yields the zero-based index of each row
-     * within the file as a non-nullable {@code u64}. It cannot be evaluated outside of a scan.
+     * The row-index expression. When evaluated as part of a Vortex scan it yields, as a non-nullable {@code u64}, each
+     * row's index in the file <em>before</em> filtering: the index is assigned to the unfiltered rows, so filtered-out
+     * rows leave gaps and the surviving rows keep their original positions rather than being renumbered. It cannot be
+     * evaluated outside of a scan.
      */
     public static Expression rowIdx() {
         return new Expression(NativeExpression.rowIdx());

--- a/java/vortex-jni/src/main/java/dev/vortex/jni/NativeExpression.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/jni/NativeExpression.java
@@ -13,6 +13,8 @@ public final class NativeExpression {
 
     public static native long root();
 
+    public static native long rowIdx();
+
     public static native long getItem(String fieldName, long childPointer);
 
     public static native long select(String[] fieldNames, long childPointer);

--- a/java/vortex-jni/src/test/java/dev/vortex/api/ExpressionTest.java
+++ b/java/vortex-jni/src/test/java/dev/vortex/api/ExpressionTest.java
@@ -4,6 +4,7 @@
 package dev.vortex.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -16,6 +17,13 @@ public final class ExpressionTest {
     @BeforeAll
     public static void loadLibrary() {
         NativeLoader.loadJni();
+    }
+
+    @Test
+    public void rowIdxBuildsAndComposes() {
+        assertNotNull(Expression.rowIdx());
+        // Mirrors `gt(row_idx(), lit(...))` on the Rust side: the row-index expression composes like any other.
+        assertNotNull(Expression.binary(Expression.BinaryOp.LT, Expression.rowIdx(), Expression.literal(5L)));
     }
 
     @Test

--- a/vortex-jni/src/expression.rs
+++ b/vortex-jni/src/expression.rs
@@ -48,6 +48,7 @@ use vortex::extension::datetime::TimeUnit;
 use vortex::extension::datetime::Timestamp;
 use vortex::extension::uuid::Uuid;
 use vortex::extension::uuid::UuidMetadata;
+use vortex::layout::layouts::row_idx::row_idx;
 use vortex::scalar::DecimalValue;
 use vortex::scalar::Scalar;
 use vortex::scalar::ScalarValue;
@@ -114,6 +115,14 @@ pub extern "system" fn Java_dev_vortex_jni_NativeExpression_root(
     _class: JClass,
 ) -> jlong {
     into_raw(root())
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_vortex_jni_NativeExpression_rowIdx(
+    _env: EnvUnowned,
+    _class: JClass,
+) -> jlong {
+    into_raw(row_idx())
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
These are necessary for supporting iceberg row positions

