### PR TITLE
Add golden-corpus determinism tests for the default compressor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,7 +454,7 @@ jobs:
 
   btrblocks-golden:
     name: "Rust (btrblocks golden corpus)"
-    timeout-minutes: 30
+    timeout-minutes: 10
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=btrblocks-golden', github.run_id)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,6 +452,38 @@ jobs:
           alert-title: "Rust tests (linux-arm64) failed on develop"
           deduplication-key: ci-rust-test-linux-arm64-failure
 
+  btrblocks-golden:
+    name: "Rust (btrblocks golden corpus)"
+    timeout-minutes: 30
+    runs-on: >-
+      ${{ github.repository == 'vortex-data/vortex'
+          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=btrblocks-golden', github.run_id)
+          || 'ubuntu-latest' }}
+    steps:
+      - uses: runs-on/action@v2
+        if: github.repository == 'vortex-data/vortex'
+        with:
+          sccache: s3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+      - uses: ./.github/actions/setup-prebuild
+        with:
+          enable-sccache: "true"
+      # The golden suite pins the compressor's decisions per feature variant, and the
+      # variants are mutually exclusive at compile time: the `default` variant only exists
+      # without `unstable_encodings` (which changes ALL_SCHEMES), so the `--all-features`
+      # workspace test jobs cannot run it. Run each feature combination explicitly.
+      - name: Golden corpus (default features)
+        run: |
+          cargo nextest run --cargo-profile ci --locked --no-fail-fast -p vortex-btrblocks --test golden
+      - name: Golden corpus (unstable_encodings)
+        run: |
+          cargo nextest run --cargo-profile ci --locked --no-fail-fast -p vortex-btrblocks --test golden \
+            --features unstable_encodings
+      - name: Golden corpus (compact, unstable_encodings + zstd + pco)
+        run: |
+          cargo nextest run --cargo-profile ci --locked --no-fail-fast -p vortex-btrblocks --test golden \
+            --features unstable_encodings,zstd,pco
+
   build-java:
     name: "Java"
     runs-on: >-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9928,6 +9928,7 @@ name = "vortex-btrblocks"
 version = "0.1.0"
 dependencies = [
  "codspeed-divan-compat",
+ "insta",
  "itertools 0.14.0",
  "num-traits",
  "pco",

--- a/vortex-btrblocks/Cargo.toml
+++ b/vortex-btrblocks/Cargo.toml
@@ -41,6 +41,7 @@ vortex-zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
 divan = { workspace = true }
+insta = { workspace = true }
 rstest = { workspace = true }
 test-with = { workspace = true }
 vortex-array = { workspace = true, features = ["_test-harness"] }

--- a/vortex-btrblocks/REUSE.toml
+++ b/vortex-btrblocks/REUSE.toml
@@ -1,0 +1,7 @@
+version = 1
+
+# `insta` snapshot files do not allow leading comment lines.
+[[annotations]]
+path = "tests/snapshots/**.snap"
+SPDX-FileCopyrightText = "Copyright the Vortex contributors"
+SPDX-License-Identifier = "Apache-2.0"

--- a/vortex-btrblocks/tests/golden.rs
+++ b/vortex-btrblocks/tests/golden.rs
@@ -9,9 +9,13 @@
 //! snapshot untouched, so snapshot churn in a later change is the reviewable signal of a
 //! behavior change.
 //!
-//! The `default` variant pins the default feature set and [`BtrBlocksCompressor::default`];
-//! it is compiled out under `unstable_encodings`, whose scheme set differs (variants pinning
-//! that feature set are gated separately).
+//! Three variants cover the feature matrix:
+//!
+//! - `default`: the default feature set and [`BtrBlocksCompressor::default`].
+//! - `unstable`: `unstable_encodings` enabled, default builder — pins Delta / OnPair
+//!   selection (compiled out of `ALL_SCHEMES` otherwise).
+//! - `compact`: `unstable_encodings` + `zstd` + `pco`, with
+//!   [`BtrBlocksCompressorBuilder::with_compact`] — pins Zstd / Pco selection.
 //!
 //! Every corpus entry is longer than 1024 values so the sampling-based estimation path is
 //! exercised, and each entry is compressed twice per run to assert determinism directly.
@@ -368,8 +372,44 @@ fn list_of_int_runs() -> VortexResult<ArrayRef> {
     Ok(ListArray::try_new(elements, offsets.into_array(), Validity::NonNullable)?.into_array())
 }
 
+/// Excludes OnPair from the golden compressors: its dictionary training (upstream `onpair`
+/// crate) iterates randomly-seeded `hashbrown` maps, so its compressed output — and therefore
+/// its sampled estimate — differs run-to-run. A nondeterministic scheme cannot serve as a
+/// golden baseline; excluding it keeps the remaining unstable schemes pinned.
+#[cfg(feature = "unstable_encodings")]
+fn without_onpair(
+    builder: vortex_btrblocks::BtrBlocksCompressorBuilder,
+) -> vortex_btrblocks::BtrBlocksCompressorBuilder {
+    use vortex_btrblocks::SchemeExt;
+    use vortex_btrblocks::schemes::string::OnPairScheme;
+
+    builder.exclude_schemes([OnPairScheme.id()])
+}
+
 #[cfg(not(feature = "unstable_encodings"))]
 #[test]
 fn golden_default() -> VortexResult<()> {
     golden_corpus_snapshots("default", &BtrBlocksCompressor::default())
+}
+
+#[cfg(feature = "unstable_encodings")]
+#[test]
+fn golden_unstable() -> VortexResult<()> {
+    use vortex_btrblocks::BtrBlocksCompressorBuilder;
+
+    golden_corpus_snapshots(
+        "unstable",
+        &without_onpair(BtrBlocksCompressorBuilder::default()).build(),
+    )
+}
+
+#[cfg(all(feature = "unstable_encodings", feature = "zstd", feature = "pco"))]
+#[test]
+fn golden_compact() -> VortexResult<()> {
+    use vortex_btrblocks::BtrBlocksCompressorBuilder;
+
+    golden_corpus_snapshots(
+        "compact",
+        &without_onpair(BtrBlocksCompressorBuilder::default().with_compact()).build(),
+    )
 }

--- a/vortex-btrblocks/tests/golden.rs
+++ b/vortex-btrblocks/tests/golden.rs
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Golden-corpus determinism tests for the default compressor.
+//!
+//! Compresses a fixed, seed-generated corpus and snapshots each entry's full encoding tree
+//! and exact byte counts. These snapshots pin the default compressor's *decisions*: any
+//! refactor of scheme selection (see the compressor cost-model track) must leave every
+//! snapshot untouched, so snapshot churn in a later change is the reviewable signal of a
+//! behavior change.
+//!
+//! The `default` variant pins the default feature set and [`BtrBlocksCompressor::default`];
+//! it is compiled out under `unstable_encodings`, whose scheme set differs (variants pinning
+//! that feature set are gated separately).
+//!
+//! Every corpus entry is longer than 1024 values so the sampling-based estimation path is
+//! exercised, and each entry is compressed twice per run to assert determinism directly.
+
+#![allow(clippy::cast_possible_truncation, clippy::tests_outside_test_module)]
+
+use std::fmt;
+use std::sync::Arc;
+use std::sync::LazyLock;
+
+use rand::RngExt;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
+use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::BoolArray;
+use vortex_array::arrays::DecimalArray;
+use vortex_array::arrays::ListArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::StructArray;
+use vortex_array::arrays::TemporalArray;
+use vortex_array::arrays::VarBinViewArray;
+use vortex_array::display::EncodingSummaryExtractor;
+use vortex_array::display::MetadataExtractor;
+use vortex_array::display::TreeContext;
+use vortex_array::display::TreeExtractor;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::DecimalDType;
+use vortex_array::dtype::Nullability;
+use vortex_array::extension::datetime::TimeUnit;
+use vortex_array::validity::Validity;
+use vortex_btrblocks::BtrBlocksCompressor;
+use vortex_buffer::Buffer;
+use vortex_error::VortexResult;
+use vortex_session::VortexSession;
+
+static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+
+/// Number of values in each numeric corpus entry: comfortably above the 1024-value sampling
+/// threshold so scheme selection runs on sampled estimates, as it does for real file chunks.
+const N: usize = 16_384;
+
+/// Header extractor printing exact byte counts (the built-in [`NbytesExtractor`] rounds
+/// through `humansize`, which could mask small size regressions).
+///
+/// [`NbytesExtractor`]: vortex_array::display::NbytesExtractor
+struct ExactNbytesExtractor;
+
+impl TreeExtractor for ExactNbytesExtractor {
+    fn write_header(
+        &self,
+        array: &ArrayRef,
+        _ctx: &TreeContext,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        write!(f, " nbytes={}", array.nbytes())
+    }
+}
+
+/// Renders the full snapshot content for one compressed corpus entry.
+fn render(input: &ArrayRef, compressed: &ArrayRef) -> String {
+    format!(
+        "input: {}, len={}, nbytes={}\n{}",
+        input.dtype(),
+        input.len(),
+        input.nbytes(),
+        compressed
+            .tree_display_builder()
+            .with(EncodingSummaryExtractor)
+            .with(ExactNbytesExtractor)
+            .with(MetadataExtractor)
+    )
+}
+
+/// Compresses every corpus entry twice (direct determinism check) and snapshots the result
+/// under `{variant}__{entry}`.
+fn golden_corpus_snapshots(variant: &str, compressor: &BtrBlocksCompressor) -> VortexResult<()> {
+    for (name, array) in corpus()? {
+        let rendered = {
+            let mut exec_ctx = SESSION.create_execution_ctx();
+            render(&array, &compressor.compress(&array, &mut exec_ctx)?)
+        };
+        let rendered_again = {
+            let mut exec_ctx = SESSION.create_execution_ctx();
+            render(&array, &compressor.compress(&array, &mut exec_ctx)?)
+        };
+        assert_eq!(
+            rendered, rendered_again,
+            "compressing corpus entry {name} twice produced different results"
+        );
+
+        insta::assert_snapshot!(format!("{variant}__{name}"), rendered);
+    }
+    Ok(())
+}
+
+/// The fixed corpus: deterministic synthetic arrays covering each scheme's habitat.
+fn corpus() -> VortexResult<Vec<(&'static str, ArrayRef)>> {
+    Ok(vec![
+        ("int_monotone_jitter", int_monotone_jitter()),
+        ("int_arithmetic_sequence", int_arithmetic_sequence()),
+        ("int_low_cardinality", int_low_cardinality()),
+        ("int_runs", int_runs()),
+        ("int_sparse_outliers", int_sparse_outliers()),
+        ("int_mostly_null", int_mostly_null()),
+        ("int_negatives", int_negatives()),
+        ("int_wide_random", int_wide_random()),
+        ("float_alp_prices", float_alp_prices()),
+        ("float_low_cardinality", float_low_cardinality()),
+        ("float_full_precision", float_full_precision()),
+        ("float_mostly_null", float_mostly_null()),
+        ("string_fsst_structured", string_fsst_structured()),
+        ("string_low_cardinality", string_low_cardinality()),
+        ("binary_low_cardinality", binary_low_cardinality()),
+        ("decimal_prices", decimal_prices()),
+        ("temporal_timestamp_micros", temporal_timestamp_micros()),
+        ("bool_random", bool_random()),
+        ("struct_mixed", struct_mixed()?),
+        ("list_of_int_runs", list_of_int_runs()?),
+    ])
+}
+
+/// Near-monotone u64 (timestamp-like): FoR/BitPacking habitat, Delta habitat when enabled.
+fn int_monotone_jitter() -> ArrayRef {
+    let mut rng = StdRng::seed_from_u64(101);
+    let mut value = 1_700_000_000_000u64;
+    let values: Buffer<u64> = (0..N)
+        .map(|_| {
+            value += 900 + rng.random_range(0..200);
+            value
+        })
+        .collect();
+    PrimitiveArray::new(values, Validity::NonNullable).into_array()
+}
+
+/// Exact arithmetic sequence: Sequence habitat (distinct == len, no nulls).
+fn int_arithmetic_sequence() -> ArrayRef {
+    let values: Buffer<i64> = (0..N as i64).map(|i| 10_000 + 7 * i).collect();
+    PrimitiveArray::new(values, Validity::NonNullable).into_array()
+}
+
+/// A handful of widely-spaced distinct values: IntDict habitat.
+fn int_low_cardinality() -> ArrayRef {
+    const DISTINCT: [i64; 6] = [0, 123_400, 617_000, 1_234_000, 12_340_000, 37_020_000];
+    let mut rng = StdRng::seed_from_u64(102);
+    let values: Buffer<i64> = (0..N).map(|_| DISTINCT[rng.random_range(0..6)]).collect();
+    PrimitiveArray::new(values, Validity::NonNullable).into_array()
+}
+
+/// Long runs over a moderate value set: RunEnd/RLE habitat.
+fn int_runs() -> ArrayRef {
+    let mut rng = StdRng::seed_from_u64(103);
+    let mut values: Vec<i32> = Vec::with_capacity(N);
+    while values.len() < N {
+        let value = rng.random_range(-50_000..50_000i32);
+        let run = rng.random_range(8..25);
+        values.extend(std::iter::repeat_n(value, run));
+    }
+    values.truncate(N);
+    PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable).into_array()
+}
+
+/// One dominant value with rare large outliers: Sparse habitat.
+fn int_sparse_outliers() -> ArrayRef {
+    let mut rng = StdRng::seed_from_u64(104);
+    let values: Buffer<i64> = (0..N)
+        .map(|_| {
+            if rng.random_range(0..100) < 5 {
+                rng.random_range(1_000_000_000..2_000_000_000i64)
+            } else {
+                1_000_000
+            }
+        })
+        .collect();
+    PrimitiveArray::new(values, Validity::NonNullable).into_array()
+}
+
+/// 95% nulls over small values: null-dominated integer habitat.
+fn int_mostly_null() -> ArrayRef {
+    let mut rng = StdRng::seed_from_u64(105);
+    let mut validity: Vec<bool> = Vec::with_capacity(N);
+    let values: Buffer<i32> = (0..N)
+        .map(|_| {
+            let valid = rng.random_range(0..100) < 5;
+            validity.push(valid);
+            if valid { rng.random_range(0..1000) } else { 0 }
+        })
+        .collect();
+    PrimitiveArray::new(
+        values,
+        Validity::Array(BoolArray::from_iter(validity).into_array()),
+    )
+    .into_array()
+}
+
+/// Small values of mixed sign: ZigZag habitat.
+fn int_negatives() -> ArrayRef {
+    let mut rng = StdRng::seed_from_u64(106);
+    let values: Buffer<i64> = (0..N).map(|_| rng.random_range(-128..128i64)).collect();
+    PrimitiveArray::new(values, Validity::NonNullable).into_array()
+}
+
+/// Full-width random u64: essentially incompressible; pins the "no scheme wins" path.
+fn int_wide_random() -> ArrayRef {
+    let mut rng = StdRng::seed_from_u64(107);
+    let values: Buffer<u64> = (0..N).map(|_| rng.random::<u64>()).collect();
+    PrimitiveArray::new(values, Validity::NonNullable).into_array()
+}
+
+/// Two-decimal-digit "prices": ALP habitat.
+fn float_alp_prices() -> ArrayRef {
+    let mut rng = StdRng::seed_from_u64(108);
+    let values: Buffer<f64> = (0..N)
+        .map(|_| rng.random_range(0..10_000_000i64) as f64 / 100.0)
+        .collect();
+    PrimitiveArray::new(values, Validity::NonNullable).into_array()
+}
+
+/// A handful of distinct floats: FloatDict habitat.
+fn float_low_cardinality() -> ArrayRef {
+    const DISTINCT: [f64; 8] = [0.0, 0.5, 1.25, 2.75, 3.5, 10.125, 100.0625, 1000.03125];
+    let mut rng = StdRng::seed_from_u64(109);
+    let values: Buffer<f64> = (0..N).map(|_| DISTINCT[rng.random_range(0..8)]).collect();
+    PrimitiveArray::new(values, Validity::NonNullable).into_array()
+}
+
+/// Full-precision uniform floats: ALP-RD habitat.
+fn float_full_precision() -> ArrayRef {
+    let mut rng = StdRng::seed_from_u64(110);
+    let values: Buffer<f64> = (0..N).map(|_| rng.random::<f64>()).collect();
+    PrimitiveArray::new(values, Validity::NonNullable).into_array()
+}
+
+/// 95% nulls over floats: null-dominated sparse float habitat.
+fn float_mostly_null() -> ArrayRef {
+    let mut rng = StdRng::seed_from_u64(111);
+    let mut validity: Vec<bool> = Vec::with_capacity(N);
+    let values: Buffer<f64> = (0..N)
+        .map(|_| {
+            let valid = rng.random_range(0..100) < 5;
+            validity.push(valid);
+            if valid {
+                rng.random::<f64>() * 100.0
+            } else {
+                0.0
+            }
+        })
+        .collect();
+    PrimitiveArray::new(
+        values,
+        Validity::Array(BoolArray::from_iter(validity).into_array()),
+    )
+    .into_array()
+}
+
+/// High-cardinality strings with shared substructure (emails): FSST habitat.
+fn string_fsst_structured() -> ArrayRef {
+    let mut rng = StdRng::seed_from_u64(112);
+    let strings: Vec<String> = (0..N)
+        .map(|_| {
+            format!(
+                "user{:06}@example{}.com",
+                rng.random_range(0..1_000_000),
+                rng.random_range(0..100)
+            )
+        })
+        .collect();
+    VarBinViewArray::from_iter_str(strings.iter().map(String::as_str)).into_array()
+}
+
+/// A dozen distinct strings: StringDict habitat.
+fn string_low_cardinality() -> ArrayRef {
+    const DISTINCT: [&str; 12] = [
+        "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel", "india",
+        "juliett", "kilo", "lima",
+    ];
+    let mut rng = StdRng::seed_from_u64(113);
+    let strings: Vec<Option<&str>> = (0..N)
+        .map(|_| Some(DISTINCT[rng.random_range(0..12)]))
+        .collect();
+    VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable)).into_array()
+}
+
+/// Low-cardinality binary blobs: BinaryDict habitat (Zstd habitat under `compact`).
+fn binary_low_cardinality() -> ArrayRef {
+    const DISTINCT: [&[u8]; 5] = [
+        &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
+        &[0xDE, 0xAD, 0xBE, 0xEF],
+        &[0x00; 16],
+        &[0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00],
+        &[0x42; 12],
+    ];
+    let mut rng = StdRng::seed_from_u64(114);
+    let blobs: Vec<Option<&[u8]>> = (0..N)
+        .map(|_| Some(DISTINCT[rng.random_range(0..5)]))
+        .collect();
+    VarBinViewArray::from_iter(blobs, DType::Binary(Nullability::NonNullable)).into_array()
+}
+
+/// Two-decimal-place decimals: DecimalScheme (byte-parts) habitat.
+fn decimal_prices() -> ArrayRef {
+    let mut rng = StdRng::seed_from_u64(115);
+    let values: Buffer<i64> = (0..N).map(|_| rng.random_range(0..10_000_000i64)).collect();
+    DecimalArray::new(values, DecimalDType::new(12, 2), Validity::NonNullable).into_array()
+}
+
+/// Near-monotone microsecond timestamps: TemporalScheme (datetime-parts) habitat.
+fn temporal_timestamp_micros() -> ArrayRef {
+    let mut rng = StdRng::seed_from_u64(116);
+    let mut value = 1_700_000_000_000_000i64;
+    let values: Buffer<i64> = (0..N)
+        .map(|_| {
+            value += rng.random_range(1_000..1_000_000);
+            value
+        })
+        .collect();
+    TemporalArray::new_timestamp(
+        PrimitiveArray::new(values, Validity::NonNullable).into_array(),
+        TimeUnit::Microseconds,
+        Some(Arc::from("UTC")),
+    )
+    .into_array()
+}
+
+/// Random booleans: no bool scheme is registered, pinning the "stays canonical" path.
+fn bool_random() -> ArrayRef {
+    let mut rng = StdRng::seed_from_u64(117);
+    BoolArray::from_iter((0..N).map(|_| rng.random::<bool>())).into_array()
+}
+
+/// Struct of int/string/float fields: pins the structural recursion path.
+fn struct_mixed() -> VortexResult<ArrayRef> {
+    Ok(StructArray::from_fields(&[
+        ("id", int_arithmetic_sequence()),
+        ("category", string_low_cardinality()),
+        ("value", float_alp_prices()),
+    ])?
+    .into_array())
+}
+
+/// Variable-length lists of run-heavy ints: pins the list offsets/elements path.
+fn list_of_int_runs() -> VortexResult<ArrayRef> {
+    let mut rng = StdRng::seed_from_u64(118);
+    let elements = int_runs();
+    let mut offsets: Vec<i32> = Vec::with_capacity(N / 4 + 1);
+    let mut offset = 0i32;
+    offsets.push(offset);
+    while (offset as usize) < N {
+        offset = (offset + rng.random_range(1..8)).min(N as i32);
+        offsets.push(offset);
+    }
+    let offsets = PrimitiveArray::new(Buffer::copy_from(&offsets), Validity::NonNullable);
+    Ok(ListArray::try_new(elements, offsets.into_array(), Validity::NonNullable)?.into_array())
+}
+
+#[cfg(not(feature = "unstable_encodings"))]
+#[test]
+fn golden_default() -> VortexResult<()> {
+    golden_corpus_snapshots("default", &BtrBlocksCompressor::default())
+}

