### PR TITLE
Deprecate vortex-array public APIs that use the hidden LEGACY_SESSION

### DIFF
--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -200,11 +200,12 @@ fn compare_dtp(
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod test {
     use rstest::rstest;
+    use vortex_array::ArrayRef;
     use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute;
+    use vortex_array::aggregate_fn::fns::sum::sum;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::TemporalArray;
     use vortex_array::dtype::IntegerPType;
@@ -231,6 +232,16 @@ mod test {
         .expect("Failed to construct DateTimePartsArray from TemporalArray")
     }
 
+    /// Count the true values in a boolean array using an explicit execution context.
+    fn true_count(array: &ArrayRef) -> usize {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        sum(array, &mut ctx)
+            .unwrap()
+            .as_primitive()
+            .as_::<usize>()
+            .unwrap()
+    }
+
     #[rstest]
     #[case(Validity::NonNullable, Validity::NonNullable)]
     #[case(Validity::NonNullable, Validity::AllValid)]
@@ -244,14 +255,14 @@ mod test {
             .into_array()
             .binary(rhs.into_array(), Operator::Eq)
             .unwrap();
-        assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
+        assert_eq!(true_count(&comparison), 1);
 
         let rhs = dtp_array_from_timestamp(0i64, rhs_validity); // January 1, 1970, 00:00:00 UTC
         let comparison = lhs
             .into_array()
             .binary(rhs.into_array(), Operator::Eq)
             .unwrap();
-        assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 0);
+        assert_eq!(true_count(&comparison), 0);
     }
 
     #[rstest]
@@ -267,14 +278,14 @@ mod test {
             .into_array()
             .binary(rhs.into_array(), Operator::NotEq)
             .unwrap();
-        assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
+        assert_eq!(true_count(&comparison), 1);
 
         let rhs = dtp_array_from_timestamp(86400i64, rhs_validity); // January 2, 1970, 00:00:00 UTC
         let comparison = lhs
             .into_array()
             .binary(rhs.into_array(), Operator::NotEq)
             .unwrap();
-        assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 0);
+        assert_eq!(true_count(&comparison), 0);
     }
 
     #[rstest]
@@ -290,7 +301,7 @@ mod test {
             .into_array()
             .binary(rhs.into_array(), Operator::Lt)
             .unwrap();
-        assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
+        assert_eq!(true_count(&comparison), 1);
     }
 
     #[rstest]
@@ -306,7 +317,7 @@ mod test {
             .into_array()
             .binary(rhs.into_array(), Operator::Gt)
             .unwrap();
-        assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
+        assert_eq!(true_count(&comparison), 1);
     }
 
     #[rstest]
@@ -340,27 +351,27 @@ mod test {
             .into_array()
             .binary(rhs.clone().into_array(), Operator::Eq)
             .unwrap();
-        assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 0);
+        assert_eq!(true_count(&comparison), 0);
 
         let comparison = lhs
             .clone()
             .into_array()
             .binary(rhs.clone().into_array(), Operator::NotEq)
             .unwrap();
-        assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
+        assert_eq!(true_count(&comparison), 1);
 
         let comparison = lhs
             .clone()
             .into_array()
             .binary(rhs.clone().into_array(), Operator::Lt)
             .unwrap();
-        assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
+        assert_eq!(true_count(&comparison), 1);
 
         let comparison = lhs
             .into_array()
             .binary(rhs.into_array(), Operator::Lte)
             .unwrap();
