### PR TITLE
Remove the unimplemented `NotKernel` extension point

### DIFF
--- a/vortex-array/src/scalar_fn/fns/not/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/not/kernel.rs
@@ -4,12 +4,10 @@
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::VTable;
 use crate::arrays::scalar_fn::ExactScalarFn;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
-use crate::kernel::ExecuteParentKernel;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::scalar_fn::fns::not::Not as NotExpr;
 
@@ -20,15 +18,6 @@ use crate::scalar_fn::fns::not::Not as NotExpr;
 /// Implementations should return `None` if the operation requires buffer access.
 pub trait NotReduce: VTable {
     fn invert(array: ArrayView<'_, Self>) -> VortexResult<Option<ArrayRef>>;
-}
-
-/// Invert a boolean array, potentially reading buffers.
-///
-/// Unlike [`NotReduce`], this trait is for invert implementations that may need
-/// to read and execute on the underlying buffers to produce the result.
-pub trait NotKernel: VTable {
-    fn invert(array: ArrayView<'_, Self>, ctx: &mut ExecutionCtx)
-    -> VortexResult<Option<ArrayRef>>;
 }
 
 /// Adaptor that wraps a [`NotReduce`] impl as an [`ArrayParentReduceRule`].
@@ -48,26 +37,5 @@ where
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         <V as NotReduce>::invert(array)
-    }
-}
-
-/// Adaptor that wraps a [`NotKernel`] impl as an [`ExecuteParentKernel`].
-#[derive(Default, Debug)]
-pub struct NotExecuteAdaptor<V>(pub V);
-
-impl<V> ExecuteParentKernel<V> for NotExecuteAdaptor<V>
-where
-    V: NotKernel,
-{
-    type Parent = ExactScalarFn<NotExpr>;
-
-    fn execute_parent(
-        &self,
-        array: ArrayView<'_, V>,
-        _parent: ScalarFnArrayView<'_, NotExpr>,
-        _child_idx: usize,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<ArrayRef>> {
-        <V as NotKernel>::invert(array, ctx)
     }
 }


### PR DESCRIPTION
Removes `NotKernel` and `NotExecuteAdaptor`, which have no implementors anywhere in the workspace. `BooleanKernel` has two and `CompareKernel` has fourteen, so an encoding that has something to contribute does implement the corresponding trait. `not` never grew one.

`NotReduce` and `NotReduceAdaptor` stay in the same file. The constant encoding implements the first and registers the second, so the metadata-only half of the extension point is live.

Removing the buffer-reading half is a statement that `not` has no encoding-aware execution today, not that it cannot have one. Restoring the trait is a revert of this commit if an encoding needs it.
