### PR TITLE
`RowFn` binary numeric `ScalarFn` rewrite

### DIFF
--- a/encodings/runend/src/trace_tests.rs
+++ b/encodings/runend/src/trace_tests.rs
@@ -73,6 +73,14 @@ fn trace_compare_on_runend() -> VortexResult<()> {
       iter 0 current=vortex.runend(bool, len=9) builder_active=false
     execute_until target=AnyCanonical root=vortex.binary(bool, len=3)
       iter 0 current=vortex.binary(bool, len=3) builder_active=false
+    optimize root=vortex.slice(i32, len=1) session=false
+      reduce_parent static:SliceReduceAdaptor(Constant) slot=0 parent=vortex.slice(i32, len=1) child=vortex.constant(i32, len=3) -> vortex.constant(i32, len=1)
+      done output=vortex.constant(i32, len=1)
+    execute_until target=AnyCanonical root=vortex.constant(i32, len=1)
+      iter 0 current=vortex.constant(i32, len=1) builder_active=false
+        Done array=vortex.primitive(i32, len=1)
+      iter 1 current=vortex.primitive(i32, len=1) builder_active=false
+      return output=vortex.primitive(i32, len=1)
         Done array=vortex.bool(bool, len=3)
       iter 1 current=vortex.bool(bool, len=3) builder_active=false
       return output=vortex.bool(bool, len=3)

--- a/vortex-array/benches/binary_ops.rs
+++ b/vortex-array/benches/binary_ops.rs
@@ -171,6 +171,14 @@ fn div_i64_nonnull(bencher: Bencher) {
 }
 
 #[divan::bench]
+fn div_i64_nullable(bencher: Bencher) {
+    let lhs = primitive_nullable(1_000_000, 7).into_array();
+    let rhs = primitive_nullable(17, 5).into_array();
+
+    bench_primitive(bencher, lhs, rhs, Operator::Div);
+}
+
+#[divan::bench]
 fn sub_i64_constant(bencher: Bencher) {
     let lhs = primitive_nonnull(0).into_array();
     let rhs = ConstantArray::new(37i64, LEN).into_array();

--- a/vortex-array/src/scalar/typed_view/primitive/numeric_operator.rs
+++ b/vortex-array/src/scalar/typed_view/primitive/numeric_operator.rs
@@ -10,7 +10,7 @@ use vortex_error::vortex_err;
 
 use crate::scalar_fn::fns::operators::Operator;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Binary element-wise operations.
 pub enum NumericOperator {
     /// Binary element-wise addition of two arrays or of two scalars.

--- a/vortex-array/src/scalar_fn/fns/binary/compare/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare/mod.rs
@@ -211,7 +211,7 @@ fn compare_arrays(
         )
         .into_array()),
         DType::Bool(_) => boolean::compare_bool(lhs, rhs, op, nullability, ctx),
-        DType::Primitive(..) => primitive::compare_primitive(lhs, rhs, op, nullability, ctx),
+        DType::Primitive(..) => primitive::compare_primitive(lhs, rhs, op, ctx),
         DType::Decimal(..) => decimal::compare_decimal(lhs, rhs, op, nullability, ctx),
         DType::Utf8(_) | DType::Binary(_) => bytes::compare_bytes(lhs, rhs, op, nullability, ctx),
         DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => {

--- a/vortex-array/src/scalar_fn/fns/binary/compare/primitive.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare/primitive.rs
@@ -1,27 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Native comparison of primitive arrays via bit-packing lane kernels.
+//! Primitive comparison execution through [`RowFn`].
 
-use vortex_buffer::BitBuffer;
+#[cfg(target_arch = "x86_64")]
+mod columnar;
+#[cfg(target_arch = "x86_64")]
+mod operand;
+
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
-use crate::IntoArray;
-use crate::arrays::BoolArray;
-use crate::arrays::ConstantArray;
 use crate::dtype::DType;
 use crate::dtype::NativePType;
-use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::match_each_native_ptype;
-use crate::scalar::Scalar;
-use crate::scalar_fn::fns::binary::compare::collect_bits;
-use crate::scalar_fn::fns::binary::compare::collect_zip_bits;
-use crate::scalar_fn::fns::binary::compare::compare_validity;
-use crate::scalar_fn::fns::binary::primitive_operand::PrimitiveOperand;
+use crate::scalar_fn::RowFn;
+use crate::scalar_fn::RowVisitor;
+use crate::scalar_fn::ScalarFnId;
+use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::VecExecutionArgs;
+use crate::scalar_fn::fns::binary::Binary;
 use crate::scalar_fn::fns::operators::CompareOperator;
 
 /// Compare two primitive arrays of the same [`PType`].
@@ -32,99 +33,78 @@ pub(super) fn compare_primitive(
     lhs: &ArrayRef,
     rhs: &ArrayRef,
     op: CompareOperator,
-    nullability: Nullability,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    let ptype = PType::try_from(lhs.dtype())?;
-    match_each_native_ptype!(ptype, |T| {
-        compare_primitive_typed::<T>(lhs, rhs, op, nullability, ctx)
-    })
+    #[cfg(target_arch = "x86_64")]
+    if use_columnar_comparison(lhs, rhs, op)? {
+        return columnar::compare_primitive(lhs, rhs, op, ctx);
+    }
+
+    let args = VecExecutionArgs::new(vec![lhs.clone(), rhs.clone()], lhs.len());
+
+    ScalarFnVTable::execute(&PrimitiveCompare, &op, &args, ctx)
 }
 
-fn compare_primitive_typed<T: NativePType>(
+/// Internal row execution for primitive comparison operators.
+#[derive(Clone)]
+struct PrimitiveCompare;
+
+impl RowFn for PrimitiveCompare {
+    type Options = CompareOperator;
+
+    const ARG_NAMES: &'static [&'static str] = &["lhs", "rhs"];
+
+    fn id(&self) -> ScalarFnId {
+        ScalarFnVTable::id(&Binary)
+    }
+
+    fn dispatch<V: RowVisitor>(
+        &self,
+        op: &Self::Options,
+        args: &[DType],
+        visitor: V,
+    ) -> VortexResult<V::VisitResult> {
+        let ptype =
+            PType::try_from(args.first().ok_or_else(|| {
+                vortex_err!("a comparison operator takes two operands, got none")
+            })?)?;
+
+        match_each_native_ptype!(ptype, |T| { visit_compare::<T, V>(*op, visitor) })
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+fn use_columnar_comparison(
     lhs: &ArrayRef,
     rhs: &ArrayRef,
     op: CompareOperator,
-    nullability: Nullability,
-    ctx: &mut ExecutionCtx,
-) -> VortexResult<ArrayRef> {
-    let len = lhs.len();
-    let lhs = PrimitiveOperand::<T>::try_new(lhs, ctx)?;
-    let rhs = PrimitiveOperand::<T>::try_new(rhs, ctx)?;
-    if lhs.len() != rhs.len() {
-        vortex_bail!(
-            "compare operator requires equal lengths, got {} and {}",
-            lhs.len(),
-            rhs.len()
-        );
+) -> VortexResult<bool> {
+    if matches!(op, CompareOperator::Eq | CompareOperator::NotEq) {
+        return Ok(false);
     }
 
-    let validity = compare_validity(lhs.validity(), rhs.validity(), nullability)?;
-
-    let bits = match (&lhs, &rhs) {
-        (
-            PrimitiveOperand::Array { values: lhs, .. },
-            PrimitiveOperand::Array { values: rhs, .. },
-        ) => compare_slices(lhs, rhs, op),
-        (
-            PrimitiveOperand::Array { values: lhs, .. },
-            PrimitiveOperand::Constant { value: rhs, .. },
-        ) => compare_slice_constant(lhs, *rhs, op),
-        (
-            PrimitiveOperand::Constant { value: lhs, .. },
-            PrimitiveOperand::Array { values: rhs, .. },
-        ) => compare_slice_constant(rhs, *lhs, op.swap()),
-        (
-            PrimitiveOperand::Constant { value: lhs, .. },
-            PrimitiveOperand::Constant { value: rhs, .. },
-        ) => {
-            // Unreachable through `execute_compare` (constant-constant is folded there), but
-            // cheap to answer anyway.
-            BitBuffer::full(apply_op(*lhs, *rhs, op), len)
-        }
-        (PrimitiveOperand::Null(_), _) | (_, PrimitiveOperand::Null(_)) => {
-            return Ok(
-                ConstantArray::new(Scalar::null(DType::Bool(Nullability::Nullable)), len)
-                    .into_array(),
-            );
-        }
-    };
-
-    Ok(BoolArray::try_new(bits, validity)?.into_array())
+    let ptype = PType::try_from(lhs.dtype())?;
+    Ok(match ptype {
+        // The fused comparison and bit-packing loop produces better x86 code for signed 64-bit
+        // integers and f64. The RowFn byte-output loop remains faster for narrower lanes.
+        PType::I64 | PType::F64 => true,
+        // LLVM vectorizes varying u64 inputs, but not the mixed-constant RowFn loop.
+        PType::U64 => lhs.as_constant().is_some() || rhs.as_constant().is_some(),
+        _ => false,
+    })
 }
 
-#[inline(always)]
-fn apply_op<T: NativePType>(lhs: T, rhs: T, op: CompareOperator) -> bool {
+fn visit_compare<T, V>(op: CompareOperator, visitor: V) -> VortexResult<V::VisitResult>
+where
+    T: NativePType,
+    V: RowVisitor,
+{
     match op {
-        CompareOperator::Eq => lhs.is_eq(rhs),
-        CompareOperator::NotEq => !lhs.is_eq(rhs),
-        CompareOperator::Gt => lhs.is_gt(rhs),
-        CompareOperator::Gte => lhs.is_ge(rhs),
-        CompareOperator::Lt => lhs.is_lt(rhs),
-        CompareOperator::Lte => lhs.is_le(rhs),
-    }
-}
-
-fn compare_slices<T: NativePType>(lhs: &[T], rhs: &[T], op: CompareOperator) -> BitBuffer {
-    // Dispatch the operator outside the lane loop so each instantiation vectorizes a single
-    // branch-free predicate.
-    match op {
-        CompareOperator::Eq => collect_zip_bits(lhs, rhs, |a: T, b: T| a.is_eq(b)),
-        CompareOperator::NotEq => collect_zip_bits(lhs, rhs, |a: T, b: T| !a.is_eq(b)),
-        CompareOperator::Gt => collect_zip_bits(lhs, rhs, T::is_gt),
-        CompareOperator::Gte => collect_zip_bits(lhs, rhs, T::is_ge),
-        CompareOperator::Lt => collect_zip_bits(lhs, rhs, T::is_lt),
-        CompareOperator::Lte => collect_zip_bits(lhs, rhs, T::is_le),
-    }
-}
-
-fn compare_slice_constant<T: NativePType>(lhs: &[T], rhs: T, op: CompareOperator) -> BitBuffer {
-    match op {
-        CompareOperator::Eq => collect_bits(lhs, |a: T| a.is_eq(rhs)),
-        CompareOperator::NotEq => collect_bits(lhs, |a: T| !a.is_eq(rhs)),
-        CompareOperator::Gt => collect_bits(lhs, |a: T| a.is_gt(rhs)),
-        CompareOperator::Gte => collect_bits(lhs, |a: T| a.is_ge(rhs)),
-        CompareOperator::Lt => collect_bits(lhs, |a: T| a.is_lt(rhs)),
-        CompareOperator::Lte => collect_bits(lhs, |a: T| a.is_le(rhs)),
+        CompareOperator::Eq => visitor.visit::<(T, T), bool>(|(lhs, rhs)| lhs.is_eq(rhs)),
+        CompareOperator::NotEq => visitor.visit::<(T, T), bool>(|(lhs, rhs)| !lhs.is_eq(rhs)),
+        CompareOperator::Gt => visitor.visit::<(T, T), bool>(|(lhs, rhs)| lhs.is_gt(rhs)),
+        CompareOperator::Gte => visitor.visit::<(T, T), bool>(|(lhs, rhs)| lhs.is_ge(rhs)),
+        CompareOperator::Lt => visitor.visit::<(T, T), bool>(|(lhs, rhs)| lhs.is_lt(rhs)),
+        CompareOperator::Lte => visitor.visit::<(T, T), bool>(|(lhs, rhs)| lhs.is_le(rhs)),
     }
 }

--- a/vortex-array/src/scalar_fn/fns/binary/compare/primitive/columnar.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare/primitive/columnar.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Fused comparison and bit-packing for wide x86 lanes.
+
+use vortex_buffer::BitBuffer;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+
+use super::operand::PrimitiveOperand;
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::IntoArray;
+use crate::arrays::BoolArray;
+use crate::arrays::ConstantArray;
+use crate::dtype::DType;
+use crate::dtype::NativePType;
+use crate::dtype::Nullability;
+use crate::dtype::PType;
+use crate::scalar::Scalar;
+use crate::scalar_fn::fns::binary::compare::collect_bits;
+use crate::scalar_fn::fns::binary::compare::collect_zip_bits;
+use crate::scalar_fn::fns::binary::compare::compare_validity;
+use crate::scalar_fn::fns::operators::CompareOperator;
+
+/// Compare primitive operands with one fused comparison and bit-packing loop.
+pub(super) fn compare_primitive(
+    lhs: &ArrayRef,
+    rhs: &ArrayRef,
+    op: CompareOperator,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    match PType::try_from(lhs.dtype())? {
+        PType::I64 => compare_primitive_typed::<i64>(lhs, rhs, op, ctx),
+        PType::U64 => compare_primitive_typed::<u64>(lhs, rhs, op, ctx),
+        PType::F64 => compare_primitive_typed::<f64>(lhs, rhs, op, ctx),
+        ptype => vortex_bail!("columnar comparison is not selected for {ptype}"),
+    }
+}
+
+fn compare_primitive_typed<T: NativePType>(
+    lhs: &ArrayRef,
+    rhs: &ArrayRef,
+    op: CompareOperator,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let len = lhs.len();
+    let nullability = Nullability::from(lhs.dtype().is_nullable() || rhs.dtype().is_nullable());
+    let lhs = PrimitiveOperand::<T>::try_new(lhs, ctx)?;
+    let rhs = PrimitiveOperand::<T>::try_new(rhs, ctx)?;
+    if lhs.len() != rhs.len() {
+        vortex_bail!(
+            "compare operator requires equal lengths, got {} and {}",
+            lhs.len(),
+            rhs.len()
+        );
+    }
+
+    let validity = compare_validity(lhs.validity(), rhs.validity(), nullability)?;
+    let bits = match (&lhs, &rhs) {
+        (
+            PrimitiveOperand::Array { values: lhs, .. },
+            PrimitiveOperand::Array { values: rhs, .. },
+        ) => compare_slices(lhs, rhs, op),
+        (
+            PrimitiveOperand::Array { values: lhs, .. },
+            PrimitiveOperand::Constant { value: rhs, .. },
+        ) => compare_slice_constant(lhs, *rhs, op),
+        (
+            PrimitiveOperand::Constant { value: lhs, .. },
+            PrimitiveOperand::Array { values: rhs, .. },
+        ) => compare_slice_constant(rhs, *lhs, op.swap()),
+        (
+            PrimitiveOperand::Constant { value: lhs, .. },
+            PrimitiveOperand::Constant { value: rhs, .. },
+        ) => BitBuffer::full(apply_op(*lhs, *rhs, op), len),
+        (PrimitiveOperand::Null(_), _) | (_, PrimitiveOperand::Null(_)) => {
+            return Ok(
+                ConstantArray::new(Scalar::null(DType::Bool(Nullability::Nullable)), len)
+                    .into_array(),
+            );
+        }
+    };
+
+    Ok(BoolArray::try_new(bits, validity)?.into_array())
+}
+
+#[inline(always)]
+fn apply_op<T: NativePType>(lhs: T, rhs: T, op: CompareOperator) -> bool {
+    match op {
+        CompareOperator::Eq => lhs.is_eq(rhs),
+        CompareOperator::NotEq => !lhs.is_eq(rhs),
+        CompareOperator::Gt => lhs.is_gt(rhs),
+        CompareOperator::Gte => lhs.is_ge(rhs),
+        CompareOperator::Lt => lhs.is_lt(rhs),
+        CompareOperator::Lte => lhs.is_le(rhs),
+    }
+}
+
+fn compare_slices<T: NativePType>(lhs: &[T], rhs: &[T], op: CompareOperator) -> BitBuffer {
+    match op {
+        CompareOperator::Eq => collect_zip_bits(lhs, rhs, |lhs: T, rhs: T| lhs.is_eq(rhs)),
+        CompareOperator::NotEq => collect_zip_bits(lhs, rhs, |lhs: T, rhs: T| !lhs.is_eq(rhs)),
+        CompareOperator::Gt => collect_zip_bits(lhs, rhs, T::is_gt),
+        CompareOperator::Gte => collect_zip_bits(lhs, rhs, T::is_ge),
+        CompareOperator::Lt => collect_zip_bits(lhs, rhs, T::is_lt),
+        CompareOperator::Lte => collect_zip_bits(lhs, rhs, T::is_le),
+    }
+}
+
+fn compare_slice_constant<T: NativePType>(lhs: &[T], rhs: T, op: CompareOperator) -> BitBuffer {
+    match op {
+        CompareOperator::Eq => collect_bits(lhs, |lhs: T| lhs.is_eq(rhs)),
+        CompareOperator::NotEq => collect_bits(lhs, |lhs: T| !lhs.is_eq(rhs)),
+        CompareOperator::Gt => collect_bits(lhs, |lhs: T| lhs.is_gt(rhs)),
+        CompareOperator::Gte => collect_bits(lhs, |lhs: T| lhs.is_ge(rhs)),
+        CompareOperator::Lt => collect_bits(lhs, |lhs: T| lhs.is_lt(rhs)),
+        CompareOperator::Lte => collect_bits(lhs, |lhs: T| lhs.is_le(rhs)),
+    }
+}

--- a/vortex-array/src/scalar_fn/fns/binary/compare/primitive/operand.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare/primitive/operand.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Decoding shared by primitive binary operators.
+//! Operand decoding for the fused primitive comparison path.
 
 use vortex_buffer::Buffer;
 use vortex_error::VortexResult;
@@ -15,19 +15,33 @@ use crate::validity::Validity;
 
 /// A materialized primitive column, a non-null constant, or an all-null constant.
 pub(super) enum PrimitiveOperand<T: NativePType> {
+    /// A varying primitive column and its validity.
     Array {
+        /// The materialized values.
         values: Buffer<T>,
+
+        /// The validity of the values.
         validity: Validity,
     },
+
+    /// A non-null value repeated for every row.
     Constant {
+        /// The repeated value.
         value: T,
+
+        /// The number of repeated rows.
         len: usize,
+
+        /// The validity implied by the constant's dtype.
         validity: Validity,
     },
+
+    /// An all-null constant with this row count.
     Null(usize),
 }
 
 impl<T: NativePType> PrimitiveOperand<T> {
+    /// Decode an operand once for the fused comparison loop.
     pub(super) fn try_new(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
         if let Some(constant) = array.as_opt::<Constant>() {
             return Ok(
@@ -49,9 +63,11 @@ impl<T: NativePType> PrimitiveOperand<T> {
         let array = array.clone().execute::<PrimitiveArray>(ctx)?;
         let validity = array.validity()?;
         let values = array.into_buffer::<T>();
+
         Ok(Self::Array { values, validity })
     }
 
+    /// Return the logical row count.
     pub(super) fn len(&self) -> usize {
         match self {
             Self::Array { values, .. } => values.len(),
@@ -59,6 +75,7 @@ impl<T: NativePType> PrimitiveOperand<T> {
         }
     }
 
+    /// Return the operand validity.
     pub(super) fn validity(&self) -> Validity {
         match self {
             Self::Array { validity, .. } => validity.clone(),

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -43,7 +43,6 @@ mod compare;
 pub use compare::*;
 mod numeric;
 pub(crate) use numeric::*;
-mod primitive_operand;
 
 use crate::scalar::NumericOperator;
 use crate::scalar::Scalar;

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/checked.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/checked.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Checked-lane execution for numeric kernels, driven by the shared
+//! Checked-lane execution for the decimal kernels, driven by the shared
 //! `vortex-compute` lane kernels.
-
-use std::ops::BitOrAssign;
+//!
+//! The primitive widths do not come through here: they are computed one row at a time by
+//! [`row`](super::row), which writes a value for every row and reduces failure evidence without
+//! scanning the finished output.
 
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
@@ -13,33 +15,18 @@ use vortex_compute::lane_kernels::IndexedSourceExt;
 use vortex_mask::AllOr;
 use vortex_mask::Mask;
 
-/// Evidence that a lane failed, anything other than [`Default`] meaning failure.
-///
-/// `bool` is the ordinary choice; [`map_checked_into`] explains why the wider members exist and
-/// asserts the width bound that membership here does **not** imply.
-///
-/// [`map_checked_into`]: IndexedSourceExt::map_checked_into
-pub(super) trait Failure: Copy + Default + PartialEq + BitOrAssign {}
-
-impl Failure for bool {}
-impl Failure for u8 {}
-impl Failure for u16 {}
-impl Failure for u32 {}
-impl Failure for u64 {}
-
 /// Apply the fallible `apply` over every lane of `source`, returning
-/// `Err(first_failing_valid_lane)` only when it returns `None` on a _valid_ lane.
+/// `Err(first_failing_valid_lane)` only when it returns `None` on a valid lane.
 ///
 /// `apply` also runs on invalid lanes, whose failures are masked out and whose values are
 /// unspecified, so it must be total: no panics or side effects on any stored lane value.
 ///
-/// This drives the one-pass early-exit kernels, which abort at the end of the enclosing 64-lane
-/// chunk. Use it when per-lane failure handling is cheap relative to the operation, as in integer
-/// division. Prefer [`checked_apply_lanes`] when the failure check itself vectorizes.
+/// This drives the one-pass early-exit kernels: failures abort at the end of the enclosing
+/// 64-lane chunk. It suits an operation whose per-lane failure handling is cheap relative to the
+/// operation itself, which is what the decimal kernels and their per-lane casts are.
 ///
-/// `#[inline]`: this must inline into the caller that builds the closure, so that a captured
-/// constant operand flattens into a register rather than living behind a pointer the loop reloads
-/// on every lane, which blocks vectorization.
+/// Keep this wrapper inlineable so captured constants can become loop invariants in the caller.
+/// The lane kernels retain their own inlining decisions.
 #[inline]
 pub(super) fn checked_lanes<S, T, Apply>(
     source: S,
@@ -61,63 +48,10 @@ where
     };
 
     let mut values = BufferMut::<T>::with_capacity(len);
-
     let out = &mut values.spare_capacity_mut()[..len];
     match valid_bits {
         None => source.try_map_into(out, apply)?,
         Some(valid_bits) => source.try_map_masked_into(valid_bits, out, apply)?,
-    }
-
-    // SAFETY: the kernels initialize every lane in `out`.
-    unsafe { values.set_len(len) };
-
-    Ok(values.freeze())
-}
-
-/// Apply the split value/failure `apply` over every lane of `source`, returning
-/// `Err(first_failing_valid_lane)` only when it flags a _valid_ lane.
-///
-/// The hot pass writes every value unconditionally and OR-reduces one piece of evidence, leaving
-/// the loop free of per-lane selects and per-chunk exit branches. Only if a lane flagged does a
-/// cold second pass re-run `apply` through the early-exit kernels, which drop null-lane failures
-/// and attribute the first valid one.
-///
-/// Like [`checked_lanes`], `apply` runs on invalid lanes and must be total.
-///
-/// `#[inline]`: see [`checked_lanes`].
-#[inline]
-pub(super) fn checked_apply_lanes<S, T, Fail, Apply>(
-    source: S,
-    valid_rows: &Mask,
-    mut apply: Apply,
-) -> Result<Buffer<T>, usize>
-where
-    S: IndexedSource + Copy,
-    T: Copy + Default,
-    Fail: Failure,
-    Apply: FnMut(S::Item) -> (T, Fail),
-{
-    let len = source.len();
-    debug_assert_eq!(len, valid_rows.len());
-
-    let valid_bits = match valid_rows.bit_buffer() {
-        AllOr::All => None,
-        AllOr::None => return Ok(Buffer::zeroed(len)),
-        AllOr::Some(valid_bits) => Some(valid_bits),
-    };
-
-    let mut values = BufferMut::<T>::with_capacity(len);
-
-    let out = &mut values.spare_capacity_mut()[..len];
-    if source.map_checked_into(out, &mut apply) != Fail::default() {
-        let mut checked = |item: S::Item| {
-            let (value, failure) = apply(item);
-            (failure == Fail::default()).then_some(value)
-        };
-        match valid_bits {
-            None => source.try_map_into(out, &mut checked)?,
-            Some(valid_bits) => source.try_map_masked_into(valid_bits, out, &mut checked)?,
-        }
     }
 
     // SAFETY: the kernels initialize every lane in `out`.

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/mod.rs
@@ -4,16 +4,19 @@
 //! Native execution of the arithmetic operators (Add/Sub/Mul/Div) of the [`Binary`] scalar
 //! function. There is no Arrow fallback.
 //!
+//! The primitive widths are computed by a [`RowFn`](crate::scalar_fn::RowFn), which owns null
+//! handling, constants, and validity for them; see [`row`]. Decimal keeps its own columnar
+//! implementation in [`decimal`].
+//!
 //! [`Binary`]: super::Binary
 
 mod checked;
 mod decimal;
 mod primitive;
-#[cfg(test)]
-mod tests;
+mod row;
 
 use decimal::execute_numeric_decimal;
-use primitive::execute_numeric_primitive;
+use row::execute_numeric_primitive;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 
@@ -81,3 +84,6 @@ fn build_empty_result(
 
     Ok(Canonical::empty(&result_dtype).into_array())
 }
+
+#[cfg(test)]
+mod tests;

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/primitive.rs
@@ -1,73 +1,48 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_buffer::Buffer;
-use vortex_compute::lane_kernels::IndexedSource;
-use vortex_compute::lane_kernels::LaneZip;
-use vortex_error::VortexResult;
-use vortex_error::vortex_err;
-use vortex_mask::Mask;
+//! Checked arithmetic for one primitive row.
 
-use super::checked::Failure;
-use super::checked::checked_apply_lanes;
-use super::checked::checked_lanes;
-use crate::ArrayRef;
-use crate::ExecutionCtx;
-use crate::IntoArray;
-use crate::arrays::ConstantArray;
-use crate::arrays::PrimitiveArray;
-use crate::builtins::ArrayBuiltins;
-use crate::dtype::DType;
+use std::ops::BitOrAssign;
+
 use crate::dtype::NativePType;
-use crate::dtype::PType;
 use crate::dtype::half::f16;
-use crate::match_each_native_ptype;
-use crate::scalar::NumericOperator;
-use crate::scalar::Scalar;
-use crate::scalar_fn::fns::binary::primitive_operand::PrimitiveOperand;
-use crate::validity::Validity;
 
-struct CheckedAdd;
+/// Checked addition, failing on integer overflow.
+pub(super) struct CheckedAdd;
 
-struct CheckedSub;
+/// Checked subtraction, failing on integer overflow.
+pub(super) struct CheckedSub;
 
-struct CheckedMul;
+/// Checked multiplication, failing on integer overflow.
+pub(super) struct CheckedMul;
 
-struct CheckedDiv;
+/// Checked division, failing on integer division by zero and on `MIN / -1`.
+pub(super) struct CheckedDiv;
 
-trait CheckedPrimitiveOp<T: NativePType>: Sized {
-    /// Message for the error raised when this operation fails on a valid lane.
+/// OR-reducible evidence that a row failed, with [`Default`] meaning success.
+pub(super) trait Failure: Copy + Default + PartialEq + BitOrAssign {}
+
+impl<T: Copy + Default + PartialEq + BitOrAssign> Failure for T {}
+
+/// One arithmetic operator at one width, split into its value and failure evidence.
+pub(super) trait CheckedPrimitiveOp<T: NativePType>: 'static + Sized {
+    /// The error reported for a batch in which some valid row failed.
     const ERROR: &'static str;
 
-    /// Whether to check inside the value loop and exit early, rather than reducing evidence over
-    /// the whole batch and re-running only once some lane has flagged.
-    const CHECKED_VALUE_LOOP: bool = false;
+    /// How this operation reports a failing row. See [`Failure`].
+    type Fail: Failure;
 
-    /// How this operation reports a failing lane. See [`Failure`].
-    type Failure: Failure;
-
-    /// Compute a lane's value and its failure evidence together.
-    ///
-    /// Overflowing-style rather than `Option<T>`, so the vectorizable kernels can write every
-    /// lane's value unconditionally and reduce the evidence separately. [`Self::checked`] is the
-    /// shape for the scalar and early-exit paths.
-    fn apply(lhs: T, rhs: T) -> (T, Self::Failure);
-
-    /// [`Self::apply`] folded into the `Option` that the early-exit kernels take.
-    #[inline(always)]
-    fn checked(lhs: T, rhs: T) -> Option<T> {
-        let (value, failed) = Self::apply(lhs, rhs);
-
-        (failed == Self::Failure::default()).then_some(value)
-    }
+    /// The result of this operation, paired with evidence of whether the row failed.
+    fn apply(lhs: T, rhs: T) -> (T, Self::Fail);
 }
 
 impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedAdd {
     const ERROR: &'static str = "integer overflow in checked add";
 
-    type Failure = bool;
+    type Fail = bool;
 
-    #[inline(always)]
+    #[inline]
     fn apply(lhs: T, rhs: T) -> (T, bool) {
         (lhs.add_value(rhs), lhs.add_error(rhs))
     }
@@ -76,9 +51,9 @@ impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedAdd {
 impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedSub {
     const ERROR: &'static str = "integer overflow in checked sub";
 
-    type Failure = bool;
+    type Fail = bool;
 
-    #[inline(always)]
+    #[inline]
     fn apply(lhs: T, rhs: T) -> (T, bool) {
         (lhs.sub_value(rhs), lhs.sub_error(rhs))
     }
@@ -87,9 +62,9 @@ impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedSub {
 impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedMul {
     const ERROR: &'static str = "integer overflow in checked mul";
 
-    type Failure = T::MulFailure;
+    type Fail = T::MulFailure;
 
-    #[inline(always)]
+    #[inline]
     fn apply(lhs: T, rhs: T) -> (T, T::MulFailure) {
         (lhs.mul_value(rhs), lhs.mul_failure(rhs))
     }
@@ -97,16 +72,10 @@ impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedMul {
 
 impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedDiv {
     const ERROR: &'static str = "integer division by zero or overflow in checked div";
-    // Integer division still lowers to scalar divides, so the split
-    // value/error-scan loop used to auto-vectorize add/sub/mul only adds a
-    // second full scan. Use the one-pass early-exit checked kernel for integer
-    // division, matching Arrow/Velox. Float division has no checked errors and
-    // stays on the split/vectorizable default path.
-    const CHECKED_VALUE_LOOP: bool = T::DIV_CHECKS_IN_VALUE_LOOP;
 
-    type Failure = bool;
+    type Fail = bool;
 
-    #[inline(always)]
+    #[inline]
     fn apply(lhs: T, rhs: T) -> (T, bool) {
         let failed = lhs.div_error(rhs);
         let value = if failed {
@@ -116,151 +85,13 @@ impl<T: CheckedArithmetic> CheckedPrimitiveOp<T> for CheckedDiv {
         };
         (value, failed)
     }
-
-    #[inline(always)]
-    fn checked(lhs: T, rhs: T) -> Option<T> {
-        lhs.div_checked(rhs)
-    }
 }
 
-/// Execute a numeric operation between two primitive-typed arrays.
-pub(super) fn execute_numeric_primitive(
-    lhs: &ArrayRef,
-    rhs: &ArrayRef,
-    op: NumericOperator,
-    ctx: &mut ExecutionCtx,
-) -> VortexResult<ArrayRef> {
-    let ptype = PType::try_from(lhs.dtype())?;
-
-    match_each_native_ptype!(ptype, |T| {
-        match op {
-            NumericOperator::Add => execute_checked_typed::<T, CheckedAdd>(lhs, rhs, ctx),
-            NumericOperator::Sub => execute_checked_typed::<T, CheckedSub>(lhs, rhs, ctx),
-            NumericOperator::Mul => execute_checked_typed::<T, CheckedMul>(lhs, rhs, ctx),
-            NumericOperator::Div => execute_checked_typed::<T, CheckedDiv>(lhs, rhs, ctx),
-        }
-    })
-}
-
-fn execute_checked_typed<T, Op>(
-    lhs: &ArrayRef,
-    rhs: &ArrayRef,
-    ctx: &mut ExecutionCtx,
-) -> VortexResult<ArrayRef>
-where
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-    Scalar: From<T>,
-    Scalar: From<Option<T>>,
-{
-    let result_dtype = lhs
-        .dtype()
-        .with_nullability(lhs.dtype().nullability() | rhs.dtype().nullability());
-    let lhs = PrimitiveOperand::<T>::try_new(lhs, ctx)?;
-    let rhs = PrimitiveOperand::<T>::try_new(rhs, ctx)?;
-    let len = lhs.len();
-    debug_assert_eq!(len, rhs.len());
-
-    let validity = lhs.validity().and(rhs.validity())?;
-    let valid_rows = validity.execute_mask(len, ctx)?;
-
-    let values = match (&lhs, &rhs) {
-        (
-            PrimitiveOperand::Array { values: lhs, .. },
-            PrimitiveOperand::Array { values: rhs, .. },
-        ) => checked_op_lanes::<_, T, Op>(
-            LaneZip::new(lhs.as_slice(), rhs.as_slice()),
-            &valid_rows,
-            |(lhs, rhs)| (lhs, rhs),
-        ),
-        (
-            PrimitiveOperand::Array { values: lhs, .. },
-            PrimitiveOperand::Constant { value: rhs, .. },
-        ) => {
-            // Capture the constant by value so it stays hoisted out of the lane loop.
-            let rhs = *rhs;
-            checked_op_lanes::<_, T, Op>(lhs.as_slice(), &valid_rows, move |lhs| (lhs, rhs))
-        }
-        (
-            PrimitiveOperand::Constant { value: lhs, .. },
-            PrimitiveOperand::Array { values: rhs, .. },
-        ) => {
-            let lhs = *lhs;
-            checked_op_lanes::<_, T, Op>(rhs.as_slice(), &valid_rows, move |rhs| (lhs, rhs))
-        }
-        (
-            PrimitiveOperand::Constant { value: lhs, .. },
-            PrimitiveOperand::Constant { value: rhs, .. },
-        ) => {
-            let value = Op::checked(*lhs, *rhs)
-                .ok_or_else(|| vortex_err!(InvalidArgument: "{}", Op::ERROR))?;
-            return Ok(constant_result_array(value, len, &result_dtype));
-        }
-        (PrimitiveOperand::Null(_), _) | (_, PrimitiveOperand::Null(_)) => Ok(Buffer::zeroed(len)),
-    }
-    .map_err(|_lane| vortex_err!(InvalidArgument: "{}", Op::ERROR))?;
-
-    primitive_result_array::<T>(values, validity, &result_dtype)
-}
-
-/// Run `Op` over the lanes of `source` in the loop shape it declares: the one-pass early-exit
-/// kernel when `Op::CHECKED_VALUE_LOOP` is set, and the split value/failure kernel otherwise.
-///
-/// `#[inline]`: see [`checked_lanes`].
-#[inline]
-fn checked_op_lanes<S, T, Op>(
-    source: S,
-    valid_rows: &Mask,
-    mut to_operands: impl FnMut(S::Item) -> (T, T),
-) -> Result<Buffer<T>, usize>
-where
-    S: IndexedSource + Copy,
-    T: NativePType,
-    Op: CheckedPrimitiveOp<T>,
-{
-    if Op::CHECKED_VALUE_LOOP {
-        checked_lanes(source, valid_rows, |item| {
-            let (lhs, rhs) = to_operands(item);
-            Op::checked(lhs, rhs)
-        })
-    } else {
-        checked_apply_lanes(source, valid_rows, |item| {
-            let (lhs, rhs) = to_operands(item);
-            Op::apply(lhs, rhs)
-        })
-    }
-}
-
-fn primitive_result_array<T: NativePType>(
-    values: Buffer<T>,
-    validity: Validity,
-    dtype: &DType,
-) -> VortexResult<ArrayRef> {
-    let array = PrimitiveArray::new(values, validity).into_array();
-    if array.dtype() == dtype {
-        return Ok(array);
-    }
-    array.cast(dtype.clone())
-}
-
-fn constant_result_array<T>(value: T, len: usize, dtype: &DType) -> ArrayRef
-where
-    T: NativePType,
-    Scalar: From<T> + From<Option<T>>,
-{
-    if dtype.is_nullable() {
-        ConstantArray::new(Some(value), len).into_array()
-    } else {
-        ConstantArray::new(value, len).into_array()
-    }
-}
-
-trait CheckedArithmetic: NativePType {
-    const DIV_CHECKS_IN_VALUE_LOOP: bool;
-
-    /// How multiplication reports a failing lane, which is width-dependent in a way the other
-    /// operations are not. `impl_checked_unsigned!` and `impl_checked_signed!` say why each family
-    /// reports what it reports.
+/// Per-width checked arithmetic. Every value method **must** be total over stored lane values.
+pub(super) trait CheckedArithmetic: NativePType {
+    /// How multiplication reports a failing row.
+    ///
+    /// This may be a word rather than `bool` when narrowing evidence would block vectorization.
     type MulFailure: Failure;
 
     fn add_value(self, rhs: Self) -> Self;
@@ -271,16 +102,9 @@ trait CheckedArithmetic: NativePType {
     fn mul_failure(self, rhs: Self) -> Self::MulFailure;
     fn div_value(self, rhs: Self) -> Self;
     fn div_error(self, rhs: Self) -> bool;
-    fn div_checked(self, rhs: Self) -> Option<Self>;
 }
 
-/// The integer arithmetic every width shares, given the two things that actually differ between
-/// them: how multiplication reports a failing lane, and how add/sub/div detect one.
-///
-/// Only `mul_failure` genuinely varies per width, so it is the macro's parameter and everything
-/// else is written once. The `$mul_failure_ty` and body are supplied by the caller because the
-/// choice between a widened high half and a `bool` is exactly the vectorization decision described
-/// on [`Failure`].
+/// Generate the shared integer operations from their failure predicates.
 macro_rules! impl_checked_integer {
     (
         $ty:ty,
@@ -291,67 +115,57 @@ macro_rules! impl_checked_integer {
             = |$mf_lhs:ident, $mf_rhs:ident| $mul_failure:expr,
     ) => {
         impl CheckedArithmetic for $ty {
-            const DIV_CHECKS_IN_VALUE_LOOP: bool = true;
-
             type MulFailure = $mul_failure_ty;
 
-            #[inline(always)]
+            #[inline]
             fn add_value(self, rhs: Self) -> Self {
                 self.wrapping_add(rhs)
             }
 
-            #[inline(always)]
+            #[inline]
             fn add_error(self, rhs: Self) -> bool {
                 let ($add_lhs, $add_rhs) = (self, rhs);
                 $add_error
             }
 
-            #[inline(always)]
+            #[inline]
             fn sub_value(self, rhs: Self) -> Self {
                 self.wrapping_sub(rhs)
             }
 
-            #[inline(always)]
+            #[inline]
             fn sub_error(self, rhs: Self) -> bool {
                 let ($sub_lhs, $sub_rhs) = (self, rhs);
                 $sub_error
             }
 
-            #[inline(always)]
+            #[inline]
             fn mul_value(self, rhs: Self) -> Self {
                 self.wrapping_mul(rhs)
             }
 
-            #[inline(always)]
+            #[inline]
             $(#[$mul_failure_attr])*
             fn mul_failure(self, rhs: Self) -> $mul_failure_ty {
                 let ($mf_lhs, $mf_rhs) = (self, rhs);
                 $mul_failure
             }
 
-            #[inline(always)]
+            #[inline]
             fn div_value(self, rhs: Self) -> Self {
                 self / rhs
             }
 
-            #[inline(always)]
+            #[inline]
             fn div_error(self, rhs: Self) -> bool {
                 let ($div_lhs, $div_rhs) = (self, rhs);
                 $div_error
-            }
-
-            #[inline(always)]
-            fn div_checked(self, rhs: Self) -> Option<Self> {
-                self.checked_div(rhs)
             }
         }
     };
 }
 
-/// The unsigned widths. `add`, `sub` and `div` are written once here, and `widening_mul` covers
-/// every width including the 64-bit one, which widens into `u128`: the discarded high half of the
-/// widened product is the failure evidence, and costs none of the comparison LLVM folds into
-/// `umul.with.overflow`.
+/// Unsigned multiplication reports its discarded high half as failure evidence.
 macro_rules! impl_checked_unsigned {
     ($ty:ty, widening_mul: $wide:ty) => {
         impl_checked_integer!(
@@ -364,12 +178,7 @@ macro_rules! impl_checked_unsigned {
     };
 }
 
-/// The signed widths, on the same principle. `widening_mul` is the shorthand for the narrow widths,
-/// whose two-sided range check over a wider product is not the shape LLVM folds into an overflow
-/// intrinsic, so they vectorize while reporting a plain `bool`. The 64-bit width cannot: deriving a
-/// `bool` there costs the comparison that scalarizes the loop, so `high_half_mul` hands back the
-/// discarded high half as a word. Both arms derive every shift and bound from `$ty`, so
-/// instantiating one at a new width cannot silently keep another width's constants.
+/// Signed widths use a range check or discarded high-half evidence.
 macro_rules! impl_checked_signed {
     ($ty:ty, widening_mul: $wide:ty) => {
         impl_checked_signed!($ty, mul_failure: bool = |lhs, rhs| {
@@ -377,9 +186,6 @@ macro_rules! impl_checked_signed {
             product < <$ty>::MIN as $wide || product > <$ty>::MAX as $wide
         });
     };
-    // Zero exactly when the product fits: a signed multiply overflows iff the high half of the true
-    // product differs from the sign extension of the half that was kept, so the two XOR to zero on
-    // the lanes that fit. `tests::test_multiply_overflow_boundaries` pins the boundaries.
     ($ty:ty, high_half_mul: $wide:ty => $failure:ty) => {
         impl_checked_signed!($ty, mul_failure: #[expect(
             clippy::cast_possible_truncation,
@@ -395,7 +201,7 @@ macro_rules! impl_checked_signed {
     (
         $ty:ty,
         mul_failure: $(#[$mul_failure_attr:meta])* $mul_failure_ty:ty
-            = |$l:ident, $r:ident| $mul_failure:expr
+            = |$lhs:ident, $rhs:ident| $mul_failure:expr
     ) => {
         impl_checked_integer!(
             $ty,
@@ -408,7 +214,7 @@ macro_rules! impl_checked_signed {
                 ((lhs ^ rhs) & (lhs ^ value)) < 0
             },
             div_error: |lhs, rhs| rhs == 0 || (lhs == <$ty>::MIN && rhs == -1),
-            mul_failure: $(#[$mul_failure_attr])* $mul_failure_ty = |$l, $r| $mul_failure,
+            mul_failure: $(#[$mul_failure_attr])* $mul_failure_ty = |$lhs, $rhs| $mul_failure,
         );
     };
 }
@@ -417,53 +223,46 @@ macro_rules! impl_checked_float {
     ($($ty:ty),+ $(,)?) => {
         $(
             impl CheckedArithmetic for $ty {
-                const DIV_CHECKS_IN_VALUE_LOOP: bool = false;
-
                 type MulFailure = bool;
 
-                #[inline(always)]
+                #[inline]
                 fn add_value(self, rhs: Self) -> Self {
                     self + rhs
                 }
 
-                #[inline(always)]
+                #[inline]
                 fn add_error(self, _rhs: Self) -> bool {
                     false
                 }
 
-                #[inline(always)]
+                #[inline]
                 fn sub_value(self, rhs: Self) -> Self {
                     self - rhs
                 }
 
-                #[inline(always)]
+                #[inline]
                 fn sub_error(self, _rhs: Self) -> bool {
                     false
                 }
 
-                #[inline(always)]
+                #[inline]
                 fn mul_value(self, rhs: Self) -> Self {
                     self * rhs
                 }
 
-                #[inline(always)]
+                #[inline]
                 fn mul_failure(self, _rhs: Self) -> bool {
                     false
                 }
 
-                #[inline(always)]
+                #[inline]
                 fn div_value(self, rhs: Self) -> Self {
                     self / rhs
                 }
 
-                #[inline(always)]
+                #[inline]
                 fn div_error(self, _rhs: Self) -> bool {
                     false
-                }
-
-                #[inline(always)]
-                fn div_checked(self, rhs: Self) -> Option<Self> {
-                    Some(self / rhs)
                 }
             }
         )+
@@ -484,30 +283,25 @@ impl_checked_float!(f16, f32, f64);
 mod tests {
     use super::CheckedArithmetic;
 
-    /// Values whose pairwise products are worth probing: the saturating boundaries, the sign-change
-    /// pivots, and a spread of magnitudes that straddles the 64-bit split.
     const PROBES: &[i64] = &[
-        0,            //
-        1,            //
-        -1,           //
-        2,            //
-        -2,           //
-        3,            //
-        i64::MIN,     //
-        i64::MIN + 1, //
-        i64::MAX,     //
-        i64::MAX - 1, //
-        1 << 31,      //
-        1 << 32,      //
-        1 << 62,      //
-        -(1 << 62),   //
-        0x7FFF_FFFF,  //
-        -0x8000_0000, //
+        0,
+        1,
+        -1,
+        2,
+        -2,
+        3,
+        i64::MIN,
+        i64::MIN + 1,
+        i64::MAX,
+        i64::MAX - 1,
+        1 << 31,
+        1 << 32,
+        1 << 62,
+        -(1 << 62),
+        0x7FFF_FFFF,
+        -0x8000_0000,
     ];
 
-    /// Every `mul_failure` impl is either a bit trick or a two-sided range check, so hold each
-    /// against the obvious reference: `reference` is the width's own `checked_mul`, whose `None`
-    /// _is_ the definition of overflow.
     #[track_caller]
     fn assert_agrees_with_checked_mul<T: CheckedArithmetic>(lhs: T, rhs: T, reference: Option<T>) {
         let failed = lhs.mul_failure(rhs) != <T::MulFailure as Default>::default();
@@ -522,14 +316,11 @@ mod tests {
                 assert_agrees_with_checked_mul(lhs, rhs, lhs.checked_mul(rhs));
 
                 let (lhs, rhs) = (lhs as u64, rhs as u64);
-
                 assert_agrees_with_checked_mul(lhs, rhs, lhs.checked_mul(rhs));
             }
         }
     }
 
-    /// The 8-bit widths are cheap enough to check exhaustively, which pins the shift of the
-    /// unsigned formula and the range check of the signed one against every product that exists.
     #[test]
     fn mul_failure_agrees_with_checked_mul_exhaustively_at_8_bits() {
         for lhs in u8::MIN..=u8::MAX {

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/row.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/row.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Primitive arithmetic execution through [`RowFn`].
+//!
+//! `Binary` keeps its registered contract; [`NumericBinary`] is only an execution helper. Decimal
+//! arithmetic remains on its existing columnar path.
+
+use vortex_error::VortexError;
+use vortex_error::VortexResult;
+use vortex_error::vortex_err;
+
+use super::primitive::CheckedAdd;
+use super::primitive::CheckedArithmetic;
+use super::primitive::CheckedDiv;
+use super::primitive::CheckedMul;
+use super::primitive::CheckedPrimitiveOp;
+use super::primitive::CheckedSub;
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::dtype::DType;
+use crate::dtype::NativePType;
+use crate::dtype::PType;
+use crate::match_each_native_ptype;
+use crate::scalar::NumericOperator;
+use crate::scalar_fn::RowFn;
+use crate::scalar_fn::RowVisitor;
+use crate::scalar_fn::ScalarFnId;
+use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::VecExecutionArgs;
+use crate::scalar_fn::fns::binary::Binary;
+use crate::scalar_fn::row::InitializedElement;
+use crate::scalar_fn::row::UninitElementSink;
+
+pub(super) fn execute_numeric_primitive(
+    lhs: &ArrayRef,
+    rhs: &ArrayRef,
+    op: NumericOperator,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let args = VecExecutionArgs::new(vec![lhs.clone(), rhs.clone()], lhs.len());
+
+    ScalarFnVTable::execute(&NumericBinary, &op, &args, ctx)
+}
+
+/// Internal row execution for the primitive arithmetic operators.
+#[derive(Clone)]
+struct NumericBinary;
+
+impl RowFn for NumericBinary {
+    type Options = NumericOperator;
+
+    const ARG_NAMES: &'static [&'static str] = &["lhs", "rhs"];
+
+    // Fallibility is queried without input dtypes, so this conservatively covers integer widths.
+    const FALLIBLE: bool = true;
+
+    fn id(&self) -> ScalarFnId {
+        // `NumericBinary` is a private implementation detail of `Binary`: it is never registered or
+        // serialized independently. Reusing the public ID keeps execution errors attributed to
+        // `Binary`. If this type becomes registrable, it needs its own ID and persistence contract.
+        ScalarFnVTable::id(&Binary)
+    }
+
+    fn dispatch<V: RowVisitor>(
+        &self,
+        op: &Self::Options,
+        args: &[DType],
+        visitor: V,
+    ) -> VortexResult<V::VisitResult> {
+        let ptype = PType::try_from(
+            args.first()
+                .ok_or_else(|| vortex_err!("a numeric operator takes two operands, got none"))?,
+        )?;
+
+        match_each_native_ptype!(ptype, |T| {
+            match op {
+                NumericOperator::Add => visit_checked::<T, CheckedAdd, V>(visitor),
+                NumericOperator::Sub => visit_checked::<T, CheckedSub, V>(visitor),
+                NumericOperator::Mul => visit_checked::<T, CheckedMul, V>(visitor),
+                NumericOperator::Div => visit_div::<T, V>(visitor),
+            }
+        })
+    }
+}
+
+fn visit_checked<T, Op, V>(visitor: V) -> VortexResult<V::VisitResult>
+where
+    T: NativePType,
+    Op: CheckedPrimitiveOp<T>,
+    V: RowVisitor,
+{
+    visitor.visit_deferred::<(T, T), T, Op::Fail>(
+        |(lhs, rhs)| Op::apply(lhs, rhs),
+        |failure| {
+            if failure != <Op::Fail as Default>::default() {
+                return Err(numeric_error(Op::ERROR));
+            }
+
+            Ok(())
+        },
+    )
+}
+
+fn visit_div<T, V>(visitor: V) -> VortexResult<V::VisitResult>
+where
+    T: CheckedArithmetic,
+    V: RowVisitor,
+{
+    if T::PTYPE.is_float() {
+        return visit_checked::<T, CheckedDiv, V>(visitor);
+    }
+
+    // Integer division is scalar and expensive, so deferring its cheap failure check preserves no
+    // vectorization. Check each divide immediately and stop at the first failure.
+    // Dense execution leaves output uninitialized. Nullable branches fill placeholders only when
+    // they need to skip invalid rows.
+    visitor.visit_into::<(T, T), UninitElementSink<T>, _>(|(lhs, rhs), output| {
+        let (value, failed) = CheckedDiv::apply(lhs, rhs);
+        if failed {
+            return Err(numeric_error(<CheckedDiv as CheckedPrimitiveOp<T>>::ERROR));
+        }
+
+        // SAFETY: `output` is the `UninitElementSink` row supplied for this callback.
+        Ok(unsafe { InitializedElement::write(output, value) })
+    })
+}
+
+/// Keep rich error construction out of row closures so the closures remain inlineable.
+#[cold]
+#[inline(never)]
+fn numeric_error(message: &'static str) -> VortexError {
+    vortex_err!(InvalidArgument: "{message}")
+}

--- a/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/tests.rs
@@ -201,8 +201,7 @@ fn test_integer_array_array_errors_on_valid_lanes() {
     assert!(result.is_err());
 }
 
-/// Multiply two non-nullable lanes of `lhs` by two of `rhs`, expecting `Some(product)` where the
-/// product fits and `None` where the checked kernel must report overflow.
+/// Assert one checked multiplication through the complete array execution path.
 #[track_caller]
 fn assert_multiply<T: NativePType>(lhs: T, rhs: T, expected: Option<T>) -> VortexResult<()> {
     let mut ctx = array_session().create_execution_ctx();
@@ -297,13 +296,11 @@ fn test_multiply_overflow_on_null_lane_ignored<T: NativePType>(
     Ok(())
 }
 
-/// The hot pass OR-reduces evidence across whole 64-lane chunks before anything looks at it, so an
-/// overflow in a late chunk must still be caught, and must still be suppressed when its lane is
-/// null. Every other test here fits in a single chunk and cannot show either.
+/// An overflow late in the batch must still be reported, unless its row is null.
 #[rstest]
 #[case::reported(true)]
 #[case::suppressed_by_null(false)]
-fn test_multiply_overflow_survives_chunk_reduction(
+fn test_multiply_overflow_survives_batch_reduction(
     #[case] lane_is_valid: bool,
 ) -> VortexResult<()> {
     const LEN: u32 = 1000;

--- a/vortex-array/src/test_harness/trace/tests.rs
+++ b/vortex-array/src/test_harness/trace/tests.rs
@@ -685,6 +685,14 @@ fn trace_compare_on_dict() -> VortexResult<()> {
       iter 0 current=vortex.dict(bool, len=5) builder_active=false
         ExecuteSlot slot=1 parent=vortex.dict(bool, len=5) child=vortex.binary(bool, len=3)
       iter 1 current=vortex.binary(bool, len=3) stack_parent=vortex.dict(bool, len=5) slot=1 builder_active=false
+    optimize root=vortex.slice(i32, len=1) session=false
+      reduce_parent static:SliceReduceAdaptor(Constant) slot=0 parent=vortex.slice(i32, len=1) child=vortex.constant(i32, len=3) -> vortex.constant(i32, len=1)
+      done output=vortex.constant(i32, len=1)
+    execute_until target=AnyCanonical root=vortex.constant(i32, len=1)
+      iter 0 current=vortex.constant(i32, len=1) builder_active=false
+        Done array=vortex.primitive(i32, len=1)
+      iter 1 current=vortex.primitive(i32, len=1) builder_active=false
+      return output=vortex.primitive(i32, len=1)
         Done array=vortex.bool(bool, len=3)
       iter 2 current=vortex.bool(bool, len=3) stack_parent=vortex.dict(bool, len=5) slot=1 builder_active=false
         pop_frame slot=1 output=vortex.dict(bool, len=5)

--- a/vortex-btrblocks/src/trace_tests.rs
+++ b/vortex-btrblocks/src/trace_tests.rs
@@ -206,6 +206,14 @@ fn trace_scan_compare_on_compressed_shipdate() -> VortexResult<()> {
         Done array=vortex.primitive(i32, len=4096)
       iter 1 current=vortex.primitive(i32, len=4096) builder_active=false
       return output=vortex.primitive(i32, len=4096)
+    optimize root=vortex.slice(i32, len=1) session=false
+      reduce_parent static:SliceReduceAdaptor(Constant) slot=0 parent=vortex.slice(i32, len=1) child=vortex.constant(i32, len=4096) -> vortex.constant(i32, len=1)
+      done output=vortex.constant(i32, len=1)
+    execute_until target=AnyCanonical root=vortex.constant(i32, len=1)
+      iter 0 current=vortex.constant(i32, len=1) builder_active=false
+        Done array=vortex.primitive(i32, len=1)
+      iter 1 current=vortex.primitive(i32, len=1) builder_active=false
+      return output=vortex.primitive(i32, len=1)
         Done array=vortex.bool(bool, len=4096)
       iter 2 current=vortex.bool(bool, len=4096) builder_active=false
       return output=vortex.bool(bool, len=4096)
@@ -264,6 +272,14 @@ fn trace_scan_compare_on_compressed_quantity() -> VortexResult<()> {
         Done array=vortex.primitive(i16, len=50)
       iter 1 current=vortex.primitive(i16, len=50) builder_active=false
       return output=vortex.primitive(i16, len=50)
+    optimize root=vortex.slice(i16, len=1) session=false
+      reduce_parent static:SliceReduceAdaptor(Constant) slot=0 parent=vortex.slice(i16, len=1) child=vortex.constant(i16, len=50) -> vortex.constant(i16, len=1)
+      done output=vortex.constant(i16, len=1)
+    execute_until target=AnyCanonical root=vortex.constant(i16, len=1)
+      iter 0 current=vortex.constant(i16, len=1) builder_active=false
+        Done array=vortex.primitive(i16, len=1)
+      iter 1 current=vortex.primitive(i16, len=1) builder_active=false
+      return output=vortex.primitive(i16, len=1)
         Done array=vortex.bool(bool, len=50)
       iter 6 current=vortex.bool(bool, len=50) stack_parent=vortex.dict(bool, len=4096) slot=1 builder_active=false
         pop_frame slot=1 output=vortex.dict(bool, len=4096)


### PR DESCRIPTION
Tracking Issue: https://github.com/vortex-data/vortex/issues/9130

Moves primitive numeric arithmetic and comparisons to `RowFn`. Selected measured comparison cases retain their columnar paths.

TODO