### PR TITLE
ci: install only the uv binary for v4 ingest (drop the workspace sync)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -123,15 +123,15 @@ jobs:
       # the RDS IAM token internally (boto3) from the assumed GitHubBenchmarkIngestRole;
       # sslmode=verify-full validates the cert.
       #
-      # ORDER MATTERS: "Install uv" runs BEFORE "Configure AWS credentials".
-      # configure-aws-credentials persists the assumed ingest-role (rds-db:connect
-      # only) as the job's ambient AWS creds; the uv setup compiles via sccache
-      # (S3-backed), so running it after the role switch fails with S3 AccessDenied.
-      # Installing uv first keeps sccache on the original S3-capable creds; the role
-      # is assumed immediately before the ingest, which needs only rds-db:connect.
+      # `sync: false` -- the ingest runs `uv run --no-project --with`, which needs only
+      # the uv binary, never the synced workspace. A full sync would rebuild
+      # vortex-python via sccache->S3, which fails under the ingest-role creds
+      # (rds-db:connect only) and is pure waste here.
       - name: Install uv for v4 ingest
         if: vars.GH_BENCH_INGEST_ROLE_ARN != ''
         uses: spiraldb/actions/.github/actions/setup-uv@a746510eafaa926484c354541cfc49b2ec06cc63  # 0.18.6
+        with:
+          sync: false
       - name: Configure AWS credentials for v4 ingest (OIDC)
         if: vars.GH_BENCH_INGEST_ROLE_ARN != ''
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6

--- a/.github/workflows/commit-metadata.yml
+++ b/.github/workflows/commit-metadata.yml
@@ -27,15 +27,13 @@ jobs:
       # ingest-role ARN var (the assume-role input that MUST exist for OIDC to
       # succeed).
       #
-      # ORDER MATTERS: "Install uv" runs BEFORE "Configure AWS credentials".
-      # configure-aws-credentials persists the assumed ingest-role (rds-db:connect
-      # only) as the job's ambient AWS creds; the uv setup compiles via sccache
-      # (S3-backed), so running it after the role switch fails with S3 AccessDenied.
-      # Installing uv first keeps sccache on the original S3-capable creds; the role
-      # is assumed immediately before the ingest, which needs only rds-db:connect.
+      # `sync: false` -- the ingest runs `uv run --no-project --with`, which needs only
+      # the uv binary, never the synced workspace (see bench.yml rationale).
       - name: Install uv for v4 ingest
         if: vars.GH_BENCH_INGEST_ROLE_ARN != ''
         uses: spiraldb/actions/.github/actions/setup-uv@a746510eafaa926484c354541cfc49b2ec06cc63  # 0.18.6
+        with:
+          sync: false
       - name: Configure AWS credentials for v4 ingest (OIDC)
         if: vars.GH_BENCH_INGEST_ROLE_ARN != ''
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -714,17 +714,9 @@ jobs:
       # job. Gated on inputs.mode == 'develop' + the ingest-role ARN var (the assume-role
       # input that MUST exist for OIDC to succeed). post-ingest.py mints the RDS IAM token
       # (boto3) from the assumed GitHubBenchmarkIngestRole; sslmode=verify-full validates
-      # the cert.
-      #
-      # ORDER MATTERS: "Install uv" runs BEFORE "Configure AWS credentials".
-      # configure-aws-credentials persists the assumed ingest-role (rds-db:connect
-      # only) as the job's ambient AWS creds; the uv setup compiles via sccache
-      # (S3-backed), so running it after the role switch fails with S3 AccessDenied.
-      # Installing uv first keeps sccache on the original S3-capable creds; the role
-      # is assumed immediately before the ingest, which needs only rds-db:connect.
-      - name: Install uv for v4 ingest
-        if: inputs.mode == 'develop' && vars.GH_BENCH_INGEST_ROLE_ARN != ''
-        uses: spiraldb/actions/.github/actions/setup-uv@a746510eafaa926484c354541cfc49b2ec06cc63  # 0.18.6
+      # the cert. No "Install uv" step here: this job already installed the uv binary
+      # in its "Install uv" step above, and the ingest runs `uv run --no-project --with`,
+      # which needs nothing beyond the binary.
       - name: Configure AWS credentials for v4 ingest (OIDC)
         if: inputs.mode == 'develop' && vars.GH_BENCH_INGEST_ROLE_ARN != ''
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6


### PR DESCRIPTION
## Rationale for this change

The benchmark v4 Postgres ingest only ever calls `uv run --no-project --with ...` — it needs the uv binary, nothing else. Yet its "Install uv" steps do a full `uv sync`, rebuilding `vortex-python` (maturin → sccache → S3) on every benchmark and commit-metadata run. That build is pure waste, and it's fragile: it can only succeed *before* the job assumes the S3-less ingest role, which is why #8516 had to impose an "ORDER MATTERS" step-ordering constraint. Worse, since #8683 made the ingest a required step, any hiccup in this unnecessary build now fails the whole benchmark job and pages incident.io.

## What changes are included in this PR?

Stop syncing the workspace: `sync: false` on the setup-uv steps in `bench.yml` and `commit-metadata.yml`, and drop the step entirely in `sql-benchmarks.yml` (that job already installs uv). The ordering constraint and its comments disappear with the sync.

## What APIs are changed? Are there any user-facing changes?

None — CI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
