### PR TITLE
Add Compaction encoding for normalizing arrays to compact form

### DIFF
--- a/vortex-array/src/arrays/compaction/array.rs
+++ b/vortex-array/src/arrays/compaction/array.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use smallvec::smallvec;
+use vortex_error::VortexExpect;
+
+use crate::ArrayRef;
+use crate::array::Array;
+use crate::array::ArrayParts;
+use crate::array::TypedArrayRef;
+use crate::array::vtable::EmptyArrayData;
+use crate::arrays::Compaction;
+
+/// The single child array to be compacted.
+pub(super) const CHILD_SLOT: usize = 0;
+pub(super) const NUM_SLOTS: usize = 1;
+pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["child"];
+
+/// Extension trait for accessing the child of a [`CompactionArray`](super::CompactionArray).
+pub trait CompactionArrayExt: TypedArrayRef<Compaction> {
+    /// The child array that will be compacted when this array is executed.
+    fn child(&self) -> &ArrayRef {
+        self.as_ref().slots()[CHILD_SLOT]
+            .as_ref()
+            .vortex_expect("validated compaction child slot")
+    }
+}
+impl<T: TypedArrayRef<Compaction>> CompactionArrayExt for T {}
+
+impl Array<Compaction> {
+    /// Wrap `child` in a [`Compaction`] array.
+    ///
+    /// Executing the resulting array produces a fully-normalized version of `child` (see the
+    /// [module docs](super) for the exact normalization rules). The logical type and length are
+    /// preserved.
+    pub fn new(child: ArrayRef) -> Self {
+        let dtype = child.dtype().clone();
+        let len = child.len();
+        unsafe {
+            Array::from_parts_unchecked(
+                ArrayParts::new(Compaction, dtype, len, EmptyArrayData)
+                    .with_slots(smallvec![Some(child)]),
+            )
+        }
+    }
+}

--- a/vortex-array/src/arrays/compaction/compact.rs
+++ b/vortex-array/src/arrays/compaction/compact.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+
+use crate::ArrayRef;
+use crate::Canonical;
+use crate::ExecutionCtx;
+use crate::IntoArray;
+use crate::arrays::ListViewArray;
+use crate::arrays::StructArray;
+use crate::arrays::listview::ListViewArrayExt;
+use crate::arrays::listview::ListViewRebuildMode;
+use crate::arrays::struct_::StructArrayExt;
+
+/// Structurally compact a canonical array.
+///
+/// - `VarBinView` buffers are garbage collected via
+///   [`compact_buffers`](crate::arrays::VarBinViewArray::compact_buffers).
+/// - `List` (ListView) arrays are rebuilt to be zero-copy convertible to a `ListArray`
+///   (overlaps removed, leading/trailing garbage trimmed), and their elements are recursively
+///   compacted.
+/// - `Struct` fields are recursively compacted.
+/// - All other canonical arrays are returned unchanged.
+///
+/// Note that recursion bottoms out at scalar canonical arrays, so this terminates.
+pub(crate) fn compact_canonical(
+    canonical: Canonical,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    Ok(match canonical {
+        Canonical::VarBinView(array) => array.compact_buffers()?.into_array(),
+        Canonical::List(list_view) => compact_list_view(list_view, ctx)?,
+        Canonical::Struct(struct_array) => compact_struct(struct_array, ctx)?,
+        // TODO(joe): recurse into FixedSizeList elements and Extension storage.
+        other => other.into_array(),
+    })
+}
+
+fn compact_list_view(list_view: ListViewArray, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+    // Make the list zero-copy convertible to a `ListArray` and trim unreferenced elements.
+    let rebuilt = list_view.rebuild(ListViewRebuildMode::MakeExact)?;
+
+    // Recursively compact the (now trimmed) element data. Compaction preserves logical length,
+    // so the existing offsets and sizes remain valid.
+    let elements = rebuilt.elements().clone().compact(ctx)?;
+    if ArrayRef::ptr_eq(&elements, rebuilt.elements()) {
+        return Ok(rebuilt.into_array());
+    }
+
+    // SAFETY: we only replace the elements child with a logically equivalent, equal-length
+    // array, which preserves the zero-copy-to-list shape established by `MakeExact`.
+    Ok(unsafe {
+        ListViewArray::new_unchecked(
+            elements,
+            rebuilt.offsets().clone(),
+            rebuilt.sizes().clone(),
+            rebuilt.validity()?,
+        )
+        .with_zero_copy_to_list(rebuilt.is_zero_copy_to_list())
+    }
+    .into_array())
+}
+
+fn compact_struct(struct_array: StructArray, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+    let fields = struct_array.unmasked_fields();
+    let mut new_fields = Vec::with_capacity(fields.len());
+    let mut changed = false;
+    for field in fields.iter() {
+        let compacted = field.clone().compact(ctx)?;
+        changed |= !ArrayRef::ptr_eq(&compacted, field);
+        new_fields.push(compacted);
+    }
+
+    if !changed {
+        return Ok(struct_array.into_array());
+    }
+
+    // SAFETY: each field is replaced with a logically equivalent, equal-length array, and the
+    // struct's dtype and validity are preserved.
+    Ok(unsafe {
+        StructArray::new_unchecked(
+            new_fields,
+            struct_array.struct_fields().clone(),
+            struct_array.len(),
+            struct_array.struct_validity(),
+        )
+    }
+    .into_array())
+}

