### PR TITLE
Report DuckDB max cardinality for exact scans

### DIFF
--- a/vortex-duckdb/cpp/include/table_function.h
+++ b/vortex-duckdb/cpp/include/table_function.h
@@ -62,6 +62,8 @@ typedef struct {
 typedef struct {
     idx_t estimated_cardinality;
     bool has_estimated_cardinality;
+    idx_t max_cardinality;
+    bool has_max_cardinality;
 } duckdb_vx_node_statistics;
 
 typedef struct {

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -297,7 +297,8 @@ unique_ptr<NodeStatistics> c_cardinality(ClientContext &, const FunctionData *bi
     auto out = make_uniq<NodeStatistics>();
     out->has_estimated_cardinality = stats.has_estimated_cardinality;
     out->estimated_cardinality = stats.estimated_cardinality;
-    out->has_max_cardinality = false;
+    out->has_max_cardinality = stats.has_max_cardinality;
+    out->max_cardinality = stats.max_cardinality;
 
     return out;
 }

--- a/vortex-duckdb/src/ffi.rs
+++ b/vortex-duckdb/src/ffi.rs
@@ -172,6 +172,12 @@ pub unsafe extern "C-unwind" fn duckdb_table_function_cardinality(
 
     match cardinality(bind_data) {
         Cardinality::Unknown => {}
+        Cardinality::Exact(c) => {
+            node_stats.has_estimated_cardinality = true;
+            node_stats.estimated_cardinality = c as _;
+            node_stats.has_max_cardinality = true;
+            node_stats.max_cardinality = c as _;
+        }
         Cardinality::Estimate(c) => {
             node_stats.has_estimated_cardinality = true;
             node_stats.estimated_cardinality = c as _;

--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -138,6 +138,8 @@ pub struct PartitionData {
 pub enum Cardinality {
     /// Unknown number of rows
     Unknown,
+    /// The exact number of rows.
+    Exact(u64),
     /// An estimate of the number of rows.
     Estimate(u64),
 }
@@ -478,12 +480,18 @@ pub fn statistics(bind_data: &TableFunctionBind, column_index: usize) -> Option<
 /// here.
 const DEFAULT_SELECTIVITY: f64 = 0.2;
 pub fn cardinality(bind_data: &TableFunctionBind) -> Cardinality {
+    let has_non_optional_filter = bind_data.has_non_optional_filter.load(Ordering::Relaxed);
     match bind_data.data_source.row_count() {
-        Precision::Exact(v) | Precision::Inexact(v) => {
-            if !bind_data.has_non_optional_filter.load(Ordering::Relaxed) {
-                // Although we may have an exact upper bound here, reporting
-                // it as exact has a negative performance impact on tpcds as
-                // it's not a real post-filter calculation.
+        Precision::Exact(v) => {
+            if !has_non_optional_filter {
+                return Cardinality::Exact(v);
+            }
+            let post_cardinality = v as f64 * DEFAULT_SELECTIVITY;
+            let post_cardinality: u64 = post_cardinality.as_();
+            Cardinality::Estimate(max(1, post_cardinality))
+        }
+        Precision::Inexact(v) => {
+            if !has_non_optional_filter {
                 return Cardinality::Estimate(v);
             }
             let post_cardinality = v as f64 * DEFAULT_SELECTIVITY;


### PR DESCRIPTION
## Rationale for this change

Reports exact cardinality to DuckDB when we know it.
