### PR TITLE
Add f64 sum benchmarks

### DIFF
--- a/vortex-array/benches/aggregate_grouped.rs
+++ b/vortex-array/benches/aggregate_grouped.rs
@@ -98,6 +98,36 @@ fn i32_clustered_nulls_input() -> ArrayRef {
     )
 }
 
+fn f64_all_valid_input() -> ArrayRef {
+    let group_sizes = random_group_sizes();
+    let element_count = total_element_count(&group_sizes);
+    let mut rng = StdRng::seed_from_u64(GROUP_SIZE_SEED);
+    let values: Buffer<f64> = (0..element_count)
+        .map(|_| rng.random_range(-1000.0..1000.0))
+        .collect();
+    contiguous_list_view(
+        PrimitiveArray::new(values, Validity::NonNullable).into_array(),
+        &group_sizes,
+    )
+}
+
+fn f64_clustered_nulls_input() -> ArrayRef {
+    let group_sizes = random_group_sizes();
+    let element_count = total_element_count(&group_sizes);
+    let mut rng = StdRng::seed_from_u64(GROUP_SIZE_SEED);
+    let values = (0..element_count).map(|i| {
+        if (i / 16) % 8 == 0 {
+            None
+        } else {
+            Some(rng.random_range(-1000.0f64..1000.0))
+        }
+    });
+    contiguous_list_view(
+        PrimitiveArray::from_option_iter(values).into_array(),
+        &group_sizes,
+    )
+}
+
 fn varbinview_input() -> ArrayRef {
     let group_sizes = random_group_sizes();
     let element_count = total_element_count(&group_sizes);
@@ -139,6 +169,22 @@ fn sum_i32_nullable_all_valid(bencher: Bencher) {
 #[divan::bench]
 fn sum_i32_clustered_nulls(bencher: Bencher) {
     let input = i32_clustered_nulls_input();
+    bencher
+        .with_inputs(|| &input)
+        .bench_refs(|input| grouped_accumulator(input, Sum));
+}
+
+#[divan::bench]
+fn sum_f64_all_valid(bencher: Bencher) {
+    let input = f64_all_valid_input();
+    bencher
+        .with_inputs(|| &input)
+        .bench_refs(|input| grouped_accumulator(input, Sum));
+}
+
+#[divan::bench]
+fn sum_f64_clustered_nulls(bencher: Bencher) {
+    let input = f64_clustered_nulls_input();
     bencher
         .with_inputs(|| &input)
         .bench_refs(|input| grouped_accumulator(input, Sum));

--- a/vortex-array/benches/aggregate_sum.rs
+++ b/vortex-array/benches/aggregate_sum.rs
@@ -63,6 +63,42 @@ fn sum_i64(bencher: Bencher) {
         .bench_refs(|(a, ctx)| a.statistics().compute_as::<i64>(Stat::Sum, ctx));
 }
 
+#[divan::bench]
+fn sum_f64(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(6);
+    let data: Vec<f64> = (0..N).map(|_| rng.random_range(-1000.0..1000.0)).collect();
+    bencher
+        .with_inputs(|| {
+            (
+                PrimitiveArray::from_iter(data.iter().copied()).into_array(),
+                SESSION.create_execution_ctx(),
+            )
+        })
+        .bench_refs(|(a, ctx)| a.statistics().compute_as::<f64>(Stat::Sum, ctx));
+}
+
+#[divan::bench]
+fn sum_f64_nulls_clustered(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(7);
+    let data: Vec<Option<f64>> = (0..N)
+        .map(|i| {
+            if (i / 64) % 10 == 0 {
+                None
+            } else {
+                Some(rng.random_range(-1000.0..1000.0))
+            }
+        })
+        .collect();
+    bencher
+        .with_inputs(|| {
+            (
+                PrimitiveArray::from_option_iter(data.iter().copied()).into_array(),
+                SESSION.create_execution_ctx(),
+            )
+        })
+        .bench_refs(|(a, ctx)| a.statistics().compute_as::<f64>(Stat::Sum, ctx));
+}
+
 // Clustered nulls: long runs of valid values broken up by occasional null blocks. This is the
 // case the run-based valid path is expected to accelerate.
 #[divan::bench]


### PR DESCRIPTION
Adds `f64` cases to the `aggregate_sum` and `aggregate_grouped` benchmarks in `vortex-array`, to establish a baseline before changing float summation to Kahan (Neumaier) compensated summation.