### PR TITLE
Increase Vortex bench size 10x, add partial filter

### DIFF
--- a/vortex-bench/sql/vortex/1_sum.sql
+++ b/vortex-bench/sql/vortex/1_sum.sql
@@ -1,3 +1,3 @@
--- When Footer changes land, vortex-duckdb should populate statistics from
--- Footer without loading and decoding the data.
+-- All zone maps are included since we don't have a filter. Vortex doesn't load
+-- data but instead populates Sum() stat from zone maps
 SELECT sum(col) FROM test;

--- a/vortex-bench/sql/vortex/2_sum-range.sql
+++ b/vortex-bench/sql/vortex/2_sum-range.sql
@@ -1,0 +1,3 @@
+-- Some zone maps are pruned, two zones are included partially, and all others
+-- are included. Only two zone maps should be decoded fully.
+SELECT sum(col) FROM test WHERE id >= 400000123 AND id < 2100000456;

--- a/vortex-bench/sql/vortex/init.sql
+++ b/vortex-bench/sql/vortex/init.sql
@@ -2,7 +2,8 @@
 
 COPY (
     SELECT
+        i AS id,
         i % 1000 AS col,
         (i * 2654435761) % 100000 AS col2
-    FROM range(250000000) t(i)
+    FROM range(2500000000) t(i)
 ) TO 'test.parquet' (FORMAT parquet);


### PR DESCRIPTION
Votex benchmarks are still noisy and we're mostly measuring
duckdb overhead. Increase them 10x, and add a query which
leaves most zone maps intact but takes some partially

(Stack for zone maps aggregation short-circuit)