### PR TITLE
perf(array): hoist per-row work out of append_varbinview

### DIFF
--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -204,6 +204,10 @@ name = "validity_is_valid"
 harness = false
 
 [[bench]]
+name = "varbin_append_varbinview"
+harness = false
+
+[[bench]]
 name = "dict_unreferenced_mask"
 harness = false
 

--- a/vortex-array/benches/varbin_append_varbinview.rs
+++ b/vortex-array/benches/varbin_append_varbinview.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Benchmarks appending a `VarBinViewArray` into a `DynVarBinBuilder`, the fallback path every
+//! string encoding without a direct branch reaches through canonicalization.
+//!
+//! `inlined` values are 12 bytes or fewer and live in the view itself, which is the common case for
+//! short strings; `heap` values exceed that and live in a data buffer.
+
+#![allow(clippy::unwrap_used)]
+
+use std::sync::LazyLock;
+
+use divan::Bencher;
+use divan::black_box;
+use vortex_array::IntoArray;
+use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
+use vortex_array::arrays::VarBinViewArray;
+use vortex_array::builders::DynVarBinBuilder;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::Nullability;
+use vortex_session::VortexSession;
+
+fn main() {
+    divan::main();
+}
+
+const SIZES: &[usize] = &[4096, 16384];
+
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
+
+fn inlined_values(len: usize, nulls: bool) -> VarBinViewArray {
+    VarBinViewArray::from_iter(
+        (0..len).map(|i| {
+            (!nulls || !i.is_multiple_of(4)).then(|| format!("{:<12}", i % 1000).into_bytes())
+        }),
+        DType::Utf8(Nullability::Nullable),
+    )
+}
+
+fn heap_values(len: usize, nulls: bool) -> VarBinViewArray {
+    VarBinViewArray::from_iter(
+        (0..len).map(|i| {
+            (!nulls || !i.is_multiple_of(4))
+                .then(|| format!("https://example.com/some/path/segment/{i}").into_bytes())
+        }),
+        DType::Utf8(Nullability::Nullable),
+    )
+}
+
+fn bench_append(bencher: Bencher, array: VarBinViewArray) {
+    let mut ctx = SESSION.create_execution_ctx();
+    let len = array.len();
+    let array = array.into_array();
+    bencher.bench_local(|| {
+        let mut builder =
+            DynVarBinBuilder::with_capacity(DType::Utf8(Nullability::Nullable), false, len);
+        array.append_to_builder(&mut builder, &mut ctx).unwrap();
+        black_box(builder.finish_into_varbin())
+    });
+}
+
+#[divan::bench(args = SIZES)]
+fn inlined_all_valid(bencher: Bencher, len: usize) {
+    bench_append(bencher, inlined_values(len, false));
+}
+
+#[divan::bench(args = SIZES)]
+fn inlined_with_nulls(bencher: Bencher, len: usize) {
+    bench_append(bencher, inlined_values(len, true));
+}
+
+#[divan::bench(args = SIZES)]
+fn heap_all_valid(bencher: Bencher, len: usize) {
+    bench_append(bencher, heap_values(len, false));
+}
+
+#[divan::bench(args = SIZES)]
+fn heap_with_nulls(bencher: Bencher, len: usize) {
+    bench_append(bencher, heap_values(len, true));
+}

--- a/vortex-array/src/arrays/varbin/builder.rs
+++ b/vortex-array/src/arrays/varbin/builder.rs
@@ -27,6 +27,7 @@ use crate::arrays::VarBinView;
 use crate::arrays::varbin::VarBinArrayExt;
 use crate::arrays::varbin::VarBinArraySlotsExt;
 use crate::arrays::varbinview::VarBinViewArrayExt;
+use crate::arrays::varbinview::build_views::BinaryView;
 use crate::builders::ArrayBuilder;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
@@ -174,6 +175,12 @@ impl<O: IntegerPType> VarBinBuilder<O> {
         self.validity.reserve(additional);
     }
 
