### PR TITLE
fix(spark): delete aborted output through the native filesystem layer

### DIFF
--- a/java/vortex-spark/src/main/java/dev/vortex/spark/write/VortexBatchWrite.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/write/VortexBatchWrite.java
@@ -5,11 +5,7 @@ package dev.vortex.spark.write;
 
 import dev.vortex.jni.NativeFiles;
 import dev.vortex.spark.VortexSparkSession;
-import java.io.IOException;
 import java.io.Serializable;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -137,21 +133,22 @@ public final class VortexBatchWrite implements Write, BatchWrite, Serializable {
     /**
      * Aborts the write job due to failures.
      *
-     * <p>This method cleans up any partially written files.
+     * <p>Deletes the files the tasks reported, through the same native filesystem layer the writers used, so that URL
+     * paths ({@code file://}, {@code s3://}) resolve the same way on cleanup as they did on write.
      *
      * @param messages commit messages from write tasks (may include failures)
      */
     @Override
     public void abort(WriterCommitMessage[] messages) {
-        for (String filePath : extractFilePaths(messages)) {
-            try {
-                Path path = Paths.get(filePath);
-                if (Files.exists(path)) {
-                    Files.delete(path);
-                }
-            } catch (IOException e) {
-                log.error("Failed to clean up file: {}", filePath, e);
-            }
+        List<String> filePaths = extractFilePaths(messages);
+        if (filePaths.isEmpty()) {
+            return;
+        }
+        log.warn("Deleting {} file(s) written before the job failed, under {}", filePaths.size(), outputPath);
+        try {
+            NativeFiles.delete(VortexSparkSession.get(options), filePaths.toArray(new String[0]), options);
+        } catch (RuntimeException e) {
+            log.error("Failed to clean up {} file(s) under {}", filePaths.size(), outputPath, e);
         }
     }
 


### PR DESCRIPTION
`abort()` fed the writers' URL paths to `java.nio`'s `Paths.get`, which does not parse URLs:

```
Paths.get("file:///tmp/out/part-00000-0.vortex")
  -> file:/tmp/out/part-00000-0.vortex   (isAbsolute=false)
```

So `Files.exists` was always false and the job-level cleanup silently deleted nothing; for `s3://` it could never work. Every partial file of a failed write was left behind.

Delete through `NativeFiles` instead — the same layer the writers used, and the same call the overwrite path already makes a few lines above — so URL paths resolve identically on cleanup and on write. A cleanup failure is logged rather than thrown, since `abort()` runs while the job is already failing.

**Worth a careful look:** this makes a currently-inert destructive path actually delete files. That is the intent of `abort()` and it only ever touches paths the tasks themselves reported, but it is a behavior change rather than a no-op fix. The `log.warn` before the delete follows the precedent set by #8767 for the overwrite path.

## Tests

No new test: the failure only reproduces when a write job aborts mid-flight, which the suite has no fixture for. Verified no regression in the write and catalog paths that exercise `VortexBatchWrite`:

- `./gradlew :vortex-spark_2.13:test --tests 'dev.vortex.spark.VortexDataSourceWriteTest' --tests 'dev.vortex.spark.VortexSessionCatalogTest' --tests 'dev.vortex.spark.VortexSqlTest'` — 19/19 pass
- same on `:vortex-spark_2.12:test` — pass
- `spotlessCheck` (both Scala versions) and `javadoc` — clean

`VortexDataSourceS3MockTest` fails locally for lack of a Docker environment, unrelated to this change.