### PR TITLE
Exclude Markdown from ruff format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ docs = { workspace = true }
 line-length = 120
 extend-exclude = [".venv", "vortex-duckdb/duckdb/**"]
 
+[tool.ruff.format]
+# ruff 0.16 started formatting Python code blocks inside Markdown by default; our docs use
+# deliberate alignment in code examples, so keep Markdown out of the formatter.
+exclude = ["*.md"]
+
 [tool.ruff.lint]
 select = ["F", "E", "W", "UP", "I"]
 # Do not auto-fix unused variables. This is really annoying when IntelliJ runs autofix while editing.


### PR DESCRIPTION
## Rationale for this change

The `Python (lint)` CI job is failing on `develop`: CI installs ruff unpinned via `uvx`, and ruff 0.16 started formatting Python code blocks inside Markdown files by default. Three docs (`docs/user-guide/spark.md`, `java/vortex-spark/README.md`, `vortex-python-cuda/README.md`) use deliberate comment alignment in their examples and now fail `ruff format --check`.

## What changes are included in this PR?

Adds `exclude = ["*.md"]` under `[tool.ruff.format]`, restoring the pre-0.16 behavior (Python sources only — 137 files — are formatted; `ruff check` is unaffected). Verified locally with ruff 0.16.0: `uvx ruff format --check .` and `uvx ruff check .` both pass.

## What APIs are changed? Are there any user-facing changes?

None — lint configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)