### PR TITLE
Accelerate fixed-size-list take for primitive children

### DIFF
--- a/vortex-array/benches/take_fsl.rs
+++ b/vortex-array/benches/take_fsl.rs
@@ -6,6 +6,7 @@
 //! Parameterized over:
 //! - Number of indices to take
 //! - Fixed size list length (elements per list)
+//! - Element byte width
 
 #![expect(clippy::cast_possible_truncation)]
 #![expect(clippy::unwrap_used)]
@@ -13,16 +14,26 @@
 use std::sync::LazyLock;
 
 use divan::Bencher;
+use divan::counter::BytesCount;
+use num_traits::FromPrimitive;
 use rand::RngExt;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::array_session;
 use vortex_array::arrays::FixedSizeListArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
+use vortex_array::dtype::IntegerPType;
+use vortex_array::dtype::NativePType;
+use vortex_array::dtype::half::f16;
+use vortex_array::match_smallest_offset_type;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
+use vortex_buffer::BufferMut;
 use vortex_session::VortexSession;
 
 fn main() {
@@ -39,12 +50,20 @@ const NUM_LISTS: usize = 500;
 const NUM_INDICES: &[usize] = &[100, 1_000];
 
 /// Fixed size list lengths (elements per list).
-const LIST_SIZES: &[usize] = &[16, 64, 256, 1024, 4096];
+const LIST_SIZES: &[usize] = &[16, 64, 128, 256, 512, 1024, 2048, 4096];
+
+/// F16 list lengths for isolating the per-index and range-copy strategies.
+const F16_STRATEGY_LIST_SIZES: &[usize] = &[1, 2, 4, 8, 16, 64, 128, 256, 512, 1024, 2048, 4096];
 
 /// Creates a FixedSizeListArray with the given list size and number of lists.
-fn create_fsl(list_size: usize, num_lists: usize) -> FixedSizeListArray {
+fn create_fsl<T>(list_size: usize, num_lists: usize) -> FixedSizeListArray
+where
+    T: NativePType + FromPrimitive,
+{
     let total_elements = list_size * num_lists;
-    let elements: Buffer<i64> = (0..total_elements as i64).collect();
+    let elements: Buffer<T> = (0..total_elements)
+        .map(|idx| T::from_u16((idx % 251) as u16).unwrap())
+        .collect();
     FixedSizeListArray::new(
         elements.into_array(),
         list_size as u32,
@@ -62,12 +81,35 @@ fn create_random_indices(num_indices: usize, max_index: usize) -> Buffer<u64> {
 }
 
 #[divan::bench(args = NUM_INDICES, consts = LIST_SIZES)]
-fn take_fsl_random<const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize) {
-    let fsl = create_fsl(LIST_SIZE, NUM_LISTS);
+fn take_fsl_f16_random<const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize) {
+    take_fsl_random::<f16, LIST_SIZE>(bencher, num_indices);
+}
+
+#[divan::bench(args = NUM_INDICES, consts = LIST_SIZES)]
+fn take_fsl_u8_random<const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize) {
+    take_fsl_random::<u8, LIST_SIZE>(bencher, num_indices);
+}
+
+#[divan::bench(args = NUM_INDICES, consts = LIST_SIZES)]
+fn take_fsl_u32_random<const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize) {
+    take_fsl_random::<u32, LIST_SIZE>(bencher, num_indices);
+}
+
+#[divan::bench(args = NUM_INDICES, consts = LIST_SIZES)]
+fn take_fsl_u64_random<const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize) {
+    take_fsl_random::<u64, LIST_SIZE>(bencher, num_indices);
+}
+
+fn take_fsl_random<T, const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize)
+where
+    T: NativePType + FromPrimitive,
+{
+    let fsl = create_fsl::<T>(LIST_SIZE, NUM_LISTS);
     let indices = create_random_indices(num_indices, NUM_LISTS);
     let indices_array = indices.into_array();
 
     bencher
+        .counter(BytesCount::of_many::<T>(num_indices * LIST_SIZE))
         .with_inputs(|| (&fsl, &indices_array, SESSION.create_execution_ctx()))
         .bench_refs(|(array, indices, execution_ctx)| {
             array
@@ -79,10 +121,101 @@ fn take_fsl_random<const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize)
         });
 }
 
