### PR TITLE
forbid todo!/unimplemented! in vortex-duckdb

### DIFF
--- a/vortex-duckdb/src/convert/dtype.rs
+++ b/vortex-duckdb/src/convert/dtype.rs
@@ -179,17 +179,19 @@ impl FromLogicalType for DType {
                 )
             }
             DUCKDB_TYPE::DUCKDB_TYPE_VARIANT => DType::Variant(nullability),
-            DUCKDB_TYPE::DUCKDB_TYPE_TIME_TZ => todo!(),
-            DUCKDB_TYPE::DUCKDB_TYPE_INTERVAL => todo!(),
-            DUCKDB_TYPE::DUCKDB_TYPE_ENUM => todo!(),
-            DUCKDB_TYPE::DUCKDB_TYPE_MAP => todo!(),
-            DUCKDB_TYPE::DUCKDB_TYPE_UUID => todo!(),
-            DUCKDB_TYPE::DUCKDB_TYPE_UNION => todo!(),
-            DUCKDB_TYPE::DUCKDB_TYPE_BIT => todo!(),
-            DUCKDB_TYPE::DUCKDB_TYPE_ANY => todo!(),
-            DUCKDB_TYPE::DUCKDB_TYPE_BIGNUM => todo!(),
-            DUCKDB_TYPE::DUCKDB_TYPE_STRING_LITERAL => todo!(),
-            DUCKDB_TYPE::DUCKDB_TYPE_INTEGER_LITERAL => todo!(),
+            other @ (DUCKDB_TYPE::DUCKDB_TYPE_TIME_TZ
+            | DUCKDB_TYPE::DUCKDB_TYPE_INTERVAL
+            | DUCKDB_TYPE::DUCKDB_TYPE_ENUM
+            | DUCKDB_TYPE::DUCKDB_TYPE_MAP
+            | DUCKDB_TYPE::DUCKDB_TYPE_UUID
+            | DUCKDB_TYPE::DUCKDB_TYPE_UNION
+            | DUCKDB_TYPE::DUCKDB_TYPE_BIT
+            | DUCKDB_TYPE::DUCKDB_TYPE_ANY
+            | DUCKDB_TYPE::DUCKDB_TYPE_BIGNUM
+            | DUCKDB_TYPE::DUCKDB_TYPE_STRING_LITERAL
+            | DUCKDB_TYPE::DUCKDB_TYPE_INTEGER_LITERAL) => {
+                vortex_bail!("{other:?} -> DType conversion is not supported")
+            }
         })
     }
 }
@@ -241,10 +243,9 @@ impl TryFrom<&DType> for LogicalType {
             DType::Struct(struct_type, _) => {
                 return LogicalType::try_from(struct_type);
             }
-            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::Variant(_) => {
-                vortex_bail!("Vortex Variant array aren't supported in DuckDB")
-            }
+            // TODO(connor): Union
+            DType::Union(..) => vortex_bail!("Vortex Union isn't supported"),
+            DType::Variant(_) => vortex_bail!("Vortex Variant array aren't supported"),
             DType::Extension(ext_dtype) => {
                 // Handle first-party extension types that have DuckDB equivalents.
                 if let Some(temporal) = ext_dtype.metadata_opt::<AnyTemporal>() {

--- a/vortex-duckdb/src/convert/expr.rs
+++ b/vortex-duckdb/src/convert/expr.rs
@@ -732,14 +732,14 @@ impl TryFrom<DUCKDB_VX_EXPR_TYPE> for Operator {
 
     fn try_from(value: DUCKDB_VX_EXPR_TYPE) -> VortexResult<Self> {
         Ok(match value {
-            DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_INVALID => vortex_bail!("invalid expr"),
+            DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_INVALID => vortex_bail!("invalid expression"),
             DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_COMPARE_EQUAL => Operator::Eq,
             DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_COMPARE_NOTEQUAL => Operator::NotEq,
             DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_COMPARE_LESSTHAN => Operator::Lt,
             DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_COMPARE_GREATERTHAN => Operator::Gt,
             DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_COMPARE_LESSTHANOREQUALTO => Operator::Lte,
             DUCKDB_VX_EXPR_TYPE::DUCKDB_VX_EXPR_TYPE_COMPARE_GREATERTHANOREQUALTO => Operator::Gte,
-            _ => todo!("cannot convert {:?}", value),
+            _ => vortex_bail!("cannot convert {:?}", value),
         })
     }
 }

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -78,11 +78,14 @@ impl ToDuckDBScalar for Scalar {
             DType::Decimal(..) => self.as_decimal().try_to_duckdb_scalar(),
             DType::Utf8(_) => self.as_utf8().try_to_duckdb_scalar(),
             DType::Binary(_) => self.as_binary().try_to_duckdb_scalar(),
-            DType::List(..) | DType::FixedSizeList(..) | DType::Struct(..) => todo!(),
-            DType::Union(..) => todo!("TODO(connor)[Union]: unimplemented"),
-            DType::Variant(_) => {
-                vortex_bail!("Vortex Variant scalars aren't supported in DuckDB")
+            DType::List(..) => vortex_bail!("Vortex List scalars aren't supported"),
+            DType::FixedSizeList(..) => {
+                vortex_bail!("Vortex FixedSizeList scalars aren't supported")
             }
+            DType::Variant(_) => vortex_bail!("Vortex Variant scalars aren't supported"),
+            DType::Struct(..) => vortex_bail!("Vortex Struct scalars aren't supported"),
+            // TODO(connor): Union
+            DType::Union(..) => vortex_bail!("Vortex Union scalars aren't supported"),
             DType::Extension(..) => self.as_extension().try_to_duckdb_scalar(),
         }
     }

--- a/vortex-duckdb/src/convert/vector.rs
+++ b/vortex-duckdb/src/convert/vector.rs
@@ -361,7 +361,7 @@ pub fn flat_vector_to_vortex(vector: &VectorRef, len: usize) -> VortexResult<Arr
             StructArray::try_new(names, children, len, vector.validity_ref(len).to_validity())
                 .map(|a| a.into_array())
         }
-        type_id => unimplemented!("missing impl for {type_id:?}"),
+        type_id => vortex_bail!("{type_id:?} flat Vector to Vortex array not supported"),
     }
 }
 

--- a/vortex-duckdb/src/lib.rs
+++ b/vortex-duckdb/src/lib.rs
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 #![expect(clippy::missing_safety_doc)]
+#![forbid(clippy::todo)]
+#![forbid(clippy::unimplemented)]
 
 use std::ffi::c_char;
 use std::ffi::c_void;


### PR DESCRIPTION
We should never crash the host if we don't have support for
something
