### PR TITLE
perf(cuda): decode FSST strings with GPU-built Arrow offsets

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -128,8 +128,8 @@ jobs:
       - name: Package CUB shared library
         run: |
           find target/release/build -path '*/out/libvortex_cub.so' \
-            -exec cp {} target/codspeed/libvortex_cub.so \;
-          test -f target/codspeed/libvortex_cub.so
+            -exec cp {} target/codspeed/walltime/vortex-cuda/libvortex_cub.so \;
+          test -f target/codspeed/walltime/vortex-cuda/libvortex_cub.so
       - name: Upload benchmark executables
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -125,6 +125,11 @@ jobs:
             --bench fsst_cuda \
             --bench runend_cuda \
             --profile bench
+      - name: Package CUB shared library
+        run: |
+          find target/release/build -path '*/out/libvortex_cub.so' \
+            -exec cp {} target/codspeed/libvortex_cub.so \;
+          test -f target/codspeed/libvortex_cub.so
       - name: Upload benchmark executables
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:

--- a/vortex-btrblocks/src/builder.rs
+++ b/vortex-btrblocks/src/builder.rs
@@ -152,19 +152,18 @@ impl BtrBlocksCompressorBuilder {
         builder
     }
 
-    /// Excludes schemes without CUDA kernel support and adds Zstd for string and binary compression.
+    /// Excludes schemes without CUDA kernel support, keeps FSST for string compression,
+    /// and adds Zstd for binary compression.
     ///
-    /// With the `unstable_encodings` feature, buffer-level Zstd compression is used which
-    /// preserves the array buffer layout for zero-conversion GPU decompression. Without it,
-    /// interleaved Zstd compression is used.
+    /// With the `unstable_encodings` feature, buffer-level Zstd compression is used for binary
+    /// arrays, preserving their buffer layout for zero-conversion GPU decompression. Without it,
+    /// interleaved binary Zstd compression is used.
     ///
     /// This preset is intended for files that will be decoded by CUDA kernels. It may choose a
     /// larger encoded representation than the default compressor.
     pub fn only_cuda_compatible(self) -> Self {
-        // String fragmentation schemes (OnPair, FSST) require host-side
-        // dictionary expansion at decode time, which is incompatible with
-        // pure-GPU decompression paths. Strip whichever string-fragment
-        // scheme is enabled by feature.
+        // Keep FSST, which has a CUDA decoder and direct Arrow offset-based export. Other
+        // string fragmentation and dictionary schemes still require unsupported decode paths.
         #[cfg_attr(
             not(any(feature = "pco", feature = "unstable_encodings")),
             allow(unused_mut)
@@ -176,7 +175,6 @@ impl BtrBlocksCompressorBuilder {
             float::FloatRLEScheme.id(),
             float::NullDominatedSparseScheme.id(),
             string::StringDictScheme.id(),
-            string::FSSTScheme.id(),
             binary::BinaryDictScheme.id(),
         ];
         #[cfg(feature = "unstable_encodings")]
@@ -190,13 +188,9 @@ impl BtrBlocksCompressorBuilder {
         let builder = self.exclude_schemes(excluded);
 
         #[cfg(all(feature = "zstd", feature = "unstable_encodings"))]
-        let builder = builder
-            .with_new_scheme(&string::ZstdBuffersScheme)
-            .with_new_scheme(&binary::ZstdBuffersScheme);
+        let builder = builder.with_new_scheme(&binary::ZstdBuffersScheme);
         #[cfg(all(feature = "zstd", not(feature = "unstable_encodings")))]
-        let builder = builder
-            .with_new_scheme(&string::ZstdScheme)
-            .with_new_scheme(&binary::ZstdScheme);
+        let builder = builder.with_new_scheme(&binary::ZstdScheme);
 
         builder
     }
@@ -238,6 +232,24 @@ mod tests {
                 .schemes
                 .iter()
                 .any(|s| s.id() == float::ALPRDScheme.id())
+        );
+    }
+
+    #[test]
+    fn cuda_compatible_uses_fsst_for_strings() {
+        let builder = BtrBlocksCompressorBuilder::default().only_cuda_compatible();
+        assert!(
+            builder
+                .schemes
+                .iter()
+                .any(|scheme| scheme.id() == string::FSSTScheme.id())
+        );
+        #[cfg(feature = "zstd")]
+        assert!(
+            !builder
+                .schemes
+                .iter()
+                .any(|scheme| scheme.id() == string::ZstdScheme.id())
         );
     }
 

