### PR TITLE
fix: validate unsigned AVX2 take indices

### DIFF
--- a/vortex-array/benches/take_primitive.rs
+++ b/vortex-array/benches/take_primitive.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Benchmarks comparing [`PVector`] take vs [`DictArray`] canonicalization.
-//!
-//! Both are tracked by number of indices/codes for fair comparison.
+//! Benchmarks for primitive take and [`DictArray`] canonicalization.
 
 #![expect(clippy::cast_possible_truncation)]
 #![expect(clippy::unwrap_used)]
@@ -11,6 +9,7 @@
 use std::sync::LazyLock;
 
 use divan::Bencher;
+use divan::counter::ItemsCount;
 use rand::distr::Uniform;
 use rand::prelude::*;
 use rand_distr::Zipf;
@@ -34,6 +33,26 @@ const NUM_INDICES: &[usize] = &[1_000, 10_000, 100_000];
 const VECTOR_SIZE: &[usize] = &[16, 256, 2048, 8192];
 
 static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
+
+#[divan::bench(sample_count = 200)]
+fn primitive_take_u32(bencher: Bencher) {
+    const NUM_INDICES: usize = 1_000_000;
+
+    let values = PrimitiveArray::from_iter(0u32..256).into_array();
+    let indices =
+        PrimitiveArray::from_iter((0..NUM_INDICES).map(|index| index as u32 & 255)).into_array();
+
+    bencher
+        .counter(ItemsCount::new(NUM_INDICES))
+        .with_inputs(|| (indices.clone(), SESSION.create_execution_ctx()))
+        .bench_values(|(indices, mut ctx)| {
+            values
+                .take(indices)
+                .unwrap()
+                .execute::<PrimitiveArray>(&mut ctx)
+                .unwrap()
+        });
+}
 
 // --- DictArray canonicalization benchmarks ---
 

--- a/vortex-array/src/arrays/primitive/compute/take/avx2.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/avx2.rs
@@ -14,7 +14,7 @@ use std::arch::x86_64::_mm_setzero_si128;
 use std::arch::x86_64::_mm_shuffle_epi32;
 use std::arch::x86_64::_mm_storeu_si128;
 use std::arch::x86_64::_mm_unpacklo_epi64;
-use std::arch::x86_64::_mm256_andnot_si256;
+use std::arch::x86_64::_mm256_and_si256;
 use std::arch::x86_64::_mm256_cmpgt_epi32;
 use std::arch::x86_64::_mm256_cmpgt_epi64;
 use std::arch::x86_64::_mm256_cvtepu8_epi32;
@@ -27,10 +27,12 @@ use std::arch::x86_64::_mm256_loadu_si256;
 use std::arch::x86_64::_mm256_mask_i32gather_epi32;
 use std::arch::x86_64::_mm256_mask_i64gather_epi32;
 use std::arch::x86_64::_mm256_mask_i64gather_epi64;
+use std::arch::x86_64::_mm256_movemask_epi8;
 use std::arch::x86_64::_mm256_set1_epi32;
 use std::arch::x86_64::_mm256_set1_epi64x;
 use std::arch::x86_64::_mm256_setzero_si256;
 use std::arch::x86_64::_mm256_storeu_si256;
+use std::arch::x86_64::_mm256_xor_si256;
 use std::convert::identity;
 
 use vortex_buffer::Alignment;
@@ -46,6 +48,7 @@ use crate::arrays::primitive::compute::take::TakeImpl;
 use crate::arrays::primitive::compute::take::take_primitive_scalar;
 use crate::arrays::primitive::vtable::Primitive;
 use crate::dtype::NativePType;
+use crate::dtype::PType;
 use crate::dtype::UnsignedPType;
 use crate::match_each_native_ptype;
 use crate::match_each_unsigned_integer_ptype;
@@ -117,9 +120,9 @@ where
 /// (AVX2 has no sub-32-bit gather) and wider than 8 bytes (`i128`, decimals) fall back to the
 /// scalar kernel.
 ///
-/// This treats `V` as plain-old-data: reinterpreting the gathered bytes as `V` is only sound
-/// because every bit pattern is a valid `V`. All primitive and decimal-backing types satisfy
-/// this, as does any `Copy` POD type the caller supplies.
+/// The gather copies the bytes of an existing `V` without changing them. Invalid lanes write zero
+/// into uninitialized output memory, but that memory is never exposed because the function panics
+/// before setting the output length.
 ///
 /// # Panics
 ///
