### PR TITLE
Fix weird malformed license notice in test file

### DIFF
--- a/vortex-array/src/arrays/datetime/test.rs
+++ b/vortex-array/src/arrays/datetime/test.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: Copyright the Vortex contributorsuse crate::dtype::Nullability;
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use rstest::rstest;
 use vortex_buffer::buffer;


### PR DESCRIPTION
## Summary

I was trying [hawkeye](https://github.com/korandoru/hawkeye) which has some nice features `reuse` doesn't have, and it found this weird issue.
