### PR TITLE
Reduce vortex-fastlanes debug symbols size by introducing debug-only path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -419,7 +419,3 @@ incremental = false
 debug = false
 debug-assertions = true
 incremental = false
-
-# This improved build times significantly for default common cases that we use locally
-[profile.dev.package.vortex-fastlanes]
-debug = false

--- a/encodings/fastlanes/src/bitpacking/compute/compare.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/compare.rs
@@ -86,12 +86,12 @@ where
         // In dev builds, using one function-pointer comparator type avoids multiplying that
         // generated code and debug info by every comparison operator.
         let cmp: fn(T, T) -> bool = match operator {
-            CompareOperator::Eq => NativePType::is_eq,
-            CompareOperator::NotEq => NativePType::is_ne,
-            CompareOperator::Lt => NativePType::is_lt,
-            CompareOperator::Lte => NativePType::is_le,
-            CompareOperator::Gt => NativePType::is_gt,
-            CompareOperator::Gte => NativePType::is_ge,
+            CompareOperator::Eq => T::is_eq,
+            CompareOperator::NotEq => T::is_ne,
+            CompareOperator::Lt => T::is_lt,
+            CompareOperator::Lte => T::is_le,
+            CompareOperator::Gt => T::is_gt,
+            CompareOperator::Gte => T::is_ge,
         };
         stream_compare_fused::<T, fn(T, T) -> bool>(lhs, rhs, nullability, cmp, ctx)
     }
@@ -100,22 +100,22 @@ where
     {
         match operator {
             CompareOperator::Eq => {
-                stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_eq(b), ctx)
+                stream_compare_fused::<T, _>(lhs, rhs, nullability, T::is_eq, ctx)
             }
             CompareOperator::NotEq => {
-                stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| !a.is_eq(b), ctx)
+                stream_compare_fused::<T, _>(lhs, rhs, nullability, T::is_ne, ctx)
             }
             CompareOperator::Lt => {
-                stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_lt(b), ctx)
+                stream_compare_fused::<T, _>(lhs, rhs, nullability, T::is_lt, ctx)
             }
             CompareOperator::Lte => {
-                stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_le(b), ctx)
+                stream_compare_fused::<T, _>(lhs, rhs, nullability, T::is_le, ctx)
             }
             CompareOperator::Gt => {
-                stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_gt(b), ctx)
+                stream_compare_fused::<T, _>(lhs, rhs, nullability, T::is_gt, ctx)
             }
             CompareOperator::Gte => {
-                stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_ge(b), ctx)
+                stream_compare_fused::<T, _>(lhs, rhs, nullability, T::is_ge, ctx)
             }
         }
     }

--- a/encodings/fastlanes/src/bitpacking/compute/compare.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/compare.rs
@@ -80,24 +80,43 @@ where
         + FastLanesComparable<Bitpacked = <T as PhysicalPType>::Physical>,
     <T as PhysicalPType>::Physical: BitPacking + NativePType + BitPackingCompare,
 {
-    match operator {
-        CompareOperator::Eq => {
-            stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_eq(b), ctx)
-        }
-        CompareOperator::NotEq => {
-            stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| !a.is_eq(b), ctx)
-        }
-        CompareOperator::Lt => {
-            stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_lt(b), ctx)
-        }
-        CompareOperator::Lte => {
-            stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_le(b), ctx)
-        }
-        CompareOperator::Gt => {
-            stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_gt(b), ctx)
-        }
-        CompareOperator::Gte => {
-            stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_ge(b), ctx)
+    #[cfg(debug_assertions)]
+    {
+        // FastLanes expands `unchecked_unpack_cmp` by width, value type, and comparator type.
+        // In dev builds, using one function-pointer comparator type avoids multiplying that
+        // generated code and debug info by every comparison operator.
+        let cmp: fn(T, T) -> bool = match operator {
+            CompareOperator::Eq => NativePType::is_eq,
+            CompareOperator::NotEq => NativePType::is_ne,
+            CompareOperator::Lt => NativePType::is_lt,
+            CompareOperator::Lte => NativePType::is_le,
+            CompareOperator::Gt => NativePType::is_gt,
+            CompareOperator::Gte => NativePType::is_ge,
+        };
+        stream_compare_fused::<T, fn(T, T) -> bool>(lhs, rhs, nullability, cmp, ctx)
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        match operator {
+            CompareOperator::Eq => {
+                stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_eq(b), ctx)
+            }
+            CompareOperator::NotEq => {
+                stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| !a.is_eq(b), ctx)
+            }
+            CompareOperator::Lt => {
+                stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_lt(b), ctx)
+            }
+            CompareOperator::Lte => {
+                stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_le(b), ctx)
+            }
+            CompareOperator::Gt => {
+                stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_gt(b), ctx)
+            }
+            CompareOperator::Gte => {
+                stream_compare_fused::<T, _>(lhs, rhs, nullability, |a, b| a.is_ge(b), ctx)
+            }
         }
     }
 }

--- a/vortex-array/src/dtype/ptype.rs
+++ b/vortex-array/src/dtype/ptype.rs
@@ -152,6 +152,12 @@ pub trait NativePType:
     /// Whether another instance of this type (`other`) is bitwise equal to `self`
     fn is_eq(self, other: Self) -> bool;
 
+
+    /// Whether another instance of this type (`other`) is bitwise not equal to `self`
+    fn is_ne(self, other: Self) -> bool {
+        !self.is_eq!(other)
+    }
+
     /// Downcast the provided object to a type-specific instance.
     fn downcast<V: PTypeDowncast>(visitor: V) -> V::Output<Self>;
 

--- a/vortex-array/src/dtype/ptype.rs
+++ b/vortex-array/src/dtype/ptype.rs
@@ -152,10 +152,9 @@ pub trait NativePType:
     /// Whether another instance of this type (`other`) is bitwise equal to `self`
     fn is_eq(self, other: Self) -> bool;
 
-
     /// Whether another instance of this type (`other`) is bitwise not equal to `self`
     fn is_ne(self, other: Self) -> bool {
-        !self.is_eq!(other)
+        !self.is_eq(other)
     }
 
     /// Downcast the provided object to a type-specific instance.


### PR DESCRIPTION
## Summary

`vortex-fastlanes` is currently a pretty big crate, due to its underlying structure/generics.

When running `cargo clean; cargo build -p vortex-fastlanes`

Currently on `develop:
- vortex-fastlanes dev build with debug: 229MB rlib 105s
- vortex-fastlanes dev build no debug: 119MB rlib 57s

We currently disable debug symbols for it to improve our development experience, but underlying crates can't enjoy that without explicitly adding the same or similar configuration.

With this branch, the build takes 30s and generates a 60MB rlib, with no performance impact for release builds.

