### PR TITLE
ci: remove v3 benchmark ingest, make v4 Postgres ingest required

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -117,26 +117,11 @@ jobs:
         run: |
           bash scripts/cat-s3.sh vortex-ci-benchmark-results data.json.gz results.json
 
-      - name: Ingest results to v3 server
-        if: vars.V3_INGEST_URL != ''
-        shell: bash
-        env:
-          INGEST_BEARER_TOKEN: ${{ secrets.INGEST_BEARER_TOKEN }}
-        run: |
-          python3 scripts/post-ingest.py results.v3.jsonl \
-            --server "${{ vars.V3_INGEST_URL }}" \
-            --commit-sha "${{ github.sha }}" \
-            --benchmark-id "${{ matrix.benchmark.id }}" \
-            --repo-url "${{ github.server_url }}/${{ github.repository }}"
-
-      # v4 (Postgres) dual-write -- BEST-EFFORT during the migration soak. The
-      # proven v3 step above is hard-required; a v4 failure must NOT fail the job
-      # (v4 is promoted to required at cutover, PR-5.1). Gated on the ingest-role
-      # ARN var (the assume-role input that MUST exist for OIDC to succeed) so it
-      # no-ops until v4 infra is wired, and every step is
-      # `continue-on-error` so an OIDC / uv / connect hiccup never breaks the v3
-      # pipeline. post-ingest.py mints the RDS IAM token internally (boto3) from
-      # the assumed GitHubBenchmarkIngestRole; sslmode=verify-full validates the cert.
+      # v4 (Postgres) ingest -- the REQUIRED benchmark-results pipeline feeding the live
+      # benchmarks website; a failure here fails the job. Gated on the ingest-role ARN var
+      # (the assume-role input that MUST exist for OIDC to succeed). post-ingest.py mints
+      # the RDS IAM token internally (boto3) from the assumed GitHubBenchmarkIngestRole;
+      # sslmode=verify-full validates the cert.
       #
       # ORDER MATTERS: "Install uv" runs BEFORE "Configure AWS credentials".
       # configure-aws-credentials persists the assumed ingest-role (rds-db:connect
@@ -146,18 +131,15 @@ jobs:
       # is assumed immediately before the ingest, which needs only rds-db:connect.
       - name: Install uv for v4 ingest
         if: vars.GH_BENCH_INGEST_ROLE_ARN != ''
-        continue-on-error: true
         uses: spiraldb/actions/.github/actions/setup-uv@a746510eafaa926484c354541cfc49b2ec06cc63  # 0.18.6
       - name: Configure AWS credentials for v4 ingest (OIDC)
         if: vars.GH_BENCH_INGEST_ROLE_ARN != ''
-        continue-on-error: true
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6
         with:
           role-to-assume: ${{ vars.GH_BENCH_INGEST_ROLE_ARN }}
           aws-region: ${{ vars.RDS_BENCH_REGION }}
-      - name: Ingest results to v4 Postgres (best-effort)
+      - name: Ingest results to v4 Postgres
         if: vars.GH_BENCH_INGEST_ROLE_ARN != ''
-        continue-on-error: true
         shell: bash
         env:
           RDS_BENCH_INSTANCE_ENDPOINT: ${{ vars.RDS_BENCH_INSTANCE_ENDPOINT }}

--- a/.github/workflows/commit-metadata.yml
+++ b/.github/workflows/commit-metadata.yml
@@ -1,7 +1,6 @@
 # Uploads commit metadata (an empty ingest envelope -- no benchmark records) on
-# every push to develop, to both the v3 server and the v4 Postgres, so the
-# `commits` dim stays populated even when no benchmark ran. Needed by both
-# backends, hence not named for either.
+# every push to develop, to the v4 Postgres, so the `commits` dim stays
+# populated even when no benchmark ran.
 
 name: Commit metadata
 
@@ -11,7 +10,7 @@ on:
   workflow_dispatch: { }
 
 permissions:
