### PR TITLE
Only run benchmark env configuration after setup is complete

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -41,8 +41,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Setup benchmark environment
-        run: sudo bash scripts/setup-benchmark.sh
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -83,6 +81,9 @@ jobs:
           profiling_frequency: 199
           extra_args: "--debuginfo-strip=false"
           parca_agent_version: "0.49.0"
+
+      - name: Setup benchmark environment
+        run: sudo bash scripts/setup-benchmark.sh
 
       - name: Run ${{ matrix.benchmark.name }} benchmark (per-combination)
         if: matrix.benchmark.id == 'random-access-bench'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -55,8 +55,6 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
-      - name: Setup benchmark environment
-        run: sudo bash scripts/setup-benchmark.sh
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -95,6 +93,9 @@ jobs:
           profiling_frequency: 199
           extra_args: "--debuginfo-strip=false"
           parca_agent_version: "0.49.0"
+
+      - name: Setup benchmark environment
+        run: sudo bash scripts/setup-benchmark.sh
 
       - name: Run ${{ matrix.benchmark.name }} benchmark (per-combination)
         if: matrix.benchmark.id == 'random-access-bench'

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -69,8 +69,6 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
-      - name: Setup benchmark environment
-        run: sudo bash scripts/setup-benchmark.sh
       - uses: ./.github/actions/setup-prebuild
         with:
           enable-sccache: ${{ github.repository == 'vortex-data/vortex' && 'true' || 'false' }}
@@ -86,6 +84,8 @@ jobs:
         env:
           RUSTFLAGS: "-C target-feature=+avx2"
         run: cargo codspeed build ${{ matrix.features }} $(printf -- '-p %s ' ${{ matrix.packages }}) --profile bench
+      - name: Setup benchmark environment
+        run: sudo bash scripts/setup-benchmark.sh
       - name: Run benchmarks
         uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2
         with:

--- a/.github/workflows/gpu-compress-bench-pr.yml
+++ b/.github/workflows/gpu-compress-bench-pr.yml
@@ -28,8 +28,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Setup benchmark environment
-        run: sudo bash scripts/setup-benchmark.sh
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -44,6 +42,8 @@ jobs:
         shell: bash
         run: |
           cargo build --locked --package compress-bench --profile release_debug --features cuda,unstable_encodings
+      - name: Setup benchmark environment
+        run: sudo bash scripts/setup-benchmark.sh
       - name: Run GPU compression benchmark
         shell: bash
         env:

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -68,8 +68,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           ref: ${{ inputs.mode == 'pr' && github.event.pull_request.head.sha || github.sha }}
-      - name: Setup benchmark environment
-        run: sudo bash scripts/setup-benchmark.sh
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -148,6 +146,9 @@ jobs:
           profiling_frequency: 199
           extra_args: "--debuginfo-strip=false"
           parca_agent_version: "0.49.0"
+
+      - name: Setup benchmark environment
+        run: sudo bash scripts/setup-benchmark.sh
 
       - name: Run ${{ matrix.name }} benchmark
         if: matrix.remote_key == null || github.event.pull_request.head.repo.fork == true


### PR DESCRIPTION
## Rationale for this change

This step (tries) to make the box more predictable at the cost of some performance, we should only run it AFTER we do all the setup (downloading dependencies, building binaries, generating data).