--- a/vortex-btrblocks/tests/snapshots/golden__compact__binary_low_cardinality.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__binary_low_cardinality.snap
@@ -1,0 +1,11 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: binary, len=16384, nbytes=315856
+root: vortex.dict(binary, len=16384) nbytes=6199
+  metadata: all_values_referenced: true
+  codes: fastlanes.bitpacked(u8, len=16384) nbytes=6144
+    metadata: bit_width: 3, offset: 0
+  values: vortex.zstd(binary, len=5) nbytes=55
+    metadata: nrows: 5, slice: 0..5

--- a/vortex-btrblocks/tests/snapshots/golden__compact__bool_random.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__bool_random.snap
@@ -1,0 +1,7 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: bool, len=16384, nbytes=2048
+root: vortex.bool(bool, len=16384) nbytes=2048
+  metadata: offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__compact__decimal_prices.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__decimal_prices.snap
@@ -1,0 +1,9 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: decimal(12,2), len=16384, nbytes=131072
+root: vortex.decimal_byte_parts(decimal(12,2), len=16384) nbytes=47666
+  metadata: 
+  msp: vortex.pco(i32, len=16384) nbytes=47666
+    metadata: ptype: i32, nrows: 16384, slice: 0..16384

--- a/vortex-btrblocks/tests/snapshots/golden__compact__float_alp_prices.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__float_alp_prices.snap
@@ -1,0 +1,9 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: f64, len=16384, nbytes=131072
+root: vortex.alp(f64, len=16384) nbytes=47699
+  metadata: exponents: e: 14, f: 12
+  encoded: vortex.pco(i64, len=16384) nbytes=47699
+    metadata: ptype: i64, nrows: 16384, slice: 0..16384

