### PR TITLE
feat(expr): partition struct validity as a first-class coordinate

### DIFF
--- a/vortex-array/src/expr/analysis/mod.rs
+++ b/vortex-array/src/expr/analysis/mod.rs
@@ -7,6 +7,7 @@ pub mod immediate_access;
 mod labeling;
 mod null_sensitive;
 mod referenced_field_paths;
+pub mod struct_part;
 
 pub use annotation::*;
 pub use fallible::label_is_fallible;
@@ -15,3 +16,4 @@ pub use labeling::*;
 pub use null_sensitive::BooleanLabels;
 pub use null_sensitive::label_null_sensitive;
 pub use referenced_field_paths::referenced_field_paths;
+pub use struct_part::*;

--- a/vortex-array/src/expr/analysis/struct_part.rs
+++ b/vortex-array/src/expr/analysis/struct_part.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use vortex_error::VortexExpect;
+
+use crate::dtype::FieldName;
+use crate::dtype::Nullability;
+use crate::dtype::StructFields;
+use crate::expr::Expression;
+use crate::expr::analysis::AnnotationFn;
+use crate::scalar_fn::fns::get_item::GetItem;
+use crate::scalar_fn::fns::is_not_null::IsNotNull;
+use crate::scalar_fn::fns::root::Root;
+use crate::scalar_fn::fns::select::Select;
+
+/// A coordinate of a struct scope: either one of its fields, or — for a nullable struct —
+/// the struct's own validity.
+///
+/// A nullable struct with `n` fields decomposes into `n + 1` coordinates. Annotating
+/// expressions with `StructPart` instead of a bare [`FieldName`] lets the validity
+/// coordinate be routed like any field, and cannot collide with a real field that happens
+/// to be named "validity".
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum StructPart {
+    /// A top-level field of the struct scope.
+    Field(FieldName),
+    /// The validity of the struct scope itself, referenced as `is_not_null($)`.
+    Validity,
+}
+
+impl Display for StructPart {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StructPart::Field(name) => write!(f, "{name}"),
+            StructPart::Validity => write!(f, "$validity"),
+        }
+    }
+}
+
+impl From<StructPart> for FieldName {
+    fn from(part: StructPart) -> Self {
+        match part {
+            StructPart::Field(name) => name,
+            // NOTE: this name is only used in the synthetic scope that recombines
+            // partitions. It is not distinguishable from a real field literally named
+            // "$validity"; routing must use the `StructPart` annotation, never this name.
+            StructPart::Validity => FieldName::from("$validity"),
+        }
+    }
+}
+
+/// Returns the free [`StructPart`] coordinates for an expression node.
+///
+/// This extends [`super::make_free_field_annotator`] with the validity coordinate of a
+/// nullable scope:
+///
+/// - **`is_not_null(root())`**: Returns `[Validity]` — the canonical reference to the
+///   scope's validity coordinate (it is also what [`crate::scalar_fn::fns::mask::Mask`]'s
+///   validity derivation produces for the expanded root, see
+///   [`crate::expr::transform::replace_root_scope`]).
+/// - **[`Select`] / [`GetItem`] on [`Root`]**: Returns the referenced fields, as
+///   `Field(..)`. These reference the field coordinates *without* the scope validity.
+/// - **[`Root`]**: Returns every field, plus `Validity` if the scope is nullable
+///   (conservative over-approximation: a bare `$` observes all coordinates).
+/// - **Everything else**: Returns empty (annotations aggregate from children).
+pub fn make_struct_part_annotator(
+    scope: &StructFields,
+    scope_nullability: Nullability,
+) -> impl AnnotationFn<Annotation = StructPart> {
+    move |expr: &Expression| {
+        if expr.is::<IsNotNull>() && expr.child(0).is::<Root>() {
+            if scope_nullability.is_nullable() {
+                return vec![StructPart::Validity];
+            }
+            // A non-nullable scope has no validity coordinate; `is_not_null($)` is a
+            // constant. Leave it unannotated so it does not force a partition.
+            return vec![];
+        } else if let Some(selection) = expr.as_opt::<Select>() {
+            if expr.child(0).is::<Root>() {
+                return selection
+                    .normalize_to_included_fields(scope.names())
+                    .vortex_expect("Select fields must be valid for scope")
+                    .into_iter()
+                    .map(StructPart::Field)
+                    .collect();
+            }
+        } else if let Some(field_name) = expr.as_opt::<GetItem>() {
+            if expr.child(0).is::<Root>() {
+                return vec![StructPart::Field(field_name.clone())];
+            }
+        } else if expr.is::<Root>() {
+            let mut parts: Vec<StructPart> = scope
+                .names()
+                .iter()
+                .cloned()
+                .map(StructPart::Field)
+                .collect();
+            if scope_nullability.is_nullable() {
+                parts.push(StructPart::Validity);
+            }
+            return parts;
+        }
+
+        vec![]
+    }
+}

--- a/vortex-array/src/expr/transform/partition.rs
+++ b/vortex-array/src/expr/transform/partition.rs
@@ -34,11 +34,12 @@ use crate::expr::traversal::TraversalOrder;
 ///
 /// ## Note
 ///
