### PR TITLE
fix(spark): include the offending path when schema inference finds no Vortex files

### DIFF
--- a/java/vortex-spark/src/main/java/dev/vortex/spark/VortexDataSourceV2.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/VortexDataSourceV2.java
@@ -62,7 +62,7 @@ public final class VortexDataSourceV2 implements TableProvider, DataSourceRegist
      *
      * @param options the data source options containing file paths
      * @return the inferred Spark SQL schema
-     * @throws RuntimeException if required path options are missing
+     * @throws IllegalArgumentException if no Vortex files can be found under the supplied paths
      * @throws RuntimeException if there's an error reading the file or converting the schema
      */
     @Override
@@ -87,7 +87,11 @@ public final class VortexDataSourceV2 implements TableProvider, DataSourceRegist
                             .findFirst();
 
             if (firstFile.isEmpty()) {
-                throw new RuntimeException(String.format("UNABLE_TO_INFER_SCHEMA format: %s", shortName()));
+                throw new IllegalArgumentException(String.format(
+                        "Unable to infer schema for %s: no .vortex files found under path %s. "
+                                + "Check that the path is correct and contains at least one Vortex file, "
+                                + "or provide an explicit schema.",
+                        shortName(), pathToInfer));
             } else {
                 pathToInfer = firstFile.get();
             }

--- a/java/vortex-spark/src/test/java/dev/vortex/spark/VortexDataSourceInferSchemaTest.java
+++ b/java/vortex-spark/src/test/java/dev/vortex/spark/VortexDataSourceInferSchemaTest.java
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+package dev.vortex.spark;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Tests for schema inference failure reporting in {@link VortexDataSourceV2}. */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public final class VortexDataSourceInferSchemaTest {
+
+    private SparkSession spark;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeAll
+    public void setUp() {
+        spark = SparkSession.builder()
+                .appName("VortexInferSchemaTest")
+                .master("local[1]")
+                .config("spark.driver.host", "127.0.0.1")
+                .config("spark.ui.enabled", "false")
+                .getOrCreate();
+    }
+
+    @AfterAll
+    public void tearDown() {
+        if (spark != null) {
+            spark.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("Reading a directory without Vortex files reports the offending path")
+    public void inferSchemaFailureNamesThePath() {
+        String emptyDir = tempDir.toString();
+
+        Throwable thrown = assertThrows(
+                Throwable.class, () -> spark.read().format("vortex").load(emptyDir));
+
+        String allMessages = messagesOf(thrown);
+        assertTrue(
+                allMessages.contains("no .vortex files found"),
+                "error should explain that no Vortex files were found, got: " + allMessages);
+        assertTrue(allMessages.contains(emptyDir), "error should name the offending path, got: " + allMessages);
+    }
+
+    /** Concatenates the messages of the whole cause chain, since Spark may wrap data source exceptions. */
+    private static String messagesOf(Throwable thrown) {
+        StringBuilder sb = new StringBuilder();
+        for (Throwable t = thrown; t != null; t = t.getCause()) {
+            sb.append(t.getMessage()).append('\n');
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Rationale for this change

When `VortexDataSourceV2.inferSchema` is pointed at a directory that contains no
`.vortex` files, it currently throws
`RuntimeException("UNABLE_TO_INFER_SCHEMA format: vortex")`. The message does not say
*which* path failed, so with multi-path reads (or a typo'd location) users have nothing
to go on. This is the same kind of diagnosability gap as #8759 (unsupported ColumnVector
type error message).

## What changes are included in this PR?

- `inferSchema` now throws `IllegalArgumentException` with a message that names the
  offending path and suggests the likely fixes:
  `Unable to infer schema for vortex: no .vortex files found under path <path>. Check
  that the path is correct and contains at least one Vortex file, or provide an explicit
  schema.`
- The `@throws` javadoc on `inferSchema` is updated to match.
- A new `VortexDataSourceInferSchemaTest` reads an empty temp directory through the real
  `spark.read().format("vortex").load(...)` path and asserts the failure message names
  the path (walking the cause chain, since Spark may wrap data source exceptions).

Passing locally on both matrix legs (`:vortex-spark_2.12:test` and
`:vortex-spark_2.13:test` with `--tests 'dev.vortex.spark.VortexDataSourceInferSchemaTest'`).

## What APIs are changed? Are there any user-facing changes?

The exception type thrown by `inferSchema` for the no-files case changes from a bare
`RuntimeException` to `IllegalArgumentException` (still a `RuntimeException` subtype),
and the message text changes as described. No other behavior changes.