### PR TITLE
Audit panic handling in detached tasks

### DIFF
--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -14,10 +14,8 @@ use std::task::Poll;
 
 use custom_labels::CURRENT_LABELSET;
 use futures::FutureExt;
-use futures::SinkExt;
 use futures::Stream;
 use futures::StreamExt;
-use futures::channel::mpsc;
 use futures::future::BoxFuture;
 use itertools::Itertools;
 use num_traits::AsPrimitive;
@@ -36,6 +34,7 @@ use vortex::error::VortexResult;
 use vortex::expr::Expression;
 use vortex::expr::stats::Precision;
 use vortex::file::v2::FileStatsLayoutReader;
+use vortex::io::kanal_ext::KanalExt as _;
 use vortex::io::runtime::BlockingRuntime as _;
 use vortex::io::runtime::current::ThreadSafeIterator;
 use vortex::layout::scan::multi::MultiLayoutChild;
@@ -230,7 +229,7 @@ pub fn init_global(init_input: &TableInitInput) -> VortexResult<TableFunctionGlo
 
     // We create an async bounded channel so that all thread-local workers can pull the next
     // available array chunk regardless of which partition it came from.
-    let (tx, rx) = mpsc::channel(num_workers * 2);
+    let (tx, rx) = kanal::bounded_async(num_workers * 2);
 
     // We drive one partition per worker thread. Each partition is driven as a spawned task
     // that pushes array chunks into the shared channel as they are produced. This spawning
