### PR TITLE
fix(cuda): pass mutated CUDA device buffers as `mut`

### DIFF
--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -8,7 +8,6 @@
 mod bench_config;
 
 use std::f64::consts::PI;
-use std::marker::PhantomData;
 use std::mem::size_of;
 use std::os::raw::c_void;
 use std::ptr;
@@ -57,7 +56,6 @@ use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
 use vortex_cuda::CudaBufferExt;
-use vortex_cuda::CudaDeviceBuffer;
 use vortex_cuda::CudaDispatchMode;
 use vortex_cuda::CudaExecutionCtx;
 use vortex_cuda::CudaSession;
@@ -79,14 +77,12 @@ use crate::bench_config::BENCH_SIZES;
 fn run_timed<T: DeviceRepr + NativePType>(
     cuda_ctx: &mut CudaExecutionCtx,
     array_len: usize,
-    output_buf: &CudaDeviceBuffer,
+    output_buf: &mut CudaSlice<T>,
     device_plan: &Arc<CudaSlice<u8>>,
     shared_mem_bytes: u32,
 ) -> VortexResult<Duration> {
     let cuda_function = cuda_ctx.load_function("dynamic_dispatch", &[T::PTYPE])?;
     let array_len_u64 = array_len as u64;
-    let output_view = output_buf.as_view::<T>();
-    let (output_ptr, record_output) = output_view.device_ptr(cuda_ctx.stream());
     let (plan_ptr, record_plan) = device_plan.device_ptr(cuda_ctx.stream());
 
     let stream = cuda_ctx.stream();
@@ -99,7 +95,7 @@ fn run_timed<T: DeviceRepr + NativePType>(
         .map_err(|e| vortex_err!("{e:?}"))?;
 
     let mut launch_builder = cuda_ctx.stream().launch_builder(&cuda_function);
-    launch_builder.arg(&output_ptr);
+    launch_builder.arg(output_buf);
     launch_builder.arg(&array_len_u64);
     launch_builder.arg(&plan_ptr);
 
@@ -115,7 +111,7 @@ fn run_timed<T: DeviceRepr + NativePType>(
             .launch(config)
             .map_err(|e| vortex_err!("kernel launch failed: {e}"))?;
     }
-    drop((record_output, record_plan));
+    drop(record_plan);
 
     let stream = cuda_ctx.stream();
     let ctx = stream.context();
@@ -140,9 +136,8 @@ struct BenchRunner<T> {
     smem_bytes: u32,
     len: usize,
     device_plan: Arc<CudaSlice<u8>>,
-    output_buf: CudaDeviceBuffer,
+    output_buf: CudaSlice<T>,
     _plan_buffers: Vec<BufferHandle>,
-    _phantom: PhantomData<T>,
 }
 
 impl<T: DeviceRepr + NativePType> BenchRunner<T> {
@@ -172,22 +167,19 @@ impl<T: DeviceRepr + NativePType> BenchRunner<T> {
             smem_bytes: shared_mem_bytes,
             len,
             device_plan,
-            output_buf: CudaDeviceBuffer::new(
-                cuda_ctx
-                    .device_alloc::<T>(len.next_multiple_of(1024))
-                    .expect("alloc output"),
-            ),
+            output_buf: cuda_ctx
+                .device_alloc::<T>(len.next_multiple_of(1024))
+                .expect("alloc output"),
             _plan_buffers: device_buffers,
-            _phantom: PhantomData,
         }
     }
 
-    fn run(&self, cuda_ctx: &mut CudaExecutionCtx) -> Duration {
+    fn run(&mut self, cuda_ctx: &mut CudaExecutionCtx) -> Duration {
         cuda_ctx.stream().synchronize().unwrap();
         run_timed::<T>(
             cuda_ctx,
             self.len,
-            &self.output_buf,
+            &mut self.output_buf,
             &self.device_plan,
             self.smem_bytes,
         )
@@ -227,7 +219,7 @@ fn bench_for_bitpacked(c: &mut Criterion) {
                 let mut cuda_ctx =
                     CudaSession::create_execution_ctx(&cuda_session()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+                let mut bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
                 b.iter_custom(|iters| {
                     let mut total_time = Duration::ZERO;
@@ -272,7 +264,7 @@ fn bench_dict_bp_codes(c: &mut Criterion) {
                 let mut cuda_ctx =
                     CudaSession::create_execution_ctx(&cuda_session()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+                let mut bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
                 b.iter_custom(|iters| {
                     let mut total_time = Duration::ZERO;
@@ -316,7 +308,7 @@ fn bench_runend(c: &mut Criterion) {
                 let mut cuda_ctx =
                     CudaSession::create_execution_ctx(&cuda_session()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+                let mut bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
                 b.iter_custom(|iters| {
                     let mut total_time = Duration::ZERO;
@@ -394,7 +386,7 @@ fn bench_dict_bp_codes_alp_for_bp_values_dynanmic_dispatch(c: &mut Criterion) {
                 let mut cuda_ctx =
                     CudaSession::create_execution_ctx(&cuda_session()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+                let mut bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
                 b.iter_custom(|iters| {
                     let mut total_time = Duration::ZERO;
@@ -424,6 +416,7 @@ mod standalone {
         offset_within_chunk: u32,
         num_patches: u32,
         n_chunks: u32,
+        indices_base: u32,
     }
 
     unsafe impl DeviceRepr for NullGpuPatches {}
@@ -438,16 +431,17 @@ mod standalone {
             offset_within_chunk: 0,
             num_patches: 0,
             n_chunks: 0,
+            indices_base: 0,
         };
     }
 
     pub(super) struct DictAlpForBitpackedRunner {
         values_packed: BufferHandle,
         codes_packed: BufferHandle,
-        values_for_buf: CudaDeviceBuffer,
-        values_alp_buf: CudaDeviceBuffer,
-        codes_buf: CudaDeviceBuffer,
-        output_buf: CudaDeviceBuffer,
+        values_for_buf: CudaSlice<i32>,
+        values_alp_buf: CudaSlice<f32>,
+        codes_buf: CudaSlice<u32>,
+        output_buf: CudaSlice<f32>,
         bit_unpack_fn: CudaFunction,
         alp_fn: CudaFunction,
         dict_fn: CudaFunction,
@@ -485,26 +479,18 @@ mod standalone {
                 .vortex_expect("codes packed");
 
             let values_len = values_bp.len();
-            let values_for_buf = CudaDeviceBuffer::new(
-                cuda_ctx
-                    .device_alloc::<i32>(values_len.next_multiple_of(1024))
-                    .vortex_expect("alloc values for"),
-            );
-            let values_alp_buf = CudaDeviceBuffer::new(
-                cuda_ctx
-                    .device_alloc::<f32>(values_len.next_multiple_of(1024))
-                    .vortex_expect("alloc values alp"),
-            );
-            let codes_buf = CudaDeviceBuffer::new(
-                cuda_ctx
-                    .device_alloc::<u32>(len.next_multiple_of(1024))
-                    .vortex_expect("alloc codes"),
-            );
-            let output_buf = CudaDeviceBuffer::new(
-                cuda_ctx
-                    .device_alloc::<f32>(len)
-                    .vortex_expect("alloc output"),
-            );
+            let values_for_buf = cuda_ctx
+                .device_alloc::<i32>(values_len.next_multiple_of(1024))
+                .vortex_expect("alloc values for");
+            let values_alp_buf = cuda_ctx
+                .device_alloc::<f32>(values_len.next_multiple_of(1024))
+                .vortex_expect("alloc values alp");
+            let codes_buf = cuda_ctx
+                .device_alloc::<u32>(len.next_multiple_of(1024))
+                .vortex_expect("alloc codes");
+            let output_buf = cuda_ctx
+                .device_alloc::<f32>(len)
+                .vortex_expect("alloc output");
 
             cuda_ctx.stream().synchronize().expect("setup sync");
 
@@ -534,15 +520,11 @@ mod standalone {
 
         // Setup owns all allocations and H2D copies; this times only the standalone
         // kernel sequence needed to mirror the fused dynamic-dispatch plan.
-        pub(super) fn run(&self, cuda_ctx: &mut CudaExecutionCtx) -> Duration {
+        pub(super) fn run(&mut self, cuda_ctx: &mut CudaExecutionCtx) -> Duration {
             cuda_ctx.stream().synchronize().unwrap();
 
             let values_packed_view = self.values_packed.cuda_view::<u32>().unwrap();
             let codes_packed_view = self.codes_packed.cuda_view::<u32>().unwrap();
-            let values_for_view = self.values_for_buf.as_view::<i32>();
-            let values_alp_view = self.values_alp_buf.as_view::<f32>();
-            let codes_view = self.codes_buf.as_view::<u32>();
-            let output_view = self.output_buf.as_view::<f32>();
             let patches = NullGpuPatches::NULL;
 
             cuda_ctx.stream().synchronize().unwrap();
@@ -561,7 +543,7 @@ mod standalone {
             {
                 let mut launch = cuda_ctx.stream().launch_builder(&self.bit_unpack_fn);
                 launch.arg(&values_packed_view);
-                launch.arg(&values_for_view);
+                launch.arg(&mut self.values_for_buf);
                 launch.arg(&self.values_reference);
                 launch.arg(&patches);
                 unsafe {
@@ -578,8 +560,8 @@ mod standalone {
             {
                 let mut launch = cuda_ctx.stream().launch_builder(&self.alp_fn);
                 let values_len = self.values_len as u64;
-                launch.arg(&values_for_view);
-                launch.arg(&values_alp_view);
+                launch.arg(&self.values_for_buf);
+                launch.arg(&mut self.values_alp_buf);
                 launch.arg(&self.alp_f);
                 launch.arg(&self.alp_e);
                 launch.arg(&values_len);
@@ -599,7 +581,7 @@ mod standalone {
                 let mut launch = cuda_ctx.stream().launch_builder(&self.bit_unpack_fn);
                 let reference = 0u32;
                 launch.arg(&codes_packed_view);
-                launch.arg(&codes_view);
+                launch.arg(&mut self.codes_buf);
                 launch.arg(&reference);
                 launch.arg(&patches);
                 unsafe {
@@ -616,10 +598,10 @@ mod standalone {
             {
                 let mut launch = cuda_ctx.stream().launch_builder(&self.dict_fn);
                 let codes_len = self.codes_len as u64;
-                launch.arg(&codes_view);
+                launch.arg(&self.codes_buf);
                 launch.arg(&codes_len);
-                launch.arg(&values_alp_view);
-                launch.arg(&output_view);
+                launch.arg(&self.values_alp_buf);
+                launch.arg(&mut self.output_buf);
                 unsafe {
                     launch
                         .launch(LaunchConfig {
@@ -711,7 +693,7 @@ fn bench_dict_bp_codes_alp_for_bp_values_composed_standalone(c: &mut Criterion) 
                     let mut cuda_ctx = CudaSession::create_execution_ctx(&session)
                         .vortex_expect("ctx")
                         .with_dispatch_mode(CudaDispatchMode::StandaloneOnly);
-                    let bench_runner = standalone::DictAlpForBitpackedRunner::new(
+                    let mut bench_runner = standalone::DictAlpForBitpackedRunner::new(
                         values_bp,
                         *values_reference,
                         exponents,
@@ -795,7 +777,7 @@ fn bench_alp_for_bitpacked_f64(c: &mut Criterion) {
                 let mut cuda_ctx =
                     CudaSession::create_execution_ctx(&cuda_session()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u64>::new(&array, n, &mut cuda_ctx);
+                let mut bench_runner = BenchRunner::<u64>::new(&array, n, &mut cuda_ctx);
 
                 b.iter_custom(|iters| {
                     let mut total_time = Duration::ZERO;
@@ -852,7 +834,7 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
                 let mut cuda_ctx =
                     CudaSession::create_execution_ctx(&cuda_session()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+                let mut bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
                 b.iter_custom(|iters| {
                     let mut total_time = Duration::ZERO;
@@ -918,7 +900,7 @@ fn bench_alp_for_bitpacked(c: &mut Criterion) {
                 let mut cuda_ctx =
                     CudaSession::create_execution_ctx(&cuda_session()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+                let mut bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
                 b.iter_custom(|iters| {
                     let mut total_time = Duration::ZERO;
@@ -965,7 +947,7 @@ fn bench_dict_bp_u8_codes_u32_values(c: &mut Criterion) {
                 let mut cuda_ctx =
                     CudaSession::create_execution_ctx(&cuda_session()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+                let mut bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
                 b.iter_custom(|iters| {
                     let mut total_time = Duration::ZERO;
@@ -1008,7 +990,7 @@ fn bench_dict_bp_u16_codes_u32_values(c: &mut Criterion) {
                 let mut cuda_ctx =
                     CudaSession::create_execution_ctx(&cuda_session()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+                let mut bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
                 b.iter_custom(|iters| {
                     let mut total_time = Duration::ZERO;
@@ -1051,7 +1033,7 @@ fn bench_dict_bp_u32_codes_u32_values(c: &mut Criterion) {
                 let mut cuda_ctx =
                     CudaSession::create_execution_ctx(&cuda_session()).vortex_expect("ctx");
 
-                let bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
+                let mut bench_runner = BenchRunner::<u32>::new(&array, n, &mut cuda_ctx);
 
                 b.iter_custom(|iters| {
                     let mut total_time = Duration::ZERO;

--- a/vortex-cuda/benches/zstd_cuda.rs
+++ b/vortex-cuda/benches/zstd_cuda.rs
@@ -82,6 +82,7 @@ async fn execute_zstd_kernel(
         .record(stream)
         .map_err(|e| vortex_err!("Failed to record start event: {:?}", e))?;
 
+    let (_device_output_ptr, record_device_output) = exec.device_output.device_ptr_mut(stream);
     let (device_actual_sizes_ptr, record_actual_sizes) =
         exec.device_actual_sizes.device_ptr_mut(stream);
     let (nvcomp_temp_buffer_ptr, record_temp) = exec.nvcomp_temp_buffer.device_ptr_mut(stream);
@@ -103,7 +104,12 @@ async fn execute_zstd_kernel(
         )
         .map_err(|e| vortex_err!("nvcomp decompress_async failed: {}", e))?;
     }
-    drop((record_actual_sizes, record_temp, record_statuses));
+    drop((
+        record_device_output,
+        record_actual_sizes,
+        record_temp,
+        record_statuses,
+    ));
 
     let end_event = ctx
         .new_event(Some(CUevent_flags::CU_EVENT_BLOCKING_SYNC))

--- a/vortex-cuda/kernels/src/zigzag.cu
+++ b/vortex-cuda/kernels/src/zigzag.cu
@@ -17,26 +17,15 @@ struct ZigZagOp {
     }
 };
 
-// Macro to generate ZigZag kernels for each type.
+// Macro to generate the in-place ZigZag kernel for each type.
 #define GENERATE_ZIGZAG_KERNEL(suffix, UnsignedType, SignedType)                                             \
     extern "C" __global__ void zigzag_##suffix(UnsignedType *__restrict values, uint64_t array_len) {        \
         /* Assigning the signed result back to UnsignedType preserves its modulo-2^N bit pattern. */         \
         scalar_kernel_inplace(values, array_len, ZigZagOp<UnsignedType, SignedType> {});                     \
     }
 
-#define GENERATE_ZIGZAG_IN_OUT_KERNEL(suffix, UnsignedType, SignedType)                                      \
-    extern "C" __global__ void zigzag_in_out_##suffix(const UnsignedType *__restrict input,                 \
-                                                       SignedType *__restrict output,                        \
-                                                       uint64_t array_len) {                                 \
-        scalar_kernel(input, output, array_len, ZigZagOp<UnsignedType, SignedType> {});                      \
-    }
 
 GENERATE_ZIGZAG_KERNEL(u8, uint8_t, int8_t)
 GENERATE_ZIGZAG_KERNEL(u16, uint16_t, int16_t)
 GENERATE_ZIGZAG_KERNEL(u32, uint32_t, int32_t)
 GENERATE_ZIGZAG_KERNEL(u64, uint64_t, int64_t)
-
-GENERATE_ZIGZAG_IN_OUT_KERNEL(u8, uint8_t, int8_t)
-GENERATE_ZIGZAG_IN_OUT_KERNEL(u16, uint16_t, int16_t)
-GENERATE_ZIGZAG_IN_OUT_KERNEL(u32, uint32_t, int32_t)
-GENERATE_ZIGZAG_IN_OUT_KERNEL(u64, uint64_t, int64_t)

--- a/vortex-cuda/kernels/src/zigzag.cu
+++ b/vortex-cuda/kernels/src/zigzag.cu
@@ -8,24 +8,20 @@
 // Converts unsigned integers back to signed using the ZigZag encoding scheme.
 // Formula: decoded = (encoded >> 1) ^ -(encoded & 1)
 // This interleaves positive and negative numbers: 0, -1, 1, -2, 2, -3, ...
-template <typename UnsignedT, typename SignedT>
+template <typename UnsignedT>
 struct ZigZagOp {
-    __device__ inline SignedT operator()(UnsignedT value) const {
-        // ZigZag decode: (n >> 1) ^ -(n & 1)
-        // The -(n & 1) is equivalent to: if (n & 1) then -1 else 0
-        return static_cast<SignedT>((value >> 1) ^ (~(value & 1) + 1));
+    __device__ inline UnsignedT operator()(UnsignedT value) const {
+        return (value >> 1) ^ (UnsignedT(0) - (value & 1));
     }
 };
 
 // Macro to generate the in-place ZigZag kernel for each type.
-#define GENERATE_ZIGZAG_KERNEL(suffix, UnsignedType, SignedType)                                             \
-    extern "C" __global__ void zigzag_##suffix(UnsignedType *__restrict values, uint64_t array_len) {        \
-        /* Assigning the signed result back to UnsignedType preserves its modulo-2^N bit pattern. */         \
-        scalar_kernel_inplace(values, array_len, ZigZagOp<UnsignedType, SignedType> {});                     \
+#define GENERATE_ZIGZAG_KERNEL(suffix, UnsignedType)                                                  \
+    extern "C" __global__ void zigzag_##suffix(UnsignedType *__restrict values, uint64_t array_len) { \
+        scalar_kernel_inplace(values, array_len, ZigZagOp<UnsignedType> {});                           \
     }
 
-
-GENERATE_ZIGZAG_KERNEL(u8, uint8_t, int8_t)
-GENERATE_ZIGZAG_KERNEL(u16, uint16_t, int16_t)
-GENERATE_ZIGZAG_KERNEL(u32, uint32_t, int32_t)
-GENERATE_ZIGZAG_KERNEL(u64, uint64_t, int64_t)
+GENERATE_ZIGZAG_KERNEL(u8, uint8_t)
+GENERATE_ZIGZAG_KERNEL(u16, uint16_t)
+GENERATE_ZIGZAG_KERNEL(u32, uint32_t)
+GENERATE_ZIGZAG_KERNEL(u64, uint64_t)

--- a/vortex-cuda/kernels/src/zigzag.cu
+++ b/vortex-cuda/kernels/src/zigzag.cu
@@ -17,8 +17,7 @@ struct ZigZagOp {
     }
 };
 
-// Macro to generate ZigZag kernel for each type.
-// In-place operation: unsigned input, signed output (same size, reinterpret).
+// Macro to generate ZigZag kernels for each type.
 #define GENERATE_ZIGZAG_KERNEL(suffix, UnsignedType, SignedType)                                             \
     extern "C" __global__ void zigzag_##suffix(UnsignedType *__restrict values, uint64_t array_len) {        \
         scalar_kernel(values,                                                                                \
@@ -27,7 +26,19 @@ struct ZigZagOp {
                       ZigZagOp<UnsignedType, SignedType> {});                                                \
     }
 
+#define GENERATE_ZIGZAG_IN_OUT_KERNEL(suffix, UnsignedType, SignedType)                                      \
+    extern "C" __global__ void zigzag_in_out_##suffix(const UnsignedType *__restrict input,                 \
+                                                       SignedType *__restrict output,                        \
+                                                       uint64_t array_len) {                                 \
+        scalar_kernel(input, output, array_len, ZigZagOp<UnsignedType, SignedType> {});                      \
+    }
+
 GENERATE_ZIGZAG_KERNEL(u8, uint8_t, int8_t)
 GENERATE_ZIGZAG_KERNEL(u16, uint16_t, int16_t)
 GENERATE_ZIGZAG_KERNEL(u32, uint32_t, int32_t)
 GENERATE_ZIGZAG_KERNEL(u64, uint64_t, int64_t)
+
+GENERATE_ZIGZAG_IN_OUT_KERNEL(u8, uint8_t, int8_t)
+GENERATE_ZIGZAG_IN_OUT_KERNEL(u16, uint16_t, int16_t)
+GENERATE_ZIGZAG_IN_OUT_KERNEL(u32, uint32_t, int32_t)
+GENERATE_ZIGZAG_IN_OUT_KERNEL(u64, uint64_t, int64_t)

--- a/vortex-cuda/kernels/src/zigzag.cu
+++ b/vortex-cuda/kernels/src/zigzag.cu
@@ -16,9 +16,9 @@ struct ZigZagOp {
 };
 
 // Macro to generate the in-place ZigZag kernel for each type.
-#define GENERATE_ZIGZAG_KERNEL(suffix, UnsignedType)                                                  \
-    extern "C" __global__ void zigzag_##suffix(UnsignedType *__restrict values, uint64_t array_len) { \
-        scalar_kernel_inplace(values, array_len, ZigZagOp<UnsignedType> {});                           \
+#define GENERATE_ZIGZAG_KERNEL(suffix, UnsignedType)                                                         \
+    extern "C" __global__ void zigzag_##suffix(UnsignedType *__restrict values, uint64_t array_len) {        \
+        scalar_kernel_inplace(values, array_len, ZigZagOp<UnsignedType> {});                                 \
     }
 
 GENERATE_ZIGZAG_KERNEL(u8, uint8_t)

--- a/vortex-cuda/kernels/src/zigzag.cu
+++ b/vortex-cuda/kernels/src/zigzag.cu
@@ -20,10 +20,8 @@ struct ZigZagOp {
 // Macro to generate ZigZag kernels for each type.
 #define GENERATE_ZIGZAG_KERNEL(suffix, UnsignedType, SignedType)                                             \
     extern "C" __global__ void zigzag_##suffix(UnsignedType *__restrict values, uint64_t array_len) {        \
-        scalar_kernel(values,                                                                                \
-                      reinterpret_cast<SignedType *>(values),                                                \
-                      array_len,                                                                             \
-                      ZigZagOp<UnsignedType, SignedType> {});                                                \
+        /* Assigning the signed result back to UnsignedType preserves its modulo-2^N bit pattern. */         \
+        scalar_kernel_inplace(values, array_len, ZigZagOp<UnsignedType, SignedType> {});                     \
     }
 
 #define GENERATE_ZIGZAG_IN_OUT_KERNEL(suffix, UnsignedType, SignedType)                                      \

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -487,11 +487,9 @@ where
             .await;
     }
 
-    let output_buffer = ctx.device_alloc::<D>(len)?;
-    let output_device = CudaDeviceBuffer::new(output_buffer);
+    let mut output_buffer = ctx.device_alloc::<D>(len)?;
 
     let values_view = values.cuda_view::<S>()?;
-    let output_view = output_device.as_view::<D>();
     let len_u64 = len as u64;
     let cuda_function = ctx.load_function_with_suffixes(
         "decimal_cast",
@@ -499,10 +497,12 @@ where
     )?;
 
     ctx.launch_kernel(&cuda_function, len, |args| {
-        args.arg(&values_view).arg(&output_view).arg(&len_u64);
+        args.arg(&values_view).arg(&mut output_buffer).arg(&len_u64);
     })?;
 
-    Ok(BufferHandle::new_device(Arc::new(output_device)))
+    Ok(BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(
+        output_buffer,
+    ))))
 }
 
 /// Export Vortex binary views as an Arrow Device array with `Utf8View`/`BinaryView` layout.
@@ -655,21 +655,25 @@ async fn export_binary_buffers(
     }
     let data_buffer_ptrs = device_buffer_from(ptr_values, ctx).await?;
     let data_buffer_lens = device_buffer_from(len_values, ctx).await?;
-    let status = device_buffer_from(vec![0u32], ctx).await?;
+    let mut status = ctx.device_alloc::<u32>(1)?;
+    ctx.stream()
+        .memset_zeros(&mut status)
+        .map_err(|err| vortex_err!("Failed to zero Arrow Binary status buffer: {err}"))?;
 
     let scan_input = init_binary_scan(
         views,
         validity,
         &data_buffer_lens,
         device_data_buffers.len(),
-        &status,
+        &mut status,
         len,
         ctx,
     )?;
     let output_offsets = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(
         exclusive_sum_i32(&scan_input, len + 1, ctx)?,
     )));
-    validate_binary_offsets(&output_offsets, len, &status, ctx)?;
+    validate_binary_offsets(&output_offsets, len, &mut status, ctx)?;
+    let status = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(status)));
 
     // One status read covers init_scan and offset validation. Both must pass before gather may
     // dereference view payloads through the scanned offsets. Enqueue both copies up front so the
@@ -726,7 +730,7 @@ fn init_binary_scan(
     validity: Option<&BufferHandle>,
     data_buffer_lens: &BufferHandle,
     data_buffer_count: usize,
-    status: &BufferHandle,
+    status: &mut CudaSlice<u32>,
     len: usize,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<CudaSlice<i32>> {
@@ -738,18 +742,17 @@ fn init_binary_scan(
         .transpose()?
         .unwrap_or(0);
     let lens_view = data_buffer_lens.cuda_view::<u64>()?;
-    let status_view = status.cuda_view::<u32>()?;
     let data_buffer_count_u64 = data_buffer_count as u64;
     let len_u64 = len as u64;
-    let scan_input = ctx.device_alloc::<i32>(scan_len)?;
+    let mut scan_input = ctx.device_alloc::<i32>(scan_len)?;
     let kernel = ctx.load_function_with_suffixes("arrow_binary", &["init_scan"])?;
 
     ctx.launch_kernel(&kernel, scan_len, |args| {
         args.arg(&views_view)
             .arg(&validity_ptr)
             .arg(&lens_view)
-            .arg(&scan_input)
-            .arg(&status_view)
+            .arg(&mut scan_input)
+            .arg(&mut *status)
             .arg(&data_buffer_count_u64)
             .arg(&len_u64);
     })?;
@@ -763,17 +766,16 @@ fn init_binary_scan(
 fn validate_binary_offsets(
     offsets: &BufferHandle,
     len: usize,
-    status: &BufferHandle,
+    status: &mut CudaSlice<u32>,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<()> {
     let scan_len = len + 1;
     let offsets_view = offsets.cuda_view::<i32>()?;
-    let status_view = status.cuda_view::<u32>()?;
     let scan_len_u64 = scan_len as u64;
     let kernel = ctx.load_function_with_suffixes("arrow_binary", &["validate_offsets"])?;
 
     ctx.launch_kernel(&kernel, scan_len, |args| {
-        args.arg(&offsets_view).arg(&status_view).arg(&scan_len_u64);
+        args.arg(&offsets_view).arg(&mut *status).arg(&scan_len_u64);
     })
 }
 
@@ -785,7 +787,7 @@ fn gather_binary_values(
     len: usize,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<BufferHandle> {
-    let output_values = ctx.device_alloc::<u8>(total_bytes.max(1))?;
+    let mut output_values = ctx.device_alloc::<u8>(total_bytes.max(1))?;
 
     if total_bytes != 0 {
         let views_view = views.cuda_view::<u8>()?;
@@ -799,7 +801,7 @@ fn gather_binary_values(
             args.arg(&views_view)
                 .arg(&ptrs_view)
                 .arg(&offsets_view)
-                .arg(&output_values)
+                .arg(&mut output_values)
                 .arg(&len_u64)
                 .arg(&total_bytes_u64);
         })?;
@@ -979,10 +981,8 @@ pub fn count_arrow_validity_nulls(
     ctx.stream()
         .memset_zeros(&mut count)
         .map_err(|err| vortex_err!("Failed to zero Arrow validity count buffer: {err}"))?;
-    let count = CudaDeviceBuffer::new(count);
 
     let input_view = bitmap.cuda_view::<u8>()?;
-    let output_view = count.as_view::<u64>();
     let len = u64::try_from(len)?;
     let arrow_offset = u64::try_from(arrow_offset)?;
 
@@ -998,14 +998,14 @@ pub fn count_arrow_validity_nulls(
     };
     ctx.launch_kernel_config(&kernel, config, expected_bytes, |args| {
         args.arg(&input_view)
-            .arg(&output_view)
+            .arg(&mut count)
             .arg(&len)
             .arg(&arrow_offset);
     })?;
 
     let valid_count = ctx
         .stream()
-        .clone_dtoh(&output_view)
+        .clone_dtoh(&count)
         .map_err(|err| vortex_err!("Failed to copy Arrow validity count to host: {err}"))?
         .into_iter()
         .next()
@@ -1055,12 +1055,9 @@ pub fn repack_arrow_validity_buffer(
     ctx.stream()
         .memset_zeros(&mut output)
         .map_err(|err| vortex_err!("Failed to zero Arrow validity buffer padding: {err}"))?;
-    // The memset above zeroed all allocation bytes after the logical output.
-    let output_device = CudaDeviceBuffer::new_with_zeroed_tail(output, output_bytes)?;
 
     if output_words > 0 {
         let input_view = input_buffer.cuda_view::<u8>()?;
-        let output_view = output_device.as_view::<u64>();
         let len = u64::try_from(len)?;
         let input_offset = u64::try_from(input_offset)?;
         let arrow_offset = u64::try_from(arrow_offset)?;
@@ -1076,7 +1073,7 @@ pub fn repack_arrow_validity_buffer(
         };
         ctx.launch_kernel_config(&kernel, config, output_words, |args| {
             args.arg(&input_view)
-                .arg(&output_view)
+                .arg(&mut output)
                 .arg(&len)
                 .arg(&input_offset)
                 .arg(&arrow_offset)
@@ -1084,6 +1081,8 @@ pub fn repack_arrow_validity_buffer(
         })?;
     }
 
+    // The memset above zeroed all allocation bytes after the logical output.
+    let output_device = CudaDeviceBuffer::new_with_zeroed_tail(output, output_bytes)?;
     Ok(BufferHandle::new_device(Arc::new(output_device)).slice(0..output_bytes))
 }
 
@@ -1255,13 +1254,13 @@ fn fixed_size_list_offsets(
     let output_len = len
         .checked_add(1)
         .ok_or_else(|| vortex_err!("FixedSizeList Arrow List offsets length overflows usize"))?;
-    let offsets = ctx.device_alloc::<i32>(output_len)?;
+    let mut offsets = ctx.device_alloc::<i32>(output_len)?;
     let base = 0i32;
     let output_len_u64 = output_len as u64;
     let kernel = ctx.load_function_with_suffixes("sequence", &["i32"])?;
 
     ctx.launch_kernel(&kernel, output_len, |args| {
-        args.arg(&offsets)
+        args.arg(&mut offsets)
             .arg(&base)
             .arg(&list_size)
             .arg(&output_len_u64);

--- a/vortex-cuda/src/arrow/list_view.rs
+++ b/vortex-cuda/src/arrow/list_view.rs
@@ -162,16 +162,16 @@ where
     O: NativePType + DeviceRepr + Send + Sync + 'static,
     S: NativePType + DeviceRepr + Send + Sync + 'static,
 {
-    let status = new_list_view_status(ctx).await?;
+    let mut status = new_list_view_status(ctx)?;
     let scan_len = list_len + 1;
 
-    let scan_input = init_list_view_rebuild_scan::<S>(&sizes, &status, list_len, ctx)?;
+    let scan_input = init_list_view_rebuild_scan::<S>(&sizes, &mut status, list_len, ctx)?;
     let output_offsets = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(
         exclusive_sum_i32(&scan_input, scan_len, ctx)?,
     )));
 
-    validate_list_view_rebuild_offsets::<S>(&sizes, &output_offsets, &status, list_len, ctx)?;
-    check_list_view_rebuild_status(&status).await?;
+    validate_list_view_rebuild_offsets::<S>(&sizes, &output_offsets, &mut status, list_len, ctx)?;
+    check_list_view_rebuild_status(&status, ctx)?;
 
     let total_values = total_values_from_offsets(&output_offsets, list_len).await?;
     let value_width = values_ptype.byte_width();
@@ -188,10 +188,10 @@ where
         elements_len,
         list_len,
         value_width,
-        &status,
+        &mut status,
         ctx,
     )?;
-    check_list_view_rebuild_status(&status).await?;
+    check_list_view_rebuild_status(&status, ctx)?;
 
     let values = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(output_values)))
         .slice(0..output_values_bytes);
@@ -199,16 +199,24 @@ where
 }
 
 /// Allocate the device status word used by list-view rebuild kernels.
-async fn new_list_view_status(ctx: &mut CudaExecutionCtx) -> VortexResult<BufferHandle> {
-    ctx.ensure_on_device(BufferHandle::new_host(
-        Buffer::from(vec![0u32]).into_byte_buffer(),
-    ))
-    .await
+fn new_list_view_status(ctx: &mut CudaExecutionCtx) -> VortexResult<CudaSlice<u32>> {
+    let mut status = ctx.device_alloc::<u32>(1)?;
+    ctx.stream()
+        .memset_zeros(&mut status)
+        .map_err(|err| vortex_err!("Failed to zero list-view rebuild status buffer: {err}"))?;
+    Ok(status)
 }
 
 /// Convert the list-view rebuild status word into a Vortex error.
-async fn check_list_view_rebuild_status(status: &BufferHandle) -> VortexResult<()> {
-    match Buffer::<u32>::from_byte_buffer(status.try_to_host()?.await?)[0] {
+fn check_list_view_rebuild_status(
+    status: &CudaSlice<u32>,
+    ctx: &CudaExecutionCtx,
+) -> VortexResult<()> {
+    let status = ctx
+        .stream()
+        .clone_dtoh(status)
+        .map_err(|err| vortex_err!("Failed to copy list-view rebuild status to host: {err}"))?[0];
+    match status {
         0 => Ok(()),
         1 => vortex_bail!(
             "cannot export device-resident ListViewArray as Arrow List: offsets/sizes are invalid for the child elements"
@@ -223,7 +231,7 @@ async fn check_list_view_rebuild_status(status: &BufferHandle) -> VortexResult<(
 /// Initialize the exclusive-scan input for rebuilt Arrow List offsets.
 fn init_list_view_rebuild_scan<S>(
     sizes: &BufferHandle,
-    status: &BufferHandle,
+    status: &mut CudaSlice<u32>,
     list_len: usize,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<CudaSlice<i32>>
@@ -232,17 +240,16 @@ where
 {
     let scan_len = list_len + 1;
     let sizes_view = sizes.cuda_view::<S>()?;
-    let status_view = status.cuda_view::<u32>()?;
     let list_len_u64 = list_len as u64;
     let scan_len_u64 = scan_len as u64;
-    let scan_input = ctx.device_alloc::<i32>(scan_len)?;
+    let mut scan_input = ctx.device_alloc::<i32>(scan_len)?;
     let init_kernel = ctx
         .load_function_with_suffixes("list_view", &["rebuild_init_scan", &S::PTYPE.to_string()])?;
 
     ctx.launch_kernel(&init_kernel, scan_len, |args| {
         args.arg(&sizes_view)
-            .arg(&scan_input)
-            .arg(&status_view)
+            .arg(&mut scan_input)
+            .arg(&mut *status)
             .arg(&list_len_u64)
             .arg(&scan_len_u64);
     })?;
@@ -254,7 +261,7 @@ where
 fn validate_list_view_rebuild_offsets<S>(
     sizes: &BufferHandle,
     output_offsets: &BufferHandle,
-    status: &BufferHandle,
+    status: &mut CudaSlice<u32>,
     list_len: usize,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<()>
@@ -263,7 +270,6 @@ where
 {
     let sizes_view = sizes.cuda_view::<S>()?;
     let output_offsets_view = output_offsets.cuda_view::<i32>()?;
-    let status_view = status.cuda_view::<u32>()?;
     let list_len_u64 = list_len as u64;
     let validate_kernel = ctx.load_function_with_suffixes(
         "list_view",
@@ -273,7 +279,7 @@ where
     ctx.launch_kernel(&validate_kernel, list_len, |args| {
         args.arg(&sizes_view)
             .arg(&output_offsets_view)
-            .arg(&status_view)
+            .arg(&mut *status)
             .arg(&list_len_u64);
     })
 }
@@ -304,7 +310,7 @@ fn gather_rebuilt_primitive_values<O, S>(
     elements_len: usize,
     list_len: usize,
     value_width: usize,
-    status: &BufferHandle,
+    status: &mut CudaSlice<u32>,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<CudaSlice<u8>>
 where
@@ -315,8 +321,7 @@ where
     let sizes_view = sizes.cuda_view::<S>()?;
     let values_view = values.cuda_view::<u8>()?;
     let output_offsets_view = output_offsets.cuda_view::<i32>()?;
-    let output_values = ctx.device_alloc::<u8>(output_values_bytes.max(1))?;
-    let status_view = status.cuda_view::<u32>()?;
+    let mut output_values = ctx.device_alloc::<u8>(output_values_bytes.max(1))?;
     let list_len_u64 = list_len as u64;
     let elements_len_u64 = elements_len as u64;
     let value_width_u64 = value_width as u64;
@@ -334,8 +339,8 @@ where
             .arg(&sizes_view)
             .arg(&output_offsets_view)
             .arg(&values_view)
-            .arg(&output_values)
-            .arg(&status_view)
+            .arg(&mut output_values)
+            .arg(&mut *status)
             .arg(&list_len_u64)
             .arg(&elements_len_u64)
             .arg(&value_width_u64);
@@ -512,17 +517,11 @@ where
     S: NativePType + DeviceRepr + Send + Sync + 'static,
 {
     let output_len = len + 1;
-    let output = ctx.device_alloc::<i32>(output_len)?;
-
-    let status = ctx
-        .ensure_on_device(BufferHandle::new_host(
-            Buffer::from(vec![0u32]).into_byte_buffer(),
-        ))
-        .await?;
+    let mut output = ctx.device_alloc::<i32>(output_len)?;
+    let mut status = new_list_view_status(ctx)?;
 
     let offsets_view = offsets.cuda_view::<O>()?;
     let sizes_view = sizes.cuda_view::<S>()?;
-    let status_view = status.cuda_view::<u32>()?;
     let list_len_u64 = len as u64;
 
     let kernel = ctx.load_function_with_suffixes(
@@ -532,12 +531,16 @@ where
     ctx.launch_kernel(&kernel, len, |args| {
         args.arg(&offsets_view)
             .arg(&sizes_view)
-            .arg(&output)
-            .arg(&status_view)
+            .arg(&mut output)
+            .arg(&mut status)
             .arg(&list_len_u64);
     })?;
 
-    match Buffer::<u32>::from_byte_buffer(status.try_to_host()?.await?)[0] {
+    let status = ctx
+        .stream()
+        .clone_dtoh(&status)
+        .map_err(|err| vortex_err!("Failed to copy list-view offsets status to host: {err}"))?[0];
+    match status {
         0 => Ok(DeviceListViewOffsets::Contiguous(BufferHandle::new_device(
             Arc::new(CudaDeviceBuffer::new(output)),
         ))),

--- a/vortex-cuda/src/arrow/offsets.rs
+++ b/vortex-cuda/src/arrow/offsets.rs
@@ -57,10 +57,12 @@ where
     let scan_len = len
         .checked_add(1)
         .ok_or_else(|| vortex_err!("Arrow offset count overflow"))?;
-    let status = ctx.copy_to_device(vec![0u32])?.await?;
+    let mut status = ctx.device_alloc::<u32>(1)?;
+    ctx.stream()
+        .memset_zeros(&mut status)
+        .map_err(|err| vortex_err!("Failed to zero Arrow offset status buffer: {err}"))?;
     let lengths_view = lengths.cuda_view::<L>()?;
-    let status_view = status.cuda_view::<u32>()?;
-    let scan_input = ctx.device_alloc::<i32>(scan_len)?;
+    let mut scan_input = ctx.device_alloc::<i32>(scan_len)?;
     let ptype = L::PTYPE.to_string();
     let scan_kernel =
         ctx.load_function_with_suffixes("arrow_offsets", &["from", "lengths", &ptype])?;
@@ -68,23 +70,20 @@ where
 
     ctx.launch_kernel(&scan_kernel, scan_len, |args| {
         args.arg(&lengths_view)
-            .arg(&scan_input)
-            .arg(&status_view)
+            .arg(&mut scan_input)
+            .arg(&mut status)
             .arg(&len_u64);
     })?;
 
-    let offsets = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(exclusive_sum_i32(
-        &scan_input,
-        scan_len,
-        ctx,
-    )?)));
-    let offsets_view = offsets.cuda_view::<i32>()?;
+    let offsets = exclusive_sum_i32(&scan_input, scan_len, ctx)?;
     let scan_len_u64 = u64::try_from(scan_len)?;
     let validate_kernel = ctx.load_function_with_suffixes("arrow_offsets", &["validate"])?;
     ctx.launch_kernel(&validate_kernel, scan_len, |args| {
-        args.arg(&offsets_view).arg(&status_view).arg(&scan_len_u64);
+        args.arg(&offsets).arg(&mut status).arg(&scan_len_u64);
     })?;
 
+    let offsets = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(offsets)));
+    let status = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(status)));
     let status_copy = status.try_to_host()?;
     let total_copy = offsets.slice_typed::<i32>(len..scan_len).try_to_host()?;
     let (status_bytes, total_bytes) = futures::try_join!(status_copy, total_copy)?;

--- a/vortex-cuda/src/device_buffer.rs
+++ b/vortex-cuda/src/device_buffer.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 
 use cudarc::driver::CudaSlice;
 use cudarc::driver::CudaView;
+use cudarc::driver::CudaViewMut;
 use cudarc::driver::DevicePtr;
 use cudarc::driver::DeviceRepr;
 use cudarc::driver::sys;
@@ -63,6 +64,7 @@ mod private {
     use cudarc::driver::CudaSlice;
     use cudarc::driver::CudaStream;
     use cudarc::driver::CudaView;
+    use cudarc::driver::CudaViewMut;
     use cudarc::driver::DeviceRepr;
     use vortex::buffer::Alignment;
     use vortex::error::VortexExpect;
@@ -74,8 +76,11 @@ mod private {
         /// Get a reference to the underlying cuStream.
         fn stream(&self) -> &Arc<CudaStream>;
 
-        /// Access the values as a bytes view
+        /// Access the values as a bytes view.
         fn as_bytes_view(&self) -> CudaView<'_, u8>;
+
+        /// Access the values as a mutable bytes view.
+        fn as_bytes_view_mut(&mut self) -> CudaViewMut<'_, u8>;
     }
 
     // CudaSlice needs to be held by the CudaDeviceBuffer
@@ -90,8 +95,15 @@ mod private {
 
         fn as_bytes_view(&self) -> CudaView<'_, u8> {
             let bytes_len = self.len() * size_of::<T>();
-            // SAFETY: all types can be reinterpreted as a byte slice
+            // SAFETY: all types can be reinterpreted as a byte slice.
             let result = unsafe { self.as_view().transmute::<u8>(bytes_len) };
+            result.vortex_expect("Downcasting CudaSlice<T> => CudaSlice<u8> must succeed")
+        }
+
+        fn as_bytes_view_mut(&mut self) -> CudaViewMut<'_, u8> {
+            let bytes_len = self.len() * size_of::<T>();
+            // SAFETY: all types can be reinterpreted as a mutable byte slice.
+            let result = unsafe { self.transmute_mut::<u8>(bytes_len) };
             result.vortex_expect("Downcasting CudaSlice<T> => CudaSlice<u8> must succeed")
         }
     }
@@ -146,8 +158,8 @@ impl CudaDeviceBuffer {
         // Return a new &[T]
         let new_len = self.len / size_of::<T>();
 
-        // SAFETY: All DeviecRepr types are aligned to < 256 bytes, which is what CUDA allocator
-        //  gives us back. So we should not suffer any alignment issues at runtime.
+        // SAFETY: All DeviceRepr types are aligned to < 256 bytes, which is what CUDA allocator
+        // gives us back. So we should not suffer any alignment issues at runtime.
         unsafe {
             self.allocation
                 .as_bytes_view()
@@ -155,6 +167,21 @@ impl CudaDeviceBuffer {
                 .transmute::<T>(new_len)
                 .vortex_expect("Failed to transmute from CudaView<u8> to CudaView<T>")
         }
+    }
+
+    pub(crate) fn with_view_mut<T: DeviceRepr + 'static, R>(
+        &mut self,
+        function: impl FnOnce(&mut CudaViewMut<'_, T>) -> R,
+    ) -> Option<R> {
+        let new_len = self.len / size_of::<T>();
+        let allocation = Arc::get_mut(&mut self.allocation)?;
+        let mut bytes = allocation.as_bytes_view_mut();
+        let mut bytes = bytes.slice_mut(self.offset..self.offset + self.len);
+        // SAFETY: The same alignment and size requirements as `as_view` apply, and unique
+        // ownership of both allocation Arcs guarantees no other device view can alias this one.
+        let mut values = unsafe { bytes.transmute_mut::<T>(new_len) }
+            .vortex_expect("Failed to transmute from CudaViewMut<u8> to CudaViewMut<T>");
+        Some(function(&mut values))
     }
 }
 
@@ -180,10 +207,7 @@ pub(crate) fn cuda_backing_allocation(handle: &BufferHandle) -> VortexResult<Buf
     })))
 }
 
-// TODO(aduffy): we should add cuda_view_mut and enforce the borrow rules. This is a bit tricky
-//  because many executions are async, we should lean into that with ownership and having any
-//  async context actions take ownership of the buffer and return ownership when they're done.
-/// Extension trait for getting a [`CudaView`] from a [`BufferHandle`].
+/// Extension trait for getting CUDA views from a [`BufferHandle`].
 pub trait CudaBufferExt {
     /// Returns a readonly [`CudaView`] for the buffer handle.
     ///
@@ -191,6 +215,22 @@ pub trait CudaBufferExt {
     ///
     /// Returns an error if the buffer is not a CUDA buffer.
     fn cuda_view<T: DeviceRepr + Send + Sync + 'static>(&self) -> VortexResult<CudaView<'_, T>>;
+
+    /// Consumes and returns this handle, calling `function` with a mutable CUDA view when the
+    /// handle and backing allocation are unique.
+    ///
+    /// The returned option is `None` when another handle references the same device buffer or
+    /// allocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer is not a CUDA buffer.
+    fn with_cuda_view_mut<T: DeviceRepr + Send + Sync + 'static, R>(
+        self,
+        function: impl FnOnce(&mut CudaViewMut<'_, T>) -> R,
+    ) -> VortexResult<(Self, Option<R>)>
+    where
+        Self: Sized;
 
     /// Returns the on-device pointer for the start of the buffer handle.
     ///
@@ -219,6 +259,29 @@ impl CudaBufferExt for BufferHandle {
             .ok_or_else(|| vortex_err!("expected CudaDeviceBuffer, was {device_buffer:?}"))?;
 
         Ok(cuda_buf.as_view::<T>())
+    }
+
+    fn with_cuda_view_mut<T: DeviceRepr + Send + Sync + 'static, R>(
+        self,
+        function: impl FnOnce(&mut CudaViewMut<'_, T>) -> R,
+    ) -> VortexResult<(Self, Option<R>)> {
+        if !self.is_on_device() {
+            return Err(vortex_err!("Buffer is not on device"));
+        }
+
+        let device_buffer = self.unwrap_device();
+        if !device_buffer.as_any().is::<CudaDeviceBuffer>() {
+            return Err(vortex_err!(
+                "expected CudaDeviceBuffer, was {device_buffer:?}"
+            ));
+        }
+
+        let device_buffer: Arc<dyn Any + Send + Sync> = device_buffer;
+        let mut cuda_buf = Arc::downcast::<CudaDeviceBuffer>(device_buffer)
+            .map_err(|_| vortex_err!("CudaDeviceBuffer downcast failed after type check"))?;
+        let result = Arc::get_mut(&mut cuda_buf).and_then(|buffer| buffer.with_view_mut(function));
+
+        Ok((BufferHandle::new_device(cuda_buf), result))
     }
 
     fn cuda_device_ptr(&self) -> VortexResult<sys::CUdeviceptr> {
@@ -340,9 +403,10 @@ impl DeviceBuffer for CudaDeviceBuffer {
         alignment: Alignment,
     ) -> VortexResult<BoxFuture<'static, VortexResult<ByteBuffer>>> {
         let stream = self.allocation.stream();
-
-        // Add offset to device pointer to account for any previous slicing operations.
-        let src_ptr = self.device_ptr + self.offset as u64;
+        let source = self.as_view::<u8>();
+        // Use cudarc's read guard so this allocation stream waits for writes submitted on any
+        // other managed stream before scheduling the device-to-host copy.
+        let (src_ptr, record_read) = source.device_ptr(stream);
 
         let mut host_buffer: ByteBufferMut =
             ByteBufferMut::with_capacity_aligned(self.len, alignment);
@@ -365,6 +429,7 @@ impl DeviceBuffer for CudaDeviceBuffer {
             .result()
             .map_err(|e| vortex_err!("Failed to schedule async copy to host: {}", e))?;
         }
+        drop(record_read);
 
         let cuda_slice = Arc::clone(&self.allocation);
 
@@ -439,5 +504,71 @@ impl DeviceBuffer for CudaDeviceBuffer {
         } else {
             vortex_panic!("some how we alloc a cuda buffer with alignment less than 256")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cudarc::driver::CudaContext;
+    use cudarc::driver::PushKernelArg;
+    use vortex::buffer::Buffer;
+    use vortex::dtype::PType;
+    use vortex::error::VortexResult;
+    use vortex::error::vortex_bail;
+
+    use super::*;
+    use crate::CudaSession;
+
+    #[crate::test]
+    async fn mutable_view_requires_unique_ownership() -> VortexResult<()> {
+        let ctx = CudaSession::create_execution_ctx(&crate::cuda_session())?;
+        let allocation = ctx.device_alloc::<u32>(4)?;
+        let mut handle = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(allocation)));
+
+        let (next, result) = handle.with_cuda_view_mut::<u32, _>(|view| view.len())?;
+        handle = next;
+        assert_eq!(result, Some(4));
+
+        let alias = handle.clone();
+        let (next, result) = handle.with_cuda_view_mut::<u32, _>(|view| view.len())?;
+        handle = next;
+        assert!(result.is_none());
+        drop(alias);
+
+        let (_, result) = handle.with_cuda_view_mut::<u32, _>(|view| view.len())?;
+        assert_eq!(result, Some(4));
+        Ok(())
+    }
+
+    #[crate::test]
+    async fn copy_to_host_waits_for_write_on_another_stream() -> VortexResult<()> {
+        let context = CudaContext::new(0)
+            .map_err(|err| vortex_err!("failed to create CUDA context: {err}"))?;
+        let cuda_session = CudaSession::with_stream_pool_capacity(context, 2);
+        let session = vortex::array::array_session().with_some(cuda_session);
+        let allocation_ctx = CudaSession::create_execution_ctx(&session)?;
+        let mut launch_ctx = CudaSession::create_execution_ctx(&session)?;
+        assert_ne!(
+            allocation_ctx.stream().cu_stream(),
+            launch_ctx.stream().cu_stream()
+        );
+
+        let handle = allocation_ctx.copy_to_device(vec![0u32; 4])?.await?;
+        let kernel = launch_ctx.load_function("constant_numeric", &[PType::U32])?;
+        let value = 42u32;
+        let len = 4u64;
+        let (handle, launch) = handle.with_cuda_view_mut::<u32, _>(|view| {
+            launch_ctx.launch_kernel(&kernel, 4, |args| {
+                args.arg(view).arg(&value).arg(&len);
+            })
+        })?;
+        let Some(launch) = launch else {
+            vortex_bail!("fresh CUDA allocation was unexpectedly shared");
+        };
+        launch?;
+
+        let values = Buffer::<u32>::from_byte_buffer(handle.try_to_host()?.await?);
+        assert_eq!(values.as_slice(), &[42; 4]);
+        Ok(())
     }
 }

--- a/vortex-cuda/src/device_buffer.rs
+++ b/vortex-cuda/src/device_buffer.rs
@@ -207,6 +207,29 @@ pub(crate) fn cuda_backing_allocation(handle: &BufferHandle) -> VortexResult<Buf
     })))
 }
 
+pub(crate) fn with_cuda_view_mut<T: DeviceRepr + Send + Sync + 'static, R>(
+    handle: BufferHandle,
+    function: impl FnOnce(&mut CudaViewMut<'_, T>) -> R,
+) -> VortexResult<(BufferHandle, Option<R>)> {
+    if !handle.is_on_device() {
+        return Err(vortex_err!("Buffer is not on device"));
+    }
+
+    let device_buffer = handle.unwrap_device();
+    if !device_buffer.as_any().is::<CudaDeviceBuffer>() {
+        return Err(vortex_err!(
+            "expected CudaDeviceBuffer, was {device_buffer:?}"
+        ));
+    }
+
+    let device_buffer: Arc<dyn Any + Send + Sync> = device_buffer;
+    let mut cuda_buf = Arc::downcast::<CudaDeviceBuffer>(device_buffer)
+        .map_err(|_| vortex_err!("CudaDeviceBuffer downcast failed after type check"))?;
+    let result = Arc::get_mut(&mut cuda_buf).and_then(|buffer| buffer.with_view_mut(function));
+
+    Ok((BufferHandle::new_device(cuda_buf), result))
+}
+
 /// Extension trait for getting CUDA views from a [`BufferHandle`].
 pub trait CudaBufferExt {
     /// Returns a readonly [`CudaView`] for the buffer handle.
@@ -215,22 +238,6 @@ pub trait CudaBufferExt {
     ///
     /// Returns an error if the buffer is not a CUDA buffer.
     fn cuda_view<T: DeviceRepr + Send + Sync + 'static>(&self) -> VortexResult<CudaView<'_, T>>;
-
-    /// Consumes and returns this handle, calling `function` with a mutable CUDA view when the
-    /// handle and backing allocation are unique.
-    ///
-    /// The returned option is `None` when another handle references the same device buffer or
-    /// allocation.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the buffer is not a CUDA buffer.
-    fn with_cuda_view_mut<T: DeviceRepr + Send + Sync + 'static, R>(
-        self,
-        function: impl FnOnce(&mut CudaViewMut<'_, T>) -> R,
-    ) -> VortexResult<(Self, Option<R>)>
-    where
-        Self: Sized;
 
     /// Returns the on-device pointer for the start of the buffer handle.
     ///
@@ -259,29 +266,6 @@ impl CudaBufferExt for BufferHandle {
             .ok_or_else(|| vortex_err!("expected CudaDeviceBuffer, was {device_buffer:?}"))?;
 
         Ok(cuda_buf.as_view::<T>())
-    }
-
-    fn with_cuda_view_mut<T: DeviceRepr + Send + Sync + 'static, R>(
-        self,
-        function: impl FnOnce(&mut CudaViewMut<'_, T>) -> R,
-    ) -> VortexResult<(Self, Option<R>)> {
-        if !self.is_on_device() {
-            return Err(vortex_err!("Buffer is not on device"));
-        }
-
-        let device_buffer = self.unwrap_device();
-        if !device_buffer.as_any().is::<CudaDeviceBuffer>() {
-            return Err(vortex_err!(
-                "expected CudaDeviceBuffer, was {device_buffer:?}"
-            ));
-        }
-
-        let device_buffer: Arc<dyn Any + Send + Sync> = device_buffer;
-        let mut cuda_buf = Arc::downcast::<CudaDeviceBuffer>(device_buffer)
-            .map_err(|_| vortex_err!("CudaDeviceBuffer downcast failed after type check"))?;
-        let result = Arc::get_mut(&mut cuda_buf).and_then(|buffer| buffer.with_view_mut(function));
-
-        Ok((BufferHandle::new_device(cuda_buf), result))
     }
 
     fn cuda_device_ptr(&self) -> VortexResult<sys::CUdeviceptr> {
@@ -525,17 +509,17 @@ mod tests {
         let allocation = ctx.device_alloc::<u32>(4)?;
         let mut handle = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(allocation)));
 
-        let (next, result) = handle.with_cuda_view_mut::<u32, _>(|view| view.len())?;
+        let (next, result) = with_cuda_view_mut::<u32, _>(handle, |view| view.len())?;
         handle = next;
         assert_eq!(result, Some(4));
 
         let alias = handle.clone();
-        let (next, result) = handle.with_cuda_view_mut::<u32, _>(|view| view.len())?;
+        let (next, result) = with_cuda_view_mut::<u32, _>(handle, |view| view.len())?;
         handle = next;
         assert!(result.is_none());
         drop(alias);
 
-        let (_, result) = handle.with_cuda_view_mut::<u32, _>(|view| view.len())?;
+        let (_, result) = with_cuda_view_mut::<u32, _>(handle, |view| view.len())?;
         assert_eq!(result, Some(4));
         Ok(())
     }
@@ -557,7 +541,7 @@ mod tests {
         let kernel = launch_ctx.load_function("constant_numeric", &[PType::U32])?;
         let value = 42u32;
         let len = 4u64;
-        let (handle, launch) = handle.with_cuda_view_mut::<u32, _>(|view| {
+        let (handle, launch) = with_cuda_view_mut::<u32, _>(handle, |view| {
             launch_ctx.launch_kernel(&kernel, 4, |args| {
                 args.arg(view).arg(&value).arg(&len);
             })

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -471,7 +471,7 @@ impl MaterializedPlan {
             )));
         }
 
-        let output_buf = CudaDeviceBuffer::new(ctx.device_alloc::<T>(len.next_multiple_of(1024))?);
+        let mut output = ctx.device_alloc::<T>(len.next_multiple_of(1024))?;
 
         // Upload the packed plan bytes to the device.
         let device_plan = Arc::new(
@@ -503,20 +503,20 @@ impl MaterializedPlan {
             .map(|view| view.device_ptr(&stream).1)
             .collect::<Vec<_>>();
 
-        let output_ptr = output_buf.offset_ptr();
         let (plan_ptr, plan_read_record) = device_plan.device_ptr(&stream);
         let array_len_u64 = len as u64;
 
         ctx.launch_kernel_config(&cuda_function, config, len, |args| {
-            args.arg(&output_ptr);
+            args.arg(&mut output);
             args.arg(&array_len_u64);
             args.arg(&plan_ptr);
         })?;
 
         drop((device_buffer_read_records, plan_read_record));
 
+        let output = CudaDeviceBuffer::new(output);
         Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
-            BufferHandle::new_device(output_buf.slice_typed::<T>(0..len)),
+            BufferHandle::new_device(output.slice_typed::<T>(0..len)),
             output_ptype,
             self.validity,
         )))
@@ -577,7 +577,6 @@ mod tests {
     use super::*;
     use crate::CanonicalCudaExt;
     use crate::CudaBufferExt;
-    use crate::CudaDeviceBuffer;
     use crate::CudaExecutionCtx;
     use crate::cuda_session;
     use crate::executor::CudaArrayExt;
@@ -788,12 +787,9 @@ mod tests {
         plan: &CudaDispatchPlan,
         shared_mem_bytes: u32,
     ) -> VortexResult<Vec<u32>> {
-        let output_slice = cuda_ctx
+        let mut output = cuda_ctx
             .device_alloc::<u32>(output_len)
             .vortex_expect("alloc output");
-        let output_buf = CudaDeviceBuffer::new(output_slice);
-        let output_view = output_buf.as_view::<u32>();
-        let (output_ptr, record_output) = output_view.device_ptr(cuda_ctx.stream());
 
         let device_plan = Arc::new(
             cuda_ctx
@@ -813,7 +809,7 @@ mod tests {
             .load_function("dynamic_dispatch", &[PType::U32])
             .vortex_expect("load kernel");
         let mut launch_builder = cuda_ctx.launch_builder(&cuda_function);
-        launch_builder.arg(&output_ptr);
+        launch_builder.arg(&mut output);
         launch_builder.arg(&array_len_u64);
         launch_builder.arg(&plan_ptr);
 
@@ -828,11 +824,11 @@ mod tests {
                 .launch(config)
                 .map_err(|e| vortex_err!("kernel launch: {e}"))?;
         }
-        drop((record_output, record_plan));
+        drop(record_plan);
 
         cuda_ctx
             .stream()
-            .clone_dtoh(&output_buf.as_view::<u32>())
+            .clone_dtoh(&output)
             .map_err(|e| vortex_err!("copy back: {e}"))
     }
 

--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -239,7 +239,8 @@ impl CudaExecutionCtx {
 
     /// Returns a launch builder for a CUDA kernel function.
     ///
-    /// Arguments can be added to the kernel launch with `.arg(buffer)`.
+    /// Arguments can be added to the kernel launch with `.arg(&buffer)`. Buffers written by the
+    /// kernel must be passed with `.arg(&mut buffer)` so their writes are tracked.
     ///
     /// # Arguments
     ///

--- a/vortex-cuda/src/kernel/arrays/constant.rs
+++ b/vortex-cuda/src/kernel/arrays/constant.rs
@@ -106,8 +106,7 @@ where
         .ok_or_else(|| vortex_err!("Expected non-null primitive scalar value"))?;
 
     // Allocate output buffer on device
-    let output_buffer = ctx.device_alloc::<P>(array_len)?;
-    let output_view = output_buffer.as_view();
+    let mut output_buffer = ctx.device_alloc::<P>(array_len)?;
     let array_len_u64 = array_len as u64;
 
     // Load kernel function
@@ -115,7 +114,7 @@ where
     let cuda_function = ctx.load_function("constant_numeric", &kernel_ptypes)?;
 
     ctx.launch_kernel(&cuda_function, array_len, |args| {
-        args.arg(&output_view);
+        args.arg(&mut output_buffer);
         args.arg(&value);
         args.arg(&array_len_u64);
     })?;
@@ -163,8 +162,7 @@ where
         .ok_or_else(|| vortex_err!("Failed to cast decimal value to native type"))?;
 
     // Allocate output buffer on device
-    let output_buffer = ctx.device_alloc::<D>(array_len)?;
-    let output_view = output_buffer.as_view();
+    let mut output_buffer = ctx.device_alloc::<D>(array_len)?;
     let array_len_u64 = array_len as u64;
 
     // Load kernel function
@@ -172,7 +170,7 @@ where
         ctx.load_function_with_suffixes("constant_numeric", &[&D::DECIMAL_TYPE.to_string()])?;
 
     ctx.launch_kernel(&cuda_function, array_len, |args| {
-        args.arg(&output_view);
+        args.arg(&mut output_buffer);
         args.arg(&value);
         args.arg(&array_len_u64);
     })?;

--- a/vortex-cuda/src/kernel/arrays/dict.rs
+++ b/vortex-cuda/src/kernel/arrays/dict.rs
@@ -138,12 +138,10 @@ async fn execute_dict_bool_typed<I: DeviceRepr + NativePType>(
     // Each CUDA thread owns complete output bytes, avoiding races between threads writing
     // different bits in the same byte. The kernel handles the final partial byte explicitly.
     let output_bytes = codes_len.div_ceil(8);
-    let output_slice = ctx.device_alloc::<u8>(output_bytes)?;
-    let output_device = CudaDeviceBuffer::new(output_slice);
+    let mut output_slice = ctx.device_alloc::<u8>(output_bytes)?;
 
     let values_view = values_device.cuda_view::<u8>()?;
     let codes_view = codes_device.cuda_view::<I>()?;
-    let output_view = output_device.as_view::<u8>();
     let codes_len_u64 = codes_len as u64;
     let values_offset_u64 = values_meta.offset() as u64;
 
@@ -154,9 +152,10 @@ async fn execute_dict_bool_typed<I: DeviceRepr + NativePType>(
             .arg(&codes_len_u64)
             .arg(&values_view)
             .arg(&values_offset_u64)
-            .arg(&output_view);
+            .arg(&mut output_slice);
     })?;
 
+    let output_device = CudaDeviceBuffer::new(output_slice);
     Ok(Canonical::Bool(BoolArray::new_handle(
         BufferHandle::new_device(Arc::new(output_device)),
         0,
@@ -190,13 +189,11 @@ async fn execute_dict_prim_typed<V: DeviceRepr + NativePType, I: DeviceRepr + Na
     let codes_device = ctx.ensure_on_device(codes_buffer).await?;
 
     // Allocate output buffer on device
-    let output_slice = ctx.device_alloc::<V>(codes_len)?;
-    let output_device = CudaDeviceBuffer::new(output_slice);
+    let mut output_slice = ctx.device_alloc::<V>(codes_len)?;
 
     // Get views for kernel launch
     let values_view = values_device.cuda_view::<V>()?;
     let codes_view = codes_device.cuda_view::<I>()?;
-    let output_view = output_device.as_view::<V>();
 
     let codes_len_u64 = codes_len as u64;
 
@@ -205,9 +202,10 @@ async fn execute_dict_prim_typed<V: DeviceRepr + NativePType, I: DeviceRepr + Na
         args.arg(&codes_view)
             .arg(&codes_len_u64)
             .arg(&values_view)
-            .arg(&output_view);
+            .arg(&mut output_slice);
     })?;
 
+    let output_device = CudaDeviceBuffer::new(output_slice);
     Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
         BufferHandle::new_device(Arc::new(output_device)),
         value_ptype,
@@ -273,13 +271,11 @@ async fn execute_dict_decimal_typed<
     let codes_device = ctx.ensure_on_device(codes_buffer).await?;
 
     // Allocate output buffer on device (codes_len * value_byte_width bytes)
-    let output_slice = ctx.device_alloc::<V>(codes_len)?;
-    let output_device = CudaDeviceBuffer::new(output_slice);
+    let mut output_slice = ctx.device_alloc::<V>(codes_len)?;
 
     // Get views for kernel launch
     let values_view = values_device.cuda_view::<V>()?;
     let codes_view = codes_device.cuda_view::<C>()?;
-    let output_view = output_device.as_view::<V>();
 
     // Load kernel function using string suffixes
     let cuda_function = ctx.load_function_with_suffixes(
@@ -291,9 +287,10 @@ async fn execute_dict_decimal_typed<
         args.arg(&codes_view)
             .arg(&codes_len_u64)
             .arg(&values_view)
-            .arg(&output_view);
+            .arg(&mut output_slice);
     })?;
 
+    let output_device = CudaDeviceBuffer::new(output_slice);
     Ok(Canonical::Decimal(DecimalArray::new_handle(
         BufferHandle::new_device(Arc::new(output_device)),
         V::DECIMAL_TYPE,
@@ -338,15 +335,13 @@ async fn execute_dict_varbinview(
     let codes_device = ctx.ensure_on_device(codes_buffer).await?;
 
     // Allocate output: one i128 per code.
-    let output_slice = ctx.device_alloc::<i128>(codes_len)?;
-    let output_device = CudaDeviceBuffer::new(output_slice);
+    let mut output_slice = ctx.device_alloc::<i128>(codes_len)?;
 
     // Dispatch by code type, reusing the existing dict_i128_<code_type> kernel.
     // BinaryView is repr(C, align(16)) and 16 bytes — identical layout to i128.
     match_each_integer_ptype!(codes_ptype, |C| {
         let values_view = values_device.cuda_view::<i128>()?;
         let codes_view = codes_device.cuda_view::<C>()?;
-        let output_view = output_device.as_view::<i128>();
 
         let codes_ptype_str = C::PTYPE.to_string();
         let cuda_function = ctx.load_function_with_suffixes("dict", &["i128", &codes_ptype_str])?;
@@ -357,9 +352,11 @@ async fn execute_dict_varbinview(
             args.arg(&codes_view);
             args.arg(&codes_len_u64);
             args.arg(&values_view);
-            args.arg(&output_view);
+            args.arg(&mut output_slice);
         })?;
     });
+
+    let output_device = CudaDeviceBuffer::new(output_slice);
 
     // Output views gathered by the kernel share the values' data buffers.
     // Outlined views reference into these buffers via buffer_index + offset,

--- a/vortex-cuda/src/kernel/encodings/alp.rs
+++ b/vortex-cuda/src/kernel/encodings/alp.rs
@@ -85,9 +85,7 @@ where
 
     // Allocate output rounded up to a full chunk: the fused kernel writes a
     // whole 1024-element chunk per block, and we slice off any padding below.
-    let output_slice = ctx.device_alloc::<A>(array_len.next_multiple_of(1024))?;
-    let output_buf = CudaDeviceBuffer::new(output_slice);
-    let output_view = output_buf.as_view::<A>();
+    let mut output_slice = ctx.device_alloc::<A>(array_len.next_multiple_of(1024))?;
 
     // Patch validity does not need to be scattered: the ALP encoder strips null
     // positions from the exception list, so patches only exist at valid
@@ -116,7 +114,7 @@ where
     let array_len_u64 = array_len as u64;
     ctx.launch_kernel_config(&cuda_function, config, array_len, |args| {
         args.arg(&input_view)
-            .arg(&output_view)
+            .arg(&mut output_slice)
             .arg(&f)
             .arg(&e)
             .arg(&array_len_u64)
@@ -127,6 +125,7 @@ where
     ctx.synchronize_stream()?;
     drop(device_patches);
 
+    let output_buf = CudaDeviceBuffer::new(output_slice);
     let output_handle = BufferHandle::new_device(output_buf.slice_typed::<A>(0..array_len));
     Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
         output_handle,

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -180,9 +180,7 @@ where
     let output_len = offset + len;
 
     // Allocate output buffer
-    let output_slice = ctx.device_alloc::<A>(output_len.next_multiple_of(1024))?;
-    let output_buf = CudaDeviceBuffer::new(output_slice);
-    let output_view = output_buf.as_view::<A>();
+    let mut output_slice = ctx.device_alloc::<A>(output_len.next_multiple_of(1024))?;
 
     let output_width = size_of::<A>() * 8;
     let cuda_function = bitpacked_cuda_kernel(bit_width, output_width, ctx)?;
@@ -203,7 +201,7 @@ where
 
     ctx.launch_kernel_config(&cuda_function, config, output_len, |args| {
         args.arg(&input_view)
-            .arg(&output_view)
+            .arg(&mut output_slice)
             .arg(&reference)
             .arg(&patches_arg);
     })?;
@@ -213,6 +211,7 @@ where
         ctx.synchronize_stream()?;
     }
 
+    let output_buf = CudaDeviceBuffer::new(output_slice);
     let output_handle =
         BufferHandle::new_device(output_buf.slice_typed::<A>(offset..(offset + len)));
 

--- a/vortex-cuda/src/kernel/encodings/date_time_parts.rs
+++ b/vortex-cuda/src/kernel/encodings/date_time_parts.rs
@@ -167,13 +167,11 @@ where
     let subseconds_device = ctx.ensure_on_device(subseconds_buffer).await?;
 
     // Allocate output buffer
-    let output_slice = ctx.device_alloc::<i64>(output_len)?;
-    let output_device = CudaDeviceBuffer::new(output_slice);
+    let mut output_slice = ctx.device_alloc::<i64>(output_len)?;
 
     let days_view = days_device.cuda_view::<DaysT>()?;
     let seconds_view = seconds_device.cuda_view::<SecondsT>()?;
     let subseconds_view = subseconds_device.cuda_view::<SubsecondsT>()?;
-    let output_view = output_device.as_view::<i64>();
 
     let cuda_function = ctx.load_function(
         "date_time_parts",
@@ -187,10 +185,11 @@ where
             .arg(&seconds_view)
             .arg(&subseconds_view)
             .arg(&divisor)
-            .arg(&output_view)
+            .arg(&mut output_slice)
             .arg(&array_len_u64);
     })?;
 
+    let output_device = CudaDeviceBuffer::new(output_slice);
     let output_buffer = BufferHandle::new_device(Arc::new(output_device));
     let output_primitive = PrimitiveArray::from_buffer_handle(output_buffer, PType::I64, validity);
 

--- a/vortex-cuda/src/kernel/encodings/for_.rs
+++ b/vortex-cuda/src/kernel/encodings/for_.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use cudarc::driver::DeviceRepr;
@@ -14,6 +15,7 @@ use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::Slice;
 use vortex::array::arrays::primitive::PrimitiveDataParts;
 use vortex::array::arrays::slice::SliceArraySlotsExt;
+use vortex::array::buffer::BufferHandle;
 use vortex::array::match_each_integer_ptype;
 use vortex::array::match_each_native_simd_ptype;
 use vortex::dtype::NativePType;
@@ -28,6 +30,7 @@ use vortex::error::vortex_ensure;
 use vortex::error::vortex_err;
 
 use crate::CudaBufferExt;
+use crate::CudaDeviceBuffer;
 use crate::executor::CudaArrayExt;
 use crate::executor::CudaExecute;
 use crate::executor::CudaExecutionCtx;
@@ -104,22 +107,24 @@ where
     } = primitive.into_data_parts();
 
     let device_buffer = ctx.ensure_on_device(buffer).await?;
-
-    // Get CUDA view of the buffer
-    let cuda_view = device_buffer.cuda_view::<P>()?;
+    let input_view = device_buffer.cuda_view::<P>()?;
+    let mut output = ctx.device_alloc::<P>(array_len)?;
     let array_len_u64 = array_len as u64;
 
-    // Load kernel function
-    let kernel_ptypes = [P::PTYPE];
-    let cuda_function = ctx.load_function("for", &kernel_ptypes)?;
+    let ptype_suffix = P::PTYPE.to_string();
+    let cuda_function =
+        ctx.load_function_with_suffixes("for", &["in", "out", ptype_suffix.as_str()])?;
 
     ctx.launch_kernel(&cuda_function, array_len, |args| {
-        args.arg(&cuda_view).arg(&reference).arg(&array_len_u64);
+        args.arg(&input_view)
+            .arg(&mut output)
+            .arg(&reference)
+            .arg(&array_len_u64);
     })?;
 
-    // Build result - in-place reuses the same buffer
+    let output = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(output)));
     Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
-        device_buffer,
+        output,
         P::PTYPE,
         validity,
     )))

--- a/vortex-cuda/src/kernel/encodings/for_.rs
+++ b/vortex-cuda/src/kernel/encodings/for_.rs
@@ -31,6 +31,7 @@ use vortex::error::vortex_err;
 
 use crate::CudaBufferExt;
 use crate::CudaDeviceBuffer;
+use crate::device_buffer::with_cuda_view_mut;
 use crate::executor::CudaArrayExt;
 use crate::executor::CudaExecute;
 use crate::executor::CudaExecutionCtx;
@@ -110,7 +111,7 @@ where
     let array_len_u64 = array_len as u64;
 
     let cuda_function = ctx.load_function("for", &[P::PTYPE])?;
-    let (next, launch) = device_buffer.with_cuda_view_mut::<P, _>(|view| {
+    let (next, launch) = with_cuda_view_mut::<P, _>(device_buffer, |view| {
         ctx.launch_kernel(&cuda_function, array_len, |args| {
             args.arg(view).arg(&reference).arg(&array_len_u64);
         })

--- a/vortex-cuda/src/kernel/encodings/for_.rs
+++ b/vortex-cuda/src/kernel/encodings/for_.rs
@@ -106,15 +106,32 @@ where
         buffer, validity, ..
     } = primitive.into_data_parts();
 
-    let device_buffer = ctx.ensure_on_device(buffer).await?;
-    let input_view = device_buffer.cuda_view::<P>()?;
-    let mut output = ctx.device_alloc::<P>(array_len)?;
+    let mut device_buffer = ctx.ensure_on_device(buffer).await?;
     let array_len_u64 = array_len as u64;
 
+    let cuda_function = ctx.load_function("for", &[P::PTYPE])?;
+    let (next, launch) = device_buffer.with_cuda_view_mut::<P, _>(|view| {
+        ctx.launch_kernel(&cuda_function, array_len, |args| {
+            args.arg(view).arg(&reference).arg(&array_len_u64);
+        })
+    })?;
+    device_buffer = next;
+    if let Some(launch) = launch {
+        launch?;
+        return Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
+            device_buffer,
+            P::PTYPE,
+            validity,
+        )));
+    }
+
+    // Preserve aliased inputs by using the out-of-place kernel only when unique mutable access is
+    // unavailable.
+    let input_view = device_buffer.cuda_view::<P>()?;
+    let mut output = ctx.device_alloc::<P>(array_len)?;
     let ptype_suffix = P::PTYPE.to_string();
     let cuda_function =
         ctx.load_function_with_suffixes("for", &["in", "out", ptype_suffix.as_str()])?;
-
     ctx.launch_kernel(&cuda_function, array_len, |args| {
         args.arg(&input_view)
             .arg(&mut output)

--- a/vortex-cuda/src/kernel/encodings/fsst.rs
+++ b/vortex-cuda/src/kernel/encodings/fsst.rs
@@ -235,7 +235,7 @@ where
 
     // The kernel gates store widths on `out_pos % N` relative to the base, so the base must
     // satisfy the widest store (u128 → 16).
-    let output = ctx.device_alloc::<u8>(total_size)?;
+    let mut output = ctx.device_alloc::<u8>(total_size)?;
     let (output_base_ptr, _) = output.device_ptr(ctx.stream());
     assert_eq!(
         output_base_ptr % 16,
@@ -260,7 +260,7 @@ where
             .arg(&output_offsets_view)
             .arg(&validity_view)
             .arg(&validity_bit_offset)
-            .arg(&output)
+            .arg(&mut output)
             .arg(&len_u64);
     })?;
 
@@ -322,8 +322,8 @@ where
 
     // The kernel checks store alignment relative to the base via
     // `out_pos % N`, so the base must satisfy the widest store (u128 → 16).
-    let device_output = ctx.device_alloc::<u8>(total_size)?;
-    let device_views = (total_size <= MAX_BUFFER_LEN)
+    let mut device_output = ctx.device_alloc::<u8>(total_size)?;
+    let mut device_views = (total_size <= MAX_BUFFER_LEN)
         .then(|| ctx.device_alloc::<i128>(num_strings))
         .transpose()?;
     let (output_base_ptr, _) = device_output.device_ptr(ctx.stream());
@@ -350,8 +350,8 @@ where
             .arg(&output_offsets_view)
             .arg(&validity_view)
             .arg(&validity_bit_offset)
-            .arg(&device_output);
-        if let Some(device_views) = device_views.as_ref() {
+            .arg(&mut device_output);
+        if let Some(device_views) = device_views.as_mut() {
             args.arg(device_views);
         } else {
             args.arg(&null_views);

--- a/vortex-cuda/src/kernel/encodings/runend.rs
+++ b/vortex-cuda/src/kernel/encodings/runend.rs
@@ -123,23 +123,24 @@ async fn decode_runend_typed<V: DeviceRepr + NativePType, E: DeviceRepr + Native
     let ends_device = ctx.ensure_on_device(ends_buffer).await?;
     let values_device = ctx.ensure_on_device(values_buffer).await?;
 
-    let output_slice = ctx.device_alloc::<V>(output_len)?;
-    let output_device = CudaDeviceBuffer::new(output_slice);
+    let mut output_slice = ctx.device_alloc::<V>(output_len)?;
 
     let ends_view = ends_device.cuda_view::<E>()?;
     let values_view = values_device.cuda_view::<V>()?;
-    let output_view = output_device.as_view::<V>();
 
     // Load kernel function
     let cuda_function = ctx.load_function("runend", &[value_ptype, E::PTYPE])?;
 
+    let num_runs_u64 = num_runs as u64;
+    let offset_u64 = offset as u64;
+    let output_len_u64 = output_len as u64;
     ctx.launch_kernel(&cuda_function, output_len, |args| {
         args.arg(&ends_view)
-            .arg(&num_runs)
+            .arg(&num_runs_u64)
             .arg(&values_view)
-            .arg(&offset)
-            .arg(&output_len)
-            .arg(&output_view);
+            .arg(&offset_u64)
+            .arg(&output_len_u64)
+            .arg(&mut output_slice);
     })?;
 
     let output_validity = match values_validity {
@@ -155,6 +156,7 @@ async fn decode_runend_typed<V: DeviceRepr + NativePType, E: DeviceRepr + Native
         }
     };
 
+    let output_device = CudaDeviceBuffer::new(output_slice);
     Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
         BufferHandle::new_device(Arc::new(output_device)),
         value_ptype,

--- a/vortex-cuda/src/kernel/encodings/sequence.rs
+++ b/vortex-cuda/src/kernel/encodings/sequence.rs
@@ -63,14 +63,17 @@ async fn execute_typed<T: NativePType + DeviceRepr>(
     nullability: Nullability,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<Canonical> {
-    let buffer = ctx.device_alloc::<T>(len)?;
+    let mut buffer = ctx.device_alloc::<T>(len)?;
 
     let len_u64 = len as u64;
 
     let kernel_func = ctx.load_function("sequence", &[T::PTYPE])?;
 
     ctx.launch_kernel(&kernel_func, len, |args| {
-        args.arg(&buffer).arg(&base).arg(&multiplier).arg(&len_u64);
+        args.arg(&mut buffer)
+            .arg(&base)
+            .arg(&multiplier)
+            .arg(&len_u64);
     })?;
 
     let output_buf = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(buffer)));

--- a/vortex-cuda/src/kernel/encodings/zigzag.rs
+++ b/vortex-cuda/src/kernel/encodings/zigzag.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use cudarc::driver::DeviceRepr;
@@ -11,6 +12,8 @@ use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::primitive::PrimitiveDataParts;
+use vortex::array::buffer::BufferHandle;
+use vortex::array::match_each_signed_integer_ptype;
 use vortex::array::match_each_unsigned_integer_ptype;
 use vortex::dtype::NativePType;
 use vortex::dtype::PType;
@@ -22,6 +25,7 @@ use vortex::error::vortex_ensure;
 use vortex::error::vortex_err;
 
 use crate::CudaBufferExt;
+use crate::CudaDeviceBuffer;
 use crate::executor::CudaArrayExt;
 use crate::executor::CudaExecute;
 use crate::executor::CudaExecutionCtx;
@@ -50,20 +54,26 @@ impl CudaExecute for ZigZagExecutor {
         // The encoded array is unsigned, we decode to signed of the same width.
         let encoded_ptype = array.encoded().dtype().as_ptype();
         let output_ptype = PType::try_from(array.dtype())?;
+        vortex_ensure!(
+            output_ptype == encoded_ptype.to_signed(),
+            "ZigZag output type {output_ptype} must be the signed equivalent of {encoded_ptype}"
+        );
 
         match_each_unsigned_integer_ptype!(encoded_ptype, |U| {
-            decode_zigzag::<U>(array, output_ptype, ctx).await
+            match_each_signed_integer_ptype!(output_ptype, |S| {
+                decode_zigzag::<U, S>(array, ctx).await
+            })
         })
     }
 }
 
-async fn decode_zigzag<U>(
+async fn decode_zigzag<U, S>(
     array: ZigZagArray,
-    output_ptype: PType,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<Canonical>
 where
     U: NativePType + DeviceRepr + Send + Sync + 'static,
+    S: NativePType + DeviceRepr + Send + Sync + 'static,
 {
     let array_len = array.encoded().len();
     vortex_ensure!(array_len > 0, "ZigZag array must not be empty");
@@ -76,22 +86,22 @@ where
     } = primitive.into_data_parts();
 
     let device_buffer = ctx.ensure_on_device(buffer).await?;
-
-    // Get CUDA view of the buffer
-    let cuda_view = device_buffer.cuda_view::<U>()?;
+    let input_view = device_buffer.cuda_view::<U>()?;
+    let mut output = ctx.device_alloc::<S>(array_len)?;
     let array_len_u64 = array_len as u64;
 
-    // Load kernel function
-    let cuda_function = ctx.load_function("zigzag", &[U::PTYPE])?;
+    let ptype_suffix = U::PTYPE.to_string();
+    let cuda_function =
+        ctx.load_function_with_suffixes("zigzag", &["in", "out", ptype_suffix.as_str()])?;
 
     ctx.launch_kernel(&cuda_function, array_len, |args| {
-        args.arg(&cuda_view).arg(&array_len_u64);
+        args.arg(&input_view).arg(&mut output).arg(&array_len_u64);
     })?;
 
-    // Build result - in-place, reinterpret as signed
+    let output = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(output)));
     Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
-        device_buffer,
-        output_ptype,
+        output,
+        S::PTYPE,
         validity,
     )))
 }

--- a/vortex-cuda/src/kernel/encodings/zigzag.rs
+++ b/vortex-cuda/src/kernel/encodings/zigzag.rs
@@ -104,15 +104,15 @@ where
         )));
     }
 
-    // Preserve aliased inputs by using the out-of-place kernel only when unique
-    // mutable access is unavailable.
+    // Preserve aliased inputs by copying into a unique allocation, then use the same in-place
+    // kernel as the zero-copy path.
     let input_view = device_buffer.cuda_view::<U>()?;
-    let mut output = ctx.device_alloc::<S>(array_len)?;
-    let ptype_suffix = U::PTYPE.to_string();
-    let cuda_function =
-        ctx.load_function_with_suffixes("zigzag", &["in", "out", ptype_suffix.as_str()])?;
+    let mut output = ctx.device_alloc::<U>(array_len)?;
+    ctx.stream()
+        .memcpy_dtod(&input_view, &mut output)
+        .map_err(|err| vortex_err!("Failed to copy shared ZigZag input: {err}"))?;
     ctx.launch_kernel(&cuda_function, array_len, |args| {
-        args.arg(&input_view).arg(&mut output).arg(&array_len_u64);
+        args.arg(&mut output).arg(&array_len_u64);
     })?;
 
     let output = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(output)));

--- a/vortex-cuda/src/kernel/encodings/zigzag.rs
+++ b/vortex-cuda/src/kernel/encodings/zigzag.rs
@@ -13,7 +13,6 @@ use vortex::array::Canonical;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::primitive::PrimitiveDataParts;
 use vortex::array::buffer::BufferHandle;
-use vortex::array::match_each_signed_integer_ptype;
 use vortex::array::match_each_unsigned_integer_ptype;
 use vortex::dtype::NativePType;
 use vortex::dtype::PType;
@@ -26,6 +25,7 @@ use vortex::error::vortex_err;
 
 use crate::CudaBufferExt;
 use crate::CudaDeviceBuffer;
+use crate::device_buffer::with_cuda_view_mut;
 use crate::executor::CudaArrayExt;
 use crate::executor::CudaExecute;
 use crate::executor::CudaExecutionCtx;
@@ -60,20 +60,18 @@ impl CudaExecute for ZigZagExecutor {
         );
 
         match_each_unsigned_integer_ptype!(encoded_ptype, |U| {
-            match_each_signed_integer_ptype!(output_ptype, |S| {
-                decode_zigzag::<U, S>(array, ctx).await
-            })
+            decode_zigzag::<U>(array, output_ptype, ctx).await
         })
     }
 }
 
-async fn decode_zigzag<U, S>(
+async fn decode_zigzag<U>(
     array: ZigZagArray,
+    output_ptype: PType,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<Canonical>
 where
     U: NativePType + DeviceRepr + Send + Sync + 'static,
-    S: NativePType + DeviceRepr + Send + Sync + 'static,
 {
     let array_len = array.encoded().len();
     vortex_ensure!(array_len > 0, "ZigZag array must not be empty");
@@ -89,7 +87,7 @@ where
     let array_len_u64 = array_len as u64;
 
     let cuda_function = ctx.load_function("zigzag", &[U::PTYPE])?;
-    let (next, launch) = device_buffer.with_cuda_view_mut::<U, _>(|view| {
+    let (next, launch) = with_cuda_view_mut::<U, _>(device_buffer, |view| {
         ctx.launch_kernel(&cuda_function, array_len, |args| {
             args.arg(view).arg(&array_len_u64);
         })
@@ -99,7 +97,7 @@ where
         launch?;
         return Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
             device_buffer,
-            S::PTYPE,
+            output_ptype,
             validity,
         )));
     }
@@ -118,7 +116,7 @@ where
     let output = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(output)));
     Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
         output,
-        S::PTYPE,
+        output_ptype,
         validity,
     )))
 }

--- a/vortex-cuda/src/kernel/encodings/zigzag.rs
+++ b/vortex-cuda/src/kernel/encodings/zigzag.rs
@@ -85,15 +85,32 @@ where
         buffer, validity, ..
     } = primitive.into_data_parts();
 
-    let device_buffer = ctx.ensure_on_device(buffer).await?;
-    let input_view = device_buffer.cuda_view::<U>()?;
-    let mut output = ctx.device_alloc::<S>(array_len)?;
+    let mut device_buffer = ctx.ensure_on_device(buffer).await?;
     let array_len_u64 = array_len as u64;
 
+    let cuda_function = ctx.load_function("zigzag", &[U::PTYPE])?;
+    let (next, launch) = device_buffer.with_cuda_view_mut::<U, _>(|view| {
+        ctx.launch_kernel(&cuda_function, array_len, |args| {
+            args.arg(view).arg(&array_len_u64);
+        })
+    })?;
+    device_buffer = next;
+    if let Some(launch) = launch {
+        launch?;
+        return Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
+            device_buffer,
+            S::PTYPE,
+            validity,
+        )));
+    }
+
+    // Preserve aliased inputs by using the out-of-place kernel only when unique
+    // mutable access is unavailable.
+    let input_view = device_buffer.cuda_view::<U>()?;
+    let mut output = ctx.device_alloc::<S>(array_len)?;
     let ptype_suffix = U::PTYPE.to_string();
     let cuda_function =
         ctx.load_function_with_suffixes("zigzag", &["in", "out", ptype_suffix.as_str()])?;
-
     ctx.launch_kernel(&cuda_function, array_len, |args| {
         args.arg(&input_view).arg(&mut output).arg(&array_len_u64);
     })?;

--- a/vortex-cuda/src/kernel/filter/mod.rs
+++ b/vortex-cuda/src/kernel/filter/mod.rs
@@ -109,7 +109,7 @@ async fn filter_sized<T: DeviceRepr + CubFilterable + Debug + Send + Sync + 'sta
         T::get_temp_size(len).map_err(|e| vortex_err!("CUB filter_temp_size failed: {}", e))?;
 
     // Allocate device buffers for input, output, mask, and temp space
-    let d_temp = ctx.device_alloc::<u8>(temp_bytes.max(1))?;
+    let mut d_temp = ctx.device_alloc::<u8>(temp_bytes.max(1))?;
     let mut d_output = ctx.device_alloc::<T>(output_len)?;
     let mut d_num_selected = ctx.device_alloc::<i64>(1)?;
     // Get raw pointers for FFI.
@@ -134,7 +134,7 @@ async fn filter_sized<T: DeviceRepr + CubFilterable + Debug + Send + Sync + 'sta
     let d_packed_view = d_packed_cuda.as_view::<u8>();
     let (d_packed_ptr, record_d_packed) = d_packed_view.device_ptr(stream);
 
-    let (d_temp_ptr, record_d_temp) = d_temp.device_ptr(stream);
+    let (d_temp_ptr, record_d_temp) = d_temp.device_ptr_mut(stream);
     let (d_output_ptr, record_d_output) = d_output.device_ptr_mut(stream);
     let (d_num_selected_ptr, record_d_num_selected) = d_num_selected.device_ptr_mut(stream);
 

--- a/vortex-cuda/src/kernel/mod.rs
+++ b/vortex-cuda/src/kernel/mod.rs
@@ -290,7 +290,7 @@ mod tests {
 
         // Allocate output buffer for 3 u32 values
         // SAFETY: Allocating uninitialized memory that will be written by kernel
-        let output = unsafe {
+        let mut output = unsafe {
             stream
                 .alloc::<u32>(3)
                 .expect("failed to allocate output buffer")
@@ -309,7 +309,7 @@ mod tests {
         };
 
         let mut launch_args = stream.launch_builder(&function);
-        launch_args.arg(&output);
+        launch_args.arg(&mut output);
 
         // SAFETY: kernel only writes to output buffer
         unsafe {

--- a/vortex-cuda/src/kernel/patches/mod.rs
+++ b/vortex-cuda/src/kernel/patches/mod.rs
@@ -92,7 +92,10 @@ pub(crate) fn build_gpu_patches(
     }
 }
 
-/// Apply a set of patches to a copy of a [`CudaDeviceBuffer`] holding `ValuesT`.
+/// Apply a set of patches to a [`CudaDeviceBuffer`] holding `ValuesT`.
+///
+/// The target is updated in place when its allocation is uniquely owned. Shared allocations are
+/// copied before patching so aliases remain unchanged.
 ///
 /// Naive scatter kernel. Kept as a reusable fallback for encoders that cannot
 /// use the chunk-based fused patching path (e.g., where `chunk_offsets` are
@@ -104,7 +107,7 @@ pub(crate) async fn execute_patches<
     IndicesT: NativePType + DeviceRepr,
 >(
     patches: Patches,
-    target: CudaDeviceBuffer,
+    mut target: CudaDeviceBuffer,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<CudaDeviceBuffer> {
     let indices = patches.indices().clone();
@@ -152,18 +155,27 @@ pub(crate) async fn execute_patches<
 
     let d_patch_indices = ctx.ensure_on_device(indices_buffer).await?;
     let d_patch_values = ctx.ensure_on_device(values_buffer).await?;
+    let d_patch_indices_view = d_patch_indices.cuda_view::<IndicesT>()?;
+    let d_patch_values_view = d_patch_values.cuda_view::<ValuesT>()?;
+    let kernel_func = ctx.load_function("patches", &[ValuesT::PTYPE, IndicesT::PTYPE])?;
+
+    if let Some(launch) = target.with_view_mut::<ValuesT, _>(|view| {
+        ctx.launch_kernel(&kernel_func, patches_len, |args| {
+            args.arg(view)
+                .arg(&d_patch_indices_view)
+                .arg(&d_patch_values_view)
+                .arg(&patches_len_u64);
+        })
+    }) {
+        launch?;
+        return Ok(target);
+    }
 
     let target_view = target.as_view::<ValuesT>();
     let mut output = ctx.device_alloc::<ValuesT>(target_view.len())?;
     ctx.stream()
         .memcpy_dtod(&target_view, &mut output)
         .map_err(|err| vortex_err!("Failed to copy CUDA patch target: {err}"))?;
-
-    let d_patch_indices_view = d_patch_indices.cuda_view::<IndicesT>()?;
-    let d_patch_values_view = d_patch_values.cuda_view::<ValuesT>()?;
-
-    let kernel_func = ctx.load_function("patches", &[ValuesT::PTYPE, IndicesT::PTYPE])?;
-
     ctx.launch_kernel(&kernel_func, patches_len, |args| {
         args.arg(&mut output)
             .arg(&d_patch_indices_view)
@@ -252,10 +264,15 @@ mod tests {
             .downcast_ref::<CudaDeviceBuffer>()
             .unwrap()
             .clone();
+        let input_ptr = device_buf.offset_ptr();
+        // Release the handle's allocation reference so `execute_patches` can
+        // prove unique ownership and patch the existing device buffer in place.
+        drop(handle);
 
         let patched_buf = execute_patches::<Values, Indices>(patches, device_buf, &mut cuda_ctx)
             .await
             .unwrap();
+        assert_eq!(patched_buf.offset_ptr(), input_ptr);
 
         let gpu_result = PrimitiveArray::from_buffer_handle(
             BufferHandle::new_device(Arc::new(patched_buf)),

--- a/vortex-cuda/src/kernel/patches/mod.rs
+++ b/vortex-cuda/src/kernel/patches/mod.rs
@@ -21,6 +21,7 @@ use vortex::dtype::PType;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
 use vortex::error::vortex_ensure;
+use vortex::error::vortex_err;
 
 use crate::CudaBufferExt;
 use crate::CudaDeviceBuffer;
@@ -91,7 +92,7 @@ pub(crate) fn build_gpu_patches(
     }
 }
 
-/// Apply a set of patches in-place onto a [`CudaDeviceBuffer`] holding `ValuesT`.
+/// Apply a set of patches to a copy of a [`CudaDeviceBuffer`] holding `ValuesT`.
 ///
 /// Naive scatter kernel. Kept as a reusable fallback for encoders that cannot
 /// use the chunk-based fused patching path (e.g., where `chunk_offsets` are
@@ -152,20 +153,25 @@ pub(crate) async fn execute_patches<
     let d_patch_indices = ctx.ensure_on_device(indices_buffer).await?;
     let d_patch_values = ctx.ensure_on_device(values_buffer).await?;
 
-    let d_target_view = target.as_view::<ValuesT>();
+    let target_view = target.as_view::<ValuesT>();
+    let mut output = ctx.device_alloc::<ValuesT>(target_view.len())?;
+    ctx.stream()
+        .memcpy_dtod(&target_view, &mut output)
+        .map_err(|err| vortex_err!("Failed to copy CUDA patch target: {err}"))?;
+
     let d_patch_indices_view = d_patch_indices.cuda_view::<IndicesT>()?;
     let d_patch_values_view = d_patch_values.cuda_view::<ValuesT>()?;
 
     let kernel_func = ctx.load_function("patches", &[ValuesT::PTYPE, IndicesT::PTYPE])?;
 
     ctx.launch_kernel(&kernel_func, patches_len, |args| {
-        args.arg(&d_target_view)
+        args.arg(&mut output)
             .arg(&d_patch_indices_view)
             .arg(&d_patch_values_view)
             .arg(&patches_len_u64);
     })?;
 
-    Ok(target)
+    Ok(CudaDeviceBuffer::new(output))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is required for correct read, write order synchronization and signaling whether operations can be done in parallel or not.
