### PR TITLE
Purge remnants of the old benchmarks website versions

### DIFF
--- a/.agents/skills/bench-performance/SKILL.md
+++ b/.agents/skills/bench-performance/SKILL.md
@@ -114,7 +114,7 @@ Supported diagnostics:
 
 - `--formats parquet,vortex,vortex-compact,lance,arrow`;
 - `--queries 6`, `--exclude-queries 1,2`, `--iterations N`, `--display-format gh-json`;
-- `--hide-progress-bar`, `-o /private/tmp/out.jsonl`, `--gh-json-v3 /private/tmp/out.v3.jsonl`;
+- `--hide-progress-bar`, `-o /private/tmp/out.jsonl`, `--ingest-jsonl /private/tmp/out.ingest.jsonl`;
 - `--verbose`, `--tracing`, `--track-memory`, `--runner NAME`, `--opt key=value`;
 - `--explain` prints query plans instead of timing;
 - `--show-metrics` prints Vortex execution-plan metrics after a timed run.
@@ -149,7 +149,7 @@ Supported diagnostics:
 - `--reuse` keeps one DuckDB connection across iterations, useful with Samply to keep work on the
   same threads;
 - common flags: `--queries`, `--exclude-queries`, `--iterations`, `--display-format`,
-  `--hide-progress-bar`, `-o`, `--gh-json-v3`, `--track-memory`, `--verbose`, `--tracing`,
+  `--hide-progress-bar`, `-o`, `--ingest-jsonl`, `--track-memory`, `--verbose`, `--tracing`,
   `--runner`, `--opt`, `--explain`.
 
 Example:
@@ -171,7 +171,7 @@ Important differences:
 - no `--formats`: the binary always generates/registers Lance data and reports `datafusion:lance`;
 - no `--explain` or `--show-metrics` path today;
 - common flags: `--queries`, `--exclude-queries`, `--iterations`, `--display-format`,
-  `--hide-progress-bar`, `-o`, `--gh-json-v3`, `--track-memory`, `--verbose`, `--tracing`,
+  `--hide-progress-bar`, `-o`, `--ingest-jsonl`, `--track-memory`, `--verbose`, `--tracing`,
   `--runner`, `--opt`;
 - `--threads` is parsed but currently not wired into the Lance/DataFusion session.
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -94,7 +94,7 @@ jobs:
           VORTEX_EXPERIMENTAL_PATCHED_ARRAY: "1"
           FLAT_LAYOUT_INLINE_ARRAY_NODE: "1"
         run: |
-          python3 scripts/random-access-split.py --v3
+          python3 scripts/random-access-split.py --emit-ingest-records
 
       - name: Run ${{ matrix.benchmark.name }} benchmark
         if: matrix.benchmark.id != 'random-access-bench'
@@ -104,7 +104,7 @@ jobs:
           VORTEX_EXPERIMENTAL_PATCHED_ARRAY: "1"
           FLAT_LAYOUT_INLINE_ARRAY_NODE: "1"
         run: |
-          bash scripts/bench-taskset.sh target/release_debug/${{ matrix.benchmark.id }} --formats ${{ matrix.benchmark.formats }} -d gh-json -o results.json --gh-json-v3 results.v3.jsonl
+          bash scripts/bench-taskset.sh target/release_debug/${{ matrix.benchmark.id }} --formats ${{ matrix.benchmark.formats }} -d gh-json -o results.json --ingest-jsonl results.ingest.jsonl
 
       - name: Setup AWS CLI
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6
@@ -153,7 +153,7 @@ jobs:
             -o "${RUNNER_TEMP}/rds-global-bundle.pem"
           DSN="postgresql://bench_ingest@${RDS_BENCH_INSTANCE_ENDPOINT}:5432/${RDS_BENCH_DB_NAME}?sslmode=verify-full&sslrootcert=${RUNNER_TEMP}/rds-global-bundle.pem"
           uv run --no-project --with 'psycopg[binary]' --with boto3 --with xxhash \
-            scripts/post-ingest.py results.v3.jsonl \
+            scripts/post-ingest.py results.ingest.jsonl \
             --postgres "${DSN}" \
             --commit-sha "${{ github.sha }}" \
             --region "${AWS_REGION}"

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -642,7 +642,7 @@ jobs:
           bash scripts/bench-taskset.sh uv run --project bench-orchestrator vx-bench run "${{ matrix.subcommand }}" \
             --targets-json '${{ steps.targets.outputs.targets_json }}' \
             --output results.json \
-            --gh-json-v3 results.v3.jsonl \
+            --ingest-jsonl results.ingest.jsonl \
             --no-build \
             --runner "ec2_${{ inputs.machine_type }}" \
             ${{ matrix.iterations && format('--iterations {0}', matrix.iterations) || '' }} \
@@ -662,7 +662,7 @@ jobs:
           bash scripts/bench-taskset.sh uv run --project bench-orchestrator vx-bench run "${{ matrix.subcommand }}" \
             --targets-json '${{ steps.targets.outputs.targets_json }}' \
             --output results.json \
-            --gh-json-v3 results.v3.jsonl \
+            --ingest-jsonl results.ingest.jsonl \
             --no-build \
             --runner "ec2_${{ inputs.machine_type }}" \
             ${{ matrix.iterations && format('--iterations {0}', matrix.iterations) || '' }} \
@@ -747,7 +747,7 @@ jobs:
             -o "${RUNNER_TEMP}/rds-global-bundle.pem"
           DSN="postgresql://bench_ingest@${RDS_BENCH_INSTANCE_ENDPOINT}:5432/${RDS_BENCH_DB_NAME}?sslmode=verify-full&sslrootcert=${RUNNER_TEMP}/rds-global-bundle.pem"
           uv run --no-project --with 'psycopg[binary]' --with boto3 --with xxhash \
-            scripts/post-ingest.py results.v3.jsonl \
+            scripts/post-ingest.py results.ingest.jsonl \
             --postgres "${DSN}" \
             --commit-sha "${{ github.sha }}" \
             --region "${AWS_REGION}"

--- a/bench-orchestrator/bench_orchestrator/cli.py
+++ b/bench-orchestrator/bench_orchestrator/cli.py
@@ -119,32 +119,32 @@ def open_results_output(path: Path | None):
 
 
 @contextmanager
-def temporary_v3_output_dir(enabled: bool):
-    """Create a temporary directory for per-backend v3 JSONL files."""
+def temporary_ingest_output_dir(enabled: bool):
+    """Create a temporary directory for per-backend ingest JSONL files."""
     if not enabled:
         yield None
         return
 
-    with TemporaryDirectory(prefix="vx-bench-v3-") as temp_dir:
+    with TemporaryDirectory(prefix="vx-bench-ingest-") as temp_dir:
         yield Path(temp_dir)
 
 
-def backend_v3_output_path(temp_dir: Path | None, index: int, backend: Engine) -> Path | None:
-    """Return the v3 JSONL path a backend should write, if v3 output is enabled."""
+def backend_ingest_output_path(temp_dir: Path | None, index: int, backend: Engine) -> Path | None:
+    """Return the ingest JSONL path a backend should write, if enabled."""
     if temp_dir is None:
         return None
     return temp_dir / f"{index:02d}-{backend.value}.jsonl"
 
 
-def write_combined_v3_output(output_path: Path, input_paths: list[Path]) -> None:
-    """Concatenate successful per-backend v3 JSONL files into the requested output."""
+def write_combined_ingest_output(output_path: Path, input_paths: list[Path]) -> None:
+    """Concatenate successful per-backend ingest JSONL files into the requested output."""
     if output_path.parent != Path():
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with output_path.open("w", encoding="utf-8") as output:
         for input_path in input_paths:
             if not input_path.exists():
