### PR TITLE
fix: ignore zero-byte benchmark file identities

### DIFF
--- a/scripts/compare-benchmark-jsons.py
+++ b/scripts/compare-benchmark-jsons.py
@@ -614,12 +614,15 @@ def format_pct_change(pct: float) -> str:
     return f"{sign}{pct:.1f}%"
 
 
-def extract_file_size_data(df: pd.DataFrame) -> dict[tuple[str, str, str, str], int]:
-    """Extract file-size rows keyed by benchmark, scale factor, format, and file."""
+def extract_file_size_data(
+    df: pd.DataFrame,
+) -> tuple[dict[tuple[str, str, str, str], int], set[tuple[str, str, str, str]]]:
+    """Extract file-size rows and the identities explicitly ignored for being empty."""
 
     data = {}
+    ignored = set()
     if df.empty:
-        return data
+        return data, ignored
 
     for _, row in df.iterrows():
         metadata = row.get("file_size")
@@ -635,19 +638,26 @@ def extract_file_size_data(df: pd.DataFrame) -> dict[tuple[str, str, str, str], 
         value = row.get("value")
         if pd.isna(value):
             continue
-        data[key] = int(value)
+        size = int(value)
+        if size == 0:
+            ignored.add(key)
+            continue
+        data[key] = size
 
-    return data
+    return data, ignored
 
 
 def format_file_size_report(base_rows: pd.DataFrame, pr_rows: pd.DataFrame) -> str:
     """Render a shared-comment file-size comparison report."""
 
-    pr_data = extract_file_size_data(pr_rows)
+    pr_data, pr_ignored = extract_file_size_data(pr_rows)
+    base_data, base_ignored = extract_file_size_data(base_rows)
+    ignored = base_ignored | pr_ignored
+    pr_data = {key: value for key, value in pr_data.items() if key not in ignored}
     if not pr_data:
         return ""
 
-    base_data = extract_file_size_data(base_rows)
+    base_data = {key: value for key, value in base_data.items() if key not in ignored}
     pr_scopes = {(benchmark, scale_factor) for benchmark, scale_factor, _file_format, _file_name in pr_data}
     base_data = {key: value for key, value in base_data.items() if key[:2] in pr_scopes}
     if not base_data:

--- a/scripts/tests/test_benchmark_reporting.py
+++ b/scripts/tests/test_benchmark_reporting.py
@@ -413,6 +413,31 @@ def test_file_size_report_reads_shared_benchmark_rows() -> None:
     assert "| part-0.vortex | 10 | vortex-file-compressed | 100 B | 125 B | +25 B | +25.0% |" in report
 
 
+def test_file_size_report_ignores_file_identities_with_a_zero_byte_side() -> None:
+    compare = load_compare_module()
+
+    report = compare.format_file_size_report(
+        pd.DataFrame(
+            [
+                file_size_record_for("base-sha", 100, "tpch", "10", "vortex-file-compressed", "head-empty"),
+                file_size_record_for("base-sha", 0, "tpch", "10", "vortex-file-compressed", "base-empty"),
+                file_size_record_for("base-sha", 100, "tpch", "10", "vortex-file-compressed", "changed"),
+            ]
+        ),
+        pd.DataFrame(
+            [
+                file_size_record_for("pr-sha", 0, "tpch", "10", "vortex-file-compressed", "head-empty"),
+                file_size_record_for("pr-sha", 125, "tpch", "10", "vortex-file-compressed", "base-empty"),
+                file_size_record_for("pr-sha", 125, "tpch", "10", "vortex-file-compressed", "changed"),
+            ]
+        ),
+    )
+
+    assert "<summary>File Size Changes (1 files changed, +25.0% overall, 1↑ 0↓)</summary>" in report
+    assert "head-empty" not in report
+    assert "base-empty" not in report
+
+
 def test_file_size_report_ignores_baseline_rows_outside_pr_scope() -> None:
     compare = load_compare_module()
 


### PR DESCRIPTION
Fixes file-size reporting when either the baseline or HEAD records an empty file. The report previously dropped the zero-byte row and then treated its missing counterpart as `0 B`, which could report a false deletion or a newly created file.

File identities with a zero-byte record on either side are now excluded from both sides before totals and missing-file comparisons. The regression test covers both asymmetric cases.

Checks: `uv run --no-project --with orjson --with pandas pytest scripts/tests/test_benchmark_reporting.py` and `ruff check scripts/compare-benchmark-jsons.py scripts/tests/test_benchmark_reporting.py`.
