### PR TITLE
Add fixed-size-list layout

### DIFF
--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -50,6 +50,8 @@ use vortex_layout::layouts::collect::CollectStrategy;
 use vortex_layout::layouts::compressed::CompressingStrategy;
 use vortex_layout::layouts::compressed::CompressorPlugin;
 use vortex_layout::layouts::dict::writer::DictStrategy;
+#[cfg(feature = "unstable_encodings")]
+use vortex_layout::layouts::fixed_size_list::writer::FixedSizeListLayoutStrategy;
 use vortex_layout::layouts::flat::writer::FlatLayoutStrategy;
 use vortex_layout::layouts::list::writer::ListLayoutStrategy;
 use vortex_layout::layouts::repartition::RepartitionStrategy;
@@ -283,8 +285,20 @@ impl WriteStrategyBuilder {
             flat
         };
 
-        // 7. for each chunk create a flat layout
-        let chunked = ChunkedLayoutStrategy::new(Arc::clone(&flat));
+        // 7. for each chunk create a leaf layout. Under the `unstable_encodings` feature,
+        // fixed-size-list chunks route through `FixedSizeListLayoutStrategy`, which stores
+        // elements and list validity as separately-addressable child layouts. Other chunks fall
+        // through to the flat strategy.
+        #[cfg(feature = "unstable_encodings")]
+        let leaf: Arc<dyn LayoutStrategy> = Arc::new(
+            FixedSizeListLayoutStrategy::default()
+                .with_elements(Arc::clone(&flat))
+                .with_validity(Arc::clone(&flat))
+                .with_fallback(Arc::clone(&flat)),
+        );
+        #[cfg(not(feature = "unstable_encodings"))]
+        let leaf: Arc<dyn LayoutStrategy> = Arc::clone(&flat);
+        let chunked = ChunkedLayoutStrategy::new(leaf);
         // 6. buffer chunks so they end up with closer segment ids physically
         let buffered = BufferedStrategy::new(chunked, 2 * ONE_MEG); // 2MB
 

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -50,8 +50,6 @@ use vortex_layout::layouts::collect::CollectStrategy;
 use vortex_layout::layouts::compressed::CompressingStrategy;
 use vortex_layout::layouts::compressed::CompressorPlugin;
 use vortex_layout::layouts::dict::writer::DictStrategy;
-#[cfg(feature = "unstable_encodings")]
-use vortex_layout::layouts::fixed_size_list::writer::FixedSizeListLayoutStrategy;
 use vortex_layout::layouts::flat::writer::FlatLayoutStrategy;
 use vortex_layout::layouts::list::writer::ListLayoutStrategy;
 use vortex_layout::layouts::repartition::RepartitionStrategy;
@@ -163,7 +161,7 @@ pub struct WriteStrategyBuilder {
     allow_encodings: Option<HashSet<ArrayId>>,
     flat_strategy: Option<Arc<dyn LayoutStrategy>>,
     probe_compressor: Option<Arc<dyn CompressorPlugin>>,
-    /// Whether to write list fields using [`ListLayoutStrategy`].
+    /// Whether to write list-like fields using structural list layouts.
     ///
     /// [`ListLayoutStrategy`]: vortex_layout::layouts::list::writer::ListLayoutStrategy
     use_list_layout: bool,
@@ -205,7 +203,7 @@ impl WriteStrategyBuilder {
         self
     }
 
-    /// Enable writing list fields with [`ListLayoutStrategy`].
+    /// Enable writing list and fixed-size-list fields with structural list layouts.
     ///
     /// **Note**: this is an unstable and experimental layout that is expected to change.
     /// Using it may lead to unreadable files in the future.
@@ -285,18 +283,7 @@ impl WriteStrategyBuilder {
             flat
         };
 
-        // 7. for each chunk create a leaf layout. Under the `unstable_encodings` feature,
-        // fixed-size-list chunks route through `FixedSizeListLayoutStrategy`, which stores
-        // elements and list validity as separately-addressable child layouts. Other chunks fall
-        // through to the flat strategy.
-        #[cfg(feature = "unstable_encodings")]
-        let leaf: Arc<dyn LayoutStrategy> = Arc::new(
-            FixedSizeListLayoutStrategy::default()
-                .with_elements(Arc::clone(&flat))
-                .with_validity(Arc::clone(&flat))
-                .with_fallback(Arc::clone(&flat)),
-        );
-        #[cfg(not(feature = "unstable_encodings"))]
+        // 7. for each chunk create a leaf layout.
         let leaf: Arc<dyn LayoutStrategy> = Arc::clone(&flat);
         let chunked = ChunkedLayoutStrategy::new(leaf);
         // 6. buffer chunks so they end up with closer segment ids physically

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -21,6 +21,7 @@ use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::DecimalArray;
 use vortex_array::arrays::Dict;
+use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::ListArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::StructArray;
@@ -1715,6 +1716,26 @@ async fn nested_list_of_list_roundtrip() -> VortexResult<()> {
         Validity::NonNullable,
     )?
     .into_array();
+    let st = StructArray::from_fields(&[("nested", outer)])?.into_array();
+
+    let result = write_read_roundtrip(st.clone()).await?;
+    assert_arrays_eq!(result, st, &mut SESSION.create_execution_ctx());
+    Ok(())
+}
+
+/// A `fixed_size_list<fixed_size_list<i32>>` column round-trips through the `TableStrategy`
+/// dispatcher, exercising fixed-size-list decomposition recursing into itself.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn nested_fixed_size_list_of_fixed_size_list_roundtrip() -> VortexResult<()> {
+    let inner = FixedSizeListArray::new(
+        buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array(),
+        2,
+        Validity::NonNullable,
+        4,
+    )
+    .into_array();
+    let outer = FixedSizeListArray::new(inner, 2, Validity::NonNullable, 2).into_array();
     let st = StructArray::from_fields(&[("nested", outer)])?.into_array();
 
     let result = write_read_roundtrip(st.clone()).await?;

--- a/vortex-layout/src/layouts/fixed_size_list/expr.rs
+++ b/vortex-layout/src/layouts/fixed_size_list/expr.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::expr::Expression;
+use vortex_array::expr::is_root;
+use vortex_array::expr::not;
+use vortex_array::expr::root;
+use vortex_array::scalar_fn::fns::is_not_null::IsNotNull;
+use vortex_array::scalar_fn::fns::is_null::IsNull;
+use vortex_array::scalar_fn::fns::list_length::ListLength;
+use vortex_error::VortexResult;
+
+/// The minimal set of fixed-size-list children an expression needs for evaluation.
+///
+/// For example:
+///     - `is_null(root())` only needs validity.
+///     - `list_length(root())` needs the fixed list size and validity, but not elements.
+///     - `root()` needs elements and validity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum FixedSizeListChildrenNeeded {
+    /// Only validity is needed (`is_null` / `is_not_null`).
+    Validity,
+    /// Only the fixed list size and validity are needed (`list_length`).
+    ListLengthAndValidity,
+    /// Elements and validity are needed.
+    Elements,
+}
+
+/// The minimal set of fixed-size-list children needed to evaluate `expr`, where `root()` is a
+/// field with fixed-size-list dtype.
+pub(super) fn get_necessary_fixed_size_list_children(
+    expr: &Expression,
+) -> FixedSizeListChildrenNeeded {
+    if is_null_root(expr) {
+        return FixedSizeListChildrenNeeded::Validity;
+    }
+
+    if is_list_length_root(expr) {
+        return FixedSizeListChildrenNeeded::ListLengthAndValidity;
+    }
+
+    if is_root(expr) {
+        return FixedSizeListChildrenNeeded::Elements;
+    }
+
+    expr.children()
+        .iter()
+        .map(get_necessary_fixed_size_list_children)
+        .max()
+        .unwrap_or(FixedSizeListChildrenNeeded::Validity)
+}
+
+fn is_null_root(expr: &Expression) -> bool {
+    (expr.is::<IsNull>() || expr.is::<IsNotNull>())
+        && expr.children().len() == 1
+        && is_root(expr.child(0))
+}
+
+fn is_list_length_root(expr: &Expression) -> bool {
+    expr.is::<ListLength>() && expr.children().len() == 1 && is_root(expr.child(0))
+}
+
+/// Rewrite a validity-class expression so it can be evaluated against the fixed-size-list's
+/// validity bool array (`true` == valid row): `is_not_null(root())` becomes `root()` and
+/// `is_null(root())` becomes `not(root())`. All other nodes are rebuilt with rewritten children.
+pub(super) fn rewrite_validity_expr(expr: &Expression) -> VortexResult<Expression> {
+    if expr.is::<IsNotNull>() && expr.children().len() == 1 && is_root(expr.child(0)) {
+        return Ok(root());
+    }
+    if expr.is::<IsNull>() && expr.children().len() == 1 && is_root(expr.child(0)) {
+        return Ok(not(root()));
+    }
+    let children = expr
+        .children()
+        .iter()
+        .map(rewrite_validity_expr)
+        .collect::<VortexResult<Vec<_>>>()?;
+    expr.clone().with_children(children)
+}
+
+/// Rewrite a list-length-class expression so it can be evaluated against an array of list lengths.
+/// `list_length(root())` becomes `root()`. Other references to `root()` are left intact: for
+/// list-length-class expressions they can only be validity checks, and the lengths array carries
+/// the same validity as the original fixed-size-list.
+pub(super) fn rewrite_list_length_expr(expr: &Expression) -> VortexResult<Expression> {
+    if is_list_length_root(expr) {
+        return Ok(root());
+    }
+
+    let children = expr
+        .children()
+        .iter()
+        .map(rewrite_list_length_expr)
+        .collect::<VortexResult<Vec<_>>>()?;
+    expr.clone().with_children(children)
+}

