### PR TITLE
Exclude benchmarks and fuzzing from default builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           # Build docs for the whole workspace (aside from vortex-python that is having hard time with the python-docs syntax),
           # including all private docs.
-          cargo doc --profile ci --no-deps --document-private-items --workspace --exclude vortex-python
+          cargo doc --profile ci --no-deps --workspace --document-private-items --workspace --exclude vortex-python
           # nextest doesn't support doc tests, so we run it here
           cargo test --profile ci --doc --workspace --all-features --exclude vortex-cxx --exclude vortex-jni --exclude vortex-ffi --exclude xtask --no-fail-fast
 
@@ -225,19 +225,19 @@ jobs:
       - name: Rustc check
         id: check
         continue-on-error: true
-        run: RUSTFLAGS="-D warnings" cargo check --profile ci --locked --all-features --all-targets
+        run: RUSTFLAGS="-D warnings" cargo check --workspace --profile ci --locked --all-features --all-targets
       - name: Rustc check (release)
         id: check-release
         continue-on-error: true
-        run: RUSTFLAGS="-D warnings" cargo check --locked --all-features --all-targets --release
+        run: RUSTFLAGS="-D warnings" cargo check --workspace --locked --all-features --all-targets --release
       - name: Rust Lint - Clippy All Features
         id: clippy-all
         continue-on-error: true
-        run: cargo clippy --profile ci --locked --all-features --all-targets -- -D warnings
+        run: cargo clippy --workspace --profile ci --locked --all-features --all-targets -- -D warnings
       - name: Rust Lint - Clippy Default Features
         id: clippy-default
         continue-on-error: true
-        run: cargo clippy --profile ci --locked --all-targets -- -D warnings
+        run: cargo clippy --workspace --profile ci --locked --all-targets -- -D warnings
       - name: Check lint results
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,11 @@ broad refactor:
 cargo build --workspace
 ```
 
+cargo build, cargo clippy, cargo nextest run without -p or --workspace don't
+cover crates that are not in "default-members" in Cargo.toml. If you change
+crates that are not in "default-members", build and test them using "-p" or
+"--workspace".
+
 ## Testing
 
 Run tests for the crate or binding you touched before broader checks:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,52 @@ members = [
     "vortex-geo",
 ]
 exclude = ["java/testfiles", "wasm-test"]
+
+# Benchmark harnesses and fuzzing account for 40% of a cold workspace build
+# and they aren't needed for ordinary builds.
+default-members = [
+    "vortex-array-macros",
+    "vortex-error",
+    "vortex-buffer",
+    "vortex-mask",
+    "vortex-utils",
+    "vortex-session",
+    "vortex-flatbuffers",
+    "vortex-metrics",
+    "vortex-io",
+    "vortex-proto",
+    "vortex-array",
+    "vortex-tensor",
+    "vortex-json",
+    "vortex-compressor",
+    "vortex-btrblocks",
+    "vortex-layout",
+    "vortex-scan",
+    "vortex-file",
+    "vortex-ipc",
+    "vortex",
+    "vortex-datafusion",
+    "vortex-duckdb",
+    "vortex-cuda",
+    "vortex-cuda/cub",
+    "vortex-cuda/ffi",
+    "vortex-cuda/gpu-scan-cli",
+    "vortex-cuda/macros",
+    "vortex-cuda/nvcomp",
+    "vortex-cxx",
+    "vortex-ffi",
+    "vortex-jni",
+    "vortex-python",
+    "vortex-tui",
+    "vortex-web/crate",
+    "vortex-sqllogictest",
+    "vortex-test/compat-gen",
+    "vortex-test/e2e-cuda",
+    "xtask",
+    "encodings/*",
+    "encodings/experimental/*",
+    "vortex-geo",
+]
 resolver = "2"
 
 [workspace.package]


### PR DESCRIPTION
This PR adds default-members in Cargo.toml which exclude benchmarks and fuzzing
from the default build. This should have an impact on CI as well.
