### PR TITLE
Fix integer overflow in BitBufferMut::truncate and append_n

### DIFF
--- a/vortex-buffer/src/bit/buf_mut.rs
+++ b/vortex-buffer/src/bit/buf_mut.rs
@@ -375,7 +375,8 @@ impl BitBufferMut {
         if len > self.len {
             return;
         }
-
+        
+        assert!(self.offset <= usize::MAX - len, "Truncate on BitBufferMut overflowed");
         let end_bit = self.offset + len;
         let new_len_bytes = end_bit.div_ceil(8);
         self.buffer.truncate(new_len_bytes);
@@ -442,6 +443,8 @@ impl BitBufferMut {
             return;
         }
 
+        assert!(self.offset.checked_add(self.len).and_then(|v| v.checked_add(n)).is_some(),
+            "Append on BitBufferMut overflowed");
         let end_bit_pos = self.offset + self.len + n;
         let required_bytes = end_bit_pos.div_ceil(8);
 

--- a/vortex-buffer/src/bit/buf_mut.rs
+++ b/vortex-buffer/src/bit/buf_mut.rs
@@ -375,8 +375,11 @@ impl BitBufferMut {
         if len > self.len {
             return;
         }
-        
-        assert!(self.offset <= usize::MAX - len, "Truncate on BitBufferMut overflowed");
+
+        assert!(
+            self.offset <= usize::MAX - len,
+            "Truncate on BitBufferMut overflowed"
+        );
         let end_bit = self.offset + len;
         let new_len_bytes = end_bit.div_ceil(8);
         self.buffer.truncate(new_len_bytes);
@@ -443,8 +446,13 @@ impl BitBufferMut {
             return;
         }
 
-        assert!(self.offset.checked_add(self.len).and_then(|v| v.checked_add(n)).is_some(),
-            "Append on BitBufferMut overflowed");
+        assert!(
+            self.offset
+                .checked_add(self.len)
+                .and_then(|v| v.checked_add(n))
+                .is_some(),
+            "Append on BitBufferMut overflowed"
+        );
         let end_bit_pos = self.offset + self.len + n;
         let required_bytes = end_bit_pos.div_ceil(8);
 


### PR DESCRIPTION
## Summary

Several methods on `BitBufferMut` use unchecked arithmetic on offset/length values, which can overflow in release mode and lead to undefined behavior reachable entirely from safe code (`#![forbid(unsafe_code)]`).

Affected methods:
- `truncate`: `self.offset + len` overflows, causing the buffer to be truncated to an incorrect size.
- `append_n`: `self.offset + self.len + n` overflows, causing incorrect capacity calculation.

Fix: add overflow assertions before the unchecked addition.

Reproduction (all use `#![forbid(unsafe_code)]`):

```rust
// 1. truncate
let buffer = ByteBufferMut::zeroed(10);
let mut bb = BitBufferMut::from_buffer(buffer, usize::MAX - 2, 80);
bb.truncate(3);
bb.set(2);

// 2. append_n
let buffer = ByteBufferMut::zeroed(2);
let mut bb = BitBufferMut::from_buffer(buffer, 1000, 0);
bb.append_n(true, usize::MAX);
bb.set(10000);
```

Related: #7979 (the `BufferMut::zeroed_aligned` overflow I reported to maintainers in April 2025; this PR addresses additional overflow sites found during the same audit)

## Testing

Existing `cargo test -p vortex-buffer` passes (789 tests + 6 doc-tests).
Both PoCs now panic with overflow message instead of UB.

Happy to adjust the approach if maintainers prefer a different fix strategy.