### PR TITLE
Optimize ChunkedArray take routing

### DIFF
--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -228,6 +228,10 @@ name = "take_primitive"
 harness = false
 
 [[bench]]
+name = "take_chunked"
+harness = false
+
+[[bench]]
 name = "piecewise_sequence_take_primitive"
 harness = false
 

--- a/vortex-array/benches/take_chunked.rs
+++ b/vortex-array/benches/take_chunked.rs
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Benchmarks [`ChunkedArray`] take routing across ordering, chunk count, duplicate density,
+//! nullability, and value-shape configurations.
+
+#![expect(clippy::unwrap_used)]
+
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use divan::Bencher;
+use divan::counter::ItemsCount;
+use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
+use vortex_array::RecursiveCanonical;
+use vortex_array::VortexSessionExecute;
+use vortex_array::array_session;
+use vortex_array::arrays::ChunkedArray;
+use vortex_array::arrays::FixedSizeListArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::StructArray;
+use vortex_array::dtype::FieldNames;
+use vortex_array::validity::Validity;
+use vortex_buffer::Buffer;
+
+fn main() {
+    divan::main();
+}
+
+const SOURCE_LEN: usize = 1 << 20;
+const NESTED_WIDTH: usize = 8;
+
+#[derive(Clone, Copy)]
+enum Pattern {
+    Sorted,
+    Shuffled,
+    Repeated,
+    Duplicate90,
+    Duplicate99,
+    SameChunk,
+    AlternatingChunks,
+    GroupedChunks,
+}
+
+impl Display for Pattern {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Sorted => "sorted",
+            Self::Shuffled => "shuffled",
+            Self::Repeated => "repeated",
+            Self::Duplicate90 => "duplicate90",
+            Self::Duplicate99 => "duplicate99",
+            Self::SameChunk => "same_chunk",
+            Self::AlternatingChunks => "alternating_chunks",
+            Self::GroupedChunks => "grouped_chunks",
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ValueKind {
+    Primitive,
+    Struct8,
+    FixedSizeList8,
+}
+
+impl Display for ValueKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Primitive => "primitive",
+            Self::Struct8 => "struct8",
+            Self::FixedSizeList8 => "fsl8",
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+enum IndexValidity {
+    NonNullable,
+    AllValid,
+    TenPercentNull,
+}
+
+impl Display for IndexValidity {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::NonNullable => "nonnull",
+            Self::AllValid => "nullable_all_valid",
+            Self::TenPercentNull => "nullable_10pct_null",
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Case {
+    group: &'static str,
+    pattern: Pattern,
+    value_kind: ValueKind,
+    validity: IndexValidity,
+    chunks: usize,
+    indices: usize,
+}
+
+impl Case {
+    const fn new(group: &'static str, pattern: Pattern, chunks: usize, indices: usize) -> Self {
+        Self {
+            group,
+            pattern,
+            value_kind: ValueKind::Primitive,
+            validity: IndexValidity::NonNullable,
+            chunks,
+            indices,
+        }
+    }
+
+    const fn with_value_kind(mut self, value_kind: ValueKind) -> Self {
+        self.value_kind = value_kind;
+        self
+    }
+
+    const fn with_validity(mut self, validity: IndexValidity) -> Self {
+        self.validity = validity;
+        self
+    }
+}
+
+impl Display for Case {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}/{}/{}/{}/chunks={}/indices={}",
+            self.group, self.pattern, self.value_kind, self.validity, self.chunks, self.indices
+        )
+    }
+}
+
+fn cases() -> Vec<Case> {
+    let mut cases = Vec::new();
+
+    for pattern in [Pattern::Sorted, Pattern::Shuffled] {
+        for chunks in [16, 1_024] {
+            for indices in [10_000, 100_000] {
+                cases.push(Case::new("core", pattern, chunks, indices));
+            }
+        }
+    }
+
+    for chunks in [1_024, 16_384] {
+        for indices in [1, 16, 256, 1_000] {
+            cases.push(Case::new("small_m", Pattern::Shuffled, chunks, indices));
+        }
+    }
+
+    for pattern in [
+        Pattern::Repeated,
+        Pattern::Duplicate90,
+        Pattern::Duplicate99,
+    ] {
+        cases.push(Case::new("duplicates", pattern, 16, 100_000));
+    }
+
+    for pattern in [Pattern::Shuffled, Pattern::Duplicate99] {
+        for value_kind in [
+            ValueKind::Primitive,
+            ValueKind::Struct8,
+            ValueKind::FixedSizeList8,
+        ] {
+            cases.push(Case::new("value_shape", pattern, 16, 10_000).with_value_kind(value_kind));
+        }
+    }
+
+    for chunks in [16, 1_024] {
+        for validity in [IndexValidity::AllValid, IndexValidity::TenPercentNull] {
+            cases.push(
+                Case::new("nullable", Pattern::Sorted, chunks, 100_000).with_validity(validity),
+            );
+        }
+    }
+
+    for pattern in [
+        Pattern::SameChunk,
+        Pattern::AlternatingChunks,
+        Pattern::GroupedChunks,
+    ] {
+        cases.push(Case::new("routing", pattern, 1_024, 100_000));
+    }
+
+    cases
+}
+
+fn primitive_values(start: usize, end: usize) -> ArrayRef {
+    PrimitiveArray::from_iter((start..end).map(|value| u64::try_from(value).unwrap())).into_array()
+}
+
+fn chunk_values(value_kind: ValueKind, start: usize, end: usize) -> ArrayRef {
+    match value_kind {
+        ValueKind::Primitive => primitive_values(start, end),
+        ValueKind::Struct8 => {
+            let fields: Vec<_> = (0..NESTED_WIDTH)
+                .map(|field| {
+                    let field_offset = u64::try_from(field * SOURCE_LEN).unwrap();
+                    PrimitiveArray::from_iter(
+                        (start..end).map(|value| u64::try_from(value).unwrap() + field_offset),
+                    )
+                    .into_array()
+                })
+                .collect();
+            StructArray::try_new(
+                FieldNames::from(["f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7"]),
+                fields,
+                end - start,
+                Validity::NonNullable,
+            )
+            .unwrap()
+            .into_array()
+        }
+        ValueKind::FixedSizeList8 => {
+            let element_start = start * NESTED_WIDTH;
+            let element_end = end * NESTED_WIDTH;
+            FixedSizeListArray::new(
+                primitive_values(element_start, element_end),
+                u32::try_from(NESTED_WIDTH).unwrap(),
+                Validity::NonNullable,
+                end - start,
+            )
+            .into_array()
+        }
+    }
+}
+
+fn chunked_values(case: Case) -> ArrayRef {
+    let chunk_len = SOURCE_LEN / case.chunks;
+    let chunks = (0..case.chunks)
+        .map(|chunk_idx| {
+            let start = chunk_idx * chunk_len;
+            let end = start + chunk_len;
+            chunk_values(case.value_kind, start, end)
+        })
+        .collect::<Vec<_>>();
+    let dtype = chunks[0].dtype().clone();
+    ChunkedArray::try_new(chunks, dtype).unwrap().into_array()
+}
+
+fn advance_random(state: &mut u64) -> u64 {
+    *state = state
+        .wrapping_mul(6_364_136_223_846_793_005)
+        .wrapping_add(1_442_695_040_888_963_407);
+    *state
+}
+
+fn index_values(case: Case) -> Vec<u64> {
+    let mut state = 0x4d59_5df4_d0f3_3173u64;
+    let mut indices = match case.pattern {
+        Pattern::Sorted | Pattern::Shuffled => (0..case.indices)
+            .map(|_| advance_random(&mut state) % u64::try_from(SOURCE_LEN).unwrap())
+            .collect(),
+        Pattern::Repeated => vec![u64::try_from(SOURCE_LEN / 2).unwrap(); case.indices],
+        Pattern::Duplicate90 | Pattern::Duplicate99 => {
+            let divisor = match case.pattern {
+                Pattern::Duplicate90 => 10,
+                Pattern::Duplicate99 => 100,
+                _ => unreachable!(),
+            };
+            let unique_count = (case.indices / divisor).max(1);
+            (0..case.indices)
+                .map(|_| {
+                    let slot = usize::try_from(
+                        advance_random(&mut state) % u64::try_from(unique_count).unwrap(),
+                    )
+                    .unwrap();
+                    u64::try_from(slot * SOURCE_LEN / unique_count).unwrap()
+                })
+                .collect()
+        }
+        Pattern::SameChunk => {
+            let chunk_len = SOURCE_LEN / case.chunks;
+            let chunk_start = (case.chunks / 2) * chunk_len;
+            (0..case.indices)
+                .map(|_| {
+                    let local = usize::try_from(
+                        advance_random(&mut state) % u64::try_from(chunk_len).unwrap(),
+                    )
+                    .unwrap();
+                    u64::try_from(chunk_start + local).unwrap()
+                })
+                .collect()
+        }
+        Pattern::AlternatingChunks => {
+            let chunk_len = SOURCE_LEN / case.chunks;
+            (0..case.indices)
+                .map(|position| {
+                    let chunk_idx = if position.is_multiple_of(2) {
+                        0
+                    } else {
+                        case.chunks - 1
+                    };
+                    let local = position / 2 % chunk_len;
+                    u64::try_from(chunk_idx * chunk_len + local).unwrap()
+                })
+                .collect()
+        }
+        Pattern::GroupedChunks => {
+            let chunk_len = SOURCE_LEN / case.chunks;
+            (0..case.indices)
+                .map(|position| {
+                    let chunk_idx = position * case.chunks / case.indices;
+                    let local = usize::try_from(
+                        advance_random(&mut state) % u64::try_from(chunk_len).unwrap(),
+                    )
+                    .unwrap();
+                    u64::try_from(chunk_idx * chunk_len + local).unwrap()
+                })
+                .collect()
+        }
+    };
+
+    if matches!(case.pattern, Pattern::Sorted) {
+        indices.sort_unstable();
+    }
+    indices
+}
+
+fn take_indices(case: Case) -> ArrayRef {
+    let indices = index_values(case);
+    match case.validity {
+        IndexValidity::NonNullable => PrimitiveArray::from_iter(indices).into_array(),
+        IndexValidity::AllValid => {
+            PrimitiveArray::new(Buffer::from(indices), Validity::AllValid).into_array()
+        }
+        IndexValidity::TenPercentNull => PrimitiveArray::new(
+            Buffer::from(indices),
+            Validity::from_iter((0..case.indices).map(|index| !index.is_multiple_of(10))),
+        )
+        .into_array(),
+    }
+}
+
+#[divan::bench(args = cases())]
+fn take(bencher: Bencher, case: Case) {
+    let values = chunked_values(case);
+    let indices = take_indices(case);
+    let session = array_session();
+
+    bencher
+        .counter(ItemsCount::new(case.indices))
+        .with_inputs(|| (indices.clone(), session.create_execution_ctx()))
+        .bench_refs(|(indices, ctx)| {
+            values
+                .take(indices.clone())
+                .unwrap()
+                .execute::<RecursiveCanonical>(ctx)
+                .unwrap()
+        });
+}

