### PR TITLE
perf[gpu]: export arrow device validity on the gpu

### DIFF
--- a/vortex-cuda/benches/arrow_validity_cuda.rs
+++ b/vortex-cuda/benches/arrow_validity_cuda.rs
@@ -53,6 +53,21 @@ unsafe fn release_arrow_device_array(array: &mut ArrowDeviceArray) {
     }
 }
 
+async fn device_validity_buffer(
+    len: usize,
+    validity_offset: usize,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<(usize, BufferHandle)> {
+    let validity_bits = BitBuffer::collect_bool(len + validity_offset, |idx| idx % 3 != 0)
+        .slice(validity_offset..validity_offset + len);
+    let (validity_offset, _, validity_buffer) = validity_bits.into_inner();
+    Ok((
+        validity_offset,
+        ctx.ensure_on_device(BufferHandle::new_host(validity_buffer))
+            .await?,
+    ))
+}
+
 async fn primitive_with_device_bool_validity(
     len: usize,
     validity_offset: usize,
@@ -63,12 +78,8 @@ async fn primitive_with_device_bool_validity(
         .ensure_on_device(BufferHandle::new_host(values.into_byte_buffer()))
         .await?;
 
-    let validity_bits = BitBuffer::collect_bool(len + validity_offset, |idx| idx % 3 != 0);
-    let validity_bits = validity_bits.slice(validity_offset..validity_offset + len);
-    let (validity_offset, _, validity_buffer) = validity_bits.into_inner();
-    let validity_buffer = ctx
-        .ensure_on_device(BufferHandle::new_host(validity_buffer))
-        .await?;
+    let (validity_offset, validity_buffer) =
+        device_validity_buffer(len, validity_offset, ctx).await?;
     let validity =
         BoolArray::new_handle(validity_buffer, validity_offset, len, Validity::NonNullable)
             .into_array();
@@ -146,17 +157,12 @@ fn benchmark_arrow_validity_repack(c: &mut Criterion) {
                 b.iter_custom(|iters| {
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
-
-                    let mut cuda_ctx =
-                        CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
-                            .vortex_expect("failed to create execution context")
-                            .with_launch_strategy(Arc::new(timed));
-                    let source = BitBuffer::collect_bool(len + INPUT_OFFSET, |idx| idx % 3 != 0);
-                    let sliced = source.slice(INPUT_OFFSET..INPUT_OFFSET + len);
-                    let (input_offset, _, input_buffer) = sliced.into_inner();
-                    let input_buffer =
-                        block_on(cuda_ctx.ensure_on_device(BufferHandle::new_host(input_buffer)))
-                            .vortex_expect("failed to copy validity input to device");
+                    let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+                        .vortex_expect("failed to create execution context")
+                        .with_launch_strategy(Arc::new(timed));
+                    let (input_offset, input_buffer) =
+                        block_on(device_validity_buffer(len, INPUT_OFFSET, &mut cuda_ctx))
+                            .vortex_expect("failed to create validity fixture");
 
                     for _ in 0..iters {
                         let output = test_harness::repack_arrow_validity_buffer(
@@ -193,17 +199,12 @@ fn benchmark_arrow_validity_count_nulls(c: &mut Criterion) {
                 b.iter_custom(|iters| {
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
-
                     let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
                         .vortex_expect("failed to create execution context")
                         .with_launch_strategy(Arc::new(timed));
-                    let source = BitBuffer::collect_bool(len + ARROW_OFFSET, |idx| {
-                        idx >= ARROW_OFFSET && idx % 3 != 0
-                    });
-                    let (_, _, input_buffer) = source.into_inner();
-                    let input_buffer =
-                        block_on(cuda_ctx.ensure_on_device(BufferHandle::new_host(input_buffer)))
-                            .vortex_expect("failed to copy validity input to device");
+                    let (_, input_buffer) =
+                        block_on(device_validity_buffer(len, ARROW_OFFSET, &mut cuda_ctx))
+                            .vortex_expect("failed to create validity fixture");
 
                     for _ in 0..iters {
                         let null_count = test_harness::count_arrow_validity_nulls(

--- a/vortex-cuda/benches/arrow_validity_cuda.rs
+++ b/vortex-cuda/benches/arrow_validity_cuda.rs
@@ -9,15 +9,27 @@ mod timed_launch_strategy;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+use std::time::Instant;
 
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::Throughput;
 use futures::executor::block_on;
+use vortex::array::IntoArray;
+use vortex::array::arrays::BoolArray;
+use vortex::array::arrays::PrimitiveArray;
 use vortex::array::buffer::BufferHandle;
+use vortex::array::validity::Validity;
 use vortex::buffer::BitBuffer;
+use vortex::buffer::Buffer;
+use vortex::dtype::PType;
 use vortex::error::VortexExpect;
+use vortex::error::VortexResult;
+use vortex::session::VortexSession;
+use vortex_cuda::CudaExecutionCtx;
 use vortex_cuda::CudaSession;
+use vortex_cuda::arrow::ArrowDeviceArray;
+use vortex_cuda::arrow::DeviceArrayExt;
 use vortex_cuda::arrow::test_harness;
 use vortex_cuda_macros::cuda_available;
 use vortex_cuda_macros::cuda_not_available;
@@ -26,12 +38,106 @@ use crate::timed_launch_strategy::TimedLaunchStrategy;
 
 const INPUT_OFFSET: usize = 5;
 const ARROW_OFFSET: usize = 3;
+const EXPORT_BENCH_SIZES: &[(usize, &str)] = &[(100_000_000, "100M")];
+
+fn validity_bitmap_byte_len(len: usize, bit_offset: usize) -> usize {
+    (bit_offset + len).div_ceil(8)
+}
+
+unsafe fn release_arrow_device_array(array: &mut ArrowDeviceArray) {
+    unsafe {
+        if let Some(release) = array.array.release {
+            release(&raw mut array.array);
+        }
+    }
+}
+
+async fn primitive_with_device_bool_validity(
+    len: usize,
+    validity_offset: usize,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<vortex::array::ArrayRef> {
+    let values = Buffer::<i32>::from_iter((0..len).map(|idx| idx as i32));
+    let values = ctx
+        .ensure_on_device(BufferHandle::new_host(values.into_byte_buffer()))
+        .await?;
+
+    let validity_bits = BitBuffer::collect_bool(len + validity_offset, |idx| idx % 3 != 0);
+    let validity_bits = validity_bits.slice(validity_offset..validity_offset + len);
+    let (validity_offset, _, validity_buffer) = validity_bits.into_inner();
+    let validity_buffer = ctx
+        .ensure_on_device(BufferHandle::new_host(validity_buffer))
+        .await?;
+    let validity =
+        BoolArray::new_handle(validity_buffer, validity_offset, len, Validity::NonNullable)
+            .into_array();
+
+    Ok(
+        PrimitiveArray::from_buffer_handle(values, PType::I32, Validity::Array(validity))
+            .into_array(),
+    )
+}
+
+fn benchmark_arrow_validity_export(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cuda");
+
+    for &(len, len_label) in EXPORT_BENCH_SIZES {
+        for (case, validity_offset) in
+            [("device_bitmap", 0), ("device_bitmap_repack", INPUT_OFFSET)]
+        {
+            group.throughput(Throughput::Bytes(
+                validity_bitmap_byte_len(len, validity_offset) as u64,
+            ));
+            group.bench_with_input(
+                BenchmarkId::new(format!("cuda/arrow_validity/export/{case}"), len_label),
+                &len,
+                |b, &len| {
+                    b.iter_custom(|iters| {
+                        let mut cuda_ctx =
+                            CudaSession::create_execution_ctx(&VortexSession::empty())
+                                .vortex_expect("failed to create execution context");
+                        let array = block_on(primitive_with_device_bool_validity(
+                            len,
+                            validity_offset,
+                            &mut cuda_ctx,
+                        ))
+                        .vortex_expect("failed to create primitive fixture");
+
+                        let mut exported_arrays = Vec::with_capacity(
+                            usize::try_from(iters)
+                                .vortex_expect("iteration count does not fit usize"),
+                        );
+
+                        let start = Instant::now();
+                        for _ in 0..iters {
+                            exported_arrays.push(
+                                block_on(array.clone().export_device_array(&mut cuda_ctx))
+                                    .vortex_expect("failed to export device array"),
+                            );
+                        }
+                        let elapsed = start.elapsed();
+
+                        for exported in &mut exported_arrays {
+                            unsafe { release_arrow_device_array(exported) };
+                        }
+
+                        elapsed
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
 
 fn benchmark_arrow_validity_repack(c: &mut Criterion) {
     let mut group = c.benchmark_group("cuda");
 
     for &(len, len_label) in bench_config::BENCH_SIZES {
-        group.throughput(Throughput::Elements(len as u64));
+        group.throughput(Throughput::Bytes(
+            validity_bitmap_byte_len(len, INPUT_OFFSET) as u64,
+        ));
         group.bench_with_input(
             BenchmarkId::new("cuda/arrow_validity/repack", len_label),
             &len,
@@ -75,7 +181,7 @@ fn benchmark_arrow_validity_repack(c: &mut Criterion) {
 criterion::criterion_group! {
     name = benches;
     config = bench_config::cuda_bench_config();
-    targets = benchmark_arrow_validity_repack
+    targets = benchmark_arrow_validity_repack, benchmark_arrow_validity_export
 }
 
 #[cuda_available]

--- a/vortex-cuda/benches/arrow_validity_cuda.rs
+++ b/vortex-cuda/benches/arrow_validity_cuda.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
+#![expect(clippy::cast_possible_truncation)]
 
 //! CUDA benchmarks for Arrow validity bitmap repacking.
 

--- a/vortex-cuda/benches/arrow_validity_cuda.rs
+++ b/vortex-cuda/benches/arrow_validity_cuda.rs
@@ -179,10 +179,56 @@ fn benchmark_arrow_validity_repack(c: &mut Criterion) {
     group.finish();
 }
 
+fn benchmark_arrow_validity_count_nulls(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cuda");
+
+    for &(len, len_label) in bench_config::BENCH_SIZES {
+        group.throughput(Throughput::Bytes(
+            validity_bitmap_byte_len(len, ARROW_OFFSET) as u64,
+        ));
+        group.bench_with_input(
+            BenchmarkId::new("cuda/arrow_validity/count_nulls", len_label),
+            &len,
+            |b, &len| {
+                b.iter_custom(|iters| {
+                    let timed = TimedLaunchStrategy::default();
+                    let timer = timed.timer();
+
+                    let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+                        .vortex_expect("failed to create execution context")
+                        .with_launch_strategy(Arc::new(timed));
+                    let source = BitBuffer::collect_bool(len + ARROW_OFFSET, |idx| {
+                        idx >= ARROW_OFFSET && idx % 3 != 0
+                    });
+                    let (_, _, input_buffer) = source.into_inner();
+                    let input_buffer =
+                        block_on(cuda_ctx.ensure_on_device(BufferHandle::new_host(input_buffer)))
+                            .vortex_expect("failed to copy validity input to device");
+
+                    for _ in 0..iters {
+                        let null_count = test_harness::count_arrow_validity_nulls(
+                            &input_buffer,
+                            len,
+                            ARROW_OFFSET,
+                            &mut cuda_ctx,
+                        )
+                        .vortex_expect("failed to count Arrow validity nulls");
+                        std::hint::black_box(null_count);
+                    }
+
+                    Duration::from_nanos(timer.load(Ordering::Relaxed))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion::criterion_group! {
     name = benches;
     config = bench_config::cuda_bench_config();
-    targets = benchmark_arrow_validity_repack, benchmark_arrow_validity_export
+    targets = benchmark_arrow_validity_repack, benchmark_arrow_validity_count_nulls, benchmark_arrow_validity_export
 }
 
 #[cuda_available]

--- a/vortex-cuda/kernels/src/arrow_validity.cu
+++ b/vortex-cuda/kernels/src/arrow_validity.cu
@@ -105,9 +105,9 @@ __device__ uint64_t warp_sum(uint64_t value) {
 }
 
 __device__ void arrow_validity_count_valid_device(const uint8_t *const input,
-                                                 uint64_t *const output,
-                                                 uint64_t len,
-                                                 uint64_t arrow_offset) {
+                                                  uint64_t *const output,
+                                                  uint64_t len,
+                                                  uint64_t arrow_offset) {
     __shared__ uint64_t warp_counts[32];
 
     const uint32_t thread = threadIdx.x;

--- a/vortex-cuda/kernels/src/arrow_validity.cu
+++ b/vortex-cuda/kernels/src/arrow_validity.cu
@@ -97,6 +97,58 @@ __device__ void arrow_validity_repack_device(const uint8_t *const input,
     }
 }
 
+__device__ uint64_t warp_sum(uint64_t value) {
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        value += __shfl_down_sync(0xffffffff, value, offset);
+    }
+    return value;
+}
+
+__device__ void arrow_validity_count_valid_device(const uint8_t *const input,
+                                                 uint64_t *const output,
+                                                 uint64_t len,
+                                                 uint64_t arrow_offset) {
+    __shared__ uint64_t warp_counts[32];
+
+    const uint32_t thread = threadIdx.x;
+    const uint64_t worker = blockIdx.x * blockDim.x + thread;
+    const uint64_t validity_bits = len + arrow_offset;
+    const uint64_t input_bytes = (validity_bits + 7) / 8;
+    const uint64_t stride = static_cast<uint64_t>(gridDim.x) * blockDim.x;
+
+    uint64_t valid_count = 0;
+    for (uint64_t byte_idx = worker; byte_idx < input_bytes; byte_idx += stride) {
+        const uint64_t byte_start = byte_idx * 8;
+        uint32_t mask = 0xff;
+        if (byte_start < arrow_offset) {
+            const uint64_t lead = arrow_offset - byte_start;
+            mask = lead >= 8 ? 0 : mask << lead;
+        }
+        const uint64_t remaining = validity_bits - byte_start;
+        if (remaining < 8) {
+            mask &= (uint32_t {1} << remaining) - 1;
+        }
+        valid_count += __popc(static_cast<uint32_t>(input[byte_idx]) & mask);
+    }
+
+    const uint32_t lane = thread & 31;
+    const uint32_t warp = thread >> 5;
+    valid_count = warp_sum(valid_count);
+    if (lane == 0) {
+        warp_counts[warp] = valid_count;
+    }
+    __syncthreads();
+
+    valid_count = thread < (blockDim.x + 31) / 32 ? warp_counts[lane] : 0;
+    if (warp == 0) {
+        valid_count = warp_sum(valid_count);
+        if (lane == 0) {
+            atomicAdd(reinterpret_cast<unsigned long long *>(output),
+                      static_cast<unsigned long long>(valid_count));
+        }
+    }
+}
+
 } // namespace
 
 // CUDA entry point for validity bitmap repacking used by Arrow Device export.
@@ -107,4 +159,12 @@ extern "C" __global__ void arrow_validity_repack(const uint8_t *const input,
                                                  uint64_t arrow_offset,
                                                  uint64_t input_bytes) {
     arrow_validity_repack_device(input, output, len, input_offset, arrow_offset, input_bytes);
+}
+
+// Kernel entry point for counting valid bits in an Arrow validity bitmap.
+extern "C" __global__ void arrow_validity_count_valid(const uint8_t *const input,
+                                                      uint64_t *const output,
+                                                      uint64_t len,
+                                                      uint64_t arrow_offset) {
+    arrow_validity_count_valid_device(input, output, len, arrow_offset);
 }

--- a/vortex-cuda/kernels/src/arrow_validity.cu
+++ b/vortex-cuda/kernels/src/arrow_validity.cu
@@ -7,8 +7,9 @@
 
 namespace {
 
-// Load the `word_idx`-th little-endian u64 of `input`, treating bytes outside
-// `[0, input_bytes)` as zero. `input` must be 8-byte aligned.
+// Transform up to 8 input bytes into a zero-extended 64-bit word:
+//
+//   [ b0 ][ b1 ][ b2 ] | end  ->  [ b0 ][ b1 ][ b2 ][ 00 ][ 00 ][ 00 ][ 00 ][ 00 ]
 __device__ uint64_t load_input_word(const uint8_t *const input, int64_t word_idx, uint64_t input_bytes) {
     if (word_idx < 0) {
         return 0;
@@ -28,11 +29,17 @@ __device__ uint64_t load_input_word(const uint8_t *const input, int64_t word_idx
     return word;
 }
 
-// Build one 64-bit word of the Arrow validity bitmap.
+// Build one output word for sliced validity. The row bits are the same, but
+// row 0 may live at a different bit position in the source and Arrow bitmaps.
+// For example, `input_offset = 5` and `arrow_offset = 0` shifts row0 from bit 5
+// in the input bitmap to bit 0 in the Arrow bitmap.
 //
-// Output bit `b` for `b` in `[arrow_offset, validity_bits)` equals input bit `b + shift`;
-// all other bits are zero. Two adjacent input words are funnel-shifted to align the input
-// bits with the output word, then the leading/trailing edges are masked.
+//   input bitmap:  [ . ][ . ][ . ][ . ][ . ][ row0 ][ row1 ][ row2 ]....
+//                                            ^ input_offset
+//   Arrow bitmap:  [ row0 ][ row1 ][ row2 ]....
+//                     ^ arrow_offset
+//
+// Padding bits are cleared so word-sized validity readers can safely over-read.
 __device__ uint64_t repack_word(const uint8_t *const input,
                                 uint64_t word_idx,
                                 int64_t shift,
@@ -56,40 +63,95 @@ __device__ uint64_t repack_word(const uint8_t *const input,
         return 0;
     }
 
-    // `>> 6` floors also for negative bit positions, unlike `/ 64` which truncates toward zero.
-    const int64_t input_bit = static_cast<int64_t>(word_start) + shift;
-    const int64_t input_word = input_bit >> 6;
-    const uint32_t bit = static_cast<uint32_t>(input_bit & 63);
+    // Each output bit `b` reads source bit `b + shift`.
+    // `>> 6` floors for negative positions, unlike `/ 64` which truncates toward zero.
+    const int64_t source_bit_start = static_cast<int64_t>(word_start) + shift;
+    const int64_t source_word = source_bit_start >> 6;
+    const uint32_t source_bit = static_cast<uint32_t>(source_bit_start & 63);
 
-    const uint64_t lo = load_input_word(input, input_word, input_bytes);
-    if (bit == 0) {
+    const uint64_t lo = load_input_word(input, source_word, input_bytes);
+    if (source_bit == 0) {
         return lo & mask;
     }
-    const uint64_t hi = load_input_word(input, input_word + 1, input_bytes);
-    return ((lo >> bit) | (hi << (64 - bit))) & mask;
+    const uint64_t hi = load_input_word(input, source_word + 1, input_bytes);
+    return ((lo >> source_bit) | (hi << (64 - source_bit))) & mask;
 }
 
-// Rebuild a possibly bit-offset Vortex validity bitmap into an Arrow-compatible bitmap.
+constexpr uint32_t WARP_SIZE = 32;
+constexpr uint32_t FULL_WARP_MASK = 0xffffffff;
+
+// First reduction step for the count kernel: sum one value per lane so each
+// warp produces a single partial count.
 //
-// `input_offset` is the bit offset into `input`; `arrow_offset` is the logical Arrow array offset
-// to preserve in the output. Bits outside `[arrow_offset, arrow_offset + len)` are left unset.
-// The output allocation must hold `ceil((len + arrow_offset) / 64)` full 64-bit words; every
-// word is written, so no zero-initialization of the output is required.
-__device__ void arrow_validity_repack_device(const uint8_t *const input,
-                                             uint64_t *const output,
-                                             uint64_t len,
-                                             uint64_t input_offset,
+//   lanes:  [a][b][c][d]... -> lane 0: a+b+c+d+...
+__device__ uint64_t warp_sum(uint64_t value) {
+    for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+        value += __shfl_down_sync(FULL_WARP_MASK, value, offset);
+    }
+    return value;
+}
+
+// Mask one bitmap byte down to actual rows. This keeps null counting from
+// including Arrow offset padding or trailing padding bits.
+//
+//   byte bits:  [ pad ][ row ][ row ][ row ][ pad ]
+//   mask:       [  0  ][  1  ][  1  ][  1  ][  0  ]
+__device__ uint32_t arrow_validity_byte_mask(uint64_t byte_idx,
                                              uint64_t arrow_offset,
-                                             uint64_t input_bytes) {
-    // One worker owns a contiguous range of output words. Each word is rebuilt locally so
-    // there are no cross-thread bit writes or atomics.
+                                             uint64_t validity_bits) {
+    const uint64_t byte_start = byte_idx * 8;
+
+    uint32_t mask = 0xff;
+    if (byte_start < arrow_offset) {
+        const uint64_t lead = arrow_offset - byte_start;
+        mask = lead >= 8 ? 0 : mask << lead;
+    }
+
+    const uint64_t remaining = validity_bits - byte_start;
+    if (remaining < 8) {
+        mask &= (uint32_t {1} << remaining) - 1;
+    }
+    return mask;
+}
+
+// Combine warp partial counts into one block total. Only thread 0 returns a
+// non-zero value so the count kernel does one global atomic per block.
+//
+//   per-thread counts -> per-warp sums -> block sum -> atomicAdd
+__device__ uint64_t block_sum_to_thread_zero(uint64_t value, uint64_t *const warp_counts) {
+    const uint32_t thread = threadIdx.x;
+    const uint32_t lane = thread & (WARP_SIZE - 1);
+    const uint32_t warp = thread / WARP_SIZE;
+    const uint32_t block_warps = (blockDim.x + WARP_SIZE - 1) / WARP_SIZE;
+
+    value = warp_sum(value);
+    if (lane == 0) {
+        warp_counts[warp] = value;
+    }
+    __syncthreads();
+
+    value = lane < block_warps ? warp_counts[lane] : 0;
+    value = warp == 0 ? warp_sum(value) : 0;
+    return thread == 0 ? value : 0;
+}
+
+} // namespace
+
+// Repack sliced validity when the source bitmap offset does not match the
+// Arrow array offset. Each thread writes independent output words.
+//
+//   thread 0 -> output word 0, word N, ...
+//   thread 1 -> output word 1, word N+1, ...
+extern "C" __global__ void arrow_validity_repack(const uint8_t *const input,
+                                                 uint64_t *const output,
+                                                 uint64_t len,
+                                                 uint64_t input_offset,
+                                                 uint64_t arrow_offset,
+                                                 uint64_t input_bytes) {
     const uint64_t worker = blockIdx.x * blockDim.x + threadIdx.x;
     const uint64_t validity_bits = len + arrow_offset;
     const uint64_t output_words = (validity_bits + 63) / 64;
     const uint64_t stride = static_cast<uint64_t>(gridDim.x) * blockDim.x;
-
-    // Translate Arrow-visible output bits back to source bitmap bits. The source bitmap may
-    // start at any bit offset, while Arrow's buffer pointer is byte-addressed.
     const int64_t shift = static_cast<int64_t>(input_offset) - static_cast<int64_t>(arrow_offset);
 
     for (uint64_t word_idx = worker; word_idx < output_words; word_idx += stride) {
@@ -97,74 +159,33 @@ __device__ void arrow_validity_repack_device(const uint8_t *const input,
     }
 }
 
-__device__ uint64_t warp_sum(uint64_t value) {
-    for (int offset = 16; offset > 0; offset >>= 1) {
-        value += __shfl_down_sync(0xffffffff, value, offset);
-    }
-    return value;
-}
-
-__device__ void arrow_validity_count_valid_device(const uint8_t *const input,
-                                                  uint64_t *const output,
-                                                  uint64_t len,
-                                                  uint64_t arrow_offset) {
-    __shared__ uint64_t warp_counts[32];
-
-    const uint32_t thread = threadIdx.x;
-    const uint64_t worker = blockIdx.x * blockDim.x + thread;
-    const uint64_t validity_bits = len + arrow_offset;
-    const uint64_t input_bytes = (validity_bits + 7) / 8;
-    const uint64_t stride = static_cast<uint64_t>(gridDim.x) * blockDim.x;
-
-    uint64_t valid_count = 0;
-    for (uint64_t byte_idx = worker; byte_idx < input_bytes; byte_idx += stride) {
-        const uint64_t byte_start = byte_idx * 8;
-        uint32_t mask = 0xff;
-        if (byte_start < arrow_offset) {
-            const uint64_t lead = arrow_offset - byte_start;
-            mask = lead >= 8 ? 0 : mask << lead;
-        }
-        const uint64_t remaining = validity_bits - byte_start;
-        if (remaining < 8) {
-            mask &= (uint32_t {1} << remaining) - 1;
-        }
-        valid_count += __popc(static_cast<uint32_t>(input[byte_idx]) & mask);
-    }
-
-    const uint32_t lane = thread & 31;
-    const uint32_t warp = thread >> 5;
-    valid_count = warp_sum(valid_count);
-    if (lane == 0) {
-        warp_counts[warp] = valid_count;
-    }
-    __syncthreads();
-
-    valid_count = thread < (blockDim.x + 31) / 32 ? warp_counts[lane] : 0;
-    if (warp == 0) {
-        valid_count = warp_sum(valid_count);
-        if (lane == 0) {
-            atomicAdd(reinterpret_cast<unsigned long long *>(output),
-                      static_cast<unsigned long long>(valid_count));
-        }
-    }
-}
-
-} // namespace
-
-// CUDA entry point for validity bitmap repacking used by Arrow Device export.
-extern "C" __global__ void arrow_validity_repack(const uint8_t *const input,
-                                                 uint64_t *const output,
-                                                 uint64_t len,
-                                                 uint64_t input_offset,
-                                                 uint64_t arrow_offset,
-                                                 uint64_t input_bytes) {
-    arrow_validity_repack_device(input, output, len, input_offset, arrow_offset, input_bytes);
-}
-
-// Kernel entry point for counting valid bits in an Arrow validity bitmap.
+// Count valid rows directly from the device bitmap so Arrow export can provide
+// an exact null_count without copying validity to the CPU.
+//
+//   bytes -> mask padding -> popcount -> block sum -> global count
 extern "C" __global__ void arrow_validity_count_valid(const uint8_t *const input,
                                                       uint64_t *const output,
                                                       uint64_t len,
                                                       uint64_t arrow_offset) {
-    arrow_validity_count_valid_device(input, output, len, arrow_offset);
+    __shared__ uint64_t warp_counts[WARP_SIZE];
+
+    const uint64_t validity_bits = len + arrow_offset;
+    const uint64_t input_bytes = (validity_bits + 7) / 8;
+    const uint64_t worker = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint64_t stride = static_cast<uint64_t>(gridDim.x) * blockDim.x;
+
+    // Grid-stride over bitmap bytes. Each byte contributes the popcount of only
+    // row bits; leading Arrow offset bits and trailing padding bits are masked out.
+    uint64_t valid_count = 0;
+    for (uint64_t byte_idx = worker; byte_idx < input_bytes; byte_idx += stride) {
+        const uint32_t mask = arrow_validity_byte_mask(byte_idx, arrow_offset, validity_bits);
+        valid_count += __popc(static_cast<uint32_t>(input[byte_idx]) & mask);
+    }
+
+    // Reduce within the block first so global contention is one atomic add per block.
+    valid_count = block_sum_to_thread_zero(valid_count, warp_counts);
+    if (threadIdx.x == 0) {
+        atomicAdd(reinterpret_cast<unsigned long long *>(output),
+                  static_cast<unsigned long long>(valid_count));
+    }
 }

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -794,39 +794,17 @@ pub(super) async fn export_arrow_validity_buffer(
                 )
             })?;
             let BoolDataParts { bits, meta } = array.into_data().into_parts(len);
-            export_validity_bitmap(
-                bits,
-                meta.offset(),
-                len,
-                arrow_offset,
-                UNKNOWN_NULL_COUNT,
-                ctx,
-            )
-            .await
+            let bitmap = ctx.ensure_on_device(bits).await?;
+            // Repack only when a bit-level offset can't be expressed by Arrow's byte-addressed
+            // validity buffer plus array offset.
+            let bitmap = if arrow_offset == 0 && meta.offset() == 0 {
+                bitmap
+            } else {
+                repack_arrow_validity_buffer(&bitmap, meta.offset(), len, arrow_offset, ctx)?
+            };
+            Ok((Some(bitmap), UNKNOWN_NULL_COUNT))
         }
     }
-}
-
-/// Move an already-materialized validity bitmap to device memory and align it for export.
-async fn export_validity_bitmap(
-    bitmap: BufferHandle,
-    bitmap_offset: usize,
-    len: usize,
-    arrow_offset: usize,
-    null_count: i64,
-    ctx: &mut CudaExecutionCtx,
-) -> VortexResult<(Option<BufferHandle>, i64)> {
-    if null_count == 0 {
-        return Ok((None, 0));
-    }
-
-    let bitmap = ctx.ensure_on_device(bitmap).await?;
-    let bitmap = if arrow_offset == 0 && bitmap_offset == 0 {
-        bitmap
-    } else {
-        repack_arrow_validity_buffer(&bitmap, bitmap_offset, len, arrow_offset, ctx)?
-    };
-    Ok((Some(bitmap), null_count))
 }
 
 /// Return the byte length needed for `len` validity bits at the given bit offset.

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -844,11 +844,8 @@ pub(super) fn repack_arrow_validity_buffer(
     arrow_offset: usize,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<BufferHandle> {
-    let validity_bits = len
-        .checked_add(arrow_offset)
-        .ok_or_else(|| vortex_err!("Arrow validity bit length overflows usize"))?;
-    let output_bytes = validity_bits.div_ceil(8);
-    let output_words = validity_bits.div_ceil(u64::BITS as usize);
+    let output_bytes = validity_bitmap_byte_len(len, arrow_offset)?;
+    let output_words = output_bytes.div_ceil(size_of::<u64>());
 
     // The kernel loads the input bitmap as 64-bit words.
     if !input_buffer

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -76,6 +76,7 @@ use crate::arrow::cuda_decimal_value_type;
 use crate::arrow::list_view::export_device_list_view;
 use crate::cub::exclusive_sum_i32;
 use crate::executor::CudaArrayExt;
+use crate::executor::execute_validity_cuda;
 
 /// An implementation of `ExportDeviceArray` that exports Vortex arrays to `ArrowDeviceArray` by
 /// first decoding the array on the GPU and then converting the canonical type to the nearest
@@ -772,6 +773,10 @@ pub(super) async fn export_arrow_validity_buffer(
     arrow_offset: usize,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<(Option<BufferHandle>, i64)> {
+    // Container export paths reach here without going through `execute_cuda`, so decode the
+    // validity on the GPU here to turn any lazy/compressed bool array (e.g. dict-encoded, or from
+    // take/scan) into a device-resident canonical bool before export.
+    let validity = execute_validity_cuda(validity, len, ctx).await?;
     match validity {
         Validity::NonNullable | Validity::AllValid => Ok((None, 0)),
         Validity::AllInvalid => Ok((
@@ -781,7 +786,7 @@ pub(super) async fn export_arrow_validity_buffer(
             )?),
             i64::try_from(len)?,
         )),
-        Validity::Array(array) if array.is_canonical() => {
+        Validity::Array(array) => {
             let array = array.try_downcast::<Bool>().map_err(|array| {
                 vortex_err!(
                     "canonical validity array must be bool, got {}",
@@ -799,10 +804,6 @@ pub(super) async fn export_arrow_validity_buffer(
             )
             .await
         }
-        Validity::Array(array) => vortex_bail!(
-            "Arrow Device export expected CUDA-executed canonical bool validity, got {}",
-            array.encoding_id()
-        ),
     }
 }
 
@@ -1687,7 +1688,7 @@ mod tests {
             )
         );
         assert_eq!(exported.array.array.length, 4);
-        assert_eq!(exported.array.array.null_count, 1);
+        assert_eq!(exported.array.array.null_count, super::UNKNOWN_NULL_COUNT);
         assert_eq!(exported.array.array.n_buffers, 2);
         assert_eq!(exported.array.array.n_children, 0);
         assert!(!exported.array.array.dictionary.is_null());
@@ -1745,7 +1746,7 @@ mod tests {
         let children = unsafe { std::slice::from_raw_parts(exported.array.array.children, 1) };
         let dict_child = unsafe { &*children[0] };
         assert!(!dict_child.dictionary.is_null());
-        assert_eq!(dict_child.null_count, 1);
+        assert_eq!(dict_child.null_count, super::UNKNOWN_NULL_COUNT);
 
         unsafe { release_exported_array(&raw mut exported.array.array) };
         Ok(())
@@ -1778,7 +1779,7 @@ mod tests {
             [0, 1, 0]
         );
         let dictionary = unsafe { &*exported.array.array.dictionary };
-        assert_eq!(dictionary.null_count, 1);
+        assert_eq!(dictionary.null_count, super::UNKNOWN_NULL_COUNT);
         assert_eq!(private_data_buffer_i32_values(dictionary, 1)?.len(), 2);
 
         unsafe { release_exported_array(&raw mut exported.array.array) };
@@ -2055,7 +2056,7 @@ mod tests {
         assert_binary_layout(
             &exported.array.array,
             5,
-            1,
+            super::UNKNOWN_NULL_COUNT,
             &[0, 0, 3, 3, 8, i32::try_from(8 + out_of_line.len())?],
             &[b"\x00\xff\xfe".as_slice(), b"short", out_of_line].concat(),
         )?;
@@ -2569,7 +2570,7 @@ mod tests {
             [0, 1, 0, 1, 2]
         );
         let dictionary = unsafe { &*elements.dictionary };
-        assert_eq!(dictionary.null_count, 1);
+        assert_eq!(dictionary.null_count, super::UNKNOWN_NULL_COUNT);
 
         unsafe { release_exported_array(&raw mut exported.array.array) };
         Ok(())
@@ -2815,7 +2816,7 @@ mod tests {
         let mut exported = utf8.export_device_array_with_schema(&mut ctx).await?;
         let field = Field::try_from(&exported.schema)?;
         assert_eq!(field, Field::new("", DataType::Utf8View, true));
-        assert_varbinview_shape(&exported.array.array, 3, 1)?;
+        assert_varbinview_shape(&exported.array.array, 3, super::UNKNOWN_NULL_COUNT)?;
         assert_eq!(exported.array.device_type, ARROW_DEVICE_CUDA);
 
         let private_data = unsafe { &*exported.array.array.private_data.cast::<PrivateData>() };
@@ -2843,7 +2844,7 @@ mod tests {
         assert_binary_layout(
             &exported.array.array,
             3,
-            1,
+            super::UNKNOWN_NULL_COUNT,
             &[0, 0, 2, i32::try_from(2 + sliced_out_of_line.len())?],
             &[b"\x00\xff".as_slice(), sliced_out_of_line].concat(),
         )?;
@@ -3113,6 +3114,40 @@ mod tests {
                 vec![PrimitiveArray::from_iter(0u32..3).into_array()],
                 3,
                 Validity::from_iter([true, false, true]),
+            )?
+            .into_array(),
+            1,
+            super::UNKNOWN_NULL_COUNT,
+            &mut ctx,
+        )
+        .await?;
+        unsafe { release_exported_array(&raw mut struct_array.array) };
+
+        Ok(())
+    }
+
+    // A container's row validity may be a non-canonical bool array (e.g. dict-encoded, or
+    // produced by take/scan). The container export paths bypass execute_cuda, so
+    // export_arrow_validity_buffer must canonicalize the validity on the GPU itself instead of
+    // bailing.
+    #[crate::test]
+    async fn test_export_struct_non_canonical_validity() -> VortexResult<()> {
+        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+            .vortex_expect("failed to create execution context");
+
+        let validity = DictArray::try_new(
+            PrimitiveArray::from_iter([0u32, 1, 0]).into_array(),
+            BoolArray::from_iter([true, false]).into_array(),
+        )?
+        .into_array();
+        assert!(!validity.is_canonical());
+
+        let mut struct_array = assert_nullable_export(
+            StructArray::try_new(
+                FieldNames::from_iter(["a"]),
+                vec![PrimitiveArray::from_iter(0u32..3).into_array()],
+                3,
+                Validity::Array(validity),
             )?
             .into_array(),
             1,

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -778,6 +778,8 @@ pub(super) async fn export_arrow_validity_buffer(
     let validity = execute_validity_cuda(validity, len, ctx).await?;
     match validity {
         Validity::NonNullable | Validity::AllValid => Ok((None, 0)),
+        // For non-Null Arrow layouts, callers still export the normal value buffers.
+        // This only marks every row null via buffer 0, the validity bitmap.
         Validity::AllInvalid => Ok((
             Some(device_zeroed_byte_buffer(
                 validity_bitmap_byte_len(len, arrow_offset)?,
@@ -832,7 +834,7 @@ fn device_zeroed_byte_buffer(
     Ok(BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(buffer))).slice(0..byte_len))
 }
 
-pub(super) fn count_arrow_validity_nulls(
+pub fn count_arrow_validity_nulls(
     bitmap: &BufferHandle,
     len: usize,
     arrow_offset: usize,
@@ -894,7 +896,7 @@ pub(super) fn count_arrow_validity_nulls(
 /// plus an array offset, so sliced compact exports need a GPU rewrite when either side has a
 /// bit-level offset. The kernel writes the output one 64-bit word at a time, funnel-shifting two
 /// adjacent input words, so the allocation is padded to whole words (zeroed by the edge masks).
-pub(super) fn repack_arrow_validity_buffer(
+pub fn repack_arrow_validity_buffer(
     input_buffer: &BufferHandle,
     input_offset: usize,
     len: usize,
@@ -3161,7 +3163,7 @@ mod tests {
     // Non-canonical row validity should export as a device-resident bitmap.
     #[crate::test]
     async fn test_export_struct_non_canonical_validity() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let validity = DictArray::try_new(

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -17,6 +17,7 @@ use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
+use vortex::array::arrays::Bool;
 use vortex::array::arrays::DecimalArray;
 use vortex::array::arrays::Dict;
 use vortex::array::arrays::DictArray;
@@ -58,7 +59,6 @@ use vortex::error::vortex_bail;
 use vortex::error::vortex_ensure;
 use vortex::error::vortex_err;
 use vortex::extension::datetime::AnyTemporal;
-use vortex::mask::Mask;
 
 use crate::CudaBufferExt;
 use crate::CudaDeviceBuffer;
@@ -772,36 +772,72 @@ pub(super) async fn export_arrow_validity_buffer(
     arrow_offset: usize,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<(Option<BufferHandle>, i64)> {
-    let mask = validity.execute_mask(len, ctx.execution_ctx())?;
-    let null_count = i64::try_from(mask.false_count())?;
-    let validity_bits = len + arrow_offset;
-    let validity_bytes = validity_bits.div_ceil(8);
-
-    let validity_buffer = match mask {
-        Mask::AllTrue(_) => return Ok((None, 0)),
-        Mask::AllFalse(_) => device_zeroed_byte_buffer(validity_bytes, ctx)?,
-        Mask::Values(values) => {
-            // Shrinking the offset below 8 bounds the host-to-device copy to the slice's bytes
-            // instead of the whole backing bitmap.
-            let bits = values.bit_buffer().clone().shrink_offset();
-            if arrow_offset == 0 && bits.offset() == 0 {
-                // Fast path: the Vortex bitmap already matches Arrow's byte-addressed layout.
-                let (_, _, buffer) = bits.into_inner();
-                ctx.ensure_on_device(BufferHandle::new_host(buffer)).await?
-            } else {
-                // Slow path: bit offsets cannot be represented by the Arrow buffer pointer.
-                // Repack on the GPU so compact/sliced exports keep Arrow offset semantics.
-                let (input_offset, _, input_buffer) = bits.into_inner();
-                let input_buffer = ctx
-                    .ensure_on_device(BufferHandle::new_host(input_buffer))
-                    .await?;
-                repack_arrow_validity_buffer(&input_buffer, input_offset, len, arrow_offset, ctx)?
-            }
+    match validity {
+        Validity::NonNullable | Validity::AllValid => Ok((None, 0)),
+        Validity::AllInvalid => Ok((
+            Some(device_zeroed_byte_buffer(
+                validity_bitmap_byte_len(len, arrow_offset)?,
+                ctx,
+            )?),
+            i64::try_from(len)?,
+        )),
+        Validity::Array(array) if array.is_canonical() => {
+            let array = array.try_downcast::<Bool>().map_err(|array| {
+                vortex_err!(
+                    "canonical validity array must be bool, got {}",
+                    array.dtype()
+                )
+            })?;
+            let BoolDataParts { bits, meta } = array.into_data().into_parts(len);
+            export_validity_bitmap(
+                bits,
+                meta.offset(),
+                len,
+                arrow_offset,
+                UNKNOWN_NULL_COUNT,
+                ctx,
+            )
+            .await
         }
-    };
-
-    Ok((Some(validity_buffer), null_count))
+        Validity::Array(array) => vortex_bail!(
+            "Arrow Device export expected CUDA-executed canonical bool validity, got {}",
+            array.encoding_id()
+        ),
+    }
 }
+
+/// Move an already-materialized validity bitmap to device memory and align it for export.
+async fn export_validity_bitmap(
+    bitmap: BufferHandle,
+    bitmap_offset: usize,
+    len: usize,
+    arrow_offset: usize,
+    null_count: i64,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<(Option<BufferHandle>, i64)> {
+    if null_count == 0 {
+        return Ok((None, 0));
+    }
+
+    let bitmap = ctx.ensure_on_device(bitmap).await?;
+    let bitmap = if arrow_offset == 0 && bitmap_offset == 0 {
+        bitmap
+    } else {
+        repack_arrow_validity_buffer(&bitmap, bitmap_offset, len, arrow_offset, ctx)?
+    };
+    Ok((Some(bitmap), null_count))
+}
+
+/// Return the byte length needed for `len` validity bits at the given bit offset.
+fn validity_bitmap_byte_len(len: usize, arrow_offset: usize) -> VortexResult<usize> {
+    Ok(len
+        .checked_add(arrow_offset)
+        .ok_or_else(|| vortex_err!("Arrow validity bit length overflows usize"))?
+        .div_ceil(8))
+}
+
+/// Arrow C Data uses -1 when the null count has not been computed.
+const UNKNOWN_NULL_COUNT: i64 = -1;
 
 /// Allocate a zeroed device buffer with cuDF-safe padding for Arrow validity masks.
 fn device_zeroed_byte_buffer(
@@ -2925,7 +2961,7 @@ mod tests {
         let mut primitive = assert_nullable_export(
             PrimitiveArray::from_option_iter([Some(1i32), None, Some(3)]).into_array(),
             2,
-            1,
+            super::UNKNOWN_NULL_COUNT,
             &mut ctx,
         )
         .await?;
@@ -2954,7 +2990,7 @@ mod tests {
                 .into_array()
                 .slice(1..4)?,
             2,
-            1,
+            super::UNKNOWN_NULL_COUNT,
             &mut ctx,
         )
         .await?;
@@ -3003,7 +3039,7 @@ mod tests {
             )
             .into_array(),
             2,
-            1,
+            super::UNKNOWN_NULL_COUNT,
             &mut ctx,
         )
         .await?;
@@ -3033,7 +3069,7 @@ mod tests {
             )
             .into_array(),
             2,
-            1,
+            super::UNKNOWN_NULL_COUNT,
             &mut ctx,
         )
         .await?;
@@ -3056,7 +3092,7 @@ mod tests {
             ])
             .into_array(),
             4,
-            1,
+            super::UNKNOWN_NULL_COUNT,
             &mut ctx,
         )
         .await?;
@@ -3080,7 +3116,7 @@ mod tests {
             )?
             .into_array(),
             1,
-            1,
+            super::UNKNOWN_NULL_COUNT,
             &mut ctx,
         )
         .await?;

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -804,7 +804,9 @@ pub(super) async fn export_arrow_validity_buffer(
             } else {
                 repack_arrow_validity_buffer(&bitmap, meta.offset(), len, arrow_offset, ctx)?
             };
-            Ok((Some(bitmap), ARROW_UNKNOWN_NULL_COUNT))
+            // Keep nullable exports self-describing for consumers that require exact null counts.
+            let null_count = count_arrow_validity_nulls(&bitmap, len, arrow_offset, ctx)?;
+            Ok((Some(bitmap), null_count))
         }
     }
 }
@@ -817,9 +819,6 @@ fn validity_bitmap_byte_len(len: usize, arrow_offset: usize) -> VortexResult<usi
         .div_ceil(8))
 }
 
-/// Arrow C Data uses -1 when the null count has not been computed.
-const ARROW_UNKNOWN_NULL_COUNT: i64 = -1;
-
 /// Allocate a zeroed device buffer with cuDF-safe padding for Arrow validity masks.
 fn device_zeroed_byte_buffer(
     byte_len: usize,
@@ -831,6 +830,62 @@ fn device_zeroed_byte_buffer(
         .memset_zeros(&mut buffer)
         .map_err(|err| vortex_err!("Failed to zero Arrow validity buffer: {err}"))?;
     Ok(BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(buffer))).slice(0..byte_len))
+}
+
+pub(super) fn count_arrow_validity_nulls(
+    bitmap: &BufferHandle,
+    len: usize,
+    arrow_offset: usize,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<i64> {
+    if len == 0 {
+        return Ok(0);
+    }
+
+    let expected_bytes = validity_bitmap_byte_len(len, arrow_offset)?;
+    vortex_ensure!(
+        bitmap.len() >= expected_bytes,
+        "Arrow validity bitmap has {} bytes, expected at least {expected_bytes}",
+        bitmap.len()
+    );
+
+    let mut count = ctx.device_alloc::<u64>(1)?;
+    ctx.stream()
+        .memset_zeros(&mut count)
+        .map_err(|err| vortex_err!("Failed to zero Arrow validity count buffer: {err}"))?;
+    let count = CudaDeviceBuffer::new(count);
+
+    let input_view = bitmap.cuda_view::<u8>()?;
+    let output_view = count.as_view::<u64>();
+    let len = u64::try_from(len)?;
+    let arrow_offset = u64::try_from(arrow_offset)?;
+
+    let kernel = ctx.load_function_with_suffixes("arrow_validity", &["count_valid"])?;
+    const COUNT_THREADS_PER_BLOCK: u32 = 256;
+    const MAX_COUNT_BLOCKS: u32 = 4096;
+    let num_blocks = u32::try_from(expected_bytes.div_ceil(COUNT_THREADS_PER_BLOCK as usize))?
+        .clamp(1, MAX_COUNT_BLOCKS);
+    let config = LaunchConfig {
+        grid_dim: (num_blocks, 1, 1),
+        block_dim: (COUNT_THREADS_PER_BLOCK, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    ctx.launch_kernel_config(&kernel, config, expected_bytes, |args| {
+        args.arg(&input_view)
+            .arg(&output_view)
+            .arg(&len)
+            .arg(&arrow_offset);
+    })?;
+
+    let valid_count = ctx
+        .stream()
+        .clone_dtoh(&output_view)
+        .map_err(|err| vortex_err!("Failed to copy Arrow validity count to host: {err}"))?
+        .into_iter()
+        .next()
+        .ok_or_else(|| vortex_err!("Arrow validity count kernel returned no output"))?;
+
+    Ok(i64::try_from(len - valid_count)?)
 }
 
 /// Repack a validity bitmap into Arrow layout without copying bitmap bits back to the CPU.
@@ -1665,10 +1720,7 @@ mod tests {
             )
         );
         assert_eq!(exported.array.array.length, 4);
-        assert_eq!(
-            exported.array.array.null_count,
-            super::ARROW_UNKNOWN_NULL_COUNT
-        );
+        assert_eq!(exported.array.array.null_count, 1);
         assert_eq!(exported.array.array.n_buffers, 2);
         assert_eq!(exported.array.array.n_children, 0);
         assert!(!exported.array.array.dictionary.is_null());
@@ -1726,7 +1778,7 @@ mod tests {
         let children = unsafe { std::slice::from_raw_parts(exported.array.array.children, 1) };
         let dict_child = unsafe { &*children[0] };
         assert!(!dict_child.dictionary.is_null());
-        assert_eq!(dict_child.null_count, super::ARROW_UNKNOWN_NULL_COUNT);
+        assert_eq!(dict_child.null_count, 1);
 
         unsafe { release_exported_array(&raw mut exported.array.array) };
         Ok(())
@@ -1759,7 +1811,7 @@ mod tests {
             [0, 1, 0]
         );
         let dictionary = unsafe { &*exported.array.array.dictionary };
-        assert_eq!(dictionary.null_count, super::ARROW_UNKNOWN_NULL_COUNT);
+        assert_eq!(dictionary.null_count, 1);
         assert_eq!(private_data_buffer_i32_values(dictionary, 1)?.len(), 2);
 
         unsafe { release_exported_array(&raw mut exported.array.array) };
@@ -2036,7 +2088,7 @@ mod tests {
         assert_binary_layout(
             &exported.array.array,
             5,
-            super::ARROW_UNKNOWN_NULL_COUNT,
+            1,
             &[0, 0, 3, 3, 8, i32::try_from(8 + out_of_line.len())?],
             &[b"\x00\xff\xfe".as_slice(), b"short", out_of_line].concat(),
         )?;
@@ -2550,7 +2602,7 @@ mod tests {
             [0, 1, 0, 1, 2]
         );
         let dictionary = unsafe { &*elements.dictionary };
-        assert_eq!(dictionary.null_count, super::ARROW_UNKNOWN_NULL_COUNT);
+        assert_eq!(dictionary.null_count, 1);
 
         unsafe { release_exported_array(&raw mut exported.array.array) };
         Ok(())
@@ -2796,7 +2848,7 @@ mod tests {
         let mut exported = utf8.export_device_array_with_schema(&mut ctx).await?;
         let field = Field::try_from(&exported.schema)?;
         assert_eq!(field, Field::new("", DataType::Utf8View, true));
-        assert_varbinview_shape(&exported.array.array, 3, super::ARROW_UNKNOWN_NULL_COUNT)?;
+        assert_varbinview_shape(&exported.array.array, 3, 1)?;
         assert_eq!(exported.array.device_type, ARROW_DEVICE_CUDA);
 
         let private_data = unsafe { &*exported.array.array.private_data.cast::<PrivateData>() };
@@ -2824,7 +2876,7 @@ mod tests {
         assert_binary_layout(
             &exported.array.array,
             3,
-            super::ARROW_UNKNOWN_NULL_COUNT,
+            1,
             &[0, 0, 2, i32::try_from(2 + sliced_out_of_line.len())?],
             &[b"\x00\xff".as_slice(), sliced_out_of_line].concat(),
         )?;
@@ -2942,7 +2994,7 @@ mod tests {
         let mut primitive = assert_nullable_export(
             PrimitiveArray::from_option_iter([Some(1i32), None, Some(3)]).into_array(),
             2,
-            super::ARROW_UNKNOWN_NULL_COUNT,
+            1,
             &mut ctx,
         )
         .await?;
@@ -2971,7 +3023,7 @@ mod tests {
                 .into_array()
                 .slice(1..4)?,
             2,
-            super::ARROW_UNKNOWN_NULL_COUNT,
+            1,
             &mut ctx,
         )
         .await?;
@@ -3020,7 +3072,7 @@ mod tests {
             )
             .into_array(),
             2,
-            super::ARROW_UNKNOWN_NULL_COUNT,
+            1,
             &mut ctx,
         )
         .await?;
@@ -3050,7 +3102,7 @@ mod tests {
             )
             .into_array(),
             2,
-            super::ARROW_UNKNOWN_NULL_COUNT,
+            1,
             &mut ctx,
         )
         .await?;
@@ -3073,7 +3125,7 @@ mod tests {
             ])
             .into_array(),
             4,
-            super::ARROW_UNKNOWN_NULL_COUNT,
+            1,
             &mut ctx,
         )
         .await?;
@@ -3097,7 +3149,7 @@ mod tests {
             )?
             .into_array(),
             1,
-            super::ARROW_UNKNOWN_NULL_COUNT,
+            1,
             &mut ctx,
         )
         .await?;
@@ -3106,10 +3158,7 @@ mod tests {
         Ok(())
     }
 
-    // A container's row validity may be a non-canonical bool array (e.g. dict-encoded, or
-    // produced by take/scan). The container export paths bypass execute_cuda, so
-    // export_arrow_validity_buffer must canonicalize the validity on the GPU itself instead of
-    // bailing.
+    // Non-canonical row validity should export as a device-resident bitmap.
     #[crate::test]
     async fn test_export_struct_non_canonical_validity() -> VortexResult<()> {
         let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
@@ -3131,7 +3180,7 @@ mod tests {
             )?
             .into_array(),
             1,
-            super::ARROW_UNKNOWN_NULL_COUNT,
+            1,
             &mut ctx,
         )
         .await?;

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -773,9 +773,8 @@ pub(super) async fn export_arrow_validity_buffer(
     arrow_offset: usize,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<(Option<BufferHandle>, i64)> {
-    // Container export paths reach here without going through `execute_cuda`, so decode the
-    // validity on the GPU here to turn any lazy/compressed bool array (e.g. dict-encoded, or from
-    // take/scan) into a device-resident canonical bool before export.
+    // Validity is exported separately from the array data. Decode it here so Arrow
+    // gets a device-resident validity buffer alongside the array it belongs to.
     let validity = execute_validity_cuda(validity, len, ctx).await?;
     match validity {
         Validity::NonNullable | Validity::AllValid => Ok((None, 0)),
@@ -795,14 +794,17 @@ pub(super) async fn export_arrow_validity_buffer(
             })?;
             let BoolDataParts { bits, meta } = array.into_data().into_parts(len);
             let bitmap = ctx.ensure_on_device(bits).await?;
-            // Repack only when a bit-level offset can't be expressed by Arrow's byte-addressed
-            // validity buffer plus array offset.
-            let bitmap = if arrow_offset == 0 && meta.offset() == 0 {
+            // ArrowDeviceArray uses ArrowArray layout with its buffers being device pointers.
+            //
+            // Validity is one bit per row, addressed via the Arrow array offset. Reuse the bitmap
+            // when Vortex's validity offset already matches Arrow's; otherwise repack on the GPU
+            // so row i is at Arrow bit `arrow_offset + i`.
+            let bitmap = if meta.offset() == arrow_offset {
                 bitmap
             } else {
                 repack_arrow_validity_buffer(&bitmap, meta.offset(), len, arrow_offset, ctx)?
             };
-            Ok((Some(bitmap), UNKNOWN_NULL_COUNT))
+            Ok((Some(bitmap), ARROW_UNKNOWN_NULL_COUNT))
         }
     }
 }
@@ -816,7 +818,7 @@ fn validity_bitmap_byte_len(len: usize, arrow_offset: usize) -> VortexResult<usi
 }
 
 /// Arrow C Data uses -1 when the null count has not been computed.
-const UNKNOWN_NULL_COUNT: i64 = -1;
+const ARROW_UNKNOWN_NULL_COUNT: i64 = -1;
 
 /// Allocate a zeroed device buffer with cuDF-safe padding for Arrow validity masks.
 fn device_zeroed_byte_buffer(
@@ -1663,7 +1665,10 @@ mod tests {
             )
         );
         assert_eq!(exported.array.array.length, 4);
-        assert_eq!(exported.array.array.null_count, super::UNKNOWN_NULL_COUNT);
+        assert_eq!(
+            exported.array.array.null_count,
+            super::ARROW_UNKNOWN_NULL_COUNT
+        );
         assert_eq!(exported.array.array.n_buffers, 2);
         assert_eq!(exported.array.array.n_children, 0);
         assert!(!exported.array.array.dictionary.is_null());
@@ -1721,7 +1726,7 @@ mod tests {
         let children = unsafe { std::slice::from_raw_parts(exported.array.array.children, 1) };
         let dict_child = unsafe { &*children[0] };
         assert!(!dict_child.dictionary.is_null());
-        assert_eq!(dict_child.null_count, super::UNKNOWN_NULL_COUNT);
+        assert_eq!(dict_child.null_count, super::ARROW_UNKNOWN_NULL_COUNT);
 
         unsafe { release_exported_array(&raw mut exported.array.array) };
         Ok(())
@@ -1754,7 +1759,7 @@ mod tests {
             [0, 1, 0]
         );
         let dictionary = unsafe { &*exported.array.array.dictionary };
-        assert_eq!(dictionary.null_count, super::UNKNOWN_NULL_COUNT);
+        assert_eq!(dictionary.null_count, super::ARROW_UNKNOWN_NULL_COUNT);
         assert_eq!(private_data_buffer_i32_values(dictionary, 1)?.len(), 2);
 
         unsafe { release_exported_array(&raw mut exported.array.array) };
@@ -2031,7 +2036,7 @@ mod tests {
         assert_binary_layout(
             &exported.array.array,
             5,
-            super::UNKNOWN_NULL_COUNT,
+            super::ARROW_UNKNOWN_NULL_COUNT,
             &[0, 0, 3, 3, 8, i32::try_from(8 + out_of_line.len())?],
             &[b"\x00\xff\xfe".as_slice(), b"short", out_of_line].concat(),
         )?;
@@ -2545,7 +2550,7 @@ mod tests {
             [0, 1, 0, 1, 2]
         );
         let dictionary = unsafe { &*elements.dictionary };
-        assert_eq!(dictionary.null_count, super::UNKNOWN_NULL_COUNT);
+        assert_eq!(dictionary.null_count, super::ARROW_UNKNOWN_NULL_COUNT);
 
         unsafe { release_exported_array(&raw mut exported.array.array) };
         Ok(())
@@ -2791,7 +2796,7 @@ mod tests {
         let mut exported = utf8.export_device_array_with_schema(&mut ctx).await?;
         let field = Field::try_from(&exported.schema)?;
         assert_eq!(field, Field::new("", DataType::Utf8View, true));
-        assert_varbinview_shape(&exported.array.array, 3, super::UNKNOWN_NULL_COUNT)?;
+        assert_varbinview_shape(&exported.array.array, 3, super::ARROW_UNKNOWN_NULL_COUNT)?;
         assert_eq!(exported.array.device_type, ARROW_DEVICE_CUDA);
 
         let private_data = unsafe { &*exported.array.array.private_data.cast::<PrivateData>() };
@@ -2819,7 +2824,7 @@ mod tests {
         assert_binary_layout(
             &exported.array.array,
             3,
-            super::UNKNOWN_NULL_COUNT,
+            super::ARROW_UNKNOWN_NULL_COUNT,
             &[0, 0, 2, i32::try_from(2 + sliced_out_of_line.len())?],
             &[b"\x00\xff".as_slice(), sliced_out_of_line].concat(),
         )?;
@@ -2937,7 +2942,7 @@ mod tests {
         let mut primitive = assert_nullable_export(
             PrimitiveArray::from_option_iter([Some(1i32), None, Some(3)]).into_array(),
             2,
-            super::UNKNOWN_NULL_COUNT,
+            super::ARROW_UNKNOWN_NULL_COUNT,
             &mut ctx,
         )
         .await?;
@@ -2966,7 +2971,7 @@ mod tests {
                 .into_array()
                 .slice(1..4)?,
             2,
-            super::UNKNOWN_NULL_COUNT,
+            super::ARROW_UNKNOWN_NULL_COUNT,
             &mut ctx,
         )
         .await?;
@@ -3015,7 +3020,7 @@ mod tests {
             )
             .into_array(),
             2,
-            super::UNKNOWN_NULL_COUNT,
+            super::ARROW_UNKNOWN_NULL_COUNT,
             &mut ctx,
         )
         .await?;
@@ -3045,7 +3050,7 @@ mod tests {
             )
             .into_array(),
             2,
-            super::UNKNOWN_NULL_COUNT,
+            super::ARROW_UNKNOWN_NULL_COUNT,
             &mut ctx,
         )
         .await?;
@@ -3068,7 +3073,7 @@ mod tests {
             ])
             .into_array(),
             4,
-            super::UNKNOWN_NULL_COUNT,
+            super::ARROW_UNKNOWN_NULL_COUNT,
             &mut ctx,
         )
         .await?;
@@ -3092,7 +3097,7 @@ mod tests {
             )?
             .into_array(),
             1,
-            super::UNKNOWN_NULL_COUNT,
+            super::ARROW_UNKNOWN_NULL_COUNT,
             &mut ctx,
         )
         .await?;
@@ -3126,7 +3131,7 @@ mod tests {
             )?
             .into_array(),
             1,
-            super::UNKNOWN_NULL_COUNT,
+            super::ARROW_UNKNOWN_NULL_COUNT,
             &mut ctx,
         )
         .await?;

--- a/vortex-cuda/src/arrow/mod.rs
+++ b/vortex-cuda/src/arrow/mod.rs
@@ -70,7 +70,18 @@ pub mod test_harness {
     use vortex::error::VortexResult;
 
     use crate::CudaExecutionCtx;
+    use crate::arrow::canonical::count_arrow_validity_nulls as count_arrow_validity_nulls_impl;
     use crate::arrow::canonical::repack_arrow_validity_buffer as repack_arrow_validity_buffer_impl;
+
+    /// Count null bits in an Arrow validity bitmap.
+    pub fn count_arrow_validity_nulls(
+        bitmap: &BufferHandle,
+        len: usize,
+        arrow_offset: usize,
+        ctx: &mut CudaExecutionCtx,
+    ) -> VortexResult<i64> {
+        count_arrow_validity_nulls_impl(bitmap, len, arrow_offset, ctx)
+    }
 
     /// Repack a validity bitmap into Arrow's byte-addressed bitmap layout on the active stream.
     pub fn repack_arrow_validity_buffer(

--- a/vortex-cuda/src/arrow/mod.rs
+++ b/vortex-cuda/src/arrow/mod.rs
@@ -66,33 +66,8 @@ pub use arrow_c_abi::ArrowDeviceType;
 #[cfg(feature = "_test-harness")]
 #[doc(hidden)]
 pub mod test_harness {
-    use vortex::array::buffer::BufferHandle;
-    use vortex::error::VortexResult;
-
-    use crate::CudaExecutionCtx;
-    use crate::arrow::canonical::count_arrow_validity_nulls as count_arrow_validity_nulls_impl;
-    use crate::arrow::canonical::repack_arrow_validity_buffer as repack_arrow_validity_buffer_impl;
-
-    /// Count null bits in an Arrow validity bitmap.
-    pub fn count_arrow_validity_nulls(
-        bitmap: &BufferHandle,
-        len: usize,
-        arrow_offset: usize,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<i64> {
-        count_arrow_validity_nulls_impl(bitmap, len, arrow_offset, ctx)
-    }
-
-    /// Repack a validity bitmap into Arrow's byte-addressed bitmap layout on the active stream.
-    pub fn repack_arrow_validity_buffer(
-        input_buffer: &BufferHandle,
-        input_offset: usize,
-        len: usize,
-        arrow_offset: usize,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<BufferHandle> {
-        repack_arrow_validity_buffer_impl(input_buffer, input_offset, len, arrow_offset, ctx)
-    }
+    pub use crate::arrow::canonical::count_arrow_validity_nulls;
+    pub use crate::arrow::canonical::repack_arrow_validity_buffer;
 }
 
 /// CUDA device memory.

--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -21,16 +21,33 @@ use vortex::array::ArrayVTable;
 use vortex::array::Canonical;
 use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
+use vortex::array::arrays::BoolArray;
+use vortex::array::arrays::DecimalArray;
 use vortex::array::arrays::Extension;
 use vortex::array::arrays::ExtensionArray;
+use vortex::array::arrays::FixedSizeListArray;
+use vortex::array::arrays::ListViewArray;
+use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::Struct;
 use vortex::array::arrays::StructArray;
+use vortex::array::arrays::VarBinViewArray;
+use vortex::array::arrays::bool::BoolDataParts;
+use vortex::array::arrays::decimal::DecimalDataParts;
 use vortex::array::arrays::extension::ExtensionArrayExt;
+use vortex::array::arrays::fixed_size_list::FixedSizeListArrayExt;
+use vortex::array::arrays::fixed_size_list::FixedSizeListDataParts;
+use vortex::array::arrays::listview::ListViewDataParts;
+use vortex::array::arrays::primitive::PrimitiveDataParts;
 use vortex::array::arrays::struct_::StructDataParts;
+use vortex::array::arrays::varbinview::VarBinViewDataParts;
 use vortex::array::buffer::BufferHandle;
+use vortex::array::validity::Validity;
+use vortex::dtype::DType;
+use vortex::dtype::Nullability;
 use vortex::dtype::PType;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
+use vortex::error::vortex_ensure;
 use vortex::error::vortex_err;
 
 use crate::CudaSession;
@@ -375,6 +392,141 @@ pub trait CudaExecute: 'static + Send + Sync + Debug {
     -> VortexResult<Canonical>;
 }
 
+async fn execute_validity_cuda(
+    validity: Validity,
+    len: usize,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<Validity> {
+    let Validity::Array(array) = validity else {
+        return Ok(validity);
+    };
+
+    vortex_ensure!(array.len() == len, "validity array length mismatch");
+    vortex_ensure!(
+        matches!(array.dtype(), DType::Bool(Nullability::NonNullable)),
+        "validity array must be non-nullable boolean, got {}",
+        array.dtype()
+    );
+
+    let canonical = array.execute_cuda(ctx).await?;
+    let Canonical::Bool(bool_array) = canonical else {
+        vortex_bail!("CUDA validity execution produced {}", canonical.dtype());
+    };
+
+    let BoolDataParts { bits, meta } = bool_array.into_data().into_parts(len);
+    let bits = ctx.ensure_on_device(bits).await?;
+    Ok(Validity::Array(
+        BoolArray::new_handle(bits, meta.offset(), meta.len(), Validity::NonNullable).into_array(),
+    ))
+}
+
+async fn execute_canonical_validity_cuda(
+    canonical: Canonical,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<Canonical> {
+    Ok(match canonical {
+        Canonical::Primitive(array) => {
+            let PrimitiveDataParts {
+                ptype,
+                buffer,
+                validity,
+            } = array.into_data_parts();
+            let len = buffer.len() / ptype.byte_width();
+            Canonical::Primitive(PrimitiveArray::from_buffer_handle(
+                buffer,
+                ptype,
+                execute_validity_cuda(validity, len, ctx).await?,
+            ))
+        }
+        Canonical::Bool(array) => {
+            let len = array.len();
+            let validity = execute_validity_cuda(array.validity()?, len, ctx).await?;
+            let BoolDataParts { bits, meta } = array.into_data().into_parts(len);
+            Canonical::Bool(BoolArray::new_handle(
+                bits,
+                meta.offset(),
+                meta.len(),
+                validity,
+            ))
+        }
+        Canonical::Decimal(array) => {
+            let DecimalDataParts {
+                decimal_dtype,
+                values,
+                values_type,
+                validity,
+            } = array.into_data_parts();
+            let len = values.len() / values_type.byte_width();
+            Canonical::Decimal(DecimalArray::new_handle(
+                values,
+                values_type,
+                decimal_dtype,
+                execute_validity_cuda(validity, len, ctx).await?,
+            ))
+        }
+        Canonical::VarBinView(array) => {
+            let len = array.len();
+            let VarBinViewDataParts {
+                dtype,
+                buffers,
+                views,
+                validity,
+            } = array.into_data_parts();
+            Canonical::VarBinView(VarBinViewArray::new_handle(
+                views,
+                buffers,
+                dtype,
+                execute_validity_cuda(validity, len, ctx).await?,
+            ))
+        }
+        Canonical::List(array) => {
+            let len = array.len();
+            let ListViewDataParts {
+                elements,
+                offsets,
+                sizes,
+                validity,
+                ..
+            } = array.into_data_parts();
+            Canonical::List(ListViewArray::new(
+                elements,
+                offsets,
+                sizes,
+                execute_validity_cuda(validity, len, ctx).await?,
+            ))
+        }
+        Canonical::FixedSizeList(array) => {
+            let len = array.len();
+            let list_size = array.list_size();
+            let FixedSizeListDataParts {
+                elements, validity, ..
+            } = array.into_data_parts();
+            Canonical::FixedSizeList(FixedSizeListArray::new(
+                elements,
+                list_size,
+                execute_validity_cuda(validity, len, ctx).await?,
+                len,
+            ))
+        }
+        Canonical::Struct(array) => {
+            let len = array.len();
+            let StructDataParts {
+                struct_fields,
+                fields,
+                validity,
+            } = array.into_data_parts();
+            Canonical::Struct(StructArray::try_new_with_dtype(
+                fields,
+                struct_fields,
+                len,
+                execute_validity_cuda(validity, len, ctx).await?,
+            )?)
+        }
+        Canonical::Extension(array) => Canonical::Extension(array),
+        other @ (Canonical::Null(_) | Canonical::Variant(_)) => other,
+    })
+}
+
 /// Extension trait for executing arrays on CUDA.
 #[async_trait]
 pub trait CudaArrayExt {
@@ -407,12 +559,16 @@ impl CudaArrayExt for ArrayRef {
                 cuda_fields.push(field.clone().execute_cuda(ctx).await?.into_array());
             }
 
-            return Ok(Canonical::Struct(StructArray::new(
-                struct_fields.names().clone(),
-                cuda_fields,
-                len,
-                validity,
-            )));
+            return execute_canonical_validity_cuda(
+                Canonical::Struct(StructArray::new(
+                    struct_fields.names().clone(),
+                    cuda_fields,
+                    len,
+                    validity,
+                )),
+                ctx,
+            )
+            .await;
         }
 
         // Extension arrays match AnyCanonical regardless of how their storage
@@ -429,7 +585,8 @@ impl CudaArrayExt for ArrayRef {
 
         if self.is_canonical() || self.is_empty() {
             trace!(encoding = ?self.encoding_id(), "skipping canonical");
-            return self.execute(&mut ctx.ctx);
+            let canonical = self.execute(&mut ctx.ctx)?;
+            return execute_canonical_validity_cuda(canonical, ctx).await;
         }
 
         // Try all GPU execution strategies: fused dynamic dispatch, partial
@@ -437,7 +594,7 @@ impl CudaArrayExt for ArrayRef {
         // If none succeed, fall back to CPU execution only when all buffers
         // remain host-resident.
         let gpu_error = match hybrid_dispatch::try_gpu_dispatch(&self, ctx).await {
-            Ok(canonical) => return Ok(canonical),
+            Ok(canonical) => return execute_canonical_validity_cuda(canonical, ctx).await,
             Err(e) => {
                 debug!(
                     encoding = %self.encoding_id(),
@@ -455,6 +612,7 @@ impl CudaArrayExt for ArrayRef {
             );
         }
 
-        self.execute(&mut ctx.ctx)
+        let canonical = self.execute(&mut ctx.ctx)?;
+        execute_canonical_validity_cuda(canonical, ctx).await
     }
 }

--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -22,24 +22,13 @@ use vortex::array::Canonical;
 use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
 use vortex::array::arrays::BoolArray;
-use vortex::array::arrays::DecimalArray;
 use vortex::array::arrays::Extension;
 use vortex::array::arrays::ExtensionArray;
-use vortex::array::arrays::FixedSizeListArray;
-use vortex::array::arrays::ListViewArray;
-use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::Struct;
 use vortex::array::arrays::StructArray;
-use vortex::array::arrays::VarBinViewArray;
 use vortex::array::arrays::bool::BoolDataParts;
-use vortex::array::arrays::decimal::DecimalDataParts;
 use vortex::array::arrays::extension::ExtensionArrayExt;
-use vortex::array::arrays::fixed_size_list::FixedSizeListArrayExt;
-use vortex::array::arrays::fixed_size_list::FixedSizeListDataParts;
-use vortex::array::arrays::listview::ListViewDataParts;
-use vortex::array::arrays::primitive::PrimitiveDataParts;
 use vortex::array::arrays::struct_::StructDataParts;
-use vortex::array::arrays::varbinview::VarBinViewDataParts;
 use vortex::array::buffer::BufferHandle;
 use vortex::array::validity::Validity;
 use vortex::dtype::DType;
@@ -392,7 +381,7 @@ pub trait CudaExecute: 'static + Send + Sync + Debug {
     -> VortexResult<Canonical>;
 }
 
-async fn execute_validity_cuda(
+pub(crate) async fn execute_validity_cuda(
     validity: Validity,
     len: usize,
     ctx: &mut CudaExecutionCtx,
@@ -418,113 +407,6 @@ async fn execute_validity_cuda(
     Ok(Validity::Array(
         BoolArray::new_handle(bits, meta.offset(), meta.len(), Validity::NonNullable).into_array(),
     ))
-}
-
-async fn execute_canonical_validity_cuda(
-    canonical: Canonical,
-    ctx: &mut CudaExecutionCtx,
-) -> VortexResult<Canonical> {
-    Ok(match canonical {
-        Canonical::Primitive(array) => {
-            let PrimitiveDataParts {
-                ptype,
-                buffer,
-                validity,
-            } = array.into_data_parts();
-            let len = buffer.len() / ptype.byte_width();
-            Canonical::Primitive(PrimitiveArray::from_buffer_handle(
-                buffer,
-                ptype,
-                execute_validity_cuda(validity, len, ctx).await?,
-            ))
-        }
-        Canonical::Bool(array) => {
-            let len = array.len();
-            let validity = execute_validity_cuda(array.validity()?, len, ctx).await?;
-            let BoolDataParts { bits, meta } = array.into_data().into_parts(len);
-            Canonical::Bool(BoolArray::new_handle(
-                bits,
-                meta.offset(),
-                meta.len(),
-                validity,
-            ))
-        }
-        Canonical::Decimal(array) => {
-            let DecimalDataParts {
-                decimal_dtype,
-                values,
-                values_type,
-                validity,
-            } = array.into_data_parts();
-            let len = values.len() / values_type.byte_width();
-            Canonical::Decimal(DecimalArray::new_handle(
-                values,
-                values_type,
-                decimal_dtype,
-                execute_validity_cuda(validity, len, ctx).await?,
-            ))
-        }
-        Canonical::VarBinView(array) => {
-            let len = array.len();
-            let VarBinViewDataParts {
-                dtype,
-                buffers,
-                views,
-                validity,
-            } = array.into_data_parts();
-            Canonical::VarBinView(VarBinViewArray::new_handle(
-                views,
-                buffers,
-                dtype,
-                execute_validity_cuda(validity, len, ctx).await?,
-            ))
-        }
-        Canonical::List(array) => {
-            let len = array.len();
-            let ListViewDataParts {
-                elements,
-                offsets,
-                sizes,
-                validity,
-                ..
-            } = array.into_data_parts();
-            Canonical::List(ListViewArray::new(
-                elements,
-                offsets,
-                sizes,
-                execute_validity_cuda(validity, len, ctx).await?,
-            ))
-        }
-        Canonical::FixedSizeList(array) => {
-            let len = array.len();
-            let list_size = array.list_size();
-            let FixedSizeListDataParts {
-                elements, validity, ..
-            } = array.into_data_parts();
-            Canonical::FixedSizeList(FixedSizeListArray::new(
-                elements,
-                list_size,
-                execute_validity_cuda(validity, len, ctx).await?,
-                len,
-            ))
-        }
-        Canonical::Struct(array) => {
-            let len = array.len();
-            let StructDataParts {
-                struct_fields,
-                fields,
-                validity,
-            } = array.into_data_parts();
-            Canonical::Struct(StructArray::try_new_with_dtype(
-                fields,
-                struct_fields,
-                len,
-                execute_validity_cuda(validity, len, ctx).await?,
-            )?)
-        }
-        Canonical::Extension(array) => Canonical::Extension(array),
-        other @ (Canonical::Null(_) | Canonical::Variant(_)) => other,
-    })
 }
 
 /// Extension trait for executing arrays on CUDA.
@@ -559,16 +441,12 @@ impl CudaArrayExt for ArrayRef {
                 cuda_fields.push(field.clone().execute_cuda(ctx).await?.into_array());
             }
 
-            return execute_canonical_validity_cuda(
-                Canonical::Struct(StructArray::new(
-                    struct_fields.names().clone(),
-                    cuda_fields,
-                    len,
-                    validity,
-                )),
-                ctx,
-            )
-            .await;
+            return Ok(Canonical::Struct(StructArray::new(
+                struct_fields.names().clone(),
+                cuda_fields,
+                len,
+                validity,
+            )));
         }
 
         // Extension arrays match AnyCanonical regardless of how their storage
@@ -585,8 +463,7 @@ impl CudaArrayExt for ArrayRef {
 
         if self.is_canonical() || self.is_empty() {
             trace!(encoding = ?self.encoding_id(), "skipping canonical");
-            let canonical = self.execute(&mut ctx.ctx)?;
-            return execute_canonical_validity_cuda(canonical, ctx).await;
+            return self.execute(&mut ctx.ctx);
         }
 
         // Try all GPU execution strategies: fused dynamic dispatch, partial
@@ -594,7 +471,7 @@ impl CudaArrayExt for ArrayRef {
         // If none succeed, fall back to CPU execution only when all buffers
         // remain host-resident.
         let gpu_error = match hybrid_dispatch::try_gpu_dispatch(&self, ctx).await {
-            Ok(canonical) => return execute_canonical_validity_cuda(canonical, ctx).await,
+            Ok(canonical) => return Ok(canonical),
             Err(e) => {
                 debug!(
                     encoding = %self.encoding_id(),
@@ -612,7 +489,6 @@ impl CudaArrayExt for ArrayRef {
             );
         }
 
-        let canonical = self.execute(&mut ctx.ctx)?;
-        execute_canonical_validity_cuda(canonical, ctx).await
+        self.execute(&mut ctx.ctx)
     }
 }

--- a/vortex-cuda/src/kernel/mod.rs
+++ b/vortex-cuda/src/kernel/mod.rs
@@ -198,8 +198,6 @@ pub(crate) fn launch_cuda_kernel_with_config(
 pub(crate) struct KernelLoader {
     /// Cache of loaded CUDA modules, keyed by module name
     modules: DashMap<String, Arc<CudaModule>>,
-    /// Cache of loaded CUDA functions, keyed by module and fully-qualified kernel name.
-    functions: DashMap<(String, String), CudaFunction>,
 }
 
 impl KernelLoader {
@@ -207,7 +205,6 @@ impl KernelLoader {
     pub fn new() -> Self {
         Self {
             modules: DashMap::default(),
-            functions: DashMap::default(),
         }
     }
 
@@ -233,11 +230,6 @@ impl KernelLoader {
         } else {
             format!("{}_{}", module_name, type_suffixes.join("_"))
         };
-
-        let function_key = (module_name.to_string(), kernel_name.clone());
-        if let Some(entry) = self.functions.get(&function_key) {
-            return Ok(entry.value().clone());
-        }
 
         // Check if module is already cached
         let module = if let Some(entry) = self.modules.get(module_name) {
@@ -265,11 +257,9 @@ impl KernelLoader {
         };
 
         // Load the CUDA function from the compiled module.
-        let function = module
+        module
             .load_function(&kernel_name)
-            .map_err(|e| vortex_err!("Failed to load kernel function '{}': {}", kernel_name, e))?;
-        self.functions.insert(function_key, function.clone());
-        Ok(function)
+            .map_err(|e| vortex_err!("Failed to load kernel function '{}': {}", kernel_name, e))
     }
 
     /// Returns the PTX file path for a given module name.

--- a/vortex-cuda/src/kernel/mod.rs
+++ b/vortex-cuda/src/kernel/mod.rs
@@ -198,6 +198,8 @@ pub(crate) fn launch_cuda_kernel_with_config(
 pub(crate) struct KernelLoader {
     /// Cache of loaded CUDA modules, keyed by module name
     modules: DashMap<String, Arc<CudaModule>>,
+    /// Cache of loaded CUDA functions, keyed by module and fully-qualified kernel name.
+    functions: DashMap<(String, String), CudaFunction>,
 }
 
 impl KernelLoader {
@@ -205,6 +207,7 @@ impl KernelLoader {
     pub fn new() -> Self {
         Self {
             modules: DashMap::default(),
+            functions: DashMap::default(),
         }
     }
 
@@ -230,6 +233,11 @@ impl KernelLoader {
         } else {
             format!("{}_{}", module_name, type_suffixes.join("_"))
         };
+
+        let function_key = (module_name.to_string(), kernel_name.clone());
+        if let Some(entry) = self.functions.get(&function_key) {
+            return Ok(entry.value().clone());
+        }
 
         // Check if module is already cached
         let module = if let Some(entry) = self.modules.get(module_name) {
@@ -257,9 +265,11 @@ impl KernelLoader {
         };
 
         // Load the CUDA function from the compiled module.
-        module
+        let function = module
             .load_function(&kernel_name)
-            .map_err(|e| vortex_err!("Failed to load kernel function '{}': {}", kernel_name, e))
+            .map_err(|e| vortex_err!("Failed to load kernel function '{}': {}", kernel_name, e))?;
+        self.functions.insert(function_key, function.clone());
+        Ok(function)
     }
 
     /// Returns the PTX file path for a given module name.


### PR DESCRIPTION
Move canonicalization of the validity buffer from the CPU to the GPU for arrow device array. As part of that this change adds a null count kernel, as the count is required by cuDF. cuDF does not support consuming `-1` (unknown true count) for passed in arrow device arrays.