### PR TITLE
bench: gate CodSpeed-unstable canonicalization microbenchmarks from simulation

### DIFF
--- a/encodings/alp/benches/alp_compress.rs
+++ b/encodings/alp/benches/alp_compress.rs
@@ -14,11 +14,6 @@ use vortex_alp::ALPRDFloat;
 use vortex_alp::RDEncoder;
 use vortex_alp::alp_encode;
 use vortex_alp::decompress_into_array;
-// Only used by `decompress_rd`, which is excluded from CodSpeed (see below).
-#[cfg(not(codspeed))]
-use vortex_array::Canonical;
-#[cfg(not(codspeed))]
-use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::dtype::NativePType;
@@ -153,16 +148,21 @@ fn compress_rd<T: ALPRDFloat + NativePType>(bencher: Bencher, args: (usize, f64)
         .bench_refs(|(primitive, encoder, ctx)| encoder.encode(primitive.as_view(), ctx))
 }
 
-// Excluded from CodSpeed's CPU simulation: this benchmark canonicalizes the decoded array, so its
-// instruction count is dominated by output-buffer allocation and `memcpy`/`memmove` (whose glibc
-// `ifunc`-selected implementation differs across runner images) rather than by the ALP-RD decode
-// itself. Under simulation it produces only false-positive regressions (it moved in 7 of the last
-// 9 PRs, bidirectionally, ranging 842-1025 us for the same code, while CodSpeed flagged "different
-// runtime environments"). Per `docs/developer-guide/benchmarking.md`, CodSpeed-incompatible
-// benchmarks are gated with `#[cfg(not(codspeed))]`; it remains available via local `cargo bench`.
+// Excluded from CodSpeed's CPU simulation. This benchmark canonicalizes the decoded array, so its
+// simulated instruction count is dominated by output-buffer allocation and glibc `memcpy`/`memmove`
+// (whose `ifunc`-selected implementation varies across runner images) rather than by the ALP-RD
+// decode itself. That makes it report spurious, bidirectional regressions under simulation even when
+// the Vortex code is byte-identical, and it cannot be stabilized by tuning inputs because the data
+// movement is the thing being measured. The compute-bound `compress_rd` encode benchmark above does
+// not have this problem and is kept. Per `docs/developer-guide/benchmarking.md` such benchmarks are
+// gated with `#[cfg(not(codspeed))]`; it remains available via local `cargo bench`. See
+// https://github.com/vortex-data/vortex/pull/8519 for the supporting analysis.
 #[cfg(not(codspeed))]
 #[divan::bench(types = [f32, f64], args = RD_BENCH_ARGS)]
 fn decompress_rd<T: ALPRDFloat + NativePType>(bencher: Bencher, args: (usize, f64)) {
+    use vortex_array::Canonical;
+    use vortex_array::IntoArray;
+
     let (n, fraction_patch) = args;
     let primitive = make_rd_array::<T>(n, fraction_patch);
     let encoder = RDEncoder::new(primitive.as_slice::<T>());

--- a/encodings/alp/benches/alp_compress.rs
+++ b/encodings/alp/benches/alp_compress.rs
@@ -14,7 +14,10 @@ use vortex_alp::ALPRDFloat;
 use vortex_alp::RDEncoder;
 use vortex_alp::alp_encode;
 use vortex_alp::decompress_into_array;
+// Only used by `decompress_rd`, which is excluded from CodSpeed (see below).
+#[cfg(not(codspeed))]
 use vortex_array::Canonical;
+#[cfg(not(codspeed))]
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
@@ -150,6 +153,14 @@ fn compress_rd<T: ALPRDFloat + NativePType>(bencher: Bencher, args: (usize, f64)
         .bench_refs(|(primitive, encoder, ctx)| encoder.encode(primitive.as_view(), ctx))
 }
 
+// Excluded from CodSpeed's CPU simulation: this benchmark canonicalizes the decoded array, so its
+// instruction count is dominated by output-buffer allocation and `memcpy`/`memmove` (whose glibc
+// `ifunc`-selected implementation differs across runner images) rather than by the ALP-RD decode
+// itself. Under simulation it produces only false-positive regressions (it moved in 7 of the last
+// 9 PRs, bidirectionally, ranging 842-1025 us for the same code, while CodSpeed flagged "different
+// runtime environments"). Per `docs/developer-guide/benchmarking.md`, CodSpeed-incompatible
+// benchmarks are gated with `#[cfg(not(codspeed))]`; it remains available via local `cargo bench`.
+#[cfg(not(codspeed))]
 #[divan::bench(types = [f32, f64], args = RD_BENCH_ARGS)]
 fn decompress_rd<T: ALPRDFloat + NativePType>(bencher: Bencher, args: (usize, f64)) {
     let (n, fraction_patch) = args;

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -70,6 +70,14 @@ fn take_10_contiguous(bencher: Bencher) {
         })
 }
 
