### PR TITLE
duckdb: pushdown expressions with LIMIT

### DIFF
--- a/vortex-bench/sql/statpopgen.sql
+++ b/vortex-bench/sql/statpopgen.sql
@@ -4,7 +4,7 @@ SELECT COUNT(*) FROM statpopgen;
 --
 -- Count the number of samples (e.g. human beings) in this dataset. The GT arrays are all the same
 -- length, even though they're not stored as a fixed-list type.
-SELECT array_length("GT", 1) FROM statpopgen LIMIT 1;
+SELECT array_length("GT") FROM statpopgen LIMIT 1;
 -- 2.
 --
 -- Extract just the genotypes as a dense list of lists. Usually this is sent to a linear algebra

--- a/vortex-duckdb/cpp/optimizer.cpp
+++ b/vortex-duckdb/cpp/optimizer.cpp
@@ -5,6 +5,7 @@
 
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_limit.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 
 void FindGetsAndProjections(LogicalOperator &op, Analyses &analyses, Projections &projections) {
@@ -20,12 +21,23 @@ void FindGetsAndProjections(LogicalOperator &op, Analyses &analyses, Projections
         LogicalProjection &projection = op.Cast<LogicalProjection>();
         D_ASSERT(projection.children.size() == 1);
         auto &child = *projection.children[0];
-        if (!IsPassthrough(projection) || child.type != LOGICAL_GET) {
+        if (!IsPassthrough(projection)) {
             break;
         }
-        // The GET itself is recorded when recursion reaches it below. Only
-        // passthrough projections wrapping a vortex GET act as aliases.
-        if (auto &get = child.Cast<LogicalGet>(); get.function.bind == duckdb_vx_table_function_bind) {
+        LogicalGet *get = nullptr;
+
+        // queries with LIMIT may include a STREAMING_LIMIT between PROJECTION and GET.
+        // See sqllogictest scalar_function_pushdown_limit.test
+        if (child.type == LOGICAL_LIMIT) {
+            if (auto &limit = child.Cast<LogicalLimit>();
+                limit.children.size() == 1 && limit.children[0]->type == LOGICAL_GET) {
+                get = &limit.children[0]->Cast<LogicalGet>();
+            }
+        } else if (child.type == LOGICAL_GET) {
+            get = &child.Cast<LogicalGet>();
+        }
+
+        if (get != nullptr && get->function.bind == duckdb_vx_table_function_bind) {
             projections.emplace(projection.table_index, projection);
         }
         break;

--- a/vortex-duckdb/cpp/scalar_fn_pushdown.cpp
+++ b/vortex-duckdb/cpp/scalar_fn_pushdown.cpp
@@ -4,6 +4,7 @@
 
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "optimizer.hpp"
 
 #include <optional>
 

--- a/vortex-sqllogictest/slt/duckdb/projection_expression_pushdown_limit.slt
+++ b/vortex-sqllogictest/slt/duckdb/projection_expression_pushdown_limit.slt
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+include ../setup.slt.no
+
+statement ok
+COPY (SELECT
+    list_value(1, generate_series) AS a FROM generate_series(10)
+) TO '${WORK_DIR}/pe-pushdown-limit.vortex';
+
+statement ok
+CREATE VIEW list_pe AS SELECT a FROM '${WORK_DIR}/pe-pushdown-limit.vortex';
+
+query TT
+EXPLAIN
+SELECT array_length(a) FROM list_pe LIMIT 1;
+----
+<REGEX>:SELECT projections


### PR DESCRIPTION
If we select from a VIEW, and the query selection from a VIEW has a LIMIT,
duckdb inserts a STREAMING_LIMIT node between a LOGICAL_PROJECTION and a
LOGICAL_GET which prevents pushdown. Account for that in the optimizer pass.

Replace statpopgen's 1 query to array_length's non-deprecated variant.

#8764 
