### PR TITLE
fix(spark): report the written file size in the commit message

### DIFF
--- a/java/vortex-spark/src/main/java/dev/vortex/spark/write/VortexDataWriter.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/write/VortexDataWriter.java
@@ -192,9 +192,6 @@ public final class VortexDataWriter implements DataWriter<InternalRow>, AutoClos
         vectorSchemaRoot.setRowCount(batchRows.size());
 
         // Export via Arrow C Data Interface and write to Vortex
-        for (FieldVector vector : vectorSchemaRoot.getFieldVectors()) {
-            bytesWritten += vector.getBufferSize();
-        }
         try (ArrowArray arrowArray = ArrowArray.allocateNew(allocator);
                 ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator)) {
             Data.exportVectorSchemaRoot(allocator, vectorSchemaRoot, null, arrowArray, arrowSchema);
@@ -327,10 +324,10 @@ public final class VortexDataWriter implements DataWriter<InternalRow>, AutoClos
                     writeBatch();
                 }
 
-                // Close the Vortex writer to finalize the file
+                // Finalize the file; the summary carries its physical size
                 if (vortexWriter != null) {
                     try {
-                        vortexWriter.close();
+                        bytesWritten = vortexWriter.finish().fileSize();
                     } finally {
                         vortexWriter = null; // Always null out the reference
                     }


### PR DESCRIPTION
## Rationale for this change

`bytesWritten` accumulated `FieldVector.getBufferSize()` per batch — the uncompressed in-memory Arrow size — and handed that to `VortexWriterCommitMessage`, whose javadoc documents it as "the number of bytes written". For a compressed file the two differ by the compression ratio.

The real value was already available: `VortexWriter.finish()` returns a summary carrying the file's physical size, and `close()` was only calling `finish()` and discarding the result.

## What changes are included in this PR?

Take the size from `finish().fileSize()` and drop the per-batch accumulation, which also removes work from the write path.

- `./gradlew :vortex-spark_2.13:test --tests '…VortexDataSourceWriteTest' --tests '…VortexDataSourceBasicTest'` — 15 pass
- same on `:vortex-spark_2.12:test` — 15 pass
- `spotlessCheck` (both variants) and `javadoc` — clean

No new test: the value only becomes observable through a commit message a driver collects, which the suite has no fixture for.

## What APIs are changed? Are there any user-facing changes?

None. `VortexWriterCommitMessage.bytesWritten()` now reports the file size rather than the in-memory size, which is what its javadoc already promised.

## AI assistance

Prepared with agentic AI assistance. I read the writer's finalization path and `VortexWriter.finish()` to confirm the summary is produced there and that `close()` discarded it.
