### PR TITLE
Eagerly build single-conjunct filter evaluations

### DIFF
--- a/vortex-layout/src/scan/tasks.rs
+++ b/vortex-layout/src/scan/tasks.rs
@@ -71,70 +71,7 @@ pub fn split_exec<A: 'static + Send>(
             let filter = Arc::clone(filter);
             let row_range = row_range.clone();
 
-            // A single-conjunct filter has no adaptive ordering to decide at runtime, so the
-            // whole evaluation can be built up-front.
-            if filter.conjuncts().len() == 1 {
-                single_conjunct_mask(reader, filter, row_range, row_mask)?
-            } else {
-                MaskFuture::new(row_mask.len(), async move {
-                    let mut mask = row_mask;
-                    let mut dynamic_versions = vec![None; filter.conjuncts().len()];
-
-                    // TODO(ngates): we could use FuturedUnordered to intersect the masks in parallel.
-                    for (idx, conjunct) in filter.conjuncts().iter().enumerate() {
-                        if mask.all_false() {
-                            return Ok(mask);
-                        }
-
-                        // Store the latest version of the dynamic expression prior to pruning.
-                        // We will re-run the pruning later if the version has changed in the meantime.
-                        dynamic_versions[idx] = filter.dynamic_updates(idx).map(|du| du.version());
-
-                        let conjunct_mask = reader
-                            .pruning_evaluation(&row_range, conjunct, mask.clone())?
-                            .await?;
-                        mask = mask.bitand(&conjunct_mask);
-                    }
-
-                    // Now we loop through the conjuncts in the preferred order and evaluate them.
-                    let mut remaining = BitVec::from_elem(filter.conjuncts().len(), true);
-                    while let Some(idx) = filter.next_conjunct(&remaining) {
-                        remaining.set(idx, false);
-                        if mask.all_false() {
-                            return Ok(mask);
-                        }
-
-                        let conjunct = &filter.conjuncts()[idx];
-
-                        // If the dynamic expression has changed since pruning, re-run the pruning.
-                        // Store the dynamic update once to avoid TOCTOU race condition
-                        let current_version = filter.dynamic_updates(idx).map(|du| du.version());
-                        if let Some(dv) = current_version
-                            && dynamic_versions[idx].is_none_or(|v| v < dv)
-                        {
-                            // The dynamic expression has been updated, re-run the pruning.
-                            dynamic_versions[idx] = Some(dv);
-                            let conjunct_mask = reader
-                                .pruning_evaluation(&row_range, conjunct, mask.clone())?
-                                .await?;
-                            mask = mask.bitand(&conjunct_mask);
-                        }
-                        if mask.all_false() {
-                            return Ok(mask);
-                        }
-
-                        let conjunct_mask = reader
-                            .filter_evaluation(&row_range, conjunct, MaskFuture::ready(mask))?
-                            .await?;
-                        filter.report_selectivity(idx, conjunct_mask.density());
-
-                        // Filter evaluations return a mask already intersected with the input mask.
-                        mask = conjunct_mask;
-                    }
-
-                    Ok(mask)
-                })
-            }
+            chained_filter_mask(reader, filter, row_range, row_mask)?
         }
     };
 
@@ -157,68 +94,100 @@ pub fn split_exec<A: 'static + Send>(
     Ok(array_fut.boxed())
 }
 
-/// Builds the filter mask for a filter made up of a single conjunct.
+/// Builds the filter mask by chaining every conjunct's evaluation at task-construction time.
 ///
-/// With only one conjunct there is no conjunct ordering to decide at runtime, so the whole
-/// pruning-then-filter chain can be constructed at task-construction time rather than when the
-/// task is first polled. This registers the conjunct's segment reads for every split before any
-/// split task runs, which lets the IO system coalesce them into larger reads.
+/// [`LayoutReader::filter_evaluation`] registers its segment reads when it is *called*, but only
+/// awaits its input mask when it is *polled*. Building the evaluations one at a time — awaiting
+/// each before constructing the next — therefore trickles reads in one conjunct at a time, per
+/// split. Feeding each conjunct's output [`MaskFuture`] straight into the next instead registers
+/// the reads for the whole chain up front, so the IO system can coalesce them, while each
+/// conjunct still receives the mask its predecessor refined.
 ///
