### PR TITLE
FFI: canonicalize array, data pointer for primitives

### DIFF
--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -202,6 +202,52 @@ typedef enum {
 } vx_estimate_type;
 
 /**
+ * Error category for vx_error.
+ */
+typedef enum {
+    /**
+     * All other errors
+     */
+    VX_ERROR_CODE_OTHER = 0,
+    /**
+     * Index out of bounds
+     */
+    VX_ERROR_CODE_OUT_OF_BOUNDS = 1,
+    /**
+     * Compute kernel execute error
+     */
+    VX_ERROR_CODE_COMPUTE = 2,
+    /**
+     * An invalid argument was provided.
+     */
+    VX_ERROR_CODE_INVALID_ARGUMENT = 3,
+    /**
+     * Serialization/deserialization error
+     */
+    VX_ERROR_CODE_SERIALIZATION = 4,
+    /**
+     * Unimplemented function
+     */
+    VX_ERROR_CODE_NOT_IMPLEMENTED = 5,
+    /**
+     * Type mismatch
+     */
+    VX_ERROR_CODE_MISMATCHED_TYPES = 6,
+    /**
+     * Assertion failed
+     */
+    VX_ERROR_CODE_ASSERTION_FAILED = 7,
+    /**
+     * IO error
+     */
+    VX_ERROR_CODE_IO = 8,
+    /**
+     * Panic inside FFI
+     */
+    VX_ERROR_CODE_PANIC = 9,
+} vx_error_code;
+
+/**
  * Equalities, inequalities, and boolean operations over possibly null values.
  * For most operations, if either side is null, the result is null.
  * VX_OPERATOR_KLEENE_AND, VX_OPERATOR_KLEENE_OR obey Kleene (three-valued)
@@ -804,6 +850,43 @@ const vx_string *vx_array_get_utf8(const vx_array *array, uint32_t index);
 const vx_binary *vx_array_get_binary(const vx_array *array, uint32_t index);
 
 /**
+ * For a canonical Bool array, return bool at "index".
+ * For invalid elements returned value is unspecified, check validity via
+ * vx_array_get_validity.
+ *
+ * Panics if "array" is not canonical - call vx_array_canonicalize first.
+ * Panics if "array" is not a Bool array.
+ * Panics if "index" is out of bounds.
+ */
+bool vx_array_get_bool(const vx_array *array, size_t index);
+
+/**
+ * Decode array into its canonical form.
+ *
+ * On error returns NULL and "sets error_out".
+ */
+const vx_array *vx_array_canonicalize(const vx_session *session, const vx_array *array, vx_error **error_out);
+
+/**
+ * Return a pointer to the values buffer of a canonical Primitive array.
+ * Pointer is valid as long as "array" is valid.
+ *
+ * Errors if array is not a canonical Primitive.
+ */
+const void *vx_array_data_ptr_primitive(const vx_array *array, vx_error **error_out);
+
+/**
+ * Return a pointer to the bitpacked buffer of a canonical Bool array.
+ * Pointer is valid as long as "array" is valid.
+ *
+ * Writes bit offset of the first element into "bit_offset_out".
+ * "bit_offset_out" must not be NULL.
+ *
+ * Errors if array is not a canonical Bool.
+ */
+const void *vx_array_data_ptr_bool(const vx_array *array, size_t *bit_offset_out, vx_error **error_out);
+
+/**
  * Apply the expression to the array, wrapping it with a ScalarFnArray.
  * This operation takes constant time as it doesn't execute the underlying
  * array. Executing the underlying array still takes O(n) time.
@@ -1055,6 +1138,11 @@ void vx_error_free(const vx_error *ptr);
  * Return an error message for this error
  */
 const vx_string *vx_error_get_message(const vx_error *error);
+
+/**
+ * Return category code for "error".
+ */
+vx_error_code vx_error_get_code(const vx_error *error);
 
 /**
  * Free an owned [`vx_expression`] object.
@@ -1565,6 +1653,12 @@ void vx_array_sink_push(vx_array_sink *sink, const vx_array *array, vx_error **e
  * to the external resource.
  */
 void vx_array_sink_close(vx_array_sink *sink, vx_error **error_out);
