### PR TITLE
Make the benchmark env script more consistent

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 120
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=bench-dedicated/family=c5d.metal/tag={1}{2}', github.run_id, matrix.benchmark.id, github.event.pull_request.head.repo.fork == false && '/extras=s3-cache' || '')
+          && format('runs-on={0}/runner=bench-dedicated/family=c6id.metal/tag={1}{2}', github.run_id, matrix.benchmark.id, github.event.pull_request.head.repo.fork == false && '/extras=s3-cache' || '')
           || 'ubuntu-latest' }}
     strategy:
       matrix:

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 120
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=bench-dedicated/tag={1}{2}', github.run_id, matrix.benchmark.id, github.event.pull_request.head.repo.fork == false && '/extras=s3-cache' || '')
+          && format('runs-on={0}/runner=bench-dedicated/family=c5d.metal/tag={1}{2}', github.run_id, matrix.benchmark.id, github.event.pull_request.head.repo.fork == false && '/extras=s3-cache' || '')
           || 'ubuntu-latest' }}
     strategy:
       matrix:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 120
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=bench-dedicated/extras=s3-cache/tag={1}', github.run_id, matrix.benchmark.id)
+          && format('runs-on={0}/runner=bench-dedicated/family=c5d.metal/extras=s3-cache/tag={1}', github.run_id, matrix.benchmark.id)
           || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 120
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=bench-dedicated/family=c5d.metal/extras=s3-cache/tag={1}', github.run_id, matrix.benchmark.id)
+          && format('runs-on={0}/runner=bench-dedicated/family=c6id.metal/extras=s3-cache/tag={1}', github.run_id, matrix.benchmark.id)
           || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,14 +126,6 @@ jobs:
             pytest --benchmark-disable test/test_hf_datasets.py
         working-directory: vortex-python/
 
-      - name: Setup benchmark environment
-        run: sudo bash scripts/setup-benchmark.sh
-
-      - name: Pytest Benchmarks - Vortex
-        run: |
-          bash ../scripts/bench-taskset.sh uv run --all-packages pytest --benchmark-only benchmark/
-        working-directory: vortex-python/
-
       - name: Doctest - PyVortex
         run: |
           uv run --all-packages make doctest
@@ -143,6 +135,16 @@ jobs:
         run: |
           uv run --all-packages make html
         working-directory: docs/
+
+      # Keep this last: setup-benchmark.sh confines everything except the wrapped
+      # benchmark to the housekeeping CPUs, so any step after it runs on few cores.
+      - name: Setup benchmark environment
+        run: sudo bash scripts/setup-benchmark.sh
+
+      - name: Pytest Benchmarks - Vortex
+        run: |
+          bash ../scripts/bench-taskset.sh uv run --all-packages pytest --benchmark-only benchmark/
+        working-directory: vortex-python/
 
   # Pins the measurement_id hash that scripts/post-ingest.py uses as the primary key of every
   # benchmarks-database fact row. The golden vectors are a frozen artifact (see the note inside

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -84,12 +84,10 @@ jobs:
         env:
           RUSTFLAGS: "-C target-feature=+avx2"
         run: cargo codspeed build ${{ matrix.features }} $(printf -- '-p %s ' ${{ matrix.packages }}) --profile bench
-      - name: Setup benchmark environment
-        run: sudo bash scripts/setup-benchmark.sh
       - name: Run benchmarks
         uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2
         with:
-          run: bash scripts/bench-taskset.sh cargo codspeed run
+          run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: "simulation"
 

--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -30,4 +30,4 @@ jobs:
       matrix:
         machine_type:
           - id: x86
-            instance_name: i7i.metal-24xl
+            instance_name: c5d.metal

--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -30,4 +30,4 @@ jobs:
       matrix:
         machine_type:
           - id: x86
-            instance_name: c5d.metal
+            instance_name: c6id.metal

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -13,7 +13,7 @@ on:
       machine_type:
         required: false
         type: string
-        default: c5d.metal
+        default: c6id.metal
 
 jobs:
   resolve-matrix:
@@ -166,7 +166,6 @@ jobs:
             --output results.json \
             --ingest-jsonl results.ingest.jsonl \
             --no-build \
-            --runner "ec2_${{ inputs.machine_type }}" \
             ${{ matrix.iterations && format('--iterations {0}', matrix.iterations) || '' }} \
             ${{ matrix.scale_factor && format('--opt scale-factor={0}', matrix.scale_factor) || '' }}
 
