### PR TITLE
CI: interactive PR control panel comment

### DIFF
--- a/.github/scripts/pr-panel-preview.sh
+++ b/.github/scripts/pr-panel-preview.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#  SPDX-License-Identifier: Apache-2.0
+#  SPDX-FileCopyrightText: Copyright the Vortex contributors
+#
+# Bounded stand-in for the `issue_comment: edited` webhook.
+#
+# GitHub only ever runs `issue_comment` workflows from the default branch, so a pull
+# request that changes the panel cannot exercise a real click through the normal path.
+# This script closes that gap by polling the panel comment for a while and applying
+# whatever it finds, using the PR's own version of the code. Everything downstream of
+# "we noticed the body changed" is identical to `pr-panel.yml`; only the trigger differs.
+#
+# Usage: pr-panel-preview.sh <owner/repo> <pr-number> [window-seconds] [poll-seconds] [notice]
+# Requires: gh (authenticated via GH_TOKEN), jq, python3.
+
+set -Eeuo pipefail
+
+repo="$1"
+pr="$2"
+window="${3:-1800}"
+interval="${4:-15}"
+notice="${5:-}"
+
+panel_marker="<!-- vortex-pr-panel -->"
+report_marker="<!-- vortex-pr-panel-report -->"
+scripts_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+current="${work}/current.md"
+next="${work}/next.md"
+report="${work}/report.md"
+outputs="${work}/outputs"
+
+gh api "/repos/${repo}/issues/${pr}/comments" --paginate >"${work}/comments.json"
+comment_id="$(jq -r --arg marker "${panel_marker}" \
+  '.[] | select(.body | contains($marker)) | .id' "${work}/comments.json" | head -n 1)"
+
+if [ -z "${comment_id}" ]; then
+  echo "::error::no panel comment found on #${pr}"
+  exit 1
+fi
+
+fetch_body() {
+  gh api "/repos/${repo}/issues/comments/${comment_id}" --jq .body >"${current}"
+}
+
+patch_body() {
+  jq -n --rawfile body "${next}" '{body: $body}' |
+    gh api --silent --method PATCH "/repos/${repo}/issues/comments/${comment_id}" --input -
+}
+
+# Runs `pr_panel apply` and exports its GitHub-Actions outputs as shell variables.
+apply() {
+  : >"${outputs}"
+  (
+    cd "${scripts_dir}"
+    GITHUB_OUTPUT="${outputs}" python3 -m pr_panel apply \
+      --body "${current}" \
+      --out "${next}" \
+      --timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      "$@"
+  )
+  changed="$(sed -n 's/^changed=//p' "${outputs}")"
+  dispatch="$(sed -n 's/^dispatch=//p' "${outputs}")"
+  actions="$(sed -n 's/^actions=//p' "${outputs}")"
+  state="$(sed -n 's/^state=//p' "${outputs}")"
+}
+
+echo "Watching panel comment ${comment_id} on #${pr} for ${window}s (every ${interval}s)"
+
+# Tell whoever is looking at the PR that their clicks are live, and for how long.
+if [ -n "${notice}" ]; then
+  fetch_body
+  apply --notice "${notice}"
+  patch_body
+fi
+
+deadline=$((SECONDS + window))
+applied=0
+
+while [ "${SECONDS}" -lt "${deadline}" ]; do
+  fetch_body
+  apply
+
+  if [ "${changed}" = "true" ]; then
+    patch_body
+    applied=$((applied + 1))
+    echo "redrew the panel (dispatch=${dispatch}, actions=${actions:-none})"
+  fi
+
+  if [ "${dispatch}" = "true" ]; then
+    # The production path dispatches `pr-panel-run.yml`, which is only dispatchable
+    # from the default branch. Rendering the report here exercises the same code.
+    (
+      cd "${scripts_dir}"
+      python3 -m pr_panel report \
+        --state "${state}" \
+        --actions "${actions}" \
+        --run-url "${RUN_URL:-}" \
+        --out "${report}"
+    )
+    bash "${scripts_dir}/upsert-comment.sh" "${repo}" "${pr}" "${report_marker}" "${report}"
+  fi
+
+  sleep "${interval}"
+done
+
+fetch_body
+apply --notice "Preview window closed. Push to this branch to reopen it."
+patch_body
+
+echo "Preview finished after applying ${applied} edit(s)."

--- a/.github/scripts/pr_panel/README.md
+++ b/.github/scripts/pr_panel/README.md
@@ -1,0 +1,83 @@
+# PR control panel
+
+An interactive form, rendered as a bot comment on every pull request. Clicking a
+checkbox changes a setting; clicking a **button** dispatches a separate workflow run
+with the whole settings blob attached.
+
+This exists to replace the current "add a label, the bot runs, the bot removes the
+label" pattern for benchmarks, where the combinations outgrew what a label list can
+show. Nothing here is wired to a real benchmark yet — the downstream workflow only
+renders the state it received.
+
+## How it works
+
+GitHub gives markdown exactly one clickable control: the task list checkbox. Ticking
+one in a comment rewrites that comment's body and delivers an `issue_comment: edited`
+webhook. Everything else is built on top of that single primitive.
+
+```
+user ticks a box
+      │
+      ▼
+issue_comment: edited ──► pr-panel.yml (apply)
+                              │  parse checkboxes, diff against embedded state
+                              │  canonicalize (radios, momentary buttons)
+                              ├─► PATCH the comment  ──► panel redraws
+                              └─► workflow_dispatch  ──► pr-panel-run.yml
+                                                            renders state back to the PR
+```
+
+The comment body is the only storage. It holds one tagged task-list line per control:
+
+```markdown
+- [x] Random access <!--c:suite.random_access-->
+```
+
+plus a trailing state blob that records what the panel last rendered:
+
+```markdown
+<!--vortex-pr-panel:state:{"controls":{...},"rev":3,"v":1}-->
+```
+
+Diffing the checkboxes against that blob is what identifies the click, and that is what
+makes controls richer than a plain checkbox possible:
+
+| Control | Behaviour |
+| --- | --- |
+| `Toggle` | Persistent on/off. The click is the new value. |
+| `Radio` | Pick-one. Checking an option unchecks its siblings on redraw; unchecking the selected one restores it, so a group is never empty. |
+| `Button` | Momentary. A tick is an edge: it dispatches an action and is cleared on redraw. |
+| `Section` | Grouping. A closed section renders as a folded `<details>` block. |
+
+Add or change controls in `spec.py`; `panel.py` needs no edits.
+
+## Properties worth knowing
+
+- **Authorization is GitHub's.** Only users with write access can tick a checkbox on
+  someone else's comment, so no separate permission check is needed.
+- **No feedback loop.** The redraw is written with `GITHUB_TOKEN`, and edits made with
+  that token do not trigger workflows.
+- **Races are serialized.** `pr-panel.yml` uses a per-PR concurrency group that never
+  cancels, and re-reads the comment body from the API rather than trusting the event
+  payload, so clicks that queue up are all observed.
+- **Hand edits self-heal.** The panel is redrawn from canonical state, so prose someone
+  typed into the comment is replaced on the next click.
+- **Redraws are skipped when they would be a no-op.** Ticking a toggle already leaves the
+  comment correct, so no write-back happens; only radios and buttons force a redraw.
+- **Deploys lag.** `issue_comment` workflows always run from the default branch, so
+  changes to this panel only take effect on PRs once merged.
+
+## Working on it locally
+
+```bash
+cd .github/scripts
+
+# Render the panel as it would first appear.
+python3 -m pr_panel demo
+
+# Simulate a click sequence; the trailing state blob shows the result.
+python3 -m pr_panel demo --click suite.sql --click runner.machine:g5.xlarge --click action.run
+
+# Tests (pure stdlib, no install needed).
+uv run --no-project --with pytest pytest tests/test_pr_panel.py
+```

--- a/.github/scripts/pr_panel/README.md
+++ b/.github/scripts/pr_panel/README.md
@@ -64,8 +64,25 @@ Add or change controls in `spec.py`; `panel.py` needs no edits.
   typed into the comment is replaced on the next click.
 - **Redraws are skipped when they would be a no-op.** Ticking a toggle already leaves the
   comment correct, so no write-back happens; only radios and buttons force a redraw.
