### PR TITLE
Expose ArrayRef::inner_mut() and ArrayInner fields as public

### DIFF
--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -79,19 +79,19 @@ pub struct ArrayRef(Arc<ArrayInner<dyn DynArrayData>>);
 
 impl ArrayRef {
     /// Create from an `Arc<ArrayInner<dyn DynArrayData>>`.
-    pub(crate) fn from_inner<D: DynArrayData>(inner: Arc<ArrayInner<D>>) -> Self {
+    pub fn from_inner<D: DynArrayData>(inner: Arc<ArrayInner<D>>) -> Self {
         Self(inner)
     }
 
     /// Returns a reference to the `dyn DynArrayData` inside the inner.
     #[inline(always)]
-    pub(crate) fn dyn_array(&self) -> &dyn DynArrayData {
+    pub fn dyn_array(&self) -> &dyn DynArrayData {
         &self.0.data
     }
 
     /// Returns a mutable reference to the inner if this is the sole owner.
     #[inline(always)]
-    pub(crate) fn inner_mut(&mut self) -> Option<&mut ArrayInner<dyn DynArrayData>> {
+    pub fn inner_mut(&mut self) -> Option<&mut ArrayInner<dyn DynArrayData>> {
         Arc::get_mut(&mut self.0)
     }
 

--- a/vortex-array/src/array/typed.rs
+++ b/vortex-array/src/array/typed.rs
@@ -42,13 +42,13 @@ use crate::validity::Validity;
 /// `ArrayRef` stores `Arc<ArrayInner<dyn DynArrayData>>` — a single 16-byte fat pointer.
 /// Metadata is accessed via `self.0.*` (a normal struct field read through the Arc),
 /// while encoding-specific methods go through `self.0.data` (vtable dispatch).
-pub(crate) struct ArrayInner<D: ?Sized> {
-    pub(crate) len: usize,
-    pub(crate) encoding_id: ArrayId,
-    pub(crate) dtype: DType,
-    pub(crate) slots: ArraySlots,
-    pub(crate) stats: ArrayStats,
-    pub(crate) data: D, // must be last for unsized coercion
+pub struct ArrayInner<D: ?Sized> {
+    pub len: usize,
+    pub encoding_id: ArrayId,
+    pub dtype: DType,
+    pub slots: ArraySlots,
+    pub stats: ArrayStats,
+    pub data: D, // must be last for unsized coercion
 }
 
 /// Construction parameters for typed arrays.


### PR DESCRIPTION
## Motivation

For use cases that hold a unique `ArrayRef` (refcount 1) and want to mutate the underlying buffer in-place, there is currently no public API. The only path is `try_into_parts()` → `try_into_buffer_mut()` → mutate → `freeze()` → `from_buffer_handle()` → `from_parts_unchecked()` — which allocates a new `Arc` and a new `ArrayInner` every time, even though the original could be mutated in-place.

This is relevant for low-latency applications that mutate columns every tick and hold sole ownership of each `ArrayRef`.

## Changes

- `ArrayRef::inner_mut()`: `pub(crate)` → `pub`
- `ArrayRef::from_inner()`: `pub(crate)` → `pub`
- `ArrayRef::dyn_array()`: `pub(crate)` → `pub`
- `ArrayInner` struct + fields: `pub(crate)` → `pub`

These are visibility widenings only — no logic changes, no API breaks, no behavioral changes.

## Usage

```rust
let mut field: ArrayRef = columns.take(idx);
if let Some(inner) = field.inner_mut() {
    // Mutate the buffer in-place. Same Arc, same allocation.
    // No try_into_parts, no from_parts_unchecked, no Arc::new.
}
columns.put(idx, field); // same ArrayRef goes back
```