### PR TITLE
Skip materializing splitless chunk children during split collection

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { shard: 1, name: "Core foundation", packages: "vortex-buffer vortex-error vortex-mask vortex-compute" }
+          - { shard: 1, name: "Core foundation", packages: "vortex-buffer vortex-error vortex-mask vortex-compute vortex-file" }
           - { shard: 2, name: "Arrays", packages: "vortex-array", features: "--features _test-harness" }
           - { shard: 3, name: "Main library", packages: "vortex" }
           - { shard: 4, name: "Encodings 1", packages: "vortex-alp vortex-bytebool vortex-datetime-parts" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10110,6 +10110,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "codspeed-divan-compat",
  "flatbuffers",
  "futures",
  "itertools 0.14.0",

--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -61,6 +61,7 @@ vortex-zigzag = { workspace = true }
 vortex-zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
+divan = { workspace = true }
 rstest = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 vortex-array = { workspace = true, features = ["_test-harness"] }
@@ -70,6 +71,10 @@ vortex-scan = { workspace = true }
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "split_collection"
+harness = false
 
 [features]
 object_store = ["dep:object_store", "vortex-io/object_store", "tokio"]

--- a/vortex-file/benches/split_collection.rs
+++ b/vortex-file/benches/split_collection.rs
@@ -6,7 +6,9 @@
 //! The default write strategy produces `struct -> zoned -> chunked -> flat` per column, so
 //! split collection walks every chunk of every column. `cold` builds a fresh reader tree per
 //! iteration (as a first scan over a file would); `warm` reuses the reader tree so lazily
-//! cached child readers persist across iterations.
+//! cached child readers persist across iterations. `cold_misaligned` scans a file whose
+//! columns share no interior chunk boundaries, so the split set cannot be collapsed by run
+//! deduplication.
 
 #![expect(clippy::unwrap_used)]
 
@@ -19,7 +21,6 @@ use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::StructArray;
 use vortex_array::dtype::Field;
 use vortex_array::dtype::FieldMask;
-use vortex_array::dtype::FieldPath;
 use vortex_array::session::ArraySessionExt;
 use vortex_buffer::Buffer;
 use vortex_buffer::ByteBufferMut;
@@ -48,7 +49,7 @@ fn main() {
 const ROWS_PER_CHUNK: usize = 1024;
 
 /// (columns, chunks) configurations.
-const CONFIGS: &[(usize, usize)] = &[(1, 1024), (8, 256), (64, 256)];
+const CONFIGS: &[(usize, usize)] = &[(64, 256)];
 
 static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     tokio::runtime::Builder::new_current_thread()
@@ -135,7 +136,7 @@ static FILES: LazyLock<HashMap<(usize, usize), VortexFile>> = LazyLock::new(|| {
 
 /// (columns, average chunks per column) for the misaligned files. A single column cannot be
 /// misaligned, so only multi-column configs are used.
-const MISALIGNED_CONFIGS: &[(usize, usize)] = &[(8, 256), (64, 256)];
+const MISALIGNED_CONFIGS: &[(usize, usize)] = &[(64, 256)];
 
 /// Per-column repartition block length: all distinct, so no two columns share interior chunk
 /// boundaries. Mirrors real files where byte-size coalescing gives each column its own chunking.
@@ -253,34 +254,4 @@ fn cold_misaligned(bencher: Bencher, config: &(usize, usize)) {
     );
 
     bencher.bench(|| collect_splits(file));
-}
-
-/// Like `warm`, but over a file whose columns share no interior chunk boundaries.
-#[divan::bench(args = MISALIGNED_CONFIGS)]
-fn warm_misaligned(bencher: Bencher, config: &(usize, usize)) {
-    let file = &MISALIGNED_FILES[config];
-    let reader = file.layout_reader().unwrap();
-    let row_count = file.row_count();
-
-    bencher.bench(|| {
-        SplitBy::Layout
-            .splits(reader.as_ref(), &(0..row_count), &[FieldMask::All])
-            .unwrap()
-    });
-}
-
-/// Fresh reader tree per iteration and a narrow field mask: split collection should only pay
-/// for the projected column, not the full schema width.
-#[divan::bench(args = CONFIGS)]
-fn cold_single_column(bencher: Bencher, config: &(usize, usize)) {
-    let file = &FILES[config];
-    let mask = [FieldMask::Prefix(FieldPath::from(Field::from("col_0")))];
-    let row_count = file.row_count();
-
-    bencher.bench(|| {
-        let reader = file.layout_reader().unwrap();
-        SplitBy::Layout
-            .splits(reader.as_ref(), &(0..row_count), &mask)
-            .unwrap()
-    });
 }

--- a/vortex-file/benches/split_collection.rs
+++ b/vortex-file/benches/split_collection.rs
@@ -147,8 +147,7 @@ fn misaligned_block_len(column: usize) -> usize {
 /// boundaries never align across columns: run deduplication in split collection cannot collapse
 /// them, exercising the sort fallback.
 fn make_misaligned_file(columns: usize, chunks: usize) -> VortexFile {
-    let mean_block_len =
-        (0..columns).map(misaligned_block_len).sum::<usize>() / columns.max(1);
+    let mean_block_len = (0..columns).map(misaligned_block_len).sum::<usize>() / columns.max(1);
     let rows = chunks * mean_block_len;
 
     let fields = (0..columns)
@@ -177,10 +176,7 @@ fn make_misaligned_file(columns: usize, chunks: usize) -> VortexFile {
                 canonicalize: false,
             },
         );
-        strategy = strategy.with_field_writer(
-            Field::from(name.as_str()),
-            Arc::new(field_strategy),
-        );
+        strategy = strategy.with_field_writer(Field::from(name.as_str()), Arc::new(field_strategy));
     }
 
     let mut buf = ByteBufferMut::empty();

--- a/vortex-file/benches/split_collection.rs
+++ b/vortex-file/benches/split_collection.rs
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Benchmarks scan split collection (`SplitBy::Layout`) over written files.
+//!
+//! The default write strategy produces `struct -> zoned -> chunked -> flat` per column, so
+//! split collection walks every chunk of every column. `cold` builds a fresh reader tree per
+//! iteration (as a first scan over a file would); `warm` reuses the reader tree so lazily
+//! cached child readers persist across iterations.
+
+#![expect(clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::sync::LazyLock;
+
+use divan::Bencher;
+use vortex_array::IntoArray;
+use vortex_array::arrays::ChunkedArray;
+use vortex_array::arrays::StructArray;
+use vortex_array::dtype::Field;
+use vortex_array::dtype::FieldMask;
+use vortex_array::dtype::FieldPath;
+use vortex_array::session::ArraySessionExt;
+use vortex_buffer::Buffer;
+use vortex_buffer::ByteBufferMut;
+use vortex_edition::Edition;
+use vortex_edition::EditionId;
+use vortex_edition::EditionInclusion;
+use vortex_edition::EditionSessionExt;
+use vortex_file::OpenOptionsSessionExt;
+use vortex_file::VortexFile;
+use vortex_file::WriteOptionsSessionExt;
+use vortex_io::session::RuntimeSession;
+use vortex_io::session::RuntimeSessionExt;
+use vortex_layout::layouts::chunked::writer::ChunkedLayoutStrategy;
+use vortex_layout::layouts::flat::writer::FlatLayoutStrategy;
+use vortex_layout::layouts::repartition::RepartitionStrategy;
+use vortex_layout::layouts::repartition::RepartitionWriterOptions;
+use vortex_layout::scan::split_by::SplitBy;
+use vortex_layout::session::LayoutSession;
+use vortex_session::VortexSession;
+use vortex_utils::aliases::hash_map::HashMap;
+
+fn main() {
+    divan::main();
+}
+
+const ROWS_PER_CHUNK: usize = 1024;
+
+/// (columns, chunks) configurations.
+const CONFIGS: &[(usize, usize)] = &[(1, 1024), (8, 256), (64, 256)];
+
+static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+});
+
+static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
+    let _guard = RUNTIME.enter();
+    let session = vortex_array::array_session()
+        .with::<LayoutSession>()
+        .with::<RuntimeSession>()
+        .with_tokio();
+    vortex_file::register_default_encodings(&session);
+    enable_all_registered_array_encodings(&session);
+    session
+});
+
+const BENCH_EDITION: EditionId = EditionId::new("bench", 2026, 8, 0);
+
+fn enable_all_registered_array_encodings(session: &VortexSession) {
+    let editions = session.editions();
+    editions
+        .declare_edition(Edition {
+            id: BENCH_EDITION,
+            min_vortex_version: None,
+        })
+        .unwrap();
+    let ids = session
+        .arrays()
+        .registry()
+        .read(|map| map.keys().copied().collect::<Vec<_>>());
+    for id in ids {
+        editions
+            .declare_inclusion(EditionInclusion::new(&id, BENCH_EDITION))
+            .unwrap();
+    }
+    session.enable_edition(BENCH_EDITION).unwrap();
+}
+
+fn make_file(columns: usize, chunks: usize) -> VortexFile {
+    let field_names = (0..columns).map(|c| format!("col_{c}")).collect::<Vec<_>>();
+    let struct_chunks = (0..chunks)
+        .map(|chunk| {
+            let fields = field_names
+                .iter()
+                .map(|name| {
+                    let start = (chunk * ROWS_PER_CHUNK) as i64;
+                    let values =
+                        Buffer::from_iter(start..start + ROWS_PER_CHUNK as i64).into_array();
+                    (name.as_str(), values)
+                })
+                .collect::<Vec<_>>();
+            StructArray::from_fields(&fields).unwrap().into_array()
+        })
+        .collect::<Vec<_>>();
+    let array = ChunkedArray::from_iter(struct_chunks).into_array();
+
+    let strategy = vortex_file::WriteStrategyBuilder::default()
+        .with_row_block_size(ROWS_PER_CHUNK)
+        .with_data_block_target_bytes(None)
+        .build();
+
+    let mut buf = ByteBufferMut::empty();
+    RUNTIME
+        .block_on(
+            SESSION
+                .write_options()
+                .with_strategy(strategy)
+                .write(&mut buf, array.to_array_stream()),
+        )
+        .unwrap();
+
+    SESSION.open_options().open_buffer(buf).unwrap()
+}
+
+static FILES: LazyLock<HashMap<(usize, usize), VortexFile>> = LazyLock::new(|| {
+    CONFIGS
+        .iter()
+        .map(|&(columns, chunks)| ((columns, chunks), make_file(columns, chunks)))
+        .collect()
+});
+
+/// (columns, average chunks per column) for the misaligned files. A single column cannot be
+/// misaligned, so only multi-column configs are used.
+const MISALIGNED_CONFIGS: &[(usize, usize)] = &[(8, 256), (64, 256)];
+
+/// Per-column repartition block length: all distinct, so no two columns share interior chunk
+/// boundaries. Mirrors real files where byte-size coalescing gives each column its own chunking.
+fn misaligned_block_len(column: usize) -> usize {
+    384 + column * 8
+}
+
+/// Like [`make_file`], but each column is chunked at a different row granularity so chunk
+/// boundaries never align across columns: run deduplication in split collection cannot collapse
+/// them, exercising the sort fallback.
+fn make_misaligned_file(columns: usize, chunks: usize) -> VortexFile {
+    let mean_block_len =
+        (0..columns).map(misaligned_block_len).sum::<usize>() / columns.max(1);
+    let rows = chunks * mean_block_len;
+
+    let fields = (0..columns)
+        .map(|c| {
+            let values = Buffer::from_iter(0..rows as i64).into_array();
+            (format!("col_{c}"), values)
+        })
+        .collect::<Vec<_>>();
+    let array = StructArray::from_fields(
+        &fields
+            .iter()
+            .map(|(name, values)| (name.as_str(), values.clone()))
+            .collect::<Vec<_>>(),
+    )
+    .unwrap()
+    .into_array();
+
+    let mut strategy = vortex_file::WriteStrategyBuilder::default();
+    for (c, (name, _)) in fields.iter().enumerate() {
+        let field_strategy = RepartitionStrategy::new(
+            ChunkedLayoutStrategy::new(FlatLayoutStrategy::default()),
+            RepartitionWriterOptions {
+                block_size_minimum: 0,
+                block_len_multiple: misaligned_block_len(c),
+                block_size_target: None,
+                canonicalize: false,
+            },
+        );
+        strategy = strategy.with_field_writer(
+            Field::from(name.as_str()),
+            Arc::new(field_strategy),
+        );
+    }
+
+    let mut buf = ByteBufferMut::empty();
+    RUNTIME
+        .block_on(
+            SESSION
+                .write_options()
+                .with_strategy(strategy.build())
+                .write(&mut buf, array.to_array_stream()),
+        )
+        .unwrap();
+
+    SESSION.open_options().open_buffer(buf).unwrap()
+}
+
+static MISALIGNED_FILES: LazyLock<HashMap<(usize, usize), VortexFile>> = LazyLock::new(|| {
+    MISALIGNED_CONFIGS
+        .iter()
+        .map(|&(columns, chunks)| ((columns, chunks), make_misaligned_file(columns, chunks)))
+        .collect()
+});
+
+fn collect_splits(file: &VortexFile) -> Vec<u64> {
+    let reader = file.layout_reader().unwrap();
+    SplitBy::Layout
+        .splits(reader.as_ref(), &(0..file.row_count()), &[FieldMask::All])
+        .unwrap()
+}
+
+/// Builds a fresh reader tree per iteration, so split collection pays child reader
+/// construction for every chunk of every column, like the first scan over a file.
+#[divan::bench(args = CONFIGS)]
+fn cold(bencher: Bencher, config: &(usize, usize)) {
+    let file = &FILES[config];
+    // Sanity-check the written chunk structure once per config.
+    let n_splits = collect_splits(file).len();
+    assert!(
+        n_splits > config.1 / 2,
+        "expected roughly one split per chunk, got {n_splits} splits for {} chunks",
+        config.1
+    );
+
+    bencher.bench(|| collect_splits(file));
+}
+
+/// Reuses the reader tree across iterations, so lazily constructed child readers are cached
+/// and split collection measures only the layout walk.
+#[divan::bench(args = CONFIGS)]
+fn warm(bencher: Bencher, config: &(usize, usize)) {
+    let file = &FILES[config];
+    let reader = file.layout_reader().unwrap();
+    let row_count = file.row_count();
+
+    bencher.bench(|| {
+        SplitBy::Layout
+            .splits(reader.as_ref(), &(0..row_count), &[FieldMask::All])
+            .unwrap()
+    });
+}
+
+/// Like `cold`, but over a file whose columns share no interior chunk boundaries, so the split
+/// set cannot be collapsed by run deduplication and must be sorted.
+#[divan::bench(args = MISALIGNED_CONFIGS)]
+fn cold_misaligned(bencher: Bencher, config: &(usize, usize)) {
+    let file = &MISALIGNED_FILES[config];
+    // Sanity-check the misalignment once per config: boundaries should be mostly distinct
+    // across columns, i.e. roughly columns × chunks in total.
+    let n_splits = collect_splits(file).len();
+    assert!(
+        n_splits > config.0 * config.1 / 2,
+        "expected mostly-distinct boundaries, got {n_splits} splits for {} columns x {} chunks",
+        config.0,
+        config.1,
+    );
+
+    bencher.bench(|| collect_splits(file));
+}
+
+/// Like `warm`, but over a file whose columns share no interior chunk boundaries.
+#[divan::bench(args = MISALIGNED_CONFIGS)]
+fn warm_misaligned(bencher: Bencher, config: &(usize, usize)) {
+    let file = &MISALIGNED_FILES[config];
+    let reader = file.layout_reader().unwrap();
+    let row_count = file.row_count();
+
+    bencher.bench(|| {
+        SplitBy::Layout
+            .splits(reader.as_ref(), &(0..row_count), &[FieldMask::All])
+            .unwrap()
+    });
+}
+
+/// Fresh reader tree per iteration and a narrow field mask: split collection should only pay
+/// for the projected column, not the full schema width.
+#[divan::bench(args = CONFIGS)]
+fn cold_single_column(bencher: Bencher, config: &(usize, usize)) {
+    let file = &FILES[config];
+    let mask = [FieldMask::Prefix(FieldPath::from(Field::from("col_0")))];
+    let row_count = file.row_count();
+
+    bencher.bench(|| {
+        let reader = file.layout_reader().unwrap();
+        SplitBy::Layout
+            .splits(reader.as_ref(), &(0..row_count), &mask)
+            .unwrap()
+    });
+}

