### PR TITLE
fix Fuzz constant OOM for CUDA

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -200,6 +200,10 @@ jobs:
       fuzz_target: compress_gpu
       runner: gpu
       extra_features: "cuda"
+      # ASan mprotects the shadow gap PROT_NONE by default, which collides with the large
+      # virtual-address range the CUDA driver reserves and makes device init fail with an
+      # OOM-style error. protect_shadow_gap=0 frees that VA range for CUDA.
+      extra_env: "ASAN_OPTIONS=protect_shadow_gap=0"
       jobs: 1
     secrets:
       R2_FUZZ_ACCESS_KEY_ID: ${{ secrets.R2_FUZZ_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary

The Fuzz check has been failing for CUDA `compress_gpu` job for a very long time now (at least a month).

After some investigation, it appears this is because ASAN will mprotect a very large memory region that conflicts with some address space that the CUDA driver wants to own, resulting in cudaCtx initialization failing with OOMs like we've been seeing.

I've run a sample Fuzz workflow with this change and confirmed we are able to get past context init now.