### PR TITLE
Document Union nullability contract

### DIFF
--- a/vortex-array/src/dtype/dtype_impl.rs
+++ b/vortex-array/src/dtype/dtype_impl.rs
@@ -80,7 +80,13 @@ impl DType {
         self.with_nullability(Nullability::Nullable)
     }
 
-    /// Get a new DType with the given nullability (but otherwise the same as `self`)
+    /// Get a new `DType` with the given nullability (but otherwise the same as `self`).
+    ///
+    /// For [`DType::Union`], this currently changes only the union-level nullability summary. It
+    /// does not rewrite the variants and can therefore produce a `DType` that fails
+    /// [`UnionVariants::nullability_constraints_satisfied`](crate::dtype::UnionVariants::nullability_constraints_satisfied).
+    /// Until [union nullability-changing operations](https://github.com/vortex-data/vortex/issues/7882)
+    /// are defined, construct union variants and their matching nullability explicitly instead.
     pub fn with_nullability(&self, nullability: Nullability) -> Self {
         match self {
             Null => Null,

--- a/vortex-array/src/dtype/mod.rs
+++ b/vortex-array/src/dtype/mod.rs
@@ -114,6 +114,16 @@ pub enum DType {
     /// A `Union` is composed of one or more **variants**, each with a name and a `DType`. A per-row
     /// `i8` tag selects which variant is "live" at that row.
     ///
+    /// Union nullability is derived from its variants: a nullable union must have at least one
+    /// nullable or [`DType::Null`] variant, while a non-nullable union must have neither. A concrete
+    /// union array has no separate parent validity bitmap. A row is logically null exactly when
+    /// its selected child value is null; nulls in inactive sparse-child positions are ignored.
+    ///
+    /// Operations that change a union's nullability require further design. Until
+    /// [issue #7882](https://github.com/vortex-data/vortex/issues/7882) is resolved, they should be
+    /// unsupported unless the output variants and union-level nullability already satisfy the
+    /// constraint above.
+    ///
     /// See [`UnionVariants`] for the type-tag conventions and accessors.
     Union(UnionVariants, Nullability),
 

--- a/vortex-array/src/dtype/union.rs
+++ b/vortex-array/src/dtype/union.rs
@@ -345,6 +345,9 @@ impl UnionVariants {
     /// - `Nullable`: at least one variant is `DType::Null` or has nullable nullability.
     /// - `NonNullable`: no `DType::Null` variants and no nullable variants.
     ///
+    /// This is a type-level summary of whether a selected variant can be null. A concrete union
+    /// array has no parent validity bitmap; its row validity is the validity of the selected child.
+    ///
     /// The check materializes each [`FieldDType`] (so it may be expensive if some are still
     /// flatbuffer-backed views).
     ///


### PR DESCRIPTION
## Rationale

The current `develop` contract is sufficient to start the canonical sparse `UnionArray`: Vortex's union-level nullability is a type-level summary derived from its variants, while a concrete row's validity comes from its selected child. There is no parent validity bitmap.

What is not yet settled is how a generic operation should *change* a union's declared nullability—for example, whether `mask` should make an existing variant nullable, require a `Null` variant, or take an explicit output type. That API question does not need to block the array layout.

This PR therefore documents the existing contract and the boundary of the deferred work rather than changing behavior.

## Arrow implementation survey

The implementations agree on the portable row-level semantic rule, but expose physical and logical nulls differently:

- [arrow-rs](https://github.com/apache/arrow-rs/blob/fed7862d1158fff90937ab7dd13dc05ab71559a6/arrow-array/src/array/mod.rs#L230-L312) has no parent null buffer; physical `is_null`/`null_count` report false/zero, while `logical_nulls()` gathers validity from the selected child. Its [`Field::new_union`](https://github.com/apache/arrow-rs/blob/fed7862d1158fff90937ab7dd13dc05ab71559a6/arrow-schema/src/field.rs#L339-L367) helper makes the outer field non-nullable.
- [Arrow C++](https://github.com/apache/arrow/blob/86c81bfe97113c12993bde4a2cd35ff5da37842b/cpp/src/arrow/array/array_base.h#L53-L107) also has no parent bitmap; `IsNull(i)` follows the selected child and `ComputeLogicalNullCount()` counts selected-child nulls.
- [Arrow Java](https://github.com/apache/arrow-java/blob/7f1f9f588af610b842ee1c3bccf6afbd528ae4db/vector/src/main/codegen/templates/DenseUnionVector.java#L783-L818) reports no physical parent nulls, while value access follows the selected child. Its dense and sparse helpers are not consistent about default outer field nullability.

The stable cross-implementation rule is therefore: the selected child determines whether a union row is logically null, and inactive sparse-child nulls are ignored. Outer Arrow `Field::nullable` conventions should not define Vortex's contract.

The investigation behind this boundary is in [this comment on #7882](https://github.com/vortex-data/vortex/issues/7882#issuecomment-4935971614).

## Changes

- document the existing variant-derived `DType::Union` nullability constraint
- document selected-child logical validity and the lack of a parent bitmap
- call out that `DType::with_nullability` currently changes only the outer summary and can create an inconsistent union DType
- require initial union operations to reject nullability-changing cases until #7882 defines them

## Initial implementation boundary

The canonical sparse array can now proceed with predeclared, internally consistent union DTypes and DType-preserving operations such as scalar access, slice, filter, and take with non-nullable indices. `mask`, nullable-index take, casts that introduce nulls, and null-appending builder behavior remain explicit follow-up work.

## Verification

- `cargo +nightly fmt --all --check`
- `cargo test -p vortex-array --doc`
- pre-push Clippy checks