--- a/vortex-layout/src/children.rs
+++ b/vortex-layout/src/children.rs
@@ -4,8 +4,6 @@
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU32;
-use std::sync::atomic::Ordering;
 
 use flatbuffers::Follow;
 use itertools::Itertools;
@@ -38,13 +36,14 @@ pub trait LayoutChildren: 'static + Send + Sync {
 
     fn nchildren(&self) -> usize;
 
-    /// Returns `true` if the child at `idx` is divisible: it may register split boundaries
-    /// strictly inside its row range (see [`VTable::is_divisible`](crate::VTable::is_divisible)).
+    /// Returns `true` if the child at `idx` is known — without materializing it — to be
+    /// indivisible: it registers no split boundaries strictly inside its row range (see
+    /// [`VTable::is_indivisible`](crate::VTable::is_indivisible)).
     ///
-    /// Implementations must conservatively return `true` when answering would require
+    /// Implementations must conservatively return `false` when answering would require
     /// materializing the child.
-    fn child_is_divisible(&self, _idx: usize) -> bool {
-        true
+    fn child_is_indivisible(&self, _idx: usize) -> bool {
+        false
     }
 }
 
@@ -73,8 +72,8 @@ impl LayoutChildren for Arc<dyn LayoutChildren> {
         self.as_ref().nchildren()
     }
 
