### PR TITLE
Optimize dict array validation to use true_count()

### DIFF
--- a/vortex-array/benches/dict_unreferenced_mask.rs
+++ b/vortex-array/benches/dict_unreferenced_mask.rs
@@ -16,6 +16,23 @@ fn main() {
     divan::main();
 }
 
+/// Flags a fixture as fully referenced when it actually is, mirroring what the encoder records.
+/// This keeps fully-referenced dictionaries on the early-exit path (as they would be in practice),
+/// rather than the blind-store path used when only some values are referenced.
+fn flag_if_all_referenced(array: DictArray, num_values: usize) -> DictArray {
+    let all_referenced = array
+        .compute_referenced_values_mask(true)
+        .unwrap()
+        .true_count()
+        == num_values;
+    if all_referenced {
+        // SAFETY: verified above that every value is referenced by a valid code.
+        unsafe { array.set_all_values_referenced(true) }
+    } else {
+        array
+    }
+}
+
 /// Benchmark with many codes (65K) relative to 1024 values.
 /// This tests performance when the values dictionary is small but many codes reference it.
 #[divan::bench(args = [
@@ -38,7 +55,45 @@ fn bench_many_codes_few_values(bencher: Bencher, num_values: i32) {
     )
     .into_array();
 
-    let array = DictArray::try_new(codes, values).unwrap();
+    let array = flag_if_all_referenced(
+        DictArray::try_new(codes, values).unwrap(),
+        num_values as usize,
+    );
+
+    bencher
+        .with_inputs(|| &array)
+        .bench_refs(|array| array.compute_referenced_values_mask(false).unwrap());
+}
+
+/// Benchmark the production shape: a 1K-16K value dictionary where only ~50% of the values are
+/// referenced, with 65K codes. Because the dictionary is not fully referenced the mask must scan
+/// every code (no early exit) — this is what `min_max`/`is_constant` see in practice.
+#[divan::bench(args = [
+    1024,
+    4096,
+    8192,
+    16384,
+])]
+fn bench_partial_coverage(bencher: Bencher, num_values: i32) {
+    let mut rng = StdRng::seed_from_u64(0);
+
+    let num_codes = 65_536;
+
+    let values = PrimitiveArray::from_iter(0..num_values).into_array();
+
+    // Codes only ever reference the first ~50% of the values.
+    #[expect(clippy::cast_sign_loss)]
+    let num_referenced = (num_values as usize / 2).max(1);
+    #[expect(clippy::cast_possible_truncation)]
+    let codes = PrimitiveArray::from_iter(
+        (0..num_codes).map(|_| rng.random_range(0..num_referenced) as u32),
+    )
+    .into_array();
+
+    let array = flag_if_all_referenced(
+        DictArray::try_new(codes, values).unwrap(),
+        num_values as usize,
+    );
 
     bencher
         .with_inputs(|| &array)
@@ -70,7 +125,10 @@ fn bench_many_nulls(bencher: Bencher, fraction_valid: f64) {
     }))
     .into_array();
 
-    let array = DictArray::try_new(codes, values).unwrap();
+    let array = flag_if_all_referenced(
+        DictArray::try_new(codes, values).unwrap(),
+        num_values as usize,
+    );
 
     bencher
         .with_inputs(|| &array)
@@ -104,7 +162,10 @@ fn bench_sparse_coverage(bencher: Bencher, fraction_coverage: f64) {
     )
     .into_array();
 
-    let array = DictArray::try_new(codes, values).unwrap();
+    let array = flag_if_all_referenced(
+        DictArray::try_new(codes, values).unwrap(),
+        num_values as usize,
+    );
 
     bencher
         .with_inputs(|| &array)

--- a/vortex-array/benches/dict_unreferenced_mask.rs
+++ b/vortex-array/benches/dict_unreferenced_mask.rs
@@ -16,23 +16,6 @@ fn main() {
     divan::main();
 }
 
-/// Flags a fixture as fully referenced when it actually is, mirroring what the encoder records.
-/// This keeps fully-referenced dictionaries on the early-exit path (as they would be in practice),
-/// rather than the blind-store path used when only some values are referenced.
-fn flag_if_all_referenced(array: DictArray, num_values: usize) -> DictArray {
-    let all_referenced = array
-        .compute_referenced_values_mask(true)
-        .unwrap()
-        .true_count()
-        == num_values;
-    if all_referenced {
-        // SAFETY: verified above that every value is referenced by a valid code.
-        unsafe { array.set_all_values_referenced(true) }
-    } else {
-        array
-    }
-}
-
 /// Benchmark with many codes (65K) relative to 1024 values.
 /// This tests performance when the values dictionary is small but many codes reference it.
 #[divan::bench(args = [
