### PR TITLE
Build benchmarks with whole-program optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -409,9 +409,16 @@ debug = "full"
 inherits = "release"
 
 [profile.bench]
-codegen-units = 16
+# Benchmarks exist to attribute a change in measurement to a change in code, so they are built
+# whole-program. With `codegen-units = 16` and no LTO, adding unrelated code to a crate reshuffles
+# which functions share a codegen unit, which changes cross-unit inlining for functions whose
+# source did not change. That reports as a regression in code the branch never touched.
+#
+# `profile.release` deliberately keeps LTO off, because Vortex's performance must not depend on a
+# downstream crate enabling it. That argument is about shipped code and does not apply here.
+codegen-units = 1
 debug = "full"
-lto = false
+lto = true
 
 [profile.samply]
 inherits = "release"


### PR DESCRIPTION
## Rationale for this change

`profile.bench` builds with `codegen-units = 16` and no LTO. Under those settings, adding unrelated code to a crate reshuffles which functions share a codegen unit, and cross-unit inlining changes for functions whose source did not change. A benchmark moves without its code moving, which is indistinguishable from a real regression.

The effect is large enough to mislead a review. On [#9255](https://github.com/vortex-data/vortex/pull/9255), which adds a row scalar function framework to `vortex-array`, CodSpeed reported 14-16% regressions across `take_filter_list_*` and `list_sum_small`. None of those have a source change on that branch, and every `take_filter_primitive_*` benchmark held. `Cargo.lock` is identical and nothing was added to the session registry, so codegen-unit partitioning is what is left.

Benchmarks exist to attribute a change in measurement to a change in code. `codegen-units = 1` with fat LTO removes the variable.

## What changes are included in this PR?

One profile, two settings: `codegen-units = 16` to `1`, and `lto = false` to `true`.

## What APIs are changed? Are there any user-facing changes?

None. `profile.bench` affects `cargo bench` and `cargo codspeed build --profile bench` only.

## Notes

`profile.release` deliberately keeps LTO off, with a comment recording why: Vortex's performance must not depend on a downstream crate enabling it. That argument is about shipped code. It does not extend to a profile whose only job is measuring a diff, and the two profiles already disagree on `codegen-units`.

The trade-off is benchmark build time. Fat LTO over one codegen unit is materially slower than 16 parallel units, and every CodSpeed shard pays it.

Open question: is the noise this removes worth the CI time it costs, or is the better fix to keep the current profile and treat sub-20% moves in untouched code as unattributable?

Merging this invalidates comparison against any baseline built with the old settings. The first CodSpeed run on this PR compares a fat-LTO head against a `codegen-units = 16` base, so its numbers describe the profile change rather than any code change. Runs after it lands are the meaningful ones.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJog96aax87Cw18Pu7M3Rj)_