### PR TITLE
Splat run-end bool decode into 64-bit words

### DIFF
--- a/encodings/runend/Cargo.toml
+++ b/encodings/runend/Cargo.toml
@@ -56,6 +56,10 @@ name = "run_end_decode_bool_corpus"
 harness = false
 
 [[bench]]
+name = "run_end_decode_bool_ablation"
+harness = false
+
+[[bench]]
 name = "run_end_take"
 harness = false
 

--- a/encodings/runend/benches/run_end_decode_bool_ablation.rs
+++ b/encodings/runend/benches/run_end_decode_bool_ablation.rs
@@ -20,17 +20,16 @@
 //! ```text
 //! run length      1     2     8    32    64   128  1024
 //! non-nullable
-//!   50/50      3.70  3.46  2.86  1.25  1.26  0.87  0.61
-//!   90/10         -  1.28  0.93  0.44  0.48  0.49  0.61
+//!   50/50      3.49  3.59  3.22  1.95  2.13  0.92  1.06
+//!   90/10         -  1.37  1.13  0.66  0.77  0.51  0.78
 //! nullable
-//!   50/50      1.97  2.09  1.92  1.21  0.74  0.50  0.63
-//!   90/10         -  1.20  1.14  0.64  0.46  0.47  0.63
+//!   50/50      2.41  2.54  2.40  1.58  1.20  0.96  0.73
+//!   90/10         -  1.46  1.35  0.96  0.73  0.60  0.84
 //! ```
 //!
-//! The splat is worth up to 3.7x while runs are short. The crossover moves in with skew, since
-//! a skewed prefill patches few runs, and in again for nullable input, where the splat builds
-//! two buffers but the prefill still skips both at once. `prefer_splat` reproduces this table's
-//! sign everywhere except non-nullable 8/90-10, where it gives up 7%.
+//! The splat is worth up to 3.6x while runs are short. The crossover moves in with skew, since a
+//! skewed prefill patches few runs. `prefer_splat` reproduces this table's sign at 25 of the 26
+//! points; the miss is non-nullable 1024/50-50, where it gives up 6%.
 
 #![expect(clippy::cast_possible_truncation)]
 