@@ -187,7 +186,6 @@ jobs:
             --output results.json \
             --ingest-jsonl results.ingest.jsonl \
             --no-build \
-            --runner "ec2_${{ inputs.machine_type }}" \
             ${{ matrix.iterations && format('--iterations {0}', matrix.iterations) || '' }} \
             --opt remote-data-dir="$REMOTE_STORAGE" \
             ${{ matrix.scale_factor && format('--opt scale-factor={0}', matrix.scale_factor) || '' }}

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -13,7 +13,7 @@ on:
       machine_type:
         required: false
         type: string
-        default: i7i.metal-24xl
+        default: c5d.metal
 
 jobs:
   resolve-matrix:
@@ -58,7 +58,7 @@ jobs:
 
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=bench-dedicated/instance-type={1}/tag={2}{3}', github.run_id, inputs.machine_type, matrix.id, (inputs.mode != 'pr' || github.event.pull_request.head.repo.fork == false) && '/extras=s3-cache' || '')
+          && format('runs-on={0}/runner=bench-dedicated/family={1}/tag={2}{3}', github.run_id, inputs.machine_type, matrix.id, (inputs.mode != 'pr' || github.event.pull_request.head.repo.fork == false) && '/extras=s3-cache' || '')
           || 'ubuntu-latest' }}
     steps:
       - uses: runs-on/action@v2

--- a/bench-orchestrator/bench_orchestrator/cli.py
+++ b/bench-orchestrator/bench_orchestrator/cli.py
@@ -4,6 +4,7 @@
 """CLI for benchmark orchestration."""
 
 import json
+import os
 import subprocess
 from contextlib import contextmanager
 from datetime import datetime, timedelta
@@ -85,6 +86,17 @@ def parse_queries(value: str | None) -> list[int] | None:
 
 def run_ref_auto_complete() -> list[str]:
     return list(map(lambda x: x.run_id, ResultStore().list_runs(limit=None)))
