### PR TITLE
Add `UnionVariants` type and embed it in `DType::Union`

### DIFF
--- a/vortex-array/src/aggregate_fn/fns/is_sorted/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/is_sorted/mod.rs
@@ -247,7 +247,7 @@ impl AggregateFnVTable for IsSorted {
             | DType::List(..)
             | DType::FixedSizeList(..)
             | DType::Struct(..)
-            | DType::Union(_)
+            | DType::Union(..)
             | DType::Variant(..)
             | DType::Extension(_) => None,
             DType::Bool(_)
@@ -264,7 +264,7 @@ impl AggregateFnVTable for IsSorted {
             | DType::List(..)
             | DType::FixedSizeList(..)
             | DType::Struct(..)
-            | DType::Union(_)
+            | DType::Union(..)
             | DType::Variant(..)
             | DType::Extension(_) => None,
             DType::Bool(_)

--- a/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
@@ -289,7 +289,9 @@ fn supports_uncompressed_size_in_bytes(dtype: &DType) -> bool {
         DType::Struct(fields, _) => fields
             .fields()
             .all(|field| supports_uncompressed_size_in_bytes(&field)),
-        DType::Union(_) => todo!("TODO(connor)[Union]: unimplemented"),
+        DType::Union(variants, _) => variants
+            .variants()
+            .all(|variant| supports_uncompressed_size_in_bytes(&variant)),
         DType::Variant(_) => false,
         DType::Extension(ext_dtype) => {
             supports_uncompressed_size_in_bytes(ext_dtype.storage_dtype())

--- a/vortex-array/src/dtype/dtype_impl.rs
+++ b/vortex-array/src/dtype/dtype_impl.rs
@@ -15,6 +15,7 @@ use crate::dtype::FieldDType;
 use crate::dtype::FieldName;
 use crate::dtype::PType;
 use crate::dtype::StructFields;
+use crate::dtype::UnionVariants;
 use crate::dtype::decimal::DecimalDType;
 use crate::dtype::decimal::DecimalType;
 use crate::dtype::extension::ExtDTypeRef;
@@ -63,7 +64,7 @@ impl DType {
             | List(_, null)
             | FixedSizeList(_, _, null)
             | Struct(_, null)
-            | Union(null)
+            | Union(_, null)
             | Variant(null) => matches!(null, Nullability::Nullable),
             Extension(ext_dtype) => ext_dtype.storage_dtype().is_nullable(),
         }
@@ -91,7 +92,7 @@ impl DType {
             List(edt, _) => List(Arc::clone(edt), nullability),
             FixedSizeList(edt, size, _) => FixedSizeList(Arc::clone(edt), *size, nullability),
             Struct(sf, _) => Struct(sf.clone(), nullability),
-            Union(_) => Union(nullability),
+            Union(vs, _) => Union(vs.clone(), nullability),
             Variant(_) => Variant(nullability),
             Extension(ext) => Extension(ext.with_nullability(nullability)),
         }
@@ -123,7 +124,15 @@ impl DType {
                         .zip_eq(rhs_dtype.fields())
                         .all(|(l, r)| l.eq_ignore_nullability(&r)))
             }
-            (Union(_), Union(_)) => true,
+            (Union(lhs, _), Union(rhs, _)) => {
+                // Equal `names` implies equal length by FieldNames equality.
+                lhs.names() == rhs.names()
+                    && lhs.type_ids() == rhs.type_ids()
+                    && lhs
+                        .variants()
+                        .zip_eq(rhs.variants())
+                        .all(|(l, r)| l.eq_ignore_nullability(&r))
+            }
             (Variant(_), Variant(_)) => true,
             (Extension(lhs_extdtype), Extension(rhs_extdtype)) => {
                 lhs_extdtype.eq_ignore_nullability(rhs_extdtype)
@@ -425,6 +434,24 @@ impl DType {
         }
     }
 
+    /// Get the [`UnionVariants`] if `self` is a [`DType::Union`], otherwise `None`.
+    pub fn as_union_variants_opt(&self) -> Option<&UnionVariants> {
+        if let Union(uv, _) = self {
+            Some(uv)
+        } else {
+            None
+        }
+    }
+
+    /// Owned version of [Self::as_union_variants_opt].
+    pub fn into_union_variants_opt(self) -> Option<UnionVariants> {
+        if let Union(uv, _) = self {
+            Some(uv)
+        } else {
+            None
+        }
+    }
+
     /// Downcast a `DType` to an `ExtDType`
     pub fn as_extension(&self) -> &ExtDTypeRef {
         let Extension(ext) = self else {
@@ -476,7 +503,7 @@ impl Display for DType {
                     .map(|(field_null, dt)| format!("{field_null}={dt}"))
                     .join(", "),
             ),
-            Union(null) => write!(f, "union(){null}"),
+            Union(uv, null) => write!(f, "union({uv}){null}"),
             Variant(null) => write!(f, "variant{null}"),
             Extension(ext) => write!(f, "{}", ext),
         }

--- a/vortex-array/src/dtype/mod.rs
+++ b/vortex-array/src/dtype/mod.rs
@@ -31,6 +31,7 @@ mod ptype;
 pub mod serde;
 pub mod session;
 mod struct_;
+mod union;
 
 use std::sync::Arc;
 
@@ -110,11 +111,11 @@ pub enum DType {
 
     /// A logical union (sum) type.
     ///
-    /// `Union` is reserved for values that are drawn from one of several possible child domains.
-    /// The exact child-type metadata and canonical storage are not yet part of the stable public
-    /// Rust API, so most callers should prefer [`DType::Variant`] for dynamically typed values or
-    /// [`DType::Struct`] for fixed schemas.
-    Union(Nullability),
+    /// A `Union` is composed of one or more **variants**, each with a name and a `DType`. A per-row
+    /// `i8` tag selects which variant is "live" at that row.
+    ///
+    /// See [`UnionVariants`] for the type-tag conventions and accessors.
+    Union(UnionVariants, Nullability),
 
     /// Dynamically typed values stored as Vortex scalars.
     ///
@@ -146,7 +147,8 @@ impl PartialEq for DType {
             }
             // StructFields handles its own Arc::ptr_eq in its PartialEq impl.
             (Self::Struct(a, na), Self::Struct(b, nb)) => na == nb && a == b,
-            (Self::Union(a), Self::Union(b)) => a == b,
+            // UnionVariants handles its own Arc::ptr_eq in its PartialEq impl.
+            (Self::Union(a, na), Self::Union(b, nb)) => na == nb && a == b,
             (Self::Variant(a), Self::Variant(b)) => a == b,
             (Self::Extension(a), Self::Extension(b)) => a == b,
             // Every variant is listed in the first position so that adding a new
@@ -178,6 +180,7 @@ pub use half;
 pub use nullability::*;
 pub use ptype::*;
 pub use struct_::*;
+pub use union::*;
 
 use crate::dtype::extension::ExtDTypeRef;
 

--- a/vortex-array/src/dtype/serde/flatbuffers.rs
+++ b/vortex-array/src/dtype/serde/flatbuffers.rs
@@ -11,6 +11,7 @@ use itertools::Itertools;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 use vortex_flatbuffers::FlatBuffer;
 use vortex_flatbuffers::FlatBufferRoot;
@@ -21,8 +22,10 @@ use vortex_session::VortexSession;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
 use crate::dtype::FieldDType;
+use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::dtype::StructFields;
+use crate::dtype::UnionVariants;
 use crate::dtype::extension::ExtId;
 use crate::dtype::extension::ForeignExtDType;
 use crate::dtype::flatbuffers as fb;
@@ -87,6 +90,42 @@ impl StructFields {
             .collect::<Vec<_>>();
 
         Ok(StructFields::from_fields(names, dtypes))
+    }
+}
+
+impl UnionVariants {
+    /// Creates a new instance from a flatbuffer-defined object and its underlying buffer.
+    fn from_fb(
+        fb_union: fbd::Union<'_>,
+        buffer: FlatBuffer,
+        session: VortexSession,
+    ) -> VortexResult<Self> {
+        let names = fb_union
+            .names()
+            .ok_or_else(|| vortex_err!("failed to parse union names from flatbuffer"))?
+            .iter()
+            .collect();
+
+        let dtypes = fb_union
+            .dtypes()
+            .ok_or_else(|| vortex_err!("failed to parse union dtypes from flatbuffer"))?
+            .iter()
+            .map(|dt| {
+                FieldDType::from(ViewedDType::from_fb_loc(
+                    dt._tab.loc(),
+                    buffer.clone(),
+                    session.clone(),
+                ))
+            })
+            .collect::<Vec<_>>();
+
+        let type_ids: Vec<i8> = fb_union
+            .type_ids()
+            .ok_or_else(|| vortex_err!("failed to parse union type_ids from flatbuffer"))?
+            .iter()
+            .collect();
+
+        UnionVariants::try_from_fields(names, dtypes, type_ids)
     }
 }
 
@@ -195,7 +234,17 @@ impl TryFrom<ViewedDType> for DType {
                 let fb_union = fb
                     .type__as_union()
                     .ok_or_else(|| vortex_err!("failed to parse union from flatbuffer"))?;
-                Ok(Self::Union(fb_union.nullable().into()))
+                let variants =
+                    UnionVariants::from_fb(fb_union, vfdt.buffer().clone(), vfdt.session.clone())?;
+
+                let nullability: Nullability = fb_union.nullable().into();
+                vortex_ensure!(
+                    variants.nullability_constraints_satisfied(nullability),
+                    "Union nullability constraint not satisfied: nullability={:?}",
+                    nullability
+                );
+
+                Ok(Self::Union(variants, nullability))
             }
             fb::Type::Variant => {
                 let fb_variant = fb
@@ -341,13 +390,33 @@ impl WriteFlatBuffer for DType {
                 )
                 .as_union_value()
             }
-            Self::Union(n) => fb::Union::create(
-                fbb,
-                &fb::UnionArgs {
-                    nullable: (*n).into(),
-                },
-            )
-            .as_union_value(),
+            Self::Union(uv, n) => {
+                let names = uv
+                    .names()
+                    .iter()
+                    .map(|name| fbb.create_string(name.as_ref()))
+                    .collect_vec();
+                let names = Some(fbb.create_vector(&names));
+
+                let dtypes = uv
+                    .variants()
+                    .map(|dtype| dtype.write_flatbuffer(fbb))
+                    .collect::<VortexResult<Vec<_>>>()?;
+                let dtypes = Some(fbb.create_vector(&dtypes));
+
+                let type_ids = Some(fbb.create_vector(uv.type_ids()));
+
+                fb::Union::create(
+                    fbb,
+                    &fb::UnionArgs {
+                        names,
+                        dtypes,
+                        type_ids,
+                        nullable: (*n).into(),
+                    },
+                )
+                .as_union_value()
+            }
             Self::Variant(n) => fb::Variant::create(
                 fbb,
                 &fb::VariantArgs {
@@ -446,6 +515,7 @@ mod test {
     use crate::dtype::DType;
     use crate::dtype::PType;
     use crate::dtype::StructFields;
+    use crate::dtype::UnionVariants;
     use crate::dtype::flatbuffers as fb;
     use crate::dtype::nullability::Nullability;
     use crate::dtype::serde::flatbuffers::ViewedDType;
@@ -501,5 +571,166 @@ mod test {
             Nullability::NonNullable,
         ));
         roundtrip_dtype(DType::Variant(Nullability::Nullable));
+    }
+
+    fn make_basic_union() -> DType {
+        DType::Union(
+            UnionVariants::new(
+                ["int", "str"].into(),
+                vec![
+                    DType::Primitive(PType::I32, Nullability::NonNullable),
+                    DType::Utf8(Nullability::NonNullable),
+                ],
+            )
+            .unwrap(),
+            Nullability::NonNullable,
+        )
+    }
+
+    #[test]
+    fn test_union_round_trip_flatbuffer() {
+        roundtrip_dtype(make_basic_union());
+    }
+
+    #[test]
+    fn test_union_round_trip_flatbuffer_with_nullability() {
+        let dtype = DType::Union(
+            UnionVariants::new(
+                ["null_variant", "str"].into(),
+                vec![DType::Null, DType::Utf8(Nullability::NonNullable)],
+            )
+            .unwrap(),
+            Nullability::Nullable,
+        );
+        roundtrip_dtype(dtype);
+    }
+
+    #[test]
+    fn test_union_round_trip_flatbuffer_with_type_id_indirection() {
+        let dtype = DType::Union(
+            UnionVariants::try_new(
+                ["a", "b", "c"].into(),
+                vec![
+                    DType::Primitive(PType::I32, Nullability::NonNullable),
+                    DType::Utf8(Nullability::NonNullable),
+                    DType::Bool(Nullability::NonNullable),
+                ],
+                vec![0, 5, 7],
+            )
+            .unwrap(),
+            Nullability::NonNullable,
+        );
+
+        let bytes = dtype.write_flatbuffer_bytes().unwrap();
+        let root_fb = root::<fb::DType>(&bytes).unwrap();
+        let view = ViewedDType::from_fb_loc(
+            root_fb._tab.loc(),
+            FlatBuffer::from(bytes.clone()),
+            SESSION.clone(),
+        );
+
+        let deserialized = DType::try_from(view).unwrap();
+        assert_eq!(dtype, deserialized);
+        let DType::Union(uv, _) = &deserialized else {
+            panic!("Expected Union");
+        };
+        assert_eq!(uv.type_ids(), &[0, 5, 7]);
+    }
+
+    #[test]
+    fn test_nested_union_round_trip_flatbuffer() {
+        let inner_union = make_basic_union();
+        let struct_with_union = DType::Struct(
+            StructFields::from_iter([
+                ("id", DType::Primitive(PType::I64, Nullability::NonNullable)),
+                ("inner", inner_union),
+            ]),
+            Nullability::NonNullable,
+        );
+
+        let outer_union = DType::Union(
+            UnionVariants::new(
+                ["plain", "nested"].into(),
+                vec![DType::Utf8(Nullability::NonNullable), struct_with_union],
+            )
+            .unwrap(),
+            Nullability::NonNullable,
+        );
+
+        roundtrip_dtype(outer_union);
+    }
+
+    /// A `UnionVariants` parsed lazily from a flatbuffer must compare equal to its eager
+    /// counterpart.
+    #[test]
+    fn test_union_viewed_dtype_equality() {
+        let eager = make_basic_union();
+
+        let bytes = eager.write_flatbuffer_bytes().unwrap();
+        let root_fb = root::<fb::DType>(&bytes).unwrap();
+        let view = ViewedDType::from_fb_loc(
+            root_fb._tab.loc(),
+            FlatBuffer::from(bytes.clone()),
+            SESSION.clone(),
+        );
+
+        let viewed = DType::try_from(view).unwrap();
+        assert_eq!(eager, viewed);
+        assert_eq!(viewed, eager);
+    }
+
+    /// A malformed flatbuffer (here, `dtypes.len() != type_ids.len()`) must round-trip
+    /// to `Err`, not panic.
+    #[test]
+    fn test_union_malformed_flatbuffer_errors() {
+        use flatbuffers::FlatBufferBuilder;
+        use vortex_buffer::ByteBuffer;
+        use vortex_flatbuffers::WriteFlatBuffer;
+
+        let mut fbb = FlatBufferBuilder::new();
+
+        // Build a Union with 2 names + 2 dtypes but only 1 type_id.
+        let name_a = fbb.create_string("a");
+        let name_b = fbb.create_string("b");
+        let names = fbb.create_vector(&[name_a, name_b]);
+
+        let dtype_a = DType::Primitive(PType::I32, Nullability::NonNullable)
+            .write_flatbuffer(&mut fbb)
+            .unwrap();
+        let dtype_b = DType::Utf8(Nullability::NonNullable)
+            .write_flatbuffer(&mut fbb)
+            .unwrap();
+        let dtypes = fbb.create_vector(&[dtype_a, dtype_b]);
+
+        let type_ids = fbb.create_vector::<i8>(&[0]);
+
+        let union_table = fb::Union::create(
+            &mut fbb,
+            &fb::UnionArgs {
+                names: Some(names),
+                dtypes: Some(dtypes),
+                type_ids: Some(type_ids),
+                nullable: false,
+            },
+        );
+
+        let dtype = fb::DType::create(
+            &mut fbb,
+            &fb::DTypeArgs {
+                type_type: fb::Type::Union,
+                type_: Some(union_table.as_union_value()),
+            },
+        );
+        fbb.finish_minimal(dtype);
+        let (vec, start) = fbb.collapse();
+        let end = vec.len();
+        let buffer = FlatBuffer::align_from(ByteBuffer::from(vec).slice(start..end));
+
+        let root_fb = root::<fb::DType>(&buffer).unwrap();
+        let view = ViewedDType::from_fb_loc(root_fb._tab.loc(), buffer, SESSION.clone());
+
+        let result = DType::try_from(view);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("length mismatch"));
     }
 }

--- a/vortex-array/src/dtype/serde/proto.rs
+++ b/vortex-array/src/dtype/serde/proto.rs
@@ -5,13 +5,16 @@ use std::sync::Arc;
 
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
+use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::dtype::StructFields;
+use crate::dtype::UnionVariants;
 use crate::dtype::extension::ExtId;
 use crate::dtype::extension::ForeignExtDType;
 use crate::dtype::field::Field;
@@ -86,7 +89,33 @@ impl DType {
                 ),
                 s.nullable.into(),
             )),
-            DtypeType::Union(u) => Ok(Self::Union(u.nullable.into())),
+            DtypeType::Union(u) => {
+                let names = u.names.iter().map(|s| s.as_str()).collect();
+                let dtypes = u
+                    .dtypes
+                    .iter()
+                    .map(|dt| DType::from_proto(dt, session))
+                    .collect::<VortexResult<Vec<_>>>()?;
+                let type_ids = u
+                    .type_ids
+                    .iter()
+                    .map(|t| {
+                        i8::try_from(*t).map_err(|_| {
+                            vortex_err!("Union type_id {t} somehow does not fit in i8")
+                        })
+                    })
+                    .collect::<VortexResult<Vec<_>>>()?;
+                let variants = UnionVariants::try_new(names, dtypes, type_ids)?;
+
+                let nullability: Nullability = u.nullable.into();
+                vortex_ensure!(
+                    variants.nullability_constraints_satisfied(nullability),
+                    "Union nullability constraint not satisfied: nullability={:?}",
+                    nullability
+                );
+
+                Ok(Self::Union(variants, nullability))
+            }
             DtypeType::Variant(v) => Ok(Self::Variant(v.nullable.into())),
             DtypeType::Extension(e) => {
                 #[expect(clippy::disallowed_methods, reason = "interning a dynamic id")]
@@ -154,7 +183,13 @@ impl TryFrom<&DType> for pb::DType {
                         .collect::<VortexResult<Vec<_>>>()?,
                     nullable: (*null).into(),
                 }),
-                DType::Union(null) => DtypeType::Union(pb::Union {
+                DType::Union(uv, null) => DtypeType::Union(pb::Union {
+                    names: uv.names().iter().map(|n| n.as_ref().to_string()).collect(),
+                    dtypes: uv
+                        .variants()
+                        .map(|d| Self::try_from(&d))
+                        .collect::<VortexResult<Vec<_>>>()?,
+                    type_ids: uv.type_ids().iter().map(|t| *t as i32).collect(),
                     nullable: (*null).into(),
                 }),
                 DType::Variant(null) => DtypeType::Variant(pb::Variant {
@@ -239,6 +274,7 @@ mod tests {
     use crate::dtype::Nullability;
     use crate::dtype::PType;
     use crate::dtype::StructFields;
+    use crate::dtype::UnionVariants;
     use crate::dtype::proto::dtype::d_type::DtypeType;
     use crate::dtype::proto::dtype::field::FieldType;
     use crate::dtype::test::SESSION;
@@ -379,6 +415,147 @@ mod tests {
     fn test_variant_round_trip() {
         let converted = round_trip_dtype(&DType::Variant(Nullability::Nullable));
         assert_eq!(DType::Variant(Nullability::Nullable), converted);
+    }
+
+    #[test]
+    fn test_union_round_trip_proto() {
+        let variants = UnionVariants::new(
+            ["int", "str"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Utf8(Nullability::NonNullable),
+            ],
+        )
+        .unwrap();
+        let dtype = DType::Union(variants, Nullability::NonNullable);
+        let converted = round_trip_dtype(&dtype);
+        assert_eq!(dtype, converted);
+    }
+
+    #[test]
+    fn test_union_round_trip_proto_with_nullability() {
+        let variants = UnionVariants::new(
+            ["null_variant", "str"].into(),
+            vec![DType::Null, DType::Utf8(Nullability::NonNullable)],
+        )
+        .unwrap();
+
+        assert!(variants.nullability_constraints_satisfied(Nullability::Nullable));
+        assert!(!variants.nullability_constraints_satisfied(Nullability::NonNullable));
+
+        let dtype = DType::Union(variants, Nullability::Nullable);
+        let converted = round_trip_dtype(&dtype);
+        assert_eq!(dtype, converted);
+    }
+
+    #[test]
+    fn test_union_round_trip_proto_with_type_id_indirection() {
+        let variants = UnionVariants::try_new(
+            ["a", "b", "c"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Utf8(Nullability::NonNullable),
+                DType::Bool(Nullability::NonNullable),
+            ],
+            vec![0, 5, 7],
+        )
+        .unwrap();
+
+        let dtype = DType::Union(variants, Nullability::NonNullable);
+        let converted = round_trip_dtype(&dtype);
+        assert_eq!(dtype, converted);
+
+        let DType::Union(uv, _) = &converted else {
+            panic!("Expected Union");
+        };
+        assert_eq!(uv.type_ids(), &[0, 5, 7]);
+        assert!(!uv.is_consecutive());
+    }
+
+    #[test]
+    fn test_union_proto_rejects_violating_nullability_constraint() {
+        // Nullable Union with no nullable or Null children must be rejected.
+        let proto = pb::DType {
+            dtype_type: Some(DtypeType::Union(pb::Union {
+                names: vec!["a".to_string(), "b".to_string()],
+                dtypes: vec![
+                    pb::DType::try_from(&DType::Primitive(PType::I32, Nullability::NonNullable))
+                        .unwrap(),
+                    pb::DType::try_from(&DType::Utf8(Nullability::NonNullable)).unwrap(),
+                ],
+                type_ids: vec![0, 1],
+                nullable: true,
+            })),
+        };
+
+        let result = DType::from_proto(&proto, &SESSION);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Union nullability constraint not satisfied")
+        );
+    }
+
+    #[test]
+    fn test_union_proto_rejects_out_of_range_type_id() {
+        let proto = pb::DType {
+            dtype_type: Some(DtypeType::Union(pb::Union {
+                names: vec!["a".to_string()],
+                dtypes: vec![
+                    pb::DType::try_from(&DType::Primitive(PType::I32, Nullability::NonNullable))
+                        .unwrap(),
+                ],
+                // 200 does not fit in i8.
+                type_ids: vec![200],
+                nullable: false,
+            })),
+        };
+
+        let result = DType::from_proto(&proto, &SESSION);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("does not fit in i8")
+        );
+    }
+
+    #[test]
+    fn test_nested_union_round_trip_proto() {
+        let inner_union = DType::Union(
+            UnionVariants::new(
+                ["a", "b"].into(),
+                vec![
+                    DType::Primitive(PType::I32, Nullability::NonNullable),
+                    DType::Utf8(Nullability::NonNullable),
+                ],
+            )
+            .unwrap(),
+            Nullability::NonNullable,
+        );
+
+        let struct_with_union = DType::Struct(
+            StructFields::from_iter([
+                ("id", DType::Primitive(PType::I64, Nullability::NonNullable)),
+                ("inner", inner_union),
+            ]),
+            Nullability::NonNullable,
+        );
+
+        let outer_union = DType::Union(
+            UnionVariants::new(
+                ["plain", "nested"].into(),
+                vec![DType::Utf8(Nullability::NonNullable), struct_with_union],
+            )
+            .unwrap(),
+            Nullability::NonNullable,
+        );
+
+        let converted = round_trip_dtype(&outer_union);
+        assert_eq!(outer_union, converted);
     }
 
     #[test]

--- a/vortex-array/src/dtype/serde/serde.rs
+++ b/vortex-array/src/dtype/serde/serde.rs
@@ -27,6 +27,7 @@ use crate::dtype::FieldNames;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::dtype::StructFields;
+use crate::dtype::UnionVariants;
 use crate::dtype::decimal::DecimalDType;
 use crate::dtype::extension::ExtDTypeRef;
 use crate::dtype::extension::ExtId;
@@ -115,7 +116,12 @@ impl Serialize for DType {
                 state.serialize_field(n)?;
                 state.end()
             }
-            DType::Union(n) => serializer.serialize_newtype_variant("DType", 11, "Union", n),
+            DType::Union(uv, n) => {
+                let mut state = serializer.serialize_tuple_variant("DType", 11, "Union", 2)?;
+                state.serialize_field(&uv)?;
+                state.serialize_field(n)?;
+                state.end()
+            }
             DType::Variant(n) => serializer.serialize_newtype_variant("DType", 10, "Variant", n),
             DType::Extension(ext) => {
                 serializer.serialize_newtype_variant("DType", 9, "Extension", ext)
@@ -133,6 +139,20 @@ impl Serialize for StructFields {
         state.serialize_field("names", self.names())?;
         let dtypes: Vec<DType> = self.fields().collect();
         state.serialize_field("dtypes", &dtypes)?;
+        state.end()
+    }
+}
+
+impl Serialize for UnionVariants {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("UnionVariants", 3)?;
+        state.serialize_field("names", self.names())?;
+        let dtypes: Vec<DType> = self.variants().collect();
+        state.serialize_field("dtypes", &dtypes)?;
+        state.serialize_field("type_ids", self.type_ids())?;
         state.end()
     }
 }
@@ -217,10 +237,9 @@ impl<'de> DeserializeSeed<'de> for DTypeSerde<'_, DType> {
                     "Struct" => access.newtype_variant_seed(StructFieldsSeed {
                         session: self.session,
                     }),
-                    "Union" => {
-                        let n = access.newtype_variant()?;
-                        Ok(DType::Union(n))
-                    }
+                    "Union" => access.newtype_variant_seed(UnionVariantsSeed {
+                        session: self.session,
+                    }),
                     "Variant" => {
                         let n = access.newtype_variant()?;
                         Ok(DType::Variant(n))
@@ -385,6 +404,132 @@ impl<'de> DeserializeSeed<'de> for StructFieldsSeed<'_> {
         deserializer.deserialize_tuple(
             2,
             StructVisitor {
+                session: self.session,
+            },
+        )
+    }
+}
+
+struct UnionVariantsSeed<'a> {
+    session: &'a VortexSession,
+}
+
+impl<'de> DeserializeSeed<'de> for UnionVariantsSeed<'_> {
+    type Value = DType;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct UnionVisitor<'a> {
+            session: &'a VortexSession,
+        }
+
+        impl<'de> Visitor<'de> for UnionVisitor<'_> {
+            type Value = DType;
+
+            fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                f.write_str("Union tuple (variants, nullability)")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let variants = seq
+                    .next_element_seed(DTypeSerde::<UnionVariants>::new(self.session))?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let nullability: Nullability = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                if !variants.nullability_constraints_satisfied(nullability) {
+                    return Err(de::Error::custom(format!(
+                        "Union nullability constraint not satisfied: nullability={:?}",
+                        nullability
+                    )));
+                }
+                Ok(DType::Union(variants, nullability))
+            }
+        }
+
+        deserializer.deserialize_tuple(
+            2,
+            UnionVisitor {
+                session: self.session,
+            },
+        )
+    }
+}
+
+impl<'de> DeserializeSeed<'de> for DTypeSerde<'_, UnionVariants> {
+    type Value = UnionVariants;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["names", "dtypes", "type_ids"];
+
+        struct UnionVariantsInnerVisitor<'a> {
+            session: &'a VortexSession,
+        }
+
+        impl<'de> Visitor<'de> for UnionVariantsInnerVisitor<'_> {
+            type Value = UnionVariants;
+
+            fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                f.write_str("struct UnionVariants")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut names: Option<FieldNames> = None;
+                let mut dtypes: Option<Vec<DType>> = None;
+                let mut type_ids: Option<Vec<i8>> = None;
+
+                while let Some(key) = map.next_key::<Cow<'_, str>>()? {
+                    match key.as_ref() {
+                        "names" => {
+                            if names.is_some() {
+                                return Err(de::Error::duplicate_field("names"));
+                            }
+                            names = Some(map.next_value()?);
+                        }
+                        "dtypes" => {
+                            if dtypes.is_some() {
+                                return Err(de::Error::duplicate_field("dtypes"));
+                            }
+                            dtypes = Some(
+                                map.next_value_seed(DTypeSerde::<Vec<DType>>::new(self.session))?,
+                            );
+                        }
+                        "type_ids" => {
+                            if type_ids.is_some() {
+                                return Err(de::Error::duplicate_field("type_ids"));
+                            }
+                            type_ids = Some(map.next_value()?);
+                        }
+                        _ => {
+                            let _ = map.next_value::<de::IgnoredAny>()?;
+                        }
+                    }
+                }
+
+                let names = names.ok_or_else(|| de::Error::missing_field("names"))?;
+                let dtypes = dtypes.ok_or_else(|| de::Error::missing_field("dtypes"))?;
+                let type_ids = type_ids.ok_or_else(|| de::Error::missing_field("type_ids"))?;
+
+                UnionVariants::try_new(names, dtypes, type_ids)
+                    .map_err(|e| de::Error::custom(e.to_string()))
+            }
+        }
+
+        deserializer.deserialize_struct(
+            "UnionVariants",
+            FIELDS,
+            UnionVariantsInnerVisitor {
                 session: self.session,
             },
         )

