### PR TITLE
refactor: preserve bound expression identity through scans

### DIFF
--- a/benchmarks/compress-bench/src/vortex.rs
+++ b/benchmarks/compress-bench/src/vortex.rs
@@ -18,7 +18,6 @@ use vortex::expr::root;
 use vortex::expr::select;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::file::WriteOptionsSessionExt;
-use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex_arrow::ToArrowType;
 use vortex_bench::Format;
 use vortex_bench::SESSION;
@@ -72,7 +71,9 @@ impl Compressor for VortexCompressor {
         if let Some(cols) = read_projection(root_columns) {
             // Columns are named "0".."num_columns-1"; project the given subset.
             let names: FieldNames = cols.iter().map(|i| i.to_string()).collect();
-            let projection = optimize_and_bind(select(names, root()), &source_dtype)?;
+            let projection = select(names, root())
+                .optimize_recursive(&source_dtype)?
+                .bind(&source_dtype)?;
             scan = scan.with_projection(projection);
         }
         let schema = Arc::new(scan.dtype()?.to_arrow_schema()?);

--- a/benchmarks/compress-bench/src/vortex.rs
+++ b/benchmarks/compress-bench/src/vortex.rs
@@ -18,6 +18,7 @@ use vortex::expr::root;
 use vortex::expr::select;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::file::WriteOptionsSessionExt;
+use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex_arrow::ToArrowType;
 use vortex_bench::Format;
 use vortex_bench::SESSION;
@@ -64,14 +65,15 @@ impl Compressor for VortexCompressor {
         let start = Instant::now();
         let data = Bytes::from(buf);
         let mut scan = SESSION.open_options().open_buffer(data)?.scan()?;
-        let root_columns = scan
-            .dtype()?
+        let source_dtype = scan.dtype()?;
+        let root_columns = source_dtype
             .as_struct_fields_opt()
             .map_or(0, |fields| fields.nfields());
         if let Some(cols) = read_projection(root_columns) {
             // Columns are named "0".."num_columns-1"; project the given subset.
             let names: FieldNames = cols.iter().map(|i| i.to_string()).collect();
-            scan = scan.with_projection(select(names, root()));
+            let projection = optimize_and_bind(select(names, root()), &source_dtype)?;
+            scan = scan.with_projection(projection);
         }
         let schema = Arc::new(scan.dtype()?.to_arrow_schema()?);
 

--- a/docs/developer-guide/internals/session.md
+++ b/docs/developer-guide/internals/session.md
@@ -78,7 +78,9 @@ session.write_options()
     .await?;
 
 // Scanning a layout
-let filter = optimize_and_bind(expr, layout_reader.dtype())?;
+let filter = expr
+    .optimize_recursive(layout_reader.dtype())?
+    .bind(layout_reader.dtype())?;
 ScanBuilder::new(session.clone(), layout_reader)
     .with_filter(filter)
     .into_array_stream()?;

--- a/docs/developer-guide/internals/session.md
+++ b/docs/developer-guide/internals/session.md
@@ -78,8 +78,9 @@ session.write_options()
     .await?;
 
 // Scanning a layout
+let filter = optimize_and_bind(expr, layout_reader.dtype())?;
 ScanBuilder::new(session.clone(), layout_reader)
-    .with_filter(expr)
+    .with_filter(filter)
     .into_array_stream()?;
 ```
 

--- a/fuzz/fuzz_targets/file_io.rs
+++ b/fuzz/fuzz_targets/file_io.rs
@@ -6,6 +6,7 @@
 use itertools::Itertools;
 use libfuzzer_sys::Corpus;
 use libfuzzer_sys::fuzz_target;
+use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
@@ -78,14 +79,21 @@ fuzz_target!(|fuzz: FuzzFileAction| -> Corpus {
         .write(&mut full_buff, array_data.to_array_iterator())
         .vortex_expect("file write should succeed in fuzz test");
 
-    let mut output = SESSION
+    let file = SESSION
         .open_options()
         .open_buffer(full_buff)
-        .vortex_expect("open_buffer should succeed in fuzz test")
+        .vortex_expect("open_buffer should succeed in fuzz test");
+    let projection = optimize_and_bind(projection_expr.unwrap_or_else(root), file.dtype())
+        .vortex_expect("projection should bind in fuzz test");
+    let filter = filter_expr
+        .map(|filter| optimize_and_bind(filter, file.dtype()))
+        .transpose()
+        .vortex_expect("filter should bind in fuzz test");
+    let mut output = file
         .scan()
         .vortex_expect("scan should succeed in fuzz test")
-        .with_projection(projection_expr.unwrap_or_else(root))
-        .with_some_filter(filter_expr)
+        .with_projection(projection)
+        .with_some_filter(filter)
         .into_array_iter(&*RUNTIME)
         .vortex_expect("into_array_iter should succeed in fuzz test")
         .try_collect::<_, Vec<_>, _>()

--- a/fuzz/fuzz_targets/file_io.rs
+++ b/fuzz/fuzz_targets/file_io.rs
@@ -6,7 +6,6 @@
 use itertools::Itertools;
 use libfuzzer_sys::Corpus;
 use libfuzzer_sys::fuzz_target;
-use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
@@ -83,10 +82,17 @@ fuzz_target!(|fuzz: FuzzFileAction| -> Corpus {
         .open_options()
         .open_buffer(full_buff)
         .vortex_expect("open_buffer should succeed in fuzz test");
-    let projection = optimize_and_bind(projection_expr.unwrap_or_else(root), file.dtype())
+    let projection = projection_expr
+        .unwrap_or_else(root)
+        .optimize_recursive(file.dtype())
+        .and_then(|expr| expr.bind(file.dtype()))
         .vortex_expect("projection should bind in fuzz test");
     let filter = filter_expr
-        .map(|filter| optimize_and_bind(filter, file.dtype()))
+        .map(|filter| {
+            filter
+                .optimize_recursive(file.dtype())
+                .and_then(|expr| expr.bind(file.dtype()))
+        })
         .transpose()
         .vortex_expect("filter should bind in fuzz test");
     let mut output = file

--- a/vortex-array/src/expr/bound_expression.rs
+++ b/vortex-array/src/expr/bound_expression.rs
@@ -12,13 +12,18 @@ use itertools::Itertools;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
+use vortex_session::VortexSession;
 
 use crate::dtype::DType;
 use crate::expr::Expression;
 use crate::expr::display::DisplayTreeExpr;
 use crate::expr::scope::Scope;
+use crate::expr::traversal::TraversalOrder;
+use crate::expr::traversal::pre_order_visit_down;
 use crate::scalar_fn::ScalarFnRef;
+use crate::scalar_fn::ScalarFnVTable;
 use crate::scalar_fn::fns::root::Root;
+use crate::stats::rewrite::StatsRewriteCtx;
 
 /// An [`Expression`] that has been type-checked against a [`Scope`].
 ///
@@ -171,6 +176,11 @@ impl BoundExpression {
         }
     }
 
+    /// Return the child at `index`.
+    pub fn child(&self, index: usize) -> &BoundExpression {
+        &self.children()[index]
+    }
+
     /// The scalar function for this node, or `None` if it is the scope root.
     pub fn as_scalar(&self) -> Option<&ScalarFnRef> {
         match &self.kind {
@@ -179,50 +189,57 @@ impl BoundExpression {
         }
     }
 
+    /// Return whether this node uses the given scalar-function vtable.
+    pub fn is<V: ScalarFnVTable>(&self) -> bool {
+        self.as_scalar().is_some_and(ScalarFnRef::is::<V>)
+    }
+
+    /// Return whether this expression tree contains a node using the given scalar-function vtable.
+    pub fn contains<V: ScalarFnVTable>(&self) -> VortexResult<bool> {
+        let mut contains = false;
+        pre_order_visit_down(self, |node| {
+            if node.is::<V>() {
+                contains = true;
+                return Ok(TraversalOrder::Stop);
+            }
+            Ok(TraversalOrder::Continue)
+        })?;
+        Ok(contains)
+    }
+
+    /// Return the typed scalar-function options when this node uses the given vtable.
+    pub fn as_opt<V: ScalarFnVTable>(&self) -> Option<&V::Options> {
+        self.as_scalar().and_then(ScalarFnRef::as_opt::<V>)
+    }
+
+    /// Return the typed scalar-function options for this node.
+    ///
+    /// # Panics
+    ///
+    /// Panics when this node is the scope root or uses a different scalar-function vtable.
+    pub fn as_<V: ScalarFnVTable>(&self) -> &V::Options {
+        self.as_opt::<V>()
+            .vortex_expect("Bound expression options type mismatch")
+    }
+
     /// Whether this node is the scope root.
     pub fn is_root(&self) -> bool {
         matches!(self.kind, BoundKind::Root)
     }
 
+    /// Return an expression that proves this predicate is definitely false from statistics.
+    pub fn falsify(&self, session: &VortexSession) -> VortexResult<Option<BoundExpression>> {
+        StatsRewriteCtx::new(session).falsify(self)
+    }
+
+    /// Return an expression that proves this predicate is definitely true from statistics.
+    pub fn satisfy(&self, session: &VortexSession) -> VortexResult<Option<BoundExpression>> {
+        StatsRewriteCtx::new(session).satisfy(self)
+    }
+
     /// Display the bound expression as a formatted tree structure.
     pub fn display_tree(&self) -> impl Display {
         DisplayTreeExpr(self)
-    }
-
-    /// Convert this bound tree back into its unbound logical representation.
-    ///
-    /// This rebuilds the expression iteratively; the bound representation does not retain a
-    /// second expression tree.
-    // TODO: This is temporary artifact of the migration from using `Expression`s to
-    // `BoundExpression`s
-    pub fn unbind(&self) -> Expression {
-        let mut pending = vec![(self, false)];
-        let mut expressions = Vec::new();
-
-        while let Some((node, visited)) = pending.pop() {
-            match node.kind() {
-                BoundKind::Root => expressions.push(crate::expr::root()),
-                BoundKind::Scalar {
-                    scalar_fn,
-                    children,
-                } if visited => {
-                    let child_start = expressions.len() - children.len();
-                    let child_expressions = expressions.split_off(child_start);
-                    expressions.push(
-                        Expression::try_new(scalar_fn.clone(), child_expressions)
-                            .vortex_expect("a bound expression always has valid arity"),
-                    );
-                }
-                BoundKind::Scalar { children, .. } => {
-                    pending.push((node, true));
-                    pending.extend(children.iter().rev().map(|child| (child, false)));
-                }
-            }
-        }
-
-        expressions
-            .pop()
-            .vortex_expect("binding always produces one expression root")
     }
 }
 
@@ -293,6 +310,7 @@ mod tests {
     use crate::expr::lit;
     use crate::expr::root;
     use crate::expr::test_harness::struct_dtype;
+    use crate::scalar_fn::fns::literal::Literal;
 
     fn scope() -> Scope {
         Scope::new(struct_dtype())
@@ -303,7 +321,7 @@ mod tests {
         let bound = root().bind_scope(&scope())?;
         assert!(bound.is_root());
         assert_eq!(bound.dtype(), &struct_dtype());
-        assert_eq!(bound.unbind(), root());
+        assert_eq!(bound, BoundExpression::new_root(struct_dtype()));
         Ok(())
     }
 
@@ -332,6 +350,14 @@ mod tests {
                 "disagreement for {expr}"
             );
         }
+        Ok(())
+    }
+
+    #[test]
+    fn contains_scalar_function() -> VortexResult<()> {
+        let bound = eq(col("a"), lit(1_i32)).bind_scope(&scope())?;
+        assert!(bound.contains::<Literal>()?);
+        assert!(!root().bind_scope(&scope())?.contains::<Literal>()?);
         Ok(())
     }
 
@@ -379,11 +405,7 @@ mod tests {
 
         assert_eq!(bound, independently_bound);
         assert_eq!(ExactBoundExpr(bound.clone()), ExactBoundExpr(bound.clone()));
-        assert_ne!(
-            ExactBoundExpr(bound.clone()),
-            ExactBoundExpr(independently_bound)
-        );
-        assert_eq!(bound.unbind(), expr);
+        assert_ne!(ExactBoundExpr(bound), ExactBoundExpr(independently_bound));
         Ok(())
     }
 

--- a/vortex-array/src/expr/expression.rs
+++ b/vortex-array/src/expr/expression.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 use itertools::Itertools;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
-use vortex_session::VortexSession;
 
 use crate::dtype::DType;
 use crate::expr::display::DisplayTreeExpr;
@@ -21,7 +20,6 @@ use crate::expr::traversal::pre_order_visit_down;
 use crate::scalar_fn::ScalarFnRef;
 use crate::scalar_fn::ScalarFnVTable;
 use crate::scalar_fn::fns::root::Root;
-use crate::stats::rewrite::StatsRewriteCtx;
 
 /// A node in a Vortex expression tree.
 ///
@@ -116,40 +114,12 @@ impl Expression {
         self.scalar_fn.validity(self)
     }
 
-    /// Returns an expression that proves this predicate is definitely false from stats.
-    ///
-    /// `scope` is the dtype of the row this expression evaluates over.
-    ///
-    /// If the returned expression evaluates to `true` for a stats scope, this expression is
-    /// guaranteed to be false for every row in that scope. `false` and `null` are unknown.
-    pub fn falsify(
-        &self,
-        scope: &DType,
-        session: &VortexSession,
-    ) -> VortexResult<Option<Expression>> {
-        StatsRewriteCtx::new(session, scope).falsify(self)
-    }
-
-    /// Returns an expression that proves this predicate is definitely true from stats.
-    ///
-    /// `scope` is the dtype of the row this expression evaluates over.
-    ///
-    /// If the returned expression evaluates to `true` for a stats scope, this expression is
-    /// guaranteed to be true for every row in that scope. `false` and `null` are unknown.
-    pub fn satisfy(
-        &self,
-        scope: &DType,
-        session: &VortexSession,
-    ) -> VortexResult<Option<Expression>> {
-        StatsRewriteCtx::new(session, scope).satisfy(self)
-    }
-
     /// Format the expression as a compact string.
     ///
     /// Since this is a recursive formatter, it is exposed on the public Expression type.
     /// See fmt_data that is only implemented on the vtable trait.
     pub fn fmt_sql(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        self.scalar_fn().fmt_sql(self, f)
+        self.scalar_fn.fmt_sql(self, f)
     }
 
     /// Display the expression as a formatted tree structure.

--- a/vortex-array/src/expr/exprs.rs
+++ b/vortex-array/src/expr/exprs.rs
@@ -16,6 +16,7 @@ use crate::dtype::DType;
 use crate::dtype::FieldName;
 use crate::dtype::FieldNames;
 use crate::dtype::Nullability;
+use crate::expr::BoundExpression;
 use crate::expr::Expression;
 use crate::scalar::Scalar;
 use crate::scalar::ScalarValue;
@@ -71,6 +72,11 @@ pub fn root() -> Expression {
     ROOT.clone()
 }
 
+/// Creates a bound expression that references a root scope with the given dtype.
+pub fn bound_root(dtype: DType) -> BoundExpression {
+    BoundExpression::new_root(dtype)
+}
+
 /// Return whether the expression is a root expression.
 pub fn is_root(expr: &Expression) -> bool {
     // root doesn't have any children, and scalar_fns have distinct ids
@@ -101,6 +107,13 @@ pub fn lit(value: impl Into<Scalar>) -> Expression {
     Literal.new_expr(value.into(), [])
 }
 
+/// Creates a bound literal expression.
+pub fn bound_lit(value: impl Into<Scalar>) -> BoundExpression {
+    Literal
+        .try_new_bound_expr(value.into(), [])
+        .vortex_expect("literal expressions are always well-typed")
+}
+
 // ---- GetItem / Col ----
 
 /// Creates an expression that accesses a field from the root array.
@@ -115,6 +128,11 @@ pub fn col(field: impl Into<FieldName>) -> Expression {
     GetItem.new_expr(field.into(), vec![root()])
 }
 
+/// Creates a bound expression that accesses a field from a root scope with the given dtype.
+pub fn bound_col(field: impl Into<FieldName>, scope: DType) -> BoundExpression {
+    bound_get_item(field, bound_root(scope))
+}
+
 /// Creates an expression that extracts a named field from a struct expression.
 ///
 /// Accesses the specified field from the result of the child expression.
@@ -125,6 +143,13 @@ pub fn col(field: impl Into<FieldName>) -> Expression {
 /// ```
 pub fn get_item(field: impl Into<FieldName>, child: Expression) -> Expression {
     GetItem.new_expr(field.into(), vec![child])
+}
+
+/// Creates a bound expression that extracts a named field from a struct expression.
+pub fn bound_get_item(field: impl Into<FieldName>, child: BoundExpression) -> BoundExpression {
+    GetItem
+        .try_new_bound_expr(field.into(), [child])
+        .vortex_expect("get-item expressions must reference a field in the child dtype")
 }
 
 // ---- VariantGet ----
@@ -139,6 +164,17 @@ pub fn variant_get(
     dtype: Option<DType>,
 ) -> Expression {
     VariantGet.new_expr(VariantGetOptions::new(path.into(), dtype), vec![child])
+}
+
+/// Creates a bound expression that extracts a path from a Variant expression.
+pub fn bound_variant_get(
+    child: BoundExpression,
+    path: impl Into<VariantPath>,
+    dtype: Option<DType>,
+) -> BoundExpression {
+    VariantGet
+        .try_new_bound_expr(VariantGetOptions::new(path.into(), dtype), [child])
+        .vortex_expect("variant-get expressions require a Variant child")
 }
 
 // ---- CaseWhen ----
@@ -156,6 +192,21 @@ pub fn case_when(
     CaseWhen.new_expr(options, [condition, then_value, else_value])
 }
 
+/// Creates a bound CASE WHEN expression with one WHEN/THEN pair and an ELSE value.
+pub fn bound_case_when(
+    condition: BoundExpression,
+    then_value: BoundExpression,
+    else_value: BoundExpression,
+) -> BoundExpression {
+    let options = CaseWhenOptions {
+        num_when_then_pairs: 1,
+        has_else: true,
+    };
+    CaseWhen
+        .try_new_bound_expr(options, [condition, then_value, else_value])
+        .vortex_expect("case expressions must have boolean conditions and matching branch dtypes")
+}
+
 /// Creates a CASE WHEN expression with one WHEN/THEN pair and no ELSE value.
 pub fn case_when_no_else(condition: Expression, then_value: Expression) -> Expression {
     let options = CaseWhenOptions {
@@ -163,6 +214,20 @@ pub fn case_when_no_else(condition: Expression, then_value: Expression) -> Expre
         has_else: false,
     };
     CaseWhen.new_expr(options, [condition, then_value])
+}
+
+/// Creates a bound CASE WHEN expression with one WHEN/THEN pair and no ELSE value.
+pub fn bound_case_when_no_else(
+    condition: BoundExpression,
+    then_value: BoundExpression,
+) -> BoundExpression {
+    let options = CaseWhenOptions {
+        num_when_then_pairs: 1,
+        has_else: false,
+    };
+    CaseWhen
+        .try_new_bound_expr(options, [condition, then_value])
+        .vortex_expect("case expressions must have boolean conditions")
 }
 
 /// Creates an n-ary CASE WHEN expression from WHEN/THEN pairs and an optional ELSE value.
@@ -195,7 +260,57 @@ pub fn nested_case_when(
     CaseWhen.new_expr(options, children)
 }
 
+/// Creates a bound n-ary CASE WHEN expression from WHEN/THEN pairs and an optional ELSE value.
+pub fn bound_nested_case_when(
+    when_then_pairs: Vec<(BoundExpression, BoundExpression)>,
+    else_value: Option<BoundExpression>,
+) -> BoundExpression {
+    assert!(
+        !when_then_pairs.is_empty(),
+        "nested_case_when requires at least one when/then pair"
+    );
+
+    let Ok(num_when_then_pairs) = u32::try_from(when_then_pairs.len()) else {
+        vortex_panic!("nested_case_when has too many when/then pairs");
+    };
+    let has_else = else_value.is_some();
+    let mut children = Vec::with_capacity(when_then_pairs.len() * 2 + usize::from(has_else));
+    for (condition, then_value) in when_then_pairs {
+        children.push(condition);
+        children.push(then_value);
+    }
+    if let Some(else_expr) = else_value {
+        children.push(else_expr);
+    }
+
+    let options = CaseWhenOptions {
+        num_when_then_pairs,
+        has_else,
+    };
+    CaseWhen
+        .try_new_bound_expr(options, children)
+        .vortex_expect("case expressions must have boolean conditions and matching branch dtypes")
+}
+
 // ---- Binary operators ----
+
+/// Creates a binary expression with the given operator.
+pub fn binary(operator: Operator, lhs: Expression, rhs: Expression) -> Expression {
+    Binary
+        .try_new_expr(operator, [lhs, rhs])
+        .vortex_expect("Failed to create binary expression")
+}
+
+/// Creates a bound binary expression with the given operator.
+pub fn bound_binary(
+    operator: Operator,
+    lhs: BoundExpression,
+    rhs: BoundExpression,
+) -> BoundExpression {
+    Binary
+        .try_new_bound_expr(operator, [lhs, rhs])
+        .vortex_expect("binary expressions must have compatible operand dtypes")
+}
 
 /// Create a new [`Binary`] using the [`Eq`](Operator::Eq) operator.
 ///
@@ -222,6 +337,11 @@ pub fn eq(lhs: Expression, rhs: Expression) -> Expression {
     Binary
         .try_new_expr(Operator::Eq, [lhs, rhs])
         .vortex_expect("Failed to create Eq binary expression")
+}
+
+/// Creates a bound equality expression.
+pub fn bound_eq(lhs: BoundExpression, rhs: BoundExpression) -> BoundExpression {
+    bound_binary(Operator::Eq, lhs, rhs)
 }
 
 /// Create a new [`Binary`] using the [`NotEq`](Operator::NotEq) operator.
@@ -251,6 +371,11 @@ pub fn not_eq(lhs: Expression, rhs: Expression) -> Expression {
         .vortex_expect("Failed to create NotEq binary expression")
 }
 
+/// Creates a bound inequality expression.
+pub fn bound_not_eq(lhs: BoundExpression, rhs: BoundExpression) -> BoundExpression {
+    bound_binary(Operator::NotEq, lhs, rhs)
+}
+
 /// Create a new [`Binary`] using the [`Gte`](Operator::Gte) operator.
 ///
 /// ## Example usage
@@ -276,6 +401,11 @@ pub fn gt_eq(lhs: Expression, rhs: Expression) -> Expression {
     Binary
         .try_new_expr(Operator::Gte, [lhs, rhs])
         .vortex_expect("Failed to create Gte binary expression")
+}
+
+/// Creates a bound greater-than-or-equal expression.
+pub fn bound_gt_eq(lhs: BoundExpression, rhs: BoundExpression) -> BoundExpression {
+    bound_binary(Operator::Gte, lhs, rhs)
 }
 
 /// Create a new [`Binary`] using the [`Gt`](Operator::Gt) operator.
@@ -305,6 +435,11 @@ pub fn gt(lhs: Expression, rhs: Expression) -> Expression {
         .vortex_expect("Failed to create Gt binary expression")
 }
 
+/// Creates a bound greater-than expression.
+pub fn bound_gt(lhs: BoundExpression, rhs: BoundExpression) -> BoundExpression {
+    bound_binary(Operator::Gt, lhs, rhs)
+}
+
 /// Create a new [`Binary`] using the [`Lte`](Operator::Lte) operator.
 ///
 /// ## Example usage
@@ -330,6 +465,11 @@ pub fn lt_eq(lhs: Expression, rhs: Expression) -> Expression {
     Binary
         .try_new_expr(Operator::Lte, [lhs, rhs])
         .vortex_expect("Failed to create Lte binary expression")
+}
+
+/// Creates a bound less-than-or-equal expression.
+pub fn bound_lt_eq(lhs: BoundExpression, rhs: BoundExpression) -> BoundExpression {
+    bound_binary(Operator::Lte, lhs, rhs)
 }
 
 /// Create a new [`Binary`] using the [`Lt`](Operator::Lt) operator.
@@ -359,6 +499,11 @@ pub fn lt(lhs: Expression, rhs: Expression) -> Expression {
         .vortex_expect("Failed to create Lt binary expression")
 }
 
+/// Creates a bound less-than expression.
+pub fn bound_lt(lhs: BoundExpression, rhs: BoundExpression) -> BoundExpression {
+    bound_binary(Operator::Lt, lhs, rhs)
+}
+
 /// Create a new [`Binary`] using the [`Or`](Operator::Or) operator.
 ///
 /// ## Example usage
@@ -384,6 +529,11 @@ pub fn or(lhs: Expression, rhs: Expression) -> Expression {
         .vortex_expect("Failed to create Or binary expression")
 }
 
+/// Creates a bound boolean OR expression.
+pub fn bound_or(lhs: BoundExpression, rhs: BoundExpression) -> BoundExpression {
+    bound_binary(Operator::Or, lhs, rhs)
+}
+
 /// Collects a list of `or`ed values into a single expression using a balanced tree.
 ///
 /// This creates a balanced binary tree to avoid deep nesting that could cause
@@ -395,6 +545,14 @@ where
     I: IntoIterator<Item = Expression>,
 {
     iter.into_iter().reduce_balanced(or)
+}
+
+/// Collects bound expressions into a balanced tree of boolean OR expressions.
+pub fn bound_or_collect<I>(iter: I) -> Option<BoundExpression>
+where
+    I: IntoIterator<Item = BoundExpression>,
+{
+    iter.into_iter().reduce_balanced(bound_or)
 }
 
 /// Create a new [`Binary`] using the [`And`](Operator::And) operator.
@@ -422,6 +580,11 @@ pub fn and(lhs: Expression, rhs: Expression) -> Expression {
         .vortex_expect("Failed to create And binary expression")
 }
 
+/// Creates a bound boolean AND expression.
+pub fn bound_and(lhs: BoundExpression, rhs: BoundExpression) -> BoundExpression {
+    bound_binary(Operator::And, lhs, rhs)
+}
+
 /// Collects a list of `and`ed values into a single expression using a balanced tree.
 ///
 /// This creates a balanced binary tree to avoid deep nesting that could cause
@@ -433,6 +596,14 @@ where
     I: IntoIterator<Item = Expression>,
 {
     iter.into_iter().reduce_balanced(and)
+}
+
+/// Collects bound expressions into a balanced tree of boolean AND expressions.
+pub fn bound_and_collect<I>(iter: I) -> Option<BoundExpression>
+where
+    I: IntoIterator<Item = BoundExpression>,
+{
+    iter.into_iter().reduce_balanced(bound_and)
 }
 
 /// The conjunction of an expression's child validities — i.e. the validity of a scalar function
@@ -475,6 +646,11 @@ pub fn checked_add(lhs: Expression, rhs: Expression) -> Expression {
         .vortex_expect("Failed to create Add binary expression")
 }
 
+/// Creates a bound checked-add expression.
+pub fn bound_checked_add(lhs: BoundExpression, rhs: BoundExpression) -> BoundExpression {
+    bound_binary(Operator::Add, lhs, rhs)
+}
+
 // ---- Not ----
 
 /// Creates an expression that logically inverts boolean values.
@@ -487,6 +663,12 @@ pub fn checked_add(lhs: Expression, rhs: Expression) -> Expression {
 /// ```
 pub fn not(operand: Expression) -> Expression {
     Not.new_expr(EmptyOptions, vec![operand])
+}
+
+/// Creates a bound expression that logically inverts boolean values.
+pub fn bound_not(operand: BoundExpression) -> BoundExpression {
+    Not.try_new_bound_expr(EmptyOptions, [operand])
+        .vortex_expect("not expressions require a boolean operand")
 }
 
 // ---- Between ----
@@ -517,6 +699,18 @@ pub fn between(
         .vortex_expect("Failed to create Between expression")
 }
 
+/// Creates a bound expression that checks if values are between two bounds.
+pub fn bound_between(
+    arr: BoundExpression,
+    lower: BoundExpression,
+    upper: BoundExpression,
+    options: BetweenOptions,
+) -> BoundExpression {
+    Between
+        .try_new_bound_expr(options, [arr, lower, upper])
+        .vortex_expect("between expressions require compatible operand dtypes")
+}
+
 // ---- Select ----
 
 /// Creates an expression that selects (includes) specific fields from an array.
@@ -532,6 +726,13 @@ pub fn select(field_names: impl Into<FieldNames>, child: Expression) -> Expressi
         .vortex_expect("Failed to create Select expression")
 }
 
+/// Creates a bound expression that selects specific fields from a struct expression.
+pub fn bound_select(field_names: impl Into<FieldNames>, child: BoundExpression) -> BoundExpression {
+    Select
+        .try_new_bound_expr(FieldSelection::Include(field_names.into()), [child])
+        .vortex_expect("select expressions require fields from a struct child")
+}
+
 /// Creates an expression that excludes specific fields from an array.
 ///
 /// Projects all fields except the specified ones from the input struct expression.
@@ -544,6 +745,16 @@ pub fn select_exclude(fields: impl Into<FieldNames>, child: Expression) -> Expre
     Select
         .try_new_expr(FieldSelection::Exclude(fields.into()), [child])
         .vortex_expect("Failed to create Select expression")
+}
+
+/// Creates a bound expression that excludes specific fields from a struct expression.
+pub fn bound_select_exclude(
+    fields: impl Into<FieldNames>,
+    child: BoundExpression,
+) -> BoundExpression {
+    Select
+        .try_new_bound_expr(FieldSelection::Exclude(fields.into()), [child])
+        .vortex_expect("select expressions require fields from a struct child")
 }
 
 // ---- Pack ----
@@ -572,6 +783,25 @@ pub fn pack(
     )
 }
 
+/// Creates a bound expression that packs values into a struct with named fields.
+pub fn bound_pack(
+    elements: impl IntoIterator<Item = (impl Into<FieldName>, BoundExpression)>,
+    nullability: Nullability,
+) -> BoundExpression {
+    let (names, values): (Vec<_>, Vec<_>) = elements
+        .into_iter()
+        .map(|(name, value)| (name.into(), value))
+        .unzip();
+    Pack.try_new_bound_expr(
+        PackOptions {
+            names: names.into(),
+            nullability,
+        },
+        values,
+    )
+    .vortex_expect("pack expressions must have one name per child")
+}
+
 // ---- Cast ----
 
 /// Creates an expression that casts values to a target data type.
@@ -588,6 +818,12 @@ pub fn cast(child: Expression, target: DType) -> Expression {
         .vortex_expect("Failed to create Cast expression")
 }
 
+/// Creates a bound expression that casts values to a target dtype.
+pub fn bound_cast(child: BoundExpression, target: DType) -> BoundExpression {
+    Cast.try_new_bound_expr(target, [child])
+        .vortex_expect("cast expressions require a supported source and target dtype")
+}
+
 // ---- FillNull ----
 
 /// Creates an expression that replaces null values with a fill value.
@@ -598,6 +834,13 @@ pub fn cast(child: Expression, target: DType) -> Expression {
 /// ```
 pub fn fill_null(child: Expression, fill_value: Expression) -> Expression {
     FillNull.new_expr(EmptyOptions, [child, fill_value])
+}
+
+/// Creates a bound expression that replaces null values with a fill value.
+pub fn bound_fill_null(child: BoundExpression, fill_value: BoundExpression) -> BoundExpression {
+    FillNull
+        .try_new_bound_expr(EmptyOptions, [child, fill_value])
+        .vortex_expect("fill-null expressions require compatible child and fill dtypes")
 }
 
 // ---- IsNull ----
@@ -614,6 +857,13 @@ pub fn is_null(child: Expression) -> Expression {
     IsNull.new_expr(EmptyOptions, vec![child])
 }
 
+/// Creates a bound expression that checks for null values.
+pub fn bound_is_null(child: BoundExpression) -> BoundExpression {
+    IsNull
+        .try_new_bound_expr(EmptyOptions, [child])
+        .vortex_expect("is-null expressions are always well-typed")
+}
+
 // ---- IsNotNull ----
 
 /// Creates an expression that checks for non-null values.
@@ -626,6 +876,13 @@ pub fn is_null(child: Expression) -> Expression {
 /// ```
 pub fn is_not_null(child: Expression) -> Expression {
     IsNotNull.new_expr(EmptyOptions, vec![child])
+}
+
+/// Creates a bound expression that checks for non-null values.
+pub fn bound_is_not_null(child: BoundExpression) -> BoundExpression {
+    IsNotNull
+        .try_new_bound_expr(EmptyOptions, [child])
+        .vortex_expect("is-not-null expressions are always well-typed")
 }
 
 // ---- Like ----
@@ -641,6 +898,11 @@ pub fn like(child: Expression, pattern: Expression) -> Expression {
     )
 }
 
+/// Creates a bound SQL LIKE expression.
+pub fn bound_like(child: BoundExpression, pattern: BoundExpression) -> BoundExpression {
+    bound_like_with_options(child, pattern, false, false)
+}
+
 /// Creates a case-insensitive SQL ILIKE expression.
 pub fn ilike(child: Expression, pattern: Expression) -> Expression {
     Like.new_expr(
@@ -650,6 +912,11 @@ pub fn ilike(child: Expression, pattern: Expression) -> Expression {
         },
         [child, pattern],
     )
+}
+
+/// Creates a bound case-insensitive SQL ILIKE expression.
+pub fn bound_ilike(child: BoundExpression, pattern: BoundExpression) -> BoundExpression {
+    bound_like_with_options(child, pattern, false, true)
 }
 
 /// Creates a negated SQL NOT LIKE expression.
@@ -663,6 +930,11 @@ pub fn not_like(child: Expression, pattern: Expression) -> Expression {
     )
 }
 
+/// Creates a bound negated SQL NOT LIKE expression.
+pub fn bound_not_like(child: BoundExpression, pattern: BoundExpression) -> BoundExpression {
+    bound_like_with_options(child, pattern, true, false)
+}
+
 /// Creates a negated case-insensitive SQL NOT ILIKE expression.
 pub fn not_ilike(child: Expression, pattern: Expression) -> Expression {
     Like.new_expr(
@@ -674,11 +946,38 @@ pub fn not_ilike(child: Expression, pattern: Expression) -> Expression {
     )
 }
 
+/// Creates a bound negated case-insensitive SQL NOT ILIKE expression.
+pub fn bound_not_ilike(child: BoundExpression, pattern: BoundExpression) -> BoundExpression {
+    bound_like_with_options(child, pattern, true, true)
+}
+
+fn bound_like_with_options(
+    child: BoundExpression,
+    pattern: BoundExpression,
+    negated: bool,
+    case_insensitive: bool,
+) -> BoundExpression {
+    Like.try_new_bound_expr(
+        LikeOptions {
+            negated,
+            case_insensitive,
+        },
+        [child, pattern],
+    )
+    .vortex_expect("like expressions require UTF-8 or binary operands")
+}
+
 // ---- Mask ----
 
 /// Creates a mask expression that applies the given boolean mask to the input array.
 pub fn mask(array: Expression, mask: Expression) -> Expression {
     Mask.new_expr(EmptyOptions, [array, mask])
+}
+
+/// Creates a bound mask expression.
+pub fn bound_mask(array: BoundExpression, mask: BoundExpression) -> BoundExpression {
+    Mask.try_new_bound_expr(EmptyOptions, [array, mask])
+        .vortex_expect("mask expressions require a boolean mask")
 }
 
 // ---- Merge ----
@@ -699,6 +998,11 @@ pub fn merge(elements: impl IntoIterator<Item = impl Into<Expression>>) -> Expre
     Merge.new_expr(DuplicateHandling::default(), values)
 }
 
+/// Creates a bound expression that merges struct expressions.
+pub fn bound_merge(elements: impl IntoIterator<Item = BoundExpression>) -> BoundExpression {
+    bound_merge_opts(elements, DuplicateHandling::default())
+}
+
 /// Creates a merge expression with explicit duplicate handling.
 pub fn merge_opts(
     elements: impl IntoIterator<Item = impl Into<Expression>>,
@@ -707,6 +1011,16 @@ pub fn merge_opts(
     use itertools::Itertools as _;
     let values = elements.into_iter().map(|value| value.into()).collect_vec();
     Merge.new_expr(duplicate_handling, values)
+}
+
+/// Creates a bound merge expression with explicit duplicate handling.
+pub fn bound_merge_opts(
+    elements: impl IntoIterator<Item = BoundExpression>,
+    duplicate_handling: DuplicateHandling,
+) -> BoundExpression {
+    Merge
+        .try_new_bound_expr(duplicate_handling, elements)
+        .vortex_expect("merge expressions require non-nullable struct children")
 }
 
 // ---- Zip ----
@@ -721,7 +1035,32 @@ pub fn zip_expr(mask: Expression, if_true: Expression, if_false: Expression) -> 
     Zip.new_expr(EmptyOptions, [if_true, if_false, mask])
 }
 
