### PR TITLE
mean() for decimals

### DIFF
--- a/vortex-array/src/aggregate_fn/fns/mean/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/mean/mod.rs
@@ -18,10 +18,16 @@ use crate::aggregate_fn::combined::CombinedOptions;
 use crate::aggregate_fn::combined::PairOptions;
 use crate::aggregate_fn::fns::count::Count;
 use crate::aggregate_fn::fns::sum::Sum;
+use crate::aggregate_fn::fns::sum::sum_decimal_dtype;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
+use crate::dtype::DecimalDType;
+use crate::dtype::MAX_PRECISION;
+use crate::dtype::MAX_SCALE;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
+use crate::dtype::i256;
+use crate::scalar::DecimalValue;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::operators::Operator;
 
@@ -45,10 +51,7 @@ pub fn mean(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
 ///
 /// Implemented as `Sum / Count` via [`BinaryCombined`].
 ///
-/// Coercion / return type:
-/// - Booleans and primitive numeric types are coerced to `f64` and the result
-///   is a nullable `f64`.
-/// - Decimals are kept as decimals but not implemented currently
+/// Booleans and primitive numeric types are cast to f64. Decimals stay decimals.
 #[derive(Clone, Debug)]
 pub struct Mean;
 
@@ -88,18 +91,18 @@ impl BinaryCombined for Mean {
     }
 
     fn finalize(&self, sum: ArrayRef, count: ArrayRef) -> VortexResult<ArrayRef> {
-        let target = match sum.dtype() {
-            DType::Decimal(..) => sum.dtype().with_nullability(Nullability::Nullable),
-            _ => DType::Primitive(PType::F64, Nullability::Nullable),
-        };
+        if let DType::Decimal(..) = sum.dtype() {
+            vortex_bail!("grouped mean over decimals is not yet supported");
+        }
+        let target = DType::Primitive(PType::F64, Nullability::Nullable);
         let sum_cast = sum.cast(target.clone())?;
         let count_cast = count.cast(target)?;
         sum_cast.binary(count_cast, Operator::Div)
     }
 
     fn finalize_scalar(&self, left_scalar: Scalar, right_scalar: Scalar) -> VortexResult<Scalar> {
-        if let DType::Decimal(..) = left_scalar.dtype() {
-            vortex_bail!("mean::finalize_scalar not yet implemented for decimal inputs");
+        if let DType::Decimal(decimal_dtype, _) = *left_scalar.dtype() {
+            return finalize_decimal_scalar(&left_scalar, &right_scalar, decimal_dtype);
         }
 
         let target = DType::Primitive(PType::F64, Nullability::Nullable);
@@ -140,13 +143,12 @@ impl BinaryCombined for Mean {
 /// - Bool stays as bool — `Sum` has a native bool path and bool → f64 isn't
 ///   currently a direct cast in vortex.
 /// - Primitive numerics → `f64` so the sum and finalize work without overflow.
+/// - Decimals stay as decimals
 fn coerced_input_dtype(input_dtype: &DType) -> Option<DType> {
     match input_dtype {
         DType::Bool(_) => Some(input_dtype.clone()),
         DType::Primitive(_, n) => Some(DType::Primitive(PType::F64, *n)),
-        DType::Decimal(..) => {
-            unimplemented!("mean is not implemented for decimals yet")
-        }
+        DType::Decimal(..) => Some(input_dtype.clone()),
         _ => None,
     }
 }
@@ -156,11 +158,57 @@ fn mean_output_dtype(input_dtype: &DType) -> Option<DType> {
         DType::Bool(_) | DType::Primitive(..) => {
             Some(DType::Primitive(PType::F64, Nullability::Nullable))
         }
-        DType::Decimal(..) => {
-            unimplemented!("mean for decimals is not yet implemented");
-        }
+        DType::Decimal(decimal_dtype, _) => Some(DType::Decimal(
+            mean_decimal_dtype(&sum_decimal_dtype(decimal_dtype)),
+            Nullability::Nullable,
+        )),
         _ => None,
     }
+}
+
+/// mean() output decimal type mimicking Spark/DataFusion/MySQL: decimal(p+4, s+4)
+fn mean_decimal_dtype(sum: &DecimalDType) -> DecimalDType {
+    DecimalDType::new(
+        u8::min(MAX_PRECISION, sum.precision().saturating_sub(6)),
+        i8::min(MAX_SCALE, sum.scale() + 4),
+    )
+}
+
+fn finalize_decimal_scalar(
+    sum: &Scalar,
+    count: &Scalar,
+    sum_decimal: DecimalDType,
+) -> VortexResult<Scalar> {
+    let target_decimal_dtype = mean_decimal_dtype(&sum_decimal);
+    let target_dtype = DType::Decimal(target_decimal_dtype, Nullability::Nullable);
+
+    // overflow
+    let Some(sum_value) = sum.as_decimal().decimal_value() else {
+        return Ok(Scalar::null(target_dtype));
+    };
+    // empty input
+    let count = count.as_primitive().typed_value::<u64>().unwrap_or(0);
+    if count == 0 {
+        return Ok(Scalar::null(target_dtype));
+    }
+
+    let Ok(sum) = DecimalValue::rescale_i256(
+        sum_value.as_i256(),
+        sum_decimal.scale(),
+        target_decimal_dtype.scale(),
+    ) else {
+        return Ok(Scalar::null(target_dtype));
+    };
+    let mean = sum / i256::from_i128(i128::from(count));
+
+    let Ok(mean) = DecimalValue::try_from_i256(mean, target_decimal_dtype) else {
+        return Ok(Scalar::null(target_dtype));
+    };
+    Ok(Scalar::decimal(
+        mean,
+        target_decimal_dtype,
+        Nullability::Nullable,
+    ))
 }
 
 #[cfg(test)]
@@ -175,7 +223,9 @@ mod tests {
     use crate::arrays::BoolArray;
     use crate::arrays::ChunkedArray;
     use crate::arrays::ConstantArray;
+    use crate::arrays::DecimalArray;
     use crate::arrays::PrimitiveArray;
+    use crate::dtype::DecimalDType;
     use crate::validity::Validity;
 
     #[test]
@@ -270,6 +320,73 @@ mod tests {
         let mut ctx = array_session().create_execution_ctx();
         let result = mean(&array, &mut ctx)?;
         assert!(result.as_primitive().as_::<f64>().is_some_and(f64::is_nan));
+        Ok(())
+    }
+
+    #[test]
+    fn mean_decimal() -> VortexResult<()> {
+        let dtype = DecimalDType::new(6, 2);
+        let array =
+            DecimalArray::new(buffer![100i32, 200, 300], dtype, Validity::NonNullable).into_array();
+        let mut ctx = array_session().create_execution_ctx();
+        let result = mean(&array, &mut ctx)?;
+        assert_eq!(
+            result.dtype(),
+            &DType::Decimal(DecimalDType::new(10, 6), Nullability::Nullable)
+        );
+        // mean(1.00, 2.00, 3.00) = 2.000000
+        assert_eq!(
+            result.as_decimal().decimal_value(),
+            Some(DecimalValue::I256(i256::from_i128(2_000_000)))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn mean_decimal_null() -> VortexResult<()> {
+        let dtype = DecimalDType::new(6, 2);
+        let validity = Validity::from_iter([true, false, true]);
+        let array = DecimalArray::new(buffer![150i32, 0, 450], dtype, validity).into_array();
+        let mut ctx = array_session().create_execution_ctx();
+        let result = mean(&array, &mut ctx)?;
+        // mean(1.50, 4.50) = 3.000000
+        assert_eq!(
+            result.as_decimal().decimal_value(),
+            Some(DecimalValue::I256(i256::from_i128(3_000_000)))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn mean_decimal_chunked() -> VortexResult<()> {
+        let dtype = DecimalDType::new(6, 2);
+        let validity = Validity::NonNullable;
+        let chunk1 = DecimalArray::new(buffer![100i32, 200], dtype, validity.clone()).into_array();
+        let chunk2 = DecimalArray::new(buffer![300i32, 400, 500], dtype, validity).into_array();
+        let dtype = chunk1.dtype().clone();
+        let chunked = ChunkedArray::try_new(vec![chunk1, chunk2], dtype)?;
+        let mut ctx = array_session().create_execution_ctx();
+        let result = mean(&chunked.into_array(), &mut ctx)?;
+        // mean(1.00, 2.00, 3.00, 4.00, 5.00) = 3.000000
+        assert_eq!(
+            result.as_decimal().decimal_value(),
+            Some(DecimalValue::I256(i256::from_i128(3_000_000)))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn mean_decimal_33() -> VortexResult<()> {
+        let dtype = DecimalDType::new(6, 2);
+        let buf = buffer![100i32, 0, 0];
+        let array = DecimalArray::new(buf, dtype, Validity::NonNullable).into_array();
+        let mut ctx = array_session().create_execution_ctx();
+        let result = mean(&array, &mut ctx)?;
+        // mean(1.00, 0.00, 0.00) = 1/3 => 0.333333
+        assert_eq!(
+            result.as_decimal().decimal_value(),
+            Some(DecimalValue::I256(i256::from_i128(333_333)))
+        );
         Ok(())
     }
 

--- a/vortex-array/src/aggregate_fn/fns/sum/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/mod.rs
@@ -77,6 +77,16 @@ pub fn sum(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
 #[derive(Clone, Debug)]
 pub struct Sum;
 
+// Both Spark and DataFusion use this heuristic.
+// - https://github.com/apache/spark/blob/fcf636d9eb8d645c24be3db2d599aba2d7e2955a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala#L66
+// - https://github.com/apache/datafusion/blob/4153adf2c0f6e317ef476febfdc834208bd46622/datafusion/functions-aggregate/src/sum.rs#L188
+pub(crate) fn sum_decimal_dtype(input: &DecimalDType) -> DecimalDType {
+    DecimalDType::new(
+        u8::min(MAX_PRECISION, input.precision() + 10),
+        input.scale(),
+    )
+}
+
 impl AggregateFnVTable for Sum {
     type Options = NumericalAggregateOpts;
     type Partial = SumPartial;
@@ -118,14 +128,7 @@ impl AggregateFnVTable for Sum {
                 }
             },
             DType::Decimal(decimal_dtype, _) => {
-                // Both Spark and DataFusion use this heuristic.
-                // - https://github.com/apache/spark/blob/fcf636d9eb8d645c24be3db2d599aba2d7e2955a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala#L66
-                // - https://github.com/apache/datafusion/blob/4153adf2c0f6e317ef476febfdc834208bd46622/datafusion/functions-aggregate/src/sum.rs#L188
-                let precision = u8::min(MAX_PRECISION, decimal_dtype.precision() + 10);
-                DType::Decimal(
-                    DecimalDType::new(precision, decimal_dtype.scale()),
-                    Nullable,
-                )
+                DType::Decimal(sum_decimal_dtype(decimal_dtype), Nullable)
             }
             // Unsupported types
             _ => return None,

--- a/vortex-array/src/arrays/decimal/compute/cast.rs
+++ b/vortex-array/src/arrays/decimal/compute/cast.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use num_traits::AsPrimitive;
 use num_traits::CheckedMul;
+use num_traits::ToPrimitive as NumToPrimitive;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_compute::lane_kernels::IndexedSourceExt;
@@ -19,11 +21,14 @@ use crate::IntoArray;
 use crate::array::ArrayView;
 use crate::arrays::Decimal;
 use crate::arrays::DecimalArray;
+use crate::arrays::PrimitiveArray;
 use crate::dtype::BigCast;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
 use crate::dtype::DecimalType;
 use crate::dtype::NativeDecimalType;
+use crate::dtype::Nullability;
+use crate::dtype::PType;
 use crate::dtype::i256;
 use crate::match_each_decimal_value_type;
 use crate::scalar::DecimalValue;
@@ -77,15 +82,18 @@ impl CastKernel for Decimal {
         dtype: &DType,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        // Early return if not casting to decimal
-        let DType::Decimal(to_decimal_dtype, to_nullability) = dtype else {
-            return Ok(None);
-        };
         let DType::Decimal(from_decimal_dtype, _) = array.dtype() else {
             vortex_panic!(
                 "DecimalArray must have decimal dtype, got {:?}",
                 array.dtype()
             );
+        };
+        if let DType::Primitive(PType::F64, nullability) = dtype {
+            let scale = from_decimal_dtype.scale();
+            return cast_to_f64(array, scale, *nullability, ctx).map(Some);
+        }
+        let DType::Decimal(to_decimal_dtype, to_nullability) = dtype else {
+            return Ok(None);
         };
 
         // If the dtype is exactly the same, return self
@@ -141,6 +149,57 @@ impl CastKernel for Decimal {
             })
         })
     }
+}
+
+fn cast_to_f64(
+    array: ArrayView<'_, Decimal>,
+    scale: i8,
+    nullability: Nullability,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let source_validity = array.validity()?;
+    let n = array.len();
+    let mask = source_validity.execute_mask(n, ctx)?;
+    let validity = source_validity.cast_nullability(nullability, n, ctx)?;
+
+    let scale: i32 = scale.as_();
+    let inv_factor: f64 = 10f64.powi(-scale);
+
+    let buffer = match &mask {
+        Mask::AllFalse(_) => BufferMut::<f64>::zeroed(n),
+        Mask::AllTrue(_) => match_each_decimal_value_type!(array.values_type(), |F| {
+            let values = array.buffer::<F>();
+            let values = values.as_slice();
+            let mut out = BufferMut::<f64>::with_capacity(n);
+            values.map_into(&mut out.spare_capacity_mut()[..n], |v: F| {
+                to_f64_lossy::<F>(v) * inv_factor
+            });
+            // SAFETY: map_into wrote every lane before returning.
+            unsafe { out.set_len(n) };
+            out
+        }),
+        Mask::Values(mask_values) => match_each_decimal_value_type!(array.values_type(), |F| {
+            let values = array.buffer::<F>();
+            let values = values.as_slice();
+            let mut out = BufferMut::<f64>::with_capacity(n);
+            let write_result = values.try_map_masked_into(
+                mask_values.bit_buffer(),
+                &mut out.spare_capacity_mut()[..n],
+                |v: F| Some(to_f64_lossy::<F>(v) * inv_factor),
+            );
+            debug_assert!(write_result.is_ok());
+            // SAFETY: try_map_masked_into wrote every lane before returning Ok.
+            unsafe { out.set_len(n) };
+            out
+        }),
+    };
+
+    Ok(PrimitiveArray::new(buffer, validity).into_array())
+}
+
+#[inline]
+fn to_f64_lossy<F: NativeDecimalType>(value: F) -> f64 {
+    NumToPrimitive::to_f64(&value).unwrap_or(f64::NAN)
 }
 
 fn cast_decimal_values<F, T>(
@@ -386,6 +445,7 @@ mod tests {
     use vortex_buffer::buffer;
 
     use super::upcast_decimal_values;
+    use crate::Canonical;
     use crate::IntoArray;
     use crate::VortexSessionExecute;
     use crate::array_session;
@@ -398,6 +458,8 @@ mod tests {
     use crate::dtype::DecimalDType;
     use crate::dtype::DecimalType;
     use crate::dtype::Nullability;
+    use crate::dtype::PType;
+    use crate::scalar::Scalar;
     use crate::validity::Validity;
 
     #[test]
@@ -768,5 +830,69 @@ mod tests {
                 .to_string()
                 .contains("Cannot downcast decimal values")
         );
+    }
+
+    #[test]
+    fn cast_decimal_f64() {
+        let dtype = DecimalDType::new(6, 2);
+        let array = DecimalArray::new(buffer![125i32, 250, -375], dtype, Validity::NonNullable);
+        let target = DType::Primitive(PType::F64, Nullability::NonNullable);
+        let casted = array.into_array().cast(target.clone()).unwrap();
+        assert_eq!(casted.dtype(), &target);
+
+        let mut ctx = array_session().create_execution_ctx();
+        let primitive = casted
+            .execute::<Canonical>(&mut ctx)
+            .unwrap()
+            .into_primitive();
+        assert_eq!(primitive.to_buffer::<f64>().as_ref(), &[1.25, 2.5, -3.75]);
+    }
+
+    #[test]
+    fn cast_decimal_f64_null() {
+        let values = [Some(100i32), None, Some(-200)];
+        let array = DecimalArray::from_option_iter(values, DecimalDType::new(6, 2));
+        let target = DType::Primitive(PType::F64, Nullability::Nullable);
+        let casted = array.into_array().cast(target.clone()).unwrap();
+        assert_eq!(casted.dtype(), &target);
+
+        let mut ctx = array_session().create_execution_ctx();
+        let primitive = casted
+            .execute::<Canonical>(&mut ctx)
+            .unwrap()
+            .into_primitive();
+
+        assert!(primitive.is_valid(0, &mut ctx).unwrap());
+        assert!(!primitive.is_valid(1, &mut ctx).unwrap());
+        assert!(primitive.is_valid(2, &mut ctx).unwrap());
+
+        assert_eq!(
+            primitive.execute_scalar(0, &mut ctx).unwrap(),
+            Scalar::from(1f64)
+        );
+        assert_eq!(
+            primitive.execute_scalar(2, &mut ctx).unwrap(),
+            Scalar::from(-2f64)
+        );
+    }
+
+    #[test]
+    fn cast_decimal_f64_all_null() {
+        let dtype = DecimalDType::new(6, 2);
+        let buf = buffer![i32::MAX, i32::MIN, 12345];
+        let array = DecimalArray::new(buf, dtype, Validity::AllInvalid);
+        let target = DType::Primitive(PType::F64, Nullability::Nullable);
+        let casted = array.into_array().cast(target.clone()).unwrap();
+        assert_eq!(casted.dtype(), &target);
+
+        let primitive = casted
+            .execute::<Canonical>(&mut array_session().create_execution_ctx())
+            .unwrap()
+            .into_primitive();
+        let mut ctx = array_session().create_execution_ctx();
+        for i in 0..2 {
+            assert!(!primitive.is_valid(i, &mut ctx).unwrap());
+        }
+        assert_eq!(primitive.to_buffer::<f64>().as_ref(), &[0.0, 0.0, 0.0]);
     }
 }


### PR DESCRIPTION
Support mean() for decimals (keeps mean as Decimal). Support casting decimals to f64 (we need this for aggregate pushdown because avg(decimal) in duckdb is f64).
