### PR TITLE
Add `list_length` scalar function

### DIFF
--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -237,6 +237,10 @@ name = "filter_bool"
 harness = false
 
 [[bench]]
+name = "list_length"
+harness = false
+
+[[bench]]
 name = "listview_rebuild"
 harness = false
 

--- a/vortex-array/benches/list_length.rs
+++ b/vortex-array/benches/list_length.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Benchmarks for the `list_length` scalar function over `List` and `ListView` inputs.
+//!
+//! `list_length` reads only the offsets/sizes (never the elements), so its cost scales with the
+//! number of lists.
+
+#![expect(clippy::unwrap_used)]
+#![expect(clippy::cast_possible_truncation)]
+
+use std::sync::LazyLock;
+
+use divan::Bencher;
+use rand::RngExt;
+use rand::SeedableRng;
+use rand::distr::Uniform;
+use rand::rngs::StdRng;
+use vortex_array::ArrayRef;
+use vortex_array::Canonical;
+use vortex_array::IntoArray;
+use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::BoolArray;
+use vortex_array::arrays::ListArray;
+use vortex_array::arrays::ListViewArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::expr::list_length;
+use vortex_array::expr::root;
+use vortex_array::validity::Validity;
+use vortex_buffer::Buffer;
+use vortex_session::VortexSession;
+
+fn main() {
+    divan::main();
+}
+
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+
+const BASE_LIST_SIZE: usize = 8;
+
+const SMALL: usize = 100;
+const MEDIUM: usize = 10_000;
+const LARGE: usize = 1_000_000;
+
+/// A uniformly-random partition of `num_lists * LIST_SIZE` elements into `num_lists` lists,
+/// plus a validity mask with ~1/8 of lists null at random positions.
+fn random_lists(num_lists: usize) -> (Vec<i32>, Validity) {
+    let mut rng = StdRng::seed_from_u64(num_lists as u64);
+    let total = (num_lists * BASE_LIST_SIZE) as i32;
+
+    let cut_dist = Uniform::new_inclusive(0i32, total).unwrap();
+    let mut cuts: Vec<i32> = (0..num_lists - 1).map(|_| rng.sample(cut_dist)).collect();
+    cuts.sort_unstable();
+    let mut sizes = Vec::with_capacity(num_lists);
+    let mut prev = 0i32;
+    for cut in cuts {
+        sizes.push(cut - prev);
+        prev = cut;
+    }
+    sizes.push(total - prev);
+
+    let null_dist = Uniform::new(0u32, 8).unwrap();
+    let valid = (0..num_lists).map(|_| rng.sample(null_dist) != 0);
+    (
+        sizes,
+        Validity::Array(BoolArray::from_iter(valid).into_array()),
+    )
+}
+
+/// A canonical `List<i32>` of `num_lists` variable-length lists, ~1/8 of them null.
+fn make_list(num_lists: usize) -> ArrayRef {
+    let (sizes, validity) = random_lists(num_lists);
+    let total: i32 = sizes.iter().sum();
+    let elements = PrimitiveArray::from_iter(0..total).into_array();
+    let offsets: Buffer<i32> = std::iter::once(0)
+        .chain(sizes.iter().scan(0i32, |acc, &s| {
+            *acc += s;
+            Some(*acc)
+        }))
+        .collect();
+    ListArray::try_new(elements, offsets.into_array(), validity)
+        .unwrap()
+        .into_array()
+}
+
+/// A gapless `ListView<i32>` of `num_lists` variable-length lists, ~1/8 of them null.
+fn make_listview(num_lists: usize) -> ArrayRef {
+    let (sizes, validity) = random_lists(num_lists);
+    let total: i32 = sizes.iter().sum();
+    let elements = PrimitiveArray::from_iter(0..total).into_array();
+    let offsets: Buffer<i32> = sizes
+        .iter()
+        .scan(0i32, |acc, &s| {
+            let start = *acc;
+            *acc += s;
+            Some(start)
+        })
+        .collect();
+    let sizes: Buffer<i32> = sizes.into_iter().collect();
+    ListViewArray::new(elements, offsets.into_array(), sizes.into_array(), validity).into_array()
+}
+
+/// Apply `list_length(root())` and materialize the result.
+fn run(bencher: Bencher, array: ArrayRef) {
+    let expr = list_length(root());
+    bencher
+        .with_inputs(|| (&array, SESSION.create_execution_ctx()))
+        .bench_refs(|(array, ctx)| {
+            array
+                .clone()
+                .apply(&expr)
+                .unwrap()
+                .execute::<Canonical>(ctx)
+                .unwrap()
+        });
+}
+
+#[divan::bench]
+fn list_small(bencher: Bencher) {
+    run(bencher, make_list(SMALL));
+}
+
+#[divan::bench]
+fn list_medium(bencher: Bencher) {
+    run(bencher, make_list(MEDIUM));
+}
+
+#[divan::bench]
+fn list_large(bencher: Bencher) {
+    run(bencher, make_list(LARGE));
+}
+
+#[divan::bench]
+fn listview_small(bencher: Bencher) {
+    run(bencher, make_listview(SMALL));
+}
+
+#[divan::bench]
+fn listview_medium(bencher: Bencher) {
+    run(bencher, make_listview(MEDIUM));
+}
+
+#[divan::bench]
+fn listview_large(bencher: Bencher) {
+    run(bencher, make_listview(LARGE));
+}

