### PR TITLE
duckdb: don't push down aggregation over floats

### DIFF
--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -671,6 +671,19 @@ pub fn pushdown_projection_aggregates(
             debug!(%expr, %i, "failed to push down projection aggregate");
             return Ok(false);
         };
+
+        // TODO(myrrc): DuckDB treats NaN as a normal value ordered greater than
+        // everything which is substandard. vortex aggregations just skip nan.
+        // don't push aggregations on floats until resolved
+        // See slt/duckdb/nan_aggregates.slt.
+        let projection_id_usize: usize = projection_id.as_();
+        if bind_data.column_fields[projection_id_usize]
+            .dtype
+            .is_float()
+        {
+            return Ok(false);
+        }
+
         debug!(%expr, %projection_id, %i, "pushed down projection aggregate");
         aggregates.push(ColumnAggregate::Real {
             projection_id,

--- a/vortex-sqllogictest/slt/duckdb/nan_aggregates.slt
+++ b/vortex-sqllogictest/slt/duckdb/nan_aggregates.slt
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# Vortex aggregate pushdown must match DuckDB's NaN semantics
+
+include ../setup.slt.no
+
+statement ok
+COPY (
+    SELECT * FROM (VALUES
+        ('nan'::DOUBLE),
+        (1.0),
+        (2.0),
+        (CAST(NULL AS DOUBLE))
+    ) AS t(x)
+) TO '${WORK_DIR}/nan-agg.vortex';
+
+query TT
+EXPLAIN
+SELECT count(*), count(x), sum(x), min(x), max(x), avg(x)
+FROM '${WORK_DIR}/nan-agg.vortex';
+----
+<REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query II
+SELECT count(*), count(x) FROM '${WORK_DIR}/nan-agg.vortex';
+----
+4 3
+
+query RR
+SELECT sum(x), avg(x) FROM '${WORK_DIR}/nan-agg.vortex';
+----
+NaN NaN
+
+query RR
+SELECT min(x), max(x) FROM '${WORK_DIR}/nan-agg.vortex';
+----
+1 NaN


### PR DESCRIPTION
Duckdb's float NaN handling is substandard and conflicts with Vortex NaN
handling. To preserve output, disable float columns aggregate pushdown as
for now.