### PR TITLE
fix: `[profile.bench]` `codegen-units = 16`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -389,7 +389,7 @@ debug = "full"
 inherits = "release"
 
 [profile.bench]
-codegen-units = 1
+codegen-units = 16
 debug = "full"
 lto = false
 


### PR DESCRIPTION
#7824 changed this field?

We use 16 since this is cargo release default.