### PR TITLE
Avoid expanding unreferenced struct plan fields

### DIFF
--- a/vortex-layout/src/plan/plans/pack.rs
+++ b/vortex-layout/src/plan/plans/pack.rs
@@ -351,8 +351,7 @@ impl PlanParentReduceRule<Pack> for ExpressionPackRule {
                 .get(&ExactBoundExpr(expression.clone()))
                 .vortex_expect("Bound expression missing free-field annotations")
                 .clone();
-        let expanded_root = expanded_struct_root(child.dtype(), fields)?;
-        let expanded = expand_struct_root(expression.clone(), &expanded_root, fields)?;
+        let expanded = expand_struct_root(expression.clone(), fields)?;
         let partitioned =
             partition_bound(expanded.clone(), make_bound_free_field_annotator(fields))?;
 
@@ -540,14 +539,13 @@ fn is_identity_expression(expression: &BoundExpression, input_dtype: &DType) -> 
 
 fn expand_struct_root(
     expression: BoundExpression,
-    expanded_root: &BoundExpression,
     fields: &StructFields,
 ) -> VortexResult<BoundExpression> {
     Ok(expression
         .transform_down(|node| {
             if node.is_root() {
                 return Ok(Transformed {
-                    value: expanded_root.clone(),
+                    value: expanded_struct_root(node.dtype(), fields)?,
                     changed: true,
                     order: TraversalOrder::Skip,
                 });
@@ -564,28 +562,23 @@ fn expand_struct_root(
                 return Ok(Transformed::no(node));
             }
 
-            if let Some(field_name) = scalar_fn.as_opt::<GetItem>() {
-                let index = fields.find(field_name).ok_or_else(|| {
-                    vortex_err!("Field {field_name} not found while expanding struct root")
-                })?;
+            if scalar_fn.is::<GetItem>() {
                 return Ok(Transformed {
-                    value: expanded_root.children()[index].clone(),
-                    changed: true,
+                    value: node,
+                    changed: false,
                     order: TraversalOrder::Skip,
                 });
             }
 
             if let Some(selection) = scalar_fn.as_opt::<Select>() {
                 let names = selection.normalize_to_included_fields(fields.names())?;
+                let root = node.children()[0].clone();
                 let children = names
                     .iter()
                     .map(|name| {
-                        let index = fields
-                            .find(name)
-                            .vortex_expect("normalized selection fields must exist in the root");
-                        expanded_root.children()[index].clone()
+                        BoundExpression::try_new(GetItem.bind(name.clone()), [root.clone()])
                     })
-                    .collect();
+                    .collect::<VortexResult<Vec<_>>>()?;
                 return Ok(Transformed {
                     value: bound_pack(names, children)?,
                     changed: true,

--- a/vortex-layout/src/plan/tests.rs
+++ b/vortex-layout/src/plan/tests.rs
@@ -30,6 +30,8 @@ use vortex_array::expr::is_null;
 use vortex_array::expr::lit;
 use vortex_array::expr::pack;
 use vortex_array::expr::root;
+use vortex_array::expr::select;
+use vortex_array::expr::select_exclude;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 use vortex_io::runtime::single::block_on;
@@ -283,6 +285,72 @@ fn struct_plan_appends_validity_when_nullable() -> VortexResult<()> {
         child_of(&nullable_plan, 2)?.dtype(),
         &DType::Bool(Nullability::NonNullable)
     );
+    Ok(())
+}
+
+#[test]
+fn struct_select_preserves_struct_output() -> VortexResult<()> {
+    let field_dtype = primitive(PType::I32, Nullability::NonNullable);
+    let layout = StructLayout::new(
+        3,
+        DType::Struct(
+            StructFields::from_iter([("a", field_dtype.clone()), ("b", field_dtype.clone())]),
+            Nullability::NonNullable,
+        ),
+        vec![
+            flat(3, field_dtype.clone(), 0),
+            flat(3, field_dtype.clone(), 1),
+        ],
+    )
+    .into_layout();
+
+    let plan = make_eval(select(["a"], root()), make_plan(layout)?)?.into_plan();
+    let optimized = optimize(plan)?;
+
+    assert_eq!(
+        optimized.dtype(),
+        &DType::Struct(
+            StructFields::from_iter([("a", field_dtype)]),
+            Nullability::NonNullable,
+        )
+    );
+    insta::assert_snapshot!(optimized.display_tree(), @r"
+    root: vortex.plan.eval({a=i32}, rows=3) expr=pack(a: $)
+      child: vortex.plan.segment_scan(i32, rows=3)
+    ");
+    Ok(())
+}
+
+#[test]
+fn struct_select_exclude_preserves_struct_output() -> VortexResult<()> {
+    let field_dtype = primitive(PType::I32, Nullability::NonNullable);
+    let layout = StructLayout::new(
+        3,
+        DType::Struct(
+            StructFields::from_iter([("a", field_dtype.clone()), ("b", field_dtype.clone())]),
+            Nullability::NonNullable,
+        ),
+        vec![
+            flat(3, field_dtype.clone(), 0),
+            flat(3, field_dtype.clone(), 1),
+        ],
+    )
+    .into_layout();
+
+    let plan = make_eval(select_exclude(["b"], root()), make_plan(layout)?)?.into_plan();
+    let optimized = optimize(plan)?;
+
+    assert_eq!(
+        optimized.dtype(),
+        &DType::Struct(
+            StructFields::from_iter([("a", field_dtype)]),
+            Nullability::NonNullable,
+        )
+    );
+    insta::assert_snapshot!(optimized.display_tree(), @r"
+    root: vortex.plan.eval({a=i32}, rows=3) expr=pack(a: $)
+      child: vortex.plan.segment_scan(i32, rows=3)
+    ");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- keep direct bound `GetItem(root)` expressions intact when partitioning a struct plan
- expand `Select(root)` into only the selected fields
- expand every field only when an expression genuinely consumes the bare struct root
- preserve include/exclude projection semantics with focused plan snapshots

## Root cause

`ExpressionStructRule` eagerly built a bound pack containing every struct field before it knew
which fields the query referenced. On the 105-field ClickBench schema, every rule application
constructed 105 `GetItem` expressions. Binding each node resolved its return dtype, repeatedly
deserializing lazy field dtypes even for a one-column query.

The expression is already bound, and the bound field annotator can partition direct field access
without expanding it. This change only synthesizes field accesses where `Select` or a bare root
semantically requires them.

## Performance

The benchmark opens all 100 ClickBench Vortex shards, filters `AdvEngineID != 0`, projects
`AdvEngineID`, warms planning once, and reports the median of 25 complete planning passes.

| Stack | Planning | Prepared execution | Rows |
| --- | ---: | ---: | ---: |
| pre-`BoundExpression` stack | 8.28 ms | 46.14 ms | 630,500 |
| #9244 with bound plans | 7.36 ms | 45.91 ms | 630,500 |
| this PR | 2.46 ms | 46.46 ms | 630,500 |

This is a 66.6% planning reduction from the bound baseline and a 70.3% reduction from the original
stack. Execution is unchanged within run-to-run noise.

A matched Samply planning-only profile over 500 all-file passes reduced main-thread CPU from
8.22 s to 1.23 s. The previous hot stack through `BoundExpression::try_new`,
`GetItem::return_dtype`, and lazy dtype deserialization is absent after the change.

## Stack

This draft is stacked on #9244 and contains one signed commit.

## Validation

- `RUSTC_WRAPPER= cargo nextest run -p vortex-layout -p vortex-scan-v2` — 215 passed
- `RUSTC_WRAPPER= cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTC_WRAPPER= cargo test --doc -p vortex-layout -p vortex-scan-v2`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