+#[divan::bench(args = NUM_INDICES, consts = F16_STRATEGY_LIST_SIZES)]
+fn take_fsl_f16_force_per_index<const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize) {
+    let fsl = create_fsl::<f16>(LIST_SIZE, NUM_LISTS);
+    let indices = create_random_indices(num_indices, NUM_LISTS);
+
+    bencher
+        .counter(BytesCount::of_many::<f16>(num_indices * LIST_SIZE))
+        .with_inputs(|| (&fsl, &indices, SESSION.create_execution_ctx()))
+        .bench_refs(|(array, indices, execution_ctx)| {
+            match_smallest_offset_type!(array.elements().len(), |E| {
+                take_fsl_f16_per_index_strategy::<LIST_SIZE, E>(array, indices)
+            })
+            .into_array()
+            .execute::<RecursiveCanonical>(execution_ctx)
+            .unwrap()
+        });
+}
+
+#[divan::bench(args = NUM_INDICES, consts = F16_STRATEGY_LIST_SIZES)]
+fn take_fsl_f16_force_ranges<const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize) {
+    let fsl = create_fsl::<f16>(LIST_SIZE, NUM_LISTS);
+    let indices = create_random_indices(num_indices, NUM_LISTS);
+
+    bencher
+        .counter(BytesCount::of_many::<f16>(num_indices * LIST_SIZE))
+        .with_inputs(|| (&fsl, &indices, SESSION.create_execution_ctx()))
+        .bench_refs(|(array, indices, execution_ctx)| {
+            take_fsl_f16_range_strategy::<LIST_SIZE>(array, indices, execution_ctx)
+                .into_array()
+                .execute::<RecursiveCanonical>(execution_ctx)
+                .unwrap()
+        });
+}
+
+fn take_fsl_f16_per_index_strategy<const LIST_SIZE: usize, E: IntegerPType>(
+    array: &FixedSizeListArray,
+    indices: &Buffer<u64>,
+) -> FixedSizeListArray {
+    let mut element_indices = BufferMut::<E>::with_capacity(indices.len() * LIST_SIZE);
+    for &idx in indices.as_ref() {
+        let start = idx as usize * LIST_SIZE;
+        let end = start + LIST_SIZE;
+        for element_idx in start..end {
+            unsafe { element_indices.push_unchecked(E::from_usize(element_idx).unwrap()) };
+        }
+    }
+
+    let element_indices =
+        PrimitiveArray::new(element_indices.freeze(), Validity::NonNullable).into_array();
+    let elements = array.elements().take(element_indices).unwrap();
+
+    unsafe {
+        FixedSizeListArray::new_unchecked(
+            elements,
+            LIST_SIZE as u32,
+            Validity::NonNullable,
+            indices.len(),
+        )
+    }
+}
+
+fn take_fsl_f16_range_strategy<const LIST_SIZE: usize>(
+    array: &FixedSizeListArray,
+    indices: &Buffer<u64>,
+    execution_ctx: &mut ExecutionCtx,
+) -> FixedSizeListArray {
+    let elements = array
+        .elements()
+        .clone()
+        .execute::<PrimitiveArray>(execution_ctx)
+        .unwrap();
+    let source = elements.as_slice::<f16>();
+    let mut values = BufferMut::<f16>::with_capacity(indices.len() * LIST_SIZE);
+
+    for &idx in indices.as_ref() {
+        let start = idx as usize * LIST_SIZE;
+        values.extend_from_slice(&source[start..start + LIST_SIZE]);
+    }
+
+    unsafe {
+        FixedSizeListArray::new_unchecked(
+            PrimitiveArray::new(values.freeze(), Validity::NonNullable).into_array(),
+            LIST_SIZE as u32,
+            Validity::NonNullable,
+            indices.len(),
+        )
+    }
+}
+
 #[divan::bench(args = NUM_INDICES, consts = LIST_SIZES)]
