### PR TITLE
Grow list builders as we append elements to it

### DIFF
--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -203,13 +203,20 @@ pub fn count_exceptions(bit_width: u8, bit_width_freq: &[usize]) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use std::sync::LazyLock;
 
     use vortex_array::Canonical;
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::ListArray;
+    use vortex_array::arrays::ListViewArray;
     use vortex_array::assert_arrays_eq;
+    use vortex_array::builders::ListBuilder;
+    use vortex_array::builders::ListViewBuilder;
+    use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
+    use vortex_array::dtype::PType;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
     use vortex_buffer::BufferMut;
@@ -264,6 +271,64 @@ mod tests {
         compression_roundtrip(1024);
         compression_roundtrip(10_000);
         compression_roundtrip(10_240);
+    }
+
+    /// List builders bulk-append the source's elements into their internal elements builder.
+    /// Fixed-width builder appends assume the caller reserved capacity, so the list builders
+    /// must grow the elements builder themselves; encoded elements exercise that because
+    /// BitPacked's `append_to_builder` writes through `uninit_range`.
+    #[test]
+    fn test_list_append_grows_elements_builder() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+
+        let elements = encode(&PrimitiveArray::from_iter((0..3072u32).map(|i| i % 256)), 8);
+        let element_dtype: Arc<DType> = Arc::new(PType::U32.into());
+
+        // 48 lists of 64 elements each.
+        let offsets = Buffer::from_iter((0..=48u64).map(|i| i * 64)).into_array();
+        let list = ListArray::try_new(
+            elements.clone().into_array(),
+            offsets,
+            Validity::NonNullable,
+        )?;
+
+        let mut listview_builder = ListViewBuilder::<u64, u32>::with_capacity(
+            Arc::clone(&element_dtype),
+            Nullability::NonNullable,
+            0,
+            0,
+        );
+        list.clone()
+            .into_array()
+            .append_to_builder(&mut listview_builder, &mut ctx)?;
+        assert_arrays_eq!(listview_builder.finish(), list, &mut ctx);
+
+        let mut list_builder = ListBuilder::<u64>::with_capacity(
+            Arc::clone(&element_dtype),
+            Nullability::NonNullable,
+            0,
+            0,
+        );
+        list.clone()
+            .into_array()
+            .append_to_builder(&mut list_builder, &mut ctx)?;
+        assert_arrays_eq!(list_builder.finish(), list, &mut ctx);
+
+        // A `ListViewArray` source appended into a `ListBuilder` appends elements list by list.
+        let listview = ListViewArray::try_new(
+            elements.into_array(),
+            Buffer::from_iter((0..48u64).map(|i| i * 64)).into_array(),
+            Buffer::from_iter(std::iter::repeat_n(64u32, 48)).into_array(),
+            Validity::NonNullable,
+        )?;
+        let mut list_builder =
+            ListBuilder::<u64>::with_capacity(element_dtype, Nullability::NonNullable, 0, 0);
+        listview
+            .into_array()
+            .append_to_builder(&mut list_builder, &mut ctx)?;
+        assert_arrays_eq!(list_builder.finish(), list, &mut ctx);
+
+        Ok(())
     }
 
     #[test]

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -111,6 +111,7 @@ impl<O: IntegerPType> ListBuilder<O> {
             self.element_dtype()
         );
 