-- **Deploys lag.** `issue_comment` workflows always run from the default branch, so
-  changes to this panel only take effect on PRs once merged.
+
+## Testing a change to the panel
+
+`issue_comment` and `pull_request_target` workflows always run from the **default
+branch**, so a PR that changes the panel cannot exercise its own apply path. Two things
+close that gap:
+
+- The panel is **posted** by the `pull_request` trigger for same-repo branches, which
+  does run the PR's version of the code. Fork PRs fall back to `pull_request_target`,
+  because a fork gets a read-only token under `pull_request`.
+- Clicks are **applied** by the `preview` job, which runs only on PRs that touch
+  `.github/scripts/pr_panel/**` or `.github/workflows/pr-panel*.yml`. It polls the panel
+  comment for 30 minutes and applies whatever it finds, using `pr-panel-preview.sh`.
+  Everything downstream of "the body changed" is the same code the webhook path runs;
+  only the trigger differs. Push again to reopen the window.
+
+The preview job renders the run report inline rather than dispatching `pr-panel-run.yml`,
+since `workflow_dispatch` also only works from the default branch. That hop is the one
+part of the flow that genuinely cannot be exercised before merge.
 
 ## Working on it locally
 

--- a/.github/scripts/pr_panel/__init__.py
+++ b/.github/scripts/pr_panel/__init__.py
@@ -1,0 +1,4 @@
+#  SPDX-License-Identifier: Apache-2.0
+#  SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+"""Interactive PR control panel rendered as a GitHub comment."""

--- a/.github/scripts/pr_panel/__main__.py
+++ b/.github/scripts/pr_panel/__main__.py
@@ -38,13 +38,18 @@ def _write_output(pairs: dict[str, str]) -> None:
 
 
 def _cmd_render(args: argparse.Namespace) -> int:
-    Path(args.out).write_text(render(initial_state()), encoding="utf-8")
+    Path(args.out).write_text(render(initial_state(notice=args.notice)), encoding="utf-8")
     return 0
 
 
 def _cmd_apply(args: argparse.Namespace) -> int:
     body = Path(args.body).read_text(encoding="utf-8")
-    result = apply_edit(body, actor=args.actor, timestamp=args.timestamp)
+    result = apply_edit(
+        body,
+        actor=args.actor,
+        timestamp=args.timestamp,
+        notice=args.notice,
+    )
     Path(args.out).write_text(result.body, encoding="utf-8")
     _write_output(
         {
@@ -99,6 +104,7 @@ def main(argv: list[str] | None = None) -> int:
 
     render_cmd = sub.add_parser("render", help="write a fresh panel body")
     render_cmd.add_argument("--out", required=True)
+    render_cmd.add_argument("--notice", default="", help="banner shown above the controls")
     render_cmd.set_defaults(func=_cmd_render)
 
     apply_cmd = sub.add_parser("apply", help="interpret an edited panel body")
@@ -106,6 +112,11 @@ def main(argv: list[str] | None = None) -> int:
     apply_cmd.add_argument("--out", required=True, help="file to write the redrawn body to")
     apply_cmd.add_argument("--actor", default="")
     apply_cmd.add_argument("--timestamp", default="")
+    apply_cmd.add_argument(
+        "--notice",
+        default=None,
+        help="replace the banner; omit to carry the existing one over",
+    )
     apply_cmd.set_defaults(func=_cmd_apply)
 
     report_cmd = sub.add_parser("report", help="render received state as a table")

--- a/.github/scripts/pr_panel/__main__.py
+++ b/.github/scripts/pr_panel/__main__.py
@@ -1,0 +1,127 @@
+#  SPDX-License-Identifier: Apache-2.0
+#  SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+"""CLI used by the PR control panel workflows.
+
+Subcommands:
+
+* ``render`` — emit the body of a brand-new panel comment.
+* ``apply``  — read an edited panel comment, emit the redrawn body, and report which
+  buttons were pressed via ``$GITHUB_OUTPUT``.
+* ``report`` — render a state blob as a table (run by the downstream workflow).
+* ``demo``   — render the panel locally and optionally simulate clicks, so the layout
+  can be eyeballed without pushing to CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from .panel import apply_edit, initial_state, parse_checkboxes, render, render_report
+
+
+def _write_output(pairs: dict[str, str]) -> None:
+    """Append ``key=value`` pairs to ``$GITHUB_OUTPUT`` if we are inside Actions."""
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        for key, value in pairs.items():
+            print(f"{key}={value}", file=sys.stderr)
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        for key, value in pairs.items():
+            if "\n" in value:
+                raise ValueError(f"output {key!r} must be single-line")
+            handle.write(f"{key}={value}\n")
+
+
+def _cmd_render(args: argparse.Namespace) -> int:
+    Path(args.out).write_text(render(initial_state()), encoding="utf-8")
+    return 0
+
+
+def _cmd_apply(args: argparse.Namespace) -> int:
+    body = Path(args.body).read_text(encoding="utf-8")
+    result = apply_edit(body, actor=args.actor, timestamp=args.timestamp)
+    Path(args.out).write_text(result.body, encoding="utf-8")
+    _write_output(
+        {
+            "changed": "true" if result.changed else "false",
+            "dispatch": "true" if result.dispatched else "false",
+            "actions": ",".join(result.dispatched),
+            "state": result.state.to_json(),
+        }
+    )
+    return 0
+
+
+def _cmd_report(args: argparse.Namespace) -> int:
+    report = render_report(args.state, run_url=args.run_url, actions=args.actions)
+    Path(args.out).write_text(report, encoding="utf-8")
+    return 0
+
+
+def _cmd_demo(args: argparse.Namespace) -> int:
+    body = render(initial_state())
+    for click in args.click:
+        checked = parse_checkboxes(body)
+        if click not in checked:
+            raise SystemExit(f"unknown control {click!r}; known: {', '.join(sorted(checked))}")
+        body = _toggle_line(body, click)
+        result = apply_edit(body, actor="demo", timestamp="2026-01-01T00:00:00Z")
+        print(
+            f"--- click {click} -> pressed={result.pressed} changed={result.changed}",
+            file=sys.stderr,
+        )
+        body = result.body
+    print(body, end="")
+    return 0
+
+
+def _toggle_line(body: str, control_id: str) -> str:
+    """Flip one checkbox, mimicking what GitHub writes when a user clicks it."""
+    lines = body.splitlines()
+    for i, line in enumerate(lines):
+        if line.rstrip().endswith(f"<!--c:{control_id}-->"):
+            if "- [ ]" in line:
+                lines[i] = line.replace("- [ ]", "- [x]", 1)
+            else:
+                lines[i] = line.replace("- [x]", "- [ ]", 1)
+            break
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="pr_panel")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    render_cmd = sub.add_parser("render", help="write a fresh panel body")
+    render_cmd.add_argument("--out", required=True)
+    render_cmd.set_defaults(func=_cmd_render)
+
+    apply_cmd = sub.add_parser("apply", help="interpret an edited panel body")
+    apply_cmd.add_argument("--body", required=True, help="file holding the current comment body")
+    apply_cmd.add_argument("--out", required=True, help="file to write the redrawn body to")
+    apply_cmd.add_argument("--actor", default="")
+    apply_cmd.add_argument("--timestamp", default="")
+    apply_cmd.set_defaults(func=_cmd_apply)
+
+    report_cmd = sub.add_parser("report", help="render received state as a table")
+    report_cmd.add_argument("--state", required=True)
+    report_cmd.add_argument("--actions", default="")
+    report_cmd.add_argument("--run-url", default="")
+    report_cmd.add_argument("--out", required=True)
+    report_cmd.set_defaults(func=_cmd_report)
+
+    demo_cmd = sub.add_parser("demo", help="render locally, optionally simulating clicks")
+    demo_cmd.add_argument("--click", action="append", default=[], metavar="CONTROL_ID")
+    demo_cmd.set_defaults(func=_cmd_demo)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/pr_panel/panel.py
+++ b/.github/scripts/pr_panel/panel.py
@@ -43,6 +43,9 @@ class PanelState:
     controls: dict[str, Any] = field(default_factory=dict)
     revision: int = 0
     last: dict[str, Any] = field(default_factory=dict)
+    # Free-form banner shown above the controls, e.g. "a run is in progress". Survives
+    # clicks, so whoever set it is the one who clears it.
+    notice: str = ""
 
     def to_json(self) -> str:
         return json.dumps(
@@ -51,6 +54,7 @@ class PanelState:
                 "rev": self.revision,
                 "controls": self.controls,
                 "last": self.last,
+                "notice": self.notice,
             },
             sort_keys=True,
             separators=(",", ":"),
@@ -65,6 +69,7 @@ class PanelState:
             controls=dict(raw.get("controls") or {}),
             revision=int(raw.get("rev") or 0),
             last=dict(raw.get("last") or {}),
+            notice=str(raw.get("notice") or ""),
         )
 
 
