### PR TITLE
Bump locked version of crossbeam-epoch to address security advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Rationale for this change

This is basically a cosmetic change to lock a newer version of `crossbeam-epoch` that isn't affected by the latest issue reported to RUSTSEC https://rustsec.org/advisories/RUSTSEC-2026-0204.html