### PR TITLE
Execute until arrays match fast path or canonical before exporting to Arrow

### DIFF
--- a/vortex-arrow/src/executor/byte.rs
+++ b/vortex-arrow/src/executor/byte.rs
@@ -13,6 +13,8 @@ use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
+use vortex_array::arrays::Chunked;
+use vortex_array::arrays::Constant;
 use vortex_array::arrays::VarBin;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::arrays::varbin::VarBinArraySlotsExt;
@@ -22,12 +24,28 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
+use vortex_array::matcher::Matcher;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 
 use crate::byte_view::execute_varbinview_to_arrow;
 use crate::executor::validity::to_arrow_null_buffer;
+
+/// Matches the encodings [`to_arrow_byte_array`] requires for export.
+///
+/// `Chunked` and `Constant` are matched to stop execution before it destroys them: they have
+/// specialized `append_to_builder` impls (chunk-wise append, scalar repeat) that the builder
+/// fallback exploits.
+struct ArrowByteExportable;
+
+impl Matcher for ArrowByteExportable {
+    type Match<'a> = &'a ArrayRef;
+
+    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
+        (array.is::<VarBin>() || array.is::<Chunked>() || array.is::<Constant>()).then_some(array)
+    }
+}
 
 /// Convert a Vortex array into an Arrow GenericBinaryArray.
 pub(super) fn to_arrow_byte_array<T: ByteArrayType>(
@@ -57,7 +75,9 @@ where
         return arrow_cast::cast(&binary_view, &T::DATA_TYPE).map_err(VortexError::from);
     }
 
-    // If the Vortex array is already in VarBin format, we can directly convert it.
+    let array = array.execute_until::<ArrowByteExportable>(ctx)?;
+
+    // If the Vortex array is in VarBin format, we can directly convert it.
     if let Some(array) = array.as_opt::<VarBin>() {
         return varbin_to_byte_array::<T>(array, ctx);
     }
