### PR TITLE
reset offsets in list builder

### DIFF
--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -16,7 +16,9 @@ use crate::Canonical;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
+use crate::arrays::List;
 use crate::arrays::ListArray;
+use crate::arrays::list::ListArrayExt;
 use crate::arrays::listview::ListViewArrayExt;
 use crate::builders::ArrayBuilder;
 use crate::builders::DEFAULT_BUILDER_CAPACITY;
@@ -218,6 +220,20 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
     }
 
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
+        // Trim the element child to the window the offsets actually reference *before*
+        // canonicalizing in `to_listview()` that would otherwise decode the entire chunk.
+        let trimmed;
+        // Only ListArray has this sliced-but-untrimmed property.
+        let array = if let Some(list) = array.as_opt::<List>() {
+            trimmed = list
+                .reset_offsets(false)
+                .vortex_expect("reset_offsets in extend_from_array_unchecked")
+                .into_array();
+            &trimmed
+        } else {
+            array
+        };
+
         #[expect(deprecated)]
         let list = array.to_listview();
         if list.is_empty() {


### PR DESCRIPTION
extend_from_array_unchecked calls to_listview(), which internally calls to_canonical() on the elements array to decode it. Because the elements buffer was never trimmed, it decodes the entire original buffer, even if you only sliced a small window out of it. In a scan that appends many small slices from a large compressed chunk, you pay the full decode cost on every single append. If you append k slices, each covering w rows of a chunk with N total rows, you decode O(k × N) instead of O(k × w).
