### PR TITLE
feat: DeltaScheme adjustable compression ratio threshold

### DIFF
--- a/vortex-btrblocks/src/builder.rs
+++ b/vortex-btrblocks/src/builder.rs
@@ -43,7 +43,7 @@ pub const ALL_SCHEMES: &[&dyn Scheme] = &[
     &integer::IntRLEScheme,
     // Prefer all other schemes above delta, for now (since its slower to decompress).
     #[cfg(feature = "unstable_encodings")]
-    &integer::DeltaScheme,
+    &integer::DeltaScheme::DEFAULT,
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // Float schemes.
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -186,7 +186,7 @@ impl BtrBlocksCompressorBuilder {
         // Delta has no GPU decode kernel and its prefix-sum decode is inherently sequential, so it
         // is incompatible with pure-GPU decompression paths.
         #[cfg(feature = "unstable_encodings")]
-        excluded.push(integer::DeltaScheme.id());
+        excluded.push(integer::DeltaScheme::DEFAULT.id());
         let builder = self.exclude_schemes(excluded);
 
         #[cfg(all(feature = "zstd", feature = "unstable_encodings"))]

--- a/vortex-btrblocks/src/builder.rs
+++ b/vortex-btrblocks/src/builder.rs
@@ -43,7 +43,7 @@ pub const ALL_SCHEMES: &[&dyn Scheme] = &[
     &integer::IntRLEScheme,
     // Prefer all other schemes above delta, for now (since its slower to decompress).
     #[cfg(feature = "unstable_encodings")]
-    &integer::DeltaScheme::DEFAULT,
+    &integer::DeltaScheme::new(1.25),
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // Float schemes.
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -186,7 +186,7 @@ impl BtrBlocksCompressorBuilder {
         // Delta has no GPU decode kernel and its prefix-sum decode is inherently sequential, so it
         // is incompatible with pure-GPU decompression paths.
         #[cfg(feature = "unstable_encodings")]
-        excluded.push(integer::DeltaScheme::DEFAULT.id());
+        excluded.push(integer::DeltaScheme::default().id());
         let builder = self.exclude_schemes(excluded);
 
         #[cfg(all(feature = "zstd", feature = "unstable_encodings"))]

--- a/vortex-btrblocks/src/schemes/integer/delta.rs
+++ b/vortex-btrblocks/src/schemes/integer/delta.rs
@@ -36,30 +36,17 @@ use crate::SchemeExt;
 /// pays off when those residuals span meaningfully fewer bits than the values themselves.
 ///
 /// The minimum penalized compression ratio required for Delta to be selected is configurable via
-/// [`DeltaScheme::new`]; [`DeltaScheme::default`] uses [`DeltaScheme::DEFAULT_MIN_RATIO`].
+/// [`DeltaScheme::new`]; [`DeltaScheme::default`] uses a ratio of `1.25`.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct DeltaScheme {
     min_ratio: f64,
 }
 
 impl DeltaScheme {
-    /// Default minimum penalized compression ratio for Delta selection.
-    ///
-    /// Delta only wins when its penalized ratio clears this threshold; otherwise we skip it in
-    /// favor of simpler, randomly-accessible encodings. The bar is set above `1.0` so we avoid
-    /// picking Delta for marginal gains that do not justify breaking random access and the
-    /// prefix-sum decode pass.
-    pub const DEFAULT_MIN_RATIO: f64 = 1.25;
-
-    /// A [`DeltaScheme`] using [`DEFAULT_MIN_RATIO`](Self::DEFAULT_MIN_RATIO).
-    ///
-    /// Usable in const contexts (e.g. the static scheme registry) where [`Default`] cannot run.
-    pub const DEFAULT: Self = Self::new(Self::DEFAULT_MIN_RATIO);
-
     /// Creates a Delta scheme requiring `min_ratio` (after the [`DELTA_PENALTY`]) before it wins.
     ///
     /// Pass a higher ratio to make Delta more conservative, or a lower one to select it more
-    /// eagerly. [`DeltaScheme::default`] uses [`DEFAULT_MIN_RATIO`](Self::DEFAULT_MIN_RATIO).
+    /// eagerly. [`DeltaScheme::default`] uses a ratio of `1.25`.
     pub const fn new(min_ratio: f64) -> Self {
         Self { min_ratio }
     }
@@ -67,7 +54,7 @@ impl DeltaScheme {
 
 impl Default for DeltaScheme {
     fn default() -> Self {
-        Self::DEFAULT
+        Self::new(1.25)
     }
 }
 

--- a/vortex-btrblocks/src/schemes/integer/delta.rs
+++ b/vortex-btrblocks/src/schemes/integer/delta.rs
@@ -34,8 +34,42 @@ use crate::SchemeExt;
 /// Delta replaces each value with its difference from an earlier value (at the FastLanes lane
 /// stride), so a later cascade layer (FoR / BitPacking) packs the smaller residuals. It only
 /// pays off when those residuals span meaningfully fewer bits than the values themselves.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct DeltaScheme;
+///
+/// The minimum penalized compression ratio required for Delta to be selected is configurable via
+/// [`DeltaScheme::new`]; [`DeltaScheme::default`] uses [`DeltaScheme::DEFAULT_MIN_RATIO`].
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct DeltaScheme {
+    min_ratio: f64,
+}
+
+impl DeltaScheme {
+    /// Default minimum penalized compression ratio for Delta selection.
+    ///
+    /// Delta only wins when its penalized ratio clears this threshold; otherwise we skip it in
+    /// favor of simpler, randomly-accessible encodings. The bar is set above `1.0` so we avoid
+    /// picking Delta for marginal gains that do not justify breaking random access and the
+    /// prefix-sum decode pass.
+    pub const DEFAULT_MIN_RATIO: f64 = 1.25;
+
+    /// A [`DeltaScheme`] using [`DEFAULT_MIN_RATIO`](Self::DEFAULT_MIN_RATIO).
+    ///
+    /// Usable in const contexts (e.g. the static scheme registry) where [`Default`] cannot run.
+    pub const DEFAULT: Self = Self::new(Self::DEFAULT_MIN_RATIO);
+
+    /// Creates a Delta scheme requiring `min_ratio` (after the [`DELTA_PENALTY`]) before it wins.
+    ///
+    /// Pass a higher ratio to make Delta more conservative, or a lower one to select it more
+    /// eagerly. [`DeltaScheme::default`] uses [`DEFAULT_MIN_RATIO`](Self::DEFAULT_MIN_RATIO).
+    pub const fn new(min_ratio: f64) -> Self {
+        Self { min_ratio }
+    }
+}
+
+impl Default for DeltaScheme {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
 
 /// Multiplicative penalty applied to Delta's estimated compression ratio.
 ///
@@ -47,13 +81,6 @@ const DELTA_PENALTY: f64 = 0.95;
 
 /// Minimum length before Delta is worth considering (one FastLanes chunk).
 const MIN_DELTA_LEN: usize = 1024;
-
-/// Minimum estimated compression ratio (after the [`DELTA_PENALTY`]) for Delta to be selected.
-///
-/// Delta only wins when its penalized ratio clears this threshold; otherwise we skip it in favor
-/// of simpler, randomly-accessible encodings. Raising the bar avoids picking Delta for marginal
-/// gains that do not justify breaking random access and the prefix-sum decode pass.
-const MIN_DELTA_RATIO: f64 = 1.25;
 
 impl Scheme for DeltaScheme {
     fn scheme_name(&self) -> &'static str {
@@ -72,7 +99,7 @@ impl Scheme for DeltaScheme {
     /// bases and the deltas children so we never delta-encode data that was already delta-encoded.
     fn descendant_exclusions(&self) -> Vec<DescendantExclusion> {
         vec![DescendantExclusion {
-            excluded: DeltaScheme.id(),
+            excluded: self.id(),
             children: ChildSelection::All,
         }]
     }
@@ -117,8 +144,9 @@ impl Scheme for DeltaScheme {
 
         // Estimating Delta needs the real transposed-delta span, so defer to a callback that
         // delta-encodes the array and measures the residual range.
+        let min_ratio = self.min_ratio;
         CompressionEstimate::Deferred(DeferredEstimate::Callback(Box::new(
-            |_compressor, data, best_so_far, _ctx, exec_ctx| {
+            move |_compressor, data, best_so_far, _ctx, exec_ctx| {
                 let primitive = data.array().clone().execute::<PrimitiveArray>(exec_ctx)?;
                 let full_width = primitive.ptype().bit_width() as f64;
 
@@ -145,7 +173,7 @@ impl Scheme for DeltaScheme {
                 };
 
                 let ratio = full_width / delta_bits * DELTA_PENALTY;
-                if ratio <= MIN_DELTA_RATIO {
+                if ratio <= min_ratio {
                     return Ok(EstimateVerdict::Skip);
                 }
                 Ok(EstimateVerdict::Ratio(ratio))

--- a/vortex-btrblocks/src/schemes/integer/delta.rs
+++ b/vortex-btrblocks/src/schemes/integer/delta.rs
@@ -48,6 +48,13 @@ const DELTA_PENALTY: f64 = 0.95;
 /// Minimum length before Delta is worth considering (one FastLanes chunk).
 const MIN_DELTA_LEN: usize = 1024;
 
+/// Minimum estimated compression ratio (after the [`DELTA_PENALTY`]) for Delta to be selected.
+///
+/// Delta only wins when its penalized ratio clears this threshold; otherwise we skip it in favor
+/// of simpler, randomly-accessible encodings. Raising the bar avoids picking Delta for marginal
+/// gains that do not justify breaking random access and the prefix-sum decode pass.
+const MIN_DELTA_RATIO: f64 = 1.25;
+
 impl Scheme for DeltaScheme {
     fn scheme_name(&self) -> &'static str {
         "vortex.int.delta"
@@ -138,7 +145,7 @@ impl Scheme for DeltaScheme {
                 };
 
                 let ratio = full_width / delta_bits * DELTA_PENALTY;
-                if ratio <= 1.0 {
+                if ratio <= MIN_DELTA_RATIO {
                     return Ok(EstimateVerdict::Skip);
                 }
                 Ok(EstimateVerdict::Ratio(ratio))


### PR DESCRIPTION
Delta is a more expensive compression scheme to decompress, so using it for a small win in compression since is a bad idea.

Set the default to 1.25

## Summary

This PR makes the `DeltaScheme` configurable by allowing users to specify a custom minimum penalized compression ratio threshold, rather than using a hardcoded value. This enables more flexible tuning of when Delta encoding is selected during compression.