--- a/vortex-btrblocks/tests/snapshots/golden__compact__float_full_precision.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__float_full_precision.snap
@@ -1,0 +1,7 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: f64, len=16384, nbytes=131072
+root: vortex.pco(f64, len=16384) nbytes=110692
+  metadata: ptype: f64, nrows: 16384, slice: 0..16384

--- a/vortex-btrblocks/tests/snapshots/golden__compact__float_low_cardinality.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__float_low_cardinality.snap
@@ -1,0 +1,13 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: f64, len=16384, nbytes=131072
+root: vortex.dict(f64, len=16384) nbytes=6184
+  metadata: all_values_referenced: true
+  codes: fastlanes.bitpacked(u8, len=16384) nbytes=6144
+    metadata: bit_width: 3, offset: 0
+  values: vortex.alp(f64, len=8) nbytes=40
+    metadata: exponents: e: 16, f: 11
+    encoded: vortex.pco(i64, len=8) nbytes=40
+      metadata: ptype: i64, nrows: 8, slice: 0..8

--- a/vortex-btrblocks/tests/snapshots/golden__compact__float_mostly_null.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__float_mostly_null.snap
@@ -1,0 +1,13 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: f64?, len=16384, nbytes=133120
+root: vortex.sparse(f64?, len=16384) nbytes=7545
+  metadata: fill_value: null
+  patch_indices: vortex.pco(u16, len=850) nbytes=636
+    metadata: ptype: u16, nrows: 850, slice: 0..850
+  patch_values: vortex.primitive(f64?, len=850) nbytes=6907
+    metadata: ptype: f64
+    validity: vortex.bool(bool, len=850) nbytes=107
+      metadata: offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__compact__int_arithmetic_sequence.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__int_arithmetic_sequence.snap
@@ -1,0 +1,7 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i64, len=16384, nbytes=131072
+root: vortex.sequence(i64, len=16384) nbytes=0
+  metadata: base: 10000i64, multiplier: 7i64

