### PR TITLE
`Decimal` Add/Sub kernels

### DIFF
--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/mod.rs
@@ -16,6 +16,7 @@ mod tests {
     use vortex_array::VortexSessionExecute;
     use vortex_array::array_session;
     use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::compute::conformance::binary_numeric::test_binary_numeric_array;
     use vortex_array::compute::conformance::consistency::test_array_consistency;
     use vortex_array::dtype::DecimalDType;
     use vortex_buffer::buffer;
@@ -73,5 +74,23 @@ mod tests {
     fn test_decimal_byte_parts_consistency(#[case] array: DecimalBytePartsArray) {
         let ctx = &mut array_session().create_execution_ctx();
         test_array_consistency(&array.into_array(), ctx);
+    }
+
+    #[rstest]
+    #[case::decimal_i32(DecimalByteParts::try_new(
+        buffer![100i32, 200, 300, 400, 500].into_array(),
+        DecimalDType::new(10, 2)
+    ).unwrap())]
+    #[case::decimal_nullable_i64(DecimalByteParts::try_new(
+        PrimitiveArray::from_option_iter([Some(1000i64), None, Some(3000), Some(4000), None]).into_array(),
+        DecimalDType::new(19, 4)
+    ).unwrap())]
+    #[case::decimal_negative(DecimalByteParts::try_new(
+        buffer![-100i32, -200, 300, -400, 500].into_array(),
+        DecimalDType::new(10, 2)
+    ).unwrap())]
+    fn test_decimal_byte_parts_binary_numeric(#[case] array: DecimalBytePartsArray) {
+        let ctx = &mut array_session().create_execution_ctx();
+        test_binary_numeric_array(&array.into_array(), ctx);
     }
 }

--- a/vortex-array/benches/binary_ops.rs
+++ b/vortex-array/benches/binary_ops.rs
@@ -19,8 +19,10 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::array_session;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
+use vortex_array::arrays::DecimalArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::builtins::ArrayBuiltins;
+use vortex_array::dtype::DecimalDType;
 use vortex_array::scalar_fn::fns::operators::Operator;
 use vortex_session::VortexSession;
 
@@ -141,6 +143,22 @@ fn sub_i64_constant(bencher: Bencher) {
 }
 
 #[divan::bench]
+fn add_decimal_i64_nonnull(bencher: Bencher) {
+    let lhs = decimal_i64_nonnull(0).into_array();
+    let rhs = decimal_i64_nonnull(1_000_000).into_array();
+
+    bench_decimal(bencher, lhs, rhs, Operator::Add);
+}
+
+#[divan::bench]
+fn add_decimal_i128_nullable(bencher: Bencher) {
+    let lhs = decimal_i128_nullable(0, 7).into_array();
+    let rhs = decimal_i128_nullable(1_000_000, 5).into_array();
+
+    bench_decimal(bencher, lhs, rhs, Operator::Add);
+}
+
+#[divan::bench]
 fn eq_i64_constant(bencher: Bencher) {
     let lhs = primitive_nonnull(0).into_array();
     let rhs = ConstantArray::new(1024i64, LEN).into_array();
@@ -176,6 +194,10 @@ fn bench_primitive(bencher: Bencher, lhs: ArrayRef, rhs: ArrayRef, operator: Ope
     bench_binary::<PrimitiveArray>(bencher, lhs, rhs, operator);
 }
 
+fn bench_decimal(bencher: Bencher, lhs: ArrayRef, rhs: ArrayRef, operator: Operator) {
+    bench_binary::<DecimalArray>(bencher, lhs, rhs, operator);
+}
+
 fn bench_bool(bencher: Bencher, lhs: ArrayRef, rhs: ArrayRef, operator: Operator) {
     bench_binary::<BoolArray>(bencher, lhs, rhs, operator);
 }
@@ -199,6 +221,17 @@ fn bench_binary<T: Executable + 'static>(
 
 fn primitive_nonnull(base: i64) -> PrimitiveArray {
     PrimitiveArray::from_iter((0..LEN as i64).map(|i| base + i))
+}
+
+fn decimal_i64_nonnull(base: i64) -> DecimalArray {
+    DecimalArray::from_iter::<i64, _>((0..LEN as i64).map(|i| base + i), DecimalDType::new(18, 2))
+}
+
+fn decimal_i128_nullable(base: i128, null_every: usize) -> DecimalArray {
+    DecimalArray::from_option_iter::<i128, _>(
+        (0..LEN as i128).map(|i| (!(i as usize).is_multiple_of(null_every)).then_some(base + i)),
+        DecimalDType::new(38, 2),
+    )
 }
 
 fn primitive_small_nonnull(offset: i64) -> PrimitiveArray {

--- a/vortex-array/src/arrays/chunked/compute/mod.rs
+++ b/vortex-array/src/arrays/chunked/compute/mod.rs
@@ -21,10 +21,12 @@ mod tests {
     use crate::VortexSessionExecute;
     use crate::array_session;
     use crate::arrays::ChunkedArray;
+    use crate::arrays::DecimalArray;
     use crate::arrays::PrimitiveArray;
     use crate::compute::conformance::binary_numeric::test_binary_numeric_array;
     use crate::compute::conformance::consistency::test_array_consistency;
     use crate::dtype::DType;
+    use crate::dtype::DecimalDType;
     use crate::dtype::Nullability;
     use crate::dtype::PType;
 
@@ -157,6 +159,13 @@ mod tests {
             buffer![500..1000].into_array().into_array(),
         ],
         DType::Primitive(PType::I32, Nullability::NonNullable),
+    ).unwrap())]
+    #[case::chunked_decimal(ChunkedArray::try_new(
+        vec![
+            DecimalArray::from_iter::<i64, _>([100, 250], DecimalDType::new(10, 2)).into_array(),
+            DecimalArray::from_iter::<i64, _>([300, 400, 500], DecimalDType::new(10, 2)).into_array(),
+        ],
+        DType::Decimal(DecimalDType::new(10, 2), Nullability::NonNullable),
     ).unwrap())]
     fn test_chunked_binary_numeric(#[case] array: ChunkedArray) {
         test_binary_numeric_array(

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -17,6 +17,7 @@ mod tests {
     use crate::VortexSessionExecute;
     use crate::array_session;
     use crate::arrays::DecimalArray;
+    use crate::compute::conformance::binary_numeric::test_binary_numeric_array;
     use crate::compute::conformance::consistency::test_array_consistency;
     use crate::dtype::DecimalDType;
     use crate::validity::Validity;
@@ -56,6 +57,54 @@ mod tests {
     ))]
     fn test_decimal_consistency(#[case] array: DecimalArray) {
         test_array_consistency(
+            &array.into_array(),
+            &mut array_session().create_execution_ctx(),
+        );
+    }
+
+    #[rstest]
+    #[case::decimal_array(DecimalArray::new(
+        buffer![100i128, 200i128, 300i128, 400i128, 500i128],
+        DecimalDType::new(19, 2),
+        Validity::NonNullable,
+    ))]
+    #[case::decimal_nullable(DecimalArray::new(
+        buffer![1000i128, 2000i128, 3000i128, 4000i128, 5000i128],
+        DecimalDType::new(19, 3),
+        Validity::from_iter([true, false, true, true, false]),
+    ))]
+    #[case::decimal_small_precision(DecimalArray::new(
+        buffer![10i128, 20i128, 30i128],
+        DecimalDType::new(5, 1),
+        Validity::NonNullable,
+    ))]
+    #[case::decimal_narrow_storage(DecimalArray::new(
+        buffer![10i8, 20i8, 30i8],
+        DecimalDType::new(5, 1),
+        Validity::NonNullable,
+    ))]
+    #[case::decimal_single(DecimalArray::new(
+        buffer![42i128],
+        DecimalDType::new(10, 0),
+        Validity::NonNullable,
+    ))]
+    #[case::decimal_large_scale(DecimalArray::new(
+        buffer![123456789012345i128, 987654321098765i128],
+        DecimalDType::new(20, 10),
+        Validity::NonNullable,
+    ))]
+    #[case::decimal_negative(DecimalArray::new(
+        buffer![-100i128, -200i128, 300i128, -400i128],
+        DecimalDType::new(10, 2),
+        Validity::NonNullable,
+    ))]
+    #[case::decimal_negative_scale(DecimalArray::new(
+        buffer![5i64, -3i64, 600i64],
+        DecimalDType::new(10, -2),
+        Validity::NonNullable,
+    ))]
+    fn test_decimal_binary_numeric(#[case] array: DecimalArray) {
+        test_binary_numeric_array(
             &array.into_array(),
             &mut array_session().create_execution_ctx(),
         );

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -20,6 +20,7 @@ mod tests {
     use crate::compute::conformance::binary_numeric::test_binary_numeric_array;
     use crate::compute::conformance::consistency::test_array_consistency;
     use crate::dtype::DecimalDType;
+    use crate::dtype::NativeDecimalType;
     use crate::validity::Validity;
 
     #[rstest]
@@ -81,6 +82,14 @@ mod tests {
     #[case::decimal_narrow_storage(DecimalArray::new(
         buffer![10i8, 20i8, 30i8],
         DecimalDType::new(5, 1),
+        Validity::NonNullable,
+    ))]
+    #[case::decimal_widened_carry(DecimalArray::new(
+        buffer![
+            <i128 as NativeDecimalType>::MAX_BY_PRECISION[38],
+            <i128 as NativeDecimalType>::MIN_BY_PRECISION[38],
+        ],
+        DecimalDType::new(38, 0),
         Validity::NonNullable,
     ))]
     #[case::decimal_single(DecimalArray::new(

--- a/vortex-array/src/arrays/decimal/utils.rs
+++ b/vortex-array/src/arrays/decimal/utils.rs
@@ -3,11 +3,30 @@
 
 use itertools::Itertools;
 use itertools::MinMaxResult;
+use vortex_buffer::Buffer;
 use vortex_error::VortexExpect;
 
 use crate::arrays::DecimalArray;
+use crate::arrays::decimal::DecimalArrayExt;
 use crate::dtype::DecimalType;
+use crate::dtype::NativeDecimalType;
 use crate::dtype::i256;
