### PR TITLE
perf(array): bulk-append paths for DynVarBinBuilder

### DIFF
--- a/vortex-array/src/arrays/varbin/builder.rs
+++ b/vortex-array/src/arrays/varbin/builder.rs
@@ -15,6 +15,7 @@ use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 
 use crate::ArrayRef;
+use crate::ArrayView;
 use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
@@ -27,6 +28,7 @@ use crate::arrays::VarBinView;
 use crate::arrays::varbin::VarBinArrayExt;
 use crate::arrays::varbin::VarBinArraySlotsExt;
 use crate::arrays::varbinview::VarBinViewArrayExt;
+use crate::arrays::varbinview::build_views::BinaryView;
 use crate::builders::ArrayBuilder;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
@@ -97,6 +99,30 @@ impl<O: IntegerPType> VarBinBuilder<O> {
     pub fn append_n_nulls(&mut self, n: usize) {
         self.offsets.push_n(self.offsets[self.offsets.len() - 1], n);
         self.validity.append_n(false, n);
+    }
+
+    /// Appends `n` non-null empty values.
+    ///
+    /// Every appended value has the same start and end offset, so no bytes are written.
+    #[inline]
+    pub fn append_n_empty(&mut self, n: usize) {
+        self.offsets.push_n(self.offsets[self.offsets.len() - 1], n);
+        self.validity.append_n(true, n);
+    }
+
+    /// Appends the same non-null value `n` times.
+    #[inline]
+    pub fn append_n_values(&mut self, value: impl AsRef<[u8]>, n: usize) {
+        let slice = value.as_ref();
+        if slice.is_empty() {
+            return self.append_n_empty(n);
+        }
+
+        self.offsets.reserve(n);
+        self.data.reserve(slice.len().saturating_mul(n));
+        for _ in 0..n {
+            self.append_value(slice);
+        }
     }
 
     #[inline]
@@ -272,9 +298,9 @@ impl DynVarBinBuilder {
 
     /// Appends the same non-null value `n` times.
     pub fn append_n_values(&mut self, value: impl AsRef<[u8]>, n: usize) {
-        let value = value.as_ref();
-        for _ in 0..n {
-            self.append_value(value);
+        match &mut self.storage {
+            DynOffsets::I32(builder) => builder.append_n_values(value, n),
+            DynOffsets::I64(builder) => builder.append_n_values(value, n),
         }
     }
 
@@ -303,7 +329,7 @@ impl DynVarBinBuilder {
     /// Appends an existing [`VarBinArray`] without constructing views.
     pub fn append_varbin(
         &mut self,
-        array: crate::ArrayView<'_, VarBin>,
+        array: ArrayView<'_, VarBin>,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let offsets = array.offsets().clone().execute::<PrimitiveArray>(ctx)?;
@@ -329,28 +355,15 @@ impl DynVarBinBuilder {
     /// Appends a [`VarBinViewArray`](crate::arrays::VarBinViewArray).
     pub fn append_varbinview(
         &mut self,
-        array: crate::ArrayView<'_, VarBinView>,
+        array: ArrayView<'_, VarBinView>,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let validity = array
             .varbinview_validity()
             .execute_mask(array.as_ref().len(), ctx)?;
-        match &validity {
-            Mask::AllTrue(_) => {
-                for index in 0..array.as_ref().len() {
-                    self.append_value(array.bytes_at(index));
-                }
-            }
-            Mask::AllFalse(len) => self.push_nulls(*len),
-            Mask::Values(values) => {
-                for (index, is_valid) in values.bit_buffer().iter().enumerate() {
-                    if is_valid {
-                        self.append_value(array.bytes_at(index));
-                    } else {
-                        self.push_null();
-                    }
-                }
-            }
+        match &mut self.storage {
+            DynOffsets::I32(builder) => append_varbinview_to(builder, array, &validity),
+            DynOffsets::I64(builder) => append_varbinview_to(builder, array, &validity),
         }
         Ok(())
     }
@@ -363,25 +376,57 @@ impl DynVarBinBuilder {
         }
     }
 
-    fn append_value(&mut self, value: impl AsRef<[u8]>) {
-        match &mut self.storage {
-            DynOffsets::I32(builder) => builder.append_value(value),
-            DynOffsets::I64(builder) => builder.append_value(value),
-        }
-    }
-
-    fn push_null(&mut self) {
-        match &mut self.storage {
-            DynOffsets::I32(builder) => builder.append_null(),
-            DynOffsets::I64(builder) => builder.append_null(),
-        }
-    }
-
     fn push_nulls(&mut self, n: usize) {
         match &mut self.storage {
             DynOffsets::I32(builder) => builder.append_n_nulls(n),
             DynOffsets::I64(builder) => builder.append_n_nulls(n),
         }
+    }
+}
+
+/// Appends `array` to a [`VarBinBuilder`] with a statically known offset type.
+///
+/// [`DynVarBinBuilder`] resolves its offset width once before calling this, so the loops below
+/// append through a monomorphized [`VarBinBuilder`] rather than re-reading [`DynOffsets`] per row.
+fn append_varbinview_to<O: IntegerPType>(
+    builder: &mut VarBinBuilder<O>,
+    array: ArrayView<'_, VarBinView>,
+    validity: &Mask,
+) {
+    // Read the views slice once. `bytes_at` would re-derive it and hand back a refcounted
+    // `ByteBuffer` per row; `view_bytes` borrows the payload instead.
+    let views = array.views();
+    match validity {
+        Mask::AllTrue(len) => {
+            builder.reserve_exact(*len);
+            for view in &views[..*len] {
+                builder.append_value(view_bytes(&array, view));
+            }
+        }
+        Mask::AllFalse(len) => builder.append_n_nulls(*len),
+        Mask::Values(values) => {
+            builder.reserve_exact(values.len());
+            // Offsets and validity must be appended in row order, so this cannot use the
+            // set-index fast paths: the null rows carry offsets too.
+            for (view, is_valid) in views[..values.len()].iter().zip(values.bit_buffer().iter()) {
+                if is_valid {
+                    builder.append_value(view_bytes(&array, view));
+                } else {
+                    builder.append_null();
+                }
+            }
+        }
+    }
+}
+
+/// Borrows the bytes of a single view without constructing a [`ByteBuffer`].
+#[inline]
+fn view_bytes<'a>(array: &'a ArrayView<'_, VarBinView>, view: &'a BinaryView) -> &'a [u8] {
+    if view.is_inlined() {
+        view.as_inlined().value()
+    } else {
+        let view_ref = view.as_view();
+        &array.buffer(view_ref.buffer_index as usize).as_slice()[view_ref.as_range()]
     }
 }
 
@@ -406,8 +451,9 @@ impl ArrayBuilder for DynVarBinBuilder {
     }
 
     fn append_zeros(&mut self, n: usize) {
-        for _ in 0..n {
-            self.append_value([]);
+        match &mut self.storage {
+            DynOffsets::I32(builder) => builder.append_n_empty(n),
+            DynOffsets::I64(builder) => builder.append_n_empty(n),
         }
     }
 
@@ -586,6 +632,55 @@ mod tests {
 
         assert_arrays_eq!(builder.finish_into_varbin(), expected, &mut ctx);
         Ok(())
+    }
+
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    fn append_zeros_appends_non_null_empty_values(#[case] large_offsets: bool) -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let mut builder = DynVarBinBuilder::with_capacity(DType::Utf8(Nullable), large_offsets, 0);
+
+        builder.append_scalar(&Scalar::utf8("hello", Nullable))?;
+        builder.append_zeros(3);
+
+        assert_eq!(builder.len(), 4);
+        let expected = VarBinArray::from_iter(
+            [Some("hello"), Some(""), Some(""), Some("")],
+            DType::Utf8(Nullable),
+        );
+        assert_arrays_eq!(builder.finish_into_varbin(), expected, &mut ctx);
+        Ok(())
+    }
+
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    fn append_n_values_repeats_the_value(#[case] large_offsets: bool) -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let mut builder = DynVarBinBuilder::with_capacity(DType::Utf8(Nullable), large_offsets, 0);
+
+        builder.append_n_values("ab", 2);
+        builder.append_null();
+        builder.append_n_values("", 2);
+
+        let expected = VarBinArray::from_iter(
+            [Some("ab"), Some("ab"), None, Some(""), Some("")],
+            DType::Utf8(Nullable),
+        );
+        assert_arrays_eq!(builder.finish_into_varbin(), expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn append_n_empty_preserves_previous_offset() {
+        let mut builder = VarBinBuilder::<i32>::new();
+        builder.append_value(b"abc");
+        builder.append_n_empty(2);
+        let array = builder.finish(DType::Utf8(Nullable));
+
+        assert_eq!(array.len(), 3);
+        assert_eq!(array.bytes().len(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Rationale for this change

`DynVarBinBuilder` is a `DType` plus an enum over `VarBinBuilder<i32>` / `VarBinBuilder<i64>`. Three of its append paths — `append_zeros`, `append_n_values`, and `append_varbinview` — looped over a per-element append that re-read the `DynOffsets` enum for every row, which is the "hidden-cost accessor in a hot loop" pattern from `AGENTS.md`.

While measuring the fix, the enum hoist turned out to be the *less* interesting half: it measured neutral on its own, because LLVM was already hoisting the discriminant out of the loops. The real per-row costs were elsewhere, and both are addressed here.

`append_varbinview` is on the export path for every non-`VarBin` string array reaching `to_arrow_byte_array`, so this is live in Arrow `StringArray`/`BinaryArray` export.

## What changes are included in this PR?

All changes are in `vortex-array/src/arrays/varbin/builder.rs`.

**Offset width resolved once per call.** `append_zeros`, `append_n_values`, and `append_varbinview` now match on `DynOffsets` once and append through a monomorphized `VarBinBuilder<O>`. `append_varbinview`'s body moved to a generic free function `append_varbinview_to<O>`; the `DynVarBinBuilder::append_value` and `push_null` shims became unused and were removed.

**`append_zeros` writes offsets in bulk.** It previously appended `n` empty values one at a time. New `VarBinBuilder::append_n_empty` repeats the previous offset with `push_n` and appends validity with `append_n`. New `VarBinBuilder::append_n_values` reserves offsets and data up front and routes empty values to `append_n_empty`.

**`append_varbinview` no longer builds a `ByteBuffer` per row.** It called `VarBinViewData::bytes_at` for each row, which re-derives the views slice from a raw pointer *and* returns a refcounted `ByteBuffer` — an `Arc` clone and drop per row. The views slice is now read once, and a new `view_bytes` helper borrows each view's payload instead: inline views from the view itself, referenced views from `buffer(idx).as_slice()`. The null rows still carry offsets, so the row-order loop is preserved rather than switching to a set-index fast path.

### Tests

Five new cases in the existing `tests` module, parameterized over both offset widths with `rstest` where applicable:

- `append_zeros_appends_non_null_empty_values` — `append_zeros` produces non-null empty values, not nulls
- `append_n_values_repeats_the_value` — including the empty-value path that delegates to `append_n_empty`
- `append_n_empty_preserves_previous_offset` — no bytes written, offsets unchanged

### Benchmark

Measured with a local divan benchmark over the three append paths. It is not included in this change; medians:

| bench | before | after |
| --- | --- | --- |
| `append_zeros/1024` | 4.073 µs | 139.7 ns |
| `append_zeros/65536` | 264.1 µs | 8.700 µs |
| `append_n_values/1024` | 7.349 µs | 5.647 µs |
| `append_n_values/65536` | 1.222 ms | 408.3 µs |
| `append_varbinview/no_nulls/1024` | 58.71 µs | 9.623 µs |
| `append_varbinview/no_nulls/65536` | 4.952 ms | 1.522 ms |
| `append_varbinview/nulls/1024` | 48.15 µs | 9.300 µs |
| `append_varbinview/nulls/65536` | 3.538 ms | 1.339 ms |

Run-to-run variance on the measurement host was high (`slowest` ran 3–5x `fastest`), so the ~1.3x on `append_n_values/1024` is close to noise; the 30x and 3x figures are well clear of it.

### Checks run

- `cargo build -p vortex-array`
- `cargo clippy -p vortex-array --all-targets --all-features`
- `cargo +nightly fmt --all`, `git diff --check`
- `cargo nextest run -p vortex-array` — 3152 passed, 1 skipped
- `cargo nextest run -p vortex-arrow -p vortex-fsst -p vortex-zstd -p vortex-onpair` — 360 passed
- `cargo nextest run -p vortex-runend -p vortex-sparse -p vortex-geo -p vortex-file` — 482 passed

Not run: workspace-wide build and clippy, and the Python and docs suites — nothing outside these crates touches the varbin builders. The `fsst_compress_offsets_overflow_i32` >2 GiB regression test is `CI`-gated and stayed skipped locally.

## What APIs are changed? Are there any user-facing changes?

Two additions to the public `VarBinBuilder<O>` surface, both documented:

- `VarBinBuilder::append_n_empty(&mut self, n: usize)`
- `VarBinBuilder::append_n_values(&mut self, value: impl AsRef<[u8]>, n: usize)`

No removals or signature changes to public API. `DynVarBinBuilder::append_n_values` keeps its signature; the two private helpers that were deleted (`append_value`, `push_null`) were never exposed. No behavior changes — the same arrays are produced, and `append_zeros` continues to append non-null empty values rather than nulls.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNAauXZ35dB57ew3F45nBB)_