### PR TITLE
Fix DF benchmark pushdown options

### DIFF
--- a/benchmarks/datafusion-bench/src/lib.rs
+++ b/benchmarks/datafusion-bench/src/lib.rs
@@ -122,7 +122,7 @@ fn vortex_table_options() -> VortexTableOptions {
     let mut opts = VortexTableOptions::default();
 
     opts.predicate_pushdown = true;
-    opts.predicate_pushdown = true;
+    opts.projection_pushdown = true;
 
     opts
 }


### PR DESCRIPTION
`predicate_pushdown` is assigned twice; the second should be `projection_pushdown`.