### PR TITLE
feat(vortex-geo): native Point extension type and GeoDistance scalar function

### DIFF
--- a/vortex-geo/src/extension/coordinate.rs
+++ b/vortex-geo/src/extension/coordinate.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Coordinate building blocks for geometry extension types: the `Struct<x, y, z?, m?>` storage,
-//! its [`Dimension`], and the decoded [`Coordinate`] value.
+//! Coordinate building blocks for geometry extension types: the
+//! `Struct<x: f64, y: f64, z?: f64, m?: f64>` storage, its [`Dimension`], and the decoded
+//! [`Coordinate`] value.
 //!
 //! The coordinate fields, where `?` marks an optional field, are:
 //! - `x` — longitude or easting
@@ -160,6 +161,11 @@ pub(crate) fn xy_columns(
         .storage_array()
         .clone()
         .execute::<StructArray>(ctx)?;
+    vortex_ensure!(
+        !storage.dtype().is_nullable(),
+        "point storage must be non-nullable to read unmasked x/y, was {}",
+        storage.dtype()
+    );
     let xs = storage
         .unmasked_field_by_name("x")?
         .clone()
@@ -173,7 +179,22 @@ pub(crate) fn xy_columns(
 
 #[cfg(test)]
 mod tests {
+    use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::ExtensionArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::arrays::StructArray;
+    use vortex_array::dtype::FieldNames;
+    use vortex_array::dtype::extension::ExtDType;
+    use vortex_array::session::ArraySession;
+    use vortex_array::validity::Validity;
+    use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
+
     use super::Coordinate;
+    use super::xy_columns;
+    use crate::extension::GeoMetadata;
+    use crate::extension::Point;
 
     /// Display emits WKT, including `z?`/`m?` when present.
     #[test]
@@ -191,5 +212,29 @@ mod tests {
             coordinate(Some(3.0), Some(4.0)).to_string(),
             "POINT ZM (1 2 3 4)"
         );
+    }
+
+    /// `xy_columns` reads the coordinate fields unmasked, so a nullable point column must be
+    /// rejected rather than decoding null rows as garbage ordinates.
+    #[test]
+    fn xy_columns_rejects_nullable_points() -> VortexResult<()> {
+        let session = VortexSession::empty().with::<ArraySession>();
+        let mut ctx = session.create_execution_ctx();
+
+        let storage = StructArray::try_new(
+            FieldNames::from(["x", "y"]),
+            vec![
+                PrimitiveArray::from_iter(vec![1.0f64]).into_array(),
+                PrimitiveArray::from_iter(vec![2.0f64]).into_array(),
+            ],
+            1,
+            Validity::AllValid,
+        )?
+        .into_array();
+        let dtype = ExtDType::<Point>::try_new(GeoMetadata { crs: None }, storage.dtype().clone())?;
+        let points = ExtensionArray::new(dtype.erased(), storage).into_array();
+
+        assert!(xy_columns(&points, &mut ctx).is_err());
+        Ok(())
     }
 }

--- a/vortex-geo/src/extension/coordinate.rs
+++ b/vortex-geo/src/extension/coordinate.rs
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Coordinate building blocks for geometry extension types: the `Struct<x, y, [z], [m]>` storage,
+//! Coordinate building blocks for geometry extension types: the `Struct<x, y, z?, m?>` storage,
 //! its [`Dimension`], and the decoded [`Coordinate`] value.
+//!
+//! The coordinate fields, where `?` marks an optional field, are:
+//! - `x` — longitude or easting
+//! - `y` — latitude or northing
+//! - `z?` — elevation
+//! - `m?` — measure: an arbitrary per-point value such as distance along a route or a timestamp
 
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -22,7 +28,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 
-/// Coordinate dimensions, matching GeoArrow. Field order is fixed: x, y, then z before m.
+/// Coordinate dimensions, matching GeoArrow. Field order is fixed: `x`, `y`, then `z` before `m`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Dimension {
     /// 2D: `x`, `y`.
@@ -48,7 +54,7 @@ impl Dimension {
     }
 }
 
-/// A decoded coordinate. `z`/`m` are `Some` iff the storage dimension includes them.
+/// A decoded coordinate. `z?`/`m?` are `Some` iff the storage dimension includes them.
 ///
 /// This is the native value produced when unpacking a [`Point`](crate::extension::Point) scalar;
 /// the rest of the coordinate machinery is crate-internal.