--- a/vortex-btrblocks/tests/snapshots/golden__compact__int_low_cardinality.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__int_low_cardinality.snap
@@ -1,0 +1,11 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i64, len=16384, nbytes=131072
+root: vortex.dict(i64, len=16384) nbytes=6177
+  metadata: all_values_referenced: true
+  codes: fastlanes.bitpacked(u8, len=16384) nbytes=6144
+    metadata: bit_width: 3, offset: 0
+  values: vortex.pco(i64, len=6) nbytes=33
+    metadata: ptype: i64, nrows: 6, slice: 0..6

--- a/vortex-btrblocks/tests/snapshots/golden__compact__int_monotone_jitter.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__int_monotone_jitter.snap
@@ -1,0 +1,7 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: u64, len=16384, nbytes=131072
+root: vortex.pco(u64, len=16384) nbytes=15715
+  metadata: ptype: u64, nrows: 16384, slice: 0..16384

--- a/vortex-btrblocks/tests/snapshots/golden__compact__int_mostly_null.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__int_mostly_null.snap
@@ -1,0 +1,9 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i32?, len=16384, nbytes=67584
+root: vortex.pco(i32?, len=16384) nbytes=3086
+  metadata: ptype: i32, nrows: 16384, slice: 0..16384
+  validity: vortex.bool(bool, len=16384) nbytes=2048
+    metadata: offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__compact__int_negatives.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__int_negatives.snap
@@ -1,0 +1,9 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i64, len=16384, nbytes=131072
+root: fastlanes.for(i64, len=16384) nbytes=16384
+  metadata: reference: -128i64
+  encoded: fastlanes.bitpacked(i64, len=16384) nbytes=16384
+    metadata: bit_width: 8, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__compact__int_runs.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__int_runs.snap
@@ -1,0 +1,9 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i32, len=16384, nbytes=65536
+root: vortex.zigzag(i32, len=16384) nbytes=2969
+  metadata: 
+  encoded: vortex.pco(u32, len=16384) nbytes=2969
+    metadata: ptype: u32, nrows: 16384, slice: 0..16384

--- a/vortex-btrblocks/tests/snapshots/golden__compact__int_sparse_outliers.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__int_sparse_outliers.snap
@@ -1,0 +1,7 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i64, len=16384, nbytes=131072
+root: vortex.pco(i64, len=16384) nbytes=3817
+  metadata: ptype: i64, nrows: 16384, slice: 0..16384

--- a/vortex-btrblocks/tests/snapshots/golden__compact__int_wide_random.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__int_wide_random.snap
@@ -1,0 +1,7 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: u64, len=16384, nbytes=131072
+root: vortex.primitive(u64, len=16384) nbytes=131072
+  metadata: ptype: u64

--- a/vortex-btrblocks/tests/snapshots/golden__compact__list_of_int_runs.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__list_of_int_runs.snap
@@ -1,0 +1,13 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: list(i32), len=4066, nbytes=81804
+root: vortex.list(list(i32), len=4066) nbytes=4434
+  metadata: 
+  elements: vortex.zigzag(i32, len=16384) nbytes=2969
+    metadata: 
+    encoded: vortex.pco(u32, len=16384) nbytes=2969
+      metadata: ptype: u32, nrows: 16384, slice: 0..16384
+  offsets: vortex.pco(u16, len=4067) nbytes=1465
+    metadata: ptype: u16, nrows: 4067, slice: 0..4067

