### PR TITLE
ci: add focused PR benchmark labels

### DIFF
--- a/.github/workflows/commit-metadata.yml
+++ b/.github/workflows/commit-metadata.yml
@@ -22,13 +22,13 @@ jobs:
         with:
           fetch-depth: 2
 
-      # v4 (Postgres) ingest -- REQUIRED (see bench.yml rationale). Empty records:
+      # v4 (Postgres) ingest -- REQUIRED (see develop-bench.yml rationale). Empty records:
       # post-ingest.py --postgres upserts the commit row only. Gated on the
       # ingest-role ARN var (the assume-role input that MUST exist for OIDC to
       # succeed).
       #
       # `sync: false` -- the ingest runs `uv run --no-project --with`, which needs only
-      # the uv binary, never the synced workspace (see bench.yml rationale).
+      # the uv binary, never the synced workspace (see develop-bench.yml rationale).
       - name: Install uv for v4 ingest
         if: vars.GH_BENCH_INGEST_ROLE_ARN != ''
         uses: spiraldb/actions/.github/actions/setup-uv@a746510eafaa926484c354541cfc49b2ec06cc63  # 0.18.6

--- a/.github/workflows/develop-bench.yml
+++ b/.github/workflows/develop-bench.yml
@@ -1,6 +1,6 @@
 # Runs after every commit to `develop` (or in other words, _after_ every pull request merges).
 
-name: Benchmarks
+name: Develop Benchmarks
 
 on:
   push:
@@ -188,7 +188,7 @@ jobs:
           deduplication-key: ci-bench-${{ matrix.benchmark.id }}-failure
 
   sql:
-    uses: ./.github/workflows/sql-benchmarks.yml
+    uses: ./.github/workflows/sql-bench-matrix.yml
     secrets: inherit
     with:
       mode: "develop"

--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   sql:
-    uses: ./.github/workflows/sql-benchmarks.yml
+    uses: ./.github/workflows/sql-bench-matrix.yml
     secrets: inherit
     with:
       mode: "develop"

--- a/.github/workflows/pr-bench-compress.yml
+++ b/.github/workflows/pr-bench-compress.yml
@@ -1,0 +1,20 @@
+# Runs the compression benchmark for a pull request.
+
+name: PR Compression Benchmark
+
+on:
+  workflow_call: { }
+  workflow_dispatch: { }
+
+permissions:
+  contents: read
+  pull-requests: write  # for commenting on PRs
+  id-token: write  # enables AWS-GitHub OIDC
+
+jobs:
+  bench:
+    uses: ./.github/workflows/pr-bench-runner.yml
+    secrets: inherit
+    with:
+      benchmark_id: compress-bench
+      benchmark_name: Compression

--- a/.github/workflows/pr-bench-dispatch.yml
+++ b/.github/workflows/pr-bench-dispatch.yml
@@ -2,7 +2,7 @@
 # This is a separate workflow so that non-benchmark label events don't create
 # phantom check suites that obscure in-progress benchmark runs on the PR.
 
-name: Benchmark Dispatch
+name: PR Benchmark Dispatch
 
 on:
   pull_request:
@@ -16,68 +16,86 @@ permissions:
   id-token: write  # enables AWS-GitHub OIDC
 
 jobs:
-  remove-bench-label:
+  remove-random-access-label:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event.label.name == 'action/benchmark'
+    if: github.event.label.name == 'action/bench-random-access'
     steps:
       - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0  # v1
         if: github.event.pull_request.head.repo.full_name == 'vortex-data/vortex'
         with:
-          labels: action/benchmark
+          labels: action/bench-random-access
           fail_on_error: true
 
-  bench:
-    needs: remove-bench-label
-    uses: ./.github/workflows/bench-pr.yml
+  random-access-bench:
+    needs: remove-random-access-label
+    uses: ./.github/workflows/pr-bench-random-access.yml
     secrets: inherit
 
-  remove-gpu-compress-bench-label:
+  remove-compress-label:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event.label.name == 'action/benchmark-gpu-compress'
+    if: github.event.label.name == 'action/bench-compress'
     steps:
       - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0  # v1
         if: github.event.pull_request.head.repo.full_name == 'vortex-data/vortex'
         with:
-          labels: action/benchmark-gpu-compress
+          labels: action/bench-compress
+          fail_on_error: true
+
+  compression-bench:
+    needs: remove-compress-label
+    uses: ./.github/workflows/pr-bench-compress.yml
+    secrets: inherit
+
+  remove-gpu-compress-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event.label.name == 'action/bench-gpu-compress'
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0  # v1
+        if: github.event.pull_request.head.repo.full_name == 'vortex-data/vortex'
+        with:
+          labels: action/bench-gpu-compress
           fail_on_error: true
 
   gpu-compress-bench:
-    needs: remove-gpu-compress-bench-label
-    uses: ./.github/workflows/gpu-compress-bench-pr.yml
+    needs: remove-gpu-compress-label
+    uses: ./.github/workflows/pr-bench-gpu-compress.yml
     secrets: inherit
 
   remove-sql-label:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event.label.name == 'action/benchmark-sql'
+    if: github.event.label.name == 'action/bench-sql'
     steps:
       - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0  # v1
         if: github.event.pull_request.head.repo.full_name == 'vortex-data/vortex'
         with:
-          labels: action/benchmark-sql
+          labels: action/bench-sql
           fail_on_error: true
 
   sql-bench:
     needs: remove-sql-label
-    uses: ./.github/workflows/sql-pr.yml
+    uses: ./.github/workflows/pr-bench-sql.yml
     secrets: inherit
+    with:
+      matrix_preset: "pr"
 
-  remove-sql-full-label:
+  remove-sql-compact-label:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event.label.name == 'action/benchmark-sql-full'
+    if: github.event.label.name == 'action/bench-sql-compact'
     steps:
       - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0  # v1
         if: github.event.pull_request.head.repo.full_name == 'vortex-data/vortex'
         with:
-          labels: action/benchmark-sql-full
+          labels: action/bench-sql-compact
           fail_on_error: true
 
-  sql-full-bench:
-    needs: remove-sql-full-label
-    uses: ./.github/workflows/sql-pr.yml
+  sql-compact-bench:
+    needs: remove-sql-compact-label
+    uses: ./.github/workflows/pr-bench-sql.yml
     secrets: inherit
     with:
-      matrix_preset: "pr-full"
+      matrix_preset: "pr-compact"

--- a/.github/workflows/pr-bench-dispatch.yml
+++ b/.github/workflows/pr-bench-dispatch.yml
@@ -3,6 +3,9 @@
 # phantom check suites that obscure in-progress benchmark runs on the PR.
 
 name: PR Benchmark Dispatch
+run-name: >-
+  PR #${{ github.event.pull_request.number }} benchmark:
+  ${{ github.event.label.name }}
 
 on:
   pull_request:

--- a/.github/workflows/pr-bench-dispatch.yml
+++ b/.github/workflows/pr-bench-dispatch.yml
@@ -40,6 +40,11 @@ jobs:
     uses: ./.github/workflows/pr-bench-compress.yml
     secrets: inherit
 
+  all-string-bench:
+    needs: remove-all-label
+    uses: ./.github/workflows/pr-bench-string.yml
+    secrets: inherit
+
   all-sql-bench:
     needs: remove-all-label
     uses: ./.github/workflows/pr-bench-sql.yml