+
+/**
+ * Abort an array sink. File footer is not written, and file is left invalid.
+ * Don't use sink after this call.
+ */
+void vx_array_sink_abort(vx_array_sink *sink);
 
 /**
  * Clone a vx_string. Returned handle must be release with vx_string_free

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -13,11 +13,15 @@ use arrow_array::ffi::FFI_ArrowSchema;
 use arrow_array::ffi::from_ffi;
 use paste::paste;
 use vortex::array::ArrayRef;
+use vortex::array::Canonical;
 use vortex::array::IntoArray;
 use vortex::array::VortexSessionExecute;
+use vortex::array::arrays::Bool;
 use vortex::array::arrays::NullArray;
+use vortex::array::arrays::Primitive;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;
+use vortex::array::arrays::bool::BoolArrayExt;
 use vortex::array::arrays::struct_::StructArrayExt;
 use vortex::array::arrow::FromArrowArray;
 use vortex::array::legacy_session;
@@ -29,16 +33,20 @@ use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_ensure;
 use vortex::error::vortex_err;
+use vortex::error::vortex_panic;
 
 use crate::arc_wrapper;
 use crate::binary::vx_binary;
 use crate::dtype::vx_dtype;
 use crate::dtype::vx_dtype_variant;
+use crate::error::try_or;
 use crate::error::try_or_default;
 use crate::error::vx_error;
 use crate::error::write_error;
 use crate::expression::vx_expression;
 use crate::ptype::vx_ptype;
+use crate::session::vx_session;
+use crate::session::vx_session_ref;
 use crate::string::vx_string;
 
 arc_wrapper!(
@@ -474,6 +482,100 @@ pub unsafe extern "C-unwind" fn vx_array_get_binary(
     }
 }
 
+/// For a canonical Bool array, return bool at "index".
+/// For invalid elements returned value is unspecified, check validity via
+/// vx_array_get_validity.
+///
+/// Panics if "array" is not canonical - call vx_array_canonicalize first.
+/// Panics if "array" is not a Bool array.
+/// Panics if "index" is out of bounds.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_array_get_bool(array: *const vx_array, index: usize) -> bool {
+    let array = vx_array::as_ref(array);
+    let bool_array = array
+        .as_opt::<Bool>()
+        .vortex_expect("vx_array_get_bool requires a canonical Bool array");
+    let bits = bool_array.to_bit_buffer();
+    if index >= bits.len() {
+        vortex_panic!(
+            "index {index} out of bounds for array of length {}",
+            bits.len()
+        );
+    }
+    bits.value(index)
+}
+
+/// Decode array into its canonical form.
+///
+/// On error returns NULL and "sets error_out".
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_array_canonicalize(
+    session: *const vx_session,
+    array: *const vx_array,
+    error_out: *mut *mut vx_error,
+) -> *const vx_array {
+    try_or_default(error_out, || {
+        let session = unsafe { vx_session_ref(session) }?;
+        let array = unsafe { vx_array_ref(array) }?;
+        let mut ctx = session.create_execution_ctx();
+        let canonical = array.clone().execute::<Canonical>(&mut ctx)?;
+        Ok(vx_array::new(Arc::new(canonical.into_array())))
+    })
+}
+
+/// Return a pointer to the values buffer of a canonical Primitive array.
+/// Pointer is valid as long as "array" is valid.
+///
+/// Errors if array is not a canonical Primitive.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_array_data_ptr_primitive(
+    array: *const vx_array,
+    error_out: *mut *mut vx_error,
+) -> *const c_void {
+    try_or(error_out, ptr::null(), || {
+        let array = unsafe { vx_array_ref(array) }?;
+        let primitive = array.as_opt::<Primitive>().ok_or_else(|| {
+            vortex_err!(
+                "vx_array_data_ptr_primitive requires a canonical Primitive array, got {}",
+                array.encoding_id()
+            )
+        })?;
+        let bytes = primitive
+            .buffer_handle()
+            .as_host_opt()
+            .ok_or_else(|| vortex_err!("array buffer is not in host memory"))?;
+        Ok(bytes.as_ptr().cast())
+    })
+}
+
+/// Return a pointer to the bitpacked buffer of a canonical Bool array.
+/// Pointer is valid as long as "array" is valid.
+///
+/// Writes bit offset of the first element into "bit_offset_out".
+/// "bit_offset_out" must not be NULL.
+///
+/// Errors if array is not a canonical Bool.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_array_data_ptr_bool(
+    array: *const vx_array,
+    bit_offset_out: *mut usize,
+    error_out: *mut *mut vx_error,
+) -> *const c_void {
+    try_or(error_out, ptr::null(), || {
+        let array = unsafe { vx_array_ref(array) }?;
+        vortex_ensure!(!bit_offset_out.is_null(), "null bit_offset_out");
+        let bool_array = array.as_opt::<Bool>().ok_or_else(|| {
+            vortex_err!(
+                "vx_array_data_ptr_bool requires a canonical Bool array, got {}",
+                array.encoding_id()
+            )
+        })?;
+        let bits = bool_array.to_bit_buffer();
+        unsafe { bit_offset_out.write(bits.offset()) };
+        Ok(bits.inner().as_ptr().cast())
+    })
+}
+
 /// Apply the expression to the array, wrapping it with a ScalarFnArray.
 /// This operation takes constant time as it doesn't execute the underlying
 /// array. Executing the underlying array still takes O(n) time.
@@ -495,6 +597,7 @@ pub unsafe extern "C" fn vx_array_apply(
 #[cfg(test)]
 mod tests {
     use std::ptr;
+    use std::slice::from_raw_parts;
 
     use vortex::array::IntoArray;
     use vortex::array::VortexSessionExecute;
@@ -519,7 +622,10 @@ mod tests {
     use crate::dtype::vx_dtype_variant;
     use crate::error::vx_error_free;
     use crate::expression::vx_expression_free;
+    use crate::session::vx_session_free;
+    use crate::session::vx_session_new;
     use crate::string::vx_string_free;
+    use crate::tests::assert_error;
     use crate::tests::assert_no_error;
 
     #[test]
@@ -931,6 +1037,154 @@ mod tests {
             vx_array_free(b);
 
             vx_array_free(vx);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_get_bool() {
+        let bools = BoolArray::from_iter([true, false, true]);
+        unsafe {
+            let array = vx_array::new(Arc::new(bools.into_array()));
+            assert!(vx_array_get_bool(array, 0));
+            assert!(!vx_array_get_bool(array, 1));
+            assert!(vx_array_get_bool(array, 2));
+            vx_array_free(array);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_canonicalize_nullable() {
+        let primitive = PrimitiveArray::new(
+            buffer![10i32, 20i32, 30i32],
+            Validity::from_iter([true, false, true]),
+        );
+
+        unsafe {
+            let session = vx_session_new();
+            let mut error = ptr::null_mut();
+            let mut bit_offset = usize::MAX;
+
+            let array = vx_array::new(Arc::new(primitive.into_array()));
+            let canonical = vx_array_canonicalize(session, array, &raw mut error);
+            assert_no_error(error);
+            let data = vx_array_data_ptr_primitive(canonical, &raw mut error);
+            assert_no_error(error);
+
+            assert_eq!(from_raw_parts(data.cast::<i32>(), 3), [10, 20, 30]);
+            let mut validity = vx_validity {
+                r#type: vx_validity_type::VX_VALIDITY_NON_NULLABLE,
+                array: ptr::null(),
+            };
+
+            vx_array_get_validity(canonical, &raw mut validity, &raw mut error);
+            assert_no_error(error);
+            assert!(matches!(
+                validity.r#type,
+                vx_validity_type::VX_VALIDITY_ARRAY
+            ));
+            let validity_bools = vx_array_canonicalize(session, validity.array, &raw mut error);
+            assert_no_error(error);
+            let bits = vx_array_data_ptr_bool(validity_bools, &raw mut bit_offset, &raw mut error);
+            assert_no_error(error);
+            assert_eq!(
+                *bits.cast::<u8>().add(bit_offset / 8) >> (bit_offset % 8) & 0b111,
+                0b101
+            );
+
+            vx_array_free(validity_bools);
+            vx_array_free(validity.array);
+            vx_array_free(canonical);
+            vx_array_free(array);
+            vx_session_free(session);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_canonicalize() {
+        let primitive = PrimitiveArray::new(buffer![1u8, 2u8], Validity::NonNullable);
+
+        unsafe {
+            let session = vx_session_new();
+            let mut error = ptr::null_mut();
+            let mut validity = vx_validity {
+                r#type: vx_validity_type::VX_VALIDITY_NON_NULLABLE,
+                array: ptr::null(),
+            };
+
+            let array = vx_array::new(Arc::new(primitive.into_array()));
+            vx_array_get_validity(array, &raw mut validity, &raw mut error);
+            assert_no_error(error);
+            assert!(matches!(
+                validity.r#type,
+                vx_validity_type::VX_VALIDITY_NON_NULLABLE
+            ));
+            assert!(validity.array.is_null());
+            vx_array_free(array);
+
+            vx_session_free(session);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_data_ptr_bool() {
+        let bools = BoolArray::from_iter([
+            true, true, false, true, false, true, true, false, true, true,
+        ]);
+
+        unsafe {
+            let session = vx_session_new();
+            let mut error = ptr::null_mut();
+            let mut bit_offset = usize::MAX;
+
+            let array = vx_array::new(Arc::new(bools.into_array()));
+            let sliced = vx_array_slice(array, 3, 10, &raw mut error);
+            assert_no_error(error);
+
+            let canonical = vx_array_canonicalize(session, sliced, &raw mut error);
+            assert_no_error(error);
+
+            let bits = vx_array_data_ptr_bool(canonical, &raw mut bit_offset, &raw mut error);
+            assert_no_error(error);
+            assert!(bit_offset < 8);
+            for (i, expected) in [true, false, true, true, false, true, true]
+                .into_iter()
+                .enumerate()
+            {
+                let bit = bit_offset + i;
+                let actual = (*bits.cast::<u8>().add(bit / 8) >> (bit % 8)) & 1 == 1;
+                assert_eq!(actual, expected, "bit {i}");
+            }
+            vx_array_free(canonical);
+            vx_array_free(sliced);
+            vx_array_free(array);
+
+            vx_session_free(session);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_data_ptr_error() {
+        let strings = VarBinViewArray::from_iter_str(["a", "b"]);
+
+        unsafe {
+            let mut error = ptr::null_mut();
+
+            let array = vx_array::new(Arc::new(strings.into_array()));
+            let data = vx_array_data_ptr_primitive(array, &raw mut error);
+            assert!(data.is_null());
+            assert_error(error);
+
+            let mut bit_offset = usize::MAX;
+            let bits = vx_array_data_ptr_bool(array, &raw mut bit_offset, &raw mut error);
+            assert!(bits.is_null());
+            assert_error(error);
+
+            vx_array_free(array);
         }
     }
 }

--- a/vortex-ffi/src/error.rs
+++ b/vortex-ffi/src/error.rs
@@ -7,35 +7,84 @@ use std::panic::catch_unwind;
 use std::ptr;
 use std::sync::Arc;
 
+use vortex::error::VortexError;
 use vortex::error::VortexResult;
 
 use crate::box_wrapper;
 use crate::string::vx_string;
 
-pub(crate) struct VortexError {
+/// Error category for vx_error.
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[expect(non_camel_case_types)]
+pub enum vx_error_code {
+    /// All other errors
+    VX_ERROR_CODE_OTHER = 0,
+    /// Index out of bounds
+    VX_ERROR_CODE_OUT_OF_BOUNDS = 1,
+    /// Compute kernel execute error
+    VX_ERROR_CODE_COMPUTE = 2,
+    /// An invalid argument was provided.
+    VX_ERROR_CODE_INVALID_ARGUMENT = 3,
+    /// Serialization/deserialization error
+    VX_ERROR_CODE_SERIALIZATION = 4,
+    /// Unimplemented function
+    VX_ERROR_CODE_NOT_IMPLEMENTED = 5,
+    /// Type mismatch
+    VX_ERROR_CODE_MISMATCHED_TYPES = 6,
+    /// Assertion failed
+    VX_ERROR_CODE_ASSERTION_FAILED = 7,
+    /// IO error
+    VX_ERROR_CODE_IO = 8,
+    /// Panic inside FFI
+    VX_ERROR_CODE_PANIC = 9,
+}
+
+fn error_code(error: &VortexError) -> vx_error_code {
+    match error {
+        VortexError::OutOfBounds(..) => vx_error_code::VX_ERROR_CODE_OUT_OF_BOUNDS,
+        VortexError::Compute(..) => vx_error_code::VX_ERROR_CODE_COMPUTE,
+        VortexError::InvalidArgument(..) => vx_error_code::VX_ERROR_CODE_INVALID_ARGUMENT,
+        VortexError::Serde(..) => vx_error_code::VX_ERROR_CODE_SERIALIZATION,
+        VortexError::NotImplemented(..) => vx_error_code::VX_ERROR_CODE_NOT_IMPLEMENTED,
+        VortexError::MismatchedTypes(..) => vx_error_code::VX_ERROR_CODE_MISMATCHED_TYPES,
+        VortexError::AssertionFailed(..) => vx_error_code::VX_ERROR_CODE_ASSERTION_FAILED,
+        VortexError::Io(..) => vx_error_code::VX_ERROR_CODE_IO,
+        VortexError::Context(_, inner) => error_code(inner),
+        VortexError::Shared(inner) => error_code(inner),
+        _ => vx_error_code::VX_ERROR_CODE_OTHER,
+    }
+}
+
+pub(crate) struct VortexFFIError {
     message: Arc<str>,
+    code: vx_error_code,
 }
 
 box_wrapper!(
     /// The error structure populated by fallible Vortex C functions.
-    VortexError,
+    VortexFFIError,
     vx_error
 );
 
-/// Create an owned Vortex FFI error from a message.
-pub(crate) fn vx_error_new(message: &str) -> *mut vx_error {
-    vx_error::new(VortexError {
+fn vx_error_new_with_code(message: &str, code: vx_error_code) -> *mut vx_error {
+    vx_error::new(VortexFFIError {
         message: message.into(),
+        code,
     })
 }
 
 /// Write an error message to `error` which has not been populated before.
 /// A null `error` pointer discards the message.
 pub(crate) fn write_error(error: *mut *mut vx_error, message: &str) {
+    write_error_with_code(error, message, vx_error_code::VX_ERROR_CODE_OTHER);
+}
+
+fn write_error_with_code(error: *mut *mut vx_error, message: &str, code: vx_error_code) {
     if error.is_null() {
         return;
     }
-    unsafe { error.write(vx_error_new(message)) };
+    unsafe { error.write(vx_error_new_with_code(message, code)) };
 }
 
 /// Clear `*error_out` to null unless `error_out` itself is null.
@@ -68,11 +117,15 @@ pub fn try_or_default<T: Default>(
             value
         }
         Ok(Err(err)) => {
-            write_error(error_out, &err.to_string());
+            write_error_with_code(error_out, &err.to_string(), error_code(&err));
             T::default()
         }
         Err(payload) => {
-            write_error(error_out, &panic_message(payload.as_ref()));
+            write_error_with_code(
+                error_out,
+                &panic_message(payload.as_ref()),
+                vx_error_code::VX_ERROR_CODE_PANIC,
+            );
             T::default()
         }
     }
@@ -93,11 +146,15 @@ pub fn try_or<T>(
             value
         }
         Ok(Err(err)) => {
-            write_error(error_out, &err.to_string());
+            write_error_with_code(error_out, &err.to_string(), error_code(&err));
             error_value
         }
         Err(payload) => {
-            write_error(error_out, &panic_message(payload.as_ref()));
+            write_error_with_code(
+                error_out,
+                &panic_message(payload.as_ref()),
+                vx_error_code::VX_ERROR_CODE_PANIC,
+            );
             error_value
         }
     }
@@ -107,6 +164,12 @@ pub fn try_or<T>(
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_error_get_message(error: *const vx_error) -> *const vx_string {
     vx_string::new(Arc::clone(&vx_error::as_ref(error).message))
+}
+
+/// Return category code for "error".
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_error_get_code(error: *const vx_error) -> vx_error_code {
+    vx_error::as_ref(error).code
 }
 
 #[cfg(test)]
@@ -158,6 +221,30 @@ mod tests {
             "panic in Vortex FFI function: boom"
         );
         unsafe { crate::string::vx_string_free(message) };
+        unsafe { vx_error_free(error) };
+    }
+
+    #[test]
+    fn test_error_codes() {
+        let mut error: *mut vx_error = ptr::null_mut();
+
+        assert_eq!(
+            try_or(&raw mut error, -1, || Err::<i32, _>(vortex_err!(
+                OutOfBounds: 5, 0, 3
+            ))),
+            -1
+        );
+        assert_eq!(
+            unsafe { vx_error_get_code(error) },
+            vx_error_code::VX_ERROR_CODE_OUT_OF_BOUNDS
+        );
+        unsafe { vx_error_free(error) };
+
+        assert_eq!(try_or(&raw mut error, -1, || panic!("panic")), -1);
+        assert_eq!(
+            unsafe { vx_error_get_code(error) },
+            vx_error_code::VX_ERROR_CODE_PANIC
+        );
         unsafe { vx_error_free(error) };
     }
 }

--- a/vortex-ffi/src/sink.rs
+++ b/vortex-ffi/src/sink.rs
@@ -119,6 +119,16 @@ pub unsafe extern "C-unwind" fn vx_array_sink_close(
     })
 }
 
+/// Abort an array sink. File footer is not written, and file is left invalid.
+/// Don't use sink after this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_array_sink_abort(sink: *mut vx_array_sink) {
+    if sink.is_null() {
+        return;
+    }
+    drop(unsafe { Box::from_raw(sink) });
+}
+
 #[cfg(test)]
 mod tests {
     use std::ffi::CString;
@@ -134,6 +144,8 @@ mod tests {
     use super::*;
     use crate::array::vx_array;
     use crate::array::vx_array_free;
+    use crate::data_source::vx_data_source_new;
+    use crate::data_source::vx_data_source_options;
     use crate::dtype::vx_dtype;
     use crate::dtype::vx_dtype_free;
     use crate::error::vx_error_free;
@@ -257,6 +269,43 @@ mod tests {
             }
 
             vx_dtype_free(vx_dtype_ptr);
+            vx_session_free(session);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_sink_abort() {
+        let dtype = DType::Primitive(vortex::dtype::PType::I32, false.into());
+        let array = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable);
+
+        let file = NamedTempFile::new().unwrap();
+        let path = CString::new(file.path().to_str().unwrap()).unwrap();
+
+        unsafe {
+            let session = vx_session_new();
+            let dtype = vx_dtype::new(Arc::new(dtype));
+
+            let mut error = std::ptr::null_mut();
+            let sink = vx_array_sink_open_file(session, path.as_ptr(), dtype, &raw mut error);
+            assert!(error.is_null());
+
+            let array = vx_array::new(Arc::new(array.into_array()));
+            vx_array_sink_push(sink, array, &raw mut error);
+            assert!(error.is_null());
+            vx_array_free(array);
+
+            vx_array_sink_abort(sink);
+
+            let opts = vx_data_source_options {
+                paths: path.as_ptr(),
+            };
+            let ds = vx_data_source_new(session, &raw const opts, &raw mut error);
+            assert!(ds.is_null());
+            assert!(!error.is_null());
+            vx_error_free(error);
+
+            vx_dtype_free(dtype);
             vx_session_free(session);
         }
     }


### PR DESCRIPTION
- Add canonicalize function for vx_array.
- Add data_ptr functions for canonicalized primitive and bool arrays.
- Add sink abort method which doesn't write file footer and leaves file invalid. Semantics here is we want to abort the sink in C++ destructor - if user hasn't called Finalize(), file will not be written correctly.
- Expose Rust's error code to FFI.