### PR TITLE
Faster str interning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ jetscii = "0.5.3"
 jiff = "0.2.0"
 jni = { version = "0.22.0" }
 kanal = "0.1.1"
-lasso = { version = "0.7", features = ["multi-threaded"] }
+lasso = { version = "0.7", features = ["multi-threaded", "inline-more"] }
 lending-iterator = "0.1.7"
 libfuzzer-sys = "0.4"
 libloading = "0.8"

--- a/vortex-session/src/registry.rs
+++ b/vortex-session/src/registry.rs
@@ -19,10 +19,12 @@ use lasso::Spur;
 use lasso::ThreadedRodeo;
 use parking_lot::RwLock;
 use vortex_error::VortexExpect;
+use vortex_utils::aliases::DefaultHashBuilder;
 use vortex_utils::aliases::dash_map::DashMap;
 
 /// Global string interner for [`Id`] values.
-static INTERNER: LazyLock<ThreadedRodeo> = LazyLock::new(ThreadedRodeo::new);
+static INTERNER: LazyLock<ThreadedRodeo<Spur, DefaultHashBuilder>> =
+    LazyLock::new(|| ThreadedRodeo::with_hasher(DefaultHashBuilder::default()));
 
 /// A lightweight, copyable identifier backed by a global string interner.
 ///


### PR DESCRIPTION
## Summary

Makes two small changes to the string interner:
1. Enables the `inline-more` feature of the `lasso` crate
2. Use the faster hasher we try and use everywhere