@@ -77,6 +82,22 @@ jobs:
   compression-bench:
     needs: remove-compress-label
     uses: ./.github/workflows/pr-bench-compress.yml
+    secrets: inherit
+
+  remove-string-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event.label.name == 'action/bench-string'
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0  # v1
+        if: github.event.pull_request.head.repo.full_name == 'vortex-data/vortex'
+        with:
+          labels: action/bench-string
+          fail_on_error: true
+
+  string-bench:
+    needs: remove-string-label
+    uses: ./.github/workflows/pr-bench-string.yml
     secrets: inherit
 
   remove-gpu-compress-label:

--- a/.github/workflows/pr-bench-dispatch.yml
+++ b/.github/workflows/pr-bench-dispatch.yml
@@ -19,6 +19,34 @@ permissions:
   id-token: write  # enables AWS-GitHub OIDC
 
 jobs:
+  remove-all-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event.label.name == 'action/bench-all'
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0  # v1
+        if: github.event.pull_request.head.repo.full_name == 'vortex-data/vortex'
+        with:
+          labels: action/bench-all
+          fail_on_error: true
+
+  all-random-access-bench:
+    needs: remove-all-label
+    uses: ./.github/workflows/pr-bench-random-access.yml
+    secrets: inherit
+
+  all-compression-bench:
+    needs: remove-all-label
+    uses: ./.github/workflows/pr-bench-compress.yml
+    secrets: inherit
+
+  all-sql-bench:
+    needs: remove-all-label
+    uses: ./.github/workflows/pr-bench-sql.yml
+    secrets: inherit
+    with:
+      matrix_preset: "pr-all"
+
   remove-random-access-label:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/pr-bench-gpu-compress.yml
+++ b/.github/workflows/pr-bench-gpu-compress.yml
@@ -1,10 +1,10 @@
 # Runs the GPU-enabled compression decompression benchmarks for a pull request.
-# Called from bench-dispatch.yml when the `action/benchmark-gpu-compress` label is added.
+# Called from pr-bench-dispatch.yml when the `action/bench-gpu-compress` label is added.
 
-name: GPU Compression Benchmarks
+name: PR GPU Compression Benchmark
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-gpu-compress
   cancel-in-progress: false
 
 on:
@@ -71,13 +71,13 @@ jobs:
           } > comment.md
           cat comment.md >> "$GITHUB_STEP_SUMMARY"
       - name: Comment PR
-        if: github.event.pull_request.head.repo.fork == false
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b  # v3
         with:
           file-path: comment.md
           comment-tag: bench-pr-comment-gpu-compress
       - name: Comment PR on failure
-        if: failure() && github.event.pull_request.head.repo.fork == false
+        if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b  # v3
         with:
           message: |

--- a/.github/workflows/pr-bench-random-access.yml
+++ b/.github/workflows/pr-bench-random-access.yml
@@ -1,0 +1,21 @@
+# Runs the random-access benchmark for a pull request.
+
+name: PR Random Access Benchmark
+
+on:
+  workflow_call: { }
+  workflow_dispatch: { }
+
+permissions:
+  contents: read
+  pull-requests: write  # for commenting on PRs
+  id-token: write  # enables AWS-GitHub OIDC
+
+jobs:
+  bench:
+    uses: ./.github/workflows/pr-bench-runner.yml
+    secrets: inherit
+    with:
+      benchmark_id: random-access-bench
+      benchmark_name: Random Access
+      with_lance: true

--- a/.github/workflows/pr-bench-runner.yml
+++ b/.github/workflows/pr-bench-runner.yml
@@ -1,17 +1,26 @@
-# Runs all benchmarks once for a pull request.
-# Called from bench-dispatch.yml when the `action/benchmark` label is added.
+# Runs one non-SQL benchmark for a pull request.
 
-name: PR Benchmarks
+name: PR Benchmark Runner
 
 concurrency:
   # The group causes runs to queue instead of running in parallel.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ inputs.benchmark_id }}
   # Don't cancel benchmarks that are already running, instead just queue them up.
   cancel-in-progress: false
 
 on:
-  workflow_call: { }
-  workflow_dispatch: { }
+  workflow_call:
+    inputs:
+      benchmark_id:
+        required: true
+        type: string
+      benchmark_name:
+        required: true
+        type: string
+      with_lance:
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -23,20 +32,8 @@ jobs:
     timeout-minutes: 120
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=bench-dedicated/family=c6id.metal/tag={1}{2}', github.run_id, matrix.benchmark.id, github.event.pull_request.head.repo.fork == false && '/extras=s3-cache' || '')
+          && format('runs-on={0}/runner=bench-dedicated/family=c6id.metal/tag={1}{2}', github.run_id, inputs.benchmark_id, github.event.pull_request.head.repo.fork == false && '/extras=s3-cache' || '')
           || 'ubuntu-latest' }}
-    strategy:
-      matrix:
-        benchmark:
-          - id: random-access-bench
-            name: Random Access
-            build_args: "--features lance"
-          - id: compress-bench
-            name: Compression
-          # No run_args: the default suite emits the three tracked metrics
-          # (size, write, read). The codec microbenchmark is a local diagnostic.
-          - id: string-bench
-            name: String Encoding
     steps:
       - uses: runs-on/action@v2
         if: github.event.pull_request.head.repo.fork == false
@@ -44,7 +41,7 @@ jobs:
           sccache: s3
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +60,8 @@ jobs:
         env:
           RUSTFLAGS: "-C target-cpu=native -C force-frame-pointers=yes"
         run: |
-          cargo build --package ${{ matrix.benchmark.id }} --profile release_debug ${{ matrix.benchmark.build_args }} --features unstable_encodings
+          cargo build --package ${{ inputs.benchmark_id }} --profile release_debug \
+            --features ${{ inputs.with_lance && 'lance,' || '' }}unstable_encodings
 
       - name: Pre-upload benchmark debuginfo to Polar Signals
         if: github.event.pull_request.head.repo.fork == false
@@ -71,7 +69,7 @@ jobs:
         continue-on-error: true
         with:
           paths: |
-            target/release_debug/${{ matrix.benchmark.id }}
+            target/release_debug/${{ inputs.benchmark_id }}
           polarsignals-cloud-token: ${{ secrets.POLAR_SIGNALS_API_KEY }}
           project-id: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
 
@@ -80,9 +78,9 @@ jobs:
         uses: polarsignals/gh-actions-ps-profiling@68ae857e375a826606352016e5b90f01a2a7ff7a  # v0.8.1
         with:
           polarsignals_cloud_token: ${{ secrets.POLAR_SIGNALS_API_KEY }}
-          labels: "branch=${{ github.ref_name }};gh_run_id=${{ github.run_id }};commit_sha=${{ github.event.pull_request.head.sha }};benchmark=${{ matrix.benchmark.id }}"
+          labels: "branch=${{ github.ref_name }};gh_run_id=${{ github.run_id }};commit_sha=${{ github.event.pull_request.head.sha }};benchmark=${{ inputs.benchmark_id }}"
           project_uuid: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
-          job_name: "${{ matrix.benchmark.id }}"
+          job_name: "${{ inputs.benchmark_id }}"
           profiling_frequency: 199
           extra_args: "--debuginfo-strip=false"
           parca_agent_version: "0.49.0"
@@ -90,8 +88,8 @@ jobs:
       - name: Setup benchmark environment
         run: sudo bash scripts/setup-benchmark.sh
 