--- a/encodings/runend/benches/run_end_decode_bool_ablation.rs
+++ b/encodings/runend/benches/run_end_decode_bool_ablation.rs
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! A/B between the two structures for run-end bool decode, in one process on one dataset.
+//!
+//! * `prefill` is a bench-local mirror of the kernel this crate shipped before the splat: memset
+//!   the output with the majority value, then `fill_range` every run whose value differs.
+//! * `shipped` is `runend_decode_typed_bool`, which picks between that same prefill and the
+//!   splat — accumulate runs into a 64-bit word, store each output word exactly once.
+//!
+//! Run lengths and values are randomised and datasets are rotated across iterations, so the
+//! per-run value branch the prefill kernel depends on cannot be memorised by the predictor.
+//!
+//! The dispatch in `prefer_splat` comes from running this grid against a build pinned to each
+//! kernel (return a constant from `prefer_splat` to re-derive it). Splat over prefill, by
+//! fastest sample:
+//!
+//! ```text
+//! run length      1     2     8    32    64   128  1024
+//! non-nullable
+//!   50/50      3.70  3.46  2.86  1.25  1.26  0.87  0.61
+//!   90/10         -  1.28  0.93  0.44  0.48  0.49  0.61
+//! nullable
+//!   50/50      1.97  2.09  1.92  1.21  0.74  0.50  0.63
+//!   90/10         -  1.20  1.14  0.64  0.46  0.47  0.63
+//! ```
+//!
+//! The splat is worth up to 3.7x while runs are short. The crossover moves in with skew, since
+//! a skewed prefill patches few runs, and in again for nullable input, where the splat builds
+//! two buffers but the prefill still skips both at once. `prefer_splat` reproduces this table's
+//! sign everywhere except non-nullable 8/90-10, where it gives up 7%.
+
+#![expect(clippy::cast_possible_truncation)]
+
+use std::fmt;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use divan::Bencher;
+use rand::RngExt;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use vortex_array::IntoArray;
+use vortex_array::arrays::BoolArray;
+use vortex_array::dtype::Nullability;
+use vortex_array::validity::Validity;
+use vortex_buffer::BitBuffer;
+use vortex_buffer::BitBufferMut;
+use vortex_buffer::Buffer;
+use vortex_buffer::BufferMut;
+use vortex_mask::Mask;
+use vortex_runend::decompress_bool::runend_decode_typed_bool;
+use vortex_runend::trimmed_ends_iter;
+
+fn main() {
+    divan::main();
+}
+
+const TOTAL_LENGTH: usize = 65_536;
+
+/// Number of independently-seeded datasets cycled across iterations.
+const DATASETS: usize = 8;
+
+/// Fraction of runs whose value is `true`.
+#[derive(Clone, Copy)]
+enum Skew {
+    /// 50/50, so the prefill kernel's `value != prefill` branch is unpredictable.
+    Even,
+    /// 90% true, the shape the adaptive prefill is designed for.
+    Skewed,
+}
+
+impl fmt::Display for Skew {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Skew::Even => write!(f, "even"),
+            Skew::Skewed => write!(f, "skewed"),
+        }
+    }
+}
+
+impl Skew {
+    fn true_probability(self) -> f64 {
+        match self {
+            Skew::Even => 0.5,
+            Skew::Skewed => 0.9,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Args {
+    avg_run_length: usize,
+    skew: Skew,
+}
+
+impl fmt::Display for Args {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "run{}_{}", self.avg_run_length, self.skew)
+    }
+}
+
+const ARGS: &[Args] = &[
+    Args {
+        avg_run_length: 1,
+        skew: Skew::Even,
+    },
+    Args {
+        avg_run_length: 2,
+        skew: Skew::Even,
+    },
+    Args {
+        avg_run_length: 8,
+        skew: Skew::Even,
+    },
+    Args {
+        avg_run_length: 32,
+        skew: Skew::Even,
+    },
+    Args {
+        avg_run_length: 64,
+        skew: Skew::Even,
+    },
+    Args {
+        avg_run_length: 128,
+        skew: Skew::Even,
+    },
+    Args {
+        avg_run_length: 1024,
+        skew: Skew::Even,
+    },
+    Args {
+        avg_run_length: 2,
+        skew: Skew::Skewed,
+    },
+    Args {
+        avg_run_length: 8,
+        skew: Skew::Skewed,
+    },
+    Args {
+        avg_run_length: 32,
+        skew: Skew::Skewed,
+    },
+    Args {
+        avg_run_length: 64,
+        skew: Skew::Skewed,
+    },
+    Args {
+        avg_run_length: 128,
+        skew: Skew::Skewed,
+    },
+    Args {
+        avg_run_length: 1024,
+        skew: Skew::Skewed,
+    },
+];
+
+/// One decode input: run ends plus the run values, and optionally per-run validity.
+struct Dataset {
+    ends: Buffer<u32>,
+    values: BitBuffer,
+    validity: Mask,
+}
+
+fn dataset(seed: u64, avg_run_length: usize, skew: Skew, nullable: bool) -> Dataset {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let max_run = (2 * avg_run_length - 1).max(1);
+    let p = skew.true_probability();
+
+    let mut ends = BufferMut::<u32>::empty();
+    let mut values = Vec::new();
+    let mut validity = Vec::new();
+
+    let mut pos = 0usize;
+    while pos < TOTAL_LENGTH {
+        let run = rng.random_range(1..=max_run).min(TOTAL_LENGTH - pos);
+        pos += run;
+        ends.push(pos as u32);
+        values.push(rng.random_bool(p));
+        if nullable {
+            validity.push(rng.random_bool(0.9));
+        }
+    }
+
+    Dataset {
+        ends: ends.freeze(),
+        values: BitBuffer::from(values),
+        validity: if nullable {
+            Mask::from(BitBuffer::from(validity))
+        } else {
+            Mask::AllTrue(pos)
+        },
+    }
+}
+
+/// Cycles `DATASETS` independently-seeded datasets across iterations.
+fn rotating(avg_run_length: usize, skew: Skew, nullable: bool) -> impl Fn() -> &'static Dataset {
+    let sets: &'static [Dataset] = Box::leak(
+        (0..DATASETS as u64)
+            .map(|k| {
+                dataset(
+                    0x5eed_u64.wrapping_add(k.wrapping_mul(0x9E37_79B9_7F4A_7C15)),
+                    avg_run_length,
+                    skew,
+                    nullable,
+                )
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    );
+    let next = AtomicUsize::new(0);
+    move || &sets[next.fetch_add(1, Ordering::Relaxed) % DATASETS]
+}
+
+#[divan::bench(args = ARGS)]
+fn shipped(bencher: Bencher, args: Args) {
+    let next = rotating(args.avg_run_length, args.skew, false);
+    bencher.with_inputs(&next).bench_values(|d| {
+        runend_decode_typed_bool(
+            d.ends.as_slice(),
+            0,
+            &d.values,
+            d.validity.clone(),
+            Nullability::NonNullable,
+            TOTAL_LENGTH,
+        )
+    });
+}
+
+#[divan::bench(args = ARGS)]
+fn prefill(bencher: Bencher, args: Args) {
+    let next = rotating(args.avg_run_length, args.skew, false);
+    bencher.with_inputs(&next).bench_values(|d| {
+        prefill_non_nullable(
+            trimmed_ends_iter(d.ends.as_slice(), 0, TOTAL_LENGTH),
+            &d.values,
+            Nullability::NonNullable,
+            TOTAL_LENGTH,
+        )
+        .into_array()
+    });
+}
+
+#[divan::bench(args = ARGS)]
+fn shipped_nullable(bencher: Bencher, args: Args) {
+    let next = rotating(args.avg_run_length, args.skew, true);
+    bencher.with_inputs(&next).bench_values(|d| {
+        runend_decode_typed_bool(
+            d.ends.as_slice(),
+            0,
+            &d.values,
+            d.validity.clone(),
+            Nullability::Nullable,
+            TOTAL_LENGTH,
+        )
+    });
+}
+
+#[divan::bench(args = ARGS)]
+fn prefill_nullable(bencher: Bencher, args: Args) {
+    let next = rotating(args.avg_run_length, args.skew, true);
+    bencher.with_inputs(&next).bench_values(|d| {
+        let Mask::Values(mask) = &d.validity else {
+            unreachable!("nullable dataset")
+        };
+        prefill_nullable_kernel(
+            trimmed_ends_iter(d.ends.as_slice(), 0, TOTAL_LENGTH),
+            &d.values,
+            mask.bit_buffer(),
+            TOTAL_LENGTH,
+        )
+        .into_array()
+    });
+}
+
+/// Threshold below which the mirrored kernel appends sequentially instead of prefilling.
+const PREFILL_RUN_THRESHOLD: usize = 32;
+
+/// Mirror of the previously shipped non-nullable kernel.
+fn prefill_non_nullable(
+    run_ends: impl Iterator<Item = usize>,
+    values: &BitBuffer,
+    nullability: Nullability,
+    length: usize,
+) -> BoolArray {
+    let num_runs = values.len();
+
+    if num_runs < PREFILL_RUN_THRESHOLD {
+        let mut decoded = BitBufferMut::with_capacity(length);
+        for (end, value) in run_ends.zip(values.iter()) {
+            decoded.append_n(value, end - decoded.len());
+        }
+        return BoolArray::new(decoded.freeze(), nullability.into());
+    }
+
+    let prefill = values.true_count() > num_runs - values.true_count();
+    let mut decoded = BitBufferMut::full(prefill, length);
+    let mut current_pos = 0usize;
+
+    for (end, value) in run_ends.zip(values.iter()) {
+        if end > current_pos && value != prefill {
+            // SAFETY: current_pos < end <= length == decoded.len()
+            unsafe { decoded.fill_range_unchecked(current_pos, end, value) };
+        }
+        current_pos = end;
+    }
+    BoolArray::new(decoded.freeze(), nullability.into())
+}
+
+/// Mirror of the previously shipped nullable kernel.
+fn prefill_nullable_kernel(
+    run_ends: impl Iterator<Item = usize>,
+    values: &BitBuffer,
+    validity_mask: &BitBuffer,
+    length: usize,
+) -> BoolArray {
+    let num_runs = values.len();
+
+    if num_runs < PREFILL_RUN_THRESHOLD {
+        let mut decoded = BitBufferMut::with_capacity(length);
+        let mut decoded_validity = BitBufferMut::with_capacity(length);
+        for (end, (value, is_valid)) in run_ends.zip(values.iter().zip(validity_mask.iter())) {
+            let run_len = end - decoded.len();
+            decoded_validity.append_n(is_valid, run_len);
+            decoded.append_n(is_valid && value, run_len);
+        }
+        return BoolArray::new(decoded.freeze(), Validity::from(decoded_validity.freeze()));
+    }
+
+    let prefill_decoded = values.true_count() > num_runs - values.true_count();
+    let prefill_valid = validity_mask.true_count() > num_runs - validity_mask.true_count();
+
+    let mut decoded = BitBufferMut::full(prefill_decoded, length);
+    let mut decoded_validity = BitBufferMut::full(prefill_valid, length);
+    let mut current_pos = 0usize;
+
+    for (end, (value, is_valid)) in run_ends.zip(values.iter().zip(validity_mask.iter())) {
+        if end > current_pos {
+            // SAFETY: current_pos < end <= length == decoded.len() == decoded_validity.len()
+            if is_valid != prefill_valid {
+                unsafe { decoded_validity.fill_range_unchecked(current_pos, end, is_valid) };
+            }
+            let want_decoded = is_valid && value;
+            if want_decoded != prefill_decoded {
+                unsafe { decoded.fill_range_unchecked(current_pos, end, want_decoded) };
+            }
+            current_pos = end;
+        }
+    }
+    BoolArray::new(decoded.freeze(), Validity::from(decoded_validity.freeze()))
+}

--- a/encodings/runend/benches/run_end_decode_bool_ablation.rs
+++ b/encodings/runend/benches/run_end_decode_bool_ablation.rs
@@ -10,40 +10,43 @@
 //!   splat — accumulate runs into a 64-bit word, store each output word exactly once, into a
 //!   buffer sized up front and overwritten by index — and between the splat's two forms.
 //!
-//! Run lengths and values are randomised and datasets are rotated across iterations, so the
-//! per-run value branch the prefill kernel depends on cannot be memorised by the predictor.
+//! Run lengths are drawn from a normal distribution about the target average and values are
+//! randomised, with datasets rotated across iterations, so neither the per-run value branch the
+//! prefill kernel depends on nor the word-boundary test the splat forms differ over can be
+//! memorised by the predictor. Matches `run_end_decode_bool_corpus`, so the constants derived
+//! here hold for the data CI measures.
 //!
-//! The dispatch in `prefer_splat` comes from running this grid against a build pinned to each
-//! kernel (return a constant from `prefer_splat` to re-derive it). Splat over prefill, by
-//! fastest sample:
+//! Both dispatch constants come from running this grid against a build pinned to each kernel
+//! (return a constant from `prefer_splat` or `prefer_blend` to re-derive them).
 //!
-//! ```text
-//! run length      1     2     8    32    64   128  1024
-//! non-nullable
-//!   50/50      3.49  3.59  3.22  1.95  2.13  0.92  1.06
-//!   90/10         -  1.37  1.13  0.66  0.77  0.51  0.78
-//! nullable
-//!   50/50      2.41  2.54  2.40  1.58  1.20  0.96  0.73
-//!   90/10         -  1.46  1.35  0.96  0.73  0.60  0.84
-//! ```
-//!
-//! The splat is worth up to 3.6x while runs are short. The crossover moves in with skew, since a
-//! skewed prefill patches few runs. `prefer_splat` reproduces this table's sign at 25 of the 26
-//! points; the miss is non-nullable 1024/50-50, where it gives up 6%.
-//!
-//! `prefer_blend` picks between the splat's two forms, and was derived the same way — pin the
-//! form and run the grid. Blend over branching, by fastest sample, splat forced:
+//! Splat over prefill, by fastest sample:
 //!
 //! ```text
 //! run length      1     2     8    16    32    48    64   128  1024
-//! non-nullable 0.75  0.79  1.02  1.35  1.71  1.39  1.15  0.86  0.74
-//! nullable     0.82  0.88  1.15  1.37  1.71  1.79  1.74  1.89  1.16
+//! non-nullable
+//!   50/50      3.57  3.67  3.71  3.75  3.45  3.02  2.91  1.52  0.85
+//!   90/10         -  1.38  1.35     -  1.14     -  0.90  0.74  0.76
+//! nullable
+//!   50/50      2.42  3.17  3.01  3.98  2.96  3.05  2.57  2.18  1.09
+//!   90/10         -  1.85  1.79     -  1.81     -  1.74  1.43  1.10
 //! ```
 //!
-//! The peak is at half a word, where a run's chance of crossing a word boundary is closest to a
-//! coin flip and the branching form's test mispredicts most.
+//! Blend over branching, splat forced:
+//!
+//! ```text
+//! run length      1     2     8    16    32    48    64   128  1024
+//! non-nullable 0.91  0.99  1.18  1.31  1.41  1.43  1.48  1.18  0.93
+//! nullable     0.87  0.90  1.03  1.15  1.27  1.52  1.25  0.94  0.89
+//! ```
+//!
+//! The splat wins wherever the prefill would have runs to patch; it only loses where patches are
+//! rare enough that the prefill is close to a bare memset. The blend wins in a band around a
+//! word: below it the boundary test predicts and its unconditional store is pure cost, above it
+//! the test predicts again and the whole-word fill dominates either way. Together the two
+//! constants pick the faster kernel at all 30 points of the splat grid.
 
 #![expect(clippy::cast_possible_truncation)]
+#![expect(clippy::unwrap_used)]
 
 use std::fmt;
 use std::sync::atomic::AtomicUsize;
@@ -53,6 +56,8 @@ use divan::Bencher;
 use rand::RngExt;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
+use rand_distr::Distribution;
+use rand_distr::Normal;
 use vortex_array::IntoArray;
 use vortex_array::arrays::BoolArray;
 use vortex_array::dtype::Nullability;
@@ -188,7 +193,10 @@ struct Dataset {
 
 fn dataset(seed: u64, avg_run_length: usize, skew: Skew, nullable: bool) -> Dataset {
     let mut rng = StdRng::seed_from_u64(seed);
-    let max_run = (2 * avg_run_length - 1).max(1);
+    // Normal about the target average, matching `run_end_decode_bool_corpus`. A standard
+    // deviation of a third of the mean puts the clamp at one element three sigma out.
+    let mean = avg_run_length as f64;
+    let run_lengths = Normal::new(mean, (mean / 3.0).max(f64::MIN_POSITIVE)).unwrap();
     let p = skew.true_probability();
 
     let mut ends = BufferMut::<u32>::empty();
@@ -197,7 +205,7 @@ fn dataset(seed: u64, avg_run_length: usize, skew: Skew, nullable: bool) -> Data
 
     let mut pos = 0usize;
     while pos < TOTAL_LENGTH {
-        let run = rng.random_range(1..=max_run).min(TOTAL_LENGTH - pos);
+        let run = (run_lengths.sample(&mut rng).round().max(1.0) as usize).min(TOTAL_LENGTH - pos);
         pos += run;
         ends.push(pos as u32);
         values.push(rng.random_bool(p));

--- a/encodings/runend/benches/run_end_decode_bool_ablation.rs
+++ b/encodings/runend/benches/run_end_decode_bool_ablation.rs
@@ -5,8 +5,10 @@
 //!
 //! * `prefill` is a bench-local mirror of the kernel this crate shipped before the splat: memset
 //!   the output with the majority value, then `fill_range` every run whose value differs.
+//! * `push_splat` is the splat as first written, appending words to a `BufferMut<u64>`.
 //! * `shipped` is `runend_decode_typed_bool`, which picks between that same prefill and the
-//!   splat — accumulate runs into a 64-bit word, store each output word exactly once.
+//!   splat — accumulate runs into a 64-bit word, store each output word exactly once, into a
+//!   buffer sized up front and overwritten by index.
 //!
 //! Run lengths and values are randomised and datasets are rotated across iterations, so the
 //! per-run value branch the prefill kernel depends on cannot be memorised by the predictor.
@@ -57,6 +59,9 @@ fn main() {
 }
 
 const TOTAL_LENGTH: usize = 65_536;
+
+/// Bits per accumulator word, mirroring the kernel.
+const WORD_BITS: usize = u64::BITS as usize;
 
 /// Number of independently-seeded datasets cycled across iterations.
 const DATASETS: usize = 8;
@@ -271,6 +276,132 @@ fn prefill_nullable(bencher: Bencher, args: Args) {
         )
         .into_array()
     });
+}
+
+#[divan::bench(args = ARGS)]
+fn push_splat(bencher: Bencher, args: Args) {
+    let next = rotating(args.avg_run_length, args.skew, false);
+    bencher.with_inputs(&next).bench_values(|d| {
+        BoolArray::new(
+            push_splat_non_nullable(d.ends.as_slice(), &d.values, TOTAL_LENGTH).freeze(),
+            Nullability::NonNullable.into(),
+        )
+        .into_array()
+    });
+}
+
+#[divan::bench(args = ARGS)]
+fn push_splat_nullable(bencher: Bencher, args: Args) {
+    let next = rotating(args.avg_run_length, args.skew, true);
+    bencher.with_inputs(&next).bench_values(|d| {
+        let Mask::Values(mask) = &d.validity else {
+            unreachable!("nullable dataset")
+        };
+        let (decoded, validity) = push_splat_nullable_kernel(
+            d.ends.as_slice(),
+            &d.values,
+            mask.bit_buffer(),
+            TOTAL_LENGTH,
+        );
+        BoolArray::new(decoded.freeze(), Validity::from(validity.freeze())).into_array()
+    });
+}
+
+/// The splat as it was first written, appending to a `BufferMut<u64>` with `push`/`push_n`
+/// instead of overwriting a pre-sized buffer.
+///
+/// This is the variant the shipped kernel replaced. The interesting part is not the append
+/// itself: `push_n` and `slice::fill` lower to the same inlined vector store loop, and the
+/// per-word capacity check merely trades places with a slice bounds check. What the append costs
+/// is inlining — `reserve`'s allocation slow path keeps `append_spanning` above LLVM's inline
+/// budget, so `&mut self` escapes into a call and the accumulator lives on the stack for the
+/// whole loop, at a read-modify-write per short run.
+struct PushSplat {
+    words: BufferMut<u64>,
+    word: u64,
+    bits: usize,
+}
+
+impl PushSplat {
+    fn with_capacity(length: usize) -> Self {
+        Self {
+            words: BufferMut::with_capacity(length.div_ceil(WORD_BITS)),
+            word: 0,
+            bits: 0,
+        }
+    }
+
+    #[inline(always)]
+    fn append_run(&mut self, value: bool, n: usize) {
+        let splat = u64::from(value).wrapping_neg();
+        if self.bits + n < WORD_BITS {
+            self.word |= splat & (((1u64 << n) - 1) << self.bits);
+            self.bits += n;
+            return;
+        }
+        self.append_spanning(splat, n);
+    }
+
+    fn append_spanning(&mut self, splat: u64, n: usize) {
+        self.words.push(self.word | (splat << self.bits));
+        let rest = n - (WORD_BITS - self.bits);
+
+        let whole = rest / WORD_BITS;
+        if whole > 0 {
+            self.words.push_n(splat, whole);
+        }
+
+        let tail = rest % WORD_BITS;
+        self.word = splat & ((1u64 << tail) - 1);
+        self.bits = tail;
+    }
+
+    fn finish(mut self, length: usize) -> BitBufferMut {
+        if self.bits > 0 {
+            self.words.push(self.word);
+        }
+        let words = length.div_ceil(WORD_BITS);
+        if self.words.len() < words {
+            self.words.push_n(0, words - self.words.len());
+        }
+        self.words.truncate(words);
+
+        let mut bytes = self.words.into_byte_buffer();
+        bytes.truncate(length.div_ceil(8));
+        BitBufferMut::from_buffer(bytes, 0, length)
+    }
+}
+
+fn push_splat_non_nullable(run_ends: &[u32], values: &BitBuffer, length: usize) -> BitBufferMut {
+    let mut decoded = PushSplat::with_capacity(length);
+    let mut pos = 0usize;
+    for (i, &end) in run_ends.iter().enumerate() {
+        let end = (end as usize).min(length);
+        decoded.append_run(values.value(i), end.saturating_sub(pos));
+        pos = end;
+    }
+    decoded.finish(length)
+}
+
+fn push_splat_nullable_kernel(
+    run_ends: &[u32],
+    values: &BitBuffer,
+    validity_mask: &BitBuffer,
+    length: usize,
+) -> (BitBufferMut, BitBufferMut) {
+    let mut decoded = PushSplat::with_capacity(length);
+    let mut decoded_validity = PushSplat::with_capacity(length);
+    let mut pos = 0usize;
+    for (i, &end) in run_ends.iter().enumerate() {
+        let end = (end as usize).min(length);
+        let run = end.saturating_sub(pos);
+        pos = end;
+
+        let is_valid = validity_mask.value(i);
+        decoded.append_run(is_valid && values.value(i), run);
+        decoded_validity.append_run(is_valid, run);
+    }
+    (decoded.finish(length), decoded_validity.finish(length))
 }
 
 /// Threshold below which the mirrored kernel appends sequentially instead of prefilling.

--- a/encodings/runend/benches/run_end_decode_bool_ablation.rs
+++ b/encodings/runend/benches/run_end_decode_bool_ablation.rs
@@ -8,7 +8,7 @@
 //! * `push_splat` is the splat as first written, appending words to a `BufferMut<u64>`.
 //! * `shipped` is `runend_decode_typed_bool`, which picks between that same prefill and the
 //!   splat — accumulate runs into a 64-bit word, store each output word exactly once, into a
-//!   buffer sized up front and overwritten by index.
+//!   buffer sized up front and overwritten by index — and between the splat's two forms.
 //!
 //! Run lengths and values are randomised and datasets are rotated across iterations, so the
 //! per-run value branch the prefill kernel depends on cannot be memorised by the predictor.
@@ -30,6 +30,18 @@
 //! The splat is worth up to 3.6x while runs are short. The crossover moves in with skew, since a
 //! skewed prefill patches few runs. `prefer_splat` reproduces this table's sign at 25 of the 26
 //! points; the miss is non-nullable 1024/50-50, where it gives up 6%.
+//!
+//! `prefer_blend` picks between the splat's two forms, and was derived the same way — pin the
+//! form and run the grid. Blend over branching, by fastest sample, splat forced:
+//!
+//! ```text
+//! run length      1     2     8    16    32    48    64   128  1024
+//! non-nullable 0.75  0.79  1.02  1.35  1.71  1.39  1.15  0.86  0.74
+//! nullable     0.82  0.88  1.15  1.37  1.71  1.79  1.74  1.89  1.16
+//! ```
+//!
+//! The peak is at half a word, where a run's chance of crossing a word boundary is closest to a
+//! coin flip and the branching form's test mispredicts most.
 
 #![expect(clippy::cast_possible_truncation)]
 
@@ -118,7 +130,15 @@ const ARGS: &[Args] = &[
         skew: Skew::Even,
     },
     Args {
+        avg_run_length: 16,
+        skew: Skew::Even,
+    },
+    Args {
         avg_run_length: 32,
+        skew: Skew::Even,
+    },
+    Args {
+        avg_run_length: 48,
         skew: Skew::Even,
     },
     Args {

--- a/encodings/runend/src/decompress_bool.rs
+++ b/encodings/runend/src/decompress_bool.rs
@@ -8,7 +8,9 @@
 //! * *splat* accumulates runs into a 64-bit word and stores each output word exactly once. Head
 //!   and tail masking is paid per output word rather than per run, and the run's value only
 //!   feeds an `AND` mask, so the value-dependent branch disappears. This is the kernel for short
-//!   runs, where it is up to 4x the prefill.
+//!   runs, where it is up to 4x the prefill. It comes in two forms, picked by [`prefer_blend`]:
+//!   one that branches on whether a run reaches the end of the word, and one that paints past
+//!   the run's end and stores every run instead.
 //! * *prefill* memsets the whole output with the majority value and then patches only the runs
 //!   that differ. One big memset beats a per-run one, so this stays ahead once runs are long
 //!   enough that the splat pays a whole-word fill per run and the patched runs are rare.
@@ -40,6 +42,12 @@ use vortex_mask::Mask;
 
 /// Bits per accumulator word.
 const WORD_BITS: usize = u64::BITS as usize;
+
+/// A mask with the low `n` bits set. `n` must be `< WORD_BITS`.
+#[inline(always)]
+fn low_mask(n: usize) -> u64 {
+    (1u64 << n) - 1
+}
 
 /// Decodes run-end encoded boolean values into a flat `BoolArray`.
 pub fn runend_decode_bools(
@@ -171,6 +179,35 @@ impl<'a> BitSplat<'a> {
         self.bits = tail;
     }
 
+    /// Appends `n` copies of `value` with no branch on whether the run ends inside the word.
+    ///
+    /// Paints the run from `bits` to the top of the word and stores unconditionally. Bits at and
+    /// above `bits` are don't-care, so painting past the run's end is free: the next run blends
+    /// over them and [`BitSplat::finish_masked`] clears whatever is left. Storing every run is
+    /// wasted work when runs are short, but there is no boundary test to mispredict — see
+    /// [`prefer_blend`] for where that trade turns over.
+    ///
+    /// Requires one word of slack past the output, since a zero-length run arriving once the
+    /// output is exactly full still stores.
+    #[inline(always)]
+    fn append_blend(&mut self, value: bool, n: usize) {
+        let splat = u64::from(value).wrapping_neg();
+
+        self.word = (self.word & low_mask(self.bits)) | (splat << self.bits);
+        self.words[self.idx] = MaybeUninit::new(self.word);
+
+        let total = self.bits + n;
+        let completed = total / WORD_BITS;
+        // Words after `idx` that this run covers end to end; `idx` itself was just stored.
+        if completed > 1 {
+            self.words[self.idx + 1..self.idx + completed].fill(MaybeUninit::new(splat));
+        }
+        self.idx += completed;
+        // Completing a word leaves the run's tail at the bottom of the next one.
+        self.word = if completed > 0 { splat } else { self.word };
+        self.bits = total % WORD_BITS;
+    }
+
     /// Flushes the accumulator and zero-fills any words the runs did not reach, leaving every
     /// word of the output initialized.
     fn finish(self) {
@@ -180,6 +217,13 @@ impl<'a> BitSplat<'a> {
             idx += 1;
         }
         self.words[idx..].fill(MaybeUninit::new(0));
+    }
+
+    /// [`BitSplat::finish`] for a sink driven by [`BitSplat::append_blend`], masking off the
+    /// don't-care bits the last store painted above `bits`.
+    fn finish_masked(mut self) {
+        self.word &= low_mask(self.bits);
+        self.finish();
     }
 }
 
@@ -273,6 +317,44 @@ impl<'a> BitSplatPair<'a> {
         self.bits = tail;
     }
 
+    /// Appends a run to both sinks with no boundary branch. See [`BitSplat::append_blend`].
+    #[inline(always)]
+    fn append_blend(&mut self, value: bool, is_valid: bool, n: usize) {
+        let splat = u64::from(value).wrapping_neg();
+        let validity_splat = u64::from(is_valid).wrapping_neg();
+
+        // One mask, one shift amount, both words.
+        let keep = low_mask(self.bits);
+        self.word = (self.word & keep) | (splat << self.bits);
+        self.validity_word = (self.validity_word & keep) | (validity_splat << self.bits);
+        self.words[self.idx] = MaybeUninit::new(self.word);
+        self.validity[self.idx] = MaybeUninit::new(self.validity_word);
+
+        let total = self.bits + n;
+        let completed = total / WORD_BITS;
+        if completed > 1 {
+            let span = self.idx + 1..self.idx + completed;
+            self.words[span.clone()].fill(MaybeUninit::new(splat));
+            self.validity[span].fill(MaybeUninit::new(validity_splat));
+        }
+        self.idx += completed;
+        self.word = if completed > 0 { splat } else { self.word };
+        self.validity_word = if completed > 0 {
+            validity_splat
+        } else {
+            self.validity_word
+        };
+        self.bits = total % WORD_BITS;
+    }
+
+    /// [`BitSplatPair::finish`] for a sink driven by [`BitSplatPair::append_blend`].
+    fn finish_masked(mut self) {
+        let keep = low_mask(self.bits);
+        self.word &= keep;
+        self.validity_word &= keep;
+        self.finish();
+    }
+
     /// Flushes both accumulators and zero-fills the words the runs did not reach.
     fn finish(self) {
         let mut idx = self.idx;
@@ -304,6 +386,45 @@ fn splat_bits_pair(
     }
     // SAFETY: the sink covered exactly `n_words` words of each buffer and was finished, so every
     // word in `0..n_words` of both is initialized, and `n_words` is the capacity of each.
+    unsafe {
+        buf.set_len(n_words);
+        validity_buf.set_len(n_words);
+    }
+    (into_bits(buf, length), into_bits(validity_buf, length))
+}
+
+/// [`splat_bits`] for a blend-driven sink, which needs a word of slack past the output.
+fn splat_blend_bits(length: usize, fill: impl FnOnce(&mut BitSplat<'_>)) -> BitBufferMut {
+    let n_words = length.div_ceil(WORD_BITS);
+    let mut buf = BufferMut::<u64>::with_capacity(n_words + 1);
+    {
+        let words = &mut buf.spare_capacity_mut()[..n_words + 1];
+        let mut splat = BitSplat::new(words);
+        fill(&mut splat);
+        splat.finish_masked();
+    }
+    // SAFETY: the sink covered exactly `n_words + 1` words and was finished, so every word in
+    // `0..n_words` is initialized; the slack word is never exposed.
+    unsafe { buf.set_len(n_words) };
+    into_bits(buf, length)
+}
+
+/// [`splat_bits_pair`] for a blend-driven sink; see [`splat_blend_bits`].
+fn splat_blend_bits_pair(
+    length: usize,
+    fill: impl FnOnce(&mut BitSplatPair<'_>),
+) -> (BitBufferMut, BitBufferMut) {
+    let n_words = length.div_ceil(WORD_BITS);
+    let mut buf = BufferMut::<u64>::with_capacity(n_words + 1);
+    let mut validity_buf = BufferMut::<u64>::with_capacity(n_words + 1);
+    {
+        let words = &mut buf.spare_capacity_mut()[..n_words + 1];
+        let validity_words = &mut validity_buf.spare_capacity_mut()[..n_words + 1];
+        let mut splat = BitSplatPair::new(words, validity_words);
+        fill(&mut splat);
+        splat.finish_masked();
+    }
+    // SAFETY: as `splat_blend_bits`, for both buffers.
     unsafe {
         buf.set_len(n_words);
         validity_buf.set_len(n_words);
@@ -386,6 +507,25 @@ fn prefer_splat(patched_runs: usize, buffers: usize, length: usize) -> bool {
     patched_runs * 6 * WORD_BITS >= length * (buffers + 1)
 }
 
+/// Chooses which splat form to use, from the average run length.
+///
+/// The forms differ only in how a run that ends inside a word is handled. The branching form
+/// tests for it and stores once per output word; the blend form paints past the run's end and
+/// stores once per run. Which wins is set by how often a run crosses a word boundary, which for
+/// runs averaging `r` bits is about `r / 64`:
+///
+/// * well below a word the test almost never fires, so it predicts and costs nothing, while the
+///   blend's store fires every run — up to 64 times per word of output;
+/// * from about a quarter of a word up, the test is close enough to a coin flip that its
+///   mispredictions cost more than the redundant stores. Measured, the blend is worth 1.35-1.9x
+///   from there, peaking at 1.7x where runs are half a word.
+///
+/// The nullable kernel crosses over earlier: it does about twice the work per run, so the extra
+/// stores are proportionally cheaper, while a misprediction costs the same.
+fn prefer_blend(num_runs: usize, buffers: usize, length: usize) -> bool {
+    length * 4 * buffers >= num_runs * WORD_BITS
+}
+
 /// Decodes run-end encoded booleans when all values are valid (non-nullable).
 fn decode_bool_non_nullable<E: IntegerPType>(
     run_ends: &[E],
@@ -405,6 +545,10 @@ fn decode_bool_non_nullable<E: IntegerPType>(
             nullability,
             length,
         );
+    }
+
+    if prefer_blend(run_ends.len(), 1, length) {
+        return blend_bool_non_nullable(run_ends, offset_e, length_e, values, nullability, length);
     }
 
     let decoded = splat_bits(length, |decoded| {
@@ -435,6 +579,10 @@ fn decode_bool_nullable<E: IntegerPType>(
         return prefill_bool_nullable(run_ends, offset_e, length_e, values, validity_mask, length);
     }
 
+    if prefer_blend(run_ends.len(), 2, length) {
+        return blend_bool_nullable(run_ends, offset_e, length_e, values, validity_mask, length);
+    }
+
     let (decoded, decoded_validity) = splat_bits_pair(length, |decoded| {
         let mut pos = 0usize;
         for (i, &end) in run_ends.iter().enumerate() {
@@ -447,6 +595,56 @@ fn decode_bool_nullable<E: IntegerPType>(
         }
     });
 
+    BoolArray::new(decoded.freeze(), Validity::from(decoded_validity.freeze()))
+}
+
+/// Splats every run with [`BitSplat::append_blend`].
+///
+/// Out of line on purpose: this is a whole second decode loop, and inlining it beside the
+/// branching one costs the branching loop about 20% in layout and register pressure — measured,
+/// with the branching loop textually unchanged either way.
+#[inline(never)]
+fn blend_bool_non_nullable<E: IntegerPType>(
+    run_ends: &[E],
+    offset_e: E,
+    length_e: E,
+    values: &BitBuffer,
+    nullability: Nullability,
+    length: usize,
+) -> BoolArray {
+    let decoded = splat_blend_bits(length, |decoded| {
+        let mut pos = 0usize;
+        for (i, &end) in run_ends.iter().enumerate() {
+            let run = run_length(end, offset_e, length_e, pos);
+            pos += run;
+            decoded.append_blend(values.value(i), run);
+        }
+    });
+    BoolArray::new(decoded.freeze(), nullability.into())
+}
+
+/// Splats every run into both buffers with [`BitSplatPair::append_blend`]. Out of line for the
+/// same reason as [`blend_bool_non_nullable`].
+#[inline(never)]
+fn blend_bool_nullable<E: IntegerPType>(
+    run_ends: &[E],
+    offset_e: E,
+    length_e: E,
+    values: &BitBuffer,
+    validity_mask: &BitBuffer,
+    length: usize,
+) -> BoolArray {
+    let (decoded, decoded_validity) = splat_blend_bits_pair(length, |decoded| {
+        let mut pos = 0usize;
+        for (i, &end) in run_ends.iter().enumerate() {
+            let run = run_length(end, offset_e, length_e, pos);
+            pos += run;
+
+            // The decoded bit is the value where valid, and false where null.
+            let is_valid = validity_mask.value(i);
+            decoded.append_blend(is_valid && values.value(i), is_valid, run);
+        }
+    });
     BoolArray::new(decoded.freeze(), Validity::from(decoded_validity.freeze()))
 }
 
@@ -523,6 +721,7 @@ mod tests {
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
+    use vortex_array::dtype::Nullability;
     use vortex_array::validity::Validity;
     use vortex_buffer::BitBuffer;
     use vortex_error::VortexResult;
@@ -690,6 +889,74 @@ mod tests {
             BitBuffer::from(expected_values),
             Validity::from(BitBuffer::from(expected_validity)),
         );
+        assert_arrays_eq!(decoded, expected, &mut ctx);
+        Ok(())
+    }
+
+    /// The blend form must agree with a naive decode at every run length, including the ones
+    /// [`prefer_blend`] would never send to it. It paints past the end of each run, so the
+    /// interesting failures are bits surviving where a later run should have covered them.
+    #[rstest]
+    fn blend_form_matches_naive(
+        #[values(1, 2, 5, 16, 31, 32, 33, 63, 64, 65, 200)] avg_run_length: usize,
+        #[values(false, true)] nullable: bool,
+        #[values(4096, 4095, 4033)] length: usize,
+    ) -> VortexResult<()> {
+        use rand::RngExt;
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let mut ctx = SESSION.create_execution_ctx();
+        let mut rng = StdRng::seed_from_u64(0xB1E4D ^ (avg_run_length as u64) << 8 ^ length as u64);
+
+        let mut ends = Vec::new();
+        let (mut values, mut validity) = (Vec::new(), Vec::new());
+        let (mut want, mut want_valid) = (Vec::new(), Vec::new());
+        let mut pos = 0usize;
+        while pos < length {
+            let run = rng
+                .random_range(1..=(2 * avg_run_length).max(1))
+                .min(length - pos);
+            pos += run;
+            ends.push(pos as u32);
+            let value = rng.random_bool(0.5);
+            let is_valid = !nullable || rng.random_bool(0.7);
+            values.push(value);
+            validity.push(is_valid);
+            want.extend(std::iter::repeat_n(is_valid && value, run));
+            want_valid.extend(std::iter::repeat_n(is_valid, run));
+        }
+
+        let values_buf = BitBuffer::from(values);
+        let validity_buf = BitBuffer::from(validity);
+        let (decoded, expected) = if nullable {
+            (
+                super::blend_bool_nullable::<u32>(
+                    &ends,
+                    0,
+                    length as u32,
+                    &values_buf,
+                    &validity_buf,
+                    length,
+                ),
+                BoolArray::new(
+                    BitBuffer::from(want),
+                    Validity::from(BitBuffer::from(want_valid)),
+                ),
+            )
+        } else {
+            (
+                super::blend_bool_non_nullable::<u32>(
+                    &ends,
+                    0,
+                    length as u32,
+                    &values_buf,
+                    Nullability::NonNullable,
+                    length,
+                ),
+                BoolArray::from(BitBuffer::from(want)),
+            )
+        };
         assert_arrays_eq!(decoded, expected, &mut ctx);
         Ok(())
     }

--- a/encodings/runend/src/decompress_bool.rs
+++ b/encodings/runend/src/decompress_bool.rs
@@ -3,14 +3,15 @@
 
 //! Optimized run-end decoding for boolean arrays.
 //!
-//! Two kernels, picked per array by [`prefer_splat`]:
+//! Two kernels, picked per array by `prefer_splat`:
 //!
 //! * *splat* accumulates runs into a 64-bit word and stores each output word exactly once. Head
 //!   and tail masking is paid per output word rather than per run, and the run's value only
 //!   feeds an `AND` mask, so the value-dependent branch disappears. This is the kernel for short
-//!   runs, where it is up to 4x the prefill. It comes in two forms, picked by [`prefer_blend`]:
+//!   runs, where it is up to 4x the prefill. It comes in two forms, picked by `prefer_blend`:
 //!   one that branches on whether a run reaches the end of the word, and one that paints past
-//!   the run's end and stores every run instead.
+//!   the run's end and stores every run instead, trading a store per run for a branch that
+//!   mispredicts once runs are near a word long.
 //! * *prefill* memsets the whole output with the majority value and then patches only the runs
 //!   that differ. One big memset beats a per-run one, so this stays ahead once runs are long
 //!   enough that the splat pays a whole-word fill per run and the patched runs are rare.
@@ -493,18 +494,17 @@ fn minority_runs(values: &BitBuffer) -> usize {
 /// The splat pays per output word; the prefill pays one memset over the whole output plus one
 /// range fill per patched run, and a range fill is far dearer than a splat step — a partial byte
 /// at each end, a `memset` call, and a data-dependent branch to decide whether to do it at all.
-/// Measured, one patched run costs about what the splat spends on three output words. So the
-/// prefill wins exactly when patches are rarer than that.
+/// So the prefill only wins once patches are rare relative to the output: measured, rarer than
+/// about one per eight output words.
 ///
-/// A second output buffer does not double the splat's side of that: [`BitSplatPair`] shares the
-/// run length, the word-boundary test and the head mask, so the second buffer adds about half the
-/// cost of the first. Hence `buffers + 1` against a doubled constant rather than `buffers`.
+/// The same threshold holds whether one buffer is being built or two: the nullable kernel
+/// doubles the work on both sides of the comparison, since the prefill memsets and patches two
+/// buffers exactly where the splat builds two.
 ///
 /// Re-derive by returning a constant from here and running `run_end_decode_bool_ablation` with
-/// each kernel pinned. On that grid this picks the faster kernel at 25 of 26 points; the miss is
-/// non-nullable 1024-element runs with 50/50 values, where it gives up 6%.
-fn prefer_splat(patched_runs: usize, buffers: usize, length: usize) -> bool {
-    patched_runs * 6 * WORD_BITS >= length * (buffers + 1)
+/// each kernel pinned. On that grid this picks the faster kernel at all 30 points.
+fn prefer_splat(patched_runs: usize, length: usize) -> bool {
+    patched_runs * 8 * WORD_BITS >= length
 }
 
 /// Chooses which splat form to use, from the average run length.
@@ -516,14 +516,15 @@ fn prefer_splat(patched_runs: usize, buffers: usize, length: usize) -> bool {
 ///
 /// * well below a word the test almost never fires, so it predicts and costs nothing, while the
 ///   blend's store fires every run — up to 64 times per word of output;
-/// * from about a quarter of a word up, the test is close enough to a coin flip that its
-///   mispredictions cost more than the redundant stores. Measured, the blend is worth 1.35-1.9x
-///   from there, peaking at 1.7x where runs are half a word.
+/// * from about an eighth of a word up, the test fires often enough to mispredict, and the blend
+///   is worth 1.2-1.5x;
+/// * far above a word the test always fires, so it predicts again, and the blend is left paying
+///   its extra store and arithmetic against a whole-word fill that dominates either way.
 ///
-/// The nullable kernel crosses over earlier: it does about twice the work per run, so the extra
-/// stores are proportionally cheaper, while a misprediction costs the same.
+/// The nullable kernel enters the band later: it does about twice the work per run, so the extra
+/// stores are proportionally dearer, while a misprediction costs the same.
 fn prefer_blend(num_runs: usize, buffers: usize, length: usize) -> bool {
-    length * 4 * buffers >= num_runs * WORD_BITS
+    length >= num_runs * 8 * buffers && length <= num_runs * 4 * WORD_BITS
 }
 
 /// Decodes run-end encoded booleans when all values are valid (non-nullable).
@@ -536,7 +537,7 @@ fn decode_bool_non_nullable<E: IntegerPType>(
 ) -> BoolArray {
     let (offset_e, length_e) = trim_bounds::<E>(offset, length);
 
-    if !prefer_splat(minority_runs(values), 1, length) {
+    if !prefer_splat(minority_runs(values), length) {
         return prefill_bool_non_nullable(
             run_ends,
             offset_e,
@@ -575,7 +576,7 @@ fn decode_bool_nullable<E: IntegerPType>(
 
     // Both buffers are prefilled and patched independently, so both sets of minority runs count.
     let patched_runs = minority_runs(values) + minority_runs(validity_mask);
-    if !prefer_splat(patched_runs, 2, length) {
+    if !prefer_splat(patched_runs, length) {
         return prefill_bool_nullable(run_ends, offset_e, length_e, values, validity_mask, length);
     }
 

--- a/encodings/runend/src/decompress_bool.rs
+++ b/encodings/runend/src/decompress_bool.rs
@@ -3,10 +3,18 @@
 
 //! Optimized run-end decoding for boolean arrays.
 //!
-//! Uses an adaptive strategy that pre-fills the buffer with the majority value
-//! (0s or 1s) and only fills the minority runs, minimizing work for skewed distributions.
+//! Two kernels, picked per array by [`prefer_splat`]:
+//!
+//! * *splat* accumulates runs into a 64-bit word and stores each output word exactly once. Head
+//!   and tail masking is paid per output word rather than per run, and the run's value only
+//!   feeds an `AND` mask, so the value-dependent branch disappears. This is the kernel for short
+//!   runs, where it is up to 4x the prefill.
+//! * *prefill* memsets the whole output with the majority value and then patches only the runs
+//!   that differ. One big memset beats a per-run one, so this stays ahead once runs are long
+//!   enough that the splat pays a `memset` call per run and the patched runs are rare.
+//!
+//! See `benches/run_end_decode_bool_ablation.rs` for the A/B the crossover comes from.
 
-use itertools::Itertools;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
@@ -15,20 +23,20 @@ use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::bool::BoolArrayExt;
 use vortex_array::dtype::DType;
+use vortex_array::dtype::IntegerPType;
 use vortex_array::dtype::Nullability;
 use vortex_array::match_each_unsigned_integer_ptype;
 use vortex_array::scalar::Scalar;
 use vortex_array::validity::Validity;
 use vortex_buffer::BitBuffer;
 use vortex_buffer::BitBufferMut;
+use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
+use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 
-use crate::iter::trimmed_ends_iter;
-
-/// Threshold for number of runs below which we use sequential append instead of prefill.
-/// With few runs, the overhead of prefilling the entire buffer dominates.
-const PREFILL_RUN_THRESHOLD: usize = 32;
+/// Bits per accumulator word.
+const WORD_BITS: usize = u64::BITS as usize;
 
 /// Decodes run-end encoded boolean values into a flat `BoolArray`.
 pub fn runend_decode_bools(
@@ -45,23 +53,10 @@ pub fn runend_decode_bools(
     let values_buf = values.to_bit_buffer();
     let nullability = values.dtype().nullability();
 
-    // Fast path for few runs with no offset - avoids iterator overhead
-    let num_runs = values_buf.len();
-    if offset == 0 && num_runs < PREFILL_RUN_THRESHOLD {
-        return Ok(match_each_unsigned_integer_ptype!(ends.ptype(), |E| {
-            decode_few_runs_no_offset(
-                ends.as_slice::<E>(),
-                &values_buf,
-                validity,
-                nullability,
-                length,
-            )
-        }));
-    }
-
     Ok(match_each_unsigned_integer_ptype!(ends.ptype(), |E| {
         runend_decode_typed_bool(
-            trimmed_ends_iter(ends.as_slice::<E>(), offset, length),
+            ends.as_slice::<E>(),
+            offset,
             &values_buf,
             validity,
             nullability,
@@ -70,15 +65,15 @@ pub fn runend_decode_bools(
     }))
 }
 
-/// Decodes run-end encoded boolean values using an adaptive strategy.
+/// Decodes run-end encoded boolean values into a flat `BoolArray`.
 ///
-/// The strategy counts true vs false runs and chooses the optimal approach:
-/// - If more true runs: pre-fill with 1s, clear false runs
-/// - If more false runs: pre-fill with 0s, fill true runs
-///
-/// This minimizes work for skewed distributions (e.g., sparse validity masks).
-pub fn runend_decode_typed_bool(
-    run_ends: impl Iterator<Item = usize>,
+/// Run ends are taken as a slice and trimmed by `offset` inline. Consuming them through an
+/// iterator chain instead costs a significant fraction of decode time: the per-run work is a
+/// handful of instructions, so `trimmed_ends_iter`'s `map`s plus a `zip_eq` plus a bit-at-a-time
+/// [`BitBuffer`] iterator are not amortized by anything.
+pub fn runend_decode_typed_bool<E: IntegerPType>(
+    run_ends: &[E],
+    offset: usize,
     values: &BitBuffer,
     values_validity: Mask,
     values_nullability: Nullability,
@@ -86,159 +81,267 @@ pub fn runend_decode_typed_bool(
 ) -> ArrayRef {
     match values_validity {
         Mask::AllTrue(_) => {
-            decode_bool_non_nullable(run_ends, values, values_nullability, length).into_array()
+            decode_bool_non_nullable(run_ends, offset, values, values_nullability, length)
+                .into_array()
         }
         Mask::AllFalse(_) => {
             ConstantArray::new(Scalar::null(DType::Bool(Nullability::Nullable)), length)
                 .into_array()
         }
         Mask::Values(mask) => {
-            decode_bool_nullable(run_ends, values, mask.bit_buffer(), length).into_array()
+            decode_bool_nullable(run_ends, offset, values, mask.bit_buffer(), length).into_array()
         }
     }
 }
 
-/// Fast path for few runs with no offset. Uses direct slice access to minimize overhead.
-/// This avoids the `trimmed_ends_iter` iterator chain which adds significant overhead
-/// for small numbers of runs.
-#[inline(always)]
-fn decode_few_runs_no_offset<E: vortex_array::dtype::IntegerPType>(
-    ends: &[E],
-    values: &BitBuffer,
-    validity: Mask,
-    nullability: Nullability,
-    length: usize,
-) -> ArrayRef {
-    match validity {
-        Mask::AllTrue(_) => {
-            let mut decoded = BitBufferMut::with_capacity(length);
-            let mut prev_end = 0usize;
-            for (i, &end) in ends.iter().enumerate() {
-                let end = end.as_().min(length);
-                decoded.append_n(values.value(i), end - prev_end);
-                prev_end = end;
-            }
-            BoolArray::new(decoded.freeze(), nullability.into()).into_array()
-        }
-        Mask::AllFalse(_) => {
-            ConstantArray::new(Scalar::null(DType::Bool(Nullability::Nullable)), length)
-                .into_array()
-        }
-        Mask::Values(mask) => {
-            let validity_buf = mask.bit_buffer();
-            let mut decoded = BitBufferMut::with_capacity(length);
-            let mut decoded_validity = BitBufferMut::with_capacity(length);
-            let mut prev_end = 0usize;
-            for (i, &end) in ends.iter().enumerate() {
-                let end = end.as_().min(length);
-                let run_len = end - prev_end;
-                let is_valid = validity_buf.value(i);
-                if is_valid {
-                    decoded_validity.append_n(true, run_len);
-                    decoded.append_n(values.value(i), run_len);
-                } else {
-                    decoded_validity.append_n(false, run_len);
-                    decoded.append_n(false, run_len);
-                }
-                prev_end = end;
-            }
-            BoolArray::new(decoded.freeze(), Validity::from(decoded_validity.freeze())).into_array()
+/// A bit sink that builds its output one 64-bit word at a time.
+///
+/// Bits are accumulated in a register and each word is written to the buffer exactly once, so a
+/// run never reads back what an earlier run stored. Compare a per-run `fill_range`, which
+/// read-modify-writes a partial byte at each end of every run.
+struct BitSplat {
+    words: BufferMut<u64>,
+    /// The word under construction. Bits at and above `bits` are always zero.
+    word: u64,
+    /// Number of bits already accumulated into `word`, always `< WORD_BITS`.
+    bits: usize,
+}
+
+impl BitSplat {
+    /// Creates a sink sized to hold `length` bits without reallocating.
+    fn with_capacity(length: usize) -> Self {
+        Self {
+            words: BufferMut::with_capacity(length.div_ceil(WORD_BITS)),
+            word: 0,
+            bits: 0,
         }
     }
+
+    /// Appends `n` copies of `value`.
+    #[inline(always)]
+    fn append_run(&mut self, value: bool, n: usize) {
+        // 0 or all-ones; the value never branches, it only masks.
+        let splat = u64::from(value).wrapping_neg();
+        if self.bits + n < WORD_BITS {
+            // `n < WORD_BITS`, so the mask shift is in range.
+            self.word |= splat & (((1u64 << n) - 1) << self.bits);
+            self.bits += n;
+            return;
+        }
+        self.append_spanning(splat, n);
+    }
+
+    /// Appends a run that reaches at least to the end of the current word.
+    ///
+    /// Whole words are memset rather than splatted one at a time.
+    fn append_spanning(&mut self, splat: u64, n: usize) {
+        // Complete the current word. `self.bits < WORD_BITS`, so the shift is in range, and the
+        // run covers every bit from `self.bits` up.
+        self.words.push(self.word | (splat << self.bits));
+        let rest = n - (WORD_BITS - self.bits);
+
+        let whole = rest / WORD_BITS;
+        if whole > 0 {
+            self.words.push_n(splat, whole);
+        }
+
+        let tail = rest % WORD_BITS;
+        self.word = splat & ((1u64 << tail) - 1);
+        self.bits = tail;
+    }
+
+    /// Flushes the accumulator into a `length`-bit buffer, zero-padding a short tail.
+    fn finish(mut self, length: usize) -> BitBufferMut {
+        if self.bits > 0 {
+            self.words.push(self.word);
+        }
+        let words = length.div_ceil(WORD_BITS);
+        if self.words.len() < words {
+            self.words.push_n(0, words - self.words.len());
+        }
+        self.words.truncate(words);
+
+        let mut bytes = self.words.into_byte_buffer();
+        bytes.truncate(length.div_ceil(8));
+        BitBufferMut::from_buffer(bytes, 0, length)
+    }
+}
+
+/// Convert `offset`/`length` into `E` once, outside the per-run loop.
+#[inline(always)]
+fn trim_bounds<E: IntegerPType>(offset: usize, length: usize) -> (E, E) {
+    let offset_e = E::from_usize(offset).unwrap_or_else(|| {
+        vortex_panic!(
+            "offset {} cannot be converted to {}",
+            offset,
+            std::any::type_name::<E>()
+        )
+    });
+    let length_e = E::from_usize(length).unwrap_or_else(|| {
+        vortex_panic!(
+            "length {} cannot be converted to {}",
+            length,
+            std::any::type_name::<E>()
+        )
+    });
+    (offset_e, length_e)
+}
+
+/// Trim a raw run end down by `offset` and clamp it to `length`.
+#[inline(always)]
+fn trim_end<E: IntegerPType>(end: E, offset: E, length: E) -> usize {
+    if end < offset {
+        vortex_panic!("run end {end} must be >= offset {offset}");
+    }
+    std::cmp::min(end - offset, length).as_()
+}
+
+/// Number of runs whose value differs from the majority: exactly the runs the prefill kernel
+/// has to patch after its memset.
+fn minority_runs(values: &BitBuffer) -> usize {
+    let true_count = values.true_count();
+    std::cmp::min(true_count, values.len() - true_count)
+}
+
+/// Chooses between the two kernels from how many runs the prefill would have to patch.
+///
+/// The splat pays per output word; the prefill pays one memset over the whole output plus one
+/// range fill per patched run, and a range fill is far dearer than a splat step — a partial byte
+/// at each end, a `memset` call, and a data-dependent branch to decide whether to do it at all.
+/// Measured, one patched run costs about what the splat spends on three output words, per buffer
+/// the splat has to build. So the prefill wins exactly when patches are rarer than that.
+///
+/// On the `run_end_decode_bool_ablation` grid this picks the faster kernel everywhere except
+/// 8-element runs with 90/10 values, where it gives up 7%.
+fn prefer_splat(patched_runs: usize, buffers: usize, length: usize) -> bool {
+    patched_runs * 3 * WORD_BITS >= length * buffers
 }
 
 /// Decodes run-end encoded booleans when all values are valid (non-nullable).
-fn decode_bool_non_nullable(
-    run_ends: impl Iterator<Item = usize>,
+fn decode_bool_non_nullable<E: IntegerPType>(
+    run_ends: &[E],
+    offset: usize,
     values: &BitBuffer,
     nullability: Nullability,
     length: usize,
 ) -> BoolArray {
-    let num_runs = values.len();
+    let (offset_e, length_e) = trim_bounds::<E>(offset, length);
 
-    // For few runs, sequential append is faster than prefill + modify
-    if num_runs < PREFILL_RUN_THRESHOLD {
-        let mut decoded = BitBufferMut::with_capacity(length);
-        for (end, value) in run_ends.zip(values.iter()) {
-            decoded.append_n(value, end - decoded.len());
-        }
-        return BoolArray::new(decoded.freeze(), nullability.into());
+    if !prefer_splat(minority_runs(values), 1, length) {
+        return prefill_bool_non_nullable(
+            run_ends,
+            offset_e,
+            length_e,
+            values,
+            nullability,
+            length,
+        );
     }
 
-    // Adaptive strategy: prefill with majority value, only flip minority runs
-    let prefill = values.true_count() > num_runs - values.true_count();
-    let mut decoded = BitBufferMut::full(prefill, length);
-    let mut current_pos = 0usize;
-
-    for (end, value) in run_ends.zip_eq(values.iter()) {
-        if end > current_pos && value != prefill {
-            // SAFETY: current_pos < end <= length == decoded.len()
-            unsafe { decoded.fill_range_unchecked(current_pos, end, value) };
-        }
-        current_pos = end;
+    let mut decoded = BitSplat::with_capacity(length);
+    let mut pos = 0usize;
+    for (i, &end) in run_ends.iter().enumerate() {
+        let end = trim_end(end, offset_e, length_e);
+        decoded.append_run(values.value(i), end.saturating_sub(pos));
+        pos = end;
     }
-    BoolArray::new(decoded.freeze(), nullability.into())
+
+    BoolArray::new(decoded.finish(length).freeze(), nullability.into())
 }
 
 /// Decodes run-end encoded booleans when values may be null (nullable).
-fn decode_bool_nullable(
-    run_ends: impl Iterator<Item = usize>,
+fn decode_bool_nullable<E: IntegerPType>(
+    run_ends: &[E],
+    offset: usize,
     values: &BitBuffer,
     validity_mask: &BitBuffer,
     length: usize,
 ) -> BoolArray {
-    let num_runs = values.len();
+    let (offset_e, length_e) = trim_bounds::<E>(offset, length);
 
-    // For few runs, sequential append is faster than prefill + modify
-    if num_runs < PREFILL_RUN_THRESHOLD {
-        return decode_nullable_sequential(run_ends, values, validity_mask, length);
+    // Both buffers are prefilled and patched independently, so both sets of minority runs count.
+    let patched_runs = minority_runs(values) + minority_runs(validity_mask);
+    if !prefer_splat(patched_runs, 2, length) {
+        return prefill_bool_nullable(run_ends, offset_e, length_e, values, validity_mask, length);
     }
 
-    // Adaptive strategy: prefill each buffer with its majority value
-    let prefill_decoded = values.true_count() > num_runs - values.true_count();
-    let prefill_valid = validity_mask.true_count() > num_runs - validity_mask.true_count();
+    let mut decoded = BitSplat::with_capacity(length);
+    let mut decoded_validity = BitSplat::with_capacity(length);
+
+    let mut pos = 0usize;
+    for (i, &end) in run_ends.iter().enumerate() {
+        let end = trim_end(end, offset_e, length_e);
+        let run = end.saturating_sub(pos);
+        pos = end;
+
+        // The decoded bit is the value where valid, and false where null.
+        let is_valid = validity_mask.value(i);
+        decoded.append_run(is_valid && values.value(i), run);
+        decoded_validity.append_run(is_valid, run);
+    }
+
+    BoolArray::new(
+        decoded.finish(length).freeze(),
+        Validity::from(decoded_validity.finish(length).freeze()),
+    )
+}
+
+/// Memsets the output with the majority value, then patches the runs that differ.
+fn prefill_bool_non_nullable<E: IntegerPType>(
+    run_ends: &[E],
+    offset: E,
+    length_e: E,
+    values: &BitBuffer,
+    nullability: Nullability,
+    length: usize,
+) -> BoolArray {
+    let prefill = 2 * values.true_count() > values.len();
+    let mut decoded = BitBufferMut::full(prefill, length);
+
+    let mut pos = 0usize;
+    for (i, &end) in run_ends.iter().enumerate() {
+        let end = trim_end(end, offset, length_e);
+        if end > pos && values.value(i) != prefill {
+            // SAFETY: pos < end <= length == decoded.len()
+            unsafe { decoded.fill_range_unchecked(pos, end, !prefill) };
+        }
+        pos = pos.max(end);
+    }
+
+    BoolArray::new(decoded.freeze(), nullability.into())
+}
+
+/// Memsets both output buffers with their majority value, then patches the runs that differ.
+fn prefill_bool_nullable<E: IntegerPType>(
+    run_ends: &[E],
+    offset: E,
+    length_e: E,
+    values: &BitBuffer,
+    validity_mask: &BitBuffer,
+    length: usize,
+) -> BoolArray {
+    let prefill_decoded = 2 * values.true_count() > values.len();
+    let prefill_valid = 2 * validity_mask.true_count() > validity_mask.len();
 
     let mut decoded = BitBufferMut::full(prefill_decoded, length);
     let mut decoded_validity = BitBufferMut::full(prefill_valid, length);
-    let mut current_pos = 0usize;
 
-    for (end, (value, is_valid)) in run_ends.zip_eq(values.iter().zip(validity_mask.iter())) {
-        if end > current_pos {
-            // SAFETY: current_pos < end <= length == decoded.len() == decoded_validity.len()
+    let mut pos = 0usize;
+    for (i, &end) in run_ends.iter().enumerate() {
+        let end = trim_end(end, offset, length_e);
+        if end > pos {
+            let is_valid = validity_mask.value(i);
+            // SAFETY: pos < end <= length == decoded.len() == decoded_validity.len()
             if is_valid != prefill_valid {
-                unsafe { decoded_validity.fill_range_unchecked(current_pos, end, is_valid) };
+                unsafe { decoded_validity.fill_range_unchecked(pos, end, is_valid) };
             }
-            // Decoded bit should be the actual value when valid, false when null.
-            let want_decoded = is_valid && value;
+            // The decoded bit is the value where valid, and false where null.
+            let want_decoded = is_valid && values.value(i);
             if want_decoded != prefill_decoded {
-                unsafe { decoded.fill_range_unchecked(current_pos, end, want_decoded) };
+                unsafe { decoded.fill_range_unchecked(pos, end, want_decoded) };
             }
-            current_pos = end;
         }
-    }
-    BoolArray::new(decoded.freeze(), Validity::from(decoded_validity.freeze()))
-}
-
-/// Sequential decode for few runs - avoids prefill overhead.
-#[inline(always)]
-fn decode_nullable_sequential(
-    run_ends: impl Iterator<Item = usize>,
-    values: &BitBuffer,
-    validity_mask: &BitBuffer,
-    length: usize,
-) -> BoolArray {
-    let mut decoded = BitBufferMut::with_capacity(length);
-    let mut decoded_validity = BitBufferMut::with_capacity(length);
-
-    for (end, (value, is_valid)) in run_ends.zip(values.iter().zip(validity_mask.iter())) {
-        let run_len = end - decoded.len();
-        if is_valid {
-            decoded_validity.append_n(true, run_len);
-            decoded.append_n(value, run_len);
-        } else {
-            decoded_validity.append_n(false, run_len);
-            decoded.append_n(false, run_len);
-        }
+        pos = pos.max(end);
     }
 
     BoolArray::new(decoded.freeze(), Validity::from(decoded_validity.freeze()))
@@ -246,12 +349,15 @@ fn decode_nullable_sequential(
 
 #[cfg(test)]
 mod tests {
+    // Test data is sized well within `u32`.
+    #![expect(clippy::cast_possible_truncation)]
+
     use std::sync::LazyLock;
 
+    use rstest::rstest;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
-    use vortex_array::arrays::bool::BoolArrayExt;
     use vortex_array::assert_arrays_eq;
     use vortex_array::validity::Validity;
     use vortex_buffer::BitBuffer;
@@ -311,30 +417,35 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn decode_bools_all_true_single_run() -> VortexResult<()> {
+    #[rstest]
+    #[case(true)]
+    #[case(false)]
+    fn decode_bools_single_run(#[case] value: bool) -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
         let ends = PrimitiveArray::from_iter([10u32]);
-        let values = BoolArray::from(BitBuffer::from(vec![true]));
+        let values = BoolArray::from(BitBuffer::from(vec![value]));
         let decoded = runend_decode_bools(ends, values, 0, 10, &mut ctx)?;
 
-        let expected = BoolArray::from(BitBuffer::from(vec![
-            true, true, true, true, true, true, true, true, true, true,
-        ]));
+        let expected = BoolArray::from(BitBuffer::from(vec![value; 10]));
         assert_arrays_eq!(decoded, expected, &mut ctx);
         Ok(())
     }
 
-    #[test]
-    fn decode_bools_all_false_single_run() -> VortexResult<()> {
+    /// Runs long enough to span whole accumulator words, at every alignment of the word grid.
+    #[rstest]
+    fn decode_bools_word_spanning(
+        #[values(1, 7, 63, 64, 65, 127, 128, 129, 1000)] first_run: usize,
+        #[values(1, 63, 64, 65, 200)] second_run: usize,
+    ) -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
-        let ends = PrimitiveArray::from_iter([10u32]);
-        let values = BoolArray::from(BitBuffer::from(vec![false]));
-        let decoded = runend_decode_bools(ends, values, 0, 10, &mut ctx)?;
+        let length = first_run + second_run;
+        let ends = PrimitiveArray::from_iter([first_run as u32, length as u32]);
+        let values = BoolArray::from(BitBuffer::from(vec![true, false]));
+        let decoded = runend_decode_bools(ends, values, 0, length, &mut ctx)?;
 
-        let expected = BoolArray::from(BitBuffer::from(vec![
-            false, false, false, false, false, false, false, false, false, false,
-        ]));
+        let mut expected = vec![true; first_run];
+        expected.extend(std::iter::repeat_n(false, second_run));
+        let expected = BoolArray::from(BitBuffer::from(expected));
         assert_arrays_eq!(decoded, expected, &mut ctx);
         Ok(())
     }
@@ -355,8 +466,6 @@ mod tests {
 
     #[test]
     fn decode_bools_nullable() -> VortexResult<()> {
-        use vortex_array::validity::Validity;
-
         let mut ctx = SESSION.create_execution_ctx();
         // 3 runs: T (valid), F (null), T (valid) -> [T, T, null, null, null, T, T, T, T, T]
         let ends = PrimitiveArray::from_iter([2u32, 5, 10]);
@@ -380,45 +489,91 @@ mod tests {
     }
 
     #[test]
-    fn decode_bools_nullable_few_runs() -> VortexResult<()> {
+    fn decode_bools_nullable_long_runs() -> VortexResult<()> {
         let mut ctx = SESSION.create_execution_ctx();
-        // Test few runs (uses fast path): 5 runs of length 2000 each
+        // 5 runs of length 2000 each, alternating validity.
         let ends = PrimitiveArray::from_iter([2000u32, 4000, 6000, 8000, 10000]);
         let values = BoolArray::new(
             BitBuffer::from(vec![true, false, true, false, true]),
             Validity::from(BitBuffer::from(vec![true, false, true, false, true])),
         );
-        let decoded = runend_decode_bools(ends, values, 0, 10000, &mut ctx)?
-            .execute::<BoolArray>(&mut ctx)?;
+        let decoded = runend_decode_bools(ends, values, 0, 10000, &mut ctx)?;
 
-        // Check length and a few values
-        assert_eq!(decoded.len(), 10000);
-        // First run: valid true
-        assert!(
-            decoded
-                .as_ref()
-                .validity()?
-                .execute_mask(decoded.as_ref().len(), &mut ctx)?
-                .value(0)
+        let mut expected_values = Vec::with_capacity(10000);
+        let mut expected_validity = Vec::with_capacity(10000);
+        for run in 0..5 {
+            let is_valid = run % 2 == 0;
+            expected_values.extend(std::iter::repeat_n(is_valid, 2000));
+            expected_validity.extend(std::iter::repeat_n(is_valid, 2000));
+        }
+        let expected = BoolArray::new(
+            BitBuffer::from(expected_values),
+            Validity::from(BitBuffer::from(expected_validity)),
         );
-        assert!(decoded.to_bit_buffer().value(0));
-        // Second run: null (validity false)
-        assert!(
-            !decoded
-                .as_ref()
-                .validity()?
-                .execute_mask(decoded.as_ref().len(), &mut ctx)?
-                .value(2000)
-        );
-        // Third run: valid true
-        assert!(
-            decoded
-                .as_ref()
-                .validity()?
-                .execute_mask(decoded.as_ref().len(), &mut ctx)?
-                .value(4000)
-        );
-        assert!(decoded.to_bit_buffer().value(4000));
+        assert_arrays_eq!(decoded, expected, &mut ctx);
+        Ok(())
+    }
+
+    /// Differential test against a naive element-at-a-time decode over randomised inputs.
+    #[rstest]
+    fn decode_bools_matches_naive(
+        #[values(1, 2, 5, 37, 64, 300)] avg_run_length: usize,
+        #[values(false, true)] nullable: bool,
+        #[values(0, 1, 63, 64, 100)] offset: usize,
+    ) -> VortexResult<()> {
+        use rand::RngExt;
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let mut ctx = SESSION.create_execution_ctx();
+        let mut rng = StdRng::seed_from_u64(0x5eed ^ (avg_run_length as u64) << 8 ^ offset as u64);
+        let total = 4096usize;
+
+        let mut ends = Vec::new();
+        let mut values = Vec::new();
+        let mut validity = Vec::new();
+        let mut expected_values = Vec::new();
+        let mut expected_validity = Vec::new();
+
+        let mut pos = 0usize;
+        while pos < total {
+            let run = rng
+                .random_range(1..=(2 * avg_run_length).max(1))
+                .min(total - pos);
+            pos += run;
+            ends.push(pos as u32);
+            let value = rng.random_bool(0.5);
+            let is_valid = !nullable || rng.random_bool(0.7);
+            values.push(value);
+            validity.push(is_valid);
+            expected_values.extend(std::iter::repeat_n(is_valid && value, run));
+            expected_validity.extend(std::iter::repeat_n(is_valid, run));
+        }
+
+        // Drop the runs that end before `offset`, mirroring what slicing produces.
+        let first_run = ends.iter().position(|&e| e as usize > offset).unwrap_or(0);
+        let length = total - offset;
+        let ends = PrimitiveArray::from_iter(ends[first_run..].iter().copied());
+        let values_array = if nullable {
+            BoolArray::new(
+                BitBuffer::from(values[first_run..].to_vec()),
+                Validity::from(BitBuffer::from(validity[first_run..].to_vec())),
+            )
+        } else {
+            BoolArray::from(BitBuffer::from(values[first_run..].to_vec()))
+        };
+
+        let decoded = runend_decode_bools(ends, values_array, offset, length, &mut ctx)?;
+
+        let expected = if nullable {
+            BoolArray::new(
+                BitBuffer::from(expected_values[offset..].to_vec()),
+                Validity::from(BitBuffer::from(expected_validity[offset..].to_vec())),
+            )
+        } else {
+            BoolArray::from(BitBuffer::from(expected_values[offset..].to_vec()))
+        };
+        assert_arrays_eq!(decoded, expected, &mut ctx);
         Ok(())
     }
 }

--- a/encodings/runend/src/decompress_bool.rs
+++ b/encodings/runend/src/decompress_bool.rs
@@ -149,8 +149,10 @@ impl<'a> BitSplat<'a> {
     ///
     /// Inlined on purpose: leaving it out of line spills the accumulator to the stack for the
     /// whole loop, since `&mut self` escapes into the call. That costs a read-modify-write per
-    /// short run, which is the common case.
-    #[inline]
+    /// short run, which is the common case, and `#[inline]` alone is not enough — the crate
+    /// build leaves it out of line even where a smaller bench-local copy of the same code is
+    /// inlined.
+    #[inline(always)]
     fn append_spanning(&mut self, splat: u64, n: usize) {
         // Complete the current word. `self.bits < WORD_BITS`, so the shift is in range, and the
         // run covers every bit from `self.bits` up.
@@ -197,30 +199,116 @@ fn splat_bits(length: usize, fill: impl FnOnce(&mut BitSplat<'_>)) -> BitBufferM
     into_bits(buf, length)
 }
 
-/// Splats `length` bits into two fresh buffers, driving `fill` over both sinks at once.
+/// Two bit sinks advanced in lockstep: the decoded bits and the validity bits of the same runs.
+///
+/// Every run appends the same number of bits to both, so the run length, the word-boundary test,
+/// the head mask and the bit counter are computed once for the pair rather than twice. Driving
+/// two independent [`BitSplat`]s instead costs a second mask chain and a second boundary branch
+/// per run, and the doubled live state spills; measured, fusing them is worth up to 1.4x.
+struct BitSplatPair<'a> {
+    /// Exactly the decoded output words, written in ascending order and each at most once.
+    words: &'a mut [MaybeUninit<u64>],
+    /// Exactly the validity output words, written in step with `words`.
+    validity: &'a mut [MaybeUninit<u64>],
+    /// Number of words already written to each, so `..idx` of both is initialized.
+    idx: usize,
+    /// The decoded word under construction. Bits at and above `bits` are always zero.
+    word: u64,
+    /// The validity word under construction, at the same bit position.
+    validity_word: u64,
+    /// Number of bits already accumulated into both words, always `< WORD_BITS`.
+    bits: usize,
+}
+
+impl<'a> BitSplatPair<'a> {
+    /// Creates a pair of sinks over the two output buffers, which it initializes in full.
+    fn new(words: &'a mut [MaybeUninit<u64>], validity: &'a mut [MaybeUninit<u64>]) -> Self {
+        Self {
+            words,
+            validity,
+            idx: 0,
+            word: 0,
+            validity_word: 0,
+            bits: 0,
+        }
+    }
+
+    /// Appends `n` copies of `value` to the decoded bits and of `is_valid` to the validity bits.
+    #[inline(always)]
+    fn append_run(&mut self, value: bool, is_valid: bool, n: usize) {
+        let splat = u64::from(value).wrapping_neg();
+        let validity_splat = u64::from(is_valid).wrapping_neg();
+        if self.bits + n < WORD_BITS {
+            // `n < WORD_BITS`, so the mask shift is in range. One mask serves both words.
+            let mask = ((1u64 << n) - 1) << self.bits;
+            self.word |= splat & mask;
+            self.validity_word |= validity_splat & mask;
+            self.bits += n;
+            return;
+        }
+        self.append_spanning(splat, validity_splat, n);
+    }
+
+    /// Appends a run that reaches at least to the end of the current word. Inlined for the same
+    /// reason as [`BitSplat::append_spanning`].
+    #[inline(always)]
+    fn append_spanning(&mut self, splat: u64, validity_splat: u64, n: usize) {
+        self.words[self.idx] = MaybeUninit::new(self.word | (splat << self.bits));
+        self.validity[self.idx] =
+            MaybeUninit::new(self.validity_word | (validity_splat << self.bits));
+        self.idx += 1;
+        let rest = n - (WORD_BITS - self.bits);
+
+        let whole = rest / WORD_BITS;
+        if whole > 0 {
+            self.words[self.idx..self.idx + whole].fill(MaybeUninit::new(splat));
+            self.validity[self.idx..self.idx + whole].fill(MaybeUninit::new(validity_splat));
+            self.idx += whole;
+        }
+
+        let tail = rest % WORD_BITS;
+        let mask = (1u64 << tail) - 1;
+        self.word = splat & mask;
+        self.validity_word = validity_splat & mask;
+        self.bits = tail;
+    }
+
+    /// Flushes both accumulators and zero-fills the words the runs did not reach.
+    fn finish(self) {
+        let mut idx = self.idx;
+        if self.bits > 0 {
+            self.words[idx] = MaybeUninit::new(self.word);
+            self.validity[idx] = MaybeUninit::new(self.validity_word);
+            idx += 1;
+        }
+        self.words[idx..].fill(MaybeUninit::new(0));
+        self.validity[idx..].fill(MaybeUninit::new(0));
+    }
+}
+
+/// Splats `length` decoded bits and `length` validity bits into two fresh buffers, driving `fill`
+/// over the fused sink.
 fn splat_bits_pair(
     length: usize,
-    fill: impl FnOnce(&mut BitSplat<'_>, &mut BitSplat<'_>),
+    fill: impl FnOnce(&mut BitSplatPair<'_>),
 ) -> (BitBufferMut, BitBufferMut) {
     let n_words = length.div_ceil(WORD_BITS);
     let mut buf = BufferMut::<u64>::with_capacity(n_words);
-    let mut other = BufferMut::<u64>::with_capacity(n_words);
+    let mut validity_buf = BufferMut::<u64>::with_capacity(n_words);
     {
         let words = &mut buf.spare_capacity_mut()[..n_words];
-        let other_words = &mut other.spare_capacity_mut()[..n_words];
-        let mut splat = BitSplat::new(words);
-        let mut other_splat = BitSplat::new(other_words);
-        fill(&mut splat, &mut other_splat);
+        let validity_words = &mut validity_buf.spare_capacity_mut()[..n_words];
+        let mut splat = BitSplatPair::new(words, validity_words);
+        fill(&mut splat);
         splat.finish();
-        other_splat.finish();
     }
-    // SAFETY: both sinks covered exactly `n_words` words and were finished, so every word in
-    // `0..n_words` of both buffers is initialized, and `n_words` is the capacity of each.
+    // SAFETY: the sink covered exactly `n_words` words of each buffer and was finished, so every
+    // word in `0..n_words` of both is initialized, and `n_words` is the capacity of each.
     unsafe {
         buf.set_len(n_words);
-        other.set_len(n_words);
+        validity_buf.set_len(n_words);
     }
-    (into_bits(buf, length), into_bits(other, length))
+    (into_bits(buf, length), into_bits(validity_buf, length))
 }
 
 /// Reinterprets initialized words as a `length`-bit buffer. Little-endian only, like the rest of
@@ -260,6 +348,18 @@ fn trim_end<E: IntegerPType>(end: E, offset: E, length: E) -> usize {
     std::cmp::min(end - offset, length).as_()
 }
 
+/// Length of the run ending at `end`, given the position the previous run reached.
+///
+/// Saturating, so that run ends which are not strictly increasing yield empty runs rather than
+/// running the output position backwards. The splat sinks are sized to exactly `length` bits, so
+/// a position that could move backwards would let the total appended exceed the buffer and turn
+/// a malformed array into a panic. Run ends are only checked for sortedness under
+/// `debug_assertions`, so a release build does see them.
+#[inline(always)]
+fn run_length<E: IntegerPType>(end: E, offset: E, length: E, pos: usize) -> usize {
+    trim_end(end, offset, length).saturating_sub(pos)
+}
+
 /// Number of runs whose value differs from the majority: exactly the runs the prefill kernel
 /// has to patch after its memset.
 fn minority_runs(values: &BitBuffer) -> usize {
@@ -272,15 +372,18 @@ fn minority_runs(values: &BitBuffer) -> usize {
 /// The splat pays per output word; the prefill pays one memset over the whole output plus one
 /// range fill per patched run, and a range fill is far dearer than a splat step — a partial byte
 /// at each end, a `memset` call, and a data-dependent branch to decide whether to do it at all.
-/// Measured, one patched run costs about what the splat spends on three output words, per buffer
-/// the splat has to build. So the prefill wins exactly when patches are rarer than that.
+/// Measured, one patched run costs about what the splat spends on three output words. So the
+/// prefill wins exactly when patches are rarer than that.
 ///
-/// On the `run_end_decode_bool_ablation` grid this picks the faster kernel everywhere except
-/// 8-element runs with 90/10 values, where it gives up 7%. The threshold was derived before the
-/// splat switched to overwriting a pre-sized buffer, which made it 5-45% faster, so it is now
-/// conservative: there are grid points it hands to the prefill that the splat would win.
+/// A second output buffer does not double the splat's side of that: [`BitSplatPair`] shares the
+/// run length, the word-boundary test and the head mask, so the second buffer adds about half the
+/// cost of the first. Hence `buffers + 1` against a doubled constant rather than `buffers`.
+///
+/// Re-derive by returning a constant from here and running `run_end_decode_bool_ablation` with
+/// each kernel pinned. On that grid this picks the faster kernel at 25 of 26 points; the miss is
+/// non-nullable 1024-element runs with 50/50 values, where it gives up 6%.
 fn prefer_splat(patched_runs: usize, buffers: usize, length: usize) -> bool {
-    patched_runs * 3 * WORD_BITS >= length * buffers
+    patched_runs * 6 * WORD_BITS >= length * (buffers + 1)
 }
 
 /// Decodes run-end encoded booleans when all values are valid (non-nullable).
@@ -307,9 +410,9 @@ fn decode_bool_non_nullable<E: IntegerPType>(
     let decoded = splat_bits(length, |decoded| {
         let mut pos = 0usize;
         for (i, &end) in run_ends.iter().enumerate() {
-            let end = trim_end(end, offset_e, length_e);
-            decoded.append_run(values.value(i), end.saturating_sub(pos));
-            pos = end;
+            let run = run_length(end, offset_e, length_e, pos);
+            pos += run;
+            decoded.append_run(values.value(i), run);
         }
     });
 
@@ -332,17 +435,15 @@ fn decode_bool_nullable<E: IntegerPType>(
         return prefill_bool_nullable(run_ends, offset_e, length_e, values, validity_mask, length);
     }
 
-    let (decoded, decoded_validity) = splat_bits_pair(length, |decoded, decoded_validity| {
+    let (decoded, decoded_validity) = splat_bits_pair(length, |decoded| {
         let mut pos = 0usize;
         for (i, &end) in run_ends.iter().enumerate() {
-            let end = trim_end(end, offset_e, length_e);
-            let run = end.saturating_sub(pos);
-            pos = end;
+            let run = run_length(end, offset_e, length_e, pos);
+            pos += run;
 
             // The decoded bit is the value where valid, and false where null.
             let is_valid = validity_mask.value(i);
-            decoded.append_run(is_valid && values.value(i), run);
-            decoded_validity.append_run(is_valid, run);
+            decoded.append_run(is_valid && values.value(i), is_valid, run);
         }
     });
 
@@ -510,6 +611,22 @@ mod tests {
         expected.extend(std::iter::repeat_n(false, second_run));
         let expected = BoolArray::from(BitBuffer::from(expected));
         assert_arrays_eq!(decoded, expected, &mut ctx);
+        Ok(())
+    }
+
+    /// Run ends are only checked for sortedness under `debug_assertions`, so a release build can
+    /// be handed ends that go backwards. They must decode to something of the right length rather
+    /// than running the splat sink past the end of its buffer.
+    #[test]
+    fn decode_bools_non_monotonic_ends() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let ends = PrimitiveArray::from_iter([100u32, 50, 100]);
+        let values = BoolArray::from(BitBuffer::from(vec![true, false, true]));
+        let decoded =
+            runend_decode_bools(ends, values, 0, 100, &mut ctx)?.execute::<BoolArray>(&mut ctx)?;
+
+        assert_eq!(decoded.len(), 100);
+        assert_eq!(decoded.into_bit_buffer().true_count(), 100);
         Ok(())
     }
 

--- a/encodings/runend/src/decompress_bool.rs
+++ b/encodings/runend/src/decompress_bool.rs
@@ -11,9 +11,12 @@
 //!   runs, where it is up to 4x the prefill.
 //! * *prefill* memsets the whole output with the majority value and then patches only the runs
 //!   that differ. One big memset beats a per-run one, so this stays ahead once runs are long
-//!   enough that the splat pays a `memset` call per run and the patched runs are rare.
+//!   enough that the splat pays a whole-word fill per run and the patched runs are rare.
 //!
-//! See `benches/run_end_decode_bool_ablation.rs` for the A/B the crossover comes from.
+//! See `benches/run_end_decode_bool_ablation.rs` for the A/B both the crossover and the splat's
+//! output-buffer strategy come from.
+
+use std::mem::MaybeUninit;
 
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
@@ -94,24 +97,33 @@ pub fn runend_decode_typed_bool<E: IntegerPType>(
     }
 }
 
-/// A bit sink that builds its output one 64-bit word at a time.
+/// A bit sink that overwrites a pre-sized word buffer, one 64-bit word at a time.
 ///
 /// Bits are accumulated in a register and each word is written to the buffer exactly once, so a
 /// run never reads back what an earlier run stored. Compare a per-run `fill_range`, which
 /// read-modify-writes a partial byte at each end of every run.
-struct BitSplat {
-    words: BufferMut<u64>,
+///
+/// The buffer is allocated once at the exact final word count and written by index. Appending it
+/// with `BufferMut::push`/`push_n` instead keeps the accumulator in memory rather than in
+/// registers and puts the spanning-run path behind an out-of-line call; measured, the index
+/// writes are worth up to 1.9x. See `push_splat` in `benches/run_end_decode_bool_ablation.rs`.
+struct BitSplat<'a> {
+    /// Exactly the output words, written in ascending order and each at most once.
+    words: &'a mut [MaybeUninit<u64>],
+    /// Number of words already written, so `words[..idx]` is initialized.
+    idx: usize,
     /// The word under construction. Bits at and above `bits` are always zero.
     word: u64,
     /// Number of bits already accumulated into `word`, always `< WORD_BITS`.
     bits: usize,
 }
 
-impl BitSplat {
-    /// Creates a sink sized to hold `length` bits without reallocating.
-    fn with_capacity(length: usize) -> Self {
+impl<'a> BitSplat<'a> {
+    /// Creates a sink over the output words, which it initializes in full.
+    fn new(words: &'a mut [MaybeUninit<u64>]) -> Self {
         Self {
-            words: BufferMut::with_capacity(length.div_ceil(WORD_BITS)),
+            words,
+            idx: 0,
             word: 0,
             bits: 0,
         }
@@ -133,16 +145,23 @@ impl BitSplat {
 
     /// Appends a run that reaches at least to the end of the current word.
     ///
-    /// Whole words are memset rather than splatted one at a time.
+    /// Whole words are filled in one pass rather than splatted one at a time.
+    ///
+    /// Inlined on purpose: leaving it out of line spills the accumulator to the stack for the
+    /// whole loop, since `&mut self` escapes into the call. That costs a read-modify-write per
+    /// short run, which is the common case.
+    #[inline]
     fn append_spanning(&mut self, splat: u64, n: usize) {
         // Complete the current word. `self.bits < WORD_BITS`, so the shift is in range, and the
         // run covers every bit from `self.bits` up.
-        self.words.push(self.word | (splat << self.bits));
+        self.words[self.idx] = MaybeUninit::new(self.word | (splat << self.bits));
+        self.idx += 1;
         let rest = n - (WORD_BITS - self.bits);
 
         let whole = rest / WORD_BITS;
         if whole > 0 {
-            self.words.push_n(splat, whole);
+            self.words[self.idx..self.idx + whole].fill(MaybeUninit::new(splat));
+            self.idx += whole;
         }
 
         let tail = rest % WORD_BITS;
@@ -150,21 +169,66 @@ impl BitSplat {
         self.bits = tail;
     }
 
-    /// Flushes the accumulator into a `length`-bit buffer, zero-padding a short tail.
-    fn finish(mut self, length: usize) -> BitBufferMut {
+    /// Flushes the accumulator and zero-fills any words the runs did not reach, leaving every
+    /// word of the output initialized.
+    fn finish(self) {
+        let mut idx = self.idx;
         if self.bits > 0 {
-            self.words.push(self.word);
+            self.words[idx] = MaybeUninit::new(self.word);
+            idx += 1;
         }
-        let words = length.div_ceil(WORD_BITS);
-        if self.words.len() < words {
-            self.words.push_n(0, words - self.words.len());
-        }
-        self.words.truncate(words);
-
-        let mut bytes = self.words.into_byte_buffer();
-        bytes.truncate(length.div_ceil(8));
-        BitBufferMut::from_buffer(bytes, 0, length)
+        self.words[idx..].fill(MaybeUninit::new(0));
     }
+}
+
+/// Splats `length` bits into a fresh buffer, driving `fill` over the sink.
+fn splat_bits(length: usize, fill: impl FnOnce(&mut BitSplat<'_>)) -> BitBufferMut {
+    let n_words = length.div_ceil(WORD_BITS);
+    let mut buf = BufferMut::<u64>::with_capacity(n_words);
+    {
+        let words = &mut buf.spare_capacity_mut()[..n_words];
+        let mut splat = BitSplat::new(words);
+        fill(&mut splat);
+        splat.finish();
+    }
+    // SAFETY: the sink covered exactly `n_words` words and was finished, so every word in
+    // `0..n_words` is initialized, and `n_words` is the capacity requested above.
+    unsafe { buf.set_len(n_words) };
+    into_bits(buf, length)
+}
+
+/// Splats `length` bits into two fresh buffers, driving `fill` over both sinks at once.
+fn splat_bits_pair(
+    length: usize,
+    fill: impl FnOnce(&mut BitSplat<'_>, &mut BitSplat<'_>),
+) -> (BitBufferMut, BitBufferMut) {
+    let n_words = length.div_ceil(WORD_BITS);
+    let mut buf = BufferMut::<u64>::with_capacity(n_words);
+    let mut other = BufferMut::<u64>::with_capacity(n_words);
+    {
+        let words = &mut buf.spare_capacity_mut()[..n_words];
+        let other_words = &mut other.spare_capacity_mut()[..n_words];
+        let mut splat = BitSplat::new(words);
+        let mut other_splat = BitSplat::new(other_words);
+        fill(&mut splat, &mut other_splat);
+        splat.finish();
+        other_splat.finish();
+    }
+    // SAFETY: both sinks covered exactly `n_words` words and were finished, so every word in
+    // `0..n_words` of both buffers is initialized, and `n_words` is the capacity of each.
+    unsafe {
+        buf.set_len(n_words);
+        other.set_len(n_words);
+    }
+    (into_bits(buf, length), into_bits(other, length))
+}
+
+/// Reinterprets initialized words as a `length`-bit buffer. Little-endian only, like the rest of
+/// the crate's bit packing.
+fn into_bits(words: BufferMut<u64>, length: usize) -> BitBufferMut {
+    let mut bytes = words.into_byte_buffer();
+    bytes.truncate(length.div_ceil(8));
+    BitBufferMut::from_buffer(bytes, 0, length)
 }
 
 /// Convert `offset`/`length` into `E` once, outside the per-run loop.
@@ -212,7 +276,9 @@ fn minority_runs(values: &BitBuffer) -> usize {
 /// the splat has to build. So the prefill wins exactly when patches are rarer than that.
 ///
 /// On the `run_end_decode_bool_ablation` grid this picks the faster kernel everywhere except
-/// 8-element runs with 90/10 values, where it gives up 7%.
+/// 8-element runs with 90/10 values, where it gives up 7%. The threshold was derived before the
+/// splat switched to overwriting a pre-sized buffer, which made it 5-45% faster, so it is now
+/// conservative: there are grid points it hands to the prefill that the splat would win.
 fn prefer_splat(patched_runs: usize, buffers: usize, length: usize) -> bool {
     patched_runs * 3 * WORD_BITS >= length * buffers
 }
@@ -238,15 +304,16 @@ fn decode_bool_non_nullable<E: IntegerPType>(
         );
     }
 
-    let mut decoded = BitSplat::with_capacity(length);
-    let mut pos = 0usize;
-    for (i, &end) in run_ends.iter().enumerate() {
-        let end = trim_end(end, offset_e, length_e);
-        decoded.append_run(values.value(i), end.saturating_sub(pos));
-        pos = end;
-    }
+    let decoded = splat_bits(length, |decoded| {
+        let mut pos = 0usize;
+        for (i, &end) in run_ends.iter().enumerate() {
+            let end = trim_end(end, offset_e, length_e);
+            decoded.append_run(values.value(i), end.saturating_sub(pos));
+            pos = end;
+        }
+    });
 
-    BoolArray::new(decoded.finish(length).freeze(), nullability.into())
+    BoolArray::new(decoded.freeze(), nullability.into())
 }
 
 /// Decodes run-end encoded booleans when values may be null (nullable).
@@ -265,25 +332,21 @@ fn decode_bool_nullable<E: IntegerPType>(
         return prefill_bool_nullable(run_ends, offset_e, length_e, values, validity_mask, length);
     }
 
-    let mut decoded = BitSplat::with_capacity(length);
-    let mut decoded_validity = BitSplat::with_capacity(length);
+    let (decoded, decoded_validity) = splat_bits_pair(length, |decoded, decoded_validity| {
+        let mut pos = 0usize;
+        for (i, &end) in run_ends.iter().enumerate() {
+            let end = trim_end(end, offset_e, length_e);
+            let run = end.saturating_sub(pos);
+            pos = end;
 
-    let mut pos = 0usize;
-    for (i, &end) in run_ends.iter().enumerate() {
-        let end = trim_end(end, offset_e, length_e);
-        let run = end.saturating_sub(pos);
-        pos = end;
+            // The decoded bit is the value where valid, and false where null.
+            let is_valid = validity_mask.value(i);
+            decoded.append_run(is_valid && values.value(i), run);
+            decoded_validity.append_run(is_valid, run);
+        }
+    });
 
-        // The decoded bit is the value where valid, and false where null.
-        let is_valid = validity_mask.value(i);
-        decoded.append_run(is_valid && values.value(i), run);
-        decoded_validity.append_run(is_valid, run);
-    }
-
-    BoolArray::new(
-        decoded.finish(length).freeze(),
-        Validity::from(decoded_validity.finish(length).freeze()),
-    )
+    BoolArray::new(decoded.freeze(), Validity::from(decoded_validity.freeze()))
 }
 
 /// Memsets the output with the majority value, then patches the runs that differ.


### PR DESCRIPTION
> Stacked on #9020 (benchmarks only) — review that first; this PR's base is that branch, so its diff is just the five commits here.

## Rationale for this change

The bool decoder prefilled the output with the majority value and then `fill_range`d every run whose value differed. Per run that costs a data-dependent branch on the run's value — which mispredicts about half the time on 50/50 data — plus a range fill that masks a partial byte at each end around its memset. Both costs are constant per run, so when runs are short the loop is `O(n · k)` with nothing amortising `k`.

A run of bools is a bit pattern, so it can be built rather than patched: OR a mask of the run's value into a 64-bit accumulator and store each output word exactly once.

## Result

On #9020's corpus benchmark, by fastest sample:

| case | before | after | speedup |
| --- | ---: | ---: | ---: |
| `128x16k_run4_even` | 4.93 ms | 1.38 ms | **3.57x** |
| `128x16k_run4_even_nullable` | 6.71 ms | 2.39 ms | 2.81x |
| `128x16k_run4_skewed` | 2.06 ms | 1.40 ms | 1.47x |
| `128x16k_run16_even` | 1.31 ms | 339 µs | **3.87x** |
| `128x16k_run16_even_nullable` | 1.78 ms | 751 µs | 2.36x |
| `128x16k_run16_skewed` | 537 µs | 338 µs | 1.59x |
| `128x16k_run64_even` | 315 µs | 143 µs | 2.20x |
| `128x16k_run64_even_nullable` | 443 µs | 259 µs | 1.71x |
| `128x16k_run64_skewed` | 148 µs | 130 µs | 1.14x |
| `4x100k_run4_even` | 943 µs | 260 µs | **3.62x** |
| `4x100k_run4_even_nullable` | 1125 µs | 433 µs | 2.60x |
| `4x100k_run4_skewed` | 381 µs | 256 µs | 1.49x |
| `4x100k_run16_even` | 234 µs | 62.8 µs | **3.72x** |
| `4x100k_run16_even_nullable` | 293 µs | 110 µs | 2.67x |
| `4x100k_run16_skewed` | 91.1 µs | 60.9 µs | 1.50x |
| `4x100k_run64_even` | 45.9 µs | 17.2 µs | 2.67x |
| `4x100k_run64_even_nullable` | 56.4 µs | 27.1 µs | 2.08x |
| `4x100k_run64_skewed` | 20.5 µs | 14.7 µs | 1.39x |

## Where the win comes from

Each commit measured on this same benchmark, at that commit. Every column is the speedup over the column to its left, so the five multiply to the total.

| case | splat | overwrite | fuse | blend | refit | total |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `128x16k_run4_even` | **3.55** | 1.06 | 0.99 | 0.96 | 1.04 | 3.68 |
| `128x16k_run4_even_nullable` | **2.03** | 1.03 | **1.27** | 0.86 | 1.13 | 2.57 |
| `128x16k_run4_skewed` | 1.49 | 1.06 | 0.99 | 0.97 | 1.03 | 1.56 |
| `128x16k_run16_even` | **2.64** | 1.18 | 0.97 | 1.14 | 1.18 | 4.05 |
| `128x16k_run16_even_nullable` | 1.74 | 1.11 | **1.23** | 1.04 | 0.99 | 2.44 |
| `128x16k_run16_skewed` | 1.05 | 1.16 | 0.98 | 1.14 | 1.19 | 1.62 |
| `128x16k_run64_even` | 1.48 | **1.28** | 1.02 | 1.19 | 1.01 | 2.35 |
| `128x16k_run64_even_nullable` | 1.03 | 0.98 | **1.51** | 1.15 | 1.02 | 1.79 |
| `128x16k_run64_skewed` | 1.18 | 1.02 | 0.99 | 0.95 | 1.07 | 1.21 |
| `4x100k_run4_even` | **3.71** | 1.07 | 0.98 | 0.98 | 1.01 | 3.86 |
| `4x100k_run4_even_nullable` | **2.02** | 1.03 | **1.30** | 0.94 | 1.07 | 2.70 |
| `4x100k_run4_skewed` | 1.49 | 1.07 | 0.98 | 0.98 | 1.01 | 1.55 |
| `4x100k_run16_even` | **2.88** | 1.24 | 0.94 | 1.16 | 1.02 | 3.99 |
| `4x100k_run16_even_nullable` | 1.69 | 1.14 | **1.26** | 1.03 | 1.09 | 2.72 |
| `4x100k_run16_skewed` | 1.06 | 1.24 | 0.96 | 1.15 | 1.01 | 1.47 |
| `4x100k_run64_even` | 1.59 | **1.79** | 0.99 | 0.98 | 0.96 | 2.66 |
| `4x100k_run64_even_nullable` | 0.99 | 0.98 | **2.00** | 1.07 | 1.00 | 2.06 |
| `4x100k_run64_skewed` | 1.24 | 1.08 | 1.00 | 0.95 | 1.06 | 1.35 |

Reading it honestly: **the splat itself is most of the win**, and the rest is worth having but is not where the headline comes from. `fuse` is nullable-only by construction, so its non-nullable column is run-to-run noise around 1.0 and should be read as nothing rather than as a small loss. `blend` and `refit` have to be read as a pair — the blend was landed with thresholds still fitted to the old uniform data, which cost up to 14% at 4-element runs, and the refit gives it back; together they are 0.94–1.36x, clearly positive at 16-element runs and neutral at 4.

## What changes are included in this PR?

**1. The splat kernel** — 1.03–3.71x, the bulk of the change. Accumulate into a `u64`, flush whole words. Nothing is read back, and the run's value only feeds an `AND` mask, so the value branch is gone. Biggest where runs are short and values even, which is where the old kernel's per-run branch mispredicted most and its range fills were smallest; near nothing at 64-element nullable runs, where the prefill was already close to a memset.

Both kernels are kept, because the prefill is not strictly worse: it *skips* majority runs entirely, so once patches are rare enough it approaches a bare memset and wins. `prefer_splat` dispatches on the count its advantage depends on. The prefill also now takes run ends as a slice and trims by offset inline rather than through `trimmed_ends_iter` plus a bit-at-a-time `BitBuffer` iterator.

**2. Overwrite a pre-sized word buffer** — 0.98–1.79x, broadly 1.03–1.28. Instead of appending with `BufferMut::push`/`push_n`. The two obvious reasons to expect a win are both wrong, and the disassembly says so: `push_n` and `slice::fill` lower to the *identical* inlined vector store loop (neither is a `memset` — the splat value is a runtime value, not a byte pattern), and the per-word capacity check trades places with a slice bounds check. The win is second-order: without `reserve`'s allocation slow path, the spanning path fits LLVM's inline budget, so `&mut self` stops escaping and the accumulator stays in registers.

**3. Fuse the nullable pair onto one bit counter** — 1.23–2.00x on nullable cases, nothing elsewhere. The nullable path drove two independent sinks that are appended to in lockstep, so every run did the bookkeeping twice, and the doubled live state spilled: ten memory operations per run against the non-nullable loop's zero.

**4. A branch-free splat form for word-scale runs** — 0.86–1.19x on its own. The remaining per-run branch — does this run reach the end of the word — is data-dependent, and its predictability tracks the run length: for runs averaging `r` bits it fires about `r/64` of the time. The new form paints the run from the current offset to the top of the word and stores unconditionally, relying on the bits above the offset being don't-care. It is not strictly better, so both forms stay, picked by average run length.

**5. Refit both constants for normally distributed run lengths** — 0.96–1.19x, recovering commit 4's losses at short runs. Matches #9020's generator, and the ablation generator to it, so the constants are fitted on the data CI measures. The kernels separate far more cleanly on this data. Splat over prefill:

```
run length      1     2     8    16    32    48    64   128  1024
non-nullable
  50/50      3.57  3.67  3.71  3.75  3.45  3.02  2.91  1.52  0.85
  90/10         -  1.38  1.35     -  1.14     -  0.90  0.74  0.76
```

Every win has at least 205 patched runs and every loss at most 102, so one threshold separates them with margin where the previous fit had borderline points either side. The nullable side splits at the same place — it doubles the work on *both* sides of the comparison, since the prefill memsets and patches two buffers exactly where the splat builds two — so `prefer_splat` loses its `buffers` parameter and becomes one patched run per eight output words.

`prefer_blend` gains an upper bound, because the band has two edges:

```
run length      1     2     8    16    32    48    64   128  1024
non-nullable 0.91  0.99  1.18  1.31  1.41  1.43  1.48  1.18  0.93
nullable     0.87  0.90  1.03  1.15  1.27  1.52  1.25  0.94  0.89
```

Far above a word the boundary test always fires and predicts again, leaving the blend paying its extra store against a whole-word fill that dominates either way. Without the bound the nullable 1024 cases came out 13% behind the original kernel, reproducibly across two runs.

**New bench target** `run_end_decode_bool_ablation`, which A/Bs the kernel structures in one process against bench-local mirrors of the previous kernel and of the append-based splat. Both constants can be re-derived from it by pinning a kernel and re-running the grid.

## Reviewer notes

- **The blend path is `#[inline(never)]`, and that is load-bearing.** With both loops inlined into one function, the *branching* loop lost 20% with its own text unchanged, measured against an in-process anchor that did not move. Expressing the choice as a const generic over a single loop did the same. Only keeping the second loop out of line leaves the first alone. Similarly, the spanning path needs `#[inline(always)]` and not `#[inline]` — the crate build leaves it out of line where an identical bench-local copy is inlined, which costs most of commit 2's win.
- **The blend form needs one word of slack past the output**, because a zero-length run arriving when the buffer is exactly full still stores, and run ends clamped to the logical length produce exactly that. `finish` must also mask the last partial word or the paint survives past the logical length where `true_count` would read it. Handling the last word by a separate slower path instead was measured and does not pay: the only per-run cost it could remove is the store's bounds check, which an unchecked-store experiment puts inside the noise.
- **Dropping the branching form entirely was considered**, on the grounds that the compressor gates run-end at an average run length of 4 (`RUN_END_THRESHOLD`), so very short runs are unreachable. Measured at that floor, always blending is free on the non-nullable path but costs 14% on the nullable one, which is reachable through comparisons pushed into a nullable run-end column. The dispatch is free, so it stays.

## What APIs are changed? Are there any user-facing changes?

`runend_decode_typed_bool` changes signature: run ends as `&[E]` plus an `offset`, instead of an `impl Iterator<Item = usize>` of already-trimmed ends. No callers outside this crate.

No behaviour change. Covered by a differential test against a naive element-at-a-time decode across run lengths 1–300, nullable and not, at offsets 0/1/63/64/100; a separate differential test pinning the blend form at eleven run lengths and three lengths chosen to land on and off the word grid; and word-boundary cases at every alignment.

Run position advances by the clamped run length rather than jumping to the run end, so a malformed array cannot run the output position backwards and overrun the sink. Run ends are only checked for sortedness under `debug_assertions`, so a release build does see unsorted ends; `decode_bools_non_monotonic_ends` covers it. All indexing stays bounds-checked — this is a panic-vs-correct-output question, not a soundness one. The only `unsafe` added is a contained `BufferMut::set_len` per output buffer, after the sink has provably initialised every word.

Checks run: `cargo test -p vortex-runend` (242 pass), `cargo test -p vortex-btrblocks -p vortex-layout -p vortex-file`, `cargo clippy -p vortex-runend --all-targets --all-features`, `cargo +nightly fmt --all`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items`, `cargo test --doc`, `git diff --check`, plus `objdump` on the built binaries to confirm the inlining claims above.