+    /// Reserves space for `additional` value *bytes*, unlike [`Self::reserve_exact`], which takes
+    /// a row count and so cannot size the data buffer.
+    fn reserve_data(&mut self, additional: usize) {
+        self.data.reserve(additional);
+    }
+
     fn set_validity(&mut self, validity: Mask) {
         self.validity = match validity {
             Mask::AllTrue(len) => BitBufferMut::new_set(len),
@@ -219,6 +226,18 @@ impl<O: IntegerPType> VarBinBuilder<O> {
         unsafe {
             VarBinArray::new_unchecked(offsets.into_array(), self.data.freeze(), dtype, validity)
         }
+    }
+}
+
+/// Resolves one view to its bytes, borrowing from `buffers` instead of building an owned
+/// `ByteBuffer` per call like `bytes_at` does.
+#[inline]
+fn view_bytes<'a>(view: &'a BinaryView, buffers: &[&'a [u8]]) -> &'a [u8] {
+    if view.is_inlined() {
+        view.as_inlined().value()
+    } else {
+        let reference = view.as_view();
+        &buffers[reference.buffer_index as usize][reference.as_range()]
     }
 }
 
@@ -327,30 +346,47 @@ impl DynVarBinBuilder {
     }
 
     /// Appends a [`VarBinViewArray`](crate::arrays::VarBinViewArray).
+    ///
+    /// Converting views to offsets must visit each value, but the views, data buffers and byte
+    /// total are all resolved once up front rather than per row.
     pub fn append_varbinview(
         &mut self,
         array: crate::ArrayView<'_, VarBinView>,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
-        let validity = array
-            .varbinview_validity()
-            .execute_mask(array.as_ref().len(), ctx)?;
+        let len = array.as_ref().len();
+        let validity = array.varbinview_validity().execute_mask(len, ctx)?;
+
+        // `views()` may be empty when every slot is null.
+        if let Mask::AllFalse(n) = &validity {
+            self.push_nulls(*n);
+            return Ok(());
+        }
+
+        let views = array.views();
+        let buffers: Vec<&[u8]> = (0..array.data_buffers().len())
+            .map(|idx| array.buffer(idx).as_slice())
+            .collect();
+
+        // An upper bound when some slots are null, which is fine for a reservation.
+        self.reserve_data(views.iter().map(|view| view.len() as usize).sum());
+
         match &validity {
             Mask::AllTrue(_) => {
-                for index in 0..array.as_ref().len() {
-                    self.append_value(array.bytes_at(index));
+                for view in views {
+                    self.append_value(view_bytes(view, &buffers));
                 }
             }
-            Mask::AllFalse(len) => self.push_nulls(*len),
-            Mask::Values(values) => {
-                for (index, is_valid) in values.bit_buffer().iter().enumerate() {
-                    if is_valid {
-                        self.append_value(array.bytes_at(index));
-                    } else {
-                        self.push_null();
-                    }
-                }
+            Mask::Values(mask_values) => {
+                let mut row = 0;
+                mask_values.bit_buffer().for_each_set_index(|index| {
+                    self.push_nulls(index - row);
+                    self.append_value(view_bytes(&views[index], &buffers));
+                    row = index + 1;
+                });
+                self.push_nulls(len - row);
             }
+            Mask::AllFalse(_) => unreachable!("handled above"),
         }
         Ok(())
     }
@@ -370,17 +406,17 @@ impl DynVarBinBuilder {
         }
     }
 
-    fn push_null(&mut self) {
-        match &mut self.storage {
-            DynOffsets::I32(builder) => builder.append_null(),
-            DynOffsets::I64(builder) => builder.append_null(),
-        }
-    }
-
     fn push_nulls(&mut self, n: usize) {
         match &mut self.storage {
             DynOffsets::I32(builder) => builder.append_n_nulls(n),
             DynOffsets::I64(builder) => builder.append_n_nulls(n),
+        }
+    }
+
+    fn reserve_data(&mut self, additional: usize) {
+        match &mut self.storage {
+            DynOffsets::I32(builder) => builder.reserve_data(additional),
+            DynOffsets::I64(builder) => builder.reserve_data(additional),
         }
     }
 }
@@ -583,6 +619,57 @@ mod tests {
         mixed
             .into_array()
             .append_to_builder(&mut builder, &mut ctx)?;
+
+        assert_arrays_eq!(builder.finish_into_varbin(), expected, &mut ctx);
+        Ok(())
+    }
+
+    /// Covers both storage kinds, every validity shape, and slices (which shift the bit offset).
+    #[rstest]
+    #[case::inlined_all_valid(vec![Some("short"), Some("tiny"), Some("abc")])]
+    #[case::inlined_with_nulls(vec![Some("short"), None, Some("abc"), None])]
+    #[case::heap_all_valid(vec![
+        Some("a string comfortably longer than twelve bytes"),
+        Some("another string that also exceeds twelve bytes"),
+    ])]
+    #[case::heap_with_nulls(vec![
+        Some("a string comfortably longer than twelve bytes"),
+        None,
+        Some("another string that also exceeds twelve bytes"),
+    ])]
+    #[case::mixed_inlined_and_heap(vec![
+        Some("tiny"),
+        Some("a string comfortably longer than twelve bytes"),
+        None,
+        Some("abc"),
+        Some("yet another string exceeding the inline limit"),
+    ])]
+    #[case::all_null(vec![None, None, None])]
+    #[case::leading_and_trailing_nulls(vec![None, Some("mid"), None])]
+    #[case::empty(vec![])]
+    fn append_varbinview_matches_source(
+        #[case] values: Vec<Option<&str>>,
+        #[values(false, true)] large_offsets: bool,
+        #[values(false, true)] sliced: bool,
+    ) -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let source =
+            VarBinViewArray::from_iter(values.iter().copied(), DType::Utf8(Nullable)).into_array();
+
+        let (source, expected) = if sliced && !values.is_empty() {
+            let start = 1.min(values.len() - 1);
+            (
+                source.slice(start..values.len())?,
+                VarBinViewArray::from_iter(values[start..].iter().copied(), DType::Utf8(Nullable))
+                    .into_array(),
+            )
+        } else {
+            (source.clone(), source)
+        };
+
+        let mut builder =
+            DynVarBinBuilder::with_capacity(DType::Utf8(Nullable), large_offsets, source.len());
+        source.append_to_builder(&mut builder, &mut ctx)?;
 
         assert_arrays_eq!(builder.finish_into_varbin(), expected, &mut ctx);
         Ok(())


