### PR TITLE
ci: move benchmark runners to c8id.metal-48xl

### DIFF
--- a/.github/workflows/develop-bench.yml
+++ b/.github/workflows/develop-bench.yml
@@ -83,7 +83,7 @@ jobs:
     timeout-minutes: 120
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=bench-dedicated/family=c6id.metal/extras=s3-cache/tag={1}', github.run_id, matrix.benchmark.id)
+          && format('runs-on={0}/runner=bench-dedicated/family=c8id.metal-48xl/extras=s3-cache/tag={1}', github.run_id, matrix.benchmark.id)
           || 'ubuntu-latest' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -30,4 +30,4 @@ jobs:
       matrix:
         machine_type:
           - id: x86
-            instance_name: c6id.metal
+            instance_name: c8id.metal-48xl

--- a/.github/workflows/pr-bench-runner.yml
+++ b/.github/workflows/pr-bench-runner.yml
@@ -75,7 +75,7 @@ jobs:
     timeout-minutes: 120
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=bench-dedicated/family=c6id.metal/tag={1}{2}', github.run_id, inputs.benchmark_id, github.event.pull_request.head.repo.fork == false && '/extras=s3-cache' || '')
+          && format('runs-on={0}/runner=bench-dedicated/family=c8id.metal-48xl/tag={1}{2}', github.run_id, inputs.benchmark_id, github.event.pull_request.head.repo.fork == false && '/extras=s3-cache' || '')
           || 'ubuntu-latest' }}
     steps:
       # `extras=s3-cache` points ACTIONS_RESULTS_URL at the RunsOn artifact proxy, but only

--- a/.github/workflows/sql-bench-matrix.yml
+++ b/.github/workflows/sql-bench-matrix.yml
@@ -13,7 +13,7 @@ on:
       machine_type:
         required: false
         type: string
-        default: c6id.metal
+        default: c8id.metal-48xl
 
 jobs:
   resolve-matrix:


### PR DESCRIPTION
## Rationale for this change

The benchmark workflows all pin their dedicated `runs-on` runner to the `c6id.metal` family. This moves them to `c8id.metal-48xl` so benchmarks execute on the newer generation bare-metal instance.

## What changes are included in this PR?

Replaced every `c6id.metal` runner reference with `c8id.metal-48xl`:

- `.github/workflows/pr-bench-runner.yml` — `family=` in the `bench` job's `runs-on` expression.
- `.github/workflows/develop-bench.yml` — `family=` in the `bench` job's `runs-on` expression.
- `.github/workflows/sql-bench-matrix.yml` — default value of the `machine_type` workflow_call input, which feeds the `build` and downstream jobs.
- `.github/workflows/nightly-bench.yml` — `instance_name` for the `x86` matrix entry passed into the SQL benchmark matrix.

No other `c6id.metal` references remain under `.github/`. The unrelated `ec2_c6id.8xlarge` string in `vortex-bench/src/runner.rs` is a runner-id parser test fixture, not a CI runner selection, so it is untouched.

## What APIs are changed? Are there any user-facing changes?

None. CI configuration only — no public API, feature flag, or generated-file changes.

### Checks run

- `yamllint --strict -c .yamllint.yaml` on the four changed workflow files — passes.
- Rust build/clippy/test checks were not run: this change touches only `.github/` YAML with no Rust or API impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EE1ue4mLVxfSXTXUNbB8Y6)_