### PR TITLE
Run-end encode boolean columns via the generic RunEnd encoding

### DIFF
--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -21,6 +21,7 @@ use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
 use vortex_array::TypedArrayRef;
 use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::Bool;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::buffer::BufferHandle;
@@ -44,6 +45,7 @@ use vortex_session::registry::CachedId;
 use crate::compress::runend_decode_primitive;
 use crate::compress::runend_decode_varbinview;
 use crate::compress::runend_encode;
+use crate::compress::runend_encode_bool;
 use crate::decompress_bool::runend_decode_bools;
 use crate::ops::find_physical_index;
 use crate::ops::find_slice_end_index;
@@ -308,8 +310,16 @@ impl RunEnd {
             let slots = smallvec![Some(ends), Some(values)];
             let data = unsafe { RunEndData::new_unchecked(0) };
             Array::try_from_parts(ArrayParts::new(RunEnd, dtype, len, data).with_slots(slots))
+        } else if let Some(barray) = array.as_opt::<Bool>() {
+            let (ends, values) = runend_encode_bool(barray, ctx);
+            let ends = ends.into_array();
+            let len = array.len();
+            let dtype = values.dtype().clone();
+            let slots = smallvec![Some(ends), Some(values)];
+            let data = unsafe { RunEndData::new_unchecked(0) };
+            Array::try_from_parts(ArrayParts::new(RunEnd, dtype, len, data).with_slots(slots))
         } else {
-            vortex_bail!("REE can only encode primitive arrays")
+            vortex_bail!("REE can only encode primitive or bool arrays")
         }
     }
 }

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -22,6 +22,7 @@ use vortex_array::IntoArray;
 use vortex_array::TypedArrayRef;
 use vortex_array::VortexSessionExecute;
 use vortex_array::array_slots;
+use vortex_array::arrays::Bool;
 use vortex_array::arrays::DecimalArray;
 use vortex_array::arrays::ListViewArray;
 use vortex_array::arrays::Primitive;
@@ -49,6 +50,7 @@ use crate::compress::runend_decode_decimal;
 use crate::compress::runend_decode_primitive;
 use crate::compress::runend_decode_varbinview;
 use crate::compress::runend_encode;
+use crate::compress::runend_encode_bool;
 use crate::decompress_bool::runend_decode_bools;
 use crate::ops::find_physical_index;
 use crate::ops::find_slice_end_index;
@@ -301,8 +303,16 @@ impl RunEnd {
             let slots = RunEndSlots { ends, values }.into_slots();
             let data = unsafe { RunEndData::new_unchecked(0) };
             Array::try_from_parts(ArrayParts::new(RunEnd, dtype, len, data).with_slots(slots))
+        } else if let Some(barray) = array.as_opt::<Bool>() {
+            let (ends, values) = runend_encode_bool(barray, ctx);
+            let ends = ends.into_array();
+            let len = array.len();
+            let dtype = values.dtype().clone();
+            let slots = RunEndSlots { ends, values }.into_slots();
+            let data = unsafe { RunEndData::new_unchecked(0) };
+            Array::try_from_parts(ArrayParts::new(RunEnd, dtype, len, data).with_slots(slots))
         } else {
-            vortex_bail!("REE can only encode primitive arrays")
+            vortex_bail!("REE can only encode primitive or bool arrays")
         }
     }
 }

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -6,6 +6,7 @@ use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::arrays::Bool;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::Primitive;
@@ -181,6 +182,158 @@ fn runend_encode_nullable_primitive<T: NativePType>(
     )
 }
 
