### PR TITLE
feat(array): builders no longer canonicalize their children [builders-child-stack]

### DIFF
--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -586,6 +586,7 @@ mod test {
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
+    use vortex_array::arrays::Chunked;
     use vortex_array::arrays::DecimalArray;
     use vortex_array::arrays::FixedSizeListArray;
     use vortex_array::arrays::ListArray;
@@ -594,6 +595,7 @@ mod test {
     use vortex_array::arrays::StructArray;
     use vortex_array::arrays::VarBinArray;
     use vortex_array::arrays::VarBinViewArray;
+    use vortex_array::arrays::chunked::ChunkedArrayExt;
     use vortex_array::arrays::listview::ListViewArrayExt;
     use vortex_array::arrays::listview::ListViewArraySlotsExt;
     use vortex_array::assert_arrays_eq;
@@ -1335,6 +1337,50 @@ mod test {
             PrimitiveArray::from_iter([2i32]),
             &mut ctx
         );
+
+        Ok(())
+    }
+
+    /// Nested builders chunk a child on the boundaries it is appended on, so the number of appends
+    /// canonicalization makes is now visible in the elements child. A run of consecutive patches
+    /// and the gap after it should cost one chunk each, not one chunk per row.
+    #[test]
+    fn test_sparse_list_chunks_elements_per_run_not_per_patch() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+
+        const PATCHES: usize = 100;
+        let patches_u32 = u32::try_from(PATCHES).vortex_expect("fits in u32");
+        let patches_i32 = i32::try_from(PATCHES).vortex_expect("fits in i32");
+
+        // `PATCHES` single-element lists, patched onto rows 0..PATCHES of a 2 * PATCHES-row array,
+        // so there is exactly one patch run followed by exactly one gap.
+        let patch_values = ListViewArray::new(
+            PrimitiveArray::from_iter(0..patches_i32).into_array(),
+            PrimitiveArray::from_iter(0..patches_u32).into_array(),
+            PrimitiveArray::from_iter(std::iter::repeat_n(1u32, PATCHES)).into_array(),
+            Validity::AllValid,
+        )
+        .into_array();
+
+        let indices = PrimitiveArray::from_iter(0..patches_u32).into_array();
+        let fill = Scalar::from(Some(vec![-1i32]));
+        let sparse = Sparse::try_new(indices, patch_values, 2 * PATCHES, fill)?.into_array();
+
+        let actual = sparse.execute::<ListViewArray>(&mut ctx)?;
+        assert_eq!(
+            actual.elements().as_::<Chunked>().nchunks(),
+            2,
+            "expected one chunk for the patch run and one for the gap",
+        );
+
+        let expected_lists = (0..patches_i32)
+            .map(|i| Some(vec![i]))
+            .chain(std::iter::repeat_n(Some(vec![-1i32]), PATCHES));
+        let expected = ListArray::from_iter_opt_slow::<u32, _, _>(
+            expected_lists,
+            Arc::new(PType::I32.into()),
+        )?;
+        assert_arrays_eq!(actual, expected, &mut ctx);
 
         Ok(())
     }

