### PR TITLE
ListArray::reset_offsets doesn't need to revalidate array after reset

### DIFF
--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -28,6 +28,7 @@ use crate::array::child_to_validity;
 use crate::array::validity_to_child;
 use crate::arrays::ConstantArray;
 use crate::arrays::List;
+use crate::arrays::ListArray;
 use crate::arrays::Primitive;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
@@ -338,7 +339,6 @@ pub trait ListArrayExt: TypedArrayRef<List> {
         let mut elements = self.sliced_elements()?;
         if recurse && elements.is_canonical() {
             let compacted = elements
-                .clone()
                 .execute::<Canonical>(ctx)?
                 .compact(ctx)?
                 .into_array();
@@ -357,7 +357,7 @@ pub trait ListArrayExt: TypedArrayRef<List> {
             Operator::Sub,
         )?;
 
-        Array::<List>::try_new(elements, adjusted_offsets, self.list_validity())
+        Ok(unsafe { ListArray::new_unchecked(elements, adjusted_offsets, self.list_validity()) })
     }
 }
 impl<T: TypedArrayRef<List>> ListArrayExt for T {}

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -357,6 +357,7 @@ pub trait ListArrayExt: TypedArrayRef<List> {
             Operator::Sub,
         )?;
 
+        // SAFETY: By resetting the offsets we simply "shift" everything left and discard trailing garbage, so all invariants remain the same.
         Ok(unsafe { ListArray::new_unchecked(elements, adjusted_offsets, self.list_validity()) })
     }
 }


### PR DESCRIPTION
Reset offsets operations if they start from a valid array they should stay valid