--- a/vortex-btrblocks/tests/snapshots/golden__compact__string_fsst_structured.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__string_fsst_structured.snap
@@ -1,0 +1,7 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: utf8, len=16384, nbytes=653785
+root: vortex.zstd(utf8, len=16384) nbytes=109119
+  metadata: nrows: 16384, slice: 0..16384

--- a/vortex-btrblocks/tests/snapshots/golden__compact__string_low_cardinality.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__string_low_cardinality.snap
@@ -1,0 +1,11 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: utf8, len=16384, nbytes=262144
+root: vortex.dict(utf8, len=16384) nbytes=8287
+  metadata: all_values_referenced: true
+  codes: fastlanes.bitpacked(u8, len=16384) nbytes=8192
+    metadata: bit_width: 4, offset: 0
+  values: vortex.zstd(utf8, len=12) nbytes=95
+    metadata: nrows: 12, slice: 0..12

--- a/vortex-btrblocks/tests/snapshots/golden__compact__struct_mixed.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__struct_mixed.snap
@@ -1,0 +1,19 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: {id=i64, category=utf8, value=f64}, len=16384, nbytes=524288
+root: vortex.struct({id=i64, category=utf8, value=f64}, len=16384) nbytes=55986
+  metadata: 
+  id: vortex.sequence(i64, len=16384) nbytes=0
+    metadata: base: 10000i64, multiplier: 7i64
+  category: vortex.dict(utf8, len=16384) nbytes=8287
+    metadata: all_values_referenced: true
+    codes: fastlanes.bitpacked(u8, len=16384) nbytes=8192
+      metadata: bit_width: 4, offset: 0
+    values: vortex.zstd(utf8, len=12) nbytes=95
+      metadata: nrows: 12, slice: 0..12
+  value: vortex.alp(f64, len=16384) nbytes=47699
+    metadata: exponents: e: 14, f: 12
+    encoded: vortex.pco(i64, len=16384) nbytes=47699
+      metadata: ptype: i64, nrows: 16384, slice: 0..16384

--- a/vortex-btrblocks/tests/snapshots/golden__compact__temporal_timestamp_micros.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__compact__temporal_timestamp_micros.snap
@@ -1,0 +1,9 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: vortex.timestamp[µs, tz=UTC](i64), len=16384, nbytes=131072
+root: vortex.ext(vortex.timestamp[µs, tz=UTC](i64), len=16384) nbytes=40985
+  metadata: 
+  storage: vortex.pco(i64, len=16384) nbytes=40985
+    metadata: ptype: i64, nrows: 16384, slice: 0..16384

--- a/vortex-btrblocks/tests/snapshots/golden__default__binary_low_cardinality.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__binary_low_cardinality.snap
@@ -1,0 +1,11 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: binary, len=16384, nbytes=315856
+root: vortex.dict(binary, len=16384) nbytes=6240
+  metadata: all_values_referenced: true
+  codes: fastlanes.bitpacked(u8, len=16384) nbytes=6144
+    metadata: bit_width: 3, offset: 0
+  values: vortex.varbinview(binary, len=5) nbytes=96
+    metadata:

--- a/vortex-btrblocks/tests/snapshots/golden__default__bool_random.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__bool_random.snap
@@ -1,0 +1,7 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: bool, len=16384, nbytes=2048
+root: vortex.bool(bool, len=16384) nbytes=2048
+  metadata: offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__default__decimal_prices.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__decimal_prices.snap
@@ -1,0 +1,9 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: decimal(12,2), len=16384, nbytes=131072
+root: vortex.decimal_byte_parts(decimal(12,2), len=16384) nbytes=49152
+  metadata: 
+  msp: fastlanes.bitpacked(i32, len=16384) nbytes=49152
+    metadata: bit_width: 24, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__default__float_alp_prices.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__float_alp_prices.snap
@@ -1,0 +1,9 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: f64, len=16384, nbytes=131072
+root: vortex.alp(f64, len=16384) nbytes=49152
+  metadata: exponents: e: 14, f: 12
+  encoded: fastlanes.bitpacked(i64, len=16384) nbytes=49152
+    metadata: bit_width: 24, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__default__float_full_precision.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__float_full_precision.snap
@@ -1,0 +1,15 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: f64, len=16384, nbytes=131072
+root: vortex.alprd(f64, len=16384) nbytes=112880
+  metadata: right_bit_width: 52, patch_offset: 0
+  left_parts: fastlanes.bitpacked(u16, len=16384) nbytes=6144
+    metadata: bit_width: 3, offset: 0
+  right_parts: fastlanes.bitpacked(u64, len=16384) nbytes=106496
+    metadata: bit_width: 52, offset: 0
+  patch_indices: vortex.primitive(u16, len=60) nbytes=120
+    metadata: ptype: u16
+  patch_values: vortex.primitive(u16, len=60) nbytes=120
+    metadata: ptype: u16

--- a/vortex-btrblocks/tests/snapshots/golden__default__float_low_cardinality.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__float_low_cardinality.snap
@@ -1,0 +1,19 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: f64, len=16384, nbytes=131072
+root: vortex.alp(f64, len=16384) nbytes=10233
+  metadata: exponents: e: 16, f: 12, patch_offset: 0
+  encoded: vortex.dict(i64, len=16384) nbytes=6200
+    metadata: all_values_referenced: true
+    codes: fastlanes.bitpacked(u8, len=16384) nbytes=6144
+      metadata: bit_width: 3, offset: 0
+    values: vortex.primitive(i64, len=7) nbytes=56
+      metadata: ptype: i64
+  patch_indices: vortex.primitive(u16, len=1996) nbytes=3992
+    metadata: ptype: u16
+  patch_values: vortex.constant(f64, len=1996) nbytes=9
+    metadata: scalar: 1000.03125f64
+  patch_chunk_offsets: vortex.primitive(u16, len=16) nbytes=32
+    metadata: ptype: u16

--- a/vortex-btrblocks/tests/snapshots/golden__default__float_mostly_null.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__float_mostly_null.snap
@@ -1,0 +1,13 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: f64?, len=16384, nbytes=133120
+root: vortex.sparse(f64?, len=16384) nbytes=8609
+  metadata: fill_value: null
+  patch_indices: vortex.primitive(u16, len=850) nbytes=1700
+    metadata: ptype: u16
+  patch_values: vortex.primitive(f64?, len=850) nbytes=6907
+    metadata: ptype: f64
+    validity: vortex.bool(bool, len=850) nbytes=107
+      metadata: offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__default__int_arithmetic_sequence.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__int_arithmetic_sequence.snap
@@ -1,0 +1,7 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i64, len=16384, nbytes=131072
+root: vortex.sequence(i64, len=16384) nbytes=0
+  metadata: base: 10000i64, multiplier: 7i64

--- a/vortex-btrblocks/tests/snapshots/golden__default__int_low_cardinality.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__int_low_cardinality.snap
@@ -1,0 +1,11 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i64, len=16384, nbytes=131072
+root: vortex.dict(i64, len=16384) nbytes=6192
+  metadata: all_values_referenced: true
+  codes: fastlanes.bitpacked(u8, len=16384) nbytes=6144
+    metadata: bit_width: 3, offset: 0
+  values: vortex.primitive(i64, len=6) nbytes=48
+    metadata: ptype: i64