@@ -106,14 +126,46 @@ mod tests {
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
     use vortex_array::array_session;
+    use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::arrays::VarBinArray;
     use vortex_array::arrays::VarBinViewArray;
+    use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
+    use vortex_array::scalar_fn::EmptyOptions;
+    use vortex_array::scalar_fn::fns::mask::Mask as MaskFn;
     use vortex_error::VortexResult;
     use vortex_mask::Mask;
 
     use crate::ArrowSessionExt;
+
+    #[test]
+    fn mask_wrapped_varbin_exports() -> VortexResult<()> {
+        let session = array_session();
+        let mut ctx = session.create_execution_ctx();
+
+        let varbin = VarBinArray::from_vec(
+            vec!["hello", "world", "vortex"],
+            DType::Utf8(Nullability::NonNullable),
+        );
+        let mask = BoolArray::from_iter([true, false, true]);
+        let masked =
+            MaskFn.try_new_array(3, EmptyOptions, [varbin.into_array(), mask.into_array()])?;
+
+        let field = Field::new("s", DataType::Utf8, true);
+        let arrow = session
+            .arrow()
+            .execute_arrow(masked, Some(&field), &mut ctx)?;
+
+        let strings = arrow.as_string::<i32>();
+        assert_eq!(strings.len(), 3);
+        assert!(!strings.is_null(0));
+        assert!(strings.is_null(1));
+        assert_eq!(strings.value(0), "hello");
+        assert_eq!(strings.value(2), "vortex");
+        Ok(())
+    }
 
     fn make_utf8_array() -> VarBinViewArray {
         VarBinViewArray::from_iter_str(["hello", "world", "this is a longer string for testing"])

--- a/vortex-arrow/src/executor/dictionary.rs
+++ b/vortex-arrow/src/executor/dictionary.rs
@@ -18,11 +18,23 @@ use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::Dict;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::dict::DictArraySlotsExt;
+use vortex_array::matcher::Matcher;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 
 use crate::ArrowArrayExecutor;
+
+/// Matches the encodings [`to_arrow_dictionary`] requires for export.
+struct ArrowDictExportable;
+
+impl Matcher for ArrowDictExportable {
+    type Match<'a> = &'a ArrayRef;
+
+    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
+        (array.is::<Dict>() || array.is::<Constant>()).then_some(array)
+    }
+}
 
 pub(super) fn to_arrow_dictionary(
     array: ArrayRef,
@@ -30,6 +42,8 @@ pub(super) fn to_arrow_dictionary(
     values_type: &DataType,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrowArrayRef> {
+    let array = array.execute_until::<ArrowDictExportable>(ctx)?;
+
     let array = match array.try_downcast::<Dict>() {
         Ok(dict) => return dict_to_dict(dict, codes_type, values_type, ctx),
         Err(array) => array,
@@ -141,6 +155,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_array::DictionaryArray as ArrowDictArray;
+    use arrow_array::StringArray;
     use arrow_array::types::UInt8Type;
     use arrow_array::types::UInt32Type;
     use arrow_schema::DataType;
@@ -148,11 +163,15 @@ mod tests {
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
     use vortex_array::array_session;
+    use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::VarBinViewArray;
+    use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability::Nullable;
     use vortex_array::scalar::Scalar;
+    use vortex_array::scalar_fn::EmptyOptions;
+    use vortex_array::scalar_fn::fns::mask::Mask;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
 
@@ -222,6 +241,25 @@ mod tests {
     ) -> VortexResult<()> {
         let actual = execute(input, &target_type)?;
         assert_eq!(expected.as_ref(), actual.as_ref());
+        Ok(())
+    }
+
+    #[test]
+    fn mask_wrapped_dict_exports() -> VortexResult<()> {
+        // Dictionary behind a lazy `mask` scalar-fn — the shape a scan produces when a row
+        // mask is applied to a dict-encoded column.
+        let dict = DictArray::try_new(
+            buffer![0u8, 1, 0].into_array(),
+            VarBinViewArray::from_iter_str(["a", "b"]).into_array(),
+        )?;
+        let mask = BoolArray::from_iter([true, false, true]);
+        let masked = Mask.try_new_array(3, EmptyOptions, [dict.into_array(), mask.into_array()])?;
+
+        let actual = execute(masked, &dict_type(DataType::UInt8, DataType::Utf8))?;
+        let flat = arrow_cast::cast(&actual, &DataType::Utf8)?;
+
+        let expected = StringArray::from(vec![Some("a"), None, Some("a")]);
+        assert_eq!(flat.as_ref(), &expected as &dyn arrow_array::Array);
         Ok(())
     }
 }

--- a/vortex-arrow/src/executor/list.rs
+++ b/vortex-arrow/src/executor/list.rs
@@ -25,6 +25,7 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
+use vortex_array::matcher::Matcher;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -33,6 +34,17 @@ use vortex_error::vortex_ensure;
 use crate::executor::validity::to_arrow_null_buffer;
 use crate::session::ArrowSessionExt;
 
+/// Matches the encodings [`to_arrow_list`] requires for export.
+struct ArrowListExportable;
+
+impl Matcher for ArrowListExportable {
+    type Match<'a> = &'a ArrayRef;
+
+    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
+        (array.is::<List>() || array.is::<Chunked>() || array.is::<ListView>()).then_some(array)
+    }
+}
+
 #[allow(rustdoc::broken_intra_doc_links)]
 /// Convert a Vortex VarBinArray into an Arrow [`GenericListArray`](arrow_array:array::GenericListArray).
 pub(super) fn to_arrow_list<O: OffsetSizeTrait + NativePType>(
@@ -40,9 +52,11 @@ pub(super) fn to_arrow_list<O: OffsetSizeTrait + NativePType>(
     elements_field: &FieldRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrowArrayRef> {
+    let array = array.execute_until::<ArrowListExportable>(ctx)?;
+
     // If the Vortex array is already in List format, we can directly convert it.
-    if let Some(array) = array.as_opt::<List>() {
-        return list_to_list::<O>(&array.into_owned(), elements_field, ctx);
+    if let Some(list) = array.as_opt::<List>() {
+        return list_to_list::<O>(&list.into_owned(), elements_field, ctx);
     }
 
     // Converting each chunk individually, then using the fast concat logic from arrow
@@ -56,24 +70,15 @@ pub(super) fn to_arrow_list<O: OffsetSizeTrait + NativePType>(
         return Ok(arrow_select::concat::concat(&refs)?);
     }
 
-    // If the Vortex array is a ListViewArray, rebuild to ZCTL if needed and convert.
-    let array = match array.try_downcast::<ListView>() {
-        Ok(array) => {
-            let zctl = if array.is_zero_copy_to_list() {
-                array
-            } else {
-                array.rebuild(ListViewRebuildMode::MakeZeroCopyToList, ctx)?
-            };
-            return list_view_zctl::<O>(zctl, elements_field, ctx);
-        }
-        Err(a) => a,
-    };
-
-    // Otherwise, we execute the array to become a ListViewArray, then rebuild to ZCTL.
+    // Otherwise the array is canonical: a ListViewArray, which we rebuild to ZCTL if needed.
     // Note: arrow_cast::cast supports ListView → List (apache/arrow-rs#8735), but it
     // unconditionally uses take. Our rebuild uses a heuristic that picks list-by-list
     // for large lists, which avoids materializing a large index buffer.
-    let list_view = array.execute::<ListViewArray>(ctx)?;
+    let list_view = array
+        .as_opt::<ListView>()
+        .vortex_expect("Must be ListView from Matcher")
+        .into_owned();
+
     let zctl = if list_view.is_zero_copy_to_list() {
         list_view
     } else {
@@ -213,15 +218,21 @@ mod tests {
     use vortex_array::Canonical;
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::arrays::SliceArray;
+    use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability::NonNullable;
+    use vortex_array::scalar_fn::EmptyOptions;
+    use vortex_array::scalar_fn::fns::mask::Mask;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
     use vortex_session::VortexSession;
 
     use crate::ArrowArrayExecutor;
+    use crate::executor::list::ListArray;
     use crate::executor::list::ListViewArray;
 
     /// A shared session for these list-executor tests, used to create execution contexts.
@@ -361,6 +372,92 @@ mod tests {
         assert_eq!(second.len(), 3);
         let second_vals = second.as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(second_vals.values(), &[2, 3, 4]);
+        Ok(())
+    }
+
+    #[test]
+    fn slice_wrapped_list_exports() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        // Lists [[1, 2], [3], [4, 5, 6]] behind a lazy Slice wrapper selecting rows 1..3.
+        let elements = PrimitiveArray::new(buffer![1i32, 2, 3, 4, 5, 6], Validity::NonNullable);
+        let elements_ptr = elements.as_slice::<i32>().as_ptr();
+        let offsets = PrimitiveArray::new(buffer![0i32, 2, 3, 6], Validity::NonNullable);
+        let list = ListArray::try_new(
+            elements.into_array(),
+            offsets.into_array(),
+            Validity::NonNullable,
+        )?;
+        let sliced = SliceArray::new(list.into_array(), 1..3).into_array();
+
+        let field = Field::new("item", DataType::Int32, false);
+        let arrow_dt = DataType::List(field.into());
+        let arrow_array = sliced.execute_arrow(Some(&arrow_dt), &mut ctx)?;
+
+        let arrow_list = arrow_array
+            .as_any()
+            .downcast_ref::<GenericListArray<i32>>()
+            .unwrap();
+        assert_eq!(arrow_list.len(), 2);
+        let first = arrow_list.value(0);
+        let first_vals = first.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(first_vals.values(), &[3]);
+        let second = arrow_list.value(1);
+        let second_vals = second.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(second_vals.values(), &[4, 5, 6]);
+
+        // The conversion shares the elements buffer regardless of which path resolves the
+        // Slice (revealed List or zero-copy-to-list ListView).
+        let values = arrow_list
+            .values()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(values.values().as_ptr(), elements_ptr);
+        Ok(())
+    }
+
+    #[test]
+    fn mask_wrapped_list_exports() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        // Lists [[1, 2], [3], [4, 5, 6]] behind a lazy `mask` scalar-fn nulling out row 1 —
+        // the shape a scan produces when a row mask is applied to a List-encoded column.
+        let elements = PrimitiveArray::new(buffer![1i32, 2, 3, 4, 5, 6], Validity::NonNullable);
+        let elements_ptr = elements.as_slice::<i32>().as_ptr();
+        let offsets = PrimitiveArray::new(buffer![0i32, 2, 3, 6], Validity::NonNullable);
+        let list = ListArray::try_new(
+            elements.into_array(),
+            offsets.into_array(),
+            Validity::NonNullable,
+        )?;
+        let mask = BoolArray::from_iter([true, false, true]);
+        let masked = Mask.try_new_array(3, EmptyOptions, [list.into_array(), mask.into_array()])?;
+
+        let field = Field::new("item", DataType::Int32, false);
+        let arrow_dt = DataType::List(field.into());
+        let arrow_array = masked.execute_arrow(Some(&arrow_dt), &mut ctx)?;
+
+        let arrow_list = arrow_array
+            .as_any()
+            .downcast_ref::<GenericListArray<i32>>()
+            .unwrap();
+        assert_eq!(arrow_list.len(), 3);
+        assert!(!arrow_list.is_null(0));
+        assert!(arrow_list.is_null(1));
+        assert!(!arrow_list.is_null(2));
+        let first = arrow_list.value(0);
+        let first_vals = first.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(first_vals.values(), &[1, 2]);
+        let third = arrow_list.value(2);
+        let third_vals = third.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(third_vals.values(), &[4, 5, 6]);
+
+        // Masking only touches validity, so the conversion still shares the elements buffer.
+        let values = arrow_list
+            .values()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(values.values().as_ptr(), elements_ptr);
         Ok(())
     }
 

--- a/vortex-arrow/src/executor/run_end.rs
+++ b/vortex-arrow/src/executor/run_end.rs
@@ -16,6 +16,7 @@ use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
+use vortex_array::matcher::Matcher;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -27,34 +28,41 @@ use vortex_runend::RunEndArraySlotsExt;
 
 use crate::ArrowArrayExecutor;
 
+/// Matches the encodings [`to_arrow_run_end`] requires for export.
+struct ArrowRunEndExportable;
+
+impl Matcher for ArrowRunEndExportable {
+    type Match<'a> = &'a ArrayRef;
+
+    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
+        (array.is::<RunEnd>() || array.is::<Constant>()).then_some(array)
+    }
+}
+
 pub(super) fn to_arrow_run_end(
     array: ArrayRef,
     ends_type: &DataType,
     values_type: &Field,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrowArrayRef> {
+    let array = array.execute_until::<ArrowRunEndExportable>(ctx)?;
+
     let array = match array.try_downcast::<Constant>() {
-        Ok(constant) => {
-            return constant_to_run_end(constant, ends_type, values_type, ctx);
-        }
+        Ok(constant) => return constant_to_run_end(constant, ends_type, values_type, ctx),
+        Err(array) => array,
+    };
+    let array = match array.try_downcast::<RunEnd>() {
+        Ok(run_end) => return run_end_to_arrow(run_end, ends_type, values_type, ctx),
         Err(array) => array,
     };
 
-    // Execute to unwrap any wrapper VTables (Slice, Filter, etc.) which may
-    // reveal a RunEndArray.
-    let array = array.execute::<ArrayRef>(ctx)?;
-    match array.try_downcast::<RunEnd>() {
-        Ok(run_end) => run_end_to_arrow(run_end, ends_type, values_type, ctx),
-        Err(array) => {
-            // Fallback: canonicalize to flat Arrow, then cast to REE.
-            let flat = array.execute_arrow(Some(values_type.data_type()), ctx)?;
-            let ree_type = DataType::RunEndEncoded(
-                Arc::new(Field::new("run_ends", ends_type.clone(), false)),
-                Arc::new(values_type.clone()),
-            );
-            arrow_cast::cast(&flat, &ree_type).map_err(VortexError::from)
-        }
-    }
+    // Fallback: canonicalize to flat Arrow, then cast to REE.
+    let flat = array.execute_arrow(Some(values_type.data_type()), ctx)?;
+    let ree_type = DataType::RunEndEncoded(
+        Arc::new(Field::new("run_ends", ends_type.clone(), false)),
+        Arc::new(values_type.clone()),
+    );
+    arrow_cast::cast(&flat, &ree_type).map_err(VortexError::from)
 }
 
 fn run_end_to_arrow(
@@ -178,18 +186,26 @@ mod tests {
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::arrays::SliceArray;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability::Nullable;
     use vortex_array::dtype::PType;
     use vortex_array::scalar::Scalar;
+    use vortex_array::validity::Validity;
+    use vortex_buffer::buffer;
     use vortex_error::VortexResult;
     use vortex_error::vortex_err;
     use vortex_session::VortexSession;
 
     use crate::ArrowArrayExecutor;
     use crate::executor::run_end::ConstantArray;
+    use crate::executor::run_end::RunEnd;
 
-    static SESSION: LazyLock<VortexSession> = LazyLock::new(vortex_array::array_session);
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
+        let session = vortex_array::array_session();
+        vortex_runend::initialize(&session);
+        session
+    });
 
     fn ree_type(ends: DataType, values_dtype: DataType) -> DataType {
         DataType::RunEndEncoded(
@@ -259,6 +275,38 @@ mod tests {
     ) -> VortexResult<()> {
         let result = execute(input, &target_type)?;
         assert_eq!(result.as_ref(), expected.as_ref());
+        Ok(())
+    }
+
+    #[test]
+    fn nested_wrappers_reveal_run_end_fast_path() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        // Runs [7, 7, 8, 8] behind two nested lazy Slice wrappers. A single execution step
+        // only merges the slices, so the exporter must keep stepping to reveal the
+        // RunEndArray underneath.
+        let ends = PrimitiveArray::new(buffer![2u32, 4], Validity::NonNullable);
+        let values = PrimitiveArray::new(buffer![7i64, 8], Validity::NonNullable);
+        let values_ptr = values.as_slice::<i64>().as_ptr();
+        let ree = RunEnd::try_new(ends.into_array(), values.into_array(), &mut ctx)?;
+        let wrapped = SliceArray::new(SliceArray::new(ree.into_array(), 0..4).into_array(), 0..4)
+            .into_array();
+
+        let result = execute(wrapped, &ree_type(DataType::Int32, DataType::Int64))?;
+
+        let ree_arrow = result
+            .as_any()
+            .downcast_ref::<RunArray<Int32Type>>()
+            .ok_or_else(|| vortex_err!("expected Int32 run-end array"))?;
+        assert_eq!(ree_arrow.run_ends().values(), &[2, 4]);
+
+        // The RunEnd fast path exports the values buffer zero-copy; the flat-then-recode
+        // fallback would materialize new buffers.
+        let arrow_values = ree_arrow
+            .values()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or_else(|| vortex_err!("expected Int64 values"))?;
+        assert_eq!(arrow_values.values().as_ptr(), values_ptr);
         Ok(())
     }
 

--- a/vortex-arrow/src/executor/struct_.rs
+++ b/vortex-arrow/src/executor/struct_.rs
@@ -22,6 +22,7 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldNames;
 use vortex_array::dtype::StructFields;
+use vortex_array::matcher::Matcher;
 use vortex_array::scalar_fn::fns::pack::Pack;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
@@ -31,12 +32,30 @@ use crate::dtype::FromArrowType;
 use crate::executor::validity::to_arrow_null_buffer;
 use crate::session::ArrowSessionExt;
 
+/// Matches the encodings [`to_arrow_struct`] requires for export.
+struct ArrowStructExportable;
+
+impl Matcher for ArrowStructExportable {
+    type Match<'a> = &'a ArrayRef;
+
+    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
+        (array.is::<Struct>()
+            || array.is::<Chunked>()
+            || array
+                .as_opt::<ScalarFn>()
+                .is_some_and(|scalar_fn| scalar_fn.scalar_fn().as_opt::<Pack>().is_some()))
+        .then_some(array)
+    }
+}
+
 pub(super) fn to_arrow_struct(
     array: ArrayRef,
     target_fields: Option<&Fields>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrowArrayRef> {
     let len = array.len();
+
+    let array = array.execute_until::<ArrowStructExportable>(ctx)?;
 
     // If the array is chunked, then we invert the chunk-of-struct to struct-of-chunk.
     let array = match array.try_downcast::<Chunked>() {
@@ -196,6 +215,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrays::varbinview::VarBinViewArray;
+    use arrow_array::Array;
     use arrow_array::ArrayRef;
     use arrow_array::PrimitiveArray as ArrowPrimitiveArray;
     use arrow_array::StringViewArray;
@@ -209,9 +229,13 @@ mod tests {
     use vortex_array::VortexSessionExecute;
     use vortex_array::array_session;
     use vortex_array::arrays;
+    use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::StructArray;
+    use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
     use vortex_array::dtype::FieldNames;
+    use vortex_array::scalar_fn::EmptyOptions;
+    use vortex_array::scalar_fn::fns::mask::Mask;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
@@ -336,6 +360,44 @@ mod tests {
                 .execute_arrow(Some(&arrow_dtype), &mut ctx)?,
             &arrow_array
         );
+        Ok(())
+    }
+
+    #[test]
+    fn mask_wrapped_struct_exports_via_struct_fast_path() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        // A struct behind a lazy `mask` scalar-fn nulling out row 1 — the shape a scan
+        // produces when a row mask is applied to a top-level struct batch.
+        let xs = PrimitiveArray::new(buffer![1i64, 2, 3], Validity::NonNullable);
+        let struct_array = StructArray::try_new(
+            FieldNames::from(["xs"]),
+            vec![xs.into_array()],
+            3,
+            Validity::NonNullable,
+        )?;
+        let mask = BoolArray::from_iter([true, false, true]);
+        let masked = Mask.try_new_array(
+            3,
+            EmptyOptions,
+            [struct_array.into_array(), mask.into_array()],
+        )?;
+
+        let arrow = masked.execute_arrow(None, &mut ctx)?;
+
+        let arrow_struct = arrow
+            .as_any()
+            .downcast_ref::<ArrowStructArray>()
+            .expect("struct array");
+        assert_eq!(arrow_struct.len(), 3);
+        assert!(!arrow_struct.is_null(0));
+        assert!(arrow_struct.is_null(1));
+        assert!(!arrow_struct.is_null(2));
+        let xs_col = arrow_struct
+            .column(0)
+            .as_any()
+            .downcast_ref::<ArrowPrimitiveArray<arrow_array::types::Int64Type>>()
+            .expect("int64 column");
+        assert_eq!(xs_col.values(), &[1, 2, 3]);
         Ok(())
     }
 


### PR DESCRIPTION
Every Arrow exporter has fast paths for non-canonical encodings, but probes for them with a one-shot downcast. Whenever a wrapper sits on top (a lazy `mask` scalar-fn, `Slice`, `Filter`, ...), the downcast misses and the exporter falls back to full canonicalization followed by a re-encode:

- wrapped `VarBin` → decode to `VarBinView`, then rebuilt into offset-based `Utf8`/`Binary` (copy every byte again)
- wrapped `Dict` → decode the whole column flat, then `arrow_cast` re-dictionary-encodes it by hashing every value
- wrapped `RunEnd` → decode flat, then re-detect runs
- wrapped `List` → canonicalize to `ListView`, then rebuild offsets/sizes for export

Scans produce these whenever a filter is not fully pushed down.

## Change

Each exporter defines a small private `Matcher` for the encodings it must see at the root and executes until one surfaces:

```rust
let array = array.execute_until::<ArrowListExportable>(ctx)?;
```

Execution stops the moment the matcher hits at the root, or when the array is canonical (in which case the existing canonical fallback runs — the dispatch below the `execute_until` is otherwise unchanged). This generalizes the one-shot `execute::<ArrayRef>` step that `to_arrow_run_end` already had, which could only unwrap a single wrapper.
