### PR TITLE
Unify numeric compute kernels with vortex-compute iteration functions

### DIFF
--- a/vortex-array/src/scalar_fn/fns/binary/numeric/checked.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/checked.rs
@@ -1,157 +1,110 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Shared checked-lane execution helpers for numeric kernels.
+//! Checked-lane execution for numeric kernels, driven by the shared
+//! `vortex-compute` lane kernels.
 
-use vortex_buffer::BitBuffer;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
+use vortex_compute::lane_kernels::IndexedSource;
+use vortex_compute::lane_kernels::IndexedSourceExt;
+use vortex_mask::AllOr;
+use vortex_mask::Mask;
 
-/// The values produced by a checked lane loop, plus whether any lane failed.
-pub(super) struct CheckedValues<T> {
-    pub(super) values: Buffer<T>,
-    pub(super) failed: bool,
-}
-
-impl<T> CheckedValues<T> {
-    pub(super) fn zeroed(len: usize) -> Self {
-        Self {
-            values: Buffer::<T>::zeroed(len),
-            failed: false,
-        }
-    }
-
-    fn failed(len: usize) -> Self {
-        Self {
-            values: Buffer::<T>::zeroed(len),
-            failed: true,
-        }
-    }
-}
-
-// Checked one-pass ops delay early exit until the end of a small block. This
-// keeps the loop generic while avoiding a branch-driven exit decision on every
-// lane; it is deliberately independent of mask density or input length.
-const CHECKED_BLOCK_LANES: usize = 16;
-
-pub(super) fn checked_all_lanes<T, F>(len: usize, mut checked_at: F) -> CheckedValues<T>
+/// Apply the fallible `f` over every lane of `source`, failing only when `f` returns `None`
+/// on a valid lane.
+///
+/// `f` is also invoked on invalid lanes (their failures are masked out and their values are
+/// unspecified), so it must be total: no panics or side effects on any stored lane value.
+///
+/// This drives the one-pass early-exit kernels: failures abort at the end of the enclosing
+/// 64-lane chunk. Use it when per-lane failure handling is cheap relative to the operation
+/// (integer division, decimal ops with per-lane casts). For operations whose failure check
+/// auto-vectorizes, prefer [`checked_apply_lanes`].
+///
+/// On failure returns `Err(first_failing_valid_lane)`.
+///
+/// `#[inline(always)]`: this wrapper and its kernel calls must inline into the caller that
+/// constructs the closure, so the closure environment (e.g. a captured constant operand)
+/// flattens into registers. Left to its own devices under `codegen-units > 1`, the compiler
+/// keeps the environment behind a pointer, and reloading a captured constant on every lane
+/// blocks vectorization of the whole loop.
+#[inline(always)]
+pub(super) fn checked_lanes<S, T, F>(source: S, valid_rows: &Mask, f: F) -> Result<Buffer<T>, usize>
 where