+
+
+def default_runner() -> str | None:
+    """Derive the runner ID from the machine actually provisioned.
+
+    runs-on exposes the real EC2 instance type in RUNS_ON_INSTANCE_TYPE, which can
+    differ from what the workflow requested, so records must never be labeled from
+    workflow inputs.
+    """
+    instance_type = os.environ.get("RUNS_ON_INSTANCE_TYPE")
+    return f"ec2_{instance_type}" if instance_type else None
 
 
 def targets_from_axes(
@@ -265,7 +277,10 @@ def run(
     ] = None,
     runner: Annotated[
         str | None,
-        typer.Option("--runner", help="Benchmark runner ID (e.g., ec2_c6id.8xlarge)"),
+        typer.Option(
+            "--runner",
+            help="Benchmark runner ID (e.g., ec2_c6id.metal); defaults to the actual EC2 instance type when available",
+        ),
     ] = None,
     output: Annotated[
         Path | None,
@@ -281,6 +296,7 @@ def run(
     query_list = parse_queries(queries)
     exclude_list = parse_queries(exclude_queries)
     strict_failures = targets_json is not None
+    runner = runner or default_runner()
 
     try:
         bench_opts = parse_options(options)

--- a/scripts/bench-taskset.sh
+++ b/scripts/bench-taskset.sh
@@ -25,7 +25,10 @@ if [[ -z "${BENCH_CPUS:-}" ]]; then
 fi
 
 if command -v numactl >/dev/null 2>&1; then
-    exec numactl --physcpubind="$BENCH_CPUS" --membind=0 "$@"
+    # --all is required: setup-benchmark.sh pins every running process (including the
+    # CI runner this shell descends from) to the housekeeping CPUs, and libnuma parses
+    # cpu lists relative to the inherited affinity mask unless told to consider all.
+    exec numactl --all --physcpubind="$BENCH_CPUS" --membind=0 "$@"
 fi
 
 exec taskset -c "$BENCH_CPUS" "$@"

--- a/scripts/bench-taskset.sh
+++ b/scripts/bench-taskset.sh
@@ -15,15 +15,12 @@ if [[ -f /tmp/vortex-benchmark.env ]]; then
     source /tmp/vortex-benchmark.env
 fi
 
-
-
 if [[ -z "${BENCH_CPUS:-}" ]]; then
     if command -v numactl >/dev/null 2>&1; then
         # All CPUs on NUMA node 0, skipping CPUs 0-1 to avoid OS interference
         BENCH_CPUS=$(numactl --hardware | awk '/^node 0 cpus:/{sep=""; for(i=4;i<=NF;i++){if($i+0>1){printf "%s%s",sep,$i; sep=","}}}')
     else
-        cpu_count="$(nproc)"
-        BENCH_CPUS="2-$((cpu_count - 1))"
+        BENCH_CPUS="2-$(($(nproc) - 1))"
     fi
 fi
 

--- a/scripts/setup-benchmark.sh
+++ b/scripts/setup-benchmark.sh
@@ -10,39 +10,60 @@ if [ "$EUID" -ne 0 ]; then
     exit 0
 fi
 
+# Write a value to a sysfs file, skipping hosts where the file is absent or read-only
+# (e.g. virtualized guests without frequency control).
+sysfs_write() {
+    [[ -n "$2" && -w "$1" ]] && echo "$2" > "$1" || true
+}
+
+# Expand a cpulist like "0-2,8" into one CPU index per line.
+expand_cpulist() {
+    [[ -n "$1" ]] || return 0
+    local parts part
+    IFS=, read -ra parts <<< "$1"
+    for part in "${parts[@]}"; do
+        seq "${part%-*}" "${part#*-}"
+    done
+}
+
 # Disable turbo boost so benchmark runs stay at a more stable clock rate.
-[[ -w /sys/devices/system/cpu/intel_pstate/no_turbo ]] && echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo || true
-[[ -w /sys/devices/system/cpu/cpufreq/boost ]] && echo 0 > /sys/devices/system/cpu/cpufreq/boost || true
+sysfs_write /sys/devices/system/cpu/intel_pstate/no_turbo 1
+sysfs_write /sys/devices/system/cpu/cpufreq/boost 0
+
+# Pin the frequency governor to performance and raise the floor to the policy max so
+# clocks hold at a constant base clock (turbo is capped above) instead of ramping
+# under powersave/schedutil.
+for policy in /sys/devices/system/cpu/cpufreq/policy*; do
+    sysfs_write "$policy/scaling_governor" performance
+    sysfs_write "$policy/scaling_min_freq" "$(cat "$policy/scaling_max_freq" 2>/dev/null)"
+done
 
 # Really discourage swapping to disk
-sysctl vm.swappiness=0
+sysctl -w vm.swappiness=0 || true
 swapoff -a || true
 
 # Might be worse if a single application uses the OS
 # https://www.intel.com/content/www/us/en/developer/articles/technical/measuring-impact-of-numa-migrations-on-performance.html
-sysctl -w kernel.numa_balancing=0
+sysctl -w kernel.numa_balancing=0 || true
 
 # Disable ASLR - https://docs.kernel.org/admin-guide/sysctl/kernel.html#randomize-va-space
-sysctl kernel.randomize_va_space=0
+sysctl -w kernel.randomize_va_space=0 || true
 
 # This is a desktop optimization, making sure its disabled
-sysctl -w kernel.sched_autogroup_enabled=0
+sysctl -w kernel.sched_autogroup_enabled=0 || true
+
+# Keep armed timers on the CPU that armed them instead of migrating them onto busy
+# (i.e. benchmark) CPUs.
+sysctl -w kernel.timer_migration=0 || true
 
 # Reduce kernel logging to minimum
 dmesg -n 1
 
-# Disable some unused services and features
-systemctl stop apparmor ModemManager
-systemctl disable apparmor ModemManager
-
-# mask prevents them from being started by other services
-systemctl mask ModemManager
-
-# For apparmor specifically, also teardown loaded profiles
-aa-teardown
-
-# Reduce background activity (Ubuntu-specific)
+# Stop background services that could wake up mid-benchmark (Ubuntu-specific list).
+# Masking prevents them from being restarted by other services.
 for unit in \
+  apparmor \
+  ModemManager \
   irqbalance \
   apt-daily.service \
   apt-daily-upgrade.service \
@@ -52,21 +73,62 @@ for unit in \
   motd-news.timer \
   apport
 do
-  systemctl disable --now "$unit" 2>/dev/null
+  systemctl disable --now "$unit" 2>/dev/null || true
+  systemctl mask "$unit" 2>/dev/null || true
 done
-systemctl mask irqbalance 2>/dev/null
 
-CPU_COUNT="$(nproc)"
-HOUSEKEEPING_CPUS="0-1"
-BENCH_CPUS="2-$((CPU_COUNT - 1))"
+# For apparmor, also teardown already-loaded profiles
+aa-teardown || true
 
-# Pin all IRQs to housekeeping CPUs
+# Split CPUs between the benchmark and everything else ("housekeeping"). On machines
+# with multiple NUMA nodes the benchmark owns all of node 0 (bench-taskset.sh binds
+# its memory to node 0) and housekeeping moves to the other nodes entirely. On
+# single-node machines housekeeping gets cores 0-1 plus their SMT siblings, so
+# background work never shares a physical core with the benchmark.
+node_dirs=(/sys/devices/system/node/node[0-9]*)
+if [[ ${#node_dirs[@]} -gt 1 && -r "${node_dirs[1]:-}/cpulist" ]]; then
+    BENCH_CPUS="$(cat /sys/devices/system/node/node0/cpulist)"
+    HOUSEKEEPING_CPUS="$(cat /sys/devices/system/node/node[1-9]*/cpulist | paste -sd, -)"
+else
+    HOUSEKEEPING_CPUS="$(expand_cpulist "$(cat /sys/devices/system/cpu/cpu{0,1}/topology/thread_siblings_list 2>/dev/null | paste -sd, -)" | sort -un | paste -sd, -)"
+    bench=()
+    for cpu in $(expand_cpulist "$(cat /sys/devices/system/cpu/online)"); do
+        [[ ",$HOUSEKEEPING_CPUS," == *",$cpu,"* ]] || bench+=("$cpu")
+    done
+    BENCH_CPUS="$(IFS=,; echo "${bench[*]}")"
+fi
+
+# Pin all IRQs to housekeeping CPUs. Some IRQs are kernel-managed and reject writes
+# with EPERM even as root.
 for f in /proc/irq/[0-9]*/smp_affinity_list; do
-  if [[ -w "$f" ]]; then
-    # Some IRQs are kernel-managed and reject writes with EPERM even as root.
-    echo "$HOUSEKEEPING_CPUS" > "$f" 2>/dev/null || true
-  fi
+  echo "$HOUSEKEEPING_CPUS" > "$f" 2>/dev/null || true
 done
+
+# Steer unbound kernel workqueues (writeback etc.) to the housekeeping CPUs. The
+# sysfs file takes a hex cpumask rather than a cpulist.
+if command -v python3 >/dev/null 2>&1; then
+    wq_mask="$(expand_cpulist "$HOUSEKEEPING_CPUS" \
+        | python3 -c 'import sys; print(f"{sum(1 << int(l) for l in sys.stdin):x}")' || true)"
+    sysfs_write /sys/devices/virtual/workqueue/cpumask "$wq_mask"
+fi
+
+# Keep everything that is not explicitly re-pinned on the housekeeping CPUs. Two
+# layers: a systemd manager default so services (re)started from now on land there,
+# and a one-shot re-pin of everything already running (daemons, the CI runner agent,
+# movable kernel threads). Plain affinity is a default rather than a ceiling (unlike
+# cpusets), so bench-taskset.sh can still move the benchmark onto BENCH_CPUS.
+mkdir -p /etc/systemd/system.conf.d
+cat > /etc/systemd/system.conf.d/99-vortex-benchmark.conf <<EOF
+[Manager]
+CPUAffinity=$HOUSEKEEPING_CPUS
+EOF
+systemctl daemon-reexec || true
+
+{ set +x; } 2>/dev/null  # the per-PID loop is far too noisy for trace output
+for pid_dir in /proc/[0-9]*; do
+    taskset -a -pc "$HOUSEKEEPING_CPUS" "${pid_dir##*/}" >/dev/null 2>&1 || true
+done
+set -x
 
 # Persist CPU affinity ranges for non-root benchmark steps in CI.
 cat > /tmp/vortex-benchmark.env <<EOF


### PR DESCRIPTION
## Rationale for this change

1. Turns out - we don't actually run on metal instances like we thought due to a syntax mistake in the runs-on node choice.
2. Change the NUMA script a bit to fix some of the pinning/power management.

## What changes are included in this PR?
<!--
No need to duplicate information from the previous section, but if you're touching many
parts of the code base, its worth explicitly noting the important changes or how they are tested.
-->

## What APIs are changed? Are there any user-facing changes?

<!--
Are there any user-facing changes that might require documentation updates
Is any public API changed?
-->
