### PR TITLE
feat[compressor]: require schemes to declare their produced encodings

### DIFF
--- a/vortex-btrblocks/src/builder.rs
+++ b/vortex-btrblocks/src/builder.rs
@@ -3,6 +3,7 @@
 
 //! Builder for configuring `BtrBlocksCompressor` instances.
 
+use vortex_array::ArrayId;
 use vortex_utils::aliases::hash_set::HashSet;
 
 use crate::BtrBlocksCompressor;
@@ -208,6 +209,16 @@ impl BtrBlocksCompressorBuilder {
         self
     }
 
+    /// Retains only schemes whose produced encodings all belong to `allowed`.
+    ///
+    /// The file writer uses this to restrict compression to the encodings of its configured
+    /// editions.
+    pub fn retain_allowed_encodings(mut self, allowed: &HashSet<ArrayId>) -> Self {
+        self.schemes
+            .retain(|s| s.produced_encodings().iter().all(|id| allowed.contains(id)));
+        self
+    }
+
     /// Builds the configured [`BtrBlocksCompressor`].
     pub fn build(self) -> BtrBlocksCompressor {
         BtrBlocksCompressor(CascadingCompressor::new(self.schemes))
@@ -216,6 +227,9 @@ impl BtrBlocksCompressorBuilder {
 
 #[cfg(test)]
 mod tests {
+    use vortex_array::VTable;
+    use vortex_fastlanes::FoR;
+
     use super::*;
 
     #[test]
@@ -227,6 +241,27 @@ mod tests {
     #[test]
     fn default_includes_all_schemes() {
         let builder = BtrBlocksCompressorBuilder::default();
+        assert_eq!(builder.schemes.len(), ALL_SCHEMES.len());
+    }
+
+    #[test]
+    fn retain_allowed_encodings_filters_schemes() {
+        let allowed: HashSet<ArrayId> = [FoR.id()].into_iter().collect();
+        let builder = BtrBlocksCompressorBuilder::default().retain_allowed_encodings(&allowed);
+        assert_eq!(builder.schemes.len(), 1);
+        assert_eq!(builder.schemes[0].id(), integer::FoRScheme.id());
+
+        let none = BtrBlocksCompressorBuilder::default().retain_allowed_encodings(&HashSet::new());
+        assert!(none.schemes.is_empty());
+    }
+
+    #[test]
+    fn retaining_all_declared_outputs_keeps_every_scheme() {
+        let allowed: HashSet<ArrayId> = ALL_SCHEMES
+            .iter()
+            .flat_map(|scheme| scheme.produced_encodings())
+            .collect();
+        let builder = BtrBlocksCompressorBuilder::default().retain_allowed_encodings(&allowed);
         assert_eq!(builder.schemes.len(), ALL_SCHEMES.len());
     }
 

--- a/vortex-btrblocks/src/schemes/binary/zstd.rs
+++ b/vortex-btrblocks/src/schemes/binary/zstd.rs
@@ -3,10 +3,12 @@
 
 //! Zstd compression for binary arrays.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_compressor::scheme::CompressionEstimate;
 use vortex_compressor::scheme::DeferredEstimate;
 use vortex_error::VortexResult;
@@ -27,6 +29,10 @@ impl Scheme for ZstdScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_binary()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![vortex_zstd::Zstd.id()]
     }
 
     fn expected_compression_ratio(

--- a/vortex-btrblocks/src/schemes/binary/zstd_buffers.rs
+++ b/vortex-btrblocks/src/schemes/binary/zstd_buffers.rs
@@ -3,10 +3,12 @@
 
 //! Zstd buffer-level binary compression preserving array layout for GPU decompression.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_compressor::scheme::CompressionEstimate;
 use vortex_compressor::scheme::DeferredEstimate;
 use vortex_error::VortexResult;
@@ -27,6 +29,10 @@ impl Scheme for ZstdBuffersScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_binary()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![vortex_zstd::ZstdBuffers.id()]
     }
 
     fn expected_compression_ratio(

--- a/vortex-btrblocks/src/schemes/decimal.rs
+++ b/vortex-btrblocks/src/schemes/decimal.rs
@@ -3,10 +3,12 @@
 
 //! Decimal compression scheme using byte-part decomposition.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_array::arrays::DecimalArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::decimal::narrowed_decimal;
@@ -36,6 +38,10 @@ impl Scheme for DecimalScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         matches!(canonical, Canonical::Decimal(_))
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![DecimalByteParts.id()]
     }
 
     /// Children: primitive=0.

--- a/vortex-btrblocks/src/schemes/float/alp.rs
+++ b/vortex-btrblocks/src/schemes/float/alp.rs
@@ -7,10 +7,12 @@ use vortex_alp::ALP;
 use vortex_alp::ALPArrayExt;
 use vortex_alp::ALPArraySlotsExt;
 use vortex_alp::alp_encode;
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_array::arrays::Patched;
 use vortex_array::arrays::patched::use_experimental_patches;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
@@ -38,6 +40,14 @@ impl Scheme for ALPScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_float()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        let mut encodings = vec![ALP.id()];
+        if use_experimental_patches() {
+            encodings.push(Patched.id());
+        }
+        encodings
     }
 
     /// Children: encoded_ints=0.

--- a/vortex-btrblocks/src/schemes/float/alprd.rs
+++ b/vortex-btrblocks/src/schemes/float/alprd.rs
@@ -6,10 +6,12 @@
 use vortex_alp::ALPRDArrayExt;
 use vortex_alp::ALPRDArrayOwnedExt;
 use vortex_alp::RDEncoder;
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_array::dtype::PType;
 use vortex_compressor::scheme::CompressionEstimate;
@@ -35,6 +37,10 @@ impl Scheme for ALPRDScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_float()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![vortex_alp::ALPRD.id()]
     }
 
     fn expected_compression_ratio(

--- a/vortex-btrblocks/src/schemes/float/pco.rs
+++ b/vortex-btrblocks/src/schemes/float/pco.rs
@@ -3,10 +3,12 @@
 
 //! Pco (pcodec) float compression.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_compressor::scheme::CompressionEstimate;
 use vortex_compressor::scheme::DeferredEstimate;
 use vortex_error::VortexResult;
@@ -27,6 +29,10 @@ impl Scheme for PcoScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_float()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![vortex_pco::Pco.id()]
     }
 
     fn expected_compression_ratio(

--- a/vortex-btrblocks/src/schemes/float/rle.rs
+++ b/vortex-btrblocks/src/schemes/float/rle.rs
@@ -3,15 +3,18 @@
 
 //! Run-length float encoding.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
+use vortex_array::VTable;
 use vortex_compressor::scheme::AncestorExclusion;
 use vortex_compressor::scheme::CompressionEstimate;
 use vortex_compressor::scheme::DeferredEstimate;
 use vortex_compressor::scheme::DescendantExclusion;
 use vortex_compressor::scheme::EstimateVerdict;
 use vortex_error::VortexResult;
+use vortex_fastlanes::RLE;
 
 use crate::ArrayAndStats;
 use crate::CascadingCompressor;
@@ -33,6 +36,10 @@ impl Scheme for FloatRLEScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_float()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![RLE.id()]
     }
 
     /// Children: values=0, indices=1, offsets=2.

--- a/vortex-btrblocks/src/schemes/float/sparse.rs
+++ b/vortex-btrblocks/src/schemes/float/sparse.rs
@@ -3,10 +3,12 @@
 
 //! Sparse encoding for null-dominated float arrays.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_compressor::scheme::ChildSelection;
@@ -37,6 +39,10 @@ impl Scheme for NullDominatedSparseScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_float()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![Sparse.id()]
     }
 
     /// Children: indices=0.

