### PR TITLE
Correctly restore unstable encoding corpus and create tokio runtime only once per process

### DIFF
--- a/.github/workflows/run-fuzzer.yml
+++ b/.github/workflows/run-fuzzer.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Run fuzzing target
         id: fuzz
         run: |
+          CORPUS_DIR="fuzz/corpus/${FUZZ_NAME}"
           FEATURES_FLAG=""
           if [ -n "${{ inputs.extra_features }}" ]; then
             FEATURES_FLAG="--features ${{ inputs.extra_features }}"
@@ -127,7 +128,7 @@ jobs:
           ${{ inputs.extra_env }} RUST_BACKTRACE=1 \
             cargo +$NIGHTLY_TOOLCHAIN fuzz run --release --debug-assertions \
             $FEATURES_FLAG \
-            ${{ inputs.fuzz_target }} -- \
+            ${{ inputs.fuzz_target }} "$CORPUS_DIR" -- \
             $FORK_FLAG -max_total_time=${{ inputs.max_time }} -rss_limit_mb=0 \
             2>&1 | tee fuzz_output.log
         continue-on-error: true

--- a/fuzz/fuzz_targets/compress_gpu.rs
+++ b/fuzz/fuzz_targets/compress_gpu.rs
@@ -4,20 +4,21 @@
 #![no_main]
 #![expect(clippy::unwrap_used)]
 
+use std::sync::LazyLock;
+
 use libfuzzer_sys::Corpus;
 use libfuzzer_sys::fuzz_target;
+use tokio::runtime::Builder;
+use tokio::runtime::Runtime;
 use vortex_error::vortex_panic;
 use vortex_fuzz::FuzzCompressGpu;
 use vortex_fuzz::run_compress_gpu;
 
-fuzz_target!(|fuzz: FuzzCompressGpu| -> Corpus {
-    // Use tokio runtime to run async GPU fuzzer
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
+static RUNTIME: LazyLock<Runtime> =
+    LazyLock::new(|| Builder::new_current_thread().enable_all().build().unwrap());
 
-    match rt.block_on(run_compress_gpu(fuzz)) {
+fuzz_target!(|fuzz: FuzzCompressGpu| -> Corpus {
+    match RUNTIME.block_on(run_compress_gpu(fuzz)) {
         Ok(true) => Corpus::Keep,
         Ok(false) => Corpus::Reject,
         Err(e) => {


### PR DESCRIPTION
I'm trying to get fuzzer into happier state, these two things showed up as obviously wrong