### PR TITLE
Upload debug info and binaries in parallel after building SQL benchmarks

### DIFF
--- a/.github/workflows/sql-bench-matrix.yml
+++ b/.github/workflows/sql-bench-matrix.yml
@@ -74,27 +74,28 @@ jobs:
             packages+=(--bin lance-bench)
           fi
           cargo build "${packages[@]}" --profile release_debug --features unstable_encodings
-      - name: Upload binaries
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
-        with:
-          name: bench-binaries
-          path: |
-            target/release_debug/data-gen
-            target/release_debug/datafusion-bench
-            target/release_debug/duckdb-bench
-            target/release_debug/lance-bench
-            target/release_debug/build/vortex-duckdb-cache/duckdb-lib-*-prebuilt/libduckdb.so
-      - name: Pre-upload SQL benchmark debuginfo to Polar Signals
-        if: inputs.mode != 'pr' || github.event.pull_request.head.repo.fork == false
-        uses: ./.github/actions/upload-parca-debuginfo
-        continue-on-error: true
-        with:
-          paths: |
-            target/release_debug/datafusion-bench
-            target/release_debug/duckdb-bench
-            ${{ inputs.mode != 'pr' && 'target/release_debug/lance-bench' || '' }}
-          polarsignals-cloud-token: ${{ secrets.POLAR_SIGNALS_API_KEY }}
-          project-id: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
+      - parallel:
+        - name: Upload binaries
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+          with:
+            name: bench-binaries
+            path: |
+              target/release_debug/data-gen
+              target/release_debug/datafusion-bench
+              target/release_debug/duckdb-bench
+              target/release_debug/lance-bench
+              target/release_debug/build/vortex-duckdb-cache/duckdb-lib-*-prebuilt/libduckdb.so
+        - name: Pre-upload SQL benchmark debuginfo to Polar Signals
+          if: inputs.mode != 'pr' || github.event.pull_request.head.repo.fork == false
+          uses: ./.github/actions/upload-parca-debuginfo
+          continue-on-error: true
+          with:
+            paths: |
+              target/release_debug/datafusion-bench
+              target/release_debug/duckdb-bench
+              ${{ inputs.mode != 'pr' && 'target/release_debug/lance-bench' || '' }}
+            polarsignals-cloud-token: ${{ secrets.POLAR_SIGNALS_API_KEY }}
+            project-id: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
 
   bench:
     needs: [resolve-matrix, build]

--- a/.github/workflows/sql-bench-matrix.yml
+++ b/.github/workflows/sql-bench-matrix.yml
@@ -75,27 +75,27 @@ jobs:
           fi
           cargo build "${packages[@]}" --profile release_debug --features unstable_encodings
       - parallel:
-        - name: Upload binaries
-          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
-          with:
-            name: bench-binaries
-            path: |
-              target/release_debug/data-gen
-              target/release_debug/datafusion-bench
-              target/release_debug/duckdb-bench
-              target/release_debug/lance-bench
-              target/release_debug/build/vortex-duckdb-cache/duckdb-lib-*-prebuilt/libduckdb.so
-        - name: Pre-upload SQL benchmark debuginfo to Polar Signals
-          if: inputs.mode != 'pr' || github.event.pull_request.head.repo.fork == false
-          uses: ./.github/actions/upload-parca-debuginfo
-          continue-on-error: true
-          with:
-            paths: |
-              target/release_debug/datafusion-bench
-              target/release_debug/duckdb-bench
-              ${{ inputs.mode != 'pr' && 'target/release_debug/lance-bench' || '' }}
-            polarsignals-cloud-token: ${{ secrets.POLAR_SIGNALS_API_KEY }}
-            project-id: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
+          - name: Upload binaries
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+            with:
+              name: bench-binaries
+              path: |
+                target/release_debug/data-gen
+                target/release_debug/datafusion-bench
+                target/release_debug/duckdb-bench
+                target/release_debug/lance-bench
+                target/release_debug/build/vortex-duckdb-cache/duckdb-lib-*-prebuilt/libduckdb.so
+          - name: Pre-upload SQL benchmark debuginfo to Polar Signals
+            if: inputs.mode != 'pr' || github.event.pull_request.head.repo.fork == false
+            uses: ./.github/actions/upload-parca-debuginfo
+            continue-on-error: true
+            with:
+              paths: |
+                target/release_debug/datafusion-bench
+                target/release_debug/duckdb-bench
+                ${{ inputs.mode != 'pr' && 'target/release_debug/lance-bench' || '' }}
+                polarsignals-cloud-token: ${{ secrets.POLAR_SIGNALS_API_KEY }}
+                project-id: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
 
   bench:
     needs: [resolve-matrix, build]


### PR DESCRIPTION
## Rationale for this change

These steps are independent, so we can run them in parallel.