### PR TITLE
Rename ArrayEq/Hash Precision to `EqMode`

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -8,7 +8,6 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 use prost::Message;
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -17,6 +16,7 @@ use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArraySlots;
 use vortex_array::ArrayView;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -55,14 +55,14 @@ use crate::alp::rules::RULES;
 pub type ALPArray = Array<ALP>;
 
 impl ArrayHash for ALPData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: EqMode) {
         self.exponents.hash(state);
         self.patches_data.hash(state);
     }
 }
 
 impl ArrayEq for ALPData {
-    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: EqMode) -> bool {
         self.exponents == other.exponents && self.patches_data == other.patches_data
     }
 }

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -8,6 +8,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 use prost::Message;
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -19,7 +20,6 @@ use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::Precision;
 use vortex_array::TypedArrayRef;
 use vortex_array::array_slots;
 use vortex_array::arrays::Primitive;
@@ -55,14 +55,14 @@ use crate::alp::rules::RULES;
 pub type ALPArray = Array<ALP>;
 
 impl ArrayHash for ALPData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
         self.exponents.hash(state);
         self.patches_data.hash(state);
     }
 }
 
 impl ArrayEq for ALPData {
-    fn array_eq(&self, other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
         self.exponents == other.exponents && self.patches_data == other.patches_data
     }
 }

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -9,7 +9,6 @@ use std::hash::Hasher;
 
 use itertools::Itertools;
 use prost::Message;
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -19,6 +18,7 @@ use vortex_array::ArrayRef;
 use vortex_array::ArraySlots;
 use vortex_array::ArrayView;
 use vortex_array::Canonical;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -75,7 +75,7 @@ pub struct ALPRDMetadata {
 }
 
 impl ArrayHash for ALPRDData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: EqMode) {
         self.left_parts_dictionary.array_hash(state, accuracy);
         self.right_bit_width.hash(state);
         self.patches_data.hash(state);
@@ -83,7 +83,7 @@ impl ArrayHash for ALPRDData {
 }
 
 impl ArrayEq for ALPRDData {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: EqMode) -> bool {
         self.left_parts_dictionary
             .array_eq(&other.left_parts_dictionary, accuracy)
             && self.right_bit_width == other.right_bit_width

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -9,6 +9,7 @@ use std::hash::Hasher;
 
 use itertools::Itertools;
 use prost::Message;
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -22,7 +23,6 @@ use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
 use vortex_array::LEGACY_SESSION;
-use vortex_array::Precision;
 use vortex_array::TypedArrayRef;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::Primitive;
@@ -75,17 +75,17 @@ pub struct ALPRDMetadata {
 }
 
 impl ArrayHash for ALPRDData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
-        self.left_parts_dictionary.array_hash(state, precision);
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+        self.left_parts_dictionary.array_hash(state, accuracy);
         self.right_bit_width.hash(state);
         self.patches_data.hash(state);
     }
 }
 
 impl ArrayEq for ALPRDData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
         self.left_parts_dictionary
-            .array_eq(&other.left_parts_dictionary, precision)
+            .array_eq(&other.left_parts_dictionary, accuracy)
             && self.right_bit_width == other.right_bit_width
             && self.patches_data == other.patches_data
     }

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -6,7 +6,6 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::hash::Hasher;
 
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -15,6 +14,7 @@ use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArraySlots;
 use vortex_array::ArrayView;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -45,13 +45,13 @@ use crate::kernel::PARENT_KERNELS;
 pub type ByteBoolArray = Array<ByteBool>;
 
 impl ArrayHash for ByteBoolData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: EqMode) {
         self.buffer.array_hash(state, accuracy);
     }
 }
 
 impl ArrayEq for ByteBoolData {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: EqMode) -> bool {
         self.buffer.array_eq(&other.buffer, accuracy)
     }
 }

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -6,6 +6,7 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::hash::Hasher;
 
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -17,7 +18,6 @@ use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::Precision;
 use vortex_array::TypedArrayRef;
 use vortex_array::arrays::BoolArray;
 use vortex_array::buffer::BufferHandle;
@@ -45,14 +45,14 @@ use crate::kernel::PARENT_KERNELS;
 pub type ByteBoolArray = Array<ByteBool>;
 
 impl ArrayHash for ByteBoolData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
-        self.buffer.array_hash(state, precision);
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+        self.buffer.array_hash(state, accuracy);
     }
 }
 
 impl ArrayEq for ByteBoolData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
-        self.buffer.array_eq(&other.buffer, precision)
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+        self.buffer.array_eq(&other.buffer, accuracy)
     }
 }
 

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -7,7 +7,6 @@ use std::fmt::Formatter;
 use std::hash::Hasher;
 
 use prost::Message;
-use vortex_array::Accuracy;
 use vortex_array::AnyCanonical;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
@@ -16,6 +15,7 @@ use vortex_array::ArrayId;
 use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -50,11 +50,11 @@ use crate::split_temporal;
 pub type DateTimePartsArray = Array<DateTimeParts>;
 
 impl ArrayHash for DateTimePartsData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: EqMode) {}
 }
 
 impl ArrayEq for DateTimePartsData {
-    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: EqMode) -> bool {
         true
     }
 }

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -7,6 +7,7 @@ use std::fmt::Formatter;
 use std::hash::Hasher;
 
 use prost::Message;
+use vortex_array::Accuracy;
 use vortex_array::AnyCanonical;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
@@ -18,7 +19,6 @@ use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::Precision;
 use vortex_array::array_slots;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::TemporalArray;
@@ -50,11 +50,11 @@ use crate::split_temporal;
 pub type DateTimePartsArray = Array<DateTimeParts>;
 
 impl ArrayHash for DateTimePartsData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _precision: Precision) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
 }
 
 impl ArrayEq for DateTimePartsData {
-    fn array_eq(&self, _other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
         true
     }
 }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -13,11 +13,11 @@ mod rules;
 mod slice;
 
 use prost::Message as _;
-use vortex_array::Accuracy;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
 use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -53,11 +53,11 @@ use crate::decimal_byte_parts::rules::PARENT_RULES;
 pub type DecimalBytePartsArray = Array<DecimalByteParts>;
 
 impl ArrayHash for DecimalBytePartsData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: EqMode) {}
 }
 
 impl ArrayEq for DecimalBytePartsData {
-    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: EqMode) -> bool {
         true
     }
 }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -13,6 +13,7 @@ mod rules;
 mod slice;
 
 use prost::Message as _;
+use vortex_array::Accuracy;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
 use vortex_array::ArrayId;
@@ -20,7 +21,6 @@ use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::Precision;
 use vortex_array::TypedArrayRef;
 use vortex_array::arrays::DecimalArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -53,11 +53,11 @@ use crate::decimal_byte_parts::rules::PARENT_RULES;
 pub type DecimalBytePartsArray = Array<DecimalByteParts>;
 
 impl ArrayHash for DecimalBytePartsData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _precision: Precision) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
 }
 
 impl ArrayEq for DecimalBytePartsData {
-    fn array_eq(&self, _other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
         true
     }
 }

--- a/encodings/experimental/onpair/src/array.rs
+++ b/encodings/experimental/onpair/src/array.rs
@@ -7,6 +7,7 @@ use std::fmt::Formatter;
 use std::hash::Hasher;
 
 use prost::Message as _;
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -18,7 +19,6 @@ use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::Precision;
 use vortex_array::array_slots;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::builders::ArrayBuilder;
@@ -196,19 +196,19 @@ impl Debug for OnPairData {
 }
 
 impl ArrayHash for OnPairData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
-        self.dict_bytes.as_host().array_hash(state, precision);
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+        self.dict_bytes.as_host().array_hash(state, accuracy);
         state.write_u32(self.bits);
     }
 }
 
 impl ArrayEq for OnPairData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
         self.bits == other.bits
             && self
                 .dict_bytes
                 .as_host()
-                .array_eq(other.dict_bytes.as_host(), precision)
+                .array_eq(other.dict_bytes.as_host(), accuracy)
     }
 }
 

--- a/encodings/experimental/onpair/src/array.rs
+++ b/encodings/experimental/onpair/src/array.rs
@@ -7,7 +7,6 @@ use std::fmt::Formatter;
 use std::hash::Hasher;
 
 use prost::Message as _;
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -16,6 +15,7 @@ use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::Canonical;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -196,14 +196,14 @@ impl Debug for OnPairData {
 }
 
 impl ArrayHash for OnPairData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: EqMode) {
         self.dict_bytes.as_host().array_hash(state, accuracy);
         state.write_u32(self.bits);
     }
 }
 
 impl ArrayEq for OnPairData {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: EqMode) -> bool {
         self.bits == other.bits
             && self
                 .dict_bytes

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -5,6 +5,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 use prost::Message;
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -16,7 +17,6 @@ use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::Precision;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::builders::ArrayBuilder;
 use vortex_array::dtype::DType;
@@ -69,19 +69,19 @@ pub struct BitPackedMetadata {
 }
 
 impl ArrayHash for BitPackedData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
         self.offset.hash(state);
         self.bit_width.hash(state);
-        self.packed.array_hash(state, precision);
+        self.packed.array_hash(state, accuracy);
         self.patches_data.hash(state);
     }
 }
 
 impl ArrayEq for BitPackedData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
         self.offset == other.offset
             && self.bit_width == other.bit_width
-            && self.packed.array_eq(&other.packed, precision)
+            && self.packed.array_eq(&other.packed, accuracy)
             && self.patches_data == other.patches_data
     }
 }

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -5,7 +5,6 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 use prost::Message;
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -14,6 +13,7 @@ use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArraySlots;
 use vortex_array::ArrayView;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -69,7 +69,7 @@ pub struct BitPackedMetadata {
 }
 
 impl ArrayHash for BitPackedData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: EqMode) {
         self.offset.hash(state);
         self.bit_width.hash(state);
         self.packed.array_hash(state, accuracy);
@@ -78,7 +78,7 @@ impl ArrayHash for BitPackedData {
 }
 
 impl ArrayEq for BitPackedData {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: EqMode) -> bool {
         self.offset == other.offset
             && self.bit_width == other.bit_width
             && self.packed.array_eq(&other.packed, accuracy)

--- a/encodings/fastlanes/src/delta/vtable/mod.rs
+++ b/encodings/fastlanes/src/delta/vtable/mod.rs
@@ -5,7 +5,6 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 use prost::Message;
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -13,6 +12,7 @@ use vortex_array::ArrayId;
 use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -58,13 +58,13 @@ pub struct DeltaMetadata {
 }
 
 impl ArrayHash for DeltaData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: EqMode) {
         self.offset.hash(state);
     }
 }
 
 impl ArrayEq for DeltaData {
-    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: EqMode) -> bool {
         self.offset == other.offset
     }
 }

--- a/encodings/fastlanes/src/delta/vtable/mod.rs
+++ b/encodings/fastlanes/src/delta/vtable/mod.rs
@@ -5,6 +5,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 use prost::Message;
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -15,7 +16,6 @@ use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::Precision;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
@@ -58,13 +58,13 @@ pub struct DeltaMetadata {
 }
 
 impl ArrayHash for DeltaData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
         self.offset.hash(state);
     }
 }
 
 impl ArrayEq for DeltaData {
-    fn array_eq(&self, other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
         self.offset == other.offset
     }
 }

--- a/encodings/fastlanes/src/for/vtable/mod.rs
+++ b/encodings/fastlanes/src/for/vtable/mod.rs
@@ -5,7 +5,6 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::hash::Hasher;
 
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -13,6 +12,7 @@ use vortex_array::ArrayId;
 use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -50,13 +50,13 @@ mod validity;
 pub type FoRArray = Array<FoR>;
 
 impl ArrayHash for FoRData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: EqMode) {
         self.reference.hash(state);
     }
 }
 
 impl ArrayEq for FoRData {
-    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: EqMode) -> bool {
         self.reference == other.reference
     }
 }