-    T: Default,
-    F: FnMut(usize) -> Option<T>,
+    S: IndexedSource,
+    T: Copy + Default,
+    F: FnMut(S::Item) -> Option<T>,
 {
+    let len = source.len();
+    debug_assert_eq!(len, valid_rows.len());
+
+    let valid_bits = match valid_rows.bit_buffer() {
+        AllOr::All => None,
+        AllOr::None => return Ok(Buffer::zeroed(len)),
+        AllOr::Some(valid_bits) => Some(valid_bits),
+    };
+
     let mut values = BufferMut::<T>::with_capacity(len);
-    let mut base = 0;
-
-    while base + CHECKED_BLOCK_LANES <= len {
-        let mut block_failed = false;
-        for idx in base..base + CHECKED_BLOCK_LANES {
-            match checked_at(idx) {
-                Some(value) => {
-                    // SAFETY: the buffer is allocated with capacity `len`, and
-                    // this loop pushes at most one value for each `idx`.
-                    unsafe { values.push_unchecked(value) };
-                }
-                None => {
-                    block_failed = true;
-                    // SAFETY: the buffer is allocated with capacity `len`, and
-                    // this loop pushes at most one value for each `idx`.
-                    unsafe { values.push_unchecked(T::default()) };
-                }
-            }
-        }
-
-        if block_failed {
-            return CheckedValues::failed(len);
-        }
-        base += CHECKED_BLOCK_LANES;
+    let out = &mut values.spare_capacity_mut()[..len];
+    match valid_bits {
+        None => source.try_map_into(out, f)?,
+        Some(valid_bits) => source.try_map_masked_into(valid_bits, out, f)?,
     }
+    // SAFETY: the kernels initialize every lane in `out`.
+    unsafe { values.set_len(len) };
+    Ok(values.freeze())
+}
 
-    for idx in base..len {
-        let Some(value) = checked_at(idx) else {
-            return CheckedValues::failed(len);
+/// Apply the split value/error `f` over every lane of `source`, failing only when `f` flags
+/// an error on a valid lane.
+///
+/// The hot pass writes every lane's value unconditionally and OR-reduces a single failure
+/// flag, which keeps the loop free of per-lane selects and per-chunk exit branches — the
+/// shape the auto-vectorizer handles best. Only if some lane flagged an error does a cold
+/// second pass re-run `f` through the early-exit kernels to filter null-lane failures and
+/// attribute the first valid one.
+///
+/// Like [`checked_lanes`], `f` is invoked on invalid lanes and must be total.
+///
+/// On failure returns `Err(first_failing_valid_lane)`.
+///
+/// `#[inline(always)]`: see [`checked_lanes`] — required so captured operands flatten out of
+/// the closure environment and the hot loop vectorizes regardless of codegen-unit count.
+#[inline(always)]
+pub(super) fn checked_apply_lanes<S, T, F>(
+    source: S,
+    valid_rows: &Mask,
+    mut f: F,
+) -> Result<Buffer<T>, usize>
+where
+    S: IndexedSource + Copy,
+    T: Copy + Default,
+    F: FnMut(S::Item) -> (T, bool),
+{
+    let len = source.len();
+    debug_assert_eq!(len, valid_rows.len());
+
+    let valid_bits = match valid_rows.bit_buffer() {
+        AllOr::All => None,
+        AllOr::None => return Ok(Buffer::zeroed(len)),
+        AllOr::Some(valid_bits) => Some(valid_bits),
+    };
+
+    let mut values = BufferMut::<T>::with_capacity(len);
+    let out = &mut values.spare_capacity_mut()[..len];
+
+    if source.map_checked_into(out, &mut f) {
+        let mut checked = |item: S::Item| {
+            let (value, error) = f(item);
+            (!error).then_some(value)
         };
-        // SAFETY: the buffer is allocated with capacity `len`, and this loop
-        // pushes at most one value for each `idx`.
-        unsafe { values.push_unchecked(value) };
-    }
-
-    CheckedValues {
-        values: values.freeze(),
-        failed: false,
-    }
-}
-
-pub(super) fn checked_valid_lanes<T, F>(
-    len: usize,
-    valid_bits: &BitBuffer,
-    mut checked_at: F,
-) -> CheckedValues<T>
-where
-    T: Default,
-    F: FnMut(usize) -> Option<T>,
-{
-    let mut values = BufferMut::<T>::zeroed(len);
-    let mut failed = false;
-    {
-        let values = values.as_mut_slice();
-        for_each_valid_idx(len, valid_bits, |idx| {
-            let Some(value) = checked_at(idx) else {
-                failed = true;
-                return false;
-            };
-            values[idx] = value;
-            true
-        });
-    }
-
-    CheckedValues {
-        values: values.freeze(),
-        failed,
-    }
-}
-
-pub(super) fn any_valid_error<F>(len: usize, valid_bits: &BitBuffer, is_error: F) -> bool
-where
-    F: Fn(usize) -> bool,
-{
-    !for_each_valid_idx(len, valid_bits, |idx| !is_error(idx))
-}
-
-fn for_each_valid_idx<F>(len: usize, valid_bits: &BitBuffer, mut f: F) -> bool
-where
-    F: FnMut(usize) -> bool,
-{
-    debug_assert_eq!(len, valid_bits.len());
-
-    for (word_idx, valid_word) in valid_bits.chunks().iter_padded().enumerate() {
-        if valid_word == 0 {
-            continue;
-        }
-
-        let offset = word_idx * 64;
-        let lanes = len.saturating_sub(offset).min(64);
-        if lanes == 64 && valid_word == u64::MAX {
-            for bit_idx in 0..64 {
-                if !f(offset + bit_idx) {
-                    return false;
-                }
-            }
-            continue;
-        }
-
-        let mut valid_word = if lanes == 64 {
-            valid_word
-        } else {
-            valid_word & ((1u64 << lanes) - 1)
-        };
-        while valid_word != 0 {
-            let bit_idx = valid_word.trailing_zeros() as usize;
-            if !f(offset + bit_idx) {
-                return false;
-            }
-            valid_word &= valid_word - 1;
+        match valid_bits {
+            None => source.try_map_into(out, &mut checked)?,
+            Some(valid_bits) => source.try_map_masked_into(valid_bits, out, &mut checked)?,
         }
     }
-
-    true
+    // SAFETY: the kernels initialize every lane in `out`.
+    unsafe { values.set_len(len) };
+    Ok(values.freeze())
 }

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
@@ -13,16 +13,15 @@
 
 use num_traits::CheckedAdd;
 use num_traits::CheckedSub;
+use vortex_buffer::Buffer;
+use vortex_compute::lane_kernels::LaneZip;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
-use vortex_mask::AllOr;
 use vortex_mask::Mask;
 
-use super::checked::CheckedValues;
-use super::checked::checked_all_lanes;
-use super::checked::checked_valid_lanes;
+use super::checked::checked_lanes;
 use crate::ArrayRef;
 use crate::Columnar;
 use crate::ExecutionCtx;
@@ -288,7 +287,7 @@ where
     let len = lhs.len();
     let bounds = DecimalValueBounds::<W>::new(result_decimal_dtype);
 
-    let checked = match (lhs, rhs) {
+    let values = match (lhs, rhs) {
         (DecimalOperand::Array { values: lhs, .. }, DecimalOperand::Array { values: rhs, .. }) => {
             checked_decimal_arrays::<W, Op>(lhs, rhs, &bounds, valid_rows)
         }
@@ -296,8 +295,8 @@ where
             let rhs = typed_constant::<W>(value);
             match_each_decimal_value_type!(lhs.values_type(), |L| {
                 let lhs = lhs.buffer::<L>();
-                checked_decimal_lanes::<W, _>(len, valid_rows, |idx| {
-                    Op::apply(<W as BigCast>::from(lhs[idx])?, rhs, &bounds)
+                checked_lanes(lhs.as_slice(), valid_rows, |lhs| {
+                    Op::apply(<W as BigCast>::from(lhs)?, rhs, &bounds)
                 })
             })
         }
@@ -305,8 +304,8 @@ where
             let lhs = typed_constant::<W>(value);
             match_each_decimal_value_type!(rhs.values_type(), |R| {
                 let rhs = rhs.buffer::<R>();
-                checked_decimal_lanes::<W, _>(len, valid_rows, |idx| {
-                    Op::apply(lhs, <W as BigCast>::from(rhs[idx])?, &bounds)
+                checked_lanes(rhs.as_slice(), valid_rows, |rhs| {
+                    Op::apply(lhs, <W as BigCast>::from(rhs)?, &bounds)
                 })
             })
         }
@@ -328,14 +327,11 @@ where
             )
             .into_array());
         }
-    };
-
-    if checked.failed {
-        return Err(vortex_err!(InvalidArgument: "{}", Op::ERROR));
     }
+    .map_err(|_lane| vortex_err!(InvalidArgument: "{}", Op::ERROR))?;
 
     Ok(DecimalArray::new(
-        checked.values,
+        values,
         result_decimal_dtype,
         validity.union_nullability(result_dtype.nullability()),
     )
@@ -347,38 +343,29 @@ fn checked_decimal_arrays<W, Op>(
     rhs: &DecimalArray,
     bounds: &DecimalValueBounds<W>,
     valid_rows: &Mask,
-) -> CheckedValues<W>
+) -> Result<Buffer<W>, usize>
 where
     W: NativeDecimalType + CheckedAdd + CheckedSub,
     Op: CheckedDecimalOp,
 {
-    let len = lhs.len();
-    debug_assert_eq!(len, rhs.len());
+    debug_assert_eq!(lhs.len(), rhs.len());
     match_each_decimal_value_type!(lhs.values_type(), |L| {
         let lhs = lhs.buffer::<L>();
         match_each_decimal_value_type!(rhs.values_type(), |R| {
             let rhs = rhs.buffer::<R>();
-            checked_decimal_lanes::<W, _>(len, valid_rows, |idx| {
-                Op::apply(
-                    <W as BigCast>::from(lhs[idx])?,
-                    <W as BigCast>::from(rhs[idx])?,
-                    bounds,
-                )
-            })
+            checked_lanes(
+                LaneZip::new(lhs.as_slice(), rhs.as_slice()),
+                valid_rows,
+                |(lhs, rhs)| {
+                    Op::apply(
+                        <W as BigCast>::from(lhs)?,
+                        <W as BigCast>::from(rhs)?,
+                        bounds,
+                    )
+                },
+            )
         })
     })
-}
-
-fn checked_decimal_lanes<W, F>(len: usize, valid_rows: &Mask, checked_at: F) -> CheckedValues<W>
-where
-    W: NativeDecimalType,
-    F: FnMut(usize) -> Option<W>,
-{
-    match valid_rows.bit_buffer() {
-        AllOr::All => checked_all_lanes(len, checked_at),
-        AllOr::None => CheckedValues::<W>::zeroed(len),
-        AllOr::Some(valid_bits) => checked_valid_lanes(len, valid_bits, checked_at),
-    }
 }
 
 fn typed_constant<W: NativeDecimalType>(value: &DecimalValue) -> W {

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
@@ -1,18 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_buffer::BitBuffer;
 use vortex_buffer::Buffer;
-use vortex_buffer::BufferMut;
+use vortex_compute::lane_kernels::IndexedSource;
+use vortex_compute::lane_kernels::LaneZip;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
-use vortex_mask::AllOr;
 use vortex_mask::Mask;
 
-use super::checked::CheckedValues;
-use super::checked::any_valid_error;
-use super::checked::checked_all_lanes;
-use super::checked::checked_valid_lanes;
+use super::checked::checked_apply_lanes;
+use super::checked::checked_lanes;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
@@ -85,7 +82,7 @@ impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedDiv {
     const ERROR: &'static str = "integer division by zero or overflow in checked div";
     // Integer division still lowers to scalar divides, so the split
     // value/error-scan loop used to auto-vectorize add/sub/mul only adds a
-    // second full scan. Use the generic branchy checked value loop for integer
+    // second full scan. Use the one-pass early-exit checked kernel for integer
     // division, matching Arrow/Velox. Float division has no checked errors and
     // stays on the split/vectorizable default path.
     const CHECKED_VALUE_LOOP: bool = T::DIV_CHECKS_IN_VALUE_LOOP;
@@ -148,19 +145,30 @@ where
     let validity = lhs.validity().and(rhs.validity())?;
     let valid_rows = validity.execute_mask(len, ctx)?;
 
-    let checked = match (&lhs, &rhs) {
+    let values = match (&lhs, &rhs) {
         (
             PrimitiveOperand::Array { values: lhs, .. },
             PrimitiveOperand::Array { values: rhs, .. },
-        ) => checked_array_array::<T, Op>(lhs, rhs, &valid_rows),
+        ) => checked_op_lanes::<_, T, Op>(
+            LaneZip::new(lhs.as_slice(), rhs.as_slice()),
+            &valid_rows,
+            |(lhs, rhs)| (lhs, rhs),
+        ),
         (
             PrimitiveOperand::Array { values: lhs, .. },
             PrimitiveOperand::Constant { value: rhs, .. },
-        ) => checked_array_constant::<T, Op>(lhs, *rhs, &valid_rows),
+        ) => {
+            // Capture the constant by value so it stays hoisted out of the lane loop.
+            let rhs = *rhs;
+            checked_op_lanes::<_, T, Op>(lhs.as_slice(), &valid_rows, move |lhs| (lhs, rhs))
+        }
         (
             PrimitiveOperand::Constant { value: lhs, .. },
             PrimitiveOperand::Array { values: rhs, .. },
-        ) => checked_constant_array::<T, Op>(*lhs, rhs, &valid_rows),
+        ) => {
+            let lhs = *lhs;
+            checked_op_lanes::<_, T, Op>(rhs.as_slice(), &valid_rows, move |rhs| (lhs, rhs))
+        }
         (
             PrimitiveOperand::Constant { value: lhs, .. },
             PrimitiveOperand::Constant { value: rhs, .. },
@@ -169,16 +177,41 @@ where
                 .ok_or_else(|| vortex_err!(InvalidArgument: "{}", Op::ERROR))?;
             return Ok(constant_result_array(value, len, &result_dtype));
         }
-        (PrimitiveOperand::Null(_), _) | (_, PrimitiveOperand::Null(_)) => {
-            CheckedValues::zeroed(len)
-        }
-    };
-
-    if checked.failed {
-        return Err(vortex_err!(InvalidArgument: "{}", Op::ERROR));
+        (PrimitiveOperand::Null(_), _) | (_, PrimitiveOperand::Null(_)) => Ok(Buffer::zeroed(len)),
     }
+    .map_err(|_lane| vortex_err!(InvalidArgument: "{}", Op::ERROR))?;
 
-    primitive_result_array::<T>(checked.values, validity, &result_dtype)
+    primitive_result_array::<T>(values, validity, &result_dtype)
+}
+
+/// Run `Op` over the lanes of `source` in the loop shape the op declares: the split
+/// value/error kernel for vectorizable ops, or the one-pass early-exit checked kernel when
+/// `Op::CHECKED_VALUE_LOOP` is set.
+///
+/// `#[inline(always)]`: keeps the `to_operands` closure environment (captured constant
+/// operands) flattened into the kernel loop — see `checked::checked_lanes`.
+#[inline(always)]
+fn checked_op_lanes<S, T, Op>(
+    source: S,
+    valid_rows: &Mask,
+    mut to_operands: impl FnMut(S::Item) -> (T, T),
+) -> Result<Buffer<T>, usize>
+where
+    S: IndexedSource + Copy,
+    T: NativePType,
+    Op: CheckedPrimitiveOp<T>,
+{
+    if Op::CHECKED_VALUE_LOOP {
+        checked_lanes(source, valid_rows, |item| {
+            let (lhs, rhs) = to_operands(item);
+            Op::checked(lhs, rhs)
+        })
+    } else {
+        checked_apply_lanes(source, valid_rows, |item| {
+            let (lhs, rhs) = to_operands(item);
+            Op::apply(lhs, rhs)
+        })
+    }
 }
 
 fn primitive_result_array<T: NativePType>(
@@ -259,214 +292,6 @@ impl<T: NativePType> PrimitiveOperand<T> {
             Self::Null(_) => Validity::AllInvalid,
         }
     }
-}
-
-fn checked_array_array<T, Op>(lhs: &[T], rhs: &[T], valid_rows: &Mask) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    debug_assert_eq!(lhs.len(), rhs.len());
-
-    match valid_rows.bit_buffer() {
-        AllOr::All if Op::CHECKED_VALUE_LOOP => checked_array_array_one_pass::<T, Op>(lhs, rhs),
-        AllOr::All => checked_array_array_all_lanes::<T, Op>(lhs, rhs),
-        AllOr::None => CheckedValues::zeroed(lhs.len()),
-        AllOr::Some(valid_bits) if Op::CHECKED_VALUE_LOOP => {
-            checked_array_array_valid_lanes_one_pass::<T, Op>(lhs, rhs, valid_bits)
-        }
-        AllOr::Some(valid_bits) => checked_array_array_valid_lanes::<T, Op>(lhs, rhs, valid_bits),
-    }
-}
-
-fn checked_array_constant<T, Op>(lhs: &[T], rhs: T, valid_rows: &Mask) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    match valid_rows.bit_buffer() {
-        AllOr::All if Op::CHECKED_VALUE_LOOP => checked_array_constant_one_pass::<T, Op>(lhs, rhs),
-        AllOr::All => checked_array_constant_all_lanes::<T, Op>(lhs, rhs),
-        AllOr::None => CheckedValues::zeroed(lhs.len()),
-        AllOr::Some(valid_bits) if Op::CHECKED_VALUE_LOOP => {
-            checked_array_constant_valid_lanes_one_pass::<T, Op>(lhs, rhs, valid_bits)
-        }
-        AllOr::Some(valid_bits) => {
-            checked_array_constant_valid_lanes::<T, Op>(lhs, rhs, valid_bits)
-        }
-    }
-}
-
-fn checked_constant_array<T, Op>(lhs: T, rhs: &[T], valid_rows: &Mask) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    match valid_rows.bit_buffer() {
-        AllOr::All if Op::CHECKED_VALUE_LOOP => checked_constant_array_one_pass::<T, Op>(lhs, rhs),
-        AllOr::All => checked_constant_array_all_lanes::<T, Op>(lhs, rhs),
-        AllOr::None => CheckedValues::zeroed(rhs.len()),
-        AllOr::Some(valid_bits) if Op::CHECKED_VALUE_LOOP => {
-            checked_constant_array_valid_lanes_one_pass::<T, Op>(lhs, rhs, valid_bits)
-        }
-        AllOr::Some(valid_bits) => {
-            checked_constant_array_valid_lanes::<T, Op>(lhs, rhs, valid_bits)
-        }
-    }
-}
-
-fn checked_array_array_all_lanes<T, Op>(lhs: &[T], rhs: &[T]) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    collect_all_lanes(lhs.len(), |idx| Op::apply(lhs[idx], rhs[idx]))
-}
-
-fn checked_array_array_valid_lanes<T, Op>(
-    lhs: &[T],
-    rhs: &[T],
-    valid_bits: &BitBuffer,
-) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    let mut checked = collect_all_lanes(lhs.len(), |idx| Op::apply(lhs[idx], rhs[idx]));
-
-    checked.failed = checked.failed
-        && any_valid_error(lhs.len(), valid_bits, |idx| Op::apply(lhs[idx], rhs[idx]).1);
-    checked
-}
-
-fn checked_array_constant_all_lanes<T, Op>(lhs: &[T], rhs: T) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    collect_all_lanes(lhs.len(), |idx| Op::apply(lhs[idx], rhs))
-}
-
-fn checked_array_constant_valid_lanes<T, Op>(
-    lhs: &[T],
-    rhs: T,
-    valid_bits: &BitBuffer,
-) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    let mut checked = collect_all_lanes(lhs.len(), |idx| Op::apply(lhs[idx], rhs));
-
-    checked.failed =
-        checked.failed && any_valid_error(lhs.len(), valid_bits, |idx| Op::apply(lhs[idx], rhs).1);
-    checked
-}
-
-fn checked_constant_array_all_lanes<T, Op>(lhs: T, rhs: &[T]) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    collect_all_lanes(rhs.len(), |idx| Op::apply(lhs, rhs[idx]))
-}
-
-fn checked_constant_array_valid_lanes<T, Op>(
-    lhs: T,
-    rhs: &[T],
-    valid_bits: &BitBuffer,
-) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    let mut checked = collect_all_lanes(rhs.len(), |idx| Op::apply(lhs, rhs[idx]));
-
-    checked.failed =
-        checked.failed && any_valid_error(rhs.len(), valid_bits, |idx| Op::apply(lhs, rhs[idx]).1);
-    checked
-}
-
-fn collect_all_lanes<T, F>(len: usize, mut value_and_error_at: F) -> CheckedValues<T>
-where
-    T: NativePType,
-    F: FnMut(usize) -> (T, bool),
-{
-    let mut values = BufferMut::<T>::with_capacity(len);
-    let slots = values.spare_capacity_mut().as_mut_ptr();
-    let mut failed = false;
-    for idx in 0..len {
-        let (value, is_error) = value_and_error_at(idx);
-        failed |= is_error;
-        // SAFETY: `idx < len <= capacity`, and each slot is written once.
-        unsafe { slots.add(idx).write(std::mem::MaybeUninit::new(value)) };
-    }
-    // SAFETY: every slot in `0..len` was initialized above.
-    unsafe { values.set_len(len) };
-    CheckedValues {
-        values: values.freeze(),
-        failed,
-    }
-}
-
-fn checked_array_array_one_pass<T, Op>(lhs: &[T], rhs: &[T]) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    checked_all_lanes(lhs.len(), |idx| Op::checked(lhs[idx], rhs[idx]))
-}
-
-fn checked_array_array_valid_lanes_one_pass<T, Op>(
-    lhs: &[T],
-    rhs: &[T],
-    valid_bits: &BitBuffer,
-) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    checked_valid_lanes(lhs.len(), valid_bits, |idx| Op::checked(lhs[idx], rhs[idx]))
-}
-
-fn checked_array_constant_one_pass<T, Op>(lhs: &[T], rhs: T) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    checked_all_lanes(lhs.len(), |idx| Op::checked(lhs[idx], rhs))
-}
-
-fn checked_array_constant_valid_lanes_one_pass<T, Op>(
-    lhs: &[T],
-    rhs: T,
-    valid_bits: &BitBuffer,
-) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    checked_valid_lanes(lhs.len(), valid_bits, |idx| Op::checked(lhs[idx], rhs))
-}
-
-fn checked_constant_array_one_pass<T, Op>(lhs: T, rhs: &[T]) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    checked_all_lanes(rhs.len(), |idx| Op::checked(lhs, rhs[idx]))
-}
-
-fn checked_constant_array_valid_lanes_one_pass<T, Op>(
-    lhs: T,
-    rhs: &[T],
-    valid_bits: &BitBuffer,
-) -> CheckedValues<T>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    checked_valid_lanes(rhs.len(), valid_bits, |idx| Op::checked(lhs, rhs[idx]))
 }
 
 trait CheckedArithmetic: NativePType {

--- a/vortex-compute/src/lane_kernels/map_into.rs
+++ b/vortex-compute/src/lane_kernels/map_into.rs
@@ -217,6 +217,52 @@ pub trait IndexedSourceExt: IndexedSource + Sized {
         }
     }
 