### PR DESCRIPTION
## Rationale for this change

Follow-up to #8902. `DynVarBinBuilder::append_varbinview` is the fallback every string encoding without a direct branch reaches through canonicalization: Sparse, RunEnd, Dict, and anything on the default `VTable::append_to_builder`. It was written per-row.

`AGENTS.md` names both anti-patterns it hit. Converting views to offsets does have to visit each value — that part is irreducible, and `AGENTS.md` explicitly carves it out ("Gather over arbitrary indices → you cannot amortize a per-element decode, but you can still materialize the backing buffer once"). The work *around* the walk is what this removes.

## What changes are included in this PR?

- **Resolve the backing storage once.** `bytes_at` re-resolved the views slice and returned an owned `ByteBuffer` on every call. The views slice and data buffer slices are now hoisted and borrowed from. Inlined values (≤ 12 bytes, the common short-string case) come straight out of the view rather than round-tripping the views handle through `into_byte_buffer().slice_ref(..)`.
- **Walk validity a word at a time.** `bit_buffer().iter().enumerate()` paid a branch per element. Now `for_each_set_index`, with gaps filled by `append_n_nulls` — the same shape the Zstd path uses.
- **Size the data buffer once.** The byte total is a sum over the fixed-width views and needs no value access, so a new private `reserve_data` sizes the buffer up front rather than letting it reallocate as it grows. `reserve_exact` takes a row count and so cannot serve this purpose, hence the separate method.

Net effect: the function no longer allocates per row, and the data buffer no longer reallocates during an append.

`append_varbinview_matches_source` covers inlined-only, heap-only, mixed, all-null, leading/trailing nulls, and empty, each across both offset widths and both sliced and unsliced. Slicing matters because it shifts the validity bit offset, which the word-at-a-time walk must respect. `for_each_set_index` needs no bounds check here: `iter_padded` zero-pads the remainder word, so it never yields an index past `len`.

## On the benchmark

Sizes are 4096 and 16384, chosen to keep every case well under 1ms (medians ~110–180µs). At those sizes the change is **within run-to-run noise**, so the benchmark is a regression guard, not evidence of a speedup. Performance validation is happening separately, outside this CI environment — the run-to-run spread on the runner used here is wide enough that small deltas are not defensible either way.

Reviewing this on structural grounds: fewer allocations per append, and conformance with the hot-loop guidance in `AGENTS.md`.

## What APIs are changed? Are there any user-facing changes?

No public API changes. `reserve_data` is private to the module. Output is unchanged.

## Verification

- `cargo test -p vortex-array -p vortex-arrow -p vortex-fsst -p vortex-onpair -p vortex-sparse -p vortex-runend -p vortex-zstd` — 3177 + 201 + 85 + 36 + 70 + 109 + 28 + 72 passed, 0 failed.
- `cargo clippy -p vortex-array --all-targets --all-features` — clean.
- `cargo +nightly fmt --all`, `git diff --check` — clean.

Independent of #8993 and #8995; all three branch from `develop` and touch disjoint code.