### PR TITLE
docs: make the 1 ms benchmark iteration budget an explicit maximum

### DIFF
--- a/docs/developer-guide/benchmarking.md
+++ b/docs/developer-guide/benchmarking.md
@@ -119,10 +119,20 @@ const VECTOR_SIZE: &[usize] = &[16, 256, 2048, 8192];
 fn my_bench<const N: usize>(bencher: Bencher, num_indices: usize) { ... }
 ```
 
-### Keep per-iteration execution time under ~1 ms
+### Keep per-iteration execution time under 1 ms
 
-Each individual iteration of the benchmarked closure should complete in
-**less than 1ms**. This is to keep benchmarks snappy, locally and on CI.
+**1 ms is the maximum, not a soft target.** Each individual iteration of the benchmarked
+closure must complete in less than 1 ms. This is to keep benchmarks snappy, locally and on
+CI.
+
+A benchmark that needs longer than that is measuring too much work at once. Shrink the
+input size until a single iteration fits, split it into smaller parameterized cases, or
+gate it with `#[cfg(not(codspeed))]` if it genuinely cannot be made to fit.
+
+The number to check against the budget is the per-iteration time, not the time the whole
+benchmark binary takes. CodSpeed reports exactly that: its performance report on a pull
+request lists the per-iteration time under `HEAD` for every benchmark the pull request adds
+or changes, so check any new benchmark there before merging.
 
 ### Gate CodSpeed-incompatible benchmarks
 


### PR DESCRIPTION
## Rationale for this change

The benchmarking guide asked for "less than 1ms" per iteration without saying whether that was an aspiration or a limit, and without saying which number to measure against it.

That gap showed up in review on #9136, where benchmarks landed at 23.8 ms and 123.4 ms per iteration. The review conversation there had no documented rule to point at — as noted on that PR, the guide "has nothing about benchmarks being too long".

This documents the rule first, on its own, so it can be cited independently of any tooling that enforces it.

## What changes are included in this PR?

Docs only — one section of `docs/developer-guide/benchmarking.md`:

- States that **1 ms is the maximum, not a soft target**.
- Says what to do when a benchmark does not fit: shrink the input, split it into smaller parameterized cases, or gate it with `#[cfg(not(codspeed))]`.
- Names the number to check: the **per-iteration** time CodSpeed reports under `HEAD` for every benchmark a PR adds or changes — not the runtime of the whole benchmark binary, which is what "this benchmark takes too long" usually gets confused with.

The heading loses its `~` (`under ~1 ms` → `under 1 ms`), which leaves the existing anchor `#keep-per-iteration-execution-time-under-1-ms` unchanged.

A follow-up branch adds CI that reads CodSpeed's report and comments when a new or changed benchmark exceeds this budget. It is deliberately kept out of this PR so the rule can be agreed on its own.

## What APIs are changed? Are there any user-facing changes?

No code, no API changes. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZJAp4wVgwTVhLyErCWFZn

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZJAp4wVgwTVhLyErCWFZn)_