### PR TITLE
fix(array): don't abort on a NUL byte in a field name

### DIFF
--- a/vortex-array/src/arrow/session.rs
+++ b/vortex-array/src/arrow/session.rs
@@ -60,6 +60,7 @@ use crate::dtype::Nullability;
 use crate::dtype::StructFields;
 use crate::dtype::arrow::TryFromArrowType;
 use crate::dtype::arrow::to_data_type_naive;
+use crate::dtype::arrow::validate_arrow_field_name;
 use crate::dtype::extension::ExtId;
 use crate::extension::datetime::AnyTemporal;
 use crate::extension::uuid::Uuid;
@@ -221,6 +222,7 @@ impl ArrowSession {
     /// For [`DType::Extension`]s, plugins registered against the extension's `Id`
     /// are tried in registration order; the first plugin to return `Some(field)` wins.
     pub fn to_arrow_field(&self, name: &str, dtype: &DType) -> VortexResult<Field> {
+        validate_arrow_field_name(name)?;
         // Handle the structural encodings, which may have recursive types
         match dtype {
             DType::List(elem_dtype, nullability) => {
@@ -790,5 +792,13 @@ mod tests {
         assert_eq!(fsb.value(0), b"0123456789abcdef");
         assert_eq!(fsb.value(1), b"fedcba9876543210");
         Ok(())
+    }
+
+    #[test]
+    fn to_arrow_field_rejects_nul_field_name() {
+        // Arrow's FFI schema export aborts on a NUL byte in a field name (#8652); reject it here.
+        let session = ArrowSession::default();
+        let dtype = DType::Primitive(PType::I32, Nullability::Nullable);
+        assert!(session.to_arrow_field("col\0hidden", &dtype).is_err());
     }
 }

--- a/vortex-array/src/dtype/arrow.rs
+++ b/vortex-array/src/dtype/arrow.rs
@@ -273,6 +273,7 @@ impl DType {
 
         let mut builder = SchemaBuilder::with_capacity(struct_dtype.names().len());
         for (field_name, field_dtype) in struct_dtype.names().iter().zip(struct_dtype.fields()) {
+            validate_arrow_field_name(field_name.as_ref())?;
             let field = if field_dtype.is_variant() {
                 let storage = DataType::Struct(variant_storage_fields_minimal());
                 Field::new(field_name.as_ref(), storage, field_dtype.is_nullable()).with_metadata(
@@ -306,6 +307,15 @@ impl DType {
     pub fn to_arrow_dtype(&self) -> VortexResult<DataType> {
         to_data_type_naive(self)
     }
+}
+
+/// Reject a field name Arrow cannot export: an interior NUL byte aborts the process during FFI
+/// schema export, where the name is copied into a NUL-terminated `CString`.
+pub(crate) fn validate_arrow_field_name(name: &str) -> VortexResult<()> {
+    if name.contains('\0') {
+        vortex_bail!("field name {name:?} cannot be exported to Arrow: contains a NUL byte");
+    }
+    Ok(())
 }
 
 /// Naive conversion from a Vortex `DType` to the nearest Arrow physical data type.
@@ -361,6 +371,7 @@ pub(crate) fn to_data_type_naive(dtype: &DType) -> VortexResult<DataType> {
         DType::Struct(struct_dtype, _) => {
             let mut fields = Vec::with_capacity(struct_dtype.names().len());
             for (field_name, field_dt) in struct_dtype.names().iter().zip(struct_dtype.fields()) {
+                validate_arrow_field_name(field_name.as_ref())?;
                 fields.push(FieldRef::from(Field::new(
                     field_name.as_ref(),
                     to_data_type_naive(&field_dt)?,
@@ -652,5 +663,34 @@ mod test {
         let dtype = DType::try_from_arrow((&DataType::Int32, Nullability::Nullable))?;
         assert_eq!(dtype, DType::Primitive(PType::I32, Nullability::Nullable));
         Ok(())
+    }
+
+    #[test]
+    fn test_to_arrow_schema_rejects_nul_field_name() {
+        // A NUL byte in a field name aborts Arrow's FFI schema export (#8652); reject it up front.
+        let dtype = DType::Struct(
+            StructFields::new(
+                FieldNames::from(["col\0hidden"]),
+                vec![DType::Primitive(PType::I32, Nullability::Nullable)],
+            ),
+            Nullability::NonNullable,
+        );
+        assert!(dtype.to_arrow_schema().is_err());
+    }
+
+    #[test]
+    fn test_to_arrow_schema_rejects_nul_in_nested_field_name() {
+        let inner = DType::Struct(
+            StructFields::new(
+                FieldNames::from(["a\0b"]),
+                vec![DType::Primitive(PType::I32, Nullability::Nullable)],
+            ),
+            Nullability::Nullable,
+        );
+        let dtype = DType::Struct(
+            StructFields::new(FieldNames::from(["outer"]), vec![inner]),
+            Nullability::NonNullable,
+        );
+        assert!(dtype.to_arrow_schema().is_err());
     }
 }


### PR DESCRIPTION
## Summary

A struct field name with an interior NUL byte aborted the whole process (`SIGABRT`) when the schema was exported across the Arrow C Data FFI: arrow-rs copies the name into a `CString` in a non-unwinding context, so `CString::new` failing on the NUL escalated to an abort instead of an error (#8652). `to_arrow_schema` / `to_data_type_naive` and `ArrowSession::to_arrow_field` now reject a NUL byte in a field name up front, so a crafted or mislabeled file surfaces a recoverable `VortexError` instead of taking down the reader.

This rejects only NUL, the byte that actually aborts (other control characters are valid in a `CString`), and guards the Arrow export boundary rather than the writer, so it also covers a `DType` from a non-Vortex producer.

Closes: #8652

## Testing

Added tests that `to_arrow_schema` (top-level and nested struct) and `ArrowSession::to_arrow_field` reject a NUL field name. `cargo nextest run -p vortex-array` passes; `fmt --all` + `clippy --all-targets --all-features` clean.

---

I'm Korean, so sorry if any wording reads a little awkward.