@@ -157,9 +162,13 @@ def apply_edit(
     *,
     actor: str = "",
     timestamp: str = "",
+    notice: str | None = None,
     panel: Panel = PANEL,
 ) -> ApplyResult:
-    """Interpret an edited panel comment and produce the redrawn body."""
+    """Interpret an edited panel comment and produce the redrawn body.
+
+    ``notice`` replaces the banner; leave it as ``None`` to carry the existing one over.
+    """
     previous = parse_state(body, panel)
     controls, pressed = canonicalize(previous.controls, parse_checkboxes(body), panel)
 
@@ -176,7 +185,12 @@ def apply_edit(
             "at": timestamp,
         }
 
-    state = PanelState(controls=controls, revision=previous.revision + 1, last=last)
+    state = PanelState(
+        controls=controls,
+        revision=previous.revision + 1,
+        last=last,
+        notice=previous.notice if notice is None else notice,
+    )
     new_body = render(state, panel)
     unchanged = _normalize(new_body) == _normalize(body)
     if unchanged:
@@ -193,9 +207,9 @@ def apply_edit(
     )
 
 
-def initial_state(panel: Panel = PANEL) -> PanelState:
+def initial_state(panel: Panel = PANEL, notice: str = "") -> PanelState:
     """State for a panel that has never been clicked."""
-    return PanelState(controls=panel.default_state(), revision=1)
+    return PanelState(controls=panel.default_state(), revision=1, notice=notice)
 
 
 def _normalize(body: str) -> str:
@@ -206,7 +220,12 @@ def _normalize(body: str) -> str:
 
 def render(state: PanelState, panel: Panel = PANEL) -> str:
     """Render canonical state as the full comment body."""
-    out: list[str] = [MARKER, "", f"## {panel.title}", "", panel.blurb, "", _status_line(state), ""]
+    out: list[str] = [MARKER, "", f"## {panel.title}", "", panel.blurb, ""]
+    if state.notice:
+        # Collapse whitespace so a notice wrapped across lines still renders as one
+        # blockquote rather than breaking out of it.
+        out.extend([f"> [!IMPORTANT]\n> {' '.join(state.notice.split())}", ""])
+    out.extend([_status_line(state), ""])
 
     for section in panel.sections:
         out.extend(_render_section(section, state))

--- a/.github/scripts/pr_panel/panel.py
+++ b/.github/scripts/pr_panel/panel.py
@@ -1,0 +1,332 @@
+#  SPDX-License-Identifier: Apache-2.0
+#  SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+"""Render, parse, and apply clicks for the PR control panel.
+
+The comment body is the entire persistence layer. It carries:
+
+* one task-list line per control, each tagged with an invisible ``<!--c:id-->`` marker,
+* a trailing ``<!--vortex-pr-panel:state:{...}-->`` blob holding the canonical state as
+  of the last render.
+
+A click rewrites a single ``- [ ]`` into ``- [x]`` (or back), which GitHub delivers as an
+``issue_comment.edited`` event. Diffing the parsed checkboxes against the embedded state
+tells us exactly which control the user touched, which is what makes momentary buttons
+and pick-one radio groups expressible in plain markdown.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from .spec import PANEL, Button, Control, Panel, Radio, Toggle
+
+# Identifies a panel comment. Kept on its own line so `grep`/`contains()` in a workflow
+# `if:` expression can cheaply pre-filter events.
+MARKER = "<!-- vortex-pr-panel -->"
+
+STATE_VERSION = 1
+
+_CONTROL_RE = re.compile(
+    r"^\s*- \[(?P<checked>[ xX])\]\s*(?P<label>.*?)\s*<!--c:(?P<id>[A-Za-z0-9_.:-]+)-->\s*$"
+)
+_STATE_RE = re.compile(r"<!--vortex-pr-panel:state:(?P<payload>.*?)-->", re.DOTALL)
+
+
+@dataclass
+class PanelState:
+    """Canonical state of the panel, as embedded in the comment."""
+
+    controls: dict[str, Any] = field(default_factory=dict)
+    revision: int = 0
+    last: dict[str, Any] = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "v": STATE_VERSION,
+                "rev": self.revision,
+                "controls": self.controls,
+                "last": self.last,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> PanelState:
+        raw = json.loads(payload)
+        if not isinstance(raw, dict):
+            raise ValueError("panel state must be a JSON object")
+        return cls(
+            controls=dict(raw.get("controls") or {}),
+            revision=int(raw.get("rev") or 0),
+            last=dict(raw.get("last") or {}),
+        )
+
+
+@dataclass
+class ApplyResult:
+    """Outcome of interpreting a comment edit."""
+
+    body: str
+    state: PanelState
+    # Control ids the user just clicked.
+    pressed: list[str]
+    # Action names for the pressed buttons that ask for a downstream run.
+    dispatched: list[str]
+    # Whether the redrawn body differs from what is already on the PR.
+    changed: bool
+
+
+def marker_id(control: Control, option_id: str = "") -> str:
+    """The stable id embedded in the comment for a control (or a radio option)."""
+    return f"{control.id}:{option_id}" if option_id else control.id
+
+
+def parse_checkboxes(body: str) -> dict[str, bool]:
+    """Extract ``marker id -> checked`` for every tagged task-list line."""
+    checked: dict[str, bool] = {}
+    for line in body.splitlines():
+        match = _CONTROL_RE.match(line)
+        if match:
+            checked[match.group("id")] = match.group("checked").lower() == "x"
+    return checked
+
+
+def parse_state(body: str, panel: Panel = PANEL) -> PanelState:
+    """Read the embedded state blob, falling back to defaults when it is absent."""
+    match = _STATE_RE.search(body)
+    if match:
+        try:
+            return PanelState.from_json(match.group("payload"))
+        except (ValueError, json.JSONDecodeError):
+            pass
+    return PanelState(controls=panel.default_state())
+
+
+def canonicalize(
+    previous: dict[str, Any],
+    checked: dict[str, bool],
+    panel: Panel = PANEL,
+) -> tuple[dict[str, Any], list[str]]:
+    """Fold the raw checkbox reading into canonical state plus any pressed buttons.
+
+    ``previous`` is what the panel last rendered, so ``checked`` differing from it is
+    precisely the user's click.
+    """
+    state: dict[str, Any] = {}
+    pressed: list[str] = []
+
+    for control in panel.controls():
+        if isinstance(control, Toggle):
+            prior = bool(previous.get(control.id, control.default))
+            state[control.id] = bool(checked.get(control.id, prior))
+        elif isinstance(control, Radio):
+            state[control.id] = _resolve_radio(control, previous, checked)
+        elif isinstance(control, Button):
+            # Momentary: a check is an edge, never stored.
+            if checked.get(control.id, False):
+                pressed.append(control.id)
+
+    return state, pressed
+
+
+def _resolve_radio(radio: Radio, previous: dict[str, Any], checked: dict[str, bool]) -> str:
+    option_ids = [option.id for option in radio.options]
+    prior = previous.get(radio.id, radio.resolved_default)
+    if prior not in option_ids:
+        prior = radio.resolved_default
+
+    now_checked = [oid for oid in option_ids if checked.get(marker_id(radio, oid), False)]
+    newly_checked = [oid for oid in now_checked if oid != prior]
+    if newly_checked:
+        # A click landed on a sibling: it wins, and the rest are cleared on re-render.
+        return newly_checked[-1]
+    if prior in now_checked or not now_checked:
+        # Unchecking the selected option would leave the group empty, so restore it.
+        return prior
+    return now_checked[0]
+
+
+def apply_edit(
+    body: str,
+    *,
+    actor: str = "",
+    timestamp: str = "",
+    panel: Panel = PANEL,
+) -> ApplyResult:
+    """Interpret an edited panel comment and produce the redrawn body."""
+    previous = parse_state(body, panel)
+    controls, pressed = canonicalize(previous.controls, parse_checkboxes(body), panel)
+
+    buttons = [c for c in (panel.control(pid) for pid in pressed) if isinstance(c, Button)]
+    if any(button.resets for button in buttons):
+        controls = panel.default_state()
+    dispatched = [button.resolved_action for button in buttons if button.dispatches]
+
+    last = dict(previous.last)
+    if buttons:
+        last = {
+            "actions": [button.resolved_action for button in buttons],
+            "by": actor,
+            "at": timestamp,
+        }
+
+    state = PanelState(controls=controls, revision=previous.revision + 1, last=last)
+    new_body = render(state, panel)
+    unchanged = _normalize(new_body) == _normalize(body)
+    if unchanged:
+        # Nothing to write back; keep the revision the user is already looking at.
+        state.revision = previous.revision
+        new_body = render(state, panel)
+
+    return ApplyResult(
+        body=new_body,
+        state=state,
+        pressed=pressed,
+        dispatched=dispatched,
+        changed=not unchanged,
+    )
+
+
+def initial_state(panel: Panel = PANEL) -> PanelState:
+    """State for a panel that has never been clicked."""
+    return PanelState(controls=panel.default_state(), revision=1)
+
+
+def _normalize(body: str) -> str:
+    """Compare bodies ignoring the revision counter and trailing whitespace."""
+    stripped = _STATE_RE.sub("", body)
+    return "\n".join(line.rstrip() for line in stripped.strip().splitlines())
+
+
+def render(state: PanelState, panel: Panel = PANEL) -> str:
+    """Render canonical state as the full comment body."""
+    out: list[str] = [MARKER, "", f"## {panel.title}", "", panel.blurb, "", _status_line(state), ""]
+
+    for section in panel.sections:
+        out.extend(_render_section(section, state))
+
+    out.extend(
+        [
+            "<sub>Checkboxes are editable by anyone with write access. Every click is "
+            "applied by the <code>PR Control Panel</code> workflow, which redraws this "
+            "comment; the buttons clear themselves once handled.</sub>",
+            "",
+            f"<!--vortex-pr-panel:state:{state.to_json()}-->",
+        ]
+    )
+    return "\n".join(out) + "\n"
+
+
+def _status_line(state: PanelState) -> str:
+    # The revision counter is deliberately *not* shown: `_normalize` compares rendered
+    # bodies to decide whether a write-back is needed, and a monotonic counter in the
+    # visible text would make every edit look like a change.
+    last = state.last
+    if last.get("actions"):
+        actions = ", ".join(f"`{a}`" for a in last["actions"])
+        who = f" by @{last['by']}" if last.get("by") else ""
+        when = f" at {last['at']}" if last.get("at") else ""
+        return f"> [!NOTE]\n> Last dispatched {actions}{who}{when}."
+    return "> [!NOTE]\n> Nothing dispatched yet."
+
+
+def _render_section(section, state: PanelState) -> list[str]:
+    out: list[str] = []
+    if section.open:
+        out.append(f"### {section.title}")
+        out.append("")
+        if section.help:
+            out.append(section.help)
+            out.append("")
+    else:
+        out.append("<details>")
+        out.append(f"<summary><b>{section.title}</b></summary>")
+        out.append("")
+        if section.help:
+            out.append(section.help)
+            out.append("")
+
+    for control in section.controls:
+        out.extend(_render_control(control, state))
+
+    # A blank line keeps the next heading (or `</details>`) out of the task list.
+    if out[-1] != "":
+        out.append("")
+    if not section.open:
+        out.extend(["</details>", ""])
+    return out
+
+
+def _render_control(control: Control, state: PanelState) -> list[str]:
+    if isinstance(control, Radio):
+        selected = state.controls.get(control.id, control.resolved_default)
+        out = [f"**{control.label}** — pick one:", ""]
+        for option in control.options:
+            out.append(
+                _checkbox(marker_id(control, option.id), _label(option), option.id == selected)
+            )
+        out.append("")
+        return out
+
+    if isinstance(control, Toggle):
+        checked = bool(state.controls.get(control.id, control.default))
+        return [_checkbox(control.id, _label(control), checked)]
+
+    # Buttons always render unchecked: they are edges, not state.
+    return [_checkbox(control.id, _label(control), False)]
+
+
+def _label(control: Control) -> str:
+    return f"{control.label} — <sub>{control.help}</sub>" if control.help else control.label
+
+
+def _checkbox(cid: str, label: str, checked: bool) -> str:
+    box = "x" if checked else " "
+    return f"- [{box}] {label} <!--c:{cid}-->"
+
+
+def render_report(
+    state_json: str,
+    *,
+    panel: Panel = PANEL,
+    run_url: str = "",
+    actions: str = "",
+) -> str:
+    """Render received state as a table.
+
+    This is what the downstream workflow prints: it proves the panel's state crosses the
+    workflow boundary intact, and stands in for whatever the run will eventually do.
+    """
+    raw = json.loads(state_json) if state_json.strip() else {}
+    controls = dict(raw.get("controls") or {}) if isinstance(raw, dict) else {}
+
+    out = ["<!-- vortex-pr-panel-report -->", "", "## Panel run report", ""]
+    if actions:
+        out.append(f"Dispatched by: {', '.join(f'`{a}`' for a in actions.split(',') if a)}")
+        out.append("")
+    if run_url:
+        out.append(f"Rendered by [this workflow run]({run_url}).")
+        out.append("")
+
+    out.extend(["| Control | Value |", "| --- | --- |"])
+    for section in panel.sections:
+        for control in section.controls:
+            if isinstance(control, Button):
+                continue
+            value = controls.get(control.id)
+            out.append(f"| {section.title} / `{control.id}` | {_format_value(control, value)} |")
+
+    out.extend(["", f"<sub>Panel revision {raw.get('rev', '?')}.</sub>", ""])
+    return "\n".join(out) + "\n"
+
+
+def _format_value(control: Control, value: Any) -> str:
+    if isinstance(control, Toggle):
+        return "✅ on" if value else "⬜ off"
+    return f"`{value}`" if value is not None else "_unset_"