--- a/vortex-array/src/arrays/compaction/mod.rs
+++ b/vortex-array/src/arrays/compaction/mod.rs
@@ -45,7 +45,7 @@ use crate::matcher::Matcher;
 /// [`Compaction`] array, instead of being decoded to canonical and compacted structurally.
 ///
 /// Implementations may read buffers. Return `Ok(None)` to decline, in which case the child is
-/// decoded to canonical and [`compact_canonical`] is applied.
+/// decoded to canonical and compacted structurally.
 pub trait CompactKernel: VTable {
     /// Attempt to compact `array` directly. See the trait docs.
     fn compact(

--- a/vortex-array/src/arrays/compaction/mod.rs
+++ b/vortex-array/src/arrays/compaction/mod.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! The [`Compaction`] encoding: normalize an array into a compact canonical form.
+//!
+//! A [`CompactionArray`] wraps a single child. Executing it produces a logically equivalent array
+//! where every inner array has been normalized to its most compact representation:
+//!
+//! - **`ListView`** arrays are rebuilt to be zero-copy convertible to an Arrow-style `ListArray`
+//!   (overlapping views deduplicated, leading/trailing garbage trimmed).
+//! - **`VarBinView`** arrays have their data buffers garbage collected.
+//! - **`Dict`** arrays are either decoded to a flat canonical array, or garbage collected in place
+//!   (dead values removed, codes remapped) — whichever is estimated to be cheaper. This is driven
+//!   by [`Dict`]'s [`CompactKernel`] via the parent-execution machinery (i.e. it is an
+//!   `execute_parent` of `compaction(dict(..))`).
+//! - **`Struct`** fields are recursively compacted.
+//!
+//! Like [`Slice`](crate::arrays::Slice), this is a transient, non-serializable encoding that only
+//! exists to drive execution; it is not registered as a default encoding.
+
+mod array;
+mod compact;
+mod vtable;
+
+#[cfg(test)]
+mod tests;
+
+pub use array::CompactionArrayExt;
+use vortex_error::VortexResult;
+pub use vtable::Compaction;
+pub use vtable::CompactionArray;
+
+use crate::AnyCanonical;
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::IntoArray;
+use crate::array::ArrayView;
+use crate::array::VTable;
+use crate::arrays::Dict;
+use crate::arrays::dict::DictArrayExt;
+use crate::kernel::ExecuteParentKernel;
+use crate::matcher::Matcher;
+
+/// A kernel that lets a child encoding compact itself when it is the direct child of a
+/// [`Compaction`] array, instead of being decoded to canonical and compacted structurally.
+///
+/// Implementations may read buffers. Return `Ok(None)` to decline, in which case the child is
+/// decoded to canonical and [`compact_canonical`] is applied.
+pub trait CompactKernel: VTable {
+    /// Attempt to compact `array` directly. See the trait docs.
+    fn compact(
+        array: ArrayView<'_, Self>,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>>;
+}
+
+/// Adaptor that lifts a [`CompactKernel`] into an [`ExecuteParentKernel`] for the [`Compaction`]
+/// parent.
+#[derive(Default, Debug)]
+pub struct CompactExecuteAdaptor<V>(pub V);
+
+impl<V> ExecuteParentKernel<V> for CompactExecuteAdaptor<V>
+where
+    V: CompactKernel,
+{
+    type Parent = Compaction;
+
+    fn execute_parent(
+        &self,
+        array: ArrayView<'_, V>,
+        _parent: <Self::Parent as Matcher>::Match<'_>,
+        child_idx: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        debug_assert_eq!(child_idx, 0, "Compaction array has a single child");
+        <V as CompactKernel>::compact(array, ctx)
+    }
+}
+
+/// Matches arrays that are considered fully compacted: any canonical array, or a [`Dict`] whose
+/// values are all referenced (i.e. already garbage collected).
+///
+/// This is the [`Matcher`] that [`ArrayRef::compact`] executes towards, so that a garbage-collected
+/// dictionary is not further decoded to canonical.
+pub struct Compacted;
+
+impl Matcher for Compacted {
+    type Match<'a> = &'a ArrayRef;
+
+    fn matches(array: &ArrayRef) -> bool {
+        if AnyCanonical::matches(array) {
+            return true;
+        }
+        array
+            .as_opt::<Dict>()
+            .is_some_and(|dict| dict.has_all_values_referenced())
+    }
+
+    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
+        Self::matches(array).then_some(array)
+    }
+}
+
+impl ArrayRef {
+    /// Normalize this array into a compact form.
+    ///
+    /// See the [module docs](self) for the exact normalization rules.
+    pub fn compact(self, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+        CompactionArray::new(self)
+            .into_array()
+            .execute_until::<Compacted>(ctx)
+    }
+}

--- a/vortex-array/src/arrays/compaction/tests.rs
+++ b/vortex-array/src/arrays/compaction/tests.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+
+use crate::IntoArray;
+use crate::LEGACY_SESSION;
+use crate::VortexSessionExecute;
+use crate::arrays::Dict;
+use crate::arrays::DictArray;
+use crate::arrays::ListView;
+use crate::arrays::ListViewArray;
+use crate::arrays::PrimitiveArray;
+use crate::arrays::Struct;
+use crate::arrays::StructArray;
+use crate::arrays::dict::DictArrayExt;
+use crate::arrays::dict::DictArraySlotsExt;
+use crate::arrays::struct_::StructArrayExt;
+use crate::assert_arrays_eq;
+use crate::dtype::FieldNames;
+use crate::validity::Validity;
+
+#[test]
+fn compact_dict_garbage_collects_dead_values() -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+
+    // Codes only reference values 0 and 2, so values 1 and 3 are dead. There is reuse (4 codes,
+    // 2 live values), so the dictionary should be garbage collected rather than flattened.
+    let codes = PrimitiveArray::from_iter(vec![0u32, 2, 0, 2]).into_array();
+    let values = PrimitiveArray::from_iter(vec![10i32, 20, 30, 40]).into_array();
+    let dict = DictArray::try_new(codes, values)?.into_array();
+
+    let compacted = dict.compact(&mut ctx)?;
+
+    let result_dict = compacted
+        .as_opt::<Dict>()
+        .expect("compacted dictionary should remain a dictionary");
+    assert_eq!(
+        result_dict.values().len(),
+        2,
+        "dead values should be dropped"
+    );
+    assert!(result_dict.has_all_values_referenced());
+
+    assert_arrays_eq!(
+        compacted,
+        PrimitiveArray::from_iter(vec![10i32, 30, 10, 30])
+    );
+    Ok(())
+}
+
+#[test]
+fn compact_dict_flattens_without_compression() -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+
+    // Every code maps to a distinct value, so the dictionary provides no compression and should be
+    // decoded to a flat canonical array.
+    let codes = PrimitiveArray::from_iter(vec![0u32, 1, 2]).into_array();
+    let values = PrimitiveArray::from_iter(vec![10i32, 20, 30]).into_array();
+    let dict = DictArray::try_new(codes, values)?.into_array();
+
+    let compacted = dict.compact(&mut ctx)?;
+
+    assert!(
+        compacted.as_opt::<Dict>().is_none(),
+        "a non-compressing dictionary should be flattened"
+    );
+    assert!(compacted.is_canonical());
+    assert_arrays_eq!(compacted, PrimitiveArray::from_iter(vec![10i32, 20, 30]));
+    Ok(())
+}
+
+#[test]
+fn compact_list_view_becomes_zero_copy_to_list() -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+
+    // Elements 0, 2 and 4 are unreferenced gaps, so this list view is not zero-copy to a list.
+    let elements = PrimitiveArray::from_iter(vec![10i32, 20, 30, 40, 50]).into_array();
+    let offsets = PrimitiveArray::from_iter(vec![1i32, 3]).into_array();
+    let sizes = PrimitiveArray::from_iter(vec![1i32, 1]).into_array();
+    let list_view =
+        ListViewArray::try_new(elements, offsets, sizes, Validity::NonNullable)?.into_array();
+    assert!(
+        !list_view
+            .clone()
+            .downcast::<ListView>()
+            .is_zero_copy_to_list()
+    );
+
+    let compacted = list_view.clone().compact(&mut ctx)?;
+
+    let result = compacted.clone().downcast::<ListView>();
+    assert!(
+        result.is_zero_copy_to_list(),
+        "compacted list view should be zero-copy to list"
+    );
+    assert_arrays_eq!(compacted, list_view);
+    Ok(())
+}
+
+#[test]
+fn compact_struct_recurses_into_fields() -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+
+    let codes = PrimitiveArray::from_iter(vec![0u32, 2, 0, 2]).into_array();
+    let values = PrimitiveArray::from_iter(vec![10i32, 20, 30, 40]).into_array();
+    let dict = DictArray::try_new(codes, values)?.into_array();
+
+    let struct_array = StructArray::try_new(
+        FieldNames::from(["dict_field"]),
+        vec![dict],
+        4,
+        Validity::NonNullable,
+    )?
+    .into_array();
+
+    let compacted = struct_array.clone().compact(&mut ctx)?;
+
+    // The field's dead dictionary values should have been garbage collected in place.
+    let field = compacted.as_::<Struct>().unmasked_field(0).clone();
+    let field_dict = field
+        .as_opt::<Dict>()
+        .expect("compacted struct field should remain a dictionary");
+    assert_eq!(field_dict.values().len(), 2);
+    assert!(field_dict.has_all_values_referenced());
+
+    assert_arrays_eq!(compacted, struct_array);
+    Ok(())
+}

