### PR TITLE
perf: cache static identifiers to avoid per-call interner locks

### DIFF
--- a/vortex-array/src/aggregate_fn/fns/all_nan/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/all_nan/mod.rs
@@ -3,6 +3,7 @@
 
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::Columnar;
@@ -34,7 +35,8 @@ impl AggregateFnVTable for AllNan {
     type Partial = bool;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.all_nan")
+        static ID: CachedId = CachedId::new("vortex.all_nan");
+        *ID
     }
 
     fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/all_non_distinct/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/all_non_distinct/mod.rs
@@ -19,6 +19,7 @@ use std::sync::LazyLock;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
+use vortex_session::registry::CachedId;
 
 use self::bool::check_bool_identical;
 use self::decimal::check_decimal_identical;
@@ -121,7 +122,8 @@ impl AggregateFnVTable for AllNonDistinct {
     type Partial = AllNonDistinctPartial;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.all_non_distinct")
+        static ID: CachedId = CachedId::new("vortex.all_non_distinct");
+        *ID
     }
 
     fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/all_non_nan/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/all_non_nan/mod.rs
@@ -3,6 +3,7 @@
 
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::Columnar;
@@ -34,7 +35,8 @@ impl AggregateFnVTable for AllNonNan {
     type Partial = bool;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.all_non_nan")
+        static ID: CachedId = CachedId::new("vortex.all_non_nan");
+        *ID
     }
 
     fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/all_non_null/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/all_non_null/mod.rs
@@ -3,6 +3,7 @@
 
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::Columnar;
@@ -26,7 +27,8 @@ impl AggregateFnVTable for AllNonNull {
     type Partial = bool;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.all_non_null")
+        static ID: CachedId = CachedId::new("vortex.all_non_null");
+        *ID
     }
 
     fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/all_null/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/all_null/mod.rs
@@ -3,6 +3,7 @@
 
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::Columnar;
@@ -26,7 +27,8 @@ impl AggregateFnVTable for AllNull {
     type Partial = bool;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.all_null")
+        static ID: CachedId = CachedId::new("vortex.all_null");
+        *ID
     }
 
     fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/bounded_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/bounded_max/mod.rs
@@ -13,6 +13,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::Columnar;
@@ -125,7 +126,8 @@ impl AggregateFnVTable for BoundedMax {
     type Partial = BoundedMaxPartial;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.bounded_max")
+        static ID: CachedId = CachedId::new("vortex.bounded_max");
+        *ID
     }
 
     fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/bounded_min/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/bounded_min/mod.rs
@@ -11,6 +11,7 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::Columnar;
@@ -79,7 +80,8 @@ impl AggregateFnVTable for BoundedMin {
     type Partial = BoundedMinPartial;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.bounded_min")
+        static ID: CachedId = CachedId::new("vortex.bounded_min");
+        *ID
     }
 
     fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/count/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/count/mod.rs
@@ -5,6 +5,7 @@ mod grouped;
 pub(crate) use grouped::CountGroupedKernel;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::Columnar;
@@ -41,7 +42,8 @@ impl AggregateFnVTable for Count {
     type Partial = CountPartial;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.count")
+        static ID: CachedId = CachedId::new("vortex.count");
+        *ID
     }
 
     fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/first/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/first/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_error::VortexResult;
+use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::Columnar;
@@ -40,7 +41,8 @@ impl AggregateFnVTable for First {
     type Partial = FirstPartial;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.first")
+        static ID: CachedId = CachedId::new("vortex.first");
+        *ID
     }
 
     fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/is_constant/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/is_constant/mod.rs
@@ -13,6 +13,7 @@ mod varbin;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_session::registry::CachedId;
 
 use self::bool::check_bool_constant;
 use self::decimal::check_decimal_constant;
@@ -258,7 +259,8 @@ impl AggregateFnVTable for IsConstant {
     type Partial = IsConstantPartial;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.is_constant")
+        static ID: CachedId = CachedId::new("vortex.is_constant");
+        *ID
     }
 
     fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/is_sorted/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/is_sorted/mod.rs
@@ -13,6 +13,7 @@ use std::fmt::Formatter;
 
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_session::registry::CachedId;
 
 use self::bool::check_bool_sorted;
 use self::decimal::check_decimal_sorted;