+use crate::match_each_decimal_value_type;
+
+/// Return the array's unscaled values widened to `W`, which must be at least as wide as the
+/// array's storage type.
+pub(crate) fn widened_buffer<W: NativeDecimalType>(array: &DecimalArray) -> Buffer<W> {
+    if array.values_type() == W::DECIMAL_TYPE {
+        return array.buffer::<W>();
+    }
+    match_each_decimal_value_type!(array.values_type(), |T| {
+        array
+            .buffer::<T>()
+            .iter()
+            .map(|v| W::from(*v).vortex_expect("widening decimal cast must succeed"))
+            .collect()
+    })
+}
 
 macro_rules! try_downcast {
     ($array:expr, from: $src:ty, to: $($dst:ty),*) => {{

--- a/vortex-array/src/compute/conformance/binary_numeric.rs
+++ b/vortex-array/src/compute/conformance/binary_numeric.rs
@@ -304,90 +304,140 @@ fn test_decimal_binary_numeric_with_scalar(
     let scalar = Scalar::decimal(value, decimal_dtype, array.dtype().nullability());
 
     // Decimal Mul/Div are not yet implemented.
-    let operators = vec![NumericOperator::Add, NumericOperator::Sub];
-
-    for operator in operators {
-        let result_decimal_dtype = numeric_op_result_decimal_dtype(decimal_dtype, operator)
-            .vortex_expect("decimal Add/Sub must have a result dtype");
-        let result_dtype = DType::Decimal(result_decimal_dtype, array.dtype().nullability());
-        let rhs_const = ConstantArray::new(scalar.clone(), array.len()).into_array();
-
+    for operator in [NumericOperator::Add, NumericOperator::Sub] {
         for lhs_is_array in [true, false] {
-            let (lhs, rhs) = if lhs_is_array {
-                (array.clone(), rhs_const.clone())
-            } else {
-                (rhs_const.clone(), array.clone())
-            };
-
-            let expected_results: Vec<Option<Scalar>> = original_values
-                .iter()
-                .map(|x| {
-                    let (lhs, rhs) = if lhs_is_array {
-                        (x.as_decimal(), scalar.as_decimal())
-                    } else {
-                        (scalar.as_decimal(), x.as_decimal())
-                    };
-                    let (Some(lhs), Some(rhs)) = (lhs.decimal_value(), rhs.decimal_value()) else {
-                        return Some(Scalar::null(result_dtype.clone()));
-                    };
-                    let lhs = lhs.as_i256();
-                    let rhs = rhs.as_i256();
-                    let value = match operator {
-                        NumericOperator::Add => lhs.checked_add(&rhs),
-                        NumericOperator::Sub => lhs.checked_sub(&rhs),
-                        NumericOperator::Mul | NumericOperator::Div => unreachable!(),
-                    }?;
-                    let value = DecimalValue::try_from_i256(value, result_decimal_dtype).ok()?;
-                    Some(Scalar::decimal(
-                        value,
-                        result_decimal_dtype,
-                        result_dtype.nullability(),
-                    ))
-                })
-                .collect();
-
-            let result = lhs
-                .binary(rhs, operator.into())
-                .vortex_expect("apply shouldn't fail")
-                .execute::<RecursiveCanonical>(ctx)
-                .map(|c| c.0.into_array());
-
-            let expects_overflow = expected_results.iter().any(Option::is_none);
-            if expects_overflow {
-                assert!(
-                    result.is_err(),
-                    "Decimal binary numeric operation should overflow for encoding {}: \
-                     {operator:?} {scalar} (lhs_is_array: {lhs_is_array})",
-                    array.encoding_id(),
-                );
-                continue;
-            }
-
-            let result = result.unwrap_or_else(|err| {
-                vortex_panic!(
-                    "Decimal binary numeric operation unexpectedly failed for encoding {}: \
-                     {operator:?} {scalar} (lhs_is_array: {lhs_is_array}): {err}",
-                    array.encoding_id(),
-                )
-            });
-
-            let actual_values = to_vec_of_scalar(&result, ctx);
-            for (idx, (actual, expected)) in actual_values.iter().zip(&expected_results).enumerate()
-            {
-                let expected_value = expected
-                    .as_ref()
-                    .vortex_expect("non-overflowing decimal lane must have an expected value");
-                assert_eq!(
-                    actual,
-                    expected_value,
-                    "Decimal binary numeric operation failed for encoding {} at index {}: \
-                     ({array:?})[{idx}] {operator:?} {scalar} (lhs_is_array: {lhs_is_array}) \
-                     expected {expected_value:?}, got {actual:?}",
-                    array.encoding_id(),
-                    idx,
-                );
-            }
+            test_decimal_binary_numeric_direction(
+                array,
+                &original_values,
+                &scalar,
+                decimal_dtype,
+                operator,
+                lhs_is_array,
+                ctx,
+            );
         }
+    }
+}
+
+fn test_decimal_binary_numeric_direction(
+    array: &ArrayRef,
+    original_values: &[Scalar],
+    scalar: &Scalar,
+    decimal_dtype: DecimalDType,
+    operator: NumericOperator,
+    lhs_is_array: bool,
+    ctx: &mut ExecutionCtx,
+) {
+    let result_decimal_dtype = numeric_op_result_decimal_dtype(decimal_dtype, operator)
+        .vortex_expect("decimal Add/Sub must have a result dtype");
+    let result_dtype = DType::Decimal(result_decimal_dtype, array.dtype().nullability());
+    let expected_results = expected_decimal_results(
+        original_values,
+        scalar,
+        operator,
+        result_decimal_dtype,
+        &result_dtype,
+        lhs_is_array,
+    );
+
+    let constant = ConstantArray::new(scalar.clone(), array.len()).into_array();
+    let (lhs, rhs) = if lhs_is_array {
+        (array.clone(), constant)
+    } else {
+        (constant, array.clone())
+    };
+    let result = lhs
+        .binary(rhs, operator.into())
+        .vortex_expect("binary decimal op shouldn't fail")
+        .execute::<RecursiveCanonical>(ctx)
+        .map(|c| c.0.into_array());
+
+    assert_decimal_results(
+        result,
+        &expected_results,
+        array,
+        scalar,
+        operator,
+        lhs_is_array,
+        ctx,
+    );
+}
+
+fn expected_decimal_results(
+    original_values: &[Scalar],
+    scalar: &Scalar,
+    operator: NumericOperator,
+    result_decimal_dtype: DecimalDType,
+    result_dtype: &DType,
+    lhs_is_array: bool,
+) -> Vec<Option<Scalar>> {
+    original_values
+        .iter()
+        .map(|value| {
+            let (lhs, rhs) = if lhs_is_array {
+                (value.as_decimal(), scalar.as_decimal())
+            } else {
+                (scalar.as_decimal(), value.as_decimal())
+            };
+            let (Some(lhs), Some(rhs)) = (lhs.decimal_value(), rhs.decimal_value()) else {
+                return Some(Scalar::null(result_dtype.clone()));
+            };
+            let value = match operator {
+                NumericOperator::Add => lhs.as_i256().checked_add(&rhs.as_i256()),
+                NumericOperator::Sub => lhs.as_i256().checked_sub(&rhs.as_i256()),
+                NumericOperator::Mul | NumericOperator::Div => unreachable!(),
+            }?;
+            let value = DecimalValue::try_from_i256(value, result_decimal_dtype).ok()?;
+            Some(Scalar::decimal(
+                value,
+                result_decimal_dtype,
+                result_dtype.nullability(),
+            ))
+        })
+        .collect()
+}
+
+fn assert_decimal_results(
+    result: vortex_error::VortexResult<ArrayRef>,
+    expected_results: &[Option<Scalar>],
+    array: &ArrayRef,
+    scalar: &Scalar,
+    operator: NumericOperator,
+    lhs_is_array: bool,
+    ctx: &mut ExecutionCtx,
+) {
+    if expected_results.iter().any(Option::is_none) {
+        assert!(
+            result.is_err(),
+            "Decimal binary numeric operation should overflow for encoding {}: \
+             {operator:?} {scalar} (lhs_is_array: {lhs_is_array})",
+            array.encoding_id(),
+        );
+        return;
+    }
+
+    let result = result.unwrap_or_else(|err| {
+        vortex_panic!(
+            "Decimal binary numeric operation unexpectedly failed for encoding {}: \
+             {operator:?} {scalar} (lhs_is_array: {lhs_is_array}): {err}",
+            array.encoding_id(),
+        )
+    });
+
+    let actual_values = to_vec_of_scalar(&result, ctx);
+    for (idx, (actual, expected)) in actual_values.iter().zip(expected_results).enumerate() {
+        let expected_value = expected
+            .as_ref()
+            .vortex_expect("non-overflowing decimal lane must have an expected value");
+        assert_eq!(
+            actual,
+            expected_value,
+            "Decimal binary numeric operation failed for encoding {} at index {}: \
+             ({array:?})[{idx}] {operator:?} {scalar} (lhs_is_array: {lhs_is_array}) \
+             expected {expected_value:?}, got {actual:?}",
+            array.encoding_id(),
+            idx,
+        );
     }
 }
 

--- a/vortex-array/src/compute/conformance/binary_numeric.rs
+++ b/vortex-array/src/compute/conformance/binary_numeric.rs
@@ -49,6 +49,7 @@ use crate::scalar::DecimalValue;
 use crate::scalar::NumericOperator;
 use crate::scalar::PrimitiveScalar;
 use crate::scalar::Scalar;
+use crate::scalar_fn::fns::binary::decimal_add_sub_result_dtype;
 
 fn to_vec_of_scalar(array: &ArrayRef, ctx: &mut ExecutionCtx) -> Vec<Scalar> {
     // Not fast, but obviously correct
@@ -299,6 +300,8 @@ fn test_decimal_binary_numeric_with_scalar(
     let original_values = to_vec_of_scalar(&canonicalized_array, ctx);
 
     let scalar = Scalar::decimal(value, decimal_dtype, array.dtype().nullability());
+    let result_decimal_dtype = decimal_add_sub_result_dtype(decimal_dtype);
+    let result_dtype = DType::Decimal(result_decimal_dtype, array.dtype().nullability());
 
     // Decimal Mul/Div are not yet implemented.
     let operators = vec![NumericOperator::Add, NumericOperator::Sub];
@@ -321,7 +324,17 @@ fn test_decimal_binary_numeric_with_scalar(
                     } else {
                         (scalar.as_decimal(), x.as_decimal())
                     };
-                    lhs.checked_binary_numeric(&rhs, operator).map(Scalar::from)
+                    let (Some(lhs), Some(rhs)) = (lhs.decimal_value(), rhs.decimal_value()) else {
+                        return Some(Scalar::null(result_dtype.clone()));
+                    };
+                    let value = match operator {
+                        NumericOperator::Add => lhs.checked_add(&rhs),
+                        NumericOperator::Sub => lhs.checked_sub(&rhs),
+                        NumericOperator::Mul | NumericOperator::Div => unreachable!(),
+                    }?;
+                    value.fits_in_precision(result_decimal_dtype).then(|| {
+                        Scalar::decimal(value, result_decimal_dtype, result_dtype.nullability())
+                    })
                 })
                 .collect();
 

--- a/vortex-array/src/compute/conformance/binary_numeric.rs
+++ b/vortex-array/src/compute/conformance/binary_numeric.rs
@@ -313,18 +313,6 @@ fn test_decimal_binary_numeric_with_scalar(
                 (rhs_const.clone(), array.clone())
             };
 
-            let result = lhs
-                .binary(rhs, operator.into())
-                .vortex_expect("apply shouldn't fail")
-                .execute::<RecursiveCanonical>(ctx)
-                .map(|c| c.0.into_array());
-
-            // Skip this operator if the entire operation fails (e.g. an overflowing lane).
-            let Ok(result) = result else {
-                continue;
-            };
-
-            let actual_values = to_vec_of_scalar(&result, ctx);
             let expected_results: Vec<Option<Scalar>> = original_values
                 .iter()
                 .map(|x| {
@@ -337,20 +325,46 @@ fn test_decimal_binary_numeric_with_scalar(
                 })
                 .collect();
 
-            // For elements that didn't overflow, check they match.
+            let result = lhs
+                .binary(rhs, operator.into())
+                .vortex_expect("apply shouldn't fail")
+                .execute::<RecursiveCanonical>(ctx)
+                .map(|c| c.0.into_array());
+
+            let expects_overflow = expected_results.iter().any(Option::is_none);
+            if expects_overflow {
+                assert!(
+                    result.is_err(),
+                    "Decimal binary numeric operation should overflow for encoding {}: \
+                     {operator:?} {scalar} (lhs_is_array: {lhs_is_array})",
+                    array.encoding_id(),
+                );
+                continue;
+            }
+
+            let result = result.unwrap_or_else(|err| {
+                vortex_panic!(
+                    "Decimal binary numeric operation unexpectedly failed for encoding {}: \
+                     {operator:?} {scalar} (lhs_is_array: {lhs_is_array}): {err}",
+                    array.encoding_id(),
+                )
+            });
+
+            let actual_values = to_vec_of_scalar(&result, ctx);
             for (idx, (actual, expected)) in actual_values.iter().zip(&expected_results).enumerate()
             {
-                if let Some(expected_value) = expected {
-                    assert_eq!(
-                        actual,
-                        expected_value,
-                        "Decimal binary numeric operation failed for encoding {} at index {}: \
-                         ({array:?})[{idx}] {operator:?} {scalar} (lhs_is_array: {lhs_is_array}) \
-                         expected {expected_value:?}, got {actual:?}",
-                        array.encoding_id(),
-                        idx,
-                    );
-                }
+                let expected_value = expected
+                    .as_ref()
+                    .vortex_expect("non-overflowing decimal lane must have an expected value");
+                assert_eq!(
+                    actual,
+                    expected_value,
+                    "Decimal binary numeric operation failed for encoding {} at index {}: \
+                     ({array:?})[{idx}] {operator:?} {scalar} (lhs_is_array: {lhs_is_array}) \
+                     expected {expected_value:?}, got {actual:?}",
+                    array.encoding_id(),
+                    idx,
+                );
             }
         }
     }

--- a/vortex-array/src/compute/conformance/binary_numeric.rs
+++ b/vortex-array/src/compute/conformance/binary_numeric.rs
@@ -40,8 +40,12 @@ use crate::RecursiveCanonical;
 use crate::arrays::ConstantArray;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
+use crate::dtype::DecimalDType;
+use crate::dtype::NativeDecimalType;
 use crate::dtype::NativePType;
 use crate::dtype::PType;
+use crate::dtype::i256;
+use crate::scalar::DecimalValue;
 use crate::scalar::NumericOperator;
 use crate::scalar::PrimitiveScalar;
 use crate::scalar::Scalar;
@@ -240,9 +244,115 @@ pub fn test_binary_numeric_array(array: &ArrayRef, ctx: &mut ExecutionCtx) {
             PType::F32 => test_binary_numeric_conformance::<f32>(array, ctx),
             PType::F64 => test_binary_numeric_conformance::<f64>(array, ctx),
         },
+        DType::Decimal(decimal_dtype, _) => {
+            test_binary_numeric_conformance_decimal(array, *decimal_dtype, ctx)
+        }
         dtype => vortex_panic!(
-            "Binary numeric tests are only supported for primitive numeric types, got {dtype}",
+            "Binary numeric tests are only supported for primitive and decimal types, got {dtype}",
         ),
+    }
+}
+
+/// Tests binary numeric operations on a decimal array against the decimal scalar
+/// implementation, using a set of representative constants: stored `0`, `1`, `-1`, the decimal
+/// `1.0` (when it fits the precision), and the largest stored value for the precision.
+fn test_binary_numeric_conformance_decimal(
+    array: &ArrayRef,
+    decimal_dtype: DecimalDType,
+    ctx: &mut ExecutionCtx,
+) {
+    let precision = decimal_dtype.precision() as usize;
+    let prec_max = <i256 as NativeDecimalType>::MAX_BY_PRECISION[precision];
+
+    let mut constants = vec![
+        i256::from_i128(0),
+        i256::from_i128(1),
+        i256::from_i128(-1),
+        prec_max,
+    ];
+    // The decimal value 1.0 (stored 10^s), when representable within the precision.
+    if decimal_dtype.scale() >= 0
+        && let Some(one) = i256::from_i128(10).checked_pow(decimal_dtype.scale() as u32)
+        && one <= prec_max
+    {
+        constants.push(one);
+    }
+
+    for constant in constants {
+        let value = DecimalValue::try_from_i256(constant, decimal_dtype)
+            .vortex_expect("conformance constants fit the precision");
+        test_decimal_binary_numeric_with_scalar(array, value, decimal_dtype, ctx);
+    }
+}
+
+fn test_decimal_binary_numeric_with_scalar(
+    array: &ArrayRef,
+    value: DecimalValue,
+    decimal_dtype: DecimalDType,
+    ctx: &mut ExecutionCtx,
+) {
+    let canonicalized_array = array
+        .clone()
+        .execute::<Canonical>(ctx)
+        .vortex_expect("Must be able to canonicalise")
+        .into_array();
+    let original_values = to_vec_of_scalar(&canonicalized_array, ctx);
+
+    let scalar = Scalar::decimal(value, decimal_dtype, array.dtype().nullability());
+
+    // Decimal Mul/Div are not yet implemented.
+    let operators = vec![NumericOperator::Add, NumericOperator::Sub];
+
+    for operator in operators {
+        let rhs_const = ConstantArray::new(scalar.clone(), array.len()).into_array();
+
+        for lhs_is_array in [true, false] {
+            let (lhs, rhs) = if lhs_is_array {
+                (array.clone(), rhs_const.clone())
+            } else {
+                (rhs_const.clone(), array.clone())
+            };
+
+            let result = lhs
+                .binary(rhs, operator.into())
+                .vortex_expect("apply shouldn't fail")
+                .execute::<RecursiveCanonical>(ctx)
+                .map(|c| c.0.into_array());
+
+            // Skip this operator if the entire operation fails (e.g. an overflowing lane).
+            let Ok(result) = result else {
+                continue;
+            };
+
+            let actual_values = to_vec_of_scalar(&result, ctx);
+            let expected_results: Vec<Option<Scalar>> = original_values
+                .iter()
+                .map(|x| {
+                    let (lhs, rhs) = if lhs_is_array {
+                        (x.as_decimal(), scalar.as_decimal())
+                    } else {
+                        (scalar.as_decimal(), x.as_decimal())
+                    };
+                    lhs.checked_binary_numeric(&rhs, operator).map(Scalar::from)
+                })
+                .collect();
+
+            // For elements that didn't overflow, check they match.
+            for (idx, (actual, expected)) in actual_values.iter().zip(&expected_results).enumerate()
+            {
+                if let Some(expected_value) = expected {
+                    assert_eq!(
+                        actual,
+                        expected_value,
+                        "Decimal binary numeric operation failed for encoding {} at index {}: \
+                         ({array:?})[{idx}] {operator:?} {scalar} (lhs_is_array: {lhs_is_array}) \
+                         expected {expected_value:?}, got {actual:?}",
+                        array.encoding_id(),
+                        idx,
+                    );
+                }
+            }
+        }
     }
 }
 

--- a/vortex-array/src/compute/conformance/binary_numeric.rs
+++ b/vortex-array/src/compute/conformance/binary_numeric.rs
@@ -49,7 +49,7 @@ use crate::scalar::DecimalValue;
 use crate::scalar::NumericOperator;
 use crate::scalar::PrimitiveScalar;
 use crate::scalar::Scalar;
-use crate::scalar_fn::fns::binary::decimal_add_sub_result_dtype;
+use crate::scalar_fn::fns::binary::numeric_op_result_decimal_dtype;
 
 fn to_vec_of_scalar(array: &ArrayRef, ctx: &mut ExecutionCtx) -> Vec<Scalar> {
     // Not fast, but obviously correct
@@ -300,13 +300,14 @@ fn test_decimal_binary_numeric_with_scalar(
     let original_values = to_vec_of_scalar(&canonicalized_array, ctx);
 
     let scalar = Scalar::decimal(value, decimal_dtype, array.dtype().nullability());
-    let result_decimal_dtype = decimal_add_sub_result_dtype(decimal_dtype);
-    let result_dtype = DType::Decimal(result_decimal_dtype, array.dtype().nullability());
 
     // Decimal Mul/Div are not yet implemented.
     let operators = vec![NumericOperator::Add, NumericOperator::Sub];
 
     for operator in operators {
+        let result_decimal_dtype = numeric_op_result_decimal_dtype(decimal_dtype, operator)
+            .vortex_expect("decimal Add/Sub must have a result dtype");
+        let result_dtype = DType::Decimal(result_decimal_dtype, array.dtype().nullability());
         let rhs_const = ConstantArray::new(scalar.clone(), array.len()).into_array();
 
         for lhs_is_array in [true, false] {

--- a/vortex-array/src/compute/conformance/binary_numeric.rs
+++ b/vortex-array/src/compute/conformance/binary_numeric.rs
@@ -25,6 +25,8 @@ use std::fmt::Debug;
 
 use itertools::Itertools;
 use num_traits::Bounded;
+use num_traits::CheckedAdd;
+use num_traits::CheckedSub;
 use num_traits::Float;
 use num_traits::Num;
 use num_traits::Signed;
@@ -328,14 +330,19 @@ fn test_decimal_binary_numeric_with_scalar(
                     let (Some(lhs), Some(rhs)) = (lhs.decimal_value(), rhs.decimal_value()) else {
                         return Some(Scalar::null(result_dtype.clone()));
                     };
+                    let lhs = lhs.as_i256();
+                    let rhs = rhs.as_i256();
                     let value = match operator {
                         NumericOperator::Add => lhs.checked_add(&rhs),
                         NumericOperator::Sub => lhs.checked_sub(&rhs),
                         NumericOperator::Mul | NumericOperator::Div => unreachable!(),
                     }?;
-                    value.fits_in_precision(result_decimal_dtype).then(|| {
-                        Scalar::decimal(value, result_decimal_dtype, result_dtype.nullability())
-                    })
+                    let value = DecimalValue::try_from_i256(value, result_decimal_dtype).ok()?;
+                    Some(Scalar::decimal(
+                        value,
+                        result_decimal_dtype,
+                        result_dtype.nullability(),
+                    ))
                 })
                 .collect();
 

--- a/vortex-array/src/expr/transform/coerce.rs
+++ b/vortex-array/src/expr/transform/coerce.rs
@@ -156,13 +156,14 @@ mod tests {
 
     #[test]
     fn decimal_arithmetic_coerces_precision_and_scale() -> VortexResult<()> {
-        let result_dtype = DType::Decimal(DecimalDType::new(4, 2), NonNullable);
+        let common_dtype = DType::Decimal(DecimalDType::new(4, 2), NonNullable);
+        let result_dtype = DType::Decimal(DecimalDType::new(5, 2), NonNullable);
         let scope = DType::Struct(
             StructFields::new(
                 ["a", "b"].into(),
                 vec![
                     DType::Decimal(DecimalDType::new(3, 1), NonNullable),
-                    result_dtype.clone(),
+                    common_dtype,
                 ],
             ),
             NonNullable,
@@ -173,29 +174,6 @@ mod tests {
 
         assert!(coerced.child(0).is::<Cast>());
         assert!(!coerced.child(1).is::<Cast>());
-        assert_eq!(coerced.return_dtype(&scope)?, result_dtype);
-        Ok(())
-    }
-
-    #[test]
-    fn decimal_arithmetic_coerces_integer_operand() -> VortexResult<()> {
-        let result_dtype = DType::Decimal(DecimalDType::new(5, 2), NonNullable);
-        let scope = DType::Struct(
-            StructFields::new(
-                ["a", "b"].into(),
-                vec![
-                    DType::Decimal(DecimalDType::new(4, 2), NonNullable),
-                    DType::Primitive(PType::I8, NonNullable),
-                ],
-            ),
-            NonNullable,
-        );
-        let expr = Binary.new_expr(Operator::Add, [col("a"), col("b")]);
-
-        let coerced = coerce_expression(expr, &scope)?;
-
-        assert!(coerced.child(0).is::<Cast>());
-        assert!(coerced.child(1).is::<Cast>());
         assert_eq!(coerced.return_dtype(&scope)?, result_dtype);
         Ok(())
     }

--- a/vortex-array/src/expr/transform/coerce.rs
+++ b/vortex-array/src/expr/transform/coerce.rs
@@ -70,6 +70,7 @@ mod tests {
     use vortex_error::VortexResult;
 
     use crate::dtype::DType;
+    use crate::dtype::DecimalDType;
     use crate::dtype::Nullability::NonNullable;
     use crate::dtype::PType;
     use crate::dtype::StructFields;
@@ -150,6 +151,52 @@ mod tests {
         let lhs_dt = coerced.child(0).return_dtype(&scope)?;
         let rhs_dt = coerced.child(1).return_dtype(&scope)?;
         assert_eq!(lhs_dt, rhs_dt);
+        Ok(())
+    }
+
+    #[test]
+    fn decimal_arithmetic_coerces_precision_and_scale() -> VortexResult<()> {
+        let result_dtype = DType::Decimal(DecimalDType::new(4, 2), NonNullable);
+        let scope = DType::Struct(
+            StructFields::new(
+                ["a", "b"].into(),
+                vec![
+                    DType::Decimal(DecimalDType::new(3, 1), NonNullable),
+                    result_dtype.clone(),
+                ],
+            ),
+            NonNullable,
+        );
+        let expr = Binary.new_expr(Operator::Add, [col("a"), col("b")]);
+
+        let coerced = coerce_expression(expr, &scope)?;
+
+        assert!(coerced.child(0).is::<Cast>());
+        assert!(!coerced.child(1).is::<Cast>());
+        assert_eq!(coerced.return_dtype(&scope)?, result_dtype);
+        Ok(())
+    }
+
+    #[test]
+    fn decimal_arithmetic_coerces_integer_operand() -> VortexResult<()> {
+        let result_dtype = DType::Decimal(DecimalDType::new(5, 2), NonNullable);
+        let scope = DType::Struct(
+            StructFields::new(
+                ["a", "b"].into(),
+                vec![
+                    DType::Decimal(DecimalDType::new(4, 2), NonNullable),
+                    DType::Primitive(PType::I8, NonNullable),
+                ],
+            ),
+            NonNullable,
+        );
+        let expr = Binary.new_expr(Operator::Add, [col("a"), col("b")]);
+
+        let coerced = coerce_expression(expr, &scope)?;
+
+        assert!(coerced.child(0).is::<Cast>());
+        assert!(coerced.child(1).is::<Cast>());
+        assert_eq!(coerced.return_dtype(&scope)?, result_dtype);
         Ok(())
     }
 

--- a/vortex-array/src/scalar/typed_view/primitive/numeric_operator.rs
+++ b/vortex-array/src/scalar/typed_view/primitive/numeric_operator.rs
@@ -5,6 +5,9 @@
 
 use std::fmt;
 
+use vortex_error::VortexError;
+use vortex_error::vortex_err;
+
 use crate::scalar_fn::fns::operators::Operator;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,6 +38,20 @@ impl From<NumericOperator> for Operator {
             NumericOperator::Sub => Operator::Sub,
             NumericOperator::Mul => Operator::Mul,
             NumericOperator::Div => Operator::Div,
+        }
+    }
+}
+
+impl TryFrom<Operator> for NumericOperator {
+    type Error = VortexError;
+
+    fn try_from(op: Operator) -> Result<Self, Self::Error> {
+        match op {
+            Operator::Add => Ok(NumericOperator::Add),
+            Operator::Sub => Ok(NumericOperator::Sub),
+            Operator::Mul => Ok(NumericOperator::Mul),
+            Operator::Div => Ok(NumericOperator::Div),
+            _ => Err(vortex_err!(InvalidArgument: "{op} is not a numeric operator")),
         }
     }
 }

--- a/vortex-array/src/scalar_fn/fns/binary/compare/decimal.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare/decimal.rs
@@ -10,8 +10,6 @@
 //! [`DecimalDType`]: crate::dtype::DecimalDType
 
 use vortex_buffer::BitBuffer;
-use vortex_buffer::Buffer;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 
@@ -21,6 +19,7 @@ use crate::IntoArray;
 use crate::arrays::BoolArray;
 use crate::arrays::Constant;
 use crate::arrays::DecimalArray;
+use crate::arrays::decimal::widened_buffer;
 use crate::dtype::NativeDecimalType;
 use crate::dtype::Nullability;
 use crate::dtype::i256;
@@ -117,21 +116,6 @@ fn compare_decimal_values(
         let lhs = widened_buffer::<W>(lhs);
         let rhs = widened_buffer::<W>(rhs);
         compare_slices::<W>(&lhs, &rhs, op)
-    })
-}
-
-/// Return the array's unscaled values widened to `W`, which must be at least as wide as the
-/// array's storage type.
-pub(super) fn widened_buffer<W: NativeDecimalType>(array: &DecimalArray) -> Buffer<W> {
-    if array.values_type() == W::DECIMAL_TYPE {
-        return array.buffer::<W>();
-    }
-    match_each_decimal_value_type!(array.values_type(), |T| {
-        array
-            .buffer::<T>()
-            .iter()
-            .map(|v| W::from(*v).vortex_expect("widening decimal cast must succeed"))
-            .collect()
     })
 }
 

--- a/vortex-array/src/scalar_fn/fns/binary/compare/nested.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare/nested.rs
@@ -31,6 +31,7 @@ use crate::arrays::ListViewArray;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::StructArray;
 use crate::arrays::VarBinViewArray;
+use crate::arrays::decimal::widened_buffer;
 use crate::arrays::extension::ExtensionArrayExt;
 use crate::arrays::fixed_size_list::FixedSizeListArrayExt;
 use crate::arrays::listview::ListViewArrayExt;
@@ -151,8 +152,8 @@ fn build_values_comparator(
             let rhs = rhs.clone().execute::<DecimalArray>(ctx)?;
             let common = lhs.values_type().max(rhs.values_type());
             crate::match_each_decimal_value_type!(common, |W| {
-                let lhs = super::decimal::widened_buffer::<W>(&lhs);
-                let rhs = super::decimal::widened_buffer::<W>(&rhs);
+                let lhs = widened_buffer::<W>(&lhs);
+                let rhs = widened_buffer::<W>(&rhs);
                 Box::new(move |i: usize, j: usize| lhs[i].cmp(&rhs[j])) as RowComparator
             })
         }

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -17,8 +17,6 @@ use vortex_session::registry::CachedId;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::dtype::DType;
-use crate::dtype::DecimalDType;
-use crate::dtype::MAX_PRECISION;
 use crate::dtype::Nullability;
 use crate::expr::and;
 use crate::expr::expression::Expression;
@@ -49,14 +47,6 @@ use crate::scalar::Scalar;
 
 #[derive(Clone)]
 pub struct Binary;
-
-/// Derive the result type for Add/Sub over operands that already share a decimal dtype.
-pub(crate) fn decimal_add_sub_result_dtype(input: DecimalDType) -> DecimalDType {
-    DecimalDType::new(
-        input.precision().saturating_add(1).min(MAX_PRECISION),
-        input.scale(),
-    )
-}
 
 impl ScalarFnVTable for Binary {
     type Options = Operator;
@@ -131,12 +121,13 @@ impl ScalarFnVTable for Binary {
             if lhs.is_primitive() && lhs.eq_ignore_nullability(rhs) {
                 return Ok(lhs.with_nullability(lhs.nullability() | rhs.nullability()));
             }
+
             if let DType::Decimal(decimal_dtype, _) = lhs
-                && matches!(operator, Operator::Add | Operator::Sub)
                 && lhs.eq_ignore_nullability(rhs)
             {
+                let numeric_op = NumericOperator::try_from(*operator)?;
                 return Ok(DType::Decimal(
-                    decimal_add_sub_result_dtype(*decimal_dtype),
+                    numeric_op_result_decimal_dtype(*decimal_dtype, numeric_op)?,
                     lhs.nullability() | rhs.nullability(),
                 ));
             }

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -17,6 +17,8 @@ use vortex_session::registry::CachedId;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::dtype::DType;
+use crate::dtype::DecimalDType;
+use crate::dtype::MAX_PRECISION;
 use crate::dtype::Nullability;
 use crate::expr::and;
 use crate::expr::expression::Expression;
@@ -47,6 +49,14 @@ use crate::scalar::Scalar;
 
 #[derive(Clone)]
 pub struct Binary;
+
+/// Derive the result type for Add/Sub over operands that already share a decimal dtype.
+pub(crate) fn decimal_add_sub_result_dtype(input: DecimalDType) -> DecimalDType {
+    DecimalDType::new(
+        input.precision().saturating_add(1).min(MAX_PRECISION),
+        input.scale(),
+    )
+}
 
 impl ScalarFnVTable for Binary {
     type Options = Operator;
@@ -118,11 +128,17 @@ impl ScalarFnVTable for Binary {
         let rhs = &arg_dtypes[1];
 
         if operator.is_arithmetic() {
-            // Decimal Mul/Div need rescaling support and are not yet implemented.
-            let decimal_supported =
-                lhs.is_decimal() && matches!(operator, Operator::Add | Operator::Sub);
-            if (lhs.is_primitive() || decimal_supported) && lhs.eq_ignore_nullability(rhs) {
+            if lhs.is_primitive() && lhs.eq_ignore_nullability(rhs) {
                 return Ok(lhs.with_nullability(lhs.nullability() | rhs.nullability()));
+            }
+            if let DType::Decimal(decimal_dtype, _) = lhs
+                && matches!(operator, Operator::Add | Operator::Sub)
+                && lhs.eq_ignore_nullability(rhs)
+            {
+                return Ok(DType::Decimal(
+                    decimal_add_sub_result_dtype(*decimal_dtype),
+                    lhs.nullability() | rhs.nullability(),
+                ));
             }
             vortex_bail!(
                 "incompatible types for arithmetic operation: {} {}",

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -118,7 +118,10 @@ impl ScalarFnVTable for Binary {
         let rhs = &arg_dtypes[1];
 
         if operator.is_arithmetic() {
-            if lhs.is_primitive() && lhs.eq_ignore_nullability(rhs) {
+            // Decimal Mul/Div need rescaling support and are not yet implemented.
+            let decimal_supported =
+                lhs.is_decimal() && matches!(operator, Operator::Add | Operator::Sub);
+            if (lhs.is_primitive() || decimal_supported) && lhs.eq_ignore_nullability(rhs) {
                 return Ok(lhs.with_nullability(lhs.nullability() | rhs.nullability()));
             }
             vortex_bail!(

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/checked.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/checked.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Shared checked-lane execution helpers for numeric kernels.
+
+use vortex_buffer::BitBuffer;
+use vortex_buffer::Buffer;
+use vortex_buffer::BufferMut;
+
+/// The values produced by a checked lane loop, plus whether any lane failed.
+pub(super) struct CheckedValues<T> {
+    pub(super) values: Buffer<T>,
+    pub(super) failed: bool,
+}
+
+impl<T> CheckedValues<T> {
+    pub(super) fn zeroed(len: usize) -> Self {
+        Self {
+            values: Buffer::<T>::zeroed(len),
+            failed: false,
+        }
+    }
+
+    fn failed(len: usize) -> Self {
+        Self {
+            values: Buffer::<T>::zeroed(len),
+            failed: true,
+        }
+    }
+}
+
+// Checked one-pass ops delay early exit until the end of a small block. This
+// keeps the loop generic while avoiding a branch-driven exit decision on every
+// lane; it is deliberately independent of mask density or input length.
+const CHECKED_BLOCK_LANES: usize = 16;
+
+pub(super) fn checked_all_lanes<T, F>(len: usize, mut checked_at: F) -> CheckedValues<T>
+where
+    T: Default,
+    F: FnMut(usize) -> Option<T>,
+{
+    let mut values = BufferMut::<T>::with_capacity(len);
+    let mut base = 0;
+
+    while base + CHECKED_BLOCK_LANES <= len {
+        let mut block_failed = false;
+        for idx in base..base + CHECKED_BLOCK_LANES {
+            match checked_at(idx) {
+                Some(value) => {
+                    // SAFETY: the buffer is allocated with capacity `len`, and
+                    // this loop pushes at most one value for each `idx`.
+                    unsafe { values.push_unchecked(value) };
+                }
+                None => {
+                    block_failed = true;
+                    // SAFETY: the buffer is allocated with capacity `len`, and
+                    // this loop pushes at most one value for each `idx`.
+                    unsafe { values.push_unchecked(T::default()) };
+                }
+            }
+        }
+
+        if block_failed {
+            return CheckedValues::failed(len);
+        }
+        base += CHECKED_BLOCK_LANES;
+    }
+
+    for idx in base..len {
+        let Some(value) = checked_at(idx) else {
+            return CheckedValues::failed(len);
+        };
+        // SAFETY: the buffer is allocated with capacity `len`, and this loop
+        // pushes at most one value for each `idx`.
+        unsafe { values.push_unchecked(value) };
+    }
+
+    CheckedValues {
+        values: values.freeze(),
+        failed: false,
+    }
+}
+
+pub(super) fn checked_valid_lanes<T, F>(
+    len: usize,
+    valid_bits: &BitBuffer,
+    mut checked_at: F,
+) -> CheckedValues<T>
+where
+    T: Default,
+    F: FnMut(usize) -> Option<T>,
+{
+    let mut values = BufferMut::<T>::zeroed(len);
+    let mut failed = false;
+    {
+        let values = values.as_mut_slice();
+        for_each_valid_idx(len, valid_bits, |idx| {
+            let Some(value) = checked_at(idx) else {
+                failed = true;
+                return false;
+            };
+            values[idx] = value;
+            true
+        });
+    }
+
+    CheckedValues {
+        values: values.freeze(),
+        failed,
+    }
+}
+
+pub(super) fn any_valid_error<F>(len: usize, valid_bits: &BitBuffer, is_error: F) -> bool
+where
+    F: Fn(usize) -> bool,
+{
+    !for_each_valid_idx(len, valid_bits, |idx| !is_error(idx))
+}
+
+fn for_each_valid_idx<F>(len: usize, valid_bits: &BitBuffer, mut f: F) -> bool
+where
+    F: FnMut(usize) -> bool,
+{
+    debug_assert_eq!(len, valid_bits.len());
+
+    for (word_idx, valid_word) in valid_bits.chunks().iter_padded().enumerate() {
+        if valid_word == 0 {
+            continue;
+        }
+
+        let offset = word_idx * 64;
+        let lanes = len.saturating_sub(offset).min(64);
+        if lanes == 64 && valid_word == u64::MAX {
+            for bit_idx in 0..64 {
+                if !f(offset + bit_idx) {
+                    return false;
+                }
+            }
+            continue;
+        }
+
+        let mut valid_word = if lanes == 64 {
+            valid_word
+        } else {
+            valid_word & ((1u64 << lanes) - 1)
+        };
+        while valid_word != 0 {
+            let bit_idx = valid_word.trailing_zeros() as usize;
+            if !f(offset + bit_idx) {
+                return false;
+            }
+            valid_word &= valid_word - 1;
+        }
+    }
+
+    true
+}

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
@@ -5,8 +5,7 @@
 //!
 //! Both operands share a logical [`DecimalDType`] (equal precision and scale). Add and Sub apply
 //! directly to the unscaled stored integers and are exact at that shared scale. The result reserves
-//! one additional precision digit for a carry, capped at Vortex's maximum decimal precision. Mul
-//! and Div require rescaling and are not yet implemented.
+//! one additional precision digit for a carry, capped at Vortex's maximum decimal precision.
 //!
 //! Lanes execute in a working width chosen so that in-precision inputs cannot spuriously
 //! overflow an intermediate value. An operation that overflows the result precision on a valid
@@ -21,10 +20,9 @@ use vortex_error::vortex_err;
 use vortex_mask::AllOr;
 use vortex_mask::Mask;
 
-use super::CheckedValues;
-use super::check_numeric_errors;
-use super::checked_all_lanes;
-use super::checked_valid_lanes;
+use super::checked::CheckedValues;
+use super::checked::checked_all_lanes;
+use super::checked::checked_valid_lanes;
 use crate::ArrayRef;
 use crate::Columnar;
 use crate::ExecutionCtx;
@@ -102,7 +100,7 @@ pub(super) fn execute_numeric_decimal(
     match_each_decimal_value_type!(
         DecimalType::smallest_decimal_value_type(&result_decimal_dtype),
         |W| {
-            execute_decimal_at_widths::<W, W>(
+            execute_decimal_at_width::<W>(
                 &lhs,
                 &rhs,
                 op,
@@ -198,7 +196,6 @@ impl<W: NativeDecimalType> DecimalValueBounds<W> {
     }
 
     /// Bounds-check a candidate result against the result precision.
-    #[inline(always)]
     fn in_precision(&self, value: W) -> Option<W> {
         (self.lower_bound <= value && value <= self.upper_bound).then_some(value)
     }
@@ -208,7 +205,7 @@ impl<W: NativeDecimalType> DecimalValueBounds<W> {
 trait CheckedDecimalOp {
     const ERROR: &'static str;
 
-    fn apply<W>(lhs: W, rhs: W, plan: &DecimalValueBounds<W>) -> Option<W>
+    fn apply<W>(lhs: W, rhs: W, bounds: &DecimalValueBounds<W>) -> Option<W>
     where
         W: NativeDecimalType + CheckedAdd + CheckedSub;
 }
@@ -220,28 +217,26 @@ struct CheckedDecimalSub;
 impl CheckedDecimalOp for CheckedDecimalAdd {
     const ERROR: &'static str = "decimal overflow in checked add";
 
-    #[inline(always)]
-    fn apply<W>(lhs: W, rhs: W, plan: &DecimalValueBounds<W>) -> Option<W>
+    fn apply<W>(lhs: W, rhs: W, bounds: &DecimalValueBounds<W>) -> Option<W>
     where
         W: NativeDecimalType + CheckedAdd + CheckedSub,
     {
-        plan.in_precision(lhs.checked_add(&rhs)?)
+        bounds.in_precision(lhs.checked_add(&rhs)?)
     }
 }
 
 impl CheckedDecimalOp for CheckedDecimalSub {
     const ERROR: &'static str = "decimal overflow in checked sub";
 
-    #[inline(always)]
-    fn apply<W>(lhs: W, rhs: W, plan: &DecimalValueBounds<W>) -> Option<W>
+    fn apply<W>(lhs: W, rhs: W, bounds: &DecimalValueBounds<W>) -> Option<W>
     where
         W: NativeDecimalType + CheckedAdd + CheckedSub,
     {
-        plan.in_precision(lhs.checked_sub(&rhs)?)
+        bounds.in_precision(lhs.checked_sub(&rhs)?)
     }
 }
 
-fn execute_decimal_at_widths<W, O>(
+fn execute_decimal_at_width<W>(
     lhs: &DecimalOperand,
     rhs: &DecimalOperand,
     op: NumericOperator,
@@ -252,12 +247,11 @@ fn execute_decimal_at_widths<W, O>(
 ) -> VortexResult<ArrayRef>
 where
     W: NativeDecimalType + CheckedAdd + CheckedSub,
-    O: NativeDecimalType,
-    DecimalValue: From<O>,
+    DecimalValue: From<W>,
 {
     macro_rules! execute_typed {
         ($Op:ty) => {
-            execute_decimal_typed::<W, O, $Op>(
+            execute_decimal_typed::<W, $Op>(
                 lhs,
                 rhs,
                 result_decimal_dtype,
@@ -278,7 +272,7 @@ where
     }
 }
 
-fn execute_decimal_typed<W, O, Op>(
+fn execute_decimal_typed<W, Op>(
     lhs: &DecimalOperand,
     rhs: &DecimalOperand,
     result_decimal_dtype: DecimalDType,
@@ -288,23 +282,22 @@ fn execute_decimal_typed<W, O, Op>(
 ) -> VortexResult<ArrayRef>
 where
     W: NativeDecimalType + CheckedAdd + CheckedSub,
-    O: NativeDecimalType,
-    DecimalValue: From<O>,
+    DecimalValue: From<W>,
     Op: CheckedDecimalOp,
 {
     let len = lhs.len();
-    let plan = DecimalValueBounds::<W>::new(result_decimal_dtype);
+    let bounds = DecimalValueBounds::<W>::new(result_decimal_dtype);
 
     let checked = match (lhs, rhs) {
         (DecimalOperand::Array { values: lhs, .. }, DecimalOperand::Array { values: rhs, .. }) => {
-            checked_decimal_arrays::<W, O, Op>(lhs, rhs, &plan, valid_rows)
+            checked_decimal_arrays::<W, Op>(lhs, rhs, &bounds, valid_rows)
         }
         (DecimalOperand::Array { values: lhs, .. }, DecimalOperand::Constant { value, .. }) => {
             let rhs = typed_constant::<W>(value);
             match_each_decimal_value_type!(lhs.values_type(), |L| {
                 let lhs = lhs.buffer::<L>();
-                checked_decimal_lanes::<W, O, _>(len, valid_rows, |idx| {
-                    Op::apply(cast_work_value::<W, L>(lhs[idx]), rhs, &plan)
+                checked_decimal_lanes::<W, _>(len, valid_rows, |idx| {
+                    Op::apply(<W as BigCast>::from(lhs[idx])?, rhs, &bounds)
                 })
             })
         }
@@ -312,8 +305,8 @@ where
             let lhs = typed_constant::<W>(value);
             match_each_decimal_value_type!(rhs.values_type(), |R| {
                 let rhs = rhs.buffer::<R>();
-                checked_decimal_lanes::<W, O, _>(len, valid_rows, |idx| {
-                    Op::apply(lhs, cast_work_value::<W, R>(rhs[idx]), &plan)
+                checked_decimal_lanes::<W, _>(len, valid_rows, |idx| {
+                    Op::apply(lhs, <W as BigCast>::from(rhs[idx])?, &bounds)
                 })
             })
         }
@@ -323,9 +316,8 @@ where
         ) => {
             let lhs = typed_constant::<W>(lhs);
             let rhs = typed_constant::<W>(rhs);
-            let value = Op::apply(lhs, rhs, &plan)
+            let value = Op::apply(lhs, rhs, &bounds)
                 .ok_or_else(|| vortex_err!(InvalidArgument: "{}", Op::ERROR))?;
-            let value = cast_result_value::<W, O>(value);
             return Ok(ConstantArray::new(
                 Scalar::decimal(
                     DecimalValue::from(value),
@@ -337,7 +329,10 @@ where
             .into_array());
         }
     };
-    check_numeric_errors(checked.failed, Op::ERROR)?;
+
+    if checked.failed {
+        return Err(vortex_err!(InvalidArgument: "{}", Op::ERROR));
+    }
 
     Ok(DecimalArray::new(
         checked.values,
@@ -347,15 +342,14 @@ where
     .into_array())
 }
 
-fn checked_decimal_arrays<W, O, Op>(
+fn checked_decimal_arrays<W, Op>(
     lhs: &DecimalArray,
     rhs: &DecimalArray,
-    plan: &DecimalValueBounds<W>,
+    bounds: &DecimalValueBounds<W>,
     valid_rows: &Mask,
-) -> CheckedValues<O>
+) -> CheckedValues<W>
 where
     W: NativeDecimalType + CheckedAdd + CheckedSub,
-    O: NativeDecimalType,
     Op: CheckedDecimalOp,
 {
     let len = lhs.len();
@@ -364,46 +358,27 @@ where
         let lhs = lhs.buffer::<L>();
         match_each_decimal_value_type!(rhs.values_type(), |R| {
             let rhs = rhs.buffer::<R>();
-            checked_decimal_lanes::<W, O, _>(len, valid_rows, |idx| {
+            checked_decimal_lanes::<W, _>(len, valid_rows, |idx| {
                 Op::apply(
-                    cast_work_value::<W, L>(lhs[idx]),
-                    cast_work_value::<W, R>(rhs[idx]),
-                    plan,
+                    <W as BigCast>::from(lhs[idx])?,
+                    <W as BigCast>::from(rhs[idx])?,
+                    bounds,
                 )
             })
         })
     })
 }
 
-fn checked_decimal_lanes<W, O, F>(
-    len: usize,
-    valid_rows: &Mask,
-    mut checked_at: F,
-) -> CheckedValues<O>
+fn checked_decimal_lanes<W, F>(len: usize, valid_rows: &Mask, checked_at: F) -> CheckedValues<W>
 where
     W: NativeDecimalType,
-    O: NativeDecimalType,
     F: FnMut(usize) -> Option<W>,
 {
     match valid_rows.bit_buffer() {
-        AllOr::All => checked_all_lanes(len, |idx| checked_at(idx).map(cast_result_value::<W, O>)),
-        AllOr::None => CheckedValues::<O>::zeroed(len),
-        AllOr::Some(valid_bits) => checked_valid_lanes(len, valid_bits, |idx| {
-            checked_at(idx).map(cast_result_value::<W, O>)
-        }),
+        AllOr::All => checked_all_lanes(len, checked_at),
+        AllOr::None => CheckedValues::<W>::zeroed(len),
+        AllOr::Some(valid_bits) => checked_valid_lanes(len, valid_bits, checked_at),
     }
-}
-
-#[inline(always)]
-fn cast_work_value<W: NativeDecimalType, T: NativeDecimalType>(value: T) -> W {
-    <W as BigCast>::from(value)
-        .vortex_expect("valid decimal input must fit the arithmetic working width")
-}
-
-#[inline(always)]
-fn cast_result_value<W: NativeDecimalType, O: NativeDecimalType>(value: W) -> O {
-    <O as BigCast>::from(value)
-        .vortex_expect("precision-checked decimal result must fit the output width")
 }
 
 fn typed_constant<W: NativeDecimalType>(value: &DecimalValue) -> W {

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
@@ -3,10 +3,10 @@
 
 //! Native execution of the arithmetic operators over decimal arrays.
 //!
-//! Both operands share a logical [`DecimalDType`] (equal precision and scale) and the result
-//! keeps that dtype: fixed-point arithmetic at the shared scale. Add and Sub apply directly to
-//! the unscaled stored integers and are exact; Mul and Div require rescaling and are not yet
-//! implemented.
+//! Both operands share a logical [`DecimalDType`] (equal precision and scale). Add and Sub apply
+//! directly to the unscaled stored integers and are exact at that shared scale. The result reserves
+//! one additional precision digit for a carry, capped at Vortex's maximum decimal precision. Mul
+//! and Div require rescaling and are not yet implemented.
 //!
 //! Lanes execute in a working width chosen so that in-precision inputs cannot spuriously
 //! overflow an intermediate value. An operation that overflows the result precision on a valid
@@ -25,6 +25,7 @@ use super::CheckedValues;
 use super::check_numeric_errors;
 use super::checked_all_lanes;
 use super::checked_valid_lanes;
+use super::decimal_add_sub_result_dtype;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
@@ -54,10 +55,11 @@ pub(super) fn execute_numeric_decimal(
     let DType::Decimal(decimal_dtype, _) = lhs.dtype() else {
         vortex_bail!("expected a decimal dtype, got {}", lhs.dtype());
     };
-    let decimal_dtype = *decimal_dtype;
-    let result_dtype = lhs
-        .dtype()
-        .with_nullability(lhs.dtype().nullability() | rhs.dtype().nullability());
+    let result_decimal_dtype = decimal_add_sub_result_dtype(*decimal_dtype);
+    let result_dtype = DType::Decimal(
+        result_decimal_dtype,
+        lhs.dtype().nullability() | rhs.dtype().nullability(),
+    );
 
     let lhs = DecimalOperand::try_new(lhs, ctx)?;
     let rhs = DecimalOperand::try_new(rhs, ctx)?;
@@ -67,82 +69,61 @@ pub(super) fn execute_numeric_decimal(
     let validity = lhs.validity().and(rhs.validity())?;
     let valid_rows = validity.execute_mask(len, ctx)?;
 
-    let work = working_type(decimal_dtype);
-    let output = DecimalType::smallest_decimal_value_type(&decimal_dtype);
-    match (work, output) {
-        (DecimalType::I8, DecimalType::I8) => execute_decimal_at_widths::<i8, i8>(
+    match DecimalType::smallest_decimal_value_type(&result_decimal_dtype) {
+        DecimalType::I8 => execute_decimal_at_widths::<i8, i8>(
             &lhs,
             &rhs,
             op,
-            decimal_dtype,
+            result_decimal_dtype,
             &result_dtype,
             validity,
             &valid_rows,
         ),
-        (DecimalType::I16, DecimalType::I8) => execute_decimal_at_widths::<i16, i8>(
+        DecimalType::I16 => execute_decimal_at_widths::<i16, i16>(
             &lhs,
             &rhs,
             op,
-            decimal_dtype,
+            result_decimal_dtype,
             &result_dtype,
             validity,
             &valid_rows,
         ),
-        (DecimalType::I16, DecimalType::I16) => execute_decimal_at_widths::<i16, i16>(
+        DecimalType::I32 => execute_decimal_at_widths::<i32, i32>(
             &lhs,
             &rhs,
             op,
-            decimal_dtype,
+            result_decimal_dtype,
             &result_dtype,
             validity,
             &valid_rows,
         ),
-        (DecimalType::I32, DecimalType::I32) => execute_decimal_at_widths::<i32, i32>(
+        DecimalType::I64 => execute_decimal_at_widths::<i64, i64>(
             &lhs,
             &rhs,
             op,
-            decimal_dtype,
+            result_decimal_dtype,
             &result_dtype,
             validity,
             &valid_rows,
         ),
-        (DecimalType::I64, DecimalType::I64) => execute_decimal_at_widths::<i64, i64>(
+        DecimalType::I128 => execute_decimal_at_widths::<i128, i128>(
             &lhs,
             &rhs,
             op,
-            decimal_dtype,
+            result_decimal_dtype,
             &result_dtype,
             validity,
             &valid_rows,
         ),
-        (DecimalType::I128, DecimalType::I128) => execute_decimal_at_widths::<i128, i128>(
+        DecimalType::I256 => execute_decimal_at_widths::<i256, i256>(
             &lhs,
             &rhs,
             op,
-            decimal_dtype,
+            result_decimal_dtype,
             &result_dtype,
             validity,
             &valid_rows,
         ),
-        (DecimalType::I256, DecimalType::I128) => execute_decimal_at_widths::<i256, i128>(
-            &lhs,
-            &rhs,
-            op,
-            decimal_dtype,
-            &result_dtype,
-            validity,
-            &valid_rows,
-        ),
-        (DecimalType::I256, DecimalType::I256) => execute_decimal_at_widths::<i256, i256>(
-            &lhs,
-            &rhs,
-            op,
-            decimal_dtype,
-            &result_dtype,
-            validity,
-            &valid_rows,
-        ),
-        _ => vortex_bail!("unsupported decimal working/output width combination: {work}/{output}"),
     }
 }
 
@@ -195,33 +176,6 @@ impl DecimalOperand {
             Self::Array { validity, .. } | Self::Constant { validity, .. } => validity.clone(),
             Self::Null(_) => Validity::AllInvalid,
         }
-    }
-}
-
-/// Choose the smallest lane width that can represent every sum or difference of two valid inputs.
-fn working_type(dtype: DecimalDType) -> DecimalType {
-    let precision = dtype.precision() as usize;
-    let max = <i256 as NativeDecimalType>::MAX_BY_PRECISION[precision];
-    let max_result = max
-        .checked_add(&max)
-        .vortex_expect("the sum of two valid decimal values must fit in i256");
-    smallest_value_type(&DecimalValue::from(max_result))
-}
-
-/// The smallest decimal value type that can represent `value`, regardless of its stored width.
-fn smallest_value_type(value: &DecimalValue) -> DecimalType {
-    if value.cast::<i8>().is_some() {
-        DecimalType::I8
-    } else if value.cast::<i16>().is_some() {
-        DecimalType::I16
-    } else if value.cast::<i32>().is_some() {
-        DecimalType::I32
-    } else if value.cast::<i64>().is_some() {
-        DecimalType::I64
-    } else if value.cast::<i128>().is_some() {
-        DecimalType::I128
-    } else {
-        DecimalType::I256
     }
 }
 
@@ -289,7 +243,7 @@ fn execute_decimal_at_widths<W, O>(
     lhs: &DecimalOperand,
     rhs: &DecimalOperand,
     op: NumericOperator,
-    decimal_dtype: DecimalDType,
+    result_decimal_dtype: DecimalDType,
     result_dtype: &DType,
     validity: Validity,
     valid_rows: &Mask,
@@ -303,7 +257,7 @@ where
         NumericOperator::Add => execute_decimal_typed::<W, O, DecimalAdd>(
             lhs,
             rhs,
-            decimal_dtype,
+            result_decimal_dtype,
             result_dtype,
             validity,
             valid_rows,
@@ -311,7 +265,7 @@ where
         NumericOperator::Sub => execute_decimal_typed::<W, O, DecimalSub>(
             lhs,
             rhs,
-            decimal_dtype,
+            result_decimal_dtype,
             result_dtype,
             validity,
             valid_rows,
@@ -326,7 +280,7 @@ where
 fn execute_decimal_typed<W, O, Op>(
     lhs: &DecimalOperand,
     rhs: &DecimalOperand,
-    decimal_dtype: DecimalDType,
+    result_decimal_dtype: DecimalDType,
     result_dtype: &DType,
     validity: Validity,
     valid_rows: &Mask,
@@ -338,7 +292,7 @@ where
     Op: CheckedDecimalOp,
 {
     let len = lhs.len();
-    let plan = DecimalOpPlan::<W>::new(decimal_dtype);
+    let plan = DecimalOpPlan::<W>::new(result_decimal_dtype);
 
     let checked = match (lhs, rhs) {
         (DecimalOperand::Array { values: lhs, .. }, DecimalOperand::Array { values: rhs, .. }) => {
@@ -374,7 +328,7 @@ where
             return Ok(ConstantArray::new(
                 Scalar::decimal(
                     DecimalValue::from(value),
-                    decimal_dtype,
+                    result_decimal_dtype,
                     result_dtype.nullability(),
                 ),
                 len,
@@ -389,7 +343,7 @@ where
 
     Ok(DecimalArray::new(
         checked.values,
-        decimal_dtype,
+        result_decimal_dtype,
         validity.union_nullability(result_dtype.nullability()),
     )
     .into_array())

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
@@ -32,7 +32,7 @@ use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrays::DecimalArray;
 use crate::arrays::decimal::DecimalArrayExt;
-use crate::arrays::decimal::widened_buffer;
+use crate::dtype::BigCast;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
 use crate::dtype::DecimalType;
@@ -62,42 +62,88 @@ pub(super) fn execute_numeric_decimal(
     let lhs = DecimalOperand::try_new(lhs, ctx)?;
     let rhs = DecimalOperand::try_new(rhs, ctx)?;
     let len = lhs.len();
-    if len != rhs.len() {
-        vortex_bail!(
-            "numeric operator requires equal lengths, got {} and {}",
-            len,
-            rhs.len()
-        );
-    }
+    debug_assert_eq!(len, rhs.len());
 
     let validity = lhs.validity().and(rhs.validity())?;
     let valid_rows = validity.execute_mask(len, ctx)?;
 
-    let work = working_type(&lhs, &rhs, decimal_dtype);
-    match_each_decimal_value_type!(work, |W| {
-        match op {
-            NumericOperator::Add => execute_decimal_typed::<W, DecimalAdd>(
-                &lhs,
-                &rhs,
-                decimal_dtype,
-                &result_dtype,
-                validity,
-                &valid_rows,
-            ),
-            NumericOperator::Sub => execute_decimal_typed::<W, DecimalSub>(
-                &lhs,
-                &rhs,
-                decimal_dtype,
-                &result_dtype,
-                validity,
-                &valid_rows,
-            ),
-            NumericOperator::Mul | NumericOperator::Div => vortex_bail!(
-                "numeric operator {:?} is not yet supported for decimal arrays",
-                op
-            ),
-        }
-    })
+    let work = working_type(decimal_dtype);
+    let output = DecimalType::smallest_decimal_value_type(&decimal_dtype);
+    match (work, output) {
+        (DecimalType::I8, DecimalType::I8) => execute_decimal_at_widths::<i8, i8>(
+            &lhs,
+            &rhs,
+            op,
+            decimal_dtype,
+            &result_dtype,
+            validity,
+            &valid_rows,
+        ),
+        (DecimalType::I16, DecimalType::I8) => execute_decimal_at_widths::<i16, i8>(
+            &lhs,
+            &rhs,
+            op,
+            decimal_dtype,
+            &result_dtype,
+            validity,
+            &valid_rows,
+        ),
+        (DecimalType::I16, DecimalType::I16) => execute_decimal_at_widths::<i16, i16>(
+            &lhs,
+            &rhs,
+            op,
+            decimal_dtype,
+            &result_dtype,
+            validity,
+            &valid_rows,
+        ),
+        (DecimalType::I32, DecimalType::I32) => execute_decimal_at_widths::<i32, i32>(
+            &lhs,
+            &rhs,
+            op,
+            decimal_dtype,
+            &result_dtype,
+            validity,
+            &valid_rows,
+        ),
+        (DecimalType::I64, DecimalType::I64) => execute_decimal_at_widths::<i64, i64>(
+            &lhs,
+            &rhs,
+            op,
+            decimal_dtype,
+            &result_dtype,
+            validity,
+            &valid_rows,
+        ),
+        (DecimalType::I128, DecimalType::I128) => execute_decimal_at_widths::<i128, i128>(
+            &lhs,
+            &rhs,
+            op,
+            decimal_dtype,
+            &result_dtype,
+            validity,
+            &valid_rows,
+        ),
+        (DecimalType::I256, DecimalType::I128) => execute_decimal_at_widths::<i256, i128>(
+            &lhs,
+            &rhs,
+            op,
+            decimal_dtype,
+            &result_dtype,
+            validity,
+            &valid_rows,
+        ),
+        (DecimalType::I256, DecimalType::I256) => execute_decimal_at_widths::<i256, i256>(
+            &lhs,
+            &rhs,
+            op,
+            decimal_dtype,
+            &result_dtype,
+            validity,
+            &valid_rows,
+        ),
+        _ => vortex_bail!("unsupported decimal working/output width combination: {work}/{output}"),
+    }
 }
 
 /// A decimal binary-operator operand: a canonical decimal array, a non-null constant, or an
@@ -152,20 +198,14 @@ impl DecimalOperand {
     }
 }
 
-/// Choose the lane width: wide enough for the operand storage and for every intermediate value
-/// that in-precision inputs can produce, capped at 256 bits.
-fn working_type(lhs: &DecimalOperand, rhs: &DecimalOperand, dtype: DecimalDType) -> DecimalType {
-    // The sum or difference of two p-digit values has at most p + 1 digits.
-    let needed_digits = (dtype.precision() + 1).min(<i256 as NativeDecimalType>::MAX_PRECISION);
-    let needed = DecimalType::smallest_decimal_value_type(&DecimalDType::new(needed_digits, 0));
-
-    let operand_type = |operand: &DecimalOperand| match operand {
-        DecimalOperand::Array { values, .. } => values.values_type(),
-        DecimalOperand::Constant { value, .. } => smallest_value_type(value),
-        DecimalOperand::Null(_) => DecimalType::I8,
-    };
-
-    needed.max(operand_type(lhs)).max(operand_type(rhs))
+/// Choose the smallest lane width that can represent every sum or difference of two valid inputs.
+fn working_type(dtype: DecimalDType) -> DecimalType {
+    let precision = dtype.precision() as usize;
+    let max = <i256 as NativeDecimalType>::MAX_BY_PRECISION[precision];
+    let max_result = max
+        .checked_add(&max)
+        .vortex_expect("the sum of two valid decimal values must fit in i256");
+    smallest_value_type(&DecimalValue::from(max_result))
 }
 
 /// The smallest decimal value type that can represent `value`, regardless of its stored width.
@@ -245,7 +285,45 @@ impl CheckedDecimalOp for DecimalSub {
     }
 }
 
-fn execute_decimal_typed<W, Op>(
+fn execute_decimal_at_widths<W, O>(
+    lhs: &DecimalOperand,
+    rhs: &DecimalOperand,
+    op: NumericOperator,
+    decimal_dtype: DecimalDType,
+    result_dtype: &DType,
+    validity: Validity,
+    valid_rows: &Mask,
+) -> VortexResult<ArrayRef>
+where
+    W: NativeDecimalType + CheckedAdd + CheckedSub,
+    O: NativeDecimalType,
+    DecimalValue: From<O>,
+{
+    match op {
+        NumericOperator::Add => execute_decimal_typed::<W, O, DecimalAdd>(
+            lhs,
+            rhs,
+            decimal_dtype,
+            result_dtype,
+            validity,
+            valid_rows,
+        ),
+        NumericOperator::Sub => execute_decimal_typed::<W, O, DecimalSub>(
+            lhs,
+            rhs,
+            decimal_dtype,
+            result_dtype,
+            validity,
+            valid_rows,
+        ),
+        NumericOperator::Mul | NumericOperator::Div => vortex_bail!(
+            "numeric operator {:?} is not yet supported for decimal arrays",
+            op
+        ),
+    }
+}
+
+fn execute_decimal_typed<W, O, Op>(
     lhs: &DecimalOperand,
     rhs: &DecimalOperand,
     decimal_dtype: DecimalDType,
@@ -255,7 +333,8 @@ fn execute_decimal_typed<W, Op>(
 ) -> VortexResult<ArrayRef>
 where
     W: NativeDecimalType + CheckedAdd + CheckedSub,
-    DecimalValue: From<W>,
+    O: NativeDecimalType,
+    DecimalValue: From<O>,
     Op: CheckedDecimalOp,
 {
     let len = lhs.len();
@@ -263,21 +342,25 @@ where
 
     let checked = match (lhs, rhs) {
         (DecimalOperand::Array { values: lhs, .. }, DecimalOperand::Array { values: rhs, .. }) => {
-            let lhs = widened_buffer::<W>(lhs);
-            let rhs = widened_buffer::<W>(rhs);
-            checked_decimal_lanes(len, valid_rows, |idx| {
-                Op::checked(lhs[idx], rhs[idx], &plan)
-            })
+            checked_decimal_arrays::<W, O, Op>(lhs, rhs, &plan, valid_rows)
         }
         (DecimalOperand::Array { values: lhs, .. }, DecimalOperand::Constant { value, .. }) => {
-            let lhs = widened_buffer::<W>(lhs);
             let rhs = typed_constant::<W>(value);
-            checked_decimal_lanes(len, valid_rows, |idx| Op::checked(lhs[idx], rhs, &plan))
+            match_each_decimal_value_type!(lhs.values_type(), |L| {
+                let lhs = lhs.buffer::<L>();
+                checked_decimal_lanes::<W, O, _>(len, valid_rows, |idx| {
+                    Op::checked(cast_work_value::<W, L>(lhs[idx]), rhs, &plan)
+                })
+            })
         }
         (DecimalOperand::Constant { value, .. }, DecimalOperand::Array { values: rhs, .. }) => {
             let lhs = typed_constant::<W>(value);
-            let rhs = widened_buffer::<W>(rhs);
-            checked_decimal_lanes(len, valid_rows, |idx| Op::checked(lhs, rhs[idx], &plan))
+            match_each_decimal_value_type!(rhs.values_type(), |R| {
+                let rhs = rhs.buffer::<R>();
+                checked_decimal_lanes::<W, O, _>(len, valid_rows, |idx| {
+                    Op::checked(lhs, cast_work_value::<W, R>(rhs[idx]), &plan)
+                })
+            })
         }
         (
             DecimalOperand::Constant { value: lhs, .. },
@@ -287,6 +370,7 @@ where
             let rhs = typed_constant::<W>(rhs);
             let value = Op::checked(lhs, rhs, &plan)
                 .ok_or_else(|| vortex_err!(InvalidArgument: "{}", Op::ERROR))?;
+            let value = cast_result_value::<W, O>(value);
             return Ok(ConstantArray::new(
                 Scalar::decimal(
                     DecimalValue::from(value),
@@ -297,7 +381,9 @@ where
             )
             .into_array());
         }
-        (DecimalOperand::Null(_), _) | (_, DecimalOperand::Null(_)) => CheckedValues::zeroed(len),
+        (DecimalOperand::Null(_), _) | (_, DecimalOperand::Null(_)) => {
+            CheckedValues::<O>::zeroed(len)
+        }
     };
     check_numeric_errors(checked.failed, Op::ERROR)?;
 
@@ -309,16 +395,63 @@ where
     .into_array())
 }
 
-fn checked_decimal_lanes<W, F>(len: usize, valid_rows: &Mask, checked_at: F) -> CheckedValues<W>
+fn checked_decimal_arrays<W, O, Op>(
+    lhs: &DecimalArray,
+    rhs: &DecimalArray,
+    plan: &DecimalOpPlan<W>,
+    valid_rows: &Mask,
+) -> CheckedValues<O>
+where
+    W: NativeDecimalType + CheckedAdd + CheckedSub,
+    O: NativeDecimalType,
+    Op: CheckedDecimalOp,
+{
+    let len = lhs.len();
+    debug_assert_eq!(len, rhs.len());
+    match_each_decimal_value_type!(lhs.values_type(), |L| {
+        let lhs = lhs.buffer::<L>();
+        match_each_decimal_value_type!(rhs.values_type(), |R| {
+            let rhs = rhs.buffer::<R>();
+            checked_decimal_lanes::<W, O, _>(len, valid_rows, |idx| {
+                Op::checked(
+                    cast_work_value::<W, L>(lhs[idx]),
+                    cast_work_value::<W, R>(rhs[idx]),
+                    plan,
+                )
+            })
+        })
+    })
+}
+
+fn checked_decimal_lanes<W, O, F>(
+    len: usize,
+    valid_rows: &Mask,
+    mut checked_at: F,
+) -> CheckedValues<O>
 where
     W: NativeDecimalType,
+    O: NativeDecimalType,
     F: FnMut(usize) -> Option<W>,
 {
     match valid_rows.bit_buffer() {
-        AllOr::All => checked_all_lanes(len, checked_at),
-        AllOr::None => CheckedValues::zeroed(len),
-        AllOr::Some(valid_bits) => checked_valid_lanes(len, valid_bits, checked_at),
+        AllOr::All => checked_all_lanes(len, |idx| checked_at(idx).map(cast_result_value::<W, O>)),
+        AllOr::None => CheckedValues::<O>::zeroed(len),
+        AllOr::Some(valid_bits) => checked_valid_lanes(len, valid_bits, |idx| {
+            checked_at(idx).map(cast_result_value::<W, O>)
+        }),
     }
+}
+
+#[inline(always)]
+fn cast_work_value<W: NativeDecimalType, T: NativeDecimalType>(value: T) -> W {
+    <W as BigCast>::from(value)
+        .vortex_expect("valid decimal input must fit the arithmetic working width")
+}
+
+#[inline(always)]
+fn cast_result_value<W: NativeDecimalType, O: NativeDecimalType>(value: W) -> O {
+    <O as BigCast>::from(value)
+        .vortex_expect("precision-checked decimal result must fit the output width")
 }
 
 fn typed_constant<W: NativeDecimalType>(value: &DecimalValue) -> W {

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
@@ -25,8 +25,8 @@ use super::CheckedValues;
 use super::check_numeric_errors;
 use super::checked_all_lanes;
 use super::checked_valid_lanes;
-use super::decimal_add_sub_result_dtype;
 use crate::ArrayRef;
+use crate::Columnar;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::Constant;
@@ -36,14 +36,33 @@ use crate::arrays::decimal::DecimalArrayExt;
 use crate::dtype::BigCast;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
-use crate::dtype::DecimalType;
+use crate::dtype::MAX_PRECISION;
 use crate::dtype::NativeDecimalType;
-use crate::dtype::i256;
 use crate::match_each_decimal_value_type;
 use crate::scalar::DecimalValue;
 use crate::scalar::NumericOperator;
 use crate::scalar::Scalar;
 use crate::validity::Validity;
+
+/// Derive the result decimal dtype for a numeric operation over same-typed operands.
+pub(crate) fn result_decimal_dtype(
+    input: DecimalDType,
+    op: NumericOperator,
+) -> VortexResult<DecimalDType> {
+    match op {
+        NumericOperator::Add | NumericOperator::Sub => {
+            // A p-digit Add/Sub result needs at most one carry digit:
+            // 2 * (10^p - 1) < 10^(p + 1). Follows Arrow rules.
+            Ok(DecimalDType::new(
+                input.precision().saturating_add(1).min(MAX_PRECISION),
+                input.scale(),
+            ))
+        }
+        NumericOperator::Mul | NumericOperator::Div => {
+            vortex_bail!("numeric operator {op} is not yet supported for decimal arrays")
+        }
+    }
+}
 
 /// Execute a numeric operation between two decimal arrays sharing a decimal dtype.
 pub(super) fn execute_numeric_decimal(
@@ -52,83 +71,61 @@ pub(super) fn execute_numeric_decimal(
     op: NumericOperator,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    let DType::Decimal(decimal_dtype, _) = lhs.dtype() else {
-        vortex_bail!("expected a decimal dtype, got {}", lhs.dtype());
-    };
-    let result_decimal_dtype = decimal_add_sub_result_dtype(*decimal_dtype);
+    let decimal_dtype = lhs
+        .dtype()
+        .as_decimal_opt()
+        .vortex_expect("inputs are both decimals");
+
+    let result_decimal_dtype = result_decimal_dtype(*decimal_dtype, op)?;
     let result_dtype = DType::Decimal(
         result_decimal_dtype,
         lhs.dtype().nullability() | rhs.dtype().nullability(),
     );
 
-    let lhs = DecimalOperand::try_new(lhs, ctx)?;
-    let rhs = DecimalOperand::try_new(rhs, ctx)?;
+    // Fast path for null constant arrays.
+    if is_null_constant(lhs) || is_null_constant(rhs) {
+        return Ok(null_result(&result_dtype, lhs.len()));
+    }
+
+    let Some(lhs) = DecimalOperand::try_new(lhs, ctx)? else {
+        return Ok(null_result(&result_dtype, lhs.len()));
+    };
+    let Some(rhs) = DecimalOperand::try_new(rhs, ctx)? else {
+        return Ok(null_result(&result_dtype, rhs.len()));
+    };
     let len = lhs.len();
     debug_assert_eq!(len, rhs.len());
 
     let validity = lhs.validity().and(rhs.validity())?;
     let valid_rows = validity.execute_mask(len, ctx)?;
 
-    match DecimalType::smallest_decimal_value_type(&result_decimal_dtype) {
-        DecimalType::I8 => execute_decimal_at_widths::<i8, i8>(
-            &lhs,
-            &rhs,
-            op,
-            result_decimal_dtype,
-            &result_dtype,
-            validity,
-            &valid_rows,
-        ),
-        DecimalType::I16 => execute_decimal_at_widths::<i16, i16>(
-            &lhs,
-            &rhs,
-            op,
-            result_decimal_dtype,
-            &result_dtype,
-            validity,
-            &valid_rows,
-        ),
-        DecimalType::I32 => execute_decimal_at_widths::<i32, i32>(
-            &lhs,
-            &rhs,
-            op,
-            result_decimal_dtype,
-            &result_dtype,
-            validity,
-            &valid_rows,
-        ),
-        DecimalType::I64 => execute_decimal_at_widths::<i64, i64>(
-            &lhs,
-            &rhs,
-            op,
-            result_decimal_dtype,
-            &result_dtype,
-            validity,
-            &valid_rows,
-        ),
-        DecimalType::I128 => execute_decimal_at_widths::<i128, i128>(
-            &lhs,
-            &rhs,
-            op,
-            result_decimal_dtype,
-            &result_dtype,
-            validity,
-            &valid_rows,
-        ),
-        DecimalType::I256 => execute_decimal_at_widths::<i256, i256>(
-            &lhs,
-            &rhs,
-            op,
-            result_decimal_dtype,
-            &result_dtype,
-            validity,
-            &valid_rows,
-        ),
-    }
+    match_each_decimal_value_type!(
+        DecimalType::smallest_decimal_value_type(&result_decimal_dtype),
+        |W| {
+            execute_decimal_at_widths::<W, W>(
+                &lhs,
+                &rhs,
+                op,
+                result_decimal_dtype,
+                &result_dtype,
+                validity,
+                &valid_rows,
+            )
+        }
+    )
 }
 
-/// A decimal binary-operator operand: a canonical decimal array, a non-null constant, or an
-/// all-null constant.
+fn is_null_constant(array: &ArrayRef) -> bool {
+    array
+        .as_opt::<Constant>()
+        .is_some_and(|constant| constant.scalar().is_null())
+}
+
+fn null_result(dtype: &DType, len: usize) -> ArrayRef {
+    ConstantArray::new(Scalar::null(dtype.clone()), len).into_array()
+}
+
+/// A decimal binary-operator operand: a canonical decimal array or a non-null constant.
 enum DecimalOperand {
     Array {
         values: DecimalArray,
@@ -139,66 +136,71 @@ enum DecimalOperand {
         len: usize,
         validity: Validity,
     },
-    Null(usize),
 }
 
 impl DecimalOperand {
-    fn try_new(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        if let Some(constant) = array.as_opt::<Constant>() {
-            return Ok(match constant.scalar().as_decimal().decimal_value() {
-                Some(value) => Self::Constant {
+    fn try_new(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Option<Self>> {
+        let columnar = array.clone().execute::<Columnar>(ctx)?;
+
+        match columnar {
+            Columnar::Constant(array) => match array.scalar().as_decimal().decimal_value() {
+                Some(value) => Ok(Some(Self::Constant {
                     value,
                     len: array.len(),
-                    validity: if constant.scalar().dtype().is_nullable() {
+                    validity: if array.scalar().dtype().is_nullable() {
                         Validity::AllValid
                     } else {
                         Validity::NonNullable
                     },
-                },
-                None => Self::Null(array.len()),
-            });
+                })),
+                None => Ok(None),
+            },
+            Columnar::Canonical(array) => {
+                let values = array.as_decimal().to_owned();
+                let validity = values.validity()?;
+                Ok(Some(Self::Array { values, validity }))
+            }
         }
-
-        let values = array.clone().execute::<DecimalArray>(ctx)?;
-        let validity = values.validity()?;
-        Ok(Self::Array { values, validity })
     }
 
     fn len(&self) -> usize {
         match self {
             Self::Array { values, .. } => values.len(),
-            Self::Constant { len, .. } | Self::Null(len) => *len,
+            Self::Constant { len, .. } => *len,
         }
     }
 
     fn validity(&self) -> Validity {
         match self {
             Self::Array { validity, .. } | Self::Constant { validity, .. } => validity.clone(),
-            Self::Null(_) => Validity::AllInvalid,
         }
     }
 }
 
-/// Per-execution constants for checked decimal lane operations at working width `W`.
-struct DecimalOpPlan<W> {
+/// Per-execution bounds for checked decimal lane operations at working width `W`.
+///
+/// Native-width checked arithmetic only detects overflow of `W`, whose range may exceed the
+/// declared decimal precision. In particular, `i256` can represent values outside precision 76,
+/// so every native result must also be checked against these logical bounds.
+struct DecimalValueBounds<W> {
     /// Inclusive stored-value bounds implied by the result precision.
-    prec_min: W,
-    prec_max: W,
+    lower_bound: W,
+    upper_bound: W,
 }
 
-impl<W: NativeDecimalType> DecimalOpPlan<W> {
+impl<W: NativeDecimalType> DecimalValueBounds<W> {
     fn new(dtype: DecimalDType) -> Self {
         let precision = dtype.precision() as usize;
         Self {
-            prec_min: W::MIN_BY_PRECISION[precision],
-            prec_max: W::MAX_BY_PRECISION[precision],
+            lower_bound: W::MIN_BY_PRECISION[precision],
+            upper_bound: W::MAX_BY_PRECISION[precision],
         }
     }
 
     /// Bounds-check a candidate result against the result precision.
     #[inline(always)]
     fn in_precision(&self, value: W) -> Option<W> {
-        (self.prec_min <= value && value <= self.prec_max).then_some(value)
+        (self.lower_bound <= value && value <= self.upper_bound).then_some(value)
     }
 }
 
@@ -206,20 +208,20 @@ impl<W: NativeDecimalType> DecimalOpPlan<W> {
 trait CheckedDecimalOp {
     const ERROR: &'static str;
 
-    fn checked<W>(lhs: W, rhs: W, plan: &DecimalOpPlan<W>) -> Option<W>
+    fn apply<W>(lhs: W, rhs: W, plan: &DecimalValueBounds<W>) -> Option<W>
     where
         W: NativeDecimalType + CheckedAdd + CheckedSub;
 }
 
-struct DecimalAdd;
+struct CheckedDecimalAdd;
 
-struct DecimalSub;
+struct CheckedDecimalSub;
 
-impl CheckedDecimalOp for DecimalAdd {
+impl CheckedDecimalOp for CheckedDecimalAdd {
     const ERROR: &'static str = "decimal overflow in checked add";
 
     #[inline(always)]
-    fn checked<W>(lhs: W, rhs: W, plan: &DecimalOpPlan<W>) -> Option<W>
+    fn apply<W>(lhs: W, rhs: W, plan: &DecimalValueBounds<W>) -> Option<W>
     where
         W: NativeDecimalType + CheckedAdd + CheckedSub,
     {
@@ -227,11 +229,11 @@ impl CheckedDecimalOp for DecimalAdd {
     }
 }
 
-impl CheckedDecimalOp for DecimalSub {
+impl CheckedDecimalOp for CheckedDecimalSub {
     const ERROR: &'static str = "decimal overflow in checked sub";
 
     #[inline(always)]
-    fn checked<W>(lhs: W, rhs: W, plan: &DecimalOpPlan<W>) -> Option<W>
+    fn apply<W>(lhs: W, rhs: W, plan: &DecimalValueBounds<W>) -> Option<W>
     where
         W: NativeDecimalType + CheckedAdd + CheckedSub,
     {
@@ -253,23 +255,22 @@ where
     O: NativeDecimalType,
     DecimalValue: From<O>,
 {
+    macro_rules! execute_typed {
+        ($Op:ty) => {
+            execute_decimal_typed::<W, O, $Op>(
+                lhs,
+                rhs,
+                result_decimal_dtype,
+                result_dtype,
+                validity,
+                valid_rows,
+            )
+        };
+    }
+
     match op {
-        NumericOperator::Add => execute_decimal_typed::<W, O, DecimalAdd>(
-            lhs,
-            rhs,
-            result_decimal_dtype,
-            result_dtype,
-            validity,
-            valid_rows,
-        ),
-        NumericOperator::Sub => execute_decimal_typed::<W, O, DecimalSub>(
-            lhs,
-            rhs,
-            result_decimal_dtype,
-            result_dtype,
-            validity,
-            valid_rows,
-        ),
+        NumericOperator::Add => execute_typed!(CheckedDecimalAdd),
+        NumericOperator::Sub => execute_typed!(CheckedDecimalSub),
         NumericOperator::Mul | NumericOperator::Div => vortex_bail!(
             "numeric operator {:?} is not yet supported for decimal arrays",
             op
@@ -292,7 +293,7 @@ where
     Op: CheckedDecimalOp,
 {
     let len = lhs.len();
-    let plan = DecimalOpPlan::<W>::new(result_decimal_dtype);
+    let plan = DecimalValueBounds::<W>::new(result_decimal_dtype);
 
     let checked = match (lhs, rhs) {
         (DecimalOperand::Array { values: lhs, .. }, DecimalOperand::Array { values: rhs, .. }) => {
@@ -303,7 +304,7 @@ where
             match_each_decimal_value_type!(lhs.values_type(), |L| {
                 let lhs = lhs.buffer::<L>();
                 checked_decimal_lanes::<W, O, _>(len, valid_rows, |idx| {
-                    Op::checked(cast_work_value::<W, L>(lhs[idx]), rhs, &plan)
+                    Op::apply(cast_work_value::<W, L>(lhs[idx]), rhs, &plan)
                 })
             })
         }
@@ -312,7 +313,7 @@ where
             match_each_decimal_value_type!(rhs.values_type(), |R| {
                 let rhs = rhs.buffer::<R>();
                 checked_decimal_lanes::<W, O, _>(len, valid_rows, |idx| {
-                    Op::checked(lhs, cast_work_value::<W, R>(rhs[idx]), &plan)
+                    Op::apply(lhs, cast_work_value::<W, R>(rhs[idx]), &plan)
                 })
             })
         }
@@ -322,7 +323,7 @@ where
         ) => {
             let lhs = typed_constant::<W>(lhs);
             let rhs = typed_constant::<W>(rhs);
-            let value = Op::checked(lhs, rhs, &plan)
+            let value = Op::apply(lhs, rhs, &plan)
                 .ok_or_else(|| vortex_err!(InvalidArgument: "{}", Op::ERROR))?;
             let value = cast_result_value::<W, O>(value);
             return Ok(ConstantArray::new(
@@ -334,9 +335,6 @@ where
                 len,
             )
             .into_array());
-        }
-        (DecimalOperand::Null(_), _) | (_, DecimalOperand::Null(_)) => {
-            CheckedValues::<O>::zeroed(len)
         }
     };
     check_numeric_errors(checked.failed, Op::ERROR)?;
@@ -352,7 +350,7 @@ where
 fn checked_decimal_arrays<W, O, Op>(
     lhs: &DecimalArray,
     rhs: &DecimalArray,
-    plan: &DecimalOpPlan<W>,
+    plan: &DecimalValueBounds<W>,
     valid_rows: &Mask,
 ) -> CheckedValues<O>
 where
@@ -367,7 +365,7 @@ where
         match_each_decimal_value_type!(rhs.values_type(), |R| {
             let rhs = rhs.buffer::<R>();
             checked_decimal_lanes::<W, O, _>(len, valid_rows, |idx| {
-                Op::checked(
+                Op::apply(
                     cast_work_value::<W, L>(lhs[idx]),
                     cast_work_value::<W, R>(rhs[idx]),
                     plan,

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Native execution of the arithmetic operators over decimal arrays.
+//!
+//! Both operands share a logical [`DecimalDType`] (equal precision and scale) and the result
+//! keeps that dtype: fixed-point arithmetic at the shared scale. Add and Sub apply directly to
+//! the unscaled stored integers and are exact; Mul and Div require rescaling and are not yet
+//! implemented.
+//!
+//! Lanes execute in a working width chosen so that in-precision inputs cannot spuriously
+//! overflow an intermediate value. An operation that overflows the result precision on a valid
+//! lane is an error; invalid lanes never error.
+
+use num_traits::CheckedAdd;
+use num_traits::CheckedSub;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
+use vortex_mask::AllOr;
+use vortex_mask::Mask;
+
+use super::CheckedValues;
+use super::check_numeric_errors;
+use super::checked_all_lanes;
+use super::checked_valid_lanes;
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::IntoArray;
+use crate::arrays::Constant;
+use crate::arrays::ConstantArray;
+use crate::arrays::DecimalArray;
+use crate::arrays::decimal::DecimalArrayExt;
+use crate::arrays::decimal::widened_buffer;
+use crate::dtype::DType;
+use crate::dtype::DecimalDType;
+use crate::dtype::DecimalType;
+use crate::dtype::NativeDecimalType;
+use crate::dtype::i256;
+use crate::match_each_decimal_value_type;
+use crate::scalar::DecimalValue;
+use crate::scalar::NumericOperator;
+use crate::scalar::Scalar;
+use crate::validity::Validity;
+
+/// Execute a numeric operation between two decimal arrays sharing a decimal dtype.
+pub(super) fn execute_numeric_decimal(
+    lhs: &ArrayRef,
+    rhs: &ArrayRef,
+    op: NumericOperator,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let DType::Decimal(decimal_dtype, _) = lhs.dtype() else {
+        vortex_bail!("expected a decimal dtype, got {}", lhs.dtype());
+    };
+    let decimal_dtype = *decimal_dtype;
+    let result_dtype = lhs
+        .dtype()
+        .with_nullability(lhs.dtype().nullability() | rhs.dtype().nullability());
+
+    let lhs = DecimalOperand::try_new(lhs, ctx)?;
+    let rhs = DecimalOperand::try_new(rhs, ctx)?;
+    let len = lhs.len();
+    if len != rhs.len() {
+        vortex_bail!(
+            "numeric operator requires equal lengths, got {} and {}",
+            len,
+            rhs.len()
+        );
+    }
+
+    let validity = lhs.validity().and(rhs.validity())?;
+    let valid_rows = validity.execute_mask(len, ctx)?;
+
+    let work = working_type(&lhs, &rhs, decimal_dtype);
+    match_each_decimal_value_type!(work, |W| {
+        match op {
+            NumericOperator::Add => execute_decimal_typed::<W, DecimalAdd>(
+                &lhs,
+                &rhs,
+                decimal_dtype,
+                &result_dtype,
+                validity,
+                &valid_rows,
+            ),
+            NumericOperator::Sub => execute_decimal_typed::<W, DecimalSub>(
+                &lhs,
+                &rhs,
+                decimal_dtype,
+                &result_dtype,
+                validity,
+                &valid_rows,
+            ),
+            NumericOperator::Mul | NumericOperator::Div => vortex_bail!(
+                "numeric operator {:?} is not yet supported for decimal arrays",
+                op
+            ),
+        }
+    })
+}
+
+/// A decimal binary-operator operand: a canonical decimal array, a non-null constant, or an
+/// all-null constant.
+enum DecimalOperand {
+    Array {
+        values: DecimalArray,
+        validity: Validity,
+    },
+    Constant {
+        value: DecimalValue,
+        len: usize,
+        validity: Validity,
+    },
+    Null(usize),
+}
+
+impl DecimalOperand {
+    fn try_new(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+        if let Some(constant) = array.as_opt::<Constant>() {
+            return Ok(match constant.scalar().as_decimal().decimal_value() {
+                Some(value) => Self::Constant {
+                    value,
+                    len: array.len(),
+                    validity: if constant.scalar().dtype().is_nullable() {
+                        Validity::AllValid
+                    } else {
+                        Validity::NonNullable
+                    },
+                },
+                None => Self::Null(array.len()),
+            });
+        }
+
+        let values = array.clone().execute::<DecimalArray>(ctx)?;
+        let validity = values.validity()?;
+        Ok(Self::Array { values, validity })
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Array { values, .. } => values.len(),
+            Self::Constant { len, .. } | Self::Null(len) => *len,
+        }
+    }
+
+    fn validity(&self) -> Validity {
+        match self {
+            Self::Array { validity, .. } | Self::Constant { validity, .. } => validity.clone(),
+            Self::Null(_) => Validity::AllInvalid,
+        }
+    }
+}
+
+/// Choose the lane width: wide enough for the operand storage and for every intermediate value
+/// that in-precision inputs can produce, capped at 256 bits.
+fn working_type(lhs: &DecimalOperand, rhs: &DecimalOperand, dtype: DecimalDType) -> DecimalType {
+    // The sum or difference of two p-digit values has at most p + 1 digits.
+    let needed_digits = (dtype.precision() + 1).min(<i256 as NativeDecimalType>::MAX_PRECISION);
+    let needed = DecimalType::smallest_decimal_value_type(&DecimalDType::new(needed_digits, 0));
+
+    let operand_type = |operand: &DecimalOperand| match operand {
+        DecimalOperand::Array { values, .. } => values.values_type(),
+        DecimalOperand::Constant { value, .. } => smallest_value_type(value),
+        DecimalOperand::Null(_) => DecimalType::I8,
+    };
+
+    needed.max(operand_type(lhs)).max(operand_type(rhs))
+}
+
+/// The smallest decimal value type that can represent `value`, regardless of its stored width.
+fn smallest_value_type(value: &DecimalValue) -> DecimalType {
+    if value.cast::<i8>().is_some() {
+        DecimalType::I8
+    } else if value.cast::<i16>().is_some() {
+        DecimalType::I16
+    } else if value.cast::<i32>().is_some() {
+        DecimalType::I32
+    } else if value.cast::<i64>().is_some() {
+        DecimalType::I64
+    } else if value.cast::<i128>().is_some() {
+        DecimalType::I128
+    } else {
+        DecimalType::I256
+    }
+}
+
+/// Per-execution constants for checked decimal lane operations at working width `W`.
+struct DecimalOpPlan<W> {
+    /// Inclusive stored-value bounds implied by the result precision.
+    prec_min: W,
+    prec_max: W,
+}
+
+impl<W: NativeDecimalType> DecimalOpPlan<W> {
+    fn new(dtype: DecimalDType) -> Self {
+        let precision = dtype.precision() as usize;
+        Self {
+            prec_min: W::MIN_BY_PRECISION[precision],
+            prec_max: W::MAX_BY_PRECISION[precision],
+        }
+    }
+
+    /// Bounds-check a candidate result against the result precision.
+    #[inline(always)]
+    fn in_precision(&self, value: W) -> Option<W> {
+        (self.prec_min <= value && value <= self.prec_max).then_some(value)
+    }
+}
+
+/// A checked fixed-point decimal operation on unscaled values at working width `W`.
+trait CheckedDecimalOp {
+    const ERROR: &'static str;
+
+    fn checked<W>(lhs: W, rhs: W, plan: &DecimalOpPlan<W>) -> Option<W>
+    where
+        W: NativeDecimalType + CheckedAdd + CheckedSub;
+}
+
+struct DecimalAdd;
+
+struct DecimalSub;
+
+impl CheckedDecimalOp for DecimalAdd {
+    const ERROR: &'static str = "decimal overflow in checked add";
+
+    #[inline(always)]
+    fn checked<W>(lhs: W, rhs: W, plan: &DecimalOpPlan<W>) -> Option<W>
+    where
+        W: NativeDecimalType + CheckedAdd + CheckedSub,
+    {
+        plan.in_precision(lhs.checked_add(&rhs)?)
+    }
+}
+
+impl CheckedDecimalOp for DecimalSub {
+    const ERROR: &'static str = "decimal overflow in checked sub";
+
+    #[inline(always)]
+    fn checked<W>(lhs: W, rhs: W, plan: &DecimalOpPlan<W>) -> Option<W>
+    where
+        W: NativeDecimalType + CheckedAdd + CheckedSub,
+    {
+        plan.in_precision(lhs.checked_sub(&rhs)?)
+    }
+}
+
+fn execute_decimal_typed<W, Op>(
+    lhs: &DecimalOperand,
+    rhs: &DecimalOperand,
+    decimal_dtype: DecimalDType,
+    result_dtype: &DType,
+    validity: Validity,
+    valid_rows: &Mask,
+) -> VortexResult<ArrayRef>
+where
+    W: NativeDecimalType + CheckedAdd + CheckedSub,
+    DecimalValue: From<W>,
+    Op: CheckedDecimalOp,
+{
+    let len = lhs.len();
+    let plan = DecimalOpPlan::<W>::new(decimal_dtype);
+
+    let checked = match (lhs, rhs) {
+        (DecimalOperand::Array { values: lhs, .. }, DecimalOperand::Array { values: rhs, .. }) => {
+            let lhs = widened_buffer::<W>(lhs);
+            let rhs = widened_buffer::<W>(rhs);
+            checked_decimal_lanes(len, valid_rows, |idx| {
+                Op::checked(lhs[idx], rhs[idx], &plan)
+            })
+        }
+        (DecimalOperand::Array { values: lhs, .. }, DecimalOperand::Constant { value, .. }) => {
+            let lhs = widened_buffer::<W>(lhs);
+            let rhs = typed_constant::<W>(value);
+            checked_decimal_lanes(len, valid_rows, |idx| Op::checked(lhs[idx], rhs, &plan))
+        }
+        (DecimalOperand::Constant { value, .. }, DecimalOperand::Array { values: rhs, .. }) => {
+            let lhs = typed_constant::<W>(value);
+            let rhs = widened_buffer::<W>(rhs);
+            checked_decimal_lanes(len, valid_rows, |idx| Op::checked(lhs, rhs[idx], &plan))
+        }
+        (
+            DecimalOperand::Constant { value: lhs, .. },
+            DecimalOperand::Constant { value: rhs, .. },
+        ) => {
+            let lhs = typed_constant::<W>(lhs);
+            let rhs = typed_constant::<W>(rhs);
+            let value = Op::checked(lhs, rhs, &plan)
+                .ok_or_else(|| vortex_err!(InvalidArgument: "{}", Op::ERROR))?;
+            return Ok(ConstantArray::new(
+                Scalar::decimal(
+                    DecimalValue::from(value),
+                    decimal_dtype,
+                    result_dtype.nullability(),
+                ),
+                len,
+            )
+            .into_array());
+        }
+        (DecimalOperand::Null(_), _) | (_, DecimalOperand::Null(_)) => CheckedValues::zeroed(len),
+    };
+    check_numeric_errors(checked.failed, Op::ERROR)?;
+
+    Ok(DecimalArray::new(
+        checked.values,
+        decimal_dtype,
+        validity.union_nullability(result_dtype.nullability()),
+    )
+    .into_array())
+}
+
+fn checked_decimal_lanes<W, F>(len: usize, valid_rows: &Mask, checked_at: F) -> CheckedValues<W>
+where
+    W: NativeDecimalType,
+    F: FnMut(usize) -> Option<W>,
+{
+    match valid_rows.bit_buffer() {
+        AllOr::All => checked_all_lanes(len, checked_at),
+        AllOr::None => CheckedValues::zeroed(len),
+        AllOr::Some(valid_bits) => checked_valid_lanes(len, valid_bits, checked_at),
+    }
+}
+
+fn typed_constant<W: NativeDecimalType>(value: &DecimalValue) -> W {
+    value
+        .cast::<W>()
+        .vortex_expect("the working width must be able to represent the constant")
+}

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
@@ -6,20 +6,19 @@
 //!
 //! [`Binary`]: super::Binary
 
+mod checked;
 mod decimal;
 mod primitive;
 #[cfg(test)]
 mod tests;
 
+use decimal::execute_numeric_decimal;
 use decimal::result_decimal_dtype;
 pub(crate) use decimal::result_decimal_dtype as numeric_op_result_decimal_dtype;
 pub(crate) use primitive::PrimitiveOperand;
-use vortex_buffer::BitBuffer;
-use vortex_buffer::Buffer;
-use vortex_buffer::BufferMut;
+use primitive::execute_numeric_primitive;
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
-use vortex_error::vortex_err;
+use vortex_error::vortex_ensure;
 
 use crate::ArrayRef;
 use crate::Canonical;
@@ -35,195 +34,51 @@ pub(crate) fn execute_numeric(
     op: NumericOperator,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    if !lhs.dtype().eq_ignore_nullability(rhs.dtype()) {
-        vortex_bail!(
-            "numeric operator requires matching types, got {} and {}",
-            lhs.dtype(),
-            rhs.dtype()
-        );
-    }
+    vortex_ensure!(
+        lhs.dtype().eq_ignore_nullability(rhs.dtype()),
+        "numeric operator requires matching types, got {} and {}",
+        lhs.dtype(),
+        rhs.dtype()
+    );
 
-    if lhs.len() != rhs.len() {
-        vortex_bail!(
-            "numeric operator requires equal lengths, got {} and {}",
-            lhs.len(),
-            rhs.len()
-        );
-    }
+    let dtype = lhs.dtype();
+    vortex_ensure!(
+        matches!(dtype, DType::Primitive(..) | DType::Decimal(..)),
+        "numeric operator is not supported for dtype {}",
+        dtype
+    );
+
+    vortex_ensure!(
+        lhs.len() == rhs.len(),
+        "numeric operator requires equal lengths, got {} and {}",
+        lhs.len(),
+        rhs.len()
+    );
 
     if lhs.is_empty() {
-        let nullability = lhs.dtype().nullability() | rhs.dtype().nullability();
-        let result_dtype = match lhs.dtype() {
-            DType::Primitive(..) => lhs.dtype().with_nullability(nullability),
-            DType::Decimal(decimal_dtype, _) => {
-                debug_assert!(matches!(op, NumericOperator::Add | NumericOperator::Sub));
-                DType::Decimal(result_decimal_dtype(*decimal_dtype, op)?, nullability)
-            }
-            dtype => vortex_bail!("numeric operator is not supported for dtype {}", dtype),
-        };
-        return Ok(Canonical::empty(&result_dtype).into_array());
+        return build_empty_result(lhs, rhs, op);
     }
 
-    match lhs.dtype() {
-        DType::Primitive(..) => primitive::execute_numeric_primitive(lhs, rhs, op, ctx),
-        DType::Decimal(..) => decimal::execute_numeric_decimal(lhs, rhs, op, ctx),
-        dtype => vortex_bail!("numeric operator is not supported for dtype {}", dtype),
+    match dtype {
+        DType::Primitive(..) => execute_numeric_primitive(lhs, rhs, op, ctx),
+        DType::Decimal(..) => execute_numeric_decimal(lhs, rhs, op, ctx),
+        _ => unreachable!("dtype is either Primitive or Decimal"),
     }
 }
 
-/// The values produced by a checked lane loop, plus whether any lane failed.
-struct CheckedValues<T> {
-    values: Buffer<T>,
-    failed: bool,
-}
-
-impl<T> CheckedValues<T> {
-    fn zeroed(len: usize) -> Self {
-        Self {
-            values: Buffer::<T>::zeroed(len),
-            failed: false,
+fn build_empty_result(
+    lhs: &ArrayRef,
+    rhs: &ArrayRef,
+    op: NumericOperator,
+) -> VortexResult<ArrayRef> {
+    let nullability = lhs.dtype().nullability() | rhs.dtype().nullability();
+    let result_dtype = match lhs.dtype() {
+        DType::Primitive(..) => lhs.dtype().with_nullability(nullability),
+        DType::Decimal(decimal_dtype, _) => {
+            DType::Decimal(result_decimal_dtype(*decimal_dtype, op)?, nullability)
         }
-    }
+        _ => unreachable!("dtype is either Primitive or Decimal"),
+    };
 
-    fn failed(len: usize) -> Self {
-        Self {
-            values: Buffer::<T>::zeroed(len),
-            failed: true,
-        }
-    }
-}
-
-// Checked one-pass ops delay early exit until the end of a small block. This
-// keeps the loop generic while avoiding a branch-driven exit decision on every
-// lane; it is deliberately independent of mask density or input length.
-const CHECKED_BLOCK_LANES: usize = 16;
-
-fn checked_all_lanes<T, F>(len: usize, mut checked_at: F) -> CheckedValues<T>
-where
-    T: Default,
-    F: FnMut(usize) -> Option<T>,
-{
-    let mut values = BufferMut::<T>::with_capacity(len);
-    let mut base = 0;
-
-    while base + CHECKED_BLOCK_LANES <= len {
-        let mut block_failed = false;
-        for idx in base..base + CHECKED_BLOCK_LANES {
-            match checked_at(idx) {
-                Some(value) => {
-                    // SAFETY: the buffer is allocated with capacity `len`, and
-                    // this loop pushes at most one value for each `idx`.
-                    unsafe { values.push_unchecked(value) };
-                }
-                None => {
-                    block_failed = true;
-                    // SAFETY: the buffer is allocated with capacity `len`, and
-                    // this loop pushes at most one value for each `idx`.
-                    unsafe { values.push_unchecked(T::default()) };
-                }
-            }
-        }
-
-        if block_failed {
-            return CheckedValues::failed(len);
-        }
-        base += CHECKED_BLOCK_LANES;
-    }
-
-    for idx in base..len {
-        let Some(value) = checked_at(idx) else {
-            return CheckedValues::failed(len);
-        };
-        // SAFETY: the buffer is allocated with capacity `len`, and this loop
-        // pushes at most one value for each `idx`.
-        unsafe { values.push_unchecked(value) };
-    }
-
-    CheckedValues {
-        values: values.freeze(),
-        failed: false,
-    }
-}
-
-fn checked_valid_lanes<T, F>(
-    len: usize,
-    valid_bits: &BitBuffer,
-    mut checked_at: F,
-) -> CheckedValues<T>
-where
-    T: Default,
-    F: FnMut(usize) -> Option<T>,
-{
-    let mut values = BufferMut::<T>::zeroed(len);
-    let mut failed = false;
-    {
-        let values = values.as_mut_slice();
-        for_each_valid_idx(len, valid_bits, |idx| {
-            let Some(value) = checked_at(idx) else {
-                failed = true;
-                return false;
-            };
-            values[idx] = value;
-            true
-        });
-    }
-
-    CheckedValues {
-        values: values.freeze(),
-        failed,
-    }
-}
-
-fn any_valid_error<F>(len: usize, valid_bits: &BitBuffer, is_error: F) -> bool
-where
-    F: Fn(usize) -> bool,
-{
-    !for_each_valid_idx(len, valid_bits, |idx| !is_error(idx))
-}
-
-fn for_each_valid_idx<F>(len: usize, valid_bits: &BitBuffer, mut f: F) -> bool
-where
-    F: FnMut(usize) -> bool,
-{
-    debug_assert_eq!(len, valid_bits.len());
-
-    for (word_idx, valid_word) in valid_bits.chunks().iter_padded().enumerate() {
-        if valid_word == 0 {
-            continue;
-        }
-
-        let offset = word_idx * 64;
-        let lanes = len.saturating_sub(offset).min(64);
-        if lanes == 64 && valid_word == u64::MAX {
-            for bit_idx in 0..64 {
-                if !f(offset + bit_idx) {
-                    return false;
-                }
-            }
-            continue;
-        }
-
-        let mut valid_word = if lanes == 64 {
-            valid_word
-        } else {
-            valid_word & ((1u64 << lanes) - 1)
-        };
-        while valid_word != 0 {
-            let bit_idx = valid_word.trailing_zeros() as usize;
-            if !f(offset + bit_idx) {
-                return false;
-            }
-            valid_word &= valid_word - 1;
-        }
-    }
-
-    true
-}
-
-fn check_numeric_errors(failed: bool, error: &'static str) -> VortexResult<()> {
-    if failed {
-        return Err(vortex_err!(InvalidArgument: "{}", error));
-    }
-
-    Ok(())
+    Ok(Canonical::empty(&result_dtype).into_array())
 }

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
@@ -6,6 +6,7 @@
 //!
 //! [`Binary`]: super::Binary
 
+mod decimal;
 mod primitive;
 #[cfg(test)]
 mod tests;
@@ -15,10 +16,12 @@ use vortex_buffer::BitBuffer;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::dtype::DType;
 use crate::scalar::NumericOperator;
 
 /// Execute a numeric operation between two arrays.
@@ -28,7 +31,19 @@ pub(crate) fn execute_numeric(
     op: NumericOperator,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    primitive::execute_numeric_primitive(lhs, rhs, op, ctx)
+    if !lhs.dtype().eq_ignore_nullability(rhs.dtype()) {
+        vortex_bail!(
+            "numeric operator requires matching types, got {} and {}",
+            lhs.dtype(),
+            rhs.dtype()
+        );
+    }
+
+    match lhs.dtype() {
+        DType::Primitive(..) => primitive::execute_numeric_primitive(lhs, rhs, op, ctx),
+        DType::Decimal(..) => decimal::execute_numeric_decimal(lhs, rhs, op, ctx),
+        dtype => vortex_bail!("numeric operator is not supported for dtype {}", dtype),
+    }
 }
 
 /// The values produced by a checked lane loop, plus whether any lane failed.

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Native execution of the arithmetic operators (Add/Sub/Mul/Div) of the [`Binary`] scalar
+//! function. There is no Arrow fallback.
+//!
+//! [`Binary`]: super::Binary
+
+mod primitive;
+#[cfg(test)]
+mod tests;
+
+pub(crate) use primitive::PrimitiveOperand;
+use vortex_buffer::BitBuffer;
+use vortex_buffer::Buffer;
+use vortex_buffer::BufferMut;
+use vortex_error::VortexResult;
+use vortex_error::vortex_err;
+
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::scalar::NumericOperator;
+
+/// Execute a numeric operation between two arrays.
+pub(crate) fn execute_numeric(
+    lhs: &ArrayRef,
+    rhs: &ArrayRef,
+    op: NumericOperator,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    primitive::execute_numeric_primitive(lhs, rhs, op, ctx)
+}
+
+/// The values produced by a checked lane loop, plus whether any lane failed.
+struct CheckedValues<T> {
+    values: Buffer<T>,
+    failed: bool,
+}
+
+impl<T> CheckedValues<T> {
+    fn zeroed(len: usize) -> Self {
+        Self {
+            values: Buffer::<T>::zeroed(len),
+            failed: false,
+        }
+    }
+
+    fn failed(len: usize) -> Self {
+        Self {
+            values: Buffer::<T>::zeroed(len),
+            failed: true,
+        }
+    }
+}
+
+// Checked one-pass ops delay early exit until the end of a small block. This
+// keeps the loop generic while avoiding a branch-driven exit decision on every
+// lane; it is deliberately independent of mask density or input length.
+const CHECKED_BLOCK_LANES: usize = 16;
+
+fn checked_all_lanes<T, F>(len: usize, mut checked_at: F) -> CheckedValues<T>
+where
+    T: Default,
+    F: FnMut(usize) -> Option<T>,
+{
+    let mut values = BufferMut::<T>::with_capacity(len);
+    let mut base = 0;
+
+    while base + CHECKED_BLOCK_LANES <= len {
+        let mut block_failed = false;
+        for idx in base..base + CHECKED_BLOCK_LANES {
+            match checked_at(idx) {
+                Some(value) => {
+                    // SAFETY: the buffer is allocated with capacity `len`, and
+                    // this loop pushes at most one value for each `idx`.
+                    unsafe { values.push_unchecked(value) };
+                }
+                None => {
+                    block_failed = true;
+                    // SAFETY: the buffer is allocated with capacity `len`, and
+                    // this loop pushes at most one value for each `idx`.
+                    unsafe { values.push_unchecked(T::default()) };
+                }
+            }
+        }
+
+        if block_failed {
+            return CheckedValues::failed(len);
+        }
+        base += CHECKED_BLOCK_LANES;
+    }
+
+    for idx in base..len {
+        let Some(value) = checked_at(idx) else {
+            return CheckedValues::failed(len);
+        };
+        // SAFETY: the buffer is allocated with capacity `len`, and this loop
+        // pushes at most one value for each `idx`.
+        unsafe { values.push_unchecked(value) };
+    }
+
+    CheckedValues {
+        values: values.freeze(),
+        failed: false,
+    }
+}
+
+fn checked_valid_lanes<T, F>(
+    len: usize,
+    valid_bits: &BitBuffer,
+    mut checked_at: F,
+) -> CheckedValues<T>
+where
+    T: Default,
+    F: FnMut(usize) -> Option<T>,
+{
+    let mut values = BufferMut::<T>::zeroed(len);
+    let mut failed = false;
+    {
+        let values = values.as_mut_slice();
+        for_each_valid_idx(len, valid_bits, |idx| {
+            let Some(value) = checked_at(idx) else {
+                failed = true;
+                return false;
+            };
+            values[idx] = value;
+            true
+        });
+    }
+
+    CheckedValues {
+        values: values.freeze(),
+        failed,
+    }
+}
+
+fn any_valid_error<F>(len: usize, valid_bits: &BitBuffer, is_error: F) -> bool
+where
+    F: Fn(usize) -> bool,
+{
+    !for_each_valid_idx(len, valid_bits, |idx| !is_error(idx))
+}
+
+fn for_each_valid_idx<F>(len: usize, valid_bits: &BitBuffer, mut f: F) -> bool
+where
+    F: FnMut(usize) -> bool,
+{
+    debug_assert_eq!(len, valid_bits.len());
+
+    for (word_idx, valid_word) in valid_bits.chunks().iter_padded().enumerate() {
+        if valid_word == 0 {
+            continue;
+        }
+
+        let offset = word_idx * 64;
+        let lanes = len.saturating_sub(offset).min(64);
+        if lanes == 64 && valid_word == u64::MAX {
+            for bit_idx in 0..64 {
+                if !f(offset + bit_idx) {
+                    return false;
+                }
+            }
+            continue;
+        }
+
+        let mut valid_word = if lanes == 64 {
+            valid_word
+        } else {
+            valid_word & ((1u64 << lanes) - 1)
+        };
+        while valid_word != 0 {
+            let bit_idx = valid_word.trailing_zeros() as usize;
+            if !f(offset + bit_idx) {
+                return false;
+            }
+            valid_word &= valid_word - 1;
+        }
+    }
+
+    true
+}
+
+fn check_numeric_errors(failed: bool, error: &'static str) -> VortexResult<()> {
+    if failed {
+        return Err(vortex_err!(InvalidArgument: "{}", error));
+    }
+
+    Ok(())
+}

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
@@ -6,13 +6,13 @@
 //!
 //! [`Binary`]: super::Binary
 
-use super::decimal_add_sub_result_dtype;
-
 mod decimal;
 mod primitive;
 #[cfg(test)]
 mod tests;
 
+use decimal::result_decimal_dtype;
+pub(crate) use decimal::result_decimal_dtype as numeric_op_result_decimal_dtype;
 pub(crate) use primitive::PrimitiveOperand;
 use vortex_buffer::BitBuffer;
 use vortex_buffer::Buffer;
@@ -57,7 +57,7 @@ pub(crate) fn execute_numeric(
             DType::Primitive(..) => lhs.dtype().with_nullability(nullability),
             DType::Decimal(decimal_dtype, _) => {
                 debug_assert!(matches!(op, NumericOperator::Add | NumericOperator::Sub));
-                DType::Decimal(decimal_add_sub_result_dtype(*decimal_dtype), nullability)
+                DType::Decimal(result_decimal_dtype(*decimal_dtype, op)?, nullability)
             }
             dtype => vortex_bail!("numeric operator is not supported for dtype {}", dtype),
         };

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
@@ -6,6 +6,8 @@
 //!
 //! [`Binary`]: super::Binary
 
+use super::decimal_add_sub_result_dtype;
+
 mod decimal;
 mod primitive;
 #[cfg(test)]
@@ -50,9 +52,15 @@ pub(crate) fn execute_numeric(
     }
 
     if lhs.is_empty() {
-        let result_dtype = lhs
-            .dtype()
-            .with_nullability(lhs.dtype().nullability() | rhs.dtype().nullability());
+        let nullability = lhs.dtype().nullability() | rhs.dtype().nullability();
+        let result_dtype = match lhs.dtype() {
+            DType::Primitive(..) => lhs.dtype().with_nullability(nullability),
+            DType::Decimal(decimal_dtype, _) => {
+                debug_assert!(matches!(op, NumericOperator::Add | NumericOperator::Sub));
+                DType::Decimal(decimal_add_sub_result_dtype(*decimal_dtype), nullability)
+            }
+            dtype => vortex_bail!("numeric operator is not supported for dtype {}", dtype),
+        };
         return Ok(Canonical::empty(&result_dtype).into_array());
     }
 

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
@@ -20,7 +20,9 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::dtype::DType;
 use crate::scalar::NumericOperator;
 
@@ -37,6 +39,21 @@ pub(crate) fn execute_numeric(
             lhs.dtype(),
             rhs.dtype()
         );
+    }
+
+    if lhs.len() != rhs.len() {
+        vortex_bail!(
+            "numeric operator requires equal lengths, got {} and {}",
+            lhs.len(),
+            rhs.len()
+        );
+    }
+
+    if lhs.is_empty() {
+        let result_dtype = lhs
+            .dtype()
+            .with_nullability(lhs.dtype().nullability() | rhs.dtype().nullability());
+        return Ok(Canonical::empty(&result_dtype).into_array());
     }
 
     match lhs.dtype() {

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
@@ -9,11 +9,10 @@ use vortex_error::vortex_err;
 use vortex_mask::AllOr;
 use vortex_mask::Mask;
 
-use super::CheckedValues;
-use super::any_valid_error;
-use super::check_numeric_errors;
-use super::checked_all_lanes;
-use super::checked_valid_lanes;
+use super::checked::CheckedValues;
+use super::checked::any_valid_error;
+use super::checked::checked_all_lanes;
+use super::checked::checked_valid_lanes;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
@@ -174,7 +173,10 @@ where
             CheckedValues::zeroed(len)
         }
     };
-    check_numeric_errors(checked.failed, Op::ERROR)?;
+
+    if checked.failed {
+        return Err(vortex_err!(InvalidArgument: "{}", Op::ERROR));
+    }
 
     primitive_result_array::<T>(checked.values, validity, &result_dtype)
 }

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
@@ -117,13 +117,6 @@ pub(super) fn execute_numeric_primitive(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let ptype = PType::try_from(lhs.dtype())?;
-    if !lhs.dtype().eq_ignore_nullability(rhs.dtype()) {
-        vortex_bail!(
-            "numeric operator requires matching primitive types, got {} and {}",
-            lhs.dtype(),
-            rhs.dtype()
-        );
-    }
 
     match_each_native_ptype!(ptype, |T| {
         match op {

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
@@ -10,6 +10,11 @@ use vortex_error::vortex_err;
 use vortex_mask::AllOr;
 use vortex_mask::Mask;
 
+use super::CheckedValues;
+use super::any_valid_error;
+use super::check_numeric_errors;
+use super::checked_all_lanes;
+use super::checked_valid_lanes;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
@@ -104,8 +109,8 @@ impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedDiv {
     }
 }
 
-/// Execute a numeric operation between two arrays.
-pub(crate) fn execute_numeric(
+/// Execute a numeric operation between two primitive-typed arrays.
+pub(super) fn execute_numeric_primitive(
     lhs: &ArrayRef,
     rhs: &ArrayRef,
     op: NumericOperator,
@@ -214,7 +219,7 @@ where
 
 /// A primitive binary-operator operand: a materialized buffer, a non-null constant, or an
 /// all-null constant.
-pub(super) enum PrimitiveOperand<T: NativePType> {
+pub(crate) enum PrimitiveOperand<T: NativePType> {
     Array {
         values: Buffer<T>,
         validity: Validity,
@@ -228,7 +233,7 @@ pub(super) enum PrimitiveOperand<T: NativePType> {
 }
 
 impl<T: NativePType> PrimitiveOperand<T> {
-    pub(super) fn try_new(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+    pub(crate) fn try_new(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
         if let Some(constant) = array.as_opt::<Constant>() {
             return Ok(
                 match constant.scalar().as_primitive().try_typed_value::<T>()? {
@@ -252,39 +257,18 @@ impl<T: NativePType> PrimitiveOperand<T> {
         Ok(Self::Array { values, validity })
     }
 
-    pub(super) fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         match self {
             Self::Array { values, .. } => values.len(),
             Self::Constant { len, .. } | Self::Null(len) => *len,
         }
     }
 
-    pub(super) fn validity(&self) -> Validity {
+    pub(crate) fn validity(&self) -> Validity {
         match self {
             Self::Array { validity, .. } => validity.clone(),
             Self::Constant { validity, .. } => validity.clone(),
             Self::Null(_) => Validity::AllInvalid,
-        }
-    }
-}
-
-struct CheckedValues<T: NativePType> {
-    values: Buffer<T>,
-    failed: bool,
-}
-
-impl<T: NativePType> CheckedValues<T> {
-    fn zeroed(len: usize) -> Self {
-        Self {
-            values: Buffer::<T>::zeroed(len),
-            failed: false,
-        }
-    }
-
-    fn failed(len: usize) -> Self {
-        Self {
-            values: Buffer::<T>::zeroed(len),
-            failed: true,
         }
     }
 }
@@ -495,133 +479,6 @@ where
     Op: CheckedPrimitiveOp<T>,
 {
     checked_valid_lanes(rhs.len(), valid_bits, |idx| Op::checked(lhs, rhs[idx]))
-}
-
-// Checked one-pass ops delay early exit until the end of a small block. This
-// keeps the loop generic while avoiding a branch-driven exit decision on every
-// lane; it is deliberately independent of mask density or input length.
-const CHECKED_BLOCK_LANES: usize = 16;
-
-fn checked_all_lanes<T, F>(len: usize, mut checked_at: F) -> CheckedValues<T>
-where
-    T: NativePType,
-    F: FnMut(usize) -> Option<T>,
-{
-    let mut values = BufferMut::<T>::with_capacity(len);
-    let mut base = 0;
-
-    while base + CHECKED_BLOCK_LANES <= len {
-        let mut block_failed = false;
-        for idx in base..base + CHECKED_BLOCK_LANES {
-            match checked_at(idx) {
-                Some(value) => {
-                    // SAFETY: the buffer is allocated with capacity `len`, and
-                    // this loop pushes at most one value for each `idx`.
-                    unsafe { values.push_unchecked(value) };
-                }
-                None => {
-                    block_failed = true;
-                    // SAFETY: the buffer is allocated with capacity `len`, and
-                    // this loop pushes at most one value for each `idx`.
-                    unsafe { values.push_unchecked(T::default()) };
-                }
-            }
-        }
-
-        if block_failed {
-            return CheckedValues::failed(len);
-        }
-        base += CHECKED_BLOCK_LANES;
-    }
-
-    for idx in base..len {
-        let Some(value) = checked_at(idx) else {
-            return CheckedValues::failed(len);
-        };
-        // SAFETY: the buffer is allocated with capacity `len`, and this loop
-        // pushes at most one value for each `idx`.
-        unsafe { values.push_unchecked(value) };
-    }
-
-    CheckedValues {
-        values: values.freeze(),
-        failed: false,
-    }
-}
-
-fn checked_valid_lanes<T, F>(
-    len: usize,
-    valid_bits: &BitBuffer,
-    mut checked_at: F,
-) -> CheckedValues<T>
-where
-    T: NativePType,
-    F: FnMut(usize) -> Option<T>,
-{
-    let mut values = BufferMut::<T>::zeroed(len);
-    let mut failed = false;
-    {
-        let values = values.as_mut_slice();
-        for_each_valid_idx(len, valid_bits, |idx| {
-            let Some(value) = checked_at(idx) else {
-                failed = true;
-                return false;
-            };
-            values[idx] = value;
-            true
-        });
-    }
-
-    CheckedValues {
-        values: values.freeze(),
-        failed,
-    }
-}
-
-fn any_valid_error<F>(len: usize, valid_bits: &BitBuffer, is_error: F) -> bool
-where
-    F: Fn(usize) -> bool,
-{
-    !for_each_valid_idx(len, valid_bits, |idx| !is_error(idx))
-}
-
-fn for_each_valid_idx<F>(len: usize, valid_bits: &BitBuffer, mut f: F) -> bool
-where
-    F: FnMut(usize) -> bool,
-{
-    debug_assert_eq!(len, valid_bits.len());
-
-    for (word_idx, valid_word) in valid_bits.chunks().iter_padded().enumerate() {
-        if valid_word == 0 {
-            continue;
-        }
-
-        let offset = word_idx * 64;
-        let lanes = len.saturating_sub(offset).min(64);
-        if lanes == 64 && valid_word == u64::MAX {
-            for bit_idx in 0..64 {
-                if !f(offset + bit_idx) {
-                    return false;
-                }
-            }
-            continue;
-        }
-
-        let mut valid_word = if lanes == 64 {
-            valid_word
-        } else {
-            valid_word & ((1u64 << lanes) - 1)
-        };
-        while valid_word != 0 {
-            let bit_idx = valid_word.trailing_zeros() as usize;
-            if !f(offset + bit_idx) {
-                return false;
-            }
-            valid_word &= valid_word - 1;
-        }
-    }
-
-    true
 }
 
 trait CheckedArithmetic: NativePType {
@@ -913,224 +770,3 @@ impl_checked_signed!(i16, widening_mul: i32);
 impl_checked_signed!(i32, widening_mul: i64);
 impl_checked_signed!(i64, overflowing_mul);
 impl_checked_float!(f16, f32, f64);
-
-fn check_numeric_errors(failed: bool, error: &'static str) -> VortexResult<()> {
-    if failed {
-        return Err(vortex_err!(InvalidArgument: "{}", error));
-    }
-
-    Ok(())
-}
-#[cfg(test)]
-mod test {
-    use vortex_buffer::buffer;
-    use vortex_error::VortexResult;
-
-    use crate::ArrayRef;
-    use crate::IntoArray;
-    use crate::RecursiveCanonical;
-    use crate::VortexSessionExecute;
-    use crate::array_session;
-    use crate::arrays::ConstantArray;
-    use crate::arrays::PrimitiveArray;
-    use crate::assert_arrays_eq;
-    use crate::builtins::ArrayBuiltins;
-    use crate::scalar::Scalar;
-    use crate::scalar_fn::fns::operators::Operator;
-    use crate::validity::Validity;
-
-    fn sub_scalar(array: &ArrayRef, scalar: impl Into<Scalar>) -> VortexResult<ArrayRef> {
-        array
-            .binary(
-                ConstantArray::new(scalar, array.len()).into_array(),
-                Operator::Sub,
-            )
-            .and_then(|a| {
-                a.execute::<RecursiveCanonical>(&mut array_session().create_execution_ctx())
-            })
-            .map(|a| a.0.into_array())
-    }
-
-    #[test]
-    fn test_scalar_subtract_unsigned() {
-        let mut ctx = array_session().create_execution_ctx();
-        let values = buffer![1u16, 2, 3].into_array();
-        let result = sub_scalar(&values, 1u16).unwrap();
-        assert_arrays_eq!(result, PrimitiveArray::from_iter([0u16, 1, 2]), &mut ctx);
-    }
-
-    #[test]
-    fn test_scalar_subtract_signed() {
-        let mut ctx = array_session().create_execution_ctx();
-        let values = buffer![1i64, 2, 3].into_array();
-        let result = sub_scalar(&values, -1i64).unwrap();
-        assert_arrays_eq!(result, PrimitiveArray::from_iter([2i64, 3, 4]), &mut ctx);
-    }
-
-    #[test]
-    fn test_scalar_subtract_nullable() {
-        let mut ctx = array_session().create_execution_ctx();
-        let values = PrimitiveArray::from_option_iter([Some(1u16), Some(2), None, Some(3)]);
-        let result = sub_scalar(&values.into_array(), Some(1u16)).unwrap();
-        assert_arrays_eq!(
-            result,
-            PrimitiveArray::from_option_iter([Some(0u16), Some(1), None, Some(2)]),
-            &mut ctx
-        );
-    }
-
-    #[test]
-    fn test_scalar_subtract_float() {
-        let mut ctx = array_session().create_execution_ctx();
-        let values = buffer![1.0f64, 2.0, 3.0].into_array();
-        let result = sub_scalar(&values, -1f64).unwrap();
-        assert_arrays_eq!(
-            result,
-            PrimitiveArray::from_iter([2.0f64, 3.0, 4.0]),
-            &mut ctx
-        );
-    }
-
-    #[test]
-    fn test_scalar_subtract_float_underflow_is_ok() {
-        let values = buffer![f32::MIN, 2.0, 3.0].into_array();
-        let _results = sub_scalar(&values, 1.0f32).unwrap();
-        let _results = sub_scalar(&values, f32::MAX).unwrap();
-    }
-
-    #[test]
-    fn test_float_divide_by_zero_is_ok() {
-        let mut ctx = array_session().create_execution_ctx();
-        let values = buffer![1.0f64, -1.0].into_array();
-        let result = values
-            .binary(
-                ConstantArray::new(0.0f64, values.len()).into_array(),
-                Operator::Div,
-            )
-            .and_then(|a| a.execute::<PrimitiveArray>(&mut array_session().create_execution_ctx()))
-            .unwrap();
-
-        assert_arrays_eq!(
-            result,
-            PrimitiveArray::from_iter([f64::INFINITY, f64::NEG_INFINITY]),
-            &mut ctx
-        );
-    }
-
-    #[test]
-    fn test_integer_overflow_errors() {
-        let values = buffer![u8::MAX].into_array();
-        let result = values
-            .binary(
-                ConstantArray::new(1u8, values.len()).into_array(),
-                Operator::Add,
-            )
-            .and_then(|a| a.execute::<PrimitiveArray>(&mut array_session().create_execution_ctx()));
-
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_integer_divide_by_zero_errors() {
-        let values = buffer![1i32].into_array();
-        let result = values
-            .binary(
-                ConstantArray::new(0i32, values.len()).into_array(),
-                Operator::Div,
-            )
-            .and_then(|a| a.execute::<PrimitiveArray>(&mut array_session().create_execution_ctx()));
-
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_integer_divide_overflow_errors() {
-        let values = buffer![i64::MIN].into_array();
-        let result = values
-            .binary(
-                ConstantArray::new(-1i64, values.len()).into_array(),
-                Operator::Div,
-            )
-            .and_then(|a| a.execute::<PrimitiveArray>(&mut array_session().create_execution_ctx()));
-
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_integer_divide_errors_ignore_null_lanes() {
-        let mut ctx = array_session().create_execution_ctx();
-        let lhs = PrimitiveArray::new(buffer![10i32, 10], Validity::from_iter([false, true]))
-            .into_array();
-        let rhs = buffer![0i32, 2].into_array();
-        let result = lhs
-            .binary(rhs, Operator::Div)
-            .and_then(|a| {
-                a.execute::<RecursiveCanonical>(&mut array_session().create_execution_ctx())
-            })
-            .map(|a| a.0.into_array())
-            .unwrap();
-
-        assert_arrays_eq!(
-            result,
-            PrimitiveArray::from_option_iter([None, Some(5i32)]),
-            &mut ctx
-        );
-    }
-
-    #[test]
-    fn test_integer_errors_ignore_null_lanes() {
-        let mut ctx = array_session().create_execution_ctx();
-        let values = PrimitiveArray::new(buffer![u8::MAX, 1], Validity::from_iter([false, true]))
-            .into_array();
-        let result = values
-            .binary(
-                ConstantArray::new(1u8, values.len()).into_array(),
-                Operator::Add,
-            )
-            .and_then(|a| {
-                a.execute::<RecursiveCanonical>(&mut array_session().create_execution_ctx())
-            })
-            .map(|a| a.0.into_array())
-            .unwrap();
-
-        assert_arrays_eq!(
-            result,
-            PrimitiveArray::from_option_iter([None, Some(2u8)]),
-            &mut ctx
-        );
-    }
-
-    #[test]
-    fn test_integer_array_array_errors_on_valid_lanes() {
-        let lhs = PrimitiveArray::new(
-            buffer![u8::MAX, 1, u8::MAX],
-            Validity::from_iter([false, true, true]),
-        )
-        .into_array();
-        let rhs = buffer![1u8, 1, 1].into_array();
-        let result = lhs
-            .binary(rhs, Operator::Add)
-            .and_then(|a| a.execute::<PrimitiveArray>(&mut array_session().create_execution_ctx()));
-
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_present_nullable_constant_preserves_nullable_output() {
-        let mut ctx = array_session().create_execution_ctx();
-        let values = buffer![1u8, 2].into_array();
-        let result = values
-            .binary(
-                ConstantArray::new(Some(1u8), values.len()).into_array(),
-                Operator::Add,
-            )
-            .and_then(|a| a.execute::<PrimitiveArray>(&mut array_session().create_execution_ctx()))
-            .unwrap();
-
-        assert_arrays_eq!(
-            result,
-            PrimitiveArray::from_option_iter([Some(2u8), Some(3)]),
-            &mut ctx
-        );
-    }
-}

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
@@ -5,7 +5,6 @@ use vortex_buffer::BitBuffer;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_mask::AllOr;
 use vortex_mask::Mask;
@@ -145,13 +144,7 @@ where
     let lhs = PrimitiveOperand::<T>::try_new(lhs, ctx)?;
     let rhs = PrimitiveOperand::<T>::try_new(rhs, ctx)?;
     let len = lhs.len();
-    if len != rhs.len() {
-        vortex_bail!(
-            "numeric operator requires equal lengths, got {} and {}",
-            len,
-            rhs.len()
-        );
-    }
+    debug_assert_eq!(len, rhs.len());
 
     let validity = lhs.validity().and(rhs.validity())?;
     let valid_rows = validity.execute_mask(len, ctx)?;

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
@@ -320,6 +320,38 @@ fn test_decimal_max_precision_overflow_on_valid_lane_errors() {
 }
 
 #[test]
+fn test_decimal_value_outside_working_width_errors() {
+    let dtype = DecimalDType::new(2, 0);
+    let value = i256::from_i128(1_000_000);
+    let lhs = DecimalArray::new(buffer![value], dtype, Validity::NonNullable).into_array();
+    let rhs = DecimalArray::new(buffer![value], dtype, Validity::NonNullable).into_array();
+
+    assert!(decimal_binary(lhs, rhs, Operator::Add).is_err());
+}
+
+#[test]
+fn test_decimal_value_outside_working_width_on_null_lane_ignored() -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(2, 0);
+    let result_dtype = result_decimal_dtype(dtype, NumericOperator::Add)?;
+    let lhs = DecimalArray::new(
+        buffer![i256::from_i128(1_000_000), i256::from_i128(1)],
+        dtype,
+        Validity::from_iter([false, true]),
+    )
+    .into_array();
+    let rhs = decimal_constant(i256::from_i128(1), dtype, 2);
+
+    let result = decimal_binary(lhs, rhs, Operator::Add)?;
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_option_iter::<i16, _>([None, Some(2)], result_dtype),
+        &mut ctx
+    );
+    Ok(())
+}
+
+#[test]
 fn test_decimal_overflow_on_null_lane_ignored() {
     let mut ctx = array_session().create_execution_ctx();
     let dtype = DecimalDType::new(76, 0);

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_buffer::buffer;
+use vortex_error::VortexResult;
+
+use crate::ArrayRef;
+use crate::IntoArray;
+use crate::RecursiveCanonical;
+use crate::VortexSessionExecute;
+use crate::array_session;
+use crate::arrays::ConstantArray;
+use crate::arrays::PrimitiveArray;
+use crate::assert_arrays_eq;
+use crate::builtins::ArrayBuiltins;
+use crate::scalar::Scalar;
+use crate::scalar_fn::fns::operators::Operator;
+use crate::validity::Validity;
+
+fn sub_scalar(array: &ArrayRef, scalar: impl Into<Scalar>) -> VortexResult<ArrayRef> {
+    array
+        .binary(
+            ConstantArray::new(scalar, array.len()).into_array(),
+            Operator::Sub,
+        )
+        .and_then(|a| a.execute::<RecursiveCanonical>(&mut array_session().create_execution_ctx()))
+        .map(|a| a.0.into_array())
+}
+
+#[test]
+fn test_scalar_subtract_unsigned() {
+    let mut ctx = array_session().create_execution_ctx();
+    let values = buffer![1u16, 2, 3].into_array();
+    let result = sub_scalar(&values, 1u16).unwrap();
+    assert_arrays_eq!(result, PrimitiveArray::from_iter([0u16, 1, 2]), &mut ctx);
+}
+
+#[test]
+fn test_scalar_subtract_signed() {
+    let mut ctx = array_session().create_execution_ctx();
+    let values = buffer![1i64, 2, 3].into_array();
+    let result = sub_scalar(&values, -1i64).unwrap();
+    assert_arrays_eq!(result, PrimitiveArray::from_iter([2i64, 3, 4]), &mut ctx);
+}
+
+#[test]
+fn test_scalar_subtract_nullable() {
+    let mut ctx = array_session().create_execution_ctx();
+    let values = PrimitiveArray::from_option_iter([Some(1u16), Some(2), None, Some(3)]);
+    let result = sub_scalar(&values.into_array(), Some(1u16)).unwrap();
+    assert_arrays_eq!(
+        result,
+        PrimitiveArray::from_option_iter([Some(0u16), Some(1), None, Some(2)]),
+        &mut ctx
+    );
+}
+
+#[test]
+fn test_scalar_subtract_float() {
+    let mut ctx = array_session().create_execution_ctx();
+    let values = buffer![1.0f64, 2.0, 3.0].into_array();
+    let result = sub_scalar(&values, -1f64).unwrap();
+    assert_arrays_eq!(
+        result,
+        PrimitiveArray::from_iter([2.0f64, 3.0, 4.0]),
+        &mut ctx
+    );
+}
+
+#[test]
+fn test_scalar_subtract_float_underflow_is_ok() {
+    let values = buffer![f32::MIN, 2.0, 3.0].into_array();
+    let _results = sub_scalar(&values, 1.0f32).unwrap();
+    let _results = sub_scalar(&values, f32::MAX).unwrap();
+}
+
+#[test]
+fn test_float_divide_by_zero_is_ok() {
+    let mut ctx = array_session().create_execution_ctx();
+    let values = buffer![1.0f64, -1.0].into_array();
+    let result = values
+        .binary(
+            ConstantArray::new(0.0f64, values.len()).into_array(),
+            Operator::Div,
+        )
+        .and_then(|a| a.execute::<PrimitiveArray>(&mut array_session().create_execution_ctx()))
+        .unwrap();
+
+    assert_arrays_eq!(
+        result,
+        PrimitiveArray::from_iter([f64::INFINITY, f64::NEG_INFINITY]),
+        &mut ctx
+    );
+}
+
+#[test]
+fn test_integer_overflow_errors() {
+    let values = buffer![u8::MAX].into_array();
+    let result = values
+        .binary(
+            ConstantArray::new(1u8, values.len()).into_array(),
+            Operator::Add,
+        )
+        .and_then(|a| a.execute::<PrimitiveArray>(&mut array_session().create_execution_ctx()));
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_integer_divide_by_zero_errors() {
+    let values = buffer![1i32].into_array();
+    let result = values
+        .binary(
+            ConstantArray::new(0i32, values.len()).into_array(),
+            Operator::Div,
+        )
+        .and_then(|a| a.execute::<PrimitiveArray>(&mut array_session().create_execution_ctx()));
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_integer_divide_overflow_errors() {
+    let values = buffer![i64::MIN].into_array();
+    let result = values
+        .binary(
+            ConstantArray::new(-1i64, values.len()).into_array(),
+            Operator::Div,
+        )
+        .and_then(|a| a.execute::<PrimitiveArray>(&mut array_session().create_execution_ctx()));
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_integer_divide_errors_ignore_null_lanes() {
+    let mut ctx = array_session().create_execution_ctx();
+    let lhs =
+        PrimitiveArray::new(buffer![10i32, 10], Validity::from_iter([false, true])).into_array();
+    let rhs = buffer![0i32, 2].into_array();
+    let result = lhs
+        .binary(rhs, Operator::Div)
+        .and_then(|a| a.execute::<RecursiveCanonical>(&mut array_session().create_execution_ctx()))
+        .map(|a| a.0.into_array())
+        .unwrap();
+
+    assert_arrays_eq!(
+        result,
+        PrimitiveArray::from_option_iter([None, Some(5i32)]),
+        &mut ctx
+    );
+}
+
+#[test]
+fn test_integer_errors_ignore_null_lanes() {
+    let mut ctx = array_session().create_execution_ctx();
+    let values =
+        PrimitiveArray::new(buffer![u8::MAX, 1], Validity::from_iter([false, true])).into_array();
+    let result = values
+        .binary(
+            ConstantArray::new(1u8, values.len()).into_array(),
+            Operator::Add,
+        )
+        .and_then(|a| a.execute::<RecursiveCanonical>(&mut array_session().create_execution_ctx()))
+        .map(|a| a.0.into_array())
+        .unwrap();
+
+    assert_arrays_eq!(
+        result,
+        PrimitiveArray::from_option_iter([None, Some(2u8)]),
+        &mut ctx
+    );
+}
+
+#[test]
+fn test_integer_array_array_errors_on_valid_lanes() {
+    let lhs = PrimitiveArray::new(
+        buffer![u8::MAX, 1, u8::MAX],
+        Validity::from_iter([false, true, true]),
+    )
+    .into_array();
+    let rhs = buffer![1u8, 1, 1].into_array();
+    let result = lhs
+        .binary(rhs, Operator::Add)
+        .and_then(|a| a.execute::<PrimitiveArray>(&mut array_session().create_execution_ctx()));
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_present_nullable_constant_preserves_nullable_output() {
+    let mut ctx = array_session().create_execution_ctx();
+    let values = buffer![1u8, 2].into_array();
+    let result = values
+        .binary(
+            ConstantArray::new(Some(1u8), values.len()).into_array(),
+            Operator::Add,
+        )
+        .and_then(|a| a.execute::<PrimitiveArray>(&mut array_session().create_execution_ctx()))
+        .unwrap();
+
+    assert_arrays_eq!(
+        result,
+        PrimitiveArray::from_option_iter([Some(2u8), Some(3)]),
+        &mut ctx
+    );
+}

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
@@ -17,6 +17,7 @@ use crate::assert_arrays_eq;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
+use crate::dtype::DecimalType;
 use crate::dtype::Nullability;
 use crate::scalar::DecimalValue;
 use crate::scalar::Scalar;
@@ -212,6 +213,19 @@ fn test_present_nullable_constant_preserves_nullable_output() {
     );
 }
 
+#[test]
+fn test_empty_primitive_constants_do_not_evaluate() -> VortexResult<()> {
+    let lhs = ConstantArray::new(u8::MAX, 0).into_array();
+    let rhs = ConstantArray::new(1u8, 0).into_array();
+
+    let result = lhs
+        .binary(rhs, Operator::Add)?
+        .execute::<RecursiveCanonical>(&mut array_session().create_execution_ctx())?;
+
+    assert!(result.0.is_empty());
+    Ok(())
+}
+
 // -- Decimal arithmetic --
 
 fn decimal_binary(lhs: ArrayRef, rhs: ArrayRef, op: Operator) -> VortexResult<ArrayRef> {
@@ -319,6 +333,46 @@ fn test_decimal_precision_stricter_than_width() {
     let rhs = DecimalArray::from_iter::<i8, _>([60], dtype).into_array();
 
     assert!(decimal_binary(lhs, rhs, Operator::Add).is_err());
+}
+
+#[rstest]
+#[case::precision_2(
+    DecimalArray::from_iter::<i8, _>([10, 20], DecimalDType::new(2, 0)),
+    DecimalType::I8,
+)]
+#[case::precision_18(
+    DecimalArray::from_iter::<i64, _>([10, 20], DecimalDType::new(18, 0)),
+    DecimalType::I64,
+)]
+#[case::precision_38(
+    DecimalArray::from_iter::<i128, _>([10, 20], DecimalDType::new(38, 0)),
+    DecimalType::I128,
+)]
+fn test_decimal_result_uses_logical_storage_width(
+    #[case] values: DecimalArray,
+    #[case] expected_type: DecimalType,
+) -> VortexResult<()> {
+    let result = decimal_binary(
+        values.clone().into_array(),
+        values.into_array(),
+        Operator::Add,
+    )?
+    .execute::<DecimalArray>(&mut array_session().create_execution_ctx())?;
+
+    assert_eq!(result.values_type(), expected_type);
+    Ok(())
+}
+
+#[test]
+fn test_decimal_empty_constants_do_not_evaluate() -> VortexResult<()> {
+    let dtype = DecimalDType::new(3, 0);
+    let lhs = decimal_constant(999i16, dtype, 0);
+    let rhs = decimal_constant(1i16, dtype, 0);
+
+    let result = decimal_binary(lhs, rhs, Operator::Add)?;
+
+    assert!(result.is_empty());
+    Ok(())
 }
 
 #[test]

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
@@ -342,13 +342,13 @@ fn test_decimal_overflow_on_null_lane_ignored() {
 fn test_decimal_add_reserves_carry_digit() {
     let mut ctx = array_session().create_execution_ctx();
     let dtype = DecimalDType::new(2, 0);
-    let lhs = DecimalArray::from_iter::<i8, _>([60], dtype).into_array();
-    let rhs = DecimalArray::from_iter::<i8, _>([60], dtype).into_array();
+    let lhs = DecimalArray::from_iter::<i8, _>([99], dtype).into_array();
+    let rhs = DecimalArray::from_iter::<i8, _>([99], dtype).into_array();
 
     let result = decimal_binary(lhs, rhs, Operator::Add).unwrap();
     assert_arrays_eq!(
         result,
-        DecimalArray::from_iter::<i16, _>([120], DecimalDType::new(3, 0)),
+        DecimalArray::from_iter::<i16, _>([198], DecimalDType::new(3, 0)),
         &mut ctx
     );
 }

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use rstest::rstest;
 use vortex_buffer::buffer;
 use vortex_error::VortexResult;
 
@@ -10,9 +11,14 @@ use crate::RecursiveCanonical;
 use crate::VortexSessionExecute;
 use crate::array_session;
 use crate::arrays::ConstantArray;
+use crate::arrays::DecimalArray;
 use crate::arrays::PrimitiveArray;
 use crate::assert_arrays_eq;
 use crate::builtins::ArrayBuiltins;
+use crate::dtype::DType;
+use crate::dtype::DecimalDType;
+use crate::dtype::Nullability;
+use crate::scalar::DecimalValue;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::operators::Operator;
 use crate::validity::Validity;
@@ -204,4 +210,222 @@ fn test_present_nullable_constant_preserves_nullable_output() {
         PrimitiveArray::from_option_iter([Some(2u8), Some(3)]),
         &mut ctx
     );
+}
+
+// -- Decimal arithmetic --
+
+fn decimal_binary(lhs: ArrayRef, rhs: ArrayRef, op: Operator) -> VortexResult<ArrayRef> {
+    lhs.binary(rhs, op)
+        .and_then(|a| a.execute::<RecursiveCanonical>(&mut array_session().create_execution_ctx()))
+        .map(|a| a.0.into_array())
+}
+
+fn decimal_constant(value: impl Into<DecimalValue>, dtype: DecimalDType, len: usize) -> ArrayRef {
+    ConstantArray::new(
+        Scalar::decimal(value.into(), dtype, Nullability::NonNullable),
+        len,
+    )
+    .into_array()
+}
+
+#[rstest]
+#[case::add(Operator::Add, [150i64, 225], [1050i64, 1225])]
+#[case::sub(Operator::Sub, [150i64, 225], [750i64, 775])]
+fn test_decimal_array_array(
+    #[case] op: Operator,
+    #[case] rhs: [i64; 2],
+    #[case] expected: [i64; 2],
+) {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(10, 2);
+    let lhs = DecimalArray::from_iter::<i64, _>([900, 1000], dtype).into_array();
+    let rhs = DecimalArray::from_iter::<i64, _>(rhs, dtype).into_array();
+
+    let result = decimal_binary(lhs, rhs, op).unwrap();
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_iter::<i64, _>(expected, dtype),
+        &mut ctx
+    );
+}
+
+#[test]
+fn test_decimal_mixed_storage_widths() {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(10, 2);
+    let lhs = DecimalArray::from_iter::<i32, _>([100, 250], dtype).into_array();
+    let rhs = DecimalArray::from_iter::<i128, _>([200, 250], dtype).into_array();
+
+    let result = decimal_binary(lhs, rhs, Operator::Add).unwrap();
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_iter::<i64, _>([300, 500], dtype),
+        &mut ctx
+    );
+}
+
+#[test]
+fn test_decimal_nullable_lanes() {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(10, 2);
+    let lhs =
+        DecimalArray::from_option_iter::<i64, _>([Some(100), None, Some(300)], dtype).into_array();
+    let rhs = DecimalArray::from_iter::<i64, _>([50, 50, 50], dtype).into_array();
+
+    let result = decimal_binary(lhs, rhs, Operator::Add).unwrap();
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_option_iter::<i64, _>([Some(150), None, Some(350)], dtype),
+        &mut ctx
+    );
+}
+
+#[test]
+fn test_decimal_overflow_on_valid_lane_errors() {
+    let dtype = DecimalDType::new(3, 0);
+    let lhs = DecimalArray::from_iter::<i16, _>([999], dtype).into_array();
+    let rhs = DecimalArray::from_iter::<i16, _>([2], dtype).into_array();
+
+    assert!(decimal_binary(lhs, rhs, Operator::Add).is_err());
+}
+
+#[test]
+fn test_decimal_overflow_on_null_lane_ignored() {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(3, 0);
+    // The null lane holds 999, so adding 500 overflows the precision there but is ignored.
+    let lhs = DecimalArray::new(
+        buffer![999i16, 1],
+        dtype,
+        Validity::from_iter([false, true]),
+    )
+    .into_array();
+    let rhs = decimal_constant(500i16, dtype, 2);
+
+    let result = decimal_binary(lhs, rhs, Operator::Add).unwrap();
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_option_iter::<i16, _>([None, Some(501)], dtype),
+        &mut ctx
+    );
+}
+
+/// A value can fit the storage width while violating the dtype precision: 60 + 60 fits an i8 but
+/// exceeds precision 2.
+#[test]
+fn test_decimal_precision_stricter_than_width() {
+    let dtype = DecimalDType::new(2, 0);
+    let lhs = DecimalArray::from_iter::<i8, _>([60], dtype).into_array();
+    let rhs = DecimalArray::from_iter::<i8, _>([60], dtype).into_array();
+
+    assert!(decimal_binary(lhs, rhs, Operator::Add).is_err());
+}
+
+#[test]
+fn test_decimal_constant_lhs_non_commutative() {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(10, 2);
+    let lhs = decimal_constant(1000i64, dtype, 2);
+    let rhs = DecimalArray::from_iter::<i64, _>([250, 400], dtype).into_array();
+
+    let result = decimal_binary(lhs, rhs, Operator::Sub).unwrap();
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_iter::<i64, _>([750, 600], dtype),
+        &mut ctx
+    );
+}
+
+#[test]
+fn test_decimal_nullable_constant_preserves_nullable_output() {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(10, 2);
+    let values = DecimalArray::from_iter::<i64, _>([100, 200], dtype).into_array();
+    let constant = ConstantArray::new(
+        Scalar::decimal(DecimalValue::from(50i64), dtype, Nullability::Nullable),
+        2,
+    )
+    .into_array();
+
+    let result = decimal_binary(values, constant, Operator::Add).unwrap();
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_option_iter::<i64, _>([Some(150), Some(250)], dtype),
+        &mut ctx
+    );
+}
+
+#[test]
+fn test_decimal_null_constant_yields_all_null() {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(10, 2);
+    let values = DecimalArray::from_iter::<i64, _>([100, 200], dtype).into_array();
+    let null_constant = ConstantArray::new(
+        Scalar::null(DType::Decimal(dtype, Nullability::Nullable)),
+        2,
+    )
+    .into_array();
+
+    let result = decimal_binary(values, null_constant, Operator::Add).unwrap();
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_option_iter::<i64, _>([None, None], dtype),
+        &mut ctx
+    );
+}
+
+/// A constant stored in a wider variant than the array storage participates through the widened
+/// working type.
+#[test]
+fn test_decimal_constant_wider_than_array_storage() {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(20, 0);
+    let values = DecimalArray::from_iter::<i8, _>([1, 2], dtype).into_array();
+    let constant = decimal_constant(10_000_000_000i64, dtype, 2);
+
+    let result = decimal_binary(values, constant, Operator::Add).unwrap();
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_iter::<i64, _>([10_000_000_001, 10_000_000_002], dtype),
+        &mut ctx
+    );
+}
+
+#[test]
+fn test_decimal_empty() {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(10, 2);
+    let empty = DecimalArray::from_iter::<i64, _>([], dtype).into_array();
+
+    let result = decimal_binary(empty.clone(), empty, Operator::Add).unwrap();
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_iter::<i64, _>([], dtype),
+        &mut ctx
+    );
+}
+
+#[test]
+fn test_decimal_constant_constant_folds() {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(10, 2);
+    let lhs = decimal_constant(150i64, dtype, 3);
+    let rhs = decimal_constant(50i64, dtype, 3);
+
+    let result = decimal_binary(lhs, rhs, Operator::Add).unwrap();
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_iter::<i64, _>([200, 200, 200], dtype),
+        &mut ctx
+    );
+}
+
+#[rstest]
+#[case::mul(Operator::Mul)]
+#[case::div(Operator::Div)]
+fn test_decimal_mul_div_unsupported(#[case] op: Operator) {
+    let dtype = DecimalDType::new(10, 2);
+    let values = DecimalArray::from_iter::<i64, _>([100], dtype).into_array();
+
+    assert!(decimal_binary(values.clone(), values, op).is_err());
 }

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
@@ -5,8 +5,9 @@ use rstest::rstest;
 use vortex_buffer::buffer;
 use vortex_error::VortexResult;
 
-use super::decimal_add_sub_result_dtype;
+use super::result_decimal_dtype;
 use crate::ArrayRef;
+use crate::Columnar;
 use crate::IntoArray;
 use crate::RecursiveCanonical;
 use crate::VortexSessionExecute;
@@ -23,6 +24,7 @@ use crate::dtype::NativeDecimalType;
 use crate::dtype::Nullability;
 use crate::dtype::i256;
 use crate::scalar::DecimalValue;
+use crate::scalar::NumericOperator;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::operators::Operator;
 use crate::validity::Validity;
@@ -246,59 +248,65 @@ fn decimal_constant(value: impl Into<DecimalValue>, dtype: DecimalDType, len: us
 }
 
 #[rstest]
-#[case::add(Operator::Add, [150i64, 225], [1050i64, 1225])]
-#[case::sub(Operator::Sub, [150i64, 225], [750i64, 775])]
+#[case::add(NumericOperator::Add, [150i64, 225], [1050i64, 1225])]
+#[case::sub(NumericOperator::Sub, [150i64, 225], [750i64, 775])]
 fn test_decimal_array_array(
-    #[case] op: Operator,
+    #[case] op: NumericOperator,
     #[case] rhs: [i64; 2],
     #[case] expected: [i64; 2],
-) {
+) -> VortexResult<()> {
     let mut ctx = array_session().create_execution_ctx();
     let dtype = DecimalDType::new(10, 2);
-    let result_dtype = decimal_add_sub_result_dtype(dtype);
+    let result_dtype = result_decimal_dtype(dtype, op)?;
     let lhs = DecimalArray::from_iter::<i64, _>([900, 1000], dtype).into_array();
     let rhs = DecimalArray::from_iter::<i64, _>(rhs, dtype).into_array();
 
-    let result = decimal_binary(lhs, rhs, op).unwrap();
+    let result = decimal_binary(lhs, rhs, op.into())?;
     assert_arrays_eq!(
         result,
         DecimalArray::from_iter::<i64, _>(expected, result_dtype),
         &mut ctx
     );
+    Ok(())
 }
 
 #[test]
-fn test_decimal_mixed_storage_widths() {
+fn test_decimal_mixed_storage_widths() -> VortexResult<()> {
     let mut ctx = array_session().create_execution_ctx();
     let dtype = DecimalDType::new(10, 2);
     let lhs = DecimalArray::from_iter::<i32, _>([100, 250], dtype).into_array();
     let rhs = DecimalArray::from_iter::<i128, _>([200, 250], dtype).into_array();
 
-    let result = decimal_binary(lhs, rhs, Operator::Add).unwrap();
+    let result = decimal_binary(lhs, rhs, Operator::Add)?;
     assert_arrays_eq!(
         result,
-        DecimalArray::from_iter::<i64, _>([300, 500], decimal_add_sub_result_dtype(dtype)),
+        DecimalArray::from_iter::<i64, _>(
+            [300, 500],
+            result_decimal_dtype(dtype, NumericOperator::Add)?,
+        ),
         &mut ctx
     );
+    Ok(())
 }
 
 #[test]
-fn test_decimal_nullable_lanes() {
+fn test_decimal_nullable_lanes() -> VortexResult<()> {
     let mut ctx = array_session().create_execution_ctx();
     let dtype = DecimalDType::new(10, 2);
     let lhs =
         DecimalArray::from_option_iter::<i64, _>([Some(100), None, Some(300)], dtype).into_array();
     let rhs = DecimalArray::from_iter::<i64, _>([50, 50, 50], dtype).into_array();
 
-    let result = decimal_binary(lhs, rhs, Operator::Add).unwrap();
+    let result = decimal_binary(lhs, rhs, Operator::Add)?;
     assert_arrays_eq!(
         result,
         DecimalArray::from_option_iter::<i64, _>(
             [Some(150), None, Some(350)],
-            decimal_add_sub_result_dtype(dtype),
+            result_decimal_dtype(dtype, NumericOperator::Add)?,
         ),
         &mut ctx
     );
+    Ok(())
 }
 
 #[test]
@@ -369,7 +377,7 @@ fn test_decimal_result_uses_widened_logical_storage_width(
     #[case] values: DecimalArray,
     #[case] expected_type: DecimalType,
 ) -> VortexResult<()> {
-    let expected_dtype = decimal_add_sub_result_dtype(values.decimal_dtype());
+    let expected_dtype = result_decimal_dtype(values.decimal_dtype(), NumericOperator::Add)?;
     let result = decimal_binary(
         values.clone().into_array(),
         values.into_array(),
@@ -428,22 +436,26 @@ fn test_decimal_empty_constants_do_not_evaluate() -> VortexResult<()> {
 }
 
 #[test]
-fn test_decimal_constant_lhs_non_commutative() {
+fn test_decimal_constant_lhs_non_commutative() -> VortexResult<()> {
     let mut ctx = array_session().create_execution_ctx();
     let dtype = DecimalDType::new(10, 2);
     let lhs = decimal_constant(1000i64, dtype, 2);
     let rhs = DecimalArray::from_iter::<i64, _>([250, 400], dtype).into_array();
 
-    let result = decimal_binary(lhs, rhs, Operator::Sub).unwrap();
+    let result = decimal_binary(lhs, rhs, Operator::Sub)?;
     assert_arrays_eq!(
         result,
-        DecimalArray::from_iter::<i64, _>([750, 600], decimal_add_sub_result_dtype(dtype),),
+        DecimalArray::from_iter::<i64, _>(
+            [750, 600],
+            result_decimal_dtype(dtype, NumericOperator::Sub)?,
+        ),
         &mut ctx
     );
+    Ok(())
 }
 
 #[test]
-fn test_decimal_nullable_constant_preserves_nullable_output() {
+fn test_decimal_nullable_constant_preserves_nullable_output() -> VortexResult<()> {
     let mut ctx = array_session().create_execution_ctx();
     let dtype = DecimalDType::new(10, 2);
     let values = DecimalArray::from_iter::<i64, _>([100, 200], dtype).into_array();
@@ -453,19 +465,22 @@ fn test_decimal_nullable_constant_preserves_nullable_output() {
     )
     .into_array();
 
-    let result = decimal_binary(values, constant, Operator::Add).unwrap();
+    let result = decimal_binary(values, constant, Operator::Add)?;
     assert_arrays_eq!(
         result,
         DecimalArray::from_option_iter::<i64, _>(
             [Some(150), Some(250)],
-            decimal_add_sub_result_dtype(dtype),
+            result_decimal_dtype(dtype, NumericOperator::Add)?,
         ),
         &mut ctx
     );
+    Ok(())
 }
 
-#[test]
-fn test_decimal_null_constant_yields_all_null() {
+#[rstest]
+#[case::null_lhs(true)]
+#[case::null_rhs(false)]
+fn test_decimal_null_constant_yields_all_null(#[case] null_lhs: bool) -> VortexResult<()> {
     let mut ctx = array_session().create_execution_ctx();
     let dtype = DecimalDType::new(10, 2);
     let values = DecimalArray::from_iter::<i64, _>([100, 200], dtype).into_array();
@@ -474,62 +489,80 @@ fn test_decimal_null_constant_yields_all_null() {
         2,
     )
     .into_array();
+    let (lhs, rhs) = if null_lhs {
+        (null_constant, values)
+    } else {
+        (values, null_constant)
+    };
 
-    let result = decimal_binary(values, null_constant, Operator::Add).unwrap();
+    let result = lhs
+        .binary(rhs, Operator::Add)?
+        .execute::<Columnar>(&mut ctx)?;
+    assert!(matches!(&result, Columnar::Constant(_)));
     assert_arrays_eq!(
-        result,
-        DecimalArray::from_option_iter::<i64, _>([None, None], decimal_add_sub_result_dtype(dtype),),
+        result.into_array(),
+        DecimalArray::from_option_iter::<i64, _>(
+            [None, None],
+            result_decimal_dtype(dtype, NumericOperator::Add)?,
+        ),
         &mut ctx
     );
+    Ok(())
 }
 
 /// A constant stored in a wider variant than the array storage participates through the widened
 /// working type.
 #[test]
-fn test_decimal_constant_wider_than_array_storage() {
+fn test_decimal_constant_wider_than_array_storage() -> VortexResult<()> {
     let mut ctx = array_session().create_execution_ctx();
     let dtype = DecimalDType::new(20, 0);
     let values = DecimalArray::from_iter::<i8, _>([1, 2], dtype).into_array();
     let constant = decimal_constant(10_000_000_000i64, dtype, 2);
 
-    let result = decimal_binary(values, constant, Operator::Add).unwrap();
+    let result = decimal_binary(values, constant, Operator::Add)?;
     assert_arrays_eq!(
         result,
         DecimalArray::from_iter::<i64, _>(
             [10_000_000_001, 10_000_000_002],
-            decimal_add_sub_result_dtype(dtype),
+            result_decimal_dtype(dtype, NumericOperator::Add)?,
         ),
         &mut ctx
     );
+    Ok(())
 }
 
 #[test]
-fn test_decimal_empty() {
+fn test_decimal_empty() -> VortexResult<()> {
     let mut ctx = array_session().create_execution_ctx();
     let dtype = DecimalDType::new(10, 2);
     let empty = DecimalArray::from_iter::<i64, _>([], dtype).into_array();
 
-    let result = decimal_binary(empty.clone(), empty, Operator::Add).unwrap();
+    let result = decimal_binary(empty.clone(), empty, Operator::Add)?;
     assert_arrays_eq!(
         result,
-        DecimalArray::from_iter::<i64, _>([], decimal_add_sub_result_dtype(dtype)),
+        DecimalArray::from_iter::<i64, _>([], result_decimal_dtype(dtype, NumericOperator::Add)?,),
         &mut ctx
     );
+    Ok(())
 }
 
 #[test]
-fn test_decimal_constant_constant_folds() {
+fn test_decimal_constant_constant_folds() -> VortexResult<()> {
     let mut ctx = array_session().create_execution_ctx();
     let dtype = DecimalDType::new(10, 2);
     let lhs = decimal_constant(150i64, dtype, 3);
     let rhs = decimal_constant(50i64, dtype, 3);
 
-    let result = decimal_binary(lhs, rhs, Operator::Add).unwrap();
+    let result = decimal_binary(lhs, rhs, Operator::Add)?;
     assert_arrays_eq!(
         result,
-        DecimalArray::from_iter::<i64, _>([200, 200, 200], decimal_add_sub_result_dtype(dtype),),
+        DecimalArray::from_iter::<i64, _>(
+            [200, 200, 200],
+            result_decimal_dtype(dtype, NumericOperator::Add)?,
+        ),
         &mut ctx
     );
+    Ok(())
 }
 
 #[rstest]

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
@@ -5,6 +5,7 @@ use rstest::rstest;
 use vortex_buffer::buffer;
 use vortex_error::VortexResult;
 
+use super::decimal_add_sub_result_dtype;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::RecursiveCanonical;
@@ -18,7 +19,9 @@ use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
 use crate::dtype::DecimalType;
+use crate::dtype::NativeDecimalType;
 use crate::dtype::Nullability;
+use crate::dtype::i256;
 use crate::scalar::DecimalValue;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::operators::Operator;
@@ -252,13 +255,14 @@ fn test_decimal_array_array(
 ) {
     let mut ctx = array_session().create_execution_ctx();
     let dtype = DecimalDType::new(10, 2);
+    let result_dtype = decimal_add_sub_result_dtype(dtype);
     let lhs = DecimalArray::from_iter::<i64, _>([900, 1000], dtype).into_array();
     let rhs = DecimalArray::from_iter::<i64, _>(rhs, dtype).into_array();
 
     let result = decimal_binary(lhs, rhs, op).unwrap();
     assert_arrays_eq!(
         result,
-        DecimalArray::from_iter::<i64, _>(expected, dtype),
+        DecimalArray::from_iter::<i64, _>(expected, result_dtype),
         &mut ctx
     );
 }
@@ -273,7 +277,7 @@ fn test_decimal_mixed_storage_widths() {
     let result = decimal_binary(lhs, rhs, Operator::Add).unwrap();
     assert_arrays_eq!(
         result,
-        DecimalArray::from_iter::<i64, _>([300, 500], dtype),
+        DecimalArray::from_iter::<i64, _>([300, 500], decimal_add_sub_result_dtype(dtype)),
         &mut ctx
     );
 }
@@ -289,16 +293,20 @@ fn test_decimal_nullable_lanes() {
     let result = decimal_binary(lhs, rhs, Operator::Add).unwrap();
     assert_arrays_eq!(
         result,
-        DecimalArray::from_option_iter::<i64, _>([Some(150), None, Some(350)], dtype),
+        DecimalArray::from_option_iter::<i64, _>(
+            [Some(150), None, Some(350)],
+            decimal_add_sub_result_dtype(dtype),
+        ),
         &mut ctx
     );
 }
 
 #[test]
-fn test_decimal_overflow_on_valid_lane_errors() {
-    let dtype = DecimalDType::new(3, 0);
-    let lhs = DecimalArray::from_iter::<i16, _>([999], dtype).into_array();
-    let rhs = DecimalArray::from_iter::<i16, _>([2], dtype).into_array();
+fn test_decimal_max_precision_overflow_on_valid_lane_errors() {
+    let dtype = DecimalDType::new(76, 0);
+    let max = <i256 as NativeDecimalType>::MAX_BY_PRECISION[76];
+    let lhs = DecimalArray::from_iter::<i256, _>([max], dtype).into_array();
+    let rhs = DecimalArray::from_iter::<i256, _>([i256::from_i128(1)], dtype).into_array();
 
     assert!(decimal_binary(lhs, rhs, Operator::Add).is_err());
 }
@@ -306,52 +314,62 @@ fn test_decimal_overflow_on_valid_lane_errors() {
 #[test]
 fn test_decimal_overflow_on_null_lane_ignored() {
     let mut ctx = array_session().create_execution_ctx();
-    let dtype = DecimalDType::new(3, 0);
-    // The null lane holds 999, so adding 500 overflows the precision there but is ignored.
-    let lhs = DecimalArray::new(
-        buffer![999i16, 1],
-        dtype,
-        Validity::from_iter([false, true]),
-    )
-    .into_array();
-    let rhs = decimal_constant(500i16, dtype, 2);
+    let dtype = DecimalDType::new(76, 0);
+    let max = <i256 as NativeDecimalType>::MAX_BY_PRECISION[76];
+    let one = i256::from_i128(1);
+    // The null lane holds the maximum value, so adding one overflows there but is ignored.
+    let lhs = DecimalArray::new(buffer![max, one], dtype, Validity::from_iter([false, true]))
+        .into_array();
+    let rhs = decimal_constant(one, dtype, 2);
 
     let result = decimal_binary(lhs, rhs, Operator::Add).unwrap();
     assert_arrays_eq!(
         result,
-        DecimalArray::from_option_iter::<i16, _>([None, Some(501)], dtype),
+        DecimalArray::from_option_iter::<i256, _>([None, Some(i256::from_i128(2))], dtype,),
         &mut ctx
     );
 }
 
-/// A value can fit the storage width while violating the dtype precision: 60 + 60 fits an i8 but
-/// exceeds precision 2.
 #[test]
-fn test_decimal_precision_stricter_than_width() {
+fn test_decimal_add_reserves_carry_digit() {
+    let mut ctx = array_session().create_execution_ctx();
     let dtype = DecimalDType::new(2, 0);
     let lhs = DecimalArray::from_iter::<i8, _>([60], dtype).into_array();
     let rhs = DecimalArray::from_iter::<i8, _>([60], dtype).into_array();
 
-    assert!(decimal_binary(lhs, rhs, Operator::Add).is_err());
+    let result = decimal_binary(lhs, rhs, Operator::Add).unwrap();
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_iter::<i16, _>([120], DecimalDType::new(3, 0)),
+        &mut ctx
+    );
 }
 
 #[rstest]
 #[case::precision_2(
     DecimalArray::from_iter::<i8, _>([10, 20], DecimalDType::new(2, 0)),
-    DecimalType::I8,
+    DecimalType::I16,
 )]
 #[case::precision_18(
     DecimalArray::from_iter::<i64, _>([10, 20], DecimalDType::new(18, 0)),
-    DecimalType::I64,
+    DecimalType::I128,
 )]
 #[case::precision_38(
     DecimalArray::from_iter::<i128, _>([10, 20], DecimalDType::new(38, 0)),
-    DecimalType::I128,
+    DecimalType::I256,
 )]
-fn test_decimal_result_uses_logical_storage_width(
+#[case::precision_76(
+    DecimalArray::from_iter::<i256, _>(
+        [i256::from_i128(10), i256::from_i128(20)],
+        DecimalDType::new(76, 0),
+    ),
+    DecimalType::I256,
+)]
+fn test_decimal_result_uses_widened_logical_storage_width(
     #[case] values: DecimalArray,
     #[case] expected_type: DecimalType,
 ) -> VortexResult<()> {
+    let expected_dtype = decimal_add_sub_result_dtype(values.decimal_dtype());
     let result = decimal_binary(
         values.clone().into_array(),
         values.into_array(),
@@ -360,18 +378,52 @@ fn test_decimal_result_uses_logical_storage_width(
     .execute::<DecimalArray>(&mut array_session().create_execution_ctx())?;
 
     assert_eq!(result.values_type(), expected_type);
+    assert_eq!(result.decimal_dtype(), expected_dtype);
+    Ok(())
+}
+
+#[test]
+fn test_decimal_precision_76_boundary() -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(76, 0);
+    let max = <i256 as NativeDecimalType>::MAX_BY_PRECISION[76];
+    let zero = i256::from_i128(0);
+    let one = i256::from_i128(1);
+
+    let result = decimal_binary(
+        DecimalArray::from_iter::<i256, _>([max], dtype).into_array(),
+        DecimalArray::from_iter::<i256, _>([zero], dtype).into_array(),
+        Operator::Add,
+    )?;
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_iter::<i256, _>([max], dtype),
+        &mut ctx
+    );
+
+    let overflow = decimal_binary(
+        DecimalArray::from_iter::<i256, _>([max], dtype).into_array(),
+        DecimalArray::from_iter::<i256, _>([one], dtype).into_array(),
+        Operator::Add,
+    );
+    assert!(overflow.is_err());
     Ok(())
 }
 
 #[test]
 fn test_decimal_empty_constants_do_not_evaluate() -> VortexResult<()> {
-    let dtype = DecimalDType::new(3, 0);
-    let lhs = decimal_constant(999i16, dtype, 0);
-    let rhs = decimal_constant(1i16, dtype, 0);
+    let dtype = DecimalDType::new(76, 0);
+    let max = <i256 as NativeDecimalType>::MAX_BY_PRECISION[76];
+    let lhs = decimal_constant(max, dtype, 0);
+    let rhs = decimal_constant(i256::from_i128(1), dtype, 0);
 
     let result = decimal_binary(lhs, rhs, Operator::Add)?;
 
     assert!(result.is_empty());
+    assert_eq!(
+        result.dtype(),
+        &DType::Decimal(dtype, Nullability::NonNullable)
+    );
     Ok(())
 }
 
@@ -385,7 +437,7 @@ fn test_decimal_constant_lhs_non_commutative() {
     let result = decimal_binary(lhs, rhs, Operator::Sub).unwrap();
     assert_arrays_eq!(
         result,
-        DecimalArray::from_iter::<i64, _>([750, 600], dtype),
+        DecimalArray::from_iter::<i64, _>([750, 600], decimal_add_sub_result_dtype(dtype),),
         &mut ctx
     );
 }
@@ -404,7 +456,10 @@ fn test_decimal_nullable_constant_preserves_nullable_output() {
     let result = decimal_binary(values, constant, Operator::Add).unwrap();
     assert_arrays_eq!(
         result,
-        DecimalArray::from_option_iter::<i64, _>([Some(150), Some(250)], dtype),
+        DecimalArray::from_option_iter::<i64, _>(
+            [Some(150), Some(250)],
+            decimal_add_sub_result_dtype(dtype),
+        ),
         &mut ctx
     );
 }
@@ -423,7 +478,7 @@ fn test_decimal_null_constant_yields_all_null() {
     let result = decimal_binary(values, null_constant, Operator::Add).unwrap();
     assert_arrays_eq!(
         result,
-        DecimalArray::from_option_iter::<i64, _>([None, None], dtype),
+        DecimalArray::from_option_iter::<i64, _>([None, None], decimal_add_sub_result_dtype(dtype),),
         &mut ctx
     );
 }
@@ -440,7 +495,10 @@ fn test_decimal_constant_wider_than_array_storage() {
     let result = decimal_binary(values, constant, Operator::Add).unwrap();
     assert_arrays_eq!(
         result,
-        DecimalArray::from_iter::<i64, _>([10_000_000_001, 10_000_000_002], dtype),
+        DecimalArray::from_iter::<i64, _>(
+            [10_000_000_001, 10_000_000_002],
+            decimal_add_sub_result_dtype(dtype),
+        ),
         &mut ctx
     );
 }
@@ -454,7 +512,7 @@ fn test_decimal_empty() {
     let result = decimal_binary(empty.clone(), empty, Operator::Add).unwrap();
     assert_arrays_eq!(
         result,
-        DecimalArray::from_iter::<i64, _>([], dtype),
+        DecimalArray::from_iter::<i64, _>([], decimal_add_sub_result_dtype(dtype)),
         &mut ctx
     );
 }
@@ -469,7 +527,7 @@ fn test_decimal_constant_constant_folds() {
     let result = decimal_binary(lhs, rhs, Operator::Add).unwrap();
     assert_arrays_eq!(
         result,
-        DecimalArray::from_iter::<i64, _>([200, 200, 200], dtype),
+        DecimalArray::from_iter::<i64, _>([200, 200, 200], decimal_add_sub_result_dtype(dtype),),
         &mut ctx
     );
 }


### PR DESCRIPTION
Adds shared infrastructure for decimal arithmetic and native Add/Sub kernels.

### Operand alignment

The execution kernel requires both operands to have the same precision and scale (nullability may differ). Addition and subtraction can then operate directly and exactly on the unscaled integers because both values use the same power-of-ten factor.

Vortex's optional coercion pass can align operands with different decimal dtypes before execution. Query-engine integrations may instead insert their own planner casts. If neither layer aligns the operands, the kernel rejects them rather than performing an implicit per-kernel rescale.

### Result precision

Adding or subtracting two `p`-digit integers can require one additional carry digit. This PR follows the Arrow/Hive result-type rule for already aligned operands, capped at Vortex's maximum decimal precision:

```text
decimal(p, s) +/- decimal(p, s) -> decimal(min(p + 1, 76), s)
```

The scale remains unchanged because the operation is performed on integers at the same scale. For example:

```text
decimal(2, 0): 60 + 60 = 120 -> decimal(3, 0)
decimal(5, 2): 123.45 + 0.55 = 124.00 -> decimal(6, 2)
```

Widening the logical precision can also widen the native storage used for the result. The kernel executes at the smallest native width capable of representing the result dtype, including the important `decimal(18, s) -> decimal(19, s)` (`i64 -> i128`) and `decimal(38, s) -> decimal(39, s)` (`i128 -> i256`) transitions. Inputs may already use a wider physical representation; they are converted into the selected working width before arithmetic.

At precision 76 the result dtype cannot widen to precision 77, so it stays at precision 76 and the kernel explicitly checks the mathematical result against the precision-76 bound. 

### Nulls, constants, and errors

- Output nullability is the union of the input nullabilities, while a lane is valid only when both input lanes are valid.
- Validity is combined and materialized once. Arithmetic runs only on valid lanes, so arbitrary values underneath null lanes cannot trigger an overflow error.
- Any native-width overflow or result-precision overflow on a valid lane returns an error for the operation.
- Constant and all-null operands are handled directly instead of first materializing full decimal buffers. Constant folding is preserved, and empty Add/Sub inputs produce a correctly widened empty dtype without evaluating a constant value.
- Decimal Mul/Div remain unsupported because they require separate result-type and rescaling rules.

### Implementation

- Splits numeric execution into `numeric/{mod,primitive,decimal,tests}.rs`, mirroring the compare implementation.
- Canonicalizes encoded decimal operands through `execute::<DecimalArray>`, while extracting constant and null operands directly.
- Uses a checked lane loop at the result's working width, followed by an explicit precision-bound check.
- Shares `widened_buffer` from `arrays/decimal` between comparison and numeric execution.

### Comparative performance

Measured over arrays with ~60k elements, using same result width in Vortex and Arrow.

| Case | Vortex Add | Arrow Add | Vortex Sub | Arrow Sub | Vortex speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| `i32`, non-null | 59.87 us | 100.4 us | 59.74 us | 100.4 us | 1.68x |
| `i64`, non-null | 61.66 us | 101.1 us | 62.29 us | 101.2 us | 1.62-1.64x |
| `i128`, non-null | 68.91 us | 145.4 us | 69.54 us | 145.6 us | 2.09-2.11x |
| `i256`, nullable | 175.4 us | 564.7 us | 163.2 us | 561.5 us | 3.22-3.44x |
