### PR TITLE
fix(vortex-bench): map gs:// scheme to gcs storage label

### DIFF
--- a/vortex-bench/src/utils/constants.rs
+++ b/vortex-bench/src/utils/constants.rs
@@ -4,3 +4,4 @@
 /// Storage type constants
 pub const STORAGE_NVME: &str = "nvme";
 pub const STORAGE_S3: &str = "s3";
+pub const STORAGE_GCS: &str = "gcs";

--- a/vortex-bench/src/utils/file.rs
+++ b/vortex-bench/src/utils/file.rs
@@ -161,11 +161,13 @@ pub fn resolve_data_url(remote_data_dir: Option<&str>, local_subdir: &str) -> Re
 /// - A storage type string ("s3", "nvme")
 /// - Or an error if the scheme is unknown
 pub fn url_scheme_to_storage(url: &Url) -> Result<String> {
+    use super::constants::STORAGE_GCS;
     use super::constants::STORAGE_NVME;
     use super::constants::STORAGE_S3;
 
     match url.scheme() {
         STORAGE_S3 => Ok(STORAGE_S3.to_owned()),
+        "gs" => Ok(STORAGE_GCS.to_owned()),
         "file" => Ok(STORAGE_NVME.to_owned()),
         otherwise => {
             bail!("unknown URL scheme: {}", otherwise)


### PR DESCRIPTION
## Rationale for this change

Running the benchmark harness (`datafusion-bench` / `query_bench`) against a remote
dataset on Google Cloud Storage (`--opt remote-data-dir=gs://…`) fails immediately
during benchmark setup with:

```
Error: unknown URL scheme: gs
```

`vortex-bench`'s `url_scheme_to_storage` helper — which maps a data-dir URL scheme to a
`storage` label used for result reporting — only handled `s3` and `file`, so any `gs://`
run bailed before a single query executed. S3 remote runs work because `s3` is handled;
GCS was simply never covered. `make_object_store` already supports `gs://` for the actual
reads, so the only gap was this reporting helper.

## What changes are included in this PR?

- Add a `STORAGE_GCS = "gcs"` constant.
- Add a `"gs"` arm to `url_scheme_to_storage` returning that label.

Verified by running TPC-H SF1 from a GCS bucket end-to-end (DataFusion + Vortex, 22/22
queries executing against `gs://…`, results tagged `storage=gcs`).

## What APIs are changed? Are there any user-facing changes?

None. This only affects the benchmark harness's storage-label reporting; no public API,
format, or behavior change outside `vortex-bench`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
