### PR TITLE
Refactor layout child access to support optional slots

### DIFF
--- a/vortex-cuda/src/file.rs
+++ b/vortex-cuda/src/file.rs
@@ -132,8 +132,11 @@ fn mark_zone_map_segments(
     control_segments: &mut [bool],
 ) -> VortexResult<()> {
     if layout.is::<Zoned>() || layout.is::<LegacyStats>() {
-        mark_layout_segments(layout.child(1)?.as_ref(), control_segments)?;
-        mark_zone_map_segments(layout.child(0)?.as_ref(), control_segments)?;
+        let (Some(data), Some(zones)) = (layout.slot(0)?, layout.slot(1)?) else {
+            vortex_bail!("zone map layout is missing its data or zones child");
+        };
+        mark_layout_segments(zones.as_ref(), control_segments)?;
+        mark_zone_map_segments(data.as_ref(), control_segments)?;
         return Ok(());
     }
 

--- a/vortex-file/src/footer/field_sizes.rs
+++ b/vortex-file/src/footer/field_sizes.rs
@@ -56,8 +56,8 @@ impl CompressedFieldSizes {
                 }
             }
 
-            for idx in 0..layout.nchildren() {
-                let child_path = match layout.child_type(idx) {
+            for (child, child_type) in layout.children()?.into_iter().zip(layout.child_types()) {
+                let child_path = match child_type {
                     LayoutChildType::Field(name) => {
                         let child_path = path.clone().push(name);
                         sizes.entry(child_path.clone()).or_insert(0);
@@ -65,7 +65,7 @@ impl CompressedFieldSizes {
                     }
                     _ => path.clone(),
                 };
-                stack.push((layout.child(idx)?, child_path));
+                stack.push((child, child_path));
             }
         }
 

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -2241,9 +2241,9 @@ async fn test_segment_ordering_dict_codes_before_values() -> VortexResult<()> {
         if layout.encoding_id().as_ref() == "vortex.dict" {
             // child 0 = values, child 1 = codes
             let values_offsets =
-                collect_segment_offsets(layout.child(0).unwrap().as_ref(), segment_specs);
+                collect_segment_offsets(layout.slot(0).unwrap().unwrap().as_ref(), segment_specs);
             let codes_offsets =
-                collect_segment_offsets(layout.child(1).unwrap().as_ref(), segment_specs);
+                collect_segment_offsets(layout.slot(1).unwrap().unwrap().as_ref(), segment_specs);
 
             assert_offsets_ordered(
                 &codes_offsets,
@@ -2363,9 +2363,9 @@ async fn test_segment_ordering_zonemaps_after_data() -> VortexResult<()> {
         if layout.is::<Zoned>() || layout.is::<LegacyStats>() {
             // child 0 = data, child 1 = zones
             let data_offsets =
-                collect_segment_offsets(layout.child(0).unwrap().as_ref(), segment_specs);
+                collect_segment_offsets(layout.slot(0).unwrap().unwrap().as_ref(), segment_specs);
             let zones_offsets =
-                collect_segment_offsets(layout.child(1).unwrap().as_ref(), segment_specs);
+                collect_segment_offsets(layout.slot(1).unwrap().unwrap().as_ref(), segment_specs);
 
             assert_offsets_ordered(
                 &data_offsets,
@@ -2395,11 +2395,11 @@ async fn test_segment_ordering_zonemaps_after_data() -> VortexResult<()> {
         if layout.is::<Zoned>() || layout.is::<LegacyStats>() {
             // child 0 = data, child 1 = zones
             all_data.extend(collect_segment_offsets(
-                layout.child(0).unwrap().as_ref(),
+                layout.slot(0).unwrap().unwrap().as_ref(),
                 segment_specs,
             ));
             all_zones.extend(collect_segment_offsets(
-                layout.child(1).unwrap().as_ref(),
+                layout.slot(1).unwrap().unwrap().as_ref(),
                 segment_specs,
             ));
             return;

--- a/vortex-layout/src/flatbuffers.rs
+++ b/vortex-layout/src/flatbuffers.rs
@@ -294,7 +294,7 @@ mod tests {
         assert_eq!(*layout.segment_ids()[0], 7);
         assert_eq!(layout.nchildren(), 1);
 
-        let child = layout.child(0).unwrap();
+        let child = layout.slot(0).unwrap().unwrap();
         assert_eq!(
             child.encoding_id().as_ref(),
             "vortex.test.foreign_child_layout"

--- a/vortex-layout/src/layout.rs
+++ b/vortex-layout/src/layout.rs
@@ -130,24 +130,42 @@ impl<V: VTable> Layout<V> {
         &self.inner.children
     }
 
-    /// Returns the number of children.
+    /// Returns the number of serialized (present) children.
     pub fn nchildren(&self) -> usize {
         self.inner.children.nchildren()
     }
 
-    /// Materialize child `idx` with its expected dtype.
-    pub fn child(&self, idx: usize) -> VortexResult<LayoutRef> {
-        self.inner.children.child(idx, &V::child_dtype(self, idx)?)
+    /// Returns the number of logical child slots, including any that are absent.
+    pub fn nslots(&self) -> usize {
+        V::nslots(self)
+    }
+
+    /// Maps a logical `slot` to the index of its serialized child, or `None` if absent.
+    pub fn slot_to_child(&self, slot: usize) -> Option<usize> {
+        V::slot_to_child(self, slot)
+    }
+
+    /// Materialize the child in logical `slot`, or `None` if the slot is absent.
+    pub fn slot(&self, slot: usize) -> VortexResult<Option<LayoutRef>> {
+        match V::slot_to_child(self, slot) {
+            Some(idx) => self
+                .inner
+                .children
+                .child(idx, &V::child_dtype(self, slot)?)
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    /// Returns the relationship of the child in logical `slot` to this layout, or `None` if the
+    /// slot is absent.
+    pub fn slot_type(&self, slot: usize) -> Option<LayoutChildType> {
+        V::slot_to_child(self, slot).map(|_| V::child_type(self, slot))
     }
 
     /// Returns a child's serialized row count without materializing it.
     pub fn child_row_count(&self, idx: usize) -> u64 {
         self.inner.children.child_row_count(idx)
-    }
-
-    /// Returns a child's relationship to this layout.
-    pub fn child_type(&self, idx: usize) -> LayoutChildType {
-        V::child_type(self, idx)
     }
 
     /// Erase this typed layout into a shared layout reference.
@@ -223,14 +241,17 @@ pub trait DynLayout: 'static + Send + Sync + Debug {
     /// Returns the logical dtype.
     fn dyn_dtype(&self) -> &DType;
 
-    /// Returns the number of children.
+    /// Returns the number of serialized (present) children.
     fn dyn_nchildren(&self) -> usize;
 
-    /// Returns child `idx`.
-    fn dyn_child(&self, idx: usize) -> VortexResult<LayoutRef>;
+    /// Returns the number of logical child slots, including any that are absent.
+    fn dyn_nslots(&self) -> usize;
 
-    /// Returns the relationship of child `idx`.
-    fn dyn_child_type(&self, idx: usize) -> LayoutChildType;
+    /// Materializes the child in logical `slot`, or `None` if the slot is absent.
+    fn dyn_slot(&self, slot: usize) -> VortexResult<Option<LayoutRef>>;
+
+    /// Returns the relationship of the child in logical `slot`, or `None` if the slot is absent.
+    fn dyn_slot_type(&self, slot: usize) -> Option<LayoutChildType>;
 
     /// Serializes layout-specific metadata.
     fn dyn_metadata(&self) -> Vec<u8>;
@@ -273,12 +294,16 @@ impl<V: VTable> DynLayout for Layout<V> {
         Layout::nchildren(self)
     }
 
-    fn dyn_child(&self, idx: usize) -> VortexResult<LayoutRef> {
-        Layout::child(self, idx)
+    fn dyn_nslots(&self) -> usize {
+        Layout::nslots(self)
     }
 
-    fn dyn_child_type(&self, idx: usize) -> LayoutChildType {
-        Layout::child_type(self, idx)
+    fn dyn_slot(&self, slot: usize) -> VortexResult<Option<LayoutRef>> {
+        Layout::slot(self, slot)
+    }
+
+    fn dyn_slot_type(&self, slot: usize) -> Option<LayoutChildType> {
+        Layout::slot_type(self, slot)
     }
 
     fn dyn_metadata(&self) -> Vec<u8> {
@@ -354,19 +379,24 @@ impl dyn DynLayout + '_ {
         self.dyn_row_count()
     }
 
-    /// Returns the number of children.
+    /// Returns the number of serialized (present) children.
     pub fn nchildren(&self) -> usize {
         self.dyn_nchildren()
     }
 
-    /// Returns child `idx`.
-    pub fn child(&self, idx: usize) -> VortexResult<LayoutRef> {
-        self.dyn_child(idx)
+    /// Returns the number of logical child slots, including any that are absent.
+    pub fn nslots(&self) -> usize {
+        self.dyn_nslots()
     }
 
-    /// Returns the relationship of child `idx`.
-    pub fn child_type(&self, idx: usize) -> LayoutChildType {
-        self.dyn_child_type(idx)
+    /// Materializes the child in logical `slot`, or `None` if the slot is absent.
+    pub fn slot(&self, slot: usize) -> VortexResult<Option<LayoutRef>> {
+        self.dyn_slot(slot)
+    }
+
+    /// Returns the relationship of the child in logical `slot`, or `None` if the slot is absent.
+    pub fn slot_type(&self, slot: usize) -> Option<LayoutChildType> {
+        self.dyn_slot_type(slot)
     }
 
     /// Returns serialized layout-specific metadata.
@@ -390,16 +420,16 @@ impl dyn DynLayout + '_ {
         self.dyn_new_reader(name, segment_source, session, ctx)
     }
 
-    /// Returns all children.
+    /// Returns all serialized (present) children, in slot order.
     pub fn children(&self) -> VortexResult<Vec<LayoutRef>> {
-        (0..self.nchildren())
-            .map(|idx| self.child(idx))
+        (0..self.nslots())
+            .filter_map(|slot| self.slot(slot).transpose())
             .try_collect()
     }
 
-    /// Returns all child types.
+    /// Returns the types of all serialized (present) children, in slot order.
     pub fn child_types(&self) -> impl Iterator<Item = LayoutChildType> + '_ {
-        (0..self.nchildren()).map(|idx| self.child_type(idx))
+        (0..self.nslots()).filter_map(|slot| self.slot_type(slot))
     }
 
     /// Returns all child names.

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -67,8 +67,12 @@ impl DictReader {
         session: VortexSession,
         ctx: crate::LayoutReaderContext,
     ) -> VortexResult<Self> {
-        let values_layout = layout.child(0)?;
-        let codes_layout = layout.child(1)?;
+        let values_layout = layout
+            .slot(0)?
+            .vortex_expect("DictLayout always has a values child");
+        let codes_layout = layout
+            .slot(1)?
+            .vortex_expect("DictLayout always has a codes child");
         let values_len = usize::try_from(values_layout.row_count())?;
         let values = values_layout.new_reader(
             format!("{name}.values").into(),

--- a/vortex-layout/src/layouts/foreign/mod.rs
+++ b/vortex-layout/src/layouts/foreign/mod.rs
@@ -153,8 +153,7 @@ impl DynLayout for ForeignLayout {
     }
 
     fn dyn_slot_type(&self, slot: usize) -> Option<LayoutChildType> {
-        (slot < self.children.len())
-            .then(|| LayoutChildType::Auxiliary(format!("[{slot}]").into()))
+        (slot < self.children.len()).then(|| LayoutChildType::Auxiliary(format!("[{slot}]").into()))
     }
 
     fn dyn_metadata(&self) -> Vec<u8> {

--- a/vortex-layout/src/layouts/foreign/mod.rs
+++ b/vortex-layout/src/layouts/foreign/mod.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use vortex_array::dtype::DType;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
-use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 
 use crate::DynLayout;
@@ -144,18 +143,18 @@ impl DynLayout for ForeignLayout {
         self.children.len()
     }
 
-    fn dyn_child(&self, idx: usize) -> VortexResult<LayoutRef> {
-        self.children.get(idx).cloned().ok_or_else(|| {
-            vortex_err!(
-                "Child index out of bounds: {} of {}",
-                idx,
-                self.children.len()
-            )
-        })
+    fn dyn_nslots(&self) -> usize {
+        // A foreign layout is opaque: its children are dense, so each slot is always present.
+        self.children.len()
     }
 
-    fn dyn_child_type(&self, idx: usize) -> LayoutChildType {
-        LayoutChildType::Auxiliary(format!("[{idx}]").into())
+    fn dyn_slot(&self, slot: usize) -> VortexResult<Option<LayoutRef>> {
+        Ok(self.children.get(slot).cloned())
+    }
+
+    fn dyn_slot_type(&self, slot: usize) -> Option<LayoutChildType> {
+        (slot < self.children.len())
+            .then(|| LayoutChildType::Auxiliary(format!("[{slot}]").into()))
     }
 
     fn dyn_metadata(&self) -> Vec<u8> {

--- a/vortex-layout/src/layouts/list/mod.rs
+++ b/vortex-layout/src/layouts/list/mod.rs
@@ -104,6 +104,19 @@ impl VTable for List {
         })
     }
 
+    fn nslots(_layout: &Layout<Self>) -> usize {
+        // Elements, offsets, and an always-slotted (optionally present) validity child.
+        VALIDITY_CHILD_INDEX + 1
+    }
+
+    fn slot_to_child(layout: &Layout<Self>, slot: usize) -> Option<usize> {
+        match slot {
+            ELEMENTS_CHILD_INDEX | OFFSETS_CHILD_INDEX => Some(slot),
+            VALIDITY_CHILD_INDEX => layout.dtype().is_nullable().then_some(VALIDITY_CHILD_INDEX),
+            _ => None,
+        }
+    }
+
     fn child_dtype(layout: &Layout<Self>, idx: usize) -> VortexResult<DType> {
         match idx {
             ELEMENTS_CHILD_INDEX => layout
@@ -176,20 +189,19 @@ impl Layout<List> {
 
     /// Returns the elements child.
     pub fn elements(&self) -> VortexResult<LayoutRef> {
-        self.child(ELEMENTS_CHILD_INDEX)
+        self.slot(ELEMENTS_CHILD_INDEX)?
+            .ok_or_else(|| vortex_err!("ListLayout elements slot is absent"))
     }
 
     /// Returns the offsets child.
     pub fn offsets(&self) -> VortexResult<LayoutRef> {
-        self.child(OFFSETS_CHILD_INDEX)
+        self.slot(OFFSETS_CHILD_INDEX)?
+            .ok_or_else(|| vortex_err!("ListLayout offsets slot is absent"))
     }
 
     /// Returns the optional validity child.
     pub fn validity(&self) -> VortexResult<Option<LayoutRef>> {
-        self.dtype()
-            .is_nullable()
-            .then(|| self.child(VALIDITY_CHILD_INDEX))
-            .transpose()
+        self.slot(VALIDITY_CHILD_INDEX)
     }
 
     /// Returns the integer ptype used by offsets.

--- a/vortex-layout/src/layouts/repartition.rs
+++ b/vortex-layout/src/layouts/repartition.rs
@@ -422,7 +422,7 @@ mod tests {
         assert!(nchildren > 1, "expected multiple chunks, got {nchildren}");
 
         for i in 0..nchildren - 1 {
-            let child = layout.child(i)?;
+            let child = layout.slot(i)?.vortex_expect("chunk slot present");
             assert_eq!(
                 child.row_count(),
                 132,
@@ -432,7 +432,9 @@ mod tests {
         }
 
         // Last child gets the remainder.
-        let last = layout.child(nchildren - 1)?;
+        let last = layout
+            .slot(nchildren - 1)?
+            .vortex_expect("chunk slot present");
         assert_eq!(last.row_count(), 1000 - 132 * (nchildren as u64 - 1));
 
         Ok(())
@@ -477,8 +479,20 @@ mod tests {
 
         assert_eq!(layout.row_count(), num_elements as u64);
         assert_eq!(layout.nchildren(), 2);
-        assert_eq!(layout.child(0)?.row_count(), 8192);
-        assert_eq!(layout.child(1)?.row_count(), 1808);
+        assert_eq!(
+            layout
+                .slot(0)?
+                .vortex_expect("chunk slot present")
+                .row_count(),
+            8192
+        );
+        assert_eq!(
+            layout
+                .slot(1)?
+                .vortex_expect("chunk slot present")
+                .row_count(),
+            1808
+        );
 
         Ok(())
     }

--- a/vortex-layout/src/layouts/struct_/mod.rs
+++ b/vortex-layout/src/layouts/struct_/mod.rs
@@ -75,23 +75,32 @@ impl VTable for Struct {
         Ok(())
     }
 
-    fn child_dtype(layout: &Layout<Self>, index: usize) -> VortexResult<DType> {
-        StructLayout::child_dtype(layout.dtype(), index)
+    fn nslots(layout: &Layout<Self>) -> usize {
+        // Slot 0 is always reserved for validity (present only when nullable); the remaining
+        // slots are the struct fields, so field `i` always occupies slot `i + 1`.
+        layout.struct_fields().nfields() + 1
     }
 
-    fn child_type(layout: &Layout<Self>, idx: usize) -> LayoutChildType {
-        let schema_index = if layout.dtype().is_nullable() {
-            idx.saturating_sub(1)
-        } else {
-            idx
-        };
-        if idx == 0 && layout.dtype().is_nullable() {
+    fn slot_to_child(layout: &Layout<Self>, slot: usize) -> Option<usize> {
+        let nullable = layout.dtype().is_nullable();
+        match slot {
+            0 => nullable.then_some(0),
+            _ => Some(slot - 1 + usize::from(nullable)),
+        }
+    }
+
+    fn child_dtype(layout: &Layout<Self>, slot: usize) -> VortexResult<DType> {
+        StructLayout::slot_dtype(layout.dtype(), slot)
+    }
+
+    fn child_type(layout: &Layout<Self>, slot: usize) -> LayoutChildType {
+        if slot == 0 {
             LayoutChildType::Auxiliary("validity".into())
         } else {
             LayoutChildType::Field(
                 layout
                     .struct_fields()
-                    .field_name(schema_index)
+                    .field_name(slot - 1)
                     .vortex_expect("Field index out of bounds")
                     .clone(),
             )
@@ -177,19 +186,93 @@ impl Layout<Struct> {
         Ok(())
     }
 
-    fn child_dtype(dtype: &DType, index: usize) -> VortexResult<DType> {
-        let schema_index = if dtype.is_nullable() {
-            index.saturating_sub(1)
-        } else {
-            index
-        };
-        if index == 0 && dtype.is_nullable() {
+    /// Returns the dtype of the child in logical `slot`: slot 0 is the non-nullable validity
+    /// bitmap, and slot `i + 1` is struct field `i`.
+    fn slot_dtype(dtype: &DType, slot: usize) -> VortexResult<DType> {
+        if slot == 0 {
             Ok(DType::Bool(Nullability::NonNullable))
         } else {
             dtype
                 .as_struct_fields_opt()
-                .and_then(|fields| fields.field_by_index(schema_index))
-                .ok_or_else(|| vortex_err!("Missing field {schema_index}"))
+                .and_then(|fields| fields.field_by_index(slot - 1))
+                .ok_or_else(|| vortex_err!("Missing field {}", slot - 1))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_array::dtype::FieldName;
+    use vortex_array::dtype::PType;
+    use vortex_session::registry::ReadContext;
+
+    use super::*;
+    use crate::layouts::flat::FlatLayout;
+    use crate::segments::SegmentId;
+
+    fn flat_child(dtype: DType, segment: u32) -> LayoutRef {
+        FlatLayout::new(3, dtype, SegmentId::from(segment), ReadContext::new([])).into_layout()
+    }
+
+    fn two_field_struct(nullability: Nullability) -> DType {
+        let i32 = DType::Primitive(PType::I32, Nullability::NonNullable);
+        DType::Struct(
+            StructFields::from_iter([("a", i32.clone()), ("b", i32)]),
+            nullability,
+        )
+    }
+
+    /// Field `i` must occupy logical slot `i + 1` regardless of whether the struct is nullable,
+    /// with slot 0 reserved for validity (absent when non-nullable).
+    #[test]
+    fn field_slots_are_stable_across_nullability() -> VortexResult<()> {
+        let i32 = DType::Primitive(PType::I32, Nullability::NonNullable);
+        let bool_ = DType::Bool(Nullability::NonNullable);
+
+        let non_null = StructLayout::new(
+            3,
+            two_field_struct(Nullability::NonNullable),
+            vec![flat_child(i32.clone(), 0), flat_child(i32.clone(), 1)],
+        );
+        // Validity + two fields, but validity is absent so only two serialized children.
+        assert_eq!(non_null.nslots(), 3);
+        assert_eq!(non_null.nchildren(), 2);
+        assert_eq!(non_null.slot_to_child(0), None);
+        assert_eq!(non_null.slot_to_child(1), Some(0));
+        assert_eq!(non_null.slot_to_child(2), Some(1));
+        // The validity slot is absent, so materializing it and its type both yield `None`.
+        assert!(non_null.slot(0)?.is_none());
+        assert_eq!(non_null.slot_type(0), None);
+
+        let nullable = StructLayout::new(
+            3,
+            two_field_struct(Nullability::Nullable),
+            vec![
+                flat_child(bool_, 0),
+                flat_child(i32.clone(), 1),
+                flat_child(i32, 2),
+            ],
+        );
+        assert_eq!(nullable.nslots(), 3);
+        assert_eq!(nullable.nchildren(), 3);
+        assert_eq!(nullable.slot_to_child(0), Some(0));
+        assert_eq!(nullable.slot_to_child(1), Some(1));
+        assert_eq!(nullable.slot_to_child(2), Some(2));
+        // The validity slot is present only for the nullable struct.
+        assert!(nullable.slot(0)?.is_some());
+        assert_eq!(
+            nullable.slot_type(0),
+            Some(LayoutChildType::Auxiliary("validity".into()))
+        );
+
+        // Field "a" is slot 1 in both layouts, even though its serialized index differs.
+        for layout in [&non_null, &nullable] {
+            assert_eq!(
+                layout.slot_type(1),
+                Some(LayoutChildType::Field(FieldName::from("a")))
+            );
+        }
+
+        Ok(())
     }
 }

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -137,20 +137,20 @@ impl StructReader {
 
     /// Return the child reader for the field, by index.
     fn field_reader_by_index(&self, idx: usize) -> VortexResult<&LayoutReaderRef> {
-        let child_index = if self.dtype().is_nullable() {
-            idx + 1
-        } else {
-            idx
-        };
-
+        // Field `idx` always occupies slot `idx + 1`; the layout maps that to a dense child index,
+        // accounting for the validity slot when the struct is nullable.
+        let child_index = self
+            .layout
+            .slot_to_child(idx + 1)
+            .vortex_expect("struct field slot is always present");
         self.lazy_children.get(child_index)
     }
 
     /// Return the reader for the struct validity, if present
     fn validity(&self) -> VortexResult<Option<&LayoutReaderRef>> {
-        self.dtype()
-            .is_nullable()
-            .then(|| self.lazy_children.get(0))
+        self.layout
+            .slot_to_child(0)
+            .map(|child_index| self.lazy_children.get(child_index))
             .transpose()
     }
 

--- a/vortex-layout/src/layouts/table.rs
+++ b/vortex-layout/src/layouts/table.rs
@@ -547,7 +547,9 @@ mod tests {
         assert_eq!(zoned.zone_len(), 4);
         assert_eq!(zoned.nzones(), 3);
 
-        let data = layout.child(0)?;
+        let data = layout
+            .slot(0)?
+            .vortex_expect("ZonedLayout always has a data child");
         assert!(data.is::<List>());
         assert_eq!(data.row_count(), 9);
         Ok(())

--- a/vortex-layout/src/layouts/zoned/mod.rs
+++ b/vortex-layout/src/layouts/zoned/mod.rs
@@ -248,7 +248,8 @@ impl LegacyStatsLayout {
     ) -> VortexResult<LayoutReaderRef> {
         if self.zone_len == 0 {
             return self
-                .child(0)?
+                .slot(0)?
+                .vortex_expect("ZonedLayout always has a data child")
                 .new_reader(name, segment_source, session, ctx);
         }
 
@@ -335,7 +336,8 @@ impl ZonedLayout {
     ) -> VortexResult<LayoutReaderRef> {
         if self.zone_len == 0 {
             return self
-                .child(0)?
+                .slot(0)?
+                .vortex_expect("ZonedLayout always has a data child")
                 .new_reader(name, segment_source, session, ctx);
         }
 

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -449,8 +449,14 @@ mod test {
         #[case] expected: [bool; 9],
     ) -> VortexResult<()> {
         let zoned_layout = layout.as_::<Zoned>();
-        let children =
-            OwnedLayoutChildren::layout_children(vec![layout.child(0)?, layout.child(1)?]);
+        let children = OwnedLayoutChildren::layout_children(vec![
+            layout
+                .slot(0)?
+                .vortex_expect("ZonedLayout always has a data child"),
+            layout
+                .slot(1)?
+                .vortex_expect("ZonedLayout always has a stats child"),
+        ]);
         let session = array_session();
         let read_ctx = ReadContext::new([]);
         let build_ctx = LayoutBuildContext {

--- a/vortex-layout/src/vtable.rs
+++ b/vortex-layout/src/vtable.rs
@@ -78,11 +78,32 @@ pub trait VTable: 'static + Clone + Send + Sync + Debug {
         .into_typed())
     }
 
-    /// Returns the expected dtype of child `idx`.
-    fn child_dtype(layout: &Layout<Self>, idx: usize) -> VortexResult<DType>;
+    /// Returns the number of logical child *slots* of this layout.
+    ///
+    /// Slots are fixed logical positions: a given child always occupies the same slot index
+    /// regardless of which optional siblings are present. A slot may be absent (see
+    /// [`slot_to_child`](VTable::slot_to_child)), in which case it has no corresponding serialized
+    /// child. The default implementation reports one slot per serialized child, i.e. every slot is
+    /// always present.
+    fn nslots(layout: &Layout<Self>) -> usize {
+        layout.nchildren()
+    }
 
-    /// Returns the relationship between child `idx` and its parent.
-    fn child_type(layout: &Layout<Self>, idx: usize) -> LayoutChildType;
+    /// Maps a logical `slot` to the index of its serialized (dense) child, or `None` if the slot
+    /// is absent for this layout instance.
+    ///
+    /// Serialized children are stored densely (present-only), so an absent slot shifts the dense
+    /// indices of the slots that follow it. This mapping centralizes that arithmetic; the default
+    /// implementation is the identity, treating slot indices and dense child indices as equal.
+    fn slot_to_child(layout: &Layout<Self>, slot: usize) -> Option<usize> {
+        (slot < Self::nslots(layout)).then_some(slot)
+    }
+
+    /// Returns the expected dtype of the child in logical `slot`.
+    fn child_dtype(layout: &Layout<Self>, slot: usize) -> VortexResult<DType>;
+
+    /// Returns the relationship between the child in logical `slot` and its parent.
+    fn child_type(layout: &Layout<Self>, slot: usize) -> LayoutChildType;
 
     /// Construct a reader for this layout.
     fn new_reader(

--- a/vortex-tui/src/browse/app.rs
+++ b/vortex-tui/src/browse/app.rs
@@ -79,10 +79,14 @@ impl LayoutCursor {
     ) -> Self {
         let mut layout = Arc::clone(footer.layout());
 
-        // Traverse the layout tree at each element of the path.
+        // Traverse the layout tree at each element of the path. Path components index into the
+        // serialized (present) children, matching the order shown in the browser.
         for component in path.iter().copied() {
             layout = layout
-                .child(component)
+                .children()
+                .vortex_expect("Failed to get child layouts")
+                .into_iter()
+                .nth(component)
                 .vortex_expect("Failed to get child layout");
         }
 

--- a/vortex-web/crate/src/wasm.rs
+++ b/vortex-web/crate/src/wasm.rs
@@ -217,8 +217,7 @@ impl VortexFileHandle {
             }
 
             if let Ok(children) = layout.children() {
-                for (i, child_layout) in children.into_iter().enumerate() {
-                    let child_type = layout.child_type(i);
+                for (child_layout, child_type) in children.into_iter().zip(layout.child_types()) {
                     let child_name = child_type.name();
                     let child_path = format!("{path}.{child_name}");
 
@@ -545,8 +544,7 @@ fn build_layout_tree(
 
     let mut children_json = Vec::new();
     if let Ok(children) = children_result {
-        for (i, child_layout) in children.iter().enumerate() {
-            let ct = layout.child_type(i);
+        for (child_layout, ct) in children.iter().zip(layout.child_types()) {
             let child_name = ct.name();
             let child_id = format!("{id}.{child_name}");
 
@@ -693,9 +691,10 @@ fn find_layout_by_id(root: &LayoutRef, node_id: &str) -> Option<LayoutRef> {
     let mut current = root.clone();
     for seg in &segments[1..] {
         let children = current.children().ok()?;
+        let child_types: Vec<_> = current.child_types().collect();
         let mut found = false;
-        for (i, child) in children.into_iter().enumerate() {
-            let name = current.child_type(i).name();
+        for (child, child_type) in children.into_iter().zip(child_types) {
+            let name = child_type.name();
             if name.as_ref() == *seg {
                 current = child;
                 found = true;


### PR DESCRIPTION
## Rationale for this change

This refactor introduces a distinction between *logical slots* (fixed positions in a layout's schema) and *serialized children* (the actual present children stored densely). This enables layouts to have optional children that may or may not be present in a given instance, while maintaining stable slot indices across different configurations.

This is similar to the previous change to arrays https://github.com/vortex-data/vortex/pull/6870

## Migration

Use slots instead of children. Instead of needing to work out the child idx using properties of the layout each slot will be at a fixed position and `None` if missing adjust offset maths.

Variable len slots can be added and the end (if two are needed you will still need more complex idx maths).



