### PR TITLE
Make Shared transparent to parent kernels

### DIFF
--- a/vortex-array/src/arrays/mod.rs
+++ b/vortex-array/src/arrays/mod.rs
@@ -132,6 +132,7 @@ pub(crate) fn initialize(session: &vortex_session::VortexSession) {
     listview::initialize(session);
     patched::initialize(session);
     primitive::initialize(session);
+    shared::initialize(session);
     struct_::initialize(session);
     varbin::initialize(session);
     varbinview::initialize(session);

--- a/vortex-array/src/arrays/shared/kernel.rs
+++ b/vortex-array/src/arrays/shared/kernel.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+use vortex_session::VortexSession;
+
+use crate::ArrayRef;
+use crate::ArrayVTable;
+use crate::ExecutionCtx;
+use crate::arrays::Shared;
+use crate::arrays::shared::SharedArrayExt;
+use crate::executor::execute_parent_for_child;
+use crate::optimizer::kernels::ArrayKernelsExt;
+use crate::optimizer::kernels::ExecuteParentFn;
+
+pub(crate) fn initialize(session: &VortexSession) {
+    session
+        .kernels()
+        .register_execute_parent_for_any_parent(Shared.id(), &[execute_parent as ExecuteParentFn]);
+}
+
+fn execute_parent(
+    child: &ArrayRef,
+    parent: &ArrayRef,
+    child_idx: usize,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Option<ArrayRef>> {
+    let Some(shared) = child.as_opt::<Shared>() else {
+        return Ok(None);
+    };
+
+    let mut current = shared.current_array_ref().clone();
+    while let Some(source) = current
+        .as_opt::<Shared>()
+        .map(|shared| shared.current_array_ref().clone())
+    {
+        current = source;
+    }
+
+    let kernels = ctx.execute_parent_kernels();
+    execute_parent_for_child(parent, &current, child_idx, kernels.as_ref(), ctx)
+}

--- a/vortex-array/src/arrays/shared/mod.rs
+++ b/vortex-array/src/arrays/shared/mod.rs
@@ -2,12 +2,17 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 mod array;
+mod kernel;
 mod vtable;
 
 pub use array::SharedArrayExt;
 pub use array::SharedData;
 pub use vtable::Shared;
 pub use vtable::SharedArray;
+
+pub(crate) fn initialize(session: &vortex_session::VortexSession) {
+    kernel::initialize(session);
+}
 
 #[cfg(test)]
 mod tests;

--- a/vortex-array/src/arrays/shared/vtable.rs
+++ b/vortex-array/src/arrays/shared/vtable.rs
@@ -113,6 +113,14 @@ impl VTable for Shared {
             .get_or_compute(|source| source.clone().execute::<Canonical>(ctx))
             .map(ExecutionResult::done)
     }
+
+    fn reduce_parent(
+        array: ArrayView<'_, Self>,
+        parent: &ArrayRef,
+        child_idx: usize,
+    ) -> VortexResult<Option<ArrayRef>> {
+        array.current_array_ref().reduce_parent(parent, child_idx)
+    }
 }
 impl OperationsVTable<Shared> for Shared {
     fn scalar_at(

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -34,6 +34,8 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::IntoArray;
 use crate::array::ArrayId;
+use crate::arrays::Shared;
+use crate::arrays::shared::SharedArrayExt;
 use crate::builders::ArrayBuilder;
 use crate::builders::builder_with_capacity_in;
 use crate::dtype::DType;
@@ -563,6 +565,35 @@ fn finalize_done(
 }
 
 fn execute_parent_for_child(
+    parent: &ArrayRef,
+    child: &ArrayRef,
+    slot_idx: usize,
+    kernels: &ParentExecutionKernels,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Option<ArrayRef>> {
+    if let Some(result) = execute_parent_for_exact_child(parent, child, slot_idx, kernels, ctx)? {
+        return Ok(Some(result));
+    }
+
+    // Shared is a transparent cache wrapper. Try kernels against the wrapped source/current array
+    // before forcing Shared to canonicalize and populate its cache.
+    let mut current = child.clone();
+    while let Some(source) = current
+        .as_opt::<Shared>()
+        .map(|shared| shared.current_array_ref().clone())
+    {
+        if let Some(result) =
+            execute_parent_for_exact_child(parent, &source, slot_idx, kernels, ctx)?
+        {
+            return Ok(Some(result));
+        }
+        current = source;
+    }
+
+    Ok(None)
+}
+
+fn execute_parent_for_exact_child(
     parent: &ArrayRef,
     child: &ArrayRef,
     slot_idx: usize,

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -34,8 +34,6 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::IntoArray;
 use crate::array::ArrayId;
-use crate::arrays::Shared;
-use crate::arrays::shared::SharedArrayExt;
 use crate::builders::ArrayBuilder;
 use crate::builders::builder_with_capacity_in;
 use crate::dtype::DType;
@@ -44,8 +42,8 @@ use crate::memory::HostAllocatorRef;
 use crate::memory::MemorySessionExt;
 use crate::optimizer::ArrayOptimizer;
 use crate::optimizer::kernels::ArrayKernelsExt;
+use crate::optimizer::kernels::ExecuteParentKernelRef;
 use crate::optimizer::kernels::ParentExecutionKernels;
-use crate::optimizer::kernels::execute_parent_key;
 use crate::stats::ArrayStats;
 use crate::stats::StatsSet;
 
@@ -362,6 +360,10 @@ impl ExecutionCtx {
         self.session.allocator()
     }
 
+    pub(crate) fn execute_parent_kernels(&self) -> Arc<ParentExecutionKernels> {
+        Arc::clone(&self.execute_parent_kernels)
+    }
+
     /// Log an execution step at the current depth.
     ///
     /// Steps are accumulated and dumped as a single trace on Drop at DEBUG level.
@@ -564,58 +566,50 @@ fn finalize_done(
     Ok((output, None))
 }
 
-fn execute_parent_for_child(
+pub(crate) fn execute_parent_for_child(
     parent: &ArrayRef,
     child: &ArrayRef,
     slot_idx: usize,
     kernels: &ParentExecutionKernels,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ArrayRef>> {
-    if let Some(result) = execute_parent_for_exact_child(parent, child, slot_idx, kernels, ctx)? {
+    if let Some(plugins) = kernels.exact(parent.encoding_id(), child.encoding_id())
+        && let Some(result) =
+            execute_parent_with_plugins(plugins.as_ref(), parent, child, slot_idx, ctx)?
+    {
         return Ok(Some(result));
     }
 
-    // Shared is a transparent cache wrapper. Try kernels against the wrapped source/current array
-    // before forcing Shared to canonicalize and populate its cache.
-    let mut current = child.clone();
-    while let Some(source) = current
-        .as_opt::<Shared>()
-        .map(|shared| shared.current_array_ref().clone())
+    if let Some(plugins) = kernels.any_parent(child.encoding_id())
+        && let Some(result) =
+            execute_parent_with_plugins(plugins.as_ref(), parent, child, slot_idx, ctx)?
     {
-        if let Some(result) =
-            execute_parent_for_exact_child(parent, &source, slot_idx, kernels, ctx)?
-        {
-            return Ok(Some(result));
-        }
-        current = source;
+        return Ok(Some(result));
     }
 
     Ok(None)
 }
 
-fn execute_parent_for_exact_child(
+fn execute_parent_with_plugins(
+    plugins: &[ExecuteParentKernelRef],
     parent: &ArrayRef,
     child: &ArrayRef,
     slot_idx: usize,
-    kernels: &ParentExecutionKernels,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ArrayRef>> {
-    let key = execute_parent_key(parent.encoding_id(), child.encoding_id());
-    if let Some(plugins) = kernels.get(&key) {
-        for plugin in plugins.as_ref() {
-            if let Some(result) = plugin.execute_parent(child, parent, slot_idx, ctx)? {
-                if cfg!(debug_assertions) {
-                    vortex_ensure!(
-                        result.len() == parent.len(),
-                        "Executed parent canonical length mismatch"
-                    );
-                    vortex_ensure!(
-                        result.dtype() == parent.dtype(),
-                        "Executed parent canonical dtype mismatch"
-                    );
-                }
-                return Ok(Some(result));
+    for plugin in plugins {
+        if let Some(result) = plugin.execute_parent(child, parent, slot_idx, ctx)? {
+            if cfg!(debug_assertions) {
+                vortex_ensure!(
+                    result.len() == parent.len(),
+                    "Executed parent canonical length mismatch"
+                );
+                vortex_ensure!(
+                    result.dtype() == parent.dtype(),
+                    "Executed parent canonical dtype mismatch"
+                );
             }
+            return Ok(Some(result));
         }
     }
 
@@ -891,10 +885,13 @@ mod tests {
     use crate::VTable as _;
     use crate::VortexSessionExecute;
     use crate::arrays::Bool;
+    use crate::arrays::BoolArray;
     use crate::arrays::Primitive;
+    use crate::arrays::PrimitiveArray;
+    use crate::arrays::SharedArray;
+    use crate::arrays::shared;
     use crate::optimizer::kernels::ExecuteParentFn;
     use crate::optimizer::kernels::KernelSession;
-    use crate::optimizer::kernels::execute_parent_key;
 
     fn noop_execute_parent(
         _child: &ArrayRef,
@@ -908,13 +905,13 @@ mod tests {
     #[test]
     fn execution_ctx_snapshots_execute_parent_kernels_at_creation() {
         let session = VortexSession::empty().with_some(KernelSession::empty());
-        let key = execute_parent_key(Bool.id(), Primitive.id());
 
         let before_registration = session.create_execution_ctx();
         assert!(
-            !before_registration
+            before_registration
                 .execute_parent_kernels
-                .contains_key(&key)
+                .exact(Bool.id(), Primitive.id())
+                .is_none()
         );
 
         session.kernels().register_execute_parent(
@@ -924,12 +921,53 @@ mod tests {
         );
 
         assert!(
-            !before_registration
+            before_registration
                 .execute_parent_kernels
-                .contains_key(&key)
+                .exact(Bool.id(), Primitive.id())
+                .is_none()
         );
 
         let after_registration = session.create_execution_ctx();
-        assert!(after_registration.execute_parent_kernels.contains_key(&key));
+        assert!(
+            after_registration
+                .execute_parent_kernels
+                .exact(Bool.id(), Primitive.id())
+                .is_some()
+        );
+    }
+
+    fn primitive_execute_parent(
+        child: &ArrayRef,
+        parent: &ArrayRef,
+        child_idx: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        assert!(child.as_opt::<Primitive>().is_some());
+        assert!(parent.as_opt::<Bool>().is_some());
+        assert_eq!(child_idx, 1);
+        Ok(Some(parent.clone()))
+    }
+
+    #[test]
+    fn shared_child_uses_any_parent_execute_kernel() -> VortexResult<()> {
+        let session = VortexSession::empty().with_some(KernelSession::empty());
+        session.kernels().register_execute_parent(
+            Bool.id(),
+            Primitive.id(),
+            &[primitive_execute_parent as ExecuteParentFn],
+        );
+        shared::initialize(&session);
+
+        let mut ctx = session.create_execution_ctx();
+        let kernels = ctx.execute_parent_kernels();
+        let parent = BoolArray::from_iter([true, false]).into_array();
+        let child =
+            SharedArray::new(PrimitiveArray::from_iter([1i32, 2]).into_array()).into_array();
+
+        let result = execute_parent_for_child(&parent, &child, 1, kernels.as_ref(), &mut ctx)?
+            .expect("shared child should dispatch to wrapped primitive kernel");
+
+        assert_eq!(result.encoding_id(), Bool.id());
+        Ok(())
     }
 }

--- a/vortex-array/src/optimizer/kernels.rs
+++ b/vortex-array/src/optimizer/kernels.rs
@@ -10,10 +10,11 @@
 //! extension encoding or take precedence over a built-in rule. When several functions are
 //! registered for the same key and kind, they are tried in registration order until one applies.
 //!
-//! Kernel entries are addressed by `(outer_id, child_id)`. For parent-reduce and execute-parent
-//! kernels, `outer_id` is the id returned by the parent array's `encoding_id()` and `child_id` is
-//! the child array's `encoding_id()`. For [`ScalarFn`](crate::arrays::ScalarFn) parents, the
-//! parent id is the scalar function id.
+//! Parent-reduce and exact execute-parent kernels are addressed by `(outer_id, child_id)`, where
+//! `outer_id` is the id returned by the parent array's `encoding_id()` and `child_id` is the child
+//! array's `encoding_id()`. Execute-parent kernels may also be registered under any parent using a
+//! separate `child_id` map. For [`ScalarFn`](crate::arrays::ScalarFn) parents, the parent id is the
+//! scalar function id.
 //!
 //! Because registered functions have different signatures for each kernel kind, the registry
 //! maintains one storage map per function type rather than a single type-erased map.
@@ -109,7 +110,23 @@ pub trait DynExecuteParentKernel: Debug + Send + Sync + 'static {
 
 pub(crate) type ExecuteParentKernelRef = Arc<dyn DynExecuteParentKernel>;
 
-pub(crate) type ParentExecutionKernels = HashMap<ExecuteParentFnId, Arc<[ExecuteParentKernelRef]>>;
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ParentExecutionKernels {
+    exact: Arc<HashMap<ExecuteParentFnId, Arc<[ExecuteParentKernelRef]>>>,
+    any_parent: Arc<HashMap<Id, Arc<[ExecuteParentKernelRef]>>>,
+}
+
+impl ParentExecutionKernels {
+    /// Look up execute-parent kernels registered for an exact `(parent, child)` pair.
+    pub(crate) fn exact(&self, parent: Id, child: Id) -> Option<&Arc<[ExecuteParentKernelRef]>> {
+        self.exact.get(&execute_parent_key(parent, child))
+    }
+
+    /// Look up execute-parent kernels registered for `child` under any parent.
+    pub(crate) fn any_parent(&self, child: Id) -> Option<&Arc<[ExecuteParentKernelRef]>> {
+        self.any_parent.get(&child)
+    }
+}
 
 #[derive(Debug)]
 struct ExecuteParentFnKernel(ExecuteParentFn);
@@ -173,12 +190,13 @@ impl Borrow<u64> for ExecuteParentFnId {
 
 /// Session-scoped registry of optimizer kernel functions.
 ///
-/// Each kernel kind has its own storage map, keyed by `(outer_id, child_id)`. Registering
-/// functions for an existing key appends them to that key's ordered list.
+/// Each kernel kind has its own storage map. Registering functions for an existing key appends
+/// them to that key's ordered list.
 #[derive(Clone, Debug)]
 pub struct ArrayKernels {
     reduce_parent: ArcSwapMap<ReduceParentFnId, Arc<[ReduceParentFn]>>,
     execute_parent: ArcSwapMap<ExecuteParentFnId, Arc<[ExecuteParentKernelRef]>>,
+    execute_parent_any_parent: ArcSwapMap<Id, Arc<[ExecuteParentKernelRef]>>,
 }
 
 impl Default for ArrayKernels {
@@ -195,6 +213,7 @@ impl ArrayKernels {
         Self {
             reduce_parent: ArcSwapMap::default(),
             execute_parent: ArcSwapMap::default(),
+            execute_parent_any_parent: ArcSwapMap::default(),
         }
     }
 
@@ -243,7 +262,24 @@ impl ArrayKernels {
             .map(|f| Arc::new(ExecuteParentFnKernel(*f)) as ExecuteParentKernelRef)
             .collect();
         self.execute_parent
-            .extend(hash_fn_id(parent, child).into(), kernels.as_slice());
+            .extend(execute_parent_key(parent, child).into(), kernels.as_slice());
+    }
+
+    /// Register [`ExecuteParentFn`]s for `child` under any parent encoding.
+    ///
+    /// The executor invokes exact `(parent, child)` kernels before these wildcard-parent kernels.
+    /// This is intended for transparent wrapper encodings that can delegate based on the actual
+    /// parent at execution time.
+    ///
+    /// If functions have already been registered for this wildcard pair, these functions are
+    /// appended after them.
+    pub fn register_execute_parent_for_any_parent(&self, child: Id, fns: &[ExecuteParentFn]) {
+        let kernels: Vec<ExecuteParentKernelRef> = fns
+            .iter()
+            .map(|f| Arc::new(ExecuteParentFnKernel(*f)) as ExecuteParentKernelRef)
+            .collect();
+        self.execute_parent_any_parent
+            .extend(child, kernels.as_slice());
     }
 
     /// Register a typed [`ExecuteParentKernel`] for `(parent, child.id())`.
@@ -261,7 +297,7 @@ impl ArrayKernels {
     {
         let child_id = child.id();
         self.execute_parent.push(
-            hash_fn_id(parent, child_id).into(),
+            execute_parent_key(parent, child_id).into(),
             Arc::new(RegisteredExecuteParentKernel {
                 _child: child,
                 kernel,
@@ -272,13 +308,22 @@ impl ArrayKernels {
     /// Returns true when one or more execute-parent kernels are registered for `(parent, child)`.
     pub fn has_execute_parent(&self, parent: Id, child: Id) -> bool {
         self.execute_parent
-            .get(&hash_fn_id(parent, child))
+            .get(&execute_parent_key(parent, child))
             .is_some()
+    }
+
+    /// Returns true when one or more execute-parent kernels are registered for any parent with
+    /// `child`.
+    pub fn has_execute_parent_for_any_parent(&self, child: Id) -> bool {
+        self.execute_parent_any_parent.get(&child).is_some()
     }
 
     /// Return the currently published execute-parent kernel snapshot.
     pub(crate) fn execute_parent_snapshot(&self) -> Arc<ParentExecutionKernels> {
-        self.execute_parent.snapshot()
+        Arc::new(ParentExecutionKernels {
+            exact: self.execute_parent.snapshot(),
+            any_parent: self.execute_parent_any_parent.snapshot(),
+        })
     }
 }
 
@@ -367,6 +412,7 @@ mod tests {
     use super::KernelSession;
     use crate::ArrayVTable;
     use crate::arrays::Bool;
+    use crate::arrays::Shared;
     use crate::scalar_fn::ScalarFnVTable;
     use crate::scalar_fn::fns::binary::Binary;
 
@@ -386,6 +432,25 @@ mod tests {
         crate::initialize(&session);
 
         assert!(session.kernels().has_execute_parent(Binary.id(), Bool.id()));
+    }
+
+    #[test]
+    fn initialize_registers_shared_for_any_parent() {
+        let session = VortexSession::empty().with_some(KernelSession::empty());
+
+        assert!(
+            !session
+                .kernels()
+                .has_execute_parent_for_any_parent(Shared.id())
+        );
+
+        crate::initialize(&session);
+
+        assert!(
+            session
+                .kernels()
+                .has_execute_parent_for_any_parent(Shared.id())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Rational for this change

`SharedArray` is a cache wrapper, but parent-kernel execution currently treats it as an ordinary child encoding. That can force canonicalization before the wrapped array gets a chance to handle the parent operation itself. This makes `SharedArray` transparent for parent reductions and parent execution, so existing encoding-specific kernels still fire through shared wrappers.

No tracked issue.

## What changes are included in this PR?

`SharedArray` now delegates parent reduction to its current wrapped array. Parent execution also checks the wrapped array before falling back to ordinary execution, avoiding unnecessary cache population and canonicalization.

## What APIs are changed? Are there any user-facing changes?

No public API changes. Query results are unchanged; this only changes internal execution dispatch.