-      - name: Run ${{ matrix.benchmark.name }} benchmark (per-combination)
-        if: matrix.benchmark.id == 'random-access-bench'
+      - name: Run ${{ inputs.benchmark_name }} benchmark (per-combination)
+        if: inputs.benchmark_id == 'random-access-bench'
         shell: bash
         env:
           RUST_BACKTRACE: full
@@ -100,16 +98,15 @@ jobs:
         run: |
           python3 scripts/random-access-split.py
 
-      - name: Run ${{ matrix.benchmark.name }} benchmark
-        if: matrix.benchmark.id != 'random-access-bench'
+      - name: Run ${{ inputs.benchmark_name }} benchmark
+        if: inputs.benchmark_id != 'random-access-bench'
         shell: bash
         env:
           RUST_BACKTRACE: full
           VORTEX_EXPERIMENTAL_PATCHED_ARRAY: "1"
           FLAT_LAYOUT_INLINE_ARRAY_NODE: "1"
         run: |
-          bash scripts/bench-taskset.sh target/release_debug/${{ matrix.benchmark.id }} \
-            ${{ matrix.benchmark.run_args }} -d gh-json -o results.json
+          bash scripts/bench-taskset.sh target/release_debug/${{ inputs.benchmark_id }} -d gh-json -o results.json
 
       - name: Setup AWS CLI
         if: github.event.pull_request.head.repo.fork == false
@@ -131,30 +128,23 @@ jobs:
           python3 scripts/s3-download.py s3://vortex-ci-benchmark-results/data.json.gz data.json.gz --no-sign-request
           gzip -d -c data.json.gz > base.json
 
-          uv run --no-project scripts/compare-benchmark-jsons.py base.json results.json "${{ matrix.benchmark.name }}" \
+          uv run --no-project scripts/compare-benchmark-jsons.py base.json results.json "${{ inputs.benchmark_name }}" \
             > comment.md
           cat comment.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment PR
-        if: github.event.pull_request.head.repo.fork == false
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b  # v3
         with:
           file-path: comment.md
-          comment-tag: bench-pr-comment-${{ matrix.benchmark.id }}
+          comment-tag: bench-pr-comment-${{ inputs.benchmark_id }}
 
       - name: Comment PR on failure
-        if: failure() && github.event.pull_request.head.repo.fork == false
+        if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b  # v3
         with:
           message: |
             # BENCHMARK FAILED
 
-            Benchmark `${{ matrix.benchmark.name }}` failed! Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
-          comment-tag: bench-pr-comment-${{ matrix.benchmark.id }}
-
-  sql:
-    uses: ./.github/workflows/sql-benchmarks.yml
-    secrets: inherit
-    with:
-      mode: "pr"
-      matrix_preset: "pr-full"
+            Benchmark `${{ inputs.benchmark_name }}` failed! Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
+          comment-tag: bench-pr-comment-${{ inputs.benchmark_id }}

--- a/.github/workflows/pr-bench-sql.yml
+++ b/.github/workflows/pr-bench-sql.yml
@@ -1,5 +1,5 @@
 # Runs SQL benchmarks once for a pull request.
-# Called from bench-dispatch.yml when SQL benchmark labels are added.
+# Called from pr-bench-dispatch.yml when SQL benchmark labels are added.
 
 name: PR SQL Benchmarks
 
@@ -26,6 +26,7 @@ on:
         default: "pr"
         options:
           - "pr"
+          - "pr-compact"
           - "pr-full"
 
 permissions:
@@ -35,7 +36,7 @@ permissions:
 
 jobs:
   sql:
-    uses: ./.github/workflows/sql-benchmarks.yml
+    uses: ./.github/workflows/sql-bench-matrix.yml
     secrets: inherit
     with:
       mode: "pr"

--- a/.github/workflows/pr-bench-sql.yml
+++ b/.github/workflows/pr-bench-sql.yml
@@ -27,6 +27,7 @@ on:
         options:
           - "pr"
           - "pr-compact"
+          - "pr-all"
           - "pr-full"
 
 permissions:

--- a/.github/workflows/pr-bench-string.yml
+++ b/.github/workflows/pr-bench-string.yml
@@ -1,0 +1,20 @@
+# Runs the string encoding benchmark for a pull request.
+
+name: PR String Encoding Benchmark
+
+on:
+  workflow_call: { }
+  workflow_dispatch: { }
+
+permissions:
+  contents: read
+  pull-requests: write  # for commenting on PRs
+  id-token: write  # enables AWS-GitHub OIDC
+
+jobs:
+  bench:
+    uses: ./.github/workflows/pr-bench-runner.yml
+    secrets: inherit
+    with:
+      benchmark_id: string-bench
+      benchmark_name: String Encoding

--- a/.github/workflows/sql-bench-matrix.yml
+++ b/.github/workflows/sql-bench-matrix.yml
@@ -170,7 +170,7 @@ jobs:
         shell: bash
         env:
           AWS_REGION: "us-east-1"
-          REMOTE_STORAGE: "s3://vortex-ci-benchmark-datasets/${{ github.ref_name }}/${{ github.run_id }}/${{ matrix.remote_key }}/"
+          REMOTE_STORAGE: "s3://vortex-ci-benchmark-datasets/${{ github.ref_name }}/${{ github.run_id }}/${{ inputs.matrix_preset }}/${{ matrix.remote_key }}/"
         run: |
           aws s3 rm --recursive "$REMOTE_STORAGE"
           aws s3 cp --recursive "${{ matrix.local_dir }}" "$REMOTE_STORAGE"
@@ -218,7 +218,7 @@ jobs:
           OTEL_EXPORTER_OTLP_ENDPOINT: "${{ (inputs.mode != 'pr' || github.event.pull_request.head.repo.fork == false) && secrets.OTEL_EXPORTER_OTLP_ENDPOINT || '' }}"
           OTEL_EXPORTER_OTLP_HEADERS: "${{ (inputs.mode != 'pr' || github.event.pull_request.head.repo.fork == false) && secrets.OTEL_EXPORTER_OTLP_HEADERS || '' }}"
           OTEL_RESOURCE_ATTRIBUTES: "bench-name=${{ matrix.id }}"
-          REMOTE_STORAGE: "s3://vortex-ci-benchmark-datasets/${{ github.ref_name }}/${{ github.run_id }}/${{ matrix.remote_key }}/"
+          REMOTE_STORAGE: "s3://vortex-ci-benchmark-datasets/${{ github.ref_name }}/${{ github.run_id }}/${{ inputs.matrix_preset }}/${{ matrix.remote_key }}/"
         run: |
           bash scripts/bench-taskset.sh uv run --project bench-orchestrator vx-bench run "${{ matrix.subcommand }}" \
             --targets-json '${{ toJSON(matrix.targets) }}' \

--- a/.github/workflows/sql-bench-matrix.yml
+++ b/.github/workflows/sql-bench-matrix.yml
@@ -1,4 +1,4 @@
-name: "SQL-related benchmarks"
+name: SQL Benchmark Matrix
 
 on:
   workflow_call:
@@ -259,8 +259,10 @@ jobs:
         with:
           file-path: comment.md
           # There is exactly one comment per comment-tag. If a comment with this tag already exists,