--- a/encodings/fastlanes/src/for/vtable/mod.rs
+++ b/encodings/fastlanes/src/for/vtable/mod.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::hash::Hasher;
 
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -15,7 +16,6 @@ use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::Precision;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
@@ -50,13 +50,13 @@ mod validity;
 pub type FoRArray = Array<FoR>;
 
 impl ArrayHash for FoRData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
         self.reference.hash(state);
     }
 }
 
 impl ArrayEq for FoRData {
-    fn array_eq(&self, other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
         self.reference == other.reference
     }
 }

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -5,7 +5,6 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 use prost::Message;
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -13,6 +12,7 @@ use vortex_array::ArrayId;
 use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -65,13 +65,13 @@ pub struct RLEMetadata {
 }
 
 impl ArrayHash for RLEData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: EqMode) {
         self.offset.hash(state);
     }
 }
 
 impl ArrayEq for RLEData {
-    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: EqMode) -> bool {
         self.offset == other.offset
     }
 }

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -5,6 +5,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 use prost::Message;
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -15,7 +16,6 @@ use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::Precision;
 use vortex_array::arrays::Primitive;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
@@ -65,13 +65,13 @@ pub struct RLEMetadata {
 }
 
 impl ArrayHash for RLEData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
         self.offset.hash(state);
     }
 }
 
 impl ArrayEq for RLEData {
-    fn array_eq(&self, other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
         self.offset == other.offset
     }
 }

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -12,7 +12,6 @@ use fsst::Compressor;
 use fsst::Decompressor;
 use fsst::Symbol;
 use prost::Message as _;
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -22,6 +21,7 @@ use vortex_array::ArrayRef;
 use vortex_array::ArraySlots;
 use vortex_array::ArrayView;
 use vortex_array::Canonical;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -80,7 +80,7 @@ impl FSSTMetadata {
 }
 
 impl ArrayHash for FSSTData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, precision: EqMode) {
         self.symbol_table.symbols.array_hash(state, precision);
         self.symbol_table
             .symbol_lengths
@@ -90,7 +90,7 @@ impl ArrayHash for FSSTData {
 }
 
 impl ArrayEq for FSSTData {
-    fn array_eq(&self, other: &Self, precision: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, precision: EqMode) -> bool {
         self.symbol_table
             .symbols
             .array_eq(&other.symbol_table.symbols, precision)

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -12,6 +12,7 @@ use fsst::Compressor;
 use fsst::Decompressor;
 use fsst::Symbol;
 use prost::Message as _;
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -25,7 +26,6 @@ use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
 use vortex_array::LEGACY_SESSION;
-use vortex_array::Precision;
 use vortex_array::TypedArrayRef;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::VarBin;
@@ -80,7 +80,7 @@ impl FSSTMetadata {
 }
 
 impl ArrayHash for FSSTData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Accuracy) {
         self.symbol_table.symbols.array_hash(state, precision);
         self.symbol_table
             .symbol_lengths
@@ -90,7 +90,7 @@ impl ArrayHash for FSSTData {
 }
 
 impl ArrayEq for FSSTData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, precision: Accuracy) -> bool {
         self.symbol_table
             .symbols
             .array_eq(&other.symbol_table.symbols, precision)

--- a/encodings/parquet-variant/src/vtable.rs
+++ b/encodings/parquet-variant/src/vtable.rs
@@ -304,13 +304,13 @@ mod tests {
     use parquet_variant_compute::VariantArray as ArrowVariantArray;
     use rstest::fixture;
     use rstest::rstest;
+    use vortex_array::Accuracy;
     use vortex_array::ArrayContext;
     use vortex_array::ArrayEq;
     use vortex_array::ArrayRef;
     use vortex_array::Canonical;
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
-    use vortex_array::Precision;
     use vortex_array::VTable;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
@@ -525,7 +525,7 @@ mod tests {
         let array = outer_pv.into_array();
         let decoded = roundtrip(array.clone())?;
 
-        assert!(array.array_eq(&decoded, Precision::Value));
+        assert!(array.array_eq(&decoded, Accuracy::Value));
         let decoded_pv = decoded
             .as_opt::<ParquetVariant>()
             .ok_or_else(|| vortex_err!("expected parquet variant array"))?;
@@ -547,7 +547,7 @@ mod tests {
         let array = pv.into_array();
         let decoded = roundtrip(array.clone())?;
 
-        assert!(array.array_eq(&decoded, Precision::Value));
+        assert!(array.array_eq(&decoded, Accuracy::Value));
         assert_eq!(decoded.dtype(), &DType::Variant(Nullability::Nullable));
         let decoded_pv = decoded
             .as_opt::<ParquetVariant>()
@@ -572,7 +572,7 @@ mod tests {
         let array = outer_pv.into_array();
         let decoded = roundtrip(array.clone())?;
 
-        assert!(array.array_eq(&decoded, Precision::Value));
+        assert!(array.array_eq(&decoded, Accuracy::Value));
         let decoded_pv = decoded
             .as_opt::<ParquetVariant>()
             .ok_or_else(|| vortex_err!("expected parquet variant array"))?;

--- a/encodings/parquet-variant/src/vtable.rs
+++ b/encodings/parquet-variant/src/vtable.rs
@@ -304,11 +304,11 @@ mod tests {
     use parquet_variant_compute::VariantArray as ArrowVariantArray;
     use rstest::fixture;
     use rstest::rstest;
-    use vortex_array::Accuracy;
     use vortex_array::ArrayContext;
     use vortex_array::ArrayEq;
     use vortex_array::ArrayRef;
     use vortex_array::Canonical;
+    use vortex_array::EqMode;
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
     use vortex_array::VTable;
@@ -525,7 +525,7 @@ mod tests {
         let array = outer_pv.into_array();
         let decoded = roundtrip(array.clone())?;
 
-        assert!(array.array_eq(&decoded, Accuracy::Value));
+        assert!(array.array_eq(&decoded, EqMode::Value));
         let decoded_pv = decoded
             .as_opt::<ParquetVariant>()
             .ok_or_else(|| vortex_err!("expected parquet variant array"))?;
@@ -547,7 +547,7 @@ mod tests {
         let array = pv.into_array();
         let decoded = roundtrip(array.clone())?;
 
-        assert!(array.array_eq(&decoded, Accuracy::Value));
+        assert!(array.array_eq(&decoded, EqMode::Value));
         assert_eq!(decoded.dtype(), &DType::Variant(Nullability::Nullable));
         let decoded_pv = decoded
             .as_opt::<ParquetVariant>()
@@ -572,7 +572,7 @@ mod tests {
         let array = outer_pv.into_array();
         let decoded = roundtrip(array.clone())?;
 
-        assert!(array.array_eq(&decoded, Accuracy::Value));
+        assert!(array.array_eq(&decoded, EqMode::Value));
         let decoded_pv = decoded
             .as_opt::<ParquetVariant>()
             .ok_or_else(|| vortex_err!("expected parquet variant array"))?;

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -18,7 +18,6 @@ use pco::wrapped::ChunkDecompressor;
 use pco::wrapped::FileCompressor;
 use pco::wrapped::FileDecompressor;
 use prost::Message;
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -26,6 +25,7 @@ use vortex_array::ArrayId;
 use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -83,7 +83,7 @@ const VALUES_PER_CHUNK: usize = pco::DEFAULT_MAX_PAGE_N;
 pub type PcoArray = Array<Pco>;
 
 impl ArrayHash for PcoData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: EqMode) {
         self.unsliced_n_rows.hash(state);
         self.slice_start.hash(state);
         self.slice_stop.hash(state);
@@ -98,7 +98,7 @@ impl ArrayHash for PcoData {
 }
 
 impl ArrayEq for PcoData {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: EqMode) -> bool {
         if self.unsliced_n_rows != other.unsliced_n_rows
             || self.slice_start != other.slice_start
             || self.slice_stop != other.slice_stop

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -18,6 +18,7 @@ use pco::wrapped::ChunkDecompressor;
 use pco::wrapped::FileCompressor;
 use pco::wrapped::FileDecompressor;
 use prost::Message;
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -28,7 +29,6 @@ use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::Precision;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
@@ -83,22 +83,22 @@ const VALUES_PER_CHUNK: usize = pco::DEFAULT_MAX_PAGE_N;
 pub type PcoArray = Array<Pco>;
 
 impl ArrayHash for PcoData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
         self.unsliced_n_rows.hash(state);
         self.slice_start.hash(state);
         self.slice_stop.hash(state);
         // Hash chunk_metas and pages using pointer-based hashing
         for chunk_meta in &self.chunk_metas {
-            chunk_meta.array_hash(state, precision);
+            chunk_meta.array_hash(state, accuracy);
         }
         for page in &self.pages {
-            page.array_hash(state, precision);
+            page.array_hash(state, accuracy);
         }
     }
 }
 
 impl ArrayEq for PcoData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
         if self.unsliced_n_rows != other.unsliced_n_rows
             || self.slice_start != other.slice_start
             || self.slice_stop != other.slice_stop
@@ -108,12 +108,12 @@ impl ArrayEq for PcoData {
             return false;
         }
         for (a, b) in self.chunk_metas.iter().zip(&other.chunk_metas) {
-            if !a.array_eq(b, precision) {
+            if !a.array_eq(b, accuracy) {
                 return false;
             }
         }
         for (a, b) in self.pages.iter().zip(&other.pages) {
-            if !a.array_eq(b, precision) {
+            if !a.array_eq(b, accuracy) {
                 return false;
             }
         }

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -8,6 +8,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 use prost::Message;
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -19,7 +20,6 @@ use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
 use vortex_array::LEGACY_SESSION;
-use vortex_array::Precision;
 use vortex_array::TypedArrayRef;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::Primitive;
@@ -65,13 +65,13 @@ pub struct RunEndMetadata {
 }
 
 impl ArrayHash for RunEndData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
         self.offset.hash(state);
     }
 }
 
 impl ArrayEq for RunEndData {
-    fn array_eq(&self, other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
         self.offset == other.offset
     }
 }

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -8,7 +8,6 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 use prost::Message;
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -16,6 +15,7 @@ use vortex_array::ArrayId;
 use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -65,13 +65,13 @@ pub struct RunEndMetadata {
 }
 
 impl ArrayHash for RunEndData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: EqMode) {
         self.offset.hash(state);
     }
 }
 
 impl ArrayEq for RunEndData {
-    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: EqMode) -> bool {
         self.offset == other.offset
     }
 }

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -9,7 +9,6 @@ use std::hash::Hasher;
 use num_traits::cast::FromPrimitive;
 use prost::Message;
 use smallvec::smallvec;
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -17,6 +16,7 @@ use vortex_array::ArrayId;
 use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::buffer::BufferHandle;
@@ -214,14 +214,14 @@ impl SequenceData {
 }
 
 impl ArrayHash for SequenceData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: EqMode) {
         self.base.hash(state);
         self.multiplier.hash(state);
     }
 }
 
 impl ArrayEq for SequenceData {
-    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: EqMode) -> bool {
         self.base == other.base && self.multiplier == other.multiplier
     }
 }

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -9,6 +9,7 @@ use std::hash::Hasher;
 use num_traits::cast::FromPrimitive;
 use prost::Message;
 use smallvec::smallvec;
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -18,7 +19,6 @@ use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
-use vortex_array::Precision;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
@@ -214,14 +214,14 @@ impl SequenceData {
 }
 
 impl ArrayHash for SequenceData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
         self.base.hash(state);
         self.multiplier.hash(state);
     }
 }
 
 impl ArrayEq for SequenceData {
-    fn array_eq(&self, other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
         self.base == other.base && self.multiplier == other.multiplier
     }
 }

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -9,7 +9,6 @@ use std::hash::Hasher;
 
 use kernel::PARENT_KERNELS;
 use prost::Message as _;
-use vortex_array::Accuracy;
 use vortex_array::AnyCanonical;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
@@ -20,6 +19,7 @@ use vortex_array::ArrayRef;
 use vortex_array::ArraySlots;
 use vortex_array::ArrayView;
 use vortex_array::Canonical;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -165,7 +165,7 @@ pub struct SparseMetadata {
 }
 
 impl ArrayHash for SparseData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: EqMode) {
         self.array_len.hash(state);
         self.patches_data.hash(state);
         self.fill_value.hash(state);
@@ -173,7 +173,7 @@ impl ArrayHash for SparseData {
 }
 
 impl ArrayEq for SparseData {
-    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: EqMode) -> bool {
         self.array_len == other.array_len
             && self.patches_data == other.patches_data
             && self.fill_value == other.fill_value

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -9,6 +9,7 @@ use std::hash::Hasher;
 
 use kernel::PARENT_KERNELS;
 use prost::Message as _;
+use vortex_array::Accuracy;
 use vortex_array::AnyCanonical;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
@@ -22,7 +23,6 @@ use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::Precision;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::Primitive;
@@ -165,7 +165,7 @@ pub struct SparseMetadata {
 }
 
 impl ArrayHash for SparseData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
         self.array_len.hash(state);
         self.patches_data.hash(state);
         self.fill_value.hash(state);
@@ -173,7 +173,7 @@ impl ArrayHash for SparseData {
 }
 
 impl ArrayEq for SparseData {
-    fn array_eq(&self, other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
         self.array_len == other.array_len
             && self.patches_data == other.patches_data
             && self.fill_value == other.fill_value

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -5,7 +5,6 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::hash::Hasher;
 
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -13,6 +12,7 @@ use vortex_array::ArrayId;
 use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -155,11 +155,11 @@ impl VTable for ZigZag {
 }
 
 impl ArrayHash for ZigZagData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: EqMode) {}
 }
 
 impl ArrayEq for ZigZagData {
-    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: EqMode) -> bool {
         true
     }
 }

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -5,6 +5,7 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::hash::Hasher;
 
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -15,7 +16,6 @@ use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::Precision;
 use vortex_array::TypedArrayRef;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
@@ -155,11 +155,11 @@ impl VTable for ZigZag {
 }
 
 impl ArrayHash for ZigZagData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _precision: Precision) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
 }
 
 impl ArrayEq for ZigZagData {
-    fn array_eq(&self, _other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
         true
     }
 }

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use itertools::Itertools as _;
 use prost::Message as _;
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -21,7 +22,6 @@ use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::Precision;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -84,18 +84,18 @@ type ViewLen = u32;
 pub type ZstdArray = Array<Zstd>;
 
 impl ArrayHash for ZstdData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
         match &self.dictionary {
             Some(dict) => {
                 true.hash(state);
-                dict.array_hash(state, precision);
+                dict.array_hash(state, accuracy);
             }
             None => {
                 false.hash(state);
             }
         }
         for frame in &self.frames {
-            frame.array_hash(state, precision);
+            frame.array_hash(state, accuracy);
         }
         self.unsliced_n_rows.hash(state);
         self.slice_start.hash(state);
