### PR TITLE
Expanding conceptual docs (and some other minor docs)

### DIFF
--- a/encodings/fastlanes/Cargo.toml
+++ b/encodings/fastlanes/Cargo.toml
@@ -13,6 +13,9 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lints]
 workspace = true
 

--- a/encodings/fastlanes/src/lib.rs
+++ b/encodings/fastlanes/src/lib.rs
@@ -20,6 +20,11 @@
 //! let session = vortex_array::array_session();
 //! vortex_fastlanes::initialize(&session);
 //! ```
+//!
+//! ## Paper
+//!
+//! The original encodings are described in the paper [The FastLanes Compression Layout](https://15721.courses.cs.cmu.edu/spring2024/papers/03-data2/p2132-afroozeh.pdf),
+//! but are not fully binary compatible. See the underlying [fastlanes](https://github.com/spiraldb/fastlanes) crate for more details.
 
 pub use bitpacking::*;
 pub use delta::*;

--- a/encodings/fastlanes/src/lib.rs
+++ b/encodings/fastlanes/src/lib.rs
@@ -3,6 +3,24 @@
 
 #![expect(clippy::cast_possible_truncation)]
 
+//! FastLanes integer encodings for Vortex arrays.
+//!
+//! This crate provides SIMD-friendly integer encodings:
+//!
+//! - [`BitPacked`] stores fixed-width integer values using the minimum bit width plus optional
+//!   patches.
+//! - [`FoR`] stores frame-of-reference deltas from a base value.
+//! - [`Delta`] stores adjacent deltas in chunked form.
+//! - [`RLE`] stores repeated runs.
+//!
+//! Call [`initialize`] to register the encodings and encoding-specific aggregate kernels in a
+//! session before deserializing or executing arrays that may contain these encodings.
+//!
+//! ```rust
+//! let session = vortex_array::array_session();
+//! vortex_fastlanes::initialize(&session);
+//! ```
+
 pub use bitpacking::*;
 pub use delta::*;
 pub use r#for::*;

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -282,6 +282,7 @@ pub(crate) fn vortex_err_from_pco(err: PcoError) -> VortexError {
 }
 
 #[derive(Clone, Debug)]