-    fn child_is_divisible(&self, idx: usize) -> bool {
-        self.as_ref().child_is_divisible(idx)
+    fn child_is_indivisible(&self, idx: usize) -> bool {
+        self.as_ref().child_is_indivisible(idx)
     }
 }
 
@@ -118,8 +117,8 @@ impl LayoutChildren for OwnedLayoutChildren {
         self.0.len()
     }
 
-    fn child_is_divisible(&self, idx: usize) -> bool {
-        self.0[idx].dyn_is_divisible()
+    fn child_is_indivisible(&self, idx: usize) -> bool {
+        self.0[idx].dyn_is_indivisible()
     }
 }
 
@@ -133,7 +132,6 @@ pub(crate) struct ViewedLayoutChildren {
     allow_unknown: bool,
     session: VortexSession,
     cache: Arc<[OnceCell<LayoutRef>]>,
-    divisibility_memo: DivisibilityMemo,
 }
 
 impl ViewedLayoutChildren {
@@ -166,7 +164,6 @@ impl ViewedLayoutChildren {
             allow_unknown,
             session,
             cache,
-            divisibility_memo: DivisibilityMemo::empty(),
         }
     }
 
@@ -292,13 +289,13 @@ impl LayoutChildren for ViewedLayoutChildren {
         self.cache.len()
     }
 
