### PR TITLE
Timeout slow tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,6 @@
+[profile.default]
+slow-timeout = { period = "30s", terminate-after = 3 }
+
 [[profile.default.overrides]]
-filter = 'test(compress_large_int)'
+filter = 'test(compress_large_int | fsst_compress_offsets_overflow_i32)'
 priority = 100

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,5 @@
 [profile.default]
-slow-timeout = { period = "30s", terminate-after = 3 }
+slow-timeout = { period = "30s", terminate-after = 5 }
 
 [[profile.default.overrides]]
 filter = 'test(compress_large_int | fsst_compress_offsets_overflow_i32)'


### PR DESCRIPTION
## Summary

It seems like the rate of tests hanging has gone up significantly recently which is very wasteful. This config marks tests as slow at 30s, and times them out after 3 periods (AKA 90 seconds).

As far as I'm aware there's only 1 test that approaches 1 minute (also raised its priority), so this change should timeout any normal run.