### PR TITLE
refactor[array]: serialization context filter by ids (not whole registry)

### DIFF
--- a/vortex-array/src/arrays/patched/vtable/mod.rs
+++ b/vortex-array/src/arrays/patched/vtable/mod.rs
@@ -588,7 +588,7 @@ mod tests {
         let session = array_session();
         session.arrays().register(Patched);
 
-        let ctx = ArrayContext::empty().with_registry(session.arrays().registry().clone());
+        let ctx = ArrayContext::empty().with_valid_ids(session.arrays().registry().ids());
         let serialized = array
             .serialize(&ctx, &session, &SerializeOptions::default())
             .unwrap();

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -190,4 +190,4 @@ pub fn legacy_session() -> &'static VortexSession {
     &LEGACY_SESSION
 }
 
-pub type ArrayContext = Context<ArrayPluginRef>;
+pub type ArrayContext = Context;

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -164,8 +164,8 @@ impl VortexWriteOptions {
         // parallel and with an empty context they can register their encodings to the context
         // in different order, changing the written bytes from run to run.
         let ctx = ArrayContext::new(ALLOWED_ENCODINGS.iter().cloned().sorted().collect())
-            // Configure a registry just to ensure only known encodings are interned.
-            .with_registry(self.session.arrays().registry().clone());
+            // Only permit encodings known to the session.
+            .with_valid_ids(self.session.arrays().registry().ids());
         let dtype = stream.dtype().clone();
 
         let (mut ptr, eof) = SequenceId::root().split();

--- a/vortex-layout/src/lib.rs
+++ b/vortex-layout/src/lib.rs
@@ -42,4 +42,4 @@ mod strategy;
 mod test;
 pub mod vtable;
 
-pub type LayoutContext = Context<LayoutEncodingRef>;
+pub type LayoutContext = Context;

--- a/vortex-session/src/registry.rs
+++ b/vortex-session/src/registry.rs
@@ -10,6 +10,7 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::hash::Hash;
+use std::marker::PhantomData;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -21,6 +22,7 @@ use parking_lot::RwLock;
 use vortex_error::VortexExpect;
 use vortex_utils::aliases::DefaultHashBuilder;
 use vortex_utils::aliases::dash_map::DashMap;
+use vortex_utils::aliases::hash_set::HashSet;
 
 /// Global string interner for [`Id`] values.
 static INTERNER: LazyLock<ThreadedRodeo<Spur, DefaultHashBuilder>> =
@@ -234,15 +236,17 @@ pub struct Context<T> {
     //  enum of Segment { Array, DType, Buffer } then we don't actually need a mutable context
     //  in the LayoutWriter, therefore we don't need a RwLock here and everyone is happier.
     ids: Arc<RwLock<Vec<Id>>>,
-    // Optional registry used to filter the permissible interned items.
-    registry: Option<Registry<T>>,
+    // Optional set used to filter the permissible interned IDs.
+    valid_ids: Option<Arc<HashSet<Id>>>,
+    _marker: PhantomData<fn() -> T>,
 }
 
 impl<T> Default for Context<T> {
     fn default() -> Self {
         Self {
             ids: Arc::new(RwLock::new(Vec::new())),
-            registry: None,
+            valid_ids: None,
+            _marker: PhantomData,
         }
     }
 }
@@ -252,7 +256,8 @@ impl<T: Clone> Context<T> {
     pub fn new(ids: Vec<Id>) -> Self {
         Self {
             ids: Arc::new(RwLock::new(ids)),
-            registry: None,
+            valid_ids: None,
+            _marker: PhantomData,
         }
     }
 
@@ -261,18 +266,25 @@ impl<T: Clone> Context<T> {
         Self::default()
     }
 
-    /// Configure a registry to restrict the permissible set of interned items.
-    pub fn with_registry(mut self, registry: Registry<T>) -> Self {
-        self.registry = Some(registry);
+    /// Restrict the permissible set of interned IDs.
+    pub fn with_valid_ids(mut self, ids: impl IntoIterator<Item = Id>) -> Self {
+        self.valid_ids = Some(Arc::new(ids.into_iter().collect()));
         self
+    }
+
+    /// Restrict the permissible set of interned IDs to the IDs currently in a registry.
+    ///
+    /// IDs registered after this call are not added to the context.
+    pub fn with_registry(self, registry: Registry<T>) -> Self {
+        self.with_valid_ids(registry.ids())
     }
 
     /// Intern an ID, returning its index.
     pub fn intern(&self, id: &Id) -> Option<u16> {
-        if let Some(registry) = &self.registry
-            && registry.find(id).is_none()
+        if let Some(valid_ids) = &self.valid_ids
+            && !valid_ids.contains(id)
         {
-            // ID not in registry, cannot intern.
+            // ID is not valid, cannot intern.
             return None;
         }
 
@@ -293,5 +305,26 @@ impl<T: Clone> Context<T> {
     /// Get the list of interned IDs.
     pub fn to_ids(&self) -> Vec<Id> {
         self.ids.read().clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CachedId;
+    use super::Context;
+
+    static VALID: CachedId = CachedId::new("vortex.test.valid");
+    static INVALID: CachedId = CachedId::new("vortex.test.invalid");
+
+    #[test]
+    fn context_filters_interned_ids() {
+        let valid = *VALID;
+        let invalid = *INVALID;
+        let context = Context::<()>::empty().with_valid_ids([valid]);
+
+        assert_eq!(context.intern(&valid), Some(0));
+        assert_eq!(context.intern(&valid), Some(0));
+        assert_eq!(context.intern(&invalid), None);
+        assert_eq!(context.to_ids(), [valid]);
     }
 }

--- a/vortex-session/src/registry.rs
+++ b/vortex-session/src/registry.rs
@@ -10,7 +10,6 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::hash::Hash;
-use std::marker::PhantomData;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -229,35 +228,32 @@ impl ReadContext {
 /// 1. This object holds an Arc of RwLock internally because we need concurrent access from the
 ///    layout writer code path. We should update SegmentSink to take an Array rather than
 ///    ByteBuffer such that serializing arrays is done sequentially.
-/// 2. The name is terrible. `Interner<T>` is better, but I want to minimize breakage for now.
+/// 2. The name is terrible. `Interner` is better, but I want to minimize breakage for now.
 #[derive(Clone, Debug)]
-pub struct Context<T> {
+pub struct Context {
     // TODO(ngates): it's a long story, but if we make SegmentSink and SegmentSource take an
     //  enum of Segment { Array, DType, Buffer } then we don't actually need a mutable context
     //  in the LayoutWriter, therefore we don't need a RwLock here and everyone is happier.
     ids: Arc<RwLock<Vec<Id>>>,
     // Optional set used to filter the permissible interned IDs.
     valid_ids: Option<Arc<HashSet<Id>>>,
-    _marker: PhantomData<fn() -> T>,
 }
 
-impl<T> Default for Context<T> {
+impl Default for Context {
     fn default() -> Self {
         Self {
             ids: Arc::new(RwLock::new(Vec::new())),
             valid_ids: None,
-            _marker: PhantomData,
         }
     }
 }
 
-impl<T: Clone> Context<T> {
+impl Context {
     /// Create a context with the given initial IDs.
     pub fn new(ids: Vec<Id>) -> Self {
         Self {
             ids: Arc::new(RwLock::new(ids)),
             valid_ids: None,
-            _marker: PhantomData,
         }
     }
 
@@ -270,13 +266,6 @@ impl<T: Clone> Context<T> {
     pub fn with_valid_ids(mut self, ids: impl IntoIterator<Item = Id>) -> Self {
         self.valid_ids = Some(Arc::new(ids.into_iter().collect()));
         self
-    }
-
-    /// Restrict the permissible set of interned IDs to the IDs currently in a registry.
-    ///
-    /// IDs registered after this call are not added to the context.
-    pub fn with_registry(self, registry: Registry<T>) -> Self {
-        self.with_valid_ids(registry.ids())
     }
 
     /// Intern an ID, returning its index.
@@ -320,7 +309,7 @@ mod tests {
     fn context_filters_interned_ids() {
         let valid = *VALID;
         let invalid = *INVALID;
-        let context = Context::<()>::empty().with_valid_ids([valid]);
+        let context = Context::empty().with_valid_ids([valid]);
 
         assert_eq!(context.intern(&valid), Some(0));
         assert_eq!(context.intern(&valid), Some(0));


### PR DESCRIPTION
The serialization context only needs registry IDs for filtering, so it now snapshots those IDs instead of retaining the entire registry.