--- a/vortex-array/src/dtype/union.rs
+++ b/vortex-array/src/dtype/union.rs
@@ -1,0 +1,614 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::fmt;
+use std::hash::Hash;
+use std::sync::Arc;
+
+use itertools::Itertools;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
+use vortex_error::vortex_ensure_eq;
+
+use crate::dtype::DType;
+use crate::dtype::FieldDType;
+use crate::dtype::FieldNames;
+use crate::dtype::Nullability;
+
+/// Type information for a union array.
+///
+/// A `UnionVariants` describes the possible alternative types for each row of a union, along with a
+/// per-variant `i8` type tag. We use the term **variants** (rather than "fields") because a union
+/// is a sum type: each row chooses exactly one alternative.
+///
+/// Per Arrow's spec, the per-row type tag is an `int8`. By default, tag `i` selects the child at
+/// offset `i` (`type_ids = [0, 1, ..., N-1]`).
+///
+/// Schemas may also use non-consecutive tags (e.g. `[0, 5, 7]`), in which case the value of
+/// `type_ids[i]` is the tag used in the data to select the child at offset `i`. Supporting
+/// non-consecutive tags lets the schema remove children without renumbering the remaining tags.
+///
+/// Variant names must be distinct. Unlike [`StructFields`](crate::dtype::StructFields), which
+/// permits duplicate field names for Arrow/Parquet round-trip fidelity, duplicates have no
+/// meaningful semantics in a sum type and are rejected at construction.
+///
+/// Note that the Arrow spec does not require distinct names (children are selected by the type-id
+/// buffer, never by name), but DuckDB requires distinct member names for its `UNION` type and
+/// resolves members by name (e.g. in `union_extract`), so permitting duplicates would break DuckDB
+/// round-trips while enabling no useful semantics.
+///
+/// ```
+/// use vortex_array::dtype::{DType, Nullability, PType, UnionVariants};
+///
+/// let variants = UnionVariants::new(
+///     ["a", "b"].into(),
+///     vec![
+///         DType::Primitive(PType::I32, Nullability::NonNullable),
+///         DType::Utf8(Nullability::NonNullable),
+///     ],
+/// )
+/// .unwrap();
+///
+/// assert_eq!(variants.len(), 2);
+/// assert_eq!(variants.type_ids(), &[0, 1]);
+/// ```
+#[allow(
+    clippy::derived_hash_with_manual_eq,
+    reason = "manual PartialEq adds Arc::ptr_eq fast path only"
+)]
+#[derive(Clone, Eq, Hash)]
+pub struct UnionVariants(Arc<UnionVariantsInner>);
+
+impl PartialEq for UnionVariants {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0) || self.0 == other.0
+    }
+}
+
+impl fmt::Debug for UnionVariants {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnionVariants")
+            .field("names", &self.0.names)
+            .field("dtypes", &self.0.dtypes)
+            .field("type_ids", &self.0.type_ids)
+            .finish()
+    }
+}
+
+impl fmt::Display for UnionVariants {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Surface non-consecutive type tags so they aren't hidden by the format. Consecutive
+        // `[0, 1, ..., N-1]` is the common case and is left implicit.
+        let show_tags = !self.is_consecutive();
+        write!(
+            f,
+            "{}",
+            self.names()
+                .iter()
+                .zip(self.variants())
+                .zip(self.type_ids().iter())
+                .map(|((name, dt), tag)| {
+                    if show_tags {
+                        format!("{name}@{tag}={dt}")
+                    } else {
+                        format!("{name}={dt}")
+                    }
+                })
+                .join(", ")
+        )
+    }
+}
+
+struct UnionVariantsInner {
+    /// The names of the variants. This is called `FieldNames` because it is shared with the
+    /// [`StructFields`](crate::dtype::StructFields) implementation.
+    names: FieldNames,
+
+    /// The types of each of the variants.
+    dtypes: Arc<[FieldDType]>,
+
+    /// One tag per variant, in variant order. The common case where children are referenced by
+    /// consecutive offsets is `[0, 1, ..., N-1]`.
+    ///
+    /// For schemas with explicit `typeIds` indirection (e.g. `[0, 5, 7]`), this stores those tags.
+    type_ids: Arc<[i8]>,
+}
+
+impl UnionVariantsInner {
+    fn from_fields(names: FieldNames, dtypes: Arc<[FieldDType]>, type_ids: Arc<[i8]>) -> Self {
+        Self {
+            names,
+            dtypes,
+            type_ids,
+        }
+    }
+}
+
+impl PartialEq for UnionVariantsInner {
+    fn eq(&self, other: &Self) -> bool {
+        self.names == other.names && self.dtypes == other.dtypes && self.type_ids == other.type_ids
+    }
+}
+
+impl Eq for UnionVariantsInner {}
+
+impl Hash for UnionVariantsInner {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.names.hash(state);
+        self.dtypes.hash(state);
+        self.type_ids.hash(state);
+    }
+}
+
+impl Default for UnionVariants {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl UnionVariants {
+    /// The variants of the empty union.
+    pub fn empty() -> Self {
+        Self(Arc::new(UnionVariantsInner::from_fields(
+            FieldNames::default(),
+            Arc::from([]),
+            Arc::from([]),
+        )))
+    }
+
+    /// Validate that `names`, `dtypes`, and `type_ids` are mutually consistent.
+    fn validate_shape(names: &FieldNames, n_dtypes: usize, type_ids: &[i8]) -> VortexResult<()> {
+        vortex_ensure_eq!(
+            names.len(),
+            n_dtypes,
+            "length mismatch between names ({}) and dtypes ({})",
+            names.len(),
+            n_dtypes
+        );
+        vortex_ensure_eq!(
+            names.len(),
+            type_ids.len(),
+            "length mismatch between names ({}) and type_ids ({})",
+            names.len(),
+            type_ids.len()
+        );
+
+        vortex_ensure!(
+            type_ids.iter().all_unique(),
+            "type_ids must be distinct, got {:?}",
+            type_ids
+        );
+        vortex_ensure!(
+            names.iter().all_unique(),
+            "union variant names must be distinct, got {:?}",
+            names
+        );
+
+        Ok(())
+    }
+
+    /// Create a new [`UnionVariants`] with explicit `type_ids`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if names, dtypes, or type IDs do not all have the same length, or if there
+    /// are any duplicate names or type ids.
+    pub fn try_new(names: FieldNames, dtypes: Vec<DType>, type_ids: Vec<i8>) -> VortexResult<Self> {
+        Self::validate_shape(&names, dtypes.len(), &type_ids)?;
+
+        let dtypes: Arc<[FieldDType]> = dtypes.into_iter().map(FieldDType::from).collect();
+        let type_ids: Arc<[i8]> = Arc::from(type_ids);
+
+        Ok(Self(Arc::new(UnionVariantsInner::from_fields(
+            names, dtypes, type_ids,
+        ))))
+    }
+
+    /// Create a new [`UnionVariants`] with consecutive `type_ids = [0, 1, ..., N-1]`.
+    ///
+    /// # Errors
+    ///
+    /// `names` and `dtypes` must have the same length, and `names.len()` cannot be more than
+    /// `i8::MAX as usize + 1` (128).
+    pub fn new(names: FieldNames, dtypes: Vec<DType>) -> VortexResult<Self> {
+        const MAX_CONSECUTIVE: usize = i8::MAX as usize + 1;
+        vortex_ensure!(
+            names.len() <= MAX_CONSECUTIVE,
+            "union supports at most {} consecutive variants, got {}",
+            MAX_CONSECUTIVE,
+            names.len()
+        );
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "the MAX_CONSECUTIVE bound above guarantees `i as i8` is in range"
+        )]
+        let type_ids: Vec<i8> = (0..names.len()).map(|i| i as i8).collect();
+
+        Self::try_new(names, dtypes, type_ids)
+    }
+
+    /// Create a new [`UnionVariants`] from pre-constructed [`FieldDType`]s, which may be owned or
+    /// backed by a flatbuffer view.
+    ///
+    /// Used by deserialization paths where the children may be lazily backed by a flatbuffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if names, dtypes, or type IDs do not all have the same length, or if there
+    /// are any duplicate names or type ids.
+    pub(crate) fn try_from_fields(
+        names: FieldNames,
+        dtypes: Vec<FieldDType>,
+        type_ids: Vec<i8>,
+    ) -> VortexResult<Self> {
+        Self::validate_shape(&names, dtypes.len(), &type_ids)?;
+
+        Ok(Self(Arc::new(UnionVariantsInner::from_fields(
+            names,
+            dtypes.into(),
+            Arc::from(type_ids),
+        ))))
+    }
+
+    /// Get the names of the variants in the union.
+    pub fn names(&self) -> &FieldNames {
+        &self.0.names
+    }
+
+    /// Returns the number of variants in the union.
+    pub fn len(&self) -> usize {
+        self.0.names.len()
+    }
+
+    /// Returns true if the union has no variants.
+    pub fn is_empty(&self) -> bool {
+        self.0.names.is_empty()
+    }
+
+    /// Returns the per-variant type tag vector. Entry `i` is the tag that the data uses to
+    /// select the variant at offset `i`.
+    pub fn type_ids(&self) -> &[i8] {
+        &self.0.type_ids
+    }
+
+    /// Returns `true` if the type tags are the consecutive sequence `[0, 1, ..., N-1]`.
+    pub fn is_consecutive(&self) -> bool {
+        self.0
+            .type_ids
+            .iter()
+            .enumerate()
+            .all(|(i, &tag)| i8::try_from(i).is_ok_and(|i| i == tag))
+    }
+
+    /// Find the offset of a variant by name. Returns `None` if no variant has the name.
+    ///
+    /// This is a linear scan over [`Self::names`]. A union has at most 128 variants (and usually
+    /// far fewer), so a linear scan beats building and probing a `HashMap` in practice.
+    pub fn find(&self, name: impl AsRef<str>) -> Option<usize> {
+        let name = name.as_ref();
+        self.0.names.iter().position(|n| n.as_ref() == name)
+    }
+
+    /// Get the [`DType`] of a variant by name. Returns `None` if no variant has the name.
+    pub fn variant(&self, name: impl AsRef<str>) -> Option<DType> {
+        let index = self.find(name)?;
+        Some(
+            self.0.dtypes[index]
+                .value()
+                .vortex_expect("variant DType must be valid"),
+        )
+    }
+
+    /// Get the [`DType`] of a variant by offset.
+    pub fn variant_by_index(&self, index: usize) -> Option<DType> {
+        Some(
+            self.0
+                .dtypes
+                .get(index)?
+                .value()
+                .vortex_expect("variant DType must be valid"),
+        )
+    }
+
+    /// Returns an ordered iterator over the variants.
+    pub fn variants(&self) -> impl ExactSizeIterator<Item = DType> + '_ {
+        self.0
+            .dtypes
+            .iter()
+            .map(|dt| dt.value().vortex_expect("variant DType must be valid"))
+    }
+
+    /// Convert a data-level type tag to a child offset. Returns `None` if the tag is not in
+    /// `type_ids`.
+    ///
+    /// This is a linear scan over [`Self::type_ids`]. The number of variants is bounded by
+    /// `i8::MAX + 1 = 128`, which fits in two cache lines, so a linear scan is faster than a
+    /// `HashMap` lookup in practice.
+    pub fn tag_to_child_index(&self, tag: i8) -> Option<usize> {
+        self.0.type_ids.iter().position(|&t| t == tag)
+    }
+
+    /// Convert a child offset to its data-level type tag.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index >= self.len()`.
+    pub fn child_index_to_tag(&self, index: usize) -> i8 {
+        self.0.type_ids[index]
+    }
+
+    /// Checks whether this set of variants satisfies the constraint imposed by a union-level
+    /// `Nullability`:
+    ///
+    /// - `Nullable`: at least one variant is `DType::Null` or has nullable nullability.
+    /// - `NonNullable`: no `DType::Null` variants and no nullable variants.
+    ///
+    /// The check materializes each [`FieldDType`] (so it may be expensive if some are still
+    /// flatbuffer-backed views).
+    ///
+    /// It is intentionally not part of `UnionVariants` construction since `Nullability` lives on
+    /// the `DType::Union(_, Nullability)` enum variant, not on `UnionVariants` itself.
+    pub fn nullability_constraints_satisfied(&self, union_nullability: Nullability) -> bool {
+        let has_null_or_nullable = self
+            .variants()
+            .any(|dt| matches!(dt, DType::Null) || dt.is_nullable());
+
+        match union_nullability {
+            Nullability::Nullable => has_null_or_nullable,
+            Nullability::NonNullable => !has_null_or_nullable,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::dtype::DType;
+    use crate::dtype::FieldNames;
+    use crate::dtype::Nullability;
+    use crate::dtype::PType;
+    use crate::dtype::UnionVariants;
+
+    fn i32_variants() -> UnionVariants {
+        UnionVariants::new(
+            ["int", "str"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Utf8(Nullability::NonNullable),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_consecutive_type_ids() {
+        let variants = i32_variants();
+        assert_eq!(variants.type_ids(), &[0, 1]);
+        assert!(variants.is_consecutive());
+        assert_eq!(variants.tag_to_child_index(0), Some(0));
+        assert_eq!(variants.tag_to_child_index(1), Some(1));
+        assert_eq!(variants.tag_to_child_index(2), None);
+        assert_eq!(variants.child_index_to_tag(0), 0);
+        assert_eq!(variants.child_index_to_tag(1), 1);
+    }
+
+    #[test]
+    fn test_type_id_indirection() {
+        let variants = UnionVariants::try_new(
+            ["a", "b", "c"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Utf8(Nullability::NonNullable),
+                DType::Bool(Nullability::NonNullable),
+            ],
+            vec![0, 5, 7],
+        )
+        .unwrap();
+
+        assert_eq!(variants.type_ids(), &[0, 5, 7]);
+        assert!(!variants.is_consecutive());
+        assert_eq!(variants.tag_to_child_index(0), Some(0));
+        assert_eq!(variants.tag_to_child_index(5), Some(1));
+        assert_eq!(variants.tag_to_child_index(7), Some(2));
+        assert_eq!(variants.tag_to_child_index(1), None);
+    }
+
+    #[test]
+    fn test_find() {
+        let variants = i32_variants();
+        assert_eq!(variants.find("int"), Some(0));
+        assert_eq!(variants.find("str"), Some(1));
+        assert!(variants.find("missing").is_none());
+
+        let value = variants.variant("int").unwrap();
+        assert_eq!(
+            value,
+            DType::Primitive(PType::I32, Nullability::NonNullable)
+        );
+    }
+
+    #[test]
+    fn test_duplicate_names_rejected() {
+        let result = UnionVariants::new(
+            ["dup", "dup"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Primitive(PType::I64, Nullability::NonNullable),
+            ],
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("distinct"));
+    }
+
+    #[test]
+    fn test_length_mismatch_rejected() {
+        let result = UnionVariants::try_new(
+            ["a", "b"].into(),
+            vec![DType::Primitive(PType::I32, Nullability::NonNullable)],
+            vec![0, 1],
+        );
+        assert!(result.is_err());
+
+        let result = UnionVariants::try_new(
+            ["a"].into(),
+            vec![DType::Primitive(PType::I32, Nullability::NonNullable)],
+            vec![0, 1],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_duplicate_type_ids_rejected() {
+        let result = UnionVariants::try_new(
+            ["a", "b"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Utf8(Nullability::NonNullable),
+            ],
+            vec![3, 3],
+        );
+        assert!(result.is_err());
+    }
+
+    #[rstest]
+    #[case::nullable_with_null_child(
+        vec![
+            DType::Null,
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+        ],
+        Nullability::Nullable,
+        true,
+    )]
+    #[case::nullable_with_nullable_child(
+        vec![
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+            DType::Utf8(Nullability::Nullable),
+        ],
+        Nullability::Nullable,
+        true,
+    )]
+    #[case::nullable_with_no_null_or_nullable(
+        vec![
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+            DType::Utf8(Nullability::NonNullable),
+        ],
+        Nullability::Nullable,
+        false,
+    )]
+    #[case::nonnullable_with_null_child(
+        vec![
+            DType::Null,
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+        ],
+        Nullability::NonNullable,
+        false,
+    )]
+    #[case::nonnullable_with_nullable_child(
+        vec![
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+            DType::Utf8(Nullability::Nullable),
+        ],
+        Nullability::NonNullable,
+        false,
+    )]
+    #[case::nonnullable_clean(
+        vec![
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+            DType::Utf8(Nullability::NonNullable),
+        ],
+        Nullability::NonNullable,
+        true,
+    )]
+    fn test_nullability_constraints(
+        #[case] dtypes: Vec<DType>,
+        #[case] nullability: Nullability,
+        #[case] expected: bool,
+    ) {
+        let names: Vec<&str> = (0..dtypes.len()).map(|i| ["a", "b", "c", "d"][i]).collect();
+        let variants = UnionVariants::new(names.as_slice().into(), dtypes).unwrap();
+        assert_eq!(
+            variants.nullability_constraints_satisfied(nullability),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_display() {
+        let variants = i32_variants();
+        let dtype = DType::Union(variants, Nullability::NonNullable);
+        assert_eq!(dtype.to_string(), "union(int=i32, str=utf8)");
+
+        let nullable = DType::Union(
+            UnionVariants::new(
+                ["int", "maybe_str"].into(),
+                vec![
+                    DType::Primitive(PType::I32, Nullability::NonNullable),
+                    DType::Utf8(Nullability::Nullable),
+                ],
+            )
+            .unwrap(),
+            Nullability::Nullable,
+        );
+        assert_eq!(nullable.to_string(), "union(int=i32, maybe_str=utf8?)?");
+    }
+
+    #[test]
+    fn test_display_with_type_id_indirection() {
+        let variants = UnionVariants::try_new(
+            ["a", "b", "c"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Utf8(Nullability::NonNullable),
+                DType::Bool(Nullability::NonNullable),
+            ],
+            vec![0, 5, 7],
+        )
+        .unwrap();
+        let dtype = DType::Union(variants, Nullability::NonNullable);
+        assert_eq!(dtype.to_string(), "union(a@0=i32, b@5=utf8, c@7=bool)");
+    }
+
+    #[test]
+    fn test_new_max_size() {
+        // 128 variants is the maximum for consecutive type_ids: tags 0..=127 all fit in i8.
+        let names: Vec<String> = (0..128).map(|i| format!("v{i}")).collect();
+        let dtypes: Vec<DType> = (0..128)
+            .map(|_| DType::Primitive(PType::I32, Nullability::NonNullable))
+            .collect();
+        let names: FieldNames = names.into_iter().collect();
+        let variants = UnionVariants::new(names, dtypes).unwrap();
+        assert_eq!(variants.len(), 128);
+        assert_eq!(variants.type_ids()[127], 127);
+        assert!(variants.is_consecutive());
+    }
+
+    #[test]
+    fn test_new_too_large_rejected() {
+        // 129 variants exceeds i8::MAX + 1 = 128.
+        let names: Vec<String> = (0..129).map(|i| format!("v{i}")).collect();
+        let dtypes: Vec<DType> = (0..129)
+            .map(|_| DType::Primitive(PType::I32, Nullability::NonNullable))
+            .collect();
+        let names: FieldNames = names.into_iter().collect();
+        let result = UnionVariants::new(names, dtypes);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("at most 128 consecutive variants")
+        );
+    }
+
+    #[test]
+    fn test_empty() {
+        let v = UnionVariants::empty();
+        assert!(v.is_empty());
+        assert_eq!(v.len(), 0);
+        assert_eq!(v.type_ids(), &[] as &[i8]);
+        assert!(v.is_consecutive());
+    }
+}

