### PR TITLE
ci: pin uvx ruff to the uv.lock version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,13 @@ jobs:
       - uses: ./.github/actions/setup-prebuild
         with:
           enable-sccache: "true"
-      # Use uvx for ruff to avoid building the Rust extension (saves ~4.5 min)
+      # Use uvx for ruff to avoid building the Rust extension (saves ~4.5 min).
+      # Pinned to the version in uv.lock: unpinned uvx pulls the latest ruff, whose
+      # formatting changes break CI without any change in the repo.
       - name: Python Lint - Format
-        run: uvx ruff format --check .
+        run: uvx ruff@0.14.0 format --check .
       - name: Python Lint - Ruff
-        run: uvx ruff check .
+        run: uvx ruff@0.14.0 check .
       # PyRight needs the project for type information, so use uv run
       - name: Python Lint - PyRight
         env:


### PR DESCRIPTION
## Problem

The Python lint job runs `uvx ruff format --check .` / `uvx ruff check .` with no version pin, so it always pulls the latest ruff release. ruff 0.16 started formatting Python code blocks inside markdown files, which made every open PR fail lint on three README/docs files that were formatted under an older ruff — with no change in the repo:

```
unformatted: File would be reformatted
  --> docs/user-guide/spark.md:1:1
  --> java/vortex-spark/README.md:1:1
  --> vortex-python-cuda/README.md:1:1
```

Meanwhile the repo's locked ruff (`uv.lock`) is 0.14.0, which passes cleanly — so local `uv run ruff` and CI disagreed.

## Fix

Pin the two uvx invocations to `ruff@0.14.0`, matching `uv.lock`. Lint results now only change when the pin is deliberately bumped (at which point any new formatting fallout lands in the same PR as the bump). Keeps uvx (per the existing comment, `uv run` would build the Rust extension, ~4.5 min).

## Checks

- `uvx ruff@0.14.0 format --check .` — 135 files already formatted
- `uvx ruff@0.14.0 check .` — all checks passed
- `uvx yamllint --strict -c .yamllint.yaml .github/workflows/ci.yml` — clean