### PR TITLE
Validate all rustdoc builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,13 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: ./.github/actions/setup-prebuild
       - name: Docs
+        env:
+          # required to make sure docs build for features
+          RUSTDOCFLAGS: "-D warnings --cfg docsrs"
         run: |
-          RUSTDOCFLAGS="-D warnings" cargo doc --profile ci --no-deps
+          # Build docs for the whole workspace (aside from vortex-python that is having hard time with the python-docs syntax),
+          # including all private docs.
+          cargo doc --profile ci --no-deps --document-private-items --workspace --exclude vortex-python
           # nextest doesn't support doc tests, so we run it here
           cargo test --profile ci --doc --workspace --all-features --exclude vortex-cxx --exclude vortex-jni --exclude vortex-ffi --exclude xtask --no-fail-fast
 

--- a/benchmarks-website/server/src/api/descriptions.rs
+++ b/benchmarks-website/server/src/api/descriptions.rs
@@ -61,7 +61,7 @@ fn static_description(name: &str) -> Option<&'static str> {
 }
 
 /// Derive a description for `TPC-H (NVMe|S3) (SF=N)` and `TPC-DS (NVMe) (SF=N)`
-/// group names. The shape is fixed because [`crate::api::groups::group_name_query`]
+/// group names. The shape is fixed because `crate::api::groups::group_name_query`
 /// emits exactly this format for tpch/tpcds. Returns `None` for any name that
 /// does not start with `TPC-H ` or `TPC-DS `.
 fn tpc_description(name: &str) -> Option<String> {

--- a/encodings/experimental/onpair/src/canonical.rs
+++ b/encodings/experimental/onpair/src/canonical.rs
@@ -3,6 +3,8 @@
 //
 //! Convert an [`OnPairArray`] to its canonical `VarBinViewArray` by handing
 //! the materialised parts to `onpair::decompress_into`.
+//! 
+//! [`OnPairArray`]: crate::OnPairArray
 
 use std::sync::Arc;
 

--- a/encodings/experimental/onpair/src/canonical.rs
+++ b/encodings/experimental/onpair/src/canonical.rs
@@ -3,7 +3,7 @@
 //
 //! Convert an [`OnPairArray`] to its canonical `VarBinViewArray` by handing
 //! the materialised parts to `onpair::decompress_into`.
-//! 
+//!
 //! [`OnPairArray`]: crate::OnPairArray
 
 use std::sync::Arc;

--- a/encodings/experimental/onpair/src/decode.rs
+++ b/encodings/experimental/onpair/src/decode.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 //
-//! Helpers for turning [`OnPair`] slot children into the inputs the upstream
+//! Helpers for turning [`OnPair`](super::OnPair) slot children into the inputs the upstream
 //! `onpair` decoder consumes.
 
 use vortex_array::ArrayRef;

--- a/encodings/fastlanes/src/bitpacking/compute/between.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/between.rs
@@ -6,6 +6,8 @@
 //! Reuses the same single-block scratch buffer as the compare kernel and folds a
 //! `lower op_l v op_u upper` predicate per element, so the full primitive never
 //! materialises.
+//!
+//! [`BitPackedArray`]: crate::BitPackedArray
 
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;

--- a/encodings/fastlanes/src/bitpacking/compute/compare.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/compare.rs
@@ -7,6 +7,9 @@
 //! block at a time through a reusable scratch buffer, and a per-element bool is folded into
 //! a [`BitBuffer`]. Patches are re-applied at the end by overwriting bits at the patched
 //! indices with `predicate(patch_value)`.
+//!
+//! [`BitPackedArray`]: crate::BitPackedArray
+//! [`BitBuffer`]: vortex_buffer::BitBuffer
 
 use fastlanes::BitPacking;
 use fastlanes::BitPackingCompare;

--- a/encodings/fastlanes/src/bitpacking/compute/compare_fused.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/compare_fused.rs
@@ -22,6 +22,9 @@
 //! garbage rows are represented as the final [`BitBuffer`] bit offset, which naturally handles
 //! sub-byte slices without copy-aligning. Inline patches are spliced in afterwards by overwriting
 //! the bits at the patched indices with `cmp(patch_value, rhs)`.
+//!
+//! [`BitPackedArray`]: crate::BitPackedArray
+//! [`BitBuffer`]: vortex_buffer::BitBuffer
 
 use fastlanes::BitPacking;
 use fastlanes::BitPackingCompare;
@@ -58,6 +61,8 @@ const WORDS_PER_CHUNK: usize = CHUNK_SIZE / U64_BITS;
 ///
 /// `cmp(value, rhs)` defines the predicate; it must be the total-order comparison matching the
 /// requested operator (e.g. `|a, b| a.is_lt(b)`).
+///
+/// [`BitPackedArray`]: crate::BitPackedArray
 pub(super) fn stream_compare_fused<T, F>(
     array: ArrayView<'_, BitPacked>,
     rhs: T,

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -28,7 +28,7 @@ use crate::BitPacked;
 use crate::BitPackedArrayExt;
 use crate::BitPackedData;
 
-/// The threshold over which it is faster to fully unpack the entire [`BitPackedArray`] and then
+/// The threshold over which it is faster to fully unpack the entire [`BitPackedArray`](crate::BitPackedArray) and then
 /// filter the result than to unpack only specific bitpacked values into the output buffer.
 pub const fn unpack_then_filter_threshold(ptype: PType) -> f64 {
     // TODO(connor): Where did these numbers come from? Add a public link after validating them.

--- a/encodings/fastlanes/src/bitpacking/compute/stream_predicate.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/stream_predicate.rs
@@ -4,12 +4,16 @@
 //! Streaming, cache-reusable predicate evaluation over a [`BitPackedArray`].
 //!
 //! Walks the encoded array one 1024-element FastLanes block at a time through a single
-//! reusable scratch buffer, splices any [`crate::patches::Patches`] into the unpacked block
+//! reusable scratch buffer, splices any [`Patches`] into the unpacked block
 //! in place via a sorted-index cursor, then folds a `Fn(T) -> bool` predicate over the
-//! block. The fold matches the canonical [`vortex_buffer::BitBuffer::collect_bool`] shape
+//! block. The fold matches the canonical [`BitBuffer::collect_bool`] shape
 //! (pack 64 bools into a `u64` in a tight auto-vectorisable inner loop) and writes the
 //! resulting words straight into the output bit buffer, so the materialised primitive
 //! never appears anywhere.
+//!
+//! [`BitPackedArray`]: crate::BitPackedArray
+//! [`BitBuffer::collect_bool`]: vortex_buffer::BitBuffer::collect_bool
+//! [`Patches`]: vortex_array::patches::Patches
 
 use num_traits::AsPrimitive;
 use vortex_array::ArrayRef;
@@ -30,7 +34,7 @@ use crate::BitPacked;
 use crate::BitPackedArrayExt;
 use crate::unpack_iter::BitPacked as BitPackedIter;
 
-/// Stream `predicate` over the unpacked values of a [`BitPackedArray`], one FastLanes
+/// Stream `predicate` over the unpacked values of a [`BitPackedArray`](crate::BitPackedArray), one FastLanes
 /// block at a time, producing a [`BoolArray`].
 pub(super) fn stream_predicate<T, P>(
     array: ArrayView<'_, BitPacked>,

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -30,7 +30,7 @@ use crate::bitpack_decompress;
 // TODO(connor): This is duplicated in `encodings/fastlanes/src/bitpacking/kernels/mod.rs`.
 /// assuming the buffer is already allocated (which will happen at most once) then unpacking
 /// all 1024 elements takes ~8.8x as long as unpacking a single element on an M2 Macbook Air.
-/// see https://github.com/vortex-data/vortex/pull/190#issue-2223752833
+/// see <https://github.com/vortex-data/vortex/pull/190#issue-2223752833>
 pub(super) const UNPACK_CHUNK_THRESHOLD: usize = 8;
 
 impl TakeExecute for BitPacked {

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -775,7 +775,7 @@ impl FSSTData {
         self.codes_bytes.as_host()
     }
 
-    /// Build a [`Decompressor`][fsst::Decompressor] that can be used to decompress values from
+    /// Build a [`Decompressor`] that can be used to decompress values from
     /// this array.
     pub fn decompressor(&self) -> Decompressor<'_> {
         Decompressor::new(self.symbols().as_slice(), self.symbol_lengths().as_slice())

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -354,7 +354,7 @@ pub struct ZstdDataParts {
     pub slice_stop: usize,
 }
 
-/// The parts of a [`ZstdArray`] returned by [`ZstdArray::into_parts`].
+/// Compressed ZStd frames and their metadata
 #[derive(Debug)]
 struct Frames {
     dictionary: Option<ByteBuffer>,

--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -494,7 +494,7 @@ impl ArrayRef {
     /// Take a slot for executor-owned physical rewrites.
     ///
     /// On return the produced parent has the taken slot set to `None`
-    /// callers must put the slot back (typically via [`put_slot_unchecked`]) before the parent is
+    /// callers must put the slot back (typically via [`Self::put_slot_unchecked`]) before the parent is
     /// returned from the execution loop.
     ///
     /// When the `Arc` was shared this allocates a fresh parent.
@@ -531,7 +531,7 @@ impl ArrayRef {
 
     /// Puts an array into `slot_idx` by either, cloning the inner array if the Arc is not exclusive
     /// or replacing the slot in this `ArrayRef`.
-    /// This is the mirror of [`take_slot_unchecked`].
+    /// This is the mirror of [`Self::take_slot_unchecked`].
     ///
     /// # Safety
     /// The replacement must have the same logical dtype and length as the taken slot, and this

--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -156,9 +156,9 @@ impl BoolData {
     }
 }
 
-/// Constructors and consuming methods for `BoolArray` (`Array<Bool>`).
+/// Constructors and consuming methods for [`BoolArray`].
 impl Array<Bool> {
-    /// Constructs a new `BoolArray`.
+    /// Constructs a new [`BoolArray`].
     ///
     /// # Panics
     ///
@@ -167,7 +167,7 @@ impl Array<Bool> {
         Self::try_new(bits, validity).vortex_expect("Failed to create BoolArray")
     }
 
-    /// Constructs a new `BoolArray` from a `BufferHandle`.
+    /// Constructs a new [`BoolArray`] from a [`BufferHandle`].
     ///
     /// # Panics
     ///
@@ -251,7 +251,7 @@ impl Array<Bool> {
     }
 }
 
-/// Internal constructors on BoolData (used by Array<Bool> constructors and VTable::build).
+// Internal constructors on BoolData (used by [`BoolArray`] constructors and [`VTable::build`]).
 impl BoolData {
     pub(super) fn try_new(bits: BitBuffer, validity: Validity) -> VortexResult<Self> {
         let bits = bits.shrink_offset();

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -78,7 +78,7 @@ pub(super) fn _canonicalize(
     })
 }
 
-/// Packs many [`StructArray`]s to instead be a single [`StructArray`], where the [`DynArrayData`] for each
+/// Packs many [`StructArray`]s to instead be a single [`StructArray`], where the [`DynArrayData`](crate::array::DynArrayData) for each
 /// field is a [`ChunkedArray`].
 ///
 /// The caller guarantees there are at least 2 chunks.

--- a/vortex-array/src/arrays/filter/execute/mod.rs
+++ b/vortex-array/src/arrays/filter/execute/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Execution logic for [`FilterArray`].
+//! Execution logic for [`super::FilterArray`].
 //!
 //! The main entrypoint is [`execute_filter`] which filters any [`Canonical`] array.
 

--- a/vortex-array/src/arrays/interleave/execute/bool.rs
+++ b/vortex-array/src/arrays/interleave/execute/bool.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Boolean-value execution: the optimized [`Interleave`](super::super::Interleave) path for
-//! boolean values.
+//! Optimized [`Interleave`] implementation for boolean values.
 
 use num_traits::AsPrimitive;
 use vortex_buffer::BitBuffer;

--- a/vortex-array/src/arrays/interleave/execute/mod.rs
+++ b/vortex-array/src/arrays/interleave/execute/mod.rs
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Execution logic for [`Interleave`](super::Interleave), dispatched on the value type.
+//! Execution logic for [`Interleave`], dispatched on the value type.
 //!
-//! All values share a type (validated in [`Interleave::check`](super::Interleave::check)), so the
+//! All values share a type (validated in [`Interleave::check`]), so the
 //! physical gather kernel is chosen from the first value. The selector types are an orthogonal
-//! concern handled within each kernel. Only boolean values are implemented today (see [`bool`]).
+//! concern handled within each kernel. Only boolean values are implemented today (see the [`bool`] module).
+//!
+//! [`Interleave::check`]: super::Interleave::check
+//! [`bool`]: module@crate::arrays::interleave::execute::bool
 
 mod bool;
 

--- a/vortex-array/src/arrow/executor/list.rs
+++ b/vortex-array/src/arrow/executor/list.rs
@@ -33,6 +33,7 @@ use crate::dtype::DType;
 use crate::dtype::NativePType;
 use crate::dtype::Nullability;
 
+#[allow(rustdoc::broken_intra_doc_links)]
 /// Convert a Vortex VarBinArray into an Arrow [`GenericListArray`](arrow_array:array::GenericListArray).
 pub(super) fn to_arrow_list<O: OffsetSizeTrait + NativePType>(
     array: ArrayRef,
@@ -81,6 +82,7 @@ pub(super) fn to_arrow_list<O: OffsetSizeTrait + NativePType>(
     list_view_zctl::<O>(zctl, elements_field, ctx)
 }
 
+#[allow(rustdoc::broken_intra_doc_links)]
 /// Convert a Vortex VarBinArray into an Arrow [`GenericListArray`](arrow_array:array::GenericListArray).
 fn list_to_list<O: OffsetSizeTrait + NativePType>(
     array: &ListArray,

--- a/vortex-array/src/builders/extension.rs
+++ b/vortex-array/src/builders/extension.rs
@@ -54,6 +54,8 @@ impl ExtensionBuilder {
     }
 
     /// The [`ExtDType`] of this builder.
+    ///
+    /// [`ExtDType`]: crate::dtype::extension::ExtDType
     fn ext_dtype(&self) -> ExtDTypeRef {
         if let DType::Extension(ext_dtype) = &self.dtype {
             ext_dtype.clone()

--- a/vortex-array/src/scalar/constructor.rs
+++ b/vortex-array/src/scalar/constructor.rs
@@ -204,7 +204,7 @@ impl Scalar {
     }
 }
 
-/// A helper enum for creating a [`ListScalar`].
+/// A helper enum for creating a `ListScalar`.
 enum ListKind {
     /// Variable-length list.
     Variable,

--- a/vortex-array/src/scalar/scalar_value.rs
+++ b/vortex-array/src/scalar/scalar_value.rs
@@ -16,7 +16,7 @@ use crate::scalar::DecimalValue;
 use crate::scalar::PValue;
 use crate::scalar::Scalar;
 
-/// The value stored in a [`Scalar`][crate::scalar::Scalar].
+/// The value stored in a [`Scalar`].
 ///
 /// This enum represents the possible non-null values that can be stored in a scalar. When the
 /// scalar is null, the value is represented as `None` in the `Option<ScalarValue>` field.

--- a/vortex-array/src/scalar_fn/typed.rs
+++ b/vortex-array/src/scalar_fn/typed.rs
@@ -4,8 +4,10 @@
 //! Typed and inner representations of scalar functions.
 //!
 //! - [`ScalarFn<V>`]: The public typed wrapper, parameterized by a concrete [`ScalarFnVTable`].
-//! - [`ScalarFn<V>`]: The private inner struct that holds the vtable + options.
+//! - [`TypedScalarFnInstance<V>`]: The inner struct that holds the vtable + options.
 //! - [`DynScalarFn`]: The private sealed trait for type-erased dispatch (bound, options in self).
+//!
+//! [`ScalarFn<V>`]: crate::arrays::scalar_fn::ScalarFn
 
 use std::any::Any;
 use std::fmt;
@@ -71,7 +73,7 @@ impl<V: ScalarFnVTable> TypedScalarFnInstance<V> {
 
 /// An object-safe, sealed trait for bound scalar function dispatch.
 ///
-/// Options are stored inside the implementing [`ScalarFn<V>`], not passed externally.
+/// Options are stored inside the implementing [`ScalarFn<V>`](crate::arrays::scalar_fn::ScalarFn), not passed externally.
 /// This is the sole trait behind [`ScalarFnRef`]'s `Arc<dyn DynScalarFn>`.
 pub(super) trait DynScalarFn: 'static + Send + Sync + super::sealed::Sealed {
     fn as_any(&self) -> &dyn Any;

--- a/vortex-bench/src/v3.rs
+++ b/vortex-bench/src/v3.rs
@@ -498,7 +498,7 @@ pub fn write_jsonl_to_path(path: &std::path::Path, records: &[V3Record]) -> std:
 /// value the server-side `value_ns: i64` deserializer can accept.
 ///
 /// The wire field is `u64` (see `value_ns` on every record type below),
-/// but the server's [`vortex_bench_server::records`] mirrors them as `i64`.
+/// but the server's records mirrors them as `i64`.
 /// Without the clamp, an overflowed measurement would land at `u64::MAX`
 /// here, fail serde deserialization on the server, and 400 the whole
 /// ingest envelope.

--- a/vortex-compressor/src/stats/cache.rs
+++ b/vortex-compressor/src/stats/cache.rs
@@ -28,7 +28,7 @@ type StatsEntry = (TypeId, Arc<dyn Any + Send + Sync>);
 
 /// Cache for compression statistics, keyed by concrete type.
 ///
-/// The cache is interior-mutable: entries can be inserted through a shared [`&StatsCache`]
+/// The cache is interior-mutable: entries can be inserted through a shared [`StatsCache`]
 /// borrow. Values are stored as [`Arc<dyn Any + Send + Sync>`] so that cached entries can be
 /// cloned out of the lock cheaply and handed back to callers as [`Arc<T>`].
 struct StatsCache {

--- a/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
+++ b/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
@@ -281,7 +281,7 @@ pub struct FusedPlan {
     /// Shared memory reserved by the non-output stages, in bytes.
     smem_byte_cursor: SmemByteOffset,
     /// Source buffers. `None` entries are placeholder slots for pending subtrees,
-    /// filled by [`materialize_with_subtrees`] before device copy.
+    /// filled by [`Self::materialize_with_subtrees`] before device copy.
     source_buffers: Vec<Option<BufferHandle>>,
     /// Bytes per element of the root (output) array.
     output_elem_bytes: u32,
@@ -749,7 +749,7 @@ impl FusedPlan {
 
     /// Reserve a placeholder buffer slot and record the array as a pending subtree.
     ///
-    /// Called from [`walk`] when [`is_dyn_dispatch_compatible`] rejects a child.
+    /// Called from [`Self::walk`] when [`is_dyn_dispatch_compatible`] rejects a child.
     /// Cases that require a separate kernel dispatch:
     ///
     /// - **F16 primitives** — no reinterpret path in the kernel.

--- a/vortex-datafusion/src/persistent/cache.rs
+++ b/vortex-datafusion/src/persistent/cache.rs
@@ -6,6 +6,8 @@ use vortex::file::Footer;
 use vortex::file::VortexFile;
 
 /// Cached Vortex file metadata for use with DataFusion's [`FileMetadataCache`].
+///
+/// [`FileMetadataCache`]: datafusion_execution::cache::cache_manager::FileMetadataCache
 pub struct CachedVortexMetadata {
     footer: Footer,
 }

--- a/vortex-datafusion/src/persistent/reader.rs
+++ b/vortex-datafusion/src/persistent/reader.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Factory for creating [`VortexReadAt`][vortex::io::VortexReadAt] instances
-//! from [`PartitionedFile`]s.
+//! Factory for creating [`VortexReadAt`] instances from [`PartitionedFile`]s.
 
 use std::fmt::Debug;
 use std::sync::Arc;

--- a/vortex-datafusion/src/persistent/stream.rs
+++ b/vortex-datafusion/src/persistent/stream.rs
@@ -12,7 +12,9 @@ use futures::Stream;
 use futures::StreamExt;
 use futures::stream::BoxStream;
 
-/// Utility to end a stream early if its backing [`PartitionFile`] can be pruned away by an updated dynamic expression.
+/// Utility to end a stream early if its backing [`PartitionedFile`] can be pruned away by an updated dynamic expression.
+///
+/// [`PartitionedFile`]: datafusion_datasource::PartitionedFile
 pub(crate) struct PrunableStream {
     file_pruner: FilePruner,
     stream: BoxStream<'static, DFResult<RecordBatch>>,

--- a/vortex-duckdb/src/exporter/fixed_size_list.rs
+++ b/vortex-duckdb/src/exporter/fixed_size_list.rs
@@ -7,7 +7,7 @@
 //! The ARRAY type in DuckDB corresponds to Vortex's [`DType::FixedSizeList`], where all
 //! lists have the same number of elements.
 //!
-//! [`DType::FixedSizeList`]: vortex_array::dtype::DType::FixedSizeList
+//! [`DType::FixedSizeList`]: vortex::dtype::DType::FixedSizeList
 use vortex::array::ExecutionCtx;
 use vortex::array::arrays::FixedSizeListArray;
 use vortex::array::arrays::fixed_size_list::FixedSizeListArrayExt;

--- a/vortex-duckdb/src/lib.rs
+++ b/vortex-duckdb/src/lib.rs
@@ -32,6 +32,7 @@ mod projection;
 mod table_function;
 
 #[rustfmt::skip]
+#[allow(rustdoc::all)]
 #[path = "./cpp.rs"]
 /// This module provides the FFI interface to our C++ code exposing additional functionality
 /// for DuckDB, such as custom data types and functions.

--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -679,7 +679,7 @@ void vx_array_get_validity(const vx_array *array, vx_validity *validity, vx_erro
 size_t vx_array_len(const vx_array *array);
 
 /**
- * Get the [`crate::vx_dtype`] of the array.
+ * Get the [`struct@crate::dtype::vx_dtype`] of the array.
  *
  * The returned pointer is valid as long as the array is valid.
  * Do NOT free the returned dtype pointer - it shares the lifetime of the array.

--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -420,9 +420,6 @@ typedef struct vx_array vx_array;
  * Once the iterator is finished (returns `null` from [`vx_array_iterator_next`]), it may panic
  * on subsequent calls to [`vx_array_iterator_next`].
  *
- * Even after the iterator is finished, an owned iterator must be released by calling
- * [`vx_array_iter_free`].
- *
  * Iterators may be passed between threads, but calls to [`vx_array_iterator_next`] should be
  * serialized and not invoked concurrently.
  */

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -208,7 +208,7 @@ pub unsafe extern "C-unwind" fn vx_array_len(array: *const vx_array) -> usize {
     vx_array::as_ref(array).len()
 }
 
-/// Get the [`crate::vx_dtype`] of the array.
+/// Get the [`struct@crate::dtype::vx_dtype`] of the array.
 ///
 /// The returned pointer is valid as long as the array is valid.
 /// Do NOT free the returned dtype pointer - it shares the lifetime of the array.

--- a/vortex-ffi/src/array_iterator.rs
+++ b/vortex-ffi/src/array_iterator.rs
@@ -17,9 +17,6 @@ box_dyn_wrapper!(
     /// Once the iterator is finished (returns `null` from [`vx_array_iterator_next`]), it may panic
     /// on subsequent calls to [`vx_array_iterator_next`].
     ///
-    /// Even after the iterator is finished, an owned iterator must be released by calling
-    /// [`vx_array_iter_free`].
-    ///
     /// Iterators may be passed between threads, but calls to [`vx_array_iterator_next`] should be
     /// serialized and not invoked concurrently.
     dyn ArrayIterator,

--- a/vortex-ffi/src/macros.rs
+++ b/vortex-ffi/src/macros.rs
@@ -8,11 +8,11 @@
 //! in our APIs and reducing boilerplate code.
 //!
 //! There are four macros provided:
-//! - [`arc_wrapper!`]: Wraps a type in an `Arc<T>` for shared ownership.
-//! - [`arc_dyn_wrapper!`]: Wraps a type in an `Arc<dyn T>` for shared ownership, allowing for dynamic
+//! - `arc_wrapper!`: Wraps a type in an `Arc<T>` for shared ownership.
+//! - `arc_dyn_wrapper!`: Wraps a type in an `Arc<dyn T>` for shared ownership, allowing for dynamic
 //!   dispatch of unsized types (like trait objects).
-//! - [`box_wrapper!`]: Wraps a type in a `Box<T>` for single ownership.
-//! - [`box_dyn_wrapper!`]: Wraps a type in a `Box<dyn T>` for single ownership, allowing for dynamic
+//! - `box_wrapper!`: Wraps a type in a `Box<T>` for single ownership.
+//! - `box_dyn_wrapper!`: Wraps a type in a `Box<dyn T>` for single ownership, allowing for dynamic
 //!   dispatch of unsized types (like trait objects).
 //!
 //! Similarly to Rust, `Box` can be chosen to provide single ownership and mutability semantics,

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -148,7 +148,7 @@ impl FileSegmentSource {
 
 impl SegmentSource for FileSegmentSource {
     fn request(&self, id: SegmentId) -> SegmentFuture {
-        // We eagerly register the read request here assuming the behaviour of [`FileRead`], where
+        // We eagerly register the read request here assuming the behaviour of [`FileSegmentSource`], where
         // coalescing becomes effective prior to the future being polled.
         let spec = *match self.segments.get(*id as usize) {
             Some(spec) => spec,
@@ -191,9 +191,9 @@ impl SegmentSource for FileSegmentSource {
     }
 }
 
-/// A future that resolves a read request from a [`FileRead`].
+/// A future that resolves a read request from a [`FileSegmentSource`].
 ///
-/// See the documentation for [`FileRead`] for details on coalescing and pre-fetching.
+/// See the documentation for [`FileSegmentSource`] for details on coalescing and pre-fetching.
 /// If dropped, the read request will be canceled where possible.
 struct ReadFuture {
     id: usize,

--- a/vortex-layout/src/children.rs
+++ b/vortex-layout/src/children.rs
@@ -62,7 +62,6 @@ impl LayoutChildren for Arc<dyn LayoutChildren> {
 }
 
 /// An implementation of [`LayoutChildren`] for in-memory owned children.
-/// See also [`ViewLayoutChildren`] for lazily deserialized children from flatbuffers.
 #[derive(Clone)]
 pub(crate) struct OwnedLayoutChildren(Vec<LayoutRef>);
 

--- a/vortex-layout/src/scan/multi.rs
+++ b/vortex-layout/src/scan/multi.rs
@@ -382,7 +382,7 @@ fn reader_partition(
 
 /// A partition backed by a single [`LayoutReaderRef`] and a row range.
 ///
-/// On `execute()`, creates a [`ScanBuilder`][crate::ScanBuilder] over the row range, enabling
+/// On `execute()`, creates a [`ScanBuilder`] over the row range, enabling
 /// internal I/O pipelining and split-level parallelism within the reader.
 struct MultiLayoutPartition {
     reader: LayoutReaderRef,

--- a/vortex-row/src/size.rs
+++ b/vortex-row/src/size.rs
@@ -73,7 +73,7 @@ pub(crate) struct SizePassResult {
 ///
 /// Fixed-width columns contribute a single scalar increment to `fixed_per_row`; they do
 /// not touch `var_lengths`. Variable-length columns add per-row contributions into the
-/// lazily-allocated `var_lengths` vec via [`dispatch_size`].
+/// lazily-allocated `var_lengths` vec via `dispatch_size`.
 ///
 /// This is shared by [`RowSize::execute`] (which wraps the result into a
 /// `Struct { fixed, var }`) and the [`RowEncode`](super::encode::RowEncode) pipeline

--- a/vortex-tensor/src/types/vector/mod.rs
+++ b/vortex-tensor/src/types/vector/mod.rs
@@ -17,8 +17,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 
-/// Validates that `storage` is a valid storage dtype for a [`Vector`] or
-/// [`NormalizedVector`](crate::normalized_vector::NormalizedVector) extension type.
+/// Validates that `storage` is a valid storage dtype for a [`Vector`].
 ///
 /// The storage must be a `FixedSizeList<float, dim, nullability>` with non-nullable float
 /// elements. The outer nullability is not constrained.

--- a/vortex-tensor/src/utils.rs
+++ b/vortex-tensor/src/utils.rs
@@ -44,7 +44,7 @@ pub(crate) const SAFETY_FACTOR: usize = 10;
 ///
 /// Reference: Croci, Fasi, Higham, Mary, Mikaitis (2022). "Stochastic rounding: implementation,
 /// error analysis and applications." Royal Society Open Science, 9: 211631, §6.1 "Probabilistic
-/// error analysis." https://doi.org/10.1098/rsos.211631
+/// error analysis." <https://doi.org/10.1098/rsos.211631>
 pub fn unit_norm_tolerance(element_ptype: PType, dimensions: usize) -> f64 {
     let machine_epsilon: f64 = match element_ptype {
         PType::F64 => f64::EPSILON,
@@ -224,6 +224,7 @@ pub fn extract_constant_flat_row(
 /// parent's unioned output, so both are persisted.
 ///
 /// [`CosineSimilarity`]: crate::scalar_fns::cosine_similarity::CosineSimilarity
+/// [`InnerProduct`]: crate::scalar_fns::inner_product::InnerProduct
 #[derive(Clone, prost::Message)]
 pub(crate) struct BinaryTensorOpMetadata {
     #[prost(message, optional, tag = "1")]

--- a/vortex-tui/src/browse/ui/query.rs
+++ b/vortex-tui/src/browse/ui/query.rs
@@ -273,8 +273,8 @@ impl QueryState {
     /// Spawn a background task for the pending query, if any.
     ///
     /// After calling `prepare_*` methods, call this to kick off execution.
-    /// The result will arrive on [`pending_rx`] and should be applied with
-    /// [`apply_query_result`].
+    /// The result will arrive on `pending_rx` and should be applied with
+    /// [`Self::apply_query_result`].
     pub(crate) fn spawn_pending(&mut self, session: &VortexSession, file_path: &str) {
         if !self.pending_execution {
             return;

--- a/vortex-tui/src/segments.rs
+++ b/vortex-tui/src/segments.rs
@@ -35,7 +35,7 @@ struct ColumnInfo {
 
 #[derive(Serialize)]
 struct SegmentInfo {
-    /// Segment name (e.g., "[0]", "data", etc.)
+    /// Segment name (e.g., "\[0\]", "data", etc.)
     name: String,
     /// Row range start
     row_offset: u64,


### PR DESCRIPTION
## Summary

Make sure to actually build rustdoc for all features and crates in the workspace, including private docs.

This PR also includes fixes for every failure I've found. In some cases we had references to dead types/interfaces, I've tried to keep the intent as close as possible to original intent.