### PR TITLE
Build tests before running tests under sanitizer

### DIFF
--- a/.github/workflows/rust-instrumented.yml
+++ b/.github/workflows/rust-instrumented.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Build tests with sanitizer
         run: |
           RUSTFLAGS="${RUSTFLAGS} ${{ matrix.sanitizer_flags }}" \
-          cargo +$NIGHTLY_TOOLCHAIN build --locked --all-features \
+          cargo +$NIGHTLY_TOOLCHAIN build --tests --locked --all-features \
             --target x86_64-unknown-linux-gnu -Zbuild-std \
             -p vortex-buffer -p vortex-fastlanes -p vortex-fsst -p vortex-alp -p vortex-array
 
@@ -214,8 +214,8 @@ jobs:
             --target x86_64-unknown-linux-gnu -Zbuild-std \
             -p vortex-ffi
       - name: Build FFI library tests and examples
+        working-directory: vortex-ffi
         run: |
-          cd vortex-ffi
           cmake -Bbuild -DBUILD_TESTS=1 -DBUILD_EXAMPLES=1 -DSANITIZER=${{ matrix.sanitizer }} -DTARGET_TRIPLE="x86_64-unknown-linux-gnu"
           cmake --build build -j
       - name: Run tests


### PR DESCRIPTION
## Summary

We currently have a build step before sanitizier runs, but we don't actually build the tests in that step, so this PR adds that. The changes these tests build times from 1:37 + 2:44 to 2:49, so about 90 seconds of savings for flows that seem to take around 7-8 minutes.
