### PR TITLE
Ungrouped aggregate function pushdown for duckdb

### DIFF
--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -27,13 +27,14 @@ const DEFAULT_DUCKDB_VERSION: &str = "1.5.3";
 
 const BUILD_ARTIFACTS: [&str; 3] = ["libduckdb.dylib", "libduckdb.so", "libduckdb_static.a"];
 
-const SOURCE_FILES: [&str; 9] = [
+const SOURCE_FILES: [&str; 10] = [
     "cpp/vortex_duckdb.cpp",
     "cpp/copy_function.cpp",
     "cpp/expr.cpp",
     "cpp/optimizer.cpp",
     "cpp/scalar_fn_pushdown.cpp",
     "cpp/cast_pushdown.cpp",
+    "cpp/aggregate_fn_pushdown.cpp",
     "cpp/table_filter.cpp",
     "cpp/table_function.cpp",
     "cpp/vector.cpp",

--- a/vortex-duckdb/cpp/aggregate_fn_pushdown.cpp
+++ b/vortex-duckdb/cpp/aggregate_fn_pushdown.cpp
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+#include "aggregate_fn_pushdown.hpp"
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/operator/logical_aggregate.hpp"
+#include "optimizer.hpp"
+#include "table_function.hpp"
+
+using enum LogicalOperatorType;
+
+LogicalOperatorPtr TryPushdownAggregateFunctions(ClientContext &context, LogicalOperatorPtr plan) {
+    Analyses analyses;
+    Projections projections;
+    FindGetsAndProjections(*plan, analyses, projections);
+    if (analyses.empty()) {
+        return plan;
+    }
+    return RewriteAggregates(context, std::move(plan), analyses, projections);
+}
+
+LogicalOperatorPtr RewriteAggregates(ClientContext &context,
+                                     LogicalOperatorPtr op,
+                                     Analyses &analyses,
+                                     const Projections &projections) {
+    for (auto &child : op->children) {
+        child = RewriteAggregates(context, std::move(child), analyses, projections);
+    }
+    if (op->type == LOGICAL_AGGREGATE_AND_GROUP_BY) {
+        return TryReplaceAggregate(context, std::move(op), analyses, projections);
+    }
+    return op;
+}
+
+static bool IsUngrouped(const LogicalAggregate &agg) {
+    return agg.groups.empty() && agg.grouping_sets.empty() && agg.grouping_functions.empty() &&
+           !agg.expressions.empty();
+}
+
+constexpr inline idx_t COUNT_STAR_PROJ_IDX = std::numeric_limits<TableColumnStorageIndex>::max();
+
+LogicalOperatorPtr TryReplaceAggregate(ClientContext &context,
+                                       LogicalOperatorPtr op,
+                                       Analyses &analyses,
+                                       const Projections &projections) {
+    LogicalAggregate &agg = op->Cast<LogicalAggregate>();
+    if (!IsUngrouped(agg)) {
+        return op;
+    }
+
+    LogicalGet *const get = GetChildGet(agg);
+    if (get == nullptr) {
+        return op;
+    }
+
+    vector<std::pair<TableColumnScanIndex, const Expression &>> input;
+    const idx_t aggregates_len = agg.expressions.size();
+    input.reserve(aggregates_len);
+
+    for (const auto &expr : agg.expressions) {
+        if (expr->GetExpressionClass() != ExpressionClass::BOUND_AGGREGATE) {
+            return op;
+        }
+        const auto &bound_aggr = expr->Cast<BoundAggregateExpression>();
+        if (bound_aggr.IsDistinct() || bound_aggr.filter != nullptr || bound_aggr.order_bys != nullptr) {
+            return op;
+        }
+
+        if (bound_aggr.function.name == "count_star") {
+            input.emplace_back(COUNT_STAR_PROJ_IDX, *expr);
+            continue;
+        }
+
+        if (bound_aggr.children.size() != 1 ||
+            bound_aggr.children[0]->GetExpressionType() != ExpressionType::BOUND_COLUMN_REF) {
+            return op;
+        }
+        const auto &bound_col = bound_aggr.children[0]->Cast<BoundColumnRefExpression>();
+        const auto binding = Resolve(bound_col.binding, analyses, projections);
+        if (!binding || &binding->analysis.get != get) {
+            return op;
+        }
+        input.emplace_back(binding->column_index, *expr);
+    }
+
+    if (!aggregate_pushdown(context, {*get, input})) {
+        return op;
+    }
+
+    // GET now returns one column per aggregate. Expand existing columns
+    auto &column_ids = get->GetMutableColumnIds();
+    get->types.resize(aggregates_len);
+    get->returned_types.resize(aggregates_len);
+    column_ids.resize(aggregates_len);
+
+    vector<string> names(aggregates_len); // need a copy because we reference original names
+
+    for (idx_t i = 0; i < aggregates_len; i++) {
+        const auto &[column_index, expr] = input[i];
+        if (column_index == COUNT_STAR_PROJ_IDX) {
+            names[i] = "count_star()";
+        } else {
+            const TableColumnStorageIndex storage_index = get->GetColumnIds()[column_index].GetPrimaryIndex();
+            names[i] = get->names[storage_index];
+        }
+        get->types[i] = expr.return_type;
+        get->returned_types[i] = expr.return_type;
+        column_ids[i] = ColumnIndex {i};
+    }
+    get->names = std::move(names);
+    get->projection_ids.clear();
+    get->table_index = agg.aggregate_index;
+
+    unique_ptr<LogicalOperator> &child = agg.children[0];
+    if (child->type == LOGICAL_GET) {
+        return std::move(child);
+    }
+    D_ASSERT(child->type == LOGICAL_PROJECTION);
+    D_ASSERT(child->children.size() == 1);
+    D_ASSERT(child->children[0]->type == LOGICAL_GET);
+    return std::move(child->children[0]);
+}
+
+LogicalGet *GetChildGet(const LogicalAggregate &agg) {
+    if (agg.children.size() != 1) {
+        return nullptr;
+    }
+    LogicalOperator &child = *agg.children[0];
+    LogicalOperator *op;
+    if (child.type == LOGICAL_GET) {
+        op = &child;
+    } else if (child.type == LOGICAL_PROJECTION && child.children.size() == 1 &&
+               child.children[0]->type == LOGICAL_GET) {
+        op = child.children[0].get();
+    } else {
+        return nullptr;
+    }
+    LogicalGet &get = op->Cast<LogicalGet>();
+    return get.function.bind == duckdb_vx_table_function_bind ? &get : nullptr;
+}

--- a/vortex-duckdb/cpp/expr.cpp
+++ b/vortex-duckdb/cpp/expr.cpp
@@ -3,11 +3,13 @@
 
 #include "expr.h"
 #include "duckdb/function/scalar_function.hpp"
+#include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/planner/expression/bound_between_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
@@ -81,6 +83,11 @@ extern "C" duckdb_state duckdb_vx_register_st_dwithin_override(duckdb_database f
     return DuckDBSuccess;
 }
 
+extern "C" const char *duckdb_vx_agg_func_name(duckdb_vx_agg_func ffi) {
+    D_ASSERT(ffi);
+    return reinterpret_cast<AggregateFunction *>(ffi)->name.c_str();
+}
+
 extern "C" const char *duckdb_vx_expr_to_string(duckdb_vx_expr ffi_expr) {
     if (!ffi_expr) {
         return nullptr;
@@ -92,7 +99,6 @@ extern "C" const char *duckdb_vx_expr_to_string(duckdb_vx_expr ffi_expr) {
     return result;
 }
 
-//! Create a DuckDB vortex error.
 extern "C" void duckdb_vx_destroy_expr(duckdb_vx_expr *ffi_expr) {
     auto expr = reinterpret_cast<Expression *>(ffi_expr);
     delete expr;
@@ -200,4 +206,10 @@ extern "C" bool duckdb_vx_expr_get_bound_cast_is_try(duckdb_vx_expr ffi_expr) {
     D_ASSERT(ffi_expr);
     auto &expr = reinterpret_cast<Expression *>(ffi_expr)->Cast<BoundCastExpression>();
     return expr.try_cast;
+}
+
+extern "C" duckdb_vx_agg_func duckdb_vx_expr_get_bound_aggregate_function(duckdb_vx_expr ffi_expr) {
+    D_ASSERT(ffi_expr);
+    auto &expr = reinterpret_cast<Expression *>(ffi_expr)->Cast<BoundAggregateExpression>();
+    return reinterpret_cast<duckdb_vx_agg_func>(&expr.function);
 }

--- a/vortex-duckdb/cpp/include/aggregate_fn_pushdown.hpp
+++ b/vortex-duckdb/cpp/include/aggregate_fn_pushdown.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+#pragma once
+#include "optimizer.hpp"
+#include "duckdb/optimizer/optimizer_extension.hpp"
+
+using namespace duckdb;
+
+// Push UNGROUPED_AGGREGATE's of form agg(T) and count_star() into GET.
+LogicalOperatorPtr TryPushdownAggregateFunctions(ClientContext &context, LogicalOperatorPtr plan);
+
+LogicalOperatorPtr RewriteAggregates(ClientContext &context,
+                                     LogicalOperatorPtr op,
+                                     Analyses &analyses,
+                                     const Projections &projections);
+
+LogicalOperatorPtr TryReplaceAggregate(ClientContext &context,
+                                       LogicalOperatorPtr op,
+                                       Analyses &analyses,
+                                       const Projections &projections);
+
+// return GET for UNGROUPED_AGGREGATE -> [GET] or for UNGROUPED_AGGREGATE ->
+// PROJECTION -> [GET], nullptr if not found.
+LogicalGet *GetChildGet(const LogicalAggregate &agg);

--- a/vortex-duckdb/cpp/include/expr.h
+++ b/vortex-duckdb/cpp/include/expr.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 
 typedef struct duckdb_vx_sfunc_ *duckdb_vx_sfunc;
+typedef struct duckdb_vx_agg_func_ *duckdb_vx_agg_func;
 
 const char *duckdb_vx_sfunc_name(duckdb_vx_sfunc ffi_func);
 
@@ -19,6 +20,8 @@ const char *duckdb_vx_sfunc_name(duckdb_vx_sfunc ffi_func);
 duckdb_state duckdb_vx_register_st_dwithin_override(duckdb_database ffi_db);
 
 typedef struct duckdb_vx_expr_ *duckdb_vx_expr;
+
+const char *duckdb_vx_agg_func_name(duckdb_vx_agg_func func);
 
 /// Return the string representation of the expression. Must be freed with `duckdb_free`.
 const char *duckdb_vx_expr_to_string(duckdb_vx_expr expr);
@@ -272,6 +275,8 @@ void duckdb_vx_expr_get_bound_function(duckdb_vx_expr expr, duckdb_vx_expr_bound
 duckdb_vx_expr duckdb_vx_expr_get_bound_cast_child(duckdb_vx_expr expr);
 
 bool duckdb_vx_expr_get_bound_cast_is_try(duckdb_vx_expr expr);
+
+duckdb_vx_agg_func duckdb_vx_expr_get_bound_aggregate_function(duckdb_vx_expr expr);
 
 #ifdef __cplusplus /* End C ABI */
 }

--- a/vortex-duckdb/cpp/include/table_function.h
+++ b/vortex-duckdb/cpp/include/table_function.h
@@ -88,6 +88,10 @@ typedef struct {
 
 duckdb_state duckdb_vx_register_table_functions(duckdb_database ffi_db);
 
+typedef struct duckdb_vx_agg_input_ *duckdb_vx_agg_input;
+idx_t duckdb_vx_aggregate_len(duckdb_vx_agg_input ffi);
+duckdb_vx_expr duckdb_vx_aggregate_at(duckdb_vx_agg_input ffi, idx_t index, idx_t *proj_idx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/vortex-duckdb/cpp/include/table_function.hpp
+++ b/vortex-duckdb/cpp/include/table_function.hpp
@@ -25,3 +25,11 @@ struct TableFunctionProjectionExpressionInput {
 // true if we can push down the expression, false otherwise
 bool projection_expression_pushdown(duckdb::ClientContext &context,
                                     const TableFunctionProjectionExpressionInput &input);
+
+struct TableFunctionUngroupedAggregateInput {
+    const duckdb::LogicalGet &get;
+    // Column scan index -> aggregate expression
+    const duckdb::vector<std::pair<idx_t, const duckdb::Expression &>> &projections;
+};
+
+bool aggregate_pushdown(duckdb::ClientContext &context, const TableFunctionUngroupedAggregateInput &input);

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -4,6 +4,7 @@
 #include "data.hpp"
 #include "error.hpp"
 #include "table_function.hpp"
+#include "expr.h"
 #include "vortex_duckdb.h"
 #include "table_function.h"
 #include "vortex.h"
@@ -171,12 +172,16 @@ struct CTableBindResult {
     vector<string> &names;
 };
 
+// This is a flaw of Duckdb API which doesn't allow passing non-const
+// expressions. We never modify the value on Rust side.
+static duckdb_vx_expr get_ffi_expr(const Expression &expr) {
+    return reinterpret_cast<duckdb_vx_expr>(const_cast<Expression *>(&expr));
+}
+
 bool projection_expression_pushdown(ClientContext &, const TableFunctionProjectionExpressionInput &input) {
     const auto &bind = input.get.bind_data->Cast<CTableBindData>();
 
-    // This is a flaw of Duckdb API which doesn't allow passing non-const
-    // expressions. We never modify the value on Rust side.
-    auto ffi_expr = reinterpret_cast<duckdb_vx_expr>(const_cast<Expression *>(&input.expression));
+    duckdb_vx_expr ffi_expr = get_ffi_expr(input.expression);
     void *const ffi_bind = bind.ffi_data->DataPtr();
     duckdb_vx_error error_out = nullptr;
 
@@ -189,6 +194,33 @@ bool projection_expression_pushdown(ClientContext &, const TableFunctionProjecti
         throw BinderException(IntoErrString(error_out));
     }
     return ret;
+}
+
+extern "C" {
+idx_t duckdb_vx_aggregate_len(duckdb_vx_agg_input ffi_input) {
+    return reinterpret_cast<const TableFunctionUngroupedAggregateInput *>(ffi_input)->projections.size();
+}
+
+duckdb_vx_expr duckdb_vx_aggregate_at(duckdb_vx_agg_input ffi_input, idx_t i, idx_t *proj_idx) {
+    const auto &input = *reinterpret_cast<const TableFunctionUngroupedAggregateInput *>(ffi_input);
+    const auto &[scan_index, expr] = input.projections[i];
+    *proj_idx = scan_index == COUNT_STAR_PROJ_IDX ? scan_index
+                                                  : input.get.GetColumnIds()[scan_index].GetPrimaryIndex();
+    return get_ffi_expr(expr);
+}
+}
+
+bool aggregate_pushdown(ClientContext &, const TableFunctionUngroupedAggregateInput &input) {
+    const auto &bind = input.get.bind_data->Cast<CTableBindData>();
+    void *const ffi_bind = bind.ffi_data->DataPtr();
+    duckdb_vx_error error_out = nullptr;
+    const auto ffi_input =
+        reinterpret_cast<duckdb_vx_agg_input>(const_cast<TableFunctionUngroupedAggregateInput *>(&input));
+    const bool res = duckdb_table_function_pushdown_projection_aggregates(ffi_bind, ffi_input, &error_out);
+    if (error_out) {
+        throw BinderException(IntoErrString(error_out));
+    }
+    return res;
 }
 
 /**
@@ -238,10 +270,11 @@ unique_ptr<GlobalTableFunctionState> c_init_global(ClientContext &context, Table
 }
 
 unique_ptr<LocalTableFunctionState>
-init_local(ExecutionContext &, TableFunctionInitInput &, GlobalTableFunctionState *global_state) {
+init_local(ExecutionContext &, TableFunctionInitInput &input, GlobalTableFunctionState *global_state) {
+    const void *const ffi_bind = input.bind_data->Cast<CTableBindData>().ffi_data->DataPtr();
     void *const ffi_global = global_state->Cast<CTableGlobalData>().ffi_data->DataPtr();
 
-    duckdb_vx_data ffi_local_data = duckdb_table_function_init_local(ffi_global);
+    duckdb_vx_data ffi_local_data = duckdb_table_function_init_local(ffi_bind, ffi_global);
     auto cdata = unique_ptr<CData>(reinterpret_cast<CData *>(ffi_local_data));
     return make_uniq<CTableLocalData>(std::move(cdata));
 }

--- a/vortex-duckdb/cpp/vortex_duckdb.cpp
+++ b/vortex-duckdb/cpp/vortex_duckdb.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#include "aggregate_fn_pushdown.hpp"
 #include "data.hpp"
 #include "error.hpp"
 #include "scalar_fn_pushdown.hpp"
@@ -271,6 +272,7 @@ extern "C" duckdb_blob duckdb_vx_value_get_geometry(duckdb_value value) {
 static void VortexOptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
     plan = TryPushdown<CastCollect, CastReplace>(input.context, std::move(plan));
     plan = TryPushdown<ScalarFnCollect, ScalarFnReplace>(input.context, std::move(plan));
+    plan = TryPushdownAggregateFunctions(input.context, std::move(plan));
 }
 
 static void VortexPreOptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {

--- a/vortex-duckdb/include/vortex.h
+++ b/vortex-duckdb/include/vortex.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#define COUNT_STAR_PROJ_IDX UINT64_MAX
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -41,6 +43,11 @@ bool duckdb_table_function_pushdown_projection_expression(void *bind_data,
                                                           duckdb_vx_error *error_out);
 
 extern
+bool duckdb_table_function_pushdown_projection_aggregates(void *bind_data,
+                                                          duckdb_vx_agg_input input,
+                                                          duckdb_vx_error *error_out);
+
+extern
 void duckdb_table_function_scan(void *global_init_data,
                                 void *local_init_data,
                                 duckdb_data_chunk output,
@@ -56,7 +63,9 @@ extern
 duckdb_vx_data duckdb_table_function_init_global(const duckdb_vx_tfunc_init_input *init_input,
                                                  duckdb_vx_error *error_out);
 
-extern duckdb_vx_data duckdb_table_function_init_local(void *global_init_data);
+extern
+duckdb_vx_data duckdb_table_function_init_local(const void *bind_data,
+                                                void *global_init_data);
 
 extern
 duckdb_vx_data duckdb_table_function_bind(duckdb_vx_tfunc_bind_input bind_input,

--- a/vortex-duckdb/src/convert/expr.rs
+++ b/vortex-duckdb/src/convert/expr.rs
@@ -1,9 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::fmt::Result;
 use std::sync::Arc;
 
 use tracing::debug;
+use vortex::aggregate_fn::Accumulator;
+use vortex::aggregate_fn::DynAccumulator;
+use vortex::aggregate_fn::EmptyOptions as AggregateEmptyOptions;
+use vortex::aggregate_fn::NumericalAggregateOpts;
+use vortex::aggregate_fn::combined::PairOptions;
+use vortex::aggregate_fn::fns::count::Count;
+use vortex::aggregate_fn::fns::first::First;
+use vortex::aggregate_fn::fns::max::Max;
+use vortex::aggregate_fn::fns::mean::Mean;
+use vortex::aggregate_fn::fns::min::Min;
+use vortex::aggregate_fn::fns::sum::Sum;
 use vortex::dtype::DType;
 use vortex::dtype::Nullability;
 use vortex::dtype::PType;
@@ -28,7 +42,7 @@ use vortex::expr::not;
 use vortex::expr::or_collect;
 use vortex::expr::root;
 use vortex::scalar::Scalar;
-use vortex::scalar_fn::EmptyOptions;
+use vortex::scalar_fn::EmptyOptions as ScalarEmptyOptions;
 use vortex::scalar_fn::ScalarFnVTableExt;
 use vortex::scalar_fn::fns::between::Between;
 use vortex::scalar_fn::fns::between::BetweenOptions;
@@ -180,7 +194,7 @@ fn try_from_geo_function(
             let Some(distance) = from_bound_f64(children[2])? else {
                 return Ok(None);
             };
-            let geo_distance = GeoDistance.new_expr(EmptyOptions, [a, b]);
+            let geo_distance = GeoDistance.new_expr(ScalarEmptyOptions, [a, b]);
             Binary.new_expr(Operator::Lte, [geo_distance, lit(distance)])
         }
         "st_distance" => {
@@ -193,7 +207,7 @@ fn try_from_geo_function(
             let Some(b) = geo_operand(children[1], ctx)? else {
                 return Ok(None);
             };
-            GeoDistance.new_expr(EmptyOptions, [a, b])
+            GeoDistance.new_expr(ScalarEmptyOptions, [a, b])
         }
         _ => return Ok(None),
     };
@@ -410,6 +424,7 @@ pub fn can_push_expression(value: &duckdb::ExpressionRef) -> bool {
             }
             op.children().all(can_push_expression)
         }
+        ExpressionClass::BoundAggregate(_) => false,
     }
 }
 
@@ -461,6 +476,71 @@ pub fn try_from_projection_expression(
         }
         _ => None,
     })
+}
+
+/// Aggregations we have pushed down in Vortex
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PushedAggregate {
+    Min,
+    Max,
+    Sum,
+    Mean,
+    // Also used for ANY_VALUE() which is allowed by definition
+    First,
+    // Valid values in column
+    Count,
+}
+
+impl Display for PushedAggregate {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            PushedAggregate::Min => f.write_str("min"),
+            PushedAggregate::Max => f.write_str("max"),
+            PushedAggregate::Sum => f.write_str("sum"),
+            PushedAggregate::Mean => f.write_str("mean"),
+            PushedAggregate::First => f.write_str("first"),
+            PushedAggregate::Count => f.write_str("count"),
+        }
+    }
+}
+
+impl PushedAggregate {
+    pub fn build(self, dtype: DType) -> VortexResult<Box<dyn DynAccumulator>> {
+        let opts = NumericalAggregateOpts::default();
+        Ok(match self {
+            Self::Min => Box::new(Accumulator::try_new(Min, opts, dtype)?),
+            Self::Max => Box::new(Accumulator::try_new(Max, opts, dtype)?),
+            Self::Sum => Box::new(Accumulator::try_new(Sum, opts, dtype)?),
+            Self::Mean => Box::new(Accumulator::try_new(
+                Mean::combined(),
+                PairOptions(opts, opts),
+                dtype,
+            )?),
+            Self::First => Box::new(Accumulator::try_new(First, AggregateEmptyOptions, dtype)?),
+            Self::Count => Box::new(Accumulator::try_new(Count, opts, dtype)?),
+        })
+    }
+}
+
+/// Check if this is an aggregate function we can handle in Vortex
+pub fn try_from_projection_aggregate(
+    expr: &duckdb::ExpressionRef,
+) -> VortexResult<Option<PushedAggregate>> {
+    let Some(expr) = expr.as_class() else {
+        return Ok(None);
+    };
+    let ExpressionClass::BoundAggregate(agg) = expr else {
+        return Ok(None);
+    };
+    Ok(Some(match agg.aggregate_function.name() {
+        "min" => PushedAggregate::Min,
+        "max" => PushedAggregate::Max,
+        "sum" | "sum_no_overflow" => PushedAggregate::Sum,
+        "avg" | "mean" => PushedAggregate::Mean,
+        "first" | "any_value" => PushedAggregate::First,
+        "count" => PushedAggregate::Count,
+        _ => return Ok(None),
+    }))
 }
 
 // If you want to add support for other expressions, also change
@@ -585,6 +665,7 @@ fn try_from_expression_inner(
                 _ => vortex_bail!("unexpected operator {:?} in bound conjunction", conj.op),
             }
         }
+        ExpressionClass::BoundAggregate(_) => return Ok(None),
     }))
 }
 

--- a/vortex-duckdb/src/convert/mod.rs
+++ b/vortex-duckdb/src/convert/mod.rs
@@ -8,8 +8,10 @@ mod table_filter;
 mod vector;
 
 pub use dtype::FromLogicalType;
+pub use expr::PushedAggregate;
 pub use expr::can_push_expression;
 pub use expr::try_from_bound_expression;
+pub use expr::try_from_projection_aggregate;
 pub use expr::try_from_projection_expression;
 pub use scalar::*;
 pub use table_filter::try_from_table_filter;

--- a/vortex-duckdb/src/duckdb/aggregate_pushdown.rs
+++ b/vortex-duckdb/src/duckdb/aggregate_pushdown.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use num_traits::AsPrimitive;
+
+use crate::cpp;
+use crate::duckdb::Expression;
+use crate::duckdb::ExpressionRef;
+use crate::lifetime_wrapper;
+
+lifetime_wrapper!(
+    /// Aggregates we want to push at Vortex at once
+    AggregatePushdownInput,
+    cpp::duckdb_vx_agg_input, |_| {});
+
+pub struct AggregateExpression<'a> {
+    pub expr: &'a ExpressionRef,
+    /// Output column projection id after the pass has expanded columns with
+    /// multiple aggregations per column
+    pub projection_id: u64,
+}
+
+impl AggregatePushdownInputRef {
+    pub fn len(&self) -> usize {
+        unsafe { cpp::duckdb_vx_aggregate_len(self.as_ptr()) }.as_()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn get(&'_ self, index: usize) -> AggregateExpression<'_> {
+        let mut projection_id = 0u64;
+        let expr = unsafe {
+            cpp::duckdb_vx_aggregate_at(self.as_ptr(), index as u64, &raw mut projection_id)
+        };
+        let expr = unsafe { Expression::borrow(expr) };
+        AggregateExpression {
+            expr,
+            projection_id,
+        }
+    }
+}

--- a/vortex-duckdb/src/duckdb/expr.rs
+++ b/vortex-duckdb/src/duckdb/expr.rs
@@ -2,13 +2,14 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::ffi::CStr;
-use std::ffi::c_void;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::ptr;
 
 use crate::cpp;
 use crate::cpp::duckdb_vx_expr_class;
+use crate::duckdb::AggregateFunction;
+use crate::duckdb::AggregateFunctionRef;
 use crate::duckdb::DDBString;
 use crate::duckdb::LogicalType;
 use crate::duckdb::LogicalTypeRef;
@@ -151,8 +152,14 @@ impl ExpressionRef {
                     ExpressionClass::BoundFunction(BoundFunction {
                         children,
                         scalar_function: unsafe { ScalarFunction::borrow(out.scalar_function) },
-                        bind_info: out.bind_info,
                     })
+                }
+                cpp::DUCKDB_VX_EXPR_CLASS::DUCKDB_VX_EXPR_CLASS_BOUND_AGGREGATE => {
+                    let aggregate_function = unsafe {
+                        let ptr = cpp::duckdb_vx_expr_get_bound_aggregate_function(self.as_ptr());
+                        AggregateFunction::borrow(ptr)
+                    };
+                    ExpressionClass::BoundAggregate(BoundAggregate { aggregate_function })
                 }
                 cpp::DUCKDB_VX_EXPR_CLASS::DUCKDB_VX_EXPR_CLASS_BOUND_REF => {
                     ExpressionClass::BoundRef
@@ -174,6 +181,7 @@ pub enum ExpressionClass<'a> {
     BoundOperator(BoundOperator<'a>),
     BoundFunction(BoundFunction<'a>),
     BoundCast(BoundCast<'a>),
+    BoundAggregate(BoundAggregate<'a>),
     /// Column inside ExpressionFilter for expression pushed down to Vortex.
     BoundRef,
 }
@@ -185,6 +193,10 @@ pub struct BoundCast<'a> {
 
 pub struct BoundColumnRef {
     pub name: DDBString,
+}
+
+pub struct BoundAggregate<'a> {
+    pub aggregate_function: &'a AggregateFunctionRef,
 }
 
 pub struct BoundConstant<'a> {
@@ -236,7 +248,6 @@ impl<'a> BoundOperator<'a> {
 pub struct BoundFunction<'a> {
     children: &'a [cpp::duckdb_vx_expr],
     pub scalar_function: &'a ScalarFunctionRef,
-    pub bind_info: *const c_void,
 }
 
 impl<'a> BoundFunction<'a> {

--- a/vortex-duckdb/src/duckdb/function.rs
+++ b/vortex-duckdb/src/duckdb/function.rs
@@ -8,6 +8,7 @@ use crate::cpp;
 use crate::lifetime_wrapper;
 
 lifetime_wrapper!(ScalarFunction, cpp::duckdb_vx_sfunc, |_| {});
+lifetime_wrapper!(AggregateFunction, cpp::duckdb_vx_agg_func, |_| {});
 
 impl ScalarFunctionRef {
     pub fn name(&self) -> &str {
@@ -17,6 +18,18 @@ impl ScalarFunctionRef {
                 .to_str()
                 .map_err(|e| vortex_err!("invalid utf-8: {e}"))
                 .vortex_expect("scalar function name should be valid UTF-8")
+        }
+    }
+}
+
+impl AggregateFunctionRef {
+    pub fn name(&self) -> &str {
+        unsafe {
+            let name_ptr = cpp::duckdb_vx_agg_func_name(self.as_ptr());
+            std::ffi::CStr::from_ptr(name_ptr)
+                .to_str()
+                .map_err(|e| vortex_err!("invalid utf-8: {e}"))
+                .vortex_expect("aggregate function name should be valid UTF-8")
         }
     }
 }

--- a/vortex-duckdb/src/duckdb/mod.rs
+++ b/vortex-duckdb/src/duckdb/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+mod aggregate_pushdown;
 mod bind_input;
 mod connection;
 mod data;
@@ -8,11 +9,11 @@ mod data_chunk;
 mod database;
 mod ddb_string;
 mod expr;
+mod function;
 mod logical_type;
 mod macro_;
 mod query_result;
 mod reusable_dict;
-mod scalar_function;
 mod selection_vector;
 mod string_map;
 mod table_filter;
@@ -24,6 +25,7 @@ mod vector_buffer;
 use std::ffi::c_void;
 use std::ptr;
 
+pub use aggregate_pushdown::*;
 pub use bind_input::*;
 pub use connection::*;
 pub use data::*;
@@ -31,10 +33,10 @@ pub use data_chunk::*;
 pub use database::*;
 pub use ddb_string::*;
 pub use expr::*;
+pub use function::*;
 pub use logical_type::*;
 pub use query_result::*;
 pub use reusable_dict::*;
-pub use scalar_function::*;
 pub use selection_vector::*;
 pub use string_map::*;
 pub use table_filter::*;

--- a/vortex-duckdb/src/ffi.rs
+++ b/vortex-duckdb/src/ffi.rs
@@ -17,6 +17,7 @@ use crate::copy::copy_to_finalize;
 use crate::copy::copy_to_initialize_global;
 use crate::copy::copy_to_sink;
 use crate::cpp;
+use crate::duckdb::AggregatePushdownInput;
 use crate::duckdb::BindInput;
 use crate::duckdb::BindResult;
 use crate::duckdb::Data;
@@ -38,6 +39,7 @@ use crate::table_function::get_partition_data;
 use crate::table_function::init_global;
 use crate::table_function::init_local;
 use crate::table_function::pushdown_complex_filter;
+use crate::table_function::pushdown_projection_aggregates;
 use crate::table_function::pushdown_projection_expression;
 use crate::table_function::scan;
 use crate::table_function::statistics;
@@ -127,6 +129,20 @@ unsafe extern "C-unwind" fn duckdb_table_function_pushdown_projection_expression
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn duckdb_table_function_pushdown_projection_aggregates(
+    bind_data: *mut c_void,
+    input: cpp::duckdb_vx_agg_input,
+    error_out: *mut cpp::duckdb_vx_error,
+) -> bool {
+    let bind_data = unsafe { bind_data.cast::<TableFunctionBind>().as_mut() }
+        .vortex_expect("bind_data null pointer");
+    let input = unsafe { AggregatePushdownInput::borrow(input) };
+    try_or(error_out, || {
+        pushdown_projection_aggregates(bind_data, input)
+    })
+}
+
+#[unsafe(no_mangle)]
 unsafe extern "C-unwind" fn duckdb_table_function_scan(
     global_init_data: *mut c_void,
     local_init_data: *mut c_void,
@@ -207,12 +223,15 @@ pub unsafe extern "C-unwind" fn duckdb_table_function_init_global(
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn duckdb_table_function_init_local(
+    bind_data: *const c_void,
     global_init_data: *mut c_void,
 ) -> cpp::duckdb_vx_data {
+    let bind_data = unsafe { bind_data.cast::<TableFunctionBind>().as_ref() }
+        .vortex_expect("bind_data null pointer");
     let global_init_data = unsafe { global_init_data.cast::<TableFunctionGlobal>().as_ref() }
         .vortex_expect("global_init_data null pointer");
 
-    let init_data = init_local(global_init_data);
+    let init_data = init_local(bind_data, global_init_data);
     Data::from(Box::new(init_data)).as_ptr()
 }
 

--- a/vortex-duckdb/src/projection.rs
+++ b/vortex-duckdb/src/projection.rs
@@ -17,12 +17,14 @@ use vortex::expr::root;
 use vortex::expr::select;
 use vortex::layout::layouts::row_idx::row_idx;
 use vortex::scan::selection::Selection;
+use vortex_utils::aliases::hash_set::HashSet;
 
 use crate::convert::try_from_table_filter;
 use crate::convert::try_from_virtual_column_filter;
 use crate::duckdb::LogicalType;
 use crate::duckdb::TableFilterClass;
 use crate::duckdb::TableFilterSetRef;
+use crate::table_function::ColumnAggregate;
 
 // See MultiFileReader for constants
 
@@ -185,6 +187,28 @@ impl Projection {
             projection,
             file_index_column_pos,
             file_row_number_column_pos,
+        }
+    }
+
+    // Create a projection for aggregate scan
+    pub fn new_aggregate(aggregates: &[ColumnAggregate], fields: &[DuckdbField]) -> Self {
+        let mut names = Vec::with_capacity(aggregates.len());
+        let mut seen: HashSet<u64> = HashSet::with_capacity(aggregates.len());
+        for aggregate in aggregates {
+            let ColumnAggregate::Real { projection_id, .. } = aggregate else {
+                continue;
+            };
+            if seen.contains(projection_id) {
+                continue;
+            }
+            seen.insert(*projection_id);
+            let projection_id: usize = projection_id.as_();
+            names.push(fields[projection_id].name.as_str());
+        }
+        Projection {
+            projection: select(names, root()),
+            file_index_column_pos: None,
+            file_row_number_column_pos: None,
         }
     }
 }

--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -19,15 +19,19 @@ use futures::StreamExt;
 use futures::future::BoxFuture;
 use itertools::Itertools;
 use num_traits::AsPrimitive;
+use parking_lot::Mutex;
 use static_assertions::assert_impl_all;
 use tracing::debug;
+use vortex::aggregate_fn::DynAccumulator;
 use vortex::array::ArrayRef;
 use vortex::array::Canonical;
+use vortex::array::ExecutionCtx;
 use vortex::array::VortexSessionExecute as _;
 use vortex::array::arrays::ScalarFn;
 use vortex::array::arrays::Struct;
 use vortex::array::arrays::StructArray;
 use vortex::array::arrays::scalar_fn::ScalarFnArrayExt;
+use vortex::array::arrays::struct_::StructArrayExt;
 use vortex::array::optimizer::ArrayOptimizer;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
@@ -45,14 +49,19 @@ use vortex::scalar_fn::fns::operators::Operator;
 use vortex::scalar_fn::fns::pack::Pack;
 use vortex::scan::DataSource;
 use vortex::scan::ScanRequest;
+use vortex_utils::aliases::hash_map::HashMap;
 use vortex_utils::parallelism::get_available_parallelism;
 
 use crate::RUNTIME;
 use crate::SESSION;
 use crate::column_statistics::ColumnStatistics;
 use crate::column_statistics::ColumnStatisticsAggregate;
+use crate::convert::PushedAggregate;
 use crate::convert::try_from_bound_expression;
+use crate::convert::try_from_projection_aggregate;
 use crate::convert::try_from_projection_expression;
+use crate::duckdb::AggregateExpression;
+use crate::duckdb::AggregatePushdownInputRef;
 use crate::duckdb::BindInputRef;
 use crate::duckdb::BindResultRef;
 use crate::duckdb::DataChunkRef;
@@ -68,6 +77,9 @@ use crate::projection::Filter;
 use crate::projection::Projection;
 use crate::projection::extract_schema_from_dtype;
 
+// Aggregate projection index for count(*). See cpp/aggregate_fn_pushdown.cpp
+pub const COUNT_STAR_PROJ_IDX: u64 = u64::MAX;
+
 pub struct TableFunctionBind {
     data_source: Arc<MultiLayoutDataSource>,
     filter_exprs: Vec<Expression>,
@@ -75,6 +87,8 @@ pub struct TableFunctionBind {
     // There exists at least one non-optional table filter or at least one
     // complex filter is pushed down.
     has_non_optional_filter: AtomicBool,
+    // Non-empty iff this scan is aggregate
+    aggregates: Vec<ColumnAggregate>,
 }
 assert_impl_all!(TableFunctionBind: Send, Clone);
 
@@ -88,6 +102,7 @@ impl Clone for TableFunctionBind {
             has_non_optional_filter: AtomicBool::new(
                 self.has_non_optional_filter.load(Ordering::Relaxed),
             ),
+            aggregates: self.aggregates.clone(),
         }
     }
 }
@@ -124,6 +139,16 @@ pub struct TableFunctionGlobal {
     bytes_read: AtomicU64,
     file_index_column_pos: Option<usize>,
     file_row_number_column_pos: Option<usize>,
+
+    // Following 4 fields are used only in aggregate scans.
+    /// ArrayRef's scanned but not aggregated in "partials".
+    /// 0 means all arrays have been aggregated but output is not written.
+    /// u64::MAX means arrays have been aggregated and we've written output row
+    pending: Arc<AtomicU64>,
+    aggregates: Vec<ColumnAggregate>,
+    // Accumulated partials
+    partials: Mutex<Vec<Box<dyn DynAccumulator>>>,
+    row_count: AtomicU64,
 }
 assert_impl_all!(TableFunctionGlobal: Send, Sync);
 
@@ -133,12 +158,23 @@ pub struct TableFunctionLocal {
     exporter: Option<ArrayExporter>,
     partition_index: u64,
     file_index: usize,
+    // Aggregate scan accumulated partials. Empty for non-aggregate scan
+    partials: Vec<Box<dyn DynAccumulator>>,
 }
 
 pub struct PartitionData {
     pub partition_index: u64,
     pub file_index_column_pos: Option<usize>,
     pub file_index: usize,
+}
+
+#[derive(Clone)]
+pub(crate) enum ColumnAggregate {
+    Real {
+        projection_id: u64,
+        aggregate: PushedAggregate,
+    },
+    CountStar,
 }
 
 #[derive(Debug)]
@@ -162,6 +198,7 @@ pub fn bind(input: &BindInputRef, result: &mut BindResultRef) -> VortexResult<Ta
         filter_exprs: vec![],
         column_fields,
         has_non_optional_filter: AtomicBool::new(false),
+        aggregates: vec![],
     })
 }
 
@@ -176,7 +213,11 @@ pub fn init_global(init_input: &TableInitInput) -> VortexResult<TableFunctionGlo
         projection,
         file_index_column_pos,
         file_row_number_column_pos,
-    } = Projection::new(projection_ids, column_ids, &bind_data.column_fields);
+    } = if bind_data.aggregates.is_empty() {
+        Projection::new(projection_ids, column_ids, &bind_data.column_fields)
+    } else {
+        Projection::new_aggregate(&bind_data.aggregates, &bind_data.column_fields)
+    };
 
     let Filter {
         filter,
@@ -231,6 +272,9 @@ pub fn init_global(init_input: &TableInitInput) -> VortexResult<TableFunctionGlo
     // available array chunk regardless of which partition it came from.
     let (tx, rx) = kanal::bounded_async(num_workers * 2);
 
+    let pending = Arc::new(AtomicU64::new(0));
+    let pending_producer = Arc::clone(&pending);
+
     // We drive one partition per worker thread. Each partition is driven as a spawned task
     // that pushes array chunks into the shared channel as they are produced. This spawning
     // allows all worker threads to drive the polling of all partitions, and then return the
@@ -239,6 +283,7 @@ pub fn init_global(init_input: &TableInitInput) -> VortexResult<TableFunctionGlo
         .partitions()
         .map(move |partition| {
             let tx = tx.clone();
+            let pending = Arc::clone(&pending_producer);
             RUNTIME.handle().spawn(async move {
                 let partition = match partition {
                     Ok(partition) => partition,
@@ -261,6 +306,7 @@ pub fn init_global(init_input: &TableInitInput) -> VortexResult<TableFunctionGlo
                     }
                 };
                 while let Some(item) = stream.next().await {
+                    pending.fetch_add(1, Ordering::Relaxed);
                     if tx
                         .send(item.map(|a| (a, Arc::clone(&cache))))
                         .await
@@ -277,6 +323,9 @@ pub fn init_global(init_input: &TableInitInput) -> VortexResult<TableFunctionGlo
 
     let iterator = RUNTIME.block_on_stream_thread_safe(|_handle| scan_driver_stream(stream, rx));
 
+    let aggregates = bind_data.aggregates.clone();
+    let partials = build_partials(&aggregates, &bind_data.column_fields)?;
+
     Ok(TableFunctionGlobal {
         iterator,
         batch_id: AtomicU64::new(0),
@@ -284,6 +333,10 @@ pub fn init_global(init_input: &TableInitInput) -> VortexResult<TableFunctionGlo
         bytes_read: AtomicU64::new(0),
         file_index_column_pos,
         file_row_number_column_pos,
+        pending,
+        aggregates,
+        partials: Mutex::new(partials),
+        row_count: AtomicU64::new(0),
     })
 }
 
@@ -320,7 +373,29 @@ impl Stream for ScanDriverStream {
     }
 }
 
-pub fn init_local(global: &TableFunctionGlobal) -> TableFunctionLocal {
+fn build_partials(
+    aggregates: &[ColumnAggregate],
+    fields: &[DuckdbField],
+) -> VortexResult<Vec<Box<dyn DynAccumulator>>> {
+    aggregates
+        .iter()
+        .filter_map(|spec| match spec {
+            ColumnAggregate::Real {
+                projection_id,
+                aggregate,
+            } => {
+                let projection_id: usize = projection_id.as_();
+                Some(aggregate.build(fields[projection_id].dtype.clone()))
+            }
+            ColumnAggregate::CountStar => None,
+        })
+        .collect()
+}
+
+pub fn init_local(
+    bind_data: &TableFunctionBind,
+    global: &TableFunctionGlobal,
+) -> TableFunctionLocal {
     unsafe {
         use custom_labels::sys;
 
@@ -336,11 +411,109 @@ pub fn init_local(global: &TableFunctionGlobal) -> TableFunctionLocal {
         CURRENT_LABELSET.set(key, value);
     }
 
+    let partials = build_partials(&global.aggregates, &bind_data.column_fields)
+        // if aggregate initialization produced an error, it would error in
+        // init_global, see "partials" initialization there
+        .vortex_expect("local state aggregate initialization failed");
+
     TableFunctionLocal {
         iterator: global.iterator.clone(),
         exporter: None,
         partition_index: 0,
         file_index: 0,
+        partials,
+    }
+}
+
+fn convert_result(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<StructArray> {
+    let array_result = array.optimize_recursive(ctx.session())?;
+    Ok(if let Some(array) = array_result.as_opt::<Struct>() {
+        array.into_owned()
+    } else if let Some(array) = array_result.as_opt::<ScalarFn>()
+        && let Some(pack_options) = array.scalar_fn().as_opt::<Pack>()
+    {
+        StructArray::new(
+            pack_options.names.clone(),
+            array.children(),
+            array.len(),
+            pack_options.nullability.into(),
+        )
+    } else {
+        array_result.execute::<Canonical>(ctx)?.into_struct()
+    })
+}
+
+fn scan_aggregate(
+    local_state: &mut TableFunctionLocal,
+    global_state: &TableFunctionGlobal,
+    chunk: &mut DataChunkRef,
+) -> VortexResult<()> {
+    let aggregates_len = global_state.aggregates.len();
+    // seen[k] = output column for requested column k.
+    // If min(x), max(x), avg(y) are requested, seen = { 0: 0, 1: 1}
+    let mut seen: HashMap<u64, usize> = HashMap::with_capacity(aggregates_len);
+    // positions[k] = column id for accumulator k
+    // If min(x), max(x), avg(y) are requested, positions = [0, 0, 1]
+    let mut positions: Vec<usize> = Vec::with_capacity(aggregates_len);
+
+    for aggregate in &global_state.aggregates {
+        let ColumnAggregate::Real { projection_id, .. } = aggregate else {
+            continue;
+        };
+        let len = seen.len();
+        let pos = seen.entry_ref(projection_id).or_insert(len);
+        positions.push(*pos);
+    }
+    let has_count_star = local_state.partials.len() < aggregates_len;
+
+    let mut ctx = SESSION.create_execution_ctx();
+    loop {
+        let Some(result) = local_state.iterator.next() else {
+            // 0 means we're the last thread, u64::MAX means output is written.
+            // is_err() means CAS didn't succeed
+            if global_state
+                .pending
+                .compare_exchange(0, u64::MAX, Ordering::AcqRel, Ordering::Relaxed)
+                .is_err()
+            {
+                return Ok(());
+            }
+
+            let mut accumulators = global_state.partials.lock();
+            let row_count = global_state.row_count.load(Ordering::Acquire) as i64;
+            let mut accum_iter = accumulators.iter_mut();
+            for (idx, aggregate) in global_state.aggregates.iter().enumerate() {
+                let value = match aggregate {
+                    ColumnAggregate::Real { .. } => {
+                        let accum = accum_iter.next().vortex_expect("partial for real agg");
+                        Value::try_from(accum.finish()?)?
+                    }
+                    ColumnAggregate::CountStar => Value::from(row_count),
+                };
+                chunk.get_vector_mut(idx).reference_value(&value);
+            }
+            chunk.set_len(1);
+            return Ok(());
+        };
+        let array = convert_result(result?.0, &mut ctx)?;
+
+        for (i, partial) in positions.iter().zip(local_state.partials.iter_mut()) {
+            partial.accumulate(array.unmasked_field(*i), &mut ctx)?;
+        }
+
+        {
+            let mut partials = global_state.partials.lock();
+            for (global, local) in partials.iter_mut().zip(&mut local_state.partials) {
+                global.combine_partials(local.flush()?)?;
+            }
+        }
+
+        if has_count_star {
+            global_state
+                .row_count
+                .fetch_add(array.len() as u64, Ordering::Relaxed);
+        }
+        global_state.pending.fetch_sub(1, Ordering::Release);
     }
 }
 
@@ -349,6 +522,10 @@ pub fn scan(
     global_state: &TableFunctionGlobal,
     chunk: &mut DataChunkRef,
 ) -> VortexResult<()> {
+    if !local_state.partials.is_empty() {
+        return scan_aggregate(local_state, global_state, chunk);
+    }
+
     loop {
         if local_state.exporter.is_none() {
             let mut ctx = SESSION.create_execution_ctx();
@@ -356,23 +533,8 @@ pub fn scan(
                 return Ok(());
             };
             let (array_result, conversion_cache) = result?;
-            let array_result = array_result.optimize_recursive(ctx.session())?;
             local_state.file_index = conversion_cache.file_index;
-
-            let array_result: StructArray = if let Some(array) = array_result.as_opt::<Struct>() {
-                array.into_owned()
-            } else if let Some(array) = array_result.as_opt::<ScalarFn>()
-                && let Some(pack_options) = array.scalar_fn().as_opt::<Pack>()
-            {
-                StructArray::new(
-                    pack_options.names.clone(),
-                    array.children(),
-                    array.len(),
-                    pack_options.nullability.into(),
-                )
-            } else {
-                array_result.execute::<Canonical>(&mut ctx)?.into_struct()
-            };
+            let array_result = convert_result(array_result, &mut ctx)?;
 
             local_state.exporter = Some(ArrayExporter::try_new(
                 &array_result,
@@ -484,6 +646,46 @@ pub fn pushdown_projection_expression(
     }
 }
 
+/// Turn a scan into an aggregate scan. Input is N aggregations, possibly over
+/// same columns. If we return true, optimized pass expands output to N columns,
+/// e.g. min(x), max(x) turns into min(x0), max(x1), 2 columns in output.
+pub fn pushdown_projection_aggregates(
+    bind_data: &mut TableFunctionBind,
+    input: &AggregatePushdownInputRef,
+) -> VortexResult<bool> {
+    let len = input.len();
+    let mut aggregates = Vec::with_capacity(len);
+    let mut has_non_count_star = false;
+
+    debug!(%len, "pushing down projection aggregates");
+    for i in 0..len {
+        let AggregateExpression {
+            expr,
+            projection_id,
+        } = input.get(i);
+        if projection_id == COUNT_STAR_PROJ_IDX {
+            aggregates.push(ColumnAggregate::CountStar);
+            continue;
+        }
+        let Some(aggregate) = try_from_projection_aggregate(expr)? else {
+            debug!(%expr, %i, "failed to push down projection aggregate");
+            return Ok(false);
+        };
+        debug!(%expr, %projection_id, %i, "pushed down projection aggregate");
+        aggregates.push(ColumnAggregate::Real {
+            projection_id,
+            aggregate,
+        });
+        has_non_count_star = true;
+    }
+    // DuckDB computes just count(*) faster than us
+    if !has_non_count_star {
+        return Ok(false);
+    }
+    bind_data.aggregates = aggregates;
+    Ok(true)
+}
+
 /// Get column-wise statistics. Available only if we're reading a single file.
 pub fn statistics(bind_data: &TableFunctionBind, column_index: usize) -> Option<ColumnStatistics> {
     let children = bind_data.data_source.children();
@@ -501,8 +703,16 @@ pub fn statistics(bind_data: &TableFunctionBind, column_index: usize) -> Option<
         Some(inner) => inner.file_stats().stats_sets(),
         None => return None,
     };
-    let stats_aggregate = ColumnStatisticsAggregate::new(&stats_sets[column_index]);
-    let dtype = bind_data.column_fields[column_index].dtype.clone();
+    let source_id = if bind_data.aggregates.is_empty() {
+        column_index
+    } else {
+        match bind_data.aggregates[column_index] {
+            ColumnAggregate::Real { projection_id, .. } => projection_id.as_(),
+            ColumnAggregate::CountStar => return None,
+        }
+    };
+    let dtype = bind_data.column_fields[source_id].dtype.clone();
+    let stats_aggregate = ColumnStatisticsAggregate::new(&stats_sets[source_id]);
     Some(ColumnStatistics::from(&stats_aggregate, dtype))
 }
 
@@ -517,6 +727,9 @@ pub fn statistics(bind_data: &TableFunctionBind, column_index: usize) -> Option<
 /// here.
 const DEFAULT_SELECTIVITY: f64 = 0.2;
 pub fn cardinality(bind_data: &TableFunctionBind) -> Cardinality {
+    // If we're doing an aggregate scan, we don't change output cardinality to
+    // 1 as we want duckdb to do our aggregation in parallel. That may look
+    // counterintuitive in the plan, though.
     let has_non_optional_filter = bind_data.has_non_optional_filter.load(Ordering::Relaxed);
     match bind_data.data_source.row_count() {
         Precision::Exact(v) => {
@@ -556,6 +769,31 @@ pub fn to_string(bind_data: &TableFunctionBind, map: &mut DuckdbStringMapRef) {
         let mut filters = bind_data.filter_exprs.iter().map(|f| format!("{f}"));
         map.push("Filters", &filters.join("\n"));
     }
+
+    if !bind_data.aggregates.is_empty() {
+        let aggregations = bind_data
+            .aggregates
+            .iter()
+            .map(|agg| match agg {
+                ColumnAggregate::Real {
+                    projection_id,
+                    aggregate,
+                } => {
+                    let projection_id: usize = projection_id.as_();
+                    format!(
+                        "{aggregate}({})",
+                        bind_data.column_fields[projection_id].name
+                    )
+                }
+                ColumnAggregate::CountStar => "count(*)".to_string(),
+            })
+            .join("\n");
+        if !aggregations.is_empty() {
+            map.push("Aggregations", &aggregations);
+        }
+        return;
+    }
+
     let projections = bind_data
         .column_fields
         .iter()

--- a/vortex-sqllogictest/Cargo.toml
+++ b/vortex-sqllogictest/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bigdecimal = { workspace = true }
 datafusion = { workspace = true }
-datafusion-functions-nested = { workspace = true }
+datafusion-functions-nested.workspace = true
 datafusion-sqllogictest = { workspace = true }
 indicatif = { workspace = true }
 regex = { workspace = true }

--- a/vortex-sqllogictest/slt/duckdb/aggregate_pushdown.slt
+++ b/vortex-sqllogictest/slt/duckdb/aggregate_pushdown.slt
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+include ../setup.slt.no
+
+statement ok
+COPY (
+WITH cte AS (SELECT generate_series AS i FROM generate_series(100000))
+SELECT (CASE WHEN i > 0 THEN i ELSE NULL END) AS i FROM cte
+)
+TO '${WORK_DIR}/agg-pushdown.vortex';
+
+query TT
+EXPLAIN
+SELECT sum(i), min(i), max(i), avg(i), mean(i), any_value(i), first(i), count(*), count(i)
+FROM '${WORK_DIR}/agg-pushdown.vortex';
+----
+<!REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query I
+SELECT sum(i) FROM '${WORK_DIR}/agg-pushdown.vortex';
+----
+5000050000
+
+query II
+SELECT min(i), max(i) FROM '${WORK_DIR}/agg-pushdown.vortex';
+----
+1 100000
+
+query RR
+SELECT avg(i), mean(i) FROM '${WORK_DIR}/agg-pushdown.vortex';
+----
+50000.5 50000.5
+
+query II
+SELECT count(*), count(i) FROM '${WORK_DIR}/agg-pushdown.vortex';
+----
+100001 100000
+
+# inverse order to test count(*) not being first
+query II
+SELECT count(i), count(*) FROM '${WORK_DIR}/agg-pushdown.vortex';
+----
+100000 100001
+
+# Just count() is rejected because not pushing it down is faster:
+# we just set chunk length and don't do any aggregation ourselves
+query TT
+EXPLAIN SELECT count(*) FROM '${WORK_DIR}/agg-pushdown.vortex';
+----
+<REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query TT
+EXPLAIN SELECT count(), count(), count() FROM '${WORK_DIR}/agg-pushdown.vortex';
+----
+<REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query III
+SELECT count(), count(), count() FROM '${WORK_DIR}/agg-pushdown.vortex';
+----
+100001 100001 100001
+
+# aggregate over scalar i.e. SELECT mean(strlen(str))
+# + cte
+# + view + recursive view
+# + cte referencing any_value()


### PR DESCRIPTION
This PR adds support for pushing down ungropped aggregates min,max,sum,avg,mean,first,any_value,count(col), and count(*).

It consists of roughly 3 parts:
1. Optimizer pass which works same as scalar function pushdown, but without visitors, because we can't express child extract with a visitor.
2. General accumulator handling in table_function.rs. This includes computing partials in every thread (so that we read data in parallel) and merging them, and also synchonization so that only one thread would write the global aggregated row count
3. Handling of count_star() (count(*)) a.k.a row count. Row count is a special accumulator because it doesn't need the array, and there's no column it aggregates.

I've tried the implementation with CountStart being a separate accumulator, and it is much more complex than current one, because you can't provide a real column to accumulate on in select(), and you need to create a dummy one. So, we pay the cost of a separate atomic and a count_star positions vector, but our expression projection handling stays simple.
We also reject count(*) if it's the only aggregate because duckdb calculating it natively (just using chunk lengths) is faster than our accumulator pipeline

On the API input note, nearly all aggregate functions except for count_star() in duckdb have one non-const argument so input is a pair of a column and an expression.

Depends on #8649 