--- a/vortex-array/src/scalar_fn/fns/binary/compare/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare/mod.rs
@@ -217,7 +217,7 @@ fn compare_arrays(
         DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => {
             nested::compare_nested(lhs, rhs, op, nullability, ctx)
         }
-        DType::Union(_) | DType::Variant(_) | DType::Extension(_) => {
+        DType::Union(..) | DType::Variant(_) | DType::Extension(_) => {
             vortex_bail!("compare is not supported for dtype {}", lhs.dtype())
         }
     }

--- a/vortex-array/src/scalar_fn/fns/binary/compare/nested.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare/nested.rs
@@ -213,7 +213,7 @@ fn build_values_comparator(
             let rhs = rhs.clone().execute::<ExtensionArray>(ctx)?;
             build_comparator(lhs.storage_array(), rhs.storage_array(), ctx)?
         }
-        DType::Union(_) | DType::Variant(_) => {
+        DType::Union(..) | DType::Variant(_) => {
             vortex_bail!("compare is not supported for dtype {}", lhs.dtype())
         }
     })

--- a/vortex-datafusion/src/convert/scalars.rs
+++ b/vortex-datafusion/src/convert/scalars.rs
@@ -382,6 +382,7 @@ mod tests {
     use vortex::dtype::Nullability;
     use vortex::dtype::PType;
     use vortex::dtype::StructFields;
+    use vortex::dtype::UnionVariants;
     use vortex::dtype::i256;
     use vortex::scalar::DecimalValue;
     use vortex::scalar::Scalar;
@@ -826,7 +827,14 @@ mod tests {
         2,
         Nullability::Nullable
     )))]
