### PR TITLE
Immutable session backed by `HashMap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10192,7 +10192,6 @@ dependencies = [
 name = "vortex-session"
 version = "0.1.0"
 dependencies = [
- "dashmap",
  "lasso",
  "parking_lot",
  "vortex-error",

--- a/docs/developer-guide/internals/session.md
+++ b/docs/developer-guide/internals/session.md
@@ -99,9 +99,10 @@ For tests or specialized use-cases, sessions can be assembled from individual co
 the `.with::<T>()` builder:
 
 ```rust
-let session = VortexSession::empty()
+let session = VortexSession::builder()
     .with::<ArraySession>()
     .with::<LayoutSession>()
     .with::<ScalarFnSession>()
-    .with::<RuntimeSession>();
+    .with::<RuntimeSession>()
+    .build();
 ```

--- a/encodings/alp/benches/alp_compress.rs
+++ b/encodings/alp/benches/alp_compress.rs
@@ -19,7 +19,6 @@ use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::dtype::NativePType;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_buffer::buffer;
@@ -51,8 +50,7 @@ const BENCH_ARGS: &[(usize, f64, f64)] = &[
     (10_000, 0.1, 1.0),
 ];
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[divan::bench(types = [f32, f64], args = BENCH_ARGS)]
 fn compress_alp<T: ALPFloat + NativePType>(bencher: Bencher, args: (usize, f64, f64)) {

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -485,7 +485,6 @@ mod tests {
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
-    use vortex_array::session::ArraySession;
     use vortex_error::VortexExpect;
     use vortex_session::VortexSession;
 
@@ -493,8 +492,7 @@ mod tests {
     use crate::alp_encode;
     use crate::decompress_into_array;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[rstest]
     #[case(0)]

--- a/encodings/alp/src/alp/plugin.rs
+++ b/encodings/alp/src/alp/plugin.rs
@@ -98,7 +98,6 @@ mod tests {
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::patched::PatchedArraySlotsExt;
     use vortex_array::buffer::BufferHandle;
-    use vortex_array::session::ArraySession;
     use vortex_array::session::ArraySessionExt;
     use vortex_error::VortexResult;
     use vortex_error::vortex_err;
@@ -111,7 +110,7 @@ mod tests {
     use crate::alp_encode;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         session.arrays().register(ALPPatchedPlugin);
         session
     });

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -322,10 +322,8 @@ mod tests {
     use vortex_array::assert_arrays_eq;
     use vortex_array::serde::SerializeOptions;
     use vortex_array::serde::SerializedArray;
-    use vortex_array::session::ArraySession;
     use vortex_array::session::ArraySessionExt;
     use vortex_buffer::ByteBufferMut;
-    use vortex_session::VortexSession;
     use vortex_session::registry::ReadContext;
 
     use super::*;
@@ -367,7 +365,7 @@ mod tests {
         let array = ByteBool::from_option_vec(vec![Some(true), None, Some(false), None]);
         let dtype = array.dtype().clone();
         let len = array.len();
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         session.arrays().register(ByteBool);
 
         let ctx = ArrayContext::empty();

--- a/encodings/datetime-parts/src/canonical.rs
+++ b/encodings/datetime-parts/src/canonical.rs
@@ -109,7 +109,6 @@ mod test {
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
-    use vortex_session::VortexSession;
 
     use crate::DateTimeParts;
     use crate::array::DateTimePartsArraySlotsExt;
@@ -133,7 +132,7 @@ mod test {
             ],
             validity.clone(),
         );
-        let mut ctx = ExecutionCtx::new(VortexSession::empty());
+        let mut ctx = ExecutionCtx::new(vortex_array::array_session());
         let date_times = DateTimeParts::try_from_temporal(
             TemporalArray::new_timestamp(
                 milliseconds.clone().into_array(),

--- a/encodings/experimental/onpair/benches/decode.rs
+++ b/encodings/experimental/onpair/benches/decode.rs
@@ -41,7 +41,6 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
-use vortex_array::session::ArraySession;
 use vortex_buffer::Buffer;
 use vortex_buffer::ByteBuffer;
 use vortex_mask::Mask;
@@ -80,8 +79,7 @@ impl DecodeInputs {
 use vortex_onpair::onpair_compress;
 use vortex_session::VortexSession;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[derive(Copy, Clone, Debug)]
 enum Shape {

--- a/encodings/experimental/onpair/src/compute/compare.rs
+++ b/encodings/experimental/onpair/src/compute/compare.rs
@@ -78,15 +78,13 @@ mod tests {
     use vortex_array::dtype::Nullability;
     use vortex_array::scalar::Scalar;
     use vortex_array::scalar_fn::fns::operators::Operator;
-    use vortex_array::session::ArraySession;
     use vortex_error::VortexResult;
     use vortex_session::VortexSession;
 
     use crate::compress::DEFAULT_DICT12_CONFIG;
     use crate::compress::onpair_compress;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[cfg_attr(miri, ignore)]
     #[rstest]

--- a/encodings/experimental/onpair/src/tests.rs
+++ b/encodings/experimental/onpair/src/tests.rs
@@ -15,7 +15,6 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::match_each_integer_ptype;
-use vortex_array::session::ArraySession;
 use vortex_array::test_harness::check_metadata;
 use vortex_array::validity::Validity;
 use vortex_buffer::BufferMut;
@@ -28,8 +27,7 @@ use crate::OnPairMetadata;
 use crate::compress::DEFAULT_DICT12_CONFIG;
 use crate::compress::onpair_compress;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 fn sample_input() -> VarBinArray {
     VarBinArray::from_iter(

--- a/encodings/experimental/onpair/tests/big_data.rs
+++ b/encodings/experimental/onpair/tests/big_data.rs
@@ -26,13 +26,11 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::scalar_fn::fns::operators::Operator;
-use vortex_array::session::ArraySession;
 use vortex_onpair::DEFAULT_DICT12_CONFIG;
 use vortex_onpair::onpair_compress;
 use vortex_session::VortexSession;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 fn corpus(n: usize) -> Vec<String> {
     let templates: &[&str] = &[

--- a/encodings/fastlanes/benches/bitpack_compare.rs
+++ b/encodings/fastlanes/benches/bitpack_compare.rs
@@ -23,7 +23,6 @@ use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::scalar_fn::fns::operators::Operator;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Alignment;
 use vortex_buffer::BufferMut;
@@ -36,8 +35,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 const LENS: &[usize] = &[1024, 64 * 1024];
 const BIT_WIDTHS: &[u8] = &[4, 16];

--- a/encodings/fastlanes/benches/bitpack_compare_sweep.rs
+++ b/encodings/fastlanes/benches/bitpack_compare_sweep.rs
@@ -27,7 +27,6 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::NativePType;
 use vortex_array::scalar::Scalar;
 use vortex_array::scalar_fn::fns::operators::Operator;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Alignment;
 use vortex_buffer::BufferMut;
@@ -40,8 +39,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 /// Number of elements per benchmarked array (64 full FastLanes blocks).
 const LEN: usize = 64 * 1024;

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -15,7 +15,6 @@ use vortex_array::IntoArray as _;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_buffer::buffer;
@@ -27,8 +26,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[divan::bench]
 fn take_10_stratified(bencher: Bencher) {

--- a/encodings/fastlanes/benches/canonicalize_bench.rs
+++ b/encodings/fastlanes/benches/canonicalize_bench.rs
@@ -12,7 +12,6 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::builders::ArrayBuilder;
 use vortex_array::builders::PrimitiveBuilder;
-use vortex_array::session::ArraySession;
 use vortex_error::VortexExpect;
 use vortex_fastlanes::bitpack_compress::test_harness::make_array;
 use vortex_session::VortexSession;
@@ -35,8 +34,7 @@ const BENCH_ARGS: &[(usize, usize, f64)] = &[
     (10000, 1000, 0.00),
 ];
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[cfg(not(codspeed))]
 #[divan::bench(args = BENCH_ARGS)]

--- a/encodings/fastlanes/benches/cast_bitpacked.rs
+++ b/encodings/fastlanes/benches/cast_bitpacked.rs
@@ -27,7 +27,6 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
@@ -39,8 +38,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 const U32: DType = DType::Primitive(PType::U32, Nullability::NonNullable);
 

--- a/encodings/fastlanes/benches/compute_between.rs
+++ b/encodings/fastlanes/benches/compute_between.rs
@@ -16,7 +16,6 @@ use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::dtype::NativePType;
-use vortex_array::session::ArraySession;
 use vortex_error::VortexExpect;
 use vortex_fastlanes::bitpack_compress::bitpack_to_best_bit_width;
 use vortex_session::VortexSession;
@@ -25,8 +24,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 fn generate_primitive_array<T: NativePType + NumCast>(
     rng: &mut StdRng,

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
@@ -437,7 +437,6 @@ mod test {
     use vortex_array::assert_arrays_eq;
     use vortex_array::builders::ArrayBuilder;
     use vortex_array::builders::PrimitiveBuilder;
-    use vortex_array::session::ArraySession;
     use vortex_buffer::Buffer;
     use vortex_error::VortexError;
     use vortex_error::vortex_err;
@@ -448,8 +447,7 @@ mod test {
     use crate::bitpack_compress::test_harness::make_array;
     use crate::bitpacking::array::BitPackedArrayExt;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[test]
     fn test_best_bit_width() {

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -210,7 +210,6 @@ mod tests {
     use vortex_array::VortexSessionExecute;
     use vortex_array::assert_arrays_eq;
     use vortex_array::dtype::Nullability;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
     use vortex_buffer::BufferMut;
@@ -226,8 +225,7 @@ mod tests {
         bitpack_encode(array, bit_width, None, &mut SESSION.create_execution_ctx()).unwrap()
     }
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     fn unpack(bitpacked: &BitPackedArray) -> VortexResult<PrimitiveArray> {
         unpack_array(bitpacked.as_view(), &mut SESSION.create_execution_ctx())

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -327,15 +327,13 @@ mod test {
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
-    use vortex_array::session::ArraySession;
     use vortex_buffer::Buffer;
     use vortex_session::VortexSession;
 
     use crate::BitPackedData;
     use crate::bitpacking::array::BitPackedArrayExt;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[test]
     fn test_encode() {

--- a/encodings/fastlanes/src/bitpacking/compute/compare.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/compare.rs
@@ -118,7 +118,6 @@ mod tests {
     use vortex_array::scalar_fn::fns::binary::CompareKernel;
     use vortex_array::scalar_fn::fns::operators::CompareOperator;
     use vortex_array::scalar_fn::fns::operators::Operator;
-    use vortex_array::session::ArraySession;
     use vortex_error::VortexResult;
     use vortex_session::VortexSession;
 
@@ -126,8 +125,7 @@ mod tests {
     use crate::BitPackedArrayExt;
     use crate::BitPackedData;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     /// All six operators on a small in-range input.
     #[rstest]

--- a/encodings/fastlanes/src/bitpacking/plugin.rs
+++ b/encodings/fastlanes/src/bitpacking/plugin.rs
@@ -100,7 +100,6 @@ mod tests {
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::patched::PatchedArraySlotsExt;
     use vortex_array::buffer::BufferHandle;
-    use vortex_array::session::ArraySession;
     use vortex_array::session::ArraySessionExt;
     use vortex_buffer::Buffer;
     use vortex_error::VortexResult;
@@ -114,7 +113,7 @@ mod tests {
     use crate::BitPackedData;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         session.arrays().register(BitPackedPatchedPlugin);
         session
     });

--- a/encodings/fastlanes/src/delta/array/delta_compress.rs
+++ b/encodings/fastlanes/src/delta/array/delta_compress.rs
@@ -106,7 +106,6 @@ mod tests {
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
-    use vortex_array::session::ArraySession;
     use vortex_error::VortexExpect;
     use vortex_error::VortexResult;
     use vortex_session::VortexSession;
@@ -116,8 +115,7 @@ mod tests {
     use crate::delta::array::delta_decompress::delta_decompress;
     use crate::delta_compress;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[rstest]
     #[case::u32((0u32..10_000).collect())]

--- a/encodings/fastlanes/src/delta/array/mod.rs
+++ b/encodings/fastlanes/src/delta/array/mod.rs
@@ -38,7 +38,7 @@ pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["bases", "deltas"];
 /// use vortex_session::VortexSession;
 /// use vortex_fastlanes::Delta;
 ///
-/// let session = VortexSession::empty().with::<ArraySession>();
+/// let session = vortex_array::array_session();
 /// let primitive = PrimitiveArray::from_iter([1_u32, 2, 3, 5, 10, 11]);
 /// let array = Delta::try_from_primitive_array(&primitive, &mut session.create_execution_ctx()).unwrap();
 /// ```
@@ -53,7 +53,7 @@ pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["bases", "deltas"];
 /// use vortex_session::VortexSession;
 /// use vortex_fastlanes::Delta;
 ///
-/// let session = VortexSession::empty().with::<ArraySession>();
+/// let session = vortex_array::array_session();
 /// let primitive = PrimitiveArray::from_iter([-3_i32, -2, -1, 0, 1, 2]);
 /// let array = Delta::try_from_primitive_array(&primitive, &mut session.create_execution_ctx()).unwrap();
 /// ```

