### PR TITLE
Optimize slice for dict and minor changes in other arrays

### DIFF
--- a/vortex-array/benches/slice_dict_primitive.rs
+++ b/vortex-array/benches/slice_dict_primitive.rs
@@ -8,7 +8,9 @@ use divan::Bencher;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::arrays::DictArray;
+use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::slice::SliceReduce;
 
 fn main() {
     divan::main();
@@ -41,6 +43,29 @@ fn slice_primitive_tight_loop(bencher: Bencher, len: usize) {
             let mut offset = 0;
             while offset + slice_len <= len {
                 out.push(arr.slice(offset..offset + slice_len).unwrap());
+                offset += slice_len;
+            }
+        });
+}
+
+#[divan::bench(args = ARRAY_LENGTHS)]
+fn slice_primitive_reduce_tight_loop(bencher: Bencher, len: usize) {
+    let arr = build_primitive(len);
+    let slice_len = 64;
+
+    let num_slices = len / slice_len;
+
+    bencher
+        .with_inputs(|| (&arr, Vec::<ArrayRef>::with_capacity(num_slices)))
+        .bench_refs(|(arr, out)| {
+            out.clear();
+            let mut offset = 0;
+            while offset + slice_len <= len {
+                out.push(
+                    <Primitive as SliceReduce>::slice(arr.as_view(), offset..offset + slice_len)
+                        .unwrap()
+                        .unwrap(),
+                );
                 offset += slice_len;
             }
         });

--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -47,13 +47,13 @@ use crate::arrays::VarBinView;
 use crate::buffer::BufferHandle;
 use crate::builders::ArrayBuilder;
 use crate::dtype::DType;
-use crate::dtype::Nullability;
 use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
 use crate::expr::stats::StatsProviderExt;
 use crate::matcher::Matcher;
 use crate::optimizer::ArrayOptimizer;
 use crate::scalar::Scalar;
+use crate::scalar::ScalarValue;
 use crate::stats::StatsSetRef;
 use crate::validity::Validity;
 
@@ -239,13 +239,10 @@ impl ArrayRef {
                     matches!(
                         stat,
                         Stat::IsConstant | Stat::IsSorted | Stat::IsStrictSorted
-                    ) && value.as_ref().as_exact().is_some_and(|v| {
-                        Scalar::try_new(DType::Bool(Nullability::NonNullable), Some(v.clone()))
-                            .vortex_expect("A stat that was expected to be a boolean stat was not")
-                            .as_bool()
-                            .value()
-                            .unwrap_or_default()
-                    })
+                    ) && value
+                        .as_ref()
+                        .as_exact()
+                        .is_some_and(|v| matches!(v, ScalarValue::Bool(true)))
                 }));
             });
         }

--- a/vortex-array/src/arrays/bool/compute/rules.rs
+++ b/vortex-array/src/arrays/bool/compute/rules.rs
@@ -47,12 +47,16 @@ impl ArrayParentReduceRule<Bool> for BoolMaskedValidityRule {
 
         // Merge the parent's validity mask into the child's validity
         // TODO(joe): make this lazy
-        Ok(Some(
-            BoolArray::new(
-                array.to_bit_buffer(),
-                array.validity()?.and(parent.validity()?)?,
-            )
-            .into_array(),
-        ))
+        // Safety:
+        // we know all elements are valid, the AND operation will fail if mismatched.
+        unsafe {
+            Ok(Some(
+                BoolArray::new_unchecked(
+                    array.to_bit_buffer(),
+                    array.validity()?.and(parent.validity()?)?,
+                )
+                .into_array(),
+            ))
+        }
     }
 }

--- a/vortex-array/src/arrays/bool/compute/rules.rs
+++ b/vortex-array/src/arrays/bool/compute/rules.rs
@@ -45,18 +45,15 @@ impl ArrayParentReduceRule<Bool> for BoolMaskedValidityRule {
             return Ok(None);
         }
 
+        let bit_buffer = array.to_bit_buffer();
         // Merge the parent's validity mask into the child's validity
         // TODO(joe): make this lazy