-  id-token: write  # enables AWS-GitHub OIDC for the best-effort v4 ingest step
+  id-token: write  # enables AWS-GitHub OIDC for the v4 ingest step
   contents: read
 
 jobs:
@@ -23,24 +22,10 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Ingest commit metadata to v3 server
-        if: vars.V3_INGEST_URL != ''
-        shell: bash
-        env:
-          INGEST_BEARER_TOKEN: ${{ secrets.INGEST_BEARER_TOKEN }}
-        run: |
-          echo -n > empty.jsonl
-          python3 scripts/post-ingest.py empty.jsonl \
-            --server "${{ vars.V3_INGEST_URL }}" \
-            --commit-sha "${{ github.sha }}" \
-            --benchmark-id "commit-metadata" \
-            --repo-url "${{ github.server_url }}/${{ github.repository }}"
-
-      # v4 (Postgres) dual-write -- BEST-EFFORT (see bench.yml rationale). Empty records:
-      # post-ingest.py --postgres upserts the commit row only. v3 above stays required;
-      # a v4 failure never fails the job (promoted to required at cutover, PR-5.1).
-      # Gated on the ingest-role ARN var (the assume-role input that MUST exist) so
-      # it no-ops until v4 infra is wired.
+      # v4 (Postgres) ingest -- REQUIRED (see bench.yml rationale). Empty records:
+      # post-ingest.py --postgres upserts the commit row only. Gated on the
+      # ingest-role ARN var (the assume-role input that MUST exist for OIDC to
+      # succeed).
       #
       # ORDER MATTERS: "Install uv" runs BEFORE "Configure AWS credentials".
       # configure-aws-credentials persists the assumed ingest-role (rds-db:connect
@@ -50,18 +35,15 @@ jobs:
       # is assumed immediately before the ingest, which needs only rds-db:connect.
       - name: Install uv for v4 ingest
         if: vars.GH_BENCH_INGEST_ROLE_ARN != ''
-        continue-on-error: true
         uses: spiraldb/actions/.github/actions/setup-uv@a746510eafaa926484c354541cfc49b2ec06cc63  # 0.18.6
       - name: Configure AWS credentials for v4 ingest (OIDC)
         if: vars.GH_BENCH_INGEST_ROLE_ARN != ''
-        continue-on-error: true
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6
         with:
           role-to-assume: ${{ vars.GH_BENCH_INGEST_ROLE_ARN }}
           aws-region: ${{ vars.RDS_BENCH_REGION }}
-      - name: Ingest commit metadata to v4 Postgres (best-effort)
+      - name: Ingest commit metadata to v4 Postgres
         if: vars.GH_BENCH_INGEST_ROLE_ARN != ''
-        continue-on-error: true
         shell: bash
         env:
           RDS_BENCH_INSTANCE_ENDPOINT: ${{ vars.RDS_BENCH_INSTANCE_ENDPOINT }}

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -709,25 +709,12 @@ jobs:
         run: |
           bash scripts/cat-s3.sh vortex-ci-benchmark-results data.json.gz results.json
 
