### PR TITLE
Remove Arrow macro benchmarks

### DIFF
--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -68,7 +68,6 @@ on:
               "name": "TPC-H SF=1 on NVME",
               "data_formats": ["parquet", "vortex", "vortex-compact", "duckdb"],
               "pr_targets": [
-                {"engine": "datafusion", "format": "arrow"},
                 {"engine": "datafusion", "format": "parquet"},
                 {"engine": "datafusion", "format": "vortex"},
                 {"engine": "datafusion", "format": "vortex-compact"},
@@ -78,7 +77,6 @@ on:
                 {"engine": "duckdb", "format": "duckdb"}
               ],
               "develop_targets": [
-                {"engine": "datafusion", "format": "arrow"},
                 {"engine": "datafusion", "format": "parquet"},
                 {"engine": "datafusion", "format": "vortex"},
                 {"engine": "datafusion", "format": "vortex-compact"},
@@ -123,7 +121,6 @@ on:
               "name": "TPC-H SF=10 on NVME",
               "data_formats": ["parquet", "vortex", "vortex-compact", "duckdb"],
               "pr_targets": [
-                {"engine": "datafusion", "format": "arrow"},
                 {"engine": "datafusion", "format": "parquet"},
                 {"engine": "datafusion", "format": "vortex"},
                 {"engine": "datafusion", "format": "vortex-compact"},
@@ -133,7 +130,6 @@ on:
                 {"engine": "duckdb", "format": "duckdb"}
               ],
               "develop_targets": [
-                {"engine": "datafusion", "format": "arrow"},
                 {"engine": "datafusion", "format": "parquet"},
                 {"engine": "datafusion", "format": "vortex"},
                 {"engine": "datafusion", "format": "vortex-compact"},
@@ -369,14 +365,12 @@ on:
               "name": "TPC-H SF=1 on NVME",
               "data_formats": ["parquet", "vortex"],
               "pr_targets": [
-                {"engine": "datafusion", "format": "arrow"},
                 {"engine": "datafusion", "format": "parquet"},
                 {"engine": "datafusion", "format": "vortex"},
                 {"engine": "duckdb", "format": "parquet"},
                 {"engine": "duckdb", "format": "vortex"}
               ],
               "develop_targets": [
-                {"engine": "datafusion", "format": "arrow"},
                 {"engine": "datafusion", "format": "parquet"},
                 {"engine": "datafusion", "format": "vortex"},
                 {"engine": "datafusion", "format": "lance"},
@@ -414,14 +408,12 @@ on:
               "name": "TPC-H SF=10 on NVME",
               "data_formats": ["parquet", "vortex"],
               "pr_targets": [
-                {"engine": "datafusion", "format": "arrow"},
                 {"engine": "datafusion", "format": "parquet"},
                 {"engine": "datafusion", "format": "vortex"},
                 {"engine": "duckdb", "format": "parquet"},
                 {"engine": "duckdb", "format": "vortex"}
               ],
               "develop_targets": [
-                {"engine": "datafusion", "format": "arrow"},
                 {"engine": "datafusion", "format": "parquet"},
                 {"engine": "datafusion", "format": "vortex"},
                 {"engine": "datafusion", "format": "lance"},

--- a/bench-orchestrator/README.md
+++ b/bench-orchestrator/README.md
@@ -269,7 +269,7 @@ vx-bench clean --older-than "30 days" --no-keep-labeled
 
 | Engine     | Supported Formats                          |
 |------------|-------------------------------------------|
-| datafusion | arrow, parquet, vortex, vortex-compact, lance |
+| datafusion | parquet, vortex, vortex-compact, lance        |
 | duckdb     | parquet, vortex, vortex-compact, duckdb   |
 | lance      | lance                                      |
 

--- a/bench-orchestrator/bench_orchestrator/config.py
+++ b/bench-orchestrator/bench_orchestrator/config.py
@@ -31,7 +31,6 @@ class Engine(Enum):
 class Format(Enum):
     """Data formats for benchmarks."""
 
-    ARROW = "arrow"
     PARQUET = "parquet"
     VORTEX = "vortex"
     VORTEX_COMPACT = "vortex-compact"
@@ -60,7 +59,6 @@ class Benchmark(Enum):
 # Engine to supported formats mapping.
 ENGINE_FORMATS: dict[Engine, list[Format]] = {
     Engine.DATAFUSION: [
-        Format.ARROW,
         Format.PARQUET,
         Format.VORTEX,
         Format.VORTEX_COMPACT,

--- a/bench-orchestrator/tests/test_config.py
+++ b/bench-orchestrator/tests/test_config.py
@@ -46,15 +46,15 @@ def test_resolve_axis_targets_offers_vortex_native_on_duckdb_only() -> None:
 def test_resolve_axis_targets_filters_unsupported_combinations() -> None:
     targets, warnings = resolve_axis_targets(
         [Engine.DATAFUSION, Engine.DUCKDB],
-        [Format.ARROW, Format.PARQUET],
+        [Format.LANCE, Format.PARQUET],
     )
 
     assert targets == [
-        BenchmarkTarget(engine=Engine.DATAFUSION, format=Format.ARROW),
+        BenchmarkTarget(engine=Engine.DATAFUSION, format=Format.LANCE),
         BenchmarkTarget(engine=Engine.DATAFUSION, format=Format.PARQUET),
         BenchmarkTarget(engine=Engine.DUCKDB, format=Format.PARQUET),
     ]
-    assert warnings == ["Format arrow is not supported by engine duckdb"]
+    assert warnings == ["Format lance is not supported by engine duckdb"]
 
 
 def test_resolve_axis_targets_skips_engines_a_benchmark_cannot_run() -> None:

--- a/benchmarks/datafusion-bench/src/lib.rs
+++ b/benchmarks/datafusion-bench/src/lib.rs
@@ -7,7 +7,6 @@ pub mod tracer;
 use std::sync::Arc;
 
 use datafusion::datasource::file_format::FileFormat;
-use datafusion::datasource::file_format::arrow::ArrowFormat;
 use datafusion::datasource::file_format::csv::CsvFormat;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::provider::DefaultTableFactory;
@@ -109,7 +108,6 @@ pub fn make_object_store(
 pub fn format_to_df_format(format: Format) -> Arc<dyn FileFormat> {
     match format {
         Format::Csv => Arc::new(CsvFormat::default()) as _,
-        Format::Arrow => Arc::new(ArrowFormat),
         Format::Parquet => Arc::new(ParquetFormat::new()),
         Format::OnDiskVortex | Format::VortexCompact | Format::VortexNative => Arc::new(
             VortexFormat::new_with_options(SESSION.clone(), vortex_table_options()),

--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -24,7 +24,11 @@ use datafusion_bench::tracer::set_labels;
 use datafusion_physical_plan::ExecutionPlan;
 use datafusion_physical_plan::collect;
 use parking_lot::Mutex;
+use vortex::file::multi::MultiFileDataSource;
 use vortex::io::filesystem::FileSystemRef;
+use vortex::io::object_store::ObjectStoreFileSystem;
+use vortex::io::session::RuntimeSessionExt;
+use vortex::scan::DataSource as _;
 use vortex::scan::DataSourceRef;
 use vortex_arrow::ToArrowType;
 use vortex_bench::Benchmark;
@@ -46,6 +50,7 @@ use vortex_bench::runner::filter_queries;
 use vortex_bench::setup_logging_and_tracing;
 use vortex_bench::v3;
 use vortex_datafusion::metrics::VortexMetricsFinder;
+use vortex_datafusion::v2::VortexTable;
 
 /// Common arguments shared across benchmarks
 #[derive(Parser)]
@@ -253,42 +258,39 @@ async fn register_benchmark_tables<B: Benchmark + ?Sized>(
     benchmark: &B,
     format: Format,
 ) -> anyhow::Result<()> {
-    match format {
-        _ if use_scan_api() && matches!(format, Format::OnDiskVortex | Format::VortexCompact) => {
-            register_v2_tables(session, benchmark, format).await
+    if use_scan_api() && matches!(format, Format::OnDiskVortex | Format::VortexCompact) {
+        register_v2_tables(session, benchmark, format).await
+    } else {
+        let benchmark_base = benchmark.data_url().join(&format!("{}/", format.name()))?;
+        let file_format = format_to_df_format(format);
+
+        for table in benchmark.table_specs().iter() {
+            let pattern = benchmark.pattern(table.name, format);
+            let table_url = ListingTableUrl::try_new(benchmark_base.clone(), pattern)?;
+
+            let listing_options = ListingOptions::new(Arc::clone(&file_format))
+                .with_session_config_options(session.state().config());
+            let mut config =
+                ListingTableConfig::new(table_url).with_listing_options(listing_options);
+
+            config = match table.schema.as_ref() {
+                Some(schema) => config.with_schema(Arc::new(schema.clone())),
+                None => config.infer_schema(&session.state()).await?,
+            };
+
+            let listing_table = Arc::new(
+                ListingTable::try_new(config)?.with_cache(
+                    session
+                        .runtime_env()
+                        .cache_manager
+                        .get_file_statistic_cache(),
+                ),
+            );
+
+            session.register_table(table.name, listing_table)?;
         }
-        _ => {
-            let benchmark_base = benchmark.data_url().join(&format!("{}/", format.name()))?;
-            let file_format = format_to_df_format(format);
 
-            for table in benchmark.table_specs().iter() {
-                let pattern = benchmark.pattern(table.name, format);
-                let table_url = ListingTableUrl::try_new(benchmark_base.clone(), pattern)?;
-
-                let listing_options = ListingOptions::new(Arc::clone(&file_format))
-                    .with_session_config_options(session.state().config());
-                let mut config =
-                    ListingTableConfig::new(table_url).with_listing_options(listing_options);
-
-                config = match table.schema.as_ref() {
-                    Some(schema) => config.with_schema(Arc::new(schema.clone())),
-                    None => config.infer_schema(&session.state()).await?,
-                };
-
-                let listing_table = Arc::new(
-                    ListingTable::try_new(config)?.with_cache(
-                        session
-                            .runtime_env()
-                            .cache_manager
-                            .get_file_statistic_cache(),
-                    ),
-                );
-
-                session.register_table(table.name, listing_table)?;
-            }
-
-            Ok(())
-        }
+        Ok(())
     }
 }
 
@@ -298,12 +300,6 @@ async fn register_v2_tables<B: Benchmark + ?Sized>(
     benchmark: &B,
     format: Format,
 ) -> anyhow::Result<()> {
-    use vortex::file::multi::MultiFileDataSource;
-    use vortex::io::object_store::ObjectStoreFileSystem;
-    use vortex::io::session::RuntimeSessionExt;
-    use vortex::scan::DataSource as _;
-    use vortex_datafusion::v2::VortexTable;
-
     let benchmark_base = benchmark.data_url().join(&format!("{}/", format.name()))?;
 
     for table in benchmark.table_specs().iter() {

--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -15,7 +15,6 @@ use datafusion::datasource::listing::ListingOptions;
 use datafusion::datasource::listing::ListingTable;
 use datafusion::datasource::listing::ListingTableConfig;
 use datafusion::datasource::listing::ListingTableUrl;
-use datafusion::parquet::arrow::ParquetRecordBatchStreamBuilder;
 use datafusion::prelude::SessionContext;
 use datafusion_bench::format_to_df_format;
 use datafusion_bench::metrics::MetricsSetExt;
@@ -24,9 +23,7 @@ use datafusion_bench::tracer::get_static_tracer;
 use datafusion_bench::tracer::set_labels;
 use datafusion_physical_plan::ExecutionPlan;
 use datafusion_physical_plan::collect;
-use futures::StreamExt;
 use parking_lot::Mutex;
-use tokio::fs::File;
 use vortex::io::filesystem::FileSystemRef;
 use vortex::scan::DataSourceRef;
 use vortex_arrow::ToArrowType;
@@ -257,7 +254,6 @@ async fn register_benchmark_tables<B: Benchmark + ?Sized>(
     format: Format,
 ) -> anyhow::Result<()> {
     match format {
-        Format::Arrow => register_arrow_tables(session, benchmark).await,
         _ if use_scan_api() && matches!(format, Format::OnDiskVortex | Format::VortexCompact) => {
             register_v2_tables(session, benchmark, format).await
         }
@@ -340,63 +336,6 @@ async fn register_v2_tables<B: Benchmark + ?Sized>(
 
         let table_provider = Arc::new(VortexTable::new(data_source, SESSION.clone(), arrow_schema));
         session.register_table(table.name, table_provider)?;
-    }
-
-    Ok(())
-}
-
-/// Load Arrow IPC files into in-memory DataFusion tables.
-async fn register_arrow_tables<B: Benchmark + ?Sized>(
-    session: &SessionContext,
-    benchmark: &B,
-) -> anyhow::Result<()> {
-    use datafusion::datasource::MemTable;
-
-    let parquet_dir = benchmark
-        .data_url()
-        .to_file_path()
-        .map_err(|_| anyhow::anyhow!("Arrow format requires local file path"))?
-        .join(Format::Parquet.name());
-
-    // Read all arrow files from the directory
-    let data_files = std::fs::read_dir(&parquet_dir)?.collect::<Result<Vec<_>, _>>()?;
-
-    for table in benchmark.table_specs().iter() {
-        let pattern = benchmark.pattern(table.name, Format::Parquet);
-
-        // Find files matching this table's pattern
-        let matching_files: Vec<_> = data_files
-            .iter()
-            .filter(|entry| {
-                let filename = entry.file_name();
-                let filename_str = filename.to_str().unwrap_or("");
-                match &pattern {
-                    Some(p) => p.matches(filename_str),
-                    None => filename_str == format!("{}.{}", table.name, Format::Parquet.ext()),
-                }
-            })
-            .collect();
-
-        // Load all matching files into memory
-        let mut all_batches = Vec::new();
-        let mut schema = None;
-
-        for dir_entry in matching_files {
-            let file = File::open(dir_entry.path()).await?;
-            let mut reader = ParquetRecordBatchStreamBuilder::new(file).await?.build()?;
-            if schema.is_none() {
-                schema = Some(reader.schema()).cloned();
-            }
-
-            while let Some(batch) = reader.next().await {
-                all_batches.push(batch?);
-            }
-        }
-
-        if let Some(schema) = schema {
-            let mem_table = MemTable::try_new(schema, vec![all_batches])?;
-            session.register_table(table.name, Arc::new(mem_table))?;
-        }
     }
 
     Ok(())

--- a/benchmarks/random-access-bench/src/lib.rs
+++ b/benchmarks/random-access-bench/src/lib.rs
@@ -169,7 +169,7 @@ async fn benchmark_random_access(
     let timing = TimingMeasurement {
         name: measurement_name.to_string(),
         storage: storage.to_string(),
-        target: Target::new(format_to_engine(format), format),
+        target: Target::new(Engine::default(), format),
         runs,
     };
     Ok(RandomAccessRun {
@@ -224,17 +224,6 @@ fn push_v3_random_access_record(records: &mut Vec<v3::V3Record>, run: &RandomAcc
 
     let dataset = v3_random_access_dataset_name(&run.dataset, run.pattern);
     records.push(v3::random_access_record(&run.timing, &dataset));
-}
-
-/// Map format to the appropriate engine for random access benchmarks.
-fn format_to_engine(format: Format) -> Engine {
-    match format {
-        Format::OnDiskVortex | Format::VortexCompact => Engine::Vortex,
-        Format::Parquet => Engine::Arrow,
-        #[cfg(feature = "lance")]
-        Format::Lance => Engine::Arrow, // Is this right here?
-        _ => Engine::default(),
-    }
 }
 
 /// Open a random accessor for any supported format.
@@ -440,7 +429,7 @@ mod tests {
         RandomAccessRun {
             timing: TimingMeasurement {
                 name: format!("random-access/{dataset}/parquet-tokio-local-disk"),
-                target: Target::new(Engine::Arrow, Format::Parquet),
+                target: Target::new(Engine::Vortex, Format::Parquet),
                 storage: STORAGE_NVME.to_string(),
                 runs: vec![Duration::from_nanos(10)],
             },

--- a/benchmarks/random-access-bench/src/main.rs
+++ b/benchmarks/random-access-bench/src/main.rs
@@ -88,28 +88,25 @@ struct Args {
     open_mode: OpenMode,
 }
 
-impl Args {
-    fn into_run_config(self) -> RunConfig {
-        RunConfig {
-            datasets: self
-                .datasets
-                .into_iter()
-                .map(DatasetArg::into_dataset)
-                .collect(),
-            formats: self.formats,
-            patterns: self.patterns,
-            time_limit: self.time_limit,
-            open_mode: self.open_mode,
-            display_format: self.display_format,
-            output_path: self.output_path,
-            gh_json_v3: self.gh_json_v3,
-        }
-    }
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
     setup_logging_and_tracing(args.verbose, args.tracing)?;
-    random_access_bench::run(args.into_run_config()).await
+
+    let run_config = RunConfig {
+        datasets: args
+            .datasets
+            .into_iter()
+            .map(DatasetArg::into_dataset)
+            .collect(),
+        formats: args.formats,
+        patterns: args.patterns,
+        time_limit: args.time_limit,
+        open_mode: args.open_mode,
+        display_format: args.display_format,
+        output_path: args.output_path,
+        gh_json_v3: args.gh_json_v3,
+    };
+
+    random_access_bench::run(run_config).await
 }

--- a/benchmarks/random-access-bench/src/render.rs
+++ b/benchmarks/random-access-bench/src/render.rs
@@ -198,7 +198,7 @@ mod tests {
         RandomAccessRun {
             timing: TimingMeasurement {
                 name: format!("random-access/{dataset}/{}-tokio-local-disk", format.ext()),
-                target: Target::new(Engine::Arrow, format),
+                target: Target::new(Engine::Vortex, format),
                 storage: "nvme".to_string(),
                 runs: vec![Duration::from_micros(micros)],
             },
@@ -272,10 +272,6 @@ mod tests {
         assert!(
             rendered.contains("vortex-cached") && rendered.contains("vortex-reopen"),
             "expected ext-based column headers, got:\n{rendered}"
-        );
-        assert!(
-            !rendered.contains("arrow"),
-            "expected no engine header row, got:\n{rendered}"
         );
         assert!(
             rendered.contains("random-access/taxi")

--- a/vortex-bench/src/lib.rs
+++ b/vortex-bench/src/lib.rs
@@ -214,7 +214,6 @@ impl Format {
 pub enum Engine {
     #[default]
     Vortex,
-    Arrow,
     #[clap(name = "datafusion")]
     #[serde(rename = "datafusion")]
     DataFusion,
@@ -229,7 +228,6 @@ impl Display for Engine {
             Engine::DataFusion => write!(f, "datafusion"),
             Engine::DuckDB => write!(f, "duckdb"),
             Engine::Vortex => write!(f, "vortex"),
-            Engine::Arrow => write!(f, "arrow"),
         }
     }
 }

--- a/vortex-bench/src/lib.rs
+++ b/vortex-bench/src/lib.rs
@@ -141,8 +141,6 @@ impl Display for Target {
 pub enum Format {
     #[clap(name = "csv")]
     Csv,
-    #[clap(name = "arrow")]
-    Arrow,
     #[clap(name = "parquet")]
     Parquet,
     #[clap(name = "vortex")]
@@ -189,7 +187,6 @@ impl Format {
     pub fn name(&self) -> &'static str {
         match self {
             Format::Csv => "csv",
-            Format::Arrow => "arrow",
             Format::Parquet => "parquet",
             Format::OnDiskVortex => "vortex-file-compressed",
             Format::VortexCompact => "vortex-compact",
@@ -202,7 +199,6 @@ impl Format {
     pub fn ext(&self) -> &'static str {
         match self {
             Format::Csv => "csv",
-            Format::Arrow => "arrow",
             Format::Parquet => "parquet",
             Format::OnDiskVortex => "vortex",
             Format::VortexCompact => "vortex",

--- a/vortex-bench/src/measurements.rs
+++ b/vortex-bench/src/measurements.rs
@@ -352,8 +352,8 @@ impl ToJson for CompressionTimingMeasurement {
     fn to_json(&self) -> serde_json::Value {
         let (name, engine) = match self.format {
             Format::OnDiskVortex => (self.name.to_string(), Engine::Vortex),
-            Format::Parquet => (format!("parquet_rs-zstd {}", self.name), Engine::Arrow),
-            Format::Lance => (format!("lance {}", self.name), Engine::Arrow),
+            Format::Parquet => (format!("parquet_rs-zstd {}", self.name), Engine::Vortex),
+            Format::Lance => (format!("lance {}", self.name), Engine::Vortex),
             _ => vortex_panic!(
                 "CompressionTimingMeasurement only supports vortex, lance, and parquet formats"
             ),
@@ -397,8 +397,8 @@ impl ToJson for CustomUnitMeasurement {
     fn to_json(&self) -> serde_json::Value {
         let engine = match self.format {
             Format::OnDiskVortex | Format::VortexCompact => Engine::Vortex,
-            Format::Parquet => Engine::Arrow,
-            Format::Lance => Engine::Arrow,
+            Format::Parquet => Engine::Vortex,
+            Format::Lance => Engine::Vortex,
             _ => Engine::Vortex, // Default to Vortex for other formats.
         };
 

--- a/vortex-bench/src/tpch/tpchgen.rs
+++ b/vortex-bench/src/tpch/tpchgen.rs
@@ -193,7 +193,7 @@ fn generate_table_files(
     options: TpchGenOptions,
 ) -> Result<Vec<BoxFuture<'static, Result<()>>>> {
     let write_format = match options.format {
-        Format::Parquet | Format::Arrow | Format::OnDiskDuckDB => Format::Parquet,
+        Format::Parquet | Format::OnDiskDuckDB => Format::Parquet,
         Format::OnDiskVortex => Format::OnDiskVortex,
         Format::VortexCompact => Format::VortexCompact,
         f => {

--- a/vortex-bench/src/v3.rs
+++ b/vortex-bench/src/v3.rs
@@ -141,7 +141,7 @@ pub struct QueryMeasurementRecord {
     pub query_idx: u32,
     /// Storage backend the run targeted (`nvme` or `s3`).
     pub storage: String,
-    /// Query engine (`datafusion`, `duckdb`, `vortex`, `arrow`).
+    /// Query engine (`datafusion`, `duckdb`, `vortex`).
     pub engine: String,
     /// On-disk format (`parquet`, `vortex-file-compressed`, `lance`, ...).
     pub format: String,
@@ -519,7 +519,6 @@ fn duration_as_ns(d: std::time::Duration) -> u64 {
 fn engine_label(engine: Engine) -> &'static str {
     match engine {
         Engine::Vortex => "vortex",
-        Engine::Arrow => "arrow",
         Engine::DataFusion => "datafusion",
         Engine::DuckDB => "duckdb",
     }
@@ -663,7 +662,7 @@ mod tests {
     fn snapshot_random_access_time() -> anyhow::Result<()> {
         let timing = TimingMeasurement {
             name: "random-access/taxi/uniform/parquet-tokio-local-disk".to_string(),
-            target: Target::new(Engine::Arrow, Format::Parquet),
+            target: Target::new(Engine::Vortex, Format::Parquet),
             storage: "nvme".to_string(),
             runs: vec![
                 Duration::from_nanos(800_000),


### PR DESCRIPTION
## Rationale for this change

Arrow macro benchmarks are very noisy and have many dependencies on minor details of their implementations. They are not a real target either.

## What changes are included in this PR?

Removes any mention of arrow from the macro benchmarks (both sql and compression/random access)

## What APIs are changed? Are there any user-facing changes?

N/A