-    #[case::union(Scalar::null(DType::Union(Nullability::Nullable)))]
+    #[case::union(Scalar::null(DType::Union(
+        UnionVariants::new(
+            ["a"].into(),
+            vec![DType::Primitive(PType::I32, Nullability::Nullable)],
+        )
+        .unwrap(),
+        Nullability::Nullable
+    )))]
     fn unsupported_vortex_scalars_return_errors(#[case] scalar: Scalar) {
         let err = scalar.try_to_df().unwrap_err();
 

--- a/vortex-flatbuffers/flatbuffers/vortex-dtype/dtype.fbs
+++ b/vortex-flatbuffers/flatbuffers/vortex-dtype/dtype.fbs
@@ -67,8 +67,13 @@ table Variant {
     nullable: bool;
 }
 
+// Explicit ids keep `nullable` at id 0, the id it had before the variant metadata fields were
+// added, so schemas written in between remain readable.
 table Union {
-    nullable: bool;
+    names: [string] (id: 1);
+    dtypes: [DType] (id: 2);
+    type_ids: [byte] (id: 3); // length must equal dtypes.len()
+    nullable: bool (id: 0);
 }
 
 union Type {

--- a/vortex-flatbuffers/src/generated/dtype.rs
+++ b/vortex-flatbuffers/src/generated/dtype.rs
@@ -1478,6 +1478,9 @@ impl<'a> ::flatbuffers::Follow<'a> for Union<'a> {
 
 impl<'a> Union<'a> {
   pub const VT_NULLABLE: ::flatbuffers::VOffsetT = 4;
+  pub const VT_NAMES: ::flatbuffers::VOffsetT = 6;
+  pub const VT_DTYPES: ::flatbuffers::VOffsetT = 8;
+  pub const VT_TYPE_IDS: ::flatbuffers::VOffsetT = 10;
 
   #[inline]
   pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
@@ -1486,9 +1489,12 @@ impl<'a> Union<'a> {
   #[allow(unused_mut)]
   pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: ::flatbuffers::Allocator + 'bldr>(
     _fbb: &'mut_bldr mut ::flatbuffers::FlatBufferBuilder<'bldr, A>,
-    args: &'args UnionArgs
+    args: &'args UnionArgs<'args>
   ) -> ::flatbuffers::WIPOffset<Union<'bldr>> {
     let mut builder = UnionBuilder::new(_fbb);
+    if let Some(x) = args.type_ids { builder.add_type_ids(x); }
+    if let Some(x) = args.dtypes { builder.add_dtypes(x); }
+    if let Some(x) = args.names { builder.add_names(x); }
     builder.add_nullable(args.nullable);
     builder.finish()
   }
@@ -1501,6 +1507,27 @@ impl<'a> Union<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<bool>(Union::VT_NULLABLE, Some(false)).unwrap()}
   }
+  #[inline]
+  pub fn names(&self) -> Option<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<&'a str>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<&'a str>>>>(Union::VT_NAMES, None)}
+  }
+  #[inline]
+  pub fn dtypes(&self) -> Option<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<DType<'a>>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<DType>>>>(Union::VT_DTYPES, None)}
+  }
+  #[inline]
+  pub fn type_ids(&self) -> Option<::flatbuffers::Vector<'a, i8>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'a, i8>>>(Union::VT_TYPE_IDS, None)}
+  }
 }
 
 impl ::flatbuffers::Verifiable for Union<'_> {