+// The four `*take_10k_{random,contiguous,...}` benches below are excluded from CodSpeed's CPU
+// simulation. Each gathers 10k elements and canonicalizes the result, so its instruction count is
+// bimodal under simulation (~195 us vs ~255 us, ±23% for unchanged code) due to output-buffer
+// allocation + `memcpy` and the SIMD bit-unpack's code-layout sensitivity across runner images
+// ("different runtime environments"). They fired in 4+ recent unrelated PRs and on this PR itself.
+// Per `docs/developer-guide/benchmarking.md` they are gated with `#[cfg(not(codspeed))]` and remain
+// available via local `cargo bench`. The other take variants here have not shown this and are kept.
+#[cfg(not(codspeed))]
 #[divan::bench]
 fn take_10k_random(bencher: Bencher) {
     let values = fixture(65_536, 8);
@@ -92,6 +100,8 @@ fn take_10k_random(bencher: Bencher) {
         })
 }
 
+// Excluded from CodSpeed: bimodal 10k take+canonicalize (see note above).
+#[cfg(not(codspeed))]
 #[divan::bench]
 fn take_10k_contiguous(bencher: Bencher) {
     let values = fixture(65_536, 8);
@@ -221,6 +231,8 @@ fn patched_take_10_contiguous(bencher: Bencher) {
         })
 }
 
+// Excluded from CodSpeed: bimodal 10k take+canonicalize (see note above).
+#[cfg(not(codspeed))]
 #[divan::bench]
 fn patched_take_10k_random(bencher: Bencher) {
     let values = (0u32..BIG_BASE2 + NUM_EXCEPTIONS).collect::<Buffer<u32>>();
@@ -262,6 +274,8 @@ fn patched_take_10k_contiguous_not_patches(bencher: Bencher) {
         })
 }
 
+// Excluded from CodSpeed: bimodal 10k take+canonicalize (see note above).
+#[cfg(not(codspeed))]
 #[divan::bench]
 fn patched_take_10k_contiguous_patches(bencher: Bencher) {
     let values = (0u32..BIG_BASE2 + NUM_EXCEPTIONS).collect::<Buffer<u32>>();

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -70,13 +70,16 @@ fn take_10_contiguous(bencher: Bencher) {
         })
 }
 
