### PR TITLE
Read the data child directly when the zone map is empty

### DIFF
--- a/vortex-layout/src/layouts/zoned/mod.rs
+++ b/vortex-layout/src/layouts/zoned/mod.rs
@@ -65,6 +65,35 @@ use crate::vtable;
 vtable!(Zoned);
 vtable!(LegacyStats);
 
+/// Builds a reader for a zoned layout, bypassing [`ZonedReader`] when the zone map is empty
+/// (`zone_len == 0`) and reading the data child directly, since there is nothing to prune with.
+/// This covers both legacy zero-length zones and layouts whose aggregates the session cannot
+/// reconstruct.
+fn zoned_reader(
+    layout: &ZonedLayout,
+    name: Arc<str>,
+    segment_source: Arc<dyn SegmentSource>,
+    session: &VortexSession,
+    ctx: &crate::LayoutReaderContext,
+) -> VortexResult<LayoutReaderRef> {
+    if layout.zone_len == 0 {
+        return layout.children.child(0, &layout.dtype)?.new_reader(
+            name,
+            segment_source,
+            session,
+            ctx,
+        );
+    }
+
+    Ok(Arc::new(ZonedReader::try_new(
+        layout.clone(),
+        name,
+        segment_source,
+        session.clone(),
+        ctx.clone(),
+    )?))
+}
+
 impl VTable for Zoned {
     type Layout = ZonedLayout;
     type Encoding = ZonedLayoutEncoding;
@@ -134,13 +163,7 @@ impl VTable for Zoned {
         session: &VortexSession,
         ctx: &crate::LayoutReaderContext,
     ) -> VortexResult<LayoutReaderRef> {
-        Ok(Arc::new(ZonedReader::try_new(
-            layout.clone(),
-            name,
-            segment_source,
-            session.clone(),
-            ctx.clone(),
-        )?))
+        zoned_reader(layout, name, segment_source, session, ctx)
     }
 
     fn build(
@@ -251,13 +274,7 @@ impl VTable for LegacyStats {
         session: &VortexSession,
         ctx: &crate::LayoutReaderContext,
     ) -> VortexResult<LayoutReaderRef> {
-        Ok(Arc::new(ZonedReader::try_new(
-            layout.0.clone(),
-            name,
-            segment_source,
-            session.clone(),
-            ctx.clone(),
-        )?))
+        zoned_reader(&layout.0, name, segment_source, session, ctx)
     }
 
     fn build(

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -72,8 +72,8 @@ impl ZonedReader {
 
     /// Get the range of zone IDs containing a row range.
     pub(crate) fn zone_range(&self, row_range: &Range<u64>) -> Range<u64> {
-        // Caller must ensure zone_len > 0. Legacy files may deserialize with zone_len == 0, but
-        // pruning_evaluation disables zoned pruning for those layouts before calling this helper.
+        // Callers rely on `zone_len > 0`. `new_reader` never constructs a `ZonedReader` for a
+        // zero-length zone map (it reads the data child directly), so this holds by construction.
         debug_assert!(self.layout.zone_len > 0, "zone_len must be > 0");
 
         let zone_len_u64 = self.layout.zone_len as u64;
@@ -127,11 +127,6 @@ impl LayoutReader for ZonedReader {
         let data_eval = self
             .data_child()?
             .pruning_evaluation(row_range, expr, mask.clone())?;
-
-        if self.layout.zone_len == 0 {
-            trace!("Stats pruning evaluation: skipping zoned pruning for legacy zero-length zones");
-            return Ok(data_eval);
-        }
 
         let Some(pruning_mask_future) = self.pruning.pruning_mask_future(expr.clone()) else {
             trace!("Stats pruning evaluation: not prune-able {expr}");
@@ -469,6 +464,21 @@ mod test {
                 .await?;
 
             assert!(result.all_true());
+
+            // The bypass returns the data child's reader, so projection reads the underlying data.
+            let projected = reader
+                .projection_evaluation(
+                    &(0..row_count),
+                    &root(),
+                    MaskFuture::new_true(row_count.try_into().unwrap()),
+                )?
+                .await?;
+            let mut ctx = array_session().create_execution_ctx();
+            assert_arrays_eq!(
+                projected,
+                buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9].into_array(),
+                &mut ctx
+            );
             Ok(())
         })
     }


### PR DESCRIPTION
## Rationale for this change

Tracking issue (only somewhat related): https://github.com/vortex-data/vortex/issues/8901

The unknown-aggregate fallback and the legacy zero-length-zone path both mean "no usable zone map", so they should read the data the same way. And I think it is fine to just remove the degenerate `ZonedLayout` parent.

## What changes are included in this PR?

When a `ZonedLayout` has `zone_len == 0`, `new_reader` returns the data child's reader directly instead of a passthrough `ZonedReader`, and the now-unreachable `zone_len == 0` branch in `ZonedReader` is removed. 

This shouldn't result in any behavior change.
