### PR TITLE
Add list-aware element repartitioning

### DIFF
--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -49,6 +49,7 @@ jobs:
     env:
       VORTEX_EXPERIMENTAL_PATCHED_ARRAY: "1"
       FLAT_LAYOUT_INLINE_ARRAY_NODE: "1"
+      VORTEX_EXPERIMENTAL_LIST_LAYOUT: "1"
       # Makes python output nicer
       COLUMNS: 120
     strategy:

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -3,6 +3,7 @@
 
 //! This module defines the default layout strategy for a Vortex file.
 
+use std::num::NonZeroU64;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -272,6 +273,7 @@ impl WriteStrategyBuilder {
     /// Builds the canonical [`LayoutStrategy`] implementation, with the configured overrides
     /// applied.
     pub fn build(self) -> Arc<dyn LayoutStrategy> {
+        let data_block_target_bytes = self.data_block_target_bytes;
         let flat: Arc<dyn LayoutStrategy> = if let Some(flat) = self.flat_strategy {
             flat
         } else {
@@ -305,7 +307,7 @@ impl WriteStrategyBuilder {
 
         // 4. prior to compression, coalesce up to a minimum size
         let coalescing = RepartitionStrategy::new(
-            compressing,
+            compressing.clone(),
             RepartitionWriterOptions {
                 // Write stream partitions roughly become segments. Because Vortex never reads less
                 // than one segment, the size of segments and, therefore, partitions, must be small
@@ -313,9 +315,9 @@ impl WriteStrategyBuilder {
                 // sufficient read concurrency for the desired throughput. One megabyte is small
                 // enough to achieve this for S3 (Durner et al., "Exploiting Cloud Object Storage for
                 // High-Performance Analytics", VLDB Vol 16, Iss 11).
-                block_size_minimum: self.data_block_target_bytes.unwrap_or(0),
+                block_size_minimum: data_block_target_bytes.unwrap_or(0),
                 block_len_multiple: self.row_block_size,
-                block_size_target: self.data_block_target_bytes,
+                block_size_target: data_block_target_bytes,
                 canonicalize: true,
             },
         );
@@ -327,25 +329,26 @@ impl WriteStrategyBuilder {
         };
         let compress_then_flat = CompressingStrategy::new(flat, Arc::clone(&stats_compressor));
 
-        // 3. apply dict encoding or fallback
         let probe_compressor = if let Some(probe_compressor) = self.probe_compressor {
             probe_compressor
         } else {
             Arc::clone(&stats_compressor)
         };
-        let dict = DictStrategy::new(
+
+        // 3. apply dict encoding or fallback
+        let leaf = DictStrategy::new(
             coalescing.clone(),
             compress_then_flat.clone(),
             coalescing,
             Default::default(),
-            probe_compressor,
+            Arc::clone(&probe_compressor),
         );
 
         let row_block_size = NonZeroUsize::new(self.row_block_size).vortex_expect("must be non 0");
 
         // 2. calculate stats for each row group
         let stats = ZonedStrategy::new(
-            dict,
+            leaf,
             compress_then_flat.clone(),
             ZonedLayoutOptions {
                 block_size: row_block_size,
@@ -368,35 +371,51 @@ impl WriteStrategyBuilder {
 
         // 0. start with splitting columns
         let validity_strategy = CollectStrategy::new(compress_then_flat.clone());
-
-        // Take any field overrides from the builder and apply them to the final strategy.
         let mut table_strategy =
             TableStrategy::new(Arc::new(validity_strategy), Arc::new(repartition))
                 .with_field_writers(self.field_writers);
 
         if self.use_list_layout {
-            // We need a closure here to enable recursive application of list layout.
-            table_strategy = table_strategy.with_list_layout_factory(
-                move |list_layout: ListLayoutStrategy| -> Arc<dyn LayoutStrategy> {
-                    let zoned = ZonedStrategy::new(
-                        list_layout,
-                        compress_then_flat.clone(),
-                        ZonedLayoutOptions {
-                            block_size: row_block_size,
-                            ..Default::default()
-                        },
-                    );
-                    Arc::new(RepartitionStrategy::new(
-                        zoned,
-                        RepartitionWriterOptions {
-                            block_size_minimum: 0,
-                            block_len_multiple: row_block_size.get(),
-                            block_size_target: None,
-                            canonicalize: false,
-                        },
-                    ))
-                },
-            );
+            let list_repartition_target = data_block_target_bytes.and_then(NonZeroU64::new);
+            // The list writer chooses these element chunk boundaries before decomposition, so
+            // preserve them through dictionary encoding and compression.
+            let list_leaf = Arc::new(DictStrategy::new(
+                compressing.clone(),
+                compress_then_flat.clone(),
+                compressing,
+                Default::default(),
+                probe_compressor,
+            ));
+
+            // The factory is applied recursively to nested lists.
+            table_strategy = table_strategy
+                .with_list_elements_strategy(list_leaf)
+                .with_list_layout_factory(
+                    move |list_layout: ListLayoutStrategy| -> Arc<dyn LayoutStrategy> {
+                        let list_layout = if let Some(target) = list_repartition_target {
+                            list_layout.with_list_aware_repartition(target)
+                        } else {
+                            list_layout
+                        };
+                        let zoned = ZonedStrategy::new(
+                            list_layout,
+                            compress_then_flat.clone(),
+                            ZonedLayoutOptions {
+                                block_size: row_block_size,
+                                ..Default::default()
+                            },
+                        );
+                        Arc::new(RepartitionStrategy::new(
+                            zoned,
+                            RepartitionWriterOptions {
+                                block_size_minimum: 0,
+                                block_len_multiple: row_block_size.get(),
+                                block_size_target: None,
+                                canonicalize: false,
+                            },
+                        ))
+                    },
+                );
         }
 
         Arc::new(table_strategy)

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -12,7 +12,9 @@ use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::pin_mut;
 use rstest::rstest;
+use vortex_array::ArrayContext;
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::array_session;
@@ -73,10 +75,14 @@ use vortex_flatbuffers::footer as fb;
 use vortex_io::session::RuntimeSession;
 use vortex_layout::DynLayout;
 use vortex_layout::layouts::flat::writer::FlatLayoutStrategy;
+use vortex_layout::layouts::list::List;
 use vortex_layout::layouts::zoned::LegacyStats;
 use vortex_layout::layouts::zoned::Zoned;
 use vortex_layout::scan::scan_builder::ScanBuilder;
 use vortex_layout::scan::split_by::SplitBy;
+use vortex_layout::segments::TestSegments;
+use vortex_layout::sequence::SequenceId;
+use vortex_layout::sequence::SequentialArrayStreamExt;
 use vortex_layout::session::LayoutSession;
 use vortex_session::VortexSession;
 
@@ -1696,6 +1702,46 @@ async fn write_read_roundtrip(array: ArrayRef) -> VortexResult<ArrayRef> {
         .into_array_stream()?
         .read_all()
         .await
+}
+
+/// The full file strategy must preserve list-aware chunks through compression. The first two
+/// sublists together exceed the 1 MiB target, while splitting at exactly 1 MiB would cut the
+/// second sublist in half.
+#[tokio::test]
+async fn list_elements_are_chunked_at_sublist_boundaries() -> VortexResult<()> {
+    fn identity_compressor(array: &ArrayRef, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+        Ok(array.clone())
+    }
+
+    let list = ListArray::try_new(
+        PrimitiveArray::from_iter(0..500_000_i32).into_array(),
+        buffer![0u32, 200_000, 300_000, 500_000].into_array(),
+        Validity::NonNullable,
+    )?
+    .into_array();
+    let strategy = crate::strategy::WriteStrategyBuilder::default()
+        .with_list_layout()
+        .with_compressor(identity_compressor)
+        .build();
+    let segments = Arc::new(TestSegments::default());
+    let (ptr, eof) = SequenceId::root().split();
+    let stream = list.to_array_stream().sequenced(ptr);
+
+    let layout = strategy
+        .write_stream(ArrayContext::empty(), segments, stream, eof, &SESSION)
+        .await?;
+    let list = if layout.is::<Zoned>() {
+        layout.child(0)?
+    } else {
+        layout
+    };
+    assert!(list.is::<List>());
+
+    let elements = list.child(0)?;
+    assert_eq!(elements.nchildren(), 2);
+    assert_eq!(elements.child(0)?.row_count(), 300_000);
+    assert_eq!(elements.child(1)?.row_count(), 200_000);
+    Ok(())
 }
 
 /// A `list<list<i32>>` column round-trips through the `TableStrategy` dispatcher, exercising list

--- a/vortex-layout/src/layouts/list/mod.rs
+++ b/vortex-layout/src/layouts/list/mod.rs
@@ -5,6 +5,7 @@
 
 mod expr;
 mod reader;
+mod repartition;
 pub mod writer;
 
 use std::sync::Arc;

--- a/vortex-layout/src/layouts/list/repartition.rs
+++ b/vortex-layout/src/layouts/list/repartition.rs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::num::NonZeroU64;
+use std::ops::Range;
+
+use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
+use vortex_array::arrays::ChunkedArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::validity::Validity;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+
+/// Canonical list parts whose sublists are kept within one output chunk.
+pub(super) struct ListChunk {
+    pub(super) elements: ArrayRef,
+    pub(super) offsets: ArrayRef,
+    pub(super) validity: Validity,
+}
+
+/// Groups canonical list parts into target-sized chunks without splitting sublists.
+pub(super) struct ListChunker {
+    target_element_bytes: u64,
+    buffer: ListChunkBuffer,
+}
+
+impl ListChunker {
+    /// Create a chunker targeting the given number of element bytes per output chunk.
+    pub(super) fn new(target_element_bytes: NonZeroU64) -> Self {
+        Self {
+            target_element_bytes: target_element_bytes.get(),
+            buffer: ListChunkBuffer::default(),
+        }
+    }
+
+    /// Buffer canonical list parts and return any completed list-aware chunks.
+    pub(super) fn push_chunk(
+        &mut self,
+        elements: ArrayRef,
+        offsets: &[u64],
+        validity: Validity,
+    ) -> VortexResult<Vec<ListChunk>> {
+        let row_count = offsets.len().saturating_sub(1);
+        if row_count == 0 {
+            self.buffer.push_empty(elements, validity);
+            return Ok(Vec::new());
+        }
+
+        let offset_base = offsets[0];
+        let element_count = offsets[row_count] - offset_base;
+        let element_bytes = estimated_element_bytes(&elements);
+        let mut output = Vec::new();
+        let mut range_start = 0;
+        let mut range_bytes: u64 = 0;
+
+        for row in 0..row_count {
+            range_bytes = range_bytes.saturating_add(estimated_range_bytes(
+                offsets[row] - offset_base,
+                offsets[row + 1] - offset_base,
+                element_count,
+                element_bytes,
+            ));
+
+            if self.buffer.element_bytes.saturating_add(range_bytes) >= self.target_element_bytes {
+                self.buffer.push_range(
+                    &elements,
+                    offsets,
+                    &validity,
+                    range_start..row + 1,
+                    range_bytes,
+                )?;
+                output.push(self.buffer.take()?);
+                range_start = row + 1;
+                range_bytes = 0;
+            }
+        }
+
+        if range_start < row_count {
+            self.buffer.push_range(
+                &elements,
+                offsets,
+                &validity,
+                range_start..row_count,
+                range_bytes,
+            )?;
+        }
+
+        Ok(output)
+    }
+
+    /// Flush any remaining buffered list parts.
+    pub(super) fn finish(&mut self) -> VortexResult<Option<ListChunk>> {
+        if self.buffer.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(self.buffer.take()?))
+        }
+    }
+}
+
+/// Estimate the flattened elements' contribution to the repartition target.
+fn estimated_element_bytes(elements: &ArrayRef) -> u64 {
+    elements
+        .dtype()
+        .element_size()
+        .and_then(|element_size| {
+            u64::try_from(element_size)
+                .ok()?
+                .checked_mul(elements.len() as u64)
+        })
+        .unwrap_or_else(|| elements.nbytes())
+}
+
+/// Estimate a range's bytes by its proportional position in the flattened element array.
+/// Taking the difference between two prefix estimates preserves the total byte count exactly.
+fn estimated_range_bytes(start: u64, end: u64, element_count: u64, nbytes: u64) -> u64 {
+    if element_count == 0 {
+        return 0;
+    }
+    let prefix = |offset: u64| {
+        u64::try_from(u128::from(offset) * u128::from(nbytes) / u128::from(element_count))
+            .vortex_expect("estimated prefix bytes cannot exceed the element array size")
+    };
+    prefix(end) - prefix(start)
+}
+
+#[derive(Default)]
+struct ListChunkBuffer {
+    elements: Vec<ArrayRef>,
+    offsets: Vec<u64>,
+    validities: Vec<(Validity, usize)>,
+    element_count: u64,
+    element_bytes: u64,
+}
+
+impl ListChunkBuffer {
+    /// Return whether the buffer contains no list parts.
+    fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    /// Append a contiguous range of sublists from one canonical input chunk.
+    fn push_range(
+        &mut self,
+        elements: &ArrayRef,
+        offsets: &[u64],
+        validity: &Validity,
+        rows: Range<usize>,
+        element_bytes: u64,
+    ) -> VortexResult<()> {
+        debug_assert!(rows.start < rows.end);
+        let offset_base = offsets[0];
+        let first_offset = offsets[rows.start];
+        let last_offset = offsets[rows.end];
+        let element_start =
+            usize::try_from(first_offset - offset_base).vortex_expect("list offset must fit usize");
+        let element_end =
+            usize::try_from(last_offset - offset_base).vortex_expect("list offset must fit usize");
+
+        self.elements
+            .push(elements.slice(element_start..element_end)?);
+        if self.offsets.is_empty() {
+            self.offsets.push(0);
+        }
+        for offset in &offsets[rows.start + 1..=rows.end] {
+            self.offsets
+                .push(self.element_count + (*offset - first_offset));
+        }
+        self.validities
+            .push((validity.slice(rows.clone())?, rows.len()));
+        self.element_count += last_offset - first_offset;
+        self.element_bytes = self.element_bytes.saturating_add(element_bytes);
+        Ok(())
+    }
+
+    /// Preserve an empty input chunk until the buffer is flushed.
+    fn push_empty(&mut self, elements: ArrayRef, validity: Validity) {
+        debug_assert!(elements.is_empty());
+        self.elements.push(elements);
+        if self.offsets.is_empty() {
+            self.offsets.push(0);
+        }
+        self.validities.push((validity, 0));
+    }
+
+    /// Materialize the buffered parts as one chunk and reset the buffer.
+    fn take(&mut self) -> VortexResult<ListChunk> {
+        let element_chunks = std::mem::take(&mut self.elements);
+        let elements = if element_chunks.len() == 1 {
+            element_chunks
+                .into_iter()
+                .next()
+                .vortex_expect("one buffered element chunk")
+        } else {
+            let dtype = element_chunks
+                .first()
+                .vortex_expect("at least one buffered element chunk")
+                .dtype()
+                .clone();
+            ChunkedArray::try_new(element_chunks, dtype)?.into_array()
+        };
+        let offsets = PrimitiveArray::from_iter(std::mem::take(&mut self.offsets)).into_array();
+        let validity = Validity::concat(std::mem::take(&mut self.validities))
+            .vortex_expect("at least one buffered validity");
+
+        self.element_count = 0;
+        self.element_bytes = 0;
+        Ok(ListChunk {
+            elements,
+            offsets,
+            validity,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::buffer;
+
+    use super::*;
+
+    fn chunker(target_element_bytes: u64) -> ListChunker {
+        ListChunker::new(
+            NonZeroU64::new(target_element_bytes).vortex_expect("test target is non-zero"),
+        )
+    }
+
+    #[test]
+    fn keeps_sublists_whole_at_chunk_boundaries() -> VortexResult<()> {
+        let mut chunker = chunker(16);
+        let mut chunks = chunker.push_chunk(
+            buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array(),
+            &[0, 2, 4, 9, 10],
+            Validity::NonNullable,
+        )?;
+        chunks.extend(chunker.finish()?);
+
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(chunks[0].elements.len(), 4);
+        assert_eq!(chunks[1].elements.len(), 5);
+        assert_eq!(chunks[2].elements.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn coalesces_sublists_across_input_chunks() -> VortexResult<()> {
+        let mut chunker = chunker(16);
+        let mut chunks = chunker.push_chunk(
+            buffer![0i32, 1].into_array(),
+            &[0, 2],
+            Validity::NonNullable,
+        )?;
+        chunks.extend(chunker.push_chunk(
+            buffer![2i32, 3, 4].into_array(),
+            &[0, 2, 3],
+            Validity::NonNullable,
+        )?);
+        chunks.extend(chunker.finish()?);
+
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].elements.len(), 4);
+        assert_eq!(chunks[0].offsets.len(), 3);
+        assert_eq!(chunks[1].elements.len(), 1);
+        Ok(())
+    }
+}

--- a/vortex-layout/src/layouts/list/writer.rs
+++ b/vortex-layout/src/layouts/list/writer.rs
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::StreamExt;
 use futures::future::try_join;
 use futures::future::try_join_all;
+use futures::pin_mut;
 use vortex_array::ArrayContext;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
@@ -16,6 +18,7 @@ use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::List;
 use vortex_array::arrays::ListView;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::list::ListArrayExt;
 use vortex_array::arrays::list::ListDataParts;
 use vortex_array::arrays::listview::list_from_list_view;
 use vortex_array::builtins::ArrayBuiltins;
@@ -24,6 +27,7 @@ use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::matcher::Matcher;
 use vortex_array::scalar_fn::fns::operators::Operator;
+use vortex_array::validity::Validity;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -31,6 +35,8 @@ use vortex_io::kanal_ext::KanalExt;
 use vortex_io::session::RuntimeSessionExt;
 use vortex_session::VortexSession;
 
+use super::repartition::ListChunk;
+use super::repartition::ListChunker;
 use crate::LayoutRef;
 use crate::LayoutStrategy;
 use crate::layouts::flat::writer::FlatLayoutStrategy;
@@ -45,6 +51,18 @@ use crate::sequence::SequentialStreamExt;
 
 /// Item carried on each child sub-stream: a sequenced, materialized chunk.
 type ChildChunk = VortexResult<(SequenceId, ArrayRef)>;
+
+struct ListChildSenders {
+    elements: kanal::AsyncSender<ChildChunk>,
+    offsets: kanal::AsyncSender<ChildChunk>,
+    validity: Option<kanal::AsyncSender<ChildChunk>>,
+}
+
+#[derive(Default)]
+struct ListTransposeState {
+    element_base: u64,
+    emitted_first_chunk: bool,
+}
 
 /// Strategy for writing list-typed arrays, with a fallback for non-list dtypes.
 ///
@@ -69,6 +87,7 @@ pub struct ListLayoutStrategy {
     offsets: Arc<dyn LayoutStrategy>,
     validity: Arc<dyn LayoutStrategy>,
     fallback: Arc<dyn LayoutStrategy>,
+    element_repartition_target: Option<NonZeroU64>,
 }
 
 impl Default for ListLayoutStrategy {
@@ -81,6 +100,7 @@ impl Default for ListLayoutStrategy {
             offsets: Arc::clone(&flat),
             validity: Arc::clone(&flat),
             fallback: flat,
+            element_repartition_target: None,
         }
     }
 }
@@ -89,6 +109,13 @@ impl ListLayoutStrategy {
     /// Strategy for the `elements` child.
     pub fn with_elements(mut self, elements: Arc<dyn LayoutStrategy>) -> Self {
         self.elements = elements;
+        self
+    }
+
+    /// Repartition the elements stream toward the requested byte size without splitting a sublist
+    /// across chunks.
+    pub fn with_list_aware_repartition(mut self, target_element_bytes: NonZeroU64) -> Self {
+        self.element_repartition_target = Some(target_element_bytes);
         self
     }
 
@@ -135,32 +162,42 @@ impl LayoutStrategy for ListLayoutStrategy {
             .vortex_expect("DType is List")
             .as_ref()
             .clone();
-        // Global (whole-column) offsets are cumulative and may exceed the input offset width,
-        // so definsively widen.
+        // Global offsets are cumulative and may exceed the input offset width.
         let offsets_dtype = DType::Primitive(PType::U64, Nullability::NonNullable);
 
-        // One bounded sub-stream per child: elements, offsets, and (when nullable) validity.
-        let (elements_tx, elements_rx) = kanal::bounded_async::<ChildChunk>(1);
-        let (offsets_tx, offsets_rx) = kanal::bounded_async::<ChildChunk>(1);
+        let (elements_tx, elements_rx) = kanal::bounded_async(1);
+        let (offsets_tx, offsets_rx) = kanal::bounded_async(1);
         let (validity_tx, validity_rx) = if is_nullable {
-            let (tx, rx) = kanal::bounded_async::<ChildChunk>(1);
+            let (tx, rx) = kanal::bounded_async(1);
             (Some(tx), Some(rx))
         } else {
             (None, None)
+        };
+        let child_senders = ListChildSenders {
+            elements: elements_tx,
+            offsets: offsets_tx,
+            validity: validity_tx,
         };
 
         // Transpose the list column into its child sub-streams and rebase offsets to global
         // positions. Kept joined with the child writers below so producer errors surface rather
         // than being hidden as an early channel close.
-        let fanout_fut = transpose_list_column(
-            stream,
-            session.clone(),
-            elements_tx,
-            offsets_tx,
-            validity_tx,
-        );
+        let transpose_session = session.clone();
+        let element_repartition_target = self.element_repartition_target;
+        let fanout_fut = async move {
+            if let Some(target) = element_repartition_target {
+                transpose_repartitioned_list_column(
+                    stream,
+                    transpose_session,
+                    child_senders,
+                    target,
+                )
+                .await
+            } else {
+                transpose_list_column(stream, transpose_session, child_senders).await
+            }
+        };
 
-        // Spawn a writer per child sub-stream, concurrently.
         let handle = session.handle();
         let mut child_specs: Vec<(
             DType,
@@ -215,77 +252,185 @@ impl LayoutStrategy for ListLayoutStrategy {
 }
 
 /// Transpose a list column into its `elements`, `offsets`, and (when present) `validity` child
-/// sub-streams, rebasing each chunk's local `offsets` to global `u64` positions so the single
+/// sub-streams. Rebases each chunk's local `offsets` to global `u64` positions so the single
 /// `offsets` child indexes into the concatenated `elements` child.
 ///
-/// `validity_tx` is `Some` exactly when the list is nullable. Errors surface to the caller, which
-/// joins this against the child writers, rather than being hidden as an early channel close.
+/// The validity sender is present only when the list is nullable. Errors surface to the caller,
+/// which joins this against the child writers, rather than being hidden as an early channel close.
 async fn transpose_list_column(
     mut stream: SendableSequentialStream,
     session: VortexSession,
-    elements_tx: kanal::AsyncSender<ChildChunk>,
-    offsets_tx: kanal::AsyncSender<ChildChunk>,
-    validity_tx: Option<kanal::AsyncSender<ChildChunk>>,
+    child_senders: ListChildSenders,
 ) -> VortexResult<()> {
     let mut exec_ctx = session.create_execution_ctx();
-    let mut element_base: u64 = 0;
-    let mut first = true;
+    let mut state = ListTransposeState::default();
     let mut saw_chunk = false;
+
     while let Some(chunk) = stream.next().await {
         let (sequence_id, array) = chunk?;
         saw_chunk = true;
+
         let mut sp = sequence_id.descend();
-        let ListDataParts {
+        let (elements, offsets, validity) = canonicalize_list_chunk(array, &mut exec_ctx)?;
+        emit_list_parts(
+            elements,
+            offsets.into_array(),
+            validity,
+            &mut sp,
+            &child_senders,
+            &mut state,
+            &mut exec_ctx,
+        )
+        .await?;
+    }
+
+    if !saw_chunk {
+        vortex_bail!("ListLayoutStrategy needs at least one chunk");
+    }
+
+    Ok(())
+}
+
+/// Transpose a list column while grouping elements into target-sized chunks without splitting
+/// sublists.
+async fn transpose_repartitioned_list_column(
+    stream: SendableSequentialStream,
+    session: VortexSession,
+    child_senders: ListChildSenders,
+    element_repartition_target: NonZeroU64,
+) -> VortexResult<()> {
+    let mut exec_ctx = session.create_execution_ctx();
+    let mut state = ListTransposeState::default();
+    let mut saw_chunk = false;
+    let mut element_chunker = ListChunker::new(element_repartition_target);
+    let stream = stream.peekable();
+    pin_mut!(stream);
+
+    while let Some(chunk) = stream.as_mut().next().await {
+        let (sequence_id, array) = chunk?;
+        saw_chunk = true;
+
+        let mut sp = sequence_id.descend();
+        let (elements, offsets, validity) = canonicalize_list_chunk(array, &mut exec_ctx)?;
+        let mut chunks =
+            element_chunker.push_chunk(elements, offsets.as_slice::<u64>(), validity)?;
+        if stream.as_mut().peek().await.is_none()
+            && let Some(chunk) = element_chunker.finish()?
+        {
+            chunks.push(chunk);
+        }
+
+        for ListChunk {
             elements,
             offsets,
             validity,
-            ..
-        } = canonicalize_to_list_parts(array, &mut exec_ctx)?;
-        let n_elements = elements.len() as u64;
-        let row_count = offsets.len().saturating_sub(1);
-        let offsets = global_offsets(offsets, element_base, first, &mut exec_ctx)?;
-        element_base += n_elements;
-        first = false;
-
-        if elements_tx
-            .send(Ok((sp.advance(), elements)))
-            .await
-            .is_err()
-            || offsets_tx.send(Ok((sp.advance(), offsets))).await.is_err()
+        } in chunks
         {
-            vortex_bail!("list child writer finished before all chunks were sent");
-        }
-        if let Some(validity_tx) = &validity_tx {
-            let validity = validity
-                .execute_mask(row_count, &mut exec_ctx)?
-                .into_array();
-            if validity_tx
-                .send(Ok((sp.advance(), validity)))
-                .await
-                .is_err()
-            {
-                vortex_bail!("list validity writer finished before all chunks were sent");
-            }
+            emit_list_parts(
+                elements,
+                offsets,
+                validity,
+                &mut sp,
+                &child_senders,
+                &mut state,
+                &mut exec_ctx,
+            )
+            .await?;
         }
     }
+
     if !saw_chunk {
         vortex_bail!("ListLayoutStrategy needs at least one chunk");
+    }
+
+    Ok(())
+}
+
+/// Canonicalize a list chunk into elements, `u64` offsets, and validity.
+fn canonicalize_list_chunk(
+    array: ArrayRef,
+    exec_ctx: &mut ExecutionCtx,
+) -> VortexResult<(ArrayRef, PrimitiveArray, Validity)> {
+    let canonical = array.execute_until::<AnyList>(exec_ctx)?;
+    let ListDataParts {
+        elements,
+        offsets,
+        validity,
+        ..
+    } = if let Some(list) = canonical.as_opt::<List>() {
+        list.reset_offsets(false, exec_ctx)?.into_data_parts()
+    } else if let Some(view) = canonical.as_opt::<ListView>() {
+        list_from_list_view(view.into_owned(), exec_ctx)?.into_data_parts()
+    } else {
+        unreachable!("AnyList matcher guarantees List or ListView")
+    };
+    let offsets = offsets
+        .cast(DType::Primitive(PType::U64, Nullability::NonNullable))?
+        .execute::<PrimitiveArray>(exec_ctx)?;
+    Ok((elements, offsets, validity))
+}
+
+/// Emit one set of list parts to the child writers, rebasing its offsets to the global element
+/// stream.
+async fn emit_list_parts(
+    elements: ArrayRef,
+    offsets: ArrayRef,
+    validity: Validity,
+    sp: &mut SequencePointer,
+    child_senders: &ListChildSenders,
+    state: &mut ListTransposeState,
+    exec_ctx: &mut ExecutionCtx,
+) -> VortexResult<()> {
+    let n_elements = elements.len() as u64;
+    let row_count = offsets.len().saturating_sub(1);
+
+    if child_senders
+        .elements
+        .send(Ok((sp.advance(), elements)))
+        .await
+        .is_err()
+    {
+        vortex_bail!("list elements writer finished before all chunks were sent");
+    }
+
+    let offsets = global_offsets(
+        offsets,
+        state.element_base,
+        !state.emitted_first_chunk,
+        exec_ctx,
+    )?;
+    state.element_base += n_elements;
+    state.emitted_first_chunk = true;
+
+    if child_senders
+        .offsets
+        .send(Ok((sp.advance(), offsets)))
+        .await
+        .is_err()
+    {
+        vortex_bail!("list offsets writer finished before all chunks were sent");
+    }
+    if let Some(validity_tx) = &child_senders.validity {
+        let validity = validity.execute_mask(row_count, exec_ctx)?.into_array();
+        if validity_tx
+            .send(Ok((sp.advance(), validity)))
+            .await
+            .is_err()
+        {
+            vortex_bail!("list validity writer finished before all chunks were sent");
+        }
     }
     Ok(())
 }
 
-/// Canonicalize a list-dtype array into [`ListDataParts`].
-fn canonicalize_to_list_parts(
-    array: ArrayRef,
-    exec_ctx: &mut ExecutionCtx,
-) -> VortexResult<ListDataParts> {
-    let canonical = array.execute_until::<AnyList>(exec_ctx)?;
-    if let Some(list) = canonical.as_opt::<List>() {
-        Ok(list.into_owned().into_data_parts())
-    } else if let Some(view) = canonical.as_opt::<ListView>() {
-        Ok(list_from_list_view(view.into_owned(), exec_ctx)?.into_data_parts())
-    } else {
-        unreachable!("AnyList matcher guarantees List or ListView")
+/// Matcher for `Array<List>` or `Array<ListView>`.
+struct AnyList;
+
+impl Matcher for AnyList {
+    type Match<'a> = ();
+
+    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
+        (array.as_opt::<List>().is_some() || array.as_opt::<ListView>().is_some()).then_some(())
     }
 }
 
@@ -300,12 +445,11 @@ fn global_offsets(
     first: bool,
     exec_ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    let widened = offsets.cast(DType::Primitive(PType::U64, Nullability::NonNullable))?;
     let based = if element_base == 0 {
-        widened
+        offsets
     } else {
-        let base = ConstantArray::new(element_base, widened.len()).into_array();
-        widened.binary(base, Operator::Add)?
+        let base = ConstantArray::new(element_base, offsets.len()).into_array();
+        offsets.binary(base, Operator::Add)?
     };
     let based = if first {
         based
@@ -314,17 +458,6 @@ fn global_offsets(
     };
     // Materialize so the child sub-stream carries a concrete array rather than a lazy expression.
     Ok(based.execute::<PrimitiveArray>(exec_ctx)?.into_array())
-}
-
-/// Matcher for `Array<List>` or `Array<ListView>`.
-struct AnyList;
-
-impl Matcher for AnyList {
-    type Match<'a> = ();
-
-    fn try_match(array: &ArrayRef) -> Option<Self::Match<'_>> {
-        (array.as_opt::<List>().is_some() || array.as_opt::<ListView>().is_some()).then_some(())
-    }
 }
 
 #[cfg(test)]

--- a/vortex-layout/src/layouts/table.rs
+++ b/vortex-layout/src/layouts/table.rs
@@ -47,6 +47,12 @@ pub fn use_experimental_list_layout() -> bool {
 
 type ListLayoutFactory = Arc<dyn Fn(ListLayoutStrategy) -> Arc<dyn LayoutStrategy> + Send + Sync>;
 
+#[derive(Clone, Copy)]
+enum LeafRole {
+    Default,
+    ListElements,
+}
+
 /// A configurable strategy for writing nested tabular data, dispatching each (sub)stream to the
 /// structural writer for its dtype.
 ///
@@ -69,6 +75,11 @@ pub struct TableStrategy {
     validity: Arc<dyn LayoutStrategy>,
     /// The writer for leaf fields, i.e. anything that is not a struct.
     leaf: Arc<dyn LayoutStrategy>,
+    /// Optional leaf strategy used below a list's `elements` child. This lets callers preserve
+    /// list-aware element chunks instead of sending them through a row-oriented leaf pipeline.
+    list_elements: Option<Arc<dyn LayoutStrategy>>,
+    /// Selects which leaf strategy this descended dispatcher uses.
+    leaf_role: LeafRole,
     /// Optional factory applied to each dynamically constructed [`ListLayoutStrategy`].
     /// Its presence also enables list decomposition.
     ///
@@ -100,6 +111,8 @@ impl TableStrategy {
             leaf_writers: Default::default(),
             validity,
             leaf: fallback,
+            list_elements: None,
+            leaf_role: LeafRole::Default,
             list_layout_factory: None,
         }
     }
@@ -159,6 +172,15 @@ impl TableStrategy {
     /// Override the default strategy for leaf columns that don't have overrides.
     pub fn with_default_strategy(mut self, default: Arc<dyn LayoutStrategy>) -> Self {
         self.leaf = default;
+        self
+    }
+
+    /// Override the leaf strategy used for fields descended through a list's `elements` child.
+    ///
+    /// This is useful when the list writer has already partitioned elements at sublist boundaries
+    /// and the ordinary leaf strategy would repartition them again.
+    pub fn with_list_elements_strategy(mut self, strategy: Arc<dyn LayoutStrategy>) -> Self {
+        self.list_elements = Some(strategy);
         self
     }
 
@@ -231,11 +253,24 @@ impl TableStrategy {
     fn list_strategy(&self) -> Option<Arc<dyn LayoutStrategy>> {
         let factory = self.list_layout_factory.as_ref()?;
         let list_layout = ListLayoutStrategy::default()
-            .with_elements(Arc::new(self.descend_clean()))
+            .with_elements(Arc::new(self.descend_list_elements()))
             .with_offsets(Arc::clone(&self.leaf))
             .with_validity(Arc::clone(&self.validity))
-            .with_fallback(Arc::clone(&self.leaf));
+            .with_fallback(self.leaf_strategy());
         Some(factory(list_layout))
+    }
+
+    fn leaf_strategy(&self) -> Arc<dyn LayoutStrategy> {
+        match (self.leaf_role, &self.list_elements) {
+            (LeafRole::ListElements, Some(strategy)) => Arc::clone(strategy),
+            _ => Arc::clone(&self.leaf),
+        }
+    }
+
+    fn descend_list_elements(&self) -> Self {
+        let mut elements = self.descend_clean();
+        elements.leaf_role = LeafRole::ListElements;
+        elements
     }
 
     /// Descend into a subfield, retaining only the overrides that apply beneath it (rebased to be
@@ -256,6 +291,8 @@ impl TableStrategy {
             leaf_writers: new_writers,
             validity: Arc::clone(&self.validity),
             leaf: Arc::clone(&self.leaf),
+            list_elements: self.list_elements.clone(),
+            leaf_role: self.leaf_role,
             list_layout_factory: self.list_layout_factory.clone(),
         }
     }
@@ -267,6 +304,8 @@ impl TableStrategy {
             leaf_writers: HashMap::default(),
             validity: Arc::clone(&self.validity),
             leaf: Arc::clone(&self.leaf),
+            list_elements: self.list_elements.clone(),
+            leaf_role: self.leaf_role,
             list_layout_factory: self.list_layout_factory.clone(),
         }
     }
@@ -319,7 +358,7 @@ impl LayoutStrategy for TableStrategy {
         }
 
         // Leaf: hand off to the leaf strategy.
-        self.leaf
+        self.leaf_strategy()
             .write_stream(ctx, segment_sink, stream, eof, session)
             .await
     }
@@ -353,6 +392,8 @@ mod tests {
     use crate::LayoutRef;
     use crate::LayoutStrategy;
     use crate::layouts::chunked::writer::ChunkedLayoutStrategy;
+    use crate::layouts::collect::CollectStrategy;
+    use crate::layouts::flat::Flat;
     use crate::layouts::flat::writer::FlatLayoutStrategy;
     use crate::layouts::list::List;
     use crate::layouts::repartition::RepartitionStrategy;
@@ -502,6 +543,85 @@ mod tests {
             ├── [0]: vortex.flat, dtype: u64, segment: 2
             └── [1]: vortex.flat, dtype: u64, segment: 3
         ");
+        Ok(())
+    }
+
+    /// List elements can use a boundary-preserving leaf while offsets retain the ordinary leaf.
+    #[tokio::test]
+    async fn dispatches_list_elements_to_dedicated_strategy() -> VortexResult<()> {
+        let chunk0 = ListArray::try_new(
+            buffer![1i32, 2, 3].into_array(),
+            buffer![0u32, 2, 3].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let chunk1 = ListArray::try_new(
+            buffer![4i32, 5, 6, 7].into_array(),
+            buffer![0u32, 1, 4].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let dtype = chunk0.dtype().clone();
+        let chunked = ChunkedArray::try_new(vec![chunk0, chunk1], dtype)?.into_array();
+
+        let flat: Arc<dyn LayoutStrategy> = Arc::new(FlatLayoutStrategy::default());
+        let ordinary_leaf: Arc<dyn LayoutStrategy> =
+            Arc::new(CollectStrategy::new(FlatLayoutStrategy::default()));
+        let list_elements: Arc<dyn LayoutStrategy> =
+            Arc::new(ChunkedLayoutStrategy::new(FlatLayoutStrategy::default()));
+        let dispatcher = TableStrategy::new(flat, ordinary_leaf)
+            .with_list_elements_strategy(list_elements)
+            .with_list_layout();
+        let layout = write(&dispatcher, chunked).await?;
+
+        insta::assert_snapshot!(layout.display_tree(), @r"
+        vortex.list, dtype: list(i32), children: 2
+        ├── elements: vortex.chunked, dtype: i32, children: 2
+        │   ├── [0]: vortex.flat, dtype: i32, segment: 0
+        │   └── [1]: vortex.flat, dtype: i32, segment: 1
+        └── offsets: vortex.flat, dtype: u64, segment: 2
+        ");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn nested_list_offsets_keep_the_ordinary_leaf_strategy() -> VortexResult<()> {
+        let inner0 = ListArray::try_new(
+            buffer![1i32, 2, 3].into_array(),
+            buffer![0u32, 2, 3].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let outer0 =
+            ListArray::try_new(inner0, buffer![0u32, 2].into_array(), Validity::NonNullable)?
+                .into_array();
+        let inner1 = ListArray::try_new(
+            buffer![4i32, 5, 6, 7].into_array(),
+            buffer![0u32, 1, 4].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let outer1 =
+            ListArray::try_new(inner1, buffer![0u32, 2].into_array(), Validity::NonNullable)?
+                .into_array();
+        let dtype = outer0.dtype().clone();
+        let chunked = ChunkedArray::try_new(vec![outer0, outer1], dtype)?.into_array();
+
+        let validity: Arc<dyn LayoutStrategy> = Arc::new(FlatLayoutStrategy::default());
+        let ordinary_leaf: Arc<dyn LayoutStrategy> =
+            Arc::new(CollectStrategy::new(FlatLayoutStrategy::default()));
+        let list_elements: Arc<dyn LayoutStrategy> =
+            Arc::new(ChunkedLayoutStrategy::new(FlatLayoutStrategy::default()));
+        let dispatcher = TableStrategy::new(validity, ordinary_leaf)
+            .with_list_elements_strategy(list_elements)
+            .with_list_layout();
+        let layout = write(&dispatcher, chunked).await?;
+
+        let inner = layout.child(0)?;
+        assert!(inner.is::<List>());
+        assert_eq!(inner.child(0)?.nchildren(), 2);
+        assert!(inner.child(1)?.is::<Flat>());
+        assert!(layout.child(1)?.is::<Flat>());
         Ok(())
     }
 


### PR DESCRIPTION
Repartition list elements toward the configured byte target without splitting sublists across chunks. Integrate this into `ListLayoutStrategy`. 