### PR TITLE
perf(sequence): build single-match bitmap directly

### DIFF
--- a/encodings/sequence/src/compute/compare.rs
+++ b/encodings/sequence/src/compute/compare.rs
@@ -14,7 +14,7 @@ use vortex_array::scalar::PValue;
 use vortex_array::scalar::Scalar;
 use vortex_array::scalar_fn::fns::binary::CompareKernel;
 use vortex_array::scalar_fn::fns::operators::CompareOperator;
-use vortex_buffer::BitBuffer;
+use vortex_buffer::BitBufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -56,7 +56,9 @@ impl CompareKernel for Sequence {
         };
 
         if let Ok(set_idx) = set_idx {
-            let buffer = BitBuffer::from_iter((0..lhs.len()).map(|idx| idx == set_idx));
+            let mut buffer = BitBufferMut::new_unset(lhs.len());
+            buffer.set(set_idx);
+            let buffer = buffer.freeze();
             Ok(Some(BoolArray::new(buffer, validity).into_array()))
         } else {
             Ok(Some(

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -4,7 +4,6 @@
 #![expect(clippy::unwrap_used)]
 #![expect(clippy::cast_possible_truncation)]
 
-use std::hint::black_box;
 use std::sync::LazyLock;
 
 use divan::Bencher;
@@ -41,7 +40,8 @@ use vortex::encodings::zigzag::zigzag_encode;
 use vortex::encodings::zstd::Zstd;
 use vortex::encodings::zstd::ZstdData;
 use vortex_array::VortexSessionExecute;
-use vortex_buffer::{BitBuffer, BitBufferMut};
+use vortex_buffer::BitBuffer;
+use vortex_buffer::BitBufferMut;
 use vortex_error::VortexResult;
 use vortex_sequence::Sequence;
 use vortex_session::VortexSession;
@@ -57,7 +57,6 @@ fn main() {
 }
 
 const NUM_VALUES: u64 = 100_000;
-const SEQUENCE_COMPARE_LENGTHS: [usize; 3] = [1_000, 100_000, 1_000_000];
 
 // Helper function to conditionally add counter based on codspeed cfg
 fn with_byte_counter<'a, 'b>(bencher: Bencher<'a, 'b>, bytes: u64) -> Bencher<'a, 'b> {
@@ -275,22 +274,22 @@ fn bench_sequence_decompress_u32(bencher: Bencher) {
         .bench_refs(|(a, ctx)| canonicalize((**a).clone(), ctx));
 }
 
-#[divan::bench(args = SEQUENCE_COMPARE_LENGTHS)]
-fn bench_sequence_compare_match_from_iter(bencher: Bencher, len: usize) {
-    let set_idx = len / 2;
-    bencher.bench(|| {
-        black_box(BitBuffer::from_iter((0..len).map(|idx| idx == set_idx)));
-    });
+#[divan::bench]
+fn bench_sequence_compare_match_from_iter(bencher: Bencher) {
+    bencher
+        .with_inputs(|| (NUM_VALUES as usize, NUM_VALUES as usize / 2))
+        .bench_values(|(len, set_idx)| BitBuffer::from_iter((0..len).map(|idx| idx == set_idx)));
 }
 
-#[divan::bench(args = SEQUENCE_COMPARE_LENGTHS)]
-fn bench_sequence_compare_match_single_set(bencher: Bencher, len: usize) {
-    let set_idx = len / 2;
-    bencher.bench(|| {
-        let mut buffer = BitBufferMut::new_unset(len);
-        buffer.set(set_idx);
-        black_box(buffer.freeze());
-    });
+#[divan::bench]
+fn bench_sequence_compare_match_single_set(bencher: Bencher) {
+    bencher
+        .with_inputs(|| (NUM_VALUES as usize, NUM_VALUES as usize / 2))
+        .bench_values(|(len, set_idx)| {
+            let mut buffer = BitBufferMut::new_unset(len);
+            buffer.set(set_idx);
+            buffer.freeze()
+        });
 }
 
 #[divan::bench(name = "alp_compress_f64")]

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -4,6 +4,7 @@
 #![expect(clippy::unwrap_used)]
 #![expect(clippy::cast_possible_truncation)]
 
+use std::hint::black_box;
 use std::sync::LazyLock;
 
 use divan::Bencher;
@@ -40,6 +41,7 @@ use vortex::encodings::zigzag::zigzag_encode;
 use vortex::encodings::zstd::Zstd;
 use vortex::encodings::zstd::ZstdData;
 use vortex_array::VortexSessionExecute;
+use vortex_buffer::{BitBuffer, BitBufferMut};
 use vortex_error::VortexResult;
 use vortex_sequence::Sequence;
 use vortex_session::VortexSession;
@@ -55,6 +57,7 @@ fn main() {
 }
 
 const NUM_VALUES: u64 = 100_000;
+const SEQUENCE_COMPARE_LENGTHS: [usize; 3] = [1_000, 100_000, 1_000_000];
 
 // Helper function to conditionally add counter based on codspeed cfg
 fn with_byte_counter<'a, 'b>(bencher: Bencher<'a, 'b>, bytes: u64) -> Bencher<'a, 'b> {
@@ -270,6 +273,24 @@ fn bench_sequence_decompress_u32(bencher: Bencher) {
     with_byte_counter(bencher, NUM_VALUES * 4)
         .with_inputs(|| (&compressed, SESSION.create_execution_ctx()))
         .bench_refs(|(a, ctx)| canonicalize((**a).clone(), ctx));
+}
+
+#[divan::bench(args = SEQUENCE_COMPARE_LENGTHS)]
+fn bench_sequence_compare_match_from_iter(bencher: Bencher, len: usize) {
+    let set_idx = len / 2;
+    bencher.bench(|| {
+        black_box(BitBuffer::from_iter((0..len).map(|idx| idx == set_idx)));
+    });
+}
+
+#[divan::bench(args = SEQUENCE_COMPARE_LENGTHS)]
+fn bench_sequence_compare_match_single_set(bencher: Bencher, len: usize) {
+    let set_idx = len / 2;
+    bencher.bench(|| {
+        let mut buffer = BitBufferMut::new_unset(len);
+        buffer.set(set_idx);
+        black_box(buffer.freeze());
+    });
 }
 
 #[divan::bench(name = "alp_compress_f64")]

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -4,6 +4,7 @@
 #![expect(clippy::unwrap_used)]
 #![expect(clippy::cast_possible_truncation)]
 
+use std::hint::black_box;
 use std::sync::LazyLock;
 
 use divan::Bencher;
@@ -40,8 +41,7 @@ use vortex::encodings::zigzag::zigzag_encode;
 use vortex::encodings::zstd::Zstd;
 use vortex::encodings::zstd::ZstdData;
 use vortex_array::VortexSessionExecute;
-use vortex_buffer::BitBuffer;
-use vortex_buffer::BitBufferMut;
+use vortex_buffer::{BitBuffer, BitBufferMut};
 use vortex_error::VortexResult;
 use vortex_sequence::Sequence;
 use vortex_session::VortexSession;
@@ -57,6 +57,7 @@ fn main() {
 }
 
 const NUM_VALUES: u64 = 100_000;
+const SEQUENCE_COMPARE_LENGTHS: [usize; 3] = [1_000, 100_000, 1_000_000];
 
 // Helper function to conditionally add counter based on codspeed cfg
 fn with_byte_counter<'a, 'b>(bencher: Bencher<'a, 'b>, bytes: u64) -> Bencher<'a, 'b> {
@@ -274,22 +275,22 @@ fn bench_sequence_decompress_u32(bencher: Bencher) {
         .bench_refs(|(a, ctx)| canonicalize((**a).clone(), ctx));
 }
 
-#[divan::bench]
-fn bench_sequence_compare_match_from_iter(bencher: Bencher) {
-    bencher
-        .with_inputs(|| (NUM_VALUES as usize, NUM_VALUES as usize / 2))
-        .bench_values(|(len, set_idx)| BitBuffer::from_iter((0..len).map(|idx| idx == set_idx)));
+#[divan::bench(args = SEQUENCE_COMPARE_LENGTHS)]
+fn bench_sequence_compare_match_from_iter(bencher: Bencher, len: usize) {
+    let set_idx = len / 2;
+    bencher.bench(|| {
+        black_box(BitBuffer::from_iter((0..len).map(|idx| idx == set_idx)));
+    });
 }
 
-#[divan::bench]
-fn bench_sequence_compare_match_single_set(bencher: Bencher) {
-    bencher
-        .with_inputs(|| (NUM_VALUES as usize, NUM_VALUES as usize / 2))
-        .bench_values(|(len, set_idx)| {
-            let mut buffer = BitBufferMut::new_unset(len);
-            buffer.set(set_idx);
-            buffer.freeze()
-        });
+#[divan::bench(args = SEQUENCE_COMPARE_LENGTHS)]
+fn bench_sequence_compare_match_single_set(bencher: Bencher, len: usize) {
+    let set_idx = len / 2;
+    bencher.bench(|| {
+        let mut buffer = BitBufferMut::new_unset(len);
+        buffer.set(set_idx);
+        black_box(buffer.freeze());
+    });
 }
 
 #[divan::bench(name = "alp_compress_f64")]

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -4,7 +4,6 @@
 #![expect(clippy::unwrap_used)]
 #![expect(clippy::cast_possible_truncation)]
 
-use std::hint::black_box;
 use std::sync::LazyLock;
 
 use divan::Bencher;
@@ -41,7 +40,6 @@ use vortex::encodings::zigzag::zigzag_encode;
 use vortex::encodings::zstd::Zstd;
 use vortex::encodings::zstd::ZstdData;
 use vortex_array::VortexSessionExecute;
-use vortex_buffer::{BitBuffer, BitBufferMut};
 use vortex_error::VortexResult;
 use vortex_sequence::Sequence;
 use vortex_session::VortexSession;
@@ -57,8 +55,6 @@ fn main() {
 }
 
 const NUM_VALUES: u64 = 100_000;
-const SEQUENCE_COMPARE_LENGTHS: [usize; 3] = [1_000, 100_000, 1_000_000];
-
 // Helper function to conditionally add counter based on codspeed cfg
 fn with_byte_counter<'a, 'b>(bencher: Bencher<'a, 'b>, bytes: u64) -> Bencher<'a, 'b> {
     #[cfg(not(codspeed))]
@@ -273,24 +269,6 @@ fn bench_sequence_decompress_u32(bencher: Bencher) {
     with_byte_counter(bencher, NUM_VALUES * 4)
         .with_inputs(|| (&compressed, SESSION.create_execution_ctx()))
         .bench_refs(|(a, ctx)| canonicalize((**a).clone(), ctx));
-}
-
-#[divan::bench(args = SEQUENCE_COMPARE_LENGTHS)]
-fn bench_sequence_compare_match_from_iter(bencher: Bencher, len: usize) {
-    let set_idx = len / 2;
-    bencher.bench(|| {
-        black_box(BitBuffer::from_iter((0..len).map(|idx| idx == set_idx)));
-    });
-}
-
-#[divan::bench(args = SEQUENCE_COMPARE_LENGTHS)]
-fn bench_sequence_compare_match_single_set(bencher: Bencher, len: usize) {
-    let set_idx = len / 2;
-    bencher.bench(|| {
-        let mut buffer = BitBufferMut::new_unset(len);
-        buffer.set(set_idx);
-        black_box(buffer.freeze());
-    });
 }
 
 #[divan::bench(name = "alp_compress_f64")]

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -55,6 +55,7 @@ fn main() {
 }
 
 const NUM_VALUES: u64 = 100_000;
+
 // Helper function to conditionally add counter based on codspeed cfg
 fn with_byte_counter<'a, 'b>(bencher: Bencher<'a, 'b>, bytes: u64) -> Bencher<'a, 'b> {
     #[cfg(not(codspeed))]


### PR DESCRIPTION
## Summary

The sequence equality kernel knows that a match bitmap contains exactly one set bit, but it currently evaluates a predicate for every row to build that bitmap. This change allocates an unset `BitBufferMut`, sets the known match index, and freezes it. The PR stays limited to the production comparison path after removing unrelated benchmark-harness edits.

## Testing

- `rustfmt` on `encodings/sequence/src/compute/compare.rs`
- `git diff --check`
- Focused `cargo test -p vortex-sequence --lib --no-default-features compute::compare::tests` was attempted twice but could not complete because the shallow checkout needs the uncached `tpchgen` Git dependency.

## AI assistance

This PR was prepared with agentic AI assistance. I inspected the issue and surrounding implementation, kept the change scoped to the requested path, and recorded the local validation limitation above.

Fixes #9092
