### PR TITLE
break[array]: Remove unimplemented child() method from VTable implementations

### DIFF
--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -707,9 +707,16 @@ impl ArrayRef {
         self.children_iter().nth(idx).cloned()
     }
 
-    /// Returns the names of the children of the array.
+    /// Returns the names of the children of the array: the slot names of the non-None slots
+    /// in order.
     pub fn children_names(&self) -> Vec<String> {
-        self.0.data.children_names(self)
+        self.0
+            .slots
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.is_some())
+            .map(|(slot_idx, _)| self.slot_name(slot_idx))
+            .collect()
     }
 
     /// Returns the array's children with their names.

--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -685,19 +685,26 @@ impl ArrayRef {
 
     // ArrayVisitor delegation methods
 
+    /// Returns an iterator over the children of the array: its non-None slots in order.
+    pub fn children_iter(&self) -> impl Iterator<Item = &ArrayRef> {
+        self.0.slots.iter().filter_map(|s| s.as_ref())
+    }
+
     /// Returns the children of the array.
     pub fn children(&self) -> Vec<ArrayRef> {
-        self.0.data.children(self)
+        self.children_iter().cloned().collect()
     }
 
     /// Returns the number of children of the array.
     pub fn nchildren(&self) -> usize {
-        self.0.data.nchildren(self)
+        self.children_iter().count()
     }
 
     /// Returns the nth child of the array without allocating a Vec.
+    ///
+    /// Returns `None` if the index is out of bounds.
     pub fn nth_child(&self, idx: usize) -> Option<ArrayRef> {
-        self.0.data.nth_child(self, idx)
+        self.children_iter().nth(idx).cloned()
     }
 
     /// Returns the names of the children of the array.
@@ -707,7 +714,10 @@ impl ArrayRef {
 
     /// Returns the array's children with their names.
     pub fn named_children(&self) -> Vec<(String, ArrayRef)> {
-        self.0.data.named_children(self)
+        self.children_names()
+            .into_iter()
+            .zip(self.children_iter().cloned())
+            .collect()
     }
 
     /// Returns the data buffers of the array.

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -80,9 +80,6 @@ pub(crate) trait DynArrayData: 'static + private::Sealed + Send + Sync + Debug {
 
     // --- Visitor methods (formerly in ArrayVisitor) ---
 
-    /// Returns the names of the children of the array.
-    fn children_names(&self, this: &ArrayRef) -> Vec<String>;
-
     /// Returns the buffers of the array.
     fn buffers(&self, this: &ArrayRef) -> Vec<ByteBuffer>;
 
@@ -251,13 +248,6 @@ impl<V: VTable> DynArrayData for ArrayData<V> {
             this.encoding_id(),
         );
         Ok(())
-    }
-
-    fn children_names(&self, this: &ArrayRef) -> Vec<String> {
-        let view: ArrayView<'_, V> = unsafe { ArrayView::new_unchecked(this, &self.data) };
-        (0..this.nchildren())
-            .map(|i| V::child_name(view, i))
-            .collect()
     }
 
     fn buffers(&self, this: &ArrayRef) -> Vec<ByteBuffer> {

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -80,22 +80,8 @@ pub(crate) trait DynArrayData: 'static + private::Sealed + Send + Sync + Debug {
 
     // --- Visitor methods (formerly in ArrayVisitor) ---
 
-    /// Returns the children of the array.
-    fn children(&self, this: &ArrayRef) -> Vec<ArrayRef>;
-
-    /// Returns the number of children of the array.
-    fn nchildren(&self, this: &ArrayRef) -> usize;
-
-    /// Returns the nth child of the array without allocating a Vec.
-    ///
-    /// Returns `None` if the index is out of bounds.
-    fn nth_child(&self, this: &ArrayRef, idx: usize) -> Option<ArrayRef>;
-
     /// Returns the names of the children of the array.
     fn children_names(&self, this: &ArrayRef) -> Vec<String>;
-
-    /// Returns the array's children with their names.
-    fn named_children(&self, this: &ArrayRef) -> Vec<(String, ArrayRef)>;
 
     /// Returns the buffers of the array.
     fn buffers(&self, this: &ArrayRef) -> Vec<ByteBuffer>;
@@ -267,42 +253,10 @@ impl<V: VTable> DynArrayData for ArrayData<V> {
         Ok(())
     }
 
-    fn children(&self, this: &ArrayRef) -> Vec<ArrayRef> {
-        let view: ArrayView<'_, V> = unsafe { ArrayView::new_unchecked(this, &self.data) };
-        view.slots().iter().filter_map(|s| s.clone()).collect()
-    }
-
-    fn nchildren(&self, this: &ArrayRef) -> usize {
-        let view: ArrayView<'_, V> = unsafe { ArrayView::new_unchecked(this, &self.data) };
-        view.slots().iter().filter(|s| s.is_some()).count()
-    }
-
-    fn nth_child(&self, this: &ArrayRef, idx: usize) -> Option<ArrayRef> {
-        let view: ArrayView<'_, V> = unsafe { ArrayView::new_unchecked(this, &self.data) };
-        view.slots()
-            .iter()
-            .filter_map(|s| s.as_ref())
-            .nth(idx)
-            .cloned()
-    }
-
     fn children_names(&self, this: &ArrayRef) -> Vec<String> {
         let view: ArrayView<'_, V> = unsafe { ArrayView::new_unchecked(this, &self.data) };
-        view.slots()
-            .iter()
-            .filter(|s| s.is_some())
-            .enumerate()
-            .map(|(i, _)| V::child_name(view, i))
-            .collect()
-    }
-
-    fn named_children(&self, this: &ArrayRef) -> Vec<(String, ArrayRef)> {
-        let view: ArrayView<'_, V> = unsafe { ArrayView::new_unchecked(this, &self.data) };
-        view.slots()
-            .iter()
-            .filter_map(|s| s.as_ref())
-            .enumerate()
-            .map(|(i, child)| (V::child_name(view, i), child.clone()))
+        (0..this.nchildren())
+            .map(|i| V::child_name(view, i))
             .collect()
     }
 

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -268,8 +268,8 @@ impl<V: VTable> DynArrayData for ArrayData<V> {
     }
 
     fn children(&self, this: &ArrayRef) -> Vec<ArrayRef> {
-        let view = unsafe { ArrayView::new_unchecked(this, &self.data) };
-        (0..V::nchildren(view)).map(|i| V::child(view, i)).collect()
+        let view: ArrayView<'_, V> = unsafe { ArrayView::new_unchecked(this, &self.data) };
+        view.slots().iter().filter_map(|s| s.clone()).collect()
     }
 
     fn nchildren(&self, this: &ArrayRef) -> usize {
@@ -278,8 +278,12 @@ impl<V: VTable> DynArrayData for ArrayData<V> {
     }
 
     fn nth_child(&self, this: &ArrayRef, idx: usize) -> Option<ArrayRef> {
-        let view = unsafe { ArrayView::new_unchecked(this, &self.data) };
-        (idx < V::nchildren(view)).then(|| V::child(view, idx))
+        let view: ArrayView<'_, V> = unsafe { ArrayView::new_unchecked(this, &self.data) };
+        view.slots()
+            .iter()
+            .filter_map(|s| s.as_ref())
+            .nth(idx)
+            .cloned()
     }
 
     fn children_names(&self, this: &ArrayRef) -> Vec<String> {
@@ -290,9 +294,12 @@ impl<V: VTable> DynArrayData for ArrayData<V> {
     }
 
     fn named_children(&self, this: &ArrayRef) -> Vec<(String, ArrayRef)> {
-        let view = unsafe { ArrayView::new_unchecked(this, &self.data) };
-        (0..V::nchildren(view))
-            .map(|i| (V::child_name(view, i), V::child(view, i)))
+        let view: ArrayView<'_, V> = unsafe { ArrayView::new_unchecked(this, &self.data) };
+        view.slots()
+            .iter()
+            .filter_map(|s| s.as_ref())
+            .enumerate()
+            .map(|(i, child)| (V::child_name(view, i), child.clone()))
             .collect()
     }
 

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -273,8 +273,8 @@ impl<V: VTable> DynArrayData for ArrayData<V> {
     }
 
     fn nchildren(&self, this: &ArrayRef) -> usize {
-        let view = unsafe { ArrayView::new_unchecked(this, &self.data) };
-        V::nchildren(view)
+        let view: ArrayView<'_, V> = unsafe { ArrayView::new_unchecked(this, &self.data) };
+        view.slots().iter().filter(|s| s.is_some()).count()
     }
 
     fn nth_child(&self, this: &ArrayRef, idx: usize) -> Option<ArrayRef> {
@@ -287,9 +287,12 @@ impl<V: VTable> DynArrayData for ArrayData<V> {
     }
 
     fn children_names(&self, this: &ArrayRef) -> Vec<String> {
-        let view = unsafe { ArrayView::new_unchecked(this, &self.data) };
-        (0..V::nchildren(view))
-            .map(|i| V::child_name(view, i))
+        let view: ArrayView<'_, V> = unsafe { ArrayView::new_unchecked(this, &self.data) };
+        view.slots()
+            .iter()
+            .filter(|s| s.is_some())
+            .enumerate()
+            .map(|(i, _)| V::child_name(view, i))
             .collect()
     }
 

--- a/vortex-array/src/array/vtable/mod.rs
+++ b/vortex-array/src/array/vtable/mod.rs
@@ -115,23 +115,6 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
         buffers: &[BufferHandle],
     ) -> VortexResult<ArrayParts<Self>>;
 
-    /// Returns the name of the child at the given index.
-    ///
-    /// The default returns the slot name of the `idx`-th non-None slot.
-    ///
-    /// # Panics
-    /// Panics if `idx` is not less than the number of non-None slots.
-    fn child_name(array: ArrayView<'_, Self>, idx: usize) -> String {
-        array
-            .slots()
-            .iter()
-            .enumerate()
-            .filter(|(_, s)| s.is_some())
-            .nth(idx)
-            .map(|(slot_idx, _)| Self::slot_name(array, slot_idx))
-            .vortex_expect("child_name index out of bounds")
-    }
-
     /// Serialize encoding metadata into a byte buffer for IPC or file storage.
     ///
     /// Return `None` if the array cannot be serialized by this encoding. Buffers and children are

--- a/vortex-array/src/array/vtable/mod.rs
+++ b/vortex-array/src/array/vtable/mod.rs
@@ -115,19 +115,12 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
         buffers: &[BufferHandle],
     ) -> VortexResult<ArrayParts<Self>>;
 
-    /// Returns the number of children in the array.
-    ///
-    /// The default counts non-None slots.
-    fn nchildren(array: ArrayView<'_, Self>) -> usize {
-        array.slots().iter().filter(|s| s.is_some()).count()
-    }
-
     /// Returns the name of the child at the given index.
     ///
     /// The default returns the slot name of the `idx`-th non-None slot.
     ///
     /// # Panics
-    /// Panics if `idx >= nchildren(array)`.
+    /// Panics if `idx` is not less than the number of non-None slots.
     fn child_name(array: ArrayView<'_, Self>, idx: usize) -> String {
         array
             .slots()

--- a/vortex-array/src/array/vtable/mod.rs
+++ b/vortex-array/src/array/vtable/mod.rs
@@ -122,21 +122,6 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
         array.slots().iter().filter(|s| s.is_some()).count()
     }
 
-    /// Returns the child at the given index.
-    ///
-    /// The default returns the `idx`-th non-None slot.
-    ///
-    /// # Panics
-    /// Panics if `idx >= nchildren(array)`.
-    fn child(array: ArrayView<'_, Self>, idx: usize) -> ArrayRef {
-        array
-            .slots()
-            .iter()
-            .filter_map(|s| s.clone())
-            .nth(idx)
-            .vortex_expect("child index out of bounds")
-    }
-
     /// Returns the name of the child at the given index.
     ///
     /// The default returns the slot name of the `idx`-th non-None slot.

--- a/vortex-array/src/arrays/patched/vtable/mod.rs
+++ b/vortex-array/src/arrays/patched/vtable/mod.rs
@@ -138,16 +138,6 @@ impl VTable for Patched {
         with_empty_buffers(self, array, buffers)
     }
 
-    fn child(array: ArrayView<'_, Self>, idx: usize) -> ArrayRef {
-        match idx {
-            PatchedSlots::INNER => array.inner().clone(),
-            PatchedSlots::LANE_OFFSETS => array.lane_offsets().clone(),
-            PatchedSlots::PATCH_INDICES => array.patch_indices().clone(),
-            PatchedSlots::PATCH_VALUES => array.patch_values().clone(),
-            _ => vortex_panic!("invalid child index for PatchedArray: {idx}"),
-        }
-    }
-
     fn serialize(
         array: ArrayView<'_, Self>,
         _session: &VortexSession,

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -96,10 +96,6 @@ impl VTable for PythonVTable {
         0
     }
 
-    fn child(_array: ArrayView<'_, Self>, idx: usize) -> ArrayRef {
-        vortex_panic!("PythonArray child index {idx} out of bounds")
-    }
-
     fn child_name(_array: ArrayView<'_, Self>, idx: usize) -> String {
         vortex_panic!("PythonArray child_name index {idx} out of bounds")
     }

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -92,10 +92,6 @@ impl VTable for PythonVTable {
         with_empty_buffers(self, array, buffers)
     }
 
-    fn nchildren(_array: ArrayView<'_, Self>) -> usize {
-        0
-    }
-
     fn child_name(_array: ArrayView<'_, Self>, idx: usize) -> String {
         vortex_panic!("PythonArray child_name index {idx} out of bounds")
     }

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -92,10 +92,6 @@ impl VTable for PythonVTable {
         with_empty_buffers(self, array, buffers)
     }
 
-    fn child_name(_array: ArrayView<'_, Self>, idx: usize) -> String {
-        vortex_panic!("PythonArray child_name index {idx} out of bounds")
-    }
-
     fn serialize(
         _array: ArrayView<'_, Self>,
         _session: &VortexSession,


### PR DESCRIPTION
Remove unneeded methods `child` and `nchildren` from the vtable these always have a default impl and so are uneeded.

# Break
While this is a VTable break it likely used outside of vortex.
