### PR TITLE
Remove execute_boolean fallback to arrow

### DIFF
--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -153,7 +153,7 @@ fn between_canonical(
         upper.clone(),
         Operator::from(options.upper_strict.to_compare_operator()),
     )?;
-    execute_boolean(&lower_cmp, &upper_cmp, Operator::And, ctx)
+    execute_boolean(lower_cmp, upper_cmp, Operator::And, ctx)
 }
 
 /// An optimized scalar expression to compute whether values fall between two bounds.

--- a/vortex-array/src/scalar_fn/fns/binary/boolean.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/boolean.rs
@@ -26,8 +26,6 @@ use crate::arrays::ScalarFn;
 use crate::arrays::scalar_fn::ExactScalarFn;
 use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
-use crate::arrow::ArrowSessionExt;
-use crate::arrow::FromArrowArray;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;

--- a/vortex-array/src/scalar_fn/fns/binary/boolean.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/boolean.rs
@@ -3,7 +3,6 @@
 
 use std::iter::repeat_n;
 
-use arrow_array::cast::AsArray;
 use vortex_buffer::BitBuffer;
 use vortex_buffer::BufferMut;
 use vortex_buffer::read_u64_le;
@@ -142,39 +141,6 @@ pub(crate) fn execute_boolean(
         vortex_bail!("No boolean kernel for two BoolArrays");
     };
     Ok(result)
-}
-
-/// Arrow implementation for Kleene boolean operations using [`Operator`].
-fn arrow_execute_boolean(
-    lhs: ArrayRef,
-    rhs: ArrayRef,
-    op: Operator,
-    ctx: &mut ExecutionCtx,
-) -> VortexResult<ArrayRef> {
-    let nullable = boolean_nullability(&lhs, &rhs);
-    let session = ctx.session().clone();
-
-    let lhs = session
-        .arrow()
-        .execute_arrow(lhs, None, ctx)?
-        .as_boolean_opt()
-        .ok_or_else(|| vortex_err!("expected lhs to be boolean"))?
-        .clone();
-
-    let rhs = session
-        .arrow()
-        .execute_arrow(rhs, None, ctx)?
-        .as_boolean_opt()
-        .ok_or_else(|| vortex_err!("expected rhs to be boolean"))?
-        .clone();
-
-    let array = match op {
-        Operator::And => arrow_arith::boolean::and_kleene(&lhs, &rhs)?,
-        Operator::Or => arrow_arith::boolean::or_kleene(&lhs, &rhs)?,
-        other => vortex_bail!("Not a boolean operator: {other}"),
-    };
-
-    ArrayRef::from_arrow(&array, nullable == Nullability::Nullable)
 }
 
 /// Handles boolean operations where at least one operand is a constant array.

--- a/vortex-array/src/scalar_fn/fns/binary/boolean.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/boolean.rs
@@ -116,34 +116,32 @@ pub fn or_kleene(lhs: &ArrayRef, rhs: &ArrayRef) -> VortexResult<ArrayRef> {
 /// This is the entry point for boolean operations from the binary expression.
 /// Handles constants and canonical boolean arrays directly, otherwise falls back to Arrow.
 pub(crate) fn execute_boolean(
-    lhs: &ArrayRef,
-    rhs: &ArrayRef,
+    lhs: ArrayRef,
+    rhs: ArrayRef,
     op: Operator,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    let nullable = boolean_nullability(lhs, rhs);
+    let nullable = boolean_nullability(&lhs, &rhs);
 
     if lhs.is_empty() {
         return Ok(Canonical::empty(&DType::Bool(nullable)).into_array());
     }
 
-    if let Some(result) = constant_boolean(lhs, rhs, op)? {
+    if let Some(result) = constant_boolean(&lhs, &rhs, op)? {
         return Ok(result);
     }
 
-    if let Some(lhs) = lhs.as_opt::<Bool>()
-        && let Some(result) = <Bool as BooleanKernel>::boolean(lhs, rhs, op, ctx)?
-    {
+    let lhs = lhs.execute::<BoolArray>(ctx)?;
+    if let Some(result) = <Bool as BooleanKernel>::boolean(lhs.as_view(), &rhs, op, ctx)? {
         return Ok(result);
     }
 
-    if let Some(rhs) = rhs.as_opt::<Bool>()
-        && let Some(result) = <Bool as BooleanKernel>::boolean(rhs, lhs, op, ctx)?
-    {
-        return Ok(result);
-    }
-
-    arrow_execute_boolean(lhs.clone(), rhs.clone(), op, ctx)
+    let rhs = rhs.execute::<BoolArray>(ctx)?;
+    let Some(result) = <Bool as BooleanKernel>::boolean(rhs.as_view(), &lhs.into_array(), op, ctx)?
+    else {
+        vortex_bail!("No boolean kernel for two BoolArrays");
+    };
+    Ok(result)
 }
 
 /// Arrow implementation for Kleene boolean operations using [`Operator`].

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -3,10 +3,6 @@
 
 use std::fmt::Formatter;
 
-#[expect(deprecated)]
-pub use boolean::and_kleene;
-#[expect(deprecated)]
-pub use boolean::or_kleene;
 use prost::Message;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -155,8 +151,8 @@ impl ScalarFnVTable for Binary {
             Operator::Lte => execute_compare(&lhs, &rhs, CompareOperator::Lte, ctx),
             Operator::Gt => execute_compare(&lhs, &rhs, CompareOperator::Gt, ctx),
             Operator::Gte => execute_compare(&lhs, &rhs, CompareOperator::Gte, ctx),
-            Operator::And => execute_boolean(&lhs, &rhs, Operator::And, ctx),
-            Operator::Or => execute_boolean(&lhs, &rhs, Operator::Or, ctx),
+            Operator::And => execute_boolean(lhs, rhs, Operator::And, ctx),
+            Operator::Or => execute_boolean(lhs, rhs, Operator::Or, ctx),
             Operator::Add => execute_numeric(&lhs, &rhs, NumericOperator::Add, ctx),
             Operator::Sub => execute_numeric(&lhs, &rhs, NumericOperator::Sub, ctx),
             Operator::Mul => execute_numeric(&lhs, &rhs, NumericOperator::Mul, ctx),

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -3,6 +3,10 @@
 
 use std::fmt::Formatter;
 
+#[expect(deprecated)]
+pub use boolean::and_kleene;
+#[expect(deprecated)]
+pub use boolean::or_kleene;
 use prost::Message;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;


### PR DESCRIPTION
It's unclear why we left it, we implement the boolean logic on vortex boolean
arrays always
