### PR TITLE
Use RowIdxLayoutReader only when #row_idx is referenced

### DIFF
--- a/vortex-array/src/expr/expression.rs
+++ b/vortex-array/src/expr/expression.rs
@@ -16,7 +16,10 @@ use vortex_session::VortexSession;
 
 use crate::dtype::DType;
 use crate::expr::display::DisplayTreeExpr;
+use crate::expr::traversal::TraversalOrder;
+use crate::expr::traversal::pre_order_visit_down;
 use crate::scalar_fn::ScalarFnRef;
+use crate::scalar_fn::ScalarFnVTable;
 use crate::scalar_fn::fns::root::Root;
 use crate::stats::rewrite::StatsRewriteCtx;
 
@@ -203,6 +206,30 @@ impl Expression {
     /// ```
     pub fn display_tree(&self) -> impl Display {
         DisplayTreeExpr(self)
+    }
+
+    /// Returns true if this expression contains expression E inside.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use vortex_array::scalar_fn::fns::literal::Literal;
+    /// # use vortex_array::expr::{eq, lit, root};
+    /// let expression = &eq(root(), lit(3u64));
+    /// assert!(expression.contains::<Literal>().unwrap());
+    /// let expression = root();
+    /// assert!(!expression.contains::<Literal>().unwrap());
+    /// ```
+    pub fn contains<E: ScalarFnVTable>(&self) -> VortexResult<bool> {
+        let mut contains = false;
+        pre_order_visit_down(self, |node| {
+            if node.is::<E>() {
+                contains = true;
+                return Ok(TraversalOrder::Stop);
+            }
+            Ok(TraversalOrder::Continue)
+        })?;
+        Ok(contains)
     }
 }
 

--- a/vortex-array/src/expr/mod.rs
+++ b/vortex-array/src/expr/mod.rs
@@ -156,6 +156,10 @@ mod tests {
     use std::collections::hash_map::RandomState;
     use std::hash::BuildHasher;
 
+    use vortex_array::expr::eq;
+    use vortex_array::expr::lit;
+    use vortex_array::expr::root;
+
     use super::*;
     use crate::dtype::DType;
     use crate::dtype::FieldNames;
@@ -164,20 +168,18 @@ mod tests {
     use crate::dtype::StructFields;
     use crate::expr::and;
     use crate::expr::col;
-    use crate::expr::eq;
     use crate::expr::get_item;
     use crate::expr::gt;
     use crate::expr::gt_eq;
-    use crate::expr::lit;
     use crate::expr::lt;
     use crate::expr::lt_eq;
     use crate::expr::not;
     use crate::expr::not_eq;
     use crate::expr::or;
-    use crate::expr::root;
     use crate::expr::select;
     use crate::expr::select_exclude;
     use crate::scalar::Scalar;
+    use crate::scalar_fn::fns::literal::Literal;
 
     #[test]
     fn basic_expr_split_test() {
@@ -310,5 +312,13 @@ mod tests {
             .to_string(),
             "{dog: 32u32, cat: \"rufus\"}"
         );
+    }
+
+    #[test]
+    fn expr_contains() {
+        let expression = &eq(root(), lit(3u64));
+        assert!(expression.contains::<Literal>().unwrap());
+        let expression = root();
+        assert!(!expression.contains::<Literal>().unwrap());
     }
 }

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -39,6 +39,7 @@ use vortex_utils::parallelism::get_available_parallelism;
 
 use crate::LayoutReader;
 use crate::LayoutReaderRef;
+use crate::layouts::row_idx::RowIdx;
 use crate::layouts::row_idx::RowIdxLayoutReader;
 use crate::scan::repeated_scan::RepeatedScan;
 use crate::scan::split_by::SplitBy;
@@ -273,14 +274,18 @@ impl<A: 'static + Send> ScanBuilder<A> {
         // conjunction splitting if a filter is provided.
         let mut layout_reader = self.layout_reader;
 
-        // Enrich the layout reader to support RowIdx expressions.
+        // Enrich the layout reader to support RowIdx expressions if scan uses #row_idx.
         // Note that this is applied below the filter layout reader since it can perform
         // better over individual conjunctions.
-        layout_reader = Arc::new(RowIdxLayoutReader::new(
-            self.row_offset,
-            layout_reader,
-            self.session.clone(),
-        ));
+        if references_row_idx(&self.projection)
+            || self.filter.as_ref().is_some_and(references_row_idx)
+        {
+            layout_reader = Arc::new(RowIdxLayoutReader::new(
+                self.row_offset,
+                layout_reader,
+                self.session.clone(),
+            ));
+        }
 
         // Normalize and simplify the expressions.
         let projection = self.projection.optimize_recursive(layout_reader.dtype())?;
@@ -431,6 +436,10 @@ impl<A: 'static + Send> Stream for LazyScanStream<A> {
     }
 }
 
+fn references_row_idx(expr: &Expression) -> bool {
+    expr.is::<RowIdx>() || expr.children().iter().any(references_row_idx)
+}
+
 /// Compute masks of field paths referenced by the projection and filter in the scan.
 ///
 /// Projection and filter must be pre-simplified.
