### PR TITLE
Make debuginfo upload on benchmarks best-effort

### DIFF
--- a/.github/actions/upload-parca-debuginfo/action.yml
+++ b/.github/actions/upload-parca-debuginfo/action.yml
@@ -14,7 +14,7 @@ inputs:
   store-address:
     description: "Parca-compatible debuginfo gRPC endpoint"
     required: false
-    default: "grpc.polarsignals.com:443"
+    default: "api.polarsignals.com:443"
   version:
     description: "parca-debuginfo version to install"
     required: false

--- a/.github/actions/upload-parca-debuginfo/action.yml
+++ b/.github/actions/upload-parca-debuginfo/action.yml
@@ -14,7 +14,7 @@ inputs:
   store-address:
     description: "Parca-compatible debuginfo gRPC endpoint"
     required: false
-    default: "api.polarsignals.com:443"
+    default: "grpc.polarsignals.com:443"
   version:
     description: "parca-debuginfo version to install"
     required: false

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Pre-upload benchmark debuginfo to Polar Signals
         if: github.event.pull_request.head.repo.fork == false
         uses: ./.github/actions/upload-parca-debuginfo
+        continue-on-error: true
         with:
           paths: |
             target/release_debug/${{ matrix.benchmark.id }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -77,6 +77,7 @@ jobs:
 
       - name: Pre-upload benchmark debuginfo to Polar Signals
         uses: ./.github/actions/upload-parca-debuginfo
+        continue-on-error: true
         with:
           paths: |
             target/release_debug/${{ matrix.benchmark.id }}

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Pre-upload SQL benchmark debuginfo to Polar Signals
         if: inputs.mode != 'pr' || github.event.pull_request.head.repo.fork == false
         uses: ./.github/actions/upload-parca-debuginfo
+        continue-on-error: true
         with:
           paths: |
             target/release_debug/datafusion-bench


### PR DESCRIPTION
## Rationale for this change

Some recent benchmarks started to fail due to an error at that step, which shouldn't block us from getting the overall numbers.

Also changed the URL because it seems like that's the right one from their docs.
