### PR TITLE
docs(spark): update the published version coordinates

### DIFF
--- a/java/vortex-spark/README.md
+++ b/java/vortex-spark/README.md
@@ -11,7 +11,7 @@ Two flavors are published to Maven Central:
 | `dev.vortex:vortex-spark_2.13` | Spark 4.x | 2.13  |
 | `dev.vortex:vortex-spark_2.12` | Spark 3.5.x | 2.12 |
 
-Use the `all` classifier JAR (e.g. `vortex-spark_2.13-0.78.0-all.jar`). It is self-contained:
+Use the `all` classifier JAR (e.g. `vortex-spark_2.13-0.83.0-all.jar`). It is self-contained:
 it bundles the Vortex JNI bindings, native libraries for Linux (x86_64 and aarch64) and macOS
 (aarch64), and relocates its Arrow, Guava, and Jackson dependencies to avoid classpath
 conflicts with Spark. The thin (unclassified) JAR does not work on its own because it
@@ -23,7 +23,7 @@ Pass the `all` JAR to `spark-shell`, `spark-submit`, or `pyspark` with `--jars`.
 either a local path or a URL, so you can point directly at Maven Central:
 
 ```shell
-spark-shell --jars https://repo1.maven.org/maven2/dev/vortex/vortex-spark_2.13/0.78.0/vortex-spark_2.13-0.78.0-all.jar
+spark-shell --jars https://repo1.maven.org/maven2/dev/vortex/vortex-spark_2.13/0.83.0/vortex-spark_2.13-0.83.0-all.jar
 ```
 
 Or configure it on the session builder, e.g. in PySpark:
@@ -31,12 +31,12 @@ Or configure it on the session builder, e.g. in PySpark:
 ```python
 spark = (
     SparkSession.builder
-    .config("spark.jars", "/path/to/vortex-spark_2.13-0.78.0-all.jar")
+    .config("spark.jars", "/path/to/vortex-spark_2.13-0.83.0-all.jar")
     .getOrCreate()
 )
 ```
 
-Note that `--packages dev.vortex:vortex-spark_2.13:0.78.0` does not work: `--packages` cannot
+Note that `--packages dev.vortex:vortex-spark_2.13:0.83.0` does not work: `--packages` cannot
 select the `all` classifier and resolves the thin JAR, which fails at runtime with
 `NoClassDefFoundError: dev/vortex/relocated/...`.
 
@@ -44,7 +44,7 @@ To depend on the connector from a JVM project instead, add the `all` classifier 
 dependency:
 
 ```kotlin
-implementation("dev.vortex:vortex-spark_2.13:0.78.0:all")
+implementation("dev.vortex:vortex-spark_2.13:0.83.0:all")
 ```
 
 ## Usage


### PR DESCRIPTION
The README's example coordinates still named `0.78.0`, five releases behind the `0.83.0` currently on Maven Central, so anyone copying the `spark-shell --jars` URL or the dependency snippet pulled a stale JAR.

Nothing regenerates these, so they need updating by hand.

## Tests

Verified the coordinates resolve:

```
$ curl -sI https://repo1.maven.org/maven2/dev/vortex/vortex-spark_2.13/0.83.0/vortex-spark_2.13-0.83.0-all.jar
HTTP 200
```

`0.83.0` is the current `<release>` in the `maven-metadata.xml` of both `vortex-spark_2.13` and `vortex-spark_2.12`.