@@ -1510,18 +1537,27 @@ impl ::flatbuffers::Verifiable for Union<'_> {
   ) -> Result<(), ::flatbuffers::InvalidFlatbuffer> {
     v.visit_table(pos)?
      .visit_field::<bool>("nullable", Self::VT_NULLABLE, false)?
+     .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, ::flatbuffers::ForwardsUOffset<&'_ str>>>>("names", Self::VT_NAMES, false)?
+     .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, ::flatbuffers::ForwardsUOffset<DType>>>>("dtypes", Self::VT_DTYPES, false)?
+     .visit_field::<::flatbuffers::ForwardsUOffset<::flatbuffers::Vector<'_, i8>>>("type_ids", Self::VT_TYPE_IDS, false)?
      .finish();
     Ok(())
   }
 }
-pub struct UnionArgs {
+pub struct UnionArgs<'a> {
     pub nullable: bool,
+    pub names: Option<::flatbuffers::WIPOffset<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<&'a str>>>>,
+    pub dtypes: Option<::flatbuffers::WIPOffset<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<DType<'a>>>>>,
+    pub type_ids: Option<::flatbuffers::WIPOffset<::flatbuffers::Vector<'a, i8>>>,
 }
-impl<'a> Default for UnionArgs {
+impl<'a> Default for UnionArgs<'a> {
   #[inline]
   fn default() -> Self {
     UnionArgs {
       nullable: false,
+      names: None,
+      dtypes: None,
+      type_ids: None,
     }
   }
 }