@@ -127,12 +130,15 @@ where
 ///
 /// # Safety
 ///
-/// The caller must ensure the `avx2` feature is enabled.
+/// The caller must ensure the `avx2` feature is enabled. Four- and eight-byte `V` types must not
+/// contain uninitialized padding because the gather reads their entire object representation as an
+/// integer lane. The production caller only supplies [`NativePType`] values, which satisfy this.
 #[target_feature(enable = "avx2")]
 #[doc(hidden)]
 unsafe fn take_avx2<V: Copy, I: UnsignedPType>(buffer: &[V], indices: &[I]) -> Buffer<V> {
     if buffer.is_empty() {
-        return Buffer::zeroed(indices.len());
+        assert!(indices.is_empty(), "take index out of bounds");
+        return Buffer::empty();
     }
 
     // Dispatch on the gather lane width. The index type must still be concretized to select the
@@ -149,11 +155,21 @@ unsafe fn take_avx2<V: Copy, I: UnsignedPType>(buffer: &[V], indices: &[I]) -> B
     }
 
     match size_of::<V>() {
+        // The i32 gather interprets u32 lanes as signed offsets. If the values slice is longer
+        // than its non-negative addressable range, a valid high u32 index must use the scalar path
+        // instead.
+        4 if I::PTYPE == PType::U32 && !i32_gather_can_address(buffer.len()) => {
+            take_primitive_scalar(buffer, indices)
+        }
         4 => dispatch!(u32),
         8 => dispatch!(u64),
         // 1/2-byte and >8-byte values have no AVX2 gather lane, so fall back to scalar.
         _ => take_primitive_scalar(buffer, indices),
     }
+}
+
+const fn i32_gather_can_address(values_len: usize) -> bool {
+    values_len <= i32::MAX as usize + 1
 }
 
 /// The main gather function that is used by the inner loop kernel for AVX2 gather.
@@ -172,11 +188,60 @@ trait GatherFn<Idx, Values> {
     ///
     /// This function can read up to `STRIDE` elements through `indices`, and read/write up to
     /// `WIDTH` elements through `src` and `dst` respectively.
-    unsafe fn gather(indices: *const Idx, max_idx: Idx, src: *const Values, dst: *mut Values);
+    ///
+    /// Returns a vector mask with all lanes set when every gathered index is valid.
+    unsafe fn gather(
+        indices: *const Idx,
+        max_idx: usize,
+        src: *const Values,
+        dst: *mut Values,
+    ) -> __m256i;
 }
 
 /// AVX2 version of [`GatherFn`] defined for 32- and 64-bit value types.
 enum AVX2Gather {}