+/// Run-end encode a `BoolArray`, returning a tuple of `(ends, values)`.
+///
+/// Boolean run values strictly alternate between valid runs, so this materializes an
+/// `num_runs`-length values array that is almost entirely redundant. A future
+/// cycling/repeat-pattern array encoding — one that logically yields `[start, !start, start, …]`
+/// in O(1) space — could stand in as this values child, recovering the single-`start`-bit
+/// compactness of a dedicated bool run-end encoding through composition rather than a separate
+/// encoding.
+pub fn runend_encode_bool(
+    array: ArrayView<Bool>,
+    ctx: &mut ExecutionCtx,
+) -> (PrimitiveArray, ArrayRef) {
+    let nullability = array.dtype().nullability();
+    let validity = match array
+        .validity()
+        .vortex_expect("run-end validity should be derivable")
+    {
+        Validity::NonNullable => None,
+        Validity::AllValid => None,
+        Validity::AllInvalid => {
+            // We can trivially return an all-null REE array
+            let ends = PrimitiveArray::new(buffer![array.len() as u64], Validity::NonNullable);
+            ends.statistics()
+                .set(Stat::IsStrictSorted, Precision::Exact(true.into()));
+            return (
+                ends,
+                ConstantArray::new(Scalar::null(array.dtype().clone()), 1).into_array(),
+            );
+        }
+        Validity::Array(a) => {
+            let bool_array = a
+                .execute::<BoolArray>(ctx)
+                .vortex_expect("validity array must be convertible to bool");
+            Some(bool_array.to_bit_buffer())
+        }
+    };
+
+    let bits = array.to_bit_buffer();
+
+    let (ends, values) = match validity {
+        None => {
+            let (ends, values) = runend_encode_bool_slice(&bits);
+            (
+                PrimitiveArray::new(ends, Validity::NonNullable),
+                BoolArray::new(values, nullability.into()).into_array(),
+            )
+        }
+        Some(validity) => {
+            let (ends, values) = runend_encode_nullable_bool_slice(&bits, &validity);
+            (
+                PrimitiveArray::new(ends, Validity::NonNullable),
+                values.into_array(),
+            )
+        }
+    };
+
+    let ends = ends
+        .narrow(ctx)
+        .vortex_expect("Ends must succeed downcasting");
+
+    ends.statistics()
+        .set(Stat::IsStrictSorted, Precision::Exact(true.into()));
+
+    (ends, values)
+}
+
+fn runend_encode_bool_slice(elements: &BitBuffer) -> (Buffer<u64>, BitBuffer) {
+    let mut ends = BufferMut::empty();
+    let mut values = BitBufferMut::empty();
+
+    if elements.is_empty() {
+        return (ends.freeze(), values.freeze());
+    }
+
+    // Run-end encode the values
+    let mut prev = elements.value(0);
+    let mut end = 1u64;
+    for i in 1..elements.len() {
+        let e = elements.value(i);
+        if e != prev {
+            ends.push(end);
+            values.append(prev);
+        }
+        prev = e;
+        end += 1;
+    }
+    ends.push(end);
+    values.append(prev);
+
+    (ends.freeze(), values.freeze())
+}
+
+fn runend_encode_nullable_bool_slice(
+    elements: &BitBuffer,
+    element_validity: &BitBuffer,
+) -> (Buffer<u64>, BoolArray) {
+    let mut ends = BufferMut::empty();
+    let mut values = BitBufferMut::empty();
+    let mut validity = BitBufferMut::empty();
+
+    if elements.is_empty() {
+        return (
+            ends.freeze(),
+            BoolArray::new(
+                values.freeze(),
+                Validity::Array(BoolArray::from(validity.freeze()).into_array()),
+            ),
+        );
+    }
+
+    let value_at = |i: usize| element_validity.value(i).then(|| elements.value(i));
+
+    // Run-end encode the values, keyed on `(value, validity)` pairs
+    let mut prev = value_at(0);
+    let mut end = 1u64;
+    for i in 1..elements.len() {
+        let e = value_at(i);
+        if e != prev {
+            ends.push(end);
+            match prev {
+                None => {
+                    validity.append(false);
+                    values.append(false);
+                }
+                Some(p) => {
+                    validity.append(true);
+                    values.append(p);
+                }
+            }
+        }
+        prev = e;
+        end += 1;
+    }
+    ends.push(end);
+
+    match prev {
+        None => {
+            validity.append(false);
+            values.append(false);
+        }
+        Some(p) => {
+            validity.append(true);
+            values.append(p);
+        }
+    }
+
+    (
+        ends.freeze(),
+        BoolArray::new(values.freeze(), Validity::from(validity.freeze())),
+    )
+}
+
 pub fn runend_decode_primitive(
     ends: PrimitiveArray,
     values: PrimitiveArray,
@@ -322,7 +475,9 @@ pub fn runend_decode_varbinview(
 mod tests {
     use std::sync::LazyLock;
 
+    use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::validity::Validity;
@@ -331,8 +486,10 @@ mod tests {
     use vortex_error::VortexResult;
     use vortex_session::VortexSession;
 
+    use crate::RunEnd;
     use crate::compress::runend_decode_primitive;
     use crate::compress::runend_encode;
+    use crate::compress::runend_encode_bool;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
         let session = vortex_array::array_session();
@@ -401,5 +558,72 @@ mod tests {
         let expected = PrimitiveArray::from_iter(vec![1i32, 1, 2, 2, 2, 3, 3, 3, 3, 3]);
         assert_arrays_eq!(decoded, expected, &mut ctx);
         Ok(())
+    }
+
+    fn roundtrip_bool(array: BoolArray) -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let expected = array.clone();
+        let (ends, values) = runend_encode_bool(array.as_view(), &mut ctx);
+        let ree = RunEnd::try_new(ends.into_array(), values, &mut ctx)?;
+        let decoded = ree.into_array().execute::<BoolArray>(&mut ctx)?;
+        assert_arrays_eq!(decoded, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn encode_bool_all_true() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::from(BitBuffer::from(vec![true; 10])))
+    }
+
+    #[test]
+    fn encode_bool_all_false() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::from(BitBuffer::from(vec![false; 10])))
+    }
+
+    #[test]
+    fn encode_bool_alternating() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::from(BitBuffer::from(vec![
+            true, true, false, false, false, true, true, true, true, true,
+        ])))
+    }
+
+    #[test]
+    fn encode_bool_leading_false() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::from(BitBuffer::from(vec![
+            false, true, true, false,
+        ])))
+    }
+
+    #[test]
+    fn encode_bool_empty() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::from(BitBuffer::from(Vec::<bool>::new())))
+    }
+
+    #[test]
+    fn encode_bool_nullable_interior_nulls() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::new(
+            BitBuffer::from(vec![true, true, false, true]),
+            Validity::from(BitBuffer::from(vec![true, true, false, true])),
+        ))
+    }
+
+    #[test]
+    fn encode_bool_nullable_mixed() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::new(
+            BitBuffer::from(vec![
+                true, true, false, false, false, true, true, true, true, true,
+            ]),
+            Validity::from(BitBuffer::from(vec![
+                true, true, false, false, true, true, true, true, false, false,
+            ])),
+        ))
+    }
+
+    #[test]
+    fn encode_bool_all_null() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::new(
+            BitBuffer::new_unset(5),
+            Validity::from(BitBuffer::new_unset(5)),
+        ))
     }
 }

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -6,6 +6,7 @@ use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::arrays::Bool;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::DecimalArray;
@@ -184,6 +185,158 @@ fn runend_encode_nullable_primitive<T: NativePType>(
     )
 }
 
