### PR TITLE
Fix decimal scalar multiplication and division

### DIFF
--- a/vortex-array/src/aggregate_fn/fns/sum/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/mod.rs
@@ -476,10 +476,14 @@ mod tests {
                 .checked_add(&rhs.as_primitive())
                 .map(Scalar::from)
                 .unwrap_or_else(|| Scalar::null(sum_dtype.as_nullable())),
-            DType::Decimal(..) => lhs
+            // Add widens the result precision, so restate the sum in the accumulator's own
+            // decimal type, treating a value that no longer fits as an overflow.
+            DType::Decimal(decimal_dtype, _) => lhs
                 .as_decimal()
-                .checked_binary_numeric(&rhs.as_decimal(), NumericOperator::Add)
-                .map(Scalar::from)
+                .checked_binary_numeric(&rhs.as_decimal(), NumericOperator::Add)?
+                .and_then(|scalar| scalar.as_decimal().decimal_value())
+                .filter(|value| value.fits_in_precision(*decimal_dtype))
+                .map(|value| Scalar::decimal(value, *decimal_dtype, Nullable))
                 .unwrap_or_else(|| Scalar::null(sum_dtype.as_nullable())),
             _ => unreachable!("Sum will always be a decimal or a primitive dtype"),
         })

--- a/vortex-array/src/scalar/typed_view/decimal/arithmetic.rs
+++ b/vortex-array/src/scalar/typed_view/decimal/arithmetic.rs
@@ -59,14 +59,20 @@ pub(crate) fn decimal_numeric_result_dtype(
             ))
         }
         NumericOperator::Mul => {
-            let result_scale = input.scale().saturating_add(input.scale());
-            if result_scale > MAX_SCALE {
-                // The SQL standard rejects a product whose scale cannot be represented rather
-                // than rounding it away.
+            // Doubling the scale in i8 would saturate a very negative sum into a legal-looking
+            // scale, so widen first. The SQL standard rejects a product whose scale cannot be
+            // represented rather than rounding it away.
+            let result_scale = <i16 as From<i8>>::from(input.scale()) * 2;
+            let Some(result_scale) = i8::try_from(result_scale)
+                .ok()
+                .filter(|scale| *scale <= MAX_SCALE)
+            else {
                 vortex_bail!(
-                    "output scale of {input} {op} {input} would exceed max scale of {MAX_SCALE}"
+                    "output scale {result_scale} of {input} {op} {input} is outside the \
+                     representable scale range of {} to {MAX_SCALE}",
+                    i8::MIN
                 );
-            }
+            };
             let result_precision = input
                 .precision()
                 .saturating_add(input.precision().saturating_add(1))

--- a/vortex-array/src/scalar/typed_view/decimal/arithmetic.rs
+++ b/vortex-array/src/scalar/typed_view/decimal/arithmetic.rs
@@ -43,8 +43,9 @@ use crate::scalar::NumericOperator;
 ///
 /// # Errors
 ///
-/// Returns an error if the operation has no valid result type: a Mul whose scale would exceed
-/// [`MAX_SCALE`], or a Div whose precision would fall outside the legal range.
+/// Returns an error if the operation has no valid result type: a Mul whose doubled scale is
+/// unrepresentable — above [`MAX_SCALE`], or below the `i8::MIN` floor of the scale field — or a
+/// Div whose precision would fall outside the legal range.
 pub(crate) fn decimal_numeric_result_dtype(
     input: DecimalDType,
     op: NumericOperator,

--- a/vortex-array/src/scalar/typed_view/decimal/arithmetic.rs
+++ b/vortex-array/src/scalar/typed_view/decimal/arithmetic.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Arrow's decimal arithmetic rules, and their evaluation over [`DecimalValue`].
+//!
+//! Vortex coerces both operands of a decimal arithmetic expression to a single [`DecimalDType`],
+//! so Arrow's general `(p1, s1) op (p2, s2)` formulas collapse to a function of one input type:
+//!
+//! | operator | result precision | result scale |
+//! | -------- | ---------------- | ------------ |
+//! | Add, Sub | `p + 1`          | `s`          |
+//! | Mul      | `2p + 1`         | `2s`         |
+//! | Div      | `p + s + 4`      | `s + 4`      |
+//!
+//! Precision saturates at [`MAX_PRECISION`]. Because Mul widens the scale, the product of the
+//! stored integers already sits at the result scale and no rounding is needed. Div instead scales
+//! the dividend up front and truncates toward zero, which is what Arrow does.
+//!
+//! Div is the one operator whose intermediate can outgrow the widest native width: scaling the
+//! dividend by `10^result_scale` overflows `i256` once `p + result_scale` passes
+//! [`MAX_PRECISION`], even for a quotient that would have fit the result precision. That is
+//! reported as an overflow. The array kernels derive their working width the same way, so both
+//! paths agree on which operations are representable.
+
+use num_traits::CheckedAdd;
+use num_traits::CheckedDiv;
+use num_traits::CheckedMul;
+use num_traits::CheckedSub;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
+
+use crate::dtype::BigCast;
+use crate::dtype::DecimalDType;
+use crate::dtype::MAX_PRECISION;
+use crate::dtype::MAX_SCALE;
+use crate::dtype::NativeDecimalType;
+use crate::match_each_decimal_value_type;
+use crate::scalar::DecimalValue;
+use crate::scalar::NumericOperator;
+
+/// Derive the result decimal dtype of a numeric operation over two operands of `input`.
+///
+/// # Errors
+///
+/// Returns an error if the operation has no valid result type: a Mul whose scale would exceed
+/// [`MAX_SCALE`], or a Div whose precision would fall outside the legal range.
+pub(crate) fn decimal_numeric_result_dtype(
+    input: DecimalDType,
+    op: NumericOperator,
+) -> VortexResult<DecimalDType> {
+    match op {
+        NumericOperator::Add | NumericOperator::Sub => {
+            // A p-digit Add/Sub result needs at most one carry digit:
+            // 2 * (10^p - 1) < 10^(p + 1).
+            Ok(DecimalDType::new(
+                input.precision().saturating_add(1).min(MAX_PRECISION),
+                input.scale(),
+            ))
+        }
+        NumericOperator::Mul => {
+            let result_scale = input.scale().saturating_add(input.scale());
+            if result_scale > MAX_SCALE {
+                // The SQL standard rejects a product whose scale cannot be represented rather
+                // than rounding it away.
+                vortex_bail!(
+                    "output scale of {input} {op} {input} would exceed max scale of {MAX_SCALE}"
+                );
+            }
+            let result_precision = input
+                .precision()
+                .saturating_add(input.precision().saturating_add(1))
+                .min(MAX_PRECISION);
+            DecimalDType::try_new(result_precision, result_scale)
+        }
+        NumericOperator::Div => {
+            // Arrow follows Postgres and MySQL in adding a fixed four fractional digits. Its
+            // precision formula `p1 - s1 + s2 + result_scale` simplifies to `p + result_scale`
+            // once both operands share a dtype.
+            let result_scale = input.scale().saturating_add(4).min(MAX_SCALE);
+            let result_precision =
+                <i16 as From<u8>>::from(input.precision()) + <i16 as From<i8>>::from(result_scale);
+            let result_precision = u8::try_from(result_precision).map_err(|_| {
+                vortex_err!(
+                    InvalidArgument:
+                    "decimal division result precision {result_precision} is invalid"
+                )
+            })?;
+            DecimalDType::try_new(result_precision.min(MAX_PRECISION), result_scale)
+        }
+    }
+}
+
+/// Apply `op` to two stored values of `input`, returning the result stored in `result`'s width.
+///
+/// Returns `None` if the result overflows `result`'s precision, or if `op` is a division by zero.
+pub(crate) fn checked_decimal_numeric(
+    lhs: DecimalValue,
+    rhs: DecimalValue,
+    input: DecimalDType,
+    result: DecimalDType,
+    op: NumericOperator,
+) -> Option<DecimalValue> {
+    let work = work_decimal_dtype(input, result, op);
+    match_each_decimal_value_type!(DecimalType::smallest_decimal_value_type(&work), |W| {
+        let value = checked_at_width::<W>(lhs.cast::<W>()?, rhs.cast::<W>()?, result.scale(), op)?;
+        DecimalValue::from(value).normalize(result)
+    })
+}
+
+/// Pick a native width wide enough to hold every intermediate of an in-precision operation.
+///
+/// The result precision covers Add, Sub and Mul, whose intermediates are the result itself. Div
+/// scales the dividend (or the divisor, for a negative result scale) by `10^result_scale` before
+/// dividing, so it needs room for `p + |result_scale|` digits.
+fn work_decimal_dtype(
+    input: DecimalDType,
+    result: DecimalDType,
+    op: NumericOperator,
+) -> DecimalDType {
+    let precision = match op {
+        NumericOperator::Add | NumericOperator::Sub | NumericOperator::Mul => result.precision(),
+        NumericOperator::Div => input
+            .precision()
+            .saturating_add(result.scale().unsigned_abs())
+            .max(result.precision())
+            .min(MAX_PRECISION),
+    };
+    DecimalDType::new(precision, 0)
+}
+
+fn checked_at_width<W>(lhs: W, rhs: W, result_scale: i8, op: NumericOperator) -> Option<W>
+where
+    W: NativeDecimalType + CheckedAdd + CheckedSub + CheckedMul + CheckedDiv,
+{
+    match op {
+        NumericOperator::Add => lhs.checked_add(&rhs),
+        NumericOperator::Sub => lhs.checked_sub(&rhs),
+        // The result scale is the sum of the operand scales, so the raw product is already
+        // correctly scaled.
+        NumericOperator::Mul => lhs.checked_mul(&rhs),
+        NumericOperator::Div => {
+            // Arrow scales the quotient by `10^(result_scale - lhs_scale + rhs_scale)`, which is
+            // `10^result_scale` for equal operand dtypes. A negative exponent scales the divisor
+            // instead of the dividend.
+            let factor =
+                decimal_scale_factor::<W>(<u32 as From<u8>>::from(result_scale.unsigned_abs()))?;
+            if result_scale >= 0 {
+                lhs.checked_mul(&factor)?.checked_div(&rhs)
+            } else {
+                lhs.checked_div(&rhs.checked_mul(&factor)?)
+            }
+        }
+    }
+}
+
+/// `10^exp` at width `W`, or `None` if it is not representable there.
+fn decimal_scale_factor<W>(exp: u32) -> Option<W>
+where
+    W: NativeDecimalType + CheckedAdd,
+{
+    let max = *W::MAX_BY_PRECISION.get(usize::try_from(exp).ok()?)?;
+    max.checked_add(&<W as BigCast>::from(1_i8)?)
+}

--- a/vortex-array/src/scalar/typed_view/decimal/dvalue.rs
+++ b/vortex-array/src/scalar/typed_view/decimal/dvalue.rs
@@ -209,6 +209,7 @@ impl DecimalValue {
         let value_type = DecimalType::smallest_decimal_value_type(&decimal_type);
         match_each_decimal_value_type!(value_type, |T| {
             let value = self.cast::<T>()?;
+            // `T` is the narrowest type covering `precision`, so both tables index in bounds.
             let precision = usize::from(decimal_type.precision());
             (T::MIN_BY_PRECISION[precision] <= value && value <= T::MAX_BY_PRECISION[precision])
                 .then_some(Self::from(value))

--- a/vortex-array/src/scalar/typed_view/decimal/dvalue.rs
+++ b/vortex-array/src/scalar/typed_view/decimal/dvalue.rs
@@ -16,7 +16,6 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 
-use crate::dtype::BigCast;
 use crate::dtype::DecimalDType;
 use crate::dtype::DecimalType;
 use crate::dtype::NativeDecimalType;
@@ -173,24 +172,12 @@ impl DecimalValue {
     /// `decimal_dtype`, after enforcing the dtype precision.
     pub(crate) fn try_from_i256(value: i256, decimal_dtype: DecimalDType) -> VortexResult<Self> {
         let decimal_value = Self::I256(value);
-        if !decimal_value.fits_in_precision(decimal_dtype) {
-            vortex_bail!(
+        decimal_value.normalize(decimal_dtype).ok_or_else(|| {
+            vortex_err!(
                 "decimal value {} does not fit in precision of {}",
                 decimal_value,
                 decimal_dtype
-            );
-        }
-
-        let target_type = DecimalType::smallest_decimal_value_type(&decimal_dtype);
-        match_each_decimal_value_type!(target_type, |T| {
-            let value = <T as BigCast>::from(value).ok_or_else(|| {
-                vortex_err!(
-                    "decimal value {} cannot be represented as {}",
-                    decimal_value,
-                    target_type
-                )
-            })?;
-            Ok(Self::from(value))
+            )
         })
     }
 
@@ -214,19 +201,18 @@ impl DecimalValue {
     /// The stored value (regardless of scale) must fit within the range defined by precision.
     /// For precision P, the maximum absolute stored value is 10^P - 1.
     pub fn fits_in_precision(&self, decimal_type: DecimalDType) -> bool {
-        // Convert to i256 for comparison
-        let value_i256 = self.as_i256();
+        self.normalize(decimal_type).is_some()
+    }
 
-        // Calculate the maximum stored value that can be represented with this precision
-        // For precision P, the max stored value is 10^P - 1
-        // This is independent of scale - scale only affects how we interpret the value
-        let ten = i256::from_i128(10);
-        let max_value = ten
-            .checked_pow(decimal_type.precision() as _)
-            .vortex_expect("precision must exist in i256");
-        let min_value = -max_value;
-
-        value_i256 > min_value && value_i256 < max_value
+    /// Checks the dtype precision and returns the value in the dtype's native storage width.
+    pub(crate) fn normalize(&self, decimal_type: DecimalDType) -> Option<Self> {
+        let value_type = DecimalType::smallest_decimal_value_type(&decimal_type);
+        match_each_decimal_value_type!(value_type, |T| {
+            let value = self.cast::<T>()?;
+            let precision = usize::from(decimal_type.precision());
+            (T::MIN_BY_PRECISION[precision] <= value && value <= T::MAX_BY_PRECISION[precision])
+                .then_some(Self::from(value))
+        })
     }
 
     /// Checked addition. Returns `None` on overflow.
@@ -239,12 +225,12 @@ impl DecimalValue {
         checked_widening_binary_op!(self, other, CheckedSub::checked_sub)
     }
 
-    /// Checked multiplication. Returns `None` on overflow.
+    /// Checked multiplication of the raw stored integers. Returns `None` on overflow.
     pub fn checked_mul(&self, other: &Self) -> Option<Self> {
         checked_widening_binary_op!(self, other, CheckedMul::checked_mul)
     }
 
-    /// Checked division. Returns `None` on overflow or division by zero.
+    /// Checked division of the raw stored integers. Returns `None` on overflow or division by zero.
     pub fn checked_div(&self, other: &Self) -> Option<Self> {
         checked_widening_binary_op!(self, other, CheckedDiv::checked_div)
     }

--- a/vortex-array/src/scalar/typed_view/decimal/mod.rs
+++ b/vortex-array/src/scalar/typed_view/decimal/mod.rs
@@ -3,9 +3,11 @@
 
 //! Definition and implementation of [`DecimalScalar`] and [`DecimalValue`].
 
+mod arithmetic;
 mod dvalue;
 mod scalar;
 
+pub(crate) use arithmetic::decimal_numeric_result_dtype;
 pub use dvalue::DecimalValue;
 pub use scalar::DecimalScalar;
 

--- a/vortex-array/src/scalar/typed_view/decimal/scalar.rs
+++ b/vortex-array/src/scalar/typed_view/decimal/scalar.rs
@@ -6,23 +6,17 @@
 use std::cmp::Ordering;
 use std::fmt;
 
-use num_traits::CheckedAdd;
-use num_traits::CheckedDiv;
-use num_traits::CheckedMul;
 use num_traits::ToPrimitive as NumToPrimitive;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
-use vortex_error::vortex_panic;
 
-use crate::dtype::BigCast;
+use super::arithmetic::checked_decimal_numeric;
+use super::arithmetic::decimal_numeric_result_dtype;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
-use crate::dtype::MAX_PRECISION;
-use crate::dtype::NativeDecimalType;
 use crate::dtype::PType;
 use crate::match_each_decimal_value;
-use crate::match_each_decimal_value_type;
 use crate::scalar::DecimalValue;
 use crate::scalar::NumericOperator;
 use crate::scalar::Scalar;
@@ -186,137 +180,58 @@ impl<'a> DecimalScalar<'a> {
 
     /// Apply the (checked) operator to self and other using SQL-style null semantics.
     ///
-    /// Both operands must share the same decimal type (precision and scale), and the result
-    /// keeps that type. Add and Sub are exact; Mul and Div are fixed-point at the shared scale,
-    /// truncating toward zero when digits beyond the scale are discarded.
+    /// Both operands must share the same decimal type `(p, s)`. The result type follows Arrow's
+    /// decimal arithmetic rules, so it is generally *wider* than the operands, and the result is
+    /// therefore an owned [`Scalar`] rather than a view:
     ///
-    /// If the operation overflows, exceeds the precision, or divides by zero, `None` is
-    /// returned.
+    /// | operator | result precision | result scale |
+    /// | -------- | ---------------- | ------------ |
+    /// | Add, Sub | `p + 1`          | `s`          |
+    /// | Mul      | `2p + 1`         | `2s`         |
+    /// | Div      | `p + s + 4`      | `s + 4`      |
+    ///
+    /// Precision saturates at the maximum decimal precision. Mul is exact — the doubled scale
+    /// leaves the raw product of the stored integers correctly scaled — while Div truncates
+    /// toward zero.
     ///
     /// If either value is null, the result is null.
+    ///
+    /// `Ok(None)` means the operation overflowed the result precision or divided by zero. Note
+    /// that the array kernels raise an error in that situation rather than yielding null.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the operands have different decimal types, or if the operation has no
+    /// valid result type: a Mul whose scale would exceed the maximum scale, or a Div whose
+    /// precision would fall outside the legal range.
     pub fn checked_binary_numeric(
         &self,
-        other: &DecimalScalar<'a>,
+        other: &DecimalScalar<'_>,
         op: NumericOperator,
-    ) -> Option<DecimalScalar<'a>> {
+    ) -> VortexResult<Option<Scalar>> {
         // We could have ops between different types but need to add rules for type inference.
         if self.decimal_type != other.decimal_type {
-            vortex_panic!(
+            vortex_bail!(
                 "decimal types must match: {} vs {}",
                 self.decimal_type,
                 other.decimal_type
             );
         }
 
-        // Use the more nullable dtype as the result type
-        let result_dtype = if self.dtype.is_nullable() {
-            self.dtype
-        } else {
-            other.dtype
+        let result_decimal_type = decimal_numeric_result_dtype(self.decimal_type, op)?;
+        let nullability = self.dtype.nullability() | other.dtype.nullability();
+        let result_dtype = DType::Decimal(result_decimal_type, nullability);
+
+        // Handle null cases using SQL semantics.
+        let (Some(lhs), Some(rhs)) = (self.decimal_value, other.decimal_value) else {
+            return Ok(Some(Scalar::null(result_dtype.as_nullable())));
         };
 
-        // Handle null cases using SQL semantics
-        let result_value = match (self.decimal_value, other.decimal_value) {
-            (None, _) | (_, None) => None,
-            (Some(lhs), Some(rhs)) => {
-                // Add/Sub on stored integers preserve the shared scale; Mul/Div must rescale.
-                let operation_result = match op {
-                    NumericOperator::Add => lhs.checked_add(&rhs),
-                    NumericOperator::Sub => lhs.checked_sub(&rhs),
-                    NumericOperator::Mul | NumericOperator::Div => {
-                        checked_fixed_point(lhs, rhs, self.decimal_type, op)
-                    }
-                }?;
-
-                Some(operation_result.normalize(self.decimal_type)?)
-            }
-        };
-
-        Some(DecimalScalar {
-            dtype: result_dtype,
-            decimal_type: self.decimal_type,
-            decimal_value: result_value,
-        })
+        Ok(
+            checked_decimal_numeric(lhs, rhs, self.decimal_type, result_decimal_type, op)
+                .map(|value| Scalar::decimal(value, result_decimal_type, nullability)),
+        )
     }
-}
-
-/// Execute fixed-point scalar arithmetic at the smallest width that can hold its intermediates.
-fn checked_fixed_point(
-    lhs: DecimalValue,
-    rhs: DecimalValue,
-    dtype: DecimalDType,
-    op: NumericOperator,
-) -> Option<DecimalValue> {
-    let work_precision = match op {
-        NumericOperator::Mul => dtype.precision().saturating_mul(2),
-        NumericOperator::Div => dtype
-            .precision()
-            .saturating_add(dtype.scale().unsigned_abs()),
-        NumericOperator::Add | NumericOperator::Sub => unreachable!("fixed-point Add/Sub"),
-    }
-    .min(MAX_PRECISION);
-    let work_dtype = DecimalDType::new(work_precision, 0);
-
-    match_each_decimal_value_type!(DecimalType::smallest_decimal_value_type(&work_dtype), |W| {
-        let lhs = lhs.cast::<W>()?;
-        let rhs = rhs.cast::<W>()?;
-        checked_fixed_point_at_width(lhs, rhs, dtype.scale(), op).map(DecimalValue::from)
-    })
-}
-
-fn checked_fixed_point_at_width<W>(lhs: W, rhs: W, scale: i8, op: NumericOperator) -> Option<W>
-where
-    W: NativeDecimalType + CheckedAdd + CheckedMul + CheckedDiv,
-{
-    let zero = W::default();
-    match op {
-        NumericOperator::Mul => {
-            let product = lhs.checked_mul(&rhs)?;
-            if scale == 0 || product == zero {
-                return Some(product);
-            }
-
-            let factor = decimal_scale_factor::<W>(scale.unsigned_abs() as u32)?;
-            if scale > 0 {
-                product.checked_div(&factor)
-            } else {
-                product.checked_mul(&factor)
-            }
-        }
-        NumericOperator::Div => {
-            if rhs == zero {
-                return None;
-            }
-            if scale == 0 {
-                return lhs.checked_div(&rhs);
-            }
-
-            if scale > 0 {
-                let factor = decimal_scale_factor::<W>(scale as u32)?;
-                lhs.checked_mul(&factor)?.checked_div(&rhs)
-            } else {
-                // trunc(trunc(lhs / rhs) / factor) equals trunc(lhs / (rhs * factor)), while
-                // avoiding an unnecessarily wide scaled divisor.
-                let quotient = lhs.checked_div(&rhs)?;
-                if quotient == zero {
-                    return Some(zero);
-                }
-                let Some(factor) = decimal_scale_factor::<W>(scale.unsigned_abs() as u32) else {
-                    return Some(zero);
-                };
-                quotient.checked_div(&factor)
-            }
-        }
-        NumericOperator::Add | NumericOperator::Sub => unreachable!("fixed-point Add/Sub"),
-    }
-}
-
-fn decimal_scale_factor<W>(exp: u32) -> Option<W>
-where
-    W: NativeDecimalType + CheckedAdd,
-{
-    let max = *W::MAX_BY_PRECISION.get(usize::try_from(exp).ok()?)?;
-    max.checked_add(&<W as BigCast>::from(1_i8)?)
 }
 
 impl PartialEq for DecimalScalar<'_> {

--- a/vortex-array/src/scalar/typed_view/decimal/scalar.rs
+++ b/vortex-array/src/scalar/typed_view/decimal/scalar.rs
@@ -6,16 +6,23 @@
 use std::cmp::Ordering;
 use std::fmt;
 
+use num_traits::CheckedAdd;
+use num_traits::CheckedDiv;
+use num_traits::CheckedMul;
 use num_traits::ToPrimitive as NumToPrimitive;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 
+use crate::dtype::BigCast;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
+use crate::dtype::MAX_PRECISION;
+use crate::dtype::NativeDecimalType;
 use crate::dtype::PType;
 use crate::match_each_decimal_value;
+use crate::match_each_decimal_value_type;
 use crate::scalar::DecimalValue;
 use crate::scalar::NumericOperator;
 use crate::scalar::Scalar;
@@ -179,14 +186,14 @@ impl<'a> DecimalScalar<'a> {
 
     /// Apply the (checked) operator to self and other using SQL-style null semantics.
     ///
-    /// If the operation overflows, None is returned.
+    /// Both operands must share the same decimal type (precision and scale), and the result
+    /// keeps that type. Add and Sub are exact; Mul and Div are fixed-point at the shared scale,
+    /// truncating toward zero when digits beyond the scale are discarded.
     ///
-    /// If the types are incompatible (ignoring nullability and precision/scale), an error is returned.
+    /// If the operation overflows, exceeds the precision, or divides by zero, `None` is
+    /// returned.
     ///
     /// If either value is null, the result is null.
-    ///
-    /// The result will have the same decimal type (precision/scale) as `self`, and the result
-    /// is checked to ensure it fits within the precision constraints.
     pub fn checked_binary_numeric(
         &self,
         other: &DecimalScalar<'a>,
@@ -212,21 +219,16 @@ impl<'a> DecimalScalar<'a> {
         let result_value = match (self.decimal_value, other.decimal_value) {
             (None, _) | (_, None) => None,
             (Some(lhs), Some(rhs)) => {
-                // Perform the operation
+                // Add/Sub on stored integers preserve the shared scale; Mul/Div must rescale.
                 let operation_result = match op {
                     NumericOperator::Add => lhs.checked_add(&rhs),
                     NumericOperator::Sub => lhs.checked_sub(&rhs),
-                    NumericOperator::Mul => lhs.checked_mul(&rhs),
-                    NumericOperator::Div => lhs.checked_div(&rhs),
+                    NumericOperator::Mul | NumericOperator::Div => {
+                        checked_fixed_point(lhs, rhs, self.decimal_type, op)
+                    }
                 }?;
 
-                // Check if the result fits within the precision constraints
-                if operation_result.fits_in_precision(self.decimal_type) {
-                    Some(operation_result)
-                } else {
-                    // Result exceeds precision, return None (overflow)
-                    return None;
-                }
+                Some(operation_result.normalize(self.decimal_type)?)
             }
         };
 
@@ -236,6 +238,85 @@ impl<'a> DecimalScalar<'a> {
             decimal_value: result_value,
         })
     }
+}
+
+/// Execute fixed-point scalar arithmetic at the smallest width that can hold its intermediates.
+fn checked_fixed_point(
+    lhs: DecimalValue,
+    rhs: DecimalValue,
+    dtype: DecimalDType,
+    op: NumericOperator,
+) -> Option<DecimalValue> {
+    let work_precision = match op {
+        NumericOperator::Mul => dtype.precision().saturating_mul(2),
+        NumericOperator::Div => dtype
+            .precision()
+            .saturating_add(dtype.scale().unsigned_abs()),
+        NumericOperator::Add | NumericOperator::Sub => unreachable!("fixed-point Add/Sub"),
+    }
+    .min(MAX_PRECISION);
+    let work_dtype = DecimalDType::new(work_precision, 0);
+
+    match_each_decimal_value_type!(DecimalType::smallest_decimal_value_type(&work_dtype), |W| {
+        let lhs = lhs.cast::<W>()?;
+        let rhs = rhs.cast::<W>()?;
+        checked_fixed_point_at_width(lhs, rhs, dtype.scale(), op).map(DecimalValue::from)
+    })
+}
+
+fn checked_fixed_point_at_width<W>(lhs: W, rhs: W, scale: i8, op: NumericOperator) -> Option<W>
+where
+    W: NativeDecimalType + CheckedAdd + CheckedMul + CheckedDiv,
+{
+    let zero = W::default();
+    match op {
+        NumericOperator::Mul => {
+            let product = lhs.checked_mul(&rhs)?;
+            if scale == 0 || product == zero {
+                return Some(product);
+            }
+
+            let factor = decimal_scale_factor::<W>(scale.unsigned_abs() as u32)?;
+            if scale > 0 {
+                product.checked_div(&factor)
+            } else {
+                product.checked_mul(&factor)
+            }
+        }
+        NumericOperator::Div => {
+            if rhs == zero {
+                return None;
+            }
+            if scale == 0 {
+                return lhs.checked_div(&rhs);
+            }
+
+            if scale > 0 {
+                let factor = decimal_scale_factor::<W>(scale as u32)?;
+                lhs.checked_mul(&factor)?.checked_div(&rhs)
+            } else {
+                // trunc(trunc(lhs / rhs) / factor) equals trunc(lhs / (rhs * factor)), while
+                // avoiding an unnecessarily wide scaled divisor.
+                let quotient = lhs.checked_div(&rhs)?;
+                if quotient == zero {
+                    return Some(zero);
+                }
+                let Some(factor) = decimal_scale_factor::<W>(scale.unsigned_abs() as u32) else {
+                    return Some(zero);
+                };
+                quotient.checked_div(&factor)
+            }
+        }
+        NumericOperator::Add | NumericOperator::Sub => unreachable!("fixed-point Add/Sub"),
+    }
+}
+
+fn decimal_scale_factor<W>(exp: u32) -> Option<W>
+where
+    W: NativeDecimalType + CheckedAdd,
+{
+    let max = *W::MAX_BY_PRECISION.get(usize::try_from(exp).ok()?)?;
+    max.checked_add(&<W as BigCast>::from(1_i8)?)
 }
 
 impl PartialEq for DecimalScalar<'_> {

--- a/vortex-array/src/scalar/typed_view/decimal/scalar.rs
+++ b/vortex-array/src/scalar/typed_view/decimal/scalar.rs
@@ -202,8 +202,9 @@ impl<'a> DecimalScalar<'a> {
     /// # Errors
     ///
     /// Returns an error if the operands have different decimal types, or if the operation has no
-    /// valid result type: a Mul whose scale would exceed the maximum scale, or a Div whose
-    /// precision would fall outside the legal range.
+    /// valid result type: a Mul whose doubled scale is unrepresentable — either above the maximum
+    /// scale or below the minimum an `i8` scale can hold — or a Div whose precision would fall
+    /// outside the legal range.
     pub fn checked_binary_numeric(
         &self,
         other: &DecimalScalar<'_>,

--- a/vortex-array/src/scalar/typed_view/decimal/tests.rs
+++ b/vortex-array/src/scalar/typed_view/decimal/tests.rs
@@ -900,6 +900,14 @@ fn checked_op(
     Some(DecimalDType::new(MAX_PRECISION, 4))
 )]
 #[case::mul_scale_exceeds_max(NumericOperator::Mul, DecimalDType::new(MAX_PRECISION, 39), None)]
+// -70 + -70 is -140, which is not representable as an i8 scale.
+#[case::mul_scale_underflows(NumericOperator::Mul, DecimalDType::new(10, -70), None)]
+// -64 + -64 is exactly i8::MIN, the most negative scale that is still representable.
+#[case::mul_scale_reaches_min(
+    NumericOperator::Mul,
+    DecimalDType::new(10, -64),
+    Some(DecimalDType::new(21, -128))
+)]
 #[case::div_precision_underflows(NumericOperator::Div, DecimalDType::new(2, -8), None)]
 fn test_decimal_numeric_result_dtype(
     #[case] op: NumericOperator,
@@ -1059,6 +1067,21 @@ fn test_decimal_scalar_null_handling() -> VortexResult<()> {
         &DType::Decimal(DecimalDType::new(11, 2), Nullability::Nullable)
     );
     Ok(())
+}
+
+#[test]
+fn test_decimal_scalar_mul_rejects_unrepresentable_scale() {
+    // 2e70 * 3e70 is 6e140, and a scale of -140 has no i8 representation. Saturating it to -128
+    // would have silently returned the raw product 6 as 6e128.
+    let dtype = DecimalDType::new(10, -70);
+    let lhs = Scalar::decimal(DecimalValue::I64(2), dtype, Nullability::NonNullable);
+    let rhs = Scalar::decimal(DecimalValue::I64(3), dtype, Nullability::NonNullable);
+
+    assert!(
+        lhs.as_decimal()
+            .checked_binary_numeric(&rhs.as_decimal(), NumericOperator::Mul)
+            .is_err()
+    );
 }
 
 #[test]

--- a/vortex-array/src/scalar/typed_view/decimal/tests.rs
+++ b/vortex-array/src/scalar/typed_view/decimal/tests.rs
@@ -907,9 +907,10 @@ fn test_decimal_scalar_checked_mul() {
     let result = scalar1
         .checked_binary_numeric(&scalar2, NumericOperator::Mul)
         .unwrap();
+    assert_eq!(result.decimal_value(), Some(DecimalValue::I64(5)));
     assert_eq!(
-        result.decimal_value(),
-        Some(DecimalValue::I256(i256::from_i128(500)))
+        result.decimal_value().map(|value| value.decimal_type()),
+        Some(DecimalType::I64)
     );
 }
 
@@ -934,9 +935,10 @@ fn test_decimal_scalar_checked_div() {
     let result = scalar1
         .checked_binary_numeric(&scalar2, NumericOperator::Div)
         .unwrap();
+    assert_eq!(result.decimal_value(), Some(DecimalValue::I64(10_000)));
     assert_eq!(
-        result.decimal_value(),
-        Some(DecimalValue::I256(i256::from_i128(100)))
+        result.decimal_value().map(|value| value.decimal_type()),
+        Some(DecimalType::I64)
     );
 }
 
@@ -960,6 +962,106 @@ fn test_decimal_scalar_checked_div_by_zero() {
 
     let result = scalar1.checked_binary_numeric(&scalar2, NumericOperator::Div);
     assert_eq!(result, None);
+}
+
+#[rstest]
+#[case::mul_truncates(15, 15, crate::scalar::NumericOperator::Mul, Some(2))]
+#[case::mul_truncates_toward_zero(-15, 15, crate::scalar::NumericOperator::Mul, Some(-2))]
+#[case::div_truncates(1_000, 300, crate::scalar::NumericOperator::Div, Some(333))]
+#[case::div_truncates_toward_zero(
+    -1_000,
+    300,
+    crate::scalar::NumericOperator::Div,
+    Some(-333)
+)]
+fn test_decimal_scalar_fixed_point(
+    #[case] lhs: i128,
+    #[case] rhs: i128,
+    #[case] op: crate::scalar::NumericOperator,
+    #[case] expected: Option<i64>,
+) {
+    let dtype = DecimalDType::new(10, 2);
+    let lhs = Scalar::decimal(DecimalValue::I128(lhs), dtype, Nullability::NonNullable);
+    let rhs = Scalar::decimal(DecimalValue::I128(rhs), dtype, Nullability::NonNullable);
+
+    let result = lhs
+        .as_decimal()
+        .checked_binary_numeric(&rhs.as_decimal(), op)
+        .and_then(|result| result.decimal_value());
+    assert_eq!(result, expected.map(DecimalValue::I64));
+    assert_eq!(
+        result.map(|value| value.decimal_type()),
+        expected.map(|_| DecimalType::I64)
+    );
+}
+
+#[rstest]
+#[case::mul(5, 3, crate::scalar::NumericOperator::Mul, Some(1_500))]
+#[case::div(600, 3, crate::scalar::NumericOperator::Div, Some(2))]
+#[case::div_truncates(5_000, 3, crate::scalar::NumericOperator::Div, Some(16))]
+fn test_decimal_scalar_fixed_point_negative_scale(
+    #[case] lhs: i128,
+    #[case] rhs: i128,
+    #[case] op: crate::scalar::NumericOperator,
+    #[case] expected: Option<i64>,
+) {
+    let dtype = DecimalDType::new(10, -2);
+    let lhs = Scalar::decimal(DecimalValue::I128(lhs), dtype, Nullability::NonNullable);
+    let rhs = Scalar::decimal(DecimalValue::I128(rhs), dtype, Nullability::NonNullable);
+
+    let result = lhs
+        .as_decimal()
+        .checked_binary_numeric(&rhs.as_decimal(), op)
+        .and_then(|result| result.decimal_value());
+    assert_eq!(result, expected.map(DecimalValue::I64));
+    assert_eq!(
+        result.map(|value| value.decimal_type()),
+        expected.map(|_| DecimalType::I64)
+    );
+}
+
+#[test]
+fn test_decimal_scalar_checked_mul_precision_overflow() {
+    let dtype = DecimalDType::new(3, 1);
+    let lhs = Scalar::decimal(DecimalValue::I16(999), dtype, Nullability::NonNullable);
+    let rhs = Scalar::decimal(DecimalValue::I16(999), dtype, Nullability::NonNullable);
+
+    let result = lhs
+        .as_decimal()
+        .checked_binary_numeric(&rhs.as_decimal(), crate::scalar::NumericOperator::Mul);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn test_decimal_scalar_checked_mul_wider_than_operand_storage() {
+    let dtype = DecimalDType::new(10, 2);
+    let lhs = Scalar::decimal(DecimalValue::I32(300_000), dtype, Nullability::NonNullable);
+
+    let result = lhs
+        .as_decimal()
+        .checked_binary_numeric(&lhs.as_decimal(), crate::scalar::NumericOperator::Mul)
+        .and_then(|result| result.decimal_value());
+    assert_eq!(result, Some(DecimalValue::I64(900_000_000)));
+    assert_eq!(
+        result.map(|value| value.decimal_type()),
+        Some(DecimalType::I64)
+    );
+}
+
+#[test]
+fn test_decimal_scalar_checked_mul_normalizes_i256_working_result() {
+    let dtype = DecimalDType::new(38, 2);
+    let lhs = Scalar::decimal(DecimalValue::I128(300_000), dtype, Nullability::NonNullable);
+
+    let result = lhs
+        .as_decimal()
+        .checked_binary_numeric(&lhs.as_decimal(), crate::scalar::NumericOperator::Mul)
+        .and_then(|result| result.decimal_value());
+    assert_eq!(result, Some(DecimalValue::I128(900_000_000)));
+    assert_eq!(
+        result.map(|value| value.decimal_type()),
+        Some(DecimalType::I128)
+    );
 }
 
 #[test]

--- a/vortex-array/src/scalar/typed_view/decimal/tests.rs
+++ b/vortex-array/src/scalar/typed_view/decimal/tests.rs
@@ -4,17 +4,22 @@
 //! Tests for decimal scalar casting functionality.
 
 use rstest::rstest;
+use vortex_error::VortexResult;
+use vortex_error::vortex_err;
 use vortex_utils::aliases::hash_set::HashSet;
 
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
 use crate::dtype::DecimalType;
+use crate::dtype::MAX_PRECISION;
 use crate::dtype::NativeDecimalType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::dtype::i256;
 use crate::scalar::DecimalValue;
+use crate::scalar::NumericOperator;
 use crate::scalar::Scalar;
+use crate::scalar::decimal_numeric_result_dtype;
 
 #[rstest]
 #[case(DecimalValue::I8(100), DecimalValue::I8(100))]
@@ -832,283 +837,248 @@ fn test_decimal_i256_overflow_cast() {
 }
 
 // Tests for checked_binary_numeric
-#[test]
-fn test_decimal_scalar_checked_add() {
-    use crate::scalar::NumericOperator;
 
-    let decimal1 = Scalar::decimal(
-        DecimalValue::I64(100),
-        DecimalDType::new(10, 2),
-        Nullability::NonNullable,
-    );
-    let scalar1 = decimal1.as_decimal();
-
-    let decimal2 = Scalar::decimal(
-        DecimalValue::I64(200),
-        DecimalDType::new(10, 2),
-        Nullability::NonNullable,
-    );
-    let scalar2 = decimal2.as_decimal();
-
-    let result = scalar1
-        .checked_binary_numeric(&scalar2, NumericOperator::Add)
-        .unwrap();
-    assert_eq!(
-        result.decimal_value(),
-        Some(DecimalValue::I256(i256::from_i128(300)))
-    );
-}
-
-#[test]
-fn test_decimal_scalar_checked_sub() {
-    use crate::scalar::NumericOperator;
-
-    let decimal1 = Scalar::decimal(
-        DecimalValue::I64(500),
-        DecimalDType::new(10, 2),
-        Nullability::NonNullable,
-    );
-    let scalar1 = decimal1.as_decimal();
-
-    let decimal2 = Scalar::decimal(
-        DecimalValue::I64(200),
-        DecimalDType::new(10, 2),
-        Nullability::NonNullable,
-    );
-    let scalar2 = decimal2.as_decimal();
-
-    let result = scalar1
-        .checked_binary_numeric(&scalar2, NumericOperator::Sub)
-        .unwrap();
-    assert_eq!(
-        result.decimal_value(),
-        Some(DecimalValue::I256(i256::from_i128(300)))
-    );
-}
-
-#[test]
-fn test_decimal_scalar_checked_mul() {
-    use crate::scalar::NumericOperator;
-
-    let decimal1 = Scalar::decimal(
-        DecimalValue::I32(50),
-        DecimalDType::new(10, 2),
-        Nullability::NonNullable,
-    );
-    let scalar1 = decimal1.as_decimal();
-
-    let decimal2 = Scalar::decimal(
-        DecimalValue::I32(10),
-        DecimalDType::new(10, 2),
-        Nullability::NonNullable,
-    );
-    let scalar2 = decimal2.as_decimal();
-
-    let result = scalar1
-        .checked_binary_numeric(&scalar2, NumericOperator::Mul)
-        .unwrap();
-    assert_eq!(result.decimal_value(), Some(DecimalValue::I64(5)));
-    assert_eq!(
-        result.decimal_value().map(|value| value.decimal_type()),
-        Some(DecimalType::I64)
-    );
-}
-
-#[test]
-fn test_decimal_scalar_checked_div() {
-    use crate::scalar::NumericOperator;
-
-    let decimal1 = Scalar::decimal(
-        DecimalValue::I64(1000),
-        DecimalDType::new(10, 2),
-        Nullability::NonNullable,
-    );
-    let scalar1 = decimal1.as_decimal();
-
-    let decimal2 = Scalar::decimal(
-        DecimalValue::I64(10),
-        DecimalDType::new(10, 2),
-        Nullability::NonNullable,
-    );
-    let scalar2 = decimal2.as_decimal();
-
-    let result = scalar1
-        .checked_binary_numeric(&scalar2, NumericOperator::Div)
-        .unwrap();
-    assert_eq!(result.decimal_value(), Some(DecimalValue::I64(10_000)));
-    assert_eq!(
-        result.decimal_value().map(|value| value.decimal_type()),
-        Some(DecimalType::I64)
-    );
-}
-
-#[test]
-fn test_decimal_scalar_checked_div_by_zero() {
-    use crate::scalar::NumericOperator;
-
-    let decimal1 = Scalar::decimal(
-        DecimalValue::I64(1000),
-        DecimalDType::new(10, 2),
-        Nullability::NonNullable,
-    );
-    let scalar1 = decimal1.as_decimal();
-
-    let decimal2 = Scalar::decimal(
-        DecimalValue::I64(0),
-        DecimalDType::new(10, 2),
-        Nullability::NonNullable,
-    );
-    let scalar2 = decimal2.as_decimal();
-
-    let result = scalar1.checked_binary_numeric(&scalar2, NumericOperator::Div);
-    assert_eq!(result, None);
+/// Applies `op` to two non-null operands of `dtype`, returning the result value and its dtype.
+fn checked_op(
+    lhs: DecimalValue,
+    rhs: DecimalValue,
+    dtype: DecimalDType,
+    op: NumericOperator,
+) -> VortexResult<Option<(DecimalValue, DecimalDType)>> {
+    let lhs = Scalar::decimal(lhs, dtype, Nullability::NonNullable);
+    let rhs = Scalar::decimal(rhs, dtype, Nullability::NonNullable);
+    let Some(result) = lhs
+        .as_decimal()
+        .checked_binary_numeric(&rhs.as_decimal(), op)?
+    else {
+        return Ok(None);
+    };
+    let result = result.as_decimal();
+    let result_dtype = DecimalDType::try_from(result.dtype())?;
+    Ok(result.decimal_value().map(|value| (value, result_dtype)))
 }
 
 #[rstest]
-#[case::mul_truncates(15, 15, crate::scalar::NumericOperator::Mul, Some(2))]
-#[case::mul_truncates_toward_zero(-15, 15, crate::scalar::NumericOperator::Mul, Some(-2))]
-#[case::div_truncates(1_000, 300, crate::scalar::NumericOperator::Div, Some(333))]
+#[case::add(
+    NumericOperator::Add,
+    DecimalDType::new(10, 2),
+    Some(DecimalDType::new(11, 2))
+)]
+#[case::sub(
+    NumericOperator::Sub,
+    DecimalDType::new(10, 2),
+    Some(DecimalDType::new(11, 2))
+)]
+#[case::mul(
+    NumericOperator::Mul,
+    DecimalDType::new(10, 2),
+    Some(DecimalDType::new(21, 4))
+)]
+#[case::div(
+    NumericOperator::Div,
+    DecimalDType::new(10, 2),
+    Some(DecimalDType::new(16, 6))
+)]
+#[case::mul_negative_scale(
+    NumericOperator::Mul,
+    DecimalDType::new(10, -2),
+    Some(DecimalDType::new(21, -4))
+)]
+#[case::div_negative_scale(
+    NumericOperator::Div,
+    DecimalDType::new(10, -2),
+    Some(DecimalDType::new(12, 2))
+)]
+#[case::add_saturates_precision(
+    NumericOperator::Add,
+    DecimalDType::new(MAX_PRECISION, 2),
+    Some(DecimalDType::new(MAX_PRECISION, 2))
+)]
+#[case::mul_saturates_precision(
+    NumericOperator::Mul,
+    DecimalDType::new(40, 2),
+    Some(DecimalDType::new(MAX_PRECISION, 4))
+)]
+#[case::mul_scale_exceeds_max(NumericOperator::Mul, DecimalDType::new(MAX_PRECISION, 39), None)]
+#[case::div_precision_underflows(NumericOperator::Div, DecimalDType::new(2, -8), None)]
+fn test_decimal_numeric_result_dtype(
+    #[case] op: NumericOperator,
+    #[case] input: DecimalDType,
+    #[case] expected: Option<DecimalDType>,
+) {
+    assert_eq!(decimal_numeric_result_dtype(input, op).ok(), expected);
+}
+
+#[rstest]
+#[case::add(DecimalDType::new(10, 2), 100, 200, NumericOperator::Add, Some(300))]
+#[case::sub(DecimalDType::new(10, 2), 500, 200, NumericOperator::Sub, Some(300))]
+// 0.50 * 0.10 = 0.0500, exact at the doubled result scale.
+#[case::mul(DecimalDType::new(10, 2), 50, 10, NumericOperator::Mul, Some(500))]
+// 0.15 * 0.17 = 0.0255, which a result pinned to scale 2 would have had to round away.
+#[case::mul_keeps_every_digit(DecimalDType::new(10, 2), 15, 17, NumericOperator::Mul, Some(255))]
+// 10.00 / 0.10 = 100.000000
+#[case::div(
+    DecimalDType::new(10, 2),
+    1_000,
+    10,
+    NumericOperator::Div,
+    Some(100_000_000)
+)]
+// 10.00 / 3.00 = 3.333333, truncated toward zero at the result scale.
+#[case::div_truncates(
+    DecimalDType::new(10, 2),
+    1_000,
+    300,
+    NumericOperator::Div,
+    Some(3_333_333)
+)]
 #[case::div_truncates_toward_zero(
