### PR TITLE
fix(arrow): return an error for incompatible Arrow export targets

### DIFF
--- a/vortex-arrow/src/executor/bool.rs
+++ b/vortex-arrow/src/executor/bool.rs
@@ -9,7 +9,9 @@ use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::bool::BoolArrayExt;
+use vortex_array::dtype::DType;
 use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
 
 use crate::null_buffer::to_null_buffer;
 
@@ -33,6 +35,11 @@ pub(super) fn to_arrow_bool(
     array: ArrayRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrowArrayRef> {
+    vortex_ensure!(
+        matches!(array.dtype(), DType::Bool(_)),
+        "Cannot convert Vortex array with dtype {} to an Arrow Boolean array",
+        array.dtype()
+    );
     let bool_array = array.execute::<BoolArray>(ctx)?;
     canonical_bool_to_arrow(&bool_array, ctx)
 }

--- a/vortex-arrow/src/executor/decimal.rs
+++ b/vortex-arrow/src/executor/decimal.rs
@@ -16,9 +16,11 @@ use num_traits::ToPrimitive;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::arrays::DecimalArray;
+use vortex_array::dtype::DType;
 use vortex_array::dtype::DecimalType;
 use vortex_buffer::Buffer;
 use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 
 use crate::null_buffer::to_null_buffer;
@@ -28,6 +30,13 @@ pub(super) fn to_arrow_decimal(
     data_type: &DataType,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrowArrayRef> {
+    vortex_ensure!(
+        matches!(array.dtype(), DType::Decimal(..)),
+        "Cannot convert Vortex array with dtype {} to an Arrow {} array",
+        array.dtype(),
+        data_type
+    );
+
     // Execute the array as a DecimalArray.
     let decimal_array = array.execute::<DecimalArray>(ctx)?;
 

--- a/vortex-arrow/src/executor/fixed_size_list.rs
+++ b/vortex-arrow/src/executor/fixed_size_list.rs
@@ -10,6 +10,7 @@ use vortex_array::arrays::FixedSizeList;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArraySlotsExt;
+use vortex_array::dtype::DType;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 
@@ -22,6 +23,12 @@ pub(super) fn to_arrow_fixed_list(
     elements_field: &FieldRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<arrow_array::ArrayRef> {
+    vortex_ensure!(
+        matches!(array.dtype(), DType::FixedSizeList(..)),
+        "Cannot convert Vortex array with dtype {} to an Arrow FixedSizeList array",
+        array.dtype()
+    );
+
     // Check for Vortex FixedSizeListArray and convert directly.
     if let Some(array) = array.as_opt::<FixedSizeList>() {
         return list_to_list(&array.into_owned(), elements_field, list_size, ctx);

--- a/vortex-arrow/src/executor/list.rs
+++ b/vortex-arrow/src/executor/list.rs
@@ -52,6 +52,12 @@ pub(super) fn to_arrow_list<O: OffsetSizeTrait + NativePType>(
     elements_field: &FieldRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrowArrayRef> {
+    vortex_ensure!(
+        matches!(array.dtype(), DType::List(..)),
+        "Cannot convert Vortex array with dtype {} to an Arrow list array",
+        array.dtype()
+    );
+
     let array = array.execute_until::<ArrowListExportable>(ctx)?;
 
     // If the Vortex array is already in List format, we can directly convert it.

--- a/vortex-arrow/src/executor/list_view.rs
+++ b/vortex-arrow/src/executor/list_view.rs
@@ -31,6 +31,12 @@ pub(super) fn to_arrow_list_view<O: OffsetSizeTrait + IntegerPType>(
     elements_field: &FieldRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<arrow_array::ArrayRef> {
+    vortex_ensure!(
+        matches!(array.dtype(), DType::List(..)),
+        "Cannot convert Vortex array with dtype {} to an Arrow list-view array",
+        array.dtype()
+    );
+
     let array = array.execute::<ListViewArray>(ctx)?;
 
     // Reclaim unreferenced elements before handing the array to Arrow. Otherwise downstream

--- a/vortex-arrow/src/executor/mod.rs
+++ b/vortex-arrow/src/executor/mod.rs
@@ -251,3 +251,94 @@ fn infer_nearest_arrow_type(array: &ArrayRef) -> VortexResult<DataType> {
     // Everything else: use canonical dtype conversion
     to_data_type_naive(array.dtype())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_schema::DataType;
+    use arrow_schema::Field;
+    use arrow_schema::TimeUnit;
+    use rstest::rstest;
+    use vortex_array::ArrayRef;
+    use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
+    use vortex_array::array_session;
+    use vortex_array::arrays::BoolArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::arrays::VarBinViewArray;
+
+    use crate::ArrowSessionExt;
+
+    fn utf8() -> ArrayRef {
+        VarBinViewArray::from_iter_str(["a", "bb"]).into_array()
+    }
+
+    fn primitive() -> ArrayRef {
+        PrimitiveArray::from_iter([1i32, 2]).into_array()
+    }
+
+    fn boolean() -> ArrayRef {
+        BoolArray::from_iter([true, false]).into_array()
+    }
+
+    fn list_target() -> DataType {
+        DataType::List(Arc::new(Field::new("item", DataType::Int32, true)))
+    }
+
+    /// Must error rather than panic inside `execute::<T>`.
+    #[rstest]
+    #[case::bool_from_utf8(utf8(), DataType::Boolean)]
+    #[case::bool_from_primitive(primitive(), DataType::Boolean)]
+    #[case::null_from_utf8(utf8(), DataType::Null)]
+    #[case::null_from_primitive(primitive(), DataType::Null)]
+    #[case::decimal_from_utf8(utf8(), DataType::Decimal128(10, 2))]
+    #[case::decimal_from_primitive(primitive(), DataType::Decimal128(10, 2))]
+    #[case::list_from_utf8(utf8(), list_target())]
+    #[case::list_from_primitive(primitive(), list_target())]
+    #[case::list_view_from_primitive(
+        primitive(),
+        DataType::ListView(Arc::new(Field::new("item", DataType::Int32, true)))
+    )]
+    #[case::fixed_size_list_from_utf8(
+        utf8(),
+        DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Int32, true)), 2)
+    )]
+    #[case::byte_from_primitive(primitive(), DataType::Utf8)]
+    #[case::byte_from_bool(boolean(), DataType::Binary)]
+    fn incompatible_target_returns_error(#[case] array: ArrayRef, #[case] target: DataType) {
+        let session = array_session();
+        let mut ctx = session.create_execution_ctx();
+        let field = Field::new("f", target.clone(), array.dtype().is_nullable());
+
+        let result = session.arrow().execute_arrow(array, Some(&field), &mut ctx);
+
+        assert!(
+            result.is_err(),
+            "expected an error exporting to {target:?}, got Ok"
+        );
+    }
+
+    /// Cross-class conversions that are genuinely supported must keep working.
+    #[rstest]
+    #[case::bool_to_int32(boolean(), DataType::Int32)]
+    #[case::bool_to_float64(boolean(), DataType::Float64)]
+    #[case::primitive_to_int64(primitive(), DataType::Int64)]
+    #[case::primitive_to_date32(primitive(), DataType::Date32)]
+    #[case::primitive_to_timestamp(primitive(), DataType::Timestamp(TimeUnit::Microsecond, None))]
+    #[case::utf8_to_binary(utf8(), DataType::Binary)]
+    #[case::utf8_to_large_utf8(utf8(), DataType::LargeUtf8)]
+    fn supported_cross_class_target_still_works(#[case] array: ArrayRef, #[case] target: DataType) {
+        let session = array_session();
+        let mut ctx = session.create_execution_ctx();
+        let field = Field::new("f", target.clone(), array.dtype().is_nullable());
+
+        let result = session.arrow().execute_arrow(array, Some(&field), &mut ctx);
+
+        assert!(
+            result.is_ok(),
+            "expected {target:?} export to succeed, got {:?}",
+            result.err()
+        );
+    }
+}

--- a/vortex-arrow/src/executor/null.rs
+++ b/vortex-arrow/src/executor/null.rs
@@ -8,7 +8,9 @@ use arrow_array::NullArray as ArrowNullArray;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::arrays::NullArray;
+use vortex_array::dtype::DType;
 use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
 
 /// Convert a canonical NullArray directly to Arrow.
 pub fn canonical_null_to_arrow(array: &NullArray) -> ArrowArrayRef {
@@ -19,6 +21,11 @@ pub(super) fn to_arrow_null(
     array: ArrayRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrowArrayRef> {
+    vortex_ensure!(
+        matches!(array.dtype(), DType::Null),
+        "Cannot convert Vortex array with dtype {} to an Arrow Null array",
+        array.dtype()
+    );
     let null_array = array.execute::<NullArray>(ctx)?;
     Ok(canonical_null_to_arrow(&null_array))
 }


### PR DESCRIPTION
## Rationale for this change

Follow-up to #8902, which added `to_arrow_array(arrow_type=...)` and `to_arrow(schema=...)`. Those parameters let a caller pick the target Arrow type, and `execute_arrow_naive` dispatches purely on that `DataType` without checking whether the source dtype can produce it.

#8902 added a guard for the byte arms. Five other arms have the same problem: they call `execute::<T>`, which is documented as panicking on a dtype mismatch:

```rust
/// Execute the array to canonical form and unwrap as a [`BoolArray`].
///
/// This will panic if the array's dtype is not bool.
impl Executable for BoolArray { ... }
```

So `vx.array([1, 2, 3]).to_arrow_array(arrow_type=pa.bool_())` panics inside `Canonical::into_bool()` instead of returning an error. A panic crossing PyO3 becomes a `PanicException`, and in a DataFusion or DuckDB worker it is a panic rather than a surfaced error.

Measured before this change, exporting each source dtype to each target:

```
source\tgt      Utf8  LargeUtf8  Binary  LargeBinary  Utf8View  BinaryView  Int32  Int64  Float64  Boolean
utf8              ok         ok      ok           ok        ok         Err    Err    Err      Err    PANIC
binary            ok         ok      ok           ok       Err          ok    Err    Err      Err    PANIC
i32              Err        Err     Err          Err       Err         Err     ok     ok       ok    PANIC
f64              Err        Err     Err          Err       Err         Err     ok     ok       ok    PANIC
bool             Err        Err     Err          Err       Err         Err     ok     ok       ok       ok
```

Extending to the remaining arms, `Boolean`, `Null`, `Decimal128`, `List`, `ListView`, and `FixedSizeList` all panic. `Date32`, `Timestamp`, `FixedSizeBinary`, and `Struct` were already fine.

## What changes are included in this PR?

A `vortex_ensure!` on the source dtype at the top of each affected arm, mirroring the existing check in `to_arrow_byte_array`: `to_arrow_bool`, `to_arrow_null`, `to_arrow_decimal`, `to_arrow_list`, `to_arrow_list_view`, and `to_arrow_fixed_list`.

The guards are per-arm rather than centralised because compatibility is not symmetric. A `Bool` source exports to `Int32` through a cast kernel, but a `Primitive` source cannot produce `Boolean`. A single "type classes must match" rule at the dispatch point would reject conversions that work today, and the per-arm requirement is local and obvious.

Two `rstest` cases in `vortex-arrow/src/executor/mod.rs`:

- `incompatible_target_returns_error` — 12 source/target pairs that previously panicked now return `Err`.
- `supported_cross_class_target_still_works` — 7 legitimate cross-class conversions (`bool → Int32`, `bool → Float64`, `i32 → Date32`, `i32 → Timestamp`, `utf8 → Binary`, …) still succeed, pinning the asymmetry above so a future centralisation attempt cannot quietly break them.

## What APIs are changed? Are there any user-facing changes?

No API changes. Behaviour change only on a path that previously aborted the process: requesting an Arrow type the source dtype cannot produce now returns a `VortexError` naming both the dtype and the target type.

## Verification

- `cargo test -p vortex-arrow -p vortex-array -p vortex-datafusion` — 3145 + 220 + 247 + 72 + 13 passed, 0 failed.
- `cargo clippy -p vortex-arrow --all-targets --all-features` — clean.
- `cargo +nightly fmt --all`, `git diff --check` — clean.

Not run: Python tests, docs doctests. This PR touches no Python or docs surface.