-    fn child_is_divisible(&self, idx: usize) -> bool {
+    fn child_is_indivisible(&self, idx: usize) -> bool {
         if idx >= self.nchildren() {
-            return true;
+            return false;
         }
         // Resolve the child's layout encoding from the flatbuffer tag alone, without
-        // deserializing the child layout. Unknown encodings are conservatively divisible so
-        // callers fall back to materializing the child.
+        // deserializing the child layout. Unknown encodings are conservatively not indivisible
+        // so callers fall back to materializing the child.
         let encoding = self
             .flatbuffer()
             .children()
@@ -306,71 +303,12 @@ impl LayoutChildren for ViewedLayoutChildren {
             .get(idx)
             .encoding();
 
-        if let Some(answer) = self.divisibility_memo.get(encoding) {
-            return answer;
-        }
-
         let answer = self
             .layout_read_ctx
             .resolve(encoding)
             .and_then(|encoding_id| self.layouts.get(&encoding_id))
-            .is_none_or(|encoding| encoding.is_divisible());
-        self.divisibility_memo.set(encoding, answer);
+            .is_some_and(|encoding| encoding.is_indivisible());
+
         answer
-    }
-}
-
-/// Single-slot cache for [`ViewedLayoutChildren::child_is_divisible`] answers, keyed by the
-/// child's flatbuffer encoding tag and shared across clones of the owning
-/// [`ViewedLayoutChildren`].
-///
-/// Divisibility depends only on the child's layout encoding, and children of one layout node
-/// almost always share an encoding — so caching the answer for the last-seen tag turns the
-/// per-child read-context resolve and registry lookup into a single atomic load for all but the
-/// first child.
-///
-/// The tag, the answer, and a validity flag are packed into one `AtomicU32` so lookups and
-/// updates are each a single atomic operation, with no locking and no torn state between the key
-/// and its answer:
-///
-/// ```text
-/// bit:  17      16       15..0
-///       valid | answer | encoding tag
-/// ```
-///
-/// `Relaxed` ordering suffices throughout: this is purely a performance cache, and each packed
-/// word is internally consistent on its own. The worst a racing `get`/`set` can cause is a
-/// redundant recomputation.
-#[derive(Clone)]
-struct DivisibilityMemo(Arc<AtomicU32>);
-
-impl DivisibilityMemo {
-    /// Low 16 bits: the flatbuffer encoding tag the cached answer belongs to.
-    const TAG: u32 = 0xFFFF;
-    /// Bit 16: the cached answer for the stored tag.
-    const ANSWER: u32 = 1 << 16;
-    /// Bit 17: set once the memo holds an entry. Needed because the atomic starts at zero, which
-    /// would otherwise be indistinguishable from a cached `(tag 0, answer false)` entry.
-    const VALID: u32 = 1 << 17;
-
-    /// Create a memo holding no entry.
-    fn empty() -> Self {
-        Self(Arc::new(AtomicU32::new(0)))
-    }
-
-    /// Return the cached answer for `tag`, or `None` if the memo is empty or holds a different
-    /// tag.
-    fn get(&self, tag: u16) -> Option<bool> {
-        let memo = self.0.load(Ordering::Relaxed);
-        (memo & Self::VALID != 0 && memo & Self::TAG == u32::from(tag))
-            .then_some(memo & Self::ANSWER != 0)
-    }
-
-    /// Cache `answer` for `tag`, replacing any previous entry.
-    fn set(&self, tag: u16, answer: bool) {
-        self.0.store(
-            u32::from(tag) | Self::VALID | if answer { Self::ANSWER } else { 0 },
-            Ordering::Relaxed,
-        );
     }
 }

--- a/vortex-layout/src/children.rs
+++ b/vortex-layout/src/children.rs
@@ -4,6 +4,8 @@
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU32;
+use std::sync::atomic::Ordering;
 
 use flatbuffers::Follow;
 use itertools::Itertools;
@@ -35,6 +37,16 @@ pub trait LayoutChildren: 'static + Send + Sync {
     fn child_row_count(&self, idx: usize) -> u64;
 
     fn nchildren(&self) -> usize;
+
+    /// Returns `true` if the child at `idx` is known — without materializing it — to register no
+    /// split boundaries strictly inside its row range (see
+    /// [`VTable::registers_interior_splits`](crate::VTable::registers_interior_splits)).
+    ///
+    /// Implementations may conservatively return `false` when the answer would require
+    /// materializing the child.
+    fn child_has_no_interior_splits(&self, _idx: usize) -> bool {
+        false
+    }
 }
 
 impl Debug for dyn LayoutChildren {
@@ -60,6 +72,10 @@ impl LayoutChildren for Arc<dyn LayoutChildren> {
 
     fn nchildren(&self) -> usize {
         self.as_ref().nchildren()
+    }
+
+    fn child_has_no_interior_splits(&self, idx: usize) -> bool {
+        self.as_ref().child_has_no_interior_splits(idx)
     }
 }
 
@@ -102,6 +118,10 @@ impl LayoutChildren for OwnedLayoutChildren {
     fn nchildren(&self) -> usize {
         self.0.len()
     }
+
+    fn child_has_no_interior_splits(&self, idx: usize) -> bool {
+        !self.0[idx].dyn_registers_interior_splits()
+    }
 }
 
 #[derive(Clone)]
@@ -114,6 +134,10 @@ pub(crate) struct ViewedLayoutChildren {
     allow_unknown: bool,
     session: VortexSession,
     cache: Arc<[OnceCell<LayoutRef>]>,
+    /// Single-slot memo for [`LayoutChildren::child_has_no_interior_splits`]: children of one
+    /// layout node almost always share an encoding, so remember the last resolved flatbuffer
+    /// encoding tag and its answer. Packed as `tag | (answer << 16) | (valid << 17)`.
+    no_interior_splits_memo: Arc<AtomicU32>,
 }
 
 impl ViewedLayoutChildren {
@@ -146,6 +170,7 @@ impl ViewedLayoutChildren {
             allow_unknown,
             session,
             cache,
+            no_interior_splits_memo: Arc::new(AtomicU32::new(0)),
         }
     }
 
@@ -269,5 +294,39 @@ impl LayoutChildren for ViewedLayoutChildren {
 
     fn nchildren(&self) -> usize {
         self.cache.len()
+    }
+
+    fn child_has_no_interior_splits(&self, idx: usize) -> bool {
+        if idx >= self.nchildren() {
+            return false;
+        }
+        // Resolve the child's layout encoding from the flatbuffer tag alone, without
+        // deserializing the child layout. Unknown encodings conservatively report interior
+        // splits so callers fall back to materializing the child.
+        let encoding = self
+            .flatbuffer()
+            .children()
+            .unwrap_or_default()
+            .get(idx)
+            .encoding();
+
+        const MEMO_VALID: u32 = 1 << 17;
+        const MEMO_ANSWER: u32 = 1 << 16;
+        const MEMO_TAG: u32 = 0xFFFF;
+        let memo = self.no_interior_splits_memo.load(Ordering::Relaxed);
+        if memo & MEMO_VALID != 0 && memo & MEMO_TAG == u32::from(encoding) {
+            return memo & MEMO_ANSWER != 0;
+        }
+
+        let answer = self
+            .layout_read_ctx
+            .resolve(encoding)
+            .and_then(|encoding_id| self.layouts.get(&encoding_id))
+            .is_some_and(|encoding| !encoding.registers_interior_splits());
+        self.no_interior_splits_memo.store(
+            u32::from(encoding) | MEMO_VALID | if answer { MEMO_ANSWER } else { 0 },
+            Ordering::Relaxed,
+        );
+        answer
     }
 }

--- a/vortex-layout/src/children.rs
+++ b/vortex-layout/src/children.rs
@@ -132,6 +132,9 @@ pub(crate) struct ViewedLayoutChildren {
     allow_unknown: bool,
     session: VortexSession,
     cache: Arc<[OnceCell<LayoutRef>]>,
+    /// Per-child answers to [`LayoutChildren::child_is_indivisible`], precomputed at
+    /// construction from the flatbuffer encoding tags alone.
+    indivisible: Arc<[bool]>,
 }
 
 impl ViewedLayoutChildren {
@@ -150,11 +153,23 @@ impl ViewedLayoutChildren {
         session: VortexSession,
     ) -> Self {
         // SAFETY: guaranteed by caller
-        let nchildren = unsafe { fbl::Layout::follow(flatbuffer.as_ref(), flatbuffer_loc) }
+        let fb_children = unsafe { fbl::Layout::follow(flatbuffer.as_ref(), flatbuffer_loc) }
             .children()
-            .unwrap_or_default()
-            .len();
-        let cache = vec![OnceCell::new(); nchildren].into_boxed_slice().into();
+            .unwrap_or_default();
+        let cache = vec![OnceCell::new(); fb_children.len()]
+            .into_boxed_slice()
+            .into();
+        // Unknown encodings are conservatively not indivisible so callers fall back to
+        // materializing the child.
+        let indivisible = fb_children
+            .iter()
+            .map(|child| {
+                layout_read_ctx
+                    .resolve(child.encoding())
+                    .and_then(|encoding_id| layouts.get(&encoding_id))
+                    .is_some_and(|encoding| encoding.is_indivisible())
+            })
+            .collect::<Arc<[bool]>>();
         Self {
             flatbuffer,
             flatbuffer_loc,
@@ -164,6 +179,7 @@ impl ViewedLayoutChildren {
             allow_unknown,
             session,
             cache,
+            indivisible,
         }
     }
 
@@ -290,25 +306,6 @@ impl LayoutChildren for ViewedLayoutChildren {
     }
 
     fn child_is_indivisible(&self, idx: usize) -> bool {
-        if idx >= self.nchildren() {
-            return false;
-        }
-        // Resolve the child's layout encoding from the flatbuffer tag alone, without
-        // deserializing the child layout. Unknown encodings are conservatively not indivisible
-        // so callers fall back to materializing the child.
-        let encoding = self
-            .flatbuffer()
-            .children()
-            .unwrap_or_default()
-            .get(idx)
-            .encoding();
-
-        let answer = self
-            .layout_read_ctx
-            .resolve(encoding)
-            .and_then(|encoding_id| self.layouts.get(&encoding_id))
-            .is_some_and(|encoding| encoding.is_indivisible());
-
-        answer
+        self.indivisible.get(idx).copied().unwrap_or(false)
     }
 }

--- a/vortex-layout/src/children.rs
+++ b/vortex-layout/src/children.rs
@@ -38,14 +38,13 @@ pub trait LayoutChildren: 'static + Send + Sync {
 
     fn nchildren(&self) -> usize;
 
-    /// Returns `true` if the child at `idx` is known — without materializing it — to register no
-    /// split boundaries strictly inside its row range (see
-    /// [`VTable::registers_interior_splits`](crate::VTable::registers_interior_splits)).
+    /// Returns `true` if the child at `idx` is divisible: it may register split boundaries
+    /// strictly inside its row range (see [`VTable::is_divisible`](crate::VTable::is_divisible)).
     ///
-    /// Implementations may conservatively return `false` when the answer would require
+    /// Implementations must conservatively return `true` when answering would require
     /// materializing the child.
-    fn child_divisibility(&self, _idx: usize) -> bool {
-        false
+    fn child_is_divisible(&self, _idx: usize) -> bool {
+        true
     }
 }
 
@@ -74,8 +73,8 @@ impl LayoutChildren for Arc<dyn LayoutChildren> {
         self.as_ref().nchildren()
     }
 
-    fn child_divisibility(&self, idx: usize) -> bool {
-        self.as_ref().child_divisibility(idx)
+    fn child_is_divisible(&self, idx: usize) -> bool {
+        self.as_ref().child_is_divisible(idx)
     }
 }
 
@@ -119,8 +118,8 @@ impl LayoutChildren for OwnedLayoutChildren {
         self.0.len()
     }
 
-    fn child_divisibility(&self, idx: usize) -> bool {
-        !self.0[idx].dyn_registers_interior_splits()
+    fn child_is_divisible(&self, idx: usize) -> bool {
+        self.0[idx].dyn_is_divisible()
     }
 }
 
@@ -134,10 +133,7 @@ pub(crate) struct ViewedLayoutChildren {
     allow_unknown: bool,
     session: VortexSession,
     cache: Arc<[OnceCell<LayoutRef>]>,
-    /// Single-slot memo for [`LayoutChildren::child_has_no_interior_splits`]: children of one
-    /// layout node almost always share an encoding, so remember the last resolved flatbuffer
-    /// encoding tag and its answer. Packed as `tag | (answer << 16) | (valid << 17)`.
-    no_interior_splits_memo: Arc<AtomicU32>,
+    divisibility_memo: DivisibilityMemo,
 }
 
 impl ViewedLayoutChildren {
@@ -170,7 +166,7 @@ impl ViewedLayoutChildren {
             allow_unknown,
             session,
             cache,
-            no_interior_splits_memo: Arc::new(AtomicU32::new(0)),
+            divisibility_memo: DivisibilityMemo::empty(),
         }
     }
 
@@ -296,13 +292,13 @@ impl LayoutChildren for ViewedLayoutChildren {
         self.cache.len()
     }
 
-    fn child_divisibility(&self, idx: usize) -> bool {
+    fn child_is_divisible(&self, idx: usize) -> bool {
         if idx >= self.nchildren() {
-            return false;
+            return true;
         }
         // Resolve the child's layout encoding from the flatbuffer tag alone, without
-        // deserializing the child layout. Unknown encodings conservatively report interior
-        // splits so callers fall back to materializing the child.
+        // deserializing the child layout. Unknown encodings are conservatively divisible so
+        // callers fall back to materializing the child.
         let encoding = self
             .flatbuffer()
             .children()
@@ -310,23 +306,71 @@ impl LayoutChildren for ViewedLayoutChildren {
             .get(idx)
             .encoding();
 
-        const MEMO_VALID: u32 = 1 << 17;
-        const MEMO_ANSWER: u32 = 1 << 16;
-        const MEMO_TAG: u32 = 0xFFFF;
-        let memo = self.no_interior_splits_memo.load(Ordering::Relaxed);
-        if memo & MEMO_VALID != 0 && memo & MEMO_TAG == u32::from(encoding) {
-            return memo & MEMO_ANSWER != 0;
+        if let Some(answer) = self.divisibility_memo.get(encoding) {
+            return answer;
         }
 
         let answer = self
             .layout_read_ctx
             .resolve(encoding)
             .and_then(|encoding_id| self.layouts.get(&encoding_id))
-            .is_some_and(|encoding| !encoding.registers_interior_splits());
-        self.no_interior_splits_memo.store(
-            u32::from(encoding) | MEMO_VALID | if answer { MEMO_ANSWER } else { 0 },
+            .is_none_or(|encoding| encoding.is_divisible());
+        self.divisibility_memo.set(encoding, answer);
+        answer
+    }
+}
+
+/// Single-slot cache for [`ViewedLayoutChildren::child_is_divisible`] answers, keyed by the
+/// child's flatbuffer encoding tag and shared across clones of the owning
+/// [`ViewedLayoutChildren`].
+///
+/// Divisibility depends only on the child's layout encoding, and children of one layout node
+/// almost always share an encoding — so caching the answer for the last-seen tag turns the
+/// per-child read-context resolve and registry lookup into a single atomic load for all but the
+/// first child.
+///
+/// The tag, the answer, and a validity flag are packed into one `AtomicU32` so lookups and
+/// updates are each a single atomic operation, with no locking and no torn state between the key
+/// and its answer:
+///
+/// ```text
+/// bit:  17      16       15..0
+///       valid | answer | encoding tag
+/// ```
+///
+/// `Relaxed` ordering suffices throughout: this is purely a performance cache, and each packed
+/// word is internally consistent on its own. The worst a racing `get`/`set` can cause is a
+/// redundant recomputation.
+#[derive(Clone)]
+struct DivisibilityMemo(Arc<AtomicU32>);
+
+impl DivisibilityMemo {
+    /// Low 16 bits: the flatbuffer encoding tag the cached answer belongs to.
+    const TAG: u32 = 0xFFFF;
+    /// Bit 16: the cached answer for the stored tag.
+    const ANSWER: u32 = 1 << 16;
+    /// Bit 17: set once the memo holds an entry. Needed because the atomic starts at zero, which
+    /// would otherwise be indistinguishable from a cached `(tag 0, answer false)` entry.
+    const VALID: u32 = 1 << 17;
+
+    /// Create a memo holding no entry.
+    fn empty() -> Self {
+        Self(Arc::new(AtomicU32::new(0)))
+    }
+
+    /// Return the cached answer for `tag`, or `None` if the memo is empty or holds a different
+    /// tag.
+    fn get(&self, tag: u16) -> Option<bool> {
+        let memo = self.0.load(Ordering::Relaxed);
+        (memo & Self::VALID != 0 && memo & Self::TAG == u32::from(tag))
+            .then_some(memo & Self::ANSWER != 0)
+    }
+
+    /// Cache `answer` for `tag`, replacing any previous entry.
+    fn set(&self, tag: u16, answer: bool) {
+        self.0.store(
+            u32::from(tag) | Self::VALID | if answer { Self::ANSWER } else { 0 },
             Ordering::Relaxed,
         );
-        answer
     }
 }

--- a/vortex-layout/src/children.rs
+++ b/vortex-layout/src/children.rs
@@ -44,7 +44,7 @@ pub trait LayoutChildren: 'static + Send + Sync {
     ///
     /// Implementations may conservatively return `false` when the answer would require
     /// materializing the child.
-    fn child_has_no_interior_splits(&self, _idx: usize) -> bool {
+    fn child_divisibility(&self, _idx: usize) -> bool {
         false
     }
 }
@@ -74,8 +74,8 @@ impl LayoutChildren for Arc<dyn LayoutChildren> {
         self.as_ref().nchildren()
     }
 
-    fn child_has_no_interior_splits(&self, idx: usize) -> bool {
-        self.as_ref().child_has_no_interior_splits(idx)
+    fn child_divisibility(&self, idx: usize) -> bool {
+        self.as_ref().child_divisibility(idx)
     }
 }
 
@@ -119,7 +119,7 @@ impl LayoutChildren for OwnedLayoutChildren {
         self.0.len()
     }
 
-    fn child_has_no_interior_splits(&self, idx: usize) -> bool {
+    fn child_divisibility(&self, idx: usize) -> bool {
         !self.0[idx].dyn_registers_interior_splits()
     }
 }
@@ -296,7 +296,7 @@ impl LayoutChildren for ViewedLayoutChildren {
         self.cache.len()
     }
 
-    fn child_has_no_interior_splits(&self, idx: usize) -> bool {
+    fn child_divisibility(&self, idx: usize) -> bool {
         if idx >= self.nchildren() {
             return false;
         }

--- a/vortex-layout/src/encoding.rs
+++ b/vortex-layout/src/encoding.rs
@@ -68,9 +68,9 @@ pub trait LayoutVTablePlugin: 'static + Send + Sync + Debug {
         build_ctx: &LayoutBuildContext<'_>,
     ) -> VortexResult<LayoutRef>;
 
-    /// Returns `true` if readers of this layout may register natural split boundaries strictly
-    /// inside their row range (see [`VTable::registers_interior_splits`]).
-    fn registers_interior_splits(&self) -> bool {
+    /// Returns `true` if this layout is divisible: its readers may register natural split
+    /// boundaries strictly inside their row range (see [`VTable::is_divisible`]).
+    fn is_divisible(&self) -> bool {
         true
     }
 }
@@ -109,8 +109,8 @@ impl<V: VTable> LayoutVTablePlugin for V {
         .into_layout())
     }
 
-    fn registers_interior_splits(&self) -> bool {
-        VTable::registers_interior_splits(self)
+    fn is_divisible(&self) -> bool {
+        VTable::is_divisible(self)
     }
 }
 

--- a/vortex-layout/src/encoding.rs
+++ b/vortex-layout/src/encoding.rs
@@ -68,10 +68,10 @@ pub trait LayoutVTablePlugin: 'static + Send + Sync + Debug {
         build_ctx: &LayoutBuildContext<'_>,
     ) -> VortexResult<LayoutRef>;
 
-    /// Returns `true` if this layout is divisible: its readers may register natural split
-    /// boundaries strictly inside their row range (see [`VTable::is_divisible`]).
-    fn is_divisible(&self) -> bool {
-        true
+    /// Returns `true` if this layout is indivisible: its readers never register natural split
+    /// boundaries strictly inside their row range (see [`VTable::is_indivisible`]).
+    fn is_indivisible(&self) -> bool {
+        false
     }
 }
 
@@ -109,8 +109,8 @@ impl<V: VTable> LayoutVTablePlugin for V {
         .into_layout())
     }
 
-    fn is_divisible(&self) -> bool {
-        VTable::is_divisible(self)
+    fn is_indivisible(&self) -> bool {
+        VTable::is_indivisible(self)
     }
 }
 

--- a/vortex-layout/src/encoding.rs
+++ b/vortex-layout/src/encoding.rs
@@ -67,6 +67,12 @@ pub trait LayoutVTablePlugin: 'static + Send + Sync + Debug {
         children: &dyn LayoutChildren,
         build_ctx: &LayoutBuildContext<'_>,
     ) -> VortexResult<LayoutRef>;
+
+    /// Returns `true` if readers of this layout may register natural split boundaries strictly
+    /// inside their row range (see [`VTable::registers_interior_splits`]).
+    fn registers_interior_splits(&self) -> bool {
+        true
+    }
 }
 
 /// Backwards-compatible name for the object-safe layout-vtable plugin.
@@ -101,6 +107,10 @@ impl<V: VTable> LayoutVTablePlugin for V {
             build_ctx,
         )?
         .into_layout())
