### PR TITLE
Constrain List/ListView builder offset, size types to 32 and 64 bit types

### DIFF
--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -1568,15 +1568,17 @@ mod test {
         expected_elements.extend(buffer![42i32; 252]);
         let expected = ListArray::try_new(
             expected_elements.freeze().into_array(),
-            buffer![0u16, 1, 2, 3, 4, 256].into_array(),
+            buffer![0u32, 1, 2, 3, 4, 256].into_array(),
             Validity::AllValid,
         )?
         .into_array();
 
+        // The canonical offsets outgrow the source's u8 offsets; u32 is the smallest offset type
+        // a list builder can produce (see `OffsetBuilderPType`).
         let actual_listview = actual.clone().execute::<ListViewArray>(&mut ctx)?;
         assert_eq!(
             actual_listview.offsets().dtype(),
-            &DType::Primitive(PType::U16, NonNullable)
+            &DType::Primitive(PType::U32, NonNullable)
         );
         assert_arrays_eq!(&actual, &expected, &mut ctx);
 

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -36,10 +36,10 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::DecimalDType;
 use vortex_array::dtype::DecimalType;
 use vortex_array::dtype::IntegerPType;
-use vortex_array::dtype::ListOffsetPType;
 use vortex_array::dtype::NativeDecimalType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
+use vortex_array::dtype::OffsetBuilderPType;
 use vortex_array::dtype::StructFields;
 use vortex_array::match_each_decimal_value_type;
 use vortex_array::match_each_integer_ptype;
@@ -202,7 +202,7 @@ fn execute_sparse_lists(
 }
 
 #[expect(clippy::too_many_arguments)]
-fn execute_sparse_lists_inner<I: IntegerPType, O: ListOffsetPType>(
+fn execute_sparse_lists_inner<I: IntegerPType, O: OffsetBuilderPType>(
     patch_indices: &[I],
     patch_values: ListViewArray,
     fill_scalar: ListScalar,
@@ -372,7 +372,7 @@ fn list_scalar_elements_array(list: ListScalar) -> Option<ArrayRef> {
     })
 }
 
-fn append_list_fill<O: ListOffsetPType, S: ListOffsetPType>(
+fn append_list_fill<O: OffsetBuilderPType, S: OffsetBuilderPType>(
     builder: &mut ListViewBuilder<O, S>,
     fill_elements: Option<&ArrayRef>,
     count: usize,

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -36,6 +36,7 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::DecimalDType;
 use vortex_array::dtype::DecimalType;
 use vortex_array::dtype::IntegerPType;
+use vortex_array::dtype::ListOffsetPType;
 use vortex_array::dtype::NativeDecimalType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
@@ -44,7 +45,7 @@ use vortex_array::match_each_decimal_value_type;
 use vortex_array::match_each_integer_ptype;
 use vortex_array::match_each_native_ptype;
 use vortex_array::match_each_unsigned_integer_ptype;
-use vortex_array::match_smallest_offset_type;
+use vortex_array::match_smallest_list_offset_type;
 use vortex_array::patches::Patches;
 use vortex_array::scalar::DecimalScalar;
 use vortex_array::scalar::ListScalar;
@@ -175,7 +176,7 @@ fn execute_sparse_lists(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     // Patch indices are non-negative; reinterpret to unsigned so this dispatches over 4 widths
-    // instead of 8. `O` is already unsigned (from `match_smallest_offset_type`).
+    // instead of 8. `O` is already unsigned (from `match_smallest_list_offset_type`).
     let indices = resolved.indices().as_::<Primitive>().into_owned();
     let indices = indices.reinterpret_cast(indices.ptype().to_unsigned());
     let values = resolved.values().as_::<ListView>().into_owned();
@@ -185,7 +186,7 @@ fn execute_sparse_lists(
     let total_canonical_values = values.elements().len() + fill_list.len() * n_filled;
 
     Ok(match_each_unsigned_integer_ptype!(indices.ptype(), |I| {
-        match_smallest_offset_type!(total_canonical_values, |O| {
+        match_smallest_list_offset_type!(total_canonical_values, |O| {
             execute_sparse_lists_inner::<I, O>(
                 indices.as_slice(),
                 values,
@@ -201,7 +202,7 @@ fn execute_sparse_lists(
 }
 
 #[expect(clippy::too_many_arguments)]
-fn execute_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
+fn execute_sparse_lists_inner<I: IntegerPType, O: ListOffsetPType>(
     patch_indices: &[I],
     patch_values: ListViewArray,
     fill_scalar: ListScalar,
@@ -371,7 +372,7 @@ fn list_scalar_elements_array(list: ListScalar) -> Option<ArrayRef> {
     })
 }
 
-fn append_list_fill<O: IntegerPType, S: IntegerPType>(
+fn append_list_fill<O: ListOffsetPType, S: ListOffsetPType>(
     builder: &mut ListViewBuilder<O, S>,
     fill_elements: Option<&ArrayRef>,
     count: usize,

--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -30,6 +30,7 @@ use crate::builders::FixedSizeListBuilder;
 use crate::builders::ListViewBuilder;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
+use crate::dtype::ListOffsetPType;
 use crate::dtype::NativePType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
@@ -238,17 +239,11 @@ fn random_list(
     // Worst-case total elements: each list can have up to 20 elements.
     let max_total_elements = array_length as u64 * 20;
 
-    match u.int_in_range(0..=5)? {
-        0 if i16::max_value_as_u64() >= max_total_elements => {
-            random_list_with_offset_type::<i16>(u, elem_dtype, null, array_length)
-        }
-        1 if i32::max_value_as_u64() >= max_total_elements => {
+    match u.int_in_range(0..=3)? {
+        0 if i32::max_value_as_u64() >= max_total_elements => {
             random_list_with_offset_type::<i32>(u, elem_dtype, null, array_length)
         }
-        3 if u16::max_value_as_u64() >= max_total_elements => {
-            random_list_with_offset_type::<u16>(u, elem_dtype, null, array_length)
-        }
-        4 if u32::max_value_as_u64() >= max_total_elements => {
+        1 if u32::max_value_as_u64() >= max_total_elements => {
             random_list_with_offset_type::<u32>(u, elem_dtype, null, array_length)
         }
         // i64 and u64 always fit; also the fallback for when narrower types don't.
@@ -262,8 +257,8 @@ fn random_list(
     }
 }
 
-/// Creates a random list array with the given [`IntegerPType`] for the internal offsets child.
-fn random_list_with_offset_type<O: IntegerPType>(
+/// Creates a random list array with the given [`ListOffsetPType`] for the internal offsets child.
+fn random_list_with_offset_type<O: ListOffsetPType>(
     u: &mut Unstructured,
     elem_dtype: &Arc<DType>,
     null: Nullability,

--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -30,9 +30,9 @@ use crate::builders::FixedSizeListBuilder;
 use crate::builders::ListViewBuilder;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
-use crate::dtype::ListOffsetPType;
 use crate::dtype::NativePType;
 use crate::dtype::Nullability;
+use crate::dtype::OffsetBuilderPType;
 use crate::dtype::PType;
 use crate::match_each_decimal_value_type;
 use crate::scalar::Scalar;
@@ -257,8 +257,8 @@ fn random_list(
     }
 }
 
-/// Creates a random list array with the given [`ListOffsetPType`] for the internal offsets child.
-fn random_list_with_offset_type<O: ListOffsetPType>(
+/// Creates a random list array with the given [`OffsetBuilderPType`] for the internal offsets child.
+fn random_list_with_offset_type<O: OffsetBuilderPType>(
     u: &mut Unstructured,
     elem_dtype: &Arc<DType>,
     null: Nullability,

--- a/vortex-array/src/arrays/list/test_harness.rs
+++ b/vortex-array/src/arrays/list/test_harness.rs
@@ -10,14 +10,14 @@ use crate::arrays::ListArray;
 use crate::builders::ArrayBuilder;
 use crate::builders::ListBuilder;
 use crate::dtype::DType;
-use crate::dtype::IntegerPType;
+use crate::dtype::ListOffsetPType;
 use crate::scalar::Scalar;
 
 impl ListArray {
     /// This is a convenience method to create a list array from an iterator of iterators.
     /// This method is slow however since each element is first converted to a scalar and then
     /// appended to the array.
-    pub fn from_iter_slow<O: IntegerPType, I: IntoIterator>(
+    pub fn from_iter_slow<O: ListOffsetPType, I: IntoIterator>(
         iter: I,
         dtype: Arc<DType>,
     ) -> VortexResult<ListArray>
@@ -44,7 +44,7 @@ impl ListArray {
         Ok(builder.finish_into_list())
     }
 
-    pub fn from_iter_opt_slow<O: IntegerPType, I: IntoIterator<Item = Option<T>>, T>(
+    pub fn from_iter_opt_slow<O: ListOffsetPType, I: IntoIterator<Item = Option<T>>, T>(
         iter: I,
         dtype: Arc<DType>,
     ) -> VortexResult<ListArray>

--- a/vortex-array/src/arrays/list/test_harness.rs
+++ b/vortex-array/src/arrays/list/test_harness.rs
@@ -10,14 +10,14 @@ use crate::arrays::ListArray;
 use crate::builders::ArrayBuilder;
 use crate::builders::ListBuilder;
 use crate::dtype::DType;
-use crate::dtype::ListOffsetPType;
+use crate::dtype::OffsetBuilderPType;
 use crate::scalar::Scalar;
 
 impl ListArray {
     /// This is a convenience method to create a list array from an iterator of iterators.
     /// This method is slow however since each element is first converted to a scalar and then
     /// appended to the array.
-    pub fn from_iter_slow<O: ListOffsetPType, I: IntoIterator>(
+    pub fn from_iter_slow<O: OffsetBuilderPType, I: IntoIterator>(
         iter: I,
         dtype: Arc<DType>,
     ) -> VortexResult<ListArray>
@@ -44,7 +44,7 @@ impl ListArray {
         Ok(builder.finish_into_list())
     }
 
-    pub fn from_iter_opt_slow<O: ListOffsetPType, I: IntoIterator<Item = Option<T>>, T>(
+    pub fn from_iter_opt_slow<O: OffsetBuilderPType, I: IntoIterator<Item = Option<T>>, T>(
         iter: I,
         dtype: Arc<DType>,
     ) -> VortexResult<ListArray>

--- a/vortex-array/src/arrays/list/vtable/mod.rs
+++ b/vortex-array/src/arrays/list/vtable/mod.rs
@@ -36,6 +36,7 @@ use crate::builders::ArrayBuilder;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
+use crate::match_each_list_builder;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
 mod operations;
@@ -199,12 +200,21 @@ impl VTable for List {
         ))
     }
 
+    // The complexity comes from the expansion of `match_each_list_builder!`.
+    #[expect(clippy::cognitive_complexity)]
     fn append_to_builder(
         array: ArrayView<'_, Self>,
         builder: &mut dyn ArrayBuilder,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
-        builder.append_list_array(array, ctx)
+        match match_each_list_builder!(&mut *builder, |b| b.append_list_array(array, ctx)) {
+            Some(result) => result,
+            None => vortex_bail!(
+                "cannot append a List array of dtype {} to a {} builder",
+                array.dtype(),
+                builder.dtype()
+            ),
+        }
     }
 }
 

--- a/vortex-array/src/arrays/listview/vtable/mod.rs
+++ b/vortex-array/src/arrays/listview/vtable/mod.rs
@@ -35,6 +35,7 @@ use crate::builders::ArrayBuilder;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
+use crate::match_each_list_builder;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
 mod kernel;
@@ -223,12 +224,21 @@ impl VTable for ListView {
         Ok(ExecutionResult::done(array))
     }
 
+    // The complexity comes from the expansion of `match_each_list_builder!`.
+    #[expect(clippy::cognitive_complexity)]
     fn append_to_builder(
         array: ArrayView<'_, Self>,
         builder: &mut dyn ArrayBuilder,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
-        builder.append_listview_array(array, ctx)
+        match match_each_list_builder!(&mut *builder, |b| b.append_listview_array(array, ctx)) {
+            Some(result) => result,
+            None => vortex_bail!(
+                "cannot append a ListView array of dtype {} to a {} builder",
+                array.dtype(),
+                builder.dtype()
+            ),
+        }
     }
 
     fn reduce_parent(

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -31,16 +31,16 @@ use crate::builders::PrimitiveBuilder;
 use crate::builders::builder_with_capacity;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
-use crate::dtype::ListOffsetPType;
 use crate::dtype::Nullability;
 use crate::dtype::Nullability::NonNullable;
+use crate::dtype::OffsetBuilderPType;
 use crate::match_each_integer_ptype;
 use crate::scalar::ListScalar;
 use crate::scalar::Scalar;
 
-/// The builder for building a [`ListArray`], parametrized by the [`ListOffsetPType`] of the
+/// The builder for building a [`ListArray`], parametrized by the [`OffsetBuilderPType`] of the
 /// `offsets` builder.
-pub struct ListBuilder<O: ListOffsetPType> {
+pub struct ListBuilder<O: OffsetBuilderPType> {
     /// The [`DType`] of the [`ListArray`]. This **must** be a [`DType::List`].
     dtype: DType,
 
@@ -54,7 +54,7 @@ pub struct ListBuilder<O: ListOffsetPType> {
     nulls: LazyBitBufferBuilder,
 }
 
-impl<O: ListOffsetPType> ListBuilder<O> {
+impl<O: OffsetBuilderPType> ListBuilder<O> {
     /// Creates a new `ListBuilder` with a capacity of [`DEFAULT_BUILDER_CAPACITY`].
     pub fn new(value_dtype: Arc<DType>, nullability: Nullability) -> Self {
         Self::with_capacity(
@@ -232,7 +232,7 @@ impl<O: ListOffsetPType> ListBuilder<O> {
     /// Appends the values of a [`ListView`]-encoded `array` to this builder.
     ///
     /// See [`append_list_array`](Self::append_list_array); this is the same hook for the canonical
-    /// [`ListViewArray`](crate::arrays::ListViewArray) encoding.
+    /// [`ListViewArray`] encoding.
     pub fn append_listview_array(
         &mut self,
         array: ArrayView<'_, ListView>,
@@ -275,7 +275,7 @@ fn extend_from_listview<O, OffsetType, SizeType>(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()>
 where
-    O: ListOffsetPType,
+    O: OffsetBuilderPType,
     OffsetType: IntegerPType,
     SizeType: IntegerPType,
 {
@@ -314,7 +314,7 @@ where
     Ok(())
 }
 
-impl<O: ListOffsetPType> ArrayBuilder for ListBuilder<O> {
+impl<O: OffsetBuilderPType> ArrayBuilder for ListBuilder<O> {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -412,8 +412,8 @@ mod tests {
     use crate::builders::list::ListArray;
     use crate::builders::list::ListBuilder;
     use crate::dtype::DType;
-    use crate::dtype::ListOffsetPType;
     use crate::dtype::Nullability;
+    use crate::dtype::OffsetBuilderPType;
     use crate::dtype::PType::I32;
     use crate::executor::VortexSessionExecute;
     use crate::scalar::Scalar;
@@ -519,7 +519,7 @@ mod tests {
         assert_eq!(list_array.list_elements_at(2).unwrap().len(), 3);
     }
 
-    fn test_extend_builder_gen<O: ListOffsetPType>() {
+    fn test_extend_builder_gen<O: OffsetBuilderPType>() {
         let list = ListArray::from_iter_opt_slow::<O, _, _>(
             [Some(vec![0, 1, 2]), None, Some(vec![4, 5])],
             Arc::new(I32.into()),

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -174,6 +174,94 @@ impl<O: IntegerPType> ListBuilder<O> {
 
         element_dtype
     }
+
+    /// Appends the values of a [`List`]-encoded `array` to this builder.
+    ///
+    /// List encodings dispatch here through
+    /// [`match_each_list_builder!`](crate::match_each_list_builder) because the concrete list
+    /// builders are generic over their offset integer type, which cannot be named through a
+    /// `dyn ArrayBuilder`.
+    pub fn append_list_array(
+        &mut self,
+        array: ArrayView<'_, List>,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<()> {
+        if array.is_empty() {
+            return Ok(());
+        }
+
+        self.nulls
+            .append_validity_mask(&array.validity()?.execute_mask(array.len(), ctx)?);
+
+        let num_lists = array.len();
+        let offsets = array.offsets().clone().execute::<PrimitiveArray>(ctx)?;
+        match_each_integer_ptype!(offsets.ptype(), |OffsetType| {
+            let offsets = offsets.as_slice::<OffsetType>();
+            let first: usize = offsets[0].as_();
+            let last: usize = offsets[num_lists].as_();
+
+            // Lists in a `ListArray` are contiguous, so the referenced elements can be appended
+            // in bulk and the offsets rebased onto this builder's elements.
+            let elements_base = self.elements_builder.len();
+            if last > first {
+                self.elements_builder.reserve_exact(last - first);
+                array
+                    .elements()
+                    .slice(first..last)?
+                    .append_to_builder(self.elements_builder.as_mut(), ctx)?;
+            }
+
+            self.offsets_builder.reserve_exact(num_lists);
+            let mut offsets_range = self.offsets_builder.uninit_range(num_lists);
+            for i in 0..num_lists {
+                let end: usize = offsets[i + 1].as_();
+                offsets_range.set_value(
+                    i,
+                    O::from_usize(end - first + elements_base)
+                        .vortex_expect("Failed to convert offset"),
+                );
+            }
+            // SAFETY: We have initialized all `num_lists` values, and since the `offsets` array is
+            // non-nullable, we are done.
+            unsafe { offsets_range.finish() };
+        });
+        Ok(())
+    }
+
+    /// Appends the values of a [`ListView`]-encoded `array` to this builder.
+    ///
+    /// See [`append_list_array`](Self::append_list_array); this is the same hook for the canonical
+    /// [`ListViewArray`](crate::arrays::ListViewArray) encoding.
+    pub fn append_listview_array(
+        &mut self,
+        array: ArrayView<'_, ListView>,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<()> {
+        if array.is_empty() {
+            return Ok(());
+        }
+
+        self.nulls
+            .append_validity_mask(&array.validity()?.execute_mask(array.len(), ctx)?);
+
+        // Note that `ListViewArray` has `n` offsets and sizes, not `n+1` offsets like `ListArray`.
+        let elements = array.elements();
+        let offsets = array.offsets().clone().execute::<PrimitiveArray>(ctx)?;
+        let sizes = array.sizes().clone().execute::<PrimitiveArray>(ctx)?;
+
+        match_each_integer_ptype!(offsets.ptype(), |OffsetType| {
+            match_each_integer_ptype!(sizes.ptype(), |SizeType| {
+                extend_from_listview(
+                    self,
+                    elements,
+                    offsets.as_slice::<OffsetType>(),
+                    sizes.as_slice::<SizeType>(),
+                    ctx,
+                )?
+            })
+        });
+        Ok(())
+    }
 }
 
 /// Appends `ListViewArray`-layout lists (`n` offsets and sizes) into a [`ListBuilder`], converting
@@ -295,84 +383,6 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
             .execute::<ListViewArray>(ctx)
             .vortex_expect("list builder should canonicalize to listview");
         Canonical::List(listview)
-    }
-
-    fn append_list_array(
-        &mut self,
-        array: ArrayView<'_, List>,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<()> {
-        if array.is_empty() {
-            return Ok(());
-        }
-
-        self.nulls
-            .append_validity_mask(&array.validity()?.execute_mask(array.len(), ctx)?);
-
-        let num_lists = array.len();
-        let offsets = array.offsets().clone().execute::<PrimitiveArray>(ctx)?;
-        match_each_integer_ptype!(offsets.ptype(), |OffsetType| {
-            let offsets = offsets.as_slice::<OffsetType>();
-            let first: usize = offsets[0].as_();
-            let last: usize = offsets[num_lists].as_();
-
-            // Lists in a `ListArray` are contiguous, so the referenced elements can be appended
-            // in bulk and the offsets rebased onto this builder's elements.
-            let elements_base = self.elements_builder.len();
-            if last > first {
-                self.elements_builder.reserve_exact(last - first);
-                array
-                    .elements()
-                    .slice(first..last)?
-                    .append_to_builder(self.elements_builder.as_mut(), ctx)?;
-            }
-
-            self.offsets_builder.reserve_exact(num_lists);
-            let mut offsets_range = self.offsets_builder.uninit_range(num_lists);
-            for i in 0..num_lists {
-                let end: usize = offsets[i + 1].as_();
-                offsets_range.set_value(
-                    i,
-                    O::from_usize(end - first + elements_base)
-                        .vortex_expect("Failed to convert offset"),
-                );
-            }
-            // SAFETY: We have initialized all `num_lists` values, and since the `offsets` array is
-            // non-nullable, we are done.
-            unsafe { offsets_range.finish() };
-        });
-        Ok(())
-    }
-
-    fn append_listview_array(
-        &mut self,
-        array: ArrayView<'_, ListView>,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<()> {
-        if array.is_empty() {
-            return Ok(());
-        }
-
-        self.nulls
-            .append_validity_mask(&array.validity()?.execute_mask(array.len(), ctx)?);
-
-        // Note that `ListViewArray` has `n` offsets and sizes, not `n+1` offsets like `ListArray`.
-        let elements = array.elements();
-        let offsets = array.offsets().clone().execute::<PrimitiveArray>(ctx)?;
-        let sizes = array.sizes().clone().execute::<PrimitiveArray>(ctx)?;
-
-        match_each_integer_ptype!(offsets.ptype(), |OffsetType| {
-            match_each_integer_ptype!(sizes.ptype(), |SizeType| {
-                extend_from_listview(
-                    self,
-                    elements,
-                    offsets.as_slice::<OffsetType>(),
-                    sizes.as_slice::<SizeType>(),
-                    ctx,
-                )?
-            })
-        });
-        Ok(())
     }
 }
 

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -31,15 +31,16 @@ use crate::builders::PrimitiveBuilder;
 use crate::builders::builder_with_capacity;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
+use crate::dtype::ListOffsetPType;
 use crate::dtype::Nullability;
 use crate::dtype::Nullability::NonNullable;
 use crate::match_each_integer_ptype;
 use crate::scalar::ListScalar;
 use crate::scalar::Scalar;
 
-/// The builder for building a [`ListArray`], parametrized by the [`IntegerPType`] of the `offsets`
-/// builder.
-pub struct ListBuilder<O: IntegerPType> {
+/// The builder for building a [`ListArray`], parametrized by the [`ListOffsetPType`] of the
+/// `offsets` builder.
+pub struct ListBuilder<O: ListOffsetPType> {
     /// The [`DType`] of the [`ListArray`]. This **must** be a [`DType::List`].
     dtype: DType,
 
@@ -53,7 +54,7 @@ pub struct ListBuilder<O: IntegerPType> {
     nulls: LazyBitBufferBuilder,
 }
 
-impl<O: IntegerPType> ListBuilder<O> {
+impl<O: ListOffsetPType> ListBuilder<O> {
     /// Creates a new `ListBuilder` with a capacity of [`DEFAULT_BUILDER_CAPACITY`].
     pub fn new(value_dtype: Arc<DType>, nullability: Nullability) -> Self {
         Self::with_capacity(
@@ -274,7 +275,7 @@ fn extend_from_listview<O, OffsetType, SizeType>(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()>
 where
-    O: IntegerPType,
+    O: ListOffsetPType,
     OffsetType: IntegerPType,
     SizeType: IntegerPType,
 {
@@ -313,7 +314,7 @@ where
     Ok(())
 }
 
-impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
+impl<O: ListOffsetPType> ArrayBuilder for ListBuilder<O> {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -411,7 +412,7 @@ mod tests {
     use crate::builders::list::ListArray;
     use crate::builders::list::ListBuilder;
     use crate::dtype::DType;
-    use crate::dtype::IntegerPType;
+    use crate::dtype::ListOffsetPType;
     use crate::dtype::Nullability;
     use crate::dtype::PType::I32;
     use crate::executor::VortexSessionExecute;
@@ -518,7 +519,7 @@ mod tests {
         assert_eq!(list_array.list_elements_at(2).unwrap().len(), 3);
     }
 
-    fn test_extend_builder_gen<O: IntegerPType>() {
+    fn test_extend_builder_gen<O: ListOffsetPType>() {
         let list = ListArray::from_iter_opt_slow::<O, _, _>(
             [Some(vec![0, 1, 2]), None, Some(vec![4, 5])],
             Arc::new(I32.into()),
@@ -607,19 +608,20 @@ mod tests {
 
         // A `ListViewBuilder` with non-`u64` (including signed) offset and size types must work
         // for both source encodings.
-        let mut lv_u32_u8 = ListViewBuilder::<u32, u8>::with_capacity(elem_dtype(), Nullable, 8, 4);
-        list.append_to_builder(&mut lv_u32_u8, &mut ctx)?;
-        assert_arrays_eq!(lv_u32_u8.finish(), list, &mut ctx);
+        let mut lv_u64_u32 =
+            ListViewBuilder::<u64, u32>::with_capacity(elem_dtype(), Nullable, 8, 4);
+        list.append_to_builder(&mut lv_u64_u32, &mut ctx)?;
+        assert_arrays_eq!(lv_u64_u32.finish(), list, &mut ctx);
 
-        let mut lv_i32_i16 =
-            ListViewBuilder::<i32, i16>::with_capacity(elem_dtype(), Nullable, 8, 4);
-        list.append_to_builder(&mut lv_i32_i16, &mut ctx)?;
-        assert_arrays_eq!(lv_i32_i16.finish(), list, &mut ctx);
+        let mut lv_i64_i32 =
+            ListViewBuilder::<i64, i32>::with_capacity(elem_dtype(), Nullable, 8, 4);
+        list.append_to_builder(&mut lv_i64_i32, &mut ctx)?;
+        assert_arrays_eq!(lv_i64_i32.finish(), list, &mut ctx);
 
-        let mut lv_u16_u16 =
-            ListViewBuilder::<u16, u16>::with_capacity(elem_dtype(), Nullable, 8, 4);
-        listview.append_to_builder(&mut lv_u16_u16, &mut ctx)?;
-        assert_arrays_eq!(lv_u16_u16.finish(), list, &mut ctx);
+        let mut lv_u32_u32 =
+            ListViewBuilder::<u32, u32>::with_capacity(elem_dtype(), Nullable, 8, 4);
+        listview.append_to_builder(&mut lv_u32_u32, &mut ctx)?;
+        assert_arrays_eq!(lv_u32_u32.finish(), list, &mut ctx);
 
         // Both source encodings appended into `ListBuilder`s with non-`u64` (including signed)
         // offset types.
@@ -627,9 +629,9 @@ mod tests {
         list.append_to_builder(&mut list_builder, &mut ctx)?;
         assert_arrays_eq!(list_builder.finish(), list, &mut ctx);
 
-        let mut list_builder_i16 = ListBuilder::<i16>::with_capacity(elem_dtype(), Nullable, 8, 4);
-        listview.append_to_builder(&mut list_builder_i16, &mut ctx)?;
-        assert_arrays_eq!(list_builder_i16.finish(), list, &mut ctx);
+        let mut list_builder_i32 = ListBuilder::<i32>::with_capacity(elem_dtype(), Nullable, 8, 4);
+        listview.append_to_builder(&mut list_builder_i32, &mut ctx)?;
+        assert_arrays_eq!(list_builder_i32.finish(), list, &mut ctx);
 
         Ok(())
     }
@@ -666,13 +668,9 @@ mod tests {
 
     #[test]
     fn test_extend_builder() {
-        test_extend_builder_gen::<i8>();
-        test_extend_builder_gen::<i16>();
         test_extend_builder_gen::<i32>();
         test_extend_builder_gen::<i64>();
 
-        test_extend_builder_gen::<u8>();
-        test_extend_builder_gen::<u16>();
         test_extend_builder_gen::<u32>();
         test_extend_builder_gen::<u64>();
     }

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -39,21 +39,22 @@ use crate::builders::lazy_null_builder::LazyBitBufferBuilder;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
+use crate::dtype::ListOffsetPType;
 use crate::dtype::Nullability;
 use crate::match_each_integer_ptype;
 use crate::scalar::ListScalar;
 use crate::scalar::Scalar;
 
-/// A builder for creating [`ListViewArray`] instances, parameterized by the [`IntegerPType`] of
-/// the `offsets` and the `sizes` builders.
+/// A builder for creating [`ListViewArray`] instances, parameterized by the [`ListOffsetPType`]
+/// of the `offsets` and the `sizes` builders.
 ///
 /// This builder tracks both offsets and sizes using potentially different integer types for memory
 /// efficiency. For example, you might use `u64` for offsets but only `u8` for sizes if your lists
 /// are small.
 ///
-/// Any combination of [`IntegerPType`] types are valid, as long as the type of `sizes` can fit into
-/// the type of `offsets`.
-pub struct ListViewBuilder<O: IntegerPType, S: IntegerPType> {
+/// Any combination of [`ListOffsetPType`] types is valid, as long as the type of `sizes` can fit
+/// into the type of `offsets`.
+pub struct ListViewBuilder<O: ListOffsetPType, S: ListOffsetPType> {
     /// The [`DType`] of the [`ListViewArray`]. This **must** be a [`DType::List`].
     dtype: DType,
 
@@ -70,7 +71,7 @@ pub struct ListViewBuilder<O: IntegerPType, S: IntegerPType> {
     nulls: LazyBitBufferBuilder,
 }
 
-impl<O: IntegerPType, S: IntegerPType> ListViewBuilder<O, S> {
+impl<O: ListOffsetPType, S: ListOffsetPType> ListViewBuilder<O, S> {
     /// Creates a new `ListViewBuilder` with a capacity of [`DEFAULT_BUILDER_CAPACITY`].
     pub fn new(element_dtype: Arc<DType>, nullability: Nullability) -> Self {
         Self::with_capacity(
@@ -325,7 +326,7 @@ impl<O: IntegerPType, S: IntegerPType> ListViewBuilder<O, S> {
     }
 }
 
-impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
+impl<O: ListOffsetPType, S: ListOffsetPType> ArrayBuilder for ListViewBuilder<O, S> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -424,8 +425,8 @@ fn extend_from_list<O, S, OffsetType>(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()>
 where
-    O: IntegerPType,
-    S: IntegerPType,
+    O: ListOffsetPType,
+    S: ListOffsetPType,
     OffsetType: IntegerPType,
 {
     let num_lists = offsets.len() - 1;
@@ -614,10 +615,10 @@ mod tests {
     #[test]
     fn test_different_offset_size_types() {
         let mut ctx = array_session().create_execution_ctx();
-        // Test u32 offsets with u8 sizes.
+        // Test u64 offsets with u32 sizes.
         let dtype: Arc<DType> = Arc::new(I32.into());
         let mut builder =
-            ListViewBuilder::<u32, u8>::with_capacity(Arc::clone(&dtype), NonNullable, 0, 0);
+            ListViewBuilder::<u64, u32>::with_capacity(Arc::clone(&dtype), NonNullable, 0, 0);
 
         builder
             .append_value(
@@ -658,10 +659,10 @@ mod tests {
             &mut ctx
         );
 
-        // Test u64 offsets with u16 sizes.
+        // Test i64 offsets with i32 sizes.
         let dtype2: Arc<DType> = Arc::new(I32.into());
         let mut builder2 =
-            ListViewBuilder::<u64, u16>::with_capacity(Arc::clone(&dtype2), NonNullable, 0, 0);
+            ListViewBuilder::<i64, i32>::with_capacity(Arc::clone(&dtype2), NonNullable, 0, 0);
 
         for i in 0..5 {
             builder2
@@ -864,7 +865,7 @@ mod tests {
         assert!(!source.is_zero_copy_to_list());
 
         let mut builder =
-            ListViewBuilder::<u32, u8>::with_capacity(Arc::clone(&dtype), Nullable, 0, 0);
+            ListViewBuilder::<u32, u32>::with_capacity(Arc::clone(&dtype), Nullable, 0, 0);
         builder
             .append_listview_array(source.as_view(), &mut ctx)
             .unwrap();

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -231,6 +231,98 @@ impl<O: IntegerPType, S: IntegerPType> ListViewBuilder<O, S> {
 
         element_dtype
     }
+
+    /// Appends the values of a [`List`]-encoded `array` to this builder.
+    ///
+    /// List encodings dispatch here through
+    /// [`match_each_list_builder!`](crate::match_each_list_builder) because the concrete list
+    /// builders are generic over their offset/size integer types, which cannot be named through a
+    /// `dyn ArrayBuilder`.
+    pub fn append_list_array(
+        &mut self,
+        array: ArrayView<'_, List>,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<()> {
+        if array.is_empty() {
+            return Ok(());
+        }
+
+        self.nulls
+            .append_validity_mask(&array.validity()?.execute_mask(array.len(), ctx)?);
+
+        let offsets = array.offsets().clone().execute::<PrimitiveArray>(ctx)?;
+        match_each_integer_ptype!(offsets.ptype(), |OffsetType| {
+            extend_from_list(
+                self,
+                array.elements(),
+                offsets.as_slice::<OffsetType>(),
+                ctx,
+            )?
+        });
+        Ok(())
+    }
+
+    /// Appends the values of a [`ListView`]-encoded `array` to this builder.
+    ///
+    /// See [`append_list_array`](Self::append_list_array); this is the same hook for the canonical
+    /// [`ListViewArray`] encoding.
+    pub fn append_listview_array(
+        &mut self,
+        array: ArrayView<'_, ListView>,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<()> {
+        if array.is_empty() {
+            return Ok(());
+        }
+
+        // Normalize to an exact zero-copy-to-list layout and then bulk append. This avoids the
+        // very expensive scalar_at-per-list path for overlapping / out-of-order list views.
+        let listview = array
+            .into_owned()
+            .rebuild(ListViewRebuildMode::MakeExact, ctx)?;
+        debug_assert!(listview.is_zero_copy_to_list());
+
+        self.nulls
+            .append_validity_mask(&array.validity()?.execute_mask(array.len(), ctx)?);
+
+        // Bulk append the new elements (which should have no gaps or overlaps).
+        let old_elements_len = self.elements_builder.len();
+        self.elements_builder
+            .reserve_exact(listview.elements().len());
+        listview
+            .elements()
+            .append_to_builder(self.elements_builder.as_mut(), ctx)?;
+        let new_elements_len = self.elements_builder.len();
+
+        // Reserve enough space for the new views.
+        let extend_length = listview.len();
+        self.sizes_builder.reserve_exact(extend_length);
+        self.offsets_builder.reserve_exact(extend_length);
+
+        // The incoming sizes might have a different type than the builder, so we need to cast.
+        let cast_sizes = listview
+            .sizes()
+            .clone()
+            .cast(self.sizes_builder.dtype().clone())?;
+        cast_sizes.append_to_builder(&mut self.sizes_builder, ctx)?;
+
+        // Now we need to adjust all of the offsets by adding the current number of elements in the
+        // builder.
+        let uninit_range = self.offsets_builder.uninit_range(extend_length);
+
+        // This should be cheap because we didn't compress after rebuilding.
+        let new_offsets = listview.offsets().clone().execute::<PrimitiveArray>(ctx)?;
+
+        match_each_integer_ptype!(new_offsets.ptype(), |A| {
+            adjust_and_extend_offsets::<O, A>(
+                uninit_range,
+                new_offsets,
+                old_elements_len,
+                new_elements_len,
+            );
+        });
+        Ok(())
+    }
 }
 
 impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
@@ -317,88 +409,6 @@ impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
 
     fn finish_into_canonical(&mut self, _ctx: &mut ExecutionCtx) -> Canonical {
         Canonical::List(self.finish_into_listview())
-    }
-
-    fn append_list_array(
-        &mut self,
-        array: ArrayView<'_, List>,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<()> {
-        if array.is_empty() {
-            return Ok(());
-        }
-
-        self.nulls
-            .append_validity_mask(&array.validity()?.execute_mask(array.len(), ctx)?);
-
-        let offsets = array.offsets().clone().execute::<PrimitiveArray>(ctx)?;
-        match_each_integer_ptype!(offsets.ptype(), |OffsetType| {
-            extend_from_list(
-                self,
-                array.elements(),
-                offsets.as_slice::<OffsetType>(),
-                ctx,
-            )?
-        });
-        Ok(())
-    }
-
-    fn append_listview_array(
-        &mut self,
-        array: ArrayView<'_, ListView>,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<()> {
-        if array.is_empty() {
-            return Ok(());
-        }
-
-        // Normalize to an exact zero-copy-to-list layout and then bulk append. This avoids the
-        // very expensive scalar_at-per-list path for overlapping / out-of-order list views.
-        let listview = array
-            .into_owned()
-            .rebuild(ListViewRebuildMode::MakeExact, ctx)?;
-        debug_assert!(listview.is_zero_copy_to_list());
-
-        self.nulls
-            .append_validity_mask(&array.validity()?.execute_mask(array.len(), ctx)?);
-
-        // Bulk append the new elements (which should have no gaps or overlaps).
-        let old_elements_len = self.elements_builder.len();
-        self.elements_builder
-            .reserve_exact(listview.elements().len());
-        listview
-            .elements()
-            .append_to_builder(self.elements_builder.as_mut(), ctx)?;
-        let new_elements_len = self.elements_builder.len();
-
-        // Reserve enough space for the new views.
-        let extend_length = listview.len();
-        self.sizes_builder.reserve_exact(extend_length);
-        self.offsets_builder.reserve_exact(extend_length);
-
-        // The incoming sizes might have a different type than the builder, so we need to cast.
-        let cast_sizes = listview
-            .sizes()
-            .clone()
-            .cast(self.sizes_builder.dtype().clone())?;
-        cast_sizes.append_to_builder(&mut self.sizes_builder, ctx)?;
-
-        // Now we need to adjust all of the offsets by adding the current number of elements in the
-        // builder.
-        let uninit_range = self.offsets_builder.uninit_range(extend_length);
-
-        // This should be cheap because we didn't compress after rebuilding.
-        let new_offsets = listview.offsets().clone().execute::<PrimitiveArray>(ctx)?;
-
-        match_each_integer_ptype!(new_offsets.ptype(), |A| {
-            adjust_and_extend_offsets::<O, A>(
-                uninit_range,
-                new_offsets,
-                old_elements_len,
-                new_elements_len,
-            );
-        });
-        Ok(())
     }
 }
 

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -39,22 +39,22 @@ use crate::builders::lazy_null_builder::LazyBitBufferBuilder;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
-use crate::dtype::ListOffsetPType;
 use crate::dtype::Nullability;
+use crate::dtype::OffsetBuilderPType;
 use crate::match_each_integer_ptype;
 use crate::scalar::ListScalar;
 use crate::scalar::Scalar;
 
-/// A builder for creating [`ListViewArray`] instances, parameterized by the [`ListOffsetPType`]
+/// A builder for creating [`ListViewArray`] instances, parameterized by the [`OffsetBuilderPType`]
 /// of the `offsets` and the `sizes` builders.
 ///
 /// This builder tracks both offsets and sizes using potentially different integer types for memory
 /// efficiency. For example, you might use `u64` for offsets but only `u8` for sizes if your lists
 /// are small.
 ///
-/// Any combination of [`ListOffsetPType`] types is valid, as long as the type of `sizes` can fit
+/// Any combination of [`OffsetBuilderPType`] types is valid, as long as the type of `sizes` can fit
 /// into the type of `offsets`.
-pub struct ListViewBuilder<O: ListOffsetPType, S: ListOffsetPType> {
+pub struct ListViewBuilder<O: OffsetBuilderPType, S: OffsetBuilderPType> {
     /// The [`DType`] of the [`ListViewArray`]. This **must** be a [`DType::List`].
     dtype: DType,
 
@@ -71,7 +71,7 @@ pub struct ListViewBuilder<O: ListOffsetPType, S: ListOffsetPType> {
     nulls: LazyBitBufferBuilder,
 }
 
-impl<O: ListOffsetPType, S: ListOffsetPType> ListViewBuilder<O, S> {
+impl<O: OffsetBuilderPType, S: OffsetBuilderPType> ListViewBuilder<O, S> {
     /// Creates a new `ListViewBuilder` with a capacity of [`DEFAULT_BUILDER_CAPACITY`].
     pub fn new(element_dtype: Arc<DType>, nullability: Nullability) -> Self {
         Self::with_capacity(
@@ -326,7 +326,7 @@ impl<O: ListOffsetPType, S: ListOffsetPType> ListViewBuilder<O, S> {
     }
 }
 
-impl<O: ListOffsetPType, S: ListOffsetPType> ArrayBuilder for ListViewBuilder<O, S> {
+impl<O: OffsetBuilderPType, S: OffsetBuilderPType> ArrayBuilder for ListViewBuilder<O, S> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -425,8 +425,8 @@ fn extend_from_list<O, S, OffsetType>(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<()>
 where
-    O: ListOffsetPType,
-    S: ListOffsetPType,
+    O: OffsetBuilderPType,
+    S: OffsetBuilderPType,
     OffsetType: IntegerPType,
 {
     let num_lists = offsets.len() - 1;

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -197,14 +197,14 @@ pub trait ArrayBuilder: Send {
 
 /// Matches a `&mut dyn ArrayBuilder` against every concrete list builder type, i.e. every
 /// [`ListBuilder`]`<O>` and [`ListViewBuilder`]`<O, S>` instantiation over the
-/// [`ListOffsetPType`](crate::dtype::ListOffsetPType) offset/size types (`u32`, `u64`, `i32`,
+/// [`OffsetBuilderPType`](crate::dtype::OffsetBuilderPType) offset/size types (`u32`, `u64`, `i32`,
 /// `i64`).
 ///
 /// Binds the downcast builder as `$builder` and evaluates `$body` with it, yielding
 /// `Some($body)`; yields `None` when the builder is not a list builder. List encodings dispatch
 /// through this matcher because the concrete list builders are generic over their offset/size
 /// integer types, which cannot be named through a `dyn ArrayBuilder`. The matcher is exhaustive
-/// because `ListOffsetPType` is sealed, so no other instantiations can be constructed.
+/// because `OffsetBuilderPType` is sealed, so no other instantiations can be constructed.
 #[macro_export]
 macro_rules! match_each_list_builder {
     ($dyn_builder:expr, | $builder:ident | $body:expr) => {{

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -34,14 +34,10 @@ use std::any::Any;
 use std::sync::Arc;
 
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
 use vortex_mask::Mask;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
-use crate::array::ArrayView;
-use crate::arrays::List;
-use crate::arrays::ListView;
 use crate::canonical::Canonical;
 use crate::dtype::DType;
 use crate::match_each_decimal_value_type;
@@ -197,39 +193,98 @@ pub trait ArrayBuilder: Send {
     /// then converts it to canonical form. Specific builders can override this with optimized
     /// implementations that avoid the intermediate [`ArrayRef`] creation.
     fn finish_into_canonical(&mut self, ctx: &mut ExecutionCtx) -> Canonical;
+}
 
-    /// Appends the values of a [`List`]-encoded `array` to this builder.
-    ///
-    /// Only list-typed builders support this; the default implementation returns an error. List
-    /// encodings dispatch through this method because the concrete list builders are generic over
-    /// their offset/size integer types, which cannot be named through a `dyn ArrayBuilder`.
-    fn append_list_array(
-        &mut self,
-        array: ArrayView<'_, List>,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<()> {
-        vortex_bail!(
-            "cannot append a List array of dtype {} to a {} builder",
-            array.dtype(),
-            self.dtype()
-        )
-    }
+/// Matches a `&mut dyn ArrayBuilder` against every concrete list builder type, i.e. every
+/// [`ListBuilder`]`<O>` and [`ListViewBuilder`]`<O, S>` instantiation over the integer
+/// offset/size types.
+///
+/// Binds the downcast builder as `$builder` and evaluates `$body` with it, yielding
+/// `Some($body)`; yields `None` when the builder is not a list builder. List encodings dispatch
+/// through this matcher because the concrete list builders are generic over their offset/size
+/// integer types, which cannot be named through a `dyn ArrayBuilder`.
+#[macro_export]
+macro_rules! match_each_list_builder {
+    ($dyn_builder:expr, | $builder:ident | $body:expr) => {{
+        let __dyn_builder: &mut dyn $crate::builders::ArrayBuilder = $dyn_builder;
+        match $crate::__match_each_list_builder!(
+            __dyn_builder,
+            $builder,
+            $body,
+            [u8, u16, u32, u64, i8, i16, i32, i64]
+        ) {
+            ::core::option::Option::Some(__result) => ::core::option::Option::Some(__result),
+            ::core::option::Option::None => $crate::__match_each_listview_builder!(
+                __dyn_builder,
+                $builder,
+                $body,
+                [u8, u16, u32, u64, i8, i16, i32, i64]
+            ),
+        }
+    }};
+}
 
-    /// Appends the values of a [`ListView`]-encoded `array` to this builder.
-    ///
-    /// See [`append_list_array`](Self::append_list_array); this is the same hook for the canonical
-    /// [`ListViewArray`](crate::arrays::ListViewArray) encoding.
-    fn append_listview_array(
-        &mut self,
-        array: ArrayView<'_, ListView>,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<()> {
-        vortex_bail!(
-            "cannot append a ListView array of dtype {} to a {} builder",
-            array.dtype(),
-            self.dtype()
-        )
-    }
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __match_each_list_builder {
+    ($target:ident, $builder:ident, $body:expr, []) => {
+        ::core::option::Option::None
+    };
+    ($target:ident, $builder:ident, $body:expr, [$offset:ty $(, $rest:ty)*]) => {
+        if let ::core::option::Option::Some($builder) =
+            $crate::builders::ArrayBuilder::as_any_mut($target)
+                .downcast_mut::<$crate::builders::ListBuilder<$offset>>()
+        {
+            ::core::option::Option::Some($body)
+        } else {
+            $crate::__match_each_list_builder!($target, $builder, $body, [$($rest),*])
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __match_each_listview_builder {
+    ($target:ident, $builder:ident, $body:expr, []) => {
+        ::core::option::Option::None
+    };
+    ($target:ident, $builder:ident, $body:expr, [$offset:ty $(, $rest:ty)*]) => {
+        match $crate::__match_each_listview_builder_size!(
+            $target,
+            $builder,
+            $body,
+            $offset,
+            [u8, u16, u32, u64, i8, i16, i32, i64]
+        ) {
+            ::core::option::Option::Some(__result) => ::core::option::Option::Some(__result),
+            ::core::option::Option::None => $crate::__match_each_listview_builder!(
+                $target,
+                $builder,
+                $body,
+                [$($rest),*]
+            ),
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __match_each_listview_builder_size {
+    ($target:ident, $builder:ident, $body:expr, $offset:ty, []) => {
+        ::core::option::Option::None
+    };
+    ($target:ident, $builder:ident, $body:expr, $offset:ty, [$size:ty $(, $rest:ty)*]) => {
+        if let ::core::option::Option::Some($builder) =
+            $crate::builders::ArrayBuilder::as_any_mut($target)
+                .downcast_mut::<$crate::builders::ListViewBuilder<$offset, $size>>()
+        {
+            ::core::option::Option::Some($body)
+        } else {
+            $crate::__match_each_listview_builder_size!(
+                $target, $builder, $body, $offset, [$($rest),*]
+            )
+        }
+    };
 }
 
 /// Construct a new canonical builder for the given [`DType`].

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -196,13 +196,15 @@ pub trait ArrayBuilder: Send {
 }
 
 /// Matches a `&mut dyn ArrayBuilder` against every concrete list builder type, i.e. every
-/// [`ListBuilder`]`<O>` and [`ListViewBuilder`]`<O, S>` instantiation over the integer
-/// offset/size types.
+/// [`ListBuilder`]`<O>` and [`ListViewBuilder`]`<O, S>` instantiation over the
+/// [`ListOffsetPType`](crate::dtype::ListOffsetPType) offset/size types (`u32`, `u64`, `i32`,
+/// `i64`).
 ///
 /// Binds the downcast builder as `$builder` and evaluates `$body` with it, yielding
 /// `Some($body)`; yields `None` when the builder is not a list builder. List encodings dispatch
 /// through this matcher because the concrete list builders are generic over their offset/size
-/// integer types, which cannot be named through a `dyn ArrayBuilder`.
+/// integer types, which cannot be named through a `dyn ArrayBuilder`. The matcher is exhaustive
+/// because `ListOffsetPType` is sealed, so no other instantiations can be constructed.
 #[macro_export]
 macro_rules! match_each_list_builder {
     ($dyn_builder:expr, | $builder:ident | $body:expr) => {{
@@ -211,14 +213,14 @@ macro_rules! match_each_list_builder {
             __dyn_builder,
             $builder,
             $body,
-            [u8, u16, u32, u64, i8, i16, i32, i64]
+            [u32, u64, i32, i64]
         ) {
             ::core::option::Option::Some(__result) => ::core::option::Option::Some(__result),
             ::core::option::Option::None => $crate::__match_each_listview_builder!(
                 __dyn_builder,
                 $builder,
                 $body,
-                [u8, u16, u32, u64, i8, i16, i32, i64]
+                [u32, u64, i32, i64]
             ),
         }
     }};
@@ -254,7 +256,7 @@ macro_rules! __match_each_listview_builder {
             $builder,
             $body,
             $offset,
-            [u8, u16, u32, u64, i8, i16, i32, i64]
+            [u32, u64, i32, i64]
         ) {
             ::core::option::Option::Some(__result) => ::core::option::Option::Some(__result),
             ::core::option::Option::None => $crate::__match_each_listview_builder!(

--- a/vortex-array/src/dtype/ptype.rs
+++ b/vortex-array/src/dtype/ptype.rs
@@ -91,6 +91,30 @@ pub trait UnsignedPType: IntegerPType + Unsigned {}
 /// Implements [`UnsignedPType`] for all possible `T` that have the correct bounds.
 impl<T> UnsignedPType for T where T: IntegerPType + Unsigned {}
 
+/// Trait for the integer types that can back a list builder's `offsets` and `sizes`: `u32`,
+/// `i32`, `u64`, and `i64`.
+///
+/// This trait is sealed and cannot be implemented for any other type. Restricting the set of
+/// widths keeps the concrete [`ListBuilder`](crate::builders::ListBuilder) and
+/// [`ListViewBuilder`](crate::builders::ListViewBuilder) instantiations small enough for
+/// [`match_each_list_builder!`](crate::match_each_list_builder) to enumerate them.
+pub trait ListOffsetPType: IntegerPType + list_offset_sealed::Sealed {}
+
+mod list_offset_sealed {
+    pub trait Sealed {}
+}
+
+macro_rules! impl_list_offset_ptype {
+    ($($T:ty),*) => {
+        $(
+            impl list_offset_sealed::Sealed for $T {}
+            impl ListOffsetPType for $T {}
+        )*
+    };
+}
+
+impl_list_offset_ptype!(u32, i32, u64, i64);
+
 /// A trait for native Rust types that correspond 1:1 to a PType.
 ///
 /// You can use the `match_each_native_ptype` macro to help with writing "generic" code over
@@ -681,6 +705,25 @@ macro_rules! match_smallest_offset_type {
             type $offset_type = u16;
             $body
         } else if n_elements <= u32::MAX as usize {
+            type $offset_type = u32;
+            $body
+        } else {
+            assert!(u64::try_from(n_elements).is_ok());
+            type $offset_type = u64;
+            $body
+        }
+    }};
+}
+
+/// Macro to match the smallest [`ListOffsetPType`] able to index a given number of elements.
+///
+/// Like [`match_smallest_offset_type!`](crate::match_smallest_offset_type), but restricted to the
+/// unsigned types valid as list builder offsets (`u32` and `u64`).
+#[macro_export]
+macro_rules! match_smallest_list_offset_type {
+    ($n_elements:expr, | $offset_type:ident | $body:block) => {{
+        let n_elements = $n_elements;
+        if n_elements <= u32::MAX as usize {
             type $offset_type = u32;
             $body
         } else {

--- a/vortex-array/src/dtype/ptype.rs
+++ b/vortex-array/src/dtype/ptype.rs
@@ -98,22 +98,22 @@ impl<T> UnsignedPType for T where T: IntegerPType + Unsigned {}
 /// widths keeps the concrete [`ListBuilder`](crate::builders::ListBuilder) and
 /// [`ListViewBuilder`](crate::builders::ListViewBuilder) instantiations small enough for
 /// [`match_each_list_builder!`](crate::match_each_list_builder) to enumerate them.
-pub trait ListOffsetPType: IntegerPType + list_offset_sealed::Sealed {}
+pub trait OffsetBuilderPType: IntegerPType + offset_builder_sealed::Sealed {}
 
-mod list_offset_sealed {
+mod offset_builder_sealed {
     pub trait Sealed {}
 }
 
-macro_rules! impl_list_offset_ptype {
+macro_rules! impl_offset_builder_ptype {
     ($($T:ty),*) => {
         $(
-            impl list_offset_sealed::Sealed for $T {}
-            impl ListOffsetPType for $T {}
+            impl offset_builder_sealed::Sealed for $T {}
+            impl OffsetBuilderPType for $T {}
         )*
     };
 }
 
-impl_list_offset_ptype!(u32, i32, u64, i64);
+impl_offset_builder_ptype!(u32, i32, u64, i64);
 
 /// A trait for native Rust types that correspond 1:1 to a PType.
 ///
@@ -715,7 +715,7 @@ macro_rules! match_smallest_offset_type {
     }};
 }
 
-/// Macro to match the smallest [`ListOffsetPType`] able to index a given number of elements.
+/// Macro to match the smallest [`OffsetBuilderPType`] able to index a given number of elements.
 ///
 /// Like [`match_smallest_offset_type!`](crate::match_smallest_offset_type), but restricted to the
 /// unsigned types valid as list builder offsets (`u32` and `u64`).

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -242,13 +242,13 @@ async fn test_read_simple_with_spawn() {
     .into_array();
 
     let lists = ChunkedArray::from_iter([
-        ListArray::from_iter_slow::<i16, _>(
+        ListArray::from_iter_slow::<i32, _>(
             vec![vec![11, 12], vec![21, 22], vec![31, 32], vec![41, 42]],
             Arc::new(I32.into()),
         )
         .unwrap()
         .into_array(),
-        ListArray::from_iter_slow::<i8, _>(
+        ListArray::from_iter_slow::<i64, _>(
             vec![vec![51, 52], vec![61, 62], vec![71, 72], vec![81, 82]],
             Arc::new(I32.into()),
         )
@@ -1623,7 +1623,7 @@ async fn test_writer_with_complex_types() -> VortexResult<()> {
     let mut ctx = SESSION.create_execution_ctx();
     let strings = VarBinArray::from(vec!["hello", "world", "test"]).into_array();
     let numbers = buffer![100i32, 200, 300].into_array();
-    let lists = ListArray::from_iter_slow::<i16, _>(
+    let lists = ListArray::from_iter_slow::<i32, _>(
         vec![vec![1, 2], vec![3, 4, 5], vec![6]],
         Arc::new(I32.into()),
     )?;


### PR DESCRIPTION
In #8609 we have inverted the flow of the append_to_builder methods. The side effect of that is we match on the builders but for lists the number of match cases is excessive due to trait bounds being arbitrary integer types. Realistically types smaller than u32 are not that useful as they define the upper bound on the size of the array. This pr introduces `OffsetBuilderPType` which constraints the offset and sizes buffer types in ListBuilder.

We will use that on VarBinBuilder in a follow up