### PR TITLE
perf[gpu]: coalesce streaming kernels

### DIFF
--- a/vortex-cuda/kernels/src/decimal_cast.cu
+++ b/vortex-cuda/kernels/src/decimal_cast.cu
@@ -67,15 +67,11 @@ __device__ __forceinline__ Output decimal_cast_value(Input value) {
 template <typename Input, typename Output>
 __device__ void
 decimal_cast_device(const Input *__restrict input, Output *__restrict output, uint64_t array_len) {
-    const uint64_t worker = blockIdx.x * blockDim.x + threadIdx.x;
-    const uint64_t startElem = start_elem(worker, array_len);
-    const uint64_t stopElem = stop_elem(worker, array_len);
+    const uint64_t elements_per_block = blockDim.x * ELEMENTS_PER_THREAD;
+    const uint64_t block_start = blockIdx.x * elements_per_block;
+    const uint64_t block_stop = min(block_start + elements_per_block, array_len);
 
-    if (startElem >= array_len) {
-        return;
-    }
-
-    for (uint64_t idx = startElem; idx < stopElem; idx++) {
+    for (uint64_t idx = block_start + threadIdx.x; idx < block_stop; idx += blockDim.x) {
         output[idx] = decimal_cast_value<Output>(input[idx]);
     }
 }

--- a/vortex-cuda/kernels/src/list_view.cu
+++ b/vortex-cuda/kernels/src/list_view.cu
@@ -37,11 +37,11 @@ __device__ void list_view_offsets_device(const OffsetT *const offsets,
                                          int32_t *const output,
                                          uint32_t *const status,
                                          uint64_t list_len) {
-    const uint64_t worker = blockIdx.x * blockDim.x + threadIdx.x;
-    const uint64_t startElem = start_elem(worker, list_len);
-    const uint64_t stopElem = stop_elem(worker, list_len);
+    const uint64_t elements_per_block = blockDim.x * ELEMENTS_PER_THREAD;
+    const uint64_t block_start = blockIdx.x * elements_per_block;
+    const uint64_t block_stop = min(block_start + elements_per_block, list_len);
 
-    for (uint64_t idx = startElem; idx < stopElem; idx++) {
+    for (uint64_t idx = block_start + threadIdx.x; idx < block_stop; idx += blockDim.x) {
         const uint64_t offset = static_cast<uint64_t>(offsets[idx]);
         const uint64_t end = offset + static_cast<uint64_t>(sizes[idx]);
         output[idx] = static_cast<int32_t>(offset);
@@ -67,11 +67,11 @@ __device__ void list_view_rebuild_init_scan_device(const SizeT *const sizes,
                                                    uint32_t *const status,
                                                    uint64_t list_len,
                                                    uint64_t scan_len) {
-    const uint64_t worker = blockIdx.x * blockDim.x + threadIdx.x;
-    const uint64_t startElem = start_elem(worker, scan_len);
-    const uint64_t stopElem = stop_elem(worker, scan_len);
+    const uint64_t elements_per_block = blockDim.x * ELEMENTS_PER_THREAD;
+    const uint64_t block_start = blockIdx.x * elements_per_block;
+    const uint64_t block_stop = min(block_start + elements_per_block, scan_len);
 
-    for (uint64_t idx = startElem; idx < stopElem; idx++) {
+    for (uint64_t idx = block_start + threadIdx.x; idx < block_stop; idx += blockDim.x) {
         if (idx >= list_len) {
             scan[idx] = 0;
             continue;
@@ -95,11 +95,11 @@ __device__ void list_view_rebuild_validate_offsets_device(const SizeT *const siz
                                                           const int32_t *const output_offsets,
                                                           uint32_t *const status,
                                                           uint64_t list_len) {
-    const uint64_t worker = blockIdx.x * blockDim.x + threadIdx.x;
-    const uint64_t startElem = start_elem(worker, list_len);
-    const uint64_t stopElem = stop_elem(worker, list_len);
+    const uint64_t elements_per_block = blockDim.x * ELEMENTS_PER_THREAD;
+    const uint64_t block_start = blockIdx.x * elements_per_block;
+    const uint64_t block_stop = min(block_start + elements_per_block, list_len);
 
-    for (uint64_t idx = startElem; idx < stopElem; idx++) {
+    for (uint64_t idx = block_start + threadIdx.x; idx < block_stop; idx += blockDim.x) {
         const int32_t offset = output_offsets[idx];
         const int32_t next_offset = output_offsets[idx + 1];
         if (offset < 0 || next_offset < 0) {

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -13,6 +13,7 @@ use cudarc::driver::LaunchConfig;
 use cudarc::driver::PushKernelArg;
 use cudarc::driver::result as cuda_driver;
 use futures::future::BoxFuture;
+use futures::future::join;
 use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::arrays::DecimalArray;
@@ -533,10 +534,16 @@ async fn export_binary_buffers(
     validate_binary_offsets(&output_offsets, len, &status, ctx)?;
 
     // One status read covers init_scan and offset validation. Both must pass before gather may
-    // dereference view payloads through the scanned offsets.
-    check_binary_status(&status).await?;
+    // dereference view payloads through the scanned offsets. Enqueue both copies up front so the
+    // readbacks share one stream round-trip; await both so an error cannot drop a copy mid-flight.
+    let status_copy = status.try_to_host()?;
+    let total_copy = output_offsets
+        .slice_typed::<i32>(len..len + 1)
+        .try_to_host()?;
+    let (status_value, total_value) = join(status_copy, total_copy).await;
 
-    let total_bytes = total_binary_bytes(&output_offsets, len).await?;
+    check_binary_status(Buffer::<u32>::from_byte_buffer(status_value?)[0])?;
+    let total_bytes = usize::try_from(Buffer::<i32>::from_byte_buffer(total_value?)[0])?;
     let output_values = gather_binary_values(
         views,
         &data_buffer_ptrs,
@@ -563,8 +570,8 @@ where
     .await
 }
 
-async fn check_binary_status(status: &BufferHandle) -> VortexResult<()> {
-    match Buffer::<u32>::from_byte_buffer(status.try_to_host()?.await?)[0] {
+fn check_binary_status(status: u32) -> VortexResult<()> {
+    match status {
         0 => Ok(()),
         1 => vortex_bail!(
             "cannot export BinaryView as Arrow Binary: a view references an invalid data buffer"
@@ -630,16 +637,6 @@ fn validate_binary_offsets(
     ctx.launch_kernel(&kernel, scan_len, |args| {
         args.arg(&offsets_view).arg(&status_view).arg(&scan_len_u64);
     })
-}
-
-async fn total_binary_bytes(offsets: &BufferHandle, len: usize) -> VortexResult<usize> {
-    let total = Buffer::<i32>::from_byte_buffer(
-        offsets
-            .slice_typed::<i32>(len..len + 1)
-            .try_to_host()?
-            .await?,
-    )[0];
-    usize::try_from(total).map_err(Into::into)
 }
 
 fn gather_binary_values(


### PR DESCRIPTION
Convert the streaming list_view kernels (offsets check, rebuild init scan, offsets validation) and decimal_cast from per-thread-contiguous element ranges to block-stride loops so warp accesses stay coalesced. On GH200 the contiguous-offsets check on 10M lists drops from 718us to 80us (~1.4 TB/s, 9x) and the take-based rebuild path improves by 35%. The rebuild gather kernel keeps its per-list layout since its access pattern is data-dependent.

Also enqueue the status and total-bytes device-to-host copies in the Arrow Binary export before awaiting either, so both readbacks complete in one stream round-trip instead of two.