### PR TITLE
test: canary for the flaky-benchmark fixes in #8742 (do not merge)

### DIFF
--- a/vortex-array/src/serde.rs
+++ b/vortex-array/src/serde.rs
@@ -329,7 +329,10 @@ impl SerializedArray {
             if session.allows_unknown() {
                 return self.decode_foreign(encoding_id, dtype, len, ctx);
             }
-            vortex_bail!("Unknown encoding: {}", encoding_id);
+            vortex_bail!(
+                "Unknown encoding: {} (not registered in this session)",
+                encoding_id
+            );
         };
 
         let children = SerializedArrayChildren {


### PR DESCRIPTION
## Rationale for this change

Validation canary for #8742 — **served its purpose, closed without merging.**

This PR stacked a deliberately layout-shifting, perf-irrelevant change (a cold-path error-string tweak in `vortex-array`, mimicking #8681 — a real PR that collected five false CodSpeed flags under glibc malloc) on top of the flaky-benchmark fixes, so CodSpeed would compare mimalloc-vs-mimalloc across different binaries — the comparison every future PR gets after #8742 merges.

## Result: Performance Gate Passed ✅

`✅ 1660 untouched benchmarks, ⏩ 47 skipped` — zero regressed, zero improved, zero new, comparing `claude/flaky-bench-canary-u68he8` (40c5e76) with `claude/flaky-microbenchmarks-cleanup-u68he8` (4efeb0d). CodSpeed posts no comment when there are no changes to report; the green check is the report.

Together with the A/A rerun on #8742 (identical tree measured twice on separate runners: all values reproduced exactly), this validates the fixes from both directions.

https://claude.ai/code/session_01T6PPcdrqcNeUkfi1EGd4oC