--- a/vortex-btrblocks/src/schemes/integer/bitpacking.rs
+++ b/vortex-btrblocks/src/schemes/integer/bitpacking.rs
@@ -3,10 +3,12 @@
 
 //! BitPacking integer encoding.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_array::arrays::Patched;
 use vortex_array::arrays::patched::use_experimental_patches;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
@@ -36,6 +38,14 @@ impl Scheme for BitPackingScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_int()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        let mut encodings = vec![BitPacked.id()];
+        if use_experimental_patches() {
+            encodings.push(Patched.id());
+        }
+        encodings
     }
 
     fn expected_compression_ratio(

--- a/vortex-btrblocks/src/schemes/integer/delta.rs
+++ b/vortex-btrblocks/src/schemes/integer/delta.rs
@@ -3,10 +3,12 @@
 
 //! FastLanes Delta integer encoding.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_compressor::builtins::BinaryDictScheme;
 use vortex_compressor::builtins::FloatDictScheme;
@@ -76,6 +78,10 @@ impl Scheme for DeltaScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_int()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![Delta.id()]
     }
 
     fn num_children(&self) -> usize {

--- a/vortex-btrblocks/src/schemes/integer/for_.rs
+++ b/vortex-btrblocks/src/schemes/integer/for_.rs
@@ -3,10 +3,12 @@
 
 //! Frame of Reference integer encoding.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_compressor::builtins::BinaryDictScheme;
 use vortex_compressor::builtins::FloatDictScheme;
@@ -39,6 +41,10 @@ impl Scheme for FoRScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_int()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![FoR.id()]
     }
 
     /// Dict codes always start at 0, so FoR (which subtracts the min) is a no-op.

