### PR TITLE
ci: cut wasted minutes from measurement_id and WASM jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+      # sync: false — the test runs via `uv run --no-project` and needs no workspace
+      # packages; the default `uv sync` builds the vortex-data Rust extension (~6 min).
       - uses: spiraldb/actions/.github/actions/setup-uv@a746510eafaa926484c354541cfc49b2ec06cc63  # 0.18.6
+        with:
+          sync: false
       - name: Pytest - measurement_id golden vectors
         run: |
           uv run --no-project --with pytest --with xxhash \
@@ -415,6 +419,10 @@ jobs:
             --exclude compress-bench --exclude xtask --exclude vortex-datafusion `
             --exclude gpu-scan-cli --exclude vortex-sqllogictest
 
+      - name: sccache stats
+        if: always() && github.repository == 'vortex-data/vortex'
+        run: sccache --show-stats
+
       - name: Alert incident.io
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/develop'
         uses: ./.github/actions/alert-incident-io
@@ -584,14 +592,23 @@ jobs:
 
   wasm-integration:
     name: "WASM integration smoke test"
-    runs-on: ubuntu-latest
     timeout-minutes: 30
+    runs-on: >-
+      ${{ github.repository == 'vortex-data/vortex'
+          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=wasm-integration', github.run_id)
+          || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
-      - uses: ./.github/actions/setup-rust
+      - uses: runs-on/action@v2
+        if: github.repository == 'vortex-data/vortex'
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sccache: s3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+      - uses: ./.github/actions/setup-prebuild
+        with:
+          enable-sccache: "true"
           targets: "wasm32-wasip1"
+      - name: Install wasm32-wasip1 target
+        run: rustup target add wasm32-wasip1
       - name: Setup Wasmer
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

Three targeted fixes from profiling recent CI runs (job/step timings + logs from PR runs of `Linters and Tests`):

- **`measurement_id golden vectors`: 6.2 min → ~20 s.** The `setup-uv` action defaults to `uv sync --all-extras --dev`, which builds the vortex-data PyO3 extension via maturin on an uncached `ubuntu-latest` runner — ~6 min of the job (verified in job logs: `Run uv sync --all-extras --dev` → `Building vortex-data`). The test itself takes ~1 s and uses `uv run --no-project`, so it needs no workspace packages. Pass `sync: false`, matching the existing `python-cuda-test` job.
- **WASM integration smoke test: ~5.2 min → expected ~1–2 min.** It was the only Rust-compiling job left on plain `ubuntu-latest` with no compiler cache; ~4.5 min is a cold `cargo build`. Moved to the prebuilt runs-on image with S3 sccache, following the same pattern as the other build jobs (fork fallback to `ubuntu-latest` preserved; `rustup target add wasm32-wasip1` mirrors what the wasm32 build job does).
- **Windows sccache observability.** `Rust tests (windows-x64)` is the ci.yml PR critical path (consistently 6.8–7.7 min across the last 8 PR runs, ~5 min of it compile). The sccache server demonstrably starts, but logs give no way to see hit rates. Added an `sccache --show-stats` step (`if: always()`, main repo only) so cache effectiveness on Windows is visible per run.

## Not included (infra-side observations from the same investigation)

- Codspeed PR runs take 9–14 min but shards compute for only 0.8–4 min — they queue 5.5–9.8 min for `amd64-medium` runners while concurrent ci.yml jobs get runners in <1 min. One PR push requests ~26 runs-on VMs at once; this looks like a concurrent-instance/pool cap in `.github-private` (this repo's `runs-on.yml` only defines images). Raising capacity there, or consolidating the 8 Codspeed shards to 4, would cut the largest remaining chunk of PR wall clock.
- The Windows pool uses `m8i-flex.2xlarge` (8 vCPU); a size bump would directly shrink the PR critical path since compile dominates and linking 53 test binaries is uncacheable.

## Checks

- `yamllint --strict -c .yamllint.yaml .github/workflows/ci.yml` — passes.
- Workflow-only change; no Rust/Python code touched, so no cargo/pytest checks were run per repo guidance. The WASM job change is best validated by this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)