### PR TITLE
test(spark): characterize VortexBatchExec input partition planning

### DIFF
--- a/java/vortex-spark/src/test/java/dev/vortex/spark/read/VortexBatchExecTest.java
+++ b/java/vortex-spark/src/test/java/dev/vortex/spark/read/VortexBatchExecTest.java
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+package dev.vortex.spark.read;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import dev.vortex.spark.VortexFilePartition;
+import java.util.List;
+import java.util.Map;
+import org.apache.spark.sql.connector.catalog.Column;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
+import org.apache.spark.sql.connector.read.InputPartition;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link VortexBatchExec} input-partition planning.
+ *
+ * <p>Characterizes how explicit {@code .vortex} paths are planned: one {@link VortexFilePartition} per file, each
+ * carrying the requested read schema and the Hive-style partition values parsed from its own path. All paths used here
+ * end in {@code .vortex} so planning never lists directories through native I/O.
+ */
+final class VortexBatchExecTest {
+
+    private static final List<Column> COLUMNS = List.of(
+            Column.create("id", org.apache.spark.sql.types.DataTypes.IntegerType),
+            Column.create("name", org.apache.spark.sql.types.DataTypes.StringType));
+
+    private static VortexBatchExec execFor(List<String> paths) {
+        return new VortexBatchExec(paths, COLUMNS, Map.of(), new Predicate[0]);
+    }
+
+    @Test
+    @DisplayName("Plans one input partition per .vortex file")
+    void plansOnePartitionPerFile() {
+        VortexBatchExec exec = execFor(List.of("/data/a.vortex", "/data/b.vortex", "/data/c.vortex"));
+
+        InputPartition[] partitions = exec.planInputPartitions();
+
+        assertEquals(3, partitions.length);
+        for (InputPartition partition : partitions) {
+            assertInstanceOf(VortexFilePartition.class, partition);
+            assertEquals(1, ((VortexFilePartition) partition).paths().size());
+        }
+    }
+
+    @Test
+    @DisplayName("Each partition carries exactly its own file path, in input order")
+    void partitionsKeepInputOrder() {
+        VortexBatchExec exec = execFor(List.of("/data/first.vortex", "/data/second.vortex"));
+
+        InputPartition[] partitions = exec.planInputPartitions();
+
+        assertEquals(List.of("/data/first.vortex"), ((VortexFilePartition) partitions[0]).paths());
+        assertEquals(List.of("/data/second.vortex"), ((VortexFilePartition) partitions[1]).paths());
+    }
+
+    @Test
+    @DisplayName("Partitions carry the requested read schema")
+    void partitionsCarryReadSchema() {
+        VortexBatchExec exec = execFor(List.of("/data/a.vortex"));
+
+        VortexFilePartition partition = (VortexFilePartition) exec.planInputPartitions()[0];
+
+        assertEquals(2, partition.readSchema().size());
+        assertEquals("id", partition.readSchema().fields()[0].name());
+        assertEquals("name", partition.readSchema().fields()[1].name());
+    }
+
+    @Test
+    @DisplayName("Hive-style partition values are parsed from each file's own path")
+    void partitionValuesParsedPerFile() {
+        VortexBatchExec exec = execFor(
+                List.of("/tbl/year=2024/month=01/a.vortex", "/tbl/year=2025/month=02/b.vortex", "/tbl/plain.vortex"));
+
+        InputPartition[] partitions = exec.planInputPartitions();
+
+        assertEquals(Map.of("year", "2024", "month", "01"), ((VortexFilePartition) partitions[0]).partitionValues());
+        assertEquals(Map.of("year", "2025", "month", "02"), ((VortexFilePartition) partitions[1]).partitionValues());
+        assertEquals(Map.of(), ((VortexFilePartition) partitions[2]).partitionValues());
+    }
+
+    @Test
+    @DisplayName("Format options are propagated to every partition")
+    void formatOptionsPropagated() {
+        Map<String, String> options = Map.of("vortex.workerThreads", "8");
+        VortexBatchExec exec = new VortexBatchExec(List.of("/data/a.vortex"), COLUMNS, options, new Predicate[0]);
+
+        VortexFilePartition partition = (VortexFilePartition) exec.planInputPartitions()[0];
+
+        assertEquals("8", partition.formatOptions().get("vortex.workerThreads"));
+    }
+}


### PR DESCRIPTION
## Rationale for this change

`VortexBatchExec` (`java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexBatchExec.java`)
turns the scan's resolved paths into Spark `InputPartition`s, and it currently has no
direct test coverage. Its planning contract is easy to break silently: each `.vortex`
file must become exactly one `VortexFilePartition`, each partition must carry the
Hive-style partition values parsed from *its own* path (not a neighbour's), and the
read schema and format options must survive into every partition — these are what the
executor-side reader relies on to materialize partition columns correctly. This
continues the characterization-test series from #8770, #8782, #8783, #8850, and #8857.

## What changes are included in this PR?

A new `VortexBatchExecTest` with 5 tests covering `planInputPartitions` for explicit
`.vortex` paths (which never touch native directory listing, keeping this a pure unit
test):

- one `VortexFilePartition` per file, each holding exactly one path;
- partitions preserve the input path order;
- the requested read schema is carried into every partition;
- Hive-style partition values are parsed from each file's own path (`year=2024/month=01`
  vs `year=2025/month=02` vs an unpartitioned path yielding an empty map);
- format options are propagated to every partition.

This is a **test-only** change; no production code is modified. All 5 tests pass
locally on both matrix legs (`:vortex-spark_2.12:test` and `:vortex-spark_2.13:test`
with `--tests 'dev.vortex.spark.read.VortexBatchExecTest'`).

## What APIs are changed? Are there any user-facing changes?

None. No production code or public API is touched.