### PR TITLE
fix(spark): correct the CTAS claim on VortexSessionCatalog.createTable

### DIFF
--- a/java/vortex-spark/src/main/java/dev/vortex/spark/VortexSessionCatalog.java
+++ b/java/vortex-spark/src/main/java/dev/vortex/spark/VortexSessionCatalog.java
@@ -47,8 +47,10 @@ public final class VortexSessionCatalog extends DelegatingCatalogExtension {
      * Creates the table in the delegate session catalog, then returns it resolved through the Vortex connector when its
      * provider is {@code vortex}.
      *
-     * <p>The conversion matters for {@code CREATE TABLE ... AS SELECT}: Spark writes the query result into the table
-     * returned here, which must therefore support V2 writes.
+     * <p>Spark does not route table creation through this overload — {@link DelegatingCatalogExtension} sends the
+     * {@code Column[]} overload straight to the delegate, and that is the one both supported Spark versions call. It is
+     * kept because the delegate may return {@code null} on the normal path, which {@link #asVortexTableIfVortex} now
+     * tolerates; {@code CREATE TABLE ... AS SELECT} gets its Vortex table from {@link #loadTable} instead.
      */
     @SuppressWarnings("deprecation")
     @Override
@@ -60,11 +62,15 @@ public final class VortexSessionCatalog extends DelegatingCatalogExtension {
 
     /**
      * Rebuilds a session-catalog table as a Vortex DataSource V2 table when its provider is {@code vortex} and it has a
-     * location; returns every other table unchanged. The schema and partitioning stored in the catalog are used as-is,
-     * no file needs to be opened.
+     * location; returns every other table unchanged, and {@code null} for a {@code null} input. The schema and
+     * partitioning stored in the catalog are used as-is, no file needs to be opened.
      */
     @SuppressWarnings("deprecation")
     private static Table asVortexTableIfVortex(Table table) {
+        if (table == null) {
+            // V2SessionCatalog.createTable returns null on its normal path.
+            return null;
+        }
         Map<String, String> properties = table.properties();
         VortexDataSourceV2 provider = new VortexDataSourceV2();
         if (!provider.shortName().equalsIgnoreCase(properties.get(TableCatalog.PROP_PROVIDER))) {


### PR DESCRIPTION
## Rationale for this change

The javadoc on `createTable` said Spark writes a `CREATE TABLE ... AS SELECT` result into the table this overload returns. It does not. `DelegatingCatalogExtension` sends the `Column[]` overload straight to the delegate, and that is the overload both supported Spark versions call — 3.5's `CreateTableAsSelectExec` directly, 4.1's via the `TableInfo` default. This override never runs; CTAS gets its Vortex table from the `loadTable` override instead.

Had it run it would have thrown: `V2SessionCatalog.createTable` returns `null` on its normal path, and `asVortexTableIfVortex` dereferenced the argument immediately.

## What changes are included in this PR?

Tolerate `null` in `asVortexTableIfVortex`, and replace the javadoc claim with what actually happens.

- `./gradlew :vortex-spark_2.13:test --tests '…VortexSessionCatalogTest' --tests '…VortexSqlTest'` — 10 pass
- same on `:vortex-spark_2.12:test`
- `spotlessCheck` (both variants) and `javadoc` — clean

`VortexSessionCatalogTest` already covers the managed-table lifecycle on both versions, which is the path CTAS actually takes.

## What APIs are changed? Are there any user-facing changes?

None.

## AI assistance

Prepared with agentic AI assistance. I verified the dispatch against the compiled `DelegatingCatalogExtension`, `CreateTableAsSelectExec` and `V2SessionCatalog` in both Spark versions rather than reasoning from the source I had.