@@ -55,45 +38,7 @@ fn bench_many_codes_few_values(bencher: Bencher, num_values: i32) {
     )
     .into_array();
 
-    let array = flag_if_all_referenced(
-        DictArray::try_new(codes, values).unwrap(),
-        num_values as usize,
-    );
-
-    bencher
-        .with_inputs(|| &array)
-        .bench_refs(|array| array.compute_referenced_values_mask(false).unwrap());
-}
-
-/// Benchmark the production shape: a 1K-16K value dictionary where only ~50% of the values are
-/// referenced, with 65K codes. Because the dictionary is not fully referenced the mask must scan
-/// every code (no early exit) — this is what `min_max`/`is_constant` see in practice.
-#[divan::bench(args = [
-    1024,
-    4096,
-    8192,
-    16384,
-])]
-fn bench_partial_coverage(bencher: Bencher, num_values: i32) {
-    let mut rng = StdRng::seed_from_u64(0);
-
-    let num_codes = 65_536;
-
-    let values = PrimitiveArray::from_iter(0..num_values).into_array();
-
-    // Codes only ever reference the first ~50% of the values.
-    #[expect(clippy::cast_sign_loss)]
-    let num_referenced = (num_values as usize / 2).max(1);
-    #[expect(clippy::cast_possible_truncation)]
-    let codes = PrimitiveArray::from_iter(
-        (0..num_codes).map(|_| rng.random_range(0..num_referenced) as u32),
-    )
-    .into_array();
-
-    let array = flag_if_all_referenced(
-        DictArray::try_new(codes, values).unwrap(),
-        num_values as usize,
-    );
+    let array = DictArray::try_new(codes, values).unwrap();
 
     bencher
         .with_inputs(|| &array)
@@ -125,10 +70,7 @@ fn bench_many_nulls(bencher: Bencher, fraction_valid: f64) {
     }))
     .into_array();
 
-    let array = flag_if_all_referenced(
-        DictArray::try_new(codes, values).unwrap(),
-        num_values as usize,
-    );
+    let array = DictArray::try_new(codes, values).unwrap();
 
     bencher
         .with_inputs(|| &array)
@@ -162,10 +104,7 @@ fn bench_sparse_coverage(bencher: Bencher, fraction_coverage: f64) {
     )
     .into_array();
 
-    let array = flag_if_all_referenced(
-        DictArray::try_new(codes, values).unwrap(),
-        num_values as usize,
-    );
+    let array = DictArray::try_new(codes, values).unwrap();
 
     bencher
         .with_inputs(|| &array)

--- a/vortex-array/src/arrays/dict/array.rs
+++ b/vortex-array/src/arrays/dict/array.rs
@@ -23,6 +23,7 @@ use crate::array::ArrayParts;
 use crate::array::TypedArrayRef;
 use crate::array_slots;
 use crate::arrays::Dict;
+use crate::arrays::PrimitiveArray;
 use crate::dtype::DType;
 use crate::dtype::PType;
 use crate::match_each_integer_ptype;
