### PR TITLE
Expand AWS session time for SQL benchmarks

### DIFF
--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -595,6 +595,8 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::245040174862:role/GitHubBenchmarkRole
           aws-region: us-east-1
+          # Expand session window, otherwise some large scale runs time out.
+          role-duration-seconds: 7200
 
       - name: Upload data
         if: matrix.remote_storage != null && (inputs.mode != 'pr' || github.event.pull_request.head.repo.fork == false)


### PR DESCRIPTION
## Rationale for this change

Turns out nightly benchmarks were very close to the default token lifetime, but a few days ago they seemed to go over, so we should expand the token for a bit.

## What changes are included in this PR?

Doubles the token duration for the sql-benchmarks flow.

## What APIs are changed? Are there any user-facing changes?

N/A