### PR TITLE
Better error message for unsupported Arrow vector type in Spark reader

### DIFF
--- a/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexArrowColumnVector.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexArrowColumnVector.java
@@ -329,7 +329,8 @@ public class VortexArrowColumnVector extends ColumnVector {
         } else if (vector instanceof DurationVector) {
             accessor = new VortexArrowColumnVector.DurationAccessor((DurationVector) vector);
         } else {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException(
+                    "Unsupported Arrow vector type: " + vector.getClass().getName());
         }
     }
 


### PR DESCRIPTION
## Rationale for this change

`VortexArrowColumnVector.initAccessor` threw a bare `UnsupportedOperationException`
with no message when it encountered an Arrow vector type it does not handle. When
this fires, the user only gets a stack trace with no indication of which type was
unsupported, making it needlessly hard to diagnose.

## What changes are included in this PR?

Include the offending vector's class name in the exception message, matching the
existing idiom already used in `ArrowUtils` (`"Unsupported Arrow type: " + ...`).
No behavior change beyond the message text.

## What APIs are changed? Are there any user-facing changes?

No API changes. Only the text of an already-thrown exception is improved.