+        let validity = array.validity()?.and(parent.validity()?)?;
+
         // Safety:
         // we know all elements are valid, the AND operation will fail if mismatched.
-        unsafe {
-            Ok(Some(
-                BoolArray::new_unchecked(
-                    array.to_bit_buffer(),
-                    array.validity()?.and(parent.validity()?)?,
-                )
-                .into_array(),
-            ))
-        }
+        let array = unsafe { BoolArray::new_unchecked(bit_buffer, validity).into_array() };
+
+        Ok(Some(array))
     }
 }

--- a/vortex-array/src/arrays/bool/compute/slice.rs
+++ b/vortex-array/src/arrays/bool/compute/slice.rs
@@ -15,12 +15,16 @@ use crate::arrays::slice::SliceReduce;
 
 impl SliceReduce for Bool {
     fn slice(array: ArrayView<'_, Bool>, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
-        Ok(Some(
-            BoolArray::new(
-                array.to_bit_buffer().slice(range.clone()),
-                array.validity()?.slice(range)?,
-            )
-            .into_array(),
-        ))
+        // Safety:
+        // range is verified in the callers and is the same for both bits and validity.
+        unsafe {
+            Ok(Some(
+                BoolArray::new_unchecked(
+                    array.to_bit_buffer().slice(range.clone()),
+                    array.validity()?.slice(range)?,
+                )
+                .into_array(),
+            ))
+        }
     }
 }

--- a/vortex-array/src/arrays/bool/compute/slice.rs
+++ b/vortex-array/src/arrays/bool/compute/slice.rs
@@ -15,16 +15,13 @@ use crate::arrays::slice::SliceReduce;
 
 impl SliceReduce for Bool {
     fn slice(array: ArrayView<'_, Bool>, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
+        let bit_buffer = array.to_bit_buffer().slice(range.clone());
+        let validity = array.validity()?.slice(range)?;
+
         // Safety:
         // range is verified in the callers and is the same for both bits and validity.
-        unsafe {
-            Ok(Some(
-                BoolArray::new_unchecked(
-                    array.to_bit_buffer().slice(range.clone()),
-                    array.validity()?.slice(range)?,
-                )
-                .into_array(),
-            ))
-        }
+        let array = unsafe { BoolArray::new_unchecked(bit_buffer, validity).into_array() };
+
+        Ok(Some(array))
     }
 }

--- a/vortex-array/src/arrays/dict/compute/slice.rs
+++ b/vortex-array/src/arrays/dict/compute/slice.rs
@@ -30,6 +30,7 @@ impl SliceReduce for Dict {
         let sliced_code = if let Some(codes) = array.codes().as_typed::<Primitive>() {
             let sliced_code = <Primitive as SliceReduce>::slice(codes, range)?
                 .vortex_expect("Primitive SliceReduce should always return Some");
+            // Because we specialize the primitive branch here, we have to make sure to handle the stat inheritance
             inherit_slice_stats(array.codes(), &sliced_code);
             sliced_code
         } else {
@@ -41,9 +42,10 @@ impl SliceReduce for Dict {
             return slice_constant_code(array, code.scalar(), sliced_code.len());
         }
         // SAFETY: slicing the codes preserves invariants.
-        Ok(Some(
-            unsafe { DictArray::new_unchecked(sliced_code, array.values().clone()) }.into_array(),
-        ))
+        let array =
+            unsafe { DictArray::new_unchecked(sliced_code, array.values().clone()).into_array() };
+
+        Ok(Some(array))
     }
 }
 

--- a/vortex-array/src/arrays/dict/compute/slice.rs
+++ b/vortex-array/src/arrays/dict/compute/slice.rs
@@ -3,6 +3,7 @@
 
 use std::ops::Range;
 
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
@@ -12,35 +13,72 @@ use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrays::Dict;
 use crate::arrays::DictArray;
+use crate::arrays::Primitive;
 use crate::arrays::dict::DictArraySlotsExt;
 use crate::arrays::slice::SliceReduce;
