### PR TITLE
Change `ALIGNMENT_TO_HOST_COPY` to `Alignment::HOST_COPY`

### DIFF
--- a/vortex-array/src/buffer.rs
+++ b/vortex-array/src/buffer.rs
@@ -9,7 +9,6 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
-use vortex_buffer::ALIGNMENT_TO_HOST_COPY;
 use vortex_buffer::Alignment;
 use vortex_buffer::ByteBuffer;
 use vortex_error::VortexExpect;
@@ -321,7 +320,7 @@ impl BufferHandle {
     pub fn try_to_host_sync(&self) -> VortexResult<ByteBuffer> {
         match &self.0 {
             Inner::Host(b) => Ok(b.clone()),
-            Inner::Device(device) => device.copy_to_host_sync(ALIGNMENT_TO_HOST_COPY),
+            Inner::Device(device) => device.copy_to_host_sync(Alignment::HOST_COPY),
         }
     }
 
@@ -331,7 +330,7 @@ impl BufferHandle {
     pub fn try_into_host_sync(self) -> VortexResult<ByteBuffer> {
         match self.0 {
             Inner::Host(b) => Ok(b),
-            Inner::Device(device) => device.copy_to_host_sync(ALIGNMENT_TO_HOST_COPY),
+            Inner::Device(device) => device.copy_to_host_sync(Alignment::HOST_COPY),
         }
     }
 
@@ -352,7 +351,7 @@ impl BufferHandle {
                 let buffer = b.clone();
                 Ok(Box::pin(async move { Ok(buffer) }))
             }
-            Inner::Device(device) => device.copy_to_host(ALIGNMENT_TO_HOST_COPY),
+            Inner::Device(device) => device.copy_to_host(Alignment::HOST_COPY),
         }
     }
 
@@ -370,7 +369,7 @@ impl BufferHandle {
     pub fn try_into_host(self) -> VortexResult<BoxFuture<'static, VortexResult<ByteBuffer>>> {
         match self.0 {
             Inner::Host(b) => Ok(Box::pin(async move { Ok(b) })),
-            Inner::Device(device) => device.copy_to_host(ALIGNMENT_TO_HOST_COPY),
+            Inner::Device(device) => device.copy_to_host(Alignment::HOST_COPY),
         }
     }
 

--- a/vortex-buffer/src/alignment.rs
+++ b/vortex-buffer/src/alignment.rs
@@ -8,9 +8,6 @@ use vortex_error::VortexError;
 use vortex_error::VortexExpect;
 use vortex_error::vortex_err;
 
-/// Default alignment for device-to-host buffer copies.
-pub const ALIGNMENT_TO_HOST_COPY: Alignment = Alignment::new(256);
-
 /// The alignment of a buffer.
 ///
 /// This type is a wrapper around `usize` that ensures the alignment is a power of 2 and fits into
@@ -19,6 +16,9 @@ pub const ALIGNMENT_TO_HOST_COPY: Alignment = Alignment::new(256);
 pub struct Alignment(usize);
 
 impl Alignment {
+    /// Default alignment for device-to-host buffer copies.
+    pub const HOST_COPY: Self = Alignment::new(256);
+
     /// Create a new alignment.
     ///
     /// ## Panics


### PR DESCRIPTION
## Summary

Just a minor API change. I think this is much nicer and removes an import at the callsite.

## API Changes

Removes the `ALIGNMENT_TO_HOST_COPY` const in favor of `Alignment::HOST_COPY`.
