### PR TITLE
Upgrade to fsst 0.6.0 and guard against out of bounds codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3308,9 +3308,9 @@ dependencies = [
 
 [[package]]
 name = "fsst-rs"
-version = "0.5.11"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b13ac798afc0d9194eb4efefef8b9332efbd80b43f302a968cb8cb23b9d5360"
+checksum = "03b614a2a7f2efc50d76c1e47d64b57c55acf6e0e718b0cae78236d147c487d0"
 dependencies = [
  "rustc-hash",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ enum-iterator = "2.0.0"
 env_logger = "0.11"
 fastlanes = "0.6.0"
 flatbuffers = "25.2.10"
-fsst-rs = "0.5.11"
+fsst-rs = "0.6.0"
 futures = { version = "0.3.31", default-features = false }
 fuzzy-matcher = "0.3"
 geo = "0.31.0"

--- a/encodings/fsst/benches/fsst_compress.rs
+++ b/encodings/fsst/benches/fsst_compress.rs
@@ -78,14 +78,6 @@ fn decompress_fsst(bencher: Bencher, (string_count, avg_len, unique_chars): (usi
 }
 
 #[divan::bench(args = BENCH_ARGS)]
-fn train_compressor(bencher: Bencher, (string_count, avg_len, unique_chars): (usize, usize, u8)) {
-    let array = generate_test_data(string_count, avg_len, unique_chars);
-    bencher
-        .with_inputs(|| (&array, SESSION.create_execution_ctx()))
-        .bench_refs(|(array, ctx)| fsst_train_compressor(array, ctx).unwrap())
-}
-
-#[divan::bench(args = BENCH_ARGS)]
 fn pushdown_compare(bencher: Bencher, (string_count, avg_len, unique_chars): (usize, usize, u8)) {
     let array = generate_test_data(string_count, avg_len, unique_chars);
     let len = array.len();

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -717,7 +717,7 @@ impl FSSTData {
     ///
     /// `symbols` and `symbol_lengths` hold only the populated entries; they are padded out to
     /// [`FSST_SYMBOL_TABLE_LEN`] entries so that [`Self::decompressor`] can borrow them without
-    /// copying. Callers that already hold a padded table should use [`Self::try_new_padded`].
+    /// copying.
     ///
     /// The offsets and validity for the codes are stored in the array's slots, not here.
     /// Use [`FSSTArrayExt::codes()`] to reconstruct a full `VarBinArray`.
@@ -740,11 +740,10 @@ impl FSSTData {
         );
         let n_symbols = symbols.len();
         // SAFETY: the symbol table shape is validated above.
+        let symbol_table = Arc::new(FSSTSymbolTable::new(symbols, symbol_lengths, n_symbols));
         unsafe {
-            Ok(Self::new_unchecked(
-                symbols,
-                symbol_lengths,
-                n_symbols,
+            Ok(Self::new_unchecked_with_symbol_table(
+                symbol_table,
                 codes_bytes,
                 len,
             ))
@@ -888,17 +887,6 @@ impl FSSTData {
             len,
             ctx,
         )
-    }
-
-    pub(crate) unsafe fn new_unchecked(
-        symbols: Buffer<Symbol>,
-        symbol_lengths: Buffer<u8>,
-        n_symbols: usize,
-        codes_bytes: BufferHandle,
-        len: usize,
-    ) -> Self {
-        let symbol_table = Arc::new(FSSTSymbolTable::new(symbols, symbol_lengths, n_symbols));
-        unsafe { Self::new_unchecked_with_symbol_table(symbol_table, codes_bytes, len) }
     }
 
     pub(crate) unsafe fn new_unchecked_with_symbol_table(

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -145,7 +145,7 @@ impl VTable for FSST {
         match idx {
             0 => BufferHandle::new_host(
                 array
-                    .padded_symbol_lengths()
+                    .padded_symbols()
                     .slice(0..array.n_symbols())
                     .into_byte_buffer(),
             ),

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -454,13 +454,47 @@ impl FSSTSymbolTable {
     /// `n_symbols` is the number of populated entries; everything past it is padding. Buffers
     /// longer than [`FSST_SYMBOL_TABLE_LEN`] are truncated; callers are expected to have rejected
     /// them already (see [`FSSTData::try_new`]).
-    fn new(symbols: Buffer<Symbol>, symbol_lengths: Buffer<u8>, n_symbols: usize) -> Self {
+    pub(crate) fn new(
+        symbols: Buffer<Symbol>,
+        symbol_lengths: Buffer<u8>,
+        n_symbols: usize,
+    ) -> Self {
         Self {
             padded_symbols: pad_symbol_table(symbols, Symbol::ZERO),
             padded_symbol_lengths: pad_symbol_table(symbol_lengths, 0),
             n_symbols: n_symbols.min(FSST_SYMBOL_TABLE_LEN),
             compressor: OnceLock::new(),
         }
+    }
+
+    /// Builds a symbol table, padding `symbols` and `symbol_lengths` out to
+    /// [`FSST_SYMBOL_TABLE_LEN`] entries if they are shorter.
+    ///
+    /// `n_symbols` is the number of populated entries; everything past it is padding. Buffers
+    /// longer than [`FSST_SYMBOL_TABLE_LEN`] are truncated; callers are expected to have rejected
+    /// them already (see [`FSSTData::try_new`]).
+    pub(crate) fn new_padded(
+        padded_symbols: Buffer<Symbol>,
+        padded_symbol_lengths: Buffer<u8>,
+        n_symbols: usize,
+    ) -> VortexResult<Self> {
+        vortex_ensure!(
+            padded_symbols.len() == FSST_SYMBOL_TABLE_LEN
+                && padded_symbol_lengths.len() == FSST_SYMBOL_TABLE_LEN,
+            InvalidArgument: "padded symbol table must have exactly {FSST_SYMBOL_TABLE_LEN} entries, found {} symbols and {} symbol lengths",
+            padded_symbols.len(),
+            padded_symbol_lengths.len()
+        );
+        vortex_ensure!(
+            n_symbols <= FSST_SYMBOL_TABLE_LEN,
+            InvalidArgument: "n_symbols must be <= {FSST_SYMBOL_TABLE_LEN}, found {n_symbols}"
+        );
+        Ok(Self {
+            padded_symbols,
+            padded_symbol_lengths,
+            n_symbols,
+            compressor: OnceLock::new(),
+        })
     }
 
     /// The populated symbols, excluding the padding added by [`Self::new`].
@@ -522,9 +556,7 @@ fn pad_symbol_table<T: Copy>(buffer: Buffer<T>, pad: T) -> Buffer<T> {
 /// with `pad`.
 ///
 /// FSST symbol tables are stored padded so that [`FSSTData::decompressor`] can borrow them as the
-/// fixed-size arrays [`Decompressor`] requires, without copying. Producers that already hold a
-/// padded table can build one here and hand it to [`FSST::try_new_padded`] to skip the copy that
-/// [`FSST::try_new`] would otherwise make.
+/// fixed-size arrays [`Decompressor`] requires, without copying.
 pub(crate) fn padded_symbol_table<T: Copy>(values: &[T], pad: T) -> Buffer<T> {
     let populated = values.len().min(FSST_SYMBOL_TABLE_LEN);
     let mut padded = BufferMut::with_capacity(FSST_SYMBOL_TABLE_LEN);
@@ -538,10 +570,6 @@ pub struct FSST;
 
 impl FSST {
     /// Build an FSST array from a set of `symbols` and `codes`.
-    ///
-    /// `symbols` and `symbol_lengths` hold only the populated entries; they are padded out to
-    /// [`FSST_SYMBOL_TABLE_LEN`] internally. Callers that already hold a padded symbol table
-    /// should use [`Self::try_new_padded`] to avoid that copy.
     ///
     /// The `codes` VarBinArray is decomposed: its bytes are stored in [`FSSTData`], while
     /// its offsets and validity become array slots. The codes VarBinArray can be
@@ -567,43 +595,6 @@ impl FSST {
         let slots = FSSTData::make_slots(&codes, &uncompressed_lengths);
         let codes_bytes = codes.bytes_handle().clone();
         let data = FSSTData::try_new(symbols, symbol_lengths, codes_bytes, len)?;
-        Ok(unsafe {
-            Array::from_parts_unchecked(ArrayParts::new(FSST, dtype, len, data).with_slots(slots))
-        })
-    }
-
-    /// Build an FSST array from a symbol table that is already padded to
-    /// [`FSST_SYMBOL_TABLE_LEN`] entries, of which the first `n_symbols` are populated.
-    ///
-    /// This is the allocation-free counterpart to [`Self::try_new`] for producers such as
-    /// [`Compressor`], whose symbol table is already stored padded.
-    pub fn try_new_padded(
-        dtype: DType,
-        padded_symbols: Buffer<Symbol>,
-        padded_symbol_lengths: Buffer<u8>,
-        n_symbols: usize,
-        codes: VarBinArray,
-        uncompressed_lengths: ArrayRef,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<FSSTArray> {
-        let len = codes.len();
-        let data = FSSTData::try_new_padded(
-            padded_symbols,
-            padded_symbol_lengths,
-            n_symbols,
-            codes.bytes_handle().clone(),
-            len,
-        )?;
-        FSSTData::validate_parts_from_codes(
-            data.symbol_table.symbols(),
-            data.symbol_table.symbol_lengths(),
-            &codes,
-            &uncompressed_lengths,
-            &dtype,
-            len,
-            ctx,
-        )?;
-        let slots = FSSTData::make_slots(&codes, &uncompressed_lengths);
         Ok(unsafe {
             Array::from_parts_unchecked(ArrayParts::new(FSST, dtype, len, data).with_slots(slots))
         })
@@ -757,40 +748,6 @@ impl FSSTData {
             Ok(Self::new_unchecked(
                 symbols,
                 symbol_lengths,
-                n_symbols,
-                codes_bytes,
-                len,
-            ))
-        }
-    }
-
-    /// Build FSST data from a symbol table that is already padded to [`FSST_SYMBOL_TABLE_LEN`]
-    /// entries, of which the first `n_symbols` are populated.
-    ///
-    /// Unlike [`Self::try_new`], this stores the buffers as given, without copying them.
-    pub fn try_new_padded(
-        padded_symbols: Buffer<Symbol>,
-        padded_symbol_lengths: Buffer<u8>,
-        n_symbols: usize,
-        codes_bytes: BufferHandle,
-        len: usize,
-    ) -> VortexResult<Self> {
-        vortex_ensure!(
-            padded_symbols.len() == FSST_SYMBOL_TABLE_LEN
-                && padded_symbol_lengths.len() == FSST_SYMBOL_TABLE_LEN,
-            InvalidArgument: "padded symbol table must have exactly {FSST_SYMBOL_TABLE_LEN} entries, found {} symbols and {} symbol lengths",
-            padded_symbols.len(),
-            padded_symbol_lengths.len()
-        );
-        vortex_ensure!(
-            n_symbols <= FSST_SYMBOL_TABLE_LEN,
-            InvalidArgument: "n_symbols must be <= {FSST_SYMBOL_TABLE_LEN}, found {n_symbols}"
-        );
-        // SAFETY: the symbol table shape is validated above.
-        unsafe {
-            Ok(Self::new_unchecked(
-                padded_symbols,
-                padded_symbol_lengths,
                 n_symbols,
                 codes_bytes,
                 len,
@@ -1099,6 +1056,7 @@ mod test {
     use crate::array::FSSTArraySlotsExt;
     use crate::array::FSSTData;
     use crate::array::FSSTMetadata;
+    use crate::array::FSSTSymbolTable;
     use crate::array::padded_symbol_table;
     use crate::fsst_compress;
     use crate::fsst_train_compressor;
@@ -1229,20 +1187,14 @@ mod test {
         let symbols_ptr = symbols.as_slice().as_ptr();
         let symbol_lengths_ptr = symbol_lengths.as_slice().as_ptr();
 
-        let data = FSSTData::try_new_padded(
-            symbols,
-            symbol_lengths,
-            1,
-            BufferHandle::new_host(Buffer::<u8>::empty()),
-            0,
-        )?;
+        let data = FSSTSymbolTable::new_padded(symbols, symbol_lengths, 1)?;
 
         assert_eq!(data.padded_symbols().as_slice().as_ptr(), symbols_ptr);
         assert_eq!(
             data.padded_symbol_lengths().as_slice().as_ptr(),
             symbol_lengths_ptr
         );
-        assert_eq!(data.n_symbols(), 1);
+        assert_eq!(data.symbols().len(), 1);
         Ok(())
     }
 
@@ -1251,22 +1203,18 @@ mod test {
     #[test]
     fn rejects_unpadded_input_to_padded_constructor() {
         assert!(
-            FSSTData::try_new_padded(
+            FSSTSymbolTable::new_padded(
                 Buffer::<Symbol>::copy_from([Symbol::from_slice(b"ab000000")]),
                 Buffer::<u8>::copy_from([2]),
                 1,
-                BufferHandle::new_host(Buffer::<u8>::empty()),
-                0,
             )
             .is_err()
         );
         assert!(
-            FSSTData::try_new_padded(
+            FSSTSymbolTable::new_padded(
                 Buffer::<Symbol>::full(Symbol::ZERO, FSST_SYMBOL_TABLE_LEN),
                 Buffer::<u8>::full(0, FSST_SYMBOL_TABLE_LEN),
                 FSST_SYMBOL_TABLE_LEN + 1,
-                BufferHandle::new_host(Buffer::<u8>::empty()),
-                0,
             )
             .is_err()
         );

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -434,7 +434,7 @@ impl Debug for FSSTData {
     }
 }
 
-pub(crate) struct FSSTSymbolTable {
+pub struct FSSTSymbolTable {
     /// Symbols padded out to [`FSST_SYMBOL_TABLE_LEN`] entries, zero-filled past `n_symbols`,
     /// so that a [`Decompressor`] can borrow them without copying.
     padded_symbols: Buffer<Symbol>,
@@ -454,11 +454,7 @@ impl FSSTSymbolTable {
     /// `n_symbols` is the number of populated entries; everything past it is padding. Buffers
     /// longer than [`FSST_SYMBOL_TABLE_LEN`] are truncated; callers are expected to have rejected
     /// them already (see [`FSSTData::try_new`]).
-    pub(crate) fn new(
-        symbols: Buffer<Symbol>,
-        symbol_lengths: Buffer<u8>,
-        n_symbols: usize,
-    ) -> Self {
+    pub fn new(symbols: Buffer<Symbol>, symbol_lengths: Buffer<u8>, n_symbols: usize) -> Self {
         Self {
             padded_symbols: pad_symbol_table(symbols, Symbol::ZERO),
             padded_symbol_lengths: pad_symbol_table(symbol_lengths, 0),
@@ -473,7 +469,7 @@ impl FSSTSymbolTable {
     /// `n_symbols` is the number of populated entries; everything past it is padding. Buffers
     /// longer than [`FSST_SYMBOL_TABLE_LEN`] are truncated; callers are expected to have rejected
     /// them already (see [`FSSTData::try_new`]).
-    pub(crate) fn new_padded(
+    pub fn new_padded(
         padded_symbols: Buffer<Symbol>,
         padded_symbol_lengths: Buffer<u8>,
         n_symbols: usize,
@@ -600,7 +596,7 @@ impl FSST {
         })
     }
 
-    pub(crate) fn try_new_with_symbol_table(
+    pub fn try_new_with_symbol_table(
         dtype: DType,
         symbol_table: Arc<FSSTSymbolTable>,
         codes: VarBinArray,

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -50,6 +50,7 @@ use vortex_array::vtable::ValidityVTable;
 use vortex_array::vtable::child_to_validity;
 use vortex_array::vtable::validity_to_child;
 use vortex_buffer::Buffer;
+use vortex_buffer::BufferMut;
 use vortex_buffer::ByteBuffer;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -84,25 +85,28 @@ impl FSSTMetadata {
     }
 }
 
+/// The number of entries in a fully-populated FSST symbol table.
+///
+/// Code 255 is reserved as the escape code, leaving 255 usable codes. [`Decompressor`] borrows
+/// the symbol table as fixed-size arrays of exactly this length, so Vortex pads the symbols and
+/// symbol lengths buffers out to it on construction.
+pub const FSST_SYMBOL_TABLE_LEN: usize = 255;
+
 impl ArrayHash for FSSTData {
     fn array_hash<H: Hasher>(&self, state: &mut H, precision: EqMode) {
-        self.symbol_table.symbols.array_hash(state, precision);
-        self.symbol_table
-            .symbol_lengths
-            .array_hash(state, precision);
+        self.padded_symbols().array_hash(state, precision);
+        self.padded_symbol_lengths().array_hash(state, precision);
         self.codes_bytes.as_host().array_hash(state, precision);
     }
 }
 
 impl ArrayEq for FSSTData {
     fn array_eq(&self, other: &Self, precision: EqMode) -> bool {
-        self.symbol_table
-            .symbols
-            .array_eq(&other.symbol_table.symbols, precision)
+        self.padded_symbols()
+            .array_eq(other.padded_symbols(), precision)
             && self
-                .symbol_table
-                .symbol_lengths
-                .array_eq(&other.symbol_table.symbol_lengths, precision)
+                .padded_symbol_lengths()
+                .array_eq(other.padded_symbol_lengths(), precision)
             && self
                 .codes_bytes
                 .as_host()
@@ -139,8 +143,8 @@ impl VTable for FSST {
 
     fn buffer(array: ArrayView<'_, Self>, idx: usize) -> BufferHandle {
         match idx {
-            0 => BufferHandle::new_host(array.symbols().clone().into_byte_buffer()),
-            1 => BufferHandle::new_host(array.symbol_lengths().clone().into_byte_buffer()),
+            0 => BufferHandle::new_host(array.symbols().into_byte_buffer()),
+            1 => BufferHandle::new_host(array.symbol_lengths().into_byte_buffer()),
             2 => array.codes_bytes_handle().clone(),
             _ => vortex_panic!("FSSTArray buffer index {idx} out of bounds"),
         }
@@ -270,8 +274,8 @@ impl VTable for FSST {
             };
 
             FSSTData::validate_parts(
-                &symbols,
-                &symbol_lengths,
+                symbols.as_slice(),
+                symbol_lengths.as_slice(),
                 &codes_bytes,
                 &codes_offsets,
                 dtype.nullability(),
@@ -411,8 +415,7 @@ impl Display for FSSTData {
         write!(
             f,
             "len: {}, nsymbols: {}",
-            self.len,
-            self.symbol_table.symbols.len()
+            self.len, self.symbol_table.n_symbols
         )
     }
 }
@@ -420,8 +423,8 @@ impl Display for FSSTData {
 impl Debug for FSSTData {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FSSTArray")
-            .field("symbols", &self.symbol_table.symbols)
-            .field("symbol_lengths", &self.symbol_table.symbol_lengths)
+            .field("symbols", &self.symbols())
+            .field("symbol_lengths", &self.symbol_lengths())
             .field("codes_bytes_len", &self.codes_bytes.len())
             .field("len", &self.len)
             .field("uncompressed_lengths", &"<outer slot>")
@@ -432,26 +435,102 @@ impl Debug for FSSTData {
 }
 
 pub(crate) struct FSSTSymbolTable {
-    symbols: Buffer<Symbol>,
-    symbol_lengths: Buffer<u8>,
+    /// Symbols padded out to [`FSST_SYMBOL_TABLE_LEN`] entries, zero-filled past `n_symbols`,
+    /// so that a [`Decompressor`] can borrow them without copying.
+    padded_symbols: Buffer<Symbol>,
+    /// Symbol lengths padded out to [`FSST_SYMBOL_TABLE_LEN`] entries, zero-filled past
+    /// `n_symbols`.
+    padded_symbol_lengths: Buffer<u8>,
+    /// The number of populated symbols. Entries at or past this index are padding.
+    n_symbols: usize,
     /// Memoized compressor used for push-down of compute by compressing the RHS.
     compressor: OnceLock<Compressor>,
 }
 
 impl FSSTSymbolTable {
-    fn new(symbols: Buffer<Symbol>, symbol_lengths: Buffer<u8>) -> Self {
+    /// Builds a symbol table, padding `symbols` and `symbol_lengths` out to
+    /// [`FSST_SYMBOL_TABLE_LEN`] entries if they are shorter.
+    ///
+    /// `n_symbols` is the number of populated entries; everything past it is padding. Buffers
+    /// longer than [`FSST_SYMBOL_TABLE_LEN`] are truncated; callers are expected to have rejected
+    /// them already (see [`FSSTData::try_new`]).
+    fn new(symbols: Buffer<Symbol>, symbol_lengths: Buffer<u8>, n_symbols: usize) -> Self {
         Self {
-            symbols,
-            symbol_lengths,
+            padded_symbols: pad_symbol_table(symbols, Symbol::ZERO),
+            padded_symbol_lengths: pad_symbol_table(symbol_lengths, 0),
+            n_symbols: n_symbols.min(FSST_SYMBOL_TABLE_LEN),
             compressor: OnceLock::new(),
         }
     }
 
-    fn compressor(&self) -> &Compressor {
-        self.compressor.get_or_init(|| {
-            Compressor::rebuild_from(self.symbols.as_slice(), self.symbol_lengths.as_slice())
-        })
+    /// The populated symbols, excluding the padding added by [`Self::new`].
+    fn symbols(&self) -> &[Symbol] {
+        &self.padded_symbols.as_slice()[..self.n_symbols]
     }
+
+    /// The populated symbol lengths, excluding the padding added by [`Self::new`].
+    fn symbol_lengths(&self) -> &[u8] {
+        &self.padded_symbol_lengths.as_slice()[..self.n_symbols]
+    }
+
+    /// The symbols buffer, padded to exactly [`FSST_SYMBOL_TABLE_LEN`] entries with
+    /// [`Symbol::ZERO`].
+    fn padded_symbols(&self) -> &Buffer<Symbol> {
+        &self.padded_symbols
+    }
+
+    /// The symbol lengths buffer, padded to exactly [`FSST_SYMBOL_TABLE_LEN`] entries with zeros.
+    fn padded_symbol_lengths(&self) -> &Buffer<u8> {
+        &self.padded_symbol_lengths
+    }
+
+    /// Borrow the padded symbol table as the fixed-size arrays expected by [`Decompressor`].
+    ///
+    /// Both buffers are padded to [`FSST_SYMBOL_TABLE_LEN`] on construction, so this is a
+    /// length check and a pointer cast rather than a copy.
+    fn decompressor(&self) -> Decompressor<'_> {
+        const PADDED: &str = "FSST symbol table is padded to FSST_SYMBOL_TABLE_LEN entries";
+        let symbols = self
+            .padded_symbols
+            .as_slice()
+            .first_chunk::<FSST_SYMBOL_TABLE_LEN>()
+            .vortex_expect(PADDED);
+        let symbol_lengths = self
+            .padded_symbol_lengths
+            .as_slice()
+            .first_chunk::<FSST_SYMBOL_TABLE_LEN>()
+            .vortex_expect(PADDED);
+        Decompressor::new(symbols, symbol_lengths)
+    }
+
+    fn compressor(&self) -> &Compressor {
+        self.compressor
+            .get_or_init(|| Compressor::rebuild_from(self.symbols(), self.symbol_lengths()))
+    }
+}
+
+/// Returns `buffer` resized to exactly [`FSST_SYMBOL_TABLE_LEN`] entries, filling any tail with
+/// `pad`. Buffers that are already the right length are returned untouched.
+fn pad_symbol_table<T: Copy>(buffer: Buffer<T>, pad: T) -> Buffer<T> {
+    if buffer.len() == FSST_SYMBOL_TABLE_LEN {
+        return buffer;
+    }
+    padded_symbol_table(buffer.as_slice(), pad)
+}
+
+/// Copies `values` into a buffer of exactly [`FSST_SYMBOL_TABLE_LEN`] entries, filling the tail
+/// with `pad`.
+///
+/// FSST symbol tables are stored padded so that [`FSSTData::decompressor`] can borrow them as the
+/// fixed-size arrays [`Decompressor`] requires, without copying. Producers that already hold a
+/// padded table can build one here and hand it to [`FSST::try_new_padded`] to skip the copy that
+/// [`FSST::try_new`] would otherwise make.
+pub(crate) fn padded_symbol_table<T: Copy>(values: &[T], pad: T) -> Buffer<T> {
+    let populated = values.len().min(FSST_SYMBOL_TABLE_LEN);
+    let mut padded = BufferMut::with_capacity(FSST_SYMBOL_TABLE_LEN);
+    padded.extend_from_slice(&values[..populated]);
+    padded.push_n(pad, FSST_SYMBOL_TABLE_LEN - populated);
+    padded.freeze()
 }
 
 #[derive(Clone, Debug)]
@@ -459,6 +538,10 @@ pub struct FSST;
 
 impl FSST {
     /// Build an FSST array from a set of `symbols` and `codes`.
+    ///
+    /// `symbols` and `symbol_lengths` hold only the populated entries; they are padded out to
+    /// [`FSST_SYMBOL_TABLE_LEN`] internally. Callers that already hold a padded symbol table
+    /// should use [`Self::try_new_padded`] to avoid that copy.
     ///
     /// The `codes` VarBinArray is decomposed: its bytes are stored in [`FSSTData`], while
     /// its offsets and validity become array slots. The codes VarBinArray can be
@@ -473,8 +556,8 @@ impl FSST {
     ) -> VortexResult<FSSTArray> {
         let len = codes.len();
         FSSTData::validate_parts_from_codes(
-            &symbols,
-            &symbol_lengths,
+            symbols.as_slice(),
+            symbol_lengths.as_slice(),
             &codes,
             &uncompressed_lengths,
             &dtype,
@@ -489,6 +572,43 @@ impl FSST {
         })
     }
 
+    /// Build an FSST array from a symbol table that is already padded to
+    /// [`FSST_SYMBOL_TABLE_LEN`] entries, of which the first `n_symbols` are populated.
+    ///
+    /// This is the allocation-free counterpart to [`Self::try_new`] for producers such as
+    /// [`Compressor`], whose symbol table is already stored padded.
+    pub fn try_new_padded(
+        dtype: DType,
+        padded_symbols: Buffer<Symbol>,
+        padded_symbol_lengths: Buffer<u8>,
+        n_symbols: usize,
+        codes: VarBinArray,
+        uncompressed_lengths: ArrayRef,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<FSSTArray> {
+        let len = codes.len();
+        let data = FSSTData::try_new_padded(
+            padded_symbols,
+            padded_symbol_lengths,
+            n_symbols,
+            codes.bytes_handle().clone(),
+            len,
+        )?;
+        FSSTData::validate_parts_from_codes(
+            data.symbol_table.symbols(),
+            data.symbol_table.symbol_lengths(),
+            &codes,
+            &uncompressed_lengths,
+            &dtype,
+            len,
+            ctx,
+        )?;
+        let slots = FSSTData::make_slots(&codes, &uncompressed_lengths);
+        Ok(unsafe {
+            Array::from_parts_unchecked(ArrayParts::new(FSST, dtype, len, data).with_slots(slots))
+        })
+    }
+
     pub(crate) fn try_new_with_symbol_table(
         dtype: DType,
         symbol_table: Arc<FSSTSymbolTable>,
@@ -498,8 +618,8 @@ impl FSST {
     ) -> VortexResult<FSSTArray> {
         let len = codes.len();
         FSSTData::validate_parts_from_codes(
-            &symbol_table.symbols,
-            &symbol_table.symbol_lengths,
+            symbol_table.symbols(),
+            symbol_table.symbol_lengths(),
             &codes,
             &uncompressed_lengths,
             &dtype,
@@ -552,8 +672,8 @@ impl FSST {
         )?;
 
         FSSTData::validate_parts_from_codes(
-            symbols,
-            symbol_lengths,
+            symbols.as_slice(),
+            symbol_lengths.as_slice(),
             &codes,
             &uncompressed_lengths,
             dtype,
@@ -608,6 +728,10 @@ impl FSSTData {
     /// corresponds either to a symbol or to the "escape code" (which tells the decoder to
     /// emit the following byte without doing a table lookup).
     ///
+    /// `symbols` and `symbol_lengths` hold only the populated entries; they are padded out to
+    /// [`FSST_SYMBOL_TABLE_LEN`] entries so that [`Self::decompressor`] can borrow them without
+    /// copying. Callers that already hold a padded table should use [`Self::try_new_padded`].
+    ///
     /// The offsets and validity for the codes are stored in the array's slots, not here.
     /// Use [`FSSTArrayExt::codes()`] to reconstruct a full `VarBinArray`.
     pub fn try_new(
@@ -616,11 +740,58 @@ impl FSSTData {
         codes_bytes: BufferHandle,
         len: usize,
     ) -> VortexResult<Self> {
-        // SAFETY: all components validated above
+        vortex_ensure!(
+            symbols.len() == symbol_lengths.len(),
+            InvalidArgument: "symbols and symbol_lengths arrays must have same length, found {} and {}",
+            symbols.len(),
+            symbol_lengths.len()
+        );
+        vortex_ensure!(
+            symbols.len() <= FSST_SYMBOL_TABLE_LEN,
+            InvalidArgument: "symbols array must have length <= {FSST_SYMBOL_TABLE_LEN}, found {}",
+            symbols.len()
+        );
+        let n_symbols = symbols.len();
+        // SAFETY: the symbol table shape is validated above.
         unsafe {
             Ok(Self::new_unchecked(
                 symbols,
                 symbol_lengths,
+                n_symbols,
+                codes_bytes,
+                len,
+            ))
+        }
+    }
+
+    /// Build FSST data from a symbol table that is already padded to [`FSST_SYMBOL_TABLE_LEN`]
+    /// entries, of which the first `n_symbols` are populated.
+    ///
+    /// Unlike [`Self::try_new`], this stores the buffers as given, without copying them.
+    pub fn try_new_padded(
+        padded_symbols: Buffer<Symbol>,
+        padded_symbol_lengths: Buffer<u8>,
+        n_symbols: usize,
+        codes_bytes: BufferHandle,
+        len: usize,
+    ) -> VortexResult<Self> {
+        vortex_ensure!(
+            padded_symbols.len() == FSST_SYMBOL_TABLE_LEN
+                && padded_symbol_lengths.len() == FSST_SYMBOL_TABLE_LEN,
+            InvalidArgument: "padded symbol table must have exactly {FSST_SYMBOL_TABLE_LEN} entries, found {} symbols and {} symbol lengths",
+            padded_symbols.len(),
+            padded_symbol_lengths.len()
+        );
+        vortex_ensure!(
+            n_symbols <= FSST_SYMBOL_TABLE_LEN,
+            InvalidArgument: "n_symbols must be <= {FSST_SYMBOL_TABLE_LEN}, found {n_symbols}"
+        );
+        // SAFETY: the symbol table shape is validated above.
+        unsafe {
+            Ok(Self::new_unchecked(
+                padded_symbols,
+                padded_symbol_lengths,
+                n_symbols,
                 codes_bytes,
                 len,
             ))
@@ -636,8 +807,8 @@ impl FSSTData {
     ) -> VortexResult<()> {
         let fsst_slots = FSSTSlotsView::from_slots(slots);
         Self::validate_parts(
-            &self.symbol_table.symbols,
-            &self.symbol_table.symbol_lengths,
+            self.symbol_table.symbols(),
+            self.symbol_table.symbol_lengths(),
             &self.codes_bytes,
             fsst_slots.codes_offsets,
             dtype.nullability(),
@@ -651,8 +822,8 @@ impl FSSTData {
     /// Validate using the decomposed components (codes bytes + offsets + nullability).
     #[expect(clippy::too_many_arguments)]
     fn validate_parts(
-        symbols: &Buffer<Symbol>,
-        symbol_lengths: &Buffer<u8>,
+        symbols: &[Symbol],
+        symbol_lengths: &[u8],
         codes_bytes: &BufferHandle,
         codes_offsets: &ArrayRef,
         codes_nullability: Nullability,
@@ -666,15 +837,15 @@ impl FSSTData {
             "FSST arrays must be Binary or Utf8, found {dtype}"
         );
 
-        if symbols.len() > 255 {
-            vortex_bail!(InvalidArgument: "symbols array must have length <= 255");
+        if symbols.len() > FSST_SYMBOL_TABLE_LEN {
+            vortex_bail!(InvalidArgument: "symbols array must have length <= {FSST_SYMBOL_TABLE_LEN}");
         }
 
         if symbols.len() != symbol_lengths.len() {
             vortex_bail!(InvalidArgument: "symbols and symbol_lengths arrays must have same length");
         }
 
-        Self::validate_symbol_lengths(symbol_lengths.as_slice())?;
+        Self::validate_symbol_lengths(symbol_lengths)?;
 
         // codes_offsets.len() - 1 == number of elements
         let codes_len = codes_offsets.len().saturating_sub(1);
@@ -745,8 +916,8 @@ impl FSSTData {
 
     /// Validate using a VarBinArray for the codes (convenience for construction paths).
     fn validate_parts_from_codes(
-        symbols: &Buffer<Symbol>,
-        symbol_lengths: &Buffer<u8>,
+        symbols: &[Symbol],
+        symbol_lengths: &[u8],
         codes: &VarBinArray,
         uncompressed_lengths: &ArrayRef,
         dtype: &DType,
@@ -769,10 +940,11 @@ impl FSSTData {
     pub(crate) unsafe fn new_unchecked(
         symbols: Buffer<Symbol>,
         symbol_lengths: Buffer<u8>,
+        n_symbols: usize,
         codes_bytes: BufferHandle,
         len: usize,
     ) -> Self {
-        let symbol_table = Arc::new(FSSTSymbolTable::new(symbols, symbol_lengths));
+        let symbol_table = Arc::new(FSSTSymbolTable::new(symbols, symbol_lengths, n_symbols));
         unsafe { Self::new_unchecked_with_symbol_table(symbol_table, codes_bytes, len) }
     }
 
@@ -799,13 +971,40 @@ impl FSSTData {
     }
 
     /// Access the symbol table array.
-    pub fn symbols(&self) -> &Buffer<Symbol> {
-        &self.symbol_table.symbols
+    ///
+    /// This is the populated prefix of the symbol table; the padding added on construction to
+    /// reach [`FSST_SYMBOL_TABLE_LEN`] is not included. Use [`Self::padded_symbols`] to get the
+    /// whole buffer.
+    pub fn symbols(&self) -> Buffer<Symbol> {
+        self.symbol_table
+            .padded_symbols()
+            .slice(0..self.symbol_table.n_symbols)
     }
 
     /// Access the symbol lengths array.
-    pub fn symbol_lengths(&self) -> &Buffer<u8> {
-        &self.symbol_table.symbol_lengths
+    ///
+    /// As with [`Self::symbols`], this excludes the padding added on construction.
+    pub fn symbol_lengths(&self) -> Buffer<u8> {
+        self.symbol_table
+            .padded_symbol_lengths()
+            .slice(0..self.symbol_table.n_symbols)
+    }
+
+    /// The whole symbols buffer, padded to exactly [`FSST_SYMBOL_TABLE_LEN`] entries with
+    /// [`Symbol::ZERO`]. Entries at or past [`Self::n_symbols`] are padding.
+    pub fn padded_symbols(&self) -> &Buffer<Symbol> {
+        self.symbol_table.padded_symbols()
+    }
+
+    /// The whole symbol lengths buffer, padded to exactly [`FSST_SYMBOL_TABLE_LEN`] entries with
+    /// zeros. Entries at or past [`Self::n_symbols`] are padding.
+    pub fn padded_symbol_lengths(&self) -> &Buffer<u8> {
+        self.symbol_table.padded_symbol_lengths()
+    }
+
+    /// The number of populated entries in the symbol table.
+    pub fn n_symbols(&self) -> usize {
+        self.symbol_table.n_symbols
     }
 
     pub(crate) fn symbol_table(&self) -> Arc<FSSTSymbolTable> {
@@ -825,7 +1024,7 @@ impl FSSTData {
     /// Build a [`Decompressor`] that can be used to decompress values from
     /// this array.
     pub fn decompressor(&self) -> Decompressor<'_> {
-        Decompressor::new(self.symbols().as_slice(), self.symbol_lengths().as_slice())
+        self.symbol_table.decompressor()
     }
 
     /// Retrieves the FSST compressor.
@@ -889,15 +1088,20 @@ mod test {
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
     use vortex_array::test_harness::check_metadata;
+    use vortex_array::vtable::VTable as _;
     use vortex_buffer::Buffer;
     use vortex_error::VortexResult;
     use vortex_error::vortex_err;
 
     use crate::FSST;
+    use crate::array::FSST_SYMBOL_TABLE_LEN;
     use crate::array::FSSTArrayExt;
     use crate::array::FSSTArraySlotsExt;
+    use crate::array::FSSTData;
     use crate::array::FSSTMetadata;
+    use crate::array::padded_symbol_table;
     use crate::fsst_compress;
+    use crate::fsst_train_compressor;
 
     #[test]
     fn slice_reuses_initialized_compressor() -> VortexResult<()> {
@@ -921,6 +1125,174 @@ mod test {
 
         assert_eq!(compressor_ptr, sliced_compressor_ptr);
         Ok(())
+    }
+
+    /// The symbol table is padded out to [`FSST_SYMBOL_TABLE_LEN`] so that `Decompressor` can
+    /// borrow it directly, but the logical accessors and the serialized buffers must still only
+    /// expose the populated prefix.
+    #[test]
+    fn symbol_table_padded_on_creation() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let strings = VarBinViewArray::from_iter_str(["abcabcab", "defghijk", "abcxyz"]);
+        let compressor = Compressor::rebuild_from(
+            [
+                Symbol::from_slice(b"abc00000"),
+                Symbol::from_slice(b"defghijk"),
+            ],
+            [3u8, 8],
+        );
+        let fsst_array = fsst_compress(&strings.into_array(), &compressor, &mut ctx)?;
+
+        assert_eq!(fsst_array.padded_symbols().len(), FSST_SYMBOL_TABLE_LEN);
+        assert_eq!(
+            fsst_array.padded_symbol_lengths().len(),
+            FSST_SYMBOL_TABLE_LEN
+        );
+        assert_eq!(fsst_array.padded_symbol_lengths().as_slice()[2..], [0; 253]);
+
+        // Accessors and serialized buffers only see the two populated symbols.
+        assert_eq!(fsst_array.n_symbols(), 2);
+        assert_eq!(fsst_array.symbols().len(), 2);
+        assert_eq!(fsst_array.symbol_lengths().as_slice(), &[3, 8]);
+        assert_eq!(
+            FSST::buffer(fsst_array.as_view(), 0).len(),
+            2 * size_of::<Symbol>()
+        );
+        assert_eq!(FSST::buffer(fsst_array.as_view(), 1).len(), 2);
+
+        let decompressed = fsst_array
+            .into_array()
+            .execute::<VarBinViewArray>(&mut ctx)?;
+        assert_eq!(decompressed.bytes_at(0).as_slice(), b"abcabcab".as_ref());
+        assert_eq!(decompressed.bytes_at(1).as_slice(), b"defghijk".as_ref());
+        assert_eq!(decompressed.bytes_at(2).as_slice(), b"abcxyz".as_ref());
+        Ok(())
+    }
+
+    /// Buffers arriving from a file hold the unpadded symbol table, so deserialization must pad
+    /// them before a `Decompressor` can borrow them.
+    #[test]
+    fn symbol_table_padded_on_deserialize() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let input = VarBinViewArray::from_iter_str(["abcabcab", "defghijk"]).into_array();
+        let compressor = fsst_train_compressor(&input, &mut ctx)?;
+        let fsst_array = fsst_compress(&input, &compressor, &mut ctx)?;
+
+        let buffers = [
+            BufferHandle::new_host(fsst_array.symbols().into_byte_buffer()),
+            BufferHandle::new_host(fsst_array.symbol_lengths().into_byte_buffer()),
+            fsst_array.codes_bytes_handle().clone(),
+        ];
+        assert!(buffers[1].len() < FSST_SYMBOL_TABLE_LEN);
+
+        let children = vec![
+            fsst_array.uncompressed_lengths().clone(),
+            fsst_array.codes_offsets().clone(),
+        ];
+
+        let deserialized = ArrayPlugin::deserialize(
+            &FSST,
+            &DType::Utf8(Nullability::NonNullable),
+            2,
+            &FSSTMetadata {
+                uncompressed_lengths_ptype: fsst_array
+                    .uncompressed_lengths()
+                    .dtype()
+                    .as_ptype()
+                    .into(),
+                codes_offsets_ptype: fsst_array.codes_offsets().dtype().as_ptype().into(),
+            }
+            .encode_to_vec(),
+            &buffers,
+            &children.as_slice(),
+            &array_session(),
+        )?;
+
+        let padded = deserialized
+            .clone()
+            .try_downcast::<FSST>()
+            .map_err(|_| vortex_err!("deserialize must return an FSST array"))?;
+        assert_eq!(padded.padded_symbols().len(), FSST_SYMBOL_TABLE_LEN);
+        assert_eq!(padded.n_symbols(), fsst_array.symbols().len());
+
+        let decompressed = deserialized.execute::<VarBinViewArray>(&mut ctx)?;
+        assert_eq!(decompressed.bytes_at(0).as_slice(), b"abcabcab".as_ref());
+        assert_eq!(decompressed.bytes_at(1).as_slice(), b"defghijk".as_ref());
+        Ok(())
+    }
+
+    /// An already-padded table must be stored as-is rather than copied again.
+    #[test]
+    fn padded_constructor_does_not_repad() -> VortexResult<()> {
+        let symbols = padded_symbol_table(&[Symbol::from_slice(b"ab000000")], Symbol::ZERO);
+        let symbol_lengths = padded_symbol_table(&[2u8], 0);
+        let symbols_ptr = symbols.as_slice().as_ptr();
+        let symbol_lengths_ptr = symbol_lengths.as_slice().as_ptr();
+
+        let data = FSSTData::try_new_padded(
+            symbols,
+            symbol_lengths,
+            1,
+            BufferHandle::new_host(Buffer::<u8>::empty()),
+            0,
+        )?;
+
+        assert_eq!(data.padded_symbols().as_slice().as_ptr(), symbols_ptr);
+        assert_eq!(
+            data.padded_symbol_lengths().as_slice().as_ptr(),
+            symbol_lengths_ptr
+        );
+        assert_eq!(data.n_symbols(), 1);
+        Ok(())
+    }
+
+    /// [`FSSTData::try_new_padded`] stores the buffers as given, so it must reject tables that are
+    /// not already padded.
+    #[test]
+    fn rejects_unpadded_input_to_padded_constructor() {
+        assert!(
+            FSSTData::try_new_padded(
+                Buffer::<Symbol>::copy_from([Symbol::from_slice(b"ab000000")]),
+                Buffer::<u8>::copy_from([2]),
+                1,
+                BufferHandle::new_host(Buffer::<u8>::empty()),
+                0,
+            )
+            .is_err()
+        );
+        assert!(
+            FSSTData::try_new_padded(
+                Buffer::<Symbol>::full(Symbol::ZERO, FSST_SYMBOL_TABLE_LEN),
+                Buffer::<u8>::full(0, FSST_SYMBOL_TABLE_LEN),
+                FSST_SYMBOL_TABLE_LEN + 1,
+                BufferHandle::new_host(Buffer::<u8>::empty()),
+                0,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_symbol_table() {
+        let codes_bytes = BufferHandle::new_host(Buffer::<u8>::empty());
+        assert!(
+            FSSTData::try_new(
+                Buffer::<Symbol>::copy_from([Symbol::from_slice(b"ab000000")]),
+                Buffer::<u8>::copy_from([2, 2]),
+                codes_bytes.clone(),
+                0,
+            )
+            .is_err()
+        );
+        assert!(
+            FSSTData::try_new(
+                Buffer::<Symbol>::full(Symbol::from_slice(b"ab000000"), FSST_SYMBOL_TABLE_LEN + 1,),
+                Buffer::<u8>::full(2, FSST_SYMBOL_TABLE_LEN + 1),
+                codes_bytes,
+                0,
+            )
+            .is_err()
+        );
     }
 
     #[cfg_attr(miri, ignore)]

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -143,8 +143,18 @@ impl VTable for FSST {
 
     fn buffer(array: ArrayView<'_, Self>, idx: usize) -> BufferHandle {
         match idx {
-            0 => BufferHandle::new_host(array.symbols().into_byte_buffer()),
-            1 => BufferHandle::new_host(array.symbol_lengths().into_byte_buffer()),
+            0 => BufferHandle::new_host(
+                array
+                    .padded_symbol_lengths()
+                    .slice(0..array.n_symbols())
+                    .into_byte_buffer(),
+            ),
+            1 => BufferHandle::new_host(
+                array
+                    .padded_symbol_lengths()
+                    .slice(0..array.n_symbols())
+                    .into_byte_buffer(),
+            ),
             2 => array.codes_bytes_handle().clone(),
             _ => vortex_panic!("FSSTArray buffer index {idx} out of bounds"),
         }
@@ -916,19 +926,15 @@ impl FSSTData {
     /// This is the populated prefix of the symbol table; the padding added on construction to
     /// reach [`FSST_SYMBOL_TABLE_LEN`] is not included. Use [`Self::padded_symbols`] to get the
     /// whole buffer.
-    pub fn symbols(&self) -> Buffer<Symbol> {
-        self.symbol_table
-            .padded_symbols()
-            .slice(0..self.symbol_table.n_symbols)
+    pub fn symbols(&self) -> &[Symbol] {
+        &self.symbol_table.padded_symbols().as_slice()[0..self.symbol_table.n_symbols]
     }
 
     /// Access the symbol lengths array.
     ///
     /// As with [`Self::symbols`], this excludes the padding added on construction.
-    pub fn symbol_lengths(&self) -> Buffer<u8> {
-        self.symbol_table
-            .padded_symbol_lengths()
-            .slice(0..self.symbol_table.n_symbols)
+    pub fn symbol_lengths(&self) -> &[u8] {
+        &self.symbol_table.padded_symbol_lengths().as_slice()[0..self.symbol_table.n_symbols]
     }
 
     /// The whole symbols buffer, padded to exactly [`FSST_SYMBOL_TABLE_LEN`] entries with
@@ -948,7 +954,7 @@ impl FSSTData {
         self.symbol_table.n_symbols
     }
 
-    pub(crate) fn symbol_table(&self) -> Arc<FSSTSymbolTable> {
+    pub fn symbol_table(&self) -> Arc<FSSTSymbolTable> {
         Arc::clone(&self.symbol_table)
     }
 
@@ -1095,7 +1101,7 @@ mod test {
         // Accessors and serialized buffers only see the two populated symbols.
         assert_eq!(fsst_array.n_symbols(), 2);
         assert_eq!(fsst_array.symbols().len(), 2);
-        assert_eq!(fsst_array.symbol_lengths().as_slice(), &[3, 8]);
+        assert_eq!(fsst_array.symbol_lengths(), &[3, 8]);
         assert_eq!(
             FSST::buffer(fsst_array.as_view(), 0).len(),
             2 * size_of::<Symbol>()
@@ -1121,8 +1127,18 @@ mod test {
         let fsst_array = fsst_compress(&input, &compressor, &mut ctx)?;
 
         let buffers = [
-            BufferHandle::new_host(fsst_array.symbols().into_byte_buffer()),
-            BufferHandle::new_host(fsst_array.symbol_lengths().into_byte_buffer()),
+            BufferHandle::new_host(
+                fsst_array
+                    .padded_symbols()
+                    .slice(0..fsst_array.n_symbols())
+                    .into_byte_buffer(),
+            ),
+            BufferHandle::new_host(
+                fsst_array
+                    .padded_symbol_lengths()
+                    .slice(0..fsst_array.n_symbols())
+                    .into_byte_buffer(),
+            ),
             fsst_array.codes_bytes_handle().clone(),
         ];
         assert!(buffers[1].len() < FSST_SYMBOL_TABLE_LEN);

--- a/encodings/fsst/src/canonical.rs
+++ b/encodings/fsst/src/canonical.rs
@@ -255,10 +255,9 @@ mod tests {
         let input = VarBinViewArray::from_iter_str(["hello"]).into_array();
         let mut ctx = SESSION.create_execution_ctx();
         let encoded = fsst_compress(&input, &fsst_train_compressor(&input, &mut ctx)?, &mut ctx)?;
-        let invalid = FSST::try_new(
+        let invalid = FSST::try_new_with_symbol_table(
             encoded.dtype().clone(),
-            encoded.symbols(),
-            encoded.symbol_lengths(),
+            encoded.symbol_table(),
             encoded.codes(),
             PrimitiveArray::from_iter([4i32]).into_array(),
             &mut ctx,

--- a/encodings/fsst/src/canonical.rs
+++ b/encodings/fsst/src/canonical.rs
@@ -257,8 +257,8 @@ mod tests {
         let encoded = fsst_compress(&input, &fsst_train_compressor(&input, &mut ctx)?, &mut ctx)?;
         let invalid = FSST::try_new(
             encoded.dtype().clone(),
-            encoded.symbols().clone(),
-            encoded.symbol_lengths().clone(),
+            encoded.symbols(),
+            encoded.symbol_lengths(),
             encoded.codes(),
             PrimitiveArray::from_iter([4i32]).into_array(),
             &mut ctx,

--- a/encodings/fsst/src/compress.rs
+++ b/encodings/fsst/src/compress.rs
@@ -36,6 +36,7 @@ use vortex_mask::Mask;
 
 use crate::FSST;
 use crate::FSSTArray;
+use crate::array::FSSTSymbolTable;
 use crate::array::padded_symbol_table;
 
 /// FSST worst case: every input byte expands to an escape + literal (2x).
@@ -328,11 +329,13 @@ impl<'c, O: OffsetBuilderPType + 'static> FsstSink<'c, O> {
         let codes = self.builder.finish_into_varbin();
         // Pad the symbol table here so that the array can hand it straight to a `Decompressor`
         // without copying.
-        FSST::try_new_padded(
+        FSST::try_new_with_symbol_table(
             dtype,
-            padded_symbol_table(self.compressor.symbol_table(), Symbol::ZERO),
-            padded_symbol_table(self.compressor.symbol_lengths(), 0),
-            self.compressor.n_symbols(),
+            Arc::new(FSSTSymbolTable::new_padded(
+                padded_symbol_table(self.compressor.symbol_table(), Symbol::ZERO),
+                padded_symbol_table(self.compressor.symbol_lengths(), 0),
+                self.compressor.n_symbols(),
+            )?),
             codes,
             self.uncompressed_lengths.into_array(),
             ctx,

--- a/encodings/fsst/src/compress.rs
+++ b/encodings/fsst/src/compress.rs
@@ -10,6 +10,7 @@
 use std::sync::Arc;
 
 use fsst::Compressor;
+use fsst::Symbol;
 use num_traits::AsPrimitive;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
@@ -26,7 +27,6 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::IntegerPType;
 use vortex_array::dtype::OffsetBuilderPType;
 use vortex_array::match_each_integer_ptype;
-use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -36,6 +36,7 @@ use vortex_mask::Mask;
 
 use crate::FSST;
 use crate::FSSTArray;
+use crate::array::padded_symbol_table;
 
 /// FSST worst case: every input byte expands to an escape + literal (2x).
 const FSST_PER_BYTE_OVERHEAD: usize = 2;
@@ -308,23 +309,30 @@ impl<'c, O: OffsetBuilderPType + 'static> FsstSink<'c, O> {
             i32::try_from(s.len()).vortex_expect("per-row uncompressed length must fit in i32"),
         );
 
-        let target = FSST_PER_BYTE_OVERHEAD * s.len();
-        if target > self.buffer.len() {
-            self.buffer.reserve(target - self.buffer.len());
-        }
+        // `compress_into` writes into the spare capacity, so the buffer must be emptied first.
+        self.buffer.clear();
+        self.buffer.reserve(FSST_PER_BYTE_OVERHEAD * s.len());
 
         // SAFETY: `self.buffer` has capacity for the FSST worst-case output of `s`.
-        unsafe { self.compressor.compress_into(s, &mut self.buffer) };
+        let written = unsafe {
+            self.compressor
+                .compress_into(s, self.buffer.spare_capacity_mut())
+        };
+        // SAFETY: `compress_into` initialized the first `written` bytes.
+        unsafe { self.buffer.set_len(written) };
 
         self.builder.append_value(&self.buffer);
     }
 
     fn finish(mut self, dtype: DType, ctx: &mut ExecutionCtx) -> VortexResult<FSSTArray> {
         let codes = self.builder.finish_into_varbin();
-        FSST::try_new(
+        // Pad the symbol table here so that the array can hand it straight to a `Decompressor`
+        // without copying.
+        FSST::try_new_padded(
             dtype,
-            Buffer::copy_from(self.compressor.symbol_table()),
-            Buffer::<u8>::copy_from(self.compressor.symbol_lengths()),
+            padded_symbol_table(self.compressor.symbol_table(), Symbol::ZERO),
+            padded_symbol_table(self.compressor.symbol_lengths(), 0),
+            self.compressor.n_symbols(),
             codes,
             self.uncompressed_lengths.into_array(),
             ctx,

--- a/encodings/fsst/src/compute/like.rs
+++ b/encodings/fsst/src/compute/like.rs
@@ -47,11 +47,8 @@ impl LikeKernel for FSST {
             return Ok(None);
         };
 
-        let symbols = array.symbols();
-        let symbol_lengths = array.symbol_lengths();
-
         let Some(matcher) =
-            FsstMatcher::try_new(symbols.as_slice(), symbol_lengths.as_slice(), pattern_bytes)?
+            FsstMatcher::try_new(array.symbols(), array.symbol_lengths(), pattern_bytes)?
         else {
             return Ok(None);
         };

--- a/vortex-btrblocks/src/schemes/string/fsst.rs
+++ b/vortex-btrblocks/src/schemes/string/fsst.rs
@@ -3,6 +3,8 @@
 
 //! FSST (Fast Static Symbol Table) string compression.
 
+use std::sync::Arc;
+
 use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
@@ -20,6 +22,7 @@ use vortex_error::VortexResult;
 use vortex_fsst::FSST;
 use vortex_fsst::FSSTArrayExt;
 use vortex_fsst::FSSTArraySlotsExt;
+use vortex_fsst::FSSTSymbolTable;
 use vortex_fsst::fsst_compress;
 use vortex_fsst::fsst_train_compressor;
 
@@ -110,11 +113,13 @@ impl Scheme for FSSTScheme {
         )?;
 
         // Reuse the padded symbol table as-is; only the codes and lengths change here.
-        let fsst = FSST::try_new_padded(
+        let fsst = FSST::try_new_with_symbol_table(
             fsst.dtype().clone(),
-            fsst.padded_symbols().clone(),
-            fsst.padded_symbol_lengths().clone(),
-            fsst.n_symbols(),
+            Arc::new(FSSTSymbolTable::new_padded(
+                fsst.padded_symbols().clone(),
+                fsst.padded_symbol_lengths().clone(),
+                fsst.n_symbols(),
+            )?),
             compressed_codes,
             compressed_original_lengths,
             exec_ctx,

--- a/vortex-btrblocks/src/schemes/string/fsst.rs
+++ b/vortex-btrblocks/src/schemes/string/fsst.rs
@@ -109,10 +109,12 @@ impl Scheme for FSSTScheme {
             fsst.codes().validity()?,
         )?;
 
-        let fsst = FSST::try_new(
+        // Reuse the padded symbol table as-is; only the codes and lengths change here.
+        let fsst = FSST::try_new_padded(
             fsst.dtype().clone(),
-            fsst.symbols().clone(),
-            fsst.symbol_lengths().clone(),
+            fsst.padded_symbols().clone(),
+            fsst.padded_symbol_lengths().clone(),
+            fsst.n_symbols(),
             compressed_codes,
             compressed_original_lengths,
             exec_ctx,

--- a/vortex-cuda/benches/fsst_cuda.rs
+++ b/vortex-cuda/benches/fsst_cuda.rs
@@ -35,6 +35,7 @@ use vortex_cuda::arrow::release_device_array;
 use vortex_cuda::executor::CudaArrayExt;
 use vortex_cuda_macros::cuda_available;
 use vortex_cuda_macros::cuda_not_available;
+use vortex_fsst::FSSTSymbolTable;
 use vortex_fsst::test_utils::make_fsst_clickbench_urls;
 
 use crate::timed_launch_strategy::TimedLaunchStrategy;
@@ -73,11 +74,13 @@ fn make_fixture(n: usize) -> FSSTBenchFixture {
         lens.as_slice::<P>().iter().map(|x| *x as u64).sum()
     });
 
-    let binary = FSST::try_new_padded(
+    let binary = FSST::try_new_with_symbol_table(
         DType::Binary(Nullability::NonNullable),
-        fsst.padded_symbols().clone(),
-        fsst.padded_symbol_lengths().clone(),
-        fsst.n_symbols(),
+        Arc::new(FSSTSymbolTable::new_padded(
+            fsst.padded_symbols().clone(),
+            fsst.padded_symbol_lengths().clone(),
+            fsst.n_symbols(),
+        ).vortex_expect("construction")),
         fsst.codes(),
         fsst.uncompressed_lengths().clone(),
         setup_ctx.execution_ctx(),

--- a/vortex-cuda/benches/fsst_cuda.rs
+++ b/vortex-cuda/benches/fsst_cuda.rs
@@ -73,10 +73,11 @@ fn make_fixture(n: usize) -> FSSTBenchFixture {
         lens.as_slice::<P>().iter().map(|x| *x as u64).sum()
     });
 
-    let binary = FSST::try_new(
+    let binary = FSST::try_new_padded(
         DType::Binary(Nullability::NonNullable),
-        fsst.symbols().clone(),
-        fsst.symbol_lengths().clone(),
+        fsst.padded_symbols().clone(),
+        fsst.padded_symbol_lengths().clone(),
+        fsst.n_symbols(),
         fsst.codes(),
         fsst.uncompressed_lengths().clone(),
         setup_ctx.execution_ctx(),

--- a/vortex-cuda/benches/fsst_cuda.rs
+++ b/vortex-cuda/benches/fsst_cuda.rs
@@ -76,11 +76,14 @@ fn make_fixture(n: usize) -> FSSTBenchFixture {
 
     let binary = FSST::try_new_with_symbol_table(
         DType::Binary(Nullability::NonNullable),
-        Arc::new(FSSTSymbolTable::new_padded(
-            fsst.padded_symbols().clone(),
-            fsst.padded_symbol_lengths().clone(),
-            fsst.n_symbols(),
-        ).vortex_expect("construction")),
+        Arc::new(
+            FSSTSymbolTable::new_padded(
+                fsst.padded_symbols().clone(),
+                fsst.padded_symbol_lengths().clone(),
+                fsst.n_symbols(),
+            )
+            .vortex_expect("construction"),
+        ),
         fsst.codes(),
         fsst.uncompressed_lengths().clone(),
         setup_ctx.execution_ctx(),

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -2519,10 +2519,9 @@ mod tests {
         let fsst = fsst_compress(&varbin, &compressor, ctx.execution_ctx())?;
 
         // Same codes, but uncompressed lengths whose sum exceeds i32::MAX.
-        let oversized = FSST::try_new(
+        let oversized = FSST::try_new_with_symbol_table(
             DType::Utf8(Nullability::NonNullable),
-            fsst.symbols(),
-            fsst.symbol_lengths(),
+            fsst.symbol_table(),
             fsst.codes(),
             PrimitiveArray::from_iter([i32::MAX, i32::MAX]).into_array(),
             ctx.execution_ctx(),

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -2521,8 +2521,8 @@ mod tests {
         // Same codes, but uncompressed lengths whose sum exceeds i32::MAX.
         let oversized = FSST::try_new(
             DType::Utf8(Nullability::NonNullable),
-            fsst.symbols().clone(),
-            fsst.symbol_lengths().clone(),
+            fsst.symbols(),
+            fsst.symbol_lengths(),
             fsst.codes(),
             PrimitiveArray::from_iter([i32::MAX, i32::MAX]).into_array(),
             ctx.execution_ctx(),

--- a/vortex-cuda/src/kernel/encodings/fsst.rs
+++ b/vortex-cuda/src/kernel/encodings/fsst.rs
@@ -217,7 +217,7 @@ where
     let len = fsst.len();
     let len_u64 = len as u64;
     let symbols_u64: Vec<u64> = fsst.symbols().iter().map(|s| s.to_u64()).collect();
-    let symbol_lengths = fsst.symbol_lengths().clone();
+    let symbol_lengths = fsst.symbol_lengths();
     let codes_bytes_handle = fsst.codes_bytes_handle().clone();
     let PrimitiveDataParts {
         buffer: codes_offsets_buffer,
@@ -302,7 +302,7 @@ where
     }
 
     let symbols_u64: Vec<u64> = fsst.symbols().iter().map(|s| s.to_u64()).collect();
-    let symbol_lengths = fsst.symbol_lengths().clone();
+    let symbol_lengths = fsst.symbol_lengths();
     let codes_bytes_handle = fsst.codes_bytes_handle().clone();
     let PrimitiveDataParts {
         buffer: codes_offsets_buffer,

--- a/vortex-cuda/src/kernel/encodings/fsst.rs
+++ b/vortex-cuda/src/kernel/encodings/fsst.rs
@@ -216,8 +216,12 @@ where
     let validity = fsst.codes().validity()?;
     let len = fsst.len();
     let len_u64 = len as u64;
-    let symbols_u64: Vec<u64> = fsst.symbols().iter().map(|s| s.to_u64()).collect();
-    let symbol_lengths = fsst.symbol_lengths();
+    let symbols_u64 = fsst
+        .symbols()
+        .iter()
+        .map(|s| s.to_u64())
+        .collect::<Vec<_>>();
+    let symbol_lengths = fsst.padded_symbol_lengths().slice(0..fsst.n_symbols());
     let codes_bytes_handle = fsst.codes_bytes_handle().clone();
     let PrimitiveDataParts {
         buffer: codes_offsets_buffer,
@@ -301,8 +305,12 @@ where
         }));
     }
 
-    let symbols_u64: Vec<u64> = fsst.symbols().iter().map(|s| s.to_u64()).collect();
-    let symbol_lengths = fsst.symbol_lengths();
+    let symbols_u64 = fsst
+        .symbols()
+        .iter()
+        .map(|s| s.to_u64())
+        .collect::<Vec<_>>();
+    let symbol_lengths = fsst.padded_symbol_lengths().slice(0..fsst.n_symbols());
     let codes_bytes_handle = fsst.codes_bytes_handle().clone();
     let PrimitiveDataParts {
         buffer: codes_offsets_buffer,

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -5,6 +5,7 @@
 
 use std::fmt;
 use std::ops::Deref;
+use std::sync::Arc;
 use std::sync::LazyLock;
 
 use divan::Bencher;
@@ -76,6 +77,7 @@ fn with_byte_counter<'a, 'b>(bencher: Bencher<'a, 'b>, bytes: u64) -> Bencher<'a
 mod setup {
     use rand::rngs::StdRng;
     use vortex_array::VortexSessionExecute;
+    use vortex_fsst::FSSTSymbolTable;
 
     use super::*;
 
@@ -301,11 +303,13 @@ mod setup {
         .unwrap();
 
         // Rebuild FSST with compressed codes
-        let compressed_fsst = FSST::try_new_padded(
+        let compressed_fsst = FSST::try_new_with_symbol_table(
             fsst.dtype().clone(),
-            fsst.padded_symbols().clone(),
-            fsst.padded_symbol_lengths().clone(),
-            fsst.n_symbols(),
+            Arc::new(FSSTSymbolTable::new_padded(
+                fsst.padded_symbols().clone(),
+                fsst.padded_symbol_lengths().clone(),
+                fsst.n_symbols(),
+            )),
             compressed_codes,
             fsst.uncompressed_lengths().clone(),
             &mut ctx,

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -309,7 +309,7 @@ mod setup {
                 fsst.padded_symbols().clone(),
                 fsst.padded_symbol_lengths().clone(),
                 fsst.n_symbols(),
-            )),
+            ).unwrap()),
             compressed_codes,
             fsst.uncompressed_lengths().clone(),
             &mut ctx,

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -301,10 +301,11 @@ mod setup {
         .unwrap();
 
         // Rebuild FSST with compressed codes
-        let compressed_fsst = FSST::try_new(
+        let compressed_fsst = FSST::try_new_padded(
             fsst.dtype().clone(),
-            fsst.symbols().clone(),
-            fsst.symbol_lengths().clone(),
+            fsst.padded_symbols().clone(),
+            fsst.padded_symbol_lengths().clone(),
+            fsst.n_symbols(),
             compressed_codes,
             fsst.uncompressed_lengths().clone(),
             &mut ctx,

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -305,11 +305,14 @@ mod setup {
         // Rebuild FSST with compressed codes
         let compressed_fsst = FSST::try_new_with_symbol_table(
             fsst.dtype().clone(),
-            Arc::new(FSSTSymbolTable::new_padded(
-                fsst.padded_symbols().clone(),
-                fsst.padded_symbol_lengths().clone(),
-                fsst.n_symbols(),
-            ).unwrap()),
+            Arc::new(
+                FSSTSymbolTable::new_padded(
+                    fsst.padded_symbols().clone(),
+                    fsst.padded_symbol_lengths().clone(),
+                    fsst.n_symbols(),
+                )
+                .unwrap(),
+            ),
             compressed_codes,
             fsst.uncompressed_lengths().clone(),
             &mut ctx,


### PR DESCRIPTION
Since the compressor now requires padded state to guarantee codes don't access
out of bounds memory we need to adjust construction and usage to preserve padding
