### PR TITLE
duckdb: don't panic on unsupported Value type

### DIFF
--- a/vortex-duckdb/src/column_statistics.rs
+++ b/vortex-duckdb/src/column_statistics.rs
@@ -22,18 +22,15 @@ pub struct ColumnStatistics {
 
 impl ColumnStatistics {
     pub fn from(stats: &ColumnStatisticsAggregate, dtype: DType) -> Self {
-        let min = stats.min.as_ref().map(|value| {
-            let value = value.clone();
-            Scalar::try_new(dtype.clone(), Some(value))
-                .vortex_expect("scalar dtype and value are incompatible")
-                .try_to_duckdb_scalar()
-                .vortex_expect("can't convert Scalar to duckdb Value")
-        });
-        let max = stats.max.as_ref().map(|value| {
+        let min = stats.min.as_ref().and_then(|value| {
             Scalar::try_new(dtype.clone(), Some(value.clone()))
-                .vortex_expect("scalar dtype and value are incompatible")
-                .try_to_duckdb_scalar()
-                .vortex_expect("can't convert Scalar to duckdb Value")
+                .and_then(|scalar| scalar.try_to_duckdb_scalar())
+                .ok()
+        });
+        let max = stats.max.as_ref().and_then(|value| {
+            Scalar::try_new(dtype.clone(), Some(value.clone()))
+                .and_then(|scalar| scalar.try_to_duckdb_scalar())
+                .ok()
         });
 
         let max_string_length = stats

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -388,6 +388,9 @@ impl<'a> TryFrom<&'a ValueRef> for Scalar {
                     vortex_bail!("List value must be a list or struct dtype")
                 }
             },
+            ExtractedValue::Unsupported(type_id) => {
+                vortex_bail!("Unsupported DuckDB value type {type_id:?}")
+            }
         }
     }
 }

--- a/vortex-duckdb/src/duckdb/value.rs
+++ b/vortex-duckdb/src/duckdb/value.rs
@@ -163,7 +163,7 @@ impl ValueRef {
                     .collect::<Vec<_>>(),
             ),
             // ...other types remain unimplemented..
-            other => vortex_panic!("Unsupported DuckDB value type {other:?}"),
+            other => ExtractedValue::Unsupported(other),
         }
     }
 }
@@ -463,6 +463,7 @@ pub enum ExtractedValue {
     TimestampTz(i64),
     Decimal(u8, i8, i128),
     List(Vec<Value>),
+    Unsupported(DUCKDB_TYPE),
 }
 
 #[cfg(test)]

--- a/vortex-duckdb/src/duckdb/value.rs
+++ b/vortex-duckdb/src/duckdb/value.rs
@@ -163,7 +163,7 @@ impl ValueRef {
                     .collect::<Vec<_>>(),
             ),
             // ...other types remain unimplemented..
-            other => vortex_panic!("Unsupported DuckDB value type {other:?}"),
+            other => ExtractedValue::Unsupported(other),
         }
     }
 }
@@ -452,6 +452,7 @@ pub enum ExtractedValue {
     TimestampTz(i64),
     Decimal(u8, i8, i128),
     List(Vec<Value>),
+    Unsupported(DUCKDB_TYPE),
 }
 
 #[cfg(test)]

--- a/vortex-sqllogictest/slt/duckdb/date_special_values.slt
+++ b/vortex-sqllogictest/slt/duckdb/date_special_values.slt
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# infinity dates survive the roundtrip, ordering, and filtering
+
+include ../setup.slt.no
+
+statement ok
+CREATE TABLE td(d DATE);
+
+statement ok
+INSERT INTO td VALUES ('infinity'), ('-infinity'), ('2020-01-01');
+
+statement ok
+COPY td TO '${WORK_DIR}/dsv.vortex';
+
+query DD
+SELECT min(d), max(d) FROM td;
+----
+-infinity infinity
+
+query DD
+SELECT min(d), max(d) FROM '${WORK_DIR}/dsv.vortex';
+----
+-infinity infinity
+
+query I
+SELECT count(*) FROM td WHERE d > DATE '2021-01-01';
+----
+1
+
+query I
+SELECT count(*) FROM '${WORK_DIR}/dsv.vortex' WHERE d > DATE '2021-01-01';
+----
+1

--- a/vortex-sqllogictest/src/duckdb.rs
+++ b/vortex-sqllogictest/src/duckdb.rs
@@ -293,7 +293,8 @@ impl std::fmt::Display for ValueDisplayAdapter {
             | ExtractedValue::TimestampMs(_)
             | ExtractedValue::TimestampS(_)
             | ExtractedValue::TimestampTz(_)
-            | ExtractedValue::List(_) => write!(f, "{}", self.0),
+            | ExtractedValue::List(_)
+            | ExtractedValue::Unsupported(_) => write!(f, "{}", self.0),
         }
     }
 }


### PR DESCRIPTION
Now we return an error to the binder instead of panic!.
