### PR TITLE
Scalar functions pushdown to Duckdb

### DIFF
--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -24,7 +24,7 @@ const DEFAULT_DUCKDB_VERSION: &str = "1.5.3";
 
 const BUILD_ARTIFACTS: [&str; 3] = ["libduckdb.dylib", "libduckdb.so", "libduckdb_static.a"];
 
-const SOURCE_FILES: [&str; 17] = [
+const SOURCE_FILES: [&str; 18] = [
     "cpp/client_context.cpp",
     "cpp/config.cpp",
     "cpp/copy_function.cpp",
@@ -34,6 +34,7 @@ const SOURCE_FILES: [&str; 17] = [
     "cpp/expr.cpp",
     "cpp/file_system.cpp",
     "cpp/logical_type.cpp",
+    "cpp/optimizer.cpp",
     "cpp/replacement_scan.cpp",
     "cpp/reusable_dict.cpp",
     "cpp/scalar_function.cpp",

--- a/vortex-duckdb/cpp/include/duckdb_vx.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "duckdb_vx/client_context.h"
+#include "duckdb_vx/optimizer.h"
 #include "duckdb_vx/config.h"
 #include "duckdb_vx/copy_function.h"
 #include "duckdb_vx/data.h"

--- a/vortex-duckdb/cpp/include/duckdb_vx/optimizer.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/optimizer.h
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+#pragma once
+#include "duckdb.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+duckdb_state duckdb_vx_optimizer_extension_register(duckdb_database ffi_db);
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+#include "duckdb/optimizer/optimizer_extension.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include <optional>
+
+// Only one consumer of this header file, so "using" is fine
+using namespace duckdb;
+
+using ExpressionPtr = unique_ptr<Expression>;
+using LogicalOperatorPtr = unique_ptr<LogicalOperator>;
+
+/**
+ * Column index in requested scan. Example:
+ *
+ * CREATE TABLE t (a1 INTEGER, a2 INTEGER, a3 INTEGER);
+ * SELECT a2, a3 FROM t;
+ *
+ * a2's TableColumnScanIndex is 0, a3's TableColumnScanIndex is 1,
+ * index is index in SELECT clause.
+ */
+using TableColumnScanIndex = idx_t;
+
+/**
+ * Column index in table's storage. Example:
+ *
+ * CREATE TABLE t (a1 INTEGER, a2 INTEGER, a3 INTEGER);
+ * SELECT a2, a3 FROM t;
+ *
+ * a2's TableColumnStorageIndex is 1, a3's TableColumnScanIndex is 2,
+ * index is index of column in table storage.
+ *
+ * for i: TableColumnScanIndex, column_ids[i].GetPrimaryIndex() is
+ * TableColumnStorageIndex
+ */
+using TableColumnStorageIndex = idx_t;
+
+using TableIndex = idx_t;
+
+struct GetAnalysis {
+    LogicalGet &get;
+    /**
+     * for fn(col), mapping of "col scan index" -> "fn expression".
+     * "fn expression" is nullptr iff column is used with a different function
+     * or without function application in the query plan.
+     */
+    unordered_map<TableColumnScanIndex, const BoundFunctionExpression *> col_to_fn;
+};
+
+using Analyses = unordered_map<TableIndex, GetAnalysis>;
+
+/*
+ * SELECT fn(col) FROM '*.vortex' yields a PROJECTION fn(col) -> GET (vortex)
+ * plan. PROJECTION's "col" table_index is 1, vortex GET's table_index is 0.
+ * So we want to track original table_index for GET in case column is found
+ * in filter we failed to push down (i.e. WHERE prefix(col, 'h')) as well as
+ * projection's table_index.
+ *
+ * So we keep a mapping of
+ *
+ * "projection table index" to "projection operator".
+ *
+ * to resolve this.
+ * For simplicity, current implementation is limited to one level i.e.
+ * PROJECTION -> GET (i.e. read from VIEW) is pushed down but VIEW->VIEW->GET
+ * or VIEW->CTE->GET is not.
+ *
+ * Storing a reference is fine because the plan outlives the optimizer pass.
+ */
+using Projections = unordered_map<TableIndex, LogicalProjection &>;
+
+/**
+ * Collect fn(col) expressions i.e. expressions where a single function (not
+ * a function chain) wraps a single bound column. If "col" is used without
+ * function application in "plan", record in "analyses.conflicts"
+ */
+struct ScalarFnCollect final : LogicalOperatorVisitor {
+    Analyses &analyses;
+    const Projections &projections;
+
+    ScalarFnCollect(Analyses &analyses, const Projections &projections);
+    void VisitOperator(LogicalOperator &op) override;
+    ExpressionPtr VisitReplace(BoundColumnRefExpression &expr, ExpressionPtr *ptr) override;
+    ExpressionPtr VisitReplace(BoundFunctionExpression &expr, ExpressionPtr *ptr) override;
+};
+
+/*
+ * For "col" in columns collected by ScalarFnCollect, replace fn(col) to "col"
+ * if "col" doesn't have conflicting usage. Update return types for bound
+ * columns and logical projections referencing this column.
+ */
+struct ScalarFnReplace final : LogicalOperatorVisitor {
+    Analyses &analyses;
+    const Projections &projections;
+
+    ScalarFnReplace(Analyses &analyses, const Projections &aliases);
+    ExpressionPtr VisitReplace(BoundColumnRefExpression &expr, ExpressionPtr *ptr) override;
+    ExpressionPtr VisitReplace(BoundFunctionExpression &expr, ExpressionPtr *ptr) override;
+};
+
+void FindGetsAndProjections(LogicalOperator &op, Analyses &analyses, Projections &aliases);
+
+LogicalOperatorPtr TryPushdownScalarFunctions(ClientContext &context, LogicalOperatorPtr plan);
+void VortexOptimizeFunction(OptimizerExtensionInput &input, LogicalOperatorPtr &plan);
+
+struct VortexOptimizerExtension final : OptimizerExtension {
+    inline VortexOptimizerExtension() : OptimizerExtension(VortexOptimizeFunction, nullptr, {}) {
+    }
+};
+
+struct GetBinding {
+    GetAnalysis &analysis;
+    TableColumnScanIndex column_index;
+    // If column binding was part of a projection, this is non-nullptr
+    LogicalProjection *projection;
+};
+
+/*
+ * Given a column binding, resolve it to a GET and a GET's column scan index.
+ * Returns nullopt for virtual columns and columns which are neither part of
+ * GET nor part of PROJECTION wrapping a GET.
+ */
+std::optional<GetBinding> Resolve(ColumnBinding binding, Analyses &analyses, const Projections &projections);
+
+#endif

--- a/vortex-duckdb/cpp/include/duckdb_vx/table_function.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/table_function.h
@@ -10,6 +10,24 @@
 
 #ifdef __cplusplus
 static_assert(sizeof(idx_t) == 8);
+
+#include "duckdb/main/capi/capi_internal.hpp"
+
+duckdb::unique_ptr<duckdb::FunctionData>
+duckdb_vx_table_function_bind(duckdb::ClientContext &context,
+                              duckdb::TableFunctionBindInput &input,
+                              duckdb::vector<duckdb::LogicalType> &return_types,
+                              duckdb::vector<duckdb::string> &names);
+
+struct TableFunctionProjectionExpressionInput {
+    const duckdb::LogicalGet &get;
+    const duckdb::Expression &expression;
+    idx_t projection_idx;
+};
+
+// true if we can push down the expression, false otherwise
+bool projection_expression_pushdown(duckdb::ClientContext &context,
+                                    const TableFunctionProjectionExpressionInput &input);
 #endif
 
 #ifdef __cplusplus

--- a/vortex-duckdb/cpp/optimizer.cpp
+++ b/vortex-duckdb/cpp/optimizer.cpp
@@ -93,13 +93,12 @@ void FindGetsAndProjections(LogicalOperator &op, Analyses &analyses, Projections
         LogicalProjection &projection = op.Cast<LogicalProjection>();
         D_ASSERT(projection.children.size() == 1);
         auto &child = *projection.children[0];
-        if (child.type != LOGICAL_GET) {
+        if (!is_passthrough(projection) || child.type != LOGICAL_GET) {
             break;
         }
         // The GET itself is recorded when recursion reaches it below. Only
         // passthrough projections wrapping a vortex GET act as aliases.
-        if (auto &get = child.Cast<LogicalGet>();
-            get.function.bind == duckdb_vx_table_function_bind && is_passthrough(projection)) {
+        if (auto &get = child.Cast<LogicalGet>(); get.function.bind == duckdb_vx_table_function_bind) {
             projections.emplace(projection.table_index, projection);
         }
         break;

--- a/vortex-duckdb/cpp/optimizer.cpp
+++ b/vortex-duckdb/cpp/optimizer.cpp
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
+#include "duckdb_vx/optimizer.h"
+#include "duckdb_vx/table_function.h"
+#include "vortex.h"
+#include <optional>
+
+/**
+ * Our optimizer runs after all duckdb optimizers. Functions that can be pushed
+ * down as complex filters (e.g. WHERE str != '') are already pushed down.
+ * If there are any functions left, this means they were not pushed down and
+ * may produce conflicts (e.g. WHERE prefix("str", 'h')).
+ */
+
+extern "C" duckdb_state duckdb_vx_optimizer_extension_register(duckdb_database ffi_db) {
+    D_ASSERT(ffi_db);
+    const DatabaseWrapper &wrapper = *reinterpret_cast<DatabaseWrapper *>(ffi_db);
+    DatabaseInstance &db = *wrapper.database->instance;
+    try {
+        DBConfig::GetConfig(db).GetCallbackManager().Register(VortexOptimizerExtension());
+    } catch (const std::exception &e) {
+        ErrorData data(e);
+        DUCKDB_LOG_ERROR(db, "Failed to create Vortex optimizer extension:\t" + data.Message());
+        return DuckDBError;
+    }
+    return DuckDBSuccess;
+}
+
+void VortexOptimizeFunction(OptimizerExtensionInput &input, LogicalOperatorPtr &plan) {
+    plan = TryPushdownScalarFunctions(input.context, std::move(plan));
+}
+
+LogicalOperatorPtr TryPushdownScalarFunctions(ClientContext &context, LogicalOperatorPtr plan) {
+    Analyses analyses;
+    Projections projections;
+    FindGetsAndProjections(*plan, analyses, projections);
+    if (analyses.empty()) {
+        return plan;
+    }
+    ScalarFnCollect(analyses, projections).VisitOperator(*plan);
+
+    bool any_pushed = false;
+    for (auto &[_, analysis] : analyses) {
+        for (auto &[column_index, expr] : analysis.col_to_fn) {
+            if (expr == nullptr) { // Conflict for column
+                continue;
+            }
+            const TableColumnStorageIndex storage_index =
+                analysis.get.GetColumnIds()[column_index].GetPrimaryIndex();
+            TableFunctionProjectionExpressionInput input {analysis.get, *expr, storage_index};
+            if (projection_expression_pushdown(context, input)) {
+                analysis.get.types[column_index] = expr->return_type;
+                analysis.get.returned_types[storage_index] = expr->return_type;
+                any_pushed = true;
+            } else { // failed to push down expression, can't replace it
+                expr = nullptr;
+            }
+        }
+    }
+
+    if (any_pushed) {
+        ScalarFnReplace(analyses, projections).VisitOperator(*plan);
+    }
+    return plan;
+}
+
+// A passthrough projection only forwards its child columns, e.g. a VIEW's
+// "SELECT col".
+static bool is_passthrough(const LogicalProjection &projection) {
+    if (projection.expressions.empty()) {
+        return false; // don't register empty projections in Projections
+    }
+    for (const auto &e : projection.expressions) {
+        if (e->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void FindGetsAndProjections(LogicalOperator &op, Analyses &analyses, Projections &projections) {
+    using enum LogicalOperatorType;
+    switch (op.type) {
+    case LOGICAL_GET: {
+        if (auto &get = op.Cast<LogicalGet>(); get.function.bind == duckdb_vx_table_function_bind) {
+            analyses.emplace(get.table_index, GetAnalysis {get, {}});
+        }
+        break;
+    }
+    case LOGICAL_PROJECTION: {
+        LogicalProjection &projection = op.Cast<LogicalProjection>();
+        D_ASSERT(projection.children.size() == 1);
+        auto &child = *projection.children[0];
+        if (child.type != LOGICAL_GET) {
+            break;
+        }
+        // The GET itself is recorded when recursion reaches it below. Only
+        // passthrough projections wrapping a vortex GET act as aliases.
+        if (auto &get = child.Cast<LogicalGet>();
+            get.function.bind == duckdb_vx_table_function_bind && is_passthrough(projection)) {
+            projections.emplace(projection.table_index, projection);
+        }
+        break;
+    }
+    default:
+        break;
+    }
+
+    for (auto &child : op.children) {
+        FindGetsAndProjections(*child, analyses, projections);
+    }
+}
+
+std::optional<GetBinding> Resolve(ColumnBinding binding, Analyses &analyses, const Projections &projections) {
+    if (IsVirtualColumn(binding.column_index)) {
+        return std::nullopt;
+    }
+    if (const auto it = analyses.find(binding.table_index); it != analyses.end()) {
+        return {{it->second, binding.column_index, nullptr}};
+    }
+
+    const auto projection_it = projections.find(binding.table_index);
+    if (projection_it == projections.end()) {
+        return std::nullopt;
+    }
+
+    LogicalProjection &projection = projection_it->second;
+    const ExpressionPtr &inner = projection.expressions[binding.column_index];
+    if (inner->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+        return std::nullopt;
+    }
+    const ColumnBinding &get_binding = inner->Cast<BoundColumnRefExpression>().binding;
+    if (IsVirtualColumn(get_binding.column_index)) {
+        return std::nullopt;
+    }
+    if (const auto it = analyses.find(get_binding.table_index); it != analyses.end()) {
+        return {{it->second, get_binding.column_index, &projection}};
+    }
+    return std::nullopt;
+}
+
+void ScalarFnCollect::VisitOperator(LogicalOperator &op) {
+    /*
+     * Logical projection expressions are columns which reference underlying
+     * GETs. Don't process them, as they would add conflicts for every column
+     * used in projection. Example: PROJECTION(col) -> GET(col). We don't want
+     * to visit BoundColumnRefExpression in PROJECTION to avoid registering a
+     * non-existent conflict.
+     *
+     * However, ScalarFnReplace will visit them because we need to update their
+     * types if pushdown succeeded.
+     */
+    if (op.type == LogicalOperatorType::LOGICAL_PROJECTION &&
+        projections.count(op.Cast<LogicalProjection>().table_index)) {
+        VisitOperatorChildren(op);
+        return;
+    }
+    LogicalOperatorVisitor::VisitOperator(op);
+}
+
+ExpressionPtr ScalarFnCollect::VisitReplace(BoundColumnRefExpression &expr, ExpressionPtr *ptr) {
+    if (const auto binding = Resolve(expr.binding, analyses, projections)) {
+        // Column is used without function applied to it, register a conflict.
+        // Not emplace() as we need to update the value if it was present
+        binding->analysis.col_to_fn[binding->column_index] = nullptr;
+    }
+    return std::move(*ptr);
+}
+
+ExpressionPtr ScalarFnCollect::VisitReplace(BoundFunctionExpression &expr, ExpressionPtr *ptr) {
+    if (expr.children.size() != 1 ||
+        expr.children[0]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+        // Descend into children so e.g. fn(col, other) still sees "col" and
+        // registers a conflict
+        return nullptr;
+    }
+    const auto &bound_col = expr.children[0]->Cast<BoundColumnRefExpression>();
+    const auto binding = Resolve(bound_col.binding, analyses, projections);
+    if (!binding) {
+        return nullptr;
+    }
+    auto &col_to_fn = binding->analysis.col_to_fn;
+
+    if (auto it = col_to_fn.find(binding->column_index); it == col_to_fn.end()) {
+        // This is the first time we see the column used by a single function.
+        col_to_fn.emplace(binding->column_index, &expr);
+    } else if (it->second == nullptr || !it->second->Equals(expr)) {
+        // Either column is used with different function in "expr" or
+        // there already is a conflict.
+        it->second = nullptr;
+    }
+
+    return std::move(*ptr);
+}
+
+static bool can_pushdown_column(const GetAnalysis &analysis, TableColumnScanIndex idx) {
+    const auto it = analysis.col_to_fn.find(idx);
+    return it != analysis.col_to_fn.end() && it->second != nullptr;
+}
+
+ExpressionPtr ScalarFnReplace::VisitReplace(BoundColumnRefExpression &expr, ExpressionPtr *ptr) {
+    const auto binding = Resolve(expr.binding, analyses, projections);
+    if (!binding) {
+        return std::move(*ptr);
+    }
+
+    const auto &[analysis, column_index, projection] = *binding;
+    if (can_pushdown_column(analysis, column_index)) {
+        expr.return_type = analysis.get.types[column_index];
+        if (projection != nullptr) {
+            projection->types[column_index] = expr.return_type;
+        }
+    }
+
+    return std::move(*ptr);
+}
+
+ExpressionPtr ScalarFnReplace::VisitReplace(BoundFunctionExpression &expr, ExpressionPtr *ptr) {
+    if (expr.children.size() != 1 ||
+        expr.children[0]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+        return nullptr; // Same as in ScalarFnCollect::VisitReplace
+    }
+    ExpressionPtr &bound_col_base = expr.children[0];
+    const auto &bound_col = bound_col_base->Cast<BoundColumnRefExpression>();
+    const auto binding = Resolve(bound_col.binding, analyses, projections);
+    if (!binding) {
+        return nullptr;
+    }
+
+    const auto &[analysis, column_index, projection] = *binding;
+    if (!can_pushdown_column(analysis, column_index)) {
+        return std::move(*ptr);
+    }
+
+    bound_col_base->return_type = analysis.get.types[column_index];
+    if (projection != nullptr) {
+        projection->types[column_index] = bound_col_base->return_type;
+    }
+    return std::move(bound_col_base);
+}
+
+ScalarFnCollect::ScalarFnCollect(Analyses &analyses, const Projections &projections)
+    : analyses(analyses), projections(projections) {
+}
+
+ScalarFnReplace::ScalarFnReplace(Analyses &analyses, const Projections &projections)
+    : analyses(analyses), projections(projections) {
+}

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -4,6 +4,7 @@
 #include "duckdb_vx/data.hpp"
 #include "duckdb_vx/error.hpp"
 #include "duckdb_vx/table_function.h"
+#include "duckdb_vx/expr.h"
 #include "vortex.h"
 
 #include "duckdb.h"
@@ -14,6 +15,7 @@
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 
 using namespace std::string_literals;
 using namespace duckdb;
@@ -170,15 +172,35 @@ struct CTableBindResult {
     vector<string> &names;
 };
 
+bool projection_expression_pushdown(ClientContext &, const TableFunctionProjectionExpressionInput &input) {
+    const auto &bind = input.get.bind_data->Cast<CTableBindData>();
+
+    // This is a flaw of Duckdb API which doesn't allow passing non-const
+    // expressions. We never modify the value on Rust side.
+    auto ffi_expr = reinterpret_cast<duckdb_vx_expr>(const_cast<Expression *>(&input.expression));
+    void *const ffi_bind = bind.ffi_data->DataPtr();
+    duckdb_vx_error error_out = nullptr;
+
+    const bool ret = duckdb_table_function_pushdown_projection_expression( //
+        ffi_bind,
+        ffi_expr,
+        input.projection_idx,
+        &error_out);
+    if (error_out) {
+        throw BinderException(IntoErrString(error_out));
+    }
+    return ret;
+}
+
 /**
  * Called for every new query. For example, if there is a VIEW over *.vortex,
  * and after a query another file is added matching the glob, for second query
  * bind() will be called again.
  */
-unique_ptr<FunctionData> c_bind(ClientContext &context,
-                                TableFunctionBindInput &input,
-                                vector<LogicalType> &return_types,
-                                vector<string> &names) {
+unique_ptr<FunctionData> duckdb_vx_table_function_bind(ClientContext &context,
+                                                       TableFunctionBindInput &input,
+                                                       vector<LogicalType> &return_types,
+                                                       vector<string> &names) {
     CTableBindResult result = {return_types, names};
 
     duckdb_vx_error error_out = nullptr;
@@ -364,7 +386,7 @@ InsertionOrderPreservingMap<string> c_to_string(TableFunctionToStringInput &inpu
 }
 
 duckdb_state register_table_function(DatabaseInstance &db, LogicalType parameter, const std::string &name) {
-    TableFunction tf(name, {}, function, c_bind, c_init_global, init_local);
+    TableFunction tf(name, {}, function, duckdb_vx_table_function_bind, c_init_global, init_local);
 
     tf.projection_pushdown = true;
     tf.filter_pushdown = true;

--- a/vortex-duckdb/include/vortex.h
+++ b/vortex-duckdb/include/vortex.h
@@ -62,6 +62,12 @@ bool duckdb_table_function_pushdown_complex_filter(void *bind_data,
                                                    duckdb_vx_error *error_out);
 
 extern
+bool duckdb_table_function_pushdown_projection_expression(void *bind_data,
+                                                          duckdb_vx_expr expr,
+                                                          size_t column_id,
+                                                          duckdb_vx_error *error_out);
+
+extern
 void duckdb_table_function_scan(void *global_init_data,
                                 void *local_init_data,
                                 duckdb_data_chunk output,

--- a/vortex-duckdb/src/convert/expr.rs
+++ b/vortex-duckdb/src/convert/expr.rs
@@ -4,7 +4,9 @@
 use std::sync::Arc;
 
 use tracing::debug;
+use vortex::dtype::DType;
 use vortex::dtype::Nullability;
+use vortex::dtype::PType;
 use vortex::error::VortexError;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
@@ -13,6 +15,8 @@ use vortex::error::vortex_ensure;
 use vortex::error::vortex_err;
 use vortex::expr::Expression;
 use vortex::expr::and_collect;
+use vortex::expr::byte_length;
+use vortex::expr::cast;
 use vortex::expr::col;
 use vortex::expr::get_item;
 use vortex::expr::is_not_null;
@@ -21,6 +25,7 @@ use vortex::expr::list_contains;
 use vortex::expr::lit;
 use vortex::expr::not;
 use vortex::expr::or_collect;
+use vortex::expr::root;
 use vortex::scalar::Scalar;
 use vortex::scalar_fn::ScalarFnVTableExt;
 use vortex::scalar_fn::fns::between::Between;
@@ -43,6 +48,7 @@ use crate::duckdb::ExpressionClass::BoundComparison;
 use crate::duckdb::ExpressionClass::BoundConjunction;
 use crate::duckdb::ExpressionClass::BoundConstant;
 use crate::duckdb::ExpressionClass::BoundRef;
+use crate::projection::DuckdbField;
 
 fn from_bound_str(value: &duckdb::ExpressionRef) -> VortexResult<String> {
     match value.as_class().vortex_expect("unknown class") {
@@ -56,6 +62,20 @@ fn try_from_bound_function(
     col_sub: Option<&Expression>,
 ) -> VortexResult<Option<Expression>> {
     let expr = match func.scalar_function.name() {
+        "strlen" => {
+            let children: Vec<_> = func.children().collect();
+            vortex_ensure!(children.len() == 1);
+            let Some(col) = try_from_expression_inner(children[0], col_sub)? else {
+                return Ok(None);
+            };
+            let col = byte_length(col);
+            // byte_length returns u64, strlen expects i64.
+            // At this point we don't know column's dtype so we ultimately
+            // set it to be nullable. For non-nullable column the nullability
+            // will be AllValid so it's a marginal cost.
+            let dtype = DType::Primitive(PType::I64, Nullability::Nullable);
+            cast(col, dtype)
+        }
         "struct_extract" => {
             let children: Vec<_> = func.children().collect();
             vortex_ensure!(children.len() == 2);
@@ -152,6 +172,7 @@ pub fn can_push_expression(value: &duckdb::ExpressionRef) -> bool {
                 || name == "suffix"
                 || name == "~~"
                 || name == "!~~"
+                || name == "strlen"
         }
         ExpressionClass::BoundOperator(op) => {
             if !matches!(
@@ -167,6 +188,28 @@ pub fn can_push_expression(value: &duckdb::ExpressionRef) -> bool {
             op.children().all(can_push_expression)
         }
     }
+}
+
+pub fn try_from_projection_expression(
+    value: &duckdb::ExpressionRef,
+    field: &DuckdbField,
+) -> VortexResult<Option<Expression>> {
+    let Some(value) = value.as_class() else {
+        return Ok(None);
+    };
+    let ExpressionClass::BoundFunction(func) = value else {
+        return Ok(None);
+    };
+    Ok(match func.scalar_function.name() {
+        "strlen" => {
+            let col = byte_length(get_item(field.name.as_str(), root()));
+            // byte_length returns u64, strlen expects i64
+            let dtype = DType::Primitive(PType::I64, field.dtype.nullability());
+            let col = cast(col, dtype);
+            Some(col)
+        }
+        _ => None,
+    })
 }
 
 // If you want to add support for other expressions, also change

--- a/vortex-duckdb/src/convert/mod.rs
+++ b/vortex-duckdb/src/convert/mod.rs
@@ -10,6 +10,7 @@ mod vector;
 pub use dtype::FromLogicalType;
 pub use expr::can_push_expression;
 pub use expr::try_from_bound_expression;
+pub use expr::try_from_projection_expression;
 pub use scalar::*;
 pub use table_filter::try_from_table_filter;
 pub use table_filter::try_from_virtual_column_filter;

--- a/vortex-duckdb/src/duckdb/database.rs
+++ b/vortex-duckdb/src/duckdb/database.rs
@@ -139,6 +139,14 @@ impl DatabaseRef {
         Ok(())
     }
 
+    pub fn register_optimizer_extension(&self) -> VortexResult<()> {
+        duckdb_try!(
+            unsafe { cpp::duckdb_vx_optimizer_extension_register(self.as_ptr()) },
+            "Failed to register optimizer extension"
+        );
+        Ok(())
+    }
+
     pub fn register_copy_function(&self) -> VortexResult<()> {
         duckdb_try!(
             unsafe { cpp::duckdb_vx_register_copy_function(self.as_ptr()) },

--- a/vortex-duckdb/src/ffi.rs
+++ b/vortex-duckdb/src/ffi.rs
@@ -39,6 +39,7 @@ use crate::table_function::get_partition_data;
 use crate::table_function::init_global;
 use crate::table_function::init_local;
 use crate::table_function::pushdown_complex_filter;
+use crate::table_function::pushdown_projection_expression;
 use crate::table_function::scan;
 use crate::table_function::statistics;
 use crate::table_function::table_scan_progress;
@@ -109,6 +110,21 @@ unsafe extern "C-unwind" fn duckdb_table_function_pushdown_complex_filter(
         .vortex_expect("bind_data null pointer");
     let expr = unsafe { Expression::borrow(expr) };
     try_or(error_out, || pushdown_complex_filter(bind_data, expr))
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C-unwind" fn duckdb_table_function_pushdown_projection_expression(
+    bind_data: *mut c_void,
+    expr: cpp::duckdb_vx_expr,
+    column_id: usize,
+    error_out: *mut cpp::duckdb_vx_error,
+) -> bool {
+    let bind_data = unsafe { bind_data.cast::<TableFunctionBind>().as_mut() }
+        .vortex_expect("bind_data null pointer");
+    let expr = unsafe { Expression::borrow(expr) };
+    try_or(error_out, || {
+        pushdown_projection_expression(bind_data, expr, column_id)
+    })
 }
 
 #[unsafe(no_mangle)]

--- a/vortex-duckdb/src/lib.rs
+++ b/vortex-duckdb/src/lib.rs
@@ -75,6 +75,7 @@ pub fn initialize(db: &DatabaseRef) -> VortexResult<()> {
         Value::from("vortex"),
     )?;
     db.register_table_functions()?;
+    db.register_optimizer_extension()?;
     db.register_copy_function()
 }
 

--- a/vortex-duckdb/src/projection.rs
+++ b/vortex-duckdb/src/projection.rs
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 use std::ops::Range;
-use std::sync::Arc;
 
 use num_traits::AsPrimitive as _;
 use vortex::dtype::DType;
-use vortex::dtype::FieldNames;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
 use vortex::expr::Expression;
 use vortex::expr::and_collect;
 use vortex::expr::col;
+use vortex::expr::get_item;
 use vortex::expr::merge;
 use vortex::expr::pack;
 use vortex::expr::root;
@@ -43,6 +42,9 @@ pub struct DuckdbField {
     pub name: String,
     pub logical_type: LogicalType,
     pub dtype: DType,
+    /// Function to use instead of get_item(col, root()), e.g. len(col).
+    /// It does not include column name so it's just "len" and not "len(col)"
+    pub projection_fn: Option<Expression>,
 }
 
 pub struct Projection {
@@ -68,6 +70,7 @@ impl Projection {
         let mut file_row_number_column_pos = None;
         let mut is_star = true;
         let mut real_column_count = 0;
+        let mut fn_col_count = 0;
 
         // DuckDB uses u64 as column indices but Rust uses usize
         for (column_pos, &column_id) in ids.iter().enumerate() {
@@ -86,47 +89,92 @@ impl Projection {
                 file_row_number_column_pos = Some(column_pos);
                 continue;
             }
+            if is_virtual_column(column_id) {
+                continue;
+            }
 
             // In SELECT * DuckDB requests all columns from 0 to column_fields in
             // increasing order. After removing virtual columns, compare column_id
             // with (0..column_fields.len()) range.
             is_star &= column_id == real_column_count;
+
+            // Example: if we SELECT len(str), we can't use root() as we try to
+            // pushdown scalar functions.
+            let column_id: usize = column_id.as_();
+            let is_projected_col = column_fields[column_id].projection_fn.is_some();
+            fn_col_count += is_projected_col as usize;
+            is_star &= !is_projected_col;
+
             real_column_count += 1;
         }
         // Duckdb can request less columns than there are in table i.e. [0, 1] with
         // 5 columns total.
         is_star &= real_column_count == column_fields.len() as u64;
 
-        let select = if is_star {
-            root()
-        } else {
-            let names = ids
-                .iter()
-                .map(|&column_id| {
-                    if has_projection_ids {
-                        let column_id: usize = column_id.as_();
-                        column_ids[column_id]
-                    } else {
-                        column_id
-                    }
-                })
-                .filter(|&col_id| !is_virtual_column(col_id))
-                .map(|column_id| {
-                    let column_id: usize = column_id.as_();
-                    Arc::from(column_fields[column_id].name.as_str())
-                })
-                .collect::<FieldNames>();
+        let has_file_row_number = file_row_number_column_pos.is_some();
+        if is_star {
+            let projection = if has_file_row_number {
+                // row_idx will be moved to correct position in scan(), prepend here
+                let row_idx_struct = pack([("file_row_number", row_idx())], false.into());
+                merge([row_idx_struct, root()])
+            } else {
+                root()
+            };
+            return Projection {
+                projection,
+                file_index_column_pos,
+                file_row_number_column_pos,
+            };
+        }
 
-            select(names, root())
-        };
+        let has_fn_columns = fn_col_count > 0;
+        let mut all_exprs = Vec::with_capacity(
+            (ids.len() + has_file_row_number as usize) * has_fn_columns as usize,
+        );
+        let mut named_fields = Vec::with_capacity(ids.len() * !has_fn_columns as usize);
 
-        // file_index column will be filled later when exporting the chunk.
-        let projection = if file_row_number_column_pos.is_some() {
+        if has_file_row_number && has_fn_columns {
             // row_idx will be moved to correct position in scan(), prepend here
+            all_exprs.push(("file_row_number", row_idx()));
+        }
+
+        for &column_id in ids {
+            let column_id = if has_projection_ids {
+                let column_id: usize = column_id.as_();
+                column_ids[column_id]
+            } else {
+                column_id
+            };
+            if is_virtual_column(column_id) {
+                continue;
+            }
+            let column_id: usize = column_id.as_();
+            let name = column_fields[column_id].name.as_str();
+            if !has_fn_columns {
+                named_fields.push(name);
+                continue;
+            }
+
+            let column_field = &column_fields[column_id];
+            let expr = match &column_field.projection_fn {
+                None => get_item(name, root()),
+                Some(func) => func.clone(),
+            };
+            all_exprs.push((name, expr));
+        }
+
+        let projection = if has_fn_columns {
+            // If file_row_number was requested, it's in all_exprs as first
+            // element
+            pack(all_exprs, false.into())
+        } else if has_file_row_number {
+            let select = select(named_fields, root());
+            // Here we need to prepend it manually
+            // row_idx will be moved to correct position in scan()
             let row_idx_struct = pack([("file_row_number", row_idx())], false.into());
             merge([row_idx_struct, select])
         } else {
-            select
+            select(named_fields, root())
         };
 
         Self {
@@ -224,6 +272,7 @@ pub fn extract_schema_from_dtype(dtype: &DType) -> VortexResult<Vec<DuckdbField>
             name: field_name.to_string(),
             logical_type,
             dtype: field_dtype,
+            projection_fn: None,
         });
     }
     Ok(fields)
@@ -232,6 +281,7 @@ pub fn extract_schema_from_dtype(dtype: &DType) -> VortexResult<Vec<DuckdbField>
 #[cfg(test)]
 mod tests {
     use vortex::dtype::DType;
+    use vortex::expr::lit;
     use vortex::expr::merge;
     use vortex::expr::pack;
     use vortex::expr::root;
@@ -242,21 +292,24 @@ mod tests {
     #[test]
     fn test_select_star() {
         let ids = [0, 1, 2];
-        let fields = [
+        let mut fields = [
             DuckdbField {
                 name: "".to_owned(),
                 logical_type: LogicalType::null(),
                 dtype: DType::Null,
+                projection_fn: None,
             },
             DuckdbField {
                 name: "".to_owned(),
                 logical_type: LogicalType::null(),
                 dtype: DType::Null,
+                projection_fn: None,
             },
             DuckdbField {
                 name: "".to_owned(),
                 logical_type: LogicalType::null(),
                 dtype: DType::Null,
+                projection_fn: None,
             },
         ];
 
@@ -284,6 +337,11 @@ mod tests {
         assert_ne!(Projection::new(None, &ids, &fields).projection, root());
 
         let ids = [2, 1, 0];
+        assert_ne!(Projection::new(None, &ids, &fields).projection, root());
+
+        // If any column has a projection expression, we can't use SELECT *
+        fields[0].projection_fn = Some(lit(true));
+        let ids = [0, 1, 2];
         assert_ne!(Projection::new(None, &ids, &fields).projection, root());
     }
 }

--- a/vortex-duckdb/src/projection.rs
+++ b/vortex-duckdb/src/projection.rs
@@ -42,9 +42,9 @@ pub struct DuckdbField {
     pub name: String,
     pub logical_type: LogicalType,
     pub dtype: DType,
-    /// Function to use instead of get_item(col, root()), e.g. len(col).
+    /// Expression to use instead of get_item(col, root()), e.g. len(col).
     /// It does not include column name so it's just "len" and not "len(col)"
-    pub projection_fn: Option<Expression>,
+    pub projection_expr: Option<Expression>,
 }
 
 pub struct Projection {
@@ -70,7 +70,7 @@ impl Projection {
         let mut file_row_number_column_pos = None;
         let mut is_star = true;
         let mut real_column_count = 0;
-        let mut fn_col_count = 0;
+        let mut projected_col_count = 0;
 
         // DuckDB uses u64 as column indices but Rust uses usize
         for (column_pos, &column_id) in ids.iter().enumerate() {
@@ -101,8 +101,8 @@ impl Projection {
             // Example: if we SELECT len(str), we can't use root() as we try to
             // pushdown scalar functions.
             let column_id: usize = column_id.as_();
-            let is_projected_col = column_fields[column_id].projection_fn.is_some();
-            fn_col_count += is_projected_col as usize;
+            let is_projected_col = column_fields[column_id].projection_expr.is_some();
+            projected_col_count += is_projected_col as usize;
             is_star &= !is_projected_col;
 
             real_column_count += 1;
@@ -127,13 +127,18 @@ impl Projection {
             };
         }
 
-        let has_fn_columns = fn_col_count > 0;
-        let mut all_exprs = Vec::with_capacity(
-            (ids.len() + has_file_row_number as usize) * has_fn_columns as usize,
-        );
-        let mut named_fields = Vec::with_capacity(ids.len() * !has_fn_columns as usize);
+        let has_columns_with_expr = projected_col_count > 0;
+        let (mut all_exprs, mut named_fields) = if has_columns_with_expr {
+            let all = Vec::with_capacity(ids.len() + has_file_row_number as usize);
+            let named = Vec::new();
+            (all, named)
+        } else {
+            let all = Vec::new();
+            let named = Vec::with_capacity(ids.len());
+            (all, named)
+        };
 
-        if has_file_row_number && has_fn_columns {
+        if has_file_row_number && has_columns_with_expr {
             // row_idx will be moved to correct position in scan(), prepend here
             all_exprs.push(("file_row_number", row_idx()));
         }
@@ -150,26 +155,26 @@ impl Projection {
             }
             let column_id: usize = column_id.as_();
             let name = column_fields[column_id].name.as_str();
-            if !has_fn_columns {
+            if !has_columns_with_expr {
                 named_fields.push(name);
                 continue;
             }
 
             let column_field = &column_fields[column_id];
-            let expr = match &column_field.projection_fn {
+            let expr = match &column_field.projection_expr {
                 None => get_item(name, root()),
                 Some(func) => func.clone(),
             };
             all_exprs.push((name, expr));
         }
 
-        let projection = if has_fn_columns {
-            // If file_row_number was requested, it's in all_exprs as first
-            // element
+        let projection = if has_columns_with_expr {
+            // If has_file_row_number is true, we have already inserted
+            // file_row_number column to all_exprs (see line 141)
             pack(all_exprs, false.into())
         } else if has_file_row_number {
             let select = select(named_fields, root());
-            // Here we need to prepend it manually
+            // Here we need to prepend file_row_number column manually.
             // row_idx will be moved to correct position in scan()
             let row_idx_struct = pack([("file_row_number", row_idx())], false.into());
             merge([row_idx_struct, select])
@@ -272,7 +277,7 @@ pub fn extract_schema_from_dtype(dtype: &DType) -> VortexResult<Vec<DuckdbField>
             name: field_name.to_string(),
             logical_type,
             dtype: field_dtype,
-            projection_fn: None,
+            projection_expr: None,
         });
     }
     Ok(fields)
@@ -297,19 +302,19 @@ mod tests {
                 name: "".to_owned(),
                 logical_type: LogicalType::null(),
                 dtype: DType::Null,
-                projection_fn: None,
+                projection_expr: None,
             },
             DuckdbField {
                 name: "".to_owned(),
                 logical_type: LogicalType::null(),
                 dtype: DType::Null,
-                projection_fn: None,
+                projection_expr: None,
             },
             DuckdbField {
                 name: "".to_owned(),
                 logical_type: LogicalType::null(),
                 dtype: DType::Null,
-                projection_fn: None,
+                projection_expr: None,
             },
         ];
 
@@ -340,7 +345,7 @@ mod tests {
         assert_ne!(Projection::new(None, &ids, &fields).projection, root());
 
         // If any column has a projection expression, we can't use SELECT *
-        fields[0].projection_fn = Some(lit(true));
+        fields[0].projection_expr = Some(lit(true));
         let ids = [0, 1, 2];
         assert_ne!(Projection::new(None, &ids, &fields).projection, root());
     }

--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -46,6 +46,7 @@ use crate::SESSION;
 use crate::column_statistics::ColumnStatistics;
 use crate::column_statistics::ColumnStatisticsAggregate;
 use crate::convert::try_from_bound_expression;
+use crate::convert::try_from_projection_expression;
 use crate::duckdb::BindInputRef;
 use crate::duckdb::BindResultRef;
 use crate::duckdb::ClientContextRef;
@@ -429,6 +430,26 @@ pub fn pushdown_complex_filter(
     Ok(report_pushed)
 }
 
+pub fn pushdown_projection_expression(
+    bind_data: &mut TableFunctionBind,
+    expr: &ExpressionRef,
+    projection_id: usize,
+) -> VortexResult<bool> {
+    let field = &bind_data.column_fields[projection_id];
+    debug!(%expr, %projection_id, col_name=field.name, "pushing down projection expression");
+    match try_from_projection_expression(expr, field)? {
+        None => {
+            debug!(%expr, "failed to push down expression");
+            Ok(false)
+        }
+        Some(vx_expr) => {
+            debug!(%expr, "pushed down expression");
+            bind_data.column_fields[projection_id].projection_fn = Some(vx_expr);
+            Ok(true)
+        }
+    }
+}
+
 /// Get column-wise statistics. Available only if we're reading a single file.
 pub fn statistics(bind_data: &TableFunctionBind, column_index: usize) -> Option<ColumnStatistics> {
     let children = bind_data.data_source.children();
@@ -494,6 +515,19 @@ pub fn to_string(bind_data: &TableFunctionBind, map: &mut DuckdbStringMapRef) {
     if !bind_data.filter_exprs.is_empty() {
         let mut filters = bind_data.filter_exprs.iter().map(|f| format!("{f}"));
         map.push("Filters", &filters.join("\n"));
+    }
+    let projections = bind_data
+        .column_fields
+        .iter()
+        .filter_map(|field| {
+            field
+                .projection_fn
+                .as_ref()
+                .map(|expr| format!("{}: {expr}", field.name))
+        })
+        .join("\n");
+    if !projections.is_empty() {
+        map.push("SELECT projections", &projections);
     }
 }
 

--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -444,7 +444,7 @@ pub fn pushdown_projection_expression(
         }
         Some(vx_expr) => {
             debug!(%expr, "pushed down expression");
-            bind_data.column_fields[projection_id].projection_fn = Some(vx_expr);
+            bind_data.column_fields[projection_id].projection_expr = Some(vx_expr);
             Ok(true)
         }
     }
@@ -521,7 +521,7 @@ pub fn to_string(bind_data: &TableFunctionBind, map: &mut DuckdbStringMapRef) {
         .iter()
         .filter_map(|field| {
             field
-                .projection_fn
+                .projection_expr
                 .as_ref()
                 .map(|expr| format!("{}: {expr}", field.name))
         })

--- a/vortex-sqllogictest/slt/duckdb/projection_expression_pushdown.slt
+++ b/vortex-sqllogictest/slt/duckdb/projection_expression_pushdown.slt
@@ -1,0 +1,427 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+include ../setup.slt.no
+
+# str has storage_index=1. This tests cases where column_index (i.e. 0 in
+# SELECT strlen(str)) is different from storage_index.
+query I
+CREATE TABLE pep_test (before INTEGER, str VARCHAR, after INTEGER);
+----
+
+query I
+INSERT INTO pep_test VALUES (0, 'Hello', 0), (1, 'Hi', 1), (2, 'Hey', 2);
+----
+3
+
+query I
+COPY (SELECT * FROM pep_test) TO '$__TEST_DIR__/pe-pushdown.vortex';
+----
+3
+
+query T
+SELECT str FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY str;
+----
+Hello
+Hey
+Hi
+
+# strlen is pushed down with direct reads from vortex.
+# Vortex EXPLAIN output now has "SELECT projections" which indicates
+# pushdown was successful
+query TT
+EXPLAIN (FORMAT json) SELECT strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex';
+----
+<REGEX>:SELECT projections
+
+# we need an "order by" for test output to be deterministic
+query I
+SELECT strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY strlen(str);
+----
+2
+3
+5
+
+# explain: same for aliased columns
+query TT
+EXPLAIN (FORMAT json) SELECT strlen(str) AS l FROM '$__TEST_DIR__/pe-pushdown.vortex';
+----
+<REGEX>:SELECT projections
+
+query I
+SELECT strlen(str) AS l FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY strlen(str);
+----
+2
+3
+5
+
+# explain: strlen with filter using strlen
+query TT
+EXPLAIN (FORMAT json)
+SELECT strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex'
+WHERE strlen(str) > 2;
+----
+<REGEX>:SELECT projections
+
+query I
+SELECT strlen(str) AS l FROM '$__TEST_DIR__/pe-pushdown.vortex'
+WHERE strlen(str) > 2
+ORDER BY strlen(str);
+----
+3
+5
+
+# Same, but filter expression has multiple children
+query I
+SELECT strlen(str) AS l FROM '$__TEST_DIR__/pe-pushdown.vortex'
+WHERE strlen(str) * 2 > 4
+ORDER BY strlen(str);
+----
+3
+5
+
+query I
+SELECT strlen(str) AS l FROM '$__TEST_DIR__/pe-pushdown.vortex'
+WHERE len(str) * 2 > 4
+ORDER BY strlen(str);
+----
+3
+5
+
+# strlen with filter using len, no pushdown
+query I
+SELECT strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex'
+WHERE len(str) > 2
+ORDER BY strlen(str);
+----
+3
+5
+
+# explain: len() in WHERE conflicts with strlen() in SELECT, no pushdown
+query TT
+EXPLAIN (FORMAT json)
+SELECT strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex' WHERE len(str) > 2;
+----
+<!REGEX>:SELECT projections
+
+# strlen with str, no pushdown
+query TI
+SELECT str, strlen(str) AS l FROM '$__TEST_DIR__/pe-pushdown.vortex'
+WHERE strlen(str) > 3 ORDER BY str;
+----
+Hello 5
+
+# explain: bare str in SELECT conflicts with strlen(), no pushdown
+query TT
+EXPLAIN (FORMAT json)
+SELECT str, strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex';
+----
+<!REGEX>:SELECT projections
+
+
+# pushdown of prefix() not supported
+query B
+SELECT prefix(str, 'H') FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY str;
+----
+true
+true
+true
+
+# conflict on str, no pushdown.
+query TI
+SELECT str, strlen(str) AS l FROM '$__TEST_DIR__/pe-pushdown.vortex'
+WHERE strlen(str) > 3 ORDER BY str;
+----
+Hello 5
+
+# conflict in SELCECT, no pushdown
+query TI
+SELECT str, strlen(str) AS l FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY str;
+----
+Hello 5
+Hey 3
+Hi 2
+
+# same with aliased strlen()
+query IT
+SELECT strlen(str) AS l, str FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY str;
+----
+5 Hello
+3 Hey
+2 Hi
+
+# str as part of multi-arg ||, conflict
+query IT
+SELECT strlen(str) AS l, str || '!' AS s FROM '$__TEST_DIR__/pe-pushdown.vortex'
+ORDER BY l;
+----
+2 Hi!
+3 Hey!
+5 Hello!
+
+query TT
+EXPLAIN (FORMAT json)
+SELECT strlen(str), str || '!' FROM '$__TEST_DIR__/pe-pushdown.vortex';
+----
+<!REGEX>:SELECT projections
+
+# strlen() and a different multi-arg use of str (substr): no pushdown
+query IT
+SELECT strlen(str) AS l, substr(str, 1, 1) AS c FROM '$__TEST_DIR__/pe-pushdown.vortex'
+ORDER BY l;
+----
+2 H
+3 H
+5 H
+
+# fn -> cte
+query I
+SELECT strlen(str) FROM (SELECT str FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY str);
+----
+5
+3
+2
+
+# fn -> cte -> cte
+query I
+WITH cte1 AS (SELECT str FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY str),
+     cte2 AS (SELECT str from cte1)
+SELECT strlen(str) FROM cte2;
+----
+5
+3
+2
+
+# cte -> fn -> cte
+query TI
+WITH cte1 AS (SELECT str FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY str),
+     cte2 AS (SELECT str, strlen(str) as l from cte1)
+SELECT str, l FROM cte2;
+----
+Hello 5
+Hey 3
+Hi 2
+
+query I
+CREATE VIEW pe1 AS SELECT str FROM '$__TEST_DIR__/pe-pushdown.vortex';
+----
+
+query T
+SELECT str FROM pe1 ORDER BY str;
+----
+Hello
+Hey
+Hi
+
+query I
+SELECT strlen(str) FROM pe1 ORDER BY strlen(str);
+----
+2
+3
+5
+
+query TT
+EXPLAIN (FORMAT JSON)
+SELECT strlen(str) FROM pe1;
+----
+<REGEX>:SELECT projections
+
+# nested view
+query I
+CREATE VIEW pe2 AS SELECT str FROM pe1;
+----
+
+query T
+SELECT str FROM pe2 ORDER BY str;
+----
+Hello
+Hey
+Hi
+
+query I
+SELECT strlen(str) FROM pe2 ORDER BY strlen(str);
+----
+2
+3
+5
+
+query TI
+SELECT str, strlen(str) FROM pe2 ORDER BY str;
+----
+Hello 5
+Hey 3
+Hi 2
+
+# fn -> cte with fn -> cte
+query I
+WITH cte1 AS (SELECT str FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY str),
+     cte2 AS (SELECT str, strlen(str) as l from cte1)
+SELECT strlen(str) FROM cte2;
+----
+5
+3
+2
+
+query II
+SELECT before, strlen(str) AS l FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY before;
+----
+0 5
+1 2
+2 3
+
+query II
+SELECT strlen(str) AS l, after FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY after;
+----
+5 0
+2 1
+3 2
+
+# virtual column don't block pushdown
+query II
+SELECT strlen(str) AS l, file_row_number FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY l DESC;
+----
+5 0
+3 2
+2 1
+
+query II
+SELECT strlen(str) AS l, file_index FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY l DESC;
+----
+5 0
+3 0
+2 0
+
+query I
+SELECT strlen(str) AS l FROM pe2 ORDER BY l DESC;
+----
+5
+3
+2
+
+# no pushdown (two levels of indirection)
+query TI
+SELECT str, strlen(str) AS l FROM pe2 ORDER BY str;
+----
+Hello 5
+Hey 3
+Hi 2
+
+# explain: two levels of indirection, no pushdown
+query TT
+EXPLAIN (FORMAT JSON)
+SELECT strlen(str) FROM pe2;
+----
+<!REGEX>:SELECT projections
+
+# cte -> view -> pe2
+query I
+WITH cte AS (SELECT str FROM pe2)
+SELECT strlen(str) FROM cte ORDER BY str;
+----
+5
+3
+2
+
+# strlen(str) * 2 must be visited correctly in replace visitor
+query II
+SELECT strlen(str) AS a, strlen(str) * 2 AS b FROM pe1 ORDER BY a;
+----
+2 4
+3 6
+5 10
+
+# conflict in SELECT, no pushdown
+query II
+SELECT strlen(str) AS a, len(str) * 2 AS b FROM pe1 ORDER BY a;
+----
+2 4
+3 6
+5 10
+
+# constant comparison is pushed down as a complex filter so WHERE disappears.
+# This is only usage of str in SELECT so we push it down
+query TT
+EXPLAIN (FORMAT JSON)
+SELECT strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex'
+WHERE str != '';
+----
+<REGEX>:SELECT projections
+
+query I
+SELECT strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex'
+WHERE str != ''
+ORDER BY strlen(str);
+----
+2
+3
+5
+
+# prefix isn't pushed down as a complex filter so WHERE is not pushed down
+# although this is only usage of str in SELECT, we can't push strlen down
+# as there is usage in WHERE.
+# This also tests functions with multiple arguments using "str" inside
+query I
+SELECT strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex'
+WHERE prefix("str", 'H') > 0
+ORDER BY strlen(str);
+----
+2
+3
+5
+
+query I
+SELECT strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex'
+WHERE suffix(concat("str", 'y'), 'y') > 0
+ORDER BY strlen(str);
+----
+2
+3
+5
+
+# explain: prefix()/suffix() in WHERE are multi-arg uses of str, no pushdown
+query TT
+EXPLAIN (FORMAT JSON)
+SELECT strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex' WHERE prefix("str", 'H') > 0;
+----
+<!REGEX>:SELECT projections
+
+# conflict with concat(), no pushdown
+query I
+SELECT strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex'
+WHERE concat(str, str) = 'HelloHello'
+ORDER BY strlen(str);
+----
+5
+
+# both strlen()s are replaced correctly.
+query II
+SELECT strlen(str), strlen(str) * 2 FROM '$__TEST_DIR__/pe-pushdown.vortex'
+ORDER BY strlen(str);
+----
+2 4
+3 6
+5 10
+
+query TT
+EXPLAIN (FORMAT JSON)
+SELECT strlen(str), strlen(str) * 2 FROM '$__TEST_DIR__/pe-pushdown.vortex';
+----
+<REGEX>:SELECT projections
+
+query I
+SELECT strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex'
+WHERE str = 'Hello' ORDER BY strlen(str);
+----
+5
+
+query TT
+EXPLAIN (FORMAT json)
+SELECT strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex' WHERE str = 'Hello';
+----
+<REGEX>:SELECT projections
+
+query TT
+EXPLAIN (FORMAT json)
+SELECT strlen(str) FROM '$__TEST_DIR__/pe-pushdown.vortex' WHERE prefix(str, 'H');
+----
+<REGEX>:SELECT projections

--- a/vortex-sqllogictest/slt/duckdb/projection_expression_pushdown.slt
+++ b/vortex-sqllogictest/slt/duckdb/projection_expression_pushdown.slt
@@ -5,19 +5,14 @@ include ../setup.slt.no
 
 # str has storage_index=1. This tests cases where column_index (i.e. 0 in
 # SELECT strlen(str)) is different from storage_index.
-query I
+statement ok
 CREATE TABLE pep_test (before INTEGER, str VARCHAR, after INTEGER);
-----
 
-query I
+statement ok
 INSERT INTO pep_test VALUES (0, 'Hello', 0), (1, 'Hi', 1), (2, 'Hey', 2);
-----
-3
 
-query I
+statement ok
 COPY (SELECT * FROM pep_test) TO '$__TEST_DIR__/pe-pushdown.vortex';
-----
-3
 
 query T
 SELECT str FROM '$__TEST_DIR__/pe-pushdown.vortex' ORDER BY str;


### PR DESCRIPTION
- Rewrite duckdb query plan to push down expresions of form `SELECT fn(col) FROM '1.vortex'` to just `SELECT col FROM '1.vortex'` if "col" isn't used without fn in the query. 
- Add printing of pushed down functions as "SELECT projections".
- Push down `strlen` in SELECT and in WHERE.

Depends on #8371 and #8341 