-// The four `*take_10k_{random,contiguous,...}` benches below are excluded from CodSpeed's CPU
-// simulation. Each gathers 10k elements and canonicalizes the result, so its instruction count is
-// bimodal under simulation (~195 us vs ~255 us, ±23% for unchanged code) due to output-buffer
-// allocation + `memcpy` and the SIMD bit-unpack's code-layout sensitivity across runner images
-// ("different runtime environments"). They fired in 4+ recent unrelated PRs and on this PR itself.
-// Per `docs/developer-guide/benchmarking.md` they are gated with `#[cfg(not(codspeed))]` and remain
-// available via local `cargo bench`. The other take variants here have not shown this and are kept.
+// The four `*take_10k_*` benches below are excluded from CodSpeed's CPU simulation. Each gathers 10k
+// elements and canonicalizes the result, so its simulated instruction count is bimodal: it is driven
+// by output-buffer allocation plus glibc `memcpy` and by the SIMD bit-unpack's code-layout
+// sensitivity across runner images, rather than by stable Vortex compute. That makes them report
+// spurious, bidirectional regressions under simulation even when the code is unchanged, and they
+// cannot be stabilized by tuning inputs because the data movement is the thing being measured. The
+// smaller take variants here are compute-bound and stable, so they are kept. Per
+// `docs/developer-guide/benchmarking.md` such benchmarks are gated with `#[cfg(not(codspeed))]` and
+// remain available via local `cargo bench`. See https://github.com/vortex-data/vortex/pull/8519 for
+// the supporting analysis.
 #[cfg(not(codspeed))]
 #[divan::bench]
 fn take_10k_random(bencher: Bencher) {

--- a/vortex-array/benches/chunk_array_builder.rs
+++ b/vortex-array/benches/chunk_array_builder.rs
@@ -14,9 +14,13 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::ConstantArray;
+// Both traits/builders below are only used by benches excluded from CodSpeed (see below).
+#[cfg(not(codspeed))]
 use vortex_array::builders::ArrayBuilder;
+#[cfg(not(codspeed))]
 use vortex_array::builders::VarBinViewBuilder;
 use vortex_array::builders::builder_with_capacity;
+#[cfg(not(codspeed))]
 use vortex_array::dtype::DType;
 use vortex_error::VortexExpect;
 use vortex_session::VortexSession;
@@ -34,6 +38,18 @@ const BENCH_ARGS: &[(usize, usize)] = &[
 
 static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
+// The following canonicalization benchmarks are excluded from CodSpeed's CPU simulation. Their
+// instruction count is dominated by output-buffer allocation and `memcpy`/`memmove` (whose
+// glibc `ifunc`-selected implementation differs across runner images) rather than by Vortex
+// compute, so under simulation they only ever report false-positive regressions: each moved in a
+// majority of recent PRs (bidirectionally, e.g. `chunked_bool_canonical_into` swung 16-35 us, a
+// ~2x range, for unchanged code) and CodSpeed flagged "different runtime environments" on the
+// comparisons. `chunked_bool_canonical_into` is additionally below the simulation noise floor
+// (~16-35 us). Per `docs/developer-guide/benchmarking.md`, CodSpeed-incompatible benchmarks are
+// gated with `#[cfg(not(codspeed))]`; they remain available via local `cargo bench`. The
+// `chunked_opt_bool_*` and `chunked_constant_*` benches below are compute-bound and stable under
+// simulation, so they are kept.
+#[cfg(not(codspeed))]
 #[divan::bench(args = BENCH_ARGS)]
 fn chunked_bool_canonical_into(bencher: Bencher, (len, chunk_count): (usize, usize)) {
     let chunk = make_bool_chunks(len, chunk_count);
@@ -73,6 +89,8 @@ fn chunked_opt_bool_into_canonical(bencher: Bencher, (len, chunk_count): (usize,
         .bench_refs(|(chunk, ctx)| (**chunk).clone().execute::<Canonical>(ctx))
 }
 
+// Excluded from CodSpeed: VarBinView canonicalization is `memcpy`-bound (see note above).
+#[cfg(not(codspeed))]
 #[divan::bench(args = BENCH_ARGS)]
 fn chunked_varbinview_canonical_into(bencher: Bencher, (len, chunk_count): (usize, usize)) {
     let chunks = make_string_chunks(false, len, chunk_count);
@@ -91,6 +109,8 @@ fn chunked_varbinview_canonical_into(bencher: Bencher, (len, chunk_count): (usiz
         })
 }
 
+// Excluded from CodSpeed: VarBinView canonicalization is `memcpy`-bound (see note above).
+#[cfg(not(codspeed))]
 #[divan::bench(args = BENCH_ARGS)]
 fn chunked_varbinview_into_canonical(bencher: Bencher, (len, chunk_count): (usize, usize)) {
     let chunks = make_string_chunks(false, len, chunk_count);
@@ -100,6 +120,8 @@ fn chunked_varbinview_into_canonical(bencher: Bencher, (len, chunk_count): (usiz
         .bench_refs(|(chunk, ctx)| (**chunk).clone().execute::<Canonical>(ctx))
 }
 
+// Excluded from CodSpeed: VarBinView canonicalization is `memcpy`-bound (see note above).
+#[cfg(not(codspeed))]
 #[divan::bench(args = BENCH_ARGS)]
 fn chunked_varbinview_opt_canonical_into(bencher: Bencher, (len, chunk_count): (usize, usize)) {
     let chunks = make_string_chunks(true, len, chunk_count);
@@ -118,6 +140,8 @@ fn chunked_varbinview_opt_canonical_into(bencher: Bencher, (len, chunk_count): (
         })
 }
 
+// Excluded from CodSpeed: VarBinView canonicalization is `memcpy`-bound (see note above).
+#[cfg(not(codspeed))]
 #[divan::bench(args = BENCH_ARGS)]
 fn chunked_varbinview_opt_into_canonical(bencher: Bencher, (len, chunk_count): (usize, usize)) {
     let chunks = make_string_chunks(true, len, chunk_count);
@@ -211,6 +235,7 @@ fn make_opt_bool_chunks(len: usize, chunk_count: usize) -> ArrayRef {
         .into_array()
 }
 
+#[cfg(not(codspeed))]
 fn make_bool_chunks(len: usize, chunk_count: usize) -> ArrayRef {
     let mut rng = StdRng::seed_from_u64(0);
 
@@ -220,6 +245,7 @@ fn make_bool_chunks(len: usize, chunk_count: usize) -> ArrayRef {
         .into_array()
 }
 
+#[cfg(not(codspeed))]
 fn make_string_chunks(nullable: bool, len: usize, chunk_count: usize) -> ArrayRef {
     let mut rng = StdRng::seed_from_u64(123);
 

--- a/vortex-array/benches/chunk_array_builder.rs
+++ b/vortex-array/benches/chunk_array_builder.rs
@@ -14,7 +14,9 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::ConstantArray;
-// Both traits/builders below are only used by benches excluded from CodSpeed (see below).
+// `ArrayBuilder`, `VarBinViewBuilder`, and `DType` are used only by the VarBinView canonicalization
+// benches and their helpers, all of which are excluded from CodSpeed (see the gating note below), so
+// they are gated to match and avoid unused-import errors under `--cfg codspeed`.
 #[cfg(not(codspeed))]
 use vortex_array::builders::ArrayBuilder;
 #[cfg(not(codspeed))]
@@ -38,17 +40,16 @@ const BENCH_ARGS: &[(usize, usize)] = &[
 
 static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
 
-// The following canonicalization benchmarks are excluded from CodSpeed's CPU simulation. Their
-// instruction count is dominated by output-buffer allocation and `memcpy`/`memmove` (whose
-// glibc `ifunc`-selected implementation differs across runner images) rather than by Vortex
-// compute, so under simulation they only ever report false-positive regressions: each moved in a
-// majority of recent PRs (bidirectionally, e.g. `chunked_bool_canonical_into` swung 16-35 us, a
-// ~2x range, for unchanged code) and CodSpeed flagged "different runtime environments" on the
-// comparisons. `chunked_bool_canonical_into` is additionally below the simulation noise floor
-// (~16-35 us). Per `docs/developer-guide/benchmarking.md`, CodSpeed-incompatible benchmarks are
-// gated with `#[cfg(not(codspeed))]`; they remain available via local `cargo bench`. The
-// `chunked_opt_bool_*` and `chunked_constant_*` benches below are compute-bound and stable under
-// simulation, so they are kept.
+// The canonicalization benchmarks gated below are excluded from CodSpeed's CPU simulation. Their
+// simulated instruction count is dominated by output-buffer allocation and glibc `memcpy`/`memmove`
+// (whose `ifunc`-selected implementation varies across runner images) rather than by Vortex compute,
+// so under simulation they report spurious, bidirectional regressions even when the code is
+// unchanged. `chunked_bool_canonical_into` is additionally small enough to sit near the simulation
+// noise floor. They cannot be stabilized by tuning inputs because the data movement is the thing
+// being measured. The `chunked_opt_bool_*` and `chunked_constant_*` benches below are compute-bound
+// and stable under simulation, so they are kept. Per `docs/developer-guide/benchmarking.md` such
+// benchmarks are gated with `#[cfg(not(codspeed))]` and remain available via local `cargo bench`.
+// See https://github.com/vortex-data/vortex/pull/8519 for the supporting analysis.
 #[cfg(not(codspeed))]
 #[divan::bench(args = BENCH_ARGS)]
 fn chunked_bool_canonical_into(bencher: Bencher, (len, chunk_count): (usize, usize)) {
@@ -235,6 +236,8 @@ fn make_opt_bool_chunks(len: usize, chunk_count: usize) -> ArrayRef {
         .into_array()
 }
 
+// Only used by `chunked_bool_canonical_into`, which is excluded from CodSpeed (see above), so this
+// helper is gated to match and avoid dead-code errors under `--cfg codspeed`.
 #[cfg(not(codspeed))]
 fn make_bool_chunks(len: usize, chunk_count: usize) -> ArrayRef {
     let mut rng = StdRng::seed_from_u64(0);
@@ -245,6 +248,8 @@ fn make_bool_chunks(len: usize, chunk_count: usize) -> ArrayRef {
         .into_array()
 }
 
+// Only used by the gated VarBinView canonicalization benches above, which are excluded from
+// CodSpeed, so this helper is gated to match and avoid dead-code errors under `--cfg codspeed`.
 #[cfg(not(codspeed))]
 fn make_string_chunks(nullable: bool, len: usize, chunk_count: usize) -> ArrayRef {
     let mut rng = StdRng::seed_from_u64(123);


### PR DESCRIPTION
## Summary

A small, recurring set of CodSpeed **Simulation** microbenchmarks report **false-positive regressions in nearly every PR**, regardless of what the PR changes. This PR gates the provably-unfixable offenders out of CodSpeed simulation (keeping them runnable via local `cargo bench`), and documents the rest with a keep/remove decision for each.

> [!NOTE]
> Draft for discussion. The analysis below justifies every benchmark I touched and explains the ones I deliberately left alone.

## How I found them

I read CodSpeed's bot comment on **9 recent PRs** spanning unrelated areas (scalar ops, SIMD take, GPU/CUDA, session refactors, stats rules, random-access splitting, etc.): #8345, #8454, #8470, #8478, #8483, #8489, #8496, #8500, #8505, #8511.

A benchmark that shows a large change in a PR that **doesn't touch its code** is, by definition, noise. The tell is when the *same unchanged code* reports very different numbers depending only on which commit it was built against. Every one of these comparisons also carried CodSpeed's own ⚠️ **"Different runtime environments detected"** warning — and this PR itself reproduced it (see *Self-validation* below).

### The flaky set (each row = identical code, different measured value)

| Benchmark | File | Observed range (unchanged code) | PRs | Verdict |
|---|---|---|---|---|
| `decompress_rd[*]` | `encodings/alp/benches/alp_compress.rs` | `f64,(100k)` **842 ↔ 1025 µs**; `(10k)` **108 ↔ 139 µs** | 7/9 | **Gate** |
| `chunked_varbinview_*` (×4) | `vortex-array/benches/chunk_array_builder.rs` | `(1000,10)` 161 ↔ 198; `(100,100)` 223 ↔ 308 µs | 6/9 | **Gate** |
| `chunked_bool_canonical_into` | `vortex-array/benches/chunk_array_builder.rs` | **16 ↔ 35 µs (~2×)** | 4/9 | **Gate** |
| `take_10k_*`, `patched_take_10k_*` (the 4 flaky ones) | `encodings/fastlanes/benches/bitpacking_take.rs` | bimodal **195 ↔ 255 µs** | 4/9 + this PR | **Gate** |
| `baseline_eq/lt[*]` | `encodings/fastlanes/benches/bitpack_compare.rs` | 243 ↔ 185, 303 ↔ 245 µs | this PR | Keep (this PR) |
| `varbinview_large` | `vortex-array/benches/listview_rebuild.rs` | 112 ↔ 131 µs | 3/9 | Keep (this PR) |
| `bitwise_not_vortex_buffer_mut[128]` | `vortex-buffer/benches/vortex_bitbuffer.rs` | **186 ↔ 244 ns** | 2/9 | Keep (this PR) |
| `sum_i32_nullable_all_valid`, `chunked_dict_*`, `encode_varbin*`, `null_count_run_end` | various | ±34–95% | 2/9, **only vs base `679e2c5`** | Keep (lower confidence) |

## Root cause

CodSpeed Simulation estimates CPU cycles from an instruction trace (Cachegrind-style). That trace is deterministic **for a fixed binary in a fixed environment**, but it includes instructions executed inside **glibc** — and `memcpy`/`memmove`/`memset` are resolved at runtime via **`ifunc`** to a SIMD variant chosen by the runner's CPU/glibc. When the develop baseline and the PR run on different runner images (which CodSpeed explicitly flags here as *"different runtime environments"*), any benchmark whose hot path is **heap allocation + byte copying** (or a tight SIMD loop sensitive to code layout) changes instruction count even though the Vortex code is byte-identical. See CodSpeed's own write-up, ["Why glibc is faster on some GitHub Actions Runners"](https://codspeed.io/blog/unrelated-benchmark-regression).

This predicts *exactly* which benchmarks flake, and the data confirms it:

- **`decompress_rd` flakes; `compress_rd` never does.** Decode materializes a fresh canonical output buffer (alloc + tight SIMD/`memcpy`); encode is compute-bound (sampling, dictionary build). Same file, same data — only the copy-bound one is noisy.
- **`chunked_varbinview_*` flakes** — canonicalizing chunked strings *is* concatenating variable-length bytes into one buffer (`memcpy`-dominated).
- **`chunked_bool_canonical_into` flakes hardest in relative terms** — it's also just **too small** (~16–35 µs).
- **`take_10k_*` is bimodal** — 10k gather + canonicalize: output alloc/`memcpy` plus the SIMD bit-unpack's code-layout sensitivity.

The data movement *is* the thing being measured, so these cannot be made stable under Simulation by tweaking inputs. `docs/developer-guide/benchmarking.md` already prescribes the remedy: *"Use `#[cfg(not(codspeed))]` for benchmarks that are incompatible with CodSpeed."*

## Changes (every gated benchmark justified)

All gated benches stay fully available via local `cargo bench` — only CodSpeed CI stops tracking them.

**`encodings/alp/benches/alp_compress.rs`**
- **`decompress_rd` → gated.** The #1 offender: moved in 7/9 sampled PRs, bidirectionally, 842↔1025 µs for identical code. Decodes to a canonical array → output-buffer alloc + `memcpy`-dominated. `compress_rd` (encode, compute-bound, never flagged) is **kept**.

**`vortex-array/benches/chunk_array_builder.rs`**
- **`chunked_varbinview_{canonical_into,into_canonical,opt_canonical_into,opt_into_canonical}` → gated.** All four flake across 6/9 PRs; all are `memcpy`-bound string canonicalization.
- **`chunked_bool_canonical_into` → gated.** Worst relative swings (~2×, 16↔35 µs) and below the Simulation noise floor.
- **Kept:** `chunked_opt_bool_*`, `chunked_constant_*` — compute-bound, never flagged.

**`encodings/fastlanes/benches/bitpacking_take.rs`**
- **`take_10k_random`, `take_10k_contiguous`, `patched_take_10k_random`, `patched_take_10k_contiguous_patches` → gated.** Bimodal ~195↔255 µs (±23%); fired in 4/9 sampled PRs and again on this PR. The other take variants in the file have not shown this instability and are **kept** (they remain useful for the sparse/bitpacked-take threshold tuning the in-file comment describes).

## Self-validation (this PR's own CodSpeed run)

The first push proved the thesis on itself: CodSpeed reported **"will not alter performance"**, correctly marked the gated benches as **skipped**, and the *only* flagged moves were pre-existing flaky benches in files this PR never touched — `take_10k_*` (±20–23%), `baseline_eq/lt` (±23–31%), `varbinview_large` (±17%). The `take_10k` gating in this PR was added in response to that run; the others are documented below.

## Deliberately *kept* (flaky ≠ delete)

- **`bitpack_compare.rs` `baseline_eq/lt[*]`** and **`listview_rebuild.rs` `varbinview_large`** — same cross-environment root cause, surfaced on this PR. Left for a focused follow-up to keep this PR's scope contained; `varbinview_large` was only seen against a couple of bases.
- **`bitwise_not_vortex_buffer_mut[128]`** — sub-µs noise, but its `INPUT_SIZE` is shared by ~25 valid `vortex`-vs-`arrow` comparison benches; not worth restructuring for a ±30 ns wobble.
- **CUDA walltime benches** (e.g. `cuda/bitpacked_u8/unpack/3bw[100M]`) — these use the **WallTime** instrument on non-macro GPU runners (you can't simulate a GPU); a separate, intentional trade-off and out of scope.

## Verification

Run locally with the pinned nightly + `cargo-codspeed`, valgrind present, for all three suites:

- ✅ `cargo codspeed build` (Simulation) succeeds for `vortex-alp`, `vortex-array` (`--features _test-harness`), and `vortex-fastlanes` — no warnings, no orphaned imports/dead code.
- ✅ `cargo codspeed run` (**Measurement mode: Simulation**) executes the suites to completion — gated benches absent at runtime; the kept benches (`compress_rd`, `chunked_opt_bool_*`, `chunked_constant_*`, the other take variants) still measure.
- ✅ Binary symbol check confirms the gated benches are compiled out under `--cfg codspeed` and present without it.
- ✅ Local `cargo bench` build path, `cargo +nightly fmt --check`, and `cargo clippy --no-deps` on all changed bench targets are clean. (Full-workspace `clippy` hits an unrelated pre-existing lint in `vortex-buffer` under this environment's toolchain; not touched here.)

## Follow-ups for maintainers

1. **Archive the gated benches on CodSpeed** so they drop off the dashboard instead of showing as "skipped".
2. The broader class (canonicalization/builder/decode-to-canonical/copy-bound) shares this root cause. The durable fix is **infrastructure-level**: ensure the develop baseline and PR runs use the same pinned runner image (so "different runtime environments" stops firing), or move these to **CodSpeed walltime/macro runners**. If that lands, several "kept" benches above could return to Simulation.