--- a/vortex-btrblocks/tests/snapshots/golden__default__int_monotone_jitter.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__int_monotone_jitter.snap
@@ -1,0 +1,9 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: u64, len=16384, nbytes=131072
+root: fastlanes.for(u64, len=16384) nbytes=49152
+  metadata: reference: 1700000001036u64
+  encoded: fastlanes.bitpacked(u64, len=16384) nbytes=49152
+    metadata: bit_width: 24, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__default__int_mostly_null.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__int_mostly_null.snap
@@ -1,0 +1,13 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i32?, len=16384, nbytes=67584
+root: vortex.sparse(i32?, len=16384) nbytes=3031
+  metadata: fill_value: null
+  patch_indices: vortex.primitive(u16, len=823) nbytes=1646
+    metadata: ptype: u16
+  patch_values: fastlanes.bitpacked(i32?, len=823) nbytes=1383
+    metadata: bit_width: 10, offset: 0
+    validity_child: vortex.bool(bool, len=823) nbytes=103
+      metadata: offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__default__int_negatives.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__int_negatives.snap
@@ -1,0 +1,9 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i64, len=16384, nbytes=131072
+root: fastlanes.for(i64, len=16384) nbytes=16384
+  metadata: reference: -128i64
+  encoded: fastlanes.bitpacked(i64, len=16384) nbytes=16384
+    metadata: bit_width: 8, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__default__int_runs.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__int_runs.snap
@@ -1,0 +1,15 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i32, len=16384, nbytes=65536
+root: vortex.runend(i32, len=16384) nbytes=3968
+  metadata: offset: 0
+  ends: fastlanes.for(u16, len=1020) nbytes=1792
+    metadata: reference: 13u16
+    encoded: fastlanes.bitpacked(u16, len=1020) nbytes=1792
+      metadata: bit_width: 14, offset: 0
+  values: fastlanes.for(i32, len=1020) nbytes=2176
+    metadata: reference: -49931i32
+    encoded: fastlanes.bitpacked(i32, len=1020) nbytes=2176
+      metadata: bit_width: 17, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__default__int_sparse_outliers.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__int_sparse_outliers.snap
@@ -1,0 +1,13 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i64, len=16384, nbytes=131072
+root: vortex.sparse(i64, len=16384) nbytes=5540
+  metadata: fill_value: 1000000i64
+  patch_indices: vortex.primitive(u16, len=848) nbytes=1696
+    metadata: ptype: u16
+  patch_values: fastlanes.for(i64, len=848) nbytes=3840
+    metadata: reference: 1000830099i64
+    encoded: fastlanes.bitpacked(i64, len=848) nbytes=3840
+      metadata: bit_width: 30, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__default__int_wide_random.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__int_wide_random.snap
@@ -1,0 +1,7 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: u64, len=16384, nbytes=131072
+root: vortex.primitive(u64, len=16384) nbytes=131072
+  metadata: ptype: u64

--- a/vortex-btrblocks/tests/snapshots/golden__default__list_of_int_runs.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__list_of_int_runs.snap
@@ -1,0 +1,25 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: list(i32), len=4066, nbytes=81804
+root: vortex.list(list(i32), len=4066) nbytes=11146
+  metadata: 
+  elements: vortex.runend(i32, len=16384) nbytes=3968
+    metadata: offset: 0
+    ends: fastlanes.for(u16, len=1020) nbytes=1792
+      metadata: reference: 13u16
+      encoded: fastlanes.bitpacked(u16, len=1020) nbytes=1792
+        metadata: bit_width: 14, offset: 0
+    values: fastlanes.for(i32, len=1020) nbytes=2176
+      metadata: reference: -49931i32
+      encoded: fastlanes.bitpacked(i32, len=1020) nbytes=2176
+        metadata: bit_width: 17, offset: 0
+  offsets: fastlanes.bitpacked(u16, len=4067) nbytes=7178
+    metadata: bit_width: 14, offset: 0
+    patch_indices: vortex.primitive(u16, len=1) nbytes=2
+      metadata: ptype: u16
+    patch_values: vortex.constant(u16, len=1) nbytes=4
+      metadata: scalar: 16384u16
+    patch_chunk_offsets: vortex.primitive(u8, len=4) nbytes=4
+      metadata: ptype: u8

--- a/vortex-btrblocks/tests/snapshots/golden__default__string_fsst_structured.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__string_fsst_structured.snap
@@ -1,0 +1,15 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: utf8, len=16384, nbytes=653785
+root: vortex.fsst(utf8, len=16384) nbytes=151382
+  metadata: len: 16384, nsymbols: 223
+  uncompressed_lengths: vortex.sparse(u8, len=16384) nbytes=3154
+    metadata: fill_value: 24u8
+    patch_indices: vortex.primitive(u16, len=1575) nbytes=3150
+      metadata: ptype: u16
+    patch_values: vortex.constant(u8, len=1575) nbytes=2
+      metadata: scalar: 23u8
+  codes_offsets: fastlanes.bitpacked(u32, len=16385) nbytes=36992
+    metadata: bit_width: 17, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__default__string_low_cardinality.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__string_low_cardinality.snap
@@ -1,0 +1,15 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: utf8, len=16384, nbytes=262144
+root: vortex.dict(utf8, len=16384) nbytes=8373
+  metadata: all_values_referenced: true
+  codes: fastlanes.bitpacked(u8, len=16384) nbytes=8192
+    metadata: bit_width: 4, offset: 0
+  values: vortex.fsst(utf8, len=12) nbytes=181
+    metadata: len: 12, nsymbols: 9
+    uncompressed_lengths: vortex.primitive(u8, len=12) nbytes=12
+      metadata: ptype: u8
+    codes_offsets: vortex.primitive(u8, len=13) nbytes=13
+      metadata: ptype: u8