--- a/vortex-btrblocks/src/schemes/integer/pco.rs
+++ b/vortex-btrblocks/src/schemes/integer/pco.rs
@@ -3,10 +3,12 @@
 
 //! Pco (pcodec) integer compression.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_compressor::scheme::CompressionEstimate;
 use vortex_compressor::scheme::DeferredEstimate;
 use vortex_compressor::scheme::EstimateVerdict;
@@ -28,6 +30,10 @@ impl Scheme for PcoScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_int()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![vortex_pco::Pco.id()]
     }
 
     fn expected_compression_ratio(

--- a/vortex-btrblocks/src/schemes/integer/rle.rs
+++ b/vortex-btrblocks/src/schemes/integer/rle.rs
@@ -3,10 +3,12 @@
 
 //! Run-length integer encoding and shared RLE compression helpers.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_compressor::scheme::AncestorExclusion;
@@ -154,6 +156,10 @@ impl Scheme for IntRLEScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_int()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![RLE.id()]
     }
 
     /// Children: values=0, indices=1, offsets=2.

--- a/vortex-btrblocks/src/schemes/integer/runend.rs
+++ b/vortex-btrblocks/src/schemes/integer/runend.rs
@@ -3,10 +3,12 @@
 
 //! Run-end integer encoding.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_compressor::builtins::BinaryDictScheme;
 use vortex_compressor::builtins::FloatDictScheme;
@@ -44,6 +46,10 @@ impl Scheme for RunEndScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_int()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![RunEnd.id()]
     }
 
     /// Children: values=0, ends=1.

--- a/vortex-btrblocks/src/schemes/integer/sequence.rs
+++ b/vortex-btrblocks/src/schemes/integer/sequence.rs
@@ -3,9 +3,11 @@
 
 //! Sequence integer encoding for sequential patterns.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
+use vortex_array::VTable;
 use vortex_compressor::builtins::BinaryDictScheme;
 use vortex_compressor::builtins::FloatDictScheme;
 use vortex_compressor::builtins::IntDictScheme;
@@ -19,6 +21,7 @@ use vortex_compressor::scheme::EstimateVerdict;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
+use vortex_sequence::Sequence;
 use vortex_sequence::sequence_encode;
 
 use crate::ArrayAndStats;