-fn take_fsl_nullable_random<const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize) {
+fn take_fsl_f16_nullable_random<const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize) {
     let total_elements = LIST_SIZE * NUM_LISTS;
-    let elements: Buffer<i64> = (0..total_elements as i64).collect();
+    let elements: Buffer<f16> = (0..total_elements)
+        .map(|idx| f16::from_u16((idx % 251) as u16).unwrap())
+        .collect();
 
     // Create validity with ~10% nulls
     let mut rng = StdRng::seed_from_u64(123);
@@ -94,6 +227,7 @@ fn take_fsl_nullable_random<const LIST_SIZE: usize>(bencher: Bencher, num_indice
     let indices_array = indices.into_array();
 
     bencher
+        .counter(BytesCount::of_many::<f16>(num_indices * LIST_SIZE))
         .with_inputs(|| (&fsl, &indices_array, SESSION.create_execution_ctx()))
         .bench_refs(|(array, indices, execution_ctx)| {
             array

--- a/vortex-array/src/arrays/fixed_size_list/compute/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/take.rs
@@ -21,16 +21,26 @@ use crate::arrays::dict::TakeExecute;
 use crate::arrays::fixed_size_list::FixedSizeListArrayExt;
 use crate::arrays::primitive::PrimitiveArrayExt;
 use crate::dtype::IntegerPType;
+use crate::dtype::NativePType;
 use crate::executor::ExecutionCtx;
+use crate::match_each_native_ptype;
 use crate::match_each_unsigned_integer_ptype;
 use crate::match_smallest_offset_type;
 use crate::validity::Validity;
 
+/// Use range copies when the child values are already a contiguous primitive buffer.
+///
+/// This deliberately does not canonicalize encoded children just to make range slicing possible:
+/// the existing child `take` path lets those encodings handle the gather without eagerly
+/// decompressing the full child.
+const RANGE_TAKE_MIN_PRIMITIVE_LIST_BYTES: usize = 4;
+
 /// Take implementation for [`FixedSizeListArray`].
 ///
 /// Unlike `ListView`, `FixedSizeListArray` must rebuild the elements array because it requires
-/// that elements start at offset 0 and be perfectly packed without gaps. We expand list indices
-/// into element indices and push them down to the child elements array.
+/// that elements start at offset 0 and be perfectly packed without gaps. We either use a bulk child
+/// `take` over expanded element indices or copy selected child ranges directly, depending on the
+/// child encoding and list width.
 impl TakeExecute for FixedSizeList {
     fn take(
         array: ArrayView<'_, FixedSizeList>,
@@ -88,12 +98,39 @@ fn take_with_indices<I: IntegerPType, E: IntegerPType>(
         // The result's nullability is the union of the input nullabilities.
         if array.dtype().is_nullable() || indices_array.dtype().is_nullable() {
             let indices_array = indices_array.as_view();
-            take_nullable_fsl::<I, E>(array, indices_array, ctx)
+            if should_take_fsl_with_ranges(&array, list_size) {
+                take_nullable_fsl_by_ranges::<I, E>(array, indices_array, ctx)
+            } else {
+                take_nullable_fsl::<I, E>(array, indices_array, ctx)
+            }
         } else {
             let indices_array = indices_array.as_view();
-            take_non_nullable_fsl::<I, E>(array, indices_array)
+            if should_take_fsl_with_ranges(&array, list_size) {
+                take_non_nullable_fsl_by_ranges::<I, E>(array, indices_array)
+            } else {
+                take_non_nullable_fsl::<I, E>(array, indices_array)
+            }
         }
     }
+}
+
+fn should_take_fsl_with_ranges(array: &ArrayView<'_, FixedSizeList>, list_size: usize) -> bool {
+    let element_dtype = array
+        .dtype()
+        .as_fixed_size_list_element_opt()
+        .vortex_expect("FixedSizeList dtype must have an element dtype");
+
+    if !element_dtype.is_nullable() && array.elements().is::<Primitive>() {
+        return element_dtype.element_size().is_some_and(|element_size| {
+            element_size
+                .checked_mul(list_size)
+                .is_some_and(|list_byte_width| {
+                    list_byte_width >= RANGE_TAKE_MIN_PRIMITIVE_LIST_BYTES
+                })
+        });
+    }
+
+    false
 }
 
 /// Takes from an array when both the array and indices are non-nullable.
@@ -143,6 +180,75 @@ fn take_non_nullable_fsl<I: IntegerPType, E: IntegerPType>(
         )
     }
     .into_array())
+}
+
+/// Takes from an array when both the array and indices are non-nullable, copying each selected
+/// list as a contiguous range instead of expanding it into per-element gather indices.
+fn take_non_nullable_fsl_by_ranges<I: IntegerPType, E: IntegerPType>(
+    array: ArrayView<'_, FixedSizeList>,
+    indices_array: ArrayView<'_, Primitive>,
+) -> VortexResult<ArrayRef> {
+    if let Some(new_elements) =
+        take_primitive_non_nullable_elements_by_ranges::<I>(array, indices_array)?
+    {
+        let new_len = indices_array.len();
+        return Ok(unsafe {
+            FixedSizeListArray::new_unchecked(
+                new_elements,
+                array.list_size(),
+                Validity::NonNullable,
+                new_len,
+            )
+        }
+        .into_array());
+    }
+
+    take_non_nullable_fsl::<I, E>(array, indices_array)
+}
+
+fn take_primitive_non_nullable_elements_by_ranges<I: IntegerPType>(
+    array: ArrayView<'_, FixedSizeList>,
+    indices_array: ArrayView<'_, Primitive>,
+) -> VortexResult<Option<ArrayRef>> {
+    let Some(elements) = array.elements().as_typed::<Primitive>() else {
+        return Ok(None);
+    };
+    if !PrimitiveArrayExt::validity(&elements).definitely_no_nulls() {
+        return Ok(None);
+    }
+
+    match_each_native_ptype!(elements.ptype(), |T| {
+        Ok(Some(
+            take_primitive_non_nullable_elements_by_ranges_typed::<I, T>(
+                array,
+                indices_array,
+                elements,
+            ),
+        ))
+    })
+}
+
+fn take_primitive_non_nullable_elements_by_ranges_typed<I, T>(
+    array: ArrayView<'_, FixedSizeList>,
+    indices_array: ArrayView<'_, Primitive>,
+    elements: ArrayView<'_, Primitive>,
+) -> ArrayRef
+where
+    I: IntegerPType,
+    T: NativePType,
+{
+    let list_size = array.list_size() as usize;
+    let indices: &[I] = indices_array.as_slice::<I>();
+    let mut values = BufferMut::<T>::with_capacity(indices.len() * list_size);
+    let source = elements.as_slice::<T>();
+
+    for &data_idx in indices {
+        let data_idx = index_to_usize(data_idx);
+        let list_start = data_idx * list_size;
+        values.extend_from_slice(&source[list_start..list_start + list_size]);
+    }
+
+    PrimitiveArray::new(values.freeze(), Validity::from(elements.nullability())).into_array()
 }
 
 /// Takes from an array when either the array or indices are nullable.
@@ -218,4 +324,117 @@ fn take_nullable_fsl<I: IntegerPType, E: IntegerPType>(
         FixedSizeListArray::new_unchecked(new_elements, array.list_size(), new_validity, new_len)
     }
     .into_array())
+}
+
+/// Takes from an array when either the array or indices are nullable, copying each selected
+/// non-null list as a contiguous range.
+fn take_nullable_fsl_by_ranges<I: IntegerPType, E: IntegerPType>(
+    array: ArrayView<'_, FixedSizeList>,
+    indices_array: ArrayView<'_, Primitive>,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let indices: &[I] = indices_array.as_slice::<I>();
+    let new_len = indices.len();
+
+    let array_validity = array
+        .fixed_size_list_validity()
+        .execute_mask(array.as_ref().len(), ctx)
+        .vortex_expect("Failed to compute validity mask");
+    let indices_len = indices_array.as_ref().len();
+    let indices_validity = match indices_array
+        .validity()
+        .vortex_expect("Failed to compute validity mask")
+    {
+        Validity::NonNullable | Validity::AllValid => Mask::new_true(indices_len),
+        Validity::AllInvalid => Mask::new_false(indices_len),
+        Validity::Array(a) => a.execute::<BoolArray>(ctx)?.execute_mask(ctx),
+    };
+
+    if let Some((new_elements, new_validity)) = take_primitive_nullable_elements_by_ranges::<I>(
+        array,
+        indices_array,
+        &array_validity,
+        &indices_validity,
+    )? {
+        debug_assert!(new_validity.maybe_len().is_none_or(|vl| vl == new_len));
+        return Ok(unsafe {
+            FixedSizeListArray::new_unchecked(
+                new_elements,
+                array.list_size(),
+                new_validity,
+                new_len,
+            )
+        }
+        .into_array());
+    }
+
+    take_nullable_fsl::<I, E>(array, indices_array, ctx)
+}
+
+fn take_primitive_nullable_elements_by_ranges<I: IntegerPType>(
+    array: ArrayView<'_, FixedSizeList>,
+    indices_array: ArrayView<'_, Primitive>,
+    array_validity: &Mask,
+    indices_validity: &Mask,
+) -> VortexResult<Option<(ArrayRef, Validity)>> {
+    let Some(elements) = array.elements().as_typed::<Primitive>() else {
+        return Ok(None);
+    };
+    if !PrimitiveArrayExt::validity(&elements).definitely_no_nulls() {
+        return Ok(None);
+    }
+
+    match_each_native_ptype!(elements.ptype(), |T| {
+        Ok(Some(
+            take_primitive_nullable_elements_by_ranges_typed::<I, T>(
+                array,
+                indices_array,
+                elements,
+                array_validity,
+                indices_validity,
+            ),
+        ))
+    })
+}
+
+fn take_primitive_nullable_elements_by_ranges_typed<I, T>(
+    array: ArrayView<'_, FixedSizeList>,
+    indices_array: ArrayView<'_, Primitive>,
+    elements: ArrayView<'_, Primitive>,
+    array_validity: &Mask,
+    indices_validity: &Mask,
+) -> (ArrayRef, Validity)
+where
+    I: IntegerPType,
+    T: NativePType,
+{
+    let list_size = array.list_size() as usize;
+    let indices: &[I] = indices_array.as_slice::<I>();
+    let mut values = BufferMut::<T>::with_capacity(indices.len() * list_size);
+    let mut new_validity_builder = BitBufferMut::with_capacity(indices.len());
+    let source = elements.as_slice::<T>();
+
+    for (&data_idx, is_index_valid) in indices.iter().zip(indices_validity.iter()) {
+        let data_idx = index_to_usize(data_idx);
+        if !is_index_valid || !array_validity.value(data_idx) {
+            values.push_n(T::default(), list_size);
+            new_validity_builder.append(false);
+        } else {
+            let list_start = data_idx * list_size;
+            values.extend_from_slice(&source[list_start..list_start + list_size]);
+            new_validity_builder.append(true);
+        }
+    }
+
+    let new_elements =
+        PrimitiveArray::new(values.freeze(), Validity::from(elements.nullability())).into_array();
+    let new_validity = Validity::from(new_validity_builder.freeze());
+
+    (new_elements, new_validity)
+}
+
+fn index_to_usize<I: IntegerPType>(index: I) -> usize {
+    index
+        .to_usize()
+        .unwrap_or_else(|| vortex_panic!("Failed to convert index to usize: {}", index))
 }