+    /// Split value/error map with **no validity awareness at all**: apply
+    /// `f(value) -> (R, bool)` to every lane, write the value unconditionally, and
+    /// OR-reduce the per-lane error flags into the returned `bool`.
+    ///
+    /// This is the highest-throughput checked shape for operations whose error
+    /// check auto-vectorizes (e.g. checked integer add/sub/mul): the loop carries a
+    /// single flag reduction with no per-lane select and no per-chunk exit branch,
+    /// so it runs at the speed of the unchecked [`map_into`]. The trade-off is that
+    /// it reports only *whether* some lane failed, not which one, and it never
+    /// exits early. Callers that need attribution or null-lane filtering should
+    /// re-run the (now known cold) input through [`try_map_into`] or
+    /// [`try_map_masked_into`] when this returns `true`.
+    ///
+    /// The flag is deliberately reduced inside the kernel rather than through a
+    /// closure-captured `&mut bool`: an escaped flag becomes a loop-carried memory
+    /// dependence that blocks auto-vectorization of the whole loop.
+    ///
+    /// [`map_into`]: IndexedSourceExt::map_into
+    /// [`try_map_into`]: IndexedSourceExt::try_map_into
+    /// [`try_map_masked_into`]: IndexedSourceExt::try_map_masked_into
+    ///
+    /// # Panics
+    ///
+    /// Panics if `out.len() != self.len()`.
+    #[inline]
+    fn map_checked_into<R, F>(self, out: &mut [MaybeUninit<R>], mut f: F) -> bool
+    where
+        R: Copy,
+        F: FnMut(Self::Item) -> (R, bool),
+    {
+        let values = self;
+        let len = values.len();
+        assert_eq!(out.len(), len, "out must have the same length as values");
+
+        let mut failed = false;
+        for idx in 0..len {
+            // SAFETY: idx < len by the loop bound, and out.len() == len.
+            let val = unsafe { values.get_unchecked(idx) };
+            let (result, error) = f(val);
+            failed |= error;
+            // SAFETY: idx < len == out.len().
+            unsafe { out.get_unchecked_mut(idx).write(result) };
+        }
+        failed
+    }
+
     /// Fallible map with **no validity awareness at all** — every `None` returned
     /// by the closure is treated as a failure, even at null lanes.
     ///
