### PR TITLE
Split SplitBy::Layout into Layout and LayoutSubSplitting variants

### DIFF
--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -505,7 +505,7 @@ fn natural_split_ranges_for_file(
 fn compute_natural_split_ranges(layout_reader: &dyn LayoutReader) -> DFResult<Arc<[Range<u64>]>> {
     let row_count = layout_reader.row_count();
     let row_range = 0..row_count;
-    let split_points: Vec<_> = SplitBy::Layout
+    let split_points: Vec<_> = SplitBy::LayoutSubSplitting
         .splits(layout_reader, &row_range, &[FieldMask::All])
         .map_err(|e| exec_datafusion_err!("Failed to compute Vortex natural splits: {e}"))?
         .into_iter()

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -247,10 +247,10 @@ impl VortexFile {
 
     /// Return the file's natural row splits as root-coordinate ranges.
     ///
-    /// These are the ranges that [`SplitBy::Layout`] would use for an all-fields scan.
+    /// These are the ranges that [`SplitBy::LayoutSubSplitting`] would use for an all-fields scan.
     pub fn splits(&self) -> VortexResult<Vec<Range<u64>>> {
         let reader = self.layout_reader()?;
-        Ok(SplitBy::Layout
+        Ok(SplitBy::LayoutSubSplitting
             .splits(reader.as_ref(), &(0..reader.row_count()), &[FieldMask::All])?
             .into_iter()
             .tuple_windows()

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -246,10 +246,10 @@ impl VortexFile {
 
     /// Return the file's natural row splits as root-coordinate ranges.
     ///
-    /// These are the ranges that [`SplitBy::LayoutSubSplitting`] would use for an all-fields scan.
+    /// These are the ranges that the default [`SplitBy`] would use for an all-fields scan.
     pub fn splits(&self) -> VortexResult<Vec<Range<u64>>> {
         let reader = self.layout_reader()?;
-        Ok(SplitBy::LayoutSubSplitting
+        Ok(SplitBy::default()
             .splits(reader.as_ref(), &(0..reader.row_count()), &[FieldMask::All])?
             .into_iter()
             .tuple_windows()

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -246,10 +246,10 @@ impl VortexFile {
 
     /// Return the file's natural row splits as root-coordinate ranges.
     ///
-    /// These are the ranges that [`SplitBy::Layout`] would use for an all-fields scan.
+    /// These are the ranges that [`SplitBy::LayoutSubSplitting`] would use for an all-fields scan.
     pub fn splits(&self) -> VortexResult<Vec<Range<u64>>> {
         let reader = self.layout_reader()?;
-        Ok(SplitBy::Layout
+        Ok(SplitBy::LayoutSubSplitting
             .splits(reader.as_ref(), &(0..reader.row_count()), &[FieldMask::All])?
             .into_iter()
             .tuple_windows()

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -2076,19 +2076,19 @@ fn layout_has_dict(layout: &dyn DynLayout) -> bool {
             .any(|child| layout_has_dict(child.as_ref()))
 }
 
-/// Mirrors the (private) `IDEAL_SPLIT_SIZE` that `SplitBy::Layout` uses to sub-divide wide
-/// chunk-boundary spans: layout splits are never wider than this many rows.
+/// Mirrors the (private) `IDEAL_SPLIT_SIZE` that `SplitBy::LayoutSubSplitting` uses to sub-divide
+/// wide chunk-boundary spans: layout splits are never wider than this many rows.
 const MAX_SPLIT_ROWS: u64 = 100_000;
 
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-async fn test_large_flat_chunk_scan_subdivides_splits() -> VortexResult<()> {
-    // A single flat (unchunked) 250k-row layout spans the 100k sub-split threshold, so the scan
-    // must decode it as multiple row-range splits.
-    let mut ctx = SESSION.create_execution_ctx();
-    const N_ROWS: u64 = 250_000;
+/// Rows in the [`large_flat_file`] fixture; spans the sub-split threshold.
+const FLAT_N_ROWS: u64 = 250_000;
+
+/// A single flat (unchunked) [`FLAT_N_ROWS`]-row layout with alternating-sign values, so filters
+/// select rows on both sides of any split boundary. Returns the opened file and original array.
+async fn large_flat_file() -> VortexResult<(VortexFile, ArrayRef)> {
     let values =
-        Buffer::from_iter((0..N_ROWS as i32).map(|i| if i % 2 == 0 { i } else { -i })).into_array();
+        Buffer::from_iter((0..FLAT_N_ROWS as i32).map(|i| if i % 2 == 0 { i } else { -i }))
+            .into_array();
 
     let mut buf = ByteBufferMut::empty();
     SESSION
@@ -2097,14 +2097,23 @@ async fn test_large_flat_chunk_scan_subdivides_splits() -> VortexResult<()> {
         .write(&mut buf, values.to_array_stream())
         .await?;
 
-    let file = SESSION.open_options().open_buffer(buf)?;
+    Ok((SESSION.open_options().open_buffer(buf)?, values))
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_large_flat_chunk_scan_subdivides_splits() -> VortexResult<()> {
+    // A single flat (unchunked) 250k-row layout spans the 100k sub-split threshold, so the scan
+    // must decode it as multiple row-range splits.
+    let mut ctx = SESSION.create_execution_ctx();
+    let (file, values) = large_flat_file().await?;
 
     // Sub-division caps each split at MAX_SPLIT_ROWS while tiling the file exactly.
     let splits = file.splits()?;
     assert!(splits.len() > 1, "expected sub-divided splits: {splits:?}");
     assert!(splits.iter().all(|r| r.end - r.start <= MAX_SPLIT_ROWS));
     assert_eq!(splits.first().map(|r| r.start), Some(0));
-    assert_eq!(splits.last().map(|r| r.end), Some(N_ROWS));
+    assert_eq!(splits.last().map(|r| r.end), Some(FLAT_N_ROWS));
     assert!(splits.windows(2).all(|w| w[0].end == w[1].start));
 
     // A full scan across the sub-splits returns the original rows.
@@ -2119,8 +2128,28 @@ async fn test_large_flat_chunk_scan_subdivides_splits() -> VortexResult<()> {
         .read_all()
         .await?;
     let expected =
-        Buffer::from_iter((0..N_ROWS as i32).filter(|i| i % 2 == 0 && *i > 0)).into_array();
+        Buffer::from_iter((0..FLAT_N_ROWS as i32).filter(|i| i % 2 == 0 && *i > 0)).into_array();
     assert_arrays_eq!(result, expected, &mut ctx);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_no_sub_splitting_keeps_large_chunk_whole() -> VortexResult<()> {
+    // The same over-wide single chunk as above, scanned with sub-splitting disabled: the scan
+    // follows the layout's chunk boundaries exactly, so the file decodes as one batch.
+    let mut ctx = SESSION.create_execution_ctx();
+    let (file, values) = large_flat_file().await?;
+
+    let mut chunks: Vec<ArrayRef> = file
+        .scan()?
+        .with_no_sub_splitting()
+        .into_array_stream()?
+        .try_collect()
+        .await?;
+    assert_eq!(chunks.len(), 1, "expected a single un-split chunk");
+    assert_arrays_eq!(chunks.remove(0), values, &mut ctx);
 
     Ok(())
 }
@@ -2137,18 +2166,7 @@ async fn test_flat_chunk_scan_with_row_count_splits(
     // results whether the split size straddles the chunk arbitrarily or exceeds the file's
     // row count (a single split).
     let mut ctx = SESSION.create_execution_ctx();
-    const N_ROWS: u64 = 250_000;
-    let values =
-        Buffer::from_iter((0..N_ROWS as i32).map(|i| if i % 2 == 0 { i } else { -i })).into_array();
-
-    let mut buf = ByteBufferMut::empty();
-    SESSION
-        .write_options()
-        .with_strategy(Arc::new(FlatLayoutStrategy::default()))
-        .write(&mut buf, values.to_array_stream())
-        .await?;
-
-    let file = SESSION.open_options().open_buffer(buf)?;
+    let (file, values) = large_flat_file().await?;
 
     let result = file
         .scan()?
@@ -2166,7 +2184,7 @@ async fn test_flat_chunk_scan_with_row_count_splits(
         .read_all()
         .await?;
     let expected =
-        Buffer::from_iter((0..N_ROWS as i32).filter(|i| i % 2 == 0 && *i > 0)).into_array();
+        Buffer::from_iter((0..FLAT_N_ROWS as i32).filter(|i| i % 2 == 0 && *i > 0)).into_array();
     assert_arrays_eq!(result, expected, &mut ctx);
 
     Ok(())
@@ -2177,7 +2195,7 @@ async fn test_flat_chunk_scan_with_row_count_splits(
 async fn test_string_chunks_stay_fine_grained_under_split_cap() -> VortexResult<()> {
     // Default writing targets ~1MiB uncompressed blocks, so ~120-byte strings chunk at a few
     // thousand rows (~8k with today's defaults). These natural boundaries sit far below the
-    // sub-split cap, and SplitBy::Layout must pass them through untouched.
+    // sub-split cap, and SplitBy::LayoutSubSplitting must pass them through untouched.
     let mut ctx = SESSION.create_execution_ctx();
     const N_ROWS: usize = 40_000;
     let strings = VarBinArray::from_iter(

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -2337,19 +2337,19 @@ fn layout_has_dict(layout: &dyn DynLayout) -> bool {
             .any(|child| layout_has_dict(child.as_ref()))
 }
 
-/// Mirrors the (private) `IDEAL_SPLIT_SIZE` that `SplitBy::Layout` uses to sub-divide wide
-/// chunk-boundary spans: layout splits are never wider than this many rows.
+/// Mirrors the (private) `IDEAL_SPLIT_SIZE` that `SplitBy::LayoutSubSplitting` uses to sub-divide
+/// wide chunk-boundary spans: layout splits are never wider than this many rows.
 const MAX_SPLIT_ROWS: u64 = 100_000;
 
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-async fn test_large_flat_chunk_scan_subdivides_splits() -> VortexResult<()> {
-    // A single flat (unchunked) 250k-row layout spans the 100k sub-split threshold, so the scan
-    // must decode it as multiple row-range splits.
-    let mut ctx = SESSION.create_execution_ctx();
-    const N_ROWS: u64 = 250_000;
+/// Rows in the [`large_flat_file`] fixture; spans the sub-split threshold.
+const FLAT_N_ROWS: u64 = 250_000;
+
+/// A single flat (unchunked) [`FLAT_N_ROWS`]-row layout with alternating-sign values, so filters
+/// select rows on both sides of any split boundary. Returns the opened file and original array.
+async fn large_flat_file() -> VortexResult<(VortexFile, ArrayRef)> {
     let values =
-        Buffer::from_iter((0..N_ROWS as i32).map(|i| if i % 2 == 0 { i } else { -i })).into_array();
+        Buffer::from_iter((0..FLAT_N_ROWS as i32).map(|i| if i % 2 == 0 { i } else { -i }))
+            .into_array();
 
     let mut buf = ByteBufferMut::empty();
     SESSION
@@ -2358,14 +2358,23 @@ async fn test_large_flat_chunk_scan_subdivides_splits() -> VortexResult<()> {
         .write(&mut buf, values.to_array_stream())
         .await?;
 
-    let file = SESSION.open_options().open_buffer(buf)?;
+    Ok((SESSION.open_options().open_buffer(buf)?, values))
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_large_flat_chunk_scan_subdivides_splits() -> VortexResult<()> {
+    // A single flat (unchunked) 250k-row layout spans the 100k sub-split threshold, so the scan
+    // must decode it as multiple row-range splits.
+    let mut ctx = SESSION.create_execution_ctx();
+    let (file, values) = large_flat_file().await?;
 
     // Sub-division caps each split at MAX_SPLIT_ROWS while tiling the file exactly.
     let splits = file.splits()?;
     assert!(splits.len() > 1, "expected sub-divided splits: {splits:?}");
     assert!(splits.iter().all(|r| r.end - r.start <= MAX_SPLIT_ROWS));
     assert_eq!(splits.first().map(|r| r.start), Some(0));
-    assert_eq!(splits.last().map(|r| r.end), Some(N_ROWS));
+    assert_eq!(splits.last().map(|r| r.end), Some(FLAT_N_ROWS));
     assert!(splits.windows(2).all(|w| w[0].end == w[1].start));
 
     // A full scan across the sub-splits returns the original rows.
@@ -2380,8 +2389,28 @@ async fn test_large_flat_chunk_scan_subdivides_splits() -> VortexResult<()> {
         .read_all()
         .await?;
     let expected =
-        Buffer::from_iter((0..N_ROWS as i32).filter(|i| i % 2 == 0 && *i > 0)).into_array();
+        Buffer::from_iter((0..FLAT_N_ROWS as i32).filter(|i| i % 2 == 0 && *i > 0)).into_array();
     assert_arrays_eq!(result, expected, &mut ctx);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_no_sub_splitting_keeps_large_chunk_whole() -> VortexResult<()> {
+    // The same over-wide single chunk as above, scanned with sub-splitting disabled: the scan
+    // follows the layout's chunk boundaries exactly, so the file decodes as one batch.
+    let mut ctx = SESSION.create_execution_ctx();
+    let (file, values) = large_flat_file().await?;
+
+    let mut chunks: Vec<ArrayRef> = file
+        .scan()?
+        .with_no_sub_splitting()
+        .into_array_stream()?
+        .try_collect()
+        .await?;
+    assert_eq!(chunks.len(), 1, "expected a single un-split chunk");
+    assert_arrays_eq!(chunks.remove(0), values, &mut ctx);
 
     Ok(())
 }
@@ -2398,18 +2427,7 @@ async fn test_flat_chunk_scan_with_row_count_splits(
     // results whether the split size straddles the chunk arbitrarily or exceeds the file's
     // row count (a single split).
     let mut ctx = SESSION.create_execution_ctx();
-    const N_ROWS: u64 = 250_000;
-    let values =
-        Buffer::from_iter((0..N_ROWS as i32).map(|i| if i % 2 == 0 { i } else { -i })).into_array();
-
-    let mut buf = ByteBufferMut::empty();
-    SESSION
-        .write_options()
-        .with_strategy(Arc::new(FlatLayoutStrategy::default()))
-        .write(&mut buf, values.to_array_stream())
-        .await?;
-
-    let file = SESSION.open_options().open_buffer(buf)?;
+    let (file, values) = large_flat_file().await?;
 
     let result = file
         .scan()?
@@ -2427,7 +2445,7 @@ async fn test_flat_chunk_scan_with_row_count_splits(
         .read_all()
         .await?;
     let expected =
-        Buffer::from_iter((0..N_ROWS as i32).filter(|i| i % 2 == 0 && *i > 0)).into_array();
+        Buffer::from_iter((0..FLAT_N_ROWS as i32).filter(|i| i % 2 == 0 && *i > 0)).into_array();
     assert_arrays_eq!(result, expected, &mut ctx);
 
     Ok(())
@@ -2438,7 +2456,7 @@ async fn test_flat_chunk_scan_with_row_count_splits(
 async fn test_string_chunks_stay_fine_grained_under_split_cap() -> VortexResult<()> {
     // Default writing targets ~1MiB uncompressed blocks, so ~120-byte strings chunk at a few
     // thousand rows (~8k with today's defaults). These natural boundaries sit far below the
-    // sub-split cap, and SplitBy::Layout must pass them through untouched.
+    // sub-split cap, and SplitBy::LayoutSubSplitting must pass them through untouched.
     let mut ctx = SESSION.create_execution_ctx();
     const N_ROWS: usize = 40_000;
     let strings = VarBinArray::from_iter(

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -87,6 +87,7 @@ use vortex_layout::layouts::table::TableStrategy;
 use vortex_layout::layouts::zoned::LegacyStats;
 use vortex_layout::layouts::zoned::Zoned;
 use vortex_layout::scan::scan_builder::ScanBuilder;
+use vortex_layout::scan::split_by::DEFAULT_MAX_SPLIT_ROWS;
 use vortex_layout::scan::split_by::SplitBy;
 use vortex_layout::session::LayoutSession;
 use vortex_scan::strict_sorted_buffer::StrictSortedBuffer;
@@ -2337,10 +2338,6 @@ fn layout_has_dict(layout: &dyn DynLayout) -> bool {
             .any(|child| layout_has_dict(child.as_ref()))
 }
 
-/// Mirrors the (private) `IDEAL_SPLIT_SIZE` that `SplitBy::LayoutSubSplitting` uses to sub-divide
-/// wide chunk-boundary spans: layout splits are never wider than this many rows.
-const MAX_SPLIT_ROWS: u64 = 100_000;
-
 /// Rows in the [`large_flat_file`] fixture; spans the sub-split threshold.
 const FLAT_N_ROWS: u64 = 250_000;
 
@@ -2369,10 +2366,14 @@ async fn test_large_flat_chunk_scan_subdivides_splits() -> VortexResult<()> {
     let mut ctx = SESSION.create_execution_ctx();
     let (file, values) = large_flat_file().await?;
 
-    // Sub-division caps each split at MAX_SPLIT_ROWS while tiling the file exactly.
+    // Sub-division caps each split at DEFAULT_MAX_SPLIT_ROWS while tiling the file exactly.
     let splits = file.splits()?;
     assert!(splits.len() > 1, "expected sub-divided splits: {splits:?}");
-    assert!(splits.iter().all(|r| r.end - r.start <= MAX_SPLIT_ROWS));
+    assert!(
+        splits
+            .iter()
+            .all(|r| r.end - r.start <= DEFAULT_MAX_SPLIT_ROWS)
+    );
     assert_eq!(splits.first().map(|r| r.start), Some(0));
     assert_eq!(splits.last().map(|r| r.end), Some(FLAT_N_ROWS));
     assert!(splits.windows(2).all(|w| w[0].end == w[1].start));
@@ -2411,6 +2412,25 @@ async fn test_no_sub_splitting_keeps_large_chunk_whole() -> VortexResult<()> {
         .await?;
     assert_eq!(chunks.len(), 1, "expected a single un-split chunk");
     assert_arrays_eq!(chunks.remove(0), values, &mut ctx);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn test_sub_splitting_max_rows_caps_scan_batches() -> VortexResult<()> {
+    // A custom `max_rows` tiles the 250k-row chunk into five evenly sized batches.
+    const MAX_ROWS: u64 = 50_000;
+    let (file, _) = large_flat_file().await?;
+
+    let chunks: Vec<ArrayRef> = file
+        .scan()?
+        .with_split_by(SplitBy::LayoutSubSplitting { max_rows: MAX_ROWS })
+        .into_array_stream()?
+        .try_collect()
+        .await?;
+    assert_eq!(chunks.len(), (FLAT_N_ROWS / MAX_ROWS) as usize);
+    assert!(chunks.iter().all(|c| c.len() as u64 <= MAX_ROWS));
 
     Ok(())
 }
@@ -2480,7 +2500,9 @@ async fn test_string_chunks_stay_fine_grained_under_split_cap() -> VortexResult<
         "expected multiple natural chunks: {splits:?}"
     );
     assert!(
-        splits.iter().all(|r| r.end - r.start < MAX_SPLIT_ROWS / 4),
+        splits
+            .iter()
+            .all(|r| r.end - r.start < DEFAULT_MAX_SPLIT_ROWS / 4),
         "string chunks should stay fine-grained, nowhere near the split cap: {splits:?}"
     );
     assert_eq!(splits.first().map(|r| r.start), Some(0));

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -2398,15 +2398,15 @@ async fn test_large_flat_chunk_scan_subdivides_splits() -> VortexResult<()> {
 
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
-async fn test_no_sub_splitting_keeps_large_chunk_whole() -> VortexResult<()> {
-    // The same over-wide single chunk as above, scanned with sub-splitting disabled: the scan
-    // follows the layout's chunk boundaries exactly, so the file decodes as one batch.
+async fn test_layout_split_keeps_large_chunk_whole() -> VortexResult<()> {
+    // The same over-wide single chunk as above, scanned with `SplitBy::Layout`: the scan follows
+    // the layout's chunk boundaries exactly, so the file decodes as one batch.
     let mut ctx = SESSION.create_execution_ctx();
     let (file, values) = large_flat_file().await?;
 
     let mut chunks: Vec<ArrayRef> = file
         .scan()?
-        .with_no_sub_splitting()
+        .with_split_by(SplitBy::Layout)
         .into_array_stream()?
         .try_collect()
         .await?;

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -95,7 +95,7 @@ impl ScanBuilder<ArrayRef> {
             ordered: true,
             row_range: None,
             selection: Default::default(),
-            split_by: SplitBy::Layout,
+            split_by: SplitBy::LayoutSubSplitting,
             // We default to four tasks per worker thread, which allows for some I/O lookahead
             // without too much impact on work-stealing.
             concurrency: 4,
@@ -188,6 +188,16 @@ impl<A: 'static + Send> ScanBuilder<A> {
     pub fn with_split_by(mut self, split_by: SplitBy) -> Self {
         self.split_by = split_by;
         self
+    }
+
+    /// Split only at the layout's own chunk boundaries, without sub-dividing wide chunk spans.
+    ///
+    /// By default ([`SplitBy::LayoutSubSplitting`]) spans between adjacent chunk boundaries that
+    /// are wider than the ideal split size are sub-divided, so a file with few, large chunks
+    /// decodes across multiple cores. This shorthand for `with_split_by(SplitBy::Layout)` disables
+    /// that sub-division, yielding fewer, larger splits that follow the file's chunking exactly.
+    pub fn with_no_sub_splitting(self) -> Self {
+        self.with_split_by(SplitBy::Layout)
     }
 
     /// Returns the per-worker row-split concurrency.

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -98,7 +98,7 @@ impl ScanBuilder<ArrayRef> {
             ordered: true,
             row_range: None,
             selection: Default::default(),
-            split_by: SplitBy::Layout,
+            split_by: SplitBy::LayoutSubSplitting,
             natural_splits: None,
             // We default to four tasks per worker thread, which allows for some I/O lookahead
             // without too much impact on work-stealing.
@@ -223,6 +223,16 @@ impl<A: 'static + Send> ScanBuilder<A> {
             &(0..self.layout_reader.row_count()),
             &field_mask,
         )
+    }
+
+    /// Split only at the layout's own chunk boundaries, without sub-dividing wide chunk spans.
+    ///
+    /// By default ([`SplitBy::LayoutSubSplitting`]) spans between adjacent chunk boundaries that
+    /// are wider than the ideal split size are sub-divided, so a file with few, large chunks
+    /// decodes across multiple cores. This shorthand for `with_split_by(SplitBy::Layout)` disables
+    /// that sub-division, yielding fewer, larger splits that follow the file's chunking exactly.
+    pub fn with_no_sub_splitting(self) -> Self {
+        self.with_split_by(SplitBy::Layout)
     }
 
     /// Returns the per-worker row-split concurrency.

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -225,17 +225,6 @@ impl<A: 'static + Send> ScanBuilder<A> {
         )
     }
 
-    /// Split only at the layout's own chunk boundaries, without sub-dividing wide chunk spans.
-    ///
-    /// By default ([`SplitBy::LayoutSubSplitting`]) spans between adjacent chunk boundaries wider
-    /// than [`DEFAULT_MAX_SPLIT_ROWS`](crate::scan::split_by::DEFAULT_MAX_SPLIT_ROWS) are
-    /// sub-divided, so a file with few, large chunks decodes across multiple cores. This shorthand
-    /// for `with_split_by(SplitBy::Layout)` disables that sub-division, yielding fewer, larger
-    /// splits that follow the file's chunking exactly.
-    pub fn with_no_sub_splitting(self) -> Self {
-        self.with_split_by(SplitBy::Layout)
-    }
-
     /// Returns the per-worker row-split concurrency.
     pub fn concurrency(&self) -> usize {
         self.concurrency

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -98,7 +98,7 @@ impl ScanBuilder<ArrayRef> {
             ordered: true,
             row_range: None,
             selection: Default::default(),
-            split_by: SplitBy::LayoutSubSplitting,
+            split_by: SplitBy::default(),
             natural_splits: None,
             // We default to four tasks per worker thread, which allows for some I/O lookahead
             // without too much impact on work-stealing.
@@ -227,10 +227,11 @@ impl<A: 'static + Send> ScanBuilder<A> {
 
     /// Split only at the layout's own chunk boundaries, without sub-dividing wide chunk spans.
     ///
-    /// By default ([`SplitBy::LayoutSubSplitting`]) spans between adjacent chunk boundaries that
-    /// are wider than the ideal split size are sub-divided, so a file with few, large chunks
-    /// decodes across multiple cores. This shorthand for `with_split_by(SplitBy::Layout)` disables
-    /// that sub-division, yielding fewer, larger splits that follow the file's chunking exactly.
+    /// By default ([`SplitBy::LayoutSubSplitting`]) spans between adjacent chunk boundaries wider
+    /// than [`DEFAULT_MAX_SPLIT_ROWS`](crate::scan::split_by::DEFAULT_MAX_SPLIT_ROWS) are
+    /// sub-divided, so a file with few, large chunks decodes across multiple cores. This shorthand
+    /// for `with_split_by(SplitBy::Layout)` disables that sub-division, yielding fewer, larger
+    /// splits that follow the file's chunking exactly.
     pub fn with_no_sub_splitting(self) -> Self {
         self.with_split_by(SplitBy::Layout)
     }

--- a/vortex-layout/src/scan/split_by.rs
+++ b/vortex-layout/src/scan/split_by.rs
@@ -24,11 +24,15 @@ const MAX_SPLIT_ROWS: u64 = IDEAL_SPLIT_SIZE;
 /// Note that each split must fit into the platform's maximum usize.
 #[derive(Default, Copy, Clone, Debug)]
 pub enum SplitBy {
-    #[default]
-    /// Splits any time there is a chunk boundary in the file. Spans between adjacent boundaries
-    /// wider than `MAX_SPLIT_ROWS` are further sub-divided so that a file with few, large chunks
-    /// can still be decoded across multiple cores.
+    /// Splits any time there is a chunk boundary in the file, and nowhere else. This yields
+    /// splits that follow the file's chunking exactly, trading intra-file decode parallelism
+    /// for fewer, larger batches.
     Layout,
+    #[default]
+    /// Splits like [`SplitBy::Layout`], except that spans between adjacent chunk boundaries
+    /// wider than `MAX_SPLIT_ROWS` are further sub-divided so that a file with few, large
+    /// chunks can still be decoded across multiple cores.
+    LayoutSubSplitting,
     /// Splits every n rows.
     RowCount(usize),
     // UncompressedSize(u64),
@@ -44,7 +48,7 @@ impl SplitBy {
         field_mask: &[FieldMask],
     ) -> VortexResult<Vec<u64>> {
         Ok(match *self {
-            SplitBy::Layout => {
+            SplitBy::Layout | SplitBy::LayoutSubSplitting => {
                 // We usually have under 100 splits so reserving upfront saves
                 // us some allocations
                 let mut row_splits = RowSplits::new_capacity(128);
@@ -54,7 +58,12 @@ impl SplitBy {
                     &SplitRange::root(row_range.clone())?,
                     &mut row_splits,
                 )?;
-                subdivide_large_spans(row_splits.into_sorted_deduped(), MAX_SPLIT_ROWS)
+                let boundaries = row_splits.into_sorted_deduped();
+                if matches!(self, SplitBy::LayoutSubSplitting) {
+                    subdivide_large_spans(boundaries, MAX_SPLIT_ROWS)
+                } else {
+                    boundaries
+                }
             }
             SplitBy::RowCount(n) => row_range
                 .clone()
@@ -203,78 +212,107 @@ mod test {
         assert_eq!(splits, vec![0u64, 3, 6, 9, 10]);
     }
 
+    /// A reader that registers a fixed set of interior split points (which may repeat) plus the
+    /// end of its row range.
+    struct StubReader {
+        name: Arc<str>,
+        dtype: DType,
+        row_count: u64,
+        interior_splits: Vec<u64>,
+    }
+
+    impl StubReader {
+        fn new(row_count: u64, interior_splits: Vec<u64>) -> Self {
+            Self {
+                name: Arc::from("stub"),
+                dtype: DType::Primitive(PType::U8, Nullability::NonNullable),
+                row_count,
+                interior_splits,
+            }
+        }
+    }
+
+    impl LayoutReader for StubReader {
+        fn name(&self) -> &Arc<str> {
+            &self.name
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn dtype(&self) -> &DType {
+            &self.dtype
+        }
+
+        fn row_count(&self) -> u64 {
+            self.row_count
+        }
+
+        fn register_splits(
+            &self,
+            _field_mask: &[FieldMask],
+            split_range: &SplitRange,
+            splits: &mut RowSplits,
+        ) -> VortexResult<()> {
+            for split in &self.interior_splits {
+                splits.push(split_range.row_offset() + split);
+            }
+            splits.push(split_range.root_row_range().end);
+            Ok(())
+        }
+
+        fn pruning_evaluation(
+            &self,
+            _: &Range<u64>,
+            _: &Expression,
+            _: Mask,
+        ) -> VortexResult<MaskFuture> {
+            unimplemented!()
+        }
+
+        fn filter_evaluation(
+            &self,
+            _: &Range<u64>,
+            _: &Expression,
+            _: MaskFuture,
+        ) -> VortexResult<MaskFuture> {
+            unimplemented!()
+        }
+
+        fn projection_evaluation(
+            &self,
+            _: &Range<u64>,
+            _: &Expression,
+            _: MaskFuture,
+        ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
+            unimplemented!()
+        }
+    }
+
     #[test]
-    fn test_layout_splits_dedup() {
-        struct DupReader {
-            name: Arc<str>,
-            dtype: DType,
-        }
-
-        impl LayoutReader for DupReader {
-            fn name(&self) -> &Arc<str> {
-                &self.name
-            }
-
-            fn as_any(&self) -> &dyn Any {
-                self
-            }
-
-            fn dtype(&self) -> &DType {
-                &self.dtype
-            }
-
-            fn row_count(&self) -> u64 {
-                10
-            }
-
-            fn register_splits(
-                &self,
-                _field_mask: &[FieldMask],
-                split_range: &SplitRange,
-                splits: &mut RowSplits,
-            ) -> VortexResult<()> {
-                splits.push(split_range.row_offset() + 5);
-                splits.push(split_range.row_offset() + 5);
-                splits.push(split_range.root_row_range().end);
-                Ok(())
-            }
-
-            fn pruning_evaluation(
-                &self,
-                _: &Range<u64>,
-                _: &Expression,
-                _: Mask,
-            ) -> VortexResult<MaskFuture> {
-                unimplemented!()
-            }
-
-            fn filter_evaluation(
-                &self,
-                _: &Range<u64>,
-                _: &Expression,
-                _: MaskFuture,
-            ) -> VortexResult<MaskFuture> {
-                unimplemented!()
-            }
-
-            fn projection_evaluation(
-                &self,
-                _: &Range<u64>,
-                _: &Expression,
-                _: MaskFuture,
-            ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
-                unimplemented!()
-            }
-        }
-
-        let reader = DupReader {
-            name: Arc::from("dup"),
-            dtype: DType::Primitive(PType::U8, Nullability::NonNullable),
-        };
-        let splits = SplitBy::Layout
-            .splits(&reader, &(0..10), &[FieldMask::All])
-            .unwrap();
+    fn test_layout_splits_dedup() -> VortexResult<()> {
+        let reader = StubReader::new(10, vec![5, 5]);
+        let splits = SplitBy::Layout.splits(&reader, &(0..10), &[FieldMask::All])?;
         assert_eq!(splits, vec![0u64, 5, 10]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_layout_keeps_large_chunk_whole() -> VortexResult<()> {
+        // A single chunk wider than MAX_SPLIT_ROWS: sub-divided by SplitBy::LayoutSubSplitting,
+        // left whole by SplitBy::Layout.
+        let row_count = MAX_SPLIT_ROWS * 2 + 1;
+        let reader = StubReader::new(row_count, vec![]);
+
+        let splits =
+            SplitBy::LayoutSubSplitting.splits(&reader, &(0..row_count), &[FieldMask::All])?;
+        assert!(splits.len() > 2, "expected sub-divided splits: {splits:?}");
+
+        let splits = SplitBy::Layout.splits(&reader, &(0..row_count), &[FieldMask::All])?;
+        assert_eq!(splits, vec![0, row_count]);
+
+        Ok(())
     }
 
     #[test]

--- a/vortex-layout/src/scan/split_by.rs
+++ b/vortex-layout/src/scan/split_by.rs
@@ -24,11 +24,15 @@ const MAX_SPLIT_ROWS: u64 = IDEAL_SPLIT_SIZE;
 /// Note that each split must fit into the platform's maximum usize.
 #[derive(Default, Copy, Clone, Debug)]
 pub enum SplitBy {
-    #[default]
-    /// Splits any time there is a chunk boundary in the file. Spans between adjacent boundaries
-    /// wider than `MAX_SPLIT_ROWS` are further sub-divided so that a file with few, large chunks
-    /// can still be decoded across multiple cores.
+    /// Splits any time there is a chunk boundary in the file, and nowhere else. This yields
+    /// splits that follow the file's chunking exactly, trading intra-file decode parallelism
+    /// for fewer, larger batches.
     Layout,
+    #[default]
+    /// Splits like [`SplitBy::Layout`], except that spans between adjacent chunk boundaries
+    /// wider than `MAX_SPLIT_ROWS` are further sub-divided so that a file with few, large
+    /// chunks can still be decoded across multiple cores.
+    LayoutSubSplitting,
     /// Splits every n rows.
     RowCount(usize),
     // UncompressedSize(u64),
@@ -44,7 +48,7 @@ impl SplitBy {
         field_mask: &[FieldMask],
     ) -> VortexResult<Vec<u64>> {
         Ok(match *self {
-            SplitBy::Layout => {
+            SplitBy::Layout | SplitBy::LayoutSubSplitting => {
                 // We usually have under 100 splits so reserving upfront saves
                 // us some allocations
                 let mut row_splits = RowSplits::new_capacity(128);
@@ -54,7 +58,12 @@ impl SplitBy {
                     &SplitRange::root(row_range.clone())?,
                     &mut row_splits,
                 )?;
-                subdivide_large_spans(row_splits.into_sorted_deduped(), MAX_SPLIT_ROWS)
+                let boundaries = row_splits.into_sorted_deduped();
+                if matches!(self, SplitBy::LayoutSubSplitting) {
+                    subdivide_large_spans(boundaries, MAX_SPLIT_ROWS)
+                } else {
+                    boundaries
+                }
             }
             SplitBy::RowCount(n) => row_range
                 .clone()
@@ -203,78 +212,107 @@ mod test {
         assert_eq!(splits, vec![0u64, 3, 6, 9, 10]);
     }
 
+    /// A reader that registers a fixed set of interior split points (which may repeat) plus the
+    /// end of its row range.
+    struct StubReader {
+        name: Arc<str>,
+        dtype: DType,
+        row_count: u64,
+        interior_splits: Vec<u64>,
+    }
+
+    impl StubReader {
+        fn new(row_count: u64, interior_splits: Vec<u64>) -> Self {
+            Self {
+                name: Arc::from("stub"),
+                dtype: DType::Primitive(PType::U8, Nullability::NonNullable),
+                row_count,
+                interior_splits,
+            }
+        }
+    }
+
+    impl LayoutReader for StubReader {
+        fn name(&self) -> &Arc<str> {
+            &self.name
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn dtype(&self) -> &DType {
+            &self.dtype
+        }
+
+        fn row_count(&self) -> u64 {
+            self.row_count
+        }
+
+        fn register_splits(
+            &self,
+            _field_mask: &[FieldMask],
+            split_range: &SplitRange,
+            splits: &mut RowSplits,
+        ) -> VortexResult<()> {
+            for split in &self.interior_splits {
+                splits.push(split_range.row_offset() + split);
+            }
+            splits.push(split_range.root_row_range().end);
+            Ok(())
+        }
+
+        fn pruning_evaluation(
+            &self,
+            _: &Range<u64>,
+            _: &BoundExpression,
+            _: Mask,
+        ) -> VortexResult<MaskFuture> {
+            unimplemented!()
+        }
+
+        fn filter_evaluation(
+            &self,
+            _: &Range<u64>,
+            _: &BoundExpression,
+            _: MaskFuture,
+        ) -> VortexResult<MaskFuture> {
+            unimplemented!()
+        }
+
+        fn projection_evaluation(
+            &self,
+            _: &Range<u64>,
+            _: &BoundExpression,
+            _: MaskFuture,
+        ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
+            unimplemented!()
+        }
+    }
+
     #[test]
-    fn test_layout_splits_dedup() {
-        struct DupReader {
-            name: Arc<str>,
-            dtype: DType,
-        }
-
-        impl LayoutReader for DupReader {
-            fn name(&self) -> &Arc<str> {
-                &self.name
-            }
-
-            fn as_any(&self) -> &dyn Any {
-                self
-            }
-
-            fn dtype(&self) -> &DType {
-                &self.dtype
-            }
-
-            fn row_count(&self) -> u64 {
-                10
-            }
-
-            fn register_splits(
-                &self,
-                _field_mask: &[FieldMask],
-                split_range: &SplitRange,
-                splits: &mut RowSplits,
-            ) -> VortexResult<()> {
-                splits.push(split_range.row_offset() + 5);
-                splits.push(split_range.row_offset() + 5);
-                splits.push(split_range.root_row_range().end);
-                Ok(())
-            }
-
-            fn pruning_evaluation(
-                &self,
-                _: &Range<u64>,
-                _: &BoundExpression,
-                _: Mask,
-            ) -> VortexResult<MaskFuture> {
-                unimplemented!()
-            }
-
-            fn filter_evaluation(
-                &self,
-                _: &Range<u64>,
-                _: &BoundExpression,
-                _: MaskFuture,
-            ) -> VortexResult<MaskFuture> {
-                unimplemented!()
-            }
-
-            fn projection_evaluation(
-                &self,
-                _: &Range<u64>,
-                _: &BoundExpression,
-                _: MaskFuture,
-            ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
-                unimplemented!()
-            }
-        }
-
-        let reader = DupReader {
-            name: Arc::from("dup"),
-            dtype: DType::Primitive(PType::U8, Nullability::NonNullable),
-        };
-        let splits = SplitBy::Layout
-            .splits(&reader, &(0..10), &[FieldMask::All])
-            .unwrap();
+    fn test_layout_splits_dedup() -> VortexResult<()> {
+        let reader = StubReader::new(10, vec![5, 5]);
+        let splits = SplitBy::Layout.splits(&reader, &(0..10), &[FieldMask::All])?;
         assert_eq!(splits, vec![0u64, 5, 10]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_layout_keeps_large_chunk_whole() -> VortexResult<()> {
+        // A single chunk wider than MAX_SPLIT_ROWS: sub-divided by SplitBy::LayoutSubSplitting,
+        // left whole by SplitBy::Layout.
+        let row_count = MAX_SPLIT_ROWS * 2 + 1;
+        let reader = StubReader::new(row_count, vec![]);
+
+        let splits =
+            SplitBy::LayoutSubSplitting.splits(&reader, &(0..row_count), &[FieldMask::All])?;
+        assert!(splits.len() > 2, "expected sub-divided splits: {splits:?}");
+
+        let splits = SplitBy::Layout.splits(&reader, &(0..row_count), &[FieldMask::All])?;
+        assert_eq!(splits, vec![0, row_count]);
+
+        Ok(())
     }
 
     #[test]

--- a/vortex-layout/src/scan/split_by.rs
+++ b/vortex-layout/src/scan/split_by.rs
@@ -7,35 +7,45 @@ use std::ops::Range;
 use vortex_array::dtype::FieldMask;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
 
 use crate::LayoutReader;
 use crate::RowSplits;
 use crate::SplitRange;
 use crate::scan::IDEAL_SPLIT_SIZE;
 
-/// Chunk-boundary spans wider than this are sub-divided into multiple row-range splits so that a
-/// file with few, large chunks can be decoded across multiple cores rather than one.
-///
-/// Reuses [`IDEAL_SPLIT_SIZE`] as the target span per split.
-const MAX_SPLIT_ROWS: u64 = IDEAL_SPLIT_SIZE;
+/// The default `max_rows` for [`SplitBy::LayoutSubSplitting`]: chunk-boundary spans wider than
+/// this are sub-divided into multiple row-range splits so that a file with few, large chunks can
+/// be decoded across multiple cores rather than one.
+pub const DEFAULT_MAX_SPLIT_ROWS: u64 = IDEAL_SPLIT_SIZE;
 
 /// Defines how the Vortex file is split into batches for reading.
 ///
 /// Note that each split must fit into the platform's maximum usize.
-#[derive(Default, Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum SplitBy {
     /// Splits any time there is a chunk boundary in the file, and nowhere else. This yields
     /// splits that follow the file's chunking exactly, trading intra-file decode parallelism
     /// for fewer, larger batches.
     Layout,
-    #[default]
     /// Splits like [`SplitBy::Layout`], except that spans between adjacent chunk boundaries
-    /// wider than `MAX_SPLIT_ROWS` are further sub-divided so that a file with few, large
-    /// chunks can still be decoded across multiple cores.
-    LayoutSubSplitting,
+    /// wider than `max_rows` are further sub-divided into evenly sized splits of at most
+    /// `max_rows` rows, so that a file with few, large chunks can still be decoded across
+    /// multiple cores. `max_rows` must be non-zero.
+    ///
+    /// This is the default, with [`DEFAULT_MAX_SPLIT_ROWS`].
+    LayoutSubSplitting { max_rows: u64 },
     /// Splits every n rows.
     RowCount(usize),
     // UncompressedSize(u64),
+}
+
+impl Default for SplitBy {
+    fn default() -> Self {
+        SplitBy::LayoutSubSplitting {
+            max_rows: DEFAULT_MAX_SPLIT_ROWS,
+        }
+    }
 }
 
 impl SplitBy {
@@ -48,22 +58,16 @@ impl SplitBy {
         field_mask: &[FieldMask],
     ) -> VortexResult<Vec<u64>> {
         Ok(match *self {
-            SplitBy::Layout | SplitBy::LayoutSubSplitting => {
-                // We usually have under 100 splits so reserving upfront saves
-                // us some allocations
-                let mut row_splits = RowSplits::new_capacity(128);
-                row_splits.push(row_range.start);
-                layout_reader.register_splits(
-                    field_mask,
-                    &SplitRange::root(row_range.clone())?,
-                    &mut row_splits,
-                )?;
-                let boundaries = row_splits.into_sorted_deduped();
-                if matches!(self, SplitBy::LayoutSubSplitting) {
-                    subdivide_large_spans(boundaries, MAX_SPLIT_ROWS)
-                } else {
-                    boundaries
-                }
+            SplitBy::Layout => layout_boundaries(layout_reader, row_range, field_mask)?,
+            SplitBy::LayoutSubSplitting { max_rows } => {
+                vortex_ensure!(
+                    max_rows > 0,
+                    "SplitBy::LayoutSubSplitting requires a non-zero max_rows"
+                );
+                subdivide_large_spans(
+                    layout_boundaries(layout_reader, row_range, field_mask)?,
+                    max_rows,
+                )
             }
             SplitBy::RowCount(n) => row_range
                 .clone()
@@ -72,6 +76,24 @@ impl SplitBy {
                 .collect(),
         })
     }
+}
+
+/// The sorted, deduplicated chunk boundaries the layout registers within `row_range`, bracketed
+/// by the range's start (the layout registers its end).
+fn layout_boundaries(
+    layout_reader: &dyn LayoutReader,
+    row_range: &Range<u64>,
+    field_mask: &[FieldMask],
+) -> VortexResult<Vec<u64>> {
+    // We usually have under 100 splits so reserving upfront saves us some allocations
+    let mut row_splits = RowSplits::new_capacity(128);
+    row_splits.push(row_range.start);
+    layout_reader.register_splits(
+        field_mask,
+        &SplitRange::root(row_range.clone())?,
+        &mut row_splits,
+    )?;
+    Ok(row_splits.into_sorted_deduped())
 }
 
 /// Sub-divide any gap between adjacent split boundaries that is wider than `max_span` into evenly
@@ -299,20 +321,33 @@ mod test {
     }
 
     #[test]
-    fn test_layout_keeps_large_chunk_whole() -> VortexResult<()> {
-        // A single chunk wider than MAX_SPLIT_ROWS: sub-divided by SplitBy::LayoutSubSplitting,
-        // left whole by SplitBy::Layout.
-        let row_count = MAX_SPLIT_ROWS * 2 + 1;
-        let reader = StubReader::new(row_count, vec![]);
+    fn test_layout_sub_splitting_max_rows() -> VortexResult<()> {
+        // A single 10-row chunk: left whole by SplitBy::Layout, sub-divided into pieces of at
+        // most `max_rows` by SplitBy::LayoutSubSplitting.
+        let reader = StubReader::new(10, vec![]);
 
-        let splits =
-            SplitBy::LayoutSubSplitting.splits(&reader, &(0..row_count), &[FieldMask::All])?;
-        assert!(splits.len() > 2, "expected sub-divided splits: {splits:?}");
+        let splits = SplitBy::Layout.splits(&reader, &(0..10), &[FieldMask::All])?;
+        assert_eq!(splits, vec![0, 10]);
 
-        let splits = SplitBy::Layout.splits(&reader, &(0..row_count), &[FieldMask::All])?;
-        assert_eq!(splits, vec![0, row_count]);
+        let splits = SplitBy::LayoutSubSplitting { max_rows: 4 }.splits(
+            &reader,
+            &(0..10),
+            &[FieldMask::All],
+        )?;
+        assert_eq!(splits, vec![0, 4, 8, 10]);
 
         Ok(())
+    }
+
+    #[test]
+    fn test_layout_sub_splitting_rejects_zero_max_rows() {
+        let reader = StubReader::new(10, vec![]);
+        let result = SplitBy::LayoutSubSplitting { max_rows: 0 }.splits(
+            &reader,
+            &(0..10),
+            &[FieldMask::All],
+        );
+        assert!(result.is_err());
     }
 
     #[test]
@@ -365,7 +400,7 @@ mod test {
             vec![0, 99_999, 100_000, 300_000],
         ];
         for boundaries in cases {
-            let out = subdivide_large_spans(boundaries.clone(), MAX_SPLIT_ROWS);
+            let out = subdivide_large_spans(boundaries.clone(), DEFAULT_MAX_SPLIT_ROWS);
             // (a) endpoints preserved
             assert_eq!(out.first(), boundaries.first());
             assert_eq!(out.last(), boundaries.last());

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -189,7 +189,11 @@ impl PyVortexDataset {
                 .scan()?
                 .with_projection(projection)
                 .with_some_filter(filter)
-                .with_split_by(split_by.map(SplitBy::RowCount).unwrap_or(SplitBy::Layout));
+                .with_split_by(
+                    split_by
+                        .map(SplitBy::RowCount)
+                        .unwrap_or(SplitBy::LayoutSubSplitting),
+                );
             if let Some((l, r)) = row_range {
                 scan = scan.with_row_range(l..r);
             }
@@ -228,7 +232,11 @@ impl PyVortexDataset {
                 .scan()?
                 .with_projection(select(FieldNames::empty(), root()))
                 .with_some_filter(filter)
-                .with_split_by(split_by.map(SplitBy::RowCount).unwrap_or(SplitBy::Layout));
+                .with_split_by(
+                    split_by
+                        .map(SplitBy::RowCount)
+                        .unwrap_or(SplitBy::LayoutSubSplitting),
+                );
             if let Some((l, r)) = row_range {
                 scan = scan.with_row_range(l..r);
             }

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -207,11 +207,7 @@ impl PyVortexDataset {
                 .scan()?
                 .with_projection(projection)
                 .with_some_filter(filter)
-                .with_split_by(
-                    split_by
-                        .map(SplitBy::RowCount)
-                        .unwrap_or(SplitBy::LayoutSubSplitting),
-                );
+                .with_split_by(split_by.map(SplitBy::RowCount).unwrap_or_default());
             if let Some((l, r)) = row_range {
                 scan = scan.with_row_range(l..r);
             }
@@ -257,11 +253,7 @@ impl PyVortexDataset {
                 .scan()?
                 .with_projection(projection)
                 .with_some_filter(filter)
-                .with_split_by(
-                    split_by
-                        .map(SplitBy::RowCount)
-                        .unwrap_or(SplitBy::LayoutSubSplitting),
-                );
+                .with_split_by(split_by.map(SplitBy::RowCount).unwrap_or_default());
             if let Some((l, r)) = row_range {
                 scan = scan.with_row_range(l..r);
             }

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -207,7 +207,11 @@ impl PyVortexDataset {
                 .scan()?
                 .with_projection(projection)
                 .with_some_filter(filter)
-                .with_split_by(split_by.map(SplitBy::RowCount).unwrap_or(SplitBy::Layout));
+                .with_split_by(
+                    split_by
+                        .map(SplitBy::RowCount)
+                        .unwrap_or(SplitBy::LayoutSubSplitting),
+                );
             if let Some((l, r)) = row_range {
                 scan = scan.with_row_range(l..r);
             }
@@ -253,7 +257,11 @@ impl PyVortexDataset {
                 .scan()?
                 .with_projection(projection)
                 .with_some_filter(filter)
-                .with_split_by(split_by.map(SplitBy::RowCount).unwrap_or(SplitBy::Layout));
+                .with_split_by(
+                    split_by
+                        .map(SplitBy::RowCount)
+                        .unwrap_or(SplitBy::LayoutSubSplitting),
+                );
             if let Some((l, r)) = row_range {
                 scan = scan.with_row_range(l..r);
             }


### PR DESCRIPTION
Allow configuring and disabling sub splitting of layout chunks. While for majority of encodings this is beneficial there are cases where it leads to duplicate work