--- a/encodings/fastlanes/src/delta/compute/cast.rs
+++ b/encodings/fastlanes/src/delta/compute/cast.rs
@@ -51,14 +51,12 @@ mod tests {
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
-    use vortex_array::session::ArraySession;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
     use vortex_session::VortexSession;
 
     use crate::Delta;
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[test]
     fn test_cast_delta_unsigned_widening_wraps() {

--- a/encodings/fastlanes/src/delta/vtable/operations.rs
+++ b/encodings/fastlanes/src/delta/vtable/operations.rs
@@ -35,7 +35,6 @@ mod tests {
     use vortex_array::assert_arrays_eq;
     use vortex_array::compute::conformance::binary_numeric::test_binary_numeric_array;
     use vortex_array::compute::conformance::consistency::test_array_consistency;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_error::VortexExpect;
@@ -44,8 +43,7 @@ mod tests {
     use crate::Delta;
     use crate::DeltaArray;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     fn da(array: &PrimitiveArray) -> DeltaArray {
         Delta::try_from_primitive_array(array, &mut SESSION.create_execution_ctx())

--- a/encodings/fastlanes/src/for/array/for_compress.rs
+++ b/encodings/fastlanes/src/for/array/for_compress.rs
@@ -58,7 +58,6 @@ mod test {
     use vortex_array::dtype::PType;
     use vortex_array::expr::stats::StatsProvider;
     use vortex_array::scalar::Scalar;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_session::VortexSession;
@@ -69,8 +68,7 @@ mod test {
     use crate::r#for::array::for_decompress::decompress;
     use crate::r#for::array::for_decompress::fused_decompress;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[test]
     fn test_compress_round_trip_small() {

--- a/encodings/fastlanes/src/lib.rs
+++ b/encodings/fastlanes/src/lib.rs
@@ -144,7 +144,7 @@ mod test {
     use super::*;
 
     pub static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty();
+        let session = vortex_array::array_session();
         session.arrays().register(BitPacked);
         session.arrays().register(Delta);
         session.arrays().register(FoR);

--- a/encodings/fastlanes/src/rle/compute/cast.rs
+++ b/encodings/fastlanes/src/rle/compute/cast.rs
@@ -58,7 +58,6 @@ mod tests {
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
     use vortex_session::VortexSession;
@@ -66,8 +65,7 @@ mod tests {
     use crate::RLEData;
     use crate::rle::RLEArray;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     fn rle(primitive: &PrimitiveArray, ctx: &mut ExecutionCtx) -> RLEArray {
         RLEData::encode(primitive.as_view(), ctx).unwrap()

--- a/encodings/fsst/benches/chunked_dict_fsst_builder.rs
+++ b/encodings/fsst/benches/chunked_dict_fsst_builder.rs
@@ -11,7 +11,6 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::builders::builder_with_capacity;
 use vortex_array::dtype::NativePType;
-use vortex_array::session::ArraySession;
 use vortex_error::VortexExpect;
 use vortex_fsst::test_utils::gen_dict_fsst_test_data;
 use vortex_session::VortexSession;
@@ -29,8 +28,7 @@ const BENCH_ARGS: &[(usize, usize, usize)] = &[
     (1000, 1000, 100),
 ];
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 fn make_dict_fsst_chunks<T: NativePType>(
     len: usize,

--- a/encodings/fsst/benches/fsst_compress.rs
+++ b/encodings/fsst/benches/fsst_compress.rs
@@ -23,7 +23,6 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::scalar::Scalar;
 use vortex_array::scalar_fn::fns::operators::Operator;
-use vortex_array::session::ArraySession;
 use vortex_fsst::fsst_compress;
 use vortex_fsst::fsst_train_compressor;
 use vortex_session::VortexSession;
@@ -32,8 +31,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 // [(string_count, avg_len, unique_chars)]
 const BENCH_ARGS: &[(usize, usize, u8)] = &[

--- a/encodings/fsst/benches/fsst_like.rs
+++ b/encodings/fsst/benches/fsst_like.rs
@@ -14,7 +14,6 @@ use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
 use vortex_array::scalar_fn::fns::like::Like;
 use vortex_array::scalar_fn::fns::like::LikeOptions;
-use vortex_array::session::ArraySession;
 use vortex_fsst::FSSTArray;
 use vortex_fsst::test_utils::NUM_STRINGS;
 use vortex_fsst::test_utils::make_fsst_clickbench_urls;
@@ -30,8 +29,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 const N: usize = NUM_STRINGS;
 

--- a/encodings/fsst/benches/fsst_url_compare.rs
+++ b/encodings/fsst/benches/fsst_url_compare.rs
@@ -18,7 +18,6 @@ use vortex_array::expr::lit;
 use vortex_array::expr::root;
 use vortex_array::scalar::Scalar;
 use vortex_array::scalar_fn::fns::operators::Operator;
-use vortex_array::session::ArraySession;
 use vortex_fsst::fsst_compress;
 use vortex_fsst::fsst_train_compressor;
 use vortex_fsst::test_utils::HIGH_MATCH_DOMAIN;
@@ -31,8 +30,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 const NUM_URLS: usize = NUM_STRINGS;
 

--- a/encodings/fsst/src/canonical.rs
+++ b/encodings/fsst/src/canonical.rs
@@ -104,15 +104,13 @@ mod tests {
     use vortex_array::builders::VarBinViewBuilder;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
-    use vortex_array::session::ArraySession;
     use vortex_error::VortexResult;
     use vortex_session::VortexSession;
 
     use crate::fsst_compress;
     use crate::fsst_train_compressor;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     fn make_data() -> (VarBinArray, Vec<Option<Vec<u8>>>) {
         const STRING_COUNT: usize = 1000;

--- a/encodings/fsst/src/compute/cast.rs
+++ b/encodings/fsst/src/compute/cast.rs
@@ -98,14 +98,12 @@ mod tests {
     use vortex_array::compute::conformance::cast::test_cast_conformance;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
-    use vortex_array::session::ArraySession;
     use vortex_session::VortexSession;
 
     use crate::fsst_compress;
     use crate::fsst_train_compressor;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[test]
     fn test_cast_fsst_nullability() {

--- a/encodings/fsst/src/compute/like.rs
+++ b/encodings/fsst/src/compute/like.rs
@@ -96,7 +96,6 @@ mod tests {
     use vortex_array::scalar_fn::fns::like::Like;
     use vortex_array::scalar_fn::fns::like::LikeKernel;
     use vortex_array::scalar_fn::fns::like::LikeOptions;
-    use vortex_array::session::ArraySession;
     use vortex_error::VortexResult;
     use vortex_session::VortexSession;
 
@@ -105,8 +104,7 @@ mod tests {
     use crate::fsst_compress;
     use crate::fsst_train_compressor;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     fn make_fsst(strings: &[Option<&str>], nullability: Nullability) -> FSSTArray {
         let varbin = VarBinArray::from_iter(strings.iter().copied(), DType::Utf8(nullability));

--- a/encodings/fsst/src/dfa/tests.rs
+++ b/encodings/fsst/src/dfa/tests.rs
@@ -20,7 +20,6 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::scalar_fn::fns::like::Like;
 use vortex_array::scalar_fn::fns::like::LikeOptions;
-use vortex_array::session::ArraySession;
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
 
@@ -32,8 +31,7 @@ use crate::FSSTArray;
 use crate::fsst_compress;
 use crate::fsst_train_compressor;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 /// Helper: make a Symbol from a byte string (up to 8 bytes, zero-padded).
 fn sym(bytes: &[u8]) -> Symbol {

--- a/encodings/fsst/src/kernel.rs
+++ b/encodings/fsst/src/kernel.rs
@@ -36,7 +36,6 @@ mod tests {
     use vortex_array::dtype::Nullability;
     use vortex_array::expr::byte_length;
     use vortex_array::expr::root;
-    use vortex_array::session::ArraySession;
     use vortex_error::VortexResult;
     use vortex_mask::Mask;
     use vortex_session::VortexSession;
@@ -45,8 +44,7 @@ mod tests {
     use crate::fsst_compress;
     use crate::fsst_train_compressor;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     fn build_test_fsst_array() -> ArrayRef {
         let mut builder = VarBinBuilder::<i32>::with_capacity(10);

--- a/encodings/parquet-variant/src/arrow.rs
+++ b/encodings/parquet-variant/src/arrow.rs
@@ -295,7 +295,6 @@ mod tests {
     use vortex_array::assert_arrays_eq;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
@@ -306,7 +305,7 @@ mod tests {
 
     #[fixture]
     fn session() -> VortexSession {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         crate::initialize(&session);
         session
     }

--- a/encodings/parquet-variant/src/vtable.rs
+++ b/encodings/parquet-variant/src/vtable.rs
@@ -323,7 +323,6 @@ mod tests {
     use vortex_array::dtype::PType;
     use vortex_array::serde::SerializeOptions;
     use vortex_array::serde::SerializedArray;
-    use vortex_array::session::ArraySession;
     use vortex_array::session::ArraySessionExt;
     use vortex_array::stream::ArrayStreamExt;
     use vortex_array::validity::Validity;
@@ -348,7 +347,7 @@ mod tests {
         let dtype = array.dtype().clone();
         let len = array.len();
 
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         session.arrays().register(ParquetVariant);
 
         let ctx = ArrayContext::empty();
@@ -387,8 +386,7 @@ mod tests {
 
     #[fixture]
     fn parquet_variant_file_session() -> VortexSession {
-        let session = VortexSession::empty()
-            .with::<ArraySession>()
+        let session = vortex_array::array_session()
             .with::<LayoutSession>()
             .with::<RuntimeSession>();
         vortex_file::register_default_encodings(&session);

--- a/encodings/pco/src/compute/cast.rs
+++ b/encodings/pco/src/compute/cast.rs
@@ -65,15 +65,13 @@ mod tests {
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_session::VortexSession;
 
     use crate::Pco;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[test]
     fn test_cast_pco_f32_to_f64() {

--- a/encodings/pco/src/tests.rs
+++ b/encodings/pco/src/tests.rs
@@ -18,7 +18,6 @@ use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::serde::SerializeOptions;
 use vortex_array::serde::SerializedArray;
-use vortex_array::session::ArraySession;
 use vortex_array::session::ArraySessionExt;
 use vortex_array::validity::Validity;
 use vortex_array::vtable::child_to_validity;
@@ -33,7 +32,7 @@ use vortex_session::registry::ReadContext;
 use crate::PcoData;
 
 static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-    let session = VortexSession::empty().with::<ArraySession>();
+    let session = vortex_array::array_session();
     session.arrays().register(Pco);
     session
 });

--- a/encodings/runend/benches/run_end_compress.rs
+++ b/encodings/runend/benches/run_end_compress.rs
@@ -13,7 +13,6 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::dtype::IntegerPType;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_runend::RunEnd;
@@ -24,8 +23,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 const BENCH_ARGS: &[(usize, usize)] = &[
     (1000, 4),

--- a/encodings/runend/benches/run_end_decode.rs
+++ b/encodings/runend/benches/run_end_decode.rs
@@ -10,7 +10,6 @@ use divan::Bencher;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::BitBuffer;
 use vortex_buffer::BufferMut;
@@ -21,8 +20,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 /// Distribution types for bool benchmarks
 #[derive(Clone, Copy)]

--- a/encodings/runend/benches/run_end_null_count.rs
+++ b/encodings/runend/benches/run_end_null_count.rs
@@ -12,7 +12,6 @@ use rand::rngs::StdRng;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::session::ArraySession;
 use vortex_buffer::Buffer;
 use vortex_runend::RunEnd;
 use vortex_runend::RunEndArray;
@@ -50,8 +49,7 @@ const BENCH_ARGS: &[(usize, usize, f64)] = &[
     (100_000, 1024, 0.5),
 ];
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[divan::bench(args = BENCH_ARGS)]
 fn null_count_run_end(bencher: Bencher, (n, run_step, valid_density): (usize, usize, f64)) {

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -521,14 +521,12 @@ mod tests {
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
-    use vortex_array::session::ArraySession;
     use vortex_buffer::buffer;
     use vortex_session::VortexSession;
 
     use crate::RunEnd;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[test]
     fn test_runend_constructor() {

--- a/encodings/runend/src/arrow.rs
+++ b/encodings/runend/src/arrow.rs
@@ -95,7 +95,6 @@ mod tests {
     use vortex_array::scalar::PValue;
     use vortex_array::search_sorted::SearchSorted;
     use vortex_array::search_sorted::SearchSortedSide;
-    use vortex_array::session::ArraySession;
     use vortex_array::session::ArraySessionExt;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
@@ -107,7 +106,7 @@ mod tests {
     use crate::ops::find_slice_end_index;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         session.arrays().register(RunEnd);
         session
     });

--- a/encodings/runend/src/compute/cast.rs
+++ b/encodings/runend/src/compute/cast.rs
@@ -46,15 +46,13 @@ mod tests {
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
-    use vortex_array::session::ArraySession;
     use vortex_buffer::buffer;
     use vortex_session::VortexSession;
 
     use crate::RunEnd;
     use crate::RunEndArray;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[test]
     fn test_cast_runend_i32_to_i64() {

--- a/encodings/runend/src/compute/take_from.rs
+++ b/encodings/runend/src/compute/take_from.rs
@@ -61,7 +61,6 @@ mod tests {
     use vortex_array::kernel::ExecuteParentKernel;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
-    use vortex_session::VortexSession;
 
     use crate::RunEnd;
     use crate::RunEndArray;
@@ -83,7 +82,7 @@ mod tests {
 
     #[test]
     fn test_execute_parent_no_offset() -> VortexResult<()> {
-        let mut ctx = ExecutionCtx::new(VortexSession::empty());
+        let mut ctx = ExecutionCtx::new(vortex_array::array_session());
         let (codes, dict) = make_dict_with_runend_codes(&mut ctx);
 
         let result = RunEndTakeFrom
@@ -98,7 +97,7 @@ mod tests {
 
     #[test]
     fn test_execute_parent_with_offset() -> VortexResult<()> {
-        let mut ctx = ExecutionCtx::new(VortexSession::empty());
+        let mut ctx = ExecutionCtx::new(vortex_array::array_session());
         let (codes, dict) = make_dict_with_runend_codes(&mut ctx);
         // Slice codes to positions 2..5 → logical codes [0, 1, 1] → values [2, 3, 3]
         let sliced_codes = unsafe {
@@ -122,7 +121,7 @@ mod tests {
 
     #[test]
     fn test_execute_parent_offset_at_run_boundary() -> VortexResult<()> {
-        let mut ctx = ExecutionCtx::new(VortexSession::empty());
+        let mut ctx = ExecutionCtx::new(vortex_array::array_session());
         let (codes, dict) = make_dict_with_runend_codes(&mut ctx);
         // Slice codes to positions 3..7 → logical codes [1, 1, 0, 0] → values [3, 3, 2, 2]
         let sliced_codes = unsafe {
@@ -146,7 +145,7 @@ mod tests {
 
     #[test]
     fn test_execute_parent_single_element_offset() -> VortexResult<()> {
-        let mut ctx = ExecutionCtx::new(VortexSession::empty());
+        let mut ctx = ExecutionCtx::new(vortex_array::array_session());
         let (codes, dict) = make_dict_with_runend_codes(&mut ctx);
         // Slice to single element at position 4 → code=1 → value=3
         let sliced_codes = unsafe {
@@ -170,7 +169,7 @@ mod tests {
 
     #[test]
     fn test_execute_parent_returns_none_for_non_codes_child() -> VortexResult<()> {
-        let mut ctx = ExecutionCtx::new(VortexSession::empty());
+        let mut ctx = ExecutionCtx::new(vortex_array::array_session());
         let (codes, dict) = make_dict_with_runend_codes(&mut ctx);
 
         let result = RunEndTakeFrom.execute_parent(codes.as_view(), dict.as_view(), 1, &mut ctx)?;

--- a/encodings/sequence/src/compute/cast.rs
+++ b/encodings/sequence/src/compute/cast.rs
@@ -99,14 +99,12 @@ mod tests {
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
-    use vortex_array::session::ArraySession;
     use vortex_session::VortexSession;
 
     use crate::Sequence;
     use crate::SequenceArray;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[test]
     fn test_cast_sequence_nullability() {

--- a/encodings/sparse/benches/sparse_canonical.rs
+++ b/encodings/sparse/benches/sparse_canonical.rs
@@ -17,7 +17,6 @@ use vortex_array::arrays::PrimitiveArray;
 use vortex_array::dtype::Nullability::NonNullable;
 use vortex_array::dtype::PType::I32;
 use vortex_array::scalar::Scalar;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_error::VortexExpect;
@@ -28,8 +27,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 const LIST_ARGS: &[(usize, usize, usize)] = &[
     // len, patch_stride, list_size

--- a/encodings/sparse/benches/sparse_pushdown.rs
+++ b/encodings/sparse/benches/sparse_pushdown.rs
@@ -31,7 +31,6 @@ use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::scalar::Scalar;
 use vortex_array::scalar_fn::fns::operators::Operator;
-use vortex_array::session::ArraySession;
 use vortex_buffer::Buffer;
 use vortex_error::VortexExpect;
 use vortex_session::VortexSession;
@@ -45,7 +44,7 @@ const LEN: usize = 1_000_000;
 
 /// Session with Sparse and its pushdown kernels registered.
 static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-    let session = VortexSession::empty().with::<ArraySession>();
+    let session = vortex_array::array_session();
     vortex_sparse::initialize(&session);
     session
 });

--- a/encodings/sparse/src/compute/between.rs
+++ b/encodings/sparse/src/compute/between.rs
@@ -74,7 +74,6 @@ mod tests {
     use vortex_array::scalar::Scalar;
     use vortex_array::scalar_fn::fns::between::BetweenOptions;
     use vortex_array::scalar_fn::fns::between::StrictComparison;
-    use vortex_array::session::ArraySession;
     use vortex_buffer::buffer;
     use vortex_session::VortexSession;
 
@@ -82,7 +81,7 @@ mod tests {
     use crate::initialize;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         initialize(&session);
         session
     });

--- a/encodings/sparse/src/compute/cast.rs
+++ b/encodings/sparse/src/compute/cast.rs
@@ -48,15 +48,13 @@ mod tests {
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
     use vortex_array::scalar::Scalar;
-    use vortex_array::session::ArraySession;
     use vortex_buffer::buffer;
     use vortex_session::VortexSession;
 
     use crate::Sparse;
     use crate::SparseArray;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[test]
     fn test_cast_sparse_i32_to_i64() {

--- a/encodings/sparse/src/compute/compare.rs
+++ b/encodings/sparse/src/compute/compare.rs
@@ -65,7 +65,6 @@ mod tests {
     use vortex_array::builtins::ArrayBuiltins;
     use vortex_array::scalar::Scalar;
     use vortex_array::scalar_fn::fns::operators::Operator;
-    use vortex_array::session::ArraySession;
     use vortex_buffer::buffer;
     use vortex_session::VortexSession;
 
@@ -74,7 +73,7 @@ mod tests {
     use crate::initialize;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         initialize(&session);
         session
     });

--- a/encodings/sparse/src/compute/fill_null.rs
+++ b/encodings/sparse/src/compute/fill_null.rs
@@ -55,7 +55,6 @@ mod tests {
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
     use vortex_array::scalar::Scalar;
-    use vortex_array::session::ArraySession;
     use vortex_buffer::buffer;
     use vortex_session::VortexSession;
 
@@ -63,7 +62,7 @@ mod tests {
     use crate::initialize;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         initialize(&session);
         session
     });

--- a/encodings/sparse/src/compute/is_constant.rs
+++ b/encodings/sparse/src/compute/is_constant.rs
@@ -73,7 +73,6 @@ mod tests {
     use vortex_array::VortexSessionExecute;
     use vortex_array::aggregate_fn::fns::is_constant::is_constant;
     use vortex_array::scalar::Scalar;
-    use vortex_array::session::ArraySession;
     use vortex_array::session::ArraySessionExt;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
@@ -85,14 +84,14 @@ mod tests {
 
     /// Session with Sparse + its pushdown kernels.
     static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         initialize(&session);
         session
     });
 
     /// Baseline session: Sparse registered but no pushdown kernels.
     static CANONICAL_SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         session.arrays().register(Sparse);
         session
     });

--- a/encodings/sparse/src/compute/min_max.rs
+++ b/encodings/sparse/src/compute/min_max.rs
@@ -69,7 +69,6 @@ mod tests {
     use vortex_array::aggregate_fn::fns::min_max::MinMaxResult;
     use vortex_array::aggregate_fn::fns::min_max::min_max;
     use vortex_array::scalar::Scalar;
-    use vortex_array::session::ArraySession;
     use vortex_array::session::ArraySessionExt;
     use vortex_buffer::buffer;
     use vortex_session::VortexSession;
@@ -79,13 +78,13 @@ mod tests {
     use crate::initialize;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         initialize(&session);
         session
     });
 
     static CANONICAL_SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         session.arrays().register(Sparse);
         session
     });

--- a/encodings/sparse/src/compute/nan_count.rs
+++ b/encodings/sparse/src/compute/nan_count.rs
@@ -77,7 +77,6 @@ mod tests {
     use vortex_array::VortexSessionExecute;
     use vortex_array::aggregate_fn::fns::nan_count::nan_count;
     use vortex_array::scalar::Scalar;
-    use vortex_array::session::ArraySession;
     use vortex_array::session::ArraySessionExt;
     use vortex_buffer::buffer;
     use vortex_session::VortexSession;
@@ -87,13 +86,13 @@ mod tests {
     use crate::initialize;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         initialize(&session);
         session
     });
 
     static CANONICAL_SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         session.arrays().register(Sparse);
         session
     });

--- a/encodings/sparse/src/compute/null_count.rs
+++ b/encodings/sparse/src/compute/null_count.rs
@@ -67,7 +67,6 @@ mod tests {
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
     use vortex_array::scalar::Scalar;
-    use vortex_array::session::ArraySession;
     use vortex_array::session::ArraySessionExt;
     use vortex_buffer::buffer;
     use vortex_session::VortexSession;
@@ -77,13 +76,13 @@ mod tests {
     use crate::initialize;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         initialize(&session);
         session
     });
 
     static CANONICAL_SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         session.arrays().register(Sparse);
         session
     });

--- a/encodings/sparse/src/compute/sum.rs
+++ b/encodings/sparse/src/compute/sum.rs
@@ -72,7 +72,6 @@ mod tests {
     use vortex_array::VortexSessionExecute;
     use vortex_array::aggregate_fn::fns::sum::sum;
     use vortex_array::scalar::Scalar;
-    use vortex_array::session::ArraySession;
     use vortex_array::session::ArraySessionExt;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
@@ -83,13 +82,13 @@ mod tests {
     use crate::initialize;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         initialize(&session);
         session
     });
 
     static CANONICAL_SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         session.arrays().register(Sparse);
         session
     });

--- a/encodings/zstd/benches/listview_rebuild.rs
+++ b/encodings/zstd/benches/listview_rebuild.rs
@@ -11,7 +11,6 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ListViewArray;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::arrays::listview::ListViewRebuildMode;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
@@ -19,8 +18,7 @@ use vortex_zstd::Zstd;
 use vortex_zstd::ZstdData;
 
 /// A shared session for the `ListView` rebuild benchmark, used to create execution contexts.
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[divan::bench(sample_size = 1000)]
 fn rebuild_naive(bencher: Bencher) {

--- a/encodings/zstd/src/compute/cast.rs
+++ b/encodings/zstd/src/compute/cast.rs
@@ -83,15 +83,13 @@ mod tests {
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_session::VortexSession;
 
     use crate::Zstd;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[test]
     fn test_cast_zstd_i32_to_i64() {

--- a/fuzz/src/fsst_like.rs
+++ b/fuzz/src/fsst_like.rs
@@ -21,7 +21,6 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::scalar_fn::fns::like::Like;
 use vortex_array::scalar_fn::fns::like::LikeOptions;
-use vortex_array::session::ArraySession;
 use vortex_error::VortexResult;
 use vortex_fsst::FSSTArray;
 use vortex_fsst::fsst_compress;
@@ -32,8 +31,7 @@ use crate::error::Backtrace;
 use crate::error::VortexFuzzError;
 use crate::error::VortexFuzzResult;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 /// A random string from a small alphabet (`a..=h`) with bounded length.
 #[derive(Debug)]

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -56,7 +56,7 @@ mod native_runtime {
         if vortex_cuda::cuda_available() {
             use vortex_cuda::CudaSessionExt;
             session = session.with::<vortex_cuda::CudaSession>();
-            vortex_cuda::initialize_cuda(&session.cuda_session());
+            vortex_cuda::initialize_cuda(session.cuda_session());
         }
         session
     });

--- a/vortex-array/benches/aggregate_max.rs
+++ b/vortex-array/benches/aggregate_max.rs
@@ -8,7 +8,6 @@ use rand::prelude::*;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::session::ArraySession;
 use vortex_session::VortexSession;
 
 fn main() {
@@ -17,8 +16,7 @@ fn main() {
 
 const N: usize = 100_000;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[divan::bench]
 fn max_i32(bencher: Bencher) {

--- a/vortex-array/benches/aggregate_sum.rs
+++ b/vortex-array/benches/aggregate_sum.rs
@@ -9,7 +9,6 @@ use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::expr::stats::Stat;
-use vortex_array::session::ArraySession;
 use vortex_session::VortexSession;
 
 fn main() {
@@ -18,8 +17,7 @@ fn main() {
 
 const N: usize = 100_000;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[divan::bench]
 fn sum_i32(bencher: Bencher) {

--- a/vortex-array/benches/binary_ops.rs
+++ b/vortex-array/benches/binary_ops.rs
@@ -20,15 +20,13 @@ use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::scalar_fn::fns::operators::Operator;
-use vortex_array::session::ArraySession;
 use vortex_session::VortexSession;
 
 fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 const LEN: usize = 65_536;
 

--- a/vortex-array/benches/cast_primitive.rs
+++ b/vortex-array/benches/cast_primitive.rs
@@ -14,7 +14,6 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::expr::stats::Stat;
-use vortex_array::session::ArraySession;
 use vortex_session::VortexSession;
 
 fn main() {
@@ -23,8 +22,7 @@ fn main() {
 
 const N: usize = 100_000;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[divan::bench]
 fn cast_u16_to_u32(bencher: Bencher) {

--- a/vortex-array/benches/chunk_array_builder.rs
+++ b/vortex-array/benches/chunk_array_builder.rs
@@ -18,7 +18,6 @@ use vortex_array::builders::ArrayBuilder;
 use vortex_array::builders::VarBinViewBuilder;
 use vortex_array::builders::builder_with_capacity;
 use vortex_array::dtype::DType;
-use vortex_array::session::ArraySession;
 use vortex_error::VortexExpect;
 use vortex_session::VortexSession;
 
@@ -33,8 +32,7 @@ const BENCH_ARGS: &[(usize, usize)] = &[
     (1000, 10),
 ];
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[divan::bench(args = BENCH_ARGS)]
 fn chunked_bool_canonical_into(bencher: Bencher, (len, chunk_count): (usize, usize)) {

--- a/vortex-array/benches/chunked_dict_builder.rs
+++ b/vortex-array/benches/chunked_dict_builder.rs
@@ -11,7 +11,6 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::dict_test::gen_dict_primitive_chunks;
 use vortex_array::builders::builder_with_capacity;
 use vortex_array::dtype::NativePType;
-use vortex_array::session::ArraySession;
 use vortex_error::VortexExpect;
 use vortex_session::VortexSession;
 
@@ -19,8 +18,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 const BENCH_ARGS: &[(usize, usize, usize)] = &[
     (1000, 10, 10),

--- a/vortex-array/benches/chunked_fsl_canonicalize.rs
+++ b/vortex-array/benches/chunked_fsl_canonicalize.rs
@@ -18,7 +18,6 @@ use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::FixedSizeListArray;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
@@ -27,8 +26,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 /// Number of lists in each chunk.
 const LISTS_PER_CHUNK: usize = 1_000;

--- a/vortex-array/benches/compare.rs
+++ b/vortex-array/benches/compare.rs
@@ -15,7 +15,6 @@ use vortex_array::arrays::BoolArray;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::scalar_fn::fns::operators::Operator;
 use vortex_buffer::Buffer;
-use vortex_session::VortexSession;
 
 fn main() {
     divan::main();
@@ -30,7 +29,7 @@ fn compare_bool(bencher: Bencher) {
 
     let arr1 = BoolArray::from_iter((0..ARRAY_SIZE).map(|_| rng.sample(range) == 0)).into_array();
     let arr2 = BoolArray::from_iter((0..ARRAY_SIZE).map(|_| rng.sample(range) == 0)).into_array();
-    let session = VortexSession::empty();
+    let session = vortex_array::array_session();
 
     bencher
         .with_inputs(|| (&arr1, &arr2, session.create_execution_ctx()))
@@ -58,7 +57,7 @@ fn compare_int(bencher: Bencher) {
         .map(|_| rng.sample(range))
         .collect::<Buffer<_>>()
         .into_array();
-    let session = VortexSession::empty();
+    let session = vortex_array::array_session();
 
     bencher
         .with_inputs(|| (&arr1, &arr2, session.create_execution_ctx()))

--- a/vortex-array/benches/dict_compare.rs
+++ b/vortex-array/benches/dict_compare.rs
@@ -22,15 +22,13 @@ use vortex_array::expr::eq;
 use vortex_array::expr::lit;
 use vortex_array::expr::root;
 use vortex_array::scalar_fn::fns::operators::Operator;
-use vortex_array::session::ArraySession;
 use vortex_session::VortexSession;
 
 fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 const LENGTH_AND_UNIQUE_VALUES: &[(usize, usize)] = &[
     // length, unique_values
@@ -59,7 +57,7 @@ fn bench_compare_primitive(bencher: divan::Bencher, (len, uniqueness): (usize, u
     )
     .unwrap();
     let value = primitive_arr.as_slice::<i32>()[0];
-    let session = VortexSession::empty();
+    let session = vortex_array::array_session();
 
     bencher
         .with_inputs(|| (&dict, session.create_execution_ctx()))
@@ -83,7 +81,7 @@ fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usiz
     .unwrap();
     let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
-    let session = VortexSession::empty();
+    let session = vortex_array::array_session();
 
     bencher
         .with_inputs(|| (&dict, session.create_execution_ctx()))
@@ -107,7 +105,7 @@ fn bench_compare_varbinview(bencher: divan::Bencher, (len, uniqueness): (usize, 
     .unwrap();
     let bytes = varbinview_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
-    let session = VortexSession::empty();
+    let session = vortex_array::array_session();
 
     bencher
         .with_inputs(|| (&dict, session.create_execution_ctx()))
@@ -146,7 +144,7 @@ fn bench_compare_sliced_dict_primitive(
     .unwrap();
     let dict = dict.into_array().slice(0..codes_len).unwrap();
     let value = primitive_arr.as_slice::<i32>()[0];
-    let session = VortexSession::empty();
+    let session = vortex_array::array_session();
 
     bencher
         .with_inputs(|| (&dict, session.create_execution_ctx()))
@@ -173,7 +171,7 @@ fn bench_compare_sliced_dict_varbinview(
     let dict = dict.into_array().slice(0..codes_len).unwrap();
     let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
-    let session = VortexSession::empty();
+    let session = vortex_array::array_session();
 
     bencher
         .with_inputs(|| (&dict, session.create_execution_ctx()))

--- a/vortex-array/benches/dict_compress.rs
+++ b/vortex-array/benches/dict_compress.rs
@@ -17,7 +17,6 @@ use vortex_array::arrays::dict_test::gen_primitive_for_dict;
 use vortex_array::arrays::dict_test::gen_varbin_words;
 use vortex_array::builders::dict::dict_encode;
 use vortex_array::dtype::NativePType;
-use vortex_array::session::ArraySession;
 use vortex_session::VortexSession;
 
 fn main() {
@@ -38,8 +37,7 @@ const BENCH_ARGS: &[(usize, usize)] = &[
     (10_000, 512),
 ];
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[divan::bench(types = [u8, f32, i64], args = BENCH_ARGS)]
 fn encode_primitives<T>(bencher: Bencher, (len, unique_values): (usize, usize))

--- a/vortex-array/benches/dict_mask.rs
+++ b/vortex-array/benches/dict_mask.rs
@@ -14,7 +14,6 @@ use vortex_array::arrays::DictArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_mask::Mask;
-use vortex_session::VortexSession;
 
 fn main() {
     divan::main();
@@ -60,7 +59,7 @@ fn bench_dict_mask(bencher: Bencher, (fraction_valid, fraction_masked): (f64, f6
     let values = PrimitiveArray::from_option_iter([None, Some(42i32)]).into_array();
     let array = DictArray::try_new(codes, values).unwrap().into_array();
     let filter_mask = filter_mask(len, fraction_masked, &mut rng);
-    let session = VortexSession::empty();
+    let session = vortex_array::array_session();
     bencher
         .with_inputs(|| (&array, &filter_mask, session.create_execution_ctx()))
         .bench_refs(|(array, filter_mask, ctx)| {

--- a/vortex-array/benches/expr/case_when_bench.rs
+++ b/vortex-array/benches/expr/case_when_bench.rs
@@ -22,12 +22,10 @@ use vortex_array::expr::lit;
 use vortex_array::expr::lt;
 use vortex_array::expr::nested_case_when;
 use vortex_array::expr::root;
-use vortex_array::session::ArraySession;
 use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 fn main() {
     divan::main();

--- a/vortex-array/benches/filter_bool.rs
+++ b/vortex-array/benches/filter_bool.rs
@@ -19,7 +19,6 @@ use rand_distr::Zipf;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
-use vortex_array::session::ArraySession;
 use vortex_buffer::BitBuffer;
 use vortex_mask::Mask;
 use vortex_session::VortexSession;
@@ -28,8 +27,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 const SIZES: &[usize] = &[1_000, 10_000, 100_000, 250_000];
 const DENSITY_SWEEP_SIZE: usize = 100_000;

--- a/vortex-array/benches/interleave.rs
+++ b/vortex-array/benches/interleave.rs
@@ -14,7 +14,6 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::InterleaveArray;
 use vortex_buffer::Buffer;
-use vortex_session::VortexSession;
 
 fn main() {
     divan::main();
@@ -54,7 +53,7 @@ fn inputs(
 #[divan::bench(args = [2, 4])]
 fn interleave_bool(bencher: Bencher, num_branches: usize) {
     let (values, array_indices, row_indices) = inputs(num_branches, false);
-    let session = VortexSession::empty();
+    let session = vortex_array::array_session();
     bencher
         .with_inputs(|| {
             (
@@ -74,7 +73,7 @@ fn interleave_bool(bencher: Bencher, num_branches: usize) {
 #[divan::bench(args = [2, 4])]
 fn interleave_bool_nullable(bencher: Bencher, num_branches: usize) {
     let (values, array_indices, row_indices) = inputs(num_branches, true);
-    let session = VortexSession::empty();
+    let session = vortex_array::array_session();
     bencher
         .with_inputs(|| {
             (

--- a/vortex-array/benches/listview_rebuild.rs
+++ b/vortex-array/benches/listview_rebuild.rs
@@ -21,7 +21,6 @@ use vortex_array::arrays::VarBinViewArray;
 use vortex_array::arrays::listview::ListViewArrayExt;
 use vortex_array::arrays::listview::ListViewRebuildMode;
 use vortex_array::dtype::FieldNames;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
@@ -31,8 +30,7 @@ fn main() {
 }
 
 /// A shared session for the `ListView` rebuild benchmarks, used to create execution contexts.
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 fn make_primitive_lv(num_lists: usize, list_size: usize, step: usize) -> ListViewArray {
     let element_count = step * num_lists + list_size;

--- a/vortex-array/benches/scalar_at_struct.rs
+++ b/vortex-array/benches/scalar_at_struct.rs
@@ -15,7 +15,6 @@ use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::StructArray;
 use vortex_array::dtype::FieldNames;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
@@ -27,8 +26,7 @@ fn main() {
 const ARRAY_SIZE: usize = 100_000;
 const NUM_ACCESSES: usize = 1000;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[divan::bench]
 fn execute_scalar_struct_simple(bencher: Bencher) {

--- a/vortex-array/benches/scalar_subtract.rs
+++ b/vortex-array/benches/scalar_subtract.rs
@@ -17,7 +17,6 @@ use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::scalar_fn::fns::operators::Operator;
-use vortex_array::session::ArraySession;
 use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
 
@@ -25,8 +24,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[divan::bench]
 fn scalar_subtract(bencher: Bencher) {

--- a/vortex-array/benches/take_filter.rs
+++ b/vortex-array/benches/take_filter.rs
@@ -30,7 +30,6 @@ use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ListArray;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::BitBuffer;
 use vortex_buffer::BitBufferMut;
@@ -58,8 +57,7 @@ const INDEX_SEED: u64 = 43;
 const LIST_SIZE: usize = 4;
 const NULL_INDEX_INTERVAL: usize = 8;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 fn primitive_array() -> ArrayRef {
     PrimitiveArray::from_iter(0..ARRAY_LEN as u32).into_array()

--- a/vortex-array/benches/take_fsl.rs
+++ b/vortex-array/benches/take_fsl.rs
@@ -20,7 +20,6 @@ use vortex_array::IntoArray;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::FixedSizeListArray;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
@@ -29,8 +28,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 /// Number of lists in the source array.
 const NUM_LISTS: usize = 500;

--- a/vortex-array/benches/take_patches.rs
+++ b/vortex-array/benches/take_patches.rs
@@ -16,7 +16,6 @@ use vortex_array::IntoArray;
 use vortex_array::ToCanonical as _;
 use vortex_array::VortexSessionExecute;
 use vortex_array::patches::Patches;
-use vortex_array::session::ArraySession;
 use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
 
@@ -24,8 +23,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 const BENCH_ARGS: &[(f64, f64)] = &[
     // patches_sparsity, index_multiple

--- a/vortex-array/benches/take_primitive.rs
+++ b/vortex-array/benches/take_primitive.rs
@@ -19,7 +19,6 @@ use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::session::ArraySession;
 use vortex_session::VortexSession;
 
 fn main() {
@@ -32,8 +31,7 @@ const NUM_INDICES: &[usize] = &[1_000, 10_000, 100_000];
 /// Size of the source vector / dictionary values.
 const VECTOR_SIZE: &[usize] = &[16, 256, 2048, 8192];
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 // --- DictArray canonicalization benchmarks ---
 

--- a/vortex-array/benches/take_struct.rs
+++ b/vortex-array/benches/take_struct.rs
@@ -15,7 +15,6 @@ use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::StructArray;
 use vortex_array::dtype::FieldNames;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
@@ -24,8 +23,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 const ARRAY_SIZE: usize = 100_000;
 const TAKE_SIZE: usize = 1000;

--- a/vortex-array/benches/to_arrow.rs
+++ b/vortex-array/benches/to_arrow.rs
@@ -25,15 +25,13 @@ use vortex_array::dtype::DecimalDType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::dtype::StructFields;
-use vortex_array::session::ArraySession;
 use vortex_session::VortexSession;
 
 fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 fn schema() -> DType {
     let fields = StructFields::from_iter([

--- a/vortex-array/benches/varbinview_zip.rs
+++ b/vortex-array/benches/varbinview_zip.rs
@@ -13,7 +13,6 @@ use vortex_array::arrays::VarBinViewArray;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
-use vortex_array::session::ArraySession;
 use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
@@ -21,8 +20,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 /// Benchmarks zip on VarBinView arrays with a highly fragmented mask (worst case for per-slice lookup paths).
 #[divan::bench]

--- a/vortex-array/src/aggregate_fn/accumulator.rs
+++ b/vortex-array/src/aggregate_fn/accumulator.rs
@@ -264,7 +264,6 @@ impl<V: AggregateFnVTable> DynAccumulator for Accumulator<V> {
 mod tests {
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
-    use vortex_session::SessionExt;
     use vortex_session::VortexSession;
 
     use crate::ArrayRef;
@@ -289,7 +288,6 @@ mod tests {
     use crate::dtype::Nullability;
     use crate::dtype::PType;
     use crate::scalar::Scalar;
-    use crate::session::ArraySession;
 
     /// Mean partial sentinel `{sum: 42.0, count: 1}` — distinguishable from the
     /// natural fan-out result `{sum: 7.0, count: 1}` that `Combined::try_accumulate`
@@ -337,7 +335,7 @@ mod tests {
     }
 
     fn fresh_session() -> VortexSession {
-        VortexSession::empty().with::<ArraySession>()
+        crate::array_session()
     }
 
     fn dict_of_seven() -> ArrayRef {

--- a/vortex-array/src/aggregate_fn/fns/bounded_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/bounded_max/mod.rs
@@ -262,7 +262,6 @@ mod tests {
     use crate::arrays::VarBinViewArray;
     use crate::dtype::Nullability;
     use crate::scalar::Scalar;
-    use crate::session::ArraySession;
     use crate::validity::Validity;
 
     fn max_bytes(value: usize) -> NonZeroUsize {
@@ -270,7 +269,7 @@ mod tests {
     }
 
     fn fresh_session() -> VortexSession {
-        VortexSession::empty().with::<ArraySession>()
+        crate::array_session()
     }
 
     #[test]

--- a/vortex-array/src/aggregate_fn/fns/bounded_min/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/bounded_min/mod.rs
@@ -250,7 +250,6 @@ mod tests {
     use crate::arrays::VarBinViewArray;
     use crate::dtype::Nullability;
     use crate::scalar::Scalar;
-    use crate::session::ArraySession;
     use crate::validity::Validity;
 
     fn max_bytes(value: usize) -> NonZeroUsize {
@@ -258,7 +257,7 @@ mod tests {
     }
 
     fn fresh_session() -> VortexSession {
-        VortexSession::empty().with::<ArraySession>()
+        crate::array_session()
     }
 
     #[test]

--- a/vortex-array/src/aggregate_fn/proto.rs
+++ b/vortex-array/src/aggregate_fn/proto.rs
@@ -170,9 +170,10 @@ mod tests {
 
     #[test]
     fn unknown_aggregate_fn_id_allow_unknown() {
-        let session = VortexSession::empty()
+        let session = VortexSession::builder()
             .with::<AggregateFnSession>()
-            .allow_unknown();
+            .allow_unknown()
+            .build();
 
         let proto = pb::AggregateFn {
             id: "vortex.test.foreign_aggregate".to_string(),

--- a/vortex-array/src/aggregate_fn/proto.rs
+++ b/vortex-array/src/aggregate_fn/proto.rs
@@ -155,7 +155,7 @@ mod tests {
 
     #[test]
     fn aggregate_fn_serde() {
-        let session = VortexSession::empty().with::<AggregateFnSession>();
+        let session = crate::array_session();
         session.aggregate_fns().register(TestAgg);
 
         let agg_fn = TestAgg.bind(EmptyOptions);

--- a/vortex-array/src/aggregate_fn/session.rs
+++ b/vortex-array/src/aggregate_fn/session.rs
@@ -4,7 +4,6 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use vortex_session::Ref;
 use vortex_session::SessionExt;
 use vortex_session::SessionVar;
 
@@ -50,7 +49,7 @@ use crate::arrays::dict::compute::min_max::DictMinMaxKernel;
 /// The default session registers the built-in aggregate functions and kernels. Additional
 /// aggregate functions and kernels may be registered by extensions when they are added to a
 /// [`VortexSession`](vortex_session::VortexSession).
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AggregateFnSession {
     registry: ArcSwapMap<AggregateFnId, AggregateFnPluginRef>,
 
@@ -222,7 +221,7 @@ impl AggregateFnSession {
 /// Extension trait for accessing aggregate function session data.
 pub trait AggregateFnSessionExt: SessionExt {
     /// Returns the aggregate function session data.
-    fn aggregate_fns(&self) -> Ref<'_, AggregateFnSession> {
+    fn aggregate_fns(&self) -> &AggregateFnSession {
         self.get::<AggregateFnSession>()
     }
 }

--- a/vortex-array/src/arc_swap_map.rs
+++ b/vortex-array/src/arc_swap_map.rs
@@ -23,14 +23,27 @@ use vortex_utils::aliases::hash_map::HashMap;
 /// optimizer-kernel and aggregate-function registries). Because every write
 /// clones the entire map, it is intended for maps that are written rarely
 /// (typically only while a session is being configured) and read often.
+///
+/// The map is held behind an [`Arc`] so that [`Clone`] shares the same
+/// underlying cell: a registry mutated through one clone is observed by all
+/// others. Session variables rely on this so that encodings registered after a
+/// session is built remain visible to clones of that session.
 pub(crate) struct ArcSwapMap<K, V> {
-    inner: ArcSwap<HashMap<K, V>>,
+    inner: Arc<ArcSwap<HashMap<K, V>>>,
 }
 
 impl<K, V> Default for ArcSwapMap<K, V> {
     fn default() -> Self {
         Self {
-            inner: ArcSwap::from_pointee(HashMap::default()),
+            inner: Arc::new(ArcSwap::from_pointee(HashMap::default())),
+        }
+    }
+}
+
+impl<K, V> Clone for ArcSwapMap<K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
         }
     }
 }
@@ -147,5 +160,16 @@ mod tests {
         map.insert(1, 1);
         map.insert(2, 2);
         assert_eq!(map.read(|m| m.values().sum::<i32>()), 3);
+    }
+
+    #[test]
+    fn clone_shares_the_same_cell() {
+        let map = ArcSwapMap::<u32, i32>::default();
+        let clone = map.clone();
+        // A write through one handle is observed through the other.
+        map.insert(1, 10);
+        assert_eq!(clone.get(&1), Some(10));
+        clone.insert(2, 20);
+        assert_eq!(map.get(&2), Some(20));
     }
 }

--- a/vortex-array/src/arrays/bool/compute/cast.rs
+++ b/vortex-array/src/arrays/bool/compute/cast.rs
@@ -67,10 +67,8 @@ mod tests {
     use crate::compute::conformance::cast::test_cast_conformance;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
-    use crate::session::ArraySession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[test]
     fn try_cast_bool_success() {

--- a/vortex-array/src/arrays/chunked/tests.rs
+++ b/vortex-array/src/arrays/chunked/tests.rs
@@ -30,11 +30,9 @@ use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::dtype::PType::I32;
 use crate::executor::execute_into_builder;
-use crate::session::ArraySession;
 use crate::validity::Validity;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
 fn chunked_array() -> ChunkedArray {
     ChunkedArray::try_new(

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -323,12 +323,10 @@ mod tests {
     use crate::memory::MemorySessionExt;
     use crate::memory::WritableHostBuffer;
     use crate::scalar::Scalar;
-    use crate::session::ArraySession;
     use crate::validity::Validity;
 
     /// A shared session for these chunked-array tests, used to create execution contexts.
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[derive(Debug)]
     struct CountingAllocator {
@@ -640,12 +638,9 @@ mod tests {
     #[test]
     fn list_canonicalize_uses_memory_session_allocator() {
         let allocations = Arc::new(AtomicUsize::new(0));
-        let session = VortexSession::empty();
-        session
-            .memory_mut()
-            .set_allocator(Arc::new(CountingAllocator {
-                allocations: Arc::clone(&allocations),
-            }));
+        let session = crate::array_session().with_allocator(Arc::new(CountingAllocator {
+            allocations: Arc::clone(&allocations),
+        }));
         let mut ctx = ExecutionCtx::new(session);
 
         let l1 = ListArray::try_new(

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -361,12 +361,10 @@ mod tests {
     use crate::expr::stats::Stat;
     use crate::expr::stats::StatsProvider;
     use crate::scalar::Scalar;
-    use crate::session::ArraySession;
     use crate::validity::Validity;
 
     /// A shared session for these constant-array tests, used to create execution contexts.
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[test]
     fn test_canonicalize_null() {

--- a/vortex-array/src/arrays/dict/compute/cast.rs
+++ b/vortex-array/src/arrays/dict/compute/cast.rs
@@ -66,10 +66,8 @@ mod tests {
     use crate::dtype::DType;
     use crate::dtype::Nullability;
     use crate::dtype::PType;
-    use crate::session::ArraySession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[test]
     fn test_cast_dict_to_wider_type() {

--- a/vortex-array/src/arrays/dict/compute/min_max.rs
+++ b/vortex-array/src/arrays/dict/compute/min_max.rs
@@ -74,10 +74,8 @@ mod tests {
     use crate::arrays::DictArray;
     use crate::arrays::PrimitiveArray;
     use crate::builders::dict::dict_encode;
-    use crate::session::ArraySession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     fn assert_min_max(array: &ArrayRef, expected: Option<(i32, i32)>) -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();

--- a/vortex-array/src/arrays/dict/compute/mod.rs
+++ b/vortex-array/src/arrays/dict/compute/mod.rs
@@ -81,10 +81,8 @@ mod test {
     use crate::dtype::Nullability;
     use crate::dtype::PType::I32;
     use crate::scalar_fn::fns::operators::Operator;
-    use crate::session::ArraySession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[test]
     fn canonicalise_nullable_primitive() {
@@ -332,10 +330,8 @@ mod tests {
     use crate::compute::conformance::consistency::test_array_consistency;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
-    use crate::session::ArraySession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[rstest]
     // Primitive arrays

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -63,10 +63,8 @@ mod tests {
     use crate::executor::VortexSessionExecute;
     use crate::extension::datetime::TimeUnit;
     use crate::extension::datetime::Timestamp;
-    use crate::session::ArraySession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[test]
     fn cast_same_ext_dtype() {

--- a/vortex-array/src/arrays/extension/compute/rules.rs
+++ b/vortex-array/src/arrays/extension/compute/rules.rs
@@ -111,10 +111,8 @@ mod tests {
     use crate::scalar::ScalarValue;
     use crate::scalar_fn::fns::binary::Binary;
     use crate::scalar_fn::fns::operators::Operator;
-    use crate::session::ArraySession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
     struct TestExt;

--- a/vortex-array/src/arrays/filter/execute/listview.rs
+++ b/vortex-array/src/arrays/filter/execute/listview.rs
@@ -73,11 +73,9 @@ mod test {
     use crate::arrays::listview::ListViewArrayExt;
     use crate::assert_arrays_eq;
     use crate::compute::conformance::filter::test_filter_conformance;
-    use crate::session::ArraySession;
     use crate::validity::Validity;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[test]
     fn test_filter_listview_conformance() {

--- a/vortex-array/src/arrays/filter/execute/take/tests.rs
+++ b/vortex-array/src/arrays/filter/execute/take/tests.rs
@@ -4,7 +4,6 @@
 use vortex_buffer::buffer;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
-use vortex_session::VortexSession;
 
 use crate::IntoArray;
 use crate::RecursiveCanonical;
@@ -41,7 +40,7 @@ fn test_take_execute_kernel_maps_indices_through_filter() -> VortexResult<()> {
         filter.clone(),
     )?
     .into_array();
-    let mut ctx = ExecutionCtx::new(VortexSession::empty());
+    let mut ctx = ExecutionCtx::new(crate::array_session());
 
     let result = filter
         .execute_parent(&parent, 1, &mut ctx)?
@@ -70,7 +69,7 @@ fn test_take_execute_kernel_nullable_fast_path_maps_indices_through_filter() -> 
         filter.clone(),
     )?
     .into_array();
-    let mut ctx = ExecutionCtx::new(VortexSession::empty());
+    let mut ctx = ExecutionCtx::new(crate::array_session());
 
     let result = filter
         .execute_parent(&parent, 1, &mut ctx)?
@@ -92,7 +91,7 @@ fn test_take_execute_kernel_fast_path_maps_indices_through_filter() -> VortexRes
     )
     .into_array();
     let parent = DictArray::try_new(buffer![2u64, 0, 3].into_array(), filter.clone())?.into_array();
-    let mut ctx = ExecutionCtx::new(VortexSession::empty());
+    let mut ctx = ExecutionCtx::new(crate::array_session());
 
     let result = filter
         .execute_parent(&parent, 1, &mut ctx)?
@@ -113,7 +112,7 @@ fn assert_take_execute_rejects_out_of_bounds_rank(
 ) -> VortexResult<()> {
     let filter = FilterArray::new(child, filter_mask).into_array();
     let parent = DictArray::try_new(codes, filter.clone())?.into_array();
-    let mut ctx = ExecutionCtx::new(VortexSession::empty());
+    let mut ctx = ExecutionCtx::new(crate::array_session());
 
     if let Err(err) = filter.execute_parent(&parent, 1, &mut ctx) {
         assert!(
@@ -191,7 +190,7 @@ fn test_take_execute_kernel_handles_empty_sequential_take() -> VortexResult<()> 
         filter.clone(),
     )?
     .into_array();
-    let mut ctx = ExecutionCtx::new(VortexSession::empty());
+    let mut ctx = ExecutionCtx::new(crate::array_session());
 
     let result = filter
         .execute_parent(&parent, 1, &mut ctx)?
@@ -216,7 +215,7 @@ fn assert_take_execute_maps_child_dtype(
     let filter =
         FilterArray::new(child, Mask::from_iter([true, false, true, true, false])).into_array();
     let parent = DictArray::try_new(buffer![2u64, 0, 1].into_array(), filter.clone())?.into_array();
-    let mut ctx = ExecutionCtx::new(VortexSession::empty());
+    let mut ctx = ExecutionCtx::new(crate::array_session());
 
     let result = filter
         .execute_parent(&parent, 1, &mut ctx)?
@@ -234,7 +233,7 @@ fn test_take_execute_kernel_skips_bool_filter_child() -> VortexResult<()> {
     )
     .into_array();
     let parent = DictArray::try_new(buffer![2u64, 0, 1].into_array(), filter.clone())?.into_array();
-    let mut ctx = ExecutionCtx::new(VortexSession::empty());
+    let mut ctx = ExecutionCtx::new(crate::array_session());
 
     let result = filter.execute_parent(&parent, 1, &mut ctx)?;
 
@@ -256,7 +255,7 @@ fn execute_primitive_take(
     .into_array();
     let indices = PrimitiveArray::from_iter((0..take_len).map(|idx| (idx % filtered_len) as u64));
     let parent = DictArray::try_new(indices.into_array(), filter.clone())?.into_array();
-    let mut ctx = ExecutionCtx::new(VortexSession::empty());
+    let mut ctx = ExecutionCtx::new(crate::array_session());
 
     filter.execute_parent(&parent, 1, &mut ctx)
 }
@@ -323,7 +322,7 @@ fn test_take_execute_kernel_handles_nullable_primitive_filter_child() -> VortexR
     )
     .into_array();
     let parent = DictArray::try_new(buffer![2u64, 0, 1].into_array(), filter.clone())?.into_array();
-    let mut ctx = ExecutionCtx::new(VortexSession::empty());
+    let mut ctx = ExecutionCtx::new(crate::array_session());
 
     let result = filter.execute_parent(&parent, 1, &mut ctx)?;
 
@@ -345,7 +344,7 @@ fn test_take_execute_kernel_preserves_nullable_all_valid_fixed_width_child() -> 
     )
     .into_array();
     let parent = DictArray::try_new(buffer![0u64, 1].into_array(), filter.clone())?.into_array();
-    let mut ctx = ExecutionCtx::new(VortexSession::empty());
+    let mut ctx = ExecutionCtx::new(crate::array_session());
 
     let result = filter
         .execute_parent(&parent, 1, &mut ctx)?
@@ -372,7 +371,7 @@ fn test_take_execute_kernel_handles_nullable_decimal_filter_child() -> VortexRes
     )
     .into_array();
     let parent = DictArray::try_new(buffer![2u64, 0, 1].into_array(), filter.clone())?.into_array();
-    let mut ctx = ExecutionCtx::new(VortexSession::empty());
+    let mut ctx = ExecutionCtx::new(crate::array_session());
 
     let result = filter.execute_parent(&parent, 1, &mut ctx)?;
 
@@ -465,7 +464,7 @@ fn test_take_execute_kernel_preserves_nullable_indices_dtype_fast_path() -> Vort
         filter.clone(),
     )?
     .into_array();
-    let mut ctx = ExecutionCtx::new(VortexSession::empty());
+    let mut ctx = ExecutionCtx::new(crate::array_session());
 
     let result = filter
         .execute_parent(&parent, 1, &mut ctx)?

--- a/vortex-array/src/arrays/list/compute/cast.rs
+++ b/vortex-array/src/arrays/list/compute/cast.rs
@@ -66,7 +66,6 @@ mod tests {
     use std::sync::LazyLock;
 
     use rstest::rstest;
-    use vortex_array::session::ArraySession;
     use vortex_buffer::buffer;
     use vortex_session::VortexSession;
 
@@ -86,8 +85,7 @@ mod tests {
     use crate::dtype::PType;
     use crate::validity::Validity;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[test]
     fn test_cast_list_success() {

--- a/vortex-array/src/arrays/list/tests.rs
+++ b/vortex-array/src/arrays/list/tests.rs
@@ -25,12 +25,10 @@ use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::PType::I32;
 use crate::scalar::Scalar;
-use crate::session::ArraySession;
 use crate::validity::Validity;
 
 /// A shared session for `List` tests, used to create execution contexts.
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
 #[test]
 fn test_empty_list_array() {

--- a/vortex-array/src/arrays/listview/tests/common.rs
+++ b/vortex-array/src/arrays/listview/tests/common.rs
@@ -12,13 +12,11 @@ use crate::IntoArray;
 use crate::arrays::BoolArray;
 use crate::arrays::ListViewArray;
 use crate::arrays::PrimitiveArray;
-use crate::session::ArraySession;
 use crate::validity::Validity;
 
 /// A shared session for `ListView` tests, used to create execution contexts via
 /// [`create_execution_ctx`](crate::VortexSessionExecute::create_execution_ctx).
-pub static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+pub static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
 /// Creates a basic ListView for testing: [[0,1,2], [3,4], [5,6], [7,8,9]]
 pub fn create_basic_listview() -> ListViewArray {

--- a/vortex-array/src/arrays/listview/tests/density.rs
+++ b/vortex-array/src/arrays/listview/tests/density.rs
@@ -7,7 +7,6 @@
 use vortex_buffer::buffer;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
-use vortex_session::VortexSession;
 
 use super::common::create_basic_listview;
 use super::common::create_empty_lists_listview;
@@ -23,13 +22,12 @@ use crate::arrays::listview::tests::common::create_empty_elements_listview;
 use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
 use crate::scalar::ScalarValue;
-use crate::session::ArraySession;
 use crate::validity::Validity;
 
 const EPS: f32 = 1e-6;
 
 fn test_execution_ctx() -> ExecutionCtx {
-    let session = VortexSession::empty().with::<ArraySession>();
+    let session = crate::array_session();
     session.create_execution_ctx()
 }
 

--- a/vortex-array/src/arrays/listview/tests/filter.rs
+++ b/vortex-array/src/arrays/listview/tests/filter.rs
@@ -22,11 +22,9 @@ use crate::arrays::PrimitiveArray;
 use crate::arrays::listview::ListViewArrayExt;
 use crate::assert_arrays_eq;
 use crate::compute::conformance::filter::test_filter_conformance;
-use crate::session::ArraySession;
 use crate::validity::Validity;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
 // Conformance tests for common filter scenarios.
 #[rstest]

--- a/vortex-array/src/arrays/listview/tests/take.rs
+++ b/vortex-array/src/arrays/listview/tests/take.rs
@@ -21,11 +21,9 @@ use crate::arrays::PrimitiveArray;
 use crate::arrays::listview::ListViewArrayExt;
 use crate::assert_arrays_eq;
 use crate::compute::conformance::take::test_take_conformance;
-use crate::session::ArraySession;
 use crate::validity::Validity;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
 // Conformance tests for common take scenarios.
 #[rstest]

--- a/vortex-array/src/arrays/primitive/array/cast.rs
+++ b/vortex-array/src/arrays/primitive/array/cast.rs
@@ -50,11 +50,9 @@ mod tests {
     use crate::dtype::DType;
     use crate::dtype::Nullability;
     use crate::dtype::PType;
-    use crate::session::ArraySession;
     use crate::validity::Validity;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[test]
     fn test_downcast_all_invalid() {

--- a/vortex-array/src/arrays/shared/tests.rs
+++ b/vortex-array/src/arrays/shared/tests.rs
@@ -3,7 +3,6 @@
 
 use vortex_buffer::buffer;
 use vortex_error::VortexResult;
-use vortex_session::VortexSession;
 
 use crate::Canonical;
 use crate::ExecutionCtx;
@@ -13,7 +12,6 @@ use crate::arrays::SharedArray;
 use crate::arrays::shared::SharedArrayExt;
 use crate::hash::ArrayEq;
 use crate::hash::EqMode;
-use crate::session::ArraySession;
 use crate::validity::Validity;
 
 #[test]
@@ -21,7 +19,7 @@ fn shared_array_caches_on_canonicalize() -> VortexResult<()> {
     let array = PrimitiveArray::new(buffer![1i32, 2, 3], Validity::NonNullable).into_array();
     let shared = SharedArray::new(array);
 
-    let session = VortexSession::empty().with::<ArraySession>();
+    let session = crate::array_session();
     let mut ctx = ExecutionCtx::new(session);
 
     let first = shared.get_or_compute(|source| source.clone().execute::<Canonical>(&mut ctx))?;

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -140,16 +140,13 @@ mod tests {
     use crate::dtype::Nullability;
     use crate::dtype::PType;
     use crate::dtype::StructFields;
-    use crate::optimizer::kernels::ArrayKernels;
     use crate::optimizer::kernels::ArrayKernelsExt;
     use crate::optimizer::kernels::ExecuteParentFn;
     use crate::scalar::Scalar;
     use crate::scalar_fn::fns::cast::Cast;
-    use crate::session::ArraySession;
     use crate::validity::Validity;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     fn null_struct_cast_execute_parent(
         child: &ArrayRef,
@@ -224,7 +221,7 @@ mod tests {
             .try_new_array(source.len(), target.clone(), [source])
             .unwrap();
         let parent_id = cast.encoding_id();
-        let session = VortexSession::empty().with::<ArrayKernels>();
+        let session = crate::array_session();
         session.kernels().register_execute_parent(
             parent_id,
             child_id,

--- a/vortex-array/src/arrays/struct_/compute/rules.rs
+++ b/vortex-array/src/arrays/struct_/compute/rules.rs
@@ -153,8 +153,7 @@ mod tests {
     use crate::scalar_fn::ScalarFnVTable;
     use crate::scalar_fn::fns::cast::Cast;
     use crate::validity::Validity;
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArrayKernels>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     fn no_struct_cast_plugin(
         _child: &ArrayRef,

--- a/vortex-array/src/arrays/varbin/compute/cast.rs
+++ b/vortex-array/src/arrays/varbin/compute/cast.rs
@@ -81,10 +81,8 @@ mod tests {
     use crate::compute::conformance::cast::test_cast_conformance;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
-    use crate::session::ArraySession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[rstest]
     #[case(

--- a/vortex-array/src/arrays/varbinview/compute/cast.rs
+++ b/vortex-array/src/arrays/varbinview/compute/cast.rs
@@ -85,10 +85,8 @@ mod tests {
     use crate::compute::conformance::cast::test_cast_conformance;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
-    use crate::session::ArraySession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[rstest]
     #[case(

--- a/vortex-array/src/arrow/executor/list.rs
+++ b/vortex-array/src/arrow/executor/list.rs
@@ -222,12 +222,10 @@ mod tests {
     use crate::arrow::executor::list::ListViewArray;
     use crate::dtype::DType;
     use crate::dtype::Nullability::NonNullable;
-    use crate::session::ArraySession;
     use crate::validity::Validity;
 
     /// A shared session for these list-executor tests, used to create execution contexts.
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[test]
     fn test_to_arrow_list_i32() -> VortexResult<()> {

--- a/vortex-array/src/arrow/executor/list_view.rs
+++ b/vortex-array/src/arrow/executor/list_view.rs
@@ -124,12 +124,10 @@ mod tests {
     use crate::arrow::ArrowArrayExecutor;
     use crate::arrow::executor::list_view::ListViewArray;
     use crate::arrow::executor::list_view::PrimitiveArray;
-    use crate::session::ArraySession;
     use crate::validity::Validity;
 
     /// A shared session for these list-view-executor tests, used to create execution contexts.
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[test]
     fn trims_zero_copy_with_significant_trailing_waste() -> VortexResult<()> {

--- a/vortex-array/src/arrow/executor/run_end.rs
+++ b/vortex-array/src/arrow/executor/run_end.rs
@@ -217,10 +217,8 @@ mod tests {
     use crate::dtype::PType;
     use crate::executor::VortexSessionExecute;
     use crate::scalar::Scalar;
-    use crate::session::ArraySession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     fn ree_type(ends: DataType, values_dtype: DataType) -> DataType {
         DataType::RunEndEncoded(

--- a/vortex-array/src/arrow/session.rs
+++ b/vortex-array/src/arrow/session.rs
@@ -39,7 +39,6 @@ use tracing::trace;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
-use vortex_session::Ref;
 use vortex_session::SessionExt;
 use vortex_session::SessionVar;
 use vortex_session::registry::Id;
@@ -163,7 +162,7 @@ pub type ArrowImportVTableRef = Arc<dyn ArrowImportVTable>;
 /// keyed by Arrow extension name. The default session pre-registers the builtin UUID
 /// plugin; temporal extensions are handled by the canonical Arrow ↔ Vortex path and do not
 /// need plugins.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ArrowSession {
     exporters: ArcSwapMap<Id, Arc<[ArrowExportVTableRef]>>,
     exporters_by_vortex: ArcSwapMap<ExtId, Arc<[ArrowExportVTableRef]>>,
@@ -610,11 +609,11 @@ impl SessionVar for ArrowSession {
 /// Extension trait for accessing the [`ArrowSession`] on a Vortex session.
 pub trait ArrowSessionExt: SessionExt {
     /// Get the Arrow session.
-    fn arrow(&self) -> Ref<'_, ArrowSession>;
+    fn arrow(&self) -> &ArrowSession;
 }
 
 impl<S: SessionExt> ArrowSessionExt for S {
-    fn arrow(&self) -> Ref<'_, ArrowSession> {
+    fn arrow(&self) -> &ArrowSession {
         self.get::<ArrowSession>()
     }
 }

--- a/vortex-array/src/builders/dict/bytes.rs
+++ b/vortex-array/src/builders/dict/bytes.rs
@@ -217,10 +217,8 @@ mod test {
     use crate::arrays::VarBinArray;
     use crate::arrays::dict::DictArraySlotsExt;
     use crate::builders::dict::dict_encode;
-    use crate::session::ArraySession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[test]
     fn encode_varbin() {

--- a/vortex-array/src/builders/dict/primitive.rs
+++ b/vortex-array/src/builders/dict/primitive.rs
@@ -168,10 +168,8 @@ mod test {
     use crate::assert_arrays_eq;
     use crate::builders::dict::dict_encode;
     use crate::builders::dict::primitive::PrimitiveArray;
-    use crate::session::ArraySession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[test]
     fn encode_primitive() {

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -1155,11 +1155,9 @@ mod test {
     use crate::canonical::StructArray;
     use crate::dtype::Nullability;
     use crate::scalar::Scalar;
-    use crate::session::ArraySession;
 
     /// A shared session for these canonical tests, used to create execution contexts.
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     fn variant_core_storage(len: usize) -> ArrayRef {
         ConstantArray::new(

--- a/vortex-array/src/dtype/mod.rs
+++ b/vortex-array/src/dtype/mod.rs
@@ -188,8 +188,5 @@ mod test {
 
     use vortex_session::VortexSession;
 
-    use crate::dtype::session::DTypeSession;
-
-    pub(crate) static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<DTypeSession>());
+    pub(crate) static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 }

--- a/vortex-array/src/dtype/serde/proto.rs
+++ b/vortex-array/src/dtype/serde/proto.rs
@@ -229,8 +229,6 @@ impl TryFrom<&pb::FieldPath> for FieldPath {
 mod tests {
     use std::sync::Arc;
 
-    use vortex_session::VortexSession;
-
     use super::*;
     use crate::dtype::DType;
     use crate::dtype::DecimalDType;
@@ -503,7 +501,7 @@ mod tests {
 
     #[test]
     fn test_unknown_extension_allow_unknown() {
-        let session = VortexSession::empty().allow_unknown();
+        let session = crate::array_session().allow_unknown();
         let proto = pb::DType {
             dtype_type: Some(DtypeType::Extension(Box::new(pb::Extension {
                 id: "vortex.test.foreign_ext".to_string(),

--- a/vortex-array/src/dtype/session.rs
+++ b/vortex-array/src/dtype/session.rs
@@ -6,7 +6,6 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use vortex_session::Ref;
 use vortex_session::SessionExt;
 use vortex_session::SessionVar;
 use vortex_session::registry::Registry;
@@ -22,7 +21,7 @@ use crate::extension::uuid::Uuid;
 pub type ExtDTypeRegistry = Registry<ExtDTypePluginRef>;
 
 /// Session for managing extension dtypes.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DTypeSession {
     registry: ExtDTypeRegistry,
 }
@@ -69,11 +68,11 @@ impl DTypeSession {
 /// Extension trait for accessing the DType session.
 pub trait DTypeSessionExt: SessionExt {
     /// Get the DType session.
-    fn dtypes(&self) -> Ref<'_, DTypeSession>;
+    fn dtypes(&self) -> &DTypeSession;
 }
 
 impl<S: SessionExt> DTypeSessionExt for S {
-    fn dtypes(&self) -> Ref<'_, DTypeSession> {
+    fn dtypes(&self) -> &DTypeSession {
         self.get::<DTypeSession>()
     }
 }

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -26,8 +26,6 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_panic;
-use vortex_session::Ref;
-use vortex_session::SessionExt;
 use vortex_session::VortexSession;
 
 use crate::AnyCanonical;
@@ -430,7 +428,7 @@ impl Executable for ArrayRef {
         for (slot_idx, slot) in array.slots().iter().enumerate() {
             let Some(child) = slot else { continue };
             if let Some(executed_parent) =
-                execute_parent_for_child(&array, child, slot_idx, kernels.as_ref(), ctx)?
+                execute_parent_for_child(&array, child, slot_idx, kernels, ctx)?
             {
                 ctx.log(format_args!(
                     "execute_parent: slot[{}]({}) rewrote {} -> {}",
@@ -542,7 +540,7 @@ fn execute_parent_for_child(
     parent: &ArrayRef,
     child: &ArrayRef,
     slot_idx: usize,
-    kernels: Option<&Ref<ArrayKernels>>,
+    kernels: Option<&ArrayKernels>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ArrayRef>> {
     if let Some(kernels) = kernels
@@ -567,7 +565,7 @@ fn try_execute_parent(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<
     for (slot_idx, slot) in array.slots().iter().enumerate() {
         let Some(child) = slot else { continue };
         if let Some(executed_parent) =
-            execute_parent_for_child(array, child, slot_idx, kernels.as_ref(), ctx)?
+            execute_parent_for_child(array, child, slot_idx, kernels, ctx)?
         {
             ctx.log(format_args!(
                 "execute_parent: slot[{}]({}) rewrote {} -> {}",

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -93,7 +93,7 @@ pub mod flatbuffers {
 /// additional encodings or kernels into it without affecting any other session. This does not
 /// register file, layout, or runtime state — those live in higher-level crates.
 pub fn array_session() -> VortexSession {
-    VortexSession::empty()
+    VortexSession::builder()
         .with::<ArraySession>()
         .with::<DTypeSession>()
         .with::<ScalarFnSession>()
@@ -102,6 +102,7 @@ pub fn array_session() -> VortexSession {
         .with::<AggregateFnSession>()
         .with::<ArrowSession>()
         .with::<MemorySession>()
+        .build()
 }
 
 // TODO(ngates): canonicalize doesn't currently take a session, therefore we cannot invoke execute

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -27,7 +27,14 @@ pub use vortex_array_macros::array_slots;
 use vortex_session::VortexSession;
 use vortex_session::registry::Context;
 
+use crate::aggregate_fn::session::AggregateFnSession;
+use crate::arrow::ArrowSession;
+use crate::dtype::session::DTypeSession;
+use crate::memory::MemorySession;
+use crate::optimizer::kernels::ArrayKernels;
+use crate::scalar_fn::session::ScalarFnSession;
 use crate::session::ArraySession;
+use crate::stats::session::StatsSession;
 
 pub mod accessor;
 pub mod aggregate_fn;
@@ -78,10 +85,28 @@ pub mod flatbuffers {
     pub use vortex_flatbuffers::array::*;
 }
 
+/// Builds a fresh [`VortexSession`] registered with all of vortex-array's built-in session
+/// variables: arrays, dtypes, scalar functions, stats, optimizer kernels, aggregate functions,
+/// Arrow conversion, and memory.
+///
+/// Each call returns an independent session (with its own registries), so callers may register
+/// additional encodings or kernels into it without affecting any other session. This does not
+/// register file, layout, or runtime state — those live in higher-level crates.
+pub fn array_session() -> VortexSession {
+    VortexSession::empty()
+        .with::<ArraySession>()
+        .with::<DTypeSession>()
+        .with::<ScalarFnSession>()
+        .with::<StatsSession>()
+        .with::<ArrayKernels>()
+        .with::<AggregateFnSession>()
+        .with::<ArrowSession>()
+        .with::<MemorySession>()
+}
+
 // TODO(ngates): canonicalize doesn't currently take a session, therefore we cannot invoke execute
 //  from the new array encodings to support back-compat for legacy encodings. So we hold a session
 //  here...
-pub static LEGACY_SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+pub static LEGACY_SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 pub type ArrayContext = Context<ArrayPluginRef>;

--- a/vortex-array/src/memory.rs
+++ b/vortex-array/src/memory.rs
@@ -16,10 +16,9 @@ use vortex_buffer::ByteBufferMut;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
-use vortex_session::Ref;
-use vortex_session::RefMut;
 use vortex_session::SessionExt;
 use vortex_session::SessionVar;
+use vortex_session::VortexSession;
 
 /// Mutable host buffer contract used by [`WritableHostBuffer`].
 pub trait HostBufferMut: Send + 'static {
@@ -173,7 +172,7 @@ pub trait HostAllocatorExt: HostAllocator {
 impl<A: HostAllocator + ?Sized> HostAllocatorExt for A {}
 
 /// Session-scoped memory configuration for Vortex arrays.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MemorySession {
     allocator: HostAllocatorRef,
 }
@@ -214,7 +213,7 @@ impl SessionVar for MemorySession {
 /// Extension trait for accessing session-scoped memory configuration.
 pub trait MemorySessionExt: SessionExt {
     /// Returns the memory session for this execution/session context.
-    fn memory(&self) -> Ref<'_, MemorySession> {
+    fn memory(&self) -> &MemorySession {
         self.get::<MemorySession>()
     }
 
@@ -223,9 +222,11 @@ pub trait MemorySessionExt: SessionExt {
         self.memory().allocator()
     }
 
-    /// Returns mutable access to the memory session.
-    fn memory_mut(&self) -> RefMut<'_, MemorySession> {
-        self.get_mut::<MemorySession>()
+    /// Returns a new session configured to use `allocator` as its host allocator.
+    fn with_allocator(self, allocator: HostAllocatorRef) -> VortexSession {
+        let mut builder = self.session().to_builder();
+        builder.get_mut::<MemorySession>().set_allocator(allocator);
+        builder.build()
     }
 }
 

--- a/vortex-array/src/optimizer/kernels.rs
+++ b/vortex-array/src/optimizer/kernels.rs
@@ -30,7 +30,6 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 
 use vortex_error::VortexResult;
-use vortex_session::Ref;
 use vortex_session::SessionExt;
 use vortex_session::SessionVar;
 use vortex_session::registry::Id;
@@ -111,7 +110,7 @@ impl Borrow<u64> for ExecuteParentFnId {
 ///
 /// Each kernel kind has its own storage map, keyed by `(outer_id, child_id)`. Registering
 /// functions for an existing key appends them to that key's ordered list.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ArrayKernels {
     reduce_parent: ArcSwapMap<ReduceParentFnId, Arc<[ReduceParentFn]>>,
     execute_parent: ArcSwapMap<ExecuteParentFnId, Arc<[ExecuteParentFn]>>,
@@ -213,9 +212,8 @@ impl SessionVar for ArrayKernels {
 /// Extension trait for accessing optimizer kernels from a
 /// [`VortexSession`](vortex_session::VortexSession).
 pub trait ArrayKernelsExt: SessionExt {
-    /// Returns the [`ArrayKernels`] session variable, inserting a default-constructed one if
-    /// none has been registered on the session yet.
-    fn kernels(&self) -> Ref<'_, ArrayKernels> {
+    /// Returns the [`ArrayKernels`] session variable.
+    fn kernels(&self) -> &ArrayKernels {
         self.get::<ArrayKernels>()
     }
 }

--- a/vortex-array/src/optimizer/mod.rs
+++ b/vortex-array/src/optimizer/mod.rs
@@ -18,7 +18,6 @@
 use smallvec::SmallVec;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
-use vortex_session::SessionExt;
 use vortex_session::VortexSession;
 
 use crate::ArrayRef;

--- a/vortex-array/src/scalar/tests/mod.rs
+++ b/vortex-array/src/scalar/tests/mod.rs
@@ -14,7 +14,4 @@ use std::sync::LazyLock;
 
 use vortex_session::VortexSession;
 
-use crate::dtype::session::DTypeSession;
-
-pub(crate) static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<DTypeSession>());
+pub(crate) static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -357,12 +357,10 @@ mod tests {
     use crate::expr::root;
     use crate::scalar::DecimalValue;
     use crate::scalar::Scalar;
-    use crate::session::ArraySession;
     use crate::test_harness::to_int_indices;
     use crate::validity::Validity;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[test]
     fn test_display() {

--- a/vortex-array/src/scalar_fn/fns/case_when.rs
+++ b/vortex-array/src/scalar_fn/fns/case_when.rs
@@ -473,10 +473,8 @@ mod tests {
     use crate::expr::root;
     use crate::expr::test_harness;
     use crate::scalar::Scalar;
-    use crate::session::ArraySession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     /// Helper to evaluate an expression using the apply+execute pattern
     fn evaluate_expr(expr: &Expression, array: &ArrayRef) -> ArrayRef {

--- a/vortex-array/src/scalar_fn/session.rs
+++ b/vortex-array/src/scalar_fn/session.rs
@@ -4,7 +4,6 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use vortex_session::Ref;
 use vortex_session::SessionExt;
 use vortex_session::SessionVar;
 use vortex_session::registry::Registry;
@@ -33,7 +32,7 @@ use crate::scalar_fn::fns::variant_get::VariantGet;
 pub type ScalarFnRegistry = Registry<ScalarFnPluginRef>;
 
 /// Session state for scalar function vtables and rewrite rules.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ScalarFnSession {
     registry: ScalarFnRegistry,
 }
@@ -92,7 +91,7 @@ impl SessionVar for ScalarFnSession {
 /// Extension trait for accessing scalar function session data.
 pub trait ScalarFnSessionExt: SessionExt {
     /// Returns the scalar function vtable registry.
-    fn scalar_fns(&self) -> Ref<'_, ScalarFnSession> {
+    fn scalar_fns(&self) -> &ScalarFnSession {
         self.get::<ScalarFnSession>()
     }
 }

--- a/vortex-array/src/session/mod.rs
+++ b/vortex-array/src/session/mod.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
-use vortex_session::Ref;
 use vortex_session::SessionExt;
 use vortex_session::SessionVar;
 use vortex_session::registry::Registry;
@@ -33,7 +32,7 @@ use crate::arrays::Variant;
 
 pub type ArrayRegistry = Registry<ArrayPluginRef>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ArraySession {
     /// The set of registered array encodings.
     registry: ArrayRegistry,
@@ -100,7 +99,7 @@ impl SessionVar for ArraySession {
 /// Session data for Vortex arrays.
 pub trait ArraySessionExt: SessionExt {
     /// Returns the array encoding registry.
-    fn arrays(&self) -> Ref<'_, ArraySession> {
+    fn arrays(&self) -> &ArraySession {
         self.get::<ArraySession>()
     }
 

--- a/vortex-array/src/stats/expr.rs
+++ b/vortex-array/src/stats/expr.rs
@@ -100,11 +100,9 @@ mod tests {
     use crate::expr::stats::Stat;
     use crate::scalar::Scalar;
     use crate::scalar::ScalarValue;
-    use crate::session::ArraySession;
     use crate::validity::Validity;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     #[test]
     fn stat_expr_reads_cached_sum() -> VortexResult<()> {

--- a/vortex-array/src/stats/rewrite.rs
+++ b/vortex-array/src/stats/rewrite.rs
@@ -156,7 +156,6 @@ fn rewrite(
 #[cfg(test)]
 mod tests {
     use vortex_error::VortexResult;
-    use vortex_session::VortexSession;
 
     use super::StatsRewriteCtx;
     use super::StatsRewriteRule;
@@ -169,7 +168,6 @@ mod tests {
     use crate::scalar_fn::ScalarFnId;
     use crate::scalar_fn::ScalarFnVTable;
     use crate::scalar_fn::fns::literal::Literal;
-    use crate::stats::session::StatsSession;
     use crate::stats::session::StatsSessionExt;
 
     #[derive(Debug)]
@@ -202,7 +200,7 @@ mod tests {
 
     #[test]
     fn combines_multiple_falsifiers_with_or() -> VortexResult<()> {
-        let session = VortexSession::empty().with::<StatsSession>();
+        let session = crate::array_session();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
         session.stats().register_rewrite(StaticLiteralRule {
             falsifier: Some(lit(false)),
@@ -222,7 +220,7 @@ mod tests {
 
     #[test]
     fn combines_multiple_satisfiers_with_or() -> VortexResult<()> {
-        let session = VortexSession::empty().with::<StatsSession>();
+        let session = crate::array_session();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
         session.stats().register_rewrite(StaticLiteralRule {
             falsifier: None,
@@ -242,7 +240,7 @@ mod tests {
 
     #[test]
     fn unregistered_expression_has_no_rewrite() -> VortexResult<()> {
-        let session = VortexSession::empty().with::<StatsSession>();
+        let session = crate::array_session();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
 
         assert_eq!(lit(true).falsify(&dtype, &session)?, None);
@@ -252,7 +250,7 @@ mod tests {
 
     #[test]
     fn non_predicate_expression_errors() {
-        let session = VortexSession::empty().with::<StatsSession>();
+        let session = crate::array_session();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
 
         assert!(lit(7).falsify(&dtype, &session).is_err());

--- a/vortex-array/src/stats/rewrite/builtins.rs
+++ b/vortex-array/src/stats/rewrite/builtins.rs
@@ -616,10 +616,8 @@ mod tests {
     use crate::scalar_fn::fns::dynamic::DynamicComparisonExpr;
     use crate::scalar_fn::fns::operators::CompareOperator;
     use crate::scalar_fn::internal::row_count::RowCount;
-    use crate::stats::session::StatsSession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<StatsSession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
     fn stat(expr: Expression, stat: Stat) -> Expression {
         let aggregate_fn = stat.aggregate_fn().expect("stat should have aggregate fn");

--- a/vortex-array/src/stats/session.rs
+++ b/vortex-array/src/stats/session.rs
@@ -7,7 +7,6 @@ use std::any::Any;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
-use vortex_session::Ref;
 use vortex_session::SessionExt;
 use vortex_session::SessionVar;
 use vortex_utils::aliases::hash_map::HashMap;
@@ -20,15 +19,15 @@ use crate::stats::rewrite::register_builtins;
 type StatsRewriteRuleSet = Arc<[StatsRewriteRuleRef]>;
 
 /// Session state for stats APIs.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct StatsSession {
-    rewrite_rules: RwLock<HashMap<ScalarFnId, StatsRewriteRuleSet>>,
+    rewrite_rules: Arc<RwLock<HashMap<ScalarFnId, StatsRewriteRuleSet>>>,
 }
 
 impl Default for StatsSession {
     fn default() -> Self {
         let this = Self {
-            rewrite_rules: RwLock::new(HashMap::default()),
+            rewrite_rules: Arc::new(RwLock::new(HashMap::default())),
         };
         register_builtins(&this);
         this
@@ -77,7 +76,7 @@ impl SessionVar for StatsSession {
 /// Extension trait for accessing stats session data.
 pub(crate) trait StatsSessionExt: SessionExt {
     /// Returns the stats session state.
-    fn stats(&self) -> Ref<'_, StatsSession> {
+    fn stats(&self) -> &StatsSession {
         self.get::<StatsSession>()
     }
 }

--- a/vortex-btrblocks/benches/compress.rs
+++ b/vortex-btrblocks/benches/compress.rs
@@ -17,14 +17,12 @@ mod benchmarks {
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
-    use vortex_array::session::ArraySession;
     use vortex_btrblocks::BtrBlocksCompressor;
     use vortex_buffer::buffer_mut;
     use vortex_session::VortexSession;
     use vortex_utils::aliases::hash_set::HashSet;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     fn make_clickbench_window_name() -> ArrayRef {
         // A test that's meant to mirror the WindowName column from ClickBench.

--- a/vortex-btrblocks/benches/compress_listview.rs
+++ b/vortex-btrblocks/benches/compress_listview.rs
@@ -21,7 +21,6 @@ mod benchmarks {
     use vortex_array::arrays::StructArray;
     use vortex_array::arrays::VarBinViewArray;
     use vortex_array::dtype::FieldNames;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_btrblocks::BtrBlocksCompressor;
     use vortex_buffer::buffer_mut;
@@ -30,8 +29,7 @@ mod benchmarks {
     const NUM_ROWS: usize = 8192;
     const SEED: u64 = 42;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     const SHORT_STRINGS: &[&str] = &[
         "alpha_one",

--- a/vortex-btrblocks/src/canonical_compressor.rs
+++ b/vortex-btrblocks/src/canonical_compressor.rs
@@ -75,7 +75,6 @@ mod tests {
     use vortex_array::assert_arrays_eq;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::BitBuffer;
     use vortex_buffer::buffer;
@@ -86,8 +85,7 @@ mod tests {
     #[cfg(feature = "zstd")]
     use crate::BtrBlocksCompressorBuilder;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     #[rstest]
     #[case::zctl(

--- a/vortex-btrblocks/src/schemes/float/scheme_selection_tests.rs
+++ b/vortex-btrblocks/src/schemes/float/scheme_selection_tests.rs
@@ -14,7 +14,6 @@ use vortex_array::arrays::PrimitiveArray;
 use vortex_array::builders::ArrayBuilder;
 use vortex_array::builders::PrimitiveBuilder;
 use vortex_array::dtype::Nullability;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_error::VortexResult;
@@ -22,8 +21,7 @@ use vortex_session::VortexSession;
 
 use crate::BtrBlocksCompressor;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[test]
 fn test_constant_compressed() -> VortexResult<()> {

--- a/vortex-btrblocks/src/schemes/float/tests.rs
+++ b/vortex-btrblocks/src/schemes/float/tests.rs
@@ -12,7 +12,6 @@ use vortex_array::builders::ArrayBuilder;
 use vortex_array::builders::PrimitiveBuilder;
 use vortex_array::display::DisplayOptions;
 use vortex_array::dtype::Nullability;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_buffer::buffer_mut;
@@ -24,8 +23,7 @@ use vortex_session::VortexSession;
 use crate::BtrBlocksCompressor;
 use crate::schemes::float::FloatRLEScheme;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[test]
 fn test_empty() -> VortexResult<()> {

--- a/vortex-btrblocks/src/schemes/integer/scheme_selection_tests.rs
+++ b/vortex-btrblocks/src/schemes/integer/scheme_selection_tests.rs
@@ -17,7 +17,6 @@ use vortex_array::arrays::PrimitiveArray;
 use vortex_array::expr::stats::Precision;
 use vortex_array::expr::stats::Stat;
 use vortex_array::expr::stats::StatsProviderExt;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_error::VortexResult;
@@ -30,8 +29,7 @@ use vortex_sparse::Sparse;
 
 use crate::BtrBlocksCompressor;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[test]
 fn test_constant_compressed() -> VortexResult<()> {

--- a/vortex-btrblocks/src/schemes/integer/tests.rs
+++ b/vortex-btrblocks/src/schemes/integer/tests.rs
@@ -15,7 +15,6 @@ use vortex_array::arrays::Dict;
 use vortex_array::arrays::Masked;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::assert_arrays_eq;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
@@ -29,8 +28,7 @@ use vortex_session::VortexSession;
 use crate::BtrBlocksCompressor;
 use crate::schemes::integer::IntRLEScheme;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[test]
 fn test_empty() -> VortexResult<()> {

--- a/vortex-btrblocks/src/schemes/string/scheme_selection_tests.rs
+++ b/vortex-btrblocks/src/schemes/string/scheme_selection_tests.rs
@@ -12,15 +12,13 @@ use vortex_array::arrays::Dict;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
-use vortex_array::session::ArraySession;
 use vortex_error::VortexResult;
 use vortex_fsst::FSST;
 use vortex_session::VortexSession;
 
 use crate::BtrBlocksCompressor;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[test]
 fn test_constant_compressed() -> VortexResult<()> {

--- a/vortex-btrblocks/src/schemes/string/tests.rs
+++ b/vortex-btrblocks/src/schemes/string/tests.rs
@@ -11,14 +11,12 @@ use vortex_array::builders::VarBinViewBuilder;
 use vortex_array::display::DisplayOptions;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
-use vortex_array::session::ArraySession;
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
 
 use crate::BtrBlocksCompressor;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 #[test]
 fn test_strings() -> VortexResult<()> {

--- a/vortex-btrblocks/tests/onpair_roundtrip.rs
+++ b/vortex-btrblocks/tests/onpair_roundtrip.rs
@@ -25,8 +25,7 @@ use vortex_array::session::ArraySession;
 use vortex_btrblocks::BtrBlocksCompressor;
 use vortex_session::VortexSession;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(|| vortex_array::array_session());
 
 /// Helper: synthetic short-string corpus that the cascading compressor should
 /// route through OnPair.

--- a/vortex-btrblocks/tests/onpair_roundtrip.rs
+++ b/vortex-btrblocks/tests/onpair_roundtrip.rs
@@ -21,11 +21,10 @@ use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
-use vortex_array::session::ArraySession;
 use vortex_btrblocks::BtrBlocksCompressor;
 use vortex_session::VortexSession;
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(|| vortex_array::array_session());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 /// Helper: synthetic short-string corpus that the cascading compressor should
 /// route through OnPair.

--- a/vortex-compressor/benches/dict_encode.rs
+++ b/vortex-compressor/benches/dict_encode.rs
@@ -11,15 +11,13 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::builders::dict::dict_encode;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::BufferMut;
 use vortex_compressor::builtins::integer_dictionary_encode;
 use vortex_compressor::stats::IntegerStats;
 use vortex_session::VortexSession;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 fn make_array() -> PrimitiveArray {
     let values: BufferMut<i32> = (0..50).cycle().take(64_000).collect();

--- a/vortex-compressor/benches/stats_calc.rs
+++ b/vortex-compressor/benches/stats_calc.rs
@@ -9,7 +9,6 @@ mod benchmarks {
     use divan::Bencher;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
     use vortex_buffer::BufferMut;
@@ -17,8 +16,7 @@ mod benchmarks {
     use vortex_compressor::stats::IntegerStats;
     use vortex_session::VortexSession;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     fn generate_dataset(max_run: u32, distinct: u32) -> Buffer<u32> {
         let mut output = BufferMut::with_capacity(64_000);

--- a/vortex-compressor/src/builtins/dict/float.rs
+++ b/vortex-compressor/src/builtins/dict/float.rs
@@ -253,11 +253,9 @@ mod tests {
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::dict::DictArraySlotsExt;
     use vortex_array::assert_arrays_eq;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
-    use vortex_session::VortexSession;
 
     use super::dictionary_encode;
     use crate::stats::FloatStats;
@@ -265,9 +263,7 @@ mod tests {
 
     #[test]
     fn test_float_dict_encode() -> VortexResult<()> {
-        let mut ctx = VortexSession::empty()
-            .with::<ArraySession>()
-            .create_execution_ctx();
+        let mut ctx = vortex_array::array_session().create_execution_ctx();
         let values = buffer![1f32, 2f32, 2f32, 0f32, 1f32];
         let validity =
             Validity::Array(BoolArray::from_iter([true, true, true, false, true]).into_array());

--- a/vortex-compressor/src/builtins/dict/integer.rs
+++ b/vortex-compressor/src/builtins/dict/integer.rs
@@ -260,20 +260,16 @@ mod tests {
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::dict::DictArraySlotsExt;
     use vortex_array::assert_arrays_eq;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
-    use vortex_session::VortexSession;
 
     use super::dictionary_encode;
     use crate::stats::IntegerStats;
 
     #[test]
     fn test_dict_encode_integer_stats() -> VortexResult<()> {
-        let mut ctx = VortexSession::empty()
-            .with::<ArraySession>()
-            .create_execution_ctx();
+        let mut ctx = vortex_array::array_session().create_execution_ctx();
         let data = buffer![100i32, 200, 100, 0, 100];
         let validity =
             Validity::Array(BoolArray::from_iter([true, true, true, false, true]).into_array());

--- a/vortex-compressor/src/compressor.rs
+++ b/vortex-compressor/src/compressor.rs
@@ -596,7 +596,6 @@ mod tests {
     use vortex_array::arrays::Constant;
     use vortex_array::arrays::NullArray;
     use vortex_array::arrays::PrimitiveArray;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_session::VortexSession;
@@ -613,8 +612,7 @@ mod tests {
     use crate::estimate::WinnerEstimate;
     use crate::scheme::SchemeExt;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     fn compressor() -> CascadingCompressor {
         CascadingCompressor::new(vec![&IntDictScheme, &FloatDictScheme, &StringDictScheme])

--- a/vortex-cuda/benches/alp_cuda.rs
+++ b/vortex-cuda/benches/alp_cuda.rs
@@ -32,7 +32,6 @@ use vortex::encodings::alp::ALPArrayExt;
 use vortex::encodings::alp::ALPFloat;
 use vortex::encodings::alp::alp_encode;
 use vortex::error::VortexExpect;
-use vortex::session::VortexSession;
 use vortex_cuda::CudaDispatchMode;
 use vortex_cuda::CudaSession;
 use vortex_cuda::executor::CudaArrayExt;

--- a/vortex-cuda/benches/alp_cuda.rs
+++ b/vortex-cuda/benches/alp_cuda.rs
@@ -110,7 +110,7 @@ where
                         let timer = timed.timer();
 
                         let mut cuda_ctx =
-                            CudaSession::create_execution_ctx(&VortexSession::empty())
+                            CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                                 .vortex_expect("failed to create execution context")
                                 .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
                                 .with_launch_strategy(Arc::new(timed));

--- a/vortex-cuda/benches/arrow_binary_cuda.rs
+++ b/vortex-cuda/benches/arrow_binary_cuda.rs
@@ -92,7 +92,7 @@ fn benchmark_arrow_binary_export(c: &mut Criterion) {
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                         .vortex_expect("failed to create execution context")
                         .with_launch_strategy(Arc::new(timed));
                     let array = block_on(out_of_line_binary(len, &mut cuda_ctx))

--- a/vortex-cuda/benches/arrow_binary_cuda.rs
+++ b/vortex-cuda/benches/arrow_binary_cuda.rs
@@ -29,7 +29,6 @@ use vortex::dtype::DType;
 use vortex::dtype::Nullability;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
-use vortex::session::VortexSession;
 use vortex_cuda::CudaExecutionCtx;
 use vortex_cuda::CudaSession;
 use vortex_cuda::arrow::ArrowDeviceArray;
@@ -92,9 +91,10 @@ fn benchmark_arrow_binary_export(c: &mut Criterion) {
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
-                        .vortex_expect("failed to create execution context")
-                        .with_launch_strategy(Arc::new(timed));
+                    let mut cuda_ctx =
+                        CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                            .vortex_expect("failed to create execution context")
+                            .with_launch_strategy(Arc::new(timed));
                     let array = block_on(out_of_line_binary(len, &mut cuda_ctx))
                         .vortex_expect("failed to create binary fixture");
 

--- a/vortex-cuda/benches/arrow_validity_cuda.rs
+++ b/vortex-cuda/benches/arrow_validity_cuda.rs
@@ -41,7 +41,7 @@ fn benchmark_arrow_validity_repack(c: &mut Criterion) {
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                         .vortex_expect("failed to create execution context")
                         .with_launch_strategy(Arc::new(timed));
                     let source = BitBuffer::collect_bool(len + INPUT_OFFSET, |idx| idx % 3 != 0);

--- a/vortex-cuda/benches/arrow_validity_cuda.rs
+++ b/vortex-cuda/benches/arrow_validity_cuda.rs
@@ -17,7 +17,6 @@ use futures::executor::block_on;
 use vortex::array::buffer::BufferHandle;
 use vortex::buffer::BitBuffer;
 use vortex::error::VortexExpect;
-use vortex::session::VortexSession;
 use vortex_cuda::CudaSession;
 use vortex_cuda::arrow::test_harness;
 use vortex_cuda_macros::cuda_available;
@@ -41,9 +40,10 @@ fn benchmark_arrow_validity_repack(c: &mut Criterion) {
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
-                        .vortex_expect("failed to create execution context")
-                        .with_launch_strategy(Arc::new(timed));
+                    let mut cuda_ctx =
+                        CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                            .vortex_expect("failed to create execution context")
+                            .with_launch_strategy(Arc::new(timed));
                     let source = BitBuffer::collect_bool(len + INPUT_OFFSET, |idx| idx % 3 != 0);
                     let sliced = source.slice(INPUT_OFFSET..INPUT_OFFSET + len);
                     let (input_offset, _, input_buffer) = sliced.into_inner();

--- a/vortex-cuda/benches/bitpacked_cuda.rs
+++ b/vortex-cuda/benches/bitpacked_cuda.rs
@@ -31,7 +31,6 @@ use vortex::encodings::fastlanes::BitPackedArray;
 use vortex::encodings::fastlanes::BitPackedData;
 use vortex::encodings::fastlanes::unpack_iter::BitPacked;
 use vortex::error::VortexExpect;
-use vortex::session::VortexSession;
 use vortex_cuda::CudaDispatchMode;
 use vortex_cuda::CudaSession;
 use vortex_cuda::executor::CudaArrayExt;
@@ -129,10 +128,11 @@ where
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
-                        .vortex_expect("failed to create execution context")
-                        .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
-                        .with_launch_strategy(Arc::new(timed));
+                    let mut cuda_ctx =
+                        CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                            .vortex_expect("failed to create execution context")
+                            .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
+                            .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
                         block_on(array.clone().into_array().execute_cuda(&mut cuda_ctx)).unwrap();

--- a/vortex-cuda/benches/bitpacked_cuda.rs
+++ b/vortex-cuda/benches/bitpacked_cuda.rs
@@ -129,7 +129,7 @@ where
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                         .vortex_expect("failed to create execution context")
                         .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
                         .with_launch_strategy(Arc::new(timed));
@@ -184,7 +184,7 @@ where
                         let timer = timed.timer();
 
                         let mut cuda_ctx =
-                            CudaSession::create_execution_ctx(&VortexSession::empty())
+                            CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                                 .vortex_expect("failed to create execution context")
                                 .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
                                 .with_launch_strategy(Arc::new(timed));

--- a/vortex-cuda/benches/date_time_parts_cuda.rs
+++ b/vortex-cuda/benches/date_time_parts_cuda.rs
@@ -68,7 +68,7 @@ fn benchmark_datetimeparts(c: &mut Criterion) {
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                         .vortex_expect("failed to create execution context")
                         .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
                         .with_launch_strategy(Arc::new(timed));

--- a/vortex-cuda/benches/date_time_parts_cuda.rs
+++ b/vortex-cuda/benches/date_time_parts_cuda.rs
@@ -30,7 +30,6 @@ use vortex::encodings::datetime_parts::DateTimePartsArray;
 use vortex::error::VortexExpect;
 use vortex::extension::datetime::TimeUnit;
 use vortex::extension::datetime::Timestamp;
-use vortex::session::VortexSession;
 use vortex_cuda::CudaDispatchMode;
 use vortex_cuda::CudaSession;
 use vortex_cuda::executor::CudaArrayExt;
@@ -68,10 +67,11 @@ fn benchmark_datetimeparts(c: &mut Criterion) {
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
-                        .vortex_expect("failed to create execution context")
-                        .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
-                        .with_launch_strategy(Arc::new(timed));
+                    let mut cuda_ctx =
+                        CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                            .vortex_expect("failed to create execution context")
+                            .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
+                            .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
                         // block on immediately here

--- a/vortex-cuda/benches/dict_cuda.rs
+++ b/vortex-cuda/benches/dict_cuda.rs
@@ -96,7 +96,7 @@ where
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                         .vortex_expect("failed to create execution context")
                         .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
                         .with_launch_strategy(Arc::new(timed));

--- a/vortex-cuda/benches/dict_cuda.rs
+++ b/vortex-cuda/benches/dict_cuda.rs
@@ -27,7 +27,6 @@ use vortex::array::validity::Validity::NonNullable;
 use vortex::buffer::Buffer;
 use vortex::dtype::NativePType;
 use vortex::error::VortexExpect;
-use vortex::session::VortexSession;
 use vortex_cuda::CudaDispatchMode;
 use vortex_cuda::CudaSession;
 use vortex_cuda::executor::CudaArrayExt;
@@ -96,10 +95,11 @@ where
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
-                        .vortex_expect("failed to create execution context")
-                        .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
-                        .with_launch_strategy(Arc::new(timed));
+                    let mut cuda_ctx =
+                        CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                            .vortex_expect("failed to create execution context")
+                            .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
+                            .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
                         block_on(dict_array.clone().into_array().execute_cuda(&mut cuda_ctx))

--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -713,7 +713,7 @@ fn bench_dict_bp_codes_alp_for_bp_values_composed_standalone(c: &mut Criterion) 
                         exponents,
                         codes_bp,
                         *len,
-                        &cuda_session,
+                        cuda_session,
                         &mut cuda_ctx,
                     );
 

--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -222,7 +222,7 @@ fn bench_for_bitpacked(c: &mut Criterion) {
             len,
             |b, &n| {
                 let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -267,7 +267,7 @@ fn bench_dict_bp_codes(c: &mut Criterion) {
             len,
             |b, &n| {
                 let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -311,7 +311,7 @@ fn bench_runend(c: &mut Criterion) {
             len,
             |b, &n| {
                 let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -388,7 +388,7 @@ fn bench_dict_bp_codes_alp_for_bp_values_dynanmic_dispatch(c: &mut Criterion) {
             len,
             |b, &n| {
                 let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -702,7 +702,7 @@ fn bench_dict_bp_codes_alp_for_bp_values_composed_standalone(c: &mut Criterion) 
             &(values_bp, values_reference, codes_bp),
             |b, (values_bp, values_reference, codes_bp)| {
                 b.iter_custom(|iters| {
-                    let session = VortexSession::empty();
+                    let session = vortex_cuda::cuda_session();
                     let cuda_session = session.cuda_session();
                     let mut cuda_ctx = CudaSession::create_execution_ctx(&session)
                         .vortex_expect("ctx")
@@ -778,7 +778,7 @@ fn bench_alp_for_bitpacked_f64(c: &mut Criterion) {
             len,
             |b, &n| {
                 let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u64>::new(&array, n, &mut cuda_ctx);
 
@@ -835,7 +835,7 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
             len,
             |b, &n| {
                 let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -900,7 +900,7 @@ fn bench_alp_for_bitpacked(c: &mut Criterion) {
             len,
             |b, &n| {
                 let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -947,7 +947,7 @@ fn bench_dict_bp_u8_codes_u32_values(c: &mut Criterion) {
             len,
             |b, &n| {
                 let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -990,7 +990,7 @@ fn bench_dict_bp_u16_codes_u32_values(c: &mut Criterion) {
             len,
             |b, &n| {
                 let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -1033,7 +1033,7 @@ fn bench_dict_bp_u32_codes_u32_values(c: &mut Criterion) {
             len,
             |b, &n| {
                 let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 

--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -53,7 +53,6 @@ use vortex::encodings::runend::RunEnd;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
-use vortex::session::VortexSession;
 use vortex_cuda::CudaBufferExt;
 use vortex_cuda::CudaDeviceBuffer;
 use vortex_cuda::CudaDispatchMode;
@@ -221,8 +220,8 @@ fn bench_for_bitpacked(c: &mut Criterion) {
             BenchmarkId::new("cuda/for_bitpacked_6bw/dispatch_u32", len_str),
             len,
             |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
+                let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                    .vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -266,8 +265,8 @@ fn bench_dict_bp_codes(c: &mut Criterion) {
             BenchmarkId::new("cuda/dict_256vals_bp8bw_codes/dispatch_u32", len_str),
             len,
             |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
+                let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                    .vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -310,8 +309,8 @@ fn bench_runend(c: &mut Criterion) {
             BenchmarkId::new("cuda/runend_100runs/dispatch_u32", len_str),
             len,
             |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
+                let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                    .vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -387,8 +386,8 @@ fn bench_dict_bp_codes_alp_for_bp_values_dynanmic_dispatch(c: &mut Criterion) {
             ),
             len,
             |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
+                let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                    .vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -777,8 +776,8 @@ fn bench_alp_for_bitpacked_f64(c: &mut Criterion) {
             BenchmarkId::new("cuda/alp_for_bp_6bw_f64/dispatch_f64", len_str),
             len,
             |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
+                let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                    .vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u64>::new(&array, n, &mut cuda_ctx);
 
@@ -834,8 +833,8 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
             ),
             len,
             |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
+                let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                    .vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -899,8 +898,8 @@ fn bench_alp_for_bitpacked(c: &mut Criterion) {
             BenchmarkId::new("cuda/alp_for_bp_6bw_f32/dispatch_f32", len_str),
             len,
             |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
+                let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                    .vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -946,8 +945,8 @@ fn bench_dict_bp_u8_codes_u32_values(c: &mut Criterion) {
             BenchmarkId::new("cuda/dict_widen_u8_to_u32/dispatch_u32", len_str),
             len,
             |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
+                let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                    .vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -989,8 +988,8 @@ fn bench_dict_bp_u16_codes_u32_values(c: &mut Criterion) {
             BenchmarkId::new("cuda/dict_widen_u16_to_u32/dispatch_u32", len_str),
             len,
             |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
+                let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                    .vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
@@ -1032,8 +1031,8 @@ fn bench_dict_bp_u32_codes_u32_values(c: &mut Criterion) {
             BenchmarkId::new("cuda/dict_nowiden_u32_to_u32/dispatch_u32", len_str),
             len,
             |b, &n| {
-                let mut cuda_ctx =
-                    CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).vortex_expect("ctx");
+                let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                    .vortex_expect("ctx");
 
                 let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 

--- a/vortex-cuda/benches/filter_cuda.rs
+++ b/vortex-cuda/benches/filter_cuda.rs
@@ -165,7 +165,7 @@ where
                 |b, (input_data, bitmask, true_count)| {
                     b.iter_custom(|iters| {
                         let mut cuda_ctx =
-                            CudaSession::create_execution_ctx(&VortexSession::empty())
+                            CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                                 .vortex_expect("failed to create execution context");
 
                         let num_items = input_data.len() as i64;

--- a/vortex-cuda/benches/filter_cuda.rs
+++ b/vortex-cuda/benches/filter_cuda.rs
@@ -27,7 +27,6 @@ use futures::executor::block_on;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
-use vortex::session::VortexSession;
 use vortex_cub::filter::CubFilterable;
 use vortex_cub::filter::cudaStream_t;
 use vortex_cuda::CudaDeviceBuffer;

--- a/vortex-cuda/benches/for_cuda.rs
+++ b/vortex-cuda/benches/for_cuda.rs
@@ -33,7 +33,6 @@ use vortex::encodings::fastlanes::FoR;
 use vortex::encodings::fastlanes::FoRArray;
 use vortex::error::VortexExpect;
 use vortex::scalar::Scalar;
-use vortex::session::VortexSession;
 use vortex_cuda::CudaDispatchMode;
 use vortex_cuda::CudaSession;
 use vortex_cuda::executor::CudaArrayExt;
@@ -90,10 +89,11 @@ where
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
-                        .vortex_expect("failed to create execution context")
-                        .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
-                        .with_launch_strategy(Arc::new(timed));
+                    let mut cuda_ctx =
+                        CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                            .vortex_expect("failed to create execution context")
+                            .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
+                            .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
                         block_on(for_array.clone().into_array().execute_cuda(&mut cuda_ctx))
@@ -129,10 +129,11 @@ where
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
-                        .vortex_expect("failed to create execution context")
-                        .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
-                        .with_launch_strategy(Arc::new(timed));
+                    let mut cuda_ctx =
+                        CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                            .vortex_expect("failed to create execution context")
+                            .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
+                            .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
                         block_on(for_array.clone().into_array().execute_cuda(&mut cuda_ctx))

--- a/vortex-cuda/benches/for_cuda.rs
+++ b/vortex-cuda/benches/for_cuda.rs
@@ -90,7 +90,7 @@ where
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                         .vortex_expect("failed to create execution context")
                         .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
                         .with_launch_strategy(Arc::new(timed));
@@ -129,7 +129,7 @@ where
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                         .vortex_expect("failed to create execution context")
                         .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
                         .with_launch_strategy(Arc::new(timed));

--- a/vortex-cuda/benches/fsst_cuda.rs
+++ b/vortex-cuda/benches/fsst_cuda.rs
@@ -23,7 +23,6 @@ use vortex::array::arrays::PrimitiveArray;
 use vortex::array::match_each_integer_ptype;
 use vortex::encodings::fsst::FSSTArrayExt;
 use vortex::error::VortexExpect;
-use vortex::session::VortexSession;
 use vortex_cuda::CudaSession;
 use vortex_cuda::executor::CudaArrayExt;
 use vortex_cuda_macros::cuda_available;
@@ -66,9 +65,10 @@ fn benchmark_fsst_cuda_decompress(c: &mut Criterion) {
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
-                        .vortex_expect("failed to create execution context")
-                        .with_launch_strategy(Arc::new(timed));
+                    let mut cuda_ctx =
+                        CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                            .vortex_expect("failed to create execution context")
+                            .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
                         block_on(fsst_array.clone().execute_cuda(&mut cuda_ctx)).unwrap();

--- a/vortex-cuda/benches/fsst_cuda.rs
+++ b/vortex-cuda/benches/fsst_cuda.rs
@@ -41,7 +41,7 @@ fn benchmark_fsst_cuda_decompress(c: &mut Criterion) {
     let mut group = c.benchmark_group("cuda");
 
     for &(n, len_str) in BENCH_SIZES {
-        let mut setup_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut setup_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
             .vortex_expect("failed to create execution context");
         let fsst = make_fsst_clickbench_urls(n, setup_ctx.execution_ctx());
 
@@ -66,7 +66,7 @@ fn benchmark_fsst_cuda_decompress(c: &mut Criterion) {
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                         .vortex_expect("failed to create execution context")
                         .with_launch_strategy(Arc::new(timed));
 

--- a/vortex-cuda/benches/list_view_cuda.rs
+++ b/vortex-cuda/benches/list_view_cuda.rs
@@ -25,7 +25,6 @@ use vortex::array::validity::Validity;
 use vortex::dtype::PType;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
-use vortex::session::VortexSession;
 use vortex_cuda::CudaExecutionCtx;
 use vortex_cuda::CudaSession;
 use vortex_cuda::arrow::ArrowDeviceArray;
@@ -90,9 +89,10 @@ fn benchmark_list_view_export(c: &mut Criterion) {
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
-                        .vortex_expect("failed to create execution context")
-                        .with_launch_strategy(Arc::new(timed));
+                    let mut cuda_ctx =
+                        CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                            .vortex_expect("failed to create execution context")
+                            .with_launch_strategy(Arc::new(timed));
                     let array = block_on(contiguous_list_view(len, &mut cuda_ctx))
                         .vortex_expect("failed to create list-view fixture");
 
@@ -120,9 +120,10 @@ fn benchmark_list_view_export(c: &mut Criterion) {
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
-                        .vortex_expect("failed to create execution context")
-                        .with_launch_strategy(Arc::new(timed));
+                    let mut cuda_ctx =
+                        CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                            .vortex_expect("failed to create execution context")
+                            .with_launch_strategy(Arc::new(timed));
                     let array = block_on(non_contiguous_primitive_list_view(len, &mut cuda_ctx))
                         .vortex_expect("failed to create list-view fixture");
 

--- a/vortex-cuda/benches/list_view_cuda.rs
+++ b/vortex-cuda/benches/list_view_cuda.rs
@@ -90,7 +90,7 @@ fn benchmark_list_view_export(c: &mut Criterion) {
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                         .vortex_expect("failed to create execution context")
                         .with_launch_strategy(Arc::new(timed));
                     let array = block_on(contiguous_list_view(len, &mut cuda_ctx))
@@ -120,7 +120,7 @@ fn benchmark_list_view_export(c: &mut Criterion) {
                     let timed = TimedLaunchStrategy::default();
                     let timer = timed.timer();
 
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                         .vortex_expect("failed to create execution context")
                         .with_launch_strategy(Arc::new(timed));
                     let array = block_on(non_contiguous_primitive_list_view(len, &mut cuda_ctx))

--- a/vortex-cuda/benches/runend_cuda.rs
+++ b/vortex-cuda/benches/runend_cuda.rs
@@ -27,7 +27,6 @@ use vortex::buffer::Buffer;
 use vortex::dtype::NativePType;
 use vortex::encodings::runend::RunEnd;
 use vortex::encodings::runend::RunEndArray;
-use vortex::session::VortexSession;
 use vortex_cuda::CudaSession;
 use vortex_cuda::executor::CudaArrayExt;
 use vortex_cuda_macros::cuda_available;
@@ -75,7 +74,8 @@ where
         group.throughput(Throughput::Bytes((len * size_of::<T>()) as u64));
 
         for run_len in [10, 1000, 100000] {
-            let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).unwrap();
+            let mut cuda_ctx =
+                CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).unwrap();
             let runend_array = make_runend_array_typed::<T>(len, run_len, cuda_ctx.execution_ctx());
 
             group.bench_with_input(

--- a/vortex-cuda/benches/runend_cuda.rs
+++ b/vortex-cuda/benches/runend_cuda.rs
@@ -75,7 +75,7 @@ where
         group.throughput(Throughput::Bytes((len * size_of::<T>()) as u64));
 
         for run_len in [10, 1000, 100000] {
-            let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty()).unwrap();
+            let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session()).unwrap();
             let runend_array = make_runend_array_typed::<T>(len, run_len, cuda_ctx.execution_ctx());
 
             group.bench_with_input(
@@ -87,7 +87,7 @@ where
                         let timer = timed.timer();
 
                         let mut cuda_ctx =
-                            CudaSession::create_execution_ctx(&VortexSession::empty())
+                            CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                                 .unwrap()
                                 .with_launch_strategy(Arc::new(timed));
 

--- a/vortex-cuda/benches/throughput_cuda.rs
+++ b/vortex-cuda/benches/throughput_cuda.rs
@@ -107,7 +107,7 @@ fn benchmark_transfer_throughput(c: &mut Criterion) {
             &(input_bytes, output_bytes),
             |b, &(in_bytes, out_bytes)| {
                 b.iter_custom(|iters| {
-                    let session = VortexSession::empty();
+                    let session = vortex_cuda::cuda_session();
                     let mut in_ctx = CudaSession::create_execution_ctx(&session).unwrap();
                     let mut out_ctx = CudaSession::create_execution_ctx(&session).unwrap();
 

--- a/vortex-cuda/benches/throughput_cuda.rs
+++ b/vortex-cuda/benches/throughput_cuda.rs
@@ -21,7 +21,6 @@ use cudarc::driver::DevicePtr;
 use cudarc::driver::DevicePtrMut;
 use cudarc::driver::sys;
 use cudarc::driver::sys::CUevent_flags;
-use vortex::session::VortexSession;
 use vortex_cuda::CudaExecutionCtx;
 use vortex_cuda::CudaSession;
 use vortex_cuda_macros::cuda_available;

--- a/vortex-cuda/benches/zstd_cuda.rs
+++ b/vortex-cuda/benches/zstd_cuda.rs
@@ -19,7 +19,6 @@ use vortex::encodings::zstd::ZstdDataParts;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
-use vortex::session::VortexSession;
 use vortex_cuda::CudaSession;
 use vortex_cuda::ZstdKernelPrep;
 use vortex_cuda::nvcomp::zstd as nvcomp_zstd;
@@ -137,8 +136,9 @@ fn benchmark_zstd_cuda_decompress(c: &mut Criterion) {
             &zstd_array,
             |b, zstd_array| {
                 b.iter_custom(|iters| {
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
-                        .vortex_expect("failed to create execution context");
+                    let mut cuda_ctx =
+                        CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
+                            .vortex_expect("failed to create execution context");
 
                     let mut total_time = Duration::ZERO;
 

--- a/vortex-cuda/benches/zstd_cuda.rs
+++ b/vortex-cuda/benches/zstd_cuda.rs
@@ -126,7 +126,7 @@ fn benchmark_zstd_cuda_decompress(c: &mut Criterion) {
     let mut group = c.benchmark_group("cuda");
 
     for (num_strings, label) in BENCH_SIZES {
-        let mut setup_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut setup_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
             .vortex_expect("failed to create execution context");
         let (zstd_array, uncompressed_size) = make_zstd_array(*num_strings, &mut setup_ctx)
             .vortex_expect("failed to create ZSTD array");
@@ -137,7 +137,7 @@ fn benchmark_zstd_cuda_decompress(c: &mut Criterion) {
             &zstd_array,
             |b, zstd_array| {
                 b.iter_custom(|iters| {
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+                    let mut cuda_ctx = CudaSession::create_execution_ctx(&vortex_cuda::cuda_session())
                         .vortex_expect("failed to create execution context");
 
                     let mut total_time = Duration::ZERO;

--- a/vortex-cuda/ffi/src/lib.rs
+++ b/vortex-cuda/ffi/src/lib.rs
@@ -14,7 +14,6 @@ use std::ptr;
 use arrow_schema::ffi::FFI_ArrowSchema;
 use vortex::error::VortexResult;
 use vortex::error::vortex_ensure;
-use vortex::session::SessionExt;
 use vortex::session::VortexSession;
 use vortex_cuda::CudaSession;
 use vortex_cuda::arrow::ArrowDeviceArray;

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -1259,7 +1259,6 @@ mod tests {
     use vortex::error::VortexResult;
     use vortex::error::vortex_bail;
     use vortex::extension::datetime::TimeUnit;
-    use vortex::session::VortexSession;
 
     use crate::CudaExecutionCtx;
     use crate::arrow::ARROW_DEVICE_CUDA;

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -1594,7 +1594,7 @@ mod tests {
         #[case] expected_len: i64,
         #[case] expected_data_type: DataType,
     ) -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let mut exported = array.export_device_array_with_schema(&mut ctx).await?;
@@ -1615,7 +1615,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_null() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let array = NullArray::new(7).into_array();
@@ -1631,7 +1631,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_dictionary() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let out_of_line = "a dictionary value stored out-of-line";
@@ -1676,7 +1676,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_struct_preserves_dictionary_child() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let dictionary = DictArray::try_new(
@@ -1718,7 +1718,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_dictionary_with_nullable_values() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let array = DictArray::try_new(
@@ -1755,7 +1755,7 @@ mod tests {
         expected_data_type: DataType,
         expected_values: Vec<T>,
     ) -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let mut exported = array.export_device_array_with_schema(&mut ctx).await?;
@@ -1885,7 +1885,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_decimal_narrowing_errors() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
         let array = DecimalArray::from_iter([i256::from_parts(0, 1)], DecimalDType::new(38, 0))
             .into_array();
@@ -1900,7 +1900,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_decimal_narrowing_from_arrow_import() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
         let array = DecimalArray::from_iter([0i128, 1, -2], DecimalDType::new(10, 2)).into_array();
 
@@ -1943,7 +1943,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_temporal() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let array = TemporalArray::new_date(
@@ -1966,7 +1966,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_bool() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let array = BoolArray::from_iter([true, false, true]).into_array();
@@ -1985,7 +1985,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_varbinview() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let out_of_line = "this is a longer string for out-of-line storage";
@@ -2001,7 +2001,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_binary_inline_outline_values() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let out_of_line = b"this binary payload is longer than twelve bytes";
@@ -2032,7 +2032,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_binary_empty_and_all_null() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let empty = VarBinViewArray::from_iter_nullable_bin(std::iter::empty::<Option<&[u8]>>())
@@ -2058,7 +2058,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_binary_invalid_data_buffer_ref_errors() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let view = BinaryView::make_view(b"this references a missing data buffer", 0, 0);
@@ -2084,7 +2084,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_binary_i32_offset_overflow_errors() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let view = BinaryView::new_ref(i32::MAX as u32 + 1, [0; 4], 0, 0);
@@ -2110,7 +2110,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_list() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let array = ListArray::try_new(
@@ -2149,7 +2149,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_host_contiguous_list_view() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let array = ListViewArray::new(
@@ -2176,7 +2176,7 @@ mod tests {
     #[crate::test]
     async fn test_export_host_non_contiguous_nested_list_view_falls_back_to_cpu() -> VortexResult<()>
     {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let elements = StructArray::new(
@@ -2218,7 +2218,7 @@ mod tests {
     #[crate::test]
     async fn test_export_host_non_contiguous_dictionary_list_view_schema_matches_rebuilt_child()
     -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let elements = DictArray::try_new(
@@ -2276,7 +2276,7 @@ mod tests {
     #[crate::test]
     async fn test_export_host_large_lists_dictionary_list_view_schema_matches_rebuilt_child()
     -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let elements = DictArray::try_new(
@@ -2329,7 +2329,7 @@ mod tests {
         #[case] offsets_ptype: PType,
         #[case] sizes_ptype: PType,
     ) -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let elements = primitive_i32_on_device(0..5, &mut ctx).await?;
@@ -2374,7 +2374,7 @@ mod tests {
         #[case] fixture: (ArrayRef, [usize; 2]),
         #[case] expected_data_type: DataType,
     ) -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let (array, expected_data_buffer_lengths) = fixture;
@@ -2405,7 +2405,7 @@ mod tests {
     #[case::u64(PrimitiveArray::from_iter([0u64, 2, 2, 5]).into_array())]
     #[crate::test]
     async fn test_export_list_with_non_i32_offsets(#[case] offsets: ArrayRef) -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let array = ListArray::try_new(
@@ -2437,7 +2437,7 @@ mod tests {
         #[case] offsets_ptype: PType,
         #[case] sizes_ptype: PType,
     ) -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let elements = primitive_i32_on_device([10, 11, 12, 13, 14], &mut ctx).await?;
@@ -2466,7 +2466,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_device_non_contiguous_dictionary_list_view() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let codes = primitive_on_device([0u8, 1, 2, 0, 1], &mut ctx).await?;
@@ -2514,7 +2514,7 @@ mod tests {
     #[crate::test]
     async fn test_export_device_non_contiguous_dictionary_list_view_nullable_values()
     -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let codes = primitive_on_device([0u8, 1, 2, 0, 1], &mut ctx).await?;
@@ -2543,7 +2543,7 @@ mod tests {
     #[crate::test]
     async fn test_export_device_non_contiguous_dictionary_list_view_nullable_codes_errors()
     -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let codes = PrimitiveArray::from_option_iter([Some(0u8), None, Some(2), Some(0), Some(1)]);
@@ -2581,7 +2581,7 @@ mod tests {
         #[case] sizes_values: &[i64],
         #[case] expected_error: &str,
     ) -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let elements = primitive_i32_on_device(0..4, &mut ctx).await?;
@@ -2609,7 +2609,7 @@ mod tests {
     #[crate::test]
     async fn test_export_device_non_contiguous_nested_list_view_returns_error() -> VortexResult<()>
     {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let field = primitive_i32_on_device(0..4, &mut ctx).await?;
@@ -2643,7 +2643,7 @@ mod tests {
     #[crate::test]
     async fn test_export_device_non_contiguous_nullable_primitive_list_view_returns_error()
     -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let elements = nullable_primitive_i32_on_device(
@@ -2673,7 +2673,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_fixed_size_list_as_list() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let array = FixedSizeListArray::new(
@@ -2718,7 +2718,7 @@ mod tests {
     // Check device metadata for data-bearing and metadata-only exports.
     #[crate::test]
     async fn test_export_device_metadata() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
         let expected_device_id = ctx.stream().context().ordinal() as i64;
 
@@ -2740,7 +2740,7 @@ mod tests {
     // Check sliced arrays preserve the expected Arrow length/offset metadata.
     #[crate::test]
     async fn test_export_sliced_arrays() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let primitive = PrimitiveArray::from_iter(0u32..10)
@@ -2766,7 +2766,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_sliced_varbinview_arrays() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let utf8 = VarBinViewArray::from_iter_nullable_str([
@@ -2831,7 +2831,7 @@ mod tests {
         #[case] arrow_offset: usize,
         #[case] len: usize,
     ) -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let logical_bits = (0..len).map(|idx| idx % 3 != 0).collect::<Vec<_>>();
@@ -2864,7 +2864,7 @@ mod tests {
 
     #[crate::test]
     async fn test_repack_arrow_validity_buffer_zeroes_padding() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let len = 9;
@@ -2894,7 +2894,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_all_false_validity_buffer_is_zeroed_on_device() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let len = 4;
@@ -2920,7 +2920,7 @@ mod tests {
     // Check nullable primitives export Arrow null bitmaps on device.
     #[crate::test]
     async fn test_export_nullable_primitive() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let mut primitive = assert_nullable_export(
@@ -2947,7 +2947,7 @@ mod tests {
     // Check nullable bool exports preserve Arrow offset metadata.
     #[crate::test]
     async fn test_export_nullable_bool() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let mut bools = assert_nullable_export(
@@ -2968,7 +2968,7 @@ mod tests {
     // Check synthesized all-null bool validity is large enough for Arrow offset-based reads.
     #[crate::test]
     async fn test_export_all_null_sliced_bool_validity_covers_arrow_offset() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let mut bools = assert_nullable_export(
@@ -2994,7 +2994,7 @@ mod tests {
     // Check nullable decimal exports include Arrow null bitmaps.
     #[crate::test]
     async fn test_export_nullable_decimal() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let mut decimal = assert_nullable_export(
@@ -3024,7 +3024,7 @@ mod tests {
     // Check nullable temporal exports include Arrow null bitmaps.
     #[crate::test]
     async fn test_export_nullable_temporal() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let mut temporal = assert_nullable_export(
@@ -3046,7 +3046,7 @@ mod tests {
     // Check nullable string-view exports include Arrow null bitmaps.
     #[crate::test]
     async fn test_export_nullable_varbinview() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let mut varbinview = assert_nullable_export(
@@ -3069,7 +3069,7 @@ mod tests {
     // Check nullable struct exports include Arrow null bitmaps.
     #[crate::test]
     async fn test_export_nullable_struct() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let mut struct_array = assert_nullable_export(
@@ -3093,7 +3093,7 @@ mod tests {
     // Check nested struct children expose cuDF-compatible Arrow Device layouts.
     #[crate::test]
     async fn test_export_nested_struct_child_layout() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let mut device_array = nested_struct_array().export_device_array(&mut ctx).await?;
@@ -3146,7 +3146,7 @@ mod tests {
     // Check parent release recursively releases children and is safe to repeat.
     #[crate::test]
     async fn test_release_is_idempotent_and_releases_children() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let mut device_array = nested_struct_array().export_device_array(&mut ctx).await?;
@@ -3194,7 +3194,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_struct() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let array = StructArray::new(
@@ -3223,7 +3223,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_struct_with_schema() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let array = StructArray::new(
@@ -3261,7 +3261,7 @@ mod tests {
     // Check nested struct device exports carry the matching Arrow schema.
     #[crate::test]
     async fn test_export_nested_struct_with_schema() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let mut exported = nested_struct_array()
@@ -3293,7 +3293,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_nested_struct_decimal_with_schema() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let nested = StructArray::new(
@@ -3354,7 +3354,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_primitive_with_schema_is_column_shaped() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let array = PrimitiveArray::from_iter(0u32..5).into_array();
@@ -3373,7 +3373,7 @@ mod tests {
 
     #[crate::test]
     async fn test_export_varbinview_with_schema_uses_utf8_view_layout() -> VortexResult<()> {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let japanese = "こんにちは";

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -636,7 +636,7 @@ mod tests {
             .collect();
 
         let bitpacked = bitpacked_array_u32(bit_width, len);
-        let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let packed = bitpacked.packed().clone();
         let device_input = futures::executor::block_on(cuda_ctx.ensure_on_device(packed))?;
         let input_ptr = device_input.cuda_device_ptr()?;
@@ -752,7 +752,7 @@ mod tests {
             })
             .collect();
 
-        let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let (input_ptr, _di) = copy_raw_to_device(&cuda_ctx, &data)?;
 
         let plan = CudaDispatchPlan::new(
@@ -853,7 +853,7 @@ mod tests {
             .collect();
 
         let bp = bitpacked_array_u32(bit_width, len);
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&bp.into_array(), &mut cuda_ctx).await?;
 
         let actual =
@@ -878,7 +878,7 @@ mod tests {
         let bp = bitpacked_array_u32(bit_width, len);
         let for_arr = FoR::try_new(bp.into_array(), Scalar::from(reference))?;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&for_arr.into_array(), &mut cuda_ctx).await?;
 
         let actual =
@@ -900,7 +900,7 @@ mod tests {
             expected.push(values[run]);
         }
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
         let re = RunEnd::new(ends_arr, values_arr, cuda_ctx.execution_ctx());
@@ -945,7 +945,7 @@ mod tests {
 
         let dict = DictArray::try_new(codes_bp.into_array(), dict_for.into_array())?;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&dict.into_array(), &mut cuda_ctx).await?;
 
         let actual =
@@ -982,7 +982,7 @@ mod tests {
             None,
         );
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&tree.into_array(), &mut cuda_ctx).await?;
 
         let actual =
@@ -1015,7 +1015,7 @@ mod tests {
         )?;
         let zz = ZigZag::try_new(bp.into_array())?;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&zz.into_array(), &mut cuda_ctx).await?;
 
         let actual =
@@ -1039,7 +1039,7 @@ mod tests {
             expected.push(values[run] + reference);
         }
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
         let re = RunEnd::new(ends_arr, values_arr, cuda_ctx.execution_ctx());
@@ -1073,7 +1073,7 @@ mod tests {
         let dict = DictArray::try_new(codes_prim.into_array(), values_prim.into_array())?;
         let for_arr = FoR::try_new(dict.into_array(), Scalar::from(reference))?;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&for_arr.into_array(), &mut cuda_ctx).await?;
 
         let actual =
@@ -1105,7 +1105,7 @@ mod tests {
         let values_prim = PrimitiveArray::new(Buffer::from(dict_values), NonNullable);
         let dict = DictArray::try_new(codes_for.into_array(), values_prim.into_array())?;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&dict.into_array(), &mut cuda_ctx).await?;
 
         let actual =
@@ -1134,7 +1134,7 @@ mod tests {
 
         let dict = DictArray::try_new(codes_bp.into_array(), values_prim.into_array())?;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&dict.into_array(), &mut cuda_ctx).await?;
 
         let actual =
@@ -1165,7 +1165,7 @@ mod tests {
         );
 
         // Execute through the hybrid dispatch path (handles widening).
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -1197,7 +1197,7 @@ mod tests {
         );
 
         // Execute through the hybrid dispatch path (handles widening).
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -1214,7 +1214,7 @@ mod tests {
         let values: Vec<u32> = vec![10, 20, 30];
         let len = 3000;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
         let re = RunEnd::new(ends_arr, values_arr, cuda_ctx.execution_ctx());
@@ -1278,7 +1278,7 @@ mod tests {
 
         let expected: Vec<u32> = data[slice_start..slice_end].to_vec();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&sliced, &mut cuda_ctx).await?;
 
         let actual = run_dynamic_dispatch_plan(
@@ -1333,7 +1333,7 @@ mod tests {
         let sliced = zz.into_array().slice(slice_start..slice_end)?;
         let expected: Vec<u32> = all_decoded[slice_start..slice_end].to_vec();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&sliced, &mut cuda_ctx).await?;
 
         let actual = run_dynamic_dispatch_plan(
@@ -1383,7 +1383,7 @@ mod tests {
             .map(|&c| dict_values[c as usize])
             .collect();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&sliced, &mut cuda_ctx).await?;
 
         let actual = run_dynamic_dispatch_plan(
@@ -1432,7 +1432,7 @@ mod tests {
         let sliced = bp.into_array().slice(slice_start..slice_end)?;
         let expected: Vec<u32> = data[slice_start..slice_end].to_vec();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&sliced, &mut cuda_ctx).await?;
 
         let actual = run_dynamic_dispatch_plan(
@@ -1485,7 +1485,7 @@ mod tests {
         let sliced = for_arr.into_array().slice(slice_start..slice_end)?;
         let expected: Vec<u32> = all_decoded[slice_start..slice_end].to_vec();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&sliced, &mut cuda_ctx).await?;
 
         let actual = run_dynamic_dispatch_plan(
@@ -1550,7 +1550,7 @@ mod tests {
         let sliced = dict.into_array().slice(slice_start..slice_end)?;
         let expected: Vec<u32> = all_decoded[slice_start..slice_end].to_vec();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&sliced, &mut cuda_ctx).await?;
 
         let actual = run_dynamic_dispatch_plan(
@@ -1582,7 +1582,7 @@ mod tests {
 
         let seq = Sequence::try_new_typed(base, multiplier, Nullability::NonNullable, len)?;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&seq.into_array(), &mut cuda_ctx).await?;
 
         let actual = run_dynamic_dispatch_plan(
@@ -1615,7 +1615,7 @@ mod tests {
 
         let seq = Sequence::try_new_typed(base, multiplier, Nullability::NonNullable, len)?;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&seq.into_array(), &mut cuda_ctx).await?;
 
         let actual_u32 = run_dynamic_dispatch_plan(
@@ -1655,7 +1655,7 @@ mod tests {
         )?;
         let array = for_arr.into_array();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -1691,7 +1691,7 @@ mod tests {
         )?;
         let array = for_arr.into_array();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -1725,7 +1725,7 @@ mod tests {
         )?;
         let array = for_arr.into_array();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -1738,7 +1738,7 @@ mod tests {
     async fn test_empty_array() -> VortexResult<()> {
         let values: Vec<u32> = vec![];
         let primitive = PrimitiveArray::new(Buffer::from(values), NonNullable);
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&primitive.into_array(), &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
         assert_eq!(result.len(), 0);
@@ -1761,7 +1761,7 @@ mod tests {
         )?;
         let array = for_arr.into_array();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -1795,7 +1795,7 @@ mod tests {
         )?;
         let array = for_arr.into_array();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -1864,7 +1864,7 @@ mod tests {
         use vortex::dtype::Nullability;
         use vortex::encodings::sequence::Sequence;
 
-        let session = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let session = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let cuda_session = session.cuda_session();
 
         // Leaf encodings.
@@ -1962,7 +1962,7 @@ mod tests {
             .into_array();
 
         // GPU decode.
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let gpu = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -2011,7 +2011,7 @@ mod tests {
             .execute::<PrimitiveArray>(&mut LEGACY_SESSION.create_execution_ctx())?;
         let expected: Vec<f64> = cpu_decoded.as_slice::<f64>().to_vec();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?;
         let result_prim = result.as_primitive();
@@ -2031,7 +2031,7 @@ mod tests {
     #[crate::test]
     async fn alp_slice_device_patches() -> VortexResult<()> {
         // Regression test for https://github.com/vortex-data/vortex/issues/7838#issuecomment-4452796116.
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let len = 4096;
         let exponents = Exponents { e: 0, f: 0 };
 
@@ -2098,7 +2098,7 @@ mod tests {
         let values: Vec<u16> = vec![100, 200, 300, 400];
         let len = 2000;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
         let re = RunEnd::new(ends_arr, values_arr, cuda_ctx.execution_ctx());
@@ -2161,7 +2161,7 @@ mod tests {
             "expected Fused for mixed-width Dict with BitPacked codes"
         );
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -2205,7 +2205,7 @@ mod tests {
             "expected Fused for mixed-width Dict with BitPacked codes"
         );
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -2249,7 +2249,7 @@ mod tests {
             "expected Fused for mixed-width Dict with FoR(BitPacked) codes"
         );
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -2303,7 +2303,7 @@ mod tests {
             "expected Fused for mixed-width RunEnd with BitPacked ends"
         );
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -2349,7 +2349,7 @@ mod tests {
             "expected Fused for mixed-width RunEnd with FoR(BitPacked) ends"
         );
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -2381,7 +2381,7 @@ mod tests {
         // Slice from 1000..3000
         let sliced = dict.into_array().slice(1000..3000)?;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&sliced, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -2400,7 +2400,7 @@ mod tests {
     /// (the bit-pattern for i32(-1)), not u32(0x000000FF) = 255.
     #[crate::test]
     fn test_load_element_sign_extends_i8_to_u32() -> VortexResult<()> {
-        let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
 
         let i8_values: Vec<i8> = vec![-1, -2, -3, 127, -128, 0, 1, 42];
         let len = i8_values.len();
@@ -2438,7 +2438,7 @@ mod tests {
     /// Same as above but for i16 → u32 widening.
     #[crate::test]
     fn test_load_element_sign_extends_i16_to_u32() -> VortexResult<()> {
-        let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
 
         let i16_values: Vec<i16> = vec![-1, -256, -32768, 32767, 0, 1, -100, 12345];
         let len = i16_values.len();
@@ -2477,7 +2477,7 @@ mod tests {
     /// Nullable Primitive array — LOAD source with validity propagated.
     #[crate::test]
     async fn test_nullable_primitive() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
 
         let array = PrimitiveArray::from_option_iter(
             (0..2048u32).map(|i| if i % 3 == 0 { None } else { Some(i) }),
@@ -2500,7 +2500,7 @@ mod tests {
     /// validity, so this produces a real nullable FoR(BitPacked) tree.
     #[crate::test]
     async fn test_nullable_for_bitpacked() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
 
         let len = 2048;
         let reference = 1000u32;
@@ -2554,7 +2554,7 @@ mod tests {
     /// AllInvalid array — kernel should be skipped entirely.
     #[crate::test]
     async fn test_all_invalid_skips_kernel() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
 
         let array = PrimitiveArray::new(Buffer::from(vec![0u32; 2048]), Validity::AllInvalid);
 
@@ -2572,7 +2572,7 @@ mod tests {
     /// AllValid nullable array — should fuse and produce AllValid output.
     #[crate::test]
     async fn test_all_valid_nullable() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
 
         let values: Vec<u32> = (0..2048).collect();
         let array = PrimitiveArray::new(Buffer::from(values.clone()), Validity::AllValid);
@@ -2610,7 +2610,7 @@ mod tests {
     async fn test_dict_nullable_values_fuses() -> VortexResult<()> {
         use vortex::buffer::buffer;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
 
         let codes = PrimitiveArray::new(buffer![0u32, 1, 2, 2, 1, 0], NonNullable);
         let values = PrimitiveArray::from_option_iter([Some(10u32), None, Some(30)]);
@@ -2636,7 +2636,7 @@ mod tests {
         use vortex::array::arrays::FilterArray;
         use vortex::mask::Mask;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
 
         let len = 2048usize;
         let values: Vec<Option<u32>> = (0..len)
@@ -2670,7 +2670,7 @@ mod tests {
     /// Empty nullable array should preserve nullability.
     #[crate::test]
     async fn test_empty_nullable_array() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
 
         let array = PrimitiveArray::new(Buffer::<u32>::empty(), Validity::AllValid);
         let result = try_gpu_dispatch(&array.into_array(), &mut cuda_ctx).await?;
@@ -2709,7 +2709,7 @@ mod tests {
 
         let array = bp.into_array();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&array, &mut cuda_ctx).await?;
         let actual = run_dynamic_dispatch_plan(
             &cuda_ctx,
@@ -2757,7 +2757,7 @@ mod tests {
             (bp.into_array(), values)
         };
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&array, &mut cuda_ctx).await?;
         let actual = run_dynamic_dispatch_plan(
             &cuda_ctx,
@@ -2797,7 +2797,7 @@ mod tests {
 
         let array = for_arr.into_array();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&array, &mut cuda_ctx).await?;
         let actual = run_dynamic_dispatch_plan(
             &cuda_ctx,
@@ -2839,7 +2839,7 @@ mod tests {
         let sliced = for_arr.into_array().slice(range.clone())?;
         let expected = all_values[range].to_vec();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&sliced, &mut cuda_ctx).await?;
         let actual = run_dynamic_dispatch_plan(
             &cuda_ctx,
@@ -2886,7 +2886,7 @@ mod tests {
         let cpu_decoded = array.clone().execute::<PrimitiveArray>(&mut ctx)?;
         let expected: Vec<f32> = cpu_decoded.as_slice::<f32>().to_vec();
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&array, &mut cuda_ctx).await?;
         let actual = run_dispatch_plan_f32(
             &cuda_ctx,
@@ -2934,7 +2934,7 @@ mod tests {
         )?;
         assert!(bp.patches().is_some(), "expected patches");
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&bp.into_array(), &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -2967,7 +2967,7 @@ mod tests {
         )?;
         assert!(bp.patches().is_some(), "expected patches");
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&bp.into_array(), &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -3000,7 +3000,7 @@ mod tests {
         )?;
         assert!(bp.patches().is_some(), "expected patches");
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let canonical = try_gpu_dispatch(&bp.into_array(), &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -3039,7 +3039,7 @@ mod tests {
         let values_prim = PrimitiveArray::new(Buffer::from(dict_values), NonNullable);
         let dict = DictArray::try_new(codes_bp.into_array(), values_prim.into_array())?;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&dict.into_array(), &mut cuda_ctx).await?;
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
@@ -3068,7 +3068,7 @@ mod tests {
         )?;
         assert!(bp.patches().is_some(), "expected patches");
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&bp.into_array(), &mut cuda_ctx).await?;
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
@@ -3100,7 +3100,7 @@ mod tests {
         )?;
         assert!(bp.patches().is_some(), "expected patches");
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&bp.into_array(), &mut cuda_ctx).await?;
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
@@ -3112,7 +3112,7 @@ mod tests {
     /// dispatch alongside patch application.
     #[crate::test]
     async fn test_nullable_bitpacked_with_patches() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
 
         let len = 3000usize;
         let bit_width: u8 = 4;
@@ -3168,7 +3168,7 @@ mod tests {
         )?;
         assert!(bp.patches().is_some(), "expected patches");
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let plan = dispatch_plan(&bp.into_array(), &mut cuda_ctx).await?;
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -563,7 +563,6 @@ mod tests {
     use vortex::encodings::zigzag::ZigZag;
     use vortex::error::VortexExpect;
     use vortex::error::VortexResult;
-    use vortex::session::VortexSession;
     use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute;
     use vortex_array::patches::Patches;

--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -96,7 +96,7 @@ pub struct CudaExecutionCtx {
 impl CudaExecutionCtx {
     /// Creates a new CUDA execution context.
     pub(crate) fn new(stream: VortexCudaStream, ctx: ExecutionCtx) -> Self {
-        let cuda_session = ctx.session().cuda_session().clone();
+        let cuda_session = (*ctx.session().cuda_session()).clone();
         Self {
             stream,
             ctx,

--- a/vortex-cuda/src/hybrid_dispatch/mod.rs
+++ b/vortex-cuda/src/hybrid_dispatch/mod.rs
@@ -171,7 +171,6 @@ mod tests {
     use vortex::error::VortexResult;
     use vortex::mask::Mask;
     use vortex::scalar::Scalar;
-    use vortex::session::VortexSession;
     use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute;
 

--- a/vortex-cuda/src/hybrid_dispatch/mod.rs
+++ b/vortex-cuda/src/hybrid_dispatch/mod.rs
@@ -196,7 +196,7 @@ mod tests {
     #[crate::test]
     async fn test_fused() -> VortexResult<()> {
         let mut ctx =
-            CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+            CudaSession::create_execution_ctx(&crate::cuda_session()).vortex_expect("ctx");
         let values: Vec<u32> = (0..2048).map(|i| (i % 128) as u32).collect();
         let bp = BitPacked::encode(
             &PrimitiveArray::new(Buffer::from(values), NonNullable).into_array(),
@@ -226,7 +226,7 @@ mod tests {
         use vortex::encodings::alp::Exponents;
 
         let mut ctx =
-            CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+            CudaSession::create_execution_ctx(&crate::cuda_session()).vortex_expect("ctx");
         let encoded: Vec<i32> = (0i32..2048).map(|i| i % 500).collect();
         let bp = BitPacked::encode(
             &PrimitiveArray::new(Buffer::from(encoded), NonNullable).into_array(),
@@ -264,7 +264,7 @@ mod tests {
         use vortex::encodings::alp::Exponents;
 
         let mut ctx =
-            CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+            CudaSession::create_execution_ctx(&crate::cuda_session()).vortex_expect("ctx");
         let encoded = PrimitiveArray::new(
             Buffer::from((0i32..2048).map(|i| i % 500).collect::<Vec<_>>()),
             NonNullable,
@@ -303,7 +303,7 @@ mod tests {
         use vortex::encodings::fastlanes;
         use vortex::encodings::zstd::ZstdBuffers;
 
-        let session = VortexSession::empty();
+        let session = crate::cuda_session();
         fastlanes::initialize(&session);
         session.arrays().register(ZstdBuffers);
         let mut ctx = CudaSession::create_execution_ctx(&session).vortex_expect("ctx");
@@ -362,7 +362,7 @@ mod tests {
     #[crate::test]
     async fn test_filter_fused_child() -> VortexResult<()> {
         let mut ctx =
-            CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+            CudaSession::create_execution_ctx(&crate::cuda_session()).vortex_expect("ctx");
 
         let len = 2048u32;
         let data: Vec<u32> = (0..len).map(|i| i % 128).collect();
@@ -405,7 +405,7 @@ mod tests {
     #[crate::test]
     async fn test_ext_storage_gpu_decode(#[case] ext: ExtensionArray) -> VortexResult<()> {
         let mut ctx =
-            CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+            CudaSession::create_execution_ctx(&crate::cuda_session()).vortex_expect("ctx");
 
         let expected_storage = canonicalize_cpu(ext.storage_array().clone())?.into_array();
         let expected = ExtensionArray::new(ext.ext_dtype().clone(), expected_storage).into_array();
@@ -428,7 +428,7 @@ mod tests {
     #[crate::test]
     async fn test_ext_canonical_storage() -> VortexResult<()> {
         let mut ctx =
-            CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+            CudaSession::create_execution_ctx(&crate::cuda_session()).vortex_expect("ctx");
 
         let ext = ExtensionArray::new(
             Date::new(TimeUnit::Days, Nullability::NonNullable).erased(),

--- a/vortex-cuda/src/kernel/arrays/constant.rs
+++ b/vortex-cuda/src/kernel/arrays/constant.rs
@@ -199,7 +199,6 @@ mod tests {
     use vortex::error::VortexExpect;
     use vortex::error::VortexResult;
     use vortex::scalar::Scalar;
-    use vortex::session::VortexSession;
 
     use super::*;
     use crate::CanonicalCudaExt;

--- a/vortex-cuda/src/kernel/arrays/constant.rs
+++ b/vortex-cuda/src/kernel/arrays/constant.rs
@@ -224,7 +224,7 @@ mod tests {
     async fn test_cuda_constant_materialization(
         #[case] constant_array: ConstantArray,
     ) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let cpu_result = crate::canonicalize_cpu(constant_array.clone())?;
@@ -244,7 +244,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_constant_empty_array() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let constant_array = ConstantArray::new(42i32, 0);
@@ -265,7 +265,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_constant_small_array() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Test with array smaller than one block (< 2048 elements)

--- a/vortex-cuda/src/kernel/arrays/dict.rs
+++ b/vortex-cuda/src/kernel/arrays/dict.rs
@@ -325,7 +325,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_u32_values_u8_codes() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Dictionary values: [100, 200, 300, 400]
@@ -357,7 +357,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_u64_values_u16_codes() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Dictionary values: large u64 values
@@ -392,7 +392,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_i32_values_u32_codes() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Dictionary values: signed integers including negatives
@@ -423,7 +423,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_large_array() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Dictionary with 256 values
@@ -455,7 +455,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_values_with_validity() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Dictionary values with nulls: [100, null, 300, 400]
@@ -487,7 +487,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_codes_with_validity() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Dictionary values: [100, 200, 300, 400]
@@ -524,7 +524,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_both_with_validity() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Dictionary values with nulls: [100, null, 300, 400]
@@ -568,7 +568,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_i64_values_with_validity() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Dictionary values with nulls (i64)
@@ -613,7 +613,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_all_valid_matches_baseline() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Non-nullable values
@@ -656,7 +656,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_decimal_i8_values() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Precision 2 uses i8 backing type
@@ -684,7 +684,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_decimal_i16_values() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Precision 4 uses i16 backing type
@@ -712,7 +712,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_decimal_i32_values() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Precision 9 uses i32 backing type
@@ -740,7 +740,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_decimal_i64_values() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Precision 18 uses i64 backing type
@@ -771,7 +771,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_decimal_i128_values() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Precision 38 uses i128 backing type
@@ -815,7 +815,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_string_values_u8_codes() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let values = VarBinViewArray::from_iter_str(["cat", "dog", "bird", "fish"]);
@@ -840,7 +840,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_string_values_u16_codes() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let values = VarBinViewArray::from_iter_str(["alpha", "beta", "gamma", "delta", "epsilon"]);
@@ -865,7 +865,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_string_max_inlined_12_bytes() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Exactly 12 bytes — the maximum inlined BinaryView size
@@ -892,7 +892,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_string_outlined_views() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // 13+ bytes — outlined BinaryViews that reference data buffers
@@ -922,7 +922,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_string_empty_strings() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let values = VarBinViewArray::from_iter_str(["", "a", ""]);
@@ -947,7 +947,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_string_values_with_validity() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let values = VarBinViewArray::from_iter_nullable_str([Some("hello"), None, Some("world")]);
@@ -973,7 +973,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_string_outlined_with_validity() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Mix of inlined, outlined, and null dictionary values
@@ -1006,7 +1006,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_dict_decimal_i256_values() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Precision 76 uses i256 backing type

--- a/vortex-cuda/src/kernel/arrays/dict.rs
+++ b/vortex-cuda/src/kernel/arrays/dict.rs
@@ -308,7 +308,6 @@ mod tests {
     use vortex::dtype::DecimalDType;
     use vortex::dtype::i256;
     use vortex::error::VortexExpect;
-    use vortex::session::VortexSession;
 
     use super::*;
     use crate::CanonicalCudaExt;

--- a/vortex-cuda/src/kernel/encodings/alp.rs
+++ b/vortex-cuda/src/kernel/encodings/alp.rs
@@ -171,7 +171,7 @@ mod tests {
     /// Patches must carry `chunk_offsets` — the fused kernel requires them.
     #[crate::test]
     async fn test_cuda_alp_decompression_f32() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // For f32 with exponents (e=0, f=2): decoded = encoded * F10[2] * IF10[0]
@@ -218,7 +218,7 @@ mod tests {
     /// preserved through the standalone ALP GPU executor.
     #[crate::test]
     async fn test_cuda_alp_nullable_with_patches() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Values that will produce ALP exceptions at non-null positions.
@@ -259,7 +259,7 @@ mod tests {
     /// elements are actually null.
     #[crate::test]
     async fn test_cuda_alp_all_valid_nullable() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let values = PrimitiveArray::new(
@@ -292,7 +292,7 @@ mod tests {
     /// (zero patches) via the offset math rather than the NULL sentinel.
     #[crate::test]
     async fn test_cuda_alp_multi_chunk_sparse_patches() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // 3072 values (3 chunks). Inject exceptions (values ALP can't encode
@@ -337,7 +337,7 @@ mod tests {
     /// so this guards the fast-path for the (i64, f64) kernel variant.
     #[crate::test]
     async fn test_cuda_alp_f64_multi_chunk_with_patches() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // 3072 values (3 chunks). Sprinkle exceptions into each chunk.
@@ -381,7 +381,7 @@ mod tests {
     /// (existing tests have ≤ 6 patches per chunk).
     #[crate::test]
     async fn test_cuda_alp_dense_patches_single_chunk() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Build a 1024-element ALP array manually with exactly 40 patches
@@ -429,7 +429,7 @@ mod tests {
     /// loop. Includes a patch in the tail.
     #[crate::test]
     async fn test_cuda_alp_partial_tail_chunk() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let values: Buffer<f64> = (0u32..1500)

--- a/vortex-cuda/src/kernel/encodings/alp.rs
+++ b/vortex-cuda/src/kernel/encodings/alp.rs
@@ -153,7 +153,6 @@ mod tests {
     use vortex::encodings::alp::Exponents;
     use vortex::encodings::alp::alp_encode;
     use vortex::error::VortexExpect;
-    use vortex::session::VortexSession;
 
     use super::*;
     use crate::CanonicalCudaExt;

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -251,7 +251,7 @@ mod tests {
         #[case] iter: impl Iterator<Item = T>,
         #[case] bw: u8,
     ) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let array = PrimitiveArray::new(iter.collect::<Buffer<_>>(), NonNullable);
@@ -283,7 +283,7 @@ mod tests {
 
     #[crate::test]
     fn test_patches() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let array = PrimitiveArray::new(
@@ -326,7 +326,7 @@ mod tests {
     #[case::bw_7(7)]
     #[crate::test]
     fn test_cuda_bitunpack_u8(#[case] bit_width: u8) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let max_val = (1u8 << bit_width).saturating_sub(1);
@@ -379,7 +379,7 @@ mod tests {
     #[case::bw_15(15)]
     #[crate::test]
     fn test_cuda_bitunpack_u16(#[case] bit_width: u8) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let max_val = (1u16 << bit_width).saturating_sub(1);
@@ -448,7 +448,7 @@ mod tests {
     #[case::bw_31(31)]
     #[crate::test]
     fn test_cuda_bitunpack_u32(#[case] bit_width: u8) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let max_val = (1u32 << bit_width).saturating_sub(1);
@@ -549,7 +549,7 @@ mod tests {
     #[case::bw_63(63)]
     #[crate::test]
     fn test_cuda_bitunpack_u64(#[case] bit_width: u8) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let max_val = (1u64 << bit_width).saturating_sub(1);
@@ -586,7 +586,7 @@ mod tests {
     #[crate::test]
     fn test_cuda_bitunpack_sliced() -> VortexResult<()> {
         let bit_width = 32;
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let max_val = (1u64 << bit_width).saturating_sub(1);
@@ -668,7 +668,7 @@ mod tests {
     /// offset_within_chunk.
     #[crate::test]
     fn test_cuda_bitunpack_sliced_patches_offset_within_chunk() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Create an array with values that will generate patches.
@@ -710,7 +710,7 @@ mod tests {
     /// Test slicing a bitpacked array multiple times, accumulating offset_within_chunk.
     #[crate::test]
     fn test_cuda_bitunpack_double_sliced_patches() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Create an array with values that will generate patches.
@@ -764,7 +764,7 @@ mod tests {
     /// Test slicing to skip an entire chunk's worth of patches.
     #[crate::test]
     fn test_cuda_bitunpack_sliced_skip_first_chunk_patches() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Create patches in first chunk only, then slice past them all.

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -233,7 +233,6 @@ mod tests {
     use vortex::buffer::buffer;
     use vortex::encodings::fastlanes::BitPackedArrayExt;
     use vortex::error::VortexExpect;
-    use vortex::session::VortexSession;
     use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute;
 

--- a/vortex-cuda/src/kernel/encodings/date_time_parts.rs
+++ b/vortex-cuda/src/kernel/encodings/date_time_parts.rs
@@ -280,7 +280,7 @@ mod tests {
         #[case] subseconds: Vec<i64>,
         #[case] time_unit: TimeUnit,
     ) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let dtp_array = make_datetimeparts_array(days, seconds, subseconds, time_unit);
@@ -301,7 +301,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_datetimeparts_large_array() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let len = 2050;
@@ -327,7 +327,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_datetimeparts_with_nulls() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let days_arr = PrimitiveArray::new(

--- a/vortex-cuda/src/kernel/encodings/date_time_parts.rs
+++ b/vortex-cuda/src/kernel/encodings/date_time_parts.rs
@@ -214,7 +214,6 @@ mod tests {
     use vortex::error::VortexExpect;
     use vortex::error::VortexResult;
     use vortex::extension::datetime::TimeUnit;
-    use vortex::session::VortexSession;
 
     use super::*;
     use crate::CanonicalCudaExt;

--- a/vortex-cuda/src/kernel/encodings/decimal_byte_parts.rs
+++ b/vortex-cuda/src/kernel/encodings/decimal_byte_parts.rs
@@ -86,7 +86,7 @@ mod tests {
         #[case] precision: u8,
         #[case] scale: i8,
     ) {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("create execution context");
 
         let decimal_dtype = DecimalDType::new(precision, scale);

--- a/vortex-cuda/src/kernel/encodings/decimal_byte_parts.rs
+++ b/vortex-cuda/src/kernel/encodings/decimal_byte_parts.rs
@@ -70,7 +70,6 @@ mod tests {
     use vortex::dtype::DecimalDType;
     use vortex::encodings::decimal_byte_parts::DecimalByteParts;
     use vortex::error::VortexExpect;
-    use vortex::session::VortexSession;
 
     use super::*;
     use crate::session::CudaSession;

--- a/vortex-cuda/src/kernel/encodings/for_.rs
+++ b/vortex-cuda/src/kernel/encodings/for_.rs
@@ -138,7 +138,6 @@ mod tests {
     use vortex::encodings::fastlanes::FoRArray;
     use vortex::error::VortexExpect;
     use vortex::scalar::Scalar;
-    use vortex::session::VortexSession;
     use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute;
 

--- a/vortex-cuda/src/kernel/encodings/for_.rs
+++ b/vortex-cuda/src/kernel/encodings/for_.rs
@@ -161,7 +161,7 @@ mod tests {
     #[case::u64(make_for_array((0..2050).map(|i| (i % 2050) as u64).collect(), 1000000u64))]
     #[crate::test]
     async fn test_cuda_for_decompression(#[case] for_array: FoRArray) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let cpu_result = crate::canonicalize_cpu(for_array.clone())?;
@@ -181,7 +181,7 @@ mod tests {
 
     #[crate::test]
     async fn test_signed_ffor() {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let values = (0i8..8i8)

--- a/vortex-cuda/src/kernel/encodings/fsst.rs
+++ b/vortex-cuda/src/kernel/encodings/fsst.rs
@@ -236,7 +236,7 @@ mod tests {
         #[case] strings: Vec<Option<&'static [u8]>>,
         #[case] nullability: Nullability,
     ) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let varbin = VarBinArray::from_iter(strings, DType::Binary(nullability));
@@ -264,7 +264,7 @@ mod tests {
     async fn test_cuda_fsst_decompression_roundtrip_large() -> VortexResult<()> {
         use vortex_fsst::test_utils::make_fsst_clickbench_urls;
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let fsst_array = make_fsst_clickbench_urls(100_000, cuda_ctx.execution_ctx()).into_array();

--- a/vortex-cuda/src/kernel/encodings/fsst.rs
+++ b/vortex-cuda/src/kernel/encodings/fsst.rs
@@ -209,7 +209,6 @@ mod tests {
     use vortex::encodings::fsst::fsst_compress;
     use vortex::encodings::fsst::fsst_train_compressor;
     use vortex::error::VortexExpect;
-    use vortex::session::VortexSession;
 
     use super::*;
     use crate::CanonicalCudaExt;

--- a/vortex-cuda/src/kernel/encodings/runend.rs
+++ b/vortex-cuda/src/kernel/encodings/runend.rs
@@ -208,7 +208,7 @@ mod tests {
     #[case::u64_ends_i32_values(|ctx: &mut vortex::array::ExecutionCtx| make_runend_array(vec![2u64, 5, 10], vec![1i32, 2, 3], ctx))]
     #[crate::test]
     async fn test_cuda_runend_types(#[case] build: RunEndBuilder) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let runend_array = build(cuda_ctx.execution_ctx());
@@ -229,7 +229,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_runend_large_array() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let num_runs = 41;
@@ -259,7 +259,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_runend_single_run() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let runend_array = make_runend_array(vec![100u32], vec![42i32], cuda_ctx.execution_ctx());
@@ -281,7 +281,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_runend_many_small_runs() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Create an array where each run has length 1.
@@ -308,7 +308,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_runend_nullable_values_falls_back_to_cpu() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // Build a RunEnd array whose values have Validity::Array (some nulls).

--- a/vortex-cuda/src/kernel/encodings/runend.rs
+++ b/vortex-cuda/src/kernel/encodings/runend.rs
@@ -174,7 +174,6 @@ mod tests {
     use vortex::encodings::runend::RunEndArray;
     use vortex::error::VortexExpect;
     use vortex::error::VortexResult;
-    use vortex::session::VortexSession;
 
     use super::*;
     use crate::CanonicalCudaExt;

--- a/vortex-cuda/src/kernel/encodings/sequence.rs
+++ b/vortex-cuda/src/kernel/encodings/sequence.rs
@@ -92,7 +92,6 @@ mod tests {
     use vortex::dtype::Nullability;
     use vortex::encodings::sequence::Sequence;
     use vortex::scalar::PValue;
-    use vortex::session::VortexSession;
 
     use crate::CanonicalCudaExt;
     use crate::CudaSession;

--- a/vortex-cuda/src/kernel/encodings/sequence.rs
+++ b/vortex-cuda/src/kernel/encodings/sequence.rs
@@ -125,7 +125,7 @@ mod tests {
         len: usize,
         nullability: Nullability,
     ) {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty()).unwrap();
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session()).unwrap();
 
         let array = Sequence::try_new_typed(base, multiplier, nullability, len).unwrap();
 

--- a/vortex-cuda/src/kernel/encodings/zigzag.rs
+++ b/vortex-cuda/src/kernel/encodings/zigzag.rs
@@ -113,7 +113,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_zigzag_decompression_u32() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         // ZigZag encoding: 0->0, 1->-1, 2->1, 3->-2, 4->2, ...

--- a/vortex-cuda/src/kernel/encodings/zigzag.rs
+++ b/vortex-cuda/src/kernel/encodings/zigzag.rs
@@ -105,7 +105,6 @@ mod tests {
     use vortex::buffer::Buffer;
     use vortex::encodings::zigzag::ZigZag;
     use vortex::error::VortexExpect;
-    use vortex::session::VortexSession;
 
     use super::*;
     use crate::CanonicalCudaExt;

--- a/vortex-cuda/src/kernel/encodings/zstd.rs
+++ b/vortex-cuda/src/kernel/encodings/zstd.rs
@@ -356,7 +356,6 @@ mod tests {
     use vortex::array::assert_arrays_eq;
     use vortex::encodings::zstd::Zstd;
     use vortex::error::VortexResult;
-    use vortex::session::VortexSession;
 
     use super::*;
     use crate::CanonicalCudaExt;

--- a/vortex-cuda/src/kernel/encodings/zstd.rs
+++ b/vortex-cuda/src/kernel/encodings/zstd.rs
@@ -365,7 +365,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_zstd_decompression_utf8() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let strings = VarBinViewArray::from_iter_str([
@@ -391,7 +391,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_zstd_decompression_multiple_frames() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let strings = VarBinViewArray::from_iter_str([
@@ -427,7 +427,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_zstd_decompression_sliced() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let strings = VarBinViewArray::from_iter_str([
@@ -462,7 +462,7 @@ mod tests {
     /// correct results instead of panicking.
     #[crate::test]
     async fn test_cuda_zstd_nullable_falls_back_to_cpu() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let strings = VarBinViewArray::from_iter_nullable_str([

--- a/vortex-cuda/src/kernel/encodings/zstd_buffers.rs
+++ b/vortex-cuda/src/kernel/encodings/zstd_buffers.rs
@@ -234,11 +234,11 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_zstd_buffers_decompression_primitive() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let input = PrimitiveArray::from_iter(0i64..1024).into_array();
-        let compressed = ZstdBuffers::compress(&input, 3, &VortexSession::empty())?;
+        let compressed = ZstdBuffers::compress(&input, 3, &crate::cuda_session())?;
 
         let cpu_result = crate::canonicalize_cpu(compressed.clone())?;
         let gpu_result = ZstdBuffersExecutor
@@ -253,7 +253,7 @@ mod tests {
 
     #[crate::test]
     async fn test_cuda_zstd_buffers_decompression_varbinview() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create execution context");
 
         let input = VarBinViewArray::from_iter_str([
@@ -265,7 +265,7 @@ mod tests {
             "baz",
         ])
         .into_array();
-        let compressed = ZstdBuffers::compress(&input, 3, &VortexSession::empty())?;
+        let compressed = ZstdBuffers::compress(&input, 3, &crate::cuda_session())?;
 
         let cpu_result = crate::canonicalize_cpu(compressed.clone())?;
         let gpu_result = ZstdBuffersExecutor

--- a/vortex-cuda/src/kernel/encodings/zstd_buffers.rs
+++ b/vortex-cuda/src/kernel/encodings/zstd_buffers.rs
@@ -226,7 +226,6 @@ mod tests {
     use vortex::array::assert_arrays_eq;
     use vortex::error::VortexExpect;
     use vortex::error::VortexResult;
-    use vortex::session::VortexSession;
 
     use super::*;
     use crate::CanonicalCudaExt;

--- a/vortex-cuda/src/kernel/filter/decimal.rs
+++ b/vortex-cuda/src/kernel/filter/decimal.rs
@@ -89,7 +89,7 @@ mod tests {
         #[case] input: DecimalArray,
         #[case] mask: Mask,
     ) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create CUDA execution context");
 
         let filter_array = FilterArray::try_new(input.clone().into_array(), mask.clone())?;
@@ -111,7 +111,7 @@ mod tests {
 
     #[crate::test]
     async fn test_gpu_filter_decimal_large_array() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create CUDA execution context");
 
         // Create a large array to test multi-block execution

--- a/vortex-cuda/src/kernel/filter/decimal.rs
+++ b/vortex-cuda/src/kernel/filter/decimal.rs
@@ -48,7 +48,6 @@ mod tests {
     use vortex::error::VortexExpect;
     use vortex::error::VortexResult;
     use vortex::mask::Mask;
-    use vortex::session::VortexSession;
 
     use crate::CanonicalCudaExt;
     use crate::FilterExecutor;

--- a/vortex-cuda/src/kernel/filter/primitive.rs
+++ b/vortex-cuda/src/kernel/filter/primitive.rs
@@ -83,7 +83,7 @@ mod tests {
         #[case] input: PrimitiveArray,
         #[case] mask: Mask,
     ) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create CUDA execution context");
 
         let filter_array = FilterArray::try_new(input.clone().into_array(), mask.clone())?;
@@ -105,7 +105,7 @@ mod tests {
 
     #[crate::test]
     async fn test_gpu_filter_large_array() -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create CUDA execution context");
 
         // Create a large array to test multi-block execution

--- a/vortex-cuda/src/kernel/filter/primitive.rs
+++ b/vortex-cuda/src/kernel/filter/primitive.rs
@@ -46,7 +46,6 @@ mod tests {
     use vortex::error::VortexExpect;
     use vortex::error::VortexResult;
     use vortex::mask::Mask;
-    use vortex::session::VortexSession;
 
     use crate::CanonicalCudaExt;
     use crate::FilterExecutor;

--- a/vortex-cuda/src/kernel/filter/varbinview.rs
+++ b/vortex-cuda/src/kernel/filter/varbinview.rs
@@ -69,7 +69,7 @@ mod tests {
         #[case] input: VarBinViewArray,
         #[case] mask: Mask,
     ) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
             .vortex_expect("failed to create CUDA execution context");
 
         let filter_array = FilterArray::try_new(input.into_array(), mask.clone())?;

--- a/vortex-cuda/src/kernel/filter/varbinview.rs
+++ b/vortex-cuda/src/kernel/filter/varbinview.rs
@@ -46,7 +46,6 @@ mod tests {
     use vortex::error::VortexExpect;
     use vortex::error::VortexResult;
     use vortex::mask::Mask;
-    use vortex::session::VortexSession;
 
     use crate::CanonicalCudaExt;
     use crate::FilterExecutor;

--- a/vortex-cuda/src/kernel/patches/mod.rs
+++ b/vortex-cuda/src/kernel/patches/mod.rs
@@ -188,7 +188,6 @@ mod tests {
     use vortex::dtype::DType;
     use vortex::dtype::NativePType;
     use vortex::dtype::Nullability;
-    use vortex::session::VortexSession;
 
     use crate::CanonicalCudaExt;
     use crate::CudaDeviceBuffer;

--- a/vortex-cuda/src/kernel/patches/mod.rs
+++ b/vortex-cuda/src/kernel/patches/mod.rs
@@ -217,7 +217,7 @@ mod tests {
     }
 
     async fn full_test_case<Values: NativePType + DeviceRepr, Indices: NativePType + DeviceRepr>() {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty()).unwrap();
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session()).unwrap();
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
 
         let values = PrimitiveArray::from_iter(0..128);

--- a/vortex-cuda/src/kernel/patches/types.rs
+++ b/vortex-cuda/src/kernel/patches/types.rs
@@ -274,7 +274,7 @@ mod tests {
         #[case] expected_offset: usize,
         #[case] expected_chunk_offsets: Vec<u32>,
     ) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let indices = PrimitiveArray::from_iter([100u32, 1100, 2100, 3100, 4100]);
         let values = PrimitiveArray::from_iter([10u32, 11, 12, 13, 14]);
         let chunk_offsets = PrimitiveArray::from_iter([0u32, 1, 2, 3, 4, 5]);
@@ -318,7 +318,7 @@ mod tests {
         #[case] chunk_offsets: ArrayRef,
         #[case] expected: ArrayRef,
     ) -> VortexResult<()> {
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let indices = PrimitiveArray::from_iter([100u32, 1100, 2100, 3100, 4100]);
         let values = PrimitiveArray::from_iter([10u32, 11, 12, 13, 14]);
         let patches = Patches::new(

--- a/vortex-cuda/src/kernel/patches/types.rs
+++ b/vortex-cuda/src/kernel/patches/types.rs
@@ -227,7 +227,6 @@ mod tests {
     use vortex::array::buffer::BufferHandle;
     use vortex::array::validity::Validity::NonNullable;
     use vortex::buffer::Buffer;
-    use vortex::session::VortexSession;
     use vortex_array::IntoArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::patches::Patches;

--- a/vortex-cuda/src/lib.rs
+++ b/vortex-cuda/src/lib.rs
@@ -131,3 +131,17 @@ pub fn initialize_cuda(session: &CudaSession) {
     session.register_kernel(Filter.id(), &FilterExecutor);
     session.register_kernel(Slice.id(), &SliceExecutor);
 }
+
+/// Builds a fresh [`VortexSession`](vortex::session::VortexSession) with all array session
+/// variables plus a default [`CudaSession`], for use in CUDA tests and benchmarks.
+///
+/// Each call returns an independent session with its own CUDA context and stream pool, matching
+/// the per-test isolation that lazily-initialized sessions previously provided.
+///
+/// # Panics
+///
+/// Panics if CUDA device 0 cannot be initialized (the same contract as [`CudaSession::default`]).
+#[cfg(any(test, feature = "_test-harness"))]
+pub fn cuda_session() -> vortex::session::VortexSession {
+    vortex::array::array_session().with::<CudaSession>()
+}

--- a/vortex-cuda/src/session.rs
+++ b/vortex-cuda/src/session.rs
@@ -12,7 +12,6 @@ use vortex::array::ArrayId;
 use vortex::array::VortexSessionExecute;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
-use vortex::session::Ref;
 use vortex::session::SessionExt;
 use vortex::session::SessionVar;
 use vortex::utils::aliases::dash_map::DashMap;
@@ -183,7 +182,7 @@ impl SessionVar for CudaSession {
 /// Extension trait for accessing the CUDA session from a Vortex session.
 pub trait CudaSessionExt: SessionExt {
     /// Returns the CUDA session.
-    fn cuda_session(&self) -> Ref<'_, CudaSession> {
+    fn cuda_session(&self) -> &CudaSession {
         self.get::<CudaSession>()
     }
 }

--- a/vortex-cuda/src/stream.rs
+++ b/vortex-cuda/src/stream.rs
@@ -269,7 +269,7 @@ mod tests {
 
     #[crate::test]
     async fn test_copy_to_device_preserves_visible_len_with_padding() -> VortexResult<()> {
-        let ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let handle = ctx.stream().copy_to_device(vec![0xab_u8])?.await?;
 
         assert_eq!(handle.len(), 1);
@@ -281,7 +281,7 @@ mod tests {
 
     #[crate::test]
     async fn test_copy_to_device_sync_preserves_visible_len_with_padding() -> VortexResult<()> {
-        let ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
         let handle = ctx.stream().copy_to_device_sync(&[1_u8, 2, 3, 4, 5])?;
 
         assert_eq!(handle.len(), 5);

--- a/vortex-cuda/src/stream.rs
+++ b/vortex-cuda/src/stream.rs
@@ -251,7 +251,6 @@ fn register_stream_callback(stream: &CudaStream) -> VortexResult<kanal::AsyncRec
 #[cfg(test)]
 mod tests {
     use vortex::error::VortexResult;
-    use vortex::session::VortexSession;
 
     use super::padded_device_allocation_len;
     use crate::CudaSession;

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -237,7 +237,7 @@ impl FileOpener for VortexOpener {
             let this_file_schema = Arc::new(calculate_physical_schema(
                 vxf.dtype(),
                 &unified_file_schema,
-                &session.arrow(),
+                session.arrow(),
             )?);
 
             let projected_physical_schema = projection.project_schema(&unified_file_schema)?;
@@ -296,7 +296,7 @@ impl FileOpener for VortexOpener {
                 Schema::new(fields)
             };
             let stream_schema =
-                calculate_physical_schema(&scan_dtype, &scan_reference_schema, &session.arrow())?;
+                calculate_physical_schema(&scan_dtype, &scan_reference_schema, session.arrow())?;
 
             let leftover_projection = leftover_projection
                 .try_map_exprs(|expr| reassign_expr_columns(expr, &stream_schema))?;

--- a/vortex-file/src/multi/mod.rs
+++ b/vortex-file/src/multi/mod.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::stream;
+pub use session::MultiFileSession;
 use session::MultiFileSessionExt;
 use tracing::debug;
 use vortex_error::VortexError;

--- a/vortex-file/src/multi/session.rs
+++ b/vortex-file/src/multi/session.rs
@@ -22,7 +22,8 @@ use crate::footer::Footer;
 ///
 /// Consider generalizing this cache into [`VortexOpenOptions`](crate::VortexOpenOptions) so
 /// that single-file opens also benefit from session-level footer caching.
-pub(super) struct MultiFileSession {
+#[derive(Clone)]
+pub struct MultiFileSession {
     footer_cache: moka::sync::Cache<String, Footer>,
 }
 
@@ -53,12 +54,12 @@ impl Debug for MultiFileSession {
 
 impl MultiFileSession {
     /// Retrieve a cached footer for the given file path.
-    pub fn get_footer(&self, path: &str) -> Option<Footer> {
+    pub(crate) fn get_footer(&self, path: &str) -> Option<Footer> {
         self.footer_cache.get(path)
     }
 
     /// Store a footer under the given file path.
-    pub fn put_footer(&self, path: &str, footer: Footer) {
+    pub(crate) fn put_footer(&self, path: &str, footer: Footer) {
         self.footer_cache.insert(path.to_string(), footer);
     }
 }
@@ -76,7 +77,7 @@ impl SessionVar for MultiFileSession {
 /// Extension trait for accessing the [`MultiFileSession`] from a session.
 pub(super) trait MultiFileSessionExt: SessionExt {
     /// Returns a reference to the [`MultiFileSession`] state.
-    fn multi_file(&self) -> vortex_session::Ref<'_, MultiFileSession> {
+    fn multi_file(&self) -> &MultiFileSession {
         self.get::<MultiFileSession>()
     }
 }

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -366,13 +366,10 @@ mod tests {
     use futures::future::BoxFuture;
     use vortex_array::IntoArray;
     use vortex_array::buffer::BufferHandle;
-    use vortex_array::dtype::session::DTypeSession;
     use vortex_array::memory::DefaultHostAllocator;
     use vortex_array::memory::HostAllocator;
     use vortex_array::memory::MemorySessionExt;
     use vortex_array::memory::WritableHostBuffer;
-    use vortex_array::scalar_fn::session::ScalarFnSession;
-    use vortex_array::session::ArraySession;
     use vortex_buffer::Alignment;
     use vortex_buffer::Buffer;
     use vortex_buffer::ByteBuffer;
@@ -431,11 +428,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_initial_read_size() {
-        let session = VortexSession::empty()
-            .with::<DTypeSession>()
-            .with::<ArraySession>()
+        let session = vortex_array::array_session()
             .with::<LayoutSession>()
-            .with::<ScalarFnSession>()
             .with::<RuntimeSession>();
 
         crate::register_default_encodings(&session);
@@ -495,11 +489,8 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn test_open_path_uses_memory_session_allocator() {
-        let session = VortexSession::empty()
-            .with::<DTypeSession>()
-            .with::<ArraySession>()
+        let session = vortex_array::array_session()
             .with::<LayoutSession>()
-            .with::<ScalarFnSession>()
             .with::<RuntimeSession>();
 
         crate::register_default_encodings(&session);
@@ -519,11 +510,9 @@ mod tests {
         std::fs::write(&file_path, ByteBuffer::from(buf).as_slice()).unwrap();
 
         let allocations = Arc::new(AtomicUsize::new(0));
-        session
-            .memory_mut()
-            .set_allocator(Arc::new(CountingAllocator {
-                allocations: Arc::clone(&allocations),
-            }));
+        let session = session.with_allocator(Arc::new(CountingAllocator {
+            allocations: Arc::clone(&allocations),
+        }));
 
         let _file = session.open_options().open_path(&file_path).await.unwrap();
         std::fs::remove_file(&file_path).unwrap();

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -53,8 +53,6 @@ use vortex_array::scalar::Scalar;
 use vortex_array::scalar_fn::ScalarFnVTableExt;
 use vortex_array::scalar_fn::fns::pack::Pack;
 use vortex_array::scalar_fn::fns::pack::PackOptions;
-use vortex_array::scalar_fn::session::ScalarFnSession;
-use vortex_array::session::ArraySession;
 use vortex_array::stats::PRUNING_STATS;
 use vortex_array::stream::ArrayStreamAdapter;
 use vortex_array::stream::ArrayStreamExt;
@@ -77,10 +75,8 @@ use crate::WriteOptionsSessionExt;
 use crate::footer::SegmentSpec;
 
 static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-    let session = VortexSession::empty()
-        .with::<ArraySession>()
+    let session = vortex_array::array_session()
         .with::<LayoutSession>()
-        .with::<ScalarFnSession>()
         .with::<RuntimeSession>();
 
     crate::register_default_encodings(&session);

--- a/vortex-file/src/v2/file_stats_reader.rs
+++ b/vortex-file/src/v2/file_stats_reader.rs
@@ -234,8 +234,6 @@ mod tests {
     use vortex_array::expr::stats::Stat;
     use vortex_array::extension::datetime::TimeUnit;
     use vortex_array::scalar::ScalarValue;
-    use vortex_array::scalar_fn::session::ScalarFnSession;
-    use vortex_array::session::ArraySession;
     use vortex_array::stats::StatsSet;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
@@ -257,10 +255,8 @@ mod tests {
     use super::*;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        VortexSession::empty()
-            .with::<ArraySession>()
+        vortex_array::array_session()
             .with::<LayoutSession>()
-            .with::<ScalarFnSession>()
             .with::<RuntimeSession>()
     });
 

--- a/vortex-file/tests/test_write_table.rs
+++ b/vortex-file/tests/test_write_table.rs
@@ -18,8 +18,6 @@ use vortex_array::arrays::StructArray;
 use vortex_array::arrays::struct_::StructArrayExt;
 use vortex_array::dtype::FieldNames;
 use vortex_array::field_path;
-use vortex_array::scalar_fn::session::ScalarFnSession;
-use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_btrblocks::BtrBlocksCompressor;
 use vortex_buffer::ByteBuffer;
@@ -33,10 +31,8 @@ use vortex_layout::session::LayoutSession;
 use vortex_session::VortexSession;
 
 static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-    let session = VortexSession::empty()
-        .with::<ArraySession>()
+    let session = vortex_array::array_session()
         .with::<LayoutSession>()
-        .with::<ScalarFnSession>()
         .with::<RuntimeSession>();
 
     vortex_file::register_default_encodings(&session);

--- a/vortex-geo/src/extension/coordinate.rs
+++ b/vortex-geo/src/extension/coordinate.rs
@@ -254,10 +254,8 @@ mod tests {
     use vortex_array::dtype::FieldNames;
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::extension::ExtDType;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_error::VortexResult;
-    use vortex_session::VortexSession;
 
     use super::Coordinate;
     use super::Dimension;
@@ -303,7 +301,7 @@ mod tests {
     /// be rejected at parse time rather than decoding null rows as garbage ordinates.
     #[test]
     fn parse_rejects_nullable_points() -> VortexResult<()> {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         let mut ctx = session.create_execution_ctx();
 
         let storage = StructArray::try_new(

--- a/vortex-geo/src/extension/point.rs
+++ b/vortex-geo/src/extension/point.rs
@@ -222,9 +222,7 @@ mod tests {
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
     use vortex_array::dtype::extension::ExtDType;
-    use vortex_array::session::ArraySession;
     use vortex_error::VortexResult;
-    use vortex_session::VortexSession;
 
     use super::Point;
     use crate::extension::GeoMetadata;
@@ -271,7 +269,7 @@ mod tests {
     /// A `Point` column round-trips through scalar execution back to the original coordinates.
     #[test]
     fn point_unpacks_coordinates() -> VortexResult<()> {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         let mut ctx = session.create_execution_ctx();
 
         let points = point_column(vec![1.0, -111.7610], vec![2.0, 34.8697])?;

--- a/vortex-geo/src/scalar_fn/distance.rs
+++ b/vortex-geo/src/scalar_fn/distance.rs
@@ -153,9 +153,7 @@ mod tests {
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::ConstantArray;
-    use vortex_array::session::ArraySession;
     use vortex_error::VortexResult;
-    use vortex_session::VortexSession;
 
     use super::GeoDistance;
     use super::euclidean_distance;
@@ -192,7 +190,7 @@ mod tests {
     /// constant query point).
     #[test]
     fn distance_over_points() -> VortexResult<()> {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         let mut ctx = session.create_execution_ctx();
 
         let a = point_column(vec![0.0, 3.0, 0.0, 3.0], vec![0.0, 0.0, 4.0, 4.0])?;
@@ -206,7 +204,7 @@ mod tests {
     /// Column-to-column distance pairs corresponding rows of the two columns.
     #[test]
     fn distance_between_columns() -> VortexResult<()> {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         let mut ctx = session.create_execution_ctx();
 
         let a = point_column(vec![0.0, 1.0], vec![0.0, 1.0])?;
@@ -220,7 +218,7 @@ mod tests {
     /// The constant query point may be either operand; distance is symmetric.
     #[test]
     fn distance_with_constant_first_operand() -> VortexResult<()> {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         let mut ctx = session.create_execution_ctx();
 
         let a = point_constant(0.0, 0.0, 4, &mut ctx)?;
@@ -234,7 +232,7 @@ mod tests {
     /// Two constant operands: every row has the same distance.
     #[test]
     fn distance_between_two_constants() -> VortexResult<()> {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         let mut ctx = session.create_execution_ctx();
 
         let a = point_constant(0.0, 0.0, 3, &mut ctx)?;

--- a/vortex-geo/src/tests/mod.rs
+++ b/vortex-geo/src/tests/mod.rs
@@ -9,12 +9,11 @@ mod wkb;
 
 use std::sync::LazyLock;
 
-use vortex_array::session::ArraySession;
 use vortex_session::VortexSession;
 
 /// A session with the geospatial types and functions registered.
 static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-    let session = VortexSession::empty().with::<ArraySession>();
+    let session = vortex_array::array_session();
     crate::initialize(&session);
     session
 });

--- a/vortex-io/src/session.rs
+++ b/vortex-io/src/session.rs
@@ -7,10 +7,12 @@ use std::fmt::Debug;
 use vortex_error::VortexExpect;
 use vortex_session::SessionExt;
 use vortex_session::SessionVar;
+use vortex_session::VortexSession;
 
 use crate::runtime::Handle;
 
 /// Session state for Vortex async runtimes.
+#[derive(Clone)]
 pub struct RuntimeSession {
     handle: Option<Handle>,
 }
@@ -53,16 +55,18 @@ pub trait RuntimeSessionExt: SessionExt {
     ///
     /// For example, if the application is launched using `#[tokio::main]`.
     #[cfg(feature = "tokio")]
-    fn with_tokio(self) -> Self {
+    fn with_tokio(self) -> VortexSession {
         use crate::runtime::tokio::TokioRuntime;
-        self.get_mut::<RuntimeSession>().handle = Some(TokioRuntime::current());
-        self
+        let mut builder = self.session().to_builder();
+        builder.get_mut::<RuntimeSession>().handle = Some(TokioRuntime::current());
+        builder.build()
     }
 
     /// Configure the runtime session to use a specific Vortex runtime handle.
-    fn with_handle(self, handle: Handle) -> Self {
-        self.get_mut::<RuntimeSession>().handle = Some(handle);
-        self
+    fn with_handle(self, handle: Handle) -> VortexSession {
+        let mut builder = self.session().to_builder();
+        builder.get_mut::<RuntimeSession>().handle = Some(handle);
+        builder.build()
     }
 }
 impl<S: SessionExt> RuntimeSessionExt for S {}

--- a/vortex-ipc/src/lib.rs
+++ b/vortex-ipc/src/lib.rs
@@ -24,8 +24,9 @@ mod test {
     use vortex_session::VortexSession;
 
     pub(crate) static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        VortexSession::empty()
+        VortexSession::builder()
             .with::<DTypeSession>()
             .with::<ArraySession>()
+            .build()
     });
 }

--- a/vortex-json/src/arrow.rs
+++ b/vortex-json/src/arrow.rs
@@ -161,7 +161,6 @@ mod tests {
     use vortex_array::dtype::extension::ExtDType;
     use vortex_error::VortexExpect;
     use vortex_error::VortexResult;
-    use vortex_session::VortexSession;
 
     use crate::Json;
     use crate::initialize;
@@ -169,7 +168,7 @@ mod tests {
     /// Export a JSON extension array to Arrow's canonical JSON extension.
     #[test]
     fn exports_json_extension_array_as_arrow_json() -> VortexResult<()> {
-        let session = VortexSession::empty();
+        let session = vortex_array::array_session();
         initialize(&session);
 
         let storage = VarBinArray::from_iter(
@@ -207,7 +206,7 @@ mod tests {
     /// Import Arrow's canonical JSON extension as a Vortex JSON extension array.
     #[test]
     fn imports_arrow_json_extension_array_as_vortex_json() -> VortexResult<()> {
-        let session = VortexSession::empty();
+        let session = vortex_array::array_session();
         initialize(&session);
 
         let mut field = Field::new("data", DataType::Utf8, false);

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -363,8 +363,6 @@ mod tests {
     use vortex_array::expr::lit;
     use vortex_array::expr::pack;
     use vortex_array::expr::root;
-    use vortex_array::scalar_fn::session::ScalarFnSession;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_error::VortexExpect;
     use vortex_error::VortexResult;
@@ -392,10 +390,8 @@ mod tests {
     // FIXME(ngates): Deprecate the global `runtime::single::block_on` helper and require tests
     // to call `block_on` on an explicit runtime instance.
     fn session_with_handle(handle: Handle) -> VortexSession {
-        VortexSession::empty()
-            .with::<ArraySession>()
+        vortex_array::array_session()
             .with::<LayoutSession>()
-            .with::<ScalarFnSession>()
             .with::<RuntimeSession>()
             .with_handle(handle)
     }

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -231,8 +231,6 @@ mod test {
     use vortex_array::expr::gt;
     use vortex_array::expr::lit;
     use vortex_array::expr::root;
-    use vortex_array::scalar_fn::session::ScalarFnSession;
-    use vortex_array::session::ArraySession;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
     use vortex_io::runtime::Handle;
@@ -262,10 +260,8 @@ mod test {
     use crate::session::LayoutSession;
 
     fn session_with_handle(handle: Handle) -> VortexSession {
-        VortexSession::empty()
-            .with::<ArraySession>()
+        vortex_array::array_session()
             .with::<LayoutSession>()
-            .with::<ScalarFnSession>()
             .with::<RuntimeSession>()
             .with_handle(handle)
     }

--- a/vortex-layout/src/scan/test.rs
+++ b/vortex-layout/src/scan/test.rs
@@ -3,8 +3,6 @@
 
 use std::sync::LazyLock;
 
-use vortex_array::scalar_fn::session::ScalarFnSession;
-use vortex_array::session::ArraySession;
 use vortex_io::runtime::Handle;
 use vortex_io::session::RuntimeSession;
 use vortex_io::session::RuntimeSessionExt;
@@ -13,10 +11,8 @@ use vortex_session::VortexSession;
 use crate::session::LayoutSession;
 
 pub fn new_session() -> VortexSession {
-    VortexSession::empty()
-        .with::<ArraySession>()
+    vortex_array::array_session()
         .with::<LayoutSession>()
-        .with::<ScalarFnSession>()
         .with::<RuntimeSession>()
 }
 

--- a/vortex-layout/src/session.rs
+++ b/vortex-layout/src/session.rs
@@ -3,7 +3,6 @@
 
 use std::any::Any;
 
-use vortex_session::Ref;
 use vortex_session::SessionExt;
 use vortex_session::SessionVar;
 use vortex_session::registry::Registry;
@@ -18,7 +17,7 @@ use crate::layouts::zoned::ZonedLayoutEncoding;
 pub type LayoutRegistry = Registry<LayoutEncodingRef>;
 
 /// Session state for layout encodings.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LayoutSession {
     registry: LayoutRegistry,
 }
@@ -69,7 +68,7 @@ impl SessionVar for LayoutSession {
 /// Extension trait for accessing layout session data.
 pub trait LayoutSessionExt: SessionExt {
     /// Returns the layout encoding registry.
-    fn layouts(&self) -> Ref<'_, LayoutSession> {
+    fn layouts(&self) -> &LayoutSession {
         self.get::<LayoutSession>()
     }
 }

--- a/vortex-layout/src/test.rs
+++ b/vortex-layout/src/test.rs
@@ -3,17 +3,13 @@
 
 use std::sync::LazyLock;
 
-use vortex_array::scalar_fn::session::ScalarFnSession;
-use vortex_array::session::ArraySession;
 use vortex_io::session::RuntimeSession;
 use vortex_session::VortexSession;
 
 use crate::session::LayoutSession;
 
 pub static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-    VortexSession::empty()
-        .with::<ArraySession>()
+    vortex_array::array_session()
         .with::<LayoutSession>()
-        .with::<ScalarFnSession>()
         .with::<RuntimeSession>()
 });

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -742,11 +742,7 @@ impl PyArray {
         // FIXME(ngates): do not copy to vec, use buffer protocol
         let array = PyArrayRef::extract(slf.as_any().as_borrowed())?;
         Ok(array
-            .serialize(
-                ctx,
-                &vortex::session::VortexSession::empty(),
-                &Default::default(),
-            )?
+            .serialize(ctx, session(), &Default::default())?
             .into_iter()
             .map(|buffer| buffer.to_vec())
             .collect())
@@ -762,7 +758,7 @@ impl PyArray {
         let py = slf.py();
         let array = PyArrayRef::extract(slf.as_any().as_borrowed())?.into_inner();
 
-        let mut encoder = MessageEncoder::new(vortex::session::VortexSession::empty());
+        let mut encoder = MessageEncoder::new(session().clone());
         let buffers = encoder.encode(EncoderMessage::Array(&array))?;
 
         // Return buffers as a list instead of concatenating
@@ -794,7 +790,7 @@ impl PyArray {
 
         let array = PyArrayRef::extract(slf.as_any().as_borrowed())?.into_inner();
 
-        let mut encoder = MessageEncoder::new(vortex::session::VortexSession::empty());
+        let mut encoder = MessageEncoder::new(session().clone());
         let array_buffers = encoder.encode(EncoderMessage::Array(&array))?;
         let dtype_buffers = encoder.encode(EncoderMessage::DType(array.dtype()))?;
 

--- a/vortex-row/benches/row_encode.rs
+++ b/vortex-row/benches/row_encode.rs
@@ -33,7 +33,6 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::StructArray;
 use vortex_array::arrays::VarBinViewArray;
-use vortex_array::session::ArraySession;
 use vortex_row::RowEncoder;
 use vortex_session::VortexSession;
 
@@ -42,8 +41,7 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 const N: usize = 100_000;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 fn main() {
     divan::main();

--- a/vortex-session/Cargo.toml
+++ b/vortex-session/Cargo.toml
@@ -20,7 +20,6 @@ all-features = true
 workspace = true
 
 [dependencies]
-dashmap = { workspace = true }
 lasso = { workspace = true }
 parking_lot = { workspace = true }
 vortex-error = { workspace = true }

--- a/vortex-session/src/immutable.rs
+++ b/vortex-session/src/immutable.rs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! The immutable [`VortexSession`] and its [`SessionBuilder`].
+//!
+//! [`VortexSession`] is backed by an immutable [`HashMap`]: once built, its set of session
+//! variables can never change, so reads are lock-free and return plain references. To modify
+//! a session, clone its state into a mutable [`SessionBuilder`] with
+//! [`VortexSession::to_builder`], apply changes, and call [`SessionBuilder::build`] to freeze it
+//! back into a new [`VortexSession`].
+
+use std::any::TypeId;
+use std::any::type_name;
+use std::hash::BuildHasherDefault;
+use std::sync::Arc;
+
+use vortex_error::VortexExpect;
+use vortex_error::vortex_panic;
+use vortex_utils::aliases::hash_map::Entry;
+use vortex_utils::aliases::hash_map::HashMap;
+
+use crate::IdHasher;
+use crate::SessionVar;
+use crate::UnknownPluginPolicy;
+
+/// A [`SessionVar`] that can be stored in a [`VortexSession`].
+///
+/// This trait is implemented automatically for every [`SessionVar`] that is also [`Clone`],
+/// so types opt in by implementing [`Clone`] rather than implementing this trait directly.
+///
+/// Cloning must produce an *independent* copy: [`SessionBuilder`] relies on it to detach a
+/// session's state before mutating it. A variable whose `Clone` shares interior-mutable state
+/// (e.g. an `Arc` around a mutable registry) will leak builder mutations back into the session
+/// it was cloned from.
+pub trait VortexSessionVar: SessionVar {
+    /// Clones this variable into a new boxed instance.
+    fn clone_var(&self) -> Box<dyn VortexSessionVar>;
+}
+
+impl<V: SessionVar + Clone> VortexSessionVar for V {
+    fn clone_var(&self) -> Box<dyn VortexSessionVar> {
+        Box::new(self.clone())
+    }
+}
+
+/// The type map backing a [`VortexSession`]. Immutable once wrapped in an `Arc`.
+type VortexSessionVars = HashMap<TypeId, Box<dyn VortexSessionVar>, BuildHasherDefault<IdHasher>>;
+
+/// A Vortex session encapsulates the set of extensible arrays, layouts, compute functions,
+/// dtypes, etc. that are available for use in a given context.
+///
+/// It is also the entry-point passed to dynamic libraries to initialize Vortex plugins.
+///
+/// The set of session variables is fixed at construction time, so lookups take no locks and
+/// hand out plain references. To change a session's state, clone it into a mutable
+/// [`SessionBuilder`] with [`VortexSession::to_builder`] and build a new session from it.
+#[derive(Clone, Debug)]
+pub struct VortexSession(Arc<VortexSessionVars>);
+
+impl VortexSession {
+    /// Create a new [`VortexSession`] with no session state.
+    pub fn empty() -> Self {
+        Self(Default::default())
+    }
+
+    /// Create an empty [`SessionBuilder`].
+    pub fn builder() -> SessionBuilder {
+        SessionBuilder::default()
+    }
+
+    /// Clone this session's state into a mutable [`SessionBuilder`].
+    ///
+    /// The builder owns an independent copy of every variable, so mutations made through it
+    /// never affect this session.
+    pub fn to_builder(&self) -> SessionBuilder {
+        SessionBuilder {
+            vars: self
+                .0
+                .iter()
+                .map(|(id, var)| (*id, var.clone_var()))
+                .collect(),
+        }
+    }
+
+    /// Returns the session variable of type `V`.
+    ///
+    /// # Panics
+    ///
+    /// If no variable of that type exists in this session.
+    #[expect(
+        clippy::same_name_method,
+        reason = "SessionExt re-exposes get/get_opt so generic `S: SessionExt` code can call them"
+    )]
+    pub fn get<V: VortexSessionVar>(&self) -> &V {
+        self.get_opt::<V>().unwrap_or_else(|| {
+            vortex_panic!("Session variable of type {} not found", type_name::<V>())
+        })
+    }
+
+    /// Returns the session variable of type `V`, if it exists.
+    #[expect(
+        clippy::same_name_method,
+        reason = "SessionExt re-exposes get/get_opt so generic `S: SessionExt` code can call them"
+    )]
+    pub fn get_opt<V: VortexSessionVar>(&self) -> Option<&V> {
+        self.0.get(&TypeId::of::<V>()).map(|var| {
+            (**var)
+                .as_any()
+                .downcast_ref::<V>()
+                .vortex_expect("Type mismatch - this is a bug")
+        })
+    }
+
+    /// Returns whether unknown plugins should deserialize as foreign placeholders.
+    pub fn allows_unknown(&self) -> bool {
+        self.get_opt::<UnknownPluginPolicy>()
+            .is_some_and(|p| p.allow_unknown)
+    }
+
+    /// Inserts a new session variable of type `V` with its default value, returning the
+    /// updated session.
+    ///
+    /// # Panics
+    ///
+    /// If a variable of that type already exists.
+    pub fn with<V: VortexSessionVar + Default>(self) -> Self {
+        self.to_builder().with::<V>().build()
+    }
+
+    /// Inserts a new session variable of type `V`, returning the updated session.
+    ///
+    /// # Panics
+    ///
+    /// If a variable of that type already exists.
+    pub fn with_some<V: VortexSessionVar>(self, var: V) -> Self {
+        self.to_builder().with_some(var).build()
+    }
+
+    /// Allow deserializing unknown plugin IDs as non-executable foreign placeholders.
+    pub fn allow_unknown(self) -> Self {
+        self.to_builder().allow_unknown().build()
+    }
+}
+
+/// A mutable builder for [`VortexSession`].
+///
+/// Holds a private, mutable copy of a session's state. Modify it freely, then call
+/// [`SessionBuilder::build`] to freeze it into a new immutable [`VortexSession`].
+#[derive(Debug, Default)]
+pub struct SessionBuilder {
+    vars: VortexSessionVars,
+}
+
+impl SessionBuilder {
+    /// Inserts a new session variable of type `V` with its default value.
+    ///
+    /// # Panics
+    ///
+    /// If a variable of that type already exists.
+    pub fn with<V: VortexSessionVar + Default>(self) -> Self {
+        self.with_some(V::default())
+    }
+
+    /// Inserts a new session variable of type `V`.
+    ///
+    /// # Panics
+    ///
+    /// If a variable of that type already exists.
+    pub fn with_some<V: VortexSessionVar>(mut self, var: V) -> Self {
+        match self.vars.entry(TypeId::of::<V>()) {
+            Entry::Occupied(_) => {
+                vortex_panic!(
+                    "Session variable of type {} already exists",
+                    type_name::<V>()
+                );
+            }
+            Entry::Vacant(e) => {
+                e.insert(Box::new(var));
+            }
+        }
+        self
+    }
+
+    /// Returns a mutable reference to the session variable of type `V`, inserting a default
+    /// one if it does not exist.
+    pub fn get_mut<V: VortexSessionVar + Default>(&mut self) -> &mut V {
+        self.vars
+            .entry(TypeId::of::<V>())
+            .or_insert_with(|| Box::new(V::default()))
+            .as_any_mut()
+            .downcast_mut::<V>()
+            .vortex_expect("Type mismatch - this is a bug")
+    }
+
+    /// Returns a mutable reference to the session variable of type `V`, if it exists.
+    pub fn get_mut_opt<V: VortexSessionVar>(&mut self) -> Option<&mut V> {
+        self.vars.get_mut(&TypeId::of::<V>()).map(|var| {
+            var.as_any_mut()
+                .downcast_mut::<V>()
+                .vortex_expect("Type mismatch - this is a bug")
+        })
+    }
+
+    /// Allow deserializing unknown plugin IDs as non-executable foreign placeholders.
+    pub fn allow_unknown(mut self) -> Self {
+        self.get_mut::<UnknownPluginPolicy>().allow_unknown = true;
+        self
+    }
+
+    /// Finalize this builder into an immutable [`VortexSession`].
+    pub fn build(self) -> VortexSession {
+        VortexSession(Arc::new(self.vars))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+
+    use super::VortexSession;
+    use crate::SessionVar;
+
+    #[derive(Clone, Debug, Default, PartialEq, Eq)]
+    struct Counter {
+        count: u32,
+    }
+
+    impl SessionVar for Counter {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct Other;
+
+    impl SessionVar for Other {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    #[test]
+    fn builder_round_trip() {
+        let session = VortexSession::builder()
+            .with_some(Counter { count: 1 })
+            .build();
+
+        assert_eq!(session.get::<Counter>(), &Counter { count: 1 });
+        assert!(session.get_opt::<Other>().is_none());
+    }
+
+    #[test]
+    fn to_builder_does_not_mutate_source() {
+        let source = VortexSession::builder()
+            .with_some(Counter { count: 1 })
+            .build();
+
+        let mut builder = source.to_builder();
+        builder.get_mut::<Counter>().count = 2;
+        let modified = builder.build();
+
+        assert_eq!(source.get::<Counter>().count, 1);
+        assert_eq!(modified.get::<Counter>().count, 2);
+    }
+
+    #[test]
+    fn get_mut_inserts_default() {
+        let mut builder = VortexSession::empty().to_builder();
+        assert!(builder.get_mut_opt::<Counter>().is_none());
+
+        builder.get_mut::<Counter>().count = 42;
+        let session = builder.build();
+
+        assert_eq!(session.get::<Counter>().count, 42);
+    }
+
+    #[test]
+    #[should_panic(expected = "already exists")]
+    fn with_some_duplicate_panics() {
+        VortexSession::builder()
+            .with::<Counter>()
+            .with_some(Counter { count: 1 });
+    }
+
+    #[test]
+    #[should_panic(expected = "not found")]
+    fn get_missing_panics() {
+        VortexSession::empty().get::<Counter>();
+    }
+
+    #[test]
+    fn allow_unknown_flag_is_opt_in() {
+        let session = VortexSession::empty();
+        assert!(!session.allows_unknown());
+
+        let session = session.to_builder().allow_unknown().build();
+        assert!(session.allows_unknown());
+    }
+}

--- a/vortex-session/src/lib.rs
+++ b/vortex-session/src/lib.rs
@@ -1,84 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+mod immutable;
 pub mod registry;
 
 use std::any::Any;
-use std::any::TypeId;
-use std::any::type_name;
 use std::fmt::Debug;
-use std::hash::BuildHasherDefault;
 use std::hash::Hasher;
-use std::ops::Deref;
-use std::ops::DerefMut;
-use std::sync::Arc;
 
-use dashmap::DashMap;
-use dashmap::Entry;
-use dashmap::mapref::one::MappedRef;
-use dashmap::mapref::one::MappedRefMut;
-use vortex_error::VortexExpect;
-use vortex_error::vortex_panic;
-
-/// A Vortex session encapsulates the set of extensible arrays, layouts, compute functions, dtypes,
-/// etc. that are available for use in a given context.
-///
-/// It is also the entry-point passed to dynamic libraries to initialize Vortex plugins.
-#[derive(Clone, Debug)]
-pub struct VortexSession(Arc<SessionVars>);
-
-impl VortexSession {
-    /// Create a new [`VortexSession`] with no session state.
-    ///
-    /// It is recommended to use the `default()` method instead provided by the main `vortex` crate.
-    pub fn empty() -> Self {
-        Self(Default::default())
-    }
-
-    /// Inserts a new session variable of type `V` with its default value.
-    ///
-    /// # Panics
-    ///
-    /// If a variable of that type already exists.
-    pub fn with<V: SessionVar + Default>(self) -> Self {
-        self.with_some(V::default())
-    }
-
-    /// Inserts a new session variable of type `V`.
-    ///
-    /// # Panics
-    ///
-    /// If a variable of that type already exists.
-    pub fn with_some<V: SessionVar>(self, var: V) -> Self {
-        match self.0.entry(TypeId::of::<V>()) {
-            Entry::Occupied(_) => {
-                vortex_panic!(
-                    "Session variable of type {} already exists",
-                    type_name::<V>()
-                );
-            }
-            Entry::Vacant(e) => {
-                e.insert(Box::new(var));
-            }
-        }
-        self
-    }
-
-    /// Allow deserializing unknown plugin IDs as non-executable foreign placeholders.
-    pub fn allow_unknown(self) -> Self {
-        let mut policy = <Self as SessionExt>::get_mut::<UnknownPluginPolicy>(&self);
-        policy.allow_unknown = true;
-        drop(policy);
-        self
-    }
-
-    /// Returns whether unknown plugins should deserialize as foreign placeholders.
-    pub fn allows_unknown(&self) -> bool {
-        <Self as SessionExt>::get_opt::<UnknownPluginPolicy>(self)
-            .map(|p| p.allow_unknown)
-            .unwrap_or(false)
-    }
-}
+pub use immutable::SessionBuilder;
+pub use immutable::VortexSession;
+pub use immutable::VortexSessionVar;
 
 #[derive(Debug, Clone, Copy, Default)]
 struct UnknownPluginPolicy {
@@ -95,26 +27,20 @@ impl SessionVar for UnknownPluginPolicy {
     }
 }
 
-/// Trait for accessing and modifying the state of a Vortex session.
+/// Trait for accessing the state of a Vortex session.
 pub trait SessionExt: Sized + private::Sealed {
     /// Returns the [`VortexSession`].
     fn session(&self) -> VortexSession;
 
-    /// Returns the scope variable of type `V`, or inserts a default one if it does not exist.
-    fn get<V: SessionVar + Default>(&self) -> Ref<'_, V>;
-
-    /// Returns the scope variable of type `V` if it exists.
-    fn get_opt<V: SessionVar>(&self) -> Option<Ref<'_, V>>;
-
-    /// Returns the scope variable of type `V`, or inserts a default one if it does not exist.
+    /// Returns the session variable of type `V`.
     ///
-    /// Note that the returned value internally holds a lock on the variable.
-    fn get_mut<V: SessionVar + Default>(&self) -> RefMut<'_, V>;
-
-    /// Returns the scope variable of type `V`, if it exists.
+    /// # Panics
     ///
-    /// Note that the returned value internally holds a lock on the variable.
-    fn get_mut_opt<V: SessionVar>(&self) -> Option<RefMut<'_, V>>;
+    /// If no variable of that type exists in this session.
+    fn get<V: VortexSessionVar>(&self) -> &V;
+
+    /// Returns the session variable of type `V` if it exists.
+    fn get_opt<V: VortexSessionVar>(&self) -> Option<&V>;
 }
 
 mod private {
@@ -127,75 +53,22 @@ impl SessionExt for VortexSession {
         self.clone()
     }
 
-    /// Returns the scope variable of type `V`, or inserts a default one if it does not exist.
-    fn get<V: SessionVar + Default>(&self) -> Ref<'_, V> {
-        // NOTE(ngates): we don't use `entry().or_insert_with_key()` here because the DashMap
-        //  would immediately acquire an exclusive write lock.
-        if let Some(v) = self.0.get(&TypeId::of::<V>()) {
-            return Ref(v.map(|v| {
-                (**v)
-                    .as_any()
-                    .downcast_ref::<V>()
-                    .vortex_expect("Type mismatch - this is a bug")
-            }));
-        }
-
-        // If we get here, the value was not present, so we insert the default with a write lock.
-        Ref(self
-            .0
-            .entry(TypeId::of::<V>())
-            .or_insert_with(|| Box::new(V::default()))
-            .downgrade()
-            .map(|v| {
-                (**v)
-                    .as_any()
-                    .downcast_ref::<V>()
-                    .vortex_expect("Type mismatch - this is a bug")
-            }))
+    fn get<V: VortexSessionVar>(&self) -> &V {
+        VortexSession::get::<V>(self)
     }
 
-    fn get_opt<V: SessionVar>(&self) -> Option<Ref<'_, V>> {
-        self.0.get(&TypeId::of::<V>()).map(|v| {
-            Ref(v.map(|v| {
-                (**v)
-                    .as_any()
-                    .downcast_ref::<V>()
-                    .vortex_expect("Type mismatch - this is a bug")
-            }))
-        })
-    }
-
-    /// Returns the scope variable of type `V`, or inserts a default one if it does not exist.
-    ///
-    /// Note that the returned value internally holds a lock on the variable.
-    fn get_mut<V: SessionVar + Default>(&self) -> RefMut<'_, V> {
-        RefMut(
-            self.0
-                .entry(TypeId::of::<V>())
-                .or_insert_with(|| Box::new(V::default()))
-                .map(|v| {
-                    (**v)
-                        .as_any_mut()
-                        .downcast_mut::<V>()
-                        .vortex_expect("Type mismatch - this is a bug")
-                }),
-        )
-    }
-
-    fn get_mut_opt<V: SessionVar>(&self) -> Option<RefMut<'_, V>> {
-        self.0.get_mut(&TypeId::of::<V>()).map(|v| {
-            RefMut(v.map(|v| {
-                (**v)
-                    .as_any_mut()
-                    .downcast_mut::<V>()
-                    .vortex_expect("Type mismatch - this is a bug")
-            }))
-        })
+    fn get_opt<V: VortexSessionVar>(&self) -> Option<&V> {
+        VortexSession::get_opt::<V>(self)
     }
 }
 
-/// A TypeMap based on `https://docs.rs/http/1.2.0/src/http/extensions.rs.html#41-266`.
-type SessionVars = DashMap<TypeId, Box<dyn SessionVar>, BuildHasherDefault<IdHasher>>;
+/// This trait defines variables that can be stored against a Vortex session.
+///
+/// Users should implement this trait for anything that you want to store on a `VortexSession`.
+pub trait SessionVar: Any + Send + Sync + Debug + 'static {
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
 
 /// With TypeIds as keys, there's no need to hash them. They are already hashes
 /// themselves, coming from the compiler. The IdHasher just holds the u64 of
@@ -216,57 +89,6 @@ impl Hasher for IdHasher {
     #[inline]
     fn write_u64(&mut self, id: u64) {
         self.0 = id;
-    }
-}
-
-/// This trait defines variables that can be stored against a Vortex session.
-///
-/// Users should implement this trait for anything that you want to store on a `VortexSession`.
-pub trait SessionVar: Any + Send + Sync + Debug + 'static {
-    fn as_any(&self) -> &dyn Any;
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-}
-
-// NOTE(ngates): we don't want to expose that the internals of a session is a DashMap, so we have
-// our own wrapped Ref type.
-pub struct Ref<'a, T>(MappedRef<'a, TypeId, Box<dyn SessionVar>, T>);
-impl<'a, T> Deref for Ref<'a, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl<'a, T> Ref<'a, T> {
-    /// Map this reference to a different target.
-    pub fn map<F, U>(self, f: F) -> Ref<'a, U>
-    where
-        F: FnOnce(&T) -> &U,
-    {
-        Ref(self.0.map(f))
-    }
-}
-
-pub struct RefMut<'a, T>(MappedRefMut<'a, TypeId, Box<dyn SessionVar>, T>);
-impl<'a, T> Deref for RefMut<'a, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl<'a, T> DerefMut for RefMut<'a, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0.deref_mut()
-    }
-}
-impl<'a, T> RefMut<'a, T> {
-    /// Map this mutable reference to a different target.
-    pub fn map<F, U>(self, f: F) -> RefMut<'a, U>
-    where
-        F: FnOnce(&mut T) -> &mut U,
-    {
-        RefMut(self.0.map(f))
     }
 }
 

--- a/vortex-tensor/src/lib.rs
+++ b/vortex-tensor/src/lib.rs
@@ -81,11 +81,10 @@ pub fn initialize(session: &VortexSession) {
 mod tests {
     use std::sync::LazyLock;
 
-    use vortex_array::session::ArraySession;
     use vortex_session::VortexSession;
 
     pub static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-        let session = VortexSession::empty().with::<ArraySession>();
+        let session = vortex_array::array_session();
         crate::initialize(&session);
         session
     });

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/patched.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/patched.rs
@@ -10,7 +10,6 @@ use vortex_array::arrays::PrimitiveArray;
 use vortex_array::patches::Patches;
 use vortex_array::vtable::ArrayVTable;
 use vortex_error::VortexResult;
-use vortex_session::VortexSession;
 
 use crate::fixtures::FlatLayoutFixture;
 
@@ -30,7 +29,7 @@ impl FlatLayoutFixture for PatchedFixture {
     }
 
     fn build(&self) -> VortexResult<ArrayRef> {
-        let mut ctx = ExecutionCtx::new(VortexSession::empty());
+        let mut ctx = ExecutionCtx::new(vortex_array::array_session());
 
         let array = PrimitiveArray::from_option_iter((0u64..2048).map(Some)).into_array();
         let patches = Patches::new(

--- a/vortex-test/e2e-cuda/src/lib.rs
+++ b/vortex-test/e2e-cuda/src/lib.rs
@@ -46,7 +46,6 @@ use vortex::array::arrays::TemporalArray;
 use vortex::array::arrays::VarBinViewArray;
 use vortex::array::arrays::varbinview::BinaryView;
 use vortex::array::arrow::ArrowSessionExt;
-use vortex::array::session::ArraySession;
 use vortex::array::validity::Validity;
 use vortex::buffer::Buffer;
 use vortex::buffer::ByteBuffer;
@@ -58,7 +57,6 @@ use vortex::dtype::Nullability;
 use vortex::extension::datetime::TimeUnit;
 use vortex::io::session::RuntimeSession;
 use vortex::layout::session::LayoutSession;
-use vortex::scalar_fn::session::ScalarFnSession;
 use vortex::session::VortexSession;
 use vortex_cuda::CudaSession;
 use vortex_cuda::arrow::ArrowDeviceArray;
@@ -67,10 +65,8 @@ use vortex_cuda::arrow::DeviceArrayExt;
 const PRIMITIVE_DTYPE_ENV: &str = "VORTEX_CUDF_PRIMITIVE_DTYPE";
 
 static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-    VortexSession::empty()
-        .with::<ArraySession>()
+    vortex::array::array_session()
         .with::<LayoutSession>()
-        .with::<ScalarFnSession>()
         .with::<RuntimeSession>()
         .with::<CudaSession>()
 });

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -24,7 +24,6 @@ use vortex::array::arrays::VarBinArray;
 use vortex::array::arrays::VarBinViewArray;
 use vortex::array::arrays::varbin::VarBinArrayExt;
 use vortex::array::builtins::ArrayBuiltins;
-use vortex::array::session::ArraySession;
 use vortex::dtype::DType;
 use vortex::dtype::PType;
 use vortex::encodings::alp::ALP;
@@ -53,8 +52,7 @@ fn main() {
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 const NUM_VALUES: u64 = 100_000;
 

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -22,7 +22,6 @@ use vortex::array::arrays::VarBinViewArray;
 use vortex::array::builders::dict::dict_encode;
 use vortex::array::builtins::ArrayBuiltins;
 use vortex::array::dtype::Nullability;
-use vortex::array::session::ArraySession;
 use vortex::dtype::PType;
 use vortex::encodings::alp::RDEncoder;
 use vortex::encodings::alp::alp_encode;
@@ -46,8 +45,7 @@ use vortex_session::VortexSession;
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
-static SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
 fn main() {
     divan::main();

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -7,6 +7,7 @@
 // vortex::compute is deprecated and will be ported over to expressions.
 pub use vortex_array::aggregate_fn;
 use vortex_array::aggregate_fn::session::AggregateFnSession;
+use vortex_array::arrow::ArrowSession;
 pub use vortex_array::compute;
 use vortex_array::dtype::session::DTypeSession;
 // vortex::expr is in the process of having its dependencies inverted, and will eventually be
@@ -172,11 +173,16 @@ impl VortexSessionDefault for VortexSession {
             .with::<StatsSession>()
             .with::<ArrayKernels>()
             .with::<AggregateFnSession>()
+            .with::<ArrowSession>()
             .with::<MemorySession>()
             .with::<RuntimeSession>();
 
         #[cfg(feature = "files")]
-        file::register_default_encodings(&session);
+        let session = {
+            let session = session.with::<file::multi::MultiFileSession>();
+            file::register_default_encodings(&session);
+            session
+        };
 
         session
     }


### PR DESCRIPTION
## Summary

This PR replaces the current `DashMap` backed session with one backed by a `HashMap`. Instead of being initialized on access which might cause deadlocks or otherwise weird performance behavior.

There's also an explicit `Builder` type for the session, allowing the user to explicitly include the components they want.