+    }
+
+    fn registers_interior_splits(&self) -> bool {
+        VTable::registers_interior_splits(self)
     }
 }
 

--- a/vortex-layout/src/layout.rs
+++ b/vortex-layout/src/layout.rs
@@ -268,9 +268,9 @@ pub trait DynLayout: 'static + Send + Sync + Debug {
         ctx: &LayoutReaderContext,
     ) -> VortexResult<LayoutReaderRef>;
 
-    /// Returns `true` if readers of this layout may register natural split boundaries strictly
-    /// inside their row range (see [`crate::VTable::registers_interior_splits`]).
-    fn dyn_registers_interior_splits(&self) -> bool {
+    /// Returns `true` if this layout is divisible: its readers may register natural split
+    /// boundaries strictly inside their row range (see [`crate::VTable::is_divisible`]).
+    fn dyn_is_divisible(&self) -> bool {
         true
     }
 }
@@ -330,8 +330,8 @@ impl<V: VTable> DynLayout for Layout<V> {
         Layout::new_reader(self, name, segment_source, session, ctx)
     }
 
-    fn dyn_registers_interior_splits(&self) -> bool {
-        self.vtable().registers_interior_splits()
+    fn dyn_is_divisible(&self) -> bool {
+        self.vtable().is_divisible()
     }
 }
 

--- a/vortex-layout/src/layout.rs
+++ b/vortex-layout/src/layout.rs
@@ -267,6 +267,12 @@ pub trait DynLayout: 'static + Send + Sync + Debug {
         session: &VortexSession,
         ctx: &LayoutReaderContext,
     ) -> VortexResult<LayoutReaderRef>;
+
+    /// Returns `true` if readers of this layout may register natural split boundaries strictly
+    /// inside their row range (see [`crate::VTable::registers_interior_splits`]).
+    fn dyn_registers_interior_splits(&self) -> bool {
+        true
+    }
 }
 
 impl<V: VTable> DynLayout for Layout<V> {
@@ -322,6 +328,10 @@ impl<V: VTable> DynLayout for Layout<V> {
         ctx: &LayoutReaderContext,
     ) -> VortexResult<LayoutReaderRef> {
         Layout::new_reader(self, name, segment_source, session, ctx)
+    }
+
+    fn dyn_registers_interior_splits(&self) -> bool {
+        self.vtable().registers_interior_splits()
     }
 }
 

