### PR TITLE
Run SQL benchmarks with plan v2

### DIFF
--- a/.github/workflows/sql-bench-matrix.yml
+++ b/.github/workflows/sql-bench-matrix.yml
@@ -103,6 +103,8 @@ jobs:
     env:
       VORTEX_EXPERIMENTAL_PATCHED_ARRAY: "1"
       FLAT_LAYOUT_INLINE_ARRAY_NODE: "1"
+      VORTEX_USE_PLAN_V2: "1"
+      DATAFUSION_OPTIMIZER_REPARTITION_FILE_SCANS: "false"
       # Makes python output nicer
       COLUMNS: 120
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10561,6 +10561,7 @@ dependencies = [
 name = "vortex-scan-v2"
 version = "0.1.0"
 dependencies = [
+ "bit-vec",
  "futures",
  "itertools 0.14.0",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9990,6 +9990,7 @@ dependencies = [
  "url",
  "vortex",
  "vortex-arrow",
+ "vortex-scan-v2",
  "vortex-utils",
 ]
 

--- a/vortex-datafusion/Cargo.toml
+++ b/vortex-datafusion/Cargo.toml
@@ -38,6 +38,7 @@ tokio-stream = { workspace = true }
 tracing = { workspace = true, features = ["std", "attributes"] }
 vortex = { workspace = true, features = ["object_store", "tokio", "files"] }
 vortex-arrow = { workspace = true }
+vortex-scan-v2 = { workspace = true }
 vortex-utils = { workspace = true, features = ["dashmap"] }
 
 [dev-dependencies]

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -54,6 +54,7 @@ use vortex::metrics::Label;
 use vortex::metrics::MetricsRegistry;
 use vortex::session::VortexSession;
 use vortex_arrow::ArrowSessionExt;
+use vortex_scan_v2::FilterMode;
 use vortex_scan_v2::ScanBuilder as PlanScanBuilder;
 use vortex_utils::aliases::dash_map::DashMap;
 use vortex_utils::aliases::dash_map::Entry;
@@ -386,6 +387,13 @@ impl FileOpener for VortexOpener {
                     }
                 }
 
+                let filter_mode = if std::env::var("VORTEX_PLAN_V2_FILTER_MODE").as_deref()
+                    == Ok("adaptive")
+                {
+                    FilterMode::Adaptive
+                } else {
+                    FilterMode::Parallel
+                };
                 let mut scan_builder = PlanScanBuilder::try_new(
                     vxf.footer().layout(),
                     vxf.segment_source(),
@@ -402,7 +410,8 @@ impl FileOpener for VortexOpener {
                         .map(unbind)
                         .transpose()
                         .map_err(|error| DataFusionError::External(Box::new(error)))?,
-                );
+                )
+                .with_filter_mode(filter_mode);
                 if let Some(limit) = limit
                     && filter.is_none()
                 {

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -42,6 +42,10 @@ use tracing::Instrument;
 use vortex::array::VortexSessionExecute;
 use vortex::error::VortexError;
 use vortex::error::VortexExpect;
+use vortex::error::VortexResult;
+use vortex::expr::BoundExpression;
+use vortex::expr::Expression;
+use vortex::expr::root;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::io::InstrumentedReadAt;
 use vortex::layout::LayoutReader;
@@ -50,6 +54,7 @@ use vortex::metrics::Label;
 use vortex::metrics::MetricsRegistry;
 use vortex::session::VortexSession;
 use vortex_arrow::ArrowSessionExt;
+use vortex_scan_v2::ScanBuilder as PlanScanBuilder;
 use vortex_utils::aliases::dash_map::DashMap;
 use vortex_utils::aliases::dash_map::Entry;
 
@@ -327,40 +332,6 @@ impl FileOpener for VortexOpener {
                 .try_map_exprs(|expr| reassign_expr_columns(expr, &stream_schema))?;
             let projector = leftover_projection.make_projector(&stream_schema)?;
 
-            // We share our layout readers with others partitions in the scan, so we can only need to read each layout in each file once.
-            let layout_reader = match layout_readers.entry(file.object_meta.location.clone()) {
-                Entry::Occupied(mut occupied_entry) => {
-                    if let Some(reader) = occupied_entry.get().upgrade() {
-                        tracing::trace!("reusing layout reader for {}", occupied_entry.key());
-                        reader
-                    } else {
-                        tracing::trace!("creating layout reader for {}", occupied_entry.key());
-                        let reader = vxf.layout_reader().map_err(|e| {
-                            DataFusionError::Execution(format!(
-                                "Failed to create layout reader: {e}"
-                            ))
-                        })?;
-                        occupied_entry.insert(Arc::downgrade(&reader));
-                        reader
-                    }
-                }
-                Entry::Vacant(vacant_entry) => {
-                    tracing::trace!("creating layout reader for {}", vacant_entry.key());
-                    let reader = vxf.layout_reader().map_err(|e| {
-                        DataFusionError::Execution(format!("Failed to create layout reader: {e}"))
-                    })?;
-                    vacant_entry.insert(Arc::downgrade(&reader));
-
-                    reader
-                }
-            };
-
-            let mut scan_builder = ScanBuilder::new(session.clone(), Arc::clone(&layout_reader));
-
-            if let Some(vortex_plan) = file.extensions.get::<VortexAccessPlan>() {
-                scan_builder = vortex_plan.apply_to_builder(scan_builder);
-            }
-
             let filter = filter
                 .and_then(|f| {
                     // Verify that all filters we've accepted from DataFusion get pushed down.
@@ -396,76 +367,174 @@ impl FileOpener for VortexOpener {
                 .map(|filter| filter.optimize_recursive(vxf.dtype())?.bind(vxf.dtype()))
                 .transpose()
                 .map_err(|e| exec_datafusion_err!("Couldn't bind Vortex scan filter: {e}"))?;
-
-            if let Some(limit) = limit
-                && filter.is_none()
-            {
-                scan_builder = scan_builder.with_limit(limit);
-            }
-
-            if let Some(concurrency) = scan_concurrency {
-                scan_builder = scan_builder.with_concurrency(concurrency);
-            }
-
-            // Set before the byte-range translation below, which computes natural splits for
-            // the fields the scan's projection and filter reference.
-            scan_builder = scan_builder
-                .with_projection(scan_projection)
-                .with_some_filter(filter);
-
-            if let Some(file_range) = file.range {
-                let byte_range = Range {
-                    start: u64::try_from(file_range.start)
-                        .map_err(|_| exec_datafusion_err!("Vortex file range start is negative"))?,
-                    end: u64::try_from(file_range.end)
-                        .map_err(|_| exec_datafusion_err!("Vortex file range end is negative"))?,
-                };
-                if byte_range.start != 0 || byte_range.end != file.object_meta.size {
-                    // Full-file scans already cover every natural split. Only translate the
-                    // byte range back into row boundaries when DataFusion has trimmed the file.
-                    let natural_splits = natural_splits_for_file(
-                        natural_splits.as_ref(),
-                        &file.object_meta.location,
-                        &scan_builder,
-                        file.object_meta.size,
-                    )?;
-
-                    let Some(row_range) =
-                        split_aligned_row_range(byte_range, natural_splits.as_ref())
-                    else {
-                        return Ok(stream::empty().boxed());
-                    };
-
-                    scan_builder = scan_builder
-                        .with_row_range(row_range)
-                        // Hand the shared full-file boundaries back to the scan so prepare()
-                        // skips its own layout walk.
-                        .with_natural_splits(Arc::clone(&natural_splits.row_boundaries));
-                }
-            }
-
             let stream_target_field = Field::new_struct("", stream_schema.fields().clone(), false);
-            let stream = scan_builder
-                .with_metrics_registry(metrics_registry)
-                .with_ordered(has_output_ordering)
-                .map(move |chunk| {
-                    let mut ctx = session.create_execution_ctx();
-                    let arrow_session = ctx.session().clone();
-                    let arrow = arrow_session.arrow().execute_arrow(
-                        chunk,
-                        Some(&stream_target_field),
-                        &mut ctx,
-                    )?;
-                    Ok(RecordBatch::from(arrow.as_struct().clone()))
-                })
-                .into_stream()
-                .map_err(|e| exec_datafusion_err!("Failed to create Vortex stream: {e}"))?
-                .map_err(move |e: VortexError| {
-                    DataFusionError::External(Box::new(e.with_context(format!(
-                        "Failed to read Vortex file: {}",
-                        file.object_meta.location
-                    ))))
-                })
+            let stream = if std::env::var("VORTEX_USE_PLAN_V2").as_deref() == Ok("1") {
+                if file.extensions.get::<VortexAccessPlan>().is_some() {
+                    return Err(exec_datafusion_err!(
+                        "plan-v2 scans do not support VortexAccessPlan"
+                    ));
+                }
+                if let Some(file_range) = file.range.as_ref() {
+                    let start = u64::try_from(file_range.start)
+                        .map_err(|_| exec_datafusion_err!("Vortex file range start is negative"))?;
+                    let end = u64::try_from(file_range.end)
+                        .map_err(|_| exec_datafusion_err!("Vortex file range end is negative"))?;
+                    if start != 0 || end != file.object_meta.size {
+                        return Err(exec_datafusion_err!(
+                            "plan-v2 scans require DataFusion file-scan repartitioning to be disabled"
+                        ));
+                    }
+                }
+
+                let mut scan_builder = PlanScanBuilder::try_new(
+                    vxf.footer().layout(),
+                    vxf.segment_source(),
+                    session.clone(),
+                )
+                .map_err(|error| DataFusionError::External(Box::new(error)))?
+                .with_projection(
+                    unbind(&scan_projection)
+                        .map_err(|error| DataFusionError::External(Box::new(error)))?,
+                )
+                .with_some_filter(
+                    filter
+                        .as_ref()
+                        .map(unbind)
+                        .transpose()
+                        .map_err(|error| DataFusionError::External(Box::new(error)))?,
+                );
+                if let Some(limit) = limit
+                    && filter.is_none()
+                {
+                    scan_builder = scan_builder.with_limit(limit);
+                }
+                if let Some(concurrency) = scan_concurrency {
+                    scan_builder = scan_builder.with_concurrency(concurrency);
+                }
+
+                let location = file.object_meta.location.clone();
+                let session = session.clone();
+                scan_builder
+                    .with_ordered(has_output_ordering)
+                    .map(move |chunk| {
+                        let mut ctx = session.create_execution_ctx();
+                        let arrow_session = ctx.session().clone();
+                        let arrow = arrow_session.arrow().execute_arrow(
+                            chunk,
+                            Some(&stream_target_field),
+                            &mut ctx,
+                        )?;
+                        Ok(RecordBatch::from(arrow.as_struct().clone()))
+                    })
+                    .into_stream()
+                    .map_err(|e| exec_datafusion_err!("Failed to create plan-v2 stream: {e}"))?
+                    .map_err(move |e: VortexError| {
+                        DataFusionError::External(Box::new(e.with_context(format!(
+                            "Failed to read Vortex file with plan v2: {location}"
+                        ))))
+                    })
+                    .boxed()
+            } else {
+                // Share layout readers between partitions so each file's layout is read once.
+                let layout_reader = match layout_readers.entry(file.object_meta.location.clone()) {
+                    Entry::Occupied(mut occupied_entry) => {
+                        if let Some(reader) = occupied_entry.get().upgrade() {
+                            tracing::trace!("reusing layout reader for {}", occupied_entry.key());
+                            reader
+                        } else {
+                            tracing::trace!("creating layout reader for {}", occupied_entry.key());
+                            let reader = vxf.layout_reader().map_err(|e| {
+                                DataFusionError::Execution(format!(
+                                    "Failed to create layout reader: {e}"
+                                ))
+                            })?;
+                            occupied_entry.insert(Arc::downgrade(&reader));
+                            reader
+                        }
+                    }
+                    Entry::Vacant(vacant_entry) => {
+                        tracing::trace!("creating layout reader for {}", vacant_entry.key());
+                        let reader = vxf.layout_reader().map_err(|e| {
+                            DataFusionError::Execution(format!(
+                                "Failed to create layout reader: {e}"
+                            ))
+                        })?;
+                        vacant_entry.insert(Arc::downgrade(&reader));
+                        reader
+                    }
+                };
+
+                let mut scan_builder =
+                    ScanBuilder::new(session.clone(), Arc::clone(&layout_reader));
+                if let Some(vortex_plan) = file.extensions.get::<VortexAccessPlan>() {
+                    scan_builder = vortex_plan.apply_to_builder(scan_builder);
+                }
+                if let Some(limit) = limit
+                    && filter.is_none()
+                {
+                    scan_builder = scan_builder.with_limit(limit);
+                }
+                if let Some(concurrency) = scan_concurrency {
+                    scan_builder = scan_builder.with_concurrency(concurrency);
+                }
+
+                // Set before translating byte ranges because natural splits depend on the fields
+                // referenced by the projection and filter.
+                scan_builder = scan_builder
+                    .with_projection(scan_projection)
+                    .with_some_filter(filter);
+                if let Some(file_range) = file.range {
+                    let byte_range = Range {
+                        start: u64::try_from(file_range.start).map_err(|_| {
+                            exec_datafusion_err!("Vortex file range start is negative")
+                        })?,
+                        end: u64::try_from(file_range.end).map_err(|_| {
+                            exec_datafusion_err!("Vortex file range end is negative")
+                        })?,
+                    };
+                    if byte_range.start != 0 || byte_range.end != file.object_meta.size {
+                        let natural_splits = natural_splits_for_file(
+                            natural_splits.as_ref(),
+                            &file.object_meta.location,
+                            &scan_builder,
+                            file.object_meta.size,
+                        )?;
+                        let Some(row_range) =
+                            split_aligned_row_range(byte_range, natural_splits.as_ref())
+                        else {
+                            return Ok(stream::empty().boxed());
+                        };
+                        scan_builder = scan_builder
+                            .with_row_range(row_range)
+                            .with_natural_splits(Arc::clone(&natural_splits.row_boundaries));
+                    }
+                }
+
+                let location = file.object_meta.location.clone();
+                let session = session.clone();
+                scan_builder
+                    .with_metrics_registry(metrics_registry)
+                    .with_ordered(has_output_ordering)
+                    .map(move |chunk| {
+                        let mut ctx = session.create_execution_ctx();
+                        let arrow_session = ctx.session().clone();
+                        let arrow = arrow_session.arrow().execute_arrow(
+                            chunk,
+                            Some(&stream_target_field),
+                            &mut ctx,
+                        )?;
+                        Ok(RecordBatch::from(arrow.as_struct().clone()))
+                    })
+                    .into_stream()
+                    .map_err(|e| exec_datafusion_err!("Failed to create Vortex stream: {e}"))?
+                    .map_err(move |e: VortexError| {
+                        DataFusionError::External(Box::new(e.with_context(format!(
+                            "Failed to read Vortex file: {location}"
+                        ))))
+                    })
+                    .boxed()
+            };
+            let stream = stream
                 .map(move |batch| {
                     let batch = if projector.projection().as_ref().is_empty() {
                         batch
@@ -492,6 +561,23 @@ impl FileOpener for VortexOpener {
         .in_current_span()
         .boxed())
     }
+}
+
+fn unbind(expression: &BoundExpression) -> VortexResult<Expression> {
+    if expression.is_root() {
+        return Ok(root());
+    }
+    Expression::try_new(
+        expression
+            .as_scalar()
+            .vortex_expect("non-root bound expression must have a scalar function")
+            .clone(),
+        expression
+            .children()
+            .iter()
+            .map(unbind)
+            .collect::<VortexResult<Vec<_>>>()?,
+    )
 }
 
 /// A file's natural split boundaries plus the precomputed byte each split is assigned to,

--- a/vortex-layout/src/plan/plans/zoned.rs
+++ b/vortex-layout/src/plan/plans/zoned.rs
@@ -34,6 +34,7 @@ use vortex_session::registry::CachedId;
 
 use crate::layouts::zoned::zone_map::ZoneMap;
 use crate::plan::Eval;
+use crate::plan::EvalPlan;
 use crate::plan::Plan;
 use crate::plan::PlanArrayFuture;
 use crate::plan::PlanChildren;
@@ -243,6 +244,26 @@ impl ZonedPlan {
         ))
     }
 
+    fn with_data_expression(&self, expression: BoundExpression) -> VortexResult<Option<Self>> {
+        let Some(data_plan) = self.data_plan()? else {
+            return Ok(None);
+        };
+        Ok(Some(
+            PlanParts {
+                vtable: Zoned,
+                dtype: expression.dtype().clone(),
+                row_count: self.row_count(),
+                children: vec![
+                    EvalPlan::try_new(expression, data_plan)?.into_plan(),
+                    self.zones_plan()?,
+                ]
+                .into(),
+                data: self.data().clone(),
+            }
+            .into_typed(),
+        ))
+    }
+
     fn execute_pruning(
         &self,
         ctx: &PlanExecutionContext,
@@ -421,7 +442,6 @@ impl PlanVTable for Zoned {
         if data_plan.dtype() != plan.dtype() || data_plan.row_count() != plan.row_count() {
             vortex_error::vortex_bail!("Zoned data child shape does not match the plan output");
         }
-        data.column_dtype = plan.dtype().clone();
         Ok(())
     }
 
@@ -455,7 +475,7 @@ impl PlanVTable for Zoned {
     }
 }
 
-/// Rewrites an abstract statistic expression over a zoned plan into its pruning state.
+/// Pushes data expressions through a zoned plan and rewrites statistic expressions into pruning.
 #[derive(Debug)]
 pub(crate) struct ExpressionZonedRule;
 
@@ -478,12 +498,17 @@ impl PlanParentReduceRule<Zoned> for ExpressionZonedRule {
             contains_root |= expression.is_root();
             Ok(TraversalOrder::Continue)
         })?;
-        if !parent.dtype().is_boolean() || !contains_stat || contains_root {
-            return Ok(None);
+        if contains_stat {
+            if !parent.dtype().is_boolean() || contains_root {
+                return Ok(None);
+            }
+            return Ok(child
+                .with_pruning(parent.expression().clone())?
+                .map(Plan::into_plan));
         }
 
         Ok(child
-            .with_pruning(parent.expression().clone())?
+            .with_data_expression(parent.expression().clone())?
             .map(Plan::into_plan))
     }
 }

--- a/vortex-layout/src/plan/tests.rs
+++ b/vortex-layout/src/plan/tests.rs
@@ -1248,6 +1248,37 @@ fn zoned_plan_exposes_data_and_zones() -> VortexResult<()> {
 }
 
 #[test]
+fn data_expression_pushes_through_zoned_and_preserves_zones() -> VortexResult<()> {
+    let dtype = primitive(PType::I32, Nullability::NonNullable);
+    let zones_dtype = DType::Struct(StructFields::empty(), Nullability::NonNullable);
+    let zone_len = NonZeroUsize::new(3).ok_or_else(|| vortex_err!("zone length is zero"))?;
+    let aggregate_fns: Arc<[AggregateFnRef]> = Vec::new().into();
+    let layout = ZonedLayout::try_new(
+        flat(5, dtype.clone(), 0),
+        flat(2, zones_dtype, 1),
+        zone_len,
+        aggregate_fns,
+    )?
+    .into_layout();
+    let source = make_plan(layout)?;
+    let expression = gt(root(), lit(5_i32)).bind(&dtype)?;
+
+    let optimized = optimize(EvalPlan::try_new(expression, source)?.into_plan())?;
+    insta::assert_snapshot!(optimized.display_tree(), @r"
+    root: vortex.plan.zoned(bool, rows=5)
+      data: vortex.plan.eval(bool, rows=5) expr=($ > 5i32)
+        child: vortex.plan.segment_scan(i32, rows=5)
+      zones: vortex.plan.segment_scan({}, rows=2)
+    ");
+    let optimized_zoned = optimized
+        .as_opt::<Zoned>()
+        .ok_or_else(|| vortex_err!("optimized plan is not zoned"))?;
+    assert!(!optimized_zoned.is_pruning());
+    assert_eq!(optimized_zoned.zones_plan()?.row_count(), 2);
+    Ok(())
+}
+
+#[test]
 fn stats_expression_rewrites_to_zoned_pruning_plan() -> VortexResult<()> {
     let dtype = primitive(PType::I32, Nullability::NonNullable);
     let max = Max.bind(NumericalAggregateOpts::skip_nans());

--- a/vortex-layout/src/scan/mod.rs
+++ b/vortex-layout/src/scan/mod.rs
@@ -13,6 +13,8 @@ mod tasks;
 #[cfg(test)]
 mod test;
 
+pub use filter::FilterExpr;
+
 /// A heuristic for an ideal split size.
 ///
 /// We don't actually know if this is right, but it is probably a good estimate.

--- a/vortex-scan-v2/Cargo.toml
+++ b/vortex-scan-v2/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
+bit-vec = { workspace = true }
 futures = { workspace = true, features = ["alloc", "async-await"] }
 itertools = { workspace = true }
 tracing = { workspace = true }

--- a/vortex-scan-v2/src/filter.rs
+++ b/vortex-scan-v2/src/filter.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use bit_vec::BitVec;
+use vortex_array::MaskFuture;
+use vortex_array::VortexSessionExecute;
+use vortex_error::VortexResult;
+use vortex_layout::plan::PlanExecutionContext;
+use vortex_layout::plan::PlanRef;
+use vortex_layout::scan::FilterExpr;
+use vortex_mask::Mask;
+
+/// Controls how a scan executes top-level filter conjunctions.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum FilterMode {
+    /// Optimizes the complete predicate as one plan, allowing independent branches to run in
+    /// parallel.
+    #[default]
+    Parallel,
+    /// Splits top-level conjunctions and executes them as an adaptively ordered mask chain.
+    Adaptive,
+}
+
+#[derive(Clone)]
+pub(crate) enum FilterPlan {
+    Parallel(PlanRef),
+    Adaptive {
+        filter: Arc<FilterExpr>,
+        plans: Arc<[PlanRef]>,
+    },
+}
+
+impl FilterPlan {
+    pub(crate) fn parallel(plan: PlanRef) -> Self {
+        Self::Parallel(plan)
+    }
+
+    pub(crate) fn adaptive(filter: FilterExpr, plans: Vec<PlanRef>) -> Self {
+        Self::Adaptive {
+            filter: Arc::new(filter),
+            plans: plans.into(),
+        }
+    }
+
+    pub(crate) fn plans(&self) -> Vec<&PlanRef> {
+        match self {
+            Self::Parallel(plan) => vec![plan],
+            Self::Adaptive { plans, .. } => plans.iter().collect(),
+        }
+    }
+
+    pub(crate) fn execute(
+        &self,
+        execution: &PlanExecutionContext,
+        row_range: &Range<u64>,
+        row_mask: Mask,
+    ) -> VortexResult<MaskFuture> {
+        match self {
+            Self::Parallel(filter) => {
+                let predicate =
+                    filter.execute(execution, row_range, MaskFuture::ready(row_mask.clone()))?;
+                let session = execution.session().clone();
+                Ok(MaskFuture::new(row_mask.len(), async move {
+                    let predicate = predicate.await?;
+                    let mut execution = session.create_execution_ctx();
+                    let predicate: Mask = predicate.null_as_false().execute(&mut execution)?;
+                    Ok(row_mask.intersect_by_rank(&predicate))
+                }))
+            }
+            Self::Adaptive { filter, plans } => {
+                let execution = execution.clone();
+                let row_range = row_range.clone();
+                let filter = Arc::clone(filter);
+                let plans = Arc::clone(plans);
+                Ok(MaskFuture::new(row_mask.len(), async move {
+                    let mut row_mask = row_mask;
+                    let mut remaining = BitVec::from_elem(plans.len(), true);
+                    while let Some(index) = filter.next_conjunct(&remaining) {
+                        remaining.set(index, false);
+                        if row_mask.all_false() {
+                            break;
+                        }
+
+                        let input_rows = row_mask.true_count();
+                        let predicate = plans[index].execute(
+                            &execution,
+                            &row_range,
+                            MaskFuture::ready(row_mask.clone()),
+                        )?;
+                        let predicate = predicate.await?;
+                        let mut ctx = execution.session().create_execution_ctx();
+                        let predicate: Mask = predicate.null_as_false().execute(&mut ctx)?;
+                        row_mask = row_mask.intersect_by_rank(&predicate);
+                        filter.report_selectivity(index, row_mask.density());
+                        tracing::trace!(
+                            target: "vortex_scan_v2::execution",
+                            conjunct = index,
+                            input_rows,
+                            output_rows = row_mask.true_count(),
+                            "applied an adaptive plan filter conjunct"
+                        );
+                    }
+                    Ok(row_mask)
+                }))
+            }
+        }
+    }
+}

--- a/vortex-scan-v2/src/lib.rs
+++ b/vortex-scan-v2/src/lib.rs
@@ -10,6 +10,7 @@
 //! Set `RUST_LOG=vortex_scan_v2=debug` to log source and optimized plan trees and selected scan
 //! splits. Use `trace` to also log execution of each split.
 
+mod filter;
 mod repeated_scan;
 mod scan_builder;
 mod splits;
@@ -18,6 +19,7 @@ mod tasks;
 #[cfg(test)]
 mod tests;
 
+pub use filter::FilterMode;
 pub use repeated_scan::RepeatedScan;
 pub use scan_builder::ScanBuilder;
 pub use splits::SplitBy;

--- a/vortex-scan-v2/src/repeated_scan.rs
+++ b/vortex-scan-v2/src/repeated_scan.rs
@@ -25,6 +25,7 @@ use vortex_layout::plan::PlanRef;
 use vortex_scan::selection::Selection;
 use vortex_utils::parallelism::get_available_parallelism;
 
+use crate::filter::FilterPlan;
 use crate::splits::Splits;
 use crate::tasks::TaskContext;
 use crate::tasks::split_exec;
@@ -34,7 +35,7 @@ pub struct RepeatedScan<A: 'static + Send> {
     execution: PlanExecutionContext,
     projection: PlanRef,
     pruning: Option<PlanRef>,
-    filter: Option<PlanRef>,
+    filter: Option<FilterPlan>,
     ordered: bool,
     row_range: Option<Range<u64>>,
     selection: Selection,
@@ -82,7 +83,7 @@ impl<A: 'static + Send> RepeatedScan<A> {
         execution: PlanExecutionContext,
         projection: PlanRef,
         pruning: Option<PlanRef>,
-        filter: Option<PlanRef>,
+        filter: Option<FilterPlan>,
         ordered: bool,
         row_range: Option<Range<u64>>,
         selection: Selection,

--- a/vortex-scan-v2/src/scan_builder.rs
+++ b/vortex-scan-v2/src/scan_builder.rs
@@ -38,6 +38,7 @@ use vortex_layout::plan::Zoned;
 use vortex_layout::plan::lower;
 use vortex_layout::plan::optimize;
 use vortex_layout::plan::plan_row_idx_expression;
+use vortex_layout::scan::FilterExpr;
 use vortex_layout::segments::SegmentSource;
 use vortex_scan::selection::Selection;
 use vortex_scan::strict_sorted_buffer::StrictSortedBuffer;
@@ -45,6 +46,8 @@ use vortex_session::VortexSession;
 use vortex_utils::parallelism::get_available_parallelism;
 
 use crate::RepeatedScan;
+use crate::filter::FilterMode;
+use crate::filter::FilterPlan;
 use crate::splits::SplitBy;
 use crate::splits::Splits;
 use crate::splits::attempt_split_ranges;
@@ -55,6 +58,7 @@ pub struct ScanBuilder<A> {
     base_plan: PlanRef,
     projection: Expression,
     filter: Option<Expression>,
+    filter_mode: FilterMode,
     ordered: bool,
     row_range: Option<Range<u64>>,
     selection: Selection,
@@ -96,6 +100,7 @@ impl ScanBuilder<ArrayRef> {
             base_plan,
             projection: root(),
             filter: None,
+            filter_mode: FilterMode::default(),
             ordered: true,
             row_range: None,
             selection: Selection::default(),
@@ -137,6 +142,12 @@ impl<A: 'static + Send> ScanBuilder<A> {
     /// Sets or clears the filter expression.
     pub fn with_some_filter(mut self, filter: Option<Expression>) -> Self {
         self.filter = filter;
+        self
+    }
+
+    /// Configures whether filter conjunctions execute in parallel or as an adaptive chain.
+    pub fn with_filter_mode(mut self, filter_mode: FilterMode) -> Self {
+        self.filter_mode = filter_mode;
         self
     }
 
@@ -232,6 +243,7 @@ impl<A: 'static + Send> ScanBuilder<A> {
             base_plan: self.base_plan,
             projection: self.projection,
             filter: self.filter,
+            filter_mode: self.filter_mode,
             ordered: self.ordered,
             row_range: self.row_range,
             selection: self.selection,
@@ -263,7 +275,7 @@ impl<A: 'static + Send> ScanBuilder<A> {
             &source,
             self.execution.session(),
         )?;
-        let filter = optimize_filter_plan(filter_expression.as_ref(), &source)?;
+        let filter = optimize_filter_plan(filter_expression.as_ref(), &source, self.filter_mode)?;
 
         let splits =
             if let Some(ranges) = attempt_split_ranges(&self.selection, self.row_range.as_ref()) {
@@ -274,7 +286,9 @@ impl<A: 'static + Send> ScanBuilder<A> {
                     .clone()
                     .unwrap_or_else(|| 0..self.base_plan.row_count());
                 let mut plans = vec![&projection];
-                plans.extend(filter.as_ref());
+                if let Some(filter) = &filter {
+                    plans.extend(filter.plans());
+                }
                 plans.extend(pruning.as_ref());
                 Splits::Natural(self.split_by.splits(&plans, &row_range)?)
             };
@@ -424,21 +438,50 @@ fn build_pruning_plan(
 fn optimize_filter_plan(
     filter: Option<&BoundExpression>,
     source: &PlanRef,
-) -> VortexResult<Option<PlanRef>> {
+    mode: FilterMode,
+) -> VortexResult<Option<FilterPlan>> {
     let Some(expression) = filter else {
         return Ok(None);
     };
-    let filter = optimize(plan_row_idx_expression(expression.clone(), source.clone())?)?;
-    vortex_ensure!(
-        filter.dtype().is_boolean(),
-        "Filter plan must produce booleans"
-    );
-    tracing::debug!(
-        target: "vortex_scan_v2::planner",
-        plan = %filter.display_tree(),
-        "optimized the filter physical plan"
-    );
-    Ok(Some(filter))
+    match mode {
+        FilterMode::Parallel => {
+            let filter = optimize(plan_row_idx_expression(expression.clone(), source.clone())?)?;
+            vortex_ensure!(
+                filter.dtype().is_boolean(),
+                "Filter plan must produce booleans"
+            );
+            tracing::debug!(
+                target: "vortex_scan_v2::planner",
+                plan = %filter.display_tree(),
+                "optimized the parallel filter physical plan"
+            );
+            Ok(Some(FilterPlan::parallel(filter)))
+        }
+        FilterMode::Adaptive => {
+            let filter = FilterExpr::new(expression.clone());
+            let plans = filter
+                .conjuncts()
+                .iter()
+                .enumerate()
+                .map(|(index, expression)| {
+                    let plan =
+                        optimize(plan_row_idx_expression(expression.clone(), source.clone())?)?;
+                    vortex_ensure!(
+                        plan.dtype().is_boolean(),
+                        "Filter conjunct plan must produce booleans"
+                    );
+                    tracing::debug!(
+                        target: "vortex_scan_v2::planner",
+                        conjunct = index,
+                        plan = %plan.display_tree(),
+                        "optimized an adaptive filter conjunct plan"
+                    );
+                    Ok(plan)
+                })
+                .collect::<VortexResult<Vec<_>>>()?;
+            Ok(Some(FilterPlan::adaptive(filter, plans)))
+        }
+    }
 }
 
 fn uses_only_pruning_sources(plan: &PlanRef) -> VortexResult<bool> {

--- a/vortex-scan-v2/src/tasks.rs
+++ b/vortex-scan-v2/src/tasks.rs
@@ -15,6 +15,8 @@ use vortex_layout::plan::uses_only_pruning_sources;
 use vortex_mask::Mask;
 use vortex_scan::row_mask::RowMask;
 
+use crate::filter::FilterPlan;
+
 pub(crate) type TaskFuture<A> = BoxFuture<'static, VortexResult<A>>;
 
 pub(crate) fn split_exec<A: 'static + Send>(
@@ -87,18 +89,7 @@ pub(crate) fn split_exec<A: 'static + Send>(
         }
 
         let filter_mask = if let Some(filter) = &ctx.filter {
-            let predicate = filter.execute(
-                &ctx.execution,
-                &row_range,
-                MaskFuture::ready(row_mask.clone()),
-            )?;
-            let session = ctx.execution.session().clone();
-            MaskFuture::new(row_mask.len(), async move {
-                let predicate = predicate.await?;
-                let mut execution = session.create_execution_ctx();
-                let predicate: Mask = predicate.null_as_false().execute(&mut execution)?;
-                Ok(row_mask.intersect_by_rank(&predicate))
-            })
+            filter.execute(&ctx.execution, &row_range, row_mask)?
         } else {
             MaskFuture::ready(row_mask)
         };
@@ -135,7 +126,7 @@ pub(crate) fn split_exec<A: 'static + Send>(
 pub(crate) struct TaskContext<A> {
     pub(crate) execution: PlanExecutionContext,
     pub(crate) pruning: Option<PlanRef>,
-    pub(crate) filter: Option<PlanRef>,
+    pub(crate) filter: Option<FilterPlan>,
     pub(crate) projection: PlanRef,
     pub(crate) mapper: Arc<dyn Fn(ArrayRef) -> VortexResult<A> + Send + Sync>,
 }

--- a/vortex-scan-v2/src/tests.rs
+++ b/vortex-scan-v2/src/tests.rs
@@ -23,6 +23,7 @@ use vortex_array::expr::checked_add;
 use vortex_array::expr::get_item;
 use vortex_array::expr::gt;
 use vortex_array::expr::lit;
+use vortex_array::expr::lt;
 use vortex_array::expr::pack;
 use vortex_array::expr::root;
 use vortex_array::stream::ArrayStreamExt;
@@ -51,6 +52,7 @@ use vortex_layout::sequence::SequentialArrayStreamExt;
 use vortex_layout::session::LayoutSession;
 use vortex_scan::strict_sorted_buffer::StrictSortedBuffer;
 
+use crate::FilterMode;
 use crate::ScanBuilder;
 use crate::SplitBy;
 
@@ -110,6 +112,47 @@ fn scans_layout_through_optimized_plans() -> VortexResult<()> {
         let expected = PrimitiveArray::from_iter(6_i32..11).into_array();
 
         assert_arrays_eq!(actual, expected, &mut session.create_execution_ctx());
+        Ok(())
+    })
+}
+
+#[test]
+fn supports_parallel_and_adaptive_filter_modes() -> VortexResult<()> {
+    block_on(|handle| async {
+        let session = array_session()
+            .with::<LayoutSession>()
+            .with::<RuntimeSession>()
+            .with_handle(handle);
+        let segments = Arc::new(TestSegments::default());
+        let (sequence, eof) = SequenceId::root().split();
+        let input = PrimitiveArray::from_iter(0_i32..10).into_array();
+        let layout = FlatLayoutStrategy::default()
+            .write_stream(
+                ArrayContext::empty().into(),
+                Arc::<TestSegments>::clone(&segments),
+                input.to_array_stream().sequenced(sequence),
+                eof,
+                &session,
+            )
+            .await?;
+        let filter = and(gt(root(), lit(2_i32)), lt(root(), lit(8_i32)));
+        let expected = PrimitiveArray::from_iter(3_i32..8).into_array();
+
+        for mode in [FilterMode::Parallel, FilterMode::Adaptive] {
+            let actual = ScanBuilder::try_new(
+                &layout,
+                Arc::<TestSegments>::clone(&segments),
+                session.clone(),
+            )?
+            .with_filter(filter.clone())
+            .with_filter_mode(mode)
+            .with_split_by(SplitBy::RowCount(3))
+            .into_array_stream()?
+            .read_all()
+            .await?;
+
+            assert_arrays_eq!(actual, expected, &mut session.create_execution_ctx());
+        }
         Ok(())
     })
 }


### PR DESCRIPTION
## Summary

- add an experimental `VORTEX_USE_PLAN_V2=1` switch to the DataFusion Vortex file opener
- push ordinary `Eval` expressions through `Zoned`, retaining the zones child around the transformed data plan
- add `FilterMode::{Parallel, Adaptive}` to plan-v2: parallel keeps the whole predicate plan, while adaptive chains top-level conjunction plans using v1's selectivity tracking
- run the SQL benchmark matrix through plan-v2 and disable DataFusion file-scan repartitioning for that path
- preserve `LayoutReader` as the default when the environment variable is unset

## Why

This stacked PR makes the plan-v2 scan path runnable in CI and lets us compare parallel predicate execution with adaptive mask chaining. Every file scan calls `vortex_scan_v2::ScanBuilder::try_new`, so benchmark timings include planning and do not use cached or precomputed physical plans.

## Q19 local results

TPC-H SF=1, DataFusion + Vortex, 100 iterations, file repartitioning disabled:

| Mode | Median | vs LayoutReader |
| --- | ---: | ---: |
| LayoutReader | 12.344 ms | baseline |
| plan-v2 parallel | 10.304 ms | -16.5% |
| plan-v2 adaptive | 11.369 ms | -7.9% |

One-run lineitem scan metrics show the tradeoff: adaptive reduced reads from 56.11 MB / 50 requests to 51.51 MB / 44 requests, but increased scan time from 7.82 ms to 10.13 ms because the mask dependencies serialize the three conjunct plans. Parallel therefore remains the default. The DataFusion adapter accepts `VORTEX_PLAN_V2_FILTER_MODE=adaptive` for direct comparison.

## Scope and limitations

The DataFusion switch is intentionally experimental. The plan-v2 adapter currently rejects `VortexAccessPlan` and partial file ranges; the SQL workflow disables DataFusion file-scan repartitioning so benchmark scans receive whole files.

## Checks

- `cargo +nightly fmt --all`
- `yamllint --strict -c .yamllint.yaml .github/workflows/sql-bench-matrix.yml`
- `cargo test -p vortex-layout`
- `cargo test -p vortex-scan-v2`
- `cargo check -p vortex-datafusion`
- `RUSTC_WRAPPER= cargo build -p datafusion-bench --profile release_debug --features unstable_encodings`
- `RUSTC_WRAPPER= VORTEX_USE_PLAN_V2=1 cargo test -p vortex-datafusion persistent::opener::tests::test_open -- --exact`
- `RUSTC_WRAPPER= cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
