### PR TITLE
Back EnabledEditions with a session Registry

### DIFF
--- a/vortex-edition/src/session.rs
+++ b/vortex-edition/src/session.rs
@@ -12,6 +12,7 @@ use vortex_session::SessionExt;
 use vortex_session::SessionGuard;
 use vortex_session::SessionVar;
 use vortex_session::registry::Id;
+use vortex_session::registry::Registry;
 
 use crate::Edition;
 use crate::EditionDeclaration;
@@ -46,19 +47,24 @@ struct Inner {
 /// same family replaces the previous selection. This is separate from [`EditionSession`]:
 /// registration describes what a session knows how to reason about, while enabling is the
 /// explicit writer policy.
+///
+/// Backed by the shared session [`Registry`] keyed by edition family, so clones observe the
+/// same selection and enabling an edition replaces the family's previous entry.
 #[derive(Clone, Debug, Default)]
 pub struct EnabledEditions {
-    inner: Arc<RwLock<BTreeMap<&'static str, EditionId>>>,
+    inner: Registry<EditionId>,
 }
 
 impl EnabledEditions {
-    /// Return the enabled editions, sorted by family.
+    /// Return the enabled editions.
     pub fn editions(&self) -> Vec<EditionId> {
-        self.inner.read().values().copied().collect()
+        self.inner.items().collect()
     }
 
     fn enable(&self, edition: EditionId) {
-        self.inner.write().insert(edition.family, edition);
+        // The family is a `&'static str`; `Into<Id>` interns it once at enable time (a rare
+        // config-time write, never on the read path).
+        self.inner.register(edition.family, edition);
     }
 }
 

--- a/vortex-edition/src/tests.rs
+++ b/vortex-edition/src/tests.rs
@@ -184,7 +184,9 @@ fn enabled_editions_are_independent_across_families() -> Result<(), crate::Editi
     session.enable_edition(FIRST)?;
     session.enable_edition(OTHER)?;
 
-    assert_eq!(session.enabled_editions().editions(), [OTHER, FIRST]);
+    let mut enabled = session.enabled_editions().editions();
+    enabled.sort_unstable();
+    assert_eq!(enabled, [OTHER, FIRST]);
     assert_eq!(session.enabled_encoding_ids().len(), 3);
     Ok(())
 }


### PR DESCRIPTION
## Rationale for this change

Replace the `RwLock`-backed `BTreeMap` behind `EnabledEditions` with the shared
`Registry<EditionId>` used by the other session variables (array encodings, scalar functions,
layouts, dtypes), keyed by edition family.

Enabling an edition maps to `Registry::register`, which replaces the family's previous entry —
matching the "at most one edition per family" semantics directly. The family `&'static str` is
interned via `Into<Id>` only at enable time (a rare config-time write), so the disallowed
hot-path interning does not apply.

`editions()` no longer guarantees an ordering; the one test that asserted a specific order sorts
the result itself.