@@ -104,9 +104,9 @@ impl ArrayHash for ZstdData {
 }
 
 impl ArrayEq for ZstdData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
         if !match (&self.dictionary, &other.dictionary) {
-            (Some(d1), Some(d2)) => d1.array_eq(d2, precision),
+            (Some(d1), Some(d2)) => d1.array_eq(d2, accuracy),
             (None, None) => true,
             _ => false,
         } {
@@ -116,7 +116,7 @@ impl ArrayEq for ZstdData {
             return false;
         }
         for (a, b) in self.frames.iter().zip(&other.frames) {
-            if !a.array_eq(b, precision) {
+            if !a.array_eq(b, accuracy) {
                 return false;
             }
         }

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 
 use itertools::Itertools as _;
 use prost::Message as _;
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -19,6 +18,7 @@ use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::Canonical;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -84,7 +84,7 @@ type ViewLen = u32;
 pub type ZstdArray = Array<Zstd>;
 
 impl ArrayHash for ZstdData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: EqMode) {
         match &self.dictionary {
             Some(dict) => {
                 true.hash(state);
@@ -104,7 +104,7 @@ impl ArrayHash for ZstdData {
 }
 
 impl ArrayEq for ZstdData {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: EqMode) -> bool {
         if !match (&self.dictionary, &other.dictionary) {
             (Some(d1), Some(d2)) => d1.array_eq(d2, accuracy),
             (None, None) => true,

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -9,7 +9,6 @@ use std::hash::Hasher;
 use std::sync::Arc;
 
 use prost::Message as _;
-use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -18,6 +17,7 @@ use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArraySlots;
 use vortex_array::ArrayView;
+use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::buffer::BufferHandle;
@@ -337,7 +337,7 @@ fn array_id_from_string(s: &str) -> ArrayId {
 }
 
 impl ArrayHash for ZstdBuffersData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: EqMode) {
         self.inner_encoding_id.hash(state);
         self.inner_metadata.hash(state);
         for buf in &self.compressed_buffers {
@@ -349,7 +349,7 @@ impl ArrayHash for ZstdBuffersData {
 }
 
 impl ArrayEq for ZstdBuffersData {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: EqMode) -> bool {
         self.inner_encoding_id == other.inner_encoding_id
             && self.inner_metadata == other.inner_metadata
             && self.compressed_buffers.len() == other.compressed_buffers.len()

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -9,6 +9,7 @@ use std::hash::Hasher;
 use std::sync::Arc;
 
 use prost::Message as _;
+use vortex_array::Accuracy;
 use vortex_array::Array;
 use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
@@ -19,7 +20,6 @@ use vortex_array::ArraySlots;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
-use vortex_array::Precision;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
 use vortex_array::scalar::Scalar;
@@ -337,11 +337,11 @@ fn array_id_from_string(s: &str) -> ArrayId {
 }
 
 impl ArrayHash for ZstdBuffersData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
         self.inner_encoding_id.hash(state);
         self.inner_metadata.hash(state);
         for buf in &self.compressed_buffers {
-            buf.array_hash(state, precision);
+            buf.array_hash(state, accuracy);
         }
         self.uncompressed_sizes.hash(state);
         self.buffer_alignments.hash(state);
@@ -349,7 +349,7 @@ impl ArrayHash for ZstdBuffersData {
 }
 
 impl ArrayEq for ZstdBuffersData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
         self.inner_encoding_id == other.inner_encoding_id
             && self.inner_metadata == other.inner_metadata
             && self.compressed_buffers.len() == other.compressed_buffers.len()
@@ -357,7 +357,7 @@ impl ArrayEq for ZstdBuffersData {
                 .compressed_buffers
                 .iter()
                 .zip(&other.compressed_buffers)
-                .all(|(a, b)| a.array_eq(b, precision))
+                .all(|(a, b)| a.array_eq(b, accuracy))
             && self.uncompressed_sizes == other.uncompressed_sizes
             && self.buffer_alignments == other.buffer_alignments
     }

--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -155,7 +155,7 @@ impl Debug for ArrayRef {
 }
 
 impl ArrayHash for ArrayRef {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: crate::Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: crate::EqMode) {
         self.0.len.hash(state);
         self.0.dtype.hash(state);
         self.0.encoding_id.hash(state);
@@ -170,7 +170,7 @@ impl ArrayHash for ArrayRef {
 }
 
 impl ArrayEq for ArrayRef {
-    fn array_eq(&self, other: &Self, accuracy: crate::Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: crate::EqMode) -> bool {
         self.0.len == other.0.len
             && self.0.dtype == other.0.dtype
             && self.0.encoding_id == other.0.encoding_id

--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -155,22 +155,22 @@ impl Debug for ArrayRef {
 }
 
 impl ArrayHash for ArrayRef {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: crate::Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: crate::Accuracy) {
         self.0.len.hash(state);
         self.0.dtype.hash(state);
         self.0.encoding_id.hash(state);
         self.0.slots.len().hash(state);
         for slot in &self.0.slots {
-            slot.array_hash(state, precision);
+            slot.array_hash(state, accuracy);
         }
         self.0
             .data
-            .dyn_array_hash(state as &mut dyn Hasher, precision);
+            .dyn_array_hash(state as &mut dyn Hasher, accuracy);
     }
 }
 
 impl ArrayEq for ArrayRef {
-    fn array_eq(&self, other: &Self, precision: crate::Precision) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: crate::Accuracy) -> bool {
         self.0.len == other.0.len
             && self.0.dtype == other.0.dtype
             && self.0.encoding_id == other.0.encoding_id
@@ -180,8 +180,8 @@ impl ArrayEq for ArrayRef {
                 .slots
                 .iter()
                 .zip(other.0.slots.iter())
-                .all(|(slot, other_slot)| slot.array_eq(other_slot, precision))
-            && self.0.data.dyn_array_eq(other, precision)
+                .all(|(slot, other_slot)| slot.array_eq(other_slot, accuracy))
+            && self.0.data.dyn_array_eq(other, accuracy)
     }
 }
 impl ArrayRef {

--- a/vortex-array/src/array/foreign.rs
+++ b/vortex-array/src/array/foreign.rs
@@ -49,7 +49,7 @@ impl Display for ForeignArrayData {
 }
 
 impl ArrayHash for ForeignArrayData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: crate::Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: crate::EqMode) {
         self.metadata.hash(state);
         self.buffers.len().hash(state);
         for buffer in &self.buffers {
@@ -59,7 +59,7 @@ impl ArrayHash for ForeignArrayData {
 }
 
 impl ArrayEq for ForeignArrayData {
-    fn array_eq(&self, other: &Self, accuracy: crate::Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: crate::EqMode) -> bool {
         self.metadata == other.metadata
             && self.buffers.len() == other.buffers.len()
             && self

--- a/vortex-array/src/array/foreign.rs
+++ b/vortex-array/src/array/foreign.rs
@@ -49,24 +49,24 @@ impl Display for ForeignArrayData {
 }
 
 impl ArrayHash for ForeignArrayData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: crate::Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: crate::Accuracy) {
         self.metadata.hash(state);
         self.buffers.len().hash(state);
         for buffer in &self.buffers {
-            buffer.array_hash(state, precision);
+            buffer.array_hash(state, accuracy);
         }
     }
 }
 
 impl ArrayEq for ForeignArrayData {
-    fn array_eq(&self, other: &Self, precision: crate::Precision) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: crate::Accuracy) -> bool {
         self.metadata == other.metadata
             && self.buffers.len() == other.buffers.len()
             && self
                 .buffers
                 .iter()
                 .zip(other.buffers.iter())
-                .all(|(lhs, rhs)| lhs.array_eq(rhs, precision))
+                .all(|(lhs, rhs)| lhs.array_eq(rhs, accuracy))
     }
 }
 

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -119,10 +119,10 @@ pub(crate) trait DynArrayData: 'static + private::Sealed + Send + Sync + Debug {
     fn metadata_fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result;
 
     /// Hashes the array contents including len, dtype, and encoding id.
-    fn dyn_array_hash(&self, state: &mut dyn Hasher, precision: crate::Precision);
+    fn dyn_array_hash(&self, state: &mut dyn Hasher, accuracy: crate::Accuracy);
 
     /// Compares two arrays of the same concrete type for equality.
-    fn dyn_array_eq(&self, other: &ArrayRef, precision: crate::Precision) -> bool;
+    fn dyn_array_eq(&self, other: &ArrayRef, accuracy: crate::Accuracy) -> bool;
 
     /// Returns a new array with the given slots.
     fn with_slots(&self, this: &ArrayRef, slots: ArraySlots) -> VortexResult<ArrayRef>;
@@ -341,19 +341,19 @@ impl<V: VTable> DynArrayData for ArrayData<V> {
         std::fmt::Display::fmt(&self.data, f)
     }
 
-    fn dyn_array_hash(&self, state: &mut dyn Hasher, precision: crate::Precision) {
+    fn dyn_array_hash(&self, state: &mut dyn Hasher, accuracy: crate::Accuracy) {
         let mut wrapper = HasherWrapper(state);
         // Note: metadata (len, dtype, encoding_id) and slots are hashed by ArrayRef.
-        self.data.array_hash(&mut wrapper, precision);
+        self.data.array_hash(&mut wrapper, accuracy);
     }
 
-    fn dyn_array_eq(&self, other: &ArrayRef, precision: crate::Precision) -> bool {
+    fn dyn_array_eq(&self, other: &ArrayRef, accuracy: crate::Accuracy) -> bool {
         // Note: metadata (len, dtype, encoding_id) and slots are compared by ArrayRef.
         other
             .dyn_array()
             .as_any()
             .downcast_ref::<Self>()
-            .is_some_and(|other_inner| self.data.array_eq(&other_inner.data, precision))
+            .is_some_and(|other_inner| self.data.array_eq(&other_inner.data, accuracy))
     }
 
     fn with_slots(&self, this: &ArrayRef, slots: ArraySlots) -> VortexResult<ArrayRef> {

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -119,10 +119,10 @@ pub(crate) trait DynArrayData: 'static + private::Sealed + Send + Sync + Debug {
     fn metadata_fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result;
 
     /// Hashes the array contents including len, dtype, and encoding id.
-    fn dyn_array_hash(&self, state: &mut dyn Hasher, accuracy: crate::Accuracy);
+    fn dyn_array_hash(&self, state: &mut dyn Hasher, accuracy: crate::EqMode);
 
     /// Compares two arrays of the same concrete type for equality.
-    fn dyn_array_eq(&self, other: &ArrayRef, accuracy: crate::Accuracy) -> bool;
+    fn dyn_array_eq(&self, other: &ArrayRef, accuracy: crate::EqMode) -> bool;
 
     /// Returns a new array with the given slots.
     fn with_slots(&self, this: &ArrayRef, slots: ArraySlots) -> VortexResult<ArrayRef>;
@@ -341,13 +341,13 @@ impl<V: VTable> DynArrayData for ArrayData<V> {
         std::fmt::Display::fmt(&self.data, f)
     }
 
-    fn dyn_array_hash(&self, state: &mut dyn Hasher, accuracy: crate::Accuracy) {
+    fn dyn_array_hash(&self, state: &mut dyn Hasher, accuracy: crate::EqMode) {
         let mut wrapper = HasherWrapper(state);
         // Note: metadata (len, dtype, encoding_id) and slots are hashed by ArrayRef.
         self.data.array_hash(&mut wrapper, accuracy);
     }
 
-    fn dyn_array_eq(&self, other: &ArrayRef, accuracy: crate::Accuracy) -> bool {
+    fn dyn_array_eq(&self, other: &ArrayRef, accuracy: crate::EqMode) -> bool {
         // Note: metadata (len, dtype, encoding_id) and slots are compared by ArrayRef.
         other
             .dyn_array()

--- a/vortex-array/src/array/vtable/mod.rs
+++ b/vortex-array/src/array/vtable/mod.rs
@@ -18,13 +18,13 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 
+use crate::Accuracy;
 use crate::Array;
 use crate::ArrayRef;
 use crate::ArrayView;
 use crate::Canonical;
 use crate::ExecutionResult;
 use crate::IntoArray;
-use crate::Precision;
 pub use crate::array::plugin::*;
 use crate::arrays::ConstantArray;
 use crate::arrays::constant::Constant;
@@ -223,12 +223,12 @@ use crate::array::ArrayId;
 pub struct EmptyArrayData;
 
 impl ArrayEq for EmptyArrayData {
-    fn array_eq(&self, _other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
         true
     }
 }
 impl ArrayHash for EmptyArrayData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _precision: Precision) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
 }
 
 impl Display for EmptyArrayData {

--- a/vortex-array/src/array/vtable/mod.rs
+++ b/vortex-array/src/array/vtable/mod.rs
@@ -18,11 +18,11 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 
-use crate::Accuracy;
 use crate::Array;
 use crate::ArrayRef;
 use crate::ArrayView;
 use crate::Canonical;
+use crate::EqMode;
 use crate::ExecutionResult;
 use crate::IntoArray;
 pub use crate::array::plugin::*;
@@ -223,12 +223,12 @@ use crate::array::ArrayId;
 pub struct EmptyArrayData;
 
 impl ArrayEq for EmptyArrayData {
-    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: EqMode) -> bool {
         true
     }
 }
 impl ArrayHash for EmptyArrayData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: EqMode) {}
 }
 
 impl Display for EmptyArrayData {

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -34,7 +34,7 @@ mod validity;
 
 use vortex_session::registry::CachedId;
 
-use crate::Precision;
+use crate::Accuracy;
 use crate::array::ArrayId;
 use crate::arrays::bool::compute::rules::RULES;
 use crate::hash::ArrayEq;
@@ -51,15 +51,15 @@ pub struct BoolMetadata {
 }
 
 impl ArrayHash for BoolData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
-        self.bits.array_hash(state, precision);
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+        self.bits.array_hash(state, accuracy);
         self.meta.offset().hash(state);
     }
 }
 
 impl ArrayEq for BoolData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
-        self.meta.offset() == other.meta.offset() && self.bits.array_eq(&other.bits, precision)
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+        self.meta.offset() == other.meta.offset() && self.bits.array_eq(&other.bits, accuracy)
     }
 }
 

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -34,7 +34,7 @@ mod validity;
 
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
+use crate::EqMode;
 use crate::array::ArrayId;
 use crate::arrays::bool::compute::rules::RULES;
 use crate::hash::ArrayEq;
@@ -51,14 +51,14 @@ pub struct BoolMetadata {
 }
 
 impl ArrayHash for BoolData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: EqMode) {
         self.bits.array_hash(state, accuracy);
         self.meta.offset().hash(state);
     }
 }
 
 impl ArrayEq for BoolData {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: EqMode) -> bool {
         self.meta.offset() == other.meta.offset() && self.bits.array_eq(&other.bits, accuracy)
     }
 }

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -14,11 +14,11 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
 use crate::Canonical;
+use crate::EqMode;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::IntoArray;
@@ -53,14 +53,14 @@ pub type ChunkedArray = Array<Chunked>;
 pub struct Chunked;
 
 impl ArrayHash for ChunkedData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: EqMode) {
         // Chunk offsets are cached derived data. Slot 0 already stores the logical offsets array,
         // and ArrayData hashing includes every slot before TypedArrayData.
     }
 }
 
 impl ArrayEq for ChunkedData {
-    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: EqMode) -> bool {
         // Chunk offsets are cached derived data. Slot 0 already stores the logical offsets array,
         // and ArrayData equality compares every slot before TypedArrayData.
         true

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -14,6 +14,7 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
@@ -21,7 +22,6 @@ use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::IntoArray;
-use crate::Precision;
 #[expect(deprecated)]
 use crate::ToCanonical as _;
 use crate::array::Array;
@@ -53,14 +53,14 @@ pub type ChunkedArray = Array<Chunked>;
 pub struct Chunked;
 
 impl ArrayHash for ChunkedData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _precision: Precision) {
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {
         // Chunk offsets are cached derived data. Slot 0 already stores the logical offsets array,
         // and ArrayData hashing includes every slot before TypedArrayData.
     }
 }
 
 impl ArrayEq for ChunkedData {
-    fn array_eq(&self, _other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
         // Chunk offsets are cached derived data. Slot 0 already stores the logical offsets array,
         // and ArrayData equality compares every slot before TypedArrayData.
         true

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -13,10 +13,10 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
+use crate::EqMode;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::IntoArray;
@@ -53,13 +53,13 @@ pub type ConstantArray = Array<Constant>;
 pub struct Constant;
 
 impl ArrayHash for ConstantData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: EqMode) {
         self.scalar.hash(state);
     }
 }
 
 impl ArrayEq for ConstantData {
-    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: EqMode) -> bool {
         self.scalar == other.scalar
     }
 }

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -13,13 +13,13 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::IntoArray;
-use crate::Precision;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
@@ -53,13 +53,13 @@ pub type ConstantArray = Array<Constant>;
 pub struct Constant;
 
 impl ArrayHash for ConstantData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
         self.scalar.hash(state);
     }
 }
 
 impl ArrayEq for ConstantData {
-    fn array_eq(&self, other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
         self.scalar == other.scalar
     }
 }

--- a/vortex-array/src/arrays/datetime/test.rs
+++ b/vortex-array/src/arrays/datetime/test.rs
@@ -6,7 +6,7 @@ use vortex_buffer::buffer;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
-use crate::Accuracy;
+use crate::EqMode;
 use crate::IntoArray;
 #[expect(deprecated)]
 use crate::ToCanonical as _;
@@ -201,7 +201,7 @@ fn test_validity_preservation(#[case] validity: Validity) {
     assert!(
         prim.validity()
             .vortex_expect("temporal validity should be derivable")
-            .array_eq(&validity, Accuracy::Ptr)
+            .array_eq(&validity, EqMode::Ptr)
     );
 }
 

--- a/vortex-array/src/arrays/datetime/test.rs
+++ b/vortex-array/src/arrays/datetime/test.rs
@@ -6,8 +6,8 @@ use vortex_buffer::buffer;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
+use crate::Accuracy;
 use crate::IntoArray;
-use crate::Precision;
 #[expect(deprecated)]
 use crate::ToCanonical as _;
 use crate::arrays::PrimitiveArray;
@@ -201,7 +201,7 @@ fn test_validity_preservation(#[case] validity: Validity) {
     assert!(
         prim.validity()
             .vortex_expect("temporal validity should be derivable")
-            .array_eq(&validity, Precision::Ptr)
+            .array_eq(&validity, Accuracy::Ptr)
     );
 }
 

--- a/vortex-array/src/arrays/decimal/vtable/mod.rs
+++ b/vortex-array/src/arrays/decimal/vtable/mod.rs
@@ -34,7 +34,7 @@ use std::hash::Hash;
 
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
+use crate::EqMode;
 use crate::array::ArrayId;
 use crate::arrays::decimal::array::SLOT_NAMES;
 use crate::arrays::decimal::compute::rules::RULES;
@@ -51,14 +51,14 @@ pub struct DecimalMetadata {
 }
 
 impl ArrayHash for DecimalData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: EqMode) {
         self.values.array_hash(state, accuracy);
         std::mem::discriminant(&self.values_type).hash(state);
     }
 }
 
 impl ArrayEq for DecimalData {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: EqMode) -> bool {
         self.values.array_eq(&other.values, accuracy) && self.values_type == other.values_type
     }
 }