+
+macro_rules! cmpgt_epu32 {
+    ($lhs:expr, $rhs:expr) => {{
+        // AVX2 only supplies a signed integer comparison. XORing each lane with its sign bit
+        // maps the unsigned ordering into the signed ordering without changing the relative
+        // order.
+        let sign_bit = _mm256_set1_epi32(i32::MIN);
+        _mm256_cmpgt_epi32(
+            _mm256_xor_si256($lhs, sign_bit),
+            _mm256_xor_si256($rhs, sign_bit),
+        )
+    }};
+}
+
+macro_rules! cmpgt_epu64 {
+    ($lhs:expr, $rhs:expr) => {{
+        // AVX2 only supplies a signed integer comparison. XORing each lane with its sign bit
+        // maps the unsigned ordering into the signed ordering without changing the relative
+        // order.
+        let sign_bit = _mm256_set1_epi64x(i64::MIN);
+        _mm256_cmpgt_epi64(
+            _mm256_xor_si256($lhs, sign_bit),
+            _mm256_xor_si256($rhs, sign_bit),
+        )
+    }};
+}
+
+macro_rules! pack_i64_mask_for_i32_gather {
+    ($mask:expr) => {{
+        let lo_bits = _mm256_extracti128_si256::<0>($mask);
+        let hi_bits = _mm256_extracti128_si256::<1>($mask);
+        let lo_packed = pack_i64_mask_half_for_i32_gather!(lo_bits);
+        let hi_packed = pack_i64_mask_half_for_i32_gather!(hi_bits);
+        _mm_unpacklo_epi64(lo_packed, hi_packed)
+    }};
+}
+
+macro_rules! pack_i64_mask_half_for_i32_gather {
+    ($mask:expr) => {
+        _mm_shuffle_epi32::<0b11_01_11_01>($mask)
+    };
+}
 
 macro_rules! impl_gather {
     ($idx:ty, $({$value:ty => load: $load:ident, extend: $extend:ident, splat: $splat:ident, zero_vec: $zero_vec:ident, mask_indices: $mask_indices:ident, mask_cvt: |$mask_var:ident| $mask_cvt:block, gather: $masked_gather:ident, store: $store:ident, WIDTH = $WIDTH:literal, STRIDE = $STRIDE:literal }),+) => {
@@ -191,7 +256,7 @@ macro_rules! impl_gather {
 
                 #[allow(unused_unsafe, clippy::cast_possible_truncation)]
                 #[inline(always)]
-                unsafe fn gather(indices: *const $idx, max_idx: $idx, src: *const $value, dst: *mut $value) {
+                unsafe fn gather(indices: *const $idx, max_idx: usize, src: *const $value, dst: *mut $value) -> __m256i {
                     const {
                         assert!($WIDTH <= $STRIDE, "dst cannot advance by more than the stride");
                     }
@@ -202,22 +267,22 @@ macro_rules! impl_gather {
                     // Extend indices to fill vector register.
                     let indices_vec = unsafe { $extend(indices_vec) };
 
-                    // Create a vec of the max idx.
                     let max_idx_vec = unsafe { $splat(max_idx as _) };
-                    // Create a mask for valid indices (where the max_idx > provided index).
-                    let invalid_mask = unsafe { _mm256_andnot_si256($mask_indices(indices_vec, max_idx_vec), $splat(-1)) };
-                    let invalid_mask = {
-                        let $mask_var = invalid_mask;
-                        $mask_cvt
-                    };
+                    // Passing the valid mask to the gather masks every invalid lane before it can
+                    // access `src`.
+                    let valid_mask = unsafe { $mask_indices!(max_idx_vec, indices_vec) };
+                    let $mask_var = valid_mask;
+                    let gather_mask = $mask_cvt;
                     let zero_vec = unsafe { $zero_vec() };
 
                     // Gather the values into new vector register, for masked positions
                     // it substitutes zero instead of accessing the src.
-                    let values_vec = unsafe { $masked_gather::<SCALE>(zero_vec, src.cast(), indices_vec, invalid_mask) };
+                    let values_vec = unsafe { $masked_gather::<SCALE>(zero_vec, src.cast(), indices_vec, gather_mask) };
 
                     // Write the vec out to dst.
                     unsafe { $store(dst.cast(), values_vec) };
+
+                    valid_mask
                 }
             }
     };
@@ -231,7 +296,7 @@ impl_gather!(u8,
         extend: _mm256_cvtepu8_epi32,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
-        mask_indices: _mm256_cmpgt_epi32,
+        mask_indices: cmpgt_epu32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -244,7 +309,7 @@ impl_gather!(u8,
         extend: _mm256_cvtepu8_epi64,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
-        mask_indices: _mm256_cmpgt_epi64,
+        mask_indices: cmpgt_epu64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -260,7 +325,7 @@ impl_gather!(u16,
         extend: _mm256_cvtepu16_epi32,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
-        mask_indices: _mm256_cmpgt_epi32,
+        mask_indices: cmpgt_epu32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -273,7 +338,7 @@ impl_gather!(u16,
         extend: _mm256_cvtepu16_epi64,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
-        mask_indices: _mm256_cmpgt_epi64,
+        mask_indices: cmpgt_epu64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -289,7 +354,7 @@ impl_gather!(u32,
         extend: identity,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
-        mask_indices: _mm256_cmpgt_epi32,
+        mask_indices: cmpgt_epu32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -302,7 +367,7 @@ impl_gather!(u32,
         extend: _mm256_cvtepu32_epi64,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
-        mask_indices: _mm256_cmpgt_epi64,
+        mask_indices: cmpgt_epu64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -317,16 +382,8 @@ impl_gather!(u64,
         extend: identity,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm_setzero_si128,
-        mask_indices: _mm256_cmpgt_epi64,
-        mask_cvt: |m| {
-            unsafe {
-                let lo_bits = _mm256_extracti128_si256::<0>(m);    // lower half
-                let hi_bits = _mm256_extracti128_si256::<1>(m);    // upper half
-                let lo_packed = _mm_shuffle_epi32::<0b01_01_01_01>(lo_bits);
-                let hi_packed = _mm_shuffle_epi32::<0b01_01_01_01>(hi_bits);
-                _mm_unpacklo_epi64(lo_packed, hi_packed)
-            }
-        },
+        mask_indices: cmpgt_epu64,
+        mask_cvt: |m| { unsafe { pack_i64_mask_for_i32_gather!(m) } },
         gather: _mm256_mask_i64gather_epi32,
         store: _mm_storeu_si128,
         WIDTH = 4, STRIDE = 4
@@ -338,7 +395,7 @@ impl_gather!(u64,
         extend: identity,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
-        mask_indices: _mm256_cmpgt_epi64,
+        mask_indices: cmpgt_epu64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -352,10 +409,9 @@ impl_gather!(u64,
 /// `Out` is the element type written to the output buffer; `Lane` (`u32` or `u64`) is the
 /// integer type the gather intrinsics operate on. The caller must pair them so that
 /// `size_of::<Out>() == size_of::<Lane>()` (the only caller, [`take_avx2`], picks `Lane` from
-/// `size_of::<Out>()`). The gather moves `size_of::<Lane>()` raw bytes per element, which only
-/// yields a valid `Out` because `Out` is plain-old-data (every bit pattern is a valid `Out`).
-/// Pointers into the `Out`-typed slices are cast to `*const Lane`/`*mut Lane`; gather tolerates
-/// the (possibly weaker) `Out` alignment.
+/// `size_of::<Out>()`). The gather copies each valid `Out` object's bytes unchanged. Pointers into
+/// the `Out`-typed slices are cast to `*const Lane`/`*mut Lane`; gather tolerates the (possibly
+/// weaker) `Out` alignment.
 #[inline(always)]
 fn exec_take<Out, Lane, Idx, Gather>(values: &[Out], indices: &[Idx]) -> Buffer<Out>
 where
@@ -363,19 +419,27 @@ where
     Idx: UnsignedPType,
     Gather: GatherFn<Idx, Lane>,
 {
-    debug_assert_eq!(
+    assert_eq!(
         size_of::<Out>(),
         size_of::<Lane>(),
         "gather lane and output element must have the same size"
     );
 
     let indices_len = indices.len();
-    let max_index = Idx::from(values.len()).unwrap_or_else(|| Idx::max_value());
+    // Lift the representability branch out of the SIMD loop. When the length does not fit in the
+    // index type, max + 1 is a widened exclusive bound that accepts every possible index.
+    let max_index: usize = if Idx::from(values.len()).is_some() {
+        values.len()
+    } else {
+        Idx::max_value().as_() + 1
+    };
     let mut buffer =
         BufferMut::<Out>::with_capacity_aligned(indices_len, Alignment::of::<__m256i>());
     let buf_uninit = buffer.spare_capacity_mut();
 
     let mut offset = 0;
+    // SAFETY: `exec_take` is only called by `take_avx2`, whose caller guarantees AVX2 support.
+    let mut all_indices_valid = unsafe { _mm256_set1_epi32(-1) };
     // Loop terminates STRIDE elements before end of the indices array because the `GatherFn`
     // might read up to STRIDE src elements at a time, even though it only advances WIDTH elements
     // in the dst.
@@ -386,7 +450,7 @@ where
         //  2. `buffer` has same len as indices so `buffer + offset + WIDTH` is always valid.
         //  3. `size_of::<Out>() == size_of::<Lane>()` (asserted above), so the `Lane`-typed
         //     pointers address the same bytes as the `Out`-typed `values`/`buffer` allocations.
-        unsafe {
+        let valid_mask = unsafe {
             Gather::gather(
                 indices.as_ptr().add(offset),
                 max_index,
@@ -394,8 +458,18 @@ where
                 buf_uninit.as_mut_ptr().add(offset).cast::<Lane>(),
             )
         };
+        // SAFETY: `exec_take` is only called by `take_avx2`, whose caller guarantees AVX2 support.
+        all_indices_valid = unsafe { _mm256_and_si256(all_indices_valid, valid_mask) };
         offset += Gather::WIDTH;
     }
+
+    // Invalid lanes were masked before gathering, so it is safe to defer the bounds failure until
+    // after the SIMD loop and avoid a conditional branch on every iteration.
+    assert!(
+        // SAFETY: `exec_take` is only called by `take_avx2`, whose caller guarantees AVX2 support.
+        unsafe { _mm256_movemask_epi8(all_indices_valid) } == -1,
+        "take index out of bounds"
+    );
 
     // Remainder.
     while offset < indices_len {
@@ -421,7 +495,77 @@ where
 #[cfg_attr(miri, ignore)]
 #[cfg(target_arch = "x86_64")]
 mod avx2_tests {
+    use std::arch::x86_64::_mm_movemask_epi8;
+    use std::arch::x86_64::_mm_set_epi64x;
+    use std::panic::RefUnwindSafe;
+    use std::panic::catch_unwind;
+
     use super::*;
+
+    fn take_avx2_if_supported<V: Copy, I: UnsignedPType>(
+        values: &[V],
+        indices: &[I],
+    ) -> Option<Buffer<V>> {
+        if !is_x86_feature_detected!("avx2") {
+            return None;
+        }
+
+        // SAFETY: AVX2 support was detected above, and every test value type has no uninitialized
+        // padding.
+        Some(unsafe { take_avx2(values, indices) })
+    }
+
+    fn assert_avx2_take_panics<V, I>(values: &[V], indices: &[I])
+    where
+        V: Copy + RefUnwindSafe,
+        I: UnsignedPType + RefUnwindSafe,
+    {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+
+        // SAFETY: AVX2 support was detected above, and every test value type has no uninitialized
+        // padding.
+        let result = catch_unwind(|| unsafe { take_avx2(values, indices) });
+        let Err(payload) = result else {
+            panic!("take should panic for an invalid index");
+        };
+        let message = payload
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| payload.downcast_ref::<String>().map(String::as_str));
+        assert_eq!(message, Some("take index out of bounds"));
+    }
+
+    #[test]
+    fn test_pack_i64_mask_for_i32_gather_preserves_lanes() {
+        if !is_x86_feature_detected!("sse2") {
+            return;
+        }
+
+        for lane_bits in 0u8..16 {
+            let lane_mask = |lane: u32| {
+                if lane_bits & (1u8 << lane) == 0 {
+                    0
+                } else {
+                    -1
+                }
+            };
+            let actual = unsafe {
+                let lo_bits = _mm_set_epi64x(lane_mask(1), lane_mask(0));
+                let hi_bits = _mm_set_epi64x(lane_mask(3), lane_mask(2));
+                let lo_packed = pack_i64_mask_half_for_i32_gather!(lo_bits);
+                let hi_packed = pack_i64_mask_half_for_i32_gather!(hi_bits);
+                let packed = _mm_unpacklo_epi64(lo_packed, hi_packed);
+                _mm_movemask_epi8(packed)
+            };
+            let expected = (0u32..4).fold(0, |bits, lane| {
+                bits | (((lane_bits >> lane) & 1) as i32 * (0b1111 << (lane * 4)))
+            });
+
+            assert_eq!(actual, expected, "lane mask {lane_bits:04b}");
+        }
+    }
 
     macro_rules! test_cases {
         (index_type => $IDX:ty, value_types => $($VAL:ty),+) => {
@@ -434,32 +578,31 @@ mod avx2_tests {
                         let values: Vec<$VAL> = (1..=127).map(|x| x as $VAL).collect();
                         let indices: Vec<$IDX> = (0..127).collect();
 
-                        let result = unsafe { take_avx2(&values, &indices) };
+                        let Some(result) = take_avx2_if_supported(&values, &indices) else {
+                            return;
+                        };
                         assert_eq!(&values, result.as_slice());
                     }
 
                     // Test take on empty array.
                     #[test]
-                    #[should_panic]
                     #[allow(clippy::cast_possible_truncation)]
                     fn [<test_avx2_take_empty_ $IDX _ $VAL>]() {
                         let values: Vec<$VAL> = vec![];
                         let indices: Vec<$IDX> = (0..127).collect();
-                        let result = unsafe { take_avx2(&values, &indices) };
-                        assert!(result.is_empty());
+
+                        assert_avx2_take_panics(&values, &indices);
                     }
 
                     // Test all invalid take indices mapping to zeros.
                     #[test]
-                    #[should_panic]
                     #[allow(clippy::cast_possible_truncation)]
                     fn [<test_avx2_take_invalid_ $IDX _ $VAL>]() {
                         let values: Vec<$VAL> = (1..=127).map(|x| x as $VAL).collect();
                         // All out of bounds indices.
                         let indices: Vec<$IDX> = (127..=254).collect();
 
-                        let result = unsafe { take_avx2(&values, &indices) };
-                        assert_eq!(&[0 as $VAL; 127], result.as_slice());
+                        assert_avx2_take_panics(&values, &indices);
                     }
                 )+
             }
@@ -488,7 +631,9 @@ mod avx2_tests {
         let values: Vec<i64> = (0..(255 + 1)).collect();
         let indices: Vec<u8> = vec![255; 20];
 
-        let result = unsafe { take_avx2(&values, &indices) };
+        let Some(result) = take_avx2_if_supported(&values, &indices) else {
+            return;
+        };
         assert_eq!(&vec![255; indices.len()], result.as_slice());
     }
 
@@ -497,8 +642,51 @@ mod avx2_tests {
         let values: Vec<i64> = (0..(65535 + 1)).collect();
         let indices: Vec<u16> = vec![65535; 20];
 
-        let result = unsafe { take_avx2(&values, &indices) };
+        let Some(result) = take_avx2_if_supported(&values, &indices) else {
+            return;
+        };
         assert_eq!(&vec![65535; indices.len()], result.as_slice());
+    }
+
+    #[test]
+    fn test_avx2_take_empty_values_and_indices() {
+        let Some(result) = take_avx2_if_supported::<u32, u32>(&[], &[]) else {
+            return;
+        };
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_i32_gather_addressable_length_boundary() {
+        assert!(i32_gather_can_address(i32::MAX as usize + 1));
+        assert!(!i32_gather_can_address(i32::MAX as usize + 2));
+    }
+
+    #[test]
+    fn test_avx2_take_u32_max_index_u32_lane() {
+        let values = vec![0u32; 8];
+        // The first eight indices execute in the SIMD loop; the scalar remainder is valid.
+        let indices = vec![0, u32::MAX, 2, 3, 4, 5, 6, 7, 0];
+
+        assert_avx2_take_panics(&values, &indices);
+    }
+
+    #[test]
+    fn test_avx2_take_u64_max_index_u32_lane() {
+        let values = vec![0u32; 8];
+        // The first four indices execute in the SIMD loop; the scalar remainder is valid.
+        let indices = vec![0, u64::MAX, 2, 3, 0];
+
+        assert_avx2_take_panics(&values, &indices);
+    }
+
+    #[test]
+    fn test_avx2_take_u64_max_index_u64_lane() {
+        let values = vec![0u64; 8];
+        // The first four indices execute in the SIMD loop; the scalar remainder is valid.
+        let indices = vec![0, u64::MAX, 2, 3, 0];
+
+        assert_avx2_take_panics(&values, &indices);
     }
 
     /// A `[u8; 4]` is a 4-byte `Copy` POD that is not a `NativePType`. This proves the kernel
@@ -508,7 +696,9 @@ mod avx2_tests {
         let values: Vec<[u8; 4]> = (1u32..=200).map(u32::to_le_bytes).collect();
         let indices: Vec<u32> = (0..200).collect();
 
-        let result = unsafe { take_avx2(&values, &indices) };
+        let Some(result) = take_avx2_if_supported(&values, &indices) else {
+            return;
+        };
         assert_eq!(values.as_slice(), result.as_slice());
     }
 
@@ -519,7 +709,9 @@ mod avx2_tests {
         let values: Vec<u16> = (1..=300).collect();
         let indices: Vec<u32> = (0..300).collect();
 
-        let result = unsafe { take_avx2(&values, &indices) };
+        let Some(result) = take_avx2_if_supported(&values, &indices) else {
+            return;
+        };
         assert_eq!(values.as_slice(), result.as_slice());
     }
 
@@ -530,7 +722,9 @@ mod avx2_tests {
         let values: Vec<[u8; 16]> = (0u128..200).map(u128::to_le_bytes).collect();
         let indices: Vec<u32> = (0..200).collect();
 
-        let result = unsafe { take_avx2(&values, &indices) };
+        let Some(result) = take_avx2_if_supported(&values, &indices) else {
+            return;
+        };
         assert_eq!(values.as_slice(), result.as_slice());
     }
 }

--- a/vortex-array/src/arrays/primitive/compute/take/mod.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/mod.rs
@@ -350,7 +350,6 @@ where
     Ok(values.freeze())
 }
 
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[cfg(test)]
 mod test {
     use rstest::rstest;


### PR DESCRIPTION
## Summary

- Fix unsigned AVX2 take bounds checks with unsigned SIMD comparisons and masked gathers.
- Fall back to scalar when i32 gathers cannot address valid u32 indices.
- Accumulate validity masks in SIMD and reduce once after the loop.
- Add regression coverage and a 1M-index primitive-take benchmark.

This is actually not as large of a change as it looks, and nothing changes in the hot path (there's just a bit more validation). The rest of the diff comes from the regression tests.