### PR TITLE
feat(datafusion): allow configuring `ExpressionConvertor` on `VortexFormat` and `VortexFormatFactory`

### DIFF
--- a/vortex-datafusion/src/convert/exprs.rs
+++ b/vortex-datafusion/src/convert/exprs.rs
@@ -72,6 +72,47 @@ pub(crate) fn make_vortex_predicate(
 }
 
 /// Trait for converting DataFusion expressions to Vortex ones.
+///
+/// # Implementing a custom convertor
+///
+/// ```
+/// use std::sync::Arc;
+///
+/// use arrow_schema::Schema;
+/// use datafusion_common::Result as DFResult;
+/// use datafusion_physical_expr::PhysicalExpr;
+/// use datafusion_physical_expr::projection::ProjectionExprs;
+/// use vortex::expr::Expression;
+/// use vortex_datafusion::convert::DefaultExpressionConvertor;
+/// use vortex_datafusion::convert::ExpressionConvertor;
+/// use vortex_datafusion::convert::ProcessedProjection;
+///
+/// struct CustomExpressionConvertor(DefaultExpressionConvertor);
+///
+/// impl ExpressionConvertor for CustomExpressionConvertor {
+///     fn can_be_pushed_down(&self, expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> bool {
+///         self.0.can_be_pushed_down(expr, schema)
+///     }
+///
+///     fn convert(&self, expr: &dyn PhysicalExpr) -> DFResult<Expression> {
+///         self.0.convert(expr)
+///     }
+///
+///     fn split_projection(
+///         &self,
+///         source_projection: ProjectionExprs,
+///         input_schema: &Schema,
+///         output_schema: &Schema,
+///     ) -> DFResult<ProcessedProjection> {
+///         self.0
+///             .split_projection(source_projection, input_schema, output_schema)
+///     }
+/// }
+///
+/// let _convertor: Arc<dyn ExpressionConvertor> = Arc::new(CustomExpressionConvertor(
+///     DefaultExpressionConvertor::default(),
+/// ));
+/// ```
 pub trait ExpressionConvertor: Send + Sync {
     /// Can an expression be pushed down given a specific schema
     fn can_be_pushed_down(&self, expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> bool;

--- a/vortex-datafusion/src/convert/exprs.rs
+++ b/vortex-datafusion/src/convert/exprs.rs
@@ -52,7 +52,9 @@ use crate::convert::FromDataFusion;
 
 /// Result of splitting a projection into Vortex expressions and leftover DataFusion projections.
 pub struct ProcessedProjection {
+    /// Projection evaluated by the Vortex scan.
     pub scan_projection: Expression,
+    /// Projection evaluated by DataFusion after the Vortex scan.
     pub leftover_projection: ProjectionExprs,
 }
 

--- a/vortex-datafusion/src/convert/mod.rs
+++ b/vortex-datafusion/src/convert/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod stats;
 
 pub use exprs::DefaultExpressionConvertor;
 pub use exprs::ExpressionConvertor;
+pub use exprs::ProcessedProjection;
 
 /// First-party trait for implementing conversion from DataFusion types to Vortex types.
 pub trait FromDataFusion<D: ?Sized>: Sized {

--- a/vortex-datafusion/src/lib.rs
+++ b/vortex-datafusion/src/lib.rs
@@ -166,12 +166,18 @@ mod common_tests {
     impl TestSessionContext {
         /// Create a new test session context with the given projection pushdown setting.
         pub fn new(projection_pushdown: bool) -> Self {
-            let store = Arc::new(InMemory::new());
             let opts = VortexTableOptions {
                 projection_pushdown,
                 ..Default::default()
             };
             let factory = Arc::new(VortexFormatFactory::new().with_options(opts));
+
+            Self::new_with_factory(factory)
+        }
+
+        /// Create a new test session context with the given Vortex format factory.
+        pub fn new_with_factory(factory: Arc<VortexFormatFactory>) -> Self {
+            let store = Arc::new(InMemory::new());
             let mut session_state_builder = SessionStateBuilder::new()
                 .with_default_features()
                 .with_table_factory(

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -68,6 +68,7 @@ use super::cache::CachedVortexMetadata;
 use super::sink::VortexSink;
 use super::source::VortexSource;
 use crate::PrecisionExt as _;
+use crate::convert::ExpressionConvertor;
 use crate::convert::TryToDataFusion;
 use crate::convert::stats::is_constant_to_distinct_count;
 
@@ -123,12 +124,17 @@ const DEFAULT_FOOTER_INITIAL_READ_SIZE_BYTES: usize = MAX_POSTSCRIPT_SIZE as usi
 pub struct VortexFormat {
     session: VortexSession,
     opts: VortexTableOptions,
+    expression_convertor: Option<Arc<dyn ExpressionConvertor>>,
 }
 
 impl Debug for VortexFormat {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("VortexFormat")
             .field("opts", &self.opts)
+            .field(
+                "has_expression_convertor",
+                &self.expression_convertor.is_some(),
+            )
             .finish()
     }
 }
@@ -270,10 +276,23 @@ impl ConfigExtension for VortexTableOptions {
 /// ```
 ///
 /// [`ListingTable`]: https://docs.rs/datafusion/latest/datafusion/datasource/listing/struct.ListingTable.html
-#[derive(Debug)]
 pub struct VortexFormatFactory {
     session: VortexSession,
     options: Option<VortexTableOptions>,
+    expression_convertor: Option<Arc<dyn ExpressionConvertor>>,
+}
+
+impl Debug for VortexFormatFactory {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VortexFormatFactory")
+            .field("session", &self.session)
+            .field("options", &self.options)
+            .field(
+                "has_expression_convertor",
+                &self.expression_convertor.is_some(),
+            )
+            .finish()
+    }
 }
 
 impl GetExt for VortexFormatFactory {
@@ -297,6 +316,7 @@ impl VortexFormatFactory {
         Self {
             session: VortexSession::default(),
             options: None,
+            expression_convertor: None,
         }
     }
 
@@ -311,6 +331,7 @@ impl VortexFormatFactory {
         Self {
             session,
             options: Some(options),
+            expression_convertor: None,
         }
     }
 
@@ -335,6 +356,15 @@ impl VortexFormatFactory {
     /// ```
     pub fn with_options(mut self, options: VortexTableOptions) -> Self {
         self.options = Some(options);
+        self
+    }
+
+    /// Sets the [`ExpressionConvertor`] used by formats and sources created by this factory.
+    pub fn with_expression_convertor(
+        mut self,
+        expression_convertor: Arc<dyn ExpressionConvertor>,
+    ) -> Self {
+        self.expression_convertor = Some(expression_convertor);
         self
     }
 }
@@ -374,14 +404,19 @@ impl FileFormatFactory for VortexFormatFactory {
             }
         }
 
-        Ok(Arc::new(VortexFormat::new_with_options(
-            self.session.clone(),
-            opts,
-        )))
+        let mut format = VortexFormat::new_with_options(self.session.clone(), opts);
+        if let Some(expression_convertor) = &self.expression_convertor {
+            format = format.with_expression_convertor(Arc::clone(expression_convertor));
+        }
+        Ok(Arc::new(format))
     }
 
     fn default(&self) -> Arc<dyn FileFormat> {
-        Arc::new(VortexFormat::new(self.session.clone()))
+        let mut format = VortexFormat::new(self.session.clone());
+        if let Some(expression_convertor) = &self.expression_convertor {
+            format = format.with_expression_convertor(Arc::clone(expression_convertor));
+        }
+        Arc::new(format)
     }
 }
 
@@ -398,13 +433,26 @@ impl VortexFormat {
 
     /// Creates a format with explicit [`VortexTableOptions`].
     pub fn new_with_options(session: VortexSession, opts: VortexTableOptions) -> Self {
-        Self { session, opts }
+        Self {
+            session,
+            opts,
+            expression_convertor: None,
+        }
     }
 
     /// Returns the format-specific configuration that will be copied into the
     /// [`VortexSource`] created for a scan.
     pub fn options(&self) -> &VortexTableOptions {
         &self.opts
+    }
+
+    /// Sets the [`ExpressionConvertor`] used by every [`VortexSource`] created by this format.
+    pub fn with_expression_convertor(
+        mut self,
+        expression_convertor: Arc<dyn ExpressionConvertor>,
+    ) -> Self {
+        self.expression_convertor = Some(expression_convertor);
+        self
     }
 }
 
@@ -702,9 +750,12 @@ impl FileFormat for VortexFormat {
     }
 
     fn file_source(&self, table_schema: TableSchema) -> Arc<dyn FileSource> {
-        Arc::new(
-            VortexSource::new(table_schema, self.session.clone()).with_options(self.opts.clone()),
-        ) as _
+        let mut source =
+            VortexSource::new(table_schema, self.session.clone()).with_options(self.opts.clone());
+        if let Some(expression_convertor) = &self.expression_convertor {
+            source = source.with_expression_convertor(Arc::clone(expression_convertor));
+        }
+        Arc::new(source) as _
     }
 }
 
@@ -730,9 +781,87 @@ fn scalar_stat_to_df(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+
+    use arrow_schema::DataType;
+    use arrow_schema::Field;
+    use datafusion_common::ScalarValue;
+    use datafusion_common::config::ConfigOptions;
+    use datafusion_expr::Operator;
+    use datafusion_physical_expr::PhysicalExpr;
+    use datafusion_physical_expr::expressions as df_expr;
+    use datafusion_physical_expr::projection::ProjectionExprs;
+    use datafusion_physical_plan::filter_pushdown::PushedDown;
+    use vortex::expr::Expression;
 
     use super::*;
     use crate::common_tests::TestSessionContext;
+    use crate::convert::DefaultExpressionConvertor;
+    use crate::convert::ProcessedProjection;
+
+    struct RejectingExpressionConvertor {
+        inner: DefaultExpressionConvertor,
+        called: Arc<AtomicBool>,
+    }
+
+    impl RejectingExpressionConvertor {
+        fn new(session: VortexSession, called: Arc<AtomicBool>) -> Self {
+            Self {
+                inner: DefaultExpressionConvertor::new(session),
+                called,
+            }
+        }
+    }
+
+    impl ExpressionConvertor for RejectingExpressionConvertor {
+        fn can_be_pushed_down(&self, _expr: &Arc<dyn PhysicalExpr>, _schema: &Schema) -> bool {
+            self.called.store(true, Ordering::Relaxed);
+            false
+        }
+
+        fn convert(&self, expr: &dyn PhysicalExpr) -> DFResult<Expression> {
+            self.inner.convert(expr)
+        }
+
+        fn split_projection(
+            &self,
+            source_projection: ProjectionExprs,
+            input_schema: &Schema,
+            output_schema: &Schema,
+        ) -> DFResult<ProcessedProjection> {
+            self.inner
+                .split_projection(source_projection, input_schema, output_schema)
+        }
+    }
+
+    fn expression_convertor_test_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]))
+    }
+
+    fn expression_convertor_test_filter() -> Arc<dyn PhysicalExpr> {
+        let column = Arc::new(df_expr::Column::new("a", 0)) as Arc<dyn PhysicalExpr>;
+        let literal =
+            Arc::new(df_expr::Literal::new(ScalarValue::Int32(Some(1)))) as Arc<dyn PhysicalExpr>;
+        Arc::new(df_expr::BinaryExpr::new(column, Operator::Gt, literal))
+    }
+
+    fn assert_uses_expression_convertor(
+        format: &dyn FileFormat,
+        called: &AtomicBool,
+    ) -> anyhow::Result<()> {
+        let source = format.file_source(TableSchema::from_file_schema(
+            expression_convertor_test_schema(),
+        ));
+        let result = source.try_pushdown_filters(
+            vec![expression_convertor_test_filter()],
+            &ConfigOptions::new(),
+        )?;
+
+        assert!(called.load(Ordering::Relaxed));
+        assert!(matches!(result.filters.as_slice(), [PushedDown::No]));
+        Ok(())
+    }
 
     #[tokio::test]
     async fn create_table() -> anyhow::Result<()> {
@@ -803,5 +932,36 @@ mod tests {
         assert_eq!(source.options().predicate_pushdown, opts.predicate_pushdown);
         assert_eq!(source.options().scan_concurrency, opts.scan_concurrency);
         Ok(())
+    }
+
+    #[test]
+    fn format_plumbs_expression_convertor() -> anyhow::Result<()> {
+        let session = VortexSession::default();
+        let called = Arc::new(AtomicBool::new(false));
+        let convertor = Arc::new(RejectingExpressionConvertor::new(
+            session.clone(),
+            Arc::clone(&called),
+        ));
+        let format = VortexFormat::new(session).with_expression_convertor(convertor);
+
+        assert_uses_expression_convertor(&format, &called)
+    }
+
+    #[test]
+    fn factory_plumbs_expression_convertor() -> anyhow::Result<()> {
+        let called = Arc::new(AtomicBool::new(false));
+        let convertor = Arc::new(RejectingExpressionConvertor::new(
+            VortexSession::default(),
+            Arc::clone(&called),
+        ));
+        let factory = VortexFormatFactory::new().with_expression_convertor(convertor);
+        let ctx = TestSessionContext::default();
+
+        let format = factory.create(&ctx.session.state(), &Default::default())?;
+        assert_uses_expression_convertor(format.as_ref(), &called)?;
+
+        called.store(false, Ordering::Relaxed);
+        let format = FileFormatFactory::default(&factory);
+        assert_uses_expression_convertor(format.as_ref(), &called)
     }
 }

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -784,6 +784,7 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::atomic::Ordering;
 