+use crate::expr::stats::Precision;
+use crate::expr::stats::Stat;
 use crate::scalar::Scalar;
+use crate::scalar::ScalarValue;
 
 impl SliceReduce for Dict {
     fn slice(array: ArrayView<'_, Self>, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
-        let sliced_code = array.codes().slice(range)?;
+        if let Some(code) = array.codes().as_opt::<Constant>() {
+            return slice_constant_code(array, code.scalar(), range.len());
+        }
+
+        let sliced_code = if let Some(codes) = array.codes().as_typed::<Primitive>() {
+            let sliced_code = <Primitive as SliceReduce>::slice(codes, range)?
+                .vortex_expect("Primitive SliceReduce should always return Some");
+            inherit_slice_stats(array.codes(), &sliced_code);
+            sliced_code
+        } else {
+            array.codes().slice(range)?
+        };
+
         // TODO(joe): if the range is size 1 replace with a constant array
         if let Some(code) = sliced_code.as_opt::<Constant>() {
-            let code = code.scalar().as_primitive().as_::<usize>();
-            return if let Some(code) = code {
-                let values = array.values().slice(code..code + 1)?;
-                Ok(Some(
-                    DictArray::new(
-                        ConstantArray::new(0u8, sliced_code.len()).into_array(),
-                        values,
-                    )
-                    .into_array(),
-                ))
-            } else {
-                Ok(Some(
-                    ConstantArray::new(Scalar::null(array.dtype().clone()), sliced_code.len())
-                        .into_array(),
-                ))
-            };
+            return slice_constant_code(array, code.scalar(), sliced_code.len());
         }
         // SAFETY: slicing the codes preserves invariants.
         Ok(Some(
             unsafe { DictArray::new_unchecked(sliced_code, array.values().clone()) }.into_array(),
+        ))
+    }
+}
+
+fn inherit_slice_stats(source: &ArrayRef, sliced: &ArrayRef) {
+    source.statistics().with_iter(|iter| {
+        sliced
+            .statistics()
+            .inherit(iter.filter(|(stat, value)| is_inheritable_true_slice_stat(*stat, value)));
+    });
+}
+
+fn is_inheritable_true_slice_stat(stat: Stat, value: &Precision<ScalarValue>) -> bool {
+    matches!(
+        stat,
+        Stat::IsConstant | Stat::IsSorted | Stat::IsStrictSorted
+    ) && value
+        .as_ref()
+        .as_exact()
+        .is_some_and(|value| matches!(value, ScalarValue::Bool(true)))
+}
+
+fn slice_constant_code(
+    array: ArrayView<'_, Dict>,
+    code: &Scalar,
+    len: usize,
+) -> VortexResult<Option<ArrayRef>> {
+    let code = code.as_primitive().as_::<usize>();
+    if let Some(code) = code {
+        let values = array.values().slice(code..code + 1)?;
+        Ok(Some(
+            DictArray::new(ConstantArray::new(0u8, len).into_array(), values).into_array(),
+        ))
+    } else {
+        Ok(Some(
+            ConstantArray::new(Scalar::null(array.dtype().clone()), len).into_array(),
         ))
     }
 }

--- a/vortex-array/src/arrays/primitive/compute/slice.rs
+++ b/vortex-array/src/arrays/primitive/compute/slice.rs
@@ -11,19 +11,19 @@ use crate::array::ArrayView;
 use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::slice::SliceReduce;
-use crate::dtype::NativePType;
-use crate::match_each_native_ptype;
 
 impl SliceReduce for Primitive {
     fn slice(array: ArrayView<'_, Self>, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
-        let result = match_each_native_ptype!(array.ptype(), |T| {
-            PrimitiveArray::from_buffer_handle(
-                array.buffer_handle().slice_typed::<T>(range.clone()),
-                T::PTYPE,
-                array.validity()?.slice(range)?,
-            )
-            .into_array()
-        });
-        Ok(Some(result))
+        let byte_width = array.ptype().byte_width();
+        let byte_range = range.start * byte_width..range.end * byte_width;
+        let values = array.buffer_handle().slice(byte_range);
+        let validity = array.validity()?.slice(range)?;
+
+        // SAFETY: slicing an existing PrimitiveArray on element boundaries preserves the buffer
+        // alignment, ptype, length, and validity invariants.
+        Ok(Some(
+            unsafe { PrimitiveArray::new_unchecked_from_handle(values, array.ptype(), validity) }
+                .into_array(),
+        ))
     }
 }