+    DecimalDType::new(10, 2),
     -1_000,
     300,
-    crate::scalar::NumericOperator::Div,
-    Some(-333)
+    NumericOperator::Div,
+    Some(-3_333_333)
 )]
-fn test_decimal_scalar_fixed_point(
+#[case::div_by_zero(DecimalDType::new(10, 2), 1_000, 0, NumericOperator::Div, None)]
+// 500 * 300 = 150000, stored at scale -4.
+#[case::mul_negative_scale(DecimalDType::new(10, -2), 5, 3, NumericOperator::Mul, Some(15))]
+// 60000 / 300 = 200.00
+#[case::div_negative_scale(DecimalDType::new(10, -2), 600, 3, NumericOperator::Div, Some(20_000))]
+// 5e12 / 2e8 = 25000, truncated to the result scale of -4.
+#[case::div_negative_result_scale(
+    DecimalDType::new(10, -8),
+    50_000,
+    2,
+    NumericOperator::Div,
+    Some(2)
+)]
+fn test_decimal_scalar_checked_binary_numeric(
+    #[case] dtype: DecimalDType,
     #[case] lhs: i128,
     #[case] rhs: i128,
-    #[case] op: crate::scalar::NumericOperator,
-    #[case] expected: Option<i64>,
-) {
-    let dtype = DecimalDType::new(10, 2);
-    let lhs = Scalar::decimal(DecimalValue::I128(lhs), dtype, Nullability::NonNullable);
-    let rhs = Scalar::decimal(DecimalValue::I128(rhs), dtype, Nullability::NonNullable);
-
-    let result = lhs
-        .as_decimal()
-        .checked_binary_numeric(&rhs.as_decimal(), op)
-        .and_then(|result| result.decimal_value());
-    assert_eq!(result, expected.map(DecimalValue::I64));
+    #[case] op: NumericOperator,
+    #[case] expected: Option<i128>,
+) -> VortexResult<()> {
+    let result = checked_op(DecimalValue::I128(lhs), DecimalValue::I128(rhs), dtype, op)?;
     assert_eq!(
-        result.map(|value| value.decimal_type()),
-        expected.map(|_| DecimalType::I64)
+        result.map(|(value, _)| value),
+        expected.map(DecimalValue::I128)
     );
+    Ok(())
+}
+
+#[test]
+fn test_decimal_scalar_mul_widens_beyond_operand_storage() -> VortexResult<()> {
+    // 1e17 * 1e17 needs 35 digits, so widening only to the operands' i64 storage would report a
+    // spurious overflow.
+    let dtype = DecimalDType::new(18, 0);
+    let operand = DecimalValue::I64(100_000_000_000_000_000);
+
+    let (value, result_dtype) = checked_op(operand, operand, dtype, NumericOperator::Mul)?
+        .ok_or_else(|| vortex_err!("expected an in-precision product"))?;
+    assert_eq!(result_dtype, DecimalDType::new(37, 0));
+    assert_eq!(
+        value,
+        DecimalValue::I128(10_000_000_000_000_000_000_000_000_000_000_000)
+    );
+    assert_eq!(value.decimal_type(), DecimalType::I128);
+    Ok(())
+}
+
+#[test]
+fn test_decimal_scalar_add_reserves_carry_digit() -> VortexResult<()> {
+    // 999 + 2 = 1001 exceeds precision 3, but the result reserves a carry digit for it.
+    let dtype = DecimalDType::new(3, 0);
+
+    let (value, result_dtype) = checked_op(
+        DecimalValue::I16(999),
+        DecimalValue::I16(2),
+        dtype,
+        NumericOperator::Add,
+    )?
+    .ok_or_else(|| vortex_err!("expected the carry digit to absorb the result"))?;
+    assert_eq!(result_dtype, DecimalDType::new(4, 0));
+    assert_eq!(value, DecimalValue::I16(1_001));
+    assert_eq!(value.decimal_type(), DecimalType::I16);
+    Ok(())
 }
 
 #[rstest]