-/// It matters most when the filter column is not part of the projection: the projection
-/// evaluation is already built eagerly, so a filter over a projected column has its segments
-/// registered either way, but a filter over an unprojected column otherwise trickles its reads
-/// in one split at a time.
-fn single_conjunct_mask(
+/// This matters most for filter columns that are not projected. The projection evaluation is
+/// already built eagerly, so a filter over a projected column has its segments registered either
+/// way; a filter over an unprojected column otherwise has nothing registering them ahead of time.
+///
+/// The evaluation order is taken from [`FilterExpr::next_conjunct`] up front rather than being
+/// re-queried between conjuncts. That ordering is recomputed only when a *completed* conjunct
+/// reports its selectivity, so within a single split it was already fixed; draining it here gives
+/// up nothing but lets the chain be built before anything is awaited. Ordering still adapts
+/// across splits.
+fn chained_filter_mask(
     reader: Arc<dyn LayoutReader>,
     filter: Arc<FilterExpr>,
     row_range: Range<u64>,
     row_mask: Mask,
 ) -> VortexResult<MaskFuture> {
     let len = row_mask.len();
-    let conjunct = filter.conjuncts()[0].clone();
+    let conjunct_count = filter.conjuncts().len();
 
-    // Store the latest version of the dynamic expression prior to pruning. We re-run the pruning
-    // if the version has changed by the time the task is polled.
-    let dynamic_version = filter.dynamic_updates(0).map(|du| du.version());
-    let pruning_eval = reader.pruning_evaluation(&row_range, &conjunct, row_mask.clone())?;
+    // Each pruning evaluation is fed the original split mask rather than the mask accumulated by
+    // the preceding conjuncts. Pruning masks are folded together with `bitand`, and intersection
+    // is associative and commutative, so the final mask is unchanged.
+    let mut dynamic_versions = Vec::with_capacity(conjunct_count);
+    let mut pruning_evals = Vec::with_capacity(conjunct_count);
+    for (idx, conjunct) in filter.conjuncts().iter().enumerate() {
+        // Store the latest version of the dynamic expression prior to pruning. We re-run the
+        // pruning if the version has changed by the time the task is polled.
+        dynamic_versions.push(filter.dynamic_updates(idx).map(|du| du.version()));
+        pruning_evals.push(reader.pruning_evaluation(&row_range, conjunct, row_mask.clone())?);
+    }
 
     let pruned = MaskFuture::new(len, {
         let reader = Arc::clone(&reader);
         let filter = Arc::clone(&filter);
-        let conjunct = conjunct.clone();
         let row_range = row_range.clone();
         async move {
-            let mut mask = row_mask.bitand(&pruning_eval.await?);
+            let mut mask = row_mask;
 
-            // If the dynamic expression has changed since pruning, re-run the pruning.
-            let current_version = filter.dynamic_updates(0).map(|du| du.version());
-            if let Some(dv) = current_version
-                && dynamic_version.is_none_or(|v| v < dv)
-                && !mask.all_false()
-            {
-                let conjunct_mask = reader
-                    .pruning_evaluation(&row_range, &conjunct, mask.clone())?
-                    .await?;
-                mask = mask.bitand(&conjunct_mask);
+            for pruning_eval in pruning_evals {
+                if mask.all_false() {
+                    // Dropping the remaining evaluations cancels their outstanding reads.
+                    return Ok(mask);
+                }
+                mask = mask.bitand(&pruning_eval.await?);
+            }
+
+            // Re-run the pruning for any conjunct whose dynamic expression has changed since.
+            for (idx, conjunct) in filter.conjuncts().iter().enumerate() {
+                if mask.all_false() {
+                    return Ok(mask);
+                }
+
+                let current_version = filter.dynamic_updates(idx).map(|du| du.version());
+                if let Some(dv) = current_version
+                    && dynamic_versions[idx].is_none_or(|v| v < dv)
+                {
+                    let conjunct_mask = reader
+                        .pruning_evaluation(&row_range, conjunct, mask.clone())?
+                        .await?;
+                    mask = mask.bitand(&conjunct_mask);
+                }
             }
 
             Ok(mask)
         }
     });
 
-    let filter_eval = reader.filter_evaluation(&row_range, &conjunct, pruned.clone())?;
+    let mut remaining = BitVec::from_elem(conjunct_count, true);
+    let mut chain = Vec::with_capacity(conjunct_count);
+    let mut mask_fut = pruned;
+    while let Some(idx) = filter.next_conjunct(&remaining) {
+        remaining.set(idx, false);
+        mask_fut = reader.filter_evaluation(&row_range, &filter.conjuncts()[idx], mask_fut)?;
+        chain.push((idx, mask_fut.clone()));
+    }
 
     Ok(MaskFuture::new(len, async move {
-        // Awaiting the pruned mask first lets us drop the filter evaluation, cancelling its
-        // reads, when pruning has already eliminated the entire split.
-        let pruned = pruned.await?;
-        if pruned.all_false() {
-            return Ok(pruned);
+        // Filter evaluations return a mask already intersected with the input mask, so the tail
+        // of the chain is the fully refined mask.
+        let mask = mask_fut.await?;
+
+        // Every link has resolved by the time the tail has, so these awaits are already complete.
+        for (idx, link) in chain {
+            filter.report_selectivity(idx, link.await?.density());
         }
 
-        // Filter evaluations return a mask already intersected with the input mask.
-        let mask = filter_eval.await?;
-        filter.report_selectivity(0, mask.density());
         Ok(mask)
     }))
 }

--- a/vortex-layout/src/scan/tasks.rs
+++ b/vortex-layout/src/scan/tasks.rs
@@ -4,6 +4,7 @@
 //! Split scanning task implementation.
 
 use std::ops::BitAnd;
+use std::ops::Range;
 use std::sync::Arc;
 
 use bit_vec::BitVec;
@@ -70,64 +71,70 @@ pub fn split_exec<A: 'static + Send>(
             let filter = Arc::clone(filter);
             let row_range = row_range.clone();
 
-            MaskFuture::new(row_mask.len(), async move {
-                let mut mask = row_mask;
-                let mut dynamic_versions = vec![None; filter.conjuncts().len()];
+            // A single-conjunct filter has no adaptive ordering to decide at runtime, so the
+            // whole evaluation can be built up-front.
+            if filter.conjuncts().len() == 1 {
+                single_conjunct_mask(reader, filter, row_range, row_mask)?
+            } else {
+                MaskFuture::new(row_mask.len(), async move {
+                    let mut mask = row_mask;
+                    let mut dynamic_versions = vec![None; filter.conjuncts().len()];
 
-                // TODO(ngates): we could use FuturedUnordered to intersect the masks in parallel.
-                for (idx, conjunct) in filter.conjuncts().iter().enumerate() {
-                    if mask.all_false() {
-                        return Ok(mask);
-                    }
+                    // TODO(ngates): we could use FuturedUnordered to intersect the masks in parallel.
+                    for (idx, conjunct) in filter.conjuncts().iter().enumerate() {
+                        if mask.all_false() {
+                            return Ok(mask);
+                        }
 
-                    // Store the latest version of the dynamic expression prior to pruning.
-                    // We will re-run the pruning later if the version has changed in the meantime.
-                    dynamic_versions[idx] = filter.dynamic_updates(idx).map(|du| du.version());
+                        // Store the latest version of the dynamic expression prior to pruning.
+                        // We will re-run the pruning later if the version has changed in the meantime.
+                        dynamic_versions[idx] = filter.dynamic_updates(idx).map(|du| du.version());
 
-                    let conjunct_mask = reader
-                        .pruning_evaluation(&row_range, conjunct, mask.clone())?
-                        .await?;
-                    mask = mask.bitand(&conjunct_mask);
-                }
-
-                // Now we loop through the conjuncts in the preferred order and evaluate them.
-                let mut remaining = BitVec::from_elem(filter.conjuncts().len(), true);
-                while let Some(idx) = filter.next_conjunct(&remaining) {
-                    remaining.set(idx, false);
-                    if mask.all_false() {
-                        return Ok(mask);
-                    }
-
-                    let conjunct = &filter.conjuncts()[idx];
-
-                    // If the dynamic expression has changed since pruning, re-run the pruning.
-                    // Store the dynamic update once to avoid TOCTOU race condition
-                    let current_version = filter.dynamic_updates(idx).map(|du| du.version());
-                    if let Some(dv) = current_version
-                        && dynamic_versions[idx].is_none_or(|v| v < dv)
-                    {
-                        // The dynamic expression has been updated, re-run the pruning.
-                        dynamic_versions[idx] = Some(dv);
                         let conjunct_mask = reader
                             .pruning_evaluation(&row_range, conjunct, mask.clone())?
                             .await?;
                         mask = mask.bitand(&conjunct_mask);
                     }
-                    if mask.all_false() {
-                        return Ok(mask);
+
+                    // Now we loop through the conjuncts in the preferred order and evaluate them.
+                    let mut remaining = BitVec::from_elem(filter.conjuncts().len(), true);
+                    while let Some(idx) = filter.next_conjunct(&remaining) {
+                        remaining.set(idx, false);
+                        if mask.all_false() {
+                            return Ok(mask);
+                        }
+
+                        let conjunct = &filter.conjuncts()[idx];
+
+                        // If the dynamic expression has changed since pruning, re-run the pruning.
+                        // Store the dynamic update once to avoid TOCTOU race condition
+                        let current_version = filter.dynamic_updates(idx).map(|du| du.version());
+                        if let Some(dv) = current_version
+                            && dynamic_versions[idx].is_none_or(|v| v < dv)
+                        {
+                            // The dynamic expression has been updated, re-run the pruning.
+                            dynamic_versions[idx] = Some(dv);
+                            let conjunct_mask = reader
+                                .pruning_evaluation(&row_range, conjunct, mask.clone())?
+                                .await?;
+                            mask = mask.bitand(&conjunct_mask);
+                        }
+                        if mask.all_false() {
+                            return Ok(mask);
+                        }
+
+                        let conjunct_mask = reader
+                            .filter_evaluation(&row_range, conjunct, MaskFuture::ready(mask))?
+                            .await?;
+                        filter.report_selectivity(idx, conjunct_mask.density());
+
+                        // Filter evaluations return a mask already intersected with the input mask.
+                        mask = conjunct_mask;
                     }
 
-                    let conjunct_mask = reader
-                        .filter_evaluation(&row_range, conjunct, MaskFuture::ready(mask))?
-                        .await?;
-                    filter.report_selectivity(idx, conjunct_mask.density());
-
-                    // Filter evaluations return a mask already intersected with the input mask.
-                    mask = conjunct_mask;
-                }
-
-                Ok(mask)
-            })
+                    Ok(mask)
+                })
+            }
         }
     };
 
@@ -148,6 +155,72 @@ pub fn split_exec<A: 'static + Send>(
     };
 
     Ok(array_fut.boxed())
+}
+
+/// Builds the filter mask for a filter made up of a single conjunct.
+///
+/// With only one conjunct there is no conjunct ordering to decide at runtime, so the whole
+/// pruning-then-filter chain can be constructed at task-construction time rather than when the
+/// task is first polled. This registers the conjunct's segment reads for every split before any
+/// split task runs, which lets the IO system coalesce them into larger reads.
+///
+/// It matters most when the filter column is not part of the projection: the projection
+/// evaluation is already built eagerly, so a filter over a projected column has its segments
+/// registered either way, but a filter over an unprojected column otherwise trickles its reads
+/// in one split at a time.
+fn single_conjunct_mask(
+    reader: Arc<dyn LayoutReader>,
+    filter: Arc<FilterExpr>,
+    row_range: Range<u64>,
+    row_mask: Mask,
+) -> VortexResult<MaskFuture> {
+    let len = row_mask.len();
+    let conjunct = filter.conjuncts()[0].clone();
+
+    // Store the latest version of the dynamic expression prior to pruning. We re-run the pruning
+    // if the version has changed by the time the task is polled.
+    let dynamic_version = filter.dynamic_updates(0).map(|du| du.version());
+    let pruning_eval = reader.pruning_evaluation(&row_range, &conjunct, row_mask.clone())?;
+
+    let pruned = MaskFuture::new(len, {
+        let reader = Arc::clone(&reader);
+        let filter = Arc::clone(&filter);
+        let conjunct = conjunct.clone();
+        let row_range = row_range.clone();
+        async move {
+            let mut mask = row_mask.bitand(&pruning_eval.await?);
+
+            // If the dynamic expression has changed since pruning, re-run the pruning.
+            let current_version = filter.dynamic_updates(0).map(|du| du.version());
+            if let Some(dv) = current_version
+                && dynamic_version.is_none_or(|v| v < dv)
+                && !mask.all_false()
+            {
+                let conjunct_mask = reader
+                    .pruning_evaluation(&row_range, &conjunct, mask.clone())?
+                    .await?;
+                mask = mask.bitand(&conjunct_mask);
+            }
+
+            Ok(mask)
+        }
+    });
+
+    let filter_eval = reader.filter_evaluation(&row_range, &conjunct, pruned.clone())?;
+
+    Ok(MaskFuture::new(len, async move {
+        // Awaiting the pruned mask first lets us drop the filter evaluation, cancelling its
+        // reads, when pruning has already eliminated the entire split.
+        let pruned = pruned.await?;
+        if pruned.all_false() {
+            return Ok(pruned);
+        }
+
+        // Filter evaluations return a mask already intersected with the input mask.
+        let mask = filter_eval.await?;
+        filter.report_selectivity(0, mask.density());
+        Ok(mask)
+    }))
 }
 
 /// Information needed to execute a single split task.


### PR DESCRIPTION
## Rationale for this change

Draft — **the I/O win is real but I could not turn it into a wall-clock win locally, and some shapes regress. Opening this so the repo's benchmark infrastructure can adjudicate on real hardware.**

`split_exec` already builds the projection evaluation outside the returned future, so projection segment reads for every split are registered before any split task is polled and the IO system can coalesce them. The filter evaluation gets no such treatment — it is built inside the `MaskFuture`, so a filter over a column that is **not** projected trickles its reads in one split at a time.

Measured on TPC-H `lineitem` at sf=10, filtering `l_linenumber > 5` while projecting only `l_extendedprice`, that costs 302 `pread64` calls versus 109 for the same filter when the filter column *is* projected. Splitting those reads by size: 150 of the 302 are under 1MB (p25 = 394KB) against a uniform ~2.26MB for the coalesced case. That population of small reads is the uncoalesced filter column.

## What changes are included in this PR?

One file, `vortex-layout/src/scan/tasks.rs`.

The filter evaluation cannot be hoisted in general: the conjunct order and the mask fed to each conjunct are chosen at runtime from selectivity statistics (`FilterExpr::next_conjunct`, `report_selectivity`). But when the filter has a **single conjunct** there is no ordering to choose, so the whole pruning-then-filter chain can be built at task-construction time. That case is handled by a new `single_conjunct_mask` helper; the multi-conjunct path is unchanged.

Two behaviours are preserved deliberately:

- The pruned mask is awaited *before* the filter evaluation, so a split that pruning eliminates entirely still drops — and therefore cancels — its filter reads. `MaskFuture` is `Shared`, so cloning it to do this is free.
- The dynamic-expression re-pruning check (`filter.dynamic_updates(0)` version comparison) still runs at poll time, since it depends on runtime state.

### Results

`pread64` counts, TPC-H `lineitem`, warm page cache. Row counts identical before/after on every shape at both scale factors.

| Query | sf=1 | sf=10 |
| --- | --- | --- |
| `lineitem_filter_only` (filter unprojected) | 30 → **20** | 302 → **177** |
| `lineitem` | 14 → 14 | 109 → 109 |
| `lineitem_and` (2 conjuncts, unchanged path) | 13 → 13 | 14 → 14 |
| `lineitem_prune` | 8 → 8 | 9 → 9 |
| `lineitem_wide` | 117 → 119 | 1162 → 1086 |

Execution time, median of 7 interleaved rounds (5 for `lineitem_wide`), each round itself the median of 15 executions (5 at sf=10, 3 for `lineitem_wide`):

| Query | sf=1 | sf=10 |
| --- | --- | --- |
| `lineitem_filter_only` | **+24.1%** | +4.3% |
| `lineitem` | −4.4% | **+26.1%** |
| `lineitem_and` | +2.0% | −0.4% |
| `lineitem_prune` | +5.3% | **+45.9%** |
| `lineitem_wide` | −4.1% | −0.9% |

So: fewer, larger reads, but slower on this machine. Two effects explain it, and both argue that a local warm-cache benchmark is the wrong oracle for this change:

1. **A saved `pread` is nearly free here.** The files are on local disk in page cache, so collapsing 302 reads into 177 saves syscalls but almost no latency. On object storage the request count is the dominant term.
2. **Eager construction moves work onto the serial path.** `RepeatedScan::execute` builds *every* split task in a loop before spawning any of them, so anything hoisted into `split_exec` leaves the worker threads and runs single-threaded ahead of execution. `lineitem_prune` at sf=10 (+45.9%, before 13–15ms vs 17–20ms, cleanly separated) is the clearest case: that query prunes away most of the file, so constructing a filter evaluation per split is work discarded on splits that pruning then eliminates. The early exit cancels the *reads* but not the *construction*.

I'd like the SQL benchmark suite to run before this is considered further; if it agrees with the local numbers, the honest conclusion is that this trade only pays off against remote storage and should be gated or dropped.

For the record, I first implemented the variant that hoists only the per-conjunct *pruning* evaluations. It changed pread counts by 0–1% and regressed `lineitem_filter_only` by ~20% at sf=1 (n=15, barely-overlapping distributions), because zone maps and pruning results are already memoized per-reader — `OnceLock<SharedZoneMap>` and `DashMap<BoundExpression, Option<SharedPruningResult>>` in `layouts/zoned/pruning.rs` — so registration order for those reads is irrelevant. That variant is not in this PR.

## What APIs are changed? Are there any user-facing changes?

None. No public API changes; `single_conjunct_mask` is a private helper. Behaviour is intended to be identical — same result arrays, same masks.

### Checks run

- `cargo nextest run -p vortex-layout -p vortex-file` — 326 passed
- `cargo clippy -p vortex-layout --all-targets --all-features` — clean
- `cargo +nightly fmt --all` — clean

Not run: the full workspace test suite, Python bindings, and docs checks — this change touches one Rust file with no API or documentation surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6qV3R62EBNgkd2Leq5YqZ)_