### PR TITLE
Unify benchmark data materialization behind `Benchmark::setup`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9712,6 +9712,7 @@ dependencies = [
  "sysinfo",
  "tabled",
  "target-lexicon",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/benchmarks/compress-bench/src/main.rs
+++ b/benchmarks/compress-bench/src/main.rs
@@ -220,6 +220,10 @@ async fn run_compress(
     })
     .collect();
 
+    // Fetch every dataset's remote inputs up front so downloads run in parallel instead of
+    // serially as each benchmark first touches its data.
+    futures::future::try_join_all(datasets.iter().map(|d| d.download())).await?;
+
     let progress = ProgressBar::new((datasets.len() * formats.len() * ops.len()) as u64);
 
     let mut measurements = vec![];

--- a/benchmarks/compress-bench/src/main.rs
+++ b/benchmarks/compress-bench/src/main.rs
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use clap::Parser;
 #[cfg(feature = "lance")]
@@ -14,7 +16,9 @@ use compress_bench::vortex::VortexCompressor;
 use indicatif::ProgressBar;
 use itertools::Itertools;
 use regex::Regex;
+use tokio::sync::Semaphore;
 use vortex::utils::aliases::hash_map::HashMap;
+use vortex::utils::parallelism::get_available_parallelism;
 use vortex_bench::Engine;
 use vortex_bench::Format;
 use vortex_bench::LogFormat;
@@ -81,6 +85,10 @@ struct Args {
     ingest_output: Option<PathBuf>,
     #[arg(long)]
     tracing: bool,
+    /// Materialize every dataset's data, report the setup timing, and exit without
+    /// benchmarking. Use on a cold cache to measure download and conversion cost.
+    #[arg(long)]
+    setup_only: bool,
     /// Format for the primary stderr log sink. `text` is the default human-readable format;
     /// `json` emits one JSON object per event, suitable for piping into `jq`.
     #[arg(long, value_enum, default_value_t = LogFormat::Text)]
@@ -112,6 +120,7 @@ async fn main() -> anyhow::Result<()> {
         args.display_format,
         args.output_path,
         args.ingest_output,
+        args.setup_only,
     )
     .await
 }
@@ -155,13 +164,16 @@ async fn run_compress(
     display_format: DisplayFormat,
     output_path: Option<PathBuf>,
     ingest_output: Option<PathBuf>,
+    setup_only: bool,
 ) -> anyhow::Result<()> {
     let targets = formats
         .iter()
         .map(|f| Target::new(Engine::default(), *f))
         .collect_vec();
 
-    let structlistofints = [
+    // Leaked so the setup phase can `tokio::spawn` per dataset, which needs `'static`. The
+    // other datasets are already static (unit structs and a `LazyLock` registry).
+    let structlistofints: &'static [StructListOfInts; 6] = Box::leak(Box::new([
         StructListOfInts::new(100, 1000, 1),
         StructListOfInts::new(1000, 1000, 1),
         StructListOfInts::new(10000, 1000, 1),
@@ -176,7 +188,7 @@ async fn run_compress(
         //     10,
         //     Some(READ_PROJECTION_COLUMNS),
         // ),
-    ];
+    ]));
 
     // Add an existing benchmark name here only after its CUDA-compatible compression and
     // decompression kernels have been verified end to end.
@@ -186,8 +198,8 @@ async fn run_compress(
     )]
     let gpu_decompress_benchmarks = vec!["TPC-H l_comment canonical"];
 