-#[case::mul(5, 3, crate::scalar::NumericOperator::Mul, Some(1_500))]
-#[case::div(600, 3, crate::scalar::NumericOperator::Div, Some(2))]
-#[case::div_truncates(5_000, 3, crate::scalar::NumericOperator::Div, Some(16))]
-fn test_decimal_scalar_fixed_point_negative_scale(
-    #[case] lhs: i128,
-    #[case] rhs: i128,
-    #[case] op: crate::scalar::NumericOperator,
-    #[case] expected: Option<i64>,
-) {
-    let dtype = DecimalDType::new(10, -2);
-    let lhs = Scalar::decimal(DecimalValue::I128(lhs), dtype, Nullability::NonNullable);
-    let rhs = Scalar::decimal(DecimalValue::I128(rhs), dtype, Nullability::NonNullable);
-
-    let result = lhs
-        .as_decimal()
-        .checked_binary_numeric(&rhs.as_decimal(), op)
-        .and_then(|result| result.decimal_value());
-    assert_eq!(result, expected.map(DecimalValue::I64));
-    assert_eq!(
-        result.map(|value| value.decimal_type()),
-        expected.map(|_| DecimalType::I64)
+#[case::add(NumericOperator::Add)]
+#[case::mul(NumericOperator::Mul)]
+fn test_decimal_scalar_overflows_saturated_precision(
+    #[case] op: NumericOperator,
+) -> VortexResult<()> {
+    // At MAX_PRECISION the result precision cannot widen any further, so an out-of-range result
+    // is a genuine overflow.
+    let dtype = DecimalDType::new(MAX_PRECISION, 0);
+    let max = DecimalValue::I256(
+        <i256 as NativeDecimalType>::MAX_BY_PRECISION[usize::from(MAX_PRECISION)],
     );
+
+    assert_eq!(checked_op(max, max, dtype, op)?, None);
+    Ok(())
 }
 
 #[test]
-fn test_decimal_scalar_checked_mul_precision_overflow() {
-    let dtype = DecimalDType::new(3, 1);
-    let lhs = Scalar::decimal(DecimalValue::I16(999), dtype, Nullability::NonNullable);
-    let rhs = Scalar::decimal(DecimalValue::I16(999), dtype, Nullability::NonNullable);
+fn test_decimal_scalar_div_reports_unrepresentable_intermediate() -> VortexResult<()> {
+    // Div scales the dividend by 10^result_scale, which needs p + result_scale digits. Past
+    // MAX_PRECISION there is no wider width to compute in, so 1e79 overflows i256 and the
+    // operation reports overflow even though the quotient 1e9 would have fit the result
+    // precision. The array kernels size their working width identically.
+    let dtype = DecimalDType::new(MAX_PRECISION, 0);
+    let pow10 = |exp: u32| {
+        i256::from_i128(10)
+            .checked_pow(exp)
+            .ok_or_else(|| vortex_err!("10^{exp} is representable as i256"))
+    };
+    let lhs = DecimalValue::I256(pow10(75)?);
+    let rhs = DecimalValue::I256(pow10(70)?);
 
-    let result = lhs
-        .as_decimal()
-        .checked_binary_numeric(&rhs.as_decimal(), crate::scalar::NumericOperator::Mul);
-    assert_eq!(result, None);
+    assert_eq!(
+        decimal_numeric_result_dtype(dtype, NumericOperator::Div)?,
+        DecimalDType::new(MAX_PRECISION, 4)
+    );
+    assert_eq!(checked_op(lhs, rhs, dtype, NumericOperator::Div)?, None);
+    Ok(())
 }
 
 #[test]
-fn test_decimal_scalar_checked_mul_wider_than_operand_storage() {
+fn test_decimal_scalar_null_handling() -> VortexResult<()> {
     let dtype = DecimalDType::new(10, 2);
-    let lhs = Scalar::decimal(DecimalValue::I32(300_000), dtype, Nullability::NonNullable);
+    let null = Scalar::null(DType::Decimal(dtype, Nullability::Nullable));
+    let value = Scalar::decimal(DecimalValue::I64(200), dtype, Nullability::NonNullable);
 
-    let result = lhs
+    let result = null
         .as_decimal()
-        .checked_binary_numeric(&lhs.as_decimal(), crate::scalar::NumericOperator::Mul)
-        .and_then(|result| result.decimal_value());
-    assert_eq!(result, Some(DecimalValue::I64(900_000_000)));
+        .checked_binary_numeric(&value.as_decimal(), NumericOperator::Add)?
+        .ok_or_else(|| vortex_err!("a null operand yields a null result, not an overflow"))?;
+    assert!(result.is_null());
     assert_eq!(
-        result.map(|value| value.decimal_type()),
-        Some(DecimalType::I64)
+        result.dtype(),
+        &DType::Decimal(DecimalDType::new(11, 2), Nullability::Nullable)
     );
+    Ok(())
 }
 
 #[test]
-fn test_decimal_scalar_checked_mul_normalizes_i256_working_result() {
-    let dtype = DecimalDType::new(38, 2);
-    let lhs = Scalar::decimal(DecimalValue::I128(300_000), dtype, Nullability::NonNullable);
-
-    let result = lhs
-        .as_decimal()
-        .checked_binary_numeric(&lhs.as_decimal(), crate::scalar::NumericOperator::Mul)
-        .and_then(|result| result.decimal_value());
-    assert_eq!(result, Some(DecimalValue::I128(900_000_000)));
-    assert_eq!(
-        result.map(|value| value.decimal_type()),
-        Some(DecimalType::I128)
-    );
-}
-
-#[test]
-fn test_decimal_scalar_null_handling() {
-    use crate::scalar::NumericOperator;
-
-    let decimal1 = Scalar::null(DType::Decimal(
-        DecimalDType::new(10, 2),
-        Nullability::Nullable,
-    ));
-    let scalar1 = decimal1.as_decimal();
-
-    let decimal2 = Scalar::decimal(
-        DecimalValue::I64(200),
+fn test_decimal_scalar_mismatched_decimal_types() {
+    let lhs = Scalar::decimal(
+        DecimalValue::I64(1),
         DecimalDType::new(10, 2),
         Nullability::NonNullable,
     );
-    let scalar2 = decimal2.as_decimal();
-
-    let result = scalar1
-        .checked_binary_numeric(&scalar2, NumericOperator::Add)
-        .unwrap();
-    assert_eq!(result.decimal_value(), None);
-}
-
-#[test]
-fn test_decimal_scalar_precision_overflow() {
-    use crate::scalar::NumericOperator;
-
-    // Create decimals with precision 3 (max value 999)
-    let decimal1 = Scalar::decimal(
-        DecimalValue::I16(999),
-        DecimalDType::new(3, 0),
+    let rhs = Scalar::decimal(
+        DecimalValue::I64(1),
+        DecimalDType::new(10, 3),
         Nullability::NonNullable,
     );
-    let scalar1 = decimal1.as_decimal();
 
-    let decimal2 = Scalar::decimal(
-        DecimalValue::I16(2),
-        DecimalDType::new(3, 0),
-        Nullability::NonNullable,
+    assert!(
+        lhs.as_decimal()
+            .checked_binary_numeric(&rhs.as_decimal(), NumericOperator::Add)
+            .is_err()
     );
-    let scalar2 = decimal2.as_decimal();
-
-    // 999 + 2 = 1001 which exceeds precision 3
-    let result = scalar1.checked_binary_numeric(&scalar2, NumericOperator::Add);
-    assert_eq!(result, None);
 }
 
 #[test]

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
@@ -33,12 +33,12 @@ use crate::arrays::decimal::DecimalArrayExt;
 use crate::dtype::BigCast;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
-use crate::dtype::MAX_PRECISION;
 use crate::dtype::NativeDecimalType;
 use crate::match_each_decimal_value_type;
 use crate::scalar::DecimalValue;
 use crate::scalar::NumericOperator;
 use crate::scalar::Scalar;
+use crate::scalar::decimal_numeric_result_dtype;
 use crate::validity::Validity;
 
 /// Derive the result decimal dtype for a numeric operation over same-typed operands.
@@ -47,14 +47,7 @@ pub(crate) fn result_decimal_dtype(
     op: NumericOperator,
 ) -> VortexResult<DecimalDType> {
     match op {
-        NumericOperator::Add | NumericOperator::Sub => {
-            // A p-digit Add/Sub result needs at most one carry digit:
-            // 2 * (10^p - 1) < 10^(p + 1). Follows Arrow rules.
-            Ok(DecimalDType::new(
-                input.precision().saturating_add(1).min(MAX_PRECISION),
-                input.scale(),
-            ))
-        }
+        NumericOperator::Add | NumericOperator::Sub => decimal_numeric_result_dtype(input, op),
         NumericOperator::Mul | NumericOperator::Div => {
             vortex_bail!("numeric operator {op} is not yet supported for decimal arrays")
         }

--- a/vortex-array/src/stats/stats_set.rs
+++ b/vortex-array/src/stats/stats_set.rs
@@ -443,30 +443,33 @@ impl MutTypedStatsSetRef<'_, '_> {
             other.get_scalar_bound::<Sum>(),
         ) {
             (Some(m1), Some(m2)) => {
-                // If the combine sum is exact, then we can sum them.
-                if let Some(scalar_value) =
-                    m1.zip(m2).as_exact().and_then(|(s1, s2)| match s1.dtype() {
-                        DType::Primitive(..) => s1
-                            .as_primitive()
-                            .checked_add(&s2.as_primitive())
-                            .and_then(|pscalar| pscalar.pvalue().map(ScalarValue::Primitive)),
-                        // Add widens the result precision, so the merged sum is only exact as a
-                        // stat if it still fits the summands' own decimal type.
-                        DType::Decimal(decimal_dtype, _) => s1
-                            .as_decimal()
-                            .checked_binary_numeric(
-                                &s2.as_decimal(),
-                                crate::scalar::NumericOperator::Add,
-                            )
-                            .ok()
-                            .flatten()
-                            .and_then(|scalar| scalar.as_decimal().decimal_value())
-                            .filter(|value| value.fits_in_precision(*decimal_dtype))
-                            .map(ScalarValue::Decimal),
-                        _ => None,
-                    })
-                {
-                    self.set(Stat::Sum, Precision::Exact(scalar_value));
+                // If the combined sum is exact, then we can sum them.
+                let merged = m1.zip(m2).as_exact().and_then(|(s1, s2)| match s1.dtype() {
+                    DType::Primitive(..) => s1
+                        .as_primitive()
+                        .checked_add(&s2.as_primitive())
+                        .and_then(|pscalar| pscalar.pvalue().map(ScalarValue::Primitive)),
+                    // Add widens the result precision, so the merged sum is only exact as a
+                    // stat if it still fits the summands' own decimal type.
+                    DType::Decimal(decimal_dtype, _) => s1
+                        .as_decimal()
+                        .checked_binary_numeric(
+                            &s2.as_decimal(),
+                            crate::scalar::NumericOperator::Add,
+                        )
+                        .ok()
+                        .flatten()
+                        .and_then(|scalar| scalar.as_decimal().decimal_value())
+                        .filter(|value| value.fits_in_precision(*decimal_dtype))
+                        .map(ScalarValue::Decimal),
+                    _ => None,
+                });
+
+                match merged {
+                    Some(scalar_value) => self.set(Stat::Sum, Precision::Exact(scalar_value)),
+                    // An overflow, an inexact bound or a non-numeric dtype leaves the combined
+                    // sum unknown. Keeping this set's own sum would report a partial total.
+                    None => self.clear(Stat::Sum),
                 }
             }
             _ => self.clear(Stat::Sum),
@@ -565,13 +568,19 @@ mod test {
     use crate::array_session;
     use crate::arrays::PrimitiveArray;
     use crate::dtype::DType;
+    use crate::dtype::DecimalDType;
+    use crate::dtype::MAX_PRECISION;
+    use crate::dtype::NativeDecimalType;
     use crate::dtype::Nullability;
     use crate::dtype::PType;
+    use crate::dtype::i256;
     use crate::expr::stats::IsConstant;
     use crate::expr::stats::Precision;
     use crate::expr::stats::Stat;
     use crate::expr::stats::StatsProvider;
     use crate::expr::stats::StatsProviderExt;
+    use crate::scalar::DecimalValue;
+    use crate::scalar::ScalarValue;
     use crate::stats::StatsSet;
     use crate::stats::stats_set::Scalar;
 
@@ -629,6 +638,32 @@ mod test {
             ),
             Precision::exact(42)
         );
+    }
+
+    #[test]
+    fn merge_sums_overflow_clears() {
+        // A sum that cannot be combined exactly leaves the merged set with no Sum at all;
+        // retaining this set's own sum would report a partial total as the combined one.
+        let dtype = DType::Primitive(PType::I64, Nullability::NonNullable);
+        let merged = StatsSet::of(Stat::Sum, Precision::exact(i64::MAX))
+            .merge_ordered(&StatsSet::of(Stat::Sum, Precision::exact(i64::MAX)), &dtype);
+
+        assert!(merged.get(Stat::Sum).is_absent());
+    }
+
+    #[test]
+    fn merge_decimal_sums_out_of_precision_clears() {
+        // A decimal(70, 0) array's Sum stat is itself decimal(76, 0): `sum_decimal_dtype` adds
+        // ten digits of headroom but saturates at MAX_PRECISION, so at this input precision there
+        // is none left and two maximal sums cannot be combined exactly.
+        let dtype = DType::Decimal(DecimalDType::new(70, 0), Nullability::NonNullable);
+        let max = ScalarValue::Decimal(DecimalValue::I256(
+            <i256 as NativeDecimalType>::MAX_BY_PRECISION[usize::from(MAX_PRECISION)],
+        ));
+        let merged = StatsSet::of(Stat::Sum, Precision::exact(max.clone()))
+            .merge_ordered(&StatsSet::of(Stat::Sum, Precision::exact(max)), &dtype);
+
+        assert!(merged.get(Stat::Sum).is_absent());
     }
 
     #[test]

--- a/vortex-array/src/stats/stats_set.rs
+++ b/vortex-array/src/stats/stats_set.rs
@@ -450,19 +450,19 @@ impl MutTypedStatsSetRef<'_, '_> {
                             .as_primitive()
                             .checked_add(&s2.as_primitive())
                             .and_then(|pscalar| pscalar.pvalue().map(ScalarValue::Primitive)),
-                        DType::Decimal(..) => s1
+                        // Add widens the result precision, so the merged sum is only exact as a
+                        // stat if it still fits the summands' own decimal type.
+                        DType::Decimal(decimal_dtype, _) => s1
                             .as_decimal()
                             .checked_binary_numeric(
                                 &s2.as_decimal(),
                                 crate::scalar::NumericOperator::Add,
                             )
-                            .map(|scalar| {
-                                ScalarValue::Decimal(
-                                    scalar
-                                        .decimal_value()
-                                        .vortex_expect("no decimal value in scalar"),
-                                )
-                            }),
+                            .ok()
+                            .flatten()
+                            .and_then(|scalar| scalar.as_decimal().decimal_value())
+                            .filter(|value| value.fits_in_precision(*decimal_dtype))
+                            .map(ScalarValue::Decimal),
                         _ => None,
                     })
                 {


### PR DESCRIPTION
Decimal scalar `Mul` and `Div` produced values at the wrong scale. They applied the operator to the raw stored integers and kept the operands' dtype, so at `decimal(10, 2)` `0.50 * 0.10` came back as `5.00` and `10.00 / 0.10` as `1.00`. `3000.00 * 3000.00` reported a false overflow even though `9000000.00` fits precision 10.

`DecimalScalar::checked_binary_numeric` now follows Arrow's decimal arithmetic rules, which are already used by Decimal Add/Sub array kernels from #8724. Vortex coerces both operands to a single dtype, so Arrow's general `(p1, s1) op (p2, s2)` formulas collapse to:

| operator | result precision | result scale |
| --- | --- | --- |
| Add, Sub | `p + 1` | `s` |
| Mul | `2p + 1` | `2s` |
| Div | `p + s + 4` | `s + 4` |

Precision saturates at `MAX_PRECISION`. Mul is exact — the doubled scale leaves the raw product correctly scaled, so there is no rounding decision to make — while Div scales the dividend by `10^result_scale` and truncates toward zero.

Because the result widens, the operation can no longer return a `DecimalScalar<'a>`: that borrows its `&'a DType` from an operand and has nowhere to put a wider type. It now returns `VortexResult<Option<Scalar>>`, where `Ok(None)` is overflow or division by zero. Mismatched operand dtypes became an error rather than a panic.

Add's result now carries `p + 1`, so `stats_set::merge_sum` and the sum test helper restate the merged sum in the summands' own decimal type and treat a value that no longer fits as overflow, preserving current behavior. That also removes a latent panic in `merge_sum` when a merged sum is null.

Div is the one operator whose intermediate can outgrow the widest native width: scaling the dividend by `10^result_scale` overflows `i256` once `p + result_scale` passes `MAX_PRECISION`, even for a quotient that would have fit the result precision. That is reported as an overflow and pinned by a test. The array kernels size their working width the same way, so both paths agree on which operations are representable.
