### PR TITLE
Ignore quick-xml rustsec since we cannot update it ourselves

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,8 +15,8 @@ feature-depth = 1
 ignore = [
     # Paste is no longer maintained because its essentially "finished".
     "RUSTSEC-2024-0436",
-    # proc-macro-error-2 is unmaintained, only used by the `test_with` test dependency
-    "RUSTSEC-2026-0173"
+    # quick-xml is a transitive dependency that we cannot upgrade ourselves
+    "RUSTSEC-2026-0195"
 ]
 
 [licenses]


### PR DESCRIPTION
Ignore rustsec warning

