### PR TITLE
VortexSession register is public and allow_unknown takes reference

### DIFF
--- a/vortex-array/src/aggregate_fn/proto.rs
+++ b/vortex-array/src/aggregate_fn/proto.rs
@@ -195,9 +195,8 @@ mod tests {
 
     #[test]
     fn unknown_aggregate_fn_id_allow_unknown() {
-        let session = VortexSession::empty()
-            .with::<AggregateFnSession>()
-            .allow_unknown();
+        let session = VortexSession::empty().with::<AggregateFnSession>();
+        session.allow_unknown();
 
         let proto = pb::AggregateFn {
             id: "vortex.test.foreign_aggregate".to_string(),

--- a/vortex-array/src/dtype/serde/proto.rs
+++ b/vortex-array/src/dtype/serde/proto.rs
@@ -229,8 +229,9 @@ impl TryFrom<&pb::FieldPath> for FieldPath {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-    use crate::array_session;
+
     use super::*;
+    use crate::array_session;
     use crate::dtype::DType;
     use crate::dtype::DecimalDType;
     use crate::dtype::Field;

--- a/vortex-array/src/dtype/serde/proto.rs
+++ b/vortex-array/src/dtype/serde/proto.rs
@@ -229,7 +229,7 @@ impl TryFrom<&pb::FieldPath> for FieldPath {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-
+    use crate::array_session;
     use super::*;
     use crate::dtype::DType;
     use crate::dtype::DecimalDType;
@@ -502,7 +502,8 @@ mod tests {
 
     #[test]
     fn test_unknown_extension_allow_unknown() {
-        let session = crate::array_session().allow_unknown();
+        let session = array_session();
+        session.allow_unknown();
         let proto = pb::DType {
             dtype_type: Some(DtypeType::Extension(Box::new(pb::Extension {
                 id: "vortex.test.foreign_ext".to_string(),

--- a/vortex-array/src/expr/proto.rs
+++ b/vortex-array/src/expr/proto.rs
@@ -116,9 +116,8 @@ mod tests {
 
     #[test]
     fn unknown_expression_id_allow_unknown() {
-        let session = VortexSession::empty()
-            .with::<ScalarFnSession>()
-            .allow_unknown();
+        let session = VortexSession::empty().with::<ScalarFnSession>();
+        session.allow_unknown();
 
         let expr_proto = pb::Expr {
             id: "vortex.test.foreign_scalar_fn".to_string(),

--- a/vortex-session/src/lib.rs
+++ b/vortex-session/src/lib.rs
@@ -96,7 +96,7 @@ mod tests {
         let session = VortexSession::empty();
         assert!(!session.allows_unknown());
 
-        let session = session.allow_unknown();
+        session.allow_unknown();
         assert!(session.allows_unknown());
     }
 }

--- a/vortex-session/src/session.rs
+++ b/vortex-session/src/session.rs
@@ -191,11 +191,11 @@ impl VortexSession {
 
     /// Inserts a session variable of type `V`, replacing any existing variable of that type.
     ///
-    /// This is the internal copy-on-write insert primitive behind [`with_some`](Self::with_some) and
+    /// This is the copy-on-write insert primitive behind [`with_some`](Self::with_some) and
     /// [`get_mut`](SessionExt::get_mut); it is not public, so a variable can only enter the type-map
     /// through those (or through a default inserted by [`get`](SessionExt::get)). The mutation is
     /// applied in place to the shared backing store, so it is visible through every clone.
-    fn register<V: VortexSessionVar>(&self, var: V) {
+    pub fn register<V: VortexSessionVar>(&self, var: V) {
         let var: Arc<dyn VortexSessionVar> = Arc::new(var);
         self.0.rcu(|current| {
             let mut next = SessionVars::clone(current);
@@ -246,9 +246,8 @@ impl VortexSession {
     /// Allow deserializing unknown plugin IDs as non-executable foreign placeholders.
     ///
     /// Mutates this session in place and returns it for chaining.
-    pub fn allow_unknown(self) -> Self {
+    pub fn allow_unknown(&self) {
         self.get_mut::<UnknownPluginPolicy>().allow_unknown = true;
-        self
     }
 }
 
@@ -435,7 +434,7 @@ mod tests {
         let session = VortexSession::empty();
         assert!(!session.allows_unknown());
 
-        let session = session.allow_unknown();
+        session.allow_unknown();
         assert!(session.allows_unknown());
     }
 

--- a/vortex-tui/src/main.rs
+++ b/vortex-tui/src/main.rs
@@ -8,7 +8,8 @@ use vortex_tui::launch;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let session = VortexSession::default().with_tokio().allow_unknown();
+    let session = VortexSession::default().with_tokio();
+    session.allow_unknown();
     if let Err(err) = launch(&session).await {
         // Defer help/version/usage errors back to clap so their formatting
         // and exit codes match the standalone-binary convention exactly.

--- a/vortex-web/crate/src/lib.rs
+++ b/vortex-web/crate/src/lib.rs
@@ -17,7 +17,7 @@ use vortex::session::VortexSession;
 mod wasm;
 
 static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-    VortexSession::default()
-        .with_handle(WasmRuntime::handle())
-        .allow_unknown()
+    let session = VortexSession::default().with_handle(WasmRuntime::handle());
+    session.allow_unknown();
+    session
 });


### PR DESCRIPTION
While integrating vortex into another project I realised that these are more
sensible apis
