### PR TITLE
Skip per-split zone-mask expansion when covering zones are uniform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10330,6 +10330,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bit-vec",
+ "codspeed-divan-compat",
  "flatbuffers",
  "futures",
  "insta",

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -55,6 +55,7 @@ vortex-session = { workspace = true }
 vortex-utils = { workspace = true, features = ["dashmap"] }
 
 [dev-dependencies]
+divan = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
 insta = { workspace = true }
 rstest = { workspace = true }
@@ -62,6 +63,10 @@ temp-env = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 vortex-array = { path = "../vortex-array", features = ["_test-harness"] }
 vortex-io = { path = "../vortex-io", features = ["tokio"] }
+
+[[bench]]
+name = "zone_mask_expansion"
+harness = false
 
 [features]
 _test-harness = []

--- a/vortex-layout/benches/zone_mask_expansion.rs
+++ b/vortex-layout/benches/zone_mask_expansion.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Benchmarks for the per-split zone-mask expansion in `ZonedReader::pruning_evaluation`.
+//!
+//! For every split, the reader turns the cached zone-level pruning mask into a row-aligned
+//! stats mask and intersects it with the incoming mask. When every zone covering the split
+//! agrees - none pruned, or all pruned - that expansion collapses to a constant, because
+//! `Mask::from_buffer` canonicalises an all-ones buffer to `AllTrue` and an all-zeros buffer
+//! to `AllFalse`, and owned-left `bitand` short circuits on both. The expanded buffer is
+//! built, counted, and thrown away.
+//!
+//! `expand` is the old behaviour and `uniform` is the fast path that reads the covering zone
+//! bits directly. `mixed` covers the case where the zones genuinely disagree and the
+//! expansion still has to run, bounding what the added `count_range` costs when it cannot
+//! short circuit.
+
+#![allow(clippy::cast_possible_truncation)]
+
+use std::hint::black_box;
+use std::ops::BitAnd;
+
+use divan::Bencher;
+use vortex_buffer::BitBuffer;
+use vortex_buffer::BitBufferMut;
+use vortex_mask::AllOr;
+use vortex_mask::Mask;
+
+fn main() {
+    divan::main();
+}
+
+/// `(split_len, zones_per_split)`. The default zone and block length are both 8192 rows, so
+/// one zone per split is the common shape; the wider cases cover multi-zone splits.
+const SPLITS: &[(usize, usize)] = &[(8_192, 1), (8_192, 4), (65_536, 8)];
+
+/// Splits with at least two covering zones, so the zones can actually disagree. A one-zone
+/// split is uniform by construction and would silently measure a fast path instead.
+const MIXED_SPLITS: &[(usize, usize)] = &[(8_192, 4), (65_536, 8)];
+
+/// A realistic incoming scan mask: `Values`, not `AllTrue`, so `bitand` takes the
+/// `(AllOr::Some, AllOr::All) => self` branch rather than the all-true short circuit.
+fn incoming(len: usize) -> Mask {
+    Mask::from_buffer(BitBuffer::from_iter((0..len).map(|i| i % 3 != 0)))
+}
+
+fn zone_lengths(split_len: usize, zones: usize) -> Vec<usize> {
+    let per_zone = split_len / zones;
+    (0..zones)
+        .map(|z| {
+            if z == zones - 1 {
+                split_len - per_zone * (zones - 1)
+            } else {
+                per_zone
+            }
+        })
+        .collect()
+}
+
+/// The zone-level pruning mask, restricted to the zones covering one split.
+fn pruning_mask(zones: usize, pruned: impl Fn(usize) -> bool) -> Mask {
+    Mask::from_buffer(BitBuffer::from_iter((0..zones).map(pruned)))
+}
+
+/// Expand the covering zones into a row-aligned buffer, then intersect. This is what ran for
+/// every split before the uniform fast path.
+fn expand(mask: Mask, pruning_mask: &Mask, zone_lengths: &[usize]) -> Mask {
+    let mut builder = BitBufferMut::with_capacity(mask.len());
+    for (zone_idx, &zone_length) in zone_lengths.iter().enumerate() {
+        builder.append_n(!pruning_mask.value(zone_idx), zone_length);
+    }
+    let stats_mask = Mask::from(builder.freeze());
+    mask.bitand(&stats_mask)
+}
+
+/// Count the pruned bits among the covering zones first, and skip the expansion when they
+/// all agree.
+fn uniform(mask: Mask, pruning_mask: &Mask, zone_lengths: &[usize]) -> Mask {
+    let covered = zone_lengths.len();
+    let pruned = match pruning_mask.bit_buffer() {
+        AllOr::All => covered,
+        AllOr::None => 0,
+        AllOr::Some(buffer) => buffer.count_range(0, covered),
+    };
+
+    if pruned == 0 {
+        mask
+    } else if pruned == covered {
+        Mask::new_false(mask.len())
+    } else {
+        expand(mask, pruning_mask, zone_lengths)
+    }
+}
+
+/// No covering zone is pruned: the stats mask is all-true and the intersection is a no-op.
+#[divan::bench(args = SPLITS)]
+fn no_zone_pruned(bencher: Bencher, (split_len, zones): (usize, usize)) {
+    let lengths = zone_lengths(split_len, zones);
+    let pruning = pruning_mask(zones, |_| false);
+    let mask = incoming(split_len);
+
+    bencher
+        .with_inputs(|| mask.clone())
+        .bench_values(|mask| black_box(uniform(mask, &pruning, &lengths)));
+}
+
+/// The same split through the old expansion, for comparison.
+#[divan::bench(args = SPLITS)]
+fn no_zone_pruned_expanded(bencher: Bencher, (split_len, zones): (usize, usize)) {
+    let lengths = zone_lengths(split_len, zones);
+    let pruning = pruning_mask(zones, |_| false);
+    let mask = incoming(split_len);
+
+    bencher
+        .with_inputs(|| mask.clone())
+        .bench_values(|mask| black_box(expand(mask, &pruning, &lengths)));
+}
+
+/// Every covering zone is pruned: the stats mask is all-false and the split drops out.
+#[divan::bench(args = SPLITS)]
+fn all_zones_pruned(bencher: Bencher, (split_len, zones): (usize, usize)) {
+    let lengths = zone_lengths(split_len, zones);
+    let pruning = pruning_mask(zones, |_| true);
+    let mask = incoming(split_len);
+
+    bencher
+        .with_inputs(|| mask.clone())
+        .bench_values(|mask| black_box(uniform(mask, &pruning, &lengths)));
+}
+
+/// The same split through the old expansion, for comparison.
+#[divan::bench(args = SPLITS)]
+fn all_zones_pruned_expanded(bencher: Bencher, (split_len, zones): (usize, usize)) {
+    let lengths = zone_lengths(split_len, zones);
+    let pruning = pruning_mask(zones, |_| true);
+    let mask = incoming(split_len);
+
+    bencher
+        .with_inputs(|| mask.clone())
+        .bench_values(|mask| black_box(expand(mask, &pruning, &lengths)));
+}
+
+/// The covering zones disagree, so the expansion still runs and the added `count_range` is
+/// the whole overhead.
+#[divan::bench(args = MIXED_SPLITS)]
+fn mixed_zones(bencher: Bencher, (split_len, zones): (usize, usize)) {
+    let lengths = zone_lengths(split_len, zones);
+    let pruning = pruning_mask(zones, |z| z % 2 == 0);
+    let mask = incoming(split_len);
+
+    bencher
+        .with_inputs(|| mask.clone())
+        .bench_values(|mask| black_box(uniform(mask, &pruning, &lengths)));
+}
+
+/// The same split through the old expansion, for comparison.
+#[divan::bench(args = MIXED_SPLITS)]
+fn mixed_zones_expanded(bencher: Bencher, (split_len, zones): (usize, usize)) {
+    let lengths = zone_lengths(split_len, zones);
+    let pruning = pruning_mask(zones, |z| z % 2 == 0);
+    let mask = incoming(split_len);
+
+    bencher
+        .with_inputs(|| mask.clone())
+        .bench_values(|mask| black_box(expand(mask, &pruning, &lengths)));
+}

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -6,7 +6,6 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
-use itertools::Itertools;
 use tracing::trace;
 use vortex_array::ArrayRef;
 use vortex_array::MaskFuture;
