### PR TITLE
bench(compress): run the full dataset suite under --gpu-decompress

### DIFF
--- a/.github/workflows/gpu-compress-bench-pr.yml
+++ b/.github/workflows/gpu-compress-bench-pr.yml
@@ -52,9 +52,10 @@ jobs:
           # `Patches` into a top-level `vortex.patched` array, which has no CUDA decode
           # kernel and makes GPU decompression fail with "No CUDA kernel for encoding
           # vortex.patched". Leaving it unset keeps patches inline in the bitpacked array,
-          # which the CUDA bitpacked kernel decodes. This matches the GPU test workflow
-          # (cuda.yaml), which also sets only FLAT_LAYOUT_INLINE_ARRAY_NODE.
-          FLAT_LAYOUT_INLINE_ARRAY_NODE: "1"
+          # which the CUDA bitpacked kernel decodes.
+          # The flat layout reads this as enabled only when it is exactly "1", so "0" leaves
+          # the array node out of line, as it was before the inline node was introduced.
+          FLAT_LAYOUT_INLINE_ARRAY_NODE: "0"
         run: |
           bash scripts/bench-taskset.sh target/release_debug/compress-bench \
             --gpu-decompress -d table > gpu-compress.txt

--- a/benchmarks/compress-bench/README.md
+++ b/benchmarks/compress-bench/README.md
@@ -15,12 +15,20 @@ See [`src/main.rs`](./src/main.rs) for the dataset list and CLI flags (`--format
 cargo run -p compress-bench --profile release_debug
 ```
 
-GPU decompression is opt-in and runs only the existing benchmark names allow-listed in
-`src/main.rs`:
+GPU decompression is opt-in. By default it runs only the existing benchmark names
+allow-listed in `src/main.rs`:
 
 ```bash
 cargo run -p compress-bench --profile release_debug \
   --features cuda,unstable_encodings -- --gpu-decompress
+```
+
+An explicit `--datasets` filter overrides the allow-list, which is how you run a
+not-yet-promoted dataset on GPU to do the end-to-end verification that promotes it:
+
+```bash
+cargo run -p compress-bench --profile release_debug \
+  --features cuda,unstable_encodings -- --gpu-decompress --datasets 'Arade'
 ```
 
 On Linux, GPU files are read with direct IO (`O_DIRECT`) so repeated iterations measure

--- a/benchmarks/compress-bench/README.md
+++ b/benchmarks/compress-bench/README.md
@@ -15,20 +15,21 @@ See [`src/main.rs`](./src/main.rs) for the dataset list and CLI flags (`--format
 cargo run -p compress-bench --profile release_debug
 ```
 
-GPU decompression is opt-in. By default it runs only the existing benchmark names
-allow-listed in `src/main.rs`:
+GPU decompression is opt-in and runs the full dataset suite:
 
 ```bash
 cargo run -p compress-bench --profile release_debug \
   --features cuda,unstable_encodings -- --gpu-decompress
 ```
 
-An explicit `--datasets` filter overrides the allow-list, which is how you run a
-not-yet-promoted dataset on GPU to do the end-to-end verification that promotes it:
+A dataset only decodes on GPU if every encoding `only_cuda_compatible()` picks for it has a
+kernel registered in `initialize_cuda`. Where one does not, the run fails with `No CUDA kernel
+for encoding ...` — the `wide table` datasets encode their columns as `vortex.list`, which has
+no kernel. Use `--datasets` to narrow the run to the datasets that decode:
 
 ```bash
 cargo run -p compress-bench --profile release_debug \
-  --features cuda,unstable_encodings -- --gpu-decompress --datasets 'Arade'
+  --features cuda,unstable_encodings -- --gpu-decompress --datasets 'TPC-H l_comment canonical'
 ```
 
 On Linux, GPU files are read with direct IO (`O_DIRECT`) so repeated iterations measure

--- a/benchmarks/compress-bench/src/main.rs
+++ b/benchmarks/compress-bench/src/main.rs
@@ -67,10 +67,11 @@ struct Args {
     ops: Vec<CompressOp>,
     #[arg(long)]
     datasets: Option<String>,
-    /// Run GPU decompression for the allow-listed benchmarks.
+    /// Run GPU decompression instead of CPU decompression.
     ///
-    /// This filters the suite to GPU-supported dataset names and runs only Vortex decompression.
-    /// Passing `--datasets` overrides the allow-list.
+    /// This runs the full dataset suite, restricted to Vortex decompression. A dataset whose
+    /// CUDA-compatible encoding has no matching CUDA kernel fails with "No CUDA kernel for
+    /// encoding ..."; use `--datasets` to narrow the run to those that decode.
     #[arg(long)]
     gpu_decompress: bool,
     #[arg(short, long, default_value_t, value_enum)]
@@ -179,14 +180,6 @@ async fn run_compress(
         // ),
     ];
 
-    // Add an existing benchmark name here only after its CUDA-compatible compression and
-    // decompression kernels have been verified end to end.
-    #[expect(
-        clippy::useless_vec,
-        reason = "this is an intentionally incremental allow-list of benchmark names"
-    )]
-    let gpu_decompress_benchmarks = vec!["TPC-H l_comment canonical"];
-
     let datasets: Vec<&dyn Dataset> = [
         &TaxiData as &dyn Dataset,
         PBI_DATASETS.get(Arade),
@@ -208,14 +201,6 @@ async fn run_compress(
     .into_iter()
     .chain(structlistofints.iter().map(|d| d as &dyn Dataset))
     .filter(|d| {
-        // An explicit `--datasets` filter overrides the allow-list, so the remaining CPU
-        // datasets can be run on GPU to do the end-to-end verification that promotes them.
-        if gpu_decompress
-            && datasets_filter.is_none()
-            && !gpu_decompress_benchmarks.contains(&d.name())
-        {
-            return false;
-        }
         if let Some(filter) = datasets_filter.as_ref() {
             filter.is_match(d.name())
         } else {

--- a/benchmarks/compress-bench/src/main.rs
+++ b/benchmarks/compress-bench/src/main.rs
@@ -70,6 +70,7 @@ struct Args {
     /// Run GPU decompression for the allow-listed benchmarks.
     ///
     /// This filters the suite to GPU-supported dataset names and runs only Vortex decompression.
+    /// Passing `--datasets` overrides the allow-list.
     #[arg(long)]
     gpu_decompress: bool,
     #[arg(short, long, default_value_t, value_enum)]
@@ -207,7 +208,12 @@ async fn run_compress(
     .into_iter()
     .chain(structlistofints.iter().map(|d| d as &dyn Dataset))
     .filter(|d| {
-        if gpu_decompress && !gpu_decompress_benchmarks.contains(&d.name()) {
+        // An explicit `--datasets` filter overrides the allow-list, so the remaining CPU
+        // datasets can be run on GPU to do the end-to-end verification that promotes them.
+        if gpu_decompress
+            && datasets_filter.is_none()
+            && !gpu_decompress_benchmarks.contains(&d.name())
+        {
             return false;
         }
         if let Some(filter) = datasets_filter.as_ref() {


### PR DESCRIPTION
## Rationale for this change

`compress-bench` runs fifteen datasets on CPU but the GPU decompression path was allow-listed to a single benchmark name, `TPC-H l_comment canonical`. The comment above the allow-list said a name goes in only after its CUDA compress and decompress have been verified end to end — but the allow-list filter ran *before* the `--datasets` regex, so `--gpu-decompress --datasets taxi` selected zero benchmarks. There was no way to run a candidate dataset on GPU to do the verification that would promote it.

This opens the GPU path up to the whole suite so we can find out where each dataset actually stands.

## What changes are included in this PR?

- Removes the `gpu_decompress_benchmarks` allow-list, so `--gpu-decompress` covers the same datasets as a CPU run.
- Sets `FLAT_LAYOUT_INLINE_ARRAY_NODE` to `"0"` in `gpu-compress-bench-pr.yml`, so the job writes the array node out of line. The flat layout treats the variable as enabled only when it is exactly `"1"`.
- Updates the README to describe the new behaviour and how to narrow a run.

### Expected failures

Not every dataset decodes on GPU yet. A dataset works only if every encoding `only_cuda_compatible()` selects for it has a kernel registered in `initialize_cuda` — there is no CPU fallback, an unregistered encoding is a hard error from `hybrid_dispatch`.

Encoding the `wide table` datasets through the GPU write path locally gives columns of `vortex.list`, with `vortex.primitive` elements and `vortex.sequence` offsets. `vortex.list` has no registered kernel, so those six benchmarks are expected to fail with `No CUDA kernel for encoding vortex.list`. Since `benchmark_decompress` propagates with `?`, the first failure aborts the run — this PR is a draft so we can see how far the GPU job gets before deciding whether to skip-and-report instead of aborting.

The remaining datasets (`taxi`, the six Public BI tables, `TPC-H l_comment chunked`) are untested; their data could not be fetched locally.

Separately, `string::NullDominatedSparseScheme` (`vortex.string.sparse`) is missing from the `only_cuda_compatible()` exclusion list even though it produces `Sparse`, which has no CUDA kernel. The integer and float variants are both excluded. Null-heavy string columns are exactly what the Public BI tables have, so this is a likely second failure source. Not fixed here.

## What APIs are changed? Are there any user-facing changes?

No API changes. Benchmark-only: `--gpu-decompress` now runs the full suite instead of one dataset, and the GPU CI job runs with the inline flat-layout array node disabled.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnBHYDv6UDMSQnjBMN1vRZ)_