@@ -1534,6 +1570,18 @@ impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> UnionBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_nullable(&mut self, nullable: bool) {
     self.fbb_.push_slot::<bool>(Union::VT_NULLABLE, nullable, false);
+  }
+  #[inline]
+  pub fn add_names(&mut self, names: ::flatbuffers::WIPOffset<::flatbuffers::Vector<'b , ::flatbuffers::ForwardsUOffset<&'b  str>>>) {
+    self.fbb_.push_slot_always::<::flatbuffers::WIPOffset<_>>(Union::VT_NAMES, names);
+  }
+  #[inline]
+  pub fn add_dtypes(&mut self, dtypes: ::flatbuffers::WIPOffset<::flatbuffers::Vector<'b , ::flatbuffers::ForwardsUOffset<DType<'b >>>>) {
+    self.fbb_.push_slot_always::<::flatbuffers::WIPOffset<_>>(Union::VT_DTYPES, dtypes);
+  }
+  #[inline]
+  pub fn add_type_ids(&mut self, type_ids: ::flatbuffers::WIPOffset<::flatbuffers::Vector<'b , i8>>) {
+    self.fbb_.push_slot_always::<::flatbuffers::WIPOffset<_>>(Union::VT_TYPE_IDS, type_ids);
   }
   #[inline]
   pub fn new(_fbb: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>) -> UnionBuilder<'a, 'b, A> {
@@ -1554,6 +1602,9 @@ impl ::core::fmt::Debug for Union<'_> {
   fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
     let mut ds = f.debug_struct("Union");
       ds.field("nullable", &self.nullable());
+      ds.field("names", &self.names());
+      ds.field("dtypes", &self.dtypes());
+      ds.field("type_ids", &self.type_ids());
       ds.finish()
   }
 }

