### PR TITLE
Harden indexed lane sources

### DIFF
--- a/vortex-compute/src/lane_kernels/source.rs
+++ b/vortex-compute/src/lane_kernels/source.rs
@@ -10,9 +10,8 @@
 /// reads carry no inter-iteration data dependency — the autovectorizer treats each
 /// lane independently.
 pub trait IndexedSource {
-    /// The per-lane item type. Must be `Copy` so the kernels can pass it through
-    /// the closure by value without extra moves.
-    type Item: Copy;
+    /// The per-lane item type passed through the kernel by value.
+    type Item;
     /// Logical lane count.
     fn len(&self) -> usize;
     /// Returns true when there are no lanes.
@@ -55,10 +54,10 @@ impl<T: Copy> IndexedSource for &mut [T] {
 
 /// Pair of two [`IndexedSource`]s of equal length. Yields `(A::Item, B::Item)` per lane.
 ///
-/// Use this to drive a binary kernel from two columns. Length equality is enforced
-/// at construction.
+/// Use this to drive a binary kernel from two columns. Length equality is enforced at
+/// construction, and the private fields prevent callers from bypassing that check.
 #[derive(Clone, Copy)]
-pub struct LaneZip<A, B>(pub A, pub B);
+pub struct LaneZip<A, B>(A, B);
 
 impl<A: IndexedSource, B: IndexedSource> LaneZip<A, B> {
     /// Build a `LaneZip` from two equal-length sources.
@@ -80,12 +79,22 @@ impl<A: IndexedSource, B: IndexedSource> IndexedSource for LaneZip<A, B> {
     type Item = (A::Item, B::Item);
     #[inline]
     fn len(&self) -> usize {
-        debug_assert_eq!(self.0.len(), self.1.len());
         self.0.len()
     }
     #[inline]
     unsafe fn get_unchecked(&self, i: usize) -> (A::Item, B::Item) {
         // SAFETY: caller guarantees i < self.len(); `new` enforces matching lengths.
         unsafe { (self.0.get_unchecked(i), self.1.get_unchecked(i)) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LaneZip;
+
+    #[test]
+    #[should_panic(expected = "LaneZip operands must have the same length")]
+    fn rejects_mismatched_lengths() {
+        _ = LaneZip::new(&[1_u8][..], &[2_u8, 3][..]);
     }
 }


### PR DESCRIPTION
## Summary

- Tracking issue: #9129

Lets indexed lane sources return borrowed or otherwise non-`Copy` items. RowFn needs this for typed row inputs without adding a second kernel abstraction.

## What changes are included in this PR?

Removes the `Copy` bound from `IndexedSource::Item`. It also makes `LaneZip` fields private, validates lengths once in `LaneZip::new`, and removes the repeated assertion from its inline `len` method.

This is a prerequisite only. The first production RowFn adopter is in #9345, so there is no meaningful RowFn performance comparison at this layer.

## What APIs are changed? Are there any user-facing changes?

`LaneZip` must now be constructed with `LaneZip::new` instead of tuple syntax. The workspace has no direct field construction outside this module.