--- a/vortex-cuda/cub/src/lib.rs
+++ b/vortex-cuda/cub/src/lib.rs
@@ -7,13 +7,15 @@
 //! which is used for GPU-accelerated filtering in Vortex.
 //!
 //! The library is compiled at build time and loaded at runtime via libloading.
-//! This avoids link-time dependencies on CUDA.
+//! This avoids link-time dependencies on CUDA. Relocated executables can bundle the compiled
+//! shared library in the same directory.
 //!
 //! # Platform Support
 //!
 //! CUB is part of the CUDA Toolkit. This crate requires CUDA (nvcc) to be
 //! available at build time.
 
+use std::env;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
@@ -32,8 +34,13 @@ static CUB_LIB: OnceLock<Result<sys::CubLibrary, String>> = OnceLock::new();
 
 fn load_cub() -> Result<sys::CubLibrary, String> {
     let lib_name = "libvortex_cub.so";
-    let build_lib_dir = env!("OUT_DIR");
-    let lib_path = PathBuf::from(build_lib_dir).join(lib_name);
+    let bundled_lib_path = env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(|parent| parent.join(lib_name)));
+    let build_lib_path = PathBuf::from(env!("OUT_DIR")).join(lib_name);
+    let lib_path = bundled_lib_path
+        .filter(|path| path.is_file())
+        .unwrap_or(build_lib_path);
 
     // SAFETY: The library at the path is a valid vortex_cub shared library
     // compiled during the build process.

--- a/vortex-cuda/kernels/src/arrow_offsets.cu
+++ b/vortex-cuda/kernels/src/arrow_offsets.cu
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+#include "config.cuh"
+
+#include <limits.h>
+#include <stdint.h>
+
+// Convert integer lengths to CUB scan input. The final zero makes an exclusive scan produce an
+// Arrow offsets array of length len + 1.
+#define GENERATE_FROM_LENGTHS_KERNEL(suffix, LengthT, is_signed)                                             \
+    extern "C" __global__ void arrow_offsets_from_lengths_##suffix(const LengthT *__restrict lengths,        \
+                                                                   int32_t *__restrict scan,                 \
+                                                                   uint32_t *status,                         \
+                                                                   uint64_t len) {                           \
+        const uint64_t scan_len = len + 1;                                                                   \
+        const uint64_t elements_per_block = (uint64_t)blockDim.x * ELEMENTS_PER_THREAD;                      \
+        const uint64_t block_start = (uint64_t)blockIdx.x * elements_per_block;                              \
+        const uint64_t block_stop = min(block_start + elements_per_block, scan_len);                         \
+        for (uint64_t idx = block_start + threadIdx.x; idx < block_stop; idx += blockDim.x) {                \
+            if (idx == len) {                                                                                \
+                scan[idx] = 0;                                                                               \
+                continue;                                                                                    \
+            }                                                                                                \
+            const LengthT raw_length = lengths[idx];                                                         \
+            if (is_signed && raw_length < 0) {                                                               \
+                scan[idx] = 0;                                                                               \
+                atomicMax(status, 1u);                                                                       \
+                continue;                                                                                    \
+            }                                                                                                \
+            const uint64_t length = (uint64_t)raw_length;                                                    \
+            if (length > (uint64_t)INT32_MAX) {                                                              \
+                scan[idx] = 0;                                                                               \
+                atomicMax(status, 2u);                                                                       \
+                continue;                                                                                    \
+            }                                                                                                \
+            scan[idx] = (int32_t)length;                                                                     \
+        }                                                                                                    \
+    }
+
+// The first i32 prefix-sum overflow must be negative because every scan input is nonnegative and at
+// most INT32_MAX. Retaining this validation as a separate pass keeps malformed inputs from reaching
+// consumers with wrapped Arrow offsets.
+extern "C" __global__ void
+arrow_offsets_validate(const int32_t *__restrict offsets, uint32_t *status, uint64_t scan_len) {
+    const uint64_t elements_per_block = (uint64_t)blockDim.x * ELEMENTS_PER_THREAD;
+    const uint64_t block_start = (uint64_t)blockIdx.x * elements_per_block;
+    const uint64_t block_stop = min(block_start + elements_per_block, scan_len);
+    for (uint64_t idx = block_start + threadIdx.x; idx < block_stop; idx += blockDim.x) {
+        if (offsets[idx] < 0) {
+            atomicMax(status, 2u);
+        }
+    }
+}
+
+GENERATE_FROM_LENGTHS_KERNEL(i8, int8_t, true)
+GENERATE_FROM_LENGTHS_KERNEL(i16, int16_t, true)
+GENERATE_FROM_LENGTHS_KERNEL(i32, int32_t, true)
+GENERATE_FROM_LENGTHS_KERNEL(i64, int64_t, true)
+GENERATE_FROM_LENGTHS_KERNEL(u8, uint8_t, false)
+GENERATE_FROM_LENGTHS_KERNEL(u16, uint16_t, false)
+GENERATE_FROM_LENGTHS_KERNEL(u32, uint32_t, false)
+GENERATE_FROM_LENGTHS_KERNEL(u64, uint64_t, false)

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -2543,7 +2543,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("FSST decoded size exceeds Arrow i32 offset range")
+                .contains("length sum exceeds Arrow i32 offset range")
         );
         Ok(())
     }

