### PR TITLE
Don't run rust toolchain install steps in main repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,13 +142,17 @@ jobs:
   # would break ON CONFLICT idempotency against the rows already in production.
   measurement-id-golden:
     name: "measurement_id golden vectors"
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{ github.repository == 'vortex-data/vortex'
+          && format('runs-on={0}/runner=amd64-small/image=ubuntu24-full-x64-pre-v2/tag=measurement-id', github.run_id)
+          || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       # sync: false — the test runs via `uv run --no-project` and needs no workspace
       # packages; the default `uv sync` builds the vortex-data Rust extension (~6 min).
       - uses: spiraldb/actions/.github/actions/setup-uv@a746510eafaa926484c354541cfc49b2ec06cc63  # 0.18.6
+        if: github.repository != 'vortex-data/vortex'
         with:
           sync: false
       - name: Pytest - measurement_id golden vectors
@@ -303,6 +307,7 @@ jobs:
         with:
           enable-sccache: "true"
       - name: Install nightly for fmt
+        if: github.repository != 'vortex-data/vortex'
         run: rustup toolchain install $NIGHTLY_TOOLCHAIN --component rustfmt
       - name: Rust Lint - Format
         id: fmt
@@ -547,6 +552,7 @@ jobs:
         with:
           enable-sccache: "true"
       - name: Install Rust nightly toolchain
+        if: github.repository != 'vortex-data/vortex'
         run: |
           rustup toolchain install $NIGHTLY_TOOLCHAIN
           rustup component add --toolchain $NIGHTLY_TOOLCHAIN rust-src rustfmt clippy llvm-tools-preview
@@ -650,6 +656,7 @@ jobs:
         with:
           enable-sccache: "true"
       - name: Install nightly for cbindgen macro expansion
+        if: github.repository != 'vortex-data/vortex'
         run: rustup toolchain install $NIGHTLY_TOOLCHAIN
       - name: "regenerate all .fbs/.proto Rust code"
         run: |
@@ -690,6 +697,9 @@ jobs:
       - uses: ./.github/actions/setup-prebuild
         with:
           enable-sccache: "true"
+      - name: Install Rust nightly toolchain
+        if: github.repository != 'vortex-data/vortex'
+        run: rustup toolchain install $NIGHTLY_TOOLCHAIN
       - name: "regenerate FFI header file"
         run: |
           cargo +$NIGHTLY_TOOLCHAIN build --profile ci -p vortex-ffi

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -72,7 +72,8 @@ jobs:
         with:
           enable-sccache: ${{ github.repository == 'vortex-data/vortex' && 'true' || 'false' }}
       - uses: ./.github/actions/system-info
-      - run: |
+      - if: github.repository != 'vortex-data/vortex'
+        run: |
           sudo apt-get update
           sudo apt-get install -y libc6-dbg
       - name: Install Codspeed

--- a/.github/workflows/rust-instrumented.yml
+++ b/.github/workflows/rust-instrumented.yml
@@ -133,6 +133,7 @@ jobs:
         with:
           enable-sccache: "true"
       - name: Install lcov
+        if: github.repository != 'vortex-data/vortex'
         run: |
           sudo apt-get update
           sudo apt-get install -y lcov libjson-xs-perl
@@ -187,6 +188,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - uses: ./.github/actions/setup-prebuild
       - name: Install Rust nightly toolchain
+        if: github.repository != 'vortex-data/vortex'
         run: |
           rustup toolchain install $NIGHTLY_TOOLCHAIN
           rustup component add --toolchain $NIGHTLY_TOOLCHAIN rust-src rustfmt clippy llvm-tools-preview
@@ -254,6 +256,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - uses: ./.github/actions/setup-prebuild
       - name: Install Rust nightly toolchain
+        if: github.repository != 'vortex-data/vortex'
         run: |
           rustup toolchain install $NIGHTLY_TOOLCHAIN
           rustup component add --toolchain $NIGHTLY_TOOLCHAIN rust-src rustfmt clippy llvm-tools-preview
@@ -304,6 +307,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - uses: ./.github/actions/setup-prebuild
       - name: Install nightly with miri
+        if: github.repository != 'vortex-data/vortex'
         run: rustup toolchain install $NIGHTLY_TOOLCHAIN --component rust-src,rustfmt,clippy,miri
       - name: Run Miri
         run: cargo +$NIGHTLY_TOOLCHAIN miri nextest run --no-fail-fast -p vortex-buffer -p vortex-ffi


### PR DESCRIPTION
We have prebuilt AMI which most of CI uses.
In the jobs we download and install rust toolchain, and we don't need
to do it for non-forks.

1. Migrate measurement-id job to prebuilt AMI.
2. Don't run nightly install in main repo.
3. Don't run LCOV installation in main repo

This depends on a private repo PR.
