### PR TITLE
duckdb: proper error messsage on COPY to invalid file

### DIFF
--- a/vortex-duckdb/src/copy.rs
+++ b/vortex-duckdb/src/copy.rs
@@ -17,6 +17,7 @@ use vortex::dtype::Nullability::Nullable;
 use vortex::dtype::StructFields;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
+use vortex::error::vortex_bail;
 use vortex::error::vortex_err;
 use vortex::file::WriteOptionsSessionExt;
 use vortex::file::WriteSummary;
@@ -88,10 +89,22 @@ pub fn copy_to_sink(
         .as_ref()
         .ok_or_else(|| vortex_err!("sink closed early"))?
         .clone();
-    RUNTIME
-        .block_on(sink.send(chunk))
-        .map_err(|e| vortex_err!("send error {e}"))?;
-    Ok(())
+    RUNTIME.block_on(async {
+        // sink.send may error with "receiver is gone" which isn't the
+        // real error
+        if sink.send(chunk).await.is_ok() {
+            return Ok(());
+        }
+        let task;
+        {
+            task = init_global.write_task.lock().take();
+        }
+        if let Some(task) = task {
+            // we can get the real error (i.e invalid path) from here
+            task.await?;
+        }
+        vortex_bail!("Writer stopped before all data was written")
+    })
 }
 
 pub fn copy_to_finalize(init_global: &mut CopyFunctionGlobal) -> VortexResult<()> {

--- a/vortex-sqllogictest/slt/duckdb/copy_errors.slt
+++ b/vortex-sqllogictest/slt/duckdb/copy_errors.slt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+include ../setup.slt.no
+
+statement error No such file or directory
+COPY (SELECT list_value(1, generate_series) AS a FROM generate_series(10))
+TO '${WORK_DIR}/does-not-exist/probe.vortex';


### PR DESCRIPTION
Replace generic "receiver is gone" error with real error message when COPY
function fails e.g. because it tries to write to a non-existent path.