--- a/vortex-layout/src/layouts/fixed_size_list/mod.rs
+++ b/vortex-layout/src/layouts/fixed_size_list/mod.rs
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+mod reader;
+pub mod writer;
+
+use std::sync::Arc;
+
+use reader::FixedSizeListReader;
+use vortex_array::DeserializeMetadata;
+use vortex_array::EmptyMetadata;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::Nullability;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_ensure;
+use vortex_error::vortex_err;
+use vortex_error::vortex_panic;
+use vortex_session::VortexSession;
+
+use crate::LayoutBuildContext;
+use crate::LayoutChildType;
+use crate::LayoutEncodingRef;
+use crate::LayoutId;
+use crate::LayoutReaderContext;
+use crate::LayoutReaderRef;
+use crate::LayoutRef;
+use crate::VTable;
+use crate::children::LayoutChildren;
+use crate::segments::SegmentId;
+use crate::segments::SegmentSource;
+use crate::vtable;
+
+/// Child index of the `elements` layout.
+pub const ELEMENTS_CHILD_INDEX: usize = 0;
+/// Child index of the `validity` layout, only present when the fixed-size list dtype is nullable.
+pub const VALIDITY_CHILD_INDEX: usize = 1;
+
+vtable!(FixedSizeList);
+
+impl VTable for FixedSizeList {
+    type Layout = FixedSizeListLayout;
+    type Encoding = FixedSizeListLayoutEncoding;
+    type Metadata = EmptyMetadata;
+
+    fn id(_encoding: &Self::Encoding) -> LayoutId {
+        LayoutId::new("vortex.fixed_size_list")
+    }
+
+    fn encoding(_layout: &Self::Layout) -> LayoutEncodingRef {
+        LayoutEncodingRef::new_ref(FixedSizeListLayoutEncoding.as_ref())
+    }
+
+    fn row_count(layout: &Self::Layout) -> u64 {
+        layout.row_count
+    }
+
+    fn dtype(layout: &Self::Layout) -> &DType {
+        &layout.dtype
+    }
+
+    fn metadata(_layout: &Self::Layout) -> Self::Metadata {
+        EmptyMetadata
+    }
+
+    fn segment_ids(_layout: &Self::Layout) -> Vec<SegmentId> {
+        vec![]
+    }
+
+    fn nchildren(layout: &Self::Layout) -> usize {
+        1 + usize::from(layout.dtype.is_nullable())
+    }
+
+    fn child(layout: &Self::Layout, idx: usize) -> VortexResult<LayoutRef> {
+        match (idx, layout.validity.as_ref()) {
+            (ELEMENTS_CHILD_INDEX, _) => Ok(Arc::clone(&layout.elements)),
+            (VALIDITY_CHILD_INDEX, Some(validity)) => Ok(Arc::clone(validity)),
+            _ => vortex_bail!("Invalid child index {idx} for FixedSizeListLayout"),
+        }
+    }
+
+    fn child_type(layout: &Self::Layout, idx: usize) -> LayoutChildType {
+        match (idx, layout.validity.is_some()) {
+            (ELEMENTS_CHILD_INDEX, _) => LayoutChildType::Auxiliary("elements".into()),
+            (VALIDITY_CHILD_INDEX, true) => LayoutChildType::Auxiliary("validity".into()),
+            _ => vortex_panic!("Invalid child index {idx} for FixedSizeListLayout"),
+        }
+    }
+
+    fn new_reader(
+        layout: &Self::Layout,
+        name: Arc<str>,
+        segment_source: Arc<dyn SegmentSource>,
+        session: &VortexSession,
+        ctx: &LayoutReaderContext,
+    ) -> VortexResult<LayoutReaderRef> {
+        Ok(Arc::new(FixedSizeListReader::try_new(
+            layout.clone(),
+            name,
+            segment_source,
+            session.clone(),
+            ctx,
+        )?))
+    }
+
+    fn build(
+        _encoding: &Self::Encoding,
+        dtype: &DType,
+        row_count: u64,
+        _metadata: &<Self::Metadata as DeserializeMetadata>::Output,
+        _segment_ids: Vec<SegmentId>,
+        children: &dyn LayoutChildren,
+        _ctx: &LayoutBuildContext<'_>,
+    ) -> VortexResult<Self::Layout> {
+        validate_children(dtype, row_count, children)?;
+
+        let element_dtype = dtype
+            .as_fixed_size_list_element_opt()
+            .ok_or_else(|| vortex_err!("FixedSizeListLayout requires a FixedSizeList dtype"))?;
+        let elements = children.child(ELEMENTS_CHILD_INDEX, element_dtype)?;
+        let validity = dtype
+            .is_nullable()
+            .then(|| children.child(VALIDITY_CHILD_INDEX, &DType::Bool(Nullability::NonNullable)))
+            .transpose()?;
+
+        Ok(FixedSizeListLayout {
+            row_count,
+            dtype: dtype.clone(),
+            elements,
+            validity,
+        })
+    }
+
+    fn with_children(layout: &mut Self::Layout, children: Vec<LayoutRef>) -> VortexResult<()> {
+        validate_child_count(layout.dtype(), children.len())?;
+
+        let mut iter = children.into_iter();
+        layout.elements = iter
+            .next()
+            .ok_or_else(|| vortex_err!("missing elements child"))?;
+        layout.validity = layout
+            .dtype
+            .is_nullable()
+            .then(|| {
+                iter.next()
+                    .ok_or_else(|| vortex_err!("missing validity child"))
+            })
+            .transpose()?;
+        Ok(())
+    }
+}
+
+fn validate_child_count(dtype: &DType, nchildren: usize) -> VortexResult<()> {
+    let expected = 1 + usize::from(dtype.is_nullable());
+    vortex_ensure!(
+        nchildren == expected,
+        "FixedSizeListLayout expects {expected} children, got {nchildren}"
+    );
+    Ok(())
+}
+
+fn validate_children(
+    dtype: &DType,
+    row_count: u64,
+    children: &dyn LayoutChildren,
+) -> VortexResult<()> {
+    validate_child_count(dtype, children.nchildren())?;
+    let DType::FixedSizeList(_, list_size, _) = dtype else {
+        vortex_bail!("FixedSizeListLayout requires a FixedSizeList dtype, got {dtype}");
+    };
+    let expected_elements = row_count
+        .checked_mul(u64::from(*list_size))
+        .ok_or_else(|| vortex_err!("fixed-size list elements row count overflow"))?;
+    let actual_elements = children.child_row_count(ELEMENTS_CHILD_INDEX);
+    vortex_ensure!(
+        actual_elements == expected_elements,
+        "FixedSizeListLayout elements row count {actual_elements} does not match expected {expected_elements}"
+    );
+    if dtype.is_nullable() {
+        let validity_rows = children.child_row_count(VALIDITY_CHILD_INDEX);
+        vortex_ensure!(
+            validity_rows == row_count,
+            "FixedSizeListLayout validity row count {validity_rows} does not match row count {row_count}"
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct FixedSizeListLayoutEncoding;
+
+/// Stores a fixed-size list by shredding elements and optional list validity into child layouts.
+#[derive(Clone, Debug)]
+pub struct FixedSizeListLayout {
+    row_count: u64,
+    dtype: DType,
+    elements: LayoutRef,
+    validity: Option<LayoutRef>,
+}
+
+impl FixedSizeListLayout {
+    /// Construct a fixed-size-list layout from its components.
+    ///
+    /// # Invariants
+    ///
+    /// - `dtype` must be a [`DType::FixedSizeList`].
+    /// - `elements.row_count() == row_count * list_size`.
+    /// - `validity` is present iff `dtype.is_nullable()`.
+    pub fn new(
+        row_count: u64,
+        dtype: DType,
+        elements: LayoutRef,
+        validity: Option<LayoutRef>,
+    ) -> Self {
+        Self {
+            row_count,
+            dtype,
+            elements,
+            validity,
+        }
+    }
+
+    /// Number of fixed-size-list rows in this layout.
+    #[inline]
+    pub fn row_count(&self) -> u64 {
+        self.row_count
+    }
+
+    #[inline]
+    pub fn elements(&self) -> &LayoutRef {
+        &self.elements
+    }
+
+    #[inline]
+    pub fn validity(&self) -> Option<&LayoutRef> {
+        self.validity.as_ref()
+    }
+
+    /// The fixed number of elements in each list row.
+    #[inline]
+    pub fn list_size(&self) -> u32 {
+        match &self.dtype {
+            DType::FixedSizeList(_, list_size, _) => *list_size,
+            _ => vortex_panic!("FixedSizeListLayout dtype must be FixedSizeList"),
+        }
+    }
+
+    /// The dtype of the inner elements column.
+    pub fn elements_dtype(&self) -> &DType {
+        self.dtype
+            .as_fixed_size_list_element_opt()
+            .vortex_expect("FixedSizeListLayout dtype must be FixedSizeList")
+    }
+}

--- a/vortex-layout/src/layouts/fixed_size_list/mod.rs
+++ b/vortex-layout/src/layouts/fixed_size_list/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+mod expr;
 mod reader;
 pub mod writer;
 
@@ -18,6 +19,7 @@ use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
 
 use crate::LayoutBuildContext;
 use crate::LayoutChildType;
@@ -45,7 +47,8 @@ impl VTable for FixedSizeList {
     type Metadata = EmptyMetadata;
 
     fn id(_encoding: &Self::Encoding) -> LayoutId {
-        LayoutId::new("vortex.fixed_size_list")
+        static ID: CachedId = CachedId::new("vortex.fixed_size_list");
+        *ID
     }
 
     fn encoding(_layout: &Self::Layout) -> LayoutEncodingRef {

--- a/vortex-layout/src/layouts/fixed_size_list/mod.rs
+++ b/vortex-layout/src/layouts/fixed_size_list/mod.rs
@@ -15,7 +15,6 @@ pub mod writer;
 use std::sync::Arc;
 
 use reader::FixedSizeListReader;
-use vortex_array::DeserializeMetadata;
 use vortex_array::EmptyMetadata;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
@@ -28,78 +27,92 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::LayoutBuildContext;
+use crate::Layout;
 use crate::LayoutChildType;
-use crate::LayoutEncodingRef;
+use crate::LayoutDeserializeArgs;
 use crate::LayoutId;
+use crate::LayoutParts;
 use crate::LayoutReaderContext;
 use crate::LayoutReaderRef;
 use crate::LayoutRef;
 use crate::VTable;
 use crate::children::LayoutChildren;
-use crate::segments::SegmentId;
+use crate::children::OwnedLayoutChildren;
 use crate::segments::SegmentSource;
-use crate::vtable;
 
 /// Child index of the `elements` layout.
 pub const ELEMENTS_CHILD_INDEX: usize = 0;
 /// Child index of the `validity` layout, only present when the fixed-size list dtype is nullable.
 pub const VALIDITY_CHILD_INDEX: usize = 1;
 
-vtable!(FixedSizeList);
+/// Fixed-size-list layout vtable.
+#[derive(Clone, Debug)]
+pub struct FixedSizeList;
+
+/// Backwards-compatible name for the fixed-size-list layout plugin.
+pub use FixedSizeList as FixedSizeListLayoutEncoding;
+
+/// A fixed-size-list layout shredded into elements and optional validity children.
+pub type FixedSizeListLayout = Layout<FixedSizeList>;
 
 impl VTable for FixedSizeList {
-    type Layout = FixedSizeListLayout;
-    type Encoding = FixedSizeListLayoutEncoding;
+    type LayoutData = ();
     type Metadata = EmptyMetadata;
 
-    fn id(_encoding: &Self::Encoding) -> LayoutId {
+    fn id(&self) -> LayoutId {
         static ID: CachedId = CachedId::new("vortex.fixed_size_list");
         *ID
     }
 
-    fn encoding(_layout: &Self::Layout) -> LayoutEncodingRef {
-        LayoutEncodingRef::new_ref(FixedSizeListLayoutEncoding.as_ref())
-    }
-
-    fn row_count(layout: &Self::Layout) -> u64 {
-        layout.row_count
-    }
-
-    fn dtype(layout: &Self::Layout) -> &DType {
-        &layout.dtype
-    }
-
-    fn metadata(_layout: &Self::Layout) -> Self::Metadata {
+    fn metadata(_layout: &Layout<Self>) -> Self::Metadata {
         EmptyMetadata
     }
 
-    fn segment_ids(_layout: &Self::Layout) -> Vec<SegmentId> {
-        vec![]
+    fn deserialize(
+        &self,
+        args: &LayoutDeserializeArgs<'_>,
+        _metadata: &EmptyMetadata,
+    ) -> VortexResult<Self::LayoutData> {
+        FixedSizeListLayout::validate_children(args.dtype, args.row_count, args.children)?;
+
+        let element_dtype = args
+            .dtype
+            .as_fixed_size_list_element_opt()
+            .ok_or_else(|| vortex_err!("FixedSizeListLayout requires a FixedSizeList dtype"))?;
+        args.children.child(ELEMENTS_CHILD_INDEX, element_dtype)?;
+        if args.dtype.is_nullable() {
+            args.children
+                .child(VALIDITY_CHILD_INDEX, &DType::Bool(Nullability::NonNullable))?;
+        }
+        Ok(())
     }
 
-    fn nchildren(layout: &Self::Layout) -> usize {
-        1 + usize::from(layout.dtype.is_nullable())
-    }
-
-    fn child(layout: &Self::Layout, idx: usize) -> VortexResult<LayoutRef> {
-        match (idx, layout.validity.as_ref()) {
-            (ELEMENTS_CHILD_INDEX, _) => Ok(Arc::clone(&layout.elements)),
-            (VALIDITY_CHILD_INDEX, Some(validity)) => Ok(Arc::clone(validity)),
+    fn child_dtype(layout: &Layout<Self>, idx: usize) -> VortexResult<DType> {
+        match idx {
+            ELEMENTS_CHILD_INDEX => layout
+                .dtype()
+                .as_fixed_size_list_element_opt()
+                .map(|dtype| dtype.as_ref().clone())
+                .ok_or_else(|| vortex_err!("FixedSizeListLayout requires a FixedSizeList dtype")),
+            VALIDITY_CHILD_INDEX if layout.dtype().is_nullable() => {
+                Ok(DType::Bool(Nullability::NonNullable))
+            }
             _ => vortex_bail!("Invalid child index {idx} for FixedSizeListLayout"),
         }
     }
 
-    fn child_type(layout: &Self::Layout, idx: usize) -> LayoutChildType {
-        match (idx, layout.validity.is_some()) {
-            (ELEMENTS_CHILD_INDEX, _) => LayoutChildType::Auxiliary("elements".into()),
-            (VALIDITY_CHILD_INDEX, true) => LayoutChildType::Auxiliary("validity".into()),
+    fn child_type(layout: &Layout<Self>, idx: usize) -> LayoutChildType {
+        match idx {
+            ELEMENTS_CHILD_INDEX => LayoutChildType::Auxiliary("elements".into()),
+            VALIDITY_CHILD_INDEX if layout.dtype().is_nullable() => {
+                LayoutChildType::Auxiliary("validity".into())
+            }
             _ => vortex_panic!("Invalid child index {idx} for FixedSizeListLayout"),
         }
     }
 
     fn new_reader(
-        layout: &Self::Layout,
+        layout: &Layout<Self>,
         name: Arc<str>,
         segment_source: Arc<dyn SegmentSource>,
         session: &VortexSession,
@@ -113,103 +126,9 @@ impl VTable for FixedSizeList {
             ctx,
         )?))
     }
-
-    fn build(
-        _encoding: &Self::Encoding,
-        dtype: &DType,
-        row_count: u64,
-        _metadata: &<Self::Metadata as DeserializeMetadata>::Output,
-        _segment_ids: Vec<SegmentId>,
-        children: &dyn LayoutChildren,
-        _ctx: &LayoutBuildContext<'_>,
-    ) -> VortexResult<Self::Layout> {
-        validate_children(dtype, row_count, children)?;
-
-        let element_dtype = dtype
-            .as_fixed_size_list_element_opt()
-            .ok_or_else(|| vortex_err!("FixedSizeListLayout requires a FixedSizeList dtype"))?;
-        let elements = children.child(ELEMENTS_CHILD_INDEX, element_dtype)?;
-        let validity = dtype
-            .is_nullable()
-            .then(|| children.child(VALIDITY_CHILD_INDEX, &DType::Bool(Nullability::NonNullable)))
-            .transpose()?;
-
-        Ok(FixedSizeListLayout {
-            row_count,
-            dtype: dtype.clone(),
-            elements,
-            validity,
-        })
-    }
-
-    fn with_children(layout: &mut Self::Layout, children: Vec<LayoutRef>) -> VortexResult<()> {
-        validate_child_count(layout.dtype(), children.len())?;
-
-        let mut iter = children.into_iter();
-        layout.elements = iter
-            .next()
-            .ok_or_else(|| vortex_err!("missing elements child"))?;
-        layout.validity = layout
-            .dtype
-            .is_nullable()
-            .then(|| {
-                iter.next()
-                    .ok_or_else(|| vortex_err!("missing validity child"))
-            })
-            .transpose()?;
-        Ok(())
-    }
 }
 
-fn validate_child_count(dtype: &DType, nchildren: usize) -> VortexResult<()> {
-    let expected = 1 + usize::from(dtype.is_nullable());
-    vortex_ensure!(
-        nchildren == expected,
-        "FixedSizeListLayout expects {expected} children, got {nchildren}"
-    );
-    Ok(())
-}
-
-fn validate_children(
-    dtype: &DType,
-    row_count: u64,
-    children: &dyn LayoutChildren,
-) -> VortexResult<()> {
-    validate_child_count(dtype, children.nchildren())?;
-    let DType::FixedSizeList(_, list_size, _) = dtype else {
-        vortex_bail!("FixedSizeListLayout requires a FixedSizeList dtype, got {dtype}");
-    };
-    let expected_elements = row_count
-        .checked_mul(u64::from(*list_size))
-        .ok_or_else(|| vortex_err!("fixed-size list elements row count overflow"))?;
-    let actual_elements = children.child_row_count(ELEMENTS_CHILD_INDEX);
-    vortex_ensure!(
-        actual_elements == expected_elements,
-        "FixedSizeListLayout elements row count {actual_elements} does not match expected {expected_elements}"
-    );
-    if dtype.is_nullable() {
-        let validity_rows = children.child_row_count(VALIDITY_CHILD_INDEX);
-        vortex_ensure!(
-            validity_rows == row_count,
-            "FixedSizeListLayout validity row count {validity_rows} does not match row count {row_count}"
-        );
-    }
-    Ok(())
-}
-
-#[derive(Debug)]
-pub struct FixedSizeListLayoutEncoding;
-
-/// Stores a fixed-size list by shredding elements and optional list validity into child layouts.
-#[derive(Clone, Debug)]
-pub struct FixedSizeListLayout {
-    row_count: u64,
-    dtype: DType,
-    elements: LayoutRef,
-    validity: Option<LayoutRef>,
-}
-
-impl FixedSizeListLayout {
+impl Layout<FixedSizeList> {
     /// Construct a fixed-size-list layout from its components.
     ///
     /// # Invariants
@@ -223,34 +142,31 @@ impl FixedSizeListLayout {
         elements: LayoutRef,
         validity: Option<LayoutRef>,
     ) -> Self {
-        Self {
-            row_count,
-            dtype,
-            elements,
-            validity,
-        }
+        let mut child_layouts = vec![elements];
+        child_layouts.extend(validity);
+        let children = OwnedLayoutChildren::layout_children(child_layouts);
+        Self::validate_children(&dtype, row_count, children.as_ref())
+            .vortex_expect("invalid fixed-size-list children");
+        LayoutParts::new(FixedSizeList, dtype, row_count, Vec::new(), children, ()).into_typed()
     }
 
-    /// Number of fixed-size-list rows in this layout.
-    #[inline]
-    pub fn row_count(&self) -> u64 {
-        self.row_count
+    /// Returns the elements child.
+    pub fn elements(&self) -> VortexResult<LayoutRef> {
+        self.child(ELEMENTS_CHILD_INDEX)
     }
 
-    #[inline]
-    pub fn elements(&self) -> &LayoutRef {
-        &self.elements
-    }
-
-    #[inline]
-    pub fn validity(&self) -> Option<&LayoutRef> {
-        self.validity.as_ref()
+    /// Returns the optional validity child.
+    pub fn validity(&self) -> VortexResult<Option<LayoutRef>> {
+        self.dtype()
+            .is_nullable()
+            .then(|| self.child(VALIDITY_CHILD_INDEX))
+            .transpose()
     }
 
     /// The fixed number of elements in each list row.
     #[inline]
     pub fn list_size(&self) -> u32 {
-        match &self.dtype {
+        match self.dtype() {
             DType::FixedSizeList(_, list_size, _) => *list_size,
             _ => vortex_panic!("FixedSizeListLayout dtype must be FixedSizeList"),
         }
@@ -258,8 +174,46 @@ impl FixedSizeListLayout {
 
     /// The dtype of the inner elements column.
     pub fn elements_dtype(&self) -> &DType {
-        self.dtype
+        self.dtype()
             .as_fixed_size_list_element_opt()
             .vortex_expect("FixedSizeListLayout dtype must be FixedSizeList")
+    }
+
+    fn validate_child_count(dtype: &DType, nchildren: usize) -> VortexResult<()> {
+        let expected = 1 + usize::from(dtype.is_nullable());
+        vortex_ensure!(
+            nchildren == expected,
+            "FixedSizeListLayout expects {expected} children, got {nchildren}"
+        );
+        Ok(())
+    }
+
+    fn validate_children(
+        dtype: &DType,
+        row_count: u64,
+        children: &dyn LayoutChildren,
+    ) -> VortexResult<()> {
+        Self::validate_child_count(dtype, children.nchildren())?;
+        let DType::FixedSizeList(element_dtype, list_size, _) = dtype else {
+            vortex_bail!("FixedSizeListLayout requires a FixedSizeList dtype, got {dtype}");
+        };
+        children.child(ELEMENTS_CHILD_INDEX, element_dtype)?;
+        let expected_elements = row_count
+            .checked_mul(u64::from(*list_size))
+            .ok_or_else(|| vortex_err!("fixed-size list elements row count overflow"))?;
+        let actual_elements = children.child_row_count(ELEMENTS_CHILD_INDEX);
+        vortex_ensure!(
+            actual_elements == expected_elements,
+            "FixedSizeListLayout elements row count {actual_elements} does not match expected {expected_elements}"
+        );
+        if dtype.is_nullable() {
+            children.child(VALIDITY_CHILD_INDEX, &DType::Bool(Nullability::NonNullable))?;
+            let validity_rows = children.child_row_count(VALIDITY_CHILD_INDEX);
+            vortex_ensure!(
+                validity_rows == row_count,
+                "FixedSizeListLayout validity row count {validity_rows} does not match row count {row_count}"
+            );
+        }
+        Ok(())
     }
 }

--- a/vortex-layout/src/layouts/fixed_size_list/mod.rs
+++ b/vortex-layout/src/layouts/fixed_size_list/mod.rs
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+//! An experimental structural layout for fixed-size-list columns.
+//!
+//! [`FixedSizeListLayout`] decomposes a fixed-size list into independently configurable
+//! `elements` and optional `validity` child layouts. The fixed list size maps outer rows directly
+//! into element ranges, so projections can skip elements belonging exclusively to unselected
+//! leading and trailing rows without storing an offsets child.
+
 mod expr;
 mod reader;
 pub mod writer;

--- a/vortex-layout/src/layouts/fixed_size_list/reader.rs
+++ b/vortex-layout/src/layouts/fixed_size_list/reader.rs
@@ -1,0 +1,621 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use futures::FutureExt;
+use futures::future::BoxFuture;
+use futures::try_join;
+use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
+use vortex_array::MaskFuture;
+use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::FixedSizeListArray;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::FieldMask;
+use vortex_array::dtype::Nullability;
+use vortex_array::expr::Expression;
+use vortex_array::expr::is_root;
+use vortex_array::expr::not;
+use vortex_array::expr::root;
+use vortex_array::scalar_fn::fns::is_not_null::IsNotNull;
+use vortex_array::scalar_fn::fns::is_null::IsNull;
+use vortex_array::validity::Validity;
+use vortex_error::VortexResult;
+use vortex_error::vortex_err;
+use vortex_mask::AllOr;
+use vortex_mask::Mask;
+use vortex_session::VortexSession;
+
+use crate::ArrayFuture;
+use crate::LayoutReader;
+use crate::LayoutReaderContext;
+use crate::LayoutReaderRef;
+use crate::RowSplits;
+use crate::SplitRange;
+use crate::layouts::fixed_size_list::FixedSizeListLayout;
+use crate::segments::SegmentSource;
+
+type OptionalArrayFuture = BoxFuture<'static, VortexResult<Option<ArrayRef>>>;
+
+#[derive(Clone)]
+pub(super) struct FixedSizeListReader {
+    layout: FixedSizeListLayout,
+    name: Arc<str>,
+    session: VortexSession,
+    elements: LayoutReaderRef,
+    validity: Option<LayoutReaderRef>,
+}
+
+impl FixedSizeListReader {
+    pub(super) fn try_new(
+        layout: FixedSizeListLayout,
+        name: Arc<str>,
+        segment_source: Arc<dyn SegmentSource>,
+        session: VortexSession,
+        ctx: &LayoutReaderContext,
+    ) -> VortexResult<Self> {
+        let elements = layout.elements().new_reader(
+            format!("{name}.elements").into(),
+            Arc::clone(&segment_source),
+            &session,
+            ctx,
+        )?;
+        let validity = layout
+            .validity()
+            .map(|v| {
+                v.new_reader(
+                    format!("{name}.validity").into(),
+                    Arc::clone(&segment_source),
+                    &session,
+                    ctx,
+                )
+            })
+            .transpose()?;
+
+        Ok(Self {
+            layout,
+            name,
+            session,
+            elements,
+            validity,
+        })
+    }
+
+    fn project_validity(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: MaskFuture,
+    ) -> VortexResult<ArrayFuture> {
+        let validity_reader = self.validity.clone();
+        let nullability = self.layout.dtype().nullability();
+        let row_range = row_range.clone();
+        let rewritten = rewrite_validity_expr(expr)?;
+
+        Ok(async move {
+            let mask = mask.await?;
+            let row_count = usize::try_from(row_range.end - row_range.start)?;
+            let out_len = if mask.all_true() {
+                row_count
+            } else {
+                mask.true_count()
+            };
+
+            let validity_array = match validity_reader.as_ref() {
+                Some(v) => Some(
+                    v.projection_evaluation(&row_range, &root(), MaskFuture::ready(mask))?
+                        .await?,
+                ),
+                None => None,
+            };
+
+            create_validity(validity_array, nullability)
+                .to_array(out_len)
+                .apply(&rewritten)
+        }
+        .boxed())
+    }
+
+    fn project_elements(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: MaskFuture,
+    ) -> VortexResult<ArrayFuture> {
+        let projection = ElementsProjection {
+            reader: self.clone(),
+            expr: expr.clone(),
+            row_range: row_range.clone(),
+        };
+
+        Ok(async move {
+            let mask = mask.await?;
+            if mask.all_true() {
+                projection.project_full_range().await
+            } else {
+                projection.project_sparse(mask).await
+            }
+        }
+        .boxed())
+    }
+}
+
+impl LayoutReader for FixedSizeListReader {
+    fn name(&self) -> &Arc<str> {
+        &self.name
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn dtype(&self) -> &DType {
+        self.layout.dtype()
+    }
+
+    fn row_count(&self) -> u64 {
+        self.layout.row_count()
+    }
+
+    fn register_splits(
+        &self,
+        field_mask: &[FieldMask],
+        split_range: &SplitRange,
+        splits: &mut RowSplits,
+    ) -> VortexResult<()> {
+        self.elements.register_splits(
+            field_mask,
+            &element_split_range(split_range, self.layout.list_size())?,
+            splits,
+        )?;
+        if let Some(validity) = &self.validity {
+            validity.register_splits(field_mask, split_range, splits)?;
+        }
+        Ok(())
+    }
+
+    fn pruning_evaluation(
+        &self,
+        _row_range: &Range<u64>,
+        _expr: &Expression,
+        mask: Mask,
+    ) -> VortexResult<MaskFuture> {
+        Ok(MaskFuture::ready(mask))
+    }
+
+    fn filter_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: MaskFuture,
+    ) -> VortexResult<MaskFuture> {
+        let len = mask.len();
+        let reader = self.clone();
+        let row_range = row_range.clone();
+        let expr = expr.clone();
+        let session = self.session.clone();
+
+        Ok(MaskFuture::new(len, async move {
+            let mask = mask.await?;
+            if mask.all_false() {
+                return Ok(mask);
+            }
+
+            let predicate = reader
+                .projection_evaluation(&row_range, &expr, MaskFuture::ready(mask.clone()))?
+                .await?;
+            let mut ctx = session.create_execution_ctx();
+            let predicate_mask = predicate.null_as_false().execute(&mut ctx)?;
+
+            if mask.all_true() {
+                Ok(predicate_mask)
+            } else {
+                Ok(mask.intersect_by_rank(&predicate_mask))
+            }
+        }))
+    }
+
+    fn projection_evaluation(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: MaskFuture,
+    ) -> VortexResult<ArrayFuture> {
+        match classify(expr) {
+            ExprClass::Validity => self.project_validity(row_range, expr, mask),
+            ExprClass::Elements => self.project_elements(row_range, expr, mask),
+        }
+    }
+}
+
+fn element_split_range(split_range: &SplitRange, list_size: u32) -> VortexResult<SplitRange> {
+    let list_size = u64::from(list_size);
+    let row_range = element_range(split_range.row_range(), list_size)?;
+    let row_offset = split_range
+        .row_offset()
+        .checked_mul(list_size)
+        .ok_or_else(|| vortex_err!("fixed-size-list split offset overflow"))?;
+    SplitRange::try_new(row_offset, row_range)
+}
+
+fn element_range(row_range: &Range<u64>, list_size: u64) -> VortexResult<Range<u64>> {
+    let start = row_range
+        .start
+        .checked_mul(list_size)
+        .ok_or_else(|| vortex_err!("fixed-size-list element range overflow"))?;
+    let end = row_range
+        .end
+        .checked_mul(list_size)
+        .ok_or_else(|| vortex_err!("fixed-size-list element range overflow"))?;
+    Ok(start..end)
+}
+
+fn fetch_validity(
+    validity: Option<&LayoutReaderRef>,
+    row_range: &Range<u64>,
+    mask: MaskFuture,
+) -> VortexResult<OptionalArrayFuture> {
+    let fut = validity
+        .map(|v| v.projection_evaluation(row_range, &root(), mask))
+        .transpose()?;
+    Ok(async move {
+        match fut {
+            Some(f) => f.await.map(Some),
+            None => Ok(None),
+        }
+    }
+    .boxed())
+}
+
+fn create_validity(validity_array: Option<ArrayRef>, nullability: Nullability) -> Validity {
+    match validity_array {
+        Some(arr) => Validity::Array(arr),
+        None => match nullability {
+            Nullability::Nullable => Validity::AllValid,
+            Nullability::NonNullable => Validity::NonNullable,
+        },
+    }
+}
+
+fn build_fixed_size_list(
+    elements: ArrayRef,
+    validity_array: Option<ArrayRef>,
+    dtype: &DType,
+    len: usize,
+    expr: &Expression,
+) -> VortexResult<ArrayRef> {
+    let DType::FixedSizeList(_, list_size, nullability) = dtype else {
+        return Err(vortex_err!(
+            "FixedSizeListLayout requires FixedSizeList dtype, got {dtype}"
+        ));
+    };
+    let validity = create_validity(validity_array, *nullability);
+    FixedSizeListArray::try_new(elements, *list_size, validity, len)?
+        .into_array()
+        .apply(expr)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ExprClass {
+    Validity,
+    Elements,
+}
+
+fn classify(expr: &Expression) -> ExprClass {
+    if (expr.is::<IsNull>() || expr.is::<IsNotNull>())
+        && expr.children().len() == 1
+        && is_root(expr.child(0))
+    {
+        return ExprClass::Validity;
+    }
+
+    if is_root(expr) {
+        return ExprClass::Elements;
+    }
+
+    expr.children()
+        .iter()
+        .map(classify)
+        .max()
+        .unwrap_or(ExprClass::Validity)
+}
+
+fn rewrite_validity_expr(expr: &Expression) -> VortexResult<Expression> {
+    if expr.is::<IsNotNull>() && expr.children().len() == 1 && is_root(expr.child(0)) {
+        return Ok(root());
+    }
+    if expr.is::<IsNull>() && expr.children().len() == 1 && is_root(expr.child(0)) {
+        return Ok(not(root()));
+    }
+    let children = expr
+        .children()
+        .iter()
+        .map(rewrite_validity_expr)
+        .collect::<VortexResult<Vec<_>>>()?;
+    expr.clone().with_children(children)
+}
+
+struct SparseElementPlan {
+    elements_range: Range<u64>,
+    element_mask: Mask,
+    kept_count: usize,
+}
+
+fn sparse_element_plan(
+    row_range: &Range<u64>,
+    mask: &Mask,
+    list_size: u64,
+) -> VortexResult<SparseElementPlan> {
+    let kept_count = mask.true_count();
+    if kept_count == 0 || list_size == 0 {
+        return Ok(SparseElementPlan {
+            elements_range: 0..0,
+            element_mask: Mask::new_true(0),
+            kept_count,
+        });
+    }
+
+    let first = mask
+        .first()
+        .ok_or_else(|| vortex_err!("sparse mask has no true values"))?;
+    let last = mask
+        .last()
+        .ok_or_else(|| vortex_err!("sparse mask has no true values"))?;
+    let first_row = row_range
+        .start
+        .checked_add(u64::try_from(first)?)
+        .ok_or_else(|| vortex_err!("fixed-size-list row range overflow"))?;
+    let last_row_exclusive = row_range
+        .start
+        .checked_add(u64::try_from(last + 1)?)
+        .ok_or_else(|| vortex_err!("fixed-size-list row range overflow"))?;
+    let elements_range = element_range(&(first_row..last_row_exclusive), list_size)?;
+    let element_mask_len = usize::try_from(elements_range.end - elements_range.start)?;
+
+    let list_size_usize = usize::try_from(list_size)?;
+    let mut element_slices = Vec::with_capacity(kept_count);
+    match mask.indices() {
+        AllOr::All => {
+            return Ok(SparseElementPlan {
+                elements_range,
+                element_mask: Mask::new_true(element_mask_len),
+                kept_count,
+            });
+        }
+        AllOr::None => {}
+        AllOr::Some(indices) => {
+            for &idx in indices {
+                let relative = idx - first;
+                let start = relative
+                    .checked_mul(list_size_usize)
+                    .ok_or_else(|| vortex_err!("fixed-size-list element mask overflow"))?;
+                element_slices.push((start, start + list_size_usize));
+            }
+        }
+    }
+
+    Ok(SparseElementPlan {
+        elements_range,
+        element_mask: Mask::from_slices(element_mask_len, element_slices),
+        kept_count,
+    })
+}
+
+struct ElementsProjection {
+    reader: FixedSizeListReader,
+    expr: Expression,
+    row_range: Range<u64>,
+}
+
+impl ElementsProjection {
+    async fn project_full_range(self) -> VortexResult<ArrayRef> {
+        let Self {
+            reader,
+            expr,
+            row_range,
+        } = self;
+        let len = usize::try_from(row_range.end - row_range.start)?;
+        let list_size = u64::from(reader.layout.list_size());
+        let elements_range = element_range(&row_range, list_size)?;
+        let elements_len = usize::try_from(elements_range.end - elements_range.start)?;
+        let elements_fut = reader.elements.projection_evaluation(
+            &elements_range,
+            &root(),
+            MaskFuture::new_true(elements_len),
+        )?;
+        let validity_fut = fetch_validity(
+            reader.validity.as_ref(),
+            &row_range,
+            MaskFuture::new_true(len),
+        )?;
+        let (elements, validity) = try_join!(elements_fut, validity_fut)?;
+        build_fixed_size_list(elements, validity, reader.layout.dtype(), len, &expr)
+    }
+
+    async fn project_sparse(self, mask: Mask) -> VortexResult<ArrayRef> {
+        let Self {
+            reader,
+            expr,
+            row_range,
+        } = self;
+        let plan = sparse_element_plan(&row_range, &mask, u64::from(reader.layout.list_size()))?;
+        let elements_fut = reader.elements.projection_evaluation(
+            &plan.elements_range,
+            &root(),
+            MaskFuture::ready(plan.element_mask),
+        )?;
+        let validity_fut = fetch_validity(
+            reader.validity.as_ref(),
+            &row_range,
+            MaskFuture::ready(mask),
+        )?;
+        let (elements, validity) = try_join!(elements_fut, validity_fut)?;
+        build_fixed_size_list(
+            elements,
+            validity,
+            reader.layout.dtype(),
+            plan.kept_count,
+            &expr,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_array::ArrayContext;
+    use vortex_array::arrays::BoolArray;
+    use vortex_array::arrays::FixedSizeListArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::assert_arrays_eq;
+    use vortex_array::expr::is_not_null;
+    use vortex_array::expr::is_null;
+    use vortex_array::validity::Validity;
+
+    use super::*;
+    use crate::LayoutStrategy;
+    use crate::layouts::fixed_size_list::writer::FixedSizeListLayoutStrategy;
+    use crate::segments::SegmentSource;
+    use crate::segments::TestSegments;
+    use crate::sequence::SequenceId;
+    use crate::sequence::SequentialArrayStreamExt;
+    use crate::test::SESSION;
+
+    async fn write_layout(
+        array: ArrayRef,
+    ) -> VortexResult<(Arc<dyn SegmentSource>, crate::LayoutRef)> {
+        let segments = Arc::new(TestSegments::default());
+        let segments_ref: Arc<dyn SegmentSource> = Arc::<TestSegments>::clone(&segments);
+        let (ptr, eof) = SequenceId::root().split();
+        let stream = array.to_array_stream().sequenced(ptr);
+        let layout = FixedSizeListLayoutStrategy::default()
+            .write_stream(ArrayContext::empty(), segments, stream, eof, &SESSION)
+            .await?;
+        Ok((segments_ref, layout))
+    }
+
+    fn create_fsl(nullable: bool) -> ArrayRef {
+        let validity = if nullable {
+            Validity::Array(BoolArray::from_iter([true, false, true, true]).into_array())
+        } else {
+            Validity::NonNullable
+        };
+        FixedSizeListArray::new(
+            PrimitiveArray::from_iter(0i32..8).into_array(),
+            2,
+            validity,
+            4,
+        )
+        .into_array()
+    }
+
+    #[rstest]
+    #[case::non_nullable(false)]
+    #[case::nullable(true)]
+    #[tokio::test]
+    async fn projection_full_range(#[case] nullable: bool) -> VortexResult<()> {
+        let fsl = create_fsl(nullable);
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout) = write_layout(fsl.clone()).await?;
+        let reader = layout.new_reader("".into(), segments, &SESSION, &ctx)?;
+
+        let result = reader
+            .projection_evaluation(&(0..4), &root(), MaskFuture::new_true(4))?
+            .await?;
+
+        let mut exec_ctx = SESSION.create_execution_ctx();
+        assert_arrays_eq!(result, fsl, &mut exec_ctx);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn projection_partial_range() -> VortexResult<()> {
+        let fsl = create_fsl(true);
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout) = write_layout(fsl.clone()).await?;
+        let reader = layout.new_reader("".into(), segments, &SESSION, &ctx)?;
+
+        let result = reader
+            .projection_evaluation(&(1..4), &root(), MaskFuture::new_true(3))?
+            .await?;
+        let expected = fsl.slice(1..4)?;
+
+        let mut exec_ctx = SESSION.create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut exec_ctx);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn projection_sparse_mask() -> VortexResult<()> {
+        let fsl = create_fsl(true);
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout) = write_layout(fsl.clone()).await?;
+        let reader = layout.new_reader("".into(), segments, &SESSION, &ctx)?;
+        let mask = Mask::from_iter([true, false, false, true]);
+
+        let result = reader
+            .projection_evaluation(&(0..4), &root(), MaskFuture::ready(mask.clone()))?
+            .await?;
+        let expected = fsl.filter(mask)?;
+
+        let mut exec_ctx = SESSION.create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut exec_ctx);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn projection_degenerate_list_size_zero() -> VortexResult<()> {
+        let fsl = FixedSizeListArray::new(
+            PrimitiveArray::empty::<i32>(Nullability::NonNullable).into_array(),
+            0,
+            Validity::Array(BoolArray::from_iter([true, false, true]).into_array()),
+            3,
+        )
+        .into_array();
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout) = write_layout(fsl.clone()).await?;
+        let reader = layout.new_reader("".into(), segments, &SESSION, &ctx)?;
+        let mask = Mask::from_iter([false, true, true]);
+
+        let result = reader
+            .projection_evaluation(&(0..3), &root(), MaskFuture::ready(mask.clone()))?
+            .await?;
+        let expected = fsl.filter(mask)?;
+
+        let mut exec_ctx = SESSION.create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut exec_ctx);
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::nullable(true, vec![true, false, true, true])]
+    #[case::non_nullable(false, vec![true, true, true, true])]
+    #[tokio::test]
+    async fn projection_validity_class(
+        #[case] nullable: bool,
+        #[case] valid: Vec<bool>,
+    ) -> VortexResult<()> {
+        let fsl = create_fsl(nullable);
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout) = write_layout(fsl).await?;
+        let reader = layout.new_reader("".into(), segments, &SESSION, &ctx)?;
+
+        let not_null = reader
+            .projection_evaluation(&(0..4), &is_not_null(root()), MaskFuture::new_true(4))?
+            .await?;
+        let mut exec_ctx = SESSION.create_execution_ctx();
+        assert_arrays_eq!(not_null, BoolArray::from_iter(valid.clone()), &mut exec_ctx);
+
+        let null = reader
+            .projection_evaluation(&(0..4), &is_null(root()), MaskFuture::new_true(4))?
+            .await?;
+        assert_arrays_eq!(
+            null,
+            BoolArray::from_iter(valid.iter().map(|v| !v).collect::<Vec<_>>()),
+            &mut exec_ctx
+        );
+        Ok(())
+    }
+}

--- a/vortex-layout/src/layouts/fixed_size_list/reader.rs
+++ b/vortex-layout/src/layouts/fixed_size_list/reader.rs
@@ -230,6 +230,10 @@ impl LayoutReader for FixedSizeListReader {
         let list_size = u64::from(self.layout.list_size());
         if list_size != 0 {
             let element_range = element_range(split_range.row_range(), list_size)?;
+
+            // The elements reader reports natural splits in element coordinates. Keep these
+            // temporary splits in element space, then convert them back to fixed-size-list row
+            // coordinates below, rounding forward so a split never cuts through a parent row.
             let mut element_splits = RowSplits::new_capacity(8);
             self.elements.register_splits(
                 field_mask,
@@ -410,7 +414,11 @@ mod tests {
 
     use super::*;
     use crate::LayoutStrategy;
+    use crate::layouts::chunked::writer::ChunkedLayoutStrategy;
     use crate::layouts::fixed_size_list::writer::FixedSizeListLayoutStrategy;
+    use crate::layouts::flat::writer::FlatLayoutStrategy;
+    use crate::layouts::repartition::RepartitionStrategy;
+    use crate::layouts::repartition::RepartitionWriterOptions;
     use crate::scan::split_by::SplitBy;
     use crate::segments::SegmentSource;
     use crate::segments::TestSegments;
@@ -421,14 +429,33 @@ mod tests {
     async fn write_layout(
         array: ArrayRef,
     ) -> VortexResult<(Arc<dyn SegmentSource>, crate::LayoutRef)> {
+        write_layout_with_strategy(&FixedSizeListLayoutStrategy::default(), array).await
+    }
+
+    async fn write_layout_with_strategy<S: LayoutStrategy>(
+        strategy: &S,
+        array: ArrayRef,
+    ) -> VortexResult<(Arc<dyn SegmentSource>, crate::LayoutRef)> {
         let segments = Arc::new(TestSegments::default());
         let segments_ref: Arc<dyn SegmentSource> = Arc::<TestSegments>::clone(&segments);
         let (ptr, eof) = SequenceId::root().split();
         let stream = array.to_array_stream().sequenced(ptr);
-        let layout = FixedSizeListLayoutStrategy::default()
+        let layout = strategy
             .write_stream(ArrayContext::empty(), segments, stream, eof, &SESSION)
             .await?;
         Ok((segments_ref, layout))
+    }
+
+    fn repartitioned_chunk_strategy(block_len_multiple: usize) -> Arc<dyn LayoutStrategy> {
+        Arc::new(RepartitionStrategy::new(
+            ChunkedLayoutStrategy::new(FlatLayoutStrategy::default()),
+            RepartitionWriterOptions {
+                block_size_minimum: 0,
+                block_len_multiple,
+                block_size_target: None,
+                canonicalize: true,
+            },
+        ))
     }
 
     fn create_fsl(nullable: bool) -> ArrayRef {
@@ -538,6 +565,88 @@ mod tests {
         )?;
 
         assert_eq!(splits, vec![0, 4]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn layout_splits_round_chunked_element_boundaries_to_parent_rows() -> VortexResult<()> {
+        let fsl = FixedSizeListArray::new(
+            PrimitiveArray::from_iter(0i32..15).into_array(),
+            3,
+            Validity::NonNullable,
+            5,
+        )
+        .into_array();
+        let strategy =
+            FixedSizeListLayoutStrategy::default().with_elements(repartitioned_chunk_strategy(4));
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout) = write_layout_with_strategy(&strategy, fsl).await?;
+        let reader = layout.new_reader("".into(), segments, &SESSION, &ctx)?;
+
+        let splits = SplitBy::Layout.splits(
+            reader.as_ref(),
+            &(0..5),
+            &[FieldMask::Exact(FieldPath::root())],
+        )?;
+
+        // Element boundaries 4, 8, and 12 map to parent rows ceil(n / 3): 2, 3, and 4.
+        assert_eq!(splits, vec![0, 2, 3, 4, 5]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn layout_splits_map_through_nested_fixed_size_lists() -> VortexResult<()> {
+        let inner = FixedSizeListArray::new(
+            PrimitiveArray::from_iter(0i32..24).into_array(),
+            3,
+            Validity::NonNullable,
+            8,
+        )
+        .into_array();
+        let outer = FixedSizeListArray::new(inner, 2, Validity::NonNullable, 4).into_array();
+
+        let inner_strategy =
+            FixedSizeListLayoutStrategy::default().with_elements(repartitioned_chunk_strategy(7));
+        let outer_strategy =
+            FixedSizeListLayoutStrategy::default().with_elements(Arc::new(inner_strategy));
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout) = write_layout_with_strategy(&outer_strategy, outer).await?;
+        let reader = layout.new_reader("".into(), segments, &SESSION, &ctx)?;
+
+        let splits = SplitBy::Layout.splits(
+            reader.as_ref(),
+            &(0..4),
+            &[FieldMask::Exact(FieldPath::root())],
+        )?;
+
+        // Primitive boundaries 7, 14, and 21 first map to inner rows 3, 5, and 7,
+        // then to outer rows 2, 3, and 4. The range end already supplies row 4.
+        assert_eq!(splits, vec![0, 2, 3, 4]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn layout_splits_preserve_chunked_validity_row_boundaries() -> VortexResult<()> {
+        let fsl = FixedSizeListArray::new(
+            PrimitiveArray::from_iter(0i32..15).into_array(),
+            3,
+            Validity::Array(BoolArray::from_iter([true, false, true, true, false]).into_array()),
+            5,
+        )
+        .into_array();
+        let strategy =
+            FixedSizeListLayoutStrategy::default().with_validity(repartitioned_chunk_strategy(2));
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout) = write_layout_with_strategy(&strategy, fsl).await?;
+        let reader = layout.new_reader("".into(), segments, &SESSION, &ctx)?;
+
+        let splits = SplitBy::Layout.splits(
+            reader.as_ref(),
+            &(0..5),
+            &[FieldMask::Exact(FieldPath::root())],
+        )?;
+
+        assert_eq!(splits, vec![0, 2, 4, 5]);
         Ok(())
     }
 

--- a/vortex-layout/src/layouts/fixed_size_list/reader.rs
+++ b/vortex-layout/src/layouts/fixed_size_list/reader.rs
@@ -8,6 +8,7 @@ use futures::FutureExt;
 use futures::future::BoxFuture;
 use futures::try_join;
 use vortex_array::ArrayRef;
+use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::MaskFuture;
 use vortex_array::VortexSessionExecute;
@@ -131,74 +132,142 @@ impl FixedSizeListReader {
         mask: MaskFuture,
     ) -> VortexResult<ArrayFuture> {
         let list_size = u64::from(self.layout.list_size());
-        let nullability = self.layout.dtype().nullability();
         let row_count = usize::try_from(row_range.end - row_range.start)?;
+        let reader = self.clone();
+        let row_range = row_range.clone();
         let rewritten = rewrite_list_length_expr(expr)?;
-        let validity_fut = fetch_validity(
-            self.validity.as_ref(),
-            row_range,
-            MaskFuture::new_true(row_count),
-        )?;
 
         Ok(async move {
-            let validity = validity_fut.await?;
+            let mask = mask.await?;
+            let validity_mask = if mask.all_true() {
+                MaskFuture::new_true(row_count)
+            } else {
+                MaskFuture::ready(mask.clone())
+            };
+            let validity =
+                fetch_validity(reader.validity.as_ref(), &row_range, validity_mask)?.await?;
+
+            let nullability = reader.layout.dtype().nullability();
             let lengths = ConstantArray::new(list_size, row_count)
                 .into_array()
                 .cast(DType::Primitive(PType::U64, nullability))?;
-            let lengths = apply_validity(lengths, validity, nullability)?;
-
-            let mask = mask.await?;
             let lengths = if mask.all_true() {
                 lengths
             } else {
                 lengths.filter(mask)?
             };
+            let lengths = apply_validity(lengths, validity, nullability)?;
             lengths.apply(&rewritten)
         }
         .boxed())
     }
 
-    fn project_elements(
+    /// Projection for [`FixedSizeListChildrenNeeded::Elements`].
+    ///
+    /// An all-true mask over the full local range reads every child concurrently. Otherwise, the
+    /// read is bounded to the first and last selected fixed-size list.
+    fn project_all(
         &self,
         row_range: &Range<u64>,
         expr: &Expression,
         mask: MaskFuture,
     ) -> VortexResult<ArrayFuture> {
+        let is_full_range = row_range.start == 0 && row_range.end == self.layout.row_count();
         let reader = self.clone();
-        let expr = expr.clone();
         let row_range = row_range.clone();
+        let expr = expr.clone();
 
         Ok(async move {
-            let row_count = usize::try_from(row_range.end - row_range.start)?;
-            let list_size = u64::from(reader.layout.list_size());
-            let elements_range = element_range(&row_range, list_size)?;
-            let elements_len = usize::try_from(elements_range.end - elements_range.start)?;
-
-            let elements_fut = reader.elements.projection_evaluation(
-                &elements_range,
-                &root(),
-                MaskFuture::new_true(elements_len),
-            )?;
-
-            let validity_fut = fetch_validity(
-                reader.validity.as_ref(),
-                &row_range,
-                MaskFuture::new_true(row_count),
-            )?;
-
-            let (elements, validity) = try_join!(elements_fut, validity_fut)?;
-            let fsl = build_fixed_size_list(elements, validity, reader.layout.dtype(), row_count)?;
-
             let mask = mask.await?;
-            let fsl = if mask.all_true() {
+            if is_full_range && mask.all_true() {
+                reader.project_all_full(&expr)?.await
+            } else {
+                reader.project_all_bounded(&row_range, &expr, mask)?.await
+            }
+        }
+        .boxed())
+    }
+
+    /// Fetch the complete `elements` and `validity` children concurrently.
+    fn project_all_full(&self, expr: &Expression) -> VortexResult<ArrayFuture> {
+        let row_count = usize::try_from(self.layout.row_count())?;
+        let list_size = u64::from(self.layout.list_size());
+        let elements_range = element_range(&(0..self.layout.row_count()), list_size)?;
+        let expr = expr.clone();
+
+        let elements_fut = self.fetch_raw_elements(&elements_range)?;
+        let validity_fut = fetch_validity(
+            self.validity.as_ref(),
+            &(0..self.layout.row_count()),
+            MaskFuture::new_true(row_count),
+        )?;
+
+        let dtype = self.layout.dtype().clone();
+        Ok(async move {
+            let (elements, validity) = try_join!(elements_fut, validity_fut)?;
+            let fsl = build_fixed_size_list(elements, validity, &dtype, row_count)?;
+            fsl.apply(&expr)
+        }
+        .boxed())
+    }
+
+    /// Bounded read for a sub-range or selective mask.
+    ///
+    /// Crops leading and trailing unselected fixed-size lists, maps the cropped row range directly
+    /// into element coordinates, and filters any holes after reconstructing the array.
+    fn project_all_bounded(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: Mask,
+    ) -> VortexResult<ArrayFuture> {
+        let Some(selected_rows) = selected_row_range(&mask) else {
+            let empty = Canonical::empty(self.layout.dtype()).into_array();
+            let expr = expr.clone();
+            return Ok(async move { empty.apply(&expr) }.boxed());
+        };
+
+        let selected_mask = mask.slice(selected_rows.clone());
+        let selected_row_range = (row_range.start + u64::try_from(selected_rows.start)?)
+            ..(row_range.start + u64::try_from(selected_rows.end)?);
+        let row_count = selected_mask.len();
+        let list_size = u64::from(self.layout.list_size());
+        let elements_range = element_range(&selected_row_range, list_size)?;
+        let expr = expr.clone();
+
+        let elements_fut = self.fetch_raw_elements(&elements_range)?;
+        let validity_fut = fetch_validity(
+            self.validity.as_ref(),
+            &selected_row_range,
+            MaskFuture::new_true(row_count),
+        )?;
+        let dtype = self.layout.dtype().clone();
+        Ok(async move {
+            let (elements, validity) = try_join!(elements_fut, validity_fut)?;
+            let fsl = build_fixed_size_list(elements, validity, &dtype, row_count)?;
+
+            let fsl = if selected_mask.all_true() {
                 fsl
             } else {
-                fsl.filter(mask)?
+                fsl.filter(selected_mask)?
             };
             fsl.apply(&expr)
         }
         .boxed())
     }
+
+    /// Fire the elements read for `row_range` in element space.
+    ///
+    /// No mask or expression is applied.
+    fn fetch_raw_elements(&self, row_range: &Range<u64>) -> VortexResult<ArrayFuture> {
+        let row_count = usize::try_from(row_range.end - row_range.start)?;
+        self.elements
+            .projection_evaluation(row_range, &root(), MaskFuture::new_true(row_count))
+    }
+}
+
+fn selected_row_range(mask: &Mask) -> Option<Range<usize>> {
+    Some(mask.first()?..mask.last()? + 1)
 }
 
 impl LayoutReader for FixedSizeListReader {
@@ -319,7 +388,7 @@ impl LayoutReader for FixedSizeListReader {
             FixedSizeListChildrenNeeded::ListLengthAndValidity => {
                 self.project_list_length(row_range, expr, mask)
             }
-            FixedSizeListChildrenNeeded::Elements => self.project_elements(row_range, expr, mask),
+            FixedSizeListChildrenNeeded::Elements => self.project_all(row_range, expr, mask),
         }
     }
 }
@@ -398,6 +467,9 @@ fn predicate_array_to_mask(array: ArrayRef, session: &VortexSession) -> VortexRe
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
     use rstest::rstest;
     use vortex_array::ArrayContext;
     use vortex_array::arrays::BoolArray;
@@ -420,6 +492,7 @@ mod tests {
     use crate::layouts::repartition::RepartitionStrategy;
     use crate::layouts::repartition::RepartitionWriterOptions;
     use crate::scan::split_by::SplitBy;
+    use crate::segments::SegmentFuture;
     use crate::segments::SegmentSource;
     use crate::segments::TestSegments;
     use crate::sequence::SequenceId;
@@ -473,6 +546,18 @@ mod tests {
         .into_array()
     }
 
+    struct CountingSegmentSource {
+        inner: Arc<dyn SegmentSource>,
+        request_count: Arc<AtomicUsize>,
+    }
+
+    impl SegmentSource for CountingSegmentSource {
+        fn request(&self, id: crate::segments::SegmentId) -> SegmentFuture {
+            self.request_count.fetch_add(1, Ordering::Relaxed);
+            self.inner.request(id)
+        }
+    }
+
     #[rstest]
     #[case::non_nullable(false)]
     #[case::nullable(true)]
@@ -524,6 +609,39 @@ mod tests {
 
         let mut exec_ctx = SESSION.create_execution_ctx();
         assert_arrays_eq!(result, expected, &mut exec_ctx);
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::first_row_non_nullable(false, Mask::from_iter([true, false, false, false]), 1)]
+    #[case::first_row_nullable(true, Mask::from_iter([true, false, false, false]), 2)]
+    #[case::no_rows_nullable(true, Mask::new_false(4), 0)]
+    #[tokio::test]
+    async fn projection_sparse_mask_bounds_element_reads(
+        #[case] nullable: bool,
+        #[case] mask: Mask,
+        #[case] expected_requests: usize,
+    ) -> VortexResult<()> {
+        let fsl = create_fsl(nullable);
+        let strategy =
+            FixedSizeListLayoutStrategy::default().with_elements(repartitioned_chunk_strategy(2));
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout) = write_layout_with_strategy(&strategy, fsl.clone()).await?;
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let source = Arc::new(CountingSegmentSource {
+            inner: segments,
+            request_count: Arc::clone(&request_count),
+        });
+        let reader = layout.new_reader("".into(), source, &SESSION, &ctx)?;
+
+        let result = reader
+            .projection_evaluation(&(0..4), &root(), MaskFuture::ready(mask.clone()))?
+            .await?;
+        let expected = fsl.filter(mask)?;
+
+        let mut exec_ctx = SESSION.create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut exec_ctx);
+        assert_eq!(request_count.load(Ordering::Relaxed), expected_requests);
         Ok(())
     }
 

--- a/vortex-layout/src/layouts/fixed_size_list/reader.rs
+++ b/vortex-layout/src/layouts/fixed_size_list/reader.rs
@@ -11,20 +11,18 @@ use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::MaskFuture;
 use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::FixedSizeListArray;
+use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldMask;
 use vortex_array::dtype::Nullability;
+use vortex_array::dtype::PType;
 use vortex_array::expr::Expression;
-use vortex_array::expr::is_root;
-use vortex_array::expr::not;
 use vortex_array::expr::root;
-use vortex_array::scalar_fn::fns::is_not_null::IsNotNull;
-use vortex_array::scalar_fn::fns::is_null::IsNull;
 use vortex_array::validity::Validity;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
-use vortex_mask::AllOr;
 use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
@@ -35,9 +33,17 @@ use crate::LayoutReaderRef;
 use crate::RowSplits;
 use crate::SplitRange;
 use crate::layouts::fixed_size_list::FixedSizeListLayout;
+use crate::layouts::fixed_size_list::expr::FixedSizeListChildrenNeeded;
+use crate::layouts::fixed_size_list::expr::get_necessary_fixed_size_list_children;
+use crate::layouts::fixed_size_list::expr::rewrite_list_length_expr;
+use crate::layouts::fixed_size_list::expr::rewrite_validity_expr;
 use crate::segments::SegmentSource;
 
 type OptionalArrayFuture = BoxFuture<'static, VortexResult<Option<ArrayRef>>>;
+
+/// The threshold of mask density below which we push the input mask into projection evaluation,
+/// and above which we evaluate the expression over all rows and intersect afterward.
+const EXPR_EVAL_THRESHOLD: f64 = 0.2;
 
 #[derive(Clone)]
 pub(super) struct FixedSizeListReader {
@@ -118,25 +124,78 @@ impl FixedSizeListReader {
         .boxed())
     }
 
+    fn project_list_length(
+        &self,
+        row_range: &Range<u64>,
+        expr: &Expression,
+        mask: MaskFuture,
+    ) -> VortexResult<ArrayFuture> {
+        let list_size = u64::from(self.layout.list_size());
+        let nullability = self.layout.dtype().nullability();
+        let row_count = usize::try_from(row_range.end - row_range.start)?;
+        let rewritten = rewrite_list_length_expr(expr)?;
+        let validity_fut = fetch_validity(
+            self.validity.as_ref(),
+            row_range,
+            MaskFuture::new_true(row_count),
+        )?;
+
+        Ok(async move {
+            let validity = validity_fut.await?;
+            let lengths = ConstantArray::new(list_size, row_count)
+                .into_array()
+                .cast(DType::Primitive(PType::U64, nullability))?;
+            let lengths = apply_validity(lengths, validity, nullability)?;
+
+            let mask = mask.await?;
+            let lengths = if mask.all_true() {
+                lengths
+            } else {
+                lengths.filter(mask)?
+            };
+            lengths.apply(&rewritten)
+        }
+        .boxed())
+    }
+
     fn project_elements(
         &self,
         row_range: &Range<u64>,
         expr: &Expression,
         mask: MaskFuture,
     ) -> VortexResult<ArrayFuture> {
-        let projection = ElementsProjection {
-            reader: self.clone(),
-            expr: expr.clone(),
-            row_range: row_range.clone(),
-        };
+        let reader = self.clone();
+        let expr = expr.clone();
+        let row_range = row_range.clone();
 
         Ok(async move {
+            let row_count = usize::try_from(row_range.end - row_range.start)?;
+            let list_size = u64::from(reader.layout.list_size());
+            let elements_range = element_range(&row_range, list_size)?;
+            let elements_len = usize::try_from(elements_range.end - elements_range.start)?;
+
+            let elements_fut = reader.elements.projection_evaluation(
+                &elements_range,
+                &root(),
+                MaskFuture::new_true(elements_len),
+            )?;
+
+            let validity_fut = fetch_validity(
+                reader.validity.as_ref(),
+                &row_range,
+                MaskFuture::new_true(row_count),
+            )?;
+
+            let (elements, validity) = try_join!(elements_fut, validity_fut)?;
+            let fsl = build_fixed_size_list(elements, validity, reader.layout.dtype(), row_count)?;
+
             let mask = mask.await?;
-            if mask.all_true() {
-                projection.project_full_range().await
+            let fsl = if mask.all_true() {
+                fsl
             } else {
-                projection.project_sparse(mask).await
-            }
+                fsl.filter(mask)?
+            };
+            fsl.apply(&expr)
         }
         .boxed())
     }
@@ -165,17 +224,43 @@ impl LayoutReader for FixedSizeListReader {
         split_range: &SplitRange,
         splits: &mut RowSplits,
     ) -> VortexResult<()> {
-        self.elements.register_splits(
-            field_mask,
-            &element_split_range(split_range, self.layout.list_size())?,
-            splits,
-        )?;
+        split_range.check_bounds(self.layout.row_count())?;
+        splits.push(split_range.root_row_range().end);
+
+        let list_size = u64::from(self.layout.list_size());
+        if list_size != 0 {
+            let element_range = element_range(split_range.row_range(), list_size)?;
+            let mut element_splits = RowSplits::new_capacity(8);
+            self.elements.register_splits(
+                field_mask,
+                &SplitRange::try_new(0, element_range.clone())?,
+                &mut element_splits,
+            )?;
+
+            for element_split in element_splits.into_sorted_deduped() {
+                if element_split <= element_range.start || element_split >= element_range.end {
+                    continue;
+                }
+                let element_offset = element_split - element_range.start;
+                let row_offset = element_offset.div_ceil(list_size);
+                let root_row = split_range
+                    .root_row_range()
+                    .start
+                    .checked_add(row_offset)
+                    .ok_or_else(|| vortex_err!("fixed-size-list split offset overflow"))?;
+                if root_row < split_range.root_row_range().end {
+                    splits.push(root_row);
+                }
+            }
+        }
+
         if let Some(validity) = &self.validity {
             validity.register_splits(field_mask, split_range, splits)?;
         }
         Ok(())
     }
 
+    // TODO(mk): either have zone pruning upstream or implement here
     fn pruning_evaluation(
         &self,
         _row_range: &Range<u64>,
@@ -203,16 +288,18 @@ impl LayoutReader for FixedSizeListReader {
                 return Ok(mask);
             }
 
-            let predicate = reader
-                .projection_evaluation(&row_range, &expr, MaskFuture::ready(mask.clone()))?
-                .await?;
-            let mut ctx = session.create_execution_ctx();
-            let predicate_mask = predicate.null_as_false().execute(&mut ctx)?;
-
-            if mask.all_true() {
-                Ok(predicate_mask)
-            } else {
+            if mask.density() < EXPR_EVAL_THRESHOLD {
+                let predicate = reader
+                    .projection_evaluation(&row_range, &expr, MaskFuture::ready(mask.clone()))?
+                    .await?;
+                let predicate_mask = predicate_array_to_mask(predicate, &session)?;
                 Ok(mask.intersect_by_rank(&predicate_mask))
+            } else {
+                let predicate = reader
+                    .projection_evaluation(&row_range, &expr, MaskFuture::new_true(len))?
+                    .await?;
+                let predicate_mask = predicate_array_to_mask(predicate, &session)?;
+                Ok(mask & &predicate_mask)
             }
         }))
     }
@@ -223,21 +310,14 @@ impl LayoutReader for FixedSizeListReader {
         expr: &Expression,
         mask: MaskFuture,
     ) -> VortexResult<ArrayFuture> {
-        match classify(expr) {
-            ExprClass::Validity => self.project_validity(row_range, expr, mask),
-            ExprClass::Elements => self.project_elements(row_range, expr, mask),
+        match get_necessary_fixed_size_list_children(expr) {
+            FixedSizeListChildrenNeeded::Validity => self.project_validity(row_range, expr, mask),
+            FixedSizeListChildrenNeeded::ListLengthAndValidity => {
+                self.project_list_length(row_range, expr, mask)
+            }
+            FixedSizeListChildrenNeeded::Elements => self.project_elements(row_range, expr, mask),
         }
     }
-}
-
-fn element_split_range(split_range: &SplitRange, list_size: u32) -> VortexResult<SplitRange> {
-    let list_size = u64::from(list_size);
-    let row_range = element_range(split_range.row_range(), list_size)?;
-    let row_offset = split_range
-        .row_offset()
-        .checked_mul(list_size)
-        .ok_or_else(|| vortex_err!("fixed-size-list split offset overflow"))?;
-    SplitRange::try_new(row_offset, row_range)
 }
 
 fn element_range(row_range: &Range<u64>, list_size: u64) -> VortexResult<Range<u64>> {
@@ -279,12 +359,24 @@ fn create_validity(validity_array: Option<ArrayRef>, nullability: Nullability) -
     }
 }
 
+fn apply_validity(
+    array: ArrayRef,
+    validity_array: Option<ArrayRef>,
+    nullability: Nullability,
+) -> VortexResult<ArrayRef> {
+    if matches!(nullability, Nullability::Nullable) {
+        let len = array.len();
+        array.mask(create_validity(validity_array, nullability).to_array(len))
+    } else {
+        Ok(array)
+    }
+}
+
 fn build_fixed_size_list(
     elements: ArrayRef,
     validity_array: Option<ArrayRef>,
     dtype: &DType,
     len: usize,
-    expr: &Expression,
 ) -> VortexResult<ArrayRef> {
     let DType::FixedSizeList(_, list_size, nullability) = dtype else {
         return Err(vortex_err!(
@@ -292,174 +384,12 @@ fn build_fixed_size_list(
         ));
     };
     let validity = create_validity(validity_array, *nullability);
-    FixedSizeListArray::try_new(elements, *list_size, validity, len)?
-        .into_array()
-        .apply(expr)
+    Ok(FixedSizeListArray::try_new(elements, *list_size, validity, len)?.into_array())
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum ExprClass {
-    Validity,
-    Elements,
-}
-
-fn classify(expr: &Expression) -> ExprClass {
-    if (expr.is::<IsNull>() || expr.is::<IsNotNull>())
-        && expr.children().len() == 1
-        && is_root(expr.child(0))
-    {
-        return ExprClass::Validity;
-    }
-
-    if is_root(expr) {
-        return ExprClass::Elements;
-    }
-
-    expr.children()
-        .iter()
-        .map(classify)
-        .max()
-        .unwrap_or(ExprClass::Validity)
-}
-
-fn rewrite_validity_expr(expr: &Expression) -> VortexResult<Expression> {
-    if expr.is::<IsNotNull>() && expr.children().len() == 1 && is_root(expr.child(0)) {
-        return Ok(root());
-    }
-    if expr.is::<IsNull>() && expr.children().len() == 1 && is_root(expr.child(0)) {
-        return Ok(not(root()));
-    }
-    let children = expr
-        .children()
-        .iter()
-        .map(rewrite_validity_expr)
-        .collect::<VortexResult<Vec<_>>>()?;
-    expr.clone().with_children(children)
-}
-
-struct SparseElementPlan {
-    elements_range: Range<u64>,
-    element_mask: Mask,
-    kept_count: usize,
-}
-
-fn sparse_element_plan(
-    row_range: &Range<u64>,
-    mask: &Mask,
-    list_size: u64,
-) -> VortexResult<SparseElementPlan> {
-    let kept_count = mask.true_count();
-    if kept_count == 0 || list_size == 0 {
-        return Ok(SparseElementPlan {
-            elements_range: 0..0,
-            element_mask: Mask::new_true(0),
-            kept_count,
-        });
-    }
-
-    let first = mask
-        .first()
-        .ok_or_else(|| vortex_err!("sparse mask has no true values"))?;
-    let last = mask
-        .last()
-        .ok_or_else(|| vortex_err!("sparse mask has no true values"))?;
-    let first_row = row_range
-        .start
-        .checked_add(u64::try_from(first)?)
-        .ok_or_else(|| vortex_err!("fixed-size-list row range overflow"))?;
-    let last_row_exclusive = row_range
-        .start
-        .checked_add(u64::try_from(last + 1)?)
-        .ok_or_else(|| vortex_err!("fixed-size-list row range overflow"))?;
-    let elements_range = element_range(&(first_row..last_row_exclusive), list_size)?;
-    let element_mask_len = usize::try_from(elements_range.end - elements_range.start)?;
-
-    let list_size_usize = usize::try_from(list_size)?;
-    let mut element_slices = Vec::with_capacity(kept_count);
-    match mask.indices() {
-        AllOr::All => {
-            return Ok(SparseElementPlan {
-                elements_range,
-                element_mask: Mask::new_true(element_mask_len),
-                kept_count,
-            });
-        }
-        AllOr::None => {}
-        AllOr::Some(indices) => {
-            for &idx in indices {
-                let relative = idx - first;
-                let start = relative
-                    .checked_mul(list_size_usize)
-                    .ok_or_else(|| vortex_err!("fixed-size-list element mask overflow"))?;
-                element_slices.push((start, start + list_size_usize));
-            }
-        }
-    }
-
-    Ok(SparseElementPlan {
-        elements_range,
-        element_mask: Mask::from_slices(element_mask_len, element_slices),
-        kept_count,
-    })
-}
-
-struct ElementsProjection {
-    reader: FixedSizeListReader,
-    expr: Expression,
-    row_range: Range<u64>,
-}
-
-impl ElementsProjection {
-    async fn project_full_range(self) -> VortexResult<ArrayRef> {
-        let Self {
-            reader,
-            expr,
-            row_range,
-        } = self;
-        let len = usize::try_from(row_range.end - row_range.start)?;
-        let list_size = u64::from(reader.layout.list_size());
-        let elements_range = element_range(&row_range, list_size)?;
-        let elements_len = usize::try_from(elements_range.end - elements_range.start)?;
-        let elements_fut = reader.elements.projection_evaluation(
-            &elements_range,
-            &root(),
-            MaskFuture::new_true(elements_len),
-        )?;
-        let validity_fut = fetch_validity(
-            reader.validity.as_ref(),
-            &row_range,
-            MaskFuture::new_true(len),
-        )?;
-        let (elements, validity) = try_join!(elements_fut, validity_fut)?;
-        build_fixed_size_list(elements, validity, reader.layout.dtype(), len, &expr)
-    }
-
-    async fn project_sparse(self, mask: Mask) -> VortexResult<ArrayRef> {
-        let Self {
-            reader,
-            expr,
-            row_range,
-        } = self;
-        let plan = sparse_element_plan(&row_range, &mask, u64::from(reader.layout.list_size()))?;
-        let elements_fut = reader.elements.projection_evaluation(
-            &plan.elements_range,
-            &root(),
-            MaskFuture::ready(plan.element_mask),
-        )?;
-        let validity_fut = fetch_validity(
-            reader.validity.as_ref(),
-            &row_range,
-            MaskFuture::ready(mask),
-        )?;
-        let (elements, validity) = try_join!(elements_fut, validity_fut)?;
-        build_fixed_size_list(
-            elements,
-            validity,
-            reader.layout.dtype(),
-            plan.kept_count,
-            &expr,
-        )
-    }
+fn predicate_array_to_mask(array: ArrayRef, session: &VortexSession) -> VortexResult<Mask> {
+    let mut ctx = session.create_execution_ctx();
+    array.null_as_false().execute(&mut ctx)
 }
 
 #[cfg(test)]
@@ -470,13 +400,18 @@ mod tests {
     use vortex_array::arrays::FixedSizeListArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
+    use vortex_array::dtype::FieldPath;
+    use vortex_array::expr::gt;
     use vortex_array::expr::is_not_null;
     use vortex_array::expr::is_null;
+    use vortex_array::expr::list_length;
+    use vortex_array::expr::lit;
     use vortex_array::validity::Validity;
 
     use super::*;
     use crate::LayoutStrategy;
     use crate::layouts::fixed_size_list::writer::FixedSizeListLayoutStrategy;
+    use crate::scan::split_by::SplitBy;
     use crate::segments::SegmentSource;
     use crate::segments::TestSegments;
     use crate::sequence::SequenceId;
@@ -589,6 +524,23 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn layout_splits_are_list_row_coordinates() -> VortexResult<()> {
+        let fsl = create_fsl(true);
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout) = write_layout(fsl).await?;
+        let reader = layout.new_reader("".into(), segments, &SESSION, &ctx)?;
+
+        let splits = SplitBy::Layout.splits(
+            reader.as_ref(),
+            &(0..4),
+            &[FieldMask::Exact(FieldPath::root())],
+        )?;
+
+        assert_eq!(splits, vec![0, 4]);
+        Ok(())
+    }
+
     #[rstest]
     #[case::nullable(true, vec![true, false, true, true])]
     #[case::non_nullable(false, vec![true, true, true, true])]
@@ -616,6 +568,62 @@ mod tests {
             BoolArray::from_iter(valid.iter().map(|v| !v).collect::<Vec<_>>()),
             &mut exec_ctx
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn projection_list_length_preserves_validity() -> VortexResult<()> {
+        let fsl = create_fsl(true);
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout) = write_layout(fsl).await?;
+        let reader = layout.new_reader("".into(), segments, &SESSION, &ctx)?;
+
+        let result = reader
+            .projection_evaluation(&(0..4), &list_length(root()), MaskFuture::new_true(4))?
+            .await?;
+
+        let expected =
+            PrimitiveArray::from_option_iter::<u64, _>([Some(2), None, Some(2), Some(2)])
+                .into_array();
+        let mut exec_ctx = SESSION.create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut exec_ctx);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn projection_list_length_applies_sparse_mask() -> VortexResult<()> {
+        let fsl = create_fsl(true);
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout) = write_layout(fsl).await?;
+        let reader = layout.new_reader("".into(), segments, &SESSION, &ctx)?;
+        let mask = Mask::from_iter([false, true, false, true]);
+
+        let result = reader
+            .projection_evaluation(&(0..4), &list_length(root()), MaskFuture::ready(mask))?
+            .await?;
+
+        let expected = PrimitiveArray::from_option_iter::<u64, _>([None, Some(2)]).into_array();
+        let mut exec_ctx = SESSION.create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut exec_ctx);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn filter_evaluation_list_length() -> VortexResult<()> {
+        let fsl = create_fsl(true);
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout) = write_layout(fsl).await?;
+        let reader = layout.new_reader("".into(), segments, &SESSION, &ctx)?;
+
+        let result = reader
+            .filter_evaluation(
+                &(0..4),
+                &gt(list_length(root()), lit(1u64)),
+                MaskFuture::new_true(4),
+            )?
+            .await?;
+
+        assert_eq!(result, Mask::from_iter([true, false, true, true]));
         Ok(())
     }
 }

--- a/vortex-layout/src/layouts/fixed_size_list/reader.rs
+++ b/vortex-layout/src/layouts/fixed_size_list/reader.rs
@@ -63,14 +63,14 @@ impl FixedSizeListReader {
         session: VortexSession,
         ctx: &LayoutReaderContext,
     ) -> VortexResult<Self> {
-        let elements = layout.elements().new_reader(
+        let elements = layout.elements()?.new_reader(
             format!("{name}.elements").into(),
             Arc::clone(&segment_source),
             &session,
             ctx,
         )?;
         let validity = layout
-            .validity()
+            .validity()?
             .map(|v| {
                 v.new_reader(
                     format!("{name}.validity").into(),

--- a/vortex-layout/src/layouts/fixed_size_list/writer.rs
+++ b/vortex-layout/src/layouts/fixed_size_list/writer.rs
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use futures::stream;
+use vortex_array::ArrayContext;
+use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
+use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::FixedSizeListArray;
+use vortex_array::arrays::fixed_size_list::FixedSizeListDataParts;
+use vortex_array::dtype::DType;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_io::session::RuntimeSessionExt;
+use vortex_session::VortexSession;
+
+use crate::IntoLayout;
+use crate::LayoutRef;
+use crate::LayoutStrategy;
+use crate::layouts::fixed_size_list::FixedSizeListLayout;
+use crate::layouts::flat::writer::FlatLayoutStrategy;
+use crate::segments::SegmentSinkRef;
+use crate::sequence::SendableSequentialStream;
+use crate::sequence::SequenceId;
+use crate::sequence::SequencePointer;
+use crate::sequence::SequentialStream;
+use crate::sequence::SequentialStreamAdapter;
+use crate::sequence::SequentialStreamExt;
+
+/// Strategy for writing fixed-size-list arrays, with a fallback for other dtypes.
+///
+/// Single-chunk only. For fixed-size-list input the strategy canonicalizes the chunk into a
+/// [`FixedSizeListArray`] and writes the `elements` and optional `validity` columns into
+/// independently configurable child strategies.
+#[derive(Clone)]
+pub struct FixedSizeListLayoutStrategy {
+    elements: Arc<dyn LayoutStrategy>,
+    validity: Arc<dyn LayoutStrategy>,
+    fallback: Arc<dyn LayoutStrategy>,
+}
+
+impl Default for FixedSizeListLayoutStrategy {
+    fn default() -> Self {
+        let flat: Arc<dyn LayoutStrategy> = Arc::new(FlatLayoutStrategy::default());
+        Self {
+            elements: Arc::clone(&flat),
+            validity: Arc::clone(&flat),
+            fallback: flat,
+        }
+    }
+}
+
+impl FixedSizeListLayoutStrategy {
+    /// Strategy for the `elements` child.
+    pub fn with_elements(mut self, elements: Arc<dyn LayoutStrategy>) -> Self {
+        self.elements = elements;
+        self
+    }
+
+    /// Strategy for the `validity` child, written only when the list dtype is nullable.
+    pub fn with_validity(mut self, validity: Arc<dyn LayoutStrategy>) -> Self {
+        self.validity = validity;
+        self
+    }
+
+    /// Strategy for non-fixed-size-list input, which is forwarded unchanged.
+    pub fn with_fallback(mut self, fallback: Arc<dyn LayoutStrategy>) -> Self {
+        self.fallback = fallback;
+        self
+    }
+}
+
+#[async_trait]
+impl LayoutStrategy for FixedSizeListLayoutStrategy {
+    async fn write_stream(
+        &self,
+        ctx: ArrayContext,
+        segment_sink: SegmentSinkRef,
+        mut stream: SendableSequentialStream,
+        mut eof: SequencePointer,
+        session: &VortexSession,
+    ) -> VortexResult<LayoutRef> {
+        let dtype = stream.dtype().clone();
+        if !dtype.is_fixed_size_list() {
+            return self
+                .fallback
+                .write_stream(ctx, segment_sink, stream, eof, session)
+                .await;
+        }
+
+        let Some(chunk) = stream.next().await else {
+            vortex_bail!("FixedSizeListLayoutStrategy needs a single chunk");
+        };
+        let (sequence_id, array) = chunk?;
+
+        let mut exec_ctx = session.create_execution_ctx();
+        let row_count = array.len();
+        let FixedSizeListDataParts {
+            elements, validity, ..
+        } = array
+            .execute::<FixedSizeListArray>(&mut exec_ctx)?
+            .into_data_parts();
+        let validity_array = dtype
+            .is_nullable()
+            .then(|| {
+                validity
+                    .execute_mask(row_count, &mut exec_ctx)
+                    .map(|m| m.into_array())
+            })
+            .transpose()?;
+
+        let handle = session.handle();
+        let (elements_task, validity_task) = {
+            let mut sp = sequence_id.descend();
+            let mut spawn_layout_writer = |strategy: Arc<dyn LayoutStrategy>, array: ArrayRef| {
+                let stream = single_chunk_stream(array.dtype().clone(), sp.advance(), array);
+                let child_eof = eof.split_off();
+                let ctx = ctx.clone();
+                let segment_sink = Arc::clone(&segment_sink);
+                let session = session.clone();
+                handle.spawn_nested(move |h| async move {
+                    let session = session.with_handle(h);
+                    strategy
+                        .write_stream(ctx, segment_sink, stream, child_eof, &session)
+                        .await
+                })
+            };
+            (
+                spawn_layout_writer(Arc::clone(&self.elements), elements),
+                validity_array.map(|arr| spawn_layout_writer(Arc::clone(&self.validity), arr)),
+            )
+        };
+
+        if stream.next().await.is_some() {
+            vortex_bail!("FixedSizeListLayoutStrategy received more than a single chunk");
+        }
+
+        let (elements_layout, validity_layout) = futures::try_join!(elements_task, async move {
+            match validity_task {
+                Some(t) => t.await.map(Some),
+                None => Ok(None),
+            }
+        },)?;
+
+        Ok(
+            FixedSizeListLayout::new(row_count as u64, dtype, elements_layout, validity_layout)
+                .into_layout(),
+        )
+    }
+
+    fn buffered_bytes(&self) -> u64 {
+        let fsl_bytes = self.elements.buffered_bytes() + self.validity.buffered_bytes();
+        fsl_bytes.max(self.fallback.buffered_bytes())
+    }
+}
+
+fn single_chunk_stream(
+    dtype: DType,
+    sequence_id: SequenceId,
+    array: ArrayRef,
+) -> SendableSequentialStream {
+    SequentialStreamAdapter::new(
+        dtype,
+        stream::once(async move { Ok((sequence_id, array)) }).boxed(),
+    )
+    .sendable()
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_array::arrays::BoolArray;
+    use vortex_array::arrays::FixedSizeListArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::validity::Validity;
+    use vortex_buffer::buffer;
+
+    use super::*;
+    use crate::segments::TestSegments;
+    use crate::sequence::SequentialArrayStreamExt;
+    use crate::test::SESSION;
+
+    async fn write<S: LayoutStrategy>(strategy: &S, array: ArrayRef) -> VortexResult<LayoutRef> {
+        let segments = Arc::new(TestSegments::default());
+        let (ptr, eof) = SequenceId::root().split();
+        let stream = array.to_array_stream().sequenced(ptr);
+        strategy
+            .write_stream(ArrayContext::empty(), segments, stream, eof, &SESSION)
+            .await
+    }
+
+    fn create_fsl(validity: Validity) -> ArrayRef {
+        FixedSizeListArray::new(buffer![1i32, 2, 3, 4, 5, 6].into_array(), 2, validity, 3)
+            .into_array()
+    }
+
+    #[tokio::test]
+    async fn basic_non_nullable_input() -> VortexResult<()> {
+        let layout = write(
+            &FixedSizeListLayoutStrategy::default(),
+            create_fsl(Validity::NonNullable),
+        )
+        .await?;
+
+        assert_eq!(
+            layout.display_tree().to_string(),
+            "vortex.fixed_size_list, dtype: fixed_size_list(i32)[2], children: 1\n\
+             └── elements: vortex.flat, dtype: i32, segment: 0\n"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn basic_nullable_input() -> VortexResult<()> {
+        let layout = write(
+            &FixedSizeListLayoutStrategy::default(),
+            create_fsl(Validity::Array(
+                BoolArray::from_iter([true, false, true]).into_array(),
+            )),
+        )
+        .await?;
+
+        assert_eq!(
+            layout.display_tree().to_string(),
+            "vortex.fixed_size_list, dtype: fixed_size_list(i32)[2]?, children: 2\n\
+             ├── elements: vortex.flat, dtype: i32, segment: 0\n\
+             └── validity: vortex.flat, dtype: bool, segment: 1\n"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn non_fixed_size_list_input_routes_to_fallback() -> VortexResult<()> {
+        let primitive = PrimitiveArray::from_iter([1i32, 2, 3]).into_array();
+        let layout = write(&FixedSizeListLayoutStrategy::default(), primitive).await?;
+        assert_eq!(
+            layout.display_tree().to_string(),
+            "vortex.flat, dtype: i32, segment: 0\n"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn empty_stream_errors() {
+        let segments = Arc::new(TestSegments::default());
+        let (_, eof) = SequenceId::root().split();
+        let empty = stream::empty::<VortexResult<(SequenceId, ArrayRef)>>().boxed();
+        let stream = SequentialStreamAdapter::new(
+            DType::FixedSizeList(
+                Arc::new(DType::Primitive(
+                    vortex_array::dtype::PType::I32,
+                    vortex_array::dtype::Nullability::NonNullable,
+                )),
+                2,
+                vortex_array::dtype::Nullability::NonNullable,
+            ),
+            empty,
+        )
+        .sendable();
+
+        let res = FixedSizeListLayoutStrategy::default()
+            .write_stream(ArrayContext::empty(), segments, stream, eof, &SESSION)
+            .await;
+        assert!(res.is_err());
+    }
+}

--- a/vortex-layout/src/layouts/fixed_size_list/writer.rs
+++ b/vortex-layout/src/layouts/fixed_size_list/writer.rs
@@ -5,16 +5,21 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::StreamExt;
-use futures::stream;
+use futures::future::try_join;
+use futures::future::try_join_all;
 use vortex_array::ArrayContext;
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::fixed_size_list::FixedSizeListDataParts;
 use vortex_array::dtype::DType;
+use vortex_array::dtype::Nullability;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_io::kanal_ext::KanalExt;
 use vortex_io::session::RuntimeSessionExt;
 use vortex_session::VortexSession;
 
@@ -31,11 +36,15 @@ use crate::sequence::SequentialStream;
 use crate::sequence::SequentialStreamAdapter;
 use crate::sequence::SequentialStreamExt;
 
+/// Item carried on each child sub-stream: a sequenced, materialized chunk.
+type ChildChunk = VortexResult<(SequenceId, ArrayRef)>;
+
 /// Strategy for writing fixed-size-list arrays, with a fallback for other dtypes.
 ///
-/// Single-chunk only. For fixed-size-list input the strategy canonicalizes the chunk into a
-/// [`FixedSizeListArray`] and writes the `elements` and optional `validity` columns into
-/// independently configurable child strategies.
+/// For fixed-size-list input the strategy transposes the whole column stream into `elements`
+/// and optional `validity` sub-streams. Each input chunk is canonicalized to a
+/// [`FixedSizeListArray`], then its children are streamed concurrently to independently
+/// configurable child strategies.
 #[derive(Clone)]
 pub struct FixedSizeListLayoutStrategy {
     elements: Arc<dyn LayoutStrategy>,
@@ -80,7 +89,7 @@ impl LayoutStrategy for FixedSizeListLayoutStrategy {
         &self,
         ctx: ArrayContext,
         segment_sink: SegmentSinkRef,
-        mut stream: SendableSequentialStream,
+        stream: SendableSequentialStream,
         mut eof: SequencePointer,
         session: &VortexSession,
     ) -> VortexResult<LayoutRef> {
@@ -92,32 +101,43 @@ impl LayoutStrategy for FixedSizeListLayoutStrategy {
                 .await;
         }
 
-        let Some(chunk) = stream.next().await else {
-            vortex_bail!("FixedSizeListLayoutStrategy needs a single chunk");
-        };
-        let (sequence_id, array) = chunk?;
+        let is_nullable = dtype.is_nullable();
+        let element_dtype = dtype
+            .as_fixed_size_list_element_opt()
+            .vortex_expect("DType is FixedSizeList")
+            .as_ref()
+            .clone();
 
-        let mut exec_ctx = session.create_execution_ctx();
-        let row_count = array.len();
-        let FixedSizeListDataParts {
-            elements, validity, ..
-        } = array
-            .execute::<FixedSizeListArray>(&mut exec_ctx)?
-            .into_data_parts();
-        let validity_array = dtype
-            .is_nullable()
-            .then(|| {
-                validity
-                    .execute_mask(row_count, &mut exec_ctx)
-                    .map(|m| m.into_array())
-            })
-            .transpose()?;
+        let (elements_tx, elements_rx) = kanal::bounded_async::<ChildChunk>(1);
+        let (validity_tx, validity_rx) = if is_nullable {
+            let (tx, rx) = kanal::bounded_async::<ChildChunk>(1);
+            (Some(tx), Some(rx))
+        } else {
+            (None, None)
+        };
+
+        let fanout_fut =
+            transpose_fixed_size_list_column(stream, session.clone(), elements_tx, validity_tx);
 
         let handle = session.handle();
-        let (elements_task, validity_task) = {
-            let mut sp = sequence_id.descend();
-            let mut spawn_layout_writer = |strategy: Arc<dyn LayoutStrategy>, array: ArrayRef| {
-                let stream = single_chunk_stream(array.dtype().clone(), sp.advance(), array);
+        let mut child_specs: Vec<(
+            DType,
+            Arc<dyn LayoutStrategy>,
+            kanal::AsyncReceiver<ChildChunk>,
+        )> = vec![(element_dtype, Arc::clone(&self.elements), elements_rx)];
+        if let Some(validity_rx) = validity_rx {
+            child_specs.push((
+                DType::Bool(Nullability::NonNullable),
+                Arc::clone(&self.validity),
+                validity_rx,
+            ));
+        }
+
+        let layout_futures: Vec<_> = child_specs
+            .into_iter()
+            .map(|(child_dtype, strategy, rx)| {
+                let child_stream =
+                    SequentialStreamAdapter::new(child_dtype, rx.into_stream().boxed()).sendable();
                 let child_eof = eof.split_off();
                 let ctx = ctx.clone();
                 let segment_sink = Arc::clone(&segment_sink);
@@ -125,29 +145,20 @@ impl LayoutStrategy for FixedSizeListLayoutStrategy {
                 handle.spawn_nested(move |h| async move {
                     let session = session.with_handle(h);
                     strategy
-                        .write_stream(ctx, segment_sink, stream, child_eof, &session)
+                        .write_stream(ctx, segment_sink, child_stream, child_eof, &session)
                         .await
                 })
-            };
-            (
-                spawn_layout_writer(Arc::clone(&self.elements), elements),
-                validity_array.map(|arr| spawn_layout_writer(Arc::clone(&self.validity), arr)),
-            )
-        };
+            })
+            .collect();
 
-        if stream.next().await.is_some() {
-            vortex_bail!("FixedSizeListLayoutStrategy received more than a single chunk");
-        }
-
-        let (elements_layout, validity_layout) = futures::try_join!(elements_task, async move {
-            match validity_task {
-                Some(t) => t.await.map(Some),
-                None => Ok(None),
-            }
-        },)?;
+        let (row_count, layouts) = try_join(fanout_fut, try_join_all(layout_futures)).await?;
+        let mut layouts = layouts.into_iter();
+        let elements_layout = layouts.next().vortex_expect("elements layout present");
+        let validity_layout =
+            is_nullable.then(|| layouts.next().vortex_expect("validity layout present"));
 
         Ok(
-            FixedSizeListLayout::new(row_count as u64, dtype, elements_layout, validity_layout)
+            FixedSizeListLayout::new(row_count, dtype, elements_layout, validity_layout)
                 .into_layout(),
         )
     }
@@ -158,27 +169,80 @@ impl LayoutStrategy for FixedSizeListLayoutStrategy {
     }
 }
 
-fn single_chunk_stream(
-    dtype: DType,
-    sequence_id: SequenceId,
+/// Transpose a fixed-size-list column into `elements` and (when present) `validity` child
+/// sub-streams. Errors surface to the caller, which joins this against the child writers, rather
+/// than being hidden as an early channel close.
+async fn transpose_fixed_size_list_column(
+    mut stream: SendableSequentialStream,
+    session: VortexSession,
+    elements_tx: kanal::AsyncSender<ChildChunk>,
+    validity_tx: Option<kanal::AsyncSender<ChildChunk>>,
+) -> VortexResult<u64> {
+    let mut exec_ctx = session.create_execution_ctx();
+    let mut row_count = 0u64;
+    let mut saw_chunk = false;
+
+    while let Some(chunk) = stream.next().await {
+        let (sequence_id, array) = chunk?;
+        saw_chunk = true;
+        let len = array.len();
+        let FixedSizeListDataParts {
+            elements, validity, ..
+        } = canonicalize_to_fixed_size_list_parts(array, &mut exec_ctx)?;
+        row_count += u64::try_from(len)?;
+
+        let mut sp = sequence_id.descend();
+        if elements_tx
+            .send(Ok((sp.advance(), elements)))
+            .await
+            .is_err()
+        {
+            vortex_bail!("fixed-size-list elements writer finished before all chunks were sent");
+        };
+
+        if let Some(validity_tx) = &validity_tx {
+            let validity = validity.execute_mask(len, &mut exec_ctx)?.into_array();
+            if validity_tx
+                .send(Ok((sp.advance(), validity)))
+                .await
+                .is_err()
+            {
+                vortex_bail!(
+                    "fixed-size-list validity writer finished before all chunks were sent"
+                );
+            }
+        }
+    }
+
+    if !saw_chunk {
+        vortex_bail!("FixedSizeListLayoutStrategy needs at least one chunk");
+    }
+
+    Ok(row_count)
+}
+
+fn canonicalize_to_fixed_size_list_parts(
     array: ArrayRef,
-) -> SendableSequentialStream {
-    SequentialStreamAdapter::new(
-        dtype,
-        stream::once(async move { Ok((sequence_id, array)) }).boxed(),
-    )
-    .sendable()
+    exec_ctx: &mut ExecutionCtx,
+) -> VortexResult<FixedSizeListDataParts> {
+    Ok(array
+        .execute::<FixedSizeListArray>(exec_ctx)?
+        .into_data_parts())
 }
 
 #[cfg(test)]
 mod tests {
+    use futures::stream;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::FixedSizeListArray;
     use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::dtype::Nullability;
+    use vortex_array::dtype::PType;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
 
     use super::*;
+    use crate::layouts::chunked::writer::ChunkedLayoutStrategy;
     use crate::segments::TestSegments;
     use crate::sequence::SequentialArrayStreamExt;
     use crate::test::SESSION;
@@ -190,6 +254,34 @@ mod tests {
         strategy
             .write_stream(ArrayContext::empty(), segments, stream, eof, &SESSION)
             .await
+    }
+
+    async fn write_chunks<S: LayoutStrategy>(
+        strategy: &S,
+        dtype: DType,
+        chunks: Vec<ArrayRef>,
+    ) -> VortexResult<LayoutRef> {
+        let segments = Arc::new(TestSegments::default());
+        let (mut ptr, eof) = SequenceId::root().split();
+        let chunks = chunks
+            .into_iter()
+            .map(move |chunk| Ok((ptr.advance(), chunk)));
+        let stream = SequentialStreamAdapter::new(dtype, stream::iter(chunks).boxed()).sendable();
+        strategy
+            .write_stream(ArrayContext::empty(), segments, stream, eof, &SESSION)
+            .await
+    }
+
+    fn i32_fsl_dtype(nullable: bool) -> DType {
+        DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
+            2,
+            if nullable {
+                Nullability::Nullable
+            } else {
+                Nullability::NonNullable
+            },
+        )
     }
 
     fn create_fsl(validity: Validity) -> ArrayRef {
@@ -233,6 +325,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn chunked_input_with_chunked_child_strategies_succeeds() -> VortexResult<()> {
+        let chunk0 = FixedSizeListArray::new(
+            buffer![1i32, 2, 3, 4].into_array(),
+            2,
+            Validity::Array(BoolArray::from_iter([true, false]).into_array()),
+            2,
+        )
+        .into_array();
+        let chunk1 = FixedSizeListArray::new(
+            buffer![5i32, 6].into_array(),
+            2,
+            Validity::Array(BoolArray::from_iter([true]).into_array()),
+            1,
+        )
+        .into_array();
+
+        let child_strategy: Arc<dyn LayoutStrategy> =
+            Arc::new(ChunkedLayoutStrategy::new(FlatLayoutStrategy::default()));
+        let strategy = FixedSizeListLayoutStrategy::default()
+            .with_elements(Arc::clone(&child_strategy))
+            .with_validity(child_strategy);
+
+        let layout = write_chunks(&strategy, i32_fsl_dtype(true), vec![chunk0, chunk1]).await?;
+
+        assert_eq!(layout.row_count(), 3);
+        insta::assert_snapshot!(layout.display_tree(), @"
+        vortex.fixed_size_list, dtype: fixed_size_list(i32)[2]?, children: 2
+        ├── elements: vortex.chunked, dtype: i32, children: 2
+        │   ├── [0]: vortex.flat, dtype: i32, segment: 0
+        │   └── [1]: vortex.flat, dtype: i32, segment: 1
+        └── validity: vortex.chunked, dtype: bool, children: 2
+            ├── [0]: vortex.flat, dtype: bool, segment: 2
+            └── [1]: vortex.flat, dtype: bool, segment: 3
+        ");
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn non_fixed_size_list_input_routes_to_fallback() -> VortexResult<()> {
         let primitive = PrimitiveArray::from_iter([1i32, 2, 3]).into_array();
         let layout = write(&FixedSizeListLayoutStrategy::default(), primitive).await?;
@@ -250,12 +380,9 @@ mod tests {
         let empty = stream::empty::<VortexResult<(SequenceId, ArrayRef)>>().boxed();
         let stream = SequentialStreamAdapter::new(
             DType::FixedSizeList(
-                Arc::new(DType::Primitive(
-                    vortex_array::dtype::PType::I32,
-                    vortex_array::dtype::Nullability::NonNullable,
-                )),
+                Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
                 2,
-                vortex_array::dtype::Nullability::NonNullable,
+                Nullability::NonNullable,
             ),
             empty,
         )

--- a/vortex-layout/src/layouts/fixed_size_list/writer.rs
+++ b/vortex-layout/src/layouts/fixed_size_list/writer.rs
@@ -23,7 +23,6 @@ use vortex_io::kanal_ext::KanalExt;
 use vortex_io::session::RuntimeSessionExt;
 use vortex_session::VortexSession;
 
-use crate::IntoLayout;
 use crate::LayoutRef;
 use crate::LayoutStrategy;
 use crate::layouts::fixed_size_list::FixedSizeListLayout;

--- a/vortex-layout/src/layouts/mod.rs
+++ b/vortex-layout/src/layouts/mod.rs
@@ -14,6 +14,7 @@ pub mod collect;
 pub mod compressed;
 pub mod dict;
 pub mod file_stats;
+pub mod fixed_size_list;
 pub mod flat;
 pub(crate) mod foreign;
 pub mod list;

--- a/vortex-layout/src/layouts/table.rs
+++ b/vortex-layout/src/layouts/table.rs
@@ -4,10 +4,11 @@
 //! A configurable writer strategy for tabular data.
 //!
 //! [`TableStrategy`] is a *dispatcher*: it inspects the dtype of the stream it is handed and
-//! routes struct columns to [`StructStrategy`], list columns to [`ListLayoutStrategy`], and
-//! everything else to the configured leaf strategy. Because it hands *itself* (suitably descended)
-//! to those structural writers as the strategy for their children, arbitrarily nested struct/list
-//! trees are written with no manual wiring.
+//! routes struct columns to [`StructStrategy`], list columns to [`ListLayoutStrategy`],
+//! fixed-size-list columns to [`FixedSizeListLayoutStrategy`], and everything else to the
+//! configured leaf strategy. Because it hands *itself* (suitably descended) to those structural
+//! writers as the strategy for their children, arbitrarily nested struct/list trees are written
+//! with no manual wiring.
 //!
 //! The dispatcher also owns field-path overrides, letting callers force a specific leaf field —
 //! at any depth — onto a custom strategy.
@@ -28,16 +29,17 @@ use vortex_utils::aliases::hash_set::HashSet;
 
 use crate::LayoutRef;
 use crate::LayoutStrategy;
+use crate::layouts::fixed_size_list::writer::FixedSizeListLayoutStrategy;
 use crate::layouts::list::writer::ListLayoutStrategy;
 use crate::layouts::struct_::StructStrategy;
 use crate::segments::SegmentSinkRef;
 use crate::sequence::SendableSequentialStream;
 use crate::sequence::SequencePointer;
 
-/// Whether [`TableStrategy`] writes list fields using a [`ListLayoutStrategy`] by
-/// default. Disabled unless the environment variable `VORTEX_EXPERIMENTAL_LIST_LAYOUT`
-/// is set to `1`.
+/// Whether [`TableStrategy`] writes list-like fields using structural list layouts by default.
+/// Disabled unless the environment variable `VORTEX_EXPERIMENTAL_LIST_LAYOUT` is set to `1`.
 ///
+/// [`FixedSizeListLayoutStrategy`]: crate::layouts::fixed_size_list::writer::FixedSizeListLayoutStrategy
 /// [`ListLayoutStrategy`]: crate::layouts::list::writer::ListLayoutStrategy
 pub fn use_experimental_list_layout() -> bool {
     static USE_EXPERIMENTAL_LIST_LAYOUT: LazyLock<bool> =
@@ -58,6 +60,9 @@ type ListLayoutFactory = Arc<dyn Fn(ListLayoutStrategy) -> Arc<dyn LayoutStrateg
 ///   strategies. Gated: only when list decomposition is enabled via
 ///   [`with_list_layout`][Self::with_list_layout] (off by default); otherwise a list falls through
 ///   to the leaf strategy.
+/// - **fixed-size-list** → [`FixedSizeListLayoutStrategy`], with `elements` written by a
+///   descended copy of this dispatcher and `validity` by the validity strategy. Gated by the same
+///   [`with_list_layout`][Self::with_list_layout] switch as list.
 /// - **anything else** → the leaf strategy.
 ///
 /// [`write_stream`]: LayoutStrategy::write_stream
@@ -70,8 +75,9 @@ pub struct TableStrategy {
     /// The writer for leaf fields, i.e. anything that is not a struct.
     leaf: Arc<dyn LayoutStrategy>,
     /// Optional factory applied to each dynamically constructed [`ListLayoutStrategy`].
-    /// Its presence also enables list decomposition.
+    /// Its presence also enables list and fixed-size-list decomposition.
     ///
+    /// [`FixedSizeListLayoutStrategy`]: crate::layouts::fixed_size_list::writer::FixedSizeListLayoutStrategy
     /// [`ListLayoutStrategy`]: crate::layouts::list::writer::ListLayoutStrategy
     list_layout_factory: Option<ListLayoutFactory>,
 }
@@ -168,7 +174,7 @@ impl TableStrategy {
         self
     }
 
-    /// Enable writing list fields with [`ListLayoutStrategy`].
+    /// Enable writing list and fixed-size-list fields with structural list layouts.
     ///
     /// **Note**: this is an unstable and experimental layout that is expected to change.
     /// Using it may lead to unreadable files in the future.
@@ -236,6 +242,18 @@ impl TableStrategy {
             .with_validity(Arc::clone(&self.validity))
             .with_fallback(Arc::clone(&self.leaf));
         Some(factory(list_layout))
+    }
+
+    /// Build the [`FixedSizeListLayoutStrategy`] used to write a fixed-size-list field stream at
+    /// this level.
+    ///
+    /// The `elements` sub-column is routed back through a clean descended dispatcher so nested
+    /// structs/lists/fixed-size-lists recurse; `validity` uses the shared validity strategy.
+    fn fixed_size_list_strategy(&self) -> FixedSizeListLayoutStrategy {
+        FixedSizeListLayoutStrategy::default()
+            .with_elements(Arc::new(self.descend_clean()))
+            .with_validity(Arc::clone(&self.validity))
+            .with_fallback(Arc::clone(&self.leaf))
     }
 
     /// Descend into a subfield, retaining only the overrides that apply beneath it (rebased to be
@@ -318,6 +336,13 @@ impl LayoutStrategy for TableStrategy {
                 .await;
         }
 
+        if dtype.is_fixed_size_list() && self.list_layout_factory.is_some() {
+            return self
+                .fixed_size_list_strategy()
+                .write_stream(ctx, segment_sink, stream, eof, session)
+                .await;
+        }
+
         // Leaf: hand off to the leaf strategy.
         self.leaf
             .write_stream(ctx, segment_sink, stream, eof, session)
@@ -336,6 +361,7 @@ mod tests {
     use vortex_array::IntoArray;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::ChunkedArray;
+    use vortex_array::arrays::FixedSizeListArray;
     use vortex_array::arrays::ListArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::StructArray;
@@ -466,6 +492,79 @@ mod tests {
         Ok(())
     }
 
+    /// Fixed-size-list decomposition is gated by the same switch as list decomposition. Without
+    /// it, fixed-size-list columns fall through to the configured leaf strategy.
+    #[tokio::test]
+    async fn fixed_size_list_uses_leaf_without_list_layout() -> VortexResult<()> {
+        let fsl = FixedSizeListArray::new(
+            buffer![1i32, 2, 3, 4, 5, 6].into_array(),
+            2,
+            Validity::NonNullable,
+            3,
+        )
+        .into_array();
+
+        let layout = write(&flat_table(), fsl).await?;
+        insta::assert_snapshot!(layout.display_tree(), @"vortex.flat, dtype: fixed_size_list(i32)[2], segment: 0");
+        Ok(())
+    }
+
+    /// A `fixed_size_list<fixed_size_list<i32>>` column: the dispatcher recurses into itself so
+    /// the outer fixed-size-list's `elements` are decomposed as a nested fixed-size-list layout.
+    #[tokio::test]
+    async fn dispatches_nested_fixed_size_list() -> VortexResult<()> {
+        let inner = FixedSizeListArray::new(
+            buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array(),
+            2,
+            Validity::NonNullable,
+            4,
+        )
+        .into_array();
+        let outer = FixedSizeListArray::new(inner, 2, Validity::NonNullable, 2).into_array();
+
+        let layout = write(&flat_table().with_list_layout(), outer).await?;
+        insta::assert_snapshot!(layout.display_tree(), @r"
+        vortex.fixed_size_list, dtype: fixed_size_list(fixed_size_list(i32)[2])[2], children: 1
+        └── elements: vortex.fixed_size_list, dtype: fixed_size_list(i32)[2], children: 1
+            └── elements: vortex.flat, dtype: i32, segment: 0
+        ");
+        Ok(())
+    }
+
+    /// A `struct<{ items: fixed_size_list<struct<{a,b}>>? }>` column: fixed-size-list
+    /// decomposition recurses into struct decomposition for the elements, and a nullable
+    /// fixed-size-list writes a validity child.
+    #[tokio::test]
+    async fn dispatches_struct_fixed_size_list_struct() -> VortexResult<()> {
+        let inner_struct = StructArray::from_fields(
+            [
+                ("a", buffer![1i32, 2, 3, 4, 5, 6].into_array()),
+                ("b", buffer![10i32, 20, 30, 40, 50, 60].into_array()),
+            ]
+            .as_slice(),
+        )?
+        .into_array();
+        let items = FixedSizeListArray::new(
+            inner_struct,
+            2,
+            Validity::Array(BoolArray::from_iter([true, false, true]).into_array()),
+            3,
+        )
+        .into_array();
+        let st = StructArray::from_fields([("items", items)].as_slice())?.into_array();
+
+        let layout = write(&flat_table().with_list_layout(), st).await?;
+        insta::assert_snapshot!(layout.display_tree(), @r"
+        vortex.struct, dtype: {items=fixed_size_list({a=i32, b=i32})[2]?}, children: 1
+        └── items: vortex.fixed_size_list, dtype: fixed_size_list({a=i32, b=i32})[2]?, children: 2
+            ├── elements: vortex.struct, dtype: {a=i32, b=i32}, children: 2
+            │   ├── a: vortex.flat, dtype: i32, segment: 1
+            │   └── b: vortex.flat, dtype: i32, segment: 2
+            └── validity: vortex.flat, dtype: bool, segment: 0
+        ");
+        Ok(())
+    }
+
     /// A multi-chunk `list<i32>` written with a chunked leaf: each sub-column (`elements`,
     /// `offsets`) becomes its own `ChunkedLayout`, so elements are chunked independently of rows.
     /// This is the "list-of-chunkeds" topology top-level decomposition unlocks.
@@ -550,6 +649,39 @@ mod tests {
         let data = layout.child(0)?;
         assert!(data.is::<List>());
         assert_eq!(data.row_count(), 9);
+        Ok(())
+    }
+
+    /// A multi-chunk `fixed_size_list<i32>` written with a chunked leaf becomes a single
+    /// fixed-size-list layout whose elements child is independently chunked.
+    #[tokio::test]
+    async fn dispatches_chunked_fixed_size_list() -> VortexResult<()> {
+        let chunk0 = FixedSizeListArray::new(
+            buffer![1i32, 2, 3, 4].into_array(),
+            2,
+            Validity::NonNullable,
+            2,
+        )
+        .into_array();
+        let chunk1 =
+            FixedSizeListArray::new(buffer![5i32, 6].into_array(), 2, Validity::NonNullable, 1)
+                .into_array();
+        let dtype = chunk0.dtype().clone();
+        let chunked = ChunkedArray::try_new(vec![chunk0, chunk1], dtype)?.into_array();
+
+        let flat: Arc<dyn LayoutStrategy> = Arc::new(FlatLayoutStrategy::default());
+        let dispatcher = TableStrategy::new(
+            Arc::clone(&flat),
+            Arc::new(ChunkedLayoutStrategy::new(FlatLayoutStrategy::default())),
+        )
+        .with_list_layout();
+        let layout = write(&dispatcher, chunked).await?;
+        insta::assert_snapshot!(layout.display_tree(), @r"
+        vortex.fixed_size_list, dtype: fixed_size_list(i32)[2], children: 1
+        └── elements: vortex.chunked, dtype: i32, children: 2
+            ├── [0]: vortex.flat, dtype: i32, segment: 0
+            └── [1]: vortex.flat, dtype: i32, segment: 1
+        ");
         Ok(())
     }
 

--- a/vortex-layout/src/session.rs
+++ b/vortex-layout/src/session.rs
@@ -13,6 +13,7 @@ use crate::LayoutEncoding;
 use crate::LayoutEncodingRef;
 use crate::layouts::chunked::Chunked;
 use crate::layouts::dict::Dict;
+use crate::layouts::fixed_size_list::FixedSizeList;
 use crate::layouts::flat::Flat;
 use crate::layouts::list::List;
 use crate::layouts::struct_::Struct;
@@ -56,6 +57,7 @@ impl Default for LayoutSession {
 
         // Register the built-in layout encodings.
         this.register(&Chunked as &dyn LayoutEncoding);
+        this.register(&FixedSizeList as &dyn LayoutEncoding);
         this.register(&Flat as &dyn LayoutEncoding);
         this.register(&Struct as &dyn LayoutEncoding);
         this.register(&Zoned as &dyn LayoutEncoding);


### PR DESCRIPTION
Add `FixedSizeListLayout` that shreds `FixedSizeList` arrays with elements and optional validity child layouts.