--- a/vortex-layout/src/layout.rs
+++ b/vortex-layout/src/layout.rs
@@ -268,10 +268,10 @@ pub trait DynLayout: 'static + Send + Sync + Debug {
         ctx: &LayoutReaderContext,
     ) -> VortexResult<LayoutReaderRef>;
 
-    /// Returns `true` if this layout is divisible: its readers may register natural split
-    /// boundaries strictly inside their row range (see [`crate::VTable::is_divisible`]).
-    fn dyn_is_divisible(&self) -> bool {
-        true
+    /// Returns `true` if this layout is indivisible: its readers never register natural split
+    /// boundaries strictly inside their row range (see [`crate::VTable::is_indivisible`]).
+    fn dyn_is_indivisible(&self) -> bool {
+        false
     }
 }
 
@@ -330,8 +330,8 @@ impl<V: VTable> DynLayout for Layout<V> {
         Layout::new_reader(self, name, segment_source, session, ctx)
     }
 
-    fn dyn_is_divisible(&self) -> bool {
-        self.vtable().is_divisible()
+    fn dyn_is_indivisible(&self) -> bool {
+        self.vtable().is_indivisible()
     }
 }
 

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -118,7 +118,7 @@ impl ChunkedReader {
                 return ChunkSkips::None;
             }
             let skips = (0..nchildren)
