### PR TITLE
FFI: get scalars from arrays

### DIFF
--- a/lang/cpp/include/vortex/array.hpp
+++ b/lang/cpp/include/vortex/array.hpp
@@ -6,6 +6,7 @@
 #include "vortex/dtype.hpp"
 #include "vortex/error.hpp"
 #include "vortex/expression.hpp"
+#include "vortex/scalar.hpp"
 #include "vortex/session.hpp"
 
 #include <vortex.h>
@@ -210,6 +211,8 @@ public:
 
     // Bulk view over Binary values.
     BytesView bytes(const Session &session) const;
+
+    Scalar scalar_at(const Session &session, size_t index) const;
 
 private:
     friend struct detail::Access;

--- a/lang/cpp/include/vortex/scalar.hpp
+++ b/lang/cpp/include/vortex/scalar.hpp
@@ -26,6 +26,27 @@ public:
     bool is_null() const;
     DataType dtype() const;
 
+    /**
+     * Read scalar's value.
+     *
+     * Supported types are bool, primitives, std::string_view, and BinaryView.
+     *
+     * std::string_view and BinaryView returned borrow from scalar and stay
+     * valid while scalar is valid.
+     *
+     * Throws if scalar type does not match T or value is Null.
+     */
+    template <element_type T>
+    T get() const;
+
+    /**
+     * Read a decimal scalar's unscaled value.
+     * int8/16/32/64_t are supported.
+     * Throws if scalar is not a decimal, is Null, or value does not fit in T.
+     */
+    template <primitive_type T>
+    T get_decimal() const;
+
 private:
     friend struct detail::Access;
     explicit Scalar(vx_scalar *owned) : handle_(owned) {
@@ -39,6 +60,58 @@ private:
     };
     std::unique_ptr<vx_scalar, Deleter> handle_;
 };
