### PR TITLE
Fix sanitizer flags for vortex-ffi doctests in CI

### DIFF
--- a/.github/workflows/rust-instrumented.yml
+++ b/.github/workflows/rust-instrumented.yml
@@ -154,6 +154,11 @@ jobs:
         # TODO(myrrc): remove --no-default-features once we make Mimalloc opt-in
       - name: Run vortex-ffi tests with sanitizer
         run: |
+          # Doctests are compiled by rustdoc, which reads RUSTDOCFLAGS rather
+          # than RUSTFLAGS. Mirror the sanitizer flags so the doctest harness is
+          # built with the same -Zsanitizer value as its dependencies, otherwise
+          # rustc rejects the ABI mismatch.
+          RUSTDOCFLAGS="${RUSTFLAGS} ${{ matrix.sanitizer_flags }}" \
           RUSTFLAGS="${RUSTFLAGS} ${{ matrix.sanitizer_flags }}" \
           cargo +$NIGHTLY_TOOLCHAIN test --locked --no-default-features \
             --target x86_64-unknown-linux-gnu --no-fail-fast -Zbuild-std \


### PR DESCRIPTION
## Summary

When running `vortex-ffi` tests with sanitizers enabled in CI, doctests were failing due to an ABI mismatch. Doctests are compiled by `rustdoc`, which reads `RUSTDOCFLAGS` rather than `RUSTFLAGS`. Without the sanitizer flags in `RUSTDOCFLAGS`, the doctest harness was built with different compiler settings than its dependencies, causing `rustc` to reject the ABI mismatch.

This change mirrors the sanitizer flags to `RUSTDOCFLAGS` so the doctest harness is built with the same `-Zsanitizer` value as its dependencies.

## Testing

The fix will be validated by the existing `rust-instrumented` CI workflow, which runs the `vortex-ffi` tests with sanitizers enabled. The doctests should now compile and run successfully without ABI mismatch errors.

https://claude.ai/code/session_01F3PLB1BLD38qjmBezhSZQd