### PR TITLE
Rename `vortex_bench_dir` to `bench_results_dir`

### DIFF
--- a/vortex-bench/src/output.rs
+++ b/vortex-bench/src/output.rs
@@ -82,7 +82,9 @@ impl BenchmarkOutput {
 ///
 /// Returns `target/vortex-bench/<benchmark_id>/results.json`.
 pub fn default_output_path(benchmark_id: &str) -> PathBuf {
-    vortex_bench_dir().join(benchmark_id).join(DEFAULT_FILENAME)
+    bench_results_dir()
+        .join(benchmark_id)
+        .join(DEFAULT_FILENAME)
 }
 
 /// Create an appropriate writer based on display format and output path.
@@ -106,10 +108,10 @@ pub fn create_output_writer(
     }
 }
 
-/// Get the base directory for vortex benchmark results.
+/// Get the base directory for benchmark results.
 ///
 /// Returns `target/vortex-bench/`.
-pub fn vortex_bench_dir() -> PathBuf {
+pub fn bench_results_dir() -> PathBuf {
     workspace_root().join("target").join("vortex-bench")
 }
 


### PR DESCRIPTION
## Rationale for this change

Inside the `vortex-bench` crate, the `vortex_bench_` prefix on `vortex_bench_dir()` is redundant and stutters at call sites (`vortex_bench::output::vortex_bench_dir()`), and the old name did not say what the directory is for. The new name matches the function's own doc comment: the base directory for benchmark results.

## What changes are included in this PR?

- Rename `vortex_bench_dir()` to `bench_results_dir()` in `vortex-bench/src/output.rs` and update its single internal call site in `default_output_path()`.
- No behavior change: the on-disk location is still `target/vortex-bench/<benchmark-id>/results.json`.

Verified with `cargo check -p vortex-bench`, `cargo clippy -p vortex-bench --all-targets`, `cargo test -p vortex-bench --lib output`, and `cargo +nightly fmt --all`.

## What APIs are changed? Are there any user-facing changes?

The function is `pub` in the `output` module of `vortex-bench`, but the crate is `publish = false` benchmark tooling and no other crate in the workspace references the function, so there is no user-facing impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmiEZHiQf7joDWHFF9YSXo

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmiEZHiQf7joDWHFF9YSXo)_