### PR TITLE
Numerical aggregate functions have an option to skip or include nans in calculation, skip by default

### DIFF
--- a/encodings/runend/src/compute/min_max.rs
+++ b/encodings/runend/src/compute/min_max.rs
@@ -6,7 +6,7 @@ use vortex_array::ExecutionCtx;
 use vortex_array::aggregate_fn::AggregateFnRef;
 use vortex_array::aggregate_fn::fns::min_max::MinMax;
 use vortex_array::aggregate_fn::fns::min_max::make_minmax_dtype;
-use vortex_array::aggregate_fn::fns::min_max::min_max;
+use vortex_array::aggregate_fn::fns::min_max::min_max_with;
 use vortex_array::aggregate_fn::kernels::DynAggregateKernel;
 use vortex_array::scalar::Scalar;
 use vortex_error::VortexResult;
@@ -28,16 +28,16 @@ impl DynAggregateKernel for RunEndMinMaxKernel {
         batch: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<Scalar>> {
-        if !aggregate_fn.is::<MinMax>() {
+        let Some(options) = aggregate_fn.as_opt::<MinMax>() else {
             return Ok(None);
-        }
+        };
 
         let Some(run_end) = batch.as_opt::<RunEnd>() else {
             return Ok(None);
         };
 
         let struct_dtype = make_minmax_dtype(batch.dtype());
-        match min_max(run_end.values(), ctx)? {
+        match min_max_with(run_end.values(), ctx, *options)? {
             Some(result) => Ok(Some(Scalar::struct_(
                 struct_dtype,
                 vec![result.min, result.max],

--- a/encodings/runend/src/compute/min_max.rs
+++ b/encodings/runend/src/compute/min_max.rs
@@ -6,7 +6,7 @@ use vortex_array::ExecutionCtx;
 use vortex_array::aggregate_fn::AggregateFnRef;
 use vortex_array::aggregate_fn::fns::min_max::MinMax;
 use vortex_array::aggregate_fn::fns::min_max::make_minmax_dtype;
-use vortex_array::aggregate_fn::fns::min_max::min_max_with;
+use vortex_array::aggregate_fn::fns::min_max::min_max;
 use vortex_array::aggregate_fn::kernels::DynAggregateKernel;
 use vortex_array::scalar::Scalar;
 use vortex_error::VortexResult;
@@ -37,7 +37,7 @@ impl DynAggregateKernel for RunEndMinMaxKernel {
         };
 
         let struct_dtype = make_minmax_dtype(batch.dtype());
-        match min_max_with(run_end.values(), ctx, *options)? {
+        match min_max(run_end.values(), ctx, *options)? {
             Some(result) => Ok(Some(Scalar::struct_(
                 struct_dtype,
                 vec![result.min, result.max],

--- a/encodings/sequence/src/compute/min_max.rs
+++ b/encodings/sequence/src/compute/min_max.rs
@@ -32,14 +32,11 @@ impl DynAggregateKernel for SequenceMinMaxKernel {
         batch: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<Scalar>> {
-        let Some(options) = aggregate_fn.as_opt::<MinMax>() else {
-            return Ok(None);
-        };
-        // The algebraic extrema assume NaN-skipping semantics; decline NaN-including requests
-        // over float sequences.
-        if !options.skip_nans && batch.dtype().is_float() {
+        if !aggregate_fn.is::<MinMax>() {
             return Ok(None);
         }
+        // Sequence arrays are always integer-typed (float multipliers are unsupported), so NaN
+        // handling never applies and `SkipNansOptions` can be ignored.
 
         let Some(seq) = batch.as_opt::<Sequence>() else {
             return Ok(None);

--- a/encodings/sequence/src/compute/min_max.rs
+++ b/encodings/sequence/src/compute/min_max.rs
@@ -32,7 +32,12 @@ impl DynAggregateKernel for SequenceMinMaxKernel {
         batch: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<Scalar>> {
-        if !aggregate_fn.is::<MinMax>() {
+        let Some(options) = aggregate_fn.as_opt::<MinMax>() else {
+            return Ok(None);
+        };
+        // The algebraic extrema assume NaN-skipping semantics; decline NaN-including requests
+        // over float sequences.
+        if !options.skip_nans && batch.dtype().is_float() {
             return Ok(None);
         }
 

--- a/encodings/sequence/src/compute/min_max.rs
+++ b/encodings/sequence/src/compute/min_max.rs
@@ -35,8 +35,6 @@ impl DynAggregateKernel for SequenceMinMaxKernel {
         if !aggregate_fn.is::<MinMax>() {
             return Ok(None);
         }
-        // Sequence arrays are always integer-typed (float multipliers are unsupported), so NaN
-        // handling never applies and `SkipNansOptions` can be ignored.
 
         let Some(seq) = batch.as_opt::<Sequence>() else {
             return Ok(None);

--- a/encodings/sparse/benches/sparse_pushdown.rs
+++ b/encodings/sparse/benches/sparse_pushdown.rs
@@ -19,6 +19,7 @@ use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::aggregate_fn::SkipNansOptions;
 use vortex_array::aggregate_fn::fns::is_constant::is_constant;
 use vortex_array::aggregate_fn::fns::min_max::min_max;
 use vortex_array::aggregate_fn::fns::null_count::null_count;
@@ -106,7 +107,9 @@ fn sparse_min_max(bencher: Bencher) {
     bencher
         .with_inputs(|| (make_sparse(40_000, false), SESSION.create_execution_ctx()))
         .bench_values(|(array, mut ctx)| {
-            divan::black_box(min_max(&array, &mut ctx).vortex_expect("min_max"))
+            divan::black_box(
+                min_max(&array, &mut ctx, SkipNansOptions::default()).vortex_expect("min_max"),
+            )
         });
 }
 

--- a/encodings/sparse/benches/sparse_pushdown.rs
+++ b/encodings/sparse/benches/sparse_pushdown.rs
@@ -19,7 +19,7 @@ use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
-use vortex_array::aggregate_fn::AggregateFnOpts;
+use vortex_array::aggregate_fn::NumericalAggregateOpts;
 use vortex_array::aggregate_fn::fns::is_constant::is_constant;
 use vortex_array::aggregate_fn::fns::min_max::min_max;
 use vortex_array::aggregate_fn::fns::null_count::null_count;
@@ -108,7 +108,8 @@ fn sparse_min_max(bencher: Bencher) {
         .with_inputs(|| (make_sparse(40_000, false), SESSION.create_execution_ctx()))
         .bench_values(|(array, mut ctx)| {
             divan::black_box(
-                min_max(&array, &mut ctx, AggregateFnOpts::default()).vortex_expect("min_max"),
+                min_max(&array, &mut ctx, NumericalAggregateOpts::default())
+                    .vortex_expect("min_max"),
             )
         });
 }

--- a/encodings/sparse/benches/sparse_pushdown.rs
+++ b/encodings/sparse/benches/sparse_pushdown.rs
@@ -19,7 +19,7 @@ use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
-use vortex_array::aggregate_fn::SkipNansOptions;
+use vortex_array::aggregate_fn::AggregateFnOpts;
 use vortex_array::aggregate_fn::fns::is_constant::is_constant;
 use vortex_array::aggregate_fn::fns::min_max::min_max;
 use vortex_array::aggregate_fn::fns::null_count::null_count;
@@ -108,7 +108,7 @@ fn sparse_min_max(bencher: Bencher) {
         .with_inputs(|| (make_sparse(40_000, false), SESSION.create_execution_ctx()))
         .bench_values(|(array, mut ctx)| {
             divan::black_box(
-                min_max(&array, &mut ctx, SkipNansOptions::default()).vortex_expect("min_max"),
+                min_max(&array, &mut ctx, AggregateFnOpts::default()).vortex_expect("min_max"),
             )
         });
 }

--- a/encodings/sparse/src/compute/min_max.rs
+++ b/encodings/sparse/src/compute/min_max.rs
@@ -65,7 +65,7 @@ mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
-    use vortex_array::aggregate_fn::AggregateFnOpts;
+    use vortex_array::aggregate_fn::NumericalAggregateOpts;
     use vortex_array::aggregate_fn::fns::min_max::MinMaxResult;
     use vortex_array::aggregate_fn::fns::min_max::min_max;
     use vortex_array::scalar::Scalar;
@@ -103,13 +103,13 @@ mod tests {
         let kernel: Option<MinMaxResult> = min_max(
             &arr,
             &mut SESSION.create_execution_ctx(),
-            AggregateFnOpts::default(),
+            NumericalAggregateOpts::default(),
         )
         .unwrap();
         let canonical: Option<MinMaxResult> = min_max(
             &arr,
             &mut CANONICAL_SESSION.create_execution_ctx(),
-            AggregateFnOpts::default(),
+            NumericalAggregateOpts::default(),
         )
         .unwrap();
         assert_eq!(kernel, canonical);

--- a/encodings/sparse/src/compute/min_max.rs
+++ b/encodings/sparse/src/compute/min_max.rs
@@ -7,7 +7,6 @@ use vortex_array::IntoArray;
 use vortex_array::aggregate_fn::Accumulator;
 use vortex_array::aggregate_fn::AggregateFnRef;
 use vortex_array::aggregate_fn::DynAccumulator;
-use vortex_array::aggregate_fn::EmptyOptions;
 use vortex_array::aggregate_fn::fns::min_max::MinMax;
 use vortex_array::aggregate_fn::kernels::DynAggregateKernel;
 use vortex_array::arrays::ConstantArray;
@@ -32,9 +31,9 @@ impl DynAggregateKernel for SparseMinMaxKernel {
         batch: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<Scalar>> {
-        if !aggregate_fn.is::<MinMax>() {
+        let Some(options) = aggregate_fn.as_opt::<MinMax>() else {
             return Ok(None);
-        }
+        };
 
         let Some(sparse) = batch.as_opt::<Sparse>() else {
             return Ok(None);
@@ -42,7 +41,7 @@ impl DynAggregateKernel for SparseMinMaxKernel {
 
         let patches = sparse.patches();
 
-        let mut acc = Accumulator::try_new(MinMax, EmptyOptions, batch.dtype().clone())?;
+        let mut acc = Accumulator::try_new(MinMax, *options, batch.dtype().clone())?;
 
         if !patches.values().is_empty() {
             acc.accumulate(patches.values(), ctx)?;

--- a/encodings/sparse/src/compute/min_max.rs
+++ b/encodings/sparse/src/compute/min_max.rs
@@ -65,6 +65,7 @@ mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
+    use vortex_array::aggregate_fn::SkipNansOptions;
     use vortex_array::aggregate_fn::fns::min_max::MinMaxResult;
     use vortex_array::aggregate_fn::fns::min_max::min_max;
     use vortex_array::scalar::Scalar;
@@ -99,10 +100,18 @@ mod tests {
     #[case(Sparse::try_new(buffer![0u64, 1, 2].into_array(), buffer![7i32, 3, 9].into_array(), 3, Scalar::from(99i32)).unwrap())]
     fn min_max_matches_canonical(#[case] array: SparseArray) {
         let arr = array.into_array();
-        let kernel: Option<MinMaxResult> =
-            min_max(&arr, &mut SESSION.create_execution_ctx()).unwrap();
-        let canonical: Option<MinMaxResult> =
-            min_max(&arr, &mut CANONICAL_SESSION.create_execution_ctx()).unwrap();
+        let kernel: Option<MinMaxResult> = min_max(
+            &arr,
+            &mut SESSION.create_execution_ctx(),
+            SkipNansOptions::default(),
+        )
+        .unwrap();
+        let canonical: Option<MinMaxResult> = min_max(
+            &arr,
+            &mut CANONICAL_SESSION.create_execution_ctx(),
+            SkipNansOptions::default(),
+        )
+        .unwrap();
         assert_eq!(kernel, canonical);
     }
 }

--- a/encodings/sparse/src/compute/min_max.rs
+++ b/encodings/sparse/src/compute/min_max.rs
@@ -65,7 +65,7 @@ mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
-    use vortex_array::aggregate_fn::SkipNansOptions;
+    use vortex_array::aggregate_fn::AggregateFnOpts;
     use vortex_array::aggregate_fn::fns::min_max::MinMaxResult;
     use vortex_array::aggregate_fn::fns::min_max::min_max;
     use vortex_array::scalar::Scalar;
@@ -103,13 +103,13 @@ mod tests {
         let kernel: Option<MinMaxResult> = min_max(
             &arr,
             &mut SESSION.create_execution_ctx(),
-            SkipNansOptions::default(),
+            AggregateFnOpts::default(),
         )
         .unwrap();
         let canonical: Option<MinMaxResult> = min_max(
             &arr,
             &mut CANONICAL_SESSION.create_execution_ctx(),
-            SkipNansOptions::default(),
+            AggregateFnOpts::default(),
         )
         .unwrap();
         assert_eq!(kernel, canonical);

--- a/encodings/sparse/src/compute/sum.rs
+++ b/encodings/sparse/src/compute/sum.rs
@@ -7,7 +7,6 @@ use vortex_array::IntoArray;
 use vortex_array::aggregate_fn::Accumulator;
 use vortex_array::aggregate_fn::AggregateFnRef;
 use vortex_array::aggregate_fn::DynAccumulator;
-use vortex_array::aggregate_fn::EmptyOptions;
 use vortex_array::aggregate_fn::fns::sum::Sum;
 use vortex_array::aggregate_fn::kernels::DynAggregateKernel;
 use vortex_array::arrays::ConstantArray;
@@ -34,9 +33,9 @@ impl DynAggregateKernel for SparseSumKernel {
         batch: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<Scalar>> {
-        if !aggregate_fn.is::<Sum>() {
+        let Some(options) = aggregate_fn.as_opt::<Sum>() else {
             return Ok(None);
-        }
+        };
 
         let Some(sparse) = batch.as_opt::<Sparse>() else {
             return Ok(None);
@@ -47,8 +46,8 @@ impl DynAggregateKernel for SparseSumKernel {
 
         // Build a fresh Sum accumulator over the array dtype and fold in the fill and patch
         // contributions. The accumulator's existing semantics (checked overflow → null
-        // partial) are preserved.
-        let mut acc = Accumulator::try_new(Sum, EmptyOptions, batch.dtype().clone())?;
+        // partial, NaN handling per the options) are preserved.
+        let mut acc = Accumulator::try_new(Sum, *options, batch.dtype().clone())?;
 
         if n_fill > 0 {
             let fill_array = ConstantArray::new(sparse.fill_scalar().clone(), n_fill).into_array();

--- a/fuzz/src/array/min_max.rs
+++ b/fuzz/src/array/min_max.rs
@@ -4,7 +4,7 @@
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray as _;
-use vortex_array::aggregate_fn::SkipNansOptions;
+use vortex_array::aggregate_fn::AggregateFnOpts;
 use vortex_array::aggregate_fn::fns::min_max::MinMaxResult;
 use vortex_array::aggregate_fn::fns::min_max::min_max;
 use vortex_error::VortexResult;
@@ -14,5 +14,5 @@ pub fn min_max_canonical_array(
     canonical: Canonical,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<MinMaxResult>> {
-    min_max(&canonical.into_array(), ctx, SkipNansOptions::default())
+    min_max(&canonical.into_array(), ctx, AggregateFnOpts::default())
 }

--- a/fuzz/src/array/min_max.rs
+++ b/fuzz/src/array/min_max.rs
@@ -4,6 +4,7 @@
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray as _;
+use vortex_array::aggregate_fn::SkipNansOptions;
 use vortex_array::aggregate_fn::fns::min_max::MinMaxResult;
 use vortex_array::aggregate_fn::fns::min_max::min_max;
 use vortex_error::VortexResult;
@@ -13,5 +14,5 @@ pub fn min_max_canonical_array(
     canonical: Canonical,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<MinMaxResult>> {
-    min_max(&canonical.into_array(), ctx)
+    min_max(&canonical.into_array(), ctx, SkipNansOptions::default())
 }

--- a/fuzz/src/array/min_max.rs
+++ b/fuzz/src/array/min_max.rs
@@ -4,7 +4,7 @@
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray as _;
-use vortex_array::aggregate_fn::AggregateFnOpts;
+use vortex_array::aggregate_fn::NumericalAggregateOpts;
 use vortex_array::aggregate_fn::fns::min_max::MinMaxResult;
 use vortex_array::aggregate_fn::fns::min_max::min_max;
 use vortex_error::VortexResult;
@@ -14,5 +14,9 @@ pub fn min_max_canonical_array(
     canonical: Canonical,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<MinMaxResult>> {
-    min_max(&canonical.into_array(), ctx, AggregateFnOpts::default())
+    min_max(
+        &canonical.into_array(),
+        ctx,
+        NumericalAggregateOpts::default(),
+    )
 }

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -43,7 +43,7 @@ use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
-use vortex_array::aggregate_fn::SkipNansOptions;
+use vortex_array::aggregate_fn::AggregateFnOpts;
 use vortex_array::aggregate_fn::fns::all_non_distinct::all_non_distinct;
 use vortex_array::aggregate_fn::fns::min_max::MinMaxResult;
 use vortex_array::aggregate_fn::fns::min_max::min_max;
@@ -668,7 +668,7 @@ pub fn run_fuzz_action(fuzz_action: FuzzArrayAction) -> VortexFuzzResult<bool> {
                 assert_scalar_eq(&expected.scalar(), &sum_result, i)?;
             }
             Action::MinMax => {
-                let min_max_result = min_max(&current_array, &mut ctx, SkipNansOptions::default())
+                let min_max_result = min_max(&current_array, &mut ctx, AggregateFnOpts::default())
                     .vortex_expect("min_max operation should succeed in fuzz test");
                 assert_min_max_eq(expected.min_max().as_ref(), min_max_result.as_ref(), i)?;
             }

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -43,6 +43,7 @@ use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::aggregate_fn::SkipNansOptions;
 use vortex_array::aggregate_fn::fns::all_non_distinct::all_non_distinct;
 use vortex_array::aggregate_fn::fns::min_max::MinMaxResult;
 use vortex_array::aggregate_fn::fns::min_max::min_max;
@@ -667,7 +668,7 @@ pub fn run_fuzz_action(fuzz_action: FuzzArrayAction) -> VortexFuzzResult<bool> {
                 assert_scalar_eq(&expected.scalar(), &sum_result, i)?;
             }
             Action::MinMax => {
-                let min_max_result = min_max(&current_array, &mut ctx)
+                let min_max_result = min_max(&current_array, &mut ctx, SkipNansOptions::default())
                     .vortex_expect("min_max operation should succeed in fuzz test");
                 assert_min_max_eq(expected.min_max().as_ref(), min_max_result.as_ref(), i)?;
             }

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -43,7 +43,7 @@ use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
-use vortex_array::aggregate_fn::AggregateFnOpts;
+use vortex_array::aggregate_fn::NumericalAggregateOpts;
 use vortex_array::aggregate_fn::fns::all_non_distinct::all_non_distinct;
 use vortex_array::aggregate_fn::fns::min_max::MinMaxResult;
 use vortex_array::aggregate_fn::fns::min_max::min_max;
@@ -668,8 +668,9 @@ pub fn run_fuzz_action(fuzz_action: FuzzArrayAction) -> VortexFuzzResult<bool> {
                 assert_scalar_eq(&expected.scalar(), &sum_result, i)?;
             }
             Action::MinMax => {
-                let min_max_result = min_max(&current_array, &mut ctx, AggregateFnOpts::default())
-                    .vortex_expect("min_max operation should succeed in fuzz test");
+                let min_max_result =
+                    min_max(&current_array, &mut ctx, NumericalAggregateOpts::default())
+                        .vortex_expect("min_max operation should succeed in fuzz test");
                 assert_min_max_eq(expected.min_max().as_ref(), min_max_result.as_ref(), i)?;
             }
             Action::FillNull(fill_value) => {

--- a/vortex-array/benches/aggregate_grouped.rs
+++ b/vortex-array/benches/aggregate_grouped.rs
@@ -14,8 +14,8 @@ use vortex_array::LEGACY_SESSION;
 use vortex_array::VortexSessionExecute;
 use vortex_array::aggregate_fn::AggregateFnVTable;
 use vortex_array::aggregate_fn::DynGroupedAccumulator;
-use vortex_array::aggregate_fn::EmptyOptions;
 use vortex_array::aggregate_fn::GroupedAccumulator;
+use vortex_array::aggregate_fn::SkipNansOptions;
 use vortex_array::aggregate_fn::fns::count::Count;
 use vortex_array::aggregate_fn::fns::sum::Sum;
 use vortex_array::arrays::ListViewArray;
@@ -149,10 +149,14 @@ fn list_element_dtype(list_view: &ArrayRef) -> DType {
 
 fn grouped_accumulator<V>(list_view: &ArrayRef, vtable: V) -> ArrayRef
 where
-    V: AggregateFnVTable<Options = EmptyOptions> + Clone,
+    V: AggregateFnVTable<Options = SkipNansOptions> + Clone,
 {
-    let mut acc =
-        GroupedAccumulator::try_new(vtable, EmptyOptions, list_element_dtype(list_view)).unwrap();
+    let mut acc = GroupedAccumulator::try_new(
+        vtable,
+        SkipNansOptions::default(),
+        list_element_dtype(list_view),
+    )
+    .unwrap();
     acc.accumulate_list(list_view, &mut LEGACY_SESSION.create_execution_ctx())
         .unwrap();
     divan::black_box(acc.finish().unwrap())

--- a/vortex-array/benches/aggregate_grouped.rs
+++ b/vortex-array/benches/aggregate_grouped.rs
@@ -12,10 +12,10 @@ use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::LEGACY_SESSION;
 use vortex_array::VortexSessionExecute;
-use vortex_array::aggregate_fn::AggregateFnOpts;
 use vortex_array::aggregate_fn::AggregateFnVTable;
 use vortex_array::aggregate_fn::DynGroupedAccumulator;
 use vortex_array::aggregate_fn::GroupedAccumulator;
+use vortex_array::aggregate_fn::NumericalAggregateOpts;
 use vortex_array::aggregate_fn::fns::count::Count;
 use vortex_array::aggregate_fn::fns::sum::Sum;
 use vortex_array::arrays::ListViewArray;
@@ -149,11 +149,11 @@ fn list_element_dtype(list_view: &ArrayRef) -> DType {
 
 fn grouped_accumulator<V>(list_view: &ArrayRef, vtable: V) -> ArrayRef
 where
-    V: AggregateFnVTable<Options = AggregateFnOpts> + Clone,
+    V: AggregateFnVTable<Options = NumericalAggregateOpts> + Clone,
 {
     let mut acc = GroupedAccumulator::try_new(
         vtable,
-        AggregateFnOpts::default(),
+        NumericalAggregateOpts::default(),
         list_element_dtype(list_view),
     )
     .unwrap();

--- a/vortex-array/benches/aggregate_grouped.rs
+++ b/vortex-array/benches/aggregate_grouped.rs
@@ -12,10 +12,10 @@ use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::LEGACY_SESSION;
 use vortex_array::VortexSessionExecute;
+use vortex_array::aggregate_fn::AggregateFnOpts;
 use vortex_array::aggregate_fn::AggregateFnVTable;
 use vortex_array::aggregate_fn::DynGroupedAccumulator;
 use vortex_array::aggregate_fn::GroupedAccumulator;
-use vortex_array::aggregate_fn::SkipNansOptions;
 use vortex_array::aggregate_fn::fns::count::Count;
 use vortex_array::aggregate_fn::fns::sum::Sum;
 use vortex_array::arrays::ListViewArray;
@@ -149,11 +149,11 @@ fn list_element_dtype(list_view: &ArrayRef) -> DType {
 
 fn grouped_accumulator<V>(list_view: &ArrayRef, vtable: V) -> ArrayRef
 where
-    V: AggregateFnVTable<Options = SkipNansOptions> + Clone,
+    V: AggregateFnVTable<Options = AggregateFnOpts> + Clone,
 {
     let mut acc = GroupedAccumulator::try_new(
         vtable,
-        SkipNansOptions::default(),
+        AggregateFnOpts::default(),
         list_element_dtype(list_view),
     )
     .unwrap();

--- a/vortex-array/src/aggregate_fn/accumulator.rs
+++ b/vortex-array/src/aggregate_fn/accumulator.rs
@@ -271,10 +271,10 @@ mod tests {
     use crate::IntoArray;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnRef;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::combined::Combined;
     use crate::aggregate_fn::combined::PairOptions;
     use crate::aggregate_fn::fns::mean::Mean;
@@ -348,7 +348,10 @@ mod tests {
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
         Accumulator::try_new(
             Mean::combined(),
-            PairOptions(AggregateFnOpts::default(), AggregateFnOpts::default()),
+            PairOptions(
+                NumericalAggregateOpts::default(),
+                NumericalAggregateOpts::default(),
+            ),
             dtype,
         )
     }

--- a/vortex-array/src/aggregate_fn/accumulator.rs
+++ b/vortex-array/src/aggregate_fn/accumulator.rs
@@ -274,7 +274,7 @@ mod tests {
     use crate::aggregate_fn::AggregateFnRef;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::EmptyOptions;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::combined::Combined;
     use crate::aggregate_fn::combined::PairOptions;
     use crate::aggregate_fn::fns::mean::Mean;
@@ -348,7 +348,7 @@ mod tests {
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
         Accumulator::try_new(
             Mean::combined(),
-            PairOptions(EmptyOptions, EmptyOptions),
+            PairOptions(SkipNansOptions::default(), SkipNansOptions::default()),
             dtype,
         )
     }

--- a/vortex-array/src/aggregate_fn/accumulator.rs
+++ b/vortex-array/src/aggregate_fn/accumulator.rs
@@ -271,10 +271,10 @@ mod tests {
     use crate::IntoArray;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnRef;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::combined::Combined;
     use crate::aggregate_fn::combined::PairOptions;
     use crate::aggregate_fn::fns::mean::Mean;
@@ -348,7 +348,7 @@ mod tests {
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
         Accumulator::try_new(
             Mean::combined(),
-            PairOptions(SkipNansOptions::default(), SkipNansOptions::default()),
+            PairOptions(AggregateFnOpts::default(), AggregateFnOpts::default()),
             dtype,
         )
     }

--- a/vortex-array/src/aggregate_fn/fns/bounded_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/bounded_max/mod.rs
@@ -17,10 +17,10 @@ use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::aggregate_fn::AggregateFnId;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnSatisfaction;
 use crate::aggregate_fn::AggregateFnVTable;
-use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::max::Max;
 use crate::aggregate_fn::fns::min_max::MinMax;
 use crate::aggregate_fn::fns::min_max::min_max;
@@ -196,7 +196,7 @@ impl AggregateFnVTable for BoundedMax {
             Columnar::Canonical(canonical) => canonical.clone().into_array(),
             Columnar::Constant(constant) => constant.clone().into_array(),
         };
-        let Some(result) = min_max(&array, ctx, SkipNansOptions::default())? else {
+        let Some(result) = min_max(&array, ctx, AggregateFnOpts::default())? else {
             return Ok(());
         };
         match truncate_max(result.max, partial.max_bytes.get())? {
@@ -217,7 +217,7 @@ impl AggregateFnVTable for BoundedMax {
 
 fn supported_dtype<'a>(_options: &BoundedMaxOptions, input_dtype: &'a DType) -> Option<&'a DType> {
     MinMax
-        .return_dtype(&SkipNansOptions::default(), input_dtype)
+        .return_dtype(&AggregateFnOpts::default(), input_dtype)
         .map(|_| input_dtype)
 }
 
@@ -253,11 +253,11 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnSatisfaction;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::AggregateFnVTableExt;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::bounded_max::BoundedMax;
     use crate::aggregate_fn::fns::bounded_max::BoundedMaxOptions;
     use crate::aggregate_fn::fns::max::Max;
@@ -420,23 +420,24 @@ mod tests {
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            stored.can_satisfy(&Max.bind(SkipNansOptions::default())),
+            stored.can_satisfy(&Max.bind(AggregateFnOpts::default())),
             AggregateFnSatisfaction::Approximate
         );
         assert_eq!(
-            stored.can_satisfy(&Max.bind(SkipNansOptions::include())),
+            stored.can_satisfy(&Max.bind(AggregateFnOpts::include_nans())),
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            Max.bind(SkipNansOptions::include()).can_satisfy(&stored),
+            Max.bind(AggregateFnOpts::include_nans())
+                .can_satisfy(&stored),
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            Max.bind(SkipNansOptions::default()).can_satisfy(&stored),
+            Max.bind(AggregateFnOpts::default()).can_satisfy(&stored),
             AggregateFnSatisfaction::Approximate
         );
         assert_eq!(
-            stored.can_satisfy(&Min.bind(SkipNansOptions::default())),
+            stored.can_satisfy(&Min.bind(AggregateFnOpts::default())),
             AggregateFnSatisfaction::No
         );
     }

--- a/vortex-array/src/aggregate_fn/fns/bounded_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/bounded_max/mod.rs
@@ -20,7 +20,7 @@ use crate::aggregate_fn::AggregateFnId;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnSatisfaction;
 use crate::aggregate_fn::AggregateFnVTable;
-use crate::aggregate_fn::EmptyOptions;
+use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::max::Max;
 use crate::aggregate_fn::fns::min_max::MinMax;
 use crate::aggregate_fn::fns::min_max::min_max;
@@ -136,7 +136,11 @@ impl AggregateFnVTable for BoundedMax {
             };
         }
 
-        if requested.is::<Max>() {
+        // The stored bound skips NaNs, so it cannot stand in for a NaN-including maximum.
+        if requested
+            .as_opt::<Max>()
+            .is_some_and(|options| options.skip_nans)
+        {
             AggregateFnSatisfaction::Approximate
         } else {
             AggregateFnSatisfaction::No
@@ -213,7 +217,7 @@ impl AggregateFnVTable for BoundedMax {
 
 fn supported_dtype<'a>(_options: &BoundedMaxOptions, input_dtype: &'a DType) -> Option<&'a DType> {
     MinMax
-        .return_dtype(&EmptyOptions, input_dtype)
+        .return_dtype(&SkipNansOptions::default(), input_dtype)
         .map(|_| input_dtype)
 }
 
@@ -253,7 +257,7 @@ mod tests {
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::AggregateFnVTableExt;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::EmptyOptions;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::bounded_max::BoundedMax;
     use crate::aggregate_fn::fns::bounded_max::BoundedMaxOptions;
     use crate::aggregate_fn::fns::max::Max;
@@ -416,15 +420,24 @@ mod tests {
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            stored.can_satisfy(&Max.bind(EmptyOptions)),
+            stored.can_satisfy(&Max.bind(SkipNansOptions::default())),
             AggregateFnSatisfaction::Approximate
         );
         assert_eq!(
-            Max.bind(EmptyOptions).can_satisfy(&stored),
+            stored.can_satisfy(&Max.bind(SkipNansOptions { skip_nans: false })),
+            AggregateFnSatisfaction::No
+        );
+        assert_eq!(
+            Max.bind(SkipNansOptions { skip_nans: false })
+                .can_satisfy(&stored),
+            AggregateFnSatisfaction::No
+        );
+        assert_eq!(
+            Max.bind(SkipNansOptions::default()).can_satisfy(&stored),
             AggregateFnSatisfaction::Approximate
         );
         assert_eq!(
-            stored.can_satisfy(&Min.bind(EmptyOptions)),
+            stored.can_satisfy(&Min.bind(SkipNansOptions::default())),
             AggregateFnSatisfaction::No
         );
     }

--- a/vortex-array/src/aggregate_fn/fns/bounded_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/bounded_max/mod.rs
@@ -17,10 +17,10 @@ use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::aggregate_fn::AggregateFnId;
-use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnSatisfaction;
 use crate::aggregate_fn::AggregateFnVTable;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::aggregate_fn::fns::max::Max;
 use crate::aggregate_fn::fns::min_max::MinMax;
 use crate::aggregate_fn::fns::min_max::min_max;
@@ -196,7 +196,7 @@ impl AggregateFnVTable for BoundedMax {
             Columnar::Canonical(canonical) => canonical.clone().into_array(),
             Columnar::Constant(constant) => constant.clone().into_array(),
         };
-        let Some(result) = min_max(&array, ctx, AggregateFnOpts::default())? else {
+        let Some(result) = min_max(&array, ctx, NumericalAggregateOpts::default())? else {
             return Ok(());
         };
         match truncate_max(result.max, partial.max_bytes.get())? {
@@ -217,7 +217,7 @@ impl AggregateFnVTable for BoundedMax {
 
 fn supported_dtype<'a>(_options: &BoundedMaxOptions, input_dtype: &'a DType) -> Option<&'a DType> {
     MinMax
-        .return_dtype(&AggregateFnOpts::default(), input_dtype)
+        .return_dtype(&NumericalAggregateOpts::default(), input_dtype)
         .map(|_| input_dtype)
 }
 
@@ -253,11 +253,11 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnSatisfaction;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::AggregateFnVTableExt;
     use crate::aggregate_fn::DynAccumulator;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::bounded_max::BoundedMax;
     use crate::aggregate_fn::fns::bounded_max::BoundedMaxOptions;
     use crate::aggregate_fn::fns::max::Max;
@@ -420,24 +420,25 @@ mod tests {
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            stored.can_satisfy(&Max.bind(AggregateFnOpts::default())),
+            stored.can_satisfy(&Max.bind(NumericalAggregateOpts::default())),
             AggregateFnSatisfaction::Approximate
         );
         assert_eq!(
-            stored.can_satisfy(&Max.bind(AggregateFnOpts::include_nans())),
+            stored.can_satisfy(&Max.bind(NumericalAggregateOpts::include_nans())),
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            Max.bind(AggregateFnOpts::include_nans())
+            Max.bind(NumericalAggregateOpts::include_nans())
                 .can_satisfy(&stored),
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            Max.bind(AggregateFnOpts::default()).can_satisfy(&stored),
+            Max.bind(NumericalAggregateOpts::default())
+                .can_satisfy(&stored),
             AggregateFnSatisfaction::Approximate
         );
         assert_eq!(
-            stored.can_satisfy(&Min.bind(AggregateFnOpts::default())),
+            stored.can_satisfy(&Min.bind(NumericalAggregateOpts::default())),
             AggregateFnSatisfaction::No
         );
     }

--- a/vortex-array/src/aggregate_fn/fns/bounded_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/bounded_max/mod.rs
@@ -196,7 +196,7 @@ impl AggregateFnVTable for BoundedMax {
             Columnar::Canonical(canonical) => canonical.clone().into_array(),
             Columnar::Constant(constant) => constant.clone().into_array(),
         };
-        let Some(result) = min_max(&array, ctx)? else {
+        let Some(result) = min_max(&array, ctx, SkipNansOptions::default())? else {
             return Ok(());
         };
         match truncate_max(result.max, partial.max_bytes.get())? {
@@ -424,12 +424,11 @@ mod tests {
             AggregateFnSatisfaction::Approximate
         );
         assert_eq!(
-            stored.can_satisfy(&Max.bind(SkipNansOptions { skip_nans: false })),
+            stored.can_satisfy(&Max.bind(SkipNansOptions::include())),
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            Max.bind(SkipNansOptions { skip_nans: false })
-                .can_satisfy(&stored),
+            Max.bind(SkipNansOptions::include()).can_satisfy(&stored),
             AggregateFnSatisfaction::No
         );
         assert_eq!(

--- a/vortex-array/src/aggregate_fn/fns/bounded_min/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/bounded_min/mod.rs
@@ -186,7 +186,7 @@ impl AggregateFnVTable for BoundedMin {
             Columnar::Canonical(canonical) => canonical.clone().into_array(),
             Columnar::Constant(constant) => constant.clone().into_array(),
         };
-        let Some(result) = min_max(&array, ctx)? else {
+        let Some(result) = min_max(&array, ctx, SkipNansOptions::default())? else {
             return Ok(());
         };
         if let Some(bound) = truncate_min(result.min, partial.max_bytes.get())? {
@@ -358,12 +358,11 @@ mod tests {
             AggregateFnSatisfaction::Approximate
         );
         assert_eq!(
-            stored.can_satisfy(&Min.bind(SkipNansOptions { skip_nans: false })),
+            stored.can_satisfy(&Min.bind(SkipNansOptions::include())),
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            Min.bind(SkipNansOptions { skip_nans: false })
-                .can_satisfy(&stored),
+            Min.bind(SkipNansOptions::include()).can_satisfy(&stored),
             AggregateFnSatisfaction::No
         );
         assert_eq!(

--- a/vortex-array/src/aggregate_fn/fns/bounded_min/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/bounded_min/mod.rs
@@ -20,7 +20,7 @@ use crate::aggregate_fn::AggregateFnId;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnSatisfaction;
 use crate::aggregate_fn::AggregateFnVTable;
-use crate::aggregate_fn::EmptyOptions;
+use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::min::Min;
 use crate::aggregate_fn::fns::min_max::MinMax;
 use crate::aggregate_fn::fns::min_max::min_max;
@@ -126,7 +126,11 @@ impl AggregateFnVTable for BoundedMin {
             };
         }
 
-        if requested.is::<Min>() {
+        // The stored bound skips NaNs, so it cannot stand in for a NaN-including minimum.
+        if requested
+            .as_opt::<Min>()
+            .is_some_and(|options| options.skip_nans)
+        {
             AggregateFnSatisfaction::Approximate
         } else {
             AggregateFnSatisfaction::No
@@ -202,7 +206,7 @@ impl AggregateFnVTable for BoundedMin {
 
 fn supported_dtype<'a>(_options: &BoundedMinOptions, input_dtype: &'a DType) -> Option<&'a DType> {
     MinMax
-        .return_dtype(&EmptyOptions, input_dtype)
+        .return_dtype(&SkipNansOptions::default(), input_dtype)
         .map(|_| input_dtype)
 }
 
@@ -241,7 +245,7 @@ mod tests {
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::AggregateFnVTableExt;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::EmptyOptions;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::bounded_min::BoundedMin;
     use crate::aggregate_fn::fns::bounded_min::BoundedMinOptions;
     use crate::aggregate_fn::fns::max::Max;
@@ -350,15 +354,24 @@ mod tests {
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            stored.can_satisfy(&Min.bind(EmptyOptions)),
+            stored.can_satisfy(&Min.bind(SkipNansOptions::default())),
             AggregateFnSatisfaction::Approximate
         );
         assert_eq!(
-            Min.bind(EmptyOptions).can_satisfy(&stored),
+            stored.can_satisfy(&Min.bind(SkipNansOptions { skip_nans: false })),
+            AggregateFnSatisfaction::No
+        );
+        assert_eq!(
+            Min.bind(SkipNansOptions { skip_nans: false })
+                .can_satisfy(&stored),
+            AggregateFnSatisfaction::No
+        );
+        assert_eq!(
+            Min.bind(SkipNansOptions::default()).can_satisfy(&stored),
             AggregateFnSatisfaction::Approximate
         );
         assert_eq!(
-            stored.can_satisfy(&Max.bind(EmptyOptions)),
+            stored.can_satisfy(&Max.bind(SkipNansOptions::default())),
             AggregateFnSatisfaction::No
         );
     }

--- a/vortex-array/src/aggregate_fn/fns/bounded_min/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/bounded_min/mod.rs
@@ -17,10 +17,10 @@ use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::aggregate_fn::AggregateFnId;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnSatisfaction;
 use crate::aggregate_fn::AggregateFnVTable;
-use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::min::Min;
 use crate::aggregate_fn::fns::min_max::MinMax;
 use crate::aggregate_fn::fns::min_max::min_max;
@@ -186,7 +186,7 @@ impl AggregateFnVTable for BoundedMin {
             Columnar::Canonical(canonical) => canonical.clone().into_array(),
             Columnar::Constant(constant) => constant.clone().into_array(),
         };
-        let Some(result) = min_max(&array, ctx, SkipNansOptions::default())? else {
+        let Some(result) = min_max(&array, ctx, AggregateFnOpts::default())? else {
             return Ok(());
         };
         if let Some(bound) = truncate_min(result.min, partial.max_bytes.get())? {
@@ -206,7 +206,7 @@ impl AggregateFnVTable for BoundedMin {
 
 fn supported_dtype<'a>(_options: &BoundedMinOptions, input_dtype: &'a DType) -> Option<&'a DType> {
     MinMax
-        .return_dtype(&SkipNansOptions::default(), input_dtype)
+        .return_dtype(&AggregateFnOpts::default(), input_dtype)
         .map(|_| input_dtype)
 }
 
@@ -241,11 +241,11 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnSatisfaction;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::AggregateFnVTableExt;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::bounded_min::BoundedMin;
     use crate::aggregate_fn::fns::bounded_min::BoundedMinOptions;
     use crate::aggregate_fn::fns::max::Max;
@@ -354,23 +354,24 @@ mod tests {
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            stored.can_satisfy(&Min.bind(SkipNansOptions::default())),
+            stored.can_satisfy(&Min.bind(AggregateFnOpts::default())),
             AggregateFnSatisfaction::Approximate
         );
         assert_eq!(
-            stored.can_satisfy(&Min.bind(SkipNansOptions::include())),
+            stored.can_satisfy(&Min.bind(AggregateFnOpts::include_nans())),
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            Min.bind(SkipNansOptions::include()).can_satisfy(&stored),
+            Min.bind(AggregateFnOpts::include_nans())
+                .can_satisfy(&stored),
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            Min.bind(SkipNansOptions::default()).can_satisfy(&stored),
+            Min.bind(AggregateFnOpts::default()).can_satisfy(&stored),
             AggregateFnSatisfaction::Approximate
         );
         assert_eq!(
-            stored.can_satisfy(&Max.bind(SkipNansOptions::default())),
+            stored.can_satisfy(&Max.bind(AggregateFnOpts::default())),
             AggregateFnSatisfaction::No
         );
     }

--- a/vortex-array/src/aggregate_fn/fns/bounded_min/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/bounded_min/mod.rs
@@ -17,10 +17,10 @@ use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::aggregate_fn::AggregateFnId;
-use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnSatisfaction;
 use crate::aggregate_fn::AggregateFnVTable;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::aggregate_fn::fns::min::Min;
 use crate::aggregate_fn::fns::min_max::MinMax;
 use crate::aggregate_fn::fns::min_max::min_max;
@@ -186,7 +186,7 @@ impl AggregateFnVTable for BoundedMin {
             Columnar::Canonical(canonical) => canonical.clone().into_array(),
             Columnar::Constant(constant) => constant.clone().into_array(),
         };
-        let Some(result) = min_max(&array, ctx, AggregateFnOpts::default())? else {
+        let Some(result) = min_max(&array, ctx, NumericalAggregateOpts::default())? else {
             return Ok(());
         };
         if let Some(bound) = truncate_min(result.min, partial.max_bytes.get())? {
@@ -206,7 +206,7 @@ impl AggregateFnVTable for BoundedMin {
 
 fn supported_dtype<'a>(_options: &BoundedMinOptions, input_dtype: &'a DType) -> Option<&'a DType> {
     MinMax
-        .return_dtype(&AggregateFnOpts::default(), input_dtype)
+        .return_dtype(&NumericalAggregateOpts::default(), input_dtype)
         .map(|_| input_dtype)
 }
 
@@ -241,11 +241,11 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnSatisfaction;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::AggregateFnVTableExt;
     use crate::aggregate_fn::DynAccumulator;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::bounded_min::BoundedMin;
     use crate::aggregate_fn::fns::bounded_min::BoundedMinOptions;
     use crate::aggregate_fn::fns::max::Max;
@@ -354,24 +354,25 @@ mod tests {
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            stored.can_satisfy(&Min.bind(AggregateFnOpts::default())),
+            stored.can_satisfy(&Min.bind(NumericalAggregateOpts::default())),
             AggregateFnSatisfaction::Approximate
         );
         assert_eq!(
-            stored.can_satisfy(&Min.bind(AggregateFnOpts::include_nans())),
+            stored.can_satisfy(&Min.bind(NumericalAggregateOpts::include_nans())),
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            Min.bind(AggregateFnOpts::include_nans())
+            Min.bind(NumericalAggregateOpts::include_nans())
                 .can_satisfy(&stored),
             AggregateFnSatisfaction::No
         );
         assert_eq!(
-            Min.bind(AggregateFnOpts::default()).can_satisfy(&stored),
+            Min.bind(NumericalAggregateOpts::default())
+                .can_satisfy(&stored),
             AggregateFnSatisfaction::Approximate
         );
         assert_eq!(
-            stored.can_satisfy(&Max.bind(AggregateFnOpts::default())),
+            stored.can_satisfy(&Max.bind(NumericalAggregateOpts::default())),
             AggregateFnSatisfaction::No
         );
     }

--- a/vortex-array/src/aggregate_fn/fns/count/grouped.rs
+++ b/vortex-array/src/aggregate_fn/fns/count/grouped.rs
@@ -94,9 +94,9 @@ mod tests {
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::DynGroupedAccumulator;
     use crate::aggregate_fn::GroupedAccumulator;
-    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::count::Count;
     use crate::arrays::FixedSizeListArray;
     use crate::arrays::ListViewArray;
@@ -112,7 +112,7 @@ mod tests {
     /// Run a grouped count through the accumulator.
     fn grouped_count_actual(groups: &ArrayRef, elem_dtype: &DType) -> VortexResult<ArrayRef> {
         let mut acc =
-            GroupedAccumulator::try_new(Count, SkipNansOptions::default(), elem_dtype.clone())?;
+            GroupedAccumulator::try_new(Count, AggregateFnOpts::default(), elem_dtype.clone())?;
         acc.accumulate_list(groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         acc.finish()
     }
@@ -220,7 +220,8 @@ mod tests {
         let expected = PrimitiveArray::new(buffer![1u64, 1], Validity::NonNullable).into_array();
         assert_arrays_eq!(&actual, &expected);
 
-        let mut acc = GroupedAccumulator::try_new(Count, SkipNansOptions::include(), elem_dtype)?;
+        let mut acc =
+            GroupedAccumulator::try_new(Count, AggregateFnOpts::include_nans(), elem_dtype)?;
         acc.accumulate_list(&groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         let actual = acc.finish()?;
         let expected = PrimitiveArray::new(buffer![2u64, 1], Validity::NonNullable).into_array();

--- a/vortex-array/src/aggregate_fn/fns/count/grouped.rs
+++ b/vortex-array/src/aggregate_fn/fns/count/grouped.rs
@@ -94,9 +94,9 @@ mod tests {
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::DynGroupedAccumulator;
     use crate::aggregate_fn::GroupedAccumulator;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::count::Count;
     use crate::arrays::FixedSizeListArray;
     use crate::arrays::ListViewArray;
@@ -111,8 +111,11 @@ mod tests {
 
     /// Run a grouped count through the accumulator.
     fn grouped_count_actual(groups: &ArrayRef, elem_dtype: &DType) -> VortexResult<ArrayRef> {
-        let mut acc =
-            GroupedAccumulator::try_new(Count, AggregateFnOpts::default(), elem_dtype.clone())?;
+        let mut acc = GroupedAccumulator::try_new(
+            Count,
+            NumericalAggregateOpts::default(),
+            elem_dtype.clone(),
+        )?;
         acc.accumulate_list(groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         acc.finish()
     }
@@ -221,7 +224,7 @@ mod tests {
         assert_arrays_eq!(&actual, &expected);
 
         let mut acc =
-            GroupedAccumulator::try_new(Count, AggregateFnOpts::include_nans(), elem_dtype)?;
+            GroupedAccumulator::try_new(Count, NumericalAggregateOpts::include_nans(), elem_dtype)?;
         acc.accumulate_list(&groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         let actual = acc.finish()?;
         let expected = PrimitiveArray::new(buffer![2u64, 1], Validity::NonNullable).into_array();

--- a/vortex-array/src/aggregate_fn/fns/count/grouped.rs
+++ b/vortex-array/src/aggregate_fn/fns/count/grouped.rs
@@ -27,7 +27,12 @@ impl DynGroupedAggregateKernel for CountGroupedKernel {
         groups: &GroupedArray,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        if !aggregate_fn.is::<Count>() {
+        let Some(options) = aggregate_fn.as_opt::<Count>() else {
+            return Ok(None);
+        };
+        // NaN-skipping counts over floats must inspect the element values, which this
+        // validity-only kernel cannot do; fall back to the per-group accumulator path.
+        if options.skip_nans && groups.elements().dtype().is_float() {
             return Ok(None);
         }
         try_grouped_count(groups, ctx)
@@ -90,8 +95,8 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::DynGroupedAccumulator;
-    use crate::aggregate_fn::EmptyOptions;
     use crate::aggregate_fn::GroupedAccumulator;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::count::Count;
     use crate::arrays::FixedSizeListArray;
     use crate::arrays::ListViewArray;
@@ -106,7 +111,8 @@ mod tests {
 
     /// Run a grouped count through the accumulator.
     fn grouped_count_actual(groups: &ArrayRef, elem_dtype: &DType) -> VortexResult<ArrayRef> {
-        let mut acc = GroupedAccumulator::try_new(Count, EmptyOptions, elem_dtype.clone())?;
+        let mut acc =
+            GroupedAccumulator::try_new(Count, SkipNansOptions::default(), elem_dtype.clone())?;
         acc.accumulate_list(groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         acc.finish()
     }
@@ -196,6 +202,29 @@ mod tests {
 
         let direct = PrimitiveArray::new(buffer![1u64, 1, 1], Validity::NonNullable).into_array();
         assert_arrays_eq!(&actual, &direct);
+        assert_arrays_eq!(&actual, &expected);
+        Ok(())
+    }
+
+    #[test]
+    fn fixed_size_counts_float_nans() -> VortexResult<()> {
+        let elements =
+            PrimitiveArray::from_option_iter([Some(1.0f64), Some(f64::NAN), None, Some(2.0)])
+                .into_array();
+        let elem_dtype = DType::Primitive(PType::F64, Nullable);
+        let groups =
+            FixedSizeListArray::try_new(elements, 2, Validity::NonNullable, 2)?.into_array();
+
+        // NaNs are excluded by default and counted otherwise.
+        let actual = grouped_count_actual(&groups, &elem_dtype)?;
+        let expected = PrimitiveArray::new(buffer![1u64, 1], Validity::NonNullable).into_array();
+        assert_arrays_eq!(&actual, &expected);
+
+        let mut acc =
+            GroupedAccumulator::try_new(Count, SkipNansOptions { skip_nans: false }, elem_dtype)?;
+        acc.accumulate_list(&groups, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let actual = acc.finish()?;
+        let expected = PrimitiveArray::new(buffer![2u64, 1], Validity::NonNullable).into_array();
         assert_arrays_eq!(&actual, &expected);
         Ok(())
     }

--- a/vortex-array/src/aggregate_fn/fns/count/grouped.rs
+++ b/vortex-array/src/aggregate_fn/fns/count/grouped.rs
@@ -220,8 +220,7 @@ mod tests {
         let expected = PrimitiveArray::new(buffer![1u64, 1], Validity::NonNullable).into_array();
         assert_arrays_eq!(&actual, &expected);
 
-        let mut acc =
-            GroupedAccumulator::try_new(Count, SkipNansOptions { skip_nans: false }, elem_dtype)?;
+        let mut acc = GroupedAccumulator::try_new(Count, SkipNansOptions::include(), elem_dtype)?;
         acc.accumulate_list(&groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         let actual = acc.finish()?;
         let expected = PrimitiveArray::new(buffer![2u64, 1], Validity::NonNullable).into_array();

--- a/vortex-array/src/aggregate_fn/fns/count/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/count/mod.rs
@@ -10,8 +10,8 @@ use crate::ArrayRef;
 use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::aggregate_fn::AggregateFnId;
-use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnVTable;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::aggregate_fn::fns::nan_count::nan_count;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -23,7 +23,7 @@ use crate::scalar::Scalar;
 /// Applies to all types. Returns a `u64` count.
 /// The identity value is zero.
 ///
-/// For float inputs, NaN handling is controlled by [`AggregateFnOpts`]: with `skip_nans` (the
+/// For float inputs, NaN handling is controlled by [`NumericalAggregateOpts`]: with `skip_nans` (the
 /// default) NaN values are treated as missing and excluded from the count, otherwise they are
 /// counted like any other non-null value.
 #[derive(Clone, Debug)]
@@ -37,7 +37,7 @@ pub struct CountPartial {
 }
 
 impl AggregateFnVTable for Count {
-    type Options = AggregateFnOpts;
+    type Options = NumericalAggregateOpts;
     type Partial = CountPartial;
 
     fn id(&self) -> AggregateFnId {
@@ -136,9 +136,9 @@ mod tests {
     use crate::IntoArray;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::count::Count;
     use crate::arrays::ChunkedArray;
     use crate::arrays::ConstantArray;
@@ -155,8 +155,11 @@ mod tests {
     static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     pub fn count(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<usize> {
-        let mut acc =
-            Accumulator::try_new(Count, AggregateFnOpts::default(), array.dtype().clone())?;
+        let mut acc = Accumulator::try_new(
+            Count,
+            NumericalAggregateOpts::default(),
+            array.dtype().clone(),
+        )?;
         acc.accumulate(array, ctx)?;
         let result = acc.finish()?;
 
@@ -197,7 +200,7 @@ mod tests {
     #[test]
     fn count_empty() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Count, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Count, NumericalAggregateOpts::default(), dtype)?;
         let result = acc.finish()?;
         assert_eq!(result.as_primitive().typed_value::<u64>(), Some(0));
         Ok(())
@@ -207,7 +210,7 @@ mod tests {
     fn count_multi_batch() -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::Nullable);
-        let mut acc = Accumulator::try_new(Count, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Count, NumericalAggregateOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3)]).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -224,7 +227,7 @@ mod tests {
     fn count_finish_resets_state() -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::Nullable);
-        let mut acc = Accumulator::try_new(Count, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Count, NumericalAggregateOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::from_option_iter([Some(1i32), None]).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -241,7 +244,7 @@ mod tests {
     #[test]
     fn count_state_merge() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut state = Count.empty_partial(&AggregateFnOpts::default(), &dtype)?;
+        let mut state = Count.empty_partial(&NumericalAggregateOpts::default(), &dtype)?;
 
         let scalar1 = Scalar::primitive(5u64, Nullability::NonNullable);
         Count.combine_partials(&mut state, scalar1)?;
@@ -258,7 +261,7 @@ mod tests {
     fn count_with_options(
         array: &ArrayRef,
         ctx: &mut ExecutionCtx,
-        options: AggregateFnOpts,
+        options: NumericalAggregateOpts,
     ) -> VortexResult<u64> {
         let mut acc = Accumulator::try_new(Count, options, array.dtype().clone())?;
         acc.accumulate(array, ctx)?;
@@ -286,7 +289,7 @@ mod tests {
                 .into_array();
         let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(
-            count_with_options(&array, &mut ctx, AggregateFnOpts::include_nans())?,
+            count_with_options(&array, &mut ctx, NumericalAggregateOpts::include_nans())?,
             3
         );
         Ok(())
@@ -312,7 +315,7 @@ mod tests {
         let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(count(&array, &mut ctx)?, 0);
         assert_eq!(
-            count_with_options(&array, &mut ctx, AggregateFnOpts::include_nans())?,
+            count_with_options(&array, &mut ctx, NumericalAggregateOpts::include_nans())?,
             5
         );
         Ok(())

--- a/vortex-array/src/aggregate_fn/fns/count/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/count/mod.rs
@@ -11,7 +11,8 @@ use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::aggregate_fn::AggregateFnId;
 use crate::aggregate_fn::AggregateFnVTable;
-use crate::aggregate_fn::EmptyOptions;
+use crate::aggregate_fn::SkipNansOptions;
+use crate::aggregate_fn::fns::nan_count::nan_count;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
@@ -21,12 +22,23 @@ use crate::scalar::Scalar;
 ///
 /// Applies to all types. Returns a `u64` count.
 /// The identity value is zero.
+///
+/// For float inputs, NaN handling is controlled by [`SkipNansOptions`]: with `skip_nans` (the
+/// default) NaN values are treated as missing and excluded from the count, otherwise they are
+/// counted like any other non-null value.
 #[derive(Clone, Debug)]
 pub struct Count;
 
+/// Partial accumulator state for the count aggregate.
+pub struct CountPartial {
+    count: u64,
+    /// Whether NaN values must be excluded from the count (float input with `skip_nans`).
+    exclude_nans: bool,
+}
+
 impl AggregateFnVTable for Count {
-    type Options = EmptyOptions;
-    type Partial = u64;
+    type Options = SkipNansOptions;
+    type Partial = CountPartial;
 
     fn id(&self) -> AggregateFnId {
         AggregateFnId::new("vortex.count")
@@ -46,10 +58,13 @@ impl AggregateFnVTable for Count {
 
     fn empty_partial(
         &self,
-        _options: &Self::Options,
-        _input_dtype: &DType,
+        options: &Self::Options,
+        input_dtype: &DType,
     ) -> VortexResult<Self::Partial> {
-        Ok(0u64)
+        Ok(CountPartial {
+            count: 0,
+            exclude_nans: options.skip_nans && input_dtype.is_float(),
+        })
     }
 
     fn combine_partials(&self, partial: &mut Self::Partial, other: Scalar) -> VortexResult<()> {
@@ -57,16 +72,16 @@ impl AggregateFnVTable for Count {
             .as_primitive()
             .typed_value::<u64>()
             .vortex_expect("count partial should not be null");
-        *partial += val;
+        partial.count += val;
         Ok(())
     }
 
     fn to_scalar(&self, partial: &Self::Partial) -> VortexResult<Scalar> {
-        Ok(Scalar::primitive(*partial, Nullability::NonNullable))
+        Ok(Scalar::primitive(partial.count, Nullability::NonNullable))
     }
 
     fn reset(&self, partial: &mut Self::Partial) {
-        *partial = 0;
+        partial.count = 0;
     }
 
     #[inline]
@@ -80,7 +95,12 @@ impl AggregateFnVTable for Count {
         batch: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<bool> {
-        *state += batch.valid_count(ctx)? as u64;
+        let mut count = batch.valid_count(ctx)? as u64;
+        if state.exclude_nans {
+            // `nan_count` shortcircuits on an exact `Stat::NaNCount` before scanning the batch.
+            count -= nan_count(batch, ctx)? as u64;
+        }
+        state.count += count;
         Ok(true)
     }
 
@@ -116,7 +136,7 @@ mod tests {
     use crate::aggregate_fn::Accumulator;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::EmptyOptions;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::count::Count;
     use crate::arrays::ChunkedArray;
     use crate::arrays::ConstantArray;
@@ -124,11 +144,15 @@ mod tests {
     use crate::dtype::DType;
     use crate::dtype::Nullability;
     use crate::dtype::PType;
+    use crate::expr::stats::Precision;
+    use crate::expr::stats::Stat;
     use crate::scalar::Scalar;
+    use crate::scalar::ScalarValue;
     use crate::validity::Validity;
 
     pub fn count(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<usize> {
-        let mut acc = Accumulator::try_new(Count, EmptyOptions, array.dtype().clone())?;
+        let mut acc =
+            Accumulator::try_new(Count, SkipNansOptions::default(), array.dtype().clone())?;
         acc.accumulate(array, ctx)?;
         let result = acc.finish()?;
 
@@ -169,7 +193,7 @@ mod tests {
     #[test]
     fn count_empty() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Count, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(Count, SkipNansOptions::default(), dtype)?;
         let result = acc.finish()?;
         assert_eq!(result.as_primitive().typed_value::<u64>(), Some(0));
         Ok(())
@@ -179,7 +203,7 @@ mod tests {
     fn count_multi_batch() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::Nullable);
-        let mut acc = Accumulator::try_new(Count, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(Count, SkipNansOptions::default(), dtype)?;
 
         let batch1 = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3)]).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -196,7 +220,7 @@ mod tests {
     fn count_finish_resets_state() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::Nullable);
-        let mut acc = Accumulator::try_new(Count, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(Count, SkipNansOptions::default(), dtype)?;
 
         let batch1 = PrimitiveArray::from_option_iter([Some(1i32), None]).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -213,7 +237,7 @@ mod tests {
     #[test]
     fn count_state_merge() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut state = Count.empty_partial(&EmptyOptions, &dtype)?;
+        let mut state = Count.empty_partial(&SkipNansOptions::default(), &dtype)?;
 
         let scalar1 = Scalar::primitive(5u64, Nullability::NonNullable);
         Count.combine_partials(&mut state, scalar1)?;
@@ -224,6 +248,69 @@ mod tests {
         let result = Count.to_scalar(&state)?;
         Count.reset(&mut state);
         assert_eq!(result.as_primitive().typed_value::<u64>(), Some(8));
+        Ok(())
+    }
+
+    fn count_with_options(
+        array: &ArrayRef,
+        ctx: &mut ExecutionCtx,
+        options: SkipNansOptions,
+    ) -> VortexResult<u64> {
+        let mut acc = Accumulator::try_new(Count, options, array.dtype().clone())?;
+        acc.accumulate(array, ctx)?;
+        Ok(acc
+            .finish()?
+            .as_primitive()
+            .typed_value::<u64>()
+            .vortex_expect("count result should not be null"))
+    }
+
+    #[test]
+    fn count_float_excludes_nans_by_default() -> VortexResult<()> {
+        let array =
+            PrimitiveArray::from_option_iter([Some(1.0f64), Some(f64::NAN), None, Some(3.0)])
+                .into_array();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        assert_eq!(count(&array, &mut ctx)?, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn count_float_includes_nans_when_not_skipping() -> VortexResult<()> {
+        let array =
+            PrimitiveArray::from_option_iter([Some(1.0f64), Some(f64::NAN), None, Some(3.0)])
+                .into_array();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        assert_eq!(
+            count_with_options(&array, &mut ctx, SkipNansOptions { skip_nans: false })?,
+            3
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn count_float_shortcircuits_on_exact_nan_count_stat() -> VortexResult<()> {
+        // The array has no NaNs; a planted exact NaNCount stat proves the count is derived from
+        // the stat rather than a scan.
+        let array =
+            PrimitiveArray::new(buffer![1.0f64, 2.0, 3.0, 4.0], Validity::NonNullable).into_array();
+        array
+            .statistics()
+            .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(3u64)));
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        assert_eq!(count(&array, &mut ctx)?, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn count_constant_nan() -> VortexResult<()> {
+        let array = ConstantArray::new(f64::NAN, 5).into_array();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        assert_eq!(count(&array, &mut ctx)?, 0);
+        assert_eq!(
+            count_with_options(&array, &mut ctx, SkipNansOptions { skip_nans: false })?,
+            5
+        );
         Ok(())
     }
 

--- a/vortex-array/src/aggregate_fn/fns/count/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/count/mod.rs
@@ -124,14 +124,16 @@ impl AggregateFnVTable for Count {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::LazyLock;
+
     use vortex_buffer::buffer;
     use vortex_error::VortexExpect;
     use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
 
     use crate::ArrayRef;
     use crate::ExecutionCtx;
     use crate::IntoArray;
-    use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
     use crate::aggregate_fn::AggregateFnVTable;
@@ -149,6 +151,8 @@ mod tests {
     use crate::scalar::Scalar;
     use crate::scalar::ScalarValue;
     use crate::validity::Validity;
+
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
     pub fn count(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<usize> {
         let mut acc =
@@ -168,7 +172,7 @@ mod tests {
     fn count_all_valid() -> VortexResult<()> {
         let array =
             PrimitiveArray::new(buffer![1i32, 2, 3, 4, 5], Validity::NonNullable).into_array();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(count(&array, &mut ctx)?, 5);
         Ok(())
     }
@@ -177,7 +181,7 @@ mod tests {
     fn count_with_nulls() -> VortexResult<()> {
         let array = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), None, Some(5)])
             .into_array();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(count(&array, &mut ctx)?, 3);
         Ok(())
     }
@@ -185,7 +189,7 @@ mod tests {
     #[test]
     fn count_all_null() -> VortexResult<()> {
         let array = PrimitiveArray::from_option_iter::<i32, _>([None, None, None]).into_array();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(count(&array, &mut ctx)?, 0);
         Ok(())
     }
@@ -201,7 +205,7 @@ mod tests {
 
     #[test]
     fn count_multi_batch() -> VortexResult<()> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::Nullable);
         let mut acc = Accumulator::try_new(Count, SkipNansOptions::default(), dtype)?;
 
@@ -218,7 +222,7 @@ mod tests {
 
     #[test]
     fn count_finish_resets_state() -> VortexResult<()> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::Nullable);
         let mut acc = Accumulator::try_new(Count, SkipNansOptions::default(), dtype)?;
 
@@ -270,7 +274,7 @@ mod tests {
         let array =
             PrimitiveArray::from_option_iter([Some(1.0f64), Some(f64::NAN), None, Some(3.0)])
                 .into_array();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(count(&array, &mut ctx)?, 2);
         Ok(())
     }
@@ -280,9 +284,9 @@ mod tests {
         let array =
             PrimitiveArray::from_option_iter([Some(1.0f64), Some(f64::NAN), None, Some(3.0)])
                 .into_array();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(
-            count_with_options(&array, &mut ctx, SkipNansOptions { skip_nans: false })?,
+            count_with_options(&array, &mut ctx, SkipNansOptions::include())?,
             3
         );
         Ok(())
@@ -297,7 +301,7 @@ mod tests {
         array
             .statistics()
             .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(3u64)));
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(count(&array, &mut ctx)?, 1);
         Ok(())
     }
@@ -305,10 +309,10 @@ mod tests {
     #[test]
     fn count_constant_nan() -> VortexResult<()> {
         let array = ConstantArray::new(f64::NAN, 5).into_array();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(count(&array, &mut ctx)?, 0);
         assert_eq!(
-            count_with_options(&array, &mut ctx, SkipNansOptions { skip_nans: false })?,
+            count_with_options(&array, &mut ctx, SkipNansOptions::include())?,
             5
         );
         Ok(())
@@ -317,7 +321,7 @@ mod tests {
     #[test]
     fn count_constant_non_null() -> VortexResult<()> {
         let array = ConstantArray::new(42i32, 10);
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(count(&array.into_array(), &mut ctx)?, 10);
         Ok(())
     }
@@ -328,7 +332,7 @@ mod tests {
             Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable)),
             10,
         );
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(count(&array.into_array(), &mut ctx)?, 0);
         Ok(())
     }
@@ -339,7 +343,7 @@ mod tests {
         let chunk2 = PrimitiveArray::from_option_iter([None, Some(5i32), None]);
         let dtype = chunk1.dtype().clone();
         let chunked = ChunkedArray::try_new(vec![chunk1.into_array(), chunk2.into_array()], dtype)?;
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(count(&chunked.into_array(), &mut ctx)?, 3);
         Ok(())
     }

--- a/vortex-array/src/aggregate_fn/fns/count/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/count/mod.rs
@@ -98,7 +98,7 @@ impl AggregateFnVTable for Count {
         let mut count = batch.valid_count(ctx)? as u64;
         if state.exclude_nans {
             // `nan_count` shortcircuits on an exact `Stat::NaNCount` before scanning the batch.
-            count -= nan_count(batch, ctx)? as u64;
+            count = count.saturating_sub(nan_count(batch, ctx)? as u64);
         }
         state.count += count;
         Ok(true)

--- a/vortex-array/src/aggregate_fn/fns/count/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/count/mod.rs
@@ -10,8 +10,8 @@ use crate::ArrayRef;
 use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::aggregate_fn::AggregateFnId;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnVTable;
-use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::nan_count::nan_count;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -23,7 +23,7 @@ use crate::scalar::Scalar;
 /// Applies to all types. Returns a `u64` count.
 /// The identity value is zero.
 ///
-/// For float inputs, NaN handling is controlled by [`SkipNansOptions`]: with `skip_nans` (the
+/// For float inputs, NaN handling is controlled by [`AggregateFnOpts`]: with `skip_nans` (the
 /// default) NaN values are treated as missing and excluded from the count, otherwise they are
 /// counted like any other non-null value.
 #[derive(Clone, Debug)]
@@ -37,7 +37,7 @@ pub struct CountPartial {
 }
 
 impl AggregateFnVTable for Count {
-    type Options = SkipNansOptions;
+    type Options = AggregateFnOpts;
     type Partial = CountPartial;
 
     fn id(&self) -> AggregateFnId {
@@ -136,9 +136,9 @@ mod tests {
     use crate::IntoArray;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::count::Count;
     use crate::arrays::ChunkedArray;
     use crate::arrays::ConstantArray;
@@ -156,7 +156,7 @@ mod tests {
 
     pub fn count(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<usize> {
         let mut acc =
-            Accumulator::try_new(Count, SkipNansOptions::default(), array.dtype().clone())?;
+            Accumulator::try_new(Count, AggregateFnOpts::default(), array.dtype().clone())?;
         acc.accumulate(array, ctx)?;
         let result = acc.finish()?;
 
@@ -197,7 +197,7 @@ mod tests {
     #[test]
     fn count_empty() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Count, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Count, AggregateFnOpts::default(), dtype)?;
         let result = acc.finish()?;
         assert_eq!(result.as_primitive().typed_value::<u64>(), Some(0));
         Ok(())
@@ -207,7 +207,7 @@ mod tests {
     fn count_multi_batch() -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::Nullable);
-        let mut acc = Accumulator::try_new(Count, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Count, AggregateFnOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3)]).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -224,7 +224,7 @@ mod tests {
     fn count_finish_resets_state() -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::Nullable);
-        let mut acc = Accumulator::try_new(Count, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Count, AggregateFnOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::from_option_iter([Some(1i32), None]).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -241,7 +241,7 @@ mod tests {
     #[test]
     fn count_state_merge() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut state = Count.empty_partial(&SkipNansOptions::default(), &dtype)?;
+        let mut state = Count.empty_partial(&AggregateFnOpts::default(), &dtype)?;
 
         let scalar1 = Scalar::primitive(5u64, Nullability::NonNullable);
         Count.combine_partials(&mut state, scalar1)?;
@@ -258,7 +258,7 @@ mod tests {
     fn count_with_options(
         array: &ArrayRef,
         ctx: &mut ExecutionCtx,
-        options: SkipNansOptions,
+        options: AggregateFnOpts,
     ) -> VortexResult<u64> {
         let mut acc = Accumulator::try_new(Count, options, array.dtype().clone())?;
         acc.accumulate(array, ctx)?;
@@ -286,7 +286,7 @@ mod tests {
                 .into_array();
         let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(
-            count_with_options(&array, &mut ctx, SkipNansOptions::include())?,
+            count_with_options(&array, &mut ctx, AggregateFnOpts::include_nans())?,
             3
         );
         Ok(())
@@ -312,7 +312,7 @@ mod tests {
         let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(count(&array, &mut ctx)?, 0);
         assert_eq!(
-            count_with_options(&array, &mut ctx, SkipNansOptions::include())?,
+            count_with_options(&array, &mut ctx, AggregateFnOpts::include_nans())?,
             5
         );
         Ok(())

--- a/vortex-array/src/aggregate_fn/fns/max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/max/mod.rs
@@ -10,10 +10,10 @@ use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::aggregate_fn::AggregateFnId;
-use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnSatisfaction;
 use crate::aggregate_fn::AggregateFnVTable;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::aggregate_fn::fns::bounded_max::BoundedMax;
 use crate::aggregate_fn::fns::min_max::MinMax;
 use crate::aggregate_fn::fns::min_max::min_max;
@@ -29,7 +29,7 @@ use crate::scalar::Scalar;
 
 /// Compute the maximum non-null value of an array.
 ///
-/// NaN handling for float inputs is controlled by [`AggregateFnOpts`]: with `skip_nans` (the
+/// NaN handling for float inputs is controlled by [`NumericalAggregateOpts`]: with `skip_nans` (the
 /// default) NaN values are ignored, otherwise any NaN value poisons the maximum to NaN.
 #[derive(Clone, Debug)]
 pub struct Max;
@@ -72,7 +72,7 @@ impl MaxPartial {
 }
 
 impl AggregateFnVTable for Max {
-    type Options = AggregateFnOpts;
+    type Options = NumericalAggregateOpts;
     type Partial = MaxPartial;
 
     fn id(&self) -> AggregateFnId {
@@ -88,7 +88,7 @@ impl AggregateFnVTable for Max {
         metadata: &[u8],
         _session: &VortexSession,
     ) -> VortexResult<Self::Options> {
-        AggregateFnOpts::deserialize(metadata)
+        NumericalAggregateOpts::deserialize(metadata)
     }
 
     fn return_dtype(&self, options: &Self::Options, input_dtype: &DType) -> Option<DType> {
@@ -194,7 +194,7 @@ impl AggregateFnVTable for Max {
             Columnar::Canonical(canonical) => canonical.clone().into_array(),
             Columnar::Constant(constant) => constant.clone().into_array(),
         };
-        let options = AggregateFnOpts {
+        let options = NumericalAggregateOpts {
             skip_nans: partial.skip_nans,
         };
         if let Some(result) = min_max(&array, ctx, options)? {
@@ -221,8 +221,8 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::DynAccumulator;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::max::Max;
     use crate::arrays::PrimitiveArray;
     use crate::dtype::DType;
@@ -238,7 +238,7 @@ mod tests {
     fn max_aggregate_fn() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Max, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Max, NumericalAggregateOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20, 5], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -256,7 +256,7 @@ mod tests {
     #[test]
     fn max_empty_group_returns_null() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Max, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Max, NumericalAggregateOpts::default(), dtype)?;
 
         assert_eq!(
             acc.finish()?,
@@ -269,7 +269,7 @@ mod tests {
     fn max_with_nan_not_skipping() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Max, AggregateFnOpts::include_nans(), dtype)?;
+        let mut acc = Accumulator::try_new(Max, NumericalAggregateOpts::include_nans(), dtype)?;
 
         let batch = PrimitiveArray::new(buffer![1.0f64, f64::NAN, -5.0], Validity::NonNullable)
             .into_array();
@@ -295,8 +295,11 @@ mod tests {
         batch
             .statistics()
             .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(1u64)));
-        let mut acc =
-            Accumulator::try_new(Max, AggregateFnOpts::include_nans(), batch.dtype().clone())?;
+        let mut acc = Accumulator::try_new(
+            Max,
+            NumericalAggregateOpts::include_nans(),
+            batch.dtype().clone(),
+        )?;
         acc.accumulate(&batch, &mut ctx)?;
         let result = acc.finish()?;
         assert!(
@@ -321,8 +324,11 @@ mod tests {
         array
             .statistics()
             .set(Stat::Max, Precision::Exact(ScalarValue::from(3.0f64)));
-        let mut acc =
-            Accumulator::try_new(Max, AggregateFnOpts::include_nans(), array.dtype().clone())?;
+        let mut acc = Accumulator::try_new(
+            Max,
+            NumericalAggregateOpts::include_nans(),
+            array.dtype().clone(),
+        )?;
         acc.accumulate(&array, &mut ctx)?;
         assert_eq!(
             acc.finish()?,
@@ -338,7 +344,11 @@ mod tests {
         batch
             .statistics()
             .set(Stat::Max, Precision::Exact(ScalarValue::from(25i32)));
-        let mut acc = Accumulator::try_new(Max, AggregateFnOpts::default(), batch.dtype().clone())?;
+        let mut acc = Accumulator::try_new(
+            Max,
+            NumericalAggregateOpts::default(),
+            batch.dtype().clone(),
+        )?;
 
         acc.accumulate(&batch, &mut ctx)?;
 

--- a/vortex-array/src/aggregate_fn/fns/max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/max/mod.rs
@@ -16,7 +16,7 @@ use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::bounded_max::BoundedMax;
 use crate::aggregate_fn::fns::min_max::MinMax;
-use crate::aggregate_fn::fns::min_max::min_max_with;
+use crate::aggregate_fn::fns::min_max::min_max;
 use crate::aggregate_fn::fns::min_max::nan_scalar;
 use crate::aggregate_fn::fns::min_max::scalar_is_nan;
 use crate::dtype::DType;
@@ -63,7 +63,7 @@ impl MaxPartial {
     }
 
     fn poison(&mut self) {
-        self.max = Some(nan_scalar(&self.element_dtype.as_nonnullable()));
+        self.max = Some(nan_scalar(&self.element_dtype));
     }
 
     fn is_poisoned(&self) -> bool {
@@ -166,9 +166,10 @@ impl AggregateFnVTable for Max {
         }
         match batch.statistics().get_as::<u64>(Stat::NaNCount) {
             Precision::Exact(0) => {
-                // NaN-free batch: the cached NaN-skipping maximum (if any) is valid.
+                // NaN-free batch: the cached NaN-skipping maximum (if any) is valid. `to_scalar`
+                // re-casts to the result dtype, so the cached scalar can merge as-is.
                 if let Some(max) = batch.statistics().get(Stat::Max).as_exact() {
-                    partial.merge(max.cast(&partial.element_dtype.as_nonnullable())?);
+                    partial.merge(max);
                     return Ok(true);
                 }
                 Ok(false)
@@ -196,7 +197,7 @@ impl AggregateFnVTable for Max {
         let options = SkipNansOptions {
             skip_nans: partial.skip_nans,
         };
-        if let Some(result) = min_max_with(&array, ctx, options)? {
+        if let Some(result) = min_max(&array, ctx, options)? {
             partial.merge(result.max);
         }
         Ok(())
@@ -268,7 +269,7 @@ mod tests {
     fn max_with_nan_not_skipping() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Max, SkipNansOptions { skip_nans: false }, dtype)?;
+        let mut acc = Accumulator::try_new(Max, SkipNansOptions::include(), dtype)?;
 
         let batch = PrimitiveArray::new(buffer![1.0f64, f64::NAN, -5.0], Validity::NonNullable)
             .into_array();
@@ -294,11 +295,7 @@ mod tests {
         batch
             .statistics()
             .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(1u64)));
-        let mut acc = Accumulator::try_new(
-            Max,
-            SkipNansOptions { skip_nans: false },
-            batch.dtype().clone(),
-        )?;
+        let mut acc = Accumulator::try_new(Max, SkipNansOptions::include(), batch.dtype().clone())?;
         acc.accumulate(&batch, &mut ctx)?;
         let result = acc.finish()?;
         assert!(
@@ -306,6 +303,28 @@ mod tests {
                 .as_primitive()
                 .typed_value::<f64>()
                 .is_some_and(f64::is_nan)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn max_nan_including_nullable_cached_stat() -> VortexResult<()> {
+        // A nullable float array's cached Max stat is reconstructed as a nullable scalar. The
+        // NaN-including shortcircuit merges it as-is; `to_scalar` re-casts to the result dtype.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array =
+            PrimitiveArray::from_option_iter([Some(1.0f64), Some(2.0), Some(3.0)]).into_array();
+        array
+            .statistics()
+            .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(0u64)));
+        array
+            .statistics()
+            .set(Stat::Max, Precision::Exact(ScalarValue::from(3.0f64)));
+        let mut acc = Accumulator::try_new(Max, SkipNansOptions::include(), array.dtype().clone())?;
+        acc.accumulate(&array, &mut ctx)?;
+        assert_eq!(
+            acc.finish()?,
+            Scalar::primitive(3.0f64, Nullability::Nullable)
         );
         Ok(())
     }

--- a/vortex-array/src/aggregate_fn/fns/max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/max/mod.rs
@@ -13,15 +13,24 @@ use crate::aggregate_fn::AggregateFnId;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnSatisfaction;
 use crate::aggregate_fn::AggregateFnVTable;
-use crate::aggregate_fn::EmptyOptions;
+use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::bounded_max::BoundedMax;
 use crate::aggregate_fn::fns::min_max::MinMax;
-use crate::aggregate_fn::fns::min_max::min_max;
+use crate::aggregate_fn::fns::min_max::min_max_with;
+use crate::aggregate_fn::fns::min_max::nan_scalar;
+use crate::aggregate_fn::fns::min_max::scalar_is_nan;
 use crate::dtype::DType;
+use crate::expr::stats::Precision;
+use crate::expr::stats::Stat;
+use crate::expr::stats::StatsProvider;
+use crate::expr::stats::StatsProviderExt;
 use crate::partial_ord::partial_max;
 use crate::scalar::Scalar;
 
 /// Compute the maximum non-null value of an array.
+///
+/// NaN handling for float inputs is controlled by [`SkipNansOptions`]: with `skip_nans` (the
+/// default) NaN values are ignored, otherwise any NaN value poisons the maximum to NaN.
 #[derive(Clone, Debug)]
 pub struct Max;
 
@@ -29,6 +38,7 @@ pub struct Max;
 pub struct MaxPartial {
     max: Option<Scalar>,
     element_dtype: DType,
+    skip_nans: bool,
 }
 
 impl MaxPartial {
@@ -37,15 +47,32 @@ impl MaxPartial {
             return;
         }
 
+        // NaN scalars are incomparable under `partial_max`; they poison the maximum when NaNs
+        // participate, and are dropped when they are skipped.
+        if scalar_is_nan(&max) || self.is_poisoned() {
+            if !self.skip_nans {
+                self.poison();
+            }
+            return;
+        }
+
         self.max = Some(match self.max.take() {
             Some(current) => partial_max(max, current).vortex_expect("incomparable max scalars"),
             None => max,
         });
     }
+
+    fn poison(&mut self) {
+        self.max = Some(nan_scalar(&self.element_dtype.as_nonnullable()));
+    }
+
+    fn is_poisoned(&self) -> bool {
+        self.max.as_ref().is_some_and(scalar_is_nan)
+    }
 }
 
 impl AggregateFnVTable for Max {
-    type Options = EmptyOptions;
+    type Options = SkipNansOptions;
     type Partial = MaxPartial;
 
     fn id(&self) -> AggregateFnId {
@@ -64,20 +91,24 @@ impl AggregateFnVTable for Max {
         Ok(EmptyOptions)
     }
 
-    fn return_dtype(&self, _options: &Self::Options, input_dtype: &DType) -> Option<DType> {
+    fn return_dtype(&self, options: &Self::Options, input_dtype: &DType) -> Option<DType> {
         MinMax
-            .return_dtype(&EmptyOptions, input_dtype)
+            .return_dtype(options, input_dtype)
             .map(|_| input_dtype.as_nullable())
     }
 
     fn can_satisfy(
         &self,
-        _options: &Self::Options,
+        options: &Self::Options,
         requested: &AggregateFnRef,
     ) -> AggregateFnSatisfaction {
-        if requested.is::<Self>() {
+        if requested
+            .as_opt::<Self>()
+            .is_some_and(|other| other == options)
+        {
             AggregateFnSatisfaction::Exact
-        } else if requested.is::<BoundedMax>() {
+        } else if requested.is::<BoundedMax>() && options.skip_nans {
+            // A NaN-including maximum may be NaN, which is not a usable upper bound.
             AggregateFnSatisfaction::Approximate
         } else {
             AggregateFnSatisfaction::No
@@ -90,12 +121,13 @@ impl AggregateFnVTable for Max {
 
     fn empty_partial(
         &self,
-        _options: &Self::Options,
+        options: &Self::Options,
         input_dtype: &DType,
     ) -> VortexResult<Self::Partial> {
         Ok(MaxPartial {
             max: None,
             element_dtype: input_dtype.clone(),
+            skip_nans: options.skip_nans,
         })
     }
 
@@ -116,8 +148,37 @@ impl AggregateFnVTable for Max {
         partial.max = None;
     }
 
-    fn is_saturated(&self, _partial: &Self::Partial) -> bool {
-        false
+    fn is_saturated(&self, partial: &Self::Partial) -> bool {
+        // A poisoned NaN-including maximum is fully determined.
+        partial.is_poisoned()
+    }
+
+    fn try_accumulate(
+        &self,
+        partial: &mut Self::Partial,
+        batch: &ArrayRef,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<bool> {
+        // NaN-aware shortcircuits only apply to the NaN-including float maximum; everything else
+        // takes the default dispatch path.
+        if partial.skip_nans || !partial.element_dtype.is_float() {
+            return Ok(false);
+        }
+        match batch.statistics().get_as::<u64>(Stat::NaNCount) {
+            Precision::Exact(0) => {
+                // NaN-free batch: the cached NaN-skipping maximum (if any) is valid.
+                if let Some(max) = batch.statistics().get(Stat::Max).as_exact() {
+                    partial.merge(max.cast(&partial.element_dtype.as_nonnullable())?);
+                    return Ok(true);
+                }
+                Ok(false)
+            }
+            Precision::Exact(_) => {
+                partial.poison();
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
     }
 
     fn accumulate(
@@ -132,7 +193,10 @@ impl AggregateFnVTable for Max {
             Columnar::Canonical(canonical) => canonical.clone().into_array(),
             Columnar::Constant(constant) => constant.clone().into_array(),
         };
-        if let Some(result) = min_max(&array, ctx)? {
+        let options = SkipNansOptions {
+            skip_nans: partial.skip_nans,
+        };
+        if let Some(result) = min_max_with(&array, ctx, options)? {
             partial.merge(result.max);
         }
         Ok(())
@@ -157,7 +221,7 @@ mod tests {
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::EmptyOptions;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::max::Max;
     use crate::arrays::PrimitiveArray;
     use crate::dtype::DType;
@@ -173,7 +237,7 @@ mod tests {
     fn max_aggregate_fn() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Max, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(Max, SkipNansOptions::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20, 5], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -191,11 +255,57 @@ mod tests {
     #[test]
     fn max_empty_group_returns_null() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Max, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(Max, SkipNansOptions::default(), dtype)?;
 
         assert_eq!(
             acc.finish()?,
             Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn max_with_nan_not_skipping() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
+        let mut acc = Accumulator::try_new(Max, SkipNansOptions { skip_nans: false }, dtype)?;
+
+        let batch = PrimitiveArray::new(buffer![1.0f64, f64::NAN, -5.0], Validity::NonNullable)
+            .into_array();
+        acc.accumulate(&batch, &mut ctx)?;
+        assert!(acc.is_saturated());
+
+        let result = acc.finish()?;
+        assert!(
+            result
+                .as_primitive()
+                .typed_value::<f64>()
+                .is_some_and(f64::is_nan)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn max_not_skipping_shortcircuits_on_exact_nan_count_stat() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        // The array has no NaNs; a planted exact NaNCount stat proves the poisoning came from
+        // the stat rather than a scan.
+        let batch = PrimitiveArray::new(buffer![1.0f64, 2.0], Validity::NonNullable).into_array();
+        batch
+            .statistics()
+            .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(1u64)));
+        let mut acc = Accumulator::try_new(
+            Max,
+            SkipNansOptions { skip_nans: false },
+            batch.dtype().clone(),
+        )?;
+        acc.accumulate(&batch, &mut ctx)?;
+        let result = acc.finish()?;
+        assert!(
+            result
+                .as_primitive()
+                .typed_value::<f64>()
+                .is_some_and(f64::is_nan)
         );
         Ok(())
     }
@@ -207,7 +317,7 @@ mod tests {
         batch
             .statistics()
             .set(Stat::Max, Precision::Exact(ScalarValue::from(25i32)));
-        let mut acc = Accumulator::try_new(Max, EmptyOptions, batch.dtype().clone())?;
+        let mut acc = Accumulator::try_new(Max, SkipNansOptions::default(), batch.dtype().clone())?;
 
         acc.accumulate(&batch, &mut ctx)?;
 

--- a/vortex-array/src/aggregate_fn/fns/max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/max/mod.rs
@@ -10,10 +10,10 @@ use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::aggregate_fn::AggregateFnId;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnSatisfaction;
 use crate::aggregate_fn::AggregateFnVTable;
-use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::bounded_max::BoundedMax;
 use crate::aggregate_fn::fns::min_max::MinMax;
 use crate::aggregate_fn::fns::min_max::min_max;
@@ -29,7 +29,7 @@ use crate::scalar::Scalar;
 
 /// Compute the maximum non-null value of an array.
 ///
-/// NaN handling for float inputs is controlled by [`SkipNansOptions`]: with `skip_nans` (the
+/// NaN handling for float inputs is controlled by [`AggregateFnOpts`]: with `skip_nans` (the
 /// default) NaN values are ignored, otherwise any NaN value poisons the maximum to NaN.
 #[derive(Clone, Debug)]
 pub struct Max;
@@ -72,7 +72,7 @@ impl MaxPartial {
 }
 
 impl AggregateFnVTable for Max {
-    type Options = SkipNansOptions;
+    type Options = AggregateFnOpts;
     type Partial = MaxPartial;
 
     fn id(&self) -> AggregateFnId {
@@ -80,7 +80,7 @@ impl AggregateFnVTable for Max {
     }
 
     fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
-        Ok(Some(vec![options.skip_nans as u8]))
+        Ok(Some(options.serialize()))
     }
 
     fn deserialize(
@@ -88,10 +88,7 @@ impl AggregateFnVTable for Max {
         metadata: &[u8],
         _session: &VortexSession,
     ) -> VortexResult<Self::Options> {
-        // A single byte encodes `skip_nans`; missing metadata defaults to skipping NaNs.
-        Ok(SkipNansOptions {
-            skip_nans: metadata.first().is_none_or(|&b| b != 0),
-        })
+        AggregateFnOpts::deserialize(metadata)
     }
 
     fn return_dtype(&self, options: &Self::Options, input_dtype: &DType) -> Option<DType> {
@@ -197,7 +194,7 @@ impl AggregateFnVTable for Max {
             Columnar::Canonical(canonical) => canonical.clone().into_array(),
             Columnar::Constant(constant) => constant.clone().into_array(),
         };
-        let options = SkipNansOptions {
+        let options = AggregateFnOpts {
             skip_nans: partial.skip_nans,
         };
         if let Some(result) = min_max(&array, ctx, options)? {
@@ -224,8 +221,8 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::max::Max;
     use crate::arrays::PrimitiveArray;
     use crate::dtype::DType;
@@ -241,7 +238,7 @@ mod tests {
     fn max_aggregate_fn() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Max, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Max, AggregateFnOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20, 5], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -259,7 +256,7 @@ mod tests {
     #[test]
     fn max_empty_group_returns_null() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Max, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Max, AggregateFnOpts::default(), dtype)?;
 
         assert_eq!(
             acc.finish()?,
@@ -272,7 +269,7 @@ mod tests {
     fn max_with_nan_not_skipping() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Max, SkipNansOptions::include(), dtype)?;
+        let mut acc = Accumulator::try_new(Max, AggregateFnOpts::include_nans(), dtype)?;
 
         let batch = PrimitiveArray::new(buffer![1.0f64, f64::NAN, -5.0], Validity::NonNullable)
             .into_array();
@@ -298,7 +295,8 @@ mod tests {
         batch
             .statistics()
             .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(1u64)));
-        let mut acc = Accumulator::try_new(Max, SkipNansOptions::include(), batch.dtype().clone())?;
+        let mut acc =
+            Accumulator::try_new(Max, AggregateFnOpts::include_nans(), batch.dtype().clone())?;
         acc.accumulate(&batch, &mut ctx)?;
         let result = acc.finish()?;
         assert!(
@@ -323,7 +321,8 @@ mod tests {
         array
             .statistics()
             .set(Stat::Max, Precision::Exact(ScalarValue::from(3.0f64)));
-        let mut acc = Accumulator::try_new(Max, SkipNansOptions::include(), array.dtype().clone())?;
+        let mut acc =
+            Accumulator::try_new(Max, AggregateFnOpts::include_nans(), array.dtype().clone())?;
         acc.accumulate(&array, &mut ctx)?;
         assert_eq!(
             acc.finish()?,
@@ -339,7 +338,7 @@ mod tests {
         batch
             .statistics()
             .set(Stat::Max, Precision::Exact(ScalarValue::from(25i32)));
-        let mut acc = Accumulator::try_new(Max, SkipNansOptions::default(), batch.dtype().clone())?;
+        let mut acc = Accumulator::try_new(Max, AggregateFnOpts::default(), batch.dtype().clone())?;
 
         acc.accumulate(&batch, &mut ctx)?;
 

--- a/vortex-array/src/aggregate_fn/fns/max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/max/mod.rs
@@ -79,16 +79,19 @@ impl AggregateFnVTable for Max {
         AggregateFnId::new("vortex.max")
     }
 
-    fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
-        Ok(Some(vec![]))
+    fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
+        Ok(Some(vec![options.skip_nans as u8]))
     }
 
     fn deserialize(
         &self,
-        _metadata: &[u8],
+        metadata: &[u8],
         _session: &VortexSession,
     ) -> VortexResult<Self::Options> {
-        Ok(EmptyOptions)
+        // A single byte encodes `skip_nans`; missing metadata defaults to skipping NaNs.
+        Ok(SkipNansOptions {
+            skip_nans: metadata.first().is_none_or(|&b| b != 0),
+        })
     }
 
     fn return_dtype(&self, options: &Self::Options, input_dtype: &DType) -> Option<DType> {

--- a/vortex-array/src/aggregate_fn/fns/mean/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/mean/mod.rs
@@ -247,7 +247,7 @@ mod tests {
         let array =
             PrimitiveArray::new(buffer![1.0f64, f64::NAN, 3.0], Validity::NonNullable).into_array();
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let keep_nans = SkipNansOptions { skip_nans: false };
+        let keep_nans = SkipNansOptions::include();
         let mut acc = Accumulator::try_new(
             Mean::combined(),
             PairOptions(keep_nans, keep_nans),

--- a/vortex-array/src/aggregate_fn/fns/mean/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/mean/mod.rs
@@ -10,7 +10,7 @@ use crate::aggregate_fn::Accumulator;
 use crate::aggregate_fn::AggregateFnId;
 use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::DynAccumulator;
-use crate::aggregate_fn::EmptyOptions;
+use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::combined::BinaryCombined;
 use crate::aggregate_fn::combined::Combined;
 use crate::aggregate_fn::combined::CombinedOptions;
@@ -30,7 +30,7 @@ use crate::scalar_fn::fns::operators::Operator;
 pub fn mean(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
     let mut acc = Accumulator::try_new(
         Mean::combined(),
-        PairOptions(EmptyOptions, EmptyOptions),
+        PairOptions(SkipNansOptions::default(), SkipNansOptions::default()),
         array.dtype().clone(),
     )?;
     acc.accumulate(array, ctx)?;
@@ -232,6 +232,34 @@ mod tests {
     }
 
     #[test]
+    fn mean_skips_nans_by_default() -> VortexResult<()> {
+        // NaNs are excluded from both the sum and the count.
+        let array =
+            PrimitiveArray::new(buffer![1.0f64, f64::NAN, 3.0], Validity::NonNullable).into_array();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let result = mean(&array, &mut ctx)?;
+        assert_eq!(result.as_primitive().as_::<f64>(), Some(2.0));
+        Ok(())
+    }
+
+    #[test]
+    fn mean_with_nan_not_skipping() -> VortexResult<()> {
+        let array =
+            PrimitiveArray::new(buffer![1.0f64, f64::NAN, 3.0], Validity::NonNullable).into_array();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let keep_nans = SkipNansOptions { skip_nans: false };
+        let mut acc = Accumulator::try_new(
+            Mean::combined(),
+            PairOptions(keep_nans, keep_nans),
+            array.dtype().clone(),
+        )?;
+        acc.accumulate(&array, &mut ctx)?;
+        let result = acc.finish()?;
+        assert!(result.as_primitive().as_::<f64>().is_some_and(f64::is_nan));
+        Ok(())
+    }
+
+    #[test]
     fn mean_all_null_returns_nan() -> VortexResult<()> {
         let array = PrimitiveArray::from_option_iter::<f64, _>([None, None, None]).into_array();
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
@@ -246,7 +274,7 @@ mod tests {
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
         let mut acc = Accumulator::try_new(
             Mean::combined(),
-            PairOptions(EmptyOptions, EmptyOptions),
+            PairOptions(SkipNansOptions::default(), SkipNansOptions::default()),
             dtype,
         )?;
 

--- a/vortex-array/src/aggregate_fn/fns/mean/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/mean/mod.rs
@@ -8,9 +8,9 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::aggregate_fn::Accumulator;
 use crate::aggregate_fn::AggregateFnId;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::DynAccumulator;
-use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::combined::BinaryCombined;
 use crate::aggregate_fn::combined::Combined;
 use crate::aggregate_fn::combined::CombinedOptions;
@@ -30,7 +30,7 @@ use crate::scalar_fn::fns::operators::Operator;
 pub fn mean(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
     let mut acc = Accumulator::try_new(
         Mean::combined(),
-        PairOptions(SkipNansOptions::default(), SkipNansOptions::default()),
+        PairOptions(AggregateFnOpts::default(), AggregateFnOpts::default()),
         array.dtype().clone(),
     )?;
     acc.accumulate(array, ctx)?;
@@ -247,7 +247,7 @@ mod tests {
         let array =
             PrimitiveArray::new(buffer![1.0f64, f64::NAN, 3.0], Validity::NonNullable).into_array();
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let keep_nans = SkipNansOptions::include();
+        let keep_nans = AggregateFnOpts::include_nans();
         let mut acc = Accumulator::try_new(
             Mean::combined(),
             PairOptions(keep_nans, keep_nans),
@@ -274,7 +274,7 @@ mod tests {
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
         let mut acc = Accumulator::try_new(
             Mean::combined(),
-            PairOptions(SkipNansOptions::default(), SkipNansOptions::default()),
+            PairOptions(AggregateFnOpts::default(), AggregateFnOpts::default()),
             dtype,
         )?;
 

--- a/vortex-array/src/aggregate_fn/fns/mean/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/mean/mod.rs
@@ -8,9 +8,9 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::aggregate_fn::Accumulator;
 use crate::aggregate_fn::AggregateFnId;
-use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::DynAccumulator;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::aggregate_fn::combined::BinaryCombined;
 use crate::aggregate_fn::combined::Combined;
 use crate::aggregate_fn::combined::CombinedOptions;
@@ -30,7 +30,10 @@ use crate::scalar_fn::fns::operators::Operator;
 pub fn mean(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
     let mut acc = Accumulator::try_new(
         Mean::combined(),
-        PairOptions(AggregateFnOpts::default(), AggregateFnOpts::default()),
+        PairOptions(
+            NumericalAggregateOpts::default(),
+            NumericalAggregateOpts::default(),
+        ),
         array.dtype().clone(),
     )?;
     acc.accumulate(array, ctx)?;
@@ -247,7 +250,7 @@ mod tests {
         let array =
             PrimitiveArray::new(buffer![1.0f64, f64::NAN, 3.0], Validity::NonNullable).into_array();
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let keep_nans = AggregateFnOpts::include_nans();
+        let keep_nans = NumericalAggregateOpts::include_nans();
         let mut acc = Accumulator::try_new(
             Mean::combined(),
             PairOptions(keep_nans, keep_nans),
@@ -274,7 +277,10 @@ mod tests {
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
         let mut acc = Accumulator::try_new(
             Mean::combined(),
-            PairOptions(AggregateFnOpts::default(), AggregateFnOpts::default()),
+            PairOptions(
+                NumericalAggregateOpts::default(),
+                NumericalAggregateOpts::default(),
+            ),
             dtype,
         )?;
 

--- a/vortex-array/src/aggregate_fn/fns/min/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min/mod.rs
@@ -13,15 +13,24 @@ use crate::aggregate_fn::AggregateFnId;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnSatisfaction;
 use crate::aggregate_fn::AggregateFnVTable;
-use crate::aggregate_fn::EmptyOptions;
+use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::bounded_min::BoundedMin;
 use crate::aggregate_fn::fns::min_max::MinMax;
-use crate::aggregate_fn::fns::min_max::min_max;
+use crate::aggregate_fn::fns::min_max::min_max_with;
+use crate::aggregate_fn::fns::min_max::nan_scalar;
+use crate::aggregate_fn::fns::min_max::scalar_is_nan;
 use crate::dtype::DType;
+use crate::expr::stats::Precision;
+use crate::expr::stats::Stat;
+use crate::expr::stats::StatsProvider;
+use crate::expr::stats::StatsProviderExt;
 use crate::partial_ord::partial_min;
 use crate::scalar::Scalar;
 
 /// Compute the minimum non-null value of an array.
+///
+/// NaN handling for float inputs is controlled by [`SkipNansOptions`]: with `skip_nans` (the
+/// default) NaN values are ignored, otherwise any NaN value poisons the minimum to NaN.
 #[derive(Clone, Debug)]
 pub struct Min;
 
@@ -29,6 +38,7 @@ pub struct Min;
 pub struct MinPartial {
     min: Option<Scalar>,
     element_dtype: DType,
+    skip_nans: bool,
 }
 
 impl MinPartial {
@@ -37,15 +47,32 @@ impl MinPartial {
             return;
         }
 
+        // NaN scalars are incomparable under `partial_min`; they poison the minimum when NaNs
+        // participate, and are dropped when they are skipped.
+        if scalar_is_nan(&min) || self.is_poisoned() {
+            if !self.skip_nans {
+                self.poison();
+            }
+            return;
+        }
+
         self.min = Some(match self.min.take() {
             Some(current) => partial_min(min, current).vortex_expect("incomparable min scalars"),
             None => min,
         });
     }
+
+    fn poison(&mut self) {
+        self.min = Some(nan_scalar(&self.element_dtype.as_nonnullable()));
+    }
+
+    fn is_poisoned(&self) -> bool {
+        self.min.as_ref().is_some_and(scalar_is_nan)
+    }
 }
 
 impl AggregateFnVTable for Min {
-    type Options = EmptyOptions;
+    type Options = SkipNansOptions;
     type Partial = MinPartial;
 
     fn id(&self) -> AggregateFnId {
@@ -64,20 +91,24 @@ impl AggregateFnVTable for Min {
         Ok(EmptyOptions)
     }
 
-    fn return_dtype(&self, _options: &Self::Options, input_dtype: &DType) -> Option<DType> {
+    fn return_dtype(&self, options: &Self::Options, input_dtype: &DType) -> Option<DType> {
         MinMax
-            .return_dtype(&EmptyOptions, input_dtype)
+            .return_dtype(options, input_dtype)
             .map(|_| input_dtype.as_nullable())
     }
 
     fn can_satisfy(
         &self,
-        _options: &Self::Options,
+        options: &Self::Options,
         requested: &AggregateFnRef,
     ) -> AggregateFnSatisfaction {
-        if requested.is::<Self>() {
+        if requested
+            .as_opt::<Self>()
+            .is_some_and(|other| other == options)
+        {
             AggregateFnSatisfaction::Exact
-        } else if requested.is::<BoundedMin>() {
+        } else if requested.is::<BoundedMin>() && options.skip_nans {
+            // A NaN-including minimum may be NaN, which is not a usable lower bound.
             AggregateFnSatisfaction::Approximate
         } else {
             AggregateFnSatisfaction::No
@@ -90,12 +121,13 @@ impl AggregateFnVTable for Min {
 
     fn empty_partial(
         &self,
-        _options: &Self::Options,
+        options: &Self::Options,
         input_dtype: &DType,
     ) -> VortexResult<Self::Partial> {
         Ok(MinPartial {
             min: None,
             element_dtype: input_dtype.clone(),
+            skip_nans: options.skip_nans,
         })
     }
 
@@ -116,8 +148,37 @@ impl AggregateFnVTable for Min {
         partial.min = None;
     }
 
-    fn is_saturated(&self, _partial: &Self::Partial) -> bool {
-        false
+    fn is_saturated(&self, partial: &Self::Partial) -> bool {
+        // A poisoned NaN-including minimum is fully determined.
+        partial.is_poisoned()
+    }
+
+    fn try_accumulate(
+        &self,
+        partial: &mut Self::Partial,
+        batch: &ArrayRef,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<bool> {
+        // NaN-aware shortcircuits only apply to the NaN-including float minimum; everything else
+        // takes the default dispatch path.
+        if partial.skip_nans || !partial.element_dtype.is_float() {
+            return Ok(false);
+        }
+        match batch.statistics().get_as::<u64>(Stat::NaNCount) {
+            Precision::Exact(0) => {
+                // NaN-free batch: the cached NaN-skipping minimum (if any) is valid.
+                if let Some(min) = batch.statistics().get(Stat::Min).as_exact() {
+                    partial.merge(min.cast(&partial.element_dtype.as_nonnullable())?);
+                    return Ok(true);
+                }
+                Ok(false)
+            }
+            Precision::Exact(_) => {
+                partial.poison();
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
     }
 
     fn accumulate(
@@ -132,7 +193,10 @@ impl AggregateFnVTable for Min {
             Columnar::Canonical(canonical) => canonical.clone().into_array(),
             Columnar::Constant(constant) => constant.clone().into_array(),
         };
-        if let Some(result) = min_max(&array, ctx)? {
+        let options = SkipNansOptions {
+            skip_nans: partial.skip_nans,
+        };
+        if let Some(result) = min_max_with(&array, ctx, options)? {
             partial.merge(result.min);
         }
         Ok(())
@@ -157,7 +221,7 @@ mod tests {
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::EmptyOptions;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::min::Min;
     use crate::arrays::PrimitiveArray;
     use crate::dtype::DType;
@@ -173,7 +237,7 @@ mod tests {
     fn min_aggregate_fn() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Min, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(Min, SkipNansOptions::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20, 5], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -191,11 +255,57 @@ mod tests {
     #[test]
     fn min_empty_group_returns_null() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Min, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(Min, SkipNansOptions::default(), dtype)?;
 
         assert_eq!(
             acc.finish()?,
             Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn min_with_nan_not_skipping() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
+        let mut acc = Accumulator::try_new(Min, SkipNansOptions { skip_nans: false }, dtype)?;
+
+        let batch = PrimitiveArray::new(buffer![1.0f64, f64::NAN, -5.0], Validity::NonNullable)
+            .into_array();
+        acc.accumulate(&batch, &mut ctx)?;
+        assert!(acc.is_saturated());
+
+        let result = acc.finish()?;
+        assert!(
+            result
+                .as_primitive()
+                .typed_value::<f64>()
+                .is_some_and(f64::is_nan)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn min_not_skipping_shortcircuits_on_exact_nan_count_stat() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        // The array has no NaNs; a planted exact NaNCount stat proves the poisoning came from
+        // the stat rather than a scan.
+        let batch = PrimitiveArray::new(buffer![1.0f64, 2.0], Validity::NonNullable).into_array();
+        batch
+            .statistics()
+            .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(1u64)));
+        let mut acc = Accumulator::try_new(
+            Min,
+            SkipNansOptions { skip_nans: false },
+            batch.dtype().clone(),
+        )?;
+        acc.accumulate(&batch, &mut ctx)?;
+        let result = acc.finish()?;
+        assert!(
+            result
+                .as_primitive()
+                .typed_value::<f64>()
+                .is_some_and(f64::is_nan)
         );
         Ok(())
     }
@@ -207,7 +317,7 @@ mod tests {
         batch
             .statistics()
             .set(Stat::Min, Precision::Exact(ScalarValue::from(3i32)));
-        let mut acc = Accumulator::try_new(Min, EmptyOptions, batch.dtype().clone())?;
+        let mut acc = Accumulator::try_new(Min, SkipNansOptions::default(), batch.dtype().clone())?;
 
         acc.accumulate(&batch, &mut ctx)?;
 

--- a/vortex-array/src/aggregate_fn/fns/min/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min/mod.rs
@@ -10,10 +10,10 @@ use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::aggregate_fn::AggregateFnId;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnSatisfaction;
 use crate::aggregate_fn::AggregateFnVTable;
-use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::bounded_min::BoundedMin;
 use crate::aggregate_fn::fns::min_max::MinMax;
 use crate::aggregate_fn::fns::min_max::min_max;
@@ -29,7 +29,7 @@ use crate::scalar::Scalar;
 
 /// Compute the minimum non-null value of an array.
 ///
-/// NaN handling for float inputs is controlled by [`SkipNansOptions`]: with `skip_nans` (the
+/// NaN handling for float inputs is controlled by [`AggregateFnOpts`]: with `skip_nans` (the
 /// default) NaN values are ignored, otherwise any NaN value poisons the minimum to NaN.
 #[derive(Clone, Debug)]
 pub struct Min;
@@ -72,7 +72,7 @@ impl MinPartial {
 }
 
 impl AggregateFnVTable for Min {
-    type Options = SkipNansOptions;
+    type Options = AggregateFnOpts;
     type Partial = MinPartial;
 
     fn id(&self) -> AggregateFnId {
@@ -80,7 +80,7 @@ impl AggregateFnVTable for Min {
     }
 
     fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
-        Ok(Some(vec![options.skip_nans as u8]))
+        Ok(Some(options.serialize()))
     }
 
     fn deserialize(
@@ -88,10 +88,7 @@ impl AggregateFnVTable for Min {
         metadata: &[u8],
         _session: &VortexSession,
     ) -> VortexResult<Self::Options> {
-        // A single byte encodes `skip_nans`; missing metadata defaults to skipping NaNs.
-        Ok(SkipNansOptions {
-            skip_nans: metadata.first().is_none_or(|&b| b != 0),
-        })
+        AggregateFnOpts::deserialize(metadata)
     }
 
     fn return_dtype(&self, options: &Self::Options, input_dtype: &DType) -> Option<DType> {
@@ -197,7 +194,7 @@ impl AggregateFnVTable for Min {
             Columnar::Canonical(canonical) => canonical.clone().into_array(),
             Columnar::Constant(constant) => constant.clone().into_array(),
         };
-        let options = SkipNansOptions {
+        let options = AggregateFnOpts {
             skip_nans: partial.skip_nans,
         };
         if let Some(result) = min_max(&array, ctx, options)? {
@@ -224,8 +221,8 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::min::Min;
     use crate::arrays::PrimitiveArray;
     use crate::dtype::DType;
@@ -241,7 +238,7 @@ mod tests {
     fn min_aggregate_fn() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Min, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Min, AggregateFnOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20, 5], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -259,7 +256,7 @@ mod tests {
     #[test]
     fn min_empty_group_returns_null() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Min, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Min, AggregateFnOpts::default(), dtype)?;
 
         assert_eq!(
             acc.finish()?,
@@ -272,7 +269,7 @@ mod tests {
     fn min_with_nan_not_skipping() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Min, SkipNansOptions::include(), dtype)?;
+        let mut acc = Accumulator::try_new(Min, AggregateFnOpts::include_nans(), dtype)?;
 
         let batch = PrimitiveArray::new(buffer![1.0f64, f64::NAN, -5.0], Validity::NonNullable)
             .into_array();
@@ -298,7 +295,8 @@ mod tests {
         batch
             .statistics()
             .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(1u64)));
-        let mut acc = Accumulator::try_new(Min, SkipNansOptions::include(), batch.dtype().clone())?;
+        let mut acc =
+            Accumulator::try_new(Min, AggregateFnOpts::include_nans(), batch.dtype().clone())?;
         acc.accumulate(&batch, &mut ctx)?;
         let result = acc.finish()?;
         assert!(
@@ -323,7 +321,8 @@ mod tests {
         array
             .statistics()
             .set(Stat::Min, Precision::Exact(ScalarValue::from(1.0f64)));
-        let mut acc = Accumulator::try_new(Min, SkipNansOptions::include(), array.dtype().clone())?;
+        let mut acc =
+            Accumulator::try_new(Min, AggregateFnOpts::include_nans(), array.dtype().clone())?;
         acc.accumulate(&array, &mut ctx)?;
         assert_eq!(
             acc.finish()?,
@@ -339,7 +338,7 @@ mod tests {
         batch
             .statistics()
             .set(Stat::Min, Precision::Exact(ScalarValue::from(3i32)));
-        let mut acc = Accumulator::try_new(Min, SkipNansOptions::default(), batch.dtype().clone())?;
+        let mut acc = Accumulator::try_new(Min, AggregateFnOpts::default(), batch.dtype().clone())?;
 
         acc.accumulate(&batch, &mut ctx)?;
 

--- a/vortex-array/src/aggregate_fn/fns/min/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min/mod.rs
@@ -16,7 +16,7 @@ use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::bounded_min::BoundedMin;
 use crate::aggregate_fn::fns::min_max::MinMax;
-use crate::aggregate_fn::fns::min_max::min_max_with;
+use crate::aggregate_fn::fns::min_max::min_max;
 use crate::aggregate_fn::fns::min_max::nan_scalar;
 use crate::aggregate_fn::fns::min_max::scalar_is_nan;
 use crate::dtype::DType;
@@ -63,7 +63,7 @@ impl MinPartial {
     }
 
     fn poison(&mut self) {
-        self.min = Some(nan_scalar(&self.element_dtype.as_nonnullable()));
+        self.min = Some(nan_scalar(&self.element_dtype));
     }
 
     fn is_poisoned(&self) -> bool {
@@ -166,9 +166,10 @@ impl AggregateFnVTable for Min {
         }
         match batch.statistics().get_as::<u64>(Stat::NaNCount) {
             Precision::Exact(0) => {
-                // NaN-free batch: the cached NaN-skipping minimum (if any) is valid.
+                // NaN-free batch: the cached NaN-skipping minimum (if any) is valid. `to_scalar`
+                // re-casts to the result dtype, so the cached scalar can merge as-is.
                 if let Some(min) = batch.statistics().get(Stat::Min).as_exact() {
-                    partial.merge(min.cast(&partial.element_dtype.as_nonnullable())?);
+                    partial.merge(min);
                     return Ok(true);
                 }
                 Ok(false)
@@ -196,7 +197,7 @@ impl AggregateFnVTable for Min {
         let options = SkipNansOptions {
             skip_nans: partial.skip_nans,
         };
-        if let Some(result) = min_max_with(&array, ctx, options)? {
+        if let Some(result) = min_max(&array, ctx, options)? {
             partial.merge(result.min);
         }
         Ok(())
@@ -268,7 +269,7 @@ mod tests {
     fn min_with_nan_not_skipping() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Min, SkipNansOptions { skip_nans: false }, dtype)?;
+        let mut acc = Accumulator::try_new(Min, SkipNansOptions::include(), dtype)?;
 
         let batch = PrimitiveArray::new(buffer![1.0f64, f64::NAN, -5.0], Validity::NonNullable)
             .into_array();
@@ -294,11 +295,7 @@ mod tests {
         batch
             .statistics()
             .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(1u64)));
-        let mut acc = Accumulator::try_new(
-            Min,
-            SkipNansOptions { skip_nans: false },
-            batch.dtype().clone(),
-        )?;
+        let mut acc = Accumulator::try_new(Min, SkipNansOptions::include(), batch.dtype().clone())?;
         acc.accumulate(&batch, &mut ctx)?;
         let result = acc.finish()?;
         assert!(
@@ -306,6 +303,28 @@ mod tests {
                 .as_primitive()
                 .typed_value::<f64>()
                 .is_some_and(f64::is_nan)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn min_nan_including_nullable_cached_stat() -> VortexResult<()> {
+        // A nullable float array's cached Min stat is reconstructed as a nullable scalar. The
+        // NaN-including shortcircuit merges it as-is; `to_scalar` re-casts to the result dtype.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array =
+            PrimitiveArray::from_option_iter([Some(1.0f64), Some(2.0), Some(3.0)]).into_array();
+        array
+            .statistics()
+            .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(0u64)));
+        array
+            .statistics()
+            .set(Stat::Min, Precision::Exact(ScalarValue::from(1.0f64)));
+        let mut acc = Accumulator::try_new(Min, SkipNansOptions::include(), array.dtype().clone())?;
+        acc.accumulate(&array, &mut ctx)?;
+        assert_eq!(
+            acc.finish()?,
+            Scalar::primitive(1.0f64, Nullability::Nullable)
         );
         Ok(())
     }

--- a/vortex-array/src/aggregate_fn/fns/min/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min/mod.rs
@@ -10,10 +10,10 @@ use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::aggregate_fn::AggregateFnId;
-use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnSatisfaction;
 use crate::aggregate_fn::AggregateFnVTable;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::aggregate_fn::fns::bounded_min::BoundedMin;
 use crate::aggregate_fn::fns::min_max::MinMax;
 use crate::aggregate_fn::fns::min_max::min_max;
@@ -29,7 +29,7 @@ use crate::scalar::Scalar;
 
 /// Compute the minimum non-null value of an array.
 ///
-/// NaN handling for float inputs is controlled by [`AggregateFnOpts`]: with `skip_nans` (the
+/// NaN handling for float inputs is controlled by [`NumericalAggregateOpts`]: with `skip_nans` (the
 /// default) NaN values are ignored, otherwise any NaN value poisons the minimum to NaN.
 #[derive(Clone, Debug)]
 pub struct Min;
@@ -72,7 +72,7 @@ impl MinPartial {
 }
 
 impl AggregateFnVTable for Min {
-    type Options = AggregateFnOpts;
+    type Options = NumericalAggregateOpts;
     type Partial = MinPartial;
 
     fn id(&self) -> AggregateFnId {
@@ -88,7 +88,7 @@ impl AggregateFnVTable for Min {
         metadata: &[u8],
         _session: &VortexSession,
     ) -> VortexResult<Self::Options> {
-        AggregateFnOpts::deserialize(metadata)
+        NumericalAggregateOpts::deserialize(metadata)
     }
 
     fn return_dtype(&self, options: &Self::Options, input_dtype: &DType) -> Option<DType> {
@@ -194,7 +194,7 @@ impl AggregateFnVTable for Min {
             Columnar::Canonical(canonical) => canonical.clone().into_array(),
             Columnar::Constant(constant) => constant.clone().into_array(),
         };
-        let options = AggregateFnOpts {
+        let options = NumericalAggregateOpts {
             skip_nans: partial.skip_nans,
         };
         if let Some(result) = min_max(&array, ctx, options)? {
@@ -221,8 +221,8 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::DynAccumulator;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::min::Min;
     use crate::arrays::PrimitiveArray;
     use crate::dtype::DType;
@@ -238,7 +238,7 @@ mod tests {
     fn min_aggregate_fn() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Min, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Min, NumericalAggregateOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20, 5], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -256,7 +256,7 @@ mod tests {
     #[test]
     fn min_empty_group_returns_null() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Min, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Min, NumericalAggregateOpts::default(), dtype)?;
 
         assert_eq!(
             acc.finish()?,
@@ -269,7 +269,7 @@ mod tests {
     fn min_with_nan_not_skipping() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Min, AggregateFnOpts::include_nans(), dtype)?;
+        let mut acc = Accumulator::try_new(Min, NumericalAggregateOpts::include_nans(), dtype)?;
 
         let batch = PrimitiveArray::new(buffer![1.0f64, f64::NAN, -5.0], Validity::NonNullable)
             .into_array();
@@ -295,8 +295,11 @@ mod tests {
         batch
             .statistics()
             .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(1u64)));
-        let mut acc =
-            Accumulator::try_new(Min, AggregateFnOpts::include_nans(), batch.dtype().clone())?;
+        let mut acc = Accumulator::try_new(
+            Min,
+            NumericalAggregateOpts::include_nans(),
+            batch.dtype().clone(),
+        )?;
         acc.accumulate(&batch, &mut ctx)?;
         let result = acc.finish()?;
         assert!(
@@ -321,8 +324,11 @@ mod tests {
         array
             .statistics()
             .set(Stat::Min, Precision::Exact(ScalarValue::from(1.0f64)));
-        let mut acc =
-            Accumulator::try_new(Min, AggregateFnOpts::include_nans(), array.dtype().clone())?;
+        let mut acc = Accumulator::try_new(
+            Min,
+            NumericalAggregateOpts::include_nans(),
+            array.dtype().clone(),
+        )?;
         acc.accumulate(&array, &mut ctx)?;
         assert_eq!(
             acc.finish()?,
@@ -338,7 +344,11 @@ mod tests {
         batch
             .statistics()
             .set(Stat::Min, Precision::Exact(ScalarValue::from(3i32)));
-        let mut acc = Accumulator::try_new(Min, AggregateFnOpts::default(), batch.dtype().clone())?;
+        let mut acc = Accumulator::try_new(
+            Min,
+            NumericalAggregateOpts::default(),
+            batch.dtype().clone(),
+        )?;
 
         acc.accumulate(&batch, &mut ctx)?;
 

--- a/vortex-array/src/aggregate_fn/fns/min/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min/mod.rs
@@ -79,16 +79,19 @@ impl AggregateFnVTable for Min {
         AggregateFnId::new("vortex.min")
     }
 
-    fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
-        Ok(Some(vec![]))
+    fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
+        Ok(Some(vec![options.skip_nans as u8]))
     }
 
     fn deserialize(
         &self,
-        _metadata: &[u8],
+        metadata: &[u8],
         _session: &VortexSession,
     ) -> VortexResult<Self::Options> {
-        Ok(EmptyOptions)
+        // A single byte encodes `skip_nans`; missing metadata defaults to skipping NaNs.
+        Ok(SkipNansOptions {
+            skip_nans: metadata.first().is_none_or(|&b| b != 0),
+        })
     }
 
     fn return_dtype(&self, options: &Self::Options, input_dtype: &DType) -> Option<DType> {

--- a/vortex-array/src/aggregate_fn/fns/min_max/extension.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/extension.rs
@@ -7,7 +7,7 @@ use super::MinMaxPartial;
 use super::MinMaxResult;
 use super::min_max;
 use crate::ExecutionCtx;
-use crate::aggregate_fn::AggregateFnOpts;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::arrays::ExtensionArray;
 use crate::arrays::extension::ExtensionArrayExt;
 use crate::dtype::Nullability;
@@ -19,12 +19,15 @@ pub(super) fn accumulate_extension(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()> {
     let non_nullable_ext_dtype = array.ext_dtype().with_nullability(Nullability::NonNullable);
-    let local = min_max(array.storage_array(), ctx, AggregateFnOpts::default())?.map(
-        |MinMaxResult { min, max }| MinMaxResult {
-            min: Scalar::extension_ref(non_nullable_ext_dtype.clone(), min),
-            max: Scalar::extension_ref(non_nullable_ext_dtype, max),
-        },
-    );
+    let local = min_max(
+        array.storage_array(),
+        ctx,
+        NumericalAggregateOpts::default(),
+    )?
+    .map(|MinMaxResult { min, max }| MinMaxResult {
+        min: Scalar::extension_ref(non_nullable_ext_dtype.clone(), min),
+        max: Scalar::extension_ref(non_nullable_ext_dtype, max),
+    });
     partial.merge(local);
     Ok(())
 }

--- a/vortex-array/src/aggregate_fn/fns/min_max/extension.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/extension.rs
@@ -7,7 +7,7 @@ use super::MinMaxPartial;
 use super::MinMaxResult;
 use super::min_max;
 use crate::ExecutionCtx;
-use crate::aggregate_fn::SkipNansOptions;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::arrays::ExtensionArray;
 use crate::arrays::extension::ExtensionArrayExt;
 use crate::dtype::Nullability;
@@ -19,7 +19,7 @@ pub(super) fn accumulate_extension(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()> {
     let non_nullable_ext_dtype = array.ext_dtype().with_nullability(Nullability::NonNullable);
-    let local = min_max(array.storage_array(), ctx, SkipNansOptions::default())?.map(
+    let local = min_max(array.storage_array(), ctx, AggregateFnOpts::default())?.map(
         |MinMaxResult { min, max }| MinMaxResult {
             min: Scalar::extension_ref(non_nullable_ext_dtype.clone(), min),
             max: Scalar::extension_ref(non_nullable_ext_dtype, max),

--- a/vortex-array/src/aggregate_fn/fns/min_max/extension.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/extension.rs
@@ -7,6 +7,7 @@ use super::MinMaxPartial;
 use super::MinMaxResult;
 use super::min_max;
 use crate::ExecutionCtx;
+use crate::aggregate_fn::SkipNansOptions;
 use crate::arrays::ExtensionArray;
 use crate::arrays::extension::ExtensionArrayExt;
 use crate::dtype::Nullability;
@@ -18,11 +19,12 @@ pub(super) fn accumulate_extension(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()> {
     let non_nullable_ext_dtype = array.ext_dtype().with_nullability(Nullability::NonNullable);
-    let local =
-        min_max(array.storage_array(), ctx)?.map(|MinMaxResult { min, max }| MinMaxResult {
+    let local = min_max(array.storage_array(), ctx, SkipNansOptions::default())?.map(
+        |MinMaxResult { min, max }| MinMaxResult {
             min: Scalar::extension_ref(non_nullable_ext_dtype.clone(), min),
             max: Scalar::extension_ref(non_nullable_ext_dtype, max),
-        });
+        },
+    );
     partial.merge(local);
     Ok(())
 }

--- a/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
@@ -46,11 +46,40 @@ static NAMES: LazyLock<FieldNames> = LazyLock::new(|| FieldNames::from(["min", "
 
 /// The minimum and maximum non-null values of an array, or `None` if there are no non-null values.
 ///
-/// NaN values are skipped; see [`min_max_with`] for NaN-including extrema.
+/// NaN handling for float inputs is controlled by [`SkipNansOptions`]: with `skip_nans` (the
+/// default) NaN values are ignored and the cached `Stat::Min`/`Stat::Max` statistics are consulted
+/// and updated. With `skip_nans=false`, any NaN value in a float array poisons both extrema to
+/// NaN; an exact `Stat::NaNCount` statistic shortcircuits the NaN scan in either direction.
 ///
 /// The result scalars have the non-nullable version of the array dtype.
 /// This will update the stats set of the array as a side effect.
-pub fn min_max(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Option<MinMaxResult>> {
+pub fn min_max(
+    array: &ArrayRef,
+    ctx: &mut ExecutionCtx,
+    options: SkipNansOptions,
+) -> VortexResult<Option<MinMaxResult>> {
+    if !options.skip_nans && array.dtype().is_float() {
+        match array.statistics().get_as::<u64>(Stat::NaNCount) {
+            // NaN-free: identical to the NaN-skipping path below, including its stat caching.
+            Precision::Exact(0) => {}
+            // At least one NaN value poisons both extrema.
+            Precision::Exact(_) => return Ok(Some(nan_minmax_result(array.dtype()))),
+            _ => {
+                if array.is_empty() || array.valid_count(ctx)? == 0 {
+                    return Ok(None);
+                }
+                // Compute with NaN-including options; the NaN-skipping `Stat::Min`/`Stat::Max`
+                // caches are neither read nor written.
+                let mut acc = Accumulator::try_new(MinMax, options, array.dtype().clone())?;
+                acc.accumulate(array, ctx)?;
+                return MinMaxResult::from_scalar(acc.finish()?);
+            }
+        }
+    }
+
+    // NaN-skipping path. Also reached for NaN-free not-skipping float arrays and all non-float
+    // arrays, where `skip_nans` has no effect.
+
     // Short-circuit using cached array statistics.
     let cached_min = array.statistics().get(Stat::Min).as_exact();
     let cached_max = array.statistics().get(Stat::Max).as_exact();
@@ -95,38 +124,6 @@ pub fn min_max(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Option<
     Ok(result)
 }
 
-/// [`min_max`] with explicit [`SkipNansOptions`].
-///
-/// With `skip_nans` (the default) this is identical to [`min_max`]: NaN values are ignored and
-/// the cached `Stat::Min`/`Stat::Max` statistics are consulted and updated. With
-/// `skip_nans=false`, any NaN value in a float array poisons both extrema to NaN; an exact
-/// `Stat::NaNCount` statistic shortcircuits the NaN scan in either direction.
-pub fn min_max_with(
-    array: &ArrayRef,
-    ctx: &mut ExecutionCtx,
-    options: SkipNansOptions,
-) -> VortexResult<Option<MinMaxResult>> {
-    if !options.skip_nans && array.dtype().is_float() {
-        match array.statistics().get_as::<u64>(Stat::NaNCount) {
-            // NaN-free: identical to the NaN-skipping path, including its stat caching.
-            Precision::Exact(0) => {}
-            // At least one NaN value poisons both extrema.
-            Precision::Exact(_) => return Ok(Some(nan_minmax_result(array.dtype()))),
-            _ => {
-                if array.is_empty() || array.valid_count(ctx)? == 0 {
-                    return Ok(None);
-                }
-                // Compute with NaN-including options; the NaN-skipping `Stat::Min`/`Stat::Max`
-                // caches are neither read nor written.
-                let mut acc = Accumulator::try_new(MinMax, options, array.dtype().clone())?;
-                acc.accumulate(array, ctx)?;
-                return MinMaxResult::from_scalar(acc.finish()?);
-            }
-        }
-    }
-    min_max(array, ctx)
-}
-
 /// A `{min: NaN, max: NaN}` result for a poisoned NaN-including min/max over `dtype`.
 fn nan_minmax_result(dtype: &DType) -> MinMaxResult {
     let nan = nan_scalar(dtype);
@@ -138,14 +135,11 @@ fn nan_minmax_result(dtype: &DType) -> MinMaxResult {
 
 /// A non-nullable NaN scalar of the float `dtype`.
 pub(crate) fn nan_scalar(dtype: &DType) -> Scalar {
-    let DType::Primitive(ptype, _) = dtype else {
-        vortex_panic!("NaN scalar requested for non-primitive dtype {}", dtype);
-    };
-    match ptype {
+    match dtype.as_ptype() {
         PType::F16 => Scalar::primitive(f16::NAN, Nullability::NonNullable),
         PType::F32 => Scalar::primitive(f32::NAN, Nullability::NonNullable),
         PType::F64 => Scalar::primitive(f64::NAN, Nullability::NonNullable),
-        _ => vortex_panic!("NaN scalar requested for non-float dtype {}", dtype),
+        _ => vortex_panic!("NaN scalar requested for non-float dtype {dtype}"),
     }
 }
 
@@ -228,7 +222,7 @@ impl MinMaxPartial {
 
     /// Poison the partial state to `{min: NaN, max: NaN}`.
     fn poison(&mut self) {
-        let nan = nan_scalar(&self.element_dtype.as_nonnullable());
+        let nan = nan_scalar(&self.element_dtype);
         self.min = Some(nan.clone());
         self.max = Some(nan);
     }
@@ -359,6 +353,8 @@ impl AggregateFnVTable for MinMax {
                 let cached_min = batch.statistics().get(Stat::Min).as_exact();
                 let cached_max = batch.statistics().get(Stat::Max).as_exact();
                 if let Some((min, max)) = cached_min.zip(cached_max) {
+                    // Cached float stats carry the (possibly nullable) array dtype; `to_scalar`
+                    // builds a struct with non-nullable fields, so normalise here.
                     let non_nullable_dtype = partial.element_dtype.as_nonnullable();
                     partial.merge(Some(MinMaxResult {
                         min: min.cast(&non_nullable_dtype)?,
@@ -433,14 +429,15 @@ impl AggregateFnVTable for MinMax {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::sync::LazyLock;
 
     use vortex_buffer::BitBuffer;
     use vortex_buffer::buffer;
     use vortex_error::VortexExpect;
     use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
 
     use crate::IntoArray as _;
-    use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
     use crate::aggregate_fn::AggregateFnVTable;
@@ -450,7 +447,6 @@ mod tests {
     use crate::aggregate_fn::fns::min_max::MinMaxResult;
     use crate::aggregate_fn::fns::min_max::make_minmax_dtype;
     use crate::aggregate_fn::fns::min_max::min_max;
-    use crate::aggregate_fn::fns::min_max::min_max_with;
     use crate::arrays::BoolArray;
     use crate::arrays::ChunkedArray;
     use crate::arrays::ConstantArray;
@@ -471,12 +467,14 @@ mod tests {
     use crate::scalar::ScalarValue;
     use crate::validity::Validity;
 
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+
     #[test]
     fn test_prim_min_max() -> VortexResult<()> {
         let p = PrimitiveArray::new(buffer![1, 2, 3], Validity::NonNullable).into_array();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(
-            min_max(&p, &mut ctx)?,
+            min_max(&p, &mut ctx, SkipNansOptions::default())?,
             Some(MinMaxResult {
                 min: 1.into(),
                 max: 3.into()
@@ -500,9 +498,9 @@ mod tests {
             Some(7),
         ])
         .into_array();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(
-            min_max(&p, &mut ctx)?,
+            min_max(&p, &mut ctx, SkipNansOptions::default())?,
             Some(MinMaxResult {
                 min: 1.into(),
                 max: 9.into()
@@ -513,7 +511,7 @@ mod tests {
 
     #[test]
     fn test_bool_min_max() -> VortexResult<()> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
 
         let all_true = BoolArray::new(
             BitBuffer::from([true, true, true].as_slice()),
@@ -521,7 +519,7 @@ mod tests {
         )
         .into_array();
         assert_eq!(
-            min_max(&all_true, &mut ctx)?,
+            min_max(&all_true, &mut ctx, SkipNansOptions::default())?,
             Some(MinMaxResult {
                 min: true.into(),
                 max: true.into()
@@ -534,7 +532,7 @@ mod tests {
         )
         .into_array();
         assert_eq!(
-            min_max(&all_false, &mut ctx)?,
+            min_max(&all_false, &mut ctx, SkipNansOptions::default())?,
             Some(MinMaxResult {
                 min: false.into(),
                 max: false.into()
@@ -547,7 +545,7 @@ mod tests {
         )
         .into_array();
         assert_eq!(
-            min_max(&mixed, &mut ctx)?,
+            min_max(&mixed, &mut ctx, SkipNansOptions::default())?,
             Some(MinMaxResult {
                 min: false.into(),
                 max: true.into()
@@ -559,8 +557,8 @@ mod tests {
     #[test]
     fn test_null_array() -> VortexResult<()> {
         let p = NullArray::new(1).into_array();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        assert_eq!(min_max(&p, &mut ctx)?, None);
+        let mut ctx = SESSION.create_execution_ctx();
+        assert_eq!(min_max(&p, &mut ctx, SkipNansOptions::default())?, None);
         Ok(())
     }
 
@@ -570,8 +568,9 @@ mod tests {
             buffer![f32::NAN, -f32::NAN, -1.0, 1.0],
             Validity::NonNullable,
         );
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let result = min_max(&array.into_array(), &mut ctx)?.vortex_expect("should have result");
+        let mut ctx = SESSION.create_execution_ctx();
+        let result = min_max(&array.into_array(), &mut ctx, SkipNansOptions::default())?
+            .vortex_expect("should have result");
         assert_eq!(f32::try_from(&result.min)?, -1.0);
         assert_eq!(f32::try_from(&result.max)?, 1.0);
         Ok(())
@@ -583,8 +582,9 @@ mod tests {
             buffer![f32::INFINITY, f32::NEG_INFINITY, -1.0, 1.0],
             Validity::NonNullable,
         );
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let result = min_max(&array.into_array(), &mut ctx)?.vortex_expect("should have result");
+        let mut ctx = SESSION.create_execution_ctx();
+        let result = min_max(&array.into_array(), &mut ctx, SkipNansOptions::default())?
+            .vortex_expect("should have result");
         assert_eq!(f32::try_from(&result.min)?, f32::NEG_INFINITY);
         assert_eq!(f32::try_from(&result.max)?, f32::INFINITY);
         Ok(())
@@ -592,7 +592,7 @@ mod tests {
 
     #[test]
     fn test_multi_batch() -> VortexResult<()> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
         let mut acc = Accumulator::try_new(MinMax, SkipNansOptions::default(), dtype)?;
 
@@ -610,7 +610,7 @@ mod tests {
 
     #[test]
     fn test_finish_resets_state() -> VortexResult<()> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
         let mut acc = Accumulator::try_new(MinMax, SkipNansOptions::default(), dtype)?;
 
@@ -654,12 +654,12 @@ mod tests {
     fn test_constant_nan() -> VortexResult<()> {
         let scalar = Scalar::primitive(f16::NAN, Nullability::NonNullable);
         let array = ConstantArray::new(scalar, 2).into_array();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        assert_eq!(min_max(&array, &mut ctx)?, None);
+        let mut ctx = SESSION.create_execution_ctx();
+        assert_eq!(min_max(&array, &mut ctx, SkipNansOptions::default())?, None);
         Ok(())
     }
 
-    const KEEP_NANS: SkipNansOptions = SkipNansOptions { skip_nans: false };
+    const KEEP_NANS: SkipNansOptions = SkipNansOptions::include();
 
     fn assert_poisoned(result: Option<MinMaxResult>) -> VortexResult<()> {
         let result = result.vortex_expect("should have result");
@@ -675,16 +675,16 @@ mod tests {
             Validity::NonNullable,
         )
         .into_array();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        assert_poisoned(min_max_with(&array, &mut ctx, KEEP_NANS)?)
+        let mut ctx = SESSION.create_execution_ctx();
+        assert_poisoned(min_max(&array, &mut ctx, KEEP_NANS)?)
     }
 
     #[test]
     fn test_prim_no_nan_not_skipping() -> VortexResult<()> {
         let array =
             PrimitiveArray::new(buffer![3.0f32, -1.0, 1.0], Validity::NonNullable).into_array();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let result = min_max_with(&array, &mut ctx, KEEP_NANS)?.vortex_expect("should have result");
+        let mut ctx = SESSION.create_execution_ctx();
+        let result = min_max(&array, &mut ctx, KEEP_NANS)?.vortex_expect("should have result");
         assert_eq!(f32::try_from(&result.min)?, -1.0);
         assert_eq!(f32::try_from(&result.max)?, 3.0);
         Ok(())
@@ -694,8 +694,8 @@ mod tests {
     fn test_constant_nan_not_skipping() -> VortexResult<()> {
         let scalar = Scalar::primitive(f64::NAN, Nullability::NonNullable);
         let array = ConstantArray::new(scalar, 2).into_array();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        assert_poisoned(min_max_with(&array, &mut ctx, KEEP_NANS)?)
+        let mut ctx = SESSION.create_execution_ctx();
+        assert_poisoned(min_max(&array, &mut ctx, KEEP_NANS)?)
     }
 
     #[test]
@@ -707,8 +707,8 @@ mod tests {
         array
             .statistics()
             .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(2u64)));
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        assert_poisoned(min_max_with(&array, &mut ctx, KEEP_NANS)?)
+        let mut ctx = SESSION.create_execution_ctx();
+        assert_poisoned(min_max(&array, &mut ctx, KEEP_NANS)?)
     }
 
     #[test]
@@ -725,16 +725,42 @@ mod tests {
         array
             .statistics()
             .set(Stat::Max, Precision::Exact(ScalarValue::from(10.0f64)));
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let result = min_max_with(&array, &mut ctx, KEEP_NANS)?.vortex_expect("should have result");
+        let mut ctx = SESSION.create_execution_ctx();
+        let result = min_max(&array, &mut ctx, KEEP_NANS)?.vortex_expect("should have result");
         assert_eq!(f64::try_from(&result.min)?, -10.0);
         assert_eq!(f64::try_from(&result.max)?, 10.0);
         Ok(())
     }
 
     #[test]
+    fn test_accumulator_nan_including_nullable_cached_stats() -> VortexResult<()> {
+        // A nullable float array's cached Min/Max stats are reconstructed as nullable scalars.
+        // The NaN-including accumulator shortcircuit must normalise them to the non-nullable
+        // struct field dtype before building the result scalar.
+        let mut ctx = SESSION.create_execution_ctx();
+        let array =
+            PrimitiveArray::from_option_iter([Some(1.0f64), Some(2.0), Some(3.0)]).into_array();
+        array
+            .statistics()
+            .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(0u64)));
+        array
+            .statistics()
+            .set(Stat::Min, Precision::Exact(ScalarValue::from(1.0f64)));
+        array
+            .statistics()
+            .set(Stat::Max, Precision::Exact(ScalarValue::from(3.0f64)));
+
+        let mut acc = Accumulator::try_new(MinMax, KEEP_NANS, array.dtype().clone())?;
+        acc.accumulate(&array, &mut ctx)?;
+        let result = MinMaxResult::from_scalar(acc.finish()?)?.vortex_expect("should have result");
+        assert_eq!(f64::try_from(&result.min)?, 1.0);
+        assert_eq!(f64::try_from(&result.max)?, 3.0);
+        Ok(())
+    }
+
+    #[test]
     fn test_multi_batch_nan_poisoning() -> VortexResult<()> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
         let mut acc = Accumulator::try_new(MinMax, KEEP_NANS, dtype)?;
 
@@ -755,8 +781,9 @@ mod tests {
         let chunk2 = PrimitiveArray::from_option_iter([Some(10i32), Some(3), None]);
         let dtype = chunk1.dtype().clone();
         let chunked = ChunkedArray::try_new(vec![chunk1.into_array(), chunk2.into_array()], dtype)?;
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let result = min_max(&chunked.into_array(), &mut ctx)?.vortex_expect("should have result");
+        let mut ctx = SESSION.create_execution_ctx();
+        let result = min_max(&chunked.into_array(), &mut ctx, SkipNansOptions::default())?
+            .vortex_expect("should have result");
         assert_eq!(result.min, Scalar::from(1i32));
         assert_eq!(result.max, Scalar::from(10i32));
         Ok(())
@@ -765,8 +792,11 @@ mod tests {
     #[test]
     fn test_all_null() -> VortexResult<()> {
         let p = PrimitiveArray::from_option_iter::<i32, _>([None, None, None]);
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        assert_eq!(min_max(&p.into_array(), &mut ctx)?, None);
+        let mut ctx = SESSION.create_execution_ctx();
+        assert_eq!(
+            min_max(&p.into_array(), &mut ctx, SkipNansOptions::default())?,
+            None
+        );
         Ok(())
     }
 
@@ -781,8 +811,9 @@ mod tests {
             ],
             DType::Utf8(Nullability::Nullable),
         );
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let result = min_max(&array.into_array(), &mut ctx)?.vortex_expect("should have result");
+        let mut ctx = SESSION.create_execution_ctx();
+        let result = min_max(&array.into_array(), &mut ctx, SkipNansOptions::default())?
+            .vortex_expect("should have result");
         assert_eq!(
             result.min,
             Scalar::utf8("hello world", Nullability::NonNullable)
@@ -804,8 +835,9 @@ mod tests {
             DecimalDType::new(4, 2),
             Validity::from_iter([true, false, true]),
         );
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let result = min_max(&decimal.into_array(), &mut ctx)?.vortex_expect("should have result");
+        let mut ctx = SESSION.create_execution_ctx();
+        let result = min_max(&decimal.into_array(), &mut ctx, SkipNansOptions::default())?
+            .vortex_expect("should have result");
 
         let non_nullable_dtype = DType::Decimal(DecimalDType::new(4, 2), Nullability::NonNullable);
         let expected_min = Scalar::try_new(
@@ -840,7 +872,7 @@ mod tests {
 
     #[test]
     fn list_and_fixed_size_list_min_max_returns_none() -> VortexResult<()> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
 
         let list_array = ListArray::try_new(
             buffer![1i32, 2, 3].into_array(),
@@ -848,7 +880,10 @@ mod tests {
             Validity::NonNullable,
         )?
         .into_array();
-        assert_eq!(min_max(&list_array, &mut ctx)?, None);
+        assert_eq!(
+            min_max(&list_array, &mut ctx, SkipNansOptions::default())?,
+            None
+        );
 
         let fixed_size_list_array = FixedSizeListArray::try_new(
             buffer![1i32, 2, 3, 4].into_array(),
@@ -857,7 +892,10 @@ mod tests {
             2,
         )?
         .into_array();
-        assert_eq!(min_max(&fixed_size_list_array, &mut ctx)?, None);
+        assert_eq!(
+            min_max(&fixed_size_list_array, &mut ctx, SkipNansOptions::default())?,
+            None
+        );
 
         Ok(())
     }
@@ -866,11 +904,12 @@ mod tests {
 
     #[test]
     fn test_bool_with_nulls() -> VortexResult<()> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
 
         let result = min_max(
             &BoolArray::from_iter(vec![Some(true), Some(true), None, None]).into_array(),
             &mut ctx,
+            SkipNansOptions::default(),
         )?;
         assert_eq!(
             result,
@@ -883,6 +922,7 @@ mod tests {
         let result = min_max(
             &BoolArray::from_iter(vec![None, Some(true), Some(true)]).into_array(),
             &mut ctx,
+            SkipNansOptions::default(),
         )?;
         assert_eq!(
             result,
@@ -895,6 +935,7 @@ mod tests {
         let result = min_max(
             &BoolArray::from_iter(vec![None, Some(true), Some(true), None]).into_array(),
             &mut ctx,
+            SkipNansOptions::default(),
         )?;
         assert_eq!(
             result,
@@ -907,6 +948,7 @@ mod tests {
         let result = min_max(
             &BoolArray::from_iter(vec![Some(false), Some(false), None, None]).into_array(),
             &mut ctx,
+            SkipNansOptions::default(),
         )?;
         assert_eq!(
             result,
@@ -925,7 +967,7 @@ mod tests {
     /// partial state.
     #[test]
     fn test_bool_chunked_with_empty_chunk() -> VortexResult<()> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
 
         let empty = BoolArray::new(BitBuffer::from([].as_slice()), Validity::NonNullable);
         let chunk1 = BoolArray::new(
@@ -941,7 +983,7 @@ mod tests {
             DType::Bool(Nullability::NonNullable),
         )?;
 
-        let result = min_max(&chunked.into_array(), &mut ctx)?;
+        let result = min_max(&chunked.into_array(), &mut ctx, SkipNansOptions::default())?;
         assert_eq!(
             result,
             Some(MinMaxResult {
@@ -960,7 +1002,7 @@ mod tests {
     /// running min/max. Empty chunks are now skipped during chunked aggregation.
     #[test]
     fn test_chunked_with_empty_constant_chunk() -> VortexResult<()> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = SESSION.create_execution_ctx();
 
         let empty = ConstantArray::new(Scalar::primitive(u32::MAX, Nullability::NonNullable), 0)
             .into_array();
@@ -972,7 +1014,7 @@ mod tests {
         )?;
 
         assert_eq!(
-            min_max(&chunked.into_array(), &mut ctx)?,
+            min_max(&chunked.into_array(), &mut ctx, SkipNansOptions::default())?,
             Some(MinMaxResult {
                 min: Scalar::primitive(0u32, Nullability::NonNullable),
                 max: Scalar::primitive(7631471u32, Nullability::NonNullable),
@@ -987,8 +1029,11 @@ mod tests {
             vec![Option::<&str>::None, None, None],
             DType::Utf8(Nullability::Nullable),
         );
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        assert_eq!(min_max(&array.into_array(), &mut ctx)?, None);
+        let mut ctx = SESSION.create_execution_ctx();
+        assert_eq!(
+            min_max(&array.into_array(), &mut ctx, SkipNansOptions::default())?,
+            None
+        );
         Ok(())
     }
 }

--- a/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
@@ -25,9 +25,9 @@ use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::aggregate_fn::Accumulator;
 use crate::aggregate_fn::AggregateFnId;
-use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::DynAccumulator;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::dtype::DType;
 use crate::dtype::FieldNames;
 use crate::dtype::Nullability;
@@ -46,7 +46,7 @@ static NAMES: LazyLock<FieldNames> = LazyLock::new(|| FieldNames::from(["min", "
 
 /// The minimum and maximum non-null values of an array, or `None` if there are no non-null values.
 ///
-/// NaN handling for float inputs is controlled by [`AggregateFnOpts`]: with `skip_nans` (the
+/// NaN handling for float inputs is controlled by [`NumericalAggregateOpts`]: with `skip_nans` (the
 /// default) NaN values are ignored and the cached `Stat::Min`/`Stat::Max` statistics are consulted
 /// and updated. With `skip_nans=false`, any NaN value in a float array poisons both extrema to
 /// NaN; an exact `Stat::NaNCount` statistic shortcircuits the NaN scan in either direction.
@@ -56,7 +56,7 @@ static NAMES: LazyLock<FieldNames> = LazyLock::new(|| FieldNames::from(["min", "
 pub fn min_max(
     array: &ArrayRef,
     ctx: &mut ExecutionCtx,
-    options: AggregateFnOpts,
+    options: NumericalAggregateOpts,
 ) -> VortexResult<Option<MinMaxResult>> {
     if !options.skip_nans && array.dtype().is_float() {
         match array.statistics().get_as::<u64>(Stat::NaNCount) {
@@ -102,7 +102,11 @@ pub fn min_max(
     }
 
     // Compute using Accumulator<MinMax>.
-    let mut acc = Accumulator::try_new(MinMax, AggregateFnOpts::default(), array.dtype().clone())?;
+    let mut acc = Accumulator::try_new(
+        MinMax,
+        NumericalAggregateOpts::default(),
+        array.dtype().clone(),
+    )?;
     acc.accumulate(array, ctx)?;
     let result_scalar = acc.finish()?;
     let result = MinMaxResult::from_scalar(result_scalar)?;
@@ -179,7 +183,7 @@ impl MinMaxResult {
 /// Returns a nullable struct scalar `{min: T, max: T}` where `T` is the non-nullable input dtype.
 /// The struct is null when the array is empty or all-null.
 ///
-/// NaN handling for float inputs is controlled by [`AggregateFnOpts`]: with `skip_nans` (the
+/// NaN handling for float inputs is controlled by [`NumericalAggregateOpts`]: with `skip_nans` (the
 /// default) NaN values are ignored, otherwise any NaN value poisons both extrema to NaN.
 #[derive(Clone, Debug)]
 pub struct MinMax;
@@ -279,7 +283,7 @@ fn minmax_compute_supported_dtype(input_dtype: &DType) -> bool {
 }
 
 impl AggregateFnVTable for MinMax {
-    type Options = AggregateFnOpts;
+    type Options = NumericalAggregateOpts;
     type Partial = MinMaxPartial;
 
     fn id(&self) -> AggregateFnId {
@@ -440,9 +444,9 @@ mod tests {
     use crate::IntoArray as _;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::min_max::MinMax;
     use crate::aggregate_fn::fns::min_max::MinMaxResult;
     use crate::aggregate_fn::fns::min_max::make_minmax_dtype;
@@ -474,7 +478,7 @@ mod tests {
         let p = PrimitiveArray::new(buffer![1, 2, 3], Validity::NonNullable).into_array();
         let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(
-            min_max(&p, &mut ctx, AggregateFnOpts::default())?,
+            min_max(&p, &mut ctx, NumericalAggregateOpts::default())?,
             Some(MinMaxResult {
                 min: 1.into(),
                 max: 3.into()
@@ -500,7 +504,7 @@ mod tests {
         .into_array();
         let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(
-            min_max(&p, &mut ctx, AggregateFnOpts::default())?,
+            min_max(&p, &mut ctx, NumericalAggregateOpts::default())?,
             Some(MinMaxResult {
                 min: 1.into(),
                 max: 9.into()
@@ -519,7 +523,7 @@ mod tests {
         )
         .into_array();
         assert_eq!(
-            min_max(&all_true, &mut ctx, AggregateFnOpts::default())?,
+            min_max(&all_true, &mut ctx, NumericalAggregateOpts::default())?,
             Some(MinMaxResult {
                 min: true.into(),
                 max: true.into()
@@ -532,7 +536,7 @@ mod tests {
         )
         .into_array();
         assert_eq!(
-            min_max(&all_false, &mut ctx, AggregateFnOpts::default())?,
+            min_max(&all_false, &mut ctx, NumericalAggregateOpts::default())?,
             Some(MinMaxResult {
                 min: false.into(),
                 max: false.into()
@@ -545,7 +549,7 @@ mod tests {
         )
         .into_array();
         assert_eq!(
-            min_max(&mixed, &mut ctx, AggregateFnOpts::default())?,
+            min_max(&mixed, &mut ctx, NumericalAggregateOpts::default())?,
             Some(MinMaxResult {
                 min: false.into(),
                 max: true.into()
@@ -558,7 +562,10 @@ mod tests {
     fn test_null_array() -> VortexResult<()> {
         let p = NullArray::new(1).into_array();
         let mut ctx = SESSION.create_execution_ctx();
-        assert_eq!(min_max(&p, &mut ctx, AggregateFnOpts::default())?, None);
+        assert_eq!(
+            min_max(&p, &mut ctx, NumericalAggregateOpts::default())?,
+            None
+        );
         Ok(())
     }
 
@@ -569,8 +576,12 @@ mod tests {
             Validity::NonNullable,
         );
         let mut ctx = SESSION.create_execution_ctx();
-        let result = min_max(&array.into_array(), &mut ctx, AggregateFnOpts::default())?
-            .vortex_expect("should have result");
+        let result = min_max(
+            &array.into_array(),
+            &mut ctx,
+            NumericalAggregateOpts::default(),
+        )?
+        .vortex_expect("should have result");
         assert_eq!(f32::try_from(&result.min)?, -1.0);
         assert_eq!(f32::try_from(&result.max)?, 1.0);
         Ok(())
@@ -583,8 +594,12 @@ mod tests {
             Validity::NonNullable,
         );
         let mut ctx = SESSION.create_execution_ctx();
-        let result = min_max(&array.into_array(), &mut ctx, AggregateFnOpts::default())?
-            .vortex_expect("should have result");
+        let result = min_max(
+            &array.into_array(),
+            &mut ctx,
+            NumericalAggregateOpts::default(),
+        )?
+        .vortex_expect("should have result");
         assert_eq!(f32::try_from(&result.min)?, f32::NEG_INFINITY);
         assert_eq!(f32::try_from(&result.max)?, f32::INFINITY);
         Ok(())
@@ -594,7 +609,7 @@ mod tests {
     fn test_multi_batch() -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(MinMax, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(MinMax, NumericalAggregateOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20, 5], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -612,7 +627,7 @@ mod tests {
     fn test_finish_resets_state() -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(MinMax, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(MinMax, NumericalAggregateOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -631,7 +646,7 @@ mod tests {
     #[test]
     fn test_state_merge() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut state = MinMax.empty_partial(&AggregateFnOpts::default(), &dtype)?;
+        let mut state = MinMax.empty_partial(&NumericalAggregateOpts::default(), &dtype)?;
 
         let struct_dtype = make_minmax_dtype(&dtype);
         let scalar1 = Scalar::struct_(
@@ -655,11 +670,14 @@ mod tests {
         let scalar = Scalar::primitive(f16::NAN, Nullability::NonNullable);
         let array = ConstantArray::new(scalar, 2).into_array();
         let mut ctx = SESSION.create_execution_ctx();
-        assert_eq!(min_max(&array, &mut ctx, AggregateFnOpts::default())?, None);
+        assert_eq!(
+            min_max(&array, &mut ctx, NumericalAggregateOpts::default())?,
+            None
+        );
         Ok(())
     }
 
-    const KEEP_NANS: AggregateFnOpts = AggregateFnOpts::include_nans();
+    const KEEP_NANS: NumericalAggregateOpts = NumericalAggregateOpts::include_nans();
 
     fn assert_poisoned(result: Option<MinMaxResult>) -> VortexResult<()> {
         let result = result.vortex_expect("should have result");
@@ -782,8 +800,12 @@ mod tests {
         let dtype = chunk1.dtype().clone();
         let chunked = ChunkedArray::try_new(vec![chunk1.into_array(), chunk2.into_array()], dtype)?;
         let mut ctx = SESSION.create_execution_ctx();
-        let result = min_max(&chunked.into_array(), &mut ctx, AggregateFnOpts::default())?
-            .vortex_expect("should have result");
+        let result = min_max(
+            &chunked.into_array(),
+            &mut ctx,
+            NumericalAggregateOpts::default(),
+        )?
+        .vortex_expect("should have result");
         assert_eq!(result.min, Scalar::from(1i32));
         assert_eq!(result.max, Scalar::from(10i32));
         Ok(())
@@ -794,7 +816,7 @@ mod tests {
         let p = PrimitiveArray::from_option_iter::<i32, _>([None, None, None]);
         let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(
-            min_max(&p.into_array(), &mut ctx, AggregateFnOpts::default())?,
+            min_max(&p.into_array(), &mut ctx, NumericalAggregateOpts::default())?,
             None
         );
         Ok(())
@@ -812,8 +834,12 @@ mod tests {
             DType::Utf8(Nullability::Nullable),
         );
         let mut ctx = SESSION.create_execution_ctx();
-        let result = min_max(&array.into_array(), &mut ctx, AggregateFnOpts::default())?
-            .vortex_expect("should have result");
+        let result = min_max(
+            &array.into_array(),
+            &mut ctx,
+            NumericalAggregateOpts::default(),
+        )?
+        .vortex_expect("should have result");
         assert_eq!(
             result.min,
             Scalar::utf8("hello world", Nullability::NonNullable)
@@ -836,8 +862,12 @@ mod tests {
             Validity::from_iter([true, false, true]),
         );
         let mut ctx = SESSION.create_execution_ctx();
-        let result = min_max(&decimal.into_array(), &mut ctx, AggregateFnOpts::default())?
-            .vortex_expect("should have result");
+        let result = min_max(
+            &decimal.into_array(),
+            &mut ctx,
+            NumericalAggregateOpts::default(),
+        )?
+        .vortex_expect("should have result");
 
         let non_nullable_dtype = DType::Decimal(DecimalDType::new(4, 2), Nullability::NonNullable);
         let expected_min = Scalar::try_new(
@@ -861,11 +891,11 @@ mod tests {
             DType::FixedSizeList(Arc::new(element_dtype), 1, Nullability::Nullable);
 
         assert_eq!(
-            MinMax.return_dtype(&AggregateFnOpts::default(), &list_dtype),
+            MinMax.return_dtype(&NumericalAggregateOpts::default(), &list_dtype),
             Some(make_minmax_dtype(&list_dtype))
         );
         assert_eq!(
-            MinMax.return_dtype(&AggregateFnOpts::default(), &fixed_size_list_dtype),
+            MinMax.return_dtype(&NumericalAggregateOpts::default(), &fixed_size_list_dtype),
             Some(make_minmax_dtype(&fixed_size_list_dtype))
         );
     }
@@ -881,7 +911,7 @@ mod tests {
         )?
         .into_array();
         assert_eq!(
-            min_max(&list_array, &mut ctx, AggregateFnOpts::default())?,
+            min_max(&list_array, &mut ctx, NumericalAggregateOpts::default())?,
             None
         );
 
@@ -893,7 +923,11 @@ mod tests {
         )?
         .into_array();
         assert_eq!(
-            min_max(&fixed_size_list_array, &mut ctx, AggregateFnOpts::default())?,
+            min_max(
+                &fixed_size_list_array,
+                &mut ctx,
+                NumericalAggregateOpts::default()
+            )?,
             None
         );
 
@@ -909,7 +943,7 @@ mod tests {
         let result = min_max(
             &BoolArray::from_iter(vec![Some(true), Some(true), None, None]).into_array(),
             &mut ctx,
-            AggregateFnOpts::default(),
+            NumericalAggregateOpts::default(),
         )?;
         assert_eq!(
             result,
@@ -922,7 +956,7 @@ mod tests {
         let result = min_max(
             &BoolArray::from_iter(vec![None, Some(true), Some(true)]).into_array(),
             &mut ctx,
-            AggregateFnOpts::default(),
+            NumericalAggregateOpts::default(),
         )?;
         assert_eq!(
             result,
@@ -935,7 +969,7 @@ mod tests {
         let result = min_max(
             &BoolArray::from_iter(vec![None, Some(true), Some(true), None]).into_array(),
             &mut ctx,
-            AggregateFnOpts::default(),
+            NumericalAggregateOpts::default(),
         )?;
         assert_eq!(
             result,
@@ -948,7 +982,7 @@ mod tests {
         let result = min_max(
             &BoolArray::from_iter(vec![Some(false), Some(false), None, None]).into_array(),
             &mut ctx,
-            AggregateFnOpts::default(),
+            NumericalAggregateOpts::default(),
         )?;
         assert_eq!(
             result,
@@ -983,7 +1017,11 @@ mod tests {
             DType::Bool(Nullability::NonNullable),
         )?;
 
-        let result = min_max(&chunked.into_array(), &mut ctx, AggregateFnOpts::default())?;
+        let result = min_max(
+            &chunked.into_array(),
+            &mut ctx,
+            NumericalAggregateOpts::default(),
+        )?;
         assert_eq!(
             result,
             Some(MinMaxResult {
@@ -1014,7 +1052,11 @@ mod tests {
         )?;
 
         assert_eq!(
-            min_max(&chunked.into_array(), &mut ctx, AggregateFnOpts::default())?,
+            min_max(
+                &chunked.into_array(),
+                &mut ctx,
+                NumericalAggregateOpts::default()
+            )?,
             Some(MinMaxResult {
                 min: Scalar::primitive(0u32, Nullability::NonNullable),
                 max: Scalar::primitive(7631471u32, Nullability::NonNullable),
@@ -1031,7 +1073,11 @@ mod tests {
         );
         let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(
-            min_max(&array.into_array(), &mut ctx, AggregateFnOpts::default())?,
+            min_max(
+                &array.into_array(),
+                &mut ctx,
+                NumericalAggregateOpts::default()
+            )?,
             None
         );
         Ok(())

--- a/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
@@ -25,9 +25,9 @@ use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::aggregate_fn::Accumulator;
 use crate::aggregate_fn::AggregateFnId;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::DynAccumulator;
-use crate::aggregate_fn::SkipNansOptions;
 use crate::dtype::DType;
 use crate::dtype::FieldNames;
 use crate::dtype::Nullability;
@@ -46,7 +46,7 @@ static NAMES: LazyLock<FieldNames> = LazyLock::new(|| FieldNames::from(["min", "
 
 /// The minimum and maximum non-null values of an array, or `None` if there are no non-null values.
 ///
-/// NaN handling for float inputs is controlled by [`SkipNansOptions`]: with `skip_nans` (the
+/// NaN handling for float inputs is controlled by [`AggregateFnOpts`]: with `skip_nans` (the
 /// default) NaN values are ignored and the cached `Stat::Min`/`Stat::Max` statistics are consulted
 /// and updated. With `skip_nans=false`, any NaN value in a float array poisons both extrema to
 /// NaN; an exact `Stat::NaNCount` statistic shortcircuits the NaN scan in either direction.
@@ -56,7 +56,7 @@ static NAMES: LazyLock<FieldNames> = LazyLock::new(|| FieldNames::from(["min", "
 pub fn min_max(
     array: &ArrayRef,
     ctx: &mut ExecutionCtx,
-    options: SkipNansOptions,
+    options: AggregateFnOpts,
 ) -> VortexResult<Option<MinMaxResult>> {
     if !options.skip_nans && array.dtype().is_float() {
         match array.statistics().get_as::<u64>(Stat::NaNCount) {
@@ -102,7 +102,7 @@ pub fn min_max(
     }
 
     // Compute using Accumulator<MinMax>.
-    let mut acc = Accumulator::try_new(MinMax, SkipNansOptions::default(), array.dtype().clone())?;
+    let mut acc = Accumulator::try_new(MinMax, AggregateFnOpts::default(), array.dtype().clone())?;
     acc.accumulate(array, ctx)?;
     let result_scalar = acc.finish()?;
     let result = MinMaxResult::from_scalar(result_scalar)?;
@@ -179,7 +179,7 @@ impl MinMaxResult {
 /// Returns a nullable struct scalar `{min: T, max: T}` where `T` is the non-nullable input dtype.
 /// The struct is null when the array is empty or all-null.
 ///
-/// NaN handling for float inputs is controlled by [`SkipNansOptions`]: with `skip_nans` (the
+/// NaN handling for float inputs is controlled by [`AggregateFnOpts`]: with `skip_nans` (the
 /// default) NaN values are ignored, otherwise any NaN value poisons both extrema to NaN.
 #[derive(Clone, Debug)]
 pub struct MinMax;
@@ -279,7 +279,7 @@ fn minmax_compute_supported_dtype(input_dtype: &DType) -> bool {
 }
 
 impl AggregateFnVTable for MinMax {
-    type Options = SkipNansOptions;
+    type Options = AggregateFnOpts;
     type Partial = MinMaxPartial;
 
     fn id(&self) -> AggregateFnId {
@@ -440,9 +440,9 @@ mod tests {
     use crate::IntoArray as _;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::min_max::MinMax;
     use crate::aggregate_fn::fns::min_max::MinMaxResult;
     use crate::aggregate_fn::fns::min_max::make_minmax_dtype;
@@ -474,7 +474,7 @@ mod tests {
         let p = PrimitiveArray::new(buffer![1, 2, 3], Validity::NonNullable).into_array();
         let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(
-            min_max(&p, &mut ctx, SkipNansOptions::default())?,
+            min_max(&p, &mut ctx, AggregateFnOpts::default())?,
             Some(MinMaxResult {
                 min: 1.into(),
                 max: 3.into()
@@ -500,7 +500,7 @@ mod tests {
         .into_array();
         let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(
-            min_max(&p, &mut ctx, SkipNansOptions::default())?,
+            min_max(&p, &mut ctx, AggregateFnOpts::default())?,
             Some(MinMaxResult {
                 min: 1.into(),
                 max: 9.into()
@@ -519,7 +519,7 @@ mod tests {
         )
         .into_array();
         assert_eq!(
-            min_max(&all_true, &mut ctx, SkipNansOptions::default())?,
+            min_max(&all_true, &mut ctx, AggregateFnOpts::default())?,
             Some(MinMaxResult {
                 min: true.into(),
                 max: true.into()
@@ -532,7 +532,7 @@ mod tests {
         )
         .into_array();
         assert_eq!(
-            min_max(&all_false, &mut ctx, SkipNansOptions::default())?,
+            min_max(&all_false, &mut ctx, AggregateFnOpts::default())?,
             Some(MinMaxResult {
                 min: false.into(),
                 max: false.into()
@@ -545,7 +545,7 @@ mod tests {
         )
         .into_array();
         assert_eq!(
-            min_max(&mixed, &mut ctx, SkipNansOptions::default())?,
+            min_max(&mixed, &mut ctx, AggregateFnOpts::default())?,
             Some(MinMaxResult {
                 min: false.into(),
                 max: true.into()
@@ -558,7 +558,7 @@ mod tests {
     fn test_null_array() -> VortexResult<()> {
         let p = NullArray::new(1).into_array();
         let mut ctx = SESSION.create_execution_ctx();
-        assert_eq!(min_max(&p, &mut ctx, SkipNansOptions::default())?, None);
+        assert_eq!(min_max(&p, &mut ctx, AggregateFnOpts::default())?, None);
         Ok(())
     }
 
@@ -569,7 +569,7 @@ mod tests {
             Validity::NonNullable,
         );
         let mut ctx = SESSION.create_execution_ctx();
-        let result = min_max(&array.into_array(), &mut ctx, SkipNansOptions::default())?
+        let result = min_max(&array.into_array(), &mut ctx, AggregateFnOpts::default())?
             .vortex_expect("should have result");
         assert_eq!(f32::try_from(&result.min)?, -1.0);
         assert_eq!(f32::try_from(&result.max)?, 1.0);
@@ -583,7 +583,7 @@ mod tests {
             Validity::NonNullable,
         );
         let mut ctx = SESSION.create_execution_ctx();
-        let result = min_max(&array.into_array(), &mut ctx, SkipNansOptions::default())?
+        let result = min_max(&array.into_array(), &mut ctx, AggregateFnOpts::default())?
             .vortex_expect("should have result");
         assert_eq!(f32::try_from(&result.min)?, f32::NEG_INFINITY);
         assert_eq!(f32::try_from(&result.max)?, f32::INFINITY);
@@ -594,7 +594,7 @@ mod tests {
     fn test_multi_batch() -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(MinMax, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(MinMax, AggregateFnOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20, 5], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -612,7 +612,7 @@ mod tests {
     fn test_finish_resets_state() -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(MinMax, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(MinMax, AggregateFnOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -631,7 +631,7 @@ mod tests {
     #[test]
     fn test_state_merge() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut state = MinMax.empty_partial(&SkipNansOptions::default(), &dtype)?;
+        let mut state = MinMax.empty_partial(&AggregateFnOpts::default(), &dtype)?;
 
         let struct_dtype = make_minmax_dtype(&dtype);
         let scalar1 = Scalar::struct_(
@@ -655,11 +655,11 @@ mod tests {
         let scalar = Scalar::primitive(f16::NAN, Nullability::NonNullable);
         let array = ConstantArray::new(scalar, 2).into_array();
         let mut ctx = SESSION.create_execution_ctx();
-        assert_eq!(min_max(&array, &mut ctx, SkipNansOptions::default())?, None);
+        assert_eq!(min_max(&array, &mut ctx, AggregateFnOpts::default())?, None);
         Ok(())
     }
 
-    const KEEP_NANS: SkipNansOptions = SkipNansOptions::include();
+    const KEEP_NANS: AggregateFnOpts = AggregateFnOpts::include_nans();
 
     fn assert_poisoned(result: Option<MinMaxResult>) -> VortexResult<()> {
         let result = result.vortex_expect("should have result");
@@ -782,7 +782,7 @@ mod tests {
         let dtype = chunk1.dtype().clone();
         let chunked = ChunkedArray::try_new(vec![chunk1.into_array(), chunk2.into_array()], dtype)?;
         let mut ctx = SESSION.create_execution_ctx();
-        let result = min_max(&chunked.into_array(), &mut ctx, SkipNansOptions::default())?
+        let result = min_max(&chunked.into_array(), &mut ctx, AggregateFnOpts::default())?
             .vortex_expect("should have result");
         assert_eq!(result.min, Scalar::from(1i32));
         assert_eq!(result.max, Scalar::from(10i32));
@@ -794,7 +794,7 @@ mod tests {
         let p = PrimitiveArray::from_option_iter::<i32, _>([None, None, None]);
         let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(
-            min_max(&p.into_array(), &mut ctx, SkipNansOptions::default())?,
+            min_max(&p.into_array(), &mut ctx, AggregateFnOpts::default())?,
             None
         );
         Ok(())
@@ -812,7 +812,7 @@ mod tests {
             DType::Utf8(Nullability::Nullable),
         );
         let mut ctx = SESSION.create_execution_ctx();
-        let result = min_max(&array.into_array(), &mut ctx, SkipNansOptions::default())?
+        let result = min_max(&array.into_array(), &mut ctx, AggregateFnOpts::default())?
             .vortex_expect("should have result");
         assert_eq!(
             result.min,
@@ -836,7 +836,7 @@ mod tests {
             Validity::from_iter([true, false, true]),
         );
         let mut ctx = SESSION.create_execution_ctx();
-        let result = min_max(&decimal.into_array(), &mut ctx, SkipNansOptions::default())?
+        let result = min_max(&decimal.into_array(), &mut ctx, AggregateFnOpts::default())?
             .vortex_expect("should have result");
 
         let non_nullable_dtype = DType::Decimal(DecimalDType::new(4, 2), Nullability::NonNullable);
@@ -861,11 +861,11 @@ mod tests {
             DType::FixedSizeList(Arc::new(element_dtype), 1, Nullability::Nullable);
 
         assert_eq!(
-            MinMax.return_dtype(&SkipNansOptions::default(), &list_dtype),
+            MinMax.return_dtype(&AggregateFnOpts::default(), &list_dtype),
             Some(make_minmax_dtype(&list_dtype))
         );
         assert_eq!(
-            MinMax.return_dtype(&SkipNansOptions::default(), &fixed_size_list_dtype),
+            MinMax.return_dtype(&AggregateFnOpts::default(), &fixed_size_list_dtype),
             Some(make_minmax_dtype(&fixed_size_list_dtype))
         );
     }
@@ -881,7 +881,7 @@ mod tests {
         )?
         .into_array();
         assert_eq!(
-            min_max(&list_array, &mut ctx, SkipNansOptions::default())?,
+            min_max(&list_array, &mut ctx, AggregateFnOpts::default())?,
             None
         );
 
@@ -893,7 +893,7 @@ mod tests {
         )?
         .into_array();
         assert_eq!(
-            min_max(&fixed_size_list_array, &mut ctx, SkipNansOptions::default())?,
+            min_max(&fixed_size_list_array, &mut ctx, AggregateFnOpts::default())?,
             None
         );
 
@@ -909,7 +909,7 @@ mod tests {
         let result = min_max(
             &BoolArray::from_iter(vec![Some(true), Some(true), None, None]).into_array(),
             &mut ctx,
-            SkipNansOptions::default(),
+            AggregateFnOpts::default(),
         )?;
         assert_eq!(
             result,
@@ -922,7 +922,7 @@ mod tests {
         let result = min_max(
             &BoolArray::from_iter(vec![None, Some(true), Some(true)]).into_array(),
             &mut ctx,
-            SkipNansOptions::default(),
+            AggregateFnOpts::default(),
         )?;
         assert_eq!(
             result,
@@ -935,7 +935,7 @@ mod tests {
         let result = min_max(
             &BoolArray::from_iter(vec![None, Some(true), Some(true), None]).into_array(),
             &mut ctx,
-            SkipNansOptions::default(),
+            AggregateFnOpts::default(),
         )?;
         assert_eq!(
             result,
@@ -948,7 +948,7 @@ mod tests {
         let result = min_max(
             &BoolArray::from_iter(vec![Some(false), Some(false), None, None]).into_array(),
             &mut ctx,
-            SkipNansOptions::default(),
+            AggregateFnOpts::default(),
         )?;
         assert_eq!(
             result,
@@ -983,7 +983,7 @@ mod tests {
             DType::Bool(Nullability::NonNullable),
         )?;
 
-        let result = min_max(&chunked.into_array(), &mut ctx, SkipNansOptions::default())?;
+        let result = min_max(&chunked.into_array(), &mut ctx, AggregateFnOpts::default())?;
         assert_eq!(
             result,
             Some(MinMaxResult {
@@ -1014,7 +1014,7 @@ mod tests {
         )?;
 
         assert_eq!(
-            min_max(&chunked.into_array(), &mut ctx, SkipNansOptions::default())?,
+            min_max(&chunked.into_array(), &mut ctx, AggregateFnOpts::default())?,
             Some(MinMaxResult {
                 min: Scalar::primitive(0u32, Nullability::NonNullable),
                 max: Scalar::primitive(7631471u32, Nullability::NonNullable),
@@ -1031,7 +1031,7 @@ mod tests {
         );
         let mut ctx = SESSION.create_execution_ctx();
         assert_eq!(
-            min_max(&array.into_array(), &mut ctx, SkipNansOptions::default())?,
+            min_max(&array.into_array(), &mut ctx, AggregateFnOpts::default())?,
             None
         );
         Ok(())

--- a/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
@@ -12,6 +12,7 @@ use std::sync::LazyLock;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_error::vortex_panic;
 
 use self::bool::accumulate_bool;
 use self::decimal::accumulate_decimal;
@@ -26,14 +27,17 @@ use crate::aggregate_fn::Accumulator;
 use crate::aggregate_fn::AggregateFnId;
 use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::DynAccumulator;
-use crate::aggregate_fn::EmptyOptions;
+use crate::aggregate_fn::SkipNansOptions;
 use crate::dtype::DType;
 use crate::dtype::FieldNames;
 use crate::dtype::Nullability;
+use crate::dtype::PType;
 use crate::dtype::StructFields;
+use crate::dtype::half::f16;
 use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
 use crate::expr::stats::StatsProvider;
+use crate::expr::stats::StatsProviderExt;
 use crate::partial_ord::partial_max;
 use crate::partial_ord::partial_min;
 use crate::scalar::Scalar;
@@ -41,6 +45,8 @@ use crate::scalar::Scalar;
 static NAMES: LazyLock<FieldNames> = LazyLock::new(|| FieldNames::from(["min", "max"]));
 
 /// The minimum and maximum non-null values of an array, or `None` if there are no non-null values.
+///
+/// NaN values are skipped; see [`min_max_with`] for NaN-including extrema.
 ///
 /// The result scalars have the non-nullable version of the array dtype.
 /// This will update the stats set of the array as a side effect.
@@ -67,7 +73,7 @@ pub fn min_max(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Option<
     }
 
     // Compute using Accumulator<MinMax>.
-    let mut acc = Accumulator::try_new(MinMax, EmptyOptions, array.dtype().clone())?;
+    let mut acc = Accumulator::try_new(MinMax, SkipNansOptions::default(), array.dtype().clone())?;
     acc.accumulate(array, ctx)?;
     let result_scalar = acc.finish()?;
     let result = MinMaxResult::from_scalar(result_scalar)?;
@@ -87,6 +93,65 @@ pub fn min_max(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Option<
     }
 
     Ok(result)
+}
+
+/// [`min_max`] with explicit [`SkipNansOptions`].
+///
+/// With `skip_nans` (the default) this is identical to [`min_max`]: NaN values are ignored and
+/// the cached `Stat::Min`/`Stat::Max` statistics are consulted and updated. With
+/// `skip_nans=false`, any NaN value in a float array poisons both extrema to NaN; an exact
+/// `Stat::NaNCount` statistic shortcircuits the NaN scan in either direction.
+pub fn min_max_with(
+    array: &ArrayRef,
+    ctx: &mut ExecutionCtx,
+    options: SkipNansOptions,
+) -> VortexResult<Option<MinMaxResult>> {
+    if !options.skip_nans && array.dtype().is_float() {
+        match array.statistics().get_as::<u64>(Stat::NaNCount) {
+            // NaN-free: identical to the NaN-skipping path, including its stat caching.
+            Precision::Exact(0) => {}
+            // At least one NaN value poisons both extrema.
+            Precision::Exact(_) => return Ok(Some(nan_minmax_result(array.dtype()))),
+            _ => {
+                if array.is_empty() || array.valid_count(ctx)? == 0 {
+                    return Ok(None);
+                }
+                // Compute with NaN-including options; the NaN-skipping `Stat::Min`/`Stat::Max`
+                // caches are neither read nor written.
+                let mut acc = Accumulator::try_new(MinMax, options, array.dtype().clone())?;
+                acc.accumulate(array, ctx)?;
+                return MinMaxResult::from_scalar(acc.finish()?);
+            }
+        }
+    }
+    min_max(array, ctx)
+}
+
+/// A `{min: NaN, max: NaN}` result for a poisoned NaN-including min/max over `dtype`.
+fn nan_minmax_result(dtype: &DType) -> MinMaxResult {
+    let nan = nan_scalar(dtype);
+    MinMaxResult {
+        min: nan.clone(),
+        max: nan,
+    }
+}
+
+/// A non-nullable NaN scalar of the float `dtype`.
+pub(crate) fn nan_scalar(dtype: &DType) -> Scalar {
+    let DType::Primitive(ptype, _) = dtype else {
+        vortex_panic!("NaN scalar requested for non-primitive dtype {}", dtype);
+    };
+    match ptype {
+        PType::F16 => Scalar::primitive(f16::NAN, Nullability::NonNullable),
+        PType::F32 => Scalar::primitive(f32::NAN, Nullability::NonNullable),
+        PType::F64 => Scalar::primitive(f64::NAN, Nullability::NonNullable),
+        _ => vortex_panic!("NaN scalar requested for non-float dtype {}", dtype),
+    }
+}
+
+/// Whether a scalar holds a primitive float NaN value.
+pub(crate) fn scalar_is_nan(scalar: &Scalar) -> bool {
+    scalar.as_primitive_opt().is_some_and(|p| p.is_nan())
 }
 
 /// The minimum and maximum non-null values of an array.
@@ -119,6 +184,9 @@ impl MinMaxResult {
 ///
 /// Returns a nullable struct scalar `{min: T, max: T}` where `T` is the non-nullable input dtype.
 /// The struct is null when the array is empty or all-null.
+///
+/// NaN handling for float inputs is controlled by [`SkipNansOptions`]: with `skip_nans` (the
+/// default) NaN values are ignored, otherwise any NaN value poisons both extrema to NaN.
 #[derive(Clone, Debug)]
 pub struct MinMax;
 
@@ -127,6 +195,7 @@ pub struct MinMaxPartial {
     min: Option<Scalar>,
     max: Option<Scalar>,
     element_dtype: DType,
+    skip_nans: bool,
 }
 
 impl MinMaxPartial {
@@ -135,6 +204,16 @@ impl MinMaxPartial {
         let Some(MinMaxResult { min, max }) = local else {
             return;
         };
+
+        // NaN scalars are incomparable under `partial_min`/`partial_max`, so they are handled
+        // explicitly: a NaN extremum poisons the partial state when NaNs participate, and is
+        // dropped when they are skipped.
+        if scalar_is_nan(&min) || scalar_is_nan(&max) || self.is_poisoned() {
+            if !self.skip_nans {
+                self.poison();
+            }
+            return;
+        }
 
         self.min = Some(match self.min.take() {
             Some(current) => partial_min(min, current).vortex_expect("incomparable min scalars"),
@@ -145,6 +224,18 @@ impl MinMaxPartial {
             Some(current) => partial_max(max, current).vortex_expect("incomparable max scalars"),
             None => max,
         });
+    }
+
+    /// Poison the partial state to `{min: NaN, max: NaN}`.
+    fn poison(&mut self) {
+        let nan = nan_scalar(&self.element_dtype.as_nonnullable());
+        self.min = Some(nan.clone());
+        self.max = Some(nan);
+    }
+
+    /// Whether the partial state is poisoned to NaN.
+    fn is_poisoned(&self) -> bool {
+        self.min.as_ref().is_some_and(scalar_is_nan)
     }
 }
 
@@ -194,7 +285,7 @@ fn minmax_compute_supported_dtype(input_dtype: &DType) -> bool {
 }
 
 impl AggregateFnVTable for MinMax {
-    type Options = EmptyOptions;
+    type Options = SkipNansOptions;
     type Partial = MinMaxPartial;
 
     fn id(&self) -> AggregateFnId {
@@ -215,13 +306,14 @@ impl AggregateFnVTable for MinMax {
 
     fn empty_partial(
         &self,
-        _options: &Self::Options,
+        options: &Self::Options,
         input_dtype: &DType,
     ) -> VortexResult<Self::Partial> {
         Ok(MinMaxPartial {
             min: None,
             max: None,
             element_dtype: input_dtype.clone(),
+            skip_nans: options.skip_nans,
         })
     }
 
@@ -245,8 +337,44 @@ impl AggregateFnVTable for MinMax {
     }
 
     #[inline]
-    fn is_saturated(&self, _partial: &Self::Partial) -> bool {
-        false
+    fn is_saturated(&self, partial: &Self::Partial) -> bool {
+        // A poisoned NaN-including min/max is fully determined.
+        partial.is_poisoned()
+    }
+
+    fn try_accumulate(
+        &self,
+        partial: &mut Self::Partial,
+        batch: &ArrayRef,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<bool> {
+        // NaN-aware shortcircuits only apply to NaN-including float min/max; everything else
+        // takes the default dispatch path.
+        if partial.skip_nans || !partial.element_dtype.is_float() {
+            return Ok(false);
+        }
+        match batch.statistics().get_as::<u64>(Stat::NaNCount) {
+            Precision::Exact(0) => {
+                // NaN-free batch: the cached NaN-skipping extrema (if any) are valid.
+                let cached_min = batch.statistics().get(Stat::Min).as_exact();
+                let cached_max = batch.statistics().get(Stat::Max).as_exact();
+                if let Some((min, max)) = cached_min.zip(cached_max) {
+                    let non_nullable_dtype = partial.element_dtype.as_nonnullable();
+                    partial.merge(Some(MinMaxResult {
+                        min: min.cast(&non_nullable_dtype)?,
+                        max: max.cast(&non_nullable_dtype)?,
+                    }));
+                    return Ok(true);
+                }
+                Ok(false)
+            }
+            Precision::Exact(_) => {
+                // At least one NaN value poisons both extrema without scanning the batch.
+                partial.poison();
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
     }
 
     fn accumulate(
@@ -261,8 +389,11 @@ impl AggregateFnVTable for MinMax {
                 if scalar.is_null() {
                     return Ok(());
                 }
-                // Skip NaN float constants
-                if scalar.as_primitive_opt().is_some_and(|p| p.is_nan()) {
+                // NaN float constants are skipped or poison the extrema, per the options.
+                if scalar_is_nan(scalar) {
+                    if !partial.skip_nans {
+                        partial.poison();
+                    }
                     return Ok(());
                 }
                 let non_nullable_dtype = scalar.dtype().as_nonnullable();
@@ -314,11 +445,12 @@ mod tests {
     use crate::aggregate_fn::Accumulator;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::EmptyOptions;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::min_max::MinMax;
     use crate::aggregate_fn::fns::min_max::MinMaxResult;
     use crate::aggregate_fn::fns::min_max::make_minmax_dtype;
     use crate::aggregate_fn::fns::min_max::min_max;
+    use crate::aggregate_fn::fns::min_max::min_max_with;
     use crate::arrays::BoolArray;
     use crate::arrays::ChunkedArray;
     use crate::arrays::ConstantArray;
@@ -332,6 +464,8 @@ mod tests {
     use crate::dtype::DecimalDType;
     use crate::dtype::Nullability;
     use crate::dtype::PType;
+    use crate::expr::stats::Precision;
+    use crate::expr::stats::Stat;
     use crate::scalar::DecimalValue;
     use crate::scalar::Scalar;
     use crate::scalar::ScalarValue;
@@ -460,7 +594,7 @@ mod tests {
     fn test_multi_batch() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(MinMax, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(MinMax, SkipNansOptions::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20, 5], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -478,7 +612,7 @@ mod tests {
     fn test_finish_resets_state() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(MinMax, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(MinMax, SkipNansOptions::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -497,7 +631,7 @@ mod tests {
     #[test]
     fn test_state_merge() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut state = MinMax.empty_partial(&EmptyOptions, &dtype)?;
+        let mut state = MinMax.empty_partial(&SkipNansOptions::default(), &dtype)?;
 
         let struct_dtype = make_minmax_dtype(&dtype);
         let scalar1 = Scalar::struct_(
@@ -523,6 +657,96 @@ mod tests {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         assert_eq!(min_max(&array, &mut ctx)?, None);
         Ok(())
+    }
+
+    const KEEP_NANS: SkipNansOptions = SkipNansOptions { skip_nans: false };
+
+    fn assert_poisoned(result: Option<MinMaxResult>) -> VortexResult<()> {
+        let result = result.vortex_expect("should have result");
+        assert!(f64::try_from(&result.min.cast(&result.min.dtype().as_nullable())?)?.is_nan());
+        assert!(f64::try_from(&result.max.cast(&result.max.dtype().as_nullable())?)?.is_nan());
+        Ok(())
+    }
+
+    #[test]
+    fn test_prim_nan_not_skipping() -> VortexResult<()> {
+        let array = PrimitiveArray::new(
+            buffer![f32::NAN, -f32::NAN, -1.0, 1.0],
+            Validity::NonNullable,
+        )
+        .into_array();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        assert_poisoned(min_max_with(&array, &mut ctx, KEEP_NANS)?)
+    }
+
+    #[test]
+    fn test_prim_no_nan_not_skipping() -> VortexResult<()> {
+        let array =
+            PrimitiveArray::new(buffer![3.0f32, -1.0, 1.0], Validity::NonNullable).into_array();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let result = min_max_with(&array, &mut ctx, KEEP_NANS)?.vortex_expect("should have result");
+        assert_eq!(f32::try_from(&result.min)?, -1.0);
+        assert_eq!(f32::try_from(&result.max)?, 3.0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_constant_nan_not_skipping() -> VortexResult<()> {
+        let scalar = Scalar::primitive(f64::NAN, Nullability::NonNullable);
+        let array = ConstantArray::new(scalar, 2).into_array();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        assert_poisoned(min_max_with(&array, &mut ctx, KEEP_NANS)?)
+    }
+
+    #[test]
+    fn test_not_skipping_shortcircuits_on_exact_nan_count_stat() -> VortexResult<()> {
+        // The array has no NaNs; a planted exact NaNCount stat proves the poisoning came from
+        // the stat rather than a scan.
+        let array =
+            PrimitiveArray::new(buffer![1.0f64, 2.0, 3.0], Validity::NonNullable).into_array();
+        array
+            .statistics()
+            .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(2u64)));
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        assert_poisoned(min_max_with(&array, &mut ctx, KEEP_NANS)?)
+    }
+
+    #[test]
+    fn test_not_skipping_uses_cached_stats_when_nan_free() -> VortexResult<()> {
+        // With an exact NaNCount of zero, the planted exact Min/Max stats are usable as-is.
+        let array =
+            PrimitiveArray::new(buffer![1.0f64, 2.0, 3.0], Validity::NonNullable).into_array();
+        array
+            .statistics()
+            .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(0u64)));
+        array
+            .statistics()
+            .set(Stat::Min, Precision::Exact(ScalarValue::from(-10.0f64)));
+        array
+            .statistics()
+            .set(Stat::Max, Precision::Exact(ScalarValue::from(10.0f64)));
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let result = min_max_with(&array, &mut ctx, KEEP_NANS)?.vortex_expect("should have result");
+        assert_eq!(f64::try_from(&result.min)?, -10.0);
+        assert_eq!(f64::try_from(&result.max)?, 10.0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_multi_batch_nan_poisoning() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
+        let mut acc = Accumulator::try_new(MinMax, KEEP_NANS, dtype)?;
+
+        let batch1 = PrimitiveArray::new(buffer![1.0f64, 2.0], Validity::NonNullable).into_array();
+        acc.accumulate(&batch1, &mut ctx)?;
+        assert!(!acc.is_saturated());
+
+        let batch2 = PrimitiveArray::new(buffer![f64::NAN], Validity::NonNullable).into_array();
+        acc.accumulate(&batch2, &mut ctx)?;
+        assert!(acc.is_saturated());
+
+        assert_poisoned(MinMaxResult::from_scalar(acc.finish()?)?)
     }
 
     #[test]
@@ -605,11 +829,11 @@ mod tests {
             DType::FixedSizeList(Arc::new(element_dtype), 1, Nullability::Nullable);
 
         assert_eq!(
-            MinMax.return_dtype(&EmptyOptions, &list_dtype),
+            MinMax.return_dtype(&SkipNansOptions::default(), &list_dtype),
             Some(make_minmax_dtype(&list_dtype))
         );
         assert_eq!(
-            MinMax.return_dtype(&EmptyOptions, &fixed_size_list_dtype),
+            MinMax.return_dtype(&SkipNansOptions::default(), &fixed_size_list_dtype),
             Some(make_minmax_dtype(&fixed_size_list_dtype))
         );
     }

--- a/vortex-array/src/aggregate_fn/fns/min_max/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/primitive.rs
@@ -20,8 +20,9 @@ pub(super) fn accumulate_primitive(
     p: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()> {
+    let skip_nans = partial.skip_nans;
     match_each_native_ptype!(p.ptype(), |T| {
-        let local = compute_min_max_with_validity::<T>(p, ctx)?;
+        let local = compute_min_max_with_validity::<T>(p, ctx, skip_nans)?;
         partial.merge(local);
         Ok(())
     })
@@ -30,6 +31,7 @@ pub(super) fn accumulate_primitive(
 fn compute_min_max_with_validity<T>(
     array: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
+    skip_nans: bool,
 ) -> VortexResult<Option<MinMaxResult>>
 where
     T: NativePType,
@@ -48,7 +50,7 @@ where
                 if T::PTYPE.is_int() {
                     integer_min_max_raw(slice).map(min_max_result)
                 } else {
-                    compute_min_max(slice.iter())
+                    compute_min_max(slice.iter(), skip_nans)
                 }
             }
             Mask::AllFalse(_) => None,
@@ -73,6 +75,7 @@ where
                         v.slices()
                             .iter()
                             .flat_map(|&(start, end)| slice[start..end].iter()),
+                        skip_nans,
                     )
                 }
             }
@@ -110,15 +113,29 @@ where
     }
 }
 
-fn compute_min_max<'a, T>(iter: impl Iterator<Item = &'a T>) -> Option<MinMaxResult>
+fn compute_min_max<'a, T>(
+    iter: impl Iterator<Item = &'a T>,
+    skip_nans: bool,
+) -> Option<MinMaxResult>
 where
     T: NativePType,
     PValue: From<T>,
 {
-    match iter
-        .filter(|v| !v.is_nan())
-        .minmax_by(|a, b| a.total_compare(**b))
-    {
+    if skip_nans {
+        minmax_by_total_order(iter.filter(|v| !v.is_nan()))
+    } else {
+        // Compute extrema under the total order (where NaNs sort to the ends) and let the
+        // partial's merge poison the result if either end is NaN.
+        minmax_by_total_order(iter)
+    }
+}
+
+fn minmax_by_total_order<'a, T>(iter: impl Iterator<Item = &'a T>) -> Option<MinMaxResult>
+where
+    T: NativePType,
+    PValue: From<T>,
+{
+    match iter.minmax_by(|a, b| a.total_compare(**b)) {
         itertools::MinMaxResult::NoElements => None,
         itertools::MinMaxResult::OneElement(&x) => {
             let scalar = Scalar::primitive(x, NonNullable);

--- a/vortex-array/src/aggregate_fn/fns/sum/bool.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/bool.rs
@@ -39,9 +39,9 @@ mod tests {
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
     use crate::aggregate_fn::Accumulator;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
     use crate::arrays::BoolArray;
@@ -108,7 +108,7 @@ mod tests {
     #[test]
     fn sum_bool_empty_produces_zero() -> VortexResult<()> {
         let dtype = DType::Bool(Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), dtype)?;
         let result = acc.finish()?;
         assert_eq!(result.as_primitive().typed_value::<u64>(), Some(0));
         Ok(())
@@ -118,7 +118,7 @@ mod tests {
     fn sum_bool_finish_resets_state() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Bool(Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), dtype)?;
 
         let batch1: BoolArray = [true, true, false].into_iter().collect();
         acc.accumulate(&batch1.into_array(), &mut ctx)?;
@@ -136,7 +136,7 @@ mod tests {
     fn sum_bool_return_dtype() -> VortexResult<()> {
         let dtype = Sum
             .return_dtype(
-                &SkipNansOptions::default(),
+                &AggregateFnOpts::default(),
                 &DType::Bool(Nullability::NonNullable),
             )
             .unwrap();

--- a/vortex-array/src/aggregate_fn/fns/sum/bool.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/bool.rs
@@ -39,9 +39,9 @@ mod tests {
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
     use crate::aggregate_fn::Accumulator;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
     use crate::arrays::BoolArray;
@@ -108,7 +108,7 @@ mod tests {
     #[test]
     fn sum_bool_empty_produces_zero() -> VortexResult<()> {
         let dtype = DType::Bool(Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Sum, NumericalAggregateOpts::default(), dtype)?;
         let result = acc.finish()?;
         assert_eq!(result.as_primitive().typed_value::<u64>(), Some(0));
         Ok(())
@@ -118,7 +118,7 @@ mod tests {
     fn sum_bool_finish_resets_state() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Bool(Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Sum, NumericalAggregateOpts::default(), dtype)?;
 
         let batch1: BoolArray = [true, true, false].into_iter().collect();
         acc.accumulate(&batch1.into_array(), &mut ctx)?;
@@ -136,7 +136,7 @@ mod tests {
     fn sum_bool_return_dtype() -> VortexResult<()> {
         let dtype = Sum
             .return_dtype(
-                &AggregateFnOpts::default(),
+                &NumericalAggregateOpts::default(),
                 &DType::Bool(Nullability::NonNullable),
             )
             .unwrap();

--- a/vortex-array/src/aggregate_fn/fns/sum/bool.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/bool.rs
@@ -41,7 +41,7 @@ mod tests {
     use crate::aggregate_fn::Accumulator;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::EmptyOptions;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
     use crate::arrays::BoolArray;
@@ -108,7 +108,7 @@ mod tests {
     #[test]
     fn sum_bool_empty_produces_zero() -> VortexResult<()> {
         let dtype = DType::Bool(Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), dtype)?;
         let result = acc.finish()?;
         assert_eq!(result.as_primitive().typed_value::<u64>(), Some(0));
         Ok(())
@@ -118,7 +118,7 @@ mod tests {
     fn sum_bool_finish_resets_state() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Bool(Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), dtype)?;
 
         let batch1: BoolArray = [true, true, false].into_iter().collect();
         acc.accumulate(&batch1.into_array(), &mut ctx)?;
@@ -135,7 +135,10 @@ mod tests {
     #[test]
     fn sum_bool_return_dtype() -> VortexResult<()> {
         let dtype = Sum
-            .return_dtype(&EmptyOptions, &DType::Bool(Nullability::NonNullable))
+            .return_dtype(
+                &SkipNansOptions::default(),
+                &DType::Bool(Nullability::NonNullable),
+            )
             .unwrap();
         assert_eq!(dtype, DType::Primitive(PType::U64, Nullability::Nullable));
         Ok(())

--- a/vortex-array/src/aggregate_fn/fns/sum/decimal.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/decimal.rs
@@ -114,8 +114,8 @@ mod tests {
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnVTable;
-    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
     use crate::arrays::DecimalArray;
@@ -357,7 +357,7 @@ mod tests {
         // Native type for precision 14 is I64 (max precision 18), so 14 < 18.
         // Use combine_partials to push state near (but under) 10^14.
         let input_dtype = DType::Decimal(DecimalDType::new(4, 0), Nullability::NonNullable);
-        let mut state = Sum.empty_partial(&SkipNansOptions::default(), &input_dtype)?;
+        let mut state = Sum.empty_partial(&AggregateFnOpts::default(), &input_dtype)?;
 
         let near_limit = Scalar::decimal(
             DecimalValue::from(99_999_999_999_990i64),
@@ -387,7 +387,7 @@ mod tests {
         // i256 arithmetic does not overflow. This tests the precision-based
         // saturation path in combine_partials.
         let input_dtype = DType::Decimal(DecimalDType::new(4, 0), Nullability::NonNullable);
-        let mut state = Sum.empty_partial(&SkipNansOptions::default(), &input_dtype)?;
+        let mut state = Sum.empty_partial(&AggregateFnOpts::default(), &input_dtype)?;
 
         let near_limit = Scalar::decimal(
             DecimalValue::from(99_999_999_999_999i64),
@@ -414,7 +414,7 @@ mod tests {
     fn sum_decimal_precision_overflow_negative() -> VortexResult<()> {
         // Same setup but with negative values: sum reaches -10^14.
         let input_dtype = DType::Decimal(DecimalDType::new(4, 0), Nullability::NonNullable);
-        let mut state = Sum.empty_partial(&SkipNansOptions::default(), &input_dtype)?;
+        let mut state = Sum.empty_partial(&AggregateFnOpts::default(), &input_dtype)?;
 
         let near_limit = Scalar::decimal(
             DecimalValue::from(-99_999_999_999_999i64),
@@ -446,7 +446,7 @@ mod tests {
         // a real array that pushes it over.
         let input_dtype = DType::Decimal(DecimalDType::new(27, 0), Nullability::NonNullable);
         let return_dtype = DecimalDType::new(37, 0);
-        let mut state = Sum.empty_partial(&SkipNansOptions::default(), &input_dtype)?;
+        let mut state = Sum.empty_partial(&AggregateFnOpts::default(), &input_dtype)?;
 
         // Set state to 10^37 - 1 via combine_partials.
         let near_limit_val: i128 = 10i128.pow(37) - 1;

--- a/vortex-array/src/aggregate_fn/fns/sum/decimal.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/decimal.rs
@@ -115,7 +115,7 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::AggregateFnVTable;
-    use crate::aggregate_fn::EmptyOptions;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
     use crate::arrays::DecimalArray;
@@ -357,7 +357,7 @@ mod tests {
         // Native type for precision 14 is I64 (max precision 18), so 14 < 18.
         // Use combine_partials to push state near (but under) 10^14.
         let input_dtype = DType::Decimal(DecimalDType::new(4, 0), Nullability::NonNullable);
-        let mut state = Sum.empty_partial(&EmptyOptions, &input_dtype)?;
+        let mut state = Sum.empty_partial(&SkipNansOptions::default(), &input_dtype)?;
 
         let near_limit = Scalar::decimal(
             DecimalValue::from(99_999_999_999_990i64),
@@ -387,7 +387,7 @@ mod tests {
         // i256 arithmetic does not overflow. This tests the precision-based
         // saturation path in combine_partials.
         let input_dtype = DType::Decimal(DecimalDType::new(4, 0), Nullability::NonNullable);
-        let mut state = Sum.empty_partial(&EmptyOptions, &input_dtype)?;
+        let mut state = Sum.empty_partial(&SkipNansOptions::default(), &input_dtype)?;
 
         let near_limit = Scalar::decimal(
             DecimalValue::from(99_999_999_999_999i64),
@@ -414,7 +414,7 @@ mod tests {
     fn sum_decimal_precision_overflow_negative() -> VortexResult<()> {
         // Same setup but with negative values: sum reaches -10^14.
         let input_dtype = DType::Decimal(DecimalDType::new(4, 0), Nullability::NonNullable);
-        let mut state = Sum.empty_partial(&EmptyOptions, &input_dtype)?;
+        let mut state = Sum.empty_partial(&SkipNansOptions::default(), &input_dtype)?;
 
         let near_limit = Scalar::decimal(
             DecimalValue::from(-99_999_999_999_999i64),
@@ -446,7 +446,7 @@ mod tests {
         // a real array that pushes it over.
         let input_dtype = DType::Decimal(DecimalDType::new(27, 0), Nullability::NonNullable);
         let return_dtype = DecimalDType::new(37, 0);
-        let mut state = Sum.empty_partial(&EmptyOptions, &input_dtype)?;
+        let mut state = Sum.empty_partial(&SkipNansOptions::default(), &input_dtype)?;
 
         // Set state to 10^37 - 1 via combine_partials.
         let near_limit_val: i128 = 10i128.pow(37) - 1;

--- a/vortex-array/src/aggregate_fn/fns/sum/decimal.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/decimal.rs
@@ -114,8 +114,8 @@ mod tests {
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnVTable;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
     use crate::arrays::DecimalArray;
@@ -357,7 +357,7 @@ mod tests {
         // Native type for precision 14 is I64 (max precision 18), so 14 < 18.
         // Use combine_partials to push state near (but under) 10^14.
         let input_dtype = DType::Decimal(DecimalDType::new(4, 0), Nullability::NonNullable);
-        let mut state = Sum.empty_partial(&AggregateFnOpts::default(), &input_dtype)?;
+        let mut state = Sum.empty_partial(&NumericalAggregateOpts::default(), &input_dtype)?;
 
         let near_limit = Scalar::decimal(
             DecimalValue::from(99_999_999_999_990i64),
@@ -387,7 +387,7 @@ mod tests {
         // i256 arithmetic does not overflow. This tests the precision-based
         // saturation path in combine_partials.
         let input_dtype = DType::Decimal(DecimalDType::new(4, 0), Nullability::NonNullable);
-        let mut state = Sum.empty_partial(&AggregateFnOpts::default(), &input_dtype)?;
+        let mut state = Sum.empty_partial(&NumericalAggregateOpts::default(), &input_dtype)?;
 
         let near_limit = Scalar::decimal(
             DecimalValue::from(99_999_999_999_999i64),
@@ -414,7 +414,7 @@ mod tests {
     fn sum_decimal_precision_overflow_negative() -> VortexResult<()> {
         // Same setup but with negative values: sum reaches -10^14.
         let input_dtype = DType::Decimal(DecimalDType::new(4, 0), Nullability::NonNullable);
-        let mut state = Sum.empty_partial(&AggregateFnOpts::default(), &input_dtype)?;
+        let mut state = Sum.empty_partial(&NumericalAggregateOpts::default(), &input_dtype)?;
 
         let near_limit = Scalar::decimal(
             DecimalValue::from(-99_999_999_999_999i64),
@@ -446,7 +446,7 @@ mod tests {
         // a real array that pushes it over.
         let input_dtype = DType::Decimal(DecimalDType::new(27, 0), Nullability::NonNullable);
         let return_dtype = DecimalDType::new(37, 0);
-        let mut state = Sum.empty_partial(&AggregateFnOpts::default(), &input_dtype)?;
+        let mut state = Sum.empty_partial(&NumericalAggregateOpts::default(), &input_dtype)?;
 
         // Set state to 10^37 - 1 via combine_partials.
         let near_limit_val: i128 = 10i128.pow(37) - 1;

--- a/vortex-array/src/aggregate_fn/fns/sum/grouped.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/grouped.rs
@@ -161,9 +161,9 @@ mod tests {
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::DynGroupedAccumulator;
     use crate::aggregate_fn::GroupedAccumulator;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
     use crate::arrays::FixedSizeListArray;
@@ -179,8 +179,11 @@ mod tests {
 
     /// Run a grouped sum through the accumulator.
     fn grouped_sum_actual(groups: &ArrayRef, elem_dtype: &DType) -> VortexResult<ArrayRef> {
-        let mut acc =
-            GroupedAccumulator::try_new(Sum, AggregateFnOpts::default(), elem_dtype.clone())?;
+        let mut acc = GroupedAccumulator::try_new(
+            Sum,
+            NumericalAggregateOpts::default(),
+            elem_dtype.clone(),
+        )?;
         acc.accumulate_list(groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         acc.finish()
     }
@@ -197,7 +200,7 @@ mod tests {
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let sum_dtype = Sum
-            .partial_dtype(&AggregateFnOpts::default(), elem_dtype)
+            .partial_dtype(&NumericalAggregateOpts::default(), elem_dtype)
             .expect("sum partial dtype");
         let mut builder = builder_with_capacity(&sum_dtype, ranges.len());
         for (i, &(offset, size)) in ranges.iter().enumerate() {
@@ -362,7 +365,7 @@ mod tests {
         let groups = listview(elements, &[(0, 3), (3, 2)], &[true, true])?;
 
         let mut acc =
-            GroupedAccumulator::try_new(Sum, AggregateFnOpts::include_nans(), elem_dtype)?;
+            GroupedAccumulator::try_new(Sum, NumericalAggregateOpts::include_nans(), elem_dtype)?;
         acc.accumulate_list(&groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         let actual = acc.finish()?;
 

--- a/vortex-array/src/aggregate_fn/fns/sum/grouped.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/grouped.rs
@@ -161,9 +161,9 @@ mod tests {
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::DynGroupedAccumulator;
     use crate::aggregate_fn::GroupedAccumulator;
-    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
     use crate::arrays::FixedSizeListArray;
@@ -180,7 +180,7 @@ mod tests {
     /// Run a grouped sum through the accumulator.
     fn grouped_sum_actual(groups: &ArrayRef, elem_dtype: &DType) -> VortexResult<ArrayRef> {
         let mut acc =
-            GroupedAccumulator::try_new(Sum, SkipNansOptions::default(), elem_dtype.clone())?;
+            GroupedAccumulator::try_new(Sum, AggregateFnOpts::default(), elem_dtype.clone())?;
         acc.accumulate_list(groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         acc.finish()
     }
@@ -197,7 +197,7 @@ mod tests {
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let sum_dtype = Sum
-            .partial_dtype(&SkipNansOptions::default(), elem_dtype)
+            .partial_dtype(&AggregateFnOpts::default(), elem_dtype)
             .expect("sum partial dtype");
         let mut builder = builder_with_capacity(&sum_dtype, ranges.len());
         for (i, &(offset, size)) in ranges.iter().enumerate() {
@@ -361,7 +361,8 @@ mod tests {
         let elem_dtype = DType::Primitive(PType::F64, NonNullable);
         let groups = listview(elements, &[(0, 3), (3, 2)], &[true, true])?;
 
-        let mut acc = GroupedAccumulator::try_new(Sum, SkipNansOptions::include(), elem_dtype)?;
+        let mut acc =
+            GroupedAccumulator::try_new(Sum, AggregateFnOpts::include_nans(), elem_dtype)?;
         acc.accumulate_list(&groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         let actual = acc.finish()?;
 

--- a/vortex-array/src/aggregate_fn/fns/sum/grouped.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/grouped.rs
@@ -32,10 +32,10 @@ impl DynGroupedAggregateKernel for PrimitiveGroupedSumEncodingKernel {
         groups: &GroupedArray,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        if !aggregate_fn.is::<Sum>() {
+        let Some(options) = aggregate_fn.as_opt::<Sum>() else {
             return Ok(None);
-        }
-        try_grouped_sum(groups, ctx)
+        };
+        try_grouped_sum(groups, ctx, options.skip_nans)
     }
 }
 
@@ -48,6 +48,7 @@ impl DynGroupedAggregateKernel for PrimitiveGroupedSumEncodingKernel {
 pub(super) fn try_grouped_sum(
     groups: &GroupedArray,
     ctx: &mut ExecutionCtx,
+    skip_nans: bool,
 ) -> VortexResult<Option<ArrayRef>> {
     if !groups.elements().is::<Primitive>() {
         return Ok(None);
@@ -61,6 +62,7 @@ pub(super) fn try_grouped_sum(
         &group_ranges,
         &group_validity,
         ctx,
+        skip_nans,
     )?))
 }
 
@@ -70,6 +72,7 @@ fn grouped_sum(
     group_ranges: &GroupRanges,
     group_validity: &Mask,
     ctx: &mut ExecutionCtx,
+    skip_nans: bool,
 ) -> VortexResult<ArrayRef> {
     let elem_mask = elements
         .as_ref()
@@ -91,7 +94,7 @@ fn grouped_sum(
         floating: |T| {
             let values = elements.as_slice::<T>();
             collect_sums::<T, f64>(values, group_ranges, group_validity, &elem_mask, all_valid,
-                |acc, slice| { sum_float_all(acc, slice); false })
+                |acc, slice| { sum_float_all(acc, slice, skip_nans); false })
         }
     );
 
@@ -159,8 +162,8 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::DynGroupedAccumulator;
-    use crate::aggregate_fn::EmptyOptions;
     use crate::aggregate_fn::GroupedAccumulator;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
     use crate::arrays::FixedSizeListArray;
@@ -176,7 +179,8 @@ mod tests {
 
     /// Run a grouped sum through the accumulator.
     fn grouped_sum_actual(groups: &ArrayRef, elem_dtype: &DType) -> VortexResult<ArrayRef> {
-        let mut acc = GroupedAccumulator::try_new(Sum, EmptyOptions, elem_dtype.clone())?;
+        let mut acc =
+            GroupedAccumulator::try_new(Sum, SkipNansOptions::default(), elem_dtype.clone())?;
         acc.accumulate_list(groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         acc.finish()
     }
@@ -193,7 +197,7 @@ mod tests {
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let sum_dtype = Sum
-            .partial_dtype(&EmptyOptions, elem_dtype)
+            .partial_dtype(&SkipNansOptions::default(), elem_dtype)
             .expect("sum partial dtype");
         let mut builder = builder_with_capacity(&sum_dtype, ranges.len());
         for (i, &(offset, size)) in ranges.iter().enumerate() {
@@ -344,6 +348,30 @@ mod tests {
                 .unwrap()
                 .is_nan()
         );
+        Ok(())
+    }
+
+    #[test]
+    fn listview_float_nan_not_skipping() -> VortexResult<()> {
+        let elements = PrimitiveArray::new(
+            buffer![1.0f64, f64::NAN, 2.0, 3.0, 4.0],
+            Validity::NonNullable,
+        )
+        .into_array();
+        let elem_dtype = DType::Primitive(PType::F64, NonNullable);
+        let groups = listview(elements, &[(0, 3), (3, 2)], &[true, true])?;
+
+        let mut acc =
+            GroupedAccumulator::try_new(Sum, SkipNansOptions { skip_nans: false }, elem_dtype)?;
+        acc.accumulate_list(&groups, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let actual = acc.finish()?;
+
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        // Group 0 contains a NaN -> NaN sum; group 1 sums normally.
+        let g0 = actual.execute_scalar(0, &mut ctx)?;
+        assert!(g0.as_primitive().typed_value::<f64>().unwrap().is_nan());
+        let g1 = actual.execute_scalar(1, &mut ctx)?;
+        assert_eq!(g1.as_primitive().typed_value::<f64>(), Some(7.0));
         Ok(())
     }
 

--- a/vortex-array/src/aggregate_fn/fns/sum/grouped.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/grouped.rs
@@ -361,8 +361,7 @@ mod tests {
         let elem_dtype = DType::Primitive(PType::F64, NonNullable);
         let groups = listview(elements, &[(0, 3), (3, 2)], &[true, true])?;
 
-        let mut acc =
-            GroupedAccumulator::try_new(Sum, SkipNansOptions { skip_nans: false }, elem_dtype)?;
+        let mut acc = GroupedAccumulator::try_new(Sum, SkipNansOptions::include(), elem_dtype)?;
         acc.accumulate_list(&groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         let actual = acc.finish()?;
 

--- a/vortex-array/src/aggregate_fn/fns/sum/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/mod.rs
@@ -26,7 +26,7 @@ use crate::aggregate_fn::Accumulator;
 use crate::aggregate_fn::AggregateFnId;
 use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::DynAccumulator;
-use crate::aggregate_fn::EmptyOptions;
+use crate::aggregate_fn::SkipNansOptions;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
 use crate::dtype::MAX_PRECISION;
@@ -35,6 +35,7 @@ use crate::dtype::PType;
 use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
 use crate::expr::stats::StatsProvider;
+use crate::expr::stats::StatsProviderExt;
 use crate::scalar::DecimalValue;
 use crate::scalar::Scalar;
 
@@ -49,7 +50,7 @@ pub fn sum(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
 
     // Compute using Accumulator<Sum>.
     // TODO(ngates): we may want to wrap this three-step dance up into an extension crate maybe.
-    let mut acc = Accumulator::try_new(Sum, EmptyOptions, array.dtype().clone())?;
+    let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), array.dtype().clone())?;
     acc.accumulate(array, ctx)?;
     let result = acc.finish()?;
 
@@ -65,11 +66,14 @@ pub fn sum(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
 ///
 /// If the sum overflows, a null scalar will be returned.
 /// If the array is all-invalid, the sum will be zero.
+///
+/// NaN handling for float inputs is controlled by [`SkipNansOptions`]: with `skip_nans` (the
+/// default) NaN values contribute nothing, otherwise any NaN value poisons the sum to NaN.
 #[derive(Clone, Debug)]
 pub struct Sum;
 
 impl AggregateFnVTable for Sum {
-    type Options = EmptyOptions;
+    type Options = SkipNansOptions;
     type Partial = SumPartial;
 
     fn id(&self) -> AggregateFnId {
@@ -139,6 +143,7 @@ impl AggregateFnVTable for Sum {
         Ok(SumPartial {
             return_dtype,
             current: Some(initial),
+            skip_nans: options.skip_nans,
         })
     }
 
@@ -223,6 +228,43 @@ impl AggregateFnVTable for Sum {
         }
     }
 
+    fn try_accumulate(
+        &self,
+        partial: &mut Self::Partial,
+        batch: &ArrayRef,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<bool> {
+        // NaN-aware shortcircuits only apply to NaN-including float sums; everything else takes
+        // the default dispatch path.
+        if partial.skip_nans || !matches!(partial.current, Some(SumState::Float(_))) {
+            return Ok(false);
+        }
+        match batch.statistics().get_as::<u64>(Stat::NaNCount) {
+            Precision::Exact(0) => {
+                // NaN-free batch: the cached NaN-skipping sum (if any) equals the
+                // NaN-including sum.
+                if let Precision::Exact(sum) = batch.statistics().get(Stat::Sum) {
+                    let sum = if sum.dtype() == &partial.return_dtype {
+                        sum
+                    } else {
+                        sum.cast(&partial.return_dtype)?
+                    };
+                    self.combine_partials(partial, sum)?;
+                    return Ok(true);
+                }
+                Ok(false)
+            }
+            Precision::Exact(_) => {
+                // At least one NaN value: the sum is NaN without scanning the batch.
+                if let Some(SumState::Float(acc)) = partial.current.as_mut() {
+                    *acc = f64::NAN;
+                }
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
     fn accumulate(
         &self,
         partial: &mut Self::Partial,
@@ -231,12 +273,17 @@ impl AggregateFnVTable for Sum {
     ) -> VortexResult<()> {
         // Constants compute scalar * len and combine via combine_partials.
         if let Columnar::Constant(c) = batch {
+            // NaN constants are treated as missing when skipping NaNs.
+            if partial.skip_nans && c.scalar().as_primitive_opt().is_some_and(|p| p.is_nan()) {
+                return Ok(());
+            }
             if let Some(product) = multiply_constant(c.scalar(), c.len(), &partial.return_dtype)? {
                 self.combine_partials(partial, product)?;
             }
             return Ok(());
         }
 
+        let skip_nans = partial.skip_nans;
         let mut inner = match partial.current.take() {
             Some(inner) => inner,
             None => return Ok(()),
@@ -244,7 +291,7 @@ impl AggregateFnVTable for Sum {
 
         let result = match batch {
             Columnar::Canonical(c) => match c {
-                Canonical::Primitive(p) => accumulate_primitive(&mut inner, p, ctx),
+                Canonical::Primitive(p) => accumulate_primitive(&mut inner, p, ctx, skip_nans),
                 Canonical::Bool(b) => accumulate_bool(&mut inner, b, ctx),
                 Canonical::Decimal(d) => accumulate_decimal(&mut inner, d, ctx),
                 _ => vortex_bail!("Unsupported canonical type for sum: {}", batch.dtype()),
@@ -278,6 +325,8 @@ pub struct SumPartial {
     return_dtype: DType,
     /// The current accumulated state, or `None` if saturated (checked overflow).
     current: Option<SumState>,
+    /// Whether NaN values in float inputs are skipped.
+    skip_nans: bool,
 }
 
 /// The accumulated sum value.
@@ -347,8 +396,8 @@ mod tests {
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
     use crate::aggregate_fn::DynGroupedAccumulator;
-    use crate::aggregate_fn::EmptyOptions;
     use crate::aggregate_fn::GroupedAccumulator;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
     use crate::arrays::BoolArray;
@@ -433,7 +482,7 @@ mod tests {
     fn sum_multi_batch() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -450,7 +499,7 @@ mod tests {
     fn sum_finish_resets_state() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -469,7 +518,7 @@ mod tests {
     #[test]
     fn sum_state_merge() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut state = Sum.empty_partial(&EmptyOptions, &dtype)?;
+        let mut state = Sum.empty_partial(&SkipNansOptions::default(), &dtype)?;
 
         let scalar1 = Scalar::primitive(100i64, Nullable);
         Sum.combine_partials(&mut state, scalar1)?;
@@ -522,7 +571,8 @@ mod tests {
     // Grouped sum tests
 
     fn run_grouped_sum(groups: &ArrayRef, elem_dtype: &DType) -> VortexResult<ArrayRef> {
-        let mut acc = GroupedAccumulator::try_new(Sum, EmptyOptions, elem_dtype.clone())?;
+        let mut acc =
+            GroupedAccumulator::try_new(Sum, SkipNansOptions::default(), elem_dtype.clone())?;
         acc.accumulate_list(groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         acc.finish()
     }
@@ -605,7 +655,7 @@ mod tests {
     fn grouped_sum_finish_resets() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let elem_dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = GroupedAccumulator::try_new(Sum, EmptyOptions, elem_dtype)?;
+        let mut acc = GroupedAccumulator::try_new(Sum, SkipNansOptions::default(), elem_dtype)?;
 
         let elements1 =
             PrimitiveArray::new(buffer![1i32, 2, 3, 4], Validity::NonNullable).into_array();

--- a/vortex-array/src/aggregate_fn/fns/sum/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/mod.rs
@@ -24,9 +24,9 @@ use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::aggregate_fn::Accumulator;
 use crate::aggregate_fn::AggregateFnId;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::DynAccumulator;
-use crate::aggregate_fn::SkipNansOptions;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
 use crate::dtype::MAX_PRECISION;
@@ -50,7 +50,7 @@ pub fn sum(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
 
     // Compute using Accumulator<Sum>.
     // TODO(ngates): we may want to wrap this three-step dance up into an extension crate maybe.
-    let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), array.dtype().clone())?;
+    let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), array.dtype().clone())?;
     acc.accumulate(array, ctx)?;
     let result = acc.finish()?;
 
@@ -67,13 +67,13 @@ pub fn sum(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
 /// If the sum overflows, a null scalar will be returned.
 /// If the array is all-invalid, the sum will be zero.
 ///
-/// NaN handling for float inputs is controlled by [`SkipNansOptions`]: with `skip_nans` (the
+/// NaN handling for float inputs is controlled by [`AggregateFnOpts`]: with `skip_nans` (the
 /// default) NaN values contribute nothing, otherwise any NaN value poisons the sum to NaN.
 #[derive(Clone, Debug)]
 pub struct Sum;
 
 impl AggregateFnVTable for Sum {
-    type Options = SkipNansOptions;
+    type Options = AggregateFnOpts;
     type Partial = SumPartial;
 
     fn id(&self) -> AggregateFnId {
@@ -81,7 +81,7 @@ impl AggregateFnVTable for Sum {
     }
 
     fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
-        Ok(Some(vec![options.skip_nans as u8]))
+        Ok(Some(options.serialize()))
     }
 
     fn deserialize(
@@ -89,10 +89,7 @@ impl AggregateFnVTable for Sum {
         metadata: &[u8],
         _session: &VortexSession,
     ) -> VortexResult<Self::Options> {
-        // A single byte encodes `skip_nans`; missing metadata defaults to skipping NaNs.
-        Ok(SkipNansOptions {
-            skip_nans: metadata.first().is_none_or(|&b| b != 0),
-        })
+        AggregateFnOpts::deserialize(metadata)
     }
 
     fn return_dtype(&self, _options: &Self::Options, input_dtype: &DType) -> Option<DType> {
@@ -396,11 +393,11 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
     use crate::aggregate_fn::DynGroupedAccumulator;
     use crate::aggregate_fn::GroupedAccumulator;
-    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
     use crate::arrays::BoolArray;
@@ -485,7 +482,7 @@ mod tests {
     fn sum_multi_batch() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -502,7 +499,7 @@ mod tests {
     fn sum_finish_resets_state() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -521,7 +518,7 @@ mod tests {
     #[test]
     fn sum_state_merge() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut state = Sum.empty_partial(&SkipNansOptions::default(), &dtype)?;
+        let mut state = Sum.empty_partial(&AggregateFnOpts::default(), &dtype)?;
 
         let scalar1 = Scalar::primitive(100i64, Nullable);
         Sum.combine_partials(&mut state, scalar1)?;
@@ -575,7 +572,7 @@ mod tests {
 
     fn run_grouped_sum(groups: &ArrayRef, elem_dtype: &DType) -> VortexResult<ArrayRef> {
         let mut acc =
-            GroupedAccumulator::try_new(Sum, SkipNansOptions::default(), elem_dtype.clone())?;
+            GroupedAccumulator::try_new(Sum, AggregateFnOpts::default(), elem_dtype.clone())?;
         acc.accumulate_list(groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         acc.finish()
     }
@@ -658,7 +655,7 @@ mod tests {
     fn grouped_sum_finish_resets() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let elem_dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = GroupedAccumulator::try_new(Sum, SkipNansOptions::default(), elem_dtype)?;
+        let mut acc = GroupedAccumulator::try_new(Sum, AggregateFnOpts::default(), elem_dtype)?;
 
         let elements1 =
             PrimitiveArray::new(buffer![1i32, 2, 3, 4], Validity::NonNullable).into_array();

--- a/vortex-array/src/aggregate_fn/fns/sum/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/mod.rs
@@ -24,9 +24,9 @@ use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::aggregate_fn::Accumulator;
 use crate::aggregate_fn::AggregateFnId;
-use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::DynAccumulator;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
 use crate::dtype::MAX_PRECISION;
@@ -50,7 +50,11 @@ pub fn sum(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
 
     // Compute using Accumulator<Sum>.
     // TODO(ngates): we may want to wrap this three-step dance up into an extension crate maybe.
-    let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), array.dtype().clone())?;
+    let mut acc = Accumulator::try_new(
+        Sum,
+        NumericalAggregateOpts::default(),
+        array.dtype().clone(),
+    )?;
     acc.accumulate(array, ctx)?;
     let result = acc.finish()?;
 
@@ -67,13 +71,13 @@ pub fn sum(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
 /// If the sum overflows, a null scalar will be returned.
 /// If the array is all-invalid, the sum will be zero.
 ///
-/// NaN handling for float inputs is controlled by [`AggregateFnOpts`]: with `skip_nans` (the
+/// NaN handling for float inputs is controlled by [`NumericalAggregateOpts`]: with `skip_nans` (the
 /// default) NaN values contribute nothing, otherwise any NaN value poisons the sum to NaN.
 #[derive(Clone, Debug)]
 pub struct Sum;
 
 impl AggregateFnVTable for Sum {
-    type Options = AggregateFnOpts;
+    type Options = NumericalAggregateOpts;
     type Partial = SumPartial;
 
     fn id(&self) -> AggregateFnId {
@@ -89,7 +93,7 @@ impl AggregateFnVTable for Sum {
         metadata: &[u8],
         _session: &VortexSession,
     ) -> VortexResult<Self::Options> {
-        AggregateFnOpts::deserialize(metadata)
+        NumericalAggregateOpts::deserialize(metadata)
     }
 
     fn return_dtype(&self, _options: &Self::Options, input_dtype: &DType) -> Option<DType> {
@@ -393,11 +397,11 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::DynAccumulator;
     use crate::aggregate_fn::DynGroupedAccumulator;
     use crate::aggregate_fn::GroupedAccumulator;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
     use crate::arrays::BoolArray;
@@ -482,7 +486,7 @@ mod tests {
     fn sum_multi_batch() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Sum, NumericalAggregateOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -499,7 +503,7 @@ mod tests {
     fn sum_finish_resets_state() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Sum, NumericalAggregateOpts::default(), dtype)?;
 
         let batch1 = PrimitiveArray::new(buffer![10i32, 20], Validity::NonNullable).into_array();
         acc.accumulate(&batch1, &mut ctx)?;
@@ -518,7 +522,7 @@ mod tests {
     #[test]
     fn sum_state_merge() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut state = Sum.empty_partial(&AggregateFnOpts::default(), &dtype)?;
+        let mut state = Sum.empty_partial(&NumericalAggregateOpts::default(), &dtype)?;
 
         let scalar1 = Scalar::primitive(100i64, Nullable);
         Sum.combine_partials(&mut state, scalar1)?;
@@ -571,8 +575,11 @@ mod tests {
     // Grouped sum tests
 
     fn run_grouped_sum(groups: &ArrayRef, elem_dtype: &DType) -> VortexResult<ArrayRef> {
-        let mut acc =
-            GroupedAccumulator::try_new(Sum, AggregateFnOpts::default(), elem_dtype.clone())?;
+        let mut acc = GroupedAccumulator::try_new(
+            Sum,
+            NumericalAggregateOpts::default(),
+            elem_dtype.clone(),
+        )?;
         acc.accumulate_list(groups, &mut LEGACY_SESSION.create_execution_ctx())?;
         acc.finish()
     }
@@ -655,7 +662,8 @@ mod tests {
     fn grouped_sum_finish_resets() -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let elem_dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = GroupedAccumulator::try_new(Sum, AggregateFnOpts::default(), elem_dtype)?;
+        let mut acc =
+            GroupedAccumulator::try_new(Sum, NumericalAggregateOpts::default(), elem_dtype)?;
 
         let elements1 =
             PrimitiveArray::new(buffer![1i32, 2, 3, 4], Validity::NonNullable).into_array();

--- a/vortex-array/src/aggregate_fn/fns/sum/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/mod.rs
@@ -80,16 +80,19 @@ impl AggregateFnVTable for Sum {
         AggregateFnId::new("vortex.sum")
     }
 
-    fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
-        Ok(Some(vec![]))
+    fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
+        Ok(Some(vec![options.skip_nans as u8]))
     }
 
     fn deserialize(
         &self,
-        _metadata: &[u8],
+        metadata: &[u8],
         _session: &VortexSession,
     ) -> VortexResult<Self::Options> {
-        Ok(EmptyOptions)
+        // A single byte encodes `skip_nans`; missing metadata defaults to skipping NaNs.
+        Ok(SkipNansOptions {
+            skip_nans: metadata.first().is_none_or(|&b| b != 0),
+        })
     }
 
     fn return_dtype(&self, _options: &Self::Options, input_dtype: &DType) -> Option<DType> {

--- a/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
@@ -356,7 +356,7 @@ mod tests {
     fn sum_f64_with_nan_not_skipping() -> VortexResult<()> {
         let arr =
             PrimitiveArray::new(buffer![1.0f64, f64::NAN, 2.0], Validity::NonNullable).into_array();
-        let result = sum_with_options(&arr, SkipNansOptions { skip_nans: false })?;
+        let result = sum_with_options(&arr, SkipNansOptions::include())?;
         assert!(result.as_primitive().typed_value::<f64>().unwrap().is_nan());
         Ok(())
     }
@@ -365,7 +365,7 @@ mod tests {
     fn sum_f64_without_nan_not_skipping() -> VortexResult<()> {
         let arr =
             PrimitiveArray::new(buffer![1.0f64, 2.0, 3.0], Validity::NonNullable).into_array();
-        let result = sum_with_options(&arr, SkipNansOptions { skip_nans: false })?;
+        let result = sum_with_options(&arr, SkipNansOptions::include())?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(6.0));
         Ok(())
     }
@@ -378,7 +378,7 @@ mod tests {
             PrimitiveArray::new(buffer![1.0f64, 2.0, 3.0], Validity::NonNullable).into_array();
         arr.statistics()
             .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(1u64)));
-        let result = sum_with_options(&arr, SkipNansOptions { skip_nans: false })?;
+        let result = sum_with_options(&arr, SkipNansOptions::include())?;
         assert!(result.as_primitive().typed_value::<f64>().unwrap().is_nan());
         Ok(())
     }
@@ -392,7 +392,7 @@ mod tests {
             .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(0u64)));
         arr.statistics()
             .set(Stat::Sum, Precision::Exact(ScalarValue::from(42.0f64)));
-        let result = sum_with_options(&arr, SkipNansOptions { skip_nans: false })?;
+        let result = sum_with_options(&arr, SkipNansOptions::include())?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(42.0));
         Ok(())
     }
@@ -404,7 +404,7 @@ mod tests {
         let result = sum_with_options(&arr, SkipNansOptions::default())?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(0.0));
 
-        let result = sum_with_options(&arr, SkipNansOptions { skip_nans: false })?;
+        let result = sum_with_options(&arr, SkipNansOptions::include())?;
         assert!(result.as_primitive().typed_value::<f64>().unwrap().is_nan());
         Ok(())
     }

--- a/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
@@ -187,8 +187,8 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::DynAccumulator;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
     use crate::arrays::ConstantArray;
@@ -291,7 +291,7 @@ mod tests {
     #[test]
     fn sum_empty_produces_zero() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Sum, NumericalAggregateOpts::default(), dtype)?;
         let result = acc.finish()?;
         assert_eq!(result.as_primitive().typed_value::<i64>(), Some(0));
         Ok(())
@@ -300,7 +300,7 @@ mod tests {
     #[test]
     fn sum_empty_f64_produces_zero() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Sum, NumericalAggregateOpts::default(), dtype)?;
         let result = acc.finish()?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(0.0));
         Ok(())
@@ -345,8 +345,11 @@ mod tests {
         Ok(())
     }
 
-    /// Sum an array with explicit [`AggregateFnOpts`] (test-only helper).
-    fn sum_with_options(arr: &crate::ArrayRef, options: AggregateFnOpts) -> VortexResult<Scalar> {
+    /// Sum an array with explicit [`NumericalAggregateOpts`] (test-only helper).
+    fn sum_with_options(
+        arr: &crate::ArrayRef,
+        options: NumericalAggregateOpts,
+    ) -> VortexResult<Scalar> {
         let mut acc = Accumulator::try_new(Sum, options, arr.dtype().clone())?;
         acc.accumulate(arr, &mut LEGACY_SESSION.create_execution_ctx())?;
         acc.finish()
@@ -356,7 +359,7 @@ mod tests {
     fn sum_f64_with_nan_not_skipping() -> VortexResult<()> {
         let arr =
             PrimitiveArray::new(buffer![1.0f64, f64::NAN, 2.0], Validity::NonNullable).into_array();
-        let result = sum_with_options(&arr, AggregateFnOpts::include_nans())?;
+        let result = sum_with_options(&arr, NumericalAggregateOpts::include_nans())?;
         assert!(result.as_primitive().typed_value::<f64>().unwrap().is_nan());
         Ok(())
     }
@@ -365,7 +368,7 @@ mod tests {
     fn sum_f64_without_nan_not_skipping() -> VortexResult<()> {
         let arr =
             PrimitiveArray::new(buffer![1.0f64, 2.0, 3.0], Validity::NonNullable).into_array();
-        let result = sum_with_options(&arr, AggregateFnOpts::include_nans())?;
+        let result = sum_with_options(&arr, NumericalAggregateOpts::include_nans())?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(6.0));
         Ok(())
     }
@@ -378,7 +381,7 @@ mod tests {
             PrimitiveArray::new(buffer![1.0f64, 2.0, 3.0], Validity::NonNullable).into_array();
         arr.statistics()
             .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(1u64)));
-        let result = sum_with_options(&arr, AggregateFnOpts::include_nans())?;
+        let result = sum_with_options(&arr, NumericalAggregateOpts::include_nans())?;
         assert!(result.as_primitive().typed_value::<f64>().unwrap().is_nan());
         Ok(())
     }
@@ -392,7 +395,7 @@ mod tests {
             .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(0u64)));
         arr.statistics()
             .set(Stat::Sum, Precision::Exact(ScalarValue::from(42.0f64)));
-        let result = sum_with_options(&arr, AggregateFnOpts::include_nans())?;
+        let result = sum_with_options(&arr, NumericalAggregateOpts::include_nans())?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(42.0));
         Ok(())
     }
@@ -401,10 +404,10 @@ mod tests {
     fn sum_constant_nan() -> VortexResult<()> {
         let arr = ConstantArray::new(f64::NAN, 4).into_array();
         // NaN constants are skipped by default and poison the sum otherwise.
-        let result = sum_with_options(&arr, AggregateFnOpts::default())?;
+        let result = sum_with_options(&arr, NumericalAggregateOpts::default())?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(0.0));
 
-        let result = sum_with_options(&arr, AggregateFnOpts::include_nans())?;
+        let result = sum_with_options(&arr, NumericalAggregateOpts::include_nans())?;
         assert!(result.as_primitive().typed_value::<f64>().unwrap().is_nan());
         Ok(())
     }
@@ -422,7 +425,7 @@ mod tests {
 
         let mut acc = Accumulator::try_new(
             Sum,
-            AggregateFnOpts::default(),
+            NumericalAggregateOpts::default(),
             DType::Primitive(PType::F64, Nullability::NonNullable),
         )?;
         acc.accumulate(&batch, &mut LEGACY_SESSION.create_execution_ctx())?;
@@ -441,7 +444,7 @@ mod tests {
     #[test]
     fn sum_checked_overflow_is_saturated() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I64, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Sum, NumericalAggregateOpts::default(), dtype)?;
         assert!(!acc.is_saturated());
 
         let batch =

--- a/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
@@ -25,16 +25,21 @@ pub(super) fn accumulate_primitive(
     inner: &mut SumState,
     p: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
+    skip_nans: bool,
 ) -> VortexResult<bool> {
     let mask = p.as_ref().validity()?.execute_mask(p.as_ref().len(), ctx)?;
     match mask.slices() {
         AllOr::None => Ok(false),
-        AllOr::All => accumulate_primitive_all(inner, p),
-        AllOr::Some(slices) => accumulate_primitive_valid(inner, p, slices),
+        AllOr::All => accumulate_primitive_all(inner, p, skip_nans),
+        AllOr::Some(slices) => accumulate_primitive_valid(inner, p, slices, skip_nans),
     }
 }
 
-fn accumulate_primitive_all(inner: &mut SumState, p: &PrimitiveArray) -> VortexResult<bool> {
+fn accumulate_primitive_all(
+    inner: &mut SumState,
+    p: &PrimitiveArray,
+    skip_nans: bool,
+) -> VortexResult<bool> {
     match inner {
         SumState::Unsigned(acc) => match_each_native_ptype!(p.ptype(),
             unsigned: |T| { Ok(sum_unsigned_all(acc, p.as_slice::<T>())) },
@@ -50,7 +55,7 @@ fn accumulate_primitive_all(inner: &mut SumState, p: &PrimitiveArray) -> VortexR
             unsigned: |_T| { vortex_panic!("float sum state with unsigned input") },
             signed: |_T| { vortex_panic!("float sum state with signed input") },
             floating: |T| {
-                sum_float_all(acc, p.as_slice::<T>());
+                sum_float_all(acc, p.as_slice::<T>(), skip_nans);
                 Ok(false)
             }
         ),
@@ -58,11 +63,18 @@ fn accumulate_primitive_all(inner: &mut SumState, p: &PrimitiveArray) -> VortexR
     }
 }
 
-/// Sum the non-NaN values of a float slice into an `f64` accumulator. NaNs are skipped to match the
-/// scalar `sum` semantics. Floats cannot overflow the accumulator, so this never reports saturation.
-pub(super) fn sum_float_all<T: NativePType>(acc: &mut f64, slice: &[T]) {
-    for &v in slice {
-        if !v.is_nan() {
+/// Sum the values of a float slice into an `f64` accumulator. When `skip_nans` is set, NaN values
+/// are skipped to match the scalar `sum` semantics; otherwise any NaN poisons the accumulator to
+/// NaN. Floats cannot overflow the accumulator, so this never reports saturation.
+pub(super) fn sum_float_all<T: NativePType>(acc: &mut f64, slice: &[T], skip_nans: bool) {
+    if skip_nans {
+        for &v in slice {
+            if !v.is_nan() {
+                *acc += ToPrimitive::to_f64(&v).vortex_expect("float to f64");
+            }
+        }
+    } else {
+        for &v in slice {
             *acc += ToPrimitive::to_f64(&v).vortex_expect("float to f64");
         }
     }
@@ -122,6 +134,7 @@ fn accumulate_primitive_valid(
     inner: &mut SumState,
     p: &PrimitiveArray,
     slices: &[(usize, usize)],
+    skip_nans: bool,
 ) -> VortexResult<bool> {
     match inner {
         SumState::Unsigned(acc) => match_each_native_ptype!(p.ptype(),
@@ -156,7 +169,7 @@ fn accumulate_primitive_valid(
             floating: |T| {
                 let values = p.as_slice::<T>();
                 for &(start, end) in slices {
-                    sum_float_all(acc, &values[start..end]);
+                    sum_float_all(acc, &values[start..end], skip_nans);
                 }
                 Ok(false)
             }
@@ -175,15 +188,19 @@ mod tests {
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::EmptyOptions;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
+    use crate::arrays::ConstantArray;
     use crate::arrays::PrimitiveArray;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
     use crate::dtype::Nullability::Nullable;
     use crate::dtype::PType;
+    use crate::expr::stats::Precision;
+    use crate::expr::stats::Stat;
     use crate::scalar::Scalar;
+    use crate::scalar::ScalarValue;
     use crate::validity::Validity;
 
     #[test]
@@ -274,7 +291,7 @@ mod tests {
     #[test]
     fn sum_empty_produces_zero() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), dtype)?;
         let result = acc.finish()?;
         assert_eq!(result.as_primitive().typed_value::<i64>(), Some(0));
         Ok(())
@@ -283,7 +300,7 @@ mod tests {
     #[test]
     fn sum_empty_f64_produces_zero() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), dtype)?;
         let result = acc.finish()?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(0.0));
         Ok(())
@@ -328,6 +345,70 @@ mod tests {
         Ok(())
     }
 
+    /// Sum an array with explicit [`SkipNansOptions`] (test-only helper).
+    fn sum_with_options(arr: &crate::ArrayRef, options: SkipNansOptions) -> VortexResult<Scalar> {
+        let mut acc = Accumulator::try_new(Sum, options, arr.dtype().clone())?;
+        acc.accumulate(arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        acc.finish()
+    }
+
+    #[test]
+    fn sum_f64_with_nan_not_skipping() -> VortexResult<()> {
+        let arr =
+            PrimitiveArray::new(buffer![1.0f64, f64::NAN, 2.0], Validity::NonNullable).into_array();
+        let result = sum_with_options(&arr, SkipNansOptions { skip_nans: false })?;
+        assert!(result.as_primitive().typed_value::<f64>().unwrap().is_nan());
+        Ok(())
+    }
+
+    #[test]
+    fn sum_f64_without_nan_not_skipping() -> VortexResult<()> {
+        let arr =
+            PrimitiveArray::new(buffer![1.0f64, 2.0, 3.0], Validity::NonNullable).into_array();
+        let result = sum_with_options(&arr, SkipNansOptions { skip_nans: false })?;
+        assert_eq!(result.as_primitive().typed_value::<f64>(), Some(6.0));
+        Ok(())
+    }
+
+    #[test]
+    fn sum_not_skipping_shortcircuits_on_exact_nan_count_stat() -> VortexResult<()> {
+        // The array has no NaNs; a planted exact NaNCount stat proves the NaN poisoning came
+        // from the stat rather than a scan.
+        let arr =
+            PrimitiveArray::new(buffer![1.0f64, 2.0, 3.0], Validity::NonNullable).into_array();
+        arr.statistics()
+            .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(1u64)));
+        let result = sum_with_options(&arr, SkipNansOptions { skip_nans: false })?;
+        assert!(result.as_primitive().typed_value::<f64>().unwrap().is_nan());
+        Ok(())
+    }
+
+    #[test]
+    fn sum_not_skipping_uses_cached_sum_when_nan_free() -> VortexResult<()> {
+        // With an exact NaNCount of zero, the planted exact Sum stat is usable as-is.
+        let arr =
+            PrimitiveArray::new(buffer![1.0f64, 2.0, 3.0], Validity::NonNullable).into_array();
+        arr.statistics()
+            .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(0u64)));
+        arr.statistics()
+            .set(Stat::Sum, Precision::Exact(ScalarValue::from(42.0f64)));
+        let result = sum_with_options(&arr, SkipNansOptions { skip_nans: false })?;
+        assert_eq!(result.as_primitive().typed_value::<f64>(), Some(42.0));
+        Ok(())
+    }
+
+    #[test]
+    fn sum_constant_nan() -> VortexResult<()> {
+        let arr = ConstantArray::new(f64::NAN, 4).into_array();
+        // NaN constants are skipped by default and poison the sum otherwise.
+        let result = sum_with_options(&arr, SkipNansOptions::default())?;
+        assert_eq!(result.as_primitive().typed_value::<f64>(), Some(0.0));
+
+        let result = sum_with_options(&arr, SkipNansOptions { skip_nans: false })?;
+        assert!(result.as_primitive().typed_value::<f64>().unwrap().is_nan());
+        Ok(())
+    }
+
     #[test]
     fn sum_f64_with_infinity() -> VortexResult<()> {
         let batch = PrimitiveArray::new(
@@ -341,7 +422,7 @@ mod tests {
 
         let mut acc = Accumulator::try_new(
             Sum,
-            EmptyOptions,
+            SkipNansOptions::default(),
             DType::Primitive(PType::F64, Nullability::NonNullable),
         )?;
         acc.accumulate(&batch, &mut LEGACY_SESSION.create_execution_ctx())?;
@@ -360,7 +441,7 @@ mod tests {
     #[test]
     fn sum_checked_overflow_is_saturated() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I64, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, EmptyOptions, dtype)?;
+        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), dtype)?;
         assert!(!acc.is_saturated());
 
         let batch =

--- a/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
@@ -187,8 +187,8 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::fns::sum::sum;
     use crate::arrays::ConstantArray;
@@ -291,7 +291,7 @@ mod tests {
     #[test]
     fn sum_empty_produces_zero() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), dtype)?;
         let result = acc.finish()?;
         assert_eq!(result.as_primitive().typed_value::<i64>(), Some(0));
         Ok(())
@@ -300,7 +300,7 @@ mod tests {
     #[test]
     fn sum_empty_f64_produces_zero() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::F64, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), dtype)?;
         let result = acc.finish()?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(0.0));
         Ok(())
@@ -345,8 +345,8 @@ mod tests {
         Ok(())
     }
 
-    /// Sum an array with explicit [`SkipNansOptions`] (test-only helper).
-    fn sum_with_options(arr: &crate::ArrayRef, options: SkipNansOptions) -> VortexResult<Scalar> {
+    /// Sum an array with explicit [`AggregateFnOpts`] (test-only helper).
+    fn sum_with_options(arr: &crate::ArrayRef, options: AggregateFnOpts) -> VortexResult<Scalar> {
         let mut acc = Accumulator::try_new(Sum, options, arr.dtype().clone())?;
         acc.accumulate(arr, &mut LEGACY_SESSION.create_execution_ctx())?;
         acc.finish()
@@ -356,7 +356,7 @@ mod tests {
     fn sum_f64_with_nan_not_skipping() -> VortexResult<()> {
         let arr =
             PrimitiveArray::new(buffer![1.0f64, f64::NAN, 2.0], Validity::NonNullable).into_array();
-        let result = sum_with_options(&arr, SkipNansOptions::include())?;
+        let result = sum_with_options(&arr, AggregateFnOpts::include_nans())?;
         assert!(result.as_primitive().typed_value::<f64>().unwrap().is_nan());
         Ok(())
     }
@@ -365,7 +365,7 @@ mod tests {
     fn sum_f64_without_nan_not_skipping() -> VortexResult<()> {
         let arr =
             PrimitiveArray::new(buffer![1.0f64, 2.0, 3.0], Validity::NonNullable).into_array();
-        let result = sum_with_options(&arr, SkipNansOptions::include())?;
+        let result = sum_with_options(&arr, AggregateFnOpts::include_nans())?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(6.0));
         Ok(())
     }
@@ -378,7 +378,7 @@ mod tests {
             PrimitiveArray::new(buffer![1.0f64, 2.0, 3.0], Validity::NonNullable).into_array();
         arr.statistics()
             .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(1u64)));
-        let result = sum_with_options(&arr, SkipNansOptions::include())?;
+        let result = sum_with_options(&arr, AggregateFnOpts::include_nans())?;
         assert!(result.as_primitive().typed_value::<f64>().unwrap().is_nan());
         Ok(())
     }
@@ -392,7 +392,7 @@ mod tests {
             .set(Stat::NaNCount, Precision::Exact(ScalarValue::from(0u64)));
         arr.statistics()
             .set(Stat::Sum, Precision::Exact(ScalarValue::from(42.0f64)));
-        let result = sum_with_options(&arr, SkipNansOptions::include())?;
+        let result = sum_with_options(&arr, AggregateFnOpts::include_nans())?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(42.0));
         Ok(())
     }
@@ -401,10 +401,10 @@ mod tests {
     fn sum_constant_nan() -> VortexResult<()> {
         let arr = ConstantArray::new(f64::NAN, 4).into_array();
         // NaN constants are skipped by default and poison the sum otherwise.
-        let result = sum_with_options(&arr, SkipNansOptions::default())?;
+        let result = sum_with_options(&arr, AggregateFnOpts::default())?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(0.0));
 
-        let result = sum_with_options(&arr, SkipNansOptions::include())?;
+        let result = sum_with_options(&arr, AggregateFnOpts::include_nans())?;
         assert!(result.as_primitive().typed_value::<f64>().unwrap().is_nan());
         Ok(())
     }
@@ -422,7 +422,7 @@ mod tests {
 
         let mut acc = Accumulator::try_new(
             Sum,
-            SkipNansOptions::default(),
+            AggregateFnOpts::default(),
             DType::Primitive(PType::F64, Nullability::NonNullable),
         )?;
         acc.accumulate(&batch, &mut LEGACY_SESSION.create_execution_ctx())?;
@@ -441,7 +441,7 @@ mod tests {
     #[test]
     fn sum_checked_overflow_is_saturated() -> VortexResult<()> {
         let dtype = DType::Primitive(PType::I64, Nullability::NonNullable);
-        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), dtype)?;
+        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), dtype)?;
         assert!(!acc.is_saturated());
 
         let batch =

--- a/vortex-array/src/aggregate_fn/proto.rs
+++ b/vortex-array/src/aggregate_fn/proto.rs
@@ -59,6 +59,7 @@ impl AggregateFnRef {
 #[cfg(test)]
 mod tests {
     use prost::Message;
+    use rstest::rstest;
     use vortex_error::VortexResult;
     use vortex_error::vortex_panic;
     use vortex_proto::expr as pb;
@@ -68,10 +69,12 @@ mod tests {
     use crate::Columnar;
     use crate::ExecutionCtx;
     use crate::aggregate_fn::AggregateFnId;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnRef;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::AggregateFnVTableExt;
     use crate::aggregate_fn::EmptyOptions;
+    use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::session::AggregateFnSession;
     use crate::aggregate_fn::session::AggregateFnSessionExt;
     use crate::dtype::DType;
@@ -166,6 +169,24 @@ mod tests {
         let deserialized = AggregateFnRef::from_proto(&deserialized_proto, &session).unwrap();
 
         assert_eq!(deserialized, agg_fn);
+    }
+
+    /// The `skip_nans` option must survive a protobuf serialize/deserialize round-trip for the
+    /// numeric aggregates, including the non-default NaN-including configuration.
+    #[rstest]
+    #[case(AggregateFnOpts::skip_nans())]
+    #[case(AggregateFnOpts::include_nans())]
+    fn numeric_aggregate_options_round_trip(#[case] options: AggregateFnOpts) -> VortexResult<()> {
+        let session = crate::array_session();
+        let agg_fn = Sum.bind(options);
+
+        let proto = agg_fn.serialize_proto()?;
+        let buf = proto.encode_to_vec();
+        let decoded = pb::AggregateFn::decode(buf.as_slice())?;
+        let round_tripped = AggregateFnRef::from_proto(&decoded, &session)?;
+
+        assert_eq!(round_tripped, agg_fn);
+        Ok(())
     }
 
     #[test]

--- a/vortex-array/src/aggregate_fn/proto.rs
+++ b/vortex-array/src/aggregate_fn/proto.rs
@@ -69,11 +69,11 @@ mod tests {
     use crate::Columnar;
     use crate::ExecutionCtx;
     use crate::aggregate_fn::AggregateFnId;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::AggregateFnRef;
     use crate::aggregate_fn::AggregateFnVTable;
     use crate::aggregate_fn::AggregateFnVTableExt;
     use crate::aggregate_fn::EmptyOptions;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::aggregate_fn::session::AggregateFnSession;
     use crate::aggregate_fn::session::AggregateFnSessionExt;
@@ -174,9 +174,11 @@ mod tests {
     /// The `skip_nans` option must survive a protobuf serialize/deserialize round-trip for the
     /// numeric aggregates, including the non-default NaN-including configuration.
     #[rstest]
-    #[case(AggregateFnOpts::skip_nans())]
-    #[case(AggregateFnOpts::include_nans())]
-    fn numeric_aggregate_options_round_trip(#[case] options: AggregateFnOpts) -> VortexResult<()> {
+    #[case(NumericalAggregateOpts::skip_nans())]
+    #[case(NumericalAggregateOpts::include_nans())]
+    fn numeric_aggregate_options_round_trip(
+        #[case] options: NumericalAggregateOpts,
+    ) -> VortexResult<()> {
         let session = crate::array_session();
         let agg_fn = Sum.bind(options);
 

--- a/vortex-array/src/aggregate_fn/vtable.rs
+++ b/vortex-array/src/aggregate_fn/vtable.rs
@@ -183,9 +183,27 @@ pub struct SkipNansOptions {
     pub skip_nans: bool,
 }
 
+impl SkipNansOptions {
+    /// Options that skip NaN values, treating them as missing during aggregation.
+    ///
+    /// This is the default configuration; see [`SkipNansOptions::include`] for the NaN-including
+    /// variant.
+    pub const fn skip() -> Self {
+        Self { skip_nans: true }
+    }
+
+    /// Options that include NaN values in the aggregate: `count` counts them, while any NaN
+    /// poisons the result of `sum`/`min`/`max`/`mean` to NaN.
+    ///
+    /// See [`SkipNansOptions::skip`] for the default NaN-skipping variant.
+    pub const fn include() -> Self {
+        Self { skip_nans: false }
+    }
+}
+
 impl Default for SkipNansOptions {
     fn default() -> Self {
-        Self { skip_nans: true }
+        Self::skip()
     }
 }
 

--- a/vortex-array/src/aggregate_fn/vtable.rs
+++ b/vortex-array/src/aggregate_fn/vtable.rs
@@ -167,6 +167,39 @@ impl Display for EmptyOptions {
     }
 }
 
+/// Options for aggregate functions over primitive numeric inputs, controlling how NaN values in
+/// floating-point arrays are handled.
+///
+/// When `skip_nans` is `true` (the default), NaN values are treated as missing: they contribute
+/// nothing to `sum`/`min`/`max`/`mean` and are excluded from `count`.
+///
+/// When `skip_nans` is `false`, NaN values participate in the aggregate: `count` includes them,
+/// while any NaN value poisons the result of `sum`/`min`/`max`/`mean` to NaN.
+///
+/// The option has no effect on non-float inputs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SkipNansOptions {
+    /// Whether NaN values are skipped (treated as missing) during aggregation.
+    pub skip_nans: bool,
+}
+
+impl Default for SkipNansOptions {
+    fn default() -> Self {
+        Self { skip_nans: true }
+    }
+}
+
+impl Display for SkipNansOptions {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        // Only the non-default configuration is displayed, so that aggregates with default
+        // options render identically to their pre-options form, e.g. `vortex.sum()`.
+        if !self.skip_nans {
+            write!(f, "skip_nans=false")?;
+        }
+        Ok(())
+    }
+}
+
 /// Factory functions for aggregate vtables.
 pub trait AggregateFnVTableExt: AggregateFnVTable {
     /// Bind this vtable with the given options into an [`AggregateFnRef`].

--- a/vortex-array/src/aggregate_fn/vtable.rs
+++ b/vortex-array/src/aggregate_fn/vtable.rs
@@ -7,8 +7,10 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::hash::Hash;
 
+use prost::Message;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_proto::expr as pb;
 use vortex_session::VortexSession;
 
 use crate::ArrayRef;
@@ -178,36 +180,52 @@ impl Display for EmptyOptions {
 ///
 /// The option has no effect on non-float inputs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct SkipNansOptions {
+pub struct AggregateFnOpts {
     /// Whether NaN values are skipped (treated as missing) during aggregation.
     pub skip_nans: bool,
 }
 
-impl SkipNansOptions {
+impl AggregateFnOpts {
     /// Options that skip NaN values, treating them as missing during aggregation.
     ///
-    /// This is the default configuration; see [`SkipNansOptions::include`] for the NaN-including
-    /// variant.
-    pub const fn skip() -> Self {
+    /// This is the default configuration; see [`AggregateFnOpts::include_nans`] for the
+    /// NaN-including variant.
+    pub const fn skip_nans() -> Self {
         Self { skip_nans: true }
     }
 
     /// Options that include NaN values in the aggregate: `count` counts them, while any NaN
     /// poisons the result of `sum`/`min`/`max`/`mean` to NaN.
     ///
-    /// See [`SkipNansOptions::skip`] for the default NaN-skipping variant.
-    pub const fn include() -> Self {
+    /// See [`AggregateFnOpts::skip_nans`] for the default NaN-skipping variant.
+    pub const fn include_nans() -> Self {
         Self { skip_nans: false }
     }
-}
 
-impl Default for SkipNansOptions {
-    fn default() -> Self {
-        Self::skip()
+    /// Serialize these options to protobuf-encoded metadata bytes.
+    pub fn serialize(&self) -> Vec<u8> {
+        pb::AggregateFnOpts {
+            skip_nans: self.skip_nans,
+        }
+        .encode_to_vec()
+    }
+
+    /// Deserialize these options from protobuf-encoded metadata bytes.
+    pub fn deserialize(metadata: &[u8]) -> VortexResult<Self> {
+        let opts = pb::AggregateFnOpts::decode(metadata)?;
+        Ok(Self {
+            skip_nans: opts.skip_nans,
+        })
     }
 }
 
-impl Display for SkipNansOptions {
+impl Default for AggregateFnOpts {
+    fn default() -> Self {
+        Self::skip_nans()
+    }
+}
+
+impl Display for AggregateFnOpts {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         // Only the non-default configuration is displayed, so that aggregates with default
         // options render identically to their pre-options form, e.g. `vortex.sum()`.

--- a/vortex-array/src/aggregate_fn/vtable.rs
+++ b/vortex-array/src/aggregate_fn/vtable.rs
@@ -180,15 +180,15 @@ impl Display for EmptyOptions {
 ///
 /// The option has no effect on non-float inputs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct AggregateFnOpts {
+pub struct NumericalAggregateOpts {
     /// Whether NaN values are skipped (treated as missing) during aggregation.
     pub skip_nans: bool,
 }
 
-impl AggregateFnOpts {
+impl NumericalAggregateOpts {
     /// Options that skip NaN values, treating them as missing during aggregation.
     ///
-    /// This is the default configuration; see [`AggregateFnOpts::include_nans`] for the
+    /// This is the default configuration; see [`NumericalAggregateOpts::include_nans`] for the
     /// NaN-including variant.
     pub const fn skip_nans() -> Self {
         Self { skip_nans: true }
@@ -197,14 +197,14 @@ impl AggregateFnOpts {
     /// Options that include NaN values in the aggregate: `count` counts them, while any NaN
     /// poisons the result of `sum`/`min`/`max`/`mean` to NaN.
     ///
-    /// See [`AggregateFnOpts::skip_nans`] for the default NaN-skipping variant.
+    /// See [`NumericalAggregateOpts::skip_nans`] for the default NaN-skipping variant.
     pub const fn include_nans() -> Self {
         Self { skip_nans: false }
     }
 
     /// Serialize these options to protobuf-encoded metadata bytes.
     pub fn serialize(&self) -> Vec<u8> {
-        pb::AggregateFnOpts {
+        pb::NumericalAggregateOpts {
             skip_nans: self.skip_nans,
         }
         .encode_to_vec()
@@ -212,20 +212,20 @@ impl AggregateFnOpts {
 
     /// Deserialize these options from protobuf-encoded metadata bytes.
     pub fn deserialize(metadata: &[u8]) -> VortexResult<Self> {
-        let opts = pb::AggregateFnOpts::decode(metadata)?;
+        let opts = pb::NumericalAggregateOpts::decode(metadata)?;
         Ok(Self {
             skip_nans: opts.skip_nans,
         })
     }
 }
 
-impl Default for AggregateFnOpts {
+impl Default for NumericalAggregateOpts {
     fn default() -> Self {
         Self::skip_nans()
     }
 }
 
-impl Display for AggregateFnOpts {
+impl Display for NumericalAggregateOpts {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         // Only the non-default configuration is displayed, so that aggregates with default
         // options render identically to their pre-options form, e.g. `vortex.sum()`.

--- a/vortex-array/src/arrays/chunked/compute/aggregate.rs
+++ b/vortex-array/src/arrays/chunked/compute/aggregate.rs
@@ -46,8 +46,8 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
-    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::DynAccumulator;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::arrays::BoolArray;
     use crate::arrays::ChunkedArray;
@@ -59,7 +59,11 @@ mod tests {
 
     fn run_sum(batch: &crate::ArrayRef) -> VortexResult<Scalar> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), batch.dtype().clone())?;
+        let mut acc = Accumulator::try_new(
+            Sum,
+            NumericalAggregateOpts::default(),
+            batch.dtype().clone(),
+        )?;
         acc.accumulate(batch, &mut ctx)?;
         acc.finish()
     }

--- a/vortex-array/src/arrays/chunked/compute/aggregate.rs
+++ b/vortex-array/src/arrays/chunked/compute/aggregate.rs
@@ -46,8 +46,8 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::arrays::BoolArray;
     use crate::arrays::ChunkedArray;
@@ -59,7 +59,7 @@ mod tests {
 
     fn run_sum(batch: &crate::ArrayRef) -> VortexResult<Scalar> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), batch.dtype().clone())?;
+        let mut acc = Accumulator::try_new(Sum, AggregateFnOpts::default(), batch.dtype().clone())?;
         acc.accumulate(batch, &mut ctx)?;
         acc.finish()
     }

--- a/vortex-array/src/arrays/chunked/compute/aggregate.rs
+++ b/vortex-array/src/arrays/chunked/compute/aggregate.rs
@@ -47,7 +47,7 @@ mod tests {
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
     use crate::aggregate_fn::DynAccumulator;
-    use crate::aggregate_fn::EmptyOptions;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::sum::Sum;
     use crate::arrays::BoolArray;
     use crate::arrays::ChunkedArray;
@@ -59,7 +59,7 @@ mod tests {
 
     fn run_sum(batch: &crate::ArrayRef) -> VortexResult<Scalar> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let mut acc = Accumulator::try_new(Sum, EmptyOptions, batch.dtype().clone())?;
+        let mut acc = Accumulator::try_new(Sum, SkipNansOptions::default(), batch.dtype().clone())?;
         acc.accumulate(batch, &mut ctx)?;
         acc.finish()
     }

--- a/vortex-array/src/arrays/dict/compute/min_max.rs
+++ b/vortex-array/src/arrays/dict/compute/min_max.rs
@@ -9,7 +9,7 @@ use crate::ExecutionCtx;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::fns::min_max::MinMax;
 use crate::aggregate_fn::fns::min_max::make_minmax_dtype;
-use crate::aggregate_fn::fns::min_max::min_max_with;
+use crate::aggregate_fn::fns::min_max::min_max;
 use crate::aggregate_fn::kernels::DynAggregateKernel;
 use crate::arrays::Dict;
 use crate::arrays::dict::DictArrayExt;
@@ -42,13 +42,13 @@ impl DynAggregateKernel for DictMinMaxKernel {
 
         let result = if dict.has_all_values_referenced() {
             // All values are referenced, compute min/max directly on the values array.
-            min_max_with(dict.values(), ctx, *options)?
+            min_max(dict.values(), ctx, *options)?
         } else {
             // Filter to only referenced values, then compute min/max.
             let referenced_mask = dict.compute_referenced_values_mask(true)?;
             let mask = Mask::from(referenced_mask);
             let filtered_values = dict.values().filter(mask)?;
-            min_max_with(&filtered_values, ctx, *options)?
+            min_max(&filtered_values, ctx, *options)?
         };
 
         match result {
@@ -70,6 +70,7 @@ mod tests {
     use crate::ArrayRef;
     use crate::IntoArray;
     use crate::VortexSessionExecute;
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::min_max::min_max;
     use crate::arrays::DictArray;
     use crate::arrays::PrimitiveArray;
@@ -79,7 +80,10 @@ mod tests {
 
     fn assert_min_max(array: &ArrayRef, expected: Option<(i32, i32)>) -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
-        match (min_max(array, &mut ctx)?, expected) {
+        match (
+            min_max(array, &mut ctx, SkipNansOptions::default())?,
+            expected,
+        ) {
             (Some(result), Some((expected_min, expected_max))) => {
                 assert_eq!(i32::try_from(&result.min)?, expected_min);
                 assert_eq!(i32::try_from(&result.max)?, expected_max);

--- a/vortex-array/src/arrays/dict/compute/min_max.rs
+++ b/vortex-array/src/arrays/dict/compute/min_max.rs
@@ -9,7 +9,7 @@ use crate::ExecutionCtx;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::fns::min_max::MinMax;
 use crate::aggregate_fn::fns::min_max::make_minmax_dtype;
-use crate::aggregate_fn::fns::min_max::min_max;
+use crate::aggregate_fn::fns::min_max::min_max_with;
 use crate::aggregate_fn::kernels::DynAggregateKernel;
 use crate::arrays::Dict;
 use crate::arrays::dict::DictArrayExt;
@@ -30,9 +30,9 @@ impl DynAggregateKernel for DictMinMaxKernel {
         batch: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<Scalar>> {
-        if !aggregate_fn.is::<MinMax>() {
+        let Some(options) = aggregate_fn.as_opt::<MinMax>() else {
             return Ok(None);
-        }
+        };
 
         let Some(dict) = batch.as_opt::<Dict>() else {
             return Ok(None);
@@ -42,13 +42,13 @@ impl DynAggregateKernel for DictMinMaxKernel {
 
         let result = if dict.has_all_values_referenced() {
             // All values are referenced, compute min/max directly on the values array.
-            min_max(dict.values(), ctx)?
+            min_max_with(dict.values(), ctx, *options)?
         } else {
             // Filter to only referenced values, then compute min/max.
             let referenced_mask = dict.compute_referenced_values_mask(true)?;
             let mask = Mask::from(referenced_mask);
             let filtered_values = dict.values().filter(mask)?;
-            min_max(&filtered_values, ctx)?
+            min_max_with(&filtered_values, ctx, *options)?
         };
 
         match result {

--- a/vortex-array/src/arrays/dict/compute/min_max.rs
+++ b/vortex-array/src/arrays/dict/compute/min_max.rs
@@ -70,7 +70,7 @@ mod tests {
     use crate::ArrayRef;
     use crate::IntoArray;
     use crate::VortexSessionExecute;
-    use crate::aggregate_fn::SkipNansOptions;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::fns::min_max::min_max;
     use crate::arrays::DictArray;
     use crate::arrays::PrimitiveArray;
@@ -81,7 +81,7 @@ mod tests {
     fn assert_min_max(array: &ArrayRef, expected: Option<(i32, i32)>) -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         match (
-            min_max(array, &mut ctx, SkipNansOptions::default())?,
+            min_max(array, &mut ctx, AggregateFnOpts::default())?,
             expected,
         ) {
             (Some(result), Some((expected_min, expected_max))) => {

--- a/vortex-array/src/arrays/dict/compute/min_max.rs
+++ b/vortex-array/src/arrays/dict/compute/min_max.rs
@@ -70,7 +70,7 @@ mod tests {
     use crate::ArrayRef;
     use crate::IntoArray;
     use crate::VortexSessionExecute;
-    use crate::aggregate_fn::AggregateFnOpts;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::min_max::min_max;
     use crate::arrays::DictArray;
     use crate::arrays::PrimitiveArray;
@@ -81,7 +81,7 @@ mod tests {
     fn assert_min_max(array: &ArrayRef, expected: Option<(i32, i32)>) -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         match (
-            min_max(array, &mut ctx, AggregateFnOpts::default())?,
+            min_max(array, &mut ctx, NumericalAggregateOpts::default())?,
             expected,
         ) {
             (Some(result), Some((expected_min, expected_max))) => {

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -20,6 +20,7 @@ use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
+use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::min_max::min_max;
 use crate::array::Array;
 use crate::array::ArrayParts;
@@ -212,7 +213,7 @@ impl ListData {
 
         // Validate that offsets min is non-negative, and max does not exceed the length of
         // the elements array.
-        if let Some(min_max) = min_max(offsets, &mut ctx)? {
+        if let Some(min_max) = min_max(offsets, &mut ctx, SkipNansOptions::default())? {
             match_each_integer_ptype!(offsets_ptype, |P| {
                 #[allow(clippy::absurd_extreme_comparisons, unused_comparisons)]
                 {

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -20,7 +20,7 @@ use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
-use crate::aggregate_fn::AggregateFnOpts;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::aggregate_fn::fns::min_max::min_max;
 use crate::array::Array;
 use crate::array::ArrayParts;
@@ -213,7 +213,7 @@ impl ListData {
 
         // Validate that offsets min is non-negative, and max does not exceed the length of
         // the elements array.
-        if let Some(min_max) = min_max(offsets, &mut ctx, AggregateFnOpts::default())? {
+        if let Some(min_max) = min_max(offsets, &mut ctx, NumericalAggregateOpts::default())? {
             match_each_integer_ptype!(offsets_ptype, |P| {
                 #[allow(clippy::absurd_extreme_comparisons, unused_comparisons)]
                 {

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -20,7 +20,7 @@ use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
-use crate::aggregate_fn::SkipNansOptions;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::fns::min_max::min_max;
 use crate::array::Array;
 use crate::array::ArrayParts;
@@ -213,7 +213,7 @@ impl ListData {
 
         // Validate that offsets min is non-negative, and max does not exceed the length of
         // the elements array.
-        if let Some(min_max) = min_max(offsets, &mut ctx, SkipNansOptions::default())? {
+        if let Some(min_max) = min_max(offsets, &mut ctx, AggregateFnOpts::default())? {
             match_each_integer_ptype!(offsets_ptype, |P| {
                 #[allow(clippy::absurd_extreme_comparisons, unused_comparisons)]
                 {

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -22,6 +22,7 @@ use crate::LEGACY_SESSION;
 #[expect(deprecated)]
 use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
+use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::min_max::min_max;
 use crate::array::Array;
 use crate::array::ArrayParts;
@@ -567,12 +568,16 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
         });
         let offsets = self.offsets().cast(wide_dtype.clone())?;
         let sizes = self.sizes().cast(wide_dtype)?;
-        let end = min_max(&offsets.binary(sizes, Operator::Add)?, ctx)?
-            .vortex_expect("non-empty array must report a min/max")
-            .max
-            .as_primitive()
-            .as_::<usize>()
-            .vortex_expect("max `offset + size` must fit in a usize");
+        let end = min_max(
+            &offsets.binary(sizes, Operator::Add)?,
+            ctx,
+            SkipNansOptions::default(),
+        )?
+        .vortex_expect("non-empty array must report a min/max")
+        .max
+        .as_primitive()
+        .as_::<usize>()
+        .vortex_expect("max `offset + size` must fit in a usize");
 
         Ok((start, end))
     }

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -22,7 +22,7 @@ use crate::LEGACY_SESSION;
 #[expect(deprecated)]
 use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
-use crate::aggregate_fn::AggregateFnOpts;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::aggregate_fn::fns::min_max::min_max;
 use crate::array::Array;
 use crate::array::ArrayParts;
@@ -571,7 +571,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
         let end = min_max(
             &offsets.binary(sizes, Operator::Add)?,
             ctx,
-            AggregateFnOpts::default(),
+            NumericalAggregateOpts::default(),
         )?
         .vortex_expect("non-empty array must report a min/max")
         .max

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -22,7 +22,7 @@ use crate::LEGACY_SESSION;
 #[expect(deprecated)]
 use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
-use crate::aggregate_fn::SkipNansOptions;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::fns::min_max::min_max;
 use crate::array::Array;
 use crate::array::ArrayParts;
@@ -571,7 +571,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
         let end = min_max(
             &offsets.binary(sizes, Operator::Add)?,
             ctx,
-            SkipNansOptions::default(),
+            AggregateFnOpts::default(),
         )?
         .vortex_expect("non-empty array must report a min/max")
         .max

--- a/vortex-array/src/arrays/primitive/array/mod.rs
+++ b/vortex-array/src/arrays/primitive/array/mod.rs
@@ -42,6 +42,7 @@ pub use patch::chunk_range;
 pub use patch::patch_chunk;
 
 use crate::ArrayRef;
+use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::min_max::min_max;
 use crate::array::child_to_validity;
 use crate::array::validity_to_child;
@@ -154,7 +155,7 @@ pub trait PrimitiveArrayExt: TypedArrayRef<Primitive> {
             return Ok(self.to_owned());
         }
 
-        let Some(min_max) = min_max(self.as_ref(), ctx)? else {
+        let Some(min_max) = min_max(self.as_ref(), ctx, SkipNansOptions::default())? else {
             return Ok(PrimitiveArray::new(
                 Buffer::<u8>::zeroed(self.len()),
                 self.validity(),

--- a/vortex-array/src/arrays/primitive/array/mod.rs
+++ b/vortex-array/src/arrays/primitive/array/mod.rs
@@ -42,7 +42,7 @@ pub use patch::chunk_range;
 pub use patch::patch_chunk;
 
 use crate::ArrayRef;
-use crate::aggregate_fn::AggregateFnOpts;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::aggregate_fn::fns::min_max::min_max;
 use crate::array::child_to_validity;
 use crate::array::validity_to_child;
@@ -155,7 +155,7 @@ pub trait PrimitiveArrayExt: TypedArrayRef<Primitive> {
             return Ok(self.to_owned());
         }
 
-        let Some(min_max) = min_max(self.as_ref(), ctx, AggregateFnOpts::default())? else {
+        let Some(min_max) = min_max(self.as_ref(), ctx, NumericalAggregateOpts::default())? else {
             return Ok(PrimitiveArray::new(
                 Buffer::<u8>::zeroed(self.len()),
                 self.validity(),

--- a/vortex-array/src/arrays/primitive/array/mod.rs
+++ b/vortex-array/src/arrays/primitive/array/mod.rs
@@ -42,7 +42,7 @@ pub use patch::chunk_range;
 pub use patch::patch_chunk;
 
 use crate::ArrayRef;
-use crate::aggregate_fn::SkipNansOptions;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::fns::min_max::min_max;
 use crate::array::child_to_validity;
 use crate::array::validity_to_child;
@@ -155,7 +155,7 @@ pub trait PrimitiveArrayExt: TypedArrayRef<Primitive> {
             return Ok(self.to_owned());
         }
 
-        let Some(min_max) = min_max(self.as_ref(), ctx, SkipNansOptions::default())? else {
+        let Some(min_max) = min_max(self.as_ref(), ctx, AggregateFnOpts::default())? else {
             return Ok(PrimitiveArray::new(
                 Buffer::<u8>::zeroed(self.len()),
                 self.validity(),

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -243,10 +243,14 @@ fn values_fit_in(
     if !compute {
         return false;
     }
-    aggregate_fn::fns::min_max::min_max(array.array(), ctx)
-        .ok()
-        .flatten()
-        .is_none_or(|mm| mm.min.cast(&target_dtype).is_ok() && mm.max.cast(&target_dtype).is_ok())
+    aggregate_fn::fns::min_max::min_max(
+        array.array(),
+        ctx,
+        aggregate_fn::SkipNansOptions::default(),
+    )
+    .ok()
+    .flatten()
+    .is_none_or(|mm| mm.min.cast(&target_dtype).is_ok() && mm.max.cast(&target_dtype).is_ok())
 }
 
 /// Cached-only check: returns `Some(fits)` if both `Min` and `Max` are present as `Exact` in the

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -246,7 +246,7 @@ fn values_fit_in(
     aggregate_fn::fns::min_max::min_max(
         array.array(),
         ctx,
-        aggregate_fn::AggregateFnOpts::default(),
+        aggregate_fn::NumericalAggregateOpts::default(),
     )
     .ok()
     .flatten()

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -246,7 +246,7 @@ fn values_fit_in(
     aggregate_fn::fns::min_max::min_max(
         array.array(),
         ctx,
-        aggregate_fn::SkipNansOptions::default(),
+        aggregate_fn::AggregateFnOpts::default(),
     )
     .ok()
     .flatten()

--- a/vortex-array/src/compute/conformance/cast.rs
+++ b/vortex-array/src/compute/conformance/cast.rs
@@ -10,7 +10,7 @@ use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::RecursiveCanonical;
 use crate::VortexSessionExecute;
-use crate::aggregate_fn::AggregateFnOpts;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::aggregate_fn::fns::min_max::MinMaxResult;
 use crate::aggregate_fn::fns::min_max::min_max;
 use crate::builtins::ArrayBuiltins;
@@ -249,7 +249,7 @@ fn fits(value: &Scalar, ptype: PType) -> bool {
 
 fn test_cast_to_primitive(array: &ArrayRef, target_ptype: PType, test_round_trip: bool) {
     let mut ctx = LEGACY_SESSION.create_execution_ctx();
-    let maybe_min_max = min_max(array, &mut ctx, AggregateFnOpts::default())
+    let maybe_min_max = min_max(array, &mut ctx, NumericalAggregateOpts::default())
         .vortex_expect("cast should succeed in conformance test");
 
     if let Some(MinMaxResult { min, max }) = maybe_min_max

--- a/vortex-array/src/compute/conformance/cast.rs
+++ b/vortex-array/src/compute/conformance/cast.rs
@@ -10,6 +10,7 @@ use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::RecursiveCanonical;
 use crate::VortexSessionExecute;
+use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::min_max::MinMaxResult;
 use crate::aggregate_fn::fns::min_max::min_max;
 use crate::builtins::ArrayBuiltins;
@@ -248,8 +249,8 @@ fn fits(value: &Scalar, ptype: PType) -> bool {
 
 fn test_cast_to_primitive(array: &ArrayRef, target_ptype: PType, test_round_trip: bool) {
     let mut ctx = LEGACY_SESSION.create_execution_ctx();
-    let maybe_min_max =
-        min_max(array, &mut ctx).vortex_expect("cast should succeed in conformance test");
+    let maybe_min_max = min_max(array, &mut ctx, SkipNansOptions::default())
+        .vortex_expect("cast should succeed in conformance test");
 
     if let Some(MinMaxResult { min, max }) = maybe_min_max
         && (!fits(&min, target_ptype) || !fits(&max, target_ptype))

--- a/vortex-array/src/compute/conformance/cast.rs
+++ b/vortex-array/src/compute/conformance/cast.rs
@@ -10,7 +10,7 @@ use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::RecursiveCanonical;
 use crate::VortexSessionExecute;
-use crate::aggregate_fn::SkipNansOptions;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::fns::min_max::MinMaxResult;
 use crate::aggregate_fn::fns::min_max::min_max;
 use crate::builtins::ArrayBuiltins;
@@ -249,7 +249,7 @@ fn fits(value: &Scalar, ptype: PType) -> bool {
 
 fn test_cast_to_primitive(array: &ArrayRef, target_ptype: PType, test_round_trip: bool) {
     let mut ctx = LEGACY_SESSION.create_execution_ctx();
-    let maybe_min_max = min_max(array, &mut ctx, SkipNansOptions::default())
+    let maybe_min_max = min_max(array, &mut ctx, AggregateFnOpts::default())
         .vortex_expect("cast should succeed in conformance test");
 
     if let Some(MinMaxResult { min, max }) = maybe_min_max

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -1017,6 +1017,7 @@ fn test_boolean_demorgan_consistency(array: &ArrayRef) {
 /// Aggregate operations on sliced arrays must produce correct results
 /// regardless of the underlying encoding's offset handling.
 fn test_slice_aggregate_consistency(array: &ArrayRef) {
+    use crate::aggregate_fn::SkipNansOptions;
     use crate::aggregate_fn::fns::min_max::min_max;
     use crate::aggregate_fn::fns::nan_count::nan_count;
     use crate::aggregate_fn::fns::sum::sum;
@@ -1075,8 +1076,8 @@ fn test_slice_aggregate_consistency(array: &ArrayRef) {
 
     // Test min_max
     if let (Ok(slice_minmax), Ok(canonical_minmax)) = (
-        min_max(&sliced, &mut ctx),
-        min_max(&canonical_sliced, &mut ctx),
+        min_max(&sliced, &mut ctx, SkipNansOptions::default()),
+        min_max(&canonical_sliced, &mut ctx, SkipNansOptions::default()),
     ) {
         match (slice_minmax, canonical_minmax) {
             (Some(s_result), Some(c_result)) => {

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -1017,7 +1017,7 @@ fn test_boolean_demorgan_consistency(array: &ArrayRef) {
 /// Aggregate operations on sliced arrays must produce correct results
 /// regardless of the underlying encoding's offset handling.
 fn test_slice_aggregate_consistency(array: &ArrayRef) {
-    use crate::aggregate_fn::SkipNansOptions;
+    use crate::aggregate_fn::AggregateFnOpts;
     use crate::aggregate_fn::fns::min_max::min_max;
     use crate::aggregate_fn::fns::nan_count::nan_count;
     use crate::aggregate_fn::fns::sum::sum;
@@ -1076,8 +1076,8 @@ fn test_slice_aggregate_consistency(array: &ArrayRef) {
 
     // Test min_max
     if let (Ok(slice_minmax), Ok(canonical_minmax)) = (
-        min_max(&sliced, &mut ctx, SkipNansOptions::default()),
-        min_max(&canonical_sliced, &mut ctx, SkipNansOptions::default()),
+        min_max(&sliced, &mut ctx, AggregateFnOpts::default()),
+        min_max(&canonical_sliced, &mut ctx, AggregateFnOpts::default()),
     ) {
         match (slice_minmax, canonical_minmax) {
             (Some(s_result), Some(c_result)) => {

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -1017,7 +1017,7 @@ fn test_boolean_demorgan_consistency(array: &ArrayRef) {
 /// Aggregate operations on sliced arrays must produce correct results
 /// regardless of the underlying encoding's offset handling.
 fn test_slice_aggregate_consistency(array: &ArrayRef) {
-    use crate::aggregate_fn::AggregateFnOpts;
+    use crate::aggregate_fn::NumericalAggregateOpts;
     use crate::aggregate_fn::fns::min_max::min_max;
     use crate::aggregate_fn::fns::nan_count::nan_count;
     use crate::aggregate_fn::fns::sum::sum;
@@ -1076,8 +1076,12 @@ fn test_slice_aggregate_consistency(array: &ArrayRef) {
 
     // Test min_max
     if let (Ok(slice_minmax), Ok(canonical_minmax)) = (
-        min_max(&sliced, &mut ctx, AggregateFnOpts::default()),
-        min_max(&canonical_sliced, &mut ctx, AggregateFnOpts::default()),
+        min_max(&sliced, &mut ctx, NumericalAggregateOpts::default()),
+        min_max(
+            &canonical_sliced,
+            &mut ctx,
+            NumericalAggregateOpts::default(),
+        ),
     ) {
         match (slice_minmax, canonical_minmax) {
             (Some(s_result), Some(c_result)) => {

--- a/vortex-array/src/expr/stats/mod.rs
+++ b/vortex-array/src/expr/stats/mod.rs
@@ -187,18 +187,20 @@ impl Stat {
                     .return_dtype(&EmptyOptions, data_type);
             }
             Self::Sum => {
+                // Statistics follow NaN-skipping semantics; request it explicitly.
                 return aggregate_fn::fns::sum::Sum
-                    .return_dtype(&SkipNansOptions::default(), data_type);
+                    .return_dtype(&SkipNansOptions::skip(), data_type);
             }
         })
     }
 
     /// Return the built-in aggregate function corresponding to this statistic, if one exists.
     pub fn aggregate_fn(&self) -> Option<AggregateFnRef> {
+        // Statistics follow NaN-skipping semantics; request it explicitly rather than the default.
         Some(match self {
-            Self::Max => aggregate_fn::fns::max::Max.bind(SkipNansOptions::default()),
-            Self::Min => aggregate_fn::fns::min::Min.bind(SkipNansOptions::default()),
-            Self::Sum => aggregate_fn::fns::sum::Sum.bind(SkipNansOptions::default()),
+            Self::Max => aggregate_fn::fns::max::Max.bind(SkipNansOptions::skip()),
+            Self::Min => aggregate_fn::fns::min::Min.bind(SkipNansOptions::skip()),
+            Self::Sum => aggregate_fn::fns::sum::Sum.bind(SkipNansOptions::skip()),
             Self::NullCount => aggregate_fn::fns::null_count::NullCount.bind(EmptyOptions),
             Self::NaNCount => aggregate_fn::fns::nan_count::NanCount.bind(EmptyOptions),
             Self::UncompressedSizeInBytes => {

--- a/vortex-array/src/expr/stats/mod.rs
+++ b/vortex-array/src/expr/stats/mod.rs
@@ -24,11 +24,11 @@ pub use provider::*;
 pub use stat_bound::*;
 
 use crate::aggregate_fn;
-use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::AggregateFnVTableExt;
 use crate::aggregate_fn::EmptyOptions;
+use crate::aggregate_fn::NumericalAggregateOpts;
 
 #[derive(
     Debug,
@@ -189,7 +189,7 @@ impl Stat {
             Self::Sum => {
                 // Statistics follow NaN-skipping semantics; request it explicitly.
                 return aggregate_fn::fns::sum::Sum
-                    .return_dtype(&AggregateFnOpts::skip_nans(), data_type);
+                    .return_dtype(&NumericalAggregateOpts::skip_nans(), data_type);
             }
         })
     }
@@ -198,9 +198,9 @@ impl Stat {
     pub fn aggregate_fn(&self) -> Option<AggregateFnRef> {
         // Statistics follow NaN-skipping semantics; request it explicitly rather than the default.
         Some(match self {
-            Self::Max => aggregate_fn::fns::max::Max.bind(AggregateFnOpts::skip_nans()),
-            Self::Min => aggregate_fn::fns::min::Min.bind(AggregateFnOpts::skip_nans()),
-            Self::Sum => aggregate_fn::fns::sum::Sum.bind(AggregateFnOpts::skip_nans()),
+            Self::Max => aggregate_fn::fns::max::Max.bind(NumericalAggregateOpts::skip_nans()),
+            Self::Min => aggregate_fn::fns::min::Min.bind(NumericalAggregateOpts::skip_nans()),
+            Self::Sum => aggregate_fn::fns::sum::Sum.bind(NumericalAggregateOpts::skip_nans()),
             Self::NullCount => aggregate_fn::fns::null_count::NullCount.bind(EmptyOptions),
             Self::NaNCount => aggregate_fn::fns::nan_count::NanCount.bind(EmptyOptions),
             Self::UncompressedSizeInBytes => {

--- a/vortex-array/src/expr/stats/mod.rs
+++ b/vortex-array/src/expr/stats/mod.rs
@@ -28,6 +28,7 @@ use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::AggregateFnVTableExt;
 use crate::aggregate_fn::EmptyOptions;
+use crate::aggregate_fn::SkipNansOptions;
 
 #[derive(
     Debug,
@@ -186,7 +187,8 @@ impl Stat {
                     .return_dtype(&EmptyOptions, data_type);
             }
             Self::Sum => {
-                return aggregate_fn::fns::sum::Sum.return_dtype(&EmptyOptions, data_type);
+                return aggregate_fn::fns::sum::Sum
+                    .return_dtype(&SkipNansOptions::default(), data_type);
             }
         })
     }
@@ -194,9 +196,9 @@ impl Stat {
     /// Return the built-in aggregate function corresponding to this statistic, if one exists.
     pub fn aggregate_fn(&self) -> Option<AggregateFnRef> {
         Some(match self {
-            Self::Max => aggregate_fn::fns::max::Max.bind(EmptyOptions),
-            Self::Min => aggregate_fn::fns::min::Min.bind(EmptyOptions),
-            Self::Sum => aggregate_fn::fns::sum::Sum.bind(EmptyOptions),
+            Self::Max => aggregate_fn::fns::max::Max.bind(SkipNansOptions::default()),
+            Self::Min => aggregate_fn::fns::min::Min.bind(SkipNansOptions::default()),
+            Self::Sum => aggregate_fn::fns::sum::Sum.bind(SkipNansOptions::default()),
             Self::NullCount => aggregate_fn::fns::null_count::NullCount.bind(EmptyOptions),
             Self::NaNCount => aggregate_fn::fns::nan_count::NanCount.bind(EmptyOptions),
             Self::UncompressedSizeInBytes => {
@@ -208,9 +210,12 @@ impl Stat {
     }
 
     /// Return the statistic represented by `aggregate_fn`, if it has a legacy stat slot.
+    ///
+    /// Min/max/sum statistics skip NaN values, so NaN-including configurations of those
+    /// aggregates have no stat slot.
     pub fn from_aggregate_fn(aggregate_fn: &AggregateFnRef) -> Option<Self> {
-        if aggregate_fn.is::<aggregate_fn::fns::sum::Sum>() {
-            return Some(Self::Sum);
+        if let Some(options) = aggregate_fn.as_opt::<aggregate_fn::fns::sum::Sum>() {
+            return options.skip_nans.then_some(Self::Sum);
         }
         if aggregate_fn.is::<aggregate_fn::fns::nan_count::NanCount>() {
             return Some(Self::NaNCount);
@@ -218,11 +223,11 @@ impl Stat {
         if aggregate_fn.is::<aggregate_fn::fns::null_count::NullCount>() {
             return Some(Self::NullCount);
         }
-        if aggregate_fn.is::<aggregate_fn::fns::min::Min>() {
-            return Some(Self::Min);
+        if let Some(options) = aggregate_fn.as_opt::<aggregate_fn::fns::min::Min>() {
+            return options.skip_nans.then_some(Self::Min);
         }
-        if aggregate_fn.is::<aggregate_fn::fns::max::Max>() {
-            return Some(Self::Max);
+        if let Some(options) = aggregate_fn.as_opt::<aggregate_fn::fns::max::Max>() {
+            return options.skip_nans.then_some(Self::Max);
         }
         if aggregate_fn
             .is::<aggregate_fn::fns::uncompressed_size_in_bytes::UncompressedSizeInBytes>()

--- a/vortex-array/src/expr/stats/mod.rs
+++ b/vortex-array/src/expr/stats/mod.rs
@@ -24,11 +24,11 @@ pub use provider::*;
 pub use stat_bound::*;
 
 use crate::aggregate_fn;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::AggregateFnVTableExt;
 use crate::aggregate_fn::EmptyOptions;
-use crate::aggregate_fn::SkipNansOptions;
 
 #[derive(
     Debug,
@@ -189,7 +189,7 @@ impl Stat {
             Self::Sum => {
                 // Statistics follow NaN-skipping semantics; request it explicitly.
                 return aggregate_fn::fns::sum::Sum
-                    .return_dtype(&SkipNansOptions::skip(), data_type);
+                    .return_dtype(&AggregateFnOpts::skip_nans(), data_type);
             }
         })
     }
@@ -198,9 +198,9 @@ impl Stat {
     pub fn aggregate_fn(&self) -> Option<AggregateFnRef> {
         // Statistics follow NaN-skipping semantics; request it explicitly rather than the default.
         Some(match self {
-            Self::Max => aggregate_fn::fns::max::Max.bind(SkipNansOptions::skip()),
-            Self::Min => aggregate_fn::fns::min::Min.bind(SkipNansOptions::skip()),
-            Self::Sum => aggregate_fn::fns::sum::Sum.bind(SkipNansOptions::skip()),
+            Self::Max => aggregate_fn::fns::max::Max.bind(AggregateFnOpts::skip_nans()),
+            Self::Min => aggregate_fn::fns::min::Min.bind(AggregateFnOpts::skip_nans()),
+            Self::Sum => aggregate_fn::fns::sum::Sum.bind(AggregateFnOpts::skip_nans()),
             Self::NullCount => aggregate_fn::fns::null_count::NullCount.bind(EmptyOptions),
             Self::NaNCount => aggregate_fn::fns::nan_count::NanCount.bind(EmptyOptions),
             Self::UncompressedSizeInBytes => {

--- a/vortex-array/src/stats/array.rs
+++ b/vortex-array/src/stats/array.rs
@@ -16,7 +16,7 @@ use super::StatsSet;
 use super::StatsSetIntoIter;
 use super::TypedStatsSetRef;
 use crate::ArrayRef;
-use crate::aggregate_fn::SkipNansOptions;
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::fns::is_constant::is_constant;
 use crate::aggregate_fn::fns::is_sorted::is_sorted;
 use crate::aggregate_fn::fns::is_sorted::is_strict_sorted;
@@ -163,9 +163,9 @@ impl StatsSetRef<'_> {
         }
 
         Ok(match stat {
-            Stat::Min => min_max(self.dyn_array_ref, ctx, SkipNansOptions::default())?
+            Stat::Min => min_max(self.dyn_array_ref, ctx, AggregateFnOpts::default())?
                 .map(|MinMaxResult { min, max: _ }| min),
-            Stat::Max => min_max(self.dyn_array_ref, ctx, SkipNansOptions::default())?
+            Stat::Max => min_max(self.dyn_array_ref, ctx, AggregateFnOpts::default())?
                 .map(|MinMaxResult { min: _, max }| max),
             Stat::Sum => {
                 Stat::Sum

--- a/vortex-array/src/stats/array.rs
+++ b/vortex-array/src/stats/array.rs
@@ -16,7 +16,7 @@ use super::StatsSet;
 use super::StatsSetIntoIter;
 use super::TypedStatsSetRef;
 use crate::ArrayRef;
-use crate::aggregate_fn::AggregateFnOpts;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::aggregate_fn::fns::is_constant::is_constant;
 use crate::aggregate_fn::fns::is_sorted::is_sorted;
 use crate::aggregate_fn::fns::is_sorted::is_strict_sorted;
@@ -163,9 +163,9 @@ impl StatsSetRef<'_> {
         }
 
         Ok(match stat {
-            Stat::Min => min_max(self.dyn_array_ref, ctx, AggregateFnOpts::default())?
+            Stat::Min => min_max(self.dyn_array_ref, ctx, NumericalAggregateOpts::default())?
                 .map(|MinMaxResult { min, max: _ }| min),
-            Stat::Max => min_max(self.dyn_array_ref, ctx, AggregateFnOpts::default())?
+            Stat::Max => min_max(self.dyn_array_ref, ctx, NumericalAggregateOpts::default())?
                 .map(|MinMaxResult { min: _, max }| max),
             Stat::Sum => {
                 Stat::Sum

--- a/vortex-array/src/stats/array.rs
+++ b/vortex-array/src/stats/array.rs
@@ -16,6 +16,7 @@ use super::StatsSet;
 use super::StatsSetIntoIter;
 use super::TypedStatsSetRef;
 use crate::ArrayRef;
+use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::is_constant::is_constant;
 use crate::aggregate_fn::fns::is_sorted::is_sorted;
 use crate::aggregate_fn::fns::is_sorted::is_strict_sorted;
@@ -162,8 +163,10 @@ impl StatsSetRef<'_> {
         }
 
         Ok(match stat {
-            Stat::Min => min_max(self.dyn_array_ref, ctx)?.map(|MinMaxResult { min, max: _ }| min),
-            Stat::Max => min_max(self.dyn_array_ref, ctx)?.map(|MinMaxResult { min: _, max }| max),
+            Stat::Min => min_max(self.dyn_array_ref, ctx, SkipNansOptions::default())?
+                .map(|MinMaxResult { min, max: _ }| min),
+            Stat::Max => min_max(self.dyn_array_ref, ctx, SkipNansOptions::default())?
+                .map(|MinMaxResult { min: _, max }| max),
             Stat::Sum => {
                 Stat::Sum
                     .dtype(self.dyn_array_ref.dtype())

--- a/vortex-array/src/stats/expr.rs
+++ b/vortex-array/src/stats/expr.rs
@@ -6,6 +6,7 @@
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnVTableExt;
 use crate::aggregate_fn::EmptyOptions;
+use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::all_nan::AllNan;
 use crate::aggregate_fn::fns::all_non_nan::AllNonNan;
 use crate::aggregate_fn::fns::all_non_null::AllNonNull;
@@ -29,12 +30,12 @@ pub fn stat(expr: Expression, aggregate_fn: AggregateFnRef) -> Expression {
 
 /// Creates `stat(expr, min_max)`, returning a nullable `{ min, max }` struct statistic.
 pub fn min_max(expr: Expression) -> Expression {
-    stat(expr, MinMax.bind(EmptyOptions))
+    stat(expr, MinMax.bind(SkipNansOptions::default()))
 }
 
 /// Creates `stat(expr, sum)`, returning a nullable sum statistic.
 pub fn sum(expr: Expression) -> Expression {
-    stat(expr, Sum.bind(EmptyOptions))
+    stat(expr, Sum.bind(SkipNansOptions::default()))
 }
 
 /// Creates `stat(expr, null_count)`, returning a nullable null-count statistic.

--- a/vortex-array/src/stats/expr.rs
+++ b/vortex-array/src/stats/expr.rs
@@ -3,10 +3,10 @@
 
 //! Expression constructors for statistics backed by aggregate functions.
 
-use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnVTableExt;
 use crate::aggregate_fn::EmptyOptions;
+use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::aggregate_fn::fns::all_nan::AllNan;
 use crate::aggregate_fn::fns::all_non_nan::AllNonNan;
 use crate::aggregate_fn::fns::all_non_null::AllNonNull;
@@ -31,13 +31,13 @@ pub fn stat(expr: Expression, aggregate_fn: AggregateFnRef) -> Expression {
 /// Creates `stat(expr, min_max)`, returning a nullable `{ min, max }` struct statistic.
 pub fn min_max(expr: Expression) -> Expression {
     // Statistics follow NaN-skipping semantics; request it explicitly rather than via the default.
-    stat(expr, MinMax.bind(AggregateFnOpts::skip_nans()))
+    stat(expr, MinMax.bind(NumericalAggregateOpts::skip_nans()))
 }
 
 /// Creates `stat(expr, sum)`, returning a nullable sum statistic.
 pub fn sum(expr: Expression) -> Expression {
     // Statistics follow NaN-skipping semantics; request it explicitly rather than via the default.
-    stat(expr, Sum.bind(AggregateFnOpts::skip_nans()))
+    stat(expr, Sum.bind(NumericalAggregateOpts::skip_nans()))
 }
 
 /// Creates `stat(expr, null_count)`, returning a nullable null-count statistic.

--- a/vortex-array/src/stats/expr.rs
+++ b/vortex-array/src/stats/expr.rs
@@ -3,10 +3,10 @@
 
 //! Expression constructors for statistics backed by aggregate functions.
 
+use crate::aggregate_fn::AggregateFnOpts;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnVTableExt;
 use crate::aggregate_fn::EmptyOptions;
-use crate::aggregate_fn::SkipNansOptions;
 use crate::aggregate_fn::fns::all_nan::AllNan;
 use crate::aggregate_fn::fns::all_non_nan::AllNonNan;
 use crate::aggregate_fn::fns::all_non_null::AllNonNull;
@@ -31,13 +31,13 @@ pub fn stat(expr: Expression, aggregate_fn: AggregateFnRef) -> Expression {
 /// Creates `stat(expr, min_max)`, returning a nullable `{ min, max }` struct statistic.
 pub fn min_max(expr: Expression) -> Expression {
     // Statistics follow NaN-skipping semantics; request it explicitly rather than via the default.
-    stat(expr, MinMax.bind(SkipNansOptions::skip()))
+    stat(expr, MinMax.bind(AggregateFnOpts::skip_nans()))
 }
 
 /// Creates `stat(expr, sum)`, returning a nullable sum statistic.
 pub fn sum(expr: Expression) -> Expression {
     // Statistics follow NaN-skipping semantics; request it explicitly rather than via the default.
-    stat(expr, Sum.bind(SkipNansOptions::skip()))
+    stat(expr, Sum.bind(AggregateFnOpts::skip_nans()))
 }
 
 /// Creates `stat(expr, null_count)`, returning a nullable null-count statistic.

--- a/vortex-array/src/stats/expr.rs
+++ b/vortex-array/src/stats/expr.rs
@@ -30,12 +30,14 @@ pub fn stat(expr: Expression, aggregate_fn: AggregateFnRef) -> Expression {
 
 /// Creates `stat(expr, min_max)`, returning a nullable `{ min, max }` struct statistic.
 pub fn min_max(expr: Expression) -> Expression {
-    stat(expr, MinMax.bind(SkipNansOptions::default()))
+    // Statistics follow NaN-skipping semantics; request it explicitly rather than via the default.
+    stat(expr, MinMax.bind(SkipNansOptions::skip()))
 }
 
 /// Creates `stat(expr, sum)`, returning a nullable sum statistic.
 pub fn sum(expr: Expression) -> Expression {
-    stat(expr, Sum.bind(SkipNansOptions::default()))
+    // Statistics follow NaN-skipping semantics; request it explicitly rather than via the default.
+    stat(expr, Sum.bind(SkipNansOptions::skip()))
 }
 
 /// Creates `stat(expr, null_count)`, returning a nullable null-count statistic.

--- a/vortex-layout/src/layouts/zoned/mod.rs
+++ b/vortex-layout/src/layouts/zoned/mod.rs
@@ -492,9 +492,9 @@ mod tests {
     use std::panic;
 
     use rstest::rstest;
+    use vortex_array::aggregate_fn::AggregateFnOpts;
     use vortex_array::aggregate_fn::AggregateFnRef;
     use vortex_array::aggregate_fn::AggregateFnVTableExt;
-    use vortex_array::aggregate_fn::SkipNansOptions;
     use vortex_array::aggregate_fn::fns::bounded_max::BoundedMax;
     use vortex_array::aggregate_fn::fns::bounded_max::BoundedMaxOptions;
     use vortex_array::aggregate_fn::fns::max::Max;
@@ -525,8 +525,8 @@ mod tests {
     #[case::min_max(ZonedMetadata {
             zone_len: 314,
             aggregate_specs: Arc::new([
-                aggregate_spec(Max.bind(SkipNansOptions::skip())),
-                aggregate_spec(Min.bind(SkipNansOptions::skip())),
+                aggregate_spec(Max.bind(AggregateFnOpts::skip_nans())),
+                aggregate_spec(Min.bind(AggregateFnOpts::skip_nans())),
             ]),
         })]
     fn test_metadata_serialization(#[case] metadata: ZonedMetadata) {

--- a/vortex-layout/src/layouts/zoned/mod.rs
+++ b/vortex-layout/src/layouts/zoned/mod.rs
@@ -492,9 +492,9 @@ mod tests {
     use std::panic;
 
     use rstest::rstest;
-    use vortex_array::aggregate_fn::AggregateFnOpts;
     use vortex_array::aggregate_fn::AggregateFnRef;
     use vortex_array::aggregate_fn::AggregateFnVTableExt;
+    use vortex_array::aggregate_fn::NumericalAggregateOpts;
     use vortex_array::aggregate_fn::fns::bounded_max::BoundedMax;
     use vortex_array::aggregate_fn::fns::bounded_max::BoundedMaxOptions;
     use vortex_array::aggregate_fn::fns::max::Max;
@@ -525,8 +525,8 @@ mod tests {
     #[case::min_max(ZonedMetadata {
             zone_len: 314,
             aggregate_specs: Arc::new([
-                aggregate_spec(Max.bind(AggregateFnOpts::skip_nans())),
-                aggregate_spec(Min.bind(AggregateFnOpts::skip_nans())),
+                aggregate_spec(Max.bind(NumericalAggregateOpts::skip_nans())),
+                aggregate_spec(Min.bind(NumericalAggregateOpts::skip_nans())),
             ]),
         })]
     fn test_metadata_serialization(#[case] metadata: ZonedMetadata) {

--- a/vortex-layout/src/layouts/zoned/mod.rs
+++ b/vortex-layout/src/layouts/zoned/mod.rs
@@ -494,7 +494,7 @@ mod tests {
     use rstest::rstest;
     use vortex_array::aggregate_fn::AggregateFnRef;
     use vortex_array::aggregate_fn::AggregateFnVTableExt;
-    use vortex_array::aggregate_fn::EmptyOptions;
+    use vortex_array::aggregate_fn::SkipNansOptions;
     use vortex_array::aggregate_fn::fns::bounded_max::BoundedMax;
     use vortex_array::aggregate_fn::fns::bounded_max::BoundedMaxOptions;
     use vortex_array::aggregate_fn::fns::max::Max;
@@ -525,8 +525,8 @@ mod tests {
     #[case::min_max(ZonedMetadata {
             zone_len: 314,
             aggregate_specs: Arc::new([
-                aggregate_spec(Max.bind(EmptyOptions)),
-                aggregate_spec(Min.bind(EmptyOptions)),
+                aggregate_spec(Max.bind(SkipNansOptions::skip())),
+                aggregate_spec(Min.bind(SkipNansOptions::skip())),
             ]),
         })]
     fn test_metadata_serialization(#[case] metadata: ZonedMetadata) {

--- a/vortex-layout/src/layouts/zoned/schema.rs
+++ b/vortex-layout/src/layouts/zoned/schema.rs
@@ -152,8 +152,8 @@ pub(crate) fn default_bounded_stat_max_bytes() -> std::num::NonZeroUsize {
 
 #[cfg(test)]
 mod tests {
+    use vortex_array::aggregate_fn::AggregateFnOpts;
     use vortex_array::aggregate_fn::AggregateFnVTableExt;
-    use vortex_array::aggregate_fn::SkipNansOptions;
     use vortex_array::aggregate_fn::fns::max::Max;
     use vortex_array::aggregate_fn::fns::min::Min;
     use vortex_array::aggregate_fn::fns::sum::Sum;
@@ -205,18 +205,18 @@ mod tests {
         let dtype = aggregate_stats_table_dtype(
             &DType::Primitive(PType::I32, Nullability::NonNullable),
             &[
-                Max.bind(SkipNansOptions::skip()),
-                Min.bind(SkipNansOptions::skip()),
-                Sum.bind(SkipNansOptions::skip()),
+                Max.bind(AggregateFnOpts::skip_nans()),
+                Min.bind(AggregateFnOpts::skip_nans()),
+                Sum.bind(AggregateFnOpts::skip_nans()),
             ],
         );
 
         assert_eq!(
             dtype.as_struct_fields().names().as_ref(),
             &[
-                Max.bind(SkipNansOptions::skip()).to_string(),
-                Min.bind(SkipNansOptions::skip()).to_string(),
-                Sum.bind(SkipNansOptions::skip()).to_string(),
+                Max.bind(AggregateFnOpts::skip_nans()).to_string(),
+                Min.bind(AggregateFnOpts::skip_nans()).to_string(),
+                Sum.bind(AggregateFnOpts::skip_nans()).to_string(),
             ]
         );
     }

--- a/vortex-layout/src/layouts/zoned/schema.rs
+++ b/vortex-layout/src/layouts/zoned/schema.rs
@@ -153,7 +153,7 @@ pub(crate) fn default_bounded_stat_max_bytes() -> std::num::NonZeroUsize {
 #[cfg(test)]
 mod tests {
     use vortex_array::aggregate_fn::AggregateFnVTableExt;
-    use vortex_array::aggregate_fn::EmptyOptions;
+    use vortex_array::aggregate_fn::SkipNansOptions;
     use vortex_array::aggregate_fn::fns::max::Max;
     use vortex_array::aggregate_fn::fns::min::Min;
     use vortex_array::aggregate_fn::fns::sum::Sum;
@@ -205,18 +205,18 @@ mod tests {
         let dtype = aggregate_stats_table_dtype(
             &DType::Primitive(PType::I32, Nullability::NonNullable),
             &[
-                Max.bind(EmptyOptions),
-                Min.bind(EmptyOptions),
-                Sum.bind(EmptyOptions),
+                Max.bind(SkipNansOptions::skip()),
+                Min.bind(SkipNansOptions::skip()),
+                Sum.bind(SkipNansOptions::skip()),
             ],
         );
 
         assert_eq!(
             dtype.as_struct_fields().names().as_ref(),
             &[
-                Max.bind(EmptyOptions).to_string(),
-                Min.bind(EmptyOptions).to_string(),
-                Sum.bind(EmptyOptions).to_string(),
+                Max.bind(SkipNansOptions::skip()).to_string(),
+                Min.bind(SkipNansOptions::skip()).to_string(),
+                Sum.bind(SkipNansOptions::skip()).to_string(),
             ]
         );
     }

--- a/vortex-layout/src/layouts/zoned/schema.rs
+++ b/vortex-layout/src/layouts/zoned/schema.rs
@@ -152,8 +152,8 @@ pub(crate) fn default_bounded_stat_max_bytes() -> std::num::NonZeroUsize {
 
 #[cfg(test)]
 mod tests {
-    use vortex_array::aggregate_fn::AggregateFnOpts;
     use vortex_array::aggregate_fn::AggregateFnVTableExt;
+    use vortex_array::aggregate_fn::NumericalAggregateOpts;
     use vortex_array::aggregate_fn::fns::max::Max;
     use vortex_array::aggregate_fn::fns::min::Min;
     use vortex_array::aggregate_fn::fns::sum::Sum;
@@ -205,18 +205,18 @@ mod tests {
         let dtype = aggregate_stats_table_dtype(
             &DType::Primitive(PType::I32, Nullability::NonNullable),
             &[
-                Max.bind(AggregateFnOpts::skip_nans()),
-                Min.bind(AggregateFnOpts::skip_nans()),
-                Sum.bind(AggregateFnOpts::skip_nans()),
+                Max.bind(NumericalAggregateOpts::skip_nans()),
+                Min.bind(NumericalAggregateOpts::skip_nans()),
+                Sum.bind(NumericalAggregateOpts::skip_nans()),
             ],
         );
 
         assert_eq!(
             dtype.as_struct_fields().names().as_ref(),
             &[
-                Max.bind(AggregateFnOpts::skip_nans()).to_string(),
-                Min.bind(AggregateFnOpts::skip_nans()).to_string(),
-                Sum.bind(AggregateFnOpts::skip_nans()).to_string(),
+                Max.bind(NumericalAggregateOpts::skip_nans()).to_string(),
+                Min.bind(NumericalAggregateOpts::skip_nans()).to_string(),
+                Sum.bind(NumericalAggregateOpts::skip_nans()).to_string(),
             ]
         );
     }

--- a/vortex-layout/src/layouts/zoned/writer.rs
+++ b/vortex-layout/src/layouts/zoned/writer.rs
@@ -11,11 +11,11 @@ use parking_lot::Mutex;
 use vortex_array::ArrayContext;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
-use vortex_array::aggregate_fn::AggregateFnOpts;
 use vortex_array::aggregate_fn::AggregateFnRef;
 use vortex_array::aggregate_fn::AggregateFnVTable;
 use vortex_array::aggregate_fn::AggregateFnVTableExt;
 use vortex_array::aggregate_fn::EmptyOptions;
+use vortex_array::aggregate_fn::NumericalAggregateOpts;
 use vortex_array::aggregate_fn::fns::bounded_max::BoundedMax;
 use vortex_array::aggregate_fn::fns::bounded_max::BoundedMaxOptions;
 use vortex_array::aggregate_fn::fns::bounded_min::BoundedMin;
@@ -189,17 +189,17 @@ fn default_zoned_aggregate_fns(dtype: &DType) -> Arc<[AggregateFnRef]> {
             }),
         ),
         _ => (
-            Max.bind(AggregateFnOpts::skip_nans()),
-            Min.bind(AggregateFnOpts::skip_nans()),
+            Max.bind(NumericalAggregateOpts::skip_nans()),
+            Min.bind(NumericalAggregateOpts::skip_nans()),
         ),
     };
 
     let mut aggregate_fns = vec![max, min];
     if Sum
-        .return_dtype(&AggregateFnOpts::skip_nans(), dtype)
+        .return_dtype(&NumericalAggregateOpts::skip_nans(), dtype)
         .is_some()
     {
-        aggregate_fns.push(Sum.bind(AggregateFnOpts::skip_nans()));
+        aggregate_fns.push(Sum.bind(NumericalAggregateOpts::skip_nans()));
     }
     aggregate_fns.push(NanCount.bind(EmptyOptions));
     aggregate_fns.push(NullCount.bind(EmptyOptions));

--- a/vortex-layout/src/layouts/zoned/writer.rs
+++ b/vortex-layout/src/layouts/zoned/writer.rs
@@ -15,6 +15,7 @@ use vortex_array::aggregate_fn::AggregateFnRef;
 use vortex_array::aggregate_fn::AggregateFnVTable;
 use vortex_array::aggregate_fn::AggregateFnVTableExt;
 use vortex_array::aggregate_fn::EmptyOptions;
+use vortex_array::aggregate_fn::SkipNansOptions;
 use vortex_array::aggregate_fn::fns::bounded_max::BoundedMax;
 use vortex_array::aggregate_fn::fns::bounded_max::BoundedMaxOptions;
 use vortex_array::aggregate_fn::fns::bounded_min::BoundedMin;
@@ -187,12 +188,15 @@ fn default_zoned_aggregate_fns(dtype: &DType) -> Arc<[AggregateFnRef]> {
                 max_bytes: default_bounded_stat_max_bytes(),
             }),
         ),
-        _ => (Max.bind(EmptyOptions), Min.bind(EmptyOptions)),
+        _ => (
+            Max.bind(SkipNansOptions::skip()),
+            Min.bind(SkipNansOptions::skip()),
+        ),
     };
 
     let mut aggregate_fns = vec![max, min];
-    if Sum.return_dtype(&EmptyOptions, dtype).is_some() {
-        aggregate_fns.push(Sum.bind(EmptyOptions));
+    if Sum.return_dtype(&SkipNansOptions::skip(), dtype).is_some() {
+        aggregate_fns.push(Sum.bind(SkipNansOptions::skip()));
     }
     aggregate_fns.push(NanCount.bind(EmptyOptions));
     aggregate_fns.push(NullCount.bind(EmptyOptions));

--- a/vortex-layout/src/layouts/zoned/writer.rs
+++ b/vortex-layout/src/layouts/zoned/writer.rs
@@ -11,11 +11,11 @@ use parking_lot::Mutex;
 use vortex_array::ArrayContext;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::aggregate_fn::AggregateFnOpts;
 use vortex_array::aggregate_fn::AggregateFnRef;
 use vortex_array::aggregate_fn::AggregateFnVTable;
 use vortex_array::aggregate_fn::AggregateFnVTableExt;
 use vortex_array::aggregate_fn::EmptyOptions;
-use vortex_array::aggregate_fn::SkipNansOptions;
 use vortex_array::aggregate_fn::fns::bounded_max::BoundedMax;
 use vortex_array::aggregate_fn::fns::bounded_max::BoundedMaxOptions;
 use vortex_array::aggregate_fn::fns::bounded_min::BoundedMin;
@@ -189,14 +189,17 @@ fn default_zoned_aggregate_fns(dtype: &DType) -> Arc<[AggregateFnRef]> {
             }),
         ),
         _ => (
-            Max.bind(SkipNansOptions::skip()),
-            Min.bind(SkipNansOptions::skip()),
+            Max.bind(AggregateFnOpts::skip_nans()),
+            Min.bind(AggregateFnOpts::skip_nans()),
         ),
     };
 
     let mut aggregate_fns = vec![max, min];
-    if Sum.return_dtype(&SkipNansOptions::skip(), dtype).is_some() {
-        aggregate_fns.push(Sum.bind(SkipNansOptions::skip()));
+    if Sum
+        .return_dtype(&AggregateFnOpts::skip_nans(), dtype)
+        .is_some()
+    {
+        aggregate_fns.push(Sum.bind(AggregateFnOpts::skip_nans()));
     }
     aggregate_fns.push(NanCount.bind(EmptyOptions));
     aggregate_fns.push(NullCount.bind(EmptyOptions));

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -344,9 +344,9 @@ mod tests {
     use std::sync::Arc;
 
     use vortex_array::IntoArray;
-    use vortex_array::aggregate_fn::AggregateFnOpts;
     use vortex_array::aggregate_fn::AggregateFnVTableExt;
     use vortex_array::aggregate_fn::EmptyOptions;
+    use vortex_array::aggregate_fn::NumericalAggregateOpts;
     use vortex_array::aggregate_fn::fns::all_non_null::AllNonNull;
     use vortex_array::aggregate_fn::fns::all_null::AllNull;
     use vortex_array::aggregate_fn::fns::bounded_max::BoundedMax;
@@ -409,8 +409,8 @@ mod tests {
         // +----------+----------+
         // |  3       |  7       |
         // +----------+----------+
-        let max = Max.bind(AggregateFnOpts::skip_nans());
-        let min = Min.bind(AggregateFnOpts::skip_nans());
+        let max = Max.bind(NumericalAggregateOpts::skip_nans());
+        let min = Min.bind(NumericalAggregateOpts::skip_nans());
         let zone_map = ZoneMap::try_new(
             PType::I32.into(),
             StructArray::from_fields(&[
@@ -710,7 +710,7 @@ mod tests {
 
     #[test]
     fn float_min_max_stat_fn_requires_nan_count() {
-        let max = Max.bind(AggregateFnOpts::skip_nans());
+        let max = Max.bind(NumericalAggregateOpts::skip_nans());
         let zone_map = ZoneMap::try_new(
             PType::F32.into(),
             StructArray::from_fields(&[(

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -346,6 +346,7 @@ mod tests {
     use vortex_array::IntoArray;
     use vortex_array::aggregate_fn::AggregateFnVTableExt;
     use vortex_array::aggregate_fn::EmptyOptions;
+    use vortex_array::aggregate_fn::SkipNansOptions;
     use vortex_array::aggregate_fn::fns::all_non_null::AllNonNull;
     use vortex_array::aggregate_fn::fns::all_null::AllNull;
     use vortex_array::aggregate_fn::fns::bounded_max::BoundedMax;
@@ -408,8 +409,8 @@ mod tests {
         // +----------+----------+
         // |  3       |  7       |
         // +----------+----------+
-        let max = Max.bind(EmptyOptions);
-        let min = Min.bind(EmptyOptions);
+        let max = Max.bind(SkipNansOptions::skip());
+        let min = Min.bind(SkipNansOptions::skip());
         let zone_map = ZoneMap::try_new(
             PType::I32.into(),
             StructArray::from_fields(&[
@@ -709,7 +710,7 @@ mod tests {
 
     #[test]
     fn float_min_max_stat_fn_requires_nan_count() {
-        let max = Max.bind(EmptyOptions);
+        let max = Max.bind(SkipNansOptions::skip());
         let zone_map = ZoneMap::try_new(
             PType::F32.into(),
             StructArray::from_fields(&[(

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -344,9 +344,9 @@ mod tests {
     use std::sync::Arc;
 
     use vortex_array::IntoArray;
+    use vortex_array::aggregate_fn::AggregateFnOpts;
     use vortex_array::aggregate_fn::AggregateFnVTableExt;
     use vortex_array::aggregate_fn::EmptyOptions;
-    use vortex_array::aggregate_fn::SkipNansOptions;
     use vortex_array::aggregate_fn::fns::all_non_null::AllNonNull;
     use vortex_array::aggregate_fn::fns::all_null::AllNull;
     use vortex_array::aggregate_fn::fns::bounded_max::BoundedMax;
@@ -409,8 +409,8 @@ mod tests {
         // +----------+----------+
         // |  3       |  7       |
         // +----------+----------+
-        let max = Max.bind(SkipNansOptions::skip());
-        let min = Min.bind(SkipNansOptions::skip());
+        let max = Max.bind(AggregateFnOpts::skip_nans());
+        let min = Min.bind(AggregateFnOpts::skip_nans());
         let zone_map = ZoneMap::try_new(
             PType::I32.into(),
             StructArray::from_fields(&[
@@ -710,7 +710,7 @@ mod tests {
 
     #[test]
     fn float_min_max_stat_fn_requires_nan_count() {
-        let max = Max.bind(SkipNansOptions::skip());
+        let max = Max.bind(AggregateFnOpts::skip_nans());
         let zone_map = ZoneMap::try_new(
             PType::F32.into(),
             StructArray::from_fields(&[(

--- a/vortex-proto/proto/expr.proto
+++ b/vortex-proto/proto/expr.proto
@@ -26,6 +26,12 @@ message AggregateFn {
   optional bytes metadata = 2;
 }
 
+// Options for numeric aggregate functions (`vortex.sum`, `vortex.min`, `vortex.max`),
+// controlling how NaN values in floating-point inputs are handled.
+message AggregateFnOpts {
+  bool skip_nans = 1;
+}
+
 // Options for `vortex.literal`
 message LiteralOpts {
   vortex.scalar.Scalar value = 1;

--- a/vortex-proto/proto/expr.proto
+++ b/vortex-proto/proto/expr.proto
@@ -28,7 +28,7 @@ message AggregateFn {
 
 // Options for numeric aggregate functions (`vortex.sum`, `vortex.min`, `vortex.max`),
 // controlling how NaN values in floating-point inputs are handled.
-message AggregateFnOpts {
+message NumericalAggregateOpts {
   bool skip_nans = 1;
 }
 

--- a/vortex-proto/src/generated/vortex.expr.rs
+++ b/vortex-proto/src/generated/vortex.expr.rs
@@ -19,6 +19,13 @@ pub struct AggregateFn {
     #[prost(bytes = "vec", optional, tag = "2")]
     pub metadata: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
+/// Options for numeric aggregate functions (`vortex.sum`, `vortex.min`, `vortex.max`),
+/// controlling how NaN values in floating-point inputs are handled.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AggregateFnOpts {
+    #[prost(bool, tag = "1")]
+    pub skip_nans: bool,
+}
 /// Options for `vortex.literal`
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LiteralOpts {

--- a/vortex-proto/src/generated/vortex.expr.rs
+++ b/vortex-proto/src/generated/vortex.expr.rs
@@ -22,7 +22,7 @@ pub struct AggregateFn {
 /// Options for numeric aggregate functions (`vortex.sum`, `vortex.min`, `vortex.max`),
 /// controlling how NaN values in floating-point inputs are handled.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct AggregateFnOpts {
+pub struct NumericalAggregateOpts {
     #[prost(bool, tag = "1")]
     pub skip_nans: bool,
 }

--- a/vortex-python/src/io.rs
+++ b/vortex-python/src/io.rs
@@ -257,7 +257,7 @@ impl PyVortexWriteOptions {
     /// >>> vx.io.VortexWriteOptions.default().write(sprl, "chonky.vortex")
     /// >>> import os
     /// >>> os.path.getsize('chonky.vortex')
-    /// 215932
+    /// 215940
     ///
     /// Wow, Vortex manages to use about two bytes per integer! So advanced. So tiny.
     ///
@@ -267,7 +267,7 @@ impl PyVortexWriteOptions {
     ///
     /// >>> vx.io.VortexWriteOptions.compact().write(sprl, "tiny.vortex")
     /// >>> os.path.getsize('tiny.vortex')
-    /// 55060
+    /// 55068
     ///
     /// Random numbers are not (usually) composed of random bytes!
     #[staticmethod]


### PR DESCRIPTION
Almost all of the time you want to skip nans but for rare cases when you don't
we need to be able to configure it