-                .map(|idx| !children.child_is_divisible(idx))
+                .map(|idx| children.child_is_indivisible(idx))
                 .collect::<Box<[bool]>>();
             if skips.iter().all(|&skip| skip) {
                 ChunkSkips::All

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -118,7 +118,7 @@ impl ChunkedReader {
                 return ChunkSkips::None;
             }
             let skips = (0..nchildren)
-                .map(|idx| children.child_has_no_interior_splits(idx))
+                .map(|idx| children.child_divisibility(idx))
                 .collect::<Box<[bool]>>();
             if skips.iter().all(|&skip| skip) {
                 ChunkSkips::All

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::future;
+use std::iter::once;
 use std::ops::Range;
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -10,6 +11,7 @@ use futures::FutureExt;
 use futures::TryStreamExt;
 use futures::future::BoxFuture;
 use futures::stream::FuturesOrdered;
+use once_cell::sync::OnceCell;
 use tracing::trace;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
@@ -40,6 +42,20 @@ pub struct ChunkedReader {
     layout: ChunkedLayout,
     name: Arc<str>,
     lazy_children: LazyReaderChildren,
+    /// Lazily computed classification of which chunks register no interior splits, letting
+    /// [`ChunkedReader::register_splits`] avoid materializing those chunks' readers.
+    chunk_skips: OnceCell<ChunkSkips>,
+}
+
+/// Which chunks of a chunked layout are known to register no interior splits.
+enum ChunkSkips {
+    /// Every chunk end is a split boundary and no chunk has interior splits (e.g. all-flat
+    /// chunks): splits come straight from the chunk offsets.
+    All,
+    /// No chunk can be skipped.
+    None,
+    /// Per-chunk answers.
+    Mixed(Box<[bool]>),
 }
 
 static UNKNOWN: LazyLock<Arc<str>> = LazyLock::new(|| Arc::from("chunked-child"));
@@ -52,38 +68,66 @@ impl ChunkedReader {
         session: &VortexSession,
         ctx: LayoutReaderContext,
     ) -> Self {
-        let nchildren = layout.nchildren();
-        let dtypes = vec![layout.dtype().clone(); nchildren];
-
-        // format!() has non-marginal overhead for short queries like random
-        // access benchmarks
-        let names = if cfg!(debug_assertions) {
-            (0..nchildren)
+        let lazy_children = if cfg!(debug_assertions) {
+            // format!() has non-marginal overhead for short queries like random
+            // access benchmarks
+            let nchildren = layout.nchildren();
+            let dtypes = vec![layout.dtype().clone(); nchildren];
+            let names = (0..nchildren)
                 .map(|idx| Arc::from(format!("{name}.[{idx}]")))
-                .collect()
+                .collect();
+            LazyReaderChildren::new(
+                Arc::clone(layout.children()),
+                dtypes,
+                names,
+                segment_source,
+                session.clone(),
+                ctx,
+            )
         } else {
-            vec![Arc::clone(&*UNKNOWN); nchildren]
+            LazyReaderChildren::new_uniform(
+                Arc::clone(layout.children()),
+                layout.dtype().clone(),
+                Arc::clone(&*UNKNOWN),
+                segment_source,
+                session.clone(),
+                ctx,
+            )
         };
-
-        let lazy_children = LazyReaderChildren::new(
-            Arc::clone(layout.children()),
-            dtypes,
-            names,
-            segment_source,
-            session.clone(),
-            ctx,
-        );
 
         Self {
             layout,
             name,
             lazy_children,
+            chunk_skips: OnceCell::new(),
         }
     }
 
     /// Return the [`LayoutReader`] for the given chunk.
     fn chunk_reader(&self, idx: usize) -> VortexResult<&LayoutReaderRef> {
         self.lazy_children.get(idx)
+    }
+
+    /// Classify which chunks are known to register no interior splits, without materializing
+    /// any chunk layouts or readers.
+    fn chunk_skips(&self) -> &ChunkSkips {
+        self.chunk_skips.get_or_init(|| {
+            let children = self.layout.children();
+            let nchildren = self.layout.nchildren();
+            if nchildren == 0 {
+                return ChunkSkips::None;
+            }
+            let skips = (0..nchildren)
+                .map(|idx| children.child_has_no_interior_splits(idx))
+                .collect::<Box<[bool]>>();
+            if skips.iter().all(|&skip| skip) {
+                ChunkSkips::All
+            } else if skips.iter().all(|&skip| !skip) {
+                ChunkSkips::None
+            } else {
+                ChunkSkips::Mixed(skips)
+            }
+        })
     }
 
     fn chunk_offset(&self, idx: usize) -> u64 {
@@ -185,24 +229,59 @@ impl LayoutReader for ChunkedReader {
             return Ok(());
         }
 
-        let iter = self.ranges(split_range.row_range());
+        let row_range = split_range.row_range();
+        let row_offset = split_range.row_offset();
+
+        // Fast path: no chunk has interior splits (e.g. all-flat chunks), so the splits are
+        // exactly the chunk-end boundaries — no chunk layouts or readers needed.
+        if matches!(self.chunk_skips(), ChunkSkips::All) {
+            let chunk_range = self.chunk_range(row_range);
+            if chunk_range.is_empty() {
+                return Ok(());
+            }
+            let offsets = &self.layout.chunk_offsets;
+            // The boundaries below are all bounded by the last one, so a single overflow check
+            // covers the whole batch.
+            let last = row_offset
+                .checked_add(offsets[chunk_range.end].min(row_range.end))
+                .vortex_expect("Chunked layout split offset overflow");
+            splits.reserve(chunk_range.len());
+            splits.extend_ascending(
+                offsets[chunk_range.start + 1..chunk_range.end]
+                    .iter()
+                    .map(|&offset| row_offset + offset)
+                    .chain(once(last)),
+            );
+            return Ok(());
+        }
+
+        let iter = self.ranges(row_range);
         splits.reserve(iter.size_hint().0);
 
         for (chunk_idx, chunk_start, child_range, _) in iter {
-            let child = self.chunk_reader(chunk_idx)?;
-            let child_row_offset = split_range
-                .row_offset()
-                .checked_add(chunk_start)
-                .vortex_expect("Chunked layout split offset overflow");
-            let child_split_range = SplitRange::try_new(child_row_offset, child_range)?;
+            let child_end = child_range.end;
 
-            child.register_splits(field_mask, &child_split_range, splits)?;
+            // Children without interior splits (e.g. flat) would only re-register this chunk's
+            // end boundary, so skip materializing a layout and reader for them.
+            let skip_child = match self.chunk_skips() {
+                ChunkSkips::All => true,
+                ChunkSkips::None => false,
+                ChunkSkips::Mixed(skips) => skips[chunk_idx],
+            };
+            if !skip_child {
+                let child = self.chunk_reader(chunk_idx)?;
+                let child_row_offset = row_offset
+                    .checked_add(chunk_start)
+                    .vortex_expect("Chunked layout split offset overflow");
+                let child_split_range = SplitRange::try_new(child_row_offset, child_range)?;
+
+                child.register_splits(field_mask, &child_split_range, splits)?;
+            }
 
             // Register the split indicating the end of this chunk
             splits.push(
-                split_range
-                    .row_offset()
-                    .checked_add(chunk_start + child_split_range.row_range().end)
+                row_offset
+                    .checked_add(chunk_start + child_end)
                     .vortex_expect("Chunked layout split offset overflow"),
             );
         }

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -115,8 +115,9 @@ impl ChunkedReader {
             let children = self.layout.children();
             let nchildren = self.layout.nchildren();
             if nchildren == 0 {
-                return ChunkSkips::None;
+                return ChunkSkips::All;
             }
+
             let skips = (0..nchildren)
                 .map(|idx| children.child_is_indivisible(idx))
                 .collect::<Box<[bool]>>();
@@ -258,12 +259,14 @@ impl LayoutReader for ChunkedReader {
         let iter = self.ranges(row_range);
         splits.reserve(iter.size_hint().0);
 
+        let chunk_skips = self.chunk_skips();
+
         for (chunk_idx, chunk_start, child_range, _) in iter {
             let child_end = child_range.end;
 
             // Children without interior splits (e.g. flat) would only re-register this chunk's
             // end boundary, so skip materializing a layout and reader for them.
-            let skip_child = match self.chunk_skips() {
+            let skip_child = match chunk_skips {
                 ChunkSkips::All => true,
                 ChunkSkips::None => false,
                 ChunkSkips::Mixed(skips) => skips[chunk_idx],

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -108,8 +108,8 @@ impl ChunkedReader {
         self.lazy_children.get(idx)
     }
 
-    /// Classify which chunks are known to register no interior splits, without materializing
-    /// any chunk layouts or readers.
+    /// Classify which chunks are known to be indivisible, without materializing any chunk
+    /// layouts or readers.
     fn chunk_skips(&self) -> &ChunkSkips {
         self.chunk_skips.get_or_init(|| {
             let children = self.layout.children();
@@ -118,7 +118,7 @@ impl ChunkedReader {
                 return ChunkSkips::None;
             }
             let skips = (0..nchildren)
-                .map(|idx| children.child_divisibility(idx))
+                .map(|idx| !children.child_is_divisible(idx))
                 .collect::<Box<[bool]>>();
             if skips.iter().all(|&skip| skip) {
                 ChunkSkips::All

--- a/vortex-layout/src/layouts/flat/mod.rs
+++ b/vortex-layout/src/layouts/flat/mod.rs
@@ -67,8 +67,8 @@ impl VTable for Flat {
 
     /// Flat readers only ever register the end of the requested range, so flat layouts are
     /// indivisible and split collection can skip materializing flat children.
-    fn is_divisible(&self) -> bool {
-        false
+    fn is_indivisible(&self) -> bool {
+        true
     }
 
     fn metadata(layout: &Layout<Self>) -> Self::Metadata {

--- a/vortex-layout/src/layouts/flat/mod.rs
+++ b/vortex-layout/src/layouts/flat/mod.rs
@@ -65,6 +65,12 @@ impl VTable for Flat {
         *ID
     }
 
+    /// Flat readers only ever register the end of the requested range, so split collection can
+    /// skip materializing flat children.
+    fn registers_interior_splits(&self) -> bool {
+        false
+    }
+
     fn metadata(layout: &Layout<Self>) -> Self::Metadata {
         ProstMetadata(FlatLayoutMetadata {
             array_encoding_tree: layout.array_tree.as_ref().map(|bytes| bytes.to_vec()),

--- a/vortex-layout/src/layouts/flat/mod.rs
+++ b/vortex-layout/src/layouts/flat/mod.rs
@@ -65,9 +65,9 @@ impl VTable for Flat {
         *ID
     }
 
-    /// Flat readers only ever register the end of the requested range, so split collection can
-    /// skip materializing flat children.
-    fn registers_interior_splits(&self) -> bool {
+    /// Flat readers only ever register the end of the requested range, so flat layouts are
+    /// indivisible and split collection can skip materializing flat children.
+    fn is_divisible(&self) -> bool {
         false
     }
 

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -371,9 +371,6 @@ impl LayoutReader for StructReader {
         split_range: &SplitRange,
         splits: &mut RowSplits,
     ) -> VortexResult<()> {
-        // In the case of an empty struct, we need to register the end split.
-        splits.push(split_range.root_row_range().end);
-
         // Register splits for the validity child, if there is one
         if let Some(validity_ref) = self.validity()? {
             validity_ref.register_splits(field_mask, split_range, splits)?;
@@ -382,7 +379,13 @@ impl LayoutReader for StructReader {
         self.layout.matching_fields(field_mask, |mask, idx| {
             self.field_reader_by_index(idx)?
                 .register_splits(&[mask], split_range, splits)
-        })
+        })?;
+
+        // In the case of an empty struct, we need to register the end split. Pushed last so it
+        // extends the final field's ascending run rather than starting a run of its own.
+        splits.push(split_range.root_row_range().end);
+
+        Ok(())
     }
 
     fn pruning_evaluation(

--- a/vortex-layout/src/reader.rs
+++ b/vortex-layout/src/reader.rs
@@ -95,29 +95,94 @@ impl SplitRange {
 }
 
 /// A collection of root-coordinate row split points.
-pub struct RowSplits(Vec<u64>);
+///
+/// Boundaries arrive as non-descending runs, one per layout subtree walked; a descending push
+/// starts a new run. A run that exactly repeats the previous surviving run — common when sibling
+/// columns share chunk boundaries — is dropped as it completes, and the final sort is skipped
+/// when only a single run survives (the boundaries are then already ascending).
+pub struct RowSplits {
+    splits: Vec<u64>,
+    /// Start index of the run currently being appended.
+    run_start: usize,
+    /// Start index of the surviving run immediately before `run_start`.
+    prev_run_start: usize,
+}
 
 impl RowSplits {
     /// Add a row boundary to the split set.
     pub fn push(&mut self, row: u64) {
-        self.0.push(row);
+        if let Some(&last) = self.splits.last()
+            && row < last
+        {
+            self.close_run();
+        }
+        self.splits.push(row);
+    }
+
+    /// Close the current run: drop it if it exactly repeats the previous surviving run,
+    /// otherwise keep it and start a new run.
+    fn close_run(&mut self) {
+        if !self.drop_repeated_run() {
+            self.prev_run_start = self.run_start;
+            self.run_start = self.splits.len();
+        }
+    }
+
+    /// Drop the current run if it exactly repeats the run before it. Repeated runs contribute
+    /// nothing to the sorted-deduped boundary set.
+    fn drop_repeated_run(&mut self) -> bool {
+        if self.run_start > 0
+            && self.splits[self.prev_run_start..self.run_start] == self.splits[self.run_start..]
+        {
+            self.splits.truncate(self.run_start);
+            return true;
+        }
+        false
+    }
+
+    /// Extend with a batch of non-descending row boundaries.
+    ///
+    /// Only the first element is checked for a descent against the current run, so the caller
+    /// must ensure the batch itself is non-descending.
+    pub fn extend_ascending(&mut self, rows: impl IntoIterator<Item = u64>) {
+        let mut rows = rows.into_iter();
+        let Some(first) = rows.next() else {
+            return;
+        };
+        self.push(first);
+        self.splits.extend(rows);
+        debug_assert!(
+            self.splits[self.run_start..].is_sorted(),
+            "extend_ascending batch must be non-descending"
+        );
     }
 
     /// Reserve space for additional row boundaries.
     pub fn reserve(&mut self, additional: usize) {
-        self.0.reserve(additional);
+        self.splits.reserve(additional);
     }
 
     /// Create a new RowSplits with preallocated "capacity"
     pub(crate) fn new_capacity(capacity: usize) -> Self {
-        Self(Vec::with_capacity(capacity))
+        Self {
+            splits: Vec::with_capacity(capacity),
+            run_start: 0,
+            prev_run_start: 0,
+        }
     }
 
     pub(crate) fn into_sorted_deduped(mut self) -> Vec<u64> {
-        self.0.sort_unstable();
-        self.0.dedup();
-        self.0.shrink_to_fit();
-        self.0
+        let final_run_dropped = self.drop_repeated_run();
+        // Surviving runs always have a descent between them, so the boundaries are ascending
+        // iff a single run survived: no run before the final one (`prev_run_start == 0`) and
+        // the final one either is the first (`run_start == 0`) or was dropped.
+        let sorted = self.prev_run_start == 0 && (self.run_start == 0 || final_run_dropped);
+        if !sorted {
+            self.splits.sort_unstable();
+        }
+        self.splits.dedup();
+        self.splits.shrink_to_fit();
+        self.splits
     }
 }
 
@@ -215,11 +280,22 @@ impl ArrayFutureExt for ArrayFuture {
     }
 }
 
+/// Per-child metadata for [`LazyReaderChildren`].
+enum ChildMeta {
+    /// Every child shares one dtype and one debug name (e.g. chunked layouts), avoiding a
+    /// clone per child at construction.
+    Uniform { dtype: DType, name: Arc<str> },
+    /// Distinct dtype and name per child.
+    PerChild {
+        dtypes: Vec<DType>,
+        names: Vec<Arc<str>>,
+    },
+}
+
 /// Lazily constructs and caches child readers while preserving reader context.
 pub struct LazyReaderChildren {
     children: Arc<dyn LayoutChildren>,
-    dtypes: Vec<DType>,
-    names: Vec<Arc<str>>,
+    meta: ChildMeta,
     segment_source: Arc<dyn SegmentSource>,
     session: VortexSession,
     ctx: LayoutReaderContext,
@@ -239,12 +315,45 @@ impl LazyReaderChildren {
         session: VortexSession,
         ctx: LayoutReaderContext,
     ) -> Self {
+        Self::with_meta(
+            children,
+            ChildMeta::PerChild { dtypes, names },
+            segment_source,
+            session,
+            ctx,
+        )
+    }
+
+    /// Create a lazy child-reader cache where every child shares `dtype` and `name`.
+    pub fn new_uniform(
+        children: Arc<dyn LayoutChildren>,
+        dtype: DType,
+        name: Arc<str>,
+        segment_source: Arc<dyn SegmentSource>,
+        session: VortexSession,
+        ctx: LayoutReaderContext,
+    ) -> Self {
+        Self::with_meta(
+            children,
+            ChildMeta::Uniform { dtype, name },
+            segment_source,
+            session,
+            ctx,
+        )
+    }
+
+    fn with_meta(
+        children: Arc<dyn LayoutChildren>,
+        meta: ChildMeta,
+        segment_source: Arc<dyn SegmentSource>,
+        session: VortexSession,
+        ctx: LayoutReaderContext,
+    ) -> Self {
         let nchildren = children.nchildren();
         let cache = (0..nchildren).map(|_| OnceCell::new()).collect();
         Self {
             children,
-            dtypes,
-            names,
+            meta,
             segment_source,
             session,
             ctx,
@@ -259,14 +368,61 @@ impl LazyReaderChildren {
         }
 
         self.cache[idx].get_or_try_init(|| {
-            let dtype = &self.dtypes[idx];
+            let (dtype, name) = match &self.meta {
+                ChildMeta::Uniform { dtype, name } => (dtype, name),
+                ChildMeta::PerChild { dtypes, names } => (&dtypes[idx], &names[idx]),
+            };
             let child = self.children.child(idx, dtype)?;
             child.new_reader(
-                Arc::clone(&self.names[idx]),
+                Arc::clone(name),
                 Arc::clone(&self.segment_source),
                 &self.session,
                 &self.ctx,
             )
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::RowSplits;
+
+    /// The result must always equal the plain sort+dedup of every pushed value, regardless of
+    /// how pushes group into runs or which runs get dropped early.
+    #[rstest]
+    // Identical runs collapse (aligned columns).
+    #[case(vec![vec![0, 5, 10], vec![0, 5, 10], vec![0, 5, 10]])]
+    // Misaligned runs merge through the sort fallback.
+    #[case(vec![vec![0, 5, 10], vec![0, 3, 10]])]
+    // A run that is a strict prefix of its predecessor is not dropped.
+    #[case(vec![vec![0, 5, 10], vec![0, 5]])]
+    // A run extending its predecessor survives.
+    #[case(vec![vec![10, 20, 30], vec![10, 20, 30, 40]])]
+    // Repeated runs after a distinct run still collapse.
+    #[case(vec![vec![0, 5], vec![0, 3, 5], vec![0, 3, 5]])]
+    // Identical runs re-diverging.
+    #[case(vec![vec![0, 5], vec![0, 5], vec![0, 3]])]
+    // Single-element descending runs.
+    #[case(vec![vec![5], vec![3], vec![1]])]
+    // Adjacent duplicates within a run.
+    #[case(vec![vec![0, 5, 5, 10]])]
+    // Single run stays untouched.
+    #[case(vec![vec![0, 5, 10]])]
+    // No pushes at all.
+    #[case(vec![])]
+    fn into_sorted_deduped_matches_model(#[case] runs: Vec<Vec<u64>>) {
+        let mut splits = RowSplits::new_capacity(16);
+        let mut model = Vec::new();
+        for run in &runs {
+            for &row in run {
+                splits.push(row);
+                model.push(row);
+            }
+        }
+        model.sort_unstable();
+        model.dedup();
+        assert_eq!(splits.into_sorted_deduped(), model);
     }
 }

--- a/vortex-layout/src/vtable.rs
+++ b/vortex-layout/src/vtable.rs
@@ -114,13 +114,13 @@ pub trait VTable: 'static + Clone + Send + Sync + Debug {
         ctx: &LayoutReaderContext,
     ) -> VortexResult<LayoutReaderRef>;
 
-    /// Returns `true` if readers of this layout may register natural split boundaries strictly
-    /// inside their row range (see [`crate::LayoutReader::register_splits`]).
+    /// Returns `true` if this layout is divisible: its readers may register natural split
+    /// boundaries strictly inside their row range (see [`crate::LayoutReader::register_splits`]).
     ///
-    /// Layouts whose readers only ever push the end of the requested range — like flat — return
-    /// `false`, which lets parent layouts skip materializing the child entirely during split
-    /// collection.
-    fn registers_interior_splits(&self) -> bool {
+    /// Indivisible layouts — like flat, whose readers only ever push the end of the requested
+    /// range — return `false`, which lets parent layouts skip materializing the child entirely
+    /// during split collection.
+    fn is_divisible(&self) -> bool {
         true
     }
 }

--- a/vortex-layout/src/vtable.rs
+++ b/vortex-layout/src/vtable.rs
@@ -113,4 +113,14 @@ pub trait VTable: 'static + Clone + Send + Sync + Debug {
         session: &VortexSession,
         ctx: &LayoutReaderContext,
     ) -> VortexResult<LayoutReaderRef>;
+
+    /// Returns `true` if readers of this layout may register natural split boundaries strictly
+    /// inside their row range (see [`crate::LayoutReader::register_splits`]).
+    ///
+    /// Layouts whose readers only ever push the end of the requested range — like flat — return
+    /// `false`, which lets parent layouts skip materializing the child entirely during split
+    /// collection.
+    fn registers_interior_splits(&self) -> bool {
+        true
+    }
 }

--- a/vortex-layout/src/vtable.rs
+++ b/vortex-layout/src/vtable.rs
@@ -114,13 +114,12 @@ pub trait VTable: 'static + Clone + Send + Sync + Debug {
         ctx: &LayoutReaderContext,
     ) -> VortexResult<LayoutReaderRef>;
 
-    /// Returns `true` if this layout is divisible: its readers may register natural split
+    /// Returns `true` if this layout is indivisible: its readers never register natural split
     /// boundaries strictly inside their row range (see [`crate::LayoutReader::register_splits`]).
     ///
     /// Indivisible layouts — like flat, whose readers only ever push the end of the requested
-    /// range — return `false`, which lets parent layouts skip materializing the child entirely
-    /// during split collection.
-    fn is_divisible(&self) -> bool {
-        true
+    /// range — let parent layouts skip materializing the child entirely during split collection.
+    fn is_indivisible(&self) -> bool {
+        false
     }
 }


### PR DESCRIPTION
## What changes are included in this PR?

Split collection previously built a full Layout + LayoutReader for every chunk of every column just so flat chunks could re-register the chunk-end boundary the parent already knows from its chunk offsets.

- `VTable::registers_interior_splits()` (default true; flat returns false) lets a layout declare that its readers only ever push the end of the requested range, forwarded through LayoutVTablePlugin and DynLayout.
- `LayoutChildren::child_has_no_interior_splits(idx)` answers that without materializing the child: owned children ask the vtable, viewed children resolve only the flatbuffer encoding tag against the registry, with a single-slot memo since siblings almost always share one encoding.
- `ChunkedReader` caches a lazy per-chunk classification; when no chunk has interior splits it bulk-extends boundaries straight from chunk_offsets.
- `RowSplits` drops consecutive identical ascending runs (columns with aligned chunk boundaries) and skips the final sort when a single run survives. StructReader pushes its end boundary after the field walk so the common case stays one ascending run.
- `LazyReaderChildren::new_uniform` avoids a DType and name clone per chunk at reader construction.

Split-collection bench medians (64 columns x 256 chunks): cold 916us ->
181us, warm 247us -> 13us; with fully misaligned columns cold 1223us -> 321us, warm 387us -> 146us.

