### PR TITLE
Publish Parquet-Variant encoding

### DIFF
--- a/encodings/parquet-variant/Cargo.toml
+++ b/encodings/parquet-variant/Cargo.toml
@@ -12,7 +12,6 @@ readme = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
-publish = false
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Mark the parquet-variant encoding as published, so it'll be published as part of the next release.
