### PR TITLE
duckdb: more const for FFI

### DIFF
--- a/vortex-duckdb/cpp/include/table_function.hpp
+++ b/vortex-duckdb/cpp/include/table_function.hpp
@@ -3,33 +3,68 @@
 
 #pragma once
 
+#include "data.hpp"
 #include "duckdb.h"
 #include "duckdb/function/function.hpp"
 #include "duckdb/function/table_function.hpp"
 
+using namespace duckdb;
+
 static_assert(sizeof(idx_t) == 8);
 
 // We need this exposed to compare function addresses in optimizer.cpp
-duckdb::unique_ptr<duckdb::FunctionData>
-duckdb_vx_table_function_bind(duckdb::ClientContext &context,
-                              duckdb::TableFunctionBindInput &input,
-                              duckdb::vector<duckdb::LogicalType> &return_types,
-                              duckdb::vector<duckdb::string> &names);
+unique_ptr<FunctionData> duckdb_vx_table_function_bind(ClientContext &context,
+                                                       TableFunctionBindInput &input,
+                                                       vector<LogicalType> &return_types,
+                                                       vector<string> &names);
 
 struct TableFunctionProjectionExpressionInput {
-    const duckdb::LogicalGet &get;
-    const duckdb::Expression &expression;
+    const LogicalGet &get;
+    const Expression &expression;
     idx_t projection_idx;
 };
 
 // true if we can push down the expression, false otherwise