+/// Pco array encoding marker.
 pub struct Pco;
 
 impl Pco {
@@ -317,6 +318,7 @@ pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["validity"];
 
 #[derive(Clone, Debug)]
+/// Encoding-specific data for a [`PcoArray`].
 pub struct PcoData {
     pub(crate) chunk_metas: Vec<ByteBuffer>,
     pub(crate) pages: Vec<ByteBuffer>,
@@ -338,6 +340,7 @@ impl Display for PcoData {
 }
 
 impl PcoData {
+    /// Validate dtype, validity, slice, and Pco component invariants.
     pub fn validate(&self, dtype: &DType, len: usize, validity: &Validity) -> VortexResult<()> {
         let _ = number_type_from_ptype(self.ptype);
         vortex_ensure!(
@@ -391,6 +394,7 @@ impl PcoData {
         Ok(())
     }
 
+    /// Construct unsliced Pco data from chunk metadata, pages, and serialized metadata.
     pub fn new(
         chunk_metas: Vec<ByteBuffer>,
         pages: Vec<ByteBuffer>,
@@ -409,6 +413,7 @@ impl PcoData {
         }
     }
 
+    /// Compress a primitive array into Pco data.
     pub fn from_primitive(
         parray: ArrayView<'_, Primitive>,
         level: usize,
@@ -497,6 +502,11 @@ impl PcoData {
         ))
     }
 
+    /// Downcast and compress an array into Pco data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the input is not a primitive array or compression fails.
     pub fn from_array(
         array: ArrayRef,
         level: usize,
@@ -512,6 +522,7 @@ impl PcoData {
         Self::from_primitive(parray.as_view(), level, nums_per_page, ctx)
     }
 
+    /// Decompress this Pco data into a primitive array.
     pub fn decompress(
         &self,
         unsliced_validity: &Validity,

--- a/encodings/pco/src/lib.rs
+++ b/encodings/pco/src/lib.rs
@@ -1,6 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+//! Pco-backed numeric compression encoding for Vortex arrays.
+//!
+//! [`PcoArray`] stores valid primitive numeric values in Pco chunks and pages, while Vortex
+//! validity tracks null rows separately. Page metadata lets slices decompress only the components
+//! required for the requested row range.
+//!
+//! Pco supports integer and floating-point primitive dtypes handled by the upstream `pco` crate.
+//! It is normally selected through the BtrBlocks compressor when the `pco` feature is enabled.
+//! To deserialize arrays manually, register the encoding in the array session:
+//!
+//! ```rust
+//! use vortex_array::session::ArraySessionExt;
+//!
+//! let session = vortex_array::array_session();
+//! session.arrays().register(vortex_pco::Pco);
+//! ```
+
 mod array;
 mod compute;
 mod rules;
@@ -9,9 +26,11 @@ mod slice;
 pub use array::*;
 
 #[derive(Clone, prost::Message)]
+/// Metadata for one Pco page.
 pub struct PcoPageInfo {
     // Since pco limits to 2^24 values per chunk, u32 is sufficient for the
     // count of values.
+    /// Number of valid primitive values stored in this page.
     #[prost(uint32, tag = "1")]
     pub n_values: u32,
 }
@@ -19,17 +38,22 @@ pub struct PcoPageInfo {
 // We're calling this Info instead of Metadata because ChunkMeta refers to a specific
 // component of a Pco file.
 #[derive(Clone, prost::Message)]
+/// Metadata for one Pco chunk.
 pub struct PcoChunkInfo {
+    /// Pages contained in this chunk.
     #[prost(message, repeated, tag = "1")]
     pub pages: Vec<PcoPageInfo>,
 }
 
 #[derive(Clone, prost::Message)]
+/// Serialized metadata for a [`PcoArray`].
 pub struct PcoMetadata {
     // would be nice to reuse one header per vortex file, but it's really only 1 byte, so
     // no issue duplicating it here per PcoArray
+    /// Pco file header bytes.
     #[prost(bytes, tag = "1")]
     pub header: Vec<u8>,
+    /// Metadata for each compressed chunk.
     #[prost(message, repeated, tag = "2")]
     pub chunks: Vec<PcoChunkInfo>,
 }

--- a/encodings/zstd/Cargo.toml
+++ b/encodings/zstd/Cargo.toml
@@ -13,6 +13,9 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
+[package.metadata.docs.rs]
+all-features = true
+
 [lints]
 workspace = true
 

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -252,9 +252,11 @@ impl VTable for Zstd {
 }
 
 #[derive(Clone, Debug)]
+/// Zstd array encoding marker.
 pub struct Zstd;
 
 impl Zstd {
+    /// Construct a [`ZstdArray`] from validated compressed data and validity.
     pub fn try_new(dtype: DType, data: ZstdData, validity: Validity) -> VortexResult<ZstdArray> {
         let len = data.len();
         data.validate(&dtype, len, &validity)?;
@@ -309,6 +311,7 @@ impl Zstd {
         )
     }
 
+    /// Decompress a [`ZstdArray`] into its canonical Vortex representation.
     pub fn decompress(array: &ZstdArray, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
         let unsliced_validity = child_to_validity(
             array.as_ref().slots()[0].as_ref(),
@@ -325,6 +328,7 @@ pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["validity"];
 
 #[derive(Clone, Debug)]
+/// Encoding-specific data for a [`ZstdArray`].
 pub struct ZstdData {
     pub(crate) dictionary: Option<ByteBuffer>,
     pub(crate) frames: Vec<ByteBuffer>,
@@ -344,13 +348,21 @@ impl Display for ZstdData {
     }
 }
 
+/// Movable parts of a [`ZstdData`] value plus its validity.
 pub struct ZstdDataParts {
+    /// Optional zstd dictionary shared by all frames.
     pub dictionary: Option<ByteBuffer>,
+    /// Compressed zstd frames.
     pub frames: Vec<ByteBuffer>,
+    /// Serialized frame and dictionary metadata.
     pub metadata: ZstdMetadata,
+    /// Unsliced validity for the array.
     pub validity: Validity,
+    /// Unsliced row count.
     pub n_rows: usize,
+    /// Start of this logical slice in unsliced row coordinates.
     pub slice_start: usize,
+    /// End of this logical slice in unsliced row coordinates.
     pub slice_stop: usize,
 }
 
@@ -466,6 +478,7 @@ pub fn reconstruct_views(
 }
 
 impl ZstdData {
+    /// Construct unsliced zstd data from raw frames and metadata.
     pub fn new(
         dictionary: Option<ByteBuffer>,
         frames: Vec<ByteBuffer>,
@@ -482,6 +495,7 @@ impl ZstdData {
         }
     }
 
+    /// Validate dtype, slice, validity, frame, and dictionary invariants.
     pub fn validate(&self, dtype: &DType, len: usize, validity: &Validity) -> VortexResult<()> {
         vortex_ensure!(
             matches!(
@@ -796,6 +810,9 @@ impl ZstdData {
         Ok(ZstdData::new(dictionary, frames, metadata, vbv.len()))
     }
 
+    /// Compress a supported canonical array into zstd data.
+    ///
+    /// Returns `Ok(None)` for canonical variants that this encoding does not support.
     pub fn from_canonical(
         canonical: &Canonical,
         level: i32,
@@ -819,6 +836,11 @@ impl ZstdData {
         }
     }
 
+    /// Canonicalize and compress an array into zstd data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the array's canonical form is unsupported or compression fails.
     pub fn from_array(
         array: ArrayRef,
         level: i32,
@@ -1019,6 +1041,7 @@ impl ZstdData {
         self.slice_stop == self.slice_start
     }
 
+    /// Split this data into movable parts, attaching the supplied validity.
     pub fn into_parts(self, validity: Validity) -> ZstdDataParts {
         ZstdDataParts {
             dictionary: self.dictionary,

--- a/encodings/zstd/src/lib.rs
+++ b/encodings/zstd/src/lib.rs
@@ -1,6 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+//! Zstd-backed compression encodings for variable-width Vortex arrays.
+//!
+//! [`ZstdArray`] stores UTF-8 or binary values as one or more zstd frames, optionally sharing a
+//! trained dictionary across frames. Frame metadata lets slices decompress only the frames that can
+//! contribute values to the requested row range.
+//!
+//! With the `unstable_encodings` feature, `ZstdBuffers` stores the buffers of another encoding as
+//! independently compressed zstd buffers while preserving the inner encoding metadata.
+//!
+//! This crate exposes array encodings only. Compression scheme selection is wired through
+//! `vortex-btrblocks` and file writing. To deserialize arrays manually, register the encoding in the
+//! array session:
+//!
+//! ```rust
+//! use vortex_array::session::ArraySessionExt;
+//!
+//! let session = vortex_array::array_session();
+//! session.arrays().register(vortex_zstd::Zstd);
+//! ```
+
 pub use array::*;
 #[cfg(feature = "unstable_encodings")]
 pub use zstd_buffers::*;
@@ -16,28 +36,38 @@ mod zstd_buffers;
 mod test;
 
 #[derive(Clone, prost::Message)]
+/// Metadata for one zstd frame.
 pub struct ZstdFrameMetadata {
+    /// Uncompressed byte size of this frame.
     #[prost(uint64, tag = "1")]
     pub uncompressed_size: u64,
+    /// Number of valid values stored in this frame.
     #[prost(uint64, tag = "2")]
     pub n_values: u64,
 }
 
 #[derive(Clone, prost::Message)]
+/// Serialized metadata for a [`ZstdArray`].
 pub struct ZstdMetadata {
     // optional, will be 0 if there's no dictionary
+    /// Dictionary size in bytes, or `0` when no dictionary is present.
     #[prost(uint32, tag = "1")]
     pub dictionary_size: u32,
+    /// Metadata for each compressed frame.
     #[prost(message, repeated, tag = "2")]
     pub frames: Vec<ZstdFrameMetadata>,
 }
 
 #[derive(Clone, prost::Message)]
+/// Serialized metadata for the unstable `ZstdBuffers` encoding.
 pub struct ZstdBuffersMetadata {
+    /// Encoding id of the inner array whose buffers were compressed.
     #[prost(string, tag = "1")]
     pub inner_encoding_id: String,
+    /// Serialized metadata of the inner array.
     #[prost(bytes = "vec", tag = "2")]
     pub inner_metadata: Vec<u8>,
+    /// Uncompressed byte size of each compressed buffer.
     #[prost(uint64, repeated, tag = "3")]
     pub uncompressed_sizes: Vec<u64>,
     /// Alignment of each buffer in bytes (must be a power of two).

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -43,9 +43,11 @@ use crate::ZstdBuffersMetadata;
 pub type ZstdBuffersArray = Array<ZstdBuffers>;
 
 #[derive(Clone, Debug)]
+/// Encoding marker for buffer-level zstd compression.
 pub struct ZstdBuffers;
 
 impl ZstdBuffers {
+    /// Construct a [`ZstdBuffersArray`] from compressed buffer data.
     pub fn try_new(
         dtype: DType,
         len: usize,
@@ -54,6 +56,10 @@ impl ZstdBuffers {
         Array::try_from_parts(ArrayParts::new(ZstdBuffers, dtype, len, data))
     }
 
+    /// Compress every top-level buffer of `array` independently with zstd.
+    ///
+    /// Children are preserved as slots and the wrapped array's serialized metadata is stored so the
+    /// original array can be rebuilt after decompression.
     pub fn compress(
         array: &ArrayRef,
         level: i32,
@@ -96,6 +102,7 @@ impl ZstdBuffers {
         Ok(compressed)
     }
 
+    /// Rebuild the wrapped array from decompressed buffer handles.
     pub fn build_inner(
         array: &ZstdBuffersArray,
         buffer_handles: &[BufferHandle],
@@ -149,6 +156,7 @@ impl Display for ZstdBuffersData {
 }
 
 #[derive(Clone, Debug)]
+/// Decode plan for buffer-level zstd decompression.
 pub struct ZstdBuffersDecodePlan {
     compressed_buffers: Vec<BufferHandle>,
     frame_sizes: Arc<[usize]>,
@@ -160,30 +168,37 @@ pub struct ZstdBuffersDecodePlan {
 }
 
 impl ZstdBuffersDecodePlan {
+    /// Compressed buffers to decode.
     pub fn compressed_buffers(&self) -> &[BufferHandle] {
         &self.compressed_buffers
     }
 
+    /// Compressed frame sizes in bytes.
     pub fn frame_sizes(&self) -> Arc<[usize]> {
         Arc::clone(&self.frame_sizes)
     }
 
+    /// Decompressed output size for each buffer.
     pub fn output_sizes(&self) -> Arc<[usize]> {
         Arc::clone(&self.output_sizes)
     }
 
+    /// Byte offsets of each decompressed buffer in one contiguous output allocation.
     pub fn output_offsets(&self) -> &[usize] {
         &self.output_offsets
     }
 
+    /// Total byte size of the planned contiguous output allocation.
     pub fn output_size_total(&self) -> usize {
         self.output_size_total
     }
 
+    /// Largest single decompressed buffer size.
     pub fn output_size_max(&self) -> usize {
         self.output_size_max
     }
 
+    /// Number of compressed frames/buffers in the plan.
     pub fn num_frames(&self) -> usize {
         self.compressed_buffers.len()
     }
@@ -273,6 +288,7 @@ impl ZstdBuffersData {
         Ok(result)
     }
 
+    /// Build a decode plan for external or device decompression.
     pub fn decode_plan(&self) -> VortexResult<ZstdBuffersDecodePlan> {
         // If invariants are somehow broken, device decompression could have UB, so ensure
         // they still hold.

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -190,6 +190,7 @@ pub(crate) trait DynArrayData: 'static + private::Sealed + Send + Sync + Debug {
 
 /// Trait for converting a type into a Vortex [`ArrayRef`].
 pub trait IntoArray {
+    /// Convert this value into the erased array handle used by generic APIs.
     fn into_array(self) -> ArrayRef;
 }
 

--- a/vortex-array/src/array/typed.rs
+++ b/vortex-array/src/array/typed.rs
@@ -3,6 +3,11 @@
 
 //! Typed array wrappers: [`ArrayData<V>`] (heap-allocated), [`Array<V>`] (typed handle),
 //! and [`ArrayView<V>`] (lightweight borrow).
+//!
+//! Encoding implementors normally construct arrays through [`ArrayParts`] and
+//! [`Array::try_from_parts`]. Compute and serialization code should accept [`ArrayRef`] when it can
+//! operate over any encoding, and downcast to [`Array<V>`] or [`ArrayView<V>`] only when it needs
+//! encoding-specific state.
 
 use std::any::Any;
 use std::fmt::Debug;
@@ -48,14 +53,22 @@ pub(crate) struct ArrayInner<D: ?Sized> {
 
 /// Construction parameters for typed arrays.
 pub struct ArrayParts<V: VTable> {
+    /// The vtable value identifying the array encoding.
     pub vtable: V,
+    /// Logical dtype of every row in the array.
     pub dtype: DType,
+    /// Number of rows in the array.
     pub len: usize,
+    /// Encoding-specific, non-child data.
     pub data: V::TypedArrayData,
+    /// Optional child arrays owned by this encoding.
     pub slots: ArraySlots,
 }
 
 impl<V: VTable> ArrayParts<V> {
+    /// Construct array parts with no child slots.
+    ///
+    /// The parts are not validated until they are passed to [`Array::try_from_parts`].
     pub fn new(vtable: V, dtype: DType, len: usize, data: V::TypedArrayData) -> Self {
         Self {
             vtable,
@@ -66,6 +79,9 @@ impl<V: VTable> ArrayParts<V> {
         }
     }
 
+    /// Attach child slots to the construction parts.
+    ///
+    /// Slot count, names, and meaning are encoding-specific and validated by [`VTable::validate`].
     pub fn with_slots(mut self, slots: ArraySlots) -> Self {
         self.slots = slots;
         self
@@ -189,6 +205,9 @@ pub struct Array<V: VTable> {
 
 impl<V: VTable> Array<V> {
     /// Create a typed array from explicit construction parameters.
+    ///
+    /// This is the safe construction path for encoding implementors. It calls
+    /// [`VTable::validate`] before publishing the array as an [`ArrayRef`].
     pub fn try_from_parts(new: ArrayParts<V>) -> VortexResult<Self> {
         let store = ArrayInner::<ArrayData<V>>::try_new(new)?;
         let inner = ArrayRef::from_inner(Arc::new(store));
@@ -232,7 +251,9 @@ impl<V: VTable> Array<V> {
         }
     }
 
-    /// Try to create from an `ArrayRef`, returning `Err` if the type doesn't match.
+    /// Try to create a typed handle from an [`ArrayRef`].
+    ///
+    /// Returns the original [`ArrayRef`] in `Err` when the encoding id does not match `V`.
     pub fn try_from_array_ref(array: ArrayRef) -> Result<Self, ArrayRef> {
         if array.is::<V>() {
             Ok(Self {
@@ -244,7 +265,7 @@ impl<V: VTable> Array<V> {
         }
     }
 
-    /// Returns the dtype.
+    /// Returns the logical dtype.
     pub fn dtype(&self) -> &DType {
         self.inner.dtype()
     }
@@ -259,12 +280,12 @@ impl<V: VTable> Array<V> {
         self.inner.len() == 0
     }
 
-    /// Returns the encoding ID.
+    /// Returns the encoding ID for `V`.
     pub fn encoding_id(&self) -> ArrayId {
         self.inner.encoding_id()
     }
 
-    /// Returns the statistics.
+    /// Returns this array's statistics set.
     pub fn statistics(&self) -> StatsSetRef<'_> {
         self.inner.statistics()
     }
@@ -274,7 +295,9 @@ impl<V: VTable> Array<V> {
         &self.downcast_inner().data
     }
 
-    /// Try to fetch a mut ref to the inner ArrayData.
+    /// Try to fetch mutable access to the encoding-specific data.
+    ///
+    /// Returns `None` when this handle is not the unique owner of the backing allocation.
     pub fn data_mut(&mut self) -> Option<&mut V::TypedArrayData> {
         let store = self.inner.inner_mut()?;
         let array_inner = store.data.as_any_mut().downcast_mut::<ArrayData<V>>();
@@ -302,6 +325,7 @@ impl<V: VTable> Array<V> {
         }
     }
 
+    /// Replace the array's statistics set and return the same typed handle.
     pub fn with_stats_set(self, stats: StatsSet) -> Self {
         self.statistics().replace(stats);
         self
@@ -343,6 +367,7 @@ impl<V: VTable> Array<V> {
 
 /// Public API methods that shadow `DynArrayData` / `ArrayRef` methods.
 impl<V: VTable> Array<V> {
+    /// Lazily or eagerly slice the array to `range`, depending on available kernels.
     pub fn slice(&self, range: std::ops::Range<usize>) -> VortexResult<ArrayRef> {
         self.inner.slice(range)
     }
@@ -365,30 +390,37 @@ impl<V: VTable> Array<V> {
         self.inner.execute_scalar(index, ctx)
     }
 
+    /// Filter the array with a selection mask.
     pub fn filter(&self, mask: vortex_mask::Mask) -> VortexResult<ArrayRef> {
         self.inner.filter(mask)
     }
 
+    /// Gather rows from this array by index.
     pub fn take(&self, indices: ArrayRef) -> VortexResult<ArrayRef> {
         self.inner.take(indices)
     }
 
+    /// Returns the array's validity representation.
     pub fn validity(&self) -> VortexResult<Validity> {
         self.inner.validity()
     }
 
+    /// Returns whether `index` is valid using the provided execution context.
     pub fn is_valid(&self, index: usize, ctx: &mut ExecutionCtx) -> VortexResult<bool> {
         self.inner.is_valid(index, ctx)
     }
 
+    /// Returns whether `index` is null using the provided execution context.
     pub fn is_invalid(&self, index: usize, ctx: &mut ExecutionCtx) -> VortexResult<bool> {
         self.inner.is_invalid(index, ctx)
     }
 
+    /// Returns whether every row is valid.
     pub fn all_valid(&self, ctx: &mut ExecutionCtx) -> VortexResult<bool> {
         self.inner.all_valid(ctx)
     }
 
+    /// Returns whether every row is null.
     pub fn all_invalid(&self, ctx: &mut ExecutionCtx) -> VortexResult<bool> {
         self.inner.all_invalid(ctx)
     }
@@ -400,26 +432,32 @@ impl<V: VTable> Array<V> {
         result
     }
 
+    /// Returns the estimated physical bytes owned or referenced by this array tree.
     pub fn nbytes(&self) -> u64 {
         self.inner.nbytes()
     }
 
+    /// Returns the number of top-level buffers exposed by this encoding.
     pub fn nbuffers(&self) -> usize {
         self.inner.nbuffers()
     }
 
+    /// Returns the scalar value when this array is known to be constant.
     pub fn as_constant(&self) -> Option<crate::scalar::Scalar> {
         self.inner.as_constant()
     }
 
+    /// Counts valid rows, executing validity arrays when necessary.
     pub fn valid_count(&self, ctx: &mut ExecutionCtx) -> VortexResult<usize> {
         self.inner.valid_count(ctx)
     }
 
+    /// Counts null rows, executing validity arrays when necessary.
     pub fn invalid_count(&self, ctx: &mut ExecutionCtx) -> VortexResult<usize> {
         self.inner.invalid_count(ctx)
     }
 
+    /// Append this array's logical values to a canonical builder.
     pub fn append_to_builder(
         &self,
         builder: &mut dyn crate::builders::ArrayBuilder,

--- a/vortex-array/src/array/view.rs
+++ b/vortex-array/src/array/view.rs
@@ -16,6 +16,10 @@ use crate::stats::StatsSetRef;
 use crate::validity::Validity;
 
 /// A lightweight, `Copy`-able typed view into an [`ArrayRef`].
+///
+/// Vtable methods receive `ArrayView<V>` so they can inspect common array metadata and
+/// encoding-specific data without cloning or downcasting an [`ArrayRef`]. The view is only valid for
+/// the lifetime of the borrowed array.
 pub struct ArrayView<'a, V: VTable> {
     array: &'a ArrayRef,
     data: &'a V::TypedArrayData,
@@ -37,42 +41,52 @@ impl<'a, V: VTable> ArrayView<'a, V> {
         Self { array, data }
     }
 
+    /// Returns the erased array handle that owns this view.
     pub fn array(&self) -> &'a ArrayRef {
         self.array
     }
 
+    /// Returns the encoding-specific data stored by this array.
     pub fn data(&self) -> &'a V::TypedArrayData {
         self.data
     }
 
+    /// Returns this array's child slots.
     pub fn slots(&self) -> &'a [Option<ArrayRef>] {
         self.array.slots()
     }
 
+    /// Returns the logical dtype.
     pub fn dtype(&self) -> &DType {
         self.array.dtype()
     }
 
+    /// Returns the number of rows.
     pub fn len(&self) -> usize {
         self.array.len()
     }
 
+    /// Returns `true` when the array has no rows.
     pub fn is_empty(&self) -> bool {
         self.array.len() == 0
     }
 
+    /// Returns the encoding ID.
     pub fn encoding_id(&self) -> ArrayId {
         self.array.encoding_id()
     }
 
+    /// Returns the array's statistics set.
     pub fn statistics(&self) -> StatsSetRef<'_> {
         self.array.statistics()
     }
 
+    /// Returns the array's validity representation.
     pub fn validity(&self) -> VortexResult<Validity> {
         self.array.validity()
     }
 
+    /// Clone the underlying [`ArrayRef`] and return it as an owned typed handle.
     pub fn into_owned(self) -> Array<V> {
         // SAFETY: we are ourselves type checked as 'V'
         unsafe { Array::<V>::from_array_ref_unchecked(self.array.clone()) }

--- a/vortex-array/src/array/vtable/mod.rs
+++ b/vortex-array/src/array/vtable/mod.rs
@@ -2,6 +2,14 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 //! This module contains the VTable definitions for a Vortex encoding.
+//!
+//! A Vortex array encoding is implemented by a small static vtable type plus an associated
+//! `TypedArrayData` value stored in each array instance. The vtable owns behavior such as
+//! validation, serialization, execution, child traversal, scalar access, and validity access.
+//!
+//! The public [`ArrayRef`](crate::ArrayRef) API performs common precondition checks before calling
+//! into these traits. Implementations should focus on encoding-specific work and uphold the
+//! documented postconditions.
 
 mod operations;
 mod validity;
@@ -54,15 +62,25 @@ use crate::validity::Validity;
 /// out of bounds). Post-conditions are validated after invocation of the vtable function and will
 /// panic if violated.
 pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
+    /// Per-array data owned by this encoding, excluding child arrays.
+    ///
+    /// Child arrays belong in [`ArrayParts::slots`](crate::ArrayParts::slots) so traversal,
+    /// serialization, and layout writers can discover them generically.
     type TypedArrayData: 'static + Send + Sync + Clone + Debug + Display + ArrayHash + ArrayEq;
 
+    /// Scalar and element-wise operation hooks for this encoding.
     type OperationsVTable: OperationsVTable<Self>;
+    /// Validity hook for nullable instances of this encoding.
     type ValidityVTable: ValidityVTable<Self>;
 
     /// Returns the ID of the array.
     fn id(&self) -> ArrayId;
 
     /// Validates that externally supplied logical metadata matches the array data.
+    ///
+    /// This is called by [`Array::try_from_parts`](crate::Array::try_from_parts) before the array
+    /// is published. Implementations should check dtype, length, slot count, child dtypes/lengths,
+    /// metadata bounds, and any buffer shape invariants that unsafe accessors depend on.
     fn validate(
         &self,
         data: &Self::TypedArrayData,
@@ -71,7 +89,7 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
         slots: &[Option<ArrayRef>],
     ) -> VortexResult<()>;
 
-    /// Returns the number of buffers in the array.
+    /// Returns the number of top-level buffers in the array.
     fn nbuffers(array: ArrayView<'_, Self>) -> usize;
 
     /// Returns the buffer at the given index.
@@ -122,14 +140,21 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
             .vortex_expect("child_name index out of bounds")
     }
 
-    /// Serialize metadata into a byte buffer for IPC or file storage.
-    /// Return `None` if the array cannot be serialized.
+    /// Serialize encoding metadata into a byte buffer for IPC or file storage.
+    ///
+    /// Return `None` if the array cannot be serialized by this encoding. Buffers and children are
+    /// serialized separately through [`buffer`](Self::buffer), [`nbuffers`](Self::nbuffers), and
+    /// child traversal.
     fn serialize(
         array: ArrayView<'_, Self>,
         session: &VortexSession,
     ) -> VortexResult<Option<Vec<u8>>>;
 
-    /// Deserialize an array from serialized components.
+    /// Deserialize an array from serialized metadata, buffers, and children.
+    ///
+    /// The returned [`ArrayParts`](crate::ArrayParts) are still validated by the generic adapter.
+    /// Deserializers should use the provided `session` to resolve plugin-owned metadata instead of
+    /// relying on global state.
     fn deserialize(
         &self,
         dtype: &DType,
@@ -140,7 +165,10 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
         session: &VortexSession,
     ) -> VortexResult<crate::array::ArrayParts<Self>>;
 
-    /// Writes the array into a canonical builder.
+    /// Writes the array's logical values into a canonical builder.
+    ///
+    /// The default implementation executes the full array to [`Canonical`] and appends that result.
+    /// Encodings may override this to avoid materializing an intermediate canonical array.
     fn append_to_builder(
         array: ArrayView<'_, Self>,
         builder: &mut dyn ArrayBuilder,
@@ -185,13 +213,18 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
     /// incorrectly contains null values.
     fn execute(array: Array<Self>, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionResult>;
 
-    /// Attempt to reduce the array to a simpler representation.
+    /// Attempt to reduce the array to a simpler representation without changing logical values.
+    ///
+    /// Reductions are opportunistic and may return `Ok(None)` when no cheaper representation is
+    /// known.
     fn reduce(array: ArrayView<'_, Self>) -> VortexResult<Option<ArrayRef>> {
         _ = array;
         Ok(None)
     }
 
-    /// Attempt to perform a reduction of the parent of this array.
+    /// Attempt to reduce `parent` after this array appears as one of its children.
+    ///
+    /// This is used by lazy arrays to let child execution unlock parent simplifications.
     fn reduce_parent(
         array: ArrayView<'_, Self>,
         parent: &ArrayRef,

--- a/vortex-array/src/array/vtable/mod.rs
+++ b/vortex-array/src/array/vtable/mod.rs
@@ -7,7 +7,7 @@
 //! `TypedArrayData` value stored in each array instance. The vtable owns behavior such as
 //! validation, serialization, execution, child traversal, scalar access, and validity access.
 //!
-//! The public [`ArrayRef`](crate::ArrayRef) API performs common precondition checks before calling
+//! The public [`ArrayRef`] API performs common precondition checks before calling
 //! into these traits. Implementations should focus on encoding-specific work and uphold the
 //! documented postconditions.
 

--- a/vortex-array/src/array/vtable/operations.rs
+++ b/vortex-array/src/array/vtable/operations.rs
@@ -10,13 +10,23 @@ use crate::array::VTable;
 use crate::scalar::Scalar;
 use crate::vtable::NotSupported;
 
+/// Element-level operations for an array encoding.
+///
+/// This trait is separated from [`VTable`](crate::array::VTable) so encodings can organize scalar
+/// access independently from traversal, serialization, and execution. The erased
+/// [`ArrayRef`](crate::ArrayRef)
+/// methods perform common checks before dispatching here.
 pub trait OperationsVTable<V: VTable> {
     /// Fetch the scalar at the given index.
     ///
     /// ## Preconditions
     ///
     /// Bounds-checking has already been performed by the time this function is called,
-    /// and the index is guaranteed to be non-null.
+    /// and the index is guaranteed to be non-null. Implementations may assume `index < len`.
+    ///
+    /// ## Postconditions
+    ///
+    /// The returned [`Scalar`] must have the same logical dtype as the array's element dtype.
     fn scalar_at(
         array: ArrayView<'_, V>,
         index: usize,

--- a/vortex-array/src/array/vtable/operations.rs
+++ b/vortex-array/src/array/vtable/operations.rs
@@ -12,7 +12,7 @@ use crate::vtable::NotSupported;
 
 /// Element-level operations for an array encoding.
 ///
-/// This trait is separated from [`VTable`](crate::array::VTable) so encodings can organize scalar
+/// This trait is separated from [`VTable`] so encodings can organize scalar
 /// access independently from traversal, serialization, and execution. The erased
 /// [`ArrayRef`](crate::ArrayRef)
 /// methods perform common checks before dispatching here.

--- a/vortex-array/src/array/vtable/validity.rs
+++ b/vortex-array/src/array/vtable/validity.rs
@@ -8,12 +8,22 @@ use crate::array::ArrayView;
 use crate::array::VTable;
 use crate::validity::Validity;
 
+/// Validity access for nullable instances of an encoding.
+///
+/// Non-nullable arrays bypass this hook and report [`Validity::NonNullable`]. Nullable arrays call
+/// into the encoding so it can expose either a constant validity state or a row-aligned boolean
+/// child array.
 pub trait ValidityVTable<V: VTable> {
     /// Returns the [`Validity`] of the array.
     ///
     /// ## Pre-conditions
     ///
     /// - The array DType is nullable.
+    ///
+    /// ## Post-conditions
+    ///
+    /// If this returns [`Validity::Array`], the child array must have the same length as `array`
+    /// and non-nullable boolean dtype.
     fn validity(array: ArrayView<'_, V>) -> VortexResult<Validity>;
 }
 
@@ -21,7 +31,9 @@ pub trait ValidityVTable<V: VTable> {
 /// to a child array.
 pub struct ValidityVTableFromChild;
 
+/// Helper trait for encodings whose validity is exactly one child slot.
 pub trait ValidityChild<V: VTable> {
+    /// Returns the child array that carries validity for `array`.
     fn validity_child(array: ArrayView<'_, V>) -> ArrayRef;
 }
 
@@ -38,9 +50,12 @@ where
 /// and a slice into it.
 pub struct ValidityVTableFromChildSliceHelper;
 
+/// Helper for encodings that keep an unsliced validity child plus a local slice range.
 pub trait ValidityChildSliceHelper {
+    /// Returns `(unsliced_validity, start, stop)` for this array's logical slice.
     fn unsliced_child_and_slice(&self) -> (&ArrayRef, usize, usize);
 
+    /// Returns a sliced validity child array for the logical range.
     fn sliced_child_array(&self) -> VortexResult<ArrayRef> {
         let (unsliced_validity, start, stop) = self.unsliced_child_and_slice();
         unsliced_validity.slice(start..stop)

--- a/vortex-array/src/arrays/mod.rs
+++ b/vortex-array/src/arrays/mod.rs
@@ -1,7 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! All the built-in encoding schemes and arrays.
+//! Built-in array encodings.
+//!
+//! Canonical arrays are the default uncompressed representation for a logical dtype:
+//! [`NullArray`], [`BoolArray`], [`PrimitiveArray`], [`DecimalArray`], [`VarBinViewArray`],
+//! [`ListViewArray`], [`FixedSizeListArray`], [`StructArray`], [`ExtensionArray`], and
+//! [`VariantArray`].
+//!
+//! Utility and lazy arrays represent common transformations without immediately materializing
+//! their result. Examples include [`ChunkedArray`] for concatenation, [`ConstantArray`] for repeated
+//! values, [`DictArray`] for dictionary encoding, [`FilterArray`] for masked rows, [`SliceArray`]
+//! for views, and [`ScalarFnArray`] for deferred scalar-function execution.
+//!
+//! Some public arrays are primarily internal building blocks. Their constructors and extension
+//! traits document the stable contract; avoid depending on undocumented slot order or metadata
+//! details.
 
 #[cfg(any(test, feature = "_test-harness"))]
 mod assertions;

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -69,7 +69,7 @@ use crate::validity::Validity;
 ///
 /// Each `Canonical` variant has a corresponding [`DType`] variant, with the notable exception of
 /// [`Canonical::VarBinView`], which is the canonical encoding for both [`DType::Utf8`] and
-/// [`DType::Binary`].
+/// [`DType::Binary`]. [`DType::Union`] does not yet have a public canonical array.
 ///
 /// # Laziness
 ///
@@ -128,7 +128,9 @@ pub enum Canonical {
     List(ListViewArray),
     FixedSizeList(FixedSizeListArray),
     Struct(StructArray),
+    /// Canonical storage for extension dtypes, wrapping the canonical form of the storage dtype.
     Extension(ExtensionArray),
+    /// Canonical storage for dynamic variant values, optionally with typed shredded paths.
     Variant(VariantArray),
 }
 

--- a/vortex-array/src/dtype/extension/mod.rs
+++ b/vortex-array/src/dtype/extension/mod.rs
@@ -3,6 +3,15 @@
 
 //! Extension DTypes, and interfaces for working with extension types.
 //!
+//! An extension dtype gives semantic meaning to values stored in an ordinary Vortex storage dtype.
+//! For example, a timestamp extension can store an integer while carrying unit/time-zone metadata.
+//! Arrays with [`DType::Extension`](crate::dtype::DType::Extension) use
+//! [`crate::arrays::ExtensionArray`] to pair the extension dtype with the storage array.
+//!
+//! Extension dtype implementations provide an [`ExtVTable`] for identity, metadata
+//! serialization, storage dtype validation, scalar validation, and typed scalar unpacking. Register
+//! extension plugins in a session before deserializing data that may reference them.
+//!
 //! ## File layout convention
 //!
 //! Each vtable-backed concept `Foo` follows this module structure:

--- a/vortex-array/src/dtype/extension/vtable.rs
+++ b/vortex-array/src/dtype/extension/vtable.rs
@@ -15,7 +15,13 @@ use crate::scalar::ScalarValue;
 /// The public API for defining new extension types.
 ///
 /// This is the non-object-safe trait that plugin authors implement to define a new extension type.
-/// It specifies the type's identity, metadata, serialization, and validation.
+/// It specifies the type's identity, metadata, serialization, storage compatibility, and scalar
+/// compatibility.
+///
+/// An extension dtype is not a new physical array layout. It is a logical wrapper around a storage
+/// [`DType`] plus metadata. Implementations should keep [`validate_dtype`](Self::validate_dtype)
+/// strict enough that every valid storage scalar can be interpreted by
+/// [`unpack_native`](Self::unpack_native).
 pub trait ExtVTable: 'static + Sized + Send + Sync + Clone + Debug + Eq + Hash {
     /// Associated type containing the deserialized metadata for this extension type.
     type Metadata: 'static + Send + Sync + Clone + Debug + Display + Eq + Hash;
@@ -37,6 +43,9 @@ pub trait ExtVTable: 'static + Sized + Send + Sync + Clone + Debug + Eq + Hash {
     fn deserialize_metadata(&self, metadata: &[u8]) -> VortexResult<Self::Metadata>;
 
     /// Validate that the given storage type is compatible with this extension type.
+    ///
+    /// This is called when constructing an [`ExtDType`] and should check both storage dtype and
+    /// extension metadata.
     fn validate_dtype(ext_dtype: &ExtDType<Self>) -> VortexResult<()>;
 
     /// Can a value of `other` be implicitly widened into this type? (e.g. GeographyType might

--- a/vortex-array/src/dtype/mod.rs
+++ b/vortex-array/src/dtype/mod.rs
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! A type system for Vortex
+//! A type system for Vortex.
 //!
 //! This crate contains the core logical type system for Vortex, including the definition of data types,
 //! and (optionally) logic for their serialization and deserialization.
+//!
+//! Vortex dtypes are logical domains, not physical layouts. Encodings are tracked separately on
+//! arrays, so the same dtype may be backed by canonical buffers, dictionary codes, compressed
+//! children, or a lazy expression array.
+//!
+//! Every non-null logical dtype carries [`Nullability`] directly. This differs from Apache Arrow,
+//! where nullability is usually field metadata.
 
 #[cfg(feature = "arbitrary")]
 mod arbitrary;
@@ -101,11 +108,19 @@ pub enum DType {
     /// `DType`. See [`StructFields`] for more information.
     Struct(StructFields, Nullability),
 
-    // TODO(connor)[Union]: Add more info here!
     /// A logical union (sum) type.
+    ///
+    /// `Union` is reserved for values that are drawn from one of several possible child domains.
+    /// The exact child-type metadata and canonical storage are not yet part of the stable public
+    /// Rust API, so most callers should prefer [`DType::Variant`] for dynamically typed values or
+    /// [`DType::Struct`] for fixed schemas.
     Union(Nullability),
 
-    /// Variant type.
+    /// Dynamically typed values stored as Vortex scalars.
+    ///
+    /// A variant value preserves its full logical value in variant storage and may also carry a
+    /// typed, row-aligned shredded representation for selected paths when materialized as a
+    /// [`VariantArray`](crate::arrays::VariantArray).
     Variant(Nullability),
 
     /// A user-defined extension type.

--- a/vortex-array/src/expr/mod.rs
+++ b/vortex-array/src/expr/mod.rs
@@ -1,9 +1,38 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Vortex's expression language.
+//! Vortex's expression language: scalar operations over [arrays](crate::ArrayRef).
 //!
-//! All expressions are serializable, and own their own wire format.
+//! An [`Expression`] is a tree of scalar operations rooted at a scope (see [`root`]). Expressions
+//! are the common currency of scans: a scan takes a *filter* expression that resolves to a boolean
+//! and a *projection* expression that shapes the output. All expressions are serializable and own
+//! their own wire format, so they can be pushed down to remote sources and reconstructed on workers.
+//!
+//! # Scalar functions
+//!
+//! Each node references a scalar function defined by a
+//! [`ScalarFnVTable`](crate::scalar_fn::ScalarFnVTable). The vtable declares the function signature,
+//! properties such as null-sensitivity, and the logic that executes it over input arrays. Built-in
+//! functions live in [`crate::scalar_fn`]; integration and plugin crates supply additional,
+//! use-case-specific functions.
+//!
+//! # Deferred execution
+//!
+//! Applying an expression to an array does not compute the result eagerly. Instead it builds a
+//! [`ScalarFnArray`](crate::arrays::ScalarFnArray) representing the deferred application, letting
+//! downstream encodings push the computation into compressed data, or fuse several expressions
+//! together, before any data is materialized. The deferred tree is executed toward canonical form
+//! only when a result is actually required.
+//!
+//! # Typing and coercion
+//!
+//! Expressions are strictly typed: an input array's dtype must match the function signature exactly,
+//! so callers perform any required type coercion themselves before building the expression (see the
+//! [`transform`] passes). The one relaxation is null-coercion — for example, equality may compare a
+//! `u32` against a `u32?`, but never a `u32` against an `i32`.
+//!
+//! Filter expressions are decomposed into independent conjuncts with [`split_conjunction`] so that
+//! scans can evaluate and reorder the most selective predicates first.
 //!
 //! The implementation takes inspiration from [Postgres] and [Apache Datafusion].
 //!

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -14,7 +14,7 @@
 //! # Core Handles
 //!
 //! [`ArrayRef`] is the erased, shared handle used by most public APIs. It carries the logical
-//! [`DType`](crate::dtype::DType), row count, encoding id, children, buffers, and statistics for an
+//! [`DType`], row count, encoding id, children, buffers, and statistics for an
 //! array tree. Use it when an API should accept any encoding.
 //!
 //! [`Array<V>`] is the typed owned handle for a known encoding `V: VTable`. It wraps an
@@ -28,9 +28,9 @@
 //!
 //! # Logical Types and Physical Encodings
 //!
-//! A [`DType`](crate::dtype::DType) describes the logical values an array may hold. It does not
+//! A [`DType`] describes the logical values an array may hold. It does not
 //! describe the memory layout. For example, a `DType::Primitive(I32, Nullable)` can be stored as a
-//! canonical [`PrimitiveArray`](crate::arrays::PrimitiveArray), a dictionary, a slice, or a
+//! canonical [`PrimitiveArray`], a dictionary, a slice, or a
 //! compressed external encoding.
 //!
 //! The [`Canonical`] enum names the default uncompressed encoding for each logical family. Execution
@@ -40,11 +40,10 @@
 //! # Built-in, Lazy, and Experimental Arrays
 //!
 //! Built-in arrays live in [`arrays`]. Some are canonical (`PrimitiveArray`, `StructArray`,
-//! `VarBinViewArray`); others are utility or lazy arrays such as
-//! [`ChunkedArray`](crate::arrays::ChunkedArray), [`ConstantArray`](crate::arrays::ConstantArray),
-//! [`FilterArray`](crate::arrays::FilterArray), [`SliceArray`](crate::arrays::SliceArray), and
-//! [`ScalarFnArray`](crate::arrays::ScalarFnArray). Lazy arrays defer work so compute kernels can
-//! operate on encoded data or prune children before materialization.
+//! `VarBinViewArray`); others are utility or lazy arrays such as [`ChunkedArray`],
+//! [`ConstantArray`], [`FilterArray`], [`SliceArray`], and [`ScalarFnArray`].
+//! Lazy arrays defer work so compute kernels can operate on encoded data or prune children
+//! before materialization.
 //!
 //! Experimental arrays are public because they are used inside Vortex, but their storage contracts
 //! may still move. Prefer the higher-level constructors and accessors documented on each array
@@ -55,7 +54,7 @@
 //! [`Validity`](crate::validity::Validity) separates nullness from values. It can be a cheap
 //! constant state (`NonNullable`, `AllValid`, `AllInvalid`) or a boolean array that may itself be
 //! encoded. [`Scalar`](crate::scalar::Scalar) is the single-value counterpart: it pairs a
-//! [`DType`](crate::dtype::DType) with an optional [`ScalarValue`](crate::scalar::ScalarValue).
+//! [`DType`] with an optional [`ScalarValue`](crate::scalar::ScalarValue).
 //!
 //! # Extending Vortex
 //!
@@ -69,6 +68,14 @@
 //!
 //! New logical extension dtypes implement [`ExtVTable`](crate::dtype::extension::ExtVTable) and
 //! store values in an ordinary Vortex storage dtype.
+//!
+//! [`PrimitiveArray`]: crate::arrays::PrimitiveArray
+//! [`DType`]: crate::dtype::DType
+//! [`ChunkedArray`]: crate::arrays::ChunkedArray
+//! [`ConstantArray`]: crate::arrays::ConstantArray
+//! [`FilterArray`]: crate::arrays::FilterArray
+//! [`SliceArray`]: crate::arrays::SliceArray
+//! [`ScalarFnArray`]: crate::arrays::ScalarFnArray
 
 extern crate self as vortex_array;
 

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -10,6 +10,65 @@
 //!
 //! Every data type recognized by Vortex also has a canonical physical encoding format, which
 //! arrays can be [canonicalized](Canonical) into for ease of access in compute functions.
+//!
+//! # Core Handles
+//!
+//! [`ArrayRef`] is the erased, shared handle used by most public APIs. It carries the logical
+//! [`DType`](crate::dtype::DType), row count, encoding id, children, buffers, and statistics for an
+//! array tree. Use it when an API should accept any encoding.
+//!
+//! [`Array<V>`] is the typed owned handle for a known encoding `V: VTable`. It wraps an
+//! [`ArrayRef`] and dereferences to the encoding-specific `V::TypedArrayData`.
+//!
+//! [`ArrayView<V>`] is the lightweight typed borrow handed to vtable methods. It exposes both the
+//! shared [`ArrayRef`] metadata and the encoding-specific data without cloning the handle.
+//!
+//! [`ArrayParts<V>`] is the construction boundary for typed arrays. It groups externally supplied
+//! logical metadata and encoding data, then [`Array::try_from_parts`] validates that they agree.
+//!
+//! # Logical Types and Physical Encodings
+//!
+//! A [`DType`](crate::dtype::DType) describes the logical values an array may hold. It does not
+//! describe the memory layout. For example, a `DType::Primitive(I32, Nullable)` can be stored as a
+//! canonical [`PrimitiveArray`](crate::arrays::PrimitiveArray), a dictionary, a slice, or a
+//! compressed external encoding.
+//!
+//! The [`Canonical`] enum names the default uncompressed encoding for each logical family. Execution
+//! normally moves an array tree toward canonical form, but canonicalization is shallow: children of
+//! canonical struct/list arrays may still be encoded.
+//!
+//! # Built-in, Lazy, and Experimental Arrays
+//!
+//! Built-in arrays live in [`arrays`]. Some are canonical (`PrimitiveArray`, `StructArray`,
+//! `VarBinViewArray`); others are utility or lazy arrays such as
+//! [`ChunkedArray`](crate::arrays::ChunkedArray), [`ConstantArray`](crate::arrays::ConstantArray),
+//! [`FilterArray`](crate::arrays::FilterArray), [`SliceArray`](crate::arrays::SliceArray), and
+//! [`ScalarFnArray`](crate::arrays::ScalarFnArray). Lazy arrays defer work so compute kernels can
+//! operate on encoded data or prune children before materialization.
+//!
+//! Experimental arrays are public because they are used inside Vortex, but their storage contracts
+//! may still move. Prefer the higher-level constructors and accessors documented on each array
+//! module rather than relying on child slot order.
+//!
+//! # Nulls and Scalars
+//!
+//! [`Validity`](crate::validity::Validity) separates nullness from values. It can be a cheap
+//! constant state (`NonNullable`, `AllValid`, `AllInvalid`) or a boolean array that may itself be
+//! encoded. [`Scalar`](crate::scalar::Scalar) is the single-value counterpart: it pairs a
+//! [`DType`](crate::dtype::DType) with an optional [`ScalarValue`](crate::scalar::ScalarValue).
+//!
+//! # Extending Vortex
+//!
+//! New array encodings implement [`VTable`], usually through the local `array_slots!` and
+//! `vtable!` patterns used by built-ins. The important extension contracts are:
+//!
+//! - [`VTable::validate`] checks that externally supplied dtype, length, slots, and data agree.
+//! - [`VTable::execute`] returns an [`ExecutionResult`] that makes progress toward canonical form.
+//! - [`OperationsVTable`] provides scalar access.
+//! - [`ValidityVTable`] exposes validity only for nullable arrays.
+//!
+//! New logical extension dtypes implement [`ExtVTable`](crate::dtype::extension::ExtVTable) and
+//! store values in an ordinary Vortex storage dtype.
 
 extern crate self as vortex_array;
 

--- a/vortex-array/src/scalar/mod.rs
+++ b/vortex-array/src/scalar/mod.rs
@@ -5,9 +5,13 @@
 //!
 //! This crate provides scalar types and values that can be used to represent individual data
 //! elements in the Vortex array system. [`Scalar`]s are composed of a logical data type ([`DType`])
-//! and an optional (encoding nullablity) value ([`ScalarValue`]).
+//! and an optional (encoding nullability) value ([`ScalarValue`]).
 //!
 //! Note that the implementations of `Scalar` are split into several different modules.
+//!
+//! `Scalar` is the single-row counterpart to [`ArrayRef`](crate::ArrayRef): it is logical, not tied
+//! to any physical array encoding. A scalar always carries its [`DType`], and null scalars are
+//! represented by `value == None`.
 
 #[cfg(feature = "arbitrary")]
 pub mod arbitrary;

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -2,6 +2,11 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 //! Array validity and nullability behavior, used by arrays and compute functions.
+//!
+//! [`Validity`] describes which rows are logically present without forcing every array to carry a
+//! materialized boolean bitmap. Constant states (`NonNullable`, `AllValid`, `AllInvalid`) are cheap
+//! to clone and inspect. [`Validity::Array`] may itself be encoded or lazy, so APIs that need exact
+//! per-row answers take an [`ExecutionCtx`] and execute the validity array as needed.
 
 use std::fmt::Debug;
 use std::ops::Range;
@@ -34,14 +39,14 @@ use crate::scalar::Scalar;
 use crate::scalar_fn::fns::binary::Binary;
 use crate::scalar_fn::fns::operators::Operator;
 
-/// Validity information for an array
+/// Validity information for an array.
 #[derive(Clone)]
 pub enum Validity {
-    /// Items *can't* be null
+    /// Items cannot be null because the dtype is non-nullable.
     NonNullable,
-    /// All items are valid
+    /// The dtype is nullable, but every item is valid.
     AllValid,
-    /// All items are null
+    /// The dtype is nullable, and every item is null.
     AllInvalid,
     /// The validity of each position in the array is determined by a boolean array.
     ///

--- a/vortex-btrblocks/Cargo.toml
+++ b/vortex-btrblocks/Cargo.toml
@@ -13,6 +13,9 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 itertools = { workspace = true }
 num-traits = { workspace = true }

--- a/vortex-btrblocks/src/builder.rs
+++ b/vortex-btrblocks/src/builder.rs
@@ -77,10 +77,10 @@ pub const ALL_SCHEMES: &[&dyn Scheme] = &[
 
 /// Builder for creating configured [`BtrBlocksCompressor`] instances.
 ///
-/// By default, all schemes in [`ALL_SCHEMES`] are enabled. Feature-gated schemes (Pco, Zstd)
-/// are not in `ALL_SCHEMES` and must be added explicitly via
-/// [`with_scheme`](BtrBlocksCompressorBuilder::with_new_scheme) or
-/// [`with_compact`](BtrBlocksCompressorBuilder::with_compact).
+/// By default, all schemes in [`ALL_SCHEMES`] are enabled in a deterministic order. Feature-gated
+/// schemes (Pco, Zstd) are not in `ALL_SCHEMES` and must be added explicitly via
+/// [`with_new_scheme`](BtrBlocksCompressorBuilder::with_new_scheme) or `with_compact` when the
+/// `zstd` feature is enabled.
 ///
 /// # Examples
 ///
@@ -166,6 +166,9 @@ impl BtrBlocksCompressorBuilder {
     /// With the `unstable_encodings` feature, buffer-level Zstd compression is used which
     /// preserves the array buffer layout for zero-conversion GPU decompression. Without it,
     /// interleaved Zstd compression is used.
+    ///
+    /// This preset is intended for files that will be decoded by CUDA kernels. It may choose a
+    /// larger encoded representation than the default compressor.
     pub fn only_cuda_compatible(self) -> Self {
         // String fragmentation schemes (OnPair, FSST) require host-side
         // dictionary expansion at decode time, which is incompatible with

--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -40,16 +40,28 @@
 //! # Example
 //!
 //! ```rust
+//! use vortex_array::{IntoArray, VortexSessionExecute, array_session};
+//! use vortex_array::arrays::PrimitiveArray;
+//! use vortex_array::validity::Validity;
 //! use vortex_btrblocks::{BtrBlocksCompressor, BtrBlocksCompressorBuilder, Scheme, SchemeExt};
 //! use vortex_btrblocks::schemes::integer::IntDictScheme;
+//! use vortex_buffer::buffer;
 //!
-//! // Default compressor with all schemes enabled.
+//! # fn example() -> vortex_error::VortexResult<()> {
+//! let session = array_session();
+//! let array = PrimitiveArray::new(buffer![42u64; 1024], Validity::NonNullable).into_array();
+//!
 //! let compressor = BtrBlocksCompressor::default();
+//! let compressed = compressor.compress(&array, &mut session.create_execution_ctx())?;
+//! assert_eq!(compressed.dtype(), array.dtype());
 //!
 //! // Remove specific schemes using the builder.
 //! let compressor = BtrBlocksCompressorBuilder::default()
 //!     .exclude_schemes([IntDictScheme.id()])
 //!     .build();
+//! # let _ = compressor;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! [BtrBlocks]: https://www.cs.cit.tum.de/fileadmin/w00cfj/dis/papers/btrblocks.pdf

--- a/vortex-btrblocks/src/schemes/integer/delta.rs
+++ b/vortex-btrblocks/src/schemes/integer/delta.rs
@@ -43,7 +43,7 @@ pub struct DeltaScheme {
 }
 
 impl DeltaScheme {
-    /// Creates a Delta scheme requiring `min_ratio` (after the [`DELTA_PENALTY`]) before it wins.
+    /// Creates a Delta scheme requiring `min_ratio` after the delta penalty before it wins.
     ///
     /// Pass a higher ratio to make Delta more conservative, or a lower one to select it more
     /// eagerly. [`DeltaScheme::default`] uses a ratio of `1.25`.

--- a/vortex-compressor/src/compressor.rs
+++ b/vortex-compressor/src/compressor.rs
@@ -75,6 +75,9 @@ mod root_list_children {
 ///
 /// No scheme may appear twice in a cascade chain. The compressor enforces this automatically
 /// along with push/pull exclusion rules declared by each scheme.
+///
+/// Downstream crates usually wrap this type with a preconfigured scheme set. Use it directly when
+/// embedding a custom fixed scheme list or testing scheme interactions.
 #[derive(Debug, Clone)]
 pub struct CascadingCompressor {
     /// The enabled compression schemes.

--- a/vortex-compressor/src/lib.rs
+++ b/vortex-compressor/src/lib.rs
@@ -16,6 +16,31 @@
 //! This crate contains no encoding dependencies. Batteries-included compressors are provided by
 //! downstream crates like `vortex-btrblocks`, which register different encodings to the compressor.
 //!
+//! # Example
+//!
+//! A [`CascadingCompressor`] can be created directly with a fixed scheme list. With no schemes it
+//! still canonicalizes supported inputs and recursively handles nested structure, but no leaf
+//! compression is selected.
+//!
+//! ```rust
+//! use vortex_array::{IntoArray, VortexSessionExecute, array_session};
+//! use vortex_array::arrays::PrimitiveArray;
+//! use vortex_array::validity::Validity;
+//! use vortex_buffer::buffer;
+//! use vortex_compressor::CascadingCompressor;
+//!
+//! # fn example() -> vortex_error::VortexResult<()> {
+//! let session = array_session();
+//! let array = PrimitiveArray::new(buffer![1i32, 2, 3], Validity::NonNullable).into_array();
+//! let compressor = CascadingCompressor::new(Vec::new());
+//!
+//! let result = compressor.compress(&array, &mut session.create_execution_ctx())?;
+//! assert_eq!(result.dtype(), array.dtype());
+//! assert_eq!(result.len(), array.len());
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! # Observability
 //!
 //! The compressor emits a small set of `tracing` spans and events on a single target so you can

--- a/vortex-compressor/src/scheme.rs
+++ b/vortex-compressor/src/scheme.rs
@@ -139,6 +139,10 @@ pub struct AncestorExclusion {
 /// to declare what they require. The compressor merges all eligible schemes' options before
 /// generating stats, so each stat is always computed at most once for a given array.
 ///
+/// A scheme implementation should be deterministic for a fixed input array and context. The
+/// compressor uses scheme order for deterministic tie-breaking, so non-deterministic estimates make
+/// compressed output harder to reproduce and compare.
+///
 /// [`scheme_name`]: Scheme::scheme_name
 /// [`matches`]: Scheme::matches
 /// [`compress`]: Scheme::compress

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -82,7 +82,10 @@ impl VortexFile {
         }
     }
 
-    /// Enable layout reader caching
+    /// Enable layout reader caching.
+    ///
+    /// Repeated calls to [`layout_reader`](Self::layout_reader), [`scan`](Self::scan), and
+    /// [`data_source`](Self::data_source) will share the same reader tree.
     pub fn with_caching(self) -> Self {
         Self {
             footer: self.footer,
@@ -170,7 +173,8 @@ impl VortexFile {
         )))
     }
 
-    /// Initiate a scan of the file, returning a builder for configuring the scan.
+    /// Initiate a scan of the file, returning a builder for projection, filtering, selection, and
+    /// execution options.
     pub fn scan(&self) -> VortexResult<ScanBuilder<ArrayRef>> {
         Ok(ScanBuilder::new(
             self.session.clone(),
@@ -202,6 +206,9 @@ impl VortexFile {
         )
     }
 
+    /// Return the file's natural row splits as root-coordinate ranges.
+    ///
+    /// These are the ranges that [`SplitBy::Layout`] would use for an all-fields scan.
     pub fn splits(&self) -> VortexResult<Vec<Range<u64>>> {
         let reader = self.layout_reader()?;
         Ok(SplitBy::Layout

--- a/vortex-file/src/footer/deserializer.rs
+++ b/vortex-file/src/footer/deserializer.rs
@@ -23,6 +23,11 @@ use crate::footer::postscript::PostscriptSegment;
 
 /// Deserialize a footer from the end of a Vortex file or created from a
 /// [`crate::footer::FooterSerializer`].
+///
+/// The deserializer is incremental because callers may initially read only the tail of a file. Call
+/// [`deserialize`](Self::deserialize) until it returns [`DeserializeStep::Done`]. If it asks for
+/// [`DeserializeStep::NeedMoreData`], prefix the requested bytes with [`prefix_data`](Self::prefix_data).
+/// If it asks for [`DeserializeStep::NeedFileSize`], call [`with_size`](Self::with_size) and retry.
 pub struct FooterDeserializer {
     // A buffer representing the end of a Vortex file.
     // During deserialization, we may need to expand this buffer by requesting more data from
@@ -52,21 +57,27 @@ impl FooterDeserializer {
         }
     }
 
+    /// Provide the file dtype externally.
+    ///
+    /// This is required for files written with [`VortexWriteOptions::exclude_dtype`](crate::VortexWriteOptions::exclude_dtype).
     pub fn with_dtype(mut self, dtype: DType) -> Self {
         self.dtype = Some(dtype);
         self
     }
 
+    /// Provide or clear the externally known file dtype.
     pub fn with_some_dtype(mut self, dtype: Option<DType>) -> Self {
         self.dtype = dtype;
         self
     }
 
+    /// Provide the total file size.
     pub fn with_size(mut self, file_size: u64) -> Self {
         self.file_size = Some(file_size);
         self
     }
 
+    /// Provide or clear the total file size.
     pub fn with_some_size(mut self, file_size: Option<u64>) -> Self {
         self.file_size = file_size;
         self
@@ -80,6 +91,9 @@ impl FooterDeserializer {
         self.buffer = buffer.freeze();
     }
 
+    /// Advance footer deserialization.
+    ///
+    /// Returns the next missing input requirement or the finished [`Footer`].
     pub fn deserialize(&mut self) -> VortexResult<DeserializeStep> {
         let postscript = if let Some(postscript) = &self.postscript {
             postscript
@@ -263,9 +277,17 @@ impl FooterDeserializer {
 }
 
 #[derive(Debug)]
+/// Result of one [`FooterDeserializer::deserialize`] step.
 pub enum DeserializeStep {
-    // The offset and length of additional data needed to continue deserialization.
-    NeedMoreData { offset: u64, len: usize },
+    /// Additional data needed to continue deserialization.
+    NeedMoreData {
+        /// Absolute file offset to read from.
+        offset: u64,
+        /// Number of bytes to read and prefix into the deserializer.
+        len: usize,
+    },
+    /// The total file size is required before offsets can be resolved.
     NeedFileSize,
+    /// Footer deserialization is complete.
     Done(Footer),
 }

--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! This module defines the footer of a Vortex file, which contains metadata about the file's contents.
+//! Vortex file footer metadata.
 //!
-//! The footer includes:
-//! - The file's layout, which describes how the data is organized
-//! - Statistics about the data, which can be used for query optimization
-//! - Segment map, which describe the physical location of data in the file
+//! A footer contains the root layout, file-level statistics, the segment map, and the read contexts
+//! needed to resolve array/layout encoding ids during deserialization.
 //!
-//! The footer is located at the end of the file and is used to interpret the file's contents.
+//! The byte-level footer and postscript layout is part of the file-format spec; this module exposes
+//! the structured Rust representation and serializer/deserializer state machine.
 mod file_layout;
 mod file_statistics;
 mod postscript;

--- a/vortex-file/src/footer/serializer.rs
+++ b/vortex-file/src/footer/serializer.rs
@@ -23,6 +23,7 @@ use crate::footer::file_layout::FooterFlatBufferWriter;
 use crate::footer::postscript::Postscript;
 use crate::footer::postscript::PostscriptSegment;
 
+/// Serializes a [`Footer`] into footer buffers and the trailing postscript/EOF marker.
 pub struct FooterSerializer {
     footer: Footer,
     exclude_dtype: bool,

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -11,7 +11,7 @@
 //! statistics, or other writer-chosen structures without changing the logical dtype seen by
 //! readers.
 //!
-//! This crate owns the file reader/writer APIs. The byte-level format lives in the Sphinx docs:
+//! This crate owns the file reader/writer APIs. The byte-level format lives in the spec's docs:
 //! <https://docs.vortex.dev/specs/file-format.html>.
 //!
 //! # Reading

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -6,13 +6,27 @@
 //! Read and write Vortex layouts, a serialization of Vortex arrays.
 //!
 //! A Vortex file stores a root [`Layout`](vortex_layout::Layout), the byte segments referenced by
-//! that layout, optional file-level statistics, and enough footer metadata to deserialize the tree.
-//! Layouts are recursive, so a file may organize data by row groups, columns, dictionaries,
-//! statistics, or other writer-chosen structures without changing the logical dtype seen by
-//! readers.
+//! that layout, an optional file-level [`DType`](vortex_array::dtype::DType) and statistics, and
+//! enough footer metadata to deserialize the tree. Layouts are recursive, so a file may organize
+//! data by row groups, columns, dictionaries, statistics, or other writer-chosen structures without
+//! changing the logical dtype seen by readers. The built-in layouts are:
 //!
-//! This crate owns the file reader/writer APIs. The byte-level format lives in the spec's docs:
-//! <https://docs.vortex.dev/specs/file-format.html>.
+//! - [`FlatLayout`](vortex_layout::layouts::flat::FlatLayout): a single contiguously serialized
+//!   array of buffers with a specific in-memory [`Alignment`](vortex_buffer::Alignment).
+//! - [`StructLayout`](vortex_layout::layouts::struct_::StructLayout): each column laid out at known
+//!   offsets, permitting a subset of columns to be read in linear time with constant-time random
+//!   access to any column.
+//! - [`ChunkedLayout`](vortex_layout::layouts::chunked::ChunkedLayout): each chunk laid out at known
+//!   offsets; locating the chunks covering a row range is an `N log(N)` search of the offsets.
+//! - [`DictLayout`](vortex_layout::layouts::dict::DictLayout): a shared dictionary of values with a
+//!   child layout holding indices.
+//! - [`ZonedLayout`](vortex_layout::layouts::zoned::ZonedLayout): a zone-map of statistics used for
+//!   filter pruning.
+//!
+//! A layout alone is _not_ a standalone Vortex file: it is not self-describing, so the file pairs it
+//! with the dtype and footer metadata needed to deserialize it. This crate owns the file
+//! reader/writer APIs; the byte-level format is described under [File Format](#file-format) below
+//! and specified in full in the docs: <https://docs.vortex.dev/specs/file-format.html>.
 //!
 //! # Reading
 //!
@@ -36,6 +50,46 @@
 //! repartitions rows, builds statistics layouts, dictionary-encodes suitable columns, compresses
 //! chunks with the BtrBlocks-style compressor, and writes flat leaf layouts. Advanced users can
 //! replace the whole strategy or override individual fields.
+//!
+//! # File Format
+//!
+//! A Vortex file begins and ends with the 4-byte magic `VTXF`. Data segments are written first, in
+//! writer-chosen order, followed by the footer flatbuffers, a postscript, and an 8-byte
+//! end-of-file marker:
+//!
+//! ```text
+//! ┌────────────────────────────┐
+//! │     Magic bytes 'VTXF'     │  4 bytes
+//! ├────────────────────────────┤
+//! │          Segments          │  serialized array chunks and per-column
+//! │     (data & statistics)    │  statistics, in writer-chosen order
+//! ├────────────────────────────┤
+//! │      DType flatbuffer      │  optional; omitted via `exclude_dtype`
+//! ├────────────────────────────┤
+//! │      Layout flatbuffer     │  required; the root Layout tree
+//! ├────────────────────────────┤
+//! │    Statistics flatbuffer   │  optional; file-level per-field statistics
+//! ├────────────────────────────┤
+//! │      Footer flatbuffer     │  required; dictionary-encoded segment map
+//! │                            │  and array/layout/compression/encryption specs
+//! ├────────────────────────────┤
+//! │         Postscript         │  offsets of the four footer segments above;
+//! │                            │  at most 65528 bytes
+//! ├────────────────────────────┤
+//! │     8-byte End of File     │  u16 version, u16 postscript length,
+//! │                            │  4 magic bytes 'VTXF'
+//! └────────────────────────────┘
+//! ```
+//!
+//! The postscript records the offset, length, and alignment of the dtype, layout, statistics, and
+//! footer segments, so a single read of the file tail (defaulting to 64KiB) is enough to locate and
+//! parse the footer. The byte-level format is specified in full at
+//! <https://docs.vortex.dev/specs/file-format.html>.
+//!
+//! A Parquet-style file is realized by nesting a chunked layout of struct layouts of chunked layouts
+//! of flat layouts: the outer chunked layout models row groups and the inner one models pages.
+//! Layouts are adaptive, so the writer is free to build arbitrarily complex layouts to trade off
+//! locality and parallelism, or to elide statistics entirely when an external index supplies them.
 //!
 //! # Footer Deserialization
 //!

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -5,89 +5,43 @@
 #![doc(html_logo_url = "/vortex/docs/_static/vortex_spiral_logo.svg")]
 //! Read and write Vortex layouts, a serialization of Vortex arrays.
 //!
-//! A layout is a serialized array which is stored in some linear and contiguous block of
-//! memory. Layouts are recursive, and there are currently three types:
+//! A Vortex file stores a root [`Layout`](vortex_layout::Layout), the byte segments referenced by
+//! that layout, optional file-level statistics, and enough footer metadata to deserialize the tree.
+//! Layouts are recursive, so a file may organize data by row groups, columns, dictionaries,
+//! statistics, or other writer-chosen structures without changing the logical dtype seen by
+//! readers.
 //!
-//! 1. The [`FlatLayout`](vortex_layout::layouts::flat::FlatLayout). A contiguously serialized array of buffers, with a specific in-memory [`Alignment`](vortex_buffer::Alignment).
-//!
-//! 2. The [`StructLayout`](vortex_layout::layouts::struct_::StructLayout). Each column of a
-//!    [`StructArray`][vortex_array::arrays::StructArray] is sequentially laid out at known offsets.
-//!    This permits reading a subset of columns in linear time, as well as constant-time random
-//!    access to any column.
-//!
-//! 3. The [`ChunkedLayout`](vortex_layout::layouts::chunked::ChunkedLayout). Each chunk of a
-//!    [`ChunkedArray`](vortex_array::arrays::ChunkedArray) is sequentially laid out at known
-//!    offsets. Finding the chunks containing row range is an `Nlog(N)` operation of searching the
-//!    offsets.
-//!
-//! 4. The [`ZonedLayout`](vortex_layout::layouts::zoned::ZonedLayout).
-//!
-//! A layout, alone, is _not_ a standalone Vortex file because layouts are not self-describing. They
-//! neither contain a description of the kind of layout (e.g. flat, column of flat, chunked of
-//! column of flat) nor a data type ([`DType`](vortex_array::dtype::DType)).
+//! This crate owns the file reader/writer APIs. The byte-level format lives in the Sphinx docs:
+//! <https://docs.vortex.dev/specs/file-format.html>.
 //!
 //! # Reading
 //!
-//! Vortex files are read using [`VortexOpenOptions`], which can be provided with information about the file's
-//! structure to save on IO before the actual data read. Once the file is open and has done the initial IO work to understand its own structure,
-//! it can be turned into a stream by calling [`VortexFile::scan`].
+//! Use [`OpenOptionsSessionExt::open_options`] to create [`VortexOpenOptions`] from a session.
+//! Opening reads or accepts a footer, builds a segment source, and returns [`VortexFile`]. Scans are
+//! configured from [`VortexFile::scan`] with projection/filter expressions, row ranges,
+//! [`Selection`](vortex_scan::selection::Selection), split strategy, and concurrency settings from
+//! `vortex-layout`.
 //!
-//! The file manages IO-oriented work and CPU-oriented work on two different underlying runtimes, which are configurable and pluggable with multiple provided implementations (Tokio, Rayon etc.).
+//! Supplying known metadata can reduce open-time IO:
 //!
-//! # File Format
+//! - [`VortexOpenOptions::with_file_size`] avoids a size request.
+//! - [`VortexOpenOptions::with_dtype`] is required for files written without an embedded dtype.
+//! - [`VortexOpenOptions::with_footer`] can open a file without reading footer bytes.
+//! - [`VortexOpenOptions::with_segment_cache`] reuses segment buffers across scans.
 //!
-//! Succinctly, the file format specification is as follows:
+//! # Writing
 //!
-//! 1. Data is written first, in a form that is describable by a Layout (typically Array IPC Messages).
-//!    1. To allow for more efficient IO & pruning, our writer implementation first writes the "data" arrays,
-//!       and then writes the "metadata" arrays (i.e., per-column statistics)
-//! 2. We write what is collectively referred to as the "Footer", which contains:
-//!    1. An optional Schema, which if present is a valid flatbuffer representing a message::Schema
-//!    2. The Layout, which is a valid footer::Layout flatbuffer, and describes the physical byte ranges & relationships amongst
-//!       the those byte ranges that we wrote in part 1.
-//!    3. The Postscript, which is a valid footer::Postscript flatbuffer, containing the absolute start offsets of the Schema & Layout
-//!       flatbuffers within the file.
-//!    4. The End-of-File marker, which is 8 bytes, and contains the u16 version, u16 postscript length, and 4 magic bytes.
+//! Use [`WriteOptionsSessionExt::write_options`] or [`VortexWriteOptions::new`] to write an
+//! [`ArrayStream`](vortex_array::stream::ArrayStream). The default [`WriteStrategyBuilder`]
+//! repartitions rows, builds statistics layouts, dictionary-encodes suitable columns, compresses
+//! chunks with the BtrBlocks-style compressor, and writes flat leaf layouts. Advanced users can
+//! replace the whole strategy or override individual fields.
 //!
-//! ## Illustrated File Format
-//! ```text
-//! ┌────────────────────────────┐
-//! │                            │
-//! │            Data            │
-//! │    (Array IPC Messages)    │
-//! │                            │
-//! ├────────────────────────────┤
-//! │                            │
-//! │   Per-Column Statistics    │
-//! │                            │
-//! ├────────────────────────────┤
-//! │                            │
-//! │     Schema Flatbuffer      │
-//! │                            │
-//! ├────────────────────────────┤
-//! │                            │
-//! │     Layout Flatbuffer      │
-//! │                            │
-//! ├────────────────────────────┤
-//! │                            │
-//! │    Postscript Flatbuffer   │
-//! │  (Schema & Layout Offsets) │
-//! │                            │
-//! ├────────────────────────────┤
-//! │     8-byte End of File     │
-//! │(Version, Postscript Length,│
-//! │       Magic Bytes)         │
-//! └────────────────────────────┘
-//! ```
+//! # Footer Deserialization
 //!
-//! A Parquet-style file format is realized by using a chunked layout containing column layouts
-//! containing chunked layouts containing flat layouts. The outer chunked layout represents row
-//! groups. The inner chunked layout represents pages.
-//!
-//! Layouts are adaptive, and the writer is free to build arbitrarily complex layouts to suit their
-//! goals of locality or parallelism. For example, one may write a column in a Struct Layout with
-//! or without chunking, or completely elide statistics to save space or if they are not needed, for
-//! example if the metadata is being stored in an external index.
+//! [`FooterDeserializer`] supports incremental footer reads. It returns [`DeserializeStep`] values
+//! when it needs more bytes or a file size, and returns [`Footer`] once all required footer segments
+//! are available. [`VortexOpenOptions`] drives this state machine for ordinary file opens.
 
 mod counting;
 mod file;
@@ -96,10 +50,12 @@ pub mod multi;
 mod open;
 mod pruning;
 mod read;
+/// Segment sources, caches, and sinks used by file readers and writers.
 pub mod segments;
 mod strategy;
 #[cfg(test)]
 mod tests;
+/// Compatibility readers for newer file-statistics layout behavior.
 pub mod v2;
 mod writer;
 

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -41,6 +41,12 @@ use crate::segments::RequestMetrics;
 const INITIAL_READ_SIZE: usize = MAX_POSTSCRIPT_SIZE as usize + EOF_SIZE;
 
 /// Open options for a Vortex file reader.
+///
+/// Options are session-bound because opening a file may need array, layout, dtype, runtime, and
+/// memory registries. Construct with [`OpenOptionsSessionExt::open_options`] for the common path.
+///
+/// The opener first resolves a [`Footer`], then creates a segment source for later scans. Known
+/// file metadata can be supplied up front to avoid IO during footer discovery.
 pub struct VortexOpenOptions {
     /// The session to use for opening the file.
     session: VortexSession,
@@ -64,6 +70,7 @@ pub struct VortexOpenOptions {
     cache_layout_reader: bool,
 }
 
+/// Extension trait for constructing [`VortexOpenOptions`] from a session.
 pub trait OpenOptionsSessionExt:
     ArraySessionExt + LayoutSessionExt + RuntimeSessionExt + MemorySessionExt
 {
@@ -89,19 +96,29 @@ impl<S: ArraySessionExt + LayoutSessionExt + RuntimeSessionExt + MemorySessionEx
 }
 
 impl VortexOpenOptions {
-    /// Configure the initial read size for the Vortex file.
+    /// Configure how many bytes to read from the end of the file before parsing the footer.
+    ///
+    /// The actual read is at least large enough to contain the maximum postscript and EOF marker,
+    /// and no larger than the file. Increase this when you expect footer segments to be near the
+    /// end and want to avoid a second footer read.
     pub fn with_initial_read_size(mut self, initial_read_size: usize) -> Self {
         self.initial_read_size = initial_read_size;
         self
     }
 
-    /// Cache file's LayoutReader between scans
+    /// Cache the file's [`LayoutReader`](vortex_layout::LayoutReader) between scans.
+    ///
+    /// This avoids rebuilding the reader tree for repeated scans of the same [`VortexFile`], at the
+    /// cost of keeping reader state alive for the lifetime of the file handle.
     pub fn with_layout_reader_cache(mut self) -> Self {
         self.cache_layout_reader = true;
         self
     }
 
     /// Configure a custom [`SegmentCache`].
+    ///
+    /// The cache is checked before the underlying file segment source. Segments covered by the
+    /// initial footer read are also inserted into an internal first-read cache.
     pub fn with_segment_cache(mut self, segment_cache: Arc<dyn SegmentCache>) -> Self {
         self.segment_cache = Some(segment_cache);
         self
@@ -135,7 +152,7 @@ impl VortexOpenOptions {
         self
     }
 
-    /// Configure a known file layout.
+    /// Configure a known file footer.
     ///
     /// If this is provided, then the Vortex file can be opened without performing any I/O.
     /// Once open, the [`Footer`] can be accessed via [`crate::VortexFile::footer`].
@@ -181,6 +198,8 @@ impl VortexOpenOptions {
     ///
     /// This uses a `BufferSegmentSource` that resolves segments synchronously
     /// by slicing the buffer directly, bypassing the async I/O pipeline.
+    ///
+    /// Segment cache and metrics registry settings are ignored for this path.
     pub fn open_buffer<B: Into<ByteBuffer>>(self, buffer: B) -> VortexResult<VortexFile> {
         let buffer: ByteBuffer = buffer.into();
 
@@ -211,7 +230,9 @@ impl VortexOpenOptions {
         })
     }
 
-    /// An API for opening a [`VortexFile`] using any [`VortexReadAt`] implementation.
+    /// Open a [`VortexFile`] using any [`VortexReadAt`] implementation.
+    ///
+    /// This is the common path for files, object stores, and custom random-access sources.
     pub async fn open_read<R: VortexReadAt + Clone>(self, reader: R) -> VortexResult<VortexFile> {
         let segment_cache = self
             .segment_cache
@@ -339,6 +360,7 @@ impl VortexOpenOptions {
 
 #[cfg(feature = "object_store")]
 impl VortexOpenOptions {
+    /// Open a Vortex file from an `object_store` backend and path.
     pub async fn open_object_store(
         self,
         object_store: &Arc<dyn object_store::ObjectStore>,

--- a/vortex-file/src/segments/cache.rs
+++ b/vortex-file/src/segments/cache.rs
@@ -13,7 +13,9 @@ use vortex_utils::aliases::hash_map::HashMap;
 
 /// Segment cache containing the initial read segments.
 pub struct InitialReadSegmentCache {
+    /// Segments that were already covered by the footer initial read.
     pub initial: RwLock<HashMap<SegmentId, ByteBuffer>>,
+    /// Delegate cache used for all misses and stores.
     pub fallback: Arc<dyn SegmentCache>,
 }
 

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -36,9 +36,13 @@ use crate::read::ReadRequest;
 use crate::read::RequestId;
 
 #[derive(Debug)]
+/// Events sent from segment futures to the coalescing read driver.
 pub enum ReadEvent {
+    /// A segment read has been registered.
     Request(ReadRequest),
+    /// A registered read future has been polled.
     Polled(RequestId),
+    /// A registered read future was dropped before completion.
     Dropped(RequestId),
 }
 
@@ -72,6 +76,10 @@ pub struct FileSegmentSource {
 }
 
 impl FileSegmentSource {
+    /// Open a file-backed segment source over `reader`.
+    ///
+    /// The returned source spawns a background driver on `handle` that coalesces and executes
+    /// random-access read requests.
     pub fn open<R: VortexReadAt + Clone>(
         segments: Arc<[SegmentSpec]>,
         reader: R,
@@ -244,13 +252,18 @@ impl Drop for ReadFuture {
     }
 }
 
+/// Metrics emitted by the file segment request driver.
 pub struct RequestMetrics {
+    /// Number of individual segment requests observed by the driver.
     pub individual_requests: Counter,
+    /// Number of physical reads after coalescing.
     pub coalesced_requests: Counter,
+    /// Distribution of how many segment requests were merged into each physical read.
     pub num_requests_coalesced: Histogram,
 }
 
 impl RequestMetrics {
+    /// Create request metrics in `metrics_registry` with shared labels.
     pub fn new(metrics_registry: &dyn MetricsRegistry, labels: Vec<Label>) -> Self {
         Self {
             individual_requests: MetricBuilder::new(metrics_registry)

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -143,6 +143,11 @@ enum CompressorConfig {
 /// Vortex provides an out-of-the-box file writer that optimizes the layout of chunks on-disk,
 /// repartitioning and compressing them to strike a balance between size on-disk,
 /// bulk decoding performance, and IOPS required to perform an indexed read.
+///
+/// The default pipeline first splits struct columns, repartitions rows into fixed-size row blocks,
+/// computes zoned statistics, applies dictionary encoding where useful, coalesces chunks toward
+/// segment-sized blocks, compresses arrays, buffers nearby chunks, and finally writes flat leaf
+/// layouts.
 pub struct WriteStrategyBuilder {
     compressor: CompressorConfig,
     row_block_size: usize,
@@ -166,14 +171,19 @@ impl Default for WriteStrategyBuilder {
 }
 
 impl WriteStrategyBuilder {
-    /// Override the row block size used to determine the zone map sizes.
+    /// Override the row block size used for row repartitioning and zoned statistics.
+    ///
+    /// Larger blocks reduce footer/statistics overhead. Smaller blocks can improve pruning and
+    /// random-access locality.
     pub fn with_row_block_size(mut self, row_block_size: usize) -> Self {
         self.row_block_size = row_block_size;
         self
     }
 
-    /// Override the default write layout for a specific field somewhere in the nested
-    /// schema tree.
+    /// Override the write layout for a specific field somewhere in the nested schema tree.
+    ///
+    /// The field path is matched after the root struct is split into columns. This is useful when a
+    /// column needs a custom compression/layout policy while the rest of the file uses defaults.
     pub fn with_field_writer(
         mut self,
         field: impl Into<FieldPath>,
@@ -184,6 +194,9 @@ impl WriteStrategyBuilder {
     }
 
     /// Override the allowed array encodings for normalization.
+    ///
+    /// The flat leaf writer uses this set when deciding whether an existing encoded array can be
+    /// written as-is or must be normalized before serialization.
     pub fn with_allow_encodings(mut self, allow_encodings: HashSet<ArrayId>) -> Self {
         self.allow_encodings = Some(allow_encodings);
         self
@@ -209,7 +222,8 @@ impl WriteStrategyBuilder {
 
     /// Set the compressor to an opaque [`CompressorPlugin`].
     ///
-    /// The compressor is used as-is for both data and stats compression.
+    /// The compressor is used as-is for both data and stats compression. Use this when the
+    /// compressor is already fully configured and should not be modified by the builder.
     pub fn with_compressor<C: CompressorPlugin>(mut self, compressor: C) -> Self {
         self.compressor = CompressorConfig::Opaque(Arc::new(compressor));
         self

--- a/vortex-file/src/v2/file_stats_reader.rs
+++ b/vortex-file/src/v2/file_stats_reader.rs
@@ -82,6 +82,7 @@ impl FileStatsLayoutReader {
         )
     }
 
+    /// Returns the file-level statistics used by this reader.
     pub fn file_stats(&self) -> &FileStatistics {
         &self.file_stats
     }

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -61,6 +61,9 @@ use crate::segments::writer::BufferedSegmentSink;
 ///
 /// Unless overridden, the default [write strategy][crate::WriteStrategyBuilder] will be used with no
 /// additional configuration.
+///
+/// Construct with [`WriteOptionsSessionExt::write_options`] for normal use so the writer inherits
+/// the session's runtime, array registry, and memory configuration.
 pub struct VortexWriteOptions {
     session: VortexSession,
     strategy: Arc<dyn LayoutStrategy>,
@@ -69,6 +72,7 @@ pub struct VortexWriteOptions {
     file_statistics: Vec<Stat>,
 }
 
+/// Extension trait for constructing [`VortexWriteOptions`] from a session.
 pub trait WriteOptionsSessionExt: SessionExt {
     /// Create [`VortexWriteOptions`] for writing to a Vortex file.
     fn write_options(&self) -> VortexWriteOptions {
@@ -97,6 +101,10 @@ impl VortexWriteOptions {
     }
 
     /// Replace the default layout strategy with the provided one.
+    ///
+    /// The strategy controls repartitioning, statistics layout, compression, and leaf segment
+    /// emission. Use [`WriteStrategyBuilder`] when only a small part of the default strategy needs
+    /// customization.
     pub fn with_strategy(mut self, strategy: Arc<dyn LayoutStrategy>) -> Self {
         self.strategy = strategy;
         self
@@ -110,7 +118,9 @@ impl VortexWriteOptions {
         self
     }
 
-    /// Configure which statistics to compute at the file-level.
+    /// Configure which statistics to compute at the file level.
+    ///
+    /// Pass an empty vector to omit file-level statistics.
     pub fn with_file_statistics(mut self, file_statistics: Vec<Stat>) -> Self {
         self.file_statistics = file_statistics;
         self
@@ -119,6 +129,9 @@ impl VortexWriteOptions {
 
 impl VortexWriteOptions {
     /// Drop into the blocking writer API using the given runtime.
+    ///
+    /// The returned adapter drives async writer internals on `runtime` while accepting ordinary
+    /// [`std::io::Write`] sinks and [`ArrayIterator`] inputs.
     pub fn blocking<B: BlockingRuntime>(self, runtime: &B) -> BlockingWrite<'_, B> {
         BlockingWrite {
             options: self,
@@ -252,6 +265,9 @@ impl VortexWriteOptions {
     }
 
     /// Create a push-based [`Writer`] that can be used to incrementally write arrays to the file.
+    ///
+    /// Each pushed chunk must have dtype `dtype`. Call [`Writer::finish`] to close the input stream,
+    /// flush remaining buffers, and receive the [`WriteSummary`].
     pub fn writer<'w, W: VortexWrite + Unpin + 'w>(self, write: W, dtype: DType) -> Writer<'w> {
         // Create a channel for sending arrays to the layout task.
         let (arrays_send, arrays_recv) = kanal::bounded_async(1);
@@ -385,7 +401,7 @@ impl Writer<'_> {
     }
 }
 
-/// A blocking API for writing Vortex files.
+/// Blocking adapter for [`VortexWriteOptions`].
 pub struct BlockingWrite<'rt, B: BlockingRuntime> {
     options: VortexWriteOptions,
     runtime: &'rt B,
@@ -393,6 +409,9 @@ pub struct BlockingWrite<'rt, B: BlockingRuntime> {
 
 impl<'rt, B: BlockingRuntime> BlockingWrite<'rt, B> {
     /// Write a Vortex file into the given `Write` sink.
+    ///
+    /// The iterator is converted to an [`ArrayStream`](vortex_array::stream::ArrayStream) and
+    /// driven to completion on the configured blocking runtime.
     pub fn write<W: Write + Unpin>(
         self,
         write: W,
@@ -405,6 +424,7 @@ impl<'rt, B: BlockingRuntime> BlockingWrite<'rt, B> {
         })
     }
 
+    /// Create a blocking push-based writer for chunks with dtype `dtype`.
     pub fn writer<'w, W: Write + Unpin + 'w>(
         self,
         write: W,
@@ -424,18 +444,22 @@ pub struct BlockingWriter<'rt, 'w, B: BlockingRuntime> {
 }
 
 impl<B: BlockingRuntime> BlockingWriter<'_, '_, B> {
+    /// Push one array chunk into the file.
     pub fn push(&mut self, chunk: ArrayRef) -> VortexResult<()> {
         self.runtime.block_on(self.writer.push(chunk))
     }
 
+    /// Returns the number of bytes written to the sink so far.
     pub fn bytes_written(&self) -> u64 {
         self.writer.bytes_written()
     }
 
+    /// Returns the number of bytes currently buffered by layout strategies.
     pub fn buffered_bytes(&self) -> u64 {
         self.writer.buffered_bytes()
     }
 
+    /// Finish writing and return the written file summary.
     pub fn finish(self) -> VortexResult<WriteSummary> {
         self.runtime.block_on(self.writer.finish())
     }
@@ -459,6 +483,7 @@ impl<W: Write + Unpin> VortexWrite for BlockingWriteAdapter<W> {
     }
 }
 
+/// Summary returned after a Vortex file is written.
 pub struct WriteSummary {
     footer: Footer,
     size: u64,

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -410,8 +410,8 @@ pub struct BlockingWrite<'rt, B: BlockingRuntime> {
 impl<'rt, B: BlockingRuntime> BlockingWrite<'rt, B> {
     /// Write a Vortex file into the given `Write` sink.
     ///
-    /// The iterator is converted to an [`ArrayStream`](vortex_array::stream::ArrayStream) and
-    /// driven to completion on the configured blocking runtime.
+    /// The iterator is converted to an [`ArrayStream`] and driven to completion on
+    /// the configured blocking runtime.
     pub fn write<W: Write + Unpin>(
         self,
         write: W,

--- a/vortex-layout/src/encoding.rs
+++ b/vortex-layout/src/encoding.rs
@@ -23,13 +23,25 @@ use crate::segments::SegmentId;
 
 /// A unique identifier for a layout encoding.
 pub type LayoutEncodingId = Id;
+/// Shared reference to a registered layout encoding.
 pub type LayoutEncodingRef = ArcRef<dyn LayoutEncoding>;
 
+/// Object-safe layout encoding registered in a [`LayoutSession`](crate::session::LayoutSession).
+///
+/// Encoding instances deserialize serialized layout metadata into concrete [`LayoutRef`] nodes.
+/// New in-tree encodings usually implement [`VTable`] and use [`LayoutEncodingAdapter`], while
+/// foreign encodings can provide an object-safe implementation directly.
 pub trait LayoutEncoding: 'static + Send + Sync + Debug + private::Sealed {
+    /// Returns this encoding as [`Any`] for downcasting.
     fn as_any(&self) -> &dyn Any;
 
+    /// Returns the globally unique encoding id.
     fn id(&self) -> LayoutEncodingId;
 
+    /// Build a layout from serialized metadata, segment ids, and children.
+    ///
+    /// Implementations must use `build_ctx` for session-scoped plugin resolution instead of global
+    /// registries.
     fn build(
         &self,
         dtype: &DType,
@@ -41,6 +53,7 @@ pub trait LayoutEncoding: 'static + Send + Sync + Debug + private::Sealed {
     ) -> VortexResult<LayoutRef>;
 }
 
+/// Object-safe adapter from a typed layout [`VTable`] to [`LayoutEncoding`].
 #[repr(transparent)]
 pub struct LayoutEncodingAdapter<V: VTable>(V::Encoding);
 

--- a/vortex-layout/src/layout.rs
+++ b/vortex-layout/src/layout.rs
@@ -27,16 +27,25 @@ use crate::display::display_tree_with_segment_sizes;
 use crate::segments::SegmentId;
 use crate::segments::SegmentSource;
 
-/// A unique identifier for a layout.
+/// A unique identifier for a layout encoding.
 pub type LayoutId = Id;
 
+/// Shared, erased handle to a layout tree node.
 pub type LayoutRef = Arc<dyn Layout>;
 
+/// Erased layout tree node.
+///
+/// A layout is immutable metadata describing how row data is organized into child layouts and
+/// physical byte segments. It is self-describing only when paired with the session registries used
+/// to deserialize its encoding ids and the segment source used to read bytes.
 pub trait Layout: 'static + Send + Sync + Debug + private::Sealed {
+    /// Returns this layout as [`Any`] for downcasting through the `dyn Layout` helpers.
     fn as_any(&self) -> &dyn Any;
 
+    /// Converts an owned layout reference into erased [`Any`] for `Arc` downcasting.
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
 
+    /// Clone this layout as an erased [`LayoutRef`].
     fn to_layout(&self) -> LayoutRef;
 
     /// Returns the [`crate::LayoutEncoding`] for this layout.
@@ -45,23 +54,26 @@ pub trait Layout: 'static + Send + Sync + Debug + private::Sealed {
     /// The number of rows in this layout.
     fn row_count(&self) -> u64;
 
-    /// The dtype of this layout when projected with the root scope.
+    /// The logical dtype of this layout when evaluated at the root scope.
     fn dtype(&self) -> &DType;
 
     /// The number of children in this layout.
     fn nchildren(&self) -> usize;
 
     /// Get the child at the given index.
+    ///
+    /// Child ordering and meaning are encoding-specific and described by
+    /// [`child_type`](Self::child_type).
     fn child(&self, idx: usize) -> VortexResult<LayoutRef>;
 
     /// Get the relative row offset of the child at the given index, returning `None` for
     /// any auxiliary children, e.g. dictionary values, zone maps, etc.
     fn child_type(&self, idx: usize) -> LayoutChildType;
 
-    /// Get the metadata for this layout.
+    /// Serialize this layout's encoding metadata.
     fn metadata(&self) -> Vec<u8>;
 
-    /// Get the segment IDs for this layout.
+    /// Get the segment IDs directly referenced by this layout node.
     fn segment_ids(&self) -> Vec<SegmentId>;
 
     /// Construct a new reader for this layout.
@@ -87,6 +99,7 @@ pub trait Layout: 'static + Send + Sync + Debug + private::Sealed {
     ) -> VortexResult<LayoutReaderRef>;
 }
 
+/// Conversion into an erased [`LayoutRef`].
 pub trait IntoLayout {
     /// Converts this type into a [`LayoutRef`].
     fn into_layout(self) -> LayoutRef;

--- a/vortex-layout/src/lib.rs
+++ b/vortex-layout/src/lib.rs
@@ -1,6 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+//! Layout trees, layout readers, scan planning, and segment IO.
+//!
+//! A [`Layout`] is the serialized, row-counted representation of an array tree. It records logical
+//! dtype, child layout relationships, segment ids, and encoding metadata; it does not own the
+//! segment bytes. A [`LayoutReader`] pairs a layout with a [`SegmentSource`](segments::SegmentSource)
+//! and session so scans can evaluate projections and filters.
+//!
+//! Most users enter this crate through file APIs, but extension authors implement [`VTable`],
+//! [`LayoutEncoding`], and [`LayoutStrategy`] to add new on-disk organizations.
+//!
+//! Scanning is built with [`scan::scan_builder::ScanBuilder`]. It accepts a projection expression,
+//! optional filter, optional row range, [`Selection`](vortex_scan::selection::Selection), split
+//! strategy, and task concurrency settings, then produces array streams or iterators.
 pub mod layouts;
 
 pub use children::*;

--- a/vortex-layout/src/reader.rs
+++ b/vortex-layout/src/reader.rs
@@ -24,6 +24,7 @@ use crate::LayoutReaderContext;
 use crate::children::LayoutChildren;
 use crate::segments::SegmentSource;
 
+/// Shared handle to a stateful layout reader.
 pub type LayoutReaderRef = Arc<dyn LayoutReader>;
 
 /// A row range used when registering natural scan splits.
@@ -93,16 +94,16 @@ impl SplitRange {
     }
 }
 
-/// A collection of row split points
+/// A collection of root-coordinate row split points.
 pub struct RowSplits(Vec<u64>);
 
 impl RowSplits {
-    /// Add row to splits
+    /// Add a row boundary to the split set.
     pub fn push(&mut self, row: u64) {
         self.0.push(row);
     }
 
-    /// Reserve space for "additional" elements
+    /// Reserve space for additional row boundaries.
     pub fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional);
     }
@@ -120,12 +121,17 @@ impl RowSplits {
     }
 }
 
-/// A [`LayoutReader`] is used to read a [`crate::Layout`] in a way that can cache state across multiple
-/// evaluation operations.
+/// Stateful reader for a [`crate::Layout`].
+///
+/// A reader owns or references any state needed to evaluate many scan operations over the same
+/// layout, such as child readers, decoded metadata, or segment caches. Scan planning calls
+/// [`register_splits`](Self::register_splits); execution calls pruning, filter, and projection
+/// evaluation for each selected row range.
 pub trait LayoutReader: 'static + Send + Sync {
     /// Returns the name of the layout reader for debugging.
     fn name(&self) -> &Arc<str>;
 
+    /// Returns this reader as [`Any`] for downcasting by specialized wrappers.
     fn as_any(&self) -> &dyn Any;
 
     /// Returns the un-projected dtype of the layout reader.
@@ -134,7 +140,11 @@ pub trait LayoutReader: 'static + Send + Sync {
     /// Returns the number of rows in the layout.
     fn row_count(&self) -> u64;
 
-    /// Register the splits of this layout reader.
+    /// Register natural split boundaries for this reader.
+    ///
+    /// `field_mask` contains the projected and filtered field paths needed by the scan.
+    /// Implementations should add root-coordinate split boundaries to `splits`, constrained to
+    /// `split_range`.
     // TODO(ngates): this is a temporary API until we make layout readers stream based.
     fn register_splits(
         &self,
@@ -186,9 +196,12 @@ pub trait LayoutReader: 'static + Send + Sync {
     ) -> VortexResult<ArrayFuture>;
 }
 
+/// Future resolving to a projected Vortex array.
 pub type ArrayFuture = BoxFuture<'static, VortexResult<ArrayRef>>;
 
+/// Helpers for futures that resolve to arrays.
 pub trait ArrayFutureExt {
+    /// Apply a row mask to the resolved array.
     fn masked(self, mask: MaskFuture) -> Self;
 }
 
@@ -202,6 +215,7 @@ impl ArrayFutureExt for ArrayFuture {
     }
 }
 
+/// Lazily constructs and caches child readers while preserving reader context.
 pub struct LazyReaderChildren {
     children: Arc<dyn LayoutChildren>,
     dtypes: Vec<DType>,
@@ -214,6 +228,9 @@ pub struct LazyReaderChildren {
 }
 
 impl LazyReaderChildren {
+    /// Create a lazy child-reader cache.
+    ///
+    /// `dtypes` and `names` must be aligned with the child indices exposed by `children`.
     pub fn new(
         children: Arc<dyn LayoutChildren>,
         dtypes: Vec<DType>,
@@ -235,6 +252,7 @@ impl LazyReaderChildren {
         }
     }
 
+    /// Return the child reader at `idx`, constructing it on first access.
     pub fn get(&self, idx: usize) -> VortexResult<&LayoutReaderRef> {
         if idx >= self.cache.len() {
             vortex_bail!("Child index out of bounds: {} of {}", idx, self.cache.len());

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -45,7 +45,17 @@ use crate::scan::split_by::SplitBy;
 use crate::scan::splits::Splits;
 use crate::scan::splits::attempt_split_ranges;
 
-/// A struct for building a scan operation.
+/// Builder for scanning a [`LayoutReader`] into arrays, streams, iterators, or mapped outputs.
+///
+/// A scan has three independent row restriction mechanisms:
+///
+/// - [`with_row_range`](Self::with_row_range) selects a contiguous range before scanning.
+/// - [`with_selection`](Self::with_selection) applies a [`Selection`] inside that range.
+/// - [`with_filter`](Self::with_filter) evaluates an expression predicate during execution.
+///
+/// Projection and filter expressions are optimized against the reader dtype during
+/// [`prepare`](Self::prepare). Work is divided by the configured [`SplitBy`] strategy or by
+/// explicit selection ranges.
 pub struct ScanBuilder<A> {
     session: VortexSession,
     layout_reader: LayoutReaderRef,
@@ -75,6 +85,7 @@ pub struct ScanBuilder<A> {
 }
 
 impl ScanBuilder<ArrayRef> {
+    /// Create a scan builder over `layout_reader` using `session` for runtime and execution state.
     pub fn new(session: VortexSession, layout_reader: Arc<dyn LayoutReader>) -> Self {
         Self {
             session,
@@ -120,55 +131,66 @@ impl ScanBuilder<ArrayRef> {
 }
 
 impl<A: 'static + Send> ScanBuilder<A> {
+    /// Add a filter expression evaluated against the projected row ranges.
     pub fn with_filter(mut self, filter: Expression) -> Self {
         self.filter = Some(filter);
         self
     }
 
+    /// Add or clear the filter expression.
     pub fn with_some_filter(mut self, filter: Option<Expression>) -> Self {
         self.filter = filter;
         self
     }
 
+    /// Set the projection expression for returned rows.
     pub fn with_projection(mut self, projection: Expression) -> Self {
         self.projection = projection;
         self
     }
 
+    /// Returns whether output chunks are yielded in file order.
     pub fn ordered(&self) -> bool {
         self.ordered
     }
 
+    /// Configure whether output chunks must be yielded in file order.
     pub fn with_ordered(mut self, ordered: bool) -> Self {
         self.ordered = ordered;
         self
     }
 
+    /// Restrict scanning to a contiguous row range.
     pub fn with_row_range(mut self, row_range: Range<u64>) -> Self {
         self.row_range = Some(row_range);
         self
     }
 
+    /// Apply a row selection to the selected row range.
     pub fn with_selection(mut self, selection: Selection) -> Self {
         self.selection = selection;
         self
     }
 
+    /// Select rows by absolute indices relative to the scan input.
     pub fn with_row_indices(mut self, row_indices: Buffer<u64>) -> Self {
         self.selection = Selection::IncludeByIndex(row_indices);
         self
     }
 
+    /// Set the root row offset used by row-index expressions.
     pub fn with_row_offset(mut self, row_offset: u64) -> Self {
         self.row_offset = row_offset;
         self
     }
 
+    /// Configure how natural scan work is split for concurrency.
     pub fn with_split_by(mut self, split_by: SplitBy) -> Self {
         self.split_by = split_by;
         self
     }
 
+    /// Returns the per-worker row-split concurrency.
     pub fn concurrency(&self) -> usize {
         self.concurrency
     }
@@ -181,21 +203,25 @@ impl<A: 'static + Send> ScanBuilder<A> {
         self
     }
 
+    /// Add or clear the metrics registry used by scan execution.
     pub fn with_some_metrics_registry(mut self, metrics: Option<Arc<dyn MetricsRegistry>>) -> Self {
         self.metrics_registry = metrics;
         self
     }
 
+    /// Set the metrics registry used by scan execution.
     pub fn with_metrics_registry(mut self, metrics: Arc<dyn MetricsRegistry>) -> Self {
         self.metrics_registry = Some(metrics);
         self
     }
 
+    /// Add or clear the maximum number of rows returned after filtering.
     pub fn with_some_limit(mut self, limit: Option<u64>) -> Self {
         self.limit = limit;
         self
     }
 
+    /// Set the maximum number of rows returned after filtering.
     pub fn with_limit(mut self, limit: u64) -> Self {
         self.limit = Some(limit);
         self
@@ -235,6 +261,7 @@ impl<A: 'static + Send> ScanBuilder<A> {
         }
     }
 
+    /// Optimize expressions, compute split ranges, and return an executable repeated scan.
     pub fn prepare(self) -> VortexResult<RepeatedScan<A>> {
         let dtype = self.dtype()?;
 

--- a/vortex-layout/src/segments/cache.rs
+++ b/vortex-layout/src/segments/cache.rs
@@ -22,13 +22,19 @@ use crate::segments::SegmentFuture;
 use crate::segments::SegmentId;
 use crate::segments::SegmentSource;
 
-/// A cache for storing and retrieving individual segment data.
+/// Cache for individual segment byte buffers.
+///
+/// Caches are optional and operate above a [`SegmentSource`]. They should only store host buffers:
+/// device buffers and other non-host handles should be passed through uncached.
 #[async_trait]
 pub trait SegmentCache: Send + Sync {
+    /// Return a cached segment, or `None` on cache miss.
     async fn get(&self, id: SegmentId) -> VortexResult<Option<ByteBuffer>>;
+    /// Store a segment in the cache.
     async fn put(&self, id: SegmentId, buffer: ByteBuffer) -> VortexResult<()>;
 }
 
+/// Segment cache implementation that never stores anything.
 pub struct NoOpSegmentCache;
 
 #[async_trait]
@@ -46,6 +52,7 @@ impl SegmentCache for NoOpSegmentCache {
 pub struct MokaSegmentCache(Cache<SegmentId, ByteBuffer, FxBuildHasher>);
 
 impl MokaSegmentCache {
+    /// Construct a Moka-backed cache capped by total buffer bytes.
     pub fn new(max_capacity_bytes: u64) -> Self {
         Self(
             CacheBuilder::new(max_capacity_bytes)
@@ -85,6 +92,7 @@ pub struct InstrumentedSegmentCache<C> {
 }
 
 impl<C: SegmentCache> InstrumentedSegmentCache<C> {
+    /// Wrap a segment cache and record hit/miss/store metrics with the supplied labels.
     pub fn new(
         segment_cache: C,
         metrics_registry: &dyn MetricsRegistry,
@@ -124,12 +132,14 @@ impl<C: SegmentCache> SegmentCache for InstrumentedSegmentCache<C> {
     }
 }
 
+/// [`SegmentSource`] wrapper that consults a [`SegmentCache`] before the underlying source.
 pub struct SegmentCacheSourceAdapter {
     cache: Arc<dyn SegmentCache>,
     source: Arc<dyn SegmentSource>,
 }
 
 impl SegmentCacheSourceAdapter {
+    /// Construct a cache-fronted source.
     pub fn new(cache: Arc<dyn SegmentCache>, source: Arc<dyn SegmentSource>) -> Self {
         Self { cache, source }
     }

--- a/vortex-layout/src/segments/mod.rs
+++ b/vortex-layout/src/segments/mod.rs
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+//! Segment access abstractions for layouts.
+//!
+//! Layouts refer to byte ranges by [`SegmentId`]. A [`SegmentSource`] resolves those ids to buffer
+//! handles for readers, while a [`SegmentSink`] assigns ids when writers emit buffers.
+//! [`SegmentCache`] implementations can sit in front of sources to reuse segment bytes across
+//! scans.
+
 mod cache;
 mod shared;
 mod sink;
@@ -20,7 +27,10 @@ pub use source::*;
 pub use test::*;
 use vortex_error::VortexError;
 
-/// The identifier for a single segment.
+/// Identifier for a single physical segment referenced by a layout.
+///
+/// Segment ids are local to a file or segment source. The file footer maps ids to physical offsets;
+/// custom storage systems may map them to object-store keys or other random-access locations.
 // TODO(ngates): should this be a `[u8]` instead? Allowing for arbitrary segment identifiers?
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SegmentId(u32);

--- a/vortex-layout/src/segments/sink.rs
+++ b/vortex-layout/src/segments/sink.rs
@@ -10,9 +10,15 @@ use vortex_error::VortexResult;
 use crate::segments::SegmentId;
 use crate::sequence::SequenceId;
 
+/// Shared writer-side segment sink.
 pub type SegmentSinkRef = Arc<dyn SegmentSink>;
 
 #[async_trait]
+/// Assigns segment ids and writes segment buffers during layout writing.
+///
+/// Segment sinks are responsible for preserving any ordering guarantees required by the storage
+/// backend. The [`SequenceId`] argument lets sinks serialize id assignment while still allowing
+/// upstream layout strategies to do work concurrently.
 pub trait SegmentSink: Send + Sync {
     /// Write the given data into a segment, ordered based on the provided sequence identifier.
     ///

--- a/vortex-layout/src/segments/source.rs
+++ b/vortex-layout/src/segments/source.rs
@@ -9,7 +9,10 @@ use crate::segments::SegmentId;
 /// Static future resolving to a segment byte buffer.
 pub type SegmentFuture = BoxFuture<'static, VortexResult<BufferHandle>>;
 
-/// A trait for providing segment data to a [`crate::LayoutReader`].
+/// Provides segment data to a [`crate::LayoutReader`].
+///
+/// Implementations may issue asynchronous file reads, object-store requests, cache lookups, or
+/// in-memory buffer slices. Returned futures must be independent and safe to poll concurrently.
 pub trait SegmentSource: 'static + Send + Sync {
     /// Request a segment, returning a future that will eventually resolve to the segment data.
     fn request(&self, id: SegmentId) -> SegmentFuture;

--- a/vortex-layout/src/strategy.rs
+++ b/vortex-layout/src/strategy.rs
@@ -12,6 +12,12 @@ use crate::sequence::SendableSequentialStream;
 use crate::sequence::SequencePointer;
 
 // [layout writer]
+/// Writes an ordered array stream into a layout tree and segment sink.
+///
+/// Layout strategies are writer-side extension points. Strategies may repartition, buffer,
+/// collect columns, compute statistics, compress arrays, or delegate to child strategies before
+/// finally emitting segments. They must preserve the logical row order represented by the
+/// [`SequencePointer`]s in the input stream.
 #[async_trait]
 pub trait LayoutStrategy: 'static + Send + Sync {
     /// Asynchronously process an ordered stream of array chunks, emitting them into a sink and

--- a/vortex-layout/src/vtable.rs
+++ b/vortex-layout/src/vtable.rs
@@ -34,9 +34,17 @@ pub struct LayoutBuildContext<'a> {
     pub array_read_ctx: &'a ReadContext,
 }
 
+/// Typed implementation contract for a layout encoding.
+///
+/// A layout vtable connects a concrete layout node type, its registered encoding object, and the
+/// metadata representation used for serialization. The object-safe [`Layout`] and
+/// [`LayoutEncoding`] APIs delegate to this trait through adapters.
 pub trait VTable: 'static + Sized + Send + Sync + Debug {
+    /// Concrete layout node type for this encoding.
     type Layout: 'static + Send + Sync + Clone + Debug + Deref<Target = dyn Layout> + IntoLayout;
+    /// Concrete encoding object registered in the session.
     type Encoding: 'static + Send + Sync + Deref<Target = dyn LayoutEncoding>;
+    /// Serialized layout metadata type.
     type Metadata: SerializeMetadata + DeserializeMetadata + Debug;
 
     /// Returns the ID of the layout encoding.
@@ -45,7 +53,7 @@ pub trait VTable: 'static + Sized + Send + Sync + Debug {
     /// Returns the encoding for the layout.
     fn encoding(layout: &Self::Layout) -> LayoutEncodingRef;
 
-    /// Returns the row count for the layout reader.
+    /// Returns the row count for the layout.
     fn row_count(layout: &Self::Layout) -> u64;
 
     /// Returns the dtype for the layout reader.
@@ -83,7 +91,11 @@ pub trait VTable: 'static + Sized + Send + Sync + Debug {
         ctx: &LayoutReaderContext,
     ) -> VortexResult<LayoutReaderRef>;
 
-    /// Construct a new [`Layout`] from the provided parts.
+    /// Construct a new [`Layout`] from deserialized parts.
+    ///
+    /// Implementations should validate child count, child types, row counts, segment references,
+    /// and dtype consistency for their encoding. The generic adapter checks the returned layout's
+    /// top-level dtype and row count, but encoding-specific invariants belong here.
     fn build(
         encoding: &Self::Encoding,
         dtype: &DType,

--- a/vortex-row/src/encoder.rs
+++ b/vortex-row/src/encoder.rs
@@ -24,6 +24,29 @@ use crate::size::RowSize;
 /// Construct with [`RowEncoder::new`] or [`RowEncoder::with_options`] to pin the per-column
 /// sort options, or use [`RowEncoder::default`] to apply ascending, nulls-first ordering to
 /// every column. The same encoder can be reused across calls.
+///
+/// # Example
+///
+/// ```rust
+/// use vortex_array::{IntoArray, VortexSessionExecute, array_session};
+/// use vortex_array::arrays::PrimitiveArray;
+/// use vortex_row::{RowEncoder, RowSortField};
+///
+/// # fn example() -> vortex_error::VortexResult<()> {
+/// let mut ctx = array_session().create_execution_ctx();
+/// let ids = PrimitiveArray::from_iter([3i32, 1, 2]).into_array();
+/// let scores = PrimitiveArray::from_iter([10i32, 20, 10]).into_array();
+///
+/// let rows = RowEncoder::new([
+///     RowSortField::ascending(),
+///     RowSortField::descending().nulls_last(),
+/// ])
+/// .encode(&[ids, scores], &mut ctx)?;
+///
+/// assert_eq!(rows.len(), 3);
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct RowEncoder {
     options: Option<RowEncodingOptions>,

--- a/vortex-row/src/lib.rs
+++ b/vortex-row/src/lib.rs
@@ -26,6 +26,9 @@
 //! 128 bits, UTF-8 and binary values, structs, and fixed-size lists. Extension, variant,
 //! union, and variable-size list arrays are rejected because this crate does not define an
 //! ordering for them.
+//!
+//! The byte-level format is documented in the row encoding spec:
+//! <https://docs.vortex.dev/specs/row-encoding.html>.
 
 mod codec;
 mod encode;

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -3,6 +3,98 @@
 
 // https://github.com/rust-lang/cargo/pull/11645#issuecomment-1536905941
 #![doc = include_str!(concat!("../", env!("CARGO_PKG_README")))]
+//! # Rust API Map
+//!
+//! The `vortex` crate is the batteries-included entry point. It re-exports the core crates under
+//! stable module names so Rust users can start here and drill down into the crate that owns a
+//! concept:
+//!
+//! - [`array`](mod@array) contains [`ArrayRef`](array::ArrayRef), canonical arrays, expressions, scalar
+//!   functions, statistics, and Arrow conversion.
+//! - [`dtype`] and [`scalar`] contain the logical type system and single-value representation.
+//! - [`file`](mod@file) contains Vortex file readers and writers when the `files` feature is enabled.
+//! - [`layout`] contains serialized layout trees, layout readers, scan builders, and segment
+//!   sources/sinks.
+//! - [`compressor`] contains the default BtrBlocks-style adaptive compressor.
+//! - [`encodings`] exposes maintained encoding crates such as FastLanes, Pco, and Zstd.
+//! - [`session`] contains [`VortexSession`](session::VortexSession), the registry container used to
+//!   make array, layout, scalar-function, and runtime plugins available.
+//!
+//! Most applications should create a default session with [`VortexSessionDefault`]. Lower-level
+//! crates expose narrower session builders when you are embedding only part of Vortex.
+//!
+//! ```rust
+//! use vortex::VortexSessionDefault;
+//! use vortex::session::VortexSession;
+//!
+//! let session = VortexSession::default();
+//! ```
+//!
+//! ## Arrays and Compression
+//!
+//! Arrays are logical values plus a physical encoding. The default compressor chooses an encoding
+//! tree that preserves the array's [`DType`](dtype::DType) while often reducing bytes in memory or
+//! on disk.
+//!
+//! ```rust
+//! use vortex::VortexSessionDefault;
+//! use vortex::array::{IntoArray, VortexSessionExecute};
+//! use vortex::array::arrays::PrimitiveArray;
+//! use vortex::buffer::buffer;
+//! use vortex::compressor::BtrBlocksCompressor;
+//! use vortex::session::VortexSession;
+//! use vortex::array::validity::Validity;
+//!
+//! # fn example() -> vortex::error::VortexResult<()> {
+//! let session = VortexSession::default();
+//! let array = PrimitiveArray::new(buffer![42u64; 1024], Validity::NonNullable).into_array();
+//! let compressed = BtrBlocksCompressor::default()
+//!     .compress(&array, &mut session.create_execution_ctx())?;
+//!
+//! assert_eq!(compressed.dtype(), array.dtype());
+//! assert_eq!(compressed.len(), array.len());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Files and Scans
+//!
+//! Vortex files store a layout tree plus segment bytes. Read and write APIs hang off the session
+//! via extension traits, and scans use expressions for projection and filtering.
+//!
+//! ```rust,no_run
+//! use vortex::VortexSessionDefault;
+//! use vortex::array::{IntoArray, stream::ArrayStreamExt};
+//! use vortex::array::arrays::PrimitiveArray;
+//! use vortex::array::expr::{gt, lit, root};
+//! use vortex::array::validity::Validity;
+//! use vortex::buffer::{ByteBufferMut, buffer};
+//! use vortex::file::{OpenOptionsSessionExt, WriteOptionsSessionExt};
+//! use vortex::session::VortexSession;
+//!
+//! # async fn example() -> vortex::error::VortexResult<()> {
+//! let session = VortexSession::default();
+//! let array = PrimitiveArray::new(buffer![0u64, 1, 2, 3, 4], Validity::NonNullable);
+//!
+//! let mut bytes = ByteBufferMut::empty();
+//! session
+//!     .write_options()
+//!     .write(&mut bytes, array.into_array().to_array_stream())
+//!     .await?;
+//!
+//! let filtered = session
+//!     .open_options()
+//!     .open_buffer(bytes)?
+//!     .scan()?
+//!     .with_filter(gt(root(), lit(2u64)))
+//!     .into_array_stream()?
+//!     .read_all()
+//!     .await?;
+//!
+//! assert_eq!(filtered.len(), 2);
+//! # Ok(())
+//! # }
+//! ```
 
 // vortex::compute is deprecated and will be ported over to expressions.
 pub use vortex_array::aggregate_fn;
@@ -25,6 +117,8 @@ use vortex_session::VortexSession;
 
 // We re-export like so in order to allow users to search inside subcrates when using the Rust docs.
 
+/// Core array APIs, canonical arrays, expressions, scalar functions, statistics, and Arrow
+/// conversion.
 pub mod array {
     pub use vortex_array::*;
 
@@ -33,10 +127,12 @@ pub mod array {
     // twice.
 }
 
+/// Aligned buffers and byte buffers used by arrays, layouts, IPC, and file IO.
 pub mod buffer {
     pub use vortex_buffer::*;
 }
 
+/// Default adaptive compression APIs based on the maintained BtrBlocks-style compressor.
 pub mod compressor {
     pub use vortex_btrblocks::BtrBlocksCompressor;
     pub use vortex_btrblocks::BtrBlocksCompressorBuilder;
@@ -44,113 +140,141 @@ pub mod compressor {
     pub use vortex_btrblocks::SchemeId;
 }
 
+/// Logical Vortex data types.
 pub mod dtype {
     pub use vortex_array::dtype::*;
 }
 
+/// Error and result types shared across Vortex crates.
 pub mod error {
     pub use vortex_error::*;
 }
 
+/// Built-in extension dtypes such as UUID and temporal types.
 pub mod extension {
     pub use vortex_array::extension::*;
 }
 
 #[cfg(feature = "files")]
+/// Vortex file readers, writers, open options, write options, and file-format footer APIs.
 pub mod file {
     pub use vortex_file::*;
 }
 
+/// Generated flatbuffer bindings used by Vortex serialization.
 pub mod flatbuffers {
     pub use vortex_flatbuffers::*;
 }
 
+/// Async and blocking IO abstractions used by file readers and writers.
 pub mod io {
     pub use vortex_io::*;
 }
 
+/// IPC serialization helpers for Vortex arrays.
 pub mod ipc {
     pub use vortex_ipc::*;
 }
 
+/// Serialized layout trees, layout readers, scan builders, and segment sources/sinks.
 pub mod layout {
     pub use vortex_layout::*;
 }
 
+/// Selection masks used by array and scan operations.
 pub mod mask {
     pub use vortex_mask::*;
 }
 
+/// Metrics traits and default metrics registry implementations.
 pub mod metrics {
     pub use vortex_metrics::*;
 }
 
+/// Generated protocol buffer bindings used by Vortex metadata.
 pub mod proto {
     pub use vortex_proto::*;
 }
 
+/// Scalar values and typed scalar views.
 pub mod scalar {
     pub use vortex_array::scalar::*;
 }
 
+/// Data-source abstractions for scan integrations.
 pub mod scan {
     pub use vortex_scan::*;
 }
 
+/// Session registries and session extension traits.
 pub mod session {
     pub use vortex_session::*;
 }
 
+/// Small utility types used across Vortex crates.
 pub mod utils {
     pub use vortex_utils::*;
 }
 
+/// Maintained array encoding crates.
 pub mod encodings {
+    /// Adaptive Lossless floating-point encodings.
     pub mod alp {
         pub use vortex_alp::*;
     }
 
+    /// Byte-per-value boolean encoding.
     pub mod bytebool {
         pub use vortex_bytebool::*;
     }
 
+    /// Date/time decomposition encodings.
     pub mod datetime_parts {
         pub use vortex_datetime_parts::*;
     }
 
+    /// Decimal byte-part decomposition encodings.
     pub mod decimal_byte_parts {
         pub use vortex_decimal_byte_parts::*;
     }
 
+    /// FastLanes integer encodings: bit-packing, delta, frame-of-reference, and RLE.
     pub mod fastlanes {
         pub use vortex_fastlanes::*;
     }
 
+    /// Fast Static Symbol Table string encoding.
     pub mod fsst {
         pub use vortex_fsst::*;
     }
 
+    /// Pco numeric compression encoding.
     pub mod pco {
         pub use vortex_pco::*;
     }
 
+    /// Arrow-compatible run-end encoding.
     pub mod runend {
         pub use vortex_runend::*;
     }
 
+    /// Fixed-step sequence encoding.
     pub mod sequence {
         pub use vortex_sequence::*;
     }
 
+    /// Sparse fill-value-plus-patches encoding.
     pub mod sparse {
         pub use vortex_sparse::*;
     }
 
+    /// Zig-zag integer transform encoding.
     pub mod zigzag {
         pub use vortex_zigzag::*;
     }
 
     #[cfg(feature = "zstd")]
+    /// Zstd-backed binary/string compression encodings.
     pub mod zstd {
         pub use vortex_zstd::*;
     }


### PR DESCRIPTION
## Summary

Adds more docs, both module level conceptual docs which pulls from `docs/`, and many local changes documenting specific functions or types. Also tried to include basic examples.

The main changes are in `vortex`, `vortex-array` and `vortex-file` and `vortex-layout`.

Was done with the help of Claude to try and find gaps/mistakes, and fill in some of the obvious changes.