-          # this action will *update* the comment instead of posting a new comment.
-          comment-tag: bench-pr-comment-${{ matrix.id }}
+          # this action will *update* the comment instead of posting a new comment. The preset is
+          # part of the tag because presets overlap on benchmark ids (`pr` and `pr-compact` share
+          # nine) and can run concurrently, so a preset-less tag would let them clobber each other.
+          comment-tag: bench-pr-comment-${{ matrix.id }}-${{ inputs.matrix_preset }}
 
       - name: Comment PR on failure
         if: failure() && inputs.mode == 'pr' && github.event.pull_request.head.repo.fork == false
@@ -270,7 +272,7 @@ jobs:
             # 🚨🚨🚨❌❌❌ SQL BENCHMARK FAILED ❌❌❌🚨🚨🚨
 
             Benchmark `${{ matrix.name }}` (${{ inputs.matrix_preset }}) failed! Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
-          comment-tag: bench-pr-comment-${{ matrix.id }}
+          comment-tag: bench-pr-comment-${{ matrix.id }}-${{ inputs.matrix_preset }}
 
       - name: Upload Benchmark Results
         if: inputs.mode == 'develop'
@@ -279,7 +281,7 @@ jobs:
           bash scripts/cat-s3.sh vortex-ci-benchmark-results data.json.gz results.json
 
       # v4 (Postgres) ingest -- the REQUIRED benchmark-results pipeline feeding the live
-      # benchmarks website (see bench.yml for the full rationale); a failure here fails the
+      # benchmarks website (see develop-bench.yml for the full rationale); a failure here fails the
       # job. Gated on inputs.mode == 'develop' + the ingest-role ARN var (the assume-role
       # input that MUST exist for OIDC to succeed). post-ingest.py mints the RDS IAM token
       # (boto3) from the assumed GitHubBenchmarkIngestRole; sslmode=verify-full validates

--- a/bench-orchestrator/README.md
+++ b/bench-orchestrator/README.md
@@ -79,6 +79,7 @@ to keep benchmark coverage in Python instead of copying large JSON matrices betw
 ```bash
 vx-bench matrix            # list available presets
 vx-bench matrix develop    # emit compact JSON
+vx-bench matrix pr-all      # emit the combined focused PR coverage
 vx-bench matrix pr-full     # emit full pull-request coverage
 vx-bench matrix nightly --pretty
 ```
@@ -158,9 +159,9 @@ vx-bench clean --older-than "30 days" [options]
 ## CI Benchmark Matrices
 
 CI benchmark coverage lives in `bench_orchestrator/ci_matrix/catalog.py`. This is the only file to
-edit when changing what runs in the `develop`, `pr`, `pr-full`, or `nightly` presets. The remaining
-modules in `ci_matrix` model, validate, and render that catalog as the JSON expected by GitHub
-Actions.
+edit when changing what runs in the `develop`, `pr`, `pr-compact`, `pr-all`, `pr-full`, or
+`nightly` presets. The remaining modules in `ci_matrix` model, validate, and render that catalog as
+the JSON expected by GitHub Actions.
 
 When adding coverage, update the benchmark declarations and the expected preset membership in
 `tests/test_matrix.py`.

--- a/bench-orchestrator/bench_orchestrator/ci_matrix/catalog.py
+++ b/bench-orchestrator/bench_orchestrator/ci_matrix/catalog.py
@@ -14,7 +14,7 @@ from .targets import df, duck
 PRESETS = {
     "develop": "Every regular SQL benchmark at full target coverage.",
     "pr": "The quicker pull-request SQL benchmark matrix.",
-    "pr-compact": "Pull-request SQL benchmarks that only run Vortex Compact.",
+    "pr-compact": "Pull-request SQL benchmarks for Vortex Compact plus Parquet controls.",
     "pr-full": "Every regular SQL benchmark at full PR target coverage.",
     "nightly": "Large-scale SF=100 TPC-H on NVMe and S3 at default targets.",
 }
@@ -53,8 +53,11 @@ STANDARD_WITH_DUCKDB_TARGETS = STANDARD_TARGETS | duck(Format.DUCKDB)
 DUCKDB_DEFAULT_TARGETS = DEFAULT_TARGETS.only(Engine.DUCKDB)
 DUCKDB_STANDARD_TARGETS = STANDARD_TARGETS.only(Engine.DUCKDB)
 DATAFUSION_VORTEX_TARGETS = df(Format.VORTEX)
-COMPACT_TARGETS = df(Format.VORTEX_COMPACT) | duck(Format.VORTEX_COMPACT)
-COMPACT_DUCKDB_TARGETS = duck(Format.VORTEX_COMPACT)
+COMPACT_TARGETS = df(Format.PARQUET, Format.VORTEX_COMPACT) | duck(
+    Format.PARQUET,
+    Format.VORTEX_COMPACT,
+)
+COMPACT_DUCKDB_TARGETS = duck(Format.PARQUET, Format.VORTEX_COMPACT)
 
 DEFAULT = Coverage(DEFAULT_TARGETS)
 STANDARD = Coverage(STANDARD_TARGETS)

--- a/bench-orchestrator/bench_orchestrator/ci_matrix/catalog.py
+++ b/bench-orchestrator/bench_orchestrator/ci_matrix/catalog.py
@@ -15,6 +15,7 @@ PRESETS = {
     "develop": "Every regular SQL benchmark at full target coverage.",
     "pr": "The quicker pull-request SQL benchmark matrix.",
     "pr-compact": "Pull-request SQL benchmarks for Vortex Compact plus Parquet controls.",
+    "pr-all": "The union of the focused PR and PR Compact benchmark matrices.",
     "pr-full": "Every regular SQL benchmark at full PR target coverage.",
     "nightly": "Large-scale SF=100 TPC-H on NVMe and S3 at default targets.",
 }
