### PR TITLE
fix(spark): name the Vortex files when a read fails

### DIFF
--- a/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexPartitionReader.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/read/VortexPartitionReader.java
@@ -95,7 +95,7 @@ final class VortexPartitionReader implements PartitionReader<ColumnarBatch> {
                         return true;
                     }
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    throw failure("load a batch from", e);
                 }
                 closeCurrentReader();
             }
@@ -119,7 +119,7 @@ final class VortexPartitionReader implements PartitionReader<ColumnarBatch> {
         try {
             root = currentReader.getVectorSchemaRoot();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw failure("read the loaded batch of", e);
         }
 
         int rowCount = root.getRowCount();
@@ -157,12 +157,17 @@ final class VortexPartitionReader implements PartitionReader<ColumnarBatch> {
         session = null;
     }
 
+    /** Wraps a failure with the paths being read, the one fact a stack trace alone does not give. */
+    private RuntimeException failure(String what, IOException cause) {
+        return new RuntimeException(String.format("Failed to %s %s", what, spark.paths()), cause);
+    }
+
     private void closeCurrentReader() {
         if (currentReader != null) {
             try {
                 currentReader.close();
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw failure("close the reader over", e);
             }
             currentReader = null;
         }


### PR DESCRIPTION
## Rationale for this change

The three `IOException` wrappers in `VortexPartitionReader` threw a bare `RuntimeException(e)`. When a scan fails mid-flight the executor log then shows the cause's stack trace but not the one fact it cannot carry: which Vortex files were being read. On a scan spanning many partitions that is the difference between a one-line diagnosis and grepping task logs.

The reader already holds the paths — it opens the `DataSource` with them.

## What changes are included in this PR?

Each wrapper now names the partition's paths and what the reader was doing (`load a batch from` / `read the loaded batch of` / `close the reader over`), through one small helper.

- `./gradlew :vortex-spark_2.13:test` — 167 tests, only the pre-existing `VortexDataSourceS3MockTest` fails here for lack of a Docker environment
- same on `:vortex-spark_2.12:test`
- `spotlessCheck` (both variants) and `javadoc` — clean

No new test: these branches need a mid-scan native I/O failure, which the suite has no fixture for.

## What APIs are changed? Are there any user-facing changes?

None. The exception type is unchanged; only the message gains the paths.

## AI assistance

Prepared with agentic AI assistance. I read the reader's three failure paths and confirmed `spark.paths()` is already available at each of them.
