### PR TITLE
Bump Rust toolchain to 1.95

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ keywords = ["vortex"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/spiraldb/vortex"
-rust-version = "1.94"
+rust-version = "1.95"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ keywords = ["vortex"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/spiraldb/vortex"
-rust-version = "1.91.0"
+rust-version = "1.94"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.94.1"
 components = ["rust-src", "rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.95"
 components = ["rust-src", "rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/vortex-array/src/arrays/chunked/compute/filter.rs
+++ b/vortex-array/src/arrays/chunked/compute/filter.rs
@@ -71,7 +71,7 @@ fn filter_slices(
     let chunk_filters = chunk_filters(array, slices)?;
 
     // Now, apply the chunk filter to every slice.
-    for (chunk, chunk_filter) in array.iter_chunks().zip(chunk_filters.into_iter()) {
+    for (chunk, chunk_filter) in array.iter_chunks().zip(chunk_filters) {
         match chunk_filter {
             // All => preserve the entire chunk unfiltered.
             ChunkFilter::All => result.push(chunk.clone()),

--- a/vortex-array/src/arrays/decimal/array.rs
+++ b/vortex-array/src/arrays/decimal/array.rs
@@ -609,7 +609,7 @@ where
         )
     }
 
-    for (idx, value) in patch_indices.iter().zip_eq(patch_values.into_iter()) {
+    for (idx, value) in patch_indices.iter().zip_eq(patch_values) {
         buffer[idx.as_() - patch_indices_offset] = <ValuesDVT as BigCast>::from(value).vortex_expect(
             "values of a given DecimalDType are representable in all compatible NativeDecimalType",
         );

--- a/vortex-bench/src/vector_dataset/download.rs
+++ b/vortex-bench/src/vector_dataset/download.rs
@@ -102,11 +102,7 @@ pub async fn download(ds: VectorDataset, layout: TrainLayout) -> Result<DatasetP
     let train_targets = paths::train_files(ds, layout, spec.num_files());
     debug_assert_eq!(urls.len(), train_targets.len());
 
-    let train_downloads: Vec<(PathBuf, String)> = train_targets
-        .iter()
-        .cloned()
-        .zip(urls.into_iter())
-        .collect();
+    let train_downloads: Vec<(PathBuf, String)> = train_targets.iter().cloned().zip(urls).collect();
     download_many(train_downloads)
         .await
         .with_context(|| format!("download train shards for {}", ds.name()))?;

--- a/vortex-cuda/build.rs
+++ b/vortex-cuda/build.rs
@@ -74,12 +74,11 @@ fn main() {
                 .is_some_and(|n| n.starts_with("bit_unpack_"));
 
             match path.extension().and_then(|e| e.to_str()) {
-                Some("cuh") | Some("h") => {
+                Some("cuh") | Some("h") if !is_generated => {
                     // Only watch hand-written .cuh/.h files, not generated ones
                     // (generated files are rebuilt when cuda_kernel_generator changes)
-                    if !is_generated {
-                        println!("cargo:rerun-if-changed={}", path.display());
-                    }
+
+                    println!("cargo:rerun-if-changed={}", path.display());
                 }
                 Some("cu") => {
                     // Only watch hand-written .cu files, not generated ones

--- a/vortex-edition/src/session.rs
+++ b/vortex-edition/src/session.rs
@@ -133,8 +133,7 @@ impl EditionSession {
     pub fn current(&self, family: &str) -> Option<Edition> {
         self.editions()
             .into_iter()
-            .filter(|e| e.id.family == family && !e.is_draft())
-            .next_back()
+            .rfind(|e| e.id.family == family && !e.is_draft())
     }
 
     /// Compute the full encoding set of an edition: every declared inclusion of the

--- a/vortex-file/src/read/driver.rs
+++ b/vortex-file/src/read/driver.rs
@@ -754,10 +754,10 @@ mod tests {
                         coalesced_operations = counter.value();
                     }
                 }
-                MetricValue::Histogram(histogram) => {
-                    if metric.name() == "io.requests.coalesced.num_coalesced" {
-                        coalesced_histogram_count = histogram.count();
-                    }
+                MetricValue::Histogram(histogram)
+                    if metric.name() == "io.requests.coalesced.num_coalesced" =>
+                {
+                    coalesced_histogram_count = histogram.count();
                 }
                 _ => {}
             }

--- a/vortex-io/src/io_buf.rs
+++ b/vortex-io/src/io_buf.rs
@@ -218,7 +218,7 @@ mod tests {
 
         assert_eq!(data.read_ptr(), data.as_ptr());
         assert_eq!(data.bytes_init(), 11);
-        assert_eq!(data.as_slice(), b"hello world");
+        assert_eq!(data, b"hello world");
     }
 
     #[test]
@@ -226,7 +226,7 @@ mod tests {
         let data: &'static [u8] = b"";
 
         assert_eq!(data.bytes_init(), 0);
-        assert_eq!(data.as_slice(), b"");
+        assert_eq!(data, b"");
     }
 
     #[rstest]

--- a/vortex-io/src/runtime/current.rs
+++ b/vortex-io/src/runtime/current.rs
@@ -182,7 +182,6 @@ impl<T> ThreadSafeIterator<T> {
     }
 }
 
-#[expect(clippy::if_then_some_else_none)] // Clippy is wrong when if/else has await.
 #[cfg(test)]
 mod tests {
     use std::any::Any;

--- a/vortex-layout/src/layouts/struct_/writer.rs
+++ b/vortex-layout/src/layouts/struct_/writer.rs
@@ -180,7 +180,7 @@ impl LayoutStrategy for StructStrategy {
             while let Some(result) = columns_vec_stream.next().await {
                 match result {
                     Ok(columns) => {
-                        for (tx, column) in column_streams_tx.iter().zip_eq(columns.into_iter()) {
+                        for (tx, column) in column_streams_tx.iter().zip_eq(columns) {
                             if tx.send(Ok(column)).await.is_err() {
                                 vortex_bail!(
                                     "struct column writer finished before all chunks were sent"

--- a/vortex-layout/src/scan/multi.rs
+++ b/vortex-layout/src/scan/multi.rs
@@ -245,8 +245,7 @@ impl DataSource for MultiLayoutDataSource {
 
         if deferred_count == 0 {
             Precision::exact(sum)
-        } else if opened_count > 0 {
-            let avg = sum / opened_count;
+        } else if let Some(avg) = sum.checked_div(opened_count) {
             let extrapolated = avg.saturating_mul(total_count);
             Precision::inexact(extrapolated)
         } else {
@@ -489,15 +488,15 @@ fn reader_partition(
         return stream::empty().boxed();
     };
     match &request.partition_selection {
-        Selection::IncludeByIndex(buffer) => {
-            if buffer.as_slice().binary_search(&partition_idx_u64).is_err() {
-                return stream::empty().boxed();
-            }
+        Selection::IncludeByIndex(buffer)
+            if buffer.as_slice().binary_search(&partition_idx_u64).is_err() =>
+        {
+            return stream::empty().boxed();
         }
-        Selection::ExcludeByIndex(buffer) => {
-            if buffer.as_slice().binary_search(&partition_idx_u64).is_ok() {
-                return stream::empty().boxed();
-            }
+        Selection::ExcludeByIndex(buffer)
+            if buffer.as_slice().binary_search(&partition_idx_u64).is_ok() =>
+        {
+            return stream::empty().boxed();
         }
         _ => {}
     };

--- a/vortex-tui/src/browse/mod.rs
+++ b/vortex-tui/src/browse/mod.rs
@@ -118,17 +118,13 @@ pub(crate) fn handle_normal_mode(app: &mut AppState, event: InputEvent) -> Handl
         }
 
         #[cfg(feature = "native")]
-        (InputKeyCode::Char('['), false, false, _) => {
-            if app.current_tab == Tab::Query {
-                app.query_state.prepare_prev_page();
-            }
+        (InputKeyCode::Char('['), false, false, _) if app.current_tab == Tab::Query => {
+            app.query_state.prepare_prev_page();
         }
 
         #[cfg(feature = "native")]
-        (InputKeyCode::Char(']'), false, false, _) => {
-            if app.current_tab == Tab::Query {
-                app.query_state.prepare_next_page();
-            }
+        (InputKeyCode::Char(']'), false, false, _) if app.current_tab == Tab::Query => {
+            app.query_state.prepare_next_page();
         }
 
         (InputKeyCode::Up, ..)
@@ -191,12 +187,12 @@ pub(crate) fn handle_normal_mode(app: &mut AppState, event: InputEvent) -> Handl
                 app.query_state.table_state.select_last();
             }
         },
-        (InputKeyCode::Enter, ..) => {
-            if app.current_tab == Tab::Layout && app.cursor.layout().nchildren() > 0 {
-                let selected = app.layouts_list_state.selected().unwrap_or_default();
-                app.cursor = app.cursor.child(selected);
-                app.reset_layout_view_state();
-            }
+        (InputKeyCode::Enter, ..)
+            if app.current_tab == Tab::Layout && app.cursor.layout().nchildren() > 0 =>
+        {
+            let selected = app.layouts_list_state.selected().unwrap_or_default();
+            app.cursor = app.cursor.child(selected);
+            app.reset_layout_view_state();
         }
         (InputKeyCode::Left, ..)
         | (InputKeyCode::Char('h'), false, false, _)
@@ -244,18 +240,14 @@ pub(crate) fn handle_normal_mode(app: &mut AppState, event: InputEvent) -> Handl
         }
 
         #[cfg(feature = "native")]
-        (InputKeyCode::Char('s'), false, false, _) => {
-            if app.current_tab == Tab::Query {
-                let col = app.query_state.selected_column();
-                app.query_state.prepare_sort(col);
-            }
+        (InputKeyCode::Char('s'), false, false, _) if app.current_tab == Tab::Query => {
+            let col = app.query_state.selected_column();
+            app.query_state.prepare_sort(col);
         }
 
         #[cfg(feature = "native")]
-        (InputKeyCode::Esc, ..) => {
-            if app.current_tab == Tab::Query {
-                app.query_state.toggle_focus();
-            }
+        (InputKeyCode::Esc, ..) if app.current_tab == Tab::Query => {
+            app.query_state.toggle_focus();
         }
 
         _ => {}
@@ -272,35 +264,35 @@ pub(crate) fn handle_search_mode(app: &mut AppState, event: InputEvent) -> Handl
             app.clear_search();
         }
 
-        (InputKeyCode::Up, ..) | (InputKeyCode::Char('p'), true, ..) => {
-            if app.current_tab == Tab::Layout {
-                navigate_layout_up(app, SCROLL_LINE);
-            }
+        (InputKeyCode::Up, ..) | (InputKeyCode::Char('p'), true, ..)
+            if app.current_tab == Tab::Layout =>
+        {
+            navigate_layout_up(app, SCROLL_LINE);
         }
-        (InputKeyCode::Down, ..) | (InputKeyCode::Char('n'), true, ..) => {
-            if app.current_tab == Tab::Layout {
-                navigate_layout_down(app, SCROLL_LINE);
-            }
+        (InputKeyCode::Down, ..) | (InputKeyCode::Char('n'), true, ..)
+            if app.current_tab == Tab::Layout =>
+        {
+            navigate_layout_down(app, SCROLL_LINE);
         }
-        (InputKeyCode::PageUp, ..) | (InputKeyCode::Char('v'), _, true, _) => {
-            if app.current_tab == Tab::Layout {
-                navigate_layout_up(app, SCROLL_PAGE);
-            }
+        (InputKeyCode::PageUp, ..) | (InputKeyCode::Char('v'), _, true, _)
+            if app.current_tab == Tab::Layout =>
+        {
+            navigate_layout_up(app, SCROLL_PAGE);
         }
-        (InputKeyCode::PageDown, ..) | (InputKeyCode::Char('v'), true, ..) => {
-            if app.current_tab == Tab::Layout {
-                navigate_layout_down(app, SCROLL_PAGE);
-            }
+        (InputKeyCode::PageDown, ..) | (InputKeyCode::Char('v'), true, ..)
+            if app.current_tab == Tab::Layout =>
+        {
+            navigate_layout_down(app, SCROLL_PAGE);
         }
-        (InputKeyCode::Home, ..) | (InputKeyCode::Char('<'), _, true, _) => {
-            if app.current_tab == Tab::Layout {
-                app.layouts_list_state.select_first();
-            }
+        (InputKeyCode::Home, ..) | (InputKeyCode::Char('<'), _, true, _)
+            if app.current_tab == Tab::Layout =>
+        {
+            app.layouts_list_state.select_first();
         }
-        (InputKeyCode::End, ..) | (InputKeyCode::Char('>'), _, true, _) => {
-            if app.current_tab == Tab::Layout {
-                app.layouts_list_state.select_last();
-            }
+        (InputKeyCode::End, ..) | (InputKeyCode::Char('>'), _, true, _)
+            if app.current_tab == Tab::Layout =>
+        {
+            app.layouts_list_state.select_last();
         }
 
         (InputKeyCode::Enter, ..) => {

--- a/vortex-tui/src/browse/ui/segments.rs
+++ b/vortex-tui/src/browse/ui/segments.rs
@@ -300,7 +300,7 @@ fn to_display_segment_tree(
                 .segments
                 .get_mut(&name)
                 .vortex_expect("Must have segment for name");
-            chunks.sort_by(|a, b| a.spec.offset.cmp(&b.spec.offset));
+            chunks.sort_by_key(|s| s.spec.offset);
 
             // Build leaf nodes for each segment chunk.
             let mut leaves = Vec::with_capacity(chunks.len());

--- a/vortex-tui/src/segments.rs
+++ b/vortex-tui/src/segments.rs
@@ -70,7 +70,7 @@ pub async fn exec_segments(session: &VortexSession, args: SegmentsArgs) -> Vorte
             let mut segments = segment_tree.segments.remove(name)?;
 
             // Sort by byte offset
-            segments.sort_by(|a, b| a.spec.offset.cmp(&b.spec.offset));
+            segments.sort_by_key(|s| s.spec.offset);
 
             // Convert to output format, computing byte gaps
             let mut current_offset = 0u64;

--- a/vortex-tui/src/tree.rs
+++ b/vortex-tui/src/tree.rs
@@ -141,7 +141,7 @@ fn layout_to_json(layout: LayoutRef) -> VortexResult<LayoutTreeNode> {
 
     let children_json: Vec<LayoutTreeNodeWithName> = children
         .into_iter()
-        .zip(child_names.into_iter())
+        .zip(child_names)
         .map(|(child, name)| {
             let node = layout_to_json(child)?;
             Ok(LayoutTreeNodeWithName {

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -385,7 +385,7 @@ fn bench_zstd_decompress_u32(bencher: Bencher) {
 fn bench_dict_compress_string(bencher: Bencher) {
     let varbinview_arr =
         VarBinViewArray::from_iter_str(gen_varbin_words(NUM_VALUES as usize, 0.00005));
-    let nbytes = varbinview_arr.nbytes() as u64;
+    let nbytes = varbinview_arr.nbytes();
     let array = varbinview_arr.into_array();
 
     with_byte_counter(bencher, nbytes)
@@ -402,7 +402,7 @@ fn bench_dict_decompress_string(bencher: Bencher) {
         &mut SESSION.create_execution_ctx(),
     )
     .unwrap();
-    let nbytes = varbinview_arr.into_array().nbytes() as u64;
+    let nbytes = varbinview_arr.into_array().nbytes();
 
     with_byte_counter(bencher, nbytes)
         .with_inputs(|| (&dict, SESSION.create_execution_ctx()))
@@ -415,7 +415,7 @@ fn bench_fsst_compress_string(bencher: Bencher) {
         VarBinViewArray::from_iter_str(gen_varbin_words(NUM_VALUES as usize, 0.00005)).into_array();
     let fsst_compressor =
         fsst_train_compressor(&varbinview_arr, &mut SESSION.create_execution_ctx()).unwrap();
-    let nbytes = varbinview_arr.nbytes() as u64;
+    let nbytes = varbinview_arr.nbytes();
 
     with_byte_counter(bencher, nbytes)
         .with_inputs(|| (&varbinview_arr, SESSION.create_execution_ctx()))
@@ -431,7 +431,7 @@ fn bench_fsst_decompress_string(bencher: Bencher) {
     let fsst_array = fsst_compress(&varbinview_arr, &fsst_compressor, &mut ctx)
         .unwrap()
         .into_array();
-    let nbytes = varbinview_arr.nbytes() as u64;
+    let nbytes = varbinview_arr.nbytes();
 
     with_byte_counter(bencher, nbytes)
         .with_inputs(|| (&fsst_array, SESSION.create_execution_ctx()))
@@ -443,7 +443,7 @@ fn bench_fsst_decompress_string(bencher: Bencher) {
 fn bench_zstd_compress_string(bencher: Bencher) {
     let varbinview_arr =
         VarBinViewArray::from_iter_str(gen_varbin_words(NUM_VALUES as usize, 0.00005)).into_array();
-    let nbytes = varbinview_arr.nbytes() as u64;
+    let nbytes = varbinview_arr.nbytes();
 
     with_byte_counter(bencher, nbytes)
         .with_inputs(|| (&varbinview_arr, SESSION.create_execution_ctx()))
@@ -470,7 +470,7 @@ fn bench_zstd_decompress_string(bencher: Bencher) {
     )
     .unwrap()
     .into_array();
-    let nbytes = varbinview_arr.nbytes() as u64;
+    let nbytes = varbinview_arr.nbytes();
 
     with_byte_counter(bencher, nbytes)
         .with_inputs(|| (&compressed, SESSION.create_execution_ctx()))


### PR DESCRIPTION
## Rationale for this change

~The upcoming Apache DataFusion release includes this requirement. This version is 3 releases behind the latest (as of this writing 1.97.1, with 1.98 being released in about 10 days).~

According to [libs.rs](https://lib.rs/stats), 67% of crates.io requests for the top 4000 crates use this version or newer.~

Started as an upgrade to 1.94, but realized that we'll need 1.95 for the full DF 55 upgrade because of geoarrow.
