### PR TITLE
Make sure both pushdown features are always enabled for DF benchmarks

### DIFF
--- a/benchmarks/datafusion-bench/src/lib.rs
+++ b/benchmarks/datafusion-bench/src/lib.rs
@@ -45,10 +45,7 @@ pub fn get_session_context() -> SessionContext {
         .build_arc()
         .expect("could not build runtime environment");
 
-    let factory = VortexFormatFactory::new().with_options(VortexTableOptions {
-        projection_pushdown: true,
-        ..Default::default()
-    });
+    let factory = VortexFormatFactory::new().with_options(vortex_table_options());
 
     let mut session_state_builder = SessionStateBuilder::new()
         .with_config(SessionConfig::from_env().expect("shouldn't fail"))
@@ -114,11 +111,20 @@ pub fn format_to_df_format(format: Format) -> Arc<dyn FileFormat> {
         Format::Csv => Arc::new(CsvFormat::default()) as _,
         Format::Arrow => Arc::new(ArrowFormat),
         Format::Parquet => Arc::new(ParquetFormat::new()),
-        Format::OnDiskVortex | Format::VortexCompact => {
-            Arc::new(VortexFormat::new(SESSION.clone()))
-        }
+        Format::OnDiskVortex | Format::VortexCompact => Arc::new(VortexFormat::new_with_options(
+            SESSION.clone(),
+            vortex_table_options(),
+        )),
         Format::OnDiskDuckDB | Format::Lance => {
             unimplemented!("Format {format} cannot be turned into a DataFusion `FileFormat`")
         }
+    }
+}
+
+fn vortex_table_options() -> VortexTableOptions {
+    VortexTableOptions {
+        projection_pushdown: true,
+        predicate_pushdown: true,
+        ..Default::default()
     }
 }


### PR DESCRIPTION
## Summary

I've realized that there are two code paths for `VortexFormat` in the benchmarks, so just making sure they always have the same config so we can all sleep better at night.