-        assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
+        assert_eq!(true_count(&comparison), 1);
 
         // `CompareOperator::Gt` and `CompareOperator::Gte` only cover the case of all lhs values
         // being larger. Therefore, these cases are not covered by unit tests.

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -203,6 +203,7 @@ fn compare_dtp(
 mod test {
     use rstest::rstest;
     use vortex_array::ArrayRef;
+    use vortex_array::ExecutionCtx;
     use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute;
     use vortex_array::aggregate_fn::fns::sum::sum;
@@ -232,10 +233,9 @@ mod test {
         .expect("Failed to construct DateTimePartsArray from TemporalArray")
     }
 
-    /// Count the true values in a boolean array using an explicit execution context.
-    fn true_count(array: &ArrayRef) -> usize {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        sum(array, &mut ctx)
+    /// Count the true values in a boolean array using the provided execution context.
+    fn true_count(array: &ArrayRef, ctx: &mut ExecutionCtx) -> usize {
+        sum(array, ctx)
             .unwrap()
             .as_primitive()
             .as_::<usize>()
@@ -248,6 +248,7 @@ mod test {
     #[case(Validity::AllValid, Validity::NonNullable)]
     #[case(Validity::AllValid, Validity::AllValid)]
     fn compare_date_time_parts_eq(#[case] lhs_validity: Validity, #[case] rhs_validity: Validity) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let lhs = dtp_array_from_timestamp(86400i64, lhs_validity); // January 2, 1970, 00:00:00 UTC
         let rhs = dtp_array_from_timestamp(86400i64, rhs_validity.clone()); // January 2, 1970, 00:00:00 UTC
         let comparison = lhs
@@ -255,14 +256,14 @@ mod test {
             .into_array()
             .binary(rhs.into_array(), Operator::Eq)
             .unwrap();
-        assert_eq!(true_count(&comparison), 1);
+        assert_eq!(true_count(&comparison, &mut ctx), 1);
 
         let rhs = dtp_array_from_timestamp(0i64, rhs_validity); // January 1, 1970, 00:00:00 UTC
         let comparison = lhs
             .into_array()
             .binary(rhs.into_array(), Operator::Eq)
             .unwrap();
-        assert_eq!(true_count(&comparison), 0);
+        assert_eq!(true_count(&comparison, &mut ctx), 0);
     }
 
     #[rstest]
@@ -271,6 +272,7 @@ mod test {
     #[case(Validity::AllValid, Validity::NonNullable)]
     #[case(Validity::AllValid, Validity::AllValid)]
     fn compare_date_time_parts_ne(#[case] lhs_validity: Validity, #[case] rhs_validity: Validity) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let lhs = dtp_array_from_timestamp(86400i64, lhs_validity); // January 2, 1970, 00:00:00 UTC
         let rhs = dtp_array_from_timestamp(86401i64, rhs_validity.clone()); // January 2, 1970, 00:00:01 UTC
         let comparison = lhs
@@ -278,14 +280,14 @@ mod test {
             .into_array()
             .binary(rhs.into_array(), Operator::NotEq)
             .unwrap();
-        assert_eq!(true_count(&comparison), 1);
+        assert_eq!(true_count(&comparison, &mut ctx), 1);
 
         let rhs = dtp_array_from_timestamp(86400i64, rhs_validity); // January 2, 1970, 00:00:00 UTC
         let comparison = lhs
             .into_array()
             .binary(rhs.into_array(), Operator::NotEq)
             .unwrap();
-        assert_eq!(true_count(&comparison), 0);
+        assert_eq!(true_count(&comparison, &mut ctx), 0);
     }
 
     #[rstest]
@@ -294,6 +296,7 @@ mod test {
     #[case(Validity::AllValid, Validity::NonNullable)]
     #[case(Validity::AllValid, Validity::AllValid)]
     fn compare_date_time_parts_lt(#[case] lhs_validity: Validity, #[case] rhs_validity: Validity) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let lhs = dtp_array_from_timestamp(0i64, lhs_validity); // January 1, 1970, 01:00:00 UTC
         let rhs = dtp_array_from_timestamp(86400i64, rhs_validity); // January 2, 1970, 00:00:00 UTC
 
@@ -301,7 +304,7 @@ mod test {
             .into_array()
             .binary(rhs.into_array(), Operator::Lt)
             .unwrap();
-        assert_eq!(true_count(&comparison), 1);
+        assert_eq!(true_count(&comparison, &mut ctx), 1);
     }
 
     #[rstest]
@@ -310,6 +313,7 @@ mod test {
     #[case(Validity::AllValid, Validity::NonNullable)]
     #[case(Validity::AllValid, Validity::AllValid)]
     fn compare_date_time_parts_gt(#[case] lhs_validity: Validity, #[case] rhs_validity: Validity) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let lhs = dtp_array_from_timestamp(86400i64, lhs_validity); // January 2, 1970, 02:00:00 UTC
         let rhs = dtp_array_from_timestamp(0i64, rhs_validity); // January 1, 1970, 01:00:00 UTC
 
@@ -317,7 +321,7 @@ mod test {
             .into_array()
             .binary(rhs.into_array(), Operator::Gt)
             .unwrap();
-        assert_eq!(true_count(&comparison), 1);
+        assert_eq!(true_count(&comparison, &mut ctx), 1);
     }
 
     #[rstest]
@@ -329,6 +333,7 @@ mod test {
         #[case] lhs_validity: Validity,
         #[case] rhs_validity: Validity,
     ) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let temporal_array = TemporalArray::new_timestamp(
             PrimitiveArray::new(buffer![0i64], lhs_validity.clone()).into_array(),
             TimeUnit::Seconds,
@@ -351,27 +356,27 @@ mod test {
             .into_array()
             .binary(rhs.clone().into_array(), Operator::Eq)
             .unwrap();
-        assert_eq!(true_count(&comparison), 0);
+        assert_eq!(true_count(&comparison, &mut ctx), 0);
 
         let comparison = lhs
             .clone()
             .into_array()
             .binary(rhs.clone().into_array(), Operator::NotEq)
             .unwrap();
-        assert_eq!(true_count(&comparison), 1);
+        assert_eq!(true_count(&comparison, &mut ctx), 1);
 
         let comparison = lhs
             .clone()
             .into_array()
             .binary(rhs.clone().into_array(), Operator::Lt)
             .unwrap();
-        assert_eq!(true_count(&comparison), 1);
+        assert_eq!(true_count(&comparison, &mut ctx), 1);
 
         let comparison = lhs
             .into_array()
             .binary(rhs.into_array(), Operator::Lte)
             .unwrap();
-        assert_eq!(true_count(&comparison), 1);
+        assert_eq!(true_count(&comparison, &mut ctx), 1);
 
         // `CompareOperator::Gt` and `CompareOperator::Gte` only cover the case of all lhs values
         // being larger. Therefore, these cases are not covered by unit tests.

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -200,6 +200,7 @@ fn compare_dtp(
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod test {
     use rstest::rstest;
     use vortex_array::LEGACY_SESSION;

--- a/encodings/datetime-parts/src/compute/rules.rs
+++ b/encodings/datetime-parts/src/compute/rules.rs
@@ -178,6 +178,7 @@ fn is_constant_zero(array: &ArrayRef) -> bool {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute;

--- a/encodings/datetime-parts/src/compute/rules.rs
+++ b/encodings/datetime-parts/src/compute/rules.rs
@@ -178,10 +178,11 @@ fn is_constant_zero(array: &ArrayRef) -> bool {
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
 mod tests {
+    use vortex_array::ArrayRef;
     use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute;
+    use vortex_array::aggregate_fn::fns::sum::sum;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::TemporalArray;
     use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
@@ -200,6 +201,16 @@ mod tests {
     use crate::DateTimePartsArray;
 
     const SECONDS_PER_DAY: i64 = 86400;
+
+    /// Count the true values in a boolean array using an explicit execution context.
+    fn true_count(array: &ArrayRef) -> usize {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        sum(array, &mut ctx)
+            .unwrap()
+            .as_primitive()
+            .as_::<usize>()
+            .unwrap()
+    }
 
     /// Create a DTP array with the given day values (all at midnight).
     fn dtp_at_midnight(days: &[i64], time_unit: TimeUnit) -> DateTimePartsArray {
@@ -286,7 +297,7 @@ mod tests {
         );
 
         // Verify correctness: days [0, 1, 2] <= 1 should give [true, true, false]
-        assert_eq!(optimized.as_bool_typed().true_count().unwrap(), 2);
+        assert_eq!(true_count(&optimized), 2);
     }
 
     #[test]
@@ -314,7 +325,7 @@ mod tests {
         let optimized = between.optimize().unwrap();
 
         // Verify correctness: days [0, 1, 2, 3, 4] between 1 and 3 should give [false, true, true, true, false]
-        assert_eq!(optimized.as_bool_typed().true_count().unwrap(), 3);
+        assert_eq!(true_count(&optimized), 3);
     }
 
     #[test]
@@ -336,7 +347,7 @@ mod tests {
         // (optimization doesn't apply, so we keep the original structure)
         // Just verify it still computes correctly
         // days [0, 1, 2] at midnight <= day 1 at noon: [true, true, false]
-        assert_eq!(optimized.as_bool_typed().true_count().unwrap(), 2);
+        assert_eq!(true_count(&optimized), 2);
     }
 
     #[test]
@@ -367,6 +378,6 @@ mod tests {
         // Should still compute correctly (just not optimized via pushdown)
         let optimized = comparison.optimize().unwrap();
         // timestamps at 1am on days [0, 1, 2] <= day 1 midnight: [true, false, false]
-        assert_eq!(optimized.as_bool_typed().true_count().unwrap(), 1);
+        assert_eq!(true_count(&optimized), 1);
     }
 }

--- a/encodings/datetime-parts/src/compute/rules.rs
+++ b/encodings/datetime-parts/src/compute/rules.rs
@@ -180,6 +180,7 @@ fn is_constant_zero(array: &ArrayRef) -> bool {
 #[cfg(test)]
 mod tests {
     use vortex_array::ArrayRef;
+    use vortex_array::ExecutionCtx;
     use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute;
     use vortex_array::aggregate_fn::fns::sum::sum;
@@ -202,10 +203,9 @@ mod tests {
 
     const SECONDS_PER_DAY: i64 = 86400;
 
-    /// Count the true values in a boolean array using an explicit execution context.
-    fn true_count(array: &ArrayRef) -> usize {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        sum(array, &mut ctx)
+    /// Count the true values in a boolean array using the provided execution context.
+    fn true_count(array: &ArrayRef, ctx: &mut ExecutionCtx) -> usize {
+        sum(array, ctx)
             .unwrap()
             .as_primitive()
             .as_::<usize>()
@@ -297,7 +297,8 @@ mod tests {
         );
 
         // Verify correctness: days [0, 1, 2] <= 1 should give [true, true, false]
-        assert_eq!(true_count(&optimized), 2);
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        assert_eq!(true_count(&optimized, &mut ctx), 2);
     }
 
     #[test]
@@ -325,7 +326,8 @@ mod tests {
         let optimized = between.optimize().unwrap();
 
         // Verify correctness: days [0, 1, 2, 3, 4] between 1 and 3 should give [false, true, true, true, false]
-        assert_eq!(true_count(&optimized), 3);
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        assert_eq!(true_count(&optimized, &mut ctx), 3);
     }
 
     #[test]
@@ -347,7 +349,8 @@ mod tests {
         // (optimization doesn't apply, so we keep the original structure)
         // Just verify it still computes correctly
         // days [0, 1, 2] at midnight <= day 1 at noon: [true, true, false]
-        assert_eq!(true_count(&optimized), 2);
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        assert_eq!(true_count(&optimized, &mut ctx), 2);
     }
 
     #[test]
@@ -364,9 +367,8 @@ mod tests {
             TimeUnit::Seconds,
             None,
         );
-        let dtp =
-            DateTimeParts::try_from_temporal(temporal, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let dtp = DateTimeParts::try_from_temporal(temporal, &mut ctx).unwrap();
         let len = dtp.len();
 
         // Compare against midnight constant
@@ -378,6 +380,6 @@ mod tests {
         // Should still compute correctly (just not optimized via pushdown)
         let optimized = comparison.optimize().unwrap();
         // timestamps at 1am on days [0, 1, 2] <= day 1 midnight: [true, false, false]
-        assert_eq!(true_count(&optimized), 1);
+        assert_eq!(true_count(&optimized, &mut ctx), 1);
     }
 }

--- a/encodings/experimental/onpair/tests/big_data.rs
+++ b/encodings/experimental/onpair/tests/big_data.rs
@@ -9,7 +9,8 @@
     clippy::cast_possible_truncation,
     clippy::redundant_clone,
     clippy::tests_outside_test_module,
-    clippy::use_debug
+    clippy::use_debug,
+    deprecated
 )]
 
 use std::sync::LazyLock;

--- a/encodings/experimental/onpair/tests/big_data.rs
+++ b/encodings/experimental/onpair/tests/big_data.rs
@@ -9,8 +9,7 @@
     clippy::cast_possible_truncation,
     clippy::redundant_clone,
     clippy::tests_outside_test_module,
-    clippy::use_debug,
-    deprecated
+    clippy::use_debug
 )]
 
 use std::sync::LazyLock;
@@ -19,6 +18,7 @@ use std::time::Instant;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::accessor::ArrayAccessor;
+use vortex_array::aggregate_fn::fns::sum::sum;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::VarBinArray;
 use vortex_array::arrays::VarBinViewArray;
@@ -122,6 +122,11 @@ fn smoke_100k_rows() {
         .execute::<vortex_array::Canonical>(&mut ctx)
         .unwrap()
         .into_array();
-    assert_eq!(eq.as_bool_typed().true_count().unwrap(), want_eq);
+    let eq_count = sum(&eq, &mut ctx)
+        .unwrap()
+        .as_primitive()
+        .as_::<usize>()
+        .unwrap();
+    assert_eq!(eq_count, want_eq);
     eprintln!("eq pushdown matches reference count ({})", want_eq);
 }

--- a/vortex-array/src/arrays/varbin/compute/compare.rs
+++ b/vortex-array/src/arrays/varbin/compute/compare.rs
@@ -23,6 +23,7 @@ use crate::arrays::VarBin;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::varbin::VarBinArrayExt;
 use crate::arrow::Datum;
+#[allow(deprecated)]
 use crate::arrow::from_arrow_array_with_len;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
@@ -34,6 +35,7 @@ use crate::scalar_fn::fns::operators::Operator;
 
 // This implementation exists so we can have custom translation of RHS to arrow that's not the same as IntoCanonical
 impl CompareKernel for VarBin {
+    #[allow(deprecated)]
     fn compare(
         lhs: ArrayView<'_, VarBin>,
         rhs: &ArrayRef,

--- a/vortex-array/src/arrays/varbin/compute/compare.rs
+++ b/vortex-array/src/arrays/varbin/compute/compare.rs
@@ -23,8 +23,7 @@ use crate::arrays::VarBin;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::varbin::VarBinArrayExt;
 use crate::arrow::Datum;
-#[allow(deprecated)]
-use crate::arrow::from_arrow_array_with_len;
+use crate::arrow::from_arrow_columnar;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
@@ -35,7 +34,6 @@ use crate::scalar_fn::fns::operators::Operator;
 
 // This implementation exists so we can have custom translation of RHS to arrow that's not the same as IntoCanonical
 impl CompareKernel for VarBin {
-    #[allow(deprecated)]
     fn compare(
         lhs: ArrayView<'_, VarBin>,
         rhs: &ArrayRef,
@@ -127,7 +125,7 @@ impl CompareKernel for VarBin {
             }
             .map_err(|err| vortex_err!("Failed to compare VarBin array: {}", err))?;
 
-            Ok(Some(from_arrow_array_with_len(&array, len, nullable)?))
+            Ok(Some(from_arrow_columnar(&array, len, nullable, ctx)?))
         } else if !rhs.is::<VarBin>() {
             // NOTE: If the rhs is not a VarBin array it will be canonicalized to a VarBinView
             // Arrow doesn't support comparing VarBin to VarBinView arrays, so we convert ourselves

--- a/vortex-array/src/arrow/datum.rs
+++ b/vortex-array/src/arrow/datum.rs
@@ -106,7 +106,7 @@ impl ArrowDatum for Datum {
 ///
 /// The provided array must have length
 #[deprecated(
-    note = "Relies on the hidden global `LEGACY_SESSION`; thread an explicit `ExecutionCtx` through `execute_scalar` instead"
+    note = "Relies on the hidden global `LEGACY_SESSION`; use `from_arrow_columnar` with an explicit `ExecutionCtx` instead"
 )]
 pub fn from_arrow_array_with_len<A>(array: A, len: usize, nullable: bool) -> VortexResult<ArrayRef>
 where

--- a/vortex-array/src/arrow/datum.rs
+++ b/vortex-array/src/arrow/datum.rs
@@ -105,6 +105,9 @@ impl ArrowDatum for Datum {
 /// # Error
 ///
 /// The provided array must have length
+#[deprecated(
+    note = "Relies on the hidden global `LEGACY_SESSION`; thread an explicit `ExecutionCtx` through `execute_scalar` instead"
+)]
 pub fn from_arrow_array_with_len<A>(array: A, len: usize, nullable: bool) -> VortexResult<ArrayRef>
 where
     ArrayRef: FromArrowArray<A>,

--- a/vortex-array/src/arrow/datum.rs
+++ b/vortex-array/src/arrow/datum.rs
@@ -134,3 +134,38 @@ where
     )
     .into_array())
 }
+
+/// Convert an Arrow array to an Array with a specific length, using the provided
+/// [`ExecutionCtx`].
+///
+/// This is useful for compute functions that delegate to Arrow using [Datum],
+/// which will return a scalar (length 1 Arrow array) if the input array is constant.
+///
+/// # Error
+///
+/// The provided array must have length `len` or `1`.
+pub fn from_arrow_columnar<A>(
+    array: A,
+    len: usize,
+    nullable: bool,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef>
+where
+    ArrayRef: FromArrowArray<A>,
+{
+    let array = ArrayRef::from_arrow(array, nullable)?;
+    if array.len() == len {
+        return Ok(array);
+    }
+
+    if array.len() != 1 {
+        vortex_panic!(
+            "Array length mismatch, expected {} got {} for encoding {}",
+            len,
+            array.len(),
+            array.encoding_id()
+        );
+    }
+
+    Ok(ConstantArray::new(array.execute_scalar(0, ctx)?, len).into_array())
+}

--- a/vortex-array/src/scalar_fn/fns/binary/compare.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare.rs
@@ -26,6 +26,7 @@ use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
 use crate::arrow::ArrowSessionExt;
 use crate::arrow::Datum;
+#[allow(deprecated)]
 use crate::arrow::from_arrow_array_with_len;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -142,6 +143,7 @@ pub(crate) fn execute_compare(
 }
 
 /// Fall back to Arrow for comparison.
+#[allow(deprecated)]
 fn arrow_compare_arrays(
     left: &ArrayRef,
     right: &ArrayRef,

--- a/vortex-array/src/scalar_fn/fns/binary/compare.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare.rs
@@ -26,8 +26,7 @@ use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
 use crate::arrow::ArrowSessionExt;
 use crate::arrow::Datum;
-#[allow(deprecated)]
-use crate::arrow::from_arrow_array_with_len;
+use crate::arrow::from_arrow_columnar;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::kernel::ExecuteParentKernel;
@@ -143,7 +142,6 @@ pub(crate) fn execute_compare(
 }
 
 /// Fall back to Arrow for comparison.
-#[allow(deprecated)]
 fn arrow_compare_arrays(
     left: &ArrayRef,
     right: &ArrayRef,
@@ -180,7 +178,7 @@ fn arrow_compare_arrays(
         }
     };
 
-    from_arrow_array_with_len(&arrow_array, left.len(), nullable)
+    from_arrow_columnar(&arrow_array, left.len(), nullable, ctx)
 }
 
 pub fn scalar_cmp(lhs: &Scalar, rhs: &Scalar, operator: CompareOperator) -> VortexResult<Scalar> {

--- a/vortex-array/src/scalar_fn/fns/binary/numeric.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric.rs
@@ -8,6 +8,7 @@ use crate::IntoArray;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrow::Datum;
+#[allow(deprecated)]
 use crate::arrow::from_arrow_array_with_len;
 use crate::executor::ExecutionCtx;
 use crate::scalar::NumericOperator;
@@ -29,6 +30,7 @@ pub(crate) fn execute_numeric(
 }
 
 /// Implementation of numeric operations using the Arrow crate.
+#[allow(deprecated)]
 pub(crate) fn arrow_numeric(
     lhs: &ArrayRef,
     rhs: &ArrayRef,

--- a/vortex-array/src/scalar_fn/fns/binary/numeric.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric.rs
@@ -8,8 +8,7 @@ use crate::IntoArray;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrow::Datum;
-#[allow(deprecated)]
-use crate::arrow::from_arrow_array_with_len;
+use crate::arrow::from_arrow_columnar;
 use crate::executor::ExecutionCtx;
 use crate::scalar::NumericOperator;
 
@@ -30,7 +29,6 @@ pub(crate) fn execute_numeric(
 }
 
 /// Implementation of numeric operations using the Arrow crate.
-#[allow(deprecated)]
 pub(crate) fn arrow_numeric(
     lhs: &ArrayRef,
     rhs: &ArrayRef,
@@ -50,7 +48,7 @@ pub(crate) fn arrow_numeric(
         NumericOperator::Div => arrow_arith::numeric::div(&left, &right)?,
     };
 
-    from_arrow_array_with_len(array.as_ref(), len, nullable)
+    from_arrow_columnar(array.as_ref(), len, nullable, ctx)
 }
 
 fn constant_numeric(

--- a/vortex-array/src/scalar_fn/fns/like/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/like/mod.rs
@@ -18,8 +18,7 @@ use vortex_session::registry::CachedId;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::arrow::Datum;
-#[allow(deprecated)]
-use crate::arrow::from_arrow_array_with_len;
+use crate::arrow::from_arrow_columnar;
 use crate::dtype::DType;
 use crate::expr::Expression;
 use crate::expr::StatsCatalog;
@@ -212,7 +211,6 @@ impl ScalarFnVTable for Like {
 }
 
 /// Implementation of LIKE using the Arrow crate.
-#[allow(deprecated)]
 pub(crate) fn arrow_like(
     array: &ArrayRef,
     pattern: &ArrayRef,
@@ -239,7 +237,7 @@ pub(crate) fn arrow_like(
         (true, true) => arrow_string::like::nilike(&lhs, &rhs)?,
     };
 
-    from_arrow_array_with_len(&result, len, nullable)
+    from_arrow_columnar(&result, len, nullable, ctx)
 }
 
 /// Variants of the LIKE filter that we know how to turn into a stats pruning predicate.

--- a/vortex-array/src/scalar_fn/fns/like/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/like/mod.rs
@@ -18,6 +18,7 @@ use vortex_session::registry::CachedId;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::arrow::Datum;
+#[allow(deprecated)]
 use crate::arrow::from_arrow_array_with_len;
 use crate::dtype::DType;
 use crate::expr::Expression;
@@ -211,6 +212,7 @@ impl ScalarFnVTable for Like {
 }
 
 /// Implementation of LIKE using the Arrow crate.
+#[allow(deprecated)]
 pub(crate) fn arrow_like(
     array: &ArrayRef,
     pattern: &ArrayRef,

--- a/vortex-array/src/variants.rs
+++ b/vortex-array/src/variants.rs
@@ -112,6 +112,9 @@ pub struct NullTyped<'a>(&'a ArrayRef);
 pub struct BoolTyped<'a>(&'a ArrayRef);
 
 impl BoolTyped<'_> {
+    #[deprecated(
+        note = "Relies on the hidden global `LEGACY_SESSION`; use `sum(array, ctx)` with an explicit `ExecutionCtx` instead"
+    )]
     pub fn true_count(&self) -> VortexResult<usize> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let true_count = sum(self.0, &mut ctx)?;
@@ -133,6 +136,10 @@ impl PrimitiveTyped<'_> {
     }
 
     /// Return the primitive value at the given index.
+    #[deprecated(
+        note = "Relies on the hidden global `LEGACY_SESSION`; use `is_valid`/`execute_scalar` with an explicit `ExecutionCtx` instead"
+    )]
+    #[allow(deprecated)]
     pub fn value(&self, idx: usize) -> VortexResult<Option<PValue>> {
         self.0
             .is_valid(idx, &mut LEGACY_SESSION.create_execution_ctx())?
@@ -141,6 +148,9 @@ impl PrimitiveTyped<'_> {
     }
 
     /// Return the primitive value at the given index, ignoring nullability.
+    #[deprecated(
+        note = "Relies on the hidden global `LEGACY_SESSION`; use `execute_scalar` with an explicit `ExecutionCtx` instead"
+    )]
     pub fn value_unchecked(&self, idx: usize) -> VortexResult<PValue> {
         Ok(self
             .0
@@ -152,6 +162,7 @@ impl PrimitiveTyped<'_> {
 }
 
 impl IndexOrd<Option<PValue>> for PrimitiveTyped<'_> {
+    #[allow(deprecated)]
     fn index_cmp(&self, idx: usize, elem: &Option<PValue>) -> VortexResult<Option<Ordering>> {
         let value = self.value(idx)?;
         Ok(value.partial_cmp(elem))
@@ -164,6 +175,7 @@ impl IndexOrd<Option<PValue>> for PrimitiveTyped<'_> {
 
 // TODO(ngates): add generics to the `value` function and implement this over T.
 impl IndexOrd<PValue> for PrimitiveTyped<'_> {
+    #[allow(deprecated)]
     fn index_cmp(&self, idx: usize, elem: &PValue) -> VortexResult<Option<Ordering>> {
         assert!(
             self.0


### PR DESCRIPTION
## Summary

Several public `vortex-array` methods construct an `ExecutionCtx` from the hidden global `LEGACY_SESSION` static instead of accepting an explicit `ExecutionCtx`. This PR marks them `#[deprecated]` so downstream callers migrate to the context-threading APIs (matching the existing `IntoArrowArray` deprecation pattern).

## Deprecated public APIs

| API | File | Suggested replacement |
|---|---|---|
| `BoolTyped::true_count` | `vortex-array/src/variants.rs` | `sum(array, ctx)` with an explicit `ExecutionCtx` |
| `PrimitiveTyped::value` | `vortex-array/src/variants.rs` | `is_valid` / `execute_scalar` with an explicit `ExecutionCtx` |
| `PrimitiveTyped::value_unchecked` | `vortex-array/src/variants.rs` | `execute_scalar` with an explicit `ExecutionCtx` |
| `from_arrow_array_with_len` | `vortex-array/src/arrow/datum.rs` | thread an explicit `ExecutionCtx` through `execute_scalar` |

Each carries a `#[deprecated(note = …)]` explaining why and what to use instead.