@@ -14,8 +13,8 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldMask;
 use vortex_array::expr::BoundExpression;
 use vortex_buffer::BitBufferMut;
-use vortex_error::VortexError;
 use vortex_error::VortexResult;
+use vortex_mask::AllOr;
 use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
@@ -97,13 +96,13 @@ impl ZonedReader {
         let zone_end = row_range.end.div_ceil(zone_len_u64);
         zone_start..zone_end
     }
+}
 
-    /// Get the row index for the first row in a zone with the given `zone_index`.
-    pub(crate) fn first_row_offset(&self, zone_idx: u64) -> u64 {
-        zone_idx
-            .saturating_mul(self.zone_len as u64)
-            .min(self.row_count)
-    }
+/// Get the row index for the first row in a zone with the given `zone_idx`.
+///
+/// Free function so that it can be used from a `'static` future without capturing the reader.
+fn first_row_offset(zone_idx: u64, zone_len: u64, row_count: u64) -> u64 {
+    zone_idx.saturating_mul(zone_len).min(row_count)
 }
 
 impl LayoutReader for ZonedReader {
@@ -149,44 +148,64 @@ impl LayoutReader for ZonedReader {
             return Ok(data_eval);
         };
 
-        let row_count = row_range.end - row_range.start;
+        let split_row_count = row_range.end - row_range.start;
+        let row_start = row_range.start;
         let zone_range = self.zone_range(row_range);
-        let zone_lengths: Vec<_> = zone_range
-            .clone()
-            .map(|zone_idx| {
-                // Figure out the range in the mask that corresponds to the zone
-                let start = usize::try_from(
-                    self.first_row_offset(zone_idx)
-                        .saturating_sub(row_range.start),
-                )?;
-                let end = usize::try_from(
-                    self.first_row_offset(zone_idx + 1)
-                        .saturating_sub(row_range.start)
-                        .min(row_count),
-                )?;
-                Ok::<_, VortexError>(end - start)
-            })
-            .try_collect()?;
+        let zone_start = usize::try_from(zone_range.start)?;
+        let zone_end = usize::try_from(zone_range.end)?;
+        let covered_zones = zone_end - zone_start;
+        let zone_len = self.zone_len as u64;
+        let layout_row_count = self.row_count;
 
         let name = Arc::clone(&self.name);
         let expr = expr.clone();
+        let mask_len = mask.len();
 
-        Ok(MaskFuture::new(mask.len(), async move {
+        Ok(MaskFuture::new(mask_len, async move {
             trace!("Invoking stats pruning evaluation {}: {}", name, expr);
 
             let pruning_mask = pruning_mask_future.await?.mask()?;
 
-            let mut builder = BitBufferMut::with_capacity(mask.len());
-            for (zone_idx, &zone_length) in zone_range.clone().zip_eq(&zone_lengths) {
-                builder.append_n(!pruning_mask.value(usize::try_from(zone_idx)?), zone_length);
-            }
+            // Only the zones covering this row range matter. Counting their pruned bits is a
+            // handful of bit reads, and the overwhelming majority of splits are uniform: either
+            // no covered zone is pruned, or all of them are. Both collapse to a constant stats
+            // mask, so we can skip expanding zones into a row-aligned buffer entirely.
+            let pruned_zones = match pruning_mask.bit_buffer() {
+                AllOr::All => covered_zones,
+                AllOr::None => 0,
+                AllOr::Some(buffer) => buffer.count_range(zone_start, zone_end),
+            };
 
-            let stats_mask = Mask::from(builder.freeze());
-            assert_eq!(stats_mask.len(), mask.len(), "Mask length mismatch");
-
-            // Intersect the masks.
             let mask_density = mask.density();
-            let mut stats_mask = mask.bitand(&stats_mask);
+            let mut stats_mask = if pruned_zones == 0 {
+                // The stats mask would be all-true, so intersecting it is a no-op.
+                mask
+            } else if pruned_zones == covered_zones {
+                // The stats mask would be all-false.
+                Mask::new_false(mask_len)
+            } else {
+                let mut builder = BitBufferMut::with_capacity(mask_len);
+                for zone_idx in zone_start..zone_end {
+                    // Figure out the range in the mask that corresponds to the zone
+                    let zone_idx_u64 = zone_idx as u64;
+                    let start = usize::try_from(
+                        first_row_offset(zone_idx_u64, zone_len, layout_row_count)
+                            .saturating_sub(row_start),
+                    )?;
+                    let end = usize::try_from(
+                        first_row_offset(zone_idx_u64 + 1, zone_len, layout_row_count)
+                            .saturating_sub(row_start)
+                            .min(split_row_count),
+                    )?;
+                    builder.append_n(!pruning_mask.value(zone_idx), end - start);
+                }
+
+                let stats_mask = Mask::from(builder.freeze());
+                assert_eq!(stats_mask.len(), mask_len, "Mask length mismatch");
+
+                // Intersect the masks.
+                mask.bitand(&stats_mask)
+            };
 
             // Forward to data child for further pruning.
             if !stats_mask.all_false() {
@@ -231,6 +250,7 @@ impl LayoutReader for ZonedReader {
 #[cfg(test)]
 mod test {
     use std::num::NonZeroUsize;
+    use std::ops::Range;
     use std::sync::Arc;
 
     use rstest::fixture;
@@ -372,6 +392,36 @@ mod test {
                 result,
                 Mask::from_iter([false, false, false, false, false, false, true, true, true])
             );
+        })
+    }
+
+    /// The zoned reader takes a uniform fast path when every zone covering the requested row
+    /// range agrees, so exercise all-pruned, all-kept and mixed ranges.
+    #[rstest]
+    #[case::only_pruned_zones(0..6, vec![false; 6])]
+    #[case::only_kept_zones(6..9, vec![true; 3])]
+    #[case::single_pruned_zone(3..6, vec![false; 3])]
+    #[case::partial_zones_mixed(1..8, vec![false, false, false, false, false, true, true])]
+    #[case::empty_range(4..4, vec![])]
+    fn test_stats_pruning_mask_zone_ranges(
+        #[from(stats_layout)] (segments, layout): (Arc<dyn SegmentSource>, LayoutRef),
+        #[case] row_range: Range<u64>,
+        #[case] expected: Vec<bool>,
+    ) -> VortexResult<()> {
+        block_on(|handle| async {
+            let session = session_with_handle(handle);
+            let reader = layout.new_reader("".into(), segments, &session, &Default::default())?;
+
+            // Values are 1..=9 in zones of 3, so `> 7` prunes zones 0 and 1 and keeps zone 2.
+            let expr = gt(root(), lit(7)).bind(reader.dtype())?;
+            let len = usize::try_from(row_range.end - row_range.start)?;
+
+            let result = reader
+                .pruning_evaluation(&row_range, &expr, Mask::new_true(len))?
+                .await?;
+
+            assert_eq!(result, Mask::from_iter(expected));
+            Ok(())
         })
     }
 


### PR DESCRIPTION
## Rationale for this change

`ZonedReader::pruning_evaluation` (the v1 `LayoutReader` scan path) caches the zone-level
pruning mask per expression, but every split still expands it into a row-aligned buffer
inside the returned `MaskFuture`:

1. a `Vec` of per-zone lengths, built eagerly — before the future is even polled,
2. a `BitBufferMut` of the full split length filled via `append_n` per zone,
3. `Mask::from(builder.freeze())` — a popcount pass,
4. a `bitand` against the incoming mask.

For most splits the zones covering that split are **uniform** — either none are pruned or
all are — and the whole expansion collapses to a constant. This PR detects that case and
skips the work.

## What changes are included in this PR?

`vortex-layout/src/layouts/zoned/reader.rs`, plus a new benchmark for the path it changes.

After resolving the zone-level pruning mask, count the pruned bits among **only the zones
covering this split** (`zone_range`) before building anything. That count is a handful of
bit reads via `BitBuffer::count_range` — it does not scan the whole zone mask — and it
short-circuits both uniform cases:

- **no covered zone pruned** → the stats mask is all-true, so intersecting is a no-op:
  continue with the incoming mask unchanged (still forwarded to the data child evaluation,
  as before);
- **every covered zone pruned** → return `Mask::new_false(mask.len())` directly;
- **otherwise** → fall through to the existing expansion.

The per-zone length computation moved onto the non-uniform path and inlined into the
builder loop, dropping the intermediate `Vec`, so uniform splits allocate nothing.
`first_row_offset` became a private free function so the non-uniform path can call it from
the `'static` future without capturing the reader.

The default zone length and row block size are both 8192, so a typical split covers one
zone and the uniform test essentially always succeeds.

### Why the fast paths are exactly equivalent

Not merely bit-equal — the same `Mask` variant. `Mask::from_buffer`
(`vortex-mask/src/lib.rs:189`) canonicalises:

```rust
if true_count == 0   { return Self::AllFalse(len); }
if true_count == len { return Self::AllTrue(len); }
```

and owned-left `bitand` (`vortex-mask/src/bitops.rs:41`) short-circuits on both:

```rust
(AllOr::None, _) | (_, AllOr::None) => Mask::new_false(self.len()),
(_, AllOr::All) => self,
```

So in the no-prune case the **old** code built an all-ones buffer, ran an O(n)
`true_count()`, got `AllTrue`, and then `bitand` returned `self` — the incoming mask,
unchanged. The buffer was allocated, filled, counted and dropped to rediscover a value the
code already held. The all-pruned case is the same story via `AllFalse` → `Mask::new_false`.

### Benchmarks

**The change is measured directly**, by a new `vortex-layout/benches/zone_mask_expansion.rs`.
`expand` reproduces the old behaviour and `uniform` is the fast path; the incoming mask is a
`Values` mask, not `AllTrue`, so `bitand` takes the `(AllOr::Some, AllOr::All) => self`
branch the real code hits rather than the all-true short circuit. Medians, split of 8192
rows over one zone:

| case | fast path | old expansion | |
| --- | --- | --- | --- |
| no covered zone pruned | 7.4 ns | 147 ns | ~20x |
| every covered zone pruned | 14.5 ns | 151 ns | ~10x |
| no covered zone pruned, 65536 rows / 8 zones | 7.4 ns | 420 ns | ~57x |

So the saving is **roughly 140–400 ns per split, per pruning expression** — real work
removed, but small next to what a split then does: decode 8192 rows across every projected
column.

`mixed_zones` covers the case where the covering zones genuinely disagree and the expansion
still runs. There the added `count_range` shows a small overhead — within a few percent, at
the edge of what the host resolves — so it is bounded rather than claimed to be free.

#### The SQL suites cannot resolve this, across three sweeps

Only the SQL suites exercise `pruning_evaluation` at all: `random-access-bench` reads rows
without filter pushdown, `string-bench` is a compression benchmark, and CodSpeed's
microbenchmarks do not cover `vortex-layout`. All three report clean, but none of them can
speak to this change.

Three full sweeps were run:
[`bench-sql` on 0fa9c84](https://github.com/vortex-data/vortex/actions/runs/31174768597),
[`bench-all` on ec8e480](https://github.com/vortex-data/vortex/actions/runs/31181500061),
and [`bench-all` on 3062ebb](https://github.com/vortex-data/vortex/actions/runs/31190622616).
Every suite in all three returned **"No clear signal"**. Attributed Vortex impact:

| suite | sweep 1 | sweep 2 | sweep 3 | range |
| --- | --- | --- | --- | --- |
| StatPopGen | −6.0% | +1.8% | −0.1% | 7.8 pts |
| ClickBench Sorted | −2.8% | +1.4% | +4.4% | 7.2 pts |
| FineWeb | +3.3% | +2.7% | +0.0% | 3.3 pts |
| PolarSignals (raw, no control) | +1.7% | −2.0% | −2.2% | 3.9 pts |
| TPC-DS SF=1 | −1.4% | +0.7% | +1.0% | 2.4 pts |
| TPC-H SF=10 | −0.3% | +1.2% | −1.1% | 2.3 pts |
| TPC-H SF=1 | +1.2% | +1.1% | +0.7% | 0.5 pts |
| ClickBench | −0.3% | −1.0% | −0.6% | 0.7 pts |
| Appian NVMe | — | +0.2% | −0.3% | 0.5 pts |

Given a ~150 ns per-split saving, this is the expected outcome: the effect sits far below
the noise floor, so the sweeps measure drift rather than the change. Five of eight repeated
suites changed sign at least once, and the two that did not — ClickBench (−0.3/−1.0/−0.6)
and TPC-H SF=1 (+1.2/+1.1/+0.7) — held **opposite** signs. They cannot both be caused by a
change that provably removes work on the dominant path, so both are per-suite systematic
offsets, not signal.

Three specific failures of the methodology, each reproduced rather than asserted:

**Baselines are not stable.** Sweep 3 alone compared against six different bases —
`0f0390a6`, `ad5de229`, `74a2b861`, `39fde8c1`, `2b3109a8`, `adab5b84` — depending on the
suite.

**A tight Parquet control does not bound Vortex-side variance.** StatPopGen's control is
the tightest in the matrix (all eleven rows 0.98–1.01, geomean 1.001x), yet in that same
run `q05` moved 1.25 🚨 and `q10` moved 0.72 🚀. Host-wide drift cannot produce a 25% and a
28% swing under a 1% control.

**The attribution step adds variance of its own.** TPC-H SF=10's *raw* Vortex geomean was
0.998x, 1.002x, 0.996x across the three sweeps — stable and centred — while the
*attributed* figure swung −0.3% / +1.2% / −1.1% because the Parquet control drifted. In
sweep 3 that drift traces to one control row: `tpch_q01/duckdb:parquet` at **1.54**.

The `statpopgen_q10` history is the clearest single illustration. HEAD measured 2.94s,
3.12s, 3.09s across the three sweeps — a tight band. The **baseline** measured 4.26s,
2.88s, 4.27s — bimodal, and the anomalous value recurred to within 0.01s. The original
−6.0% reading was a slow baseline being read as a fast HEAD.

ClickBench Sorted is the loudest suite (+4.4%, and the only ❌ in the matrix) and also the
least usable: `clickbench-sorted_q23` alone drives it, measuring 2.0× faster and 2.6×
slower on two formats *within sweep 2*, then 1.98× and 2.46× slower in sweep 3. Its
DataFusion Parquet control carries a 1.47 🚨, and its `.vortex` files differ between base
and HEAD — 100 larger, 100 smaller, up to ±2.3% per file — so the two sides decode
materially different bytes. That compressor nondeterminism recurs elsewhere: `Euro2016` in
compress-bench differed by +18KB in sweep 2 and −234KB in sweep 3.

**No SQL suite in any sweep showed a credible regression**, and the lowest-noise ones read
zero: Appian NVMe +0.2% / −0.3% with every control row in 0.98–1.02, StatPopGen −0.1%
against a 1.001x control, FineWeb +0.0% where suite and control moved identically (1.003x
each).

The four S3 suites are excluded throughout: all flagged "environment too noisy", with
Parquet controls drifting −3.4%, −8.5% and −11.4%, one control row moving 5.34s → 0.85s,
and different baselines used across runs. Two sweep-3 examples show why they are excluded,
and both happen to point the *favourable* way:

- **FineWeb S3**, attributed −7.9% off a Vortex geomean of 0.976x and a DuckDB Parquet
  control of 1.141x — where that control is set by a single row,
  `fineweb_q06/duckdb:parquet`, at **3.43** (1.57s → 5.39s) on a path this change cannot
  touch.
- **TPC-H SF=10 on S3**, attributed **−11.4%** — the largest number anywhere in the matrix.
  Its DataFusion rows contradict themselves query by query within the one run:
  `tpch_q04` measured 0.65 🚀 on `vortex-compact` and 1.62 🚨 on `parquet`; `tpch_q06`
  measured 0.71 and 1.33. Same query, same host, same run, opposite ~1.5x moves — and the
  Parquet side cannot be touched by this change at all. These are S3-bound queries whose
  cost is dominated by network IO, so a ~150 ns per-split saving cannot register at 11%.

Neither is evidence for this PR, and they are listed here so the two loudest favourable
numbers on the page are not mistaken for one.

Earlier revisions of this description made two claims that did not survive: local
microbenchmark numbers (`clickbench_plan_perf`, `SCAN_VERSION=v1`) of 6–9% at TPC-H SF=10,
and a correlation between sorted data layouts and favourable results. Both rested on single
measurements that reversed on repetition, and have been removed rather than reconciled.

### Tests

Added `test_stats_pruning_mask_zone_ranges`, an `rstest` over row ranges covering only
pruned zones, only kept zones, a single pruned zone, a mixed partial range, and an empty
range — exercising both new fast paths and the unchanged expansion path.

## What APIs are changed? Are there any user-facing changes?

None. `ZonedReader::first_row_offset` was a `pub(crate)` helper used only within this file;
it is now a private free function. No public API or behavior change.

### Checks run

- `cargo test -p vortex-layout -p vortex-file` — pass
- `cargo clippy -p vortex-layout --all-targets --all-features` — clean
- `cargo +nightly fmt --all`, `git diff --check` — clean
- `cargo bench -p vortex-layout --bench zone_mask_expansion` — figures above

Not run: workspace-wide tests, Python/docs checks — the change is confined to one Rust file
plus a new bench target, with no public API surface.