### PR TITLE
Direct issues to templates instead of GitHub Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report something that isn't working correctly
-labels: ["needs-triage"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Features, Questions
-    url: https://github.com/vortex-data/vortex/discussions/new/choose
-    about: Our preferred starting point if you have any questions or suggestions about configuration, features or behavior.
+  - name: Community Slack
+    url: https://vortex.dev/slack
+    about: Chat with the community for quick questions and discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["feature"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What are you trying to do that Vortex doesn't support today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Alternatives considered, links, or anything else helpful
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,24 @@
+name: Question
+description: Ask a question about using or configuring Vortex
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please check the [documentation](https://docs.vortex.dev) first. For quick
+        back-and-forth, try the [Vortex Slack channel](https://vortex.dev/slack).
+
+  - type: textarea
+    id: question
+    attributes:
+      label: What's your question?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What you've tried, relevant code, or your environment
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,11 +75,13 @@ At the time of writing, the following individuals serve as Committers & Maintain
 
 Our CI process enforces an extensive set of linter (e.g., `clippy`) rules, as well as language-specific formatters (e.g., `cargo fmt`). Beyond that, we document additional style guidelines in [STYLE.md](STYLE.md).
 
-## Reporting Issues
+## Issues and Questions
 
-Bugs should be filed as [GitHub Issues](https://github.com/vortex-data/vortex/issues). Open-ended
-questions and feature requests should be filed as
-[GitHub Discussions](https://github.com/vortex-data/vortex/discussions).
+Bugs, feature requests, and questions should all be filed as
+[GitHub Issues](https://github.com/vortex-data/vortex/issues/new/choose). We strongly prefer that
+you use one of the provided issue templates rather than opening a blank issue; templates make sure
+we get the information needed to act on your report. For quick questions, the
+[Vortex Slack channel](https://vortex.dev/slack) is also a good option.
 
 ## Developer Certificate of Origin (DCO)
 

--- a/docs/developer-guide/embedding/index.md
+++ b/docs/developer-guide/embedding/index.md
@@ -3,7 +3,7 @@
 :::{warning}
 This section is under construction. For guidance on embedding Vortex, please join the
 [Vortex Slack channel](https://vortex.dev/slack)
-or start a [GitHub Discussion](https://github.com/vortex-data/vortex/discussions).
+or open a [GitHub Issue](https://github.com/vortex-data/vortex/issues/new/choose).
 :::
 
 Vortex can be embedded into applications and services via its C FFI, C++ wrapper, or the Scan API.

--- a/docs/developer-guide/extending/index.md
+++ b/docs/developer-guide/extending/index.md
@@ -3,7 +3,7 @@
 :::{warning}
 This section is under construction. For guidance on extending Vortex, please join the
 [Vortex Slack channel](https://vortex.dev/slack)
-or start a [GitHub Discussion](https://github.com/vortex-data/vortex/discussions).
+or open a [GitHub Issue](https://github.com/vortex-data/vortex/issues/new/choose).
 :::
 
 Vortex is designed to be extended with custom types, encodings, layouts, and compute functions.

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -7,15 +7,17 @@ The full contributing guide lives in the repository:
 
 Below is a brief summary.
 
-## Reporting Issues
+## Issues and Questions
 
-Bugs should be filed as [GitHub Issues](https://github.com/vortex-data/vortex/issues). Open-ended
-questions and feature requests should be filed as
-[GitHub Discussions](https://github.com/vortex-data/vortex/discussions).
+Bugs, feature requests, and questions should all be filed as
+[GitHub Issues](https://github.com/vortex-data/vortex/issues/new/choose). We strongly prefer that
+you use one of the provided issue templates rather than opening a blank issue; templates make sure
+we get the information needed to act on your report. For quick questions, the
+[Vortex Slack channel](https://vortex.dev/slack) is also a good option.
 
 ## Code Contributions
 
-1. Start a discussion on GitHub (unless the change is trivial).
+1. Start a discussion by creating or commenting on a GitHub Issue (unless the change is trivial).
 2. Implement the change, including tests for new functionality or bug fixes.
 3. Open a pull request — ensure CI passes and that you sign off your commits (see below).
    CI requires approval from a committer for first-time contributors.


### PR DESCRIPTION
## Rationale for this change

We want to move away from discussions in general because they are not great to work with and everyone is more familiar with issues.

## What changes are included in this PR?

Remove the Discussions redirect from the issue chooser and add Feature Request and Question issue forms in its place. Update CONTRIBUTING.md and the docs to point at issues (or Slack) rather than Discussions, and fix bug_report.yml to apply the existing "bug" label instead of the nonexistent "needs-triage".

## What APIs are changed? Are there any user-facing changes?

N/A