### PR TITLE
Guard calling is_nan on scalar value on dtype being a float

### DIFF
--- a/vortex-array/src/aggregate_fn/fns/max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/max/mod.rs
@@ -49,7 +49,7 @@ impl MaxPartial {
 
         // NaN scalars are incomparable under `partial_max`; they poison the maximum when NaNs
         // participate, and are dropped when they are skipped.
-        if scalar_is_nan(&max) || self.is_poisoned() {
+        if self.element_dtype.is_float() && (scalar_is_nan(&max) || self.is_poisoned()) {
             if !self.skip_nans {
                 self.poison();
             }
@@ -67,7 +67,7 @@ impl MaxPartial {
     }
 
     fn is_poisoned(&self) -> bool {
-        self.max.as_ref().is_some_and(scalar_is_nan)
+        self.element_dtype.is_float() && self.max.as_ref().is_some_and(scalar_is_nan)
     }
 }
 

--- a/vortex-array/src/aggregate_fn/fns/max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/max/mod.rs
@@ -49,7 +49,7 @@ impl MaxPartial {
 
         // NaN scalars are incomparable under `partial_max`; they poison the maximum when NaNs
         // participate, and are dropped when they are skipped.
-        if self.element_dtype.is_float() && (scalar_is_nan(&max) || self.is_poisoned()) {
+        if scalar_is_nan(&max) || self.is_poisoned() {
             if !self.skip_nans {
                 self.poison();
             }

--- a/vortex-array/src/aggregate_fn/fns/min/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min/mod.rs
@@ -49,7 +49,7 @@ impl MinPartial {
 
         // NaN scalars are incomparable under `partial_min`; they poison the minimum when NaNs
         // participate, and are dropped when they are skipped.
-        if scalar_is_nan(&min) || self.is_poisoned() {
+        if self.element_dtype.is_float() && (scalar_is_nan(&min) || self.is_poisoned()) {
             if !self.skip_nans {
                 self.poison();
             }
@@ -67,7 +67,7 @@ impl MinPartial {
     }
 
     fn is_poisoned(&self) -> bool {
-        self.min.as_ref().is_some_and(scalar_is_nan)
+        self.element_dtype.is_float() && self.min.as_ref().is_some_and(scalar_is_nan)
     }
 }
 

--- a/vortex-array/src/aggregate_fn/fns/min/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min/mod.rs
@@ -49,7 +49,7 @@ impl MinPartial {
 
         // NaN scalars are incomparable under `partial_min`; they poison the minimum when NaNs
         // participate, and are dropped when they are skipped.
-        if self.element_dtype.is_float() && (scalar_is_nan(&min) || self.is_poisoned()) {
+        if scalar_is_nan(&min) || self.is_poisoned() {
             if !self.skip_nans {
                 self.poison();
             }

--- a/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
@@ -149,6 +149,10 @@ pub(crate) fn nan_scalar(dtype: &DType) -> Scalar {
 
 /// Whether a scalar holds a primitive float NaN value.
 pub(crate) fn scalar_is_nan(scalar: &Scalar) -> bool {
+    if !scalar.dtype().is_float() {
+        return false;
+    }
+
     scalar.as_primitive_opt().is_some_and(|p| p.is_nan())
 }
 

--- a/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
@@ -210,9 +210,7 @@ impl MinMaxPartial {
         // NaN scalars are incomparable under `partial_min`/`partial_max`, so they are handled
         // explicitly: a NaN extremum poisons the partial state when NaNs participate, and is
         // dropped when they are skipped.
-        if self.element_dtype.is_float()
-            && (scalar_is_nan(&min) || scalar_is_nan(&max) || self.is_poisoned())
-        {
+        if scalar_is_nan(&min) || scalar_is_nan(&max) || self.is_poisoned() {
             if !self.skip_nans {
                 self.poison();
             }

--- a/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
@@ -210,7 +210,9 @@ impl MinMaxPartial {
         // NaN scalars are incomparable under `partial_min`/`partial_max`, so they are handled
         // explicitly: a NaN extremum poisons the partial state when NaNs participate, and is
         // dropped when they are skipped.
-        if scalar_is_nan(&min) || scalar_is_nan(&max) || self.is_poisoned() {
+        if self.element_dtype.is_float()
+            && (scalar_is_nan(&min) || scalar_is_nan(&max) || self.is_poisoned())
+        {
             if !self.skip_nans {
                 self.poison();
             }
@@ -237,7 +239,7 @@ impl MinMaxPartial {
 
     /// Whether the partial state is poisoned to NaN.
     fn is_poisoned(&self) -> bool {
-        self.min.as_ref().is_some_and(scalar_is_nan)
+        self.element_dtype.is_float() && self.min.as_ref().is_some_and(scalar_is_nan)
     }
 }
 

--- a/vortex-array/src/dtype/ptype.rs
+++ b/vortex-array/src/dtype/ptype.rs
@@ -21,6 +21,7 @@ use num_traits::Unsigned;
 use num_traits::bounds::UpperBounded;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 
 use crate::dtype::DType;
@@ -845,7 +846,7 @@ impl TryFrom<&DType> for PType {
         if let DType::Primitive(p, _) = value {
             Ok(*p)
         } else {
-            Err(vortex_err!("Cannot convert DType {} into PType", value))
+            vortex_bail!("Cannot convert DType {value} into PType")
         }
     }
 }


### PR DESCRIPTION
Downcasting scalars is more expensive than checking dtypes