@@ -156,39 +157,13 @@ pub trait DictArrayExt: TypedArrayRef<Dict> + DictArraySlotsExt {
         let values_len = self.values().len();
 
         // `seen[i]` records whether value `i` is referenced by at least one valid code.
-        // `mark_referenced` stops as soon as every value has been seen: dictionaries are
-        // frequently referenced by far more codes than they have values, so this commonly skips
-        // the bulk of the scatter — and the final pack, since the resulting mask is then constant.
         let mut seen = vec![false; values_len];
-        let all_referenced = match codes_validity.bit_buffer() {
-            AllOr::All => {
-                match_each_integer_ptype!(codes_primitive.ptype(), |P| {
-                    #[allow(
-                        clippy::cast_possible_truncation,
-                        clippy::cast_sign_loss,
-                        reason = "codes are non-negative indices; a negative signed code would wrap to a large usize and panic on the bounds-checked array index"
-                    )]
-                    let indices = codes_primitive
-                        .as_slice::<P>()
-                        .iter()
-                        .map(|&idx| idx as usize);
-                    mark_referenced(&mut seen, indices)
-                })
-            }
-            AllOr::None => values_len == 0,
-            AllOr::Some(mask) => {
-                match_each_integer_ptype!(codes_primitive.ptype(), |P| {
-                    let codes = codes_primitive.as_slice::<P>();
-                    #[allow(
-                        clippy::cast_possible_truncation,
-                        clippy::cast_sign_loss,
-                        reason = "codes are non-negative indices; a negative signed code would wrap to a large usize and panic on the bounds-checked array index"
-                    )]
-                    let indices = mask.set_indices().map(|i| codes[i] as usize);
-                    mark_referenced(&mut seen, indices)
-                })
-            }
-        };
+        let all_referenced = populate_seen(
+            &mut seen,
+            &codes_primitive,
+            codes_validity.bit_buffer(),
+            self.has_all_values_referenced(),
+        );
 
         // When every value is referenced the mask is constant, so we avoid rebuilding it.
         if all_referenced {
@@ -204,12 +179,68 @@ pub trait DictArrayExt: TypedArrayRef<Dict> + DictArraySlotsExt {
 }
 impl<T: TypedArrayRef<Dict>> DictArrayExt for T {}
 
-/// Marks `seen[idx] = true` for every index yielded by `indices`.
+/// Populates `seen` so that `seen[v]` is `true` iff value `v` is referenced by a valid code, and
+/// returns whether every value ended up referenced.
 ///
-/// Returns `true` as soon as every entry in `seen` has been marked (allowing the caller to stop
-/// early), otherwise `false` once `indices` is exhausted. The store is skipped for already-seen
-/// values, which in the common case of many codes per value avoids a read-modify-write storm on a
-/// handful of hot bytes.
+/// When `expect_all` is set — the caller believes the whole dictionary is referenced, e.g. during
+/// validation — the scan stops via [`mark_referenced`] as soon as every value has been seen.
+/// Otherwise, the common case where only some values are referenced (`min_max`/`is_constant`), a
+/// branchless blind store is used: writing every reference unconditionally avoids the branch
+/// mispredictions and read-modify-write contention that a data-dependent skip incurs on a small,
+/// densely-referenced dictionary.
+fn populate_seen(
+    seen: &mut [bool],
+    codes: &PrimitiveArray,
+    validity: AllOr<&BitBuffer>,
+    expect_all: bool,
+) -> bool {
+    match validity {
+        AllOr::All => match_each_integer_ptype!(codes.ptype(), |P| {
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "codes are non-negative indices; a negative signed code wraps to a large usize and panics on the bounds-checked array index"
+            )]
+            let indices = codes.as_slice::<P>().iter().map(|&c| c as usize);
+            scatter_into(seen, indices, expect_all)
+        }),
+        AllOr::None => seen.is_empty(),
+        AllOr::Some(valid) => match_each_integer_ptype!(codes.ptype(), |P| {
+            let codes = codes.as_slice::<P>();
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "codes are non-negative indices; a negative signed code wraps to a large usize and panics on the bounds-checked array index"
+            )]
+            let indices = valid.set_indices().map(|i| codes[i] as usize);
+            scatter_into(seen, indices, expect_all)
+        }),
+    }
+}
+
+/// Scatters references into `seen` and reports whether all values are referenced, choosing the
+/// early-exit or blind-store strategy based on `expect_all`. See [`populate_seen`].
+fn scatter_into(
+    seen: &mut [bool],
+    indices: impl IntoIterator<Item = usize>,
+    expect_all: bool,
+) -> bool {
+    if expect_all {
+        mark_referenced(seen, indices)
+    } else {
+        for idx in indices {
+            seen[idx] = true;
+        }
+        seen.iter().all(|&b| b)
+    }
+}
+
+/// Marks `seen[idx] = true` for every index yielded by `indices`, stopping as soon as every entry
+/// has been marked.
+///
+/// Returns `true` if every entry was marked (allowing the caller to stop early), otherwise `false`
+/// once `indices` is exhausted. The store is skipped for already-seen values, which when most codes
+/// repeat a fully-referenced dictionary lets the scan finish after only a fraction of the codes.
 fn mark_referenced(seen: &mut [bool], indices: impl IntoIterator<Item = usize>) -> bool {
     let mut remaining = seen.len();
     if remaining == 0 {

--- a/vortex-array/src/arrays/dict/array.rs
+++ b/vortex-array/src/arrays/dict/array.rs
@@ -6,7 +6,6 @@ use std::fmt::Formatter;
 
 use smallvec::smallvec;
 use vortex_buffer::BitBuffer;
-use vortex_buffer::BitBufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -24,7 +23,6 @@ use crate::array::ArrayParts;
 use crate::array::TypedArrayRef;
 use crate::array_slots;
 use crate::arrays::Dict;
-use crate::arrays::PrimitiveArray;
 use crate::dtype::DType;
 use crate::dtype::PType;
 use crate::match_each_integer_ptype;
@@ -137,9 +135,6 @@ pub trait DictArrayExt: TypedArrayRef<Dict> + DictArraySlotsExt {
             }
 
             let referenced_mask = self.compute_referenced_values_mask(true)?;
-            // "all values referenced" is equivalent to every bit being set, i.e. the popcount
-            // equals the length. `true_count` uses a vectorized popcount, which is much faster
-            // than iterating the buffer bit-by-bit.
             let all_referenced = referenced_mask.true_count() == referenced_mask.len();
 
             vortex_ensure!(all_referenced, "value in dict not referenced");
@@ -154,150 +149,47 @@ pub trait DictArrayExt: TypedArrayRef<Dict> + DictArraySlotsExt {
             .validity()?
             .execute_mask(codes.len(), &mut LEGACY_SESSION.create_execution_ctx())?;
         #[expect(deprecated)]
-        let codes_primitive = codes.to_primitive();
+        let codes_primitive = self.codes().to_primitive();
         let values_len = self.values().len();
 
-        // `seen[i]` is a non-zero byte iff value `i` is referenced by at least one valid code.
-        // A byte (rather than a packed bit) keeps the scatter a contended-free blind store and
-        // lets [`pack_seen`] fold eight values into a bitmap byte with a single multiply.
-        let mut seen = vec![0u8; values_len];
-        let all_referenced = populate_seen(
-            &mut seen,
-            &codes_primitive,
-            codes_validity.bit_buffer(),
-            self.has_all_values_referenced(),
-        );
+        let init_value = !referenced;
+        let referenced_value = referenced;
 
-        // When every value is referenced the mask is constant, so we avoid rebuilding it.
-        if all_referenced {
-            return Ok(BitBuffer::full(referenced, values_len));
+        let mut values_vec = vec![init_value; values_len];
+        match codes_validity.bit_buffer() {
+            AllOr::All => {
+                match_each_integer_ptype!(codes_primitive.ptype(), |P| {
+                    #[allow(
+                        clippy::cast_possible_truncation,
+                        clippy::cast_sign_loss,
+                        reason = "codes are non-negative indices; a negative signed code would wrap to a large usize and panic on the bounds-checked array index"
+                    )]
+                    for &idx in codes_primitive.as_slice::<P>() {
+                        values_vec[idx as usize] = referenced_value;
+                    }
+                });
+            }
+            AllOr::None => {}
+            AllOr::Some(mask) => {
+                match_each_integer_ptype!(codes_primitive.ptype(), |P| {
+                    let codes = codes_primitive.as_slice::<P>();
+
+                    #[allow(
+                        clippy::cast_possible_truncation,
+                        clippy::cast_sign_loss,
+                        reason = "codes are non-negative indices; a negative signed code would wrap to a large usize and panic on the bounds-checked array index"
+                    )]
+                    mask.set_indices().for_each(|idx| {
+                        values_vec[codes[idx] as usize] = referenced_value;
+                    });
+                });
+            }
         }
 
