### PR TITLE
refactor(array): own struct field vectors

### DIFF
--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -3,7 +3,6 @@
 
 use std::borrow::Borrow;
 use std::iter::once;
-use std::sync::Arc;
 
 use itertools::Itertools;
 use vortex_error::VortexExpect;
@@ -159,7 +158,7 @@ pub(super) const FIELDS_OFFSET: usize = 1;
 /// ```
 pub struct StructDataParts {
     pub struct_fields: StructFields,
-    pub fields: Arc<[ArrayRef]>,
+    pub fields: Vec<ArrayRef>,
     pub validity: Validity,
 }
 
@@ -198,7 +197,7 @@ pub trait StructArrayExt: TypedArrayRef<Struct> {
             .map(|s| s.as_ref().vortex_expect("StructArray field slot"))
     }
 
-    fn unmasked_fields(&self) -> Arc<[ArrayRef]> {
+    fn unmasked_fields(&self) -> Vec<ArrayRef> {
         self.iter_unmasked_fields().cloned().collect()
     }
 
@@ -235,7 +234,7 @@ impl Array<Struct> {
     /// Creates a new `StructArray`.
     pub fn new(
         names: FieldNames,
-        fields: impl Into<Arc<[ArrayRef]>>,
+        fields: impl IntoIterator<Item = ArrayRef>,
         length: usize,
         validity: Validity,
     ) -> Self {
@@ -246,11 +245,11 @@ impl Array<Struct> {
     /// Constructs a new `StructArray`.
     pub fn try_new(
         names: FieldNames,
-        fields: impl Into<Arc<[ArrayRef]>>,
+        fields: impl IntoIterator<Item = ArrayRef>,
         length: usize,
         validity: Validity,
     ) -> VortexResult<Self> {
-        let fields = fields.into();
+        let fields: Vec<_> = fields.into_iter().collect();
         let field_dtypes: Vec<_> = fields.iter().map(|d| d.dtype().clone()).collect();
         let dtype = StructFields::new(names, field_dtypes);
         let slots = make_struct_slots(&fields, &validity, length);
@@ -271,12 +270,12 @@ impl Array<Struct> {
     ///
     /// Caller must ensure the field arrays match the supplied dtype, length, and validity.
     pub unsafe fn new_unchecked(
-        fields: impl Into<Arc<[ArrayRef]>>,
+        fields: impl IntoIterator<Item = ArrayRef>,
         dtype: StructFields,
         length: usize,
         validity: Validity,
     ) -> Self {
-        let fields = fields.into();
+        let fields: Vec<_> = fields.into_iter().collect();
         let outer_dtype = DType::Struct(dtype, validity.nullability());
         let slots = make_struct_slots(&fields, &validity, length);
         unsafe {
@@ -288,12 +287,12 @@ impl Array<Struct> {
 
     /// Constructs a new `StructArray` with an explicit dtype.
     pub fn try_new_with_dtype(
-        fields: impl Into<Arc<[ArrayRef]>>,
+        fields: impl IntoIterator<Item = ArrayRef>,
         dtype: StructFields,
         length: usize,
         validity: Validity,
     ) -> VortexResult<Self> {
-        let fields = fields.into();
+        let fields: Vec<_> = fields.into_iter().collect();
         let outer_dtype = DType::Struct(dtype, validity.nullability());
         let slots = make_struct_slots(&fields, &validity, length);
         Array::try_from_parts(
@@ -393,7 +392,7 @@ impl Array<Struct> {
 
     // TODO(ngates): remove this... it doesn't help to consume self.
     pub fn into_data_parts(self) -> StructDataParts {
-        let fields: Arc<[ArrayRef]> = self.slots()[FIELDS_OFFSET..]
+        let fields: Vec<ArrayRef> = self.slots()[FIELDS_OFFSET..]
             .iter()
             .map(|s| s.as_ref().vortex_expect("StructArray field slot").clone())
             .collect();
@@ -448,7 +447,7 @@ impl Array<Struct> {
         let types = struct_dtype.fields().chain(once(array.dtype().clone()));
         let new_fields = StructFields::new(names.collect(), types.collect());
 
-        let children: Arc<[ArrayRef]> = self.slots()[FIELDS_OFFSET..]
+        let children: Vec<ArrayRef> = self.slots()[FIELDS_OFFSET..]
             .iter()
             .map(|s| s.as_ref().vortex_expect("StructArray field slot").clone())
             .chain(once(array))

--- a/vortex-array/src/arrays/struct_/compute/mask.rs
+++ b/vortex-array/src/arrays/struct_/compute/mask.rs
@@ -15,7 +15,7 @@ use crate::validity::Validity;
 impl MaskReduce for Struct {
     fn mask(array: ArrayView<'_, Struct>, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         StructArray::try_new_with_dtype(
-            array.unmasked_fields().iter().cloned().collect::<Vec<_>>(),
+            array.unmasked_fields(),
             array.struct_fields().clone(),
             array.len(),
             array.validity()?.and(Validity::Array(mask.clone()))?,

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -228,7 +228,7 @@ impl Canonical {
                     struct_dtype
                         .fields()
                         .map(|f| Canonical::empty(&f).into_array())
-                        .collect::<Arc<[_]>>(),
+                        .collect::<Vec<_>>(),
                     struct_dtype.clone(),
                     0,
                     Validity::from(n),
@@ -854,9 +854,9 @@ impl Executable for RecursiveCanonical {
                     validity,
                 } = st.into_data_parts();
                 let executed_fields = fields
-                    .iter()
-                    .map(|f| Ok(f.clone().execute::<RecursiveCanonical>(ctx)?.0.into_array()))
-                    .collect::<VortexResult<Arc<[_]>>>()?;
+                    .into_iter()
+                    .map(|f| Ok(f.execute::<RecursiveCanonical>(ctx)?.0.into_array()))
+                    .collect::<VortexResult<Vec<_>>>()?;
 
                 Ok(RecursiveCanonical(Canonical::Struct(unsafe {
                     StructArray::new_unchecked(

--- a/vortex-duckdb/src/convert/vector.rs
+++ b/vortex-duckdb/src/convert/vector.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::sync::Arc;
-
 use num_traits::AsPrimitive;
 use vortex::array::ArrayRef;
 use vortex::array::IntoArray;
@@ -377,7 +375,7 @@ pub fn data_chunk_to_vortex(
             vector.flatten(len);
             flat_vector_to_vortex(vector, len.as_())
         })
-        .collect::<VortexResult<Arc<_>>>()?;
+        .collect::<VortexResult<Vec<_>>>()?;
     StructArray::try_new(
         field_names.clone(),
         columns,


### PR DESCRIPTION
## Summary

- change Struct array constructors to accept owned `ArrayRef` iterators
- expose Struct fields as `Vec<ArrayRef>` from `StructDataParts` and `unmasked_fields`
- update canonicalization and masking call sites to consume owned fields

## Why

A follow-up change needs to transfer Struct fields into `ArraySlots` without cloning every `ArrayRef`. This PR isolates the required public API changes so downstream impact can be reviewed separately.