-/// This function currently respects the validity of each field in the scope, but the not validity
-/// of the scope itself. The fix would be for the returned `PartitionedExpr` to include a partition
-/// expression for computing the validity, or to include that expression as part of the root.
-///
-/// See <https://github.com/vortex-data/vortex/issues/1907>.
+/// This function is agnostic to what the annotations denote. To partition over a *nullable*
+/// struct scope, expand the root with
+/// [`replace_root_scope`][crate::expr::transform::replace_root_scope] and annotate with
+/// [`make_struct_part_annotator`][crate::expr::analysis::make_struct_part_annotator], which
+/// treats the scope's own validity as one more coordinate alongside its fields
+/// (see <https://github.com/vortex-data/vortex/issues/1907>).
 pub fn partition<A: AnnotationFn>(
     expr: Expression,
     scope: &DType,
@@ -217,21 +218,28 @@ where
 mod tests {
     use rstest::fixture;
     use rstest::rstest;
+    use vortex_utils::aliases::hash_set::HashSet;
 
     use super::*;
     use crate::dtype::DType;
     use crate::dtype::Nullability::NonNullable;
+    use crate::dtype::Nullability::Nullable;
     use crate::dtype::PType::I32;
     use crate::dtype::StructFields;
     use crate::expr::analysis::make_free_field_annotator;
+    use crate::expr::analysis::make_struct_part_annotator;
+    use crate::expr::analysis::struct_part::StructPart;
     use crate::expr::and;
     use crate::expr::col;
     use crate::expr::get_item;
+    use crate::expr::gt;
+    use crate::expr::is_not_null;
     use crate::expr::lit;
     use crate::expr::merge;
     use crate::expr::pack;
     use crate::expr::root;
     use crate::expr::transform::replace::replace_root_fields;
+    use crate::expr::transform::replace::replace_root_scope;
 
     #[fixture]
     fn dtype() -> DType {
@@ -327,6 +335,33 @@ mod tests {
 
         // One for id.a and id.b
         assert_eq!(partitioned.partitions.len(), 2);
+    }
+
+    #[rstest]
+    fn test_partition_validity_coordinate() -> VortexResult<()> {
+        // A nullable struct scope has a validity coordinate alongside its fields. After
+        // expanding the root, a validity observer partitions to the validity coordinate and
+        // a field predicate partitions to the field — the validity is never guessed at a
+        // fixed position.
+        let dtype = DType::Struct(
+            StructFields::from_iter([("a", I32.into()), ("b", DType::from(I32))]),
+            Nullable,
+        );
+        let fields = dtype.as_struct_fields_opt().unwrap();
+
+        let expr = and(is_not_null(root()), gt(get_item("a", root()), lit(5)));
+        let expr = replace_root_scope(expr, &dtype).optimize_recursive(&dtype)?;
+
+        let partitioned = partition(expr, &dtype, make_struct_part_annotator(fields, Nullable))?;
+
+        let annotations: HashSet<StructPart> =
+            partitioned.partition_annotations.iter().cloned().collect();
+        assert_eq!(
+            annotations,
+            HashSet::from_iter([StructPart::Validity, StructPart::Field("a".into())]),
+            "{partitioned}"
+        );
+        Ok(())
     }
 
     #[rstest]

--- a/vortex-array/src/expr/transform/replace.rs
+++ b/vortex-array/src/expr/transform/replace.rs
@@ -3,10 +3,13 @@
 
 use vortex_error::VortexExpect;
 
+use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::StructFields;
 use crate::expr::Expression;
 use crate::expr::col;
+use crate::expr::is_not_null;
+use crate::expr::mask;
 use crate::expr::pack;
 use crate::expr::root;
 use crate::expr::traversal::NodeExt;
@@ -33,26 +36,61 @@ pub fn replace(expr: Expression, needle: &Expression, replacement: Expression) -
 
 /// Expand the `root` expression with a pack of the given struct fields.
 pub fn replace_root_fields(expr: Expression, fields: &StructFields) -> Expression {
-    replace(
-        expr,
-        &root(),
-        pack(
-            fields
-                .names()
-                .iter()
-                .map(|name| (name.clone(), col(name.clone()))),
-            Nullability::NonNullable,
-        ),
+    replace(expr, &root(), root_fields_expansion(fields))
+}
+
+/// Expand the `root` expression of a struct scope into an expression over its coordinates.
+///
+/// For a non-nullable struct scope this is a `pack` of every field, as in
+/// [`replace_root_fields`]. For a nullable struct scope, the scope has one more coordinate
+/// than it has fields — its own validity — so the expansion is the identity
+///
+/// ```text
+/// $ == mask(pack(f1: $.f1, ..., fn: $.fn), is_not_null($))
+/// ```
+///
+/// where the surviving `$.f` references denote the fields *without* the struct's own
+/// validity applied (`pack` reassembles the values, `mask` re-applies the struct validity).
+/// This keeps the validity coordinate in the expression term, so downstream analyses
+/// (e.g. partitioning) can route it like any other coordinate instead of re-applying it
+/// out-of-band.
+pub fn replace_root_scope(expr: Expression, scope: &DType) -> Expression {
+    let fields = scope
+        .as_struct_fields_opt()
+        .vortex_expect("replace_root_scope requires a struct scope");
+    let expansion = match scope.nullability() {
+        Nullability::NonNullable => root_fields_expansion(fields),
+        Nullability::Nullable => mask(root_fields_expansion(fields), is_not_null(root())),
+    };
+    replace(expr, &root(), expansion)
+}
+
+fn root_fields_expansion(fields: &StructFields) -> Expression {
+    pack(
+        fields
+            .names()
+            .iter()
+            .map(|name| (name.clone(), col(name.clone()))),
+        Nullability::NonNullable,
     )
 }
 
 #[cfg(test)]
 mod test {
     use super::replace;
+    use super::replace_root_scope;
+    use crate::dtype::DType;
     use crate::dtype::Nullability::NonNullable;
+    use crate::dtype::Nullability::Nullable;
+    use crate::dtype::PType::I32;
+    use crate::dtype::StructFields;
+    use crate::expr::col;
     use crate::expr::get_item;
+    use crate::expr::is_not_null;
     use crate::expr::lit;
+    use crate::expr::mask;
     use crate::expr::pack;
+    use crate::expr::root;
 
     #[test]
     fn test_replace_full_tree() {
@@ -70,5 +108,31 @@ mod test {
         let replacement = lit(42);
         let replaced_expr = replace(e, &needle, replacement);
         assert_eq!(replaced_expr.to_string(), "pack(a: 1i32, b: 42i32)");
+    }
+
+    #[test]
+    fn test_replace_root_scope_non_nullable() {
+        let dtype = DType::Struct(
+            StructFields::from_iter([("a", I32.into()), ("b", DType::from(I32))]),
+            NonNullable,
+        );
+        let expanded = replace_root_scope(root(), &dtype);
+        let expected = pack([("a", col("a")), ("b", col("b"))], NonNullable);
+        assert_eq!(&expanded, &expected);
+    }
+
+    #[test]
+    fn test_replace_root_scope_nullable() {
+        let dtype = DType::Struct(
+            StructFields::from_iter([("a", I32.into()), ("b", DType::from(I32))]),
+            Nullable,
+        );
+        let expanded = replace_root_scope(root(), &dtype);
+        // A nullable struct scope has n + 1 coordinates: its fields, and its own validity.
+        let expected = mask(
+            pack([("a", col("a")), ("b", col("b"))], NonNullable),
+            is_not_null(root()),
+        );
+        assert_eq!(&expanded, &expected);
     }
 }

--- a/vortex-array/src/scalar_fn/erased.rs
+++ b/vortex-array/src/scalar_fn/erased.rs
@@ -138,6 +138,15 @@ impl ScalarFnRef {
         }))
     }
 
+    /// Like [`Self::validity`], but returns `None` when the vtable does not define a validity
+    /// derivation, instead of falling back to `is_not_null(expr)`.
+    ///
+    /// Rewrites that turn `is_not_null(expr)` into the derived validity must use this method:
+    /// the fallback would make such a rewrite a self-referential no-op.
+    pub fn validity_opt(&self, expr: &Expression) -> VortexResult<Option<Expression>> {
+        self.0.validity(expr)
+    }
+
     /// Execute the expression given the input arguments.
     pub fn execute(
         &self,

--- a/vortex-array/src/scalar_fn/fns/get_item.rs
+++ b/vortex-array/src/scalar_fn/fns/get_item.rs
@@ -154,6 +154,15 @@ impl ScalarFnVTable for GetItem {
     ) -> VortexResult<Option<Expression>> {
         let child = expr.child(0);
 
+        // `get_item` distributes over `mask`: `get_item(f, mask(s, m)) == mask(get_item(f, s), m)`
+        // (a field of a masked struct is the field masked by the same mask). This exposes the
+        // field access to a `pack` beneath the mask, letting it collapse to a single coordinate.
+        if child.is::<Mask>() {
+            let input = child.child(0).clone();
+            let m = child.child(1).clone();
+            return Ok(Some(GetItem.new_expr(field_name.clone(), [input]).mask(m)?));
+        }
+
         // If the child is a Pack expression, we can directly return the corresponding child.
         if let Some(pack) = child.as_opt::<Pack>() {
             let idx = pack
@@ -256,6 +265,22 @@ mod tests {
             item.dtype(),
             &DType::Primitive(PType::I32, Nullability::Nullable)
         );
+    }
+
+    #[test]
+    fn test_get_item_distributes_over_mask() -> vortex_error::VortexResult<()> {
+        use crate::expr::mask;
+        use crate::expr::test_harness;
+
+        // get_item(a, mask(pack(..), m)) == mask(get_item(a, pack(..)), m) == mask(a-child, m)
+        let m = get_item("bool1", root());
+        let expr = get_item(
+            "a",
+            mask(pack([("a", lit(1)), ("b", lit(2))], NonNullable), m.clone()),
+        );
+        let simplified = expr.optimize_recursive(&test_harness::struct_dtype())?;
+        assert_eq!(&simplified, &mask(lit(1), m));
+        Ok(())
     }
 
     #[test]

--- a/vortex-array/src/scalar_fn/fns/is_not_null.rs
+++ b/vortex-array/src/scalar_fn/fns/is_not_null.rs
@@ -88,6 +88,19 @@ impl ScalarFnVTable for IsNotNull {
         }
     }
 
+    fn simplify_untyped(
+        &self,
+        _options: &Self::Options,
+        expr: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        // `is_not_null(e)` IS `e`'s validity. If the child derives its validity as an
+        // expression (e.g. `mask(a, m)` derives `and(validity(a), m)`), absorb it so that
+        // validity observers reduce to expressions over the validity coordinates instead of
+        // forcing evaluation of the child's values.
+        let child = expr.child(0);
+        child.scalar_fn().validity_opt(child)
+    }
+
     fn is_null_sensitive(&self, _instance: &Self::Options) -> bool {
         true
     }
@@ -130,6 +143,19 @@ mod tests {
 
     static STATS_SESSION: LazyLock<VortexSession> =
         LazyLock::new(|| VortexSession::empty().with::<StatsSession>());
+
+    #[test]
+    fn absorbs_mask_validity() -> VortexResult<()> {
+        use crate::expr::and;
+        use crate::expr::mask;
+
+        // `is_not_null(e)` IS `e`'s validity: for `mask(a, m)` it absorbs to
+        // `and(is_not_null(a), m)` without evaluating the masked values.
+        let expr = is_not_null(mask(col("col1"), col("bool1")));
+        let simplified = expr.optimize_recursive(&test_harness::struct_dtype())?;
+        assert_eq!(&simplified, &and(is_not_null(col("col1")), col("bool1")));
+        Ok(())
+    }
 
     #[test]
     fn dtype() {

--- a/vortex-array/src/scalar_fn/fns/is_null.rs
+++ b/vortex-array/src/scalar_fn/fns/is_null.rs
@@ -12,6 +12,8 @@ use crate::arrays::ConstantArray;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
+use crate::expr::Expression;
+use crate::expr::not;
 use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::EmptyOptions;
@@ -79,6 +81,19 @@ impl ScalarFnVTable for IsNull {
         }
     }
 
+    fn simplify_untyped(
+        &self,
+        _options: &Self::Options,
+        expr: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        // `is_null(e)` is the negation of `e`'s validity. If the child derives its validity
+        // as an expression (e.g. `mask(a, m)` derives `and(validity(a), m)`), absorb it so
+        // that validity observers reduce to expressions over the validity coordinates
+        // instead of forcing evaluation of the child's values.
+        let child = expr.child(0);
+        Ok(child.scalar_fn().validity_opt(child)?.map(not))
+    }
+
     fn is_null_sensitive(&self, _instance: &Self::Options) -> bool {
         true
     }
@@ -127,6 +142,23 @@ mod tests {
             is_null(root()).return_dtype(&dtype).unwrap(),
             DType::Bool(Nullability::NonNullable)
         );
+    }
+
+    #[test]
+    fn absorbs_mask_validity() -> VortexResult<()> {
+        use crate::expr::and;
+        use crate::expr::mask;
+        use crate::expr::not;
+
+        // `is_null(e)` is the negation of `e`'s validity: for `mask(a, m)` it absorbs to
+        // `not(and(is_not_null(a), m))` without evaluating the masked values.
+        let expr = is_null(mask(col("col1"), col("bool1")));
+        let simplified = expr.optimize_recursive(&test_harness::struct_dtype())?;
+        assert_eq!(
+            &simplified,
+            &not(and(crate::expr::is_not_null(col("col1")), col("bool1")))
+        );
+        Ok(())
     }
 
     #[test]

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -5,15 +5,8 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
-use futures::try_join;
 use itertools::Itertools;
-use vortex_array::ArrayRef;
-use vortex_array::IntoArray;
 use vortex_array::MaskFuture;
-use vortex_array::VortexSessionExecute;
-use vortex_array::arrays::StructArray;
-use vortex_array::arrays::struct_::StructArrayExt;
-use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldMask;
 use vortex_array::dtype::FieldName;
@@ -21,15 +14,15 @@ use vortex_array::dtype::Nullability;
 use vortex_array::dtype::StructFields;
 use vortex_array::expr::ExactExpr;
 use vortex_array::expr::Expression;
+use vortex_array::expr::StructPart;
 use vortex_array::expr::col;
-use vortex_array::expr::make_free_field_annotator;
+use vortex_array::expr::is_not_null;
+use vortex_array::expr::make_struct_part_annotator;
 use vortex_array::expr::root;
 use vortex_array::expr::transform::PartitionedExpr;
 use vortex_array::expr::transform::partition;
 use vortex_array::expr::transform::replace;
-use vortex_array::expr::transform::replace_root_fields;
-use vortex_array::scalar_fn::fns::merge::Merge;
-use vortex_array::scalar_fn::fns::pack::Pack;
+use vortex_array::expr::transform::replace_root_scope;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
@@ -103,8 +96,10 @@ impl StructReader {
             ctx,
         );
 
-        // Create an expanded root expression that contains all fields of the struct.
-        let expanded_root_expr = replace_root_fields(root(), struct_dt);
+        // Create an expanded root expression that contains all coordinates of the struct:
+        // every field, plus — for a nullable struct — its validity, referenced as
+        // `is_not_null($)` and re-applied with a `mask` at the position where `$` occurred.
+        let expanded_root_expr = replace_root_scope(root(), layout.dtype());
 
         // This is where we need to do some complex things with the scan in order to split it into
         // different scans for different fields.
@@ -154,6 +149,29 @@ impl StructReader {
             .transpose()
     }
 
+    /// Return the child reader for a [`StructPart`] coordinate.
+    fn part_reader(&self, part: &StructPart) -> VortexResult<&LayoutReaderRef> {
+        match part {
+            StructPart::Field(name) => self.field_reader(name),
+            StructPart::Validity => self.validity()?.ok_or_else(|| {
+                vortex_err!("Validity partition requested for non-nullable struct layout")
+            }),
+        }
+    }
+
+    /// Rewrite a partition expression from the struct scope into the scope of the child
+    /// that the partition is routed to ("stepping in").
+    fn step_into_part(part: &StructPart, expr: Expression) -> Expression {
+        match part {
+            // Field partitions reference the field as `$.name`; the child's root IS the
+            // field (stored without the struct's own validity applied).
+            StructPart::Field(name) => replace(expr, &col(name.clone()), root()),
+            // The validity partition references the coordinate as `is_not_null($)`; the
+            // child's root IS the validity buffer (a non-nullable bool column).
+            StructPart::Validity => replace(expr, &is_not_null(root()), root()),
+        }
+    }
+
     /// Utility for partitioning an expression over the fields of a struct.
     fn partition_expr(&self, expr: Expression) -> VortexResult<Partitioned> {
         let key = ExactExpr(expr.clone());
@@ -171,39 +189,41 @@ impl StructReader {
     }
 
     fn compute_partitioned_expr(&self, expr: Expression) -> VortexResult<Partitioned> {
-        // First, we expand the root scope into the fields of the struct to ensure
-        // that partitioning works correctly.
+        // First, we expand the root scope into the coordinates of the struct (fields plus,
+        // if nullable, the struct's own validity) to ensure that partitioning works
+        // correctly.
         let expr = replace(expr, &root(), self.expanded_root_expr.clone());
         let expr = expr.optimize_recursive(self.dtype())?;
 
-        // Partition the expression into expressions that can be evaluated over individual fields
+        // Partition the expression into expressions that can be evaluated over individual
+        // coordinates.
         let mut partitioned = partition(
             expr.clone(),
             self.dtype(),
-            make_free_field_annotator(
+            make_struct_part_annotator(
                 self.dtype()
                     .as_struct_fields_opt()
                     .vortex_expect("We know it's a struct DType"),
+                self.dtype().nullability(),
             ),
         )?;
 
         if partitioned.partitions.len() == 1 {
-            // If there's only one partition, we step into the field scope of the original
-            // expression by replacing any `$.a` with `$`.
-            return Ok(Partitioned::Single(
-                partitioned.partition_names[0].clone(),
-                replace(expr, &col(partitioned.partition_names[0].clone()), root()),
-            ));
+            // If there's only one partition, we step into the child scope of the original
+            // expression.
+            let part = partitioned.partition_annotations[0].clone();
+            let stepped = Self::step_into_part(&part, expr);
+            return Ok(Partitioned::Single(part, stepped));
         }
 
         // We now need to process the partitioned expressions to rewrite the root scope
-        // to be that of the field, rather than the struct. In other words, "stepping in"
-        // to the field scope.
+        // to be that of the child, rather than the struct. In other words, "stepping in"
+        // to the child scope.
         partitioned.partitions = partitioned
             .partitions
             .iter()
-            .zip_eq(partitioned.partition_names.iter())
-            .map(|(e, name)| replace(e.clone(), &col(name.clone()), root()))
+            .zip_eq(partitioned.partition_annotations.iter())
+            .map(|(e, part)| Self::step_into_part(part, e.clone()))
             .collect();
 
         Ok(Partitioned::Multi(Arc::new(partitioned)))
@@ -215,10 +235,10 @@ impl StructReader {
 // TODO(joe): this is a duplicate of the Partitioned enum in arrays/expr/vtable/rules
 #[derive(Clone)]
 enum Partitioned {
-    /// An expression which only operates over a single field
-    Single(FieldName, Expression),
-    /// An expression which operates over multiple fields
-    Multi(Arc<PartitionedExpr<FieldName>>),
+    /// An expression which only operates over a single coordinate
+    Single(StructPart, Expression),
+    /// An expression which operates over multiple coordinates
+    Multi(Arc<PartitionedExpr<StructPart>>),
 }
 
 impl LayoutReader for StructReader {
@@ -262,11 +282,11 @@ impl LayoutReader for StructReader {
     ) -> VortexResult<MaskFuture> {
         // Partition the expression into expressions that can be evaluated over individual fields
         match &self.partition_expr(expr.clone())? {
-            Partitioned::Single(name, partition) => self
-                .field_reader(name)?
+            Partitioned::Single(part, partition) => self
+                .part_reader(part)?
                 .pruning_evaluation(row_range, partition, mask)
                 .map_err(|err| {
-                    err.with_context(format!("While evaluating pruning filter partition {name}"))
+                    err.with_context(format!("While evaluating pruning filter partition {part}"))
                 }),
             Partitioned::Multi(_) => {
                 // TODO(ngates): if all partitions are boolean, we can use a pruning evaluation. Otherwise
@@ -284,27 +304,27 @@ impl LayoutReader for StructReader {
     ) -> VortexResult<MaskFuture> {
         // Partition the expression into expressions that can be evaluated over individual fields
         match &self.partition_expr(expr.clone())? {
-            Partitioned::Single(name, partition) => self
-                .field_reader(name)?
+            Partitioned::Single(part, partition) => self
+                .part_reader(part)?
                 .filter_evaluation(row_range, partition, mask)
                 .map_err(|err| {
-                    err.with_context(format!("While evaluating filter partition {name}"))
+                    err.with_context(format!("While evaluating filter partition {part}"))
                 }),
             Partitioned::Multi(partitioned) => Arc::clone(partitioned).into_mask_future(
                 mask,
-                |name, expr, mask| {
-                    self.field_reader(name)?
+                |part, expr, mask| {
+                    self.part_reader(part)?
                         .filter_evaluation(row_range, expr, mask)
                         .map_err(|err| {
-                            err.with_context(format!("While evaluating filter partition {name}"))
+                            err.with_context(format!("While evaluating filter partition {part}"))
                         })
                 },
-                |name, expr, mask| {
-                    self.field_reader(name)?
+                |part, expr, mask| {
+                    self.part_reader(part)?
                         .projection_evaluation(row_range, expr, mask)
                         .map_err(|err| {
                             err.with_context(format!(
-                                "While evaluating projection partition {name}"
+                                "While evaluating projection partition {part}"
                             ))
                         })
                 },
@@ -319,66 +339,30 @@ impl LayoutReader for StructReader {
         expr: &Expression,
         mask_fut: MaskFuture,
     ) -> VortexResult<ArrayFuture> {
-        let validity_fut = self
-            .validity()?
-            .map(|reader| reader.projection_evaluation(row_range, &root(), mask_fut.clone()))
-            .transpose()?;
-
-        // Partition the expression into expressions that can be evaluated over individual fields
-        let (projected, is_pack_merge) = match &self.partition_expr(expr.clone())? {
-            Partitioned::Single(name, partition) => (
-                self.field_reader(name)?
-                    .projection_evaluation(row_range, partition, mask_fut)
-                    .map_err(|err| {
-                        err.with_context(format!("While evaluating projection partition {name}"))
-                    })?,
-                partition.is::<Pack>() || partition.is::<Merge>(),
-            ),
-
-            Partitioned::Multi(partitioned) => (
-                Arc::clone(partitioned).into_array_future(mask_fut, |name, expr, mask| {
-                    self.field_reader(name)?
+        // Partition the expression into expressions that can be evaluated over individual
+        // coordinates. For a nullable struct the expanded root expression carries the
+        // struct's validity as an ordinary coordinate (`mask(pack(..), is_not_null($))`),
+        // so the validity is read and re-applied exactly where the original expression
+        // referenced the scope — there is no positional side-channel.
+        match &self.partition_expr(expr.clone())? {
+            Partitioned::Single(part, partition) => self
+                .part_reader(part)?
+                .projection_evaluation(row_range, partition, mask_fut)
+                .map_err(|err| {
+                    err.with_context(format!("While evaluating projection partition {part}"))
+                }),
+            Partitioned::Multi(partitioned) => {
+                Arc::clone(partitioned).into_array_future(mask_fut, |part, expr, mask| {
+                    self.part_reader(part)?
                         .projection_evaluation(row_range, expr, mask)
                         .map_err(|err| {
                             err.with_context(format!(
-                                "While evaluating projection partition {name}"
+                                "While evaluating projection partition {part}"
                             ))
                         })
-                })?,
-                partitioned.root.is::<Pack>() || partitioned.root.is::<Merge>(),
-            ),
-        };
-
-        let session = self.session.clone();
-        Ok(Box::pin(async move {
-            if let Some(validity_fut) = validity_fut {
-                let (array, validity) = try_join!(projected, validity_fut)?;
-
-                // If root expression was a pack, then we apply the validity to each child field
-                if is_pack_merge {
-                    let mut ctx = session.create_execution_ctx();
-                    let struct_array = array.execute::<StructArray>(&mut ctx)?;
-                    let masked_fields: Vec<ArrayRef> = struct_array
-                        .iter_unmasked_fields()
-                        .map(|a| a.clone().mask(validity.clone()))
-                        .try_collect()?;
-
-                    Ok(StructArray::try_new(
-                        struct_array.names().clone(),
-                        masked_fields,
-                        struct_array.len(),
-                        struct_array.validity()?,
-                    )?
-                    .into_array())
-                } else {
-                    // If the root expression was not a pack or merge, e.g. if it's something like
-                    // a get_item, then we apply the validity directly to the result
-                    array.mask(validity)
-                }
-            } else {
-                projected.await
+                })
             }
-        }))
+        }
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -413,6 +397,8 @@ mod tests {
     use vortex_array::expr::eq;
     use vortex_array::expr::get_item;
     use vortex_array::expr::gt;
+    use vortex_array::expr::is_not_null;
+    use vortex_array::expr::is_null;
     use vortex_array::expr::lit;
     use vortex_array::expr::or;
     use vortex_array::expr::pack;
@@ -534,6 +520,54 @@ mod tests {
                             ("a", buffer![7, 2, 3].into_array()),
                             ("b", buffer![4, 5, 6].into_array()),
                             ("c", buffer![4, 5, 6].into_array()),
+                        ],
+                        Validity::Array(BoolArray::from_iter([false, true, true]).into_array()),
+                    )
+                    .unwrap()
+                    .into_array()
+                    .to_array_stream()
+                    .sequenced(ptr),
+                    eof,
+                    &session,
+                )
+                .await
+        })
+        .unwrap();
+
+        (segments, layout)
+    }
+
+    /// A nullable struct layout with a real field named "validity", whose values differ
+    /// from the struct's own validity so that confusing the two fails loudly.
+    ///
+    /// | field "validity" | a | struct validity |
+    /// |------------------|---|-----------------|
+    /// | true             | 1 | false (NULL)    |
+    /// | false            | 2 | true            |
+    /// | true             | 3 | true            |
+    #[fixture]
+    fn validity_named_field_layout() -> (Arc<dyn SegmentSource>, LayoutRef) {
+        let ctx = ArrayContext::empty();
+        let segments = Arc::new(TestSegments::default());
+        let (ptr, eof) = SequenceId::root().split();
+        let strategy = TableStrategy::new(
+            Arc::new(FlatLayoutStrategy::default()),
+            Arc::new(FlatLayoutStrategy::default()),
+        );
+        let segments2 = Arc::<TestSegments>::clone(&segments);
+        let layout = block_on(|handle| async move {
+            let session = SESSION.clone().with_handle(handle);
+            strategy
+                .write_stream(
+                    ctx,
+                    segments2,
+                    StructArray::try_from_iter_with_validity(
+                        [
+                            (
+                                "validity",
+                                BoolArray::from_iter([true, false, true]).into_array(),
+                            ),
+                            ("a", buffer![1, 2, 3].into_array()),
                         ],
                         Validity::Array(BoolArray::from_iter([false, true, true]).into_array()),
                     )
@@ -714,6 +748,133 @@ mod tests {
             expected_b,
             &mut ctx
         );
+    }
+
+    #[rstest]
+    fn test_struct_layout_filter_is_not_null_root(
+        #[from(null_struct_layout)] (segments, layout): (Arc<dyn SegmentSource>, LayoutRef),
+    ) {
+        // `is_not_null($)` observes the struct's own validity. It must be routed to the
+        // validity child, not constant-folded away by the field expansion.
+        let reader = layout
+            .new_reader("".into(), segments, &SESSION, &Default::default())
+            .unwrap();
+        let filt = is_not_null(root());
+        let result = block_on(|_| {
+            reader
+                .filter_evaluation(&(0..3), &filt, MaskFuture::new_true(3))
+                .unwrap()
+        })
+        .unwrap();
+        assert_eq!(result, Mask::from_iter([false, true, true]));
+    }
+
+    #[rstest]
+    fn test_struct_layout_filter_null_rows_do_not_match(
+        #[from(null_struct_layout)] (segments, layout): (Arc<dyn SegmentSource>, LayoutRef),
+    ) {
+        // Row 0 of the struct is null, but the field child stores `a = 7` in that slot.
+        // A predicate on the field must not observe the bytes stored under a null row.
+        let reader = layout
+            .new_reader("".into(), segments, &SESSION, &Default::default())
+            .unwrap();
+        let filt = eq(col("a"), lit(7));
+        let result = block_on(|_| {
+            reader
+                .filter_evaluation(&(0..3), &filt, MaskFuture::new_true(3))
+                .unwrap()
+        })
+        .unwrap();
+        assert_eq!(result, Mask::from_iter([false, false, false]));
+    }
+
+    #[rstest]
+    fn test_struct_layout_projection_is_null_root(
+        #[from(null_struct_layout)] (segments, layout): (Arc<dyn SegmentSource>, LayoutRef),
+    ) {
+        // Projecting `is_null($)` returns the negated struct validity. It must be read from
+        // the validity child and must not itself be masked (it is a total expression).
+        let mut ctx = SESSION.create_execution_ctx();
+        let reader = layout
+            .new_reader("".into(), segments, &SESSION, &Default::default())
+            .unwrap();
+        let expr = is_null(root());
+        let result = block_on(|_| {
+            reader
+                .projection_evaluation(&(0..3), &expr, MaskFuture::new_true(3))
+                .unwrap()
+        })
+        .unwrap();
+        let expected = BoolArray::from_iter([true, false, false]);
+        assert_arrays_eq!(result, expected, &mut ctx);
+    }
+
+    #[rstest]
+    fn test_struct_layout_projection_literal_untouched_by_validity(
+        #[from(null_struct_layout)] (segments, layout): (Arc<dyn SegmentSource>, LayoutRef),
+    ) {
+        // A validity-independent expression must not receive the struct's validity: the
+        // struct being null at row 0 does not make `lit(1)` null at row 0.
+        let reader = layout
+            .new_reader("".into(), segments, &SESSION, &Default::default())
+            .unwrap();
+        let expr = pack([("x", lit(1))], Nullability::NonNullable);
+        let result = block_on(|_| {
+            reader
+                .projection_evaluation(&(0..3), &expr, MaskFuture::new_true(3))
+                .unwrap()
+        })
+        .unwrap();
+
+        assert_eq!(
+            result
+                .execute_scalar(0, &mut array_session().create_execution_ctx())
+                .unwrap()
+                .as_struct()
+                .field_by_idx(0)
+                .unwrap(),
+            Scalar::primitive(1, Nullability::NonNullable)
+        );
+    }
+
+    #[rstest]
+    fn test_struct_layout_field_named_validity(
+        #[from(validity_named_field_layout)] (segments, layout): (
+            Arc<dyn SegmentSource>,
+            LayoutRef,
+        ),
+    ) {
+        // A real field named "validity" must not be confused with the struct's own
+        // validity coordinate: projecting it returns the field values (masked by the
+        // struct validity), while `is_not_null($)` returns the struct validity itself.
+        let mut ctx = SESSION.create_execution_ctx();
+        let reader = layout
+            .new_reader("".into(), segments, &SESSION, &Default::default())
+            .unwrap();
+
+        let expr = get_item("validity", root());
+        let result = block_on(|_| {
+            reader
+                .projection_evaluation(&(0..3), &expr, MaskFuture::new_true(3))
+                .unwrap()
+        })
+        .unwrap();
+        assert_eq!(
+            result.dtype(),
+            &DType::Bool(Nullability::Nullable),
+            "field projection should have the field's dtype"
+        );
+        let expected = BoolArray::from_iter([None, Some(false), Some(true)]);
+        assert_arrays_eq!(result, expected, &mut ctx);
+
+        let filt = is_not_null(root());
+        let result = block_on(|_| {
+            reader
+                .filter_evaluation(&(0..3), &filt, MaskFuture::new_true(3))
+                .unwrap()
+        })
+        .unwrap();
+        assert_eq!(result, Mask::from_iter([false, true, true]));
     }
 
     #[rstest]


### PR DESCRIPTION
## Rationale for this change

Partitioning a nullable struct scope decomposes it into n+1 coordinates (n fields plus the struct's own validity), but only the n fields had expression-level names: `replace_root_fields` rewrote `$` into `pack(f: $.f, …)`, whose validity is hard-wired `lit(true)`. The validity coordinate was dropped from the term and re-applied by `StructReader` as a positional side-channel — projection-only, at a syntactically guessed position. Consequences, each covered by a new failing-first test:

- Validity observers were constant-folded through pack's always-valid claim: `is_not_null($)` filtered to all-true, `is_null($)` projected wrongly.
- The filter path never read the validity child, so predicates on fields matched the bytes stored under null rows.
- Validity-independent expressions were over-masked: projecting `lit(1)` over a nullable struct returned null at null rows.
- The side-channel guessed mask placement from the root expression's shape (`is_pack_merge`), which cannot be correct for every expression.
- The validity child was addressed by the user-space name `"validity"`, collidable with a real field of that name.

This PR makes the validity coordinate part of the expression term, so it is routed, read, and re-applied by the same generic partitioning machinery as fields. It is the first part of the plan discussed for #1907; follow-ups (generic mask-distribution over non-null-sensitive infallible fns, `and(m, mask(x, m)) → and(m, x)` to restore full filter pushdown over nullable structs, a per-fn `is_null_sensitive` audit including `GetItem`, and sub-expression dedup in the partition splitter) restore pushdown depth and are pure optimizations — this PR is the correctness core.

- Closes: #1907

## What changes are included in this PR?

**`vortex-array`**

- `replace_root_scope` (`expr/transform/replace.rs`): expands a nullable struct scope with the identity `$ == mask(pack(f: $.f, …), is_not_null($))`, so the validity is read and re-applied exactly where `$` occurred. Non-nullable scopes expand to the plain pack as before, and the existing `mask(x, lit(true))` simplification collapses the identity for scopes that turn out non-nullable.
- `StructPart { Field(FieldName), Validity }` + `make_struct_part_annotator` (`expr/analysis/struct_part.rs`): annotates `is_not_null($)` as the validity coordinate and fields as before; partitions are routed by annotation, not by field name, removing the `"validity"` name collision.
- `is_null` / `is_not_null` absorb a child's vtable-derived validity expression via the new `ScalarFnRef::validity_opt` (the `Option`-returning form; the existing `validity()` fallback of `is_not_null(child)` would make the rewrite a self-referential no-op). With `Mask::validity() = and(child_validity, m)`, `is_not_null(mask(pack(..), V))` folds to `V`.
- `get_item` distributes over `mask` (`get_item(f, mask(s, m)) == mask(get_item(f, s), m)`), keeping single-field projections narrow (they read the field plus the validity child, not every field).

**`vortex-layout`**

- `StructReader` partitions with the `StructPart` annotator, routes `Validity` partitions to child 0, and steps validity partitions into the bool child's scope (`is_not_null($) → $`). The projection-time validity side-channel (`validity_fut` + `is_pack_merge` guessing) is deleted: the `mask` node in the partitioned root re-applies validity at struct level through the existing `Mask` kernel, and the existing `null_as_false` at the filter boundary converts validity-induced nulls to excluded rows. The filter and pruning paths now see the validity coordinate through the same partitioning as projection.

**Tests** (the five new `StructReader` tests fail before this change; verified against the parent commit)

- filter `is_not_null($)` over a nullable struct returns the struct validity instead of all-true
- filter `eq($.a, 7)` does not match a row whose stored bytes satisfy the predicate under a null struct row
- projection `is_null($)` returns the negated validity instead of a mis-masked constant
- projection `pack(x: lit(1))` is not nulled at null struct rows
- a real field named `"validity"` projects as the field while `is_not_null($)` still routes to the struct's validity

Plus expression-level tests for the expansion identity, the absorb rules, the `get_item`/`mask` distribution, and partitioning `and(is_not_null($), $.a > 5)` into exactly `{Validity}` and `{Field(a)}` coordinates.

Checks run: `cargo nextest run -p vortex-array -p vortex-layout -p vortex-file -p vortex-scan -p vortex-datafusion` (3611 tests pass), `cargo test --doc -p vortex-array`, `cargo +nightly fmt --all`, `cargo clippy --all-targets` on the affected crate closure (clean). Not run: workspace-wide `--all-features` clippy (the sandbox lacks `protoc` for `lance-encoding` and network access for the `vortex-duckdb` build script — failures are environmental and unrelated to this change).

## What APIs are changed? Are there any user-facing changes?

- New public APIs: `expr::transform::replace_root_scope`, `expr::analysis::{StructPart, make_struct_part_annotator}`, `ScalarFnRef::validity_opt`. No existing signatures changed (`replace_root_fields` is kept).
- Behavioral changes are bug fixes visible to readers of nullable structs: filters now respect struct-level nulls (previously they could match garbage bytes under null rows), `is_null($)`/`is_not_null($)` observe real validity, and total expressions are no longer masked. Filters over nullable structs currently evaluate at struct level (partitions per referenced field + validity) rather than fully pushed down; pushdown is restored by the follow-up rewrite rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fo6HoW3WV5UAKwVoymZjyf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fo6HoW3WV5UAKwVoymZjyf)_