@@ -544,6 +590,26 @@ mod tests {
             (v <= u32::MAX as u64).then_some(v as u32)
         });
         assert!(res.is_ok(), "null lane should bypass the range check");
+    }
+
+    #[test]
+    fn map_checked_into_writes_all_lanes_and_reduces_flag() {
+        let mut values: Vec<u64> = (0..130).collect();
+        let mut out = vec![MaybeUninit::<u32>::uninit(); 130];
+        let failed = values
+            .as_slice()
+            .map_checked_into(&mut out, |v| (v as u32, v > u32::MAX as u64));
+        assert!(!failed);
+        assert_eq!(write_t(out), (0..130u32).collect::<Vec<_>>());
+
+        values[77] = (u32::MAX as u64) + 1;
+        let mut out = vec![MaybeUninit::<u32>::uninit(); 130];
+        let failed = values
+            .as_slice()
+            .map_checked_into(&mut out, |v| (v as u32, v > u32::MAX as u64));
+        assert!(failed);
+        // Failing lanes still write their (wrapped) value.
+        assert_eq!(write_t(out)[76], 76);
     }
 
     #[test]

--- a/vortex-compute/src/lane_kernels/source.rs
+++ b/vortex-compute/src/lane_kernels/source.rs
@@ -57,6 +57,7 @@ impl<T: Copy> IndexedSource for &mut [T] {
 ///
 /// Use this to drive a binary kernel from two columns. Length equality is enforced
 /// at construction.
+#[derive(Clone, Copy)]
 pub struct LaneZip<A, B>(pub A, pub B);
 
 impl<A: IndexedSource, B: IndexedSource> LaneZip<A, B> {


### PR DESCRIPTION
Essentially unifiying the LaneZip with numerical compute functions required
adding another function `IndexedSourceExt::map_checked_into` —
a split value/error kernel (f(item) -> (R, bool), writes every lane, OR-reduces one flag, no early exit)

With that the numerical compute functions get simd support and we don't have to
special case them for primitive compute. map_into doesn't work because the bool
exit flag prevents vectorisation, hence we need to carry the error in the loop
and only afterwards recheck the failures

fix #8922 