+/// Run-end encode a `BoolArray`, returning a tuple of `(ends, values)`.
+///
+/// Boolean run values strictly alternate between valid runs, so this materializes an
+/// `num_runs`-length values array that is almost entirely redundant. A future
+/// cycling/repeat-pattern array encoding — one that logically yields `[start, !start, start, …]`
+/// in O(1) space — could stand in as this values child, recovering the single-`start`-bit
+/// compactness of a dedicated bool run-end encoding through composition rather than a separate
+/// encoding.
+pub fn runend_encode_bool(
+    array: ArrayView<Bool>,
+    ctx: &mut ExecutionCtx,
+) -> (PrimitiveArray, ArrayRef) {
+    let nullability = array.dtype().nullability();
+    let validity = match array
+        .validity()
+        .vortex_expect("run-end validity should be derivable")
+    {
+        Validity::NonNullable => None,
+        Validity::AllValid => None,
+        Validity::AllInvalid => {
+            // We can trivially return an all-null REE array
+            let ends = PrimitiveArray::new(buffer![array.len() as u64], Validity::NonNullable);
+            ends.statistics()
+                .set(Stat::IsStrictSorted, Precision::Exact(true.into()));
+            return (
+                ends,
+                ConstantArray::new(Scalar::null(array.dtype().clone()), 1).into_array(),
+            );
+        }
+        Validity::Array(a) => {
+            let bool_array = a
+                .execute::<BoolArray>(ctx)
+                .vortex_expect("validity array must be convertible to bool");
+            Some(bool_array.to_bit_buffer())
+        }
+    };
+
+    let bits = array.to_bit_buffer();
+
+    let (ends, values) = match validity {
+        None => {
+            let (ends, values) = runend_encode_bool_slice(&bits);
+            (
+                PrimitiveArray::new(ends, Validity::NonNullable),
+                BoolArray::new(values, nullability.into()).into_array(),
+            )
+        }
+        Some(validity) => {
+            let (ends, values) = runend_encode_nullable_bool_slice(&bits, &validity);
+            (
+                PrimitiveArray::new(ends, Validity::NonNullable),
+                values.into_array(),
+            )
+        }
+    };
+
+    let ends = ends
+        .narrow(ctx)
+        .vortex_expect("Ends must succeed downcasting");
+
+    ends.statistics()
+        .set(Stat::IsStrictSorted, Precision::Exact(true.into()));
+
+    (ends, values)
+}
+
+fn runend_encode_bool_slice(elements: &BitBuffer) -> (Buffer<u64>, BitBuffer) {
+    let mut ends = BufferMut::empty();
+    let mut values = BitBufferMut::empty();
+
+    if elements.is_empty() {
+        return (ends.freeze(), values.freeze());
+    }
+
+    // Run-end encode the values
+    let mut prev = elements.value(0);
+    let mut end = 1u64;
+    for i in 1..elements.len() {
+        let e = elements.value(i);
+        if e != prev {
+            ends.push(end);
+            values.append(prev);
+        }
+        prev = e;
+        end += 1;
+    }
+    ends.push(end);
+    values.append(prev);
+
+    (ends.freeze(), values.freeze())
+}
+
+fn runend_encode_nullable_bool_slice(
+    elements: &BitBuffer,
+    element_validity: &BitBuffer,
+) -> (Buffer<u64>, BoolArray) {
+    let mut ends = BufferMut::empty();
+    let mut values = BitBufferMut::empty();
+    let mut validity = BitBufferMut::empty();
+
+    if elements.is_empty() {
+        return (
+            ends.freeze(),
+            BoolArray::new(
+                values.freeze(),
+                Validity::Array(BoolArray::from(validity.freeze()).into_array()),
+            ),
+        );
+    }
+
+    let value_at = |i: usize| element_validity.value(i).then(|| elements.value(i));
+
+    // Run-end encode the values, keyed on `(value, validity)` pairs
+    let mut prev = value_at(0);
+    let mut end = 1u64;
+    for i in 1..elements.len() {
+        let e = value_at(i);
+        if e != prev {
+            ends.push(end);
+            match prev {
+                None => {
+                    validity.append(false);
+                    values.append(false);
+                }
+                Some(p) => {
+                    validity.append(true);
+                    values.append(p);
+                }
+            }
+        }
+        prev = e;
+        end += 1;
+    }
+    ends.push(end);
+
+    match prev {
+        None => {
+            validity.append(false);
+            values.append(false);
+        }
+        Some(p) => {
+            validity.append(true);
+            values.append(p);
+        }
+    }
+
+    (
+        ends.freeze(),
+        BoolArray::new(values.freeze(), Validity::from(validity.freeze())),
+    )
+}
+
 pub fn runend_decode_primitive(
     ends: PrimitiveArray,
     values: PrimitiveArray,
@@ -352,7 +505,9 @@ pub fn runend_decode_varbinview(
 mod tests {
     use std::sync::LazyLock;
 
+    use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::validity::Validity;
@@ -361,8 +516,10 @@ mod tests {
     use vortex_error::VortexResult;
     use vortex_session::VortexSession;
 
+    use crate::RunEnd;
     use crate::compress::runend_decode_primitive;
     use crate::compress::runend_encode;
+    use crate::compress::runend_encode_bool;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
         let session = vortex_array::array_session();
@@ -431,5 +588,72 @@ mod tests {
         let expected = PrimitiveArray::from_iter(vec![1i32, 1, 2, 2, 2, 3, 3, 3, 3, 3]);
         assert_arrays_eq!(decoded, expected, &mut ctx);
         Ok(())
+    }
+
+    fn roundtrip_bool(array: BoolArray) -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let expected = array.clone();
+        let (ends, values) = runend_encode_bool(array.as_view(), &mut ctx);
+        let ree = RunEnd::try_new(ends.into_array(), values, &mut ctx)?;
+        let decoded = ree.into_array().execute::<BoolArray>(&mut ctx)?;
+        assert_arrays_eq!(decoded, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn encode_bool_all_true() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::from(BitBuffer::from(vec![true; 10])))
+    }
+
+    #[test]
+    fn encode_bool_all_false() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::from(BitBuffer::from(vec![false; 10])))
+    }
+
+    #[test]
+    fn encode_bool_alternating() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::from(BitBuffer::from(vec![
+            true, true, false, false, false, true, true, true, true, true,
+        ])))
+    }
+
+    #[test]
+    fn encode_bool_leading_false() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::from(BitBuffer::from(vec![
+            false, true, true, false,
+        ])))
+    }
+
+    #[test]
+    fn encode_bool_empty() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::from(BitBuffer::from(Vec::<bool>::new())))
+    }
+
+    #[test]
+    fn encode_bool_nullable_interior_nulls() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::new(
+            BitBuffer::from(vec![true, true, false, true]),
+            Validity::from(BitBuffer::from(vec![true, true, false, true])),
+        ))
+    }
+
+    #[test]
+    fn encode_bool_nullable_mixed() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::new(
+            BitBuffer::from(vec![
+                true, true, false, false, false, true, true, true, true, true,
+            ]),
+            Validity::from(BitBuffer::from(vec![
+                true, true, false, false, true, true, true, true, false, false,
+            ])),
+        ))
+    }
+
+    #[test]
+    fn encode_bool_all_null() -> VortexResult<()> {
+        roundtrip_bool(BoolArray::new(
+            BitBuffer::new_unset(5),
+            Validity::from(BitBuffer::new_unset(5)),
+        ))
     }
 }