--- a/vortex-flatbuffers/src/generated/message.rs
+++ b/vortex-flatbuffers/src/generated/message.rs
@@ -2,8 +2,8 @@
 // @generated
 extern crate alloc;
 
-use crate::array::*;
 use crate::dtype::*;
+use crate::array::*;
 
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 pub const ENUM_MIN_MESSAGE_VERSION: u8 = 0;

--- a/vortex-proto/proto/dtype.proto
+++ b/vortex-proto/proto/dtype.proto
@@ -75,6 +75,9 @@ message Variant {
 }
 
 message Union {
+  repeated string names = 1;
+  repeated DType dtypes = 2;
+  repeated int32 type_ids = 3; // length must equal dtypes.len(); each value must fit in int8
   bool nullable = 4;
 }
 

--- a/vortex-proto/src/generated/vortex.dtype.rs
+++ b/vortex-proto/src/generated/vortex.dtype.rs
@@ -71,8 +71,15 @@ pub struct Variant {
     #[prost(bool, tag = "1")]
     pub nullable: bool,
 }
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Union {
+    #[prost(string, repeated, tag = "1")]
+    pub names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag = "2")]
+    pub dtypes: ::prost::alloc::vec::Vec<DType>,
+    /// length must equal dtypes.len(); each value must fit in int8
+    #[prost(int32, repeated, tag = "3")]
+    pub type_ids: ::prost::alloc::vec::Vec<i32>,
     #[prost(bool, tag = "4")]
     pub nullable: bool,
 }