-                raise RuntimeError(f"v3 output was not written by benchmark backend: {input_path}")
+                raise RuntimeError(f"ingest output was not written by benchmark backend: {input_path}")
             with input_path.open("r", encoding="utf-8") as input_file:
                 for line in input_file:
                     output.write(line)
@@ -245,9 +245,9 @@ def run(
         Path | None,
         typer.Option("--output", help="Optional path for compatibility JSONL output"),
     ] = None,
-    gh_json_v3: Annotated[
+    ingest_output: Annotated[
         Path | None,
-        typer.Option("--gh-json-v3", help="Optional path for v3 JSONL records emitted by the benchmark binary"),
+        typer.Option("--ingest-jsonl", help="Optional path for ingest JSONL records emitted by the benchmark binary"),
     ] = None,
     options: Annotated[list[str] | None, typer.Option("--opt", help="Engine or benchmark specific options")] = None,
 ) -> None:
@@ -318,13 +318,13 @@ def run(
         with (
             store.create_run(config, build_config) as ctx,
             open_results_output(output) as compatibility_file,
-            temporary_v3_output_dir(gh_json_v3 is not None) as v3_temp_dir,
+            temporary_ingest_output_dir(ingest_output is not None) as ingest_temp_dir,
         ):
-            v3_output_parts: list[Path] = []
+            ingest_output_parts: list[Path] = []
             for backend_idx, (backend, backend_targets) in enumerate(backend_groups.items()):
                 executor = BenchmarkExecutor(binary_paths[backend], backend, verbose=verbose)
                 backend_formats = [target.format for target in backend_targets]
-                backend_gh_json_v3 = backend_v3_output_path(v3_temp_dir, backend_idx, backend)
+                backend_ingest_output = backend_ingest_output_path(ingest_temp_dir, backend_idx, backend)
 
                 try:
                     results = executor.run(
@@ -339,7 +339,7 @@ def run(
                         sample_rate=sample_rate,
                         tracing=tracing,
                         runner=runner,
-                        gh_json_v3=backend_gh_json_v3,
+                        ingest_output=backend_ingest_output,
                         on_result=lambda line, store_writer=ctx.write_raw_json, compatibility=compatibility_file: (
                             write_result_line(
                                 line,
@@ -348,8 +348,8 @@ def run(
                             )
                         ),
                     )
-                    if backend_gh_json_v3 is not None:
-                        v3_output_parts.append(backend_gh_json_v3)
+                    if backend_ingest_output is not None:
+                        ingest_output_parts.append(backend_ingest_output)
                     console.print(f"[green]{backend.value}: {len(results)} results[/green]")
                 except RuntimeError as exc:
                     ctx.metadata.partial = True
@@ -358,8 +358,8 @@ def run(
                     console.print(f"[red]{backend.value} failed: {exc}[/red]")
                     soft_failures.append(str(exc))
 
-            if gh_json_v3 is not None:
-                write_combined_v3_output(gh_json_v3, v3_output_parts)
+            if ingest_output is not None:
+                write_combined_ingest_output(ingest_output, ingest_output_parts)
 
             ctx.metadata.binaries = {backend.value: str(path) for backend, path in binary_paths.items()}
     except RuntimeError as exc:

--- a/bench-orchestrator/bench_orchestrator/runner/executor.py
+++ b/bench-orchestrator/bench_orchestrator/runner/executor.py
@@ -40,7 +40,7 @@ class BenchmarkExecutor:
         sample_rate: int | None = None,
         tracing: bool = False,
         runner: str | None = None,
-        gh_json_v3: Path | None = None,
+        ingest_output: Path | None = None,
     ) -> list[str]:
         """Build the command used to execute a benchmark binary."""
         cmd = [
@@ -68,8 +68,8 @@ class BenchmarkExecutor:
             cmd.append("--tracing")
         if runner:
             cmd.extend(["--runner", runner])
-        if gh_json_v3 is not None:
-            cmd.extend(["--gh-json-v3", str(gh_json_v3)])
+        if ingest_output is not None:
+            cmd.extend(["--ingest-jsonl", str(ingest_output)])
         if options:
             for key, value in options.items():
                 cmd.extend(["--opt", f"{key}={value}"])
@@ -101,7 +101,7 @@ class BenchmarkExecutor:
         sample_rate: int | None = None,
         tracing: bool = False,
         runner: str | None = None,
-        gh_json_v3: Path | None = None,
+        ingest_output: Path | None = None,
         on_result: Callable[[str], None] | None = None,
     ) -> list[str]:
         """
@@ -132,7 +132,7 @@ class BenchmarkExecutor:
             sample_rate=sample_rate,
             tracing=tracing,
             runner=runner,
-            gh_json_v3=gh_json_v3,
+            ingest_output=ingest_output,
         )
 
         if self.verbose:

--- a/bench-orchestrator/tests/test_cli.py
+++ b/bench-orchestrator/tests/test_cli.py
@@ -107,9 +107,9 @@ def test_run_writes_compatibility_results_output(tmp_path, monkeypatch) -> None:
     assert metadata["binaries"] == {"datafusion": str(binary_path)}
 
 
-def test_run_combines_gh_json_v3_output_per_backend(tmp_path, monkeypatch) -> None:
+def test_run_combines_ingest_output_per_backend(tmp_path, monkeypatch) -> None:
     run_store = ResultStore(base_dir=tmp_path / "runs")
-    output_path = tmp_path / "artifacts" / "results.v3.jsonl"
+    output_path = tmp_path / "artifacts" / "results.ingest.jsonl"
     binary_paths = {
         cli_module.Engine.DATAFUSION: tmp_path / "datafusion-bench",
         cli_module.Engine.DUCKDB: tmp_path / "duckdb-bench",
@@ -123,10 +123,10 @@ def test_run_combines_gh_json_v3_output_per_backend(tmp_path, monkeypatch) -> No
     seen_backend_paths = []
 
     def fake_run(self, **kwargs):
-        backend_output = kwargs["gh_json_v3"]
+        backend_output = kwargs["ingest_output"]
         assert backend_output is not None
         assert backend_output != output_path
-        backend_output.write_text(f"{self.backend.value}-v3\n", encoding="utf-8")
+        backend_output.write_text(f"{self.backend.value}-ingest\n", encoding="utf-8")
         seen_backend_paths.append(backend_output)
         return []
 
@@ -140,12 +140,12 @@ def test_run_combines_gh_json_v3_output_per_backend(tmp_path, monkeypatch) -> No
             "--targets-json",
             '[{"engine":"datafusion","format":"parquet"},{"engine":"duckdb","format":"parquet"}]',
             "--no-build",
-            "--gh-json-v3",
+            "--ingest-jsonl",
             str(output_path),
         ],
     )
 
     assert result.exit_code == 0
-    assert output_path.read_text(encoding="utf-8") == "datafusion-v3\nduckdb-v3\n"
+    assert output_path.read_text(encoding="utf-8") == "datafusion-ingest\nduckdb-ingest\n"
     assert len(seen_backend_paths) == 2
     assert seen_backend_paths[0] != seen_backend_paths[1]

--- a/bench-orchestrator/tests/test_executor.py
+++ b/bench-orchestrator/tests/test_executor.py
@@ -61,21 +61,21 @@ def test_build_command_omits_formats_for_lance_backend() -> None:
     assert "1,3" in cmd
 
 
-def test_build_command_includes_gh_json_v3_when_set() -> None:
+def test_build_command_includes_ingest_output_when_set() -> None:
     executor = BenchmarkExecutor(Path("/tmp/duckdb-bench"), Engine.DUCKDB)
 
     cmd = executor.build_command(
         benchmark=Benchmark.TPCH,
         formats=[Format.PARQUET],
-        gh_json_v3=Path("results.v3.jsonl"),
+        ingest_output=Path("results.ingest.jsonl"),
     )
 
-    assert "--gh-json-v3" in cmd
-    flag_idx = cmd.index("--gh-json-v3")
-    assert cmd[flag_idx + 1] == "results.v3.jsonl"
+    assert "--ingest-jsonl" in cmd
+    flag_idx = cmd.index("--ingest-jsonl")
+    assert cmd[flag_idx + 1] == "results.ingest.jsonl"
 
 
-def test_build_command_omits_gh_json_v3_when_unset() -> None:
+def test_build_command_omits_ingest_output_when_unset() -> None:
     executor = BenchmarkExecutor(Path("/tmp/duckdb-bench"), Engine.DUCKDB)
 
     cmd = executor.build_command(
@@ -83,7 +83,7 @@ def test_build_command_omits_gh_json_v3_when_unset() -> None:
         formats=[Format.PARQUET],
     )
 
-    assert "--gh-json-v3" not in cmd
+    assert "--ingest-jsonl" not in cmd
 
 
 def test_run_streams_logs_without_counting_them(tmp_path: Path) -> None:

--- a/benchmarks/compress-bench/src/main.rs
+++ b/benchmarks/compress-bench/src/main.rs
@@ -69,10 +69,9 @@ struct Args {
     display_format: DisplayFormat,
     #[arg(short, long)]
     output_path: Option<PathBuf>,
-    /// Additionally write v3 JSONL records to this path. See
-    /// `benchmarks-website/planning/02-contracts.md`.
-    #[arg(long)]
-    gh_json_v3: Option<PathBuf>,
+    /// Additionally write benchmark ingest JSONL records to this path.
+    #[arg(long = "ingest-jsonl")]
+    ingest_output: Option<PathBuf>,
     #[arg(long)]
     tracing: bool,
     /// Format for the primary stderr log sink. `text` is the default human-readable format;
@@ -94,7 +93,7 @@ async fn main() -> anyhow::Result<()> {
         args.ops,
         args.display_format,
         args.output_path,
-        args.gh_json_v3,
+        args.ingest_output,
     )
     .await
 }
@@ -123,7 +122,7 @@ async fn run_compress(
     ops: Vec<CompressOp>,
     display_format: DisplayFormat,
     output_path: Option<PathBuf>,
-    gh_json_v3: Option<PathBuf>,
+    ingest_output: Option<PathBuf>,
 ) -> anyhow::Result<()> {
     let targets = formats
         .iter()
@@ -195,7 +194,7 @@ async fn run_compress(
 
     progress.finish();
 
-    if let Some(path) = gh_json_v3 {
+    if let Some(path) = ingest_output {
         v3::write_jsonl_to_path(&path, &v3_records)?;
     }
 

--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -88,10 +88,9 @@ struct Args {
     #[arg(short)]
     output_path: Option<PathBuf>,
 
-    /// Additionally write v3 JSONL records to this path. See
-    /// `benchmarks-website/planning/02-contracts.md`.
-    #[arg(long)]
-    gh_json_v3: Option<PathBuf>,
+    /// Additionally write benchmark ingest JSONL records to this path.
+    #[arg(long = "ingest-jsonl")]
+    ingest_output: Option<PathBuf>,
 
     #[arg(long, default_value_t = false)]
     show_metrics: bool,
@@ -237,7 +236,7 @@ async fn main() -> anyhow::Result<()> {
             print_metrics(plans.as_ref());
         }
 
-        if let Some(path) = args.gh_json_v3.as_ref() {
+        if let Some(path) = args.ingest_output.as_ref() {
             v3::write_jsonl_to_path(path, &runner.v3_records())?;
         }
 

--- a/benchmarks/duckdb-bench/src/main.rs
+++ b/benchmarks/duckdb-bench/src/main.rs
@@ -65,10 +65,9 @@ struct Args {
     #[arg(short)]
     output_path: Option<PathBuf>,
 
-    /// Additionally write v3 JSONL records to this path. See
-    /// `benchmarks-website/planning/02-contracts.md`.
-    #[arg(long)]
-    gh_json_v3: Option<PathBuf>,
+    /// Additionally write benchmark ingest JSONL records to this path.
+    #[arg(long = "ingest-jsonl")]
+    ingest_output: Option<PathBuf>,
 
     #[arg(long, default_value_t = false)]
     track_memory: bool,
@@ -214,7 +213,7 @@ fn main() -> anyhow::Result<()> {
     )?;
 
     if !args.explain {
-        if let Some(path) = args.gh_json_v3.as_ref() {
+        if let Some(path) = args.ingest_output.as_ref() {
             v3::write_jsonl_to_path(path, &runner.v3_records())?;
         }
 

--- a/benchmarks/lance-bench/src/main.rs
+++ b/benchmarks/lance-bench/src/main.rs
@@ -61,10 +61,9 @@ struct Args {
     #[arg(short)]
     output_path: Option<PathBuf>,
 
-    /// Additionally write v3 JSONL records to this path. See
-    /// `benchmarks-website/planning/02-contracts.md`.
-    #[arg(long)]
-    gh_json_v3: Option<PathBuf>,
+    /// Additionally write benchmark ingest JSONL records to this path.
+    #[arg(long = "ingest-jsonl")]
+    ingest_output: Option<PathBuf>,
 
     #[arg(long, default_value_t = false)]
     hide_progress_bar: bool,
@@ -131,7 +130,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .await?;
 
-    if let Some(path) = args.gh_json_v3.as_ref() {
+    if let Some(path) = args.ingest_output.as_ref() {
         v3::write_jsonl_to_path(path, &runner.v3_records())?;
     }
 

--- a/benchmarks/random-access-bench/src/lib.rs
+++ b/benchmarks/random-access-bench/src/lib.rs
@@ -293,8 +293,8 @@ pub struct RunConfig {
     pub display_format: DisplayFormat,
     /// Optional path for the primary result output.
     pub output_path: Option<PathBuf>,
-    /// Optional path for v3 JSONL benchmark records.
-    pub gh_json_v3: Option<PathBuf>,
+    /// Optional path for benchmark ingest JSONL records.
+    pub ingest_output: Option<PathBuf>,
 }
 
 /// Run random-access benchmarks with `config`.
@@ -307,7 +307,7 @@ pub async fn run(config: RunConfig) -> Result<()> {
         open_mode,
         display_format,
         output_path,
-        gh_json_v3,
+        ingest_output,
     } = config;
 
     let reopen_variants: &[bool] = match open_mode {
@@ -389,7 +389,7 @@ pub async fn run(config: RunConfig) -> Result<()> {
 
     progress.finish();
 
-    if let Some(path) = gh_json_v3 {
+    if let Some(path) = ingest_output {
         v3::write_jsonl_to_path(&path, &v3_records)?;
     }
 

--- a/benchmarks/random-access-bench/src/main.rs
+++ b/benchmarks/random-access-bench/src/main.rs
@@ -63,10 +63,9 @@ struct Args {
     display_format: DisplayFormat,
     #[arg(short)]
     output_path: Option<PathBuf>,
-    /// Additionally write v3 JSONL records to this path. See
-    /// `benchmarks-website/planning/02-contracts.md`.
-    #[arg(long)]
-    gh_json_v3: Option<PathBuf>,
+    /// Additionally write benchmark ingest JSONL records to this path.
+    #[arg(long = "ingest-jsonl")]
+    ingest_output: Option<PathBuf>,
     /// Which datasets to benchmark random access on.
     #[arg(
         long,
@@ -105,7 +104,7 @@ async fn main() -> Result<()> {
         open_mode: args.open_mode,
         display_format: args.display_format,
         output_path: args.output_path,
-        gh_json_v3: args.gh_json_v3,
+        ingest_output: args.ingest_output,
     };
 
     random_access_bench::run(run_config).await

--- a/scripts/post-ingest.py
+++ b/scripts/post-ingest.py
@@ -7,45 +7,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-"""Ingest a `--gh-json-v3` JSONL file into the benchmarks store.
+"""Ingest benchmark JSONL records into the v4 Postgres store.
 
-Reads bare v3 records from a JSONL file produced by `vortex-bench --gh-json-v3`
-and fills the `commit` fields by shelling out to `git show`. Two mutually
-exclusive ingest modes select the destination substrate:
+`vortex-bench --ingest-jsonl` writes the current versioned JSONL record shape. This script
+fills commit metadata from `git show`, computes the internal `measurement_id`,
+then atomically upserts the whole file into the RDS fact tables.
 
-- `--server <url>` (v3): wraps the records in an envelope and POSTs to
-  `<server>/api/ingest` with a bearer token. Standard library only -- urllib,
-  json, subprocess.
-- `--postgres <dsn>` (v4): computes the server-internal `measurement_id`
-  locally (via `_measurement_id.py`) and upserts directly into the RDS
-  Postgres tables with `INSERT ... ON CONFLICT (measurement_id) DO UPDATE`,
-  over a verify-full TLS connection, authenticating with an RDS IAM auth token
-  when the DSN carries no password. Requires `psycopg`, `boto3`, and `xxhash`
-  from the project environment; these are imported lazily inside the
-  `--postgres` code path so the v3 `--server` path stays standard-library-only
-  under a bare `python3` (CI invokes `python3 scripts/post-ingest.py`, not
-  `uv run`, and the v3 path is in production until the Phase 5 cutover). The
-  PEP 723 metadata block below intentionally keeps `dependencies = []` for that
-  reason; run the `--postgres` mode from the repo's uv environment.
+The wire contract is shared with the benchmarks-website repository:
 
-The default envelope size (60 MiB, just under the server's 64 MiB body limit)
-is sized so a single JSONL run normally posts in one envelope -- preserving the
-"per-file all-or-nothing" contract the server documents. If the JSONL is large
-enough that splitting kicks in, the script emits a warning and proceeds with the
-chunked semantics (per-chunk commit, mid-chunk failure leaves earlier chunks
-ingested; subsequent retries re-upsert via the server's ON CONFLICT idempotency
-on `measurement_id`). The `--postgres` mode applies a whole JSONL file in one
-transaction (all-or-nothing), with no chunking.
-
-Wire-contract pointers (kept in sync as a coordinated change per
-the `vortex-data/benchmarks-website` repo's `AGENTS.md`):
-
-- the `vortex-data/benchmarks-website` repo's `server/src/records.rs` - envelope + per-record wire
-  shapes that the server deserializes.
-- `vortex-bench/src/v3.rs` - bare-record producer that writes the JSONL this
-  script wraps.
-- the `vortex-data/benchmarks-website` repo's `server/src/schema.rs` - `SCHEMA_VERSION` source of
-  truth that the `SCHEMA_VERSION` constant below MUST equal at every bump.
+- `vortex-bench/src/v3.rs` owns the producer record shape.
+- `benchmarks-website/CONTRACT.md` documents the transport and schema contract.
+- `benchmarks-website/web/lib/schema-version.ts` is the `SCHEMA_VERSION` source
+  of truth that the constant below must match.
 """
 
 from __future__ import annotations
@@ -56,62 +29,40 @@ import math
 import os
 import subprocess
 import sys
-import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
-from datetime import UTC, datetime
 from pathlib import Path
 
-# MUST equal the `vortex-data/benchmarks-website` repo's `server/src/schema.rs::SCHEMA_VERSION`.
-# Bumping this is a coordinated change across schema.rs, records.rs, v3.rs,
-# and this script. See the `vortex-data/benchmarks-website` repo's `AGENTS.md` ("Wire shapes are a
-# coordinated change") for the full list of coupled sites.
+# MUST equal `benchmarks-website/web/lib/schema-version.ts::SCHEMA_VERSION`.
+# Bumping this is a coordinated change across the website contract, v3.rs, and
+# this script.
 SCHEMA_VERSION = 1
-# Default sized to fit comfortably under the server's 64 MiB ingest body
-# limit while leaving headroom for HTTP and JSON framing overhead. The
-# point is to keep a normal JSONL run in one envelope so the documented
-# "per-file all-or-nothing" contract holds.
-DEFAULT_MAX_ENVELOPE_BYTES = 60 * 1024 * 1024
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description=(
-            "Ingest a v3 JSONL records file: --server POSTs a v3 envelope to "
-            "/api/ingest; --postgres upserts directly into the RDS Postgres tables."
-        ),
-    )
+    parser = argparse.ArgumentParser(description="Ingest benchmark JSONL records into RDS Postgres.")
     parser.add_argument(
         "jsonl_path",
         type=Path,
-        help="Path to the JSONL file written by vortex-bench --gh-json-v3.",
+        help="Path to the JSONL file written by vortex-bench --ingest-jsonl.",
     )
-    mode = parser.add_mutually_exclusive_group(required=True)
-    mode.add_argument(
-        "--server",
-        help=(
-            "v3 mode: server base URL, e.g. http://localhost:8080. Wraps the "
-            "records in an envelope and POSTs to <server>/api/ingest with a "
-            "bearer token. Mutually exclusive with --postgres."
-        ),
-    )
-    mode.add_argument(
+    parser.add_argument(
         "--postgres",
         metavar="DSN",
+        required=True,
         help=(
-            "v4 mode: libpq DSN for the RDS Postgres ingest target, e.g. "
+            "Libpq DSN for the RDS Postgres ingest target, e.g. "
             "'postgresql://bench_ingest@host:5432/benchmarks?sslmode=verify-full"
             "&sslrootcert=/path/rds-ca.pem'. Computes measurement_id locally and "
             "upserts via INSERT ... ON CONFLICT DO UPDATE. If the DSN carries no "
-            "password, an RDS IAM auth token is minted for the DSN's user. "
-            "Mutually exclusive with --server."
+            "password, an RDS IAM auth token is minted for the DSN's user."
         ),
     )
     parser.add_argument(
         "--region",
         default=None,
         help=(
-            "AWS region for RDS IAM token minting (--postgres mode). Precedence: "
+            "AWS region for RDS IAM token minting. Precedence: "
             "this explicit --region, then the boto3 session region, then the region "
             "parsed from the RDS hostname."
         ),
@@ -120,18 +71,6 @@ def parse_args() -> argparse.Namespace:
         "--commit-sha",
         required=True,
         help="40-hex commit SHA. Usually ${{ github.sha }} in CI.",
-    )
-    parser.add_argument(
-        "--benchmark-id",
-        default=None,
-        help="Run identifier echoed back in run_meta.benchmark_id. Required for "
-        "--server mode; unused by --postgres mode (the v4 tables have no "
-        "benchmark_id column).",
-    )
-    parser.add_argument(
-        "--token-env",
-        default="INGEST_BEARER_TOKEN",
-        help="Env var holding the bearer token (default: INGEST_BEARER_TOKEN).",
     )
     parser.add_argument(
         "--repo-url",
@@ -148,13 +87,7 @@ def parse_args() -> argparse.Namespace:
         "--timeout",
         type=float,
         default=30.0,
-        help="HTTP timeout in seconds (default: 30).",
-    )
-    parser.add_argument(
-        "--max-envelope-bytes",
-        type=int,
-        default=DEFAULT_MAX_ENVELOPE_BYTES,
-        help=(f"Maximum encoded JSON bytes per POST before splitting records (default: {DEFAULT_MAX_ENVELOPE_BYTES})."),
+        help="Site cache refresh timeout in seconds (default: 30).",
     )
     return parser.parse_args()
 
@@ -216,120 +149,13 @@ def build_commit(sha: str, repo_url: str, git_dir: Path | None) -> dict:
     }
 
 
-def build_envelope(run_meta: dict, commit: dict, records: list[dict]) -> dict:
-    return {
-        "run_meta": run_meta,
-        "commit": commit,
-        "records": records,
-    }
+# `psycopg`, `boto3`, and `_measurement_id` (which pulls in `xxhash`) are
+# imported lazily below so `--help` and syntax checks need no optional packages.
 
-
-def encode_envelope(envelope: dict) -> bytes:
-    return json.dumps(envelope, separators=(",", ":")).encode("utf-8")
-
-
-def chunk_envelopes(
-    run_meta: dict,
-    commit: dict,
-    records: list[dict],
-    max_envelope_bytes: int,
-) -> list[tuple[dict, bytes]]:
-    if max_envelope_bytes <= 0:
-        raise SystemExit("--max-envelope-bytes must be positive")
-    if not records:
-        envelope = build_envelope(run_meta, commit, [])
-        return [(envelope, encode_envelope(envelope))]
-
-    # Cost model: re-encoding the growing envelope per record was O(N^2) in
-    # the size of the JSONL on the CI hot path. Instead track each record's
-    # encoded size once (`json.dumps(record)`) and reason about the
-    # cumulative chunk size via that plus per-record separator overhead
-    # plus a one-time envelope shell. Cross-check at chunk flush time by
-    # encoding the actual chunk and `assert len(body) <= cap` so a
-    # misestimation surfaces here, not at the server.
-    shell = build_envelope(run_meta, commit, [])
-    shell_bytes = len(encode_envelope(shell))
-    # `,` between records inside the JSON array.
-    record_sep_bytes = 1
-
-    def encoded_size(records_chunk: list[dict]) -> int:
-        env = build_envelope(run_meta, commit, records_chunk)
-        return len(encode_envelope(env))
-
-    encoded_records: list[bytes] = [json.dumps(r, separators=(",", ":")).encode("utf-8") for r in records]
-
-    chunks: list[tuple[dict, bytes]] = []
-    batch: list[dict] = []
-    batch_payload_bytes = 0
-
-    def flush_batch() -> None:
-        env = build_envelope(run_meta, commit, batch)
-        body = encode_envelope(env)
-        assert len(body) <= max_envelope_bytes, (
-            f"chunk_envelopes invariant violated: {len(body)} > {max_envelope_bytes}"
-        )
-        chunks.append((env, body))
-
-    for i, record in enumerate(records):
-        record_bytes = len(encoded_records[i])
-        # First record in a fresh batch has no separator before it.
-        delta = record_bytes if not batch else record_bytes + record_sep_bytes
-        projected = shell_bytes + batch_payload_bytes + delta
-
-        if not batch and projected > max_envelope_bytes:
-            # First record in a fresh batch ALONE exceeds the cap. Refuse
-            # rather than ship an over-cap chunk that the server will 413.
-            raise SystemExit(
-                f"single record exceeds --max-envelope-bytes "
-                f"(record {i} encodes to {record_bytes} bytes; "
-                f"envelope shell adds {shell_bytes}; cap is {max_envelope_bytes}). "
-                f"Raise --max-envelope-bytes, or trim the record before posting."
-            )
-
-        if batch and projected > max_envelope_bytes:
-            flush_batch()
-            batch = [record]
-            batch_payload_bytes = record_bytes
-        else:
-            batch.append(record)
-            batch_payload_bytes += delta
-
-    if batch:
-        flush_batch()
-    return chunks
-
-
-def post(server: str, body: bytes, token: str, timeout: float) -> tuple[int, bytes]:
-    url = f"{server.rstrip('/')}/api/ingest"
-    request = urllib.request.Request(
-        url,
-        data=body,
-        method="POST",
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {token}",
-        },
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
-            return response.status, response.read()
-    except urllib.error.HTTPError as exc:
-        return exc.code, exc.read()
-
-
-# --------------------------------------------------------------------------
-# Postgres dual-write mode (--postgres)
-# --------------------------------------------------------------------------
-# The v4 ingest path. `psycopg`, `boto3`, and `_measurement_id` (which pulls in
-# `xxhash`) are imported lazily inside the functions below so the v3 `--server`
-# path above stays standard-library-only under a bare `python3`.
-
-# Per-`kind` record field sets, mirroring the `#[serde(deny_unknown_fields)]`
-# structs in the `vortex-data/benchmarks-website` repo's `server/src/records.rs`. `required` plus
-# `optional` is the exact set of fields a record of that `kind` may carry
-# (besides `kind` itself); an unknown field is rejected loudly, preserving the
-# v3 server's deny_unknown_fields behavior so producer/schema drift surfaces
-# instead of silently dropping data. `optional` fields default to NULL.
+# Per-`kind` record field sets. `required` plus `optional` is the exact set of
+# fields a record of that `kind` may carry (besides `kind` itself); unknown
+# fields fail loudly so producer/schema drift cannot silently drop data.
+# `optional` fields default to NULL.
 _RECORD_FIELDS: dict[str, tuple[frozenset[str], frozenset[str]]] = {
     "query_measurement": (
         frozenset(
@@ -415,8 +241,7 @@ def _measurement_id_module():
 def _validate_record_fields(record: object, index: int) -> str:
     """Validate a record's `kind` and field set; return the `kind`.
 
-    Mirrors the server's deny_unknown_fields + required-field deserialization:
-    a non-object record, an unknown `kind`, an unknown field, or a missing
+    A non-object record, an unknown `kind`, an unknown field, or a missing
     required field is a loud error keyed by the record's index.
     """
     if not isinstance(record, dict):
@@ -431,7 +256,7 @@ def _validate_record_fields(record: object, index: int) -> str:
     present = set(record) - {"kind"}
     unknown = present - required - optional
     if unknown:
-        raise SystemExit(f"record {index} ({kind}): unknown field(s) {sorted(unknown)} (deny_unknown_fields)")
+        raise SystemExit(f"record {index} ({kind}): unknown field(s) {sorted(unknown)}")
     missing = required - present
     if missing:
         raise SystemExit(f"record {index} ({kind}): missing required field(s) {sorted(missing)}")
@@ -457,7 +282,7 @@ def _require_finite(value: object, field: str, kind: str, index: int) -> None:
         )
 
 
-# i32/i64 bounds enforced by the Postgres INTEGER/BIGINT columns and the v3 serde.
+# i32/i64 bounds enforced by the Postgres INTEGER/BIGINT columns.
 _INT32_MIN, _INT32_MAX = -(2**31), 2**31 - 1
 _INT64_MIN, _INT64_MAX = -(2**63), 2**63 - 1
 
@@ -467,11 +292,10 @@ def _require_int(value: object, field: str, kind: str, index: int, *, bits: int)
 
     The integer columns bind straight to INTEGER/BIGINT; psycopg adapts a Python
     float to float8 and Postgres assignment-casts (rounds) it, so a JSON float
-    would silently persist a rounded value where the v3 server's serde `i32`/`i64`
-    rejects it. An out-of-range integer would otherwise fail late as an uncaught
+    would silently persist a rounded value. An out-of-range integer would otherwise fail late as an uncaught
     `struct.error` (i32 hash dims via `_write_i32`) or a raw Postgres 22003
     overflow; validate the type AND width here so a malformed scalar fails loud
-    (record-indexed) instead, matching the v3 serde boundary.
+    with its record index.
     """
     lo, hi = (_INT32_MIN, _INT32_MAX) if bits == 32 else (_INT64_MIN, _INT64_MAX)
     if isinstance(value, bool) or not isinstance(value, int):
@@ -484,11 +308,11 @@ def _require_int_list(value: object, field: str, kind: str, index: int) -> None:
     """Raise loudly unless `value` is a JSON array of plain (non-bool) i64 integers.
 
     Guards the `all_runtimes_ns` -> `bigint[]` bind: the explicit `::bigint[]`
-    cast is permissive in ways the v3 server's `Vec<i64>` serde is not. psycopg
+    cast accepts values that are not valid JSON integer arrays. psycopg
     sends the string `"{}"` as text and the cast parses it into an empty array, a
     `[1, null]` list adapts to `{1,NULL}`, and an out-of-i64 element hits a raw
-    Postgres 22003 -- each diverges from or fails differently than the v3 path.
-    Validate the element type AND i64 range so a malformed value fails loud.
+    Postgres 22003. Validate the element type AND i64 range so a malformed value
+    fails loud.
     """
     if not isinstance(value, list) or any(isinstance(x, bool) or not isinstance(x, int) for x in value):
         raise SystemExit(f"record {index} ({kind}): {field} must be a JSON array of integers, got {value!r}")
@@ -497,7 +321,7 @@ def _require_int_list(value: object, field: str, kind: str, index: int) -> None:
 
 
 def _require_str(value: object, field: str, kind: str, index: int) -> None:
-    """Raise loudly unless `value` is a string. Mirrors the v3 serde `String` fields."""
+    """Raise loudly unless `value` is a string."""
     if not isinstance(value, str):
         raise SystemExit(f"record {index} ({kind}): {field} must be a string, got {value!r}")
 
@@ -511,8 +335,7 @@ def _require_opt_str(value: object, field: str, kind: str, index: int) -> None:
 def _memory_quartet_consistent(r: dict) -> bool:
     """The four `query_measurements` memory columns are all set or all absent.
 
-    Mirrors `ingest.rs::memory_quartet_consistent`: a partial quartet is a
-    validation error, not a half-populated row.
+    A partial quartet is a validation error, not a half-populated row.
     """
     present = [
         r.get("peak_physical") is not None,
@@ -523,9 +346,8 @@ def _memory_quartet_consistent(r: dict) -> bool:
     return not any(present) or all(present)
 
 
-# Per-kind field -> type token, mirroring the v3 server's typed serde boundary in
-# `records.rs`. The direct-to-Postgres writer can no longer lean on server-side
-# deserialization, so every field is type/range-validated here. Tokens:
+# Per-kind field -> type token. Every field is type/range-validated before the
+# direct Postgres write. Tokens:
 #   "str"     required String        "opt_str"  Option<String>
 #   "i32"     required i32           "i64"      required i64
 #   "opt_i64" Option<i64>            "i64_list" Vec<i64> (all_runtimes_ns)
@@ -593,13 +415,11 @@ _FIELD_TYPES: dict[str, tuple[tuple[str, str], ...]] = {
 
 
 def _validate_record_values(record: dict, kind: str, index: int) -> None:
-    """Validate every field's type/range against the v3 server's serde boundary.
+    """Validate every field's type/range before the Postgres write.
 
-    Runs in `ingest_postgres`'s loop (where the record index is known) so every
-    failure is reported as `record {index} ({kind}): ...`, matching the v3
-    server's indexed per-record errors. Drives field type/range checks off
-    `_FIELD_TYPES`, then applies the semantic checks the type alone does not cover
-    (the storage enum + memory quartet for query_measurements).
+    Runs in `ingest_postgres`'s loop, where the record index is known. It drives
+    type/range checks from `_FIELD_TYPES`, then applies semantic checks the type
+    alone does not cover (the storage enum + memory quartet for query_measurements).
     """
     for field, typ in _FIELD_TYPES[kind]:
         if typ == "str":
@@ -641,7 +461,7 @@ def _upsert_returning_was_update(conn, sql: str, params: tuple) -> bool:
     the flag from the single atomic statement removes that window. A duplicate
     `measurement_id` within ONE transaction is also handled correctly: the second
     upsert locks the tuple the first created (stamping its xmax), so it is
-    classified as an update, matching the v3 server. `sql` must end with
+    classified as an update. `sql` must end with
     `RETURNING (xmax = 0) AS inserted`.
     """
     row = conn.execute(sql, params).fetchone()
@@ -649,7 +469,7 @@ def _upsert_returning_was_update(conn, sql: str, params: tuple) -> bool:
 
 
 def _insert_query_measurement(conn, mid_mod, r: dict) -> bool:
-    """Upsert a `query_measurements` row. Mirrors `ingest.rs::insert_query_measurement`.
+    """Upsert a `query_measurements` row.
 
     Record values are validated by `_validate_record_values` before dispatch.
     """
@@ -712,7 +532,7 @@ def _insert_query_measurement(conn, mid_mod, r: dict) -> bool:
 
 
 def _insert_compression_time(conn, mid_mod, r: dict) -> bool:
-    """Upsert a `compression_times` row. Mirrors `ingest.rs::insert_compression_time`."""
+    """Upsert a `compression_times` row."""
     mid = mid_mod.measurement_id_compression_time(
         commit_sha=r["commit_sha"],
         dataset=r["dataset"],
@@ -749,7 +569,7 @@ def _insert_compression_time(conn, mid_mod, r: dict) -> bool:
 
 
 def _insert_compression_size(conn, mid_mod, r: dict) -> bool:
-    """Upsert a `compression_sizes` row. Mirrors `ingest.rs::insert_compression_size`."""
+    """Upsert a `compression_sizes` row."""
     mid = mid_mod.measurement_id_compression_size(
         commit_sha=r["commit_sha"],
         dataset=r["dataset"],
@@ -780,7 +600,7 @@ def _insert_compression_size(conn, mid_mod, r: dict) -> bool:
 
 
 def _insert_random_access(conn, mid_mod, r: dict) -> bool:
-    """Upsert a `random_access_times` row. Mirrors `ingest.rs::insert_random_access`."""
+    """Upsert a `random_access_times` row."""
     mid = mid_mod.measurement_id_random_access(
         commit_sha=r["commit_sha"],
         dataset=r["dataset"],
@@ -813,7 +633,7 @@ def _insert_random_access(conn, mid_mod, r: dict) -> bool:
 
 
 def _insert_vector_search(conn, mid_mod, r: dict) -> bool:
-    """Upsert a `vector_search_runs` row. Mirrors `ingest.rs::insert_vector_search`.
+    """Upsert a `vector_search_runs` row.
 
     `threshold` is validated finite by `_validate_record_values` before dispatch.
     """
@@ -874,7 +694,7 @@ _APPLY_RECORD = {
 
 
 def _upsert_commit(conn, commit: dict) -> None:
-    """Upsert the `commits` dim row. Mirrors `ingest.rs::upsert_commit`."""
+    """Upsert the `commits` dimension row."""
     conn.execute(
         """
         INSERT INTO commits (
@@ -905,20 +725,17 @@ def _upsert_commit(conn, commit: dict) -> None:
     )
 
 
-# Mirrors the v3 server's `WRITE_CONFLICT_ATTEMPTS`
-# (the `vortex-data/benchmarks-website` repo's `server/src/ingest.rs`). The DuckDB ingest wrapped
-# `apply_envelope_once` in `retry_write_conflicts`; the DuckDB -> Postgres substrate change
-# must preserve that behavior, since the dual-write CI runs ~14 concurrent writers.
+# CI runs concurrent writers whose upserts can touch commits and dimensions in
+# conflicting orders. Retrying transaction-level deadlocks and serialization
+# failures keeps each JSONL file all-or-nothing.
 _WRITE_CONFLICT_ATTEMPTS = 128
 
 
 def _retry_write_conflicts(op):
-    """Retry `op` on a Postgres write conflict, mirroring the v3 server's `retry_write_conflicts`.
+    """Retry `op` on a Postgres write conflict.
 
-    The v3 DuckDB ingest retried on write conflicts up to `WRITE_CONFLICT_ATTEMPTS` times; the
-    Postgres writer must preserve that, because the dual-write CI runs many concurrent writers
-    whose row-level `ON CONFLICT DO UPDATE` upserts touching the same `commits` / dim rows in
-    conflicting orders can deadlock. The retryable analogs on Postgres are deadlock
+    Row-level `ON CONFLICT DO UPDATE` upserts touching the same commits or
+    dimensions in conflicting orders can deadlock. The retryable Postgres errors are deadlock
     (`SQLSTATE 40P01`) and serialization failure (`40001`); both abort one transaction cleanly,
     so re-running the whole transaction is safe. A non-retryable error (e.g. a validation
     `SystemExit`) propagates immediately. Returns `op`'s value on the first success.
@@ -931,31 +748,23 @@ def _retry_write_conflicts(op):
         except (pg_errors.DeadlockDetected, pg_errors.SerializationFailure):
             # The failing `op`'s `with conn.transaction()` block already rolled back, so the
             # connection is idle and the whole transaction can be retried. Re-raise on the
-            # final attempt (mirrors v3 returning the error after the last try; the bare
-            # retry loop mirrors v3's `std::thread::yield_now()` between attempts).
+            # final attempt.
             if attempt >= _WRITE_CONFLICT_ATTEMPTS:
                 raise
     raise AssertionError("unreachable: _retry_write_conflicts exited without return or raise")
 
 
 def ingest_postgres(conn, commit: dict, records: list[dict]) -> tuple[int, int]:
-    """Upsert a commit and its records into Postgres, retrying on write conflicts.
-
-    Wraps `_ingest_postgres_once` in `_retry_write_conflicts` (mirroring the v3 server's
-    `apply_envelope = retry_write_conflicts(apply_envelope_once)`). Returns `(inserted, updated)`
-    aggregated across all fact tables.
-    """
+    """Upsert a commit and its records into Postgres, retrying on write conflicts."""
     mid_mod = _measurement_id_module()
     return _retry_write_conflicts(lambda: _ingest_postgres_once(conn, commit, records, mid_mod))
 
 
 def _ingest_postgres_once(conn, commit: dict, records: list[dict], mid_mod) -> tuple[int, int]:
-    """Upsert a commit and its records into Postgres in one transaction (a single attempt).
+    """Upsert a commit and its records in one transaction (a single attempt).
 
-    Mirrors the v3 server's `apply_envelope_once`: upsert `commits` first, then each fact
-    record, classifying each as inserted or updated. Any validation failure rolls the whole
-    transaction back (all-or-nothing). Returns `(inserted, updated)` aggregated across all
-    fact tables.
+    Upsert `commits` first, then each fact record while classifying it as inserted
+    or updated. Any validation failure rolls the whole transaction back.
     """
     inserted = 0
     updated = 0
@@ -966,7 +775,7 @@ def _ingest_postgres_once(conn, commit: dict, records: list[dict], mid_mod) -> t
             if record["commit_sha"] != commit["sha"]:
                 raise SystemExit(
                     f"record {idx} ({kind}): commit_sha {record['commit_sha']!r} does not "
-                    f"match envelope commit.sha {commit['sha']!r}"
+                    f"match the requested commit SHA {commit['sha']!r}"
                 )
             _validate_record_values(record, kind, idx)
             if _APPLY_RECORD[kind](conn, mid_mod, record):
@@ -1160,11 +969,8 @@ def _main_postgres(args: argparse.Namespace) -> int:
             separators=(",", ":"),
         )
     )
-    # Best-effort site-cache refresh after a successful write. No-op unless both
-    # env vars are set (so the script stays inert until the ops wiring lands),
-    # and it can never fail the ingest. The ops prerequisite (setting the two env
-    # vars in Vercel and as GitHub secrets/vars) is documented in the "Ops
-    # prerequisite" section of .big-plans/ct__bench-v4-uiux-r3-design.md.
+    # Best-effort site-cache refresh after a successful write. It runs only
+    # when both environment variables are configured and can never fail ingest.
     base_url = os.environ.get("BENCH_SITE_BASE_URL")
     revalidate_token = os.environ.get("BENCH_REVALIDATE_TOKEN")
     if base_url and revalidate_token:
@@ -1172,83 +978,8 @@ def _main_postgres(args: argparse.Namespace) -> int:
     return 0
 
 
-def _main_server(args: argparse.Namespace) -> int:
-    if args.benchmark_id is None:
-        print("error: --benchmark-id is required in --server mode", file=sys.stderr)
-        return 2
-    token = os.environ.get(args.token_env)
-    if not token:
-        print(
-            f"error: env var {args.token_env} is not set",
-            file=sys.stderr,
-        )
-        return 2
-
-    records = read_records(args.jsonl_path)
-    commit = build_commit(args.commit_sha, args.repo_url, args.git_dir)
-    run_meta = {
-        "benchmark_id": args.benchmark_id,
-        "schema_version": SCHEMA_VERSION,
-        "started_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
-    }
-
-    chunks = chunk_envelopes(run_meta, commit, records, args.max_envelope_bytes)
-    if len(chunks) > 1:
-        print(
-            f"warning: JSONL exceeds --max-envelope-bytes ({args.max_envelope_bytes} B); "
-            f"splitting into {len(chunks)} envelopes. Each chunk commits independently on "
-            "the server, so a mid-stream failure leaves earlier chunks ingested. "
-            "Re-run on failure to re-upsert via measurement_id ON CONFLICT.",
-            file=sys.stderr,
-        )
-    inserted = 0
-    updated = 0
-    raw_bodies: list[str] = []
-    for idx, (envelope, body) in enumerate(chunks, start=1):
-        if len(chunks) > 1:
-            print(
-                f"POST chunk {idx}/{len(chunks)} records={len(envelope['records'])} bytes={len(body)}",
-                file=sys.stderr,
-            )
-        status, response = post(args.server, body, token, args.timeout)
-        body_text = response.decode("utf-8", errors="replace")
-
-        if status >= 400:
-            print(
-                f"error: POST {args.server}/api/ingest chunk {idx}/{len(chunks)} -> {status}\n{body_text}",
-                file=sys.stderr,
-            )
-            return 1
-
-        try:
-            parsed = json.loads(body_text)
-            inserted += int(parsed.get("inserted", 0))
-            updated += int(parsed.get("updated", 0))
-        except (TypeError, ValueError, json.JSONDecodeError):
-            raw_bodies.append(body_text)
-
-    if raw_bodies:
-        print("\n".join(raw_bodies))
-    else:
-        print(
-            json.dumps(
-                {
-                    "chunks": len(chunks),
-                    "records": len(records),
-                    "inserted": inserted,
-                    "updated": updated,
-                },
-                separators=(",", ":"),
-            )
-        )
-    return 0
-
-
 def main() -> int:
-    args = parse_args()
-    if args.postgres is not None:
-        return _main_postgres(args)
-    return _main_server(args)
+    return _main_postgres(parse_args())
 
 
 if __name__ == "__main__":

--- a/scripts/random-access-split.py
+++ b/scripts/random-access-split.py
@@ -23,7 +23,7 @@ PATTERNS = ["correlated", "uniform"]
 OPEN_MODES = ["cached", "reopen"]
 
 
-def run_combinations(emit_v3: bool) -> None:
+def run_combinations(emit_ingest_records: bool) -> None:
     PARTS_DIR.mkdir(parents=True, exist_ok=True)
     i = 0
     for dataset in DATASETS:
@@ -47,8 +47,8 @@ def run_combinations(emit_v3: bool) -> None:
                         "-o",
                         str(PARTS_DIR / f"{i}.gh.json"),
                     ]
-                    if emit_v3:
-                        args += ["--gh-json-v3", str(PARTS_DIR / f"{i}.v3.jsonl")]
+                    if emit_ingest_records:
+                        args += ["--ingest-jsonl", str(PARTS_DIR / f"{i}.ingest.jsonl")]
                     print("+", " ".join(args), flush=True)
                     subprocess.run(args, check=True)
                     i += 1
@@ -82,19 +82,19 @@ def merge(pattern: str, key: Callable[[dict], object], out_path: str) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--v3",
+        "--emit-ingest-records",
         action="store_true",
-        help="merge --gh-json-v3 records into results.v3.jsonl",
+        help="merge --ingest-jsonl records into results.ingest.jsonl",
     )
     args = parser.parse_args()
 
-    run_combinations(args.v3)
+    run_combinations(args.emit_ingest_records)
     merge(f"{PARTS_DIR}/*.gh.json", lambda record: record["name"], "results.json")
-    if args.v3:
+    if args.emit_ingest_records:
         merge(
-            f"{PARTS_DIR}/*.v3.jsonl",
+            f"{PARTS_DIR}/*.ingest.jsonl",
             lambda record: (record["kind"], record["dataset"], record["format"]),
-            "results.v3.jsonl",
+            "results.ingest.jsonl",
         )
 
 

--- a/vortex-bench/src/v3.rs
+++ b/vortex-bench/src/v3.rs
@@ -1,19 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! v3 wire-format records emitted by `--gh-json-v3`.
+//! Benchmark wire-format records emitted by `--ingest-jsonl`.
 //!
 //! Each record on the wire is one of five `kind`-discriminated shapes that
-//! map 1:1 to the v3 fact tables. The records here are **bare**: the
-//! ingest envelope (`run_meta` + `commit`) is added by
-//! `scripts/post-ingest.py` before POSTing to
-//! `bench.vortex.dev/api/ingest` — keeps the Rust emitter dependency-light
-//! and lets CI fill the commit fields from `${{ github.sha }}` plus
-//! `git show`.
+//! map 1:1 to the Postgres fact tables. The records here are **bare**;
+//! `scripts/post-ingest.py` fills the commit metadata from `${{ github.sha }}`
+//! plus `git show`, computes the internal `measurement_id`, and upserts them
+//! directly into the database.
 //!
-//! Wire-shape source of truth: [`vortex_bench_server::records`]. When
-//! changing a shape, change both sides in the same commit and run the
-//! server's snapshot tests.
+//! When changing a shape, update `benchmarks-website/CONTRACT.md`,
+//! `benchmarks-website/web/lib/schema-version.ts`, and
+//! `scripts/post-ingest.py` in the same logical change.
 //!
 //! ## Producer mapping
 //!
@@ -56,19 +54,6 @@
 //! For SQL query suites (everything that flows through `query_measurements`),
 //! the dim columns are populated as documented on
 //! [`benchmark_dataset_dims`].
-//!
-//! ## Historical-data side
-//!
-//! [`vortex_bench_migrate::classifier`] is the bug-for-bug port of v2's
-//! `getGroup` that recovers the same `(kind, dim tuple)` triple from the
-//! v2 S3 dump. It exists only for the one-shot migration; once cutover
-//! lands and the historical archive is loaded, both the migrator and its
-//! classifier go away. For new ingest, no classifier is needed — the
-//! emitter writes v3-shape records directly.
-//!
-//! [`vortex_bench_server::records`]: ../../../benchmarks-website/server/src/records.rs
-//! [`vortex_bench_migrate::classifier`]: ../../../benchmarks-website/migrate/src/classifier.rs
-
 use std::io::Write;
 use std::sync::LazyLock;
 
@@ -99,7 +84,7 @@ pub static ENV_TRIPLE: LazyLock<String> = LazyLock::new(|| {
 /// Wire-format kind discriminator. One value per fact table.
 ///
 /// Each variant flattens its inner record next to a `"kind"` field, matching the
-/// shape consumed by `/api/ingest`.
+/// shape consumed by `scripts/post-ingest.py`.
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum V3Record {
@@ -463,9 +448,7 @@ pub fn vector_search_record(
     rows_scanned: u64,
     bytes_scanned: u64,
 ) -> V3Record {
-    // Clamp at `i32::MAX`: server-side `iterations` is `i32` (see the
-    // same-named field on `vortex_bench_server::records::VectorSearchRun`),
-    // so saturating to `u32::MAX` would 400 the envelope.
+    // The Postgres `iterations` column is `INTEGER`, so clamp at `i32::MAX`.
     let iterations = u32::try_from(all_runs_ns.len()).unwrap_or(i32::MAX as u32);
     V3Record::VectorSearchRun(VectorSearchRunRecord {
         commit_sha: GIT_COMMIT_ID.clone(),
@@ -747,13 +730,13 @@ mod tests {
 
     #[test]
     fn compression_records_lowercase_dataset_for_v2_history_match() {
-        // The v2 → v3 migrate classifier stores `dataset = series.to_lowercase()`
-        // for compress-bench records (see `benchmarks-website/migrate/src/classifier.rs`).
+        // The historical v2 backfill stores `dataset = series.to_lowercase()`
+        // for compress-bench records.
         // Datasets whose `Dataset::name()` returns mixed case
         // (`TPC-H l_comment chunked`, every PBI name like `Arade`/`CMSprovider`)
         // would otherwise emit live records that do not merge with their
-        // migrated history. Lowercasing inside the v3 helpers keeps the trait
-        // API simple for non-v3 callers while still matching migrate's shape.
+        // migrated history. Lowercasing inside these wire helpers keeps the trait
+        // API simple for other callers while still matching the historical shape.
         let timing = CompressionTimingMeasurement {
             name: "compress time/TPC-H l_comment chunked".to_string(),
             format: Format::OnDiskVortex,


### PR DESCRIPTION
Removes all references to the older versions of the benchmarks website.

This is basically all cosmetic renames, as we still technically use the v3 ingest pipeline, but "v3" no longer means anything in this repo.

The only non-cosmetic thing is removing dead code in the post-ingest python script.