### PR TITLE
fix: accept FixedSizeList dtype when deserializing ListValue scalars

### DIFF
--- a/vortex-array/src/scalar/proto.rs
+++ b/vortex-array/src/scalar/proto.rs
@@ -441,9 +441,13 @@ fn list_from_proto(
     dtype: &DType,
     session: &VortexSession,
 ) -> VortexResult<ScalarValue> {
-    let element_dtype = dtype
-        .as_list_element_opt()
-        .ok_or_else(|| vortex_err!(Serde: "expected List dtype for ListValue, got {dtype}"))?;
+    let element_dtype = match dtype {
+        DType::List(edt, _) => edt,
+        DType::FixedSizeList(edt, ..) => edt,
+        _ => {
+            vortex_bail!(Serde: "expected List or FixedSizeList dtype for ListValue, got {dtype}")
+        }
+    };
 
     let mut values = Vec::with_capacity(v.values.len());
     for elem in v.values.iter() {

--- a/vortex-array/src/scalar/tests/round_trip.rs
+++ b/vortex-array/src/scalar/tests/round_trip.rs
@@ -254,6 +254,25 @@ mod tests {
         assert_eq!(extracted.as_slice(), &large_binary);
     }
 
+    // Test that fixed-size list scalars round-trip through protobuf. This is
+    // the path taken by a ConstantArray of a fixed-size list dtype (e.g. a
+    // UUID column stored as fixed_size_list(u8)[16]), whose scalar metadata
+    // is serialized as a protobuf ListValue.
+    #[test]
+    fn test_protobuf_fixed_size_list_round_trip() {
+        let fsl = Scalar::fixed_size_list(
+            Arc::new(DType::Primitive(PType::U8, Nullability::NonNullable)),
+            (0u8..16)
+                .map(|i| Scalar::primitive(i, Nullability::NonNullable))
+                .collect(),
+            Nullability::NonNullable,
+        );
+
+        let pb_fsl = pb::Scalar::from(&fsl);
+        let round_tripped = Scalar::from_proto(&pb_fsl, &SESSION).unwrap();
+        assert_eq!(fsl, round_tripped);
+    }
+
     // Test that nullable and non-nullable types are preserved
     #[test]
     fn test_nullability_preservation() {


### PR DESCRIPTION
Scalar serialization writes `ScalarValue::Tuple` as a protobuf `ListValue` for both `List` and `FixedSizeList` dtypes, but `list_from_proto` only accepted `List`. Since #8667 made constant detection unconditional, a constant fixed-size list column (e.g. UUIDs stored as `fixed_size_list(u8)[16]`) is compressed to a `ConstantArray` whose scalar metadata then fails to deserialize on read:

    expected List dtype for ListValue, got fixed_size_list(u8)[16]

so files written this way come back unreadable. Scalar validation already handles `FixedSizeList` + `Tuple` (including the size check), so deserialization was the only gap.

Includes a proto round-trip test that fails without the fix.