-      - name: Ingest results to v3 server
-        if: inputs.mode == 'develop' && vars.V3_INGEST_URL != ''
-        shell: bash
-        env:
-          INGEST_BEARER_TOKEN: ${{ secrets.INGEST_BEARER_TOKEN }}
-        run: |
-          python3 scripts/post-ingest.py results.v3.jsonl \
-            --server "${{ vars.V3_INGEST_URL }}" \
-            --commit-sha "${{ github.sha }}" \
-            --benchmark-id "${{ matrix.id }}" \
-            --repo-url "${{ github.server_url }}/${{ github.repository }}"
-
-      # v4 (Postgres) dual-write -- BEST-EFFORT during the migration soak (see bench.yml
-      # for the full rationale). The v3 step above is hard-required; a v4 failure must NOT
-      # fail the job (v4 is promoted to required at cutover, PR-5.1). Gated on
-      # inputs.mode == 'develop' (matching v3) + the ingest-role ARN var (the assume-role
-      # input that MUST exist for OIDC to succeed; it no-ops until v4 infra is wired), and
-      # every step is continue-on-error. post-ingest.py mints the RDS IAM token (boto3) from
-      # the assumed GitHubBenchmarkIngestRole; sslmode=verify-full validates the cert.
+      # v4 (Postgres) ingest -- the REQUIRED benchmark-results pipeline feeding the live
+      # benchmarks website (see bench.yml for the full rationale); a failure here fails the
+      # job. Gated on inputs.mode == 'develop' + the ingest-role ARN var (the assume-role
+      # input that MUST exist for OIDC to succeed). post-ingest.py mints the RDS IAM token
+      # (boto3) from the assumed GitHubBenchmarkIngestRole; sslmode=verify-full validates
+      # the cert.
       #
       # ORDER MATTERS: "Install uv" runs BEFORE "Configure AWS credentials".
       # configure-aws-credentials persists the assumed ingest-role (rds-db:connect
@@ -737,18 +724,15 @@ jobs:
       # is assumed immediately before the ingest, which needs only rds-db:connect.
       - name: Install uv for v4 ingest
         if: inputs.mode == 'develop' && vars.GH_BENCH_INGEST_ROLE_ARN != ''
-        continue-on-error: true
         uses: spiraldb/actions/.github/actions/setup-uv@a746510eafaa926484c354541cfc49b2ec06cc63  # 0.18.6
       - name: Configure AWS credentials for v4 ingest (OIDC)
         if: inputs.mode == 'develop' && vars.GH_BENCH_INGEST_ROLE_ARN != ''
-        continue-on-error: true
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6
         with:
           role-to-assume: ${{ vars.GH_BENCH_INGEST_ROLE_ARN }}
           aws-region: ${{ vars.RDS_BENCH_REGION }}
-      - name: Ingest results to v4 Postgres (best-effort)
+      - name: Ingest results to v4 Postgres
         if: inputs.mode == 'develop' && vars.GH_BENCH_INGEST_ROLE_ARN != ''
-        continue-on-error: true
         shell: bash
         env:
           RDS_BENCH_INSTANCE_ENDPOINT: ${{ vars.RDS_BENCH_INSTANCE_ENDPOINT }}


### PR DESCRIPTION
## What

Removes the v3 (EC2/DuckDB) leg of the benchmark-results dual-write and promotes the v4 (RDS Postgres) ingest from best-effort to required.

- Deletes the three "Ingest ... to v3 server" steps (`bench.yml`, `sql-benchmarks.yml`, `commit-metadata.yml`), each gated on `vars.V3_INGEST_URL`.
- Removes `continue-on-error: true` from the v4 ingest step groups so a v4 ingest failure now fails the job (and alerts incident.io on develop).
- Rewrites the stale soak-era comments, which claimed v3 was hard-required and v4 best-effort — reality is now inverted.

## Why

The benchmarks website fully cut over to v4 (Vercel + RDS Postgres) on 2026-06-19 and has been stable since; the pre-cutover history was backfilled into v4 on 2026-07-07, so v3 holds nothing v4 lacks. This unblocks terminating the v3 EC2 host.

## Deliberately untouched

- The `--gh-json-v3 results.v3.jsonl` emitters, `scripts/post-ingest.py` (including its now-unused `--server` mode), and `scripts/_measurement_id.py` — the v3 JSONL format **is** v4's wire format; only the HTTP-to-EC2 leg is removed.
- The v2 legacy S3 uploads (`cat-s3.sh`, commit-metadata job in `bench.yml`) — still consumed by PR-benchmark comparison; separate teardown.

After merge, the repo-level `V3_INGEST_URL` var and `INGEST_BEARER_TOKEN`/`ADMIN_BEARER_TOKEN` secrets can be deleted (every removed step was gated on the var, so ordering is safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)