### PR TITLE
fix(spark): reject MapType instead of emitting a childless Arrow List

### DIFF
--- a/java/vortex-spark/src/main/java/dev/vortex/spark/write/SparkToArrowSchema.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/write/SparkToArrowSchema.java
@@ -23,7 +23,6 @@ import org.apache.spark.sql.types.DoubleType;
 import org.apache.spark.sql.types.FloatType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
-import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructField;
@@ -125,9 +124,6 @@ public final class SparkToArrowSchema {
             return new ArrowType.List();
         } else if (sparkType instanceof StructType) {
             return new ArrowType.Struct();
-        } else if (sparkType instanceof MapType) {
-            // Map is represented as List<Struct<key, value>> in Arrow
-            return new ArrowType.List();
         } else {
             throw new UnsupportedOperationException("Unsupported Spark type for Arrow conversion: "
                     + sparkType.getClass().getName());

--- a/java/vortex-spark/src/test/java/dev/vortex/spark/write/SparkToArrowSchemaTest.java
+++ b/java/vortex-spark/src/test/java/dev/vortex/spark/write/SparkToArrowSchemaTest.java
@@ -173,4 +173,14 @@ final class SparkToArrowSchemaTest {
                 assertThrows(UnsupportedOperationException.class, () -> SparkToArrowSchema.convert(schema));
         assertTrue(e.getMessage().contains("CalendarIntervalType"));
     }
+
+    @Test
+    @DisplayName("MapType is rejected rather than converted to a childless List")
+    void mapTypeIsRejected() {
+        StructType schema =
+                new StructType().add("m", DataTypes.createMapType(DataTypes.StringType, DataTypes.IntegerType));
+        UnsupportedOperationException e =
+                assertThrows(UnsupportedOperationException.class, () -> SparkToArrowSchema.convert(schema));
+        assertTrue(e.getMessage().contains("MapType"));
+    }
 }


### PR DESCRIPTION
`SparkToArrowSchema` mapped `MapType` to a childless `ArrowType.List`, which is an invalid Arrow list (a List must have exactly one child). Drop the branch so `MapType` falls through to the existing fail-fast `UnsupportedOperationException`, and add a test.