### PR TITLE
fix[file]: read the one-row pruning result in can_prune instead of re…

### DIFF
--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -12,7 +12,7 @@ use std::sync::OnceLock;
 
 use itertools::Itertools;
 use vortex_array::ArrayRef;
-use vortex_array::Canonical;
+use vortex_array::Columnar;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ConstantArray;
@@ -245,12 +245,16 @@ impl VortexFile {
         let applied = substitute_row_count(applied, &row_count_replacement)?;
 
         let mut ctx = self.session.create_execution_ctx();
-        let result = applied
-            .execute::<Canonical>(&mut ctx)?
-            .into_bool()
-            .into_array()
-            .execute_scalar(0, &mut ctx)?;
-        Ok(result.as_bool().value() == Some(true))
+        Ok(match applied.execute::<Columnar>(&mut ctx)? {
+            Columnar::Constant(s) => s.scalar().as_bool().value() == Some(true),
+            Columnar::Canonical(c) => {
+                c.into_array()
+                    .execute_scalar(0, &mut ctx)?
+                    .as_bool()
+                    .value()
+                    == Some(true)
+            }
+        })
     }
 
     pub fn splits(&self) -> VortexResult<Vec<Range<u64>>> {

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -12,7 +12,7 @@ use std::sync::OnceLock;
 
 use itertools::Itertools;
 use vortex_array::ArrayRef;
-use vortex_array::Columnar;
+use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ConstantArray;
@@ -245,10 +245,12 @@ impl VortexFile {
         let applied = substitute_row_count(applied, &row_count_replacement)?;
 
         let mut ctx = self.session.create_execution_ctx();
-        Ok(match applied.execute::<Columnar>(&mut ctx)? {
-            Columnar::Constant(s) => s.scalar().as_bool().value() == Some(true),
-            Columnar::Canonical(_) => false,
-        })
+        let result = applied
+            .execute::<Canonical>(&mut ctx)?
+            .into_bool()
+            .into_array()
+            .execute_scalar(0, &mut ctx)?;
+        Ok(result.as_bool().value() == Some(true))
     }
 
     pub fn splits(&self) -> VortexResult<Vec<Range<u64>>> {

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -35,6 +35,7 @@ use vortex_array::dtype::PType::I32;
 use vortex_array::dtype::StructFields;
 use vortex_array::expr::and;
 use vortex_array::expr::cast;
+use vortex_array::expr::col;
 use vortex_array::expr::eq;
 use vortex_array::expr::get_item;
 use vortex_array::expr::gt;
@@ -1950,6 +1951,42 @@ async fn test_segment_ordering_zonemaps_after_data() -> VortexResult<()> {
         &all_zones_offsets,
         "global: all data segments should come before all zone map segments",
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_can_prune_composite_predicates() -> VortexResult<()> {
+    // Regression test for `can_prune` after `ScalarFnConstantRule` was removed
+    // (#7575): composite falsification trees no longer constant-fold during
+    // execution, so `can_prune` must read the one-row evaluated result instead
+    // of requiring a `Columnar::Constant`. `Eq` is affected too: its
+    // falsification is internally `or(min > lit, lit > max)`.
+    let st = StructArray::from_fields(&[
+        ("age", buffer![15i32, 18, 22, 25].into_array()),
+        ("price", buffer![120i32, 130, 140, 150].into_array()),
+    ])?;
+    let mut buf = ByteBufferMut::empty();
+    SESSION
+        .write_options()
+        .write(&mut buf, st.into_array().to_array_stream())
+        .await?;
+    let file = SESSION.open_options().open_buffer(buf)?;
+
+    // Bare comparisons: falsified directly by min/max stats.
+    assert!(file.can_prune(&gt(col("age"), lit(30)))?);
+    assert!(file.can_prune(&lt(col("price"), lit(100)))?);
+
+    // Composite predicates whose falsifications are boolean trees.
+    assert!(file.can_prune(&and(gt(col("age"), lit(30)), lt(col("price"), lit(100))))?);
+    assert!(file.can_prune(&or(gt(col("age"), lit(30)), lt(col("age"), lit(10))))?);
+    assert!(file.can_prune(&eq(col("age"), lit(5)))?);
+
+    // Non-falsifiable controls: rows may match, so pruning must refuse.
+    assert!(!file.can_prune(&gt(col("age"), lit(20)))?);
+    assert!(!file.can_prune(&eq(col("age"), lit(18)))?);
+    assert!(!file.can_prune(&and(gt(col("age"), lit(20)), gt(col("price"), lit(100))))?);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Closes: #8366

`VortexFile::can_prune` stopped pruning for every `and`/`or` and `eq` predicate after #7575 removed bottom-up constant-folding. It evaluates a predicate's stat-falsification expression over the one-row file-stats array, but only read a folded `Columnar::Constant` result and mapped `Columnar::Canonical(_)` to `false`, discarding the computed boolean. Post-#7575, composite falsifications (boolean `and`/`or` trees, and the `or(min > lit, lit > max)` that `eq` expands to) execute to a one-row `Canonical` instead of folding, so pruning silently stopped for them. Bare `gt`/`lt` comparisons still fold through the compare kernel's one-level constant fast path, so only composite and `eq` predicates regressed.

It went unnoticed upstream because `can_prune` has no in-repo callers, the scan path prunes through `FileStatsLayoutReader::evaluate_file_stats`, which already reads the one-row result out correctly. This change makes `can_prune` mirror that read-out (execute to `Canonical`, take the row-0 scalar) and adds an end-to-end regression test covering bare, `and`/`or`, and `eq` predicates with non-falsifiable controls.

## API Changes

No signature changes. This restores the runtime behavior of the public `VortexFile::can_prune`: it now returns `true` (prunable) for `and`/`or`/`eq` predicates that file statistics prove cannot match, where it previously returned `false`. No engine integration is affected. The scan path already pruned correctly via `evaluate_file_stats`; only direct callers of `can_prune` saw the regression. No docs changes needed.

## Testing

- New `test_can_prune_composite_predicates` (`vortex-file/src/tests.rs`): writes a file with stat-bounded `age`/`price` columns and asserts pruning for bare, `and`, `or`, and `eq` falsifiable predicates, plus non-falsifiable controls that must not prune.
- Verified non-vacuous: the test fails against the pre-fix `Columnar::Canonical(_) => false` arm and passes after.
- `cargo nextest run -p vortex-file` — 62/62 pass (existing suite + new test).
- `cargo +nightly fmt -p vortex-file` and `cargo clippy -p vortex-file --all-targets` clean.

## AI assistance

Developed with assistance from Claude Code (agentic AI) for root-cause analysis, the fix, and the regression test. All changes were reviewed and verified by me against the Vortex source and a downstream test suite.