+    use arrow_array::Int32Array;
     use arrow_schema::DataType;
     use arrow_schema::Field;
     use datafusion_common::ScalarValue;
@@ -800,27 +801,56 @@ mod tests {
     use crate::convert::DefaultExpressionConvertor;
     use crate::convert::ProcessedProjection;
 
-    struct RejectingExpressionConvertor {
-        inner: DefaultExpressionConvertor,
-        called: Arc<AtomicBool>,
+    #[derive(Clone, Copy)]
+    enum PushdownMode {
+        Reject,
+        Delegate,
     }
 
-    impl RejectingExpressionConvertor {
-        fn new(session: VortexSession, called: Arc<AtomicBool>) -> Self {
+    #[derive(Default)]
+    struct ExpressionConvertorCalls {
+        can_be_pushed_down: AtomicBool,
+        convert: AtomicBool,
+    }
+
+    impl ExpressionConvertorCalls {
+        fn reset(&self) {
+            self.can_be_pushed_down.store(false, Ordering::Relaxed);
+            self.convert.store(false, Ordering::Relaxed);
+        }
+    }
+
+    struct TestExpressionConvertor {
+        inner: DefaultExpressionConvertor,
+        pushdown_mode: PushdownMode,
+        calls: Arc<ExpressionConvertorCalls>,
+    }
+
+    impl TestExpressionConvertor {
+        fn new(
+            session: VortexSession,
+            pushdown_mode: PushdownMode,
+            calls: Arc<ExpressionConvertorCalls>,
+        ) -> Self {
             Self {
                 inner: DefaultExpressionConvertor::new(session),
-                called,
+                pushdown_mode,
+                calls,
             }
         }
     }
 
-    impl ExpressionConvertor for RejectingExpressionConvertor {
-        fn can_be_pushed_down(&self, _expr: &Arc<dyn PhysicalExpr>, _schema: &Schema) -> bool {
-            self.called.store(true, Ordering::Relaxed);
-            false
+    impl ExpressionConvertor for TestExpressionConvertor {
+        fn can_be_pushed_down(&self, expr: &Arc<dyn PhysicalExpr>, schema: &Schema) -> bool {
+            self.calls.can_be_pushed_down.store(true, Ordering::Relaxed);
+            match self.pushdown_mode {
+                PushdownMode::Reject => false,
+                PushdownMode::Delegate => self.inner.can_be_pushed_down(expr, schema),
+            }
         }
 
         fn convert(&self, expr: &dyn PhysicalExpr) -> DFResult<Expression> {
+            self.calls.convert.store(true, Ordering::Relaxed);
             self.inner.convert(expr)
         }
 
@@ -846,9 +876,9 @@ mod tests {
         Arc::new(df_expr::BinaryExpr::new(column, Operator::Gt, literal))
     }
 
-    fn assert_uses_expression_convertor(
+    fn assert_rejects_pushdown_with_expression_convertor(
         format: &dyn FileFormat,
-        called: &AtomicBool,
+        calls: &ExpressionConvertorCalls,
     ) -> anyhow::Result<()> {
         let source = format.file_source(TableSchema::from_file_schema(
             expression_convertor_test_schema(),
@@ -858,7 +888,8 @@ mod tests {
             &ConfigOptions::new(),
         )?;
 
-        assert!(called.load(Ordering::Relaxed));
+        assert!(calls.can_be_pushed_down.load(Ordering::Relaxed));
+        assert!(!calls.convert.load(Ordering::Relaxed));
         assert!(matches!(result.filters.as_slice(), [PushedDown::No]));
         Ok(())
     }
@@ -937,31 +968,79 @@ mod tests {
     #[test]
     fn format_plumbs_expression_convertor() -> anyhow::Result<()> {
         let session = VortexSession::default();
-        let called = Arc::new(AtomicBool::new(false));
-        let convertor = Arc::new(RejectingExpressionConvertor::new(
+        let calls = Arc::new(ExpressionConvertorCalls::default());
+        let convertor = Arc::new(TestExpressionConvertor::new(
             session.clone(),
-            Arc::clone(&called),
+            PushdownMode::Reject,
+            Arc::clone(&calls),
         ));
         let format = VortexFormat::new(session).with_expression_convertor(convertor);
 
-        assert_uses_expression_convertor(&format, &called)
+        assert_rejects_pushdown_with_expression_convertor(&format, &calls)
     }
 
     #[test]
     fn factory_plumbs_expression_convertor() -> anyhow::Result<()> {
-        let called = Arc::new(AtomicBool::new(false));
-        let convertor = Arc::new(RejectingExpressionConvertor::new(
+        let calls = Arc::new(ExpressionConvertorCalls::default());
+        let convertor = Arc::new(TestExpressionConvertor::new(
             VortexSession::default(),
-            Arc::clone(&called),
+            PushdownMode::Reject,
+            Arc::clone(&calls),
         ));
         let factory = VortexFormatFactory::new().with_expression_convertor(convertor);
         let ctx = TestSessionContext::default();
 
         let format = factory.create(&ctx.session.state(), &Default::default())?;
-        assert_uses_expression_convertor(format.as_ref(), &called)?;
+        assert_rejects_pushdown_with_expression_convertor(format.as_ref(), &calls)?;
 
-        called.store(false, Ordering::Relaxed);
+        calls.reset();
         let format = FileFormatFactory::default(&factory);
-        assert_uses_expression_convertor(format.as_ref(), &called)
+        assert_rejects_pushdown_with_expression_convertor(format.as_ref(), &calls)
+    }
+
+    #[tokio::test]
+    async fn external_table_query_uses_factory_expression_convertor() -> anyhow::Result<()> {
+        let calls = Arc::new(ExpressionConvertorCalls::default());
+        let convertor = Arc::new(TestExpressionConvertor::new(
+            VortexSession::default(),
+            PushdownMode::Delegate,
+            Arc::clone(&calls),
+        ));
+        let factory = Arc::new(VortexFormatFactory::new().with_expression_convertor(convertor));
+        let ctx = TestSessionContext::new_with_factory(factory);
+
+        ctx.session
+            .sql(
+                "CREATE EXTERNAL TABLE numbers (a INT NOT NULL) \
+                 STORED AS vortex LOCATION '/expression-convertor/'",
+            )
+            .await?;
+        ctx.session
+            .sql("INSERT INTO numbers VALUES (1), (2), (3)")
+            .await?
+            .collect()
+            .await?;
+
+        calls.reset();
+        let batches = ctx
+            .session
+            .sql("SELECT a FROM numbers WHERE a > 1 ORDER BY a")
+            .await?
+            .collect()
+            .await?;
+
+        assert!(calls.can_be_pushed_down.load(Ordering::Relaxed));
+        assert!(calls.convert.load(Ordering::Relaxed));
+        let mut values = Vec::new();
+        for batch in batches {
+            let array = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .ok_or_else(|| anyhow::anyhow!("expected Int32 result column"))?;
+            values.extend(array.values().iter().copied());
+        }
+        assert_eq!(values, vec![2, 3]);
+        Ok(())
     }
 }


### PR DESCRIPTION
## Rationale for this change

<!--
Why are you proposing this change, and what is its impact?
Is it part of a long term effort, or a bigger change?

If this PR is related to a tracked effort or an open issue, please link to the relevant issue.
-->

`VortexSource::with_expression_convertor` already allows swapping in a custom `ExpressionConvertor`, but there was no way to configure one when the source is created through `VortexFormat` / `VortexFormatFactory` — the path used by `ListingTable` and `CREATE EXTERNAL TABLE`. Engine integrations that need a custom expression conversion or pushdown strategy could not use it through those entry points.

This PR plumbs an optional `ExpressionConvertor` through `VortexFormatFactory` and `VortexFormat` so that every `VortexSource` they create picks it up. This makes the workaround suggested in #8763 (rejecting unsupported pushdowns via a custom convertor) usable from the `ListingTable` path, where the source is created by the format rather than constructed directly.

- Related to: #8763

## What changes are included in this PR?

<!--
No need to duplicate information from the previous section, but if you're touching many
parts of the code base, it's worth explicitly noting the important changes or how they are tested.
-->

- `VortexFormatFactory::with_expression_convertor` and `VortexFormat::with_expression_convertor` builder methods; the convertor is forwarded through `FileFormatFactory::create` / `default()` and `FileFormat::file_source` into the `VortexSource`.
- Re-export `ProcessedProjection` from `vortex_datafusion::convert`. The `ExpressionConvertor` trait was already public, but `split_projection` returned a type that downstream crates could not name. The trait documentation now includes a compiling downstream implementation example.
- Manual `Debug` impls for `VortexFormat` / `VortexFormatFactory` that report whether a custom convertor is set (the trait object itself is not `Debug`).

## How was this tested?

- Unit tests cover `VortexFormat` directly and both `VortexFormatFactory` entry points (`create` and `default`). A rejecting test convertor verifies that `can_be_pushed_down` is consulted, the filter is reported as `PushedDown::No`, and `convert` is not called for rejected filters.
- An end-to-end `CREATE EXTERNAL TABLE` test registers a factory with a custom convertor, inserts data, executes a filtered query, verifies both `can_be_pushed_down` and `convert` are called, and validates the result.
- A compiling doctest implements `ExpressionConvertor` through the public `vortex_datafusion::convert` API, proving downstream crates can name `ProcessedProjection`.

Validation:

- `cargo nextest run -p vortex-datafusion`
- `cargo test --doc -p vortex-datafusion`
- `cargo clippy -p vortex-datafusion --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`

## What APIs are changed? Are there any user-facing changes?

<!--
Are there any user-facing changes that might require documentation updates?
Is any public API changed?
-->

- New public methods: `VortexFormatFactory::with_expression_convertor`, `VortexFormat::with_expression_convertor`.
- Newly re-exported: `vortex_datafusion::convert::ProcessedProjection`.
- No behavior change for existing users: without a configured convertor, sources keep using `DefaultExpressionConvertor` as before.

---

*This PR was developed with AI assistance; all changes were reviewed by the haohuaijin.*