### PR TITLE
Make StructArray genuinely use the array_slots macro

### DIFF
--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -475,7 +475,6 @@ fn execute_sparse_struct(
         ),
     };
     let patch_values_as_struct = unresolved_patches.values().as_::<Struct>().into_owned();
-    let columns_patch_values = patch_values_as_struct.unmasked_fields();
     let names = patch_values_as_struct.names();
     let validity = top_level_fill_validity.patch(
         len,
@@ -494,8 +493,8 @@ fn execute_sparse_struct(
 
     Ok(StructArray::try_from_iter_with_validity(
         names.iter().zip_eq(
-            columns_patch_values
-                .iter()
+            patch_values_as_struct
+                .iter_unmasked_fields()
                 .cloned()
                 .zip_eq(fill_values)
                 .map(|(patch_values, fill_value)| unsafe {

--- a/vortex-array/src/aggregate_fn/fns/is_constant/struct_.rs
+++ b/vortex-array/src/aggregate_fn/fns/is_constant/struct_.rs
@@ -10,7 +10,7 @@ use crate::arrays::struct_::StructArrayExt;
 
 /// Check if a struct array is constant by checking each field independently.
 pub(super) fn check_struct_constant(s: &StructArray, ctx: &mut ExecutionCtx) -> VortexResult<bool> {
-    for field in s.unmasked_fields().iter() {
+    for field in s.iter_unmasked_fields() {
         if !is_constant(field, ctx)? {
             return Ok(false);
         }

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -89,11 +89,11 @@ impl<'a> SlotSlice<'a> {
     }
 
     /// Iterate the slots in order.
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = &'a ArrayRef> + use<'a> {
-        let expect = self.expect;
-        self.slots
-            .iter()
-            .map(move |slot| slot.as_ref().vortex_expect(expect))
+    pub fn iter(&self) -> SlotSliceIter<'a> {
+        SlotSliceIter {
+            inner: self.slots.iter(),
+            expect: self.expect,
+        }
     }
 
     /// Clone every slot into an owned `Vec`.
@@ -109,6 +109,49 @@ impl std::ops::Index<usize> for SlotSlice<'_> {
         self.slots[idx].as_ref().vortex_expect(self.expect)
     }
 }
+
+impl<'a> IntoIterator for SlotSlice<'a> {
+    type Item = &'a ArrayRef;
+    type IntoIter = SlotSliceIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator over the present slots of a [`SlotSlice`], yielding `&ArrayRef`.
+#[derive(Clone)]
+pub struct SlotSliceIter<'a> {
+    inner: std::slice::Iter<'a, Option<ArrayRef>>,
+    expect: &'static str,
+}
+
+impl<'a> Iterator for SlotSliceIter<'a> {
+    type Item = &'a ArrayRef;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|slot| slot.as_ref().vortex_expect(self.expect))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl DoubleEndedIterator for SlotSliceIter<'_> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next_back()
+            .map(|slot| slot.as_ref().vortex_expect(self.expect))
+    }
+}
+
+impl ExactSizeIterator for SlotSliceIter<'_> {}
 
 /// The public API trait for all Vortex arrays.
 ///

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -250,11 +250,11 @@ pub fn recursive_list_from_list_view(
             }
         }
         Canonical::Struct(struct_array) => {
-            let fields = struct_array.unmasked_fields();
-            let mut converted_fields = Vec::with_capacity(fields.len());
+            let mut converted_fields =
+                Vec::with_capacity(struct_array.iter_unmasked_fields().len());
             let mut any_changed = false;
 
-            for field in fields.iter() {
+            for field in struct_array.iter_unmasked_fields() {
                 let converted_field = recursive_list_from_list_view(field.clone(), ctx)?;
                 // Avoid cloning if elements didn't change.
                 any_changed |= !ArrayRef::ptr_eq(&converted_field, field);

--- a/vortex-array/src/arrays/masked/execute.rs
+++ b/vortex-array/src/arrays/masked/execute.rs
@@ -143,10 +143,16 @@ fn mask_validity_fixed_size_list(
 fn mask_validity_struct(array: StructArray, validity: Validity) -> VortexResult<StructArray> {
     let len = array.len();
     let new_validity = Validity::and(array.validity()?, validity)?;
-    let fields = array.unmasked_fields();
-    let struct_fields = array.struct_fields();
+    let struct_fields = array.struct_fields().clone();
     // SAFETY: We're only changing validity, not the data structure.
-    Ok(unsafe { StructArray::new_unchecked(fields, struct_fields.clone(), len, new_validity) })
+    Ok(unsafe {
+        StructArray::new_unchecked(
+            array.iter_unmasked_fields().cloned(),
+            struct_fields,
+            len,
+            new_validity,
+        )
+    })
 }
 
 fn mask_validity_union(array: UnionArray, validity: Validity) -> VortexResult<UnionArray> {

--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -182,7 +182,11 @@ pub(super) fn make_struct_slots(
     slots
 }
 
-pub trait StructArrayExt: TypedArrayRef<Struct> {
+/// Struct-specific accessors.
+///
+/// Slot accessors (`validity`, `fields`, `slots_view`) live on the generated
+/// [`StructArraySlotsExt`] supertrait; this trait layers struct-specific lookups on top.
+pub trait StructArrayExt: StructArraySlotsExt {
     fn nullability(&self) -> crate::dtype::Nullability {
         match self.as_ref().dtype() {
             DType::Struct(_, nullability) => *nullability,
@@ -195,25 +199,20 @@ pub trait StructArrayExt: TypedArrayRef<Struct> {
     }
 
     fn struct_validity(&self) -> Validity {
-        child_to_validity(
-            self.as_ref().slots()[StructSlots::VALIDITY].as_ref(),
-            self.nullability(),
-        )
+        child_to_validity(self.validity(), self.nullability())
     }
 
     fn iter_unmasked_fields(&self) -> impl Iterator<Item = &ArrayRef> + '_ {
-        self.as_ref().slots()[StructSlots::FIELDS_OFFSET..]
-            .iter()
-            .map(|s| s.as_ref().vortex_expect("StructArray field slot"))
+        self.fields().iter()
     }
 
     fn unmasked_fields(&self) -> Vec<ArrayRef> {
-        self.iter_unmasked_fields().cloned().collect()
+        self.fields().iter().cloned().collect()
     }
 
     fn unmasked_field(&self, idx: usize) -> &ArrayRef {
-        self.as_ref().slots()[StructSlots::FIELDS_OFFSET + idx]
-            .as_ref()
+        self.fields()
+            .get(idx)
             .vortex_expect("StructArray field slot")
     }
 

--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -202,7 +202,7 @@ pub trait StructArrayExt: StructArraySlotsExt {
         child_to_validity(self.validity(), self.nullability())
     }
 
-    fn iter_unmasked_fields(&self) -> impl Iterator<Item = &ArrayRef> + '_ {
+    fn iter_unmasked_fields(&self) -> impl ExactSizeIterator<Item = &ArrayRef> + '_ {
         self.fields().iter()
     }
 
@@ -553,7 +553,7 @@ impl Array<Struct> {
         if struct_validity.definitely_no_nulls() {
             return Self::try_new(
                 self.names().clone(),
-                self.unmasked_fields(),
+                self.iter_unmasked_fields().cloned(),
                 self.len(),
                 new_validity,
             );

--- a/vortex-array/src/arrays/struct_/compute/mask.rs
+++ b/vortex-array/src/arrays/struct_/compute/mask.rs
@@ -15,7 +15,7 @@ use crate::validity::Validity;
 impl MaskReduce for Struct {
     fn mask(array: ArrayView<'_, Struct>, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         StructArray::try_new_with_dtype(
-            array.unmasked_fields(),
+            array.iter_unmasked_fields().cloned(),
             array.struct_fields().clone(),
             array.len(),
             array.validity()?.and(Validity::Array(mask.clone()))?,

--- a/vortex-array/src/arrays/struct_/mod.rs
+++ b/vortex-array/src/arrays/struct_/mod.rs
@@ -3,6 +3,7 @@
 
 mod array;
 pub use array::StructArrayExt;
+pub use array::StructArraySlotsExt;
 pub use array::StructDataParts;
 pub use array::StructSlots;
 pub use array::StructSlotsView;

--- a/vortex-tui/src/browse/ui/layouts.rs
+++ b/vortex-tui/src/browse/ui/layouts.rs
@@ -176,8 +176,7 @@ fn render_array(app: &AppState, area: Rect, buf: &mut Buffer, is_stats_table: bo
         // Canonicalize each field once so the per-row `execute_scalar` calls below do not
         // re-decode the field encodings for every row.
         let field_arrays: Vec<ArrayRef> = struct_array
-            .unmasked_fields()
-            .iter()
+            .iter_unmasked_fields()
             .map(|field| {
                 field
                     .clone()


### PR DESCRIPTION
Previously StructSlots was only used for its two index constants; the
generated view, ext trait, and conversions were dead. Make StructArrayExt
a subtrait of the generated StructArraySlotsExt and route slot access
through the generated accessors, matching UnionArrayExt:

- struct_validity() uses the generated `validity()` slot accessor.
- iter_unmasked_fields() / unmasked_fields() / unmasked_field() use the
  generated `fields()` SlotSlice (zero-copy borrow) instead of indexing
  raw slots with hand-written vortex_expect.
- Export StructArraySlotsExt for parity with UnionArraySlotsExt.

Read paths are unchanged in cost (SlotSlice is a Copy borrow); this only
removes the duplicated hand-rolled slot indexing.

Signed-off-by: Joe Isaacs <joe.isaacs@live.co.uk>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017BF3K2eZTEnCsqMsN3wGtc