+        self.elements_builder.reserve_exact(array.len());
         array.append_to_builder(self.elements_builder.as_mut(), ctx)?;
         self.nulls.append_non_null();
         self.offsets_builder.append_value(
@@ -192,7 +193,11 @@ where
     let num_lists = new_offsets.len();
     debug_assert_eq!(num_lists, new_sizes.len());
 
+    let total_elements: usize = new_sizes.iter().map(|size| size.as_()).sum();
+    builder.elements_builder.reserve_exact(total_elements);
+
     let mut curr_offset = builder.elements_builder.len();
+    builder.offsets_builder.reserve_exact(num_lists);
     let mut offsets_range = builder.offsets_builder.uninit_range(num_lists);
 
     // We need to append each list individually, converting from `ListViewArray` format to
@@ -315,12 +320,14 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
             // in bulk and the offsets rebased onto this builder's elements.
             let elements_base = self.elements_builder.len();
             if last > first {
+                self.elements_builder.reserve_exact(last - first);
                 array
                     .elements()
                     .slice(first..last)?
                     .append_to_builder(self.elements_builder.as_mut(), ctx)?;
             }
 
+            self.offsets_builder.reserve_exact(num_lists);
             let mut offsets_range = self.offsets_builder.uninit_range(num_lists);
             for i in 0..num_lists {
                 let end: usize = offsets[i + 1].as_();
@@ -612,6 +619,36 @@ mod tests {
         let mut list_builder_i16 = ListBuilder::<i16>::with_capacity(elem_dtype(), Nullable, 8, 4);
         listview.append_to_builder(&mut list_builder_i16, &mut ctx)?;
         assert_arrays_eq!(list_builder_i16.finish(), list, &mut ctx);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_append_list_arrays_grow_builder() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let dtype: Arc<DType> = Arc::new(I32.into());
+
+        // Enough lists to exceed the offsets capacity of a zero-capacity builder, so appending
+        // must grow the builder rather than panic in `uninit_range`.
+        let lists: Vec<Option<Vec<i32>>> =
+            (0..100).map(|i| (i % 10 != 0).then(|| vec![i])).collect();
+        let source = ListArray::from_iter_opt_slow::<u32, _, _>(lists.clone(), Arc::clone(&dtype))?;
+        let expected = ListArray::from_iter_opt_slow::<u32, _, _>(
+            lists.iter().cloned().chain(lists.iter().cloned()),
+            Arc::clone(&dtype),
+        )?;
+
+        // Appending twice checks growth from a non-empty builder and offset rebasing.
+        let mut builder = ListBuilder::<u32>::with_capacity(Arc::clone(&dtype), Nullable, 0, 0);
+        builder.append_list_array(source.as_view(), &mut ctx)?;
+        builder.append_list_array(source.as_view(), &mut ctx)?;
+        assert_arrays_eq!(builder.finish(), expected, &mut ctx);
+
+        let source_listview = source.into_array().execute::<ListViewArray>(&mut ctx)?;
+        let mut builder = ListBuilder::<u32>::with_capacity(dtype, Nullable, 0, 0);
+        builder.append_listview_array(source_listview.as_view(), &mut ctx)?;
+        builder.append_listview_array(source_listview.as_view(), &mut ctx)?;
+        assert_arrays_eq!(builder.finish(), expected, &mut ctx);
 
         Ok(())
     }

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -142,6 +142,7 @@ impl<O: IntegerPType, S: IntegerPType> ListViewBuilder<O, S> {
             "appending this list would cause an offset overflow"
         );
 
+        self.elements_builder.reserve_exact(num_elements);
         array.append_to_builder(self.elements_builder.as_mut(), ctx)?;
         self.nulls.append_non_null();
 
@@ -431,11 +432,14 @@ where
     );
 
     if last > first {
+        builder.elements_builder.reserve_exact(last - first);
         elements
             .slice(first..last)?
             .append_to_builder(builder.elements_builder.as_mut(), ctx)?;
     }
 
+    builder.offsets_builder.reserve_exact(num_lists);
+    builder.sizes_builder.reserve_exact(num_lists);
     let mut offsets_range = builder.offsets_builder.uninit_range(num_lists);
     let mut sizes_range = builder.sizes_builder.uninit_range(num_lists);
     for i in 0..num_lists {
@@ -504,6 +508,7 @@ mod tests {
 
     use vortex_buffer::buffer;
     use vortex_error::VortexExpect;
+    use vortex_error::VortexResult;
 
     use super::ListViewBuilder;
     use crate::IntoArray;
@@ -797,6 +802,35 @@ mod tests {
             PrimitiveArray::from_iter([4i32, 5]),
             &mut ctx
         );
+    }
+
+    #[test]
+    fn test_append_list_array_grows_builder() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let dtype: Arc<DType> = Arc::new(I32.into());
+
+        // Enough lists to exceed the offsets/sizes capacity of a zero-capacity builder, so
+        // appending must grow the builder rather than panic in `uninit_range`.
+        let lists: Vec<Option<Vec<i32>>> =
+            (0..100).map(|i| (i % 10 != 0).then(|| vec![i])).collect();
+        let source = ListArray::from_iter_opt_slow::<u32, _, _>(lists.clone(), Arc::clone(&dtype))?;
+
+        let mut builder =
+            ListViewBuilder::<u32, u32>::with_capacity(Arc::clone(&dtype), Nullable, 0, 0);
+        builder.append_list_array(source.as_view(), &mut ctx)?;
+        // Append a second time to check growth from a non-empty builder and offset rebasing.
+        builder.append_list_array(source.as_view(), &mut ctx)?;
+
+        let listview = builder.finish_into_listview();
+        assert!(listview.is_zero_copy_to_list());
+
+        let expected = ListArray::from_iter_opt_slow::<u32, _, _>(
+            lists.iter().cloned().chain(lists.iter().cloned()),
+            dtype,
+        )?;
+        assert_arrays_eq!(listview, expected, &mut ctx);
+
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Grow List/ListView builders when we append to them. Since they're variable
length we can't preallocate them

