### PR TITLE
Don't use SharedArray for dict values

### DIFF
--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -100,10 +100,10 @@ impl DictReader {
                     )
                     .vortex_expect("must construct dict values array evaluation")
                     .map_err(Arc::new)
-                    .map(move |array| {
-                        let array = array?;
-                        Ok(SharedArray::new(array).into_array())
-                    })
+                    //.map(move |array| {
+                    //    let array = array?;
+                    //    Ok(SharedArray::new(array).into_array())
+                    //})
                     .boxed()
                     .shared()
             })


### PR DESCRIPTION
SharedArray prevents us from using FSST data in queries like
SELECT byte_length(str), from SharedArray we already get decompressed
VarBinView data.

Check what of performance impact is not using the array
