### PR TITLE
perf[mask]: check AllTrue/AllFalse in eq

### DIFF
--- a/vortex-mask/src/eq.rs
+++ b/vortex-mask/src/eq.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::mem;
+
 use crate::Mask;
 
 impl PartialEq for Mask {
@@ -8,6 +10,9 @@ impl PartialEq for Mask {
     fn eq(&self, other: &Self) -> bool {
         if self.len() != other.len() {
             return false;
+        }
+        if mem::discriminant(self) == mem::discriminant(other) && !matches!(self, Mask::Values(_)) {
+            return true;
         }
         if self.true_count() != other.true_count() {
             return false;


### PR DESCRIPTION
If two Mask::AllTrue or AllFalse are passed we don't need a bit buffer to check equality