### PR TITLE
Shrink zstd buffer before returning 

### DIFF
--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -661,9 +661,10 @@ impl ZstdData {
                 .unwrap_or(value_bytes.len());
 
             let uncompressed = &value_bytes.slice(frame_byte_starts[i]..frame_byte_end);
-            let compressed = compressor
+            let mut compressed = compressor
                 .compress(uncompressed)
                 .map_err(|err| VortexError::from(err).with_context("while compressing"))?;
+            compressed.shrink_to_fit();
             frame_metas.push(ZstdFrameMetadata {
                 uncompressed_size: uncompressed.len() as u64,
                 n_values: values_per_frame.min(n_values - i * values_per_frame) as u64,

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -83,7 +83,8 @@ impl ZstdBuffers {
             buffer_alignments.push(u32::from(handle.alignment()));
             let host_buf = handle.clone().try_to_host_sync()?;
             uncompressed_sizes.push(host_buf.len() as u64);
-            let compressed = compressor.compress(&host_buf)?;
+            let mut compressed = compressor.compress(&host_buf)?;
+            compressed.shrink_to_fit();
             compressed_buffers.push(BufferHandle::new_host(ByteBuffer::from(compressed)));
         }
 


### PR DESCRIPTION
## Before 
- ztd buffers were the same size as the uncompressed input for the full life-time 

## After
- zstd buffers fit to size after determining the compressed size