### PR TITLE
Require explicit `is_strict` declarations for `ScalarFnVTable`

### DIFF
--- a/vortex-array/src/scalar_fn/vtable.rs
+++ b/vortex-array/src/scalar_fn/vtable.rs
@@ -229,13 +229,10 @@ pub trait ScalarFnVTable: 'static + Sized + Clone + Send + Sync {
     ///
     /// Nullary functions are vacuously strict because they have no input values.
     ///
-    /// Conservatively defaults to `false` (non-strict).
+    /// Every implementation must declare its strictness explicitly.
     ///
     /// This method only checks the expression itself, not its children.
-    fn is_strict(&self, options: &Self::Options) -> bool {
-        _ = options;
-        false
-    }
+    fn is_strict(&self, options: &Self::Options) -> bool;
 
     /// Returns whether this expression is semantically fallible. Conservatively defaults to
     /// `true`.


### PR DESCRIPTION
Removes the default `is_strict` implementation on `ScalarFnVTable` so every scalar function must declare its strictness deliberately instead of silently inheriting the conservative `false`. Follow-up to #8930, where the default was retained to keep the rename mechanical.
