### PR TITLE
chore: tidy up a few compile-time assertions

### DIFF
--- a/vortex-array/src/arrays/varbinview/build_views.rs
+++ b/vortex-array/src/arrays/varbinview/build_views.rs
@@ -230,7 +230,7 @@ mod tests {
         const N: usize = 9000;
         const LEN: usize = 1000;
         // The final offset is (N - 1) * LEN, which must exceed 2^23 to be a meaningful check.
-        const _: () = assert!((N - 1) * LEN > (1 << 23));
+        const { assert!((N - 1) * LEN > (1 << 23)) };
 
         let values: Vec<Vec<u8>> = (0..N)
             .map(|i| {

--- a/vortex-array/src/dtype/dtype_impl.rs
+++ b/vortex-array/src/dtype/dtype_impl.rs
@@ -35,7 +35,7 @@ pub trait NativeDType {
     fn dtype() -> DType;
 }
 
-/// Assert that the size of DType is 16 bytes.
+/// Assert that the size of DType is 24 bytes.
 #[cfg(not(target_arch = "wasm32"))]
 const _: [(); size_of::<DType>()] = [(); 24]; // FIXME(ngates): should we keep this at 16?
 

--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -79,9 +79,7 @@ impl From<Infallible> for VortexError {
     }
 }
 
-const _: () = {
-    assert!(size_of::<VortexError>() < 128);
-};
+const _: () = assert!(size_of::<VortexError>() < 128);
 
 /// The top-level error type for Vortex.
 #[non_exhaustive]


### PR DESCRIPTION
Uses `const { assert!(..) }` for the function-body assertion in `build_views` to match the existing const-block sites, removes a redundant block around the single `assert!` in `vortex-error`, and corrects a doc comment that claimed `DType` is 16 bytes while the assertion below it checked for 24.