### PR TITLE
Ignore RUSTSEC-2026-0173

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,8 @@ feature-depth = 1
 ignore = [
     # Paste is no longer maintained because its essentially "finished".
     "RUSTSEC-2024-0436",
+    # proc-macro-error-2 is unmaintained, only used by the `test_with` test dependency
+    "RUSTSEC-2026-0173"
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

Ignore [RUSTSEC-2026-0173](https://rustsec.org/advisories/RUSTSEC-2026-0173), its only pulled by a very minor dev-only dependency, we can keep an eye out to if/when `test_with` upgrades to an alternative crate or just re-implement the minimal proc-macro we need from it.