--- a/vortex-array/src/arrays/decimal/vtable/mod.rs
+++ b/vortex-array/src/arrays/decimal/vtable/mod.rs
@@ -34,7 +34,7 @@ use std::hash::Hash;
 
 use vortex_session::registry::CachedId;
 
-use crate::Precision;
+use crate::Accuracy;
 use crate::array::ArrayId;
 use crate::arrays::decimal::array::SLOT_NAMES;
 use crate::arrays::decimal::compute::rules::RULES;
@@ -51,15 +51,15 @@ pub struct DecimalMetadata {
 }
 
 impl ArrayHash for DecimalData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
-        self.values.array_hash(state, precision);
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+        self.values.array_hash(state, accuracy);
         std::mem::discriminant(&self.values_type).hash(state);
     }
 }
 
 impl ArrayEq for DecimalData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
-        self.values.array_eq(&other.values, precision) && self.values_type == other.values_type
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+        self.values.array_eq(&other.values, accuracy) && self.values_type == other.values_type
     }
 }
 

--- a/vortex-array/src/arrays/dict/compute/rules.rs
+++ b/vortex-array/src/arrays/dict/compute/rules.rs
@@ -3,9 +3,9 @@
 
 use vortex_error::VortexResult;
 
-use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayRef;
+use crate::EqMode;
 use crate::IntoArray;
 use crate::array::ArrayView;
 use crate::array::VTable;
