### PR TITLE
vortex-file: Spawn tasks via runtime instead of directly via tokio

### DIFF
--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -468,12 +468,13 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn file_segment_source_panic_propagates_to_all_concurrent_readers() {
         let source = Arc::new(panicking_source());
+        let handle = TokioRuntime::current();
         let reader_count = 8;
 
         let readers: Vec<_> = (0..reader_count)
             .map(|_| {
                 let source = Arc::clone(&source);
-                tokio::spawn(async move {
+                handle.spawn(async move {
                     AssertUnwindSafe(source.request(SegmentId::from(0)))
                         .catch_unwind()
                         .await
@@ -488,7 +489,7 @@ mod tests {
 
         let mut original_panics = 0;
         for reader in joined {
-            match reader.expect("reader task panicked at the join boundary") {
+            match reader {
                 // The first reader to observe completion re-raises the original panic.
                 Err(payload) => {
                     assert!(
@@ -557,10 +558,11 @@ mod tests {
             RequestMetrics::new(&metrics, vec![]),
         ));
 
+        let handle = TokioRuntime::current();
         let tasks: Vec<_> = (0..n)
             .map(|i| {
                 let source = Arc::clone(&source);
-                tokio::spawn(async move { source.request(SegmentId::from(i)).await })
+                handle.spawn(async move { source.request(SegmentId::from(i)).await })
             })
             .collect();
 


### PR DESCRIPTION
## Rationale for this change

I upgraded to 0.78 and some automation we have that detects when dependencies use raw `tokio::spawn` got triggered. We need to control all spawn points, both for correctness testing and for instrumentation purposes. I realize that these spawns are in test code, but I thought since vortex already has the runtime abstractions, it wouldn't hurt to use them in the tests as well (admittedly our tooling is not crazily sophisticated so it can't distinguish whether it's testing code or not).

## What changes are included in this PR?

Use `TokioRuntime` instead of raw `tokio::spawn` in tests.

## What APIs are changed? Are there any user-facing changes?

n/a