### PR TITLE
perf(array): cut per-lane cost from decimal add/sub and mixed-width compare

### DIFF
--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -130,6 +130,10 @@ name = "binary_ops"
 harness = false
 
 [[bench]]
+name = "decimal_binary"
+harness = false
+
+[[bench]]
 name = "kleene_bool"
 harness = false
 

--- a/vortex-array/benches/decimal_binary.rs
+++ b/vortex-array/benches/decimal_binary.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Decimal Add/Sub and comparison over the native decimal kernels.
+//!
+//! Three costs are isolated here:
+//!
+//! * `checked_*` — the `i256` overflow test and the result-precision bounds test, benchmarked over
+//!   contiguous buffers without the surrounding compute stack.
+//! * `add_*` / `sub_*` — the same work through the kernel, at each precision. The `p37` / `p38`
+//!   pair covers the working width chosen for the result precision: both are stored as `i128`, so
+//!   any difference between them is the width the result dtype forces the lane loop into.
+//! * `compare_*` — comparison of operands whose storage widths differ, which is the normal case
+//!   because compressed chunks are narrowed independently of each other.
+
+#![expect(clippy::unwrap_used)]
+#![expect(
+    clippy::cast_possible_truncation,
+    reason = "benchmark fixtures use indices that fit in the chosen widths"
+)]
+
+use std::sync::LazyLock;
+
+use divan::Bencher;
+use divan::counter::ItemsCount;
+use mimalloc::MiMalloc;
+use num_traits::CheckedAdd;
+use num_traits::WrappingSub;
+use vortex_array::ArrayRef;
+use vortex_array::Canonical;
+use vortex_array::Executable;
+use vortex_array::IntoArray;
+use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
+use vortex_array::arrays::DecimalArray;
+use vortex_array::builtins::ArrayBuiltins;
+use vortex_array::dtype::DecimalDType;
+use vortex_array::dtype::NativeDecimalType;
+use vortex_array::dtype::i256;
+use vortex_array::scalar_fn::fns::operators::Operator;
+use vortex_buffer::Buffer;
+use vortex_session::VortexSession;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
+fn main() {
+    LazyLock::force(&SESSION);
+    divan::main();
+}
+
+static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
+
+const LEN: usize = 65_536;
+
+// The overflow and bounds tests on their own, over contiguous i256 buffers.
+
+#[divan::bench]
+fn checked_add_i256(bencher: Bencher) {
+    let (lhs, rhs) = i256_operands();
+
+    bencher.counter(ItemsCount::new(LEN)).bench_local(|| {
+        let mut sum = 0usize;
+        for (a, b) in lhs.iter().zip(rhs.iter()) {
+            sum += a.checked_add(b).is_some() as usize;
+        }
+        sum
+    });
+}
+
+#[divan::bench]
+fn checked_add_bounds_i256(bencher: Bencher) {
+    let (lhs, rhs) = i256_operands();
+    let lower = <i256 as NativeDecimalType>::MIN_BY_PRECISION[76];
+    let upper = <i256 as NativeDecimalType>::MAX_BY_PRECISION[76];
+
+    bencher.counter(ItemsCount::new(LEN)).bench_local(|| {
+        let mut sum = 0usize;
+        for (a, b) in lhs.iter().zip(rhs.iter()) {
+            sum += a.checked_add(b).is_some_and(|v| lower <= v && v <= upper) as usize;
+        }
+        sum
+    });
+}
+
+/// The fused form the kernel applies: overflow read off the high-limb sign bits, and both
+/// precision bounds folded into a single unsigned comparison. Spelled out here so the three
+/// `checked_*` benchmarks can be compared against each other from any revision.
+#[divan::bench]
+fn overflowing_add_bounds_i256(bencher: Bencher) {
+    let (lhs, rhs) = i256_operands();
+    let lower = <i256 as NativeDecimalType>::MIN_BY_PRECISION[76];
+    let span = <i256 as WrappingSub>::wrapping_sub(
+        &<i256 as NativeDecimalType>::MAX_BY_PRECISION[76],
+        &lower,
+    );
+
+    #[expect(clippy::cast_sign_loss, reason = "reinterpreting the bit pattern")]
+    fn le_unsigned(lhs: i256, rhs: i256) -> bool {
+        let (low, high) = lhs.to_parts();
+        let (rhs_low, rhs_high) = rhs.to_parts();
+        (high as u128, low) <= (rhs_high as u128, rhs_low)
+    }
+
+    fn overflowing_add(lhs: i256, rhs: i256) -> (i256, bool) {
+        let sum = lhs.wrapping_add(rhs);
+        let (_, lhs_high) = lhs.to_parts();
+        let (_, rhs_high) = rhs.to_parts();
+        let (_, sum_high) = sum.to_parts();
+        (sum, ((lhs_high ^ sum_high) & (rhs_high ^ sum_high)) < 0)
+    }
+
+    bencher.counter(ItemsCount::new(LEN)).bench_local(|| {
+        let mut sum = 0usize;
+        for (a, b) in lhs.iter().zip(rhs.iter()) {
+            let (value, overflow) = overflowing_add(*a, *b);
+            sum += (!overflow
+                & le_unsigned(<i256 as WrappingSub>::wrapping_sub(&value, &lower), span))
+                as usize;
+        }
+        sum
+    });
+}
+
+// Add/Sub through the kernel.
+
+#[divan::bench]
+fn add_i64_p18(bencher: Bencher) {
+    let lhs = decimal_i64(18, 0).into_array();
+    let rhs = decimal_i64(18, 1).into_array();
+
+    bench_decimal(bencher, lhs, rhs, Operator::Add);
+}
+
+#[divan::bench]
+fn add_i128_p37(bencher: Bencher) {
+    let lhs = decimal_i128(37, 0).into_array();
+    let rhs = decimal_i128(37, 1).into_array();
+
+    bench_decimal(bencher, lhs, rhs, Operator::Add);
+}
+
+#[divan::bench]
+fn add_i128_p38(bencher: Bencher) {
+    let lhs = decimal_i128(38, 0).into_array();
+    let rhs = decimal_i128(38, 1).into_array();
+
+    bench_decimal(bencher, lhs, rhs, Operator::Add);
+}
+
+#[divan::bench]
+fn add_i256_p76(bencher: Bencher) {
+    let lhs = decimal_i256(0).into_array();
+    let rhs = decimal_i256(1).into_array();
+
+    bench_decimal(bencher, lhs, rhs, Operator::Add);
+}
+
+#[divan::bench]
+fn sub_i256_p76(bencher: Bencher) {
+    let lhs = decimal_i256(0).into_array();
+    let rhs = decimal_i256(1).into_array();
+
+    bench_decimal(bencher, lhs, rhs, Operator::Sub);
+}
+
+#[divan::bench]
+fn add_i256_p76_nullable(bencher: Bencher) {
+    let lhs = decimal_i256_nullable(0, 7).into_array();
+    let rhs = decimal_i256_nullable(1, 5).into_array();
+
+    bench_decimal(bencher, lhs, rhs, Operator::Add);
+}
+
+// Comparison, same and mixed storage widths.
+
+#[divan::bench]
+fn compare_i128_i128_p38(bencher: Bencher) {
+    let lhs = decimal_i128(38, 0).into_array();
+    let rhs = decimal_i128(38, 1).into_array();
+
+    bench_compare(bencher, lhs, rhs, Operator::Gte);
+}
+
+#[divan::bench]
+fn compare_i32_i128_p38(bencher: Bencher) {
+    let lhs = decimal_i32(38, 0).into_array();
+    let rhs = decimal_i128(38, 1).into_array();
+
+    bench_compare(bencher, lhs, rhs, Operator::Gte);
+}
+
+#[divan::bench]
+fn compare_i128_i32_p38(bencher: Bencher) {
+    let lhs = decimal_i128(38, 0).into_array();
+    let rhs = decimal_i32(38, 1).into_array();
+
+    bench_compare(bencher, lhs, rhs, Operator::Gte);
+}
+
+#[divan::bench]
+fn compare_i64_i256_p76(bencher: Bencher) {
+    let lhs = decimal_i64(76, 0).into_array();
+    let rhs = decimal_i256(1).into_array();
+
+    bench_compare(bencher, lhs, rhs, Operator::Gte);
+}
+
+fn bench_decimal(bencher: Bencher, lhs: ArrayRef, rhs: ArrayRef, operator: Operator) {
+    bench_binary::<DecimalArray>(bencher, lhs, rhs, operator);
+}
+
+fn bench_compare(bencher: Bencher, lhs: ArrayRef, rhs: ArrayRef, operator: Operator) {
+    bench_binary::<Canonical>(bencher, lhs, rhs, operator);
+}
+
+fn bench_binary<T: Executable + 'static>(
+    bencher: Bencher,
+    lhs: ArrayRef,
+    rhs: ArrayRef,
+    operator: Operator,
+) {
+    let mut ctx = SESSION.create_execution_ctx();
+
+    bencher.counter(ItemsCount::new(LEN)).bench_local(|| {
+        lhs.clone()
+            .binary(rhs.clone(), operator)
+            .unwrap()
+            .execute::<T>(&mut ctx)
+            .unwrap()
+    });
+}
+
+/// Two operand buffers whose sums stay well inside precision 76, so the benchmark measures the
+/// checks themselves rather than an early exit out of the lane loop.
+fn i256_operands() -> (Buffer<i256>, Buffer<i256>) {
+    let scale = i256::from_i128(10).wrapping_pow(60);
+    let lhs = (0..LEN as i128)
+        .map(|i| i256::from_i128(i % 977) * scale)
+        .collect();
+    let rhs = (0..LEN as i128)
+        .map(|i| i256::from_i128(i % 599) * scale)
+        .collect();
+    (lhs, rhs)
+}
+
+fn decimal_i32(precision: u8, offset: i32) -> DecimalArray {
+    DecimalArray::from_iter::<i32, _>(
+        (0..LEN as i32).map(|i| (i + offset) % 1_000_000),
+        DecimalDType::new(precision, 2),
+    )
+}
+
+fn decimal_i64(precision: u8, offset: i64) -> DecimalArray {
+    DecimalArray::from_iter::<i64, _>(
+        (0..LEN as i64).map(|i| (i + offset) % 1_000_000_000),
+        DecimalDType::new(precision, 2),
+    )
+}
+
+/// Values wide enough to occupy most of the declared precision, so a narrower working width could
+/// not represent them.
+fn decimal_i128(precision: u8, offset: i128) -> DecimalArray {
+    let base = <i128 as NativeDecimalType>::MAX_BY_PRECISION[precision as usize] / 4;
+    DecimalArray::from_iter::<i128, _>(
+        (0..LEN as i128).map(|i| base + ((i + offset) % 1_000_000)),
+        DecimalDType::new(precision, 2),
+    )
+}
+
+fn decimal_i256(offset: i128) -> DecimalArray {
+    let base = <i256 as NativeDecimalType>::MAX_BY_PRECISION[76] / i256::from_i128(4);
+    DecimalArray::from_iter::<i256, _>(
+        (0..LEN as i128).map(|i| base + i256::from_i128((i + offset) % 1_000_000)),
+        DecimalDType::new(76, 2),
+    )
+}
+
+fn decimal_i256_nullable(offset: i128, null_every: usize) -> DecimalArray {
+    let base = <i256 as NativeDecimalType>::MAX_BY_PRECISION[76] / i256::from_i128(4);
+    DecimalArray::from_option_iter::<i256, _>(
+        (0..LEN as i128).map(|i| {
+            (!(i as usize).is_multiple_of(null_every))
+                .then(|| base + i256::from_i128((i + offset) % 1_000_000))
+        }),
+        DecimalDType::new(76, 2),
+    )
+}

