### PR TITLE
Benchmarks compare against last successful run that is reachable from branch

### DIFF
--- a/.github/workflows/pr-bench-runner.yml
+++ b/.github/workflows/pr-bench-runner.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sql-bench-matrix.yml
+++ b/.github/workflows/sql-bench-matrix.yml
@@ -121,6 +121,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           ref: ${{ inputs.mode == 'pr' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: ${{ inputs.mode == 'pr' && '0' || '1' }}
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/compare-benchmark-jsons.py
+++ b/scripts/compare-benchmark-jsons.py
@@ -14,6 +14,7 @@
 import math
 import os
 import re
+import subprocess
 import sys
 from dataclasses import dataclass
 from io import StringIO
@@ -216,8 +217,24 @@ def read_jsonl_rows_for_commit(path: str, commit_id: str) -> pd.DataFrame:
     return pd.DataFrame(rows_by_identity.values())
 
 
-def read_latest_baseline_rows(path: str, pr: pd.DataFrame) -> pd.DataFrame:
-    """Read rows from the latest history commit matching the PR benchmark.
+def git_tree_commit_ids() -> set[str]:
+    """Return every commit reachable from the checked-out branch head."""
+
+    commits = subprocess.run(
+        ["git", "rev-list", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return set(commits.splitlines())
+
+
+def read_latest_baseline_rows(
+    path: str,
+    pr: pd.DataFrame,
+    reachable_commit_ids: set[str],
+) -> pd.DataFrame:
+    """Read rows from the latest reachable commit matching the PR benchmark.
 
     A benchmark can be new to the PR workflow and therefore have no baseline
     yet. Return an empty frame with the PR schema in that case so the report
@@ -236,7 +253,7 @@ def read_latest_baseline_rows(path: str, pr: pd.DataFrame) -> pd.DataFrame:
             record = orjson.loads(line)
             if benchmark_identity(record) in pr_identities:
                 commit_id = record.get("commit_id")
-                if commit_id is not None:
+                if commit_id is not None and commit_id in reachable_commit_ids:
                     baseline_commit_id = commit_id
 
     if baseline_commit_id is None:
@@ -245,15 +262,24 @@ def read_latest_baseline_rows(path: str, pr: pd.DataFrame) -> pd.DataFrame:
     return read_jsonl_rows_for_commit(path, baseline_commit_id)
 
 
-def select_latest_baseline_rows(base: pd.DataFrame, pr: pd.DataFrame) -> pd.DataFrame:
-    """Select rows from the latest baseline commit containing this benchmark.
+def select_latest_baseline_rows(
+    base: pd.DataFrame,
+    pr: pd.DataFrame,
+    reachable_commit_ids: set[str],
+) -> pd.DataFrame:
+    """Select rows from the latest reachable commit containing this benchmark.
 
     The persisted benchmark history is append-only. A row only appears after
-    that benchmark job uploaded results, so the newest commit with matching row
-    identities is the latest successful baseline for the benchmark under test.
+    that benchmark job uploaded results, so the newest reachable commit with
+    matching row identities is the latest successful baseline for the benchmark
+    under test.
     """
 
     if base.empty or "commit_id" not in base.columns:
+        return base
+
+    base = base[base["commit_id"].isin(reachable_commit_ids)].copy()
+    if base.empty:
         return base
 
     commit_ids = base["commit_id"].dropna().unique()
@@ -961,7 +987,7 @@ def main() -> None:
 
     pr = pd.read_json(sys.argv[2], lines=True)
     title = format_title(benchmark_name, pr)
-    base = read_latest_baseline_rows(sys.argv[1], pr)
+    base = read_latest_baseline_rows(sys.argv[1], pr, git_tree_commit_ids())
 
     base_commit_ids = set(base["commit_id"].unique())
     pr_commit_id = set(pr["commit_id"].unique())

--- a/scripts/tests/test_benchmark_reporting.py
+++ b/scripts/tests/test_benchmark_reporting.py
@@ -80,6 +80,14 @@ def render_report(
     pr_rows: list[dict[str, object]],
     benchmark_name: str,
 ) -> str:
+    head_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    base_rows = [row | {"commit_id": head_commit} for row in base_rows]
     base_path = tmp_path / "base.jsonl"
     pr_path = tmp_path / "pr.jsonl"
     base_path.write_text("".join(f"{json.dumps(row)}\n" for row in base_rows), encoding="utf-8")
@@ -136,7 +144,7 @@ def test_select_latest_baseline_rows_uses_latest_matching_benchmark_commit() -> 
         ]
     )
 
-    selected = compare.select_latest_baseline_rows(history, pr)
+    selected = compare.select_latest_baseline_rows(history, pr, {"base-old", "base-current"})
 
     assert set(selected["commit_id"]) == {"base-current"}
     assert len(selected) == 2
@@ -196,10 +204,59 @@ def test_read_latest_baseline_rows_streams_latest_matching_benchmark_commit(tmp_
         ]
     )
 
-    selected = compare.read_latest_baseline_rows(history_path, pr)
+    selected = compare.read_latest_baseline_rows(history_path, pr, {"base-old", "base-current"})
 
     assert set(selected["commit_id"]) == {"base-current"}
     assert len(selected) == 2
+
+
+def test_read_latest_baseline_rows_skips_commits_outside_git_tree(tmp_path: Path) -> None:
+    compare = load_compare_module()
+    history_path = tmp_path / "history.jsonl"
+    history_rows = [
+        stored_timing_row("base-reachable", "tpch_q01/datafusion:parquet", 100),
+        file_size_record_for(
+            "base-reachable",
+            100,
+            "tpch",
+            "1.0",
+            "vortex-file-compressed",
+            "part-0.vortex",
+        ),
+        stored_timing_row("base-off-tree", "tpch_q01/datafusion:parquet", 110),
+        file_size_record_for(
+            "base-off-tree",
+            120,
+            "tpch",
+            "1.0",
+            "vortex-file-compressed",
+            "part-0.vortex",
+        ),
+    ]
+    history_path.write_text(
+        "".join(f"{json.dumps(row)}\n" for row in history_rows),
+        encoding="utf-8",
+    )
+    pr = pd.DataFrame([stored_timing_row("pr", "tpch_q01/datafusion:parquet", 105)])
+
+    selected = compare.read_latest_baseline_rows(history_path, pr, {"base-reachable"})
+
+    assert set(selected["commit_id"]) == {"base-reachable"}
+    assert len(selected) == 2
+
+
+def test_read_latest_baseline_rows_returns_empty_without_reachable_match(tmp_path: Path) -> None:
+    compare = load_compare_module()
+    history_path = tmp_path / "history.jsonl"
+    history_path.write_text(
+        f"{json.dumps(stored_timing_row('base-off-tree', 'tpch_q01/datafusion:parquet', 100))}\n",
+        encoding="utf-8",
+    )
+    pr = pd.DataFrame([stored_timing_row("pr", "tpch_q01/datafusion:parquet", 105)])
+
+    selected = compare.read_latest_baseline_rows(history_path, pr, set())
+
+    assert selected.empty
 
 
 def test_read_latest_baseline_rows_uses_last_result_from_rerun(tmp_path: Path) -> None:
@@ -217,7 +274,7 @@ def test_read_latest_baseline_rows_uses_last_result_from_rerun(tmp_path: Path) -
     )
     pr = pd.DataFrame([stored_timing_row("pr", "tpch_q01/datafusion:parquet", 105)])
 
-    selected = compare.read_latest_baseline_rows(history_path, pr)
+    selected = compare.read_latest_baseline_rows(history_path, pr, {"base"})
 
     assert len(selected) == 1
     assert selected.iloc[0]["value"] == 110


### PR DESCRIPTION
## Rationale for this change

Instead of comparing against `develop`, compare benchmark results to the last successful run that's also reachable from the branch's
