### PR TITLE
feat(file): make Footer::new public

### DIFF
--- a/vortex-file/src/footer/mod.rs
+++ b/vortex-file/src/footer/mod.rs
@@ -50,7 +50,7 @@ pub struct Footer {
 }
 
 impl Footer {
-    pub(crate) fn new(
+    pub fn new(
         root_layout: LayoutRef,
         segments: Arc<[SegmentSpec]>,
         statistics: Option<FileStatistics>,


### PR DESCRIPTION
## Rationale for this change

`vortex-file` already exposes everything needed to write a Vortex file without the bundled `VortexWriteOptions::write` driver — the `SegmentSink` trait, `accumulate_stats`, `FileStatistics`, `FooterSerializer`, etc. are all public — *except* the final step of constructing the `Footer`. `Footer::new` is `pub(crate)`, so downstream code that drives the layout/segment-write pipeline directly (e.g. a custom `LayoutStrategy` paired with a custom `SegmentSink`) has to either fork the crate or re-implement the writer inside it just to assemble the footer. This closes that single gap.

## What changes are included in this PR?

- Change `Footer::new` from `pub(crate)` to `pub`.

No behavioral change and no new dependencies. `cargo check` and `cargo fmt --check` pass locally.

## What APIs are changed? Are there any user-facing changes?

One additive, non-breaking change: `vortex_file::Footer::new` is now public. Nothing else changes.

---

**AI assistance disclosure:** prepared with an agentic AI coding assistant (Claude Code), per the project's AI policy. The author reviewed the change and verification steps.