--- a/vortex-array/src/arrays/primitive/compute/slice.rs
+++ b/vortex-array/src/arrays/primitive/compute/slice.rs
@@ -19,11 +19,13 @@ impl SliceReduce for Primitive {
         let values = array.buffer_handle().slice(byte_range);
         let validity = array.validity()?.slice(range)?;
 
-        // SAFETY: slicing an existing PrimitiveArray on element boundaries preserves the buffer
+        // SAFETY:
+        //slicing an existing PrimitiveArray on element boundaries preserves the buffer
         // alignment, ptype, length, and validity invariants.
-        Ok(Some(
-            unsafe { PrimitiveArray::new_unchecked_from_handle(values, array.ptype(), validity) }
-                .into_array(),
-        ))
+        let array = unsafe {
+            PrimitiveArray::new_unchecked_from_handle(values, array.ptype(), validity).into_array()
+        };
+
+        Ok(Some(array))
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/slice.rs
+++ b/vortex-array/src/arrays/varbinview/compute/slice.rs
@@ -16,16 +16,20 @@ use crate::arrays::varbinview::BinaryView;
 
 impl SliceReduce for VarBinView {
     fn slice(array: ArrayView<'_, Self>, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
-        Ok(Some(
-            VarBinViewArray::new_handle(
-                array
-                    .views_handle()
-                    .slice_typed::<BinaryView>(range.clone()),
-                Arc::clone(array.data_buffers()),
-                array.dtype().clone(),
-                array.validity()?.slice(range)?,
-            )
-            .into_array(),
-        ))
+        // Safety:
+        // range is validated within bounds, and is shared between all children.
+        unsafe {
+            Ok(Some(
+                VarBinViewArray::new_handle_unchecked(
+                    array
+                        .views_handle()
+                        .slice_typed::<BinaryView>(range.clone()),
+                    Arc::clone(array.data_buffers()),
+                    array.dtype().clone(),
+                    array.validity()?.slice(range)?,
+                )
+                .into_array(),
+            ))
+        }
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/slice.rs
+++ b/vortex-array/src/arrays/varbinview/compute/slice.rs
@@ -16,20 +16,19 @@ use crate::arrays::varbinview::BinaryView;
 
 impl SliceReduce for VarBinView {
     fn slice(array: ArrayView<'_, Self>, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
+        let views = array
+            .views_handle()
+            .slice_typed::<BinaryView>(range.clone());
+        let data_buffers = Arc::clone(array.data_buffers());
+        let dtype = array.dtype().clone();
+        let validity = array.validity()?.slice(range)?;
+
         // Safety:
         // range is validated within bounds, and is shared between all children.
-        unsafe {
-            Ok(Some(
-                VarBinViewArray::new_handle_unchecked(
-                    array
-                        .views_handle()
-                        .slice_typed::<BinaryView>(range.clone()),
-                    Arc::clone(array.data_buffers()),
-                    array.dtype().clone(),
-                    array.validity()?.slice(range)?,
-                )
-                .into_array(),
-            ))
-        }
+        let array = unsafe {
+            VarBinViewArray::new_handle_unchecked(views, data_buffers, dtype, validity).into_array()
+        };
+
+        Ok(Some(array))
     }
 }


### PR DESCRIPTION
## Summary

Includes a few optimizations around array slicing:
1. In the general case, no need to allocate a full new Scalar to check what stats can be inherited.
2. BoolArray, Primitive and VarBinView can use existing unchecked constructors. 
3. For dict - specialize primitive codes and call them directly instead of going through optimization.