--- a/vortex-btrblocks/tests/snapshots/golden__default__struct_mixed.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__struct_mixed.snap
@@ -1,0 +1,23 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: {id=i64, category=utf8, value=f64}, len=16384, nbytes=524288
+root: vortex.struct({id=i64, category=utf8, value=f64}, len=16384) nbytes=57525
+  metadata: 
+  id: vortex.sequence(i64, len=16384) nbytes=0
+    metadata: base: 10000i64, multiplier: 7i64
+  category: vortex.dict(utf8, len=16384) nbytes=8373
+    metadata: all_values_referenced: true
+    codes: fastlanes.bitpacked(u8, len=16384) nbytes=8192
+      metadata: bit_width: 4, offset: 0
+    values: vortex.fsst(utf8, len=12) nbytes=181
+      metadata: len: 12, nsymbols: 9
+      uncompressed_lengths: vortex.primitive(u8, len=12) nbytes=12
+        metadata: ptype: u8
+      codes_offsets: vortex.primitive(u8, len=13) nbytes=13
+        metadata: ptype: u8
+  value: vortex.alp(f64, len=16384) nbytes=49152
+    metadata: exponents: e: 14, f: 12
+    encoded: fastlanes.bitpacked(i64, len=16384) nbytes=49152
+      metadata: bit_width: 24, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__default__temporal_timestamp_micros.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__default__temporal_timestamp_micros.snap
@@ -1,0 +1,11 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: vortex.timestamp[µs, tz=UTC](i64), len=16384, nbytes=131072
+root: vortex.ext(vortex.timestamp[µs, tz=UTC](i64), len=16384) nbytes=67584
+  metadata: 
+  storage: fastlanes.for(i64, len=16384) nbytes=67584
+    metadata: reference: 1700000000891673i64
+    encoded: fastlanes.bitpacked(i64, len=16384) nbytes=67584
+      metadata: bit_width: 33, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__binary_low_cardinality.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__binary_low_cardinality.snap
@@ -1,0 +1,11 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: binary, len=16384, nbytes=315856
+root: vortex.dict(binary, len=16384) nbytes=6240
+  metadata: all_values_referenced: true
+  codes: fastlanes.bitpacked(u8, len=16384) nbytes=6144
+    metadata: bit_width: 3, offset: 0
+  values: vortex.varbinview(binary, len=5) nbytes=96
+    metadata:

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__bool_random.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__bool_random.snap
@@ -1,0 +1,7 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: bool, len=16384, nbytes=2048
+root: vortex.bool(bool, len=16384) nbytes=2048
+  metadata: offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__decimal_prices.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__decimal_prices.snap
@@ -1,0 +1,9 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: decimal(12,2), len=16384, nbytes=131072
+root: vortex.decimal_byte_parts(decimal(12,2), len=16384) nbytes=49152
+  metadata: 
+  msp: fastlanes.bitpacked(i32, len=16384) nbytes=49152
+    metadata: bit_width: 24, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__float_alp_prices.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__float_alp_prices.snap
@@ -1,0 +1,9 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: f64, len=16384, nbytes=131072
+root: vortex.alp(f64, len=16384) nbytes=49152
+  metadata: exponents: e: 14, f: 12
+  encoded: fastlanes.bitpacked(i64, len=16384) nbytes=49152
+    metadata: bit_width: 24, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__float_full_precision.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__float_full_precision.snap
@@ -1,0 +1,15 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: f64, len=16384, nbytes=131072
+root: vortex.alprd(f64, len=16384) nbytes=112880
+  metadata: right_bit_width: 52, patch_offset: 0
+  left_parts: fastlanes.bitpacked(u16, len=16384) nbytes=6144
+    metadata: bit_width: 3, offset: 0
+  right_parts: fastlanes.bitpacked(u64, len=16384) nbytes=106496
+    metadata: bit_width: 52, offset: 0
+  patch_indices: vortex.primitive(u16, len=60) nbytes=120
+    metadata: ptype: u16
+  patch_values: vortex.primitive(u16, len=60) nbytes=120
+    metadata: ptype: u16

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__float_low_cardinality.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__float_low_cardinality.snap
@@ -1,0 +1,19 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: f64, len=16384, nbytes=131072
+root: vortex.alp(f64, len=16384) nbytes=10233
+  metadata: exponents: e: 16, f: 12, patch_offset: 0
+  encoded: vortex.dict(i64, len=16384) nbytes=6200
+    metadata: all_values_referenced: true
+    codes: fastlanes.bitpacked(u8, len=16384) nbytes=6144
+      metadata: bit_width: 3, offset: 0
+    values: vortex.primitive(i64, len=7) nbytes=56
+      metadata: ptype: i64
+  patch_indices: vortex.primitive(u16, len=1996) nbytes=3992
+    metadata: ptype: u16
+  patch_values: vortex.constant(f64, len=1996) nbytes=9
+    metadata: scalar: 1000.03125f64
+  patch_chunk_offsets: vortex.primitive(u16, len=16) nbytes=32
+    metadata: ptype: u16

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__float_mostly_null.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__float_mostly_null.snap
@@ -1,0 +1,13 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: f64?, len=16384, nbytes=133120
+root: vortex.sparse(f64?, len=16384) nbytes=8609
+  metadata: fill_value: null
+  patch_indices: vortex.primitive(u16, len=850) nbytes=1700
+    metadata: ptype: u16
+  patch_values: vortex.primitive(f64?, len=850) nbytes=6907
+    metadata: ptype: f64
+    validity: vortex.bool(bool, len=850) nbytes=107
+      metadata: offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__int_arithmetic_sequence.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__int_arithmetic_sequence.snap
@@ -1,0 +1,7 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i64, len=16384, nbytes=131072
+root: vortex.sequence(i64, len=16384) nbytes=0
+  metadata: base: 10000i64, multiplier: 7i64

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__int_low_cardinality.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__int_low_cardinality.snap
@@ -1,0 +1,11 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i64, len=16384, nbytes=131072
+root: vortex.dict(i64, len=16384) nbytes=6192
+  metadata: all_values_referenced: true
+  codes: fastlanes.bitpacked(u8, len=16384) nbytes=6144
+    metadata: bit_width: 3, offset: 0
+  values: vortex.primitive(i64, len=6) nbytes=48
+    metadata: ptype: i64

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__int_monotone_jitter.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__int_monotone_jitter.snap
@@ -1,0 +1,15 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: u64, len=16384, nbytes=131072
+root: fastlanes.delta(u64, len=16384) nbytes=19840
+  metadata: offset: 0
+  bases: vortex.primitive(u64, len=256) nbytes=2048
+    metadata: ptype: u64
+  deltas: vortex.dict(u64, len=16384) nbytes=17792
+    metadata: all_values_referenced: true
+    codes: vortex.primitive(u8, len=16384) nbytes=16384
+      metadata: ptype: u8
+    values: fastlanes.bitpacked(u64, len=201) nbytes=1408
+      metadata: bit_width: 11, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__int_mostly_null.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__int_mostly_null.snap
@@ -1,0 +1,13 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i32?, len=16384, nbytes=67584
+root: vortex.sparse(i32?, len=16384) nbytes=3031
+  metadata: fill_value: null
+  patch_indices: vortex.primitive(u16, len=823) nbytes=1646
+    metadata: ptype: u16
+  patch_values: fastlanes.bitpacked(i32?, len=823) nbytes=1383
+    metadata: bit_width: 10, offset: 0
+    validity_child: vortex.bool(bool, len=823) nbytes=103
+      metadata: offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__int_negatives.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__int_negatives.snap
@@ -1,0 +1,9 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i64, len=16384, nbytes=131072
+root: fastlanes.for(i64, len=16384) nbytes=16384
+  metadata: reference: -128i64
+  encoded: fastlanes.bitpacked(i64, len=16384) nbytes=16384
+    metadata: bit_width: 8, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__int_runs.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__int_runs.snap
@@ -1,0 +1,15 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i32, len=16384, nbytes=65536
+root: vortex.runend(i32, len=16384) nbytes=3968
+  metadata: offset: 0
+  ends: fastlanes.for(u16, len=1020) nbytes=1792
+    metadata: reference: 13u16
+    encoded: fastlanes.bitpacked(u16, len=1020) nbytes=1792
+      metadata: bit_width: 14, offset: 0
+  values: fastlanes.for(i32, len=1020) nbytes=2176
+    metadata: reference: -49931i32
+    encoded: fastlanes.bitpacked(i32, len=1020) nbytes=2176
+      metadata: bit_width: 17, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__int_sparse_outliers.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__int_sparse_outliers.snap
@@ -1,0 +1,13 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: i64, len=16384, nbytes=131072
+root: vortex.sparse(i64, len=16384) nbytes=5540
+  metadata: fill_value: 1000000i64
+  patch_indices: vortex.primitive(u16, len=848) nbytes=1696
+    metadata: ptype: u16
+  patch_values: fastlanes.for(i64, len=848) nbytes=3840
+    metadata: reference: 1000830099i64
+    encoded: fastlanes.bitpacked(i64, len=848) nbytes=3840
+      metadata: bit_width: 30, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__int_wide_random.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__int_wide_random.snap
@@ -1,0 +1,7 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: u64, len=16384, nbytes=131072
+root: vortex.primitive(u64, len=16384) nbytes=131072
+  metadata: ptype: u64

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__list_of_int_runs.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__list_of_int_runs.snap
@@ -1,0 +1,25 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: list(i32), len=4066, nbytes=81804
+root: vortex.list(list(i32), len=4066) nbytes=11146
+  metadata: 
+  elements: vortex.runend(i32, len=16384) nbytes=3968
+    metadata: offset: 0
+    ends: fastlanes.for(u16, len=1020) nbytes=1792
+      metadata: reference: 13u16
+      encoded: fastlanes.bitpacked(u16, len=1020) nbytes=1792
+        metadata: bit_width: 14, offset: 0
+    values: fastlanes.for(i32, len=1020) nbytes=2176
+      metadata: reference: -49931i32
+      encoded: fastlanes.bitpacked(i32, len=1020) nbytes=2176
+        metadata: bit_width: 17, offset: 0
+  offsets: fastlanes.bitpacked(u16, len=4067) nbytes=7178
+    metadata: bit_width: 14, offset: 0
+    patch_indices: vortex.primitive(u16, len=1) nbytes=2
+      metadata: ptype: u16
+    patch_values: vortex.constant(u16, len=1) nbytes=4
+      metadata: scalar: 16384u16
+    patch_chunk_offsets: vortex.primitive(u8, len=4) nbytes=4
+      metadata: ptype: u8

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__string_fsst_structured.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__string_fsst_structured.snap
@@ -1,0 +1,15 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: utf8, len=16384, nbytes=653785
+root: vortex.fsst(utf8, len=16384) nbytes=151382
+  metadata: len: 16384, nsymbols: 223
+  uncompressed_lengths: vortex.sparse(u8, len=16384) nbytes=3154
+    metadata: fill_value: 24u8
+    patch_indices: vortex.primitive(u16, len=1575) nbytes=3150
+      metadata: ptype: u16
+    patch_values: vortex.constant(u8, len=1575) nbytes=2
+      metadata: scalar: 23u8
+  codes_offsets: fastlanes.bitpacked(u32, len=16385) nbytes=36992
+    metadata: bit_width: 17, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__string_low_cardinality.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__string_low_cardinality.snap
@@ -1,0 +1,15 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: utf8, len=16384, nbytes=262144
+root: vortex.dict(utf8, len=16384) nbytes=8373
+  metadata: all_values_referenced: true
+  codes: fastlanes.bitpacked(u8, len=16384) nbytes=8192
+    metadata: bit_width: 4, offset: 0
+  values: vortex.fsst(utf8, len=12) nbytes=181
+    metadata: len: 12, nsymbols: 9
+    uncompressed_lengths: vortex.primitive(u8, len=12) nbytes=12
+      metadata: ptype: u8
+    codes_offsets: vortex.primitive(u8, len=13) nbytes=13
+      metadata: ptype: u8

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__struct_mixed.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__struct_mixed.snap
@@ -1,0 +1,23 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: {id=i64, category=utf8, value=f64}, len=16384, nbytes=524288
+root: vortex.struct({id=i64, category=utf8, value=f64}, len=16384) nbytes=57525
+  metadata: 
+  id: vortex.sequence(i64, len=16384) nbytes=0
+    metadata: base: 10000i64, multiplier: 7i64
+  category: vortex.dict(utf8, len=16384) nbytes=8373
+    metadata: all_values_referenced: true
+    codes: fastlanes.bitpacked(u8, len=16384) nbytes=8192
+      metadata: bit_width: 4, offset: 0
+    values: vortex.fsst(utf8, len=12) nbytes=181
+      metadata: len: 12, nsymbols: 9
+      uncompressed_lengths: vortex.primitive(u8, len=12) nbytes=12
+        metadata: ptype: u8
+      codes_offsets: vortex.primitive(u8, len=13) nbytes=13
+        metadata: ptype: u8
+  value: vortex.alp(f64, len=16384) nbytes=49152
+    metadata: exponents: e: 14, f: 12
+    encoded: fastlanes.bitpacked(i64, len=16384) nbytes=49152
+      metadata: bit_width: 24, offset: 0