@@ -87,6 +88,7 @@ BENCHMARKS = (
         runs={
             "pr": DEFAULT,
             "pr-compact": COMPACT,
+            "pr-all": STANDARD,
             "pr-full": DEFAULT_WITH_DUCKDB_PR_FULL,
             "develop": FULL_LOCAL,
         },
@@ -98,6 +100,7 @@ BENCHMARKS = (
         runs={
             "pr": DEFAULT,
             "pr-compact": COMPACT,
+            "pr-all": STANDARD,
             "pr-full": DEFAULT_WITH_DUCKDB_PR_FULL,
             "develop": FULL_LOCAL,
         },
@@ -111,6 +114,7 @@ BENCHMARKS = (
         runs={
             "pr": DEFAULT,
             "pr-compact": COMPACT,
+            "pr-all": STANDARD,
             "pr-full": FULL_PR,
             "develop": FULL_LOCAL,
         },
@@ -127,6 +131,7 @@ BENCHMARKS = (
         runs={
             "pr": DEFAULT,
             "pr-compact": COMPACT,
+            "pr-all": STANDARD,
             "pr-full": STANDARD,
             "develop": STANDARD,
         },
@@ -140,6 +145,7 @@ BENCHMARKS = (
         runs={
             "pr": DEFAULT,
             "pr-compact": COMPACT,
+            "pr-all": STANDARD,
             "pr-full": FULL_PR,
             "develop": FULL_LOCAL,
         },
@@ -155,6 +161,7 @@ BENCHMARKS = (
         remote_key="tpch/10.0",
         runs={
             "pr-compact": COMPACT,
+            "pr-all": COMPACT,
             "pr-full": STANDARD,
             "develop": STANDARD,
         },
@@ -184,6 +191,7 @@ BENCHMARKS = (
         runs={
             "pr": DEFAULT,
             "pr-compact": COMPACT,
+            "pr-all": STANDARD,
             "pr-full": STANDARD_WITH_DUCKDB,
             "develop": STANDARD_WITH_DUCKDB,
         },
@@ -197,6 +205,7 @@ BENCHMARKS = (
         runs={
             "pr": DUCKDB_DEFAULT,
             "pr-compact": COMPACT_DUCKDB,
+            "pr-all": DUCKDB_STANDARD,
             "pr-full": DUCKDB_STANDARD,
             "develop": DUCKDB_STANDARD,
         },
@@ -209,6 +218,7 @@ BENCHMARKS = (
         runs={
             "pr": DEFAULT,
             "pr-compact": COMPACT,
+            "pr-all": STANDARD,
             "pr-full": STANDARD,
             "develop": STANDARD,
         },
@@ -224,6 +234,7 @@ BENCHMARKS = (
         runs={
             "pr": DEFAULT,
             "pr-compact": COMPACT,
+            "pr-all": STANDARD,
             "pr-full": STANDARD,
             "develop": STANDARD,
         },
@@ -235,6 +246,7 @@ BENCHMARKS = (
         scale_factor=1,
         runs={
             "pr": DATAFUSION_VORTEX,
+            "pr-all": DATAFUSION_VORTEX,
             "pr-full": DATAFUSION_VORTEX,
             "develop": DATAFUSION_VORTEX,
         },
@@ -246,6 +258,7 @@ BENCHMARKS = (
         iterations=10,
         runs={
             "pr-compact": COMPACT,
+            "pr-all": COMPACT,
             "pr-full": DEFAULT_WITH_DUCKDB_PR_FULL,
             "develop": STANDARD_WITH_DUCKDB,
         },

--- a/bench-orchestrator/bench_orchestrator/ci_matrix/catalog.py
+++ b/bench-orchestrator/bench_orchestrator/ci_matrix/catalog.py
@@ -14,6 +14,7 @@ from .targets import df, duck
 PRESETS = {
     "develop": "Every regular SQL benchmark at full target coverage.",
     "pr": "The quicker pull-request SQL benchmark matrix.",
+    "pr-compact": "Pull-request SQL benchmarks that only run Vortex Compact.",
     "pr-full": "Every regular SQL benchmark at full PR target coverage.",
     "nightly": "Large-scale SF=100 TPC-H on NVMe and S3 at default targets.",
 }
@@ -52,6 +53,8 @@ STANDARD_WITH_DUCKDB_TARGETS = STANDARD_TARGETS | duck(Format.DUCKDB)
 DUCKDB_DEFAULT_TARGETS = DEFAULT_TARGETS.only(Engine.DUCKDB)
 DUCKDB_STANDARD_TARGETS = STANDARD_TARGETS.only(Engine.DUCKDB)
 DATAFUSION_VORTEX_TARGETS = df(Format.VORTEX)
+COMPACT_TARGETS = df(Format.VORTEX_COMPACT) | duck(Format.VORTEX_COMPACT)
+COMPACT_DUCKDB_TARGETS = duck(Format.VORTEX_COMPACT)
 
 DEFAULT = Coverage(DEFAULT_TARGETS)
 STANDARD = Coverage(STANDARD_TARGETS)
@@ -68,6 +71,8 @@ STANDARD_WITH_DUCKDB = Coverage(STANDARD_WITH_DUCKDB_TARGETS)
 DUCKDB_DEFAULT = Coverage(DUCKDB_DEFAULT_TARGETS)
 DUCKDB_STANDARD = Coverage(DUCKDB_STANDARD_TARGETS)
 DATAFUSION_VORTEX = Coverage(DATAFUSION_VORTEX_TARGETS)
+COMPACT = Coverage(COMPACT_TARGETS)
+COMPACT_DUCKDB = Coverage(COMPACT_DUCKDB_TARGETS)
 
 # Concrete benchmark cases
 
@@ -78,6 +83,7 @@ BENCHMARKS = (
         name="Clickbench on NVME",
         runs={
             "pr": DEFAULT,
+            "pr-compact": COMPACT,
             "pr-full": DEFAULT_WITH_DUCKDB_PR_FULL,
             "develop": FULL_LOCAL,
         },
@@ -88,6 +94,7 @@ BENCHMARKS = (
         name="Clickbench Sorted on NVME",
         runs={
             "pr": DEFAULT,
+            "pr-compact": COMPACT,
             "pr-full": DEFAULT_WITH_DUCKDB_PR_FULL,
             "develop": FULL_LOCAL,
         },
@@ -100,6 +107,7 @@ BENCHMARKS = (
         iterations=10,
         runs={
             "pr": DEFAULT,
+            "pr-compact": COMPACT,
             "pr-full": FULL_PR,
             "develop": FULL_LOCAL,
         },
@@ -115,6 +123,7 @@ BENCHMARKS = (
         remote_key="tpch/1.0",
         runs={
             "pr": DEFAULT,
+            "pr-compact": COMPACT,
             "pr-full": STANDARD,
             "develop": STANDARD,
         },
@@ -127,6 +136,7 @@ BENCHMARKS = (
         iterations=10,
         runs={
             "pr": DEFAULT,
+            "pr-compact": COMPACT,
             "pr-full": FULL_PR,
             "develop": FULL_LOCAL,
         },
@@ -141,6 +151,7 @@ BENCHMARKS = (
         local_dir="vortex-bench/data/tpch/10.0",
         remote_key="tpch/10.0",
         runs={
+            "pr-compact": COMPACT,
             "pr-full": STANDARD,
             "develop": STANDARD,
         },
@@ -169,6 +180,7 @@ BENCHMARKS = (
         scale_factor=1.0,
         runs={
             "pr": DEFAULT,
+            "pr-compact": COMPACT,
             "pr-full": STANDARD_WITH_DUCKDB,
             "develop": STANDARD_WITH_DUCKDB,
         },
@@ -181,6 +193,7 @@ BENCHMARKS = (
         local_dir="vortex-bench/data/statpopgen",
         runs={
             "pr": DUCKDB_DEFAULT,
+            "pr-compact": COMPACT_DUCKDB,
             "pr-full": DUCKDB_STANDARD,
             "develop": DUCKDB_STANDARD,
         },
@@ -192,6 +205,7 @@ BENCHMARKS = (
         scale_factor=100,
         runs={
             "pr": DEFAULT,
+            "pr-compact": COMPACT,
             "pr-full": STANDARD,
             "develop": STANDARD,
         },
@@ -206,6 +220,7 @@ BENCHMARKS = (
         remote_key="fineweb",
         runs={
             "pr": DEFAULT,
+            "pr-compact": COMPACT,
             "pr-full": STANDARD,
             "develop": STANDARD,
         },
@@ -227,6 +242,7 @@ BENCHMARKS = (
         name="Appian on NVME",
         iterations=10,
         runs={
+            "pr-compact": COMPACT,
             "pr-full": DEFAULT_WITH_DUCKDB_PR_FULL,
             "develop": STANDARD_WITH_DUCKDB,
         },

--- a/bench-orchestrator/tests/test_matrix.py
+++ b/bench-orchestrator/tests/test_matrix.py
@@ -84,10 +84,10 @@ def test_pr_target_selection() -> None:
     assert ("datafusion", "lance") in _targets(develop["tpch-nvme"])
     assert all(("datafusion", "lance") not in _targets(entry) for entry in pr_full.values())
     assert "vortex-compact" in cast("list[str]", pr_full["clickbench-nvme"]["data_formats"])
-    assert all(
-        all(target[1] == "vortex-compact" for target in _targets(entry)) and entry["data_formats"] == ["vortex-compact"]
-        for entry in pr_compact.values()
-    )
+    for entry in pr_compact.values():
+        targets = _targets(entry)
+        assert {file_format for _engine, file_format in targets} == {"parquet", "vortex-compact"}
+        assert set(cast("list[str]", entry["data_formats"])) == {"parquet", "vortex-compact"}
 
 
 def test_resolver_rejects_empty_targets() -> None:

--- a/bench-orchestrator/tests/test_matrix.py
+++ b/bench-orchestrator/tests/test_matrix.py
@@ -33,6 +33,9 @@ REGULAR_IDS = (
     "appian-nvme",
     "vortex-queries",
 )
+COMPACT_IDS = tuple(
+    benchmark_id for benchmark_id in REGULAR_IDS if benchmark_id not in {"polarsignals", "vortex-queries"}
+)
 EXPECTED_IDS = {
     "develop": REGULAR_IDS,
     "pr": tuple(
@@ -40,6 +43,7 @@ EXPECTED_IDS = {
         for benchmark_id in REGULAR_IDS
         if benchmark_id not in {"tpch-s3-10", "appian-nvme", "vortex-queries"}
     ),
+    "pr-compact": COMPACT_IDS,
     "pr-full": REGULAR_IDS,
     "nightly": ("tpch-nvme", "tpch-s3"),
 }
@@ -68,6 +72,7 @@ def test_matrix_presets(preset: str, expected_ids: tuple[str, ...]) -> None:
 def test_pr_target_selection() -> None:
     develop = {entry["id"]: entry for entry in _entries("develop")}
     pr = {entry["id"]: entry for entry in _entries("pr")}
+    pr_compact = {entry["id"]: entry for entry in _entries("pr-compact")}
     pr_full = {entry["id"]: entry for entry in _entries("pr-full")}
 
     assert _targets(pr["tpch-nvme"]) == {
@@ -79,6 +84,10 @@ def test_pr_target_selection() -> None:
     assert ("datafusion", "lance") in _targets(develop["tpch-nvme"])
     assert all(("datafusion", "lance") not in _targets(entry) for entry in pr_full.values())
     assert "vortex-compact" in cast("list[str]", pr_full["clickbench-nvme"]["data_formats"])
+    assert all(
+        all(target[1] == "vortex-compact" for target in _targets(entry)) and entry["data_formats"] == ["vortex-compact"]
+        for entry in pr_compact.values()
+    )
 
 
 def test_resolver_rejects_empty_targets() -> None:

--- a/bench-orchestrator/tests/test_matrix.py
+++ b/bench-orchestrator/tests/test_matrix.py
@@ -36,6 +36,7 @@ REGULAR_IDS = (
 COMPACT_IDS = tuple(
     benchmark_id for benchmark_id in REGULAR_IDS if benchmark_id not in {"polarsignals", "vortex-queries"}
 )
+PR_ALL_IDS = tuple(benchmark_id for benchmark_id in REGULAR_IDS if benchmark_id != "vortex-queries")
 EXPECTED_IDS = {
     "develop": REGULAR_IDS,
     "pr": tuple(
@@ -44,6 +45,7 @@ EXPECTED_IDS = {
         if benchmark_id not in {"tpch-s3-10", "appian-nvme", "vortex-queries"}
     ),
     "pr-compact": COMPACT_IDS,
+    "pr-all": PR_ALL_IDS,
     "pr-full": REGULAR_IDS,
     "nightly": ("tpch-nvme", "tpch-s3"),
 }
@@ -88,6 +90,24 @@ def test_pr_target_selection() -> None:
         targets = _targets(entry)
         assert {file_format for _engine, file_format in targets} == {"parquet", "vortex-compact"}
         assert set(cast("list[str]", entry["data_formats"])) == {"parquet", "vortex-compact"}
+
+
+def test_pr_all_is_union_of_focused_presets() -> None:
+    pr = {entry["id"]: entry for entry in _entries("pr")}
+    pr_compact = {entry["id"]: entry for entry in _entries("pr-compact")}
+    pr_all = {entry["id"]: entry for entry in _entries("pr-all")}
+
+    assert set(pr_all) == set(pr) | set(pr_compact)
+    for benchmark_id, entry in pr_all.items():
+        expected_targets: set[tuple[str, str]] = set()
+        expected_formats: set[str] = set()
+        for preset in (pr, pr_compact):
+            if source := preset.get(benchmark_id):
+                expected_targets |= _targets(source)
+                expected_formats |= set(cast("list[str]", source["data_formats"]))
+
+        assert _targets(entry) == expected_targets
+        assert set(cast("list[str]", entry["data_formats"])) == expected_formats
 
 
 def test_resolver_rejects_empty_targets() -> None:

--- a/docs/developer-guide/benchmarking.md
+++ b/docs/developer-guide/benchmarking.md
@@ -225,8 +225,8 @@ Benchmarks run automatically on all commits to `develop` and can be run on-deman
 - **GPU compression** -- `action/bench-gpu-compress` runs the allow-listed Vortex decompression
   cases on a GPU runner.
 - **SQL** -- `action/bench-sql` runs the `pr` preset, which excludes `vortex-compact`.
-- **SQL Compact** -- `action/bench-sql-compact` runs the `pr-compact` preset, which generates
-  and benchmarks only `vortex-compact`.
+- **SQL Compact** -- `action/bench-sql-compact` runs the `pr-compact` preset, which benchmarks
+  `vortex-compact` plus Parquet control rows used to distinguish code changes from runner drift.
 
 All CI benchmarks run on dedicated instances with the `release_debug` profile and
 `-C target-cpu=native` to produce representative numbers.

--- a/docs/developer-guide/benchmarking.md
+++ b/docs/developer-guide/benchmarking.md
@@ -220,14 +220,13 @@ Benchmarks run automatically on all commits to `develop` and can be run on-deman
 
 - **Post-commit** -- compression, random access, and SQL benchmarks run on every commit to
   `develop`, with results uploaded for historical tracking.
-- **PR benchmarks** -- triggered by the `action/benchmark` label. Results are compared against
-  the latest `develop` run and posted as a PR comment.
-- **GPU compression benchmarks** -- triggered by the `action/benchmark-gpu-compress` label. Runs
-  the allow-listed Vortex decompression cases on a GPU runner and posts the timings as a PR comment.
-- **SQL benchmarks** -- triggered by the `action/benchmark-sql` label. Runs the base SQL matrix,
-  which excludes Appian, TPC-H SF=10 on S3, `vortex-compact`, and `duckdb:duckdb`.
-- **Full SQL benchmarks** -- triggered by the `action/benchmark-sql-full` label. Runs the full
-  SQL matrix of suites, engines, formats, and storage backends (NVMe, S3).
+- **Random access** -- `action/bench-random-access` runs only the random-access benchmark.
+- **Compression** -- `action/bench-compress` runs only the compression benchmark.
+- **GPU compression** -- `action/bench-gpu-compress` runs the allow-listed Vortex decompression
+  cases on a GPU runner.
+- **SQL** -- `action/bench-sql` runs the `pr` preset, which excludes `vortex-compact`.
+- **SQL Compact** -- `action/bench-sql-compact` runs the `pr-compact` preset, which generates
+  and benchmarks only `vortex-compact`.
 
 All CI benchmarks run on dedicated instances with the `release_debug` profile and
 `-C target-cpu=native` to produce representative numbers.

--- a/docs/developer-guide/benchmarking.md
+++ b/docs/developer-guide/benchmarking.md
@@ -227,6 +227,9 @@ Benchmarks run automatically on all commits to `develop` and can be run on-deman
 - **SQL** -- `action/bench-sql` runs the `pr` preset, which excludes `vortex-compact`.
 - **SQL Compact** -- `action/bench-sql-compact` runs the `pr-compact` preset, which benchmarks
   `vortex-compact` plus Parquet control rows used to distinguish code changes from runner drift.
+- **All CPU benchmarks** -- `action/bench-all` runs random access, compression, and the `pr-all`
+  SQL preset, which combines the `pr` and `pr-compact` coverage without repeating shared jobs. Do
+  not combine it with other benchmark labels; GPU compression is the only exception.
 
 All CI benchmarks run on dedicated instances with the `release_debug` profile and
 `-C target-cpu=native` to produce representative numbers.

--- a/docs/developer-guide/benchmarking.md
+++ b/docs/developer-guide/benchmarking.md
@@ -218,18 +218,20 @@ uv run --project bench-orchestrator vx-bench run tpch \
 
 Benchmarks run automatically on all commits to `develop` and can be run on-demand for PRs:
 
-- **Post-commit** -- compression, random access, and SQL benchmarks run on every commit to
-  `develop`, with results uploaded for historical tracking.
+- **Post-commit** -- compression, string encoding, random access, and SQL benchmarks run on every
+  commit to `develop`, with results uploaded for historical tracking.
 - **Random access** -- `action/bench-random-access` runs only the random-access benchmark.
 - **Compression** -- `action/bench-compress` runs only the compression benchmark.
+- **String encoding** -- `action/bench-string` runs only the string encoding benchmark.
 - **GPU compression** -- `action/bench-gpu-compress` runs the allow-listed Vortex decompression
   cases on a GPU runner.
 - **SQL** -- `action/bench-sql` runs the `pr` preset, which excludes `vortex-compact`.
 - **SQL Compact** -- `action/bench-sql-compact` runs the `pr-compact` preset, which benchmarks
   `vortex-compact` plus Parquet control rows used to distinguish code changes from runner drift.
-- **All CPU benchmarks** -- `action/bench-all` runs random access, compression, and the `pr-all`
-  SQL preset, which combines the `pr` and `pr-compact` coverage without repeating shared jobs. Do
-  not combine it with other benchmark labels; GPU compression is the only exception.
+- **All CPU benchmarks** -- `action/bench-all` runs random access, compression, string encoding,
+  and the `pr-all` SQL preset, which combines the `pr` and `pr-compact` coverage without
+  repeating shared jobs. Do not combine it with other benchmark labels; GPU compression is the
+  only exception.
 
 All CI benchmarks run on dedicated instances with the `release_debug` profile and
 `-C target-cpu=native` to produce representative numbers.

--- a/scripts/compare-benchmark-jsons.py
+++ b/scripts/compare-benchmark-jsons.py
@@ -106,7 +106,7 @@ def normalize_format_name(value: Any) -> str | None:
     return FORMAT_DISPLAY_NAMES.get(value, value)
 
 
-def comparison_target(name: Any, target: Any = None) -> tuple[str, str, int | None]:
+def comparison_target(name: Any, target: Any = None) -> tuple[str, str, int | str | None]:
     """Return the engine, display format, and optional SQL query number."""
 
     target_engine = None
@@ -119,6 +119,20 @@ def comparison_target(name: Any, target: Any = None) -> tuple[str, str, int | No
     name_engine = match.group(2) if match is not None else None
     name_format = match.group(3) if match is not None else None
     query = int(match.group(1)) if match is not None else None
+
+    if match is None and isinstance(name, str):
+        random_access = re.match(
+            r"^(?P<prefix>random-access(?:/.*)?)/"
+            r"(?P<file_format>parquet|vortex|lance)-(?P<variant>.+)$",
+            name,
+        )
+        if random_access is not None:
+            file_format = random_access.group("file_format")
+            if file_format == "vortex":
+                file_format = "vortex-file-compressed"
+            return "random-access", file_format, (
+                f"{random_access.group('prefix')}/{random_access.group('variant')}"
+            )
 
     engine = str(target_engine or name_engine or "unknown")
     file_format = str(target_format or normalize_format_name(name_format) or "unknown")
@@ -170,17 +184,35 @@ def benchmark_identity_rows(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def read_jsonl_rows_for_commit(path: str, commit_id: str) -> pd.DataFrame:
-    """Read only rows matching a commit from a JSONL benchmark history."""
+    """Read the latest copy of each row matching a history commit.
 
-    rows = []
+    Re-running a develop workflow appends a second result block for the same
+    commit. Keeping the last copy of each logical row prevents a many-to-one
+    merge from weighting that baseline multiple times.
+    """
+
+    rows_by_identity: dict[tuple[Any, ...], dict[str, Any]] = {}
     with open(path, encoding="utf-8") as lines:
         for line in lines:
             if '"commit_id"' not in line or f'"{commit_id}"' not in line:
                 continue
             record = orjson.loads(line)
-            if record.get("commit_id") == commit_id:
-                rows.append(record)
-    return pd.DataFrame(rows)
+            if record.get("commit_id") != commit_id:
+                continue
+
+            file_size = record.get("file_size")
+            if isinstance(file_size, dict):
+                identity = (
+                    FILE_SIZE_METRIC,
+                    file_size.get("benchmark"),
+                    file_size.get("scale_factor"),
+                    file_size.get("format"),
+                    file_size.get("file"),
+                )
+            else:
+                identity = ("timing", benchmark_identity(record))
+            rows_by_identity[identity] = record
+    return pd.DataFrame(rows_by_identity.values())
 
 
 def read_latest_baseline_rows(path: str, pr: pd.DataFrame) -> pd.DataFrame:
@@ -261,7 +293,7 @@ def normalize_measurement_rows(df: pd.DataFrame) -> pd.DataFrame:
         columns=["engine", "file_format", "query"],
         index=df.index,
     )
-    df["query"] = pd.array(df["query"], dtype="Int64")
+    df["query"] = df["query"].astype(object)
     return df
 
 
@@ -422,7 +454,7 @@ def build_statistical_analysis(df: pd.DataFrame, threshold_pct: int) -> dict[str
         rows.append(
             {
                 "name": row["name"],
-                "query": int(row["query"]),
+                "query": row["query"],
                 "engine": row["engine"],
                 "file_format": row["file_format"],
                 "combo": f"{row['engine']}:{row['file_format']}",
@@ -442,7 +474,7 @@ def build_statistical_analysis(df: pd.DataFrame, threshold_pct: int) -> dict[str
         beta_log_ratio = float(group["log_ratio"].mean())
         query_rows.append(
             {
-                "query": int(query),
+                "query": query,
                 "beta_log_ratio": beta_log_ratio,
                 "beta_ratio": float(np.exp(beta_log_ratio)),
                 "beta_log_se": mean_with_standard_error(group, "log_ratio", "log_ratio_se"),

--- a/scripts/compare-benchmark-jsons.py
+++ b/scripts/compare-benchmark-jsons.py
@@ -130,9 +130,10 @@ def comparison_target(name: Any, target: Any = None) -> tuple[str, str, int | st
             file_format = random_access.group("file_format")
             if file_format == "vortex":
                 file_format = "vortex-file-compressed"
-            return "random-access", file_format, (
-                f"{random_access.group('prefix')}/{random_access.group('variant')}"
+            query = (
+                None if file_format == "lance" else f"{random_access.group('prefix')}/{random_access.group('variant')}"
             )
+            return "random-access", file_format, query
 
     engine = str(target_engine or name_engine or "unknown")
     file_format = str(target_format or normalize_format_name(name_format) or "unknown")

--- a/scripts/tests/test_benchmark_reporting.py
+++ b/scripts/tests/test_benchmark_reporting.py
@@ -241,25 +241,46 @@ def test_within_engine_analysis_uses_each_engines_own_parquet_control() -> None:
     assert compare.build_verdict(analyses["duckdb"])["impact"] == "+20.0%"
 
 
-def test_random_access_rows_use_matching_parquet_controls() -> None:
+def test_random_access_attribution_excludes_lance_rows() -> None:
     compare = load_compare_module()
     rows = [
         timing_row("random-access/taxi/correlated/parquet-tokio-local-disk", 100, 110),
         timing_row("random-access/taxi/correlated/vortex-tokio-local-disk", 100, 99),
+        timing_row("random-access/taxi/correlated/lance-tokio-local-disk", 100, 200),
         timing_row("random-access/taxi/uniform/parquet-tokio-local-disk", 100, 110),
         timing_row("random-access/taxi/uniform/vortex-tokio-local-disk", 100, 99),
+        timing_row("random-access/taxi/uniform/lance-tokio-local-disk", 100, 200),
     ]
     df = pd.DataFrame(rows)
     df[["engine", "file_format", "query"]] = df["name"].apply(compare.extract_target_fields)
 
     analyses = compare.build_within_engine_statistical_analyses(df, threshold_pct=5)
 
+    assert df.loc[df["file_format"] == "lance", "query"].isna().all()
     assert set(analyses) == {"random-access"}
     assert set(analyses["random-access"]["detail_df"]["file_format"]) == {
         "parquet",
         "vortex-file-compressed",
     }
     assert compare.build_verdict(analyses["random-access"])["status"] == "Likely improvement"
+
+
+def test_random_access_report_keeps_lance_details_without_attribution(tmp_path: Path) -> None:
+    names_and_values = [
+        ("random-access/taxi/correlated/parquet-tokio-local-disk", 110),
+        ("random-access/taxi/correlated/vortex-tokio-local-disk", 99),
+        ("random-access/taxi/correlated/lance-tokio-local-disk", 200),
+        ("random-access/taxi/uniform/parquet-tokio-local-disk", 110),
+        ("random-access/taxi/uniform/vortex-tokio-local-disk", 99),
+        ("random-access/taxi/uniform/lance-tokio-local-disk", 200),
+    ]
+    base_rows = [stored_timing_row("base-sha", name, 100) for name, _pr_value in names_and_values]
+    pr_rows = [stored_timing_row("pr-sha", name, pr_value) for name, pr_value in names_and_values]
+
+    report = render_report(tmp_path, base_rows, pr_rows, "Random Access")
+
+    assert "**Attributed Vortex impact**: -10.0%" in report
+    assert "<summary>random-access / lance / ns " in report
 
 
 def test_comparison_report_groups_by_target_and_unit(tmp_path: Path) -> None:

--- a/scripts/tests/test_benchmark_reporting.py
+++ b/scripts/tests/test_benchmark_reporting.py
@@ -202,6 +202,27 @@ def test_read_latest_baseline_rows_streams_latest_matching_benchmark_commit(tmp_
     assert len(selected) == 2
 
 
+def test_read_latest_baseline_rows_uses_last_result_from_rerun(tmp_path: Path) -> None:
+    compare = load_compare_module()
+    history_path = tmp_path / "history.jsonl"
+    history_path.write_text(
+        "".join(
+            f"{json.dumps(row)}\n"
+            for row in [
+                stored_timing_row("base", "tpch_q01/datafusion:parquet", 100),
+                stored_timing_row("base", "tpch_q01/datafusion:parquet", 110),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    pr = pd.DataFrame([stored_timing_row("pr", "tpch_q01/datafusion:parquet", 105)])
+
+    selected = compare.read_latest_baseline_rows(history_path, pr)
+
+    assert len(selected) == 1
+    assert selected.iloc[0]["value"] == 110
+
+
 def test_within_engine_analysis_uses_each_engines_own_parquet_control() -> None:
     compare = load_compare_module()
     rows = [
@@ -218,6 +239,27 @@ def test_within_engine_analysis_uses_each_engines_own_parquet_control() -> None:
     assert set(analyses) == {"datafusion", "duckdb"}
     assert compare.build_verdict(analyses["datafusion"])["impact"] == "-10.0%"
     assert compare.build_verdict(analyses["duckdb"])["impact"] == "+20.0%"
+
+
+def test_random_access_rows_use_matching_parquet_controls() -> None:
+    compare = load_compare_module()
+    rows = [
+        timing_row("random-access/taxi/correlated/parquet-tokio-local-disk", 100, 110),
+        timing_row("random-access/taxi/correlated/vortex-tokio-local-disk", 100, 99),
+        timing_row("random-access/taxi/uniform/parquet-tokio-local-disk", 100, 110),
+        timing_row("random-access/taxi/uniform/vortex-tokio-local-disk", 100, 99),
+    ]
+    df = pd.DataFrame(rows)
+    df[["engine", "file_format", "query"]] = df["name"].apply(compare.extract_target_fields)
+
+    analyses = compare.build_within_engine_statistical_analyses(df, threshold_pct=5)
+
+    assert set(analyses) == {"random-access"}
+    assert set(analyses["random-access"]["detail_df"]["file_format"]) == {
+        "parquet",
+        "vortex-file-compressed",
+    }
+    assert compare.build_verdict(analyses["random-access"])["status"] == "Likely improvement"
 
 
 def test_comparison_report_groups_by_target_and_unit(tmp_path: Path) -> None:


### PR DESCRIPTION
Adds focused PR benchmark triggers:

- `action/bench-random-access`
- `action/bench-compress`
- `action/bench-string` (https://github.com/vortex-data/vortex/pull/9060)
- `action/bench-sql` (excludes Vortex Compact)
- `action/bench-sql-compact` (Vortex Compact plus Parquet controls)
- `action/bench-all` (random access, compression, string encoding, and SQL, while GPU remains separate)

Each trigger dispatches a role-specific reusable workflow. PR benchmarks check out `github.event.pull_request.head.sha`. SQL coverage stays in the Python catalog and is resolved into a matrix at runtime. The all-CPU path uses a single `pr-all` preset (the exact union of `pr` and `pr-compact`), so shared SQL jobs run once instead of twice.

Benchmark reporting now:

- Keeps the latest rerun for each logical timing or file-size result.
- Includes Parquet controls in `pr-compact` to distinguish code changes from runner drift.
- Namespaces remote datasets by preset to prevent concurrent jobs from clobbering each other.

TODO: After merge, delete the legacy `action/benchmark*` labels once `develop` uses the new dispatcher.
