### PR TITLE
Remove debug symbols from vortex-fastlanes on `dev` profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9563,7 +9563,6 @@ dependencies = [
  "vortex",
  "vortex-alp",
  "vortex-array",
- "vortex-bench",
  "vortex-btrblocks",
  "vortex-buffer",
  "vortex-bytebool",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -418,6 +418,9 @@ incremental = false
 # This rule only applies to dependencies that are not members of the workspace.
 [profile.ci.package."*"]
 debug = false
-debug-assertions = false
-strip = "debuginfo"
+debug-assertions = true
 incremental = false
+
+# This improved build times significantly for default common cases that we use locally
+[profile.dev.package.vortex-fastlanes]
+debug = false

--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -65,7 +65,6 @@ tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 vortex = { path = ".", features = ["tokio"] }
-vortex-bench = { workspace = true, features = ["unstable_encodings"] }
 vortex-tensor = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Summary

Inspired by @myrrc's #8634, this change makes a few subtle changes to our `dev` and `ci` build profiles. The main change here is removing debug symbols from `vortex-fastlanes`, which for a full build of the main package (`cargo build -p vortex --all-features --all-targets`) reduces build time by about 33% (from 90 seconds to under 60).

The others are:
1. For the `ci` profile, enables `debug_assertions` and remove the explicit `strip` which seems redundant, and doesn't seem to make a measurable difference in build times.
2. Remove `vortex-bench` as a dev dependency for `vortex`, which is just weird and unused.