### PR TITLE
Decouple optional features from pulling `vortex-file` features for top crate

### DIFF
--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -72,7 +72,12 @@ default = ["files", "zstd"]
 files = ["dep:vortex-file"]
 memmap2 = ["vortex-buffer/memmap2"]
 object_store = ["vortex-file/object_store", "vortex-io/object_store"]
-tokio = ["vortex-file/tokio"]
+tokio = [
+    "vortex-error/tokio",
+    "vortex-file?/tokio",
+    "vortex-io/tokio",
+    "vortex-layout/tokio",
+]
 zstd = ["dep:vortex-zstd", "vortex-file/zstd"]
 pretty = ["vortex-array/table-display"]
 serde = ["vortex-array/serde", "vortex-buffer/serde", "vortex-mask/serde"]

--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -71,14 +71,14 @@ vortex-tensor = { workspace = true }
 default = ["files", "zstd"]
 files = ["dep:vortex-file"]
 memmap2 = ["vortex-buffer/memmap2"]
-object_store = ["vortex-file/object_store", "vortex-io/object_store"]
+object_store = ["vortex-file?/object_store", "vortex-io/object_store"]
 tokio = [
     "vortex-error/tokio",
     "vortex-file?/tokio",
     "vortex-io/tokio",
     "vortex-layout/tokio",
 ]
-zstd = ["dep:vortex-zstd", "vortex-file/zstd"]
+zstd = ["dep:vortex-zstd", "vortex-file?/zstd"]
 pretty = ["vortex-array/table-display"]
 serde = ["vortex-array/serde", "vortex-buffer/serde", "vortex-mask/serde"]
 # This feature enabled unstable encodings for which we don't guarantee stability.

--- a/vortex/examples/tracing_vortex.rs
+++ b/vortex/examples/tracing_vortex.rs
@@ -6,7 +6,7 @@
 //! This example demonstrates a real-world use case: implementing a `tracing` subscriber
 //! that writes all log events and spans to Vortex files.
 //!
-//! Run with: cargo run --example tracing_vortex --features tokio
+//! Run with: cargo run --example tracing_vortex --features files,tokio
 
 #![expect(
     clippy::disallowed_types,


### PR DESCRIPTION
## Rationale for this change

`vortex-files` pull a lot of encodings which makes it a very big dependency.
Some systems only need the core APIs, but enabling "tokio", "zstd" or "object-store" currently pulls in the full `vortex-file`.

## What changes are included in this PR?

Make the features of "vortex" use a weak link to "vortex-file", so it doesn't pull it in by default.

## What APIs are changed? Are there any user-facing changes?

Some feature configurations will require adjustment.