--- a/vortex-array/benches/list_length.rs
+++ b/vortex-array/benches/list_length.rs
@@ -116,31 +116,31 @@ fn run(bencher: Bencher, array: ArrayRef) {
 }
 
 #[divan::bench]
-fn list_small(bencher: Bencher) {
+fn list_length_small(bencher: Bencher) {
     run(bencher, make_list(SMALL));
 }
 
 #[divan::bench]
-fn list_medium(bencher: Bencher) {
+fn list_length_medium(bencher: Bencher) {
     run(bencher, make_list(MEDIUM));
 }
 
 #[divan::bench]
-fn list_large(bencher: Bencher) {
+fn list_length_large(bencher: Bencher) {
     run(bencher, make_list(LARGE));
 }
 
 #[divan::bench]
-fn listview_small(bencher: Bencher) {
+fn listview_length_small(bencher: Bencher) {
     run(bencher, make_listview(SMALL));
 }
 
 #[divan::bench]
-fn listview_medium(bencher: Bencher) {
+fn listview_length_medium(bencher: Bencher) {
     run(bencher, make_listview(MEDIUM));
 }
 
 #[divan::bench]
-fn listview_large(bencher: Bencher) {
+fn listview_length_large(bencher: Bencher) {
     run(bencher, make_listview(LARGE));
 }

--- a/vortex-array/src/expr/exprs.rs
+++ b/vortex-array/src/expr/exprs.rs
@@ -754,11 +754,9 @@ pub fn ext_storage(input: Expression) -> Expression {
 
 // ---- ListLength ----
 
-/// Creates an expression that computes the number of elements in each list.
-///
-/// This is akin to ANSI SQL `CARDINALITY()`, or DuckDB's `len()`/`array_length()`. The result is
-/// a `U64` array; a null list yields a null length. It reads only the list's offsets, not the
-/// element values.
+/// Creates an expression that computes the number of elements in each list
+/// for `List` and `FixedSizeList` inputs. This is akin to ANSI SQL `CARDINALITY()`,
+/// or DuckDB's `len()`/`array_length()`.
 ///
 /// ```rust
 /// # use vortex_array::expr::{list_length, root};

--- a/vortex-array/src/expr/exprs.rs
+++ b/vortex-array/src/expr/exprs.rs
@@ -37,6 +37,7 @@ use crate::scalar_fn::fns::is_null::IsNull;
 use crate::scalar_fn::fns::like::Like;
 use crate::scalar_fn::fns::like::LikeOptions;
 use crate::scalar_fn::fns::list_contains::ListContains;
+use crate::scalar_fn::fns::list_length::ListLength;
 use crate::scalar_fn::fns::literal::Literal;
 use crate::scalar_fn::fns::mask::Mask;
 use crate::scalar_fn::fns::merge::DuplicateHandling;
@@ -749,4 +750,20 @@ pub fn byte_length(input: Expression) -> Expression {
 /// ```
 pub fn ext_storage(input: Expression) -> Expression {
     ExtStorage.new_expr(EmptyOptions, [input])
+}
+
+// ---- ListLength ----
+
+/// Creates an expression that computes the number of elements in each list.
+///
+/// This is akin to ANSI SQL `CARDINALITY()`, or DuckDB's `len()`/`array_length()`. The result is
+/// a `U64` array; a null list yields a null length. It reads only the list's offsets, not the
+/// element values.
+///
+/// ```rust
+/// # use vortex_array::expr::{list_length, root};
+/// let expr = list_length(root());
+/// ```
+pub fn list_length(input: Expression) -> Expression {
+    ListLength.new_expr(EmptyOptions, [input])
 }

--- a/vortex-array/src/scalar_fn/fns/list_length.rs
+++ b/vortex-array/src/scalar_fn/fns/list_length.rs
@@ -12,8 +12,10 @@ use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::array::ArrayView;
 use crate::arrays::ConstantArray;
+use crate::arrays::FixedSizeList;
 use crate::arrays::List;
 use crate::arrays::ListView;
+use crate::arrays::fixed_size_list::FixedSizeListArrayExt;
 use crate::arrays::list::ListArrayExt;
 use crate::arrays::listview::ListViewArrayExt;
 use crate::builtins::ArrayBuiltins;
@@ -27,13 +29,8 @@ use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ExecutionArgs;
-use crate::scalar_fn::ReduceCtx;
-use crate::scalar_fn::ReduceNode;
-use crate::scalar_fn::ReduceNodeRef;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
-use crate::scalar_fn::ScalarFnVTableExt;
-use crate::scalar_fn::fns::literal::Literal;
 use crate::scalar_fn::fns::operators::Operator;
 
 /// Number of elements in each list of a `List` or `FixedSizeList` typed array.
@@ -101,22 +98,6 @@ impl ScalarFnVTable for ListLength {
         list_length(&input, nullability, ctx)
     }
 
-    fn reduce(
-        &self,
-        _options: &Self::Options,
-        node: &dyn ReduceNode,
-        ctx: &dyn ReduceCtx,
-    ) -> VortexResult<Option<ReduceNodeRef>> {
-        // The length of nonnullable fixed-size list is constant
-        if let DType::FixedSizeList(_, size, Nullability::NonNullable) =
-            node.child(0).node_dtype()?
-        {
-            let length = Scalar::primitive(size as u64, Nullability::NonNullable);
-            return Ok(Some(ctx.new_node(Literal.bind(length), &[])?));
-        }
-        Ok(None)
-    }
-
     fn validity(
         &self,
         _: &Self::Options,
@@ -148,30 +129,24 @@ pub(crate) fn list_length(
     nullability: Nullability,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    let (lengths, validity) = match array.dtype() {
-        // The length of fixed-size list is constant, so just need to carry over validity
-        DType::FixedSizeList(_, size, _) => {
-            let lengths = ConstantArray::new(
-                Scalar::primitive(*size as u64, Nullability::NonNullable),
-                array.len(),
-            )
-            .into_array();
-            (lengths, array.validity()?)
-        }
-        DType::List(..) => {
-            let list = array.clone().execute_until::<AnyList>(ctx)?;
+    let any_list = array.clone().execute_until::<AnyList>(ctx)?;
 
-            if let Some(list) = list.as_opt::<List>() {
-                let lengths = list_length_from_offsets(list)?;
-                (lengths, list.list_validity())
-            } else if let Some(list_view) = list.as_opt::<ListView>() {
-                // Length array is exactly the sizes child
-                (list_view.sizes().clone(), list_view.listview_validity())
-            } else {
-                unreachable!("AnyList matcher guarantees List or ListView")
-            }
-        }
-        other => vortex_bail!("list_length() requires List or FixedSizeList, got {other}"),
+    let (lengths, validity) = if let Some(fsl) = any_list.as_opt::<FixedSizeList>() {
+        // The length of fixed-size list is constant, so just need to carry over validity
+        let size = fsl.list_size() as u64;
+        let lengths =
+            ConstantArray::new(Scalar::primitive(size, Nullability::NonNullable), fsl.len())
+                .into_array();
+        (lengths, fsl.validity()?)
+    } else if let Some(lv) = any_list.as_opt::<ListView>() {
+        // Length array is exactly the sizes child
+        (lv.sizes().clone(), lv.listview_validity())
+    } else if let Some(l) = any_list.as_opt::<List>() {
+        let lengths = list_length_from_offsets(l)?;
+        (lengths, l.list_validity())
+    } else {
+        let dtype = any_list.dtype();
+        vortex_bail!("list_length() requires List, ListView, or FixedSizeList but got {dtype}")
     };
 
     // Cast to `U64`
@@ -197,14 +172,17 @@ fn list_length_from_offsets(list: ArrayView<'_, List>) -> VortexResult<ArrayRef>
         .binary(offsets.slice(0..n)?, Operator::Sub)
 }
 
-/// Matches an `Array<List>` or `Array<ListView>`.
+/// Matches an `Array<List>`, `Array<ListView>`, or `Array<FixedSizeList>`
 struct AnyList;
 
 impl Matcher for AnyList {
     type Match<'a> = ();
 
     fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        (array.as_opt::<List>().is_some() || array.as_opt::<ListView>().is_some()).then_some(())
+        (array.as_opt::<List>().is_some()
+            || array.as_opt::<ListView>().is_some()
+            || array.as_opt::<FixedSizeList>().is_some())
+        .then_some(())
     }
 }
 
@@ -212,6 +190,7 @@ impl Matcher for AnyList {
 mod tests {
     use std::sync::Arc;
 
+    use insta::assert_snapshot;
     use rstest::rstest;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
@@ -226,16 +205,14 @@ mod tests {
     use crate::arrays::ListArray;
     use crate::arrays::ListViewArray;
     use crate::arrays::PrimitiveArray;
-    use crate::arrays::ScalarFn;
-    use crate::arrays::scalar_fn::ScalarFnArrayExt;
     use crate::assert_arrays_eq;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
     use crate::dtype::PType;
+    use crate::expr::cast;
     use crate::expr::list_length;
     use crate::expr::root;
     use crate::scalar::Scalar;
-    use crate::scalar_fn::fns::literal::Literal;
     use crate::validity::Validity;
 
     fn create_list_elements() -> ArrayRef {
@@ -365,14 +342,6 @@ mod tests {
         let fsl = create_fixed_size_list(Validity::NonNullable);
         let result = fsl.apply(&list_length(root()))?;
 
-        // A non-nullable fixed-size list reduces to a constant literal length, never touching the
-        // `ListLength` execution path.
-        assert!(
-            result
-                .as_opt::<ScalarFn>()
-                .is_some_and(|f| f.scalar_fn().as_opt::<Literal>().is_some()),
-            "list_length over a non-nullable FixedSizeList must reduce to a constant literal"
-        );
         let mut ctx = array_session().create_execution_ctx();
         assert_arrays_eq!(result, PrimitiveArray::from_iter([2u64, 2, 2, 2]), &mut ctx);
         Ok(())
@@ -390,6 +359,30 @@ mod tests {
 
         let expected = PrimitiveArray::from_option_iter::<u64, _>([Some(2), None, Some(2), None]);
         assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn test_fallible_child_expression_fails() -> VortexResult<()> {
+        let fsl = create_fixed_size_list(Validity::Array(
+            BoolArray::from_iter([true, false, true, false]).into_array(),
+        ));
+        let failing_cast_dtype = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
+            2,
+            Nullability::NonNullable,
+        );
+
+        let lengths = fsl.apply(&list_length(cast(root(), failing_cast_dtype)))?;
+
+        let mut ctx = array_session().create_execution_ctx();
+        let result = lengths.execute::<ArrayRef>(&mut ctx);
+
+        assert_snapshot!(
+            result.unwrap_err().to_string(),
+            @"Invalid argument error: Cannot cast array with invalid values to non-nullable type."
+
+        );
         Ok(())
     }
 

--- a/vortex-array/src/scalar_fn/fns/list_length.rs
+++ b/vortex-array/src/scalar_fn/fns/list_length.rs
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use num_traits::AsPrimitive;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
+
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::IntoArray;
+use crate::arrays::ConstantArray;
+use crate::arrays::List;
+use crate::arrays::ListView;
+use crate::arrays::ListViewArray;
+use crate::arrays::list::ListArrayExt;
+use crate::arrays::listview::ListViewArrayExt;
+use crate::builtins::ArrayBuiltins;
+use crate::dtype::DType;
+use crate::dtype::Nullability;
+use crate::dtype::PType;
+use crate::expr::Expression;
+use crate::scalar::Scalar;
+use crate::scalar_fn::Arity;
+use crate::scalar_fn::ChildName;
+use crate::scalar_fn::EmptyOptions;
+use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::ScalarFnId;
+use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::fns::operators::Operator;
+
+/// Number of elements in each list of a `List` typed array.
+///
+/// This is computed purely from the list's offsets/sizes (the per-list length), never reading the
+/// element *values*. Validity is carried over from the original array.
+#[derive(Clone)]
+pub struct ListLength;
+
+impl ScalarFnVTable for ListLength {
+    type Options = EmptyOptions;
+
+    fn id(&self) -> ScalarFnId {
+        static ID: CachedId = CachedId::new("vortex.list.length");
+        *ID
+    }
+
+    fn serialize(&self, _instance: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
+        Ok(Some(vec![]))
+    }
+
+    fn deserialize(
+        &self,
+        _metadata: &[u8],
+        _session: &VortexSession,
+    ) -> VortexResult<Self::Options> {
+        Ok(EmptyOptions)
+    }
+
+    fn arity(&self, _options: &Self::Options) -> Arity {
+        Arity::Exact(1)
+    }
+
+    fn child_name(&self, _instance: &Self::Options, child_idx: usize) -> ChildName {
+        match child_idx {
+            0 => ChildName::from("input"),
+            _ => unreachable!("Invalid child index {child_idx} for list_length()"),
+        }
+    }
+
+    fn return_dtype(&self, _options: &Self::Options, arg_dtypes: &[DType]) -> VortexResult<DType> {
+        match &arg_dtypes[0] {
+            DType::List(_, nullable) => Ok(DType::Primitive(PType::U64, *nullable)),
+            other => vortex_bail!("list_length() requires List, got {other}"),
+        }
+    }
+
+    fn execute(
+        &self,
+        _options: &Self::Options,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let input = args.get(0)?;
+        let nullability = input.dtype().nullability();
+
+        if let Some(scalar) = input.as_constant() {
+            let len_scalar = scalar_list_length(&scalar, nullability)?;
+            return Ok(ConstantArray::new(len_scalar, args.row_count()).into_array());
+        }
+
+        match input.dtype() {
+            DType::List(..) => list_length(&input, nullability, ctx),
+            other => vortex_bail!("list_length() requires List, got {other}"),
+        }
+    }
+
+    fn validity(
+        &self,
+        _: &Self::Options,
+        expression: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        Ok(Some(expression.child(0).validity()?))
+    }
+
+    fn is_null_sensitive(&self, _options: &Self::Options) -> bool {
+        false
+    }
+
+    fn is_fallible(&self, _options: &Self::Options) -> bool {
+        false
+    }
+}
+
+fn scalar_list_length(scalar: &Scalar, nullability: Nullability) -> VortexResult<Scalar> {
+    if scalar.is_null() {
+        let dtype = DType::Primitive(PType::U64, Nullability::Nullable);
+        return Ok(Scalar::null(dtype));
+    }
+    let len: u64 = scalar.as_list().len().as_();
+    Ok(Scalar::primitive(len, nullability))
+}
+
+pub(crate) fn list_length(
+    array: &ArrayRef,
+    nullability: Nullability,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    // TODO(mk): short-circuit when array is all null
+
+    let (lengths, validity) = if let Some(list) = array.as_opt::<ListView>() {
+        // Length array is exactly size child
+        (list.sizes().clone(), list.listview_validity())
+    } else if let Some(list) = array.as_opt::<List>() {
+        // `length[i] = offsets[i + 1] - offsets[i]`
+        let offsets = list.offsets();
+        let n = offsets.len().saturating_sub(1);
+        let lengths = offsets
+            .slice(1..offsets.len())?
+            .binary(offsets.slice(0..n)?, Operator::Sub)?;
+        (lengths, list.list_validity())
+    } else {
+        // Otherwise execute to `ListViewArray` and take size child
+        let list = array.clone().execute::<ListViewArray>(ctx)?;
+        (list.sizes().clone(), list.listview_validity())
+    };
+
+    // Cast to the declared `U64` result
+    let len = lengths.len();
+    let lengths = lengths.cast(DType::Primitive(PType::U64, nullability))?;
+
+    // Carry over validity mask for nullable arrays
+    if matches!(nullability, Nullability::Nullable) {
+        lengths.mask(validity.to_array(len))
+    } else {
+        Ok(lengths)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rstest::rstest;
+    use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
+
+    use crate::ArrayRef;
+    use crate::IntoArray;
+    use crate::VortexSessionExecute;
+    use crate::arrays::BoolArray;
+    use crate::arrays::ConstantArray;
+    use crate::arrays::ListArray;
+    use crate::arrays::ListViewArray;
+    use crate::arrays::PrimitiveArray;
+    use crate::assert_arrays_eq;
+    use crate::dtype::DType;
+    use crate::dtype::Nullability;
+    use crate::dtype::PType;
+    use crate::expr::list_length;
+    use crate::expr::root;
+    use crate::scalar::Scalar;
+    use crate::validity::Validity;
+
+    fn create_list_elements() -> ArrayRef {
+        PrimitiveArray::from_option_iter::<i32, _>([
+            Some(1),
+            Some(2),
+            Some(3),
+            Some(4),
+            Some(5),
+            Some(6),
+            None,
+        ])
+        .into_array()
+    }
+
+    #[rstest]
+    #[case(buffer![0u32, 2, 5, 5, 7].into_array())]
+    #[case(buffer![0u64, 2, 5, 5, 7].into_array())]
+    fn test_list_length(#[case] offsets: ArrayRef) -> VortexResult<()> {
+        let elements = create_list_elements();
+        let list = ListArray::try_new(elements, offsets, Validity::NonNullable)?.into_array();
+        let result = list.apply(&list_length(root()))?;
+        assert_arrays_eq!(result, PrimitiveArray::from_iter([2u64, 3, 0, 2]));
+        Ok(())
+    }
+
+    #[rstest]
+    #[case(buffer![0u32, 2, 5, 5, 7].into_array())]
+    #[case(buffer![0u64, 2, 5, 5, 7].into_array())]
+    fn test_nullable_list_length(#[case] offsets: ArrayRef) -> VortexResult<()> {
+        let elements = create_list_elements();
+        let list = ListArray::try_new(
+            elements,
+            offsets,
+            Validity::Array(BoolArray::from_iter([true, false, true, false]).into_array()),
+        )?
+        .into_array();
+        let result = list.apply(&list_length(root()))?;
+
+        let session = VortexSession::empty();
+        let mut ctx = session.create_execution_ctx();
+        let result = result.execute::<PrimitiveArray>(&mut ctx)?;
+
+        let expected = PrimitiveArray::from_option_iter::<u64, _>([Some(2), None, Some(0), None]);
+
+        assert_arrays_eq!(result, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_null_scalar_list_length() -> VortexResult<()> {
+        let null_scalar = Scalar::null(DType::List(
+            Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
+            Nullability::Nullable,
+        ));
+        let array = ConstantArray::new(null_scalar, 2).into_array();
+        let result = array.apply(&list_length(root()))?;
+
+        let session = VortexSession::empty();
+        let mut ctx = session.create_execution_ctx();
+        assert!(!result.is_valid(0, &mut ctx)?);
+        assert!(!result.is_valid(1, &mut ctx)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_listview_length() -> VortexResult<()> {
+        let elements = create_list_elements();
+        let lv = ListViewArray::new(
+            elements,
+            buffer![5u32, 0, 4, 1].into_array(),
+            buffer![2u32, 3, 0, 2].into_array(),
+            Validity::NonNullable,
+        )
+        .into_array();
+        let result = lv.apply(&list_length(root()))?;
+        assert_arrays_eq!(result, PrimitiveArray::from_iter([2u64, 3, 0, 2]));
+        Ok(())
+    }
+
+    #[test]
+    fn test_listview_length_nullable() -> VortexResult<()> {
+        let elements = create_list_elements();
+        let lv = ListViewArray::new(
+            elements,
+            buffer![5u32, 0, 4, 1].into_array(),
+            buffer![2u32, 3, 0, 2].into_array(),
+            Validity::Array(BoolArray::from_iter([true, false, true, false]).into_array()),
+        )
+        .into_array();
+        let result = lv.apply(&list_length(root()))?;
+
+        let session = VortexSession::empty();
+        let mut ctx = session.create_execution_ctx();
+        let result = result.execute::<PrimitiveArray>(&mut ctx)?;
+
+        let expected = PrimitiveArray::from_option_iter::<u64, _>([Some(2), None, Some(0), None]);
+        assert_arrays_eq!(result, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_list_length_take() -> VortexResult<()> {
+        let elements = create_list_elements();
+        let list = ListArray::try_new(
+            elements,
+            buffer![0u32, 2, 5, 5, 7].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let taken = list.take(buffer![3u64, 0, 2].into_array())?;
+
+        let result = taken.apply(&list_length(root()))?;
+        assert_arrays_eq!(result, PrimitiveArray::from_iter([2u64, 2, 0]));
+        Ok(())
+    }
+
+    #[test]
+    fn test_display() {
+        let expr = list_length(root());
+        assert_eq!(expr.to_string(), "vortex.list.length($)");
+    }
+}

--- a/vortex-array/src/scalar_fn/fns/list_length.rs
+++ b/vortex-array/src/scalar_fn/fns/list_length.rs
@@ -190,7 +190,6 @@ impl Matcher for AnyList {
 mod tests {
     use std::sync::Arc;
 
-    use insta::assert_snapshot;
     use rstest::rstest;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
@@ -378,11 +377,14 @@ mod tests {
         let mut ctx = array_session().create_execution_ctx();
         let result = lengths.execute::<ArrayRef>(&mut ctx);
 
-        assert_snapshot!(
-            result.unwrap_err().to_string(),
-            @"Invalid argument error: Cannot cast array with invalid values to non-nullable type."
+        assert!(result.is_err());
 
+        let err_message = result.unwrap_err().to_string();
+
+        assert!(
+            err_message.contains("Cannot cast array with invalid values to non-nullable type.")
         );
+
         Ok(())
     }
 

--- a/vortex-array/src/scalar_fn/fns/list_length.rs
+++ b/vortex-array/src/scalar_fn/fns/list_length.rs
@@ -10,10 +10,10 @@ use vortex_session::registry::CachedId;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::array::ArrayView;
 use crate::arrays::ConstantArray;
 use crate::arrays::List;
 use crate::arrays::ListView;
-use crate::arrays::ListViewArray;
 use crate::arrays::list::ListArrayExt;
 use crate::arrays::listview::ListViewArrayExt;
 use crate::builtins::ArrayBuiltins;
@@ -21,19 +21,26 @@ use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::expr::Expression;
+use crate::matcher::Matcher;
 use crate::scalar::Scalar;
 use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::ReduceCtx;
+use crate::scalar_fn::ReduceNode;
+use crate::scalar_fn::ReduceNodeRef;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
+use crate::scalar_fn::fns::literal::Literal;
 use crate::scalar_fn::fns::operators::Operator;
 
-/// Number of elements in each list of a `List` typed array.
+/// Number of elements in each list of a `List` or `FixedSizeList` typed array.
 ///
-/// This is computed purely from the list's offsets/sizes (the per-list length), never reading the
-/// element *values*. Validity is carried over from the original array.
+/// This is computed purely from the list's offsets (`ListArray`), sizes (`ListViewArray`), or
+/// dtype (`FixedSizeListArray`) without reading the element *values*. Validity is carried over
+/// from the original array.
 #[derive(Clone)]
 pub struct ListLength;
 
@@ -70,8 +77,10 @@ impl ScalarFnVTable for ListLength {
 
     fn return_dtype(&self, _options: &Self::Options, arg_dtypes: &[DType]) -> VortexResult<DType> {
         match &arg_dtypes[0] {
-            DType::List(_, nullable) => Ok(DType::Primitive(PType::U64, *nullable)),
-            other => vortex_bail!("list_length() requires List, got {other}"),
+            DType::List(_, nullable) | DType::FixedSizeList(_, _, nullable) => {
+                Ok(DType::Primitive(PType::U64, *nullable))
+            }
+            other => vortex_bail!("list_length() requires List or FixedSizeList, got {other}"),
         }
     }
 
@@ -89,10 +98,23 @@ impl ScalarFnVTable for ListLength {
             return Ok(ConstantArray::new(len_scalar, args.row_count()).into_array());
         }
 
-        match input.dtype() {
-            DType::List(..) => list_length(&input, nullability, ctx),
-            other => vortex_bail!("list_length() requires List, got {other}"),
+        list_length(&input, nullability, ctx)
+    }
+
+    fn reduce(
+        &self,
+        _options: &Self::Options,
+        node: &dyn ReduceNode,
+        ctx: &dyn ReduceCtx,
+    ) -> VortexResult<Option<ReduceNodeRef>> {
+        // The length of nonnullable fixed-size list is constant
+        if let DType::FixedSizeList(_, size, Nullability::NonNullable) =
+            node.child(0).node_dtype()?
+        {
+            let length = Scalar::primitive(size as u64, Nullability::NonNullable);
+            return Ok(Some(ctx.new_node(Literal.bind(length), &[])?));
         }
+        Ok(None)
     }
 
     fn validity(
@@ -126,26 +148,33 @@ pub(crate) fn list_length(
     nullability: Nullability,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    // TODO(mk): short-circuit when array is all null
+    let (lengths, validity) = match array.dtype() {
+        // The length of fixed-size list is constant, so just need to carry over validity
+        DType::FixedSizeList(_, size, _) => {
+            let lengths = ConstantArray::new(
+                Scalar::primitive(*size as u64, Nullability::NonNullable),
+                array.len(),
+            )
+            .into_array();
+            (lengths, array.validity()?)
+        }
+        DType::List(..) => {
+            let list = array.clone().execute_until::<AnyList>(ctx)?;
 
-    let (lengths, validity) = if let Some(list) = array.as_opt::<ListView>() {
-        // Length array is exactly size child
-        (list.sizes().clone(), list.listview_validity())
-    } else if let Some(list) = array.as_opt::<List>() {
-        // `length[i] = offsets[i + 1] - offsets[i]`
-        let offsets = list.offsets();
-        let n = offsets.len().saturating_sub(1);
-        let lengths = offsets
-            .slice(1..offsets.len())?
-            .binary(offsets.slice(0..n)?, Operator::Sub)?;
-        (lengths, list.list_validity())
-    } else {
-        // Otherwise execute to `ListViewArray` and take size child
-        let list = array.clone().execute::<ListViewArray>(ctx)?;
-        (list.sizes().clone(), list.listview_validity())
+            if let Some(list) = list.as_opt::<List>() {
+                let lengths = list_length_from_offsets(list)?;
+                (lengths, list.list_validity())
+            } else if let Some(list_view) = list.as_opt::<ListView>() {
+                // Length array is exactly the sizes child
+                (list_view.sizes().clone(), list_view.listview_validity())
+            } else {
+                unreachable!("AnyList matcher guarantees List or ListView")
+            }
+        }
+        other => vortex_bail!("list_length() requires List or FixedSizeList, got {other}"),
     };
 
-    // Cast to the declared `U64` result
+    // Cast to `U64`
     let len = lengths.len();
     let lengths = lengths.cast(DType::Primitive(PType::U64, nullability))?;
 
@@ -154,6 +183,28 @@ pub(crate) fn list_length(
         lengths.mask(validity.to_array(len))
     } else {
         Ok(lengths)
+    }
+}
+
+/// Calculate the lengths of `ListArray` elements via the `offsets` child:
+/// `length[i] = offsets[i + 1] - offsets[i]`.
+fn list_length_from_offsets(list: ArrayView<'_, List>) -> VortexResult<ArrayRef> {
+    let offsets = list.offsets();
+    let n = offsets.len().saturating_sub(1);
+
+    offsets
+        .slice(1..offsets.len())?
+        .binary(offsets.slice(0..n)?, Operator::Sub)
+}
+
+/// Matches an `Array<List>` or `Array<ListView>`.
+struct AnyList;
+
+impl Matcher for AnyList {
+    type Match<'a> = ();
+
+    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
+        (array.as_opt::<List>().is_some() || array.as_opt::<ListView>().is_some()).then_some(())
     }
 }
 
@@ -171,9 +222,12 @@ mod tests {
     use crate::VortexSessionExecute;
     use crate::arrays::BoolArray;
     use crate::arrays::ConstantArray;
+    use crate::arrays::FixedSizeListArray;
     use crate::arrays::ListArray;
     use crate::arrays::ListViewArray;
     use crate::arrays::PrimitiveArray;
+    use crate::arrays::ScalarFn;
+    use crate::arrays::scalar_fn::ScalarFnArrayExt;
     use crate::assert_arrays_eq;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
@@ -181,6 +235,7 @@ mod tests {
     use crate::expr::list_length;
     use crate::expr::root;
     use crate::scalar::Scalar;
+    use crate::scalar_fn::fns::literal::Literal;
     use crate::validity::Validity;
 
     fn create_list_elements() -> ArrayRef {
@@ -296,6 +351,45 @@ mod tests {
 
         let result = taken.apply(&list_length(root()))?;
         assert_arrays_eq!(result, PrimitiveArray::from_iter([2u64, 2, 0]));
+        Ok(())
+    }
+
+    fn create_fixed_size_list(validity: Validity) -> ArrayRef {
+        // 4 lists of size 2 over 8 primitive elements.
+        let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5, 6, 7, 8]).into_array();
+        FixedSizeListArray::new(elements, 2, validity, 4).into_array()
+    }
+
+    #[test]
+    fn test_fixed_size_list_length() -> VortexResult<()> {
+        let fsl = create_fixed_size_list(Validity::NonNullable);
+        let result = fsl.apply(&list_length(root()))?;
+
+        // A non-nullable fixed-size list reduces to a constant literal length, never touching the
+        // `ListLength` execution path.
+        assert!(
+            result
+                .as_opt::<ScalarFn>()
+                .is_some_and(|f| f.scalar_fn().as_opt::<Literal>().is_some()),
+            "list_length over a non-nullable FixedSizeList must reduce to a constant literal"
+        );
+        assert_arrays_eq!(result, PrimitiveArray::from_iter([2u64, 2, 2, 2]));
+        Ok(())
+    }
+
+    #[test]
+    fn test_fixed_size_list_length_nullable() -> VortexResult<()> {
+        let fsl = create_fixed_size_list(Validity::Array(
+            BoolArray::from_iter([true, false, true, false]).into_array(),
+        ));
+        let result = fsl.apply(&list_length(root()))?;
+
+        let session = VortexSession::empty();
+        let mut ctx = session.create_execution_ctx();
+        let result = result.execute::<PrimitiveArray>(&mut ctx)?;
+
+        let expected = PrimitiveArray::from_option_iter::<u64, _>([Some(2), None, Some(2), None]);
+        assert_arrays_eq!(result, expected);
         Ok(())
     }
 

--- a/vortex-array/src/scalar_fn/fns/list_length.rs
+++ b/vortex-array/src/scalar_fn/fns/list_length.rs
@@ -215,11 +215,11 @@ mod tests {
     use rstest::rstest;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
-    use vortex_session::VortexSession;
 
     use crate::ArrayRef;
     use crate::IntoArray;
     use crate::VortexSessionExecute;
+    use crate::array_session;
     use crate::arrays::BoolArray;
     use crate::arrays::ConstantArray;
     use crate::arrays::FixedSizeListArray;
@@ -258,7 +258,8 @@ mod tests {
         let elements = create_list_elements();
         let list = ListArray::try_new(elements, offsets, Validity::NonNullable)?.into_array();
         let result = list.apply(&list_length(root()))?;
-        assert_arrays_eq!(result, PrimitiveArray::from_iter([2u64, 3, 0, 2]));
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, PrimitiveArray::from_iter([2u64, 3, 0, 2]), &mut ctx);
         Ok(())
     }
 
@@ -275,13 +276,12 @@ mod tests {
         .into_array();
         let result = list.apply(&list_length(root()))?;
 
-        let session = VortexSession::empty();
-        let mut ctx = session.create_execution_ctx();
+        let mut ctx = array_session().create_execution_ctx();
         let result = result.execute::<PrimitiveArray>(&mut ctx)?;
 
         let expected = PrimitiveArray::from_option_iter::<u64, _>([Some(2), None, Some(0), None]);
 
-        assert_arrays_eq!(result, expected);
+        assert_arrays_eq!(result, expected, &mut ctx);
 
         Ok(())
     }
@@ -295,8 +295,7 @@ mod tests {
         let array = ConstantArray::new(null_scalar, 2).into_array();
         let result = array.apply(&list_length(root()))?;
 
-        let session = VortexSession::empty();
-        let mut ctx = session.create_execution_ctx();
+        let mut ctx = array_session().create_execution_ctx();
         assert!(!result.is_valid(0, &mut ctx)?);
         assert!(!result.is_valid(1, &mut ctx)?);
         Ok(())
@@ -313,7 +312,8 @@ mod tests {
         )
         .into_array();
         let result = lv.apply(&list_length(root()))?;
-        assert_arrays_eq!(result, PrimitiveArray::from_iter([2u64, 3, 0, 2]));
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, PrimitiveArray::from_iter([2u64, 3, 0, 2]), &mut ctx);
         Ok(())
     }
 
@@ -329,12 +329,11 @@ mod tests {
         .into_array();
         let result = lv.apply(&list_length(root()))?;
 
-        let session = VortexSession::empty();
-        let mut ctx = session.create_execution_ctx();
+        let mut ctx = array_session().create_execution_ctx();
         let result = result.execute::<PrimitiveArray>(&mut ctx)?;
 
         let expected = PrimitiveArray::from_option_iter::<u64, _>([Some(2), None, Some(0), None]);
-        assert_arrays_eq!(result, expected);
+        assert_arrays_eq!(result, expected, &mut ctx);
         Ok(())
     }
 
@@ -350,7 +349,8 @@ mod tests {
         let taken = list.take(buffer![3u64, 0, 2].into_array())?;
 
         let result = taken.apply(&list_length(root()))?;
-        assert_arrays_eq!(result, PrimitiveArray::from_iter([2u64, 2, 0]));
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, PrimitiveArray::from_iter([2u64, 2, 0]), &mut ctx);
         Ok(())
     }
 
@@ -373,7 +373,8 @@ mod tests {
                 .is_some_and(|f| f.scalar_fn().as_opt::<Literal>().is_some()),
             "list_length over a non-nullable FixedSizeList must reduce to a constant literal"
         );
-        assert_arrays_eq!(result, PrimitiveArray::from_iter([2u64, 2, 2, 2]));
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, PrimitiveArray::from_iter([2u64, 2, 2, 2]), &mut ctx);
         Ok(())
     }
 
@@ -384,12 +385,11 @@ mod tests {
         ));
         let result = fsl.apply(&list_length(root()))?;
 
-        let session = VortexSession::empty();
-        let mut ctx = session.create_execution_ctx();
+        let mut ctx = array_session().create_execution_ctx();
         let result = result.execute::<PrimitiveArray>(&mut ctx)?;
 
         let expected = PrimitiveArray::from_option_iter::<u64, _>([Some(2), None, Some(2), None]);
-        assert_arrays_eq!(result, expected);
+        assert_arrays_eq!(result, expected, &mut ctx);
         Ok(())
     }
 

--- a/vortex-array/src/scalar_fn/fns/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/mod.rs
@@ -14,6 +14,7 @@ pub mod is_not_null;
 pub mod is_null;
 pub mod like;
 pub mod list_contains;
+pub mod list_length;
 pub mod literal;
 pub mod mask;
 pub mod merge;

--- a/vortex-array/src/scalar_fn/session.rs
+++ b/vortex-array/src/scalar_fn/session.rs
@@ -20,6 +20,7 @@ use crate::scalar_fn::fns::is_not_null::IsNotNull;
 use crate::scalar_fn::fns::is_null::IsNull;
 use crate::scalar_fn::fns::like::Like;
 use crate::scalar_fn::fns::list_contains::ListContains;
+use crate::scalar_fn::fns::list_length::ListLength;
 use crate::scalar_fn::fns::literal::Literal;
 use crate::scalar_fn::fns::merge::Merge;
 use crate::scalar_fn::fns::not::Not;
@@ -67,6 +68,7 @@ impl Default for ScalarFnSession {
         this.register(IsNull);
         this.register(Like);
         this.register(ListContains);
+        this.register(ListLength);
         this.register(Literal);
         this.register(Merge);
         this.register(Not);


### PR DESCRIPTION
Adds a `list_length` scalar function returning the number of elements in each list of a `List`-like array.

- Computed purely from the list's offsets/sizes — it never reads elements. Different paths for `List`, `ListView`, and `FixedSizeList` arrays. 
- Returns a `U64` array; a null list yields a null length.
- Registered as a built-in (`vortex.list.length`) alongside `list_contains`, and exposed via the `list_length(expr)` expression constructor.