### PR TITLE
docs: update doc links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ We ask that you read the guidelines below in order to make the process as stream
 >
 > For the full AI policy — including disclosure requirements, review standards for
 > AI-generated PRs, and rules for autonomous agents — see the
-> [contributing guide](https://vortex.dev/project/contributing.html#ai-assistance).
+> [contributing guide](https://docs.vortex.dev/project/contributing#ai-assistance).
 
 ## Code Contributions
 

--- a/docs/developer-guide/embedding/index.md
+++ b/docs/developer-guide/embedding/index.md
@@ -2,8 +2,8 @@
 
 :::{warning}
 This section is under construction. For guidance on embedding Vortex, please join the
-[Vortex Slack channel](https://join.slack.com/t/vortex-array/shared_invite/zt-2ycp2w24h-sRdrGbMGPmQwCuPQT40Jig)
-or start a [GitHub Discussion](https://github.com/spiraldb/vortex/discussions).
+[Vortex Slack channel](https://vortex.dev/slack)
+or start a [GitHub Discussion](https://github.com/vortex-data/vortex/discussions).
 :::
 
 Vortex can be embedded into applications and services via its C FFI, C++ wrapper, or the Scan API.

--- a/docs/developer-guide/extending/index.md
+++ b/docs/developer-guide/extending/index.md
@@ -3,7 +3,7 @@
 :::{warning}
 This section is under construction. For guidance on extending Vortex, please join the
 [Vortex Slack channel](https://vortex.dev/slack)
-or start a [GitHub Discussion](https://github.com/spiraldb/vortex/discussions).
+or start a [GitHub Discussion](https://github.com/vortex-data/vortex/discussions).
 :::
 
 Vortex is designed to be extended with custom types, encodings, layouts, and compute functions.


### PR DESCRIPTION
fixup links for vortex from spiral and the `docs.` subdomain