### PR TITLE
Use PiecewiseSequence for List take elements

### DIFF
--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -64,8 +64,8 @@ impl TakeExecute for List {
 
         match_each_unsigned_integer_ptype!(offsets.ptype(), |O| {
             match_each_unsigned_integer_ptype!(indices.ptype(), |I| {
-                match_smallest_offset_type!(total_approx, |OutputOffsetType| {
-                    take_with_piecewise_elements::<I, O, OutputOffsetType>(
+                match_smallest_offset_type!(total_approx, |OutOffset| {
+                    take_with_piecewise_elements::<I, O, OutOffset>(
                         array,
                         offsets.as_view(),
                         indices.as_view(),
@@ -79,11 +79,7 @@ impl TakeExecute for List {
     }
 }
 
-fn take_with_piecewise_elements<
-    I: IntegerPType,
-    O: IntegerPType,
-    OutputOffsetType: IntegerPType,
->(
+fn take_with_piecewise_elements<I: IntegerPType, O: IntegerPType, OutOffset: IntegerPType>(
     array: ArrayView<'_, List>,
     offsets_array: ArrayView<'_, Primitive>,
     indices_array: ArrayView<'_, Primitive>,
@@ -97,16 +93,16 @@ fn take_with_piecewise_elements<
         .len()
         .checked_add(1)
         .ok_or_else(|| vortex_err!("List take offsets length overflow"))?;
-    let mut new_offsets = BufferMut::<OutputOffsetType>::with_capacity(offsets_capacity);
+    let mut new_offsets = BufferMut::<OutOffset>::with_capacity(offsets_capacity);
     let mut element_starts = BufferMut::<u64>::with_capacity(indices.len());
     let mut element_lengths = BufferMut::<u64>::with_capacity(indices.len());
 
     let mut current_offset = 0usize;
-    new_offsets.push(OutputOffsetType::zero());
+    new_offsets.push(OutOffset::zero());
 
     for (&data_idx, is_valid) in indices.iter().zip_eq(validity_mask.iter()) {
         if !is_valid {
-            new_offsets.push(new_offset_value::<OutputOffsetType>(current_offset));
+            new_offsets.push(new_offset_value::<OutOffset>(current_offset));
             element_starts.push(0);
             element_lengths.push(0);
             continue;
@@ -123,7 +119,7 @@ fn take_with_piecewise_elements<
         current_offset = current_offset
             .checked_add(length)
             .ok_or_else(|| vortex_err!("List take output elements length overflow"))?;
-        new_offsets.push(new_offset_value::<OutputOffsetType>(current_offset));
+        new_offsets.push(new_offset_value::<OutOffset>(current_offset));
         element_starts.push(start as u64);
         element_lengths.push(length as u64);
     }
@@ -343,9 +339,9 @@ where
     };
     let validity = array.validity()?.take(indices_ref)?;
 
-    match_smallest_offset_type!(total_elements, |OutputOffset| {
+    match_smallest_offset_type!(total_elements, |OutOffset| {
         let gathered = if all_valid {
-            gather_piecewise_list_constant_length::<S, Offset, OutputOffset>(
+            gather_piecewise_list_constant_length::<S, Offset, OutOffset>(
                 array.elements(),
                 offsets,
                 starts,
@@ -354,7 +350,7 @@ where
                 total_elements,
             )?
         } else {
-            gather_piecewise_list_constant_length_validity::<S, Offset, OutputOffset>(
+            gather_piecewise_list_constant_length_validity::<S, Offset, OutOffset>(
                 array.elements(),
                 offsets,
                 starts,
@@ -407,9 +403,9 @@ where
         piecewise_list_elements_len_validity(offsets, starts, lengths, data_validity)?
     };
 
-    match_smallest_offset_type!(total_elements, |OutputOffset| {
+    match_smallest_offset_type!(total_elements, |OutOffset| {
         let gathered = if all_valid {
-            gather_piecewise_list::<S, L, Offset, OutputOffset>(
+            gather_piecewise_list::<S, L, Offset, OutOffset>(
                 array.elements(),
                 offsets,
                 starts,
@@ -418,7 +414,7 @@ where
                 total_elements,
             )?
         } else {
-            gather_piecewise_list_validity::<S, L, Offset, OutputOffset>(
+            gather_piecewise_list_validity::<S, L, Offset, OutOffset>(
                 array.elements(),
                 offsets,
                 starts,
@@ -445,8 +441,8 @@ struct GatheredList {
     offsets: ArrayRef,
 }
 
-struct ValidPieceGather<OutputOffset> {
-    new_offsets: BufferMut<OutputOffset>,
+struct ValidPieceGather<OutOffset> {
+    new_offsets: BufferMut<OutOffset>,
     element_starts: BufferMut<u64>,
     element_lengths: BufferMut<u64>,
     output_elements: usize,
@@ -574,7 +570,7 @@ where
     Ok(total)
 }
 
-fn gather_piecewise_list_constant_length<S, Offset, OutputOffset>(
+fn gather_piecewise_list_constant_length<S, Offset, OutOffset>(
     elements: &ArrayRef,
     offsets: &[Offset],
     starts: &[S],
@@ -585,17 +581,17 @@ fn gather_piecewise_list_constant_length<S, Offset, OutputOffset>(
 where
     S: UnsignedPType,
     Offset: UnsignedPType,
-    OutputOffset: IntegerPType,
+    OutOffset: IntegerPType,
 {
     let offsets_capacity = output_len
         .checked_add(1)
         .ok_or_else(|| vortex_err!("List take offsets length overflow"))?;
-    let mut new_offsets = BufferMut::<OutputOffset>::with_capacity(offsets_capacity);
+    let mut new_offsets = BufferMut::<OutOffset>::with_capacity(offsets_capacity);
     let mut element_starts = BufferMut::<u64>::with_capacity(starts.len());
     let mut element_lengths = BufferMut::<u64>::with_capacity(starts.len());
     let mut output_elements = 0usize;
 
-    new_offsets.push(OutputOffset::zero());
+    new_offsets.push(OutOffset::zero());
     for start in starts {
         let start: usize = start.as_();
         if length == 0 {
@@ -609,7 +605,7 @@ where
             let offset: usize = offset.as_();
             let relative = offset - element_start;
             let output_offset = output_elements + relative;
-            new_offsets.push(new_offset_value::<OutputOffset>(output_offset));
+            new_offsets.push(new_offset_value::<OutOffset>(output_offset));
         }
 
         let element_length = element_end - element_start;
@@ -636,7 +632,7 @@ where
     Ok(GatheredList { elements, offsets })
 }
 
-fn gather_piecewise_list_constant_length_validity<S, Offset, OutputOffset>(
+fn gather_piecewise_list_constant_length_validity<S, Offset, OutOffset>(
     elements: &ArrayRef,
     offsets: &[Offset],
     starts: &[S],
@@ -648,19 +644,19 @@ fn gather_piecewise_list_constant_length_validity<S, Offset, OutputOffset>(
 where
     S: UnsignedPType,
     Offset: UnsignedPType,
-    OutputOffset: IntegerPType,
+    OutOffset: IntegerPType,
 {
     let offsets_capacity = output_len
         .checked_add(1)
         .ok_or_else(|| vortex_err!("List take offsets length overflow"))?;
     let mut gather = ValidPieceGather {
-        new_offsets: BufferMut::<OutputOffset>::with_capacity(offsets_capacity),
+        new_offsets: BufferMut::<OutOffset>::with_capacity(offsets_capacity),
         element_starts: BufferMut::<u64>::with_capacity(output_len),
         element_lengths: BufferMut::<u64>::with_capacity(output_len),
         output_elements: 0,
     };
 
-    gather.new_offsets.push(OutputOffset::zero());
+    gather.new_offsets.push(OutOffset::zero());
     for start in starts {
         let start: usize = start.as_();
         if length == 0 {
@@ -689,7 +685,7 @@ where
     Ok(GatheredList { elements, offsets })
 }
 
-fn gather_piecewise_list<S, L, Offset, OutputOffset>(
+fn gather_piecewise_list<S, L, Offset, OutOffset>(
     elements: &ArrayRef,
     offsets: &[Offset],
     starts: &[S],
@@ -701,17 +697,17 @@ where
     S: UnsignedPType,
     L: UnsignedPType,
     Offset: UnsignedPType,
-    OutputOffset: IntegerPType,
+    OutOffset: IntegerPType,
 {
     let offsets_capacity = output_len
         .checked_add(1)
         .ok_or_else(|| vortex_err!("List take offsets length overflow"))?;
-    let mut new_offsets = BufferMut::<OutputOffset>::with_capacity(offsets_capacity);
+    let mut new_offsets = BufferMut::<OutOffset>::with_capacity(offsets_capacity);
     let mut element_starts = BufferMut::<u64>::with_capacity(starts.len());
     let mut element_lengths = BufferMut::<u64>::with_capacity(lengths.len());
     let mut output_elements = 0usize;
 
-    new_offsets.push(OutputOffset::zero());
+    new_offsets.push(OutOffset::zero());
     for (&start, &length) in starts.iter().zip_eq(lengths) {
         let start: usize = start.as_();
         let length: usize = length.as_();
@@ -726,7 +722,7 @@ where
             let offset: usize = offset.as_();
             let relative = offset - element_start;
             let output_offset = output_elements + relative;
-            new_offsets.push(new_offset_value::<OutputOffset>(output_offset));
+            new_offsets.push(new_offset_value::<OutOffset>(output_offset));
         }
 
         let element_length = element_end - element_start;
@@ -753,7 +749,7 @@ where
     Ok(GatheredList { elements, offsets })
 }
 
-fn gather_piecewise_list_validity<S, L, Offset, OutputOffset>(
+fn gather_piecewise_list_validity<S, L, Offset, OutOffset>(
     elements: &ArrayRef,
     offsets: &[Offset],
     starts: &[S],
@@ -766,19 +762,19 @@ where
     S: UnsignedPType,
     L: UnsignedPType,
     Offset: UnsignedPType,
-    OutputOffset: IntegerPType,
+    OutOffset: IntegerPType,
 {
     let offsets_capacity = output_len
         .checked_add(1)
         .ok_or_else(|| vortex_err!("List take offsets length overflow"))?;
     let mut gather = ValidPieceGather {
-        new_offsets: BufferMut::<OutputOffset>::with_capacity(offsets_capacity),
+        new_offsets: BufferMut::<OutOffset>::with_capacity(offsets_capacity),
         element_starts: BufferMut::<u64>::with_capacity(output_len),
         element_lengths: BufferMut::<u64>::with_capacity(output_len),
         output_elements: 0,
     };
 
-    gather.new_offsets.push(OutputOffset::zero());
+    gather.new_offsets.push(OutOffset::zero());
     for (&start, &length) in starts.iter().zip_eq(lengths) {
         let start: usize = start.as_();
         let length: usize = length.as_();
@@ -808,22 +804,22 @@ where
     Ok(GatheredList { elements, offsets })
 }
 
-fn gather_valid_piece<Offset, OutputOffset>(
+fn gather_valid_piece<Offset, OutOffset>(
     offsets: &[Offset],
     data_validity: &Mask,
     start: usize,
     length: usize,
-    gather: &mut ValidPieceGather<OutputOffset>,
+    gather: &mut ValidPieceGather<OutOffset>,
 ) where
     Offset: UnsignedPType,
-    OutputOffset: IntegerPType,
+    OutOffset: IntegerPType,
 {
     let offset_range = &offsets[start..][..=length];
     for (data_idx, window) in (start..).zip(offset_range.windows(2)) {
         if !data_validity.value(data_idx) {
             gather
                 .new_offsets
-                .push(new_offset_value::<OutputOffset>(gather.output_elements));
+                .push(new_offset_value::<OutOffset>(gather.output_elements));
             continue;
         }
 
@@ -837,7 +833,7 @@ fn gather_valid_piece<Offset, OutputOffset>(
         }
         gather
             .new_offsets
-            .push(new_offset_value::<OutputOffset>(gather.output_elements));
+            .push(new_offset_value::<OutOffset>(gather.output_elements));
     }
 }
 

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -25,10 +25,7 @@ use crate::arrays::list::ListArrayExt;
 use crate::arrays::piecewise_sequence::constant_unsigned_usize;
 use crate::arrays::piecewise_sequence::maybe_contiguous_slices;
 use crate::arrays::primitive::PrimitiveArrayExt;
-use crate::builders::ArrayBuilder;
-use crate::builders::PrimitiveBuilder;
 use crate::dtype::IntegerPType;
-use crate::dtype::Nullability;
 use crate::dtype::UnsignedPType;
 use crate::executor::ExecutionCtx;
 use crate::match_each_unsigned_integer_ptype;
@@ -66,7 +63,7 @@ impl TakeExecute for List {
         match_each_unsigned_integer_ptype!(offsets.ptype(), |O| {
             match_each_unsigned_integer_ptype!(indices.ptype(), |I| {
                 match_smallest_offset_type!(total_approx, |OutputOffsetType| {
-                    _take::<I, O, OutputOffsetType>(
+                    take_with_piecewise_elements::<I, O, OutputOffsetType>(
                         array,
                         offsets.as_view(),
                         indices.as_view(),
@@ -79,7 +76,11 @@ impl TakeExecute for List {
     }
 }
 
-fn _take<I: IntegerPType, O: IntegerPType, OutputOffsetType: IntegerPType>(
+fn take_with_piecewise_elements<
+    I: IntegerPType,
+    O: IntegerPType,
+    OutputOffsetType: IntegerPType,
+>(
     array: ArrayView<'_, List>,
     offsets_array: ArrayView<'_, Primitive>,
     indices_array: ArrayView<'_, Primitive>,
@@ -93,56 +94,78 @@ fn _take<I: IntegerPType, O: IntegerPType, OutputOffsetType: IntegerPType>(
         .vortex_expect("Failed to compute validity mask")
         .execute_mask(indices_array.as_ref().len(), ctx)?;
 
-    if !indices_validity.all_true() || !data_validity.all_true() {
-        return _take_nullable::<I, O, OutputOffsetType>(array, offsets_array, indices_array, ctx);
-    }
-
     let offsets: &[O] = offsets_array.as_slice();
     let indices: &[I] = indices_array.as_slice();
 
-    let mut new_offsets = PrimitiveBuilder::<OutputOffsetType>::with_capacity(
-        Nullability::NonNullable,
-        indices.len(),
-    );
-    let mut elements_to_take =
-        PrimitiveBuilder::with_capacity(Nullability::NonNullable, 2 * indices.len());
+    let offsets_capacity = indices
+        .len()
+        .checked_add(1)
+        .ok_or_else(|| vortex_err!("List take offsets length overflow"))?;
+    let mut new_offsets = BufferMut::<OutputOffsetType>::with_capacity(offsets_capacity);
+    let mut element_starts = BufferMut::<u64>::with_capacity(indices.len());
+    let mut element_lengths = BufferMut::<u64>::with_capacity(indices.len());
 
-    let mut current_offset = OutputOffsetType::zero();
-    new_offsets.append_zero();
+    let mut current_offset = 0usize;
+    new_offsets.push(OutputOffsetType::zero());
 
-    for &data_idx in indices {
+    for (&data_idx, index_valid) in indices.iter().zip_eq(indices_validity.iter()) {
+        if !index_valid {
+            new_offsets.push(new_offset_value::<OutputOffsetType>(current_offset)?);
+            element_starts.push(0);
+            element_lengths.push(0);
+            continue;
+        }
+
         let data_idx: usize = data_idx.as_();
+
+        if !data_validity.value(data_idx) {
+            new_offsets.push(new_offset_value::<OutputOffsetType>(current_offset)?);
+            element_starts.push(0);
+            element_lengths.push(0);
+            continue;
+        }
 
         let start = offsets[data_idx];
         let stop = offsets[data_idx + 1];
+        let start: usize = start.as_();
+        let stop: usize = stop.as_();
+        let length = stop
+            .checked_sub(start)
+            .ok_or_else(|| vortex_err!("List offsets are not monotonic at offset {stop}"))?;
 
-        // Annoyingly, we can't turn (start..end) into a range, so we're doing that manually.
-        //
-        // We could convert start and end to usize, but that would impose a potentially
-        // harder constraint - now we don't care if they fit into usize as long as their
-        // difference does.
-        let additional: usize = (stop - start).as_();
-
-        // TODO(0ax1): optimize this
-        elements_to_take.reserve_exact(additional);
-        for i in 0..additional {
-            elements_to_take.append_value(start + O::from_usize(i).vortex_expect("i < additional"));
-        }
-        current_offset +=
-            OutputOffsetType::from_usize((stop - start).as_()).vortex_expect("offset conversion");
-        new_offsets.append_value(current_offset);
+        current_offset = current_offset
+            .checked_add(length)
+            .ok_or_else(|| vortex_err!("List take output elements length overflow"))?;
+        new_offsets.push(new_offset_value::<OutputOffsetType>(current_offset)?);
+        element_starts.push(start as u64);
+        element_lengths.push(length as u64);
     }
 
-    let elements_to_take = elements_to_take.finish();
-    let new_offsets = new_offsets.finish();
+    let new_offsets = PrimitiveArray::new(new_offsets.freeze(), Validity::NonNullable).into_array();
+    let multipliers = ConstantArray::new(1u64, element_starts.len()).into_array();
 
-    let new_elements = array.elements().take(elements_to_take)?;
+    // SAFETY: valid source rows contribute ranges derived from list offsets; null index/source
+    // rows contribute zero-length placeholder ranges. `current_offset` is the sum of all generated
+    // element lengths, and multiplier 1 preserves contiguous ranges.
+    let element_indices = unsafe {
+        PiecewiseSequenceArray::new_unchecked(
+            element_starts.into_array(),
+            element_lengths.into_array(),
+            multipliers,
+            current_offset,
+        )
+    };
+    let new_elements = array.elements().take(element_indices.into_array())?;
 
-    Ok(ListArray::try_new(
-        new_elements,
-        new_offsets,
-        array.validity()?.take(indices_array.array())?,
-    )?
+    // SAFETY: offsets are rebuilt from the gathered element ranges and have one entry per output
+    // row plus the leading zero; validity is produced by the usual take-validity path.
+    Ok(unsafe {
+        ListArray::new_unchecked(
+            new_elements,
+            new_offsets,
+            array.validity()?.take(indices_array.array())?,
+        )
+    }
     .into_array())
 }
 
@@ -840,83 +863,6 @@ fn gather_valid_piece<Offset, OutputOffset>(
 
 fn new_offset_value<T: IntegerPType>(value: usize) -> T {
     T::from_usize(value).vortex_expect("output offset fits selected offset type")
-}
-
-// Kept out-of-line: as a single-callsite generic helper it would otherwise be inlined into every
-// monomorphization of `_take`, duplicating the entire nullable path across all specializations.
-#[inline(never)]
-fn _take_nullable<I: IntegerPType, O: IntegerPType, OutputOffsetType: IntegerPType>(
-    array: ArrayView<'_, List>,
-    offsets_array: ArrayView<'_, Primitive>,
-    indices_array: ArrayView<'_, Primitive>,
-    ctx: &mut ExecutionCtx,
-) -> VortexResult<ArrayRef> {
-    let offsets: &[O] = offsets_array.as_slice();
-    let indices: &[I] = indices_array.as_slice();
-    let data_validity = array
-        .list_validity()
-        .execute_mask(array.as_ref().len(), ctx)?;
-    let indices_validity = indices_array
-        .validity()
-        .vortex_expect("Failed to compute validity mask")
-        .execute_mask(indices_array.as_ref().len(), ctx)?;
-
-    let mut new_offsets = PrimitiveBuilder::<OutputOffsetType>::with_capacity(
-        Nullability::NonNullable,
-        indices.len(),
-    );
-
-    // This will be the indices we push down to the child array to call `take` with.
-    //
-    // There are 2 things to note here:
-    // - We do not know how many elements we need to take from our child since lists are variable
-    //   size: thus we arbitrarily choose a capacity of `2 * # of indices`.
-    // - The type of the primitive builder needs to fit the largest offset of the (parent)
-    //   `ListArray`, so we make this `PrimitiveBuilder` generic over `O` (instead of `I`).
-    let mut elements_to_take =
-        PrimitiveBuilder::<O>::with_capacity(Nullability::NonNullable, 2 * indices.len());
-
-    let mut current_offset = OutputOffsetType::zero();
-    new_offsets.append_zero();
-
-    for (data_idx, index_valid) in indices.iter().zip(indices_validity.iter()) {
-        if !index_valid {
-            new_offsets.append_value(current_offset);
-            continue;
-        }
-
-        let data_idx: usize = data_idx.as_();
-
-        if !data_validity.value(data_idx) {
-            new_offsets.append_value(current_offset);
-            continue;
-        }
-
-        let start = offsets[data_idx];
-        let stop = offsets[data_idx + 1];
-
-        // See the note in `_take` on the reasoning.
-        let additional: usize = (stop - start).as_();
-
-        elements_to_take.reserve_exact(additional);
-        for i in 0..additional {
-            elements_to_take.append_value(start + O::from_usize(i).vortex_expect("i < additional"));
-        }
-        current_offset +=
-            OutputOffsetType::from_usize((stop - start).as_()).vortex_expect("offset conversion");
-        new_offsets.append_value(current_offset);
-    }
-
-    let elements_to_take = elements_to_take.finish();
-    let new_offsets = new_offsets.finish();
-    let new_elements = array.elements().take(elements_to_take)?;
-
-    Ok(ListArray::try_new(
-        new_elements,
-        new_offsets,
-        array.validity()?.take(indices_array.array())?,
-    )?
-    .into_array())
 }
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -979,15 +979,13 @@ mod test {
     }
 
     #[test]
-    fn null_source_row_ignores_invalid_offset_payload() {
+    fn null_source_row_uses_valid_empty_output_range() {
         let mut ctx = array_session().create_execution_ctx();
-        let list = unsafe {
-            ListArray::new_unchecked(
-                buffer![1i32, 2].into_array(),
-                buffer![0u32, 2, 999].into_array(),
-                Validity::from_iter([true, false]),
-            )
-        }
+        let list = ListArray::new(
+            buffer![1i32, 2, 7, 8].into_array(),
+            buffer![0u32, 2, 4].into_array(),
+            Validity::from_iter([true, false]),
+        )
         .into_array();
 
         let idx = buffer![0u32, 1].into_array();

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -883,6 +883,7 @@ mod test {
     use crate::arrays::PiecewiseSequenceArray;
     use crate::arrays::PrimitiveArray;
     use crate::arrays::listview::ListViewArrayExt;
+    use crate::assert_arrays_eq;
     use crate::compute::conformance::take::test_take_conformance;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
@@ -969,6 +970,55 @@ mod test {
                 .unwrap(),
             Scalar::list(element_dtype, vec![], Nullability::Nullable)
         );
+    }
+
+    #[test]
+    fn null_index_ignores_out_of_bounds_payload() {
+        let mut ctx = array_session().create_execution_ctx();
+        let list = ListArray::try_new(
+            buffer![1i32, 2, 3, 4].into_array(),
+            buffer![0u32, 2, 4].into_array(),
+            Validity::NonNullable,
+        )
+        .unwrap()
+        .into_array();
+
+        let idx = PrimitiveArray::new(
+            buffer![1u32, 99, 0],
+            Validity::from_iter([true, false, true]),
+        )
+        .into_array();
+        let result = list.take(idx).unwrap();
+
+        let expected = ListArray::new(
+            buffer![3i32, 4, 1, 2].into_array(),
+            buffer![0u32, 2, 2, 4].into_array(),
+            Validity::from_iter([true, false, true]),
+        );
+        assert_arrays_eq!(expected, result, &mut ctx);
+    }
+
+    #[test]
+    fn null_source_row_ignores_invalid_offset_payload() {
+        let mut ctx = array_session().create_execution_ctx();
+        let list = unsafe {
+            ListArray::new_unchecked(
+                buffer![1i32, 2].into_array(),
+                buffer![0u32, 2, 999].into_array(),
+                Validity::from_iter([true, false]),
+            )
+        }
+        .into_array();
+
+        let idx = buffer![0u32, 1].into_array();
+        let result = list.take(idx).unwrap();
+
+        let expected = ListArray::new(
+            buffer![1i32, 2].into_array(),
+            buffer![0u32, 2, 2].into_array(),
+            Validity::from_iter([true, false]),
+        );
+        assert_arrays_eq!(expected, result, &mut ctx);
     }
 
     #[test]

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -3,7 +3,6 @@
 
 use itertools::Itertools as _;
 use vortex_buffer::BufferMut;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
@@ -25,11 +24,13 @@ use crate::arrays::list::ListArrayExt;
 use crate::arrays::piecewise_sequence::constant_unsigned_usize;
 use crate::arrays::piecewise_sequence::maybe_contiguous_slices;
 use crate::arrays::primitive::PrimitiveArrayExt;
+use crate::builtins::ArrayBuiltins;
 use crate::dtype::IntegerPType;
 use crate::dtype::UnsignedPType;
 use crate::executor::ExecutionCtx;
 use crate::match_each_unsigned_integer_ptype;
 use crate::match_smallest_offset_type;
+use crate::scalar::Scalar;
 use crate::validity::Validity;
 
 // TODO(connor)[ListView]: Re-revert to the version where we simply convert to a `ListView` and call
@@ -53,10 +54,16 @@ impl TakeExecute for List {
             return Ok(Some(taken));
         }
 
-        let indices = indices.clone().execute::<PrimitiveArray>(ctx)?;
+        let new_validity = array.validity()?.take(indices)?;
+        let normalized_indices = indices
+            .clone()
+            .mask(new_validity.to_array(indices.len()))?
+            .fill_null(Scalar::from(0).cast(indices.dtype())?)?;
+        let indices = normalized_indices.execute::<PrimitiveArray>(ctx)?;
         let indices = indices.reinterpret_cast(indices.ptype().to_unsigned());
         let offsets = array.offsets().clone().execute::<PrimitiveArray>(ctx)?;
         let offsets = offsets.reinterpret_cast(offsets.ptype().to_unsigned());
+        let validity_mask = new_validity.execute_mask(indices.len(), ctx)?;
         // This is an over-approximation of the total number of elements in the resulting array.
         let total_approx = array.elements().len().saturating_mul(indices.len());
 
@@ -67,7 +74,8 @@ impl TakeExecute for List {
                         array,
                         offsets.as_view(),
                         indices.as_view(),
-                        ctx,
+                        new_validity,
+                        &validity_mask,
                     )
                     .map(Some)
                 })
@@ -84,16 +92,9 @@ fn take_with_piecewise_elements<
     array: ArrayView<'_, List>,
     offsets_array: ArrayView<'_, Primitive>,
     indices_array: ArrayView<'_, Primitive>,
-    ctx: &mut ExecutionCtx,
+    new_validity: Validity,
+    validity_mask: &Mask,
 ) -> VortexResult<ArrayRef> {
-    let data_validity = array
-        .list_validity()
-        .execute_mask(array.as_ref().len(), ctx)?;
-    let indices_validity = indices_array
-        .validity()
-        .vortex_expect("Failed to compute validity mask")
-        .execute_mask(indices_array.as_ref().len(), ctx)?;
-
     let offsets: &[O] = offsets_array.as_slice();
     let indices: &[I] = indices_array.as_slice();
 
@@ -108,8 +109,8 @@ fn take_with_piecewise_elements<
     let mut current_offset = 0usize;
     new_offsets.push(OutputOffsetType::zero());
 
-    for (&data_idx, index_valid) in indices.iter().zip_eq(indices_validity.iter()) {
-        if !index_valid {
+    for (&data_idx, is_valid) in indices.iter().zip_eq(validity_mask.iter()) {
+        if !is_valid {
             new_offsets.push(new_offset_value::<OutputOffsetType>(current_offset)?);
             element_starts.push(0);
             element_lengths.push(0);
@@ -117,13 +118,6 @@ fn take_with_piecewise_elements<
         }
 
         let data_idx: usize = data_idx.as_();
-
-        if !data_validity.value(data_idx) {
-            new_offsets.push(new_offset_value::<OutputOffsetType>(current_offset)?);
-            element_starts.push(0);
-            element_lengths.push(0);
-            continue;
-        }
 
         let start = offsets[data_idx];
         let stop = offsets[data_idx + 1];
@@ -159,14 +153,7 @@ fn take_with_piecewise_elements<
 
     // SAFETY: offsets are rebuilt from the gathered element ranges and have one entry per output
     // row plus the leading zero; validity is produced by the usual take-validity path.
-    Ok(unsafe {
-        ListArray::new_unchecked(
-            new_elements,
-            new_offsets,
-            array.validity()?.take(indices_array.array())?,
-        )
-    }
-    .into_array())
+    Ok(unsafe { ListArray::new_unchecked(new_elements, new_offsets, new_validity) }.into_array())
 }
 
 fn take_slices(

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -24,13 +24,11 @@ use crate::arrays::list::ListArrayExt;
 use crate::arrays::piecewise_sequence::constant_unsigned_usize;
 use crate::arrays::piecewise_sequence::maybe_contiguous_slices;
 use crate::arrays::primitive::PrimitiveArrayExt;
-use crate::builtins::ArrayBuiltins;
 use crate::dtype::IntegerPType;
 use crate::dtype::UnsignedPType;
 use crate::executor::ExecutionCtx;
 use crate::match_each_unsigned_integer_ptype;
 use crate::match_smallest_offset_type;
-use crate::scalar::Scalar;
 use crate::validity::Validity;
 
 // TODO(connor)[ListView]: Re-revert to the version where we simply convert to a `ListView` and call
@@ -55,11 +53,7 @@ impl TakeExecute for List {
         }
 
         let new_validity = array.validity()?.take(indices)?;
-        let normalized_indices = indices
-            .clone()
-            .mask(new_validity.to_array(indices.len()))?
-            .fill_null(Scalar::from(0).cast(indices.dtype())?)?;
-        let indices = normalized_indices.execute::<PrimitiveArray>(ctx)?;
+        let indices = indices.clone().execute::<PrimitiveArray>(ctx)?;
         let indices = indices.reinterpret_cast(indices.ptype().to_unsigned());
         let offsets = array.offsets().clone().execute::<PrimitiveArray>(ctx)?;
         let offsets = offsets.reinterpret_cast(offsets.ptype().to_unsigned());

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -3,6 +3,7 @@
 
 use itertools::Itertools as _;
 use vortex_buffer::BufferMut;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
@@ -105,7 +106,7 @@ fn take_with_piecewise_elements<
 
     for (&data_idx, is_valid) in indices.iter().zip_eq(validity_mask.iter()) {
         if !is_valid {
-            new_offsets.push(new_offset_value::<OutputOffsetType>(current_offset)?);
+            new_offsets.push(new_offset_value::<OutputOffsetType>(current_offset));
             element_starts.push(0);
             element_lengths.push(0);
             continue;
@@ -117,14 +118,12 @@ fn take_with_piecewise_elements<
         let stop = offsets[data_idx + 1];
         let start: usize = start.as_();
         let stop: usize = stop.as_();
-        let length = stop
-            .checked_sub(start)
-            .ok_or_else(|| vortex_err!("List offsets are not monotonic at offset {stop}"))?;
+        let length = stop - start;
 
         current_offset = current_offset
             .checked_add(length)
             .ok_or_else(|| vortex_err!("List take output elements length overflow"))?;
-        new_offsets.push(new_offset_value::<OutputOffsetType>(current_offset)?);
+        new_offsets.push(new_offset_value::<OutputOffsetType>(current_offset));
         element_starts.push(start as u64);
         element_lengths.push(length as u64);
     }


### PR DESCRIPTION
This is just a simplification. List::take already had a specialized implementation. The new PiecewiseSequence specializations in various primitive arrays supersede this change.

EDIT: Heh, I guess the PiecewiseSequence stuff is actually even faster than old List::take. Nice.


---

codex:

## Summary
- replace List take's dense per-element index expansion with PiecewiseSequence element runs
- preserve FSL-style null handling: null index/source rows emit zero-length placeholder runs while output validity still comes from Validity::take
- let the elements child choose its own optimized take implementation through the normal ArrayRef::take path

## Validation
- cargo +nightly fmt --all
- cargo test -p vortex-array arrays::list::compute::take
- cargo check -p vortex-array
- cargo clippy -p vortex-array --all-targets --all-features -- -D warnings
- git diff --check