### PR TITLE
Vectorize checked multiplication by reporting evidence, not a comparison

### DIFF
--- a/vortex-array/src/scalar_fn/fns/binary/numeric/checked.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/checked.rs
@@ -4,6 +4,8 @@
 //! Checked-lane execution for numeric kernels, driven by the shared
 //! `vortex-compute` lane kernels.
 
+use std::ops::BitOrAssign;
+
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_compute::lane_kernels::IndexedSource;
@@ -11,30 +13,43 @@ use vortex_compute::lane_kernels::IndexedSourceExt;
 use vortex_mask::AllOr;
 use vortex_mask::Mask;
 
-/// Apply the fallible `f` over every lane of `source`, failing only when `f` returns `None`
-/// on a valid lane.
+/// Evidence that a lane failed, anything other than [`Default`] meaning failure.
 ///
-/// `f` is also invoked on invalid lanes (their failures are masked out and their values are
-/// unspecified), so it must be total: no panics or side effects on any stored lane value.
+/// `bool` is the ordinary choice; [`map_checked_into`] explains why the wider members exist and
+/// asserts the width bound that membership here does **not** imply.
 ///
-/// This drives the one-pass early-exit kernels: failures abort at the end of the enclosing
-/// 64-lane chunk. Use it when per-lane failure handling is cheap relative to the operation
-/// (integer division, decimal ops with per-lane casts). For operations whose failure check
-/// auto-vectorizes, prefer [`checked_apply_lanes`].
+/// [`map_checked_into`]: IndexedSourceExt::map_checked_into
+pub(super) trait Failure: Copy + Default + PartialEq + BitOrAssign {}
+
+impl Failure for bool {}
+impl Failure for u8 {}
+impl Failure for u16 {}
+impl Failure for u32 {}
+impl Failure for u64 {}
+
+/// Apply the fallible `apply` over every lane of `source`, returning
+/// `Err(first_failing_valid_lane)` only when it returns `None` on a _valid_ lane.
 ///
-/// On failure returns `Err(first_failing_valid_lane)`.
+/// `apply` also runs on invalid lanes, whose failures are masked out and whose values are
+/// unspecified, so it must be total: no panics or side effects on any stored lane value.
 ///
-/// `#[inline(always)]`: this wrapper and its kernel calls must inline into the caller that
-/// constructs the closure, so the closure environment (e.g. a captured constant operand)
-/// flattens into registers. Left to its own devices under `codegen-units > 1`, the compiler
-/// keeps the environment behind a pointer, and reloading a captured constant on every lane
-/// blocks vectorization of the whole loop.
-#[inline(always)]
-pub(super) fn checked_lanes<S, T, F>(source: S, valid_rows: &Mask, f: F) -> Result<Buffer<T>, usize>
+/// This drives the one-pass early-exit kernels, which abort at the end of the enclosing 64-lane
+/// chunk. Use it when per-lane failure handling is cheap relative to the operation, as in integer
+/// division. Prefer [`checked_apply_lanes`] when the failure check itself vectorizes.
+///
+/// `#[inline]`: this must inline into the caller that builds the closure, so that a captured
+/// constant operand flattens into a register rather than living behind a pointer the loop reloads
+/// on every lane, which blocks vectorization.
+#[inline]
+pub(super) fn checked_lanes<S, T, Apply>(
+    source: S,
+    valid_rows: &Mask,
+    apply: Apply,
+) -> Result<Buffer<T>, usize>
 where
     S: IndexedSource,
     T: Copy + Default,
-    F: FnMut(S::Item) -> Option<T>,
+    Apply: FnMut(S::Item) -> Option<T>,
 {
     let len = source.len();
     debug_assert_eq!(len, valid_rows.len());
@@ -46,41 +61,41 @@ where
     };
 
     let mut values = BufferMut::<T>::with_capacity(len);
+
     let out = &mut values.spare_capacity_mut()[..len];
     match valid_bits {
-        None => source.try_map_into(out, f)?,
-        Some(valid_bits) => source.try_map_masked_into(valid_bits, out, f)?,
+        None => source.try_map_into(out, apply)?,
+        Some(valid_bits) => source.try_map_masked_into(valid_bits, out, apply)?,
     }
+
     // SAFETY: the kernels initialize every lane in `out`.
     unsafe { values.set_len(len) };
