### PR TITLE
Register mask/slice execute-parent kernels for `Dict`

### DIFF
--- a/vortex-array/src/arrays/dict/compute/mask.rs
+++ b/vortex-array/src/arrays/dict/compute/mask.rs
@@ -4,14 +4,17 @@
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::array::ArrayView;
 use crate::arrays::Dict;
 use crate::arrays::DictArray;
+use crate::arrays::Primitive;
 use crate::arrays::dict::DictArraySlotsExt;
 use crate::arrays::scalar_fn::ScalarFnFactoryExt;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::fns::mask::Mask as MaskExpr;
+use crate::scalar_fn::fns::mask::MaskKernel;
 use crate::scalar_fn::fns::mask::MaskReduce;
 
 impl MaskReduce for Dict {
@@ -25,5 +28,67 @@ impl MaskReduce for Dict {
         Ok(Some(unsafe {
             DictArray::new_unchecked(masked_codes, array.values().clone()).into_array()
         }))
+    }
+}
+
+impl MaskKernel for Dict {
+    fn mask(
+        array: ArrayView<'_, Dict>,
+        mask: &ArrayRef,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        // Keep Primitive codes probe-able: AND the mask into their validity instead of hiding
+        // them behind a scalar-fn wrapper, which would defeat downstream fast paths that
+        // downcast the codes (constant-code slicing, specialized primitive slicing, ...).
+        if let Some(codes) = array.codes().as_typed::<Primitive>()
+            && let Some(masked_codes) = <Primitive as MaskReduce>::mask(codes, mask)?
+        {
+            // SAFETY: masking codes doesn't change dict invariants
+            return Ok(Some(unsafe {
+                DictArray::new_unchecked(masked_codes, array.values().clone()).into_array()
+            }));
+        }
+
+        <Dict as MaskReduce>::mask(array, mask)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
+    use vortex_error::vortex_err;
+
+    use crate::IntoArray;
+    use crate::VortexSessionExecute;
+    use crate::array_session;
+    use crate::arrays::BoolArray;
+    use crate::arrays::Dict;
+    use crate::arrays::DictArray;
+    use crate::arrays::Primitive;
+    use crate::arrays::VarBinViewArray;
+    use crate::arrays::dict::DictArraySlotsExt;
+    use crate::arrays::scalar_fn::ScalarFnFactoryExt;
+    use crate::scalar_fn::EmptyOptions;
+    use crate::scalar_fn::fns::mask::Mask;
+
+    #[test]
+    fn mask_kernel_keeps_primitive_codes_probeable() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let dict = DictArray::try_new(
+            buffer![0u8, 1, 0].into_array(),
+            VarBinViewArray::from_iter_str(["a", "b"]).into_array(),
+        )?;
+        let mask = BoolArray::from_iter([true, false, true]);
+        let masked = Mask.try_new_array(3, EmptyOptions, [dict.into_array(), mask.into_array()])?;
+
+        // The mask execute-parent kernel reveals a Dict whose codes remain Primitive (with
+        // masked validity) rather than being hidden behind a scalar-fn wrapper.
+        let revealed = masked.execute_until::<Dict>(&mut ctx)?;
+        let dict = revealed
+            .try_downcast::<Dict>()
+            .map_err(|a| vortex_err!("expected Dict, got {}", a.encoding_id()))?;
+        assert!(dict.codes().is::<Primitive>());
+        Ok(())
     }
 }

--- a/vortex-array/src/arrays/dict/compute/slice.rs
+++ b/vortex-array/src/arrays/dict/compute/slice.rs
@@ -7,6 +7,7 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::array::ArrayView;
 use crate::arrays::Constant;
@@ -15,11 +16,22 @@ use crate::arrays::Dict;
 use crate::arrays::DictArray;
 use crate::arrays::Primitive;
 use crate::arrays::dict::DictArraySlotsExt;
+use crate::arrays::slice::SliceKernel;
 use crate::arrays::slice::SliceReduce;
 use crate::expr::stats::Precision;
 use crate::expr::stats::Stat;
 use crate::scalar::Scalar;
 use crate::scalar::ScalarValue;
+
+impl SliceKernel for Dict {
+    fn slice(
+        array: ArrayView<'_, Self>,
+        range: Range<usize>,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        <Dict as SliceReduce>::slice(array, range)
+    }
+}
 
 impl SliceReduce for Dict {
     fn slice(array: ArrayView<'_, Self>, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/arrays/dict/vtable/kernel.rs
+++ b/vortex-array/src/arrays/dict/vtable/kernel.rs
@@ -6,13 +6,17 @@ use vortex_session::VortexSession;
 use crate::ArrayVTable;
 use crate::arrays::Chunked;
 use crate::arrays::Dict;
+use crate::arrays::Slice;
 use crate::arrays::dict::TakeExecuteAdaptor;
+use crate::arrays::slice::SliceExecuteAdaptor;
 use crate::optimizer::kernels::ArrayKernelsExt;
 use crate::scalar_fn::ScalarFnVTable;
 use crate::scalar_fn::fns::binary::Binary;
 use crate::scalar_fn::fns::binary::CompareExecuteAdaptor;
 use crate::scalar_fn::fns::fill_null::FillNull;
 use crate::scalar_fn::fns::fill_null::FillNullExecuteAdaptor;
+use crate::scalar_fn::fns::mask::Mask;
+use crate::scalar_fn::fns::mask::MaskExecuteAdaptor;
 
 pub(crate) fn initialize(session: &VortexSession) {
     let kernels = session.kernels();
@@ -20,4 +24,6 @@ pub(crate) fn initialize(session: &VortexSession) {
     kernels.register_execute_parent_kernel(Dict.id(), Chunked, TakeExecuteAdaptor(Chunked));
     kernels.register_execute_parent_kernel(Dict.id(), Dict, TakeExecuteAdaptor(Dict));
     kernels.register_execute_parent_kernel(FillNull.id(), Dict, FillNullExecuteAdaptor(Dict));
+    kernels.register_execute_parent_kernel(Mask.id(), Dict, MaskExecuteAdaptor(Dict));
+    kernels.register_execute_parent_kernel(Slice.id(), Dict, SliceExecuteAdaptor(Dict));
 }


### PR DESCRIPTION
Registers mask and slice execute-parent kernels for `Dict`. The `SliceKernel` impl delegates to the existing `SliceReduce` impl. The `MaskKernel` impl differs from the `MaskReduce` rule in that  masked codes stay `Primitive`. The reduce rule wraps the codes in a `mask` scalar-fn (it may have to — at construction the mask can still be an unevaluated expression). Reusing that shape in the execute kernel hides the codes behind a `ScalarFn` and defeats downstream fast paths that downcast them. 