@@ -38,6 +41,10 @@ impl Scheme for SequenceScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_int()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![Sequence.id()]
     }
 
     /// Sequence encoding on dictionary codes just adds a layer of indirection without compressing

--- a/vortex-btrblocks/src/schemes/integer/sparse.rs
+++ b/vortex-btrblocks/src/schemes/integer/sparse.rs
@@ -3,10 +3,13 @@
 
 //! Sparse integer encoding for single-value-dominated arrays.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
+use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
@@ -41,6 +44,10 @@ impl Scheme for SparseScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_int()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![Sparse.id(), Constant.id()]
     }
 
     fn stats_options(&self) -> GenerateStatsOptions {

--- a/vortex-btrblocks/src/schemes/integer/zigzag.rs
+++ b/vortex-btrblocks/src/schemes/integer/zigzag.rs
@@ -3,10 +3,12 @@
 
 //! ZigZag integer encoding for signed integers.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_compressor::builtins::BinaryDictScheme;
 use vortex_compressor::builtins::FloatDictScheme;
@@ -42,6 +44,10 @@ impl Scheme for ZigZagScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_int()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![ZigZag.id()]
     }
 
     /// Children: encoded=0.

--- a/vortex-btrblocks/src/schemes/string/fsst.rs
+++ b/vortex-btrblocks/src/schemes/string/fsst.rs
@@ -3,11 +3,14 @@
 
 //! FSST (Fast Static Symbol Table) string compression.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::VarBin;
 use vortex_array::arrays::VarBinArray;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_array::arrays::varbin::VarBinArrayExt;
@@ -41,6 +44,10 @@ impl Scheme for FSSTScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_utf8()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![FSST.id(), VarBin.id()]
     }
 
     /// Children: lengths=0, code_offsets=1.

--- a/vortex-btrblocks/src/schemes/string/onpair.rs
+++ b/vortex-btrblocks/src/schemes/string/onpair.rs
@@ -3,10 +3,12 @@
 
 //! OnPair short-string compression (dict-12).
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_compressor::scheme::CompressionEstimate;
@@ -45,6 +47,10 @@ impl Scheme for OnPairScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_utf8()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![OnPair.id()]
     }
 
     /// 4 primitive slot children flow through the cascading compressor:

--- a/vortex-btrblocks/src/schemes/string/sparse.rs
+++ b/vortex-btrblocks/src/schemes/string/sparse.rs
@@ -3,10 +3,12 @@
 
 //! Sparse encoding for null-dominated string arrays.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_compressor::scheme::ChildSelection;
@@ -38,6 +40,10 @@ impl Scheme for NullDominatedSparseScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_utf8()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![Sparse.id()]
     }
 
     /// Children: indices=0.

--- a/vortex-btrblocks/src/schemes/string/zstd.rs
+++ b/vortex-btrblocks/src/schemes/string/zstd.rs
@@ -3,10 +3,12 @@
 
 //! Zstd string compression without dictionaries (nvCOMP compatible).
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_compressor::scheme::CompressionEstimate;
 use vortex_compressor::scheme::DeferredEstimate;
 use vortex_error::VortexResult;
@@ -27,6 +29,10 @@ impl Scheme for ZstdScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_utf8()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![vortex_zstd::Zstd.id()]
     }
 
     fn expected_compression_ratio(

--- a/vortex-btrblocks/src/schemes/string/zstd_buffers.rs
+++ b/vortex-btrblocks/src/schemes/string/zstd_buffers.rs
@@ -3,10 +3,12 @@
 
 //! Zstd buffer-level string compression preserving array layout for GPU decompression.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_compressor::scheme::CompressionEstimate;
 use vortex_compressor::scheme::DeferredEstimate;
 use vortex_error::VortexResult;
@@ -27,6 +29,10 @@ impl Scheme for ZstdBuffersScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_utf8()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![vortex_zstd::ZstdBuffers.id()]
     }
 
     fn expected_compression_ratio(

--- a/vortex-btrblocks/src/schemes/temporal.rs
+++ b/vortex-btrblocks/src/schemes/temporal.rs
@@ -3,10 +3,12 @@
 
 //! Temporal compression scheme using datetime-part decomposition.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::TemporalArray;
@@ -51,6 +53,10 @@ impl Scheme for TemporalScheme {
             AnyTemporal::try_match(ext_dtype),
             Some(TemporalMetadata::Timestamp(..))
         )
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![DateTimeParts.id()]
     }
 
     /// Children: days=0, seconds=1, subseconds=2.

