### PR TITLE
fix(spark): keep the cause when a path cannot be loaded as a table

### DIFF
--- a/java/vortex-spark/src/main/java/dev/vortex/spark/VortexCatalog.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/VortexCatalog.java
@@ -12,6 +12,8 @@ import org.apache.spark.sql.connector.catalog.TableChange;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A path-based Spark catalog for querying Vortex files directly from SQL.
@@ -30,6 +32,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * vortex.`/path/to/data`}), and pushdown all behave identically. The catalog holds no state and supports no DDL.
  */
 public final class VortexCatalog implements TableCatalog {
+    private static final Logger log = LoggerFactory.getLogger(VortexCatalog.class);
+
     private static final String PATH_KEY = "path";
 
     private String name = "vortex";
@@ -85,8 +89,14 @@ public final class VortexCatalog implements TableCatalog {
             schema = provider.inferSchema(options);
             partitioning = provider.inferPartitioning(options);
         } catch (RuntimeException e) {
-            // Missing or unreadable paths surface as "table not found" to SQL users.
-            throw new NoSuchTableException(ident);
+            // Missing or unreadable paths surface as "table not found" to SQL users. NoSuchTableException
+            // has no cause-accepting constructor common to the supported Spark versions, so carry the
+            // original failure as a suppressed exception and log it: it names the offending path and
+            // distinguishes an empty directory from a credentials or unsupported-type error.
+            log.warn("Cannot load {} as a Vortex table, reporting it as not found", path, e);
+            NoSuchTableException notFound = new NoSuchTableException(ident);
+            notFound.addSuppressed(e);
+            throw notFound;
         }
         return provider.getTable(schema, partitioning, Map.of(PATH_KEY, path));
     }


### PR DESCRIPTION
## Rationale for this change

`loadTable` translates a failed schema inference into `NoSuchTableException` so SQL users see "table not found" rather than an internal error. But it discarded the original exception entirely — no cause, no suppressed, no log.

That threw away the message #8858 added, which names the offending path, and collapsed a credentials failure or an unsupported Arrow type into the same "not found" as an empty directory.

## What changes are included in this PR?

`NoSuchTableException` has no cause-accepting constructor common to Spark 3.5 and 4.1 (only `(Identifier)` is), so the original failure is carried as a suppressed exception and logged at warn.

- `./gradlew :vortex-spark_2.13:test --tests '…VortexCatalogTest' --tests '…VortexSqlTest'` — 16 pass
- same on `:vortex-spark_2.12:test`
- `spotlessCheck` (both variants) and `javadoc` — clean

The existing `VortexCatalogTest.unreadablePathIsReportedAsMissingTable` and `VortexSqlTest.testDirectPathNotFound` still pass: the exception type is unchanged.

## What APIs are changed? Are there any user-facing changes?

None. Same exception type; the cause is now recoverable from `getSuppressed()` and appears in the log.

## AI assistance

Prepared with agentic AI assistance. I checked the `NoSuchTableException` constructors available in both supported Spark versions before choosing `addSuppressed` over a cause argument.
