### PR TITLE
duckdb: convert aggregate results to duckdb requested output type

### DIFF
--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -46,7 +46,7 @@ const SOURCE_FILES: [&str; 11] = [
 
 // Duckdb C API function we use.
 // This lowers codegen'd src/cpp.rs by four times.
-const DUCKDB_C_API_FUNCTIONS: [&str; 133] = [
+const DUCKDB_C_API_FUNCTIONS: [&str; 134] = [
     "duckdb_array_type_array_size",
     "duckdb_array_type_child_type",
     "duckdb_array_vector_get_child",
@@ -68,6 +68,7 @@ const DUCKDB_C_API_FUNCTIONS: [&str; 133] = [
     "duckdb_create_decimal_type",
     "duckdb_create_double",
     "duckdb_create_float",
+    "duckdb_create_hugeint",
     "duckdb_create_int16",
     "duckdb_create_int32",
     "duckdb_create_int64",

--- a/vortex-duckdb/src/duckdb/value.rs
+++ b/vortex-duckdb/src/duckdb/value.rs
@@ -192,6 +192,17 @@ impl Value {
         unsafe { Self::own(cpp::duckdb_vx_value_create_null(logical_type.as_ptr())) }
     }
 
+    pub fn new_hugeint(value: i128) -> Self {
+        let lower: u64 = value.as_();
+        let upper: i64 = (value >> 64).as_();
+        unsafe {
+            Self::own(cpp::duckdb_create_hugeint(cpp::duckdb_hugeint {
+                lower,
+                upper,
+            }))
+        }
+    }
+
     pub fn new_decimal(precision: u8, scale: i8, value: i128) -> Self {
         unsafe {
             Self::own(cpp::duckdb_create_decimal(cpp::duckdb_decimal {

--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -36,6 +36,7 @@ use vortex::array::optimizer::ArrayOptimizer;
 use vortex::dtype::PType;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
+use vortex::error::vortex_bail;
 use vortex::expr::Expression;
 use vortex::expr::stats::Precision;
 use vortex::file::v2::FileStatsLayoutReader;
@@ -45,6 +46,7 @@ use vortex::io::runtime::current::ThreadSafeIterator;
 use vortex::layout::scan::multi::MultiLayoutChild;
 use vortex::layout::scan::multi::MultiLayoutDataSource;
 use vortex::metrics::tracing::get_global_labels;
+use vortex::scalar::Scalar;
 use vortex::scalar_fn::fns::binary::Binary;
 use vortex::scalar_fn::fns::operators::Operator;
 use vortex::scalar_fn::fns::pack::Pack;
@@ -61,6 +63,7 @@ use crate::convert::PushedAggregate;
 use crate::convert::try_from_bound_expression;
 use crate::convert::try_from_projection_aggregate;
 use crate::convert::try_from_projection_expression;
+use crate::cpp::DUCKDB_TYPE;
 use crate::duckdb::AggregateExpression;
 use crate::duckdb::AggregatePushdownInputRef;
 use crate::duckdb::BindInputRef;
@@ -68,6 +71,7 @@ use crate::duckdb::BindResultRef;
 use crate::duckdb::DataChunkRef;
 use crate::duckdb::DuckdbStringMapRef;
 use crate::duckdb::ExpressionRef;
+use crate::duckdb::LogicalTypeRef;
 use crate::duckdb::TableInitInput;
 use crate::duckdb::Value;
 use crate::exporter::ArrayExporter;
@@ -447,6 +451,30 @@ fn convert_result(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Struc
     })
 }
 
+fn aggregate_output_value(scalar: Scalar, expected: &LogicalTypeRef) -> VortexResult<Value> {
+    let primitive_i128 = |scalar: &Scalar| -> VortexResult<Option<i128>> {
+        let primitive = scalar.as_primitive();
+        Ok(match primitive.ptype() {
+            PType::I64 => primitive.typed_value::<i64>().map(i128::from),
+            PType::U64 => primitive.typed_value::<u64>().map(i128::from),
+            other => vortex_bail!("expected {expected:?} output type, got {other}"),
+        })
+    };
+    match expected.as_type_id() {
+        DUCKDB_TYPE::DUCKDB_TYPE_HUGEINT => Ok(match primitive_i128(&scalar)? {
+            Some(value) => Value::new_hugeint(value),
+            None => Value::null(expected),
+        }),
+        DUCKDB_TYPE::DUCKDB_TYPE_BIGINT if scalar.dtype().is_unsigned_int() => {
+            Ok(match primitive_i128(&scalar)? {
+                Some(value) => Value::from(i64::try_from(value)?),
+                None => Value::null(expected),
+            })
+        }
+        _ => Value::try_from(scalar),
+    }
+}
+
 fn scan_aggregate(
     local_state: &mut TableFunctionLocal,
     global_state: &TableFunctionGlobal,
@@ -490,7 +518,8 @@ fn scan_aggregate(
                 let value = match aggregate {
                     ColumnAggregate::Real { .. } => {
                         let accum = accum_iter.next().vortex_expect("partial for real agg");
-                        Value::try_from(accum.finish()?)?
+                        let expected = chunk.get_vector_mut(idx).logical_type();
+                        aggregate_output_value(accum.finish()?, &expected)?
                     }
                     ColumnAggregate::CountStar => Value::from(row_count),
                 };

--- a/vortex-sqllogictest/slt/duckdb/agg_corner_filter.slt
+++ b/vortex-sqllogictest/slt/duckdb/agg_corner_filter.slt
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# Aggregate scans with pushed filters accumulate post-filter rows
+
+include ../setup.slt.no
+
+statement ok
+CREATE TABLE tf(i INTEGER, j INTEGER);
+
+statement ok
+INSERT INTO tf VALUES (1, 10), (2, 20), (3, 30), (NULL, 40);
+
+statement ok
+COPY tf TO '${WORK_DIR}/aggregate-with-filter.vortex';
+
+query IIIIR
+SELECT count(*), count(i), sum(i), max(j), avg(j) FROM tf WHERE i > 1;
+----
+2 2 5 30 25
+
+query IIIIR
+SELECT count(*), count(i), sum(i), max(j), avg(j) FROM '${WORK_DIR}/aggregate-with-filter.vortex' WHERE i > 1;
+----
+2 2 5 30 25


### PR DESCRIPTION
Duckdb widens output aggregation results to avoid overflow. This means
output column may be i128 even if input scalars are not. Our reference_value
doesn't cast duckdb Value to desired type but reinterprets bits which lead
to undefined behaviour.
