### PR TITLE
fix(spark): write null array elements as nulls instead of zeros

### DIFF
--- a/java/vortex-spark/src/main/java/dev/vortex/spark/write/VortexDataWriter.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/write/VortexDataWriter.java
@@ -250,8 +250,16 @@ public final class VortexDataWriter implements DataWriter<InternalRow>, AutoClos
             ListVector listVector = ((ListVector) vector);
             int writtenElements = listVector.getElementEndIndex(listVector.getLastSet());
             listVector.startNewValue(rowIndex);
+            FieldVector elementVector = listVector.getDataVector();
             for (int i = 0; i < data.numElements(); i++) {
-                populateVector(listVector.getDataVector(), arrayType.elementType(), data, i, writtenElements + i);
+                int elementIndex = writtenElements + i;
+                if (data.isNullAt(i)) {
+                    // Reading a null slot of a fixed-width element returns the zeroed slot, and the
+                    // typed setters mark it valid, so a null element must be written explicitly.
+                    elementVector.setNull(elementIndex);
+                } else {
+                    populateVector(elementVector, arrayType.elementType(), data, i, elementIndex);
+                }
             }
             listVector.endValue(rowIndex, data.numElements());
         } else {

--- a/java/vortex-spark/src/test/java/dev/vortex/spark/VortexDataSourceWriteTest.java
+++ b/java/vortex-spark/src/test/java/dev/vortex/spark/VortexDataSourceWriteTest.java
@@ -440,6 +440,38 @@ public final class VortexDataSourceWriteTest {
         assertFalse(findVortexFiles(outputPath).isEmpty(), "TimestampNTZ write should create Vortex files");
     }
 
+    @Test
+    @DisplayName("Null array elements round-trip as nulls, not as zeros")
+    public void testWriteArrayWithNullElements() {
+        // A fixed-width element is the interesting case: reading a null slot yields the zeroed
+        // slot, so a missing null check writes 0 with the validity bit set.
+        Dataset<Row> arraysDf = spark.range(0, 1)
+                .selectExpr(
+                        "cast(id as int) as id",
+                        "array(1, cast(null as int), 3) as ints",
+                        "array(cast(null as double), 2.5) as doubles",
+                        "array('a', cast(null as string), 'c') as strings");
+
+        Path outputPath = tempDir.resolve("array_nulls_output");
+        arraysDf.write()
+                .format("vortex")
+                .option("path", outputPath.toUri().toString())
+                .mode(SaveMode.Overwrite)
+                .save();
+
+        Row read = spark.read()
+                .format("vortex")
+                .option("path", outputPath.toUri().toString())
+                .load()
+                .selectExpr("ints", "doubles", "strings")
+                .collectAsList()
+                .get(0);
+
+        assertEquals(Arrays.asList(1, null, 3), read.getList(0));
+        assertEquals(Arrays.asList(null, 2.5d), read.getList(1));
+        assertEquals(Arrays.asList("a", null, "c"), read.getList(2));
+    }
+
     /** Creates a test DataFrame with monotonically increasing integers and their string representations. */
     private Dataset<Row> createTestDataFrame(int numRows) {
         // Create DataFrame with monotonically increasing integers


### PR DESCRIPTION
The `ArrayType` branch of `populateVector` wrote every element through `populateVector` without checking `ArrayData.isNullAt`, unlike the top-level field path and the struct-child path which both check.

For a fixed-width element that silently corrupts data. `UnsafeArrayData.getInt` does not consult the null bitset — it reads the element slot directly — and `UnsafeArrayWriter.setNull4Bytes` zeroes that slot, so the read returns `0`; `IntVector.setSafe` then marks the position valid. `array(1, null, 3)` was written as a non-null `[1, 0, 3]`.

Variable-width elements happened to survive: their getters return `null` and the existing `str != null` guard skips the write, leaving the validity bit clear.

## Tests

New round-trip case in `VortexDataSourceWriteTest` covering fixed-width, floating-point and variable-width elements. It fails on the parent commit:

```
expected: <[1, null, 3]> but was: <[1, 0, 3]>
```

- `./gradlew :vortex-spark_2.13:test --tests 'dev.vortex.spark.VortexDataSourceWriteTest'` — 10/10 pass
- `./gradlew :vortex-spark_2.12:test --tests 'dev.vortex.spark.VortexDataSourceWriteTest'` — 10/10 pass
- `spotlessCheck` (both Scala versions) and `javadoc` — clean

`VortexDataSourceS3MockTest` fails locally for lack of a Docker environment, unrelated to this change.