### PR TITLE
Add list_transform expression

### DIFF
--- a/vortex-array/src/expr/exprs.rs
+++ b/vortex-array/src/expr/exprs.rs
@@ -38,6 +38,8 @@ use crate::scalar_fn::fns::like::Like;
 use crate::scalar_fn::fns::like::LikeOptions;
 use crate::scalar_fn::fns::list_contains::ListContains;
 use crate::scalar_fn::fns::list_length::ListLength;
+use crate::scalar_fn::fns::list_transform::ListTransform;
+use crate::scalar_fn::fns::list_transform::ListTransformOptions;
 use crate::scalar_fn::fns::literal::Literal;
 use crate::scalar_fn::fns::mask::Mask;
 use crate::scalar_fn::fns::merge::DuplicateHandling;
@@ -764,4 +766,22 @@ pub fn ext_storage(input: Expression) -> Expression {
 /// ```
 pub fn list_length(input: Expression) -> Expression {
     ListLength.new_expr(EmptyOptions, [input])
+}
+
+// ---- ListTransform ----
+
+/// Creates an expression that transforms every element of a list with `body`, preserving the
+/// list's structure (offsets and list-level validity). This is akin to DuckDB's
+/// `list_transform()` with a lambda.
+///
+/// `body` is evaluated with the list's elements as its root scope: within `body`, `root()`
+/// refers to the element rather than the enclosing row. For example, DuckDB's
+/// `list_transform(tags, lambda x: x + 1)` is expressed as:
+///
+/// ```rust
+/// # use vortex_array::expr::{checked_add, get_item, list_transform, lit, root};
+/// let expr = list_transform(get_item("tags", root()), checked_add(root(), lit(1)));
+/// ```
+pub fn list_transform(input: Expression, body: Expression) -> Expression {
+    ListTransform.new_expr(ListTransformOptions { body }, [input])
 }

--- a/vortex-array/src/expr/proto.rs
+++ b/vortex-array/src/expr/proto.rs
@@ -15,6 +15,10 @@ use crate::scalar_fn::session::ScalarFnSessionExt;
 pub trait ExprSerializeProtoExt {
     /// Serialize the expression to its protobuf representation.
     fn serialize_proto(&self) -> VortexResult<pb::Expr>;
+
+    /// Serialize the expression to its protobuf representation, returning `Ok(None)` if any
+    /// node in the tree is not serializable.
+    fn try_serialize_proto(&self) -> VortexResult<Option<pb::Expr>>;
 }
 
 impl ExprSerializeProtoExt for Expression {
@@ -34,6 +38,26 @@ impl ExprSerializeProtoExt for Expression {
             children,
             metadata: Some(metadata),
         })
+    }
+
+    fn try_serialize_proto(&self) -> VortexResult<Option<pb::Expr>> {
+        let mut children = Vec::with_capacity(self.children().len());
+        for child in self.children().iter() {
+            match child.try_serialize_proto()? {
+                Some(child) => children.push(child),
+                None => return Ok(None),
+            }
+        }
+
+        let Some(metadata) = self.options().serialize()? else {
+            return Ok(None);
+        };
+
+        Ok(Some(pb::Expr {
+            id: self.id().to_string(),
+            children,
+            metadata: Some(metadata),
+        }))
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/list_length.rs
+++ b/vortex-array/src/scalar_fn/fns/list_length.rs
@@ -31,6 +31,7 @@ use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::fns::list_transform::ListTransform;
 use crate::scalar_fn::fns::operators::Operator;
 
 /// Number of elements in each list of a `List` or `FixedSizeList` typed array.
@@ -96,6 +97,20 @@ impl ScalarFnVTable for ListLength {
         }
 
         list_length(&input, nullability, ctx)
+    }
+
+    fn simplify_untyped(
+        &self,
+        _options: &Self::Options,
+        expr: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        // `list_transform` preserves list lengths, so skip it entirely:
+        // list_length(list_transform(l, f)) == list_length(l).
+        let input = expr.child(0);
+        if input.is::<ListTransform>() {
+            return Ok(Some(expr.clone().with_children([input.child(0).clone()])?));
+        }
+        Ok(None)
     }
 
     fn validity(
@@ -173,7 +188,7 @@ fn list_length_from_offsets(list: ArrayView<'_, List>) -> VortexResult<ArrayRef>
 }
 
 /// Matches an `Array<List>`, `Array<ListView>`, or `Array<FixedSizeList>`
-struct AnyList;
+pub(crate) struct AnyList;
 
 impl Matcher for AnyList {
     type Match<'a> = ();

--- a/vortex-array/src/scalar_fn/fns/list_transform/design.md
+++ b/vortex-array/src/scalar_fn/fns/list_transform/design.md
@@ -1,0 +1,398 @@
+# `list_transform` — Higher-Order List Functions as Vortex Expressions
+
+*Goal: support `list_transform(l, x -> f(x))` — apply an expression to every element of a
+list, preserving list structure — as a first-class Vortex expression.*
+
+---
+
+## 1. Motivation
+
+`list_transform` is the gateway to the whole higher-order function (HOF) family — `list_filter`, `list_reduce`, `element_at` — because it introduces the one
+thing Vortex expressions don't have yet: **a sub-expression evaluated in a different scope** (the
+list's elements) **at a different cardinality** (element count, not row count).
+
+Why it's worth doing well:
+
+1. **Structure-preserving execution.** `list_transform` never changes list *shape* — offsets and
+list validity pass through untouched. Only the elements child is rewritten. In Vortex terms,
+the transform of a `ListArray` is `ListArray::try_new(apply(elements, body), offsets, validity)` — a deferred, nearly-free wrapper.
+2. **Compression-aware element evaluation.** Because the body is applied to the elements child via the normal deferred expression machinery, all existing encoded-array kernels fire: a
+dictionary-encoded elements child evaluates the body over dictionary *values* only; constant
+elements fold to a constant. Eager engines (DuckDB) flatten to vectors first and can't do this.
+3. **Layout pushdown.** With the shredded `ListLayout` (elements / offsets / validity as
+independent sub-layout trees), `list_transform(col, x -> x.a)` should read **only the `a`
+sub-layout of the elements subtree** — offsets and validity stream through unchanged. This is the `len`/`element_at` pushdown frontier from `list-storage-formats.md`, extended to arbitrary element expressions.
+
+## 2. Survey: how other engines implement lambda HOFs
+
+Every vectorized engine converges on the same two ideas. **(a)** The lambda is a *bind-time*
+construct, never a runtime value: the body is bound, stashed somewhere the executor can reach, and the lambda node disappears from the expression tree before execution. **(b)** Execution evaluates the body **once over the flattened elements**, then reattaches the original offsets; outer-column references ("captures") are replicated to element cardinality, usually zero-copy.
+
+### DuckDB (the closest model; verified against source @ `36c64ee8`, 2026-07)
+
+- **Representation.** Parse-level `LambdaExpression` (shared with the JSON `->` operator;
+disambiguated in the binder, which is why DuckDB 1.3 introduced Python-style `lambda x: ...` syntax and is deprecating `->`). The binder pushes a `DummyBinding` for the parameters onto a scope stack (`lambda_bindings`, innermost-first — nested lambdas shadow), binds the body, and rewrites every leaf to a physical slot index (`BoundReferenceExpression`) against a fixed input chunk layout: `[params, reversed][outer-lambda params][captures]`.
+- **Capture hoisting is the load-bearing idea.** Column refs from the enclosing row scope are
+hoisted out of the body and appended as *ordinary arguments* of the surrounding call:
+`list_transform(l, x -> x + col)` physically becomes `list_transform(l, col)` with the body in bind data. Captures thus get all standard per-argument optimizer machinery (folding, CSE, projection pushdown) for free.
+- **The body lives in `FunctionData` (bind data), not as a child.** Each HOF supplies a
+`bind_lambda` callback mapping parameter index → type (param 0 = list child type, param 1 =
+`BIGINT` index). The `BoundLambdaExpression` child is erased after binding. Known footgun:
+generic expression-tree walks (e.g. volatility for constant-folding) don't see the body, so
+foldability must special-case it (`BoundFunctionExpression::IsFoldable`; bug history #8108).
+- **Execution** (`ExecuteLambda`, post-#9395 revamp, ~10³× faster than the naive first cut):
+iterate rows, gathering element positions into a selection vector; every non-constant capture
+gets a parallel selection vector with `sel[k] = row_idx` — a **dictionary-vector expansion of
+row values to element cardinality, zero copy**. When the batch hits `STANDARD_VECTOR_SIZE`
+(2048), run a plain `ExpressionExecutor` over `[index?][element slice][captures...]`. Batches deliberately cross list boundaries (a 10k-element list = ~5 invocations; hundreds of small lists = 1). Transform output reuses input lengths with re-densified offsets; filter gathers surviving input elements rather than re-evaluating.
+- **Null semantics.** `SPECIAL_HANDLING`: NULL list → NULL result row (body never runs on its
+elements); NULL *element* flows through the body's own null semantics (`x + 1` → NULL);
+empty list → empty list, no evaluation.
+- **Optimizer.** Lambda functions are const-foldable unless the body is volatile; subqueries and
+UNNEST are banned inside bodies; a dedicated rewrite collapses the 3-stage list-comprehension desugaring into `list_transform(list_filter(l, cond), expr)`.
+
+### ClickHouse
+
+`arrayMap(x -> e, arr)` compiles the lambda to a `ColumnFunction`; captured columns are attached with `appendArguments` and **replicated to element granularity via the array's offsets**
+(`ColumnFunction::replicate(offsets)`), then the body is evaluated once over the flattened nested data column. Same flatten-evaluate-reattach shape as DuckDB, replication instead of selection
+vectors.
+
+### Spark / Catalyst (the counter-example)
+
+`transform` is a `HigherOrderFunction` whose lambda is a real expression node:
+`LambdaFunction(body, Seq(NamedLambdaVariable))`, resolved by `bindLambdaFunction`. Execution is **row-at-a-time**: for each row, loop over elements, mutate the `NamedLambdaVariable`'s `AtomicReference` value, evaluate the body. No vectorization, no codegen for the loop — a well-known perf cliff. Useful lesson: named-variable nodes with interpreter-mutable state is the design to avoid in a columnar engine.
+
+### Velox, Trino, StarRocks, Polars
+
+- **Velox**: lambdas are first-class *vector* functions — a `FunctionVector` carries (body, capture
+rows); vector functions receive it and `apply` it to element-cardinality vectors; captures are
+wrapped in dictionaries to align cardinality. Fully vectorized, same core trick.
+- **Trino/Presto**: lambdas compile to JVM bytecode (`LambdaDefinitionExpression`); arrays are
+processed per row-block. Vectorized in blocks but not offset-preserving in the DuckDB sense.
+- **StarRocks**: `array_map` with explicit capture-column replication (`array_map_expr.cpp`) —
+the ClickHouse approach.
+- **Polars**: `list.eval(pl.element() * 2)` — notably, the *element* is addressed by a dedicated
+root-like expression (`pl.element()`) evaluated against the exploded child, with an elementwise fast path that skips per-list grouping. This is the closest existing design to what's proposed below: **the lambda "variable" is just the root of a sub-expression whose scope is the elements array.**
+
+### DataFusion (lambda support is NEW and shipped)
+
+DataFusion merged lambda support in **PR #21679 (2026-04-28)**, closing the long-standing HOF issue (#14205, closed as completed 2026-04-29) — and it shipped in **DataFusion 54, the exact version Vortex pins today** (verified: the `lambda.rs` / `lambda_variable.rs` / `higher_order_function.rs` modules are present in the `datafusion-physical-expr-54.0.0` crate Vortex builds against).
+
+The representation (Spark-style named variables, not DuckDB-style bind data):
+
+- Logical: three new `Expr` variants — `HigherOrderFunction { func: Arc<dyn HigherOrderUDF>, args }`, `Lambda { params: Vec<String>, body }`, and `LambdaVariable { name, field }`. `HigherOrderUDF` is the lambda-accepting analogue of `ScalarUDFImpl`.
+- Physical: `HigherOrderFunctionExpr` (`datafusion-physical-expr/src/higher_order_function.rs:70`; exposes `fun()`, `name()`, `args()`, `return_type()`, `nullable()`), with lambda arguments as
+`LambdaExpr { params: Vec<String>, body: Arc<dyn PhysicalExpr> }`
+(`expressions/lambda.rs:41`) containing `LambdaVariable { index: usize, field }` leaves
+(`expressions/lambda_variable.rs:35`) — physical variables are resolved to positional indices.
+- One HOF exists so far: `array_transform` in `datafusion-functions-nested`
+(`array_transform_higher_order_function()`), i.e. exactly our target. SQL:
+`SELECT array_transform([2, 3], v -> v != 2)`. Nested lambdas are supported.
+- **Column capture was deferred upstream** (removed from the initial PR; tracked in
+#21172) — DataFusion lambdas are capture-free today, which aligns exactly with the capture-free v1 proposed here.
+
+Consequence: the DataFusion converter arm is **in scope for v1** (§6.2), same tier as the
+expression itself — this is now the same story as `list_length`, where DF pushdown was the
+motivating consumer.
+
+## 3. Where Vortex is today
+
+- An expression is `Expression { scalar_fn: ScalarFnRef, children: Arc<Vec<Expression>> }` (`vortex-array/src/expr/expression.rs:27`). Operations implement `ScalarFnVTable`(`vortex-array/src/scalar_fn/vtable.rs:39`) with typed, hashable, serializable `Options`.
+- **Single scope.** Expressions evaluate against one `ArrayRef`; `root()` (`fns/root.rs`) is the
+scope reference and every leaf sees the same root (`vortex-array/src/expression.rs:18`). There is no variable/binding machinery of any kind.
+- **Children are evaluated eagerly, at row cardinality.** `ScalarFnVTable::execute` receives
+already-evaluated child arrays (`ExecutionArgs`, `vtable.rs:320`). A lambda body therefore
+**cannot be an ordinary child**: it must run at element cardinality against a scope that only
+exists inside `execute` (the elements child of the evaluated list argument).
+- **Deferred execution.** `ArrayRef::apply(expr)` builds a lazy `ScalarFnArray`; computation
+happens via `execute_until` / canonicalization with encoded-array kernels. `list_length`'s
+`execute` (`fns/list_length.rs:84`) is the model: `execute_until::<AnyList>` to reach a
+`List`/`ListView`/`FixedSizeList`, then answer from structure.
+- **Serialization.** Options serialize to bytes inside `pb::Expr` metadata; `deserialize` receives
+a `&VortexSession` (`vtable.rs:56`) — which is exactly what's needed to deserialize a *nested expression* via `Expression::from_proto` (`expr/proto.rs:41`).
+- `Expression` is `Clone + Debug + Display + PartialEq + Eq + Hash` — it satisfies every bound `ScalarFnVTable::Options` requires. Nothing blocks embedding an expression in options.
+
+## 4. Design
+
+### 4.1 The lambda body lives in `Options`; its scope is the elements array
+
+```rust
+/// Options for the `list_transform` scalar function.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ListTransformOptions {
+    /// The lambda body. Evaluated with the list's *elements* array as its root scope:
+    /// within this expression, `root()` refers to the element, not the row.
+    pub body: Expression,
+}
+
+pub struct ListTransform;
+
+impl ScalarFnVTable for ListTransform {
+    type Options = ListTransformOptions;
+    // id: "vortex.list.transform"
+    // arity: Exact(1), child 0 = "input" (the list)
+    ...
+}
+```
+
+Two decisions in one, each with a rejected alternative:
+
+**(a) Body in `Options`, not as a child** — DuckDB's bind-data approach, adapted.
+
+|  | body in `Options` (chosen) | body as child + "scoped child" support |
+| --- | --- | --- |
+| Framework change | none — `Options` already supports nested exprs (Eq/Hash/serde all work) | evaluator, `ExecutionArgs`, arity checking, and every visitor must learn "child N evaluates lazily in scope S" |
+| Scope confusion | impossible by construction: row-scope passes (field analysis, validity rewrites, DataFusion conversion of siblings) never descend into the body with the wrong root | every existing traversal must be audited to skip/rescope the body child |
+| Blind spots | scope-*independent* properties must delegate explicitly (see below) | none |
+| Precedent | DuckDB bind data; Polars `list.eval` | Spark `LambdaFunction` node |
+
+The blind-spot cost is real but small and enumerable — the same footgun DuckDB hit with
+foldability (#8108), avoided here by delegation:
+
+- `is_fallible` → `true` iff any node of `body` is fallible (walk `body` in the impl).
+- `is_null_sensitive` → `false` for the *list* dimension (masking list validity commutes with
+transform, same argument as `list_length`); the body's own null sensitivity is internal to it.
+- `serialize`/`deserialize` → body encoded as `pb::Expr` bytes in options metadata; deserialization uses the session's scalar-fn registry, which is why `deserialize` takes a session.
+- Display/`fmt_sql` → render as `vortex.list.transform(input, x -> <body>)`, printing the body with its root shown as the lambda parameter to avoid two meanings of `$` in one line.
+- Expression-tree transforms (`expr/transform`, analysis passes) will not rewrite inside the body. That is *correct* for scope-dependent passes and acceptable for the rest; if a pass ever needs to see inside (e.g. a global "collect all referenced encodings"), add an explicit
+`ScalarFnVTable` hook rather than flattening the scope distinction.
+
+**(b) `root()` *is* the lambda parameter** — no variable nodes, no de Bruijn indices, no name
+resolution. `x -> x + 1` is simply `add(root(), lit(1))` evaluated with the elements array as
+root. This is Polars' `pl.element()` insight expressed with machinery Vortex already has:
+
+- The elements array **is** a complete evaluation scope; the body is an ordinary expression
+against it. `x -> x.a + 1` = `add(get_item("a", root()), lit(1))` — struct element access works with zero new code.
+- Nesting composes: the body of a transform over `List<List<i32>>` may itself contain a
+`list_transform`, whose own body's root is the inner element. Each level rebinds root naturally.
+- What this deliberately *cannot* express: **captures** (outer row columns in the body) and the
+**index parameter** `(x, i)`. Both have a clean forward path that changes no v1 code — the scope generalizes from "the element" to "a struct of the element plus expanded companions" (§8) — exactly DuckDB's input-chunk layout `[index][element][captures]`, expressed as a struct scope instead of positional slots.
+
+### 4.2 Typing
+
+```
+return_dtype(options, args):
+    match args[0]:
+        List(elem, n)              => List(body.return_dtype(elem)?, n)
+        FixedSizeList(elem, sz, n) => FixedSizeList(body.return_dtype(elem)?, sz, n)
+        other                      => bail
+```
+
+`Expression::return_dtype(scope)` (`expression.rs:95`) already threads a scope dtype through `root()`, so the body types itself against the element dtype with no new machinery. Note `list_transform` preserves the *fixed-size* structure of FSL inputs (unlike DuckDB, which casts ARRAY→LIST at bind time) — the output needs no offsets, and the FSL layout fast path (no offsets IO) survives the transform.
+
+Nullability: list-level nullability passes through (transform of a null list is a null list).
+Element-level nullability is whatever `body.return_dtype(elem)` says — the body sees the element dtype's nullability and its own semantics decide the output's.
+
+### 4.3 Execution
+
+```rust
+fn execute(&self, options, args, ctx) -> VortexResult<ArrayRef> {
+    let input = args.get(0)?;
+
+    // 1. Constant list: transform the scalar's elements once, wrap in ConstantArray.
+    if let Some(scalar) = input.as_constant() { ... }
+
+    // 2. Reach a structural list encoding (same matcher as list_length).
+    let any_list = input.execute_until::<AnyList>(ctx)?;
+
+    // 3. Rewrap: transform elements, keep structure.
+    //    List:          ListArray::try_new(elements.apply(&options.body)?, offsets, validity)
+    //    FixedSizeList: FixedSizeListArray::new(elements.apply(&options.body)?, size, validity, len)
+    //    ListView:      canonicalize to List first (see below), then as List.
+}
+```
+
+The key property: **`execute` does no element work.** `elements.apply(body)` builds a deferred
+`ScalarFnArray` over the elements child; evaluation happens on demand with full access to
+encoded-array kernels. If the elements child is dictionary-encoded, the body runs over the
+dictionary values; if constant, it folds. This is the structural advantage over DuckDB's
+flatten-into-2048-row-batches loop: DuckDB pays O(total elements) through the executor no matter how the elements were encoded; Vortex pays O(encoded elements).
+
+**Unreferenced elements and fallibility.** Evaluating the *whole* elements child computes results
+for positions no list references. For a canonical `List`, monotonic offsets tile
+`[offsets[0], offsets[len])` with no gaps, so unreferenced positions exist only (a) outside
+`[first, last)` after slicing, and (b) *under null lists*, whose ranges Arrow allows to hold
+arbitrary values. Policy, mirroring the existing dictionary-pushdown rule (`vtable.rs:227`):
+
+- If the body is **infallible** (`x + 1` on wrapping semantics, `get_item`, casts that can't fail):
+evaluate the full child (or the `[first, last)` slice with offsets rebased by `offsets - first`
+when the input was sliced — same arithmetic as `list_length_from_offsets` in reverse). Wasted work on null-list ranges is bounded and harmless.
+- If the body is **fallible** (checked arithmetic, narrowing cast): evaluate only referenced
+elements. v1 does this the blunt way — mask elements under null lists before applying the body (element validity = list validity repeated by lengths), or gather-compact when offsets don't start at zero. This is a correctness requirement, not an optimization: a checked cast must not error on garbage under a null list that the query never observes.
+
+**ListView** ranges may overlap, gap, and reorder — per-position evaluation is still positionally
+correct (the body is elementwise), so an infallible body can be applied to the ListView's elements
+child directly, preserving the view structure (and its element-sharing win: shared elements are
+transformed once). Fallible bodies canonicalize to `List` first. Start with
+canonicalize-always-for-ListView if simpler; it's a performance knob, not semantics.
+
+**Null semantics** (matches DuckDB/ClickHouse/Spark):
+
+| input row | output row |
+| --- | --- |
+| `null` list | `null` list (body never observably runs on its elements) |
+| `[]` | `[]` |
+| `[4, null, 5]` with body `x+1` | `[5, null, 6]` — null elements flow through the body's own null semantics |
+
+`validity(expr)` = `expr.child(0).validity()` (identical to `list_length.rs:101`);
+`is_null_sensitive` = `false`.
+
+### 4.4 Algebraic rewrites (`simplify_untyped`)
+
+These fall out of the representation almost for free and are where the expression-level design
+pays rent:
+
+1. **Identity elimination**: `list_transform(l, x -> x)` → `l` (body is exactly `root()`).
+2. **Fusion**: `list_transform(list_transform(l, f), g)` → `list_transform(l, g[root := f])` — substitute `f` for every `root()` in `g`. One pass over the elements instead of two, and one deferred wrapper instead of a materialized intermediate list. (DuckDB needs a bespoke list-comprehension optimizer rule for a special case of this; here it's a three-line
+substitution because bodies are ordinary expressions.)
+3. **Length preservation**: `list_length(list_transform(l, f))` → `list_length(l)` — implemented in `ListLength::simplify_untyped` (or a shared reduce rule); a transform never changes offsets, so the composition should never fetch elements at all.
+4. **Constant folding** happens through the normal machinery: constant list input takes the
+scalar fast path; constant *elements* fold inside the deferred body evaluation.
+
+Fusion + length-preservation are also the safety net for engines that push down enthusiastically:
+a pathological `list_length(list_transform(...))` from a generated query costs nothing.
+
+### 4.5 Public API
+
+```rust
+/// Transform every element of a list with `body`, preserving list structure.
+///
+/// `body` is evaluated with the list's elements as its root scope: within `body`,
+/// `root()` refers to the element. `list_transform(col("tags"), add(root(), lit(1)))`
+/// is DuckDB's `list_transform(tags, lambda x: x + 1)`.
+pub fn list_transform(input: Expression, body: Expression) -> Expression {
+    ListTransform.new_expr(ListTransformOptions { body }, [input])
+}
+```
+
+in `vortex-array/src/expr/exprs.rs` next to `list_length` (`:765`); vtable registered in
+`scalar_fn/session.rs` (`:61-79`) and declared in `fns/mod.rs`. Python bindings expose it as
+`vx.expr.list_transform(expr, body)` where the element is addressed by the existing root/column builder — worth a follow-up to give Python an ergonomic `element()` alias.
+
+## 5. Layout pushdown
+
+Day one, nothing is required: the FSL layout reader materializes the list and `.apply()`s the whole
+expression (`fixed_size_list/reader.rs:312`), which now simply works for `list_transform` — and because `execute` returns a deferred wrapper, "materializes" still touches only what the body needs.
+
+The real win lands with the shredded `ListLayout` (elements / offsets / validity sub-layouts):
+
+- `projection_evaluation(row_range, list_transform(root(), body), mask)` routes **`body` to the elements child reader** as its own projection over the mapped element range, while offsets and validity stream through untouched — structurally identical to how the struct layout partitions expressions per field (`struct_/reader.rs:316` + `partition_expr`) and how the FSL reader maps row ranges to element ranges in `register_splits` (`fixed_size_list/reader.rs:162`).
+- Composition is where it gets good: `list_transform(col, x -> x.a)` — the elements subtree is a struct layout, `body = get_item("a", root())` partitions to the `a` sub-layout, and the scan reads offsets + `elements.a` only. `list_length(list_transform(...))` after rewrite 4.4(3) reads offsets only. Neither Parquet nor ORC can express either.
+- The scope alignment is exact by construction: the elements reader's dtype *is* the body's root
+scope. No adapter layer.
+
+This section is future work gated on `ListLayout` itself, but it constrains v1: the body must
+remain an inspectable `Expression` (which options-embedding preserves) so the layout reader can extract and route it.
+
+## 6. Engine integration
+
+### 6.1 DuckDB (near-term, real lambdas today)
+
+`vortex-duckdb/src/convert/expr.rs` already converts list functions (`list_length` at `:70-73`). For `list_transform`, DuckDB hands us a `BoundFunctionExpression` whose children are
+`[list, capture...]` and whose **bind data holds the bound body** with slot-indexed leaf
+references (input chunk layout `[index?][element][captures...]`). Conversion for v1:
+
+- function name `list_transform` / `array_transform`, `has_index == false`, zero captures →
+convert the body by mapping `BoundReferenceExpression{slot 0}` → `root()` and recursing through
+the supported-function whitelist; wrap as `list_transform(input, body)`.
+- any capture, index parameter, or unsupported body node → don't push down (DuckDB executes it).
+
+### 6.2 DataFusion (v1 scope — DF 54 ships `array_transform` + lambdas)
+
+The converter follows the `ArrayLength` recipe (`vortex-datafusion/src/convert/exprs.rs:166-195`
+
+- `can_scalar_fn_be_pushed_down:612`), with one structural difference: the physical node is a
+`HigherOrderFunctionExpr`, not a `ScalarFunctionExpr`, so it needs its own downcast arm in
+`convert()` (`:279`) and `can_be_pushed_down_impl` (`:489`) rather than a new entry in the
+scalar-function whitelist.
+
+Conversion for `array_transform(list, LambdaExpr { params: [v], body })`:
+
+1. Convert the list argument as usual (column / `get_item` chain); require it to resolve to
+`List | LargeList | FixedSizeList` (same gating shape as `can_array_length_be_pushed_down`).
+2. Convert `body` recursively with one extra rule: `LambdaVariable` with the innermost lambda's
+index → `root()`. A `LambdaVariable` referring to an *outer* lambda's parameter is a
+capture-across-scopes — not expressible in v1, don't push down. (Upstream DF is capture-free today anyway, #21172.)
+3. Nested `HigherOrderFunctionExpr` inside the body recurses through the same arm — nested
+transforms convert naturally because each level rebinds `root()` (§4.1b).
+4. Multi-parameter lambdas (index form), or any body node outside the supported set → no
+pushdown; DataFusion executes the expression itself, unchanged behavior.
+5. Wrap as `cast(list_transform(input, body), return_dtype)` if DF's declared return field
+disagrees with Vortex's (mirroring the `list_length` cast).
+
+Add an slt suite mirroring `list_length_pushdown.slt`.
+
+### 6.3 Direct consumers
+
+`vortex-scan`/`vortex-file` users and the Python bindings can use the expression immediately —
+worth a benchmark in `vortex-file/benches/` next to the FSL layout bench to keep the
+offsets-passthrough property honest.
+
+## 7. Risks and open questions
+
+1. **DataFusion's HOF API is brand new** (merged 2026-04, one function so far, capture support
+still open upstream as #21172) — expect the `HigherOrderUDF`/`LambdaExpr` surface to move across DF upgrades; keep the converter arm thin and conservative.
+2. **Fallible bodies over unreferenced elements** (§4.3) is the subtlest correctness point. The
+proposed policy reuses the existing `is_fallible` contract, but the null-list-garbage case
+needs a dedicated test with a checked cast as the body.
+3. **Options-embedded expressions are a new pattern.** Nothing in the vtable contract forbids it
+(all trait bounds are satisfied, serde has the session hook), but `list_transform` would be the first — expect to touch display and possibly `expr/arbitrary.rs` (proptest generation) to
+account for it. Any pass discovered to *need* body visibility gets an explicit vtable hook.
+4. **`ScalarFnArray` over elements whose parent list is lazy**: `execute_until::<AnyList>` may
+itself canonicalize a compressed list encoding; confirm the elements child it exposes preserves encodings (it should — that's the point of `execute_until` stopping at the matcher).
+5. **Display ambiguity**: two nested transforms print two scopes; the `x ->` rendering must pick
+distinct parameter names per nesting depth (trivial counter) or accept `$` meaning
+nearest-enclosing scope, documented.
+
+## 8. Future work (in likely order)
+
+1. **`list_filter`** — same options-embedded body returning `Bool`; execution computes an element selection then rebuilds offsets by per-list surviving counts (DuckDB gathers surviving input elements rather than re-evaluating — same trick applies). Requires the offsets-recompute helper that `list_length_from_offsets` is the inverse of.
+2. **Index parameter and captures via struct scope.** Generalize the body's scope from `element` to `struct { elem, idx?, captures... }`: positions from offsets
+(`idx = iota(total) - repeat(starts, lengths)`), captures replicated to element cardinality by `repeat(col, lengths)` — ClickHouse's `replicate(offsets)`, which for Vortex is a `take` with a run-length index array and therefore *stays lazy*. Body addresses them as `get_item("elem", root())` etc. No v1 code changes shape; `ListTransformOptions` grows a `captures: Vec<Expression>` (row-scope, ordinary children semantics — hoisted like DuckDB) and
+`with_index: bool`.
+3. **`list_reduce`** — fundamentally different loop (sequential across positions, parallel across
+rows; accumulator type widening forced DuckDB into double-binding). Do not force it into the
+transform mold; design separately.
+4. **`ListLayout` pushdown** per §5, once the layout exists.
+5. **Pruning through transforms**: `list_max(list_transform(l, f)) > c` ⇒ for monotone `f`, prune with `f`-transformed element zone maps. Speculative; note only.
+
+## 9. Implementation checklist (v1)
+
+- [ ] `vortex-array/src/scalar_fn/fns/list_transform/mod.rs` — `ListTransform` vtable:
+`id`, `arity Exact(1)`, `child_name "input"`, `return_dtype` (§4.2), `execute` (§4.3),
+`validity`/`is_null_sensitive` (as `list_length`), `is_fallible` (delegate to body),
+`serialize`/`deserialize` (body as `pb::Expr`), `fmt_sql`, `simplify_untyped` (§4.4 rules 1–2).
+- [ ] Rule 4.4(3) in `ListLength::simplify_untyped`.
+- [ ] Constructor in `expr/exprs.rs`; registration in `scalar_fn/session.rs`; decl in `fns/mod.rs`.
+- [ ] Tests mirroring `list_length.rs`: rstest over offset widths; nullable lists; null elements;
+empty lists; ListView (incl. overlapping views); FSL (structure preserved); sliced + taken
+inputs (offset rebase); constant input; fallible body over a list with null-list garbage
+ranges; nested `list_transform` over `List<List<i32>>`; fusion/identity rewrites via
+`display_tree` snapshots; serde round-trip through proto.
+- [ ] DuckDB converter arm (§6.1) + sqllogictest mirroring
+`vortex-sqllogictest/slt/datafusion/list_length_pushdown.slt` for the DuckDB path.
+- [ ] Bench in `vortex-file/benches/` (transform-of-projection vs full decode).
+
+---
+
+## Appendix: sources
+
+- DuckDB: PRs #3694 (original lambdas),
+#8851 (n-ary + index, `bind_lambda` callback),
+#9395 (vectorized revamp, ~10³× speedups),
+#9909 (`list_reduce`),
+#17235 (`lambda x:` syntax, `->` deprecation);
+blog: Friendly Lists and Their Buddies, the Lambdas;
+source: `src/planner/binder/expression/bind_lambda.cpp`,
+`extension/core_functions/lambda_functions.cpp` @ `36c64ee8`.
+- ClickHouse: `ColumnFunction::replicate` / `arrayMap` in
+`src/Functions/array/FunctionArrayMapped.h`.
+- Spark: `org.apache.spark.sql.catalyst.expressions.higherOrderFunctions.scala`
+(`HigherOrderFunction`, `LambdaFunction`, `NamedLambdaVariable`, `ArrayTransform`).
+- Velox: lambda functions doc.
+- Polars: `list.eval` / `pl.element()`.
+- Vortex: `vortex-array/src/scalar_fn/{vtable.rs,fns/list_length.rs}`,
+`vortex-array/src/expr/{expression.rs,proto.rs,exprs.rs}`,
+`vortex-layout/src/layouts/fixed_size_list/reader.rs`,
+`vortex-layout/src/layouts/list/list-storage-formats.md`,
+`vortex-datafusion/src/convert/exprs.rs`, `vortex-duckdb/src/convert/expr.rs`.

--- a/vortex-array/src/scalar_fn/fns/list_transform/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_transform/mod.rs
@@ -1,0 +1,604 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use prost::Message;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_proto::expr as pb;
+use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
+
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::IntoArray;
+use crate::arrays::ConstantArray;
+use crate::arrays::FixedSizeList;
+use crate::arrays::FixedSizeListArray;
+use crate::arrays::List;
+use crate::arrays::ListArray;
+use crate::arrays::ListView;
+use crate::arrays::ListViewArray;
+use crate::arrays::fixed_size_list::FixedSizeListArrayExt;
+use crate::arrays::list::ListArrayExt;
+use crate::arrays::listview::ListViewArrayExt;
+use crate::dtype::DType;
+use crate::expr::Expression;
+use crate::expr::label_is_fallible;
+use crate::expr::list_transform;
+use crate::expr::proto::ExprSerializeProtoExt;
+use crate::expr::root;
+use crate::expr::transform::replace;
+use crate::scalar::Scalar;
+use crate::scalar_fn::Arity;
+use crate::scalar_fn::ChildName;
+use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::ScalarFnId;
+use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::fns::list_length::AnyList;
+use crate::scalar_fn::fns::root::Root;
+
+/// Options for [`ListTransform`], holding the lambda body.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ListTransformOptions {
+    /// The lambda body, evaluated with the list's *elements* array as its root scope: within
+    /// this expression, `root()` refers to the element rather than the enclosing row.
+    pub body: Expression,
+}
+
+impl Display for ListTransformOptions {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "-> {}", self.body)
+    }
+}
+
+/// Applies an expression to every element of a `List`, `ListView`, or `FixedSizeList` typed
+/// array, preserving the list structure.
+///
+/// This is the Vortex equivalent of DuckDB's `list_transform(l, lambda x: ...)`: offsets (or
+/// the fixed size) and list-level validity pass through untouched, and only the elements child
+/// is rewritten by applying the body expression with the elements array as its root scope.
+/// Null lists stay null, empty lists stay empty, and null elements flow through the body's own
+/// null semantics.
+#[derive(Clone)]
+pub struct ListTransform;
+
+impl ScalarFnVTable for ListTransform {
+    type Options = ListTransformOptions;
+
+    fn id(&self) -> ScalarFnId {
+        static ID: CachedId = CachedId::new("vortex.list.transform");
+        *ID
+    }
+
+    fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
+        Ok(Some(options.body.serialize_proto()?.encode_to_vec()))
+    }
+
+    fn deserialize(&self, metadata: &[u8], session: &VortexSession) -> VortexResult<Self::Options> {
+        let body = pb::Expr::decode(metadata)?;
+        Ok(ListTransformOptions {
+            body: Expression::from_proto(&body, session)?,
+        })
+    }
+
+    fn arity(&self, _options: &Self::Options) -> Arity {
+        Arity::Exact(1)
+    }
+
+    fn child_name(&self, _options: &Self::Options, child_idx: usize) -> ChildName {
+        match child_idx {
+            0 => ChildName::from("input"),
+            _ => unreachable!("Invalid child index {child_idx} for list_transform()"),
+        }
+    }
+
+    fn fmt_sql(
+        &self,
+        options: &Self::Options,
+        expr: &Expression,
+        f: &mut Formatter<'_>,
+    ) -> fmt::Result {
+        write!(f, "{}(", self.id())?;
+        expr.child(0).fmt_sql(f)?;
+        write!(f, ", -> ")?;
+        options.body.fmt_sql(f)?;
+        write!(f, ")")
+    }
+
+    fn return_dtype(&self, options: &Self::Options, args: &[DType]) -> VortexResult<DType> {
+        match &args[0] {
+            DType::List(elem, nullable) => Ok(DType::List(
+                options.body.return_dtype(elem)?.into(),
+                *nullable,
+            )),
+            DType::FixedSizeList(elem, size, nullable) => Ok(DType::FixedSizeList(
+                options.body.return_dtype(elem)?.into(),
+                *size,
+                *nullable,
+            )),
+            other => vortex_bail!("list_transform() requires List or FixedSizeList, got {other}"),
+        }
+    }
+
+    fn execute(
+        &self,
+        options: &Self::Options,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let input = args.get(0)?;
+
+        if let Some(scalar) = input.as_constant() {
+            let transformed = transform_scalar(&scalar, options, ctx)?;
+            return Ok(ConstantArray::new(transformed, args.row_count()).into_array());
+        }
+
+        let any_list = input.execute_until::<AnyList>(ctx)?;
+        transform_list(&any_list, &options.body)
+    }
+
+    fn simplify_untyped(
+        &self,
+        options: &Self::Options,
+        expr: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        // Identity: list_transform(l, x -> x) == l.
+        if options.body.is::<Root>() {
+            return Ok(Some(expr.child(0).clone()));
+        }
+
+        // Fusion: list_transform(list_transform(l, f), g) == list_transform(l, g[root := f]).
+        // Substitution only touches the outer body's children, so a nested transform inside `g`
+        // keeps its own body (and root scope) intact while its input is still rewritten.
+        let input = expr.child(0);
+        if let Some(inner) = input.as_opt::<ListTransform>() {
+            let fused = replace(options.body.clone(), &root(), inner.body.clone());
+            return Ok(Some(list_transform(input.child(0).clone(), fused)));
+        }
+
+        Ok(None)
+    }
+
+    fn validity(
+        &self,
+        _options: &Self::Options,
+        expression: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        Ok(Some(expression.child(0).validity()?))
+    }
+
+    fn is_null_sensitive(&self, _options: &Self::Options) -> bool {
+        false
+    }
+
+    fn is_fallible(&self, options: &Self::Options) -> bool {
+        // This node evaluates the whole body, so its fallibility is the body's. The body lives
+        // in the options rather than as a child, so generic tree walks cannot see it.
+        label_is_fallible(&options.body)
+            .get(&options.body)
+            .copied()
+            .unwrap_or(true)
+    }
+}
+
+/// Transform each list of `any_list` (a `List`, `ListView`, or `FixedSizeList` array) by
+/// applying `body` to its elements child, preserving the list structure.
+///
+/// The elements are wrapped in a deferred expression array, so no element values are computed
+/// here. Note that this evaluates `body` over every position of the elements child, including
+/// positions referenced only by null lists.
+// TODO(#design §4.3): fallible bodies should not be evaluated over elements referenced only by
+// null lists, which Arrow permits to hold arbitrary values.
+fn transform_list(any_list: &ArrayRef, body: &Expression) -> VortexResult<ArrayRef> {
+    if let Some(fsl) = any_list.as_opt::<FixedSizeList>() {
+        let elements = fsl.elements().clone().apply(body)?;
+        Ok(
+            FixedSizeListArray::new(elements, fsl.list_size(), fsl.validity()?, fsl.len())
+                .into_array(),
+        )
+    } else if let Some(lv) = any_list.as_opt::<ListView>() {
+        let elements = lv.elements().clone().apply(body)?;
+        Ok(ListViewArray::new(
+            elements,
+            lv.offsets().clone(),
+            lv.sizes().clone(),
+            lv.listview_validity(),
+        )
+        .into_array())
+    } else if let Some(l) = any_list.as_opt::<List>() {
+        let elements = l.elements().clone().apply(body)?;
+        Ok(ListArray::try_new(elements, l.offsets().clone(), l.list_validity())?.into_array())
+    } else {
+        let dtype = any_list.dtype();
+        vortex_bail!("list_transform() requires List, ListView, or FixedSizeList but got {dtype}")
+    }
+}
+
+/// Transform a constant list scalar by transforming a single-row list array and extracting the
+/// resulting scalar.
+fn transform_scalar(
+    scalar: &Scalar,
+    options: &ListTransformOptions,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Scalar> {
+    let out_dtype = ListTransform.return_dtype(options, std::slice::from_ref(scalar.dtype()))?;
+    if scalar.is_null() {
+        return Ok(Scalar::null(out_dtype));
+    }
+
+    let one_row = ConstantArray::new(scalar.clone(), 1)
+        .into_array()
+        .execute_until::<AnyList>(ctx)?;
+    transform_list(&one_row, &options.body)?.execute_scalar(0, ctx)
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
+
+    use crate::ArrayRef;
+    use crate::IntoArray;
+    use crate::VortexSessionExecute;
+    use crate::array_session;
+    use crate::arrays::BoolArray;
+    use crate::arrays::ConstantArray;
+    use crate::arrays::FixedSizeListArray;
+    use crate::arrays::ListArray;
+    use crate::arrays::ListViewArray;
+    use crate::arrays::PrimitiveArray;
+    use crate::assert_arrays_eq;
+    use crate::dtype::DType;
+    use crate::dtype::Nullability;
+    use crate::dtype::PType;
+    use crate::expr::checked_add;
+    use crate::expr::get_item;
+    use crate::expr::list_length;
+    use crate::expr::list_transform;
+    use crate::expr::lit;
+    use crate::expr::pack;
+    use crate::expr::root;
+    use crate::validity::Validity;
+
+    fn create_list_elements() -> ArrayRef {
+        PrimitiveArray::from_option_iter::<i32, _>([
+            Some(1),
+            Some(2),
+            Some(3),
+            Some(4),
+            Some(5),
+            Some(6),
+            None,
+        ])
+        .into_array()
+    }
+
+    fn incremented_elements() -> ArrayRef {
+        PrimitiveArray::from_option_iter::<i32, _>([
+            Some(2),
+            Some(3),
+            Some(4),
+            Some(5),
+            Some(6),
+            Some(7),
+            None,
+        ])
+        .into_array()
+    }
+
+    #[rstest]
+    #[case(buffer![0u32, 2, 5, 5, 7].into_array())]
+    #[case(buffer![0u64, 2, 5, 5, 7].into_array())]
+    fn test_list_transform(#[case] offsets: ArrayRef) -> VortexResult<()> {
+        let list = ListArray::try_new(
+            create_list_elements(),
+            offsets.clone(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let result = list.apply(&list_transform(root(), checked_add(root(), lit(1))))?;
+
+        let expected = ListArray::try_new(incremented_elements(), offsets, Validity::NonNullable)?
+            .into_array();
+
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn test_nullable_list_transform() -> VortexResult<()> {
+        let validity =
+            Validity::Array(BoolArray::from_iter([true, false, true, false]).into_array());
+        let list = ListArray::try_new(
+            create_list_elements(),
+            buffer![0u32, 2, 5, 5, 7].into_array(),
+            validity.clone(),
+        )?
+        .into_array();
+        let result = list.apply(&list_transform(root(), checked_add(root(), lit(1))))?;
+
+        let expected = ListArray::try_new(
+            incremented_elements(),
+            buffer![0u32, 2, 5, 5, 7].into_array(),
+            validity,
+        )?
+        .into_array();
+
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn test_listview_transform() -> VortexResult<()> {
+        let lv = ListViewArray::new(
+            create_list_elements(),
+            buffer![5u32, 0, 4, 1].into_array(),
+            buffer![2u32, 3, 0, 2].into_array(),
+            Validity::NonNullable,
+        )
+        .into_array();
+        let result = lv.apply(&list_transform(root(), checked_add(root(), lit(1))))?;
+
+        let expected = ListViewArray::new(
+            incremented_elements(),
+            buffer![5u32, 0, 4, 1].into_array(),
+            buffer![2u32, 3, 0, 2].into_array(),
+            Validity::NonNullable,
+        )
+        .into_array();
+
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn test_fixed_size_list_transform() -> VortexResult<()> {
+        let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5, 6, 7, 8]).into_array();
+        let fsl = FixedSizeListArray::new(elements, 2, Validity::NonNullable, 4).into_array();
+        let result = fsl.apply(&list_transform(root(), checked_add(root(), lit(1))))?;
+
+        // The fixed-size structure is preserved.
+        assert!(matches!(result.dtype(), DType::FixedSizeList(_, 2, _)));
+
+        let expected_elements = PrimitiveArray::from_iter([2i32, 3, 4, 5, 6, 7, 8, 9]).into_array();
+        let expected =
+            FixedSizeListArray::new(expected_elements, 2, Validity::NonNullable, 4).into_array();
+
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn test_constant_list_transform() -> VortexResult<()> {
+        let list = ListArray::try_new(
+            PrimitiveArray::from_iter([1i32, 2, 3]).into_array(),
+            buffer![0u32, 3].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+
+        let mut ctx = array_session().create_execution_ctx();
+        let scalar = list.execute_scalar(0, &mut ctx)?;
+        let constant = ConstantArray::new(scalar, 4).into_array();
+
+        let result = constant.apply(&list_transform(root(), checked_add(root(), lit(1))))?;
+
+        let expected = ListArray::try_new(
+            PrimitiveArray::from_iter([2i32, 3, 4, 2, 3, 4, 2, 3, 4, 2, 3, 4]).into_array(),
+            buffer![0u32, 3, 6, 9, 12].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn test_null_constant_list_transform() -> VortexResult<()> {
+        let null_scalar = crate::scalar::Scalar::null(DType::List(
+            std::sync::Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
+            Nullability::Nullable,
+        ));
+        let constant = ConstantArray::new(null_scalar, 2).into_array();
+        let result = constant.apply(&list_transform(root(), checked_add(root(), lit(1))))?;
+
+        let mut ctx = array_session().create_execution_ctx();
+        assert!(!result.is_valid(0, &mut ctx)?);
+        assert!(!result.is_valid(1, &mut ctx)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_list_transform_take() -> VortexResult<()> {
+        let list = ListArray::try_new(
+            create_list_elements(),
+            buffer![0u32, 2, 5, 5, 7].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let taken = list.take(buffer![3u64, 0, 2].into_array())?;
+
+        let result = taken.apply(&list_transform(root(), checked_add(root(), lit(1))))?;
+
+        // Transform-then-take equals take-then-transform.
+        let expected = list
+            .apply(&list_transform(root(), checked_add(root(), lit(1))))?
+            .take(buffer![3u64, 0, 2].into_array())?;
+
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn test_nested_list_transform() -> VortexResult<()> {
+        // [[1, 2], [3]], [], [[4, 5]]
+        let inner = ListArray::try_new(
+            PrimitiveArray::from_iter([1i32, 2, 3, 4, 5]).into_array(),
+            buffer![0u32, 2, 3, 5].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let outer = ListArray::try_new(
+            inner,
+            buffer![0u32, 2, 2, 3].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+
+        // Increment every innermost element: the outer body's root is the inner list, and the
+        // inner body's root is the innermost element.
+        let expr = list_transform(root(), list_transform(root(), checked_add(root(), lit(1))));
+        let result = outer.apply(&expr)?;
+
+        let expected_inner = ListArray::try_new(
+            PrimitiveArray::from_iter([2i32, 3, 4, 5, 6]).into_array(),
+            buffer![0u32, 2, 3, 5].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let expected = ListArray::try_new(
+            expected_inner,
+            buffer![0u32, 2, 2, 3].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn test_struct_element_transform() -> VortexResult<()> {
+        // Transform a list of structs into a list of one of its fields: x -> x.a
+        let a = PrimitiveArray::from_iter([1i32, 2, 3]).into_array();
+        let b = PrimitiveArray::from_iter([10i32, 20, 30]).into_array();
+        let elements = crate::arrays::StructArray::try_new(
+            ["a", "b"].into(),
+            vec![a.clone(), b],
+            3,
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let list = ListArray::try_new(
+            elements,
+            buffer![0u32, 1, 3].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+
+        let result = list.apply(&list_transform(root(), get_item("a", root())))?;
+
+        let expected =
+            ListArray::try_new(a, buffer![0u32, 1, 3].into_array(), Validity::NonNullable)?
+                .into_array();
+
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn test_identity_simplification() -> VortexResult<()> {
+        let input = get_item("tags", root());
+        let expr = list_transform(input.clone(), root());
+        assert_eq!(expr.scalar_fn().simplify_untyped(&expr)?, Some(input));
+        Ok(())
+    }
+
+    #[test]
+    fn test_fusion_simplification() -> VortexResult<()> {
+        let input = get_item("tags", root());
+        let f = checked_add(root(), lit(1));
+        let g = checked_add(root(), lit(2));
+        let expr = list_transform(list_transform(input.clone(), f.clone()), g);
+
+        let expected = list_transform(input, checked_add(f, lit(2)));
+        assert_eq!(expr.scalar_fn().simplify_untyped(&expr)?, Some(expected));
+        Ok(())
+    }
+
+    #[test]
+    fn test_fusion_preserves_nested_scope() -> VortexResult<()> {
+        // The outer body contains a nested transform: its input (a child) is in the outer
+        // scope and must be substituted, while its own body must be left untouched.
+        let f = get_item("a", root());
+        let g = list_transform(root(), checked_add(root(), lit(1)));
+        let expr = list_transform(list_transform(get_item("tags", root()), f.clone()), g);
+
+        let expected = list_transform(
+            get_item("tags", root()),
+            list_transform(f, checked_add(root(), lit(1))),
+        );
+        assert_eq!(expr.scalar_fn().simplify_untyped(&expr)?, Some(expected));
+        Ok(())
+    }
+
+    #[test]
+    fn test_list_length_of_transform_simplification() -> VortexResult<()> {
+        let input = get_item("tags", root());
+        let expr = list_length(list_transform(input.clone(), checked_add(root(), lit(1))));
+        assert_eq!(
+            expr.scalar_fn().simplify_untyped(&expr)?,
+            Some(list_length(input))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_serde_roundtrip() -> VortexResult<()> {
+        use prost::Message;
+
+        use crate::expr::proto::ExprSerializeProtoExt;
+
+        let expr = list_transform(
+            get_item("tags", root()),
+            checked_add(get_item("a", root()), lit(1)),
+        );
+
+        let buf = expr.serialize_proto()?.encode_to_vec();
+        let decoded = vortex_proto::expr::Expr::decode(buf.as_slice())?;
+        let roundtrip = crate::expr::Expression::from_proto(&decoded, &array_session())?;
+
+        assert_eq!(roundtrip, expr);
+        Ok(())
+    }
+
+    #[test]
+    fn test_return_dtype() -> VortexResult<()> {
+        let expr = list_transform(root(), pack([("x", root())], Nullability::NonNullable));
+        let scope = DType::List(
+            std::sync::Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
+            Nullability::Nullable,
+        );
+        let dtype = expr.return_dtype(&scope)?;
+
+        // List nullability passes through; the element dtype is the body's return dtype.
+        let DType::List(elem, Nullability::Nullable) = dtype else {
+            panic!("expected nullable list dtype");
+        };
+        assert!(matches!(elem.as_ref(), DType::Struct(..)));
+        Ok(())
+    }
+
+    #[test]
+    fn test_display() {
+        let body = checked_add(root(), lit(1));
+        let expr = list_transform(root(), body.clone());
+        assert_eq!(
+            expr.to_string(),
+            format!("vortex.list.transform($, -> {body})")
+        );
+    }
+}

--- a/vortex-array/src/scalar_fn/fns/list_transform/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_transform/mod.rs
@@ -6,6 +6,7 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 
 use prost::Message;
+use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_proto::expr as pb;
@@ -13,6 +14,7 @@ use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
@@ -22,12 +24,15 @@ use crate::arrays::List;
 use crate::arrays::ListArray;
 use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
+use crate::arrays::PrimitiveArray;
 use crate::arrays::fixed_size_list::FixedSizeListArrayExt;
 use crate::arrays::list::ListArrayExt;
 use crate::arrays::listview::ListViewArrayExt;
+use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
+use crate::dtype::Nullability;
+use crate::dtype::PType;
 use crate::expr::Expression;
-use crate::expr::label_is_fallible;
 use crate::expr::list_transform;
 use crate::expr::proto::ExprSerializeProtoExt;
 use crate::expr::root;
@@ -38,8 +43,10 @@ use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::SimplifyCtx;
 use crate::scalar_fn::fns::list_length::AnyList;
 use crate::scalar_fn::fns::root::Root;
+use crate::validity::Validity;
 
 /// Options for [`ListTransform`], holding the lambda body.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -75,7 +82,10 @@ impl ScalarFnVTable for ListTransform {
     }
 
     fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
-        Ok(Some(options.body.serialize_proto()?.encode_to_vec()))
+        Ok(options
+            .body
+            .try_serialize_proto()?
+            .map(|body| body.encode_to_vec()))
     }
 
     fn deserialize(&self, metadata: &[u8], session: &VortexSession) -> VortexResult<Self::Options> {
@@ -104,9 +114,7 @@ impl ScalarFnVTable for ListTransform {
     ) -> fmt::Result {
         write!(f, "{}(", self.id())?;
         expr.child(0).fmt_sql(f)?;
-        write!(f, ", -> ")?;
-        options.body.fmt_sql(f)?;
-        write!(f, ")")
+        write!(f, ", {})", options)
     }
 
     fn return_dtype(&self, options: &Self::Options, args: &[DType]) -> VortexResult<DType> {
@@ -132,13 +140,20 @@ impl ScalarFnVTable for ListTransform {
     ) -> VortexResult<ArrayRef> {
         let input = args.get(0)?;
 
+        // A zero-row batch must not evaluate the body: with a constant input, the eager scalar
+        // path below could error on element values no row observes.
+        if args.row_count() == 0 {
+            let out_dtype = self.return_dtype(options, std::slice::from_ref(input.dtype()))?;
+            return Ok(Canonical::empty(&out_dtype).into_array());
+        }
+
         if let Some(scalar) = input.as_constant() {
             let transformed = transform_scalar(&scalar, options, ctx)?;
             return Ok(ConstantArray::new(transformed, args.row_count()).into_array());
         }
 
         let any_list = input.execute_until::<AnyList>(ctx)?;
-        transform_list(&any_list, &options.body)
+        transform_list(&any_list, &options.body, ctx)
     }
 
     fn simplify_untyped(
@@ -146,18 +161,53 @@ impl ScalarFnVTable for ListTransform {
         options: &Self::Options,
         expr: &Expression,
     ) -> VortexResult<Option<Expression>> {
+        // Fusion: list_transform(list_transform(l, f), g) == list_transform(l, g[root := f]).
+        // Substitution only touches the outer body's children, so a nested transform inside `g`
+        // keeps its own body (and root scope) intact while its input is still rewritten.
+        //
+        // The whole transform chain is collapsed in a single rewrite so that deep chains do not
+        // exhaust the optimizer's per-node iteration budget, and only bodies with at most one
+        // root reference are fused, since each substitution duplicates the inner body once per
+        // root occurrence (multiplying across fusion steps).
+        let mut input = expr.child(0);
+        let mut body = options.body.clone();
+        let mut fused = false;
+        while let Some(inner) = input.as_opt::<ListTransform>() {
+            if count_root_refs(&body) > 1 {
+                break;
+            }
+            body = replace(body, &root(), inner.body.clone());
+            input = input.child(0);
+            fused = true;
+        }
+
+        Ok(fused.then(|| list_transform(input.clone(), body)))
+    }
+
+    fn simplify(
+        &self,
+        options: &Self::Options,
+        expr: &Expression,
+        ctx: &dyn SimplifyCtx,
+    ) -> VortexResult<Option<Expression>> {
+        // If the input is not list-typed, leave the node intact so the type error still
+        // surfaces through return_dtype rather than being rewritten away.
+        let input_dtype = ctx.return_dtype(expr.child(0))?;
+        let element_dtype = match &input_dtype {
+            DType::List(elem, _) | DType::FixedSizeList(elem, ..) => elem.as_ref().clone(),
+            _ => return Ok(None),
+        };
+
         // Identity: list_transform(l, x -> x) == l.
         if options.body.is::<Root>() {
             return Ok(Some(expr.child(0).clone()));
         }
 
-        // Fusion: list_transform(list_transform(l, f), g) == list_transform(l, g[root := f]).
-        // Substitution only touches the outer body's children, so a nested transform inside `g`
-        // keeps its own body (and root scope) intact while its input is still rewritten.
-        let input = expr.child(0);
-        if let Some(inner) = input.as_opt::<ListTransform>() {
-            let fused = replace(options.body.clone(), &root(), inner.body.clone());
-            return Ok(Some(list_transform(input.child(0).clone(), fused)));
+        // The body is invisible to the optimizer's children traversal, so optimize it here
+        // against its own scope: the element dtype.
+        let optimized = options.body.optimize_recursive(&element_dtype)?;
+        if optimized != options.body {
+            return Ok(Some(list_transform(expr.child(0).clone(), optimized)));
         }
 
         Ok(None)
@@ -178,22 +228,42 @@ impl ScalarFnVTable for ListTransform {
     fn is_fallible(&self, options: &Self::Options) -> bool {
         // This node evaluates the whole body, so its fallibility is the body's. The body lives
         // in the options rather than as a child, so generic tree walks cannot see it.
-        label_is_fallible(&options.body)
-            .get(&options.body)
-            .copied()
-            .unwrap_or(true)
+        expr_is_fallible(&options.body)
     }
+}
+
+/// Whether any node of the expression is fallible. A nested `list_transform` inside the tree
+/// reports its own body's fallibility through its signature.
+fn expr_is_fallible(expr: &Expression) -> bool {
+    expr.signature().is_fallible() || expr.children().iter().any(expr_is_fallible)
+}
+
+/// The number of `root()` references in the expression. Does not descend into options-embedded
+/// bodies of nested `list_transform` nodes, whose root refers to their own scope.
+fn count_root_refs(expr: &Expression) -> usize {
+    if expr.is::<Root>() {
+        return 1;
+    }
+    expr.children().iter().map(count_root_refs).sum()
 }
 
 /// Transform each list of `any_list` (a `List`, `ListView`, or `FixedSizeList` array) by
 /// applying `body` to its elements child, preserving the list structure.
 ///
-/// The elements are wrapped in a deferred expression array, so no element values are computed
-/// here. Note that this evaluates `body` over every position of the elements child, including
-/// positions referenced only by null lists.
-// TODO(#design §4.3): fallible bodies should not be evaluated over elements referenced only by
-// null lists, which Arrow permits to hold arbitrary values.
-fn transform_list(any_list: &ArrayRef, body: &Expression) -> VortexResult<ArrayRef> {
+/// For infallible bodies the elements are wrapped in a deferred expression array, so no element
+/// values are computed here. A fallible body must only be evaluated over elements some visible
+/// list references — ListView gaps, and ranges under null lists (which Arrow permits to hold
+/// arbitrary values), could otherwise raise errors from data that is not logically part of the
+/// array — so that path first gathers the referenced elements into a compact `List`.
+///
+/// A fallible body over a `FixedSizeList` with null lists still evaluates the null rows' element
+/// strides: the fixed-size structure cannot drop them. Canonical null FSL rows hold default
+/// values rather than garbage, so this only matters for externally-created arrays.
+fn transform_list(
+    any_list: &ArrayRef,
+    body: &Expression,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
     if let Some(fsl) = any_list.as_opt::<FixedSizeList>() {
         let elements = fsl.elements().clone().apply(body)?;
         Ok(
@@ -201,6 +271,18 @@ fn transform_list(any_list: &ArrayRef, body: &Expression) -> VortexResult<ArrayR
                 .into_array(),
         )
     } else if let Some(lv) = any_list.as_opt::<ListView>() {
+        if expr_is_fallible(body) {
+            let validity = lv.listview_validity();
+            let (elements, offsets) = gather_referenced_elements(
+                lv.elements(),
+                lv.offsets(),
+                Some(lv.sizes()),
+                &validity,
+                lv.len(),
+                ctx,
+            )?;
+            return Ok(ListArray::try_new(elements.apply(body)?, offsets, validity)?.into_array());
+        }
         let elements = lv.elements().clone().apply(body)?;
         Ok(ListViewArray::new(
             elements,
@@ -210,12 +292,72 @@ fn transform_list(any_list: &ArrayRef, body: &Expression) -> VortexResult<ArrayR
         )
         .into_array())
     } else if let Some(l) = any_list.as_opt::<List>() {
+        let validity = l.list_validity();
+        // A canonical List's offsets tile the referenced range contiguously, so unreferenced
+        // positions exist only under null lists.
+        if expr_is_fallible(body) && !matches!(validity, Validity::NonNullable | Validity::AllValid)
+        {
+            let (elements, offsets) = gather_referenced_elements(
+                l.elements(),
+                l.offsets(),
+                None,
+                &validity,
+                l.len(),
+                ctx,
+            )?;
+            return Ok(ListArray::try_new(elements.apply(body)?, offsets, validity)?.into_array());
+        }
         let elements = l.elements().clone().apply(body)?;
         Ok(ListArray::try_new(elements, l.offsets().clone(), l.list_validity())?.into_array())
     } else {
         let dtype = any_list.dtype();
         vortex_bail!("list_transform() requires List, ListView, or FixedSizeList but got {dtype}")
     }
+}
+
+/// Gather exactly the elements referenced by valid lists into a compact elements array with
+/// dense offsets, so a fallible body never observes unreferenced positions.
+///
+/// `sizes` is `Some` for ListView semantics (`elements[offsets[i]..offsets[i] + sizes[i]]`) and
+/// `None` for List semantics (`elements[offsets[i]..offsets[i + 1]]`). Null lists contribute
+/// zero-length ranges; the caller reattaches the original validity.
+fn gather_referenced_elements(
+    elements: &ArrayRef,
+    offsets: &ArrayRef,
+    sizes: Option<&ArrayRef>,
+    validity: &Validity,
+    len: usize,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<(ArrayRef, ArrayRef)> {
+    let u64_dtype = DType::Primitive(PType::U64, Nullability::NonNullable);
+    let offsets = offsets
+        .cast(u64_dtype.clone())?
+        .execute::<PrimitiveArray>(ctx)?;
+    let offsets = offsets.as_slice::<u64>();
+    let sizes = sizes
+        .map(|sizes| sizes.cast(u64_dtype)?.execute::<PrimitiveArray>(ctx))
+        .transpose()?;
+    let sizes = sizes.as_ref().map(|sizes| sizes.as_slice::<u64>());
+
+    let mask = validity.execute_mask(len, ctx)?;
+
+    let mut indices = BufferMut::<u64>::empty();
+    let mut new_offsets = BufferMut::<u64>::with_capacity(len + 1);
+    new_offsets.push(0);
+    for row in 0..len {
+        if mask.value(row) {
+            let start = offsets[row];
+            let end = match sizes {
+                Some(sizes) => start + sizes[row],
+                None => offsets[row + 1],
+            };
+            indices.extend(start..end);
+        }
+        new_offsets.push(indices.len() as u64);
+    }
+
+    let gathered = elements.take(indices.freeze().into_array())?;
+    Ok((gathered, new_offsets.freeze().into_array()))
 }
 
 /// Transform a constant list scalar by transforming a single-row list array and extracting the
@@ -233,15 +375,21 @@ fn transform_scalar(
     let one_row = ConstantArray::new(scalar.clone(), 1)
         .into_array()
         .execute_until::<AnyList>(ctx)?;
-    transform_list(&one_row, &options.body)?.execute_scalar(0, ctx)
+    transform_list(&one_row, &options.body, ctx)?.execute_scalar(0, ctx)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use prost::Message;
     use rstest::rstest;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
+    use vortex_error::vortex_bail;
+    use vortex_proto::expr as pb;
 
+    use super::ListTransform;
     use crate::ArrayRef;
     use crate::IntoArray;
     use crate::VortexSessionExecute;
@@ -252,18 +400,31 @@ mod tests {
     use crate::arrays::ListArray;
     use crate::arrays::ListViewArray;
     use crate::arrays::PrimitiveArray;
+    use crate::arrays::StructArray;
     use crate::assert_arrays_eq;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
     use crate::dtype::PType;
+    use crate::expr::Expression;
+    use crate::expr::and;
+    use crate::expr::cast;
     use crate::expr::checked_add;
     use crate::expr::get_item;
     use crate::expr::list_length;
     use crate::expr::list_transform;
     use crate::expr::lit;
     use crate::expr::pack;
+    use crate::expr::proto::ExprSerializeProtoExt;
     use crate::expr::root;
+    use crate::scalar::Scalar;
     use crate::validity::Validity;
+
+    fn i32_list_dtype() -> DType {
+        DType::List(
+            Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
+            Nullability::NonNullable,
+        )
+    }
 
     fn create_list_elements() -> ArrayRef {
         PrimitiveArray::from_option_iter::<i32, _>([
@@ -365,9 +526,6 @@ mod tests {
         let fsl = FixedSizeListArray::new(elements, 2, Validity::NonNullable, 4).into_array();
         let result = fsl.apply(&list_transform(root(), checked_add(root(), lit(1))))?;
 
-        // The fixed-size structure is preserved.
-        assert!(matches!(result.dtype(), DType::FixedSizeList(_, 2, _)));
-
         let expected_elements = PrimitiveArray::from_iter([2i32, 3, 4, 5, 6, 7, 8, 9]).into_array();
         let expected =
             FixedSizeListArray::new(expected_elements, 2, Validity::NonNullable, 4).into_array();
@@ -405,8 +563,8 @@ mod tests {
 
     #[test]
     fn test_null_constant_list_transform() -> VortexResult<()> {
-        let null_scalar = crate::scalar::Scalar::null(DType::List(
-            std::sync::Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
+        let null_scalar = Scalar::null(DType::List(
+            Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
             Nullability::Nullable,
         ));
         let constant = ConstantArray::new(null_scalar, 2).into_array();
@@ -484,7 +642,7 @@ mod tests {
         // Transform a list of structs into a list of one of its fields: x -> x.a
         let a = PrimitiveArray::from_iter([1i32, 2, 3]).into_array();
         let b = PrimitiveArray::from_iter([10i32, 20, 30]).into_array();
-        let elements = crate::arrays::StructArray::try_new(
+        let elements = StructArray::try_new(
             ["a", "b"].into(),
             vec![a.clone(), b],
             3,
@@ -511,9 +669,32 @@ mod tests {
 
     #[test]
     fn test_identity_simplification() -> VortexResult<()> {
-        let input = get_item("tags", root());
-        let expr = list_transform(input.clone(), root());
-        assert_eq!(expr.scalar_fn().simplify_untyped(&expr)?, Some(input));
+        let expr = list_transform(root(), root());
+        assert_eq!(expr.optimize_recursive(&i32_list_dtype())?, root());
+        Ok(())
+    }
+
+    #[test]
+    fn test_identity_preserves_type_error() -> VortexResult<()> {
+        // The identity rewrite is type-gated: an ill-typed non-list input must keep failing
+        // return_dtype instead of being rewritten into a well-typed non-list expression.
+        let expr = list_transform(lit(5), root());
+        let scope = DType::Primitive(PType::I32, Nullability::NonNullable);
+        let optimized = expr.optimize_recursive(&scope)?;
+        assert!(optimized.return_dtype(&scope).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_body_is_optimized() -> VortexResult<()> {
+        // The body simplifies to root() against its element scope, after which the identity
+        // rule collapses the whole transform.
+        let expr = list_transform(root(), and(root(), lit(true)));
+        let scope = DType::List(
+            Arc::new(DType::Bool(Nullability::NonNullable)),
+            Nullability::NonNullable,
+        );
+        assert_eq!(expr.optimize_recursive(&scope)?, root());
         Ok(())
     }
 
@@ -558,18 +739,14 @@ mod tests {
 
     #[test]
     fn test_serde_roundtrip() -> VortexResult<()> {
-        use prost::Message;
-
-        use crate::expr::proto::ExprSerializeProtoExt;
-
         let expr = list_transform(
             get_item("tags", root()),
             checked_add(get_item("a", root()), lit(1)),
         );
 
         let buf = expr.serialize_proto()?.encode_to_vec();
-        let decoded = vortex_proto::expr::Expr::decode(buf.as_slice())?;
-        let roundtrip = crate::expr::Expression::from_proto(&decoded, &array_session())?;
+        let decoded = pb::Expr::decode(buf.as_slice())?;
+        let roundtrip = Expression::from_proto(&decoded, &array_session())?;
 
         assert_eq!(roundtrip, expr);
         Ok(())
@@ -579,14 +756,14 @@ mod tests {
     fn test_return_dtype() -> VortexResult<()> {
         let expr = list_transform(root(), pack([("x", root())], Nullability::NonNullable));
         let scope = DType::List(
-            std::sync::Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
+            Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
             Nullability::Nullable,
         );
         let dtype = expr.return_dtype(&scope)?;
 
         // List nullability passes through; the element dtype is the body's return dtype.
-        let DType::List(elem, Nullability::Nullable) = dtype else {
-            panic!("expected nullable list dtype");
+        let DType::List(elem, Nullability::Nullable) = &dtype else {
+            vortex_bail!("expected nullable list dtype, got {dtype}");
         };
         assert!(matches!(elem.as_ref(), DType::Struct(..)));
         Ok(())
@@ -600,5 +777,131 @@ mod tests {
             expr.to_string(),
             format!("vortex.list.transform($, -> {body})")
         );
+    }
+
+    #[test]
+    fn test_fallible_body_skips_listview_gaps() -> VortexResult<()> {
+        // Visible data is [[1], [3]]; the gap element (i32::MAX) is referenced by no view and
+        // must not be evaluated by the fallible body.
+        let lv = ListViewArray::new(
+            PrimitiveArray::from_iter([1i32, i32::MAX, 3]).into_array(),
+            buffer![0u32, 2].into_array(),
+            buffer![1u32, 1].into_array(),
+            Validity::NonNullable,
+        )
+        .into_array();
+        let result = lv.apply(&list_transform(root(), checked_add(root(), lit(1))))?;
+
+        let expected = ListArray::try_new(
+            PrimitiveArray::from_iter([2i32, 4]).into_array(),
+            buffer![0u64, 1, 2].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn test_fallible_body_skips_null_list_garbage() -> VortexResult<()> {
+        // Arrow permits a null list to reference arbitrary element values; the fallible body
+        // must not error on them.
+        let list = ListArray::try_new(
+            PrimitiveArray::from_iter([1i32, i32::MAX]).into_array(),
+            buffer![0u32, 1, 2].into_array(),
+            Validity::Array(BoolArray::from_iter([true, false]).into_array()),
+        )?
+        .into_array();
+        let result = list.apply(&list_transform(root(), checked_add(root(), lit(1))))?;
+
+        let expected = ListArray::try_new(
+            PrimitiveArray::from_iter([2i32]).into_array(),
+            buffer![0u64, 1, 1].into_array(),
+            Validity::Array(BoolArray::from_iter([true, false]).into_array()),
+        )?
+        .into_array();
+
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn test_zero_row_constant_fallible_body() -> VortexResult<()> {
+        let list = ListArray::try_new(
+            PrimitiveArray::from_iter([i32::MAX]).into_array(),
+            buffer![0u32, 1].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+
+        let mut ctx = array_session().create_execution_ctx();
+        let scalar = list.execute_scalar(0, &mut ctx)?;
+        let constant = ConstantArray::new(scalar, 0).into_array();
+
+        // A zero-row batch must not evaluate the body over the constant's elements.
+        let result = constant.apply(&list_transform(root(), checked_add(root(), lit(1))))?;
+        let result = result.execute::<ArrayRef>(&mut ctx)?;
+        assert_eq!(result.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_null_fsl_constant_fallible_body() -> VortexResult<()> {
+        // A null FixedSizeList constant canonicalizes to default-filled placeholder elements;
+        // a fallible body must not run over them.
+        let null_scalar = Scalar::null(DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::I32, Nullability::Nullable)),
+            2,
+            Nullability::Nullable,
+        ));
+        let constant = ConstantArray::new(null_scalar, 3).into_array();
+
+        let body = cast(
+            root(),
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+        );
+        let result = constant.apply(&list_transform(root(), body))?;
+
+        let mut ctx = array_session().create_execution_ctx();
+        assert!(!result.is_valid(0, &mut ctx)?);
+        assert!(!result.is_valid(2, &mut ctx)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_fusion_skips_multi_root_bodies() -> VortexResult<()> {
+        // Fusing a body with multiple root references would duplicate the inner body per
+        // occurrence, so it is skipped.
+        let inner = list_transform(get_item("tags", root()), checked_add(root(), lit(1)));
+        let expr = list_transform(inner, checked_add(root(), root()));
+        assert_eq!(expr.scalar_fn().simplify_untyped(&expr)?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_deep_fusion_chain() -> VortexResult<()> {
+        // The whole chain must collapse in a single rewrite rather than consuming one optimizer
+        // iteration per level (the per-node budget is 100).
+        let mut expr = root();
+        for _ in 0..150 {
+            expr = list_transform(expr, checked_add(root(), lit(1)));
+        }
+
+        let optimized = expr.optimize_recursive(&i32_list_dtype())?;
+        assert!(optimized.is::<ListTransform>());
+        assert_eq!(optimized.child(0), &root());
+        Ok(())
+    }
+
+    #[test]
+    fn test_is_fallible_delegates_to_body() {
+        let fallible = list_transform(root(), checked_add(root(), lit(1)));
+        assert!(fallible.signature().is_fallible());
+
+        let infallible = list_transform(root(), get_item("a", root()));
+        assert!(!infallible.signature().is_fallible());
     }
 }

--- a/vortex-array/src/scalar_fn/fns/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/mod.rs
@@ -15,6 +15,7 @@ pub mod is_null;
 pub mod like;
 pub mod list_contains;
 pub mod list_length;
+pub mod list_transform;
 pub mod literal;
 pub mod mask;
 pub mod merge;

--- a/vortex-array/src/scalar_fn/session.rs
+++ b/vortex-array/src/scalar_fn/session.rs
@@ -22,6 +22,7 @@ use crate::scalar_fn::fns::is_null::IsNull;
 use crate::scalar_fn::fns::like::Like;
 use crate::scalar_fn::fns::list_contains::ListContains;
 use crate::scalar_fn::fns::list_length::ListLength;
+use crate::scalar_fn::fns::list_transform::ListTransform;
 use crate::scalar_fn::fns::literal::Literal;
 use crate::scalar_fn::fns::merge::Merge;
 use crate::scalar_fn::fns::not::Not;
@@ -70,6 +71,7 @@ impl Default for ScalarFnSession {
         this.register(Like);
         this.register(ListContains);
         this.register(ListLength);
+        this.register(ListTransform);
         this.register(Literal);
         this.register(Merge);
         this.register(Not);


### PR DESCRIPTION
Adds `list_transform` — DuckDB's `list_transform(l, lambda x: x + 1)` — as a Vortex expression, the first higher-order list function. The design doc (research into DuckDB/ClickHouse/Spark/Velox/Polars/DataFusion lambda implementations plus the Vortex design rationale) is included at `vortex-array/src/scalar_fn/fns/list_transform/design.md`.

### Design

Two decisions carry the feature (see design.md §4 for the trade-off tables):

- **The lambda body is an ordinary `Expression` stored in the fn's `Options`, not a child.** Children are evaluated eagerly at row cardinality, but the body must run at element cardinality against a scope that only exists inside `execute`. Options already support this (`Expression` is `Eq + Hash`, and options serde has the session hook needed to deserialize a nested expression). This is DuckDB's bind-data approach; scope-independent properties (fallibility, serialization, body optimization) delegate explicitly.
- **`root()` is the lambda parameter.** Within the body, `root()` refers to the element — no variable nodes or name resolution. `x -> x.a + 1` is `checked_add(get_item("a", root()), lit(1))`. Nested transforms rebind root naturally; captures and the `(x, i)` index form have a forward path via a struct scope (design.md §8) with no v1 changes.

### Semantics & execution

- Offsets (or the fixed size) and list validity pass through untouched; only the elements child is rewritten via a **deferred** `apply(body)` — dictionary-encoded elements evaluate the body over dictionary values only.
- Null list → null; empty list → empty; null elements flow through the body's null semantics. FixedSizeList structure is preserved (no cast to List).
- A **fallible** body is only evaluated over elements some visible list references: ListView gaps/overlaps and ranges under null lists (which Arrow permits to hold arbitrary values) are gathered out first. Known limitation: FSL strides under null rows can't be dropped (documented).

### Rewrites

- Identity: `list_transform(l, x -> x)` → `l` (typed, gated on the input being list-typed so type errors still surface).
- Fusion: `list_transform(list_transform(l, f), g)` → `list_transform(l, g[root := f])`, collapsing whole chains in one rewrite, skipped for bodies with >1 root reference (substitution would duplicate `f` per occurrence).
- `list_length(list_transform(l, f))` → `list_length(l)` — the composition reads offsets only.
- The body is optimized against its element scope from the typed `simplify` hook (it's invisible to the optimizer's children traversal by design).

The second commit addresses findings from an 8-angle adversarial review (each finding independently verified with repro tests): the fallible-body/unreferenced-elements gather path, a zero-row constant guard, the fusion chain/occurrence guards, type-error preservation, and assorted cleanups.