--- a/vortex-btrblocks/src/builder.rs
+++ b/vortex-btrblocks/src/builder.rs
@@ -11,6 +11,7 @@ use crate::Scheme;
 use crate::SchemeExt;
 use crate::SchemeId;
 use crate::schemes::binary;
+use crate::schemes::bool;
 use crate::schemes::decimal;
 use crate::schemes::float;
 use crate::schemes::integer;
@@ -60,6 +61,10 @@ pub const ALL_SCHEMES: &[&dyn Scheme] = &[
     // Binary schemes.
     ////////////////////////////////////////////////////////////////////////////////////////////////
     &binary::BinaryDictScheme,
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    // Bool schemes.
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    &bool::BoolRunEndScheme,
     // Decimal schemes.
     &decimal::DecimalScheme,
     // Temporal schemes.

--- a/vortex-btrblocks/src/builder.rs
+++ b/vortex-btrblocks/src/builder.rs
@@ -12,6 +12,7 @@ use crate::Scheme;
 use crate::SchemeExt;
 use crate::SchemeId;
 use crate::schemes::binary;
+use crate::schemes::bool;
 use crate::schemes::decimal;
 use crate::schemes::float;
 use crate::schemes::integer;
@@ -61,6 +62,10 @@ pub const ALL_SCHEMES: &[&dyn Scheme] = &[
     // Binary schemes.
     ////////////////////////////////////////////////////////////////////////////////////////////////
     &binary::BinaryDictScheme,
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    // Bool schemes.
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    &bool::BoolRunEndScheme,
     // Decimal schemes.
     &decimal::DecimalScheme,
     // Temporal schemes.

--- a/vortex-btrblocks/src/canonical_compressor.rs
+++ b/vortex-btrblocks/src/canonical_compressor.rs
@@ -140,6 +140,27 @@ mod tests {
     }
 
     #[test]
+    fn test_run_heavy_bool_uses_runend() -> VortexResult<()> {
+        use vortex_runend::RunEnd;
+
+        let mut ctx = SESSION.create_execution_ctx();
+        // Long alternating runs (avg run length 64 >> threshold) but not constant.
+        let bits: Vec<bool> = (0..512).map(|i| (i / 64) % 2 == 0).collect();
+        let array = BoolArray::new(BitBuffer::from(bits), Validity::NonNullable);
+        let compressed = BtrBlocksCompressor::default().compress(
+            &array.clone().into_array(),
+            &mut SESSION.create_execution_ctx(),
+        )?;
+        assert!(
+            compressed.is::<RunEnd>(),
+            "expected RunEnd, got {}",
+            compressed.encoding_id()
+        );
+        assert_arrays_eq!(compressed, array, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
     fn test_constant_all_false() -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         let array = BoolArray::new(BitBuffer::from(vec![false; 100]), Validity::NonNullable);

--- a/vortex-btrblocks/src/schemes/bool/mod.rs
+++ b/vortex-btrblocks/src/schemes/bool/mod.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Compression schemes for boolean columns.
+
+mod runend;
+
+pub use runend::BoolRunEndScheme;

--- a/vortex-btrblocks/src/schemes/bool/runend.rs
+++ b/vortex-btrblocks/src/schemes/bool/runend.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Run-end encoding for boolean columns via the generic [`RunEnd`] encoding.
+//!
+//! Boolean runs strictly alternate, so a run-end encoded bool array is a generic
+//! `RunEnd{ends, values}` whose values child is the per-run boolean array. A future
+//! cycling/repeat-pattern array encoding could stand in as that values child to recover
+//! single-`start`-bit compactness through composition — see [`runend_encode_bool`].
+
+use vortex_array::ArrayRef;
+use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::arrays::Bool;
+use vortex_array::arrays::bool::BoolArrayExt;
+use vortex_compressor::scheme::ChildSelection;
+use vortex_compressor::scheme::CompressionEstimate;
+use vortex_compressor::scheme::DeferredEstimate;
+use vortex_compressor::scheme::DescendantExclusion;
+use vortex_compressor::scheme::EstimateVerdict;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_runend::RunEnd;
+use vortex_runend::compress::runend_encode_bool;
+
+use crate::ArrayAndStats;
+use crate::CascadingCompressor;
+use crate::CompressorContext;
+use crate::Scheme;
+use crate::SchemeExt;
+use crate::schemes::integer::RunEndScheme;
+
+/// Minimum average run length before run-end encoding a boolean column is considered worthwhile.
+const RUN_END_THRESHOLD: usize = 4;
+
+/// Run-end encoding for boolean columns.
+///
+/// Emits a generic [`RunEnd`] array whose values child is the per-run boolean array; the run
+/// `ends` (child 1) are cascaded for further compression.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct BoolRunEndScheme;
+
+impl BoolRunEndScheme {
+    /// Count the number of runs in the canonical boolean array.
+    ///
+    /// Uses the word-at-a-time `set_slices` iterator rather than a per-bit scan.
+    fn run_count(array: &ArrayRef) -> usize {
+        let bool_array = array
+            .as_opt::<Bool>()
+            .vortex_expect("BoolRunEndScheme matches only canonical bool arrays");
+        let bits = bool_array.to_bit_buffer();
+        let len = bits.len();
+        if len == 0 {
+            return 0;
+        }
+
+        // Each `true` slice is one run; a `false` gap before it or a trailing `false` gap is
+        // another. `set_slices` yields the maximal `true` ranges word-at-a-time.
+        let mut runs = 0usize;
+        let mut cursor = 0usize;
+        for (start, end) in bits.set_slices() {
+            if start > cursor {
+                runs += 1; // leading/interior false gap
+            }
+            runs += 1; // the true run
+            cursor = end;
+        }
+        if cursor < len {
+            runs += 1; // trailing false gap
+        }
+        runs
+    }
+}
+
+impl Scheme for BoolRunEndScheme {
+    fn scheme_name(&self) -> &'static str {
+        "vortex.bool.runend"
+    }
+
+    fn matches(&self, canonical: &Canonical) -> bool {
+        canonical.dtype().is_boolean()
+    }
+
+    /// Children: values=0, ends=1.
+    fn num_children(&self) -> usize {
+        2
+    }
+
+    /// RunEnd ends (child 1) are monotonically increasing positions with all unique values, so
+    /// run-end encoding them again is pointless.
+    fn descendant_exclusions(&self) -> Vec<DescendantExclusion> {
+        vec![DescendantExclusion {
+            excluded: RunEndScheme.id(),
+            children: ChildSelection::One(1),
+        }]
+    }
+
+    fn expected_compression_ratio(
+        &self,
+        data: &ArrayAndStats,
+        _compress_ctx: CompressorContext,
+        _exec_ctx: &mut ExecutionCtx,
+    ) -> CompressionEstimate {
+        let length = data.array_len();
+        if length == 0 {
+            return CompressionEstimate::Verdict(EstimateVerdict::Skip);
+        }
+
+        let runs = Self::run_count(data.array()).max(1);
+        if length / runs < RUN_END_THRESHOLD {
+            return CompressionEstimate::Verdict(EstimateVerdict::Skip);
+        }
+
+        CompressionEstimate::Deferred(DeferredEstimate::Sample)
+    }
+
+    fn compress(
+        &self,
+        compressor: &CascadingCompressor,
+        data: &ArrayAndStats,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let bool_array = data
+            .array()
+            .as_opt::<Bool>()
+            .vortex_expect("BoolRunEndScheme matches only canonical bool arrays");
+        let length = data.array_len();
+
+        let (ends, values) = runend_encode_bool(bool_array, exec_ctx);
+
+        let compressed_values =
+            compressor.compress_child(&values, &compress_ctx, self.id(), 0, exec_ctx)?;
+
+        let compressed_ends =
+            compressor.compress_child(&ends.into_array(), &compress_ctx, self.id(), 1, exec_ctx)?;
+
+        // SAFETY: compression preserves the strictly-increasing ends invariant.
+        Ok(unsafe {
+            RunEnd::new_unchecked(compressed_ends, compressed_values, 0, length).into_array()
+        })
+    }
+}

--- a/vortex-btrblocks/src/schemes/bool/runend.rs
+++ b/vortex-btrblocks/src/schemes/bool/runend.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Run-end encoding for boolean columns via the generic [`RunEnd`] encoding.
+//!
+//! Boolean runs strictly alternate, so a run-end encoded bool array is a generic
+//! `RunEnd{ends, values}` whose values child is the per-run boolean array. A future
+//! cycling/repeat-pattern array encoding could stand in as that values child to recover
+//! single-`start`-bit compactness through composition — see [`runend_encode_bool`].
+
+use vortex_array::ArrayId;
+use vortex_array::ArrayRef;
+use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::VTable;
+use vortex_array::arrays::Bool;
+use vortex_array::arrays::bool::BoolArrayExt;
+use vortex_compressor::scheme::ChildSelection;
+use vortex_compressor::scheme::CompressionEstimate;
+use vortex_compressor::scheme::DeferredEstimate;
+use vortex_compressor::scheme::DescendantExclusion;
+use vortex_compressor::scheme::EstimateVerdict;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_runend::RunEnd;
+use vortex_runend::compress::runend_encode_bool;
+
+use crate::ArrayAndStats;
+use crate::CascadingCompressor;
+use crate::CompressorContext;
+use crate::Scheme;
+use crate::SchemeExt;
+use crate::schemes::integer::RunEndScheme;
+
+/// Minimum average run length before run-end encoding a boolean column is considered worthwhile.
+const RUN_END_THRESHOLD: usize = 4;
+
+/// Run-end encoding for boolean columns.
+///
+/// Emits a generic [`RunEnd`] array whose values child is the per-run boolean array; the run
+/// `ends` (child 1) are cascaded for further compression.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct BoolRunEndScheme;
+
+impl BoolRunEndScheme {
+    /// Count the number of runs in the canonical boolean array.
+    ///
+    /// Uses the word-at-a-time `set_slices` iterator rather than a per-bit scan.
+    fn run_count(array: &ArrayRef) -> usize {
+        let bool_array = array
+            .as_opt::<Bool>()
+            .vortex_expect("BoolRunEndScheme matches only canonical bool arrays");
+        let bits = bool_array.to_bit_buffer();
+        let len = bits.len();
+        if len == 0 {
+            return 0;
+        }
+
+        // Each `true` slice is one run; a `false` gap before it or a trailing `false` gap is
+        // another. `set_slices` yields the maximal `true` ranges word-at-a-time.
+        let mut runs = 0usize;
+        let mut cursor = 0usize;
+        for (start, end) in bits.set_slices() {
+            if start > cursor {
+                runs += 1; // leading/interior false gap
+            }
+            runs += 1; // the true run
+            cursor = end;
+        }
+        if cursor < len {
+            runs += 1; // trailing false gap
+        }
+        runs
+    }
+}
+
+impl Scheme for BoolRunEndScheme {
+    fn scheme_name(&self) -> &'static str {
+        "vortex.bool.runend"
+    }
+
+    fn matches(&self, canonical: &Canonical) -> bool {
+        canonical.dtype().is_boolean()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![RunEnd.id()]
+    }
+
+    /// Children: values=0, ends=1.
+    fn num_children(&self) -> usize {
+        2
+    }
+
+    /// RunEnd ends (child 1) are monotonically increasing positions with all unique values, so
+    /// run-end encoding them again is pointless.
+    fn descendant_exclusions(&self) -> Vec<DescendantExclusion> {
+        vec![DescendantExclusion {
+            excluded: RunEndScheme.id(),
+            children: ChildSelection::One(1),
+        }]
+    }
+
+    fn expected_compression_ratio(
+        &self,
+        data: &ArrayAndStats,
+        _compress_ctx: CompressorContext,
+        _exec_ctx: &mut ExecutionCtx,
+    ) -> CompressionEstimate {
+        let length = data.array_len();
+        if length == 0 {
+            return CompressionEstimate::Verdict(EstimateVerdict::Skip);
+        }
+
+        let runs = Self::run_count(data.array()).max(1);
+        if length / runs < RUN_END_THRESHOLD {
+            return CompressionEstimate::Verdict(EstimateVerdict::Skip);
+        }
+
+        CompressionEstimate::Deferred(DeferredEstimate::Sample)
+    }
+
+    fn compress(
+        &self,
+        compressor: &CascadingCompressor,
+        data: &ArrayAndStats,
+        compress_ctx: CompressorContext,
+        exec_ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let bool_array = data
+            .array()
+            .as_opt::<Bool>()
+            .vortex_expect("BoolRunEndScheme matches only canonical bool arrays");
+        let length = data.array_len();
+
+        let (ends, values) = runend_encode_bool(bool_array, exec_ctx);
+
+        let compressed_values =
+            compressor.compress_child(&values, &compress_ctx, self.id(), 0, exec_ctx)?;
+
+        let compressed_ends =
+            compressor.compress_child(&ends.into_array(), &compress_ctx, self.id(), 1, exec_ctx)?;
+
+        // SAFETY: compression preserves the strictly-increasing ends invariant.
+        Ok(unsafe {
+            RunEnd::new_unchecked(compressed_ends, compressed_values, 0, length).into_array()
+        })
+    }
+}

--- a/vortex-btrblocks/src/schemes/mod.rs
+++ b/vortex-btrblocks/src/schemes/mod.rs
@@ -4,6 +4,7 @@
 //! Compression scheme implementations.
 
 pub mod binary;
+pub mod bool;
 pub mod float;
 pub mod integer;
 pub mod string;


### PR DESCRIPTION
## Summary

Boolean columns are now run-end compressed through the **generic `RunEnd`** encoding rather than a bespoke bool encoding. The generic crate already *decodes* bool-valued run-end arrays (`decompress_bool.rs`, and the `DType::Bool` branch of `run_end_canonicalize`); the only missing piece was the *encode* side, which this PR adds.

This supersedes the earlier approach in this PR (a standalone `vortex-runend-bool` encoding). As discussed on the design, `RunEndBool` is really just `RunEnd` whose values are the implicit alternating pattern `[start, !start, …]`, so it is better expressed by composing the generic encoding than by duplicating its compute surface.

### Changes

1. **`vortex-runend` — bool encode path** (`compress.rs`):
   - `runend_encode_bool(ArrayView<Bool>, ctx) -> (ends, values)` mirrors the existing primitive encoders' validity handling — a new run starts whenever the `(value, validity)` pair changes, and per-run validity lives in the `BoolArray` values child.
   - `RunEnd::encode` now accepts `Bool` in addition to `Primitive`.

2. **`vortex-btrblocks` — auto-selection** (`schemes/bool/runend.rs`):
   - New `BoolRunEndScheme` emits a generic `RunEnd{ends, BoolArray values}` and cascades both children. Registered in `ALL_SCHEMES`; gated on average run length (word-at-a-time run counting via `set_slices`).

### Design note (future work)

The generic form materializes an `num_runs`-length alternating values child that is almost entirely redundant. A doc note on `runend_encode_bool` records that a future cycling/repeat-pattern array encoding — one that logically yields `[start, !start, …]` in O(1) space — could stand in as that values child, recovering the single-`start`-bit compactness of a dedicated bool run-end encoding through composition rather than a separate encoding.

### Tests / checks

- `cargo test -p vortex-runend` — 78 passed (new bool encode round-trips incl. interior-null cases + existing decode).
- `cargo test -p vortex-btrblocks` — 39 passed, incl. `test_run_heavy_bool_uses_runend` (run-heavy bool selects generic `RunEnd`) and existing bool/constant tests.
- `cargo clippy -p vortex-runend -p vortex-btrblocks` clean; `cargo +nightly fmt` clean.
- Not run locally: `vortex-duckdb` C++ layer (proxy blocks the DuckDB source download); its Rust uses only the unchanged generic `RunEndArray`.