### PR TITLE
Make ScalarFn array validity lazy when the function defines a validity expression

### DIFF
--- a/vortex-array/src/arrays/scalar_fn/vtable/validity.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/validity.rs
@@ -8,13 +8,16 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::VortexSessionExecute;
+use crate::array::Array;
 use crate::array::ArrayView;
 use crate::array::ValidityVTable;
+use crate::array::child_to_validity;
 use crate::arrays::ConstantArray;
 use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::scalar_fn::vtable::ArrayExpr;
 use crate::arrays::scalar_fn::vtable::FakeEq;
 use crate::arrays::scalar_fn::vtable::ScalarFn;
+use crate::dtype::Nullability;
 use crate::expr::Expression;
 use crate::expr::lit;
 use crate::legacy_session;
@@ -23,6 +26,39 @@ use crate::scalar_fn::VecExecutionArgs;
 use crate::scalar_fn::fns::literal::Literal;
 use crate::scalar_fn::fns::root::Root;
 use crate::validity::Validity;
+
+/// Convert an expression tree into a lazy array DAG without executing it.
+///
+/// This assumes all leaf expressions are either ArrayExpr (wrapping actual arrays) or Literals.
+fn expr_to_lazy_array(expr: &Expression, row_count: usize) -> VortexResult<ArrayRef> {
+    // Handle Root expression - this should not happen in validity expressions
+    if expr.is::<Root>() {
+        vortex_bail!("Root expression cannot be converted in validity context");
+    }
+
+    // Handle Literal expression - create a constant array
+    if expr.is::<Literal>() {
+        let scalar = expr.as_::<Literal>();
+        return Ok(ConstantArray::new(scalar.clone(), row_count).into_array());
+    }
+
+    // Handle ArrayExpr leaves - unwrap the array they hold
+    if expr.is::<ArrayExpr>() {
+        return Ok(expr.as_::<ArrayExpr>().0.clone());
+    }
+
+    // Recursively convert child expressions into lazy input arrays
+    let children: Vec<ArrayRef> = expr
+        .children()
+        .iter()
+        .map(|child| expr_to_lazy_array(child, row_count))
+        .collect::<VortexResult<_>>()?;
+
+    Ok(
+        Array::<ScalarFn>::try_new_with_len(expr.scalar_fn().clone(), children, row_count)?
+            .into_array(),
+    )
+}
 
 /// Execute an expression tree recursively.
 ///
@@ -71,15 +107,32 @@ impl ValidityVTable<ScalarFn> for ScalarFn {
             .collect::<VortexResult<_>>()?;
 
         let expr = Expression::try_new(array.scalar_fn().clone(), inputs)?;
-        let validity_expr = array.scalar_fn().validity(&expr)?;
 
-        #[allow(clippy::disallowed_methods)]
-        let ctx = &mut legacy_session().create_execution_ctx();
-        // Execute the validity expression. All leaves are ArrayExpr nodes.
-        Ok(Validity::Array(execute_expr(
-            &validity_expr,
-            array.len(),
-            ctx,
-        )?))
+        match array.scalar_fn().validity_opt(&expr)? {
+            Some(validity_expr) => {
+                // The function defines its validity as an expression over its inputs, so we can
+                // represent it as a lazy array DAG without executing anything. If the expression
+                // is already a constant it is folded back into AllValid/AllInvalid.
+                let validity_array = expr_to_lazy_array(&validity_expr, array.len())?;
+                Ok(child_to_validity(
+                    Some(&validity_array),
+                    Nullability::Nullable,
+                ))
+            }
+            None => {
+                // The function's validity can only be determined by executing the function
+                // itself (e.g. Kleene logic and/or). Representing that lazily would create a
+                // self-referential array (is_not_null over this very expression), so execute it
+                // eagerly instead.
+                let validity_expr = array.scalar_fn().validity(&expr)?;
+                #[allow(clippy::disallowed_methods)]
+                let ctx = &mut legacy_session().create_execution_ctx();
+                Ok(Validity::Array(execute_expr(
+                    &validity_expr,
+                    array.len(),
+                    ctx,
+                )?))
+            }
+        }
     }
 }

--- a/vortex-array/src/scalar_fn/erased.rs
+++ b/vortex-array/src/scalar_fn/erased.rs
@@ -132,10 +132,20 @@ impl ScalarFnRef {
 
     /// Transforms the expression into one representing the validity of this expression.
     pub fn validity(&self, expr: &Expression) -> VortexResult<Expression> {
-        Ok(self.0.validity(expr)?.unwrap_or_else(|| {
+        Ok(self.validity_opt(expr)?.unwrap_or_else(|| {
             // TODO(ngates): make validity a mandatory method on VTable to avoid this fallback.
             IsNotNull.new_expr(EmptyOptions, [expr.clone()])
         }))
+    }
+
+    /// Transforms the expression into one representing the validity of this expression,
+    /// returning `None` if the function does not define a validity expression.
+    ///
+    /// When `None` is returned, the validity can only be determined by executing the
+    /// expression itself (e.g. Kleene logic `and`/`or`), and [`Self::validity`] falls back to
+    /// `is_not_null` over the expression.
+    pub fn validity_opt(&self, expr: &Expression) -> VortexResult<Option<Expression>> {
+        self.0.validity(expr)
     }
 
     /// Execute the expression given the input arguments.


### PR DESCRIPTION
## Summary

Lazy validity for `ScalarFn` arrays. (Originally part of a 4-PR stack; the prerequisites — `definitely_no_nulls`/`execute_no_nulls` in #8333, the `mask_eq` semantics fix in #8334, and `definitely_all_null` — have all since landed on `develop`, so this PR is now a single standalone commit rebased onto current develop.)

Previously `ValidityVTable<ScalarFn>` always **eagerly executed** the validity expression via the legacy session. Now, when the scalar function provides a validity expression over its inputs, the expression is converted into a **lazy ScalarFn array DAG** instead:

- `Literal` nodes → `ConstantArray`
- `ArrayExpr` leaves → unwrap to the child array they hold
- interior nodes → lazy `ScalarFn` arrays via `Array::<ScalarFn>::try_new_with_len`
- constant results are folded back into `AllValid`/`AllInvalid` via `child_to_validity`

### Why the eager path remains for some functions

Functions that don't define a validity expression (Kleene `and`/`or`, where validity depends on the computed *values*) keep the eager path. The erased fallback for these is `is_not_null(expr)` — self-referential: lazily materializing it means resolving the validity of the inner node, which spawns another `is_not_null` DAG over a fresh copy of the same node, recursing without ever shrinking. This manifested as a stack overflow in element-wise execution paths (`execute_scalar` → `is_invalid` → `validity()`), caught by `test_bool_consistency`. The new `ScalarFnRef::validity_opt` exposes whether a function defines its own validity expression so the vtable can pick the right path.

## Checks

- `cargo nextest run -p vortex-array` (3197 passed)
- `cargo nextest run -p vortex-file -p vortex-layout -p vortex-scan -p vortex-btrblocks -p vortex-compressor -p vortex-datafusion -p vortex-fastlanes -p vortex-runend -p vortex-sparse -p vortex-fsst -p vortex-alp -p vortex-zstd -p vortex-pco -p vortex-datetime-parts -p vortex-ipc` (1429 passed)
- `cargo clippy -p vortex-array --all-targets`, `cargo +nightly fmt --check`
- Could not run `vortex-cuda`, `vortex-duckdb`, or lance-dependent benches locally (CUDA toolkit / DuckDB source download / `protoc` unavailable in the sandbox) — CI covers them.

https://claude.ai/code/session_01VPQ7dfZtijfrsjAipwXvEj