--- a/vortex-array/src/dtype/bigint/mod.rs
+++ b/vortex-array/src/dtype/bigint/mod.rs
@@ -105,6 +105,44 @@ impl i256 {
         Self(self.0.wrapping_add(other.0))
     }
 
+    /// Wrapping (modular) subtraction. Computes `self - other`, wrapping around at the boundary.
+    pub fn wrapping_sub(&self, other: Self) -> Self {
+        Self(self.0.wrapping_sub(other.0))
+    }
+
+    /// Computes `self + other`, returning the wrapped result and whether an overflow occurred.
+    ///
+    /// Signed addition overflows exactly when both operands share a sign that the sum does not,
+    /// which is a property of the sign bit alone. Testing it as
+    /// `((lhs ^ sum) & (rhs ^ sum)) < 0` over the high limbs costs two 128-bit `xor`s, an `and`
+    /// and a sign test, rather than the pair of full 256-bit three-way comparisons that
+    /// re-deriving the condition from the operand ordering requires.
+    #[inline]
+    pub fn overflowing_add(self, other: Self) -> (Self, bool) {
+        let sum = self.wrapping_add(other);
+        let (_, lhs_high) = self.to_parts();
+        let (_, rhs_high) = other.to_parts();
+        let (_, sum_high) = sum.to_parts();
+        (sum, ((lhs_high ^ sum_high) & (rhs_high ^ sum_high)) < 0)
+    }
+
+    /// Computes `self - other`, returning the wrapped result and whether an overflow occurred.
+    ///
+    /// Signed subtraction overflows exactly when the operands differ in sign and the difference
+    /// does not take the sign of the left-hand side. See [`i256::overflowing_add`] for why this
+    /// is cheaper than comparing the operands.
+    #[inline]
+    pub fn overflowing_sub(self, other: Self) -> (Self, bool) {
+        let difference = self.wrapping_sub(other);
+        let (_, lhs_high) = self.to_parts();
+        let (_, rhs_high) = other.to_parts();
+        let (_, difference_high) = difference.to_parts();
+        (
+            difference,
+            ((lhs_high ^ rhs_high) & (lhs_high ^ difference_high)) < 0,
+        )
+    }
+
     /// Return the memory representation of this integer as a byte array in little-endian byte order.
     #[inline]
     pub const fn to_le_bytes(&self) -> [u8; 32] {
@@ -205,8 +243,10 @@ impl One for i256 {
 }
 
 impl CheckedAdd for i256 {
+    #[inline]
     fn checked_add(&self, v: &Self) -> Option<Self> {
-        self.0.checked_add(v.0).map(Self)
+        let (sum, overflow) = self.overflowing_add(*v);
+        (!overflow).then_some(sum)
     }
 }
 
@@ -217,8 +257,10 @@ impl WrappingAdd for i256 {
 }
 
 impl CheckedSub for i256 {
+    #[inline]
     fn checked_sub(&self, v: &Self) -> Option<Self> {
-        self.0.checked_sub(v.0).map(Self)
+        let (difference, overflow) = self.overflowing_sub(*v);
+        (!overflow).then_some(difference)
     }
 }
 
@@ -515,6 +557,89 @@ mod tests {
         assert_eq!(result, Some(i256::from_i128(300)));
 
         // Note: Testing overflow would require values larger than i128
+    }
+
+    #[test]
+    fn test_i256_overflowing_add() {
+        assert_eq!(
+            i256::from_i128(100).overflowing_add(i256::from_i128(200)),
+            (i256::from_i128(300), false)
+        );
+        assert_eq!(
+            i256::MAX.overflowing_add(i256::ZERO),
+            (i256::MAX, false),
+            "adding zero never overflows"
+        );
+        assert_eq!(
+            i256::MAX.overflowing_add(i256::ONE),
+            (i256::MIN, true),
+            "positive overflow wraps to the minimum"
+        );
+        assert_eq!(
+            i256::MIN.overflowing_add(-i256::ONE),
+            (i256::MAX, true),
+            "negative overflow wraps to the maximum"
+        );
+        assert_eq!(
+            i256::MIN.overflowing_add(i256::MAX),
+            (-i256::ONE, false),
+            "opposite signs can never overflow"
+        );
+        // Crossing the low limb into the high limb is not an overflow.
+        let low_max = i256::from_parts(u128::MAX, 0);
+        assert_eq!(
+            low_max.overflowing_add(i256::ONE),
+            (i256::from_parts(0, 1), false)
+        );
+    }
+
+    #[test]
+    fn test_i256_overflowing_sub() {
+        assert_eq!(
+            i256::from_i128(500).overflowing_sub(i256::from_i128(200)),
+            (i256::from_i128(300), false)
+        );
+        assert_eq!(
+            i256::from_i128(200).overflowing_sub(i256::from_i128(500)),
+            (i256::from_i128(-300), false)
+        );
+        assert_eq!(
+            i256::MIN.overflowing_sub(i256::ONE),
+            (i256::MAX, true),
+            "negative overflow wraps to the maximum"
+        );
+        assert_eq!(
+            i256::MAX.overflowing_sub(-i256::ONE),
+            (i256::MIN, true),
+            "positive overflow wraps to the minimum"
+        );
+        assert_eq!(
+            i256::MAX.overflowing_sub(i256::MAX),
+            (i256::ZERO, false),
+            "equal signs can never overflow"
+        );
+        // Borrowing from the high limb is not an overflow.
+        assert_eq!(
+            i256::from_parts(0, 1).overflowing_sub(i256::ONE),
+            (i256::from_parts(u128::MAX, 0), false)
+        );
+    }
+
+    #[test]
+    fn test_i256_checked_add_sub_at_the_boundary() {
+        assert_eq!(i256::MAX.checked_add(&i256::ONE), None);
+        assert_eq!(i256::MIN.checked_add(&-i256::ONE), None);
+        assert_eq!(
+            i256::MAX.checked_add(&-i256::ONE),
+            Some(i256::MAX - i256::ONE)
+        );
+
+        assert_eq!(i256::MIN.checked_sub(&i256::ONE), None);
+        assert_eq!(i256::MAX.checked_sub(&-i256::ONE), None);
+        assert_eq!(
+            i256::MIN.checked_sub(&-i256::ONE),
+            Some(i256::MIN + i256::ONE)
+        );
     }
 
     #[test]

--- a/vortex-array/src/scalar_fn/fns/binary/compare/decimal.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare/decimal.rs
@@ -5,11 +5,15 @@
 //!
 //! Both operands share a logical [`DecimalDType`] (equal precision and scale), so comparing the
 //! unscaled integer values is sufficient. The physical storage width may differ per operand; when
-//! it does, both sides are widened once to the larger storage type before the lane loop.
+//! it does, the narrower side is widened lane by lane inside the comparison loop rather than
+//! materialized into a widened buffer first.
 //!
 //! [`DecimalDType`]: crate::dtype::DecimalDType
 
+use std::cmp::Ordering;
+
 use vortex_buffer::BitBuffer;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 
@@ -19,7 +23,7 @@ use crate::IntoArray;
 use crate::arrays::BoolArray;
 use crate::arrays::Constant;
 use crate::arrays::DecimalArray;
-use crate::arrays::decimal::widened_buffer;
+use crate::dtype::BigCast;
 use crate::dtype::NativeDecimalType;
 use crate::dtype::Nullability;
 use crate::dtype::i256;
@@ -111,12 +115,24 @@ fn compare_decimal_values(
     rhs: &DecimalArray,
     op: CompareOperator,
 ) -> BitBuffer {
-    let common = lhs.values_type().max(rhs.values_type());
-    match_each_decimal_value_type!(common, |W| {
-        let lhs = widened_buffer::<W>(lhs);
-        let rhs = widened_buffer::<W>(rhs);
-        compare_slices::<W>(&lhs, &rhs, op)
-    })
+    // Compressed chunks are narrowed independently, so mixed storage widths are the common case
+    // rather than the exception. Widening the narrow side is a per-lane sign extension, so it is
+    // fused into the comparison instead of materializing a whole widened buffer first.
+    match lhs.values_type().cmp(&rhs.values_type()) {
+        Ordering::Equal => match_each_decimal_value_type!(lhs.values_type(), |T| {
+            compare_slices::<T, T, T>(&lhs.buffer::<T>(), &rhs.buffer::<T>(), op)
+        }),
+        Ordering::Less => match_each_decimal_value_type!(rhs.values_type(), |W| {
+            match_each_decimal_value_type!(lhs.values_type(), |L| {
+                compare_slices::<L, W, W>(&lhs.buffer::<L>(), &rhs.buffer::<W>(), op)
+            })
+        }),
+        Ordering::Greater => match_each_decimal_value_type!(lhs.values_type(), |W| {
+            match_each_decimal_value_type!(rhs.values_type(), |R| {
+                compare_slices::<W, R, W>(&lhs.buffer::<W>(), &rhs.buffer::<R>(), op)
+            })
+        }),
+    }
 }
 
 fn compare_decimal_constant(
@@ -145,14 +161,38 @@ fn compare_decimal_constant(
     })
 }
 