--- a/vortex-btrblocks/tests/snapshots/golden__unstable__temporal_timestamp_micros.snap
+++ b/vortex-btrblocks/tests/snapshots/golden__unstable__temporal_timestamp_micros.snap
@@ -1,0 +1,13 @@
+---
+source: vortex-btrblocks/tests/golden.rs
+expression: rendered
+---
+input: vortex.timestamp[µs, tz=UTC](i64), len=16384, nbytes=131072
+root: vortex.ext(vortex.timestamp[µs, tz=UTC](i64), len=16384) nbytes=43008
+  metadata: 
+  storage: fastlanes.delta(i64, len=16384) nbytes=43008
+    metadata: offset: 0
+    bases: vortex.primitive(i64, len=256) nbytes=2048
+      metadata: ptype: i64
+    deltas: fastlanes.bitpacked(i64, len=16384) nbytes=40960
+      metadata: bit_width: 20, offset: 0


### PR DESCRIPTION
Tracking Issue: https://github.com/vortex-data/vortex/issues/8701
Closes: https://github.com/vortex-data/vortex/issues/6171

## Rationale for this change

Groundwork for making the compressor's selection policy pluggable (#7697): before any refactoring of scheme selection, pin the compressor's current decisions with reviewable golden snapshots, so each subsequent PR can demonstrate unchanged selection behavior by showing zero snapshot churn. Test-only, and lands first so later PRs diff against a committed baseline.

This also closes #6171 by adding dedicated regression coverage for whether the compressor produces the expected array tree, across a representative corpus rather than one-off encoding assertions.

## What changes are included in this PR?

A golden test suite in `vortex-btrblocks`: 20 seed-generated corpus entries spanning the registered schemes' habitats, each compressed twice per run (direct determinism check) and snapshotted as its full encoding tree with exact array-level byte counts. Three feature variants cover the default scheme pool, `unstable_encodings`, and `with_compact` (+`zstd`+`pco`).

A dedicated `btrblocks-golden` CI job runs all three feature combinations explicitly. The variants are mutually exclusive at compile time (`unstable_encodings` changes `ALL_SCHEMES`), so the existing `--all-features` workspace test jobs compile the `default` variant out, and it would otherwise only run incidentally in the default-features musl job.

OnPair is excluded from the golden compressors: its dictionary training is nondeterministic run-to-run (randomly-seeded hash maps in the upstream crate), so it cannot serve as a baseline. That's a pre-existing bug worth its own issue.

## What APIs are changed? Are there any user-facing changes?

None (tests and CI only).