--- a/vortex-compressor/src/builtins/dict/binary.rs
+++ b/vortex-compressor/src/builtins/dict/binary.rs
@@ -6,10 +6,13 @@
 //! Vortex encoders must always produce unsigned integer codes; signed codes are only accepted
 //! for external compatibility.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
+use vortex_array::arrays::Dict;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::dict::DictArrayExt;
@@ -43,6 +46,10 @@ impl Scheme for BinaryDictScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_binary()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![Dict.id()]
     }
 
     fn stats_options(&self) -> GenerateStatsOptions {

--- a/vortex-compressor/src/builtins/dict/float.rs
+++ b/vortex-compressor/src/builtins/dict/float.rs
@@ -6,11 +6,14 @@
 //! Vortex encoders must always produce unsigned integer codes; signed codes are only accepted for
 //! external compatibility.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
+use vortex_array::arrays::Dict;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
@@ -49,6 +52,10 @@ impl Scheme for FloatDictScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_float()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![Dict.id()]
     }
 
     fn stats_options(&self) -> GenerateStatsOptions {

--- a/vortex-compressor/src/builtins/dict/integer.rs
+++ b/vortex-compressor/src/builtins/dict/integer.rs
@@ -6,11 +6,14 @@
 //! Vortex encoders must always produce unsigned integer codes; signed codes are only accepted
 //! for external compatibility.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
+use vortex_array::arrays::Dict;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
@@ -44,6 +47,10 @@ impl Scheme for IntDictScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_int()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![Dict.id()]
     }
 
     fn stats_options(&self) -> GenerateStatsOptions {

--- a/vortex-compressor/src/builtins/dict/string.rs
+++ b/vortex-compressor/src/builtins/dict/string.rs
@@ -6,10 +6,13 @@
 //! Vortex encoders must always produce unsigned integer codes; signed codes are only accepted
 //! for external compatibility.
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::VTable;
+use vortex_array::arrays::Dict;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::dict::DictArrayExt;
@@ -43,6 +46,10 @@ impl Scheme for StringDictScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         canonical.dtype().is_utf8()
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![Dict.id()]
     }
 
     fn stats_options(&self) -> GenerateStatsOptions {

--- a/vortex-compressor/src/compressor/tests.rs
+++ b/vortex-compressor/src/compressor/tests.rs
@@ -4,6 +4,7 @@
 use std::sync::LazyLock;
 
 use parking_lot::Mutex;
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
@@ -63,6 +64,10 @@ impl Scheme for DirectRatioScheme {
         matches_integer_primitive(canonical)
     }
 
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        Vec::new()
+    }
+
     fn expected_compression_ratio(
         &self,
         _data: &ArrayAndStats,
@@ -95,6 +100,10 @@ impl Scheme for ImmediateAlwaysUseScheme {
         matches_integer_primitive(canonical)
     }
 
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        Vec::new()
+    }
+
     fn expected_compression_ratio(
         &self,
         _data: &ArrayAndStats,
@@ -125,6 +134,10 @@ impl Scheme for CallbackAlwaysUseScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         matches_integer_primitive(canonical)
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        Vec::new()
     }
 
     fn expected_compression_ratio(
@@ -161,6 +174,10 @@ impl Scheme for CallbackSkipScheme {
         matches_integer_primitive(canonical)
     }
 
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        Vec::new()
+    }
+
     fn expected_compression_ratio(
         &self,
         _data: &ArrayAndStats,
@@ -193,6 +210,10 @@ impl Scheme for CallbackRatioScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         matches_integer_primitive(canonical)
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        Vec::new()
     }
 
     fn expected_compression_ratio(
@@ -229,6 +250,10 @@ impl Scheme for HugeRatioScheme {
         matches_integer_primitive(canonical)
     }
 
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        Vec::new()
+    }
+
     fn expected_compression_ratio(
         &self,
         _data: &ArrayAndStats,
@@ -259,6 +284,10 @@ impl Scheme for ZeroBytesSamplingScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         matches_integer_primitive(canonical)
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        Vec::new()
     }
 
     fn expected_compression_ratio(
@@ -470,6 +499,10 @@ impl Scheme for ThresholdObservingScheme {
         matches_integer_primitive(canonical)
     }
 
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        Vec::new()
+    }
+
     fn expected_compression_ratio(
         &self,
         _data: &ArrayAndStats,
@@ -505,6 +538,10 @@ impl Scheme for CallbackMatchingRatioScheme {
 
     fn matches(&self, canonical: &Canonical) -> bool {
         matches_integer_primitive(canonical)
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        Vec::new()
     }
 
     fn expected_compression_ratio(

--- a/vortex-compressor/src/scheme/mod.rs
+++ b/vortex-compressor/src/scheme/mod.rs
@@ -23,6 +23,7 @@ pub use estimate::EstimateVerdict;
 pub use exclusion::AncestorExclusion;
 pub use exclusion::ChildSelection;
 pub use exclusion::DescendantExclusion;
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
@@ -122,6 +123,13 @@ pub trait Scheme: Debug + Send + Sync {
 
     /// Whether this scheme can compress the given canonical array.
     fn matches(&self, canonical: &Canonical) -> bool;
+
+    /// The array encodings this scheme itself may introduce into its compressed output.
+    ///
+    /// Cascaded children are compressed by other schemes, which declare their own encodings,
+    /// so only encodings constructed directly by [`compress`](Scheme::compress) belong here.
+    /// Canonical arrays the scheme merely rearranges do not need to be declared.
+    fn produced_encodings(&self) -> Vec<ArrayId>;
 
     /// Returns the stats generation options this scheme requires. The compressor merges all
     /// eligible schemes' options before generating stats so that a single stats pass satisfies

--- a/vortex-tensor/src/encodings/l2_denorm.rs
+++ b/vortex-tensor/src/encodings/l2_denorm.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
+use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_compressor::CascadingCompressor;
 use vortex_compressor::scheme::CompressionEstimate;
 use vortex_compressor::scheme::CompressorContext;
@@ -15,6 +17,7 @@ use vortex_compressor::stats::ArrayAndStats;
 use vortex_error::VortexResult;
 
 use crate::matcher::AnyTensor;
+use crate::scalar_fns::l2_denorm::L2Denorm;
 use crate::scalar_fns::l2_denorm::normalize_as_l2_denorm;
 
 #[derive(Debug)]
@@ -30,6 +33,10 @@ impl Scheme for L2DenormScheme {
             canonical,
             Canonical::Extension(ext) if ext.ext_dtype().is::<AnyTensor>()
         )
+    }
+
+    fn produced_encodings(&self) -> Vec<ArrayId> {
+        vec![L2Denorm.id()]
     }
 
     fn expected_compression_ratio(


### PR DESCRIPTION
## Summary

Adds a required `Scheme::produced_encodings() -> Vec<ArrayId>` method returning the array encodings a scheme may itself introduce into its compressed output. Cascaded children are compressed by other schemes, which declare their own encodings, so only encodings constructed directly by `compress` belong here; canonical arrays the scheme merely rearranges do not need to be declared.

`BtrBlocksCompressorBuilder::retain_allowed_encodings` uses these declarations to drop any scheme that could produce an encoding outside a permitted set, so an encoding policy can be enforced *before* compression rather than being rejected after the fact.