@@ -178,7 +178,7 @@ impl ArrayParentReduceRule<Dict> for DictionaryScalarFnCodesPullUpRule {
         if !parent.iter_children().enumerate().all(|(idx, c)| {
             idx == child_idx
                 || c.as_opt::<Dict>()
-                    .is_some_and(|c| c.codes().array_eq(array.codes(), Accuracy::Value))
+                    .is_some_and(|c| c.codes().array_eq(array.codes(), EqMode::Value))
         }) {
             return Ok(None);
         }

--- a/vortex-array/src/arrays/dict/compute/rules.rs
+++ b/vortex-array/src/arrays/dict/compute/rules.rs
@@ -3,10 +3,10 @@
 
 use vortex_error::VortexResult;
 
+use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayRef;
 use crate::IntoArray;
-use crate::Precision;
 use crate::array::ArrayView;
 use crate::array::VTable;
 use crate::arrays::Constant;
@@ -175,11 +175,10 @@ impl ArrayParentReduceRule<Dict> for DictionaryScalarFnCodesPullUpRule {
         }
 
         // Now run the slightly more expensive check that all siblings have the same codes as us.
-        // We use the cheaper Precision::Ptr to avoid doing data comparisons.
         if !parent.iter_children().enumerate().all(|(idx, c)| {
             idx == child_idx
                 || c.as_opt::<Dict>()
-                    .is_some_and(|c| c.codes().array_eq(array.codes(), Precision::Value))
+                    .is_some_and(|c| c.codes().array_eq(array.codes(), Accuracy::Value))
         }) {
             return Ok(None);
         }

--- a/vortex-array/src/arrays/dict/vtable/mod.rs
+++ b/vortex-array/src/arrays/dict/vtable/mod.rs
@@ -20,12 +20,12 @@ use super::DictOwnedExt;
 use super::DictParts;
 use super::array::DictSlots;
 use super::array::DictSlotsView;
-use crate::Accuracy;
 use crate::AnyCanonical;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
 use crate::Canonical;
+use crate::EqMode;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
@@ -59,11 +59,11 @@ pub type DictArray = Array<Dict>;
 pub struct Dict;
 
 impl ArrayHash for DictData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: EqMode) {}
 }
 
 impl ArrayEq for DictData {
-    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: EqMode) -> bool {
         true
     }
 }

--- a/vortex-array/src/arrays/dict/vtable/mod.rs
+++ b/vortex-array/src/arrays/dict/vtable/mod.rs
@@ -20,12 +20,12 @@ use super::DictOwnedExt;
 use super::DictParts;
 use super::array::DictSlots;
 use super::array::DictSlotsView;
+use crate::Accuracy;
 use crate::AnyCanonical;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
 use crate::Canonical;
-use crate::Precision;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
@@ -59,11 +59,11 @@ pub type DictArray = Array<Dict>;
 pub struct Dict;
 
 impl ArrayHash for DictData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _precision: Precision) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
 }
 
 impl ArrayEq for DictData {
-    fn array_eq(&self, _other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
         true
     }
 }

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -13,13 +13,13 @@ use vortex_mask::Mask;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::Accuracy;
 use crate::AnyCanonical;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::IntoArray;
-use crate::Precision;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
@@ -51,14 +51,14 @@ pub type FilterArray = Array<Filter>;
 pub struct Filter;
 
 impl ArrayHash for FilterData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
-        self.mask.array_hash(state, precision);
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+        self.mask.array_hash(state, accuracy);
     }
 }
 
 impl ArrayEq for FilterData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
-        self.mask.array_eq(&other.mask, precision)
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+        self.mask.array_eq(&other.mask, accuracy)
     }
 }
 

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -13,12 +13,12 @@ use vortex_mask::Mask;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
 use crate::AnyCanonical;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
 use crate::Canonical;
+use crate::EqMode;
 use crate::IntoArray;
 use crate::array::Array;
 use crate::array::ArrayId;
@@ -51,13 +51,13 @@ pub type FilterArray = Array<Filter>;
 pub struct Filter;
 
 impl ArrayHash for FilterData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: EqMode) {
         self.mask.array_hash(state, accuracy);
     }
 }
 
 impl ArrayEq for FilterData {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: EqMode) -> bool {
         self.mask.array_eq(&other.mask, accuracy)
     }
 }

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -13,12 +13,12 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
-use crate::Precision;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
@@ -43,15 +43,13 @@ pub type FixedSizeListArray = Array<FixedSizeList>;
 pub struct FixedSizeList;
 
 impl ArrayHash for FixedSizeListData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
-        let _precision = precision;
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
         self.degenerate_len.hash(state);
     }
 }
 
 impl ArrayEq for FixedSizeListData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
-        let _precision = precision;
+    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
         self.degenerate_len == other.degenerate_len
     }
 }

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -13,10 +13,10 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
+use crate::EqMode;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::array::Array;
@@ -43,13 +43,13 @@ pub type FixedSizeListArray = Array<FixedSizeList>;
 pub struct FixedSizeList;
 
 impl ArrayHash for FixedSizeListData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: EqMode) {
         self.degenerate_len.hash(state);
     }
 }
 
 impl ArrayEq for FixedSizeListData {
-    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: EqMode) -> bool {
         self.degenerate_len == other.degenerate_len
     }
 }

--- a/vortex-array/src/arrays/list/vtable/mod.rs
+++ b/vortex-array/src/arrays/list/vtable/mod.rs
@@ -13,13 +13,13 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::IntoArray;
-use crate::Precision;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
@@ -54,11 +54,11 @@ pub struct ListMetadata {
 }
 
 impl ArrayHash for ListData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _precision: Precision) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
 }
 
 impl ArrayEq for ListData {
-    fn array_eq(&self, _other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
         true
     }
 }

--- a/vortex-array/src/arrays/list/vtable/mod.rs
+++ b/vortex-array/src/arrays/list/vtable/mod.rs
@@ -13,10 +13,10 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
+use crate::EqMode;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::IntoArray;
@@ -54,11 +54,11 @@ pub struct ListMetadata {
 }
 
 impl ArrayHash for ListData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: EqMode) {}
 }
 
 impl ArrayEq for ListData {
-    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: EqMode) -> bool {
         true
     }
 }

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -291,9 +291,9 @@ mod tests {
     use super::super::tests::common::create_nullable_listview;
     use super::super::tests::common::create_overlapping_listview;
     use super::recursive_list_from_list_view;
-    use crate::Accuracy;
     use crate::ArrayEq;
     use crate::ArrayRef;
+    use crate::EqMode;
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
@@ -395,7 +395,7 @@ mod tests {
             nullable_list_view
                 .validity()
                 .vortex_expect("listview validity should be derivable")
-                .array_eq(&validity, Accuracy::Ptr)
+                .array_eq(&validity, EqMode::Ptr)
         );
         assert_eq!(nullable_list_view.len(), 3);
 

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -291,11 +291,11 @@ mod tests {
     use super::super::tests::common::create_nullable_listview;
     use super::super::tests::common::create_overlapping_listview;
     use super::recursive_list_from_list_view;
+    use crate::Accuracy;
     use crate::ArrayEq;
     use crate::ArrayRef;
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
-    use crate::Precision;
     use crate::VortexSessionExecute;
     use crate::arrays::BoolArray;
     use crate::arrays::FixedSizeListArray;
@@ -395,7 +395,7 @@ mod tests {
             nullable_list_view
                 .validity()
                 .vortex_expect("listview validity should be derivable")
-                .array_eq(&validity, Precision::Ptr)
+                .array_eq(&validity, Accuracy::Ptr)
         );
         assert_eq!(nullable_list_view.len(), 3);
 

--- a/vortex-array/src/arrays/listview/vtable/mod.rs
+++ b/vortex-array/src/arrays/listview/vtable/mod.rs
@@ -14,12 +14,12 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
-use crate::Precision;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
@@ -59,13 +59,13 @@ pub struct ListViewMetadata {
 }
 
 impl ArrayHash for ListViewData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
         self.is_zero_copy_to_list().hash(state);
     }
 }
 
 impl ArrayEq for ListViewData {
-    fn array_eq(&self, other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
         self.is_zero_copy_to_list() == other.is_zero_copy_to_list()
     }
 }

--- a/vortex-array/src/arrays/listview/vtable/mod.rs
+++ b/vortex-array/src/arrays/listview/vtable/mod.rs
@@ -14,10 +14,10 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
+use crate::EqMode;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::array::Array;
@@ -59,13 +59,13 @@ pub struct ListViewMetadata {
 }
 
 impl ArrayHash for ListViewData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: EqMode) {
         self.is_zero_copy_to_list().hash(state);
     }
 }
 
 impl ArrayEq for ListViewData {
-    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: EqMode) -> bool {
         self.is_zero_copy_to_list() == other.is_zero_copy_to_list()
     }
 }

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -15,12 +15,12 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
 use crate::AnyCanonical;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
 use crate::Canonical;
+use crate::EqMode;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
@@ -51,11 +51,11 @@ pub type MaskedArray = Array<Masked>;
 pub struct Masked;
 
 impl ArrayHash for MaskedData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: EqMode) {}
 }
 
 impl ArrayEq for MaskedData {
-    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: EqMode) -> bool {
         true
     }
 }

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -15,6 +15,7 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::Accuracy;
 use crate::AnyCanonical;
 use crate::ArrayEq;
 use crate::ArrayHash;
@@ -22,7 +23,6 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
-use crate::Precision;
 use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayId;
@@ -51,11 +51,11 @@ pub type MaskedArray = Array<Masked>;
 pub struct Masked;
 
 impl ArrayHash for MaskedData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _precision: Precision) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
 }
 
 impl ArrayEq for MaskedData {
-    fn array_eq(&self, _other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
         true
     }
 }

--- a/vortex-array/src/arrays/patched/vtable/mod.rs
+++ b/vortex-array/src/arrays/patched/vtable/mod.rs
@@ -19,9 +19,9 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
 use crate::ArrayRef;
 use crate::Canonical;
+use crate::EqMode;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::IntoArray;
@@ -82,14 +82,14 @@ pub struct PatchedMetadata {
 }
 
 impl ArrayHash for PatchedData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: EqMode) {
         self.offset.hash(state);
         self.n_lanes.hash(state);
     }
 }
 
 impl ArrayEq for PatchedData {
-    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: EqMode) -> bool {
         self.offset == other.offset && self.n_lanes == other.n_lanes
     }
 }

