### PR TITLE
chore: Inline slot index aliases into generated slot constants

### DIFF
--- a/vortex-array/src/arrays/chunked/array.rs
+++ b/vortex-array/src/arrays/chunked/array.rs
@@ -44,9 +44,6 @@ pub struct ChunkedSlots {
     pub chunks: Vec<ArrayRef>,
 }
 
-pub(super) const CHUNK_OFFSETS_SLOT: usize = ChunkedSlots::CHUNK_OFFSETS;
-pub(super) const CHUNKS_OFFSET: usize = ChunkedSlots::CHUNKS_OFFSET;
-
 #[derive(Clone, Debug)]
 pub struct ChunkedData {
     pub(super) chunk_offsets: Vec<usize>,
@@ -62,24 +59,27 @@ impl Display for ChunkedData {
 
 pub trait ChunkedArrayExt: TypedArrayRef<Chunked> {
     fn chunk_offsets_array(&self) -> &ArrayRef {
-        self.as_ref().slots()[CHUNK_OFFSETS_SLOT]
+        self.as_ref().slots()[ChunkedSlots::CHUNK_OFFSETS]
             .as_ref()
             .vortex_expect("validated chunk offsets slot")
     }
 
     fn nchunks(&self) -> usize {
-        self.as_ref().slots().len().saturating_sub(CHUNKS_OFFSET)
+        self.as_ref()
+            .slots()
+            .len()
+            .saturating_sub(ChunkedSlots::CHUNKS_OFFSET)
     }
 
     fn chunk(&self, idx: usize) -> &ArrayRef {
-        self.as_ref().slots()[CHUNKS_OFFSET + idx]
+        self.as_ref().slots()[ChunkedSlots::CHUNKS_OFFSET + idx]
             .as_ref()
             .vortex_expect("validated chunk slot")
     }
 
     fn iter_chunks<'a>(&'a self) -> Box<dyn Iterator<Item = &'a ArrayRef> + 'a> {
         Box::new(
-            self.as_ref().slots()[CHUNKS_OFFSET..]
+            self.as_ref().slots()[ChunkedSlots::CHUNKS_OFFSET..]
                 .iter()
                 .map(|slot| slot.as_ref().vortex_expect("validated chunk slot")),
         )
@@ -133,7 +133,7 @@ impl ChunkedData {
     pub(super) fn new(chunk_offsets: Vec<usize>) -> Self {
         Self {
             chunk_offsets,
-            next_builder_slot: CHUNKS_OFFSET,
+            next_builder_slot: ChunkedSlots::CHUNKS_OFFSET,
         }
     }
 

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -32,8 +32,7 @@ use crate::array::with_empty_buffers;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::chunked::ChunkedArrayExt;
 use crate::arrays::chunked::ChunkedData;
-use crate::arrays::chunked::array::CHUNK_OFFSETS_SLOT;
-use crate::arrays::chunked::array::CHUNKS_OFFSET;
+use crate::arrays::chunked::array::ChunkedSlots;
 use crate::arrays::chunked::compute::rules::PARENT_RULES;
 use crate::arrays::chunked::vtable::canonical::_canonicalize;
 use crate::buffer::BufferHandle;
@@ -88,7 +87,7 @@ impl VTable for Chunked {
             !slots.is_empty(),
             "ChunkedArray must have at least a chunk offsets slot"
         );
-        let chunk_offsets = slots[CHUNK_OFFSETS_SLOT]
+        let chunk_offsets = slots[ChunkedSlots::CHUNK_OFFSETS]
             .as_ref()
             .vortex_expect("validated chunk offsets slot");
         vortex_ensure!(
@@ -103,10 +102,10 @@ impl VTable for Chunked {
             data.chunk_offsets.len()
         );
         vortex_ensure!(
-            data.chunk_offsets.len() == slots.len() - CHUNKS_OFFSET + 1,
+            data.chunk_offsets.len() == slots.len() - ChunkedSlots::CHUNKS_OFFSET + 1,
             "ChunkedArray chunk offsets length {} does not match {} chunks",
             data.chunk_offsets.len(),
-            slots.len() - CHUNKS_OFFSET
+            slots.len() - ChunkedSlots::CHUNKS_OFFSET
         );
         vortex_ensure!(
             data.chunk_offsets
@@ -125,7 +124,7 @@ impl VTable for Chunked {
             .tuple_windows()
             .enumerate()
         {
-            let chunk = slots[CHUNKS_OFFSET + idx]
+            let chunk = slots[ChunkedSlots::CHUNKS_OFFSET + idx]
                 .as_ref()
                 .vortex_expect("validated chunk slot");
             vortex_ensure!(
@@ -193,7 +192,7 @@ impl VTable for Chunked {
 
         let nchunks = children.len() - 1;
         let chunk_offsets = children.get(
-            CHUNK_OFFSETS_SLOT,
+            ChunkedSlots::CHUNK_OFFSETS,
             &DType::Primitive(PType::U64, Nullability::NonNullable),
             nchunks + 1,
         )?;
@@ -219,7 +218,11 @@ impl VTable for Chunked {
             .enumerate()
         {
             let chunk_len = end - start;
-            slots.push(Some(children.get(idx + CHUNKS_OFFSET, dtype, chunk_len)?));
+            slots.push(Some(children.get(
+                idx + ChunkedSlots::CHUNKS_OFFSET,
+                dtype,
+                chunk_len,
+            )?));
         }
 
         Ok(ArrayParts::new(
@@ -244,8 +247,8 @@ impl VTable for Chunked {
 
     fn slot_name(_array: ArrayView<'_, Self>, idx: usize) -> String {
         match idx {
-            CHUNK_OFFSETS_SLOT => "chunk_offsets".to_string(),
-            n => format!("chunks[{}]", n - CHUNKS_OFFSET),
+            ChunkedSlots::CHUNK_OFFSETS => "chunk_offsets".to_string(),
+            n => format!("chunks[{}]", n - ChunkedSlots::CHUNKS_OFFSET),
         }
     }
 
@@ -265,7 +268,7 @@ impl VTable for Chunked {
             }
             // For all other types, use the builder path via AppendChild.
             _ => {
-                let slot_idx = array.next_builder_slot.max(CHUNKS_OFFSET);
+                let slot_idx = array.next_builder_slot.max(ChunkedSlots::CHUNKS_OFFSET);
                 if slot_idx < array.slots().len() {
                     Ok(ExecutionResult::append_child(
                         array.with_next_builder_slot(slot_idx + 1),

--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -39,11 +39,6 @@ pub struct StructSlots {
     pub fields: Vec<ArrayRef>,
 }
 
-/// The validity bitmap indicating which struct elements are non-null.
-pub(super) const VALIDITY_SLOT: usize = StructSlots::VALIDITY;
-/// The offset at which the struct field arrays begin in the slots vector.
-pub(super) const FIELDS_OFFSET: usize = StructSlots::FIELDS_OFFSET;
-
 /// A struct array that stores multiple named fields as columns, similar to a database row.
 ///
 /// This mirrors the Apache Arrow Struct array encoding and provides a columnar representation
@@ -199,13 +194,13 @@ pub trait StructArrayExt: TypedArrayRef<Struct> {
 
     fn struct_validity(&self) -> Validity {
         child_to_validity(
-            self.as_ref().slots()[VALIDITY_SLOT].as_ref(),
+            self.as_ref().slots()[StructSlots::VALIDITY].as_ref(),
             self.nullability(),
         )
     }
 
     fn iter_unmasked_fields(&self) -> impl Iterator<Item = &ArrayRef> + '_ {
-        self.as_ref().slots()[FIELDS_OFFSET..]
+        self.as_ref().slots()[StructSlots::FIELDS_OFFSET..]
             .iter()
             .map(|s| s.as_ref().vortex_expect("StructArray field slot"))
     }
@@ -215,7 +210,7 @@ pub trait StructArrayExt: TypedArrayRef<Struct> {
     }
 
     fn unmasked_field(&self, idx: usize) -> &ArrayRef {
-        self.as_ref().slots()[FIELDS_OFFSET + idx]
+        self.as_ref().slots()[StructSlots::FIELDS_OFFSET + idx]
             .as_ref()
             .vortex_expect("StructArray field slot")
     }
@@ -405,7 +400,7 @@ impl Array<Struct> {
 
     // TODO(ngates): remove this... it doesn't help to consume self.
     pub fn into_data_parts(self) -> StructDataParts {
-        let fields: Vec<ArrayRef> = self.slots()[FIELDS_OFFSET..]
+        let fields: Vec<ArrayRef> = self.slots()[StructSlots::FIELDS_OFFSET..]
             .iter()
             .map(|s| s.as_ref().vortex_expect("StructArray field slot").clone())
             .collect();
@@ -424,7 +419,7 @@ impl Array<Struct> {
 
         let position = struct_dtype.find(name.as_ref())?;
 
-        let slot_position = FIELDS_OFFSET + position;
+        let slot_position = StructSlots::FIELDS_OFFSET + position;
         let field = self.slots()[slot_position]
             .as_ref()
             .vortex_expect("StructArray field slot")
@@ -460,7 +455,7 @@ impl Array<Struct> {
         let types = struct_dtype.fields().chain(once(array.dtype().clone()));
         let new_fields = StructFields::new(names.collect(), types.collect());
 
-        let children: Vec<ArrayRef> = self.slots()[FIELDS_OFFSET..]
+        let children: Vec<ArrayRef> = self.slots()[StructSlots::FIELDS_OFFSET..]
             .iter()
             .map(|s| s.as_ref().vortex_expect("StructArray field slot").clone())
             .chain(once(array))

--- a/vortex-array/src/arrays/struct_/vtable/mod.rs
+++ b/vortex-array/src/arrays/struct_/vtable/mod.rs
@@ -18,8 +18,7 @@ use crate::array::EmptyArrayData;
 use crate::array::VTable;
 use crate::array::child_to_validity;
 use crate::array::with_empty_buffers;
-use crate::arrays::struct_::array::FIELDS_OFFSET;
-use crate::arrays::struct_::array::VALIDITY_SLOT;
+use crate::arrays::struct_::array::StructSlots;
 use crate::arrays::struct_::array::make_struct_slots;
 use crate::arrays::struct_::compute::rules::PARENT_RULES;
 use crate::buffer::BufferHandle;
@@ -77,7 +76,7 @@ impl VTable for Struct {
             );
         }
 
-        let validity = child_to_validity(slots[VALIDITY_SLOT].as_ref(), *nullability);
+        let validity = child_to_validity(slots[StructSlots::VALIDITY].as_ref(), *nullability);
         if let Some(validity_len) = validity.maybe_len()
             && validity_len != len
         {
@@ -88,7 +87,7 @@ impl VTable for Struct {
             );
         }
 
-        let field_slots = &slots[FIELDS_OFFSET..];
+        let field_slots = &slots[StructSlots::FIELDS_OFFSET..];
         if field_slots.is_empty() {
             return Ok(());
         }
@@ -188,10 +187,10 @@ impl VTable for Struct {
     }
 
     fn slot_name(array: ArrayView<'_, Self>, idx: usize) -> String {
-        if idx == VALIDITY_SLOT {
+        if idx == StructSlots::VALIDITY {
             "validity".to_string()
         } else {
-            array.dtype().as_struct_fields().names()[idx - FIELDS_OFFSET].to_string()
+            array.dtype().as_struct_fields().names()[idx - StructSlots::FIELDS_OFFSET].to_string()
         }
     }
 

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -796,7 +796,12 @@ macro_rules! require_opt_child {
 /// Like [`require_opt_child!`], `$parent` is moved (not cloned) into the early-return path.
 ///
 /// ```ignore
-/// require_patches!(array, PATCH_INDICES_SLOT, PATCH_VALUES_SLOT, PATCH_CHUNK_OFFSETS_SLOT);
+/// require_patches!(
+///     array,
+///     MySlots::PATCH_INDICES,
+///     MySlots::PATCH_VALUES,
+///     MySlots::PATCH_CHUNK_OFFSETS
+/// );
 /// ```
 #[macro_export]
 macro_rules! require_patches {
@@ -826,7 +831,7 @@ macro_rules! require_patches {
 /// Like [`require_opt_child!`], `$parent` is moved (not cloned) into the early-return path.
 ///
 /// ```ignore
-/// require_validity!(array, VALIDITY_SLOT);
+/// require_validity!(array, MySlots::VALIDITY);
 /// ```
 #[macro_export]
 macro_rules! require_validity {


### PR DESCRIPTION
Inline trivial constants.

## break

Use the new constant values