### PR TITLE
Remove libc6-dbg install for codspeed

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -73,9 +73,6 @@ jobs:
         with:
           enable-sccache: ${{ github.repository == 'vortex-data/vortex' && 'true' || 'false' }}
       - uses: ./.github/actions/system-info
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y libc6-dbg
       - name: Install Codspeed
         uses: taiki-e/cache-cargo-install-action@66c9585ef5ca780ee69399975a5e911f47905995
         with:
@@ -166,9 +163,6 @@ jobs:
           nvidia-smi
           nvidia-smi -L
           nvidia-smi -q -d Memory
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y libc6-dbg
       - name: Install Codspeed
         uses: taiki-e/cache-cargo-install-action@66c9585ef5ca780ee69399975a5e911f47905995
         with:


### PR DESCRIPTION
## Rationale for this change

Seems like our AMIs already have it installed, and `apt-get update` seems to stall randomly.

From a recent [run](https://github.com/vortex-data/vortex/actions/runs/30920901763/job/92040114831?pr=9108):
```
Fetched 39.6 MB in 4min 11s (158 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
libc6-dbg is already the newest version (2.39-0ubuntu8.8).
```