### PR TITLE
Fix remaining flaky CodSpeed microbenchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10566,6 +10566,7 @@ dependencies = [
  "arbitrary",
  "codspeed-divan-compat",
  "itertools 0.14.0",
+ "mimalloc",
  "num-traits",
  "prost 0.14.4",
  "rand 0.10.2",

--- a/encodings/runend/Cargo.toml
+++ b/encodings/runend/Cargo.toml
@@ -30,6 +30,7 @@ workspace = true
 [dev-dependencies]
 divan = { workspace = true }
 itertools = { workspace = true }
+mimalloc = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
 vortex-array = { workspace = true, features = ["_test-harness"] }

--- a/encodings/runend/benches/run_end_compress.rs
+++ b/encodings/runend/benches/run_end_compress.rs
@@ -7,6 +7,7 @@ use std::sync::LazyLock;
 
 use divan::Bencher;
 use itertools::repeat_n;
+use mimalloc::MiMalloc;
 use vortex_array::IntoArray;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
@@ -18,6 +19,12 @@ use vortex_buffer::Buffer;
 use vortex_runend::RunEnd;
 use vortex_runend::compress::runend_encode;
 use vortex_session::VortexSession;
+
+// `runend_encode` allocates its output buffers inside the timed region, so route allocation
+// through vendored mimalloc to keep glibc malloc (which varies across runner images) out of
+// the measured trace.
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 fn main() {
     divan::main();

--- a/vortex-array/benches/cast_decimal.rs
+++ b/vortex-array/benches/cast_decimal.rs
@@ -14,6 +14,7 @@
 use std::sync::LazyLock;
 
 use divan::Bencher;
+use mimalloc::MiMalloc;
 use rand::prelude::*;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
@@ -27,6 +28,12 @@ use vortex_array::dtype::Nullability;
 use vortex_array::validity::Validity;
 use vortex_buffer::BufferMut;
 use vortex_session::VortexSession;
+
+// The copy casts allocate their output buffer inside the timed region, so route allocation
+// through vendored mimalloc to keep glibc malloc (which varies across runner images) out of
+// the measured trace.
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 fn main() {
     divan::main();

--- a/vortex-buffer/benches/vortex_bitbuffer.rs
+++ b/vortex-buffer/benches/vortex_bitbuffer.rs
@@ -176,7 +176,12 @@ fn slice_arrow_buffer(bencher: Bencher, length: usize) {
         });
 }
 
-#[divan::bench(args = INPUT_SIZE)]
+/// A 128-bit `true_count` is a popcount over two `u64` words, so the measurement is fixed
+/// dispatch and harness overhead plus binary code layout rather than the count itself. Only
+/// sizes where the popcount loop dominates are worth measuring.
+const TRUE_COUNT_INPUT_SIZE: &[usize] = &[1024, 2048, 16_384, 65_536];
+
+#[divan::bench(args = TRUE_COUNT_INPUT_SIZE)]
 fn true_count_vortex_buffer(bencher: Bencher, length: usize) {
     let buffer = BitBuffer::from_iter((0..length).map(true_count_pattern));
 
@@ -185,7 +190,7 @@ fn true_count_vortex_buffer(bencher: Bencher, length: usize) {
         .bench_refs(|buffer| buffer.true_count())
 }
 
-#[divan::bench(args = INPUT_SIZE)]
+#[divan::bench(args = TRUE_COUNT_INPUT_SIZE)]
 fn true_count_arrow_buffer(bencher: Bencher, length: usize) {
     let buffer = Arrow(BooleanBuffer::from_iter(
         (0..length).map(true_count_pattern),


### PR DESCRIPTION
## Rationale for this change

- Closes: #8807

Three benchmarks stayed flaky after #8742, flipping between the same two values on PRs that can't affect them. Same root causes and fixes as #8742:

| Benchmark | Seen flaky on | Why | Fix |
| --- | --- | --- | --- |
| `true_count_vortex_buffer[128]` | ±11.17% on 9 unrelated PRs (#8805, #8811, #8812, #8820, #8843, #8803, …) | a 128-bit popcount measures harness overhead and code layout, not the count | drop the 128 size |
| runend `compress[(100000, 4)]` | ±11.9% on #8805, #8750, #8856 | allocates in the timed region; glibc malloc differs across runner images | mimalloc as global allocator |
| `cast_decimal` `copy_*[65536]` | identical flags on #8838 and #8724 | same glibc-malloc cause (512 KB alloc per iteration) | mimalloc as global allocator |

Left alone: `compact_sliced[(4096, 90)]` (single sighting) and the CUDA walltime benches (hosted-runner walltime noise, a runner config issue).

The allocator swap shifts every benchmark in the two touched binaries once — see the comment below. Needs a one-time CodSpeed acknowledgment, like #8742.

## What changes are included in this PR?

One commit per benchmark; bench files only. Ran `cargo check` + `clippy` on the three bench targets, smoke-ran the binaries, `cargo +nightly fmt`.