### PR TITLE
Install libc debug symbols for codspeed benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -51,6 +51,9 @@ jobs:
         run: sudo bash scripts/setup-benchmark.sh
       - uses: ./.github/actions/setup-prebuild
       - uses: ./.github/actions/system-info
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y libc6-dbg
       - name: Install Codspeed
         uses: taiki-e/cache-cargo-install-action@66c9585ef5ca780ee69399975a5e911f47905995
         with:
@@ -91,6 +94,9 @@ jobs:
           nvidia-smi
           nvidia-smi -L
           nvidia-smi -q -d Memory
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y libc6-dbg
       - name: Install Codspeed
         uses: taiki-e/cache-cargo-install-action@66c9585ef5ca780ee69399975a5e911f47905995
         with:


### PR DESCRIPTION
## Summary

Install libc's debug symbols for codspeed runs, to get better symbolication for some of the code we end up calling.

For example, for the noisy `chunked_bool_canonical_into` we currently get (note the unknown spans on the left):
<img width="1275" height="231" alt="Screenshot 2026-06-12 at 09 03 39" src="https://github.com/user-attachments/assets/e97f57e0-467a-4d41-8438-63ebebe6bd27" />

With this change we get (note all the new blue spans, other colors are just noise):
<img width="1282" height="228" alt="Screenshot 2026-06-12 at 09 04 22" src="https://github.com/user-attachments/assets/402c9be7-822c-442e-a825-327d0972d878" />

They include both memory allocation function but often more useful to us - SIMD instructions! On this PR's runs with a quick look I've found:
- `_int_malloc`
- `malloc_consolidate`
- `__memset_avx2_unaligned_erms`
- `__memcpy_avx_unaligned_erms`
- `__memcmp_avx2_movbe`
- `tcache_get_n`





