### PR TITLE
perf(array): hoist decimal same-scale cast plan

### DIFF
--- a/vortex-array/src/arrays/decimal/compute/cast.rs
+++ b/vortex-array/src/arrays/decimal/compute/cast.rs
@@ -216,41 +216,48 @@ where
 {
     let values = array.buffer::<F>();
     let values = values.as_slice();
-    let cast_plan = DecimalCastPlan::<T>::new(from_decimal_dtype, to_decimal_dtype);
-
-    let buffer = match valid_values {
-        Mask::AllTrue(_) => {
-            let mut buffer = BufferMut::<T>::with_capacity(values.len());
-            values
-                .try_map_into(&mut buffer.spare_capacity_mut()[..values.len()], |value| {
-                    cast_plan.cast(value)
-                })
-                .map_err(|idx| {
-                    decimal_cast_error::<F, T>(values[idx], from_decimal_dtype, to_decimal_dtype)
-                })?;
-            // SAFETY: try_map_into initializes every lane before returning Ok.
-            unsafe { buffer.set_len(values.len()) };
-            buffer.freeze()
+    let cast_result = match DecimalCastPlan::<T>::new(from_decimal_dtype, to_decimal_dtype) {
+        DecimalCastPlan::SameScale { min, max } => {
+            cast_decimal_buffer(values, valid_values, |value| {
+                let value = <T as BigCast>::from(value)?;
+                (value >= min && value <= max).then_some(value)
+            })
         }
-        Mask::AllFalse(_) => BufferMut::<T>::zeroed(values.len()).freeze(),
-        Mask::Values(mask) => {
-            let mut buffer = BufferMut::<T>::with_capacity(values.len());
-            values
-                .try_map_masked_into(
-                    mask.bit_buffer(),
-                    &mut buffer.spare_capacity_mut()[..values.len()],
-                    |value| cast_plan.cast(value),
-                )
-                .map_err(|idx| {
-                    decimal_cast_error::<F, T>(values[idx], from_decimal_dtype, to_decimal_dtype)
-                })?;
-            // SAFETY: try_map_masked_into initializes every lane before returning Ok.
-            unsafe { buffer.set_len(values.len()) };
-            buffer.freeze()
-        }
+        cast_plan => cast_decimal_buffer(values, valid_values, |value| cast_plan.cast(value)),
     };
+    let buffer = cast_result.map_err(|idx| {
+        decimal_cast_error::<F, T>(values[idx], from_decimal_dtype, to_decimal_dtype)
+    })?;
 
     Ok(DecimalArray::new(buffer, to_decimal_dtype, validity).into_array())
+}
+
+fn cast_decimal_buffer<F, T>(
+    values: &[F],
+    valid_values: &Mask,
+    mut cast: impl FnMut(F) -> Option<T>,
+) -> Result<Buffer<T>, usize>
+where
+    F: NativeDecimalType,
+    T: NativeDecimalType,
+{
+    let mut buffer = BufferMut::<T>::with_capacity(values.len());
+    match valid_values {
+        Mask::AllTrue(_) => {
+            values.try_map_into(&mut buffer.spare_capacity_mut()[..values.len()], &mut cast)?;
+        }
+        Mask::AllFalse(_) => return Ok(BufferMut::<T>::zeroed(values.len()).freeze()),
+        Mask::Values(mask) => {
+            values.try_map_masked_into(
+                mask.bit_buffer(),
+                &mut buffer.spare_capacity_mut()[..values.len()],
+                &mut cast,
+            )?;
+        }
+    }
+    // SAFETY: the selected map kernel initialized every lane before returning Ok.
+    unsafe { buffer.set_len(values.len()) };
+    Ok(buffer.freeze())
 }
 
 #[cold]


### PR DESCRIPTION
## Summary

- Evaluate the `SameScale` cast plan once for each array.
- Use a direct closure for each value in a same-scale cast.
- Use `cast_decimal_buffer` for dense, null, and masked output buffers.
- Keep the existing operation for all other cast plans.

## Problem

The previous code called `DecimalCastPlan::cast` for each value. That function matched the cast plan for each value.

The benchmark profile uses 16 code-generation units and no LTO. An unrelated source addition changed the LLVM output for this function. The nullable copy benchmark increased from approximately 65 µs to 99 µs.

Samply showed the same hot call path in both binaries:

```text
try_map_masked_into -> DecimalCastPlan::cast
```

The slow binary used a larger function and more stack loads and stores. The new code moves the common plan match outside the value loop. This makes the loop independent of that match.

## Benchmarks

Command:

```console
cargo bench -p vortex-array --bench cast_decimal -- --sample-count 100 --min-time 3 --max-time 6 --color never
```

| benchmark | develop median | this PR median | change |
|---|---:|---:|---:|
| `copy_non_nullable[65536]` | 70.10 µs | 41.18 µs | -41.3% |
| `copy_nullable[65536]` | 65.11 µs | 56.44 µs | -13.3% |
| `in_place_non_nullable[65536]` | 590.5 ns | 610.7 ns | +20.2 ns |
| `in_place_nullable[65536]` | 680.5 ns | 690.7 ns | +10.2 ns |

The in-place cases do not use the changed buffer path. Their differences are 10 ns and 20 ns.

## Verification

- `cargo nextest run -p vortex-array -E 'test(/arrays::decimal::compute::cast::tests/)'` — 23 passed
- `cargo clippy --all-targets --all-features`
- `cargo +nightly fmt --all --check`

## AI assistance

This PR was prepared with OpenAI Codex. The human author reviewed the code, benchmark results, profile data, and test results.