@@ -232,7 +233,8 @@ impl AggregateFnVTable for IsSorted {
     type Partial = IsSortedPartial;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.is_sorted")
+        static ID: CachedId = CachedId::new("vortex.is_sorted");
+        *ID
     }
 
     fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/last/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/last/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_error::VortexResult;
+use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::Columnar;
@@ -40,7 +41,8 @@ impl AggregateFnVTable for Last {
     type Partial = LastPartial;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.last")
+        static ID: CachedId = CachedId::new("vortex.last");
+        *ID
     }
 
     fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/max/mod.rs
@@ -4,6 +4,7 @@
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::Columnar;
@@ -76,7 +77,8 @@ impl AggregateFnVTable for Max {
     type Partial = MaxPartial;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.max")
+        static ID: CachedId = CachedId::new("vortex.max");
+        *ID
     }
 
     fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/mean/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/mean/mod.rs
@@ -3,6 +3,7 @@
 
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
@@ -62,7 +63,8 @@ impl BinaryCombined for Mean {
     type Right = Count;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.mean")
+        static ID: CachedId = CachedId::new("vortex.mean");
+        *ID
     }
 
     fn left(&self) -> Sum {

--- a/vortex-array/src/aggregate_fn/fns/min/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min/mod.rs
@@ -4,6 +4,7 @@
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::Columnar;
@@ -76,7 +77,8 @@ impl AggregateFnVTable for Min {
     type Partial = MinPartial;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.min")
+        static ID: CachedId = CachedId::new("vortex.min");
+        *ID
     }
 
     fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/min_max/mod.rs
@@ -13,6 +13,7 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_panic;
+use vortex_session::registry::CachedId;
 
 use self::bool::accumulate_bool;
 use self::decimal::accumulate_decimal;
@@ -291,7 +292,8 @@ impl AggregateFnVTable for MinMax {
     type Partial = MinMaxPartial;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.min_max")
+        static ID: CachedId = CachedId::new("vortex.min_max");
+        *ID
     }
 
     fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/nan_count/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/nan_count/mod.rs
@@ -8,6 +8,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use self::primitive::accumulate_primitive;
 use crate::ArrayRef;
@@ -84,7 +85,8 @@ impl AggregateFnVTable for NanCount {
     type Partial = u64;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.nan_count")
+        static ID: CachedId = CachedId::new("vortex.nan_count");
+        *ID
     }
 
     fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/null_count/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/null_count/mod.rs
@@ -5,6 +5,7 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::Columnar;
@@ -59,7 +60,8 @@ impl AggregateFnVTable for NullCount {
     type Partial = u64;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.null_count")
+        static ID: CachedId = CachedId::new("vortex.null_count");
+        *ID
     }
 
     fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/sum/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/mod.rs
@@ -13,6 +13,7 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use self::bool::accumulate_bool;
 use self::constant::multiply_constant;
@@ -81,7 +82,8 @@ impl AggregateFnVTable for Sum {
     type Partial = SumPartial;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.sum")
+        static ID: CachedId = CachedId::new("vortex.sum");
+        *ID
     }
 
     fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
@@ -28,6 +28,7 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_mask::Mask;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::Canonical;
@@ -101,7 +102,8 @@ impl AggregateFnVTable for UncompressedSizeInBytes {
     type Partial = u64;
 
     fn id(&self) -> AggregateFnId {
-        AggregateFnId::new("vortex.uncompressed_size_in_bytes")
+        static ID: CachedId = CachedId::new("vortex.uncompressed_size_in_bytes");
+        *ID
     }
 
     fn serialize(&self, _options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/extension/datetime/date.rs
+++ b/vortex-array/src/extension/datetime/date.rs
@@ -9,6 +9,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
+use vortex_session::registry::CachedId;
 
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -79,7 +80,8 @@ impl ExtVTable for Date {
     type NativeValue<'a> = DateValue;
 
     fn id(&self) -> ExtId {
-        ExtId::new("vortex.date")
+        static ID: CachedId = CachedId::new("vortex.date");
+        *ID
     }
 
     fn serialize_metadata(&self, metadata: &Self::Metadata) -> VortexResult<Vec<u8>> {

--- a/vortex-array/src/extension/datetime/time.rs
+++ b/vortex-array/src/extension/datetime/time.rs
@@ -9,6 +9,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
+use vortex_session::registry::CachedId;
 
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -80,7 +81,8 @@ impl ExtVTable for Time {
     type NativeValue<'a> = TimeValue;
 
     fn id(&self) -> ExtId {
-        ExtId::new("vortex.time")
+        static ID: CachedId = CachedId::new("vortex.time");
+        *ID
     }
 
     fn serialize_metadata(&self, metadata: &Self::Metadata) -> VortexResult<Vec<u8>> {

--- a/vortex-array/src/extension/datetime/timestamp.rs
+++ b/vortex-array/src/extension/datetime/timestamp.rs
@@ -13,6 +13,7 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
+use vortex_session::registry::CachedId;
 
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -114,7 +115,8 @@ impl ExtVTable for Timestamp {
     type NativeValue<'a> = TimestampValue<'a>;
 
     fn id(&self) -> ExtId {
-        ExtId::new("vortex.timestamp")
+        static ID: CachedId = CachedId::new("vortex.timestamp");
+        *ID
     }
 
     // NOTE(ngates): unfortunately we're stuck with this hand-rolled serialization format for

--- a/vortex-array/src/extension/uuid/vtable.rs
+++ b/vortex-array/src/extension/uuid/vtable.rs
@@ -7,6 +7,7 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_ensure_eq;
 use vortex_error::vortex_err;
+use vortex_session::registry::CachedId;
 
 use crate::dtype::DType;
 use crate::dtype::PType;
@@ -27,7 +28,8 @@ impl ExtVTable for Uuid {
     type NativeValue<'a> = uuid::Uuid;
 
     fn id(&self) -> ExtId {
-        ExtId::new("vortex.uuid")
+        static ID: CachedId = CachedId::new("vortex.uuid");
+        *ID
     }
 
     fn serialize_metadata(&self, metadata: &Self::Metadata) -> VortexResult<Vec<u8>> {

--- a/vortex-cuda/src/layout.rs
+++ b/vortex-cuda/src/layout.rs
@@ -65,6 +65,7 @@ use vortex::scalar::ScalarTruncation;
 use vortex::scalar::lower_bound;
 use vortex::scalar::upper_bound;
 use vortex::session::VortexSession;
+use vortex::session::registry::CachedId;
 use vortex::session::registry::ReadContext;
 use vortex::utils::aliases::hash_map::HashMap;
 use vortex::utils::aliases::hash_set::HashSet;
@@ -131,7 +132,8 @@ impl VTable for CudaFlat {
     type Metadata = ProstMetadata<CudaFlatLayoutMetadata>;
 
     fn id(_encoding: &Self::Encoding) -> LayoutId {
-        LayoutId::new("vortex.cuda_flat")
+        static ID: CachedId = CachedId::new("vortex.cuda_flat");
+        *ID
     }
 
     fn encoding(_layout: &Self::Layout) -> LayoutEncodingRef {

--- a/vortex-geo/src/extension/point.rs
+++ b/vortex-geo/src/extension/point.rs
@@ -61,7 +61,8 @@ impl ExtVTable for Point {
     type NativeValue<'a> = Coordinate;
 
     fn id(&self) -> ExtId {
-        ExtId::new_static("vortex.geo.point")
+        static ID: CachedId = CachedId::new("vortex.geo.point");
+        *ID
     }
 
     fn serialize_metadata(&self, metadata: &Self::Metadata) -> VortexResult<Vec<u8>> {

--- a/vortex-geo/src/extension/polygon.rs
+++ b/vortex-geo/src/extension/polygon.rs
@@ -62,7 +62,8 @@ impl ExtVTable for Polygon {
     type NativeValue<'a> = &'a ScalarValue;
 
     fn id(&self) -> ExtId {
-        ExtId::new_static("vortex.geo.polygon")
+        static ID: CachedId = CachedId::new("vortex.geo.polygon");
+        *ID
     }
 
     fn serialize_metadata(&self, metadata: &Self::Metadata) -> VortexResult<Vec<u8>> {

--- a/vortex-geo/src/extension/wkb.rs
+++ b/vortex-geo/src/extension/wkb.rs
@@ -136,7 +136,8 @@ impl ExtVTable for WellKnownBinary {
     type NativeValue<'a> = Wkb<'a>;
 
     fn id(&self) -> ExtId {
-        ExtId::new_static("vortex.geo.wkb")
+        static ID: CachedId = CachedId::new("vortex.geo.wkb");
+        *ID
     }
 
     fn serialize_metadata(&self, metadata: &Self::Metadata) -> VortexResult<Vec<u8>> {

--- a/vortex-geo/src/scalar_fn/distance.rs
+++ b/vortex-geo/src/scalar_fn/distance.rs
@@ -26,6 +26,7 @@ use vortex_array::scalar_fn::TypedScalarFnInstance;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::extension::geometries;
 use crate::extension::single_geometry;
@@ -50,7 +51,8 @@ impl ScalarFnVTable for GeoDistance {
     type Options = EmptyOptions;
 
     fn id(&self) -> ScalarFnId {
-        ScalarFnId::new("vortex.geo.distance")
+        static ID: CachedId = CachedId::new("vortex.geo.distance");
+        *ID
     }
 
     fn serialize(&self, _: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-json/src/dtype.rs
+++ b/vortex-json/src/dtype.rs
@@ -11,6 +11,7 @@ use vortex_array::scalar::ScalarValue;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
+use vortex_session::registry::CachedId;
 
 /// JSON logical type backed by UTF-8 string storage.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -21,7 +22,8 @@ impl ExtVTable for Json {
     type NativeValue<'a> = &'a str;
 
     fn id(&self) -> ExtId {
-        ExtId::new("vortex.json")
+        static ID: CachedId = CachedId::new("vortex.json");
+        *ID
     }
 
     fn serialize_metadata(&self, _metadata: &Self::Metadata) -> VortexResult<Vec<u8>> {

--- a/vortex-layout/src/layouts/chunked/mod.rs
+++ b/vortex-layout/src/layouts/chunked/mod.rs
@@ -11,6 +11,7 @@ use vortex_array::EmptyMetadata;
 use vortex_array::dtype::DType;
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::LayoutBuildContext;
 use crate::LayoutChildType;
@@ -35,7 +36,8 @@ impl VTable for Chunked {
     type Metadata = EmptyMetadata;
 
     fn id(_encoding: &Self::Encoding) -> LayoutId {
-        LayoutId::new("vortex.chunked")
+        static ID: CachedId = CachedId::new("vortex.chunked");
+        *ID
     }
 
     fn encoding(_layout: &Self::Layout) -> LayoutEncodingRef {

--- a/vortex-layout/src/layouts/dict/mod.rs
+++ b/vortex-layout/src/layouts/dict/mod.rs
@@ -19,6 +19,7 @@ use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::LayoutBuildContext;
 use crate::LayoutChildType;
@@ -40,7 +41,8 @@ impl VTable for Dict {
     type Metadata = ProstMetadata<DictLayoutMetadata>;
 
     fn id(_encoding: &Self::Encoding) -> LayoutId {
-        LayoutId::new("vortex.dict")
+        static ID: CachedId = CachedId::new("vortex.dict");
+        *ID
     }
 
     fn encoding(_layout: &Self::Layout) -> LayoutEncodingRef {

--- a/vortex-layout/src/layouts/flat/mod.rs
+++ b/vortex-layout/src/layouts/flat/mod.rs
@@ -16,6 +16,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 use vortex_session::registry::ReadContext;
 
 use crate::LayoutBuildContext;
@@ -46,7 +47,8 @@ impl VTable for Flat {
     type Metadata = ProstMetadata<FlatLayoutMetadata>;
 
     fn id(_encoding: &Self::Encoding) -> LayoutId {
-        LayoutId::new("vortex.flat")
+        static ID: CachedId = CachedId::new("vortex.flat");
+        *ID
     }
 
     fn encoding(_layout: &Self::Layout) -> LayoutEncodingRef {

--- a/vortex-layout/src/layouts/struct_/mod.rs
+++ b/vortex-layout/src/layouts/struct_/mod.rs
@@ -20,6 +20,7 @@ use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 use vortex_session::SessionExt;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::LayoutBuildContext;
 use crate::LayoutChildType;
@@ -42,7 +43,8 @@ impl VTable for Struct {
     type Metadata = EmptyMetadata;
 
     fn id(_encoding: &Self::Encoding) -> LayoutId {
-        LayoutId::new("vortex.struct")
+        static ID: CachedId = CachedId::new("vortex.struct");
+        *ID
     }
 
     fn encoding(_layout: &Self::Layout) -> LayoutEncodingRef {

--- a/vortex-layout/src/layouts/zoned/mod.rs
+++ b/vortex-layout/src/layouts/zoned/mod.rs
@@ -41,6 +41,7 @@ use vortex_error::vortex_ensure;
 use vortex_error::vortex_ensure_eq;
 use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::LayoutBuildContext;
 use crate::LayoutChildType;
@@ -70,7 +71,8 @@ impl VTable for Zoned {
     type Metadata = ZonedMetadata;
 
     fn id(_encoding: &Self::Encoding) -> LayoutId {
-        LayoutId::new("vortex.zoned")
+        static ID: CachedId = CachedId::new("vortex.zoned");
+        *ID
     }
 
     fn encoding(_layout: &Self::Layout) -> LayoutEncodingRef {
@@ -187,7 +189,8 @@ impl VTable for LegacyStats {
     type Metadata = LegacyStatsMetadata;
 
     fn id(_encoding: &Self::Encoding) -> LayoutId {
-        LayoutId::new("vortex.stats")
+        static ID: CachedId = CachedId::new("vortex.stats");
+        *ID
     }
 
     fn encoding(_layout: &Self::Layout) -> LayoutEncodingRef {

--- a/vortex-tensor/src/types/fixed_shape_tensor/vtable.rs
+++ b/vortex-tensor/src/types/fixed_shape_tensor/vtable.rs
@@ -10,6 +10,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_ensure_eq;
+use vortex_session::registry::CachedId;
 
 use crate::types::fixed_shape_tensor::FixedShapeTensor;
 use crate::types::fixed_shape_tensor::FixedShapeTensorMetadata;
@@ -22,7 +23,8 @@ impl ExtVTable for FixedShapeTensor {
     type NativeValue<'a> = &'a ScalarValue;
 
     fn id(&self) -> ExtId {
-        ExtId::new("vortex.tensor.fixed_shape_tensor")
+        static ID: CachedId = CachedId::new("vortex.tensor.fixed_shape_tensor");
+        *ID
     }
 
     fn serialize_metadata(&self, metadata: &Self::Metadata) -> VortexResult<Vec<u8>> {

--- a/vortex-tensor/src/types/vector/vtable.rs
+++ b/vortex-tensor/src/types/vector/vtable.rs
@@ -8,6 +8,7 @@ use vortex_array::dtype::extension::ExtId;
 use vortex_array::dtype::extension::ExtVTable;
 use vortex_array::scalar::ScalarValue;
 use vortex_error::VortexResult;
+use vortex_session::registry::CachedId;
 
 use crate::types::vector::Vector;
 use crate::types::vector::validate_vector_storage_dtype;
@@ -19,7 +20,8 @@ impl ExtVTable for Vector {
     type NativeValue<'a> = &'a ScalarValue;
 
     fn id(&self) -> ExtId {
-        ExtId::new("vortex.tensor.vector")
+        static ID: CachedId = CachedId::new("vortex.tensor.vector");
+        *ID
     }
 
     fn serialize_metadata(&self, _metadata: &Self::Metadata) -> VortexResult<Vec<u8>> {


### PR DESCRIPTION
## Summary

`id()` methods for encodings, scalar/aggregate functions, layouts and extension dtypes built their `Id` via `Id::new`/`Id::new_static`, which interns into a globally locked table (`ThreadedRodeo`) on every call. As noted in #8380 this made identifier construction a hot-path bottleneck under multi-threaded and random access. They now read a `CachedId` static that interns once on first access and returns the cached `Id` lock-free thereafter; the interned value is unchanged, so encoding and serialization behaviour is identical.

This is the migration half of #8380; the workspace `clippy` lint that forbids the locking constructors (so the regression can't return) follows in a separate PR.

Refs: #8380

## Testing

`cargo nextest run -p vortex-session -p vortex-array -p vortex-layout -p vortex-geo -p vortex-tensor -p vortex-json` passes; `cargo +nightly fmt --all --check` and `cargo clippy --all-targets` clean. `vortex-cuda` could not be built locally (no CUDA toolchain); its one migrated `id()` uses the same pattern.

---

I'm Korean, so sorry if any wording reads a little awkward.