@@ -58,14 +64,14 @@ pub struct Coordinate {
     x: f64,
     /// The y (latitude/northing) ordinate.
     y: f64,
-    /// The optional z (elevation) ordinate.
+    /// The optional `z?` (elevation) ordinate.
     z: Option<f64>,
-    /// The optional m (measure) ordinate.
+    /// The optional `m?` (measure) ordinate.
     m: Option<f64>,
 }
 
 impl Coordinate {
-    /// A 2D coordinate (no `z`/`m`).
+    /// A 2D coordinate (`z?`/`m?` unset).
     pub fn xy(x: f64, y: f64) -> Self {
         Coordinate {
             x,
@@ -85,12 +91,12 @@ impl Coordinate {
         self.y
     }
 
-    /// The z (elevation) ordinate, if the dimension includes one.
+    /// The `z?` (elevation) ordinate, if the dimension includes one.
     pub fn z(&self) -> Option<f64> {
         self.z
     }
 
-    /// The m (measure) ordinate, if the dimension includes one.
+    /// The `m?` (measure) ordinate, if the dimension includes one.
     pub fn m(&self) -> Option<f64> {
         self.m
     }
@@ -123,7 +129,7 @@ pub(crate) fn coordinate_dimension(dtype: &DType) -> VortexResult<Dimension> {
     Dimension::from_field_names(&names)
 }
 
-/// Decode a [`Coordinate`] from a coordinate `Struct<x, y, [z], [m]>` scalar (`z`/`m` read iff
+/// Decode a [`Coordinate`] from a coordinate `Struct<x, y, z?, m?>` scalar (`z?`/`m?` read iff
 /// present, so the same decoder serves every dimension).
 pub(crate) fn coordinate_from_struct(scalar: &Scalar) -> VortexResult<Coordinate> {
     let fields = scalar.as_struct();
@@ -158,7 +164,7 @@ pub(crate) fn coordinate_from_scalar(scalar: &Scalar) -> VortexResult<Coordinate
 }
 
 /// Canonicalize a point column once and return its flat `x`/`y` `f64` columns. The bulk counterpart
-/// to [`coordinate_from_scalar`]; distances use only `x`/`y`, so `z`/`m` are ignored.
+/// to [`coordinate_from_scalar`]; distances use only `x`/`y`, so `z?`/`m?` are ignored.
 pub(crate) fn xy_columns(
     points: &ArrayRef,
     ctx: &mut ExecutionCtx,

--- a/vortex-geo/src/extension/coordinate.rs
+++ b/vortex-geo/src/extension/coordinate.rs
@@ -1,24 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! The coordinate building block shared by geometry extension types: the `Struct<x, y, [z], [m]>`
-//! storage, its [`Dimension`], the decoded [`Coordinate`] value, and the readers that decode it.
-//! `z`/`m` are optional, so all four GeoArrow dimensions share one value type — no third-party deps.
+//! Coordinate building blocks for geometry extension types: the `Struct<x, y, [z], [m]>` storage,
+//! its [`Dimension`], and the decoded [`Coordinate`] value.
 
 use std::fmt::Display;
 use std::fmt::Formatter;
 
 use vortex_array::ArrayRef;
-use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
+use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::StructArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::struct_::StructArrayExt;
 use vortex_array::dtype::DType;
-use vortex_array::dtype::FieldNames;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
-use vortex_array::dtype::StructFields;
 use vortex_array::scalar::Scalar;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -26,7 +24,7 @@ use vortex_error::vortex_err;
 
 /// Coordinate dimensions, matching GeoArrow. Field order is fixed: x, y, then z before m.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Dimension {
+pub(crate) enum Dimension {
     /// 2D: `x`, `y`.
     Xy,
     /// 3D with elevation: `x`, `y`, `z`.
@@ -38,18 +36,8 @@ pub enum Dimension {
 }
 
 impl Dimension {
-    /// The coordinate struct field names for this dimension, in GeoArrow order.
-    pub fn field_names(self) -> &'static [&'static str] {
-        match self {
-            Dimension::Xy => &["x", "y"],
-            Dimension::Xyz => &["x", "y", "z"],
-            Dimension::Xym => &["x", "y", "m"],
-            Dimension::Xyzm => &["x", "y", "z", "m"],
-        }
-    }
-
     /// Recover the dimension from a coordinate's field names, in GeoArrow order.
-    pub fn from_field_names(names: &[&str]) -> VortexResult<Dimension> {
+    pub(crate) fn from_field_names(names: &[&str]) -> VortexResult<Dimension> {
         Ok(match names {
             ["x", "y"] => Dimension::Xy,
             ["x", "y", "z"] => Dimension::Xyz,
@@ -61,16 +49,19 @@ impl Dimension {
 }
 
 /// A decoded coordinate. `z`/`m` are `Some` iff the storage dimension includes them.
+///
+/// This is the native value produced when unpacking a [`Point`](crate::extension::Point) scalar;
+/// the rest of the coordinate machinery is crate-internal.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Coordinate {
     /// The x (longitude/easting) ordinate.
-    pub x: f64,
+    x: f64,
     /// The y (latitude/northing) ordinate.
-    pub y: f64,
+    y: f64,
     /// The optional z (elevation) ordinate.
-    pub z: Option<f64>,
+    z: Option<f64>,
     /// The optional m (measure) ordinate.
-    pub m: Option<f64>,
+    m: Option<f64>,
 }
 
 impl Coordinate {
@@ -83,6 +74,26 @@ impl Coordinate {
             m: None,
         }
     }
+
+    /// The x (longitude/easting) ordinate.
+    pub fn x(&self) -> f64 {
+        self.x
+    }
+
+    /// The y (latitude/northing) ordinate.
+    pub fn y(&self) -> f64 {
+        self.y
+    }
+
+    /// The z (elevation) ordinate, if the dimension includes one.
+    pub fn z(&self) -> Option<f64> {
+        self.z
+    }
+
+    /// The m (measure) ordinate, if the dimension includes one.
+    pub fn m(&self) -> Option<f64> {
+        self.m
+    }
 }
 
 impl Display for Coordinate {
@@ -91,23 +102,9 @@ impl Display for Coordinate {
     }
 }
 
-/// The coordinate storage dtype for a dimension: `Struct<x, y, [z], [m]>` of non-nullable f64.
-pub fn coordinate_dtype(dim: Dimension, nullability: Nullability) -> DType {
-    let names = dim.field_names();
-    let fields = std::iter::repeat_n(
-        DType::Primitive(PType::F64, Nullability::NonNullable),
-        names.len(),
-    )
-    .collect::<Vec<_>>();
-    DType::Struct(
-        StructFields::new(FieldNames::from(names), fields),
-        nullability,
-    )
-}
-
 /// Validate that `dtype` is a coordinate struct of non-nullable `f64` fields, returning its
 /// [`Dimension`]. Any of the four GeoArrow dimensions validates.
-pub fn coordinate_dimension(dtype: &DType) -> VortexResult<Dimension> {
+pub(crate) fn coordinate_dimension(dtype: &DType) -> VortexResult<Dimension> {
     let DType::Struct(fields, _) = dtype else {
         vortex_bail!("coordinate storage must be a Struct, was {dtype}");
     };
@@ -153,7 +150,7 @@ pub(crate) fn coordinate_from_struct(scalar: &Scalar) -> VortexResult<Coordinate
 
 /// Decode a [`Coordinate`] from an extension-typed point scalar (unwrapped to its coordinate
 /// storage) or a bare coordinate `Struct` scalar. The per-row decode used by the distance fns.
-pub fn coordinate_from_scalar(scalar: &Scalar) -> VortexResult<Coordinate> {
+pub(crate) fn coordinate_from_scalar(scalar: &Scalar) -> VortexResult<Coordinate> {
     match scalar.dtype().as_extension_opt() {
         Some(_) => coordinate_from_struct(&scalar.as_extension().to_storage_scalar()),
         None => coordinate_from_struct(scalar),
@@ -161,28 +158,24 @@ pub fn coordinate_from_scalar(scalar: &Scalar) -> VortexResult<Coordinate> {
 }
 
 /// Canonicalize a point column once and return its flat `x`/`y` `f64` columns. The bulk counterpart
-/// to [`coordinate_from_scalar`]; distance is planar, so `z`/`m` are ignored.
+/// to [`coordinate_from_scalar`]; distances use only `x`/`y`, so `z`/`m` are ignored.
 pub(crate) fn xy_columns(
     points: &ArrayRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<(PrimitiveArray, PrimitiveArray)> {
     let storage = points
         .clone()
-        .execute::<Canonical>(ctx)?
-        .into_extension()
+        .execute::<ExtensionArray>(ctx)?
         .storage_array()
         .clone()
-        .execute::<Canonical>(ctx)?
-        .into_struct();
+        .execute::<StructArray>(ctx)?;
     let xs = storage
         .unmasked_field_by_name("x")?
         .clone()
-        .execute::<Canonical>(ctx)?
-        .into_primitive();
+        .execute::<PrimitiveArray>(ctx)?;
     let ys = storage
         .unmasked_field_by_name("y")?
         .clone()
-        .execute::<Canonical>(ctx)?
-        .into_primitive();
+        .execute::<PrimitiveArray>(ctx)?;
     Ok((xs, ys))
 }

--- a/vortex-geo/src/extension/coordinate.rs
+++ b/vortex-geo/src/extension/coordinate.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! The coordinate building block shared by geometry extension types: the `Struct<x, y, [z], [m]>`
+//! storage, its [`Dimension`], the decoded [`Coordinate`] value, and the readers that decode it.
+//! `z`/`m` are optional, so all four GeoArrow dimensions share one value type — no third-party deps.
+
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use vortex_array::ArrayRef;
+use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::extension::ExtensionArrayExt;
+use vortex_array::arrays::struct_::StructArrayExt;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::FieldNames;
+use vortex_array::dtype::Nullability;
+use vortex_array::dtype::PType;
+use vortex_array::dtype::StructFields;
+use vortex_array::scalar::Scalar;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
+
+/// Coordinate dimensions, matching GeoArrow. Field order is fixed: x, y, then z before m.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Dimension {
+    /// 2D: `x`, `y`.
+    Xy,
+    /// 3D with elevation: `x`, `y`, `z`.
+    Xyz,
+    /// 3D with a measure: `x`, `y`, `m`.
+    Xym,
+    /// 4D: `x`, `y`, `z`, `m`.
+    Xyzm,
+}
+
+impl Dimension {
+    /// The coordinate struct field names for this dimension, in GeoArrow order.
+    pub fn field_names(self) -> &'static [&'static str] {
+        match self {
+            Dimension::Xy => &["x", "y"],
+            Dimension::Xyz => &["x", "y", "z"],
+            Dimension::Xym => &["x", "y", "m"],
+            Dimension::Xyzm => &["x", "y", "z", "m"],
+        }
+    }
+
+    /// Recover the dimension from a coordinate's field names, in GeoArrow order.
+    pub fn from_field_names(names: &[&str]) -> VortexResult<Dimension> {
+        Ok(match names {
+            ["x", "y"] => Dimension::Xy,
+            ["x", "y", "z"] => Dimension::Xyz,
+            ["x", "y", "m"] => Dimension::Xym,
+            ["x", "y", "z", "m"] => Dimension::Xyzm,
+            _ => vortex_bail!("not a valid GeoArrow coordinate dimension: {names:?}"),
+        })
+    }
+}
+
+/// A decoded coordinate. `z`/`m` are `Some` iff the storage dimension includes them.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Coordinate {
+    /// The x (longitude/easting) ordinate.
+    pub x: f64,
+    /// The y (latitude/northing) ordinate.
+    pub y: f64,
+    /// The optional z (elevation) ordinate.
+    pub z: Option<f64>,
+    /// The optional m (measure) ordinate.
+    pub m: Option<f64>,
+}
+
+impl Coordinate {
+    /// A 2D coordinate (no `z`/`m`).
+    pub fn xy(x: f64, y: f64) -> Self {
+        Coordinate {
+            x,
+            y,
+            z: None,
+            m: None,
+        }
+    }
+}
+
+impl Display for Coordinate {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "POINT({} {})", self.x, self.y)
+    }
+}
+
+/// The coordinate storage dtype for a dimension: `Struct<x, y, [z], [m]>` of non-nullable f64.
+pub fn coordinate_dtype(dim: Dimension, nullability: Nullability) -> DType {
+    let names = dim.field_names();
+    let fields = std::iter::repeat_n(
+        DType::Primitive(PType::F64, Nullability::NonNullable),
+        names.len(),
+    )
+    .collect::<Vec<_>>();
+    DType::Struct(
+        StructFields::new(FieldNames::from(names), fields),
+        nullability,
+    )
+}
+
+/// Validate that `dtype` is a coordinate struct of non-nullable `f64` fields, returning its
+/// [`Dimension`]. Any of the four GeoArrow dimensions validates.
+pub fn coordinate_dimension(dtype: &DType) -> VortexResult<Dimension> {
+    let DType::Struct(fields, _) = dtype else {
+        vortex_bail!("coordinate storage must be a Struct, was {dtype}");
+    };
+    let names: Vec<&str> = fields.names().iter().map(|n| n.as_ref()).collect();
+    for (i, field) in fields.fields().enumerate() {
+        if !matches!(
+            field,
+            DType::Primitive(PType::F64, Nullability::NonNullable)
+        ) {
+            vortex_bail!(
+                "coordinate field {} must be non-nullable f64, was {field}",
+                names[i]
+            );
+        }
+    }
+    Dimension::from_field_names(&names)
+}
+
+/// Decode a [`Coordinate`] from a coordinate `Struct<x, y, [z], [m]>` scalar (`z`/`m` read iff
+/// present, so the same decoder serves every dimension).
+pub(crate) fn coordinate_from_struct(scalar: &Scalar) -> VortexResult<Coordinate> {
+    let fields = scalar.as_struct();
+    let required = |name: &str| -> VortexResult<f64> {
+        f64::try_from(
+            &fields
+                .field(name)
+                .ok_or_else(|| vortex_err!("coordinate missing {name}"))?,
+        )
+    };
+    let optional = |name: &str| -> VortexResult<Option<f64>> {
+        fields
+            .field(name)
+            .map(|value| f64::try_from(&value))
+            .transpose()
+    };
+    Ok(Coordinate {
+        x: required("x")?,
+        y: required("y")?,
+        z: optional("z")?,
+        m: optional("m")?,
+    })
+}
+
+/// Decode a [`Coordinate`] from an extension-typed point scalar (unwrapped to its coordinate
+/// storage) or a bare coordinate `Struct` scalar. The per-row decode used by the distance fns.
+pub fn coordinate_from_scalar(scalar: &Scalar) -> VortexResult<Coordinate> {
+    match scalar.dtype().as_extension_opt() {
+        Some(_) => coordinate_from_struct(&scalar.as_extension().to_storage_scalar()),
+        None => coordinate_from_struct(scalar),
+    }
+}
+
+/// Canonicalize a point column once and return its flat `x`/`y` `f64` columns. The bulk counterpart
+/// to [`coordinate_from_scalar`]; distance is planar, so `z`/`m` are ignored.
+pub(crate) fn xy_columns(
+    points: &ArrayRef,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<(PrimitiveArray, PrimitiveArray)> {
+    let storage = points
+        .clone()
+        .execute::<Canonical>(ctx)?
+        .into_extension()
+        .storage_array()
+        .clone()
+        .execute::<Canonical>(ctx)?
+        .into_struct();
+    let xs = storage
+        .unmasked_field_by_name("x")?
+        .clone()
+        .execute::<Canonical>(ctx)?
+        .into_primitive();
+    let ys = storage
+        .unmasked_field_by_name("y")?
+        .clone()
+        .execute::<Canonical>(ctx)?
+        .into_primitive();
+    Ok((xs, ys))
+}

--- a/vortex-geo/src/extension/coordinate.rs
+++ b/vortex-geo/src/extension/coordinate.rs
@@ -26,6 +26,7 @@ use vortex_array::dtype::PType;
 use vortex_array::scalar::Scalar;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 
 /// Coordinate dimensions, matching GeoArrow. Field order is fixed: `x`, `y`, then `z` before `m`.
@@ -61,13 +62,13 @@ impl Dimension {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Coordinate {
     /// The x (longitude/easting) ordinate.
-    x: f64,
+    pub x: f64,
     /// The y (latitude/northing) ordinate.
-    y: f64,
+    pub y: f64,
     /// The optional `z?` (elevation) ordinate.
-    z: Option<f64>,
+    pub z: Option<f64>,
     /// The optional `m?` (measure) ordinate.
-    m: Option<f64>,
+    pub m: Option<f64>,
 }
 
 impl Coordinate {
@@ -80,31 +81,16 @@ impl Coordinate {
             m: None,
         }
     }
-
-    /// The x (longitude/easting) ordinate.
-    pub fn x(&self) -> f64 {
-        self.x
-    }
-
-    /// The y (latitude/northing) ordinate.
-    pub fn y(&self) -> f64 {
-        self.y
-    }
-
-    /// The `z?` (elevation) ordinate, if the dimension includes one.
-    pub fn z(&self) -> Option<f64> {
-        self.z
-    }
-
-    /// The `m?` (measure) ordinate, if the dimension includes one.
-    pub fn m(&self) -> Option<f64> {
-        self.m
-    }
 }
 
 impl Display for Coordinate {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "POINT({} {})", self.x, self.y)
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+        match (self.z, self.m) {
+            (None, None) => write!(fmt, "POINT({} {})", self.x, self.y),
+            (Some(z), None) => write!(fmt, "POINT Z ({} {} {})", self.x, self.y, z),
+            (None, Some(m)) => write!(fmt, "POINT M ({} {} {})", self.x, self.y, m),
+            (Some(z), Some(m)) => write!(fmt, "POINT ZM ({} {} {} {})", self.x, self.y, z, m),
+        }
     }
 }
 
@@ -116,15 +102,14 @@ pub(crate) fn coordinate_dimension(dtype: &DType) -> VortexResult<Dimension> {
     };
     let names: Vec<&str> = fields.names().iter().map(|n| n.as_ref()).collect();
     for (i, field) in fields.fields().enumerate() {
-        if !matches!(
-            field,
-            DType::Primitive(PType::F64, Nullability::NonNullable)
-        ) {
-            vortex_bail!(
-                "coordinate field {} must be non-nullable f64, was {field}",
-                names[i]
-            );
-        }
+        vortex_ensure!(
+            matches!(
+                field,
+                DType::Primitive(PType::F64, Nullability::NonNullable)
+            ),
+            "coordinate field {} must be non-nullable f64, was {field}",
+            names[i]
+        );
     }
     Dimension::from_field_names(&names)
 }
@@ -157,8 +142,8 @@ pub(crate) fn coordinate_from_struct(scalar: &Scalar) -> VortexResult<Coordinate
 /// Decode a [`Coordinate`] from an extension-typed point scalar (unwrapped to its coordinate
 /// storage) or a bare coordinate `Struct` scalar. The per-row decode used by the distance fns.
 pub(crate) fn coordinate_from_scalar(scalar: &Scalar) -> VortexResult<Coordinate> {
-    match scalar.dtype().as_extension_opt() {
-        Some(_) => coordinate_from_struct(&scalar.as_extension().to_storage_scalar()),
+    match scalar.as_extension_opt() {
+        Some(ext_scalar) => coordinate_from_struct(&ext_scalar.to_storage_scalar()),
         None => coordinate_from_struct(scalar),
     }
 }
@@ -184,4 +169,27 @@ pub(crate) fn xy_columns(
         .clone()
         .execute::<PrimitiveArray>(ctx)?;
     Ok((xs, ys))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Coordinate;
+
+    /// Display emits WKT, including `z?`/`m?` when present.
+    #[test]
+    fn display_is_wkt() {
+        let coordinate = |z, m| Coordinate {
+            x: 1.0,
+            y: 2.0,
+            z,
+            m,
+        };
+        assert_eq!(coordinate(None, None).to_string(), "POINT(1 2)");
+        assert_eq!(coordinate(Some(3.0), None).to_string(), "POINT Z (1 2 3)");
+        assert_eq!(coordinate(None, Some(4.0)).to_string(), "POINT M (1 2 4)");
+        assert_eq!(
+            coordinate(Some(3.0), Some(4.0)).to_string(),
+            "POINT ZM (1 2 3 4)"
+        );
+    }
 }

--- a/vortex-geo/src/extension/coordinate.rs
+++ b/vortex-geo/src/extension/coordinate.rs
@@ -149,21 +149,31 @@ pub(crate) fn coordinate_from_scalar(scalar: &Scalar) -> VortexResult<Coordinate
     }
 }
 
-/// Canonicalize a point column once and return its flat `x`/`y` `f64` columns. The bulk counterpart
-/// to [`coordinate_from_scalar`]; distances use only `x`/`y`, so `z?`/`m?` are ignored.
-pub(crate) fn xy_columns(
+/// Validated, executed `x`/`y` columns of a point array. The bulk counterpart to [`Coordinate`];
+/// `z?`/`m?` are not executed.
+pub(crate) struct ParsedCoordinates {
+    /// The flat `f64` `x` column.
+    pub(crate) xs: PrimitiveArray,
+    /// The flat `f64` `y` column.
+    pub(crate) ys: PrimitiveArray,
+}
+
+/// Validate a point column's coordinate storage (layout and non-nullability) and execute its
+/// `x`/`y` columns.
+pub(crate) fn parse_storage(
     points: &ArrayRef,
     ctx: &mut ExecutionCtx,
-) -> VortexResult<(PrimitiveArray, PrimitiveArray)> {
+) -> VortexResult<ParsedCoordinates> {
     let storage = points
         .clone()
         .execute::<ExtensionArray>(ctx)?
         .storage_array()
         .clone()
         .execute::<StructArray>(ctx)?;
+    coordinate_dimension(storage.dtype())?;
     vortex_ensure!(
         !storage.dtype().is_nullable(),
-        "point storage must be non-nullable to read unmasked x/y, was {}",
+        "coordinate storage must be non-nullable to read unmasked ordinates, was {}",
         storage.dtype()
     );
     let xs = storage
@@ -174,7 +184,7 @@ pub(crate) fn xy_columns(
         .unmasked_field_by_name("y")?
         .clone()
         .execute::<PrimitiveArray>(ctx)?;
-    Ok((xs, ys))
+    Ok(ParsedCoordinates { xs, ys })
 }
 
 #[cfg(test)]
@@ -192,7 +202,7 @@ mod tests {
     use vortex_session::VortexSession;
 
     use super::Coordinate;
-    use super::xy_columns;
+    use super::parse_storage;
     use crate::extension::GeoMetadata;
     use crate::extension::Point;
 
@@ -214,10 +224,10 @@ mod tests {
         );
     }
 
-    /// `xy_columns` reads the coordinate fields unmasked, so a nullable point column must be
-    /// rejected rather than decoding null rows as garbage ordinates.
+    /// [`parse_storage`] reads the coordinate fields unmasked, so a nullable point column must
+    /// be rejected at parse time rather than decoding null rows as garbage ordinates.
     #[test]
-    fn xy_columns_rejects_nullable_points() -> VortexResult<()> {
+    fn parse_rejects_nullable_points() -> VortexResult<()> {
         let session = VortexSession::empty().with::<ArraySession>();
         let mut ctx = session.create_execution_ctx();
 
@@ -234,7 +244,7 @@ mod tests {
         let dtype = ExtDType::<Point>::try_new(GeoMetadata { crs: None }, storage.dtype().clone())?;
         let points = ExtensionArray::new(dtype.erased(), storage).into_array();
 
-        assert!(xy_columns(&points, &mut ctx).is_err());
+        assert!(parse_storage(&points, &mut ctx).is_err());
         Ok(())
     }
 }

--- a/vortex-geo/src/extension/mod.rs
+++ b/vortex-geo/src/extension/mod.rs
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+mod coordinate;
+mod point;
 mod wkb;
 
 use std::fmt::Display;
 
+pub(crate) use coordinate::xy_columns;
+pub use coordinate::*;
+pub use point::*;
 pub use wkb::*;
 
 /// Extension metadata that is common to all the geospatial extension types.

--- a/vortex-geo/src/extension/mod.rs
+++ b/vortex-geo/src/extension/mod.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-mod coordinate;
+pub(crate) mod coordinate;
 mod point;
 mod wkb;
 
 use std::fmt::Display;
 
-pub(crate) use coordinate::xy_columns;
-pub use coordinate::*;
 pub use point::*;
 pub use wkb::*;
 

--- a/vortex-geo/src/extension/point.rs
+++ b/vortex-geo/src/extension/point.rs
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 //! The [`Point`] geometry extension type (`vortex.geo.point`): a location stored columnarly as
-//! `Struct<x, y, [z], [m]>` of `f64`, tagged with [`GeoMetadata`] (CRS).
+//! `Struct<x, y, z?, m?>` of `f64`, tagged with [`GeoMetadata`] (CRS). `z?` is an optional
+//! elevation and `m?` an optional measure — an arbitrary per-point value such as distance along a
+//! route or a timestamp.
 
 use prost::Message;
 use vortex_array::dtype::extension::ExtDType;
@@ -17,7 +19,7 @@ use super::coordinate::Coordinate;
 use super::coordinate::coordinate_dimension;
 use super::coordinate::coordinate_from_struct;
 
-/// A single location: `geoarrow.point`, stored as `Struct<x, y, [z], [m]>` of `f64`.
+/// A single location: `geoarrow.point`, stored as `Struct<x, y, z?, m?>` of `f64`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct Point;
 
@@ -97,7 +99,7 @@ mod tests {
     }
 
     /// `Point` accepts every GeoArrow dimension; the canonical field names round-trip to their
-    /// dimension, so a z/m swap or a mislabel would be caught.
+    /// dimension, so a `z?`/`m?` swap or a mislabel would be caught.
     #[test]
     fn point_validates_every_dimension() -> VortexResult<()> {
         let cases = [

--- a/vortex-geo/src/extension/point.rs
+++ b/vortex-geo/src/extension/point.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! The [`Point`] geometry extension type (`vortex.geo.point`): a location stored columnarly as
+//! `Struct<x, y, [z], [m]>` of `f64`, tagged with [`GeoMetadata`] (CRS).
+
+use prost::Message;
+use vortex_array::dtype::extension::ExtDType;
+use vortex_array::dtype::extension::ExtId;
+use vortex_array::dtype::extension::ExtVTable;
+use vortex_array::scalar::Scalar;
+use vortex_array::scalar::ScalarValue;
+use vortex_error::VortexResult;
+
+use super::GeoMetadata;
+use super::coordinate::Coordinate;
+use super::coordinate::coordinate_dimension;
+use super::coordinate::coordinate_from_struct;
+
+/// A single location: `geoarrow.point`, stored as `Struct<x, y, [z], [m]>` of `f64`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct Point;
+
+impl ExtVTable for Point {
+    type Metadata = GeoMetadata;
+    type NativeValue<'a> = Coordinate;
+
+    fn id(&self) -> ExtId {
+        ExtId::new_static("vortex.geo.point")
+    }
+
+    fn serialize_metadata(&self, metadata: &Self::Metadata) -> VortexResult<Vec<u8>> {
+        Ok(metadata.encode_to_vec())
+    }
+
+    fn deserialize_metadata(&self, metadata: &[u8]) -> VortexResult<Self::Metadata> {
+        Ok(GeoMetadata::decode(metadata)?)
+    }
+
+    fn validate_dtype(ext_dtype: &ExtDType<Self>) -> VortexResult<()> {
+        coordinate_dimension(ext_dtype.storage_dtype()).map(|_| ())
+    }
+
+    fn unpack_native<'a>(
+        ext_dtype: &'a ExtDType<Self>,
+        storage_value: &'a ScalarValue,
+    ) -> VortexResult<Coordinate> {
+        let storage = Scalar::try_new(
+            ext_dtype.storage_dtype().clone(),
+            Some(storage_value.clone()),
+        )?;
+        coordinate_from_struct(&storage)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::ExtensionArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::arrays::StructArray;
+    use vortex_array::dtype::DType;
+    use vortex_array::dtype::Nullability;
+    use vortex_array::dtype::PType;
+    use vortex_array::dtype::extension::ExtDType;
+    use vortex_array::session::ArraySession;
+    use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
+
+    use super::Point;
+    use crate::extension::Coordinate;
+    use crate::extension::Dimension;
+    use crate::extension::GeoMetadata;
+    use crate::extension::coordinate_dimension;
+    use crate::extension::coordinate_dtype;
+    use crate::extension::coordinate_from_scalar;
+
+    fn geo_meta() -> GeoMetadata {
+        GeoMetadata {
+            crs: Some("EPSG:4326".to_string()),
+        }
+    }
+
+    /// `Point` accepts every GeoArrow dimension; the storage carries the canonical field names and
+    /// the dimension round-trips, so a z/m swap or a mislabel would be caught.
+    #[test]
+    fn point_validates_every_dimension() -> VortexResult<()> {
+        let cases = [
+            (Dimension::Xy, ["x", "y"].as_slice()),
+            (Dimension::Xyz, ["x", "y", "z"].as_slice()),
+            (Dimension::Xym, ["x", "y", "m"].as_slice()),
+            (Dimension::Xyzm, ["x", "y", "z", "m"].as_slice()),
+        ];
+        for (dim, expected_fields) in cases {
+            let storage = coordinate_dtype(dim, Nullability::NonNullable);
+            let DType::Struct(fields, _) = &storage else {
+                unreachable!("coordinate_dtype builds a struct");
+            };
+            let names: Vec<&str> = fields.names().iter().map(|n| n.as_ref()).collect();
+            assert_eq!(names.as_slice(), expected_fields);
+            assert_eq!(coordinate_dimension(&storage)?, dim);
+            ExtDType::<Point>::try_new(geo_meta(), storage)?;
+        }
+        Ok(())
+    }
+
+    /// Invalid storage is rejected at dtype construction: both non-struct storage and a struct whose
+    /// fields are not GeoArrow coordinates.
+    #[test]
+    fn point_rejects_invalid_storage() -> VortexResult<()> {
+        let primitive = DType::Primitive(PType::F64, Nullability::NonNullable);
+        assert!(ExtDType::<Point>::try_new(geo_meta(), primitive).is_err());
+
+        let wrong_fields = StructArray::from_fields(&[
+            ("a", PrimitiveArray::from_iter(vec![0.0f64]).into_array()),
+            ("b", PrimitiveArray::from_iter(vec![0.0f64]).into_array()),
+        ])?
+        .into_array();
+        assert!(ExtDType::<Point>::try_new(geo_meta(), wrong_fields.dtype().clone()).is_err());
+        Ok(())
+    }
+
+    /// A `Point` column round-trips through scalar execution back to the original coordinates.
+    #[test]
+    fn point_unpacks_coordinates() -> VortexResult<()> {
+        let session = VortexSession::empty().with::<ArraySession>();
+        let mut ctx = session.create_execution_ctx();
+
+        let storage = StructArray::from_fields(&[
+            (
+                "x",
+                PrimitiveArray::from_iter(vec![1.0f64, -111.7610]).into_array(),
+            ),
+            (
+                "y",
+                PrimitiveArray::from_iter(vec![2.0f64, 34.8697]).into_array(),
+            ),
+        ])?
+        .into_array();
+        let dtype = ExtDType::<Point>::try_new(geo_meta(), storage.dtype().clone())?;
+        let points = ExtensionArray::new(dtype.erased(), storage).into_array();
+
+        assert_eq!(
+            coordinate_from_scalar(&points.execute_scalar(0, &mut ctx)?)?,
+            Coordinate::xy(1.0, 2.0)
+        );
+        assert_eq!(
+            coordinate_from_scalar(&points.execute_scalar(1, &mut ctx)?)?,
+            Coordinate::xy(-111.7610, 34.8697)
+        );
+        Ok(())
+    }
+}

--- a/vortex-geo/src/extension/point.rs
+++ b/vortex-geo/src/extension/point.rs
@@ -61,20 +61,21 @@ mod tests {
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::StructArray;
     use vortex_array::dtype::DType;
+    use vortex_array::dtype::FieldNames;
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
+    use vortex_array::dtype::StructFields;
     use vortex_array::dtype::extension::ExtDType;
     use vortex_array::session::ArraySession;
     use vortex_error::VortexResult;
     use vortex_session::VortexSession;
 
     use super::Point;
-    use crate::extension::Coordinate;
-    use crate::extension::Dimension;
     use crate::extension::GeoMetadata;
-    use crate::extension::coordinate_dimension;
-    use crate::extension::coordinate_dtype;
-    use crate::extension::coordinate_from_scalar;
+    use crate::extension::coordinate::Coordinate;
+    use crate::extension::coordinate::Dimension;
+    use crate::extension::coordinate::coordinate_dimension;
+    use crate::extension::coordinate::coordinate_from_scalar;
 
     fn geo_meta() -> GeoMetadata {
         GeoMetadata {
@@ -82,8 +83,21 @@ mod tests {
         }
     }
 
-    /// `Point` accepts every GeoArrow dimension; the storage carries the canonical field names and
-    /// the dimension round-trips, so a z/m swap or a mislabel would be caught.
+    /// A coordinate storage dtype with the given field names, non-nullable `f64` per field.
+    fn coordinate_dtype(names: &[&'static str]) -> DType {
+        let fields = std::iter::repeat_n(
+            DType::Primitive(PType::F64, Nullability::NonNullable),
+            names.len(),
+        )
+        .collect::<Vec<_>>();
+        DType::Struct(
+            StructFields::new(FieldNames::from(names), fields),
+            Nullability::NonNullable,
+        )
+    }
+
+    /// `Point` accepts every GeoArrow dimension; the canonical field names round-trip to their
+    /// dimension, so a z/m swap or a mislabel would be caught.
     #[test]
     fn point_validates_every_dimension() -> VortexResult<()> {
         let cases = [
@@ -92,13 +106,8 @@ mod tests {
             (Dimension::Xym, ["x", "y", "m"].as_slice()),
             (Dimension::Xyzm, ["x", "y", "z", "m"].as_slice()),
         ];
-        for (dim, expected_fields) in cases {
-            let storage = coordinate_dtype(dim, Nullability::NonNullable);
-            let DType::Struct(fields, _) = &storage else {
-                unreachable!("coordinate_dtype builds a struct");
-            };
-            let names: Vec<&str> = fields.names().iter().map(|n| n.as_ref()).collect();
-            assert_eq!(names.as_slice(), expected_fields);
+        for (dim, names) in cases {
+            let storage = coordinate_dtype(names);
             assert_eq!(coordinate_dimension(&storage)?, dim);
             ExtDType::<Point>::try_new(geo_meta(), storage)?;
         }

--- a/vortex-geo/src/lib.rs
+++ b/vortex-geo/src/lib.rs
@@ -5,17 +5,25 @@ use std::sync::Arc;
 
 use vortex_array::arrow::ArrowSessionExt;
 use vortex_array::dtype::session::DTypeSessionExt;
+use vortex_array::scalar_fn::session::ScalarFnSessionExt;
 use vortex_session::VortexSession;
 
+use crate::extension::Point;
 use crate::extension::WellKnownBinary;
+use crate::scalar_fn::GeoDistance;
 
 pub mod extension;
+pub mod scalar_fn;
 /// Set up a session with support for geospatial extension types, encodings and layouts.
 pub fn initialize(session: &VortexSession) {
-    // register geospatial extension types
+    // Register the geospatial extension types.
     session.dtypes().register(WellKnownBinary);
     session.arrow().register_exporter(Arc::new(WellKnownBinary));
     session.arrow().register_importer(Arc::new(WellKnownBinary));
+    session.dtypes().register(Point);
+
+    // Register the geometry scalar functions.
+    session.scalar_fns().register(GeoDistance);
 }
 
 #[cfg(test)]

--- a/vortex-geo/src/lib.rs
+++ b/vortex-geo/src/lib.rs
@@ -10,7 +10,7 @@ use vortex_session::VortexSession;
 
 use crate::extension::Point;
 use crate::extension::WellKnownBinary;
-use crate::scalar_fn::GeoDistance;
+use crate::scalar_fn::distance::GeoDistance;
 
 pub mod extension;
 pub mod scalar_fn;

--- a/vortex-geo/src/scalar_fn/distance.rs
+++ b/vortex-geo/src/scalar_fn/distance.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Planar distance between the paired points of two columns.
+
+use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::ScalarFnArray;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::Nullability;
+use vortex_array::dtype::PType;
+use vortex_array::scalar_fn::Arity;
+use vortex_array::scalar_fn::ChildName;
+use vortex_array::scalar_fn::EmptyOptions;
+use vortex_array::scalar_fn::ExecutionArgs;
+use vortex_array::scalar_fn::ScalarFnId;
+use vortex_array::scalar_fn::ScalarFnVTable;
+use vortex_array::scalar_fn::TypedScalarFnInstance;
+use vortex_error::VortexResult;
+use vortex_session::VortexSession;
+
+use crate::extension::xy_columns;
+
+/// Planar Euclidean distance between `(ax, ay)` and `(bx, by)`.
+fn euclidean_distance(ax: f64, ay: f64, bx: f64, by: f64) -> f64 {
+    let dx = ax - bx;
+    let dy = ay - by;
+    (dx * dx + dy * dy).sqrt()
+}
+
+/// Expression computing the planar distance between the paired points of two columns. A constant
+/// query point is just a [`ConstantArray`](vortex_array::arrays::ConstantArray) operand.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct GeoDistance;
+
+impl GeoDistance {
+    /// A lazy `ScalarFnArray` computing the distance between each row of `a` and `b`.
+    pub fn try_new_array(a: ArrayRef, b: ArrayRef, len: usize) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(
+            TypedScalarFnInstance::new(GeoDistance, EmptyOptions).erased(),
+            vec![a, b],
+            len,
+        )
+    }
+}
+
+impl ScalarFnVTable for GeoDistance {
+    type Options = EmptyOptions;
+
+    fn id(&self) -> ScalarFnId {
+        ScalarFnId::new("vortex.geo.distance")
+    }
+
+    fn serialize(&self, _: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
+        Ok(Some(vec![]))
+    }
+
+    fn deserialize(&self, _: &[u8], _: &VortexSession) -> VortexResult<Self::Options> {
+        Ok(EmptyOptions)
+    }
+
+    fn arity(&self, _: &Self::Options) -> Arity {
+        Arity::Exact(2)
+    }
+
+    fn child_name(&self, _: &Self::Options, child_idx: usize) -> ChildName {
+        match child_idx {
+            0 => ChildName::from("a"),
+            1 => ChildName::from("b"),
+            _ => unreachable!("distance has exactly two children"),
+        }
+    }
+
+    fn return_dtype(&self, _: &Self::Options, _: &[DType]) -> VortexResult<DType> {
+        Ok(DType::Primitive(PType::F64, Nullability::NonNullable))
+    }
+
+    fn execute(
+        &self,
+        _: &Self::Options,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        // Bulk path: one tight loop over the flat x/y slices, straight into the output buffer.
+        let (ax, ay) = xy_columns(&args.get(0)?, ctx)?;
+        let (bx, by) = xy_columns(&args.get(1)?, ctx)?;
+        let a = ax.as_slice::<f64>().iter().zip(ay.as_slice::<f64>());
+        let b = bx.as_slice::<f64>().iter().zip(by.as_slice::<f64>());
+        let distances = a
+            .zip(b)
+            .map(|((&ax, &ay), (&bx, &by))| euclidean_distance(ax, ay, bx, by));
+        Ok(PrimitiveArray::from_iter(distances).into_array())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_array::ArrayRef;
+    use vortex_array::ExecutionCtx;
+    use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::ConstantArray;
+    use vortex_array::arrays::ExtensionArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::arrays::StructArray;
+    use vortex_array::dtype::extension::ExtDType;
+    use vortex_array::session::ArraySession;
+    use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
+
+    use super::GeoDistance;
+    use super::euclidean_distance;
+    use crate::extension::GeoMetadata;
+    use crate::extension::Point;
+
+    /// A `Point` column (CRS `EPSG:4326`) over the given x/y coordinates.
+    fn point_column(xs: Vec<f64>, ys: Vec<f64>) -> VortexResult<ArrayRef> {
+        let storage = StructArray::from_fields(&[
+            ("x", PrimitiveArray::from_iter(xs).into_array()),
+            ("y", PrimitiveArray::from_iter(ys).into_array()),
+        ])?
+        .into_array();
+        let metadata = GeoMetadata {
+            crs: Some("EPSG:4326".to_string()),
+        };
+        let dtype = ExtDType::<Point>::try_new(metadata, storage.dtype().clone())?;
+        Ok(ExtensionArray::new(dtype.erased(), storage).into_array())
+    }
+
+    /// A constant `Point` column of length `len`, every row at `(x, y)`.
+    fn point_constant(
+        x: f64,
+        y: f64,
+        len: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let single = point_column(vec![x], vec![y])?.execute_scalar(0, ctx)?;
+        Ok(ConstantArray::new(single, len).into_array())
+    }
+
+    /// The kernel computes planar Euclidean distance (the 3–4–5 triangle).
+    #[test]
+    fn euclidean_distance_is_planar() {
+        assert_eq!(euclidean_distance(0.0, 0.0, 3.0, 4.0), 5.0);
+        assert_eq!(euclidean_distance(1.5, -1.5, 1.5, -1.5), 0.0);
+    }
+
+    /// `GeoDistance` returns the per-row distance between two point columns (here the second is a
+    /// constant query point).
+    #[test]
+    fn distance_over_points() -> VortexResult<()> {
+        let session = VortexSession::empty().with::<ArraySession>();
+        let mut ctx = session.create_execution_ctx();
+
+        let a = point_column(vec![0.0, 3.0, 0.0, 3.0], vec![0.0, 0.0, 4.0, 4.0])?;
+        let b = point_constant(0.0, 0.0, 4, &mut ctx)?;
+        let distance = GeoDistance::try_new_array(a, b, 4)?.into_array();
+
+        let got: Vec<f64> = (0..4)
+            .map(|idx| f64::try_from(&distance.execute_scalar(idx, &mut ctx)?))
+            .collect::<VortexResult<_>>()?;
+        assert_eq!(got, vec![0.0, 3.0, 4.0, 5.0]);
+        Ok(())
+    }
+}

--- a/vortex-geo/src/scalar_fn/distance.rs
+++ b/vortex-geo/src/scalar_fn/distance.rs
@@ -6,6 +6,7 @@
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::ScalarFnArray;
@@ -93,19 +94,19 @@ impl ScalarFnVTable for GeoDistance {
     ) -> VortexResult<ArrayRef> {
         let a = args.get(0)?;
         let b = args.get(1)?;
-        match (a.as_constant(), b.as_constant()) {
+        match (a.as_opt::<Constant>(), b.as_opt::<Constant>()) {
             (Some(qa), Some(qb)) => {
-                let qa = coordinate_from_scalar(&qa)?;
-                let qb = coordinate_from_scalar(&qb)?;
-                let distance = euclidean_distance(qa.x(), qa.y(), qb.x(), qb.y());
+                let qa = coordinate_from_scalar(qa.scalar())?;
+                let qb = coordinate_from_scalar(qb.scalar())?;
+                let distance = euclidean_distance(qa.x, qa.y, qb.x, qb.y);
                 Ok(ConstantArray::new(
                     Scalar::primitive(distance, Nullability::NonNullable),
                     a.len(),
                 )
                 .into_array())
             }
-            (Some(query), None) => distances_to_constant(&b, &query, ctx),
-            (None, Some(query)) => distances_to_constant(&a, &query, ctx),
+            (Some(query), None) => distances_to_constant(&b, query.scalar(), ctx),
+            (None, Some(query)) => distances_to_constant(&a, query.scalar(), ctx),
             (None, None) => {
                 let (axs, ays) = xy_columns(&a, ctx)?;
                 let (bxs, bys) = xy_columns(&b, ctx)?;
@@ -134,7 +135,7 @@ fn distances_to_constant(
         .as_slice::<f64>()
         .iter()
         .zip(ys.as_slice::<f64>())
-        .map(|(&x, &y)| euclidean_distance(x, y, query.x(), query.y()));
+        .map(|(&x, &y)| euclidean_distance(x, y, query.x, query.y));
     Ok(PrimitiveArray::from_iter(distances).into_array())
 }
 

--- a/vortex-geo/src/scalar_fn/distance.rs
+++ b/vortex-geo/src/scalar_fn/distance.rs
@@ -25,7 +25,7 @@ use vortex_error::VortexResult;
 use vortex_session::VortexSession;
 
 use crate::extension::coordinate::coordinate_from_scalar;
-use crate::extension::coordinate::xy_columns;
+use crate::extension::coordinate::parse_storage;
 
 /// Straight-line (L2) distance between `(ax, ay)` and `(bx, by)`.
 fn euclidean_distance(ax: f64, ay: f64, bx: f64, by: f64) -> f64 {
@@ -108,13 +108,20 @@ impl ScalarFnVTable for GeoDistance {
             (Some(query), None) => distances_to_constant(&b, query.scalar(), ctx),
             (None, Some(query)) => distances_to_constant(&a, query.scalar(), ctx),
             (None, None) => {
-                let (axs, ays) = xy_columns(&a, ctx)?;
-                let (bxs, bys) = xy_columns(&b, ctx)?;
-                let distances = axs
+                let a_coords = parse_storage(&a, ctx)?;
+                let b_coords = parse_storage(&b, ctx)?;
+                let distances = a_coords
+                    .xs
                     .as_slice::<f64>()
                     .iter()
-                    .zip(ays.as_slice::<f64>())
-                    .zip(bxs.as_slice::<f64>().iter().zip(bys.as_slice::<f64>()))
+                    .zip(a_coords.ys.as_slice::<f64>())
+                    .zip(
+                        b_coords
+                            .xs
+                            .as_slice::<f64>()
+                            .iter()
+                            .zip(b_coords.ys.as_slice::<f64>()),
+                    )
                     .map(|((&ax, &ay), (&bx, &by))| euclidean_distance(ax, ay, bx, by));
                 Ok(PrimitiveArray::from_iter(distances).into_array())
             }
@@ -130,11 +137,12 @@ fn distances_to_constant(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let query = coordinate_from_scalar(query)?;
-    let (xs, ys) = xy_columns(points, ctx)?;
-    let distances = xs
+    let coords = parse_storage(points, ctx)?;
+    let distances = coords
+        .xs
         .as_slice::<f64>()
         .iter()
-        .zip(ys.as_slice::<f64>())
+        .zip(coords.ys.as_slice::<f64>())
         .map(|(&x, &y)| euclidean_distance(x, y, query.x, query.y));
     Ok(PrimitiveArray::from_iter(distances).into_array())
 }

--- a/vortex-geo/src/scalar_fn/distance.rs
+++ b/vortex-geo/src/scalar_fn/distance.rs
@@ -34,7 +34,7 @@ fn euclidean_distance(ax: f64, ay: f64, bx: f64, by: f64) -> f64 {
 }
 
 /// Straight-line (Euclidean) distance between two point operands — "planar" distance in GIS terms
-/// (e.g. PostGIS `ST_Distance`). No geodesic correction, and `z`/`m` are ignored.
+/// (e.g. PostGIS `ST_Distance`). No geodesic correction, and `z?`/`m?` are ignored.
 ///
 /// The operands are two point columns of equal length; either (or both) may be constant, in which
 /// case the constant query point is decoded once and broadcast.

--- a/vortex-geo/src/scalar_fn/distance.rs
+++ b/vortex-geo/src/scalar_fn/distance.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Planar distance between the paired points of two columns.
+//! Planar distance from a point column to a constant query point.
 
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
@@ -19,8 +19,10 @@ use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_array::scalar_fn::TypedScalarFnInstance;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 use vortex_session::VortexSession;
 
+use crate::extension::coordinate_from_scalar;
 use crate::extension::xy_columns;
 
 /// Planar Euclidean distance between `(ax, ay)` and `(bx, by)`.
@@ -30,14 +32,17 @@ fn euclidean_distance(ax: f64, ay: f64, bx: f64, by: f64) -> f64 {
     (dx * dx + dy * dy).sqrt()
 }
 
-/// Expression computing the planar distance between the paired points of two columns. A constant
-/// query point is just a [`ConstantArray`](vortex_array::arrays::ConstantArray) operand.
+/// Planar distance from each point in a point column to a single constant query point. The first
+/// operand is the point column, the second the constant query point; column-to-column distance is
+/// not supported.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct GeoDistance;
 
 impl GeoDistance {
-    /// A lazy `ScalarFnArray` computing the distance between each row of `a` and `b`.
-    pub fn try_new_array(a: ArrayRef, b: ArrayRef, len: usize) -> VortexResult<ScalarFnArray> {
+    /// A lazy `ScalarFnArray` computing the distance from each row of the point column `a` to the
+    /// constant query point `b`. The output length is taken from `a`.
+    pub fn try_new_array(a: ArrayRef, b: ArrayRef) -> VortexResult<ScalarFnArray> {
+        let len = a.len();
         ScalarFnArray::try_new(
             TypedScalarFnInstance::new(GeoDistance, EmptyOptions).erased(),
             vec![a, b],
@@ -83,14 +88,18 @@ impl ScalarFnVTable for GeoDistance {
         args: &dyn ExecutionArgs,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        // Bulk path: one tight loop over the flat x/y slices, straight into the output buffer.
-        let (ax, ay) = xy_columns(&args.get(0)?, ctx)?;
-        let (bx, by) = xy_columns(&args.get(1)?, ctx)?;
-        let a = ax.as_slice::<f64>().iter().zip(ay.as_slice::<f64>());
-        let b = bx.as_slice::<f64>().iter().zip(by.as_slice::<f64>());
-        let distances = a
-            .zip(b)
-            .map(|((&ax, &ay), (&bx, &by))| euclidean_distance(ax, ay, bx, by));
+        // `a` is the point column; `b` is the constant query point, decoded once and broadcast.
+        let points = args.get(0)?;
+        let Some(query) = args.get(1)?.as_constant() else {
+            vortex_bail!("GeoDistance requires a constant query point as its second operand");
+        };
+        let query = coordinate_from_scalar(&query)?;
+        let (xs, ys) = xy_columns(&points, ctx)?;
+        let distances = xs
+            .as_slice::<f64>()
+            .iter()
+            .zip(ys.as_slice::<f64>())
+            .map(|(&x, &y)| euclidean_distance(x, y, query.x, query.y));
         Ok(PrimitiveArray::from_iter(distances).into_array())
     }
 }
@@ -98,6 +107,7 @@ impl ScalarFnVTable for GeoDistance {
 #[cfg(test)]
 mod tests {
     use vortex_array::ArrayRef;
+    use vortex_array::Canonical;
     use vortex_array::ExecutionCtx;
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
@@ -140,6 +150,15 @@ mod tests {
         Ok(ConstantArray::new(single, len).into_array())
     }
 
+    /// Execute a `GeoDistance` array and read back its per-row `f64` distances.
+    fn distances(distance: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Vec<f64>> {
+        Ok(distance
+            .execute::<Canonical>(ctx)?
+            .into_primitive()
+            .as_slice::<f64>()
+            .to_vec())
+    }
+
     /// The kernel computes planar Euclidean distance (the 3–4–5 triangle).
     #[test]
     fn euclidean_distance_is_planar() {
@@ -156,12 +175,38 @@ mod tests {
 
         let a = point_column(vec![0.0, 3.0, 0.0, 3.0], vec![0.0, 0.0, 4.0, 4.0])?;
         let b = point_constant(0.0, 0.0, 4, &mut ctx)?;
-        let distance = GeoDistance::try_new_array(a, b, 4)?.into_array();
+        let distance = GeoDistance::try_new_array(a, b)?.into_array();
 
-        let got: Vec<f64> = (0..4)
-            .map(|idx| f64::try_from(&distance.execute_scalar(idx, &mut ctx)?))
-            .collect::<VortexResult<_>>()?;
-        assert_eq!(got, vec![0.0, 3.0, 4.0, 5.0]);
+        assert_eq!(distances(distance, &mut ctx)?, vec![0.0, 3.0, 4.0, 5.0]);
+        Ok(())
+    }
+
+    /// Without a constant query point on either side, column-to-column distance is unsupported and
+    /// the kernel errors rather than computing it.
+    #[test]
+    fn distance_requires_constant_query_point() -> VortexResult<()> {
+        let session = VortexSession::empty().with::<ArraySession>();
+        let mut ctx = session.create_execution_ctx();
+
+        let a = point_column(vec![0.0, 1.0], vec![0.0, 1.0])?;
+        let b = point_column(vec![3.0, 1.0], vec![4.0, 1.0])?;
+        let distance = GeoDistance::try_new_array(a, b)?.into_array();
+
+        assert!(distance.execute::<Canonical>(&mut ctx).is_err());
+        Ok(())
+    }
+
+    /// Two constant operands: every row has the same distance.
+    #[test]
+    fn distance_between_two_constants() -> VortexResult<()> {
+        let session = VortexSession::empty().with::<ArraySession>();
+        let mut ctx = session.create_execution_ctx();
+
+        let a = point_constant(0.0, 0.0, 3, &mut ctx)?;
+        let b = point_constant(3.0, 4.0, 3, &mut ctx)?;
+        let distance = GeoDistance::try_new_array(a, b)?.into_array();
+
+        assert_eq!(distances(distance, &mut ctx)?, vec![5.0, 5.0, 5.0]);
         Ok(())
     }
 }

--- a/vortex-geo/src/scalar_fn/distance.rs
+++ b/vortex-geo/src/scalar_fn/distance.rs
@@ -1,16 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Planar distance from a point column to a constant query point.
+//! Straight-line (Euclidean) distance between points; "planar" distance in GIS terms.
 
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::ScalarFnArray;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
+use vortex_array::scalar::Scalar;
 use vortex_array::scalar_fn::Arity;
 use vortex_array::scalar_fn::ChildName;
 use vortex_array::scalar_fn::EmptyOptions;
@@ -19,28 +21,29 @@ use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_array::scalar_fn::TypedScalarFnInstance;
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
 use vortex_session::VortexSession;
 
-use crate::extension::coordinate_from_scalar;
-use crate::extension::xy_columns;
+use crate::extension::coordinate::coordinate_from_scalar;
+use crate::extension::coordinate::xy_columns;
 
-/// Planar Euclidean distance between `(ax, ay)` and `(bx, by)`.
+/// Straight-line (L2) distance between `(ax, ay)` and `(bx, by)`.
 fn euclidean_distance(ax: f64, ay: f64, bx: f64, by: f64) -> f64 {
     let dx = ax - bx;
     let dy = ay - by;
     (dx * dx + dy * dy).sqrt()
 }
 
-/// Planar distance from each point in a point column to a single constant query point. The first
-/// operand is the point column, the second the constant query point; column-to-column distance is
-/// not supported.
+/// Straight-line (Euclidean) distance between two point operands — "planar" distance in GIS terms
+/// (e.g. PostGIS `ST_Distance`). No geodesic correction, and `z`/`m` are ignored.
+///
+/// The operands are two point columns of equal length; either (or both) may be constant, in which
+/// case the constant query point is decoded once and broadcast.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct GeoDistance;
 
 impl GeoDistance {
-    /// A lazy `ScalarFnArray` computing the distance from each row of the point column `a` to the
-    /// constant query point `b`. The output length is taken from `a`.
+    /// A lazy `ScalarFnArray` computing the per-row distance between the point columns `a` and
+    /// `b`; either may be constant. The output length is taken from `a`.
     pub fn try_new_array(a: ArrayRef, b: ArrayRef) -> VortexResult<ScalarFnArray> {
         let len = a.len();
         ScalarFnArray::try_new(
@@ -88,20 +91,51 @@ impl ScalarFnVTable for GeoDistance {
         args: &dyn ExecutionArgs,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        // `a` is the point column; `b` is the constant query point, decoded once and broadcast.
-        let points = args.get(0)?;
-        let Some(query) = args.get(1)?.as_constant() else {
-            vortex_bail!("GeoDistance requires a constant query point as its second operand");
-        };
-        let query = coordinate_from_scalar(&query)?;
-        let (xs, ys) = xy_columns(&points, ctx)?;
-        let distances = xs
-            .as_slice::<f64>()
-            .iter()
-            .zip(ys.as_slice::<f64>())
-            .map(|(&x, &y)| euclidean_distance(x, y, query.x, query.y));
-        Ok(PrimitiveArray::from_iter(distances).into_array())
+        let a = args.get(0)?;
+        let b = args.get(1)?;
+        match (a.as_constant(), b.as_constant()) {
+            (Some(qa), Some(qb)) => {
+                let qa = coordinate_from_scalar(&qa)?;
+                let qb = coordinate_from_scalar(&qb)?;
+                let distance = euclidean_distance(qa.x(), qa.y(), qb.x(), qb.y());
+                Ok(ConstantArray::new(
+                    Scalar::primitive(distance, Nullability::NonNullable),
+                    a.len(),
+                )
+                .into_array())
+            }
+            (Some(query), None) => distances_to_constant(&b, &query, ctx),
+            (None, Some(query)) => distances_to_constant(&a, &query, ctx),
+            (None, None) => {
+                let (axs, ays) = xy_columns(&a, ctx)?;
+                let (bxs, bys) = xy_columns(&b, ctx)?;
+                let distances = axs
+                    .as_slice::<f64>()
+                    .iter()
+                    .zip(ays.as_slice::<f64>())
+                    .zip(bxs.as_slice::<f64>().iter().zip(bys.as_slice::<f64>()))
+                    .map(|((&ax, &ay), (&bx, &by))| euclidean_distance(ax, ay, bx, by));
+                Ok(PrimitiveArray::from_iter(distances).into_array())
+            }
+        }
     }
+}
+
+/// Distance from each row of `points` to a constant `query` point, decoded once and broadcast.
+/// Distance is symmetric, so this serves a constant on either side.
+fn distances_to_constant(
+    points: &ArrayRef,
+    query: &Scalar,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let query = coordinate_from_scalar(query)?;
+    let (xs, ys) = xy_columns(points, ctx)?;
+    let distances = xs
+        .as_slice::<f64>()
+        .iter()
+        .zip(ys.as_slice::<f64>())
+        .map(|(&x, &y)| euclidean_distance(x, y, query.x(), query.y()));
+    Ok(PrimitiveArray::from_iter(distances).into_array())
 }
 
 #[cfg(test)]
@@ -159,9 +193,9 @@ mod tests {
             .to_vec())
     }
 
-    /// The kernel computes planar Euclidean distance (the 3–4–5 triangle).
+    /// The kernel computes straight-line distance (the 3–4–5 triangle).
     #[test]
-    fn euclidean_distance_is_planar() {
+    fn euclidean_distance_is_straight_line() {
         assert_eq!(euclidean_distance(0.0, 0.0, 3.0, 4.0), 5.0);
         assert_eq!(euclidean_distance(1.5, -1.5, 1.5, -1.5), 0.0);
     }
@@ -181,10 +215,9 @@ mod tests {
         Ok(())
     }
 
-    /// Without a constant query point on either side, column-to-column distance is unsupported and
-    /// the kernel errors rather than computing it.
+    /// Column-to-column distance pairs corresponding rows of the two columns.
     #[test]
-    fn distance_requires_constant_query_point() -> VortexResult<()> {
+    fn distance_between_columns() -> VortexResult<()> {
         let session = VortexSession::empty().with::<ArraySession>();
         let mut ctx = session.create_execution_ctx();
 
@@ -192,7 +225,21 @@ mod tests {
         let b = point_column(vec![3.0, 1.0], vec![4.0, 1.0])?;
         let distance = GeoDistance::try_new_array(a, b)?.into_array();
 
-        assert!(distance.execute::<Canonical>(&mut ctx).is_err());
+        assert_eq!(distances(distance, &mut ctx)?, vec![5.0, 0.0]);
+        Ok(())
+    }
+
+    /// The constant query point may be either operand; distance is symmetric.
+    #[test]
+    fn distance_with_constant_first_operand() -> VortexResult<()> {
+        let session = VortexSession::empty().with::<ArraySession>();
+        let mut ctx = session.create_execution_ctx();
+
+        let a = point_constant(0.0, 0.0, 4, &mut ctx)?;
+        let b = point_column(vec![0.0, 3.0, 0.0, 3.0], vec![0.0, 0.0, 4.0, 4.0])?;
+        let distance = GeoDistance::try_new_array(a, b)?.into_array();
+
+        assert_eq!(distances(distance, &mut ctx)?, vec![0.0, 3.0, 4.0, 5.0]);
         Ok(())
     }
 

--- a/vortex-geo/src/scalar_fn/mod.rs
+++ b/vortex-geo/src/scalar_fn/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Geometry scalar functions over the [`Point`](crate::extension::Point) type. Currently
+//! [`GeoDistance`], the planar distance between two point columns.
+
+pub mod distance;
+
+pub use distance::GeoDistance;

--- a/vortex-geo/src/scalar_fn/mod.rs
+++ b/vortex-geo/src/scalar_fn/mod.rs
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Geometry scalar functions over the [`Point`](crate::extension::Point) type. Currently
-//! [`GeoDistance`], the planar distance between two point columns.
+//! Geometry scalar functions over the [`Point`](crate::extension::Point) type.
 
 pub mod distance;
-
-pub use distance::GeoDistance;


### PR DESCRIPTION
## Summary

This PR adds a native point type to `vortex-geo`. Points are by far the most common geometry in analytical datasets, and a columnar representation makes their coordinates directly accessible without parsing WKB.

It also adds the scalar function: point-to-point distance with PostGIS `ST_Distance` semantics (planar/Euclidean, results in CRS units).

## API Changes

Adds to `vortex-geo`, all registered through `vortex_geo::initialize`:

- Extension type `Point` (`vortex.geo.point`): a location stored as `Struct<x, y, z?, m?>` of non-nullable `f64`, where `z?` is an optional elevation and `m?` an optional measure. 
- `Coordinate`: the internal value a point scalar unpacks to.
- Scalar function `GeoDistance` (`vortex.geo.distance`): per-row distance between two equal-length point columns; either or both operands may be constant, in which case the query point is decoded once and broadcast.

## Testing

Unit tests cover dtype validation for every GeoArrow dimension (and rejection of invalid storage), round-tripping a point column through scalar execution back to the original coordinates, WKT display for all four dimensions, and distance over all operand shapes: column-to-constant (either side), column-to-column, and constant-to-constant.