### PR TITLE
Pin every `#[array_slots]` field to an explicit slot index

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -200,12 +200,16 @@ impl VTable for ALP {
 #[array_slots(ALP)]
 pub struct ALPSlots {
     /// The ALP-encoded values array.
+    #[slot(0)]
     pub encoded: ArrayRef,
     /// The indices of exception values that could not be ALP-encoded.
+    #[slot(1)]
     pub patch_indices: Option<ArrayRef>,
     /// The exception values that could not be ALP-encoded.
+    #[slot(2)]
     pub patch_values: Option<ArrayRef>,
     /// Chunk offsets for the patch indices/values.
+    #[slot(3)]
     pub patch_chunk_offsets: Option<ArrayRef>,
 }
 

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -313,14 +313,19 @@ impl VTable for ALPRD {
 #[array_slots(ALPRD)]
 pub struct ALPRDSlots {
     /// The left (most significant) parts of the real-double encoded values.
+    #[slot(0)]
     pub left_parts: ArrayRef,
     /// The right (least significant) parts of the real-double encoded values.
+    #[slot(1)]
     pub right_parts: ArrayRef,
     /// The indices of left-parts exception values that could not be dictionary-encoded.
+    #[slot(2)]
     pub patch_indices: Option<ArrayRef>,
     /// The exception values for left-parts that could not be dictionary-encoded.
+    #[slot(3)]
     pub patch_values: Option<ArrayRef>,
     /// Chunk offsets for the left-parts patch indices/values.
+    #[slot(4)]
     pub patch_chunk_offsets: Option<ArrayRef>,
 }
 

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -179,6 +179,7 @@ impl VTable for ByteBool {
 #[array_slots(ByteBool)]
 pub struct ByteBoolSlots {
     /// The validity bitmap indicating which elements are non-null.
+    #[slot(0)]
     pub validity: Option<ArrayRef>,
 }
 

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -212,10 +212,13 @@ impl VTable for DateTimeParts {
 #[array_slots(DateTimeParts)]
 pub struct DateTimePartsSlots {
     /// The days component of the datetime, stored as an integer array.
+    #[slot(0)]
     pub days: ArrayRef,
     /// The seconds component of the datetime (within the day).
+    #[slot(1)]
     pub seconds: ArrayRef,
     /// The sub-second component of the datetime.
+    #[slot(2)]
     pub subseconds: ArrayRef,
 }
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -175,6 +175,7 @@ impl VTable for DecimalByteParts {
 #[array_slots(DecimalByteParts)]
 pub struct DecimalBytePartsSlots {
     /// The most significant parts of the decimal values.
+    #[slot(0)]
     pub msp: ArrayRef,
 }
 

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -36,12 +36,16 @@ use crate::unpack_iter::BitUnpackedChunks;
 #[array_slots(crate::BitPacked)]
 pub struct BitPackedSlots {
     /// The indices of exception values that don't fit in the bit-packed representation.
+    #[slot(0)]
     pub patch_indices: Option<ArrayRef>,
     /// The exception values that don't fit in the bit-packed representation.
+    #[slot(1)]
     pub patch_values: Option<ArrayRef>,
     /// Chunk offsets for the patch indices/values.
+    #[slot(2)]
     pub patch_chunk_offsets: Option<ArrayRef>,
     /// The validity bitmap indicating which elements are non-null.
+    #[slot(3)]
     pub validity_child: Option<ArrayRef>,
 }
 

--- a/encodings/fastlanes/src/delta/array/mod.rs
+++ b/encodings/fastlanes/src/delta/array/mod.rs
@@ -19,8 +19,10 @@ pub mod delta_decompress;
 #[array_slots(crate::Delta)]
 pub struct DeltaSlots {
     /// The base values for each block of deltas.
+    #[slot(0)]
     pub bases: ArrayRef,
     /// The delta-encoded values relative to the base values.
+    #[slot(1)]
     pub deltas: ArrayRef,
 }
 

--- a/encodings/fastlanes/src/for/array/mod.rs
+++ b/encodings/fastlanes/src/for/array/mod.rs
@@ -18,6 +18,7 @@ pub mod for_decompress;
 #[array_slots(crate::FoR)]
 pub struct FoRSlots {
     /// The encoded array with the frame-of-reference (minimum value) subtracted.
+    #[slot(0)]
     pub encoded: ArrayRef,
 }
 

--- a/encodings/fastlanes/src/rle/array/mod.rs
+++ b/encodings/fastlanes/src/rle/array/mod.rs
@@ -17,8 +17,10 @@ pub mod rle_decompress;
 #[array_slots(crate::RLE)]
 pub struct RLESlots {
     /// Run values in the dictionary.
+    #[slot(0)]
     pub values: ArrayRef,
     /// Chunk-local indices from all chunks. The start of each chunk is looked up in `values_idx_offsets`.
+    #[slot(1)]
     pub indices: ArrayRef,
     /// Index start positions of each value chunk.
     ///
@@ -29,6 +31,7 @@ pub struct RLESlots {
     /// let values = [10, 20, 30, 40];           // Global values array
     /// let values_idx_offsets = [0, 2];         // Chunk 0 starts at index 0, Chunk 1 starts at index 2
     /// ```
+    #[slot(2)]
     pub values_idx_offsets: ArrayRef,
 }
 

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -364,10 +364,13 @@ impl VTable for FSST {
 #[array_slots(FSST)]
 pub struct FSSTSlots {
     /// Lengths of the original values before compression, can be compressed.
+    #[slot(0)]
     pub uncompressed_lengths: ArrayRef,
     /// The offsets array for the FSST-compressed codes.
+    #[slot(1)]
     pub codes_offsets: ArrayRef,
     /// The validity bitmap for the compressed codes.
+    #[slot(2)]
     pub codes_validity: Option<ArrayRef>,
 }
 

--- a/encodings/onpair/src/array.rs
+++ b/encodings/onpair/src/array.rs
@@ -105,17 +105,22 @@ impl OnPairMetadata {
 pub struct OnPairSlots {
     /// Primitive integer dictionary offsets, length `dict_size + 1`. The
     /// cascading compressor may re-encode this child independently.
+    #[slot(0)]
     pub dict_offsets: ArrayRef,
     /// Primitive integer token codes. Downstream integer compression may
     /// narrow or bit-pack this child independently of the OnPair metadata.
+    #[slot(1)]
     pub codes: ArrayRef,
     /// Primitive integer row offsets into `codes`, length `num_rows + 1`. The
     /// cascading compressor may re-encode this child independently.
+    #[slot(2)]
     pub codes_offsets: ArrayRef,
     /// Integer decoded-length child, length `num_rows`. Used to size the
     /// canonical output buffer.
+    #[slot(3)]
     pub uncompressed_lengths: ArrayRef,
     /// Optional validity child for the outer string column.
+    #[slot(4)]
     pub validity: Option<ArrayRef>,
 }
 

--- a/encodings/parquet-variant/src/array.rs
+++ b/encodings/parquet-variant/src/array.rs
@@ -53,12 +53,16 @@ use crate::ParquetVariantArray;
 #[array_slots(ParquetVariant)]
 pub struct ParquetVariantSlots {
     /// The validity bitmap indicating which elements are non-null.
+    #[slot(0)]
     pub validity: Option<ArrayRef>,
     /// The metadata array for the Parquet variant values.
+    #[slot(1)]
     pub metadata: ArrayRef,
     /// The value array containing the Parquet variant data.
+    #[slot(2)]
     pub value: Option<ArrayRef>,
     /// The typed value array for strongly-typed Parquet variant data.
+    #[slot(3)]
     pub typed_value: Option<ArrayRef>,
 }
 

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -345,6 +345,7 @@ impl Pco {
 #[array_slots(Pco)]
 pub struct PcoSlots {
     /// The validity bitmap indicating which elements are non-null.
+    #[slot(0)]
     pub validity: Option<ArrayRef>,
 }
 

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -184,8 +184,10 @@ impl VTable for RunEnd {
 #[array_slots(RunEnd)]
 pub struct RunEndSlots {
     /// The run-end positions marking where each run terminates.
+    #[slot(0)]
     pub ends: ArrayRef,
     /// The values for each run.
+    #[slot(1)]
     pub values: ArrayRef,
 }
 

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -117,8 +117,11 @@ pub type SparseArray = Array<Sparse>;
 
 #[vortex_array::array_slots(Sparse)]
 pub struct SparseSlots {
+    #[slot(0)]
     pub patch_indices: ArrayRef,
+    #[slot(1)]
     pub patch_values: ArrayRef,
+    #[slot(2)]
     pub patch_chunk_offsets: Option<ArrayRef>,
 }
 

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -164,6 +164,7 @@ impl ArrayEq for ZigZagData {
 #[array_slots(ZigZag)]
 pub struct ZigZagSlots {
     /// The zigzag-encoded values (signed integers mapped to unsigned).
+    #[slot(0)]
     pub encoded: ArrayRef,
 }
 

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -405,6 +405,7 @@ impl Zstd {
 #[array_slots(Zstd)]
 pub struct ZstdSlots {
     /// The validity bitmap indicating which elements are non-null.
+    #[slot(0)]
     pub validity: Option<ArrayRef>,
 }
 

--- a/vortex-array-macros/src/lib.rs
+++ b/vortex-array-macros/src/lib.rs
@@ -4,33 +4,49 @@
 //! Proc macros for `vortex-array`.
 
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use quote::format_ident;
 use quote::quote;
 use syn::Field;
 use syn::Fields;
 use syn::Ident;
 use syn::ItemStruct;
+use syn::LitInt;
 use syn::Path;
+use syn::Token;
 use syn::Type;
 use syn::Visibility;
+use syn::parse::Parse;
+use syn::parse::ParseStream;
 use syn::parse_macro_input;
 use syn::spanned::Spanned;
+
+/// Name of the per-field attribute that pins a field to a slot index.
+const SLOT_ATTR: &str = "slot";
 
 /// Generate slot index constants, a borrowed view struct, and a typed ext trait
 /// from a slot struct definition.
 ///
-/// Fields must be `ArrayRef` (required slot), `Option<ArrayRef>` (optional slot), or —
-/// for the final field only — `Vec<ArrayRef>` (variadic tail of required slots).
-/// Field declaration order determines slot indices.
+/// Fields must be `ArrayRef` (required slot), `Option<ArrayRef>` (optional slot), or
+/// `Vec<ArrayRef>` (variadic tail of required slots).
+///
+/// Every field must carry a `#[slot(..)]` attribute naming the exact slot index it maps
+/// to. The attribute — not the declaration order — defines the storage layout, so fields
+/// may be reordered, grouped, or documented in any order without changing the slot
+/// indices an array is built from or read back with.
 ///
 /// # Example
 ///
 /// ```ignore
 /// #[array_slots(Patched)]
 /// pub struct PatchedSlots {
+///     #[slot(0)]
 ///     pub inner: ArrayRef,
+///     #[slot(1)]
 ///     pub lane_offsets: ArrayRef,
+///     #[slot(2)]
 ///     pub patch_indices: ArrayRef,
+///     #[slot(3)]
 ///     pub patch_values: ArrayRef,
 /// }
 /// ```
@@ -40,7 +56,7 @@ use syn::spanned::Spanned;
 /// Given the above, the macro generates:
 ///
 /// ```ignore
-/// // --- The original struct is preserved as-is ---
+/// // --- The original struct, minus the consumed `#[slot(..)]` attributes ---
 /// pub struct PatchedSlots { ... }
 ///
 /// // --- Slot index constants and conversion methods on the struct ---
@@ -84,6 +100,16 @@ use syn::spanned::Spanned;
 /// impl<T: TypedArrayRef<Patched>> PatchedArraySlotsExt for T {}
 /// ```
 ///
+/// # Slot index annotations
+///
+/// - Fixed fields use `#[slot(N)]`, where `N` is the exact index of the slot.
+/// - A variadic tail uses `#[slot(N..)]`, where `N` is the index its first slot occupies.
+///
+/// The annotations are validated at compile time: the fixed indices must cover
+/// `0..FIXED_COUNT` exactly — no duplicates and no gaps — and a variadic tail must start
+/// immediately after the last fixed slot. A field without a `#[slot(..)]` attribute is a
+/// compile error, so the layout can never silently fall back to declaration order.
+///
 /// # Required vs optional slots
 ///
 /// - `ArrayRef` — the slot must be present. `from_slots()` panics if `None`.
@@ -98,15 +124,17 @@ use syn::spanned::Spanned;
 ///
 /// # Variadic tail slots
 ///
-/// The final field may be `Vec<ArrayRef>`, declaring that every slot from that
-/// position onward belongs to a homogeneous, variable-length run of required slots.
-/// This supports encodings like `Chunked` (`[chunk_offsets, chunks...]`),
-/// `Struct` (`[validity?, fields...]`), and `Union` (`[type_ids, children...]`).
+/// One field may be `Vec<ArrayRef>`, declaring that every slot from its index onward
+/// belongs to a homogeneous, variable-length run of required slots. This supports
+/// encodings like `Chunked` (`[chunk_offsets, chunks...]`), `Struct`
+/// (`[validity?, fields...]`), and `Union` (`[type_ids, children...]`).
 ///
 /// ```ignore
 /// #[array_slots(Chunked)]
 /// pub struct ChunkedSlots {
+///     #[slot(0)]
 ///     pub chunk_offsets: ArrayRef,
+///     #[slot(1..)]
 ///     pub chunks: Vec<ArrayRef>,
 /// }
 /// ```
@@ -186,43 +214,31 @@ fn expand_array_slots(
         .map(|segment| &segment.ident)
         .ok_or_else(|| syn::Error::new(encoding.span(), "missing encoding type"))?;
 
-    let struct_ident = &item_struct.ident;
-    let struct_vis = &item_struct.vis;
-    let view_ident = format_ident!("{}View", ident_name(struct_ident));
+    let struct_ident = item_struct.ident.clone();
+    let struct_vis = item_struct.vis.clone();
+    let view_ident = format_ident!("{}View", ident_name(&struct_ident));
     let ext_ident = format_ident!("{}ArraySlotsExt", ident_name(encoding_ident));
 
     let field_specs = fields
         .iter()
-        .enumerate()
-        .map(|(index, field)| SlotField::new(field, index, struct_ident))
+        .map(|field| SlotField::new(field, &struct_ident))
         .collect::<syn::Result<Vec<_>>>()?;
 
-    // A variadic tail is only permitted as the final field, at most once.
-    for spec in field_specs.iter().rev().skip(1) {
-        if matches!(spec.slot_type, SlotFieldType::VariadicTail) {
-            return Err(syn::Error::new(
-                spec.field_ident.span(),
-                "#[array_slots] only the final field may be a variadic Vec<ArrayRef> tail",
-            ));
-        }
-    }
+    // The `#[slot(..)]` annotations, not the declaration order, define storage order.
+    let (fixed_specs, tail_spec) = partition_by_slot_index(&field_specs)?;
 
-    let (fixed_specs, tail_spec) = match field_specs.split_last() {
-        Some((last, rest)) if matches!(last.slot_type, SlotFieldType::VariadicTail) => {
-            (rest, Some(last))
-        }
-        _ => (field_specs.as_slice(), None),
-    };
-
-    let idx_consts = fixed_specs.iter().map(SlotField::idx_const);
+    let idx_consts = fixed_specs.iter().copied().map(SlotField::idx_const);
     let view_fields = field_specs.iter().map(SlotField::view_field);
     let view_from_slots = field_specs.iter().map(SlotField::view_from_slots);
     let view_to_owned = field_specs.iter().map(SlotField::view_to_owned);
     let ext_methods = field_specs.iter().map(SlotField::ext_method);
 
-    let counts = gen_counts(fixed_specs, tail_spec);
-    let from_slots = gen_from_slots(fixed_specs, tail_spec);
-    let into_slots = gen_into_slots(fixed_specs, tail_spec);
+    let counts = gen_counts(&fixed_specs, tail_spec);
+    let from_slots = gen_from_slots(&fixed_specs, tail_spec);
+    let into_slots = gen_into_slots(&fixed_specs, tail_spec);
+
+    // `#[slot(..)]` is inert helper syntax consumed here; strip it from the emitted struct.
+    let item_struct = strip_slot_attrs(item_struct);
 
     Ok(quote! {
         #item_struct
@@ -275,8 +291,93 @@ fn expand_array_slots(
     })
 }
 
+/// Split the fields into the fixed slots (sorted by slot index) and the optional variadic
+/// tail, validating that the annotated indices describe a complete, gap-free layout.
+fn partition_by_slot_index(
+    field_specs: &[SlotField],
+) -> syn::Result<(Vec<&SlotField>, Option<&SlotField>)> {
+    let mut fixed_specs = Vec::with_capacity(field_specs.len());
+    let mut tail_spec: Option<&SlotField> = None;
+
+    for spec in field_specs {
+        if matches!(spec.slot_type, SlotFieldType::VariadicTail) {
+            if let Some(previous) = tail_spec {
+                return Err(syn::Error::new(
+                    spec.index_span,
+                    format!(
+                        "#[array_slots] allows at most one variadic tail, but `{}` is already \
+                         declared as one",
+                        previous.slot_name
+                    ),
+                ));
+            }
+            tail_spec = Some(spec);
+        } else {
+            fixed_specs.push(spec);
+        }
+    }
+
+    fixed_specs.sort_by_key(|spec| spec.index);
+
+    for (expected, spec) in fixed_specs.iter().enumerate() {
+        if spec.index == expected {
+            continue;
+        }
+        // `fixed_specs` is sorted, so a smaller index than expected means the previous
+        // field claimed the same slot, and a larger one means nothing claimed `expected`.
+        return Err(if spec.index < expected {
+            syn::Error::new(
+                spec.index_span,
+                format!(
+                    "#[array_slots] slot index {} is claimed by both `{}` and `{}`",
+                    spec.index,
+                    fixed_specs[expected - 1].slot_name,
+                    spec.slot_name
+                ),
+            )
+        } else {
+            syn::Error::new(
+                spec.index_span,
+                format!(
+                    "#[array_slots] no field claims slot index {expected}; fixed slot indices \
+                     must cover 0..{} without gaps",
+                    fixed_specs.len()
+                ),
+            )
+        });
+    }
+
+    if let Some(tail) = tail_spec
+        && tail.index != fixed_specs.len()
+    {
+        return Err(syn::Error::new(
+            tail.index_span,
+            format!(
+                "#[array_slots] variadic tail `{}` must start at slot index {}, immediately after \
+                 the {} fixed slot(s), but is annotated `#[slot({}..)]`",
+                tail.slot_name,
+                fixed_specs.len(),
+                fixed_specs.len(),
+                tail.index
+            ),
+        ));
+    }
+
+    Ok((fixed_specs, tail_spec))
+}
+
+/// Remove the inert `#[slot(..)]` helper attributes so the struct can be re-emitted.
+fn strip_slot_attrs(mut item_struct: ItemStruct) -> ItemStruct {
+    if let Fields::Named(fields) = &mut item_struct.fields {
+        for field in &mut fields.named {
+            field.attrs.retain(|attr| !attr.path().is_ident(SLOT_ATTR));
+        }
+    }
+    item_struct
+}
+
 fn gen_counts(
-    fixed_specs: &[SlotField],
+    fixed_specs: &[&SlotField],
     tail_spec: Option<&SlotField>,
 ) -> proc_macro2::TokenStream {
     let names = fixed_specs.iter().map(|field| field.slot_name.as_str());
@@ -317,10 +418,10 @@ fn gen_counts(
 }
 
 fn gen_from_slots(
-    fixed_specs: &[SlotField],
+    fixed_specs: &[&SlotField],
     tail_spec: Option<&SlotField>,
 ) -> proc_macro2::TokenStream {
-    let owned_from_slots = fixed_specs.iter().map(SlotField::owned_from_slots);
+    let owned_from_slots = fixed_specs.iter().copied().map(SlotField::owned_from_slots);
 
     match tail_spec {
         None => quote! {
@@ -354,10 +455,10 @@ fn gen_from_slots(
 }
 
 fn gen_into_slots(
-    fixed_specs: &[SlotField],
+    fixed_specs: &[&SlotField],
     tail_spec: Option<&SlotField>,
 ) -> proc_macro2::TokenStream {
-    let fixed_into_slots = fixed_specs.iter().map(SlotField::storage_slot);
+    let fixed_into_slots = fixed_specs.iter().copied().map(SlotField::storage_slot);
 
     match tail_spec {
         None => quote! {
@@ -386,18 +487,45 @@ struct SlotField {
     slot_name: String,
     slot_type: SlotFieldType,
     index: usize,
+    index_span: Span,
     expect_message: syn::LitStr,
     struct_ident: Ident,
 }
 
 impl SlotField {
-    fn new(field: &Field, index: usize, struct_ident: &Ident) -> syn::Result<Self> {
+    fn new(field: &Field, struct_ident: &Ident) -> syn::Result<Self> {
         let field_ident = field
             .ident
             .clone()
             .ok_or_else(|| syn::Error::new(field.span(), "slot fields must be named"))?;
         let field_name = ident_name(&field_ident);
         let slot_type = SlotFieldType::from_syn_type(&field.ty)?;
+        let annotation = SlotIndexAttr::from_field(field, &field_name)?;
+
+        match (slot_type, annotation.variadic) {
+            (SlotFieldType::VariadicTail, false) => {
+                return Err(syn::Error::new(
+                    annotation.span,
+                    format!(
+                        "`{field_name}` is a variadic `Vec<ArrayRef>` tail, so it must be \
+                         annotated `#[slot({}..)]`",
+                        annotation.index
+                    ),
+                ));
+            }
+            (SlotFieldType::Required | SlotFieldType::Optional, true) => {
+                return Err(syn::Error::new(
+                    annotation.span,
+                    format!(
+                        "`#[slot(N..)]` declares a variadic `Vec<ArrayRef>` tail; `{field_name}` \
+                         occupies a single slot, so annotate it `#[slot({})]`",
+                        annotation.index
+                    ),
+                ));
+            }
+            _ => {}
+        }
+
         let const_ident = match slot_type {
             SlotFieldType::VariadicTail => {
                 format_ident!("{}_OFFSET", to_screaming_snake_case(&field_name))
@@ -415,7 +543,8 @@ impl SlotField {
             const_ident,
             slot_name: field_name,
             slot_type,
-            index,
+            index: annotation.index,
+            index_span: annotation.span,
             expect_message,
             struct_ident: struct_ident.clone(),
         })
@@ -556,6 +685,63 @@ impl SlotField {
     }
 }
 
+/// A parsed `#[slot(N)]` or `#[slot(N..)]` field annotation.
+struct SlotIndexAttr {
+    index: usize,
+    /// Whether the trailing `..` was present, marking a variadic tail.
+    variadic: bool,
+    span: Span,
+}
+
+impl SlotIndexAttr {
+    fn from_field(field: &Field, field_name: &str) -> syn::Result<Self> {
+        let mut annotation = None;
+        for attr in &field.attrs {
+            if !attr.path().is_ident(SLOT_ATTR) {
+                continue;
+            }
+            if annotation.is_some() {
+                return Err(syn::Error::new(
+                    attr.span(),
+                    format!("`{field_name}` has more than one `#[slot(..)]` attribute"),
+                ));
+            }
+            annotation = Some(attr.parse_args::<Self>()?);
+        }
+
+        annotation.ok_or_else(|| {
+            syn::Error::new(
+                field.span(),
+                format!(
+                    "`{field_name}` is missing a `#[slot(N)]` attribute; every field of an \
+                     `#[array_slots]` struct must pin itself to a slot index so that reordering \
+                     field declarations cannot change the slot layout"
+                ),
+            )
+        })
+    }
+}
+
+impl Parse for SlotIndexAttr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let literal: LitInt = input.parse()?;
+        let index = literal.base10_parse::<usize>()?;
+        let variadic = input.peek(Token![..]);
+        if variadic {
+            input.parse::<Token![..]>()?;
+        }
+        if !input.is_empty() {
+            return Err(input.error("expected `#[slot(N)]` or `#[slot(N..)]`"));
+        }
+
+        Ok(Self {
+            index,
+            variadic,
+            span: literal.span(),
+        })
+    }
+}
+
 #[derive(Clone, Copy)]
 enum SlotFieldType {
     Required,
@@ -583,8 +769,7 @@ impl SlotFieldType {
 
         Err(syn::Error::new(
             ty.span(),
-            "#[array_slots] fields must be ArrayRef, Option<ArrayRef>, or (final field only) \
-             Vec<ArrayRef>",
+            "#[array_slots] fields must be ArrayRef, Option<ArrayRef>, or Vec<ArrayRef>",
         ))
     }
 

--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -33,6 +33,7 @@ use crate::validity::Validity;
 #[array_slots(Bool)]
 pub struct BoolSlots {
     /// The validity bitmap indicating which elements are non-null.
+    #[slot(0)]
     pub validity: Option<ArrayRef>,
 }
 

--- a/vortex-array/src/arrays/chunked/array.rs
+++ b/vortex-array/src/arrays/chunked/array.rs
@@ -39,8 +39,10 @@ use crate::validity::Validity;
 #[array_slots(Chunked)]
 pub struct ChunkedSlots {
     /// The non-nullable `u64` array of cumulative chunk offsets.
+    #[slot(0)]
     pub chunk_offsets: ArrayRef,
     /// The chunk arrays, each sharing the outer dtype.
+    #[slot(1..)]
     pub chunks: Vec<ArrayRef>,
 }
 

--- a/vortex-array/src/arrays/decimal/array.rs
+++ b/vortex-array/src/arrays/decimal/array.rs
@@ -46,6 +46,7 @@ use crate::validity::Validity;
 #[array_slots(Decimal)]
 pub struct DecimalSlots {
     /// The validity bitmap indicating which elements are non-null.
+    #[slot(0)]
     pub validity: Option<ArrayRef>,
 }
 

--- a/vortex-array/src/arrays/dict/array.rs
+++ b/vortex-array/src/arrays/dict/array.rs
@@ -45,8 +45,10 @@ pub struct DictMetadata {
 #[array_slots(Dict)]
 pub struct DictSlots {
     /// The codes array mapping each element to a dictionary entry.
+    #[slot(0)]
     pub codes: ArrayRef,
     /// The dictionary values array containing the unique values.
+    #[slot(1)]
     pub values: ArrayRef,
 }
 

--- a/vortex-array/src/arrays/extension/array.rs
+++ b/vortex-array/src/arrays/extension/array.rs
@@ -20,6 +20,7 @@ use crate::dtype::extension::ExtVTable;
 #[array_slots(Extension)]
 pub struct ExtensionSlots {
     /// The backing storage array for this extension array.
+    #[slot(0)]
     pub storage: ArrayRef,
 }
 

--- a/vortex-array/src/arrays/filter/array.rs
+++ b/vortex-array/src/arrays/filter/array.rs
@@ -17,6 +17,7 @@ use crate::arrays::Filter;
 #[array_slots(Filter)]
 pub struct FilterSlots {
     /// The source array being filtered.
+    #[slot(0)]
     pub child: ArrayRef,
 }
 

--- a/vortex-array/src/arrays/fixed_size_list/array.rs
+++ b/vortex-array/src/arrays/fixed_size_list/array.rs
@@ -28,12 +28,14 @@ pub struct FixedSizeListSlots {
     ///
     /// The fixed-size list scalars are contiguous (regardless of nullability for easy lookups),
     /// each with equal size in memory.
+    #[slot(0)]
     pub elements: ArrayRef,
     /// The validity / null map of the array.
     ///
     /// Note that this null map refers to which fixed-size list scalars are null, **not** which
     /// sub-elements of fixed-size list scalars are null. The `elements` array will track
     /// individual value nullability.
+    #[slot(1)]
     pub validity: Option<ArrayRef>,
 }
 

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -42,10 +42,13 @@ use crate::validity::Validity;
 #[array_slots(List)]
 pub struct ListSlots {
     /// The elements data array containing all list elements concatenated together.
+    #[slot(0)]
     pub elements: ArrayRef,
     /// The offsets array defining the start/end of each list within the elements array.
+    #[slot(1)]
     pub offsets: ArrayRef,
     /// The validity bitmap indicating which list elements are non-null.
+    #[slot(2)]
     pub validity: Option<ArrayRef>,
 }
 

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -46,18 +46,22 @@ use crate::validity::Validity;
 pub struct ListViewSlots {
     /// The `elements` data array, where each list scalar is a _slice_ of the `elements` array,
     /// and each inner list element is a _scalar_ of the `elements` array.
+    #[slot(0)]
     pub elements: ArrayRef,
     /// The `offsets` array indicating the start position of each list in elements.
     ///
     /// Since we also store `sizes`, this `offsets` field is allowed to be stored out-of-order
     /// (which is different from [`ListArray`](crate::arrays::ListArray)).
+    #[slot(1)]
     pub offsets: ArrayRef,
     /// The `sizes` array indicating the length of each list.
     ///
     /// This field is intended to be paired with a corresponding offset to determine the list
     /// scalar we want to access.
+    #[slot(2)]
     pub sizes: ArrayRef,
     /// The validity bitmap indicating which list elements are non-null.
+    #[slot(3)]
     pub validity: Option<ArrayRef>,
 }
 

--- a/vortex-array/src/arrays/masked/array.rs
+++ b/vortex-array/src/arrays/masked/array.rs
@@ -23,8 +23,10 @@ use crate::validity::Validity;
 #[array_slots(Masked)]
 pub struct MaskedSlots {
     /// The underlying child array being masked.
+    #[slot(0)]
     pub child: ArrayRef,
     /// The validity bitmap defining which elements are non-null.
+    #[slot(1)]
     pub validity: Option<ArrayRef>,
 }
 

--- a/vortex-array/src/arrays/patched/array.rs
+++ b/vortex-array/src/arrays/patched/array.rs
@@ -54,12 +54,16 @@ pub struct PatchedData {
 #[array_slots(Patched)]
 pub struct PatchedSlots {
     /// The inner array containing the base unpatched values.
+    #[slot(0)]
     pub inner: ArrayRef,
     /// The lane offsets array for locating patches within lanes.
+    #[slot(1)]
     pub lane_offsets: ArrayRef,
     /// The indices of patched (exception) values.
+    #[slot(2)]
     pub patch_indices: ArrayRef,
     /// The patched (exception) values at the corresponding indices.
+    #[slot(3)]
     pub patch_values: ArrayRef,
 }
 
@@ -372,19 +376,37 @@ mod tests {
     use crate::arrays::Chunked;
     use crate::arrays::Null;
     use crate::arrays::PrimitiveArray;
+    use crate::arrays::Union;
     use crate::validity::Validity;
 
     #[array_slots(Null)]
     struct OptionalPatchedSlots {
+        #[slot(0)]
         required: ArrayRef,
+        #[slot(1)]
         maybe: Option<ArrayRef>,
     }
 
     #[array_slots(Chunked)]
     struct VariadicSlots {
+        #[slot(0)]
         offsets: ArrayRef,
+        #[slot(1)]
         maybe_validity: Option<ArrayRef>,
+        #[slot(2..)]
         chunks: Vec<ArrayRef>,
+    }
+
+    /// The same layout as [`VariadicSlots`], but with every field declaration moved. The
+    /// `#[slot(..)]` annotations must keep the storage layout identical.
+    #[array_slots(Union)]
+    struct ShuffledVariadicSlots {
+        #[slot(2..)]
+        chunks: Vec<ArrayRef>,
+        #[slot(1)]
+        maybe_validity: Option<ArrayRef>,
+        #[slot(0)]
+        offsets: ArrayRef,
     }
 
     #[test]
@@ -471,5 +493,70 @@ mod tests {
         let owned = VariadicSlots::from_slots(slot_vec.into());
         assert!(owned.chunks.is_empty());
         assert_eq!(owned.into_slots().len(), 2);
+    }
+
+    #[test]
+    fn slot_indices_follow_annotations_not_declaration_order() {
+        assert_eq!(
+            ShuffledVariadicSlots::OFFSETS,
+            VariadicSlots::OFFSETS,
+            "field declaration order must not move a slot"
+        );
+        assert_eq!(
+            ShuffledVariadicSlots::MAYBE_VALIDITY,
+            VariadicSlots::MAYBE_VALIDITY
+        );
+        assert_eq!(
+            ShuffledVariadicSlots::CHUNKS_OFFSET,
+            VariadicSlots::CHUNKS_OFFSET
+        );
+        assert_eq!(
+            ShuffledVariadicSlots::FIXED_COUNT,
+            VariadicSlots::FIXED_COUNT
+        );
+        assert_eq!(ShuffledVariadicSlots::slot_name(0), "offsets");
+        assert_eq!(ShuffledVariadicSlots::slot_name(1), "maybe_validity");
+        assert_eq!(ShuffledVariadicSlots::slot_name(3), "chunks[1]");
+    }
+
+    #[test]
+    fn shuffled_declaration_order_round_trips_through_storage() {
+        let offsets = PrimitiveArray::new(buffer![0u64, 3], Validity::NonNullable).into_array();
+        let validity = PrimitiveArray::new(buffer![1u8, 1], Validity::NonNullable).into_array();
+        let chunk = PrimitiveArray::new(buffer![1u8, 2, 3], Validity::NonNullable).into_array();
+
+        let slot_vec = vec![
+            Some(offsets.clone()),
+            Some(validity.clone()),
+            Some(chunk.clone()),
+        ];
+
+        let view = ShuffledVariadicSlotsView::from_slots(&slot_vec);
+        assert_eq!(view.offsets.len(), offsets.len());
+        assert_eq!(view.maybe_validity.map(|v| v.len()), Some(validity.len()));
+        assert_eq!(view.chunks.len(), 1);
+        assert_eq!(view.chunks[0].len(), chunk.len());
+
+        // `into_slots` must emit annotation order, not the shuffled declaration order.
+        let round_tripped = ShuffledVariadicSlots::from_slots(slot_vec.into()).into_slots();
+        assert_eq!(round_tripped.len(), 3);
+        assert_eq!(
+            round_tripped[ShuffledVariadicSlots::OFFSETS]
+                .as_ref()
+                .map(|s| s.len()),
+            Some(offsets.len())
+        );
+        assert_eq!(
+            round_tripped[ShuffledVariadicSlots::MAYBE_VALIDITY]
+                .as_ref()
+                .map(|s| s.len()),
+            Some(validity.len())
+        );
+        assert_eq!(
+            round_tripped[ShuffledVariadicSlots::CHUNKS_OFFSET]
+                .as_ref()
+                .map(|s| s.len()),
+            Some(chunk.len())
+        );
     }
 }

--- a/vortex-array/src/arrays/piecewise_sequence/array.rs
+++ b/vortex-array/src/arrays/piecewise_sequence/array.rs
@@ -16,10 +16,13 @@ use crate::dtype::PType;
 #[array_slots(PiecewiseSequence)]
 pub struct PiecewiseSequenceSlots {
     /// The inclusive start index of each sequential piece.
+    #[slot(0)]
     pub starts: ArrayRef,
     /// The length of each sequential piece.
+    #[slot(1)]
     pub lengths: ArrayRef,
     /// The distance between consecutive indices in each piece.
+    #[slot(2)]
     pub multipliers: ArrayRef,
 }
 

--- a/vortex-array/src/arrays/primitive/array/mod.rs
+++ b/vortex-array/src/arrays/primitive/array/mod.rs
@@ -52,6 +52,7 @@ use crate::builtins::ArrayBuiltins;
 #[array_slots(Primitive)]
 pub struct PrimitiveSlots {
     /// The validity bitmap indicating which elements are non-null.
+    #[slot(0)]
     pub validity: Option<ArrayRef>,
 }
 

--- a/vortex-array/src/arrays/shared/array.rs
+++ b/vortex-array/src/arrays/shared/array.rs
@@ -23,6 +23,7 @@ use crate::arrays::Shared;
 #[array_slots(Shared)]
 pub struct SharedSlots {
     /// The source array that is shared and lazily computed.
+    #[slot(0)]
     pub source: ArrayRef,
 }
 

--- a/vortex-array/src/arrays/slice/array.rs
+++ b/vortex-array/src/arrays/slice/array.rs
@@ -17,6 +17,7 @@ use crate::arrays::Slice;
 #[array_slots(Slice)]
 pub struct SliceSlots {
     /// The underlying child array being sliced.
+    #[slot(0)]
     pub child: ArrayRef,
 }
 

--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -34,8 +34,10 @@ use crate::validity::Validity;
 #[array_slots(Struct)]
 pub struct StructSlots {
     /// The optional row-level validity child.
+    #[slot(0)]
     pub validity: Option<ArrayRef>,
     /// The field arrays, one per struct field, all sharing the outer length.
+    #[slot(1..)]
     pub fields: Vec<ArrayRef>,
 }
 

--- a/vortex-array/src/arrays/union/array.rs
+++ b/vortex-array/src/arrays/union/array.rs
@@ -27,8 +27,10 @@ use crate::dtype::UnionVariants;
 #[array_slots(Union)]
 pub struct UnionSlots {
     /// The row-aligned array of type IDs selecting a union child.
+    #[slot(0)]
     pub type_ids: ArrayRef,
     /// The row-aligned sparse children in variant order.
+    #[slot(1..)]
     pub children: Vec<ArrayRef>,
 }
 

--- a/vortex-array/src/arrays/varbin/array.rs
+++ b/vortex-array/src/arrays/varbin/array.rs
@@ -34,8 +34,10 @@ use crate::validity::Validity;
 #[array_slots(VarBin)]
 pub struct VarBinSlots {
     /// The offsets array defining the start/end of each variable-length binary element.
+    #[slot(0)]
     pub offsets: ArrayRef,
     /// The validity bitmap indicating which elements are non-null.
+    #[slot(1)]
     pub validity: Option<ArrayRef>,
 }
 

--- a/vortex-array/src/arrays/varbinview/array.rs
+++ b/vortex-array/src/arrays/varbinview/array.rs
@@ -39,6 +39,7 @@ use crate::validity::Validity;
 #[array_slots(VarBinView)]
 pub struct VarBinViewSlots {
     /// The validity bitmap indicating which elements are non-null.
+    #[slot(0)]
     pub validity: Option<ArrayRef>,
 }
 

--- a/vortex-array/src/arrays/variant/mod.rs
+++ b/vortex-array/src/arrays/variant/mod.rs
@@ -34,10 +34,12 @@ use crate::dtype::DType;
 #[array_slots(Variant)]
 pub struct VariantSlots {
     /// The logical variant storage that preserves the full value for every row.
+    #[slot(0)]
     pub core_storage: ArrayRef,
     /// The optional row-aligned typed shredded tree for selected variant paths.
     /// This slot is `Some` only if the array was canonicalized and the shredded data
     /// was pulled out of the underlying variant storage.
+    #[slot(1)]
     pub shredded: Option<ArrayRef>,
 }
 


### PR DESCRIPTION
## Rationale for this change

Follow-up to #8950, which landed the `#[array_slots]` macro with variadic tail support.

The macro derives slot indices from **field declaration order**. That makes the physical
storage layout an implicit consequence of how the struct happens to be written: reordering
two fields, grouping related fields together, or inserting a new field in the middle
silently renumbers the slots. Nothing in the source says which index a field occupies, so
the change looks cosmetic in review while actually altering the layout arrays are built
from and read back with.

Slot indices are a storage contract. They should be stated, not inferred.

## What changes are included in this PR?

### Macro (`vortex-array-macros/src/lib.rs`)

Every field of an `#[array_slots]` struct must now carry a `#[slot(N)]` attribute naming
the exact index it maps to — `#[slot(N..)]` for a variadic `Vec<ArrayRef>` tail:

```rust
#[array_slots(Chunked)]
pub struct ChunkedSlots {
    #[slot(0)]
    pub chunk_offsets: ArrayRef,
    #[slot(1..)]
    pub chunks: Vec<ArrayRef>,
}
```

The annotation — not the declaration order — drives the generated constants, `from_slots`,
and `into_slots`. `into_slots` emits in annotation order, and `NAMES` / `FIXED_NAMES` are
sorted by index, so declaration order becomes purely cosmetic. Because indices are now
authoritative, the variadic tail no longer has to be the last *declared* field.

`#[slot(..)]` is inert helper syntax consumed during expansion and stripped from the
re-emitted struct.
