### PR TITLE
Fix wasm32 build by gating MultiFileSession on non-wasm targets

### DIFF
--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -303,6 +303,11 @@ impl VortexSessionDefault for VortexSession {
 
         #[cfg(feature = "files")]
         let session = {
+            // `MultiFileSession` holds a `moka` cache whose clock reads `std::time::Instant::now()`
+            // when constructed. `Instant` is unsupported on `wasm32` and panics with "time not
+            // implemented on this platform". Multi-file scanning is not available on wasm anyway, so
+            // only register this session variable on non-wasm targets.
+            #[cfg(not(target_arch = "wasm32"))]
             let session = session.with::<file::multi::MultiFileSession>();
             file::register_default_encodings(&session);
             session

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -301,13 +301,12 @@ impl VortexSessionDefault for VortexSession {
             .with::<MemorySession>()
             .with::<RuntimeSession>();
 
-        #[cfg(feature = "files")]
+        // `MultiFileSession` holds a `moka` cache whose clock reads `std::time::Instant::now()`
+        // when constructed. `Instant` is unsupported on `wasm32` and panics with "time not
+        // implemented on this platform". Multi-file scanning is not available on wasm anyway, so
+        // only register this session variable on non-wasm targets.
+        #[cfg(all(feature = "files", not(target_arch = "wasm32")))]
         let session = {
-            // `MultiFileSession` holds a `moka` cache whose clock reads `std::time::Instant::now()`
-            // when constructed. `Instant` is unsupported on `wasm32` and panics with "time not
-            // implemented on this platform". Multi-file scanning is not available on wasm anyway, so
-            // only register this session variable on non-wasm targets.
-            #[cfg(not(target_arch = "wasm32"))]
             let session = session.with::<file::multi::MultiFileSession>();
             file::register_default_encodings(&session);
             session


### PR DESCRIPTION
## Rationale for this change

The `MultiFileSession` holds a `moka` cache that reads `std::time::Instant::now()` during construction. The `Instant` type is unsupported on `wasm32` targets and panics with "time not implemented on this platform". Since multi-file scanning is not available on wasm anyway, this change gates the `MultiFileSession` registration behind a `#[cfg(not(target_arch = "wasm32"))]` guard to allow the wasm32 build to succeed.

## What changes are included in this PR?

Added a `#[cfg(not(target_arch = "wasm32"))]` attribute to the `MultiFileSession` registration in `vortex/src/lib.rs` to prevent instantiation of the session on wasm32 targets where `std::time::Instant` is not available.

## What APIs are changed? Are there any user-facing changes?

No public APIs are changed. This is a build fix that prevents a panic on wasm32 targets. Multi-file scanning functionality remains unavailable on wasm, as it was before.

https://claude.ai/code/session_01P5VUBo8DhakxhhF1Ux2Kte