@@ -239,7 +238,7 @@ pub fn init_global(init_input: &TableInitInput) -> VortexResult<TableFunctionGlo
     let stream = scan
         .partitions()
         .map(move |partition| {
-            let mut tx = tx.clone();
+            let tx = tx.clone();
             RUNTIME.handle().spawn(async move {
                 let partition = match partition {
                     Ok(partition) => partition,
@@ -288,13 +287,13 @@ pub fn init_global(init_input: &TableInitInput) -> VortexResult<TableFunctionGlo
     })
 }
 
-fn scan_driver_stream<S>(stream: S, rx: mpsc::Receiver<ScanItem>) -> ScanDriverStream
+fn scan_driver_stream<S>(stream: S, rx: kanal::AsyncReceiver<ScanItem>) -> ScanDriverStream
 where
     S: Stream<Item = ()> + Send + 'static,
 {
     ScanDriverStream {
         driver: Some(stream.collect::<()>().boxed()),
-        rx: rx.boxed(),
+        rx: rx.into_stream().boxed(),
     }
 }
 
@@ -585,8 +584,6 @@ mod tests {
     use std::sync::atomic::Ordering::Relaxed;
     use std::task::Poll;
 
-    use futures::channel::mpsc;
-
     use crate::RUNTIME;
     use crate::table_function::progress;
     use crate::table_function::scan_driver_stream;
@@ -607,7 +604,7 @@ mod tests {
 
     #[test]
     fn scan_driver_panic_propagates_through_iterator() {
-        let (tx, rx) = mpsc::channel(1);
+        let (tx, rx) = kanal::bounded_async(1);
         let _tx = tx;
         let stream = futures::stream::poll_fn(|_| -> Poll<Option<()>> {
             panic!("duckdb scan driver panic");

--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -4,13 +4,21 @@
 use std::cmp::max;
 use std::fmt::Formatter;
 use std::fmt::{self};
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
 
 use custom_labels::CURRENT_LABELSET;
+use futures::FutureExt;
+use futures::SinkExt;
+use futures::Stream;
 use futures::StreamExt;
+use futures::channel::mpsc;
+use futures::future::BoxFuture;
 use itertools::Itertools;
 use num_traits::AsPrimitive;
 use static_assertions::assert_impl_all;
@@ -28,7 +36,6 @@ use vortex::error::VortexResult;
 use vortex::expr::Expression;
 use vortex::expr::stats::Precision;
 use vortex::file::v2::FileStatsLayoutReader;
-use vortex::io::kanal_ext::KanalExt as _;
 use vortex::io::runtime::BlockingRuntime as _;
 use vortex::io::runtime::current::ThreadSafeIterator;
 use vortex::layout::scan::multi::MultiLayoutChild;
@@ -108,7 +115,8 @@ impl<'a> TableInitInput<'a> {
     }
 }
 
-type DataSourceIterator = ThreadSafeIterator<VortexResult<(ArrayRef, Arc<ConversionCache>)>>;
+type ScanItem = VortexResult<(ArrayRef, Arc<ConversionCache>)>;
+type DataSourceIterator = ThreadSafeIterator<ScanItem>;
 
 pub struct TableFunctionGlobal {
     iterator: DataSourceIterator,
@@ -222,7 +230,7 @@ pub fn init_global(init_input: &TableInitInput) -> VortexResult<TableFunctionGlo
 
     // We create an async bounded channel so that all thread-local workers can pull the next
     // available array chunk regardless of which partition it came from.
-    let (tx, rx) = kanal::bounded_async(num_workers * 2);
+    let (tx, rx) = mpsc::channel(num_workers * 2);
 
     // We drive one partition per worker thread. Each partition is driven as a spawned task
     // that pushes array chunks into the shared channel as they are produced. This spawning
@@ -231,7 +239,7 @@ pub fn init_global(init_input: &TableInitInput) -> VortexResult<TableFunctionGlo
     let stream = scan
         .partitions()
         .map(move |partition| {
-            let tx = tx.clone();
+            let mut tx = tx.clone();
             RUNTIME.handle().spawn(async move {
                 let partition = match partition {
                     Ok(partition) => partition,
@@ -268,10 +276,7 @@ pub fn init_global(init_input: &TableInitInput) -> VortexResult<TableFunctionGlo
         })
         .buffer_unordered(num_workers);
 
-    // Spawn a task to drive the partition stream and push array chunks into the channel.
-    RUNTIME.handle().spawn(stream.collect::<()>()).detach();
-
-    let iterator = RUNTIME.block_on_stream_thread_safe(|_handle| rx.into_stream());
+    let iterator = RUNTIME.block_on_stream_thread_safe(|_handle| scan_driver_stream(stream, rx));
 
     Ok(TableFunctionGlobal {
         iterator,
@@ -281,6 +286,39 @@ pub fn init_global(init_input: &TableInitInput) -> VortexResult<TableFunctionGlo
         file_index_column_pos,
         file_row_number_column_pos,
     })
+}
+
+fn scan_driver_stream<S>(stream: S, rx: mpsc::Receiver<ScanItem>) -> ScanDriverStream
+where
+    S: Stream<Item = ()> + Send + 'static,
+{
+    ScanDriverStream {
+        driver: Some(stream.collect::<()>().boxed()),
+        rx: rx.boxed(),
+    }
+}
+
+struct ScanDriverStream {
+    driver: Option<BoxFuture<'static, ()>>,
+    rx: futures::stream::BoxStream<'static, ScanItem>,
+}
+
+impl Stream for ScanDriverStream {
+    type Item = ScanItem;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if let Some(driver) = this.driver.as_mut()
+            && driver.as_mut().poll(cx).is_ready()
+        {
+            this.driver = None;
+        }
+
+        match this.rx.as_mut().poll_next(cx) {
+            Poll::Ready(None) if this.driver.is_some() => Poll::Pending,
+            poll => poll,
+        }
+    }
 }
 
 pub fn init_local(global: &TableFunctionGlobal) -> TableFunctionLocal {
@@ -545,8 +583,13 @@ fn progress(bytes_read: &AtomicU64, bytes_total: &AtomicU64) -> f64 {
 mod tests {
     use std::sync::atomic::AtomicU64;
     use std::sync::atomic::Ordering::Relaxed;
+    use std::task::Poll;
 
+    use futures::channel::mpsc;
+
+    use crate::RUNTIME;
     use crate::table_function::progress;
+    use crate::table_function::scan_driver_stream;
 
     #[test]
     fn test_table_scan_progress() {
@@ -560,5 +603,27 @@ mod tests {
 
         bytes_total.fetch_add(100, Relaxed);
         assert!((progress(&bytes_read, &bytes_total) - 50.).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn scan_driver_panic_propagates_through_iterator() {
+        let (tx, rx) = mpsc::channel(1);
+        let _tx = tx;
+        let stream = futures::stream::poll_fn(|_| -> Poll<Option<()>> {
+            panic!("duckdb scan driver panic");
+        });
+
+        let mut iter =
+            RUNTIME.block_on_stream_thread_safe(|_handle| scan_driver_stream(stream, rx));
+        let panic = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| iter.next())) {
+            Ok(_) => panic!("driver panic must propagate through iterator"),
+            Err(panic) => panic,
+        };
+        let message = panic
+            .downcast_ref::<&'static str>()
+            .copied()
+            .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+            .unwrap_or("<unknown panic>");
+        assert!(message.contains("duckdb scan driver panic"));
     }
 }

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -223,19 +223,24 @@ impl Future for ReadFuture {
     type Output = VortexResult<BufferHandle>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let _ = self.driver_task.poll(cx);
-
         match self.recv.poll_unpin(cx) {
-            Poll::Ready(result) => {
+            // note: we are skipping polled and dropped events for this if the future is ready on
+            //       the first poll, that means this request was completed before it was polled,
+            //       as part of a coalesced request.
+            Poll::Ready(Ok(result)) => {
                 self.finished = true;
-                // note: we are skipping polled and dropped events for this if the future
-                //       is ready on the first poll, that means this request was completed
-                //       before it was polled, as part of a coalesced request.
-                Poll::Ready(result.unwrap_or_else(|e| {
-                    let _ = self.driver_task.poll(cx);
-                    Err(vortex_err!("ReadRequest dropped by runtime: {e}"))
-                }))
+                Poll::Ready(result)
             }
+            // The request's sender was dropped, so the driver task has finished. Join it so a
+            // panic raised while driving reads is re-raised here rather than surfacing as a
+            // generic error. Only report the dropped error once the driver has finished cleanly.
+            Poll::Ready(Err(e)) => match self.driver_task.poll(cx) {
+                Poll::Ready(()) => {
+                    self.finished = true;
+                    Poll::Ready(Err(vortex_err!("ReadRequest dropped by runtime: {e}")))
+                }
+                Poll::Pending => Poll::Pending,
+            },
             Poll::Pending if !self.polled => {
                 self.polled = true;
                 // Notify the I/O stream that this request has been polled.
@@ -267,16 +272,19 @@ impl DriverTask {
             return Poll::Pending;
         };
 
-        let Some(task) = guard.as_mut() else {
+        // Take the task out while polling: if the poll re-raises a driver panic, the handle is
+        // dropped during unwind and never put back, so a concurrent reader observes `None` here
+        // and reports a dropped error rather than re-polling an already-completed handle.
+        let Some(mut task) = guard.take() else {
             return Poll::Ready(());
         };
 
-        match Pin::new(task).poll(cx) {
-            Poll::Ready(()) => {
-                *guard = None;
-                Poll::Ready(())
+        match Pin::new(&mut task).poll(cx) {
+            Poll::Ready(()) => Poll::Ready(()),
+            Poll::Pending => {
+                *guard = Some(task);
+                Poll::Pending
             }
-            Poll::Pending => Poll::Pending,
         }
     }
 }
@@ -365,6 +373,8 @@ impl SegmentSource for BufferSegmentSource {
 
 #[cfg(test)]
 mod tests {
+    use std::panic::AssertUnwindSafe;
+
     use futures::future::BoxFuture;
     use vortex_io::runtime::tokio::TokioRuntime;
     use vortex_layout::segments::SegmentSource;
@@ -397,22 +407,103 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    #[should_panic(expected = "Runtime dropped task without completing it, likely it panicked")]
-    async fn file_segment_source_propagates_read_driver_panic() {
+    fn panicking_source() -> FileSegmentSource {
         let segments: Arc<[SegmentSpec]> = Arc::from([SegmentSpec {
             offset: 0,
             length: 4,
             alignment: Alignment::none(),
         }]);
         let metrics = DefaultMetricsRegistry::default();
-        let source = FileSegmentSource::open(
+        FileSegmentSource::open(
             segments,
             PanickingReadAt,
             TokioRuntime::current(),
             RequestMetrics::new(&metrics, vec![]),
-        );
+        )
+    }
 
+    #[tokio::test]
+    #[should_panic(expected = "Runtime dropped task without completing it, likely it panicked")]
+    async fn file_segment_source_propagates_read_driver_panic() {
+        let source = panicking_source();
         let _result = source.request(SegmentId::from(0)).await;
+    }
+
+    // A read-driver panic must propagate on *every* run rather than sometimes surfacing as a
+    // generic "dropped by runtime" error, which is nondeterministic.
+    #[tokio::test]
+    async fn file_segment_source_read_driver_panic_propagates_deterministically() {
+        for i in 0..100 {
+            let source = panicking_source();
+            let outcome = AssertUnwindSafe(source.request(SegmentId::from(0)))
+                .catch_unwind()
+                .await;
+            assert!(
+                outcome.is_err(),
+                "read-driver panic was not propagated on iteration {i}; \
+                 the request resolved instead of panicking"
+            );
+        }
+    }
+
+    #[derive(Clone)]
+    struct SlowErrReadAt;
+
+    impl VortexReadAt for SlowErrReadAt {
+        fn concurrency(&self) -> usize {
+            4
+        }
+
+        fn size(&self) -> BoxFuture<'static, VortexResult<u64>> {
+            async { Ok(1024) }.boxed()
+        }
+
+        fn read_at(
+            &self,
+            offset: u64,
+            _length: usize,
+            _alignment: Alignment,
+        ) -> BoxFuture<'static, VortexResult<BufferHandle>> {
+            async move {
+                // Stagger completions so some reads finish while others are still in flight.
+                for _ in 0..(offset as usize % 5 + 1) {
+                    tokio::task::yield_now().await;
+                }
+                vortex_bail!("slow read done")
+            }
+            .boxed()
+        }
+    }
+
+    // Many segment reads driven on separate tasks must all make progress and complete.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn read_driver_concurrent_reads_make_progress() {
+        let n = 16u32;
+        let segments: Arc<[SegmentSpec]> = (0..n)
+            .map(|i| SegmentSpec {
+                offset: u64::from(i) * 4,
+                length: 4,
+                alignment: Alignment::none(),
+            })
+            .collect();
+        let metrics = DefaultMetricsRegistry::default();
+        let source = Arc::new(FileSegmentSource::open(
+            segments,
+            SlowErrReadAt,
+            TokioRuntime::current(),
+            RequestMetrics::new(&metrics, vec![]),
+        ));
+
+        let tasks: Vec<_> = (0..n)
+            .map(|i| {
+                let source = Arc::clone(&source);
+                tokio::spawn(async move { source.request(SegmentId::from(i)).await })
+            })
+            .collect();
+
+        let joined =
+            tokio::time::timeout(std::time::Duration::from_secs(5), future::join_all(tasks)).await;
+
+        assert!(joined.is_ok(), "concurrent reads stalled before completing");
     }
 }

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -423,7 +423,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Runtime dropped task without completing it, likely it panicked")]
+    #[should_panic(expected = "read-at panic")]
     async fn file_segment_source_propagates_read_driver_panic() {
         let source = panicking_source();
         let _result = source.request(SegmentId::from(0)).await;

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -24,6 +24,7 @@ use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 use vortex_io::VortexReadAt;
 use vortex_io::runtime::Handle;
+use vortex_io::runtime::JoinOutcome;
 use vortex_io::runtime::Task;
 use vortex_layout::segments::SegmentFuture;
 use vortex_layout::segments::SegmentId;
@@ -261,7 +262,10 @@ struct DriverTask {
 }
 
 struct DriverTaskState {
+    /// Background driver task
     task: Option<Task<()>>,
+    /// Waiters for tasks that might wait on this driver,
+    /// which we wake up on panic, abort or at the end.
     waiters: Vec<Waker>,
     finished: bool,
 }
@@ -294,24 +298,31 @@ impl DriverTask {
             return Poll::Pending;
         };
 
-        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            Pin::new(&mut task).poll(cx)
-        })) {
-            Ok(Poll::Ready(())) => {
+        match task.poll_join(cx) {
+            // The driver finished cleanly, or the runtime dropped it before it completed (for
+            // example during shutdown). Neither carries a panic, so readers report a graceful
+            // dropped error rather than turning a benign teardown into a panic.
+            Poll::Ready(JoinOutcome::Completed(()) | JoinOutcome::Aborted) => {
                 let waiters = state.finish();
                 drop(state);
-                wake_all(waiters);
+                for waiter in waiters {
+                    waiter.wake();
+                }
                 Poll::Ready(())
             }
-            Ok(Poll::Pending) => {
+            Poll::Pending => {
                 state.task = Some(task);
                 state.register(cx.waker());
                 Poll::Pending
             }
-            Err(panic) => {
+            // A panic raised while driving reads: re-raise it here so it surfaces to the caller
+            // instead of collapsing into a generic error.
+            Poll::Ready(JoinOutcome::Panicked(panic)) => {
                 let waiters = state.finish();
                 drop(state);
-                wake_all(waiters);
+                for waiter in waiters {
+                    waiter.wake();
+                }
                 std::panic::resume_unwind(panic)
             }
         }
@@ -329,12 +340,6 @@ impl DriverTaskState {
         self.finished = true;
         self.task = None;
         std::mem::take(&mut self.waiters)
-    }
-}
-
-fn wake_all(waiters: Vec<Waker>) {
-    for waiter in waiters {
-        waiter.wake();
     }
 }
 

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -8,12 +9,13 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::task::Context;
 use std::task::Poll;
-use std::task::Waker;
 
 use futures::FutureExt;
 use futures::StreamExt;
 use futures::channel::mpsc;
 use futures::future;
+use futures::future::BoxFuture;
+use futures::future::Shared;
 use parking_lot::Mutex;
 use vortex_array::buffer::BufferHandle;
 use vortex_buffer::Alignment;
@@ -25,7 +27,6 @@ use vortex_error::vortex_panic;
 use vortex_io::VortexReadAt;
 use vortex_io::runtime::Handle;
 use vortex_io::runtime::JoinOutcome;
-use vortex_io::runtime::Task;
 use vortex_layout::segments::SegmentFuture;
 use vortex_layout::segments::SegmentId;
 use vortex_layout::segments::SegmentSource;
@@ -72,12 +73,26 @@ pub enum ReadEvent {
 ///
 /// I/O requests will be processed in the order they are `registered`, however coalescing may mean
 /// other registered requests are lumped together into a single I/O operation.
+/// A cloneable handle to the background read driver, shared by every in-flight [`ReadFuture`].
+///
+/// [`Shared`] fans a single completion out to all readers with correct waker bookkeeping, so a
+/// reader is always woken when the driver finishes — even if another reader polled the driver more
+/// recently and was then dropped. Its output is `()`; a driver panic is carried out of band in
+/// [`DriverPanic`] so it can be re-raised on the reader side.
+type SharedDriver = Shared<BoxFuture<'static, ()>>;
+
+/// Slot holding the driver's panic payload, if it panicked while driving reads. The first reader to
+/// observe completion takes the payload and re-raises it; later readers report a graceful error.
+type DriverPanic = Arc<Mutex<Option<Box<dyn Any + Send>>>>;
+
 pub struct FileSegmentSource {
     segments: Arc<[SegmentSpec]>,
     /// A queue for sending read request events to the I/O stream.
     events: mpsc::UnboundedSender<ReadEvent>,
-    /// Background request driver task.
-    driver_task: DriverTask,
+    /// Background request driver, joined by readers to surface a driver panic.
+    driver: SharedDriver,
+    /// Panic payload captured if the driver panicked while driving reads.
+    driver_panic: DriverPanic,
     /// The next read request ID.
     next_id: Arc<AtomicUsize>,
 }
@@ -151,12 +166,30 @@ impl FileSegmentSource {
                 .await
         };
 
-        let driver_task = DriverTask::new(handle.spawn(drive_fut));
+        // Spawn the driver so the runtime makes I/O progress independently of any reader. Readers
+        // join it (below) only to surface a panic raised while driving reads.
+        let mut task = handle.spawn(drive_fut);
+        let driver_panic: DriverPanic = Arc::new(Mutex::new(None));
+        let driver = {
+            let driver_panic = Arc::clone(&driver_panic);
+            async move {
+                // Poll for the terminal outcome without re-raising: a benign abort (runtime
+                // teardown) resolves to `()` so readers report a graceful error, while a panic is
+                // stashed for the first reader to re-raise.
+                if let JoinOutcome::Panicked(panic) = future::poll_fn(|cx| task.poll_join(cx)).await
+                {
+                    *driver_panic.lock() = Some(panic);
+                }
+            }
+            .boxed()
+            .shared()
+        };
 
         Self {
             segments,
             events: send,
-            driver_task,
+            driver,
+            driver_panic,
             next_id: Arc::new(AtomicUsize::new(0)),
         }
     }
@@ -200,7 +233,8 @@ impl SegmentSource for FileSegmentSource {
             polled: false,
             finished: false,
             events: self.events.clone(),
-            driver_task: self.driver_task.clone(),
+            driver: self.driver.clone(),
+            driver_panic: Arc::clone(&self.driver_panic),
         };
 
         // One allocation: we only box the returned SegmentFuture, not the inner ReadFuture.
@@ -218,7 +252,8 @@ struct ReadFuture {
     polled: bool,
     finished: bool,
     events: mpsc::UnboundedSender<ReadEvent>,
-    driver_task: DriverTask,
+    driver: SharedDriver,
+    driver_panic: DriverPanic,
 }
 
 impl Future for ReadFuture {
@@ -233,12 +268,17 @@ impl Future for ReadFuture {
                 self.finished = true;
                 Poll::Ready(result)
             }
-            // The request's sender was dropped, so the driver task has finished. Join it so a
-            // panic raised while driving reads is re-raised here rather than surfacing as a
-            // generic error. Only report the dropped error once the driver has finished cleanly.
-            Poll::Ready(Err(e)) => match self.driver_task.poll(cx) {
+            // The request's sender was dropped, so the driver has finished. Join it so a panic
+            // raised while driving reads is re-raised here rather than surfacing as a generic
+            // error. Only report the dropped error once the driver has finished.
+            Poll::Ready(Err(e)) => match self.driver.poll_unpin(cx) {
                 Poll::Ready(()) => {
                     self.finished = true;
+                    // Re-raise the driver panic on the first reader to observe it; later readers
+                    // fall through to the graceful dropped error.
+                    if let Some(panic) = self.driver_panic.lock().take() {
+                        std::panic::resume_unwind(panic);
+                    }
                     Poll::Ready(Err(vortex_err!("ReadRequest dropped by runtime: {e}")))
                 }
                 Poll::Pending => Poll::Pending,
@@ -253,93 +293,6 @@ impl Future for ReadFuture {
             }
             _ => Poll::Pending,
         }
-    }
-}
-
-#[derive(Clone)]
-struct DriverTask {
-    state: Arc<Mutex<DriverTaskState>>,
-}
-
-struct DriverTaskState {
-    /// Background driver task
-    task: Option<Task<()>>,
-    /// Waiters for tasks that might wait on this driver,
-    /// which we wake up on panic, abort or at the end.
-    waiters: Vec<Waker>,
-    finished: bool,
-}
-
-impl DriverTask {
-    fn new(task: Task<()>) -> Self {
-        Self {
-            state: Arc::new(Mutex::new(DriverTaskState {
-                task: Some(task),
-                waiters: Vec::new(),
-                finished: false,
-            })),
-        }
-    }
-
-    fn poll(&self, cx: &mut Context<'_>) -> Poll<()> {
-        let Some(mut state) = self.state.try_lock() else {
-            cx.waker().wake_by_ref();
-            return Poll::Pending;
-        };
-
-        if state.finished {
-            return Poll::Ready(());
-        }
-
-        // Take the task out while polling so completion can be cached before waking every reader
-        // parked on the shared task.
-        let Some(mut task) = state.task.take() else {
-            state.register(cx.waker());
-            return Poll::Pending;
-        };
-
-        match task.poll_join(cx) {
-            // The driver finished cleanly, or the runtime dropped it before it completed (for
-            // example during shutdown). Neither carries a panic, so readers report a graceful
-            // dropped error rather than turning a benign teardown into a panic.
-            Poll::Ready(JoinOutcome::Completed(()) | JoinOutcome::Aborted) => {
-                let waiters = state.finish();
-                drop(state);
-                for waiter in waiters {
-                    waiter.wake();
-                }
-                Poll::Ready(())
-            }
-            Poll::Pending => {
-                state.task = Some(task);
-                state.register(cx.waker());
-                Poll::Pending
-            }
-            // A panic raised while driving reads: re-raise it here so it surfaces to the caller
-            // instead of collapsing into a generic error.
-            Poll::Ready(JoinOutcome::Panicked(panic)) => {
-                let waiters = state.finish();
-                drop(state);
-                for waiter in waiters {
-                    waiter.wake();
-                }
-                std::panic::resume_unwind(panic)
-            }
-        }
-    }
-}
-
-impl DriverTaskState {
-    fn register(&mut self, waker: &Waker) {
-        if !self.waiters.iter().any(|waiter| waiter.will_wake(waker)) {
-            self.waiters.push(waker.clone());
-        }
-    }
-
-    fn finish(&mut self) -> Vec<Waker> {
-        self.finished = true;
-        self.task = None;
-        std::mem::take(&mut self.waiters)
     }
 }
 
@@ -476,7 +429,7 @@ mod tests {
         )
     }
 
-    fn panic_message(payload: &(dyn std::any::Any + Send)) -> &str {
+    fn panic_message(payload: &(dyn Any + Send)) -> &str {
         payload
             .downcast_ref::<&str>()
             .copied()
@@ -508,65 +461,52 @@ mod tests {
         }
     }
 
+    // A driver panic must surface to every concurrent reader sharing one driver: exactly one
+    // reader re-raises the original panic, the rest report a graceful error, and none hang. This
+    // also covers the fan-out invariant — `Shared` wakes every reader on completion, so a reader
+    // dropped mid-flight can never swallow another reader's wake-up.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn read_driver_panic_wakes_all_waiters() {
-        let waiter_count = 8;
-        let (release_send, release_recv) = oneshot::channel();
-        let task = TokioRuntime::current().spawn(async move {
-            let _ = release_recv.into_future().await;
-            panic!("read-at panic");
-        });
-        let driver_task = DriverTask::new(task);
-        let registered = Arc::new(AtomicUsize::new(0));
+    async fn file_segment_source_panic_propagates_to_all_concurrent_readers() {
+        let source = Arc::new(panicking_source());
+        let reader_count = 8;
 
-        let waiters: Vec<_> = (0..waiter_count)
+        let readers: Vec<_> = (0..reader_count)
             .map(|_| {
-                let driver_task = driver_task.clone();
-                let registered = Arc::clone(&registered);
+                let source = Arc::clone(&source);
                 tokio::spawn(async move {
-                    let mut counted = false;
-                    AssertUnwindSafe(future::poll_fn(move |cx| {
-                        let poll = driver_task.poll(cx);
-                        if matches!(poll, Poll::Pending) && !counted {
-                            counted = true;
-                            registered.fetch_add(1, Ordering::SeqCst);
-                        }
-                        poll
-                    }))
-                    .catch_unwind()
-                    .await
+                    AssertUnwindSafe(source.request(SegmentId::from(0)))
+                        .catch_unwind()
+                        .await
                 })
             })
             .collect();
 
-        while registered.load(Ordering::SeqCst) < waiter_count {
-            tokio::task::yield_now().await;
-        }
-
-        release_send
-            .send(())
-            .expect("driver task should still be waiting for release");
         let joined =
-            tokio::time::timeout(std::time::Duration::from_secs(5), future::join_all(waiters))
+            tokio::time::timeout(std::time::Duration::from_secs(5), future::join_all(readers))
                 .await
-                .expect("driver panic left waiters parked");
+                .expect("a reader hung instead of observing the driver panic");
 
-        let mut saw_panic = false;
-        for waiter in joined {
-            match waiter.expect("waiter task should catch driver panic") {
-                Ok(()) => {}
+        let mut original_panics = 0;
+        for reader in joined {
+            match reader.expect("reader task panicked at the join boundary") {
+                // The first reader to observe completion re-raises the original panic.
                 Err(payload) => {
-                    saw_panic = true;
                     assert!(
                         panic_message(&*payload).contains("read-at panic"),
                         "got: {:?}",
                         panic_message(&*payload)
                     );
+                    original_panics += 1;
                 }
+                // Every other reader reports a graceful dropped-by-runtime error.
+                Ok(result) => assert!(result.is_err(), "expected a dropped-by-runtime error"),
             }
         }
 
-        assert!(saw_panic, "driver panic was not propagated to any waiter");
+        assert_eq!(
+            original_panics, 1,
+            "exactly one reader should re-raise the original driver panic"
+        );
     }
 
     #[derive(Clone)]

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::task::Context;
 use std::task::Poll;
+use std::task::Waker;
 
 use futures::FutureExt;
 use futures::StreamExt;
@@ -256,36 +257,84 @@ impl Future for ReadFuture {
 
 #[derive(Clone)]
 struct DriverTask {
-    task: Arc<Mutex<Option<Task<()>>>>,
+    state: Arc<Mutex<DriverTaskState>>,
+}
+
+struct DriverTaskState {
+    task: Option<Task<()>>,
+    waiters: Vec<Waker>,
+    finished: bool,
 }
 
 impl DriverTask {
     fn new(task: Task<()>) -> Self {
         Self {
-            task: Arc::new(Mutex::new(Some(task))),
+            state: Arc::new(Mutex::new(DriverTaskState {
+                task: Some(task),
+                waiters: Vec::new(),
+                finished: false,
+            })),
         }
     }
 
     fn poll(&self, cx: &mut Context<'_>) -> Poll<()> {
-        let Some(mut guard) = self.task.try_lock() else {
+        let Some(mut state) = self.state.try_lock() else {
             cx.waker().wake_by_ref();
             return Poll::Pending;
         };
 
-        // Take the task out while polling: if the poll re-raises a driver panic, the handle is
-        // dropped during unwind and never put back, so a concurrent reader observes `None` here
-        // and reports a dropped error rather than re-polling an already-completed handle.
-        let Some(mut task) = guard.take() else {
+        if state.finished {
             return Poll::Ready(());
+        }
+
+        // Take the task out while polling so completion can be cached before waking every reader
+        // parked on the shared task.
+        let Some(mut task) = state.task.take() else {
+            state.register(cx.waker());
+            return Poll::Pending;
         };
 
-        match Pin::new(&mut task).poll(cx) {
-            Poll::Ready(()) => Poll::Ready(()),
-            Poll::Pending => {
-                *guard = Some(task);
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            Pin::new(&mut task).poll(cx)
+        })) {
+            Ok(Poll::Ready(())) => {
+                let waiters = state.finish();
+                drop(state);
+                wake_all(waiters);
+                Poll::Ready(())
+            }
+            Ok(Poll::Pending) => {
+                state.task = Some(task);
+                state.register(cx.waker());
                 Poll::Pending
             }
+            Err(panic) => {
+                let waiters = state.finish();
+                drop(state);
+                wake_all(waiters);
+                std::panic::resume_unwind(panic)
+            }
         }
+    }
+}
+
+impl DriverTaskState {
+    fn register(&mut self, waker: &Waker) {
+        if !self.waiters.iter().any(|waiter| waiter.will_wake(waker)) {
+            self.waiters.push(waker.clone());
+        }
+    }
+
+    fn finish(&mut self) -> Vec<Waker> {
+        self.finished = true;
+        self.task = None;
+        std::mem::take(&mut self.waiters)
+    }
+}
+
+fn wake_all(waiters: Vec<Waker>) {
+    for waiter in waiters {
+        waiter.wake();
     }
 }
 
@@ -422,6 +471,14 @@ mod tests {
         )
     }
 
+    fn panic_message(payload: &(dyn std::any::Any + Send)) -> &str {
+        payload
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+            .unwrap_or("<non-string panic>")
+    }
+
     #[tokio::test]
     #[should_panic(expected = "read-at panic")]
     async fn file_segment_source_propagates_read_driver_panic() {
@@ -444,6 +501,67 @@ mod tests {
                  the request resolved instead of panicking"
             );
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn read_driver_panic_wakes_all_waiters() {
+        let waiter_count = 8;
+        let (release_send, release_recv) = oneshot::channel();
+        let task = TokioRuntime::current().spawn(async move {
+            let _ = release_recv.into_future().await;
+            panic!("read-at panic");
+        });
+        let driver_task = DriverTask::new(task);
+        let registered = Arc::new(AtomicUsize::new(0));
+
+        let waiters: Vec<_> = (0..waiter_count)
+            .map(|_| {
+                let driver_task = driver_task.clone();
+                let registered = Arc::clone(&registered);
+                tokio::spawn(async move {
+                    let mut counted = false;
+                    AssertUnwindSafe(future::poll_fn(move |cx| {
+                        let poll = driver_task.poll(cx);
+                        if matches!(poll, Poll::Pending) && !counted {
+                            counted = true;
+                            registered.fetch_add(1, Ordering::SeqCst);
+                        }
+                        poll
+                    }))
+                    .catch_unwind()
+                    .await
+                })
+            })
+            .collect();
+
+        while registered.load(Ordering::SeqCst) < waiter_count {
+            tokio::task::yield_now().await;
+        }
+
+        release_send
+            .send(())
+            .expect("driver task should still be waiting for release");
+        let joined =
+            tokio::time::timeout(std::time::Duration::from_secs(5), future::join_all(waiters))
+                .await
+                .expect("driver panic left waiters parked");
+
+        let mut saw_panic = false;
+        for waiter in joined {
+            match waiter.expect("waiter task should catch driver panic") {
+                Ok(()) => {}
+                Err(payload) => {
+                    saw_panic = true;
+                    assert!(
+                        panic_message(&*payload).contains("read-at panic"),
+                        "got: {:?}",
+                        panic_message(&*payload)
+                    );
+                }
+            }
+        }
+
+        assert!(saw_panic, "driver panic was not propagated to any waiter");
     }
 
     #[derive(Clone)]

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
@@ -12,6 +13,7 @@ use futures::FutureExt;
 use futures::StreamExt;
 use futures::channel::mpsc;
 use futures::future;
+use parking_lot::Mutex;
 use vortex_array::buffer::BufferHandle;
 use vortex_buffer::Alignment;
 use vortex_buffer::ByteBuffer;
@@ -21,6 +23,7 @@ use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 use vortex_io::VortexReadAt;
 use vortex_io::runtime::Handle;
+use vortex_io::runtime::Task;
 use vortex_layout::segments::SegmentFuture;
 use vortex_layout::segments::SegmentId;
 use vortex_layout::segments::SegmentSource;
@@ -71,6 +74,8 @@ pub struct FileSegmentSource {
     segments: Arc<[SegmentSpec]>,
     /// A queue for sending read request events to the I/O stream.
     events: mpsc::UnboundedSender<ReadEvent>,
+    /// Background request driver task.
+    driver_task: DriverTask,
     /// The next read request ID.
     next_id: Arc<AtomicUsize>,
 }
@@ -144,11 +149,12 @@ impl FileSegmentSource {
                 .await
         };
 
-        handle.spawn(drive_fut).detach();
+        let driver_task = DriverTask::new(handle.spawn(drive_fut));
 
         Self {
             segments,
             events: send,
+            driver_task,
             next_id: Arc::new(AtomicUsize::new(0)),
         }
     }
@@ -192,6 +198,7 @@ impl SegmentSource for FileSegmentSource {
             polled: false,
             finished: false,
             events: self.events.clone(),
+            driver_task: self.driver_task.clone(),
         };
 
         // One allocation: we only box the returned SegmentFuture, not the inner ReadFuture.
@@ -209,23 +216,25 @@ struct ReadFuture {
     polled: bool,
     finished: bool,
     events: mpsc::UnboundedSender<ReadEvent>,
+    driver_task: DriverTask,
 }
 
 impl Future for ReadFuture {
     type Output = VortexResult<BufferHandle>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let _ = self.driver_task.poll(cx);
+
         match self.recv.poll_unpin(cx) {
             Poll::Ready(result) => {
                 self.finished = true;
                 // note: we are skipping polled and dropped events for this if the future
                 //       is ready on the first poll, that means this request was completed
                 //       before it was polled, as part of a coalesced request.
-                Poll::Ready(
-                    result.unwrap_or_else(|e| {
-                        Err(vortex_err!("ReadRequest dropped by runtime: {e}"))
-                    }),
-                )
+                Poll::Ready(result.unwrap_or_else(|e| {
+                    let _ = self.driver_task.poll(cx);
+                    Err(vortex_err!("ReadRequest dropped by runtime: {e}"))
+                }))
             }
             Poll::Pending if !self.polled => {
                 self.polled = true;
@@ -236,6 +245,38 @@ impl Future for ReadFuture {
                 }
             }
             _ => Poll::Pending,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct DriverTask {
+    task: Arc<Mutex<Option<Task<()>>>>,
+}
+
+impl DriverTask {
+    fn new(task: Task<()>) -> Self {
+        Self {
+            task: Arc::new(Mutex::new(Some(task))),
+        }
+    }
+
+    fn poll(&self, cx: &mut Context<'_>) -> Poll<()> {
+        let Some(mut guard) = self.task.try_lock() else {
+            cx.waker().wake_by_ref();
+            return Poll::Pending;
+        };
+
+        let Some(task) = guard.as_mut() else {
+            return Poll::Ready(());
+        };
+
+        match Pin::new(task).poll(cx) {
+            Poll::Ready(()) => {
+                *guard = None;
+                Poll::Ready(())
+            }
+            Poll::Pending => Poll::Pending,
         }
     }
 }
@@ -319,5 +360,59 @@ impl SegmentSource for BufferSegmentSource {
 
         let slice = self.buffer.slice(start..end).aligned(spec.alignment);
         future::ready(Ok(BufferHandle::new_host(slice))).boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::future::BoxFuture;
+    use vortex_io::runtime::tokio::TokioRuntime;
+    use vortex_layout::segments::SegmentSource;
+    use vortex_metrics::DefaultMetricsRegistry;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct PanickingReadAt;
+
+    impl VortexReadAt for PanickingReadAt {
+        fn concurrency(&self) -> usize {
+            1
+        }
+
+        fn size(&self) -> BoxFuture<'static, VortexResult<u64>> {
+            async { Ok(4) }.boxed()
+        }
+
+        fn read_at(
+            &self,
+            _offset: u64,
+            _length: usize,
+            _alignment: Alignment,
+        ) -> BoxFuture<'static, VortexResult<BufferHandle>> {
+            async {
+                panic!("read-at panic");
+            }
+            .boxed()
+        }
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "Runtime dropped task without completing it, likely it panicked")]
+    async fn file_segment_source_propagates_read_driver_panic() {
+        let segments: Arc<[SegmentSpec]> = Arc::from([SegmentSpec {
+            offset: 0,
+            length: 4,
+            alignment: Alignment::none(),
+        }]);
+        let metrics = DefaultMetricsRegistry::default();
+        let source = FileSegmentSource::open(
+            segments,
+            PanickingReadAt,
+            TokioRuntime::current(),
+            RequestMetrics::new(&metrics, vec![]),
+        );
+
+        let _result = source.request(SegmentId::from(0)).await;
     }
 }

--- a/vortex-io/src/runtime/current.rs
+++ b/vortex-io/src/runtime/current.rs
@@ -1,11 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
 
 use futures::Stream;
 use futures::StreamExt;
+use futures::future::poll_fn;
 use futures::stream::BoxStream;
+use parking_lot::Mutex;
 use smol::block_on;
 
 use crate::runtime::BlockingRuntime;
@@ -67,22 +73,24 @@ impl CurrentThreadRuntime {
         // This allows multiple worker threads to drive the execution while all waiting for results
         // on the channel.
         let (result_tx, result_rx) = kanal::bounded_async(1);
-        self.executor
-            .spawn(async move {
-                futures::pin_mut!(stream);
-                while let Some(item) = stream.next().await {
-                    // If all receivers are dropped, we stop driving the stream.
-                    if let Err(e) = result_tx.send(item).await {
-                        tracing::trace!("all receivers dropped, stopping stream: {}", e);
-                        break;
-                    }
+        let driver = self.executor.spawn(async move {
+            futures::pin_mut!(stream);
+            while let Some(item) = stream.next().await {
+                // If all receivers are dropped, we stop driving the stream.
+                if let Err(e) = result_tx.send(item).await {
+                    tracing::trace!("all receivers dropped, stopping stream: {}", e);
+                    break;
                 }
-            })
-            .detach();
+            }
+        });
 
         ThreadSafeIterator {
             executor: Arc::clone(&self.executor),
             results: result_rx,
+            driver: Arc::new(Mutex::new(DriverState {
+                task: Some(driver),
+                joining: false,
+            })),
         }
     }
 }
@@ -132,6 +140,12 @@ impl<T> Iterator for CurrentThreadIterator<'_, T> {
 pub struct ThreadSafeIterator<T> {
     executor: Arc<smol::Executor<'static>>,
     results: kanal::AsyncReceiver<T>,
+    driver: Arc<Mutex<DriverState>>,
+}
+
+struct DriverState {
+    task: Option<smol::Task<()>>,
+    joining: bool,
 }
 
 // Manual clone implementation since `T` does not need to be `Clone`.
@@ -140,6 +154,7 @@ impl<T> Clone for ThreadSafeIterator<T> {
         Self {
             executor: Arc::clone(&self.executor),
             results: self.results.clone(),
+            driver: Arc::clone(&self.driver),
         }
     }
 }
@@ -148,7 +163,92 @@ impl<T> Iterator for ThreadSafeIterator<T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        block_on(self.executor.run(self.results.recv())).ok()
+        let driver = Arc::clone(&self.driver);
+        let recv = self.results.recv();
+
+        block_on(self.executor.run(async move {
+            futures::pin_mut!(recv);
+            let mut recv_done = false;
+            let mut is_joiner = false;
+            poll_fn(move |cx| {
+                poll_finished_driver(&driver, cx);
+
+                if recv_done {
+                    return poll_join_driver(&driver, cx, &mut is_joiner).map(|()| None);
+                }
+
+                match recv.as_mut().poll(cx) {
+                    Poll::Ready(Ok(item)) => {
+                        recv_done = true;
+                        Poll::Ready(Some(item))
+                    }
+                    Poll::Ready(Err(_)) => {
+                        recv_done = true;
+                        poll_join_driver(&driver, cx, &mut is_joiner).map(|()| None)
+                    }
+                    Poll::Pending => Poll::Pending,
+                }
+            })
+            .await
+        }))
+    }
+}
+
+fn poll_finished_driver(driver: &Mutex<DriverState>, cx: &mut Context<'_>) {
+    let Some(mut guard) = driver.try_lock() else {
+        return;
+    };
+
+    let Some(task) = guard.task.as_mut() else {
+        return;
+    };
+
+    if !task.is_finished() {
+        return;
+    }
+
+    if Pin::new(task).poll(cx).is_ready() {
+        guard.task = None;
+        guard.joining = false;
+    }
+}
+
+fn poll_join_driver(
+    driver: &Mutex<DriverState>,
+    cx: &mut Context<'_>,
+    is_joiner: &mut bool,
+) -> Poll<()> {
+    let Some(mut guard) = driver.try_lock() else {
+        if *is_joiner {
+            cx.waker().wake_by_ref();
+            return Poll::Pending;
+        }
+        return Poll::Ready(());
+    };
+
+    if guard.task.is_none() {
+        return Poll::Ready(());
+    }
+
+    if !*is_joiner {
+        if guard.joining {
+            return Poll::Ready(());
+        }
+        guard.joining = true;
+        *is_joiner = true;
+    }
+
+    let Some(task) = guard.task.as_mut() else {
+        return Poll::Ready(());
+    };
+
+    match Pin::new(task).poll(cx) {
+        Poll::Ready(()) => {
+            guard.task = None;
+            guard.joining = false;
+            Poll::Ready(())
+        }
+        Poll::Pending => Poll::Pending,
     }
 }
 
@@ -159,6 +259,7 @@ mod tests {
     use std::sync::Barrier;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
+    use std::task::Poll;
     use std::thread;
     use std::time::Duration;
 
@@ -259,6 +360,26 @@ mod tests {
         let mut collected: Vec<_> = all_results.iter().flatten().copied().collect();
         collected.sort();
         assert_eq!(collected, (0..total_items).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_block_on_stream_thread_safe_propagates_driver_panic() {
+        let runtime = CurrentThreadRuntime::new();
+        let mut iter = runtime.block_on_stream_thread_safe(|_h| {
+            stream::poll_fn(|_| -> Poll<Option<usize>> {
+                panic!("stream driver panic");
+            })
+            .boxed()
+        });
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| iter.next()))
+            .expect_err("stream panic must propagate through iterator");
+        let message = panic
+            .downcast_ref::<&'static str>()
+            .copied()
+            .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+            .unwrap_or("<unknown panic>");
+        assert!(message.contains("stream driver panic"));
     }
 
     #[test]

--- a/vortex-io/src/runtime/current.rs
+++ b/vortex-io/src/runtime/current.rs
@@ -2,14 +2,10 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::Context;
-use std::task::Poll;
 
 use futures::Stream;
 use futures::StreamExt;
-use futures::future::poll_fn;
 use futures::stream::BoxStream;
 use parking_lot::Mutex;
 use smol::block_on;
@@ -87,10 +83,7 @@ impl CurrentThreadRuntime {
         ThreadSafeIterator {
             executor: Arc::clone(&self.executor),
             results: result_rx,
-            driver: Arc::new(Mutex::new(DriverState {
-                task: Some(driver),
-                joining: false,
-            })),
+            driver: Arc::new(Mutex::new(Some(driver))),
         }
     }
 }
@@ -140,12 +133,10 @@ impl<T> Iterator for CurrentThreadIterator<'_, T> {
 pub struct ThreadSafeIterator<T> {
     executor: Arc<smol::Executor<'static>>,
     results: kanal::AsyncReceiver<T>,
-    driver: Arc<Mutex<DriverState>>,
-}
-
-struct DriverState {
-    task: Option<smol::Task<()>>,
-    joining: bool,
+    /// Handle to the task driving the stream. Once the stream ends, the first consumer to
+    /// observe it joins the task so a panic raised while driving the stream is re-raised rather
+    /// than silently ending the iterator.
+    driver: Arc<Mutex<Option<smol::Task<()>>>>,
 }
 
 // Manual clone implementation since `T` does not need to be `Clone`.
@@ -163,98 +154,27 @@ impl<T> Iterator for ThreadSafeIterator<T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let driver = Arc::clone(&self.driver);
-        let recv = self.results.recv();
-
-        block_on(self.executor.run(async move {
-            futures::pin_mut!(recv);
-            let mut recv_done = false;
-            let mut is_joiner = false;
-            poll_fn(move |cx| {
-                poll_finished_driver(&driver, cx);
-
-                if recv_done {
-                    return poll_join_driver(&driver, cx, &mut is_joiner).map(|()| None);
+        match block_on(self.executor.run(self.results.recv())) {
+            Ok(item) => Some(item),
+            // The result channel closes when the driver task finishes. Join the task so a panic
+            // raised while driving the stream is re-raised here instead of being lost. The first
+            // consumer to observe closure joins it; any later consumer just sees the stream end.
+            Err(_) => {
+                let task = self.driver.lock().take();
+                if let Some(task) = task {
+                    block_on(self.executor.run(task));
                 }
-
-                match recv.as_mut().poll(cx) {
-                    Poll::Ready(Ok(item)) => {
-                        recv_done = true;
-                        Poll::Ready(Some(item))
-                    }
-                    Poll::Ready(Err(_)) => {
-                        recv_done = true;
-                        poll_join_driver(&driver, cx, &mut is_joiner).map(|()| None)
-                    }
-                    Poll::Pending => Poll::Pending,
-                }
-            })
-            .await
-        }))
-    }
-}
-
-fn poll_finished_driver(driver: &Mutex<DriverState>, cx: &mut Context<'_>) {
-    let Some(mut guard) = driver.try_lock() else {
-        return;
-    };
-
-    let Some(task) = guard.task.as_mut() else {
-        return;
-    };
-
-    if !task.is_finished() {
-        return;
-    }
-
-    if Pin::new(task).poll(cx).is_ready() {
-        guard.task = None;
-        guard.joining = false;
-    }
-}
-
-fn poll_join_driver(
-    driver: &Mutex<DriverState>,
-    cx: &mut Context<'_>,
-    is_joiner: &mut bool,
-) -> Poll<()> {
-    let Some(mut guard) = driver.try_lock() else {
-        if *is_joiner {
-            cx.waker().wake_by_ref();
-            return Poll::Pending;
+                None
+            }
         }
-        return Poll::Ready(());
-    };
-
-    if guard.task.is_none() {
-        return Poll::Ready(());
-    }
-
-    if !*is_joiner {
-        if guard.joining {
-            return Poll::Ready(());
-        }
-        guard.joining = true;
-        *is_joiner = true;
-    }
-
-    let Some(task) = guard.task.as_mut() else {
-        return Poll::Ready(());
-    };
-
-    match Pin::new(task).poll(cx) {
-        Poll::Ready(()) => {
-            guard.task = None;
-            guard.joining = false;
-            Poll::Ready(())
-        }
-        Poll::Pending => Poll::Pending,
     }
 }
 
 #[expect(clippy::if_then_some_else_none)] // Clippy is wrong when if/else has await.
 #[cfg(test)]
 mod tests {
+    use std::any::Any;
+    use std::panic::AssertUnwindSafe;
     use std::sync::Arc;
     use std::sync::Barrier;
     use std::sync::atomic::AtomicUsize;
@@ -372,7 +292,7 @@ mod tests {
             .boxed()
         });
 
-        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| iter.next()))
+        let panic = std::panic::catch_unwind(AssertUnwindSafe(|| iter.next()))
             .expect_err("stream panic must propagate through iterator");
         let message = panic
             .downcast_ref::<&'static str>()
@@ -380,6 +300,119 @@ mod tests {
             .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
             .unwrap_or("<unknown panic>");
         assert!(message.contains("stream driver panic"));
+    }
+
+    fn panic_message(panic: &(dyn Any + Send)) -> &str {
+        panic
+            .downcast_ref::<&'static str>()
+            .copied()
+            .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+            .unwrap_or("<unknown panic>")
+    }
+
+    // A driver panic must propagate on *every* run, regardless of executor scheduling. Running
+    // the scenario many times guards against a return to timing-dependent propagation.
+    #[test]
+    fn test_block_on_stream_thread_safe_panic_propagation_is_deterministic() {
+        for i in 0..2000 {
+            let mut iter = CurrentThreadRuntime::new().block_on_stream_thread_safe(|_h| {
+                stream::poll_fn(|_| -> Poll<Option<usize>> {
+                    panic!("deterministic driver panic");
+                })
+                .boxed()
+            });
+
+            let outcome = std::panic::catch_unwind(AssertUnwindSafe(|| iter.next()));
+            assert!(
+                outcome.is_err(),
+                "driver panic was swallowed on iteration {i}: next() returned {:?}",
+                outcome.ok().flatten(),
+            );
+        }
+    }
+
+    // A panic after some items were already produced must still surface, not be seen as a clean
+    // end of stream.
+    #[test]
+    fn test_block_on_stream_thread_safe_panic_after_items() {
+        let mut emitted = 0usize;
+        let iter = CurrentThreadRuntime::new().block_on_stream_thread_safe(move |_h| {
+            stream::poll_fn(move |_| -> Poll<Option<usize>> {
+                if emitted < 3 {
+                    emitted += 1;
+                    Poll::Ready(Some(emitted))
+                } else {
+                    panic!("driver panic after items");
+                }
+            })
+            .boxed()
+        });
+
+        // Drain the iterator. The terminal event must be a propagated panic, never a clean
+        // `None`. This avoids depending on exactly how many buffered items survive channel close.
+        let outcome = std::panic::catch_unwind(AssertUnwindSafe(move || iter.collect::<Vec<_>>()));
+        match outcome {
+            Ok(items) => panic!("driver panic was swallowed; stream ended cleanly with {items:?}"),
+            Err(panic) => assert!(panic_message(&*panic).contains("driver panic after items")),
+        }
+    }
+
+    // With multiple consumers, a driver panic must reach *every* consumer that observes the end
+    // of the stream; it must never be swallowed by all of them. Exactly one consumer joins the
+    // driver and observes the panic; the rest see the stream end.
+    #[test]
+    fn test_block_on_stream_thread_safe_multi_consumer_panic_surfaced() {
+        let iter = CurrentThreadRuntime::new().block_on_stream_thread_safe(|_h| {
+            stream::poll_fn(|_| -> Poll<Option<usize>> {
+                panic!("multi consumer driver panic");
+            })
+            .boxed()
+        });
+
+        let num_threads = 4;
+        let barrier = Arc::new(Barrier::new(num_threads));
+        let panics = Arc::new(AtomicUsize::new(0));
+
+        let handles: Vec<_> = (0..num_threads)
+            .map(|_| {
+                let mut iter = iter.clone();
+                let barrier = Arc::clone(&barrier);
+                let panics = Arc::clone(&panics);
+                thread::spawn(move || {
+                    barrier.wait();
+                    match std::panic::catch_unwind(AssertUnwindSafe(|| iter.next())) {
+                        // The driver panicked before producing anything, so a clean end is the
+                        // only non-panic outcome a consumer may observe.
+                        Ok(None) => {}
+                        Ok(Some(_)) => panic!("no item was produced before the driver panicked"),
+                        Err(panic) => {
+                            assert!(panic_message(&*panic).contains("multi consumer driver panic"));
+                            panics.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().expect("consumer thread panicked uncaught");
+        }
+
+        // The panic surfaces to exactly one consumer and is never swallowed by all of them.
+        assert_eq!(panics.load(Ordering::SeqCst), 1);
+    }
+
+    // Clean completion must return `None` with no spurious panic.
+    #[test]
+    fn test_block_on_stream_thread_safe_clean_completion_returns_none() {
+        let mut iter = CurrentThreadRuntime::new()
+            .block_on_stream_thread_safe(|_h| stream::iter(vec![1usize, 2, 3]).boxed());
+
+        assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.next(), Some(2));
+        assert_eq!(iter.next(), Some(3));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
     }
 
     #[test]

--- a/vortex-io/src/runtime/handle.rs
+++ b/vortex-io/src/runtime/handle.rs
@@ -196,6 +196,19 @@ impl Handle {
 /// or the panic payload if the task panicked, so it can be re-raised on the joining side.
 type TaskOutput<T> = Result<T, Box<dyn Any + Send>>;
 
+/// The terminal outcome of joining a spawned [`Task`] with [`Task::poll_join`], without
+/// re-raising a panic.
+pub enum JoinOutcome<T> {
+    /// The task ran to completion and produced this value.
+    Completed(T),
+    /// The task panicked. Carries the original panic payload, ready to be re-raised with
+    /// [`std::panic::resume_unwind`].
+    Panicked(Box<dyn Any + Send>),
+    /// The runtime dropped the task's future before it completed, for example because the task
+    /// was aborted or the runtime shut down. No value or panic payload is available.
+    Aborted,
+}
+
 /// A handle to a spawned Task.
 ///
 /// If this handle is dropped, the task is cancelled where possible. In order to allow the task to
@@ -212,24 +225,40 @@ impl<T> Task<T> {
     pub fn detach(mut self) {
         drop(self.abort_handle.take());
     }
+
+    /// Poll the task to completion, reporting the terminal state as a [`JoinOutcome`] instead of
+    /// re-raising a panic or panicking on abort.
+    ///
+    /// This lets a caller distinguish a task panic (which it may re-raise via
+    /// [`std::panic::resume_unwind`]) from the runtime dropping the task before it completed — for
+    /// example a runtime shutting down while work is in flight — which is benign. The [`Future`]
+    /// implementation, by contrast, re-raises a panic and itself panics on abort.
+    pub fn poll_join(&mut self, cx: &mut Context<'_>) -> Poll<JoinOutcome<T>> {
+        match ready!(self.recv.poll_unpin(cx)) {
+            Ok(Ok(output)) => Poll::Ready(JoinOutcome::Completed(output)),
+            Ok(Err(panic)) => Poll::Ready(JoinOutcome::Panicked(panic)),
+            // The result channel closed without delivering a value: the runtime dropped the task's
+            // future before it completed (for example the task was aborted or the runtime shut
+            // down).
+            Err(_recv_err) => Poll::Ready(JoinOutcome::Aborted),
+        }
+    }
 }
 
 impl<T> Future for Task<T> {
     type Output = T;
 
     #[expect(clippy::panic)]
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match ready!(self.recv.poll_unpin(cx)) {
-            Ok(Ok(result)) => Poll::Ready(result),
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match ready!(self.get_mut().poll_join(cx)) {
+            JoinOutcome::Completed(output) => Poll::Ready(output),
             // The task panicked: re-raise the original panic on the joining side, preserving its
             // message and payload rather than collapsing it into a generic error.
-            Ok(Err(panic)) => std::panic::resume_unwind(panic),
-            Err(_recv_err) => {
-                // The result channel closed without delivering a value, which means the runtime
-                // dropped the task's future before it completed (for example, the task was
-                // aborted). If the caller aborted this task by dropping it, they wouldn't be able
-                // to poll it anymore, so we consider a closed channel a runtime programming error
-                // and panic.
+            JoinOutcome::Panicked(panic) => std::panic::resume_unwind(panic),
+            JoinOutcome::Aborted => {
+                // The runtime dropped the task's future before it completed. If the caller aborted
+                // this task by dropping it, they wouldn't be able to poll it anymore, so we
+                // consider a closed channel a runtime programming error and panic.
 
                 // NOTE(ngates): we don't use vortex_panic to avoid printing a useless backtrace.
                 panic!("Runtime dropped task without completing it")
@@ -244,5 +273,54 @@ impl<T> Drop for Task<T> {
         if let Some(handle) = self.abort_handle.take() {
             handle.abort();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::task::noop_waker;
+
+    use super::*;
+
+    // A task whose result channel closed without a value — the runtime dropped its future before
+    // it sent a result — must report `Aborted`, so callers can treat a benign teardown as a
+    // recoverable stop rather than a propagated panic.
+    #[test]
+    fn poll_join_reports_aborted_when_channel_closed_without_value() {
+        let (send, recv) = oneshot::channel::<TaskOutput<()>>();
+        // Simulate the runtime dropping the task's future before it sent a result.
+        drop(send);
+
+        let mut task = Task::<()> {
+            recv: recv.into_future(),
+            abort_handle: None,
+        };
+
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert!(matches!(
+            task.poll_join(&mut cx),
+            Poll::Ready(JoinOutcome::Aborted)
+        ));
+    }
+
+    // A completed task reports its value through `poll_join` rather than re-raising or panicking.
+    #[test]
+    fn poll_join_reports_completed_value() {
+        let (send, recv) = oneshot::channel::<TaskOutput<u32>>();
+        // Ignore the send result: the payload type is not `Debug`, and the receiver is alive.
+        drop(send.send(Ok(7)));
+
+        let mut task = Task::<u32> {
+            recv: recv.into_future(),
+            abort_handle: None,
+        };
+
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert!(matches!(
+            task.poll_join(&mut cx),
+            Poll::Ready(JoinOutcome::Completed(7))
+        ));
     }
 }

--- a/vortex-io/src/runtime/handle.rs
+++ b/vortex-io/src/runtime/handle.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
+use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Weak;
@@ -77,8 +79,11 @@ impl Handle {
         let span = tracing::trace_span!(target: "vortex_io::spawn", "spawn");
         let abort_handle = self.runtime().spawn(
             async move {
+                // Catch a panic so it can be re-raised on the joining side (see `Task::poll`)
+                // rather than being lost, matching `tokio::JoinError` / `smol::Task` semantics.
+                let output = AssertUnwindSafe(f).catch_unwind().await;
                 // Task::detach allows the receiver to be dropped, so we ignore send errors.
-                drop(send.send(f.await));
+                drop(send.send(output));
             }
             .instrument(span)
             .boxed(),
@@ -116,8 +121,10 @@ impl Handle {
         let span = tracing::trace_span!(target: "vortex_io::spawn_io", "spawn_io");
         let abort_handle = self.runtime().spawn_io(
             async move {
+                // See `spawn`: catch a panic so it re-raises on the joining side.
+                let output = AssertUnwindSafe(f).catch_unwind().await;
                 // Task::detach allows the receiver to be dropped, so we ignore send errors.
-                drop(send.send(f.await));
+                drop(send.send(output));
             }
             .instrument(span)
             .boxed(),
@@ -148,8 +155,10 @@ impl Handle {
             let _guard = span.enter();
             // Optimistically avoid the work if the result won't be used.
             if !send.is_closed() {
+                // Catch a panic so it re-raises on the joining side (see `Task::poll`).
+                let output = std::panic::catch_unwind(AssertUnwindSafe(f));
                 // Task::detach allows the receiver to be dropped, so we ignore send errors.
-                drop(send.send(f()));
+                drop(send.send(output));
             }
         }));
         Task {
@@ -170,8 +179,10 @@ impl Handle {
             let _guard = span.enter();
             // Optimistically avoid the work if the result won't be used.
             if !send.is_closed() {
+                // Catch a panic so it re-raises on the joining side (see `Task::poll`).
+                let output = std::panic::catch_unwind(AssertUnwindSafe(f));
                 // Task::detach allows the receiver to be dropped, so we ignore send errors.
-                drop(send.send(f()));
+                drop(send.send(output));
             }
         }));
         Task {
@@ -181,13 +192,17 @@ impl Handle {
     }
 }
 
+/// The value carried from a spawned task back to its [`Task`] handle: either the task's output,
+/// or the panic payload if the task panicked, so it can be re-raised on the joining side.
+type TaskOutput<T> = Result<T, Box<dyn Any + Send>>;
+
 /// A handle to a spawned Task.
 ///
 /// If this handle is dropped, the task is cancelled where possible. In order to allow the task to
 /// continue running in the background, call [`Task::detach`].
 #[must_use = "When a Task is dropped without being awaited, it is cancelled"]
 pub struct Task<T> {
-    recv: oneshot::AsyncReceiver<T>,
+    recv: oneshot::AsyncReceiver<TaskOutput<T>>,
     abort_handle: Option<AbortHandleRef>,
 }
 
@@ -205,16 +220,19 @@ impl<T> Future for Task<T> {
     #[expect(clippy::panic)]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match ready!(self.recv.poll_unpin(cx)) {
-            Ok(result) => Poll::Ready(result),
+            Ok(Ok(result)) => Poll::Ready(result),
+            // The task panicked: re-raise the original panic on the joining side, preserving its
+            // message and payload rather than collapsing it into a generic error.
+            Ok(Err(panic)) => std::panic::resume_unwind(panic),
             Err(_recv_err) => {
-                // If the other end of the channel was dropped, it means the runtime dropped
-                // the future without ever completing it. If the caller aborted this task by
-                // dropping it, then they wouldn't be able to poll it anymore.
-                // So we consider a closed channel to be a Runtime programming error and therefore
-                // we panic.
+                // The result channel closed without delivering a value, which means the runtime
+                // dropped the task's future before it completed (for example, the task was
+                // aborted). If the caller aborted this task by dropping it, they wouldn't be able
+                // to poll it anymore, so we consider a closed channel a runtime programming error
+                // and panic.
 
                 // NOTE(ngates): we don't use vortex_panic to avoid printing a useless backtrace.
-                panic!("Runtime dropped task without completing it, likely it panicked")
+                panic!("Runtime dropped task without completing it")
             }
         }
     }

--- a/vortex-io/src/runtime/tests.rs
+++ b/vortex-io/src/runtime/tests.rs
@@ -4,6 +4,7 @@
 #![cfg(feature = "tokio")]
 #![expect(clippy::cast_possible_truncation)]
 
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -16,8 +17,6 @@ use vortex_buffer::Alignment;
 use vortex_buffer::ByteBuffer;
 use vortex_buffer::ByteBufferMut;
 use vortex_error::VortexResult;
-
-use std::panic::AssertUnwindSafe;
 
 use crate::VortexReadAt;
 use crate::runtime::Task;

--- a/vortex-io/src/runtime/tests.rs
+++ b/vortex-io/src/runtime/tests.rs
@@ -17,7 +17,10 @@ use vortex_buffer::ByteBuffer;
 use vortex_buffer::ByteBufferMut;
 use vortex_error::VortexResult;
 
+use std::panic::AssertUnwindSafe;
+
 use crate::VortexReadAt;
+use crate::runtime::Task;
 use crate::runtime::single::block_on;
 use crate::runtime::tokio::TokioRuntime;
 use crate::std_file::FileReadAt;
@@ -223,6 +226,51 @@ async fn test_handle_spawn_cpu() {
     let result = task.await;
     assert_eq!(result, 100);
     assert_eq!(counter.load(Ordering::SeqCst), 1);
+}
+
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> &str {
+    payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("<non-string panic>")
+}
+
+// Joining a spawned future that panicked must re-raise the *original* panic, not a generic
+// "Runtime dropped task" message.
+#[test]
+fn test_spawned_future_panic_reraises_original() {
+    let outcome = block_on(|handle| {
+        async move {
+            let task: Task<()> = handle.spawn(async move { panic!("original spawn panic") });
+            AssertUnwindSafe(task).catch_unwind().await
+        }
+        .boxed_local()
+    });
+
+    let payload = outcome.expect_err("panicking task must propagate a panic");
+    assert!(
+        panic_message(&*payload).contains("original spawn panic"),
+        "got: {:?}",
+        panic_message(&*payload)
+    );
+}
+
+// Same for CPU tasks.
+#[tokio::test]
+async fn test_spawned_cpu_task_panic_reraises_original() {
+    let handle = TokioRuntime::current();
+    let task: Task<()> = handle.spawn_cpu(|| panic!("original cpu panic"));
+
+    let payload = AssertUnwindSafe(task)
+        .catch_unwind()
+        .await
+        .expect_err("panicking cpu task must propagate a panic");
+    assert!(
+        panic_message(&*payload).contains("original cpu panic"),
+        "got: {:?}",
+        panic_message(&*payload)
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Rationale for this change

Following #8672, I've audited a few other suspicous code paths that had similar shape, mostly on the read side.

## What changes are included in this PR?

1. Propagate panics and shutdown correctly for `FileSegmentSource`.
2. Handle panics correctly in the shared iterator used by DuckDB
3. Misc panic handling around our runtime abstraction. 

## What APIs are changed? Are there any user-facing changes?

None