+
     Ok(values.freeze())
 }
 
-/// Apply the split value/error `f` over every lane of `source`, failing only when `f` flags
-/// an error on a valid lane.
+/// Apply the split value/failure `apply` over every lane of `source`, returning
+/// `Err(first_failing_valid_lane)` only when it flags a _valid_ lane.
 ///
-/// The hot pass writes every lane's value unconditionally and OR-reduces a single failure
-/// flag, which keeps the loop free of per-lane selects and per-chunk exit branches — the
-/// shape the auto-vectorizer handles best. Only if some lane flagged an error does a cold
-/// second pass re-run `f` through the early-exit kernels to filter null-lane failures and
-/// attribute the first valid one.
+/// The hot pass writes every value unconditionally and OR-reduces one piece of evidence, leaving
+/// the loop free of per-lane selects and per-chunk exit branches. Only if a lane flagged does a
+/// cold second pass re-run `apply` through the early-exit kernels, which drop null-lane failures
+/// and attribute the first valid one.
 ///
-/// Like [`checked_lanes`], `f` is invoked on invalid lanes and must be total.
+/// Like [`checked_lanes`], `apply` runs on invalid lanes and must be total.
 ///
-/// On failure returns `Err(first_failing_valid_lane)`.
-///
-/// `#[inline(always)]`: see [`checked_lanes`] — required so captured operands flatten out of
-/// the closure environment and the hot loop vectorizes regardless of codegen-unit count.
-#[inline(always)]
-pub(super) fn checked_apply_lanes<S, T, F>(
+/// `#[inline]`: see [`checked_lanes`].
+#[inline]
+pub(super) fn checked_apply_lanes<S, T, Fail, Apply>(
     source: S,
     valid_rows: &Mask,
-    mut f: F,
+    mut apply: Apply,
 ) -> Result<Buffer<T>, usize>
 where
     S: IndexedSource + Copy,
     T: Copy + Default,
-    F: FnMut(S::Item) -> (T, bool),
+    Fail: Failure,
+    Apply: FnMut(S::Item) -> (T, Fail),
 {
     let len = source.len();
     debug_assert_eq!(len, valid_rows.len());
@@ -92,19 +107,21 @@ where
     };
 
     let mut values = BufferMut::<T>::with_capacity(len);
-    let out = &mut values.spare_capacity_mut()[..len];
 
-    if source.map_checked_into(out, &mut f) {
+    let out = &mut values.spare_capacity_mut()[..len];
+    if source.map_checked_into(out, &mut apply) != Fail::default() {
         let mut checked = |item: S::Item| {
-            let (value, error) = f(item);
-            (!error).then_some(value)
+            let (value, failure) = apply(item);
+            (failure == Fail::default()).then_some(value)
         };
         match valid_bits {
             None => source.try_map_into(out, &mut checked)?,
             Some(valid_bits) => source.try_map_masked_into(valid_bits, out, &mut checked)?,
         }
     }
+
     // SAFETY: the kernels initialize every lane in `out`.
     unsafe { values.set_len(len) };
+
     Ok(values.freeze())
 }

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
@@ -8,6 +8,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 use vortex_mask::Mask;
 
+use super::checked::Failure;
 use super::checked::checked_apply_lanes;
 use super::checked::checked_lanes;
 use crate::ArrayRef;
@@ -35,24 +36,36 @@ struct CheckedMul;
 struct CheckedDiv;
 
 trait CheckedPrimitiveOp<T: NativePType>: Sized {
+    /// Message for the error raised when this operation fails on a valid lane.
     const ERROR: &'static str;
+
+    /// Whether to check inside the value loop and exit early, rather than reducing evidence over
+    /// the whole batch and re-running only once some lane has flagged.
     const CHECKED_VALUE_LOOP: bool = false;
 
-    // The vectorizable kernels need an overflowing-style result, not
-    // `Option<T>`: every lane can write a value unconditionally while reducing
-    // the error flag separately. `checked` is still available for scalar and
-    // one-pass paths where early exit is the right shape.
-    fn apply(lhs: T, rhs: T) -> (T, bool);
+    /// How this operation reports a failing lane. See [`Failure`].
+    type Failure: Failure;
 
+    /// Compute a lane's value and its failure evidence together.
+    ///
+    /// Overflowing-style rather than `Option<T>`, so the vectorizable kernels can write every
+    /// lane's value unconditionally and reduce the evidence separately. [`Self::checked`] is the
+    /// shape for the scalar and early-exit paths.
+    fn apply(lhs: T, rhs: T) -> (T, Self::Failure);
+
+    /// [`Self::apply`] folded into the `Option` that the early-exit kernels take.
     #[inline(always)]
     fn checked(lhs: T, rhs: T) -> Option<T> {
         let (value, failed) = Self::apply(lhs, rhs);
-        if failed { None } else { Some(value) }
+
+        (failed == Self::Failure::default()).then_some(value)
     }
 }
 
 impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedAdd {
     const ERROR: &'static str = "integer overflow in checked add";
+
+    type Failure = bool;
 
     #[inline(always)]
     fn apply(lhs: T, rhs: T) -> (T, bool) {
@@ -63,6 +76,8 @@ impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedAdd {
 impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedSub {
     const ERROR: &'static str = "integer overflow in checked sub";
 
+    type Failure = bool;
+
     #[inline(always)]
     fn apply(lhs: T, rhs: T) -> (T, bool) {
         (lhs.sub_value(rhs), lhs.sub_error(rhs))
@@ -72,9 +87,11 @@ impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedSub {
 impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedMul {
     const ERROR: &'static str = "integer overflow in checked mul";
 
+    type Failure = T::MulFailure;
+
     #[inline(always)]
-    fn apply(lhs: T, rhs: T) -> (T, bool) {
-        (lhs.mul_value(rhs), lhs.mul_error(rhs))
+    fn apply(lhs: T, rhs: T) -> (T, T::MulFailure) {
+        (lhs.mul_value(rhs), lhs.mul_failure(rhs))
     }
 }
 
@@ -86,6 +103,8 @@ impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedDiv {
     // division, matching Arrow/Velox. Float division has no checked errors and
     // stays on the split/vectorizable default path.
     const CHECKED_VALUE_LOOP: bool = T::DIV_CHECKS_IN_VALUE_LOOP;
+
+    type Failure = bool;
 
     #[inline(always)]
     fn apply(lhs: T, rhs: T) -> (T, bool) {
@@ -184,13 +203,11 @@ where
     primitive_result_array::<T>(values, validity, &result_dtype)
 }
 
-/// Run `Op` over the lanes of `source` in the loop shape the op declares: the split
-/// value/error kernel for vectorizable ops, or the one-pass early-exit checked kernel when
-/// `Op::CHECKED_VALUE_LOOP` is set.
+/// Run `Op` over the lanes of `source` in the loop shape it declares: the one-pass early-exit
+/// kernel when `Op::CHECKED_VALUE_LOOP` is set, and the split value/failure kernel otherwise.
 ///
-/// `#[inline(always)]`: keeps the `to_operands` closure environment (captured constant
-/// operands) flattened into the kernel loop — see `checked::checked_lanes`.
-#[inline(always)]
+/// `#[inline]`: see [`checked_lanes`].
+#[inline]
 fn checked_op_lanes<S, T, Op>(
     source: S,
     valid_rows: &Mask,
@@ -297,12 +314,16 @@ impl<T: NativePType> PrimitiveOperand<T> {
 trait CheckedArithmetic: NativePType {
     const DIV_CHECKS_IN_VALUE_LOOP: bool;
 
+    /// How multiplication reports a failing lane, which is width-dependent in a way the other
+    /// operations are not. Each impl's `mul_failure` says why it chose what it chose.
+    type MulFailure: Failure;
+
     fn add_value(self, rhs: Self) -> Self;
     fn add_error(self, rhs: Self) -> bool;
     fn sub_value(self, rhs: Self) -> Self;
     fn sub_error(self, rhs: Self) -> bool;
     fn mul_value(self, rhs: Self) -> Self;
-    fn mul_error(self, rhs: Self) -> bool;
+    fn mul_failure(self, rhs: Self) -> Self::MulFailure;
     fn div_value(self, rhs: Self) -> Self;
     fn div_error(self, rhs: Self) -> bool;
     fn div_checked(self, rhs: Self) -> Option<Self>;
@@ -312,6 +333,8 @@ macro_rules! impl_checked_unsigned {
     ($ty:ty,widening_mul: $wide:ty) => {
         impl CheckedArithmetic for $ty {
             const DIV_CHECKS_IN_VALUE_LOOP: bool = true;
+
+            type MulFailure = $ty;
 
             #[inline(always)]
             fn add_value(self, rhs: Self) -> Self {
@@ -338,9 +361,11 @@ macro_rules! impl_checked_unsigned {
                 self.wrapping_mul(rhs)
             }
 
+            /// The bits the narrow product discards, which are non-zero exactly when the multiply
+            /// overflowed and cost none of the comparison LLVM folds into `umul.with.overflow`.
             #[inline(always)]
-            fn mul_error(self, rhs: Self) -> bool {
-                (self as $wide) * (rhs as $wide) > <$ty>::MAX as $wide
+            fn mul_failure(self, rhs: Self) -> $ty {
+                (((self as $wide) * (rhs as $wide)) >> <$ty>::BITS) as $ty
             }
 
             #[inline(always)]
@@ -363,6 +388,8 @@ macro_rules! impl_checked_unsigned {
         impl CheckedArithmetic for $ty {
             const DIV_CHECKS_IN_VALUE_LOOP: bool = true;
 
+            type MulFailure = u64;
+
             #[inline(always)]
             fn add_value(self, rhs: Self) -> Self {
                 self.wrapping_add(rhs)
@@ -388,9 +415,13 @@ macro_rules! impl_checked_unsigned {
                 self.wrapping_mul(rhs)
             }
 
+            /// As the narrower widths, but through `u128`, because this arm is the 64-bit width and
+            /// has no wider native type to widen into.
             #[inline(always)]
-            fn mul_error(self, rhs: Self) -> bool {
-                self.overflowing_mul(rhs).1
+            fn mul_failure(self, rhs: Self) -> u64 {
+                const { assert!(<$ty>::BITS == 64) };
+
+                (((self as u128) * (rhs as u128)) >> 64) as u64
             }
 
             #[inline(always)]
@@ -416,6 +447,8 @@ macro_rules! impl_checked_signed {
         impl CheckedArithmetic for $ty {
             const DIV_CHECKS_IN_VALUE_LOOP: bool = true;
 
+            type MulFailure = bool;
+
             #[inline(always)]
             fn add_value(self, rhs: Self) -> Self {
                 self.wrapping_add(rhs)
@@ -443,9 +476,12 @@ macro_rules! impl_checked_signed {
                 self.wrapping_mul(rhs)
             }
 
+            /// A plain `bool`, because the two-sided range check is not the shape LLVM folds
+            /// into an overflow intrinsic, so these widths vectorize without reporting evidence.
             #[inline(always)]
-            fn mul_error(self, rhs: Self) -> bool {
+            fn mul_failure(self, rhs: Self) -> bool {
                 let product = (self as $wide) * (rhs as $wide);
+
                 product < <$ty>::MIN as $wide || product > <$ty>::MAX as $wide
             }
 
@@ -469,6 +505,8 @@ macro_rules! impl_checked_signed {
         impl CheckedArithmetic for $ty {
             const DIV_CHECKS_IN_VALUE_LOOP: bool = true;
 
+            type MulFailure = u64;
+
             #[inline(always)]
             fn add_value(self, rhs: Self) -> Self {
                 self.wrapping_add(rhs)
@@ -496,9 +534,23 @@ macro_rules! impl_checked_signed {
                 self.wrapping_mul(rhs)
             }
 
+            /// A signed multiply overflows exactly when the discarded half of the true product
+            /// differs from the sign extension of the half that was kept, so the two XOR to zero
+            /// on the lanes that fit. `tests::test_i64_multiply_overflow_boundaries` pins the
+            /// boundaries this replaces `overflowing_mul` at.
             #[inline(always)]
-            fn mul_error(self, rhs: Self) -> bool {
-                self.overflowing_mul(rhs).1
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "the truncated half is the result, and the discarded half is the evidence"
+            )]
+            fn mul_failure(self, rhs: Self) -> u64 {
+                const { assert!(<$ty>::BITS == 64) };
+
+                let wide = (self as i128) * (rhs as i128);
+                let kept = wide as i64;
+                let discarded = (wide >> 64) as i64;
+
+                (discarded ^ (kept >> 63)) as u64
             }
 
             #[inline(always)]
@@ -524,6 +576,8 @@ macro_rules! impl_checked_float {
         $(
             impl CheckedArithmetic for $ty {
                 const DIV_CHECKS_IN_VALUE_LOOP: bool = false;
+
+                type MulFailure = bool;
 
                 #[inline(always)]
                 fn add_value(self, rhs: Self) -> Self {
@@ -551,7 +605,7 @@ macro_rules! impl_checked_float {
                 }
 
                 #[inline(always)]
-                fn mul_error(self, _rhs: Self) -> bool {
+                fn mul_failure(self, _rhs: Self) -> bool {
                     false
                 }
 
@@ -583,3 +637,69 @@ impl_checked_signed!(i16, widening_mul: i32);
 impl_checked_signed!(i32, widening_mul: i64);
 impl_checked_signed!(i64, overflowing_mul);
 impl_checked_float!(f16, f32, f64);
+
+#[cfg(test)]
+mod tests {
+    use super::CheckedArithmetic;
+
+    /// Values whose pairwise products are worth probing: the saturating boundaries, the sign-change
+    /// pivots, and a spread of magnitudes that straddles the 64-bit split.
+    const PROBES: &[i64] = &[
+        0,            //
+        1,            //
+        -1,           //
+        2,            //
+        -2,           //
+        3,            //
+        i64::MIN,     //
+        i64::MIN + 1, //
+        i64::MAX,     //
+        i64::MAX - 1, //
+        1 << 31,      //
+        1 << 32,      //
+        1 << 62,      //
+        -(1 << 62),   //
+        0x7FFF_FFFF,  //
+        -0x8000_0000, //
+    ];
+
+    /// Every `mul_failure` impl is either a bit trick or a two-sided range check, so hold each
+    /// against the obvious reference: `reference` is the width's own `checked_mul`, whose `None`
+    /// _is_ the definition of overflow.
+    #[track_caller]
+    fn assert_agrees_with_checked_mul<T: CheckedArithmetic>(lhs: T, rhs: T, reference: Option<T>) {
+        let failed = lhs.mul_failure(rhs) != <T::MulFailure as Default>::default();
+
+        assert_eq!(failed, reference.is_none(), "{lhs:?} * {rhs:?}");
+    }
+
+    #[test]
+    fn mul_failure_agrees_with_checked_mul_at_64_bits() {
+        for &lhs in PROBES {
+            for &rhs in PROBES {
+                assert_agrees_with_checked_mul(lhs, rhs, lhs.checked_mul(rhs));
+
+                let (lhs, rhs) = (lhs as u64, rhs as u64);
+
+                assert_agrees_with_checked_mul(lhs, rhs, lhs.checked_mul(rhs));
+            }
+        }
+    }
+
+    /// The 8-bit widths are cheap enough to check exhaustively, which pins the shift of the
+    /// unsigned formula and the range check of the signed one against every product that exists.
+    #[test]
+    fn mul_failure_agrees_with_checked_mul_exhaustively_at_8_bits() {
+        for lhs in u8::MIN..=u8::MAX {
+            for rhs in u8::MIN..=u8::MAX {
+                assert_agrees_with_checked_mul(lhs, rhs, lhs.checked_mul(rhs));
+            }
+        }
+
+        for lhs in i8::MIN..=i8::MAX {
+            for rhs in i8::MIN..=i8::MAX {
+                assert_agrees_with_checked_mul(lhs, rhs, lhs.checked_mul(rhs));
+            }
+        }
+    }
+}

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use rstest::rstest;
+use vortex_buffer::Buffer;
 use vortex_buffer::buffer;
 use vortex_error::VortexResult;
 
@@ -21,6 +22,7 @@ use crate::dtype::DType;
 use crate::dtype::DecimalDType;
 use crate::dtype::DecimalType;
 use crate::dtype::NativeDecimalType;
+use crate::dtype::NativePType;
 use crate::dtype::Nullability;
 use crate::dtype::i256;
 use crate::scalar::DecimalValue;
@@ -197,6 +199,132 @@ fn test_integer_array_array_errors_on_valid_lanes() {
         .and_then(|a| a.execute::<PrimitiveArray>(&mut array_session().create_execution_ctx()));
 
     assert!(result.is_err());
+}
+
+/// Multiply two non-nullable lanes of `lhs` by two of `rhs`, expecting `Some(product)` where the
+/// product fits and `None` where the checked kernel must report overflow.
+#[track_caller]
+fn assert_multiply<T: NativePType>(lhs: T, rhs: T, expected: Option<T>) -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+    let result = PrimitiveArray::from_iter([lhs, lhs])
+        .into_array()
+        .binary(
+            PrimitiveArray::from_iter([rhs, rhs]).into_array(),
+            Operator::Mul,
+        )?
+        .execute::<PrimitiveArray>(&mut ctx);
+
+    let Some(product) = expected else {
+        assert!(result.is_err(), "{lhs:?} * {rhs:?} must report overflow");
+        return Ok(());
+    };
+
+    assert_arrays_eq!(
+        result?,
+        PrimitiveArray::from_iter([product, product]),
+        &mut ctx
+    );
+
+    Ok(())
+}
+
+/// Multiplication derives overflow from the bits the narrow product discards rather than from a
+/// comparison, and it does so by a different formula per width, so each boundary of each formula is
+/// worth pinning. The 8 and 32-bit signed cases cover the two-sided range check, the 64-bit signed
+/// ones the sign-extension XOR, and the unsigned ones the high-half shift.
+#[rstest]
+#[case::i8_fits(100i8, 1, Some(100))]
+#[case::i8_overflows(100i8, 2, None)]
+#[case::i8_min_times_minus_one(i8::MIN,     -1,       None)]
+#[case::i32_fits(             1i32 << 15,   1 << 15,  Some(1 << 30))]
+#[case::i32_min_times_minus_one(i32::MIN,   -1,       None)]
+#[case::i64_min_times_one(i64::MIN, 1, Some(i64::MIN))]
+#[case::i64_minus_one_squared(-1i64,        -1,       Some(1))]
+#[case::i64_max_times_one(i64::MAX, 1, Some(i64::MAX))]
+#[case::i64_negative_product( -5i64,        3,        Some(-15))]
+#[case::i64_zero(0i64, i64::MIN, Some(0))]
+#[case::i64_min_times_minus_one(i64::MIN,   -1,       None)]
+#[case::i64_max_times_two(i64::MAX, 2, None)]
+#[case::i64_min_times_two(i64::MIN, 2, None)]
+#[case::u8_fits(200u8, 1, Some(200))]
+#[case::u8_overflows(200u8, 2, None)]
+#[case::u16_boundary(65535u16, 1, Some(65535))]
+#[case::u32_halves(           1u32 << 16,   1 << 15,  Some(1 << 31))]
+#[case::u32_overflows(        1u32 << 16,   1 << 16,  None)]
+#[case::u64_max(u64::MAX, 1, Some(u64::MAX))]
+#[case::u64_overflows(u64::MAX, 2, None)]
+fn test_multiply_overflow_boundaries<T: NativePType>(
+    #[case] lhs: T,
+    #[case] rhs: T,
+    #[case] expected: Option<T>,
+) -> VortexResult<()> {
+    assert_multiply(lhs, rhs, expected)
+}
+
+/// An overflowing multiply behind a null row stays invisible, whichever width of evidence the lane
+/// reports: `bool` for narrow signed, the operand itself for unsigned, and `u64` for 64-bit.
+#[rstest]
+#[case::signed_8(i8::MAX, 3, 9)]
+#[case::unsigned_32(u32::MAX, 7, 49)]
+#[case::signed_64(i64::MAX, 2, 4)]
+fn test_multiply_overflow_on_null_lane_ignored<T: NativePType>(
+    #[case] overflowing: T,
+    #[case] rhs: T,
+    #[case] expected: T,
+) -> VortexResult<()> {
+    let mut ctx = array_session().create_execution_ctx();
+    let lhs = PrimitiveArray::new(
+        Buffer::copy_from([overflowing, rhs]),
+        Validity::from_iter([false, true]),
+    )
+    .into_array();
+
+    let result = lhs
+        .binary(
+            PrimitiveArray::from_iter([rhs, rhs]).into_array(),
+            Operator::Mul,
+        )?
+        .execute::<RecursiveCanonical>(&mut ctx)?
+        .0
+        .into_array();
+
+    assert_arrays_eq!(
+        result,
+        PrimitiveArray::from_option_iter([None, Some(expected)]),
+        &mut ctx
+    );
+
+    Ok(())
+}
+
+/// The hot pass OR-reduces evidence across whole 64-lane chunks before anything looks at it, so an
+/// overflow in a late chunk must still be caught, and must still be suppressed when its lane is
+/// null. Every other test here fits in a single chunk and cannot show either.
+#[rstest]
+#[case::reported(true)]
+#[case::suppressed_by_null(false)]
+fn test_multiply_overflow_survives_chunk_reduction(
+    #[case] lane_is_valid: bool,
+) -> VortexResult<()> {
+    const LEN: u32 = 1000;
+    const OVERFLOW_AT: u32 = 700;
+
+    let mut ctx = array_session().create_execution_ctx();
+    let mut lhs: Vec<u32> = (0..LEN).map(|i| i % 100 + 1).collect();
+    lhs[OVERFLOW_AT as usize] = u32::MAX;
+
+    let validity = Validity::from_iter((0..LEN).map(|i| i != OVERFLOW_AT || lane_is_valid));
+    let result = PrimitiveArray::new(Buffer::copy_from(&lhs), validity)
+        .into_array()
+        .binary(
+            PrimitiveArray::from_iter(vec![3u32; LEN as usize]).into_array(),
+            Operator::Mul,
+        )?
+        .execute::<RecursiveCanonical>(&mut ctx);
+
+    assert_eq!(result.is_err(), lane_is_valid);
+
+    Ok(())
 }
 
 #[test]

--- a/vortex-compute/src/lane_kernels/map_into.rs
+++ b/vortex-compute/src/lane_kernels/map_into.rs
@@ -5,6 +5,7 @@
 //! caller-provided `&mut [MaybeUninit<R>]`.
 
 use std::mem::MaybeUninit;
+use std::ops::BitOrAssign;
 
 use vortex_buffer::BitBuffer;
 
@@ -217,22 +218,19 @@ pub trait IndexedSourceExt: IndexedSource + Sized {
         }
     }
 
-    /// Split value/error map with **no validity awareness at all**: apply
-    /// `f(value) -> (R, bool)` to every lane, write the value unconditionally, and
-    /// OR-reduce the per-lane error flags into the returned `bool`.
+    /// Split value/failure map with **no validity awareness at all**: write every lane's value
+    /// unconditionally and OR-reduce its failure evidence into the return.
     ///
-    /// This is the highest-throughput checked shape for operations whose error
-    /// check auto-vectorizes (e.g. checked integer add/sub/mul): the loop carries a
-    /// single flag reduction with no per-lane select and no per-chunk exit branch,
-    /// so it runs at the speed of the unchecked [`map_into`]. The trade-off is that
-    /// it reports only *whether* some lane failed, not which one, and it never
-    /// exits early. Callers that need attribution or null-lane filtering should
-    /// re-run the (now known cold) input through [`try_map_into`] or
-    /// [`try_map_masked_into`] when this returns `true`.
+    /// The fastest checked shape, running at the speed of the unchecked [`map_into`] in exchange
+    /// for reporting only _that_ some lane failed and never exiting early. Re-run the now known
+    /// cold input through [`try_map_into`] or [`try_map_masked_into`] to attribute the failure or
+    /// to drop the null-lane ones. The evidence reduces inside the kernel because a captured `&mut`
+    /// becomes a loop-carried memory dependence that blocks vectorization.
     ///
-    /// The flag is deliberately reduced inside the kernel rather than through a
-    /// closure-captured `&mut bool`: an escaped flag becomes a loop-carried memory
-    /// dependence that blocks auto-vectorization of the whole loop.
+    /// Anything other than [`Default`] means failure, and `bool` is the ordinary `Fail`. Wider
+    /// words exist for operations where deriving a `bool` costs the vectorization it guards.
+    /// **`Fail` must be no wider than `R`**, asserted below, or the reduction rather than the
+    /// operation decides how many lanes fit in a vector.
     ///
     /// [`map_into`]: IndexedSourceExt::map_into
     /// [`try_map_into`]: IndexedSourceExt::try_map_into
@@ -242,21 +240,30 @@ pub trait IndexedSourceExt: IndexedSource + Sized {
     ///
     /// Panics if `out.len() != self.len()`.
     #[inline]
-    fn map_checked_into<R, F>(self, out: &mut [MaybeUninit<R>], mut f: F) -> bool
+    fn map_checked_into<R, Fail, Apply>(self, out: &mut [MaybeUninit<R>], mut apply: Apply) -> Fail
     where
-        R: Copy,
-        F: FnMut(Self::Item) -> (R, bool),
+        Fail: Copy + Default + BitOrAssign,
+        Apply: FnMut(Self::Item) -> (R, Fail),
     {
+        const {
+            assert!(
+                size_of::<Fail>() <= size_of::<R>(),
+                "failure evidence must be no wider than the value, or it bounds the vector width"
+            )
+        };
+
         let values = self;
         let len = values.len();
         assert_eq!(out.len(), len, "out must have the same length as values");
 
-        let mut failed = false;
+        let mut failed = Fail::default();
         for idx in 0..len {
             // SAFETY: idx < len by the loop bound, and out.len() == len.
             let val = unsafe { values.get_unchecked(idx) };
-            let (result, error) = f(val);
-            failed |= error;
+
+            let (result, failure) = apply(val);
+            failed |= failure;
+
             // SAFETY: idx < len == out.len().
             unsafe { out.get_unchecked_mut(idx).write(result) };
         }


### PR DESCRIPTION
Replaces the per-lane overflow comparison in checked multiplication with the bits the narrow product discards. An unsigned checked multiply widens both operands, multiplies, and compares the product against the narrow maximum, and LLVM canonicalizes that into `llvm.umul.with.overflow`, which has no vector lowering. Eight spellings of the check compile to the same scalar code. The lane now returns the discarded half of the true product, which is non-zero on exactly the lanes that overflow, and `map_checked_into` OR-reduces it. Overflow detection is unchanged for every input.

The narrow signed widths keep their two-sided range check, which LLVM does not fold, so they measure neutral below. `map_checked_into` asserts that the evidence is no wider than the value, because a wider word puts the reduction rather than the arithmetic in charge of how many lanes a vector covers. The three kernel wrappers also relax from `#[inline(always)]` to `#[inline]`, which measures the same.

Open question: do the 64-bit widths need `u64` evidence rather than `bool`? There is no vector integer multiply at 64-bit width below AVX-512DQ, so the width is possibly not load-bearing on the CodSpeed runner.

Follow-up: prove from cached `Stat::Min` and `Stat::Max` that a multiply cannot overflow and skip the check entirely, the way `values_fit_in` already does for narrowing casts in `cast.rs`. Against a build with the check compiled out, that is worth a further 1.9x at `u8` and nothing at `u32`.

<details>
<summary>Benchmark results</summary>

`binary_ops`, 65536 rows, divan fastest of 100 samples, interleaved A/B over two rounds against `develop` on an Apple M4 Max. `add_i64_nonnull`, `div_i64_nonnull` and `eq_i64_constant` are controls over untouched code.

| benchmark | before | after | |
| --- | --- | --- | --- |
| `mul_u8_nonnull` | 10.74 µs | 1.332 µs | 8.1x |
| `mul_u16_nonnull` | 11.58 µs | 1.707 µs | 6.8x |
| `mul_u32_nonnull` | 12.29 µs | 3.457 µs | 3.6x |
| `mul_u64_nonnull` | 12.41 µs | 6.999 µs | 1.8x |
| `mul_i64_nonnull` | 13.20 µs | 8.082 µs | 1.6x |
| `mul_i8_nonnull` | 1.457 µs | 1.457 µs | neutral |
| `mul_i16_nonnull` | 2.624 µs | 2.624 µs | neutral |
| `mul_i32_nonnull` | 3.957 µs | 3.999 µs | neutral |
| `mul_i32_nullable` | 4.540 µs | 4.540 µs | neutral |
| `mul_i32_constant` | 3.915 µs | 3.957 µs | neutral |
| `add_i64_nonnull` | 6.791 µs | 6.832 µs | control |
| `div_i64_nonnull` | 18.79 µs | 17.54 µs | control |
| `eq_i64_constant` | 3.582 µs | 3.582 µs | control |

`mul.with.overflow` falls from 20 occurrences to 4 across the checked kernels, and OR reductions appear at `v16i8`, `v8i16` and `v4i32`, each the width of its own operand. The remaining 4 are the scalar constant-folding path.

CodSpeed runs on x86, where the 64-bit rows are expected to differ from the aarch64 numbers above.

</details>