--- a/.github/scripts/pr_panel/spec.py
+++ b/.github/scripts/pr_panel/spec.py
@@ -189,16 +189,20 @@ PANEL = Panel(
         Section(
             id="actions",
             title="Actions",
-            help="Momentary buttons. They clear themselves once the click is handled.",
+            help=(
+                "Tick one of these to press it. GitHub strips `<button>` from comments, "
+                "so a checkbox is the only clickable control available — these clear "
+                "themselves once the click is handled."
+            ),
             controls=(
                 Button(
                     id="action.run",
-                    label="**Run** — dispatch a run with the settings above",
+                    label="&nbsp;▶️&nbsp; **RUN BENCHMARKS** — with the settings above",
                     action="run",
                 ),
                 Button(
                     id="action.reset",
-                    label="**Reset** — restore the default settings",
+                    label="&nbsp;♻️&nbsp; **RESET** — restore the default settings",
                     action="reset",
                     dispatches=False,
                     resets=True,

--- a/.github/scripts/pr_panel/spec.py
+++ b/.github/scripts/pr_panel/spec.py
@@ -1,0 +1,209 @@
+#  SPDX-License-Identifier: Apache-2.0
+#  SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+"""Declarative definition of the PR control panel.
+
+The panel is a single bot-authored PR comment whose markdown task list doubles as a
+form. Every control owns a stable id that is embedded in the comment as an invisible
+HTML comment, so labels can be reworded without breaking state.
+
+This module contains *only* the description of the UI. Rendering, parsing, and click
+semantics live in ``panel.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+CONTROL_ID = str
+
+
+@dataclass(frozen=True)
+class Toggle:
+    """A persistent on/off control. Clicking it flips the stored value."""
+
+    id: CONTROL_ID
+    label: str
+    default: bool = False
+    help: str = ""
+
+
+@dataclass(frozen=True)
+class RadioOption:
+    """One choice within a `Radio` group."""
+
+    id: CONTROL_ID
+    label: str
+    help: str = ""
+
+
+@dataclass(frozen=True)
+class Radio:
+    """A pick-one group. Checking an option unchecks its siblings on the next render.
+
+    Markdown has no `<select>`, so a radio group is emulated: the panel accepts the
+    newly checked option and rewrites the rest of the group as unchecked.
+    """
+
+    id: CONTROL_ID
+    label: str
+    options: tuple[RadioOption, ...]
+    default: CONTROL_ID = ""
+    help: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.options:
+            raise ValueError(f"radio {self.id!r} needs at least one option")
+        if self.default and self.default not in {o.id for o in self.options}:
+            raise ValueError(f"radio {self.id!r} default {self.default!r} is not an option")
+
+    @property
+    def resolved_default(self) -> CONTROL_ID:
+        return self.default or self.options[0].id
+
+
+@dataclass(frozen=True)
+class Button:
+    """A momentary control. Checking it triggers an action, then it clears itself."""
+
+    id: CONTROL_ID
+    label: str
+    help: str = ""
+    # Action name handed to the downstream workflow.
+    action: str = ""
+    # Whether pressing it dispatches the downstream workflow, or only edits panel state.
+    dispatches: bool = True
+    # Whether pressing it restores every control to its default.
+    resets: bool = False
+
+    @property
+    def resolved_action(self) -> str:
+        return self.action or self.id
+
+
+Control = Toggle | Radio | Button
+
+
+@dataclass(frozen=True)
+class Section:
+    """A group of controls, rendered as a collapsible `<details>` block when closed."""
+
+    id: CONTROL_ID
+    title: str
+    controls: tuple[Control, ...]
+    # Sections rendered open are always visible; closed ones start folded.
+    open: bool = True
+    help: str = ""
+
+
+@dataclass(frozen=True)
+class Panel:
+    """The whole panel: a title, some prose, and an ordered list of sections."""
+
+    title: str
+    blurb: str
+    sections: tuple[Section, ...] = field(default_factory=tuple)
+
+    def controls(self):
+        for section in self.sections:
+            yield from section.controls
+
+    def control(self, control_id: CONTROL_ID) -> Control | None:
+        for control in self.controls():
+            if control.id == control_id:
+                return control
+        return None
+
+    def buttons(self) -> tuple[Button, ...]:
+        return tuple(c for c in self.controls() if isinstance(c, Button))
+
+    def default_state(self) -> dict[str, object]:
+        """The state a freshly posted panel starts in."""
+        state: dict[str, object] = {}
+        for control in self.controls():
+            if isinstance(control, Toggle):
+                state[control.id] = control.default
+            elif isinstance(control, Radio):
+                state[control.id] = control.resolved_default
+        return state
+
+
+# The demo panel. Nothing here is wired to a real benchmark yet: it exists to prove the
+# click -> re-render -> dispatch loop with one control of every kind.
+PANEL = Panel(
+    title="Benchmark Control Panel",
+    blurb=(
+        "Configure a benchmark run by clicking the checkboxes below, then press "
+        "**Run** to dispatch it. Your click is applied by a workflow, so the panel "
+        "takes a few seconds to redraw."
+    ),
+    sections=(
+        Section(
+            id="suites",
+            title="Suites",
+            help="Which benchmark suites to include in the run.",
+            controls=(
+                Toggle(id="suite.random_access", label="Random access", default=True),
+                Toggle(id="suite.compression", label="Compression", default=True),
+                Toggle(id="suite.sql", label="SQL (TPC-H / Clickbench)"),
+                Toggle(id="suite.gpu_compression", label="GPU compression"),
+            ),
+        ),
+        Section(
+            id="runner",
+            title="Runner",
+            open=False,
+            help="Where the run executes.",
+            controls=(
+                Radio(
+                    id="runner.machine",
+                    label="Machine",
+                    default="c6id.metal",
+                    options=(
+                        RadioOption(id="c6id.metal", label="`c6id.metal` (bare metal, default)"),
+                        RadioOption(id="c7i.8xlarge", label="`c7i.8xlarge`"),
+                        RadioOption(id="g5.xlarge", label="`g5.xlarge` (GPU)"),
+                    ),
+                ),
+            ),
+        ),
+        Section(
+            id="options",
+            title="Options",
+            open=False,
+            help="Extra knobs applied to every selected suite.",
+            controls=(
+                Radio(
+                    id="options.preset",
+                    label="Matrix preset",
+                    default="pr",
+                    options=(
+                        RadioOption(id="pr", label="`pr` — quick subset"),
+                        RadioOption(id="pr-full", label="`pr-full` — everything"),
+                    ),
+                ),
+                Toggle(id="options.profile", label="Capture a continuous profile"),
+                Toggle(id="options.unstable_encodings", label="Enable unstable encodings"),
+            ),
+        ),
+        Section(
+            id="actions",
+            title="Actions",
+            help="Momentary buttons. They clear themselves once the click is handled.",
+            controls=(
+                Button(
+                    id="action.run",
+                    label="**Run** — dispatch a run with the settings above",
+                    action="run",
+                ),
+                Button(
+                    id="action.reset",
+                    label="**Reset** — restore the default settings",
+                    action="reset",
+                    dispatches=False,
+                    resets=True,
+                ),
+            ),
+        ),
+    ),
+)

--- a/.github/scripts/pyproject.toml
+++ b/.github/scripts/pyproject.toml
@@ -25,3 +25,8 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
+
+[tool.ruff.lint.isort]
+# Without this, whether these count as first-party depends on the directory ruff is
+# invoked from, so import order lints flip depending on the caller's cwd.
+known-first-party = ["fuzz_report", "pr_panel"]

--- a/.github/scripts/pyproject.toml
+++ b/.github/scripts/pyproject.toml
@@ -7,6 +7,12 @@ dependencies = [
     "jinja2>=3.1",
 ]
 
+[tool.setuptools]
+# Pin the packaged module: `pip install -e .github/scripts` installs the fuzz reporter
+# only. Sibling packages here (e.g. `pr_panel`) are run directly with `python3 -m` and
+# would otherwise break setuptools' flat-layout auto-discovery.
+packages = ["fuzz_report"]
+
 [project.optional-dependencies]
 dev = [
     "pytest>=7",

--- a/.github/scripts/tests/conftest.py
+++ b/.github/scripts/tests/conftest.py
@@ -1,0 +1,9 @@
+#  SPDX-License-Identifier: Apache-2.0
+#  SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+"""Make the sibling script packages importable without installing them."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/.github/scripts/tests/test_pr_panel.py
+++ b/.github/scripts/tests/test_pr_panel.py
@@ -1,0 +1,204 @@
+#  SPDX-License-Identifier: Apache-2.0
+#  SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+"""Tests for the PR control panel render/parse/apply cycle."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pr_panel.panel import (
+    MARKER,
+    apply_edit,
+    initial_state,
+    marker_id,
+    parse_checkboxes,
+    parse_state,
+    render,
+    render_report,
+)
+from pr_panel.spec import PANEL, Button, Radio, Toggle
+
+
+def click(body: str, control_id: str) -> str:
+    """Flip one checkbox the way GitHub rewrites the body when a user clicks it."""
+    lines = body.splitlines()
+    for i, line in enumerate(lines):
+        if line.rstrip().endswith(f"<!--c:{control_id}-->"):
+            if "- [ ]" in line:
+                lines[i] = line.replace("- [ ]", "- [x]", 1)
+            else:
+                lines[i] = line.replace("- [x]", "- [ ]", 1)
+            return "\n".join(lines) + "\n"
+    raise AssertionError(f"no control line for {control_id!r}")
+
+
+@pytest.fixture
+def fresh() -> str:
+    return render(initial_state())
+
+
+def test_control_ids_are_unique():
+    ids = [c.id for c in PANEL.controls()]
+    assert len(ids) == len(set(ids))
+
+
+def test_fresh_panel_carries_marker_and_state(fresh: str):
+    assert fresh.startswith(MARKER)
+    assert parse_state(fresh).controls == PANEL.default_state()
+
+
+def test_every_control_is_rendered_and_parseable(fresh: str):
+    found = parse_checkboxes(fresh)
+    for control in PANEL.controls():
+        if isinstance(control, Radio):
+            for option in control.options:
+                assert marker_id(control, option.id) in found
+        else:
+            assert control.id in found
+
+
+def test_render_is_idempotent(fresh: str):
+    assert apply_edit(fresh).body == fresh
+    assert apply_edit(fresh).changed is False
+
+
+def test_toggle_click_is_persisted(fresh: str):
+    result = apply_edit(click(fresh, "suite.sql"))
+    assert result.state.controls["suite.sql"] is True
+    # The user's own click already left the comment correct, so there is nothing to
+    # write back to GitHub.
+    assert result.changed is False
+
+    result = apply_edit(click(result.body, "suite.sql"))
+    assert result.state.controls["suite.sql"] is False
+
+
+def test_radio_selection_unchecks_siblings(fresh: str):
+    result = apply_edit(click(fresh, "runner.machine:g5.xlarge"))
+
+    assert result.state.controls["runner.machine"] == "g5.xlarge"
+    assert result.changed is True
+
+    checked = parse_checkboxes(result.body)
+    selected = [k for k, v in checked.items() if k.startswith("runner.machine:") and v]
+    assert selected == ["runner.machine:g5.xlarge"]
+
+
+def test_radio_cannot_be_emptied(fresh: str):
+    """Unchecking the selected option restores it: a group always has a selection."""
+    result = apply_edit(click(fresh, "runner.machine:c6id.metal"))
+
+    assert result.state.controls["runner.machine"] == "c6id.metal"
+    assert parse_checkboxes(result.body)["runner.machine:c6id.metal"] is True
+
+
+def test_two_clicks_landing_in_one_event_pick_the_last(fresh: str):
+    """A user can out-click the workflow; the newest selection wins."""
+    body = click(click(fresh, "runner.machine:c7i.8xlarge"), "runner.machine:g5.xlarge")
+    result = apply_edit(body)
+
+    assert result.state.controls["runner.machine"] == "g5.xlarge"
+
+
+def test_button_press_dispatches_and_clears(fresh: str):
+    result = apply_edit(click(fresh, "action.run"), actor="ada", timestamp="2026-01-01T00:00:00Z")
+
+    assert result.pressed == ["action.run"]
+    assert result.dispatched == ["run"]
+    assert result.changed is True
+    # The button must not stay pressed, or the next edit would re-dispatch it.
+    assert parse_checkboxes(result.body)["action.run"] is False
+    assert result.state.last == {
+        "actions": ["run"],
+        "by": "ada",
+        "at": "2026-01-01T00:00:00Z",
+    }
+    assert "Last dispatched `run` by @ada" in result.body
+
+
+def test_button_press_carries_current_settings(fresh: str):
+    body = apply_edit(click(fresh, "suite.sql")).body
+    body = apply_edit(click(body, "options.preset:pr-full")).body
+    result = apply_edit(click(body, "action.run"))
+
+    assert result.state.controls["suite.sql"] is True
+    assert result.state.controls["options.preset"] == "pr-full"
+
+
+def test_reset_restores_defaults_without_dispatching(fresh: str):
+    body = apply_edit(click(fresh, "suite.sql")).body
+    body = apply_edit(click(body, "runner.machine:g5.xlarge")).body
+
+    result = apply_edit(click(body, "action.reset"))
+
+    assert result.state.controls == PANEL.default_state()
+    assert result.dispatched == []
+    assert result.changed is True
+
+
+def test_state_survives_a_full_round_trip(fresh: str):
+    body = apply_edit(click(fresh, "options.profile")).body
+    reparsed = parse_state(body)
+
+    assert reparsed.controls["options.profile"] is True
+    assert json.loads(reparsed.to_json())["v"] == 1
+
+
+def test_corrupt_state_blob_falls_back_to_the_checkboxes(fresh: str):
+    blob = fresh[fresh.index("<!--vortex-pr-panel:state:") :]
+    body = click(fresh.replace(blob, "<!--vortex-pr-panel:state:not json-->\n"), "suite.sql")
+
+    result = apply_edit(body)
+
+    assert result.state.controls["suite.sql"] is True
+
+
+def test_prose_edits_do_not_lose_state(fresh: str):
+    """A human editing the comment text is repaired on the next apply."""
+    mangled = fresh.replace("### Suites", "### Suites (edited by hand)")
+    result = apply_edit(click(mangled, "suite.sql"))
+
+    assert result.state.controls["suite.sql"] is True
+    assert "### Suites (edited by hand)" not in result.body
+    assert result.changed is True
+
+
+def test_revision_advances_only_on_visible_change(fresh: str):
+    assert parse_state(fresh).revision == 1
+    assert apply_edit(fresh).state.revision == 1
+    assert apply_edit(click(fresh, "action.run")).state.revision == 2
+
+
+def test_report_renders_every_non_button_control(fresh: str):
+    state = parse_state(click(fresh, "suite.sql")).to_json()
+    report = render_report(state, run_url="https://example.invalid/run/1", actions="run")
+
+    for control in PANEL.controls():
+        if isinstance(control, Button):
+            assert f"`{control.id}`" not in report
+        else:
+            assert f"`{control.id}`" in report
+    assert "https://example.invalid/run/1" in report
+
+
+def test_report_shows_toggle_and_radio_values(fresh: str):
+    report = render_report(parse_state(fresh).to_json())
+
+    assert "✅ on" in report
+    assert "⬜ off" in report
+    assert "`c6id.metal`" in report
+
+
+def test_report_tolerates_empty_state():
+    assert "Panel run report" in render_report("")
+
+
+@pytest.mark.parametrize("control", [c for c in PANEL.controls() if isinstance(c, Toggle)])
+def test_each_toggle_round_trips(fresh: str, control: Toggle):
+    result = apply_edit(click(fresh, control.id))
+
+    assert result.state.controls[control.id] is (not control.default)
+    assert result.dispatched == []

--- a/.github/scripts/tests/test_pr_panel.py
+++ b/.github/scripts/tests/test_pr_panel.py
@@ -172,6 +172,31 @@ def test_revision_advances_only_on_visible_change(fresh: str):
     assert apply_edit(click(fresh, "action.run")).state.revision == 2
 
 
+def test_notice_renders_and_survives_clicks(fresh: str):
+    announced = apply_edit(fresh, notice="preview window is open").body
+    assert "> preview window is open" in announced
+
+    clicked = apply_edit(click(announced, "suite.sql"))
+    assert clicked.state.notice == "preview window is open"
+    assert "> preview window is open" in clicked.body
+
+
+def test_notice_is_collapsed_to_one_blockquote_line(fresh: str):
+    body = apply_edit(fresh, notice="wrapped\n   across    lines").body
+
+    assert "> wrapped across lines" in body
+    # A raw newline here would terminate the blockquote and break the panel layout.
+    assert "\n> wrapped" in body and "lines\n" in body
+
+
+def test_notice_can_be_replaced_and_cleared(fresh: str):
+    body = apply_edit(fresh, notice="first").body
+    body = apply_edit(body, notice="second").body
+    assert "> second" in body and "first" not in body
+
+    assert apply_edit(body, notice="").state.notice == ""
+
+
 def test_report_renders_every_non_button_control(fresh: str):
     state = parse_state(click(fresh, "suite.sql")).to_json()
     report = render_report(state, run_url="https://example.invalid/run/1", actions="run")

--- a/.github/scripts/upsert-comment.sh
+++ b/.github/scripts/upsert-comment.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#  SPDX-License-Identifier: Apache-2.0
+#  SPDX-FileCopyrightText: Copyright the Vortex contributors
+#
+# Create or update a marker-tagged comment on an issue or pull request, so repeated
+# runs edit one comment instead of piling up new ones.
+#
+# Usage: upsert-comment.sh <owner/repo> <issue-number> <marker> <body-file>
+# Requires: gh (authenticated via GH_TOKEN), jq.
+
+set -Eeuo pipefail
+
+repo="$1"
+issue="$2"
+marker="$3"
+body_file="$4"
+
+comments="$(mktemp)"
+gh api "/repos/${repo}/issues/${issue}/comments" --paginate >"${comments}"
+
+# `--paginate` emits one JSON array per page, which jq reads as a stream.
+existing="$(jq -r --arg marker "${marker}" \
+  '.[] | select(.body | contains($marker)) | .id' "${comments}" | head -n 1)"
+
+payload="$(jq -n --rawfile body "${body_file}" '{body: $body}')"
+
+if [ -n "${existing}" ]; then
+  printf '%s' "${payload}" |
+    gh api --silent --method PATCH "/repos/${repo}/issues/comments/${existing}" --input -
+  echo "Updated comment ${existing}"
+else
+  printf '%s' "${payload}" |
+    gh api --silent --method POST "/repos/${repo}/issues/${issue}/comments" --input -
+  echo "Created a new comment on #${issue}"
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,23 @@ jobs:
           uv run --no-project --with pytest --with xxhash \
             pytest scripts/tests/test_measurement_id.py
 
+  # The PR control panel encodes its state in the markdown of a bot comment, so a
+  # render/parse regression silently drops whatever the user clicked. These tests are
+  # pure stdlib and take under a second.
+  pr-panel:
+    name: "PR control panel"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: spiraldb/actions/.github/actions/setup-uv@a746510eafaa926484c354541cfc49b2ec06cc63  # 0.18.6
+        with:
+          sync: false
+      - name: Pytest - PR control panel
+        run: |
+          uv run --no-project --with pytest \
+            pytest .github/scripts/tests/test_pr_panel.py
+
   python-cuda-test:
     name: "Python CUDA (test)"
     if: github.repository == 'vortex-data/vortex'

--- a/.github/workflows/pr-panel-run.yml
+++ b/.github/workflows/pr-panel-run.yml
@@ -1,0 +1,70 @@
+#  SPDX-License-Identifier: Apache-2.0
+#  SPDX-FileCopyrightText: Copyright the Vortex contributors
+#
+# The downstream half of the PR control panel.
+#
+# `pr-panel.yml` dispatches this workflow when a panel button is pressed, handing over
+# the panel state as JSON. Today it only renders that state back to the PR, which is
+# the point: it proves the settings survive the hop into a separate workflow run. This
+# is where a real benchmark run would eventually be launched from.
+
+name: PR Control Panel Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number to report back to"
+        required: true
+        type: string
+      state:
+        description: "Panel state as JSON"
+        required: true
+        type: string
+      actions:
+        description: "Comma-separated button actions that triggered this run"
+        required: false
+        type: string
+        default: ""
+
+concurrency:
+  group: pr-panel-run-${{ github.event.inputs.pr }}
+  cancel-in-progress: false
+
+permissions: { }
+
+jobs:
+  report:
+    name: Report panel state
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write  # PR conversation comments go through the issues API
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
+
+      - name: Render the received state
+        working-directory: .github/scripts
+        env:
+          PANEL_STATE: ${{ inputs.state }}
+          PANEL_ACTIONS: ${{ inputs.actions }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 -m pr_panel report \
+            --state "$PANEL_STATE" \
+            --actions "$PANEL_ACTIONS" \
+            --run-url "$RUN_URL" \
+            --out "$RUNNER_TEMP/report.md"
+          cat "$RUNNER_TEMP/report.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post the report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ inputs.pr }}
+        run: |
+          bash .github/scripts/upsert-comment.sh \
+            "$REPO" "$PR" "<!-- vortex-pr-panel-report -->" "$RUNNER_TEMP/report.md"

--- a/.github/workflows/pr-panel.yml
+++ b/.github/workflows/pr-panel.yml
@@ -169,7 +169,8 @@ jobs:
       github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Must comfortably exceed PREVIEW_WINDOW_SECONDS below.
+    timeout-minutes: 130
     concurrency:
       # A newer push supersedes the window a previous one opened.
       group: pr-panel-preview-${{ github.event.pull_request.number }}
@@ -204,8 +205,12 @@ jobs:
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Long enough that a reviewer can come back to the PR and still find it live.
+          # Only ever runs on PRs that change the panel.
+          PREVIEW_WINDOW_SECONDS: "7200"
         run: |
-          bash .github/scripts/pr-panel-preview.sh "$REPO" "$PR" 1800 15 \
-            "Clicks are being applied live by [a preview run]($RUN_URL) for the next 30
-            minutes, because \`issue_comment\` workflows only run from the default
-            branch. Once this is merged, clicks apply in seconds with no preview run."
+          bash .github/scripts/pr-panel-preview.sh "$REPO" "$PR" "$PREVIEW_WINDOW_SECONDS" 15 \
+            "Clicks are being applied live by [a preview run]($RUN_URL) for the next
+            $((PREVIEW_WINDOW_SECONDS / 60)) minutes, because \`issue_comment\` workflows
+            only run from the default branch. Once this is merged, clicks apply in
+            seconds with no preview run."

--- a/.github/workflows/pr-panel.yml
+++ b/.github/workflows/pr-panel.yml
@@ -1,0 +1,150 @@
+#  SPDX-License-Identifier: Apache-2.0
+#  SPDX-FileCopyrightText: Copyright the Vortex contributors
+#
+# Interactive control panel for pull requests.
+#
+# A markdown task list in a bot comment is the only clickable control GitHub gives us:
+# toggling a checkbox rewrites the comment body, which arrives here as
+# `issue_comment: edited`. This workflow diffs the checkboxes against the state blob
+# embedded in the comment, redraws the comment from canonical state, and dispatches
+# `pr-panel-run.yml` when a button was pressed.
+#
+# Notes for anyone changing this file:
+#
+# - `issue_comment` workflows always run from the *default branch*. Edits here do not
+#   take effect on a PR until they are merged; use `.github/scripts/pr_panel demo` and
+#   the unit tests to iterate locally.
+# - `pull_request_target` is used only so that PRs from forks also get a panel; a fork
+#   PR gets a read-only token under `pull_request`. Nothing here checks out or executes
+#   PR head code, so the elevated token never sees untrusted input.
+# - Edits made with `GITHUB_TOKEN` do not trigger workflows, so redrawing the comment
+#   cannot loop back into this workflow.
+# - Only users with write access can tick a checkbox on someone else's comment, so
+#   GitHub's own permissions are the authorization model.
+
+name: PR Control Panel
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  issue_comment:
+    types: [edited]
+
+concurrency:
+  # Serialize per PR: two quick clicks must not interleave their read-modify-write of
+  # the comment body. Never cancel, or a click would be silently dropped.
+  group: pr-panel-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions: { }
+
+jobs:
+  post:
+    name: Post panel
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write  # PR conversation comments go through the issues API
+      pull-requests: write
+    steps:
+      # Checks out the base branch, never the PR head.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
+
+      - name: Render panel
+        working-directory: .github/scripts
+        run: python3 -m pr_panel render --out "$RUNNER_TEMP/panel.md"
+
+      - name: Post panel comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          bash .github/scripts/upsert-comment.sh \
+            "$REPO" "$PR" "<!-- vortex-pr-panel -->" "$RUNNER_TEMP/panel.md"
+
+  apply:
+    name: Apply click
+    # Only react to edits of a panel comment, and never to our own write-back.
+    if: >-
+      github.event_name == 'issue_comment'
+      && github.event.issue.pull_request
+      && github.event.comment.user.login == 'github-actions[bot]'
+      && github.event.sender.login != 'github-actions[bot]'
+      && contains(github.event.comment.body, '<!-- vortex-pr-panel -->')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: write  # dispatch pr-panel-run.yml
+      issues: write  # edit the panel comment
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
+
+      # Re-read the body instead of trusting the event payload: if clicks queued up,
+      # the payload is already stale.
+      - name: Fetch current panel body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api "/repos/$REPO/issues/comments/$COMMENT_ID" --jq .body \
+            > "$RUNNER_TEMP/current.md"
+
+      - name: Apply the click
+        id: apply
+        working-directory: .github/scripts
+        env:
+          ACTOR: ${{ github.event.sender.login }}
+        run: |
+          python3 -m pr_panel apply \
+            --body "$RUNNER_TEMP/current.md" \
+            --out "$RUNNER_TEMP/next.md" \
+            --actor "$ACTOR" \
+            --timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+      - name: Redraw the panel
+        if: steps.apply.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          jq -n --rawfile body "$RUNNER_TEMP/next.md" '{body: $body}' \
+            | gh api --silent --method PATCH \
+                "/repos/$REPO/issues/comments/$COMMENT_ID" --input -
+
+      - name: Dispatch the run
+        if: steps.apply.outputs.dispatch == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.event.repository.default_branch }}
+          PR: ${{ github.event.issue.number }}
+          PANEL_ACTIONS: ${{ steps.apply.outputs.actions }}
+          PANEL_STATE: ${{ steps.apply.outputs.state }}
+        run: |
+          gh api --silent --method POST \
+            "/repos/$REPO/actions/workflows/pr-panel-run.yml/dispatches" \
+            -f "ref=$REF" \
+            -f "inputs[pr]=$PR" \
+            -f "inputs[actions]=$PANEL_ACTIONS" \
+            -f "inputs[state]=$PANEL_STATE"
+
+      - name: Summary
+        env:
+          PANEL_ACTIONS: ${{ steps.apply.outputs.actions }}
+          CHANGED: ${{ steps.apply.outputs.changed }}
+        run: |
+          {
+            echo "### PR control panel"
+            echo ""
+            echo "- redrawn: \`$CHANGED\`"
+            echo "- dispatched: \`${PANEL_ACTIONS:-none}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr-panel.yml
+++ b/.github/workflows/pr-panel.yml
@@ -11,12 +11,13 @@
 #
 # Notes for anyone changing this file:
 #
-# - `issue_comment` workflows always run from the *default branch*. Edits here do not
-#   take effect on a PR until they are merged; use `.github/scripts/pr_panel demo` and
-#   the unit tests to iterate locally.
-# - `pull_request_target` is used only so that PRs from forks also get a panel; a fork
-#   PR gets a read-only token under `pull_request`. Nothing here checks out or executes
-#   PR head code, so the elevated token never sees untrusted input.
+# - `issue_comment` workflows always run from the *default branch*. Edits to the apply
+#   path do not reach a PR until they are merged, which is what the `preview` job below
+#   exists to work around.
+# - Same-repo PRs post the panel via `pull_request`, so the panel is rendered by the
+#   PR's own code and can be iterated on before merge. Fork PRs get a read-only token
+#   under `pull_request`, so they are handled by `pull_request_target` instead — which
+#   checks out the base branch and never executes fork code.
 # - Edits made with `GITHUB_TOKEN` do not trigger workflows, so redrawing the comment
 #   cannot loop back into this workflow.
 # - Only users with write access can tick a checkbox on someone else's comment, so
@@ -25,30 +26,35 @@
 name: PR Control Panel
 
 on:
+  pull_request:
+    types: [opened, reopened, synchronize]
   pull_request_target:
     types: [opened, reopened]
   issue_comment:
     types: [edited]
-
-concurrency:
-  # Serialize per PR: two quick clicks must not interleave their read-modify-write of
-  # the comment body. Never cancel, or a click would be silently dropped.
-  group: pr-panel-${{ github.event.issue.number || github.event.pull_request.number }}
-  cancel-in-progress: false
 
 permissions: { }
 
 jobs:
   post:
     name: Post panel
-    if: github.event_name == 'pull_request_target'
+    # One of the two PR triggers handles any given PR, never both: `pull_request` for
+    # same-repo branches, `pull_request_target` for forks.
+    if: >-
+      (github.event_name == 'pull_request'
+       && github.event.pull_request.head.repo.full_name == github.repository)
+      || (github.event_name == 'pull_request_target'
+          && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: pr-panel-post-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       issues: write  # PR conversation comments go through the issues API
       pull-requests: write
     steps:
-      # Checks out the base branch, never the PR head.
+      # For `pull_request_target` this is the base branch, never the fork's head.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           persist-credentials: false
@@ -77,6 +83,11 @@ jobs:
       && contains(github.event.comment.body, '<!-- vortex-pr-panel -->')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      # Serialize per PR: two quick clicks must not interleave their read-modify-write
+      # of the comment body. Never cancel, or a click would be silently dropped.
+      group: pr-panel-apply-${{ github.event.issue.number }}
+      cancel-in-progress: false
     permissions:
       actions: write  # dispatch pr-panel-run.yml
       issues: write  # edit the panel comment
@@ -148,3 +159,53 @@ jobs:
             echo "- redrawn: \`$CHANGED\`"
             echo "- dispatched: \`${PANEL_ACTIONS:-none}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  preview:
+    name: Preview clicks
+    # Only for PRs that change the panel itself. Those are exactly the PRs whose apply
+    # path cannot be exercised, because `issue_comment` runs from the default branch.
+    needs: post
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    concurrency:
+      # A newer push supersedes the window a previous one opened.
+      group: pr-panel-preview-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check whether this PR touches the panel
+        id: touched
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -Eeuo pipefail
+          if git diff --name-only "$BASE_SHA...HEAD" \
+              | grep -Eq '^\.github/(scripts/pr[-_]panel|workflows/pr-panel)'; then
+            echo "yes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "yes=false" >> "$GITHUB_OUTPUT"
+            echo "Panel unchanged; skipping the preview window." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Watch for clicks
+        if: steps.touched.outputs.yes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          bash .github/scripts/pr-panel-preview.sh "$REPO" "$PR" 1800 15 \
+            "Clicks are being applied live by [a preview run]($RUN_URL) for the next 30
+            minutes, because \`issue_comment\` workflows only run from the default
+            branch. Once this is merged, clicks apply in seconds with no preview run."


### PR DESCRIPTION
## Rationale for this change

Benchmarks are triggered today by adding an `action/benchmark*` label, which the bot removes once the run starts. That works for a handful of switches, but the combinations (suite × runner × preset × flags) have outgrown what a flat label list can express or display — you cannot see the current configuration anywhere, and every new knob is another label.

This PR proves out an alternative UX: a comment posted unconditionally on every PR that behaves like a form. It is deliberately **not** wired to any real benchmark — the goal is to validate the interaction model before moving the benchmark plumbing onto it.

### Does GitHub actually support this?

Yes, with one primitive: the markdown task-list checkbox is the only clickable control GitHub renders in a comment. Ticking one rewrites the comment body and delivers `issue_comment: edited`. Everything else is built on top of that:

```
user ticks a box
      │
      ▼
issue_comment: edited ──► pr-panel.yml (apply)
                              │  parse checkboxes, diff against the embedded state blob
                              │  canonicalize (radios, momentary buttons)
                              ├─► PATCH the comment  ──► panel redraws
                              └─► workflow_dispatch  ──► pr-panel-run.yml
                                                            renders the state back to the PR
```

The comment body is the entire storage layer. Each control is a tagged task-list line, and a trailing HTML comment records the state as of the last render:

```markdown
- [x] Random access <!--c:suite.random_access-->
...
<!--vortex-pr-panel:state:{"controls":{...},"rev":3,"v":1}-->
```

Diffing the checkboxes against that blob identifies which control was clicked, which is what makes controls richer than a bare checkbox expressible:

| Control | Behaviour |
| --- | --- |
| `Toggle` | Persistent on/off. |
| `Radio` | Pick-one — checking an option unchecks its siblings on redraw; unchecking the selected one restores it, so a group is never empty. |
| `Button` | Momentary — a tick dispatches an action and is cleared on redraw, mirroring today's add-label/remove-label pattern. |
| `Section` | Grouping; a closed section renders as a folded `<details>` block. |

Properties that fall out of the design:

- **Authorization is GitHub's own.** Only users with write access can tick a checkbox on someone else's comment, so there is no separate permission check.
- **No feedback loop.** The redraw is written with `GITHUB_TOKEN`, and edits made with that token do not trigger workflows.
- **Races are serialized.** A per-PR concurrency group that never cancels, plus re-reading the body from the API instead of trusting the (possibly stale) event payload.
- **Hand edits self-heal**, because the comment is redrawn from canonical state.
- **Redraws are skipped when they would be a no-op** — ticking a toggle already leaves the comment correct, so only radios and buttons force a write-back.

## What changes are included in this PR?

- `.github/scripts/pr_panel/` — the panel itself. `spec.py` is a declarative control tree (adding a knob is a few lines there and nothing else); `panel.py` holds render, parse, and click semantics; `__main__.py` is the CLI used by the workflows, plus a `demo` subcommand that renders the panel and simulates clicks locally.
- `.github/workflows/pr-panel.yml` — posts the panel on PR open/reopen, and applies clicks on `issue_comment: edited`.
- `.github/workflows/pr-panel-run.yml` — the dispatched downstream workflow. It renders the received state as a table into the job summary and a PR comment, which is what demonstrates that the settings cross the workflow boundary intact. This is where a benchmark run would eventually be launched from.
- `.github/scripts/upsert-comment.sh` — marker-based find-or-create so repeated runs edit one comment instead of piling up.
- `ci.yml` — a `pr-panel` job running the 24 unit tests (pure stdlib, well under a second).
- `.github/scripts/pyproject.toml` — pins `packages = ["fuzz_report"]`, so that adding a sibling package here does not break `pip install -e .github/scripts` via setuptools flat-layout auto-discovery.

### Two things to validate on a live PR

Both are load-bearing assumptions that unit tests cannot cover, and neither takes effect until this is merged, because `issue_comment` and `pull_request_target` workflows always run from the default branch:

1. That a checkbox toggle inside a collapsed `<details>` block stays clickable. The `Runner` and `Options` sections are deliberately collapsed to exercise this; if it does not hold, the fallback is rendering every section as a plain open heading, which is a one-line change in `spec.py`.
2. End-to-end latency of the click → redraw loop, which determines whether the interaction feels responsive enough to keep.

## What APIs are changed? Are there any user-facing changes?

No library or public API changes — this is CI tooling only. It adds no behaviour to existing workflows: the current `action/benchmark*` labels and `bench-dispatch.yml` are untouched, and the panel dispatches nothing but its own no-op reporting workflow.

The user-facing change is a new bot comment on every PR once merged. `.github/scripts/pr_panel/README.md` documents the design and how to iterate locally.

### Checks run

- `uv run --no-project --with pytest pytest .github/scripts/tests/test_pr_panel.py` — 24 passed
- `yamllint --strict -c .yamllint.yaml .github/` — clean
- `ruff check --config .github/scripts/pyproject.toml pr_panel tests` — clean
- `reuse lint` — compliant
- `bash -n .github/scripts/upsert-comment.sh`
- Verified `uv pip install --no-deps -e .github/scripts` still resolves `fuzz_report` after the setuptools pin

Not run: Rust checks (`cargo fmt`/`clippy`/`nextest`), as no Rust, feature flags, or generated files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8xYqGxvVBTBjXbN8qa6Vw

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8xYqGxvVBTBjXbN8qa6Vw)_