### PR TITLE
bench: warm ArrayKernels before the bench loop

### DIFF
--- a/vortex-array/benches/aggregate_grouped.rs
+++ b/vortex-array/benches/aggregate_grouped.rs
@@ -28,6 +28,7 @@ use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 

--- a/vortex-array/benches/aggregate_max.rs
+++ b/vortex-array/benches/aggregate_max.rs
@@ -7,16 +7,18 @@ use divan::Bencher;
 use rand::prelude::*;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
 const N: usize = 100_000;
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 #[divan::bench]
 fn max_i32(bencher: Bencher) {

--- a/vortex-array/benches/aggregate_sum.rs
+++ b/vortex-array/benches/aggregate_sum.rs
@@ -7,17 +7,19 @@ use divan::Bencher;
 use rand::prelude::*;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::expr::stats::Stat;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
 const N: usize = 100_000;
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 #[divan::bench]
 fn sum_i32(bencher: Bencher) {

--- a/vortex-array/benches/binary_ops.rs
+++ b/vortex-array/benches/binary_ops.rs
@@ -15,6 +15,7 @@ use vortex_array::ArrayRef;
 use vortex_array::Executable;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -23,10 +24,11 @@ use vortex_array::scalar_fn::fns::operators::Operator;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 const LEN: usize = 65_536;
 

--- a/vortex-array/benches/bool_zip.rs
+++ b/vortex-array/benches/bool_zip.rs
@@ -10,16 +10,18 @@ use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::BoolArray;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 const LEN: usize = 65_536;
 

--- a/vortex-array/benches/cast_primitive.rs
+++ b/vortex-array/benches/cast_primitive.rs
@@ -10,6 +10,7 @@ use rand::prelude::*;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
@@ -19,6 +20,7 @@ use vortex_array::expr::stats::Stat;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
@@ -26,7 +28,7 @@ fn main() {
 // the kernel cost shows up clearly rather than being hidden by DRAM bandwidth.
 const SIZES: &[usize] = &[65_536];
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 #[divan::bench(args = SIZES)]
 fn cast_u16_to_u32(bencher: Bencher, n: usize) {

--- a/vortex-array/benches/chunk_array_builder.rs
+++ b/vortex-array/benches/chunk_array_builder.rs
@@ -11,6 +11,7 @@ use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::ConstantArray;
@@ -22,6 +23,7 @@ use vortex_error::VortexExpect;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
@@ -32,7 +34,7 @@ const BENCH_ARGS: &[(usize, usize)] = &[
     (1000, 10),
 ];
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 #[divan::bench(args = BENCH_ARGS)]
 fn chunked_bool_canonical_into(bencher: Bencher, (len, chunk_count): (usize, usize)) {

--- a/vortex-array/benches/chunked_dict_builder.rs
+++ b/vortex-array/benches/chunked_dict_builder.rs
@@ -15,6 +15,7 @@ use vortex_error::VortexExpect;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 

--- a/vortex-array/benches/chunked_fsl_canonicalize.rs
+++ b/vortex-array/benches/chunked_fsl_canonicalize.rs
@@ -16,6 +16,7 @@ use divan::Bencher;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::validity::Validity;
@@ -23,10 +24,11 @@ use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 /// Number of lists in each chunk.
 const LISTS_PER_CHUNK: usize = 1_000;

--- a/vortex-array/benches/dict_compare.rs
+++ b/vortex-array/benches/dict_compare.rs
@@ -9,6 +9,7 @@ use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::VarBinArray;
 use vortex_array::arrays::VarBinViewArray;
@@ -24,10 +25,11 @@ use vortex_array::scalar_fn::fns::operators::Operator;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 const LENGTH_AND_UNIQUE_VALUES: &[(usize, usize)] = &[
     // length, unique_values

--- a/vortex-array/benches/dict_compress.rs
+++ b/vortex-array/benches/dict_compress.rs
@@ -11,6 +11,7 @@ use rand::distr::StandardUniform;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::VarBinArray;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::arrays::dict_test::gen_primitive_for_dict;
@@ -20,6 +21,7 @@ use vortex_array::dtype::NativePType;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
@@ -37,7 +39,7 @@ const BENCH_ARGS: &[(usize, usize)] = &[
     (10_000, 512),
 ];
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 #[divan::bench(types = [u8, f32, i64], args = BENCH_ARGS)]
 fn encode_primitives<T>(bencher: Bencher, (len, unique_values): (usize, usize))

--- a/vortex-array/benches/expr/case_when_bench.rs
+++ b/vortex-array/benches/expr/case_when_bench.rs
@@ -11,6 +11,7 @@ use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::StructArray;
 use vortex_array::expr::case_when;
@@ -25,9 +26,10 @@ use vortex_array::expr::root;
 use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 

--- a/vortex-array/benches/filter_bool.rs
+++ b/vortex-array/benches/filter_bool.rs
@@ -18,16 +18,18 @@ use rand::prelude::*;
 use rand_distr::Zipf;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::BoolArray;
 use vortex_buffer::BitBuffer;
 use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 const SIZES: &[usize] = &[1_000, 10_000, 100_000, 250_000];
 const DENSITY_SWEEP_SIZE: usize = 100_000;

--- a/vortex-array/benches/listview_rebuild.rs
+++ b/vortex-array/benches/listview_rebuild.rs
@@ -12,6 +12,7 @@ use divan::Bencher;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::ListArray;
 use vortex_array::arrays::ListViewArray;
@@ -26,11 +27,12 @@ use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
 /// A shared session for the `ListView` rebuild benchmarks, used to create execution contexts.
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 fn make_primitive_lv(num_lists: usize, list_size: usize, step: usize) -> ListViewArray {
     let element_count = step * num_lists + list_size;

--- a/vortex-array/benches/primitive_zip.rs
+++ b/vortex-array/benches/primitive_zip.rs
@@ -9,21 +9,25 @@
 
 use std::sync::LazyLock;
 
+use arrow_array::ArrayRef;
 use divan::Bencher;
 use vortex_array::IntoArray;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::builtins::ArrayBuiltins;
+use vortex_array::validity::Validity;
 use vortex_buffer::BufferMut;
 use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 // Sized so the bench stays well under a few hundred microseconds under CodSpeed's instruction-count
 // simulation, which runs ~10x the local walltime; the branchless value blend is still exercised.
@@ -49,7 +53,7 @@ fn nullable(bencher: Bencher) {
     run(bencher, if_true, if_false);
 }
 
-fn run(bencher: Bencher, if_true: vortex_array::ArrayRef, if_false: vortex_array::ArrayRef) {
+fn run(bencher: Bencher, if_true: ArrayRef, if_false: ArrayRef) {
     let mask = mask();
     bencher
         .with_inputs(|| {
@@ -71,10 +75,7 @@ fn run(bencher: Bencher, if_true: vortex_array::ArrayRef, if_false: vortex_array
 fn nonnull_array(base: i64) -> PrimitiveArray {
     let mut values = BufferMut::<i64>::with_capacity(LEN);
     values.extend((0..LEN as i64).map(|i| base + i));
-    PrimitiveArray::new(
-        values.freeze(),
-        vortex_array::validity::Validity::NonNullable,
-    )
+    PrimitiveArray::new(values.freeze(), Validity::NonNullable)
 }
 
 fn nullable_array(base: i64, null_every: usize) -> PrimitiveArray {

--- a/vortex-array/benches/primitive_zip.rs
+++ b/vortex-array/benches/primitive_zip.rs
@@ -9,8 +9,8 @@
 
 use std::sync::LazyLock;
 
-use arrow_array::ArrayRef;
 use divan::Bencher;
+use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;

--- a/vortex-array/benches/scalar_at_struct.rs
+++ b/vortex-array/benches/scalar_at_struct.rs
@@ -13,6 +13,7 @@ use rand::rngs::StdRng;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::StructArray;
 use vortex_array::dtype::FieldNames;
 use vortex_array::validity::Validity;
@@ -20,13 +21,14 @@ use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
 const ARRAY_SIZE: usize = 100_000;
 const NUM_ACCESSES: usize = 1000;
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 #[divan::bench]
 fn execute_scalar_struct_simple(bencher: Bencher) {

--- a/vortex-array/benches/scalar_subtract.rs
+++ b/vortex-array/benches/scalar_subtract.rs
@@ -5,7 +5,6 @@
 
 use std::sync::LazyLock;
 
-use arrow_array::Scalar;
 use divan::Bencher;
 use rand::RngExt;
 use rand::SeedableRng;
@@ -18,6 +17,7 @@ use vortex_array::array_session;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::builtins::ArrayBuiltins;
+use vortex_array::scalar::Scalar;
 use vortex_array::scalar_fn::fns::operators::Operator;
 use vortex_buffer::Buffer;
 use vortex_session::VortexSession;

--- a/vortex-array/benches/scalar_subtract.rs
+++ b/vortex-array/benches/scalar_subtract.rs
@@ -5,6 +5,7 @@
 
 use std::sync::LazyLock;
 
+use arrow_array::Scalar;
 use divan::Bencher;
 use rand::RngExt;
 use rand::SeedableRng;
@@ -13,6 +14,7 @@ use rand::rngs::StdRng;
 use vortex_array::IntoArray;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::builtins::ArrayBuiltins;
@@ -21,10 +23,11 @@ use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 #[divan::bench]
 fn scalar_subtract(bencher: Bencher) {
@@ -50,11 +53,7 @@ fn scalar_subtract(bencher: Bencher) {
             chunked
                 .clone()
                 .binary(
-                    ConstantArray::new(
-                        vortex_array::scalar::Scalar::from(to_subtract),
-                        chunked.len(),
-                    )
-                    .into_array(),
+                    ConstantArray::new(Scalar::from(to_subtract), chunked.len()).into_array(),
                     Operator::Sub,
                 )
                 .unwrap()

--- a/vortex-array/benches/take_filter.rs
+++ b/vortex-array/benches/take_filter.rs
@@ -28,6 +28,7 @@ use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::ListArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::validity::Validity;
@@ -38,6 +39,7 @@ use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
@@ -57,7 +59,7 @@ const INDEX_SEED: u64 = 43;
 const LIST_SIZE: usize = 4;
 const NULL_INDEX_INTERVAL: usize = 8;
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 fn primitive_array() -> ArrayRef {
     PrimitiveArray::from_iter(0..ARRAY_LEN as u32).into_array()

--- a/vortex-array/benches/take_fsl.rs
+++ b/vortex-array/benches/take_fsl.rs
@@ -19,16 +19,18 @@ use rand::rngs::StdRng;
 use vortex_array::IntoArray;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 /// Number of lists in the source array.
 const NUM_LISTS: usize = 500;

--- a/vortex-array/benches/take_patches.rs
+++ b/vortex-array/benches/take_patches.rs
@@ -15,15 +15,17 @@ use vortex_array::IntoArray;
 #[expect(deprecated)]
 use vortex_array::ToCanonical as _;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::patches::Patches;
 use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 const BENCH_ARGS: &[(f64, f64)] = &[
     // patches_sparsity, index_multiple

--- a/vortex-array/benches/take_primitive.rs
+++ b/vortex-array/benches/take_primitive.rs
@@ -17,11 +17,13 @@ use rand_distr::Zipf;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
@@ -31,7 +33,7 @@ const NUM_INDICES: &[usize] = &[1_000, 10_000, 100_000];
 /// Size of the source vector / dictionary values.
 const VECTOR_SIZE: &[usize] = &[16, 256, 2048, 8192];
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 // --- DictArray canonicalization benchmarks ---
 

--- a/vortex-array/benches/take_struct.rs
+++ b/vortex-array/benches/take_struct.rs
@@ -13,6 +13,7 @@ use rand::rngs::StdRng;
 use vortex_array::IntoArray;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::StructArray;
 use vortex_array::dtype::FieldNames;
 use vortex_array::validity::Validity;
@@ -20,10 +21,11 @@ use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 const ARRAY_SIZE: usize = 100_000;
 const TAKE_SIZE: usize = 1000;

--- a/vortex-array/benches/to_arrow.rs
+++ b/vortex-array/benches/to_arrow.rs
@@ -10,6 +10,7 @@ use divan::Bencher;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::DecimalArray;
 use vortex_array::arrays::ListArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -28,10 +29,11 @@ use vortex_array::dtype::StructFields;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 fn schema() -> DType {
     let fields = StructFields::from_iter([
@@ -89,9 +91,6 @@ fn to_arrow_dtype(bencher: Bencher) {
 #[allow(non_snake_case)]
 #[divan::bench]
 fn ArrowExportVTable_to_arrow_field(bencher: Bencher) {
-    // Warm the ArrowSession
-    drop(SESSION.arrow().to_arrow_field("", &schema()).unwrap());
-
     bencher
         .with_inputs(schema)
         .bench_values(|dtype| SESSION.arrow().to_arrow_field("", &dtype).unwrap())
@@ -110,13 +109,6 @@ fn to_arrow_array(bencher: Bencher) {
 #[allow(non_snake_case)]
 #[divan::bench]
 fn ArrowExportVTable_execute_arrow(bencher: Bencher) {
-    // Warm the ArrowSession
-    drop(
-        SESSION
-            .arrow()
-            .execute_arrow(array(), None, &mut SESSION.create_execution_ctx()),
-    );
-
     bencher
         .with_inputs(|| (array(), SESSION.create_execution_ctx()))
         .bench_values(|(array, mut ctx)| {

--- a/vortex-array/benches/varbinview_zip.rs
+++ b/vortex-array/benches/varbinview_zip.rs
@@ -9,6 +9,7 @@ use divan::Bencher;
 use vortex_array::IntoArray;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
@@ -17,10 +18,11 @@ use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 /// Benchmarks zip on VarBinView arrays with a highly fragmented mask (worst case for per-slice lookup paths).
 #[divan::bench]

--- a/vortex-array/src/test_harness.rs
+++ b/vortex-array/src/test_harness.rs
@@ -7,13 +7,10 @@ use goldenfile::Mint;
 use goldenfile::differs::binary_diff;
 use itertools::Itertools;
 use vortex_error::VortexResult;
-use vortex_session::SessionExt;
 
 use crate::ExecutionCtx;
 use crate::arrays::BoolArray;
 use crate::arrays::bool::BoolArrayExt;
-use crate::optimizer::kernels::ArrayKernels;
-use crate::optimizer::kernels::KernelSession;
 
 /// Check that a named metadata matches its previous versioning.
 ///

--- a/vortex-array/src/test_harness.rs
+++ b/vortex-array/src/test_harness.rs
@@ -7,10 +7,13 @@ use goldenfile::Mint;
 use goldenfile::differs::binary_diff;
 use itertools::Itertools;
 use vortex_error::VortexResult;
+use vortex_session::SessionExt;
 
 use crate::ExecutionCtx;
 use crate::arrays::BoolArray;
 use crate::arrays::bool::BoolArrayExt;
+use crate::optimizer::kernels::ArrayKernels;
+use crate::optimizer::kernels::KernelSession;
 
 /// Check that a named metadata matches its previous versioning.
 ///

--- a/vortex-compressor/benches/dict_encode.rs
+++ b/vortex-compressor/benches/dict_encode.rs
@@ -8,6 +8,7 @@ use std::sync::LazyLock;
 use divan::Bencher;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::builders::dict::dict_encode;
@@ -15,7 +16,7 @@ use vortex_array::validity::Validity;
 use vortex_buffer::BufferMut;
 use vortex_session::VortexSession;
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 fn make_array() -> PrimitiveArray {
     let values: BufferMut<i32> = (0..50).cycle().take(64_000).collect();
@@ -41,5 +42,6 @@ fn encode_generic(bencher: Bencher) {
 }
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main()
 }

--- a/vortex-row/benches/row_encode.rs
+++ b/vortex-row/benches/row_encode.rs
@@ -34,7 +34,6 @@ use vortex_array::array_session;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::StructArray;
 use vortex_array::arrays::VarBinViewArray;
-use vortex_array::test_harness::WarmSession;
 use vortex_row::RowEncoder;
 use vortex_session::VortexSession;
 

--- a/vortex-row/benches/row_encode.rs
+++ b/vortex-row/benches/row_encode.rs
@@ -30,9 +30,11 @@ use rand::distr::Alphanumeric;
 use rand::rngs::StdRng;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::StructArray;
 use vortex_array::arrays::VarBinViewArray;
+use vortex_array::test_harness::WarmSession;
 use vortex_row::RowEncoder;
 use vortex_session::VortexSession;
 
@@ -41,9 +43,10 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 const N: usize = 100_000;
 
-static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -44,12 +44,15 @@ use vortex::encodings::runend::RunEnd;
 use vortex::encodings::runend::RunEndArrayExt;
 use vortex::error::VortexExpect;
 use vortex::extension::datetime::TimeUnit;
+use vortex_array::optimizer::kernels::KernelSession;
+use vortex_session::SessionExt;
 use vortex_session::VortexSession;
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -44,8 +44,6 @@ use vortex::encodings::runend::RunEnd;
 use vortex::encodings::runend::RunEndArrayExt;
 use vortex::error::VortexExpect;
 use vortex::extension::datetime::TimeUnit;
-use vortex_array::optimizer::kernels::KernelSession;
-use vortex_session::SessionExt;
 use vortex_session::VortexSession;
 
 #[global_allocator]

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -39,8 +39,10 @@ use vortex::encodings::zigzag::zigzag_encode;
 use vortex::encodings::zstd::Zstd;
 use vortex::encodings::zstd::ZstdData;
 use vortex_array::VortexSessionExecute;
+use vortex_array::optimizer::kernels::ArrayKernels;
 use vortex_error::VortexResult;
 use vortex_sequence::Sequence;
+use vortex_session::SessionExt;
 use vortex_session::VortexSession;
 
 #[global_allocator]
@@ -49,6 +51,7 @@ static GLOBAL: MiMalloc = MiMalloc;
 static SESSION: LazyLock<VortexSession> = LazyLock::new(VortexSession::default);
 
 fn main() {
+    LazyLock::force(&SESSION);
     divan::main();
 }
 

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -39,10 +39,8 @@ use vortex::encodings::zigzag::zigzag_encode;
 use vortex::encodings::zstd::Zstd;
 use vortex::encodings::zstd::ZstdData;
 use vortex_array::VortexSessionExecute;
-use vortex_array::optimizer::kernels::ArrayKernels;
 use vortex_error::VortexResult;
 use vortex_sequence::Sequence;
-use vortex_session::SessionExt;
 use vortex_session::VortexSession;
 
 #[global_allocator]


### PR DESCRIPTION
Change benchmarks to force initialisation of vortex session before start of benchmarking loop