@@ -494,6 +503,7 @@ mod test {
     use crate::LayoutReader;
     use crate::RowSplits;
     use crate::SplitRange;
+    use crate::layouts::row_idx::row_idx;
     use crate::scan::test::SCAN_SESSION;
     use crate::scan::test::session_with_handle;
 
@@ -895,5 +905,11 @@ mod test {
         assert_eq!(values.as_ref(), [1, 2]);
 
         Ok(())
+    }
+
+    #[test]
+    fn references_row_idx() {
+        assert!(super::references_row_idx(&eq(row_idx(), lit(3u64))));
+        assert!(!super::references_row_idx(&eq(root(), lit(1i32))));
     }
 }

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -19,6 +19,8 @@ use vortex_array::dtype::FieldMask;
 use vortex_array::expr::Expression;
 use vortex_array::expr::analysis::referenced_field_paths;
 use vortex_array::expr::root;
+use vortex_array::expr::traversal::TraversalOrder;
+use vortex_array::expr::traversal::pre_order_visit_down;
 use vortex_array::iter::ArrayIterator;
 use vortex_array::iter::ArrayIteratorAdapter;
 use vortex_array::stats::StatsSet;
@@ -274,12 +276,27 @@ impl<A: 'static + Send> ScanBuilder<A> {
         // conjunction splitting if a filter is provided.
         let mut layout_reader = self.layout_reader;
 
+        let mut found_row_idx = false;
+        pre_order_visit_down(&self.projection, |node| {
+            if node.is::<RowIdx>() {
+                found_row_idx = true;
+                return Ok(TraversalOrder::Stop);
+            }
+            Ok(TraversalOrder::Continue)
+        })?;
+        if !found_row_idx && let Some(filter) = self.filter.as_ref() {
+            pre_order_visit_down(filter, |node| {
+                if node.is::<RowIdx>() {
+                    found_row_idx = true;
+                    return Ok(TraversalOrder::Stop);
+                }
+                Ok(TraversalOrder::Continue)
+            })?;
+        }
         // Enrich the layout reader to support RowIdx expressions if scan uses #row_idx.
         // Note that this is applied below the filter layout reader since it can perform
         // better over individual conjunctions.
-        if references_row_idx(&self.projection)
-            || self.filter.as_ref().is_some_and(references_row_idx)
-        {
+        if found_row_idx {
             layout_reader = Arc::new(RowIdxLayoutReader::new(
                 self.row_offset,
                 layout_reader,
@@ -436,10 +453,6 @@ impl<A: 'static + Send> Stream for LazyScanStream<A> {
     }
 }
 
-fn references_row_idx(expr: &Expression) -> bool {
-    expr.is::<RowIdx>() || expr.children().iter().any(references_row_idx)
-}
-
 /// Compute masks of field paths referenced by the projection and filter in the scan.
 ///
 /// Projection and filter must be pre-simplified.
@@ -503,7 +516,6 @@ mod test {
     use crate::LayoutReader;
     use crate::RowSplits;
     use crate::SplitRange;
-    use crate::layouts::row_idx::row_idx;
     use crate::scan::test::SCAN_SESSION;
     use crate::scan::test::session_with_handle;
 
@@ -905,11 +917,5 @@ mod test {
         assert_eq!(values.as_ref(), [1, 2]);
 
         Ok(())
-    }
-
-    #[test]
-    fn references_row_idx() {
-        assert!(super::references_row_idx(&eq(row_idx(), lit(3u64))));
-        assert!(!super::references_row_idx(&eq(root(), lit(1i32))));
     }
 }

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -19,8 +19,6 @@ use vortex_array::dtype::FieldMask;
 use vortex_array::expr::Expression;
 use vortex_array::expr::analysis::referenced_field_paths;
 use vortex_array::expr::root;
-use vortex_array::expr::traversal::TraversalOrder;
-use vortex_array::expr::traversal::pre_order_visit_down;
 use vortex_array::iter::ArrayIterator;
 use vortex_array::iter::ArrayIteratorAdapter;
 use vortex_array::stats::StatsSet;
@@ -276,26 +274,13 @@ impl<A: 'static + Send> ScanBuilder<A> {
         // conjunction splitting if a filter is provided.
         let mut layout_reader = self.layout_reader;
 
-        let mut found_row_idx = false;
-        pre_order_visit_down(&self.projection, |node| {
-            if node.is::<RowIdx>() {
-                found_row_idx = true;
-                return Ok(TraversalOrder::Stop);
-            }
-            Ok(TraversalOrder::Continue)
-        })?;
-        if !found_row_idx && let Some(filter) = self.filter.as_ref() {
-            pre_order_visit_down(filter, |node| {
-                if node.is::<RowIdx>() {
-                    found_row_idx = true;
-                    return Ok(TraversalOrder::Stop);
-                }
-                Ok(TraversalOrder::Continue)
-            })?;
-        }
         // Enrich the layout reader to support RowIdx expressions if scan uses #row_idx.
         // Note that this is applied below the filter layout reader since it can perform
         // better over individual conjunctions.
+        let mut found_row_idx = self.projection.contains::<RowIdx>()?;
+        if !found_row_idx && let Some(filter) = self.filter.as_ref() {
+            found_row_idx = filter.contains::<RowIdx>()?;
+        }
         if found_row_idx {
             layout_reader = Arc::new(RowIdxLayoutReader::new(
                 self.row_offset,


### PR DESCRIPTION
Currently we wrap layout readers with RowIdxLayoutReader even if it's not used.
This increases CPU usage on requests that don't use it (i.e. clickbench).
The cost of recursive expression iteration is lower than runtime of
RowIdxLayoutReader so it's a net benefit.

Add expression.contains() method which checks expression has another expression inside.
