### PR TITLE
Disallow the legacy global session and allowlist existing call sites

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -17,4 +17,5 @@ disallowed-methods = [
     { path = "std::thread::available_parallelism", reason = "This function might do an unbounded amount of work, use `vortex_utils::parallelism::get_available_parallelism instead" },
     { path = "vortex_session::registry::Id::new", reason = "Interning a static id on every call grabs the interner lock (#8380). Use a `CachedId` static for static ids; for a dynamic string, annotate the call with `#[expect(clippy::disallowed_methods)]`.", allow-invalid = true },
     { path = "vortex_session::registry::Id::new_static", reason = "Interning a static id on every call grabs the interner lock; use a `CachedId` static instead (#8380).", allow-invalid = true },
+    { path = "vortex_array::legacy_session", reason = "Relies on the hidden global session; thread an explicit `VortexSession`/`ExecutionCtx` through instead" },
 ]

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -159,6 +159,7 @@ impl VTable for ALPRD {
         ))
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn deserialize(
         &self,
         dtype: &DType,
@@ -470,6 +471,7 @@ fn patches_from_slots(
     PatchesData::patches_from_slots(patches_data, len, slots, LP_PATCH_SLOTS)
 }
 
+#[allow(clippy::disallowed_methods)]
 fn validate_parts(
     dtype: &DType,
     len: usize,

--- a/encodings/alp/src/alp_rd/compute/mask.rs
+++ b/encodings/alp/src/alp_rd/compute/mask.rs
@@ -14,6 +14,7 @@ use crate::ALPRD;
 use crate::ALPRDArrayExt;
 
 impl MaskReduce for ALPRD {
+    #[allow(clippy::disallowed_methods)]
     fn mask(array: ArrayView<'_, Self>, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         let masked_left_parts = MaskExpr.try_new_array(
             array.left_parts().len(),

--- a/encodings/fastlanes/src/delta/vtable/validity.rs
+++ b/encodings/fastlanes/src/delta/vtable/validity.rs
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayView;
-use vortex_array::LEGACY_SESSION;
 use vortex_array::VortexSessionExecute;
+use vortex_array::legacy_session;
 use vortex_array::validity::Validity;
 use vortex_array::vtable::ValidityVTable;
 use vortex_error::VortexResult;
@@ -13,13 +13,14 @@ use crate::bit_transpose::untranspose_validity;
 use crate::delta::array::DeltaArrayExt;
 
 impl ValidityVTable<Delta> for Delta {
+    #[allow(clippy::disallowed_methods)]
     fn validity(array: ArrayView<'_, Delta>) -> VortexResult<Validity> {
         let start = array.offset();
         let end = start + array.len();
 
         let validity = untranspose_validity(
             &array.deltas().validity()?,
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut legacy_session().create_execution_ctx(),
         )?;
         validity.slice(start..end)
     }

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -25,7 +25,6 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
 use vortex_array::TypedArrayRef;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::VarBin;
@@ -37,6 +36,7 @@ use vortex_array::builders::VarBinViewBuilder;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
+use vortex_array::legacy_session;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::smallvec::smallvec;
 use vortex_array::validity::Validity;
@@ -114,6 +114,7 @@ impl VTable for FSST {
         *ID
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn validate(
         &self,
         data: &Self::TypedArrayData,
@@ -122,7 +123,7 @@ impl VTable for FSST {
         slots: &[Option<ArrayRef>],
     ) -> VortexResult<()> {
         // TODO(ctx): trait fixes - VTable::validate has a fixed signature.
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = legacy_session().create_execution_ctx();
         data.validate(dtype, len, slots, &mut ctx)
     }
 

--- a/encodings/runend/src/arbitrary.rs
+++ b/encodings/runend/src/arbitrary.rs
@@ -5,7 +5,6 @@ use arbitrary::Arbitrary;
 use arbitrary::Result;
 use arbitrary::Unstructured;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::arbitrary::ArbitraryArray;
@@ -14,6 +13,7 @@ use vortex_array::arrays::arbitrary::ArbitraryWith;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
+use vortex_array::legacy_session;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_error::VortexExpect;
@@ -39,12 +39,13 @@ impl ArbitraryRunEndArray {
     /// Generate an arbitrary RunEndArray with the given dtype for values.
     ///
     /// The dtype must be a primitive or boolean type.
+    #[allow(clippy::disallowed_methods)]
     pub fn with_dtype(u: &mut Unstructured, dtype: &DType, len: Option<usize>) -> Result<Self> {
         // Number of runs (values/ends pairs)
         let num_runs = u.int_in_range(0..=20)?;
 
         // TODO(ctx): trait fixes - Arbitrary::arbitrary has a fixed signature.
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = legacy_session().create_execution_ctx();
         if num_runs == 0 {
             // Empty RunEndArray
             let ends = PrimitiveArray::from_iter(Vec::<u64>::new()).into_array();

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -19,7 +19,6 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
 use vortex_array::TypedArrayRef;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::Primitive;
@@ -28,6 +27,7 @@ use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
+use vortex_array::legacy_session;
 use vortex_array::scalar::PValue;
 use vortex_array::search_sorted::SearchSorted;
 use vortex_array::search_sorted::SearchSortedSide;
@@ -86,6 +86,7 @@ impl VTable for RunEnd {
         *ID
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn validate(
         &self,
         data: &Self::TypedArrayData,
@@ -100,7 +101,7 @@ impl VTable for RunEnd {
             .as_ref()
             .vortex_expect("RunEndArray values slot");
         // TODO(ctx): trait fixes - VTable::validate has a fixed signature.
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = legacy_session().create_execution_ctx();
         RunEndData::validate_parts(ends, values, data.offset, len, &mut ctx)?;
         vortex_ensure!(
             values.dtype() == dtype,

--- a/encodings/runend/src/arrow.rs
+++ b/encodings/runend/src/arrow.rs
@@ -5,12 +5,12 @@ use arrow_array::RunArray;
 use arrow_array::types::RunEndIndexType;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_array::arrow::FromArrowArray;
 use vortex_array::dtype::NativePType;
+use vortex_array::legacy_session;
 use vortex_array::scalar::PValue;
 use vortex_array::search_sorted::SearchSorted;
 use vortex_array::search_sorted::SearchSortedSide;
@@ -25,6 +25,7 @@ impl<R: RunEndIndexType> FromArrowArray<&RunArray<R>> for RunEndData
 where
     R::Native: NativePType,
 {
+    #[allow(clippy::disallowed_methods)]
     fn from_arrow(array: &RunArray<R>, nullable: bool) -> VortexResult<Self> {
         let offset = array.run_ends().offset();
         let len = array.run_ends().len();
@@ -57,7 +58,7 @@ where
 
         // SAFETY: arrow-rs enforces the RunEndArray invariants, we inherit their guarantees.
         // TODO(ctx): trait fixes - FromArrowArray::from_arrow has a fixed signature.
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = legacy_session().create_execution_ctx();
         RunEndData::validate_parts(&ends_slice, &values_slice, offset, len, &mut ctx)?;
         Ok(unsafe { RunEndData::new_unchecked(offset) })
     }

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -504,6 +504,7 @@ impl VTable for ZstdBuffers {
 }
 
 impl OperationsVTable<ZstdBuffers> for ZstdBuffers {
+    #[allow(clippy::disallowed_methods)]
     fn scalar_at(
         array: ArrayView<'_, ZstdBuffers>,
         index: usize,
@@ -514,13 +515,14 @@ impl OperationsVTable<ZstdBuffers> for ZstdBuffers {
         // canonical
         let inner_array = ZstdBuffers::decompress_and_build_inner(
             &array.into_owned(),
-            &vortex_array::LEGACY_SESSION,
+            vortex_array::legacy_session(),
         )?;
         inner_array.execute_scalar(index, ctx)
     }
 }
 
 impl ValidityVTable<ZstdBuffers> for ZstdBuffers {
+    #[allow(clippy::disallowed_methods)]
     fn validity(
         array: ArrayView<'_, ZstdBuffers>,
     ) -> VortexResult<vortex_array::validity::Validity> {
@@ -530,7 +532,7 @@ impl ValidityVTable<ZstdBuffers> for ZstdBuffers {
 
         let inner_array = ZstdBuffers::decompress_and_build_inner(
             &array.into_owned(),
-            &vortex_array::LEGACY_SESSION,
+            vortex_array::legacy_session(),
         )?;
         inner_array.validity()
     }

--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -26,7 +26,6 @@ use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VTable;
 use crate::VortexSessionExecute;
 use crate::aggregate_fn::fns::sum::sum;
@@ -50,6 +49,7 @@ use crate::dtype::DType;
 use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
 use crate::expr::stats::StatsProviderExt;
+use crate::legacy_session;
 use crate::matcher::Matcher;
 use crate::optimizer::ArrayOptimizer;
 use crate::scalar::Scalar;
@@ -269,8 +269,9 @@ impl ArrayRef {
         note = "Use `execute_scalar` instead, which allows passing an execution context for more \
         efficient execution when fetching multiple scalars from the same array."
     )]
+    #[allow(clippy::disallowed_methods)]
     pub fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
-        self.execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+        self.execute_scalar(index, &mut legacy_session().create_execution_ctx())
     }
 
     /// Execute the array to extract a scalar at the given index.
@@ -360,8 +361,9 @@ impl ArrayRef {
 
     /// Returns the canonical representation of the array.
     #[deprecated(note = "use `array.execute::<Canonical>(ctx)` instead")]
+    #[allow(clippy::disallowed_methods)]
     pub fn into_canonical(self) -> VortexResult<Canonical> {
-        self.execute(&mut LEGACY_SESSION.create_execution_ctx())
+        self.execute(&mut legacy_session().create_execution_ctx())
     }
 
     /// Returns the canonical representation of the array.

--- a/vortex-array/src/array/typed.rs
+++ b/vortex-array/src/array/typed.rs
@@ -23,12 +23,12 @@ use crate::ArrayRef;
 use crate::ArraySlots;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
 use crate::array::VTable;
 use crate::dtype::DType;
+use crate::legacy_session;
 use crate::stats::ArrayStats;
 use crate::stats::StatsSet;
 use crate::stats::StatsSetRef;
@@ -382,9 +382,10 @@ impl<V: VTable> Array<V> {
         note = "Use `execute_scalar` instead, which allows passing an execution context for more \
         efficient execution when fetching multiple scalars from the same array."
     )]
+    #[allow(clippy::disallowed_methods)]
     pub fn scalar_at(&self, index: usize) -> VortexResult<crate::scalar::Scalar> {
         self.inner
-            .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(index, &mut legacy_session().create_execution_ctx())
     }
 
     /// Execute the array to extract a scalar at the given index.

--- a/vortex-array/src/arrays/constant/compute/cast.rs
+++ b/vortex-array/src/arrays/constant/compute/cast.rs
@@ -25,7 +25,6 @@ mod tests {
     use rstest::rstest;
 
     use crate::IntoArray;
-    use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::arrays::ConstantArray;
     use crate::builtins::ArrayBuiltins;
@@ -33,6 +32,7 @@ mod tests {
     use crate::dtype::DType;
     use crate::dtype::DecimalDType;
     use crate::dtype::Nullability;
+    use crate::legacy_session;
     use crate::scalar::DecimalValue;
     use crate::scalar::Scalar;
 
@@ -48,6 +48,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::disallowed_methods)]
     fn test_cast_constant_i64_to_decimal() {
         let target_dtype = DType::Decimal(DecimalDType::new(21, 2), Nullability::NonNullable);
         let casted = ConstantArray::new(Scalar::from(42i64), 5)
@@ -57,7 +58,7 @@ mod tests {
 
         assert_eq!(casted.dtype(), &target_dtype);
         let scalar = casted
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut legacy_session().create_execution_ctx())
             .unwrap();
         assert_eq!(
             scalar.as_decimal().decimal_value(),

--- a/vortex-array/src/arrays/constant/compute/take.rs
+++ b/vortex-array/src/arrays/constant/compute/take.rs
@@ -6,7 +6,6 @@ use vortex_mask::AllOr;
 
 use crate::ArrayRef;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::array::ArrayView;
 use crate::arrays::Constant;
@@ -14,13 +13,15 @@ use crate::arrays::ConstantArray;
 use crate::arrays::MaskedArray;
 use crate::arrays::dict::TakeReduce;
 use crate::arrays::dict::TakeReduceAdaptor;
+use crate::legacy_session;
 use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar::Scalar;
 use crate::validity::Validity;
 
 impl TakeReduce for Constant {
+    #[allow(clippy::disallowed_methods)]
     fn take(array: ArrayView<'_, Constant>, indices: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = legacy_session().create_execution_ctx();
         let result = match indices
             .validity()?
             .execute_mask(indices.len(), &mut ctx)?

--- a/vortex-array/src/arrays/dict/array.rs
+++ b/vortex-array/src/arrays/dict/array.rs
@@ -15,7 +15,6 @@ use vortex_mask::AllOr;
 
 use crate::ArrayRef;
 use crate::ArraySlots;
-use crate::LEGACY_SESSION;
 #[expect(deprecated)]
 use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
@@ -26,6 +25,7 @@ use crate::array_slots;
 use crate::arrays::Dict;
 use crate::dtype::DType;
 use crate::dtype::PType;
+use crate::legacy_session;
 use crate::match_each_integer_ptype;
 
 #[derive(Clone, prost::Message)]
@@ -144,11 +144,12 @@ pub trait DictArrayExt: TypedArrayRef<Dict> + DictArraySlotsExt {
         Ok(())
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn compute_referenced_values_mask(&self, referenced: bool) -> VortexResult<BitBuffer> {
         let codes = self.codes();
         let codes_validity = codes
             .validity()?
-            .execute_mask(codes.len(), &mut LEGACY_SESSION.create_execution_ctx())?;
+            .execute_mask(codes.len(), &mut legacy_session().create_execution_ctx())?;
         #[expect(deprecated)]
         let codes_primitive = self.codes().to_primitive();
         let values_len = self.values().len();

--- a/vortex-array/src/arrays/dict/compute/rules.rs
+++ b/vortex-array/src/arrays/dict/compute/rules.rs
@@ -284,6 +284,7 @@ mod tests {
     use crate::scalar_fn::fns::not::Not;
 
     #[test]
+    #[allow(clippy::disallowed_methods)]
     fn chunked_dict_with_shared_values_pulls_values_up() -> VortexResult<()> {
         let values = buffer![10u32, 20, 30].into_array();
         let chunk0 = DictArray::try_new(buffer![0u8, 1].into_array(), values.clone())?.into_array();
@@ -298,7 +299,7 @@ mod tests {
 
         assert!(ArrayRef::ptr_eq(dict.values(), &values));
         assert_eq!(codes.nchunks(), 2);
-        let mut ctx = crate::LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = crate::legacy_session().create_execution_ctx();
         assert_arrays_eq!(
             optimized,
             PrimitiveArray::from_iter([10u32, 20, 30, 10, 20]),
@@ -309,6 +310,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::disallowed_methods)]
     fn chunked_dict_with_distinct_values_stays_chunked() -> VortexResult<()> {
         let values0 = buffer![10u32, 20, 30].into_array();
         let values1 = buffer![10u32, 20, 30].into_array();
@@ -321,7 +323,7 @@ mod tests {
         let optimized = array.optimize()?;
 
         assert!(optimized.is::<Chunked>());
-        let mut ctx = crate::LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = crate::legacy_session().create_execution_ctx();
         assert_arrays_eq!(
             optimized,
             PrimitiveArray::from_iter([10u32, 20, 30, 10, 20]),

--- a/vortex-array/src/arrays/filter/execute/varbinview.rs
+++ b/vortex-array/src/arrays/filter/execute/varbinview.rs
@@ -10,12 +10,12 @@ use vortex_mask::MaskValues;
 
 use crate::ArrayRef;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
 use crate::arrow::ArrowSessionExt;
 use crate::arrow::FromArrowArray;
+use crate::legacy_session;
 
 pub fn filter_varbinview(array: &VarBinViewArray, mask: &Arc<MaskValues>) -> VarBinViewArray {
     // Delegate to the Arrow implementation of filter over `VarBinView`.
@@ -25,16 +25,17 @@ pub fn filter_varbinview(array: &VarBinViewArray, mask: &Arc<MaskValues>) -> Var
         .into_owned()
 }
 
+#[allow(clippy::disallowed_methods)]
 fn arrow_filter_fn(array: &ArrayRef, mask: &Mask) -> vortex_error::VortexResult<ArrayRef> {
     let values = match &mask {
         Mask::Values(values) => values,
         Mask::AllTrue(_) | Mask::AllFalse(_) => unreachable!("check in filter invoke"),
     };
 
-    let array_ref = LEGACY_SESSION.arrow().execute_arrow(
+    let array_ref = legacy_session().arrow().execute_arrow(
         array.clone(),
         None,
-        &mut LEGACY_SESSION.create_execution_ctx(),
+        &mut legacy_session().create_execution_ctx(),
     )?;
     let mask_array = BooleanArray::new(values.bit_buffer().clone().into(), None);
     let filtered = arrow_select::filter::filter(array_ref.as_ref(), &mask_array)?;

--- a/vortex-array/src/arrays/fixed_size_list/array.rs
+++ b/vortex-array/src/arrays/fixed_size_list/array.rs
@@ -12,7 +12,6 @@ use vortex_error::vortex_ensure;
 
 use crate::ArrayRef;
 use crate::ArraySlots;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayParts;
@@ -21,6 +20,7 @@ use crate::array::child_to_validity;
 use crate::array::validity_to_child;
 use crate::arrays::FixedSizeList;
 use crate::dtype::DType;
+use crate::legacy_session;
 use crate::validity::Validity;
 
 /// The `elements` data array, where each fixed-size list scalar is a _slice_ of the `elements`
@@ -231,6 +231,7 @@ pub trait FixedSizeListArrayExt: TypedArrayRef<FixedSizeList> {
         child_to_validity(self.as_ref().slots()[VALIDITY_SLOT].as_ref(), nullability)
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn fixed_size_list_elements_at(&self, index: usize) -> VortexResult<ArrayRef> {
         debug_assert!(
             index < self.as_ref().len(),
@@ -242,7 +243,7 @@ pub trait FixedSizeListArrayExt: TypedArrayRef<FixedSizeList> {
         {
             debug_assert!(
                 self.fixed_size_list_validity()
-                    .execute_is_valid(index, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_is_valid(index, &mut legacy_session().create_execution_ctx())
                     .unwrap_or(false)
             );
         }

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -18,7 +18,6 @@ use crate::ArraySlots;
 use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::aggregate_fn::NumericalAggregateOpts;
 use crate::aggregate_fn::fns::min_max::min_max;
@@ -33,6 +32,7 @@ use crate::arrays::Primitive;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::NativePType;
+use crate::legacy_session;
 use crate::match_each_integer_ptype;
 use crate::match_each_native_ptype;
 use crate::scalar_fn::fns::operators::Operator;
@@ -182,6 +182,7 @@ impl ListData {
     /// Validates the components that would be used to create a `ListArray`.
     ///
     /// This function checks all the invariants required by `ListArray::new_unchecked`.
+    #[allow(clippy::disallowed_methods)]
     pub fn validate(
         elements: &ArrayRef,
         offsets: &ArrayRef,
@@ -202,7 +203,7 @@ impl ListData {
 
         // We can safely unwrap the DType as primitive now
         let offsets_ptype = offsets.dtype().as_ptype();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = legacy_session().create_execution_ctx();
 
         // Offsets must be sorted (but not strictly sorted, zero-length lists are allowed)
         if let Some(is_sorted) = offsets.statistics().compute_is_sorted(&mut ctx) {
@@ -296,6 +297,7 @@ pub trait ListArrayExt: TypedArrayRef<List> {
         )
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn offset_at(&self, index: usize) -> VortexResult<usize> {
         vortex_ensure!(
             index <= self.as_ref().len(),
@@ -309,7 +311,7 @@ pub trait ListArrayExt: TypedArrayRef<List> {
             }))
         } else {
             self.offsets()
-                .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())?
+                .execute_scalar(index, &mut legacy_session().create_execution_ctx())?
                 .as_primitive()
                 .as_::<usize>()
                 .ok_or_else(|| vortex_error::vortex_err!("offset value does not fit in usize"))

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -18,7 +18,6 @@ use vortex_mask::Mask;
 use crate::ArrayRef;
 use crate::ArraySlots;
 use crate::ExecutionCtx;
-use crate::LEGACY_SESSION;
 #[expect(deprecated)]
 use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
@@ -39,6 +38,7 @@ use crate::dtype::DType;
 use crate::dtype::IntegerPType;
 use crate::dtype::PType;
 use crate::expr::stats::Stat;
+use crate::legacy_session;
 use crate::match_each_integer_ptype;
 use crate::match_each_unsigned_integer_ptype;
 use crate::scalar_fn::fns::operators::Operator;
@@ -382,6 +382,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
         )
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn offset_at(&self, index: usize) -> usize {
         assert!(
             index < self.as_ref().len(),
@@ -393,7 +394,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
             .map(|p| match_each_integer_ptype!(p.ptype(), |P| { p.as_slice::<P>()[index].as_() }))
             .unwrap_or_else(|| {
                 self.offsets()
-                    .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(index, &mut legacy_session().create_execution_ctx())
                     .vortex_expect("offsets must support execute_scalar")
                     .as_primitive()
                     .as_::<usize>()
@@ -401,6 +402,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
             })
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn size_at(&self, index: usize) -> usize {
         assert!(
             index < self.as_ref().len(),
@@ -413,7 +415,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
             .map(|p| match_each_integer_ptype!(p.ptype(), |P| { p.as_slice::<P>()[index].as_() }))
             .unwrap_or_else(|| {
                 self.sizes()
-                    .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(index, &mut legacy_session().create_execution_ctx())
                     .vortex_expect("sizes must support execute_scalar")
                     .as_primitive()
                     .as_::<usize>()
@@ -740,6 +742,7 @@ where
 
 /// Helper function to validate if the `ListViewArray` components are actually zero-copyable to
 /// [`ListArray`](crate::arrays::ListArray).
+#[allow(clippy::disallowed_methods)]
 fn validate_zctl(
     elements: &ArrayRef,
     offsets_primitive: PrimitiveArray,
@@ -747,7 +750,7 @@ fn validate_zctl(
 ) -> VortexResult<()> {
     // Offsets must be sorted (but not strictly sorted, zero-length lists are allowed), even
     // if there are null views.
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let mut ctx = legacy_session().create_execution_ctx();
     if let Some(is_sorted) = offsets_primitive.statistics().compute_is_sorted(&mut ctx) {
         vortex_ensure!(is_sorted, "offsets must be sorted");
     } else {

--- a/vortex-array/src/arrays/masked/array.rs
+++ b/vortex-array/src/arrays/masked/array.rs
@@ -9,7 +9,6 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 
 use crate::ArrayRef;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayParts;
@@ -18,6 +17,7 @@ use crate::array::child_to_validity;
 use crate::array::validity_to_child;
 use crate::array_slots;
 use crate::arrays::Masked;
+use crate::legacy_session;
 use crate::validity::Validity;
 
 #[array_slots(Masked)]
@@ -75,13 +75,14 @@ impl MaskedData {
 
 impl Array<Masked> {
     /// Constructs a new `MaskedArray`.
+    #[allow(clippy::disallowed_methods)]
     pub fn try_new(child: ArrayRef, validity: Validity) -> VortexResult<Self> {
         let dtype = child.dtype().as_nullable();
         let len = child.len();
         let validity_slot = validity_to_child(&validity, len);
         let data = MaskedData::try_new(
             len,
-            child.all_valid(&mut LEGACY_SESSION.create_execution_ctx())?,
+            child.all_valid(&mut legacy_session().create_execution_ctx())?,
             validity,
         )?;
         Ok(unsafe {

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -23,7 +23,6 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::EqMode;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayId;
@@ -42,6 +41,7 @@ use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::executor::ExecutionCtx;
 use crate::executor::ExecutionResult;
+use crate::legacy_session;
 use crate::require_child;
 use crate::scalar::Scalar;
 use crate::serde::ArrayChildren;
@@ -122,6 +122,7 @@ impl VTable for Masked {
         Ok(Some(vec![]))
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn deserialize(
         &self,
         dtype: &DType,
@@ -160,7 +161,7 @@ impl VTable for Masked {
         let validity_slot = validity_to_child(&validity, len);
         let data = MaskedData::try_new(
             len,
-            child.all_valid(&mut LEGACY_SESSION.create_execution_ctx())?,
+            child.all_valid(&mut legacy_session().create_execution_ctx())?,
             validity,
         )?;
         Ok(ArrayParts::new(self.clone(), dtype.clone(), len, data)

--- a/vortex-array/src/arrays/patched/array.rs
+++ b/vortex-array/src/arrays/patched/array.rs
@@ -16,7 +16,6 @@ use crate::ArraySlots;
 use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayParts;
@@ -31,6 +30,7 @@ use crate::dtype::DType;
 use crate::dtype::IntegerPType;
 use crate::dtype::NativePType;
 use crate::dtype::PType;
+use crate::legacy_session;
 use crate::match_each_native_ptype;
 use crate::match_each_unsigned_integer_ptype;
 use crate::patches::Patches;
@@ -110,17 +110,18 @@ pub trait PatchedArrayExt: PatchedArraySlotsExt {
     }
 
     #[inline]
+    #[allow(clippy::disallowed_methods)]
     fn lane_range(&self, chunk: usize, lane: usize) -> VortexResult<Range<usize>> {
         assert!(chunk * 1024 <= self.as_ref().len() + self.offset());
         assert!(lane < self.n_lanes());
 
         let start = self.lane_offsets().execute_scalar(
             chunk * self.n_lanes() + lane,
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut legacy_session().create_execution_ctx(),
         )?;
         let stop = self.lane_offsets().execute_scalar(
             chunk * self.n_lanes() + lane + 1,
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut legacy_session().create_execution_ctx(),
         )?;
 
         let start = start

--- a/vortex-array/src/arrays/primitive/array/top_value.rs
+++ b/vortex-array/src/arrays/primitive/array/top_value.rs
@@ -10,16 +10,17 @@ use vortex_mask::AllOr;
 use vortex_mask::Mask;
 use vortex_utils::aliases::hash_map::HashMap;
 
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::primitive::NativeValue;
 use crate::dtype::NativePType;
+use crate::legacy_session;
 use crate::match_each_native_ptype;
 use crate::scalar::PValue;
 
 impl PrimitiveArray {
     /// Compute most common present value of this array
+    #[allow(clippy::disallowed_methods)]
     pub fn top_value(&self) -> VortexResult<Option<(PValue, usize)>> {
         if self.is_empty() {
             return Ok(None);
@@ -34,7 +35,7 @@ impl PrimitiveArray {
                 self.as_slice::<P>(),
                 self.as_ref().validity()?.execute_mask(
                     self.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx(),
+                    &mut legacy_session().create_execution_ctx(),
                 )?,
             );
             Ok(Some((top.into(), count)))

--- a/vortex-array/src/arrays/scalar_fn/vtable/validity.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/validity.rs
@@ -5,7 +5,6 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::array::ArrayView;
 use crate::array::ValidityVTable;
@@ -15,6 +14,7 @@ use crate::arrays::scalar_fn::vtable::FakeEq;
 use crate::arrays::scalar_fn::vtable::ScalarFn;
 use crate::expr::Expression;
 use crate::expr::lit;
+use crate::legacy_session;
 use crate::scalar_fn::TypedScalarFnInstance;
 use crate::scalar_fn::VecExecutionArgs;
 use crate::scalar_fn::fns::literal::Literal;
@@ -24,8 +24,9 @@ use crate::validity::Validity;
 /// Execute an expression tree recursively.
 ///
 /// This assumes all leaf expressions are either ArrayExpr (wrapping actual arrays) or Literals.
+#[allow(clippy::disallowed_methods)]
 fn execute_expr(expr: &Expression, row_count: usize) -> VortexResult<ArrayRef> {
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let mut ctx = legacy_session().create_execution_ctx();
 
     // Handle Root expression - this should not happen in validity expressions
     if expr.is::<Root>() {

--- a/vortex-array/src/arrays/varbin/array.rs
+++ b/vortex-array/src/arrays/varbin/array.rs
@@ -15,7 +15,6 @@ use vortex_error::vortex_err;
 
 use crate::ArrayRef;
 use crate::ArraySlots;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayParts;
@@ -28,6 +27,7 @@ use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
 use crate::dtype::Nullability;
+use crate::legacy_session;
 use crate::match_each_integer_ptype;
 use crate::validity::Validity;
 
@@ -230,6 +230,7 @@ impl VarBinData {
     }
 
     /// Validates that every non-null value is valid UTF-8.
+    #[allow(clippy::disallowed_methods)]
     fn validate_utf8(offsets: &ArrayRef, bytes: &[u8], validity: &Validity) -> VortexResult<()> {
         let validate_at = |i: usize, start: usize, end: usize| -> VortexResult<()> {
             let string_bytes = &bytes[start..end];
@@ -242,7 +243,7 @@ impl VarBinData {
             Ok(())
         };
 
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = legacy_session().create_execution_ctx();
         // TODO(joe): update the created VarBin with this decompressed Array.
         let primitive_offsets = offsets.clone().execute::<PrimitiveArray>(&mut ctx)?;
 
@@ -335,6 +336,7 @@ pub trait VarBinArrayExt: TypedArrayRef<VarBin> {
         )
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn offset_at(&self, index: usize) -> usize {
         assert!(
             index <= self.as_ref().len(),
@@ -344,7 +346,7 @@ pub trait VarBinArrayExt: TypedArrayRef<VarBin> {
 
         (&self
             .offsets()
-            .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(index, &mut legacy_session().create_execution_ctx())
             .vortex_expect("offsets must support execute_scalar"))
             .try_into()
             .vortex_expect("Failed to convert offset to usize")

--- a/vortex-array/src/arrays/varbin/builder.rs
+++ b/vortex-array/src/arrays/varbin/builder.rs
@@ -8,8 +8,6 @@ use vortex_error::vortex_panic;
 
 use crate::IntoArray;
 #[cfg(debug_assertions)]
-use crate::LEGACY_SESSION;
-#[cfg(debug_assertions)]
 use crate::VortexSessionExecute;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::VarBinArray;
@@ -17,6 +15,8 @@ use crate::dtype::DType;
 use crate::dtype::IntegerPType;
 use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
+#[cfg(debug_assertions)]
+use crate::legacy_session;
 use crate::validity::Validity;
 
 pub struct VarBinBuilder<O: IntegerPType> {
@@ -94,6 +94,7 @@ impl<O: IntegerPType> VarBinBuilder<O> {
         self.validity.append_n(true, num);
     }
 
+    #[allow(clippy::disallowed_methods)]
     pub fn finish(self, dtype: DType) -> VarBinArray {
         let offsets = PrimitiveArray::new(self.offsets.freeze(), Validity::NonNullable);
         let nulls = self.validity.freeze();
@@ -107,7 +108,7 @@ impl<O: IntegerPType> VarBinBuilder<O> {
         {
             let offsets_are_sorted = offsets
                 .statistics()
-                .compute_is_sorted(&mut LEGACY_SESSION.create_execution_ctx())
+                .compute_is_sorted(&mut legacy_session().create_execution_ctx())
                 .unwrap_or(false);
             debug_assert!(offsets_are_sorted, "VarBinBuilder offsets must be sorted");
         }

--- a/vortex-array/src/arrays/varbinview/array.rs
+++ b/vortex-array/src/arrays/varbinview/array.rs
@@ -18,7 +18,6 @@ use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 
 use crate::ArraySlots;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayParts;
@@ -32,6 +31,7 @@ use crate::builders::ArrayBuilder;
 use crate::builders::VarBinViewBuilder;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
+use crate::legacy_session;
 use crate::validity::Validity;
 
 /// The validity bitmap indicating which elements are non-null.
@@ -309,6 +309,7 @@ impl VarBinViewData {
         Ok(())
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn validate_views<F>(
         views: &Buffer<BinaryView>,
         buffers: &Arc<[ByteBuffer]>,
@@ -370,7 +371,7 @@ impl VarBinViewData {
             // into a mask once and zip it with the views, validating only the valid (non-null)
             // entries.
             Validity::Array(_) => {
-                let mut ctx = LEGACY_SESSION.create_execution_ctx();
+                let mut ctx = legacy_session().create_execution_ctx();
                 let mask = validity.execute_mask(views.len(), &mut ctx)?;
                 for ((idx, view), valid) in views.iter().enumerate().zip(mask.iter()) {
                     if valid {

--- a/vortex-array/src/arrays/varbinview/compact.rs
+++ b/vortex-array/src/arrays/varbinview/compact.rs
@@ -11,12 +11,12 @@ use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::varbinview::Ref;
 use crate::builders::ArrayBuilder;
 use crate::builders::VarBinViewBuilder;
+use crate::legacy_session;
 
 const DEFAULT_COMPACTION_THRESHOLD: f64 = 0.5;
 const MIN_RETAINED_BYTES_PER_ROW_TO_CHECK_COMPACTION: u64 = 128;
@@ -69,13 +69,14 @@ impl VarBinViewArray {
     /// Iterates over all valid, non-inlined views, calling the provided
     /// closure for each one.
     #[inline(always)]
+    #[allow(clippy::disallowed_methods)]
     fn iter_valid_views<F>(&self, mut f: F) -> VortexResult<()>
     where
         F: FnMut(&Ref),
     {
         match self.as_ref().validity()?.execute_mask(
             self.as_ref().len(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut legacy_session().create_execution_ctx(),
         )? {
             Mask::AllTrue(_) => {
                 for &view in self.views().iter() {

--- a/vortex-array/src/arrow/datum.rs
+++ b/vortex-array/src/arrow/datum.rs
@@ -12,13 +12,13 @@ use vortex_error::vortex_panic;
 
 use crate::ArrayRef;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrow::ArrowSessionExt;
 use crate::arrow::FromArrowArray;
 use crate::executor::ExecutionCtx;
+use crate::legacy_session;
 
 /// A wrapper around a generic Arrow array that can be used as a Datum in Arrow compute.
 #[derive(Debug)]
@@ -106,8 +106,9 @@ impl ArrowDatum for Datum {
 ///
 /// The provided array must have length
 #[deprecated(
-    note = "Relies on the hidden global `LEGACY_SESSION`; use `from_arrow_columnar` with an explicit `ExecutionCtx` instead"
+    note = "Relies on the hidden global `legacy_session()`; use `from_arrow_columnar` with an explicit `ExecutionCtx` instead"
 )]
+#[allow(clippy::disallowed_methods)]
 pub fn from_arrow_array_with_len<A>(array: A, len: usize, nullable: bool) -> VortexResult<ArrayRef>
 where
     ArrayRef: FromArrowArray<A>,
@@ -128,7 +129,7 @@ where
 
     Ok(ConstantArray::new(
         array
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut legacy_session().create_execution_ctx())
             .vortex_expect("array of length 1 must support execute_scalar(0)"),
         len,
     )

--- a/vortex-array/src/arrow/executor/byte.rs
+++ b/vortex-array/src/arrow/executor/byte.rs
@@ -84,13 +84,13 @@ mod tests {
     use vortex_mask::Mask;
 
     use crate::IntoArray;
-    use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
     use crate::array_session;
     use crate::arrow::ArrowArrayExecutor;
     use crate::arrow::executor::byte::VarBinViewArray;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
+    use crate::legacy_session;
 
     fn make_utf8_array() -> VarBinViewArray {
         VarBinViewArray::from_iter_str(["hello", "world", "this is a longer string for testing"])
@@ -184,6 +184,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::disallowed_methods)]
     fn filtered_utf8_view_export_does_not_retain_unselected_buffers() -> VortexResult<()> {
         let unselected = "x".repeat(1 << 20);
         let array =
@@ -194,7 +195,7 @@ mod tests {
 
         let arrow = filtered.execute_arrow(
             Some(&DataType::Utf8View),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut legacy_session().create_execution_ctx(),
         )?;
 
         assert_eq!(arrow.as_string_view().value(0), "selected");

--- a/vortex-array/src/arrow/mod.rs
+++ b/vortex-array/src/arrow/mod.rs
@@ -23,8 +23,8 @@ pub use null_buffer::to_null_buffer;
 pub use session::*;
 
 use crate::ArrayRef;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
+use crate::legacy_session;
 
 /// Construct a Vortex array from an Arrow array (or other Arrow container) of type `A`.
 ///
@@ -66,11 +66,16 @@ pub trait IntoArrowArray {
 impl IntoArrowArray for ArrayRef {
     /// Convert this [`crate::ArrayRef`] into an Arrow [`crate::ArrayRef`] by using the array's
     /// preferred (cheapest) Arrow [`DataType`].
+    #[allow(clippy::disallowed_methods)]
     fn into_arrow_preferred(self) -> VortexResult<ArrowArrayRef> {
-        self.execute_arrow(None, &mut LEGACY_SESSION.create_execution_ctx())
+        self.execute_arrow(None, &mut legacy_session().create_execution_ctx())
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn into_arrow(self, data_type: &DataType) -> VortexResult<ArrowArrayRef> {
-        self.execute_arrow(Some(data_type), &mut LEGACY_SESSION.create_execution_ctx())
+        self.execute_arrow(
+            Some(data_type),
+            &mut legacy_session().create_execution_ctx(),
+        )
     }
 }

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -13,7 +13,6 @@ use vortex_mask::Mask;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::BoolArray;
 use crate::arrays::bool::BoolArrayExt;
@@ -25,6 +24,7 @@ use crate::canonical::Canonical;
 use crate::canonical::ToCanonical as _;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
+use crate::legacy_session;
 use crate::scalar::Scalar;
 
 pub struct BoolBuilder {
@@ -127,10 +127,11 @@ impl ArrayBuilder for BoolBuilder {
         Ok(())
     }
 
+    #[allow(clippy::disallowed_methods)]
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         #[expect(deprecated)]
         let bool_array = array.to_bool();
-        self.append_bool_array(&bool_array, &mut LEGACY_SESSION.create_execution_ctx())
+        self.append_bool_array(&bool_array, &mut legacy_session().create_execution_ctx())
             .vortex_expect("Failed to append bool array");
     }
 

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -13,7 +13,6 @@ use vortex_mask::Mask;
 
 use crate::ArrayRef;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 #[expect(deprecated)]
 use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
@@ -28,6 +27,7 @@ use crate::dtype::DecimalDType;
 use crate::dtype::NativeDecimalType;
 use crate::dtype::Nullability;
 use crate::dtype::i256;
+use crate::legacy_session;
 use crate::match_each_decimal_value;
 use crate::match_each_decimal_value_type;
 use crate::scalar::DecimalValue;
@@ -195,6 +195,7 @@ impl ArrayBuilder for DecimalBuilder {
         Ok(())
     }
 
+    #[allow(clippy::disallowed_methods)]
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         #[expect(deprecated)]
         let decimal_array = array.to_decimal();
@@ -213,7 +214,7 @@ impl ArrayBuilder for DecimalBuilder {
                 .vortex_expect("validity_mask")
                 .execute_mask(
                     decimal_array.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx(),
+                    &mut legacy_session().create_execution_ctx(),
                 )
                 .vortex_expect("Failed to compute validity mask"),
         );

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -14,7 +14,6 @@ use vortex_mask::Mask;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::FixedSizeListArray;
 use crate::arrays::fixed_size_list::FixedSizeListArrayExt;
@@ -27,6 +26,7 @@ use crate::canonical::Canonical;
 use crate::canonical::ToCanonical as _;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
+use crate::legacy_session;
 use crate::scalar::ListScalar;
 use crate::scalar::Scalar;
 
@@ -242,6 +242,7 @@ impl ArrayBuilder for FixedSizeListBuilder {
 
     /// This will increase the capacity if extending with this `array` would go past the original
     /// capacity.
+    #[allow(clippy::disallowed_methods)]
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         #[expect(deprecated)]
         let fsl = array.to_fixed_size_list();
@@ -254,7 +255,7 @@ impl ArrayBuilder for FixedSizeListBuilder {
             &array
                 .validity()
                 .vortex_expect("validity_mask in extend_from_array_unchecked")
-                .execute_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_mask(array.len(), &mut legacy_session().create_execution_ctx())
                 .vortex_expect("Failed to compute validity mask"),
         );
     }

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -15,7 +15,6 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::ListArray;
 use crate::arrays::listview::ListViewArrayExt;
@@ -30,6 +29,7 @@ use crate::dtype::DType;
 use crate::dtype::IntegerPType;
 use crate::dtype::Nullability;
 use crate::dtype::Nullability::NonNullable;
+use crate::legacy_session;
 use crate::match_each_integer_ptype;
 use crate::scalar::ListScalar;
 use crate::scalar::Scalar;
@@ -222,6 +222,7 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
         self.append_value(scalar.as_list())
     }
 
+    #[allow(clippy::disallowed_methods)]
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         #[expect(deprecated)]
         let list = array.to_listview();
@@ -234,7 +235,7 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
             &array
                 .validity()
                 .vortex_expect("validity_mask in extend_from_array_unchecked")
-                .execute_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_mask(array.len(), &mut legacy_session().create_execution_ctx())
                 .vortex_expect("Failed to compute validity mask"),
         );
 

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -21,7 +21,6 @@ use vortex_mask::Mask;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::ExecutionCtx;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::array::IntoArray;
 use crate::arrays::ListViewArray;
@@ -38,6 +37,7 @@ use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
 use crate::dtype::Nullability;
+use crate::legacy_session;
 use crate::match_each_integer_ptype;
 use crate::scalar::ListScalar;
 use crate::scalar::Scalar;
@@ -296,12 +296,13 @@ impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
         self.append_value(list_scalar)
     }
 
+    #[allow(clippy::disallowed_methods)]
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         // TODO: The `ArrayBuilder` trait does not thread an `ExecutionCtx` through its extend
-        // methods, so we are forced to mint a fresh `LEGACY_SESSION` context here on every call
+        // methods, so we are forced to mint a fresh `legacy_session()` context here on every call
         // (which for chunked input means once per chunk). Once the trait carries a `&mut
         // ExecutionCtx`, the caller's session should be reused instead.
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = legacy_session().create_execution_ctx();
 
         let listview = array
             .clone()

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -13,7 +13,6 @@ use vortex_mask::Mask;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::PrimitiveArray;
 use crate::builders::ArrayBuilder;
@@ -25,6 +24,7 @@ use crate::canonical::ToCanonical as _;
 use crate::dtype::DType;
 use crate::dtype::NativePType;
 use crate::dtype::Nullability;
+use crate::legacy_session;
 use crate::scalar::Scalar;
 
 /// The builder for building a [`PrimitiveArray`], parametrized by the `PType`.
@@ -200,11 +200,12 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
         Ok(())
     }
 
+    #[allow(clippy::disallowed_methods)]
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         #[expect(deprecated)]
         let array = array.to_primitive();
 
-        self.append_primitive_array(&array, &mut LEGACY_SESSION.create_execution_ctx())
+        self.append_primitive_array(&array, &mut legacy_session().create_execution_ctx())
             .vortex_expect("Failed to append primitive array");
     }
 

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -13,7 +13,6 @@ use vortex_mask::Mask;
 
 use crate::ArrayRef;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::StructArray;
 use crate::arrays::struct_::StructArrayExt;
@@ -27,6 +26,7 @@ use crate::canonical::ToCanonical as _;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::StructFields;
+use crate::legacy_session;
 use crate::scalar::Scalar;
 use crate::scalar::StructScalar;
 
@@ -168,6 +168,7 @@ impl ArrayBuilder for StructBuilder {
         self.append_value(scalar.as_struct())
     }
 
+    #[allow(clippy::disallowed_methods)]
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         #[expect(deprecated)]
         let array = array.to_struct();
@@ -183,7 +184,7 @@ impl ArrayBuilder for StructBuilder {
             &array
                 .validity()
                 .vortex_expect("validity_mask")
-                .execute_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_mask(array.len(), &mut legacy_session().create_execution_ctx())
                 .vortex_expect("Failed to compute validity mask"),
         );
     }

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -22,7 +22,6 @@ use vortex_utils::aliases::hash_map::HashMap;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::varbinview::VarBinViewArrayExt;
@@ -34,6 +33,7 @@ use crate::canonical::Canonical;
 #[expect(deprecated)]
 use crate::canonical::ToCanonical as _;
 use crate::dtype::DType;
+use crate::legacy_session;
 use crate::scalar::Scalar;
 
 /// The builder for building a [`VarBinViewArray`].
@@ -372,10 +372,11 @@ impl ArrayBuilder for VarBinViewBuilder {
         Ok(())
     }
 
+    #[allow(clippy::disallowed_methods)]
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         #[expect(deprecated)]
         let array = array.to_varbinview();
-        self.append_varbinview_array(&array, &mut LEGACY_SESSION.create_execution_ctx())
+        self.append_varbinview_array(&array, &mut legacy_session().create_execution_ctx())
             .vortex_expect("Failed to append varbinview array");
     }
 

--- a/vortex-array/src/display/mod.rs
+++ b/vortex-array/src/display/mod.rs
@@ -19,8 +19,8 @@ use itertools::Itertools as _;
 pub use tree_display::TreeDisplay;
 
 use crate::ArrayRef;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
+use crate::legacy_session;
 
 /// Describe how to convert an array to a string.
 ///
@@ -521,6 +521,7 @@ impl ArrayRef {
         DisplayArrayAs(self, DisplayOptions::TableDisplay)
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn fmt_as(&self, f: &mut std::fmt::Formatter, options: &DisplayOptions) -> std::fmt::Result {
         match options {
             DisplayOptions::MetadataOnly => EncodingSummaryExtractor::write(self, f),
@@ -536,7 +537,7 @@ impl ArrayRef {
                 let is_truncated = self.len() > limit;
 
                 let fmt_scalar = |i| {
-                    self.execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    self.execute_scalar(i, &mut legacy_session().create_execution_ctx())
                         .map_or_else(|e| format!("<error: {e}>"), |s| s.to_string())
                 };
                 write!(
@@ -587,7 +588,7 @@ impl ArrayRef {
 
                 let mut builder = tabled::builder::Builder::default();
                 // Reuse a single execution context across all per-row accesses below.
-                let mut ctx = LEGACY_SESSION.create_execution_ctx();
+                let mut ctx = legacy_session().create_execution_ctx();
 
                 // Special logic for struct arrays.
                 let DType::Struct(sf, _) = self.dtype() else {

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -184,6 +184,12 @@ pub fn array_session() -> VortexSession {
 // TODO(ngates): canonicalize doesn't currently take a session, therefore we cannot invoke execute
 //  from the new array encodings to support back-compat for legacy encodings. So we hold a session
 //  here...
-pub static LEGACY_SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
+/// Returns the hidden global [`VortexSession`] used as a back-compat shim for code paths that
+/// cannot yet thread an explicit session through.
+#[inline]
+pub fn legacy_session() -> &'static VortexSession {
+    static LEGACY_SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
+    LazyLock::force(&LEGACY_SESSION)
+}
 
 pub type ArrayContext = Context<ArrayPluginRef>;

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -189,7 +189,7 @@ pub fn array_session() -> VortexSession {
 #[inline]
 pub fn legacy_session() -> &'static VortexSession {
     static LEGACY_SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
-    LazyLock::force(&LEGACY_SESSION)
+    &LEGACY_SESSION
 }
 
 pub type ArrayContext = Context<ArrayPluginRef>;

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -23,7 +23,6 @@ use crate::ArrayRef;
 use crate::ArraySlots;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
@@ -36,6 +35,7 @@ use crate::dtype::Nullability;
 use crate::dtype::Nullability::NonNullable;
 use crate::dtype::PType;
 use crate::dtype::UnsignedPType;
+use crate::legacy_session;
 use crate::match_each_integer_ptype;
 use crate::match_each_unsigned_integer_ptype;
 use crate::scalar::PValue;
@@ -238,6 +238,7 @@ pub struct Patches {
 }
 
 impl Patches {
+    #[allow(clippy::disallowed_methods)]
     pub fn new(
         array_len: usize,
         offset: usize,
@@ -266,7 +267,7 @@ impl Patches {
         if indices.is_host() && values.is_host() {
             let max = usize::try_from(&indices.execute_scalar(
                 indices.len() - 1,
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut legacy_session().create_execution_ctx(),
             )?)
             .map_err(|_| vortex_err!("indices must be a number"))?;
             vortex_ensure!(
@@ -278,7 +279,7 @@ impl Patches {
             {
                 use crate::VortexSessionExecute;
                 use crate::aggregate_fn::fns::is_sorted::is_sorted;
-                let mut ctx = LEGACY_SESSION.create_execution_ctx();
+                let mut ctx = legacy_session().create_execution_ctx();
                 assert!(
                     is_sorted(&indices, &mut ctx).unwrap_or(false),
                     "Patch indices must be sorted"
@@ -381,13 +382,14 @@ impl Patches {
     }
 
     #[inline]
+    #[allow(clippy::disallowed_methods)]
     pub fn chunk_offset_at(&self, idx: usize) -> VortexResult<usize> {
         let Some(chunk_offsets) = &self.chunk_offsets else {
             vortex_bail!("chunk_offsets must be set to retrieve offset at index")
         };
 
         chunk_offsets
-            .execute_scalar(idx, &mut LEGACY_SESSION.create_execution_ctx())?
+            .execute_scalar(idx, &mut legacy_session().create_execution_ctx())?
             .as_primitive()
             .as_::<usize>()
             .ok_or_else(|| vortex_err!("chunk offset does not fit in usize"))
@@ -441,12 +443,13 @@ impl Patches {
     }
 
     /// Get the patched value at a given index if it exists.
+    #[allow(clippy::disallowed_methods)]
     pub fn get_patched(&self, index: usize) -> VortexResult<Option<Scalar>> {
         self.search_index(index)?
             .to_found()
             .map(|patch_idx| {
                 self.values()
-                    .execute_scalar(patch_idx, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(patch_idx, &mut legacy_session().create_execution_ctx())
             })
             .transpose()
     }
@@ -625,10 +628,11 @@ impl Patches {
     }
 
     /// Returns the minimum patch index
+    #[allow(clippy::disallowed_methods)]
     pub fn min_index(&self) -> VortexResult<usize> {
         let first = self
             .indices
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())?
+            .execute_scalar(0, &mut legacy_session().create_execution_ctx())?
             .as_primitive()
             .as_::<usize>()
             .ok_or_else(|| vortex_err!("index does not fit in usize"))?;
@@ -636,12 +640,13 @@ impl Patches {
     }
 
     /// Returns the maximum patch index
+    #[allow(clippy::disallowed_methods)]
     pub fn max_index(&self) -> VortexResult<usize> {
         let last = self
             .indices
             .execute_scalar(
                 self.indices.len() - 1,
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut legacy_session().create_execution_ctx(),
             )?
             .as_primitive()
             .as_::<usize>()
@@ -743,6 +748,7 @@ impl Patches {
     }
 
     /// Slice the patches by a range of the patched array.
+    #[allow(clippy::disallowed_methods)]
     pub fn slice(&self, range: Range<usize>) -> VortexResult<Option<Self>> {
         let slice_start_idx = self.search_index(range.start)?.to_index();
         let slice_end_idx = self.search_index(range.end)?.to_index();
@@ -769,7 +775,7 @@ impl Patches {
             .as_ref()
             .map(|new_chunk_offsets| -> VortexResult<usize> {
                 let new_chunk_base = new_chunk_offsets
-                    .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())?
+                    .execute_scalar(0, &mut legacy_session().create_execution_ctx())?
                     .as_primitive()
                     .as_::<usize>()
                     .ok_or_else(|| vortex_err!("chunk offset does not fit in usize"))?;

--- a/vortex-array/src/search_sorted.rs
+++ b/vortex-array/src/search_sorted.rs
@@ -13,8 +13,8 @@ use std::hint;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
+use crate::legacy_session;
 use crate::scalar::Scalar;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -270,8 +270,9 @@ fn search_sorted_side_idx<F: FnMut(usize) -> VortexResult<Ordering>>(
 }
 
 impl IndexOrd<Scalar> for ArrayRef {
+    #[allow(clippy::disallowed_methods)]
     fn index_cmp(&self, idx: usize, elem: &Scalar) -> VortexResult<Option<Ordering>> {
-        let scalar_a = self.execute_scalar(idx, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let scalar_a = self.execute_scalar(idx, &mut legacy_session().create_execution_ctx())?;
         Ok(scalar_a.partial_cmp(elem))
     }
 

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -24,7 +24,6 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::BoolArray;
 use crate::arrays::ChunkedArray;
@@ -33,6 +32,7 @@ use crate::arrays::scalar_fn::ScalarFnFactoryExt;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
+use crate::legacy_session;
 use crate::optimizer::ArrayOptimizer;
 use crate::patches::Patches;
 use crate::scalar::Scalar;
@@ -186,15 +186,17 @@ impl Validity {
     /// Returns whether the `index` item is valid.
     #[deprecated(note = "use `execute_is_valid` with an explicit `ExecutionCtx`")]
     #[inline]
+    #[allow(clippy::disallowed_methods)]
     pub fn is_valid(&self, index: usize) -> VortexResult<bool> {
-        self.execute_is_valid(index, &mut LEGACY_SESSION.create_execution_ctx())
+        self.execute_is_valid(index, &mut legacy_session().create_execution_ctx())
     }
 
     /// Returns whether the `index` item is null.
     #[deprecated(note = "use `execute_is_null` with an explicit `ExecutionCtx`")]
     #[inline]
+    #[allow(clippy::disallowed_methods)]
     pub fn is_null(&self, index: usize) -> VortexResult<bool> {
-        self.execute_is_null(index, &mut LEGACY_SESSION.create_execution_ctx())
+        self.execute_is_null(index, &mut legacy_session().create_execution_ctx())
     }
 
     #[inline]

--- a/vortex-array/src/variants.rs
+++ b/vortex-array/src/variants.rs
@@ -12,7 +12,6 @@ use vortex_mask::Mask;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
-use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::aggregate_fn::fns::sum::sum;
 use crate::arrays::BoolArray;
@@ -22,6 +21,7 @@ use crate::dtype::DType;
 use crate::dtype::FieldNames;
 use crate::dtype::PType;
 use crate::dtype::extension::ExtDTypeRef;
+use crate::legacy_session;
 use crate::scalar::PValue;
 use crate::scalar::Scalar;
 use crate::search_sorted::IndexOrd;
@@ -113,10 +113,11 @@ pub struct BoolTyped<'a>(&'a ArrayRef);
 
 impl BoolTyped<'_> {
     #[deprecated(
-        note = "Relies on the hidden global `LEGACY_SESSION`; use `sum(array, ctx)` with an explicit `ExecutionCtx` instead"
+        note = "Relies on the hidden global `legacy_session()`; use `sum(array, ctx)` with an explicit `ExecutionCtx` instead"
     )]
+    #[allow(clippy::disallowed_methods)]
     pub fn true_count(&self) -> VortexResult<usize> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = legacy_session().create_execution_ctx();
         let true_count = sum(self.0, &mut ctx)?;
         Ok(true_count
             .as_primitive()
@@ -137,24 +138,26 @@ impl PrimitiveTyped<'_> {
 
     /// Return the primitive value at the given index.
     #[deprecated(
-        note = "Relies on the hidden global `LEGACY_SESSION`; use `is_valid`/`execute_scalar` with an explicit `ExecutionCtx` instead"
+        note = "Relies on the hidden global `legacy_session()`; use `is_valid`/`execute_scalar` with an explicit `ExecutionCtx` instead"
     )]
     #[allow(deprecated)]
+    #[allow(clippy::disallowed_methods)]
     pub fn value(&self, idx: usize) -> VortexResult<Option<PValue>> {
         self.0
-            .is_valid(idx, &mut LEGACY_SESSION.create_execution_ctx())?
+            .is_valid(idx, &mut legacy_session().create_execution_ctx())?
             .then(|| self.value_unchecked(idx))
             .transpose()
     }
 
     /// Return the primitive value at the given index, ignoring nullability.
     #[deprecated(
-        note = "Relies on the hidden global `LEGACY_SESSION`; use `execute_scalar` with an explicit `ExecutionCtx` instead"
+        note = "Relies on the hidden global `legacy_session()`; use `execute_scalar` with an explicit `ExecutionCtx` instead"
     )]
+    #[allow(clippy::disallowed_methods)]
     pub fn value_unchecked(&self, idx: usize) -> VortexResult<PValue> {
         Ok(self
             .0
-            .execute_scalar(idx, &mut LEGACY_SESSION.create_execution_ctx())?
+            .execute_scalar(idx, &mut legacy_session().create_execution_ctx())?
             .as_primitive()
             .pvalue()
             .unwrap_or_else(|| PValue::zero(&self.ptype())))
@@ -176,10 +179,11 @@ impl IndexOrd<Option<PValue>> for PrimitiveTyped<'_> {
 // TODO(ngates): add generics to the `value` function and implement this over T.
 impl IndexOrd<PValue> for PrimitiveTyped<'_> {
     #[allow(deprecated)]
+    #[allow(clippy::disallowed_methods)]
     fn index_cmp(&self, idx: usize, elem: &PValue) -> VortexResult<Option<Ordering>> {
         assert!(
             self.0
-                .all_valid(&mut LEGACY_SESSION.create_execution_ctx())?
+                .all_valid(&mut legacy_session().create_execution_ctx())?
         );
         let value = self.value_unchecked(idx)?;
         Ok(value.partial_cmp(elem))

--- a/vortex-cuda/src/canonical.rs
+++ b/vortex-cuda/src/canonical.rs
@@ -7,7 +7,6 @@ use async_trait::async_trait;
 use futures::future::try_join_all;
 use vortex::array::Canonical;
 use vortex::array::IntoArray;
-use vortex::array::LEGACY_SESSION;
 use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::BoolArray;
 use vortex::array::arrays::DecimalArray;
@@ -23,6 +22,7 @@ use vortex::array::arrays::struct_::StructDataParts;
 use vortex::array::arrays::varbinview::BinaryView;
 use vortex::array::arrays::varbinview::VarBinViewDataParts;
 use vortex::array::buffer::BufferHandle;
+use vortex::array::legacy_session;
 use vortex::buffer::BitBuffer;
 use vortex::buffer::Buffer;
 use vortex::buffer::ByteBuffer;
@@ -38,6 +38,7 @@ pub trait CanonicalCudaExt {
 
 #[async_trait]
 impl CanonicalCudaExt for Canonical {
+    #[allow(clippy::disallowed_methods)]
     async fn into_host(self) -> VortexResult<Self> {
         match self {
             Canonical::Struct(struct_array) => {
@@ -55,7 +56,7 @@ impl CanonicalCudaExt for Canonical {
                     host_fields.push(
                         field
                             .clone()
-                            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+                            .execute::<Canonical>(&mut legacy_session().create_execution_ctx())?
                             .into_host()
                             .await?
                             .into_array(),
@@ -144,7 +145,7 @@ impl CanonicalCudaExt for Canonical {
                 let host_storage = ext
                     .storage_array()
                     .clone()
-                    .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+                    .execute::<Canonical>(&mut legacy_session().create_execution_ctx())?
                     .into_host()
                     .await?
                     .into_array();

--- a/vortex-cxx/src/read.rs
+++ b/vortex-cxx/src/read.rs
@@ -15,9 +15,9 @@ use arrow_schema::Schema;
 use arrow_schema::SchemaRef;
 use futures::stream::TryStreamExt;
 use vortex::array::ArrayRef;
-use vortex::array::LEGACY_SESSION;
 use vortex::array::VortexSessionExecute;
 use vortex::array::arrow::ArrowSessionExt;
+use vortex::array::legacy_session;
 use vortex::buffer::Buffer;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::io::runtime::BlockingRuntime;
@@ -149,6 +149,7 @@ pub(crate) struct ThreadsafeCloneableReader {
     inner: Box<dyn ThreadsafeCloneableReaderTrait>,
 }
 
+#[allow(clippy::disallowed_methods)]
 pub(crate) fn scan_builder_into_threadsafe_cloneable_reader(
     builder: Box<VortexScanBuilder>,
 ) -> Result<Box<ThreadsafeCloneableReader>, Box<dyn std::error::Error + Send + Sync>> {
@@ -167,7 +168,11 @@ pub(crate) fn scan_builder_into_threadsafe_cloneable_reader(
         .map(move |b| {
             SESSION
                 .arrow()
-                .execute_arrow(b, Some(&target), &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_arrow(
+                    b,
+                    Some(&target),
+                    &mut legacy_session().create_execution_ctx(),
+                )
                 .map(|struct_array| RecordBatch::from(struct_array.as_struct()))
         })
         .into_stream()?

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -14,13 +14,13 @@ use arrow_array::ffi::from_ffi;
 use paste::paste;
 use vortex::array::ArrayRef;
 use vortex::array::IntoArray;
-use vortex::array::LEGACY_SESSION;
 use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::NullArray;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;
 use vortex::array::arrays::struct_::StructArrayExt;
 use vortex::array::arrow::FromArrowArray;
+use vortex::array::legacy_session;
 use vortex::array::validity::Validity;
 use vortex::buffer::Buffer;
 use vortex::dtype::DType;
@@ -219,6 +219,7 @@ pub unsafe extern "C-unwind" fn vx_array_dtype(array: *const vx_array) -> *const
 // Returns NULL and sets error_out if index is out of bounds or array doesn't
 // have dtype DTYPE_STRUCT.
 #[unsafe(no_mangle)]
+#[allow(clippy::disallowed_methods)]
 pub unsafe extern "C-unwind" fn vx_array_get_field(
     array: *const vx_array,
     index: usize,
@@ -227,7 +228,7 @@ pub unsafe extern "C-unwind" fn vx_array_get_field(
     try_or_default(error_out, || {
         let array = vx_array::as_ref(array);
 
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = legacy_session().create_execution_ctx();
         let field_array = array
             .clone()
             .execute::<StructArray>(&mut ctx)?
@@ -258,6 +259,7 @@ pub unsafe extern "C-unwind" fn vx_array_slice(
 /// validity array. Sets error if index is out of bounds or underlying validity
 /// array is corrupted.
 #[unsafe(no_mangle)]
+#[allow(clippy::disallowed_methods)]
 pub unsafe extern "C-unwind" fn vx_array_element_is_invalid(
     array: *const vx_array,
     index: usize,
@@ -265,12 +267,13 @@ pub unsafe extern "C-unwind" fn vx_array_element_is_invalid(
 ) -> bool {
     try_or_default(error, || {
         vortex_ensure!(!array.is_null());
-        vx_array::as_ref(array).is_invalid(index, &mut LEGACY_SESSION.create_execution_ctx())
+        vx_array::as_ref(array).is_invalid(index, &mut legacy_session().create_execution_ctx())
     })
 }
 
 /// Check how many items in the array are invalid (null).
 #[unsafe(no_mangle)]
+#[allow(clippy::disallowed_methods)]
 pub unsafe extern "C-unwind" fn vx_array_invalid_count(
     array: *const vx_array,
     error_out: *mut *mut vx_error,
@@ -278,7 +281,7 @@ pub unsafe extern "C-unwind" fn vx_array_invalid_count(
     try_or_default(error_out, || {
         vortex_ensure!(!array.is_null());
         let array = vx_array::as_ref(array);
-        array.invalid_count(&mut LEGACY_SESSION.create_execution_ctx())
+        array.invalid_count(&mut legacy_session().create_execution_ctx())
     })
 }
 
@@ -394,8 +397,9 @@ macro_rules! ffiarray_get_ptype {
             pub unsafe extern "C-unwind" fn [<vx_array_get_ $ptype>](array: *const vx_array, index: usize) -> $ptype {
                 let array = vx_array::as_ref(array);
                 // TODO(joe): propagate this error up instead of expecting
+                #[allow(clippy::disallowed_methods)]
                 let value = array
-                    .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(index, &mut legacy_session().create_execution_ctx())
                     .vortex_expect("scalar_at failed");
                 // TODO(joe): propagate this error up instead of expecting
                 value.as_primitive()
@@ -407,8 +411,9 @@ macro_rules! ffiarray_get_ptype {
             pub unsafe extern "C-unwind" fn [<vx_array_get_storage_ $ptype>](array: *const vx_array, index: usize) -> $ptype {
                 let array = vx_array::as_ref(array);
                 // TODO(joe): propagate this error up instead of expecting
+                #[allow(clippy::disallowed_methods)]
                 let value = array
-                    .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(index, &mut legacy_session().create_execution_ctx())
                     .vortex_expect("scalar_at failed");
                 // TODO(joe): propagate this error up instead of expecting
                 value.as_extension()
@@ -436,6 +441,7 @@ ffiarray_get_ptype!(f64);
 /// Return the utf-8 string at `index` in the array. The pointer will be null if the value at `index` is null.
 /// The caller must free the returned pointer.
 #[unsafe(no_mangle)]
+#[allow(clippy::disallowed_methods)]
 pub unsafe extern "C-unwind" fn vx_array_get_utf8(
     array: *const vx_array,
     index: u32,
@@ -443,7 +449,7 @@ pub unsafe extern "C-unwind" fn vx_array_get_utf8(
     let array = vx_array::as_ref(array);
     // TODO(joe): propagate this error up instead of expecting
     let value = array
-        .execute_scalar(index as usize, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(index as usize, &mut legacy_session().create_execution_ctx())
         .vortex_expect("scalar_at failed");
     let utf8_scalar = value.as_utf8();
     if let Some(buffer) = utf8_scalar.value() {
@@ -456,6 +462,7 @@ pub unsafe extern "C-unwind" fn vx_array_get_utf8(
 /// Return the binary at `index` in the array. The pointer will be null if the value at `index` is null.
 /// The caller must free the returned pointer.
 #[unsafe(no_mangle)]
+#[allow(clippy::disallowed_methods)]
 pub unsafe extern "C-unwind" fn vx_array_get_binary(
     array: *const vx_array,
     index: u32,
@@ -463,7 +470,7 @@ pub unsafe extern "C-unwind" fn vx_array_get_binary(
     let array = vx_array::as_ref(array);
     // TODO(joe): propagate this error up instead of expecting
     let value = array
-        .execute_scalar(index as usize, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(index as usize, &mut legacy_session().create_execution_ctx())
         .vortex_expect("scalar_at failed");
     let binary_scalar = value.as_binary();
     if let Some(bytes) = binary_scalar.value() {

--- a/vortex-layout/src/layouts/file_stats.rs
+++ b/vortex-layout/src/layouts/file_stats.rs
@@ -11,7 +11,6 @@ use parking_lot::Mutex;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
 use vortex_array::VortexSessionExecute;
 use vortex_array::aggregate_fn::fns::sum::sum;
 use vortex_array::arrays::ConstantArray;
@@ -26,6 +25,7 @@ use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::expr::stats::Precision;
 use vortex_array::expr::stats::Stat;
+use vortex_array::legacy_session;
 use vortex_array::scalar::Scalar;
 use vortex_array::scalar::ScalarTruncation;
 use vortex_array::scalar::lower_bound;
@@ -236,8 +236,9 @@ struct NamedArrays {
 }
 
 impl NamedArrays {
+    #[allow(clippy::disallowed_methods)]
     fn all_invalid(&self) -> VortexResult<bool> {
-        self.arrays[0].all_invalid(&mut LEGACY_SESSION.create_execution_ctx())
+        self.arrays[0].all_invalid(&mut legacy_session().create_execution_ctx())
     }
 }
 

--- a/vortex-layout/src/layouts/zoned/builder.rs
+++ b/vortex-layout/src/layouts/zoned/builder.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 use itertools::Itertools;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
-use vortex_array::LEGACY_SESSION;
 use vortex_array::VortexSessionExecute;
 use vortex_array::aggregate_fn::AggregateFnRef;
 use vortex_array::arrays::StructArray;
@@ -16,6 +15,7 @@ use vortex_array::builders::ArrayBuilder;
 use vortex_array::builders::builder_with_capacity;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldName;
+use vortex_array::legacy_session;
 use vortex_array::scalar::Scalar;
 use vortex_array::validity::Validity;
 use vortex_error::VortexResult;
@@ -153,8 +153,9 @@ struct NamedArrays {
 }
 
 impl NamedArrays {
+    #[allow(clippy::disallowed_methods)]
     fn all_invalid(&self) -> VortexResult<bool> {
         // By convention the first array is the logical validity signal for the stat column.
-        self.arrays[0].all_invalid(&mut LEGACY_SESSION.create_execution_ctx())
+        self.arrays[0].all_invalid(&mut legacy_session().create_execution_ctx())
     }
 }

--- a/vortex-python/src/iter/mod.rs
+++ b/vortex-python/src/iter/mod.rs
@@ -20,12 +20,12 @@ use pyo3::prelude::*;
 use pyo3::types::PyIterator;
 use vortex::array::Canonical;
 use vortex::array::IntoArray;
-use vortex::array::LEGACY_SESSION;
 use vortex::array::VortexSessionExecute;
 use vortex::array::arrow::ArrowSessionExt;
 use vortex::array::iter::ArrayIterator;
 use vortex::array::iter::ArrayIteratorAdapter;
 use vortex::array::iter::ArrayIteratorExt;
+use vortex::array::legacy_session;
 use vortex::dtype::DType;
 
 use crate::arrays::PyArrayRef;
@@ -114,6 +114,7 @@ impl PyArrayIterator {
     /// Convert the :class:`vortex.ArrayIterator` into a :class:`pyarrow.RecordBatchReader`.
     ///
     /// Note that this performs the conversion on the current thread.
+    #[allow(clippy::disallowed_methods)]
     fn to_arrow(slf: Bound<Self>) -> PyVortexResult<Py<PyAny>> {
         let schema = Arc::new(slf.get().dtype().to_arrow_schema()?);
         let target = Field::new_struct("", schema.fields().clone(), false);
@@ -132,7 +133,7 @@ impl PyArrayIterator {
                     session().arrow().execute_arrow(
                         chunk?,
                         Some(&target),
-                        &mut LEGACY_SESSION.create_execution_ctx(),
+                        &mut legacy_session().create_execution_ctx(),
                     )
                 })
                 .map(|chunk| chunk.map_err(|e| ArrowError::ExternalError(Box::new(e))))


### PR DESCRIPTION
This changes LEGACY_SESSION top level lazy static into a method.

We also disallow this method from being used in the codebase and enshrine
existing call sites with exceptions

Signed-off-by: Robert Kruszewski <github@robertk.io>
