### PR TITLE
Ignore PyO3 rustsec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,7 +209,7 @@ proc-macro2 = "1.0.95"
 prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"
-pyo3 = { version = "0.28.0" }
+pyo3 = { version = "0.29.0" }
 pyo3-bytes = "0.6"
 pyo3-log = "0.13.0"
 pyo3-object_store = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,7 +209,7 @@ proc-macro2 = "1.0.95"
 prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"
-pyo3 = { version = "0.29.0" }
+pyo3 = { version = "0.28.0" }
 pyo3-bytes = "0.6"
 pyo3-log = "0.13.0"
 pyo3-object_store = "0.9.0"

--- a/deny.toml
+++ b/deny.toml
@@ -16,7 +16,12 @@ ignore = [
     # Paste is no longer maintained because its essentially "finished".
     "RUSTSEC-2024-0436",
     # proc-macro-error-2 is unmaintained, only used by the `test_with` test dependency
-    "RUSTSEC-2026-0173"
+    "RUSTSEC-2026-0173",
+    # Out-of-bounds read in `nth`/`nth_back` on pyo3 list/tuple iterators, fixed only in pyo3
+    # 0.29.0. We cannot bump until pyo3-bytes, pyo3-log, and pyo3-object_store support 0.29 (all
+    # pin pyo3 to <0.29, and pyo3-ffi `links = "python"` forbids two pyo3 versions in the graph).
+    # Not exploitable here: `vortex-python` never calls `nth`/`nth_back` on these iterators.
+    "RUSTSEC-2026-0176"
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

Ignores the pyo3 rustsec because there are other dependencies that haven't upgraded yet.

## Testing

N/A
