### PR TITLE
duckdb: Restrict pushed aggregations

### DIFF
--- a/vortex-duckdb/src/projection.rs
+++ b/vortex-duckdb/src/projection.rs
@@ -192,21 +192,35 @@ impl Projection {
 
     // Create a projection for aggregate scan
     pub fn new_aggregate(aggregates: &[ColumnAggregate], fields: &[DuckdbField]) -> Self {
-        let mut names = Vec::with_capacity(aggregates.len());
+        let mut exprs = Vec::with_capacity(aggregates.len());
         let mut seen: HashSet<u64> = HashSet::with_capacity(aggregates.len());
+        let mut has_columns_with_expr = false;
         for aggregate in aggregates {
             let ColumnAggregate::Real { projection_id, .. } = aggregate else {
                 continue;
             };
-            if seen.contains(projection_id) {
+            if !seen.insert(*projection_id) {
                 continue;
             }
-            seen.insert(*projection_id);
             let projection_id: usize = projection_id.as_();
-            names.push(fields[projection_id].name.as_str());
+            let field = &fields[projection_id];
+            let expr = match &field.projection_expr {
+                None => get_item(field.name.as_str(), root()),
+                Some(func) => {
+                    has_columns_with_expr = true;
+                    func.clone()
+                }
+            };
+            exprs.push((field.name.as_str(), expr));
         }
+        let projection = if has_columns_with_expr {
+            pack(exprs, false.into())
+        } else {
+            let names = exprs.into_iter().map(|(name, _)| name).collect::<Vec<_>>();
+            select(names, root())
+        };
         Projection {
-            projection: select(names, root()),
+            projection,
             file_index_column_pos: None,
             file_row_number_column_pos: None,
         }

--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -33,6 +33,7 @@ use vortex::array::arrays::StructArray;
 use vortex::array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex::array::arrays::struct_::StructArrayExt;
 use vortex::array::optimizer::ArrayOptimizer;
+use vortex::dtype::DType;
 use vortex::dtype::PType;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
@@ -332,7 +333,11 @@ pub fn init_global(init_input: &TableInitInput) -> VortexResult<TableFunctionGlo
     let iterator = RUNTIME.block_on_stream_thread_safe(|_handle| scan_driver_stream(stream, rx));
 
     let aggregates = bind_data.aggregates.clone();
-    let partials = build_partials(&aggregates, &bind_data.column_fields)?;
+    let partials = build_partials(
+        &aggregates,
+        &bind_data.column_fields,
+        bind_data.data_source.dtype(),
+    )?;
 
     Ok(TableFunctionGlobal {
         iterator,
@@ -381,9 +386,18 @@ impl Stream for ScanDriverStream {
     }
 }
 
+/// Dtype over which we accumulate
+fn aggregate_input_dtype(field: &DuckdbField, scope: &DType) -> VortexResult<DType> {
+    match &field.projection_expr {
+        None => Ok(field.dtype.clone()),
+        Some(expr) => expr.return_dtype(scope),
+    }
+}
+
 fn build_partials(
     aggregates: &[ColumnAggregate],
     fields: &[DuckdbField],
+    scope: &DType,
 ) -> VortexResult<Vec<Box<dyn DynAccumulator>>> {
     aggregates
         .iter()
@@ -393,7 +407,10 @@ fn build_partials(
                 aggregate,
             } => {
                 let projection_id: usize = projection_id.as_();
-                Some(aggregate.build(fields[projection_id].dtype.clone()))
+                Some(
+                    aggregate_input_dtype(&fields[projection_id], scope)
+                        .and_then(|dtype| aggregate.build(dtype)),
+                )
             }
             ColumnAggregate::CountStar => None,
         })
@@ -419,10 +436,14 @@ pub fn init_local(
         CURRENT_LABELSET.set(key, value);
     }
 
-    let partials = build_partials(&global.aggregates, &bind_data.column_fields)
-        // if aggregate initialization produced an error, it would error in
-        // init_global, see "partials" initialization there
-        .vortex_expect("local state aggregate initialization failed");
+    let partials = build_partials(
+        &global.aggregates,
+        &bind_data.column_fields,
+        bind_data.data_source.dtype(),
+    )
+    // if aggregate initialization produced an error, it would error in
+    // init_global, see "partials" initialization there
+    .vortex_expect("local state aggregate initialization failed");
 
     TableFunctionLocal {
         iterator: global.iterator.clone(),
@@ -715,7 +736,10 @@ pub fn pushdown_projection_aggregates(
         };
 
         let projection_id_usize: usize = projection_id.as_();
-        let dtype = &bind_data.column_fields[projection_id_usize].dtype;
+        let field = &bind_data.column_fields[projection_id_usize];
+        let Ok(dtype) = aggregate_input_dtype(field, bind_data.data_source.dtype()) else {
+            return Ok(false);
+        };
 
         // duckdb's min() returns nan only when every value is nan.
         // vortex's min() either ignores or counts nans.
@@ -724,12 +748,32 @@ pub fn pushdown_projection_aggregates(
             return Ok(false);
         }
 
-        // duckdb's sum() on i64/u64 extends to i128/u128 but vortex
-        // accumulators work on i64/u64 max.
-        if aggregate == PushedAggregate::Sum
+        let mean_or_sum = matches!(aggregate, PushedAggregate::Sum | PushedAggregate::Mean);
+
+        // duckdb's sum() and avg() on i64/u64 accumulate in i128/u128, vortex
+        // sum()/avg() work on i64/u64 max and overflow to null
+        if mean_or_sum
             && dtype.is_primitive()
             && matches!(dtype.as_ptype(), PType::I64 | PType::U64)
         {
+            return Ok(false);
+        }
+
+        // duckdb decimal sum() overflows to error, vortex sum overlows to NULL
+        // duckdb's avg() on decimals returns a double, vortex's mean stays
+        // decimal.
+        if mean_or_sum && matches!(dtype, DType::Decimal(..)) {
+            return Ok(false);
+        }
+
+        // vortex doesn't have list comparison
+        if matches!(aggregate, PushedAggregate::Min | PushedAggregate::Max)
+            && matches!(dtype, DType::List(..) | DType::FixedSizeList(..))
+        {
+            return Ok(false);
+        }
+
+        if aggregate.build(dtype).is_err() {
             return Ok(false);
         }
 

--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -709,6 +709,53 @@ pub fn pushdown_projection_expression(
     }
 }
 
+fn can_push_projection_aggregate(
+    aggregate: &PushedAggregate,
+    bind_data: &TableFunctionBind,
+    projection_id: u64,
+) -> bool {
+    let projection_id_usize: usize = projection_id.as_();
+    let field = &bind_data.column_fields[projection_id_usize];
+    let Ok(dtype) = aggregate_input_dtype(field, bind_data.data_source.dtype()) else {
+        return false;
+    };
+
+    // duckdb's min() returns nan only when every value is nan.
+    // vortex's min() either ignores or counts nans.
+    // See slt/duckdb/nan_aggregates.slt.
+    if *aggregate == PushedAggregate::Min && dtype.is_float() {
+        return false;
+    }
+
+    let mean_or_sum = matches!(aggregate, PushedAggregate::Sum | PushedAggregate::Mean);
+
+    // duckdb's sum() and avg() on i64/u64 accumulate in i128/u128, vortex
+    // sum()/avg() work on i64/u64 max and overflow to null
+    if mean_or_sum && dtype.is_primitive() && matches!(dtype.as_ptype(), PType::I64 | PType::U64) {
+        return false;
+    }
+
+    // duckdb decimal sum() overflows to error, vortex sum overflows to NULL
+    // duckdb's avg() on decimals returns a double, vortex's mean stays
+    // decimal.
+    if mean_or_sum && matches!(dtype, DType::Decimal(..)) {
+        return false;
+    }
+
+    // vortex doesn't have list comparison
+    if matches!(aggregate, PushedAggregate::Min | PushedAggregate::Max)
+        && matches!(dtype, DType::List(..) | DType::FixedSizeList(..))
+    {
+        return false;
+    }
+
+    if aggregate.build(dtype).is_err() {
+        return false;
+    }
+
+    true
+}
+
 /// Turn a scan into an aggregate scan. Input is N aggregations, possibly over
 /// same columns. If we return true, optimized pass expands output to N columns,
 /// e.g. min(x), max(x) turns into min(x0), max(x1), 2 columns in output.
@@ -722,67 +769,11 @@ pub fn pushdown_projection_aggregates(
 
     debug!(%len, "pushing down projection aggregates");
     for i in 0..len {
-        let AggregateExpression {
-            expr,
-            projection_id,
-        } = input.get(i);
-        if projection_id == COUNT_STAR_PROJ_IDX {
-            aggregates.push(ColumnAggregate::CountStar);
-            continue;
-        }
-        let Some(aggregate) = try_from_projection_aggregate(expr)? else {
-            debug!(%expr, %i, "failed to push down projection aggregate");
+        let Some(aggregate) = try_push_projection_aggregate(bind_data, input.get(i), i)? else {
             return Ok(false);
         };
-
-        let projection_id_usize: usize = projection_id.as_();
-        let field = &bind_data.column_fields[projection_id_usize];
-        let Ok(dtype) = aggregate_input_dtype(field, bind_data.data_source.dtype()) else {
-            return Ok(false);
-        };
-
-        // duckdb's min() returns nan only when every value is nan.
-        // vortex's min() either ignores or counts nans.
-        // See slt/duckdb/nan_aggregates.slt.
-        if aggregate == PushedAggregate::Min && dtype.is_float() {
-            return Ok(false);
-        }
-
-        let mean_or_sum = matches!(aggregate, PushedAggregate::Sum | PushedAggregate::Mean);
-
-        // duckdb's sum() and avg() on i64/u64 accumulate in i128/u128, vortex
-        // sum()/avg() work on i64/u64 max and overflow to null
-        if mean_or_sum
-            && dtype.is_primitive()
-            && matches!(dtype.as_ptype(), PType::I64 | PType::U64)
-        {
-            return Ok(false);
-        }
-
-        // duckdb decimal sum() overflows to error, vortex sum overlows to NULL
-        // duckdb's avg() on decimals returns a double, vortex's mean stays
-        // decimal.
-        if mean_or_sum && matches!(dtype, DType::Decimal(..)) {
-            return Ok(false);
-        }
-
-        // vortex doesn't have list comparison
-        if matches!(aggregate, PushedAggregate::Min | PushedAggregate::Max)
-            && matches!(dtype, DType::List(..) | DType::FixedSizeList(..))
-        {
-            return Ok(false);
-        }
-
-        if aggregate.build(dtype).is_err() {
-            return Ok(false);
-        }
-
-        debug!(%expr, %projection_id, %i, "pushed down projection aggregate");
-        aggregates.push(ColumnAggregate::Real {
-            projection_id,
-            aggregate,
-        });
-        has_non_count_star = true;
+        has_non_count_star |= matches!(aggregate, ColumnAggregate::Real { .. });
+        aggregates.push(aggregate);
     }
     // DuckDB computes just count(*) faster than us
     if !has_non_count_star {
@@ -790,6 +781,33 @@ pub fn pushdown_projection_aggregates(
     }
     bind_data.aggregates = aggregates;
     Ok(true)
+}
+
+fn try_push_projection_aggregate(
+    bind_data: &TableFunctionBind,
+    aggregate: AggregateExpression<'_>,
+    i: usize,
+) -> VortexResult<Option<ColumnAggregate>> {
+    let AggregateExpression {
+        expr,
+        projection_id,
+    } = aggregate;
+    if projection_id == COUNT_STAR_PROJ_IDX {
+        return Ok(Some(ColumnAggregate::CountStar));
+    }
+    let Some(aggregate) = try_from_projection_aggregate(expr)? else {
+        debug!(%expr, %i, "failed to push down projection aggregate");
+        return Ok(None);
+    };
+    if !can_push_projection_aggregate(&aggregate, bind_data, projection_id) {
+        debug!(%expr, %i, "failed to push down projection aggregate");
+        return Ok(None);
+    }
+    debug!(%expr, %projection_id, %i, "pushed down projection aggregate");
+    Ok(Some(ColumnAggregate::Real {
+        projection_id,
+        aggregate,
+    }))
 }
 
 /// Get column-wise statistics. Available only if we're reading a single file.

--- a/vortex-sqllogictest/slt/duckdb/agg_corner_avg_overflow.slt
+++ b/vortex-sqllogictest/slt/duckdb/agg_corner_avg_overflow.slt
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# avg(i64) whose sum overflows i64: duckdb computes it, vortex Mean
+# accumulates the numerator in i64 and returns NULL on overflow
+
+include ../setup.slt.no
+
+statement ok
+CREATE TABLE t1(i BIGINT);
+
+statement ok
+INSERT INTO t1 VALUES (9223372036854775807), (9223372036854775807);
+
+statement ok
+COPY t1 TO '${WORK_DIR}/c1.vortex';
+
+query R
+SELECT avg(i) FROM t1;
+----
+9223372036854776000
+
+query R
+SELECT avg(i) FROM '${WORK_DIR}/c1.vortex';
+----
+9223372036854776000

--- a/vortex-sqllogictest/slt/duckdb/agg_corner_min_list.slt
+++ b/vortex-sqllogictest/slt/duckdb/agg_corner_min_list.slt
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# Vortex minmax does not implement list comparison
+
+include ../setup.slt.no
+
+statement ok
+CREATE TABLE t6(l INTEGER[]);
+
+statement ok
+INSERT INTO t6 VALUES ([1,2]), ([3]);
+
+statement ok
+COPY t6 TO '${WORK_DIR}/c6.vortex';
+
+query ?
+SELECT min(l) FROM t6;
+----
+[1, 2]
+
+query ?
+SELECT min(l) FROM '${WORK_DIR}/c6.vortex';
+----
+[1, 2]

--- a/vortex-sqllogictest/slt/duckdb/agg_corner_min_struct.slt
+++ b/vortex-sqllogictest/slt/duckdb/agg_corner_min_struct.slt
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# Vortex Accumulator doesn't support min/max for STRUCT
+
+include ../setup.slt.no
+
+statement ok
+CREATE TABLE t7(s STRUCT(a INTEGER));
+
+statement ok
+INSERT INTO t7 VALUES ({'a': 1}), ({'a': 2});
+
+statement ok
+COPY t7 TO '${WORK_DIR}/c7.vortex';
+
+query ?
+SELECT min(s) FROM t7;
+----
+{'a': 1}
+
+query ?
+SELECT min(s) FROM '${WORK_DIR}/c7.vortex';
+----
+{'a': 1}

--- a/vortex-sqllogictest/slt/duckdb/agg_corner_plan_shapes.slt
+++ b/vortex-sqllogictest/slt/duckdb/agg_corner_plan_shapes.slt
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# aggregate pushdown with reordered columns, count(*) between real
+# aggregates, and two aggregate scans in one query
+
+include ../setup.slt.no
+
+statement ok
+CREATE TABLE tp(a INTEGER, b INTEGER, c INTEGER);
+
+statement ok
+INSERT INTO tp VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300);
+
+statement ok
+COPY tp TO '${WORK_DIR}/cp.vortex';
+
+query II
+SELECT max(c), min(a) FROM tp;
+----
+300 1
+
+query II
+SELECT max(c), min(a) FROM '${WORK_DIR}/cp.vortex';
+----
+300 1
+
+query III
+SELECT min(c), count(*), max(a) FROM tp;
+----
+100 3 3
+
+query III
+SELECT min(c), count(*), max(a) FROM '${WORK_DIR}/cp.vortex';
+----
+100 3 3
+
+query I
+SELECT sum(a) FROM '${WORK_DIR}/cp.vortex' UNION ALL SELECT min(c) FROM '${WORK_DIR}/cp.vortex' ORDER BY 1;
+----
+6
+100
+
+# DISTINCT and FILTER clauses must not be pushed down
+
+query II
+SELECT sum(DISTINCT a), count(a) FILTER (WHERE a > 1) FROM tp;
+----
+6 2
+
+query II
+SELECT sum(DISTINCT a), count(a) FILTER (WHERE a > 1) FROM '${WORK_DIR}/cp.vortex';
+----
+6 2

--- a/vortex-sqllogictest/slt/duckdb/agg_corner_scalar_fn.slt
+++ b/vortex-sqllogictest/slt/duckdb/agg_corner_scalar_fn.slt
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# aggregate over a scalar fn pushed into the scan
+
+include ../setup.slt.no
+
+statement ok
+CREATE TABLE t5(s VARCHAR);
+
+statement ok
+INSERT INTO t5 VALUES ('aa'), ('b');
+
+statement ok
+COPY t5 TO '${WORK_DIR}/c5.vortex';
+
+query I
+SELECT sum(strlen(s)) FROM t5;
+----
+3
+
+# sum over strlen is not pushed as an aggregate, but strlen
+# is pushed
+query TT
+EXPLAIN SELECT sum(strlen(s)) FROM '${WORK_DIR}/c5.vortex';
+----
+<REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query TT
+EXPLAIN (FORMAT json) SELECT sum(strlen(s)) FROM '${WORK_DIR}/c5.vortex';
+----
+<REGEX>:SELECT projections
+
+query I
+SELECT sum(strlen(s)) FROM '${WORK_DIR}/c5.vortex';
+----
+3
+
+query I
+SELECT min(strlen(s)) FROM t5;
+----
+1
+
+# min over strlen is pushed down
+query TT
+EXPLAIN SELECT min(strlen(s)) FROM '${WORK_DIR}/c5.vortex';
+----
+<!REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query I
+SELECT min(strlen(s)) FROM '${WORK_DIR}/c5.vortex';
+----
+1
+
+query R
+SELECT avg(strlen(s)) FROM t5;
+----
+1.5
+
+query R
+SELECT avg(strlen(s)) FROM '${WORK_DIR}/c5.vortex';
+----
+1.5
+
+query II
+SELECT max(strlen(s)), count(strlen(s)) FROM t5;
+----
+2 2
+
+query TT
+EXPLAIN SELECT max(strlen(s)), count(strlen(s)) FROM '${WORK_DIR}/c5.vortex';
+----
+<!REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query II
+SELECT max(strlen(s)), count(strlen(s)) FROM '${WORK_DIR}/c5.vortex';
+----
+2 2
+
+query IIR
+SELECT sum(strlen(s)::INTEGER), min(strlen(s)::INTEGER), avg(strlen(s)::INTEGER) FROM t5;
+----
+3 1 1.5
+
+query IIR
+SELECT sum(strlen(s)::INTEGER), min(strlen(s)::INTEGER), avg(strlen(s)::INTEGER) FROM '${WORK_DIR}/c5.vortex';
+----
+3 1 1.5
+
+# first/any_value over a pushed fn; single row to stay deterministic
+
+statement ok
+CREATE TABLE t5o(s VARCHAR);
+
+statement ok
+INSERT INTO t5o VALUES ('aa');
+
+statement ok
+COPY t5o TO '${WORK_DIR}/c5o.vortex';
+
+query II
+SELECT first(strlen(s)), any_value(strlen(s)) FROM t5o;
+----
+2 2
+
+query II
+SELECT first(strlen(s)), any_value(strlen(s)) FROM '${WORK_DIR}/c5o.vortex';
+----
+2 2
+
+statement ok
+CREATE TABLE t5n(s VARCHAR);
+
+statement ok
+INSERT INTO t5n VALUES ('7'), ('123');
+
+statement ok
+COPY t5n TO '${WORK_DIR}/c5n.vortex';
+
+query I
+SELECT min(strlen(s)) FROM t5n;
+----
+1
+
+query I
+SELECT min(strlen(s)) FROM '${WORK_DIR}/c5n.vortex';
+----
+1

--- a/vortex-sqllogictest/slt/duckdb/mean_all_null.slt
+++ b/vortex-sqllogictest/slt/duckdb/mean_all_null.slt
@@ -13,7 +13,7 @@ COPY (SELECT * FROM (VALUES (1),(2),(CAST(NULL AS BIGINT))) AS t(x)) TO '${WORK_
 query TT
 EXPLAIN SELECT avg(x) FROM '${WORK_DIR}/i-null.vortex';
 ----
-<!REGEX>:.*UNGROUPED_AGGREGATE.*
+<REGEX>:.*UNGROUPED_AGGREGATE.*
 
 query R
 SELECT avg(x) FROM '${WORK_DIR}/i-null.vortex';


### PR DESCRIPTION
- Forbid aggregation of Decimal sum/mean: different overflow semantics
- Allow pushdown of aggregations over scalars i.e. min(strlen(x)).
  Forbid pushdown of aggregations over non-allowed types i.e.
  sum(strlen(x))
- Forbid min/max of String and List since we don't have an implementation
  for that
