### PR TITLE
Share primitive binary operand decoding

### DIFF
--- a/vortex-array/src/scalar_fn/fns/binary/compare/primitive.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare/primitive.rs
@@ -18,10 +18,10 @@ use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::match_each_native_ptype;
 use crate::scalar::Scalar;
-use crate::scalar_fn::fns::binary::PrimitiveOperand;
 use crate::scalar_fn::fns::binary::compare::collect_bits;
 use crate::scalar_fn::fns::binary::compare::collect_zip_bits;
 use crate::scalar_fn::fns::binary::compare::compare_validity;
+use crate::scalar_fn::fns::binary::primitive_operand::PrimitiveOperand;
 use crate::scalar_fn::fns::operators::CompareOperator;
 
 /// Compare two primitive arrays of the same [`PType`].

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -43,6 +43,7 @@ mod compare;
 pub use compare::*;
 mod numeric;
 pub(crate) use numeric::*;
+mod primitive_operand;
 
 use crate::scalar::NumericOperator;
 use crate::scalar::Scalar;

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
@@ -13,7 +13,6 @@ mod primitive;
 mod tests;
 
 use decimal::execute_numeric_decimal;
-pub(crate) use primitive::PrimitiveOperand;
 use primitive::execute_numeric_primitive;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
@@ -14,7 +14,6 @@ use super::checked::checked_lanes;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrays::PrimitiveArray;
 use crate::builtins::ArrayBuiltins;
@@ -25,6 +24,7 @@ use crate::dtype::half::f16;
 use crate::match_each_native_ptype;
 use crate::scalar::NumericOperator;
 use crate::scalar::Scalar;
+use crate::scalar_fn::fns::binary::primitive_operand::PrimitiveOperand;
 use crate::validity::Validity;
 
 struct CheckedAdd;
@@ -252,62 +252,6 @@ where
         ConstantArray::new(Some(value), len).into_array()
     } else {
         ConstantArray::new(value, len).into_array()
-    }
-}
-
-/// A primitive binary-operator operand: a materialized buffer, a non-null constant, or an
-/// all-null constant.
-pub(crate) enum PrimitiveOperand<T: NativePType> {
-    Array {
-        values: Buffer<T>,
-        validity: Validity,
-    },
-    Constant {
-        value: T,
-        len: usize,
-        validity: Validity,
-    },
-    Null(usize),
-}
-
-impl<T: NativePType> PrimitiveOperand<T> {
-    pub(crate) fn try_new(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        if let Some(constant) = array.as_opt::<Constant>() {
-            return Ok(
-                match constant.scalar().as_primitive().try_typed_value::<T>()? {
-                    Some(value) => Self::Constant {
-                        value,
-                        len: array.len(),
-                        validity: if constant.scalar().dtype().is_nullable() {
-                            Validity::AllValid
-                        } else {
-                            Validity::NonNullable
-                        },
-                    },
-                    None => Self::Null(array.len()),
-                },
-            );
-        }
-
-        let array = array.clone().execute::<PrimitiveArray>(ctx)?;
-        let validity = array.validity()?;
-        let values = array.into_buffer::<T>();
-        Ok(Self::Array { values, validity })
-    }
-
-    pub(crate) fn len(&self) -> usize {
-        match self {
-            Self::Array { values, .. } => values.len(),
-            Self::Constant { len, .. } | Self::Null(len) => *len,
-        }
-    }
-
-    pub(crate) fn validity(&self) -> Validity {
-        match self {
-            Self::Array { validity, .. } => validity.clone(),
-            Self::Constant { validity, .. } => validity.clone(),
-            Self::Null(_) => Validity::AllInvalid,
-        }
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/binary/primitive_operand.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/primitive_operand.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Decoding shared by primitive binary operators.
+
+use vortex_buffer::Buffer;
+use vortex_error::VortexResult;
+
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::arrays::Constant;
+use crate::arrays::PrimitiveArray;
+use crate::dtype::NativePType;
+use crate::validity::Validity;
+
+/// A materialized primitive column, a non-null constant, or an all-null constant.
+pub(super) enum PrimitiveOperand<T: NativePType> {
+    Array {
+        values: Buffer<T>,
+        validity: Validity,
+    },
+    Constant {
+        value: T,
+        len: usize,
+        validity: Validity,
+    },
+    Null(usize),
+}
+
+impl<T: NativePType> PrimitiveOperand<T> {
+    pub(super) fn try_new(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+        if let Some(constant) = array.as_opt::<Constant>() {
+            return Ok(
+                match constant.scalar().as_primitive().try_typed_value::<T>()? {
+                    Some(value) => Self::Constant {
+                        value,
+                        len: array.len(),
+                        validity: if constant.scalar().dtype().is_nullable() {
+                            Validity::AllValid
+                        } else {
+                            Validity::NonNullable
+                        },
+                    },
+                    None => Self::Null(array.len()),
+                },
+            );
+        }
+
+        let array = array.clone().execute::<PrimitiveArray>(ctx)?;
+        let validity = array.validity()?;
+        let values = array.into_buffer::<T>();
+        Ok(Self::Array { values, validity })
+    }
+
+    pub(super) fn len(&self) -> usize {
+        match self {
+            Self::Array { values, .. } => values.len(),
+            Self::Constant { len, .. } | Self::Null(len) => *len,
+        }
+    }
+
+    pub(super) fn validity(&self) -> Validity {
+        match self {
+            Self::Array { validity, .. } => validity.clone(),
+            Self::Constant { validity, .. } => validity.clone(),
+            Self::Null(_) => Validity::AllInvalid,
+        }
+    }
+}


### PR DESCRIPTION
## Rationale for this change

Primitive comparison currently imports `PrimitiveOperand` through numeric execution. This moves the decoder to the binary module so both implementations depend on a neutral location.

Just thought it was weird where it is now