-fn compare_slices<T: NativeDecimalType>(lhs: &[T], rhs: &[T], op: CompareOperator) -> BitBuffer {
+/// Compare two decimal buffers stored at widths `L` and `R` at the common width `W`.
+///
+/// `W` must be at least as wide as both `L` and `R`, so that both widening casts are lossless.
+fn compare_slices<L, R, W>(lhs: &[L], rhs: &[R], op: CompareOperator) -> BitBuffer
+where
+    L: NativeDecimalType,
+    R: NativeDecimalType,
+    W: NativeDecimalType,
+{
+    /// Widen a lane to the comparison width. Constant-folds away whenever `N` is `W`, and for a
+    /// genuine widening it is the sign extension alone: the cast is infallible by construction.
+    #[inline]
+    fn widen<N: NativeDecimalType, W: NativeDecimalType>(value: N) -> W {
+        <W as BigCast>::from(value).vortex_expect("decimal compare widens to a common width")
+    }
+
+    macro_rules! zip {
+        (| $a:ident, $b:ident | $predicate:expr) => {
+            collect_zip_bits(lhs, rhs, |a: L, b: R| {
+                let ($a, $b) = (widen::<L, W>(a), widen::<R, W>(b));
+                $predicate
+            })
+        };
+    }
+
     match op {
-        CompareOperator::Eq => collect_zip_bits(lhs, rhs, |a: T, b: T| a == b),
-        CompareOperator::NotEq => collect_zip_bits(lhs, rhs, |a: T, b: T| a != b),
-        CompareOperator::Gt => collect_zip_bits(lhs, rhs, |a: T, b: T| a > b),
-        CompareOperator::Gte => collect_zip_bits(lhs, rhs, |a: T, b: T| a >= b),
-        CompareOperator::Lt => collect_zip_bits(lhs, rhs, |a: T, b: T| a < b),
-        CompareOperator::Lte => collect_zip_bits(lhs, rhs, |a: T, b: T| a <= b),
+        CompareOperator::Eq => zip!(|a, b| a == b),
+        CompareOperator::NotEq => zip!(|a, b| a != b),
+        CompareOperator::Gt => zip!(|a, b| a > b),
+        CompareOperator::Gte => zip!(|a, b| a >= b),
+        CompareOperator::Lt => zip!(|a, b| a < b),
+        CompareOperator::Lte => zip!(|a, b| a <= b),
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/binary/compare/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare/mod.rs
@@ -290,10 +290,13 @@ pub(super) fn bit_buffer_from_words(words: BufferMut<u64>, len: usize) -> BitBuf
 }
 
 /// Bit-pack the predicate `f(lhs[i], rhs[i])` over two equal-length slices into a [`BitBuffer`].
-pub(super) fn collect_zip_bits<T: Copy>(
-    lhs: &[T],
-    rhs: &[T],
-    mut f: impl FnMut(T, T) -> bool,
+///
+/// The two slices need not share an element type: decimal operands can be stored at different
+/// widths and are widened lane by lane inside `f`.
+pub(super) fn collect_zip_bits<L: Copy, R: Copy>(
+    lhs: &[L],
+    rhs: &[R],
+    mut f: impl FnMut(L, R) -> bool,
 ) -> BitBuffer {
     let len = lhs.len();
     let mut words = BufferMut::<u64>::zeroed(len.div_ceil(64));

--- a/vortex-array/src/scalar_fn/fns/binary/compare/tests.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare/tests.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::cmp::Ordering;
 use std::sync::Arc;
 
 use rstest::rstest;
@@ -29,8 +30,10 @@ use crate::dtype::DType;
 use crate::dtype::DecimalDType;
 use crate::dtype::FieldName;
 use crate::dtype::FieldNames;
+use crate::dtype::NativeDecimalType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
+use crate::dtype::i256;
 use crate::extension::datetime::TimeUnit;
 use crate::extension::datetime::Timestamp;
 use crate::extension::datetime::TimestampOptions;
@@ -527,8 +530,8 @@ fn decimal_compare() {
     assert_arrays_eq!(result, BoolArray::from_iter([true, false, false]), &mut ctx);
 }
 
-/// Two decimal arrays with the same logical dtype but different storage widths compare through
-/// the widened common storage type.
+/// Two decimal arrays with the same logical dtype but different storage widths compare at the
+/// wider of the two widths.
 #[test]
 fn decimal_compare_mixed_storage_widths() {
     let mut ctx = array_session().create_execution_ctx();
@@ -538,6 +541,93 @@ fn decimal_compare_mixed_storage_widths() {
 
     let result = execute_compare_test(lhs, rhs, Operator::Lte);
     assert_arrays_eq!(result, BoolArray::from_iter([true, true, false]), &mut ctx);
+}
+
+/// Mixed storage widths must agree with the ordering of the unscaled values for every operator and
+/// in either operand order, including when only the wider side can represent its own values.
+#[rstest]
+#[case(Operator::Eq, Ordering::is_eq as fn(Ordering) -> bool)]
+#[case(Operator::NotEq, Ordering::is_ne)]
+#[case(Operator::Lt, Ordering::is_lt)]
+#[case(Operator::Lte, Ordering::is_le)]
+#[case(Operator::Gt, Ordering::is_gt)]
+#[case(Operator::Gte, Ordering::is_ge)]
+fn decimal_compare_mixed_widths_match_value_ordering(
+    #[case] op: Operator,
+    #[case] holds: fn(Ordering) -> bool,
+) {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(38, 2);
+    let narrow = [0i32, 1, -1, i32::MAX, i32::MIN, 12_345];
+    let wide = [
+        0i128,
+        -1,
+        1,
+        i32::MAX as i128 + 1,
+        i32::MIN as i128 - 1,
+        12_345,
+    ];
+
+    let narrow_array = DecimalArray::from_iter::<i32, _>(narrow, dtype).into_array();
+    let wide_array = DecimalArray::from_iter::<i128, _>(wide, dtype).into_array();
+
+    let result = execute_compare_test(narrow_array.clone(), wide_array.clone(), op);
+    assert_arrays_eq!(
+        result,
+        BoolArray::from_iter(
+            narrow
+                .iter()
+                .zip(wide.iter())
+                .map(|(l, r)| holds((*l as i128).cmp(r)))
+        ),
+        &mut ctx
+    );
+
+    let result = execute_compare_test(wide_array, narrow_array, op);
+    assert_arrays_eq!(
+        result,
+        BoolArray::from_iter(
+            wide.iter()
+                .zip(narrow.iter())
+                .map(|(l, r)| holds(l.cmp(&(*r as i128))))
+        ),
+        &mut ctx
+    );
+}
+
+/// The same check where the wider side is an `i256`, so the narrow side is sign extended across
+/// the limb boundary.
+#[rstest]
+#[case(Operator::Lt, Ordering::is_lt as fn(Ordering) -> bool)]
+#[case(Operator::Gte, Ordering::is_ge)]
+#[case(Operator::Eq, Ordering::is_eq)]
+fn decimal_compare_i64_against_i256(#[case] op: Operator, #[case] holds: fn(Ordering) -> bool) {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(76, 0);
+    let narrow = [0i64, -1, 1, i64::MAX, i64::MIN];
+    let wide = [
+        i256::ZERO,
+        -i256::ONE,
+        i256::from_i128(i64::MAX as i128 + 1),
+        i256::from_i128(i64::MAX as i128),
+        <i256 as NativeDecimalType>::MIN_BY_PRECISION[76],
+    ];
+
+    let result = execute_compare_test(
+        DecimalArray::from_iter::<i64, _>(narrow, dtype).into_array(),
+        DecimalArray::from_iter::<i256, _>(wide, dtype).into_array(),
+        op,
+    );
+    assert_arrays_eq!(
+        result,
+        BoolArray::from_iter(
+            narrow
+                .iter()
+                .zip(wide.iter())
+                .map(|(l, r)| holds(i256::from_i128(*l as i128).cmp(r)))
+        ),
+        &mut ctx
+    );
 }
 
 /// A decimal constant that does not fit the array's narrow storage type still compares

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
@@ -5,14 +5,13 @@
 //!
 //! Both operands share a logical [`DecimalDType`] (equal precision and scale). Add and Sub apply
 //! directly to the unscaled stored integers and are exact at that shared scale. The result reserves
-//! one additional precision digit for a carry, capped at Vortex's maximum decimal precision.
+//! one additional precision digit for a carry, as long as that digit does not push the result into
+//! a wider working width (see [`result_decimal_dtype`]).
 //!
-//! Lanes execute in a working width chosen so that in-precision inputs cannot spuriously
-//! overflow an intermediate value. An operation that overflows the result precision on a valid
-//! lane is an error; invalid lanes never error.
+//! Lanes execute at the working width of the result precision. Every lane is checked twice: once
+//! for overflow of the working width, and once against the bounds implied by the result precision.
+//! A valid lane failing either check is an error; invalid lanes never error.
 
-use num_traits::CheckedAdd;
-use num_traits::CheckedSub;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -34,13 +33,16 @@ use crate::arrays::decimal::DecimalArrayExt;
 use crate::dtype::BigCast;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
-use crate::dtype::MAX_PRECISION;
 use crate::dtype::NativeDecimalType;
+use crate::dtype::i256;
 use crate::match_each_decimal_value_type;
 use crate::scalar::DecimalValue;
 use crate::scalar::NumericOperator;
 use crate::scalar::Scalar;
 use crate::validity::Validity;
+
+/// The widest decimal precision that still fits a native `i128`.
+const NATIVE_MAX_PRECISION: u8 = <i128 as NativeDecimalType>::MAX_PRECISION;
 
 /// Derive the result decimal dtype for a numeric operation over same-typed operands.
 pub(crate) fn result_decimal_dtype(
@@ -49,10 +51,22 @@ pub(crate) fn result_decimal_dtype(
 ) -> VortexResult<DecimalDType> {
     match op {
         NumericOperator::Add | NumericOperator::Sub => {
-            // A p-digit Add/Sub result needs at most one carry digit:
-            // 2 * (10^p - 1) < 10^(p + 1). Follows Arrow rules.
+            // A p-digit Add/Sub result needs at most one carry digit, because
+            // 2 * (10^p - 1) < 10^(p + 1). Reserving that digit is free while it stays inside a
+            // native integer, but 39 digits no longer fit an `i128`: promoting `Decimal(38, s)` —
+            // by far the most common wide decimal — to `Decimal(39, s)` would put every lane of
+            // this and every later operation through software 256-bit arithmetic for one digit.
+            // Arrow saturates at its own type boundary for the same reason, so the precision
+            // saturates here too and a sum that no longer fits is an overflow error rather than a
+            // silently widened column.
+            let precision = input.precision();
+            let cap = if precision <= NATIVE_MAX_PRECISION {
+                NATIVE_MAX_PRECISION
+            } else {
+                <i256 as NativeDecimalType>::MAX_PRECISION
+            };
             Ok(DecimalDType::new(
-                input.precision().saturating_add(1).min(MAX_PRECISION),
+                precision.saturating_add(1).min(cap),
                 input.scale(),
             ))
         }
@@ -175,29 +189,116 @@ impl DecimalOperand {
     }
 }
 
+/// Lane arithmetic for a decimal working width, phrased so that neither the overflow test nor the
+/// precision test needs a branch.
+///
+/// The natural spelling — `checked_add` followed by `lower <= v && v <= upper` — costs four
+/// three-way comparisons per lane. That is one instruction each for a native integer, but for
+/// [`i256`] every one of them is a 256-bit lexicographic compare. Deriving overflow from the sign
+/// bits instead, and folding the two bounds into a single unsigned comparison, removes all four.
+trait DecimalLane: NativeDecimalType {
+    /// `self + rhs` wrapped to `Self`, and whether the exact sum overflowed `Self`.
+    fn overflowing_add(self, rhs: Self) -> (Self, bool);
+
+    /// `self - rhs` wrapped to `Self`, and whether the exact difference overflowed `Self`.
+    fn overflowing_sub(self, rhs: Self) -> (Self, bool);
+
+    /// `self - origin` wrapped to `Self`.
+    fn wrapping_sub(self, origin: Self) -> Self;
+
+    /// `self <= other`, with both operands read as unsigned integers of the same width.
+    fn le_unsigned(self, other: Self) -> bool;
+}
+
+macro_rules! impl_decimal_lane {
+    ($T:ty, $U:ty) => {
+        impl DecimalLane for $T {
+            #[inline]
+            fn overflowing_add(self, rhs: Self) -> (Self, bool) {
+                <$T>::overflowing_add(self, rhs)
+            }
+
+            #[inline]
+            fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
+                <$T>::overflowing_sub(self, rhs)
+            }
+
+            #[inline]
+            fn wrapping_sub(self, origin: Self) -> Self {
+                <$T>::wrapping_sub(self, origin)
+            }
+
+            #[inline]
+            #[expect(clippy::cast_sign_loss, reason = "reinterpreting the bit pattern")]
+            fn le_unsigned(self, other: Self) -> bool {
+                (self as $U) <= (other as $U)
+            }
+        }
+    };
+}
+
+impl_decimal_lane!(i8, u8);
+impl_decimal_lane!(i16, u16);
+impl_decimal_lane!(i32, u32);
+impl_decimal_lane!(i64, u64);
+impl_decimal_lane!(i128, u128);
+
+impl DecimalLane for i256 {
+    #[inline]
+    fn overflowing_add(self, rhs: Self) -> (Self, bool) {
+        i256::overflowing_add(self, rhs)
+    }
+
+    #[inline]
+    fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
+        i256::overflowing_sub(self, rhs)
+    }
+
+    #[inline]
+    fn wrapping_sub(self, origin: Self) -> Self {
+        i256::wrapping_sub(&self, origin)
+    }
+
+    #[inline]
+    #[expect(clippy::cast_sign_loss, reason = "reinterpreting the bit pattern")]
+    fn le_unsigned(self, other: Self) -> bool {
+        let (low, high) = self.to_parts();
+        let (other_low, other_high) = other.to_parts();
+        (high as u128, low) <= (other_high as u128, other_low)
+    }
+}
+
 /// Per-execution bounds for checked decimal lane operations at working width `W`.
 ///
 /// Native-width checked arithmetic only detects overflow of `W`, whose range may exceed the
 /// declared decimal precision. In particular, `i256` can represent values outside precision 76,
 /// so every native result must also be checked against these logical bounds.
 struct DecimalValueBounds<W> {
-    /// Inclusive stored-value bounds implied by the result precision.
+    /// The inclusive lower stored-value bound implied by the result precision.
     lower_bound: W,
-    upper_bound: W,
+    /// The width of the in-precision range, `upper_bound - lower_bound`.
+    span: W,
 }
 
-impl<W: NativeDecimalType> DecimalValueBounds<W> {
+impl<W: DecimalLane> DecimalValueBounds<W> {
     fn new(dtype: DecimalDType) -> Self {
         let precision = dtype.precision() as usize;
+        let lower_bound = W::MIN_BY_PRECISION[precision];
         Self {
-            lower_bound: W::MIN_BY_PRECISION[precision],
-            upper_bound: W::MAX_BY_PRECISION[precision],
+            lower_bound,
+            span: W::MAX_BY_PRECISION[precision].wrapping_sub(lower_bound),
         }
     }
 
     /// Bounds-check a candidate result against the result precision.
-    fn in_precision(&self, value: W) -> Option<W> {
-        (self.lower_bound <= value && value <= self.upper_bound).then_some(value)
+    ///
+    /// Biasing by the lower bound turns the two-sided signed range test into a single unsigned
+    /// one: `x` lies in `[lower, upper]` exactly when `x - lower`, read as an unsigned integer,
+    /// is at most `upper - lower`. Values below the lower bound wrap around to a large unsigned
+    /// value and fail the same comparison.
+    #[inline]
+    fn in_precision(&self, value: W) -> bool {
+        value.wrapping_sub(self.lower_bound).le_unsigned(self.span)
     }
 }
 
@@ -205,9 +306,7 @@ impl<W: NativeDecimalType> DecimalValueBounds<W> {
 trait CheckedDecimalOp {
     const ERROR: &'static str;
 
-    fn apply<W>(lhs: W, rhs: W, bounds: &DecimalValueBounds<W>) -> Option<W>
-    where
-        W: NativeDecimalType + CheckedAdd + CheckedSub;
+    fn apply<W: DecimalLane>(lhs: W, rhs: W, bounds: &DecimalValueBounds<W>) -> Option<W>;
 }
 
 struct CheckedDecimalAdd;
@@ -217,22 +316,20 @@ struct CheckedDecimalSub;
 impl CheckedDecimalOp for CheckedDecimalAdd {
     const ERROR: &'static str = "decimal overflow in checked add";
 
-    fn apply<W>(lhs: W, rhs: W, bounds: &DecimalValueBounds<W>) -> Option<W>
-    where
-        W: NativeDecimalType + CheckedAdd + CheckedSub,
-    {
-        bounds.in_precision(lhs.checked_add(&rhs)?)
+    #[inline]
+    fn apply<W: DecimalLane>(lhs: W, rhs: W, bounds: &DecimalValueBounds<W>) -> Option<W> {
+        let (value, overflow) = lhs.overflowing_add(rhs);
+        (!overflow & bounds.in_precision(value)).then_some(value)
     }
 }
 
 impl CheckedDecimalOp for CheckedDecimalSub {
     const ERROR: &'static str = "decimal overflow in checked sub";
 
-    fn apply<W>(lhs: W, rhs: W, bounds: &DecimalValueBounds<W>) -> Option<W>
-    where
-        W: NativeDecimalType + CheckedAdd + CheckedSub,
-    {
-        bounds.in_precision(lhs.checked_sub(&rhs)?)
+    #[inline]
+    fn apply<W: DecimalLane>(lhs: W, rhs: W, bounds: &DecimalValueBounds<W>) -> Option<W> {
+        let (value, overflow) = lhs.overflowing_sub(rhs);
+        (!overflow & bounds.in_precision(value)).then_some(value)
     }
 }
 
@@ -246,7 +343,7 @@ fn execute_decimal_at_width<W>(
     valid_rows: &Mask,
 ) -> VortexResult<ArrayRef>
 where
-    W: NativeDecimalType + CheckedAdd + CheckedSub,
+    W: DecimalLane,
     DecimalValue: From<W>,
 {
     macro_rules! execute_typed {
@@ -281,7 +378,7 @@ fn execute_decimal_typed<W, Op>(
     valid_rows: &Mask,
 ) -> VortexResult<ArrayRef>
 where
-    W: NativeDecimalType + CheckedAdd + CheckedSub,
+    W: DecimalLane,
     DecimalValue: From<W>,
     Op: CheckedDecimalOp,
 {
@@ -349,7 +446,7 @@ fn checked_decimal_arrays<W, Op>(
     valid_rows: &Mask,
 ) -> CheckedValues<W>
 where
-    W: NativeDecimalType + CheckedAdd + CheckedSub,
+    W: DecimalLane,
     Op: CheckedDecimalOp,
 {
     let len = lhs.len();

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
@@ -386,6 +386,135 @@ fn test_decimal_add_reserves_carry_digit() {
 }
 
 #[rstest]
+#[case::precision_1(1, 2)]
+#[case::precision_17(17, 18)]
+#[case::precision_37(37, 38)]
+// 39 digits do not fit an i128, so the carry digit is dropped rather than widening to i256.
+#[case::precision_38(38, 38)]
+#[case::precision_39(39, 40)]
+#[case::precision_75(75, 76)]
+#[case::precision_76(76, 76)]
+fn test_decimal_add_sub_result_precision(
+    #[case] precision: u8,
+    #[case] expected: u8,
+    #[values(NumericOperator::Add, NumericOperator::Sub)] op: NumericOperator,
+) -> VortexResult<()> {
+    let result = result_decimal_dtype(DecimalDType::new(precision, 0), op)?;
+    assert_eq!(result.precision(), expected);
+    Ok(())
+}
+
+#[test]
+fn test_decimal_precision_38_saturation_reports_overflow() -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(38, 0);
+    let max = <i128 as NativeDecimalType>::MAX_BY_PRECISION[38];
+
+    // A sum that still fits 38 digits is exact and stays at the i128 working width.
+    let result = decimal_binary(
+        DecimalArray::from_iter::<i128, _>([max - 1], dtype).into_array(),
+        DecimalArray::from_iter::<i128, _>([1], dtype).into_array(),
+        Operator::Add,
+    )?;
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_iter::<i128, _>([max], dtype),
+        &mut ctx
+    );
+
+    // A sum needing the 39th digit is an overflow error, not a silent widening to i256.
+    assert!(
+        decimal_binary(
+            DecimalArray::from_iter::<i128, _>([max], dtype).into_array(),
+            DecimalArray::from_iter::<i128, _>([1], dtype).into_array(),
+            Operator::Add,
+        )
+        .is_err()
+    );
+    Ok(())
+}
+
+/// Every lane must agree with exact 256-bit arithmetic bounded by the result precision: an
+/// in-range pair produces the exact value, an out-of-range pair is an error. Covers each working
+/// width, including the two precisions where the result precision saturates.
+#[rstest]
+#[case::precision_2(2)]
+#[case::precision_4(4)]
+#[case::precision_9(9)]
+#[case::precision_18(18)]
+#[case::precision_38(38)]
+#[case::precision_39(39)]
+#[case::precision_76(76)]
+fn test_decimal_add_sub_matches_exact_arithmetic(
+    #[case] precision: u8,
+    #[values(NumericOperator::Add, NumericOperator::Sub)] op: NumericOperator,
+) -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+    let dtype = DecimalDType::new(precision, 0);
+    let result_dtype = result_decimal_dtype(dtype, op)?;
+    let result_precision = result_dtype.precision() as usize;
+    let lower = <i256 as NativeDecimalType>::MIN_BY_PRECISION[result_precision];
+    let upper = <i256 as NativeDecimalType>::MAX_BY_PRECISION[result_precision];
+
+    let max = <i256 as NativeDecimalType>::MAX_BY_PRECISION[precision as usize];
+    let half = max / i256::from_i128(2);
+    let operands = [i256::ZERO, i256::ONE, -i256::ONE, max, -max, half, -half];
+
+    let mut in_range = Vec::new();
+    for lhs in operands {
+        for rhs in operands {
+            // Both operands are in precision, so the exact result cannot itself overflow an i256.
+            let exact = match op {
+                NumericOperator::Add => lhs + rhs,
+                _ => lhs - rhs,
+            };
+            if lower <= exact && exact <= upper {
+                in_range.push((lhs, rhs, exact));
+                continue;
+            }
+            assert!(
+                decimal_binary(
+                    DecimalArray::from_iter::<i256, _>([lhs], dtype).into_array(),
+                    DecimalArray::from_iter::<i256, _>([rhs], dtype).into_array(),
+                    op.into(),
+                )
+                .is_err(),
+                "{lhs} {op} {rhs} is outside decimal({result_precision}, 0) and must error"
+            );
+        }
+    }
+
+    let result = decimal_binary(
+        DecimalArray::from_iter::<i256, _>(in_range.iter().map(|(lhs, ..)| *lhs), dtype)
+            .into_array(),
+        DecimalArray::from_iter::<i256, _>(in_range.iter().map(|(_, rhs, _)| *rhs), dtype)
+            .into_array(),
+        op.into(),
+    )?;
+    assert_arrays_eq!(
+        result,
+        DecimalArray::from_iter::<i256, _>(
+            in_range.iter().map(|(_, _, exact)| *exact),
+            result_dtype
+        ),
+        &mut ctx
+    );
+    Ok(())
+}
+
+#[test]
+fn test_decimal_working_width_overflow_wrapping_into_precision_errors() {
+    // Out-of-precision inputs whose sum wraps the i128 working width back into the in-precision
+    // range: `i128::MAX + i128::MAX` wraps to -2. The bounds check alone would accept that, so the
+    // overflow check has to reject it first.
+    let dtype = DecimalDType::new(38, 0);
+    let lhs = DecimalArray::from_iter::<i128, _>([i128::MAX], dtype).into_array();
+    let rhs = DecimalArray::from_iter::<i128, _>([i128::MAX], dtype).into_array();
+
+    assert!(decimal_binary(lhs, rhs, Operator::Add).is_err());
+}
+
+#[rstest]
 #[case::precision_2(
     DecimalArray::from_iter::<i8, _>([10, 20], DecimalDType::new(2, 0)),
     DecimalType::I16,
@@ -394,9 +523,14 @@ fn test_decimal_add_reserves_carry_digit() {
     DecimalArray::from_iter::<i64, _>([10, 20], DecimalDType::new(18, 0)),
     DecimalType::I128,
 )]
+#[case::precision_37(
+    DecimalArray::from_iter::<i128, _>([10, 20], DecimalDType::new(37, 0)),
+    DecimalType::I128,
+)]
+// The carry digit saturates at 38 rather than promoting the result to an i256 working width.
 #[case::precision_38(
     DecimalArray::from_iter::<i128, _>([10, 20], DecimalDType::new(38, 0)),
-    DecimalType::I256,
+    DecimalType::I128,
 )]
 #[case::precision_76(
     DecimalArray::from_iter::<i256, _>(


### PR DESCRIPTION
## Rationale for this change

Three independent per-lane costs in the native decimal kernels. All are hot in decimal-heavy scans, and all are paid on every row.

**1. `i256` overflow detection re-derives what the addition already knew.** `arrow_buffer::i256::checked_add` computes the wrapped sum and then infers overflow from the operand ordering — two full 256-bit three-way comparisons plus short-circuit branches. Signed overflow is a property of the sign bit alone, so it can be read off the high limbs. Native `i128` gets the same answer from a single `seto`.

**2. Vortex then stacks two more branchy `i256` compares on top.** `DecimalValueBounds::in_precision` bounds-checked the candidate result with `lower <= v && v <= upper`. That is four three-way comparisons per lane in total, and for `i256` every one of them is a 256-bit lexicographic compare.

**3. `result_decimal_dtype` promoted `p = 38` to `39`, which forces an `i256` working width.** `Decimal(38, s)` is by far the most common wide decimal, and 39 digits do not fit an `i128`, so reserving the carry digit put every lane of that operation — and of every later operation on the result — through software 256-bit arithmetic for the sake of one digit. Measured 2.4x tax on identical `i128`-stored data. Arrow saturates the result precision at its own type boundary rather than widening.

**4. `compare_decimal_values` materialized a widened buffer per operand.** Because compressed chunks are narrowed independently, operands with different storage widths are the normal case rather than the exception, so this allocation-and-copy ran on most decimal comparisons.

## What changes are included in this PR?

`vortex-array/src/dtype/bigint/mod.rs`

- New `i256::overflowing_add` / `overflowing_sub`, deriving overflow from the high limbs: `((a ^ r) & (b ^ r)) < 0` for addition, `((a ^ b) & (a ^ r)) < 0` for subtraction.
- New inherent `i256::wrapping_sub`, alongside the existing `wrapping_add`.
- `CheckedAdd` / `CheckedSub` for `i256` now go through those, so every caller benefits.

`vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs`

- New private `DecimalLane` trait carrying the overflow test, a wrapping subtract, and an unsigned comparison. Implemented for `i8`..`i128` over the built-in `overflowing_*`, and for `i256` over the new methods.
- `DecimalValueBounds` stores `lower_bound` and `span` (`upper - lower`) instead of a bound pair. `in_precision` biases by the lower bound so both sides collapse into one unsigned comparison: `v` is in `[lower, upper]` exactly when `v - lower`, read unsigned, is at most `span`.
- `CheckedDecimalAdd` / `CheckedDecimalSub` combine the two tests branchlessly (`!overflow & in_precision`). Both tests are kept: the overflow test is what stops a working-width wrap from landing back inside the precision bounds and being accepted.
- The Add/Sub carry digit now saturates at 38 the way it already saturated at 76.

`vortex-array/src/scalar_fn/fns/binary/compare/{decimal,mod}.rs`

- `compare_slices` is generic over both operand storage widths plus the comparison width, and widens the narrow side lane by lane inside the loop. Dispatch splits on which side is narrower, so the widening cast constant-folds to a sign extension.
- `collect_zip_bits` takes two element types rather than one.

`vortex-array/benches/decimal_binary.rs` (new)

- The overflow and bounds tests over contiguous `i256` buffers, in three forms (`checked_add`, `checked_add` + naive bounds, fused), spelled out so they can be compared from any revision.
- Add/Sub through the kernel at each working width, with `p37`/`p38` isolating the precision tax on identically stored data.
- Comparison at same and mixed storage widths, both operand orders.

### Measurements

`cargo bench -p vortex-array --bench decimal_binary`, 65,536 lanes, divan `fastest`:

| benchmark | before | after | speedup |
| --- | --- | --- | --- |
| `checked_add_i256` | 242.0 µs | 154.0 µs | 1.57x |
| `checked_add_bounds_i256` | 789.5 µs | 255.6 µs | 3.09x |
| `add_i128_p38` | 372.7 µs | 153.7 µs | 2.42x |
| `add_i256_p76` | 370.0 µs | 314.1 µs | 1.18x |
| `sub_i256_p76` | 385.2 µs | 317.1 µs | 1.21x |
| `compare_i32_i128_p38` | 111.5 µs | 64.1 µs | 1.74x |
| `compare_i128_i32_p38` | 111.4 µs | 64.0 µs | 1.74x |
| `compare_i64_i256_p76` | 281.4 µs | 126.5 µs | 2.22x |
| `add_i128_p37` (control, untouched path) | 156.5 µs | 154.1 µs | 1.02x |
| `compare_i128_i128_p38` (control, same widths) | 65.7 µs | 68.6 µs | 0.96x |
| `overflowing_add_bounds_i256` (bench-local, unchanged code) | 212.4 µs | 208.7 µs | 1.02x |

`add_i128_p38` at 153.7 µs now matches `add_i128_p37` at 154.1 µs, so the precision tax is gone rather than reduced. The two controls and the unchanged-code benchmark bound run-to-run noise at a few percent.

### Tests

- `i256` overflow at both boundaries, opposite-sign pairs that can never overflow, and carries/borrows across the limb boundary that are not overflows.
- A differential test that every Add/Sub lane agrees with exact 256-bit arithmetic bounded by the result precision, over in-precision extremes at precisions 2, 4, 9, 18, 38, 39 and 76 — so each working width is covered, including both saturating precisions. In-range pairs must produce the exact value; out-of-range pairs must error.
- `test_decimal_working_width_overflow_wrapping_into_precision_errors`: `i128::MAX + i128::MAX` at `Decimal(38, 0)` wraps to `-2`, which the bounds test alone would accept. Pins the overflow test as load-bearing.
- `test_decimal_precision_38_saturation_reports_overflow`: a sum that still fits 38 digits stays exact at the `i128` working width; one needing the 39th digit errors.
- Mixed-width comparison against the value ordering for all six operators in both operand orders, plus `i64` against `i256` so the narrow side is sign extended across the limb boundary.

## What APIs are changed? Are there any user-facing changes?

Two user-facing changes.

**`Decimal(38, s)` Add/Sub now yields `Decimal(38, s)` instead of `Decimal(39, s)`.** Sums that need the 39th digit are now an overflow error instead of a widened result. This matches Arrow, which caps an Add/Sub result at the maximum precision of the operand type rather than widening. Precisions below 38 and above 38 are unchanged: the carry digit is still reserved (it stays inside a native integer, or the column is already `i256`), and precision 76 still saturates as before.

**New public methods on `vortex_array::dtype::i256`**: `overflowing_add`, `overflowing_sub`, `wrapping_sub`. Additive only. `CheckedAdd`/`CheckedSub` for `i256` keep their existing semantics; only the derivation changed.

No documentation updates needed — the module docs for both kernels are updated in place.

### Checks run

- `cargo nextest run -p vortex-array` — 3188 passed, 1 skipped
- `cargo nextest run -p vortex-btrblocks -p vortex-datafusion -p vortex-compressor` — 332 passed
- `cargo nextest run -p vortex-file -p vortex-scan` — 143 passed
- `cargo test --doc -p vortex-array` — 72 passed
- `cargo clippy -p vortex-array --all-targets --all-features` — clean
- `cargo +nightly fmt --all`, `git diff --check` — clean

Not run in this environment: `cargo build --workspace` and `cargo clippy` workspace-wide fail before reaching Vortex code — `lance-encoding` (a `vortex-bench` dependency) needs `protoc`, and `vortex-duckdb`'s build script needs its C++ toolchain. Neither is reachable here and neither is touched by this change. Python bindings were not exercised; no Python or PyO3 files changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_016JAuvhRLYRXN9DaHoehUCP)_