### PR TITLE
fix `get_item` parent reduce rule

### DIFF
--- a/vortex-array/src/arrays/struct_/compute/rules.rs
+++ b/vortex-array/src/arrays/struct_/compute/rules.rs
@@ -102,9 +102,13 @@ impl ArrayParentReduceRule<Struct> for StructGetItemRule {
             })?;
 
         match child.validity()? {
-            Validity::NonNullable | Validity::AllValid => {
-                // If the struct is non-nullable or all valid, the field's validity is unchanged
+            Validity::NonNullable => {
+                // If the struct is non-nullable, the field's validity is unchanged
                 Ok(Some(field.clone()))
+            }
+            Validity::AllValid => {
+                // If struct is nullable, field must also be nullable
+                field.clone().cast(field.dtype().as_nullable()).map(Some)
             }
             Validity::AllInvalid => {
                 // If everything is invalid, the field is also all invalid

--- a/vortex-array/src/scalar_fn/fns/get_item.rs
+++ b/vortex-array/src/scalar_fn/fns/get_item.rs
@@ -198,6 +198,7 @@ impl ScalarFnVTable for GetItem {
 #[cfg(test)]
 mod tests {
     use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
 
     use crate::IntoArray;
     use crate::dtype::DType;
@@ -256,6 +257,24 @@ mod tests {
             item.dtype(),
             &DType::Primitive(PType::I32, Nullability::Nullable)
         );
+    }
+
+    #[test]
+    fn get_non_nullable_field_from_all_valid_nullable_struct() -> VortexResult<()> {
+        let st = StructArray::try_new(
+            FieldNames::from(["a"]),
+            vec![buffer![1i32].into_array()],
+            1,
+            Validity::AllValid,
+        )?
+        .into_array();
+
+        let item = st.apply(&get_item("a", root()))?;
+        assert_eq!(
+            item.dtype(),
+            &DType::Primitive(PType::I32, Nullability::Nullable)
+        );
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Suppose we have nullable struct `S` with non-nullable field `A`. Even if `S` is all-valid, `get_item("A")` should cast `A` as nullable. 