### PR TITLE
fix: LazyScanStream prepare/execute is CPU-work not I/O

### DIFF
--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -425,9 +425,8 @@ impl<A: 'static + Send> Stream for LazyScanStream<A> {
                     let num_workers = get_available_parallelism().unwrap_or(1);
                     let concurrency = builder.concurrency * num_workers;
                     let handle = builder.session.handle();
-                    let task = handle.spawn_blocking(move || {
-                        builder.prepare().and_then(|scan| scan.execute(None))
-                    });
+                    let task = handle
+                        .spawn_cpu(move || builder.prepare().and_then(|scan| scan.execute(None)));
                     self.state = LazyScanState::Preparing(PreparingScan {
                         ordered,
                         concurrency,


### PR DESCRIPTION
Scan preparation and execution in LazyScanStream is CPU-bound work, so spawn it with Handle::spawn_cpu instead of the blocking I/O pool.

recreation of #7580 