### PR TITLE
`Lambda` and `Variable` `Expression`s and `BoundExpression`s

### DIFF
--- a/vortex-array/src/expr/analysis/fallible.rs
+++ b/vortex-array/src/expr/analysis/fallible.rs
@@ -10,8 +10,11 @@ pub fn label_is_fallible(expr: &Expression) -> BooleanLabels<'_> {
         expr,
         |expr| match expr {
             Expression::Scalar { scalar_fn, .. } => scalar_fn.signature().is_fallible(),
-            // The scope itself cannot fail.
-            Expression::Root => false,
+            // These add no fallibility of their own. Note this is the *self* label: a lambda's
+            // body is one of its children, so the folded label at a lambda node is the body's
+            // fallibility. A higher-order function therefore picks the body up through the
+            // ordinary fold instead of walking it by hand.
+            Expression::Root | Expression::Variable(_) | Expression::Lambda(_) => false,
         },
         |acc, &child| acc | child,
     )
@@ -80,5 +83,29 @@ mod tests {
         let labels = label_is_fallible(&expr);
         assert_eq!(labels.get(&child), Some(&false));
         assert_eq!(labels.get(&expr), Some(&false));
+    }
+}
+
+#[cfg(test)]
+mod lambda_tests {
+    use super::*;
+    use crate::expr::checked_add;
+    use crate::expr::lambda;
+    use crate::expr::lit;
+    use crate::expr::var;
+
+    /// A lambda contributes no fallibility of its own, but its body is one of its children, so the
+    /// label at the lambda node is the body's. That is what lets a future higher-order function
+    /// pick the body up through the ordinary fold rather than walking it by hand.
+    #[test]
+    fn a_lambdas_label_is_its_bodys_fallibility() {
+        let fallible = Expression::from(lambda(["x"], checked_add(var("x"), lit(1i32))));
+        assert_eq!(label_is_fallible(&fallible).get(&fallible), Some(&true));
+
+        let infallible = Expression::from(lambda(["x"], var("x")));
+        assert_eq!(
+            label_is_fallible(&infallible).get(&infallible),
+            Some(&false)
+        );
     }
 }

