### PR TITLE
Validate row-index selections

### DIFF
--- a/java/vortex-jni/src/main/java/dev/vortex/api/ScanOptions.java
+++ b/java/vortex-jni/src/main/java/dev/vortex/api/ScanOptions.java
@@ -36,6 +36,8 @@ public interface ScanOptions {
     /**
      * Sorted ascending, unique row indices that should be included in (or excluded from) the scan, depending on
      * {@link #selectionMode()}.
+     *
+     * <p>The native scan validates this contract and rejects indices that are not strictly ascending.
      */
     Optional<long[]> selectionIndices();
 
@@ -64,9 +66,6 @@ public interface ScanOptions {
         if (hasIndices && hasRoaringBitmap) {
             throw new IllegalArgumentException("row selection must use either indices or roaring bitmap, not both");
         }
-        if (hasIndices) {
-            validateSelectionIndices(selectionIndices().orElseThrow());
-        }
 
         switch (selectionMode()) {
             case INCLUDE_ALL -> {
@@ -88,20 +87,6 @@ public interface ScanOptions {
                     throw new IllegalArgumentException("selection roaring bitmap must not be empty");
                 }
             }
-        }
-    }
-
-    private static void validateSelectionIndices(long[] selectionIndices) {
-        long previous = -1L;
-        for (int i = 0; i < selectionIndices.length; i++) {
-            long index = selectionIndices[i];
-            if (index < 0) {
-                throw new IllegalArgumentException("selection indices must be non-negative");
-            }
-            if (i > 0 && index <= previous) {
-                throw new IllegalArgumentException("selection indices must be sorted ascending and unique");
-            }
-            previous = index;
         }
     }
 

--- a/java/vortex-jni/src/test/java/dev/vortex/api/TestMinimal.java
+++ b/java/vortex-jni/src/test/java/dev/vortex/api/TestMinimal.java
@@ -6,6 +6,7 @@ package dev.vortex.api;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import dev.vortex.arrow.ArrowAllocation;
 import dev.vortex.jni.NativeLoader;
@@ -226,10 +227,15 @@ public final class TestMinimal {
     }
 
     @Test
-    public void testSelectionIndicesMustBeSortedAndUnique() {
-        IllegalArgumentException exception =
-                assertThrows(IllegalArgumentException.class, () -> ScanOptions.includeRows(2, 1));
-        assertEquals("selection indices must be sorted ascending and unique", exception.getMessage());
+    public void testSelectionIndicesMustBeSortedAndUnique() throws Exception {
+        Session session = Session.create();
+        DataSource ds = DataSource.open(session, writePath);
+
+        RuntimeException exception =
+                assertThrows(RuntimeException.class, () -> ds.scan(ScanOptions.includeRows(2, 1)));
+        assertTrue(
+                exception.getMessage().contains("must be strictly increasing"),
+                "unexpected message: " + exception.getMessage());
     }
 
     @Test

--- a/java/vortex-jni/src/test/java/dev/vortex/api/TestMinimal.java
+++ b/java/vortex-jni/src/test/java/dev/vortex/api/TestMinimal.java
@@ -231,8 +231,7 @@ public final class TestMinimal {
         Session session = Session.create();
         DataSource ds = DataSource.open(session, writePath);
 
-        RuntimeException exception =
-                assertThrows(RuntimeException.class, () -> ds.scan(ScanOptions.includeRows(2, 1)));
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> ds.scan(ScanOptions.includeRows(2, 1)));
         assertTrue(
                 exception.getMessage().contains("must be strictly increasing"),
                 "unexpected message: " + exception.getMessage());

--- a/vortex-bench/src/random_access/take.rs
+++ b/vortex-bench/src/random_access/take.rs
@@ -25,6 +25,7 @@ use vortex::array::stream::ArrayStreamExt;
 use vortex::buffer::Buffer;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexFile;
+use vortex::scan::selection::StrictSortedBuffer;
 use vortex::utils::aliases::hash_map::HashMap;
 
 use crate::Format;
@@ -76,7 +77,7 @@ impl RandomAccessor for VortexRandomAccessor {
         let array = self
             .file
             .scan()?
-            .with_row_indices(indices_buf)?
+            .with_row_indices(StrictSortedBuffer::try_new(indices_buf)?)
             .into_array_stream()?
             .read_all()
             .await?;

--- a/vortex-bench/src/random_access/take.rs
+++ b/vortex-bench/src/random_access/take.rs
@@ -76,7 +76,7 @@ impl RandomAccessor for VortexRandomAccessor {
         let array = self
             .file
             .scan()?
-            .with_row_indices(indices_buf)
+            .with_row_indices(indices_buf)?
             .into_array_stream()?
             .read_all()
             .await?;

--- a/vortex-bench/src/random_access/take.rs
+++ b/vortex-bench/src/random_access/take.rs
@@ -25,7 +25,7 @@ use vortex::array::stream::ArrayStreamExt;
 use vortex::buffer::Buffer;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexFile;
-use vortex::scan::selection::StrictSortedBuffer;
+use vortex::scan::strict_sorted_buffer::StrictSortedBuffer;
 use vortex::utils::aliases::hash_map::HashMap;
 
 use crate::Format;

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -617,6 +617,7 @@ mod tests {
     use vortex::io::object_store::ObjectStoreWrite;
     use vortex::metrics::DefaultMetricsRegistry;
     use vortex::scan::selection::Selection;
+    use vortex::scan::selection::StrictSortedBuffer;
     use vortex::session::VortexSession;
     use vortex_arrow::FromArrowArray;
 
@@ -1415,8 +1416,6 @@ mod tests {
     // Test that Selection::IncludeByIndex filters to specific row indices.
     async fn test_selection_include_by_index() -> anyhow::Result<()> {
         use datafusion::arrow::util::pretty::pretty_format_batches_with_options;
-        use vortex::buffer::Buffer;
-        use vortex::scan::selection::Selection;
 
         let object_store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
         let file_path = "/path/file.vortex";
@@ -1429,9 +1428,9 @@ mod tests {
         let mut file = PartitionedFile::new(file_path.to_string(), data_size);
         file.extensions
             .insert(
-                VortexAccessPlan::default().with_selection(Selection::include_by_index(
-                    Buffer::from_iter(vec![1, 3, 5, 7]),
-                )?),
+                VortexAccessPlan::default().with_selection(Selection::IncludeByIndex(
+                    StrictSortedBuffer::try_new(Buffer::from_iter(vec![1, 3, 5, 7]))?,
+                )),
             );
 
         let opener = make_test_opener(
@@ -1473,9 +1472,9 @@ mod tests {
         let mut file = PartitionedFile::new(file_path.to_string(), data_size);
         file.extensions
             .insert(
-                VortexAccessPlan::default().with_selection(Selection::exclude_by_index(
-                    Buffer::from_iter(vec![0, 2, 4, 6, 8]),
-                )?),
+                VortexAccessPlan::default().with_selection(Selection::ExcludeByIndex(
+                    StrictSortedBuffer::try_new(Buffer::from_iter(vec![0, 2, 4, 6, 8]))?,
+                )),
             );
 
         let opener = make_test_opener(

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -1429,9 +1429,9 @@ mod tests {
         let mut file = PartitionedFile::new(file_path.to_string(), data_size);
         file.extensions
             .insert(
-                VortexAccessPlan::default().with_selection(Selection::IncludeByIndex(
+                VortexAccessPlan::default().with_selection(Selection::include_by_index(
                     Buffer::from_iter(vec![1, 3, 5, 7]),
-                )),
+                )?),
             );
 
         let opener = make_test_opener(
@@ -1473,9 +1473,9 @@ mod tests {
         let mut file = PartitionedFile::new(file_path.to_string(), data_size);
         file.extensions
             .insert(
-                VortexAccessPlan::default().with_selection(Selection::ExcludeByIndex(
+                VortexAccessPlan::default().with_selection(Selection::exclude_by_index(
                     Buffer::from_iter(vec![0, 2, 4, 6, 8]),
-                )),
+                )?),
             );
 
         let opener = make_test_opener(

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -617,7 +617,7 @@ mod tests {
     use vortex::io::object_store::ObjectStoreWrite;
     use vortex::metrics::DefaultMetricsRegistry;
     use vortex::scan::selection::Selection;
-    use vortex::scan::selection::StrictSortedBuffer;
+    use vortex::scan::strict_sorted_buffer::StrictSortedBuffer;
     use vortex::session::VortexSession;
     use vortex_arrow::FromArrowArray;
 

--- a/vortex-duckdb/src/convert/table_filter.rs
+++ b/vortex-duckdb/src/convert/table_filter.rs
@@ -25,6 +25,7 @@ use vortex::scalar_fn::ScalarFnVTableExt;
 use vortex::scalar_fn::fns::binary::Binary;
 use vortex::scalar_fn::fns::operators::CompareOperator;
 use vortex::scan::selection::Selection;
+use vortex::scan::selection::StrictSortedBuffer;
 
 use super::expr::try_from_bound_expression_with_col_sub;
 use crate::cpp::DUCKDB_VX_EXPR_TYPE;
@@ -179,7 +180,7 @@ pub fn try_from_virtual_column_filter(
                 .map(nonnegative_number_from_value)
                 .collect::<VortexResult<Vec<u64>>>()?;
             Ok((
-                Selection::include_by_index(Buffer::from_iter(indices))?,
+                Selection::IncludeByIndex(StrictSortedBuffer::try_new(Buffer::from_iter(indices))?),
                 None,
             ))
         }
@@ -220,7 +221,9 @@ pub fn try_from_virtual_column_filter(
             }
             let range = (start < end).then_some(start..end);
             let sel = indices
-                .map(|v| Selection::include_by_index(Buffer::from_iter(v)))
+                .map(|v| {
+                    StrictSortedBuffer::try_new(Buffer::from_iter(v)).map(Selection::IncludeByIndex)
+                })
                 .transpose()?
                 .unwrap_or(Selection::All);
             Ok((sel, range))

--- a/vortex-duckdb/src/convert/table_filter.rs
+++ b/vortex-duckdb/src/convert/table_filter.rs
@@ -166,12 +166,6 @@ fn intersect_sorted(left: &[u64], right: &[u64]) -> Vec<u64> {
     result
 }
 
-fn normalize_indices(mut indices: Vec<u64>) -> Vec<u64> {
-    indices.sort_unstable();
-    indices.dedup();
-    indices
-}
-
 /// For constant comparison on IN filters over file_index or file_row_number
 /// virtual column, create a selection and a range covering the same range as
 /// expressions do.
@@ -185,7 +179,7 @@ pub fn try_from_virtual_column_filter(
                 .map(nonnegative_number_from_value)
                 .collect::<VortexResult<Vec<u64>>>()?;
             Ok((
-                Selection::include_by_index(Buffer::from_iter(normalize_indices(indices)))?,
+                Selection::include_by_index(Buffer::from_iter(indices))?,
                 None,
             ))
         }

--- a/vortex-duckdb/src/convert/table_filter.rs
+++ b/vortex-duckdb/src/convert/table_filter.rs
@@ -166,6 +166,12 @@ fn intersect_sorted(left: &[u64], right: &[u64]) -> Vec<u64> {
     result
 }
 
+fn normalize_indices(mut indices: Vec<u64>) -> Vec<u64> {
+    indices.sort_unstable();
+    indices.dedup();
+    indices
+}
+
 /// For constant comparison on IN filters over file_index or file_row_number
 /// virtual column, create a selection and a range covering the same range as
 /// expressions do.
@@ -178,7 +184,10 @@ pub fn try_from_virtual_column_filter(
                 .iter()
                 .map(nonnegative_number_from_value)
                 .collect::<VortexResult<Vec<u64>>>()?;
-            Ok((Selection::IncludeByIndex(Buffer::from_iter(indices)), None))
+            Ok((
+                Selection::include_by_index(Buffer::from_iter(normalize_indices(indices)))?,
+                None,
+            ))
         }
         TableFilterClass::ConstantComparison(const_) => {
             let n = nonnegative_number_from_value(const_.value)?;
@@ -206,7 +215,7 @@ pub fn try_from_virtual_column_filter(
                 let (sel, range) = try_from_virtual_column_filter(child)?;
                 if let Selection::IncludeByIndex(buf) = sel {
                     indices = Some(match indices {
-                        None => buf.iter().copied().collect(),
+                        None => buf.as_slice().to_vec(),
                         Some(existing) => intersect_sorted(&existing, buf.as_ref()),
                     });
                 }
@@ -217,7 +226,8 @@ pub fn try_from_virtual_column_filter(
             }
             let range = (start < end).then_some(start..end);
             let sel = indices
-                .map(|v| Selection::IncludeByIndex(Buffer::from_iter(v)))
+                .map(|v| Selection::include_by_index(Buffer::from_iter(v)))
+                .transpose()?
                 .unwrap_or(Selection::All);
             Ok((sel, range))
         }

--- a/vortex-duckdb/src/convert/table_filter.rs
+++ b/vortex-duckdb/src/convert/table_filter.rs
@@ -25,7 +25,7 @@ use vortex::scalar_fn::ScalarFnVTableExt;
 use vortex::scalar_fn::fns::binary::Binary;
 use vortex::scalar_fn::fns::operators::CompareOperator;
 use vortex::scan::selection::Selection;
-use vortex::scan::selection::StrictSortedBuffer;
+use vortex::scan::strict_sorted_buffer::StrictSortedBuffer;
 
 use super::expr::try_from_bound_expression_with_col_sub;
 use crate::cpp::DUCKDB_VX_EXPR_TYPE;
@@ -211,7 +211,7 @@ pub fn try_from_virtual_column_filter(
                 if let Selection::IncludeByIndex(buf) = sel {
                     indices = Some(match indices {
                         None => buf.as_slice().to_vec(),
-                        Some(existing) => intersect_sorted(&existing, buf.as_ref()),
+                        Some(existing) => intersect_sorted(&existing, buf.as_slice()),
                     });
                 }
                 if let Some(r) = range {

--- a/vortex-ffi/src/scan.rs
+++ b/vortex-ffi/src/scan.rs
@@ -32,6 +32,7 @@ use vortex::scan::Partition;
 use vortex::scan::PartitionStream;
 use vortex::scan::ScanRequest;
 use vortex::scan::selection::Selection;
+use vortex::scan::selection::StrictSortedBuffer;
 use vortex_arrow::ArrowSessionExt;
 use vortex_arrow::ToArrowType;
 
@@ -178,13 +179,13 @@ fn scan_request(opts: *const vx_scan_options) -> VortexResult<ScanRequest> {
             vortex_ensure!(!selection.idx.is_null());
             let buf = unsafe { slice::from_raw_parts(selection.idx, selection.idx_len) };
             let buf = Buffer::copy_from(buf);
-            Selection::include_by_index(buf)?
+            Selection::IncludeByIndex(StrictSortedBuffer::try_new(buf)?)
         }
         vx_scan_selection_include::VX_SELECTION_EXCLUDE_RANGE => {
             vortex_ensure!(!selection.idx.is_null());
             let buf = unsafe { slice::from_raw_parts(selection.idx, selection.idx_len) };
             let buf = Buffer::copy_from(buf);
-            Selection::exclude_by_index(buf)?
+            Selection::ExcludeByIndex(StrictSortedBuffer::try_new(buf)?)
         }
     };
 

--- a/vortex-ffi/src/scan.rs
+++ b/vortex-ffi/src/scan.rs
@@ -178,13 +178,13 @@ fn scan_request(opts: *const vx_scan_options) -> VortexResult<ScanRequest> {
             vortex_ensure!(!selection.idx.is_null());
             let buf = unsafe { slice::from_raw_parts(selection.idx, selection.idx_len) };
             let buf = Buffer::copy_from(buf);
-            Selection::IncludeByIndex(buf)
+            Selection::include_by_index(buf)?
         }
         vx_scan_selection_include::VX_SELECTION_EXCLUDE_RANGE => {
             vortex_ensure!(!selection.idx.is_null());
             let buf = unsafe { slice::from_raw_parts(selection.idx, selection.idx_len) };
             let buf = Buffer::copy_from(buf);
-            Selection::ExcludeByIndex(buf)
+            Selection::exclude_by_index(buf)?
         }
     };
 

--- a/vortex-ffi/src/scan.rs
+++ b/vortex-ffi/src/scan.rs
@@ -32,7 +32,7 @@ use vortex::scan::Partition;
 use vortex::scan::PartitionStream;
 use vortex::scan::ScanRequest;
 use vortex::scan::selection::Selection;
-use vortex::scan::selection::StrictSortedBuffer;
+use vortex::scan::strict_sorted_buffer::StrictSortedBuffer;
 use vortex_arrow::ArrowSessionExt;
 use vortex_arrow::ToArrowType;
 

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -754,6 +754,7 @@ async fn test_with_indices_simple() {
         .scan()
         .unwrap()
         .with_row_indices(Buffer::<u64>::empty())
+        .unwrap()
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -771,6 +772,7 @@ async fn test_with_indices_simple() {
         .scan()
         .unwrap()
         .with_row_indices(Buffer::from_iter(kept_indices))
+        .unwrap()
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -796,6 +798,7 @@ async fn test_with_indices_simple() {
         .scan()
         .unwrap()
         .with_row_indices((0u64..500).collect::<Buffer<_>>())
+        .unwrap()
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -841,6 +844,7 @@ async fn test_with_indices_on_two_columns() {
         .scan()
         .unwrap()
         .with_row_indices(Buffer::from_iter(kept_indices))
+        .unwrap()
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -898,6 +902,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .unwrap()
         .with_filter(gt(get_item("numbers", root()), lit(50_i16)))
         .with_row_indices(Buffer::empty())
+        .unwrap()
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -916,6 +921,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .unwrap()
         .with_filter(gt(get_item("numbers", root()), lit(50_i16)))
         .with_row_indices(Buffer::from_iter(kept_indices))
+        .unwrap()
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -944,6 +950,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .unwrap()
         .with_filter(gt(get_item("numbers", root()), lit(50_i16)))
         .with_row_indices((0..500).collect::<Buffer<_>>())
+        .unwrap()
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -1246,7 +1253,7 @@ async fn file_take() -> VortexResult<()> {
     let vxf = chunked_file().await?;
     let result = vxf
         .scan()?
-        .with_row_indices(buffer![0, 1, 8])
+        .with_row_indices(buffer![0, 1, 8])?
         .into_array_stream()?
         .read_all()
         .await?;

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -78,6 +78,7 @@ use vortex_layout::layouts::zoned::Zoned;
 use vortex_layout::scan::scan_builder::ScanBuilder;
 use vortex_layout::scan::split_by::SplitBy;
 use vortex_layout::session::LayoutSession;
+use vortex_scan::selection::StrictSortedBuffer;
 use vortex_session::VortexSession;
 
 use crate::MAX_POSTSCRIPT_SIZE;
@@ -96,6 +97,10 @@ static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
 
     session
 });
+
+fn strict_sorted(indices: Buffer<u64>) -> StrictSortedBuffer<u64> {
+    StrictSortedBuffer::try_new(indices).expect("test indices should be strictly increasing")
+}
 
 #[tokio::test]
 async fn test_eof_values() {
@@ -753,8 +758,7 @@ async fn test_with_indices_simple() {
     let actual_kept_array = file
         .scan()
         .unwrap()
-        .with_row_indices(Buffer::<u64>::empty())
-        .unwrap()
+        .with_row_indices(strict_sorted(Buffer::<u64>::empty()))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -771,8 +775,7 @@ async fn test_with_indices_simple() {
     let actual_kept_array = file
         .scan()
         .unwrap()
-        .with_row_indices(Buffer::from_iter(kept_indices))
-        .unwrap()
+        .with_row_indices(strict_sorted(Buffer::from_iter(kept_indices)))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -797,8 +800,7 @@ async fn test_with_indices_simple() {
     let actual_array = file
         .scan()
         .unwrap()
-        .with_row_indices((0u64..500).collect::<Buffer<_>>())
-        .unwrap()
+        .with_row_indices(strict_sorted((0u64..500).collect::<Buffer<_>>()))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -843,8 +845,7 @@ async fn test_with_indices_on_two_columns() {
     let array = file
         .scan()
         .unwrap()
-        .with_row_indices(Buffer::from_iter(kept_indices))
-        .unwrap()
+        .with_row_indices(strict_sorted(Buffer::from_iter(kept_indices)))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -901,8 +902,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .scan()
         .unwrap()
         .with_filter(gt(get_item("numbers", root()), lit(50_i16)))
-        .with_row_indices(Buffer::empty())
-        .unwrap()
+        .with_row_indices(strict_sorted(Buffer::empty()))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -920,8 +920,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .scan()
         .unwrap()
         .with_filter(gt(get_item("numbers", root()), lit(50_i16)))
-        .with_row_indices(Buffer::from_iter(kept_indices))
-        .unwrap()
+        .with_row_indices(strict_sorted(Buffer::from_iter(kept_indices)))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -949,8 +948,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .scan()
         .unwrap()
         .with_filter(gt(get_item("numbers", root()), lit(50_i16)))
-        .with_row_indices((0..500).collect::<Buffer<_>>())
-        .unwrap()
+        .with_row_indices(strict_sorted((0..500).collect::<Buffer<_>>()))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -1253,7 +1251,7 @@ async fn file_take() -> VortexResult<()> {
     let vxf = chunked_file().await?;
     let result = vxf
         .scan()?
-        .with_row_indices(buffer![0, 1, 8])?
+        .with_row_indices(StrictSortedBuffer::try_new(buffer![0, 1, 8])?)
         .into_array_stream()?
         .read_all()
         .await?;

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -78,7 +78,7 @@ use vortex_layout::layouts::zoned::Zoned;
 use vortex_layout::scan::scan_builder::ScanBuilder;
 use vortex_layout::scan::split_by::SplitBy;
 use vortex_layout::session::LayoutSession;
-use vortex_scan::selection::StrictSortedBuffer;
+use vortex_scan::strict_sorted_buffer::StrictSortedBuffer;
 use vortex_session::VortexSession;
 
 use crate::MAX_POSTSCRIPT_SIZE;

--- a/vortex-jni/src/scan.rs
+++ b/vortex-jni/src/scan.rs
@@ -43,7 +43,7 @@ use vortex::scan::PartitionRef;
 use vortex::scan::PartitionStream;
 use vortex::scan::ScanRequest;
 use vortex::scan::selection::Selection;
-use vortex::scan::selection::StrictSortedBuffer;
+use vortex::scan::strict_sorted_buffer::StrictSortedBuffer;
 use vortex_arrow::ArrowSessionExt;
 
 use crate::POOL;

--- a/vortex-jni/src/scan.rs
+++ b/vortex-jni/src/scan.rs
@@ -94,8 +94,8 @@ fn build_scan_request(
 
     let selection = match selection_include {
         0 => Selection::All,
-        1 => Selection::IncludeByIndex(Buffer::copy_from(selection_idx)),
-        2 => Selection::ExcludeByIndex(Buffer::copy_from(selection_idx)),
+        1 => Selection::include_by_index(Buffer::copy_from(selection_idx))?,
+        2 => Selection::exclude_by_index(Buffer::copy_from(selection_idx))?,
         3 => Selection::IncludeRoaring(deserialize_roaring_selection(selection_roaring_bitmap)?),
         4 => Selection::ExcludeRoaring(deserialize_roaring_selection(selection_roaring_bitmap)?),
         other => vortex_bail!("unknown selection include code: {other}"),

--- a/vortex-jni/src/scan.rs
+++ b/vortex-jni/src/scan.rs
@@ -43,6 +43,7 @@ use vortex::scan::PartitionRef;
 use vortex::scan::PartitionStream;
 use vortex::scan::ScanRequest;
 use vortex::scan::selection::Selection;
+use vortex::scan::selection::StrictSortedBuffer;
 use vortex_arrow::ArrowSessionExt;
 
 use crate::POOL;
@@ -94,8 +95,12 @@ fn build_scan_request(
 
     let selection = match selection_include {
         0 => Selection::All,
-        1 => Selection::include_by_index(Buffer::copy_from(selection_idx))?,
-        2 => Selection::exclude_by_index(Buffer::copy_from(selection_idx))?,
+        1 => Selection::IncludeByIndex(StrictSortedBuffer::try_new(Buffer::copy_from(
+            selection_idx,
+        ))?),
+        2 => Selection::ExcludeByIndex(StrictSortedBuffer::try_new(Buffer::copy_from(
+            selection_idx,
+        ))?),
         3 => Selection::IncludeRoaring(deserialize_roaring_selection(selection_roaring_bitmap)?),
         4 => Selection::ExcludeRoaring(deserialize_roaring_selection(selection_roaring_bitmap)?),
         other => vortex_bail!("unknown selection include code: {other}"),

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -24,7 +24,6 @@ use vortex_array::iter::ArrayIteratorAdapter;
 use vortex_array::stats::StatsSet;
 use vortex_array::stream::ArrayStream;
 use vortex_array::stream::ArrayStreamAdapter;
-use vortex_buffer::Buffer;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -34,6 +33,7 @@ use vortex_io::runtime::Task;
 use vortex_io::session::RuntimeSessionExt;
 use vortex_metrics::MetricsRegistry;
 use vortex_scan::selection::Selection;
+use vortex_scan::selection::StrictSortedBuffer;
 use vortex_session::VortexSession;
 use vortex_utils::parallelism::get_available_parallelism;
 
@@ -172,10 +172,10 @@ impl<A: 'static + Send> ScanBuilder<A> {
         self
     }
 
-    /// Select rows by absolute indices relative to the scan input.
-    pub fn with_row_indices(mut self, row_indices: Buffer<u64>) -> VortexResult<Self> {
-        self.selection = Selection::include_by_index(row_indices)?;
-        Ok(self)
+    /// Select rows by strictly sorted absolute indices relative to the scan input.
+    pub fn with_row_indices(mut self, row_indices: StrictSortedBuffer<u64>) -> Self {
+        self.selection = Selection::IncludeByIndex(row_indices);
+        self
     }
 
     /// Set the root row offset used by row-index expressions.

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -173,9 +173,9 @@ impl<A: 'static + Send> ScanBuilder<A> {
     }
 
     /// Select rows by absolute indices relative to the scan input.
-    pub fn with_row_indices(mut self, row_indices: Buffer<u64>) -> Self {
-        self.selection = Selection::IncludeByIndex(row_indices);
-        self
+    pub fn with_row_indices(mut self, row_indices: Buffer<u64>) -> VortexResult<Self> {
+        self.selection = Selection::include_by_index(row_indices)?;
+        Ok(self)
     }
 
     /// Set the root row offset used by row-index expressions.

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -33,7 +33,7 @@ use vortex_io::runtime::Task;
 use vortex_io::session::RuntimeSessionExt;
 use vortex_metrics::MetricsRegistry;
 use vortex_scan::selection::Selection;
-use vortex_scan::selection::StrictSortedBuffer;
+use vortex_scan::strict_sorted_buffer::StrictSortedBuffer;
 use vortex_session::VortexSession;
 use vortex_utils::parallelism::get_available_parallelism;
 

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -67,7 +67,7 @@ pub fn read_array_from_reader(
     if let Some(indices) = indices {
         let primitive = indices.execute::<PrimitiveArray>(ctx)?;
         let indices = primitive.into_buffer();
-        scan = scan.with_row_indices(indices);
+        scan = scan.with_row_indices(indices)?;
     }
 
     if let Some((l, r)) = row_range {

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -25,6 +25,7 @@ use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexFile;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::layout::scan::split_by::SplitBy;
+use vortex::scan::selection::StrictSortedBuffer;
 use vortex_arrow::ToArrowType;
 
 use crate::RUNTIME;
@@ -67,7 +68,7 @@ pub fn read_array_from_reader(
     if let Some(indices) = indices {
         let primitive = indices.execute::<PrimitiveArray>(ctx)?;
         let indices = primitive.into_buffer();
-        scan = scan.with_row_indices(indices)?;
+        scan = scan.with_row_indices(StrictSortedBuffer::try_new(indices)?);
     }
 
     if let Some((l, r)) = row_range {

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -25,7 +25,7 @@ use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexFile;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::layout::scan::split_by::SplitBy;
-use vortex::scan::selection::StrictSortedBuffer;
+use vortex::scan::strict_sorted_buffer::StrictSortedBuffer;
 use vortex_arrow::ToArrowType;
 
 use crate::RUNTIME;

--- a/vortex-python/src/file.rs
+++ b/vortex-python/src/file.rs
@@ -27,6 +27,7 @@ use vortex::io::runtime::BlockingRuntime;
 use vortex::layout::scan::scan_builder::ScanBuilder;
 use vortex::layout::scan::split_by::SplitBy;
 use vortex::layout::segments::MokaSegmentCache;
+use vortex::scan::selection::StrictSortedBuffer;
 use vortex_arrow::ToArrowType;
 
 use crate::RUNTIME;
@@ -221,7 +222,7 @@ fn scan_builder(
     if let Some(indices) = indices {
         let casted = indices.cast(DType::Primitive(PType::U64, NonNullable))?;
         let indices = casted.execute::<PrimitiveArray>(ctx)?.into_buffer::<u64>();
-        builder = builder.with_row_indices(indices)?;
+        builder = builder.with_row_indices(StrictSortedBuffer::try_new(indices)?);
     }
 
     if let Some(batch_size) = batch_size {

--- a/vortex-python/src/file.rs
+++ b/vortex-python/src/file.rs
@@ -221,7 +221,7 @@ fn scan_builder(
     if let Some(indices) = indices {
         let casted = indices.cast(DType::Primitive(PType::U64, NonNullable))?;
         let indices = casted.execute::<PrimitiveArray>(ctx)?.into_buffer::<u64>();
-        builder = builder.with_row_indices(indices);
+        builder = builder.with_row_indices(indices)?;
     }
 
     if let Some(batch_size) = batch_size {

--- a/vortex-python/src/file.rs
+++ b/vortex-python/src/file.rs
@@ -27,7 +27,7 @@ use vortex::io::runtime::BlockingRuntime;
 use vortex::layout::scan::scan_builder::ScanBuilder;
 use vortex::layout::scan::split_by::SplitBy;
 use vortex::layout::segments::MokaSegmentCache;
-use vortex::scan::selection::StrictSortedBuffer;
+use vortex::scan::strict_sorted_buffer::StrictSortedBuffer;
 use vortex_arrow::ToArrowType;
 
 use crate::RUNTIME;

--- a/vortex-scan/README.md
+++ b/vortex-scan/README.md
@@ -90,7 +90,7 @@ use vortex_scan::Selection;
 
 // Select specific rows by index
 let scan = ScanBuilder::new(layout_reader)
-.with_selection(Selection::IncludeByIndex(indices.into()))
+.with_selection(Selection::include_by_index(indices.into())?)
 .build() ?;
 
 // Or use row ranges

--- a/vortex-scan/README.md
+++ b/vortex-scan/README.md
@@ -86,11 +86,11 @@ let record_batch: RecordBatch = batch ?;
 ### Row Selection
 
 ```rust
-use vortex_scan::Selection;
+use vortex_scan::selection::{Selection, StrictSortedBuffer};
 
 // Select specific rows by index
 let scan = ScanBuilder::new(layout_reader)
-.with_selection(Selection::include_by_index(indices.into())?)
+.with_selection(Selection::IncludeByIndex(StrictSortedBuffer::try_new(indices.into())?))
 .build() ?;
 
 // Or use row ranges

--- a/vortex-scan/README.md
+++ b/vortex-scan/README.md
@@ -86,7 +86,8 @@ let record_batch: RecordBatch = batch ?;
 ### Row Selection
 
 ```rust
-use vortex_scan::selection::{Selection, StrictSortedBuffer};
+use vortex_scan::selection::Selection;
+use vortex_scan::strict_sorted_buffer::StrictSortedBuffer;
 
 // Select specific rows by index
 let scan = ScanBuilder::new(layout_reader)

--- a/vortex-scan/src/lib.rs
+++ b/vortex-scan/src/lib.rs
@@ -24,6 +24,7 @@
 
 pub mod row_mask;
 pub mod selection;
+pub mod strict_sorted_buffer;
 
 use std::any::Any;
 use std::ops::Range;

--- a/vortex-scan/src/selection.rs
+++ b/vortex-scan/src/selection.rs
@@ -7,6 +7,7 @@ use std::ops::Not;
 use std::ops::Range;
 
 use vortex_buffer::Buffer;
+use vortex_error::VortexError;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_panic;
@@ -14,88 +15,74 @@ use vortex_mask::Mask;
 
 use crate::row_mask::RowMask;
 
-/// A validated selection of rows to include by absolute row index.
+/// A buffer whose values are known to be strictly sorted in ascending order.
 #[derive(Clone, Debug)]
-pub struct IncludeByIndex {
-    indices: Buffer<u64>,
+pub struct StrictSortedBuffer<T> {
+    buffer: Buffer<T>,
 }
 
-impl IncludeByIndex {
-    /// Create a new include-by-index selection.
-    pub fn try_new(indices: Buffer<u64>) -> VortexResult<Self> {
-        validate_indices(&indices)?;
-        Ok(Self { indices })
+impl<T> StrictSortedBuffer<T> {
+    /// Return the sorted values.
+    pub fn as_slice(&self) -> &[T] {
+        self.buffer.as_slice()
     }
 
-    /// Return the selected row indices.
-    pub fn as_slice(&self) -> &[u64] {
-        self.indices.as_slice()
+    /// Return the sorted buffer.
+    pub fn into_inner(self) -> Buffer<T> {
+        self.buffer
     }
 
-    /// Return true if the selection contains no row indices.
+    /// Return true if the buffer contains no values.
     pub fn is_empty(&self) -> bool {
-        self.indices.is_empty()
+        self.buffer.is_empty()
     }
 
-    /// Return the number of selected row indices.
+    /// Return the number of values in the buffer.
     pub fn len(&self) -> usize {
-        self.indices.len()
+        self.buffer.len()
     }
 }
 
-impl std::ops::Deref for IncludeByIndex {
-    type Target = [u64];
+impl<T: Ord> StrictSortedBuffer<T> {
+    /// Create a new buffer, failing if the values are not strictly increasing.
+    pub fn try_new(buffer: Buffer<T>) -> VortexResult<Self> {
+        validate_strictly_sorted(buffer.as_slice())?;
+        Ok(Self { buffer })
+    }
+}
+
+impl<T> Default for StrictSortedBuffer<T> {
+    fn default() -> Self {
+        Self {
+            buffer: Buffer::default(),
+        }
+    }
+}
+
+impl<T: Ord> TryFrom<Buffer<T>> for StrictSortedBuffer<T> {
+    type Error = VortexError;
+
+    fn try_from(value: Buffer<T>) -> Result<Self, Self::Error> {
+        Self::try_new(value)
+    }
+}
+
+impl<T> From<StrictSortedBuffer<T>> for Buffer<T> {
+    fn from(value: StrictSortedBuffer<T>) -> Self {
+        value.into_inner()
+    }
+}
+
+impl<T> std::ops::Deref for StrictSortedBuffer<T> {
+    type Target = [T];
 
     fn deref(&self) -> &Self::Target {
         self.as_slice()
     }
 }
 
-impl AsRef<[u64]> for IncludeByIndex {
-    fn as_ref(&self) -> &[u64] {
-        self.as_slice()
-    }
-}
-
-/// A validated selection of rows to exclude by absolute row index.
-#[derive(Clone, Debug)]
-pub struct ExcludeByIndex {
-    indices: Buffer<u64>,
-}
-
-impl ExcludeByIndex {
-    /// Create a new exclude-by-index selection.
-    pub fn try_new(indices: Buffer<u64>) -> VortexResult<Self> {
-        validate_indices(&indices)?;
-        Ok(Self { indices })
-    }
-
-    /// Return the excluded row indices.
-    pub fn as_slice(&self) -> &[u64] {
-        self.indices.as_slice()
-    }
-
-    /// Return true if the selection contains no row indices.
-    pub fn is_empty(&self) -> bool {
-        self.indices.is_empty()
-    }
-
-    /// Return the number of excluded row indices.
-    pub fn len(&self) -> usize {
-        self.indices.len()
-    }
-}
-
-impl std::ops::Deref for ExcludeByIndex {
-    type Target = [u64];
-
-    fn deref(&self) -> &Self::Target {
-        self.as_slice()
-    }
-}
-
-impl AsRef<[u64]> for ExcludeByIndex {
-    fn as_ref(&self) -> &[u64] {
+impl<T> AsRef<[T]> for StrictSortedBuffer<T> {
+    fn as_ref(&self) -> &[T] {
         self.as_slice()
     }
 }
@@ -108,9 +95,9 @@ pub enum Selection {
     #[default]
     All,
     /// A selection of sorted, unique rows to include by index.
-    IncludeByIndex(IncludeByIndex),
+    IncludeByIndex(StrictSortedBuffer<u64>),
     /// A selection of sorted, unique rows to exclude by index.
-    ExcludeByIndex(ExcludeByIndex),
+    ExcludeByIndex(StrictSortedBuffer<u64>),
     /// A selection of rows to include using a [`roaring::RoaringTreemap`].
     IncludeRoaring(roaring::RoaringTreemap),
     /// A selection of rows to exclude using a [`roaring::RoaringTreemap`].
@@ -118,16 +105,6 @@ pub enum Selection {
 }
 
 impl Selection {
-    /// Create a selection of rows to include by absolute row index.
-    pub fn include_by_index(indices: Buffer<u64>) -> VortexResult<Self> {
-        Ok(Self::IncludeByIndex(IncludeByIndex::try_new(indices)?))
-    }
-
-    /// Create a selection of rows to exclude by absolute row index.
-    pub fn exclude_by_index(indices: Buffer<u64>) -> VortexResult<Self> {
-        Ok(Self::ExcludeByIndex(ExcludeByIndex::try_new(indices)?))
-    }
-
     /// Return the row count for this selection.
     pub fn row_count(&self, total_rows: u64) -> u64 {
         match self {
@@ -270,18 +247,13 @@ impl Selection {
     }
 }
 
-fn validate_indices(indices: &[u64]) -> VortexResult<()> {
-    // Row-mask extraction uses binary search over these indices, and row_count treats
-    // them as set membership. Unsorted or duplicate input can otherwise silently
-    // mis-select rows or over-report the selected row count.
-    for (idx, window) in indices.windows(2).enumerate() {
+fn validate_strictly_sorted<T: Ord>(values: &[T]) -> VortexResult<()> {
+    for (idx, window) in values.windows(2).enumerate() {
         if window[0] >= window[1] {
             vortex_bail!(
-                "row index selection must be strictly increasing at positions {} and {}: {} >= {}",
+                "buffer values must be strictly increasing at positions {} and {}",
                 idx,
-                idx + 1,
-                window[0],
-                window[1]
+                idx + 1
             );
         }
     }
@@ -310,32 +282,30 @@ mod tests {
     use vortex_buffer::Buffer;
 
     use super::Selection;
+    use super::StrictSortedBuffer;
+
+    fn strict_sorted(indices: impl IntoIterator<Item = u64>) -> StrictSortedBuffer<u64> {
+        StrictSortedBuffer::try_new(Buffer::from_iter(indices))
+            .expect("test indices should be strictly increasing")
+    }
 
     fn include(indices: impl IntoIterator<Item = u64>) -> Selection {
-        Selection::include_by_index(Buffer::from_iter(indices))
-            .expect("test indices should be strictly increasing")
+        Selection::IncludeByIndex(strict_sorted(indices))
     }
 
     fn exclude(indices: impl IntoIterator<Item = u64>) -> Selection {
-        Selection::exclude_by_index(Buffer::from_iter(indices))
-            .expect("test indices should be strictly increasing")
+        Selection::ExcludeByIndex(strict_sorted(indices))
     }
 
     #[test]
-    fn include_by_index_rejects_unsorted_indices() {
-        let err = Selection::include_by_index(Buffer::from_iter([3, 1])).unwrap_err();
+    fn strict_sorted_buffer_rejects_unsorted_values() {
+        let err = StrictSortedBuffer::try_new(Buffer::from_iter([3, 1])).unwrap_err();
         assert!(err.to_string().contains("strictly increasing"));
     }
 
     #[test]
-    fn include_by_index_rejects_duplicate_indices() {
-        let err = Selection::include_by_index(Buffer::from_iter([1, 1])).unwrap_err();
-        assert!(err.to_string().contains("strictly increasing"));
-    }
-
-    #[test]
-    fn exclude_by_index_rejects_unsorted_indices() {
-        let err = Selection::exclude_by_index(Buffer::from_iter([3, 1])).unwrap_err();
+    fn strict_sorted_buffer_rejects_duplicate_values() {
+        let err = StrictSortedBuffer::try_new(Buffer::from_iter([1, 1])).unwrap_err();
         assert!(err.to_string().contains("strictly increasing"));
     }
 

--- a/vortex-scan/src/selection.rs
+++ b/vortex-scan/src/selection.rs
@@ -7,10 +7,98 @@ use std::ops::Not;
 use std::ops::Range;
 
 use vortex_buffer::Buffer;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 
 use crate::row_mask::RowMask;
+
+/// A validated selection of rows to include by absolute row index.
+#[derive(Clone, Debug)]
+pub struct IncludeByIndex {
+    indices: Buffer<u64>,
+}
+
+impl IncludeByIndex {
+    /// Create a new include-by-index selection.
+    pub fn try_new(indices: Buffer<u64>) -> VortexResult<Self> {
+        validate_indices(&indices)?;
+        Ok(Self { indices })
+    }
+
+    /// Return the selected row indices.
+    pub fn as_slice(&self) -> &[u64] {
+        self.indices.as_slice()
+    }
+
+    /// Return true if the selection contains no row indices.
+    pub fn is_empty(&self) -> bool {
+        self.indices.is_empty()
+    }
+
+    /// Return the number of selected row indices.
+    pub fn len(&self) -> usize {
+        self.indices.len()
+    }
+}
+
+impl std::ops::Deref for IncludeByIndex {
+    type Target = [u64];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl AsRef<[u64]> for IncludeByIndex {
+    fn as_ref(&self) -> &[u64] {
+        self.as_slice()
+    }
+}
+
+/// A validated selection of rows to exclude by absolute row index.
+#[derive(Clone, Debug)]
+pub struct ExcludeByIndex {
+    indices: Buffer<u64>,
+}
+
+impl ExcludeByIndex {
+    /// Create a new exclude-by-index selection.
+    pub fn try_new(indices: Buffer<u64>) -> VortexResult<Self> {
+        validate_indices(&indices)?;
+        Ok(Self { indices })
+    }
+
+    /// Return the excluded row indices.
+    pub fn as_slice(&self) -> &[u64] {
+        self.indices.as_slice()
+    }
+
+    /// Return true if the selection contains no row indices.
+    pub fn is_empty(&self) -> bool {
+        self.indices.is_empty()
+    }
+
+    /// Return the number of excluded row indices.
+    pub fn len(&self) -> usize {
+        self.indices.len()
+    }
+}
+
+impl std::ops::Deref for ExcludeByIndex {
+    type Target = [u64];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl AsRef<[u64]> for ExcludeByIndex {
+    fn as_ref(&self) -> &[u64] {
+        self.as_slice()
+    }
+}
 
 /// A selection identifies a set of rows to include in the scan (in addition to applying any
 /// filter predicates).
@@ -19,10 +107,10 @@ pub enum Selection {
     /// No selection, all rows are included.
     #[default]
     All,
-    /// A selection of sorted rows to include by index.
-    IncludeByIndex(Buffer<u64>),
-    /// A selection of sorted rows to exclude by index.
-    ExcludeByIndex(Buffer<u64>),
+    /// A selection of sorted, unique rows to include by index.
+    IncludeByIndex(IncludeByIndex),
+    /// A selection of sorted, unique rows to exclude by index.
+    ExcludeByIndex(ExcludeByIndex),
     /// A selection of rows to include using a [`roaring::RoaringTreemap`].
     IncludeRoaring(roaring::RoaringTreemap),
     /// A selection of rows to exclude using a [`roaring::RoaringTreemap`].
@@ -30,6 +118,16 @@ pub enum Selection {
 }
 
 impl Selection {
+    /// Create a selection of rows to include by absolute row index.
+    pub fn include_by_index(indices: Buffer<u64>) -> VortexResult<Self> {
+        Ok(Self::IncludeByIndex(IncludeByIndex::try_new(indices)?))
+    }
+
+    /// Create a selection of rows to exclude by absolute row index.
+    pub fn exclude_by_index(indices: Buffer<u64>) -> VortexResult<Self> {
+        Ok(Self::ExcludeByIndex(ExcludeByIndex::try_new(indices)?))
+    }
+
     /// Return the row count for this selection.
     pub fn row_count(&self, total_rows: u64) -> u64 {
         match self {
@@ -62,12 +160,12 @@ impl Selection {
         match self {
             Selection::All => RowMask::new(range.start, Mask::new_true(range_len)),
             Selection::IncludeByIndex(include) => {
-                let mask = indices_range(range, include)
+                let indices = include.as_slice();
+                let mask = indices_range(range, indices)
                     .map(|idx_range| {
                         Mask::from_indices(
                             range_len,
-                            include
-                                .slice(idx_range)
+                            indices[idx_range]
                                 .iter()
                                 .map(|idx| {
                                     idx.checked_sub(range.start).unwrap_or_else(|| {
@@ -89,10 +187,26 @@ impl Selection {
                 RowMask::new(range.start, mask)
             }
             Selection::ExcludeByIndex(exclude) => {
-                let mask = Selection::IncludeByIndex(exclude.clone())
-                    .row_mask(range)
-                    .mask()
-                    .clone();
+                let indices = exclude.as_slice();
+                let mask = indices_range(range, indices)
+                    .map(|idx_range| {
+                        Mask::from_indices(
+                            range_len,
+                            indices[idx_range]
+                                .iter()
+                                .map(|idx| {
+                                    idx.checked_sub(range.start).unwrap_or_else(|| {
+                                        vortex_panic!(
+                                            "index underflow, range: {:?}, idx: {:?}",
+                                            range,
+                                            idx
+                                        )
+                                    })
+                                })
+                                .filter_map(|idx| usize::try_from(idx).ok()),
+                        )
+                    })
+                    .unwrap_or_else(|| Mask::new_false(range_len));
                 RowMask::new(range.start, mask.not())
             }
             Selection::IncludeRoaring(roaring) => {
@@ -156,6 +270,24 @@ impl Selection {
     }
 }
 
+fn validate_indices(indices: &[u64]) -> VortexResult<()> {
+    // Row-mask extraction uses binary search over these indices, and row_count treats
+    // them as set membership. Unsorted or duplicate input can otherwise silently
+    // mis-select rows or over-report the selected row count.
+    for (idx, window) in indices.windows(2).enumerate() {
+        if window[0] >= window[1] {
+            vortex_bail!(
+                "row index selection must be strictly increasing at positions {} and {}: {} >= {}",
+                idx,
+                idx + 1,
+                window[0],
+                window[1]
+            );
+        }
+    }
+    Ok(())
+}
+
 /// Find the positional range within row_indices that covers all rows in the given range.
 fn indices_range(range: &Range<u64>, row_indices: &[u64]) -> Option<Range<usize>> {
     if row_indices.first().is_some_and(|&first| first >= range.end)
@@ -177,9 +309,39 @@ fn indices_range(range: &Range<u64>, row_indices: &[u64]) -> Option<Range<usize>
 mod tests {
     use vortex_buffer::Buffer;
 
+    use super::Selection;
+
+    fn include(indices: impl IntoIterator<Item = u64>) -> Selection {
+        Selection::include_by_index(Buffer::from_iter(indices))
+            .expect("test indices should be strictly increasing")
+    }
+
+    fn exclude(indices: impl IntoIterator<Item = u64>) -> Selection {
+        Selection::exclude_by_index(Buffer::from_iter(indices))
+            .expect("test indices should be strictly increasing")
+    }
+
+    #[test]
+    fn include_by_index_rejects_unsorted_indices() {
+        let err = Selection::include_by_index(Buffer::from_iter([3, 1])).unwrap_err();
+        assert!(err.to_string().contains("strictly increasing"));
+    }
+
+    #[test]
+    fn include_by_index_rejects_duplicate_indices() {
+        let err = Selection::include_by_index(Buffer::from_iter([1, 1])).unwrap_err();
+        assert!(err.to_string().contains("strictly increasing"));
+    }
+
+    #[test]
+    fn exclude_by_index_rejects_unsorted_indices() {
+        let err = Selection::exclude_by_index(Buffer::from_iter([3, 1])).unwrap_err();
+        assert!(err.to_string().contains("strictly increasing"));
+    }
+
     #[test]
     fn test_row_mask_all() {
-        let selection = super::Selection::IncludeByIndex(Buffer::from_iter(vec![1, 3, 5, 7]));
+        let selection = include([1, 3, 5, 7]);
         let range = 1..8;
         let row_mask = selection.row_mask(&range);
 
@@ -188,7 +350,7 @@ mod tests {
 
     #[test]
     fn test_row_mask_slice() {
-        let selection = super::Selection::IncludeByIndex(Buffer::from_iter(vec![1, 3, 5, 7]));
+        let selection = include([1, 3, 5, 7]);
         let range = 3..6;
         let row_mask = selection.row_mask(&range);
 
@@ -197,7 +359,7 @@ mod tests {
 
     #[test]
     fn test_row_mask_exclusive() {
-        let selection = super::Selection::IncludeByIndex(Buffer::from_iter(vec![1, 3, 5, 7]));
+        let selection = include([1, 3, 5, 7]);
         let range = 3..5;
         let row_mask = selection.row_mask(&range);
 
@@ -206,7 +368,7 @@ mod tests {
 
     #[test]
     fn test_row_mask_all_false() {
-        let selection = super::Selection::IncludeByIndex(Buffer::from_iter(vec![1, 3, 5, 7]));
+        let selection = include([1, 3, 5, 7]);
         let range = 8..10;
         let row_mask = selection.row_mask(&range);
 
@@ -215,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_row_mask_all_true() {
-        let selection = super::Selection::IncludeByIndex(Buffer::from_iter(vec![1, 3, 4, 5, 6]));
+        let selection = include([1, 3, 4, 5, 6]);
         let range = 3..7;
         let row_mask = selection.row_mask(&range);
 
@@ -224,7 +386,7 @@ mod tests {
 
     #[test]
     fn test_row_mask_zero() {
-        let selection = super::Selection::IncludeByIndex(Buffer::from_iter(vec![0]));
+        let selection = include([0]);
         let range = 0..5;
         let row_mask = selection.row_mask(&range);
 
@@ -244,7 +406,7 @@ mod tests {
             roaring.insert(5);
             roaring.insert(7);
 
-            let selection = super::super::Selection::IncludeRoaring(roaring);
+            let selection = Selection::IncludeRoaring(roaring);
             let range = 1..8;
             let row_mask = selection.row_mask(&range);
 
@@ -259,7 +421,7 @@ mod tests {
             roaring.insert(5);
             roaring.insert(7);
 
-            let selection = super::super::Selection::IncludeRoaring(roaring);
+            let selection = Selection::IncludeRoaring(roaring);
             let range = 3..6;
             let row_mask = selection.row_mask(&range);
 
@@ -274,7 +436,7 @@ mod tests {
             roaring.insert(5);
             roaring.insert(7);
 
-            let selection = super::super::Selection::IncludeRoaring(roaring);
+            let selection = Selection::IncludeRoaring(roaring);
             let range = 8..10;
             let row_mask = selection.row_mask(&range);
 
@@ -289,7 +451,7 @@ mod tests {
                 roaring.insert(i);
             }
 
-            let selection = super::super::Selection::IncludeRoaring(roaring);
+            let selection = Selection::IncludeRoaring(roaring);
             let range = 1000..2000;
             let row_mask = selection.row_mask(&range);
 
@@ -304,7 +466,7 @@ mod tests {
             roaring.insert(3);
             roaring.insert(5);
 
-            let selection = super::super::Selection::ExcludeRoaring(roaring);
+            let selection = Selection::ExcludeRoaring(roaring);
             let range = 0..7;
             let row_mask = selection.row_mask(&range);
 
@@ -320,7 +482,7 @@ mod tests {
                 roaring.insert(i);
             }
 
-            let selection = super::super::Selection::ExcludeRoaring(roaring);
+            let selection = Selection::ExcludeRoaring(roaring);
             let range = 10..20;
             let row_mask = selection.row_mask(&range);
 
@@ -333,7 +495,7 @@ mod tests {
             roaring.insert(100);
             roaring.insert(101);
 
-            let selection = super::super::Selection::ExcludeRoaring(roaring);
+            let selection = Selection::ExcludeRoaring(roaring);
             let range = 0..10;
             let row_mask = selection.row_mask(&range);
 
@@ -349,7 +511,7 @@ mod tests {
             roaring.insert(7);
             roaring.insert(15); // Outside range
 
-            let selection = super::super::Selection::ExcludeRoaring(roaring);
+            let selection = Selection::ExcludeRoaring(roaring);
             let range = 5..10;
             let row_mask = selection.row_mask(&range);
 
@@ -360,7 +522,7 @@ mod tests {
         #[test]
         fn test_roaring_include_empty() {
             let roaring = RoaringTreemap::new();
-            let selection = super::super::Selection::IncludeRoaring(roaring);
+            let selection = Selection::IncludeRoaring(roaring);
             let range = 0..100;
             let row_mask = selection.row_mask(&range);
 
@@ -370,7 +532,7 @@ mod tests {
         #[test]
         fn test_roaring_exclude_empty() {
             let roaring = RoaringTreemap::new();
-            let selection = super::super::Selection::ExcludeRoaring(roaring);
+            let selection = Selection::ExcludeRoaring(roaring);
             let range = 0..100;
             let row_mask = selection.row_mask(&range);
 
@@ -383,7 +545,7 @@ mod tests {
             roaring.insert(0);
             roaring.insert(99);
 
-            let selection = super::super::Selection::IncludeRoaring(roaring);
+            let selection = Selection::IncludeRoaring(roaring);
             let range = 0..100;
             let row_mask = selection.row_mask(&range);
 
@@ -397,7 +559,7 @@ mod tests {
             roaring.insert_range(10..20);
             roaring.insert_range(30..40);
 
-            let selection = super::super::Selection::IncludeRoaring(roaring);
+            let selection = Selection::IncludeRoaring(roaring);
             let range = 15..35;
             let row_mask = selection.row_mask(&range);
 
@@ -413,7 +575,7 @@ mod tests {
             roaring.insert(u64::MAX - 1);
             roaring.insert(u64::MAX);
 
-            let selection = super::super::Selection::IncludeRoaring(roaring);
+            let selection = Selection::IncludeRoaring(roaring);
             let range = u64::MAX - 10..u64::MAX;
             let row_mask = selection.row_mask(&range);
 
@@ -426,7 +588,7 @@ mod tests {
             let mut roaring = RoaringTreemap::new();
             roaring.insert(u64::MAX - 1);
 
-            let selection = super::super::Selection::ExcludeRoaring(roaring);
+            let selection = Selection::ExcludeRoaring(roaring);
             let range = u64::MAX - 10..u64::MAX;
             let row_mask = selection.row_mask(&range);
 
@@ -439,14 +601,13 @@ mod tests {
             // Test that RoaringTreemap and Buffer produce same results
             let indices = vec![1, 3, 5, 7, 9];
 
-            let buffer_selection =
-                super::super::Selection::IncludeByIndex(Buffer::from_iter(indices.clone()));
+            let buffer_selection = include(indices.clone());
 
             let mut roaring = RoaringTreemap::new();
             for idx in &indices {
                 roaring.insert(*idx);
             }
-            let roaring_selection = super::super::Selection::IncludeRoaring(roaring);
+            let roaring_selection = Selection::IncludeRoaring(roaring);
 
             let range = 0..12;
             let buffer_mask = buffer_selection.row_mask(&range);
@@ -463,14 +624,13 @@ mod tests {
             // Test that ExcludeRoaring and ExcludeByIndex produce same results
             let indices = vec![2, 4, 6, 8];
 
-            let buffer_selection =
-                super::super::Selection::ExcludeByIndex(Buffer::from_iter(indices.clone()));
+            let buffer_selection = exclude(indices.clone());
 
             let mut roaring = RoaringTreemap::new();
             for idx in &indices {
                 roaring.insert(*idx);
             }
-            let roaring_selection = super::super::Selection::ExcludeRoaring(roaring);
+            let roaring_selection = Selection::ExcludeRoaring(roaring);
 
             let range = 0..10;
             let buffer_mask = buffer_selection.row_mask(&range);

--- a/vortex-scan/src/selection.rs
+++ b/vortex-scan/src/selection.rs
@@ -6,86 +6,11 @@
 use std::ops::Not;
 use std::ops::Range;
 
-use vortex_buffer::Buffer;
-use vortex_error::VortexError;
-use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
 use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 
 use crate::row_mask::RowMask;
-
-/// A buffer whose values are known to be strictly sorted in ascending order.
-#[derive(Clone, Debug)]
-pub struct StrictSortedBuffer<T> {
-    buffer: Buffer<T>,
-}
-
-impl<T> StrictSortedBuffer<T> {
-    /// Return the sorted values.
-    pub fn as_slice(&self) -> &[T] {
-        self.buffer.as_slice()
-    }
-
-    /// Return the sorted buffer.
-    pub fn into_inner(self) -> Buffer<T> {
-        self.buffer
-    }
-
-    /// Return true if the buffer contains no values.
-    pub fn is_empty(&self) -> bool {
-        self.buffer.is_empty()
-    }
-
-    /// Return the number of values in the buffer.
-    pub fn len(&self) -> usize {
-        self.buffer.len()
-    }
-}
-
-impl<T: Ord> StrictSortedBuffer<T> {
-    /// Create a new buffer, failing if the values are not strictly increasing.
-    pub fn try_new(buffer: Buffer<T>) -> VortexResult<Self> {
-        validate_strictly_sorted(buffer.as_slice())?;
-        Ok(Self { buffer })
-    }
-}
-
-impl<T> Default for StrictSortedBuffer<T> {
-    fn default() -> Self {
-        Self {
-            buffer: Buffer::default(),
-        }
-    }
-}
-
-impl<T: Ord> TryFrom<Buffer<T>> for StrictSortedBuffer<T> {
-    type Error = VortexError;
-
-    fn try_from(value: Buffer<T>) -> Result<Self, Self::Error> {
-        Self::try_new(value)
-    }
-}
-
-impl<T> From<StrictSortedBuffer<T>> for Buffer<T> {
-    fn from(value: StrictSortedBuffer<T>) -> Self {
-        value.into_inner()
-    }
-}
-
-impl<T> std::ops::Deref for StrictSortedBuffer<T> {
-    type Target = [T];
-
-    fn deref(&self) -> &Self::Target {
-        self.as_slice()
-    }
-}
-
-impl<T> AsRef<[T]> for StrictSortedBuffer<T> {
-    fn as_ref(&self) -> &[T] {
-        self.as_slice()
-    }
-}
+use crate::strict_sorted_buffer::StrictSortedBuffer;
 
 /// A selection identifies a set of rows to include in the scan (in addition to applying any
 /// filter predicates).
@@ -184,19 +109,6 @@ impl Selection {
     }
 }
 
-fn validate_strictly_sorted<T: Ord>(values: &[T]) -> VortexResult<()> {
-    for (idx, window) in values.windows(2).enumerate() {
-        if window[0] >= window[1] {
-            vortex_bail!(
-                "buffer values must be strictly increasing at positions {} and {}",
-                idx,
-                idx + 1
-            );
-        }
-    }
-    Ok(())
-}
-
 /// Build the mask of positions within `range` that are named by the given sorted row indices.
 fn index_mask(range: &Range<u64>, range_len: usize, row_indices: &[u64]) -> Mask {
     indices_range(range, row_indices)
@@ -250,7 +162,7 @@ mod tests {
     use vortex_buffer::Buffer;
 
     use super::Selection;
-    use super::StrictSortedBuffer;
+    use crate::strict_sorted_buffer::StrictSortedBuffer;
 
     fn strict_sorted(indices: impl IntoIterator<Item = u64>) -> StrictSortedBuffer<u64> {
         StrictSortedBuffer::try_new(Buffer::from_iter(indices))
@@ -263,18 +175,6 @@ mod tests {
 
     fn exclude(indices: impl IntoIterator<Item = u64>) -> Selection {
         Selection::ExcludeByIndex(strict_sorted(indices))
-    }
-
-    #[test]
-    fn strict_sorted_buffer_rejects_unsorted_values() {
-        let err = StrictSortedBuffer::try_new(Buffer::from_iter([3, 1])).unwrap_err();
-        assert!(err.to_string().contains("strictly increasing"));
-    }
-
-    #[test]
-    fn strict_sorted_buffer_rejects_duplicate_values() {
-        let err = StrictSortedBuffer::try_new(Buffer::from_iter([1, 1])).unwrap_err();
-        assert!(err.to_string().contains("strictly increasing"));
     }
 
     #[test]

--- a/vortex-scan/src/selection.rs
+++ b/vortex-scan/src/selection.rs
@@ -137,54 +137,10 @@ impl Selection {
         match self {
             Selection::All => RowMask::new(range.start, Mask::new_true(range_len)),
             Selection::IncludeByIndex(include) => {
-                let indices = include.as_slice();
-                let mask = indices_range(range, indices)
-                    .map(|idx_range| {
-                        Mask::from_indices(
-                            range_len,
-                            indices[idx_range]
-                                .iter()
-                                .map(|idx| {
-                                    idx.checked_sub(range.start).unwrap_or_else(|| {
-                                        vortex_panic!(
-                                            "index underflow, range: {:?}, idx: {:?}",
-                                            range,
-                                            idx
-                                        )
-                                    })
-                                })
-                                .filter_map(|idx| {
-                                    // Only include indices that fit in usize
-                                    usize::try_from(idx).ok()
-                                }),
-                        )
-                    })
-                    .unwrap_or_else(|| Mask::new_false(range_len));
-
-                RowMask::new(range.start, mask)
+                RowMask::new(range.start, index_mask(range, range_len, include))
             }
             Selection::ExcludeByIndex(exclude) => {
-                let indices = exclude.as_slice();
-                let mask = indices_range(range, indices)
-                    .map(|idx_range| {
-                        Mask::from_indices(
-                            range_len,
-                            indices[idx_range]
-                                .iter()
-                                .map(|idx| {
-                                    idx.checked_sub(range.start).unwrap_or_else(|| {
-                                        vortex_panic!(
-                                            "index underflow, range: {:?}, idx: {:?}",
-                                            range,
-                                            idx
-                                        )
-                                    })
-                                })
-                                .filter_map(|idx| usize::try_from(idx).ok()),
-                        )
-                    })
-                    .unwrap_or_else(|| Mask::new_false(range_len));
-                RowMask::new(range.start, mask.not())
+                RowMask::new(range.start, index_mask(range, range_len, exclude).not())
             }
             Selection::IncludeRoaring(roaring) => {
                 use std::ops::BitAnd;
@@ -199,20 +155,8 @@ impl Selection {
 
                 // Otherwise, intersect with the selected range and shift to relativize.
                 let roaring = roaring.bitand(range_treemap);
-                let mask = Mask::from_indices(
-                    range_len,
-                    roaring
-                        .iter()
-                        .map(|idx| {
-                            idx.checked_sub(range.start).unwrap_or_else(|| {
-                                vortex_panic!("index underflow, range: {:?}, idx: {:?}", range, idx)
-                            })
-                        })
-                        .filter_map(|idx| {
-                            // Only include indices that fit in usize
-                            usize::try_from(idx).ok()
-                        }),
-                );
+                let mask =
+                    Mask::from_indices(range_len, roaring.iter().map(|idx| relativize(range, idx)));
 
                 RowMask::new(range.start, mask)
             }
@@ -231,14 +175,7 @@ impl Selection {
                 let roaring = roaring.bitand(range_treemap);
                 let mask = Mask::from_excluded_indices(
                     range_len,
-                    roaring
-                        .iter()
-                        .map(|idx| {
-                            idx.checked_sub(range.start).unwrap_or_else(|| {
-                                vortex_panic!("index underflow, range: {:?}, idx: {:?}", range, idx)
-                            })
-                        })
-                        .filter_map(|idx| usize::try_from(idx).ok()),
+                    roaring.iter().map(|idx| relativize(range, idx)),
                 );
 
                 RowMask::new(range.start, mask)
@@ -258,6 +195,37 @@ fn validate_strictly_sorted<T: Ord>(values: &[T]) -> VortexResult<()> {
         }
     }
     Ok(())
+}
+
+/// Build the mask of positions within `range` that are named by the given sorted row indices.
+fn index_mask(range: &Range<u64>, range_len: usize, row_indices: &[u64]) -> Mask {
+    indices_range(range, row_indices)
+        .map(|idx_range| {
+            Mask::from_indices(
+                range_len,
+                row_indices[idx_range]
+                    .iter()
+                    .map(|&idx| relativize(range, idx)),
+            )
+        })
+        .unwrap_or_else(|| Mask::new_false(range_len))
+}
+
+/// Shift an absolute row index to be relative to the start of `range`.
+///
+/// Panics if the index is not a `usize`-sized offset into `range`. Callers have already narrowed
+/// the indices to `range`, whose own length had to fit in a `usize` to size the mask, so a failure
+/// here means that invariant was broken rather than that the index was merely out of bounds.
+fn relativize(range: &Range<u64>, idx: u64) -> usize {
+    idx.checked_sub(range.start)
+        .and_then(|relative| usize::try_from(relative).ok())
+        .unwrap_or_else(|| {
+            vortex_panic!(
+                "index {:?} is not a usize offset into range {:?}",
+                idx,
+                range
+            )
+        })
 }
 
 /// Find the positional range within row_indices that covers all rows in the given range.

--- a/vortex-scan/src/strict_sorted_buffer.rs
+++ b/vortex-scan/src/strict_sorted_buffer.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Defines a [`Buffer`] wrapper whose values are known to be strictly sorted.
+
+use std::ops::Deref;
+
+use vortex_buffer::Buffer;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+
+/// A buffer whose values are known to be strictly sorted in ascending order.
+///
+/// Dereferences to the inner [`Buffer`], which in turn dereferences to a slice.
+#[derive(Clone, Debug)]
+pub struct StrictSortedBuffer<T> {
+    buffer: Buffer<T>,
+}
+
+impl<T> StrictSortedBuffer<T> {
+    /// Create a new buffer without checking that the values are strictly increasing.
+    ///
+    /// # Safety
+    ///
+    /// The values must be strictly increasing. Callers of [`StrictSortedBuffer`] rely on this
+    /// invariant, for example to binary search the buffer.
+    pub unsafe fn new_unchecked(buffer: Buffer<T>) -> Self {
+        Self { buffer }
+    }
+
+    /// Return the sorted buffer.
+    pub fn into_inner(self) -> Buffer<T> {
+        self.buffer
+    }
+}
+
+impl<T: Ord> StrictSortedBuffer<T> {
+    /// Create a new buffer, failing if the values are not strictly increasing.
+    pub fn try_new(buffer: Buffer<T>) -> VortexResult<Self> {
+        for (idx, window) in buffer.windows(2).enumerate() {
+            if window[0] >= window[1] {
+                vortex_bail!(
+                    "buffer values must be strictly increasing at positions {} and {}",
+                    idx,
+                    idx + 1
+                );
+            }
+        }
+        Ok(Self { buffer })
+    }
+}
+
+impl<T> Default for StrictSortedBuffer<T> {
+    fn default() -> Self {
+        Self {
+            buffer: Buffer::default(),
+        }
+    }
+}
+
+impl<T> Deref for StrictSortedBuffer<T> {
+    type Target = Buffer<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.buffer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::Buffer;
+
+    use super::StrictSortedBuffer;
+
+    #[test]
+    fn rejects_unsorted_values() {
+        let err = StrictSortedBuffer::try_new(Buffer::from_iter([3, 1])).unwrap_err();
+        assert!(err.to_string().contains("strictly increasing"));
+    }
+
+    #[test]
+    fn rejects_duplicate_values() {
+        let err = StrictSortedBuffer::try_new(Buffer::from_iter([1, 1])).unwrap_err();
+        assert!(err.to_string().contains("strictly increasing"));
+    }
+}


### PR DESCRIPTION
## Rational for this change

We binary search the row selections and therefore panic if they are out of order. Therefore we should validate them on-construction to be sorted

## What changes are included in this PR?

Include/ExcludeByIndex has try_new constructors.

An alternative would be to have a SortedBuffer<T> wrapper type perhaps?

## What APIs are changed? Are there any user-facing changes?

Include/ExcludeByIndex