### PR TITLE
duckdb: TIMESTAMPTZ keeps microsecond precision

### DIFF
--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -355,6 +355,16 @@ impl<'a> TryFrom<&'a ValueRef> for Scalar {
                     Some(ScalarValue::from(seconds)),
                 )?,
             )),
+            ExtractedValue::TimestampTz(micros) => Ok(Scalar::extension::<Timestamp>(
+                TimestampOptions {
+                    unit: TimeUnit::Microseconds,
+                    tz: Some("UTC".into()),
+                },
+                Scalar::try_new(
+                    DType::Primitive(I64, Nullable),
+                    Some(ScalarValue::from(micros)),
+                )?,
+            )),
             ExtractedValue::Decimal(precision, scale, value) => Ok(Scalar::decimal(
                 DecimalValue::I128(value),
                 DecimalDType::try_new(precision, scale)?,

--- a/vortex-duckdb/src/duckdb/value.rs
+++ b/vortex-duckdb/src/duckdb/value.rs
@@ -131,7 +131,7 @@ impl ValueRef {
             DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_S => ExtractedValue::TimestampS(unsafe {
                 cpp::duckdb_get_timestamp_s(self.as_ptr()).seconds
             }),
-            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_TZ => ExtractedValue::TimestampS(unsafe {
+            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_TZ => ExtractedValue::TimestampTz(unsafe {
                 cpp::duckdb_get_timestamp_tz(self.as_ptr()).micros
             }),
             DUCKDB_TYPE::DUCKDB_TYPE_DECIMAL => {
@@ -448,6 +448,8 @@ pub enum ExtractedValue {
     Timestamp(i64),
     TimestampMs(i64),
     TimestampS(i64),
+    /// UTC microseconds
+    TimestampTz(i64),
     Decimal(u8, i8, i128),
     List(Vec<Value>),
 }

--- a/vortex-sqllogictest/slt/duckdb/timestamptz_filter.slt
+++ b/vortex-sqllogictest/slt/duckdb/timestamptz_filter.slt
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# TIMESTAMPTZ literals keep microsecond precision
+
+include ../setup.slt.no
+
+statement ok
+SET TimeZone = 'UTC';
+
+statement ok
+CREATE TABLE tz(t TIMESTAMPTZ);
+
+statement ok
+INSERT INTO tz VALUES ('2020-01-01 10:00:00+00'), ('2021-06-15 12:30:00+00');
+
+statement ok
+COPY tz TO '${WORK_DIR}/ctz.vortex';
+
+query I
+SELECT count(*) FROM tz WHERE t = TIMESTAMPTZ '2020-01-01 10:00:00+00';
+----
+1
+
+query I
+SELECT count(*) FROM '${WORK_DIR}/ctz.vortex' WHERE t = TIMESTAMPTZ '2020-01-01 10:00:00+00';
+----
+1
+
+query I
+SELECT count(*) FROM tz WHERE t > TIMESTAMPTZ '2020-06-01 00:00:00+00';
+----
+1
+
+query I
+SELECT count(*) FROM '${WORK_DIR}/ctz.vortex' WHERE t > TIMESTAMPTZ '2020-06-01 00:00:00+00';
+----
+1
+
+query PP
+SELECT min(t), max(t) FROM tz;
+----
+2020-01-01 10:00:00+00 2021-06-15 12:30:00+00
+
+query PP
+SELECT min(t), max(t) FROM '${WORK_DIR}/ctz.vortex';
+----
+2020-01-01 10:00:00+00 2021-06-15 12:30:00+00

--- a/vortex-sqllogictest/src/duckdb.rs
+++ b/vortex-sqllogictest/src/duckdb.rs
@@ -292,6 +292,7 @@ impl std::fmt::Display for ValueDisplayAdapter {
             | ExtractedValue::Timestamp(_)
             | ExtractedValue::TimestampMs(_)
             | ExtractedValue::TimestampS(_)
+            | ExtractedValue::TimestampTz(_)
             | ExtractedValue::List(_) => write!(f, "{}", self.0),
         }
     }


### PR DESCRIPTION
TIMESTAMPTZ was cropped to second precision before.
