### PR TITLE
fix(spark): correct the @throws contract on VortexScanBuilder.build

### DIFF
--- a/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexScanBuilder.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexScanBuilder.java
@@ -108,16 +108,17 @@ public final class VortexScanBuilder
     /**
      * Builds a VortexScan with the configured paths and columns.
      *
+     * <p>An empty column list is allowed: aggregates such as {@code count()} need no column data, and the scan then
+     * reads the minimal schema.
+     *
      * @return a new VortexScan instance
-     * @throws IllegalStateException if no paths or columns have been added
+     * @throws IllegalStateException if no paths have been added
      */
     @Override
     public Scan build() {
         var paths = this.paths.build();
 
         checkState(!paths.isEmpty(), "paths cannot be empty");
-        // Allow empty columns for operations like count() that don't need actual column data
-        // If no columns are specified, we'll read the minimal schema needed
 
         return new VortexScan(
                 paths,


### PR DESCRIPTION
The Javadoc on `VortexScanBuilder.build()` promised `IllegalStateException` when no columns had been added:

```java
 * @throws IllegalStateException if no paths or columns have been added
```

but `build()` deliberately allows an empty column list — aggregates such as `count()` need not project any data — and only the path check is enforced:

```java
checkState(!paths.isEmpty(), "paths cannot be empty");
```

This documents what the method actually does, and promotes the explanatory implementation comment into the Javadoc where callers can see it.

Doc-only, no behavior change.

## Tests

- `./gradlew javadoc` — clean
- `./gradlew :vortex-spark_2.13:test --tests 'dev.vortex.spark.read.*'` — 49/49 pass
- `./gradlew :vortex-spark_2.13:spotlessCheck` and `:vortex-spark_2.12:spotlessCheck` — clean