### PR TITLE
Fix Kleene boolean dictionary pushdown

### DIFF
--- a/vortex-array/src/arrays/dict/compute/rules.rs
+++ b/vortex-array/src/arrays/dict/compute/rules.rs
@@ -271,6 +271,7 @@ mod tests {
     use crate::arrays::BoolArray;
     use crate::arrays::Chunked;
     use crate::arrays::ChunkedArray;
+    use crate::arrays::ConstantArray;
     use crate::arrays::Dict;
     use crate::arrays::DictArray;
     use crate::arrays::PrimitiveArray;
@@ -279,10 +280,14 @@ mod tests {
     use crate::arrays::dict::DictArraySlotsExt;
     use crate::arrays::scalar_fn::ScalarFnFactoryExt;
     use crate::assert_arrays_eq;
+    use crate::dtype::Nullability;
     use crate::executor::VortexSessionExecute;
     use crate::optimizer::ArrayOptimizer;
+    use crate::scalar::Scalar;
     use crate::scalar_fn::EmptyOptions;
+    use crate::scalar_fn::fns::binary::Binary;
     use crate::scalar_fn::fns::not::Not;
+    use crate::scalar_fn::fns::operators::Operator;
 
     #[test]
     #[allow(clippy::disallowed_methods)]
@@ -352,6 +357,40 @@ mod tests {
 
         assert!(result.has_all_values_referenced());
 
+        Ok(())
+    }
+
+    #[test]
+    fn kleene_and_dict_values_pushdown_counterexample() -> VortexResult<()> {
+        let codes = PrimitiveArray::from_option_iter([Some(0u8), Some(1), None]).into_array();
+        let values = BoolArray::from_iter([true, false]).into_array();
+        let dict = DictArray::try_new(codes, values)?.into_array();
+        let const_false =
+            ConstantArray::new(Scalar::bool(false, Nullability::NonNullable), 3).into_array();
+        let expr = Binary.try_new_array(3, Operator::And, vec![dict, const_false])?;
+
+        let mut ctx = array_session().create_execution_ctx();
+        // Kleene AND: null AND false == false, so all three rows must be valid `false`.
+        let expected = expr.clone().execute::<BoolArray>(&mut ctx)?.into_array();
+        let optimized = expr.optimize()?;
+        assert_arrays_eq!(optimized, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn kleene_or_dict_values_pushdown_counterexample() -> VortexResult<()> {
+        let codes = PrimitiveArray::from_option_iter([Some(0u8), Some(1), None]).into_array();
+        let values = BoolArray::from_iter([true, false]).into_array();
+        let dict = DictArray::try_new(codes, values)?.into_array();
+        let const_true =
+            ConstantArray::new(Scalar::bool(true, Nullability::NonNullable), 3).into_array();
+        let expr = Binary.try_new_array(3, Operator::Or, vec![dict, const_true])?;
+
+        let mut ctx = array_session().create_execution_ctx();
+        // Kleene OR: null OR true == true, so all three rows must be valid `true`.
+        let expected = expr.clone().execute::<BoolArray>(&mut ctx)?.into_array();
+        let optimized = expr.optimize()?;
+        assert_arrays_eq!(optimized, expected, &mut ctx);
         Ok(())
     }
 }

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -252,8 +252,11 @@ impl ScalarFnVTable for Binary {
         })
     }
 
-    fn is_null_sensitive(&self, _operator: &Operator) -> bool {
-        false
+    fn is_null_sensitive(&self, operator: &Operator) -> bool {
+        // Kleene AND/OR is not strict (`false AND null = false`, `true OR null = true`), so
+        // these operators cannot be pushed through dictionary null codes. This is consistent
+        // with `validity` returning `None` for AND/OR above.
+        matches!(operator, Operator::And | Operator::Or)
     }
 
     fn is_fallible(&self, operator: &Operator) -> bool {


### PR DESCRIPTION
## Why

Dictionary values pushdown rewrites `f(dict(codes, values), constant)` as
`dict(codes, f(values, constant))`. At a null code, the original evaluates
`f(null, constant)`, while the rewritten dictionary is always null. This requires `f` to be
strict: a null dictionary argument must force a null result while siblings remain unmasked.

Kleene booleans are not strict: `false AND null = false` and `true OR null = true`.
With values `[true, false]`, codes `[0, 1, null]`, and constant `false`, direct AND execution
returns `[false, false, false]`; the old optimization returned `[false, false, null]`. OR with
constant `true` had the dual bug.

## Fix

Mark Kleene `AND`/`OR` as null-sensitive, consistent with `Binary::validity()` already returning
`None` for them, and add both dictionary regression tests.

Declining the pushdown is always sound because it leaves the original expression unchanged. The
trade-off is that safe instances such as `and(dict, true)` also stop pushing down: a function-level
flag cannot inspect the sibling constant. If needed, array-level Kleene folds such as
`and(x, false) -> false` and `or(x, true) -> true` can recover those cases soundly.