### PR TITLE
fix(ipc): bound the sizes MessageDecoder asks callers to allocate

### DIFF
--- a/vortex-ipc/src/messages/decoder.rs
+++ b/vortex-ipc/src/messages/decoder.rs
@@ -30,6 +30,58 @@ pub enum DecoderMessage {
     DType(FlatBuffer),
 }
 
+/// Upper bounds on the sizes an IPC message is allowed to declare.
+///
+/// A message declares the length of its flatbuffer header and of its body before either has been
+/// received. Callers of [`MessageDecoder::read_next`] are expected to allocate a buffer of the
+/// size reported by [`PollRead::NeedMore`], so an unbounded declared size lets a few bytes of
+/// input request an arbitrarily large allocation. The decoder rejects a message whose declared
+/// sizes exceed these limits before reporting `NeedMore`, so no caller ever allocates on behalf
+/// of an oversized declaration.
+///
+/// The defaults are far above any message Vortex writes; raise them only when a producer is
+/// known to emit larger messages, and prefer [`Self::UNLIMITED`] only for trusted local input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MessageLimits {
+    /// The largest flatbuffer header, in bytes, that a message may declare.
+    pub max_header_size: usize,
+    /// The largest body, in bytes, that a message may declare.
+    pub max_body_size: usize,
+}
+
+impl MessageLimits {
+    /// The default header limit: 16 MiB.
+    ///
+    /// A header holds only flatbuffer-encoded metadata (the encoding ids, row count, and dtype),
+    /// which stays in the kilobytes even for very wide schemas.
+    pub const DEFAULT_MAX_HEADER_SIZE: usize = 16 << 20;
+
+    /// The default body limit: 1 GiB.
+    ///
+    /// A body holds the serialized buffers of a single array message. Writers chunk their output
+    /// well below this, so the limit only rejects declarations that could not have come from a
+    /// well-formed stream.
+    pub const DEFAULT_MAX_BODY_SIZE: usize = 1 << 30;
+
+    /// Limits that permit any size representable by the format.
+    ///
+    /// Only use this when the byte stream is trusted: it restores the behaviour where a malformed
+    /// message can request an arbitrarily large allocation.
+    pub const UNLIMITED: Self = Self {
+        max_header_size: usize::MAX,
+        max_body_size: usize::MAX,
+    };
+}
+
+impl Default for MessageLimits {
+    fn default() -> Self {
+        Self {
+            max_header_size: Self::DEFAULT_MAX_HEADER_SIZE,
+            max_body_size: Self::DEFAULT_MAX_BODY_SIZE,
+        }
+    }
+}
+
 #[derive(Default)]
 enum State {
     #[default]
@@ -67,9 +119,24 @@ pub enum PollRead {
 pub struct MessageDecoder {
     /// The current state of the decoder.
     state: State,
+    /// Bounds on the sizes a message may declare.
+    limits: MessageLimits,
 }
 
 impl MessageDecoder {
+    /// Create a decoder that enforces the given [`MessageLimits`].
+    pub fn new(limits: MessageLimits) -> Self {
+        Self {
+            state: State::default(),
+            limits,
+        }
+    }
+
+    /// The size limits this decoder enforces.
+    pub fn limits(&self) -> MessageLimits {
+        self.limits
+    }
+
     /// Attempt to read the next message from the bytes object.
     ///
     /// If the message is incomplete, the function will return `NeedMore` with the _total_ number
@@ -83,8 +150,16 @@ impl MessageDecoder {
                         return Ok(PollRead::NeedMore(4));
                     }
 
-                    let msg_length = bytes.get_u32_le();
-                    self.state = State::Header(msg_length as usize);
+                    let msg_length = bytes.get_u32_le() as usize;
+                    // Checked before `NeedMore` so that a caller sizing its buffer from the
+                    // reported value never allocates for an oversized declaration.
+                    if msg_length > self.limits.max_header_size {
+                        vortex_bail!(
+                            "IPC message header size {msg_length} exceeds the limit of {} bytes",
+                            self.limits.max_header_size
+                        );
+                    }
+                    self.state = State::Header(msg_length);
                 }
                 State::Header(msg_length) => {
                     if bytes.remaining() < *msg_length {
@@ -107,6 +182,14 @@ impl MessageDecoder {
                     let body_length = usize::try_from(msg.body_size()).map_err(|_| {
                         vortex_err!("body size {} is too large for usize", msg.body_size())
                     })?;
+                    // As above: reject an oversized declaration before a caller sizes its buffer
+                    // from the `NeedMore` below.
+                    if body_length > self.limits.max_body_size {
+                        vortex_bail!(
+                            "IPC message body size {body_length} exceeds the limit of {} bytes",
+                            self.limits.max_body_size
+                        );
+                    }
                     if bytes.remaining() < body_length {
                         return Ok(PollRead::NeedMore(body_length));
                     }
@@ -215,5 +298,97 @@ mod test {
         let array = ConstantArray::new(10i32, 20);
         assert_eq!(array.nbuffers(), 1, "Array should have a single buffer");
         write_and_read(&array.into_array());
+    }
+
+    /// Build a `BufferMessage` header declaring `body_size` bytes, prefixed by its length.
+    ///
+    /// The body itself is omitted: the point is that the decoder must reject the declaration
+    /// before any caller sizes a buffer from it.
+    fn message_declaring_body(body_size: u64) -> BytesMut {
+        let mut fbb = flatbuffers::FlatBufferBuilder::new();
+        let header = fb::BufferMessage::create(
+            &mut fbb,
+            &fb::BufferMessageArgs {
+                alignment_exponent: 0,
+            },
+        )
+        .as_union_value();
+
+        let mut msg = fb::MessageBuilder::new(&mut fbb);
+        msg.add_version(Default::default());
+        msg.add_header_type(MessageHeader::BufferMessage);
+        msg.add_header(header);
+        msg.add_body_size(body_size);
+        let msg = msg.finish();
+        fbb.finish_minimal(msg);
+
+        let header_bytes = fbb.finished_data();
+        let mut out = BytesMut::new();
+        out.extend_from_slice(&u32::try_from(header_bytes.len()).unwrap().to_le_bytes());
+        out.extend_from_slice(header_bytes);
+        out
+    }
+
+    #[test]
+    fn rejects_oversized_declared_header() {
+        // Four bytes of input claiming a ~4 GiB header.
+        let mut buffer = BytesMut::from(&u32::MAX.to_le_bytes()[..]);
+
+        let err = MessageDecoder::default()
+            .read_next(&mut buffer)
+            .expect_err("an oversized header declaration must be rejected");
+        assert!(
+            err.to_string().contains("exceeds the limit"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_oversized_declared_body() {
+        // A well-formed header declaring a 256 TiB body, with none of it present.
+        let mut buffer = message_declaring_body(1 << 48);
+
+        let err = MessageDecoder::default()
+            .read_next(&mut buffer)
+            .expect_err("an oversized body declaration must be rejected");
+        assert!(
+            err.to_string().contains("exceeds the limit"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn body_within_limit_asks_for_more_bytes() {
+        // A body under the limit still round-trips through `NeedMore`, so the check rejects only
+        // oversized declarations rather than short-circuiting the normal incomplete-read path.
+        let mut buffer = message_declaring_body(4096);
+
+        match MessageDecoder::default().read_next(&mut buffer).unwrap() {
+            PollRead::NeedMore(n) => assert_eq!(n, 4096),
+            otherwise => vortex_panic!("Expected NeedMore, got {:?}", otherwise),
+        }
+    }
+
+    #[test]
+    fn limits_are_configurable() {
+        let limits = MessageLimits {
+            max_body_size: 128,
+            ..MessageLimits::default()
+        };
+
+        let mut buffer = message_declaring_body(4096);
+        assert!(
+            MessageDecoder::new(limits).read_next(&mut buffer).is_err(),
+            "a body above the configured limit must be rejected"
+        );
+
+        let mut buffer = message_declaring_body(4096);
+        match MessageDecoder::new(MessageLimits::UNLIMITED)
+            .read_next(&mut buffer)
+            .unwrap()
+        {
+            PollRead::NeedMore(n) => assert_eq!(n, 4096),
+            otherwise => vortex_panic!("Expected NeedMore, got {:?}", otherwise),
+        }
     }
 }

--- a/vortex-ipc/src/messages/reader_async.rs
+++ b/vortex-ipc/src/messages/reader_async.rs
@@ -15,6 +15,7 @@ use vortex_error::vortex_err;
 
 use crate::messages::DecoderMessage;
 use crate::messages::MessageDecoder;
+use crate::messages::MessageLimits;
 use crate::messages::PollRead;
 
 pin_project! {
@@ -30,10 +31,15 @@ pin_project! {
 
 impl<R> AsyncMessageReader<R> {
     pub fn new(read: R) -> Self {
+        Self::with_limits(read, MessageLimits::default())
+    }
+
+    /// Create a reader that enforces the given [`MessageLimits`] on the incoming stream.
+    pub fn with_limits(read: R, limits: MessageLimits) -> Self {
         AsyncMessageReader {
             read,
             buffer: BytesMut::new(),
-            decoder: MessageDecoder::default(),
+            decoder: MessageDecoder::new(limits),
             state: ReadState::default(),
         }
     }

--- a/vortex-ipc/src/messages/reader_buf.rs
+++ b/vortex-ipc/src/messages/reader_buf.rs
@@ -7,6 +7,7 @@ use vortex_error::vortex_err;
 
 use crate::messages::DecoderMessage;
 use crate::messages::MessageDecoder;
+use crate::messages::MessageLimits;
 use crate::messages::PollRead;
 
 /// An IPC message reader backed by a `Read` stream.
@@ -17,9 +18,14 @@ pub struct BufMessageReader<B> {
 
 impl<B: Buf> BufMessageReader<B> {
     pub fn new(buffer: B) -> Self {
+        Self::with_limits(buffer, MessageLimits::default())
+    }
+
+    /// Create a reader that enforces the given [`MessageLimits`] on the buffered messages.
+    pub fn with_limits(buffer: B, limits: MessageLimits) -> Self {
         BufMessageReader {
             buffer,
-            decoder: MessageDecoder::default(),
+            decoder: MessageDecoder::new(limits),
         }
     }
 }

--- a/vortex-ipc/src/messages/reader_sync.rs
+++ b/vortex-ipc/src/messages/reader_sync.rs
@@ -8,6 +8,7 @@ use vortex_error::VortexResult;
 
 use crate::messages::DecoderMessage;
 use crate::messages::MessageDecoder;
+use crate::messages::MessageLimits;
 use crate::messages::PollRead;
 
 /// An IPC message reader backed by a `Read` stream.
@@ -19,10 +20,15 @@ pub struct SyncMessageReader<R> {
 
 impl<R: Read> SyncMessageReader<R> {
     pub fn new(read: R) -> Self {
+        Self::with_limits(read, MessageLimits::default())
+    }
+
+    /// Create a reader that enforces the given [`MessageLimits`] on the incoming stream.
+    pub fn with_limits(read: R, limits: MessageLimits) -> Self {
         SyncMessageReader {
             read,
             buffer: BytesMut::new(),
-            decoder: MessageDecoder::default(),
+            decoder: MessageDecoder::new(limits),
         }
     }
 }


### PR DESCRIPTION
## Rationale for this change

An IPC message declares the length of its flatbuffer header and of its body before either has been received, and `PollRead::NeedMore` asks the caller to size its read buffer from those declarations:

> The inner value is the **total** number of bytes the buffer should contain […] Callers should: 1. Resize the buffer to this length.

Neither declaration was bounded. `msg_length` is a `u32` read straight off the wire (`decoder.rs`, `State::Length`) and `body_size` is a `u64` from the message header (`State::Reading`), so a short frame declaring a large body made both `SyncMessageReader` and `AsyncMessageReader` resize their buffers to that length before a single body byte had arrived. Resource use was decoupled from bytes actually delivered, which matters wherever a Vortex IPC stream can be fed by something other than a Vortex writer.

The repository already has the pattern this follows: `footer/postscript.rs` checks a declared metadata count against `MAX_METADATA_SEGMENTS` before using it to size a `Vec`/`HashSet`. This applies the same shape to the IPC decoder.

## What changes are included in this PR?

- **`MessageLimits`** — a `Copy` struct with `max_header_size` / `max_body_size`, a `Default`, and an `UNLIMITED` constant.
- **Enforcement in `MessageDecoder::read_next`**, at both declaration sites, placed *before* the corresponding `NeedMore` return so no caller ever sizes a buffer from a rejected declaration.
- **Checked in the decoder, not at the `resize` call sites.** The decoder is what turns untrusted bytes into a size request, so bounding it there covers every reader — including `BufMessageReader`, which errors on `NeedMore` today, and any reader added later — rather than requiring each to remember the check.
- **`with_limits` constructors** on `SyncMessageReader`, `AsyncMessageReader`, and `BufMessageReader`.
- **Four tests** in `decoder.rs`: an oversized header declaration and an oversized body declaration are rejected; a body under the limit still returns `NeedMore` normally (so the check does not short-circuit the ordinary incomplete-read path); and the limits are configurable in both directions.

### Choice of defaults

16 MiB header / 1 GiB body. Headers carry only flatbuffer metadata — encoding ids, row count, dtype — which stays in the kilobytes even for wide schemas. Bodies carry one message's serialized array buffers, which writers chunk far below 1 GiB. Both are well clear of anything `MessageEncoder` produces, so this should reject only declarations that could not have come from a well-formed stream. Happy to move either number if you have a workload closer to the line than I'd assume.

## What APIs are changed? Are there any user-facing changes?

Additive, no breaking changes:

- New public `MessageLimits` exported from `vortex_ipc::messages`.
- New `MessageDecoder::new(limits)` and `MessageDecoder::limits()`. `MessageDecoder::default()` still exists and now carries the default limits.
- New `with_limits` constructors on the three readers; existing `new` constructors are unchanged and delegate to the defaults.

The one behavioural change: a stream declaring a header above 16 MiB or a body above 1 GiB now returns an error where it previously attempted the allocation. `MessageLimits::UNLIMITED` restores the prior behaviour for trusted local input.

## Related sites not changed here

I looked for the same shape elsewhere — a length read from the stream driving an allocation before the corresponding bytes are known to exist — and found these, all left alone to keep this reviewable:

- `encodings/zstd/src/array.rs` (~L1055) — `with_capacity_aligned` from a summed declared uncompressed size. Note the sibling path in `zstd_buffers.rs` (~L264) *does* call `validate_frame_content_size` against the real zstd frame header first, so the guarded version already exists next door.
- `encodings/pco/src/array.rs` (~L611, ~L630) — `with_capacity` / `reserve` from metadata value counts.
- `encodings/fsst/src/canonical.rs` (~L56) — capacity from the summed `uncompressed_lengths` child.

Two adjacent things I noticed and did not touch:

- `zstd` and `pco` both `set_len` before filling and then hand out `&mut [T]` over the uninitialised tail. The FSST path already does this correctly with `spare_capacity_mut`.
- `SyncMessageReader::next` resizes to `nbytes` and then calls `Read::read` once, which may fill only part of the buffer — but the next `read_next` sees `remaining() == nbytes` and decodes the zero-padded tail as if it were data. `AsyncMessageReader` handles this properly with its `Filling` state. This looks like a real partial-read bug for non-file readers, separate from this change; happy to open an issue or fold in a fix if you'd prefer.

## Checks

- `cargo test -p vortex-ipc` — 10 passed, including the 4 new tests and the existing round-trip / chunked / single-byte-chunk partial-read tests.
- `cargo clippy -p vortex-ipc --all-targets --all-features` — clean.
- `cargo +nightly fmt` — applied.

Not run: workspace-wide build/clippy/tests. The change is confined to `vortex-ipc` and is additive, but the new public type is exported, so a wider check before merge is worthwhile.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJ6EcH13SxeEs2gfqybVd8)_