-        Ok(pack_seen(&seen, referenced))
+        Ok(BitBuffer::from(values_vec))
     }
 }
 impl<T: TypedArrayRef<Dict>> DictArrayExt for T {}
-
-/// Populates `seen` so that `seen[v]` is `true` iff value `v` is referenced by a valid code, and
-/// returns whether every value ended up referenced.
-///
-/// When `expect_all` is set — the caller believes the whole dictionary is referenced, e.g. during
-/// validation — the scan stops via [`mark_referenced`] as soon as every value has been seen.
-/// Otherwise, the common case where only some values are referenced (`min_max`/`is_constant`), a
-/// branchless blind store is used: writing every reference unconditionally avoids the branch
-/// mispredictions and read-modify-write contention that a data-dependent skip incurs on a small,
-/// densely-referenced dictionary.
-fn populate_seen(
-    seen: &mut [u8],
-    codes: &PrimitiveArray,
-    validity: AllOr<&BitBuffer>,
-    expect_all: bool,
-) -> bool {
-    match validity {
-        AllOr::All => match_each_integer_ptype!(codes.ptype(), |P| {
-            #[allow(
-                clippy::cast_possible_truncation,
-                clippy::cast_sign_loss,
-                reason = "codes are non-negative indices; a negative signed code wraps to a large usize and panics on the bounds-checked array index"
-            )]
-            let indices = codes.as_slice::<P>().iter().map(|&c| c as usize);
-            scatter_into(seen, indices, expect_all)
-        }),
-        AllOr::None => seen.is_empty(),
-        AllOr::Some(valid) => match_each_integer_ptype!(codes.ptype(), |P| {
-            let codes = codes.as_slice::<P>();
-            #[allow(
-                clippy::cast_possible_truncation,
-                clippy::cast_sign_loss,
-                reason = "codes are non-negative indices; a negative signed code wraps to a large usize and panics on the bounds-checked array index"
-            )]
-            let indices = valid.set_indices().map(|i| codes[i] as usize);
-            scatter_into(seen, indices, expect_all)
-        }),
-    }
-}
-
-/// Scatters references into `seen` and reports whether all values are referenced, choosing the
-/// early-exit or blind-store strategy based on `expect_all`. See [`populate_seen`].
-fn scatter_into(
-    seen: &mut [u8],
-    indices: impl IntoIterator<Item = usize>,
-    expect_all: bool,
-) -> bool {
-    if expect_all {
-        mark_referenced(seen, indices)
-    } else {
-        for idx in indices {
-            seen[idx] = 1;
-        }
-        seen.iter().all(|&b| b != 0)
-    }
-}
-
-/// Marks `seen[idx] = true` for every index yielded by `indices`, stopping as soon as every entry
-/// has been marked.
-///
-/// Returns `true` if every entry was marked (allowing the caller to stop early), otherwise `false`
-/// once `indices` is exhausted. The store is skipped for already-seen values, which when most codes
-/// repeat a fully-referenced dictionary lets the scan finish after only a fraction of the codes.
-fn mark_referenced(seen: &mut [u8], indices: impl IntoIterator<Item = usize>) -> bool {
-    let mut remaining = seen.len();
-    if remaining == 0 {
-        return true;
-    }
-    for idx in indices {
-        if seen[idx] == 0 {
-            seen[idx] = 1;
-            remaining -= 1;
-            if remaining == 0 {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-/// Packs `seen` (a non-zero byte per referenced value) into a bitmap. When `referenced` is set the
-/// result marks referenced values; otherwise it marks the unreferenced ones.
-///
-/// The hot loop folds eight `seen` bytes into one bitmap byte with a single multiply: masking to
-/// the low bit of each byte and multiplying by `0x0102_0408_1020_4080` gathers those eight low bits
-/// into the top byte, LSB-first. This is branchless, needs no target features (so it stays portable
-/// across architectures), and is an order of magnitude faster than a scalar bit-packing loop on the
-/// 1K-16K value dictionaries `min_max`/`is_constant` evaluate.
-fn pack_seen(seen: &[u8], referenced: bool) -> BitBuffer {
-    /// Isolates the low bit of each of the eight bytes in a `u64`.
-    const LOW_BITS: u64 = 0x0101_0101_0101_0101;
-    /// Gathers those eight low bits into the most-significant byte, LSB-first.
-    const GATHER: u64 = 0x0102_0408_1020_4080;
-
-    let len = seen.len();
-    let mut builder = BitBufferMut::new_unset(len);
-    let dst = builder.as_mut_slice();
-
-    let mut chunks = seen.chunks_exact(8);
-    for (byte, chunk) in dst.iter_mut().zip(chunks.by_ref()) {
-        let mut block = [0u8; 8];
-        block.copy_from_slice(chunk);
-        let bits = u64::from_le_bytes(block);
-        let packed = (((bits & LOW_BITS).wrapping_mul(GATHER)) >> 56) as u8;
-        *byte = if referenced { packed } else { !packed };
-    }
-
-    let tail = chunks.remainder();
-    if !tail.is_empty() {
-        let mut byte = 0u8;
-        for (k, &b) in tail.iter().enumerate() {
-            if (b != 0) == referenced {
-                byte |= 1 << k;
-            }
-        }
-        // The final partial byte sits after every full chunk written above.
-        dst[len / 8] = byte;
-    }
-
-    builder.freeze()
-}
 
 /// Concrete parts of a [`DictArray`](super::DictArray) after iterative execution.
 pub struct DictParts {
@@ -430,22 +322,6 @@ mod test {
     use crate::dtype::PType;
     use crate::dtype::UnsignedPType;
     use crate::validity::Validity;
-
-    #[test]
-    fn pack_seen_matches_reference() {
-        // `pack_seen` must agree bit-for-bit with a per-bit reference for both polarities and for
-        // lengths that exercise full 8-byte chunks, partial tails, and word boundaries.
-        for len in [
-            0usize, 1, 7, 8, 9, 15, 16, 63, 64, 65, 127, 1000, 1023, 1024,
-        ] {
-            let seen: Vec<u8> = (0..len).map(|i| u8::from(i % 3 == 0)).collect();
-            for referenced in [true, false] {
-                let got = super::pack_seen(&seen, referenced);
-                let expected = BitBuffer::collect_bool(len, |i| (seen[i] != 0) == referenced);
-                assert_eq!(got, expected, "len={len} referenced={referenced}");
-            }
-        }
-    }
 
     #[test]
     fn nullable_codes_validity() {

--- a/vortex-array/src/arrays/dict/array.rs
+++ b/vortex-array/src/arrays/dict/array.rs
@@ -6,6 +6,7 @@ use std::fmt::Formatter;
 
 use smallvec::smallvec;
 use vortex_buffer::BitBuffer;
+use vortex_buffer::BitBufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -156,8 +157,10 @@ pub trait DictArrayExt: TypedArrayRef<Dict> + DictArraySlotsExt {
         let codes_primitive = codes.to_primitive();
         let values_len = self.values().len();
 
-        // `seen[i]` records whether value `i` is referenced by at least one valid code.
-        let mut seen = vec![false; values_len];
+        // `seen[i]` is a non-zero byte iff value `i` is referenced by at least one valid code.
+        // A byte (rather than a packed bit) keeps the scatter a contended-free blind store and
+        // lets [`pack_seen`] fold eight values into a bitmap byte with a single multiply.
+        let mut seen = vec![0u8; values_len];
         let all_referenced = populate_seen(
             &mut seen,
             &codes_primitive,
@@ -170,11 +173,7 @@ pub trait DictArrayExt: TypedArrayRef<Dict> + DictArraySlotsExt {
             return Ok(BitBuffer::full(referenced, values_len));
         }
 
-        Ok(if referenced {
-            BitBuffer::from(seen)
-        } else {
-            BitBuffer::collect_bool(values_len, |i| !seen[i])
-        })
+        Ok(pack_seen(&seen, referenced))
     }
 }
 impl<T: TypedArrayRef<Dict>> DictArrayExt for T {}
@@ -189,7 +188,7 @@ impl<T: TypedArrayRef<Dict>> DictArrayExt for T {}
 /// mispredictions and read-modify-write contention that a data-dependent skip incurs on a small,
 /// densely-referenced dictionary.
 fn populate_seen(
-    seen: &mut [bool],
+    seen: &mut [u8],
     codes: &PrimitiveArray,
     validity: AllOr<&BitBuffer>,
     expect_all: bool,
@@ -221,7 +220,7 @@ fn populate_seen(
 /// Scatters references into `seen` and reports whether all values are referenced, choosing the
 /// early-exit or blind-store strategy based on `expect_all`. See [`populate_seen`].
 fn scatter_into(
-    seen: &mut [bool],
+    seen: &mut [u8],
     indices: impl IntoIterator<Item = usize>,
     expect_all: bool,
 ) -> bool {
@@ -229,9 +228,9 @@ fn scatter_into(
         mark_referenced(seen, indices)
     } else {
         for idx in indices {
-            seen[idx] = true;
+            seen[idx] = 1;
         }
-        seen.iter().all(|&b| b)
+        seen.iter().all(|&b| b != 0)
     }
 }
 
@@ -241,14 +240,14 @@ fn scatter_into(
 /// Returns `true` if every entry was marked (allowing the caller to stop early), otherwise `false`
 /// once `indices` is exhausted. The store is skipped for already-seen values, which when most codes
 /// repeat a fully-referenced dictionary lets the scan finish after only a fraction of the codes.
-fn mark_referenced(seen: &mut [bool], indices: impl IntoIterator<Item = usize>) -> bool {
+fn mark_referenced(seen: &mut [u8], indices: impl IntoIterator<Item = usize>) -> bool {
     let mut remaining = seen.len();
     if remaining == 0 {
         return true;
     }
     for idx in indices {
-        if !seen[idx] {
-            seen[idx] = true;
+        if seen[idx] == 0 {
+            seen[idx] = 1;
             remaining -= 1;
             if remaining == 0 {
                 return true;
@@ -256,6 +255,48 @@ fn mark_referenced(seen: &mut [bool], indices: impl IntoIterator<Item = usize>) 
         }
     }
     false
+}
+
+/// Packs `seen` (a non-zero byte per referenced value) into a bitmap. When `referenced` is set the
+/// result marks referenced values; otherwise it marks the unreferenced ones.
+///
+/// The hot loop folds eight `seen` bytes into one bitmap byte with a single multiply: masking to
+/// the low bit of each byte and multiplying by `0x0102_0408_1020_4080` gathers those eight low bits
+/// into the top byte, LSB-first. This is branchless, needs no target features (so it stays portable
+/// across architectures), and is an order of magnitude faster than a scalar bit-packing loop on the
+/// 1K-16K value dictionaries `min_max`/`is_constant` evaluate.
+fn pack_seen(seen: &[u8], referenced: bool) -> BitBuffer {
+    /// Isolates the low bit of each of the eight bytes in a `u64`.
+    const LOW_BITS: u64 = 0x0101_0101_0101_0101;
+    /// Gathers those eight low bits into the most-significant byte, LSB-first.
+    const GATHER: u64 = 0x0102_0408_1020_4080;
+
+    let len = seen.len();
+    let mut builder = BitBufferMut::new_unset(len);
+    let dst = builder.as_mut_slice();
+
+    let mut chunks = seen.chunks_exact(8);
+    for (byte, chunk) in dst.iter_mut().zip(chunks.by_ref()) {
+        let mut block = [0u8; 8];
+        block.copy_from_slice(chunk);
+        let bits = u64::from_le_bytes(block);
+        let packed = (((bits & LOW_BITS).wrapping_mul(GATHER)) >> 56) as u8;
+        *byte = if referenced { packed } else { !packed };
+    }
+
+    let tail = chunks.remainder();
+    if !tail.is_empty() {
+        let mut byte = 0u8;
+        for (k, &b) in tail.iter().enumerate() {
+            if (b != 0) == referenced {
+                byte |= 1 << k;
+            }
+        }
+        // The final partial byte sits after every full chunk written above.
+        dst[len / 8] = byte;
+    }
+
+    builder.freeze()
 }
 
 /// Concrete parts of a [`DictArray`](super::DictArray) after iterative execution.
@@ -389,6 +430,22 @@ mod test {
     use crate::dtype::PType;
     use crate::dtype::UnsignedPType;
     use crate::validity::Validity;
+
+    #[test]
+    fn pack_seen_matches_reference() {
+        // `pack_seen` must agree bit-for-bit with a per-bit reference for both polarities and for
+        // lengths that exercise full 8-byte chunks, partial tails, and word boundaries.
+        for len in [
+            0usize, 1, 7, 8, 9, 15, 16, 63, 64, 65, 127, 1000, 1023, 1024,
+        ] {
+            let seen: Vec<u8> = (0..len).map(|i| u8::from(i % 3 == 0)).collect();
+            for referenced in [true, false] {
+                let got = super::pack_seen(&seen, referenced);
+                let expected = BitBuffer::collect_bool(len, |i| (seen[i] != 0) == referenced);
+                assert_eq!(got, expected, "len={len} referenced={referenced}");
+            }
+        }
+    }
 
     #[test]
     fn nullable_codes_validity() {

--- a/vortex-array/src/arrays/dict/array.rs
+++ b/vortex-array/src/arrays/dict/array.rs
@@ -135,7 +135,10 @@ pub trait DictArrayExt: TypedArrayRef<Dict> + DictArraySlotsExt {
             }
 
             let referenced_mask = self.compute_referenced_values_mask(true)?;
-            let all_referenced = referenced_mask.iter().all(|v| v);
+            // "all values referenced" is equivalent to every bit being set, i.e. the popcount
+            // equals the length. `true_count` uses a vectorized popcount, which is much faster
+            // than iterating the buffer bit-by-bit.
+            let all_referenced = referenced_mask.true_count() == referenced_mask.len();
 
             vortex_ensure!(all_referenced, "value in dict not referenced");
         }

--- a/vortex-array/src/arrays/dict/array.rs
+++ b/vortex-array/src/arrays/dict/array.rs
@@ -152,14 +152,15 @@ pub trait DictArrayExt: TypedArrayRef<Dict> + DictArraySlotsExt {
             .validity()?
             .execute_mask(codes.len(), &mut LEGACY_SESSION.create_execution_ctx())?;
         #[expect(deprecated)]
-        let codes_primitive = self.codes().to_primitive();
+        let codes_primitive = codes.to_primitive();
         let values_len = self.values().len();
 
-        let init_value = !referenced;
-        let referenced_value = referenced;
-
-        let mut values_vec = vec![init_value; values_len];
-        match codes_validity.bit_buffer() {
+        // `seen[i]` records whether value `i` is referenced by at least one valid code.
+        // `mark_referenced` stops as soon as every value has been seen: dictionaries are
+        // frequently referenced by far more codes than they have values, so this commonly skips
+        // the bulk of the scatter — and the final pack, since the resulting mask is then constant.
+        let mut seen = vec![false; values_len];
+        let all_referenced = match codes_validity.bit_buffer() {
             AllOr::All => {
                 match_each_integer_ptype!(codes_primitive.ptype(), |P| {
                     #[allow(
@@ -167,32 +168,64 @@ pub trait DictArrayExt: TypedArrayRef<Dict> + DictArraySlotsExt {
                         clippy::cast_sign_loss,
                         reason = "codes are non-negative indices; a negative signed code would wrap to a large usize and panic on the bounds-checked array index"
                     )]
-                    for &idx in codes_primitive.as_slice::<P>() {
-                        values_vec[idx as usize] = referenced_value;
-                    }
-                });
+                    let indices = codes_primitive
+                        .as_slice::<P>()
+                        .iter()
+                        .map(|&idx| idx as usize);
+                    mark_referenced(&mut seen, indices)
+                })
             }
-            AllOr::None => {}
+            AllOr::None => values_len == 0,
             AllOr::Some(mask) => {
                 match_each_integer_ptype!(codes_primitive.ptype(), |P| {
                     let codes = codes_primitive.as_slice::<P>();
-
                     #[allow(
                         clippy::cast_possible_truncation,
                         clippy::cast_sign_loss,
                         reason = "codes are non-negative indices; a negative signed code would wrap to a large usize and panic on the bounds-checked array index"
                     )]
-                    mask.set_indices().for_each(|idx| {
-                        values_vec[codes[idx] as usize] = referenced_value;
-                    });
-                });
+                    let indices = mask.set_indices().map(|i| codes[i] as usize);
+                    mark_referenced(&mut seen, indices)
+                })
             }
+        };
+
+        // When every value is referenced the mask is constant, so we avoid rebuilding it.
+        if all_referenced {
+            return Ok(BitBuffer::full(referenced, values_len));
         }
 
-        Ok(BitBuffer::from(values_vec))
+        Ok(if referenced {
+            BitBuffer::from(seen)
+        } else {
+            BitBuffer::collect_bool(values_len, |i| !seen[i])
+        })
     }
 }
 impl<T: TypedArrayRef<Dict>> DictArrayExt for T {}
+
+/// Marks `seen[idx] = true` for every index yielded by `indices`.
+///
+/// Returns `true` as soon as every entry in `seen` has been marked (allowing the caller to stop
+/// early), otherwise `false` once `indices` is exhausted. The store is skipped for already-seen
+/// values, which in the common case of many codes per value avoids a read-modify-write storm on a
+/// handful of hot bytes.
+fn mark_referenced(seen: &mut [bool], indices: impl IntoIterator<Item = usize>) -> bool {
+    let mut remaining = seen.len();
+    if remaining == 0 {
+        return true;
+    }
+    for idx in indices {
+        if !seen[idx] {
+            seen[idx] = true;
+            remaining -= 1;
+            if remaining == 0 {
+                return true;
+            }
+        }
+    }
+    false
+}
 
 /// Concrete parts of a [`DictArray`](super::DictArray) after iterative execution.
 pub struct DictParts {


### PR DESCRIPTION
## Summary

Replace an inefficient `iter().all()` check with a direct `true_count()` comparison when validating that all values in a dictionary array are referenced.
