### PR TITLE
`inline(always)` on `push`

### DIFF
--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -353,7 +353,7 @@ impl<T> BufferMut<T> {
     }
 
     /// Appends a scalar to the buffer.
-    #[inline]
+    #[inline(always)]
     pub fn push(&mut self, value: T) {
         self.reserve(1);
         unsafe { self.push_unchecked(value) }


### PR DESCRIPTION
got a -10% regression after https://github.com/vortex-data/vortex/pull/8875