### PR TITLE
Better error message in case of unknown encoding id

### DIFF
--- a/vortex-array/src/serde.rs
+++ b/vortex-array/src/serde.rs
@@ -329,7 +329,7 @@ impl SerializedArray {
             if session.allows_unknown() {
                 return self.decode_foreign(encoding_id, dtype, len, ctx);
             }
-            return Err(vortex_err!("Unknown encoding: {}", encoding_id));
+            vortex_bail!("Unknown encoding: {}", encoding_id);
         };
 
         let children = SerializedArrayChildren {

--- a/vortex-layout/src/children.rs
+++ b/vortex-layout/src/children.rs
@@ -218,15 +218,14 @@ impl LayoutChildren for ViewedLayoutChildren {
             let encoding_id = self
                 .layout_read_ctx
                 .resolve(fb_child.encoding())
-                .ok_or_else(|| vortex_err!("Encoding not found: {}", fb_child.encoding()))?;
+                .ok_or_else(|| {
+                    vortex_err!("Unknown layout encoding index: {}", fb_child.encoding())
+                })?;
             let Some(encoding) = self.layouts.find(&encoding_id) else {
                 if self.allow_unknown {
                     return viewed_children.foreign_layout_from_fb(fb_child, dtype);
                 }
-                return Err(vortex_err!(
-                    "Encoding not found in registry: {}",
-                    fb_child.encoding()
-                ));
+                vortex_bail!("Unknown layout encoding: {encoding_id}");
             };
 
             let build_ctx = LayoutBuildContext {


### PR DESCRIPTION
Unify error messages between layout and array encoding id missing