+/// Creates a bound zip expression that conditionally selects between two arrays.
+pub fn bound_zip_expr(
+    mask: BoundExpression,
+    if_true: BoundExpression,
+    if_false: BoundExpression,
+) -> BoundExpression {
+    Zip.try_new_bound_expr(EmptyOptions, [if_true, if_false, mask])
+        .vortex_expect("zip expressions require a boolean mask and compatible value dtypes")
+}
+
 // ---- Dynamic ----
+
+/// Creates a dynamic comparison expression from its complete options.
+pub fn dynamic_with_options(options: DynamicComparisonExpr, lhs: Expression) -> Expression {
+    DynamicComparison.new_expr(options, [lhs])
+}
+
+/// Creates a bound dynamic comparison expression from its complete options.
+pub fn bound_dynamic_with_options(
+    options: DynamicComparisonExpr,
+    lhs: BoundExpression,
+) -> BoundExpression {
+    DynamicComparison
+        .try_new_bound_expr(options, [lhs])
+        .vortex_expect("dynamic comparisons require a compatible left-hand dtype")
+}
 
 /// Creates a dynamic comparison expression.
 pub fn dynamic(
@@ -731,7 +1070,7 @@ pub fn dynamic(
     default: bool,
     lhs: Expression,
 ) -> Expression {
-    DynamicComparison.new_expr(
+    dynamic_with_options(
         DynamicComparisonExpr {
             operator,
             rhs: Arc::new(Rhs {
@@ -740,7 +1079,28 @@ pub fn dynamic(
             }),
             default,
         },
-        [lhs],
+        lhs,
+    )
+}
+
+/// Creates a bound dynamic comparison expression.
+pub fn bound_dynamic(
+    operator: CompareOperator,
+    rhs_value: impl Fn() -> Option<ScalarValue> + Send + Sync + 'static,
+    rhs_dtype: DType,
+    default: bool,
+    lhs: BoundExpression,
+) -> BoundExpression {
+    bound_dynamic_with_options(
+        DynamicComparisonExpr {
+            operator,
+            rhs: Arc::new(Rhs {
+                value: Arc::new(rhs_value),
+                dtype: rhs_dtype,
+            }),
+            default,
+        },
+        lhs,
     )
 }
 
@@ -758,6 +1118,13 @@ pub fn list_contains(list: Expression, value: Expression) -> Expression {
     ListContains.new_expr(EmptyOptions, [list, value])
 }
 
+/// Creates a bound expression that checks if a value is contained in a list.
+pub fn bound_list_contains(list: BoundExpression, value: BoundExpression) -> BoundExpression {
+    ListContains
+        .try_new_bound_expr(EmptyOptions, [list, value])
+        .vortex_expect("list-contains expressions require a compatible list and value dtype")
+}
+
 // ---- ByteLength ----
 
 /// Creates an expression that computes the byte length of each element.
@@ -769,6 +1136,13 @@ pub fn list_contains(list: Expression, value: Expression) -> Expression {
 /// ```
 pub fn byte_length(input: Expression) -> Expression {
     ByteLength.new_expr(EmptyOptions, [input])
+}
+
+/// Creates a bound expression that computes each element's byte length.
+pub fn bound_byte_length(input: BoundExpression) -> BoundExpression {
+    ByteLength
+        .try_new_bound_expr(EmptyOptions, [input])
+        .vortex_expect("byte-length expressions require a variable-length binary child")
 }
 
 // ---- ExtStorage ----
@@ -783,6 +1157,13 @@ pub fn ext_storage(input: Expression) -> Expression {
     ExtStorage.new_expr(EmptyOptions, [input])
 }
 
+/// Creates a bound expression that extracts an extension array's storage values.
+pub fn bound_ext_storage(input: BoundExpression) -> BoundExpression {
+    ExtStorage
+        .try_new_bound_expr(EmptyOptions, [input])
+        .vortex_expect("extension-storage expressions require an extension child")
+}
+
 // ---- ListLength ----
 
 /// Creates an expression that computes the number of elements in each list
@@ -795,6 +1176,13 @@ pub fn ext_storage(input: Expression) -> Expression {
 /// ```
 pub fn list_length(input: Expression) -> Expression {
     ListLength.new_expr(EmptyOptions, [input])
+}
+
+/// Creates a bound expression that computes the number of elements in each list.
+pub fn bound_list_length(input: BoundExpression) -> BoundExpression {
+    ListLength
+        .try_new_bound_expr(EmptyOptions, [input])
+        .vortex_expect("list-length expressions require a list child")
 }
 
 // ---- ListSum ----
@@ -815,8 +1203,78 @@ pub fn list_sum(input: Expression) -> Expression {
     ListSum.new_expr(NumericalAggregateOpts::default(), [input])
 }
 
+/// Creates a bound expression that sums the elements of each list.
+pub fn bound_list_sum(input: BoundExpression) -> BoundExpression {
+    ListSum
+        .try_new_bound_expr(NumericalAggregateOpts::default(), [input])
+        .vortex_expect("list-sum expressions require a numeric list child")
+}
+
 /// Creates a [`list_sum`] expression with explicit [`NumericalAggregateOpts`], controlling
 /// whether NaN float elements are skipped (the default) or poison the list's sum to NaN.
 pub fn list_sum_opts(input: Expression, options: NumericalAggregateOpts) -> Expression {
     ListSum.new_expr(options, [input])
+}
+
+/// Creates a bound list-sum expression with explicit aggregate options.
+pub fn bound_list_sum_opts(
+    input: BoundExpression,
+    options: NumericalAggregateOpts,
+) -> BoundExpression {
+    ListSum
+        .try_new_bound_expr(options, [input])
+        .vortex_expect("list-sum expressions require a numeric list child")
+}
+
+/// Constructors for expressions whose children have already been bound and type-checked.
+///
+/// These mirror the constructors in [`crate::expr`] and panic when the supplied children do not
+/// form a well-typed expression. Use [`BoundExpression::try_new`] when construction must be
+/// fallible.
+pub mod bound {
+    pub use super::bound_and as and;
+    pub use super::bound_and_collect as and_collect;
+    pub use super::bound_between as between;
+    pub use super::bound_binary as binary;
+    pub use super::bound_byte_length as byte_length;
+    pub use super::bound_case_when as case_when;
+    pub use super::bound_case_when_no_else as case_when_no_else;
+    pub use super::bound_cast as cast;
+    pub use super::bound_checked_add as checked_add;
+    pub use super::bound_col as col;
+    pub use super::bound_dynamic as dynamic;
+    pub use super::bound_dynamic_with_options as dynamic_with_options;
+    pub use super::bound_eq as eq;
+    pub use super::bound_ext_storage as ext_storage;
+    pub use super::bound_fill_null as fill_null;
+    pub use super::bound_get_item as get_item;
+    pub use super::bound_gt as gt;
+    pub use super::bound_gt_eq as gt_eq;
+    pub use super::bound_ilike as ilike;
+    pub use super::bound_is_not_null as is_not_null;
+    pub use super::bound_is_null as is_null;
+    pub use super::bound_like as like;
+    pub use super::bound_list_contains as list_contains;
+    pub use super::bound_list_length as list_length;
+    pub use super::bound_list_sum as list_sum;
+    pub use super::bound_list_sum_opts as list_sum_opts;
+    pub use super::bound_lit as lit;
+    pub use super::bound_lt as lt;
+    pub use super::bound_lt_eq as lt_eq;
+    pub use super::bound_mask as mask;
+    pub use super::bound_merge as merge;
+    pub use super::bound_merge_opts as merge_opts;
+    pub use super::bound_nested_case_when as nested_case_when;
+    pub use super::bound_not as not;
+    pub use super::bound_not_eq as not_eq;
+    pub use super::bound_not_ilike as not_ilike;
+    pub use super::bound_not_like as not_like;
+    pub use super::bound_or as or;
+    pub use super::bound_or_collect as or_collect;
+    pub use super::bound_pack as pack;
+    pub use super::bound_root as root;
+    pub use super::bound_select as select;
+    pub use super::bound_select_exclude as select_exclude;
+    pub use super::bound_variant_get as variant_get;
+    pub use super::bound_zip_expr as zip_expr;
 }

--- a/vortex-array/src/expr/mod.rs
+++ b/vortex-array/src/expr/mod.rs
@@ -72,7 +72,54 @@ pub mod traversal;
 pub use analysis::*;
 pub use bound_expression::*;
 pub use expression::*;
-pub use exprs::*;
+pub use exprs::and;
+pub use exprs::and_collect;
+pub use exprs::between;
+pub use exprs::binary;
+pub use exprs::bound;
+pub use exprs::byte_length;
+pub use exprs::case_when;
+pub use exprs::case_when_no_else;
+pub use exprs::cast;
+pub use exprs::checked_add;
+pub use exprs::col;
+pub use exprs::dynamic;
+pub use exprs::dynamic_with_options;
+pub use exprs::eq;
+pub use exprs::ext_storage;
+pub use exprs::fill_null;
+pub use exprs::get_item;
+pub use exprs::gt;
+pub use exprs::gt_eq;
+pub use exprs::ilike;
+pub use exprs::is_not_null;
+pub use exprs::is_null;
+pub use exprs::is_root;
+pub use exprs::like;
+pub use exprs::list_contains;
+pub use exprs::list_length;
+pub use exprs::list_sum;
+pub use exprs::list_sum_opts;
+pub use exprs::lit;
+pub use exprs::lt;
+pub use exprs::lt_eq;
+pub use exprs::mask;
+pub use exprs::merge;
+pub use exprs::merge_opts;
+pub use exprs::nested_case_when;
+pub use exprs::not;
+pub use exprs::not_eq;
+pub use exprs::not_ilike;
+pub use exprs::not_like;
+pub use exprs::or;
+pub use exprs::or_collect;
+pub use exprs::pack;
+pub use exprs::root;
+pub use exprs::select;
+pub use exprs::select_exclude;
+pub use exprs::union_child_validities;
+pub use exprs::variant_get;
+pub use exprs::zip_expr;
 pub use scope::*;
 
 pub trait VortexExprExt {
@@ -167,6 +214,8 @@ mod tests {
     use crate::dtype::PType;
     use crate::dtype::StructFields;
     use crate::expr::and;
+    use crate::expr::bound;
+    use crate::expr::case_when;
     use crate::expr::col;
     use crate::expr::get_item;
     use crate::expr::gt;
@@ -213,6 +262,46 @@ mod tests {
         // Structurally identical expressions built separately are distinct keys.
         let rebuilt = ExactExpr(eq(get_item("col1", root()), lit(1)));
         assert_ne!(a, rebuilt);
+    }
+
+    #[test]
+    fn bound_constructors_preserve_order_and_types() -> vortex_error::VortexResult<()> {
+        let value_dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
+        let scope = DType::Struct(
+            StructFields::from_iter([("value", value_dtype.clone())]),
+            Nullability::NonNullable,
+        );
+
+        let root = bound::root(scope.clone());
+        let value = bound::get_item("value", root);
+        let literal = bound::lit(5i32);
+        let condition = bound::gt(value.clone(), literal.clone());
+        assert_eq!(condition.dtype(), &DType::Bool(Nullability::NonNullable));
+        assert_eq!(condition.children(), &[value.clone(), literal.clone()]);
+
+        let case = bound::case_when(condition.clone(), value.clone(), literal.clone());
+        assert_eq!(case.dtype(), &value_dtype);
+        assert_eq!(case.children(), &[condition.clone(), value, literal]);
+
+        let packed = bound::pack(
+            [("condition", condition.clone()), ("value", case.clone())],
+            Nullability::NonNullable,
+        );
+        assert_eq!(packed.children(), &[condition, case.clone()]);
+        assert_eq!(
+            packed.dtype(),
+            &DType::Struct(
+                StructFields::from_iter([
+                    ("condition", DType::Bool(Nullability::NonNullable)),
+                    ("value", value_dtype),
+                ]),
+                Nullability::NonNullable,
+            )
+        );
+
+        let unbound = case_when(gt(col("value"), lit(5i32)), col("value"), lit(5i32));
+        assert_eq!(unbound.bind(&scope)?, case);
+        Ok(())
     }
 
     #[test]

--- a/vortex-array/src/expr/transform/bound_partition.rs
+++ b/vortex-array/src/expr/transform/bound_partition.rs
@@ -372,7 +372,7 @@ mod tests {
 
         // An un-expanded root expression is annotated by all fields, but since it is a single node
         assert_eq!(partitioned.partitions.len(), 0);
-        assert_eq!(partitioned.root.unbind(), root());
+        assert_eq!(partitioned.root, root().bind(&dtype).unwrap());
 
         // Instead, callers must expand the root expression themselves.
         let expr = replace_root_fields(expr, fields);
@@ -386,9 +386,13 @@ mod tests {
         let expr = get_item("y", get_item("a", root()));
 
         let partitioned = partition_by_field(expr.bind(&dtype).unwrap(), &dtype).unwrap();
+        let root_dtype =
+            partition_root_dtype(&partitioned.partition_names, &partitioned.partitions);
         assert_eq!(
-            partitioned.root.unbind(),
+            partitioned.root,
             get_item("a_0", get_item("a", root()))
+                .bind(&root_dtype)
+                .unwrap()
         );
     }
 
@@ -406,14 +410,16 @@ mod tests {
 
         let split_a = partitioned.find_partition(&"a".into()).unwrap();
         assert_eq!(
-            split_a.unbind(),
-            pack(
+            split_a,
+            &pack(
                 [
                     ("a_0", get_item("x", get_item("a", root()))),
                     ("a_1", get_item("y", get_item("a", root())))
                 ],
                 NonNullable
             )
+            .bind(&dtype)
+            .unwrap()
         );
     }
 
@@ -441,9 +447,11 @@ mod tests {
 
         let partitioned = partition_by_field(expr.bind(&dtype).unwrap(), &dtype).unwrap();
         let expected = merge([get_item("a_0", col("a")), get_item("b_0", col("b"))]);
+        let root_dtype =
+            partition_root_dtype(&partitioned.partition_names, &partitioned.partitions);
         assert_eq!(
-            partitioned.root.unbind(),
-            expected,
+            partitioned.root,
+            expected.bind(&root_dtype).unwrap(),
             "{} {}",
             partitioned.root,
             expected
@@ -453,11 +461,19 @@ mod tests {
 
         let part_a = partitioned.find_partition(&"a".into()).unwrap();
         let expected_a = pack([("a_0", col("a"))], NonNullable);
-        assert_eq!(part_a.unbind(), expected_a, "{part_a} {expected_a}");
+        assert_eq!(
+            part_a,
+            &expected_a.bind(&dtype).unwrap(),
+            "{part_a} {expected_a}"
+        );
 
         let part_b = partitioned.find_partition(&"b".into()).unwrap();
         let expected_b = pack([("b_0", pack([("b", col("b"))], NonNullable))], NonNullable);
-        assert_eq!(part_b.unbind(), expected_b, "{part_b} {expected_b}");
+        assert_eq!(
+            part_b,
+            &expected_b.bind(&dtype).unwrap(),
+            "{part_b} {expected_b}"
+        );
     }
 
     #[rstest]

--- a/vortex-array/src/expr/transform/bound_partition.rs
+++ b/vortex-array/src/expr/transform/bound_partition.rs
@@ -22,14 +22,12 @@ use crate::expr::analysis::Annotation;
 use crate::expr::analysis::AnnotationFn;
 use crate::expr::analysis::BoundAnnotations;
 use crate::expr::analysis::descendent_bound_annotations;
+use crate::expr::bound::get_item;
+use crate::expr::bound::pack;
 use crate::expr::traversal::NodeExt;
 use crate::expr::traversal::NodeRewriter;
 use crate::expr::traversal::Transformed;
 use crate::expr::traversal::TraversalOrder;
-use crate::scalar_fn::ScalarFnVTableExt;
-use crate::scalar_fn::fns::get_item::GetItem;
-use crate::scalar_fn::fns::pack::Pack;
-use crate::scalar_fn::fns::pack::PackOptions;
 
 /// Partition an expression into sub-expressions that are uniquely associated with an annotation.
 /// A root expression is also returned that can be used to recombine the results of the partitions
@@ -75,12 +73,12 @@ where
 
     for (annotation, exprs) in collector.sub_expressions {
         // We pack all sub-expressions for the same annotation into a single expression.
-        let names = exprs
+        let names: FieldNames = exprs
             .iter()
             .enumerate()
             .map(|(idx, _)| PartitionCollector::field_name(&annotation, idx))
             .collect();
-        let expr = bound_pack(names, exprs)?;
+        let expr = pack(names.into_iter().zip(exprs), Nullability::NonNullable);
 
         partitions.push(expr);
         partition_annotations.push(annotation);
@@ -259,11 +257,11 @@ where
         let field_name = PartitionCollector::field_name(annotation, *offset);
         *offset += 1;
 
-        let partition = bound_get_item(
+        let partition = get_item(
             FieldName::from(annotation.clone()),
             BoundExpression::new_root(self.root_dtype.clone()),
-        )?;
-        let value = bound_get_item(field_name, partition)?;
+        );
+        let value = get_item(field_name, partition);
 
         Ok(Transformed {
             value,
@@ -271,20 +269,6 @@ where
             order: TraversalOrder::Skip,
         })
     }
-}
-
-fn bound_get_item(field_name: FieldName, child: BoundExpression) -> VortexResult<BoundExpression> {
-    BoundExpression::try_new(GetItem.bind(field_name), [child])
-}
-
-fn bound_pack(names: FieldNames, children: Vec<BoundExpression>) -> VortexResult<BoundExpression> {
-    BoundExpression::try_new(
-        Pack.bind(PackOptions {
-            names,
-            nullability: Nullability::NonNullable,
-        }),
-        children,
-    )
 }
 
 fn partition_root_dtype(names: &FieldNames, partitions: &[BoundExpression]) -> DType {

--- a/vortex-array/src/scalar_fn/fns/dynamic.rs
+++ b/vortex-array/src/scalar_fn/fns/dynamic.rs
@@ -19,7 +19,7 @@ use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::dtype::DType;
-use crate::expr::Expression;
+use crate::expr::BoundExpression;
 use crate::expr::display::ExprDisplay;
 use crate::expr::traversal::NodeExt;
 use crate::expr::traversal::NodeVisitor;
@@ -205,15 +205,19 @@ pub struct DynamicExprUpdates {
 }
 
 impl DynamicExprUpdates {
-    pub fn new(expr: &Expression) -> Option<Self> {
+    /// Track dynamic scalar functions contained in a bound expression tree.
+    pub fn new(expr: &BoundExpression) -> Option<Self> {
         #[derive(Default)]
         struct Visitor(Vec<DynamicComparisonExpr>);
 
         impl NodeVisitor<'_> for Visitor {
-            type NodeTy = Expression;
+            type NodeTy = BoundExpression;
 
             fn visit_down(&mut self, node: &'_ Self::NodeTy) -> VortexResult<TraversalOrder> {
-                if let Some(dynamic) = node.as_opt::<DynamicComparison>() {
+                if let Some(dynamic) = node
+                    .as_scalar()
+                    .and_then(|scalar_fn| scalar_fn.as_opt::<DynamicComparison>())
+                {
                     self.0.push(dynamic.clone());
                 }
                 Ok(TraversalOrder::Continue)

--- a/vortex-array/src/scalar_fn/fns/is_not_null.rs
+++ b/vortex-array/src/scalar_fn/fns/is_not_null.rs
@@ -253,13 +253,17 @@ mod tests {
     #[test]
     fn test_is_not_null_falsification() -> VortexResult<()> {
         let expr = is_not_null(col("a"));
+        let dtype = test_harness::struct_dtype();
 
         assert_eq!(
-            expr.falsify(&test_harness::struct_dtype(), &STATS_SESSION)?,
-            Some(or(
-                eq(null_count(col("a")), RowCount.new_expr(EmptyOptions, []),),
-                all_null(col("a")),
-            ))
+            expr.bind(&dtype)?.falsify(&STATS_SESSION)?,
+            Some(
+                or(
+                    eq(null_count(col("a")), RowCount.new_expr(EmptyOptions, []),),
+                    all_null(col("a")),
+                )
+                .bind(&dtype)?
+            )
         );
         Ok(())
     }

--- a/vortex-array/src/scalar_fn/fns/is_null.rs
+++ b/vortex-array/src/scalar_fn/fns/is_null.rs
@@ -238,13 +238,11 @@ mod tests {
     #[test]
     fn test_is_null_falsification() -> VortexResult<()> {
         let expr = is_null(col("a"));
+        let dtype = test_harness::struct_dtype();
 
         assert_eq!(
-            expr.falsify(&test_harness::struct_dtype(), &STATS_SESSION)?,
-            Some(or(
-                eq(null_count(col("a")), lit(0u64)),
-                all_non_null(col("a")),
-            ))
+            expr.bind(&dtype)?.falsify(&STATS_SESSION)?,
+            Some(or(eq(null_count(col("a")), lit(0u64)), all_non_null(col("a")),).bind(&dtype)?)
         );
         Ok(())
     }

--- a/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
@@ -600,23 +600,26 @@ mod tests {
         );
 
         assert_eq!(
-            expr.falsify(&scope, &STATS_SESSION)?,
-            Some(and(
+            expr.bind(&scope)?.falsify(&STATS_SESSION)?,
+            Some(
                 and(
-                    or(
-                        lt(stat(col("a"), Stat::Max), lit(1i32)),
-                        gt(stat(col("a"), Stat::Min), lit(1i32)),
+                    and(
+                        or(
+                            lt(stat(col("a"), Stat::Max), lit(1i32)),
+                            gt(stat(col("a"), Stat::Min), lit(1i32)),
+                        ),
+                        or(
+                            lt(stat(col("a"), Stat::Max), lit(2i32)),
+                            gt(stat(col("a"), Stat::Min), lit(2i32)),
+                        )
                     ),
                     or(
-                        lt(stat(col("a"), Stat::Max), lit(2i32)),
-                        gt(stat(col("a"), Stat::Min), lit(2i32)),
+                        lt(stat(col("a"), Stat::Max), lit(3i32)),
+                        gt(stat(col("a"), Stat::Min), lit(3i32)),
                     )
-                ),
-                or(
-                    lt(stat(col("a"), Stat::Max), lit(3i32)),
-                    gt(stat(col("a"), Stat::Min), lit(3i32)),
                 )
-            ))
+                .bind(&scope)?
+            )
         );
         Ok(())
     }

--- a/vortex-array/src/scalar_fn/vtable.rs
+++ b/vortex-array/src/scalar_fn/vtable.rs
@@ -19,6 +19,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::dtype::DType;
+use crate::expr::BoundExpression;
 use crate::expr::Expression;
 use crate::expr::display::ExprDisplay;
 use crate::scalar_fn::ScalarFnId;
@@ -391,6 +392,15 @@ pub trait ScalarFnVTableExt: ScalarFnVTable {
         children: impl IntoIterator<Item = Expression>,
     ) -> VortexResult<Expression> {
         Expression::try_new(self.bind(options), children)
+    }
+
+    /// Try to create a bound expression with this vtable, the given options, and bound children.
+    fn try_new_bound_expr(
+        &self,
+        options: Self::Options,
+        children: impl IntoIterator<Item = BoundExpression>,
+    ) -> VortexResult<BoundExpression> {
+        BoundExpression::try_new(self.bind(options), children)
     }
 }
 impl<V: ScalarFnVTable> ScalarFnVTableExt for V {}

--- a/vortex-array/src/stats/bind.rs
+++ b/vortex-array/src/stats/bind.rs
@@ -18,11 +18,10 @@ use vortex_error::VortexResult;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::dtype::DType;
 use crate::expr::BoundExpression;
+use crate::expr::bound::lit;
 use crate::expr::traversal::NodeExt;
 use crate::expr::traversal::Transformed;
 use crate::scalar::Scalar;
-use crate::scalar_fn::ScalarFnVTableExt;
-use crate::scalar_fn::fns::literal::Literal;
 use crate::scalar_fn::fns::stat::StatFn;
 
 /// A target that can bind abstract statistics to concrete expressions.
@@ -88,7 +87,7 @@ fn bind_stat_fn(
 }
 
 fn null_expr(dtype: DType) -> VortexResult<BoundExpression> {
-    Literal.try_new_bound_expr(Scalar::null(dtype.as_nullable()), [])
+    Ok(lit(Scalar::null(dtype.as_nullable())))
 }
 
 #[cfg(test)]

--- a/vortex-array/src/stats/bind.rs
+++ b/vortex-array/src/stats/bind.rs
@@ -17,11 +17,12 @@ use vortex_error::VortexResult;
 
 use crate::aggregate_fn::AggregateFnRef;
 use crate::dtype::DType;
-use crate::expr::Expression;
-use crate::expr::lit;
+use crate::expr::BoundExpression;
 use crate::expr::traversal::NodeExt;
 use crate::expr::traversal::Transformed;
 use crate::scalar::Scalar;
+use crate::scalar_fn::ScalarFnVTableExt;
+use crate::scalar_fn::fns::literal::Literal;
 use crate::scalar_fn::fns::stat::StatFn;
 
 /// A target that can bind abstract statistics to concrete expressions.
@@ -31,26 +32,23 @@ use crate::scalar_fn::fns::stat::StatFn;
 /// field reference in the per-zone stats table, while a file-stats binder can translate the same
 /// placeholder into a literal value from the file footer.
 pub trait StatBinder {
-    /// The dtype scope used to type-check expressions before stats are bound.
-    fn scope(&self) -> &DType;
-
     /// Bind `aggregate_fn(input)` to a concrete expression.
     ///
     /// Implementations should return `Ok(None)` when the requested aggregate
     /// statistic is unavailable in their backing representation.
     fn bind_aggregate(
         &self,
-        input: &Expression,
+        input: &BoundExpression,
         aggregate_fn: &AggregateFnRef,
         stat_dtype: &DType,
-    ) -> VortexResult<Option<Expression>>;
+    ) -> VortexResult<Option<BoundExpression>>;
 
     /// Expression to use when a stat is unavailable.
     ///
     /// The default is a nullable null literal, which preserves three-valued
     /// pruning semantics for stats-table execution.
-    fn missing_stat(&self, dtype: DType) -> VortexResult<Expression> {
-        Ok(null_expr(dtype))
+    fn missing_stat(&self, dtype: DType) -> VortexResult<BoundExpression> {
+        null_expr(dtype)
     }
 }
 
@@ -60,43 +58,37 @@ pub trait StatBinder {
 /// are responsible for expressing stat semantics; binding maps aggregate-backed
 /// stat requests to the concrete stats representation supported by the binder.
 pub fn bind_stats<B: StatBinder + ?Sized>(
-    predicate: Expression,
+    predicate: BoundExpression,
     binder: &B,
-) -> VortexResult<Expression> {
-    let scope = binder.scope().clone();
+) -> VortexResult<BoundExpression> {
     Ok(predicate
         .transform_down(|expr| {
             if !expr.is::<StatFn>() {
                 return Ok(Transformed::no(expr));
             }
 
-            match bind_stat_fn(&expr, &scope, binder)? {
+            match bind_stat_fn(&expr, binder)? {
                 Some(bound) => Ok(Transformed::yes(bound)),
-                None => {
-                    let dtype = expr.return_dtype(&scope)?;
-                    Ok(Transformed::yes(binder.missing_stat(dtype)?))
-                }
+                None => Ok(Transformed::yes(binder.missing_stat(expr.dtype().clone())?)),
             }
         })?
         .into_inner())
 }
 
 fn bind_stat_fn(
-    expr: &Expression,
-    scope: &DType,
+    expr: &BoundExpression,
     binder: &(impl StatBinder + ?Sized),
-) -> VortexResult<Option<Expression>> {
+) -> VortexResult<Option<BoundExpression>> {
     let options = expr.as_::<StatFn>();
     let aggregate_fn = options.aggregate_fn();
     // `StatFn` has exactly one child: the expression the aggregate statistic is computed over.
     let input = expr.child(0);
 
-    let stat_dtype = expr.return_dtype(scope)?;
-    binder.bind_aggregate(input, aggregate_fn, &stat_dtype)
+    binder.bind_aggregate(input, aggregate_fn, expr.dtype())
 }
 
-fn null_expr(dtype: DType) -> Expression {
-    lit(Scalar::null(dtype.as_nullable()))
+fn null_expr(dtype: DType) -> VortexResult<BoundExpression> {
+    Literal.try_new_bound_expr(Scalar::null(dtype.as_nullable()), [])
 }
 
 #[cfg(test)]
@@ -111,6 +103,7 @@ mod tests {
     use crate::expr::col;
     use crate::expr::get_item;
     use crate::expr::is_null;
+    use crate::expr::lit;
     use crate::expr::or;
     use crate::expr::root;
     use crate::expr::stats::Stat;
@@ -119,6 +112,7 @@ mod tests {
 
     struct TestBinder {
         input_scope: DType,
+        stats_scope: DType,
         bind_nan_count: bool,
     }
 
@@ -132,28 +126,33 @@ mod tests {
                     )]),
                     Nullability::NonNullable,
                 ),
+                stats_scope: DType::Struct(
+                    StructFields::from_iter([(
+                        "f_nan_count",
+                        DType::Primitive(PType::U64, Nullability::NonNullable),
+                    )]),
+                    Nullability::NonNullable,
+                ),
                 bind_nan_count,
             }
         }
     }
 
     impl StatBinder for TestBinder {
-        fn scope(&self) -> &DType {
-            &self.input_scope
-        }
-
         fn bind_aggregate(
             &self,
-            _input: &Expression,
+            _input: &BoundExpression,
             aggregate_fn: &AggregateFnRef,
             _stat_dtype: &DType,
-        ) -> VortexResult<Option<Expression>> {
+        ) -> VortexResult<Option<BoundExpression>> {
             let Some(stat) = Stat::from_aggregate_fn(aggregate_fn) else {
                 return Ok(None);
             };
 
             if stat == Stat::NaNCount && self.bind_nan_count {
-                Ok(Some(get_item("f_nan_count", root())))
+                Ok(Some(
+                    get_item("f_nan_count", root()).bind(&self.stats_scope)?,
+                ))
             } else {
                 Ok(None)
             }
@@ -164,9 +163,9 @@ mod tests {
     fn nan_count_binds_to_direct_stat_slot() -> VortexResult<()> {
         let binder = TestBinder::new(true);
 
-        let bound = bind_stats(nan_count(col("f")), &binder)?;
+        let bound = bind_stats(nan_count(col("f")).bind(&binder.input_scope)?, &binder)?;
 
-        assert_eq!(bound, col("f_nan_count"));
+        assert_eq!(bound, col("f_nan_count").bind(&binder.stats_scope)?);
         Ok(())
     }
 
@@ -174,9 +173,12 @@ mod tests {
     fn all_non_nan_does_not_derive_from_nan_count() -> VortexResult<()> {
         let binder = TestBinder::new(true);
 
-        let bound = bind_stats(all_non_nan(col("f")), &binder)?;
+        let bound = bind_stats(all_non_nan(col("f")).bind(&binder.input_scope)?, &binder)?;
 
-        assert_eq!(bound, lit(Scalar::null(DType::Bool(Nullability::Nullable))));
+        assert_eq!(
+            bound,
+            lit(Scalar::null(DType::Bool(Nullability::Nullable))).bind(&binder.stats_scope)?
+        );
         Ok(())
     }
 
@@ -185,13 +187,22 @@ mod tests {
         let binder = TestBinder::new(false);
         let null_bool = lit(Scalar::null(DType::Bool(Nullability::Nullable)));
 
-        let bound = bind_stats(and(lit(false), all_non_nan(col("f"))), &binder)?;
+        let bound = bind_stats(
+            and(lit(false), all_non_nan(col("f"))).bind(&binder.input_scope)?,
+            &binder,
+        )?;
 
-        assert_eq!(bound, and(lit(false), null_bool.clone()));
+        assert_eq!(
+            bound,
+            and(lit(false), null_bool.clone()).bind(&binder.stats_scope)?
+        );
 
-        let bound = bind_stats(or(lit(true), all_non_nan(col("f"))), &binder)?;
+        let bound = bind_stats(
+            or(lit(true), all_non_nan(col("f"))).bind(&binder.input_scope)?,
+            &binder,
+        )?;
 
-        assert_eq!(bound, or(lit(true), null_bool));
+        assert_eq!(bound, or(lit(true), null_bool).bind(&binder.stats_scope)?);
         Ok(())
     }
 
@@ -199,9 +210,9 @@ mod tests {
     fn unrelated_expressions_do_not_request_nan_count() -> VortexResult<()> {
         let binder = TestBinder::new(false);
 
-        let bound = bind_stats(is_null(col("f")), &binder)?;
+        let bound = bind_stats(is_null(col("f")).bind(&binder.input_scope)?, &binder)?;
 
-        assert_eq!(bound, is_null(col("f")));
+        assert_eq!(bound, is_null(col("f")).bind(&binder.input_scope)?);
         Ok(())
     }
 }

--- a/vortex-array/src/stats/expr.rs
+++ b/vortex-array/src/stats/expr.rs
@@ -3,6 +3,8 @@
 
 //! Expression constructors for statistics backed by aggregate functions.
 
+use vortex_error::VortexExpect;
+
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnVTableExt;
 use crate::aggregate_fn::EmptyOptions;
@@ -15,6 +17,7 @@ use crate::aggregate_fn::fns::min_max::MinMax;
 use crate::aggregate_fn::fns::nan_count::NanCount;
 use crate::aggregate_fn::fns::null_count::NullCount;
 use crate::aggregate_fn::fns::sum::Sum;
+use crate::expr::BoundExpression;
 use crate::expr::Expression;
 use crate::scalar_fn::ScalarFnVTableExt;
 pub use crate::scalar_fn::fns::stat::StatFn;
@@ -28,10 +31,20 @@ pub fn stat(expr: Expression, aggregate_fn: AggregateFnRef) -> Expression {
     StatFn.new_expr(StatOptions::new(aggregate_fn), [expr])
 }
 
+fn bound_stat(expr: BoundExpression, aggregate_fn: AggregateFnRef) -> BoundExpression {
+    StatFn
+        .try_new_bound_expr(StatOptions::new(aggregate_fn), [expr])
+        .vortex_expect("stat expressions must use an aggregate supported by the child dtype")
+}
+
 /// Creates `stat(expr, min_max)`, returning a nullable `{ min, max }` struct statistic.
 pub fn min_max(expr: Expression) -> Expression {
     // Statistics follow NaN-skipping semantics; request it explicitly rather than via the default.
     stat(expr, MinMax.bind(NumericalAggregateOpts::skip_nans()))
+}
+
+fn bound_min_max(expr: BoundExpression) -> BoundExpression {
+    bound_stat(expr, MinMax.bind(NumericalAggregateOpts::skip_nans()))
 }
 
 /// Creates `stat(expr, sum)`, returning a nullable sum statistic.
@@ -40,9 +53,17 @@ pub fn sum(expr: Expression) -> Expression {
     stat(expr, Sum.bind(NumericalAggregateOpts::skip_nans()))
 }
 
+fn bound_sum(expr: BoundExpression) -> BoundExpression {
+    bound_stat(expr, Sum.bind(NumericalAggregateOpts::skip_nans()))
+}
+
 /// Creates `stat(expr, null_count)`, returning a nullable null-count statistic.
 pub fn null_count(expr: Expression) -> Expression {
     stat(expr, NullCount.bind(EmptyOptions))
+}
+
+fn bound_null_count(expr: BoundExpression) -> BoundExpression {
+    bound_stat(expr, NullCount.bind(EmptyOptions))
 }
 
 /// Creates `stat(expr, all_null)`, returning a nullable all-null statistic.
@@ -50,9 +71,17 @@ pub fn all_null(expr: Expression) -> Expression {
     stat(expr, AllNull.bind(EmptyOptions))
 }
 
+fn bound_all_null(expr: BoundExpression) -> BoundExpression {
+    bound_stat(expr, AllNull.bind(EmptyOptions))
+}
+
 /// Creates `stat(expr, all_nan)`, returning a nullable all-NaN statistic.
 pub fn all_nan(expr: Expression) -> Expression {
     stat(expr, AllNan.bind(EmptyOptions))
+}
+
+fn bound_all_nan(expr: BoundExpression) -> BoundExpression {
+    bound_stat(expr, AllNan.bind(EmptyOptions))
 }
 
 /// Creates `stat(expr, all_non_null)`, returning a nullable all-non-null statistic.
@@ -60,14 +89,80 @@ pub fn all_non_null(expr: Expression) -> Expression {
     stat(expr, AllNonNull.bind(EmptyOptions))
 }
 
+fn bound_all_non_null(expr: BoundExpression) -> BoundExpression {
+    bound_stat(expr, AllNonNull.bind(EmptyOptions))
+}
+
 /// Creates `stat(expr, all_non_nan)`, returning a nullable all-non-NaN statistic.
 pub fn all_non_nan(expr: Expression) -> Expression {
     stat(expr, AllNonNan.bind(EmptyOptions))
 }
 
+fn bound_all_non_nan(expr: BoundExpression) -> BoundExpression {
+    bound_stat(expr, AllNonNan.bind(EmptyOptions))
+}
+
 /// Creates `stat(expr, nan_count)`, returning a nullable NaN-count statistic.
 pub fn nan_count(expr: Expression) -> Expression {
     stat(expr, NanCount.bind(EmptyOptions))
+}
+
+fn bound_nan_count(expr: BoundExpression) -> BoundExpression {
+    bound_stat(expr, NanCount.bind(EmptyOptions))
+}
+
+/// Constructors for statistic expressions whose input has already been bound.
+///
+/// These mirror the constructors in [`crate::stats`] and panic when the aggregate does not support
+/// the input dtype.
+pub mod bound {
+    use crate::aggregate_fn::AggregateFnRef;
+    use crate::expr::BoundExpression;
+
+    /// Creates a bound expression that reads a stored aggregate statistic.
+    pub fn stat(expr: BoundExpression, aggregate_fn: AggregateFnRef) -> BoundExpression {
+        super::bound_stat(expr, aggregate_fn)
+    }
+
+    /// Creates a bound nullable `{ min, max }` statistic expression.
+    pub fn min_max(expr: BoundExpression) -> BoundExpression {
+        super::bound_min_max(expr)
+    }
+
+    /// Creates a bound nullable sum statistic expression.
+    pub fn sum(expr: BoundExpression) -> BoundExpression {
+        super::bound_sum(expr)
+    }
+
+    /// Creates a bound nullable null-count statistic expression.
+    pub fn null_count(expr: BoundExpression) -> BoundExpression {
+        super::bound_null_count(expr)
+    }
+
+    /// Creates a bound nullable all-null statistic expression.
+    pub fn all_null(expr: BoundExpression) -> BoundExpression {
+        super::bound_all_null(expr)
+    }
+
+    /// Creates a bound nullable all-NaN statistic expression.
+    pub fn all_nan(expr: BoundExpression) -> BoundExpression {
+        super::bound_all_nan(expr)
+    }
+
+    /// Creates a bound nullable all-non-null statistic expression.
+    pub fn all_non_null(expr: BoundExpression) -> BoundExpression {
+        super::bound_all_non_null(expr)
+    }
+
+    /// Creates a bound nullable all-non-NaN statistic expression.
+    pub fn all_non_nan(expr: BoundExpression) -> BoundExpression {
+        super::bound_all_non_nan(expr)
+    }
+
+    /// Creates a bound nullable NaN-count statistic expression.
+    pub fn nan_count(expr: BoundExpression) -> BoundExpression {
+        super::bound_nan_count(expr)
+    }
 }
 
 #[cfg(test)]
@@ -83,6 +178,7 @@ mod tests {
     use super::all_non_nan;
     use super::all_non_null;
     use super::all_null;
+    use super::bound as bound_stats;
     use super::null_count;
     use super::stat;
     use super::sum;
@@ -99,6 +195,7 @@ mod tests {
     use crate::dtype::DType;
     use crate::dtype::Nullability;
     use crate::dtype::PType;
+    use crate::expr::bound as bound_expr;
     use crate::expr::root;
     use crate::expr::stats::Precision;
     use crate::expr::stats::Stat;
@@ -107,6 +204,21 @@ mod tests {
     use crate::validity::Validity;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
+
+    #[test]
+    fn bound_stats_constructor_preserves_child_and_dtype() -> VortexResult<()> {
+        let input_dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
+        let root = bound_expr::root(input_dtype.clone());
+        let bound = bound_stats::sum(root.clone());
+
+        assert_eq!(bound.children(), &[root]);
+        assert_eq!(
+            bound.dtype(),
+            &DType::Primitive(PType::I64, Nullability::Nullable)
+        );
+        assert_eq!(bound, sum(crate::expr::root()).bind(&input_dtype)?);
+        Ok(())
+    }
 
     #[test]
     fn stat_expr_reads_cached_sum() -> VortexResult<()> {

--- a/vortex-array/src/stats/mod.rs
+++ b/vortex-array/src/stats/mod.rs
@@ -11,6 +11,7 @@ pub use expr::all_nan;
 pub use expr::all_non_nan;
 pub use expr::all_non_null;
 pub use expr::all_null;
+pub use expr::bound;
 pub use expr::min_max;
 pub use expr::nan_count;
 pub use expr::null_count;

--- a/vortex-array/src/stats/rewrite.rs
+++ b/vortex-array/src/stats/rewrite.rs
@@ -9,11 +9,14 @@ use std::sync::Arc;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_session::VortexSession;
+use vortex_utils::iter::ReduceBalancedIterExt;
 
 use crate::dtype::DType;
-use crate::expr::Expression;
-use crate::expr::or_collect;
+use crate::expr::BoundExpression;
 use crate::scalar_fn::ScalarFnId;
+use crate::scalar_fn::ScalarFnVTableExt;
+use crate::scalar_fn::fns::binary::Binary;
+use crate::scalar_fn::fns::operators::Operator;
 use crate::stats::session::StatsSessionExt;
 
 mod builtins;
@@ -53,9 +56,9 @@ pub trait StatsRewriteRule: Debug + Send + Sync + 'static {
     /// Returns `Ok(None)` when this rule cannot construct a sound falsity proof for `expr`.
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         _ = expr;
         _ = ctx;
         Ok(None)
@@ -73,9 +76,9 @@ pub trait StatsRewriteRule: Debug + Send + Sync + 'static {
     /// Returns `Ok(None)` when this rule cannot construct a sound truth proof for `expr`.
     fn satisfy(
         &self,
-        expr: &Expression,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         _ = expr;
         _ = ctx;
         Ok(None)
@@ -85,13 +88,12 @@ pub trait StatsRewriteRule: Debug + Send + Sync + 'static {
 /// Context passed to stats rewrite rules.
 pub struct StatsRewriteCtx<'a> {
     session: &'a VortexSession,
-    scope: &'a DType,
 }
 
 impl<'a> StatsRewriteCtx<'a> {
     /// Create a rewrite context for `session`.
-    pub fn new(session: &'a VortexSession, scope: &'a DType) -> Self {
-        Self { session, scope }
+    pub fn new(session: &'a VortexSession) -> Self {
+        Self { session }
     }
 
     /// Returns the session that owns the rewrite registry.
@@ -100,23 +102,23 @@ impl<'a> StatsRewriteCtx<'a> {
     }
 
     /// Return the dtype of `expr` within this rewrite scope.
-    pub fn return_dtype(&self, expr: &Expression) -> VortexResult<DType> {
-        expr.return_dtype(self.scope)
+    pub fn return_dtype(&self, expr: &BoundExpression) -> VortexResult<DType> {
+        Ok(expr.dtype().clone())
     }
 
     /// Rewrite `expr` into a stats-backed falsifier.
-    pub fn falsify(&self, expr: &Expression) -> VortexResult<Option<Expression>> {
+    pub fn falsify(&self, expr: &BoundExpression) -> VortexResult<Option<BoundExpression>> {
         self.ensure_predicate(expr)?;
         rewrite(expr, self, StatsRewriteRule::falsify)
     }
 
     /// Rewrite `expr` into a stats-backed satisfier.
-    pub fn satisfy(&self, expr: &Expression) -> VortexResult<Option<Expression>> {
+    pub fn satisfy(&self, expr: &BoundExpression) -> VortexResult<Option<BoundExpression>> {
         self.ensure_predicate(expr)?;
         rewrite(expr, self, StatsRewriteRule::satisfy)
     }
 
-    fn ensure_predicate(&self, expr: &Expression) -> VortexResult<()> {
+    fn ensure_predicate(&self, expr: &BoundExpression) -> VortexResult<()> {
         let dtype = self.return_dtype(expr)?;
         vortex_ensure!(
             matches!(dtype, DType::Bool(_)),
@@ -127,18 +129,18 @@ impl<'a> StatsRewriteCtx<'a> {
 }
 
 fn rewrite(
-    expr: &Expression,
+    expr: &BoundExpression,
     ctx: &StatsRewriteCtx<'_>,
     apply: fn(
         &dyn StatsRewriteRule,
-        &Expression,
+        &BoundExpression,
         &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>>,
-) -> VortexResult<Option<Expression>> {
-    let rules = ctx
-        .session()
-        .stats()
-        .rewrite_rules_for(expr.scalar_fn().id());
+    ) -> VortexResult<Option<BoundExpression>>,
+) -> VortexResult<Option<BoundExpression>> {
+    let Some(scalar_fn) = expr.as_scalar() else {
+        return Ok(None);
+    };
+    let rules = ctx.session().stats().rewrite_rules_for(scalar_fn.id());
     let Some(rules) = rules else {
         return Ok(None);
     };
@@ -150,7 +152,9 @@ fn rewrite(
         }
     }
 
-    Ok(or_collect(rewrites))
+    rewrites
+        .into_iter()
+        .try_reduce_balanced(|lhs, rhs| Binary.try_new_bound_expr(Operator::Or, [lhs, rhs]))
 }
 
 #[cfg(test)]
@@ -162,7 +166,7 @@ mod tests {
     use crate::dtype::DType;
     use crate::dtype::Nullability;
     use crate::dtype::PType;
-    use crate::expr::Expression;
+    use crate::expr::BoundExpression;
     use crate::expr::lit;
     use crate::expr::or;
     use crate::scalar_fn::ScalarFnId;
@@ -172,8 +176,8 @@ mod tests {
 
     #[derive(Debug)]
     struct StaticLiteralRule {
-        falsifier: Option<Expression>,
-        satisfier: Option<Expression>,
+        falsifier: Option<BoundExpression>,
+        satisfier: Option<BoundExpression>,
     }
 
     impl StatsRewriteRule for StaticLiteralRule {
@@ -183,17 +187,17 @@ mod tests {
 
         fn falsify(
             &self,
-            _expr: &Expression,
+            _expr: &BoundExpression,
             _ctx: &StatsRewriteCtx<'_>,
-        ) -> VortexResult<Option<Expression>> {
+        ) -> VortexResult<Option<BoundExpression>> {
             Ok(self.falsifier.clone())
         }
 
         fn satisfy(
             &self,
-            _expr: &Expression,
+            _expr: &BoundExpression,
             _ctx: &StatsRewriteCtx<'_>,
-        ) -> VortexResult<Option<Expression>> {
+        ) -> VortexResult<Option<BoundExpression>> {
             Ok(self.satisfier.clone())
         }
     }
@@ -203,17 +207,17 @@ mod tests {
         let session = crate::array_session();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
         session.stats().register_rewrite(StaticLiteralRule {
-            falsifier: Some(lit(false)),
+            falsifier: Some(lit(false).bind(&dtype)?),
             satisfier: None,
         });
         session.stats().register_rewrite(StaticLiteralRule {
-            falsifier: Some(lit(true)),
+            falsifier: Some(lit(true).bind(&dtype)?),
             satisfier: None,
         });
 
         assert_eq!(
-            lit(true).falsify(&dtype, &session)?,
-            Some(or(lit(false), lit(true)))
+            lit(true).bind(&dtype)?.falsify(&session)?,
+            Some(or(lit(false), lit(true)).bind(&dtype)?)
         );
         Ok(())
     }
@@ -224,16 +228,16 @@ mod tests {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
         session.stats().register_rewrite(StaticLiteralRule {
             falsifier: None,
-            satisfier: Some(lit(false)),
+            satisfier: Some(lit(false).bind(&dtype)?),
         });
         session.stats().register_rewrite(StaticLiteralRule {
             falsifier: None,
-            satisfier: Some(lit(true)),
+            satisfier: Some(lit(true).bind(&dtype)?),
         });
 
         assert_eq!(
-            lit(true).satisfy(&dtype, &session)?,
-            Some(or(lit(false), lit(true)))
+            lit(true).bind(&dtype)?.satisfy(&session)?,
+            Some(or(lit(false), lit(true)).bind(&dtype)?)
         );
         Ok(())
     }
@@ -243,17 +247,20 @@ mod tests {
         let session = crate::array_session();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
 
-        assert_eq!(lit(true).falsify(&dtype, &session)?, None);
-        assert_eq!(lit(true).satisfy(&dtype, &session)?, None);
+        let expr = lit(true).bind(&dtype)?;
+        assert_eq!(expr.falsify(&session)?, None);
+        assert_eq!(expr.satisfy(&session)?, None);
         Ok(())
     }
 
     #[test]
-    fn non_predicate_expression_errors() {
+    fn non_predicate_expression_errors() -> VortexResult<()> {
         let session = crate::array_session();
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
 
-        assert!(lit(7).falsify(&dtype, &session).is_err());
-        assert!(lit(7).satisfy(&dtype, &session).is_err());
+        let expr = lit(7).bind(&dtype)?;
+        assert!(expr.falsify(&session).is_err());
+        assert!(expr.satisfy(&session).is_err());
+        Ok(())
     }
 }

--- a/vortex-array/src/stats/rewrite/builtins.rs
+++ b/vortex-array/src/stats/rewrite/builtins.rs
@@ -13,7 +13,7 @@ use crate::aggregate_fn::fns::all_non_nan::AllNonNan;
 use crate::aggregate_fn::fns::all_non_null::AllNonNull;
 use crate::aggregate_fn::fns::all_null::AllNull;
 use crate::dtype::DType;
-use crate::expr::BoundExpression as BoundExpr;
+use crate::expr::BoundExpression;
 use crate::expr::bound::and;
 use crate::expr::bound::and_collect;
 use crate::expr::bound::binary;
@@ -70,7 +70,7 @@ pub(crate) fn register_builtins(session: &StatsSession) {
     session.register_rewrite(DynamicComparisonAllNonNanStatsRewrite);
 }
 
-fn row_count() -> BoundExpr {
+fn row_count() -> BoundExpression {
     RowCount
         .try_new_bound_expr(EmptyOptions, [])
         .vortex_expect("row-count expressions are always well-typed")
@@ -86,9 +86,9 @@ impl StatsRewriteRule for BinaryNanCountStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         binary_falsify::<NanCountProof>(expr, ctx)
     }
 }
@@ -103,17 +103,17 @@ impl StatsRewriteRule for BinaryAllNonNanStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         binary_falsify::<AllNonNanProof>(expr, ctx)
     }
 }
 
 fn binary_falsify<P: NonNanProof>(
-    expr: &BoundExpr,
+    expr: &BoundExpression,
     ctx: &StatsRewriteCtx<'_>,
-) -> VortexResult<Option<BoundExpr>> {
+) -> VortexResult<Option<BoundExpression>> {
     let operator = expr.as_::<Binary>();
     let lhs = expr.child(0);
     let rhs = expr.child(1);
@@ -186,9 +186,9 @@ impl StatsRewriteRule for BetweenStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         let options = expr.as_::<Between>();
         let arr = expr.child(0).clone();
         let lower = expr.child(1).clone();
@@ -210,17 +210,17 @@ impl StatsRewriteRule for IsNullNullCountStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         Ok(null_count(expr.child(0), ctx).map(|null_count| eq(null_count, lit(0u64))))
     }
 
     fn satisfy(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         Ok(null_count(expr.child(0), ctx).map(|null_count| eq(null_count, row_count())))
     }
 }
@@ -235,9 +235,9 @@ impl StatsRewriteRule for IsNullAllNonNullStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         _ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         Ok(Some(all_non_null(expr.child(0))))
     }
 }
@@ -252,9 +252,9 @@ impl StatsRewriteRule for IsNullAllNullStatsRewrite {
 
     fn satisfy(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         _ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         Ok(Some(all_null(expr.child(0))))
     }
 }
@@ -269,17 +269,17 @@ impl StatsRewriteRule for IsNotNullNullCountStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         Ok(null_count(expr.child(0), ctx).map(|null_count| eq(null_count, row_count())))
     }
 
     fn satisfy(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         Ok(null_count(expr.child(0), ctx).map(|null_count| eq(null_count, lit(0u64))))
     }
 }
@@ -294,9 +294,9 @@ impl StatsRewriteRule for IsNotNullAllNullStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         _ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         Ok(Some(all_null(expr.child(0))))
     }
 }
@@ -311,9 +311,9 @@ impl StatsRewriteRule for IsNotNullAllNonNullStatsRewrite {
 
     fn satisfy(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         _ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         Ok(Some(all_non_null(expr.child(0))))
     }
 }
@@ -328,9 +328,9 @@ impl StatsRewriteRule for LikeStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         let like_options = expr.as_::<Like>();
         if like_options.negated || like_options.case_insensitive {
             return Ok(None);
@@ -383,9 +383,9 @@ impl StatsRewriteRule for ListContainsNanCountStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         list_contains_falsify::<NanCountProof>(expr, ctx)
     }
 }
@@ -400,17 +400,17 @@ impl StatsRewriteRule for ListContainsAllNonNanStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         list_contains_falsify::<AllNonNanProof>(expr, ctx)
     }
 }
 
 fn list_contains_falsify<P: NonNanProof>(
-    expr: &BoundExpr,
+    expr: &BoundExpression,
     ctx: &StatsRewriteCtx<'_>,
-) -> VortexResult<Option<BoundExpr>> {
+) -> VortexResult<Option<BoundExpression>> {
     let list = expr.child(0);
     let needle = expr.child(1);
 
@@ -457,9 +457,9 @@ impl StatsRewriteRule for DynamicComparisonNanCountStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         dynamic_comparison_falsify::<NanCountProof>(expr, ctx)
     }
 }
@@ -474,17 +474,17 @@ impl StatsRewriteRule for DynamicComparisonAllNonNanStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         dynamic_comparison_falsify::<AllNonNanProof>(expr, ctx)
     }
 }
 
 fn dynamic_comparison_falsify<P: NonNanProof>(
-    expr: &BoundExpr,
+    expr: &BoundExpression,
     ctx: &StatsRewriteCtx<'_>,
-) -> VortexResult<Option<BoundExpr>> {
+) -> VortexResult<Option<BoundExpression>> {
     let dynamic = expr.as_::<DynamicComparison>();
     let lhs = expr.child(0);
 
@@ -509,36 +509,36 @@ fn dynamic_comparison_falsify<P: NonNanProof>(
     with_non_nan_guards::<P>(ctx, [lhs], value_predicate)
 }
 
-fn min(expr: &BoundExpr, ctx: &StatsRewriteCtx<'_>) -> Option<BoundExpr> {
+fn min(expr: &BoundExpression, ctx: &StatsRewriteCtx<'_>) -> Option<BoundExpression> {
     stat_expr(expr, Stat::Min, ctx)
 }
 
-fn max(expr: &BoundExpr, ctx: &StatsRewriteCtx<'_>) -> Option<BoundExpr> {
+fn max(expr: &BoundExpression, ctx: &StatsRewriteCtx<'_>) -> Option<BoundExpression> {
     stat_expr(expr, Stat::Max, ctx)
 }
 
-fn null_count(expr: &BoundExpr, ctx: &StatsRewriteCtx<'_>) -> Option<BoundExpr> {
+fn null_count(expr: &BoundExpression, ctx: &StatsRewriteCtx<'_>) -> Option<BoundExpression> {
     stat_expr(expr, Stat::NullCount, ctx)
 }
 
-fn all_null(expr: &BoundExpr) -> BoundExpr {
+fn all_null(expr: &BoundExpression) -> BoundExpression {
     stat_fn(expr.clone(), AllNull.bind(AggregateEmptyOptions))
 }
 
-fn all_non_null(expr: &BoundExpr) -> BoundExpr {
+fn all_non_null(expr: &BoundExpression) -> BoundExpression {
     stat_fn(expr.clone(), AllNonNull.bind(AggregateEmptyOptions))
 }
 
 enum NanCheck {
     NotNeeded,
-    Check(BoundExpr),
+    Check(BoundExpression),
     Unavailable,
 }
 
 trait NonNanProof {
     const EMIT_UNGUARDED_REWRITES: bool;
 
-    fn check(ctx: &StatsRewriteCtx<'_>, expr: &BoundExpr) -> VortexResult<NanCheck>;
+    fn check(ctx: &StatsRewriteCtx<'_>, expr: &BoundExpression) -> VortexResult<NanCheck>;
 }
 
 struct NanCountProof;
@@ -546,7 +546,7 @@ struct NanCountProof;
 impl NonNanProof for NanCountProof {
     const EMIT_UNGUARDED_REWRITES: bool = true;
 
-    fn check(ctx: &StatsRewriteCtx<'_>, expr: &BoundExpr) -> VortexResult<NanCheck> {
+    fn check(ctx: &StatsRewriteCtx<'_>, expr: &BoundExpression) -> VortexResult<NanCheck> {
         non_nan_check(ctx, expr, |expr| {
             match stat_expr(expr, Stat::NaNCount, ctx) {
                 Some(nan_count) => NanCheck::Check(eq(nan_count, lit(0u64))),
@@ -561,7 +561,7 @@ struct AllNonNanProof;
 impl NonNanProof for AllNonNanProof {
     const EMIT_UNGUARDED_REWRITES: bool = false;
 
-    fn check(ctx: &StatsRewriteCtx<'_>, expr: &BoundExpr) -> VortexResult<NanCheck> {
+    fn check(ctx: &StatsRewriteCtx<'_>, expr: &BoundExpression) -> VortexResult<NanCheck> {
         non_nan_check(ctx, expr, |expr| {
             NanCheck::Check(stat_fn(expr.clone(), AllNonNan.bind(AggregateEmptyOptions)))
         })
@@ -573,8 +573,8 @@ impl NonNanProof for AllNonNanProof {
 // from float to non-float still needs a proof about the float source values.
 fn non_nan_check(
     ctx: &StatsRewriteCtx<'_>,
-    expr: &BoundExpr,
-    proof: impl FnOnce(&BoundExpr) -> NanCheck,
+    expr: &BoundExpression,
+    proof: impl FnOnce(&BoundExpression) -> NanCheck,
 ) -> VortexResult<NanCheck> {
     if let Some(scalar) = expr.as_opt::<Literal>() {
         if !scalar.dtype().is_float() {
@@ -606,7 +606,11 @@ fn has_nans(dtype: &DType) -> bool {
     dtype.is_float()
 }
 
-fn stat_expr(expr: &BoundExpr, stat: Stat, ctx: &StatsRewriteCtx<'_>) -> Option<BoundExpr> {
+fn stat_expr(
+    expr: &BoundExpression,
+    stat: Stat,
+    ctx: &StatsRewriteCtx<'_>,
+) -> Option<BoundExpression> {
     if let Some(literal) = literal_stat(expr, stat) {
         return Some(literal);
     }
@@ -635,9 +639,9 @@ fn stat_expr(expr: &BoundExpr, stat: Stat, ctx: &StatsRewriteCtx<'_>) -> Option<
 
 fn with_non_nan_guards<'a, P: NonNanProof>(
     ctx: &StatsRewriteCtx<'_>,
-    exprs: impl IntoIterator<Item = &'a BoundExpr>,
-    value_predicate: BoundExpr,
-) -> VortexResult<Option<BoundExpr>> {
+    exprs: impl IntoIterator<Item = &'a BoundExpression>,
+    value_predicate: BoundExpression,
+) -> VortexResult<Option<BoundExpression>> {
     let mut nan_checks = Vec::new();
     for expr in exprs {
         match P::check(ctx, expr)? {
@@ -658,7 +662,7 @@ fn with_non_nan_guards<'a, P: NonNanProof>(
     })
 }
 
-fn literal_stat(expr: &BoundExpr, stat: Stat) -> Option<BoundExpr> {
+fn literal_stat(expr: &BoundExpression, stat: Stat) -> Option<BoundExpression> {
     let scalar = expr.as_opt::<Literal>()?;
     match stat {
         Stat::Min | Stat::Max => Some(lit(scalar.clone())),
@@ -680,11 +684,11 @@ fn literal_stat(expr: &BoundExpr, stat: Stat) -> Option<BoundExpr> {
 }
 
 fn cast_stat(
-    expr: &BoundExpr,
+    expr: &BoundExpression,
     dtype: &DType,
     stat: Stat,
     ctx: &StatsRewriteCtx<'_>,
-) -> Option<BoundExpr> {
+) -> Option<BoundExpression> {
     match stat {
         Stat::Min | Stat::Max => stat_expr(expr, stat, ctx).map(|stat| cast(stat, dtype.clone())),
         Stat::NaNCount | Stat::Sum | Stat::UncompressedSizeInBytes => stat_expr(expr, stat, ctx),
@@ -692,7 +696,7 @@ fn cast_stat(
     }
 }
 
-fn stat_fn(expr: BoundExpr, aggregate_fn: AggregateFnRef) -> BoundExpr {
+fn stat_fn(expr: BoundExpression, aggregate_fn: AggregateFnRef) -> BoundExpression {
     stat(expr, aggregate_fn)
 }
 
@@ -713,7 +717,7 @@ mod tests {
     use crate::dtype::PType;
     use crate::dtype::StructFields;
     use crate::expr::BoundExpression;
-    use crate::expr::Expression as BoundExpr;
+    use crate::expr::Expression;
     use crate::expr::and;
     use crate::expr::between;
     use crate::expr::cast;
@@ -745,12 +749,12 @@ mod tests {
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
-    fn stat(expr: BoundExpr, stat: Stat) -> BoundExpr {
+    fn stat(expr: Expression, stat: Stat) -> Expression {
         let aggregate_fn = stat.aggregate_fn().expect("stat should have aggregate fn");
         stat_fn(expr, aggregate_fn)
     }
 
-    fn stat_fn(expr: BoundExpr, aggregate_fn: AggregateFnRef) -> BoundExpr {
+    fn stat_fn(expr: Expression, aggregate_fn: AggregateFnRef) -> Expression {
         StatFn.new_expr(StatOptions::new(aggregate_fn), [expr])
     }
 
@@ -775,23 +779,23 @@ mod tests {
         )
     }
 
-    fn falsify(expr: &BoundExpr) -> VortexResult<Option<BoundExpression>> {
+    fn falsify(expr: &Expression) -> VortexResult<Option<BoundExpression>> {
         expr.bind(&test_scope())?.falsify(&SESSION)
     }
 
-    fn satisfy(expr: &BoundExpr) -> VortexResult<Option<BoundExpression>> {
+    fn satisfy(expr: &Expression) -> VortexResult<Option<BoundExpression>> {
         expr.bind(&test_scope())?.satisfy(&SESSION)
     }
 
-    fn bind_expected(expr: Option<BoundExpr>) -> VortexResult<Option<BoundExpression>> {
+    fn bind_expected(expr: Option<Expression>) -> VortexResult<Option<BoundExpression>> {
         expr.map(|expr| expr.bind(&test_scope())).transpose()
     }
 
-    fn all_null(expr: &BoundExpr) -> BoundExpr {
+    fn all_null(expr: &Expression) -> Expression {
         crate::stats::all_null(expr.clone())
     }
 
-    fn all_non_null(expr: &BoundExpr) -> BoundExpr {
+    fn all_non_null(expr: &Expression) -> Expression {
         crate::stats::all_non_null(expr.clone())
     }
 
@@ -801,7 +805,7 @@ mod tests {
         };
     }
 
-    fn nan_guarded(expr: BoundExpr, value_predicate: BoundExpr) -> BoundExpr {
+    fn nan_guarded(expr: Expression, value_predicate: Expression) -> Expression {
         or(
             and(
                 eq(stat(expr.clone(), Stat::NaNCount), lit(0u64)),

--- a/vortex-array/src/stats/rewrite/builtins.rs
+++ b/vortex-array/src/stats/rewrite/builtins.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
-use vortex_utils::iter::ReduceBalancedIterExt;
 
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnVTableExt;
@@ -15,8 +14,20 @@ use crate::aggregate_fn::fns::all_non_null::AllNonNull;
 use crate::aggregate_fn::fns::all_null::AllNull;
 use crate::dtype::DType;
 use crate::expr::BoundExpression as BoundExpr;
+use crate::expr::bound::and;
+use crate::expr::bound::and_collect;
+use crate::expr::bound::binary;
+use crate::expr::bound::cast;
+use crate::expr::bound::dynamic_with_options;
+use crate::expr::bound::eq;
+use crate::expr::bound::gt;
+use crate::expr::bound::gt_eq;
+use crate::expr::bound::lit;
+use crate::expr::bound::lt;
+use crate::expr::bound::lt_eq;
+use crate::expr::bound::or;
+use crate::expr::bound::or_collect;
 use crate::expr::stats::Stat;
-use crate::scalar::Scalar;
 use crate::scalar::StringLike;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ScalarFnId;
@@ -36,8 +47,7 @@ use crate::scalar_fn::fns::literal::Literal;
 use crate::scalar_fn::fns::operators::CompareOperator;
 use crate::scalar_fn::fns::operators::Operator;
 use crate::scalar_fn::internal::row_count::RowCount;
-use crate::stats::expr::StatFn;
-use crate::stats::expr::StatOptions;
+use crate::stats::bound::stat;
 use crate::stats::rewrite::StatsRewriteCtx;
 use crate::stats::rewrite::StatsRewriteRule;
 use crate::stats::session::StatsSession;
@@ -58,59 +68,6 @@ pub(crate) fn register_builtins(session: &StatsSession) {
     session.register_rewrite(ListContainsAllNonNanStatsRewrite);
     session.register_rewrite(DynamicComparisonNanCountStatsRewrite);
     session.register_rewrite(DynamicComparisonAllNonNanStatsRewrite);
-}
-
-fn binary(operator: Operator, lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
-    Binary
-        .try_new_bound_expr(operator, [lhs, rhs])
-        .vortex_expect("stats rewrites must construct well-typed binary expressions")
-}
-
-fn and(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
-    binary(Operator::And, lhs, rhs)
-}
-
-fn or(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
-    binary(Operator::Or, lhs, rhs)
-}
-
-fn eq(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
-    binary(Operator::Eq, lhs, rhs)
-}
-
-fn gt(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
-    binary(Operator::Gt, lhs, rhs)
-}
-
-fn gt_eq(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
-    binary(Operator::Gte, lhs, rhs)
-}
-
-fn lt(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
-    binary(Operator::Lt, lhs, rhs)
-}
-
-fn lt_eq(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
-    binary(Operator::Lte, lhs, rhs)
-}
-
-fn and_collect(exprs: impl IntoIterator<Item = BoundExpr>) -> Option<BoundExpr> {
-    exprs.into_iter().reduce_balanced(and)
-}
-
-fn or_collect(exprs: impl IntoIterator<Item = BoundExpr>) -> Option<BoundExpr> {
-    exprs.into_iter().reduce_balanced(or)
-}
-
-fn lit(value: impl Into<Scalar>) -> BoundExpr {
-    Literal
-        .try_new_bound_expr(value.into(), [])
-        .vortex_expect("literal expressions are always well-typed")
-}
-
-fn cast(expr: BoundExpr, dtype: DType) -> BoundExpr {
-    Cast.try_new_bound_expr(dtype, [expr])
-        .vortex_expect("stats rewrites only preserve casts from a bound predicate")
 }
 
 fn row_count() -> BoundExpr {
@@ -541,16 +498,14 @@ fn dynamic_comparison_falsify<P: NonNanProof>(
         return Ok(None);
     };
 
-    let value_predicate = DynamicComparison
-        .try_new_bound_expr(
-            DynamicComparisonExpr {
-                operator,
-                rhs: Arc::clone(&dynamic.rhs),
-                default: !dynamic.default,
-            },
-            [lhs_stat],
-        )
-        .vortex_expect("a rewritten dynamic comparison preserves its bound input type");
+    let value_predicate = dynamic_with_options(
+        DynamicComparisonExpr {
+            operator,
+            rhs: Arc::clone(&dynamic.rhs),
+            default: !dynamic.default,
+        },
+        lhs_stat,
+    );
     with_non_nan_guards::<P>(ctx, [lhs], value_predicate)
 }
 
@@ -738,9 +693,7 @@ fn cast_stat(
 }
 
 fn stat_fn(expr: BoundExpr, aggregate_fn: AggregateFnRef) -> BoundExpr {
-    StatFn
-        .try_new_bound_expr(StatOptions::new(aggregate_fn), [expr])
-        .vortex_expect("stats rewrites only construct supported aggregate expressions")
+    stat(expr, aggregate_fn)
 }
 
 #[cfg(test)]
@@ -751,8 +704,6 @@ mod tests {
     use vortex_error::VortexResult;
     use vortex_session::VortexSession;
 
-    use super::StatFn;
-    use super::StatOptions;
     use crate::aggregate_fn::AggregateFnRef;
     use crate::aggregate_fn::AggregateFnVTableExt;
     use crate::aggregate_fn::EmptyOptions as AggregateEmptyOptions;
@@ -789,6 +740,8 @@ mod tests {
     use crate::scalar_fn::fns::dynamic::DynamicComparisonExpr;
     use crate::scalar_fn::fns::operators::CompareOperator;
     use crate::scalar_fn::internal::row_count::RowCount;
+    use crate::stats::expr::StatFn;
+    use crate::stats::expr::StatOptions;
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 

--- a/vortex-array/src/stats/rewrite/builtins.rs
+++ b/vortex-array/src/stats/rewrite/builtins.rs
@@ -3,7 +3,9 @@
 
 use std::sync::Arc;
 
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_utils::iter::ReduceBalancedIterExt;
 
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::AggregateFnVTableExt;
@@ -12,19 +14,9 @@ use crate::aggregate_fn::fns::all_non_nan::AllNonNan;
 use crate::aggregate_fn::fns::all_non_null::AllNonNull;
 use crate::aggregate_fn::fns::all_null::AllNull;
 use crate::dtype::DType;
-use crate::expr::Expression;
-use crate::expr::and;
-use crate::expr::and_collect;
-use crate::expr::cast;
-use crate::expr::eq;
-use crate::expr::gt;
-use crate::expr::gt_eq;
-use crate::expr::lit;
-use crate::expr::lt;
-use crate::expr::lt_eq;
-use crate::expr::or;
-use crate::expr::or_collect;
+use crate::expr::BoundExpression as BoundExpr;
 use crate::expr::stats::Stat;
+use crate::scalar::Scalar;
 use crate::scalar::StringLike;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ScalarFnId;
@@ -68,6 +60,65 @@ pub(crate) fn register_builtins(session: &StatsSession) {
     session.register_rewrite(DynamicComparisonAllNonNanStatsRewrite);
 }
 
+fn binary(operator: Operator, lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
+    Binary
+        .try_new_bound_expr(operator, [lhs, rhs])
+        .vortex_expect("stats rewrites must construct well-typed binary expressions")
+}
+
+fn and(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
+    binary(Operator::And, lhs, rhs)
+}
+
+fn or(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
+    binary(Operator::Or, lhs, rhs)
+}
+
+fn eq(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
+    binary(Operator::Eq, lhs, rhs)
+}
+
+fn gt(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
+    binary(Operator::Gt, lhs, rhs)
+}
+
+fn gt_eq(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
+    binary(Operator::Gte, lhs, rhs)
+}
+
+fn lt(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
+    binary(Operator::Lt, lhs, rhs)
+}
+
+fn lt_eq(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
+    binary(Operator::Lte, lhs, rhs)
+}
+
+fn and_collect(exprs: impl IntoIterator<Item = BoundExpr>) -> Option<BoundExpr> {
+    exprs.into_iter().reduce_balanced(and)
+}
+
+fn or_collect(exprs: impl IntoIterator<Item = BoundExpr>) -> Option<BoundExpr> {
+    exprs.into_iter().reduce_balanced(or)
+}
+
+fn lit(value: impl Into<Scalar>) -> BoundExpr {
+    Literal
+        .try_new_bound_expr(value.into(), [])
+        .vortex_expect("literal expressions are always well-typed")
+}
+
+fn cast(expr: BoundExpr, dtype: DType) -> BoundExpr {
+    Cast.try_new_bound_expr(dtype, [expr])
+        .vortex_expect("stats rewrites only preserve casts from a bound predicate")
+}
+
+fn row_count() -> BoundExpr {
+    RowCount
+        .try_new_bound_expr(EmptyOptions, [])
+        .vortex_expect("row-count expressions are always well-typed")
+}
+
 #[derive(Debug)]
 struct BinaryNanCountStatsRewrite;
 
@@ -78,9 +129,9 @@ impl StatsRewriteRule for BinaryNanCountStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         binary_falsify::<NanCountProof>(expr, ctx)
     }
 }
@@ -95,17 +146,17 @@ impl StatsRewriteRule for BinaryAllNonNanStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         binary_falsify::<AllNonNanProof>(expr, ctx)
     }
 }
 
 fn binary_falsify<P: NonNanProof>(
-    expr: &Expression,
+    expr: &BoundExpr,
     ctx: &StatsRewriteCtx<'_>,
-) -> VortexResult<Option<Expression>> {
+) -> VortexResult<Option<BoundExpr>> {
     let operator = expr.as_::<Binary>();
     let lhs = expr.child(0);
     let rhs = expr.child(1);
@@ -178,16 +229,16 @@ impl StatsRewriteRule for BetweenStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         let options = expr.as_::<Between>();
         let arr = expr.child(0).clone();
         let lower = expr.child(1).clone();
         let upper = expr.child(2).clone();
 
-        let lhs = Binary.new_expr(options.lower_strict.to_operator(), [lower, arr.clone()]);
-        let rhs = Binary.new_expr(options.upper_strict.to_operator(), [arr, upper]);
+        let lhs = binary(options.lower_strict.to_operator(), lower, arr.clone());
+        let rhs = binary(options.upper_strict.to_operator(), arr, upper);
         ctx.falsify(&and(lhs, rhs))
     }
 }
@@ -202,19 +253,18 @@ impl StatsRewriteRule for IsNullNullCountStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         Ok(null_count(expr.child(0), ctx).map(|null_count| eq(null_count, lit(0u64))))
     }
 
     fn satisfy(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
-        Ok(null_count(expr.child(0), ctx)
-            .map(|null_count| eq(null_count, RowCount.new_expr(EmptyOptions, []))))
+    ) -> VortexResult<Option<BoundExpr>> {
+        Ok(null_count(expr.child(0), ctx).map(|null_count| eq(null_count, row_count())))
     }
 }
 
@@ -228,9 +278,9 @@ impl StatsRewriteRule for IsNullAllNonNullStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         _ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         Ok(Some(all_non_null(expr.child(0))))
     }
 }
@@ -245,9 +295,9 @@ impl StatsRewriteRule for IsNullAllNullStatsRewrite {
 
     fn satisfy(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         _ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         Ok(Some(all_null(expr.child(0))))
     }
 }
@@ -262,18 +312,17 @@ impl StatsRewriteRule for IsNotNullNullCountStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
-        Ok(null_count(expr.child(0), ctx)
-            .map(|null_count| eq(null_count, RowCount.new_expr(EmptyOptions, []))))
+    ) -> VortexResult<Option<BoundExpr>> {
+        Ok(null_count(expr.child(0), ctx).map(|null_count| eq(null_count, row_count())))
     }
 
     fn satisfy(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         Ok(null_count(expr.child(0), ctx).map(|null_count| eq(null_count, lit(0u64))))
     }
 }
@@ -288,9 +337,9 @@ impl StatsRewriteRule for IsNotNullAllNullStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         _ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         Ok(Some(all_null(expr.child(0))))
     }
 }
@@ -305,9 +354,9 @@ impl StatsRewriteRule for IsNotNullAllNonNullStatsRewrite {
 
     fn satisfy(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         _ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         Ok(Some(all_non_null(expr.child(0))))
     }
 }
@@ -322,9 +371,9 @@ impl StatsRewriteRule for LikeStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         let like_options = expr.as_::<Like>();
         if like_options.negated || like_options.case_insensitive {
             return Ok(None);
@@ -377,9 +426,9 @@ impl StatsRewriteRule for ListContainsNanCountStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         list_contains_falsify::<NanCountProof>(expr, ctx)
     }
 }
@@ -394,17 +443,17 @@ impl StatsRewriteRule for ListContainsAllNonNanStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         list_contains_falsify::<AllNonNanProof>(expr, ctx)
     }
 }
 
 fn list_contains_falsify<P: NonNanProof>(
-    expr: &Expression,
+    expr: &BoundExpr,
     ctx: &StatsRewriteCtx<'_>,
-) -> VortexResult<Option<Expression>> {
+) -> VortexResult<Option<BoundExpr>> {
     let list = expr.child(0);
     let needle = expr.child(1);
 
@@ -451,9 +500,9 @@ impl StatsRewriteRule for DynamicComparisonNanCountStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         dynamic_comparison_falsify::<NanCountProof>(expr, ctx)
     }
 }
@@ -468,17 +517,17 @@ impl StatsRewriteRule for DynamicComparisonAllNonNanStatsRewrite {
 
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         dynamic_comparison_falsify::<AllNonNanProof>(expr, ctx)
     }
 }
 
 fn dynamic_comparison_falsify<P: NonNanProof>(
-    expr: &Expression,
+    expr: &BoundExpr,
     ctx: &StatsRewriteCtx<'_>,
-) -> VortexResult<Option<Expression>> {
+) -> VortexResult<Option<BoundExpr>> {
     let dynamic = expr.as_::<DynamicComparison>();
     let lhs = expr.child(0);
 
@@ -492,47 +541,49 @@ fn dynamic_comparison_falsify<P: NonNanProof>(
         return Ok(None);
     };
 
-    let value_predicate = DynamicComparison.new_expr(
-        DynamicComparisonExpr {
-            operator,
-            rhs: Arc::clone(&dynamic.rhs),
-            default: !dynamic.default,
-        },
-        [lhs_stat],
-    );
+    let value_predicate = DynamicComparison
+        .try_new_bound_expr(
+            DynamicComparisonExpr {
+                operator,
+                rhs: Arc::clone(&dynamic.rhs),
+                default: !dynamic.default,
+            },
+            [lhs_stat],
+        )
+        .vortex_expect("a rewritten dynamic comparison preserves its bound input type");
     with_non_nan_guards::<P>(ctx, [lhs], value_predicate)
 }
 
-fn min(expr: &Expression, ctx: &StatsRewriteCtx<'_>) -> Option<Expression> {
+fn min(expr: &BoundExpr, ctx: &StatsRewriteCtx<'_>) -> Option<BoundExpr> {
     stat_expr(expr, Stat::Min, ctx)
 }
 
-fn max(expr: &Expression, ctx: &StatsRewriteCtx<'_>) -> Option<Expression> {
+fn max(expr: &BoundExpr, ctx: &StatsRewriteCtx<'_>) -> Option<BoundExpr> {
     stat_expr(expr, Stat::Max, ctx)
 }
 
-fn null_count(expr: &Expression, ctx: &StatsRewriteCtx<'_>) -> Option<Expression> {
+fn null_count(expr: &BoundExpr, ctx: &StatsRewriteCtx<'_>) -> Option<BoundExpr> {
     stat_expr(expr, Stat::NullCount, ctx)
 }
 
-fn all_null(expr: &Expression) -> Expression {
+fn all_null(expr: &BoundExpr) -> BoundExpr {
     stat_fn(expr.clone(), AllNull.bind(AggregateEmptyOptions))
 }
 
-fn all_non_null(expr: &Expression) -> Expression {
+fn all_non_null(expr: &BoundExpr) -> BoundExpr {
     stat_fn(expr.clone(), AllNonNull.bind(AggregateEmptyOptions))
 }
 
 enum NanCheck {
     NotNeeded,
-    Check(Expression),
+    Check(BoundExpr),
     Unavailable,
 }
 
 trait NonNanProof {
     const EMIT_UNGUARDED_REWRITES: bool;
 
-    fn check(ctx: &StatsRewriteCtx<'_>, expr: &Expression) -> VortexResult<NanCheck>;
+    fn check(ctx: &StatsRewriteCtx<'_>, expr: &BoundExpr) -> VortexResult<NanCheck>;
 }
 
 struct NanCountProof;
@@ -540,7 +591,7 @@ struct NanCountProof;
 impl NonNanProof for NanCountProof {
     const EMIT_UNGUARDED_REWRITES: bool = true;
 
-    fn check(ctx: &StatsRewriteCtx<'_>, expr: &Expression) -> VortexResult<NanCheck> {
+    fn check(ctx: &StatsRewriteCtx<'_>, expr: &BoundExpr) -> VortexResult<NanCheck> {
         non_nan_check(ctx, expr, |expr| {
             match stat_expr(expr, Stat::NaNCount, ctx) {
                 Some(nan_count) => NanCheck::Check(eq(nan_count, lit(0u64))),
@@ -555,7 +606,7 @@ struct AllNonNanProof;
 impl NonNanProof for AllNonNanProof {
     const EMIT_UNGUARDED_REWRITES: bool = false;
 
-    fn check(ctx: &StatsRewriteCtx<'_>, expr: &Expression) -> VortexResult<NanCheck> {
+    fn check(ctx: &StatsRewriteCtx<'_>, expr: &BoundExpr) -> VortexResult<NanCheck> {
         non_nan_check(ctx, expr, |expr| {
             NanCheck::Check(stat_fn(expr.clone(), AllNonNan.bind(AggregateEmptyOptions)))
         })
@@ -567,8 +618,8 @@ impl NonNanProof for AllNonNanProof {
 // from float to non-float still needs a proof about the float source values.
 fn non_nan_check(
     ctx: &StatsRewriteCtx<'_>,
-    expr: &Expression,
-    proof: impl FnOnce(&Expression) -> NanCheck,
+    expr: &BoundExpr,
+    proof: impl FnOnce(&BoundExpr) -> NanCheck,
 ) -> VortexResult<NanCheck> {
     if let Some(scalar) = expr.as_opt::<Literal>() {
         if !scalar.dtype().is_float() {
@@ -600,7 +651,7 @@ fn has_nans(dtype: &DType) -> bool {
     dtype.is_float()
 }
 
-fn stat_expr(expr: &Expression, stat: Stat, ctx: &StatsRewriteCtx<'_>) -> Option<Expression> {
+fn stat_expr(expr: &BoundExpr, stat: Stat, ctx: &StatsRewriteCtx<'_>) -> Option<BoundExpr> {
     if let Some(literal) = literal_stat(expr, stat) {
         return Some(literal);
     }
@@ -629,9 +680,9 @@ fn stat_expr(expr: &Expression, stat: Stat, ctx: &StatsRewriteCtx<'_>) -> Option
 
 fn with_non_nan_guards<'a, P: NonNanProof>(
     ctx: &StatsRewriteCtx<'_>,
-    exprs: impl IntoIterator<Item = &'a Expression>,
-    value_predicate: Expression,
-) -> VortexResult<Option<Expression>> {
+    exprs: impl IntoIterator<Item = &'a BoundExpr>,
+    value_predicate: BoundExpr,
+) -> VortexResult<Option<BoundExpr>> {
     let mut nan_checks = Vec::new();
     for expr in exprs {
         match P::check(ctx, expr)? {
@@ -652,7 +703,7 @@ fn with_non_nan_guards<'a, P: NonNanProof>(
     })
 }
 
-fn literal_stat(expr: &Expression, stat: Stat) -> Option<Expression> {
+fn literal_stat(expr: &BoundExpr, stat: Stat) -> Option<BoundExpr> {
     let scalar = expr.as_opt::<Literal>()?;
     match stat {
         Stat::Min | Stat::Max => Some(lit(scalar.clone())),
@@ -674,11 +725,11 @@ fn literal_stat(expr: &Expression, stat: Stat) -> Option<Expression> {
 }
 
 fn cast_stat(
-    expr: &Expression,
+    expr: &BoundExpr,
     dtype: &DType,
     stat: Stat,
     ctx: &StatsRewriteCtx<'_>,
-) -> Option<Expression> {
+) -> Option<BoundExpr> {
     match stat {
         Stat::Min | Stat::Max => stat_expr(expr, stat, ctx).map(|stat| cast(stat, dtype.clone())),
         Stat::NaNCount | Stat::Sum | Stat::UncompressedSizeInBytes => stat_expr(expr, stat, ctx),
@@ -686,8 +737,10 @@ fn cast_stat(
     }
 }
 
-fn stat_fn(expr: Expression, aggregate_fn: AggregateFnRef) -> Expression {
-    StatFn.new_expr(StatOptions::new(aggregate_fn), [expr])
+fn stat_fn(expr: BoundExpr, aggregate_fn: AggregateFnRef) -> BoundExpr {
+    StatFn
+        .try_new_bound_expr(StatOptions::new(aggregate_fn), [expr])
+        .vortex_expect("stats rewrites only construct supported aggregate expressions")
 }
 
 #[cfg(test)]
@@ -700,8 +753,6 @@ mod tests {
 
     use super::StatFn;
     use super::StatOptions;
-    use super::all_non_null;
-    use super::all_null;
     use crate::aggregate_fn::AggregateFnRef;
     use crate::aggregate_fn::AggregateFnVTableExt;
     use crate::aggregate_fn::EmptyOptions as AggregateEmptyOptions;
@@ -710,7 +761,8 @@ mod tests {
     use crate::dtype::Nullability;
     use crate::dtype::PType;
     use crate::dtype::StructFields;
-    use crate::expr::Expression;
+    use crate::expr::BoundExpression;
+    use crate::expr::Expression as BoundExpr;
     use crate::expr::and;
     use crate::expr::between;
     use crate::expr::cast;
@@ -740,12 +792,12 @@ mod tests {
 
     static SESSION: LazyLock<VortexSession> = LazyLock::new(crate::array_session);
 
-    fn stat(expr: Expression, stat: Stat) -> Expression {
+    fn stat(expr: BoundExpr, stat: Stat) -> BoundExpr {
         let aggregate_fn = stat.aggregate_fn().expect("stat should have aggregate fn");
         stat_fn(expr, aggregate_fn)
     }
 
-    fn stat_fn(expr: Expression, aggregate_fn: AggregateFnRef) -> Expression {
+    fn stat_fn(expr: BoundExpr, aggregate_fn: AggregateFnRef) -> BoundExpr {
         StatFn.new_expr(StatOptions::new(aggregate_fn), [expr])
     }
 
@@ -770,15 +822,33 @@ mod tests {
         )
     }
 
-    fn falsify(expr: &Expression) -> VortexResult<Option<Expression>> {
-        expr.falsify(&test_scope(), &SESSION)
+    fn falsify(expr: &BoundExpr) -> VortexResult<Option<BoundExpression>> {
+        expr.bind(&test_scope())?.falsify(&SESSION)
     }
 
-    fn satisfy(expr: &Expression) -> VortexResult<Option<Expression>> {
-        expr.satisfy(&test_scope(), &SESSION)
+    fn satisfy(expr: &BoundExpr) -> VortexResult<Option<BoundExpression>> {
+        expr.bind(&test_scope())?.satisfy(&SESSION)
     }
 
-    fn nan_guarded(expr: Expression, value_predicate: Expression) -> Expression {
+    fn bind_expected(expr: Option<BoundExpr>) -> VortexResult<Option<BoundExpression>> {
+        expr.map(|expr| expr.bind(&test_scope())).transpose()
+    }
+
+    fn all_null(expr: &BoundExpr) -> BoundExpr {
+        crate::stats::all_null(expr.clone())
+    }
+
+    fn all_non_null(expr: &BoundExpr) -> BoundExpr {
+        crate::stats::all_non_null(expr.clone())
+    }
+
+    macro_rules! assert_rewrite_eq {
+        ($actual:expr, $expected:expr) => {
+            assert_eq!($actual, bind_expected($expected)?)
+        };
+    }
+
+    fn nan_guarded(expr: BoundExpr, value_predicate: BoundExpr) -> BoundExpr {
         or(
             and(
                 eq(stat(expr.clone(), Stat::NaNCount), lit(0u64)),
@@ -794,13 +864,13 @@ mod tests {
     #[test]
     fn rewrites_comparison_falsifier() -> VortexResult<()> {
         let expr = gt(col("a"), lit(10));
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&expr)?,
             Some(lt_eq(stat(col("a"), Stat::Max), lit(10)))
         );
 
         let expr = eq(col("a"), col("b"));
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&expr)?,
             Some(or(
                 gt(stat(col("a"), Stat::Min), stat(col("b"), Stat::Max)),
@@ -809,7 +879,7 @@ mod tests {
         );
 
         let expr = eq(col("s"), col("t"));
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&expr)?,
             Some(or(
                 gt(stat(col("s"), Stat::Min), stat(col("t"), Stat::Max)),
@@ -822,7 +892,7 @@ mod tests {
     #[test]
     fn rewrites_boolean_falsifiers() -> VortexResult<()> {
         let expr = and(gt(col("a"), lit(10)), lt(col("a"), lit(50)));
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&expr)?,
             Some(or(
                 lt_eq(stat(col("a"), Stat::Max), lit(10)),
@@ -844,7 +914,7 @@ mod tests {
             },
         );
 
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&expr)?,
             Some(or(
                 gt(lit(10), stat(col("a"), Stat::Max)),
@@ -856,7 +926,7 @@ mod tests {
 
     #[test]
     fn rewrites_null_falsifiers() -> VortexResult<()> {
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&is_null(col("a")))?,
             Some(or(
                 eq(stat(col("a"), Stat::NullCount), lit(0u64)),
@@ -864,7 +934,7 @@ mod tests {
             ))
         );
 
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&is_not_null(col("a")))?,
             Some(or(
                 eq(
@@ -879,7 +949,7 @@ mod tests {
 
     #[test]
     fn rewrites_null_satisfiers() -> VortexResult<()> {
-        assert_eq!(
+        assert_rewrite_eq!(
             satisfy(&is_null(col("a")))?,
             Some(or(
                 eq(
@@ -890,7 +960,7 @@ mod tests {
             ))
         );
 
-        assert_eq!(
+        assert_rewrite_eq!(
             satisfy(&is_not_null(col("a")))?,
             Some(or(
                 eq(stat(col("a"), Stat::NullCount), lit(0u64)),
@@ -909,7 +979,7 @@ mod tests {
         );
         let expr = list_contains(lit(list), col("a"));
 
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&expr)?,
             Some(and(
                 and(
@@ -934,7 +1004,7 @@ mod tests {
     #[test]
     fn rewrites_like_falsifier() -> VortexResult<()> {
         let expr = like(col("s"), lit("prefix%"));
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&expr)?,
             Some(or(
                 gt_eq(stat(col("s"), Stat::Min), lit("prefiy")),
@@ -943,7 +1013,7 @@ mod tests {
         );
 
         let expr = like(col("s"), lit(r"\%%"));
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&expr)?,
             Some(or(
                 gt_eq(stat(col("s"), Stat::Min), lit("&")),
@@ -952,7 +1022,7 @@ mod tests {
         );
 
         let expr = like(col("s"), lit("pref%ix%"));
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&expr)?,
             Some(or(
                 gt_eq(stat(col("s"), Stat::Min), lit("preg")),
@@ -961,7 +1031,7 @@ mod tests {
         );
 
         let expr = like(col("s"), lit("pref_ix_"));
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&expr)?,
             Some(or(
                 gt_eq(stat(col("s"), Stat::Min), lit("preg")),
@@ -970,7 +1040,7 @@ mod tests {
         );
 
         let expr = like(col("s"), lit("exact"));
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&expr)?,
             Some(or(
                 gt(stat(col("s"), Stat::Min), lit("exact")),
@@ -979,7 +1049,7 @@ mod tests {
         );
 
         let expr = like(col("s"), lit("%suffix"));
-        assert_eq!(falsify(&expr)?, None);
+        assert_rewrite_eq!(falsify(&expr)?, None);
         Ok(())
     }
 
@@ -994,7 +1064,7 @@ mod tests {
         );
         let dynamic = expr.as_::<DynamicComparison>();
 
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&expr)?,
             Some(DynamicComparison.new_expr(
                 DynamicComparisonExpr {
@@ -1013,7 +1083,7 @@ mod tests {
         let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
         let expr = gt(cast(col("f"), dtype.clone()), lit(5i32));
 
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&expr)?,
             Some(nan_guarded(
                 col("f"),
@@ -1031,8 +1101,8 @@ mod tests {
             nested_struct_dtype(),
             vec![Scalar::primitive(1.0f32, Nullability::Nullable)],
         );
-        assert_eq!(falsify(&lt_eq(col("n"), lit(struct_scalar.clone())))?, None);
-        assert_eq!(falsify(&eq(col("n"), lit(struct_scalar)))?, None);
+        assert_rewrite_eq!(falsify(&lt_eq(col("n"), lit(struct_scalar.clone())))?, None);
+        assert_rewrite_eq!(falsify(&eq(col("n"), lit(struct_scalar)))?, None);
         Ok(())
     }
 
@@ -1041,7 +1111,7 @@ mod tests {
         let dtype = DType::Primitive(PType::I64, Nullability::NonNullable);
         let expr = eq(cast(col("a"), dtype.clone()), lit(42i64));
 
-        assert_eq!(
+        assert_rewrite_eq!(
             falsify(&expr)?,
             Some(or(
                 gt(cast(stat(col("a"), Stat::Min), dtype.clone()), lit(42i64)),

--- a/vortex-bench/src/datasets/tpch_l_comment.rs
+++ b/vortex-bench/src/datasets/tpch_l_comment.rs
@@ -16,7 +16,6 @@ use vortex::dtype::Nullability::NonNullable;
 use vortex::expr::col;
 use vortex::expr::pack;
 use vortex::file::OpenOptionsSessionExt;
-use vortex::layout::scan::scan_builder::optimize_and_bind;
 
 use crate::Format;
 use crate::IdempotentPath;
@@ -67,10 +66,9 @@ impl Dataset for TPCHLCommentChunked {
 
         let path = data_dir.join("lineitem.vortex");
         let file = SESSION.open_options().open_path(path).await?;
-        let projection = optimize_and_bind(
-            pack(vec![("l_comment", col("l_comment"))], NonNullable),
-            file.dtype(),
-        )?;
+        let projection = pack(vec![("l_comment", col("l_comment"))], NonNullable)
+            .optimize_recursive(file.dtype())?
+            .bind(file.dtype())?;
         let chunks: Vec<_> = file
             .scan()?
             .with_projection(projection)

--- a/vortex-bench/src/datasets/tpch_l_comment.rs
+++ b/vortex-bench/src/datasets/tpch_l_comment.rs
@@ -16,6 +16,7 @@ use vortex::dtype::Nullability::NonNullable;
 use vortex::expr::col;
 use vortex::expr::pack;
 use vortex::file::OpenOptionsSessionExt;
+use vortex::layout::scan::scan_builder::optimize_and_bind;
 
 use crate::Format;
 use crate::IdempotentPath;
@@ -66,9 +67,13 @@ impl Dataset for TPCHLCommentChunked {
 
         let path = data_dir.join("lineitem.vortex");
         let file = SESSION.open_options().open_path(path).await?;
+        let projection = optimize_and_bind(
+            pack(vec![("l_comment", col("l_comment"))], NonNullable),
+            file.dtype(),
+        )?;
         let chunks: Vec<_> = file
             .scan()?
-            .with_projection(pack(vec![("l_comment", col("l_comment"))], NonNullable))
+            .with_projection(projection)
             .map({
                 let ctx = ctx.clone();
                 move |a| {

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -46,7 +46,6 @@ use vortex::file::OpenOptionsSessionExt;
 use vortex::io::InstrumentedReadAt;
 use vortex::layout::LayoutReader;
 use vortex::layout::scan::scan_builder::ScanBuilder;
-use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex::metrics::Label;
 use vortex::metrics::MetricsRegistry;
 use vortex::session::VortexSession;
@@ -300,8 +299,10 @@ impl FileOpener for VortexOpener {
 
             // The schema of the stream returned from the vortex scan.
             // We use a reference schema for types that don't roundtrip (Dictionary, Utf8, etc.).
-            let scan_projection =
-                optimize_and_bind(scan_projection, vxf.dtype()).map_err(|_e| {
+            let scan_projection = scan_projection
+                .optimize_recursive(vxf.dtype())
+                .and_then(|projection| projection.bind(vxf.dtype()))
+                .map_err(|_e| {
                     exec_datafusion_err!("Couldn't get the dtype for the underlying Vortex scan")
                 })?;
             let scan_dtype = scan_projection.dtype().clone();
@@ -392,7 +393,7 @@ impl FileOpener for VortexOpener {
                 })
                 .transpose()?;
             let filter = filter
-                .map(|filter| optimize_and_bind(filter, vxf.dtype()))
+                .map(|filter| filter.optimize_recursive(vxf.dtype())?.bind(vxf.dtype()))
                 .transpose()
                 .map_err(|e| exec_datafusion_err!("Couldn't bind Vortex scan filter: {e}"))?;
 

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -46,6 +46,7 @@ use vortex::file::OpenOptionsSessionExt;
 use vortex::io::InstrumentedReadAt;
 use vortex::layout::LayoutReader;
 use vortex::layout::scan::scan_builder::ScanBuilder;
+use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex::metrics::Label;
 use vortex::metrics::MetricsRegistry;
 use vortex::session::VortexSession;
@@ -299,9 +300,11 @@ impl FileOpener for VortexOpener {
 
             // The schema of the stream returned from the vortex scan.
             // We use a reference schema for types that don't roundtrip (Dictionary, Utf8, etc.).
-            let scan_dtype = scan_projection.return_dtype(vxf.dtype()).map_err(|_e| {
-                exec_datafusion_err!("Couldn't get the dtype for the underlying Vortex scan")
-            })?;
+            let scan_projection =
+                optimize_and_bind(scan_projection, vxf.dtype()).map_err(|_e| {
+                    exec_datafusion_err!("Couldn't get the dtype for the underlying Vortex scan")
+                })?;
+            let scan_dtype = scan_projection.dtype().clone();
 
             // When projection pushdown is enabled, the scan outputs the projected columns.
             // When disabled, the scan outputs raw columns and the projection is applied after.
@@ -388,6 +391,10 @@ impl FileOpener for VortexOpener {
                     make_vortex_predicate(expr_convertor.as_ref(), &pushed).transpose()
                 })
                 .transpose()?;
+            let filter = filter
+                .map(|filter| optimize_and_bind(filter, vxf.dtype()))
+                .transpose()
+                .map_err(|e| exec_datafusion_err!("Couldn't bind Vortex scan filter: {e}"))?;
 
             if let Some(limit) = limit
                 && filter.is_none()

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -48,6 +48,7 @@ use vortex::file::OpenOptionsSessionExt;
 use vortex::io::InstrumentedReadAt;
 use vortex::layout::LayoutReader;
 use vortex::layout::scan::scan_builder::ScanBuilder;
+use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex::layout::scan::split_by::SplitBy;
 use vortex::metrics::Label;
 use vortex::metrics::MetricsRegistry;
@@ -302,9 +303,11 @@ impl FileOpener for VortexOpener {
 
             // The schema of the stream returned from the vortex scan.
             // We use a reference schema for types that don't roundtrip (Dictionary, Utf8, etc.).
-            let scan_dtype = scan_projection.return_dtype(vxf.dtype()).map_err(|_e| {
-                exec_datafusion_err!("Couldn't get the dtype for the underlying Vortex scan")
-            })?;
+            let scan_projection =
+                optimize_and_bind(scan_projection, vxf.dtype()).map_err(|_e| {
+                    exec_datafusion_err!("Couldn't get the dtype for the underlying Vortex scan")
+                })?;
+            let scan_dtype = scan_projection.dtype().clone();
 
             // When projection pushdown is enabled, the scan outputs the projected columns.
             // When disabled, the scan outputs raw columns and the projection is applied after.
@@ -419,6 +422,10 @@ impl FileOpener for VortexOpener {
                     make_vortex_predicate(expr_convertor.as_ref(), &pushed).transpose()
                 })
                 .transpose()?;
+            let filter = filter
+                .map(|filter| optimize_and_bind(filter, vxf.dtype()))
+                .transpose()
+                .map_err(|e| exec_datafusion_err!("Couldn't bind Vortex scan filter: {e}"))?;
 
             if let Some(limit) = limit
                 && filter.is_none()

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -48,7 +48,6 @@ use vortex::file::OpenOptionsSessionExt;
 use vortex::io::InstrumentedReadAt;
 use vortex::layout::LayoutReader;
 use vortex::layout::scan::scan_builder::ScanBuilder;
-use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex::layout::scan::split_by::SplitBy;
 use vortex::metrics::Label;
 use vortex::metrics::MetricsRegistry;
@@ -303,8 +302,10 @@ impl FileOpener for VortexOpener {
 
             // The schema of the stream returned from the vortex scan.
             // We use a reference schema for types that don't roundtrip (Dictionary, Utf8, etc.).
-            let scan_projection =
-                optimize_and_bind(scan_projection, vxf.dtype()).map_err(|_e| {
+            let scan_projection = scan_projection
+                .optimize_recursive(vxf.dtype())
+                .and_then(|projection| projection.bind(vxf.dtype()))
+                .map_err(|_e| {
                     exec_datafusion_err!("Couldn't get the dtype for the underlying Vortex scan")
                 })?;
             let scan_dtype = scan_projection.dtype().clone();
@@ -423,7 +424,7 @@ impl FileOpener for VortexOpener {
                 })
                 .transpose()?;
             let filter = filter
-                .map(|filter| optimize_and_bind(filter, vxf.dtype()))
+                .map(|filter| filter.optimize_recursive(vxf.dtype())?.bind(vxf.dtype()))
                 .transpose()
                 .map_err(|e| exec_datafusion_err!("Couldn't bind Vortex scan filter: {e}"))?;
 

--- a/vortex-file/src/file.rs
+++ b/vortex-file/src/file.rs
@@ -236,8 +236,7 @@ impl VortexFile {
         };
 
         can_prune_file_stats(
-            filter,
-            self.footer.dtype(),
+            &filter.bind(self.footer.dtype())?,
             self.footer.row_count(),
             stats,
             fields,

--- a/vortex-file/src/pruning.rs
+++ b/vortex-file/src/pruning.rs
@@ -10,11 +10,10 @@ use vortex_array::arrays::NullArray;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldPath;
 use vortex_array::dtype::StructFields;
-use vortex_array::expr::Expression;
-use vortex_array::expr::is_root;
-use vortex_array::expr::lit;
+use vortex_array::expr::BoundExpression;
 use vortex_array::expr::stats::Stat;
 use vortex_array::scalar::Scalar;
+use vortex_array::scalar_fn::ScalarFnVTableExt;
 use vortex_array::scalar_fn::fns::cast::Cast;
 use vortex_array::scalar_fn::fns::get_item::GetItem;
 use vortex_array::scalar_fn::fns::literal::Literal;
@@ -27,30 +26,27 @@ use vortex_session::VortexSession;
 use crate::FileStatistics;
 
 pub(crate) fn can_prune_file_stats(
-    expr: &Expression,
-    dtype: &DType,
+    expr: &BoundExpression,
     row_count: u64,
     file_stats: &FileStatistics,
     struct_fields: &StructFields,
     session: &VortexSession,
 ) -> VortexResult<bool> {
-    let Some(pruning_expr) = expr.falsify(dtype, session)? else {
+    let Some(pruning_expr) = expr.falsify(session)? else {
         return Ok(false);
     };
 
     let binder = FileStatsBinder {
-        dtype,
         file_stats,
         struct_fields,
     };
     let pruning_expr = bind_stats(pruning_expr, &binder)?;
 
-    let simplified = pruning_expr.optimize_recursive(&DType::Null)?;
-    if let Some(result) = simplified.as_opt::<Literal>() {
+    if let Some(result) = pruning_expr.as_opt::<Literal>() {
         return Ok(result.as_bool().value() == Some(true));
     }
 
-    let pruning = NullArray::new(1).into_array().apply(&pruning_expr)?;
+    let pruning = NullArray::new(1).into_array().apply_bound(&pruning_expr)?;
     let row_count_replacement = ConstantArray::new(row_count, pruning.len()).into_array();
     let pruning = substitute_row_count(pruning, &row_count_replacement)?;
 
@@ -65,22 +61,17 @@ pub(crate) fn can_prune_file_stats(
 }
 
 struct FileStatsBinder<'a> {
-    dtype: &'a DType,
     file_stats: &'a FileStatistics,
     struct_fields: &'a StructFields,
 }
 
 impl StatBinder for FileStatsBinder<'_> {
-    fn scope(&self) -> &DType {
-        self.dtype
-    }
-
     fn bind_aggregate(
         &self,
-        input: &Expression,
+        input: &BoundExpression,
         aggregate_fn: &AggregateFnRef,
         _stat_dtype: &DType,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         let Some(stat) = Stat::from_aggregate_fn(aggregate_fn) else {
             return Ok(None);
         };
@@ -92,7 +83,7 @@ impl StatBinder for FileStatsBinder<'_> {
 }
 
 impl FileStatsBinder<'_> {
-    fn stat_ref(&self, field_path: &FieldPath, stat: Stat) -> Option<Expression> {
+    fn stat_ref(&self, field_path: &FieldPath, stat: Stat) -> Option<BoundExpression> {
         // FileStats currently only holds top-level field statistics.
         if field_path.parts().len() != 1 {
             return None;
@@ -107,12 +98,12 @@ impl FileStatsBinder<'_> {
         let stat_dtype = stat.dtype(&field_dtype)?;
         let stat_scalar = Scalar::try_new(stat_dtype, Some(stat_value)).ok()?;
 
-        Some(lit(stat_scalar))
+        Literal.try_new_bound_expr(stat_scalar, []).ok()
     }
 }
 
-fn direct_field_path(expr: &Expression) -> Option<FieldPath> {
-    if is_root(expr) {
+fn direct_field_path(expr: &BoundExpression) -> Option<FieldPath> {
+    if expr.is_root() {
         return Some(FieldPath::root());
     }
 

--- a/vortex-file/src/pruning.rs
+++ b/vortex-file/src/pruning.rs
@@ -11,9 +11,9 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldPath;
 use vortex_array::dtype::StructFields;
 use vortex_array::expr::BoundExpression;
+use vortex_array::expr::bound::lit;
 use vortex_array::expr::stats::Stat;
 use vortex_array::scalar::Scalar;
-use vortex_array::scalar_fn::ScalarFnVTableExt;
 use vortex_array::scalar_fn::fns::cast::Cast;
 use vortex_array::scalar_fn::fns::get_item::GetItem;
 use vortex_array::scalar_fn::fns::literal::Literal;
@@ -98,7 +98,7 @@ impl FileStatsBinder<'_> {
         let stat_dtype = stat.dtype(&field_dtype)?;
         let stat_scalar = Scalar::try_new(stat_dtype, Some(stat_value)).ok()?;
 
-        Literal.try_new_bound_expr(stat_scalar, []).ok()
+        Some(lit(stat_scalar))
     }
 }
 

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -38,6 +38,8 @@ use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::dtype::PType::I32;
 use vortex_array::dtype::StructFields;
+use vortex_array::expr::BoundExpression;
+use vortex_array::expr::Expression;
 use vortex_array::expr::and;
 use vortex_array::expr::cast;
 use vortex_array::expr::col;
@@ -85,6 +87,7 @@ use vortex_layout::layouts::table::TableStrategy;
 use vortex_layout::layouts::zoned::LegacyStats;
 use vortex_layout::layouts::zoned::Zoned;
 use vortex_layout::scan::scan_builder::ScanBuilder;
+use vortex_layout::scan::scan_builder::optimize_and_bind;
 use vortex_layout::scan::split_by::SplitBy;
 use vortex_layout::session::LayoutSession;
 use vortex_scan::strict_sorted_buffer::StrictSortedBuffer;
@@ -111,6 +114,10 @@ static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
 
 fn strict_sorted(indices: Buffer<u64>) -> StrictSortedBuffer<u64> {
     StrictSortedBuffer::try_new(indices).expect("test indices should be strictly increasing")
+}
+
+fn bind_scan_expr(file: &VortexFile, expr: Expression) -> BoundExpression {
+    optimize_and_bind(expr, file.dtype()).vortex_expect("scan expression should bind")
 }
 
 #[tokio::test]
@@ -320,7 +327,7 @@ async fn test_read_projection() {
     let array = file
         .scan()
         .unwrap()
-        .with_projection(select(["strings"], root()))
+        .with_projection(bind_scan_expr(&file, select(["strings"], root())))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -346,7 +353,7 @@ async fn test_read_projection() {
     let array = file
         .scan()
         .unwrap()
-        .with_projection(select(["numbers"], root()))
+        .with_projection(bind_scan_expr(&file, select(["numbers"], root())))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -517,18 +524,19 @@ async fn issue_5385_filter_casted_column() {
         .await
         .unwrap();
 
-    let result = SESSION
-        .open_options()
-        .open_buffer(buf)
-        .unwrap()
+    let file = SESSION.open_options().open_buffer(buf).unwrap();
+    let result = file
         .scan()
         .unwrap()
-        .with_filter(eq(
-            cast(
-                get_item("x", root()),
-                DType::Primitive(PType::U16, Nullability::NonNullable),
+        .with_filter(bind_scan_expr(
+            &file,
+            eq(
+                cast(
+                    get_item("x", root()),
+                    DType::Primitive(PType::U16, Nullability::NonNullable),
+                ),
+                lit(1u16),
             ),
-            lit(1u16),
         ))
         .into_array_stream()
         .unwrap()
@@ -569,13 +577,14 @@ async fn filter_string() {
         .await
         .unwrap();
 
-    let result: Vec<_> = SESSION
-        .open_options()
-        .open_buffer(buf)
-        .unwrap()
+    let file = SESSION.open_options().open_buffer(buf).unwrap();
+    let result: Vec<_> = file
         .scan()
         .unwrap()
-        .with_filter(eq(get_item("name", root()), lit("Joseph")))
+        .with_filter(bind_scan_expr(
+            &file,
+            eq(get_item("name", root()), lit("Joseph")),
+        ))
         .into_array_stream()
         .unwrap()
         .try_collect()
@@ -629,17 +638,18 @@ async fn filter_or() {
         .await
         .unwrap();
 
-    let result: Vec<_> = SESSION
-        .open_options()
-        .open_buffer(buf)
-        .unwrap()
+    let file = SESSION.open_options().open_buffer(buf).unwrap();
+    let result: Vec<_> = file
         .scan()
         .unwrap()
-        .with_filter(or(
-            eq(get_item("name", root()), lit("Angela")),
-            and(
-                gt_eq(get_item("age", root()), lit(20)),
-                lt_eq(get_item("age", root()), lit(30)),
+        .with_filter(bind_scan_expr(
+            &file,
+            or(
+                eq(get_item("name", root()), lit("Angela")),
+                and(
+                    gt_eq(get_item("age", root()), lit(20)),
+                    lt_eq(get_item("age", root()), lit(30)),
+                ),
             ),
         ))
         .into_array_stream()
@@ -697,15 +707,16 @@ async fn filter_and() {
         .await
         .unwrap();
 
-    let result: Vec<_> = SESSION
-        .open_options()
-        .open_buffer(buf)
-        .unwrap()
+    let file = SESSION.open_options().open_buffer(buf).unwrap();
+    let result: Vec<_> = file
         .scan()
         .unwrap()
-        .with_filter(and(
-            gt(get_item("age", root()), lit(21)),
-            lt_eq(get_item("age", root()), lit(33)),
+        .with_filter(bind_scan_expr(
+            &file,
+            and(
+                gt(get_item("age", root()), lit(21)),
+                lt_eq(get_item("age", root()), lit(33)),
+            ),
         ))
         .into_array_stream()
         .unwrap()
@@ -911,7 +922,10 @@ async fn test_with_indices_and_with_row_filter_simple() {
     let actual_kept_array = file
         .scan()
         .unwrap()
-        .with_filter(gt(get_item("numbers", root()), lit(50_i16)))
+        .with_filter(bind_scan_expr(
+            &file,
+            gt(get_item("numbers", root()), lit(50_i16)),
+        ))
         .with_row_indices(strict_sorted(Buffer::empty()))
         .into_array_stream()
         .unwrap()
@@ -929,7 +943,10 @@ async fn test_with_indices_and_with_row_filter_simple() {
     let actual_kept_array = file
         .scan()
         .unwrap()
-        .with_filter(gt(get_item("numbers", root()), lit(50_i16)))
+        .with_filter(bind_scan_expr(
+            &file,
+            gt(get_item("numbers", root()), lit(50_i16)),
+        ))
         .with_row_indices(strict_sorted(Buffer::from_iter(kept_indices)))
         .into_array_stream()
         .unwrap()
@@ -957,7 +974,10 @@ async fn test_with_indices_and_with_row_filter_simple() {
     let actual_array = file
         .scan()
         .unwrap()
-        .with_filter(gt(get_item("numbers", root()), lit(50_i16)))
+        .with_filter(bind_scan_expr(
+            &file,
+            gt(get_item("numbers", root()), lit(50_i16)),
+        ))
         .with_row_indices(strict_sorted((0..500).collect::<Buffer<_>>()))
         .into_array_stream()
         .unwrap()
@@ -1019,7 +1039,10 @@ async fn filter_string_chunked() {
     let actual_array = file
         .scan()
         .unwrap()
-        .with_filter(eq(get_item("name", root()), lit("Joseph")))
+        .with_filter(bind_scan_expr(
+            &file,
+            eq(get_item("name", root()), lit("Joseph")),
+        ))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -1109,9 +1132,12 @@ async fn test_pruning_with_or() {
     let actual_array = file
         .scan()
         .unwrap()
-        .with_filter(or(
-            lt_eq(get_item("letter", root()), lit("J")),
-            lt(get_item("number", root()), lit(25)),
+        .with_filter(bind_scan_expr(
+            &file,
+            or(
+                lt_eq(get_item("letter", root()), lit("J")),
+                lt(get_item("number", root()), lit(25)),
+            ),
         ))
         .into_array_stream()
         .unwrap()
@@ -1184,7 +1210,10 @@ async fn test_repeated_projection() {
     let actual = file
         .scan()
         .unwrap()
-        .with_projection(select(["strings", "strings"], root()))
+        .with_projection(bind_scan_expr(
+            &file,
+            select(["strings", "strings"], root()),
+        ))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -1298,7 +1327,7 @@ async fn write_nullable_top_level_struct() {
 
 async fn round_trip(
     array: &ArrayRef,
-    f: impl Fn(ScanBuilder<ArrayRef>) -> VortexResult<ScanBuilder<ArrayRef>>,
+    f: impl FnOnce(ScanBuilder<ArrayRef>) -> VortexResult<ScanBuilder<ArrayRef>>,
 ) -> VortexResult<ArrayRef> {
     let mut writer = vec![];
     SESSION
@@ -1361,15 +1390,19 @@ async fn write_nullable_nested_struct() -> VortexResult<()> {
 #[tokio::test]
 async fn scan_empty_fields() -> VortexResult<()> {
     let array = (0..10000).collect::<PrimitiveArray>();
-
-    let result = round_trip(&array.clone().into_array(), |scan| {
-        Ok(scan.with_projection(Pack.new_expr(
+    let projection = optimize_and_bind(
+        Pack.new_expr(
             PackOptions {
                 names: Default::default(),
                 nullability: Nullability::Nullable,
             },
             [],
-        )))
+        ),
+        array.dtype(),
+    )?;
+
+    let result = round_trip(&array.clone().into_array(), |scan| {
+        Ok(scan.with_projection(projection))
     })
     .await?;
 
@@ -2193,13 +2226,9 @@ async fn timestamp_unit_mismatch() -> Result<(), Box<dyn std::error::Error>> {
         )),
     );
 
-    let mut stream = SESSION
-        .open_options()
-        .open_buffer(buf)?
-        .scan()?
-        .with_filter(filter_expr)
-        .into_array_stream()?;
-
+    let file = SESSION.open_options().open_buffer(buf)?;
+    let filter = optimize_and_bind(filter_expr, file.dtype())?;
+    let mut stream = file.scan()?.with_filter(filter).into_array_stream()?;
     let result = stream.try_next().await;
 
     assert!(result.is_err());
@@ -2246,13 +2275,9 @@ async fn timestamp_unit_mismatch_errors_with_constant_children()
         )),
     );
 
-    let stream = SESSION
-        .open_options()
-        .open_buffer(buf)?
-        .scan()?
-        .with_filter(filter_expr)
-        .into_array_stream()?;
-
+    let file = SESSION.open_options().open_buffer(buf)?;
+    let filter = optimize_and_bind(filter_expr, file.dtype())?;
+    let stream = file.scan()?.with_filter(filter).into_array_stream()?;
     let results = stream.try_collect::<Vec<_>>().await;
 
     assert!(
@@ -2345,7 +2370,7 @@ async fn test_large_flat_chunk_scan_subdivides_splits() -> VortexResult<()> {
     // A filtered scan crossing sub-split boundaries selects exactly the matching rows.
     let result = file
         .scan()?
-        .with_filter(gt(root(), lit(0i32)))
+        .with_filter(bind_scan_expr(&file, gt(root(), lit(0i32))))
         .into_array_stream()?
         .read_all()
         .await?;
@@ -2392,7 +2417,7 @@ async fn test_flat_chunk_scan_with_row_count_splits(
     let result = file
         .scan()?
         .with_split_by(SplitBy::RowCount(rows_per_split))
-        .with_filter(gt(root(), lit(0i32)))
+        .with_filter(bind_scan_expr(&file, gt(root(), lit(0i32))))
         .into_array_stream()?
         .read_all()
         .await?;
@@ -2755,9 +2780,9 @@ async fn repro_8166_binary_gt_all_ff_max() -> VortexResult<()> {
         )),
     );
 
-    let result = SESSION
-        .open_options()
-        .open_buffer(buf)?
+    let file = SESSION.open_options().open_buffer(buf)?;
+    let filter = optimize_and_bind(filter, file.dtype())?;
+    let result = file
         .scan()?
         .with_filter(filter)
         .into_array_stream()?

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -87,7 +87,6 @@ use vortex_layout::layouts::table::TableStrategy;
 use vortex_layout::layouts::zoned::LegacyStats;
 use vortex_layout::layouts::zoned::Zoned;
 use vortex_layout::scan::scan_builder::ScanBuilder;
-use vortex_layout::scan::scan_builder::optimize_and_bind;
 use vortex_layout::scan::split_by::SplitBy;
 use vortex_layout::session::LayoutSession;
 use vortex_scan::strict_sorted_buffer::StrictSortedBuffer;
@@ -117,7 +116,9 @@ fn strict_sorted(indices: Buffer<u64>) -> StrictSortedBuffer<u64> {
 }
 
 fn bind_scan_expr(file: &VortexFile, expr: Expression) -> BoundExpression {
-    optimize_and_bind(expr, file.dtype()).vortex_expect("scan expression should bind")
+    expr.optimize_recursive(file.dtype())
+        .and_then(|expr| expr.bind(file.dtype()))
+        .vortex_expect("scan expression should bind")
 }
 
 #[tokio::test]
@@ -1390,16 +1391,16 @@ async fn write_nullable_nested_struct() -> VortexResult<()> {
 #[tokio::test]
 async fn scan_empty_fields() -> VortexResult<()> {
     let array = (0..10000).collect::<PrimitiveArray>();
-    let projection = optimize_and_bind(
-        Pack.new_expr(
+    let projection = Pack
+        .new_expr(
             PackOptions {
                 names: Default::default(),
                 nullability: Nullability::Nullable,
             },
             [],
-        ),
-        array.dtype(),
-    )?;
+        )
+        .optimize_recursive(array.dtype())?
+        .bind(array.dtype())?;
 
     let result = round_trip(&array.clone().into_array(), |scan| {
         Ok(scan.with_projection(projection))
@@ -2227,7 +2228,9 @@ async fn timestamp_unit_mismatch() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let file = SESSION.open_options().open_buffer(buf)?;
-    let filter = optimize_and_bind(filter_expr, file.dtype())?;
+    let filter = filter_expr
+        .optimize_recursive(file.dtype())?
+        .bind(file.dtype())?;
     let mut stream = file.scan()?.with_filter(filter).into_array_stream()?;
     let result = stream.try_next().await;
 
@@ -2276,7 +2279,9 @@ async fn timestamp_unit_mismatch_errors_with_constant_children()
     );
 
     let file = SESSION.open_options().open_buffer(buf)?;
-    let filter = optimize_and_bind(filter_expr, file.dtype())?;
+    let filter = filter_expr
+        .optimize_recursive(file.dtype())?
+        .bind(file.dtype())?;
     let stream = file.scan()?.with_filter(filter).into_array_stream()?;
     let results = stream.try_collect::<Vec<_>>().await;
 
@@ -2781,7 +2786,9 @@ async fn repro_8166_binary_gt_all_ff_max() -> VortexResult<()> {
     );
 
     let file = SESSION.open_options().open_buffer(buf)?;
-    let filter = optimize_and_bind(filter, file.dtype())?;
+    let filter = filter
+        .optimize_recursive(file.dtype())?
+        .bind(file.dtype())?;
     let result = file
         .scan()?
         .with_filter(filter)

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -38,6 +38,8 @@ use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::dtype::PType::I32;
 use vortex_array::dtype::StructFields;
+use vortex_array::expr::BoundExpression;
+use vortex_array::expr::Expression;
 use vortex_array::expr::and;
 use vortex_array::expr::cast;
 use vortex_array::expr::col;
@@ -85,6 +87,7 @@ use vortex_layout::layouts::table::TableStrategy;
 use vortex_layout::layouts::zoned::LegacyStats;
 use vortex_layout::layouts::zoned::Zoned;
 use vortex_layout::scan::scan_builder::ScanBuilder;
+use vortex_layout::scan::scan_builder::optimize_and_bind;
 use vortex_layout::scan::split_by::SplitBy;
 use vortex_layout::session::LayoutSession;
 use vortex_session::VortexSession;
@@ -107,6 +110,10 @@ static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
 
     session
 });
+
+fn bind_scan_expr(file: &VortexFile, expr: Expression) -> BoundExpression {
+    optimize_and_bind(expr, file.dtype()).vortex_expect("scan expression should bind")
+}
 
 #[tokio::test]
 async fn test_eof_values() {
@@ -315,7 +322,7 @@ async fn test_read_projection() {
     let array = file
         .scan()
         .unwrap()
-        .with_projection(select(["strings"], root()))
+        .with_projection(bind_scan_expr(&file, select(["strings"], root())))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -341,7 +348,7 @@ async fn test_read_projection() {
     let array = file
         .scan()
         .unwrap()
-        .with_projection(select(["numbers"], root()))
+        .with_projection(bind_scan_expr(&file, select(["numbers"], root())))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -512,18 +519,19 @@ async fn issue_5385_filter_casted_column() {
         .await
         .unwrap();
 
-    let result = SESSION
-        .open_options()
-        .open_buffer(buf)
-        .unwrap()
+    let file = SESSION.open_options().open_buffer(buf).unwrap();
+    let result = file
         .scan()
         .unwrap()
-        .with_filter(eq(
-            cast(
-                get_item("x", root()),
-                DType::Primitive(PType::U16, Nullability::NonNullable),
+        .with_filter(bind_scan_expr(
+            &file,
+            eq(
+                cast(
+                    get_item("x", root()),
+                    DType::Primitive(PType::U16, Nullability::NonNullable),
+                ),
+                lit(1u16),
             ),
-            lit(1u16),
         ))
         .into_array_stream()
         .unwrap()
@@ -564,13 +572,14 @@ async fn filter_string() {
         .await
         .unwrap();
 
-    let result: Vec<_> = SESSION
-        .open_options()
-        .open_buffer(buf)
-        .unwrap()
+    let file = SESSION.open_options().open_buffer(buf).unwrap();
+    let result: Vec<_> = file
         .scan()
         .unwrap()
-        .with_filter(eq(get_item("name", root()), lit("Joseph")))
+        .with_filter(bind_scan_expr(
+            &file,
+            eq(get_item("name", root()), lit("Joseph")),
+        ))
         .into_array_stream()
         .unwrap()
         .try_collect()
@@ -624,17 +633,18 @@ async fn filter_or() {
         .await
         .unwrap();
 
-    let result: Vec<_> = SESSION
-        .open_options()
-        .open_buffer(buf)
-        .unwrap()
+    let file = SESSION.open_options().open_buffer(buf).unwrap();
+    let result: Vec<_> = file
         .scan()
         .unwrap()
-        .with_filter(or(
-            eq(get_item("name", root()), lit("Angela")),
-            and(
-                gt_eq(get_item("age", root()), lit(20)),
-                lt_eq(get_item("age", root()), lit(30)),
+        .with_filter(bind_scan_expr(
+            &file,
+            or(
+                eq(get_item("name", root()), lit("Angela")),
+                and(
+                    gt_eq(get_item("age", root()), lit(20)),
+                    lt_eq(get_item("age", root()), lit(30)),
+                ),
             ),
         ))
         .into_array_stream()
@@ -692,15 +702,16 @@ async fn filter_and() {
         .await
         .unwrap();
 
-    let result: Vec<_> = SESSION
-        .open_options()
-        .open_buffer(buf)
-        .unwrap()
+    let file = SESSION.open_options().open_buffer(buf).unwrap();
+    let result: Vec<_> = file
         .scan()
         .unwrap()
-        .with_filter(and(
-            gt(get_item("age", root()), lit(21)),
-            lt_eq(get_item("age", root()), lit(33)),
+        .with_filter(bind_scan_expr(
+            &file,
+            and(
+                gt(get_item("age", root()), lit(21)),
+                lt_eq(get_item("age", root()), lit(33)),
+            ),
         ))
         .into_array_stream()
         .unwrap()
@@ -906,7 +917,10 @@ async fn test_with_indices_and_with_row_filter_simple() {
     let actual_kept_array = file
         .scan()
         .unwrap()
-        .with_filter(gt(get_item("numbers", root()), lit(50_i16)))
+        .with_filter(bind_scan_expr(
+            &file,
+            gt(get_item("numbers", root()), lit(50_i16)),
+        ))
         .with_row_indices(Buffer::empty())
         .into_array_stream()
         .unwrap()
@@ -924,7 +938,10 @@ async fn test_with_indices_and_with_row_filter_simple() {
     let actual_kept_array = file
         .scan()
         .unwrap()
-        .with_filter(gt(get_item("numbers", root()), lit(50_i16)))
+        .with_filter(bind_scan_expr(
+            &file,
+            gt(get_item("numbers", root()), lit(50_i16)),
+        ))
         .with_row_indices(Buffer::from_iter(kept_indices))
         .into_array_stream()
         .unwrap()
@@ -952,7 +969,10 @@ async fn test_with_indices_and_with_row_filter_simple() {
     let actual_array = file
         .scan()
         .unwrap()
-        .with_filter(gt(get_item("numbers", root()), lit(50_i16)))
+        .with_filter(bind_scan_expr(
+            &file,
+            gt(get_item("numbers", root()), lit(50_i16)),
+        ))
         .with_row_indices((0..500).collect::<Buffer<_>>())
         .into_array_stream()
         .unwrap()
@@ -1014,7 +1034,10 @@ async fn filter_string_chunked() {
     let actual_array = file
         .scan()
         .unwrap()
-        .with_filter(eq(get_item("name", root()), lit("Joseph")))
+        .with_filter(bind_scan_expr(
+            &file,
+            eq(get_item("name", root()), lit("Joseph")),
+        ))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -1104,9 +1127,12 @@ async fn test_pruning_with_or() {
     let actual_array = file
         .scan()
         .unwrap()
-        .with_filter(or(
-            lt_eq(get_item("letter", root()), lit("J")),
-            lt(get_item("number", root()), lit(25)),
+        .with_filter(bind_scan_expr(
+            &file,
+            or(
+                lt_eq(get_item("letter", root()), lit("J")),
+                lt(get_item("number", root()), lit(25)),
+            ),
         ))
         .into_array_stream()
         .unwrap()
@@ -1179,7 +1205,10 @@ async fn test_repeated_projection() {
     let actual = file
         .scan()
         .unwrap()
-        .with_projection(select(["strings", "strings"], root()))
+        .with_projection(bind_scan_expr(
+            &file,
+            select(["strings", "strings"], root()),
+        ))
         .into_array_stream()
         .unwrap()
         .read_all()
@@ -1293,7 +1322,7 @@ async fn write_nullable_top_level_struct() {
 
 async fn round_trip(
     array: &ArrayRef,
-    f: impl Fn(ScanBuilder<ArrayRef>) -> VortexResult<ScanBuilder<ArrayRef>>,
+    f: impl FnOnce(ScanBuilder<ArrayRef>) -> VortexResult<ScanBuilder<ArrayRef>>,
 ) -> VortexResult<ArrayRef> {
     let mut writer = vec![];
     SESSION
@@ -1356,15 +1385,19 @@ async fn write_nullable_nested_struct() -> VortexResult<()> {
 #[tokio::test]
 async fn scan_empty_fields() -> VortexResult<()> {
     let array = (0..10000).collect::<PrimitiveArray>();
-
-    let result = round_trip(&array.clone().into_array(), |scan| {
-        Ok(scan.with_projection(Pack.new_expr(
+    let projection = optimize_and_bind(
+        Pack.new_expr(
             PackOptions {
                 names: Default::default(),
                 nullability: Nullability::Nullable,
             },
             [],
-        )))
+        ),
+        array.dtype(),
+    )?;
+
+    let result = round_trip(&array.clone().into_array(), |scan| {
+        Ok(scan.with_projection(projection))
     })
     .await?;
 
@@ -2188,13 +2221,9 @@ async fn timestamp_unit_mismatch() -> Result<(), Box<dyn std::error::Error>> {
         )),
     );
 
-    let mut stream = SESSION
-        .open_options()
-        .open_buffer(buf)?
-        .scan()?
-        .with_filter(filter_expr)
-        .into_array_stream()?;
-
+    let file = SESSION.open_options().open_buffer(buf)?;
+    let filter = optimize_and_bind(filter_expr, file.dtype())?;
+    let mut stream = file.scan()?.with_filter(filter).into_array_stream()?;
     let result = stream.try_next().await;
 
     assert!(result.is_err());
@@ -2241,13 +2270,9 @@ async fn timestamp_unit_mismatch_errors_with_constant_children()
         )),
     );
 
-    let stream = SESSION
-        .open_options()
-        .open_buffer(buf)?
-        .scan()?
-        .with_filter(filter_expr)
-        .into_array_stream()?;
-
+    let file = SESSION.open_options().open_buffer(buf)?;
+    let filter = optimize_and_bind(filter_expr, file.dtype())?;
+    let stream = file.scan()?.with_filter(filter).into_array_stream()?;
     let results = stream.try_collect::<Vec<_>>().await;
 
     assert!(
@@ -2340,7 +2365,7 @@ async fn test_large_flat_chunk_scan_subdivides_splits() -> VortexResult<()> {
     // A filtered scan crossing sub-split boundaries selects exactly the matching rows.
     let result = file
         .scan()?
-        .with_filter(gt(root(), lit(0i32)))
+        .with_filter(bind_scan_expr(&file, gt(root(), lit(0i32))))
         .into_array_stream()?
         .read_all()
         .await?;
@@ -2387,7 +2412,7 @@ async fn test_flat_chunk_scan_with_row_count_splits(
     let result = file
         .scan()?
         .with_split_by(SplitBy::RowCount(rows_per_split))
-        .with_filter(gt(root(), lit(0i32)))
+        .with_filter(bind_scan_expr(&file, gt(root(), lit(0i32))))
         .into_array_stream()?
         .read_all()
         .await?;
@@ -2750,9 +2775,9 @@ async fn repro_8166_binary_gt_all_ff_max() -> VortexResult<()> {
         )),
     );
 
-    let result = SESSION
-        .open_options()
-        .open_buffer(buf)?
+    let file = SESSION.open_options().open_buffer(buf)?;
+    let filter = optimize_and_bind(filter, file.dtype())?;
+    let result = file
         .scan()?
         .with_filter(filter)
         .into_array_stream()?

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -87,7 +87,6 @@ use vortex_layout::layouts::table::TableStrategy;
 use vortex_layout::layouts::zoned::LegacyStats;
 use vortex_layout::layouts::zoned::Zoned;
 use vortex_layout::scan::scan_builder::ScanBuilder;
-use vortex_layout::scan::scan_builder::optimize_and_bind;
 use vortex_layout::scan::split_by::SplitBy;
 use vortex_layout::session::LayoutSession;
 use vortex_session::VortexSession;
@@ -112,7 +111,9 @@ static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
 });
 
 fn bind_scan_expr(file: &VortexFile, expr: Expression) -> BoundExpression {
-    optimize_and_bind(expr, file.dtype()).vortex_expect("scan expression should bind")
+    expr.optimize_recursive(file.dtype())
+        .and_then(|expr| expr.bind(file.dtype()))
+        .vortex_expect("scan expression should bind")
 }
 
 #[tokio::test]
@@ -1385,16 +1386,16 @@ async fn write_nullable_nested_struct() -> VortexResult<()> {
 #[tokio::test]
 async fn scan_empty_fields() -> VortexResult<()> {
     let array = (0..10000).collect::<PrimitiveArray>();
-    let projection = optimize_and_bind(
-        Pack.new_expr(
+    let projection = Pack
+        .new_expr(
             PackOptions {
                 names: Default::default(),
                 nullability: Nullability::Nullable,
             },
             [],
-        ),
-        array.dtype(),
-    )?;
+        )
+        .optimize_recursive(array.dtype())?
+        .bind(array.dtype())?;
 
     let result = round_trip(&array.clone().into_array(), |scan| {
         Ok(scan.with_projection(projection))
@@ -2222,7 +2223,9 @@ async fn timestamp_unit_mismatch() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let file = SESSION.open_options().open_buffer(buf)?;
-    let filter = optimize_and_bind(filter_expr, file.dtype())?;
+    let filter = filter_expr
+        .optimize_recursive(file.dtype())?
+        .bind(file.dtype())?;
     let mut stream = file.scan()?.with_filter(filter).into_array_stream()?;
     let result = stream.try_next().await;
 
@@ -2271,7 +2274,9 @@ async fn timestamp_unit_mismatch_errors_with_constant_children()
     );
 
     let file = SESSION.open_options().open_buffer(buf)?;
-    let filter = optimize_and_bind(filter_expr, file.dtype())?;
+    let filter = filter_expr
+        .optimize_recursive(file.dtype())?
+        .bind(file.dtype())?;
     let stream = file.scan()?.with_filter(filter).into_array_stream()?;
     let results = stream.try_collect::<Vec<_>>().await;
 
@@ -2776,7 +2781,9 @@ async fn repro_8166_binary_gt_all_ff_max() -> VortexResult<()> {
     );
 
     let file = SESSION.open_options().open_buffer(buf)?;
-    let filter = optimize_and_bind(filter, file.dtype())?;
+    let filter = filter
+        .optimize_recursive(file.dtype())?
+        .bind(file.dtype())?;
     let result = file
         .scan()?
         .with_filter(filter)

--- a/vortex-file/src/v2/file_stats_reader.rs
+++ b/vortex-file/src/v2/file_stats_reader.rs
@@ -16,7 +16,6 @@ use vortex_array::dtype::FieldMask;
 use vortex_array::dtype::StructFields;
 use vortex_array::expr::BoundExpression;
 use vortex_array::expr::ExactBoundExpr;
-use vortex_array::expr::Expression;
 use vortex_error::VortexResult;
 use vortex_layout::ArrayFuture;
 use vortex_layout::LayoutReader;
@@ -73,10 +72,9 @@ impl FileStatsLayoutReader {
     ///
     /// Row-count placeholders are resolved against the full file row count,
     /// independent of the requested row range.
-    fn evaluate_file_stats(&self, expr: &Expression) -> VortexResult<bool> {
+    fn evaluate_file_stats(&self, expr: &BoundExpression) -> VortexResult<bool> {
         can_prune_file_stats(
             expr,
-            self.child.dtype(),
             self.child.row_count(),
             &self.file_stats,
             &self.struct_fields,
@@ -129,8 +127,7 @@ impl LayoutReader for FileStatsLayoutReader {
         }
 
         // Evaluate and cache.
-        let expression = expr.unbind();
-        let pruned = self.evaluate_file_stats(&expression)?;
+        let pruned = self.evaluate_file_stats(expr)?;
         self.prune_cache.insert(key, pruned);
 
         if pruned {

--- a/vortex-geo/src/prune/distance.rs
+++ b/vortex-geo/src/prune/distance.rs
@@ -4,12 +4,7 @@
 //! `ST_Distance(geom, const) <op> radius` pruning.
 
 use geo::Rect as GeoRect;
-use vortex_array::expr::Expression;
-use vortex_array::expr::gt;
-use vortex_array::expr::gt_eq;
-use vortex_array::expr::lit;
-use vortex_array::expr::lt;
-use vortex_array::expr::lt_eq;
+use vortex_array::expr::BoundExpression as BoundExpr;
 use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_array::scalar_fn::fns::binary::Binary;
@@ -21,6 +16,11 @@ use vortex_error::VortexResult;
 
 use super::aabb_stat;
 use super::geometry_and_constant;
+use super::gt;
+use super::gt_eq;
+use super::lit;
+use super::lt;
+use super::lt_eq;
 use super::max_dist_sq;
 use super::min_dist_sq;
 use super::query_aabb;
@@ -42,9 +42,9 @@ impl StatsRewriteRule for GeoDistancePrune {
 
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         // Only the ordered comparisons prune today. `== r` could prune in the future (a chunk is
         // provably empty when `r` lies outside its box's [min, max] distance interval), it's just
         // not implemented. `!= r` cannot: pruning would need every row's distance to equal `r`,
@@ -94,11 +94,11 @@ impl StatsRewriteRule for GeoDistancePrune {
 ///
 /// A distance is always `>= 0`, which decides the degenerate radii up front.
 fn distance_prune_proof(
-    geom: &Expression,
+    geom: &BoundExpr,
     query: GeoRect<f64>,
     op: Operator,
     radius: f64,
-) -> Option<Expression> {
+) -> Option<BoundExpr> {
     // A distance is always non-negative, so degenerate radii resolve without touching the box.
     match op {
         // `<= r` / `< r` with a negative radius (or zero, for `<`) match nothing: prune every chunk.
@@ -130,7 +130,7 @@ mod tests {
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
-    use vortex_array::expr::Expression;
+    use vortex_array::expr::BoundExpression;
     use vortex_array::expr::gt_eq;
     use vortex_array::expr::lit;
     use vortex_array::expr::lt_eq;
@@ -158,7 +158,7 @@ mod tests {
         operator: Operator,
         geom_first: bool,
         radius: impl Into<Scalar>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         let session = geo_session();
         let mut ctx = session.create_execution_ctx();
 
@@ -170,9 +170,11 @@ mod tests {
             [lit(origin), root()]
         };
         let distance = GeoDistance.new_expr(EmptyOptions, operands);
-        let predicate = Binary.new_expr(operator, [distance, lit(radius.into())]);
+        let predicate = Binary
+            .new_expr(operator, [distance, lit(radius.into())])
+            .bind(&scope)?;
 
-        GeoDistancePrune.falsify(&predicate, &StatsRewriteCtx::new(&session, &scope))
+        GeoDistancePrune.falsify(&predicate, &StatsRewriteCtx::new(&session))
     }
 
     /// A null geometry literal (`ST_Distance(geom, NULL) <= r`) declines cleanly instead of
@@ -184,9 +186,11 @@ mod tests {
         let scope = point_column(vec![0.0], vec![0.0])?.dtype().clone();
         let null_query = Scalar::null(scope.as_nullable());
         let distance = GeoDistance.new_expr(EmptyOptions, [root(), lit(null_query)]);
-        let predicate = Binary.new_expr(Operator::Lte, [distance, lit(0.5f64)]);
+        let predicate = Binary
+            .new_expr(Operator::Lte, [distance, lit(0.5f64)])
+            .bind(&scope)?;
 
-        let ctx = StatsRewriteCtx::new(&session, &scope);
+        let ctx = StatsRewriteCtx::new(&session);
         assert!(GeoDistancePrune.falsify(&predicate, &ctx)?.is_none());
         Ok(())
     }
@@ -231,11 +235,10 @@ mod tests {
         Ok(())
     }
 
-    /// Filter expressions arrive uncoerced, so `distance <= 10` may carry an integer literal -
-    /// it casts and prunes like an f64 radius.
+    /// An uncoerced integer radius is rejected while binding the comparison.
     #[test]
-    fn integer_radius_prunes() -> VortexResult<()> {
-        assert!(falsify_distance(Operator::Lte, true, 10i64)?.is_some());
+    fn uncoerced_integer_radius_fails_to_bind() -> VortexResult<()> {
+        assert!(falsify_distance(Operator::Lte, true, 10i64).is_err());
         Ok(())
     }
 
@@ -259,8 +262,7 @@ mod tests {
         Ok(())
     }
 
-    /// A scope dtype without `GeometryAabb` support gets no proof - the stat reference would
-    /// fail to bind at prune time.
+    /// A non-geometry scope is rejected while binding, before stats rewriting.
     #[test]
     fn unsupported_scope_is_not_pruned() -> VortexResult<()> {
         let session = geo_session();
@@ -270,9 +272,7 @@ mod tests {
         let origin = point_column(vec![0.0], vec![0.0])?.execute_scalar(0, &mut ctx)?;
         let distance = GeoDistance.new_expr(EmptyOptions, [root(), lit(origin)]);
         let predicate = lt_eq(distance, lit(0.5f64));
-
-        let ctx = StatsRewriteCtx::new(&session, &scope);
-        assert!(GeoDistancePrune.falsify(&predicate, &ctx)?.is_none());
+        assert!(predicate.bind(&scope).is_err());
         Ok(())
     }
 
@@ -282,8 +282,8 @@ mod tests {
         let session = geo_session();
         let scope = point_column(vec![0.0], vec![0.0])?.dtype().clone();
 
-        let predicate = lt_eq(lit(1.0f64), lit(2.0f64));
-        let ctx = StatsRewriteCtx::new(&session, &scope);
+        let predicate = lt_eq(lit(1.0f64), lit(2.0f64)).bind(&scope)?;
+        let ctx = StatsRewriteCtx::new(&session);
         assert!(GeoDistancePrune.falsify(&predicate, &ctx)?.is_none());
         Ok(())
     }
@@ -305,7 +305,8 @@ mod tests {
         let distance = GeoDistance.new_expr(EmptyOptions, [root(), lit(origin)]);
         let predicate = lt_eq(distance, lit(0.5f64));
         let proof = predicate
-            .falsify(&point_dtype, &session)?
+            .bind(&point_dtype)?
+            .falsify(&session)?
             .expect("distance filter should be falsifiable");
 
         // `true` means the zone is pruned: chunk 0 (near origin) is kept, chunk 1 (far) is skipped.
@@ -330,7 +331,8 @@ mod tests {
         let distance = GeoDistance.new_expr(EmptyOptions, [root(), lit(origin)]);
         let predicate = lt_eq(distance, lit(1.0f64));
         let proof = predicate
-            .falsify(&point_dtype, &session)?
+            .bind(&point_dtype)?
+            .falsify(&session)?
             .expect("distance filter should be falsifiable");
 
         assert_eq!(
@@ -361,7 +363,8 @@ mod tests {
         let origin = point_column(vec![0.0], vec![0.0])?.execute_scalar(0, &mut ctx)?;
         let distance = GeoDistance.new_expr(EmptyOptions, [root(), lit(origin)]);
         let proof = gt_eq(distance, lit(2.0f64))
-            .falsify(&point_dtype, &session)?
+            .bind(&point_dtype)?
+            .falsify(&session)?
             .expect("distance filter should be falsifiable");
 
         // Chunk 0 (within 2) is pruned for `>= 2`; chunk 1 (beyond 2) is kept.
@@ -383,7 +386,8 @@ mod tests {
         let origin = point_column(vec![0.0], vec![0.0])?.execute_scalar(0, &mut ctx)?;
         let distance = GeoDistance.new_expr(EmptyOptions, [root(), lit(origin)]);
         let proof = lt_eq(distance, lit(0.5f64))
-            .falsify(&point_dtype, &session)?
+            .bind(&point_dtype)?
+            .falsify(&session)?
             .expect("distance filter should be falsifiable");
 
         let mask = zone_map.prune(&proof, &session)?;

--- a/vortex-geo/src/prune/distance.rs
+++ b/vortex-geo/src/prune/distance.rs
@@ -4,7 +4,7 @@
 //! `ST_Distance(geom, const) <op> radius` pruning.
 
 use geo::Rect as GeoRect;
-use vortex_array::expr::BoundExpression as BoundExpr;
+use vortex_array::expr::BoundExpression;
 use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_array::scalar_fn::fns::binary::Binary;
@@ -42,9 +42,9 @@ impl StatsRewriteRule for GeoDistancePrune {
 
     fn falsify(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         // Only the ordered comparisons prune today. `== r` could prune in the future (a chunk is
         // provably empty when `r` lies outside its box's [min, max] distance interval), it's just
         // not implemented. `!= r` cannot: pruning would need every row's distance to equal `r`,
@@ -94,11 +94,11 @@ impl StatsRewriteRule for GeoDistancePrune {
 ///
 /// A distance is always `>= 0`, which decides the degenerate radii up front.
 fn distance_prune_proof(
-    geom: &BoundExpr,
+    geom: &BoundExpression,
     query: GeoRect<f64>,
     op: Operator,
     radius: f64,
-) -> Option<BoundExpr> {
+) -> Option<BoundExpression> {
     // A distance is always non-negative, so degenerate radii resolve without touching the box.
     match op {
         // `<= r` / `< r` with a negative radius (or zero, for `<`) match nothing: prune every chunk.

--- a/vortex-geo/src/prune/intersects.rs
+++ b/vortex-geo/src/prune/intersects.rs
@@ -3,9 +3,7 @@
 
 //! `ST_Intersects(geom, const)` pruning.
 
-use vortex_array::expr::Expression;
-use vortex_array::expr::gt;
-use vortex_array::expr::lit;
+use vortex_array::expr::BoundExpression as BoundExpr;
 use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_array::stats::rewrite::StatsRewriteCtx;
@@ -14,6 +12,8 @@ use vortex_error::VortexResult;
 
 use super::aabb_stat;
 use super::geometry_and_constant;
+use super::gt;
+use super::lit;
 use super::min_dist_sq;
 use super::query_aabb;
 use crate::scalar_fn::intersects::GeoIntersects;
@@ -34,9 +34,9 @@ impl StatsRewriteRule for GeoIntersectsPrune {
 
     fn falsify(
         &self,
-        expr: &Expression,
+        expr: &BoundExpr,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<Expression>> {
+    ) -> VortexResult<Option<BoundExpr>> {
         let Some((geom, constant)) = geometry_and_constant(expr, ctx)? else {
             return Ok(None);
         };
@@ -56,7 +56,7 @@ mod tests {
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
-    use vortex_array::expr::Expression;
+    use vortex_array::expr::BoundExpression;
     use vortex_array::expr::lit;
     use vortex_array::expr::root;
     use vortex_array::scalar::Scalar;
@@ -75,7 +75,7 @@ mod tests {
 
     /// Run the intersects rule against `GeoIntersects(root, point(1.0, 0.5))`, operands swapped
     /// when `geom_first` is false.
-    fn falsify_intersects(geom_first: bool) -> VortexResult<Option<Expression>> {
+    fn falsify_intersects(geom_first: bool) -> VortexResult<Option<BoundExpression>> {
         let session = geo_session();
         let mut ctx = session.create_execution_ctx();
 
@@ -86,8 +86,10 @@ mod tests {
         } else {
             [lit(query), root()]
         };
-        let predicate = GeoIntersects.new_expr(EmptyOptions, operands);
-        GeoIntersectsPrune.falsify(&predicate, &StatsRewriteCtx::new(&session, &scope))
+        let predicate = GeoIntersects
+            .new_expr(EmptyOptions, operands)
+            .bind(&scope)?;
+        GeoIntersectsPrune.falsify(&predicate, &StatsRewriteCtx::new(&session))
     }
 
     /// Intersects is symmetric: both operand orders produce a proof.
@@ -99,8 +101,7 @@ mod tests {
         Ok(())
     }
 
-    /// A scope dtype without `GeometryAabb` support gets no proof, the stat reference would
-    /// fail to bind at prune time.
+    /// A non-geometry scope is rejected while binding, before stats rewriting.
     #[test]
     fn unsupported_scope_is_not_pruned() -> VortexResult<()> {
         let session = geo_session();
@@ -109,9 +110,7 @@ mod tests {
         let scope = DType::Primitive(PType::F64, Nullability::NonNullable);
         let query = point_column(vec![0.0], vec![0.0])?.execute_scalar(0, &mut ctx)?;
         let predicate = GeoIntersects.new_expr(EmptyOptions, [root(), lit(query)]);
-
-        let ctx = StatsRewriteCtx::new(&session, &scope);
-        assert!(GeoIntersectsPrune.falsify(&predicate, &ctx)?.is_none());
+        assert!(predicate.bind(&scope).is_err());
         Ok(())
     }
 
@@ -123,9 +122,11 @@ mod tests {
 
         let scope = point_column(vec![0.0], vec![0.0])?.dtype().clone();
         let null_query = Scalar::null(scope.as_nullable());
-        let predicate = GeoIntersects.new_expr(EmptyOptions, [root(), lit(null_query)]);
+        let predicate = GeoIntersects
+            .new_expr(EmptyOptions, [root(), lit(null_query)])
+            .bind(&scope)?;
 
-        let ctx = StatsRewriteCtx::new(&session, &scope);
+        let ctx = StatsRewriteCtx::new(&session);
         assert!(GeoIntersectsPrune.falsify(&predicate, &ctx)?.is_none());
         Ok(())
     }
@@ -152,7 +153,8 @@ mod tests {
         let query = point_column(vec![1.0], vec![0.5])?.execute_scalar(0, &mut ctx)?;
         let predicate = GeoIntersects.new_expr(EmptyOptions, [root(), lit(query)]);
         let proof = predicate
-            .falsify(&point_dtype, &session)?
+            .bind(&point_dtype)?
+            .falsify(&session)?
             .expect("intersects filter should be falsifiable");
 
         let mask = zone_map.prune(&proof, &session)?;
@@ -172,7 +174,8 @@ mod tests {
         let query = point_column(vec![0.0], vec![0.0])?.execute_scalar(0, &mut ctx)?;
         let proof = GeoIntersects
             .new_expr(EmptyOptions, [root(), lit(query)])
-            .falsify(&point_dtype, &session)?
+            .bind(&point_dtype)?
+            .falsify(&session)?
             .expect("intersects filter should be falsifiable");
 
         let mask = zone_map.prune(&proof, &session)?;

--- a/vortex-geo/src/prune/intersects.rs
+++ b/vortex-geo/src/prune/intersects.rs
@@ -3,7 +3,7 @@
 
 //! `ST_Intersects(geom, const)` pruning.
 
-use vortex_array::expr::BoundExpression as BoundExpr;
+use vortex_array::expr::BoundExpression;
 use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_array::stats::rewrite::StatsRewriteCtx;
@@ -34,9 +34,9 @@ impl StatsRewriteRule for GeoIntersectsPrune {
 
     fn falsify(
         &self,
-        expr: &BoundExpr,
+        expr: &BoundExpression,
         ctx: &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpr>> {
+    ) -> VortexResult<Option<BoundExpression>> {
         let Some((geom, constant)) = geometry_and_constant(expr, ctx)? else {
             return Ok(None);
         };

--- a/vortex-geo/src/prune/mod.rs
+++ b/vortex-geo/src/prune/mod.rs
@@ -22,22 +22,22 @@ pub use intersects::GeoIntersectsPrune;
 use vortex_array::VortexSessionExecute;
 use vortex_array::aggregate_fn::AggregateFnVTableExt;
 use vortex_array::aggregate_fn::EmptyOptions;
-use vortex_array::dtype::FieldName;
 use vortex_array::expr::BoundExpression as BoundExpr;
+use vortex_array::expr::bound::binary;
+use vortex_array::expr::bound::case_when;
+use vortex_array::expr::bound::checked_add;
+use vortex_array::expr::bound::ext_storage;
+use vortex_array::expr::bound::get_item;
+use vortex_array::expr::bound::gt;
+use vortex_array::expr::bound::gt_eq;
+use vortex_array::expr::bound::lit;
+use vortex_array::expr::bound::lt;
+use vortex_array::expr::bound::lt_eq;
 use vortex_array::scalar::Scalar;
-use vortex_array::scalar_fn::EmptyOptions as ScalarEmptyOptions;
-use vortex_array::scalar_fn::ScalarFnVTableExt;
-use vortex_array::scalar_fn::fns::binary::Binary;
-use vortex_array::scalar_fn::fns::case_when::CaseWhen;
-use vortex_array::scalar_fn::fns::case_when::CaseWhenOptions;
-use vortex_array::scalar_fn::fns::ext_storage::ExtStorage;
-use vortex_array::scalar_fn::fns::get_item::GetItem;
 use vortex_array::scalar_fn::fns::literal::Literal;
 use vortex_array::scalar_fn::fns::operators::Operator;
-use vortex_array::scalar_fn::fns::stat::StatFn;
-use vortex_array::scalar_fn::fns::stat::StatOptions;
+use vortex_array::stats::bound::stat;
 use vortex_array::stats::rewrite::StatsRewriteCtx;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use crate::aggregate_fn::GeometryAabb;
@@ -101,62 +101,6 @@ fn aabb_stat(geom: &BoundExpr) -> BoundExpr {
     ext_storage(stat(geom.clone(), GeometryAabb.bind(EmptyOptions)))
 }
 
-fn stat(expr: BoundExpr, aggregate_fn: vortex_array::aggregate_fn::AggregateFnRef) -> BoundExpr {
-    StatFn
-        .try_new_bound_expr(StatOptions::new(aggregate_fn), [expr])
-        .vortex_expect("geometry pruning only requests a supported aggregate")
-}
-
-fn ext_storage(input: BoundExpr) -> BoundExpr {
-    ExtStorage
-        .try_new_bound_expr(ScalarEmptyOptions, [input])
-        .vortex_expect("the geometry AABB aggregate returns an extension value")
-}
-
-fn get_item(field: impl Into<FieldName>, child: BoundExpr) -> BoundExpr {
-    GetItem
-        .try_new_bound_expr(field.into(), [child])
-        .vortex_expect("geometry AABB fields are fixed by its storage dtype")
-}
-
-fn lit(value: impl Into<Scalar>) -> BoundExpr {
-    Literal
-        .try_new_bound_expr(value.into(), [])
-        .vortex_expect("literal expressions are always well-typed")
-}
-
-fn case_when(condition: BoundExpr, then_value: BoundExpr, else_value: BoundExpr) -> BoundExpr {
-    CaseWhen
-        .try_new_bound_expr(
-            CaseWhenOptions {
-                num_when_then_pairs: 1,
-                has_else: true,
-            },
-            [condition, then_value, else_value],
-        )
-        .vortex_expect("geometry pruning case expressions have matching branch dtypes")
-}
-
-fn gt(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
-    binop(Operator::Gt, lhs, rhs)
-}
-
-fn gt_eq(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
-    binop(Operator::Gte, lhs, rhs)
-}
-
-fn lt(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
-    binop(Operator::Lt, lhs, rhs)
-}
-
-fn lt_eq(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
-    binop(Operator::Lte, lhs, rhs)
-}
-
-fn checked_add(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
-    binop(Operator::Add, lhs, rhs)
-}
-
 /// Lower bound on every row's squared distance to the query AABB: zero when the boxes overlap or
 /// touch, positive iff they are strictly separated.
 ///
@@ -170,8 +114,8 @@ fn min_dist_sq(aabb: &BoundExpr, query: GeoRect<f64>) -> BoundExpr {
         maximum(
             lit(0.0),
             maximum(
-                binop(Operator::Sub, lit(q_lo), hi),
-                binop(Operator::Sub, lo, lit(q_hi)),
+                binary(Operator::Sub, lit(q_lo), hi),
+                binary(Operator::Sub, lo, lit(q_hi)),
             ),
         )
     };
@@ -189,7 +133,7 @@ fn max_dist_sq(aabb: &BoundExpr, query: GeoRect<f64>) -> BoundExpr {
     // boxes can be apart. The nullable AABB field is the second `maximum`/`minimum` argument so
     // that `case_when`'s else branch carries the nullability - a missing stat propagates null.
     let span = |q_lo: f64, q_hi: f64, lo: BoundExpr, hi: BoundExpr| {
-        binop(
+        binary(
             Operator::Sub,
             maximum(lit(q_hi), hi),
             minimum(lit(q_lo), lo),
@@ -200,16 +144,9 @@ fn max_dist_sq(aabb: &BoundExpr, query: GeoRect<f64>) -> BoundExpr {
     checked_add(square(dx), square(dy))
 }
 
-/// `a <op> b`.
-fn binop(op: Operator, a: BoundExpr, b: BoundExpr) -> BoundExpr {
-    Binary
-        .try_new_bound_expr(op, [a, b])
-        .vortex_expect("binary expression")
-}
-
 /// `e * e`.
 fn square(e: BoundExpr) -> BoundExpr {
-    binop(Operator::Mul, e.clone(), e)
+    binary(Operator::Mul, e.clone(), e)
 }
 
 /// `max(a, b)`.

--- a/vortex-geo/src/prune/mod.rs
+++ b/vortex-geo/src/prune/mod.rs
@@ -22,22 +22,21 @@ pub use intersects::GeoIntersectsPrune;
 use vortex_array::VortexSessionExecute;
 use vortex_array::aggregate_fn::AggregateFnVTableExt;
 use vortex_array::aggregate_fn::EmptyOptions;
-use vortex_array::expr::Expression;
-use vortex_array::expr::case_when;
-use vortex_array::expr::checked_add;
-use vortex_array::expr::ext_storage;
-use vortex_array::expr::get_item;
-use vortex_array::expr::gt;
-use vortex_array::expr::is_root;
-use vortex_array::expr::lit;
-use vortex_array::expr::lt;
+use vortex_array::dtype::FieldName;
+use vortex_array::expr::BoundExpression as BoundExpr;
 use vortex_array::scalar::Scalar;
+use vortex_array::scalar_fn::EmptyOptions as ScalarEmptyOptions;
 use vortex_array::scalar_fn::ScalarFnVTableExt;
 use vortex_array::scalar_fn::fns::binary::Binary;
+use vortex_array::scalar_fn::fns::case_when::CaseWhen;
+use vortex_array::scalar_fn::fns::case_when::CaseWhenOptions;
+use vortex_array::scalar_fn::fns::ext_storage::ExtStorage;
+use vortex_array::scalar_fn::fns::get_item::GetItem;
 use vortex_array::scalar_fn::fns::literal::Literal;
 use vortex_array::scalar_fn::fns::operators::Operator;
+use vortex_array::scalar_fn::fns::stat::StatFn;
+use vortex_array::scalar_fn::fns::stat::StatOptions;
 use vortex_array::stats::rewrite::StatsRewriteCtx;
-use vortex_array::stats::stat;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
@@ -53,15 +52,15 @@ use crate::extension::single_geometry;
 /// An asymmetric predicate (e.g. a future contains) must recover which operand is the column
 /// itself instead of calling this.
 fn geometry_and_constant<'a>(
-    expr: &'a Expression,
+    expr: &'a BoundExpr,
     ctx: &StatsRewriteCtx<'_>,
-) -> VortexResult<Option<(&'a Expression, &'a Scalar)>> {
+) -> VortexResult<Option<(&'a BoundExpr, &'a Scalar)>> {
     // The predicate is symmetric, so the column (scope root) and the constant may be on either
     // side.
     let (lhs, rhs) = (expr.child(0), expr.child(1));
-    let (geom, constant) = if is_root(lhs) {
+    let (geom, constant) = if lhs.is_root() {
         (lhs, rhs)
-    } else if is_root(rhs) {
+    } else if rhs.is_root() {
         (rhs, lhs)
     } else {
         return Ok(None);
@@ -96,22 +95,78 @@ fn query_aabb(constant: &Scalar, ctx: &StatsRewriteCtx<'_>) -> VortexResult<Opti
 ///
 /// A chunk written without the statistic reads as null here; every proof built on top must let
 /// that null propagate to its root, where the zone map keeps the chunk.
-fn aabb_stat(geom: &Expression) -> Expression {
+fn aabb_stat(geom: &BoundExpr) -> BoundExpr {
     // `ext_storage` unwraps the native `geoarrow.box` stat value to its backing struct, so
     // proofs can `get_item` the coordinate fields.
     ext_storage(stat(geom.clone(), GeometryAabb.bind(EmptyOptions)))
+}
+
+fn stat(expr: BoundExpr, aggregate_fn: vortex_array::aggregate_fn::AggregateFnRef) -> BoundExpr {
+    StatFn
+        .try_new_bound_expr(StatOptions::new(aggregate_fn), [expr])
+        .vortex_expect("geometry pruning only requests a supported aggregate")
+}
+
+fn ext_storage(input: BoundExpr) -> BoundExpr {
+    ExtStorage
+        .try_new_bound_expr(ScalarEmptyOptions, [input])
+        .vortex_expect("the geometry AABB aggregate returns an extension value")
+}
+
+fn get_item(field: impl Into<FieldName>, child: BoundExpr) -> BoundExpr {
+    GetItem
+        .try_new_bound_expr(field.into(), [child])
+        .vortex_expect("geometry AABB fields are fixed by its storage dtype")
+}
+
+fn lit(value: impl Into<Scalar>) -> BoundExpr {
+    Literal
+        .try_new_bound_expr(value.into(), [])
+        .vortex_expect("literal expressions are always well-typed")
+}
+
+fn case_when(condition: BoundExpr, then_value: BoundExpr, else_value: BoundExpr) -> BoundExpr {
+    CaseWhen
+        .try_new_bound_expr(
+            CaseWhenOptions {
+                num_when_then_pairs: 1,
+                has_else: true,
+            },
+            [condition, then_value, else_value],
+        )
+        .vortex_expect("geometry pruning case expressions have matching branch dtypes")
+}
+
+fn gt(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
+    binop(Operator::Gt, lhs, rhs)
+}
+
+fn gt_eq(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
+    binop(Operator::Gte, lhs, rhs)
+}
+
+fn lt(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
+    binop(Operator::Lt, lhs, rhs)
+}
+
+fn lt_eq(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
+    binop(Operator::Lte, lhs, rhs)
+}
+
+fn checked_add(lhs: BoundExpr, rhs: BoundExpr) -> BoundExpr {
+    binop(Operator::Add, lhs, rhs)
 }
 
 /// Lower bound on every row's squared distance to the query AABB: zero when the boxes overlap or
 /// touch, positive iff they are strictly separated.
 ///
 /// Prunes "near" predicates: `min_dist_sq > r^2` proves every row is farther than `r`.
-fn min_dist_sq(aabb: &Expression, query: GeoRect<f64>) -> Expression {
+fn min_dist_sq(aabb: &BoundExpr, query: GeoRect<f64>) -> BoundExpr {
     let field = |name: &str| get_item(name, aabb.clone());
     // Per axis: gap = max(0, q_lo - aabb_hi, aabb_lo - q_hi), positive only when the intervals
     // are separated. The nearest two points of the boxes are one axis-gap apart per axis, so the
     // squared distance is gap_x^2 + gap_y^2 (squared throughout to avoid a sqrt).
-    let gap = |q_lo: f64, q_hi: f64, lo: Expression, hi: Expression| {
+    let gap = |q_lo: f64, q_hi: f64, lo: BoundExpr, hi: BoundExpr| {
         maximum(
             lit(0.0),
             maximum(
@@ -128,12 +183,12 @@ fn min_dist_sq(aabb: &Expression, query: GeoRect<f64>) -> Expression {
 /// Upper bound on every row's squared distance to the query AABB.
 ///
 /// Prunes "far" predicates: `max_dist_sq < r^2` proves every row is within `r`.
-fn max_dist_sq(aabb: &Expression, query: GeoRect<f64>) -> Expression {
+fn max_dist_sq(aabb: &BoundExpr, query: GeoRect<f64>) -> BoundExpr {
     let field = |name: &str| get_item(name, aabb.clone());
     // Per axis: span = max(q_hi, aabb_hi) - min(q_lo, aabb_lo), the farthest two points of the
     // boxes can be apart. The nullable AABB field is the second `maximum`/`minimum` argument so
     // that `case_when`'s else branch carries the nullability - a missing stat propagates null.
-    let span = |q_lo: f64, q_hi: f64, lo: Expression, hi: Expression| {
+    let span = |q_lo: f64, q_hi: f64, lo: BoundExpr, hi: BoundExpr| {
         binop(
             Operator::Sub,
             maximum(lit(q_hi), hi),
@@ -146,23 +201,23 @@ fn max_dist_sq(aabb: &Expression, query: GeoRect<f64>) -> Expression {
 }
 
 /// `a <op> b`.
-fn binop(op: Operator, a: Expression, b: Expression) -> Expression {
+fn binop(op: Operator, a: BoundExpr, b: BoundExpr) -> BoundExpr {
     Binary
-        .try_new_expr(op, [a, b])
+        .try_new_bound_expr(op, [a, b])
         .vortex_expect("binary expression")
 }
 
 /// `e * e`.
-fn square(e: Expression) -> Expression {
+fn square(e: BoundExpr) -> BoundExpr {
     binop(Operator::Mul, e.clone(), e)
 }
 
 /// `max(a, b)`.
-fn maximum(a: Expression, b: Expression) -> Expression {
+fn maximum(a: BoundExpr, b: BoundExpr) -> BoundExpr {
     case_when(gt(a.clone(), b.clone()), a, b)
 }
 
 /// `min(a, b)`.
-fn minimum(a: Expression, b: Expression) -> Expression {
+fn minimum(a: BoundExpr, b: BoundExpr) -> BoundExpr {
     case_when(lt(a.clone(), b.clone()), a, b)
 }

--- a/vortex-geo/src/prune/mod.rs
+++ b/vortex-geo/src/prune/mod.rs
@@ -22,7 +22,7 @@ pub use intersects::GeoIntersectsPrune;
 use vortex_array::VortexSessionExecute;
 use vortex_array::aggregate_fn::AggregateFnVTableExt;
 use vortex_array::aggregate_fn::EmptyOptions;
-use vortex_array::expr::BoundExpression as BoundExpr;
+use vortex_array::expr::BoundExpression;
 use vortex_array::expr::bound::binary;
 use vortex_array::expr::bound::case_when;
 use vortex_array::expr::bound::checked_add;
@@ -52,9 +52,9 @@ use crate::extension::single_geometry;
 /// An asymmetric predicate (e.g. a future contains) must recover which operand is the column
 /// itself instead of calling this.
 fn geometry_and_constant<'a>(
-    expr: &'a BoundExpr,
+    expr: &'a BoundExpression,
     ctx: &StatsRewriteCtx<'_>,
-) -> VortexResult<Option<(&'a BoundExpr, &'a Scalar)>> {
+) -> VortexResult<Option<(&'a BoundExpression, &'a Scalar)>> {
     // The predicate is symmetric, so the column (scope root) and the constant may be on either
     // side.
     let (lhs, rhs) = (expr.child(0), expr.child(1));
@@ -95,7 +95,7 @@ fn query_aabb(constant: &Scalar, ctx: &StatsRewriteCtx<'_>) -> VortexResult<Opti
 ///
 /// A chunk written without the statistic reads as null here; every proof built on top must let
 /// that null propagate to its root, where the zone map keeps the chunk.
-fn aabb_stat(geom: &BoundExpr) -> BoundExpr {
+fn aabb_stat(geom: &BoundExpression) -> BoundExpression {
     // `ext_storage` unwraps the native `geoarrow.box` stat value to its backing struct, so
     // proofs can `get_item` the coordinate fields.
     ext_storage(stat(geom.clone(), GeometryAabb.bind(EmptyOptions)))
@@ -105,12 +105,12 @@ fn aabb_stat(geom: &BoundExpr) -> BoundExpr {
 /// touch, positive iff they are strictly separated.
 ///
 /// Prunes "near" predicates: `min_dist_sq > r^2` proves every row is farther than `r`.
-fn min_dist_sq(aabb: &BoundExpr, query: GeoRect<f64>) -> BoundExpr {
+fn min_dist_sq(aabb: &BoundExpression, query: GeoRect<f64>) -> BoundExpression {
     let field = |name: &str| get_item(name, aabb.clone());
     // Per axis: gap = max(0, q_lo - aabb_hi, aabb_lo - q_hi), positive only when the intervals
     // are separated. The nearest two points of the boxes are one axis-gap apart per axis, so the
     // squared distance is gap_x^2 + gap_y^2 (squared throughout to avoid a sqrt).
-    let gap = |q_lo: f64, q_hi: f64, lo: BoundExpr, hi: BoundExpr| {
+    let gap = |q_lo: f64, q_hi: f64, lo: BoundExpression, hi: BoundExpression| {
         maximum(
             lit(0.0),
             maximum(
@@ -127,12 +127,12 @@ fn min_dist_sq(aabb: &BoundExpr, query: GeoRect<f64>) -> BoundExpr {
 /// Upper bound on every row's squared distance to the query AABB.
 ///
 /// Prunes "far" predicates: `max_dist_sq < r^2` proves every row is within `r`.
-fn max_dist_sq(aabb: &BoundExpr, query: GeoRect<f64>) -> BoundExpr {
+fn max_dist_sq(aabb: &BoundExpression, query: GeoRect<f64>) -> BoundExpression {
     let field = |name: &str| get_item(name, aabb.clone());
     // Per axis: span = max(q_hi, aabb_hi) - min(q_lo, aabb_lo), the farthest two points of the
     // boxes can be apart. The nullable AABB field is the second `maximum`/`minimum` argument so
     // that `case_when`'s else branch carries the nullability - a missing stat propagates null.
-    let span = |q_lo: f64, q_hi: f64, lo: BoundExpr, hi: BoundExpr| {
+    let span = |q_lo: f64, q_hi: f64, lo: BoundExpression, hi: BoundExpression| {
         binary(
             Operator::Sub,
             maximum(lit(q_hi), hi),
@@ -145,16 +145,16 @@ fn max_dist_sq(aabb: &BoundExpr, query: GeoRect<f64>) -> BoundExpr {
 }
 
 /// `e * e`.
-fn square(e: BoundExpr) -> BoundExpr {
+fn square(e: BoundExpression) -> BoundExpression {
     binary(Operator::Mul, e.clone(), e)
 }
 
 /// `max(a, b)`.
-fn maximum(a: BoundExpr, b: BoundExpr) -> BoundExpr {
+fn maximum(a: BoundExpression, b: BoundExpression) -> BoundExpression {
     case_when(gt(a.clone(), b.clone()), a, b)
 }
 
 /// `min(a, b)`.
-fn minimum(a: BoundExpr, b: BoundExpr) -> BoundExpr {
+fn minimum(a: BoundExpression, b: BoundExpression) -> BoundExpression {
     case_when(lt(a.clone(), b.clone()), a, b)
 }

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -21,14 +21,12 @@ use vortex_array::dtype::FieldMask;
 use vortex_array::dtype::Nullability;
 use vortex_array::expr::BoundExpression;
 use vortex_array::expr::ExactBoundExpr;
+use vortex_array::expr::bound::pack as bound_pack;
 use vortex_array::expr::direct_bound_annotations;
 use vortex_array::expr::label_bound_tree;
 use vortex_array::expr::root;
 use vortex_array::expr::transform::partition_bound_annotations;
 use vortex_array::optimizer::ArrayOptimizer;
-use vortex_array::scalar_fn::ScalarFnVTableExt;
-use vortex_array::scalar_fn::fns::pack::Pack;
-use vortex_array::scalar_fn::fns::pack::PackOptions;
 use vortex_array::scalar_fn::is_negative_cost;
 use vortex_error::VortexError;
 use vortex_error::VortexExpect;
@@ -303,13 +301,7 @@ impl LayoutReader for DictReader {
         let values_eval = if let Some(inner) = expr_inner {
             // "outer" takes a struct field with PUSHDOWN_ANNOTATION name, so
             // pack inner with this name as well
-            let inner = BoundExpression::try_new(
-                Pack.bind(PackOptions {
-                    names: [PUSHDOWN_ANNOTATION].into(),
-                    nullability: Nullability::NonNullable,
-                }),
-                [inner],
-            )?;
+            let inner = bound_pack([(PUSHDOWN_ANNOTATION, inner)], Nullability::NonNullable);
 
             // We can't use values_eval as it uses values_array_uncanonical
             // which in turn gets populated from self.values. If
@@ -381,6 +373,7 @@ mod tests {
     use vortex_array::dtype::StructFields;
     use vortex_array::expr::BoundExpression;
     use vortex_array::expr::Expression;
+    use vortex_array::expr::bound::pack as bound_pack;
     use vortex_array::expr::byte_length;
     use vortex_array::expr::cast;
     use vortex_array::expr::eq;
@@ -390,9 +383,6 @@ mod tests {
     use vortex_array::expr::lit;
     use vortex_array::expr::pack;
     use vortex_array::expr::root;
-    use vortex_array::scalar_fn::ScalarFnVTableExt;
-    use vortex_array::scalar_fn::fns::pack::Pack;
-    use vortex_array::scalar_fn::fns::pack::PackOptions;
     use vortex_array::validity::Validity;
     use vortex_btrblocks::BtrBlocksCompressor;
     use vortex_error::VortexExpect;
@@ -765,13 +755,10 @@ mod tests {
         )
         .into_array();
 
-        let pushed_expr = Pack.try_new_bound_expr(
-            PackOptions {
-                names: [FieldName::from(PUSHDOWN_ANNOTATION)].into(),
-                nullability: Nullability::NonNullable,
-            },
-            [inner],
-        )?;
+        let pushed_expr = bound_pack(
+            [(FieldName::from(PUSHDOWN_ANNOTATION), inner)],
+            Nullability::NonNullable,
+        );
         let pushed = array.clone().apply_bound(&pushed_expr)?;
         let actual = pushed.apply_bound(&outer)?;
         let expected = array.apply(&original)?;

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -55,7 +55,7 @@ pub struct DictReader {
     /// Cached dict values array
     values_array: OnceLock<SharedArrayFuture>,
     /// Cache of expression evaluation results on the values array by expression
-    values_evals: DashMap<BoundExpression, SharedArrayFuture>,
+    values_evals: DashMap<ExactBoundExpr, SharedArrayFuture>,
 
     values: LayoutReaderRef,
     codes: LayoutReaderRef,
@@ -153,13 +153,15 @@ impl DictReader {
         // shouldn't.
         // TODO(joe): fixme
 
+        let key = ExactBoundExpr(expr.clone());
+
         // Check cache first with read-only lock
-        if let Some(fut) = self.values_evals.get(&expr) {
+        if let Some(fut) = self.values_evals.get(&key) {
             return fut.clone();
         }
 
         self.values_evals
-            .entry(expr.clone())
+            .entry(key)
             .or_insert_with(|| {
                 self.values_array_uncanonical()
                     .map(move |array| {

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -376,6 +376,8 @@ mod tests {
     use vortex_array::dtype::FieldNames;
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
+    use vortex_array::dtype::StructFields;
+    use vortex_array::expr::BoundExpression;
     use vortex_array::expr::Expression;
     use vortex_array::expr::byte_length;
     use vortex_array::expr::cast;
@@ -386,6 +388,9 @@ mod tests {
     use vortex_array::expr::lit;
     use vortex_array::expr::pack;
     use vortex_array::expr::root;
+    use vortex_array::scalar_fn::ScalarFnVTableExt;
+    use vortex_array::scalar_fn::fns::pack::Pack;
+    use vortex_array::scalar_fn::fns::pack::PackOptions;
     use vortex_array::validity::Validity;
     use vortex_btrblocks::BtrBlocksCompressor;
     use vortex_error::VortexExpect;
@@ -746,7 +751,11 @@ mod tests {
         get_item(format!("_{idx}"), get_item("", root()))
     }
 
-    fn test_apply(original: Expression, outer: Expression, inner: Expression) -> VortexResult<()> {
+    fn test_apply(
+        original: Expression,
+        outer: BoundExpression,
+        inner: BoundExpression,
+    ) -> VortexResult<()> {
         let mut ctx = array_session().create_execution_ctx();
         let array = VarBinArray::from_iter(
             [Some("abc"), Some("def"), None],
@@ -754,29 +763,39 @@ mod tests {
         )
         .into_array();
 
-        let pushed = array.clone().apply(&pack(
-            [(PUSHDOWN_ANNOTATION, inner)],
-            Nullability::NonNullable,
-        ))?;
-        let actual = pushed.apply(&outer)?;
+        let pushed_expr = Pack.try_new_bound_expr(
+            PackOptions {
+                names: [FieldName::from(PUSHDOWN_ANNOTATION)].into(),
+                nullability: Nullability::NonNullable,
+            },
+            [inner],
+        )?;
+        let pushed = array.clone().apply_bound(&pushed_expr)?;
+        let actual = pushed.apply_bound(&outer)?;
         let expected = array.apply(&original)?;
         assert_arrays_eq!(actual, expected, &mut ctx);
         Ok(())
     }
 
-    fn split_unbound(
+    fn split_bound(
         expr: Expression,
         dtype: &DType,
-    ) -> VortexResult<(Expression, Option<Expression>)> {
+    ) -> VortexResult<(BoundExpression, Option<BoundExpression>)> {
         let bound = expr.bind(dtype)?;
-        let (outer, inner) = split_expression_for_pushdown(&bound)?;
-        Ok((outer.unbind(), inner.map(|expr| expr.unbind())))
+        split_expression_for_pushdown(&bound)
+    }
+
+    fn pushed_scope(inner: &BoundExpression) -> DType {
+        DType::Struct(
+            StructFields::from_iter([(PUSHDOWN_ANNOTATION, inner.dtype().clone())]),
+            Nullability::NonNullable,
+        )
     }
 
     #[test]
     fn split_expr_root() {
-        let (outer, inner) = split_unbound(root(), &DType::Null).unwrap();
-        assert_eq!(outer, root());
+        let (outer, inner) = split_bound(root(), &DType::Null).unwrap();
+        assert_eq!(outer, root().bind(&DType::Null).unwrap());
         assert_eq!(inner, None);
     }
 
@@ -785,22 +804,27 @@ mod tests {
         // cast is fallible, thus not pushed
         let target = DType::Primitive(PType::I64, Nullability::Nullable);
         let expr = cast(byte_length(root()), target.clone());
-        let (outer, inner) = split_unbound(expr.clone(), &DType::Utf8(false.into()))?;
+        let dtype = DType::Utf8(false.into());
+        let (outer, inner) = split_bound(expr.clone(), &dtype)?;
         let inner = inner.unwrap();
         // [0] = cast([1], dtype)
         // [1] = byte_length(root)
-        assert_eq!(outer, cast(pushed_ref(0), target));
-        assert_eq!(inner, pushed_inner([byte_length(root())]));
+        assert_eq!(
+            outer,
+            cast(pushed_ref(0), target).bind(&pushed_scope(&inner))?
+        );
+        assert_eq!(inner, pushed_inner([byte_length(root())]).bind(&dtype)?);
         test_apply(expr, outer, inner)
     }
 
     #[test]
     fn split_expr_full_pushdown() -> VortexResult<()> {
         let expr = byte_length(root());
-        let (outer, inner) = split_unbound(expr.clone(), &DType::Utf8(false.into()))?;
+        let dtype = DType::Utf8(false.into());
+        let (outer, inner) = split_bound(expr.clone(), &dtype)?;
         let inner = inner.unwrap();
-        assert_eq!(outer, pushed_ref(0));
-        assert_eq!(inner, pushed_inner([byte_length(root())]));
+        assert_eq!(outer, pushed_ref(0).bind(&pushed_scope(&inner))?);
+        assert_eq!(inner, pushed_inner([byte_length(root())]).bind(&dtype)?);
         test_apply(expr, outer, inner)
     }
 
@@ -808,8 +832,9 @@ mod tests {
     fn split_expr_no_pushdown() {
         // like is fallible, thus not pushed. lit() does not reference root()
         let expr = like(root(), lit("abc"));
-        let (outer, inner) = split_unbound(expr.clone(), &DType::Utf8(true.into())).unwrap();
-        assert_eq!(outer, expr);
+        let dtype = DType::Utf8(true.into());
+        let (outer, inner) = split_bound(expr.clone(), &dtype).unwrap();
+        assert_eq!(outer, expr.bind(&dtype).unwrap());
         assert_eq!(inner, None);
     }
 }

--- a/vortex-layout/src/layouts/list/expr.rs
+++ b/vortex-layout/src/layouts/list/expr.rs
@@ -4,12 +4,10 @@
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::expr::BoundExpression;
-use vortex_array::scalar_fn::EmptyOptions;
-use vortex_array::scalar_fn::ScalarFnVTableExt;
+use vortex_array::expr::bound::not;
 use vortex_array::scalar_fn::fns::is_not_null::IsNotNull;
 use vortex_array::scalar_fn::fns::is_null::IsNull;
 use vortex_array::scalar_fn::fns::list_length::ListLength;
-use vortex_array::scalar_fn::fns::not::Not;
 use vortex_error::VortexResult;
 
 /// The minimal set of list children an expression needs for evaluation.
@@ -84,10 +82,7 @@ fn rewrite_validity_expr_with_root(
         && expr.children().len() == 1
         && expr.children()[0].is_root()
     {
-        return BoundExpression::try_new(
-            Not.bind(EmptyOptions),
-            [BoundExpression::new_root(root_dtype.clone())],
-        );
+        return Ok(not(BoundExpression::new_root(root_dtype.clone())));
     }
     if expr.is_root() {
         return Ok(BoundExpression::new_root(root_dtype.clone()));

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -17,11 +17,12 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldMask;
 use vortex_array::dtype::FieldName;
-use vortex_array::dtype::FieldNames;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::StructFields;
 use vortex_array::expr::BoundExpression;
 use vortex_array::expr::ExactBoundExpr;
+use vortex_array::expr::bound::get_item;
+use vortex_array::expr::bound::pack;
 use vortex_array::expr::make_bound_free_field_annotator;
 use vortex_array::expr::root;
 use vortex_array::expr::transform::BoundPartitionedExpr;
@@ -29,11 +30,9 @@ use vortex_array::expr::transform::partition_bound;
 use vortex_array::expr::traversal::NodeExt;
 use vortex_array::expr::traversal::Transformed;
 use vortex_array::expr::traversal::TraversalOrder;
-use vortex_array::scalar_fn::ScalarFnVTableExt;
 use vortex_array::scalar_fn::fns::get_item::GetItem;
 use vortex_array::scalar_fn::fns::merge::Merge;
 use vortex_array::scalar_fn::fns::pack::Pack;
-use vortex_array::scalar_fn::fns::pack::PackOptions;
 use vortex_array::scalar_fn::fns::select::Select;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -243,9 +242,12 @@ fn expanded_struct_root(
     let children = fields
         .names()
         .iter()
-        .map(|name| BoundExpression::try_new(GetItem.bind(name.clone()), [root.clone()]))
-        .try_collect()?;
-    bound_pack(fields.names().clone(), children)
+        .map(|name| get_item(name.clone(), root.clone()))
+        .collect::<Vec<_>>();
+    Ok(pack(
+        fields.names().iter().cloned().zip(children),
+        Nullability::NonNullable,
+    ))
 }
 
 fn expand_struct_root(
@@ -287,7 +289,7 @@ fn expand_struct_root(
 
             if let Some(selection) = scalar_fn.as_opt::<Select>() {
                 let names = selection.normalize_to_included_fields(fields.names())?;
-                let children = names
+                let children: Vec<_> = names
                     .iter()
                     .map(|name| {
                         let idx = fields.find(name).vortex_expect(
@@ -297,7 +299,7 @@ fn expand_struct_root(
                     })
                     .collect();
                 return Ok(Transformed {
-                    value: bound_pack(names, children)?,
+                    value: pack(names.into_iter().zip(children), Nullability::NonNullable),
                     changed: true,
                     order: TraversalOrder::Skip,
                 });
@@ -332,16 +334,6 @@ fn step_into_struct_field(
             }
         })?
         .into_inner())
-}
-
-fn bound_pack(names: FieldNames, children: Vec<BoundExpression>) -> VortexResult<BoundExpression> {
-    BoundExpression::try_new(
-        Pack.bind(PackOptions {
-            names,
-            nullability: Nullability::NonNullable,
-        }),
-        children,
-    )
 }
 
 fn is_pack_or_merge(expr: &BoundExpression) -> bool {

--- a/vortex-layout/src/layouts/zoned/pruning.rs
+++ b/vortex-layout/src/layouts/zoned/pruning.rs
@@ -19,6 +19,7 @@ use vortex_array::aggregate_fn::AggregateFnRef;
 use vortex_array::arrays::StructArray;
 use vortex_array::dtype::DType;
 use vortex_array::expr::BoundExpression;
+use vortex_array::expr::ExactBoundExpr;
 use vortex_array::expr::root;
 use vortex_array::scalar_fn::fns::dynamic::DynamicExprUpdates;
 use vortex_error::SharedVortexResult;
@@ -47,9 +48,9 @@ pub(super) struct PruningState {
     aggregate_fns: Arc<[AggregateFnRef]>,
     lazy_children: Arc<LazyReaderChildren>,
     session: VortexSession,
-    pruning_result: LazyLock<DashMap<BoundExpression, Option<SharedPruningResult>>>,
+    pruning_result: LazyLock<DashMap<ExactBoundExpr, Option<SharedPruningResult>>>,
     zone_map: OnceLock<SharedZoneMap>,
-    pruning_predicates: LazyLock<Arc<DashMap<BoundExpression, PredicateCache>>>,
+    pruning_predicates: LazyLock<Arc<DashMap<ExactBoundExpr, PredicateCache>>>,
 }
 
 impl PruningState {
@@ -78,12 +79,14 @@ impl PruningState {
     }
 
     pub(super) fn pruning_mask_future(&self, expr: BoundExpression) -> Option<SharedPruningResult> {
-        if let Some(result) = self.pruning_result.get(&expr) {
+        let key = ExactBoundExpr(expr.clone());
+
+        if let Some(result) = self.pruning_result.get(&key) {
             return result.value().clone();
         }
 
         self.pruning_result
-            .entry(expr.clone())
+            .entry(key)
             .or_insert_with(|| {
                 let dynamic_updates = DynamicExprUpdates::new(&expr);
                 match self.pruning_predicate(expr.clone()) {
@@ -124,8 +127,10 @@ impl PruningState {
     }
 
     fn pruning_predicate(&self, expr: BoundExpression) -> Option<BoundExpression> {
+        let key = ExactBoundExpr(expr.clone());
+
         self.pruning_predicates
-            .entry(expr.clone())
+            .entry(key)
             .or_default()
             .get_or_init(move || match expr.falsify(&self.session) {
                 Ok(predicate) => predicate,

--- a/vortex-layout/src/layouts/zoned/pruning.rs
+++ b/vortex-layout/src/layouts/zoned/pruning.rs
@@ -19,7 +19,6 @@ use vortex_array::aggregate_fn::AggregateFnRef;
 use vortex_array::arrays::StructArray;
 use vortex_array::dtype::DType;
 use vortex_array::expr::BoundExpression;
-use vortex_array::expr::Expression;
 use vortex_array::expr::root;
 use vortex_array::scalar_fn::fns::dynamic::DynamicExprUpdates;
 use vortex_error::SharedVortexResult;
@@ -38,7 +37,7 @@ use crate::layouts::zoned::zone_map::ZoneMap;
 type SharedZoneMap = Shared<BoxFuture<'static, SharedVortexResult<ZoneMap>>>;
 pub(super) type SharedPruningResult =
     Shared<BoxFuture<'static, SharedVortexResult<Arc<PruningResult>>>>;
-type PredicateCache = Arc<OnceLock<Option<Expression>>>;
+type PredicateCache = Arc<OnceLock<Option<BoundExpression>>>;
 
 pub(super) struct PruningState {
     zone_count: usize,
@@ -50,7 +49,7 @@ pub(super) struct PruningState {
     session: VortexSession,
     pruning_result: LazyLock<DashMap<BoundExpression, Option<SharedPruningResult>>>,
     zone_map: OnceLock<SharedZoneMap>,
-    pruning_predicates: LazyLock<Arc<DashMap<Expression, PredicateCache>>>,
+    pruning_predicates: LazyLock<Arc<DashMap<BoundExpression, PredicateCache>>>,
 }
 
 impl PruningState {
@@ -86,7 +85,7 @@ impl PruningState {
         self.pruning_result
             .entry(expr.clone())
             .or_insert_with(|| {
-                let expr = expr.unbind();
+                let dynamic_updates = DynamicExprUpdates::new(&expr);
                 match self.pruning_predicate(expr.clone()) {
                     None => {
                         trace!(%expr, "no pruning predicate");
@@ -95,7 +94,6 @@ impl PruningState {
                     Some(predicate) => {
                         trace!(%expr, ?predicate, "constructed pruning predicate");
                         let zone_map = self.zone_map();
-                        let dynamic_updates = DynamicExprUpdates::new(&expr);
                         let session = self.session.clone();
 
                         Some(
@@ -125,11 +123,11 @@ impl PruningState {
             .clone()
     }
 
-    fn pruning_predicate(&self, expr: Expression) -> Option<Expression> {
+    fn pruning_predicate(&self, expr: BoundExpression) -> Option<BoundExpression> {
         self.pruning_predicates
             .entry(expr.clone())
             .or_default()
-            .get_or_init(move || match expr.falsify(&self.dtype, &self.session) {
+            .get_or_init(move || match expr.falsify(&self.session) {
                 Ok(predicate) => predicate,
                 Err(error) => {
                     trace!(%expr, %error, "failed to construct stats rewrite predicate");
@@ -188,7 +186,7 @@ impl PruningState {
 
 pub(super) struct PruningResult {
     zone_map: ZoneMap,
-    predicate: Expression,
+    predicate: BoundExpression,
     dynamic_updates: Option<DynamicExprUpdates>,
     latest_result: RwLock<(u64, Mask)>,
     session: VortexSession,

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -16,24 +16,20 @@ use vortex_array::aggregate_fn::fns::all_non_null::AllNonNull;
 use vortex_array::aggregate_fn::fns::all_null::AllNull;
 use vortex_array::aggregate_fn::fns::bounded_max::BOUNDED_MAX_BOUND;
 use vortex_array::aggregate_fn::fns::bounded_max::BoundedMax;
-use vortex_array::aggregate_fn::fns::nan_count::NanCount;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::StructArray;
 use vortex_array::arrays::struct_::StructArrayExt;
 use vortex_array::dtype::DType;
+use vortex_array::expr::BoundExpression;
 use vortex_array::expr::Expression;
 use vortex_array::expr::eq;
 use vortex_array::expr::get_item;
-use vortex_array::expr::is_root;
 use vortex_array::expr::lit;
 use vortex_array::expr::root;
 use vortex_array::expr::stats::Stat;
-use vortex_array::expr::traversal::NodeExt;
-use vortex_array::expr::traversal::Transformed;
 use vortex_array::scalar_fn::EmptyOptions;
 use vortex_array::scalar_fn::ScalarFnVTableExt;
-use vortex_array::scalar_fn::fns::stat::StatFn;
 use vortex_array::scalar_fn::internal::row_count::RowCount;
 use vortex_array::scalar_fn::internal::row_count::contains_row_count;
 use vortex_array::scalar_fn::internal::row_count::substitute_row_count;
@@ -43,6 +39,7 @@ use vortex_array::validity::Validity;
 use vortex_buffer::buffer;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_error::vortex_ensure;
 use vortex_mask::Mask;
 use vortex_runend::RunEnd;
 use vortex_session::VortexSession;
@@ -131,7 +128,7 @@ impl ZoneMap {
     /// Apply a pruning predicate to this zone map.
     ///
     /// `predicate` should be a stats rewrite expression such as the result of
-    /// [`Expression::falsify`]. The returned mask has one value per zone, where
+    /// [`BoundExpression::falsify`]. The returned mask has one value per zone, where
     /// `true` means the zone cannot contain matching rows and can be skipped.
     ///
     /// If the predicate contains [`row_count`][vortex_array::scalar_fn::internal::row_count]
@@ -141,13 +138,17 @@ impl ZoneMap {
     /// `row_count` is a layout property rather than a stored stats field, and the
     /// final zone may be shorter than the nominal zone length, so it is materialized
     /// only after the predicate has been lowered to the zone-map table.
-    pub fn prune(&self, predicate: &Expression, session: &VortexSession) -> VortexResult<Mask> {
+    pub fn prune(
+        &self,
+        predicate: &BoundExpression,
+        session: &VortexSession,
+    ) -> VortexResult<Mask> {
         let mut ctx = session.create_execution_ctx();
         let num_zones = self.array.len();
         let predicate = self.lower_stats(predicate.clone())?;
 
         let array = self.array.clone().into_array();
-        let applied = array.apply(&predicate)?;
+        let applied = array.apply_bound(&predicate)?;
 
         if !contains_row_count(&applied) {
             return applied.null_as_false().execute(&mut ctx);
@@ -158,42 +159,9 @@ impl ZoneMap {
         substituted.null_as_false().execute(&mut ctx)
     }
 
-    fn lower_stats(&self, predicate: Expression) -> VortexResult<Expression> {
-        let predicate = self.lower_non_float_nan_stats(predicate)?;
+    fn lower_stats(&self, predicate: BoundExpression) -> VortexResult<BoundExpression> {
         let binder = ZoneMapStatsBinder { zone_map: self };
-        bind_stats(predicate, &binder)?.optimize_recursive(self.array.dtype())
-    }
-
-    fn lower_non_float_nan_stats(&self, predicate: Expression) -> VortexResult<Expression> {
-        predicate
-            .transform_down(|expr| {
-                if !expr.is::<StatFn>() {
-                    return Ok(Transformed::no(expr));
-                }
-
-                let options = expr.as_::<StatFn>();
-                let aggregate_fn = options.aggregate_fn();
-                let input_dtype = expr.child(0).return_dtype(&self.column_dtype)?;
-
-                if has_nans(&input_dtype) {
-                    return Ok(Transformed::no(expr));
-                }
-
-                if aggregate_fn.is::<NanCount>() {
-                    return Ok(Transformed::yes(lit(0u64)));
-                }
-
-                if aggregate_fn.is::<AllNan>() {
-                    return Ok(Transformed::yes(lit(false)));
-                }
-
-                if aggregate_fn.is::<AllNonNan>() {
-                    return Ok(Transformed::yes(lit(true)));
-                }
-
-                Ok(Transformed::no(expr))
-            })
-            .map(Transformed::into_inner)
+        bind_stats(predicate, &binder)
     }
 }
 
@@ -202,57 +170,73 @@ struct ZoneMapStatsBinder<'a> {
 }
 
 impl StatBinder for ZoneMapStatsBinder<'_> {
-    fn scope(&self) -> &DType {
-        &self.zone_map.column_dtype
-    }
-
     fn bind_aggregate(
         &self,
-        input: &Expression,
+        input: &BoundExpression,
         aggregate_fn: &AggregateFnRef,
         _stat_dtype: &DType,
-    ) -> VortexResult<Option<Expression>> {
-        if !is_root(input) {
+    ) -> VortexResult<Option<BoundExpression>> {
+        if !input.is_root() {
             return Ok(None);
         }
+        vortex_ensure!(
+            input.dtype() == &self.zone_map.column_dtype,
+            "Stats predicate root dtype {} does not match zone-map column dtype {}",
+            input.dtype(),
+            self.zone_map.column_dtype
+        );
 
         if let Some(stat_expr) = self.zone_map.aggregate_field_expr(aggregate_fn) {
-            return Ok(Some(stat_expr));
+            return Ok(Some(self.bind_target(stat_expr)?));
         }
 
         if aggregate_fn.is::<AllNull>() {
-            return Ok(self
+            return self
                 .zone_map
                 .stat_field_expr(Stat::NullCount)
-                .map(|null_count| eq(null_count, row_count_expr())));
+                .map(|null_count| self.bind_target(eq(null_count, row_count_expr())))
+                .transpose();
         }
 
         if aggregate_fn.is::<AllNonNull>() {
-            return Ok(self
+            return self
                 .zone_map
                 .stat_field_expr(Stat::NullCount)
-                .map(|null_count| eq(null_count, lit(0u64))));
+                .map(|null_count| self.bind_target(eq(null_count, lit(0u64))))
+                .transpose();
         }
 
         if aggregate_fn.is::<AllNan>() {
-            return Ok(self
+            return self
                 .zone_map
                 .stat_field_expr(Stat::NaNCount)
-                .map(|nan_count| eq(nan_count, row_count_expr())));
+                .map(|nan_count| self.bind_target(eq(nan_count, row_count_expr())))
+                .transpose();
         }
 
         if aggregate_fn.is::<AllNonNan>() {
-            return Ok(self
+            return self
                 .zone_map
                 .stat_field_expr(Stat::NaNCount)
-                .map(|nan_count| eq(nan_count, lit(0u64))));
+                .map(|nan_count| self.bind_target(eq(nan_count, lit(0u64))))
+                .transpose();
         }
 
         if let Some(stat) = Stat::from_aggregate_fn(aggregate_fn) {
-            return Ok(self.zone_map.stat_field_expr(stat));
+            return self
+                .zone_map
+                .stat_field_expr(stat)
+                .map(|expr| self.bind_target(expr))
+                .transpose();
         }
 
         Ok(None)
+    }
+}
+
+impl ZoneMapStatsBinder<'_> {
+    fn bind_target(&self, expr: Expression) -> VortexResult<BoundExpression> {
+        expr.bind(self.zone_map.array.dtype())
     }
 }
 
@@ -318,10 +302,6 @@ fn row_count_expr() -> Expression {
     RowCount.new_expr(EmptyOptions, [])
 }
 
-fn has_nans(dtype: &DType) -> bool {
-    matches!(dtype, DType::Primitive(ptype, _) if ptype.is_float())
-}
-
 /// Build per-zone row counts for a zone map.
 ///
 /// `zone_len` is the nominal zone size; only the final zone may be shorter. The
@@ -385,6 +365,7 @@ mod tests {
     use vortex_array::dtype::FieldNames;
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
+    use vortex_array::expr::BoundExpression;
     use vortex_array::expr::Expression;
     use vortex_array::expr::cast;
     use vortex_array::expr::gt;
@@ -402,12 +383,22 @@ mod tests {
     use vortex_array::stats::all_null;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
+    use vortex_mask::Mask;
 
     use crate::layouts::zoned::zone_map::ZoneMap;
     use crate::test::SESSION;
 
-    fn falsify(expr: &Expression, dtype: DType) -> Expression {
-        expr.falsify(&dtype, &SESSION).unwrap().unwrap()
+    fn falsify(expr: &Expression, dtype: DType) -> BoundExpression {
+        expr.bind(&dtype)
+            .unwrap()
+            .falsify(&SESSION)
+            .unwrap()
+            .unwrap()
+    }
+
+    fn prune(zone_map: &ZoneMap, predicate: &Expression) -> VortexResult<Mask> {
+        zone_map.prune(&predicate.bind(&zone_map.column_dtype)?, &SESSION)
     }
 
     fn default_bounded_stat_max_bytes() -> NonZeroUsize {
@@ -631,7 +622,7 @@ mod tests {
         )
         .unwrap();
 
-        let mask = zone_map.prune(&all_null(root()), &SESSION).unwrap();
+        let mask = prune(&zone_map, &all_null(root())).unwrap();
         assert_arrays_eq!(
             mask.into_array(),
             BoolArray::from_iter([false, true, true]),
@@ -654,7 +645,7 @@ mod tests {
         )
         .unwrap();
 
-        let mask = zone_map.prune(&all_non_null(root()), &SESSION).unwrap();
+        let mask = prune(&zone_map, &all_non_null(root())).unwrap();
         assert_arrays_eq!(
             mask.into_array(),
             BoolArray::from_iter([true, false, false]),
@@ -679,14 +670,14 @@ mod tests {
         .unwrap();
         let ctx = &mut SESSION.create_execution_ctx();
 
-        let mask = zone_map.prune(&all_null(root()), &SESSION).unwrap();
+        let mask = prune(&zone_map, &all_null(root())).unwrap();
         assert_arrays_eq!(
             mask.into_array(),
             BoolArray::from_iter([true, false, true]),
             ctx
         );
 
-        let mask = zone_map.prune(&all_non_null(root()), &SESSION).unwrap();
+        let mask = prune(&zone_map, &all_non_null(root())).unwrap();
         assert_arrays_eq!(
             mask.into_array(),
             BoolArray::from_iter([false, true, false]),
@@ -711,14 +702,14 @@ mod tests {
         .unwrap();
         let ctx = &mut SESSION.create_execution_ctx();
 
-        let mask = zone_map.prune(&all_nan(root()), &SESSION).unwrap();
+        let mask = prune(&zone_map, &all_nan(root())).unwrap();
         assert_arrays_eq!(
             mask.into_array(),
             BoolArray::from_iter([true, false, true]),
             ctx
         );
 
-        let mask = zone_map.prune(&all_non_nan(root()), &SESSION).unwrap();
+        let mask = prune(&zone_map, &all_non_nan(root())).unwrap();
         assert_arrays_eq!(
             mask.into_array(),
             BoolArray::from_iter([false, true, false]),
@@ -727,22 +718,17 @@ mod tests {
     }
 
     #[test]
-    fn non_float_nan_stat_fns_lower_to_constants() {
-        let zone_map = ZoneMap::try_new(
-            PType::I32.into(),
-            StructArray::try_new(FieldNames::empty(), vec![], 2, Validity::NonNullable).unwrap(),
-            Arc::new([]),
-            4,
-            8,
-        )
-        .unwrap();
-        let ctx = &mut SESSION.create_execution_ctx();
-
-        let mask = zone_map.prune(&all_nan(root()), &SESSION).unwrap();
-        assert_arrays_eq!(mask.into_array(), BoolArray::from_iter([false, false]), ctx);
-
-        let mask = zone_map.prune(&all_non_nan(root()), &SESSION).unwrap();
-        assert_arrays_eq!(mask.into_array(), BoolArray::from_iter([true, true]), ctx);
+    fn non_float_nan_stat_fns_fail_to_bind() {
+        let dtype = DType::from(PType::I32);
+        for expr in [all_nan(root()), all_non_nan(root())] {
+            let error = expr.bind(&dtype).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("does not support input dtype i32"),
+                "{error}"
+            );
+        }
     }
 
     #[test]
@@ -757,7 +743,7 @@ mod tests {
         .unwrap();
         let ctx = &mut SESSION.create_execution_ctx();
 
-        let mask = zone_map.prune(&all_non_null(root()), &SESSION).unwrap();
+        let mask = prune(&zone_map, &all_non_null(root())).unwrap();
         assert_arrays_eq!(
             mask.into_array(),
             BoolArray::from_iter([false, false, false]),
@@ -899,7 +885,7 @@ mod tests {
         let predicate = is_null(vortex_array::stats::stat(root(), max_fn));
 
         // Missing StatFn lowers to a nullable null literal, so `is_null(...)` is true for every zone.
-        let mask = zone_map.prune(&predicate, &SESSION).unwrap();
+        let mask = prune(&zone_map, &predicate).unwrap();
         assert_arrays_eq!(
             mask.into_array(),
             BoolArray::from_iter([true, true, true]),
@@ -922,7 +908,7 @@ mod tests {
             .aggregate_fn()
             .expect("max should have an aggregate function");
         let predicate = is_null(vortex_array::stats::stat(root(), max_fn));
-        let error = zone_map.prune(&predicate, &SESSION).unwrap_err();
+        let error = prune(&zone_map, &predicate).unwrap_err();
 
         assert!(
             error
@@ -975,7 +961,7 @@ mod tests {
         )
         .unwrap();
 
-        let mask = zone_map.prune(&all_null(root()), &SESSION).unwrap();
+        let mask = prune(&zone_map, &all_null(root())).unwrap();
         assert_arrays_eq!(
             mask.into_array(),
             BoolArray::from_iter([false, true, true]),
@@ -999,7 +985,7 @@ mod tests {
         )
         .unwrap();
 
-        let mask = zone_map.prune(&all_non_null(root()), &SESSION).unwrap();
+        let mask = prune(&zone_map, &all_non_null(root())).unwrap();
         assert_arrays_eq!(
             mask.into_array(),
             BoolArray::from_iter([true, false, false]),

--- a/vortex-layout/src/lib.rs
+++ b/vortex-layout/src/lib.rs
@@ -11,9 +11,9 @@
 //! Most users enter this crate through file APIs, but extension authors implement [`VTable`] and
 //! [`LayoutStrategy`] to add new on-disk organizations.
 //!
-//! Scanning is built with [`scan::scan_builder::ScanBuilder`]. It accepts a projection expression,
-//! optional filter, optional row range, [`Selection`](vortex_scan::selection::Selection), split
-//! strategy, and task concurrency settings, then produces array streams or iterators.
+//! Scanning is built with [`scan::scan_builder::ScanBuilder`]. It accepts a bound projection,
+//! optional bound filter, optional row range, [`Selection`](vortex_scan::selection::Selection),
+//! split strategy, and task concurrency settings, then produces array streams or iterators.
 pub mod layouts;
 
 pub use children::*;

--- a/vortex-layout/src/scan/filter.rs
+++ b/vortex-layout/src/scan/filter.rs
@@ -58,10 +58,7 @@ impl FilterExpr {
         let conjuncts = bound_conjuncts(&expr);
         let num_conjuncts = conjuncts.len();
 
-        let dynamic_conjuncts = conjuncts
-            .iter()
-            .map(|expr| DynamicExprUpdates::new(&expr.unbind()))
-            .collect_vec();
+        let dynamic_conjuncts = conjuncts.iter().map(DynamicExprUpdates::new).collect_vec();
 
         Self {
             conjuncts,

--- a/vortex-layout/src/scan/filter.rs
+++ b/vortex-layout/src/scan/filter.rs
@@ -173,13 +173,12 @@ mod tests {
         let filter = FilterExpr::new(bound);
         let conjuncts = filter.conjuncts();
 
-        assert_eq!(
-            conjuncts
-                .iter()
-                .map(|expr| expr.unbind())
-                .collect::<Vec<_>>(),
-            vec![root(), not(root()), lit(true)]
-        );
+        let expected = vec![
+            root().bind(&dtype)?,
+            not(root()).bind(&dtype)?,
+            lit(true).bind(&dtype)?,
+        ];
+        assert_eq!(conjuncts, expected.as_slice());
         assert_eq!(
             conjuncts
                 .iter()

--- a/vortex-layout/src/scan/layout.rs
+++ b/vortex-layout/src/scan/layout.rs
@@ -41,7 +41,6 @@ use vortex_session::VortexSession;
 
 use crate::LayoutReaderRef;
 use crate::scan::scan_builder::ScanBuilder;
-use crate::scan::scan_builder::optimize_and_bind;
 
 /// An implementation of a [`DataSource`] that reads data from a [`LayoutReaderRef`].
 pub struct LayoutReaderDataSource {
@@ -116,10 +115,16 @@ impl DataSource for LayoutReaderDataSource {
         let total_rows = self.reader.row_count();
         let row_range = scan_request.row_range.unwrap_or(0..total_rows);
 
-        let projection = optimize_and_bind(scan_request.projection, self.reader.dtype())?;
+        let projection = scan_request
+            .projection
+            .optimize_recursive(self.reader.dtype())?
+            .bind(self.reader.dtype())?;
         let filter = scan_request
             .filter
-            .map(|expr| optimize_and_bind(expr, self.reader.dtype()))
+            .map(|expr| {
+                expr.optimize_recursive(self.reader.dtype())?
+                    .bind(self.reader.dtype())
+            })
             .transpose()?;
         let dtype = projection.dtype().clone();
 

--- a/vortex-layout/src/scan/layout.rs
+++ b/vortex-layout/src/scan/layout.rs
@@ -18,7 +18,7 @@ use vortex_array::arrays::ConstantArray;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldPath;
 use vortex_array::dtype::Nullability;
-use vortex_array::expr::Expression;
+use vortex_array::expr::BoundExpression;
 use vortex_array::expr::stats::Precision;
 use vortex_array::scalar::Scalar;
 use vortex_array::stats::StatsSet;
@@ -41,6 +41,7 @@ use vortex_session::VortexSession;
 
 use crate::LayoutReaderRef;
 use crate::scan::scan_builder::ScanBuilder;
+use crate::scan::scan_builder::optimize_and_bind;
 
 /// An implementation of a [`DataSource`] that reads data from a [`LayoutReaderRef`].
 pub struct LayoutReaderDataSource {
@@ -115,13 +116,18 @@ impl DataSource for LayoutReaderDataSource {
         let total_rows = self.reader.row_count();
         let row_range = scan_request.row_range.unwrap_or(0..total_rows);
 
-        let dtype = scan_request.projection.return_dtype(self.reader.dtype())?;
+        let projection = optimize_and_bind(scan_request.projection, self.reader.dtype())?;
+        let filter = scan_request
+            .filter
+            .map(|expr| optimize_and_bind(expr, self.reader.dtype()))
+            .transpose()?;
+        let dtype = projection.dtype().clone();
 
         // If the dtype is an empty struct, and there is no filter, we can return a special
         // length-only scan.
         if let DType::Struct(fields, Nullability::NonNullable) = &dtype
             && fields.nfields() == 0
-            && scan_request.filter.is_none()
+            && filter.is_none()
         {
             // FIXME(ngates): extract out maybe?
             let row_count = row_range.end - row_range.start;
@@ -139,14 +145,13 @@ impl DataSource for LayoutReaderDataSource {
 
         // Check file-level pruning: if the filter can be proven false for the entire row range
         // using file-level statistics (e.g. via FileStatsLayoutReader), skip the scan entirely.
-        if let Some(filter) = &scan_request.filter {
-            let filter = filter.bind(self.reader.dtype())?;
+        if let Some(filter) = &filter {
             let mask = Mask::new_true(
                 usize::try_from(row_range.end - row_range.start).unwrap_or(usize::MAX),
             );
             let pruning_result = self
                 .reader
-                .pruning_evaluation(&row_range, &filter, mask)?
+                .pruning_evaluation(&row_range, filter, mask)?
                 .now_or_never();
             if let Some(Ok(result_mask)) = pruning_result
                 && result_mask.all_false()
@@ -162,8 +167,8 @@ impl DataSource for LayoutReaderDataSource {
             reader: Arc::clone(&self.reader),
             session: self.session.clone(),
             dtype,
-            projection: scan_request.projection,
-            filter: scan_request.filter,
+            projection,
+            filter,
             limit: scan_request.limit,
             selection: scan_request.selection,
             ordered: scan_request.ordered,
@@ -183,8 +188,8 @@ struct LayoutReaderScan {
     reader: LayoutReaderRef,
     session: VortexSession,
     dtype: DType,
-    projection: Expression,
-    filter: Option<Expression>,
+    projection: BoundExpression,
+    filter: Option<BoundExpression>,
     limit: Option<u64>,
     ordered: bool,
     selection: Selection,
@@ -276,8 +281,8 @@ impl Stream for LayoutReaderScan {
 struct LayoutReaderSplit {
     reader: LayoutReaderRef,
     session: VortexSession,
-    projection: Expression,
-    filter: Option<Expression>,
+    projection: BoundExpression,
+    filter: Option<BoundExpression>,
     limit: Option<u64>,
     ordered: bool,
     row_range: Range<u64>,

--- a/vortex-layout/src/scan/multi.rs
+++ b/vortex-layout/src/scan/multi.rs
@@ -26,6 +26,7 @@
 
 use std::any::Any;
 use std::collections::VecDeque;
+use std::ops::Range;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -36,6 +37,7 @@ use itertools::Itertools;
 use tracing::Instrument;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldPath;
+use vortex_array::expr::BoundExpression;
 use vortex_array::expr::stats::Precision;
 use vortex_array::stats::StatsSet;
 use vortex_array::stream::ArrayStreamAdapter;
@@ -43,6 +45,7 @@ use vortex_array::stream::ArrayStreamExt;
 use vortex_array::stream::SendableArrayStream;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
 use vortex_io::session::RuntimeSessionExt;
 use vortex_mask::Mask;
 use vortex_scan::DataSource;
@@ -58,6 +61,7 @@ use vortex_utils::parallelism::get_available_parallelism;
 
 use crate::LayoutReaderRef;
 use crate::scan::scan_builder::ScanBuilder;
+use crate::scan::scan_builder::optimize_and_bind;
 
 /// Default concurrency for opening deferred readers.
 const DEFAULT_CONCURRENCY: usize = 8;
@@ -299,12 +303,14 @@ impl DataSource for MultiLayoutDataSource {
             }
         }
 
-        let dtype = scan_request.projection.return_dtype(&self.dtype)?;
+        let request = BoundScanRequest::try_new(scan_request, &self.dtype)?;
+        let dtype = request.projection.dtype().clone();
 
         Ok(Box::new(MultiLayoutScan {
             session: self.session.clone(),
+            source_dtype: self.dtype.clone(),
             dtype,
-            request: scan_request,
+            request,
             ready,
             deferred,
             handle: self.session.handle(),
@@ -317,10 +323,51 @@ impl DataSource for MultiLayoutDataSource {
     }
 }
 
+#[derive(Clone)]
+struct BoundScanRequest {
+    projection: BoundExpression,
+    filter: Option<BoundExpression>,
+    row_range: Option<Range<u64>>,
+    selection: Selection,
+    partition_selection: Selection,
+    partition_range: Option<Range<u64>>,
+    ordered: bool,
+    limit: Option<u64>,
+}
+
+impl BoundScanRequest {
+    fn try_new(request: ScanRequest, dtype: &DType) -> VortexResult<Self> {
+        let ScanRequest {
+            projection,
+            filter,
+            row_range,
+            selection,
+            partition_selection,
+            partition_range,
+            ordered,
+            limit,
+        } = request;
+
+        Ok(Self {
+            projection: optimize_and_bind(projection, dtype)?,
+            filter: filter
+                .map(|expr| optimize_and_bind(expr, dtype))
+                .transpose()?,
+            row_range,
+            selection,
+            partition_selection,
+            partition_range,
+            ordered,
+            limit,
+        })
+    }
+}
+
 struct MultiLayoutScan {
     session: VortexSession,
+    source_dtype: DType,
     dtype: DType,
-    request: ScanRequest,
+    request: BoundScanRequest,
     ready: VecDeque<LayoutReaderRef>,
     deferred: VecDeque<Arc<dyn LayoutReaderFactory>>,
     handle: vortex_io::runtime::Handle,
@@ -344,6 +391,7 @@ impl DataSourceScan for MultiLayoutScan {
     fn partitions(self: Box<Self>) -> PartitionStream {
         let Self {
             session,
+            source_dtype,
             dtype: _,
             request,
             ready,
@@ -400,7 +448,9 @@ impl DataSourceScan for MultiLayoutScan {
             .chain(deferred_stream)
             .enumerate()
             .flat_map(move |(i, reader_result)| match reader_result {
-                Ok(reader) => reader_partition(i, reader, session.clone(), request.clone()),
+                Ok(reader) => {
+                    reader_partition(i, reader, session.clone(), &source_dtype, request.clone())
+                }
                 Err(e) => stream::once(async move { Err(e) }).boxed(),
             })
             .boxed()
@@ -416,8 +466,18 @@ fn reader_partition(
     partition_idx: usize,
     reader: LayoutReaderRef,
     session: VortexSession,
-    request: ScanRequest,
+    source_dtype: &DType,
+    request: BoundScanRequest,
 ) -> PartitionStream {
+    if reader.dtype() != source_dtype {
+        let error = vortex_err!(
+            "Multi-layout reader dtype mismatch: expected {}, got {}",
+            source_dtype,
+            reader.dtype()
+        );
+        return stream::once(async move { Err(error) }).boxed();
+    }
+
     let row_count = reader.row_count();
     let row_range = request.row_range.clone().unwrap_or(0..row_count);
 
@@ -446,8 +506,7 @@ fn reader_partition(
     if let Some(filter) = &request.filter {
         let mask_len = usize::try_from(row_range.end - row_range.start).unwrap_or(usize::MAX);
         let mask = Mask::new_true(mask_len);
-        if let Ok(filter) = filter.bind(reader.dtype())
-            && let Ok(pruning_future) = reader.pruning_evaluation(&row_range, &filter, mask)
+        if let Ok(pruning_future) = reader.pruning_evaluation(&row_range, filter, mask)
             && let Some(Ok(result_mask)) = pruning_future.now_or_never()
             && result_mask.all_false()
         {
@@ -459,7 +518,7 @@ fn reader_partition(
         Ok(Box::new(MultiLayoutPartition {
             reader,
             session,
-            request: ScanRequest {
+            request: BoundScanRequest {
                 row_range: Some(row_range),
                 ..request
             },
@@ -476,7 +535,7 @@ fn reader_partition(
 struct MultiLayoutPartition {
     reader: LayoutReaderRef,
     session: VortexSession,
-    request: ScanRequest,
+    request: BoundScanRequest,
     index: usize,
 }
 

--- a/vortex-layout/src/scan/multi.rs
+++ b/vortex-layout/src/scan/multi.rs
@@ -43,6 +43,7 @@ use vortex_array::stats::StatsSet;
 use vortex_array::stream::ArrayStreamAdapter;
 use vortex_array::stream::ArrayStreamExt;
 use vortex_array::stream::SendableArrayStream;
+use vortex_error::SharedVortexResult;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
@@ -326,7 +327,7 @@ impl DataSource for MultiLayoutDataSource {
 #[derive(Clone)]
 struct BoundScanRequest {
     projection: BoundExpression,
-    filter: Option<BoundExpression>,
+    filter: SharedVortexResult<Option<BoundExpression>>,
     row_range: Option<Range<u64>>,
     selection: Selection,
     partition_selection: Selection,
@@ -352,7 +353,8 @@ impl BoundScanRequest {
             projection: optimize_and_bind(projection, dtype)?,
             filter: filter
                 .map(|expr| optimize_and_bind(expr, dtype))
-                .transpose()?,
+                .transpose()
+                .map_err(Arc::new),
             row_range,
             selection,
             partition_selection,
@@ -503,7 +505,7 @@ fn reader_partition(
 
     // Check file-level pruning: if the filter can be proven false for the entire row range
     // using file-level statistics, skip this reader entirely.
-    if let Some(filter) = &request.filter {
+    if let Ok(Some(filter)) = &request.filter {
         let mask_len = usize::try_from(row_range.end - row_range.start).unwrap_or(usize::MAX);
         let mask = Mask::new_true(mask_len);
         if let Ok(pruning_future) = reader.pruning_evaluation(&row_range, filter, mask)
@@ -559,7 +561,11 @@ impl Partition for MultiLayoutPartition {
             .limit
             .map_or(row_count, |limit| row_count.min(limit));
 
-        if self.request.filter.is_some() {
+        let has_filter = match &self.request.filter {
+            Ok(filter) => filter.is_some(),
+            Err(_) => true,
+        };
+        if has_filter {
             Precision::inexact(row_count)
         } else {
             Precision::exact(row_count)
@@ -572,10 +578,11 @@ impl Partition for MultiLayoutPartition {
 
     fn execute(self: Box<Self>) -> VortexResult<SendableArrayStream> {
         let request = self.request;
+        let filter = request.filter?;
         let mut builder = ScanBuilder::new(self.session, self.reader)
             .with_selection(request.selection)
             .with_projection(request.projection)
-            .with_some_filter(request.filter)
+            .with_some_filter(filter)
             .with_some_limit(request.limit)
             .with_ordered(request.ordered);
 
@@ -596,6 +603,10 @@ impl Partition for MultiLayoutPartition {
 mod tests {
     use rstest::rstest;
     use vortex_array::dtype::Nullability;
+    use vortex_array::dtype::PType;
+    use vortex_array::expr::eq;
+    use vortex_array::expr::lit;
+    use vortex_array::expr::root;
 
     use super::*;
     use crate::scan::test::new_session;
@@ -629,5 +640,20 @@ mod tests {
     #[case::no_children(vec![], Precision::exact(0u64))]
     fn byte_size_precision(#[case] sizes: Vec<Option<u64>>, #[case] expected: Precision<u64>) {
         assert_eq!(deferred_source(sizes).byte_size(), expected);
+    }
+
+    #[test]
+    fn filter_binding_errors_are_deferred() -> VortexResult<()> {
+        let dtype = DType::Primitive(PType::U8, Nullability::NonNullable);
+        let request = ScanRequest {
+            filter: Some(eq(root(), lit(67_i32))),
+            ..ScanRequest::default()
+        };
+
+        let request = BoundScanRequest::try_new(request, &dtype)?;
+
+        assert_eq!(request.projection.dtype(), &dtype);
+        assert!(request.filter.is_err());
+        Ok(())
     }
 }

--- a/vortex-layout/src/scan/multi.rs
+++ b/vortex-layout/src/scan/multi.rs
@@ -62,7 +62,6 @@ use vortex_utils::parallelism::get_available_parallelism;
 
 use crate::LayoutReaderRef;
 use crate::scan::scan_builder::ScanBuilder;
-use crate::scan::scan_builder::optimize_and_bind;
 
 /// Default concurrency for opening deferred readers.
 const DEFAULT_CONCURRENCY: usize = 8;
@@ -350,9 +349,9 @@ impl BoundScanRequest {
         } = request;
 
         Ok(Self {
-            projection: optimize_and_bind(projection, dtype)?,
+            projection: projection.optimize_recursive(dtype)?.bind(dtype)?,
             filter: filter
-                .map(|expr| optimize_and_bind(expr, dtype))
+                .map(|expr| expr.optimize_recursive(dtype)?.bind(dtype))
                 .transpose()
                 .map_err(Arc::new),
             row_range,

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -17,7 +17,6 @@ use vortex_array::ArrayRef;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldMask;
 use vortex_array::expr::BoundExpression;
-use vortex_array::expr::Expression;
 use vortex_array::expr::analysis::referenced_field_paths;
 use vortex_array::iter::ArrayIterator;
 use vortex_array::iter::ArrayIteratorAdapter;
@@ -45,11 +44,6 @@ use crate::scan::repeated_scan::RepeatedScan;
 use crate::scan::split_by::SplitBy;
 use crate::scan::splits::Splits;
 use crate::scan::splits::attempt_split_ranges;
-
-/// Optimize `expr` against `scope`, then bind it into a typed expression tree.
-pub fn optimize_and_bind(expr: Expression, scope: &DType) -> VortexResult<BoundExpression> {
-    expr.optimize_recursive(scope)?.bind(scope)
-}
 
 /// Builder for scanning a [`LayoutReader`] into arrays, streams, iterators, or mapped outputs.
 ///

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -19,7 +19,6 @@ use vortex_array::dtype::FieldMask;
 use vortex_array::expr::BoundExpression;
 use vortex_array::expr::Expression;
 use vortex_array::expr::analysis::referenced_field_paths;
-use vortex_array::expr::root;
 use vortex_array::iter::ArrayIterator;
 use vortex_array::iter::ArrayIteratorAdapter;
 use vortex_array::stats::StatsSet;
@@ -47,6 +46,11 @@ use crate::scan::split_by::SplitBy;
 use crate::scan::splits::Splits;
 use crate::scan::splits::attempt_split_ranges;
 
+/// Optimize `expr` against `scope`, then bind it into a typed expression tree.
+pub fn optimize_and_bind(expr: Expression, scope: &DType) -> VortexResult<BoundExpression> {
+    expr.optimize_recursive(scope)?.bind(scope)
+}
+
 /// Builder for scanning a [`LayoutReader`] into arrays, streams, iterators, or mapped outputs.
 ///
 /// A scan has three independent row restriction mechanisms:
@@ -55,14 +59,13 @@ use crate::scan::splits::attempt_split_ranges;
 /// - [`with_selection`](Self::with_selection) applies a [`Selection`] inside that range.
 /// - [`with_filter`](Self::with_filter) evaluates an expression predicate during execution.
 ///
-/// Projection and filter expressions are optimized against the reader dtype during
-/// [`prepare`](Self::prepare). Work is divided by the configured [`SplitBy`] strategy or by
-/// explicit selection ranges.
+/// Projection and filter expressions must be bound against the reader dtype. Work is divided by
+/// the configured [`SplitBy`] strategy or by explicit selection ranges.
 pub struct ScanBuilder<A> {
     session: VortexSession,
     layout_reader: LayoutReaderRef,
-    projection: Expression,
-    filter: Option<Expression>,
+    projection: BoundExpression,
+    filter: Option<BoundExpression>,
     /// Whether the scan needs to return splits in the order they appear in the file.
     ordered: bool,
     /// Optionally read a subset of the rows in the file.
@@ -92,10 +95,11 @@ pub struct ScanBuilder<A> {
 impl ScanBuilder<ArrayRef> {
     /// Create a scan builder over `layout_reader` using `session` for runtime and execution state.
     pub fn new(session: VortexSession, layout_reader: Arc<dyn LayoutReader>) -> Self {
+        let projection = BoundExpression::new_root(layout_reader.dtype().clone());
         Self {
             session,
             layout_reader,
-            projection: root(),
+            projection,
             filter: None,
             ordered: true,
             row_range: None,
@@ -137,20 +141,20 @@ impl ScanBuilder<ArrayRef> {
 }
 
 impl<A: 'static + Send> ScanBuilder<A> {
-    /// Add a filter expression evaluated against the projected row ranges.
-    pub fn with_filter(mut self, filter: Expression) -> Self {
+    /// Add a filter expression bound against the reader dtype.
+    pub fn with_filter(mut self, filter: BoundExpression) -> Self {
         self.filter = Some(filter);
         self
     }
 
-    /// Add or clear the filter expression.
-    pub fn with_some_filter(mut self, filter: Option<Expression>) -> Self {
+    /// Add or clear a filter expression bound against the reader dtype.
+    pub fn with_some_filter(mut self, filter: Option<BoundExpression>) -> Self {
         self.filter = filter;
         self
     }
 
-    /// Set the projection expression for returned rows.
-    pub fn with_projection(mut self, projection: Expression) -> Self {
+    /// Set a projection expression bound against the reader dtype.
+    pub fn with_projection(mut self, projection: BoundExpression) -> Self {
         self.projection = projection;
         self
     }
@@ -219,14 +223,7 @@ impl<A: 'static + Send> ScanBuilder<A> {
     /// them back via [`with_natural_splits`](Self::with_natural_splits) to skip the layout walk
     /// in `prepare`.
     pub fn full_file_splits(&self) -> VortexResult<Vec<u64>> {
-        let dtype = self.layout_reader.dtype();
-        let bound_projection = self.projection.optimize_recursive(dtype)?.bind(dtype)?;
-        let bound_filter = self
-            .filter
-            .as_ref()
-            .map(|f| f.optimize_recursive(dtype)?.bind(dtype))
-            .transpose()?;
-        let field_mask = referenced_field_masks(&bound_projection, bound_filter.as_ref())?;
+        let field_mask = referenced_field_masks(&self.projection, self.filter.as_ref())?;
         self.split_by.splits(
             self.layout_reader.as_ref(),
             &(0..self.layout_reader.row_count()),
@@ -273,7 +270,7 @@ impl<A: 'static + Send> ScanBuilder<A> {
 
     /// The [`DType`] returned by the scan, after applying the projection.
     pub fn dtype(&self) -> VortexResult<DType> {
-        self.projection.return_dtype(self.layout_reader.dtype())
+        Ok(self.projection.dtype().clone())
     }
 
     /// The session used by the scan.
@@ -333,19 +330,8 @@ impl<A: 'static + Send> ScanBuilder<A> {
             ));
         }
 
-        // Normalize and simplify the expressions.
-        let projection = self.projection.optimize_recursive(layout_reader.dtype())?;
-
-        let filter = self
-            .filter
-            .map(|f| f.optimize_recursive(layout_reader.dtype()))
-            .transpose()?;
-
-        let bound_projection = projection.bind(layout_reader.dtype())?;
-        let bound_filter = filter
-            .as_ref()
-            .map(|expr| expr.bind(layout_reader.dtype()))
-            .transpose()?;
+        let bound_projection = self.projection;
+        let bound_filter = self.filter;
 
         // Compute the row splits of the scan.
         let splits =
@@ -539,6 +525,7 @@ mod test {
     use vortex_array::dtype::PType;
     use vortex_array::dtype::StructFields;
     use vortex_array::expr::BoundExpression;
+    use vortex_array::expr::ExactBoundExpr;
     use vortex_array::expr::eq;
     use vortex_array::expr::get_item;
     use vortex_array::expr::is_not_null;
@@ -576,6 +563,24 @@ mod test {
             ]),
             Nullability::NonNullable,
         )
+    }
+
+    #[test]
+    fn bound_setters_preserve_identity() -> VortexResult<()> {
+        let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
+        let projection = eq(root(), lit(1_i32)).bind(&dtype)?;
+        let filter = eq(root(), lit(2_i32)).bind(&dtype)?;
+        let expected_projection = ExactBoundExpr(projection.clone());
+        let expected_filter = ExactBoundExpr(filter.clone());
+        let reader = Arc::new(CountingLayoutReader::new(Arc::new(AtomicUsize::new(0))));
+
+        let builder = ScanBuilder::new(SCAN_SESSION.clone(), reader)
+            .with_projection(projection)
+            .with_filter(filter);
+
+        assert_eq!(ExactBoundExpr(builder.projection), expected_projection);
+        assert_eq!(builder.filter.map(ExactBoundExpr), Some(expected_filter));
+        Ok(())
     }
 
     #[test]

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -19,7 +19,6 @@ use vortex_array::dtype::FieldMask;
 use vortex_array::expr::BoundExpression;
 use vortex_array::expr::Expression;
 use vortex_array::expr::analysis::referenced_field_paths;
-use vortex_array::expr::root;
 use vortex_array::iter::ArrayIterator;
 use vortex_array::iter::ArrayIteratorAdapter;
 use vortex_array::stats::StatsSet;
@@ -47,6 +46,11 @@ use crate::scan::split_by::SplitBy;
 use crate::scan::splits::Splits;
 use crate::scan::splits::attempt_split_ranges;
 
+/// Optimize `expr` against `scope`, then bind it into a typed expression tree.
+pub fn optimize_and_bind(expr: Expression, scope: &DType) -> VortexResult<BoundExpression> {
+    expr.optimize_recursive(scope)?.bind(scope)
+}
+
 /// Builder for scanning a [`LayoutReader`] into arrays, streams, iterators, or mapped outputs.
 ///
 /// A scan has three independent row restriction mechanisms:
@@ -55,14 +59,13 @@ use crate::scan::splits::attempt_split_ranges;
 /// - [`with_selection`](Self::with_selection) applies a [`Selection`] inside that range.
 /// - [`with_filter`](Self::with_filter) evaluates an expression predicate during execution.
 ///
-/// Projection and filter expressions are optimized against the reader dtype during
-/// [`prepare`](Self::prepare). Work is divided by the configured [`SplitBy`] strategy or by
-/// explicit selection ranges.
+/// Projection and filter expressions must be bound against the reader dtype. Work is divided by
+/// the configured [`SplitBy`] strategy or by explicit selection ranges.
 pub struct ScanBuilder<A> {
     session: VortexSession,
     layout_reader: LayoutReaderRef,
-    projection: Expression,
-    filter: Option<Expression>,
+    projection: BoundExpression,
+    filter: Option<BoundExpression>,
     /// Whether the scan needs to return splits in the order they appear in the file.
     ordered: bool,
     /// Optionally read a subset of the rows in the file.
@@ -89,10 +92,11 @@ pub struct ScanBuilder<A> {
 impl ScanBuilder<ArrayRef> {
     /// Create a scan builder over `layout_reader` using `session` for runtime and execution state.
     pub fn new(session: VortexSession, layout_reader: Arc<dyn LayoutReader>) -> Self {
+        let projection = BoundExpression::new_root(layout_reader.dtype().clone());
         Self {
             session,
             layout_reader,
-            projection: root(),
+            projection,
             filter: None,
             ordered: true,
             row_range: None,
@@ -133,20 +137,20 @@ impl ScanBuilder<ArrayRef> {
 }
 
 impl<A: 'static + Send> ScanBuilder<A> {
-    /// Add a filter expression evaluated against the projected row ranges.
-    pub fn with_filter(mut self, filter: Expression) -> Self {
+    /// Add a filter expression bound against the reader dtype.
+    pub fn with_filter(mut self, filter: BoundExpression) -> Self {
         self.filter = Some(filter);
         self
     }
 
-    /// Add or clear the filter expression.
-    pub fn with_some_filter(mut self, filter: Option<Expression>) -> Self {
+    /// Add or clear a filter expression bound against the reader dtype.
+    pub fn with_some_filter(mut self, filter: Option<BoundExpression>) -> Self {
         self.filter = filter;
         self
     }
 
-    /// Set the projection expression for returned rows.
-    pub fn with_projection(mut self, projection: Expression) -> Self {
+    /// Set a projection expression bound against the reader dtype.
+    pub fn with_projection(mut self, projection: BoundExpression) -> Self {
         self.projection = projection;
         self
     }
@@ -231,7 +235,7 @@ impl<A: 'static + Send> ScanBuilder<A> {
 
     /// The [`DType`] returned by the scan, after applying the projection.
     pub fn dtype(&self) -> VortexResult<DType> {
-        self.projection.return_dtype(self.layout_reader.dtype())
+        Ok(self.projection.dtype().clone())
     }
 
     /// The session used by the scan.
@@ -290,19 +294,8 @@ impl<A: 'static + Send> ScanBuilder<A> {
             ));
         }
 
-        // Normalize and simplify the expressions.
-        let projection = self.projection.optimize_recursive(layout_reader.dtype())?;
-
-        let filter = self
-            .filter
-            .map(|f| f.optimize_recursive(layout_reader.dtype()))
-            .transpose()?;
-
-        let bound_projection = projection.bind(layout_reader.dtype())?;
-        let bound_filter = filter
-            .as_ref()
-            .map(|expr| expr.bind(layout_reader.dtype()))
-            .transpose()?;
+        let bound_projection = self.projection;
+        let bound_filter = self.filter;
 
         // Construct field masks and compute the row splits of the scan.
         let field_mask = referenced_field_masks(&bound_projection, bound_filter.as_ref())?;
@@ -494,6 +487,7 @@ mod test {
     use vortex_array::dtype::PType;
     use vortex_array::dtype::StructFields;
     use vortex_array::expr::BoundExpression;
+    use vortex_array::expr::ExactBoundExpr;
     use vortex_array::expr::eq;
     use vortex_array::expr::get_item;
     use vortex_array::expr::is_not_null;
@@ -531,6 +525,24 @@ mod test {
             ]),
             Nullability::NonNullable,
         )
+    }
+
+    #[test]
+    fn bound_setters_preserve_identity() -> VortexResult<()> {
+        let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
+        let projection = eq(root(), lit(1_i32)).bind(&dtype)?;
+        let filter = eq(root(), lit(2_i32)).bind(&dtype)?;
+        let expected_projection = ExactBoundExpr(projection.clone());
+        let expected_filter = ExactBoundExpr(filter.clone());
+        let reader = Arc::new(CountingLayoutReader::new(Arc::new(AtomicUsize::new(0))));
+
+        let builder = ScanBuilder::new(SCAN_SESSION.clone(), reader)
+            .with_projection(projection)
+            .with_filter(filter);
+
+        assert_eq!(ExactBoundExpr(builder.projection), expected_projection);
+        assert_eq!(builder.filter.map(ExactBoundExpr), Some(expected_filter));
+        Ok(())
     }
 
     #[test]

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -24,7 +24,6 @@ use vortex::expr::select;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexFile;
 use vortex::io::runtime::BlockingRuntime;
-use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex::layout::scan::split_by::SplitBy;
 use vortex::scan::strict_sorted_buffer::StrictSortedBuffer;
 use vortex_arrow::ToArrowType;
@@ -60,9 +59,15 @@ pub fn read_array_from_reader(
     row_range: Option<(u64, u64)>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    let projection = optimize_and_bind(projection, vortex_file.dtype())?;
+    let projection = projection
+        .optimize_recursive(vortex_file.dtype())?
+        .bind(vortex_file.dtype())?;
     let filter = filter
-        .map(|filter| optimize_and_bind(filter, vortex_file.dtype()))
+        .map(|filter| {
+            filter
+                .optimize_recursive(vortex_file.dtype())?
+                .bind(vortex_file.dtype())
+        })
         .transpose()?;
     let mut scan = vortex_file.scan()?.with_projection(projection);
 
@@ -191,9 +196,11 @@ impl PyVortexDataset {
         let filter = filter_from_python(row_filter);
 
         let reader = self_.py().detach(move || {
-            let projection = optimize_and_bind(projection, vxf.dtype())?;
+            let projection = projection
+                .optimize_recursive(vxf.dtype())?
+                .bind(vxf.dtype())?;
             let filter = filter
-                .map(|filter| optimize_and_bind(filter, vxf.dtype()))
+                .map(|filter| filter.optimize_recursive(vxf.dtype())?.bind(vxf.dtype()))
                 .transpose()?;
             let mut scan = vxf
                 .scan()?
@@ -234,9 +241,11 @@ impl PyVortexDataset {
         let vxf = self_.vxf.clone();
         let filter = filter_from_python(row_filter);
         let n_rows: usize = self_.py().detach(move || {
-            let projection = optimize_and_bind(select(FieldNames::empty(), root()), vxf.dtype())?;
+            let projection = select(FieldNames::empty(), root())
+                .optimize_recursive(vxf.dtype())?
+                .bind(vxf.dtype())?;
             let filter = filter
-                .map(|filter| optimize_and_bind(filter, vxf.dtype()))
+                .map(|filter| filter.optimize_recursive(vxf.dtype())?.bind(vxf.dtype()))
                 .transpose()?;
             let mut scan = vxf
                 .scan()?

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -24,6 +24,7 @@ use vortex::expr::select;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexFile;
 use vortex::io::runtime::BlockingRuntime;
+use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex::layout::scan::split_by::SplitBy;
 use vortex::scan::strict_sorted_buffer::StrictSortedBuffer;
 use vortex_arrow::ToArrowType;
@@ -59,6 +60,10 @@ pub fn read_array_from_reader(
     row_range: Option<(u64, u64)>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
+    let projection = optimize_and_bind(projection, vortex_file.dtype())?;
+    let filter = filter
+        .map(|filter| optimize_and_bind(filter, vortex_file.dtype()))
+        .transpose()?;
     let mut scan = vortex_file.scan()?.with_projection(projection);
 
     if let Some(filter) = filter {
@@ -186,6 +191,10 @@ impl PyVortexDataset {
         let filter = filter_from_python(row_filter);
 
         let reader = self_.py().detach(move || {
+            let projection = optimize_and_bind(projection, vxf.dtype())?;
+            let filter = filter
+                .map(|filter| optimize_and_bind(filter, vxf.dtype()))
+                .transpose()?;
             let mut scan = vxf
                 .scan()?
                 .with_projection(projection)
@@ -225,9 +234,13 @@ impl PyVortexDataset {
         let vxf = self_.vxf.clone();
         let filter = filter_from_python(row_filter);
         let n_rows: usize = self_.py().detach(move || {
+            let projection = optimize_and_bind(select(FieldNames::empty(), root()), vxf.dtype())?;
+            let filter = filter
+                .map(|filter| optimize_and_bind(filter, vxf.dtype()))
+                .transpose()?;
             let mut scan = vxf
                 .scan()?
-                .with_projection(select(FieldNames::empty(), root()))
+                .with_projection(projection)
                 .with_some_filter(filter)
                 .with_split_by(split_by.map(SplitBy::RowCount).unwrap_or(SplitBy::Layout));
             if let Some((l, r)) = row_range {

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -24,6 +24,7 @@ use vortex::expr::select;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexFile;
 use vortex::io::runtime::BlockingRuntime;
+use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex::layout::scan::split_by::SplitBy;
 use vortex_arrow::ToArrowType;
 
@@ -58,6 +59,10 @@ pub fn read_array_from_reader(
     row_range: Option<(u64, u64)>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
+    let projection = optimize_and_bind(projection, vortex_file.dtype())?;
+    let filter = filter
+        .map(|filter| optimize_and_bind(filter, vortex_file.dtype()))
+        .transpose()?;
     let mut scan = vortex_file.scan()?.with_projection(projection);
 
     if let Some(filter) = filter {
@@ -185,6 +190,10 @@ impl PyVortexDataset {
         let filter = filter_from_python(row_filter);
 
         let reader = self_.py().detach(move || {
+            let projection = optimize_and_bind(projection, vxf.dtype())?;
+            let filter = filter
+                .map(|filter| optimize_and_bind(filter, vxf.dtype()))
+                .transpose()?;
             let mut scan = vxf
                 .scan()?
                 .with_projection(projection)
@@ -224,9 +233,13 @@ impl PyVortexDataset {
         let vxf = self_.vxf.clone();
         let filter = filter_from_python(row_filter);
         let n_rows: usize = self_.py().detach(move || {
+            let projection = optimize_and_bind(select(FieldNames::empty(), root()), vxf.dtype())?;
+            let filter = filter
+                .map(|filter| optimize_and_bind(filter, vxf.dtype()))
+                .transpose()?;
             let mut scan = vxf
                 .scan()?
-                .with_projection(select(FieldNames::empty(), root()))
+                .with_projection(projection)
                 .with_some_filter(filter)
                 .with_split_by(split_by.map(SplitBy::RowCount).unwrap_or(SplitBy::Layout));
             if let Some((l, r)) = row_range {

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -24,7 +24,6 @@ use vortex::expr::select;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexFile;
 use vortex::io::runtime::BlockingRuntime;
-use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex::layout::scan::split_by::SplitBy;
 use vortex_arrow::ToArrowType;
 
@@ -59,9 +58,15 @@ pub fn read_array_from_reader(
     row_range: Option<(u64, u64)>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    let projection = optimize_and_bind(projection, vortex_file.dtype())?;
+    let projection = projection
+        .optimize_recursive(vortex_file.dtype())?
+        .bind(vortex_file.dtype())?;
     let filter = filter
-        .map(|filter| optimize_and_bind(filter, vortex_file.dtype()))
+        .map(|filter| {
+            filter
+                .optimize_recursive(vortex_file.dtype())?
+                .bind(vortex_file.dtype())
+        })
         .transpose()?;
     let mut scan = vortex_file.scan()?.with_projection(projection);
 
@@ -190,9 +195,11 @@ impl PyVortexDataset {
         let filter = filter_from_python(row_filter);
 
         let reader = self_.py().detach(move || {
-            let projection = optimize_and_bind(projection, vxf.dtype())?;
+            let projection = projection
+                .optimize_recursive(vxf.dtype())?
+                .bind(vxf.dtype())?;
             let filter = filter
-                .map(|filter| optimize_and_bind(filter, vxf.dtype()))
+                .map(|filter| filter.optimize_recursive(vxf.dtype())?.bind(vxf.dtype()))
                 .transpose()?;
             let mut scan = vxf
                 .scan()?
@@ -233,9 +240,11 @@ impl PyVortexDataset {
         let vxf = self_.vxf.clone();
         let filter = filter_from_python(row_filter);
         let n_rows: usize = self_.py().detach(move || {
-            let projection = optimize_and_bind(select(FieldNames::empty(), root()), vxf.dtype())?;
+            let projection = select(FieldNames::empty(), root())
+                .optimize_recursive(vxf.dtype())?
+                .bind(vxf.dtype())?;
             let filter = filter
-                .map(|filter| optimize_and_bind(filter, vxf.dtype()))
+                .map(|filter| filter.optimize_recursive(vxf.dtype())?.bind(vxf.dtype()))
                 .transpose()?;
             let mut scan = vxf
                 .scan()?

--- a/vortex-python/src/file.rs
+++ b/vortex-python/src/file.rs
@@ -25,6 +25,7 @@ use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexFile;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::layout::scan::scan_builder::ScanBuilder;
+use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex::layout::scan::split_by::SplitBy;
 use vortex::layout::segments::MokaSegmentCache;
 use vortex::scan::strict_sorted_buffer::StrictSortedBuffer;
@@ -172,10 +173,15 @@ impl PyVortexFile {
             .map(Arc::new);
 
         let reader = slf.py().detach(|| {
+            let filter = expr
+                .map(|e| optimize_and_bind(e.into_inner(), vxf.dtype()))
+                .transpose()?;
+            let projection =
+                optimize_and_bind(projection.map(|p| p.0).unwrap_or_else(root), vxf.dtype())?;
             let mut builder = vxf
                 .scan()?
-                .with_some_filter(expr.map(|e| e.into_inner()))
-                .with_projection(projection.map(|p| p.0).unwrap_or_else(root));
+                .with_some_filter(filter)
+                .with_projection(projection);
 
             if let Some(limit) = limit {
                 builder = builder.with_limit(limit);
@@ -220,10 +226,14 @@ fn scan_builder(
     batch_size: Option<usize>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ScanBuilder<ArrayRef>> {
+    let projection = optimize_and_bind(projection.unwrap_or_else(root), vxf.dtype())?;
+    let expr = expr
+        .map(|expr| optimize_and_bind(expr, vxf.dtype()))
+        .transpose()?;
     let mut builder = vxf
         .scan()?
         .with_some_filter(expr)
-        .with_projection(projection.unwrap_or_else(root));
+        .with_projection(projection);
 
     if let Some(limit) = limit {
         builder = builder.with_limit(limit);

--- a/vortex-python/src/file.rs
+++ b/vortex-python/src/file.rs
@@ -25,7 +25,6 @@ use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexFile;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::layout::scan::scan_builder::ScanBuilder;
-use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex::layout::scan::split_by::SplitBy;
 use vortex::layout::segments::MokaSegmentCache;
 use vortex::scan::strict_sorted_buffer::StrictSortedBuffer;
@@ -174,10 +173,17 @@ impl PyVortexFile {
 
         let reader = slf.py().detach(|| {
             let filter = expr
-                .map(|e| optimize_and_bind(e.into_inner(), vxf.dtype()))
+                .map(|e| {
+                    e.into_inner()
+                        .optimize_recursive(vxf.dtype())?
+                        .bind(vxf.dtype())
+                })
                 .transpose()?;
-            let projection =
-                optimize_and_bind(projection.map(|p| p.0).unwrap_or_else(root), vxf.dtype())?;
+            let projection = projection
+                .map(|p| p.0)
+                .unwrap_or_else(root)
+                .optimize_recursive(vxf.dtype())?
+                .bind(vxf.dtype())?;
             let mut builder = vxf
                 .scan()?
                 .with_some_filter(filter)
@@ -226,9 +232,12 @@ fn scan_builder(
     batch_size: Option<usize>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ScanBuilder<ArrayRef>> {
-    let projection = optimize_and_bind(projection.unwrap_or_else(root), vxf.dtype())?;
+    let projection = projection
+        .unwrap_or_else(root)
+        .optimize_recursive(vxf.dtype())?
+        .bind(vxf.dtype())?;
     let expr = expr
-        .map(|expr| optimize_and_bind(expr, vxf.dtype()))
+        .map(|expr| expr.optimize_recursive(vxf.dtype())?.bind(vxf.dtype()))
         .transpose()?;
     let mut builder = vxf
         .scan()?

--- a/vortex-python/src/file.rs
+++ b/vortex-python/src/file.rs
@@ -26,7 +26,6 @@ use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexFile;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::layout::scan::scan_builder::ScanBuilder;
-use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex::layout::scan::split_by::SplitBy;
 use vortex::layout::segments::MokaSegmentCache;
 use vortex_arrow::ToArrowType;
@@ -173,10 +172,17 @@ impl PyVortexFile {
 
         let reader = slf.py().detach(|| {
             let filter = expr
-                .map(|e| optimize_and_bind(e.into_inner(), vxf.dtype()))
+                .map(|e| {
+                    e.into_inner()
+                        .optimize_recursive(vxf.dtype())?
+                        .bind(vxf.dtype())
+                })
                 .transpose()?;
-            let projection =
-                optimize_and_bind(projection.map(|p| p.0).unwrap_or_else(root), vxf.dtype())?;
+            let projection = projection
+                .map(|p| p.0)
+                .unwrap_or_else(root)
+                .optimize_recursive(vxf.dtype())?
+                .bind(vxf.dtype())?;
             let mut builder = vxf
                 .scan()?
                 .with_some_filter(filter)
@@ -225,9 +231,12 @@ fn scan_builder(
     batch_size: Option<usize>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ScanBuilder<ArrayRef>> {
-    let projection = optimize_and_bind(projection.unwrap_or_else(root), vxf.dtype())?;
+    let projection = projection
+        .unwrap_or_else(root)
+        .optimize_recursive(vxf.dtype())?
+        .bind(vxf.dtype())?;
     let expr = expr
-        .map(|expr| optimize_and_bind(expr, vxf.dtype()))
+        .map(|expr| expr.optimize_recursive(vxf.dtype())?.bind(vxf.dtype()))
         .transpose()?;
     let mut builder = vxf
         .scan()?

--- a/vortex-python/src/file.rs
+++ b/vortex-python/src/file.rs
@@ -26,6 +26,7 @@ use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexFile;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::layout::scan::scan_builder::ScanBuilder;
+use vortex::layout::scan::scan_builder::optimize_and_bind;
 use vortex::layout::scan::split_by::SplitBy;
 use vortex::layout::segments::MokaSegmentCache;
 use vortex_arrow::ToArrowType;
@@ -171,10 +172,15 @@ impl PyVortexFile {
             .map(Arc::new);
 
         let reader = slf.py().detach(|| {
+            let filter = expr
+                .map(|e| optimize_and_bind(e.into_inner(), vxf.dtype()))
+                .transpose()?;
+            let projection =
+                optimize_and_bind(projection.map(|p| p.0).unwrap_or_else(root), vxf.dtype())?;
             let mut builder = vxf
                 .scan()?
-                .with_some_filter(expr.map(|e| e.into_inner()))
-                .with_projection(projection.map(|p| p.0).unwrap_or_else(root));
+                .with_some_filter(filter)
+                .with_projection(projection);
 
             if let Some(limit) = limit {
                 builder = builder.with_limit(limit);
@@ -219,10 +225,14 @@ fn scan_builder(
     batch_size: Option<usize>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ScanBuilder<ArrayRef>> {
+    let projection = optimize_and_bind(projection.unwrap_or_else(root), vxf.dtype())?;
+    let expr = expr
+        .map(|expr| optimize_and_bind(expr, vxf.dtype()))
+        .transpose()?;
     let mut builder = vxf
         .scan()?
         .with_some_filter(expr)
-        .with_projection(projection.unwrap_or_else(root));
+        .with_projection(projection);
 
     if let Some(limit) = limit {
         builder = builder.with_limit(limit);

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -70,6 +70,7 @@
 //! use vortex::array::validity::Validity;
 //! use vortex::buffer::{ByteBufferMut, buffer};
 //! use vortex::file::{OpenOptionsSessionExt, WriteOptionsSessionExt};
+//! use vortex::layout::scan::scan_builder::optimize_and_bind;
 //! use vortex::session::VortexSession;
 //!
 //! # async fn example() -> vortex::error::VortexResult<()> {
@@ -82,11 +83,13 @@
 //!     .write(&mut bytes, array.into_array().to_array_stream())
 //!     .await?;
 //!
-//! let filtered = session
+//! let file = session
 //!     .open_options()
-//!     .open_buffer(bytes)?
+//!     .open_buffer(bytes)?;
+//! let filter = optimize_and_bind(gt(root(), lit(2u64)), file.dtype())?;
+//! let filtered = file
 //!     .scan()?
-//!     .with_filter(gt(root(), lit(2u64)))
+//!     .with_filter(filter)
 //!     .into_array_stream()?
 //!     .read_all()
 //!     .await?;
@@ -357,6 +360,7 @@ mod test {
     use vortex_file::OpenOptionsSessionExt;
     use vortex_file::WriteOptionsSessionExt;
     use vortex_file::WriteStrategyBuilder;
+    use vortex_layout::scan::scan_builder::optimize_and_bind;
     use vortex_session::VortexSession;
 
     use crate as vortex;
@@ -438,12 +442,11 @@ mod test {
         // [write]
 
         // [read]
-        let array = session
-            .open_options()
-            .open_path(path.clone())
-            .await?
+        let file = session.open_options().open_path(path.clone()).await?;
+        let filter = optimize_and_bind(gt(root(), lit(2u64)), file.dtype())?;
+        let array = file
             .scan()?
-            .with_filter(gt(root(), lit(2u64)))
+            .with_filter(filter)
             .into_array_stream()?
             .read_all()
             .await?;
@@ -537,12 +540,11 @@ mod test {
             .await?;
 
         // Read the file back, but project down to just the "value" column.
-        let projected = session
-            .open_options()
-            .open_path(path.clone())
-            .await?
+        let file = session.open_options().open_path(path.clone()).await?;
+        let projection = optimize_and_bind(select(["value"], root()), file.dtype())?;
+        let projected = file
             .scan()?
-            .with_projection(select(["value"], root()))
+            .with_projection(projection)
             .into_array_stream()?
             .read_all()
             .await?;

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -70,7 +70,6 @@
 //! use vortex::array::validity::Validity;
 //! use vortex::buffer::{ByteBufferMut, buffer};
 //! use vortex::file::{OpenOptionsSessionExt, WriteOptionsSessionExt};
-//! use vortex::layout::scan::scan_builder::optimize_and_bind;
 //! use vortex::session::VortexSession;
 //!
 //! # async fn example() -> vortex::error::VortexResult<()> {
@@ -86,7 +85,9 @@
 //! let file = session
 //!     .open_options()
 //!     .open_buffer(bytes)?;
-//! let filter = optimize_and_bind(gt(root(), lit(2u64)), file.dtype())?;
+//! let filter = gt(root(), lit(2u64))
+//!     .optimize_recursive(file.dtype())?
+//!     .bind(file.dtype())?;
 //! let filtered = file
 //!     .scan()?
 //!     .with_filter(filter)
@@ -360,7 +361,6 @@ mod test {
     use vortex_file::OpenOptionsSessionExt;
     use vortex_file::WriteOptionsSessionExt;
     use vortex_file::WriteStrategyBuilder;
-    use vortex_layout::scan::scan_builder::optimize_and_bind;
     use vortex_session::VortexSession;
 
     use crate as vortex;
@@ -443,7 +443,9 @@ mod test {
 
         // [read]
         let file = session.open_options().open_path(path.clone()).await?;
-        let filter = optimize_and_bind(gt(root(), lit(2u64)), file.dtype())?;
+        let filter = gt(root(), lit(2u64))
+            .optimize_recursive(file.dtype())?
+            .bind(file.dtype())?;
         let array = file
             .scan()?
             .with_filter(filter)
@@ -541,7 +543,9 @@ mod test {
 
         // Read the file back, but project down to just the "value" column.
         let file = session.open_options().open_path(path.clone()).await?;
-        let projection = optimize_and_bind(select(["value"], root()), file.dtype())?;
+        let projection = select(["value"], root())
+            .optimize_recursive(file.dtype())?
+            .bind(file.dtype())?;
         let projected = file
             .scan()?
             .with_projection(projection)


### PR DESCRIPTION
## Summary

- require scan-builder projection and filter setters to take `BoundExpression`
- optimize and bind scan expressions once at the source boundary, preserving the exact bound tree through pruning and partition scans
- rewrite statistics expressions and conjunct comparisons directly on bound trees instead of unbinding and rebinding them
- defer multi-layout filter-binding failures to partition execution so scan construction keeps its existing error timing

## Why

Rebinding a structurally identical expression creates a new exact tree identity and defeats identity-keyed caches. Keeping one bound tree through scan planning and execution makes exact caching reliable.

## Break

Use `Expression::bind(dtype)` before passing a projection or filter to a scan plan.