--- a/vortex-array/src/arrays/patched/vtable/mod.rs
+++ b/vortex-array/src/arrays/patched/vtable/mod.rs
@@ -19,12 +19,12 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::Accuracy;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::IntoArray;
-use crate::Precision;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
@@ -82,14 +82,14 @@ pub struct PatchedMetadata {
 }
 
 impl ArrayHash for PatchedData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
         self.offset.hash(state);
         self.n_lanes.hash(state);
     }
 }
 
 impl ArrayEq for PatchedData {
-    fn array_eq(&self, other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
         self.offset == other.offset && self.n_lanes == other.n_lanes
     }
 }

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -29,7 +29,7 @@ use vortex_buffer::Alignment;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::Precision;
+use crate::Accuracy;
 use crate::array::ArrayId;
 use crate::arrays::primitive::array::SLOT_NAMES;
 use crate::arrays::primitive::compute::rules::RULES;
@@ -40,14 +40,14 @@ use crate::hash::ArrayHash;
 pub type PrimitiveArray = Array<Primitive>;
 
 impl ArrayHash for PrimitiveData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
-        self.buffer.array_hash(state, precision);
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+        self.buffer.array_hash(state, accuracy);
     }
 }
 
 impl ArrayEq for PrimitiveData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
-        self.buffer.array_eq(&other.buffer, precision)
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+        self.buffer.array_eq(&other.buffer, accuracy)
     }
 }
 

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -29,7 +29,7 @@ use vortex_buffer::Alignment;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
+use crate::EqMode;
 use crate::array::ArrayId;
 use crate::arrays::primitive::array::SLOT_NAMES;
 use crate::arrays::primitive::compute::rules::RULES;
@@ -40,13 +40,13 @@ use crate::hash::ArrayHash;
 pub type PrimitiveArray = Array<Primitive>;
 
 impl ArrayHash for PrimitiveData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: EqMode) {
         self.buffer.array_hash(state, accuracy);
     }
 }
 
 impl ArrayEq for PrimitiveData {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: EqMode) -> bool {
         self.buffer.array_eq(&other.buffer, accuracy)
     }
 }

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -17,12 +17,12 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
 use crate::ArraySlots;
 use crate::IntoArray;
-use crate::Precision;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
@@ -56,13 +56,13 @@ pub struct ScalarFn {
 }
 
 impl ArrayHash for ScalarFnData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
         self.scalar_fn().hash(state);
     }
 }
 
 impl ArrayEq for ScalarFnData {
-    fn array_eq(&self, other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
         self.scalar_fn() == other.scalar_fn()
     }
 }

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -17,11 +17,11 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
 use crate::ArraySlots;
+use crate::EqMode;
 use crate::IntoArray;
 use crate::array::Array;
 use crate::array::ArrayId;
@@ -56,13 +56,13 @@ pub struct ScalarFn {
 }
 
 impl ArrayHash for ScalarFnData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: EqMode) {
         self.scalar_fn().hash(state);
     }
 }
 
 impl ArrayEq for ScalarFnData {
-    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: EqMode) -> bool {
         self.scalar_fn() == other.scalar_fn()
     }
 }

--- a/vortex-array/src/arrays/shared/tests.rs
+++ b/vortex-array/src/arrays/shared/tests.rs
@@ -11,8 +11,8 @@ use crate::IntoArray;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::SharedArray;
 use crate::arrays::shared::SharedArrayExt;
-use crate::hash::Accuracy as HashAccuracy;
 use crate::hash::ArrayEq;
+use crate::hash::EqMode;
 use crate::session::ArraySession;
 use crate::validity::Validity;
 
@@ -29,7 +29,7 @@ fn shared_array_caches_on_canonicalize() -> VortexResult<()> {
     // Second call should return cached without invoking the closure.
     let second = shared.get_or_compute(|_| panic!("should not execute twice"))?;
 
-    assert!(first.array_eq(&second, HashAccuracy::Value));
+    assert!(first.array_eq(&second, EqMode::Value));
 
     Ok(())
 }

--- a/vortex-array/src/arrays/shared/tests.rs
+++ b/vortex-array/src/arrays/shared/tests.rs
@@ -11,8 +11,8 @@ use crate::IntoArray;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::SharedArray;
 use crate::arrays::shared::SharedArrayExt;
+use crate::hash::Accuracy as HashAccuracy;
 use crate::hash::ArrayEq;
-use crate::hash::Precision as HashPrecision;
 use crate::session::ArraySession;
 use crate::validity::Validity;
 
@@ -29,7 +29,7 @@ fn shared_array_caches_on_canonicalize() -> VortexResult<()> {
     // Second call should return cached without invoking the closure.
     let second = shared.get_or_compute(|_| panic!("should not execute twice"))?;
 
-    assert!(first.array_eq(&second, HashPrecision::Value));
+    assert!(first.array_eq(&second, HashAccuracy::Value));
 
     Ok(())
 }

--- a/vortex-array/src/arrays/shared/vtable.rs
+++ b/vortex-array/src/arrays/shared/vtable.rs
@@ -9,13 +9,13 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
-use crate::Precision;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
@@ -39,11 +39,11 @@ pub type SharedArray = Array<Shared>;
 pub struct Shared;
 
 impl ArrayHash for SharedData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _precision: Precision) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
 }
 
 impl ArrayEq for SharedData {
-    fn array_eq(&self, _other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
         true
     }
 }

--- a/vortex-array/src/arrays/shared/vtable.rs
+++ b/vortex-array/src/arrays/shared/vtable.rs
@@ -9,11 +9,11 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
 use crate::Canonical;
+use crate::EqMode;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::array::Array;
@@ -39,11 +39,11 @@ pub type SharedArray = Array<Shared>;
 pub struct Shared;
 
 impl ArrayHash for SharedData {
-    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: Accuracy) {}
+    fn array_hash<H: Hasher>(&self, _state: &mut H, _accuracy: EqMode) {}
 }
 
 impl ArrayEq for SharedData {
-    fn array_eq(&self, _other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, _other: &Self, _accuracy: EqMode) -> bool {
         true
     }
 }

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -15,11 +15,11 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::Accuracy;
 use crate::AnyCanonical;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
-use crate::Precision;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
@@ -47,14 +47,14 @@ pub type SliceArray = Array<Slice>;
 pub struct Slice;
 
 impl ArrayHash for SliceData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
         self.range.start.hash(state);
         self.range.end.hash(state);
     }
 }
 
 impl ArrayEq for SliceData {
-    fn array_eq(&self, other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
         self.range == other.range
     }
 }

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -15,11 +15,11 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
 use crate::AnyCanonical;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
+use crate::EqMode;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
@@ -47,14 +47,14 @@ pub type SliceArray = Array<Slice>;
 pub struct Slice;
 
 impl ArrayHash for SliceData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, _accuracy: EqMode) {
         self.range.start.hash(state);
         self.range.end.hash(state);
     }
 }
 
 impl ArrayEq for SliceData {
-    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: EqMode) -> bool {
         self.range == other.range
     }
 }

--- a/vortex-array/src/arrays/varbin/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbin/vtable/mod.rs
@@ -39,7 +39,7 @@ use canonical::varbin_to_canonical;
 use kernel::PARENT_KERNELS;
 use vortex_session::VortexSession;
 
-use crate::Accuracy;
+use crate::EqMode;
 use crate::arrays::varbin::compute::rules::PARENT_RULES;
 use crate::hash::ArrayEq;
 use crate::hash::ArrayHash;
@@ -54,13 +54,13 @@ pub struct VarBinMetadata {
 }
 
 impl ArrayHash for VarBinData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: EqMode) {
         self.bytes().array_hash(state, accuracy);
     }
 }
 
 impl ArrayEq for VarBinData {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: EqMode) -> bool {
         self.bytes().array_eq(other.bytes(), accuracy)
     }
 }

--- a/vortex-array/src/arrays/varbin/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbin/vtable/mod.rs
@@ -39,7 +39,7 @@ use canonical::varbin_to_canonical;
 use kernel::PARENT_KERNELS;
 use vortex_session::VortexSession;
 
-use crate::Precision;
+use crate::Accuracy;
 use crate::arrays::varbin::compute::rules::PARENT_RULES;
 use crate::hash::ArrayEq;
 use crate::hash::ArrayHash;
@@ -54,14 +54,14 @@ pub struct VarBinMetadata {
 }
 
 impl ArrayHash for VarBinData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
-        self.bytes().array_hash(state, precision);
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+        self.bytes().array_hash(state, accuracy);
     }
 }
 
 impl ArrayEq for VarBinData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
-        self.bytes().array_eq(other.bytes(), precision)
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+        self.bytes().array_eq(other.bytes(), accuracy)
     }
 }
 

--- a/vortex-array/src/arrays/varbinview/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/mod.rs
@@ -15,10 +15,10 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::Accuracy;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
-use crate::Precision;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
@@ -44,23 +44,23 @@ pub type VarBinViewArray = Array<VarBinView>;
 pub struct VarBinView;
 
 impl ArrayHash for VarBinViewData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
         for buffer in self.buffers.iter() {
-            buffer.array_hash(state, precision);
+            buffer.array_hash(state, accuracy);
         }
-        self.views.array_hash(state, precision);
+        self.views.array_hash(state, accuracy);
     }
 }
 
 impl ArrayEq for VarBinViewData {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
         self.buffers.len() == other.buffers.len()
             && self
                 .buffers
                 .iter()
                 .zip(other.buffers.iter())
-                .all(|(a, b)| a.array_eq(b, precision))
-            && self.views.array_eq(&other.views, precision)
+                .all(|(a, b)| a.array_eq(b, accuracy))
+            && self.views.array_eq(&other.views, accuracy)
     }
 }
 

--- a/vortex-array/src/arrays/varbinview/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/mod.rs
@@ -15,8 +15,8 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::Accuracy;
 use crate::ArrayRef;
