### PR TITLE
Benchmark unsigned 64-bit multiplication

### DIFF
--- a/vortex-array/benches/binary_ops.rs
+++ b/vortex-array/benches/binary_ops.rs
@@ -135,6 +135,14 @@ fn mul_u32_nonnull(bencher: Bencher) {
 }
 
 #[divan::bench]
+fn mul_u64_nonnull(bencher: Bencher) {
+    let lhs = primitive_u64_small_nonnull(1).into_array();
+    let rhs = primitive_u64_small_nonnull(17).into_array();
+
+    bench_primitive(bencher, lhs, rhs, Operator::Mul);
+}
+
+#[divan::bench]
 fn mul_i32_nullable(bencher: Bencher) {
     let lhs = primitive_i32_small_nullable(1, 7).into_array();
     let rhs = primitive_i32_small_nullable(17, 5).into_array();
@@ -284,6 +292,10 @@ fn primitive_i32_small_nonnull(offset: i32) -> PrimitiveArray {
 
 fn primitive_u32_small_nonnull(offset: u32) -> PrimitiveArray {
     PrimitiveArray::from_iter((0..LEN).map(|i| ((i + offset as usize) % 4096 + 1) as u32))
+}
+
+fn primitive_u64_small_nonnull(offset: u64) -> PrimitiveArray {
+    PrimitiveArray::from_iter((0..LEN).map(|i| ((i + offset as usize) % 4096 + 1) as u64))
 }
 
 fn primitive_nonzero() -> PrimitiveArray {


### PR DESCRIPTION
Adds a `mul_u64_nonnull` case to `binary_ops`. The suite covers `Mul` at every signed width and at `u8`, `u16` and `u32`, but not at `u64`, which takes a different overflow check because it has no wider native type to widen into.

This lands separately so that CodSpeed records a baseline on `develop` before #9210 changes that check. Measured on that PR, the width gains 1.8x, which no existing benchmark would have caught.