--- a/vortex-array/src/arrays/compaction/vtable.rs
+++ b/vortex-array/src/arrays/compaction/vtable.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_ensure;
+use vortex_error::vortex_panic;
+use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
+
+use crate::AnyCanonical;
+use crate::ArrayRef;
+use crate::array::Array;
+use crate::array::ArrayId;
+use crate::array::ArrayView;
+use crate::array::OperationsVTable;
+use crate::array::VTable;
+use crate::array::ValidityVTable;
+use crate::array::vtable::EmptyArrayData;
+use crate::arrays::compaction::CompactionArrayExt;
+use crate::arrays::compaction::array::CHILD_SLOT;
+use crate::arrays::compaction::array::SLOT_NAMES;
+use crate::arrays::compaction::compact::compact_canonical;
+use crate::buffer::BufferHandle;
+use crate::dtype::DType;
+use crate::executor::ExecutionCtx;
+use crate::executor::ExecutionResult;
+use crate::require_child;
+use crate::scalar::Scalar;
+use crate::serde::ArrayChildren;
+use crate::validity::Validity;
+
+/// A [`Compaction`]-encoded Vortex array.
+///
+/// See the [module docs](super) for semantics.
+pub type CompactionArray = Array<Compaction>;
+
+/// An encoding that normalizes its child into a compact canonical form when executed.
+#[derive(Clone, Debug)]
+pub struct Compaction;
+
+impl VTable for Compaction {
+    type TypedArrayData = EmptyArrayData;
+    type OperationsVTable = Self;
+    type ValidityVTable = Self;
+
+    fn id(&self) -> ArrayId {
+        static ID: CachedId = CachedId::new("vortex.compaction");
+        *ID
+    }
+
+    fn validate(
+        &self,
+        _data: &Self::TypedArrayData,
+        dtype: &DType,
+        len: usize,
+        slots: &[Option<ArrayRef>],
+    ) -> VortexResult<()> {
+        vortex_ensure!(
+            slots[CHILD_SLOT].is_some(),
+            "CompactionArray child slot must be present"
+        );
+        let child = slots[CHILD_SLOT]
+            .as_ref()
+            .vortex_expect("validated child slot");
+        vortex_ensure!(
+            child.dtype() == dtype,
+            "CompactionArray dtype {} does not match child dtype {}",
+            dtype,
+            child.dtype()
+        );
+        vortex_ensure!(
+            child.len() == len,
+            "CompactionArray length {} does not match child length {}",
+            len,
+            child.len()
+        );
+        Ok(())
+    }
+
+    fn nbuffers(_array: ArrayView<'_, Self>) -> usize {
+        0
+    }
+
+    fn buffer(_array: ArrayView<'_, Self>, _idx: usize) -> BufferHandle {
+        vortex_panic!("CompactionArray has no buffers")
+    }
+
+    fn buffer_name(_array: ArrayView<'_, Self>, _idx: usize) -> Option<String> {
+        None
+    }
+
+    fn slot_name(_array: ArrayView<'_, Self>, idx: usize) -> String {
+        SLOT_NAMES[idx].to_string()
+    }
+
+    fn serialize(
+        _array: ArrayView<'_, Self>,
+        _session: &VortexSession,
+    ) -> VortexResult<Option<Vec<u8>>> {
+        vortex_bail!("Compaction array is not serializable")
+    }
+
+    fn deserialize(
+        &self,
+        _dtype: &DType,
+        _len: usize,
+        _metadata: &[u8],
+        _buffers: &[BufferHandle],
+        _children: &dyn ArrayChildren,
+        _session: &VortexSession,
+    ) -> VortexResult<crate::array::ArrayParts<Self>> {
+        vortex_bail!("Compaction array is not serializable")
+    }
+
+    fn execute(array: Array<Self>, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionResult> {
+        // Child encodings that can compact themselves more cheaply than a full decode (e.g.
+        // `Dict` via garbage collection) intercept this before we get here, via their
+        // `execute_parent` kernels. Everything else is decoded to canonical and compacted
+        // structurally.
+        let array = require_child!(array, array.child(), CHILD_SLOT => AnyCanonical);
+        let canonical = array.child().as_::<AnyCanonical>().into();
+        compact_canonical(canonical, ctx).map(ExecutionResult::done)
+    }
+}
+
+impl OperationsVTable<Compaction> for Compaction {
+    fn scalar_at(
+        array: ArrayView<'_, Compaction>,
+        index: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
+        array.child().execute_scalar(index, ctx)
+    }
+}
+
+impl ValidityVTable<Compaction> for Compaction {
+    fn validity(array: ArrayView<'_, Compaction>) -> VortexResult<Validity> {
+        array.child().validity()
+    }
+}

--- a/vortex-array/src/arrays/dict/compaction.rs
+++ b/vortex-array/src/arrays/dict/compaction.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Compaction support for [`Dict`] arrays.
+//!
+//! When a dictionary is the child of a [`Compaction`](crate::arrays::Compaction) array, we can
+//! often avoid a full decode. A dictionary that has accumulated unreferenced ("dead") values
+//! after slicing/taking can either be:
+//!
+//! - left alone, if every value is still referenced and the dictionary still compresses;
+//! - garbage collected in place, dropping dead values and remapping codes, keeping the data
+//!   dictionary-encoded; or
+//! - decoded to a flat canonical array, when the dictionary no longer earns its indirection.
+//!
+//! We pick the cheapest option with a simple heuristic and let the fallback path handle the flat
+//! decode.
+
+use num_traits::FromPrimitive;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_mask::Mask;
+
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::IntoArray;
+use crate::array::ArrayView;
+use crate::arrays::Dict;
+use crate::arrays::DictArray;
+use crate::arrays::PrimitiveArray;
+use crate::arrays::compaction::CompactKernel;
+use crate::arrays::dict::DictArrayExt;
+use crate::arrays::dict::DictArraySlotsExt;
+use crate::match_each_integer_ptype;
+
+impl CompactKernel for Dict {
+    fn compact(
+        array: ArrayView<'_, Dict>,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        let values = array.values();
+        let codes = array.codes();
+        let num_values = values.len();
+        let num_codes = codes.len();
+
+        // Which values are referenced by at least one (valid) code.
+        let referenced = array.compute_referenced_values_mask(true)?;
+        let num_referenced = referenced.iter().filter(|r| *r).count();
+
+        // If every code maps to a distinct value the dictionary provides no compression, so a flat
+        // decode is at least as good. Decline and let the fallback decode to canonical.
+        if num_referenced >= num_codes {
+            return Ok(None);
+        }
+
+        // The dictionary still compresses. If there are no dead values it is already compact, so
+        // keep it as-is (and record that all values are referenced for downstream kernels).
+        if num_referenced == num_values {
+            // SAFETY: we just verified that every value is referenced.
+            let dict = unsafe {
+                array
+                    .array()
+                    .clone()
+                    .downcast::<Dict>()
+                    .set_all_values_referenced(true)
+            };
+            return Ok(Some(dict.into_array()));
+        }
+
+        // Otherwise garbage collect: drop dead values and remap the codes.
+        let codes_ptype = codes.dtype().as_ptype();
+        let remap = match_each_integer_ptype!(codes_ptype, |P| {
+            let mut new_index: usize = 0;
+            let mut remap = Vec::<P>::with_capacity(num_values);
+            for is_referenced in referenced.iter() {
+                // Unreferenced slots are never indexed by a code, so their value is irrelevant.
+                remap.push(
+                    <P as FromPrimitive>::from_usize(new_index)
+                        .vortex_expect("compacted dictionary index does not fit in code type"),
+                );
+                if is_referenced {
+                    new_index += 1;
+                }
+            }
+            PrimitiveArray::from_iter(remap).into_array()
+        });
+
+        // `take` preserves the nullability of `codes`, so null codes stay null.
+        let new_codes = remap.take(codes.clone())?;
+        let new_values = values.filter(Mask::from(referenced))?;
+
+        // SAFETY: `new_codes` index into `new_values` by construction, and we have dropped exactly
+        // the unreferenced values, so all remaining values are referenced.
+        let dict = unsafe {
+            DictArray::new_unchecked(new_codes, new_values).set_all_values_referenced(true)
+        };
+        Ok(Some(dict.into_array()))
+    }
+}

--- a/vortex-array/src/arrays/dict/mod.rs
+++ b/vortex-array/src/arrays/dict/mod.rs
@@ -14,6 +14,8 @@ pub use arbitrary::ArbitraryDictArray;
 mod array;
 pub use array::*;
 
+mod compaction;
+
 pub(crate) mod compute;
 mod execute;
 

--- a/vortex-array/src/arrays/dict/vtable/kernel.rs
+++ b/vortex-array/src/arrays/dict/vtable/kernel.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use crate::arrays::Dict;
+use crate::arrays::compaction::CompactExecuteAdaptor;
 use crate::arrays::dict::TakeExecuteAdaptor;
 use crate::kernel::ParentKernelSet;
 use crate::scalar_fn::fns::binary::CompareExecuteAdaptor;
@@ -11,4 +12,5 @@ pub(super) const PARENT_KERNELS: ParentKernelSet<Dict> = ParentKernelSet::new(&[
     ParentKernelSet::lift(&CompareExecuteAdaptor(Dict)),
     ParentKernelSet::lift(&TakeExecuteAdaptor(Dict)),
     ParentKernelSet::lift(&FillNullExecuteAdaptor(Dict)),
+    ParentKernelSet::lift(&CompactExecuteAdaptor(Dict)),
 ]);

--- a/vortex-array/src/arrays/mod.rs
+++ b/vortex-array/src/arrays/mod.rs
@@ -23,6 +23,10 @@ pub mod chunked;
 pub use chunked::Chunked;
 pub use chunked::ChunkedArray;
 
+pub mod compaction;
+pub use compaction::Compaction;
+pub use compaction::CompactionArray;
+
 pub mod constant;
 pub use constant::Constant;
 pub use constant::ConstantArray;


### PR DESCRIPTION
This is more of an idea for now

## Summary

This PR introduces the `Compaction` encoding, a transient array wrapper that normalizes its child into a compact canonical form when executed. This is similar to the existing `Slice` encoding in that it's non-serializable and exists primarily to drive execution.

The `Compaction` encoding handles structural normalization of various array types:

- **`ListView`** arrays are rebuilt to be zero-copy convertible to Arrow-style `ListArray` (overlapping views deduplicated, leading/trailing garbage trimmed)
- **`VarBinView`** arrays have their data buffers garbage collected
- **`Dict`** arrays are either decoded to flat canonical form or garbage collected in place (dead values removed, codes remapped) based on a cost heuristic
- **`Struct`** fields are recursively compacted

