### PR TITLE
Add split-collection benchmark for scan planning

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { shard: 1, name: "Core foundation", packages: "vortex-buffer vortex-error vortex-mask vortex-compute" }
+          - { shard: 1, name: "Core foundation", packages: "vortex-buffer vortex-error vortex-mask vortex-compute vortex-file" }
           - { shard: 2, name: "Arrays", packages: "vortex-array", features: "--features _test-harness" }
           - { shard: 3, name: "Main library", packages: "vortex" }
           - { shard: 4, name: "Encodings 1", packages: "vortex-alp vortex-bytebool vortex-datetime-parts" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10110,6 +10110,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "codspeed-divan-compat",
  "flatbuffers",
  "futures",
  "itertools 0.14.0",

--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -61,6 +61,7 @@ vortex-zigzag = { workspace = true }
 vortex-zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
+divan = { workspace = true }
 rstest = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 vortex-array = { workspace = true, features = ["_test-harness"] }
@@ -70,6 +71,10 @@ vortex-scan = { workspace = true }
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "split_collection"
+harness = false
 
 [features]
 object_store = ["dep:object_store", "vortex-io/object_store", "tokio"]

--- a/vortex-file/benches/split_collection.rs
+++ b/vortex-file/benches/split_collection.rs
@@ -147,8 +147,7 @@ fn misaligned_block_len(column: usize) -> usize {
 /// boundaries never align across columns: run deduplication in split collection cannot collapse
 /// them, exercising the sort fallback.
 fn make_misaligned_file(columns: usize, chunks: usize) -> VortexFile {
-    let mean_block_len =
-        (0..columns).map(misaligned_block_len).sum::<usize>() / columns.max(1);
+    let mean_block_len = (0..columns).map(misaligned_block_len).sum::<usize>() / columns.max(1);
     let rows = chunks * mean_block_len;
 
     let fields = (0..columns)
@@ -177,10 +176,7 @@ fn make_misaligned_file(columns: usize, chunks: usize) -> VortexFile {
                 canonicalize: false,
             },
         );
-        strategy = strategy.with_field_writer(
-            Field::from(name.as_str()),
-            Arc::new(field_strategy),
-        );
+        strategy = strategy.with_field_writer(Field::from(name.as_str()), Arc::new(field_strategy));
     }
 
     let mut buf = ByteBufferMut::empty();

--- a/vortex-file/benches/split_collection.rs
+++ b/vortex-file/benches/split_collection.rs
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Benchmarks scan split collection (`SplitBy::Layout`) over written files.
+//!
+//! The default write strategy produces `struct -> zoned -> chunked -> flat` per column, so
+//! split collection walks every chunk of every column. `cold` builds a fresh reader tree per
+//! iteration (as a first scan over a file would); `warm` reuses the reader tree so lazily
+//! cached child readers persist across iterations.
+
+#![expect(clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::sync::LazyLock;
+
+use divan::Bencher;
+use vortex_array::IntoArray;
+use vortex_array::arrays::ChunkedArray;
+use vortex_array::arrays::StructArray;
+use vortex_array::dtype::Field;
+use vortex_array::dtype::FieldMask;
+use vortex_array::dtype::FieldPath;
+use vortex_array::session::ArraySessionExt;
+use vortex_buffer::Buffer;
+use vortex_buffer::ByteBufferMut;
+use vortex_edition::Edition;
+use vortex_edition::EditionId;
+use vortex_edition::EditionInclusion;
+use vortex_edition::EditionSessionExt;
+use vortex_file::OpenOptionsSessionExt;
+use vortex_file::VortexFile;
+use vortex_file::WriteOptionsSessionExt;
+use vortex_io::session::RuntimeSession;
+use vortex_io::session::RuntimeSessionExt;
+use vortex_layout::layouts::chunked::writer::ChunkedLayoutStrategy;
+use vortex_layout::layouts::flat::writer::FlatLayoutStrategy;
+use vortex_layout::layouts::repartition::RepartitionStrategy;
+use vortex_layout::layouts::repartition::RepartitionWriterOptions;
+use vortex_layout::scan::split_by::SplitBy;
+use vortex_layout::session::LayoutSession;
+use vortex_session::VortexSession;
+use vortex_utils::aliases::hash_map::HashMap;
+
+fn main() {
+    divan::main();
+}
+
+const ROWS_PER_CHUNK: usize = 1024;
+
+/// (columns, chunks) configurations.
+const CONFIGS: &[(usize, usize)] = &[(1, 1024), (8, 256), (64, 256)];
+
+static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+});
+
+static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
+    let _guard = RUNTIME.enter();
+    let session = vortex_array::array_session()
+        .with::<LayoutSession>()
+        .with::<RuntimeSession>()
+        .with_tokio();
+    vortex_file::register_default_encodings(&session);
+    enable_all_registered_array_encodings(&session);
+    session
+});
+
+const BENCH_EDITION: EditionId = EditionId::new("bench", 2026, 8, 0);
+
+fn enable_all_registered_array_encodings(session: &VortexSession) {
+    let editions = session.editions();
+    editions
+        .declare_edition(Edition {
+            id: BENCH_EDITION,
+            min_vortex_version: None,
+        })
+        .unwrap();
+    let ids = session
+        .arrays()
+        .registry()
+        .read(|map| map.keys().copied().collect::<Vec<_>>());
+    for id in ids {
+        editions
+            .declare_inclusion(EditionInclusion::new(&id, BENCH_EDITION))
+            .unwrap();
+    }
+    session.enable_edition(BENCH_EDITION).unwrap();
+}
+
+fn make_file(columns: usize, chunks: usize) -> VortexFile {
+    let field_names = (0..columns).map(|c| format!("col_{c}")).collect::<Vec<_>>();
+    let struct_chunks = (0..chunks)
+        .map(|chunk| {
+            let fields = field_names
+                .iter()
+                .map(|name| {
+                    let start = (chunk * ROWS_PER_CHUNK) as i64;
+                    let values =
+                        Buffer::from_iter(start..start + ROWS_PER_CHUNK as i64).into_array();
+                    (name.as_str(), values)
+                })
+                .collect::<Vec<_>>();
+            StructArray::from_fields(&fields).unwrap().into_array()
+        })
+        .collect::<Vec<_>>();
+    let array = ChunkedArray::from_iter(struct_chunks).into_array();
+
+    let strategy = vortex_file::WriteStrategyBuilder::default()
+        .with_row_block_size(ROWS_PER_CHUNK)
+        .with_data_block_target_bytes(None)
+        .build();
+
+    let mut buf = ByteBufferMut::empty();
+    RUNTIME
+        .block_on(
+            SESSION
+                .write_options()
+                .with_strategy(strategy)
+                .write(&mut buf, array.to_array_stream()),
+        )
+        .unwrap();
+
+    SESSION.open_options().open_buffer(buf).unwrap()
+}
+
+static FILES: LazyLock<HashMap<(usize, usize), VortexFile>> = LazyLock::new(|| {
+    CONFIGS
+        .iter()
+        .map(|&(columns, chunks)| ((columns, chunks), make_file(columns, chunks)))
+        .collect()
+});
+
+/// (columns, average chunks per column) for the misaligned files. A single column cannot be
+/// misaligned, so only multi-column configs are used.
+const MISALIGNED_CONFIGS: &[(usize, usize)] = &[(8, 256), (64, 256)];
+
+/// Per-column repartition block length: all distinct, so no two columns share interior chunk
+/// boundaries. Mirrors real files where byte-size coalescing gives each column its own chunking.
+fn misaligned_block_len(column: usize) -> usize {
+    384 + column * 8
+}
+
+/// Like [`make_file`], but each column is chunked at a different row granularity so chunk
+/// boundaries never align across columns: run deduplication in split collection cannot collapse
+/// them, exercising the sort fallback.
+fn make_misaligned_file(columns: usize, chunks: usize) -> VortexFile {
+    let mean_block_len =
+        (0..columns).map(misaligned_block_len).sum::<usize>() / columns.max(1);
+    let rows = chunks * mean_block_len;
+
+    let fields = (0..columns)
+        .map(|c| {
+            let values = Buffer::from_iter(0..rows as i64).into_array();
+            (format!("col_{c}"), values)
+        })
+        .collect::<Vec<_>>();
+    let array = StructArray::from_fields(
+        &fields
+            .iter()
+            .map(|(name, values)| (name.as_str(), values.clone()))
+            .collect::<Vec<_>>(),
+    )
+    .unwrap()
+    .into_array();
+
+    let mut strategy = vortex_file::WriteStrategyBuilder::default();
+    for (c, (name, _)) in fields.iter().enumerate() {
+        let field_strategy = RepartitionStrategy::new(
+            ChunkedLayoutStrategy::new(FlatLayoutStrategy::default()),
+            RepartitionWriterOptions {
+                block_size_minimum: 0,
+                block_len_multiple: misaligned_block_len(c),
+                block_size_target: None,
+                canonicalize: false,
+            },
+        );
+        strategy = strategy.with_field_writer(
+            Field::from(name.as_str()),
+            Arc::new(field_strategy),
+        );
+    }
+
+    let mut buf = ByteBufferMut::empty();
+    RUNTIME
+        .block_on(
+            SESSION
+                .write_options()
+                .with_strategy(strategy.build())
+                .write(&mut buf, array.to_array_stream()),
+        )
+        .unwrap();
+
+    SESSION.open_options().open_buffer(buf).unwrap()
+}
+
+static MISALIGNED_FILES: LazyLock<HashMap<(usize, usize), VortexFile>> = LazyLock::new(|| {
+    MISALIGNED_CONFIGS
+        .iter()
+        .map(|&(columns, chunks)| ((columns, chunks), make_misaligned_file(columns, chunks)))
+        .collect()
+});
+
+fn collect_splits(file: &VortexFile) -> Vec<u64> {
+    let reader = file.layout_reader().unwrap();
+    SplitBy::Layout
+        .splits(reader.as_ref(), &(0..file.row_count()), &[FieldMask::All])
+        .unwrap()
+}
+
+/// Builds a fresh reader tree per iteration, so split collection pays child reader
+/// construction for every chunk of every column, like the first scan over a file.
+#[divan::bench(args = CONFIGS)]
+fn cold(bencher: Bencher, config: &(usize, usize)) {
+    let file = &FILES[config];
+    // Sanity-check the written chunk structure once per config.
+    let n_splits = collect_splits(file).len();
+    assert!(
+        n_splits > config.1 / 2,
+        "expected roughly one split per chunk, got {n_splits} splits for {} chunks",
+        config.1
+    );
+
+    bencher.bench(|| collect_splits(file));
+}
+
+/// Reuses the reader tree across iterations, so lazily constructed child readers are cached
+/// and split collection measures only the layout walk.
+#[divan::bench(args = CONFIGS)]
+fn warm(bencher: Bencher, config: &(usize, usize)) {
+    let file = &FILES[config];
+    let reader = file.layout_reader().unwrap();
+    let row_count = file.row_count();
+
+    bencher.bench(|| {
+        SplitBy::Layout
+            .splits(reader.as_ref(), &(0..row_count), &[FieldMask::All])
+            .unwrap()
+    });
+}
+
+/// Like `cold`, but over a file whose columns share no interior chunk boundaries, so the split
+/// set cannot be collapsed by run deduplication and must be sorted.
+#[divan::bench(args = MISALIGNED_CONFIGS)]
+fn cold_misaligned(bencher: Bencher, config: &(usize, usize)) {
+    let file = &MISALIGNED_FILES[config];
+    // Sanity-check the misalignment once per config: boundaries should be mostly distinct
+    // across columns, i.e. roughly columns × chunks in total.
+    let n_splits = collect_splits(file).len();
+    assert!(
+        n_splits > config.0 * config.1 / 2,
+        "expected mostly-distinct boundaries, got {n_splits} splits for {} columns x {} chunks",
+        config.0,
+        config.1,
+    );
+
+    bencher.bench(|| collect_splits(file));
+}
+
+/// Like `warm`, but over a file whose columns share no interior chunk boundaries.
+#[divan::bench(args = MISALIGNED_CONFIGS)]
+fn warm_misaligned(bencher: Bencher, config: &(usize, usize)) {
+    let file = &MISALIGNED_FILES[config];
+    let reader = file.layout_reader().unwrap();
+    let row_count = file.row_count();
+
+    bencher.bench(|| {
+        SplitBy::Layout
+            .splits(reader.as_ref(), &(0..row_count), &[FieldMask::All])
+            .unwrap()
+    });
+}
+
+/// Fresh reader tree per iteration and a narrow field mask: split collection should only pay
+/// for the projected column, not the full schema width.
+#[divan::bench(args = CONFIGS)]
+fn cold_single_column(bencher: Bencher, config: &(usize, usize)) {
+    let file = &FILES[config];
+    let mask = [FieldMask::Prefix(FieldPath::from(Field::from("col_0")))];
+    let row_count = file.row_count();
+
+    bencher.bench(|| {
+        let reader = file.layout_reader().unwrap();
+        SplitBy::Layout
+            .splits(reader.as_ref(), &(0..row_count), &mask)
+            .unwrap()
+    });
+}


### PR DESCRIPTION
## Rationale for this change

Benchmarks SplitBy::Layout over written files (struct -> chunked -> flat per column) across column and chunk counts:

- cold: fresh reader tree per iteration, as the first scan over a file
- warm: reused reader tree
- cold_single_column: narrow field mask over a wide schema
- {cold,warm}_misaligned: per-column chunk granularities so no two columns share interior chunk boundaries