--- a/vortex-row/src/codec.rs
+++ b/vortex-row/src/codec.rs
@@ -228,7 +228,7 @@ pub(crate) fn row_width_for_dtype(dtype: &DType) -> VortexResult<RowWidth> {
         DType::Variant(_) => {
             vortex_bail!("row encoding does not support Variant arrays (no well-defined ordering)")
         }
-        DType::Union(_) => vortex_bail!("row encoding does not support Union arrays"),
+        DType::Union(..) => vortex_bail!("row encoding does not support Union arrays"),
         dtype => vortex_bail!("row encoding does not support dtype: {dtype:?}"),
     }
 }


### PR DESCRIPTION
## Rationale for this change

Tracking Issue: https://github.com/vortex-data/vortex/issues/7882

We want to make `DType::Union` usable. This PR has been resurrected from https://github.com/vortex-data/vortex/pull/7902.

## What changes are included in this PR?

Replaces `DType::Union(Nullability)` with `DType::Union(UnionVariants, Nullability)`. `UnionVariants` carries a `FieldNames` list, per-variant `FieldDType`s, and an `i8` type-id vector (supporting non-consecutive tags like `[0, 5, 7]` so children can be removed without renumbering).

The flatbuffer and protobuf `Union` schemas are extended with the `names`/`dtypes`/`type_ids` fields, and serde, flatbuffers, and protobuf paths are filled in with round-trip tests and nullability-constraint checks. The flatbuffer `Union` table uses explicit field ids so that `nullable` keeps the id it had before this change, keeping the schema conformant with develop.

Existing `DType::Union(..)` match arms that reject or skip unions are left in place, and concrete implementations will come later.

## What APIs are changed? Are there any user-facing changes?

`DType::Union` will now have a type parameter `UnionVariants`.