-    let datasets: Vec<&dyn Dataset> = [
-        &TaxiData as &dyn Dataset,
+    let datasets: Vec<&'static dyn Dataset> = [
+        &TaxiData as &'static dyn Dataset,
         PBI_DATASETS.get(Arade),
         PBI_DATASETS.get(Bimbo),
         PBI_DATASETS.get(CMSprovider),
@@ -205,7 +217,7 @@ async fn run_compress(
         &DownloadableDataset::AirQuality,
     ]
     .into_iter()
-    .chain(structlistofints.iter().map(|d| d as &dyn Dataset))
+    .chain(structlistofints.iter().map(|d| d as &'static dyn Dataset))
     .filter(|d| {
         if gpu_decompress && !gpu_decompress_benchmarks.contains(&d.name()) {
             return false;
@@ -220,9 +232,11 @@ async fn run_compress(
     })
     .collect();
 
-    // Fetch every dataset's remote inputs up front so downloads run in parallel instead of
-    // serially as each benchmark first touches its data.
-    futures::future::try_join_all(datasets.iter().map(|d| d.download())).await?;
+    let setup = prepare_datasets(&datasets).await?;
+    setup.report();
+    if setup_only {
+        return Ok(());
+    }
 
     let progress = ProgressBar::new((datasets.len() * formats.len() * ops.len()) as u64);
 
@@ -271,6 +285,88 @@ async fn run_compress(
             print_measurements_json(&mut writer, measurements.ratios, DOC_PATH)
         }
     }
+}
+
+/// Wall-clock cost of materializing every dataset, split by stage.
+struct SetupTiming {
+    download: Duration,
+    convert: Duration,
+    /// Per-dataset convert time, slowest first.
+    per_dataset: Vec<(String, Duration)>,
+    concurrency: usize,
+}
+
+impl SetupTiming {
+    fn total(&self) -> Duration {
+        self.download + self.convert
+    }
+
+    /// Log the phase breakdown. Setup is idempotent, so this is only meaningful on a cold
+    /// cache — a warm run reports near-zero and says nothing about the parallelism.
+    fn report(&self) {
+        tracing::info!(
+            "setup: {:.1}s total ({:.1}s download, {:.1}s convert at concurrency {})",
+            self.total().as_secs_f64(),
+            self.download.as_secs_f64(),
+            self.convert.as_secs_f64(),
+            self.concurrency,
+        );
+        let serial: Duration = self.per_dataset.iter().map(|(_, d)| *d).sum();
+        tracing::info!(
+            "setup: convert was {:.1}s of work across {} datasets, {:.1}x speedup from overlap",
+            serial.as_secs_f64(),
+            self.per_dataset.len(),
+            serial.as_secs_f64() / self.convert.as_secs_f64().max(f64::MIN_POSITIVE),
+        );
+        for (name, elapsed) in self.per_dataset.iter().take(5) {
+            tracing::info!("setup:   {name}: {:.1}s", elapsed.as_secs_f64());
+        }
+    }
+}
+
+/// Materialize every dataset's Parquet before any benchmark runs, in two stages.
+///
+/// Downloads go first and all at once: they are network bound, and the shared pool caps
+/// total in-flight requests. Conversion (bz2 decompress, CSV to Parquet, generation) is CPU
+/// and disk bound, so it is capped at the available parallelism instead — which under
+/// `scripts/bench-taskset.sh` is the pinned NUMA node's core count, not the whole machine.
+async fn prepare_datasets(datasets: &[&'static dyn Dataset]) -> anyhow::Result<SetupTiming> {
+    let started = Instant::now();
+    futures::future::try_join_all(datasets.iter().map(|d| d.download())).await?;
+    let download = started.elapsed();
+
+    let concurrency = get_available_parallelism().unwrap_or(1).max(1);
+    let permits = Arc::new(Semaphore::new(concurrency));
+    let started = Instant::now();
+
+    // `tokio::spawn`, not `buffer_unordered`: `to_parquet_path` does its generation and
+    // conversion work synchronously inside an async fn, so it never yields. Polled from a
+    // single task the futures would run strictly one after another — spawning puts each on
+    // its own runtime worker, and the semaphore keeps that bounded. This mirrors
+    // `convert_parquet_directory_to_vortex`.
+    let mut per_dataset: Vec<(String, Duration)> =
+        futures::future::try_join_all(datasets.iter().map(|d| {
+            let permits = Arc::clone(&permits);
+            let d = *d;
+            tokio::spawn(async move {
+                let _permit = permits.acquire().await?;
+                let started = Instant::now();
+                d.to_parquet_path().await?;
+                anyhow::Ok((d.name().to_owned(), started.elapsed()))
+            })
+        }))
+        .await?
+        .into_iter()
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let convert = started.elapsed();
+
+    per_dataset.sort_by_key(|(_, elapsed)| std::cmp::Reverse(*elapsed));
+    Ok(SetupTiming {
+        download,
+        convert,
+        per_dataset,
+        concurrency,
+    })
 }
 
 async fn run_benchmark_for_dataset(

--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -34,16 +34,15 @@ use vortex::scan::DataSourceRef;
 use vortex_arrow::ToArrowType;
 use vortex_bench::Benchmark;
 use vortex_bench::BenchmarkArg;
-use vortex_bench::CompactionStrategy;
 use vortex_bench::Engine;
 use vortex_bench::Format;
 use vortex_bench::Opt;
 use vortex_bench::Opts;
 use vortex_bench::SESSION;
-use vortex_bench::conversions::convert_parquet_directory_to_vortex;
 use vortex_bench::create_benchmark;
 use vortex_bench::create_output_writer;
 use vortex_bench::display::DisplayFormat;
+use vortex_bench::prepare_data;
 use vortex_bench::runner::BenchmarkMode;
 use vortex_bench::runner::BenchmarkQueryResult;
 use vortex_bench::runner::SqlBenchmarkRunner;
@@ -134,29 +133,7 @@ async fn main() -> anyhow::Result<()> {
         args.exclude_queries.as_ref(),
     );
 
-    // Generate Vortex files from Parquet for any Vortex formats requested
-    if benchmark.data_url().scheme() == "file" {
-        benchmark.generate_base_data().await?;
-
-        let base_path = benchmark
-            .data_url()
-            .to_file_path()
-            .map_err(|_| anyhow::anyhow!("Invalid file URL: {}", benchmark.data_url()))?;
-
-        for format in args.formats.iter() {
-            match format {
-                Format::OnDiskVortex => {
-                    convert_parquet_directory_to_vortex(&base_path, CompactionStrategy::Default)
-                        .await?;
-                }
-                Format::VortexCompact => {
-                    convert_parquet_directory_to_vortex(&base_path, CompactionStrategy::Compact)
-                        .await?;
-                }
-                _ => {}
-            }
-        }
-    }
+    prepare_data(&*benchmark, &args.formats).await?;
 
     let benchmark_name = benchmark.dataset().to_string();
 

--- a/benchmarks/duckdb-bench/src/main.rs
+++ b/benchmarks/duckdb-bench/src/main.rs
@@ -11,15 +11,14 @@ use duckdb_bench::DuckClient;
 use tokio::runtime::Runtime;
 use vortex::metrics::tracing::set_global_labels;
 use vortex_bench::BenchmarkArg;
-use vortex_bench::CompactionStrategy;
 use vortex_bench::Engine;
 use vortex_bench::Format;
 use vortex_bench::Opt;
 use vortex_bench::Opts;
-use vortex_bench::conversions::convert_parquet_directory_to_vortex;
 use vortex_bench::create_benchmark;
 use vortex_bench::create_output_writer;
 use vortex_bench::display::DisplayFormat;
+use vortex_bench::prepare_data;
 use vortex_bench::runner::BenchmarkMode;
 use vortex_bench::runner::SqlBenchmarkRunner;
 use vortex_bench::runner::filter_queries;
@@ -120,38 +119,8 @@ fn main() -> anyhow::Result<()> {
         // This is ugly, but otherwise some complicated async interaction might result in a deadlock
         let runtime = Runtime::new()?;
 
-        runtime.block_on(async {
-            benchmark.generate_base_data().await?;
-
-            let base_path = benchmark
-                .data_url()
-                .to_file_path()
-                .map_err(|_| anyhow::anyhow!("Invalid file URL: {}", benchmark.data_url()))?;
-
-            for format in args.formats.iter().copied() {
-                match format {
-                    Format::OnDiskVortex => {
-                        convert_parquet_directory_to_vortex(
-                            &base_path,
-                            CompactionStrategy::Default,
-                        )
-                        .await?;
-                    }
-                    Format::VortexCompact => {
-                        convert_parquet_directory_to_vortex(
-                            &base_path,
-                            CompactionStrategy::Compact,
-                        )
-                        .await?;
-                    }
-                    // OnDiskDuckDB tables are created during register_tables by loading from Parquet
-                    _ => {}
-                }
-                benchmark.prepare_format(format, &base_path).await?;
-            }
-
-            anyhow::Ok(())
-        })?;
+        // OnDiskDuckDB tables are created during register_tables by loading from Parquet.
+        runtime.block_on(prepare_data(&*benchmark, &args.formats))?;
     }
 
     let mut runner = SqlBenchmarkRunner::new(

--- a/benchmarks/lance-bench/src/main.rs
+++ b/benchmarks/lance-bench/src/main.rs
@@ -24,6 +24,7 @@ use vortex_bench::Opts;
 use vortex_bench::create_benchmark;
 use vortex_bench::create_output_writer;
 use vortex_bench::display::DisplayFormat;
+use vortex_bench::prepare_data;
 use vortex_bench::runner::BenchmarkMode;
 use vortex_bench::runner::BenchmarkQueryResult;
 use vortex_bench::runner::SqlBenchmarkRunner;
@@ -93,8 +94,8 @@ async fn main() -> anyhow::Result<()> {
         args.exclude_queries.as_ref(),
     );
 
-    // Generate base Parquet data first
-    benchmark.generate_base_data().await?;
+    // Lance is derived from Parquet, so materialize that first.
+    prepare_data(&*benchmark, &[Format::Parquet]).await?;
 
     // Convert Parquet to Lance format
     generate_lance_data(&*benchmark).await?;

--- a/vortex-bench/Cargo.toml
+++ b/vortex-bench/Cargo.toml
@@ -84,6 +84,7 @@ wkb = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 rstest = { workspace = true }
+tempfile = { workspace = true }
 
 [features]
 unstable_encodings = ["vortex/unstable_encodings"]

--- a/vortex-bench/src/appian/mod.rs
+++ b/vortex-bench/src/appian/mod.rs
@@ -37,8 +37,8 @@ use vortex::error::VortexExpect;
 use crate::Benchmark;
 use crate::BenchmarkDataset;
 use crate::Format;
+use crate::SetupCtx;
 use crate::TableSpec;
-use crate::datasets::data_downloads::download_data;
 use crate::utils::file::resolve_data_url;
 
 /// Upstream `.duckdb` blob; pinned to the URL hard-coded into DuckDB's
@@ -113,10 +113,6 @@ impl AppianBenchmark {
                 "Failed to convert data URL to filesystem path - ensure data_url uses 'file://' scheme"
             ))
     }
-
-    fn parquet_dir(&self) -> anyhow::Result<PathBuf> {
-        Ok(self.base_dir()?.join(Format::Parquet.name()))
-    }
 }
 
 #[async_trait::async_trait]
@@ -129,13 +125,12 @@ impl Benchmark for AppianBenchmark {
         Ok(appian_queries().collect())
     }
 
-    async fn generate_base_data(&self) -> anyhow::Result<()> {
-        if self.data_url.scheme() != "file" {
-            return Ok(());
-        }
+    async fn setup(&self, ctx: &SetupCtx, _format: Format) -> anyhow::Result<()> {
+        let parquet_dir = ctx.staging().to_path_buf();
 
-        let parquet_dir = self.parquet_dir()?;
-        fs::create_dir_all(&parquet_dir)?;
+        for table in TABLES {
+            ctx.emit(*table, parquet_dir.join(format!("{table}.parquet")));
+        }
 
         // Idempotency: if every target Parquet is already in place, do nothing.
         if TABLES
@@ -152,7 +147,12 @@ impl Benchmark for AppianBenchmark {
 
         // Download the upstream `.duckdb` blob into the dataset cache directory.
         let blob_path = self.base_dir()?.join("appian_benchmark_data.duckdb");
-        let blob = download_data(blob_path, UPSTREAM_BLOB_URL).await?;
+        let blob = ctx
+            .download([(UPSTREAM_BLOB_URL, blob_path.clone())])
+            .await?
+            .into_iter()
+            .next()
+            .unwrap_or(blob_path);
 
         // DuckDB SQL can't use a query result as a projection list, so build per-table
         // lowercased projections in Rust, then run all nine `COPY`s in a single subprocess.

--- a/vortex-bench/src/benchmark.rs
+++ b/vortex-bench/src/benchmark.rs
@@ -44,10 +44,10 @@ pub trait Benchmark: Send + Sync {
 
     /// Formats this benchmark can materialize without help.
     ///
-    /// [`prepare_data`] derives the rest. Parquet is the pivot: Vortex is converted from it,
-    /// and nothing converts back, so a benchmark that omits Parquet here cannot serve a
-    /// Parquet run. Suites that write Vortex straight from a row generator list it alongside
-    /// Parquet to skip a needless round trip through Parquet on disk.
+    /// [`prepare_data`] derives the rest by converting between Parquet and Vortex, in either
+    /// direction. Listing only Parquet is the common case; suites that write Vortex straight
+    /// from a row generator list it too, so requesting Vortex skips a needless round trip
+    /// through Parquet on disk.
     ///
     /// [`prepare_data`]: crate::setup::prepare_data
     fn native_formats(&self) -> &[Format] {

--- a/vortex-bench/src/benchmark.rs
+++ b/vortex-bench/src/benchmark.rs
@@ -12,6 +12,7 @@ use url::Url;
 use crate::BenchmarkDataset;
 use crate::Engine;
 use crate::Format;
+use crate::setup::SetupCtx;
 
 /// Specification for a table in a benchmark dataset.
 #[derive(Debug)]
@@ -41,17 +42,29 @@ pub trait Benchmark: Send + Sync {
         Vec::new()
     }
 
-    /// Generate or prepare base data for the benchmark (typically Parquet format).
-    /// This is the canonical source data that can be converted to other formats.
-    /// This should be idempotent - safe to call multiple times.
+    /// Formats this benchmark can materialize without help.
     ///
-    /// Format-specific benchmark binaries (like lance-bench, datafusion-bench, duckdb-bench) should
-    /// call this method to ensure base data exists, then perform their own format conversion.
-    async fn generate_base_data(&self) -> anyhow::Result<()>;
+    /// [`prepare_data`] derives the rest. Parquet is the pivot: Vortex is converted from it,
+    /// and nothing converts back, so a benchmark that omits Parquet here cannot serve a
+    /// Parquet run. Suites that write Vortex straight from a row generator list it alongside
+    /// Parquet to skip a needless round trip through Parquet on disk.
+    ///
+    /// [`prepare_data`]: crate::setup::prepare_data
+    fn native_formats(&self) -> &[Format] {
+        &[Format::Parquet]
+    }
 
-    /// Prepare benchmark- and format-specific data beyond the Parquet base that
-    /// [`Benchmark::generate_base_data`] produced. Called once per requested format, after the base
-    /// data exists. Default: nothing.
+    /// Materialize `format` into `ctx.staging()`, registering each produced file with
+    /// [`SetupCtx::emit`].
+    ///
+    /// Only called for formats listed in [`Benchmark::native_formats`]. Must be idempotent:
+    /// the staging directory persists across runs, so work already done should be skipped
+    /// rather than repeated.
+    async fn setup(&self, ctx: &SetupCtx, format: Format) -> anyhow::Result<()>;
+
+    /// Prepare benchmark- and format-specific data beyond what [`Benchmark::setup`] or the
+    /// Parquet-to-Vortex conversion produced. Called once per requested format, after that
+    /// format's data exists. Default: nothing.
     async fn prepare_format(&self, _format: Format, _base_path: &Path) -> anyhow::Result<()> {
         Ok(())
     }

--- a/vortex-bench/src/bin/data-gen.rs
+++ b/vortex-bench/src/bin/data-gen.rs
@@ -15,14 +15,13 @@ use tracing::info;
 use vortex::error::VortexExpect;
 use vortex_bench::Benchmark;
 use vortex_bench::BenchmarkArg;
-use vortex_bench::CompactionStrategy;
 use vortex_bench::Format;
 use vortex_bench::LogFormat;
 use vortex_bench::Opt;
 use vortex_bench::Opts;
-use vortex_bench::conversions::convert_parquet_directory_to_vortex;
 use vortex_bench::create_benchmark;
 use vortex_bench::generate_duckdb_registration_sql;
+use vortex_bench::prepare_data;
 use vortex_bench::setup_logging_and_tracing_with_format;
 
 #[derive(Parser)]
@@ -59,39 +58,21 @@ async fn main() -> anyhow::Result<()> {
 
     let benchmark = create_benchmark(args.benchmark, &opts)?;
 
-    // Generate base Parquet data - this is the source for all other formats
-    benchmark.generate_base_data().await?;
+    // Materialize every requested format: the benchmark produces the ones it can natively,
+    // and the rest are derived from Parquet.
+    prepare_data(&*benchmark, &args.formats).await?;
 
-    // Convert to other formats as needed (only for local file URLs)
-    if benchmark.data_url().scheme() == "file" {
+    if benchmark.data_url().scheme() == "file"
+        && args
+            .formats
+            .iter()
+            .any(|f| matches!(f, Format::OnDiskDuckDB))
+    {
         let base_path = benchmark
             .data_url()
             .to_file_path()
             .map_err(|_| anyhow::anyhow!("Invalid file URL: {}", benchmark.data_url()))?;
-
-        if args
-            .formats
-            .iter()
-            .any(|f| matches!(f, Format::OnDiskVortex))
-        {
-            convert_parquet_directory_to_vortex(&base_path, CompactionStrategy::Default).await?;
-        }
-
-        if args
-            .formats
-            .iter()
-            .any(|f| matches!(f, Format::VortexCompact))
-        {
-            convert_parquet_directory_to_vortex(&base_path, CompactionStrategy::Compact).await?;
-        }
-
-        if args
-            .formats
-            .iter()
-            .any(|f| matches!(f, Format::OnDiskDuckDB))
-        {
-            generate_duckdb(&base_path, &*benchmark)?;
-        }
+        generate_duckdb(&base_path, &*benchmark)?;
     }
 
     Ok(())

--- a/vortex-bench/src/clickbench/benchmark.rs
+++ b/vortex-bench/src/clickbench/benchmark.rs
@@ -10,7 +10,9 @@ use url::Url;
 
 use crate::Benchmark;
 use crate::BenchmarkDataset;
+use crate::Format;
 use crate::IdempotentPath;
+use crate::SetupCtx;
 use crate::TableSpec;
 use crate::clickbench::*;
 use crate::utils::file::resolve_data_url;
@@ -84,14 +86,10 @@ impl Benchmark for ClickBenchBenchmark {
         read_clickbench_queries(self.queries_file.as_deref())
     }
 
-    async fn generate_base_data(&self) -> Result<()> {
-        if self.data_url.scheme() != "file" {
-            return Ok(());
+    async fn setup(&self, ctx: &SetupCtx, _format: Format) -> Result<()> {
+        for path in self.flavor.download(ctx).await? {
+            ctx.emit("hits", path);
         }
-
-        let basepath = clickbench_flavor(self.flavor).to_data_path();
-        self.flavor.download(basepath).await?;
-
         Ok(())
     }
 
@@ -135,12 +133,15 @@ impl Benchmark for ClickBenchSortedBenchmark {
             .collect())
     }
 
-    async fn generate_base_data(&self) -> Result<()> {
-        if self.data_url.scheme() != "file" {
-            return Ok(());
+    async fn setup(&self, ctx: &SetupCtx, _format: Format) -> Result<()> {
+        generate_sorted_clickbench(CLICKBENCH_SORTED_NAME.to_data_path()).await?;
+        for entry in fs::read_dir(ctx.staging())? {
+            let path = entry?.path();
+            if path.extension().is_some_and(|e| e == "parquet") {
+                ctx.emit("hits", path);
+            }
         }
-
-        generate_sorted_clickbench(CLICKBENCH_SORTED_NAME.to_data_path()).await
+        Ok(())
     }
 
     fn expected_row_counts(&self) -> Option<Vec<usize>> {
@@ -166,8 +167,4 @@ impl Benchmark for ClickBenchSortedBenchmark {
     fn table_specs(&self) -> Vec<TableSpec> {
         vec![TableSpec::new("hits", Some(HITS_SCHEMA.clone()))]
     }
-}
-
-fn clickbench_flavor(flavor: Flavor) -> String {
-    format!("clickbench_{flavor}")
 }

--- a/vortex-bench/src/clickbench/data.rs
+++ b/vortex-bench/src/clickbench/data.rs
@@ -30,8 +30,7 @@ use crate::Format;
 use crate::IdempotentPath;
 // Re-export for use by clickbench_benchmark
 pub use crate::conversions::convert_parquet_directory_to_vortex;
-use crate::datasets::data_downloads::download_data;
-use crate::datasets::data_downloads::download_many;
+use crate::setup::SetupCtx;
 use crate::utils::file::temp_download_filepath;
 
 /// Benchmark and local data directory name for ClickBench sorted by event time.
@@ -211,30 +210,35 @@ impl Display for Flavor {
 }
 
 impl Flavor {
-    // TODO(joe): move these elsewhere.
-    pub async fn download(&self, basepath: impl AsRef<Path>) -> anyhow::Result<()> {
-        let basepath = basepath.as_ref();
-        match self {
+    /// Fetch this flavor's Parquet shards into `ctx.staging()`, returning their paths.
+    pub async fn download(&self, ctx: &SetupCtx) -> anyhow::Result<Vec<PathBuf>> {
+        let parquet_dir = ctx.staging();
+        let downloads: Vec<(String, PathBuf)> = match self {
             Flavor::Single => {
-                let output_path = basepath.join(Format::Parquet.name()).join("hits.parquet");
                 info!("Downloading single clickbench file");
-                let url = "https://pub-3ba949c0f0354ac18db1f0f14f0a2c52.r2.dev/clickbench/parquet_single/hits.parquet";
-                download_data(output_path, url).await?;
+                vec![(
+                    "https://pub-3ba949c0f0354ac18db1f0f14f0a2c52.r2.dev/clickbench/parquet_single/hits.parquet".to_owned(),
+                    parquet_dir.join("hits.parquet"),
+                )]
             }
             Flavor::Partitioned => {
                 // The clickbench-provided file is missing some higher-level type info, so we reprocess it
                 // to add that info, see https://github.com/ClickHouse/ClickBench/issues/7.
                 info!("Downloading 100 ClickBench parquet shards");
-                let parquet_dir = basepath.join(Format::Parquet.name());
-                let downloads = (0_u32..100).map(|idx| {
-                    let output_path = parquet_dir.join(format!("hits_{idx}.parquet"));
-                    let url = format!("https://pub-3ba949c0f0354ac18db1f0f14f0a2c52.r2.dev/clickbench/parquet_many/hits_{idx}.parquet");
-                    (output_path, url)
-                });
-                download_many(downloads).await?;
+                (0_u32..100)
+                    .map(|idx| {
+                        (
+                            format!("https://pub-3ba949c0f0354ac18db1f0f14f0a2c52.r2.dev/clickbench/parquet_many/hits_{idx}.parquet"),
+                            parquet_dir.join(format!("hits_{idx}.parquet")),
+                        )
+                    })
+                    .collect()
             }
-        }
-        Ok(())
+        };
+
+        let paths: Vec<PathBuf> = downloads.iter().map(|(_, p)| p.clone()).collect();
+        ctx.download(downloads).await?;
+        Ok(paths)
     }
 }
 
@@ -245,10 +249,13 @@ impl Flavor {
 /// pushdown has a visible job to do.
 pub async fn generate_sorted_clickbench(basepath: impl AsRef<Path>) -> anyhow::Result<()> {
     let basepath = basepath.as_ref();
-    let source_base = CLICKBENCH_PARTITIONED_NAME.to_data_path();
-    Flavor::Partitioned.download(&source_base).await?;
-
-    let source_parquet_dir = source_base.join(Format::Parquet.name());
+    // Sorted ClickBench is derived from the partitioned flavor's shards, so fetch those into
+    // the partitioned dataset's own cache directory first.
+    let source_parquet_dir = CLICKBENCH_PARTITIONED_NAME
+        .to_data_path()
+        .join(Format::Parquet.name());
+    let source_ctx = SetupCtx::new(&source_parquet_dir)?;
+    Flavor::Partitioned.download(&source_ctx).await?;
     let output_parquet_dir = basepath.join(Format::Parquet.name());
 
     if output_parquet_dir.exists() {

--- a/vortex-bench/src/conversions.rs
+++ b/vortex-bench/src/conversions.rs
@@ -43,6 +43,7 @@ use vortex::dtype::extension::ExtDType;
 use vortex::dtype::extension::ExtDTypeRef;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
+use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexWriteOptions;
 use vortex::file::WriteOptionsSessionExt;
 use vortex::file::WriteStrategyBuilder;
@@ -55,6 +56,7 @@ use vortex::utils::aliases::hash_set::HashSet;
 use vortex::utils::parallelism::get_available_parallelism;
 use vortex_arrow::FromArrowArray;
 use vortex_arrow::FromArrowType;
+use vortex_arrow::ToArrowType;
 use vortex_spatial::extension::SpatialMetadata;
 use vortex_spatial::extension::WellKnownBinary;
 use wkb::Endianness;
@@ -278,6 +280,88 @@ pub async fn convert_parquet_directory_to_vortex(
         .buffer_unordered(concurrency)
         .try_collect::<Vec<_>>()
         .await?;
+
+    Ok(())
+}
+
+/// Convert a single Vortex file to Parquet, streaming record batches so memory stays bounded.
+///
+/// This is the reverse of [`convert_parquet_file_to_vortex`], and makes Vortex-native suites
+/// able to serve a Parquet run. Note it is not a round-trip inverse: Vortex logical types with
+/// no Parquet equivalent are written as whatever [`vortex_arrow`] lowers them to, so a
+/// Parquet → Vortex → Parquet cycle can widen types.
+pub async fn convert_vortex_file_to_parquet(
+    vortex_path: &Path,
+    output_path: &Path,
+) -> anyhow::Result<()> {
+    let scan = SESSION
+        .open_options()
+        .open_path(vortex_path)
+        .await?
+        .scan()?;
+    let schema = Arc::new(scan.dtype()?.to_arrow_schema()?);
+
+    let mut writer =
+        AsyncArrowWriter::try_new(File::create(output_path).await?, Arc::clone(&schema), None)?;
+    let stream = scan.into_record_batch_stream(schema)?;
+    futures::pin_mut!(stream);
+    while let Some(batch) = stream.next().await {
+        writer.write(&batch?).await?;
+    }
+    writer.close().await?;
+    Ok(())
+}
+
+/// Convert every Vortex file in `<input_path>/vortex/` into `<input_path>/parquet/`.
+///
+/// The mirror of [`convert_parquet_directory_to_vortex`]: same per-file idempotency and same
+/// memory-derived concurrency limit.
+pub async fn convert_vortex_directory_to_parquet(input_path: &Path) -> anyhow::Result<()> {
+    let vortex_dir = input_path.join(Format::OnDiskVortex.name());
+    let parquet_dir = input_path.join(Format::Parquet.name());
+    create_dir_all(&parquet_dir).await?;
+
+    let vortex_inputs = fs::read_dir(&vortex_dir)?.collect::<std::io::Result<Vec<_>>>()?;
+    trace!(
+        "Found {} vortex files in {}",
+        vortex_inputs.len(),
+        vortex_dir.display()
+    );
+
+    let ext = Format::OnDiskVortex.ext();
+    let iter = vortex_inputs
+        .iter()
+        .filter(|entry| entry.path().extension().is_some_and(|e| e == ext));
+
+    let concurrency = calculate_concurrency();
+    futures::stream::iter(iter)
+        .map(|dir_entry| {
+            let vortex_file_path = dir_entry.path();
+            let filename = {
+                let mut temp = vortex_file_path.clone();
+                temp.set_extension("");
+                temp.file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_default()
+            };
+            let output_path = parquet_dir.join(format!("{filename}.parquet"));
+
+            tokio::spawn(
+                async move {
+                    idempotent_async(output_path.as_path(), move |pq_file| async move {
+                        info!("Converting '{filename}' to Parquet");
+                        convert_vortex_file_to_parquet(&vortex_file_path, &pq_file).await
+                    })
+                    .await
+                }
+                .in_current_span(),
+            )
+        })
+        .buffer_unordered(concurrency)
+        .try_collect::<Vec<_>>()
+        .await?
+        .into_iter()
+        .collect::<anyhow::Result<Vec<_>>>()?;
 
     Ok(())
 }

--- a/vortex-bench/src/datasets/data_downloads.rs
+++ b/vortex-bench/src/datasets/data_downloads.rs
@@ -162,6 +162,21 @@ static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
         .expect("failed to build shared benchmark HTTP client")
 });
 
+/// The shared HTTP client, for callers that must consume a response stream rather than land a
+/// file on disk. Prefer [`download_data`] or [`download_many`] whenever the bytes are wanted
+/// as a file: they add retries, progress reporting, and idempotency on top of this client.
+pub fn http_client() -> &'static Client {
+    &HTTP_CLIENT
+}
+
+/// Ceiling on concurrent downloads across the whole process.
+///
+/// Each [`download_many`] call runs its own AIMD controller, so without this cap `N`
+/// concurrent batches would ramp to `N * MAX_IN_FLIGHT` sockets with no shared backoff
+/// signal. Per-batch controllers still decide how far *each* batch ramps; this only bounds
+/// the total.
+static GLOBAL_IN_FLIGHT: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(MAX_IN_FLIGHT));
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Progress-bar templates
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -498,6 +513,10 @@ async fn download_one(fname: PathBuf, url: &str, batch: Option<&BatchProgress>) 
         .unwrap_or("<download>")
         .to_owned();
     idempotent_async(&fname, async move |tmp_path| {
+        let _global = GLOBAL_IN_FLIGHT
+            .acquire()
+            .await
+            .expect("global download semaphore is never closed");
         retry_get(&HTTP_CLIENT, url, &tmp_path, &display_name, batch).await
     })
     .await

--- a/vortex-bench/src/datasets/mod.rs
+++ b/vortex-bench/src/datasets/mod.rs
@@ -7,8 +7,6 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde::Serialize;
-use vortex::array::ArrayRef;
-use vortex::array::ExecutionCtx;
 
 use crate::clickbench::Flavor;
 
@@ -34,7 +32,7 @@ pub(crate) fn normalize_benchmark_runner_id(benchmark_runner: &str) -> String {
 }
 
 #[async_trait]
-pub trait Dataset {
+pub trait Dataset: Send + Sync {
     fn name(&self) -> &str;
 
     /// Map this dataset to the v3 `(dataset, dataset_variant)` pair emitted
@@ -48,7 +46,14 @@ pub trait Dataset {
         (self.name(), None)
     }
 
-    async fn to_vortex_array(&self, ctx: &mut ExecutionCtx) -> Result<ArrayRef>;
+    /// Fetch this dataset's remote inputs to local disk.
+    ///
+    /// Idempotent, so runners can `join_all` the downloads of every dataset up front and
+    /// the later [`Dataset::to_parquet_path`] call finds the files already present.
+    /// Datasets that generate their data locally use the no-op default.
+    async fn download(&self) -> Result<()> {
+        Ok(())
+    }
 
     /// Get the path to the parquet file for this dataset.
     ///

--- a/vortex-bench/src/datasets/struct_list_of_ints.rs
+++ b/vortex-bench/src/datasets/struct_list_of_ints.rs
@@ -76,13 +76,6 @@ impl StructListOfInts {
             self.num_columns, self.chunk_count, self.row_count
         )
     }
-}
-
-#[async_trait]
-impl Dataset for StructListOfInts {
-    fn name(&self) -> &str {
-        &self.name
-    }
 
     async fn to_vortex_array(&self, _ctx: &mut ExecutionCtx) -> Result<ArrayRef> {
         let names: FieldNames = (0..self.num_columns)
@@ -128,6 +121,13 @@ impl Dataset for StructListOfInts {
 
         let chunks = chunks?;
         Ok(ChunkedArray::from_iter(chunks).into_array())
+    }
+}
+
+#[async_trait]
+impl Dataset for StructListOfInts {
+    fn name(&self) -> &str {
+        &self.name
     }
 
     async fn to_parquet_path(&self) -> Result<PathBuf> {

--- a/vortex-bench/src/datasets/taxi_data.rs
+++ b/vortex-bench/src/datasets/taxi_data.rs
@@ -8,7 +8,6 @@ use async_trait::async_trait;
 use tokio::fs::File as TokioFile;
 use tokio::io::AsyncWriteExt;
 use vortex::array::ArrayRef;
-use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
 use vortex::array::stream::ArrayStreamExt;
 use vortex::file::OpenOptionsSessionExt;
@@ -38,8 +37,8 @@ impl Dataset for TaxiData {
         "taxi"
     }
 
-    async fn to_vortex_array(&self, _ctx: &mut ExecutionCtx) -> Result<ArrayRef> {
-        fetch_taxi_data().await
+    async fn download(&self) -> Result<()> {
+        taxi_data_parquet().await.map(|_| ())
     }
 
     async fn to_parquet_path(&self) -> Result<PathBuf> {

--- a/vortex-bench/src/datasets/tpch_l_comment.rs
+++ b/vortex-bench/src/datasets/tpch_l_comment.rs
@@ -44,13 +44,8 @@ async fn ensure_tpch_parquet() -> Result<PathBuf> {
         .ok_or_else(|| anyhow::anyhow!("No lineitem parquet file found"))
 }
 
-#[async_trait]
-impl Dataset for TPCHLCommentChunked {
-    fn name(&self) -> &str {
-        "TPC-H l_comment chunked"
-    }
-
-    async fn to_vortex_array(&self, ctx: &mut ExecutionCtx) -> Result<ArrayRef> {
+impl TPCHLCommentChunked {
+    pub async fn to_vortex_array(&self, ctx: &mut ExecutionCtx) -> Result<ArrayRef> {
         let base_path = "tpch".to_data_path();
         let scale_factor_dir = base_path.join("1.0");
         let data_dir = scale_factor_dir.join(Format::OnDiskVortex.name());
@@ -86,6 +81,13 @@ impl Dataset for TPCHLCommentChunked {
 
         Ok(ChunkedArray::from_iter(chunks).into_array())
     }
+}
+
+#[async_trait]
+impl Dataset for TPCHLCommentChunked {
+    fn name(&self) -> &str {
+        "TPC-H l_comment chunked"
+    }
 
     async fn to_parquet_path(&self) -> Result<PathBuf> {
         ensure_tpch_parquet().await
@@ -94,16 +96,18 @@ impl Dataset for TPCHLCommentChunked {
 
 pub struct TPCHLCommentCanonical;
 
+impl TPCHLCommentCanonical {
+    pub async fn to_vortex_array(&self, ctx: &mut ExecutionCtx) -> Result<ArrayRef> {
+        let comments_chunked = TPCHLCommentChunked.to_vortex_array(ctx).await?;
+        let comments_canonical = comments_chunked.execute::<StructArray>(ctx)?.into_array();
+        Ok(ChunkedArray::from_iter([comments_canonical]).into_array())
+    }
+}
+
 #[async_trait]
 impl Dataset for TPCHLCommentCanonical {
     fn name(&self) -> &str {
         "TPC-H l_comment canonical"
-    }
-
-    async fn to_vortex_array(&self, ctx: &mut ExecutionCtx) -> Result<ArrayRef> {
-        let comments_chunked = TPCHLCommentChunked.to_vortex_array(ctx).await?;
-        let comments_canonical = comments_chunked.execute::<StructArray>(ctx)?.into_array();
-        Ok(ChunkedArray::from_iter([comments_canonical]).into_array())
     }
 
     async fn to_parquet_path(&self) -> Result<PathBuf> {

--- a/vortex-bench/src/downloadable_dataset.rs
+++ b/vortex-bench/src/downloadable_dataset.rs
@@ -2,20 +2,10 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use async_trait::async_trait;
-use tokio::fs::File;
-use vortex::array::ArrayRef;
-use vortex::array::ExecutionCtx;
-use vortex::array::IntoArray;
-use vortex::array::stream::ArrayStreamExt;
-use vortex::file::OpenOptionsSessionExt;
-use vortex::file::WriteOptionsSessionExt;
 
 use crate::IdempotentPath;
-use crate::SESSION;
-use crate::conversions::parquet_to_vortex_chunks;
 use crate::datasets::Dataset;
 use crate::datasets::data_downloads::download_data;
-use crate::idempotent_async;
 
 /// Datasets which can be downloaded over HTTP in Parquet format.
 ///
@@ -58,35 +48,8 @@ impl Dataset for DownloadableDataset {
         }
     }
 
-    async fn to_vortex_array(&self, _ctx: &mut ExecutionCtx) -> anyhow::Result<ArrayRef> {
-        let parquet = self.to_parquet_path().await?;
-        let dir = format!("{}/", self.name()).to_data_path();
-        let vortex = dir.join(format!("{}.vortex", self.name()));
-
-        let data = parquet_to_vortex_chunks(parquet).await?;
-        idempotent_async(&vortex, async |path| -> anyhow::Result<()> {
-            SESSION
-                .write_options()
-                .write(
-                    &mut File::create(path)
-                        .await
-                        .map_err(|e| anyhow::anyhow!("Failed to create file: {}", e))?,
-                    data.into_array().to_array_stream(),
-                )
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to write vortex file: {}", e))?;
-            Ok(())
-        })
-        .await?;
-
-        Ok(SESSION
-            .open_options()
-            .open_path(vortex.as_path())
-            .await?
-            .scan()?
-            .into_array_stream()?
-            .read_all()
-            .await?)
+    async fn download(&self) -> anyhow::Result<()> {
+        self.to_parquet_path().await.map(|_| ())
     }
 
     async fn to_parquet_path(&self) -> anyhow::Result<PathBuf> {

--- a/vortex-bench/src/fineweb/mod.rs
+++ b/vortex-bench/src/fineweb/mod.rs
@@ -2,15 +2,14 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fs;
-use std::path::PathBuf;
 
-use tracing::info;
 use url::Url;
 
 use crate::Benchmark;
 use crate::BenchmarkDataset;
+use crate::Format;
+use crate::SetupCtx;
 use crate::TableSpec;
-use crate::datasets::data_downloads::download_data;
 use crate::utils::file::resolve_data_url;
 use crate::workspace_root;
 
@@ -41,15 +40,7 @@ impl FinewebBenchmark {
     }
 }
 
-impl FinewebBenchmark {
-    fn parquet_path(&self) -> anyhow::Result<PathBuf> {
-        self.data_url
-            .join("parquet/")?
-            .join("sample.parquet")?
-            .to_file_path()
-            .map_err(|_| anyhow::anyhow!("Failed to convert data URL to filesystem path - ensure data_url uses 'file://' scheme"))
-    }
-}
+impl FinewebBenchmark {}
 
 #[async_trait::async_trait]
 impl Benchmark for FinewebBenchmark {
@@ -75,14 +66,10 @@ impl Benchmark for FinewebBenchmark {
             .collect())
     }
 
-    async fn generate_base_data(&self) -> anyhow::Result<()> {
-        if self.data_url.scheme() != "file" {
-            return Ok(());
-        }
-
-        let parquet = download_data(self.parquet_path()?, SAMPLE_URL).await?;
-        info!("fineweb base data generated in {}", parquet.display());
-
+    async fn setup(&self, ctx: &SetupCtx, _format: Format) -> anyhow::Result<()> {
+        let path = ctx.staging().join("sample.parquet");
+        ctx.download([(SAMPLE_URL, path.clone())]).await?;
+        ctx.emit("fineweb", path);
         Ok(())
     }
 

--- a/vortex-bench/src/lib.rs
+++ b/vortex-bench/src/lib.rs
@@ -55,6 +55,7 @@ pub mod public_bi;
 pub mod random_access;
 pub mod realnest;
 pub mod runner;
+pub mod setup;
 pub mod spatialbench;
 pub mod statpopgen;
 pub mod tpcds;
@@ -69,6 +70,8 @@ pub use benchmark::TableSpec;
 pub use datasets::BenchmarkDataset;
 pub use output::BenchmarkOutput;
 pub use output::create_output_writer;
+pub use setup::SetupCtx;
+pub use setup::prepare_data;
 use vortex::VortexSessionDefault;
 pub use vortex::error::vortex_panic;
 use vortex::io::session::RuntimeSessionExt;
@@ -232,7 +235,7 @@ impl Display for Engine {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum CompactionStrategy {
     Compact,
     #[default]

--- a/vortex-bench/src/polarsignals/benchmark.rs
+++ b/vortex-bench/src/polarsignals/benchmark.rs
@@ -14,6 +14,7 @@ use crate::Benchmark;
 use crate::BenchmarkDataset;
 use crate::Format;
 use crate::IdempotentPath;
+use crate::SetupCtx;
 use crate::TableSpec;
 use crate::idempotent;
 use crate::workspace_root;
@@ -47,14 +48,6 @@ impl PolarSignalsBenchmark {
             n_rows,
         })
     }
-
-    fn parquet_path(&self) -> Result<std::path::PathBuf> {
-        self.data_url
-            .join("parquet/")?
-            .join(&format!("{FILE_NAME}.parquet"))?
-            .to_file_path()
-            .map_err(|_| anyhow::anyhow!("failed to convert data URL to filesystem path"))
-    }
 }
 
 #[async_trait::async_trait]
@@ -78,16 +71,9 @@ impl Benchmark for PolarSignalsBenchmark {
             .collect())
     }
 
-    async fn generate_base_data(&self) -> Result<()> {
-        if self.data_url.scheme() != "file" {
-            anyhow::bail!(
-                "unsupported URL scheme '{}' - only 'file://' URLs are supported",
-                self.data_url.scheme()
-            );
-        }
-
+    async fn setup(&self, ctx: &SetupCtx, _format: Format) -> Result<()> {
         let n_rows = self.n_rows;
-        let parquet_path = self.parquet_path()?;
+        let parquet_path = ctx.staging().join(format!("{FILE_NAME}.parquet"));
         idempotent(&parquet_path, |tmp_path| {
             tracing::info!(
                 n_rows,
@@ -96,6 +82,7 @@ impl Benchmark for PolarSignalsBenchmark {
             );
             generate_polarsignals_parquet(n_rows, tmp_path)
         })?;
+        ctx.emit(FILE_NAME, parquet_path);
         Ok(())
     }
 

--- a/vortex-bench/src/public_bi.rs
+++ b/vortex-bench/src/public_bi.rs
@@ -25,13 +25,9 @@ use tokio::process::Command as TokioCommand;
 use tracing::info;
 use tracing::trace;
 use url::Url;
-use vortex::array::ArrayRef;
-use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
-use vortex::array::stream::ArrayStreamExt;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
-use vortex::file::OpenOptionsSessionExt;
 use vortex::file::WriteOptionsSessionExt;
 use vortex::utils::aliases::hash_map::HashMap;
 
@@ -462,25 +458,8 @@ impl Dataset for PBIBenchmark {
         (&self.name, None)
     }
 
-    async fn to_vortex_array(&self, _ctx: &mut ExecutionCtx) -> anyhow::Result<ArrayRef> {
-        let dataset = self.dataset()?;
-        dataset.write_as_vortex().await?;
-        // reading only the first table, each table in a PBI benchmark
-        // has its own schema.
-        let path = dataset
-            .list_files(FileType::Vortex)
-            .first()
-            .ok_or_else(|| anyhow!("must have at least one table"))?
-            .clone();
-
-        Ok(SESSION
-            .open_options()
-            .open_path(path.as_path())
-            .await?
-            .scan()?
-            .into_array_stream()?
-            .read_all()
-            .await?)
+    async fn download(&self) -> anyhow::Result<()> {
+        self.dataset()?.download_bzips().await
     }
 
     async fn to_parquet_path(&self) -> anyhow::Result<PathBuf> {

--- a/vortex-bench/src/public_bi.rs
+++ b/vortex-bench/src/public_bi.rs
@@ -133,6 +133,217 @@ pub fn fetch_schemas_and_queries() -> anyhow::Result<PathBuf> {
     Ok(Path::new(env!("CARGO_MANIFEST_DIR")).join("public_bi"))
 }
 
+/// Every Public BI dataset and its tables, vendored from the upstream
+/// `benchmark/<dataset>/data-urls.txt` files.
+///
+/// Upstream stores one URL per table, but all 206 of them are
+/// `{DATA_URL_PREFIX}/{dataset}/{table}.csv.bz2`, so only the table names are
+/// recorded here and [`data_urls`] rebuilds the URL.
+const DATASET_TABLES: &[(&str, &[&str])] = &[
+    ("Arade", &["Arade_1"]),
+    ("Bimbo", &["Bimbo_1"]),
+    ("CMSprovider", &["CMSprovider_1", "CMSprovider_2"]),
+    ("CityMaxCapita", &["CityMaxCapita_1"]),
+    (
+        "CommonGovernment",
+        &[
+            "CommonGovernment_10",
+            "CommonGovernment_11",
+            "CommonGovernment_12",
+            "CommonGovernment_13",
+            "CommonGovernment_1",
+            "CommonGovernment_2",
+            "CommonGovernment_3",
+            "CommonGovernment_4",
+            "CommonGovernment_5",
+            "CommonGovernment_6",
+            "CommonGovernment_7",
+            "CommonGovernment_8",
+            "CommonGovernment_9",
+        ],
+    ),
+    ("Corporations", &["Corporations_1"]),
+    ("Eixo", &["Eixo_1"]),
+    ("Euro2016", &["Euro2016_1"]),
+    ("Food", &["Food_1"]),
+    (
+        "Generico",
+        &[
+            "Generico_1",
+            "Generico_2",
+            "Generico_3",
+            "Generico_4",
+            "Generico_5",
+        ],
+    ),
+    ("HashTags", &["HashTags_1"]),
+    ("Hatred", &["Hatred_1"]),
+    ("IGlocations1", &["IGlocations1_1"]),
+    ("IGlocations2", &["IGlocations2_1", "IGlocations2_2"]),
+    ("IUBLibrary", &["IUBLibrary_1"]),
+    (
+        "MLB",
+        &[
+            "MLB_10", "MLB_11", "MLB_12", "MLB_13", "MLB_14", "MLB_15", "MLB_16", "MLB_17",
+            "MLB_18", "MLB_19", "MLB_1", "MLB_20", "MLB_21", "MLB_22", "MLB_23", "MLB_24",
+            "MLB_25", "MLB_26", "MLB_27", "MLB_28", "MLB_29", "MLB_2", "MLB_30", "MLB_31",
+            "MLB_32", "MLB_33", "MLB_34", "MLB_35", "MLB_36", "MLB_37", "MLB_38", "MLB_39",
+            "MLB_3", "MLB_40", "MLB_41", "MLB_42", "MLB_43", "MLB_44", "MLB_45", "MLB_46",
+            "MLB_47", "MLB_48", "MLB_49", "MLB_4", "MLB_50", "MLB_51", "MLB_52", "MLB_53",
+            "MLB_54", "MLB_55", "MLB_56", "MLB_57", "MLB_58", "MLB_59", "MLB_5", "MLB_60",
+            "MLB_61", "MLB_62", "MLB_63", "MLB_64", "MLB_65", "MLB_66", "MLB_67", "MLB_68",
+            "MLB_6", "MLB_7", "MLB_8", "MLB_9",
+        ],
+    ),
+    ("MedPayment1", &["MedPayment1_1"]),
+    ("MedPayment2", &["MedPayment2_1"]),
+    ("Medicare1", &["Medicare1_1", "Medicare1_2"]),
+    ("Medicare2", &["Medicare2_1", "Medicare2_2"]),
+    ("Medicare3", &["Medicare3_1"]),
+    ("Motos", &["Motos_1", "Motos_2"]),
+    ("MulheresMil", &["MulheresMil_1"]),
+    ("NYC", &["NYC_1", "NYC_2"]),
+    ("PanCreactomy1", &["PanCreactomy1_1"]),
+    ("PanCreactomy2", &["PanCreactomy2_1", "PanCreactomy2_2"]),
+    ("Physicians", &["Physicians_1"]),
+    (
+        "Provider",
+        &[
+            "Provider_1",
+            "Provider_2",
+            "Provider_3",
+            "Provider_4",
+            "Provider_5",
+            "Provider_6",
+            "Provider_7",
+            "Provider_8",
+        ],
+    ),
+    ("RealEstate1", &["RealEstate1_1", "RealEstate1_2"]),
+    (
+        "RealEstate2",
+        &[
+            "RealEstate2_1",
+            "RealEstate2_2",
+            "RealEstate2_3",
+            "RealEstate2_4",
+            "RealEstate2_5",
+            "RealEstate2_6",
+            "RealEstate2_7",
+        ],
+    ),
+    (
+        "Redfin1",
+        &["Redfin1_1", "Redfin1_2", "Redfin1_3", "Redfin1_4"],
+    ),
+    ("Redfin2", &["Redfin2_1", "Redfin2_2", "Redfin2_3"]),
+    ("Redfin3", &["Redfin3_1", "Redfin3_2"]),
+    ("Redfin4", &["Redfin4_1"]),
+    (
+        "Rentabilidad",
+        &[
+            "Rentabilidad_1",
+            "Rentabilidad_2",
+            "Rentabilidad_3",
+            "Rentabilidad_4",
+            "Rentabilidad_5",
+            "Rentabilidad_6",
+            "Rentabilidad_7",
+            "Rentabilidad_8",
+            "Rentabilidad_9",
+        ],
+    ),
+    ("Romance", &["Romance_1", "Romance_2"]),
+    (
+        "SalariesFrance",
+        &[
+            "SalariesFrance_10",
+            "SalariesFrance_11",
+            "SalariesFrance_12",
+            "SalariesFrance_13",
+            "SalariesFrance_1",
+            "SalariesFrance_2",
+            "SalariesFrance_3",
+            "SalariesFrance_4",
+            "SalariesFrance_5",
+            "SalariesFrance_6",
+            "SalariesFrance_7",
+            "SalariesFrance_8",
+            "SalariesFrance_9",
+        ],
+    ),
+    (
+        "TableroSistemaPenal",
+        &[
+            "TableroSistemaPenal_1",
+            "TableroSistemaPenal_2",
+            "TableroSistemaPenal_3",
+            "TableroSistemaPenal_4",
+            "TableroSistemaPenal_5",
+            "TableroSistemaPenal_6",
+            "TableroSistemaPenal_7",
+            "TableroSistemaPenal_8",
+        ],
+    ),
+    (
+        "Taxpayer",
+        &[
+            "Taxpayer_10",
+            "Taxpayer_1",
+            "Taxpayer_2",
+            "Taxpayer_3",
+            "Taxpayer_4",
+            "Taxpayer_5",
+            "Taxpayer_6",
+            "Taxpayer_7",
+            "Taxpayer_8",
+            "Taxpayer_9",
+        ],
+    ),
+    ("Telco", &["Telco_1"]),
+    (
+        "TrainsUK1",
+        &["TrainsUK1_1", "TrainsUK1_2", "TrainsUK1_3", "TrainsUK1_4"],
+    ),
+    ("TrainsUK2", &["TrainsUK2_1", "TrainsUK2_2"]),
+    ("USCensus", &["USCensus_1", "USCensus_2", "USCensus_3"]),
+    ("Uberlandia", &["Uberlandia_1"]),
+    ("Wins", &["Wins_1", "Wins_2", "Wins_3", "Wins_4"]),
+    (
+        "YaleLanguages",
+        &[
+            "YaleLanguages_1",
+            "YaleLanguages_2",
+            "YaleLanguages_3",
+            "YaleLanguages_4",
+            "YaleLanguages_5",
+        ],
+    ),
+];
+
+/// Bucket holding every Public BI table dump.
+const DATA_URL_PREFIX: &str = "https://pub-334c2a12c9bf46f3b8464a8718df8cae.r2.dev";
+
+/// `(table name, source URL)` for every table in `dataset`.
+///
+/// Vendored rather than parsed from the upstream `data-urls.txt` so the download list is
+/// known at compile time, and a fetch of the upstream repo cannot change what we download.
+fn data_urls(dataset: &str) -> anyhow::Result<Vec<(String, Url)>> {
+    let tables = DATASET_TABLES
+        .iter()
+        .find(|(name, _)| *name == dataset)
+        .map(|(_, tables)| *tables)
+        .ok_or_else(|| anyhow!("unknown Public BI dataset {dataset}"))?;
+
+    tables
+        .iter()
+        .map(|table| {
+            let url = Url::parse(&format!("{DATA_URL_PREFIX}/{dataset}/{table}.csv.bz2"))?;
+            Ok(((*table).to_owned(), url))
+        })
+        .collect()
+}
+
 #[derive(Debug)]
 pub struct PBIDatasets {
     benchmarks: HashMap<PBIDataset, PBIBenchmark>,
@@ -206,26 +417,18 @@ impl PBIBenchmark {
         Ok(queries)
     }
 
-    /// Return table name and Url pairs. Each Url is pointing to a csv.bz2 file for the table.
+    /// Table name and source URL pairs, from the vendored [`DATASET_TABLES`] listing.
     fn tables(&self) -> anyhow::Result<Vec<Table>> {
-        fs::read_to_string(self.base_path.join("data-urls.txt"))?
-            .lines()
-            .map(|url_str| {
-                let url = Url::parse(url_str)?;
-                let table_name = url
-                    .path_segments()
-                    .and_then(|mut path| path.next_back())
-                    .and_then(|filename| filename.strip_suffix(".csv.bz2"))
-                    .ok_or_else(|| anyhow!("invalid url {url}"))?;
-                let create_table_sql = self.table_sql(table_name)?;
+        data_urls(&self.name)?
+            .into_iter()
+            .map(|(name, data_url)| {
                 Ok(Table {
-                    create_table_sql,
-                    name: table_name.to_string(),
-                    data_url: url,
+                    create_table_sql: self.table_sql(&name)?,
+                    name,
+                    data_url,
                 })
             })
-            .collect::<anyhow::Result<Vec<Table>>>()
-            .map_err(|_| anyhow!("invalid urls in data-urls.txt"))
+            .collect()
     }
 
     fn table_sql(&self, table_name: &str) -> anyhow::Result<String> {
@@ -596,5 +799,44 @@ mod tests {
             base_path: PathBuf::new(),
         };
         assert_eq!(bench.v3_dataset_dims(), ("CMSprovider", None));
+    }
+
+    /// Every `PBIDataset` variant must appear in the vendored listing, or `data_urls` fails
+    /// at runtime for that dataset.
+    #[test]
+    fn every_dataset_variant_has_vendored_tables() -> anyhow::Result<()> {
+        for dataset in PBIDataset::value_variants() {
+            let name = format!("{dataset:?}");
+            let urls =
+                data_urls(&name).with_context(|| format!("{name} missing from DATASET_TABLES"))?;
+            assert!(!urls.is_empty(), "{name} has no tables");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn data_urls_rebuild_the_upstream_layout() -> anyhow::Result<()> {
+        let urls = data_urls("Arade")?;
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0].0, "Arade_1");
+        assert_eq!(
+            urls[0].1.as_str(),
+            "https://pub-334c2a12c9bf46f3b8464a8718df8cae.r2.dev/Arade/Arade_1.csv.bz2",
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_dataset_is_rejected() {
+        assert!(data_urls("NotADataset").is_err());
+    }
+
+    /// 206 tables across 46 datasets, matching the upstream `data-urls.txt` corpus this was
+    /// vendored from. A drift here means upstream added or removed a table dump.
+    #[test]
+    fn vendored_corpus_size_is_pinned() {
+        assert_eq!(DATASET_TABLES.len(), 46);
+        let tables: usize = DATASET_TABLES.iter().map(|(_, t)| t.len()).sum();
+        assert_eq!(tables, 206);
     }
 }

--- a/vortex-bench/src/public_bi.rs
+++ b/vortex-bench/src/public_bi.rs
@@ -36,6 +36,7 @@ use crate::BenchmarkDataset;
 use crate::Format;
 use crate::IdempotentPath;
 use crate::SESSION;
+use crate::SetupCtx;
 use crate::TableSpec;
 use crate::conversions::parquet_to_vortex_chunks;
 use crate::datasets::Dataset;
@@ -517,9 +518,17 @@ impl Benchmark for PublicBiBenchmark {
         self.pbi_benchmark().queries()
     }
 
-    async fn generate_base_data(&self) -> anyhow::Result<()> {
+    async fn setup(&self, ctx: &SetupCtx, _format: Format) -> anyhow::Result<()> {
         let pbi_data = self.pbi_benchmark().dataset()?;
-        pbi_data.write_as_parquet().await
+        pbi_data.write_as_parquet().await?;
+        for (table, path) in pbi_data
+            .tables
+            .iter()
+            .zip(pbi_data.list_files(FileType::Parquet))
+        {
+            ctx.emit(&table.name, path);
+        }
+        Ok(())
     }
 
     fn dataset(&self) -> BenchmarkDataset {

--- a/vortex-bench/src/public_bi.rs
+++ b/vortex-bench/src/public_bi.rs
@@ -139,6 +139,10 @@ pub fn fetch_schemas_and_queries() -> anyhow::Result<PathBuf> {
 /// Upstream stores one URL per table, but all 206 of them are
 /// `{DATA_URL_PREFIX}/{dataset}/{table}.csv.bz2`, so only the table names are
 /// recorded here and [`data_urls`] rebuilds the URL.
+///
+/// Derived from the Public BI benchmark (<https://github.com/cwida/public_bi_benchmark>),
+/// MIT licensed, Copyright (c) 2019 CWI Database Architectures Group. The underlying table
+/// dumps are anonymized Tableau Public workbooks and carry their own provenance.
 const DATASET_TABLES: &[(&str, &[&str])] = &[
     ("Arade", &["Arade_1"]),
     ("Bimbo", &["Bimbo_1"]),

--- a/vortex-bench/src/realnest/gharchive.rs
+++ b/vortex-bench/src/realnest/gharchive.rs
@@ -9,15 +9,15 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-use tokio::io::AsyncWriteExt;
 use tracing::info;
 use url::Url;
 
 use crate::Benchmark;
 use crate::BenchmarkDataset;
+use crate::Format;
+use crate::SetupCtx;
 use crate::TableSpec;
 use crate::idempotent;
-use crate::idempotent_async;
 use crate::utils::file::resolve_data_url;
 use crate::workspace_root;
 
@@ -47,18 +47,9 @@ impl GithubArchiveBenchmark {
 }
 
 impl GithubArchiveBenchmark {
-    fn json_path(&self) -> anyhow::Result<PathBuf> {
+    fn json_dir(&self) -> anyhow::Result<PathBuf> {
         self.data_url
             .join("json/")?
-            .join("events.json.gz")?
-            .to_file_path()
-            .map_err(|_| anyhow::anyhow!("Failed to convert data URL to filesystem path - ensure data_url uses 'file://' scheme"))
-    }
-
-    fn parquet_path(&self) -> anyhow::Result<PathBuf> {
-        self.data_url
-            .join("parquet/")?
-            .join("events.parquet")?
             .to_file_path()
             .map_err(|_| anyhow::anyhow!("Failed to convert data URL to filesystem path - ensure data_url uses 'file://' scheme"))
     }
@@ -88,38 +79,30 @@ impl Benchmark for GithubArchiveBenchmark {
             .collect())
     }
 
-    async fn generate_base_data(&self) -> anyhow::Result<()> {
-        if self.data_url.scheme() != "file" {
-            return Ok(());
-        }
+    async fn setup(&self, ctx: &SetupCtx, _format: Format) -> anyhow::Result<()> {
+        // One file per hour, fetched in parallel through the shared pool. Each lands
+        // separately so a failure re-fetches only the missing hours; DuckDB then reads the
+        // whole set through a glob.
+        let json_dir = self.json_dir()?;
+        fs::create_dir_all(&json_dir)?;
+        let downloads: Vec<(String, PathBuf)> = (0..=23)
+            .map(|hour| {
+                (
+                    raw_json_url(hour),
+                    json_dir.join(format!("2024-10-01-{hour}.json.gz")),
+                )
+            })
+            .collect();
+        info!(
+            "Downloading {} GithubArchive JSON source files",
+            downloads.len()
+        );
+        ctx.download(downloads).await?;
 
-        let json = idempotent_async(&self.json_path()?, |json_path| async move {
-            info!("Downloading GithubArchive JSON source files");
-            let mut w = tokio::fs::File::create(json_path).await?;
-            let client = reqwest::Client::new();
-            for hour in 0..=23 {
-                let url = raw_json_url(hour);
-                info!("Downloading archive {url}");
-                let response = client
-                    .get(url)
-                    .send()
-                    .await?
-                    .error_for_status()
-                    .map_err(|err| anyhow::anyhow!("error fetching gharchive data: {err}"))?;
+        let json_glob = json_dir.join("*.json.gz").display().to_string();
 
-                let body = response.bytes().await?;
-
-                w.write_all(&body).await?;
-                w.flush().await?;
-            }
-
-            Ok(())
-        })
-        .await?;
-
-        let json_path = json.display().to_string();
-
-        let parquet = idempotent(&self.parquet_path()?, move |parquet_path| {
+        let output_path = ctx.staging().join("events.parquet");
+        let parquet = idempotent(&output_path, move |parquet_path| {
             let parquet = parquet_path.display().to_string();
             info!(
                 "Converting GithubArchive JSON to Parquet with DuckDB @ {}",
@@ -129,7 +112,7 @@ impl Benchmark for GithubArchiveBenchmark {
                 .arg("-c")
                 .arg(format!(
                     "
-                    CREATE TABLE events AS select * from read_ndjson_auto('{json_path}', ignore_errors = true);
+                    CREATE TABLE events AS select * from read_ndjson_auto('{json_glob}', ignore_errors = true);
                     COPY events TO '{parquet}' (FORMAT parquet);
                     "
                 ))
@@ -144,6 +127,7 @@ impl Benchmark for GithubArchiveBenchmark {
         })?;
 
         info!("gharchive base data generated in {}", parquet.display());
+        ctx.emit("events", parquet);
 
         Ok(())
     }

--- a/vortex-bench/src/setup.rs
+++ b/vortex-bench/src/setup.rs
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Dataset materialization: the [`SetupCtx`] handed to [`Benchmark::setup`] and the driver
+//! that turns natively-produced formats into every requested one.
+//!
+//! # Model
+//!
+//! A benchmark declares the formats it can produce without help via
+//! [`Benchmark::native_formats`], and materializes one of them in
+//! [`Benchmark::setup`]. Everything else is derived by [`prepare_data`].
+//!
+//! Parquet is the pivot format because it is the only one that can be derived *from*:
+//! [`crate::conversions`] converts Parquet to Vortex, but nothing converts Vortex back to
+//! Parquet. A benchmark that produces only Vortex therefore cannot serve a Parquet run.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
+use parking_lot::Mutex;
+use reqwest::Client;
+use tracing::info;
+
+use crate::Benchmark;
+use crate::CompactionStrategy;
+use crate::Format;
+use crate::conversions::convert_parquet_directory_to_vortex;
+use crate::datasets::data_downloads::download_many;
+use crate::datasets::data_downloads::http_client;
+
+/// A parquet (or other native-format) file produced by [`Benchmark::setup`], tagged with the
+/// table it belongs to.
+///
+/// Tables are many-to-one with files: ClickBench emits 100 files for the single `hits` table,
+/// while Appian emits nine files for nine tables.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Emitted {
+    pub table: String,
+    pub path: PathBuf,
+}
+
+/// Context handed to [`Benchmark::setup`].
+///
+/// Owns the staging directory the benchmark writes into, the shared download pool, and the
+/// list of files the benchmark has produced so far.
+pub struct SetupCtx {
+    staging: PathBuf,
+    emitted: Mutex<Vec<Emitted>>,
+}
+
+impl SetupCtx {
+    /// Create a context staging into `staging`, creating the directory if needed.
+    ///
+    /// `staging` is deliberately stable across runs rather than a fresh temp dir, so a failure
+    /// partway through a multi-file dataset leaves the already-fetched files in place for the
+    /// next attempt.
+    pub fn new(staging: impl Into<PathBuf>) -> Result<Self> {
+        let staging = staging.into();
+        std::fs::create_dir_all(&staging)?;
+        Ok(Self {
+            staging,
+            emitted: Mutex::new(Vec::new()),
+        })
+    }
+
+    /// Directory this benchmark should write its output into.
+    pub fn staging(&self) -> &Path {
+        &self.staging
+    }
+
+    /// Idempotently fetch `(url, path)` pairs through the shared download pool.
+    ///
+    /// Pass every file the benchmark needs in one call: the pool ramps concurrency across the
+    /// whole batch and renders a single progress block. Files already on disk are skipped.
+    pub async fn download<I, S, P>(&self, files: I) -> Result<Vec<PathBuf>>
+    where
+        I: IntoIterator<Item = (S, P)>,
+        S: Into<String>,
+        P: Into<PathBuf>,
+    {
+        // `download_many` takes `(path, url)`; flip so call sites read `(url, path)`.
+        let downloads: Vec<(PathBuf, String)> = files
+            .into_iter()
+            .map(|(url, path)| (path.into(), url.into()))
+            .collect();
+        download_many(downloads).await
+    }
+
+    /// The shared HTTP client, for datasets that must consume a response stream rather than
+    /// land a file — see [`crate::statpopgen`], which decodes a multi-hundred-gigabyte VCF on
+    /// the fly and stops after a fixed row count.
+    pub fn http(&self) -> &'static Client {
+        http_client()
+    }
+
+    /// Register a file this benchmark produced as (part of) `table`.
+    pub fn emit(&self, table: impl Into<String>, path: impl Into<PathBuf>) {
+        self.emitted.lock().push(Emitted {
+            table: table.into(),
+            path: path.into(),
+        });
+    }
+
+    /// Every file registered via [`SetupCtx::emit`], in emission order.
+    pub fn emitted(&self) -> Vec<Emitted> {
+        self.emitted.lock().clone()
+    }
+}
+
+/// Materialize `formats` for `benchmark`.
+///
+/// Formats the benchmark lists in [`Benchmark::native_formats`] are produced directly by
+/// [`Benchmark::setup`]. The Vortex formats are derived from Parquet when the benchmark does
+/// not produce them natively. Benchmarks whose data already lives remotely (a non-`file://`
+/// [`Benchmark::data_url`]) are skipped entirely.
+pub async fn prepare_data(benchmark: &dyn Benchmark, formats: &[Format]) -> Result<()> {
+    if benchmark.data_url().scheme() != "file" {
+        info!(
+            "{}: data is remote ({}), nothing to materialize",
+            benchmark.dataset_name(),
+            benchmark.data_url(),
+        );
+        return Ok(());
+    }
+
+    let base_path = benchmark
+        .data_url()
+        .to_file_path()
+        .map_err(|_| anyhow::anyhow!("Invalid file URL: {}", benchmark.data_url()))?;
+
+    let native = benchmark.native_formats();
+
+    // Parquet underpins every derived format, so produce it if anything needs it.
+    let needs_parquet = formats
+        .iter()
+        .any(|f| !native.contains(f) || *f == Format::Parquet);
+    if needs_parquet && native.contains(&Format::Parquet) {
+        setup_format(benchmark, &base_path, Format::Parquet).await?;
+    }
+
+    for &format in formats {
+        // Lance and DuckDB are built by their own bench binaries from the Parquet above.
+        if matches!(format, Format::Lance | Format::OnDiskDuckDB | Format::Csv) {
+            continue;
+        }
+
+        match plan(native, format)
+            .with_context(|| format!("benchmark {}", benchmark.dataset_name()))?
+        {
+            Plan::Native(Format::Parquet) => {
+                // Already produced above.
+            }
+            Plan::Native(format) => setup_format(benchmark, &base_path, format).await?,
+            Plan::DeriveFromParquet(format, compaction) => {
+                convert_parquet_directory_to_vortex(&base_path, compaction).await?;
+                benchmark.prepare_format(format, &base_path).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Run `benchmark`'s setup for one natively-produced format, staging into `<base>/<format>/`.
+async fn setup_format(benchmark: &dyn Benchmark, base_path: &Path, format: Format) -> Result<()> {
+    let staging = base_path.join(format.name());
+    let ctx = SetupCtx::new(&staging)?;
+
+    benchmark.setup(&ctx, format).await?;
+
+    let emitted = ctx.emitted();
+    info!(
+        "{}: setup produced {} {format} file(s) in {}",
+        benchmark.dataset_name(),
+        emitted.len(),
+        staging.display(),
+    );
+
+    benchmark.prepare_format(format, base_path).await?;
+    Ok(())
+}
+
+/// Which formats a benchmark produces natively and which are derived from Parquet.
+///
+/// Split out so the routing is testable without running a download or a generator.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Plan {
+    /// `setup` is called for this format directly.
+    Native(Format),
+    /// Parquet is produced, then converted with this strategy.
+    DeriveFromParquet(Format, CompactionStrategy),
+}
+
+pub(crate) fn plan(native: &[Format], requested: Format) -> Result<Plan> {
+    if native.contains(&requested) {
+        return Ok(Plan::Native(requested));
+    }
+    if !native.contains(&Format::Parquet) {
+        bail!("cannot produce {requested}: not native ({native:?}) and Parquet is unavailable");
+    }
+    match requested {
+        Format::OnDiskVortex => Ok(Plan::DeriveFromParquet(
+            requested,
+            CompactionStrategy::Default,
+        )),
+        Format::VortexCompact => Ok(Plan::DeriveFromParquet(
+            requested,
+            CompactionStrategy::Compact,
+        )),
+        other => bail!("cannot derive {other} from Parquet"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    /// StatPopGen streams HTTP straight to Parquet, then Vortex comes off that Parquet — the
+    /// case that a URL-to-path download descriptor could not express.
+    #[test]
+    fn streaming_only_suite_derives_vortex_from_its_parquet() -> Result<()> {
+        let native = [Format::Parquet];
+        assert_eq!(
+            plan(&native, Format::Parquet)?,
+            Plan::Native(Format::Parquet)
+        );
+        assert_eq!(
+            plan(&native, Format::OnDiskVortex)?,
+            Plan::DeriveFromParquet(Format::OnDiskVortex, CompactionStrategy::Default),
+        );
+        Ok(())
+    }
+
+    /// TPC-H writes Vortex from its row generator, so it must not round-trip through Parquet.
+    #[test]
+    fn generator_that_writes_vortex_natively_skips_the_parquet_round_trip() -> Result<()> {
+        let native = [Format::Parquet, Format::OnDiskVortex];
+        assert_eq!(
+            plan(&native, Format::OnDiskVortex)?,
+            Plan::Native(Format::OnDiskVortex),
+        );
+        Ok(())
+    }
+
+    /// Parquet is the only pivot: nothing converts Vortex back, so a Vortex-only suite
+    /// asking for Parquet is an error rather than a silent no-op.
+    #[test]
+    fn vortex_only_suite_cannot_produce_parquet() {
+        let native = [Format::OnDiskVortex];
+        assert!(plan(&native, Format::Parquet).is_err());
+        assert!(plan(&native, Format::Lance).is_err());
+    }
+
+    #[test]
+    fn emit_records_table_and_path_in_order() -> Result<()> {
+        let dir = tempdir()?;
+        let ctx = SetupCtx::new(dir.path())?;
+
+        ctx.emit("hits", dir.path().join("hits_0.parquet"));
+        ctx.emit("hits", dir.path().join("hits_1.parquet"));
+
+        let emitted = ctx.emitted();
+        assert_eq!(emitted.len(), 2);
+        assert!(emitted.iter().all(|e| e.table == "hits"));
+        assert_eq!(emitted[0].path, dir.path().join("hits_0.parquet"));
+        assert_eq!(emitted[1].path, dir.path().join("hits_1.parquet"));
+        Ok(())
+    }
+
+    #[test]
+    fn new_creates_the_staging_directory() -> Result<()> {
+        let dir = tempdir()?;
+        let staging = dir.path().join("nested").join("parquet");
+        let ctx = SetupCtx::new(&staging)?;
+        assert!(staging.is_dir());
+        assert_eq!(ctx.staging(), staging);
+        Ok(())
+    }
+}

--- a/vortex-bench/src/setup.rs
+++ b/vortex-bench/src/setup.rs
@@ -10,9 +10,9 @@
 //! [`Benchmark::native_formats`], and materializes one of them in
 //! [`Benchmark::setup`]. Everything else is derived by [`prepare_data`].
 //!
-//! Parquet is the pivot format because it is the only one that can be derived *from*:
-//! [`crate::conversions`] converts Parquet to Vortex, but nothing converts Vortex back to
-//! Parquet. A benchmark that produces only Vortex therefore cannot serve a Parquet run.
+//! Parquet and Vortex convert in both directions, so either can act as the pivot: a
+//! Parquet-native suite derives Vortex, and a Vortex-native suite derives Parquet. A suite
+//! that produces neither can only serve the formats it lists.
 
 use std::path::Path;
 use std::path::PathBuf;
@@ -28,6 +28,7 @@ use crate::Benchmark;
 use crate::CompactionStrategy;
 use crate::Format;
 use crate::conversions::convert_parquet_directory_to_vortex;
+use crate::conversions::convert_vortex_directory_to_parquet;
 use crate::datasets::data_downloads::download_many;
 use crate::datasets::data_downloads::http_client;
 
@@ -133,29 +134,32 @@ pub async fn prepare_data(benchmark: &dyn Benchmark, formats: &[Format]) -> Resu
 
     let native = benchmark.native_formats();
 
-    // Parquet underpins every derived format, so produce it if anything needs it.
-    let needs_parquet = formats
+    let plans = formats
         .iter()
-        .any(|f| !native.contains(f) || *f == Format::Parquet);
-    if needs_parquet && native.contains(&Format::Parquet) {
-        setup_format(benchmark, &base_path, Format::Parquet).await?;
+        // Lance and DuckDB are built by their own bench binaries from the Parquet below.
+        .filter(|f| !matches!(f, Format::Lance | Format::OnDiskDuckDB | Format::Csv))
+        .map(|&f| plan(native, f))
+        .collect::<Result<Vec<_>>>()
+        .with_context(|| format!("benchmark {}", benchmark.dataset_name()))?;
+
+    // Run `setup` once per source format any plan depends on, before any derivation reads it.
+    let mut sources: Vec<Format> = plans.iter().map(Plan::source).collect();
+    sources.sort_unstable_by_key(|f| f.name());
+    sources.dedup();
+    for source in sources {
+        setup_format(benchmark, &base_path, source).await?;
     }
 
-    for &format in formats {
-        // Lance and DuckDB are built by their own bench binaries from the Parquet above.
-        if matches!(format, Format::Lance | Format::OnDiskDuckDB | Format::Csv) {
-            continue;
-        }
-
-        match plan(native, format)
-            .with_context(|| format!("benchmark {}", benchmark.dataset_name()))?
-        {
-            Plan::Native(Format::Parquet) => {
-                // Already produced above.
-            }
-            Plan::Native(format) => setup_format(benchmark, &base_path, format).await?,
+    for plan in plans {
+        match plan {
+            // Produced by the source loop above.
+            Plan::Native(_) => {}
             Plan::DeriveFromParquet(format, compaction) => {
                 convert_parquet_directory_to_vortex(&base_path, compaction).await?;
+                benchmark.prepare_format(format, &base_path).await?;
+            }
+            Plan::DeriveFromVortex(format) => {
+                convert_vortex_directory_to_parquet(&base_path).await?;
                 benchmark.prepare_format(format, &base_path).await?;
             }
         }
@@ -183,7 +187,7 @@ async fn setup_format(benchmark: &dyn Benchmark, base_path: &Path, format: Forma
     Ok(())
 }
 
-/// Which formats a benchmark produces natively and which are derived from Parquet.
+/// How one requested format gets produced.
 ///
 /// Split out so the routing is testable without running a download or a generator.
 #[derive(Debug, PartialEq, Eq)]
@@ -192,25 +196,45 @@ pub(crate) enum Plan {
     Native(Format),
     /// Parquet is produced, then converted with this strategy.
     DeriveFromParquet(Format, CompactionStrategy),
+    /// Vortex is produced, then converted back to Parquet.
+    DeriveFromVortex(Format),
 }
 
+impl Plan {
+    /// The format `setup` must produce before this plan can run.
+    fn source(&self) -> Format {
+        match self {
+            Plan::Native(format) => *format,
+            Plan::DeriveFromParquet(..) => Format::Parquet,
+            Plan::DeriveFromVortex(_) => Format::OnDiskVortex,
+        }
+    }
+}
+
+/// Pick how to produce `requested` given what the benchmark makes natively.
+///
+/// Parquet and Vortex convert in both directions, so either can serve as the pivot: a
+/// Parquet-native suite derives Vortex, and a Vortex-native suite derives Parquet.
 pub(crate) fn plan(native: &[Format], requested: Format) -> Result<Plan> {
     if native.contains(&requested) {
         return Ok(Plan::Native(requested));
     }
-    if !native.contains(&Format::Parquet) {
-        bail!("cannot produce {requested}: not native ({native:?}) and Parquet is unavailable");
-    }
+
     match requested {
-        Format::OnDiskVortex => Ok(Plan::DeriveFromParquet(
+        Format::OnDiskVortex if native.contains(&Format::Parquet) => Ok(Plan::DeriveFromParquet(
             requested,
             CompactionStrategy::Default,
         )),
-        Format::VortexCompact => Ok(Plan::DeriveFromParquet(
+        Format::VortexCompact if native.contains(&Format::Parquet) => Ok(Plan::DeriveFromParquet(
             requested,
             CompactionStrategy::Compact,
         )),
-        other => bail!("cannot derive {other} from Parquet"),
+        // Reverse direction: only plain on-disk Vortex is a valid source. Reading back a
+        // compacted file would produce identical Parquet, so it is not worth a second path.
+        Format::Parquet if native.contains(&Format::OnDiskVortex) => {
+            Ok(Plan::DeriveFromVortex(requested))
+        }
+        other => bail!("cannot produce {other}: native formats are {native:?}"),
     }
 }
 
@@ -247,13 +271,36 @@ mod tests {
         Ok(())
     }
 
-    /// Parquet is the only pivot: nothing converts Vortex back, so a Vortex-only suite
-    /// asking for Parquet is an error rather than a silent no-op.
+    /// Conversion runs both ways, so a Vortex-only suite can serve a Parquet run.
     #[test]
-    fn vortex_only_suite_cannot_produce_parquet() {
+    fn vortex_only_suite_derives_parquet() -> Result<()> {
         let native = [Format::OnDiskVortex];
-        assert!(plan(&native, Format::Parquet).is_err());
-        assert!(plan(&native, Format::Lance).is_err());
+        assert_eq!(
+            plan(&native, Format::Parquet)?,
+            Plan::DeriveFromVortex(Format::Parquet),
+        );
+        Ok(())
+    }
+
+    /// A format with no conversion path from anything native is still a hard error.
+    #[test]
+    fn unreachable_format_is_an_error() {
+        assert!(plan(&[Format::OnDiskVortex], Format::Lance).is_err());
+        // VortexCompact is only derivable from Parquet, which this suite does not produce.
+        assert!(plan(&[Format::OnDiskVortex], Format::VortexCompact).is_err());
+    }
+
+    #[test]
+    fn source_is_what_setup_must_produce() {
+        assert_eq!(Plan::Native(Format::Parquet).source(), Format::Parquet);
+        assert_eq!(
+            Plan::DeriveFromParquet(Format::OnDiskVortex, CompactionStrategy::Default).source(),
+            Format::Parquet,
+        );
+        assert_eq!(
+            Plan::DeriveFromVortex(Format::Parquet).source(),
+            Format::OnDiskVortex,
+        );
     }
 
     #[test]

--- a/vortex-bench/src/spatialbench/benchmark.rs
+++ b/vortex-bench/src/spatialbench/benchmark.rs
@@ -12,6 +12,7 @@ use crate::Benchmark;
 use crate::BenchmarkDataset;
 use crate::Engine;
 use crate::Format;
+use crate::SetupCtx;
 use crate::TableSpec;
 use crate::spatialbench::datagen;
 use crate::spatialbench::datagen::Table;
@@ -80,10 +81,7 @@ impl Benchmark for SpatialBenchBenchmark {
             .collect())
     }
 
-    async fn generate_base_data(&self) -> anyhow::Result<()> {
-        if self.data_url.scheme() != "file" {
-            return Ok(());
-        }
+    async fn setup(&self, ctx: &SetupCtx, _format: Format) -> anyhow::Result<()> {
         let base_data_dir = self
             .data_url
             .to_file_path()
@@ -111,6 +109,11 @@ impl Benchmark for SpatialBenchBenchmark {
         ];
         datagen::spatially_sort_tables(&base_data_dir.join(Format::Parquet.name()), &derived_dirs)
             .await?;
+
+        for table in self.base_tables() {
+            let name = table.name();
+            ctx.emit(name, ctx.staging().join(format!("{name}.parquet")));
+        }
         Ok(())
     }
 

--- a/vortex-bench/src/statpopgen/download_vcf.rs
+++ b/vortex-bench/src/statpopgen/download_vcf.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -29,15 +30,24 @@ use crate::statpopgen::schema::schema_from_vcf_header;
 const ROW_GROUP_SIZE_IN_VARIANTS: u64 = 1024;
 
 impl StatPopGenBenchmark {
-    pub async fn download_parquet(&self) -> Result<()> {
+    /// Stream the gnomAD VCF into `parquet_output_path`, stopping after `self.n_rows`
+    /// records.
+    ///
+    /// The source is far too large to land on disk, so this consumes the response body
+    /// directly rather than going through the file-based download helpers. `client` is the
+    /// shared pooled client from [`crate::SetupCtx::http`].
+    pub async fn download_parquet(
+        &self,
+        client: &Client,
+        parquet_output_path: &Path,
+    ) -> Result<()> {
         let url = format!(
             "https://gnomad-public-us-east-1.s3.amazonaws.com/release/3.1.2/vcf/genomes/{}.vcf.bgz",
             StatPopGenBenchmark::FILE_NAME
         );
-        let parquet_output_path = self.parquet_path()?;
 
         idempotent_async(
-            &parquet_output_path,
+            parquet_output_path,
             async |parquet_output_path| -> Result<()> {
                 info!(
                     "Downloading first {} lines of gnomAD v3.1.2 HGDP-1kG chr21.",
@@ -45,7 +55,6 @@ impl StatPopGenBenchmark {
                 );
 
                 // Fetch the remote stream
-                let client = Client::new();
                 let response = client
                     .get(url)
                     .send()

--- a/vortex-bench/src/statpopgen/statpopgen_benchmark.rs
+++ b/vortex-bench/src/statpopgen/statpopgen_benchmark.rs
@@ -11,6 +11,7 @@ use crate::Benchmark;
 use crate::BenchmarkDataset;
 use crate::Format;
 use crate::IdempotentPath;
+use crate::SetupCtx;
 use crate::TableSpec;
 use crate::workspace_root;
 
@@ -122,15 +123,13 @@ impl Benchmark for StatPopGenBenchmark {
             .collect())
     }
 
-    async fn generate_base_data(&self) -> Result<()> {
-        if self.data_url.scheme() != "file" {
-            anyhow::bail!(
-                "Unsupported URL scheme '{}' - only 'file://' URLs are supported for local datasets",
-                self.data_url.scheme()
-            );
-        }
-
-        self.download_parquet().await?;
+    /// Streams the gnomAD VCF straight into Parquet — the source `.vcf.bgz` is hundreds of
+    /// gigabytes and we stop after `n_rows`, so it is never landed on disk. Vortex is then
+    /// derived from the Parquet this produces, like any other suite.
+    async fn setup(&self, ctx: &SetupCtx, _format: Format) -> Result<()> {
+        let parquet = ctx.staging().join(format!("{}.parquet", Self::FILE_NAME));
+        self.download_parquet(ctx.http(), &parquet).await?;
+        ctx.emit("statpopgen", parquet);
         Ok(())
     }
 

--- a/vortex-bench/src/tpcds/tpcds_benchmark.rs
+++ b/vortex-bench/src/tpcds/tpcds_benchmark.rs
@@ -13,6 +13,7 @@ use crate::Benchmark;
 use crate::BenchmarkDataset;
 use crate::Format;
 use crate::IdempotentPath;
+use crate::SetupCtx;
 use crate::TableSpec;
 use crate::tpcds::duckdb::generate_tpcds;
 use crate::tpcds::tpcds_queries;
@@ -64,20 +65,25 @@ impl Benchmark for TpcDsBenchmark {
         Ok(tpcds_queries().collect())
     }
 
-    async fn generate_base_data(&self) -> Result<()> {
+    async fn setup(&self, ctx: &SetupCtx, format: Format) -> Result<()> {
         let base_data_dir = self
             .data_url
             .to_file_path()
             .map_err(|_| anyhow!("Invalid file URL: {}", self.data_url))?;
 
         info!(
-            "Generating TPC-DS data with scale factor {} for format {:?}",
+            "Generating TPC-DS data with scale factor {} for format {format:?}",
             self.scale_factor,
-            Format::Parquet
         );
 
         generate_tpcds(base_data_dir, self.scale_factor.clone())?;
 
+        for table in self.tables() {
+            ctx.emit(
+                table,
+                ctx.staging().join(format!("{table}.{}", format.ext())),
+            );
+        }
         Ok(())
     }
 

--- a/vortex-bench/src/tpch/benchmark.rs
+++ b/vortex-bench/src/tpch/benchmark.rs
@@ -12,6 +12,7 @@ use crate::Benchmark;
 use crate::BenchmarkDataset;
 use crate::Format;
 use crate::IdempotentPath;
+use crate::SetupCtx;
 use crate::TableSpec;
 use crate::tpch::EXPECTED_ROW_COUNTS_SF1;
 use crate::tpch::EXPECTED_ROW_COUNTS_SF10;
@@ -83,20 +84,28 @@ impl Benchmark for TpcHBenchmark {
         Ok(tpch_queries().collect())
     }
 
-    async fn generate_base_data(&self) -> anyhow::Result<()> {
-        if self.data_url.scheme() != "file" {
-            return Ok(());
-        }
+    /// TPC-H writes Vortex straight from the row generator, so it never pays for a Parquet
+    /// round trip on disk when only Vortex is requested.
+    fn native_formats(&self) -> &[Format] {
+        &[Format::Parquet, Format::OnDiskVortex, Format::VortexCompact]
+    }
 
+    async fn setup(&self, ctx: &SetupCtx, format: Format) -> anyhow::Result<()> {
         let base_data_dir = self
             .data_url
             .to_file_path()
             .map_err(|_| anyhow::anyhow!("Invalid file URL: {}", self.data_url.as_str()))?;
 
-        let options = TpchGenOptions::new(self.scale_factor.clone(), base_data_dir);
-
+        let options =
+            TpchGenOptions::new(self.scale_factor.clone(), base_data_dir).with_format(format);
         tpchgen::generate_tpch_tables(options).await?;
 
+        for table in self.tables() {
+            ctx.emit(
+                table,
+                ctx.staging().join(format!("{table}.{}", format.ext())),
+            );
+        }
         Ok(())
     }
 

--- a/vortex-bench/src/vortex_queries.rs
+++ b/vortex-bench/src/vortex_queries.rs
@@ -10,7 +10,6 @@ use std::process::Command;
 
 use anyhow::Context;
 use anyhow::Result;
-use anyhow::anyhow;
 use anyhow::bail;
 use glob::Pattern;
 use tracing::debug;
@@ -20,6 +19,7 @@ use vortex::error::VortexExpect;
 use crate::Benchmark;
 use crate::BenchmarkDataset;
 use crate::Format;
+use crate::SetupCtx;
 use crate::TableSpec;
 use crate::bench_dir;
 use crate::resolve_data_url;
@@ -114,14 +114,10 @@ impl Benchmark for VortexBenchmark {
             .collect()
     }
 
-    async fn generate_base_data(&self) -> Result<()> {
-        let data_dir = self
-            .data_url
-            .to_file_path()
-            .map_err(|_| anyhow!("Invalid file URL: {}", self.data_url.as_str()))?;
-        let parquet_dir = data_dir.join(Format::Parquet.name());
-        fs::create_dir_all(&parquet_dir)?;
+    async fn setup(&self, ctx: &SetupCtx, _format: Format) -> Result<()> {
+        let parquet_dir = ctx.staging().to_path_buf();
         let parquet_file = parquet_dir.join("test.parquet");
+        ctx.emit("test", parquet_file.clone());
 
         if parquet_file.exists() {
             debug!("Parquet data present in {}", parquet_dir.display());


### PR DESCRIPTION
## Rationale for this change

Benchmark data was fetched lazily and serially: `compress-bench` downloaded each dataset at the moment the benchmark first touched it, so network time interleaved with measurement instead of happening up front. Investigating that surfaced a wider problem — every suite had its own idea of how data gets materialized. Twelve benchmarks split across `download_data`, `download_many`, two hand-rolled `reqwest` clients, and a `generate_base_data` hook, with the Parquet→Vortex conversion loop copy-pasted into four driver binaries.

This unifies that behind one trait method, and fixes two real bugs found along the way.

## What changes are included in this PR?

**A single materialization entry point.** `generate_base_data` is replaced by:

```rust
fn native_formats(&self) -> &[Format] { &[Format::Parquet] }
async fn setup(&self, ctx: &SetupCtx, format: Format) -> Result<()>;
```

A benchmark declares which formats it can produce without help and materializes one into `ctx.staging()`, registering each output with `ctx.emit(table, path)`. The new `prepare_data` driver derives the rest and is now the only caller of the conversion functions, replacing the duplicated loop in `data-gen`, `datafusion-bench`, `duckdb-bench`, and `lance-bench`.

`SetupCtx` exposes a persistent staging directory, `download()` onto the shared pool, and `http()` for the one suite that must consume a response stream rather than land a file.

**Vortex→Parquet conversion**, so the pivot works in both directions. `convert_vortex_file_to_parquet` streams record batches out; `convert_vortex_directory_to_parquet` mirrors the existing directory walk with the same per-file idempotency and memory-derived concurrency limit. Previously a Vortex-native suite could never serve a Parquet run. Note this is not a round-trip inverse — Vortex logical types without a Parquet equivalent are written as whatever the Arrow lowering produces.

**TPC-H no longer round-trips through Parquet.** It lists Parquet and both Vortex flavors as native and passes `format` into `TpchGenOptions::with_format`, so `--formats vortex` writes Vortex straight from the row generator instead of writing Parquet to disk and reading it back.

**GhArchive bug fix.** Its 24 hourly JSON files were fetched serially with no retries and appended into one file guarded by a single idempotency check, so a failure on the last hour discarded all 24. They now download in parallel through the shared pool, land separately, and are read back via a DuckDB glob.

**Unbounded download concurrency fix.** Each `download_many` call runs its own AIMD controller, so concurrent batches ramped to `N × 256` sockets with no shared backoff signal. Total in-flight is now bounded process-wide.

**Public BI URLs vendored.** The download list came from `data-urls.txt`, sparse-checked-out from an upstream repo at runtime. All 206 upstream URLs across 46 datasets are `{PREFIX}/{dataset}/{table}.csv.bz2` with no exceptions, so only table names are recorded and `data_urls` rebuilds the URL. Verified the constant reproduces all 206 exactly. The upstream repo is MIT licensed (Copyright CWI Database Architectures Group) and already mirrored by this org; attribution is recorded alongside the constant. The fetch script is still required for the table and query SQL, which is not vendored.

Also hoists the `data_url.scheme() != "file"` remote-data check out of ten implementations into the driver, and drops the per-benchmark path helpers now that staging owns the layout.

## What APIs are changed? Are there any user-facing changes?

`vortex-bench` is not published, so this is internal only.

- `Benchmark::generate_base_data` is removed, replaced by `Benchmark::setup` and `Benchmark::native_formats`. Any out-of-tree implementation must be ported.
- `Dataset::to_vortex_array` is removed from the trait — no caller used it through the trait. The two internal uses became inherent methods.
- New: `vortex_bench::setup` (`SetupCtx`, `prepare_data`), and `conversions::convert_vortex_{file,directory}_to_parquet`.
- Requesting a format that cannot be produced or derived is now a hard error rather than a silent no-op.

No changes to the query suites, engines, or measurement output, so benchmark numbers should be unchanged.

## Testing

`cargo build`, `cargo clippy --all-targets`, and `cargo +nightly fmt` are clean on `vortex-bench`, `compress-bench`, `string-bench`, and `datafusion-bench`. `cargo test -p vortex-bench` passes 69 tests, including new coverage of format routing (both derivation directions, and the unreachable-format error) and of the vendored URL corpus.

Ran `data-gen public-bi --opt dataset=arade --formats parquet` end to end: it downloads 162,560,322 bytes through the vendored URL — matching the server's `Content-Length` exactly — and decompresses to 850 MB of CSV before reaching the DuckDB step.

**Not verified:** `duckdb-bench` does not compile in my environment (`vortex-duckdb`'s build script cannot fetch the DuckDB release tarball; this reproduces on a clean checkout), so its edit is compile-unverified. It is a mechanical substitution of the loop `prepare_data` now performs, but deserves a local build. No benchmarks were run, so the performance claims above are structural, not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011sqJ9xx11nhvYyEb2qx53n)_