--- a/vortex-cuda/src/arrow/mod.rs
+++ b/vortex-cuda/src/arrow/mod.rs
@@ -10,6 +10,7 @@
 
 mod canonical;
 mod list_view;
+mod offsets;
 
 use std::ffi::CString;
 use std::ffi::c_char;
@@ -30,6 +31,8 @@ pub(crate) use canonical::CanonicalDeviceArrayExport;
 use cudarc::driver::CudaEvent;
 use cudarc::driver::CudaStream;
 use cudarc::runtime::sys::cudaEvent_t;
+pub(crate) use offsets::I32Offsets;
+pub(crate) use offsets::i32_offsets_from_lengths;
 use vortex::array::ArrayRef;
 use vortex::array::arrays::Dict;
 use vortex::array::arrays::FixedSizeList;

--- a/vortex-cuda/src/arrow/offsets.rs
+++ b/vortex-cuda/src/arrow/offsets.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Device construction of standard Arrow `i32` offsets.
+
+use std::sync::Arc;
+
+use cudarc::driver::DeviceRepr;
+use cudarc::driver::PushKernelArg;
+use vortex::array::arrays::PrimitiveArray;
+use vortex::array::arrays::primitive::PrimitiveDataParts;
+use vortex::array::buffer::BufferHandle;
+use vortex::array::match_each_integer_ptype;
+use vortex::buffer::Buffer;
+use vortex::dtype::NativePType;
+use vortex::error::VortexResult;
+use vortex::error::vortex_bail;
+use vortex::error::vortex_err;
+
+use crate::CudaBufferExt;
+use crate::CudaDeviceBuffer;
+use crate::cub::exclusive_sum_i32;
+use crate::executor::CudaExecutionCtx;
+
+pub(crate) struct I32Offsets {
+    pub(crate) buffer: BufferHandle,
+    pub(crate) total: usize,
+}
+
+/// Build Arrow-compatible offsets from a canonical integer length array.
+///
+/// Length conversion, prefix sum, and overflow validation stay on the active CUDA stream. Only the
+/// final offset and status word are copied to the host because callers need the total to size their
+/// output allocation.
+pub(crate) async fn i32_offsets_from_lengths(
+    lengths: PrimitiveArray,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<I32Offsets> {
+    let len = lengths.len();
+    let ptype = lengths.ptype();
+    let PrimitiveDataParts { buffer, .. } = lengths.into_data_parts();
+    let lengths = ctx.ensure_on_device(buffer).await?;
+
+    match_each_integer_ptype!(ptype, |L| {
+        i32_offsets_from_lengths_typed::<L>(&lengths, len, ctx).await
+    })
+}
+
+async fn i32_offsets_from_lengths_typed<L>(
+    lengths: &BufferHandle,
+    len: usize,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<I32Offsets>
+where
+    L: NativePType + DeviceRepr + Send + Sync + 'static,
+{
+    let scan_len = len
+        .checked_add(1)
+        .ok_or_else(|| vortex_err!("Arrow offset count overflow"))?;
+    let status = ctx.copy_to_device(vec![0u32])?.await?;
+    let lengths_view = lengths.cuda_view::<L>()?;
+    let status_view = status.cuda_view::<u32>()?;
+    let scan_input = ctx.device_alloc::<i32>(scan_len)?;
+    let ptype = L::PTYPE.to_string();
+    let scan_kernel =
+        ctx.load_function_with_suffixes("arrow_offsets", &["from", "lengths", &ptype])?;
+    let len_u64 = u64::try_from(len)?;
+
+    ctx.launch_kernel(&scan_kernel, scan_len, |args| {
+        args.arg(&lengths_view)
+            .arg(&scan_input)
+            .arg(&status_view)
+            .arg(&len_u64);
+    })?;
+
+    let offsets = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(exclusive_sum_i32(
+        &scan_input,
+        scan_len,
+        ctx,
+    )?)));
+    let offsets_view = offsets.cuda_view::<i32>()?;
+    let scan_len_u64 = u64::try_from(scan_len)?;
+    let validate_kernel = ctx.load_function_with_suffixes("arrow_offsets", &["validate"])?;
+    ctx.launch_kernel(&validate_kernel, scan_len, |args| {
+        args.arg(&offsets_view).arg(&status_view).arg(&scan_len_u64);
+    })?;
+
+    let status_copy = status.try_to_host()?;
+    let total_copy = offsets.slice_typed::<i32>(len..scan_len).try_to_host()?;
+    let (status_bytes, total_bytes) = futures::try_join!(status_copy, total_copy)?;
+    match Buffer::<u32>::from_byte_buffer(status_bytes)[0] {
+        0 => {}
+        1 => vortex_bail!("cannot build Arrow offsets from a negative length"),
+        2 => vortex_bail!("length sum exceeds Arrow i32 offset range"),
+        status => vortex_bail!("unexpected Arrow offset status {status}"),
+    }
+
+    Ok(I32Offsets {
+        buffer: offsets,
+        total: usize::try_from(Buffer::<i32>::from_byte_buffer(total_bytes)[0])?,
+    })
+}