+use crate::EqMode;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::array::Array;
@@ -44,7 +44,7 @@ pub type VarBinViewArray = Array<VarBinView>;
 pub struct VarBinView;
 
 impl ArrayHash for VarBinViewData {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: EqMode) {
         for buffer in self.buffers.iter() {
             buffer.array_hash(state, accuracy);
         }
@@ -53,7 +53,7 @@ impl ArrayHash for VarBinViewData {
 }
 
 impl ArrayEq for VarBinViewData {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: EqMode) -> bool {
         self.buffers.len() == other.buffers.len()
             && self
                 .buffers

--- a/vortex-array/src/buffer.rs
+++ b/vortex-array/src/buffer.rs
@@ -17,9 +17,9 @@ use vortex_error::VortexResult;
 use vortex_utils::dyn_traits::DynEq;
 use vortex_utils::dyn_traits::DynHash;
 
+use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
-use crate::Precision;
 
 /// A handle to a buffer allocation.
 ///
@@ -409,14 +409,14 @@ impl BufferHandle {
 
 impl ArrayHash for BufferHandle {
     // TODO(aduffy): implement for array hash
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
         match &self.0 {
-            Inner::Host(host) => host.array_hash(state, precision),
-            Inner::Device(dev) => match precision {
-                Precision::Ptr => {
+            Inner::Host(host) => host.array_hash(state, accuracy),
+            Inner::Device(dev) => match accuracy {
+                Accuracy::Ptr => {
                     Arc::as_ptr(dev).hash(state);
                 }
-                Precision::Value => {
+                Accuracy::Value => {
                     dev.hash(state);
                 }
             },
@@ -425,12 +425,12 @@ impl ArrayHash for BufferHandle {
 }
 
 impl ArrayEq for BufferHandle {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
         match (&self.0, &other.0) {
-            (Inner::Host(b), Inner::Host(b2)) => b.array_eq(b2, precision),
-            (Inner::Device(b), Inner::Device(b2)) => match precision {
-                Precision::Ptr => Arc::ptr_eq(b, b2),
-                Precision::Value => b.eq(b2),
+            (Inner::Host(b), Inner::Host(b2)) => b.array_eq(b2, accuracy),
+            (Inner::Device(b), Inner::Device(b2)) => match accuracy {
+                Accuracy::Ptr => Arc::ptr_eq(b, b2),
+                Accuracy::Value => b.eq(b2),
             },
             _ => false,
         }

--- a/vortex-array/src/buffer.rs
+++ b/vortex-array/src/buffer.rs
@@ -17,9 +17,9 @@ use vortex_error::VortexResult;
 use vortex_utils::dyn_traits::DynEq;
 use vortex_utils::dyn_traits::DynHash;
 
-use crate::Accuracy;
 use crate::ArrayEq;
 use crate::ArrayHash;
+use crate::EqMode;
 
 /// A handle to a buffer allocation.
 ///
@@ -409,14 +409,14 @@ impl BufferHandle {
 
 impl ArrayHash for BufferHandle {
     // TODO(aduffy): implement for array hash
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: EqMode) {
         match &self.0 {
             Inner::Host(host) => host.array_hash(state, accuracy),
             Inner::Device(dev) => match accuracy {
-                Accuracy::Ptr => {
+                EqMode::Ptr => {
                     Arc::as_ptr(dev).hash(state);
                 }
-                Accuracy::Value => {
+                EqMode::Value => {
                     dev.hash(state);
                 }
             },
@@ -425,12 +425,12 @@ impl ArrayHash for BufferHandle {
 }
 
 impl ArrayEq for BufferHandle {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: EqMode) -> bool {
         match (&self.0, &other.0) {
             (Inner::Host(b), Inner::Host(b2)) => b.array_eq(b2, accuracy),
             (Inner::Device(b), Inner::Device(b2)) => match accuracy {
-                Accuracy::Ptr => Arc::ptr_eq(b, b2),
-                Accuracy::Value => b.eq(b2),
+                EqMode::Ptr => Arc::ptr_eq(b, b2),
+                EqMode::Value => b.eq(b2),
             },
             _ => false,
         }

--- a/vortex-array/src/hash.rs
+++ b/vortex-array/src/hash.rs
@@ -12,12 +12,12 @@ use vortex_mask::Mask;
 use crate::patches::Patches;
 use crate::validity::Validity;
 
-/// The accuracy level for structural equality and hashing of arrays.
+/// The equality mode for structural equality and hashing of arrays.
 ///
-/// This configuration option defines how precise the hash/equals results are given the set of
+/// This configuration option defines how precise the hash/equals results are for the set of
 /// data buffers backing the array.
 #[derive(Clone, Copy, Debug)]
-pub enum Accuracy {
+pub enum EqMode {
     /// Data buffers are compared by their pointer and length only. This is the fastest option, but
     /// may lead to false negatives if two arrays contain identical data but are backed by
     /// different buffers.
@@ -27,50 +27,50 @@ pub enum Accuracy {
     Value,
 }
 
-/// A hash trait for arrays that represents structural equality with a configurable level of
-/// accuracy. This trait is used primarily to implement common subtree elimination and other
+/// A hash trait for arrays that represents structural equality with a configurable equality mode.
+/// This trait is used primarily to implement common subtree elimination and other
 /// array-based caching mechanisms.
 ///
-/// The accuracy of the hash defines what level of structural equality is represented. See
-/// [`Accuracy`] for more details.
+/// The equality mode defines what level of structural equality is represented. See
+/// [`EqMode`] for more details.
 ///
-/// Note that where [`Accuracy::Ptr`] is used, the hash is only valid for the lifetime of the
+/// Note that where [`EqMode::Ptr`] is used, the hash is only valid for the lifetime of the
 /// object.
 pub trait ArrayHash {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy);
+    fn array_hash<H: Hasher>(&self, state: &mut H, eq_mode: EqMode);
 }
 
 /// A dynamic version of [`ArrayHash`].
 pub trait DynArrayDataHash: private::SealedHash {
-    fn dyn_array_hash(&self, state: &mut dyn Hasher, accuracy: Accuracy);
+    fn dyn_array_hash(&self, state: &mut dyn Hasher, eq_mode: EqMode);
 }
 
 impl<T: ArrayHash + ?Sized> DynArrayDataHash for T {
-    fn dyn_array_hash(&self, mut state: &mut dyn Hasher, accuracy: Accuracy) {
-        ArrayHash::array_hash(self, &mut state, accuracy);
+    fn dyn_array_hash(&self, mut state: &mut dyn Hasher, eq_mode: EqMode) {
+        ArrayHash::array_hash(self, &mut state, eq_mode);
     }
 }
 
-/// An equality trait for arrays that represents structural equality with a configurable level of
-/// accuracy. This trait is used primarily to implement common subtree elimination and other
+/// An equality trait for arrays that represents structural equality with a configurable equality
+/// mode. This trait is used primarily to implement common subtree elimination and other
 /// array-based caching mechanisms.
 ///
-/// The accuracy of the equality check defines what level of structural equality is represented. See
-/// [`Accuracy`] for more details.
+/// The equality mode defines what level of structural equality is represented. See
+/// [`EqMode`] for more details.
 pub trait ArrayEq {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool;
+    fn array_eq(&self, other: &Self, eq_mode: EqMode) -> bool;
 }
 
 /// A dynamic version of [`ArrayEq`].
 pub trait DynArrayDataEq: private::SealedEq {
-    fn dyn_array_eq(&self, other: &dyn Any, accuracy: Accuracy) -> bool;
+    fn dyn_array_eq(&self, other: &dyn Any, eq_mode: EqMode) -> bool;
 }
 
 impl<T: ArrayEq + 'static> DynArrayDataEq for T {
-    fn dyn_array_eq(&self, other: &dyn Any, accuracy: Accuracy) -> bool {
+    fn dyn_array_eq(&self, other: &dyn Any, eq_mode: EqMode) -> bool {
         other
             .downcast_ref::<Self>()
-            .is_some_and(|other| ArrayEq::array_eq(self, other, accuracy))
+            .is_some_and(|other| ArrayEq::array_eq(self, other, eq_mode))
     }
 }
 
@@ -85,36 +85,36 @@ mod private {
 }
 
 impl<T: Hash> ArrayHash for Buffer<T> {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
-        match accuracy {
-            Accuracy::Ptr => {
+    fn array_hash<H: Hasher>(&self, state: &mut H, eq_mode: EqMode) {
+        match eq_mode {
+            EqMode::Ptr => {
                 self.as_ptr().hash(state);
                 self.len().hash(state);
             }
-            Accuracy::Value => {
+            EqMode::Value => {
                 self.as_ref().hash(state);
             }
         }
     }
 }
 impl<T: PartialEq> ArrayEq for Buffer<T> {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
-        match accuracy {
-            Accuracy::Ptr => self.as_ptr() == other.as_ptr() && self.len() == other.len(),
-            Accuracy::Value => self.as_ref() == other.as_ref(),
+    fn array_eq(&self, other: &Self, eq_mode: EqMode) -> bool {
+        match eq_mode {
+            EqMode::Ptr => self.as_ptr() == other.as_ptr() && self.len() == other.len(),
+            EqMode::Value => self.as_ref() == other.as_ref(),
         }
     }
 }
 
 impl ArrayHash for BitBuffer {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
-        match accuracy {
-            Accuracy::Ptr => {
+    fn array_hash<H: Hasher>(&self, state: &mut H, eq_mode: EqMode) {
+        match eq_mode {
+            EqMode::Ptr => {
                 self.inner().as_ptr().hash(state);
                 self.offset().hash(state);
                 self.len().hash(state);
             }
-            Accuracy::Value => {
+            EqMode::Value => {
                 // NOTE(ngates): this is really rather expensive...
                 for chunk in self.chunks().iter_padded() {
                     chunk.hash(state);
@@ -124,24 +124,24 @@ impl ArrayHash for BitBuffer {
     }
 }
 impl ArrayEq for BitBuffer {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
-        match accuracy {
-            Accuracy::Ptr => {
+    fn array_eq(&self, other: &Self, eq_mode: EqMode) -> bool {
+        match eq_mode {
+            EqMode::Ptr => {
                 self.inner().as_ptr() == other.inner().as_ptr()
                     && self.offset() == other.offset()
                     && self.len() == other.len()
             }
-            Accuracy::Value => self.eq(other),
+            EqMode::Value => self.eq(other),
         }
     }
 }
 
 impl<T: ArrayHash> ArrayHash for Option<T> {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, eq_mode: EqMode) {
         match self {
             Some(value) => {
                 true.hash(state);
-                value.array_hash(state, accuracy);
+                value.array_hash(state, eq_mode);
             }
             None => {
                 false.hash(state);
@@ -151,9 +151,9 @@ impl<T: ArrayHash> ArrayHash for Option<T> {
 }
 
 impl<T: ArrayEq> ArrayEq for Option<T> {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, eq_mode: EqMode) -> bool {
         match (self, other) {
-            (Some(v1), Some(v2)) => v1.array_eq(v2, accuracy),
+            (Some(v1), Some(v2)) => v1.array_eq(v2, eq_mode),
             (None, None) => true,
             _ => false,
         }
@@ -161,7 +161,7 @@ impl<T: ArrayEq> ArrayEq for Option<T> {
 }
 
 impl ArrayHash for Mask {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, eq_mode: EqMode) {
         std::mem::discriminant(self).hash(state);
         match self {
             Mask::AllTrue(len) => {
@@ -171,18 +171,18 @@ impl ArrayHash for Mask {
                 len.hash(state);
             }
             Mask::Values(values) => {
-                values.bit_buffer().array_hash(state, accuracy);
+                values.bit_buffer().array_hash(state, eq_mode);
             }
         }
     }
 }
 impl ArrayEq for Mask {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, eq_mode: EqMode) -> bool {
         match (self, other) {
             (Mask::AllTrue(len1), Mask::AllTrue(len2)) => len1 == len2,
             (Mask::AllFalse(len1), Mask::AllFalse(len2)) => len1 == len2,
             (Mask::Values(buf1), Mask::Values(buf2)) => {
-                buf1.bit_buffer().array_eq(buf2.bit_buffer(), accuracy)
+                buf1.bit_buffer().array_eq(buf2.bit_buffer(), eq_mode)
             }
             _ => false,
         }
@@ -190,40 +190,40 @@ impl ArrayEq for Mask {
 }
 
 impl ArrayHash for Validity {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, eq_mode: EqMode) {
         std::mem::discriminant(self).hash(state);
         if let Validity::Array(array) = self {
-            array.array_hash(state, accuracy);
+            array.array_hash(state, eq_mode);
         }
     }
 }
 
 impl ArrayEq for Validity {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, eq_mode: EqMode) -> bool {
         match (self, other) {
             (Validity::AllValid, Validity::AllValid) => true,
             (Validity::AllInvalid, Validity::AllInvalid) => true,
             (Validity::NonNullable, Validity::NonNullable) => true,
-            (Validity::Array(arr1), Validity::Array(arr2)) => arr1.array_eq(arr2, accuracy),
+            (Validity::Array(arr1), Validity::Array(arr2)) => arr1.array_eq(arr2, eq_mode),
             _ => false,
         }
     }
 }
 
 impl ArrayHash for Patches {
-    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, eq_mode: EqMode) {
         self.array_len().hash(state);
         self.offset().hash(state);
-        self.indices().array_hash(state, accuracy);
-        self.values().array_hash(state, accuracy);
+        self.indices().array_hash(state, eq_mode);
+        self.values().array_hash(state, eq_mode);
     }
 }
 
 impl ArrayEq for Patches {
-    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, eq_mode: EqMode) -> bool {
         self.array_len() == other.array_len()
             && self.offset() == other.offset()
-            && self.indices().array_eq(other.indices(), accuracy)
-            && self.values().array_eq(other.values(), accuracy)
+            && self.indices().array_eq(other.indices(), eq_mode)
+            && self.values().array_eq(other.values(), eq_mode)
     }
 }

--- a/vortex-array/src/hash.rs
+++ b/vortex-array/src/hash.rs
@@ -12,12 +12,12 @@ use vortex_mask::Mask;
 use crate::patches::Patches;
 use crate::validity::Validity;
 
-/// The precision level for structural equality and hashing of arrays.
+/// The accuracy level for structural equality and hashing of arrays.
 ///
 /// This configuration option defines how precise the hash/equals results are given the set of
 /// data buffers backing the array.
 #[derive(Clone, Copy, Debug)]
-pub enum Precision {
+pub enum Accuracy {
     /// Data buffers are compared by their pointer and length only. This is the fastest option, but
     /// may lead to false negatives if two arrays contain identical data but are backed by
     /// different buffers.
@@ -28,49 +28,49 @@ pub enum Precision {
 }
 
 /// A hash trait for arrays that represents structural equality with a configurable level of
-/// precision. This trait is used primarily to implement common subtree elimination and other
+/// accuracy. This trait is used primarily to implement common subtree elimination and other
 /// array-based caching mechanisms.
 ///
-/// The precision of the hash defines what level of structural equality is represented. See
-/// [`Precision`] for more details.
+/// The accuracy of the hash defines what level of structural equality is represented. See
+/// [`Accuracy`] for more details.
 ///
-/// Note that where [`Precision::Ptr`] is used, the hash is only valid for the lifetime of the
+/// Note that where [`Accuracy::Ptr`] is used, the hash is only valid for the lifetime of the
 /// object.
 pub trait ArrayHash {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision);
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy);
 }
 
 /// A dynamic version of [`ArrayHash`].
 pub trait DynArrayDataHash: private::SealedHash {
-    fn dyn_array_hash(&self, state: &mut dyn Hasher, precision: Precision);
+    fn dyn_array_hash(&self, state: &mut dyn Hasher, accuracy: Accuracy);
 }
 
 impl<T: ArrayHash + ?Sized> DynArrayDataHash for T {
-    fn dyn_array_hash(&self, mut state: &mut dyn Hasher, precision: Precision) {
-        ArrayHash::array_hash(self, &mut state, precision);
+    fn dyn_array_hash(&self, mut state: &mut dyn Hasher, accuracy: Accuracy) {
+        ArrayHash::array_hash(self, &mut state, accuracy);
     }
 }
 
 /// An equality trait for arrays that represents structural equality with a configurable level of
-/// precision. This trait is used primarily to implement common subtree elimination and other
+/// accuracy. This trait is used primarily to implement common subtree elimination and other
 /// array-based caching mechanisms.
 ///
-/// The precision of the equality check defines what level of structural equality is represented. See
-/// [`Precision`] for more details.
+/// The accuracy of the equality check defines what level of structural equality is represented. See
+/// [`Accuracy`] for more details.
 pub trait ArrayEq {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool;
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool;
 }
 
 /// A dynamic version of [`ArrayEq`].
 pub trait DynArrayDataEq: private::SealedEq {
-    fn dyn_array_eq(&self, other: &dyn Any, precision: Precision) -> bool;
+    fn dyn_array_eq(&self, other: &dyn Any, accuracy: Accuracy) -> bool;
 }
 
 impl<T: ArrayEq + 'static> DynArrayDataEq for T {
-    fn dyn_array_eq(&self, other: &dyn Any, precision: Precision) -> bool {
+    fn dyn_array_eq(&self, other: &dyn Any, accuracy: Accuracy) -> bool {
         other
             .downcast_ref::<Self>()
-            .is_some_and(|other| ArrayEq::array_eq(self, other, precision))
+            .is_some_and(|other| ArrayEq::array_eq(self, other, accuracy))
     }
 }
 
@@ -85,36 +85,36 @@ mod private {
 }
 
 impl<T: Hash> ArrayHash for Buffer<T> {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
-        match precision {
-            Precision::Ptr => {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+        match accuracy {
+            Accuracy::Ptr => {
                 self.as_ptr().hash(state);
                 self.len().hash(state);
             }
-            Precision::Value => {
+            Accuracy::Value => {
                 self.as_ref().hash(state);
             }
         }
     }
 }
 impl<T: PartialEq> ArrayEq for Buffer<T> {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
-        match precision {
-            Precision::Ptr => self.as_ptr() == other.as_ptr() && self.len() == other.len(),
-            Precision::Value => self.as_ref() == other.as_ref(),
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+        match accuracy {
+            Accuracy::Ptr => self.as_ptr() == other.as_ptr() && self.len() == other.len(),
+            Accuracy::Value => self.as_ref() == other.as_ref(),
         }
     }
 }
 
 impl ArrayHash for BitBuffer {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
-        match precision {
-            Precision::Ptr => {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
+        match accuracy {
+            Accuracy::Ptr => {
                 self.inner().as_ptr().hash(state);
                 self.offset().hash(state);
                 self.len().hash(state);
             }
-            Precision::Value => {
+            Accuracy::Value => {
                 // NOTE(ngates): this is really rather expensive...
                 for chunk in self.chunks().iter_padded() {
                     chunk.hash(state);
@@ -124,24 +124,24 @@ impl ArrayHash for BitBuffer {
     }
 }
 impl ArrayEq for BitBuffer {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
-        match precision {
-            Precision::Ptr => {
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
+        match accuracy {
+            Accuracy::Ptr => {
                 self.inner().as_ptr() == other.inner().as_ptr()
                     && self.offset() == other.offset()
                     && self.len() == other.len()
             }
-            Precision::Value => self.eq(other),
+            Accuracy::Value => self.eq(other),
         }
     }
 }
 
 impl<T: ArrayHash> ArrayHash for Option<T> {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
         match self {
             Some(value) => {
                 true.hash(state);
-                value.array_hash(state, precision);
+                value.array_hash(state, accuracy);
             }
             None => {
                 false.hash(state);
@@ -151,9 +151,9 @@ impl<T: ArrayHash> ArrayHash for Option<T> {
 }
 
 impl<T: ArrayEq> ArrayEq for Option<T> {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
         match (self, other) {
-            (Some(v1), Some(v2)) => v1.array_eq(v2, precision),
+            (Some(v1), Some(v2)) => v1.array_eq(v2, accuracy),
             (None, None) => true,
             _ => false,
         }
@@ -161,7 +161,7 @@ impl<T: ArrayEq> ArrayEq for Option<T> {
 }
 
 impl ArrayHash for Mask {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
         std::mem::discriminant(self).hash(state);
         match self {
             Mask::AllTrue(len) => {
@@ -171,18 +171,18 @@ impl ArrayHash for Mask {
                 len.hash(state);
             }
             Mask::Values(values) => {
-                values.bit_buffer().array_hash(state, precision);
+                values.bit_buffer().array_hash(state, accuracy);
             }
         }
     }
 }
 impl ArrayEq for Mask {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
         match (self, other) {
             (Mask::AllTrue(len1), Mask::AllTrue(len2)) => len1 == len2,
             (Mask::AllFalse(len1), Mask::AllFalse(len2)) => len1 == len2,
             (Mask::Values(buf1), Mask::Values(buf2)) => {
-                buf1.bit_buffer().array_eq(buf2.bit_buffer(), precision)
+                buf1.bit_buffer().array_eq(buf2.bit_buffer(), accuracy)
             }
             _ => false,
         }
@@ -190,40 +190,40 @@ impl ArrayEq for Mask {
 }
 
 impl ArrayHash for Validity {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
         std::mem::discriminant(self).hash(state);
         if let Validity::Array(array) = self {
-            array.array_hash(state, precision);
+            array.array_hash(state, accuracy);
         }
     }
 }
 
 impl ArrayEq for Validity {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
         match (self, other) {
             (Validity::AllValid, Validity::AllValid) => true,
             (Validity::AllInvalid, Validity::AllInvalid) => true,
             (Validity::NonNullable, Validity::NonNullable) => true,
-            (Validity::Array(arr1), Validity::Array(arr2)) => arr1.array_eq(arr2, precision),
+            (Validity::Array(arr1), Validity::Array(arr2)) => arr1.array_eq(arr2, accuracy),
             _ => false,
         }
     }
 }
 
 impl ArrayHash for Patches {
-    fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {
+    fn array_hash<H: Hasher>(&self, state: &mut H, accuracy: Accuracy) {
         self.array_len().hash(state);
         self.offset().hash(state);
-        self.indices().array_hash(state, precision);
-        self.values().array_hash(state, precision);
+        self.indices().array_hash(state, accuracy);
+        self.values().array_hash(state, accuracy);
     }
 }
 
 impl ArrayEq for Patches {
-    fn array_eq(&self, other: &Self, precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, accuracy: Accuracy) -> bool {
         self.array_len() == other.array_len()
             && self.offset() == other.offset()
-            && self.indices().array_eq(other.indices(), precision)
-            && self.values().array_eq(other.values(), precision)
+            && self.indices().array_eq(other.indices(), accuracy)
+            && self.values().array_eq(other.values(), accuracy)
     }
 }

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -4,6 +4,7 @@
 use std::hash::Hash;
 use std::sync::Arc;
 
+use vortex::array::Accuracy;
 use vortex::array::Array;
 use vortex::array::ArrayEq;
 use vortex::array::ArrayHash;
@@ -14,7 +15,6 @@ use vortex::array::ArrayView;
 use vortex::array::ExecutionCtx;
 use vortex::array::ExecutionResult;
 use vortex::array::OperationsVTable;
-use vortex::array::Precision;
 use vortex::array::VTable;
 use vortex::array::ValidityVTable;
 use vortex::array::buffer::BufferHandle;
@@ -37,13 +37,13 @@ pub struct PythonVTable {
 }
 
 impl ArrayHash for PythonArray {
-    fn array_hash<H: std::hash::Hasher>(&self, state: &mut H, _precision: Precision) {
+    fn array_hash<H: std::hash::Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
         Arc::as_ptr(&self.object).hash(state);
     }
 }
 
 impl ArrayEq for PythonArray {
-    fn array_eq(&self, other: &Self, _precision: Precision) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
         Arc::ptr_eq(&self.object, &other.object)
     }
 }

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -4,7 +4,6 @@
 use std::hash::Hash;
 use std::sync::Arc;
 
-use vortex::array::Accuracy;
 use vortex::array::Array;
 use vortex::array::ArrayEq;
 use vortex::array::ArrayHash;
@@ -12,6 +11,7 @@ use vortex::array::ArrayId;
 use vortex::array::ArrayParts;
 use vortex::array::ArrayRef;
 use vortex::array::ArrayView;
+use vortex::array::EqMode;
 use vortex::array::ExecutionCtx;
 use vortex::array::ExecutionResult;
 use vortex::array::OperationsVTable;
@@ -37,13 +37,13 @@ pub struct PythonVTable {
 }
 
 impl ArrayHash for PythonArray {
-    fn array_hash<H: std::hash::Hasher>(&self, state: &mut H, _accuracy: Accuracy) {
+    fn array_hash<H: std::hash::Hasher>(&self, state: &mut H, _accuracy: EqMode) {
         Arc::as_ptr(&self.object).hash(state);
     }
 }
 
 impl ArrayEq for PythonArray {
-    fn array_eq(&self, other: &Self, _accuracy: Accuracy) -> bool {
+    fn array_eq(&self, other: &Self, _accuracy: EqMode) -> bool {
         Arc::ptr_eq(&self.object, &other.object)
     }
 }


### PR DESCRIPTION
## Summary

This PR renames the `Precision` enum that we use to do array hashing and equality checks to `Accuracy`, as we already have a `Precision` enum we use for stats, that is also part of the binary format.

## API Changes

Just the renamed enum, which should be relatively minor.

## Testing

N/A
