### PR TITLE
Add Map core edition

### DIFF
--- a/vortex-python/src/io.rs
+++ b/vortex-python/src/io.rs
@@ -303,7 +303,7 @@ impl PyVortexWriteOptions {
     /// >>> vx.io.VortexWriteOptions.default().write(sprl, "chonky.vortex")
     /// >>> import os
     /// >>> os.path.getsize('chonky.vortex')
-    /// 215900
+    /// 215932
     ///
     /// Wow, Vortex manages to use about two bytes per integer! So advanced. So tiny.
     ///
@@ -313,7 +313,7 @@ impl PyVortexWriteOptions {
     ///
     /// >>> vx.io.VortexWriteOptions.compact().write(sprl, "tiny.vortex")
     /// >>> os.path.getsize('tiny.vortex')
-    /// 55028
+    /// 55060
     ///
     /// Random numbers are not (usually) composed of random bytes!
     #[staticmethod]

--- a/vortex-sqllogictest/slt/datafusion/map_roundtrip.slt
+++ b/vortex-sqllogictest/slt/datafusion/map_roundtrip.slt
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+include ../setup.slt.no
+
+query I
+COPY (
+  SELECT id, map(keys, vals) AS attrs
+  FROM (VALUES
+    (1, [1, 2], ['one', CAST(NULL AS VARCHAR)]),
+    (2, [], []),
+    (3, [3], ['three'])
+  ) AS t(id, keys, vals)
+) TO '${WORK_DIR}/datafusion/map_roundtrip/maps.vortex'
+STORED AS VORTEX;
+----
+3
+
+statement ok
+CREATE VIEW map_rows AS SELECT * FROM '${WORK_DIR}/datafusion/map_roundtrip/maps.vortex';
+
+query I? rowsort
+SELECT id, attrs FROM map_rows;
+----
+1 {1: one, 2: NULL}
+2 {}
+3 {3: three}
+
+query II??? rowsort
+SELECT
+  id,
+  cardinality(attrs),
+  map_keys(attrs),
+  map_values(attrs),
+  map_extract(attrs, 2)
+FROM map_rows;
+----
+1 2 [1, 2] [one, NULL] [NULL]
+2 0 [] [] [NULL]
+3 1 [3] [three] [NULL]
+
+statement ok
+DROP VIEW map_rows;

--- a/vortex/src/editions/core/mod.rs
+++ b/vortex/src/editions/core/mod.rs
@@ -10,8 +10,10 @@ pub mod v2025_05;
 pub mod v2025_06;
 pub mod v2025_10;
 pub mod v2026_07;
+pub mod v2026_08_1;
 
 pub use v2025_05::CORE_2025_05_0;
 pub use v2025_06::CORE_2025_06_0;
 pub use v2025_10::CORE_2025_10_0;
 pub use v2026_07::CORE_2026_07_0;
+pub use v2026_08_1::CORE_2026_08_1;

--- a/vortex/src/editions/core/mod.rs
+++ b/vortex/src/editions/core/mod.rs
@@ -10,10 +10,10 @@ pub mod v2025_05;
 pub mod v2025_06;
 pub mod v2025_10;
 pub mod v2026_07;
-pub mod v2026_08_1;
+pub mod v2026_08;
 
 pub use v2025_05::CORE_2025_05_0;
 pub use v2025_06::CORE_2025_06_0;
 pub use v2025_10::CORE_2025_10_0;
 pub use v2026_07::CORE_2026_07_0;
-pub use v2026_08_1::CORE_2026_08_1;
+pub use v2026_08::CORE_2026_08;

--- a/vortex/src/editions/core/v2026_08.rs
+++ b/vortex/src/editions/core/v2026_08.rs
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! The August 2026 core edition revision adding the canonical Map encoding.
+//! The August 2026 core edition adding the canonical Map encoding.
 
 use vortex_edition::Edition;
 use vortex_edition::EditionDeclaration;
 use vortex_edition::EditionId;
 
-/// The August 2026 core edition revision containing canonical Map arrays.
-pub const CORE_2026_08_1: EditionId = EditionId::new("core", 2026, 8, 1);
+/// The August 2026 core edition containing canonical Map arrays.
+pub const CORE_2026_08: EditionId = EditionId::new("core", 2026, 8, 0);
 
-/// The declaration of [`CORE_2026_08_1`] and the encodings that join the family at it.
+/// The declaration of [`CORE_2026_08`] and the encodings that join the family at it.
 pub static DECLARATION: EditionDeclaration = EditionDeclaration {
     edition: Edition {
-        id: CORE_2026_08_1,
+        id: CORE_2026_08,
         min_vortex_version: Some("0.84.0"),
     },
     added: &[&"vortex.map"],

--- a/vortex/src/editions/core/v2026_08_1.rs
+++ b/vortex/src/editions/core/v2026_08_1.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! The August 2026 core edition revision adding the canonical Map encoding.
+
+use vortex_edition::Edition;
+use vortex_edition::EditionDeclaration;
+use vortex_edition::EditionId;
+
+/// The August 2026 core edition revision containing canonical Map arrays.
+pub const CORE_2026_08_1: EditionId = EditionId::new("core", 2026, 8, 1);
+
+/// The declaration of [`CORE_2026_08_1`] and the encodings that join the family at it.
+pub static DECLARATION: EditionDeclaration = EditionDeclaration {
+    edition: Edition {
+        id: CORE_2026_08_1,
+        min_vortex_version: Some("0.84.0"),
+    },
+    added: &[&"vortex.map"],
+};

--- a/vortex/src/editions/mod.rs
+++ b/vortex/src/editions/mod.rs
@@ -9,7 +9,7 @@
 //! policy with [`crate::editions::enable_default_editions`].
 //!
 //! The default file writer resolves the session's enabled editions at write time. The
-//! facade enables the newest frozen `core` edition, [`crate::editions::CORE_2026_08_1`], and
+//! facade enables the newest frozen `core` edition, [`crate::editions::CORE_2026_08`], and
 //! additionally enables the latest unstable edition when the `unstable_encodings` feature is
 //! selected.
 
@@ -33,14 +33,14 @@ pub use self::core::CORE_2025_05_0;
 pub use self::core::CORE_2025_06_0;
 pub use self::core::CORE_2025_10_0;
 pub use self::core::CORE_2026_07_0;
-pub use self::core::CORE_2026_08_1;
+pub use self::core::CORE_2026_08;
 pub use self::unstable::UNSTABLE_2025_05_0;
 pub use self::unstable::UNSTABLE_2026_02_0;
 pub use self::unstable::UNSTABLE_2026_04_0;
 pub use self::unstable::UNSTABLE_2026_06_0;
 
 /// The `core` edition enabled for writing by the default Vortex session.
-pub const DEFAULT_CORE_EDITION: EditionId = CORE_2026_08_1;
+pub const DEFAULT_CORE_EDITION: EditionId = CORE_2026_08;
 
 /// The `unstable` edition enabled for writing by the default Vortex session when the
 /// `unstable_encodings` feature is selected.
@@ -52,7 +52,7 @@ pub static EDITION_DECLARATIONS: &[&EditionDeclaration] = &[
     &core::v2025_06::DECLARATION,
     &core::v2025_10::DECLARATION,
     &core::v2026_07::DECLARATION,
-    &core::v2026_08_1::DECLARATION,
+    &core::v2026_08::DECLARATION,
     &unstable::v2025_05::DECLARATION,
     &unstable::v2026_02::DECLARATION,
     &unstable::v2026_04::DECLARATION,

--- a/vortex/src/editions/mod.rs
+++ b/vortex/src/editions/mod.rs
@@ -9,7 +9,7 @@
 //! policy with [`crate::editions::enable_default_editions`].
 //!
 //! The default file writer resolves the session's enabled editions at write time. The
-//! facade enables the newest frozen `core` edition, [`crate::editions::CORE_2026_07_0`], and
+//! facade enables the newest frozen `core` edition, [`crate::editions::CORE_2026_08_1`], and
 //! additionally enables the latest unstable edition when the `unstable_encodings` feature is
 //! selected.
 
@@ -33,13 +33,14 @@ pub use self::core::CORE_2025_05_0;
 pub use self::core::CORE_2025_06_0;
 pub use self::core::CORE_2025_10_0;
 pub use self::core::CORE_2026_07_0;
+pub use self::core::CORE_2026_08_1;
 pub use self::unstable::UNSTABLE_2025_05_0;
 pub use self::unstable::UNSTABLE_2026_02_0;
 pub use self::unstable::UNSTABLE_2026_04_0;
 pub use self::unstable::UNSTABLE_2026_06_0;
 
 /// The `core` edition enabled for writing by the default Vortex session.
-pub const DEFAULT_CORE_EDITION: EditionId = CORE_2026_07_0;
+pub const DEFAULT_CORE_EDITION: EditionId = CORE_2026_08_1;
 
 /// The `unstable` edition enabled for writing by the default Vortex session when the
 /// `unstable_encodings` feature is selected.
@@ -51,6 +52,7 @@ pub static EDITION_DECLARATIONS: &[&EditionDeclaration] = &[
     &core::v2025_06::DECLARATION,
     &core::v2025_10::DECLARATION,
     &core::v2026_07::DECLARATION,
+    &core::v2026_08_1::DECLARATION,
     &unstable::v2025_05::DECLARATION,
     &unstable::v2026_02::DECLARATION,
     &unstable::v2026_04::DECLARATION,

--- a/vortex/src/editions/tests.rs
+++ b/vortex/src/editions/tests.rs
@@ -39,7 +39,7 @@ use vortex_utils::aliases::hash_set::HashSet;
 
 use super::CORE_2025_05_0;
 use super::CORE_2026_07_0;
-use super::CORE_2026_08_1;
+use super::CORE_2026_08;
 use super::DEFAULT_CORE_EDITION;
 use super::DEFAULT_UNSTABLE_EDITION;
 use super::EDITION_DECLARATIONS;
@@ -139,7 +139,7 @@ fn encodings_in_editions_unions_families() {
 fn earlier_editions_are_subsets() {
     let session = session().unwrap_or_else(|e| panic!("registering editions: {e}"));
     let first = session.encodings_in(&CORE_2025_05_0);
-    let latest = session.encodings_in(&CORE_2026_08_1);
+    let latest = session.encodings_in(&CORE_2026_08);
     assert!(first.iter().all(|inclusion| {
         latest
             .iter()
@@ -170,7 +170,7 @@ fn core_edition_ids_are_registered_array_encodings() {
 
     let session = VortexSession::default();
     let registry = session.arrays().registry().clone();
-    for inclusion in session.editions().encodings_in(&CORE_2026_08_1) {
+    for inclusion in session.editions().encodings_in(&CORE_2026_08) {
         assert!(
             registry.contains_key(&inclusion.encoding_id),
             "{} is declared in core but not registered as an array encoding",

--- a/vortex/src/editions/tests.rs
+++ b/vortex/src/editions/tests.rs
@@ -39,6 +39,7 @@ use vortex_utils::aliases::hash_set::HashSet;
 
 use super::CORE_2025_05_0;
 use super::CORE_2026_07_0;
+use super::CORE_2026_08_1;
 use super::DEFAULT_CORE_EDITION;
 use super::DEFAULT_UNSTABLE_EDITION;
 use super::EDITION_DECLARATIONS;
@@ -138,7 +139,7 @@ fn encodings_in_editions_unions_families() {
 fn earlier_editions_are_subsets() {
     let session = session().unwrap_or_else(|e| panic!("registering editions: {e}"));
     let first = session.encodings_in(&CORE_2025_05_0);
-    let latest = session.encodings_in(&CORE_2026_07_0);
+    let latest = session.encodings_in(&CORE_2026_08_1);
     assert!(first.iter().all(|inclusion| {
         latest
             .iter()
@@ -169,7 +170,7 @@ fn core_edition_ids_are_registered_array_encodings() {
 
     let session = VortexSession::default();
     let registry = session.arrays().registry().clone();
-    for inclusion in session.editions().encodings_in(&CORE_2026_07_0) {
+    for inclusion in session.editions().encodings_in(&CORE_2026_08_1) {
         assert!(
             registry.contains_key(&inclusion.encoding_id),
             "{} is declared in core but not registered as an array encoding",


### PR DESCRIPTION
## Rationale for this change

New version that includes the map array and some testing changes around that.

Not sure what's our process for new editions is, but figured I'll at least put this up. Should the array not be in the default session until then? How do we manage this process?