### PR TITLE
Build CUDA benchmarks once, but run in parallel

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -69,6 +69,8 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: "simulation"
 
+  # Getting a GPU box is slow, in the future we can build on a box without one and only run
+  # on GPU machines.
   bench-codspeed-cuda-build:
     if: github.repository == 'vortex-data/vortex'
     name: "Build Codspeed CUDA benchmarks"

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -98,6 +98,10 @@ jobs:
             --bench fsst_cuda \
             --bench runend_cuda \
             --profile bench
+      - name: Verify CUDA kernels were built
+        run: test -f vortex-cuda/kernels/gen/release/dynamic_dispatch.ptx
+      - name: Stage CUDA kernels with Codspeed artifacts
+        run: cp -R vortex-cuda/kernels/gen/release target/codspeed/cuda-kernels
       - name: Upload benchmark executables
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
@@ -150,6 +154,7 @@ jobs:
         uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2
         env:
           CARGO_MANIFEST_DIR: ${{ github.workspace }}/vortex-cuda
+          VORTEX_CUDA_KERNELS_DIR: ${{ github.workspace }}/target/codspeed/cuda-kernels
         with:
           run: cargo codspeed run $(printf -- '--bench %s ' ${{ matrix.benches }})
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -69,8 +69,46 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: "simulation"
 
+  bench-codspeed-cuda-build:
+    if: github.repository == 'vortex-data/vortex'
+    name: "Build Codspeed CUDA benchmarks"
+    timeout-minutes: 30
+    runs-on: >-
+      runs-on=${{ github.run_id }}/family=g5/cpu=8/image=ubuntu24-gpu-x64/tag=bench-codspeed-cuda-build
+    steps:
+      - uses: runs-on/action@v2
+        with:
+          sccache: s3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: ./.github/actions/setup-rust
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Codspeed
+        uses: taiki-e/cache-cargo-install-action@66c9585ef5ca780ee69399975a5e911f47905995
+        with:
+          tool: cargo-codspeed
+      - name: Build benchmarks
+        run: |
+          cargo codspeed build -m walltime \
+            --bench bitpacked_cuda \
+            --bench dynamic_dispatch_cuda \
+            --bench alp_cuda \
+            --bench date_time_parts_cuda \
+            --bench dict_cuda \
+            --bench fsst_cuda \
+            --bench runend_cuda \
+            --profile bench
+      - name: Upload benchmark executables
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: codspeed-cuda-benchmarks
+          path: target/codspeed/
+          retention-days: 1
+          if-no-files-found: error
+
   bench-codspeed-cuda:
     if: github.repository == 'vortex-data/vortex'
+    needs: [bench-codspeed-cuda-build]
     strategy:
       matrix:
         include:
@@ -101,8 +139,13 @@ jobs:
         uses: taiki-e/cache-cargo-install-action@66c9585ef5ca780ee69399975a5e911f47905995
         with:
           tool: cargo-codspeed
-      - name: Build benchmarks
-        run: cargo codspeed build -m walltime $(printf -- '--bench %s ' ${{ matrix.benches }}) --profile bench
+      - name: Download benchmark executables
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: codspeed-cuda-benchmarks
+          path: target/codspeed
+      - name: Restore executable permissions
+        run: find target/codspeed -type f -exec chmod +x {} +
       - name: Run benchmarks
         uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2
         env:


### PR DESCRIPTION
## Summary

Reducing the amount of GPU machines we need to get from AWS, and save some money.
An easy follow up here is to build on a machine without a GPU, which should also save some time on startup.