### PR TITLE
Register mask/slice execute-parent kernels for List and VarBin

### DIFF
--- a/vortex-array/src/arrays/list/compute/kernels.rs
+++ b/vortex-array/src/arrays/list/compute/kernels.rs
@@ -7,16 +7,22 @@ use crate::ArrayVTable;
 use crate::arrays::Dict;
 use crate::arrays::Filter;
 use crate::arrays::List;
+use crate::arrays::Slice;
 use crate::arrays::dict::TakeExecuteAdaptor;
 use crate::arrays::filter::FilterExecuteAdaptor;
+use crate::arrays::slice::SliceExecuteAdaptor;
 use crate::optimizer::kernels::ArrayKernelsExt;
 use crate::scalar_fn::ScalarFnVTable;
 use crate::scalar_fn::fns::cast::Cast;
 use crate::scalar_fn::fns::cast::CastExecuteAdaptor;
+use crate::scalar_fn::fns::mask::Mask;
+use crate::scalar_fn::fns::mask::MaskExecuteAdaptor;
 
 pub(crate) fn initialize(session: &VortexSession) {
     let kernels = session.kernels();
     kernels.register_execute_parent_kernel(Cast.id(), List, CastExecuteAdaptor(List));
     kernels.register_execute_parent_kernel(Filter.id(), List, FilterExecuteAdaptor(List));
     kernels.register_execute_parent_kernel(Dict.id(), List, TakeExecuteAdaptor(List));
+    kernels.register_execute_parent_kernel(Mask.id(), List, MaskExecuteAdaptor(List));
+    kernels.register_execute_parent_kernel(Slice.id(), List, SliceExecuteAdaptor(List));
 }

--- a/vortex-array/src/arrays/list/compute/mask.rs
+++ b/vortex-array/src/arrays/list/compute/mask.rs
@@ -4,11 +4,13 @@
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::array::ArrayView;
 use crate::arrays::List;
 use crate::arrays::ListArray;
 use crate::arrays::list::ListArraySlotsExt;
+use crate::scalar_fn::fns::mask::MaskKernel;
 use crate::scalar_fn::fns::mask::MaskReduce;
 use crate::validity::Validity;
 
@@ -20,5 +22,15 @@ impl MaskReduce for List {
             array.validity()?.and(Validity::Array(mask.clone()))?,
         )
         .map(|a| Some(a.into_array()))
+    }
+}
+
+impl MaskKernel for List {
+    fn mask(
+        array: ArrayView<'_, List>,
+        mask: &ArrayRef,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        <List as MaskReduce>::mask(array, mask)
     }
 }

--- a/vortex-array/src/arrays/list/compute/slice.rs
+++ b/vortex-array/src/arrays/list/compute/slice.rs
@@ -6,11 +6,13 @@ use std::ops::Range;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::array::ArrayView;
 use crate::arrays::List;
 use crate::arrays::ListArray;
 use crate::arrays::list::ListArraySlotsExt;
+use crate::arrays::slice::SliceKernel;
 use crate::arrays::slice::SliceReduce;
 
 impl SliceReduce for List {
@@ -23,5 +25,15 @@ impl SliceReduce for List {
             )
             .into_array(),
         ))
+    }
+}
+
+impl SliceKernel for List {
+    fn slice(
+        array: ArrayView<'_, Self>,
+        range: Range<usize>,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        <List as SliceReduce>::slice(array, range)
     }
 }

--- a/vortex-array/src/arrays/varbin/compute/mask.rs
+++ b/vortex-array/src/arrays/varbin/compute/mask.rs
@@ -4,11 +4,13 @@
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::array::ArrayView;
 use crate::arrays::VarBin;
 use crate::arrays::VarBinArray;
 use crate::arrays::varbin::VarBinArraySlotsExt;
+use crate::scalar_fn::fns::mask::MaskKernel;
 use crate::scalar_fn::fns::mask::MaskReduce;
 use crate::validity::Validity;
 
@@ -23,6 +25,16 @@ impl MaskReduce for VarBin {
             )?
             .into_array(),
         ))
+    }
+}
+
+impl MaskKernel for VarBin {
+    fn mask(
+        array: ArrayView<'_, VarBin>,
+        mask: &ArrayRef,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        <VarBin as MaskReduce>::mask(array, mask)
     }
 }
 

--- a/vortex-array/src/arrays/varbin/compute/slice.rs
+++ b/vortex-array/src/arrays/varbin/compute/slice.rs
@@ -6,16 +6,28 @@ use std::ops::Range;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::array::ArrayView;
 use crate::arrays::VarBin;
 use crate::arrays::VarBinArray;
+use crate::arrays::slice::SliceKernel;
 use crate::arrays::slice::SliceReduce;
 use crate::arrays::varbin::VarBinArraySlotsExt;
 
 impl SliceReduce for VarBin {
     fn slice(array: ArrayView<'_, Self>, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         VarBin::_slice(array, range).map(Some)
+    }
+}
+
+impl SliceKernel for VarBin {
+    fn slice(
+        array: ArrayView<'_, Self>,
+        range: Range<usize>,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        <VarBin as SliceReduce>::slice(array, range)
     }
 }
 

--- a/vortex-array/src/arrays/varbin/vtable/kernel.rs
+++ b/vortex-array/src/arrays/varbin/vtable/kernel.rs
@@ -6,15 +6,19 @@ use vortex_session::VortexSession;
 use crate::ArrayVTable;
 use crate::arrays::Dict;
 use crate::arrays::Filter;
+use crate::arrays::Slice;
 use crate::arrays::VarBin;
 use crate::arrays::dict::TakeExecuteAdaptor;
 use crate::arrays::filter::FilterExecuteAdaptor;
+use crate::arrays::slice::SliceExecuteAdaptor;
 use crate::optimizer::kernels::ArrayKernelsExt;
 use crate::scalar_fn::ScalarFnVTable;
 use crate::scalar_fn::fns::binary::Binary;
 use crate::scalar_fn::fns::binary::CompareExecuteAdaptor;
 use crate::scalar_fn::fns::cast::Cast;
 use crate::scalar_fn::fns::cast::CastExecuteAdaptor;
+use crate::scalar_fn::fns::mask::Mask;
+use crate::scalar_fn::fns::mask::MaskExecuteAdaptor;
 
 pub(crate) fn initialize(session: &VortexSession) {
     let kernels = session.kernels();
@@ -22,4 +26,6 @@ pub(crate) fn initialize(session: &VortexSession) {
     kernels.register_execute_parent_kernel(Binary.id(), VarBin, CompareExecuteAdaptor(VarBin));
     kernels.register_execute_parent_kernel(Filter.id(), VarBin, FilterExecuteAdaptor(VarBin));
     kernels.register_execute_parent_kernel(Dict.id(), VarBin, TakeExecuteAdaptor(VarBin));
+    kernels.register_execute_parent_kernel(Mask.id(), VarBin, MaskExecuteAdaptor(VarBin));
+    kernels.register_execute_parent_kernel(Slice.id(), VarBin, SliceExecuteAdaptor(VarBin));
 }


### PR DESCRIPTION
Registers mask and slice execute-parent kernels for `List` and `VarBin`. The `MaskKernel`/`SliceKernel` impls are delegations to the encodings' existing `MaskReduce`/`SliceReduce` implementations.
