### PR TITLE
Add #[inline] hints to hot path functions

### DIFF
--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -390,16 +390,19 @@ impl ArrayRef {
     }
 
     /// Does the array match the given matcher.
+    #[inline]
     pub fn is<M: Matcher>(&self) -> bool {
         M::matches(self)
     }
 
     /// Returns the array downcast by the given matcher.
+    #[inline]
     pub fn as_<M: Matcher>(&self) -> M::Match<'_> {
         self.as_opt::<M>().vortex_expect("Failed to downcast")
     }
 
     /// Returns the array downcast by the given matcher.
+    #[inline]
     pub fn as_opt<M: Matcher>(&self) -> Option<M::Match<'_>> {
         M::try_match(self)
     }
@@ -738,10 +741,12 @@ impl IntoArray for ArrayRef {
 impl<V: VTable> Matcher for V {
     type Match<'a> = ArrayView<'a, V>;
 
+    #[inline]
     fn matches(array: &ArrayRef) -> bool {
         array.0.data.as_any().is::<ArrayData<V>>()
     }
 
+    #[inline]
     fn try_match(array: &'_ ArrayRef) -> Option<ArrayView<'_, V>> {
         let inner = array.0.data.as_any().downcast_ref::<ArrayData<V>>()?;
         // # Safety checked by `downcast_ref`.

--- a/vortex-array/src/arrays/varbinview/compute/zip.rs
+++ b/vortex-array/src/arrays/varbinview/compute/zip.rs
@@ -177,6 +177,7 @@ fn push_range(
     }
 }
 
+#[inline]
 fn push_view(
     view: BinaryView,
     buffer_lookup: &[u32],

--- a/vortex-array/src/buffer.rs
+++ b/vortex-array/src/buffer.rs
@@ -249,6 +249,7 @@ impl BufferHandle {
     }
 
     /// Downcast this handle as a handle to a host-resident buffer, or `None`.
+    #[inline]
     pub fn as_host_opt(&self) -> Option<&ByteBuffer> {
         match &self.0 {
             Inner::Host(buffer) => Some(buffer),
@@ -266,6 +267,7 @@ impl BufferHandle {
 
     /// A version of [`as_host_opt`][Self::as_host_opt] that panics if the allocation is
     /// not a host allocation.
+    #[inline]
     pub fn as_host(&self) -> &ByteBuffer {
         self.as_host_opt().vortex_expect("expected host buffer")
     }

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -367,6 +367,7 @@ impl ArrayBuilder for VarBinViewBuilder {
 }
 
 impl VarBinViewBuilder {
+    #[inline]
     fn push_view(
         &mut self,
         view: BinaryView,
@@ -758,6 +759,7 @@ enum PrecomputedViewAdjustment {
 }
 
 impl PrecomputedViewAdjustment {
+    #[inline]
     fn adjust_view(&self, view: &BinaryView) -> BinaryView {
         if view.is_inlined() {
             return *view;
@@ -815,6 +817,7 @@ struct RewritingViewAdjustment {
 impl RewritingViewAdjustment {
     /// Can return None if this view can't be adjusted, because there is no precomputed lookup
     /// for the current buffer.
+    #[inline]
     fn adjust_view(&self, view: &BinaryView) -> Option<BinaryView> {
         if view.is_inlined() {
             return Some(*view);

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -1072,6 +1072,7 @@ pub struct AnyCanonical;
 impl Matcher for AnyCanonical {
     type Match<'a> = CanonicalView<'a>;
 
+    #[inline]
     fn matches(array: &ArrayRef) -> bool {
         array.is::<Null>()
             || array.is::<Bool>()
@@ -1085,6 +1086,7 @@ impl Matcher for AnyCanonical {
             || array.is::<Extension>()
     }
 
+    #[inline]
     fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
         if let Some(a) = array.as_opt::<Null>() {
             Some(CanonicalView::Null(a))

--- a/vortex-array/src/matcher.rs
+++ b/vortex-array/src/matcher.rs
@@ -8,6 +8,7 @@ pub trait Matcher {
     type Match<'a>;
 
     /// Check if the given array matches this matcher type
+    #[inline]
     fn matches(array: &ArrayRef) -> bool {
         Self::try_match(array).is_some()
     }

--- a/vortex-array/src/search_sorted.rs
+++ b/vortex-array/src/search_sorted.rs
@@ -113,12 +113,10 @@ pub trait IndexOrd<V> {
         Ok(matches!(self.index_cmp(idx, elem)?, Some(Less | Equal)))
     }
 
-    #[inline]
     fn index_gt(&self, idx: usize, elem: &V) -> VortexResult<bool> {
         Ok(matches!(self.index_cmp(idx, elem)?, Some(Greater)))
     }
 
-    #[inline]
     fn index_ge(&self, idx: usize, elem: &V) -> VortexResult<bool> {
         Ok(matches!(self.index_cmp(idx, elem)?, Some(Greater | Equal)))
     }

--- a/vortex-array/src/search_sorted.rs
+++ b/vortex-array/src/search_sorted.rs
@@ -103,18 +103,22 @@ pub trait IndexOrd<V> {
     /// For example, if self\[idx\] > elem, return Some(Greater).
     fn index_cmp(&self, idx: usize, elem: &V) -> VortexResult<Option<Ordering>>;
 
+    #[inline]
     fn index_lt(&self, idx: usize, elem: &V) -> VortexResult<bool> {
         Ok(matches!(self.index_cmp(idx, elem)?, Some(Less)))
     }
 
+    #[inline]
     fn index_le(&self, idx: usize, elem: &V) -> VortexResult<bool> {
         Ok(matches!(self.index_cmp(idx, elem)?, Some(Less | Equal)))
     }
 
+    #[inline]
     fn index_gt(&self, idx: usize, elem: &V) -> VortexResult<bool> {
         Ok(matches!(self.index_cmp(idx, elem)?, Some(Greater)))
     }
 
+    #[inline]
     fn index_ge(&self, idx: usize, elem: &V) -> VortexResult<bool> {
         Ok(matches!(self.index_cmp(idx, elem)?, Some(Greater | Equal)))
     }
@@ -132,6 +136,7 @@ pub trait IndexOrd<V> {
 /// |left |array\[i-1\] < value <= array\[i\]|
 /// |right|array\[i-1\] <= value < array\[i\]|
 pub trait SearchSorted<T> {
+    #[inline]
     fn search_sorted(&self, value: &T, side: SearchSortedSide) -> VortexResult<SearchResult>
     where
         Self: IndexOrd<T>,
@@ -180,6 +185,7 @@ impl<S, T> SearchSorted<T> for S
 where
     S: IndexOrd<T> + ?Sized,
 {
+    #[inline]
     fn search_sorted_by<
         F: FnMut(usize) -> VortexResult<Ordering>,
         N: FnMut(usize) -> VortexResult<Ordering>,
@@ -210,6 +216,7 @@ where
 }
 
 // Code adapted from Rust standard library slice::binary_search_by
+#[inline]
 fn search_sorted_side_idx<F: FnMut(usize) -> VortexResult<Ordering>>(
     mut find: F,
     from: usize,
@@ -276,11 +283,13 @@ impl IndexOrd<Scalar> for ArrayRef {
 }
 
 impl<T: PartialOrd> IndexOrd<T> for [T] {
+    #[inline]
     fn index_cmp(&self, idx: usize, elem: &T) -> VortexResult<Option<Ordering>> {
         // SAFETY: Used in search_sorted_by same as the standard library. The search_sorted ensures idx is in bounds
         Ok(unsafe { self.get_unchecked(idx) }.partial_cmp(elem))
     }
 
+    #[inline]
     fn index_len(&self) -> usize {
         self.len()
     }

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -392,7 +392,6 @@ impl From<Vec<bool>> for BitBuffer {
 }
 
 impl FromIterator<bool> for BitBuffer {
-    #[inline]
     fn from_iter<T: IntoIterator<Item = bool>>(iter: T) -> Self {
         BitBufferMut::from_iter(iter).freeze()
     }

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -392,6 +392,7 @@ impl From<Vec<bool>> for BitBuffer {
 }
 
 impl FromIterator<bool> for BitBuffer {
+    #[inline]
     fn from_iter<T: IntoIterator<Item = bool>>(iter: T) -> Self {
         BitBufferMut::from_iter(iter).freeze()
     }

--- a/vortex-buffer/src/bit/buf_mut.rs
+++ b/vortex-buffer/src/bit/buf_mut.rs
@@ -581,6 +581,7 @@ impl From<Vec<bool>> for BitBufferMut {
 }
 
 impl FromIterator<bool> for BitBufferMut {
+    #[inline]
     fn from_iter<T: IntoIterator<Item = bool>>(iter: T) -> Self {
         let mut iter = iter.into_iter();
 


### PR DESCRIPTION
## Summary

This PR adds `#[inline]` hints to a collection of small, frequently-called functions across the codebase to improve performance. These are primarily simple wrapper methods, trait implementations, and utility functions that benefit from inlining to reduce function call overhead.

These are all candidates for inlining because they are:
1. Small wrapper functions with minimal logic
2. Called frequently in hot paths (e.g., binary search, array access)
3. Generic or trait methods where inlining enables better monomorphization
4. Simple accessors and type checks
