### PR TITLE
Random access: drop the reopen (-footer) variant and prepare the Vortex scan once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9711,6 +9711,7 @@ dependencies = [
  "parquet 56.2.1",
  "parquet 58.4.0",
  "rand 0.10.2",
+ "rand_distr 0.6.0",
  "regex",
  "reqwest 0.13.4",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9722,6 +9722,7 @@ dependencies = [
  "sysinfo",
  "tabled",
  "target-lexicon",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/benchmarks/random-access-bench/README.md
+++ b/benchmarks/random-access-bench/README.md
@@ -13,7 +13,9 @@ Two access patterns are generated with a fixed seed (see [`src/main.rs`](./src/m
 Each pattern runs over four datasets (`taxi`, `feature-vectors`, `nested-lists`,
 `nested-structs`) in Parquet, Lance, and Vortex. The file handle is opened once per
 benchmark target and reused, so the timed region covers the lookup against warm file
-metadata. CI drives the full matrix via
+metadata. For Vortex the scan is prepared inside the first timed run and reused by the
+rest, so only that first run pays for expression binding and split computation. CI drives
+the full matrix via
 [`scripts/random-access-split.py`](../../scripts/random-access-split.py).
 
 ## Running locally

--- a/benchmarks/random-access-bench/README.md
+++ b/benchmarks/random-access-bench/README.md
@@ -11,8 +11,9 @@ Two access patterns are generated with a fixed seed (see [`src/main.rs`](./src/m
   simulating lookups with no locality.
 
 Each pattern runs over four datasets (`taxi`, `feature-vectors`, `nested-lists`,
-`nested-structs`) in Parquet, Lance, and Vortex, both with a cached open file handle and
-reopening the file per lookup. CI drives the full matrix via
+`nested-structs`) in Parquet, Lance, and Vortex. The file handle is opened once per
+benchmark target and reused, so the timed region covers the lookup against warm file
+metadata. CI drives the full matrix via
 [`scripts/random-access-split.py`](../../scripts/random-access-split.py).
 
 ## Running locally

--- a/benchmarks/random-access-bench/src/lib.rs
+++ b/benchmarks/random-access-bench/src/lib.rs
@@ -108,34 +108,13 @@ fn generate_indices(dataset: &dyn BenchDataset, pattern: AccessPattern) -> Vec<u
 }
 
 // ---------------------------------------------------------------------------
-// Benchmark configuration
-// ---------------------------------------------------------------------------
-
-/// Controls whether the file handle is reused or reopened each iteration.
-#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
-pub enum OpenMode {
-    /// Reuse the file handle across iterations (cached metadata).
-    #[clap(name = "cached")]
-    Cached,
-    /// Reopen the file each iteration (includes footer parsing).
-    #[clap(name = "reopen")]
-    Reopen,
-    /// Run both cached and reopen variants.
-    #[clap(name = "both")]
-    Both,
-}
-
-// ---------------------------------------------------------------------------
 // Benchmark core
 // ---------------------------------------------------------------------------
 
 /// Run a random access benchmark.
 ///
-/// Runs the take operation repeatedly until the time limit is reached,
-/// collecting timing for each run. When `reopen` is true, the accessor is
-/// recreated from scratch before each iteration so that file metadata
-/// parsing is included in the timing.
-#[expect(clippy::too_many_arguments)]
+/// The accessor is opened once and reused, so the timed region covers the take
+/// itself against warm file metadata.
 async fn benchmark_random_access(
     dataset: &dyn BenchDataset,
     format: Format,
@@ -144,12 +123,11 @@ async fn benchmark_random_access(
     indices: &[u64],
     time_limit_secs: u64,
     storage: &str,
-    reopen: bool,
 ) -> Result<RandomAccessRun> {
     let time_limit = Duration::from_secs(time_limit_secs);
     let overall_start = Instant::now();
     let mut runs = Vec::new();
-    let mut accessor = open_accessor(dataset, format).await?;
+    let accessor = open_accessor(dataset, format).await?;
 
     loop {
         let start = Instant::now();
@@ -159,10 +137,6 @@ async fn benchmark_random_access(
 
         if overall_start.elapsed() >= time_limit {
             break;
-        }
-
-        if reopen {
-            accessor = open_accessor(dataset, format).await?;
         }
     }
 
@@ -176,7 +150,6 @@ async fn benchmark_random_access(
         display_name: display_name(dataset.name(), pattern),
         dataset: dataset.name().to_string(),
         pattern,
-        reopen,
         timing,
     })
 }
@@ -218,10 +191,6 @@ fn v3_random_access_dataset_name(dataset: &str, pattern: Option<AccessPattern>) 
 }
 
 fn push_v3_random_access_record(records: &mut Vec<v3::V3Record>, run: &RandomAccessRun) {
-    if run.reopen {
-        return;
-    }
-
     let dataset = v3_random_access_dataset_name(&run.dataset, run.pattern);
     records.push(v3::random_access_record(&run.timing, &dataset));
 }
@@ -287,8 +256,6 @@ pub struct RunConfig {
     pub patterns: Vec<AccessPattern>,
     /// Maximum duration of each benchmark target in seconds.
     pub time_limit: u64,
-    /// Whether each benchmark run reuses or reopens its file handle.
-    pub open_mode: OpenMode,
     /// Format used to emit measurements.
     pub display_format: DisplayFormat,
     /// Optional path for the primary result output.
@@ -304,23 +271,16 @@ pub async fn run(config: RunConfig) -> Result<()> {
         formats,
         patterns,
         time_limit,
-        open_mode,
         display_format,
         output_path,
         ingest_output,
     } = config;
 
-    let reopen_variants: &[bool] = match open_mode {
-        OpenMode::Cached => &[false],
-        OpenMode::Reopen => &[true],
-        OpenMode::Both => &[false, true],
-    };
-
     let total_steps: usize = datasets
         .iter()
         .map(|d| {
             let legacy_extra = if d.name() == "taxi" { formats.len() } else { 0 };
-            (formats.len() * patterns.len() + legacy_extra) * reopen_variants.len()
+            formats.len() * patterns.len() + legacy_extra
         })
         .sum();
     let progress = ProgressBar::new(total_steps as u64);
@@ -334,55 +294,39 @@ pub async fn run(config: RunConfig) -> Result<()> {
         for format in &formats {
             if dataset.name() == "taxi" {
                 let name = measurement_name(dataset.name(), None, *format);
-                for &reopen in reopen_variants {
-                    let bench_name = if reopen {
-                        format!("{name}-footer")
-                    } else {
-                        name.clone()
-                    };
-                    let run = benchmark_random_access(
-                        dataset.as_ref(),
-                        *format,
-                        &bench_name,
-                        None,
-                        &FIXED_TAXI_INDICES,
-                        time_limit,
-                        STORAGE_NVME,
-                        reopen,
-                    )
-                    .await?;
+                let run = benchmark_random_access(
+                    dataset.as_ref(),
+                    *format,
+                    &name,
+                    None,
+                    &FIXED_TAXI_INDICES,
+                    time_limit,
+                    STORAGE_NVME,
+                )
+                .await?;
 
-                    push_v3_random_access_record(&mut v3_records, &run);
-                    runs.push(run);
-                    progress.inc(1);
-                }
+                push_v3_random_access_record(&mut v3_records, &run);
+                runs.push(run);
+                progress.inc(1);
             }
 
             for pattern in &patterns {
                 let indices = generate_indices(dataset.as_ref(), *pattern);
                 let name = measurement_name(dataset.name(), Some(*pattern), *format);
-                for &reopen in reopen_variants {
-                    let bench_name = if reopen {
-                        format!("{name}-footer")
-                    } else {
-                        name.clone()
-                    };
-                    let run = benchmark_random_access(
-                        dataset.as_ref(),
-                        *format,
-                        &bench_name,
-                        Some(*pattern),
-                        &indices,
-                        time_limit,
-                        STORAGE_NVME,
-                        reopen,
-                    )
-                    .await?;
+                let run = benchmark_random_access(
+                    dataset.as_ref(),
+                    *format,
+                    &name,
+                    Some(*pattern),
+                    &indices,
+                    time_limit,
+                    STORAGE_NVME,
+                )
+                .await?;
 
-                    push_v3_random_access_record(&mut v3_records, &run);
-                    runs.push(run);
-                    progress.inc(1);
-                }
+                push_v3_random_access_record(&mut v3_records, &run);
+                runs.push(run);
+                progress.inc(1);
             }
         }
     }
@@ -397,7 +341,7 @@ pub async fn run(config: RunConfig) -> Result<()> {
 
     match display_format {
         DisplayFormat::Table => {
-            render_random_access_table(&mut writer, &runs, &formats, reopen_variants)?;
+            render_random_access_table(&mut writer, &runs, &formats)?;
         }
         DisplayFormat::GhJson => {
             let timings: Vec<TimingMeasurement> = runs.into_iter().map(|r| r.timing).collect();
@@ -425,7 +369,7 @@ mod tests {
         );
     }
 
-    fn fake_run(dataset: &str, pattern: Option<AccessPattern>, reopen: bool) -> RandomAccessRun {
+    fn fake_run(dataset: &str, pattern: Option<AccessPattern>) -> RandomAccessRun {
         RandomAccessRun {
             timing: TimingMeasurement {
                 name: format!("random-access/{dataset}/parquet-tokio-local-disk"),
@@ -435,23 +379,18 @@ mod tests {
             },
             dataset: dataset.to_string(),
             pattern,
-            reopen,
             display_name: display_name(dataset, pattern),
         }
     }
 
     #[test]
-    fn v3_random_access_records_skip_reopen_variants() {
+    fn v3_random_access_records_carry_pattern_qualified_datasets() {
         let mut records = Vec::new();
 
-        push_v3_random_access_record(&mut records, &fake_run("taxi", None, false));
+        push_v3_random_access_record(&mut records, &fake_run("taxi", None));
         push_v3_random_access_record(
             &mut records,
-            &fake_run("taxi", Some(AccessPattern::Uniform), false),
-        );
-        push_v3_random_access_record(
-            &mut records,
-            &fake_run("taxi", Some(AccessPattern::Correlated), true),
+            &fake_run("taxi", Some(AccessPattern::Uniform)),
         );
 
         assert_eq!(records.len(), 2);

--- a/benchmarks/random-access-bench/src/lib.rs
+++ b/benchmarks/random-access-bench/src/lib.rs
@@ -114,7 +114,9 @@ fn generate_indices(dataset: &dyn BenchDataset, pattern: AccessPattern) -> Vec<u
 /// Run a random access benchmark.
 ///
 /// The accessor is opened once and reused, so the timed region covers the take
-/// itself against warm file metadata.
+/// itself against warm file metadata. Since the indices are fixed for the whole
+/// loop, the Vortex accessor prepares its scan during the first timed run and
+/// reuses it thereafter; that first run is the only one to include preparation.
 async fn benchmark_random_access(
     dataset: &dyn BenchDataset,
     format: Format,

--- a/benchmarks/random-access-bench/src/main.rs
+++ b/benchmarks/random-access-bench/src/main.rs
@@ -7,7 +7,6 @@ use anyhow::Result;
 use clap::Parser;
 use clap::ValueEnum;
 use random_access_bench::AccessPattern;
-use random_access_bench::OpenMode;
 use random_access_bench::RunConfig;
 use vortex_bench::Format;
 use vortex_bench::datasets::feature_vectors::FeatureVectorsData;
@@ -82,9 +81,6 @@ struct Args {
         default_values_t = vec![AccessPattern::Correlated, AccessPattern::Uniform]
     )]
     patterns: Vec<AccessPattern>,
-    /// Whether to reopen the file on each iteration, use a cached handle, or run both.
-    #[arg(long, value_enum, default_value_t = OpenMode::Both)]
-    open_mode: OpenMode,
 }
 
 #[tokio::main]
@@ -101,7 +97,6 @@ async fn main() -> Result<()> {
         formats: args.formats,
         patterns: args.patterns,
         time_limit: args.time_limit,
-        open_mode: args.open_mode,
         display_format: args.display_format,
         output_path: args.output_path,
         ingest_output: args.ingest_output,

--- a/benchmarks/random-access-bench/src/render.rs
+++ b/benchmarks/random-access-bench/src/render.rs
@@ -3,16 +3,13 @@
 
 //! Custom console-table rendering for random-access benchmark results.
 //!
-//! Random-access has two extra dimensions beyond what the shared
-//! [`vortex_bench::display::render_table`] handles: the access pattern (which
-//! we keep on the row) and the open mode (cached vs reopen), which becomes a
-//! second-level column header inlined into the format label (e.g.
-//! `parquet-cached`, `parquet-reopen`). Rather than push those concerns into
-//! the shared renderer, we keep this layout local.
+//! Random-access has one extra dimension beyond what the shared
+//! [`vortex_bench::display::render_table`] handles: the access pattern, which
+//! we keep on the row. Rather than push that concern into the shared renderer,
+//! we keep this layout local.
 //!
 //! Rows are keyed by `(dataset, Option<AccessPattern>)` in the order they are
-//! first observed in `runs`; columns are the cartesian product of `formats`
-//! and `reopen_variants`.
+//! first observed in `runs`; columns are the `formats`.
 
 use std::io::Write;
 
@@ -28,13 +25,12 @@ use vortex_bench::utils::aliases::hash_map::HashMap;
 use crate::AccessPattern;
 
 /// One row of random-access timing for a `(dataset, pattern)` benchmark and a
-/// specific `(format, reopen)` combination. Carries the same
-/// [`TimingMeasurement`] used for JSON output so the two emitters stay in sync.
+/// specific format. Carries the same [`TimingMeasurement`] used for JSON output
+/// so the two emitters stay in sync.
 pub struct RandomAccessRun {
     pub timing: TimingMeasurement,
     pub dataset: String,
     pub pattern: Option<AccessPattern>,
-    pub reopen: bool,
     /// Row label for this run (e.g. `random-access/taxi/uniform`). Format is
     /// implied by the column header, so it is not part of the label.
     pub display_name: String,
@@ -42,29 +38,22 @@ pub struct RandomAccessRun {
 
 /// Render a random-access benchmark result table.
 ///
-/// Columns are `formats × reopen_variants` with `{format-ext}-{open-mode}`
-/// headers (e.g. `vortex-cached`, `parquet-reopen`). Rows are unique
-/// `(dataset, pattern)` pairs in the order they were observed in `runs`.
+/// Columns are the `formats`, headed by `{format-ext}` (e.g. `vortex`,
+/// `parquet`). Rows are unique `(dataset, pattern)` pairs in the order they
+/// were observed in `runs`.
 ///
-/// The first column (the baseline) is the leftmost format / cached variant;
-/// each non-baseline cell is colored relative to the baseline value in its
-/// row.
+/// The first column (the baseline) is the leftmost format; each non-baseline
+/// cell is colored relative to the baseline value in its row.
 pub fn render_random_access_table<W: Write>(
     writer: &mut W,
     runs: &[RandomAccessRun],
     formats: &[Format],
-    reopen_variants: &[bool],
 ) -> Result<()> {
-    // Columns: cartesian product of (format, reopen) in the user-supplied
-    // ordering. Storing the cell key alongside its display label keeps the
-    // lookup loop straightforward.
-    let columns: Vec<(Format, bool, String)> = formats
+    // Storing the cell key alongside its display label keeps the lookup loop
+    // straightforward.
+    let columns: Vec<(Format, String)> = formats
         .iter()
-        .flat_map(|format| {
-            reopen_variants
-                .iter()
-                .map(move |&reopen| (*format, reopen, column_label(*format, reopen)))
-        })
+        .map(|format| (*format, column_label(*format)))
         .collect();
 
     // Rows: unique (dataset, pattern) keys in insertion order. Insertion
@@ -72,7 +61,7 @@ pub fn render_random_access_table<W: Write>(
     // rows appear before pattern rows.
     let mut rows: Vec<(String, Option<AccessPattern>, String)> = Vec::new();
     let mut row_index: HashMap<(String, Option<AccessPattern>), usize> = HashMap::new();
-    let mut cells: HashMap<(usize, Format, bool), u128> = HashMap::new();
+    let mut cells: HashMap<(usize, Format), u128> = HashMap::new();
 
     for run in runs {
         let key = (run.dataset.clone(), run.pattern);
@@ -86,34 +75,29 @@ pub fn render_random_access_table<W: Write>(
             }
         };
         let format = run.timing.target.format;
-        cells.insert(
-            (idx, format, run.reopen),
-            run.timing.median_time().as_micros(),
-        );
+        cells.insert((idx, format), run.timing.median_time().as_micros());
     }
 
     let mut table_builder = Builder::default();
 
-    // Single header row: `Benchmark | format-mode | format-mode | ...`.
+    // Single header row: `Benchmark | format | format | ...`.
     let header: Vec<String> = std::iter::once("Benchmark".to_owned())
-        .chain(columns.iter().map(|(_, _, label)| label.clone()))
+        .chain(columns.iter().map(|(_, label)| label.clone()))
         .collect();
     table_builder.push_record(header);
 
     // Baseline for each row is the leftmost column. We capture it before
     // emitting the row so non-baseline cells can be colored relative to it.
-    let baseline_column = columns
-        .first()
-        .map(|(format, reopen, _)| (*format, *reopen));
+    let baseline_column = columns.first().map(|(format, _)| *format);
 
     let mut colors = Vec::new();
     for (row_idx, (_, _, label)) in rows.iter().enumerate() {
-        let baseline_value = baseline_column
-            .and_then(|(format, reopen)| cells.get(&(row_idx, format, reopen)).copied());
+        let baseline_value =
+            baseline_column.and_then(|format| cells.get(&(row_idx, format)).copied());
 
         let mut record = vec![label.clone()];
-        for (col_idx, (format, reopen, _)) in columns.iter().enumerate() {
-            let value = cells.get(&(row_idx, *format, *reopen)).copied();
+        for (col_idx, (format, _)) in columns.iter().enumerate() {
+            let value = cells.get(&(row_idx, *format)).copied();
             record.push(match (value, baseline_value) {
                 (Some(v), Some(base)) if base > 0 => {
                     let ratio = v as f64 / base as f64;
@@ -142,12 +126,10 @@ pub fn render_random_access_table<W: Write>(
     Ok(())
 }
 
-/// `{format-ext}-{mode}` (e.g. `vortex-cached`, `parquet-reopen`). Using
-/// `Format::ext()` keeps headers narrow (`vortex` rather than
-/// `vortex-file-compressed`).
-fn column_label(format: Format, reopen: bool) -> String {
-    let mode = if reopen { "reopen" } else { "cached" };
-    format!("{}-{}", format.ext(), mode)
+/// `{format-ext}` (e.g. `vortex`, `parquet`). Using `Format::ext()` keeps
+/// headers narrow (`vortex` rather than `vortex-file-compressed`).
+fn column_label(format: Format) -> String {
+    format.ext().to_string()
 }
 
 /// Mirror of the coloring used by `vortex_bench::display::render_table`:
@@ -192,7 +174,6 @@ mod tests {
         dataset: &str,
         pattern: Option<AccessPattern>,
         format: Format,
-        reopen: bool,
         micros: u64,
     ) -> RandomAccessRun {
         RandomAccessRun {
@@ -204,7 +185,6 @@ mod tests {
             },
             dataset: dataset.to_string(),
             pattern,
-            reopen,
             display_name: match pattern {
                 Some(p) => format!("random-access/{dataset}/{}", p.name()),
                 None => format!("random-access/{dataset}"),
@@ -213,64 +193,31 @@ mod tests {
     }
 
     #[test]
-    fn column_label_uses_format_ext_and_mode() {
-        assert_eq!(column_label(Format::Parquet, false), "parquet-cached");
-        assert_eq!(column_label(Format::Parquet, true), "parquet-reopen");
-        assert_eq!(column_label(Format::OnDiskVortex, false), "vortex-cached");
+    fn column_label_uses_format_ext() {
+        assert_eq!(column_label(Format::Parquet), "parquet");
+        assert_eq!(column_label(Format::OnDiskVortex), "vortex");
     }
 
     #[test]
-    fn render_emits_single_header_row_with_format_mode_columns() -> Result<()> {
+    fn render_emits_single_header_row_with_format_columns() -> Result<()> {
         let runs = vec![
-            run("taxi", None, Format::Parquet, false, 100),
-            run("taxi", None, Format::Parquet, true, 200),
-            run("taxi", None, Format::OnDiskVortex, false, 50),
-            run("taxi", None, Format::OnDiskVortex, true, 110),
-            run(
-                "taxi",
-                Some(AccessPattern::Uniform),
-                Format::Parquet,
-                false,
-                300,
-            ),
-            run(
-                "taxi",
-                Some(AccessPattern::Uniform),
-                Format::Parquet,
-                true,
-                600,
-            ),
+            run("taxi", None, Format::Parquet, 100),
+            run("taxi", None, Format::OnDiskVortex, 50),
+            run("taxi", Some(AccessPattern::Uniform), Format::Parquet, 300),
             run(
                 "taxi",
                 Some(AccessPattern::Uniform),
                 Format::OnDiskVortex,
-                false,
                 150,
-            ),
-            run(
-                "taxi",
-                Some(AccessPattern::Uniform),
-                Format::OnDiskVortex,
-                true,
-                330,
             ),
         ];
 
         let mut buf = Vec::new();
-        render_random_access_table(
-            &mut buf,
-            &runs,
-            &[Format::Parquet, Format::OnDiskVortex],
-            &[false, true],
-        )?;
+        render_random_access_table(&mut buf, &runs, &[Format::Parquet, Format::OnDiskVortex])?;
         let rendered = strip_ansi(&String::from_utf8(buf)?);
 
         assert!(
-            rendered.contains("parquet-cached") && rendered.contains("parquet-reopen"),
-            "expected format-mode column headers, got:\n{rendered}"
-        );
-        assert!(
-            rendered.contains("vortex-cached") && rendered.contains("vortex-reopen"),
+            rendered.contains("parquet") && rendered.contains("vortex"),
             "expected ext-based column headers, got:\n{rendered}"
         );
         assert!(
@@ -283,14 +230,12 @@ mod tests {
 
     #[test]
     fn render_renders_dash_for_missing_cells() -> Result<()> {
-        let runs = vec![
-            run("taxi", None, Format::Parquet, false, 100),
-            // No reopen variant supplied for taxi, but the column is still
-            // listed in `reopen_variants` — that cell should render as `-`.
-        ];
+        // No vortex run supplied, but the column is still listed in `formats`
+        // — that cell should render as `-`.
+        let runs = vec![run("taxi", None, Format::Parquet, 100)];
 
         let mut buf = Vec::new();
-        render_random_access_table(&mut buf, &runs, &[Format::Parquet], &[false, true])?;
+        render_random_access_table(&mut buf, &runs, &[Format::Parquet, Format::OnDiskVortex])?;
         let rendered = strip_ansi(&String::from_utf8(buf)?);
 
         assert!(

--- a/scripts/random-access-split.py
+++ b/scripts/random-access-split.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 """
-Run random-access-bench once per (dataset, format, pattern, open-mode)
+Run random-access-bench once per (dataset, format, pattern)
 then merge the per-combination outputs
 """
 
@@ -20,7 +20,6 @@ PARTS_DIR = Path("parts")
 DATASETS = ["taxi", "feature-vectors", "nested-lists", "nested-structs"]
 FORMATS = ["parquet", "lance", "vortex"]
 PATTERNS = ["correlated", "uniform"]
-OPEN_MODES = ["cached", "reopen"]
 
 
 def run_combinations(emit_ingest_records: bool) -> None:
@@ -29,29 +28,26 @@ def run_combinations(emit_ingest_records: bool) -> None:
     for dataset in DATASETS:
         for fmt in FORMATS:
             for pattern in PATTERNS:
-                for open_mode in OPEN_MODES:
-                    args = [
-                        "bash",
-                        str(SCRIPT_DIR / "bench-taskset.sh"),
-                        BINARY,
-                        "--datasets",
-                        dataset,
-                        "--formats",
-                        fmt,
-                        "--patterns",
-                        pattern,
-                        "--open-mode",
-                        open_mode,
-                        "-d",
-                        "gh-json",
-                        "-o",
-                        str(PARTS_DIR / f"{i}.gh.json"),
-                    ]
-                    if emit_ingest_records:
-                        args += ["--ingest-jsonl", str(PARTS_DIR / f"{i}.ingest.jsonl")]
-                    print("+", " ".join(args), flush=True)
-                    subprocess.run(args, check=True)
-                    i += 1
+                args = [
+                    "bash",
+                    str(SCRIPT_DIR / "bench-taskset.sh"),
+                    BINARY,
+                    "--datasets",
+                    dataset,
+                    "--formats",
+                    fmt,
+                    "--patterns",
+                    pattern,
+                    "-d",
+                    "gh-json",
+                    "-o",
+                    str(PARTS_DIR / f"{i}.gh.json"),
+                ]
+                if emit_ingest_records:
+                    args += ["--ingest-jsonl", str(PARTS_DIR / f"{i}.ingest.jsonl")]
+                print("+", " ".join(args), flush=True)
+                subprocess.run(args, check=True)
+                i += 1
 
 
 """

--- a/vortex-bench/Cargo.toml
+++ b/vortex-bench/Cargo.toml
@@ -84,6 +84,7 @@ wkb = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 rstest = { workspace = true }
+tempfile = { workspace = true }
 
 [features]
 unstable_encodings = ["vortex/unstable_encodings"]

--- a/vortex-bench/Cargo.toml
+++ b/vortex-bench/Cargo.toml
@@ -54,6 +54,7 @@ noodles-vcf = { workspace = true, features = ["async"] }
 parking_lot = { workspace = true }
 parquet = { workspace = true, features = ["async"] }
 rand = { workspace = true }
+rand_distr = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream"] }
 serde = { workspace = true, features = ["derive"] }

--- a/vortex-bench/examples/take_phases.rs
+++ b/vortex-bench/examples/take_phases.rs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Decompose a random-access take into its phases to see where the time goes.
+
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::time::Duration;
+use std::time::Instant;
+
+use rand::RngExt;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand_distr::Distribution;
+use rand_distr::Exp;
+use vortex::array::stream::ArrayStreamExt;
+use vortex::buffer::Buffer;
+use vortex::file::OpenOptionsSessionExt;
+use vortex::scan::strict_sorted_buffer::StrictSortedBuffer;
+use vortex_bench::SESSION;
+
+const NUM_CLUSTERS: usize = 5;
+const CLUSTER_SIZE: usize = 20;
+const POISSON_EXPECTED_COUNT: usize = 100;
+
+fn correlated(row_count: u64) -> Vec<u64> {
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut indices = Vec::with_capacity(NUM_CLUSTERS * CLUSTER_SIZE);
+    for _ in 0..NUM_CLUSTERS {
+        let start = rng.random_range(0..row_count.saturating_sub(CLUSTER_SIZE as u64));
+        for offset in 0..CLUSTER_SIZE as u64 {
+            indices.push(start + offset);
+        }
+    }
+    indices.sort_unstable();
+    indices
+}
+
+fn uniform(row_count: u64) -> anyhow::Result<Vec<u64>> {
+    let mut rng = StdRng::seed_from_u64(42);
+    let rate = POISSON_EXPECTED_COUNT as f64 / row_count as f64;
+    let exp = Exp::new(rate)?;
+    let mut indices = Vec::with_capacity(POISSON_EXPECTED_COUNT);
+    let mut pos = 0.0_f64;
+    loop {
+        let gap: f64 = exp.sample(&mut rng);
+        pos += gap;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "positions below row_count fit in u64"
+        )]
+        let idx = pos as u64;
+        if idx >= row_count {
+            break;
+        }
+        indices.push(idx);
+    }
+    Ok(indices)
+}
+
+fn median(mut v: Vec<Duration>) -> Duration {
+    v.sort_unstable();
+    v[v.len() / 2]
+}
+
+/// Read syscalls issued by this process so far.
+fn syscr() -> u64 {
+    std::fs::read_to_string("/proc/self/io")
+        .ok()
+        .and_then(|s| {
+            s.lines()
+                .find_map(|l| l.strip_prefix("syscr: ").map(|v| v.trim().parse().ok()))
+        })
+        .flatten()
+        .unwrap_or(0)
+}
+
+/// Bytes this process has pulled through read syscalls so far.
+fn rchar() -> u64 {
+    std::fs::read_to_string("/proc/self/io")
+        .ok()
+        .and_then(|s| {
+            s.lines()
+                .find_map(|l| l.strip_prefix("rchar: ").map(|v| v.trim().parse().ok()))
+        })
+        .flatten()
+        .unwrap_or(0)
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let (Some(path), Some(pattern)) = (args.get(1), args.get(2)) else {
+        anyhow::bail!("usage: take_phases <file.vortex> <correlated|uniform> [reps] [max-indices]")
+    };
+    let path = PathBuf::from(path);
+    let reps: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(20);
+
+    let file = SESSION
+        .open_options()
+        .with_layout_reader_cache()
+        .open_path(path.as_path())
+        .await?;
+    let row_count = file.row_count();
+
+    let mut indices = match pattern.as_str() {
+        "correlated" => correlated(row_count),
+        _ => uniform(row_count)?,
+    };
+    // Optional 5th arg: keep only the first N indices, to see how cost scales with index count.
+    if let Some(n) = args.get(4).and_then(|s| s.parse::<usize>().ok()) {
+        indices.truncate(n);
+    }
+    let indices_len = indices.len();
+
+    // Phase timings, per repetition.
+    let mut t_scan = Vec::new(); // file.scan() -- ScanBuilder construction
+    let mut t_rowidx = Vec::new(); // with_row_indices(StrictSortedBuffer)
+    let mut t_prepare = Vec::new(); // ScanBuilder::prepare()
+    let mut t_stream = Vec::new(); // RepeatedScan::execute_array_stream (task construction)
+    let mut t_read = Vec::new(); // read_all() -- IO + decode
+    let mut t_total = Vec::new();
+    let mut n_tasks = 0usize;
+    let mut io_bytes: Vec<u64> = Vec::new();
+    let mut io_calls: Vec<u64> = Vec::new();
+
+    for _ in 0..reps {
+        let total = Instant::now();
+
+        let s = Instant::now();
+        let builder = file.scan()?;
+        t_scan.push(s.elapsed());
+
+        let s = Instant::now();
+        let indices_buf: Buffer<u64> = Buffer::from(indices.clone());
+        let builder = builder.with_row_indices(StrictSortedBuffer::try_new(indices_buf)?);
+        t_rowidx.push(s.elapsed());
+
+        let s = Instant::now();
+        let prepared = builder.prepare()?;
+        t_prepare.push(s.elapsed());
+
+        n_tasks = prepared.execute(None)?.len();
+
+        let s = Instant::now();
+        let stream = prepared.execute_array_stream(None)?;
+        t_stream.push(s.elapsed());
+
+        let io_before = rchar();
+        let calls_before = syscr();
+        let s = Instant::now();
+        let array = stream.read_all().await?;
+        t_read.push(s.elapsed());
+        io_bytes.push(rchar() - io_before);
+        io_calls.push(syscr() - calls_before);
+
+        t_total.push(total.elapsed());
+        black_box(array);
+    }
+
+    let name = path.file_name().map_or_else(
+        || path.display().to_string(),
+        |n| n.to_string_lossy().into_owned(),
+    );
+    println!("== {name} / {pattern} ==");
+    println!("  rows in file : {row_count}");
+    println!("  indices      : {indices_len}");
+    println!("  split tasks  : {n_tasks}");
+    io_bytes.sort_unstable();
+    let med_io = io_bytes[io_bytes.len() / 2];
+    println!(
+        "  read syscalls: {:.2} MiB per take  ({:.0} bytes per row returned)",
+        med_io as f64 / (1024.0 * 1024.0),
+        med_io as f64 / indices_len as f64
+    );
+    io_calls.sort_unstable();
+    let med_calls = io_calls[io_calls.len() / 2];
+    println!(
+        "  read calls   : {med_calls} per take  ({:.1} KiB average read size)",
+        med_io as f64 / med_calls.max(1) as f64 / 1024.0
+    );
+    let m_total = median(t_total.clone());
+    let phase = |label: &str, v: Vec<Duration>| {
+        let m = median(v);
+        println!(
+            "  {label:<24} {:>9.1} us  ({:>5.2}% of take)",
+            m.as_secs_f64() * 1e6,
+            100.0 * m.as_secs_f64() / m_total.as_secs_f64()
+        );
+    };
+    phase("file.scan()", t_scan);
+    phase("with_row_indices()", t_rowidx);
+    phase("prepare()", t_prepare);
+    phase("execute_array_stream()", t_stream);
+    phase("read_all()", t_read);
+    println!("  {:<24} {:>9.1} us", "TOTAL", m_total.as_secs_f64() * 1e6);
+
+    Ok(())
+}

--- a/vortex-bench/src/random_access/take.rs
+++ b/vortex-bench/src/random_access/take.rs
@@ -12,12 +12,14 @@ use arrow_select::take::take_record_batch;
 use async_trait::async_trait;
 use futures::stream;
 use itertools::Itertools;
+use parking_lot::Mutex;
 use parquet::arrow::ParquetRecordBatchStreamBuilder;
 use parquet::arrow::arrow_reader::ArrowReaderMetadata;
 use parquet::arrow::arrow_reader::ArrowReaderOptions;
 use parquet::file::metadata::PageIndexPolicy;
 use stream::StreamExt;
 use tokio::fs::File;
+use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::IntoArray;
 use vortex::array::VortexSessionExecute;
@@ -25,6 +27,7 @@ use vortex::array::stream::ArrayStreamExt;
 use vortex::buffer::Buffer;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexFile;
+use vortex::layout::scan::repeated_scan::RepeatedScan;
 use vortex::scan::strict_sorted_buffer::StrictSortedBuffer;
 use vortex::utils::aliases::hash_map::HashMap;
 
@@ -33,13 +36,25 @@ use crate::SESSION;
 use crate::random_access::RandomAccessor;
 use crate::random_access::RandomAccessorRet;
 
+/// A scan prepared for a fixed set of row indices.
+struct PreparedTake {
+    indices: Arc<[u64]>,
+    scan: Arc<RepeatedScan<ArrayRef>>,
+}
+
 /// Random accessor for Vortex format files.
 ///
-/// The file handle is opened at construction time and reused across `take()` calls.
+/// The file handle is opened at construction time and reused across `take()` calls, as is the
+/// [`RepeatedScan`] prepared by the first `take()`.
 pub struct VortexRandomAccessor {
     name: String,
     format: Format,
     file: VortexFile,
+    /// Scan prepared by the first `take()` and reused while the indices are unchanged.
+    ///
+    /// A prepared scan pins its selection, and with row indices the split ranges are derived
+    /// from that selection, so a new index set requires preparing again.
+    prepared: Mutex<Option<PreparedTake>>,
 }
 
 impl VortexRandomAccessor {
@@ -58,7 +73,33 @@ impl VortexRandomAccessor {
             name: name.into(),
             format,
             file,
+            prepared: Mutex::new(None),
         })
+    }
+
+    /// Return the prepared scan for `indices`, preparing one if the cache does not hold it.
+    fn prepared_scan(&self, indices: &[u64]) -> anyhow::Result<Arc<RepeatedScan<ArrayRef>>> {
+        let mut prepared = self.prepared.lock();
+
+        if let Some(prepared) = prepared.as_ref()
+            && prepared.indices.as_ref() == indices
+        {
+            return Ok(Arc::clone(&prepared.scan));
+        }
+
+        let indices_buf: Buffer<u64> = Buffer::from(indices.to_vec());
+        let scan = Arc::new(
+            self.file
+                .scan()?
+                .with_row_indices(StrictSortedBuffer::try_new(indices_buf)?)
+                .prepare()?,
+        );
+        *prepared = Some(PreparedTake {
+            indices: Arc::from(indices),
+            scan: Arc::clone(&scan),
+        });
+
+        Ok(scan)
     }
 }
 
@@ -73,12 +114,9 @@ impl RandomAccessor for VortexRandomAccessor {
     }
 
     async fn take(&self, indices: &[u64]) -> anyhow::Result<RandomAccessorRet> {
-        let indices_buf: Buffer<u64> = Buffer::from(indices.to_vec());
         let array = self
-            .file
-            .scan()?
-            .with_row_indices(StrictSortedBuffer::try_new(indices_buf)?)
-            .into_array_stream()?
+            .prepared_scan(indices)?
+            .execute_array_stream(None)?
             .read_all()
             .await?;
 
@@ -188,5 +226,92 @@ impl RandomAccessor for ParquetRandomAccessor {
 
         let result = concat_batches(&schema, &batches)?;
         Ok(RandomAccessorRet::RecordBatch(result))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex::array::IntoArray as _;
+    use vortex::array::arrays::PrimitiveArray;
+    use vortex::array::stream::ArrayStreamAdapter;
+    use vortex::file::WriteOptionsSessionExt;
+
+    use super::*;
+
+    /// Write `0..count` as a single-column Vortex file and return its path.
+    async fn write_vortex_file(dir: &tempfile::TempDir, count: i32) -> anyhow::Result<PathBuf> {
+        let array = Buffer::from((0..count).collect::<Vec<i32>>()).into_array();
+        let mut buf = Vec::new();
+        SESSION
+            .write_options()
+            .write(
+                &mut buf,
+                ArrayStreamAdapter::new(array.dtype().clone(), stream::iter([Ok(array)])),
+            )
+            .await?;
+
+        let path = dir.path().join("data.vortex");
+        std::fs::write(&path, buf)?;
+        Ok(path)
+    }
+
+    async fn take_values(
+        accessor: &VortexRandomAccessor,
+        indices: &[u64],
+    ) -> anyhow::Result<Vec<i32>> {
+        let RandomAccessorRet::ArrayRef(array) = accessor.take(indices).await? else {
+            anyhow::bail!("expected an ArrayRef from the Vortex accessor")
+        };
+        let mut ctx = SESSION.create_execution_ctx();
+        let primitive = array.execute::<PrimitiveArray>(&mut ctx)?;
+        Ok(primitive.as_slice::<i32>().to_vec())
+    }
+
+    #[tokio::test]
+    async fn prepared_scan_is_reused_for_repeated_indices() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = write_vortex_file(&dir, 1_000).await?;
+        let accessor = VortexRandomAccessor::open(&path, "test", Format::OnDiskVortex).await?;
+
+        let indices = [3u64, 7, 42];
+        let first = accessor.prepared_scan(&indices)?;
+        let second = accessor.prepared_scan(&indices)?;
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "repeated takes must reuse the prepared scan"
+        );
+
+        // The reused scan must keep returning the rows it was prepared for.
+        assert_eq!(take_values(&accessor, &indices).await?, vec![3, 7, 42]);
+        assert_eq!(take_values(&accessor, &indices).await?, vec![3, 7, 42]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn changed_indices_prepare_a_new_scan() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = write_vortex_file(&dir, 1_000).await?;
+        let accessor = VortexRandomAccessor::open(&path, "test", Format::OnDiskVortex).await?;
+
+        let first = accessor.prepared_scan(&[3u64, 7, 42])?;
+        let second = accessor.prepared_scan(&[4u64, 8, 43])?;
+        assert!(
+            !Arc::ptr_eq(&first, &second),
+            "a new index set must prepare a new scan"
+        );
+
+        // A prepared scan pins its selection, so the second index set must not
+        // return the rows cached for the first.
+        assert_eq!(
+            take_values(&accessor, &[4u64, 8, 43]).await?,
+            vec![4, 8, 43]
+        );
+        assert_eq!(
+            take_values(&accessor, &[3u64, 7, 42]).await?,
+            vec![3, 7, 42]
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Rationale for this change

Two changes to the random-access benchmark, both about what the timed region actually contains.

**1. The reopen (`-footer`) variant measured something other than its name.**

The benchmark ran every target twice: once with a cached accessor and once reopening it between
iterations, emitting the latter under a `-footer` measurement name.

The `-footer` name and the doc comment on `benchmark_random_access` both claimed the reopen
variant included file metadata parsing in the timing. It did not — the re-open happened after
`runs.push(start.elapsed())`, so only the take itself was ever timed. What the variant actually
measured was a take against cold in-process caches, which is not what its name advertised.

Those rows were also excluded from the v3 ingest records (`push_v3_random_access_record`
returned early on `run.reopen`), so nothing downstream consumed them: the benchmarks website
only ever plotted the cached numbers. The variant cost half the suite&#39;s CI wall clock to
produce a mislabelled column in the PR comment.

**2. The Vortex take re-prepared its scan on every iteration.**

`VortexRandomAccessor::take` built a fresh `ScanBuilder` per call, so each timed iteration
re-paid `prepare()` — dtype resolution, projection binding, the `RowIdx` reader-enrichment
check, and split computation. Only the `VortexFile` handle and its layout reader cache were
reused. The loop takes the same indices throughout a measurement, so the scan can be prepared
once and reused.

## What changes are included in this PR?

Removing the reopen variant:

- Drop `OpenMode`, the `--open-mode` flag, and the `reopen` plumbing through
  `benchmark_random_access` / `RandomAccessRun`. The accessor is opened once and reused, so the
  timed region covers the take against warm file metadata — which is what the surviving numbers
  always were.
- `push_v3_random_access_record` no longer needs its reopen guard and emits unconditionally.
- The table renderer&#39;s columns are now plain formats (`parquet`, `vortex`, `lance`) rather than
  `{format}-{open-mode}` pairs.
- `scripts/random-access-split.py` loses the open-mode axis: 48 → 24 invocations per run.

Preparing the scan once:

- `take` now goes through `prepared_scan`, which prepares a `RepeatedScan` on first use and
  returns the cached one thereafter. The first timed run still pays preparation; the rest
  measure the take alone.
- The cache is keyed on the indices. A prepared scan pins its selection, and with row indices
  the split ranges are derived from that selection (`ScanBuilder::prepare` takes the
  `Splits::Ranges` branch), so a new index set must prepare again — reusing the previous scan
  would silently return the wrong rows. Two tests cover this: one asserts the prepared scan is
  reused across repeated takes, the other that a changed index set prepares a new scan and
  returns the newly requested rows.
- README and the `benchmark_random_access` doc comment updated to describe both behaviours.

## Effect on baseline continuity

Measurement names are unchanged throughout, so every surviving row still pairs with its S3
baseline counterpart and the Postgres ingest keeps its series. Only the `…-footer` rows
disappear from `results.json`.

One caveat worth flagging for whoever reads the next comparison: change 2 moves scan
preparation out of every iteration after the first, so **a step change in the Vortex numbers at
this commit is expected and is not a runtime improvement**. The rows measure a slightly
different thing from here on.

## What APIs are changed? Are there any user-facing changes?

No library API changes. The `random-access-bench` binary loses its `--open-mode` flag, and the
`…-tokio-local-disk-footer` measurements stop being emitted.

## Checks run locally

- `cargo test -p vortex-bench` — 60 passed (including the 2 new prepared-scan tests)
- `cargo test -p random-access-bench` — 6 passed
- `cargo clippy -p vortex-bench -p random-access-bench --all-targets` — clean
- `cargo +nightly fmt --all` — no diff
- `ruff check` and `python3 -m py_compile` on `scripts/random-access-split.py`
- Ran the rebuilt binary (with and without `--features lance`) in both `table` and `gh-json`
  modes to confirm the new column layout and the unchanged measurement names.

I verified the new tests fail without the fix: dropping the index comparison from the cache
lookup makes `changed_indices_prepare_a_new_scan` fail.

`cargo nextest` is not installed in my environment, so the crate tests ran under `cargo test`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0145v7rv6d87FGLPvNxSfUAH)_