--- a/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
@@ -343,6 +343,7 @@ mod tests {
 
     use crate::ArrayRef;
     use crate::IntoArray;
+    use crate::RecursiveCanonical;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
     use crate::aggregate_fn::AggregateFnVTable;
@@ -382,14 +383,21 @@ mod tests {
     use crate::validity::Validity;
 
     fn materialized_uncompressed_size_in_bytes(array: &ArrayRef) -> u64 {
+        let mut ctx = array_session().create_execution_ctx();
         let mut builder = builder_with_capacity(array.dtype(), array.len());
         array
-            .append_to_builder(
-                builder.as_mut(),
-                &mut array_session().create_execution_ctx(),
-            )
+            .append_to_builder(builder.as_mut(), &mut ctx)
             .vortex_expect("appended");
-        builder.finish().nbytes()
+
+        // A builder keeps its children in whatever encoding they were appended in, so the bytes of
+        // what it finishes only stand in for the uncompressed size once the whole tree is decoded.
+        builder
+            .finish()
+            .execute::<RecursiveCanonical>(&mut ctx)
+            .vortex_expect("recursively canonicalized")
+            .0
+            .into_array()
+            .nbytes()
     }
 
     fn aggregate(array: &ArrayRef) -> VortexResult<u64> {

--- a/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/uncompressed_size_in_bytes/mod.rs
@@ -341,6 +341,7 @@ mod tests {
 
     use crate::ArrayRef;
     use crate::IntoArray;
+    use crate::RecursiveCanonical;
     use crate::VortexSessionExecute;
     use crate::aggregate_fn::Accumulator;
     use crate::aggregate_fn::AggregateFnVTable;
@@ -380,14 +381,21 @@ mod tests {
     use crate::validity::Validity;
 
     fn materialized_uncompressed_size_in_bytes(array: &ArrayRef) -> u64 {
+        let mut ctx = array_session().create_execution_ctx();
         let mut builder = builder_with_capacity(array.dtype(), array.len());
         array
-            .append_to_builder(
-                builder.as_mut(),
-                &mut array_session().create_execution_ctx(),
-            )
+            .append_to_builder(builder.as_mut(), &mut ctx)
             .vortex_expect("appended");
-        builder.finish().nbytes()
+
+        // A builder keeps its children in whatever encoding they were appended in, so the bytes of
+        // what it finishes only stand in for the uncompressed size once the whole tree is decoded.
+        builder
+            .finish()
+            .execute::<RecursiveCanonical>(&mut ctx)
+            .vortex_expect("recursively canonicalized")
+            .0
+            .into_array()
+            .nbytes()
     }
 
     fn aggregate(array: &ArrayRef) -> VortexResult<u64> {

--- a/vortex-array/src/builders/child.rs
+++ b/vortex-array/src/builders/child.rs
@@ -1,0 +1,498 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
+use vortex_mask::Mask;
+
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::IntoArray;
+use crate::arrays::ChunkedArray;
+use crate::arrays::MaskedArray;
+use crate::builders::ArrayBuilder;
+use crate::builders::builder_with_capacity;
+use crate::dtype::DType;
+use crate::dtype::Nullability;
+use crate::scalar::Scalar;
+use crate::validity::Validity;
+
+/// Accumulates the child of a nested [`ArrayBuilder`] without canonicalizing appended arrays.
+///
+/// Nested builders receive values from two sources: individual [`Scalar`]s, which have to be
+/// materialized into a canonical builder, and whole arrays, whose encoding the builder has no
+/// reason to decode. A `ChildBuilder` keeps the latter as chunks and materializes only the former,
+/// stitching everything back together into a [`ChunkedArray`] on [`finish`](Self::finish) when
+/// more than one chunk accumulated.
+///
+/// This keeps canonical arrays canonical only at the top level, which is all that [`Canonical`]
+/// promises: the fields of a `StructArray`, the elements of a list, and the storage of an
+/// extension array may all stay compressed.
+///
+/// [`Canonical`]: crate::Canonical
+pub struct ChildBuilder {
+    /// The [`DType`] shared by every chunk and by the scalar builder.
+    dtype: DType,
+
+    /// Completed chunks, in logical order. Never contains an empty chunk.
+    chunks: Vec<ArrayRef>,
+
+    /// The summed length of `chunks`.
+    chunks_len: usize,
+
+    /// Builder holding the scalars appended after the last chunk.
+    pending: Box<dyn ArrayBuilder>,
+}
+
+impl ChildBuilder {
+    /// Creates a new `ChildBuilder` whose scalar builder is pre-allocated for `capacity` values.
+    pub fn with_capacity(dtype: &DType, capacity: usize) -> Self {
+        Self {
+            dtype: dtype.clone(),
+            chunks: Vec::new(),
+            chunks_len: 0,
+            pending: builder_with_capacity(dtype, capacity),
+        }
+    }
+
+    /// The number of values appended so far.
+    pub fn len(&self) -> usize {
+        self.chunks_len + self.pending.len()
+    }
+
+    /// Appends every value of `array` to the child as a chunk of its own, keeping its encoding.
+    ///
+    /// However short the array, it becomes a chunk: the caller had a whole array to hand, and
+    /// deciding on its behalf that its values are cheaper copied than referenced would be guessing
+    /// at a boundary only the caller can see. Callers that would rather have the values copied
+    /// should append them as scalars.
+    ///
+    /// Nothing is decoded here, so `_ctx` goes unused; it stays in the signature so that the
+    /// nested builders forwarding their [`ExecutionCtx`] here do not have to explain why they
+    /// don't.
+    pub fn append_array(&mut self, array: &ArrayRef, _ctx: &mut ExecutionCtx) -> VortexResult<()> {
+        vortex_ensure!(
+            array.dtype() == &self.dtype,
+            "Cannot append an array of dtype {} to a child builder of dtype {}",
+            array.dtype(),
+            self.dtype,
+        );
+
+        if array.is_empty() {
+            return Ok(());
+        }
+
+        self.flush_pending();
+        self.chunks_len += array.len();
+        self.chunks.push(array.clone());
+
+        Ok(())
+    }
+
+    /// Appends a single [`Scalar`] to the child.
+    pub fn append_scalar(&mut self, scalar: &Scalar) -> VortexResult<()> {
+        self.pending.append_scalar(scalar)
+    }
+
+    /// Appends `n` "zero" values to the child.
+    ///
+    /// See [`ArrayBuilder::append_zeros`].
+    pub fn append_zeros(&mut self, n: usize) {
+        self.pending.append_zeros(n)
+    }
+
+    /// Appends `n` null values to the child.
+    ///
+    /// See [`ArrayBuilder::append_nulls`].
+    pub fn append_nulls(&mut self, n: usize) {
+        self.pending.append_nulls(n)
+    }
+
+    /// Appends `n` default values to the child.
+    ///
+    /// See [`ArrayBuilder::append_defaults`].
+    pub fn append_defaults(&mut self, n: usize) {
+        self.pending.append_defaults(n)
+    }
+
+    /// Allocates space for `additional` more values in the scalar builder.
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.pending.reserve_exact(additional)
+    }
+
+    /// Overrides the validity of every value appended so far.
+    ///
+    /// # Safety
+    ///
+    /// `validity` must have the same length as [`self.len()`](Self::len).
+    ///
+    /// # Panics
+    ///
+    /// Panics if a chunk that was kept in its original encoding contains nulls, since replacing
+    /// the validity of such a chunk would require decoding it.
+    pub unsafe fn set_validity_unchecked(&mut self, validity: Mask) {
+        if !self.dtype.is_nullable() {
+            return;
+        }
+
+        if self.chunks.is_empty() {
+            // Fast path: every value lives in the scalar builder, which owns its null buffer.
+            unsafe { self.pending.set_validity_unchecked(validity) };
+            return;
+        }
+
+        // The chunks carry their own validity, so the override has to be pushed into each of them.
+        self.flush_pending();
+        let mut offset = 0;
+        for chunk in &mut self.chunks {
+            let end = offset + chunk.len();
+            *chunk = MaskedArray::try_new(
+                chunk.clone(),
+                Validity::from_mask(validity.slice(offset..end), Nullability::Nullable),
+            )
+            .vortex_expect("cannot override the validity of a child chunk that contains nulls")
+            .into_array();
+            offset = end;
+        }
+    }
+
+    /// Finishes the child, combining the accumulated chunks into a [`ChunkedArray`] when there is
+    /// more than one of them.
+    pub fn finish(&mut self) -> ArrayRef {
+        if self.chunks.is_empty() {
+            return self.pending.finish();
+        }
+
+        self.flush_pending();
+        self.chunks_len = 0;
+
+        let mut chunks = std::mem::take(&mut self.chunks);
+        if chunks.len() == 1 {
+            return chunks.remove(0);
+        }
+
+        ChunkedArray::try_new(chunks, self.dtype.clone())
+            .vortex_expect("every child chunk has the child dtype")
+            .into_array()
+    }
+
+    /// Moves whatever the scalar builder holds into `chunks`, keeping the chunks in logical order.
+    fn flush_pending(&mut self) {
+        if self.pending.is_empty() {
+            return;
+        }
+        self.chunks_len += self.pending.len();
+        let pending = self.pending.finish();
+        self.chunks.push(pending);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_buffer::buffer;
+    use vortex_error::VortexExpect;
+    use vortex_error::VortexResult;
+    use vortex_mask::Mask;
+
+    use super::ChildBuilder;
+    use crate::ArrayRef;
+    use crate::IntoArray;
+    use crate::VortexSessionExecute;
+    use crate::array_session;
+    use crate::arrays::Chunked;
+    use crate::arrays::ChunkedArray;
+    use crate::arrays::Constant;
+    use crate::arrays::ConstantArray;
+    use crate::arrays::Masked;
+    use crate::arrays::Primitive;
+    use crate::arrays::PrimitiveArray;
+    use crate::arrays::chunked::ChunkedArrayExt;
+    use crate::assert_arrays_eq;
+    use crate::dtype::DType;
+    use crate::dtype::Nullability::NonNullable;
+    use crate::dtype::Nullability::Nullable;
+    use crate::dtype::PType::I32;
+    use crate::scalar::Scalar;
+
+    /// An arbitrary array length. `ChildBuilder` treats no length specially, so the tests only
+    /// need a length long enough to tell chunks apart.
+    const CHUNK_LEN: usize = 64;
+
+    /// A non-canonical array of `len` values, all equal to `value`.
+    fn constant(value: i32, len: usize) -> ArrayRef {
+        ConstantArray::new(value, len).into_array()
+    }
+
+    /// A non-canonical *nullable* array of `len` non-null values, all equal to `value`.
+    fn nullable_constant(value: i32, len: usize) -> ArrayRef {
+        ConstantArray::new(Scalar::primitive(value, Nullable), len).into_array()
+    }
+
+    #[test]
+    fn test_appended_arrays_are_kept_as_chunks() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let mut builder = ChildBuilder::with_capacity(&DType::from(I32), 0);
+
+        builder.append_array(&constant(1, CHUNK_LEN), &mut ctx)?;
+        builder.append_array(&constant(2, CHUNK_LEN), &mut ctx)?;
+        assert_eq!(builder.len(), 2 * CHUNK_LEN);
+
+        let child = builder.finish();
+        let chunked = child.as_::<Chunked>();
+        assert_eq!(chunked.nchunks(), 2);
+        // The chunks were never decoded.
+        assert!(chunked.iter_chunks().all(|c| c.is::<Constant>()));
+
+        Ok(())
+    }
+
+    /// However short the appended array, its encoding survives: a single-value array is a chunk
+    /// too. A caller that wants the values copied appends them as scalars instead.
+    #[test]
+    fn test_short_arrays_are_kept_as_chunks_too() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let mut builder = ChildBuilder::with_capacity(&DType::from(I32), 0);
+
+        builder.append_array(&constant(1, 1), &mut ctx)?;
+        builder.append_array(&constant(2, 1), &mut ctx)?;
+        assert_eq!(builder.len(), 2);
+
+        let child = builder.finish();
+        let chunked = child.as_::<Chunked>();
+        assert_eq!(chunked.nchunks(), 2);
+        assert!(chunked.iter_chunks().all(|c| c.is::<Constant>()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_scalars_interleaved_with_chunks_keep_their_order() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let mut builder = ChildBuilder::with_capacity(&DType::from(I32), 0);
+
+        builder.append_scalar(&1i32.into())?;
+        builder.append_array(&constant(2, CHUNK_LEN), &mut ctx)?;
+        builder.append_scalar(&3i32.into())?;
+
+        let child = builder.finish();
+        assert_eq!(child.len(), CHUNK_LEN + 2);
+
+        let expected = ChunkedArray::try_new(
+            vec![
+                buffer![1i32].into_array(),
+                constant(2, CHUNK_LEN),
+                buffer![3i32].into_array(),
+            ],
+            DType::from(I32),
+        )?
+        .into_array();
+        assert_arrays_eq!(&child, &expected, &mut ctx);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_single_chunk_is_not_wrapped() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let mut builder = ChildBuilder::with_capacity(&DType::from(I32), 0);
+
+        builder.append_array(&constant(7, CHUNK_LEN), &mut ctx)?;
+
+        let child = builder.finish();
+        assert!(child.is::<Constant>());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_arrays_never_become_chunks() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let mut builder = ChildBuilder::with_capacity(&DType::from(I32), 0);
+        let empty = constant(1, CHUNK_LEN).slice(0..0)?;
+
+        builder.append_array(&empty, &mut ctx)?;
+        builder.append_array(&constant(1, CHUNK_LEN), &mut ctx)?;
+        builder.append_array(&empty, &mut ctx)?;
+        builder.append_array(&constant(2, CHUNK_LEN), &mut ctx)?;
+        builder.append_array(&empty, &mut ctx)?;
+
+        assert_eq!(builder.len(), 2 * CHUNK_LEN);
+        assert_eq!(builder.finish().as_::<Chunked>().nchunks(), 2);
+
+        Ok(())
+    }
+
+    /// An empty child must still finish as an empty array rather than as an empty [`ChunkedArray`].
+    #[test]
+    fn test_empty_child_finishes_without_chunks() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let mut builder = ChildBuilder::with_capacity(&DType::from(I32), 0);
+
+        builder.append_array(&constant(1, CHUNK_LEN).slice(0..0)?, &mut ctx)?;
+
+        let child = builder.finish();
+        assert!(child.is_empty());
+        assert!(child.is::<Primitive>());
+
+        Ok(())
+    }
+
+    /// The dtype check has to run before the empty check, so that a mismatched array is rejected
+    /// whether or not it would have become a chunk.
+    #[rstest]
+    #[case::empty(0)]
+    #[case::non_empty(CHUNK_LEN)]
+    fn test_appending_a_mismatched_dtype_is_rejected(#[case] len: usize) {
+        let mut ctx = array_session().create_execution_ctx();
+        let mut builder = ChildBuilder::with_capacity(&DType::from(I32), 0);
+
+        let wrong_dtype = ConstantArray::new(1i64, len).into_array();
+        assert!(builder.append_array(&wrong_dtype, &mut ctx).is_err());
+    }
+
+    /// Everything the scalar builder can produce has to be flushed ahead of the next chunk.
+    #[test]
+    fn test_zeros_and_nulls_around_chunks_keep_their_order() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let dtype = DType::Primitive(I32, Nullable);
+        let mut builder = ChildBuilder::with_capacity(&dtype, 0);
+
+        builder.append_array(&nullable_constant(1, CHUNK_LEN), &mut ctx)?;
+        builder.append_nulls(2);
+        builder.append_array(&nullable_constant(2, CHUNK_LEN), &mut ctx)?;
+        builder.append_zeros(1);
+
+        let child = builder.finish();
+        assert_eq!(child.len(), 2 * CHUNK_LEN + 3);
+        assert_eq!(child.as_::<Chunked>().nchunks(), 4);
+
+        let expected = PrimitiveArray::from_option_iter(
+            std::iter::repeat_n(Some(1i32), CHUNK_LEN)
+                .chain([None, None])
+                .chain(std::iter::repeat_n(Some(2i32), CHUNK_LEN))
+                .chain([Some(0)]),
+        )
+        .into_array();
+        assert_arrays_eq!(&child, &expected, &mut ctx);
+
+        Ok(())
+    }
+
+    /// Overriding the validity once chunks exist has to push the override into each chunk, sliced
+    /// to that chunk's own range.
+    #[test]
+    fn test_set_validity_pushes_the_override_into_every_chunk() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let dtype = DType::Primitive(I32, Nullable);
+        let mut builder = ChildBuilder::with_capacity(&dtype, 0);
+
+        builder.append_array(&nullable_constant(1, CHUNK_LEN), &mut ctx)?;
+        builder.append_array(&nullable_constant(2, CHUNK_LEN), &mut ctx)?;
+
+        // Straddle the chunk boundary, so an override sliced wrongly cannot pass.
+        let invalid = [CHUNK_LEN - 1, CHUNK_LEN];
+        let validity = Mask::from_iter((0..2 * CHUNK_LEN).map(|i| !invalid.contains(&i)));
+        unsafe { builder.set_validity_unchecked(validity) };
+
+        let child = builder.finish();
+        let chunked = child.as_::<Chunked>();
+        assert_eq!(chunked.nchunks(), 2);
+        // The override was layered over the chunks rather than decoding them.
+        assert!(chunked.iter_chunks().all(|chunk| chunk.is::<Masked>()));
+
+        let expected = PrimitiveArray::from_option_iter(
+            (0..2 * CHUNK_LEN)
+                .map(|i| (!invalid.contains(&i)).then_some(if i < CHUNK_LEN { 1i32 } else { 2 })),
+        )
+        .into_array();
+        assert_arrays_eq!(&child, &expected, &mut ctx);
+
+        Ok(())
+    }
+
+    /// Values still sitting in the scalar builder are part of the override too.
+    #[test]
+    fn test_set_validity_covers_pending_scalars() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let dtype = DType::Primitive(I32, Nullable);
+        let mut builder = ChildBuilder::with_capacity(&dtype, 0);
+
+        builder.append_array(&nullable_constant(1, CHUNK_LEN), &mut ctx)?;
+        builder.append_scalar(&Scalar::primitive(2i32, Nullable))?;
+
+        let mut validity = vec![true; CHUNK_LEN + 1];
+        validity[CHUNK_LEN] = false;
+        unsafe { builder.set_validity_unchecked(Mask::from_iter(validity)) };
+
+        let child = builder.finish();
+        let expected = PrimitiveArray::from_option_iter(
+            std::iter::repeat_n(Some(1i32), CHUNK_LEN).chain([None]),
+        )
+        .into_array();
+        assert_arrays_eq!(&child, &expected, &mut ctx);
+
+        Ok(())
+    }
+
+    /// A non-nullable child cannot carry nulls, so the override is dropped and the chunks are left
+    /// exactly as they were appended.
+    #[test]
+    fn test_set_validity_is_a_noop_for_a_non_nullable_child() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let mut builder = ChildBuilder::with_capacity(&DType::from(I32), 0);
+
+        builder.append_array(&constant(1, CHUNK_LEN), &mut ctx)?;
+        builder.append_array(&constant(2, CHUNK_LEN), &mut ctx)?;
+        unsafe { builder.set_validity_unchecked(Mask::new_false(2 * CHUNK_LEN)) };
+
+        let child = builder.finish();
+        let chunked = child.as_::<Chunked>();
+        assert!(chunked.iter_chunks().all(|chunk| chunk.is::<Constant>()));
+
+        let expected = ChunkedArray::try_new(
+            vec![constant(1, CHUNK_LEN), constant(2, CHUNK_LEN)],
+            DType::from(I32),
+        )?
+        .into_array();
+        assert_arrays_eq!(&child, &expected, &mut ctx);
+
+        Ok(())
+    }
+
+    /// Replacing the validity of a chunk that already contains nulls would mean decoding it, which
+    /// is exactly what the chunk exists to avoid.
+    #[test]
+    #[should_panic(expected = "cannot override the validity of a child chunk that contains nulls")]
+    fn test_set_validity_rejects_a_chunk_that_contains_nulls() {
+        let mut ctx = array_session().create_execution_ctx();
+        let dtype = DType::Primitive(I32, Nullable);
+        let mut builder = ChildBuilder::with_capacity(&dtype, 0);
+
+        let with_nulls = ConstantArray::new(Scalar::null(dtype), CHUNK_LEN).into_array();
+        builder
+            .append_array(&with_nulls, &mut ctx)
+            .vortex_expect("append");
+
+        unsafe { builder.set_validity_unchecked(Mask::new_true(CHUNK_LEN)) };
+    }
+
+    #[test]
+    fn test_finish_resets_the_builder() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let mut builder = ChildBuilder::with_capacity(&DType::from(I32), 0);
+
+        builder.append_array(&constant(1, CHUNK_LEN), &mut ctx)?;
+        builder.append_scalar(&2i32.into())?;
+        assert_eq!(builder.finish().len(), CHUNK_LEN + 1);
+
+        assert_eq!(builder.len(), 0);
+        builder.append_scalar(&3i32.into())?;
+
+        let expected = PrimitiveArray::new(buffer![3i32], NonNullable.into()).into_array();
+        assert_arrays_eq!(&builder.finish(), &expected, &mut ctx);
+
+        Ok(())
+    }
+}