--- a/vortex-array/src/arrays/chunked/compute/take.rs
+++ b/vortex-array/src/arrays/chunked/compute/take.rs
@@ -3,7 +3,7 @@
 
 use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
-use vortex_mask::Mask;
+use vortex_error::vortex_bail;
 
 use crate::ArrayRef;
 use crate::Canonical;
@@ -38,58 +38,69 @@ fn take_chunked(
     let indices_values = indices.as_slice::<u64>();
     let n = indices_values.len();
 
-    // 1. Sort (value, orig_pos) pairs so indices for the same chunk are contiguous.
-    //    Skip null indices — their final_take slots stay 0 and are masked null by validity.
-    let mut pairs: Vec<(u64, usize)> = indices_values
-        .iter()
-        .enumerate()
-        .filter(|&(i, _)| indices_mask.value(i))
-        .map(|(i, &v)| (v, i))
-        .collect();
-    pairs.sort_unstable();
-
-    // 2. Fused pass: walk sorted pairs against chunk boundaries.
-    //    - Dedup inline → build per-chunk filter masks
-    //    - Scatter final_take[orig_pos] = dedup_idx for every pair
+    // Route each valid index into its source chunk. Within each bucket, preserve the request order
+    // so the taken chunks can be assembled and then restored to the original cross-chunk order.
     let chunk_offsets = array.chunk_offset_values();
     let nchunks = array.nchunks();
-    let mut chunks = Vec::with_capacity(nchunks);
-    let mut final_take = BufferMut::<u64>::with_capacity(n);
-    final_take.push_n(0u64, n);
+    let mut buckets = vec![Vec::<(u64, usize)>::new(); nchunks];
+    let mut monotonic = true;
+    let mut last_index = None;
+    let mut sorted_chunk_idx = 0;
 
-    let mut cursor = 0usize;
-    let mut dedup_idx = 0u64;
-
-    for chunk_idx in 0..nchunks {
-        let chunk_start = chunk_offsets[chunk_idx];
-        let chunk_end = chunk_offsets[chunk_idx + 1];
-        let chunk_len = chunk_end - chunk_start;
-        let chunk_end_u64 = u64::try_from(chunk_end)?;
-
-        let range_end = cursor + pairs[cursor..].partition_point(|&(v, _)| v < chunk_end_u64);
-        let chunk_pairs = &pairs[cursor..range_end];
-
-        if !chunk_pairs.is_empty() {
-            let mut local_indices: Vec<usize> = Vec::new();
-            for (i, &(val, orig_pos)) in chunk_pairs.iter().enumerate() {
-                if cursor + i > 0 && val != pairs[cursor + i - 1].0 {
-                    dedup_idx += 1;
-                }
-                let local = usize::try_from(val)? - chunk_start;
-                if local_indices.last() != Some(&local) {
-                    local_indices.push(local);
-                }
-                final_take[orig_pos] = dedup_idx;
-            }
-
-            let filter_mask = Mask::from_indices(chunk_len, local_indices);
-            chunks.push(array.chunk(chunk_idx).filter(filter_mask)?);
+    for (original_position, &index) in indices_values.iter().enumerate() {
+        if !indices_mask.value(original_position) {
+            continue;
         }
 
-        cursor = range_end;
+        let index = usize::try_from(index)?;
+        if index >= array.len() {
+            vortex_bail!(OutOfBounds: index, 0, array.len());
+        }
+
+        let still_sorted = last_index.is_none_or(|last_index| index >= last_index);
+        let chunk_idx = if monotonic && still_sorted {
+            while chunk_offsets[sorted_chunk_idx + 1] <= index {
+                sorted_chunk_idx += 1;
+            }
+            sorted_chunk_idx
+        } else {
+            monotonic = false;
+            chunk_offsets.partition_point(|&offset| offset <= index) - 1
+        };
+        last_index = Some(index);
+
+        let local_index = u64::try_from(index - chunk_offsets[chunk_idx])?;
+        buckets[chunk_idx].push((local_index, original_position));
     }
 
-    // SAFETY: every chunk came from a filter on a chunk with the same base dtype,
+    let mut chunks = Vec::with_capacity(nchunks);
+    let mut final_take = (!monotonic || indices.dtype().is_nullable()).then(|| {
+        let mut final_take = BufferMut::<u64>::with_capacity(n);
+        final_take.push_n(0u64, n);
+        final_take
+    });
+    let mut grouped_position = 0u64;
+
+    for (chunk_idx, bucket) in buckets.into_iter().enumerate() {
+        if bucket.is_empty() {
+            continue;
+        }
+
+        let mut local_indices = BufferMut::<u64>::with_capacity(bucket.len());
+        for (local_index, original_position) in bucket {
+            local_indices.push(local_index);
+            if let Some(final_take) = &mut final_take {
+                final_take[original_position] = grouped_position;
+            }
+            grouped_position += 1;
+        }
+
+        let local_indices =
+            PrimitiveArray::new(local_indices.freeze(), Validity::NonNullable).into_array();
+        chunks.push(array.chunk(chunk_idx).take(local_indices)?);
+    }
+
+    // SAFETY: every chunk came from a take on a chunk with the same base dtype,
     // unioned with the index nullability.
     let flat = unsafe { ChunkedArray::new_unchecked(chunks, array.dtype().clone()) }
         .into_array()
@@ -97,15 +108,15 @@ fn take_chunked(
         .execute::<Canonical>(ctx)?
         .into_array();
 
-    // 4. Single take to restore original order and expand duplicates.
-    //    Carry the original index validity so null indices produce null outputs.
-    let take_validity = Validity::from_mask(
-        indices
-            .as_ref()
-            .validity()?
-            .execute_mask(indices.as_ref().len(), ctx)?,
-        indices.dtype().nullability(),
-    );
+    // Non-nullable monotonic indices are already in the same order as the assembled chunks, so no
+    // final reorder is needed.
+    let Some(final_take) = final_take else {
+        return Ok(flat);
+    };
+
+    // Restore original order. Carry the original index validity so null indices produce null
+    // outputs.
+    let take_validity = Validity::from_mask(indices_mask, indices.dtype().nullability());
     flat.take(PrimitiveArray::new(final_take.freeze(), take_validity).into_array())
 }
 
@@ -259,6 +270,33 @@ mod test {
         assert_arrays_eq!(
             result,
             PrimitiveArray::from_iter([8i32, 0, 5, 3, 2, 7, 1, 6, 4]),
+            &mut ctx
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_take_shuffled_duplicates_with_empty_chunks() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let empty = PrimitiveArray::empty::<i32>(Nullability::NonNullable).into_array();
+        let arr = ChunkedArray::try_new(
+            vec![
+                empty.clone(),
+                buffer![0i32, 1].into_array(),
+                empty.clone(),
+                buffer![2i32, 3].into_array(),
+                empty,
+            ],
+            PrimitiveArray::empty::<i32>(Nullability::NonNullable)
+                .dtype()
+                .clone(),
+        )?;
+
+        let result = arr.take(buffer![3u64, 0, 2, 0, 3, 1, 2].into_array())?;
+
+        assert_arrays_eq!(
+            result,
+            PrimitiveArray::from_iter([3i32, 0, 2, 0, 3, 1, 2]),
             &mut ctx
         );
         Ok(())

--- a/vortex-array/src/arrays/chunked/compute/take.rs
+++ b/vortex-array/src/arrays/chunked/compute/take.rs
@@ -4,6 +4,7 @@
 use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_mask::Mask;
 
 use crate::ArrayRef;
 use crate::Canonical;
@@ -22,6 +23,91 @@ use crate::validity::Validity;
 
 // TODO(joe): this is pretty unoptimized but better than before. We want canonical using a builder
 // we also want to return a chunked array ideally.
+fn take_chunked_via_sort(
+    array: ArrayView<'_, Chunked>,
+    indices: &PrimitiveArray,
+    indices_mask: Mask,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let indices_values = indices.as_slice::<u64>();
+    let n = indices_values.len();
+    let mut pairs: Vec<(u64, usize)> = indices_values
+        .iter()
+        .enumerate()
+        .filter(|&(position, _)| indices_mask.value(position))
+        .map(|(position, &index)| (index, position))
+        .collect();
+    pairs.sort_unstable();
+
+    if let Some(&(index, _)) = pairs.last() {
+        let index = usize::try_from(index)?;
+        if index >= array.len() {
+            vortex_bail!(OutOfBounds: index, 0, array.len());
+        }
+    }
+
+    let chunk_offsets = array.chunk_offset_values();
+    let nchunks = array.nchunks();
+    let mut chunks = Vec::with_capacity(nchunks);
+    let mut final_take = BufferMut::<u64>::with_capacity(n);
+    final_take.push_n(0u64, n);
+    let mut cursor = 0usize;
+    let mut dedup_idx = 0u64;
+
+    for chunk_idx in 0..nchunks {
+        let chunk_start = chunk_offsets[chunk_idx];
+        let chunk_end = chunk_offsets[chunk_idx + 1];
+        let chunk_len = chunk_end - chunk_start;
+        let chunk_end_u64 = u64::try_from(chunk_end)?;
+        let range_end = cursor + pairs[cursor..].partition_point(|&(v, _)| v < chunk_end_u64);
+        let chunk_pairs = &pairs[cursor..range_end];
+
+        if !chunk_pairs.is_empty() {
+            let mut local_indices = Vec::new();
+            for (i, &(value, original_position)) in chunk_pairs.iter().enumerate() {
+                if cursor + i > 0 && value != pairs[cursor + i - 1].0 {
+                    dedup_idx += 1;
+                }
+                let local_index = usize::try_from(value)? - chunk_start;
+                if local_indices.last() != Some(&local_index) {
+                    local_indices.push(local_index);
+                }
+                final_take[original_position] = dedup_idx;
+            }
+
+            chunks.push(
+                array
+                    .chunk(chunk_idx)
+                    .filter(Mask::from_indices(chunk_len, local_indices))?,
+            );
+        }
+
+        cursor = range_end;
+    }
+
+    // SAFETY: every chunk came from a filter on a chunk with the same base dtype.
+    let flat = unsafe { ChunkedArray::new_unchecked(chunks, array.dtype().clone()) }
+        .into_array()
+        .execute::<Canonical>(ctx)?
+        .into_array();
+    let take_validity = Validity::from_mask(indices_mask, indices.dtype().nullability());
+    flat.take(PrimitiveArray::new(final_take.freeze(), take_validity).into_array())
+}
+
+fn valid_indices_are_monotonic(indices: &[u64], indices_mask: &Mask) -> bool {
+    let mut previous = None;
+    for (position, &index) in indices.iter().enumerate() {
+        if !indices_mask.value(position) {
+            continue;
+        }
+        if previous.is_some_and(|previous| index < previous) {
+            return false;
+        }
+        previous = Some(index);
+    }
+    true
+}
+
 fn take_chunked(
     array: ArrayView<'_, Chunked>,
     indices: &ArrayRef,
@@ -37,11 +123,22 @@ fn take_chunked(
         .execute_mask(indices.as_ref().len(), ctx)?;
     let indices_values = indices.as_slice::<u64>();
     let n = indices_values.len();
+    let chunk_offsets = array.chunk_offset_values();
+    let nchunks = array.nchunks();
+
+    // For a small unsorted fixed-size-list take over a small number of chunks, sorting has lower
+    // fixed overhead and lets the nested elements filter in source order. Larger, monotonic, and
+    // non-nested takes use bucketing.
+    if matches!(array.dtype(), DType::FixedSizeList(..))
+        && n <= 64
+        && nchunks <= 16
+        && !valid_indices_are_monotonic(indices_values, &indices_mask)
+    {
+        return take_chunked_via_sort(array, &indices, indices_mask, ctx);
+    }
 
     // Route each valid index into its source chunk. Within each bucket, preserve the request order
     // so the taken chunks can be assembled and then restored to the original cross-chunk order.
-    let chunk_offsets = array.chunk_offset_values();
-    let nchunks = array.nchunks();
     let mut buckets = vec![Vec::<(u64, usize)>::new(); nchunks];
     let mut monotonic = true;
     let mut last_index = None;
@@ -141,6 +238,7 @@ mod test {
     use crate::array_session;
     use crate::arrays::BoolArray;
     use crate::arrays::ChunkedArray;
+    use crate::arrays::FixedSizeListArray;
     use crate::arrays::PrimitiveArray;
     use crate::arrays::StructArray;
     use crate::arrays::chunked::ChunkedArrayExt;
@@ -299,6 +397,38 @@ mod test {
             PrimitiveArray::from_iter([3i32, 0, 2, 0, 3, 1, 2]),
             &mut ctx
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_take_small_shuffled_fixed_size_lists() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let first = FixedSizeListArray::new(
+            buffer![0i32, 1, 2, 3].into_array(),
+            2,
+            Validity::NonNullable,
+            2,
+        )
+        .into_array();
+        let second = FixedSizeListArray::new(
+            buffer![4i32, 5, 6, 7].into_array(),
+            2,
+            Validity::NonNullable,
+            2,
+        )
+        .into_array();
+        let dtype = first.dtype().clone();
+        let array = ChunkedArray::try_new(vec![first, second], dtype)?;
+
+        let result = array.take(buffer![3u64, 0, 2, 1, 3].into_array())?;
+        let expected = FixedSizeListArray::new(
+            buffer![6i32, 7, 0, 1, 4, 5, 2, 3, 6, 7].into_array(),
+            2,
+            Validity::NonNullable,
+            5,
+        );
+
+        assert_arrays_eq!(result, expected, &mut ctx);
         Ok(())
     }
 

--- a/vortex-array/src/test_harness/trace/tests.rs
+++ b/vortex-array/src/test_harness/trace/tests.rs
@@ -581,32 +581,22 @@ fn trace_take_on_chunked() -> VortexResult<()> {
     insta::assert_snapshot!(traced.trace.to_string(), @"
     execute_until target=AnyCanonical root=vortex.dict(i32, len=4)
       iter 0 current=vortex.dict(i32, len=4) builder_active=false
-    execute_until target=AnyCanonical root=vortex.chunked(i32, len=3)
-      iter 0 current=vortex.chunked(i32, len=3) builder_active=false
-        builder start array=vortex.chunked(i32, len=3)
-        AppendChild slot=1 parent=vortex.chunked(i32, len=3) child=vortex.filter(i32, len=1)
-        builder append child=vortex.filter(i32, len=1)
-    execute_until target=AnyCanonical root=vortex.filter(i32, len=1)
-      iter 0 current=vortex.filter(i32, len=1) builder_active=false
-        Done array=vortex.primitive(i32, len=1)
-      iter 1 current=vortex.primitive(i32, len=1) builder_active=false
-      return output=vortex.primitive(i32, len=1)
-      iter 1 current=vortex.chunked(i32, len=3) builder_active=true
-        AppendChild slot=2 parent=vortex.chunked(i32, len=3) child=vortex.filter(i32, len=2)
-        builder append child=vortex.filter(i32, len=2)
-    execute_until target=AnyCanonical root=vortex.filter(i32, len=2)
-      iter 0 current=vortex.filter(i32, len=2) builder_active=false
-        Done array=vortex.primitive(i32, len=2)
-      iter 1 current=vortex.primitive(i32, len=2) builder_active=false
-      return output=vortex.primitive(i32, len=2)
-      iter 2 current=vortex.chunked(i32, len=3) builder_active=true
+    execute_until target=AnyCanonical root=vortex.chunked(i32, len=4)
+      iter 0 current=vortex.chunked(i32, len=4) builder_active=false
+        builder start array=vortex.chunked(i32, len=4)
+        AppendChild slot=1 parent=vortex.chunked(i32, len=4) child=vortex.dict(i32, len=1)
+        builder append child=vortex.dict(i32, len=1)
+      iter 1 current=vortex.chunked(i32, len=4) builder_active=true
+        AppendChild slot=2 parent=vortex.chunked(i32, len=4) child=vortex.dict(i32, len=3)
+        builder append child=vortex.dict(i32, len=3)
+      iter 2 current=vortex.chunked(i32, len=4) builder_active=true
         Done array=vortex.primitive(i32, len=0)
-        builder finish output=vortex.primitive(i32, len=3)
-      iter 3 current=vortex.primitive(i32, len=3) builder_active=false
-      return output=vortex.primitive(i32, len=3)
+        builder finish output=vortex.primitive(i32, len=4)
+      iter 3 current=vortex.primitive(i32, len=4) builder_active=false
+      return output=vortex.primitive(i32, len=4)
         child_execute_parent session[0]:execute_parent_fn slot=1 parent=vortex.dict(i32, len=4) child=vortex.chunked(i32, len=5) -> vortex.dict(i32, len=4)
       iter 1 current=vortex.dict(i32, len=4) builder_active=false
-        child_execute_parent session[0]:execute_parent_fn slot=1 parent=vortex.dict(i32, len=4) child=vortex.primitive(i32, len=3) -> vortex.primitive(i32, len=4)
+        child_execute_parent session[0]:execute_parent_fn slot=1 parent=vortex.dict(i32, len=4) child=vortex.primitive(i32, len=4) -> vortex.primitive(i32, len=4)
       iter 2 current=vortex.primitive(i32, len=4) builder_active=false
       return output=vortex.primitive(i32, len=4)
     ");


### PR DESCRIPTION
## Summary

- replace global comparison sorting in `ChunkedArray::take` with per-chunk index buckets
- route monotonic indices with a linear chunk cursor and arbitrary indices with binary search over chunk offsets
- preserve original ordering, nulls, duplicates, nested dtypes, and bounds behavior
- skip the final reorder take when non-nullable indices are already monotonic
- add a deterministic 32-case Divan benchmark covering ordering, chunk counts, duplicate density, nullability, nested values, and routing patterns

## Why

The previous implementation sorted every valid `(global_index, original_position)` pair, then filtered each touched chunk before taking again to restore order. That made chunk routing approximately `O(M log M + C)`. Bucketing removes the global comparison sort: arbitrary routing is approximately `O(M log C + C)`, while monotonic routing is `O(M + C)`.

## Benchmarks

Command, run sequentially against the original implementation and this branch:

```bash
CARGO_INCREMENTAL=0 cargo bench -p vortex-array --bench take_chunked -- --sample-count 100
```

Source length was 1,048,576 rows. Nested cases used `RecursiveCanonical` so child values were fully materialized. Values below are medians from 100 Divan samples. All 32 candidate medians improved.

### Core ordering

| Pattern | Chunks | Indices | Before | After | Speedup |
|---|---:|---:|---:|---:|---:|
| Shuffled | 16 | 10,000 | 205.1 µs | 66.49 µs | 3.08× |
| Shuffled | 16 | 100,000 | 2.460 ms | 576.5 µs | 4.27× |
| Shuffled | 1,024 | 10,000 | 838.5 µs | 608.4 µs | 1.38× |
| Shuffled | 1,024 | 100,000 | 3.240 ms | 1.631 ms | 1.99× |
| Sorted | 16 | 10,000 | 92.74 µs | 44.02 µs | 2.11× |
| Sorted | 16 | 100,000 | 850.1 µs | 315.1 µs | 2.70× |
| Sorted | 1,024 | 10,000 | 698.0 µs | 501.9 µs | 1.39× |
| Sorted | 1,024 | 100,000 | 1.622 ms | 907.7 µs | 1.79× |

### Small request count / high chunk count

| Chunks | Indices | Before | After | Speedup |
|---:|---:|---:|---:|---:|
| 1,024 | 1 | 2.916 µs | 2.124 µs | 1.37× |
| 1,024 | 16 | 18.74 µs | 8.666 µs | 2.16× |
| 1,024 | 256 | 139.5 µs | 97.16 µs | 1.44× |
| 1,024 | 1,000 | 349.9 µs | 269.4 µs | 1.30× |
| 16,384 | 1 | 16.43 µs | 15.66 µs | 1.05× |
| 16,384 | 16 | 131.8 µs | 24.08 µs | 5.47× |
| 16,384 | 256 | 445.4 µs | 122.8 µs | 3.63× |
| 16,384 | 1,000 | 929.0 µs | 419.4 µs | 2.22× |

### Duplicate density

| Pattern | Chunks | Indices | Before | After | Speedup |
|---|---:|---:|---:|---:|---:|
| One repeated index | 16 | 100,000 | 364.9 µs | 273.7 µs | 1.33× |
| 90% duplicates | 16 | 100,000 | 1.859 ms | 529.2 µs | 3.51× |
| 99% duplicates | 16 | 100,000 | 1.825 ms | 520.3 µs | 3.51× |

### Value shape

| Pattern | Value | Chunks | Indices | Before | After | Speedup |
|---|---|---:|---:|---:|---:|---:|
| 99% duplicates | Primitive | 16 | 10,000 | 125.0 µs | 62.81 µs | 1.99× |
| 99% duplicates | Struct, 8 fields | 16 | 10,000 | 1.134 ms | 701.2 µs | 1.62× |
| 99% duplicates | Fixed-size list, width 8 | 16 | 10,000 | 1.468 ms | 648.5 µs | 2.26× |
| Shuffled | Primitive | 16 | 10,000 | 163.4 µs | 65.91 µs | 2.48× |
| Shuffled | Struct, 8 fields | 16 | 10,000 | 1.733 ms | 779.5 µs | 2.22× |
| Shuffled | Fixed-size list, width 8 | 16 | 10,000 | 2.150 ms | 664.6 µs | 3.24× |

### Nullable sorted indices

| Validity | Chunks | Indices | Before | After | Speedup |
|---|---:|---:|---:|---:|---:|
| Nullable, all valid | 16 | 100,000 | 776.7 µs | 370.8 µs | 2.09× |
| Nullable, all valid | 1,024 | 100,000 | 1.513 ms | 957.1 µs | 1.58× |
| Nullable, 10% null | 16 | 100,000 | 777.8 µs | 395.2 µs | 1.97× |
| Nullable, 10% null | 1,024 | 100,000 | 1.502 ms | 1.016 ms | 1.48× |

### Chunk routing patterns

| Pattern | Chunks | Indices | Before | After | Speedup |
|---|---:|---:|---:|---:|---:|
| Same-chunk random | 1,024 | 100,000 | 1.830 ms | 614.1 µs | 2.98× |
| Alternating first/last chunk | 1,024 | 100,000 | 2.027 ms | 757.7 µs | 2.68× |
| Grouped by chunk | 1,024 | 100,000 | 2.814 ms | 1.490 ms | 1.89× |

## Validation

- `CARGO_INCREMENTAL=0 cargo test -p vortex-array --lib arrays::chunked::compute::take::test` — 10 passed
- `CARGO_INCREMENTAL=0 cargo clippy --all-targets --all-features`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`