--- a/vortex-array/src/expr/analysis/immediate_access.rs
+++ b/vortex-array/src/expr/analysis/immediate_access.rs
@@ -66,7 +66,13 @@ pub fn make_bound_free_field_annotator(
 ) -> impl AnnotationFn<BoundExpression, Annotation = FieldName> {
     move |expr: &BoundExpression| {
         let Some(scalar_fn) = expr.as_scalar() else {
-            return scope.names().iter().cloned().collect();
+            // Only the scope root reads every field. A variable resolves against a frame, so it
+            // reads none of them, and saying otherwise would defeat column pruning.
+            return if expr.is_root() {
+                scope.names().iter().cloned().collect()
+            } else {
+                vec![]
+            };
         };
 
         if let Some(selection) = scalar_fn.as_opt::<Select>() {
@@ -84,5 +90,41 @@ pub fn make_bound_free_field_annotator(
         }
 
         vec![]
+    }
+}
+
+#[cfg(test)]
+mod variable_tests {
+    use vortex_error::VortexResult;
+
+    use super::*;
+    use crate::dtype::DType;
+    use crate::dtype::Nullability;
+    use crate::dtype::PType;
+    use crate::expr::Scope;
+    use crate::expr::lambda;
+    use crate::expr::test_harness::struct_dtype;
+    use crate::expr::var;
+
+    /// Only the scope root reads every field. A variable resolves against a frame, so treating it
+    /// like a root would mark a lambda body as reading the whole struct and defeat column pruning.
+    #[test]
+    fn a_bound_variable_accesses_no_root_fields() -> VortexResult<()> {
+        let scope_dtype = struct_dtype();
+        let fields = scope_dtype
+            .as_struct_fields_opt()
+            .vortex_expect("test scope is a struct");
+
+        let bound = lambda(["x"], var("x")).bind(
+            &Scope::new(scope_dtype.clone()),
+            [DType::Primitive(PType::I32, Nullability::NonNullable)],
+        )?;
+
+        let annotator = make_bound_free_field_annotator(fields);
+        assert!(
+            annotator(bound.body()).is_empty(),
+            "a variable should read no root fields"
+        );
+        Ok(())
     }
 }

--- a/vortex-array/src/expr/analysis/referenced_field_paths.rs
+++ b/vortex-array/src/expr/analysis/referenced_field_paths.rs
@@ -84,7 +84,7 @@ impl NodeFolderContext for ReferencedFieldPaths {
         {
             let child_fields = node.children()[0]
                 .dtype()
-                .as_struct_fields_opt()
+                .and_then(|dtype| dtype.as_struct_fields_opt())
                 .ok_or_else(|| vortex_err!("Select child is not a struct"))?;
             let included_fields = selection.normalize_to_included_fields(child_fields.names())?;
 

--- a/vortex-array/src/expr/analysis/strict.rs
+++ b/vortex-array/src/expr/analysis/strict.rs
@@ -14,8 +14,11 @@ pub fn label_strict(expr: &Expression) -> BooleanLabels<'_> {
         expr,
         |expr| match expr {
             Expression::Scalar { scalar_fn, .. } => scalar_fn.signature().is_strict(),
-            // Vacuously strict.
-            Expression::Root => true,
+            // Vacuously strict: nullary, so no argument can be null.
+            Expression::Root | Expression::Variable { .. } => true,
+            // A lambda is not a value, so strictness is not a meaningful question about it. Take
+            // the contract's conservative default rather than inventing an answer.
+            Expression::Lambda { .. } => false,
         },
         |acc, &child| acc & child,
     )

--- a/vortex-array/src/expr/bound_expression.rs
+++ b/vortex-array/src/expr/bound_expression.rs
@@ -27,17 +27,11 @@ use crate::scalar_fn::ScalarFnRef;
 /// Binding is purely logical: it deals only in [`DType`]s and never sees an array, a length, or an
 /// encoding.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct BoundExpression {
-    kind: BoundKind,
-    dtype: DType,
-}
-
-/// The per-variant contents of a [`BoundExpression`], mirroring the logical variants of
-/// [`Expression`].
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum BoundKind {
+pub enum BoundExpression {
     /// A scalar function applied to bound children.
     Scalar {
+        /// The dtype this node evaluates to.
+        dtype: DType,
         /// The scalar function for this node.
         scalar_fn: ScalarFnRef,
         /// The bound children, in argument order.
@@ -47,7 +41,10 @@ pub enum BoundKind {
         children: Arc<Vec<BoundExpression>>,
     },
     /// The scope itself. Its dtype is the scope's root dtype.
-    Root,
+    Root {
+        /// The dtype this node evaluates to.
+        dtype: DType,
+    },
 }
 
 /// A bound-expression wrapper that compares shared tree identity instead of structure.
@@ -56,23 +53,31 @@ pub struct ExactBoundExpr(pub BoundExpression);
 
 impl PartialEq for ExactBoundExpr {
     fn eq(&self, other: &Self) -> bool {
-        match (&self.0.kind, &other.0.kind) {
-            (BoundKind::Root, BoundKind::Root) => self.0.dtype == other.0.dtype,
+        match (&self.0, &other.0) {
             (
-                BoundKind::Scalar {
+                BoundExpression::Root { dtype: lhs_dtype },
+                BoundExpression::Root { dtype: rhs_dtype },
+            ) => lhs_dtype == rhs_dtype,
+            (
+                BoundExpression::Scalar {
+                    dtype: lhs_dtype,
                     scalar_fn: lhs_fn,
                     children: lhs_children,
                 },
-                BoundKind::Scalar {
+                BoundExpression::Scalar {
+                    dtype: rhs_dtype,
                     scalar_fn: rhs_fn,
                     children: rhs_children,
                 },
             ) => {
                 lhs_fn == rhs_fn
                     && Arc::ptr_eq(lhs_children, rhs_children)
-                    && self.0.dtype == other.0.dtype
+                    && lhs_dtype == rhs_dtype
             }
-            _ => false,
+            // No catch-all: a new variant must state its own identity rather than silently
+            // comparing unequal, which would put `eq` out of step with `hash`.
+            (BoundExpression::Root { .. }, BoundExpression::Scalar { .. })
+            | (BoundExpression::Scalar { .. }, BoundExpression::Root { .. }) => false,
         }
     }
 }
@@ -83,11 +88,12 @@ impl Hash for ExactBoundExpr {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // DType differences are resolved by equality. Omitting the potentially lazy dtype keeps
         // identity-keyed cache lookups from deserializing an entire schema just to compute a hash.
-        match &self.0.kind {
-            BoundKind::Root => state.write_u8(0),
-            BoundKind::Scalar {
+        match &self.0 {
+            BoundExpression::Root { .. } => state.write_u8(0),
+            BoundExpression::Scalar {
                 scalar_fn,
                 children,
+                ..
             } => {
                 state.write_u8(1);
                 scalar_fn.hash(state);
@@ -100,10 +106,7 @@ impl Hash for ExactBoundExpr {
 impl BoundExpression {
     /// Create a bound root expression with the given dtype.
     pub fn new_root(dtype: DType) -> Self {
-        Self {
-            kind: BoundKind::Root,
-            dtype,
-        }
+        Self::Root { dtype }
     }
 
     /// Create a bound scalar node from a scalar function and already-bound children.
@@ -125,12 +128,10 @@ impl BoundExpression {
             .collect_vec();
         let dtype = scalar_fn.return_dtype(&arg_dtypes)?;
 
-        Ok(Self {
-            kind: BoundKind::Scalar {
-                scalar_fn,
-                children: children.into(),
-            },
+        Ok(Self::Scalar {
             dtype,
+            scalar_fn,
+            children: children.into(),
         })
     }
 
@@ -140,7 +141,7 @@ impl BoundExpression {
         children: impl IntoIterator<Item = BoundExpression>,
     ) -> VortexResult<Self> {
         let children = Vec::from_iter(children);
-        let BoundKind::Scalar { scalar_fn, .. } = &self.kind else {
+        let BoundExpression::Scalar { scalar_fn, .. } = &self else {
             vortex_ensure!(
                 children.is_empty(),
                 "Root expression cannot have {} children",
@@ -154,33 +155,30 @@ impl BoundExpression {
 
     /// The dtype this expression evaluates to.
     pub fn dtype(&self) -> &DType {
-        &self.dtype
+        match self {
+            Self::Scalar { dtype, .. } | Self::Root { dtype } => dtype,
+        }
     }
 
-    /// The per-variant contents of this node.
-    pub fn kind(&self) -> &BoundKind {
-        &self.kind
-    }
-
-    /// The bound children of this node, in argument order. Empty for [`BoundKind::Root`].
+    /// The bound children of this node, in argument order. Empty for [`BoundExpression::Root`].
     pub fn children(&self) -> &[BoundExpression] {
-        match &self.kind {
-            BoundKind::Scalar { children, .. } => children.as_slice(),
-            BoundKind::Root => &[],
+        match self {
+            Self::Scalar { children, .. } => children.as_slice(),
+            Self::Root { .. } => &[],
         }
     }
 
     /// The scalar function for this node, or `None` if it is the scope root.
     pub fn as_scalar(&self) -> Option<&ScalarFnRef> {
-        match &self.kind {
-            BoundKind::Scalar { scalar_fn, .. } => Some(scalar_fn),
-            BoundKind::Root => None,
+        match self {
+            Self::Scalar { scalar_fn, .. } => Some(scalar_fn),
+            Self::Root { .. } => None,
         }
     }
 
     /// Whether this node is the scope root.
     pub fn is_root(&self) -> bool {
-        matches!(self.kind, BoundKind::Root)
+        matches!(self, Self::Root { .. })
     }
 
     /// Display the bound expression as a formatted tree structure.
@@ -199,11 +197,12 @@ impl BoundExpression {
         let mut expressions = Vec::new();
 
         while let Some((node, visited)) = pending.pop() {
-            match node.kind() {
-                BoundKind::Root => expressions.push(crate::expr::root()),
-                BoundKind::Scalar {
+            match node {
+                BoundExpression::Root { .. } => expressions.push(crate::expr::root()),
+                BoundExpression::Scalar {
                     scalar_fn,
                     children,
+                    ..
                 } if visited => {
                     let child_start = expressions.len() - children.len();
                     let child_expressions = expressions.split_off(child_start);
@@ -212,7 +211,7 @@ impl BoundExpression {
                             .vortex_expect("a bound expression always has valid arity"),
                     );
                 }
-                BoundKind::Scalar { children, .. } => {
+                BoundExpression::Scalar { children, .. } => {
                     pending.push((node, true));
                     pending.extend(children.iter().rev().map(|child| (child, false)));
                 }
@@ -227,9 +226,9 @@ impl BoundExpression {
 
 impl Display for BoundExpression {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self.kind() {
-            BoundKind::Scalar { scalar_fn, .. } => scalar_fn.fmt_sql(self, f),
-            BoundKind::Root => f.write_str("$"),
+        match self {
+            Self::Scalar { scalar_fn, .. } => scalar_fn.fmt_sql(self, f),
+            Self::Root { .. } => f.write_str("$"),
         }
     }
 }
@@ -265,7 +264,7 @@ impl Expression {
 /// Iterative drop to avoid stack overflows on deep trees.
 impl Drop for BoundExpression {
     fn drop(&mut self) {
-        let BoundKind::Scalar { children, .. } = &mut self.kind else {
+        let Self::Scalar { children, .. } = self else {
             return;
         };
         let Some(children) = Arc::get_mut(children) else {
@@ -274,7 +273,7 @@ impl Drop for BoundExpression {
 
         let mut to_drop = std::mem::take(children);
         while let Some(mut child) = to_drop.pop() {
-            if let BoundKind::Scalar { children, .. } = &mut child.kind
+            if let BoundExpression::Scalar { children, .. } = &mut child
                 && let Some(grandchildren) = Arc::get_mut(children)
             {
                 to_drop.append(grandchildren);
@@ -355,8 +354,10 @@ mod tests {
         let bound = eq(col("a"), lit(1_i32)).bind_scope(&scope())?;
         let cloned = bound.clone();
 
-        let (BoundKind::Scalar { children: a, .. }, BoundKind::Scalar { children: b, .. }) =
-            (bound.kind(), cloned.kind())
+        let (
+            BoundExpression::Scalar { children: a, .. },
+            BoundExpression::Scalar { children: b, .. },
+        ) = (&bound, &cloned)
         else {
             unreachable!("eq is a scalar node")
         };

--- a/vortex-array/src/expr/bound_expression.rs
+++ b/vortex-array/src/expr/bound_expression.rs
@@ -11,12 +11,17 @@ use std::sync::Arc;
 use itertools::Itertools;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
+use vortex_error::vortex_err;
 
 use crate::dtype::DType;
 use crate::expr::Expression;
 use crate::expr::display::DisplayTreeExpr;
+use crate::expr::lambda::Lambda;
+use crate::expr::scope::Frame;
 use crate::expr::scope::Scope;
+use crate::expr::variable::Variable;
 use crate::scalar_fn::ScalarFnRef;
 
 /// An [`Expression`] that has been type-checked against a [`Scope`].
@@ -45,6 +50,62 @@ pub enum BoundExpression {
         /// The dtype this node evaluates to.
         dtype: DType,
     },
+    /// A resolved reference to a bound variable.
+    Variable {
+        /// The dtype this node evaluates to.
+        dtype: DType,
+        /// The variable that was resolved.
+        variable: Variable,
+        /// Index of the frame it resolved in, counted from the outermost. Kept so a capture check
+        /// can compare it against the depth at a binder without redoing resolution.
+        depth: usize,
+    },
+    /// A lambda.
+    ///
+    /// The only variant without a dtype: a lambda is not a value. Its function type is recorded
+    /// structurally on [`BoundLambda`] instead — `param_dtypes` is the argument side and
+    /// [`body_dtype`](BoundLambda::body_dtype) the result side.
+    Lambda(BoundLambda),
+}
+
+/// A bound lambda.
+///
+/// A struct as well as a variant, mirroring [`Expression::Lambda`]: the struct lets an API that
+/// wants a lambda — a higher-order function — demand one in its signature, while the variant keeps
+/// a node for traversal to see.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BoundLambda {
+    params: Box<[Variable]>,
+    param_dtypes: Arc<Vec<DType>>,
+    body: Arc<BoundExpression>,
+}
+
+impl BoundLambda {
+    /// The variables this lambda binds, in declaration order.
+    pub fn params(&self) -> &[Variable] {
+        &self.params
+    }
+
+    /// The dtypes of the parameters, in declaration order.
+    pub fn param_dtypes(&self) -> &[DType] {
+        &self.param_dtypes
+    }
+
+    /// The bound body.
+    pub fn body(&self) -> &BoundExpression {
+        &self.body
+    }
+
+    /// The dtype the body evaluates to — the result side of the function type.
+    pub fn body_dtype(&self) -> Option<&DType> {
+        self.body.dtype()
+    }
+}
+
+impl From<BoundLambda> for BoundExpression {
+    fn from(lambda: BoundLambda) -> Self {
+        BoundExpression::Lambda(lambda)
+    }
 }
 
 /// A bound-expression wrapper that compares shared tree identity instead of structure.
@@ -76,8 +137,29 @@ impl PartialEq for ExactBoundExpr {
             }
             // No catch-all: a new variant must state its own identity rather than silently
             // comparing unequal, which would put `eq` out of step with `hash`.
-            (BoundExpression::Root { .. }, BoundExpression::Scalar { .. })
-            | (BoundExpression::Scalar { .. }, BoundExpression::Root { .. }) => false,
+            (
+                BoundExpression::Variable {
+                    dtype: lhs_dtype,
+                    variable: lhs_var,
+                    depth: lhs_depth,
+                },
+                BoundExpression::Variable {
+                    dtype: rhs_dtype,
+                    variable: rhs_var,
+                    depth: rhs_depth,
+                },
+            ) => lhs_var == rhs_var && lhs_depth == rhs_depth && lhs_dtype == rhs_dtype,
+            (BoundExpression::Lambda(lhs), BoundExpression::Lambda(rhs)) => {
+                lhs.params == rhs.params
+                    && lhs.param_dtypes == rhs.param_dtypes
+                    && Arc::ptr_eq(&lhs.body, &rhs.body)
+            }
+            // No catch-all: a new variant must state its own identity, or `eq` drifts out of step
+            // with `hash` and keys stop equalling themselves.
+            (BoundExpression::Root { .. }, _)
+            | (BoundExpression::Scalar { .. }, _)
+            | (BoundExpression::Variable { .. }, _)
+            | (BoundExpression::Lambda(_), _) => false,
         }
     }
 }
@@ -90,6 +172,18 @@ impl Hash for ExactBoundExpr {
         // identity-keyed cache lookups from deserializing an entire schema just to compute a hash.
         match &self.0 {
             BoundExpression::Root { .. } => state.write_u8(0),
+            BoundExpression::Variable {
+                variable, depth, ..
+            } => {
+                state.write_u8(2);
+                variable.hash(state);
+                depth.hash(state);
+            }
+            BoundExpression::Lambda(lambda) => {
+                state.write_u8(3);
+                lambda.params.hash(state);
+                Arc::as_ptr(&lambda.body).hash(state);
+            }
             BoundExpression::Scalar {
                 scalar_fn,
                 children,
@@ -124,8 +218,12 @@ impl BoundExpression {
 
         let arg_dtypes = children
             .iter()
-            .map(|child| child.dtype().clone())
-            .collect_vec();
+            .map(|child| {
+                child.dtype().cloned().ok_or_else(|| {
+                    vortex_err!("a scalar function argument must be a value, got {child}")
+                })
+            })
+            .collect::<VortexResult<Vec<_>>>()?;
         let dtype = scalar_fn.return_dtype(&arg_dtypes)?;
 
         Ok(Self::Scalar {
@@ -154,9 +252,22 @@ impl BoundExpression {
     }
 
     /// The dtype this expression evaluates to.
-    pub fn dtype(&self) -> &DType {
+    /// The dtype this expression evaluates to, erroring for a lambda, which is not a value.
+    ///
+    /// Prefer this where the node is a value by construction; it turns what would otherwise be an
+    /// `unwrap` at each call site into one clear error.
+    pub fn value_dtype(&self) -> VortexResult<&DType> {
+        self.dtype()
+            .ok_or_else(|| vortex_err!("expected a value, got a lambda: {self}"))
+    }
+
+    /// The dtype this expression evaluates to, or `None` for a lambda, which is not a value.
+    pub fn dtype(&self) -> Option<&DType> {
         match self {
-            Self::Scalar { dtype, .. } | Self::Root { dtype } => dtype,
+            Self::Scalar { dtype, .. } | Self::Root { dtype } | Self::Variable { dtype, .. } => {
+                Some(dtype)
+            }
+            Self::Lambda(_) => None,
         }
     }
 
@@ -164,7 +275,8 @@ impl BoundExpression {
     pub fn children(&self) -> &[BoundExpression] {
         match self {
             Self::Scalar { children, .. } => children.as_slice(),
-            Self::Root { .. } => &[],
+            Self::Lambda(lambda) => std::slice::from_ref(&lambda.body),
+            Self::Root { .. } | Self::Variable { .. } => &[],
         }
     }
 
@@ -172,7 +284,7 @@ impl BoundExpression {
     pub fn as_scalar(&self) -> Option<&ScalarFnRef> {
         match self {
             Self::Scalar { scalar_fn, .. } => Some(scalar_fn),
-            Self::Root { .. } => None,
+            Self::Root { .. } | Self::Variable { .. } | Self::Lambda(_) => None,
         }
     }
 
@@ -199,6 +311,20 @@ impl BoundExpression {
         while let Some((node, visited)) = pending.pop() {
             match node {
                 BoundExpression::Root { .. } => expressions.push(crate::expr::root()),
+                BoundExpression::Variable { variable, .. } => {
+                    expressions.push(Expression::Variable(variable.clone()))
+                }
+                BoundExpression::Lambda(lambda) if visited => {
+                    let body = expressions.pop().vortex_expect("body was pushed");
+                    expressions.push(Expression::from(Lambda::new(
+                        lambda.params.iter().cloned(),
+                        body,
+                    )));
+                }
+                BoundExpression::Lambda(lambda) => {
+                    pending.push((node, true));
+                    pending.push((&lambda.body, false));
+                }
                 BoundExpression::Scalar {
                     scalar_fn,
                     children,
@@ -229,6 +355,13 @@ impl Display for BoundExpression {
         match self {
             Self::Scalar { scalar_fn, .. } => scalar_fn.fmt_sql(self, f),
             Self::Root { .. } => f.write_str("$"),
+            Self::Variable { variable, .. } => write!(f, "${variable}"),
+            Self::Lambda(lambda) => write!(
+                f,
+                "({}) -> {}",
+                lambda.params.iter().join(", "),
+                lambda.body
+            ),
         }
     }
 }
@@ -244,20 +377,79 @@ impl Expression {
     }
 
     /// Bind this expression against an explicit [`Scope`].
+    ///
+    /// Errors on a lambda: a lambda has no dtype, so only whoever supplies its parameter types can
+    /// bind it. See [`Lambda::bind`].
     pub fn bind_scope(&self, scope: &Scope) -> VortexResult<BoundExpression> {
-        if self.is_root() {
-            return Ok(BoundExpression::new_root(scope.root().clone()));
+        match self {
+            Expression::Root => Ok(BoundExpression::new_root(scope.root().clone())),
+            Expression::Variable(variable) => {
+                let (dtype, depth) = scope.resolve(variable).ok_or_else(|| {
+                    vortex_err!(
+                        "unbound variable '{variable}'; the scope binds {} frame(s)",
+                        scope.depth()
+                    )
+                })?;
+                Ok(BoundExpression::Variable {
+                    dtype: dtype.clone(),
+                    variable: variable.clone(),
+                    depth,
+                })
+            }
+            Expression::Lambda(lambda) => vortex_bail!(
+                "a lambda ({}) is not a value and cannot be bound here; use Lambda::bind, \
+                 which supplies its parameter types",
+                lambda.params().iter().join(", ")
+            ),
+            Expression::Scalar {
+                scalar_fn,
+                children,
+            } => {
+                let children: Vec<_> = children
+                    .iter()
+                    .map(|child| child.bind_scope(scope))
+                    .try_collect()?;
+                BoundExpression::try_new(scalar_fn.clone(), children)
+            }
         }
+    }
+}
 
-        let children: Vec<_> = self
-            .children()
-            .iter()
-            .map(|child| child.bind_scope(scope))
-            .try_collect()?;
-        let scalar_fn = self
-            .as_scalar()
-            .vortex_expect("root was handled above, so this is a scalar node");
-        BoundExpression::try_new(scalar_fn.clone(), children)
+impl Lambda {
+    /// Bind this lambda, supplying the dtypes of its parameters.
+    ///
+    /// The parameter dtypes come from the caller because a lambda cannot know them — they are
+    /// determined by whatever applies it. A higher-order function derives them from its own
+    /// arguments and calls this.
+    ///
+    /// The body is bound under `scope` extended with one frame holding the parameters, so a
+    /// parameter shadows an outer binding of the same name.
+    pub fn bind(
+        &self,
+        scope: &Scope,
+        param_dtypes: impl IntoIterator<Item = DType>,
+    ) -> VortexResult<BoundLambda> {
+        let param_dtypes = Vec::from_iter(param_dtypes);
+        vortex_ensure!(
+            param_dtypes.len() == self.params().len(),
+            "lambda binds {} parameter(s) but {} dtype(s) were supplied",
+            self.params().len(),
+            param_dtypes.len()
+        );
+
+        let frame = Frame::try_new(
+            self.params()
+                .iter()
+                .cloned()
+                .zip(param_dtypes.iter().cloned()),
+        )?;
+        let body = self.body().bind_scope(&scope.push_frame(frame))?;
+
+        Ok(BoundLambda {
+            params: self.params().into(),
+            param_dtypes: Arc::new(param_dtypes),
+            body: Arc::new(body),
+        })
     }
 }
 
@@ -303,7 +495,7 @@ mod tests {
     fn root_binds_to_the_scope() -> VortexResult<()> {
         let bound = root().bind_scope(&scope())?;
         assert!(bound.is_root());
-        assert_eq!(bound.dtype(), &struct_dtype());
+        assert_eq!(bound.dtype(), Some(&struct_dtype()));
         assert_eq!(bound.unbind(), root());
         Ok(())
     }
@@ -313,14 +505,14 @@ mod tests {
         let expr = eq(col("a"), lit(1_i32));
         let bound = expr.bind_scope(&scope())?;
 
-        assert_eq!(bound.dtype(), &DType::Bool(Nullability::NonNullable));
+        assert_eq!(bound.dtype(), Some(&DType::Bool(Nullability::NonNullable)));
 
         let lhs = &bound.children()[0];
         assert_eq!(
             lhs.dtype(),
-            &DType::Primitive(PType::I32, Nullability::NonNullable)
+            Some(&DType::Primitive(PType::I32, Nullability::NonNullable))
         );
-        assert_eq!(lhs.children()[0].dtype(), &struct_dtype());
+        assert_eq!(lhs.children()[0].dtype(), Some(&struct_dtype()));
         Ok(())
     }
 
@@ -329,7 +521,7 @@ mod tests {
         for expr in [root(), col("a"), eq(col("a"), lit(1_i32)), lit(true)] {
             assert_eq!(
                 expr.bind(&struct_dtype())?.dtype(),
-                &expr.return_dtype(&struct_dtype())?,
+                Some(&expr.return_dtype(&struct_dtype())?),
                 "disagreement for {expr}"
             );
         }

--- a/vortex-array/src/expr/display.rs
+++ b/vortex-array/src/expr/display.rs
@@ -5,6 +5,8 @@ use std::fmt;
 use std::fmt::Display;
 use std::fmt::Formatter;
 
+use itertools::Itertools;
+
 use crate::expr::BoundExpression;
 use crate::expr::Expression;
 use crate::scalar_fn::ChildName;
@@ -65,7 +67,10 @@ impl DisplayTreeNode for Expression {
     fn tree_child_name(&self, index: usize) -> ChildName {
         match self {
             Expression::Scalar { scalar_fn, .. } => scalar_fn.signature().child_name(index),
-            Expression::Root => unreachable!("the scope root has no children"),
+            Expression::Lambda { .. } => ChildName::from("body"),
+            Expression::Root | Expression::Variable(_) => {
+                unreachable!("a leaf expression has no children")
+            }
         }
     }
 
@@ -73,6 +78,10 @@ impl DisplayTreeNode for Expression {
         match self {
             Expression::Scalar { scalar_fn, .. } => Display::fmt(scalar_fn, f),
             Expression::Root => write!(f, "{ROOT_DISPLAY}"),
+            Expression::Variable(variable) => write!(f, "${variable}"),
+            Expression::Lambda(lambda) => {
+                write!(f, "lambda({})", lambda.params().iter().join(", "))
+            }
         }
     }
 }
@@ -85,7 +94,10 @@ impl DisplayTreeNode for BoundExpression {
     fn tree_child_name(&self, index: usize) -> ChildName {
         match self {
             BoundExpression::Scalar { scalar_fn, .. } => scalar_fn.signature().child_name(index),
-            BoundExpression::Root { .. } => unreachable!("the scope root has no children"),
+            BoundExpression::Lambda(_) => ChildName::from("body"),
+            BoundExpression::Root { .. } | BoundExpression::Variable { .. } => {
+                unreachable!("a leaf bound node has no children")
+            }
         }
     }
 
@@ -93,6 +105,10 @@ impl DisplayTreeNode for BoundExpression {
         match self {
             BoundExpression::Scalar { scalar_fn, .. } => Display::fmt(scalar_fn, f),
             BoundExpression::Root { .. } => write!(f, "{ROOT_DISPLAY}"),
+            BoundExpression::Variable { variable, .. } => write!(f, "${variable}"),
+            BoundExpression::Lambda(lambda) => {
+                write!(f, "lambda({})", lambda.params().iter().join(", "))
+            }
         }
     }
 }

--- a/vortex-array/src/expr/display.rs
+++ b/vortex-array/src/expr/display.rs
@@ -6,7 +6,6 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 
 use crate::expr::BoundExpression;
-use crate::expr::BoundKind;
 use crate::expr::Expression;
 use crate::scalar_fn::ChildName;
 
@@ -84,16 +83,16 @@ impl DisplayTreeNode for BoundExpression {
     }
 
     fn tree_child_name(&self, index: usize) -> ChildName {
-        match self.kind() {
-            BoundKind::Scalar { scalar_fn, .. } => scalar_fn.signature().child_name(index),
-            BoundKind::Root => unreachable!("the scope root has no children"),
+        match self {
+            BoundExpression::Scalar { scalar_fn, .. } => scalar_fn.signature().child_name(index),
+            BoundExpression::Root { .. } => unreachable!("the scope root has no children"),
         }
     }
 
     fn fmt_tree_node(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self.kind() {
-            BoundKind::Scalar { scalar_fn, .. } => Display::fmt(scalar_fn, f),
-            BoundKind::Root => write!(f, "{ROOT_DISPLAY}"),
+        match self {
+            BoundExpression::Scalar { scalar_fn, .. } => Display::fmt(scalar_fn, f),
+            BoundExpression::Root { .. } => write!(f, "{ROOT_DISPLAY}"),
         }
     }
 }

--- a/vortex-array/src/expr/expression.rs
+++ b/vortex-array/src/expr/expression.rs
@@ -11,13 +11,16 @@ use std::sync::Arc;
 use itertools::Itertools;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_session::VortexSession;
 
 use crate::dtype::DType;
 use crate::expr::display::DisplayTreeExpr;
+use crate::expr::lambda::Lambda;
 use crate::expr::traversal::TraversalOrder;
 use crate::expr::traversal::pre_order_visit_down;
+use crate::expr::variable::Variable;
 use crate::scalar_fn::ScalarFnRef;
 use crate::scalar_fn::ScalarFnVTable;
 use crate::stats::rewrite::StatsRewriteCtx;
@@ -42,6 +45,18 @@ pub enum Expression {
     },
     /// The full scope of the expression evaluation.
     Root,
+    /// A reference to a name bound by an enclosing [`Expression::Lambda`].
+    ///
+    /// Like [`Expression::Root`], its dtype comes from the scope rather than from children, so it
+    /// is resolved during binding.
+    Variable(Variable),
+    /// A body evaluated under a frame binding `params`.
+    ///
+    /// A lambda is **not a value**: its parameter dtypes are determined by whatever applies it, so
+    /// it has no dtype of its own and cannot be bound by
+    /// [`bind_scope`](Expression::bind_scope). Use
+    /// [`Lambda::bind`], which takes the parameter types.
+    Lambda(Lambda),
 }
 
 impl Expression {
@@ -70,11 +85,27 @@ impl Expression {
         matches!(self, Self::Root)
     }
 
+    /// The variable this expression references, if it is a variable.
+    pub fn as_variable(&self) -> Option<&Variable> {
+        match self {
+            Self::Variable(variable) => Some(variable),
+            _ => None,
+        }
+    }
+
+    /// The lambda this expression holds, if it is one.
+    pub fn as_lambda(&self) -> Option<&Lambda> {
+        match self {
+            Self::Lambda(lambda) => Some(lambda),
+            _ => None,
+        }
+    }
+
     /// Returns the scalar fn for this expression, or `None` if it is not a scalar node.
     pub fn as_scalar(&self) -> Option<&ScalarFnRef> {
         match self {
             Self::Scalar { scalar_fn, .. } => Some(scalar_fn),
-            Self::Root => None,
+            Self::Root | Self::Variable(_) | Self::Lambda(_) => None,
         }
     }
 
@@ -99,10 +130,16 @@ impl Expression {
     }
 
     /// Returns the children of this expression.
+    /// Returns the sub-expressions of this node.
+    ///
+    /// A [`Expression::Lambda`] yields its body, so generic traversal reaches it — but only by
+    /// passing through the `Lambda` node, which is a scope boundary. A pass that is not
+    /// scope-aware must handle that variant rather than descending blindly.
     pub fn children(&self) -> &[Expression] {
         match self {
             Self::Scalar { children, .. } => children.as_slice(),
-            Self::Root => NO_CHILDREN,
+            Self::Lambda(lambda) => std::slice::from_ref(lambda.body_arc()),
+            Self::Root | Self::Variable(_) => NO_CHILDREN,
         }
     }
 
@@ -118,13 +155,24 @@ impl Expression {
     ) -> VortexResult<Self> {
         let children = Vec::from_iter(children);
         match &self {
-            Self::Root => {
+            Self::Root | Self::Variable(_) => {
                 vortex_ensure!(
                     children.is_empty(),
-                    "Expression arity mismatch: root expects 0 children but got {}",
+                    "Expression arity mismatch: {self} expects 0 children but got {}",
                     children.len()
                 );
-                Ok(Self::Root)
+                Ok(self.clone())
+            }
+            Self::Lambda(lambda) => {
+                vortex_ensure!(
+                    children.len() == 1,
+                    "Expression arity mismatch: a lambda expects 1 child but got {}",
+                    children.len()
+                );
+                Ok(Self::Lambda(Lambda::new(
+                    lambda.params().iter().cloned(),
+                    children.into_iter().next().vortex_expect("checked above"),
+                )))
             }
             Self::Scalar { scalar_fn, .. } => {
                 vortex_ensure!(
@@ -145,6 +193,14 @@ impl Expression {
     pub fn return_dtype(&self, scope: &DType) -> VortexResult<DType> {
         match self {
             Self::Root => Ok(scope.clone()),
+            // A variable resolves against a frame, which this entry point does not carry. Erroring
+            // keeps callers that only have a root dtype from silently mistyping a lambda body.
+            Self::Variable(variable) => vortex_bail!(
+                "variable '{variable}' can only be typed by binding against a scope with frames"
+            ),
+            Self::Lambda(_) => {
+                vortex_bail!("a lambda has no data type; use Lambda::bind to type its body")
+            }
             Self::Scalar {
                 scalar_fn,
                 children,
@@ -165,6 +221,11 @@ impl Expression {
         match self {
             // The scope is exactly as valid as itself.
             Self::Root => Ok(Self::Root),
+            // A variable is exactly as valid as whatever it is bound to.
+            Self::Variable(_) => Ok(self.clone()),
+            Self::Lambda(_) => {
+                vortex_bail!("a lambda has no validity; it is not a value")
+            }
             Self::Scalar { scalar_fn, .. } => scalar_fn.validity(self),
         }
     }
@@ -204,6 +265,8 @@ impl Expression {
     pub fn fmt_sql(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::Root => write!(f, "$"),
+            Self::Variable(variable) => write!(f, "${variable}"),
+            Self::Lambda(lambda) => Display::fmt(lambda, f),
             Self::Scalar { scalar_fn, .. } => scalar_fn.fmt_sql(self, f),
         }
     }
@@ -289,6 +352,14 @@ impl Expression {
     }
 }
 
+/// `Root` stands in as the default so that a body can be moved out during the iterative [`Drop`]
+/// below. It is never observed by callers.
+impl Default for Expression {
+    fn default() -> Self {
+        Self::Root
+    }
+}
+
 /// The default display implementation for expressions uses the 'SQL'-style format.
 impl Display for Expression {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -299,19 +370,34 @@ impl Display for Expression {
 /// Iterative drop for expression to avoid stack overflows.
 impl Drop for Expression {
     fn drop(&mut self) {
-        let Self::Scalar { children, .. } = self else {
-            return;
-        };
-        let Some(children) = Arc::get_mut(children) else {
-            return;
-        };
+        let mut children_to_drop = Vec::new();
+        match self {
+            Self::Scalar { children, .. } => {
+                if let Some(children) = Arc::get_mut(children) {
+                    children_to_drop.append(children);
+                }
+            }
+            Self::Lambda(lambda) => {
+                if let Some(body) = lambda.take_unique_body() {
+                    children_to_drop.push(body);
+                }
+            }
+            Self::Root | Self::Variable(_) => return,
+        }
 
-        let mut children_to_drop = std::mem::take(children);
         while let Some(mut child) = children_to_drop.pop() {
-            if let Self::Scalar { children, .. } = &mut child
-                && let Some(expr_children) = Arc::get_mut(children)
-            {
-                children_to_drop.append(expr_children);
+            match &mut child {
+                Self::Scalar { children, .. } => {
+                    if let Some(expr_children) = Arc::get_mut(children) {
+                        children_to_drop.append(expr_children);
+                    }
+                }
+                Self::Lambda(lambda) => {
+                    if let Some(body) = lambda.take_unique_body() {
+                        children_to_drop.push(body);
+                    }
+                }
+                Self::Root | Self::Variable(_) => {}
             }
         }
     }

--- a/vortex-array/src/expr/exprs.rs
+++ b/vortex-array/src/expr/exprs.rs
@@ -16,6 +16,8 @@ use crate::dtype::FieldName;
 use crate::dtype::FieldNames;
 use crate::dtype::Nullability;
 use crate::expr::Expression;
+use crate::expr::lambda::Lambda;
+use crate::expr::variable::Variable;
 use crate::scalar::Scalar;
 use crate::scalar::ScalarValue;
 use crate::scalar_fn::EmptyOptions;
@@ -62,6 +64,23 @@ use crate::scalar_fn::fns::zip::Zip;
 /// This is commonly used as the starting point for field access and other operations.
 pub fn root() -> Expression {
     Expression::Root
+}
+
+/// Creates an expression referencing the value bound to `name` in the enclosing scope.
+///
+/// A variable has no dtype of its own; it is resolved when the expression is bound. Binding fails
+/// if no enclosing frame introduces the name.
+pub fn var(name: impl AsRef<str>) -> Expression {
+    Expression::Variable(Variable::new(name))
+}
+
+/// Creates a lambda binding `params` over `body`.
+///
+/// A lambda is not a value: its parameter dtypes are supplied by whatever applies it, so binding
+/// one requires [`Lambda::bind`] rather than
+/// [`bind_scope`](Expression::bind_scope).
+pub fn lambda(params: impl IntoIterator<Item = impl Into<Variable>>, body: Expression) -> Lambda {
+    Lambda::new(params, body)
 }
 
 /// Return whether the expression is a root expression.

--- a/vortex-array/src/expr/lambda.rs
+++ b/vortex-array/src/expr/lambda.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+use itertools::Itertools;
+
+use crate::expr::Expression;
+use crate::expr::variable::Variable;
+
+/// A body evaluated under a frame binding `params`.
+///
+/// A lambda is **not a value**: its parameter dtypes are determined by whatever applies it, so it
+/// has no dtype of its own and cannot be bound by
+/// [`bind_scope`](Expression::bind_scope). Bind it with [`Lambda::bind`], which takes the parameter
+/// types.
+///
+/// It is a struct rather than only an enum variant so that an API expecting a lambda — a
+/// higher-order function, for instance — can say so in its signature and reject anything else at
+/// compile time. A lambda is still reachable as [`Expression::Lambda`], because traversal needs a
+/// node to see: that node is the scope boundary.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Lambda {
+    params: Box<[Variable]>,
+    body: Arc<Expression>,
+}
+
+impl Lambda {
+    /// Create a lambda binding `params` over `body`.
+    pub fn new(params: impl IntoIterator<Item = impl Into<Variable>>, body: Expression) -> Self {
+        Self {
+            params: params.into_iter().map(Into::into).collect(),
+            body: Arc::new(body),
+        }
+    }
+
+    /// The variables this lambda binds, in declaration order.
+    pub fn params(&self) -> &[Variable] {
+        &self.params
+    }
+
+    /// The expression evaluated under the parameter frame.
+    pub fn body(&self) -> &Expression {
+        &self.body
+    }
+
+    /// Take the body if this lambda holds the only reference to it.
+    ///
+    /// Used by `Expression`'s iterative [`Drop`] to drain a lambda chain onto a worklist instead of
+    /// recursing through it, which would overflow the stack on a deeply nested chain.
+    pub(crate) fn take_unique_body(&mut self) -> Option<Expression> {
+        Arc::get_mut(&mut self.body).map(std::mem::take)
+    }
+
+    /// The body as a shared handle, so a caller can hand back a one-element slice.
+    pub(crate) fn body_arc(&self) -> &Arc<Expression> {
+        &self.body
+    }
+}
+
+impl Display for Lambda {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "({}) -> {}", self.params.iter().join(", "), self.body)
+    }
+}
+
+impl From<Lambda> for Expression {
+    fn from(lambda: Lambda) -> Self {
+        Expression::Lambda(lambda)
+    }
+}

--- a/vortex-array/src/expr/mod.rs
+++ b/vortex-array/src/expr/mod.rs
@@ -62,18 +62,22 @@ pub(crate) mod expression;
 mod exprs;
 pub(crate) mod field;
 pub mod forms;
+pub mod lambda;
 mod optimize;
 pub mod proto;
 pub mod scope;
 pub mod stats;
 pub mod transform;
 pub mod traversal;
+pub mod variable;
 
 pub use analysis::*;
 pub use bound_expression::*;
 pub use expression::*;
 pub use exprs::*;
+pub use lambda::*;
 pub use scope::*;
+pub use variable::*;
 
 pub trait VortexExprExt {
     /// Accumulate all field references from this expression and its children in a set
@@ -116,6 +120,8 @@ impl PartialEq for ExactExpr {
     fn eq(&self, other: &Self) -> bool {
         match (&self.0, &other.0) {
             (Expression::Root, Expression::Root) => true,
+            (Expression::Variable(lhs), Expression::Variable(rhs)) => lhs == rhs,
+            (Expression::Lambda(lhs), Expression::Lambda(rhs)) => lhs == rhs,
             (
                 Expression::Scalar {
                     scalar_fn: lhs_fn,
@@ -136,6 +142,14 @@ impl Hash for ExactExpr {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match &self.0 {
             Expression::Root => state.write_u8(0),
+            Expression::Variable(variable) => {
+                state.write_u8(2);
+                variable.hash(state);
+            }
+            Expression::Lambda(lambda) => {
+                state.write_u8(3);
+                lambda.hash(state);
+            }
             Expression::Scalar {
                 scalar_fn,
                 children,

--- a/vortex-array/src/expr/optimize.rs
+++ b/vortex-array/src/expr/optimize.rs
@@ -44,7 +44,7 @@ impl Expression {
     fn simplify_untyped_node(&self) -> VortexResult<Option<Expression>> {
         match self {
             Expression::Scalar { scalar_fn, .. } => scalar_fn.simplify_untyped(self),
-            Expression::Root => Ok(None),
+            Expression::Root | Expression::Variable { .. } | Expression::Lambda { .. } => Ok(None),
         }
     }
 
@@ -52,7 +52,7 @@ impl Expression {
     fn simplify_node(&self, ctx: &dyn SimplifyCtx) -> VortexResult<Option<Expression>> {
         match self {
             Expression::Scalar { scalar_fn, .. } => scalar_fn.simplify(self, ctx),
-            Expression::Root => Ok(None),
+            Expression::Root | Expression::Variable { .. } | Expression::Lambda { .. } => Ok(None),
         }
     }
 
@@ -64,7 +64,7 @@ impl Expression {
     ) -> VortexResult<Option<ReduceNodeRef>> {
         match self {
             Expression::Scalar { scalar_fn, .. } => scalar_fn.reduce(node, ctx),
-            Expression::Root => Ok(None),
+            Expression::Root | Expression::Variable { .. } | Expression::Lambda { .. } => Ok(None),
         }
     }
 

--- a/vortex-array/src/expr/proto.rs
+++ b/vortex-array/src/expr/proto.rs
@@ -3,6 +3,7 @@
 
 use itertools::Itertools;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 use vortex_proto::expr as pb;
@@ -24,12 +25,24 @@ pub(crate) const ROOT_ID: &str = "vortex.root";
 
 impl ExprSerializeProtoExt for Expression {
     fn serialize_proto(&self) -> VortexResult<pb::Expr> {
-        let Some(scalar_fn) = self.as_scalar() else {
-            return Ok(pb::Expr {
-                id: ROOT_ID.to_string(),
-                children: vec![],
-                metadata: Some(vec![]),
-            });
+        let scalar_fn = match self {
+            Expression::Root => {
+                return Ok(pb::Expr {
+                    id: ROOT_ID.to_string(),
+                    children: vec![],
+                    metadata: Some(vec![]),
+                });
+            }
+            // There is no wire format for these yet. Rejecting is the only safe answer: falling
+            // through would serialize them as a root and silently drop the name, parameters and
+            // body.
+            Expression::Variable(variable) => {
+                vortex_bail!("variable '{variable}' is not serializable")
+            }
+            Expression::Lambda(lambda) => {
+                vortex_bail!("lambda ({lambda}) is not serializable")
+            }
+            Expression::Scalar { scalar_fn, .. } => scalar_fn,
         };
 
         let children = self
@@ -139,6 +152,23 @@ mod tests {
         let deser_expr = Expression::from_proto(&s_expr, &array_session()).unwrap();
 
         assert_eq!(&deser_expr, &expr);
+    }
+
+    /// Neither has a wire format yet, so serializing must fail rather than silently emitting a
+    /// root and losing the name, parameters and body.
+    #[test]
+    fn variables_and_lambdas_are_not_serializable() {
+        use crate::expr::lambda;
+        use crate::expr::var;
+
+        assert!(var("x").serialize_proto().is_err());
+        assert!(
+            Expression::from(lambda(["x"], var("x")))
+                .serialize_proto()
+                .is_err()
+        );
+        // Root still round-trips on its historical id.
+        assert_eq!(root().serialize_proto().unwrap().id, "vortex.root");
     }
 
     #[test]

--- a/vortex-array/src/expr/scope.rs
+++ b/vortex-array/src/expr/scope.rs
@@ -1,27 +1,101 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::sync::Arc;
+
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+
 use crate::dtype::DType;
+use crate::expr::variable::Variable;
+
+/// A set of named bindings introduced by a single binder.
+///
+/// A lambda pushes exactly one frame, holding its parameters. Names within a frame must be unique;
+/// a name in an inner frame shadows the same name in an outer one.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Frame(Arc<Vec<(Variable, DType)>>);
+
+impl Frame {
+    /// Create a frame from its bindings, in declaration order.
+    ///
+    /// Errors if a name is bound more than once, since a reference to it would be ambiguous.
+    pub fn try_new(bindings: impl IntoIterator<Item = (Variable, DType)>) -> VortexResult<Self> {
+        let bindings = Vec::from_iter(bindings);
+        for (idx, (name, _)) in bindings.iter().enumerate() {
+            if bindings[..idx].iter().any(|(seen, _)| seen == name) {
+                vortex_bail!("duplicate binding '{name}' in a single frame");
+            }
+        }
+        Ok(Self(Arc::new(bindings)))
+    }
+
+    /// The bindings in this frame, in declaration order.
+    pub fn bindings(&self) -> &[(Variable, DType)] {
+        &self.0
+    }
+
+    /// The dtype bound to `name` in this frame, if any.
+    pub fn get(&self, name: &Variable) -> Option<&DType> {
+        self.0
+            .iter()
+            .find_map(|(bound, dtype)| (bound == name).then_some(dtype))
+    }
+}
 
 /// The context an [`Expression`](crate::expr::Expression) is bound against.
 ///
-/// Today a scope is just the dtype that [`root`](crate::expr::root) resolves to. It is an opaque
-/// struct rather than a bare [`DType`] so that lexical bindings can be added later without changing
-/// [`Expression::bind_scope`](crate::expr::Expression::bind_scope)'s signature.
+/// A scope is the dtype that [`root`](crate::expr::root) resolves to, plus a stack of [`Frame`]s
+/// holding named bindings. The stack is what distinguishes "this binder's own name" from "a name
+/// introduced by an enclosing binder", which is the information a capture check needs.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Scope {
     root: DType,
+    /// Innermost frame last.
+    frames: Vec<Frame>,
 }
 
 impl Scope {
-    /// Create a scope in which `root` resolves to the given dtype.
+    /// Create a scope in which `root` resolves to the given dtype, with no bindings.
     pub fn new(root: DType) -> Self {
-        Self { root }
+        Self {
+            root,
+            frames: Vec::new(),
+        }
     }
 
     /// The dtype that `root` resolves to.
     pub fn root(&self) -> &DType {
         &self.root
+    }
+
+    /// The number of enclosing binders.
+    pub fn depth(&self) -> usize {
+        self.frames.len()
+    }
+
+    /// Return this scope extended with one more frame, which becomes the innermost.
+    pub fn push_frame(&self, frame: Frame) -> Self {
+        let mut frames = self.frames.clone();
+        frames.push(frame);
+        Self {
+            root: self.root.clone(),
+            frames,
+        }
+    }
+
+    /// Resolve `name`, searching innermost-first so that inner bindings shadow outer ones.
+    ///
+    /// Returns the bound dtype and the index of the frame it was found in, counted from the
+    /// outermost so the value stays stable as further frames are pushed. Comparing it against the
+    /// [`depth`](Scope::depth) at a binder distinguishes a reference to that binder's own parameter
+    /// from a capture of something further out.
+    pub fn resolve(&self, name: &Variable) -> Option<(&DType, usize)> {
+        self.frames
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(depth, frame)| frame.get(name).map(|dtype| (dtype, depth)))
     }
 }
 
@@ -33,13 +107,72 @@ impl From<DType> for Scope {
 
 #[cfg(test)]
 mod tests {
+    use vortex_error::VortexResult;
+
     use super::*;
     use crate::dtype::Nullability;
+    use crate::dtype::PType;
+
+    fn i32_() -> DType {
+        DType::Primitive(PType::I32, Nullability::NonNullable)
+    }
+
+    fn utf8() -> DType {
+        DType::Utf8(Nullability::NonNullable)
+    }
 
     #[test]
     fn root_round_trips() {
         let dtype = DType::Bool(Nullability::Nullable);
         assert_eq!(Scope::new(dtype.clone()).root(), &dtype);
         assert_eq!(Scope::from(dtype.clone()).root(), &dtype);
+    }
+
+    #[test]
+    fn an_empty_scope_resolves_nothing() {
+        let scope = Scope::new(i32_());
+        assert_eq!(scope.depth(), 0);
+        assert!(scope.resolve(&Variable::new("x")).is_none());
+    }
+
+    #[test]
+    fn resolve_reports_the_frame_it_was_found_in() -> VortexResult<()> {
+        let scope = Scope::new(i32_())
+            .push_frame(Frame::try_new([(Variable::new("a"), i32_())])?)
+            .push_frame(Frame::try_new([(Variable::new("b"), utf8())])?);
+
+        assert_eq!(scope.resolve(&Variable::new("a")), Some((&i32_(), 0)));
+        assert_eq!(scope.resolve(&Variable::new("b")), Some((&utf8(), 1)));
+        assert_eq!(scope.depth(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn inner_frames_shadow_outer_ones() -> VortexResult<()> {
+        let scope = Scope::new(i32_())
+            .push_frame(Frame::try_new([(Variable::new("x"), i32_())])?)
+            .push_frame(Frame::try_new([(Variable::new("x"), utf8())])?);
+
+        assert_eq!(scope.resolve(&Variable::new("x")), Some((&utf8(), 1)));
+        Ok(())
+    }
+
+    /// A name bound twice in one frame is ambiguous, so it is rejected rather than silently
+    /// resolved by position.
+    #[test]
+    fn duplicate_names_in_one_frame_are_rejected() {
+        assert!(
+            Frame::try_new([(Variable::new("x"), i32_()), (Variable::new("x"), utf8())]).is_err()
+        );
+    }
+
+    #[test]
+    fn pushing_a_frame_does_not_mutate_the_original() -> VortexResult<()> {
+        let outer = Scope::new(i32_());
+        let inner = outer.push_frame(Frame::try_new([(Variable::new("x"), i32_())])?);
+
+        assert!(outer.resolve(&Variable::new("x")).is_none());
+        assert!(inner.resolve(&Variable::new("x")).is_some());
+        Ok(())
     }
 }

--- a/vortex-array/src/expr/transform/bound_partition.rs
+++ b/vortex-array/src/expr/transform/bound_partition.rs
@@ -293,7 +293,12 @@ fn partition_root_dtype(names: &FieldNames, partitions: &[BoundExpression]) -> D
             names.clone(),
             partitions
                 .iter()
-                .map(|partition| partition.dtype().clone())
+                .map(|partition| {
+                    partition
+                        .dtype()
+                        .cloned()
+                        .vortex_expect("a partition is always a value")
+                })
                 .collect(),
         ),
         Nullability::NonNullable,
@@ -468,7 +473,7 @@ mod tests {
 
         partitioned.replace_partitions(vec![replacement].into_boxed_slice())?;
 
-        assert_eq!(partitioned.root.dtype(), &field_dtype);
+        assert_eq!(partitioned.root.dtype(), Some(&field_dtype));
         Ok(())
     }
 }

--- a/vortex-array/src/expr/traversal/mod.rs
+++ b/vortex-array/src/expr/traversal/mod.rs
@@ -24,7 +24,6 @@ use vortex_error::VortexResult;
 
 use crate::expr::BoundExpression;
 use crate::expr::Expression;
-use crate::expr::bound_expression::BoundKind;
 use crate::expr::traversal::fold::NodeFolderContextWrapper;
 
 /// Signal to control a traversal's flow
@@ -534,7 +533,7 @@ impl Node for BoundExpression {
         &'a self,
         mut f: F,
     ) -> VortexResult<TraversalOrder> {
-        let BoundKind::Scalar { children, .. } = self.kind() else {
+        let BoundExpression::Scalar { children, .. } = self else {
             return Ok(TraversalOrder::Continue);
         };
 
@@ -552,7 +551,7 @@ impl Node for BoundExpression {
         self,
         mut f: F,
     ) -> VortexResult<Transformed<Self>> {
-        let BoundKind::Scalar { children, .. } = self.kind() else {
+        let BoundExpression::Scalar { children, .. } = &self else {
             return Ok(Transformed::no(self));
         };
 
@@ -583,16 +582,16 @@ impl Node for BoundExpression {
     }
 
     fn iter_children<T>(&self, f: impl FnOnce(&mut dyn Iterator<Item = &Self>) -> T) -> T {
-        match self.kind() {
-            BoundKind::Scalar { children, .. } => f(&mut children.iter()),
-            BoundKind::Root => f(&mut std::iter::empty()),
+        match self {
+            BoundExpression::Scalar { children, .. } => f(&mut children.iter()),
+            BoundExpression::Root { .. } => f(&mut std::iter::empty()),
         }
     }
 
     fn children_count(&self) -> usize {
-        match self.kind() {
-            BoundKind::Scalar { children, .. } => children.len(),
-            BoundKind::Root => 0,
+        match self {
+            BoundExpression::Scalar { children, .. } => children.len(),
+            BoundExpression::Root { .. } => 0,
         }
     }
 }

--- a/vortex-array/src/expr/traversal/mod.rs
+++ b/vortex-array/src/expr/traversal/mod.rs
@@ -584,14 +584,18 @@ impl Node for BoundExpression {
     fn iter_children<T>(&self, f: impl FnOnce(&mut dyn Iterator<Item = &Self>) -> T) -> T {
         match self {
             BoundExpression::Scalar { children, .. } => f(&mut children.iter()),
-            BoundExpression::Root { .. } => f(&mut std::iter::empty()),
+            BoundExpression::Lambda(lambda) => f(&mut std::iter::once(lambda.body())),
+            BoundExpression::Root { .. } | BoundExpression::Variable { .. } => {
+                f(&mut std::iter::empty())
+            }
         }
     }
 
     fn children_count(&self) -> usize {
         match self {
             BoundExpression::Scalar { children, .. } => children.len(),
-            BoundExpression::Root { .. } => 0,
+            BoundExpression::Lambda(_) => 1,
+            BoundExpression::Root { .. } | BoundExpression::Variable { .. } => 0,
         }
     }
 }

--- a/vortex-array/src/expr/variable.rs
+++ b/vortex-array/src/expr/variable.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::sync::Arc;
+
+/// The name of a value bound in a [`Scope`](crate::expr::Scope).
+///
+/// Deliberately distinct from [`FieldName`](crate::dtype::FieldName): a variable and a struct field
+/// live in different namespaces, and giving them the same type would let one be passed where the
+/// other is meant.
+///
+/// The same type is used in both positions a variable appears — as a parameter of
+/// [`Expression::Lambda`](crate::expr::Expression::Lambda), which introduces the name, and inside
+/// [`Expression::Variable`](crate::expr::Expression::Variable), which references it.
+#[derive(Clone, Debug)]
+pub struct Variable(Arc<str>);
+
+impl Variable {
+    /// Create a variable with the given name.
+    pub fn new(name: impl AsRef<str>) -> Self {
+        Self(Arc::from(name.as_ref()))
+    }
+
+    /// The variable's name.
+    pub fn name(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Compares by name, with a pointer-equality fast path for the common case of a cloned handle.
+impl PartialEq for Variable {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0) || self.0 == other.0
+    }
+}
+
+impl Eq for Variable {}
+
+impl Hash for Variable {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Hash the name, not the pointer, so equal names hash equally.
+        self.0.hash(state);
+    }
+}
+
+impl Display for Variable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<T: AsRef<str>> From<T> for Variable {
+    fn from(name: T) -> Self {
+        Self::new(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn equality_is_by_name_not_identity() {
+        let x1 = Variable::new("x");
+        let x2 = Variable::new("x");
+        let y = Variable::new("y");
+
+        // Independently constructed, so no shared allocation to short-circuit on.
+        assert_eq!(x1, x2);
+        assert_ne!(x1, y);
+    }
+
+    #[test]
+    fn equal_variables_hash_equally() {
+        use std::collections::hash_map::RandomState;
+        use std::hash::BuildHasher;
+
+        let state = RandomState::new();
+        assert_eq!(
+            state.hash_one(Variable::new("x")),
+            state.hash_one(Variable::new("x"))
+        );
+    }
+
+    #[test]
+    fn cloning_shares_the_name() {
+        let original = Variable::new("x");
+        let cloned = original.clone();
+        assert!(Arc::ptr_eq(&original.0, &cloned.0));
+    }
+}

--- a/vortex-array/src/expression.rs
+++ b/vortex-array/src/expression.rs
@@ -10,7 +10,6 @@ use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::ScalarFnArray;
 use crate::expr::BoundExpression;
-use crate::expr::BoundKind;
 use crate::expr::Expression;
 use crate::optimizer::ArrayOptimizer;
 use crate::scalar_fn::fns::literal::Literal;
@@ -18,10 +17,11 @@ use crate::scalar_fn::fns::literal::Literal;
 impl ArrayRef {
     /// Apply a bound expression to this array, producing a new array in constant time.
     pub fn apply_bound(self, expr: &BoundExpression) -> VortexResult<ArrayRef> {
-        let BoundKind::Scalar {
+        let BoundExpression::Scalar {
             scalar_fn,
             children,
-        } = expr.kind()
+            ..
+        } = expr
         else {
             return Ok(self);
         };

--- a/vortex-array/src/expression.rs
+++ b/vortex-array/src/expression.rs
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use itertools::Itertools;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 
 use crate::ArrayRef;
 use crate::IntoArray;
@@ -17,13 +17,22 @@ use crate::scalar_fn::fns::literal::Literal;
 impl ArrayRef {
     /// Apply a bound expression to this array, producing a new array in constant time.
     pub fn apply_bound(self, expr: &BoundExpression) -> VortexResult<ArrayRef> {
-        let BoundExpression::Scalar {
-            scalar_fn,
-            children,
-            ..
-        } = expr
-        else {
-            return Ok(self);
+        let (scalar_fn, children) = match expr {
+            // Root evaluates to the scope, which is this array.
+            BoundExpression::Root { .. } => return Ok(self),
+            // Execution has no variable environment, so a variable cannot be evaluated. It must be
+            // substituted by whatever bound it before the tree reaches the array layer.
+            BoundExpression::Variable { variable, .. } => vortex_bail!(
+                "cannot evaluate variable '{variable}': execution has no variable environment"
+            ),
+            BoundExpression::Lambda(lambda) => {
+                vortex_bail!("cannot evaluate a lambda ({lambda:?}); it must be applied first")
+            }
+            BoundExpression::Scalar {
+                scalar_fn,
+                children,
+                ..
+            } => (scalar_fn, children),
         };
 
         if let Some(scalar) = scalar_fn.as_opt::<Literal>() {
@@ -43,10 +52,17 @@ impl ArrayRef {
 
     /// Apply the expression to this array, producing a new array in constant time.
     pub fn apply(self, expr: &Expression) -> VortexResult<ArrayRef> {
-        // If the expression is a root, return self.
-        if expr.is_root() {
-            return Ok(self);
-        }
+        let scalar_fn = match expr {
+            // Root evaluates to the scope, which is this array.
+            Expression::Root => return Ok(self),
+            Expression::Variable(variable) => vortex_bail!(
+                "cannot evaluate variable '{variable}': execution has no variable environment"
+            ),
+            Expression::Lambda(lambda) => {
+                vortex_bail!("cannot evaluate a lambda ({lambda}); it must be applied first")
+            }
+            Expression::Scalar { scalar_fn, .. } => scalar_fn,
+        };
 
         // Manually convert literals to ConstantArray.
         if let Some(scalar) = expr.as_opt::<Literal>() {
@@ -59,11 +75,6 @@ impl ArrayRef {
             .iter()
             .map(|e| self.clone().apply(e))
             .try_collect()?;
-
-        // And wrap the scalar function up in an array.
-        let scalar_fn = expr
-            .as_scalar()
-            .vortex_expect("root and literal were handled above, so this is a scalar node");
         let array =
             ScalarFnArray::try_new_with_len(scalar_fn.clone(), children, self.len())?.into_array();
 

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -302,7 +302,9 @@ impl LayoutReader for ChunkedReader {
         mask: MaskFuture,
     ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
         if row_range.is_empty() {
-            return Ok(future::ready(Ok(Canonical::empty(expr.dtype()).into_array())).boxed());
+            return Ok(
+                future::ready(Ok(Canonical::empty(expr.value_dtype()?).into_array())).boxed(),
+            );
         }
 
         let mut chunk_evals = vec![];

--- a/vortex-layout/src/layouts/list/reader.rs
+++ b/vortex-layout/src/layouts/list/reader.rs
@@ -210,7 +210,7 @@ impl ListReader {
     ) -> VortexResult<ArrayFuture> {
         // Crop to the smallest contiguous row range containing every selected list.
         let Some(selected_rows) = selected_row_range(&mask) else {
-            let empty = Canonical::empty(expr.dtype()).into_array();
+            let empty = Canonical::empty(expr.value_dtype()?).into_array();
             return Ok(async move { Ok(empty) }.boxed());
         };
 

--- a/vortex-layout/src/layouts/partitioned.rs
+++ b/vortex-layout/src/layouts/partitioned.rs
@@ -54,7 +54,7 @@ impl<P: Send + Sync + 'static> BoundPartitionedExprEval<P> for BoundPartitionedE
             .zip_eq(self.partitions.iter())
             .map(|(annotation, expr)| {
                 Ok::<_, VortexError>(
-                    if matches!(expr.dtype(), DType::Bool(Nullability::NonNullable)) {
+                    if matches!(expr.dtype(), Some(DType::Bool(Nullability::NonNullable))) {
                         // If the partition evaluates to a boolean, we can evaluate it as a mask which
                         // can often be more efficient since nulls are turned into `false` early on,
                         // and layouts can perform predicate pruning / indexing.

--- a/vortex-layout/src/scan/filter.rs
+++ b/vortex-layout/src/scan/filter.rs
@@ -186,12 +186,12 @@ mod tests {
         assert_eq!(
             conjuncts
                 .iter()
-                .map(|expr| expr.dtype().clone())
+                .map(|expr| expr.dtype().cloned())
                 .collect::<Vec<_>>(),
             vec![
-                DType::Bool(Nullability::Nullable),
-                DType::Bool(Nullability::Nullable),
-                DType::Bool(Nullability::NonNullable),
+                Some(DType::Bool(Nullability::Nullable)),
+                Some(DType::Bool(Nullability::Nullable)),
+                Some(DType::Bool(Nullability::NonNullable)),
             ]
         );
         Ok(())


### PR DESCRIPTION
Adds lambdas and variables as `Expression` Variants and implements the scope machinery to bind them. 

```rust
/// A name bound in a scope.
pub struct Variable(Arc<str>);

/// A body evaluated under a frame binding `params`.
pub struct Lambda { params: Box<[Variable]>, body: Arc<Expression> }

pub enum Expression {
    Scalar { scalar_fn: ScalarFnRef, children: Arc<Vec<Expression>> },
    Root,
    Variable(Variable),
    Lambda(Lambda),
}

pub struct Scope { root: DType, frames: Vec<Frame> }   // Frame: [(Variable, DType)]
```

Binding:

```rust
expr.bind_scope(&scope)                      // errors on a lambda in a value position
lambda.bind(&scope, param_dtypes)            // -> BoundLambda
scope.push_frame(frame)                      // a caller can bind names without any binder node
```

## Design notes

**A lambda is bound by whoever knows its parameter types.** They come from whatever applies it, so
`Lambda::bind` takes them. That is the entry point a higher-order function will call with types
derived from its own arguments; here, tests call it directly.

**`BoundLambda` is a struct, not a `BoundKind` variant.** A lambda has no `DType`, and every
`BoundExpression` is guaranteed to have one. The function type is recorded structurally instead:
`param_dtypes` is the argument side, `body_dtype()` the result side.

**`Scope` carries frames, not a flat map.** A flat `name -> dtype` map cannot distinguish "this
binder's own parameter" from "a name from an enclosing binder", which is what a capture check needs.
`resolve` returns the dtype *and* the frame depth so that check is later a comparison rather than a
re-derivation.