+
+template <element_type T>
+T Scalar::get() const {
+    vx_scalar *h = handle_.get();
+    if constexpr (std::is_same_v<T, bool>) {
+        return vx_scalar_get_bool(h);
+    } else if constexpr (std::is_same_v<T, std::string_view>) {
+        vx_view v = vx_scalar_get_utf8(h);
+        return std::string_view(v.ptr, v.len);
+    } else if constexpr (std::is_same_v<T, BinaryView>) {
+        vx_view v = vx_scalar_get_binary(h);
+        return BinaryView(reinterpret_cast<const std::byte *>(v.ptr), v.len);
+    } else if constexpr (std::is_same_v<T, uint8_t>) {
+        return vx_scalar_get_u8(h);
+    } else if constexpr (std::is_same_v<T, uint16_t>) {
+        return vx_scalar_get_u16(h);
+    } else if constexpr (std::is_same_v<T, uint32_t>) {
+        return vx_scalar_get_u32(h);
+    } else if constexpr (std::is_same_v<T, uint64_t>) {
+        return vx_scalar_get_u64(h);
+    } else if constexpr (std::is_same_v<T, int8_t>) {
+        return vx_scalar_get_i8(h);
+    } else if constexpr (std::is_same_v<T, int16_t>) {
+        return vx_scalar_get_i16(h);
+    } else if constexpr (std::is_same_v<T, int32_t>) {
+        return vx_scalar_get_i32(h);
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+        return vx_scalar_get_i64(h);
+    } else if constexpr (std::is_same_v<T, float>) {
+        return vx_scalar_get_f32(h);
+    } else if constexpr (std::is_same_v<T, double>) {
+        return vx_scalar_get_f64(h);
+    } else {
+        static_assert(false, "f16 scalar get is not supported");
+    }
+}
+
+template <primitive_type T>
+T Scalar::get_decimal() const {
+    vx_scalar *h = handle_.get();
+    if constexpr (std::is_same_v<T, int8_t>) {
+        return vx_scalar_get_decimal_i8(h);
+    } else if constexpr (std::is_same_v<T, int16_t>) {
+        return vx_scalar_get_decimal_i16(h);
+    } else if constexpr (std::is_same_v<T, int32_t>) {
+        return vx_scalar_get_decimal_i32(h);
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+        return vx_scalar_get_decimal_i64(h);
+    } else {
+        static_assert(false, "unsupported decimal scalar get type");
+    }
+}
 
 namespace detail {
 vx_scalar *make_bool(bool value, bool nullable);

--- a/lang/cpp/include/vortex/scalar.hpp
+++ b/lang/cpp/include/vortex/scalar.hpp
@@ -42,7 +42,8 @@ public:
     /**
      * Read a decimal scalar's unscaled value.
      * int8/16/32/64_t are supported.
-     * Throws if scalar is not a decimal, is Null, or value does not fit in T.
+     * Throws if scalar is not a decimal or is Null.
+     * Trying to get decimal's value that overflows T is UB.
      */
     template <primitive_type T>
     T get_decimal() const;
@@ -69,8 +70,8 @@ T Scalar::get() const {
 
     const DataType data_type = dtype();
     const DataTypeVariant variant = data_type.variant();
-    if (variant == Null) {
-        throw VortexException("DataType is null", InvalidArgument);
+    if (is_null()) {
+        throw VortexException("Scalar is null", InvalidArgument);
     }
 
     const vx_scalar *const h = handle_.get();
@@ -158,6 +159,9 @@ T Scalar::get() const {
 
 template <primitive_type T>
 T Scalar::get_decimal() const {
+    if (is_null()) {
+        throw VortexException("Scalar is null", ErrorCode::InvalidArgument);
+    }
     if (dtype().variant() != DataTypeVariant::Decimal) {
         throw VortexException("DataType is not Decimal", ErrorCode::InvalidArgument);
     }

--- a/lang/cpp/include/vortex/scalar.hpp
+++ b/lang/cpp/include/vortex/scalar.hpp
@@ -63,43 +63,105 @@ private:
 
 template <element_type T>
 T Scalar::get() const {
-    const vx_scalar *h = handle_.get();
+    using enum DataTypeVariant;
+    using enum ErrorCode;
+    using enum PType;
+
+    const DataType data_type = dtype();
+    const DataTypeVariant variant = data_type.variant();
+    if (variant == Null) {
+        throw VortexException("DataType is null", InvalidArgument);
+    }
+
+    const vx_scalar *const h = handle_.get();
     if constexpr (std::is_same_v<T, bool>) {
+        if (variant != Bool) {
+            throw VortexException("scalar get type doesn't match", InvalidArgument);
+        }
         return vx_scalar_get_bool(h);
     } else if constexpr (std::is_same_v<T, std::string_view>) {
+        if (variant != Utf8) {
+            throw VortexException("scalar get type doesn't match", InvalidArgument);
+        }
         vx_view v = vx_scalar_get_utf8(h);
         return std::string_view(v.ptr, v.len);
     } else if constexpr (std::is_same_v<T, BinaryView>) {
+        if (variant != Binary) {
+            throw VortexException("scalar get type doesn't match", InvalidArgument);
+        }
         vx_view v = vx_scalar_get_binary(h);
         return BinaryView(reinterpret_cast<const std::byte *>(v.ptr), v.len);
     } else if constexpr (std::is_same_v<T, uint8_t>) {
+        if (variant != Primitive || data_type.primitive_type() != U8) {
+            throw VortexException("scalar get type doesn't match", ErrorCode::InvalidArgument);
+        }
         return vx_scalar_get_u8(h);
     } else if constexpr (std::is_same_v<T, uint16_t>) {
+        if (variant != Primitive || data_type.primitive_type() != U16) {
+            throw VortexException("scalar get type doesn't match", ErrorCode::InvalidArgument);
+        }
         return vx_scalar_get_u16(h);
     } else if constexpr (std::is_same_v<T, uint32_t>) {
+        if (variant != Primitive || data_type.primitive_type() != U32) {
+            throw VortexException("scalar get type doesn't match", ErrorCode::InvalidArgument);
+        }
         return vx_scalar_get_u32(h);
     } else if constexpr (std::is_same_v<T, uint64_t>) {
+        if (variant != Primitive || data_type.primitive_type() != U64) {
+            throw VortexException("scalar get type doesn't match", ErrorCode::InvalidArgument);
+        }
         return vx_scalar_get_u64(h);
     } else if constexpr (std::is_same_v<T, int8_t>) {
+        if (variant != Primitive || data_type.primitive_type() != I8) {
+            throw VortexException("scalar get type doesn't match", ErrorCode::InvalidArgument);
+        }
         return vx_scalar_get_i8(h);
     } else if constexpr (std::is_same_v<T, int16_t>) {
+        if (variant != Primitive || data_type.primitive_type() != I16) {
+            throw VortexException("scalar get type doesn't match", ErrorCode::InvalidArgument);
+        }
         return vx_scalar_get_i16(h);
     } else if constexpr (std::is_same_v<T, int32_t>) {
+        if (variant != Primitive || data_type.primitive_type() != I32) {
+            throw VortexException("scalar get type doesn't match", ErrorCode::InvalidArgument);
+        }
         return vx_scalar_get_i32(h);
     } else if constexpr (std::is_same_v<T, int64_t>) {
+        if (variant != Primitive || data_type.primitive_type() != I64) {
+            throw VortexException("scalar get type doesn't match", ErrorCode::InvalidArgument);
+        }
         return vx_scalar_get_i64(h);
     } else if constexpr (std::is_same_v<T, float>) {
+        if (variant != Primitive || data_type.primitive_type() != F32) {
+            throw VortexException("scalar get type doesn't match", ErrorCode::InvalidArgument);
+        }
         return vx_scalar_get_f32(h);
     } else if constexpr (std::is_same_v<T, double>) {
+        if (variant != Primitive || data_type.primitive_type() != F64) {
+            throw VortexException("scalar get type doesn't match", ErrorCode::InvalidArgument);
+        }
         return vx_scalar_get_f64(h);
+    } else if constexpr (std::is_same_v<T, float16_t>) {
+        if (variant != Primitive || data_type.primitive_type() != F16) {
+            throw VortexException("scalar get type doesn't match", ErrorCode::InvalidArgument);
+        }
+        const uint16_t bits = vx_scalar_get_f16_bits(h);
+#if __STDCPP_FLOAT16_T__ != 1
+        return {.bits = bits};
+#else
+        return std::bit_cast<float16_t>(bits);
+#endif
     } else {
-        static_assert(false, "f16 scalar get is not supported");
+        static_assert(false, "scalar get is not supported for this type");
     }
 }
 
 template <primitive_type T>
 T Scalar::get_decimal() const {
-    const vx_scalar *h = handle_.get();
+    if (dtype().variant() != DataTypeVariant::Decimal) {
+        throw VortexException("DataType is not Decimal", ErrorCode::InvalidArgument);
+    }
+    const vx_scalar *const h = handle_.get();
     if constexpr (std::is_same_v<T, int8_t>) {
         return vx_scalar_get_decimal_i8(h);
     } else if constexpr (std::is_same_v<T, int16_t>) {

--- a/lang/cpp/include/vortex/scalar.hpp
+++ b/lang/cpp/include/vortex/scalar.hpp
@@ -49,21 +49,21 @@ public:
 
 private:
     friend struct detail::Access;
-    explicit Scalar(vx_scalar *owned) : handle_(owned) {
+    explicit Scalar(const vx_scalar *owned) : handle_(owned) {
     }
-    vx_scalar *release() && {
+    const vx_scalar *release() && {
         return handle_.release();
     }
 
     struct Deleter {
-        void operator()(vx_scalar *ptr) const noexcept;
+        void operator()(const vx_scalar *ptr) const noexcept;
     };
-    std::unique_ptr<vx_scalar, Deleter> handle_;
+    std::unique_ptr<const vx_scalar, Deleter> handle_;
 };
 
 template <element_type T>
 T Scalar::get() const {
-    vx_scalar *h = handle_.get();
+    const vx_scalar *h = handle_.get();
     if constexpr (std::is_same_v<T, bool>) {
         return vx_scalar_get_bool(h);
     } else if constexpr (std::is_same_v<T, std::string_view>) {
@@ -99,7 +99,7 @@ T Scalar::get() const {
 
 template <primitive_type T>
 T Scalar::get_decimal() const {
-    vx_scalar *h = handle_.get();
+    const vx_scalar *h = handle_.get();
     if constexpr (std::is_same_v<T, int8_t>) {
         return vx_scalar_get_decimal_i8(h);
     } else if constexpr (std::is_same_v<T, int16_t>) {

--- a/lang/cpp/src/array.cpp
+++ b/lang/cpp/src/array.cpp
@@ -5,6 +5,8 @@
 #include "vortex/common.hpp"
 #include "vortex/dtype.hpp"
 #include "vortex/error.hpp"
+#include "vortex/scalar.hpp"
+#include "vortex/session.hpp"
 
 #include <vortex.h>
 
@@ -322,6 +324,13 @@ BytesView Array::bytes(const Session &session) const {
     detail::ValidityBits validity(session, raw);
     const size_t len = vx_array_len(raw);
     return BytesView(std::move(canonical), std::move(validity), len);
+}
+
+Scalar Array::scalar_at(const Session &session, size_t index) const {
+    vx_error *error = nullptr;
+    const vx_scalar *scalar = vx_array_get_scalar(Access::c_ptr(session), handle_.get(), index, &error);
+    throw_on_error(error);
+    return Access::adopt<Scalar>(scalar);
 }
 
 bool PrimitiveView<bool>::value(size_t i) const {

--- a/lang/cpp/src/array.cpp
+++ b/lang/cpp/src/array.cpp
@@ -325,6 +325,11 @@ BytesView Array::bytes(const Session &session) const {
 }
 
 bool PrimitiveView<bool>::value(size_t i) const {
+    if (i >= size_) {
+        throw VortexException("index " + std::to_string(i) + " out of bounds for view of size " +
+                                  std::to_string(size_),
+                              ErrorCode::OutOfBounds);
+    }
     return vx_array_get_bool(Access::c_ptr(canonical_), i);
 }
 

--- a/lang/cpp/src/scalar.cpp
+++ b/lang/cpp/src/scalar.cpp
@@ -17,7 +17,7 @@ namespace vortex {
 using detail::Access;
 using detail::throw_on_error;
 
-void Scalar::Deleter::operator()(vx_scalar *ptr) const noexcept {
+void Scalar::Deleter::operator()(const vx_scalar *ptr) const noexcept {
     vx_scalar_free(ptr);
 }
 

--- a/lang/cpp/tests/expression.cpp
+++ b/lang/cpp/tests/expression.cpp
@@ -85,6 +85,7 @@ TEST_CASE("Operator overloading", "[expr]") {
     REQUIRE(bits.value(1));
     REQUIRE(bits.value(2));
     REQUIRE_FALSE(bits.value(3));
+    REQUIRE_THROWS_AS(bits.value(data.size()), VortexException);
 }
 
 TEST_CASE("Apply error", "[expr]") {

--- a/lang/cpp/tests/float16_t.cpp
+++ b/lang/cpp/tests/float16_t.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-#include "vortex/dtype.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <vortex/scalar.hpp>
 
@@ -25,11 +24,13 @@ TEST_CASE("F16 scalar", "[scalar]") {
     Scalar scalar = scalar::of(float16t);
     REQUIRE(scalar.dtype().variant() == DataTypeVariant::Primitive);
     REQUIRE(scalar.dtype().primitive_type() == vortex::PType::F16);
+    REQUIRE(scalar.get<float16_t>() == float16t);
 
     _Float16 float16t_alias = 1.0f16;
     scalar = scalar::of(float16t_alias);
     REQUIRE(scalar.dtype().variant() == DataTypeVariant::Primitive);
     REQUIRE(scalar.dtype().primitive_type() == vortex::PType::F16);
+    REQUIRE(scalar.get<float16_t>() == float16t_alias);
 }
 #endif
 } // namespace

--- a/lang/cpp/tests/float16_t_compat.cpp
+++ b/lang/cpp/tests/float16_t_compat.cpp
@@ -34,5 +34,6 @@ TEST_CASE("F16 scalar (compatibility)", "[scalar]") {
     Scalar scalar = scalar::of(float16t);
     REQUIRE(scalar.dtype().variant() == DataTypeVariant::Primitive);
     REQUIRE(scalar.dtype().primitive_type() == vortex::PType::F16);
+    REQUIRE(scalar.get<float16_t>() == float16t);
 }
 } // namespace

--- a/lang/cpp/tests/scalar.cpp
+++ b/lang/cpp/tests/scalar.cpp
@@ -46,16 +46,19 @@ TEST_CASE("Null scalar", "[scalar]") {
     Scalar s = scalar::null(dtype::int32(true));
     REQUIRE(s.is_null());
     REQUIRE(s.dtype().variant() == DataTypeVariant::Primitive);
-    REQUIRE_THROWS_AS(s.get<float>(), VortexException);
+    REQUIRE_THROWS_AS(s.get<int32_t>(), VortexException);
 }
 
 TEST_CASE("UTF-8 scalar", "[scalar]") {
     Scalar s = scalar::of("hello"sv);
     REQUIRE_FALSE(s.is_null());
     REQUIRE(s.dtype().variant() == DataTypeVariant::Utf8);
+    REQUIRE_THROWS_AS(s.get<float>(), VortexException);
 
     REQUIRE_FALSE(scalar::of(""sv).is_null());
     s = scalar::of("Широкая строка"sv);
+    REQUIRE_THROWS_AS(s.get<bool>(), VortexException);
+    REQUIRE_THROWS_AS(s.get_decimal<int8_t>(), VortexException);
     REQUIRE(s.dtype().variant() == DataTypeVariant::Utf8);
 
     REQUIRE_THROWS_AS(scalar::of("\xFF\xFE"sv), VortexException);
@@ -115,6 +118,9 @@ TEST_CASE("String getters", "[scalar]") {
 }
 
 TEST_CASE("Decimal getters", "[scalar]") {
+    Scalar s = scalar::null(dtype::decimal(5, 2));
+    REQUIRE_THROWS_AS(s.get_decimal<int8_t>(), VortexException);
+
     REQUIRE(decimal<int8_t>(56, 5, 2).get_decimal<int8_t>() == 56);
     REQUIRE(decimal<int16_t>(1234, 5, 2).get_decimal<int16_t>() == 1234);
     REQUIRE(decimal<int32_t>(5678, 6, 2).get_decimal<int32_t>() == 5678);

--- a/lang/cpp/tests/scalar.cpp
+++ b/lang/cpp/tests/scalar.cpp
@@ -10,6 +10,8 @@ using namespace std::string_view_literals;
 
 namespace {
 using enum vortex::PType;
+using scalar::decimal;
+using scalar::of;
 
 TEST_CASE("Boolean scalar", "[scalar]") {
     Scalar s = scalar::of(true);
@@ -29,7 +31,7 @@ TEST_CASE("Integer scalars", "[scalar]") {
 }
 
 TEST_CASE("Float scalars", "[scalar]") {
-    REQUIRE(scalar::of(1.5F).dtype().primitive_type() == F32);
+    REQUIRE(scalar::of(1.5f).dtype().primitive_type() == F32);
     REQUIRE(scalar::of(1.5).dtype().primitive_type() == F64);
     REQUIRE(scalar::of(float16_t {0x3C00}).dtype().primitive_type() == F16);
 }
@@ -85,6 +87,32 @@ TEST_CASE("Decimal scalars", "[scalar]") {
     REQUIRE(d64.dtype().variant() == DataTypeVariant::Decimal);
     REQUIRE(d64.dtype().decimal_precision() == 12);
     REQUIRE(d64.dtype().decimal_scale() == 3);
+}
+
+TEST_CASE("Primitive getters", "[scalar]") {
+    REQUIRE(of<uint64_t>(1ULL << 40).get<uint64_t>() == (1ULL << 40));
+    REQUIRE(of<int32_t>(-7).get<int32_t>() == -7);
+    REQUIRE(of(2.5).get<double>() == 2.5);
+    REQUIRE(of(true).get<bool>());
+}
+
+TEST_CASE("String getters", "[scalar]") {
+    Scalar s = of("hello"sv);
+    REQUIRE(s.get<std::string_view>() == "hello"sv);
+
+    const std::byte bytes[] = {std::byte {1}, std::byte {2}, std::byte {0}, std::byte {4}};
+    Scalar b = of(std::span<const std::byte> {bytes});
+    BinaryView view = b.get<BinaryView>();
+    REQUIRE(view.size() == 4);
+    REQUIRE(view[0] == std::byte {1});
+    REQUIRE(view[3] == std::byte {4});
+}
+
+TEST_CASE("Decimal getters", "[scalar]") {
+    REQUIRE(decimal<int8_t>(56, 5, 2).get_decimal<int8_t>() == 56);
+    REQUIRE(decimal<int16_t>(1234, 5, 2).get_decimal<int16_t>() == 1234);
+    REQUIRE(decimal<int32_t>(5678, 6, 2).get_decimal<int32_t>() == 5678);
+    REQUIRE(decimal<int64_t>(99999, 12, 3).get_decimal<int64_t>() == 99999);
 }
 
 TEST_CASE("Copy scalar", "[scalar]") {

--- a/lang/cpp/tests/scalar.cpp
+++ b/lang/cpp/tests/scalar.cpp
@@ -46,6 +46,7 @@ TEST_CASE("Null scalar", "[scalar]") {
     Scalar s = scalar::null(dtype::int32(true));
     REQUIRE(s.is_null());
     REQUIRE(s.dtype().variant() == DataTypeVariant::Primitive);
+    REQUIRE_THROWS_AS(s.get<float>(), VortexException);
 }
 
 TEST_CASE("UTF-8 scalar", "[scalar]") {
@@ -87,6 +88,11 @@ TEST_CASE("Decimal scalars", "[scalar]") {
     REQUIRE(d64.dtype().variant() == DataTypeVariant::Decimal);
     REQUIRE(d64.dtype().decimal_precision() == 12);
     REQUIRE(d64.dtype().decimal_scale() == 3);
+}
+
+TEST_CASE("Invalid scalar getter", "[scalar]") {
+    Scalar scalar = of<int32_t>(0);
+    REQUIRE_THROWS_AS(scalar.get<double>(), VortexException);
 }
 
 TEST_CASE("Primitive getters", "[scalar]") {

--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -750,7 +750,8 @@ bool vx_array_get_bool(const vx_array *array, size_t index);
  *
  * If element at index is invalid, returns a Null vx_scalar.
  *
- * This is an expensive operation. If you need bulk access, use
+ * This operation executes the array to extract a scalar and thus is
+ * expensive. If you need bulk access, use
  * vx_array_data_ptr_primitive or vx_data_ptr_bool.
  *
  * Errors if "index" is out of bounds.
@@ -1290,6 +1291,14 @@ double vx_scalar_get_f64(const vx_scalar *scalar);
  * The value is read from raw uint16_t.
  */
 vx_scalar *vx_scalar_new_f16_bits(uint16_t bits, bool is_nullable);
+
+/**
+ * Return 16-bit floating point value stored in scalar.
+ * The value is read into raw uint16_t.
+ *
+ * Panics if scalar is not a primitive scalar of this type or is null.
+ */
+uint16_t vx_scalar_get_f16_bits(const vx_scalar *scalar);
 
 /**
  * Create a UTF-8 scalar.

--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -429,7 +429,10 @@ typedef struct vx_partition vx_partition;
 
 /**
  * A vx_scalar is a single value with an associated vx_dtype.
+ *
  * Scalar value may be Null is vx_dtype is nullable.
+ * One example where you can get a Null scalar is vx_array_get_scalar
+ * where the element at some index is invalid/null.
  */
 typedef struct vx_scalar vx_scalar;
 
@@ -645,7 +648,10 @@ const vx_array *vx_array_slice(const vx_array *array, size_t start, size_t stop,
  * validity array. Sets error if index is out of bounds or underlying validity
  * array is corrupted.
  */
-bool vx_array_element_is_invalid(const vx_array *array, size_t index, vx_error **error);
+bool vx_array_element_is_invalid(const vx_session *session,
+                                 const vx_array *array,
+                                 size_t index,
+                                 vx_error **error);
 
 /**
  * Check how many items in the array are invalid (null).
@@ -708,50 +714,6 @@ const vx_array *vx_array_new_primitive(vx_ptype ptype,
 const vx_array *
 vx_array_from_arrow(FFI_ArrowArray *array, FFI_ArrowSchema *schema, bool nullable, vx_error **error_out);
 
-uint8_t vx_array_get_u8(const vx_array *array, size_t index);
-
-uint8_t vx_array_get_storage_u8(const vx_array *array, size_t index);
-
-uint16_t vx_array_get_u16(const vx_array *array, size_t index);
-
-uint16_t vx_array_get_storage_u16(const vx_array *array, size_t index);
-
-uint32_t vx_array_get_u32(const vx_array *array, size_t index);
-
-uint32_t vx_array_get_storage_u32(const vx_array *array, size_t index);
-
-uint64_t vx_array_get_u64(const vx_array *array, size_t index);
-
-uint64_t vx_array_get_storage_u64(const vx_array *array, size_t index);
-
-int8_t vx_array_get_i8(const vx_array *array, size_t index);
-
-int8_t vx_array_get_storage_i8(const vx_array *array, size_t index);
-
-int16_t vx_array_get_i16(const vx_array *array, size_t index);
-
-int16_t vx_array_get_storage_i16(const vx_array *array, size_t index);
-
-int32_t vx_array_get_i32(const vx_array *array, size_t index);
-
-int32_t vx_array_get_storage_i32(const vx_array *array, size_t index);
-
-int64_t vx_array_get_i64(const vx_array *array, size_t index);
-
-int64_t vx_array_get_storage_i64(const vx_array *array, size_t index);
-
-uint16_t vx_array_get_f16(const vx_array *array, size_t index);
-
-uint16_t vx_array_get_storage_f16(const vx_array *array, size_t index);
-
-float vx_array_get_f32(const vx_array *array, size_t index);
-
-float vx_array_get_storage_f32(const vx_array *array, size_t index);
-
-double vx_array_get_f64(const vx_array *array, size_t index);
-
-double vx_array_get_storage_f64(const vx_array *array, size_t index);
-
 /**
  * Return UTF-8 string at "index" in a canonical Utf8 array.
  *
@@ -782,6 +744,19 @@ vx_view vx_array_binary_at(const vx_array *array, size_t index, vx_error **error
  * Panics if "index" is out of bounds.
  */
 bool vx_array_get_bool(const vx_array *array, size_t index);
+
+/**
+ * Get array's element at position "index".
+ *
+ * If element at index is invalid, returns a Null vx_scalar.
+ *
+ * This is an expensive operation. If you need bulk access, use
+ * vx_array_data_ptr_primitive or vx_data_ptr_bool.
+ *
+ * Errors if "index" is out of bounds.
+ */
+const vx_scalar *
+vx_array_get_scalar(const vx_session *session, const vx_array *array, size_t index, vx_error **error_out);
 
 /**
  * Decode array into its canonical form.
@@ -1174,7 +1149,7 @@ vx_scalar *vx_scalar_clone(const vx_scalar *scalar);
 const vx_dtype *vx_scalar_dtype(const vx_scalar *scalar);
 
 /**
- * Return whether scalar is a typed null value.
+ * Return whether scalar is a typed Null value.
  */
 bool vx_scalar_is_null(const vx_scalar *scalar);
 
@@ -1184,80 +1159,174 @@ bool vx_scalar_is_null(const vx_scalar *scalar);
 vx_scalar *vx_scalar_new_bool(bool value, bool is_nullable);
 
 /**
- * Create an unsigned 8-bit integer scalar.
+ * Return the boolean value stored in the scalar.
+ *
+ * Panics if the scalar is not a Bool scalar, or is null.
+ */
+bool vx_scalar_get_bool(const vx_scalar *scalar);
+
+/**
+ * Create a u8 scalar.
  */
 vx_scalar *vx_scalar_new_u8(uint8_t value, bool is_nullable);
 
 /**
- * Create an unsigned 16-bit integer scalar.
+ * Return u8 value stored in scalar.
+ *
+ * Panics if scalar is not a primitive scalar of this type or is null.
+ */
+uint8_t vx_scalar_get_u8(const vx_scalar *scalar);
+
+/**
+ * Create a u16 scalar.
  */
 vx_scalar *vx_scalar_new_u16(uint16_t value, bool is_nullable);
 
 /**
- * Create an unsigned 32-bit integer scalar.
+ * Return u16 value stored in scalar.
+ *
+ * Panics if scalar is not a primitive scalar of this type or is null.
+ */
+uint16_t vx_scalar_get_u16(const vx_scalar *scalar);
+
+/**
+ * Create a u32 scalar.
  */
 vx_scalar *vx_scalar_new_u32(uint32_t value, bool is_nullable);
 
 /**
- * Create an unsigned 64-bit integer scalar.
+ * Return u32 value stored in scalar.
+ *
+ * Panics if scalar is not a primitive scalar of this type or is null.
+ */
+uint32_t vx_scalar_get_u32(const vx_scalar *scalar);
+
+/**
+ * Create a u64 scalar.
  */
 vx_scalar *vx_scalar_new_u64(uint64_t value, bool is_nullable);
 
 /**
- * Create a signed 8-bit integer scalar.
+ * Return u64 value stored in scalar.
+ *
+ * Panics if scalar is not a primitive scalar of this type or is null.
+ */
+uint64_t vx_scalar_get_u64(const vx_scalar *scalar);
+
+/**
+ * Create a i8 scalar.
  */
 vx_scalar *vx_scalar_new_i8(int8_t value, bool is_nullable);
 
 /**
- * Create a signed 16-bit integer scalar.
+ * Return i8 value stored in scalar.
+ *
+ * Panics if scalar is not a primitive scalar of this type or is null.
+ */
+int8_t vx_scalar_get_i8(const vx_scalar *scalar);
+
+/**
+ * Create a i16 scalar.
  */
 vx_scalar *vx_scalar_new_i16(int16_t value, bool is_nullable);
 
 /**
- * Create a signed 32-bit integer scalar.
+ * Return i16 value stored in scalar.
+ *
+ * Panics if scalar is not a primitive scalar of this type or is null.
+ */
+int16_t vx_scalar_get_i16(const vx_scalar *scalar);
+
+/**
+ * Create a i32 scalar.
  */
 vx_scalar *vx_scalar_new_i32(int32_t value, bool is_nullable);
 
 /**
- * Create a signed 64-bit integer scalar.
+ * Return i32 value stored in scalar.
+ *
+ * Panics if scalar is not a primitive scalar of this type or is null.
+ */
+int32_t vx_scalar_get_i32(const vx_scalar *scalar);
+
+/**
+ * Create a i64 scalar.
  */
 vx_scalar *vx_scalar_new_i64(int64_t value, bool is_nullable);
 
 /**
- * Create a 32-bit floating point scalar.
+ * Return i64 value stored in scalar.
+ *
+ * Panics if scalar is not a primitive scalar of this type or is null.
+ */
+int64_t vx_scalar_get_i64(const vx_scalar *scalar);
+
+/**
+ * Create a f32 scalar.
  */
 vx_scalar *vx_scalar_new_f32(float value, bool is_nullable);
 
 /**
- * Create a 64-bit floating point scalar.
+ * Return f32 value stored in scalar.
+ *
+ * Panics if scalar is not a primitive scalar of this type or is null.
+ */
+float vx_scalar_get_f32(const vx_scalar *scalar);
+
+/**
+ * Create a f64 scalar.
  */
 vx_scalar *vx_scalar_new_f64(double value, bool is_nullable);
 
 /**
- * Create a 16-bit floating point scalar.
+ * Return f64 value stored in scalar.
  *
- * The value is read from raw half-precision bits because C has no portable
- * half-precision floating point ABI.
+ * Panics if scalar is not a primitive scalar of this type or is null.
+ */
+double vx_scalar_get_f64(const vx_scalar *scalar);
+
+/**
+ * Create a 16-bit floating point scalar.
+ * The value is read from raw uint16_t.
  */
 vx_scalar *vx_scalar_new_f16_bits(uint16_t bits, bool is_nullable);
 
 /**
  * Create a UTF-8 scalar.
  *
- * The string bytes are copied into the scalar. Invalid UTF-8 returns NULL and
- * writes the error output.
+ * "value" bytes are copied into scalar.
+ * Errors on invalid UTF-8.
  */
 vx_scalar *vx_scalar_new_utf8(vx_view value, bool is_nullable, vx_error **err);
 
 /**
  * Create a binary scalar.
  *
- * The byte range is copied into the scalar. NULL "ptr" is allowed only when
- * len == 0.
+ * Byte range is copied into the scalar.
+ *
+ * NULL "ptr" is allowed only when len == 0.
  *
  * Returns NULL and sets "err" on error.
  */
 vx_scalar *vx_scalar_new_binary(const uint8_t *ptr, size_t len, bool is_nullable, vx_error **err);
+
+/**
+ * Return UTF-8 string stored in scalar.
+ *
+ * Returned view borrows the scalar and is valid as long as "scalar" is valid.
+ *
+ * Panics if scalar is not a Utf8 scalar, or is null.
+ */
+vx_view vx_scalar_get_utf8(const vx_scalar *scalar);
+
+/**
+ * Return binary bytes stored in the scalar.
+ *
+ * Returned view borrows scalar and is valid as long as "scalar" is valid.
+ *
+ * Panics if scalar is not a Binary scalar, or is null.
+ */
+vx_view vx_scalar_get_binary(const vx_scalar *scalar);
 
 /**
  * Create a typed null scalar.
@@ -1270,9 +1339,7 @@ vx_scalar *vx_scalar_new_binary(const uint8_t *ptr, size_t len, bool is_nullable
 vx_scalar *vx_scalar_new_null(const vx_dtype *dtype, vx_error **err);
 
 /**
- * Create a decimal scalar.
- *
- * The unscaled value is provided as a signed 8-bit integer.
+ * Create a decimal scalar from a signed i8 unscaled value.
  *
  * Returns NULL and sets "err" on error.
  */
@@ -1280,9 +1347,15 @@ vx_scalar *
 vx_scalar_new_decimal_i8(int8_t value, uint8_t precision, int8_t scale, bool is_nullable, vx_error **err);
 
 /**
- * Create a decimal scalar.
+ * Return the unscaled i8 value of a decimal scalar.
  *
- * The unscaled value is provided as a signed 16-bit integer.
+ * Panics if the scalar is not a decimal scalar, is null, or the
+ * unscaled value does not fit in i8.
+ */
+int8_t vx_scalar_get_decimal_i8(const vx_scalar *scalar);
+
+/**
+ * Create a decimal scalar from a signed i16 unscaled value.
  *
  * Returns NULL and sets "err" on error.
  */
@@ -1290,9 +1363,15 @@ vx_scalar *
 vx_scalar_new_decimal_i16(int16_t value, uint8_t precision, int8_t scale, bool is_nullable, vx_error **err);
 
 /**
- * Create a decimal scalar.
+ * Return the unscaled i16 value of a decimal scalar.
  *
- * The unscaled value is provided as a signed 32-bit integer.
+ * Panics if the scalar is not a decimal scalar, is null, or the
+ * unscaled value does not fit in i16.
+ */
+int16_t vx_scalar_get_decimal_i16(const vx_scalar *scalar);
+
+/**
+ * Create a decimal scalar from a signed i32 unscaled value.
  *
  * Returns NULL and sets "err" on error.
  */
@@ -1300,14 +1379,28 @@ vx_scalar *
 vx_scalar_new_decimal_i32(int32_t value, uint8_t precision, int8_t scale, bool is_nullable, vx_error **err);
 
 /**
- * Create a decimal scalar.
+ * Return the unscaled i32 value of a decimal scalar.
  *
- * The unscaled value is provided as a signed 64-bit integer.
+ * Panics if the scalar is not a decimal scalar, is null, or the
+ * unscaled value does not fit in i32.
+ */
+int32_t vx_scalar_get_decimal_i32(const vx_scalar *scalar);
+
+/**
+ * Create a decimal scalar from a signed i64 unscaled value.
  *
  * Returns NULL and sets "err" on error.
  */
 vx_scalar *
 vx_scalar_new_decimal_i64(int64_t value, uint8_t precision, int8_t scale, bool is_nullable, vx_error **err);
+
+/**
+ * Return the unscaled i64 value of a decimal scalar.
+ *
+ * Panics if the scalar is not a decimal scalar, is null, or the
+ * unscaled value does not fit in i64.
+ */
+int64_t vx_scalar_get_decimal_i64(const vx_scalar *scalar);
 
 /**
  * Create a decimal scalar.

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -506,7 +506,8 @@ pub unsafe extern "C-unwind" fn vx_array_get_bool(array: *const vx_array, index:
 ///
 /// If element at index is invalid, returns a Null vx_scalar.
 ///
-/// This is an expensive operation. If you need bulk access, use
+/// This operation executes the array to extract a scalar and thus is
+/// expensive. If you need bulk access, use
 /// vx_array_data_ptr_primitive or vx_data_ptr_bool.
 ///
 /// Errors if "index" is out of bounds.

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -10,7 +10,6 @@ use arrow_array::array::make_array;
 use arrow_array::ffi::FFI_ArrowArray;
 use arrow_array::ffi::FFI_ArrowSchema;
 use arrow_array::ffi::from_ffi;
-use paste::paste;
 use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::IntoArray;
@@ -45,11 +44,11 @@ use crate::error::vx_error;
 use crate::error::write_error;
 use crate::expression::vx_expression;
 use crate::ptype::vx_ptype;
+use crate::scalar::vx_scalar;
 use crate::session::vx_session;
 use crate::session::vx_session_ref;
-use crate::string::vx_view;
+use crate::vx_view;
 
-// ArrayRef has an Arc inside
 box_wrapper!(
     /// Arrays are reference-counted handles to owned memory buffers that hold
     /// scalars. These buffers can be held in a number of physical encodings to
@@ -264,13 +263,14 @@ pub unsafe extern "C-unwind" fn vx_array_slice(
 #[unsafe(no_mangle)]
 #[allow(clippy::disallowed_methods)]
 pub unsafe extern "C-unwind" fn vx_array_element_is_invalid(
+    session: *const vx_session,
     array: *const vx_array,
     index: usize,
     error: *mut *mut vx_error,
 ) -> bool {
     try_or_default(error, || {
-        vortex_ensure!(!array.is_null());
-        vx_array::as_ref(array).is_invalid(index, &mut legacy_session().create_execution_ctx())
+        let session = unsafe { vx_session_ref(session) }?;
+        vx_array::as_ref(array).is_invalid(index, &mut session.create_execution_ctx())
     })
 }
 
@@ -421,54 +421,6 @@ pub unsafe extern "C-unwind" fn vx_array_from_arrow(
     })
 }
 
-macro_rules! ffiarray_get_ptype {
-    ($ptype:ident) => {
-        paste! {
-            #[unsafe(no_mangle)]
-            pub unsafe extern "C-unwind" fn [<vx_array_get_ $ptype>](array: *const vx_array, index: usize) -> $ptype {
-                let array = vx_array::as_ref(array);
-                // TODO(joe): propagate this error up instead of expecting
-                #[allow(clippy::disallowed_methods)]
-                let value = array
-                    .execute_scalar(index, &mut legacy_session().create_execution_ctx())
-                    .vortex_expect("scalar_at failed");
-                // TODO(joe): propagate this error up instead of expecting
-                value.as_primitive()
-                    .as_::<$ptype>()
-                    .vortex_expect("null value")
-            }
-
-            #[unsafe(no_mangle)]
-            pub unsafe extern "C-unwind" fn [<vx_array_get_storage_ $ptype>](array: *const vx_array, index: usize) -> $ptype {
-                let array = vx_array::as_ref(array);
-                // TODO(joe): propagate this error up instead of expecting
-                #[allow(clippy::disallowed_methods)]
-                let value = array
-                    .execute_scalar(index, &mut legacy_session().create_execution_ctx())
-                    .vortex_expect("scalar_at failed");
-                // TODO(joe): propagate this error up instead of expecting
-                value.as_extension()
-                    .to_storage_scalar()
-                    .as_primitive()
-                    .as_::<$ptype>()
-                    .vortex_expect("null value")
-            }
-        }
-    };
-}
-
-ffiarray_get_ptype!(u8);
-ffiarray_get_ptype!(u16);
-ffiarray_get_ptype!(u32);
-ffiarray_get_ptype!(u64);
-ffiarray_get_ptype!(i8);
-ffiarray_get_ptype!(i16);
-ffiarray_get_ptype!(i32);
-ffiarray_get_ptype!(i64);
-ffiarray_get_ptype!(f16);
-ffiarray_get_ptype!(f32);
-ffiarray_get_ptype!(f64);
-
 /// SAFETY: "array" must be null or a valid "vx_array"
 unsafe fn varbinview_at(
     array: *const vx_array,
@@ -550,6 +502,29 @@ pub unsafe extern "C-unwind" fn vx_array_get_bool(array: *const vx_array, index:
     bits.value(index)
 }
 
+/// Get array's element at position "index".
+///
+/// If element at index is invalid, returns a Null vx_scalar.
+///
+/// This is an expensive operation. If you need bulk access, use
+/// vx_array_data_ptr_primitive or vx_data_ptr_bool.
+///
+/// Errors if "index" is out of bounds.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_array_get_scalar(
+    session: *const vx_session,
+    array: *const vx_array,
+    index: usize,
+    error_out: *mut *mut vx_error,
+) -> *const vx_scalar {
+    try_or_default(error_out, || {
+        let session = vx_session::as_ref(session);
+        let array = vx_array::as_ref(array);
+        let scalar = array.execute_scalar(index, &mut session.create_execution_ctx())?;
+        Ok(vx_scalar::new(scalar))
+    })
+}
+
 /// Decode array into its canonical form.
 ///
 /// On error returns NULL and "sets error_out".
@@ -560,8 +535,8 @@ pub unsafe extern "C-unwind" fn vx_array_canonicalize(
     error_out: *mut *mut vx_error,
 ) -> *const vx_array {
     try_or_default(error_out, || {
-        let session = unsafe { vx_session_ref(session) }?;
-        let array = unsafe { vx_array_ref(array) }?;
+        let session = vx_session::as_ref(session);
+        let array = vx_array::as_ref(array);
         let mut ctx = session.create_execution_ctx();
         let canonical = array.clone().execute::<Canonical>(&mut ctx)?;
         Ok(vx_array::new(canonical.into_array()))
@@ -578,7 +553,7 @@ pub unsafe extern "C-unwind" fn vx_array_data_ptr_primitive(
     error_out: *mut *mut vx_error,
 ) -> *const c_void {
     try_or(error_out, ptr::null(), || {
-        let array = unsafe { vx_array_ref(array) }?;
+        let array = vx_array::as_ref(array);
         let primitive = array.as_opt::<Primitive>().ok_or_else(|| {
             vortex_err!(
                 "vx_array_data_ptr_primitive requires a canonical Primitive array, got {}",
@@ -607,7 +582,7 @@ pub unsafe extern "C-unwind" fn vx_array_data_ptr_bool(
     error_out: *mut *mut vx_error,
 ) -> *const c_void {
     try_or(error_out, ptr::null(), || {
-        let array = unsafe { vx_array_ref(array) }?;
+        let array = vx_array::as_ref(array);
         vortex_ensure!(!bit_offset_out.is_null(), "null bit_offset_out");
         let bool_array = array.as_opt::<Bool>().ok_or_else(|| {
             vortex_err!(
@@ -655,8 +630,6 @@ mod tests {
     use vortex::array::arrays::bool::BoolArrayExt;
     use vortex::array::validity::Validity;
     use vortex::buffer::buffer;
-    #[cfg(not(miri))]
-    use vortex::dtype::half::f16;
     use vortex::expr::eq;
     use vortex::expr::lit;
     use vortex::expr::root;
@@ -667,16 +640,36 @@ mod tests {
     use crate::dtype::vx_dtype_variant;
     use crate::error::vx_error_free;
     use crate::expression::vx_expression_free;
+    use crate::scalar::*;
     use crate::session::vx_session_free;
     use crate::session::vx_session_new;
     use crate::tests::assert_error;
     use crate::tests::assert_no_error;
+
+    unsafe fn get_i32(session: *const vx_session, array: *const vx_array, index: usize) -> i32 {
+        let mut error = ptr::null_mut();
+        let scalar = unsafe { vx_array_get_scalar(session, array, index, &raw mut error) };
+        assert_no_error(error);
+        let value = unsafe { vx_scalar_get_i32(scalar) };
+        unsafe { vx_scalar_free(scalar.cast_mut()) };
+        value
+    }
+
+    unsafe fn get_u8(session: *const vx_session, array: *const vx_array, index: usize) -> u8 {
+        let mut error = ptr::null_mut();
+        let scalar = unsafe { vx_array_get_scalar(session, array, index, &raw mut error) };
+        assert_no_error(error);
+        let value = unsafe { vx_scalar_get_u8(scalar) };
+        unsafe { vx_scalar_free(scalar.cast_mut()) };
+        value
+    }
 
     #[test]
     // TODO(joe): enable once this is fixed https://github.com/Amanieu/parking_lot/issues/477
     #[cfg_attr(miri, ignore)]
     fn test_simple() {
         unsafe {
+            let session = vx_session_new();
             let primitive = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable);
             let ffi_array = vx_array::new(primitive.into_array());
 
@@ -688,12 +681,26 @@ mod tests {
                 vx_dtype_variant::DTYPE_PRIMITIVE
             );
 
-            assert_eq!(vx_array_get_i32(ffi_array, 0), 1);
-            assert_eq!(vx_array_get_i32(ffi_array, 1), 2);
-            assert_eq!(vx_array_get_i32(ffi_array, 2), 3);
+            let mut error = ptr::null_mut();
+
+            let scalar = vx_array_get_scalar(session, ffi_array, 0, &raw mut error);
+            assert_no_error(error);
+            assert_eq!(vx_scalar_get_i32(scalar), 1);
+            vx_scalar_free(scalar);
+
+            let scalar = vx_array_get_scalar(session, ffi_array, 1, &raw mut error);
+            assert_no_error(error);
+            assert_eq!(vx_scalar_get_i32(scalar), 2);
+            vx_scalar_free(scalar);
+
+            let scalar = vx_array_get_scalar(session, ffi_array, 2, &raw mut error);
+            assert_no_error(error);
+            assert_eq!(vx_scalar_get_i32(scalar), 3);
+            vx_scalar_free(scalar);
 
             vx_dtype_free(array_dtype);
             vx_array_free(ffi_array);
+            vx_session_free(session);
         }
     }
 
@@ -715,6 +722,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn test_slice() {
         unsafe {
+            let session = vx_session_new();
             let primitive =
                 PrimitiveArray::new(buffer![1i32, 2i32, 3i32, 4i32, 5i32], Validity::NonNullable);
             let ffi_array = vx_array::new(primitive.into_array());
@@ -723,12 +731,12 @@ mod tests {
             let sliced = vx_array_slice(ffi_array, 1, 4, &raw mut error);
             assert_no_error(error);
             assert_eq!(vx_array_len(sliced), 3);
-            assert_eq!(vx_array_get_i32(sliced, 0), 2);
-            assert_eq!(vx_array_get_i32(sliced, 1), 3);
-            assert_eq!(vx_array_get_i32(sliced, 2), 4);
+            assert_eq!(get_i32(session, sliced, 0), 2);
+            assert_eq!(get_i32(session, sliced, 2), 4);
 
             vx_array_free(sliced);
             vx_array_free(ffi_array);
+            vx_session_free(session);
         }
     }
 
@@ -737,6 +745,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn test_null_operations() {
         unsafe {
+            let session = vx_session_new();
             let primitive = PrimitiveArray::new(
                 buffer![1i32, 2i32, 3i32],
                 Validity::from_iter([true, false, true]),
@@ -744,11 +753,26 @@ mod tests {
             let ffi_array = vx_array::new(primitive.into_array());
 
             let mut error = ptr::null_mut();
-            assert!(!vx_array_element_is_invalid(ffi_array, 0, &raw mut error));
+            assert!(!vx_array_element_is_invalid(
+                session,
+                ffi_array,
+                0,
+                &raw mut error
+            ));
             assert_no_error(error);
-            assert!(vx_array_element_is_invalid(ffi_array, 1, &raw mut error));
+            assert!(vx_array_element_is_invalid(
+                session,
+                ffi_array,
+                1,
+                &raw mut error
+            ));
             assert_no_error(error);
-            assert!(!vx_array_element_is_invalid(ffi_array, 2, &raw mut error));
+            assert!(!vx_array_element_is_invalid(
+                session,
+                ffi_array,
+                2,
+                &raw mut error
+            ));
             assert_no_error(error);
 
             let null_count = vx_array_invalid_count(ffi_array, &raw mut error);
@@ -756,6 +780,7 @@ mod tests {
             assert_eq!(null_count, 1);
 
             vx_array_free(ffi_array);
+            vx_session_free(session);
         }
     }
 
@@ -764,6 +789,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn test_get_field() {
         unsafe {
+            let session = vx_session_new();
             let names = VarBinViewArray::from_iter_str(["Alice", "Bob", "Charlie"]);
             let ages = PrimitiveArray::new(buffer![30u8, 25u8, 35u8], Validity::NonNullable);
             let struct_array = StructArray::try_new(
@@ -783,9 +809,9 @@ mod tests {
             let field1 = vx_array_get_field(ffi_array, 1, &raw mut error);
             assert_no_error(error);
             assert_eq!(vx_array_len(field1), 3);
-            assert_eq!(vx_array_get_u8(field1, 0), 30);
-            assert_eq!(vx_array_get_u8(field1, 1), 25);
-            assert_eq!(vx_array_get_u8(field1, 2), 35);
+            assert_eq!(get_u8(session, field1, 0), 30);
+            assert_eq!(get_u8(session, field1, 1), 25);
+            assert_eq!(get_u8(session, field1, 2), 35);
 
             // Test out of bounds
             let field_oob = vx_array_get_field(ffi_array, 2, &raw mut error);
@@ -796,136 +822,7 @@ mod tests {
             vx_array_free(field0);
             vx_array_free(field1);
             vx_array_free(ffi_array);
-        }
-    }
-
-    #[test]
-    // TODO(joe): enable once this is fixed https://github.com/Amanieu/parking_lot/issues/477
-    #[cfg_attr(miri, ignore)]
-    fn test_primitive_getters() {
-        unsafe {
-            // Test a representative sample of primitive types
-            // The macro generates identical code for all types, so exhaustive testing is redundant
-
-            // Test signed integer with edge cases
-            let mut error = ptr::null_mut();
-            let validity = vx_validity {
-                r#type: vx_validity_type::VX_VALIDITY_NON_NULLABLE,
-                array: ptr::null(),
-            };
-
-            let i32_array = [i32::MAX, i32::MIN, 0];
-            let ffi_i32 = vx_array_new_primitive(
-                vx_ptype::PTYPE_I32,
-                i32_array.as_ptr() as *const c_void,
-                i32_array.len(),
-                &raw const validity,
-                &raw mut error,
-            );
-            assert_no_error(error);
-            assert!(!ffi_i32.is_null());
-
-            assert!(vx_array_is_primitive(ffi_i32, vx_ptype::PTYPE_I32));
-            assert_eq!(vx_array_get_i32(ffi_i32, 0), i32::MAX);
-            assert_eq!(vx_array_get_i32(ffi_i32, 1), i32::MIN);
-            assert_eq!(vx_array_get_i32(ffi_i32, 2), 0);
-            vx_array_free(ffi_i32);
-
-            // Test unsigned integer
-            let u64_array = [u64::MAX, 0u64, 42u64];
-            let ffi_u64 = vx_array_new_primitive(
-                vx_ptype::PTYPE_U64,
-                u64_array.as_ptr() as *const c_void,
-                u64_array.len(),
-                &raw const validity,
-                &raw mut error,
-            );
-            assert_no_error(error);
-            assert!(!ffi_u64.is_null());
-            assert!(vx_array_is_primitive(ffi_u64, vx_ptype::PTYPE_U64));
-            assert_eq!(vx_array_get_u64(ffi_u64, 0), u64::MAX);
-            assert_eq!(vx_array_get_u64(ffi_u64, 1), 0);
-            assert_eq!(vx_array_get_u64(ffi_u64, 2), 42);
-            vx_array_free(ffi_u64);
-
-            // Test floating point including special values
-            let f64_array = [f64::NEG_INFINITY, 0.0f64, f64::NAN];
-            let ffi_f64 = vx_array_new_primitive(
-                vx_ptype::PTYPE_F64,
-                f64_array.as_ptr() as *const c_void,
-                f64_array.len(),
-                &raw const validity,
-                &raw mut error,
-            );
-            assert_no_error(error);
-            assert!(!ffi_f64.is_null());
-            assert!(vx_array_is_primitive(ffi_f64, vx_ptype::PTYPE_F64));
-            assert_eq!(vx_array_get_f64(ffi_f64, 0), f64::NEG_INFINITY);
-            assert_eq!(vx_array_get_f64(ffi_f64, 1), 0.0);
-            assert!(vx_array_get_f64(ffi_f64, 2).is_nan());
-            vx_array_free(ffi_f64);
-
-            // Test f16 (special half-precision type) - skip in Miri due to inline assembly
-            #[cfg(not(miri))]
-            {
-                let f16_array = [f16::from_f32(1.0), f16::from_f32(-0.5)];
-                let ffi_f16 = vx_array_new_primitive(
-                    vx_ptype::PTYPE_F16,
-                    f16_array.as_ptr() as *const c_void,
-                    f16_array.len(),
-                    &raw const validity,
-                    &raw mut error,
-                );
-                assert_no_error(error);
-                assert!(!ffi_f16.is_null());
-                assert_eq!(vx_array_get_f16(ffi_f16, 0), f16::from_f32(1.0));
-                assert_eq!(vx_array_get_f16(ffi_f16, 1), f16::from_f32(-0.5));
-                vx_array_free(ffi_f16);
-            }
-        }
-    }
-
-    #[test]
-    // TODO(joe): enable once this is fixed https://github.com/Amanieu/parking_lot/issues/477
-    #[cfg_attr(miri, ignore)]
-    fn test_utf8_binary_at() {
-        unsafe {
-            let long = "a string that is longer than twelve bytes";
-            let utf8_array =
-                VarBinViewArray::from_iter_nullable_str([Some("hello"), None, Some(long)]);
-            let ffi_array = vx_array::new(utf8_array.into_array());
-
-            let mut error = ptr::null_mut();
-            let inlined = vx_array_utf8_at(ffi_array, 0, &raw mut error);
-            assert!(error.is_null());
-            assert_eq!(inlined.as_str().unwrap(), "hello");
-
-            vx_array_utf8_at(ffi_array, 1, &raw mut error);
-            assert!(error.is_null());
-
-            let buffered = vx_array_utf8_at(ffi_array, 2, &raw mut error);
-            assert!(error.is_null());
-            assert_eq!(buffered.as_str().unwrap(), long);
-
-            vx_array_utf8_at(ffi_array, 3, &raw mut error);
-            assert_error(error);
-
-            vx_array_free(ffi_array);
-
-            let numbers =
-                PrimitiveArray::new(buffer![1i32, 2i32], Validity::NonNullable).into_array();
-            let ffi_array = vx_array::new(numbers);
-            let value = vx_array_utf8_at(ffi_array, 0, &raw mut error);
-            assert!(value.ptr.is_null());
-            assert_error(error);
-            vx_array_free(ffi_array);
-
-            let binary_array = VarBinViewArray::from_iter_bin(vec![vec![0x01, 0x02, 0x03]]);
-            let ffi_array = vx_array::new(binary_array.into_array());
-            let bin = vx_array_binary_at(ffi_array, 0, &raw mut error);
-            assert!(error.is_null());
-            assert_eq!(bin.as_bytes().unwrap(), &[0x01, 0x02, 0x03]);
-            vx_array_free(ffi_array);
+            vx_session_free(session);
         }
     }
 
@@ -1049,6 +946,8 @@ mod tests {
         assert!(!vx.is_null());
 
         unsafe {
+            let session = vx_session_new();
+
             assert!(vx_array_has_dtype(vx, vx_dtype_variant::DTYPE_STRUCT));
             assert_eq!(vx_array_len(vx), 3);
             assert!(!vx_array_is_nullable(vx));
@@ -1056,31 +955,19 @@ mod tests {
             let a = vx_array_get_field(vx, 0, &raw mut error);
             assert_no_error(error);
             assert!(vx_array_is_primitive(a, vx_ptype::PTYPE_I32));
-            assert_eq!(vx_array_get_i32(a, 0), 1);
-            assert_eq!(vx_array_get_i32(a, 2), 3);
+            assert_eq!(get_i32(session, a, 0), 1);
+            assert_eq!(get_i32(session, a, 2), 3);
             vx_array_free(a);
 
             let b = vx_array_get_field(vx, 1, &raw mut error);
             assert_no_error(error);
             assert!(vx_array_has_dtype(b, vx_dtype_variant::DTYPE_UTF8));
-            assert!(vx_array_element_is_invalid(b, 1, &raw mut error));
+            assert!(vx_array_element_is_invalid(session, b, 1, &raw mut error));
             assert_no_error(error);
             vx_array_free(b);
 
             vx_array_free(vx);
-        }
-    }
-
-    #[test]
-    #[cfg_attr(miri, ignore)]
-    fn test_get_bool() {
-        let bools = BoolArray::from_iter([true, false, true]);
-        unsafe {
-            let array = vx_array::new(bools.into_array());
-            assert!(vx_array_get_bool(array, 0));
-            assert!(!vx_array_get_bool(array, 1));
-            assert!(vx_array_get_bool(array, 2));
-            vx_array_free(array);
+            vx_session_free(session);
         }
     }
 

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -825,6 +825,49 @@ mod tests {
             vx_session_free(session);
         }
     }
+    #[test]
+    // TODO(joe): enable once this is fixed https://github.com/Amanieu/parking_lot/issues/477
+    #[cfg_attr(miri, ignore)]
+    fn test_utf8_binary_at() {
+        unsafe {
+            let long = "a string that is longer than twelve bytes";
+            let utf8_array =
+                VarBinViewArray::from_iter_nullable_str([Some("hello"), None, Some(long)]);
+            let ffi_array = vx_array::new(utf8_array.into_array());
+
+            let mut error = ptr::null_mut();
+            let inlined = vx_array_utf8_at(ffi_array, 0, &raw mut error);
+            assert!(error.is_null());
+            assert_eq!(inlined.as_str().unwrap(), "hello");
+
+            vx_array_utf8_at(ffi_array, 1, &raw mut error);
+            assert!(error.is_null());
+
+            let buffered = vx_array_utf8_at(ffi_array, 2, &raw mut error);
+            assert!(error.is_null());
+            assert_eq!(buffered.as_str().unwrap(), long);
+
+            vx_array_utf8_at(ffi_array, 3, &raw mut error);
+            assert_error(error);
+
+            vx_array_free(ffi_array);
+
+            let numbers =
+                PrimitiveArray::new(buffer![1i32, 2i32], Validity::NonNullable).into_array();
+            let ffi_array = vx_array::new(numbers);
+            let value = vx_array_utf8_at(ffi_array, 0, &raw mut error);
+            assert!(value.ptr.is_null());
+            assert_error(error);
+            vx_array_free(ffi_array);
+
+            let binary_array = VarBinViewArray::from_iter_bin(vec![vec![0x01, 0x02, 0x03]]);
+            let ffi_array = vx_array::new(binary_array.into_array());
+            let bin = vx_array_binary_at(ffi_array, 0, &raw mut error);
+            assert!(error.is_null());
+            assert_eq!(bin.as_bytes().unwrap(), &[0x01, 0x02, 0x03]);
+            vx_array_free(ffi_array);
+        }
+    }
 
     #[test]
     #[cfg_attr(miri, ignore)]
@@ -1102,6 +1145,19 @@ mod tests {
             assert!(bits.is_null());
             assert_error(error);
 
+            vx_array_free(array);
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_get_bool() {
+        let bools = BoolArray::from_iter([true, false, true]);
+        unsafe {
+            let array = vx_array::new(bools.into_array());
+            assert!(vx_array_get_bool(array, 0));
+            assert!(!vx_array_get_bool(array, 1));
+            assert!(vx_array_get_bool(array, 2));
             vx_array_free(array);
         }
     }

--- a/vortex-ffi/src/scalar.rs
+++ b/vortex-ffi/src/scalar.rs
@@ -125,6 +125,19 @@ pub unsafe extern "C-unwind" fn vx_scalar_new_f16_bits(
     ))
 }
 
+/// Return 16-bit floating point value stored in scalar.
+/// The value is read into raw uint16_t.
+///
+/// Panics if scalar is not a primitive scalar of this type or is null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_get_f16_bits(scalar: *const vx_scalar) -> u16 {
+    let value = vx_scalar::as_ref(scalar)
+        .as_primitive()
+        .typed_value::<f16>()
+        .vortex_expect("scalar is null or not a u16");
+    f16::to_bits(value)
+}
+
 /// Create a UTF-8 scalar.
 ///
 /// "value" bytes are copied into scalar.

--- a/vortex-ffi/src/scalar.rs
+++ b/vortex-ffi/src/scalar.rs
@@ -1,18 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! FFI interface for working with Vortex scalar values.
-
 use std::ptr;
 use std::slice;
-use std::str;
 use std::sync::Arc;
 
+use paste::paste;
 use vortex::dtype::DType;
 use vortex::dtype::DecimalDType;
 use vortex::dtype::Nullability;
 use vortex::dtype::half::f16;
 use vortex::dtype::i256;
+use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
 use vortex::error::vortex_ensure;
@@ -28,7 +27,10 @@ use crate::string::vx_view;
 
 box_wrapper!(
     /// A vx_scalar is a single value with an associated vx_dtype.
+    ///
     /// Scalar value may be Null is vx_dtype is nullable.
+    /// One example where you can get a Null scalar is vx_array_get_scalar
+    /// where the element at some index is invalid/null.
     Scalar,
     vx_scalar
 );
@@ -45,7 +47,7 @@ pub unsafe extern "C-unwind" fn vx_scalar_dtype(scalar: *const vx_scalar) -> *co
     vx_dtype::new(vx_scalar::as_ref(scalar).dtype().clone())
 }
 
-/// Return whether scalar is a typed null value.
+/// Return whether scalar is a typed Null value.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_scalar_is_null(scalar: *const vx_scalar) -> bool {
     vx_scalar::as_ref(scalar).is_null()
@@ -60,70 +62,58 @@ pub unsafe extern "C-unwind" fn vx_scalar_new_bool(
     vx_scalar::new(Scalar::bool(value, Nullability::from(is_nullable)))
 }
 
-/// Create an unsigned 8-bit integer scalar.
+/// Return the boolean value stored in the scalar.
+///
+/// Panics if the scalar is not a Bool scalar, or is null.
 #[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_scalar_new_u8(value: u8, is_nullable: bool) -> *mut vx_scalar {
-    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
+pub unsafe extern "C-unwind" fn vx_scalar_get_bool(scalar: *const vx_scalar) -> bool {
+    vx_scalar::as_ref(scalar)
+        .as_bool()
+        .value()
+        .vortex_expect("scalar is null or not a bool")
 }
 
-/// Create an unsigned 16-bit integer scalar.
-#[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_scalar_new_u16(value: u16, is_nullable: bool) -> *mut vx_scalar {
-    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
+macro_rules! scalar_primitive {
+    ($ptype:ident) => {
+        paste! {
+            #[doc = concat!(" Create a ", stringify!($ptype), " scalar.")]
+            #[unsafe(no_mangle)]
+            pub unsafe extern "C-unwind" fn [<vx_scalar_new_ $ptype>](
+                value: $ptype,
+                is_nullable: bool,
+            ) -> *mut vx_scalar {
+                vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
+            }
+
+            #[doc = concat!(" Return ", stringify!($ptype), " value stored in scalar.")]
+            ///
+            /// Panics if scalar is not a primitive scalar of this type or is null.
+            #[unsafe(no_mangle)]
+            pub unsafe extern "C-unwind" fn [<vx_scalar_get_ $ptype>](
+                scalar: *const vx_scalar,
+            ) -> $ptype {
+                vx_scalar::as_ref(scalar)
+                    .as_primitive()
+                    .typed_value::<$ptype>()
+                    .vortex_expect(concat!("scalar is null or not a ", stringify!($ptype)))
+            }
+        }
+    };
 }
 
-/// Create an unsigned 32-bit integer scalar.
-#[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_scalar_new_u32(value: u32, is_nullable: bool) -> *mut vx_scalar {
-    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
-}
-
-/// Create an unsigned 64-bit integer scalar.
-#[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_scalar_new_u64(value: u64, is_nullable: bool) -> *mut vx_scalar {
-    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
-}
-
-/// Create a signed 8-bit integer scalar.
-#[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_scalar_new_i8(value: i8, is_nullable: bool) -> *mut vx_scalar {
-    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
-}
-
-/// Create a signed 16-bit integer scalar.
-#[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_scalar_new_i16(value: i16, is_nullable: bool) -> *mut vx_scalar {
-    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
-}
-
-/// Create a signed 32-bit integer scalar.
-#[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_scalar_new_i32(value: i32, is_nullable: bool) -> *mut vx_scalar {
-    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
-}
-
-/// Create a signed 64-bit integer scalar.
-#[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_scalar_new_i64(value: i64, is_nullable: bool) -> *mut vx_scalar {
-    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
-}
-
-/// Create a 32-bit floating point scalar.
-#[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_scalar_new_f32(value: f32, is_nullable: bool) -> *mut vx_scalar {
-    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
-}
-
-/// Create a 64-bit floating point scalar.
-#[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_scalar_new_f64(value: f64, is_nullable: bool) -> *mut vx_scalar {
-    vx_scalar::new(Scalar::primitive(value, Nullability::from(is_nullable)))
-}
+scalar_primitive!(u8);
+scalar_primitive!(u16);
+scalar_primitive!(u32);
+scalar_primitive!(u64);
+scalar_primitive!(i8);
+scalar_primitive!(i16);
+scalar_primitive!(i32);
+scalar_primitive!(i64);
+scalar_primitive!(f32);
+scalar_primitive!(f64);
 
 /// Create a 16-bit floating point scalar.
-///
-/// The value is read from raw half-precision bits because C has no portable
-/// half-precision floating point ABI.
+/// The value is read from raw uint16_t.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_scalar_new_f16_bits(
     bits: u16,
@@ -137,8 +127,8 @@ pub unsafe extern "C-unwind" fn vx_scalar_new_f16_bits(
 
 /// Create a UTF-8 scalar.
 ///
-/// The string bytes are copied into the scalar. Invalid UTF-8 returns NULL and
-/// writes the error output.
+/// "value" bytes are copied into scalar.
+/// Errors on invalid UTF-8.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_scalar_new_utf8(
     value: vx_view,
@@ -156,8 +146,9 @@ pub unsafe extern "C-unwind" fn vx_scalar_new_utf8(
 
 /// Create a binary scalar.
 ///
-/// The byte range is copied into the scalar. NULL "ptr" is allowed only when
-/// len == 0.
+/// Byte range is copied into the scalar.
+///
+/// NULL "ptr" is allowed only when len == 0.
 ///
 /// Returns NULL and sets "err" on error.
 #[unsafe(no_mangle)]
@@ -174,6 +165,34 @@ pub unsafe extern "C-unwind" fn vx_scalar_new_binary(
             Nullability::from(is_nullable),
         )))
     })
+}
+
+/// Return UTF-8 string stored in scalar.
+///
+/// Returned view borrows the scalar and is valid as long as "scalar" is valid.
+///
+/// Panics if scalar is not a Utf8 scalar, or is null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_get_utf8(scalar: *const vx_scalar) -> vx_view {
+    let value = vx_scalar::as_ref(scalar)
+        .as_utf8()
+        .value()
+        .vortex_expect("scalar is null or not a utf8");
+    vx_view::from_str(value.as_str())
+}
+
+/// Return binary bytes stored in the scalar.
+///
+/// Returned view borrows scalar and is valid as long as "scalar" is valid.
+///
+/// Panics if scalar is not a Binary scalar, or is null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_scalar_get_binary(scalar: *const vx_scalar) -> vx_view {
+    let value = vx_scalar::as_ref(scalar)
+        .as_binary()
+        .value()
+        .vortex_expect("scalar is null or not a binary");
+    vx_view::from_bytes(value.as_slice())
 }
 
 /// Create a typed null scalar.
@@ -194,77 +213,55 @@ pub unsafe extern "C-unwind" fn vx_scalar_new_null(
     })
 }
 
-/// Create a decimal scalar.
-///
-/// The unscaled value is provided as a signed 8-bit integer.
-///
-/// Returns NULL and sets "err" on error.
-#[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_scalar_new_decimal_i8(
-    value: i8,
-    precision: u8,
-    scale: i8,
-    is_nullable: bool,
-    err: *mut *mut vx_error,
-) -> *mut vx_scalar {
-    try_or(err, ptr::null_mut(), || {
-        decimal_scalar_from_value(DecimalValue::I8(value), precision, scale, is_nullable)
-    })
+macro_rules! scalar_decimal {
+    ($int:ident, $variant:ident) => {
+        paste! {
+            #[doc = concat!(" Create a decimal scalar from a signed ", stringify!($int), " unscaled value.")]
+            ///
+            /// Returns NULL and sets "err" on error.
+            #[unsafe(no_mangle)]
+            pub unsafe extern "C-unwind" fn [<vx_scalar_new_decimal_ $int>](
+                value: $int,
+                precision: u8,
+                scale: i8,
+                is_nullable: bool,
+                err: *mut *mut vx_error,
+            ) -> *mut vx_scalar {
+                try_or(err, ptr::null_mut(), || {
+                    decimal_scalar_from_value(
+                        DecimalValue::$variant(value),
+                        precision,
+                        scale,
+                        is_nullable,
+                    )
+                })
+            }
+
+            #[doc = concat!(" Return the unscaled ", stringify!($int), " value of a decimal scalar.")]
+            ///
+            /// Panics if the scalar is not a decimal scalar, is null, or the
+            #[doc = concat!(" unscaled value does not fit in ", stringify!($int), ".")]
+            #[unsafe(no_mangle)]
+            pub unsafe extern "C-unwind" fn [<vx_scalar_get_decimal_ $int>](
+                scalar: *const vx_scalar,
+            ) -> $int {
+                vx_scalar::as_ref(scalar)
+                    .as_decimal()
+                    .decimal_value()
+                    .and_then(|value| value.cast::<$int>())
+                    .vortex_expect(concat!(
+                        "scalar is null or its decimal value does not fit in ",
+                        stringify!($int)
+                    ))
+            }
+        }
+    };
 }
 
-/// Create a decimal scalar.
-///
-/// The unscaled value is provided as a signed 16-bit integer.
-///
-/// Returns NULL and sets "err" on error.
-#[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_scalar_new_decimal_i16(
-    value: i16,
-    precision: u8,
-    scale: i8,
-    is_nullable: bool,
-    err: *mut *mut vx_error,
-) -> *mut vx_scalar {
-    try_or(err, ptr::null_mut(), || {
-        decimal_scalar_from_value(DecimalValue::I16(value), precision, scale, is_nullable)
-    })
-}
-
-/// Create a decimal scalar.
-///
-/// The unscaled value is provided as a signed 32-bit integer.
-///
-/// Returns NULL and sets "err" on error.
-#[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_scalar_new_decimal_i32(
-    value: i32,
-    precision: u8,
-    scale: i8,
-    is_nullable: bool,
-    err: *mut *mut vx_error,
-) -> *mut vx_scalar {
-    try_or(err, ptr::null_mut(), || {
-        decimal_scalar_from_value(DecimalValue::I32(value), precision, scale, is_nullable)
-    })
-}
-
-/// Create a decimal scalar.
-///
-/// The unscaled value is provided as a signed 64-bit integer.
-///
-/// Returns NULL and sets "err" on error.
-#[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_scalar_new_decimal_i64(
-    value: i64,
-    precision: u8,
-    scale: i8,
-    is_nullable: bool,
-    err: *mut *mut vx_error,
-) -> *mut vx_scalar {
-    try_or(err, ptr::null_mut(), || {
-        decimal_scalar_from_value(DecimalValue::I64(value), precision, scale, is_nullable)
-    })
-}
+scalar_decimal!(i8, I8);
+scalar_decimal!(i16, I16);
+scalar_decimal!(i32, I32);
+scalar_decimal!(i64, I64);
 
 /// Create a decimal scalar.
 ///
@@ -439,6 +436,10 @@ mod tests {
     use std::ptr;
     use std::sync::Arc;
 
+    use vortex::array::IntoArray;
+    use vortex::array::arrays::PrimitiveArray;
+    use vortex::array::validity::Validity;
+    use vortex::buffer::buffer;
     use vortex::dtype::DType;
     use vortex::dtype::DecimalDType;
     use vortex::dtype::Nullability;
@@ -448,40 +449,16 @@ mod tests {
     use vortex::scalar::DecimalValue;
     use vortex::scalar::Scalar;
 
+    use crate::array::*;
     use crate::dtype::vx_dtype;
     use crate::dtype::vx_dtype_free;
     use crate::dtype::vx_dtype_new_bool;
     use crate::dtype::vx_dtype_new_primitive;
     use crate::ptype::vx_ptype;
-    use crate::scalar::vx_scalar;
-    use crate::scalar::vx_scalar_clone;
-    use crate::scalar::vx_scalar_dtype;
-    use crate::scalar::vx_scalar_free;
-    use crate::scalar::vx_scalar_is_null;
-    use crate::scalar::vx_scalar_new_binary;
-    use crate::scalar::vx_scalar_new_bool;
-    use crate::scalar::vx_scalar_new_decimal_i8;
-    use crate::scalar::vx_scalar_new_decimal_i16;
-    use crate::scalar::vx_scalar_new_decimal_i32;
-    use crate::scalar::vx_scalar_new_decimal_i64;
-    use crate::scalar::vx_scalar_new_decimal_i128_le;
-    use crate::scalar::vx_scalar_new_decimal_i256_le;
-    use crate::scalar::vx_scalar_new_f16_bits;
-    use crate::scalar::vx_scalar_new_f32;
-    use crate::scalar::vx_scalar_new_f64;
-    use crate::scalar::vx_scalar_new_fixed_size_list;
-    use crate::scalar::vx_scalar_new_i8;
-    use crate::scalar::vx_scalar_new_i16;
-    use crate::scalar::vx_scalar_new_i32;
-    use crate::scalar::vx_scalar_new_i64;
-    use crate::scalar::vx_scalar_new_list;
-    use crate::scalar::vx_scalar_new_null;
-    use crate::scalar::vx_scalar_new_struct;
-    use crate::scalar::vx_scalar_new_u8;
-    use crate::scalar::vx_scalar_new_u16;
-    use crate::scalar::vx_scalar_new_u32;
-    use crate::scalar::vx_scalar_new_u64;
-    use crate::scalar::vx_scalar_new_utf8;
+    use crate::scalar::*;
+    use crate::session::vx_session;
+    use crate::session::vx_session_free;
+    use crate::session::vx_session_new;
     use crate::string::vx_view;
     use crate::tests::assert_error;
     use crate::tests::assert_no_error;
@@ -653,7 +630,7 @@ mod tests {
             );
             assert_no_error(error);
 
-            let i256_value = vortex::dtype::i256::from_i128(12345);
+            let i256_value = i256::from_i128(12345);
             assert_scalar(
                 vx_scalar_new_decimal_i256_le(
                     i256_value.to_le_bytes().as_ptr(),
@@ -799,6 +776,113 @@ mod tests {
             assert!(!empty.is_null());
             vx_scalar_free(empty);
             vx_dtype_free(dtype);
+        }
+    }
+
+    #[test]
+    // TODO(joe): enable once this is fixed https://github.com/Amanieu/parking_lot/issues/477
+    #[cfg_attr(miri, ignore)]
+    fn test_array_scalar_getters() {
+        unsafe fn get_i32(session: *const vx_session, array: *const vx_array, index: usize) -> i32 {
+            let mut error = ptr::null_mut();
+            let scalar = unsafe { vx_array_get_scalar(session, array, index, &raw mut error) };
+            assert_no_error(error);
+            let value = unsafe { vx_scalar_get_i32(scalar) };
+            unsafe { vx_scalar_free(scalar.cast_mut()) };
+            value
+        }
+
+        unsafe fn get_f64(session: *const vx_session, array: *const vx_array, index: usize) -> f64 {
+            let mut error = ptr::null_mut();
+            let scalar = unsafe { vx_array_get_scalar(session, array, index, &raw mut error) };
+            assert_no_error(error);
+            let value = unsafe { vx_scalar_get_f64(scalar) };
+            unsafe { vx_scalar_free(scalar.cast_mut()) };
+            value
+        }
+
+        unsafe {
+            let session = vx_session_new();
+
+            let i32_array =
+                PrimitiveArray::new(buffer![i32::MAX, i32::MIN, 0], Validity::NonNullable)
+                    .into_array();
+            let ffi_i32 = vx_array::new(i32_array);
+            assert!(vx_array_is_primitive(ffi_i32, vx_ptype::PTYPE_I32));
+            assert_eq!(get_i32(session, ffi_i32, 0), i32::MAX);
+            assert_eq!(get_i32(session, ffi_i32, 1), i32::MIN);
+            assert_eq!(get_i32(session, ffi_i32, 2), 0);
+            vx_array_free(ffi_i32);
+
+            let f64_array = PrimitiveArray::new(
+                buffer![f64::NEG_INFINITY, 0.0f64, f64::NAN],
+                Validity::NonNullable,
+            )
+            .into_array();
+            let ffi_f64 = vx_array::new(f64_array);
+            assert_eq!(get_f64(session, ffi_f64, 0), f64::NEG_INFINITY);
+            assert_eq!(get_f64(session, ffi_f64, 1), 0.0);
+            assert!(get_f64(session, ffi_f64, 2).is_nan());
+            vx_array_free(ffi_f64);
+
+            vx_session_free(session);
+        }
+    }
+
+    #[test]
+    fn test_scalar_primitive_getters() {
+        unsafe {
+            let s = vx_scalar_new_i32(-42, false);
+            assert_eq!(vx_scalar_get_i32(s), -42);
+            vx_scalar_free(s);
+
+            let s = vx_scalar_new_u64(u64::MAX, true);
+            assert_eq!(vx_scalar_get_u64(s), u64::MAX);
+            vx_scalar_free(s);
+
+            let s = vx_scalar_new_f64(1.5, false);
+            assert_eq!(vx_scalar_get_f64(s), 1.5);
+            vx_scalar_free(s);
+
+            let s = vx_scalar_new_bool(true, false);
+            assert!(vx_scalar_get_bool(s));
+            vx_scalar_free(s);
+        }
+    }
+
+    #[test]
+    fn test_scalar_string_getters() {
+        unsafe {
+            let mut error = ptr::null_mut();
+
+            let value = "hello";
+            let s = vx_scalar_new_utf8(vx_view::from_str(value), false, &raw mut error);
+            assert_no_error(error);
+            assert_eq!(vx_scalar_get_utf8(s).as_str().unwrap(), value);
+            vx_scalar_free(s);
+
+            let bytes = b"\xde\xad\xbe\xef";
+            let s = vx_scalar_new_binary(bytes.as_ptr(), bytes.len(), false, &raw mut error);
+            assert_no_error(error);
+            assert_eq!(vx_scalar_get_binary(s).as_bytes().unwrap(), bytes);
+            vx_scalar_free(s);
+        }
+    }
+
+    #[test]
+    fn test_scalar_decimal_getters() {
+        unsafe {
+            let mut error = ptr::null_mut();
+
+            let s = vx_scalar_new_decimal_i32(1234, 5, 2, false, &raw mut error);
+            assert_no_error(error);
+            assert_eq!(vx_scalar_get_decimal_i32(s), 1234);
+            vx_scalar_free(s);
+
+            let s = vx_scalar_new_decimal_i64(99999, 12, 3, false, &raw mut error);
+            assert_no_error(error);
+            assert_eq!(vx_scalar_get_decimal_i64(s), 99999);
+            vx_scalar_free(s);
         }
     }
 }

--- a/vortex-ffi/test/array.cpp
+++ b/vortex-ffi/test/array.cpp
@@ -19,6 +19,11 @@ TEST_CASE("Null array creation", "[array]") {
 }
 
 TEST_CASE("Primitive array creation", "[array]") {
+    vx_session *session = vx_session_new();
+    defer {
+        vx_session_free(session);
+    };
+
     std::vector<uint8_t> buffer(20, 1);
     buffer[3] = 8;
 
@@ -39,13 +44,13 @@ TEST_CASE("Primitive array creation", "[array]") {
     REQUIRE(vx_array_len(array) == buffer.size());
 
     for (size_t i = 0; i < buffer.size(); ++i) {
-        REQUIRE(buffer[i] == vx_array_get_u8(array, i));
+        REQUIRE(buffer[i] == array_get_u8(session, array, i));
     }
 
     buffer = {};
 
     for (size_t i = 0; i < 20; ++i) {
-        REQUIRE(vx_array_get_u8(array, i) == (i == 3 ? 8 : 1));
+        REQUIRE(array_get_u8(session, array, i) == (i == 3 ? 8 : 1));
     }
 
     vx_array_free(array);

--- a/vortex-ffi/test/common.h
+++ b/vortex-ffi/test/common.h
@@ -27,6 +27,24 @@ inline void require_no_error(vx_error *error, bool assert = true) {
     }
 }
 
+inline uint8_t array_get_u8(vx_session *session, const vx_array *array, size_t index) {
+    vx_error *error = nullptr;
+    const vx_scalar *scalar = vx_array_get_scalar(session, array, index, &error);
+    require_no_error(error);
+    const uint8_t value = vx_scalar_get_u8(scalar);
+    vx_scalar_free(scalar);
+    return value;
+}
+
+inline uint16_t array_get_u16(vx_session *session, const vx_array *array, size_t index) {
+    vx_error *error = nullptr;
+    const vx_scalar *scalar = vx_array_get_scalar(session, array, index, &error);
+    require_no_error(error);
+    const uint16_t value = vx_scalar_get_u16(scalar);
+    vx_scalar_free(scalar);
+    return value;
+}
+
 template <class F>
 struct Defer {
     Defer(F &&f) : f(std::move(f)) {

--- a/vortex-ffi/test/scalar.cpp
+++ b/vortex-ffi/test/scalar.cpp
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+#include <vortex.h>
+#include "common.h"
+
+using namespace std::string_view_literals;
+
+TEST_CASE("Primitive getters", "[scalar]") {
+    vx_scalar *u64 = vx_scalar_new_u64(UINT64_MAX, true);
+    defer {
+        vx_scalar_free(u64);
+    };
+    REQUIRE(vx_scalar_get_u64(u64) == UINT64_MAX);
+
+    vx_scalar *f64 = vx_scalar_new_f64(1.5, false);
+    defer {
+        vx_scalar_free(f64);
+    };
+    REQUIRE(vx_scalar_get_f64(f64) == 1.5);
+}
+
+TEST_CASE("String getters", "[scalar]") {
+    vx_error *error = nullptr;
+
+    const std::string_view text = "hello"sv;
+    vx_scalar *utf8 = vx_scalar_new_utf8(vx_view {text.data(), text.size()}, false, &error);
+    require_no_error(error);
+    defer {
+        vx_scalar_free(utf8);
+    };
+    REQUIRE(to_string_view(vx_scalar_get_utf8(utf8)) == text);
+
+    const uint8_t bytes[] = {0xde, 0xad, 0xbe, 0xef};
+    vx_scalar *binary = vx_scalar_new_binary(bytes, sizeof(bytes), false, &error);
+    require_no_error(error);
+    defer {
+        vx_scalar_free(binary);
+    };
+    const vx_view view = vx_scalar_get_binary(binary);
+    REQUIRE(view.len == sizeof(bytes));
+    REQUIRE(std::memcmp(view.ptr, bytes, sizeof(bytes)) == 0);
+}
+
+TEST_CASE("Decimal getters", "[scalar]") {
+    vx_error *error = nullptr;
+
+    vx_scalar *d32 = vx_scalar_new_decimal_i32(1234, 5, 2, false, &error);
+    require_no_error(error);
+    defer {
+        vx_scalar_free(d32);
+    };
+    REQUIRE(vx_scalar_get_decimal_i32(d32) == 1234);
+
+    vx_scalar *d64 = vx_scalar_new_decimal_i64(99999, 12, 3, false, &error);
+    require_no_error(error);
+    defer {
+        vx_scalar_free(d64);
+    };
+    REQUIRE(vx_scalar_get_decimal_i64(d64) == 99999);
+}

--- a/vortex-ffi/test/scan.cpp
+++ b/vortex-ffi/test/scan.cpp
@@ -302,7 +302,7 @@ TEST_CASE("Write file and read dtypes", "[datasource]") {
     REQUIRE(to_string_view(height_name) == "height");
 }
 
-void verify_age_field(const vx_array *age_field) {
+void verify_age_field(vx_session *session, const vx_array *age_field) {
     REQUIRE(vx_array_has_dtype(age_field, DTYPE_PRIMITIVE));
     const vx_dtype *dtype = vx_array_dtype(age_field);
     defer {
@@ -311,11 +311,11 @@ void verify_age_field(const vx_array *age_field) {
     REQUIRE(vx_dtype_primitive_ptype(dtype) == PTYPE_U8);
     REQUIRE(vx_array_len(age_field) == SAMPLE_ROWS);
     for (size_t i = 0; i < SAMPLE_ROWS; ++i) {
-        REQUIRE(vx_array_get_u8(age_field, i) == i);
+        REQUIRE(array_get_u8(session, age_field, i) == i);
     }
 }
 
-void verify_height_field(const vx_array *height_field) {
+void verify_height_field(vx_session *session, const vx_array *height_field) {
     REQUIRE(vx_array_has_dtype(height_field, DTYPE_PRIMITIVE));
     const vx_dtype *dtype = vx_array_dtype(height_field);
     defer {
@@ -324,11 +324,11 @@ void verify_height_field(const vx_array *height_field) {
     REQUIRE(vx_dtype_primitive_ptype(dtype) == PTYPE_U16);
     REQUIRE(vx_array_len(height_field) == SAMPLE_ROWS);
     for (size_t i = 0; i < SAMPLE_ROWS; ++i) {
-        REQUIRE(vx_array_get_u16(height_field, i) > 0);
+        REQUIRE(array_get_u16(session, height_field, i) > 0);
     }
 }
 
-void verify_sample_array(const vx_array *array) {
+void verify_sample_array(vx_session *session, const vx_array *array) {
     REQUIRE(vx_array_len(array) == SAMPLE_ROWS);
     REQUIRE(vx_array_has_dtype(array, DTYPE_STRUCT));
 
@@ -363,12 +363,12 @@ void verify_sample_array(const vx_array *array) {
 
     const vx_array *age_field = vx_array_get_field(array, 0, &error);
     require_no_error(error);
-    verify_age_field(age_field);
+    verify_age_field(session, age_field);
     vx_array_free(age_field);
 
     const vx_array *height_field = vx_array_get_field(array, 1, &error);
     require_no_error(error);
-    verify_height_field(height_field);
+    verify_height_field(session, height_field);
     vx_array_free(height_field);
 
     REQUIRE(vx_array_get_field(array, 2, &error) == nullptr);
@@ -413,7 +413,7 @@ TEST_CASE("Requesting scans", "[datasource]") {
     }
 }
 
-void basic_scan(const vx_data_source *ds) {
+void basic_scan(vx_session *session, const vx_data_source *ds) {
     vx_error *error = nullptr;
     vx_estimate estimate = {};
     vx_scan *scan = vx_data_source_scan(ds, nullptr, &estimate, &error);
@@ -450,7 +450,7 @@ void basic_scan(const vx_data_source *ds) {
     REQUIRE(vx_partition_next(partition, &error) == nullptr);
     require_no_error(error);
 
-    verify_sample_array(array);
+    verify_sample_array(session, array);
 }
 
 TEST_CASE("Basic scan", "[datasource]") {
@@ -472,7 +472,7 @@ TEST_CASE("Basic scan", "[datasource]") {
         vx_data_source_free(ds);
     };
 
-    basic_scan(ds);
+    basic_scan(session, ds);
 }
 
 TEST_CASE("Basic scan from memory", "[datasource]") {
@@ -496,7 +496,7 @@ TEST_CASE("Basic scan from memory", "[datasource]") {
         vx_data_source_free(ds);
     };
 
-    basic_scan(ds);
+    basic_scan(session, ds);
 }
 
 TEST_CASE("Multithreaded scan", "[datasource]") {
@@ -590,15 +590,11 @@ TEST_CASE("Multithreaded scan", "[datasource]") {
         defer {
             vx_array_free(array);
         };
-        verify_sample_array(array);
+        verify_sample_array(session, array);
     }
 }
 
-const vx_array *scan_with_options(vx_scan_options &options) {
-    vx_session *session = vx_session_new();
-    defer {
-        vx_session_free(session);
-    };
+const vx_array *scan_with_options(vx_session *session, vx_scan_options &options) {
     TempPath path = write_sample(session);
     vx_error *error = nullptr;
 
@@ -636,29 +632,41 @@ const vx_array *scan_with_options(vx_scan_options &options) {
 }
 
 TEST_CASE("Project all fields", "[projection]") {
+    vx_session *session = vx_session_new();
+    defer {
+        vx_session_free(session);
+    };
     vx_scan_options opts = {};
-    const vx_array *array = scan_with_options(opts);
+    const vx_array *array = scan_with_options(session, opts);
     defer {
         vx_array_free(array);
     };
-    verify_sample_array(array);
+    verify_sample_array(session, array);
 }
 
 TEST_CASE("Project root", "[projection]") {
+    vx_session *session = vx_session_new();
+    defer {
+        vx_session_free(session);
+    };
     vx_expression *root = vx_expression_root();
     defer {
         vx_expression_free(root);
     };
     vx_scan_options opts = {};
     opts.projection = root;
-    const vx_array *array = scan_with_options(opts);
+    const vx_array *array = scan_with_options(session, opts);
     defer {
         vx_array_free(array);
     };
-    verify_sample_array(array);
+    verify_sample_array(session, array);
 }
 
 TEST_CASE("Project single field", "[projection]") {
+    vx_session *session = vx_session_new();
+    defer {
+        vx_session_free(session);
+    };
     vx_expression *root = vx_expression_root();
     defer {
         vx_expression_free(root);
@@ -673,11 +681,11 @@ TEST_CASE("Project single field", "[projection]") {
 
     {
         opts.projection = age_field;
-        const vx_array *array = scan_with_options(opts);
+        const vx_array *array = scan_with_options(session, opts);
         defer {
             vx_array_free(array);
         };
-        verify_age_field(array);
+        verify_age_field(session, array);
     }
 
     vx_expression *height_field = vx_expression_get_item(vx_view_from_cstr("height"), root);
@@ -688,15 +696,19 @@ TEST_CASE("Project single field", "[projection]") {
 
     {
         opts.projection = height_field;
-        const vx_array *array = scan_with_options(opts);
+        const vx_array *array = scan_with_options(session, opts);
         defer {
             vx_array_free(array);
         };
-        verify_height_field(array);
+        verify_height_field(session, array);
     }
 }
 
 TEST_CASE("Filter with literal expression", "[filter]") {
+    vx_session *session = vx_session_new();
+    defer {
+        vx_session_free(session);
+    };
     vx_expression *root = vx_expression_root();
     defer {
         vx_expression_free(root);
@@ -731,7 +743,7 @@ TEST_CASE("Filter with literal expression", "[filter]") {
 
     vx_scan_options opts = {};
     opts.filter = filter;
-    const vx_array *array = scan_with_options(opts);
+    const vx_array *array = scan_with_options(session, opts);
     defer {
         vx_array_free(array);
     };
@@ -747,11 +759,15 @@ TEST_CASE("Filter with literal expression", "[filter]") {
     };
 
     for (size_t i = 0; i < vx_array_len(filtered_age); ++i) {
-        REQUIRE(vx_array_get_u8(filtered_age, i) == static_cast<uint8_t>(threshold + i));
+        REQUIRE(array_get_u8(session, filtered_age, i) == static_cast<uint8_t>(threshold + i));
     }
 }
 
 TEST_CASE("Project UTF-8 literal expression", "[projection]") {
+    vx_session *session = vx_session_new();
+    defer {
+        vx_session_free(session);
+    };
     constexpr auto value = "constant"sv;
     vx_error *scalar_error = nullptr;
     vx_scalar *literal_scalar =
@@ -772,17 +788,13 @@ TEST_CASE("Project UTF-8 literal expression", "[projection]") {
 
     vx_scan_options opts = {};
     opts.projection = literal_expr;
-    const vx_array *array = scan_with_options(opts);
+    const vx_array *array = scan_with_options(session, opts);
     defer {
         vx_array_free(array);
     };
 
     REQUIRE(vx_array_len(array) == SAMPLE_ROWS);
 
-    vx_session *session = vx_session_new();
-    defer {
-        vx_session_free(session);
-    };
     vx_error *canon_error = nullptr;
     const vx_array *canonical = vx_array_canonicalize(session, array, &canon_error);
     require_no_error(canon_error);


### PR DESCRIPTION
- Add vx_array_get_scalar method for retrieving vx_scalar.
- Add scalar's primitive, utf8, bool, and binary getters generated from a macro.
- Replace decimal scalar creation functions with a macro.
- Remove vx_array's primitive getters in favor of obtaining a vx_scalar.
- Add C++ API support for getting array's Scalar at index.
#7483