-bool projection_expression_pushdown(duckdb::ClientContext &context,
+bool projection_expression_pushdown(ClientContext &context,
                                     const TableFunctionProjectionExpressionInput &input);
 
 struct TableFunctionUngroupedAggregateInput {
-    const duckdb::LogicalGet &get;
+    const LogicalGet &get;
     // Column scan index -> aggregate expression
-    const duckdb::vector<std::pair<idx_t, const duckdb::Expression &>> &projections;
+    const vector<std::pair<idx_t, const Expression &>> &projections;
 };
 
-bool aggregate_pushdown(duckdb::ClientContext &context, const TableFunctionUngroupedAggregateInput &input);
+bool aggregate_pushdown(ClientContext &context, const TableFunctionUngroupedAggregateInput &input);
+
+struct VortexBindData final : FunctionData {
+    VortexBindData(unique_ptr<CData> ffi_data, const vector<LogicalType> &types)
+        : ffi_data(std::move(ffi_data)), types(types) {
+    }
+    unique_ptr<FunctionData> Copy() const override;
+    bool Equals(const FunctionData &other) const override;
+
+    unique_ptr<CData> ffi_data;
+    vector<LogicalType> types;
+};
+
+struct VortexGlobalData final : GlobalTableFunctionState {
+    explicit VortexGlobalData(unique_ptr<CData> ffi_data) : ffi_data(std::move(ffi_data)) {
+    }
+
+    idx_t MaxThreads() const override {
+        return GlobalTableFunctionState::MAX_THREADS;
+    }
+
+    unique_ptr<CData> ffi_data;
+};
+
+struct VortexLocalData final : LocalTableFunctionState {
+    explicit VortexLocalData(unique_ptr<CData> ffi_data) : ffi_data(std::move(ffi_data)) {
+    }
+    unique_ptr<CData> ffi_data;
+};
+
+struct VortexBindResults {
+    vector<LogicalType> &return_types;
+    vector<string> &names;
+};

--- a/vortex-duckdb/cpp/include/vector.h
+++ b/vortex-duckdb/cpp/include/vector.h
@@ -22,8 +22,6 @@ void duckdb_vx_vector_dictionary(duckdb_vector ffi_vector,
                                  duckdb_selection_vector ffi_sel_vec,
                                  idx_t count);
 
-void duckdb_vx_set_dictionary_vector_length(duckdb_vector dict, unsigned int len);
-
 // Reset vector's validity mask to nullptr, making all vector's elements valid.
 // vector must not be a DictionaryVector or a SequenceVector
 void duckdb_vx_vector_set_all_valid(duckdb_vector ffi_vector);

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -20,55 +20,43 @@
 #include "duckdb/planner/operator/logical_get.hpp"
 
 using namespace std::string_literals;
-using namespace duckdb;
 constexpr column_t COLUMN_IDENTIFIER_FILE_INDEX = MultiFileReader::COLUMN_IDENTIFIER_FILE_INDEX;
 constexpr column_t COLUMN_IDENTIFIER_FILE_ROW_NUMBER = MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER;
 
-struct CTableBindData final : FunctionData {
-    CTableBindData(unique_ptr<CData> ffi_data_p, const vector<LogicalType> &types)
-        : ffi_data(std::move(ffi_data_p)), types(types) {
-    }
-    unique_ptr<FunctionData> Copy() const override;
-    bool Equals(const FunctionData &other_base) const override;
-
-    unique_ptr<CData> ffi_data;
-    vector<LogicalType> types;
-};
-
-unique_ptr<FunctionData> CTableBindData::Copy() const {
+unique_ptr<FunctionData> VortexBindData::Copy() const {
     const auto copied_ffi_data = duckdb_table_function_bind_data_clone(ffi_data->DataPtr());
     auto ffi_data_p = unique_ptr<CData>(reinterpret_cast<CData *>(copied_ffi_data));
-    return make_uniq<CTableBindData>(std::move(ffi_data_p), types);
+    return make_uniq<VortexBindData>(std::move(ffi_data_p), types);
 }
 
-bool CTableBindData::Equals(const FunctionData &other_base) const {
-    const CTableBindData &other = other_base.Cast<CTableBindData>();
+bool VortexBindData::Equals(const FunctionData &other_base) const {
+    const VortexBindData &other = other_base.Cast<VortexBindData>();
     // if "types" are different, "ffi_data" would also be different as it
     // contains types inside, so omit "types" from comparison.
     return ffi_data.get() == other.ffi_data.get();
 }
 
-struct CTableGlobalData final : GlobalTableFunctionState {
-    explicit CTableGlobalData(unique_ptr<CData> ffi_data) : ffi_data(std::move(ffi_data)) {
-    }
+// This is a flaw of Duckdb API which doesn't allow passing non-const
+// expressions. We never modify the value on Rust side.
+static duckdb_vx_expr get_ffi_expr(const Expression &expr) {
+    return reinterpret_cast<duckdb_vx_expr>(const_cast<Expression *>(&expr));
+}
 
-    idx_t MaxThreads() const override {
-        return GlobalTableFunctionState::MAX_THREADS;
-    }
+static void *get_ffi_bind(const FunctionData *bind_data) {
+    return bind_data->Cast<VortexBindData>().ffi_data->DataPtr();
+}
 
-    unique_ptr<CData> ffi_data;
-};
+static void *get_ffi_global(GlobalTableFunctionState *state) {
+    return state->Cast<VortexGlobalData>().ffi_data->DataPtr();
+}
 
-struct CTableLocalData final : LocalTableFunctionState {
-    explicit CTableLocalData(unique_ptr<CData> ffi_data) : ffi_data(std::move(ffi_data)) {
-    }
-
-    unique_ptr<CData> ffi_data;
-};
+static void *get_ffi_local(LocalTableFunctionState *state) {
+    return state->Cast<VortexLocalData>().ffi_data->DataPtr();
+}
 
 double
 table_scan_progress(ClientContext &, const FunctionData *, const GlobalTableFunctionState *global_state) {
-    void *const c_global_state = global_state->Cast<CTableGlobalData>().ffi_data->DataPtr();
+    void *const c_global_state = global_state->Cast<VortexGlobalData>().ffi_data->DataPtr();
     return duckdb_table_function_scan_progress(c_global_state);
 }
 
@@ -125,8 +113,8 @@ unique_ptr<BaseStatistics> statistics(ClientContext &, const FunctionData *bind_
         return {};
     }
 
-    const auto &bind = bind_data->Cast<CTableBindData>();
-    void *const ffi_bind = bind.ffi_data->DataPtr();
+    const auto &bind = bind_data->Cast<VortexBindData>();
+    const void *const ffi_bind = get_ffi_bind(bind_data);
 
     duckdb_column_statistics statistics = {};
     if (!duckdb_table_function_statistics(ffi_bind, column_index, &statistics)) {
@@ -167,22 +155,9 @@ unique_ptr<BaseStatistics> statistics(ClientContext &, const FunctionData *bind_
     }
 }
 
-struct CTableBindResult {
-    vector<LogicalType> &return_types;
-    vector<string> &names;
-};
-
-// This is a flaw of Duckdb API which doesn't allow passing non-const
-// expressions. We never modify the value on Rust side.
-static duckdb_vx_expr get_ffi_expr(const Expression &expr) {
-    return reinterpret_cast<duckdb_vx_expr>(const_cast<Expression *>(&expr));
-}
-
 bool projection_expression_pushdown(ClientContext &, const TableFunctionProjectionExpressionInput &input) {
-    const auto &bind = input.get.bind_data->Cast<CTableBindData>();
-
     duckdb_vx_expr ffi_expr = get_ffi_expr(input.expression);
-    void *const ffi_bind = bind.ffi_data->DataPtr();
+    void *const ffi_bind = get_ffi_bind(input.get.bind_data.get());
     duckdb_vx_error error_out = nullptr;
 
     const bool ret = duckdb_table_function_pushdown_projection_expression( //
@@ -211,8 +186,7 @@ duckdb_vx_expr duckdb_vx_aggregate_at(duckdb_vx_agg_input ffi_input, idx_t i, id
 }
 
 bool aggregate_pushdown(ClientContext &, const TableFunctionUngroupedAggregateInput &input) {
-    const auto &bind = input.get.bind_data->Cast<CTableBindData>();
-    void *const ffi_bind = bind.ffi_data->DataPtr();
+    void *const ffi_bind = get_ffi_bind(input.get.bind_data.get());
     duckdb_vx_error error_out = nullptr;
     const auto ffi_input =
         reinterpret_cast<duckdb_vx_agg_input>(const_cast<TableFunctionUngroupedAggregateInput *>(&input));
@@ -223,34 +197,29 @@ bool aggregate_pushdown(ClientContext &, const TableFunctionUngroupedAggregateIn
     return res;
 }
 
-/**
- * Called for every new query. For example, if there is a VIEW over *.vortex,
- * and after a query another file is added matching the glob, for second query
- * bind() will be called again.
- */
 unique_ptr<FunctionData> duckdb_vx_table_function_bind(ClientContext &,
                                                        TableFunctionBindInput &input,
                                                        vector<LogicalType> &return_types,
                                                        vector<string> &names) {
-    CTableBindResult result = {return_types, names};
+    VortexBindResults result = {return_types, names};
 
     duckdb_vx_error error_out = nullptr;
-    auto ffi_bind_data = duckdb_table_function_bind(reinterpret_cast<duckdb_vx_tfunc_bind_input>(&input),
-                                                    reinterpret_cast<duckdb_vx_tfunc_bind_result>(&result),
-                                                    &error_out);
+    duckdb_vx_tfunc_bind_input bind_input = reinterpret_cast<duckdb_vx_tfunc_bind_input>(&input);
+    duckdb_vx_tfunc_bind_result bind_result = reinterpret_cast<duckdb_vx_tfunc_bind_result>(&result);
+    duckdb_vx_data ffi_bind_data = duckdb_table_function_bind(bind_input, bind_result, &error_out);
     if (error_out) {
         throw BinderException(IntoErrString(error_out));
     }
 
     auto cdata = unique_ptr<CData>(reinterpret_cast<CData *>(ffi_bind_data));
-    return make_uniq<CTableBindData>(std::move(cdata), return_types);
+    return make_uniq<VortexBindData>(std::move(cdata), return_types);
 }
 
-unique_ptr<GlobalTableFunctionState> c_init_global(ClientContext &context, TableFunctionInitInput &input) {
-    const CTableBindData &bind = input.bind_data->Cast<CTableBindData>();
+unique_ptr<GlobalTableFunctionState> init_global(ClientContext &context, TableFunctionInitInput &input) {
+    const void *const ffi_bind = get_ffi_bind(input.bind_data.get());
 
     duckdb_vx_tfunc_init_input ffi_input = {
-        .bind_data = bind.ffi_data->DataPtr(),
+        .bind_data = ffi_bind,
         .column_ids = input.column_ids.data(),
         .column_ids_count = input.column_ids.size(),
         .projection_ids = input.projection_ids.data(),
@@ -266,22 +235,22 @@ unique_ptr<GlobalTableFunctionState> c_init_global(ClientContext &context, Table
     }
 
     auto cdata = unique_ptr<CData>(reinterpret_cast<CData *>(ffi_global_data));
-    return make_uniq<CTableGlobalData>(std::move(cdata));
+    return make_uniq<VortexGlobalData>(std::move(cdata));
 }
 
 unique_ptr<LocalTableFunctionState>
 init_local(ExecutionContext &, TableFunctionInitInput &input, GlobalTableFunctionState *global_state) {
-    const void *const ffi_bind = input.bind_data->Cast<CTableBindData>().ffi_data->DataPtr();
-    void *const ffi_global = global_state->Cast<CTableGlobalData>().ffi_data->DataPtr();
+    const void *const ffi_bind = get_ffi_bind(input.bind_data.get());
+    void *const ffi_global = get_ffi_global(global_state);
 
     duckdb_vx_data ffi_local_data = duckdb_table_function_init_local(ffi_bind, ffi_global);
     auto cdata = unique_ptr<CData>(reinterpret_cast<CData *>(ffi_local_data));
-    return make_uniq<CTableLocalData>(std::move(cdata));
+    return make_uniq<VortexLocalData>(std::move(cdata));
 }
 
 void function(ClientContext &, TableFunctionInput &input, DataChunk &output) {
-    void *const ffi_global = input.global_state->Cast<CTableGlobalData>().ffi_data->DataPtr();
-    void *const ffi_local = input.local_state->Cast<CTableLocalData>().ffi_data->DataPtr();
+    void *const ffi_global = get_ffi_global(input.global_state.get());
+    void *const ffi_local = get_ffi_local(input.local_state.get());
 
     duckdb_data_chunk chunk = reinterpret_cast<duckdb_data_chunk>(&output);
     duckdb_vx_error error_out = nullptr;
@@ -293,21 +262,8 @@ void function(ClientContext &, TableFunctionInput &input, DataChunk &output) {
 
 using FilterVec = vector<unique_ptr<Expression>>;
 
-/*
- * Table filter pushdown is used for two tasks in duckdb:
- *
- * 1. Prune files based on filename or hive partitioning, see Parquet
- * filter pushdown. We don't use this because we do own file-level pruning in
- * FileStatsLayoutReader, and we don't support hive partitioning yet.
- *
- * 2. Avoid reading unused file data. Filter expressions are pushed to Vortex,
- * converted to Vortex expressions and used during the scan.
- * Duckdb pushes a subset of expressions i.e. equality operators, and also
- * expressions which return true in pushdown_expression.
- */
 void pushdown_complex_filter(const FunctionData &bind_data, FilterVec &filters) {
-    const auto &bind = bind_data.Cast<CTableBindData>();
-    void *const ffi_bind = bind.ffi_data->DataPtr();
+    void *const ffi_bind = get_ffi_bind(&bind_data);
     duckdb_vx_error error_out = nullptr;
 
     for (auto iter = filters.begin(); iter != filters.end();) {
@@ -321,11 +277,11 @@ void pushdown_complex_filter(const FunctionData &bind_data, FilterVec &filters) 
     }
 }
 
-unique_ptr<NodeStatistics> c_cardinality(ClientContext &, const FunctionData *bind_data) {
-    auto &bind = bind_data->Cast<CTableBindData>();
+unique_ptr<NodeStatistics> cardinality(ClientContext &, const FunctionData *bind_data) {
+    const void *const ffi_bind = get_ffi_bind(bind_data);
 
     duckdb_vx_node_statistics stats = {};
-    duckdb_table_function_cardinality(bind.ffi_data->DataPtr(), &stats);
+    duckdb_table_function_cardinality(ffi_bind, &stats);
 
     auto out = make_uniq<NodeStatistics>();
     out->has_estimated_cardinality = stats.has_estimated_cardinality;
@@ -350,7 +306,7 @@ extern "C" void duckdb_vx_tfunc_bind_result_add_column(duckdb_vx_tfunc_bind_resu
     D_ASSERT(ffi_result);
     D_ASSERT(name_str);
     D_ASSERT(ffi_type);
-    const CTableBindResult &result = *reinterpret_cast<CTableBindResult *>(ffi_result);
+    const VortexBindResults &result = *reinterpret_cast<VortexBindResults *>(ffi_result);
     const LogicalType logical_type = *reinterpret_cast<LogicalType *>(ffi_type);
 
     result.names.emplace_back(name_str, name_len);
@@ -373,15 +329,9 @@ TablePartitionInfo get_partition_info(ClientContext &, TableFunctionPartitionInp
                : TablePartitionInfo::NOT_PARTITIONED;
 }
 
-/**
- * Duckdb requests this function after exporting the chunk. We answer with
- * partition_index we have exported as well as information about constant
- * columns in this partition. As data is partitioned by array exporters, in
- * each partition ~ exported array file_index is constant.
- */
 OperatorPartitionData get_partition_data(ClientContext &, TableFunctionGetPartitionInput &input) {
-    void *const ffi_global = input.global_state->Cast<CTableGlobalData>().ffi_data->DataPtr();
-    void *const ffi_local = input.local_state->Cast<CTableLocalData>().ffi_data->DataPtr();
+    void *const ffi_global = get_ffi_global(input.global_state.get());
+    void *const ffi_local = get_ffi_local(input.local_state.get());
     duckdb_vx_partition_data partition_data;
     duckdb_table_function_get_partition_data(ffi_global, ffi_local, &partition_data);
 
@@ -408,16 +358,16 @@ extern "C" void duckdb_vx_string_map_insert(duckdb_vx_string_map map, const char
     reinterpret_cast<InsertionOrderPreservingMap<string> *>(map)->insert(key, value);
 }
 
-InsertionOrderPreservingMap<string> c_to_string(TableFunctionToStringInput &input) {
+InsertionOrderPreservingMap<string> to_string(TableFunctionToStringInput &input) {
     InsertionOrderPreservingMap<string> result;
     duckdb_vx_string_map ffi_map = reinterpret_cast<duckdb_vx_string_map>(&result);
-    void *const ffi_bind = input.bind_data->Cast<CTableBindData>().ffi_data->DataPtr();
+    const void *const ffi_bind = get_ffi_bind(input.bind_data.get());
     duckdb_table_function_to_string(ffi_bind, ffi_map);
     return result;
 }
 
 duckdb_state register_table_function(DatabaseInstance &db, LogicalType parameter, const std::string &name) {
-    TableFunction tf(name, {}, function, duckdb_vx_table_function_bind, c_init_global, init_local);
+    TableFunction tf(name, {}, function, duckdb_vx_table_function_bind, init_global, init_local);
 
     tf.projection_pushdown = true;
     tf.filter_pushdown = true;
@@ -430,10 +380,10 @@ duckdb_state register_table_function(DatabaseInstance &db, LogicalType parameter
     tf.pushdown_complex_filter = [](auto &, auto &, FunctionData *bind_data, FilterVec &filters) {
         pushdown_complex_filter(*bind_data, filters);
     };
-    tf.cardinality = c_cardinality;
+    tf.cardinality = cardinality;
     tf.get_partition_info = get_partition_info;
     tf.get_partition_data = get_partition_data;
-    tf.to_string = c_to_string;
+    tf.to_string = to_string;
     tf.table_scan_progress = table_scan_progress;
     tf.statistics = statistics;
 

--- a/vortex-duckdb/cpp/vector.cpp
+++ b/vortex-duckdb/cpp/vector.cpp
@@ -26,11 +26,6 @@ extern "C" void duckdb_vx_vector_dictionary(duckdb_vector ffi_vector,
     vector->Dictionary(*dict, dictionary_size, *sel_vec, count);
 }
 
-extern "C" void duckdb_vx_set_dictionary_vector_length(duckdb_vector dict, unsigned int len) {
-    auto ddict = reinterpret_cast<duckdb::Vector *>(dict);
-    ddict->GetBuffer()->Cast<DictionaryBuffer>().SetDictionarySize(len);
-}
-
 extern "C" void
 duckdb_vx_sequence_vector(duckdb_vector c_vector, int64_t start, int64_t step, idx_t capacity) {
     auto vector = reinterpret_cast<Vector *>(c_vector);

--- a/vortex-duckdb/include/vortex.h
+++ b/vortex-duckdb/include/vortex.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif // __cplusplus
 
-extern void duckdb_table_function_to_string(void *bind_data, duckdb_vx_string_map map);
+extern void duckdb_table_function_to_string(const void *bind_data, duckdb_vx_string_map map);
 
 extern
 bool duckdb_table_function_statistics(const void *bind_data,
@@ -56,7 +56,7 @@ void duckdb_table_function_scan(void *global_init_data,
 extern bool duckdb_table_function_pushdown_expression(duckdb_vx_expr expr);
 
 extern
-void duckdb_table_function_cardinality(void *bind_data,
+void duckdb_table_function_cardinality(const void *bind_data,
                                        duckdb_vx_node_statistics *node_stats_out);
 
 extern

--- a/vortex-duckdb/src/duckdb/vector.rs
+++ b/vortex-duckdb/src/duckdb/vector.rs
@@ -112,12 +112,6 @@ impl VectorRef {
         }
     }
 
-    // Used to by duckdb to know the dictionary value length (since each vector doesn't know its own
-    // length only its capacity).
-    pub fn set_dictionary_len(&mut self, len: u32) {
-        unsafe { cpp::duckdb_vx_set_dictionary_vector_length(self.as_ptr(), len) }
-    }
-
     pub fn to_sequence(&mut self, start: i64, stop: i64, capacity: u64) {
         unsafe { cpp::duckdb_vx_sequence_vector(self.as_ptr(), start, stop, capacity) }
     }

--- a/vortex-duckdb/src/ffi.rs
+++ b/vortex-duckdb/src/ffi.rs
@@ -48,7 +48,7 @@ use crate::table_function::to_string;
 
 #[unsafe(no_mangle)]
 unsafe extern "C-unwind" fn duckdb_table_function_to_string(
-    bind_data: *mut c_void,
+    bind_data: *const c_void,
     map: cpp::duckdb_vx_string_map,
 ) {
     let bind_data = unsafe { bind_data.cast::<TableFunctionBind>().as_ref() }
@@ -178,7 +178,7 @@ pub unsafe extern "C-unwind" fn duckdb_table_function_pushdown_expression(
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn duckdb_table_function_cardinality(
-    bind_data: *mut c_void,
+    bind_data: *const c_void,
     node_stats_out: *mut cpp::duckdb_vx_node_statistics,
 ) {
     let bind_data = unsafe { bind_data.cast::<TableFunctionBind>().as_ref() }

--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -188,6 +188,9 @@ pub enum Cardinality {
     Estimate(u64),
 }
 
+// Called for every new query. For example, if there is a VIEW over *.vortex,
+// and after a query another file is added matching the glob, for second query
+// bind() will be called again.
 pub fn bind(input: &BindInputRef, result: &mut BindResultRef) -> VortexResult<TableFunctionBind> {
     let data_source = bind_multi_file_scan(input)?;
     let column_fields = extract_schema_from_dtype(data_source.dtype())?;
@@ -585,6 +588,15 @@ pub fn table_scan_progress(global_state: &TableFunctionGlobal) -> f64 {
     progress(&global_state.bytes_read, &global_state.bytes_total)
 }
 
+/// Table filter pushdown is used for two tasks in duckdb:
+///
+/// 1. Prune files based on filename or hive partitioning, see Parquet
+///    filter pushdown. We don't use this because we do own file-level pruning
+///    in FileStatsLayoutReader, and we don't support hive partitioning yet.
+/// 2. Avoid reading unused file data. Filter expressions are pushed to Vortex,
+///    converted to Vortex expressions and used during the scan.
+///    Duckdb pushes a subset of expressions i.e. equality operators, and also
+///    expressions which return true in pushdown_expression.
 pub fn pushdown_complex_filter(
     bind_data: &mut TableFunctionBind,
     expr: &ExpressionRef,
@@ -773,6 +785,10 @@ pub fn cardinality(bind_data: &TableFunctionBind) -> Cardinality {
     }
 }
 
+/// Duckdb requests this function after exporting the chunk. We answer with
+/// partition_index we have exported as well as information about constant
+/// columns in this partition. As data is partitioned by array exporters, in
+/// each partition ~ exported array file_index is constant.
 pub fn get_partition_data(
     global_init_data: &TableFunctionGlobal,
     local_init_data: &mut TableFunctionLocal,


### PR DESCRIPTION
- Remove unused `duckdb_vx_set_dictionary_vector_length`.
- Move comments about duckdb callbacks from C++ to Rust side.
- Add const modifiers to some callbacks.
- Add helper `get_ffi_*` functions for C++ side.
- Move structs to header file

#8628 