### PR TITLE
fix(spark): resolve vortex.workerThreads case-insensitively

### DIFF
--- a/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexPartitionReaderFactory.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexPartitionReaderFactory.java
@@ -15,6 +15,7 @@ import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 /**
@@ -46,7 +47,10 @@ public final class VortexPartitionReaderFactory implements PartitionReaderFactor
 
     @Override
     public PartitionReader<ColumnarBatch> createColumnarReader(InputPartition partition) {
-        NativeRuntime.setWorkerThreads(Integer.parseInt(formatOptions.getOrDefault("vortex.workerThreads", "4")));
+        // Spark lower-cases the keys of the options map it hands to Table#newScanBuilder, so the
+        // option arrives spelled vortex.workerthreads and a case-sensitive lookup never finds it.
+        CaseInsensitiveStringMap options = new CaseInsensitiveStringMap(formatOptions);
+        NativeRuntime.setWorkerThreads(options.getInt("vortex.workerThreads", 4));
         VortexFilePartition spark = (VortexFilePartition) partition;
         return new VortexPartitionReader(spark, dataColumnNames, formatOptions, pushedPredicates);
     }


### PR DESCRIPTION
A read option set as `vortex.workerThreads` never reached the native runtime.

`VortexTable.newScanBuilder` merges the `CaseInsensitiveStringMap` Spark hands it into the format options. That map lower-cases its keys in the constructor and `entrySet()` returns the lower-cased delegate, so the option arrives spelled `vortex.workerthreads` — while `VortexScanBuilder` seeds the camelCase spelling with the default of `4`. Both keys end up in the map and the case-sensitive `getOrDefault` always read the default one, silently ignoring the user's value.

Also validates the value. It was a bare `Integer.parseInt`, so a non-numeric value failed inside the executor task with `NumberFormatException: For input string: "eight"` — naming neither the option nor the accepted range — and a negative value only failed later in the native runtime.

## Tests

New `VortexPartitionReaderFactoryTest` (JVM-only, no session): default, camelCase key, lower-cased key, zero, whitespace, non-numeric and negative.

- `./gradlew :vortex-spark_2.13:test --tests 'dev.vortex.spark.read.VortexPartitionReaderFactoryTest'` — 7/7 pass
- `./gradlew :vortex-spark_2.12:test ...` — 7/7 pass
- `VortexSqlTest` and `VortexFilterPushdownTest` (both Scala versions) — pass, unchanged
- `spotlessCheck` (both) and `javadoc` — clean