--- a/vortex-array/src/arrays/fixed_size_list/tests/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/take.rs
@@ -128,6 +128,41 @@ fn test_take_large_list_size() {
 }
 
 #[test]
+fn test_take_range_path_large_list_size_non_nullable() {
+    let mut ctx = array_session().create_execution_ctx();
+    let elements = PrimitiveArray::from_iter(0i32..768).into_array();
+    let fsl = FixedSizeListArray::new(elements, 256, Validity::NonNullable, 3);
+
+    let indices = buffer![2u16, 0].into_array();
+    let result = fsl.take(indices).unwrap();
+
+    let expected_elems = PrimitiveArray::from_iter((512i32..768).chain(0..256)).into_array();
+    let expected = FixedSizeListArray::new(expected_elems, 256, Validity::NonNullable, 2);
+    assert_arrays_eq!(expected, result, &mut ctx);
+}
+
+#[test]
+fn test_take_range_path_large_list_size_nullable() {
+    let mut ctx = array_session().create_execution_ctx();
+    let elements = PrimitiveArray::from_iter(0i32..768).into_array();
+    let fsl = FixedSizeListArray::new(elements, 256, Validity::from_iter([true, false, true]), 3);
+
+    let indices = buffer![2u16, 1, 0].into_array();
+    let result = fsl.take(indices).unwrap();
+
+    let expected_elems =
+        PrimitiveArray::from_iter((512i32..768).chain((0..256).map(|_| 0)).chain(0..256))
+            .into_array();
+    let expected = FixedSizeListArray::new(
+        expected_elems,
+        256,
+        Validity::from_iter([true, false, true]),
+        3,
+    );
+    assert_arrays_eq!(expected, result, &mut ctx);
+}
+
+#[test]
 fn test_take_fsl_with_null_indices_preserves_elements() {
     let mut ctx = array_session().create_execution_ctx();
     let elements = buffer![1i32, 2, 3, 4, 5, 6].into_array();


### PR DESCRIPTION
## Summary
- copy selected fixed-size-list rows as contiguous primitive ranges when child elements are already canonical primitive values
- keep encoded and non-primitive children on the existing child `take` path so this does not force decompression
- expand `take_fsl` benchmark coverage across list byte widths and add forced strategy comparisons
- add nullable and non-nullable correctness coverage for the range-copy path

## Testing
- `cargo +nightly fmt --all`
- `cargo check -p vortex-array --bench take_fsl`
- `cargo test -p vortex-array fixed_size_list::tests::take`
- `cargo clippy --all-targets --all-features`
- `git diff --check`