--- a/vortex-array/src/builders/extension.rs
+++ b/vortex-array/src/builders/extension.rs
@@ -13,8 +13,8 @@ use crate::IntoArray;
 use crate::arrays::ExtensionArray;
 use crate::arrays::extension::ExtensionArrayExt;
 use crate::builders::ArrayBuilder;
+use crate::builders::ChildBuilder;
 use crate::builders::DEFAULT_BUILDER_CAPACITY;
-use crate::builders::builder_with_capacity;
 use crate::canonical::Canonical;
 use crate::dtype::DType;
 use crate::dtype::extension::ExtDTypeRef;
@@ -24,7 +24,7 @@ use crate::scalar::Scalar;
 /// The builder for building a [`ExtensionArray`].
 pub struct ExtensionBuilder {
     dtype: DType,
-    storage: Box<dyn ArrayBuilder>,
+    storage: ChildBuilder,
 }
 
 impl ExtensionBuilder {
@@ -36,7 +36,7 @@ impl ExtensionBuilder {
     /// Creates a new `ExtensionBuilder` with the given `capacity`.
     pub fn with_capacity(ext_dtype: ExtDTypeRef, capacity: usize) -> Self {
         Self {
-            storage: builder_with_capacity(ext_dtype.storage_dtype(), capacity),
+            storage: ChildBuilder::with_capacity(ext_dtype.storage_dtype(), capacity),
             dtype: DType::Extension(ext_dtype),
         }
     }
@@ -53,9 +53,7 @@ impl ExtensionBuilder {
         array: &ExtensionArray,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
-        array
-            .storage_array()
-            .append_to_builder(self.storage.as_mut(), ctx)
+        self.storage.append_array(array.storage_array(), ctx)
     }
 
     /// Finishes the builder directly into a [`ExtensionArray`].

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -17,9 +17,9 @@ use crate::IntoArray;
 use crate::arrays::FixedSizeListArray;
 use crate::arrays::fixed_size_list::FixedSizeListArraySlotsExt;
 use crate::builders::ArrayBuilder;
+use crate::builders::ChildBuilder;
 use crate::builders::DEFAULT_BUILDER_CAPACITY;
 use crate::builders::LazyBitBufferBuilder;
-use crate::builders::builder_with_capacity;
 use crate::canonical::Canonical;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -34,7 +34,7 @@ pub struct FixedSizeListBuilder {
     /// The builder for the underlying elements of the [`FixedSizeListArray`].
     ///
     /// This builder will have a capacity equal to the `list_size * capacity`.
-    elements_builder: Box<dyn ArrayBuilder>,
+    elements_builder: ChildBuilder,
 
     /// The null map builder of the [`FixedSizeListArray`].
     ///
@@ -62,7 +62,7 @@ impl FixedSizeListBuilder {
     ) -> Self {
         let elements_capacity = capacity * list_size as usize;
 
-        let elements_builder = builder_with_capacity(&element_dtype, elements_capacity);
+        let elements_builder = ChildBuilder::with_capacity(&element_dtype, elements_capacity);
         let fsl_dtype = DType::FixedSizeList(element_dtype, list_size, nullability);
         let nulls = LazyBitBufferBuilder::new(capacity);
 
@@ -98,7 +98,7 @@ impl FixedSizeListBuilder {
             self.list_size()
         );
 
-        array.append_to_builder(self.elements_builder.as_mut(), ctx)?;
+        self.elements_builder.append_array(array, ctx)?;
         self.nulls.append_non_null();
 
         Ok(())
@@ -115,9 +115,7 @@ impl FixedSizeListBuilder {
             return Ok(());
         }
 
-        array
-            .elements()
-            .append_to_builder(self.elements_builder.as_mut(), ctx)?;
+        self.elements_builder.append_array(array.elements(), ctx)?;
         self.nulls
             .append_validity_mask(&array.validity()?.execute_mask(array.len(), ctx)?);
         Ok(())

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -26,10 +26,10 @@ use crate::arrays::list::ListArraySlotsExt;
 use crate::arrays::listview::ListViewArraySlotsExt;
 use crate::arrays::listview::ListViewRebuildMode;
 use crate::builders::ArrayBuilder;
+use crate::builders::ChildBuilder;
 use crate::builders::DEFAULT_BUILDER_CAPACITY;
 use crate::builders::LazyBitBufferBuilder;
 use crate::builders::PrimitiveBuilder;
-use crate::builders::builder_with_capacity;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
 use crate::dtype::Nullability;
@@ -46,7 +46,7 @@ pub struct ListBuilder<O: OffsetBuilderPType> {
     dtype: DType,
 
     /// The builder for the underlying elements of the [`ListArray`].
-    elements_builder: Box<dyn ArrayBuilder>,
+    elements_builder: ChildBuilder,
 
     /// The builder for the `offsets` into the `elements` array.
     offsets_builder: PrimitiveBuilder<O>,
@@ -81,7 +81,7 @@ impl<O: OffsetBuilderPType> ListBuilder<O> {
         elements_capacity: usize,
         capacity: usize,
     ) -> Self {
-        let elements_builder = builder_with_capacity(value_dtype.as_ref(), elements_capacity);
+        let elements_builder = ChildBuilder::with_capacity(value_dtype.as_ref(), elements_capacity);
         let mut offsets_builder = PrimitiveBuilder::<O>::with_capacity(NonNullable, capacity + 1);
 
         // The first offset is always 0 and represents an empty list.
@@ -113,8 +113,7 @@ impl<O: OffsetBuilderPType> ListBuilder<O> {
             self.element_dtype()
         );
 
-        self.elements_builder.reserve_exact(array.len());
-        array.append_to_builder(self.elements_builder.as_mut(), ctx)?;
+        self.elements_builder.append_array(array, ctx)?;
         self.nulls.append_non_null();
         self.offsets_builder.append_value(
             O::from_usize(self.elements_builder.len())
@@ -206,11 +205,8 @@ impl<O: OffsetBuilderPType> ListBuilder<O> {
             // in bulk and the offsets rebased onto this builder's elements.
             let elements_base = self.elements_builder.len();
             if last > first {
-                self.elements_builder.reserve_exact(last - first);
-                array
-                    .elements()
-                    .slice(first..last)?
-                    .append_to_builder(self.elements_builder.as_mut(), ctx)?;
+                self.elements_builder
+                    .append_array(&array.elements().slice(first..last)?, ctx)?;
             }
 
             self.offsets_builder.reserve_exact(num_lists);
@@ -306,10 +302,9 @@ where
 
     let elements_base = builder.elements_builder.len();
     if last > first {
-        builder.elements_builder.reserve_exact(last - first);
-        new_elements
-            .slice(first..last)?
-            .append_to_builder(builder.elements_builder.as_mut(), ctx)?;
+        builder
+            .elements_builder
+            .append_array(&new_elements.slice(first..last)?, ctx)?;
     }
 
     builder.offsets_builder.reserve_exact(num_lists);

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -31,10 +31,10 @@ use crate::arrays::list::ListArraySlotsExt;
 use crate::arrays::listview::ListViewArraySlotsExt;
 use crate::arrays::listview::ListViewRebuildMode;
 use crate::builders::ArrayBuilder;
+use crate::builders::ChildBuilder;
 use crate::builders::DEFAULT_BUILDER_CAPACITY;
 use crate::builders::PrimitiveBuilder;
 use crate::builders::UninitRange;
-use crate::builders::builder_with_capacity;
 use crate::builders::lazy_null_builder::LazyBitBufferBuilder;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
@@ -59,7 +59,7 @@ pub struct ListViewBuilder<O: OffsetBuilderPType, S: OffsetBuilderPType> {
     dtype: DType,
 
     /// The builder for the underlying elements of the [`ListArray`](crate::arrays::ListArray).
-    elements_builder: Box<dyn ArrayBuilder>,
+    elements_builder: ChildBuilder,
 
     /// The builder for the `offsets` into the `elements` array.
     offsets_builder: PrimitiveBuilder<O>,
@@ -105,7 +105,7 @@ impl<O: OffsetBuilderPType, S: OffsetBuilderPType> ListViewBuilder<O, S> {
         elements_capacity: usize,
         capacity: usize,
     ) -> Self {
-        let elements_builder = builder_with_capacity(&element_dtype, elements_capacity);
+        let elements_builder = ChildBuilder::with_capacity(&element_dtype, elements_capacity);
 
         let offsets_builder =
             PrimitiveBuilder::<O>::with_capacity(Nullability::NonNullable, capacity);
@@ -152,8 +152,7 @@ impl<O: OffsetBuilderPType, S: OffsetBuilderPType> ListViewBuilder<O, S> {
             "appending this list would cause an offset overflow"
         );
 
-        self.elements_builder.reserve_exact(num_elements);
-        array.append_to_builder(self.elements_builder.as_mut(), ctx)?;
+        self.elements_builder.append_array(array, ctx)?;
         self.nulls.append_non_null();
 
         self.offsets_builder.append_value(
@@ -311,10 +310,7 @@ impl<O: OffsetBuilderPType, S: OffsetBuilderPType> ListViewBuilder<O, S> {
         // Bulk append the trimmed elements; the offsets are rebased onto them below.
         let old_elements_len = self.elements_builder.len();
         self.elements_builder
-            .reserve_exact(listview.elements().len());
-        listview
-            .elements()
-            .append_to_builder(self.elements_builder.as_mut(), ctx)?;
+            .append_array(listview.elements(), ctx)?;
         let new_elements_len = self.elements_builder.len();
 
         // Reserve enough space for the new views.
@@ -465,10 +461,9 @@ where
     );
 
     if last > first {
-        builder.elements_builder.reserve_exact(last - first);
-        elements
-            .slice(first..last)?
-            .append_to_builder(builder.elements_builder.as_mut(), ctx)?;
+        builder
+            .elements_builder
+            .append_array(&elements.slice(first..last)?, ctx)?;
     }
 
     builder.offsets_builder.reserve_exact(num_lists);

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -6,6 +6,12 @@
 //! Every logical type in Vortex has a canonical (uncompressed) in-memory encoding. This module
 //! provides pre-allocated builders to construct new canonical arrays.
 //!
+//! Canonical form is not recursive, and neither are these builders: appending an array to a nested
+//! builder keeps the child in the encoding it arrived in instead of decoding it. The fields of a
+//! [`StructArray`](crate::arrays::StructArray), the elements of a list, and the storage of an
+//! [`ExtensionArray`](crate::arrays::ExtensionArray) may therefore come back compressed, or as a
+//! [`ChunkedArray`](crate::arrays::ChunkedArray) when several arrays were appended in turn.
+//!
 //! ## Example:
 //!
 //! ```
@@ -49,6 +55,7 @@ mod lazy_null_builder;
 pub(crate) use lazy_null_builder::LazyBitBufferBuilder;
 
 mod bool;
+mod child;
 mod decimal;
 pub mod dict;
 mod extension;
@@ -62,6 +69,7 @@ mod struct_;
 mod varbinview;
 
 pub use bool::*;
+pub(crate) use child::ChildBuilder;
 pub use decimal::*;
 pub use extension::*;
 pub use fixed_size_list::*;
@@ -179,6 +187,9 @@ pub trait ArrayBuilder: Send {
     unsafe fn set_validity_unchecked(&mut self, validity: Mask);
 
     /// Constructs an Array from the builder components.
+    ///
+    /// The returned array is canonical at the top level only; its children keep whatever encoding
+    /// they were appended with.
     ///
     /// # Panics
     ///

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -17,9 +17,9 @@ use crate::IntoArray;
 use crate::arrays::StructArray;
 use crate::arrays::struct_::StructArrayExt;
 use crate::builders::ArrayBuilder;
+use crate::builders::ChildBuilder;
 use crate::builders::DEFAULT_BUILDER_CAPACITY;
 use crate::builders::LazyBitBufferBuilder;
-use crate::builders::builder_with_capacity;
 use crate::canonical::Canonical;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -30,7 +30,7 @@ use crate::scalar::StructScalar;
 /// The builder for building a [`StructArray`].
 pub struct StructBuilder {
     dtype: DType,
-    builders: Vec<Box<dyn ArrayBuilder>>,
+    builders: Vec<ChildBuilder>,
     nulls: LazyBitBufferBuilder,
 }
 
@@ -48,7 +48,7 @@ impl StructBuilder {
     ) -> Self {
         let builders = struct_dtype
             .fields()
-            .map(|dt| builder_with_capacity(&dt, capacity))
+            .map(|dt| ChildBuilder::with_capacity(&dt, capacity))
             .collect();
 
         Self {
@@ -131,7 +131,7 @@ impl StructBuilder {
             .iter_unmasked_fields()
             .zip_eq(self.builders.iter_mut())
         {
-            field.append_to_builder(builder.as_mut(), ctx)?;
+            builder.append_array(field, ctx)?;
         }
 
         self.nulls

--- a/vortex-array/src/builders/tests.rs
+++ b/vortex-array/src/builders/tests.rs
@@ -4,16 +4,44 @@
 use std::sync::Arc;
 
 use rstest::rstest;
+use vortex_buffer::Buffer;
+use vortex_buffer::buffer;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::ArrayRef;
 use crate::Canonical;
 use crate::ExecutionCtx;
+use crate::RecursiveCanonical;
 use crate::VortexSessionExecute;
 use crate::array::IntoArray;
 use crate::array_session;
+use crate::arrays::Chunked;
+use crate::arrays::ChunkedArray;
+use crate::arrays::Constant;
+use crate::arrays::ConstantArray;
+use crate::arrays::Extension;
+use crate::arrays::ExtensionArray;
+use crate::arrays::FixedSizeList;
+use crate::arrays::FixedSizeListArray;
+use crate::arrays::List;
+use crate::arrays::ListArray;
+use crate::arrays::ListView;
+use crate::arrays::ListViewArray;
+use crate::arrays::Primitive;
+use crate::arrays::PrimitiveArray;
+use crate::arrays::Struct;
+use crate::arrays::StructArray;
+use crate::arrays::chunked::ChunkedArrayExt;
+use crate::arrays::extension::ExtensionArraySlotsExt;
+use crate::arrays::fixed_size_list::FixedSizeListArraySlotsExt;
+use crate::arrays::list::ListArraySlotsExt;
+use crate::arrays::listview::ListViewArraySlotsExt;
+use crate::arrays::struct_::StructArrayExt;
+use crate::assert_arrays_eq;
 use crate::builders::ArrayBuilder;
+use crate::builders::ListBuilder;
 use crate::builders::builder_with_capacity;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
@@ -24,6 +52,7 @@ use crate::dtype::half::f16;
 use crate::extension::datetime::TimeUnit;
 use crate::extension::datetime::Timestamp;
 use crate::scalar::Scalar;
+use crate::validity::Validity;
 
 /// Test that `append_zeros` produces the same result as manually appending `Scalar::default_value`.
 ///
@@ -898,5 +927,372 @@ fn test_set_validity_noop_when_non_nullable() -> VortexResult<()> {
             "index {i} should remain valid"
         );
     }
+    Ok(())
+}
+
+/// Builders only promise a canonical *top level*, so a child array that is long enough to be worth
+/// a chunk must come back out of the builder in the encoding it went in with.
+///
+/// Each case appends the same array twice, which additionally checks that the two chunks are
+/// stitched back together into a [`ChunkedArray`] rather than being decoded and concatenated.
+#[rstest]
+#[case::struct_field(
+    StructArray::try_from_iter([("a", constant_i32())])
+        .vortex_expect("struct array")
+        .into_array(),
+    |array: &ArrayRef| array.as_::<Struct>().unmasked_field(0).clone()
+)]
+#[case::list_elements(
+    ListViewArray::new(
+        constant_i32(),
+        (0..CHUNK_LEN as u64).collect::<Buffer<_>>().into_array(),
+        Buffer::full(1u64, CHUNK_LEN).into_array(),
+        Validity::NonNullable,
+    )
+    .into_array(),
+    |array: &ArrayRef| array.as_::<ListView>().elements().clone()
+)]
+#[case::fixed_size_list_elements(
+    FixedSizeListArray::new(
+        constant_i32(),
+        2,
+        Validity::NonNullable,
+        CHUNK_LEN / 2,
+    )
+    .into_array(),
+    |array: &ArrayRef| array.as_::<FixedSizeList>().elements().clone()
+)]
+#[case::extension_storage(
+    ExtensionArray::new(
+        Timestamp::new(TimeUnit::Milliseconds, Nullability::NonNullable).erased(),
+        ConstantArray::new(
+            Scalar::primitive(0i64, Nullability::NonNullable),
+            CHUNK_LEN,
+        )
+        .into_array(),
+    )
+    .into_array(),
+    |array: &ArrayRef| array.as_::<Extension>().storage().clone()
+)]
+fn test_children_are_not_canonicalized(
+    #[case] array: ArrayRef,
+    #[case] child_of: fn(&ArrayRef) -> ArrayRef,
+) -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+
+    let mut builder = builder_with_capacity(array.dtype(), 0);
+    array.append_to_builder(builder.as_mut(), &mut ctx)?;
+    array.append_to_builder(builder.as_mut(), &mut ctx)?;
+    let built = builder.finish();
+
+    let child = child_of(&built);
+    let chunked = child.as_::<Chunked>();
+    assert_eq!(
+        chunked.nchunks(),
+        2,
+        "expected one chunk per appended array"
+    );
+    assert!(
+        chunked.iter_chunks().all(|chunk| chunk.is::<Constant>()),
+        "the constant-encoded child was decoded by the builder",
+    );
+
+    let expected = ChunkedArray::try_new(vec![array.clone(), array], built.dtype().clone())?;
+    assert_arrays_eq!(&built, &expected, &mut ctx);
+
+    Ok(())
+}
+
+/// A child is chunked on the boundaries it is appended on, however small the appends. Appending
+/// scalars instead is what asks the builder to copy the values into one canonical child.
+#[test]
+fn test_children_are_chunked_on_the_boundaries_they_are_appended_on() -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+
+    let elements = ConstantArray::new(1i32, 2).into_array();
+    let array = FixedSizeListArray::new(elements, 2, Validity::NonNullable, 1).into_array();
+
+    let mut builder = builder_with_capacity(array.dtype(), 0);
+    for _ in 0..CHUNK_LEN {
+        array.append_to_builder(builder.as_mut(), &mut ctx)?;
+    }
+    let built = builder.finish();
+
+    assert_eq!(built.len(), CHUNK_LEN);
+    assert_eq!(
+        built
+            .as_::<FixedSizeList>()
+            .elements()
+            .as_::<Chunked>()
+            .nchunks(),
+        CHUNK_LEN,
+        "one chunk per appended array",
+    );
+
+    // The same values appended as scalars land in a single canonical child.
+    let mut builder = builder_with_capacity(array.dtype(), 0);
+    let scalar = array.execute_scalar(0, &mut ctx)?;
+    for _ in 0..CHUNK_LEN {
+        builder.append_scalar(&scalar)?;
+    }
+    let built_from_scalars = builder.finish();
+
+    assert!(
+        built_from_scalars
+            .as_::<FixedSizeList>()
+            .elements()
+            .is::<Primitive>()
+    );
+    assert_arrays_eq!(&built_from_scalars, &built, &mut ctx);
+
+    Ok(())
+}
+
+/// A builder that mixes appended arrays with scalar appends must keep the two in order.
+#[test]
+fn test_struct_builder_interleaves_arrays_and_scalars() -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+
+    let array = StructArray::try_from_iter([("a", constant_i32())])?.into_array();
+    let scalar = Scalar::struct_(
+        array.dtype().clone(),
+        vec![Scalar::primitive(1i32, Nullability::NonNullable)],
+    );
+
+    let mut builder = builder_with_capacity(array.dtype(), 0);
+    builder.append_scalar(&scalar)?;
+    array.append_to_builder(builder.as_mut(), &mut ctx)?;
+    builder.append_scalar(&scalar)?;
+    let built = builder.finish();
+
+    let scalar_array = StructArray::try_from_iter([(
+        "a",
+        PrimitiveArray::new(buffer![1i32], Validity::NonNullable),
+    )])?
+    .into_array();
+    let expected = ChunkedArray::try_new(
+        vec![scalar_array.clone(), array, scalar_array],
+        built.dtype().clone(),
+    )?;
+    assert_arrays_eq!(&built, &expected, &mut ctx);
+
+    Ok(())
+}
+
+/// An arbitrary array length. Nested builders treat no length specially, so the tests only need a
+/// length long enough to tell chunks apart.
+const CHUNK_LEN: usize = 64;
+
+/// A non-canonical array of [`CHUNK_LEN`] `i32` values.
+fn constant_i32() -> ArrayRef {
+    ConstantArray::new(0i32, CHUNK_LEN).into_array()
+}
+
+/// Two lists of [`CHUNK_LEN`] elements each, so that appending them chunks the elements.
+fn two_lists_of_chunk_len() -> ListViewArray {
+    ListViewArray::new(
+        iota(2 * CHUNK_LEN),
+        u64s([0, CHUNK_LEN]),
+        u64s([CHUNK_LEN, CHUNK_LEN]),
+        Validity::NonNullable,
+    )
+}
+
+/// `0..n` as an `i32` array, so that the values of one chunk are distinguishable from the next.
+fn iota(n: usize) -> ArrayRef {
+    (0..n)
+        .map(|i| i32::try_from(i).vortex_expect("iota value fits in an i32"))
+        .collect::<Buffer<_>>()
+        .into_array()
+}
+
+/// A `u64` array of list offsets or sizes.
+fn u64s(values: impl IntoIterator<Item = usize>) -> ArrayRef {
+    values
+        .into_iter()
+        .map(|v| u64::try_from(v).vortex_expect("list offset fits in a u64"))
+        .collect::<Buffer<_>>()
+        .into_array()
+}
+
+/// Once a list builder keeps its elements as chunks, `elements_builder.len()` is a running total
+/// across those chunks — every offset appended afterwards has to be rebased onto it.
+///
+/// The two cases cover the two bulk paths into the elements builder: appending a `ListViewArray`
+/// rebases the view's own offsets, while appending a `ListArray` slices the elements first.
+#[rstest]
+#[case::from_listview(two_lists_of_chunk_len().into_array())]
+#[case::from_list(
+    ListArray::new(
+        iota(2 * CHUNK_LEN),
+        u64s([0, CHUNK_LEN, 2 * CHUNK_LEN]),
+        Validity::NonNullable,
+    )
+    .into_array()
+)]
+fn test_list_offsets_are_rebased_across_element_chunks(
+    #[case] lists: ArrayRef,
+) -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+
+    let mut builder = builder_with_capacity(
+        &DType::List(
+            Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable)),
+            Nullability::NonNullable,
+        ),
+        0,
+    );
+    lists.append_to_builder(builder.as_mut(), &mut ctx)?;
+    lists.append_to_builder(builder.as_mut(), &mut ctx)?;
+    let built = builder.finish();
+
+    assert!(
+        built.as_::<ListView>().elements().is::<Chunked>(),
+        "the elements should have been kept as chunks",
+    );
+
+    let expected = ChunkedArray::try_new(vec![lists.clone(), lists], built.dtype().clone())?;
+    assert_arrays_eq!(&built, &expected, &mut ctx);
+
+    Ok(())
+}
+
+/// `ListBuilder` computes each offset from the running element count as well, and reaches the
+/// elements builder through `append_array_as_list` rather than a bulk append.
+#[test]
+fn test_list_builder_offsets_are_rebased_across_element_chunks() -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+    let element_dtype = Arc::new(DType::Primitive(PType::I32, Nullability::NonNullable));
+
+    let mut builder =
+        ListBuilder::<u64>::with_capacity(element_dtype, Nullability::NonNullable, 0, 0);
+    for value in 0..3i32 {
+        builder
+            .append_array_as_list(&ConstantArray::new(value, CHUNK_LEN).into_array(), &mut ctx)?;
+    }
+    let built = builder.finish();
+
+    assert!(built.as_::<List>().elements().is::<Chunked>());
+
+    let expected = ListArray::new(
+        (0..3i32)
+            .flat_map(|value| std::iter::repeat_n(value, CHUNK_LEN))
+            .collect::<Buffer<_>>()
+            .into_array(),
+        u64s((0..=3).map(|i| i * CHUNK_LEN)),
+        Validity::NonNullable,
+    );
+    assert_arrays_eq!(&built, &expected, &mut ctx);
+
+    Ok(())
+}
+
+/// A nested builder's own validity buffer is independent of its chunked child, so nulls appended
+/// alongside chunks must survive.
+#[rstest]
+#[case::fixed_size_list(
+    FixedSizeListArray::new(
+        iota(CHUNK_LEN),
+        4,
+        Validity::from_iter((0..CHUNK_LEN / 4).map(|i| i % 3 != 0)),
+        CHUNK_LEN / 4,
+    )
+    .into_array(),
+    |array: &ArrayRef| array.as_::<FixedSizeList>().elements().clone()
+)]
+#[case::struct_(
+    StructArray::try_from_iter_with_validity(
+        [("a", iota(CHUNK_LEN))],
+        Validity::from_iter((0..CHUNK_LEN).map(|i| i % 3 != 0)),
+    )
+    .vortex_expect("struct array")
+    .into_array(),
+    |array: &ArrayRef| array.as_::<Struct>().unmasked_field(0).clone()
+)]
+fn test_validity_survives_chunked_children(
+    #[case] array: ArrayRef,
+    #[case] child_of: fn(&ArrayRef) -> ArrayRef,
+) -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+
+    let mut builder = builder_with_capacity(array.dtype(), 0);
+    array.append_to_builder(builder.as_mut(), &mut ctx)?;
+    builder.append_nulls(1);
+    array.append_to_builder(builder.as_mut(), &mut ctx)?;
+    let built = builder.finish();
+
+    assert!(child_of(&built).is::<Chunked>());
+
+    let mut null = builder_with_capacity(array.dtype(), 1);
+    null.append_nulls(1);
+    let expected = ChunkedArray::try_new(
+        vec![array.clone(), null.finish(), array],
+        built.dtype().clone(),
+    )?;
+    assert_arrays_eq!(&built, &expected, &mut ctx);
+
+    Ok(())
+}
+
+/// An extension array has no validity of its own — it lives in the storage — so overriding the
+/// builder's validity has to reach into the chunked storage.
+#[test]
+fn test_extension_set_validity_reaches_chunked_storage() -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+    let ext_dtype = Timestamp::new(TimeUnit::Milliseconds, Nullability::Nullable).erased();
+
+    let array = ExtensionArray::new(
+        ext_dtype.clone(),
+        ConstantArray::new(Scalar::primitive(0i64, Nullability::Nullable), CHUNK_LEN).into_array(),
+    )
+    .into_array();
+
+    let mut builder = builder_with_capacity(array.dtype(), 0);
+    array.append_to_builder(builder.as_mut(), &mut ctx)?;
+    array.append_to_builder(builder.as_mut(), &mut ctx)?;
+
+    let invalid = [0, 2 * CHUNK_LEN - 1];
+    builder.set_validity(Mask::from_iter(
+        (0..2 * CHUNK_LEN).map(|i| !invalid.contains(&i)),
+    ));
+    let built = builder.finish();
+
+    assert!(built.as_::<Extension>().storage().is::<Chunked>());
+
+    let expected = ExtensionArray::new(
+        ext_dtype,
+        PrimitiveArray::from_option_iter(
+            (0..2 * CHUNK_LEN).map(|i| (!invalid.contains(&i)).then_some(0i64)),
+        )
+        .into_array(),
+    )
+    .into_array();
+    assert_arrays_eq!(&built, &expected, &mut ctx);
+
+    Ok(())
+}
+
+/// Consumers that genuinely need a fully-decoded tree ask for it, and must still get one.
+#[test]
+fn test_chunked_children_canonicalize_recursively() -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+
+    let array = StructArray::try_from_iter([("a", constant_i32())])?.into_array();
+    let mut builder = builder_with_capacity(array.dtype(), 0);
+    array.append_to_builder(builder.as_mut(), &mut ctx)?;
+    array.append_to_builder(builder.as_mut(), &mut ctx)?;
+    let built = builder.finish();
+
+    let recursive = built.clone().execute::<RecursiveCanonical>(&mut ctx)?.0;
+    assert!(
+        recursive
+            .clone()
+            .into_array()
+            .as_::<Struct>()
+            .unmasked_field(0)
+            .is::<Primitive>()
+    );
+    assert_arrays_eq!(&recursive.into_array(), &built, &mut ctx);
+
     Ok(())
 }


### PR DESCRIPTION
Builders are lazy. Fully canonical builders force a lot of unnecessary decompression which goes against what vortex aims for. With this change builders behave more like canonical arrays where the top level isn't lazy but the children are. Practically speaking this means that all nested type builders store lazy children and validity