--- a/vortex-cuda/src/kernel/encodings/fsst.rs
+++ b/vortex-cuda/src/kernel/encodings/fsst.rs
@@ -13,8 +13,10 @@ use cudarc::driver::PushKernelArg;
 use tracing::instrument;
 use vortex::array::ArrayRef;
 use vortex::array::Canonical;
+use vortex::array::arrays::Bool;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::VarBinViewArray;
+use vortex::array::arrays::bool::BoolDataParts;
 use vortex::array::arrays::primitive::PrimitiveDataParts;
 use vortex::array::arrays::varbin::VarBinArrayExt;
 use vortex::array::arrays::varbinview::build_views::MAX_BUFFER_LEN;
@@ -25,7 +27,7 @@ use vortex::array::match_each_integer_ptype;
 use vortex::array::match_each_unsigned_integer_ptype;
 use vortex::array::validity::Validity;
 use vortex::buffer::Alignment;
-use vortex::buffer::ByteBuffer;
+use vortex::buffer::Buffer;
 use vortex::dtype::DType;
 use vortex::dtype::NativePType;
 use vortex::encodings::fsst::FSST;
@@ -35,10 +37,15 @@ use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
 
+use crate::CanonicalCudaExt;
 use crate::CudaBufferExt;
 use crate::CudaDeviceBuffer;
+use crate::arrow::I32Offsets;
+use crate::arrow::i32_offsets_from_lengths;
+use crate::executor::CudaArrayExt;
 use crate::executor::CudaExecute;
 use crate::executor::CudaExecutionCtx;
+use crate::executor::execute_validity_cuda;
 
 /// Device-resident offset-based result of FSST decompression.
 pub(crate) struct FSSTVarBin {
@@ -53,19 +60,30 @@ pub(crate) struct FSSTVarBin {
 ///
 /// `BitBuffer` slices normalize whole-byte offsets but can retain a sub-byte offset. Passing that
 /// offset to CUDA lets the kernels address sliced validity directly without repacking it on host.
-fn cuda_validity(
+async fn cuda_validity(
     validity: &Validity,
     len: usize,
     ctx: &mut CudaExecutionCtx,
-) -> VortexResult<(u64, ByteBuffer)> {
-    let bits = validity
-        .clone()
-        .execute_mask(len, ctx.execution_ctx())?
-        .into_bit_buffer();
-    let (bit_offset, bit_len, bytes) = bits.into_inner();
-    debug_assert_eq!(bit_len, len);
-    let byte_len = (bit_offset + bit_len).div_ceil(8);
-    Ok((bit_offset as u64, bytes.slice(0..byte_len)))
+) -> VortexResult<(u64, BufferHandle)> {
+    match execute_validity_cuda(validity.clone(), len, ctx).await? {
+        Validity::NonNullable | Validity::AllValid => Ok((
+            0,
+            BufferHandle::new_host(Buffer::from(vec![u8::MAX; len.div_ceil(8)]).into_byte_buffer()),
+        )),
+        Validity::AllInvalid => Ok((
+            0,
+            BufferHandle::new_host(Buffer::from(vec![0u8; len.div_ceil(8)]).into_byte_buffer()),
+        )),
+        Validity::Array(array) => {
+            let bool_array = array.try_downcast::<Bool>().map_err(|array| {
+                vortex_err!("CUDA validity execution produced {}", array.dtype())
+            })?;
+            let BoolDataParts { bits, meta } = bool_array.into_data().into_parts(len);
+            let bit_offset = meta.offset();
+            let byte_len = (bit_offset + len).div_ceil(8);
+            Ok((u64::try_from(bit_offset)?, bits.slice(0..byte_len)))
+        }
+    }
 }
 
 /// CUDA decoder for FSST.
@@ -105,12 +123,18 @@ impl CudaExecute for FSSTExecutor {
         let lens = fsst
             .uncompressed_lengths()
             .clone()
-            .execute::<PrimitiveArray>(ctx.execution_ctx())?;
+            .execute_cuda(ctx)
+            .await?
+            .into_host()
+            .await?
+            .into_primitive();
         let codes_offsets = fsst
             .codes()
             .offsets()
             .clone()
-            .execute::<PrimitiveArray>(ctx.execution_ctx())?;
+            .execute_cuda(ctx)
+            .await?
+            .into_primitive();
 
         // Prefix-sum lens to per-string u64 output offsets so the kernel
         // knows where to write each decoded string.
@@ -145,45 +169,28 @@ pub(crate) async fn decode_fsst_varbin(
     let lens = fsst
         .uncompressed_lengths()
         .clone()
-        .execute::<PrimitiveArray>(ctx.execution_ctx())?;
+        .execute_cuda(ctx)
+        .await?
+        .into_primitive();
     let codes_offsets = fsst
         .codes()
         .offsets()
         .clone()
-        .execute::<PrimitiveArray>(ctx.execution_ctx())?;
-
-    let output_offsets = match_each_integer_ptype!(lens.ptype(), |P| {
-        let mut offsets = Vec::with_capacity(lens.len() + 1);
-        let mut acc = 0u64;
-        offsets.push(0i32);
-        #[allow(clippy::unnecessary_cast)]
-        for &length in lens.as_slice::<P>() {
-            let length = u64::try_from(length as i128)
-                .map_err(|_| vortex_err!("FSST uncompressed length cannot be negative"))?;
-            acc = acc
-                .checked_add(length)
-                .ok_or_else(|| vortex_err!("FSST decoded size overflow"))?;
-            offsets
-                .push(i32::try_from(acc).map_err(|_| {
-                    vortex_err!("FSST decoded size exceeds Arrow i32 offset range")
-                })?);
-        }
-        VortexResult::Ok(offsets)
-    })?;
-    let total_size = usize::try_from(
-        *output_offsets
-            .last()
-            .vortex_expect("output_offsets has at least one entry"),
-    )?;
+        .execute_cuda(ctx)
+        .await?
+        .into_primitive();
+    let I32Offsets {
+        buffer: output_offsets,
+        total: total_size,
+    } = i32_offsets_from_lengths(lens, ctx).await?;
 
     if total_size == 0 {
-        let offsets = ctx.copy_to_device(output_offsets)?.await?;
         let allocation = CudaDeviceBuffer::new(ctx.device_alloc::<u8>(1)?);
         let values = BufferHandle::new_device(allocation.slice(0..0));
         return Ok(FSSTVarBin {
             dtype,
             len,
-            offsets,
+            offsets: output_offsets,
             values,
             validity,
         });
@@ -197,7 +204,7 @@ pub(crate) async fn decode_fsst_varbin(
 async fn decode_fsst_varbin_typed<U>(
     fsst: FSSTArray,
     codes_offsets: PrimitiveArray,
-    output_offsets: Vec<i32>,
+    output_offsets: BufferHandle,
     total_size: usize,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<FSSTVarBin>
@@ -215,13 +222,12 @@ where
         buffer: codes_offsets_buffer,
         ..
     } = codes_offsets.into_data_parts();
-    let (validity_bit_offset, validity_bits) = cuda_validity(&validity, len, ctx)?;
+    let (validity_bit_offset, validity_bits) = cuda_validity(&validity, len, ctx).await?;
 
-    let (symbols, symbol_lengths, output_offsets, validity_device, codes_bytes, codes_offsets) = futures::try_join!(
+    let (symbols, symbol_lengths, validity_device, codes_bytes, codes_offsets) = futures::try_join!(
         ctx.copy_to_device(symbols_u64)?,
         ctx.copy_to_device(symbol_lengths)?,
-        ctx.copy_to_device(output_offsets)?,
-        ctx.copy_to_device(validity_bits)?,
+        ctx.ensure_on_device(validity_bits),
         ctx.ensure_on_device(codes_bytes_handle),
         ctx.ensure_on_device(codes_offsets_buffer),
     )?;
@@ -302,13 +308,13 @@ where
         ..
     } = codes_offsets.into_data_parts();
 
-    let (validity_bit_offset, validity_bits) = cuda_validity(&validity, num_strings, ctx)?;
+    let (validity_bit_offset, validity_bits) = cuda_validity(&validity, num_strings, ctx).await?;
 
     let (symbols, symbol_lengths, output_offsets, validity_device, codes_bytes, codes_offsets) = futures::try_join!(
         ctx.copy_to_device(symbols_u64)?,
         ctx.copy_to_device(symbol_lengths)?,
         ctx.copy_to_device(output_offsets)?,
-        ctx.copy_to_device(validity_bits)?,
+        ctx.ensure_on_device(validity_bits),
         ctx.ensure_on_device(codes_bytes_handle),
         ctx.ensure_on_device(codes_offsets_buffer),
     )?;


### PR DESCRIPTION
Keep FSST in the CUDA-compatible BtrBlocks writer and export decoded strings with standard offset-based Arrow layouts.

Build and validate Arrow i32 offsets on the GPU with a generic length conversion and CUB scan, avoiding per-batch length and offset round trips through host memory. Decode device-resident FSST metadata and validity through CUDA so staged files import into cuDF as verified owned strings.