### PR TITLE
Benchmark SIMD kernels per instruction set on CodSpeed

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,9 +18,9 @@ timeout = 3600
 # Environment variables for PyO3. Ensures reproducible builds and avoids spurious recompilations.
 [env]
 PYO3_ENVIRONMENT_SIGNATURE = { value = "cpython-3.11-64bit", force = true }
-# Benchmark variant defaults, read at compile time by `vortex-bench-support`. Neither is
-# forced, so a CI leg that exports its own values wins. Under `local` every benchmark runs,
-# whatever variants it is tagged with, and the empty prefix leaves benchmark names bare.
+# Benchmark leg defaults, read at compile time by the code `vortex-bench-support`'s `#[isa]`
+# generates. Neither is forced, so a CI leg that exports its own values wins. Under `local`
+# every benchmark runs, whatever it is tagged with, and the empty prefix leaves names bare.
 VORTEX_BENCH_VARIANT = "local"
 VORTEX_BENCH_PREFIX = ""
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,14 +18,14 @@ timeout = 3600
 # Environment variables for PyO3. Ensures reproducible builds and avoids spurious recompilations.
 [env]
 PYO3_ENVIRONMENT_SIGNATURE = { value = "cpython-3.11-64bit", force = true }
-# Read by benchmarks marked `#[isa]` (see the `vortex-bench-support` crate), which expands to
-# code reading both with `env!`. VORTEX_BENCH_VARIANT names the run: the benchmark is skipped
-# when it is "simulation", and runs otherwise. VORTEX_BENCH_PREFIX is prepended to the
-# benchmark's name, so a CI leg can label the numbers it produced.
+# Read by benchmarks marked `#[cpu_features]` (see the `vortex-bench-support` crate), which
+# expands to code reading both with `env!`. VORTEX_BENCH_VARIANT names the run: the benchmark
+# is skipped when it is "simulation", and runs otherwise. VORTEX_BENCH_PREFIX is prepended to
+# the benchmark's name, so a CI leg can label the numbers it produced.
 #
-# The values below are the ones a plain `cargo bench` wants: nothing skipped, names left bare.
-# The per-instruction-set jobs in `.github/workflows/codspeed.yml` set their own. Neither is
-# `force`d, so the value those jobs export wins over the one here.
+# The values below are what a plain `cargo bench` wants: nothing skipped, names left bare. The
+# per-feature-set jobs in `.github/workflows/codspeed.yml` set their own. Neither is `force`d,
+# so the value those jobs export wins over the one here.
 VORTEX_BENCH_VARIANT = "local"
 VORTEX_BENCH_PREFIX = ""
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,6 +18,11 @@ timeout = 3600
 # Environment variables for PyO3. Ensures reproducible builds and avoids spurious recompilations.
 [env]
 PYO3_ENVIRONMENT_SIGNATURE = { value = "cpython-3.11-64bit", force = true }
+# Benchmark variant defaults, read at compile time by `vortex-bench-support`. Neither is
+# forced, so a CI leg that exports its own values wins. Under `local` every benchmark runs,
+# whatever variants it is tagged with, and the empty prefix leaves benchmark names bare.
+VORTEX_BENCH_VARIANT = "local"
+VORTEX_BENCH_PREFIX = ""
 
 [cache.global-clean]
 # Anything older than this duration will be deleted in the source cache.

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,9 +18,14 @@ timeout = 3600
 # Environment variables for PyO3. Ensures reproducible builds and avoids spurious recompilations.
 [env]
 PYO3_ENVIRONMENT_SIGNATURE = { value = "cpython-3.11-64bit", force = true }
-# Benchmark leg defaults, read at compile time by the code `vortex-bench-support`'s `#[isa]`
-# generates. Neither is forced, so a CI leg that exports its own values wins. Under `local`
-# every benchmark runs, whatever it is tagged with, and the empty prefix leaves names bare.
+# Read by benchmarks marked `#[isa]` (see the `vortex-bench-support` crate), which expands to
+# code reading both with `env!`. VORTEX_BENCH_VARIANT names the run: the benchmark is skipped
+# when it is "simulation", and runs otherwise. VORTEX_BENCH_PREFIX is prepended to the
+# benchmark's name, so a CI leg can label the numbers it produced.
+#
+# The values below are the ones a plain `cargo bench` wants: nothing skipped, names left bare.
+# The per-instruction-set jobs in `.github/workflows/codspeed.yml` set their own. Neither is
+# `force`d, so the value those jobs export wins over the one here.
 VORTEX_BENCH_VARIANT = "local"
 VORTEX_BENCH_PREFIX = ""
 

--- a/.github/actions/system-info/action.yml
+++ b/.github/actions/system-info/action.yml
@@ -10,10 +10,13 @@ runs:
         echo "=== CPU Model ==="
         lscpu
         echo "=== /proc/cpuinfo summary ==="
-        grep -m1 "model name" /proc/cpuinfo
+        # x86 exposes "model name"; aarch64 has no such line (lscpu above covers it), and
+        # `shell: bash` runs with `set -e`, so a missing match must not fail the step.
+        grep -m1 "model name" /proc/cpuinfo || true
         nproc
         echo "=== CPU Flags ==="
-        grep -m1 "flags" /proc/cpuinfo
+        # x86 exposes "flags"; aarch64 exposes "Features".
+        grep -m1 -E "^(flags|Features)" /proc/cpuinfo || true
 
         echo "=== Memory ==="
         free -h

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Build benchmarks
         env:
           RUSTFLAGS: "-C target-feature=+avx2"
-          # Benchmarks carrying an `#[isa(..)]` tag belong to a walltime leg below and are
+          # Benchmarks carrying `#[cpu_features]` belong to a walltime leg below and are
           # skipped here. Untagged ones run as they always have, under bare names, so this
           # job's CodSpeed history is unaffected.
           VORTEX_BENCH_VARIANT: simulation
@@ -93,21 +93,21 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: "simulation"
 
-  # Walltime measurements on real silicon, one leg per instruction set.
+  # Walltime measurements on real silicon, one leg per CPU feature set.
   #
   # The sharded job above measures simulated instruction counts on one x86-64 build. That
-  # says nothing about code whose machine code depends on the instruction set it was compiled
-  # for, and nothing at all about Arm. A benchmark opts in with `#[isa]` and is then built
-  # and measured once per leg here. VORTEX_BENCH_VARIANT takes those benchmarks out of the
-  # sharded job and VORTEX_BENCH_PREFIX qualifies their names, so each leg reports its own
-  # series rather than the legs fighting over a shared one.
+  # says nothing about code whose machine code depends on the features it was compiled for,
+  # and nothing at all about Arm. A benchmark opts in with `#[cpu_features]` and is then
+  # built and measured once per leg here. VORTEX_BENCH_VARIANT takes those benchmarks out of
+  # the sharded job and VORTEX_BENCH_PREFIX qualifies their names, so each leg reports its
+  # own series rather than the legs fighting over a shared one.
   #
-  # This matrix is the only place the legs are named — `#[isa]` carries no leg list, so
-  # adding one is a change here alone. Each `family` must implement its instruction set: the
-  # build enables it globally, so surrounding code may use it and will fault on a machine
-  # that lacks it. These are metal instances, as the other walltime benchmark jobs use, so
-  # measurements are not taken through a hypervisor.
-  bench-codspeed-isa:
+  # This matrix is the only place the legs are named — the attribute carries no leg list, so
+  # adding one is a change here alone. Each `family` must implement the features its leg
+  # enables: they are enabled globally, so surrounding code may use them and will fault on a
+  # machine that lacks them. These are metal instances, as the other walltime benchmark jobs
+  # use, so measurements are not taken through a hypervisor.
+  bench-codspeed-cpu-features:
     if: github.repository == 'vortex-data/vortex'
     strategy:
       fail-fast: false
@@ -116,7 +116,7 @@ jobs:
           # avx2 and avx512 share a family so the only difference between the two series is
           # the build flags, not the silicon. c7i.metal-24xl is the smaller of the two c7i
           # metal sizes: current-generation Sapphire Rapids, and AVX-512 capable.
-          - isa: avx2
+          - features: avx2
             family: c7i.metal-24xl
             image: ubuntu24-full-x64-pre-v2
             rustflags: "-C target-feature=+avx2"
@@ -125,21 +125,21 @@ jobs:
           # under test selects, but the rest of the build — anything the compiler
           # auto-vectorizes, the scalar baselines included — sees the whole feature set, and
           # a two-feature build is not what anything ships on.
-          - isa: avx512
+          - features: avx512
             family: c7i.metal-24xl
             image: ubuntu24-full-x64-pre-v2
             rustflags: >-
               -C target-feature=+avx512f,+avx512bw,+avx512cd,+avx512dq,+avx512vl,+avx512ifma,+avx512vbmi,+avx512vbmi2,+avx512vnni,+avx512bitalg,+avx512vpopcntdq,+avx512bf16,+avx512fp16
           # Graviton3, the cheapest current-generation Arm metal. Graviton2 (c6g.metal) is
           # cheaper still but predates SVE, so it cannot host a future SVE leg.
-          - isa: neon
+          - features: neon
             family: c7g.metal
             image: ubuntu24-full-arm64-pre-v2
             rustflags: "-C target-feature=+neon"
-    name: "Benchmark with Codspeed (${{ matrix.isa }})"
+    name: "Benchmark with Codspeed (${{ matrix.features }})"
     timeout-minutes: 60
     runs-on: >-
-      runs-on=${{ github.run_id }}/runner=bench-dedicated/family=${{ matrix.family }}/image=${{ matrix.image }}/disk=large/extras=s3-cache/tag=bench-codspeed-isa-${{ matrix.isa }}
+      runs-on=${{ github.run_id }}/runner=bench-dedicated/family=${{ matrix.family }}/image=${{ matrix.image }}/disk=large/extras=s3-cache/tag=bench-codspeed-cpu-features-${{ matrix.features }}
     steps:
       - uses: runs-on/action@v2
         with:
@@ -154,7 +154,7 @@ jobs:
         with:
           tool: cargo-codspeed
       # Which packages to build is derived from the source rather than listed here, so a
-      # crate that adds an `#[isa]` benchmark is picked up without editing this workflow.
+      # crate that adds an `#[cpu_features]` benchmark is picked up without editing this workflow.
       # Building the whole workspace would do the same, but links every bench binary in it
       # — with debuginfo, from the bench profile — to measure only the tagged ones.
       - name: Select packages with tagged benchmarks
@@ -170,17 +170,17 @@ jobs:
               for package in meta["packages"]
               for target in package["targets"]
               if "bench" in target["kind"]
-              and "#[isa]" in pathlib.Path(target["src_path"]).read_text()
+              and "cpu_features]" in pathlib.Path(target["src_path"]).read_text()
           )
           if not tagged:
-              raise SystemExit("no benchmark carries `#[isa]`; this job has nothing to measure")
+              raise SystemExit("no benchmark carries `#[cpu_features]`; this job has nothing to measure")
           print("packages=" + " ".join(f"-p {name}" for name in dict.fromkeys(tagged)))
           EOF
       - name: Build benchmarks
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
-          VORTEX_BENCH_VARIANT: ${{ matrix.isa }}
-          VORTEX_BENCH_PREFIX: "${{ matrix.isa }}::"
+          VORTEX_BENCH_VARIANT: ${{ matrix.features }}
+          VORTEX_BENCH_PREFIX: "${{ matrix.features }}::"
         run: |
           cargo codspeed build --locked -m walltime --profile bench \
             ${{ steps.select.outputs.packages }}
@@ -194,8 +194,8 @@ jobs:
       # CodSpeed that way are compiled in here and divan would otherwise measure them.
       #
       # divan matches the filter's `::`-separated components against the benchmark path's,
-      # so this selects paths of the form `<bench target>::<isa>::<name>`. That middle
-      # component only exists because `#[isa]` puts it there: an untagged benchmark has one
+      # so this selects paths of the form `<bench target>::<features>::<name>`. That middle
+      # component only exists because `#[cpu_features]` puts it there: an untagged benchmark has one
       # component fewer and cannot match, whatever it is called.
       - name: Run benchmarks
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8  # v5
@@ -207,7 +207,7 @@ jobs:
           # sampling is close to free next to the minute-plus spent building it.
           DIVAN_SAMPLE_COUNT: "1000"
         with:
-          run: bash scripts/bench-taskset.sh cargo codspeed run -- '.*::${{ matrix.isa }}::'
+          run: bash scripts/bench-taskset.sh cargo codspeed run -- '.*::${{ matrix.features }}::'
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: "walltime"
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -33,7 +33,7 @@ jobs:
       pull-requests: read
     outputs:
       run-cuda-benchmarks: ${{ github.event_name != 'pull_request' || steps.filter.outputs.cuda == 'true' }}
-      run-arch-benchmarks: ${{ github.event_name != 'pull_request' || steps.filter.outputs.arch == 'true' }}
+      run-isa-benchmarks: ${{ github.event_name != 'pull_request' || steps.filter.outputs.isa == 'true' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4
@@ -45,9 +45,9 @@ jobs:
               - "vortex-cuda/**"
               # Only this workflow defines the CUDA benchmark jobs.
               - ".github/workflows/codspeed.yml"
-            arch:
-              # Sources of the benchmarks the per-architecture legs measure. Keep in sync
-              # with the `benches` entries in the bench-codspeed-arch matrix below.
+            isa:
+              # Sources of the benchmarks the per-instruction-set legs measure. Keep in sync
+              # with the `benches` entries in the bench-codspeed-isa matrix below.
               - "vortex-buffer/**"
               - "benchmarks/bench-support/**"
               - ".github/workflows/codspeed.yml"
@@ -100,40 +100,66 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: "simulation"
 
-  # Walltime measurements on real silicon, one leg per CPU architecture.
+  # Walltime measurements on real silicon, one leg per instruction set.
   #
   # The sharded job above measures simulated instruction counts on x86-64 only, which says
   # nothing about how a hand-written SIMD kernel performs, and nothing at all about Arm. A
-  # benchmark opts in by naming its instruction set with `#[isa(..)]`; the instruction sets
-  # of one architecture share that architecture's leg and are selected at runtime, so adding
-  # an AVX-512 benchmark needs no new leg here. VORTEX_BENCH_VARIANT selects the benchmarks
-  # for the leg and VORTEX_BENCH_PREFIX qualifies their names, so the two legs don't collide
-  # over the `#[isa(any)]` baselines they share.
-  bench-codspeed-arch:
+  # benchmark opts in by naming its instruction set with `#[isa(..)]`; each one is built with
+  # that instruction set enabled and run on silicon that has it, so a leg measures what its
+  # name says. VORTEX_BENCH_VARIANT selects the benchmarks for the leg and VORTEX_BENCH_PREFIX
+  # qualifies their names, so legs don't collide over the `#[isa(any)]` baselines they share.
+  #
+  # Each `isa` here must match a tag in `vortex_bench_support`'s ISA table, and each `runner`
+  # must name a machine that actually implements the instruction set: the build enables it
+  # globally, so surrounding code may use it and will fault on a machine that lacks it.
+  bench-codspeed-isa:
     needs: [changes]
     if: >-
       always() && github.repository == 'vortex-data/vortex' &&
-      needs.changes.outputs.run-arch-benchmarks == 'true'
+      needs.changes.outputs.run-isa-benchmarks == 'true'
     strategy:
       fail-fast: false
       matrix:
         include:
-          - leg: x86
+          # x86-64 baseline. `+sse2` is redundant — the target guarantees it — but spelled
+          # out so a leg's flags always say what it measures.
+          - isa: sse2
+            runner: amd64-medium
+            image: ubuntu24-full-x64-pre-v2
+            rustflags: "-C target-feature=+sse2"
+            packages: "vortex-buffer"
+            benches: "collect_bool"
+          - isa: avx2
             runner: amd64-medium
             image: ubuntu24-full-x64-pre-v2
             rustflags: "-C target-feature=+avx2"
             packages: "vortex-buffer"
             benches: "collect_bool"
-          - leg: arm
+          # Needs an AVX-512 capable runner.
+          - isa: avx512
+            runner: amd64-medium
+            image: ubuntu24-full-x64-pre-v2
+            rustflags: "-C target-feature=+avx512f,+avx512bw"
+            packages: "vortex-buffer"
+            benches: "collect_bool"
+          # aarch64 baseline. `+neon` is likewise redundant on this target.
+          - isa: neon
             runner: arm64-medium
             image: ubuntu24-full-arm64-pre-v2
             rustflags: "-C target-feature=+neon"
             packages: "vortex-buffer"
             benches: "collect_bool"
-    name: "Benchmark with Codspeed (${{ matrix.leg }})"
+          # Needs an SVE capable runner (Graviton3 or newer).
+          - isa: sve
+            runner: arm64-medium
+            image: ubuntu24-full-arm64-pre-v2
+            rustflags: "-C target-feature=+sve"
+            packages: "vortex-buffer"
+            benches: "collect_bool"
+    name: "Benchmark with Codspeed (${{ matrix.isa }})"
     timeout-minutes: 30
     runs-on: >-
-      runs-on=${{ github.run_id }}/runner=${{ matrix.runner }}/image=${{ matrix.image }}/extras=s3-cache/tag=bench-codspeed-arch-${{ matrix.leg }}
+      runs-on=${{ github.run_id }}/runner=${{ matrix.runner }}/image=${{ matrix.image }}/extras=s3-cache/tag=bench-codspeed-isa-${{ matrix.isa }}
     steps:
       - uses: runs-on/action@v2
         with:
@@ -150,8 +176,8 @@ jobs:
       - name: Build benchmarks
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
-          VORTEX_BENCH_VARIANT: ${{ matrix.leg }}
-          VORTEX_BENCH_PREFIX: "${{ matrix.leg }}::"
+          VORTEX_BENCH_VARIANT: ${{ matrix.isa }}
+          VORTEX_BENCH_PREFIX: "${{ matrix.isa }}::"
         run: |
           cargo codspeed build --locked -m walltime --profile bench \
             $(printf -- '-p %s ' ${{ matrix.packages }}) \

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -107,11 +107,13 @@ jobs:
   # benchmark opts in by naming its instruction set with `#[isa(..)]`; each one is built with
   # that instruction set enabled and run on silicon that has it, so a leg measures what its
   # name says. VORTEX_BENCH_VARIANT selects the benchmarks for the leg and VORTEX_BENCH_PREFIX
-  # qualifies their names, so legs don't collide over the `#[isa(any)]` baselines they share.
+  # qualifies their names, so legs don't collide over the `#[isa(all)]` baselines they share.
   #
-  # Each `isa` here must match a tag in `vortex_bench_support`'s ISA table, and each `runner`
+  # Each `isa` here must match a tag in `vortex_bench_support`'s ISA table, and each `family`
   # must name a machine that actually implements the instruction set: the build enables it
-  # globally, so surrounding code may use it and will fault on a machine that lacks it.
+  # globally, so surrounding code may use it and will fault on a machine that lacks it. These
+  # are metal instances, as the other walltime benchmark jobs use, so measurements are not
+  # taken through a hypervisor.
   bench-codspeed-isa:
     needs: [changes]
     if: >-
@@ -121,45 +123,33 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # x86-64 baseline. `+sse2` is redundant — the target guarantees it — but spelled
-          # out so a leg's flags always say what it measures.
-          - isa: sse2
-            runner: amd64-medium
-            image: ubuntu24-full-x64-pre-v2
-            rustflags: "-C target-feature=+sse2"
-            packages: "vortex-buffer"
-            benches: "collect_bool"
+          # avx2 and avx512 share a family so the only difference between the two series is
+          # the build flags, not the silicon. c7i.metal-24xl is the smaller of the two c7i
+          # metal sizes: current-generation Sapphire Rapids, and AVX-512 capable.
           - isa: avx2
-            runner: amd64-medium
+            family: c7i.metal-24xl
             image: ubuntu24-full-x64-pre-v2
             rustflags: "-C target-feature=+avx2"
             packages: "vortex-buffer"
             benches: "collect_bool"
-          # Needs an AVX-512 capable runner.
           - isa: avx512
-            runner: amd64-medium
+            family: c7i.metal-24xl
             image: ubuntu24-full-x64-pre-v2
             rustflags: "-C target-feature=+avx512f,+avx512bw"
             packages: "vortex-buffer"
             benches: "collect_bool"
-          # aarch64 baseline. `+neon` is likewise redundant on this target.
+          # Graviton3, the cheapest current-generation Arm metal. Graviton2 (c6g.metal) is
+          # cheaper still but predates SVE, so it cannot host a future SVE leg.
           - isa: neon
-            runner: arm64-medium
+            family: c7g.metal
             image: ubuntu24-full-arm64-pre-v2
             rustflags: "-C target-feature=+neon"
-            packages: "vortex-buffer"
-            benches: "collect_bool"
-          # Needs an SVE capable runner (Graviton3 or newer).
-          - isa: sve
-            runner: arm64-medium
-            image: ubuntu24-full-arm64-pre-v2
-            rustflags: "-C target-feature=+sve"
             packages: "vortex-buffer"
             benches: "collect_bool"
     name: "Benchmark with Codspeed (${{ matrix.isa }})"
     timeout-minutes: 30
     runs-on: >-
-      runs-on=${{ github.run_id }}/runner=${{ matrix.runner }}/image=${{ matrix.image }}/extras=s3-cache/tag=bench-codspeed-isa-${{ matrix.isa }}
+      runs-on=${{ github.run_id }}/runner=bench-dedicated/family=${{ matrix.family }}/image=${{ matrix.image }}/extras=s3-cache/tag=bench-codspeed-isa-${{ matrix.isa }}
     steps:
       - uses: runs-on/action@v2
         with:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -88,9 +88,9 @@ jobs:
       - name: Build benchmarks
         env:
           RUSTFLAGS: "-C target-feature=+avx2"
-          # Benchmarks gated with `ignore_unless_variant!` run their `simulation`-tagged
-          # subset here. The name prefix stays empty, so names measured before variants
-          # existed keep their CodSpeed history; only the walltime legs qualify names.
+          # Benchmarks carrying an `#[isa(..)]` tag belong to a walltime leg below and are
+          # skipped here. Untagged ones run as they always have, under bare names, so this
+          # job's CodSpeed history is unaffected.
           VORTEX_BENCH_VARIANT: simulation
         run: cargo codspeed build --locked ${{ matrix.features }} $(printf -- '-p %s ' ${{ matrix.packages }}) --profile bench
       - name: Run benchmarks
@@ -103,11 +103,12 @@ jobs:
   # Walltime measurements on real silicon, one leg per CPU architecture.
   #
   # The sharded job above measures simulated instruction counts on x86-64 only, which says
-  # nothing about how a hand-written SIMD kernel performs, and nothing at all about aarch64.
-  # Each leg here builds with its own target features and sets VORTEX_BENCH_VARIANT, which
-  # selects the benchmarks tagged for that architecture, and VORTEX_BENCH_PREFIX, which
-  # qualifies their names so the two legs don't collide over the architecture-neutral
-  # baselines they share.
+  # nothing about how a hand-written SIMD kernel performs, and nothing at all about Arm. A
+  # benchmark opts in by naming its instruction set with `#[isa(..)]`; the instruction sets
+  # of one architecture share that architecture's leg and are selected at runtime, so adding
+  # an AVX-512 benchmark needs no new leg here. VORTEX_BENCH_VARIANT selects the benchmarks
+  # for the leg and VORTEX_BENCH_PREFIX qualifies their names, so the two legs don't collide
+  # over the `#[isa(any)]` baselines they share.
   bench-codspeed-arch:
     needs: [changes]
     if: >-
@@ -117,13 +118,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - leg: x86_64
+          - leg: x86
             runner: amd64-medium
             image: ubuntu24-full-x64-pre-v2
             rustflags: "-C target-feature=+avx2"
             packages: "vortex-buffer"
             benches: "collect_bool"
-          - leg: aarch64
+          - leg: arm
             runner: arm64-medium
             image: ubuntu24-full-arm64-pre-v2
             rustflags: "-C target-feature=+neon"

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -93,20 +93,7 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: "simulation"
 
-  # Walltime measurements on real silicon, one leg per CPU feature set.
-  #
-  # The sharded job above measures simulated instruction counts on one x86-64 build. That
-  # says nothing about code whose machine code depends on the features it was compiled for,
-  # and nothing at all about Arm. A benchmark opts in with `#[cpu_features]` and is then
-  # built and measured once per leg here. VORTEX_BENCH_VARIANT takes those benchmarks out of
-  # the sharded job and VORTEX_BENCH_PREFIX qualifies their names, so each leg reports its
-  # own series rather than the legs fighting over a shared one.
-  #
-  # This matrix is the only place the legs are named — the attribute carries no leg list, so
-  # adding one is a change here alone. Each `family` must implement the features its leg
-  # enables: they are enabled globally, so surrounding code may use them and will fault on a
-  # machine that lacks them. These are metal instances, as the other walltime benchmark jobs
-  # use, so measurements are not taken through a hypervisor.
+  # Walltime on metal for benchmarks marked `#[cpu_features]`, one leg per feature set. A leg's `family` must implement the features it enables, which are enabled globally.
   bench-codspeed-cpu-features:
     if: github.repository == 'vortex-data/vortex'
     strategy:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -165,16 +165,18 @@ jobs:
       # spawns processes that would otherwise be pinned to the housekeeping CPUs.
       - name: Setup benchmark environment
         run: sudo bash scripts/setup-benchmark.sh
-      # The trailing filter is what keeps a leg to its own benchmarks. Unlike a simulation
-      # build, a walltime one does not set `--cfg codspeed`, so benchmarks excluded from
-      # CodSpeed that way are compiled in here and divan would measure them — under bare
-      # names, which every leg would then upload to the same series. `#[isa]` puts the leg
-      # tag in the name of every benchmark it owns, so filtering on it selects exactly
-      # those; the per-leg `ignore` still applies on top.
+      # The trailing filter is what keeps a leg to the tagged benchmarks. Unlike a simulation
+      # build, a walltime one does not set `--cfg codspeed`, so benchmarks kept out of
+      # CodSpeed that way are compiled in here and divan would otherwise measure them.
+      #
+      # divan matches the filter's `::`-separated components against the benchmark path's,
+      # so this selects paths of the form `<bench target>::<isa>::<name>`. That middle
+      # component only exists because `#[isa]` puts it there: an untagged benchmark has one
+      # component fewer and cannot match, whatever it is called.
       - name: Run benchmarks
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8  # v5
         with:
-          run: bash scripts/bench-taskset.sh cargo codspeed run -- '${{ matrix.isa }}::'
+          run: bash scripts/bench-taskset.sh cargo codspeed run -- '.*::${{ matrix.isa }}::'
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: "walltime"
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -33,7 +33,6 @@ jobs:
       pull-requests: read
     outputs:
       run-cuda-benchmarks: ${{ github.event_name != 'pull_request' || steps.filter.outputs.cuda == 'true' }}
-      run-isa-benchmarks: ${{ github.event_name != 'pull_request' || steps.filter.outputs.isa == 'true' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4
@@ -44,12 +43,6 @@ jobs:
             cuda:
               - "vortex-cuda/**"
               # Only this workflow defines the CUDA benchmark jobs.
-              - ".github/workflows/codspeed.yml"
-            isa:
-              # Sources of the benchmarks the per-instruction-set legs measure. Keep in sync
-              # with the `benches` entries in the bench-codspeed-isa matrix below.
-              - "vortex-buffer/**"
-              - "benchmarks/bench-support/**"
               - ".github/workflows/codspeed.yml"
 
   bench-codspeed:
@@ -115,10 +108,7 @@ jobs:
   # are metal instances, as the other walltime benchmark jobs use, so measurements are not
   # taken through a hypervisor.
   bench-codspeed-isa:
-    needs: [changes]
-    if: >-
-      always() && github.repository == 'vortex-data/vortex' &&
-      needs.changes.outputs.run-isa-benchmarks == 'true'
+    if: github.repository == 'vortex-data/vortex'
     strategy:
       fail-fast: false
       matrix:
@@ -130,24 +120,18 @@ jobs:
             family: c7i.metal-24xl
             image: ubuntu24-full-x64-pre-v2
             rustflags: "-C target-feature=+avx2"
-            packages: "vortex-buffer"
-            benches: "collect_bool"
           - isa: avx512
             family: c7i.metal-24xl
             image: ubuntu24-full-x64-pre-v2
             rustflags: "-C target-feature=+avx512f,+avx512bw"
-            packages: "vortex-buffer"
-            benches: "collect_bool"
           # Graviton3, the cheapest current-generation Arm metal. Graviton2 (c6g.metal) is
           # cheaper still but predates SVE, so it cannot host a future SVE leg.
           - isa: neon
             family: c7g.metal
             image: ubuntu24-full-arm64-pre-v2
             rustflags: "-C target-feature=+neon"
-            packages: "vortex-buffer"
-            benches: "collect_bool"
     name: "Benchmark with Codspeed (${{ matrix.isa }})"
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: >-
       runs-on=${{ github.run_id }}/runner=bench-dedicated/family=${{ matrix.family }}/image=${{ matrix.image }}/extras=s3-cache/tag=bench-codspeed-isa-${{ matrix.isa }}
     steps:
@@ -168,10 +152,14 @@ jobs:
           RUSTFLAGS: ${{ matrix.rustflags }}
           VORTEX_BENCH_VARIANT: ${{ matrix.isa }}
           VORTEX_BENCH_PREFIX: "${{ matrix.isa }}::"
+        # Every benchmark in the workspace, so a crate that adds an `#[isa]` benchmark is
+        # picked up without editing this matrix. The filter on the run step is what keeps
+        # the leg to the tagged ones, so building more costs build time and nothing else.
+        # vortex-cuda needs a CUDA toolchain and vortex-duckdb a DuckDB build; neither is
+        # present here, and the sharded job leaves them out for the same reason.
         run: |
           cargo codspeed build --locked -m walltime --profile bench \
-            $(printf -- '-p %s ' ${{ matrix.packages }}) \
-            $(printf -- '--bench %s ' ${{ matrix.benches }})
+            --workspace --exclude vortex-cuda --exclude vortex-duckdb
       # Pinning clocks and reserving CPUs only pays off for walltime measurements, so this
       # runs here but not in the simulation job. It must come after setup, which itself
       # spawns processes that would otherwise be pinned to the housekeeping CPUs.

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -33,6 +33,7 @@ jobs:
       pull-requests: read
     outputs:
       run-cuda-benchmarks: ${{ github.event_name != 'pull_request' || steps.filter.outputs.cuda == 'true' }}
+      run-arch-benchmarks: ${{ github.event_name != 'pull_request' || steps.filter.outputs.arch == 'true' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4
@@ -43,6 +44,12 @@ jobs:
             cuda:
               - "vortex-cuda/**"
               # Only this workflow defines the CUDA benchmark jobs.
+              - ".github/workflows/codspeed.yml"
+            arch:
+              # Sources of the benchmarks the per-architecture legs measure. Keep in sync
+              # with the `benches` entries in the bench-codspeed-arch matrix below.
+              - "vortex-buffer/**"
+              - "benchmarks/bench-support/**"
               - ".github/workflows/codspeed.yml"
 
   bench-codspeed:
@@ -81,6 +88,10 @@ jobs:
       - name: Build benchmarks
         env:
           RUSTFLAGS: "-C target-feature=+avx2"
+          # Benchmarks gated with `ignore_unless_variant!` run their `simulation`-tagged
+          # subset here. The name prefix stays empty, so names measured before variants
+          # existed keep their CodSpeed history; only the walltime legs qualify names.
+          VORTEX_BENCH_VARIANT: simulation
         run: cargo codspeed build --locked ${{ matrix.features }} $(printf -- '-p %s ' ${{ matrix.packages }}) --profile bench
       - name: Run benchmarks
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8  # v5
@@ -88,6 +99,73 @@ jobs:
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: "simulation"
+
+  # Walltime measurements on real silicon, one leg per CPU architecture.
+  #
+  # The sharded job above measures simulated instruction counts on x86-64 only, which says
+  # nothing about how a hand-written SIMD kernel performs, and nothing at all about aarch64.
+  # Each leg here builds with its own target features and sets VORTEX_BENCH_VARIANT, which
+  # selects the benchmarks tagged for that architecture, and VORTEX_BENCH_PREFIX, which
+  # qualifies their names so the two legs don't collide over the architecture-neutral
+  # baselines they share.
+  bench-codspeed-arch:
+    needs: [changes]
+    if: >-
+      always() && github.repository == 'vortex-data/vortex' &&
+      needs.changes.outputs.run-arch-benchmarks == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - leg: x86_64
+            runner: amd64-medium
+            image: ubuntu24-full-x64-pre-v2
+            rustflags: "-C target-feature=+avx2"
+            packages: "vortex-buffer"
+            benches: "collect_bool"
+          - leg: aarch64
+            runner: arm64-medium
+            image: ubuntu24-full-arm64-pre-v2
+            rustflags: "-C target-feature=+neon"
+            packages: "vortex-buffer"
+            benches: "collect_bool"
+    name: "Benchmark with Codspeed (${{ matrix.leg }})"
+    timeout-minutes: 30
+    runs-on: >-
+      runs-on=${{ github.run_id }}/runner=${{ matrix.runner }}/image=${{ matrix.image }}/extras=s3-cache/tag=bench-codspeed-arch-${{ matrix.leg }}
+    steps:
+      - uses: runs-on/action@v2
+        with:
+          sccache: s3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: ./.github/actions/setup-prebuild
+        with:
+          enable-sccache: "true"
+      - uses: ./.github/actions/system-info
+      - name: Install Codspeed
+        uses: taiki-e/cache-cargo-install-action@66c9585ef5ca780ee69399975a5e911f47905995
+        with:
+          tool: cargo-codspeed
+      - name: Build benchmarks
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+          VORTEX_BENCH_VARIANT: ${{ matrix.leg }}
+          VORTEX_BENCH_PREFIX: "${{ matrix.leg }}::"
+        run: |
+          cargo codspeed build --locked -m walltime --profile bench \
+            $(printf -- '-p %s ' ${{ matrix.packages }}) \
+            $(printf -- '--bench %s ' ${{ matrix.benches }})
+      # Pinning clocks and reserving CPUs only pays off for walltime measurements, so this
+      # runs here but not in the simulation job. It must come after setup, which itself
+      # spawns processes that would otherwise be pinned to the housekeeping CPUs.
+      - name: Setup benchmark environment
+        run: sudo bash scripts/setup-benchmark.sh
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8  # v5
+        with:
+          run: bash scripts/bench-taskset.sh cargo codspeed run
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          mode: "walltime"
 
   # Getting a GPU box is slow, in the future we can build on a box without one and only run
   # on GPU machines.

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -193,6 +193,13 @@ jobs:
       # component fewer and cannot match, whatever it is called.
       - name: Run benchmarks
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8  # v5
+        env:
+          # divan's default of 100 samples leaves these benchmarks too noisy to compare
+          # across runs: the same commit measured twice varied by up to 2.2x on the 1,024
+          # element cases and ~50-70% on the 65,536 element ones. At 1,000 samples the same
+          # experiment stays within ~6-10%, and the suite still runs in seconds, so the extra
+          # sampling is close to free next to the minute-plus spent building it.
+          DIVAN_SAMPLE_COUNT: "1000"
         with:
           run: bash scripts/bench-taskset.sh cargo codspeed run -- '.*::${{ matrix.isa }}::'
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -95,18 +95,18 @@ jobs:
 
   # Walltime measurements on real silicon, one leg per instruction set.
   #
-  # The sharded job above measures simulated instruction counts on x86-64 only, which says
-  # nothing about how a hand-written SIMD kernel performs, and nothing at all about Arm. A
-  # benchmark opts in by naming its instruction set with `#[isa(..)]`; each one is built with
-  # that instruction set enabled and run on silicon that has it, so a leg measures what its
-  # name says. VORTEX_BENCH_VARIANT selects the benchmarks for the leg and VORTEX_BENCH_PREFIX
-  # qualifies their names, so legs don't collide over the `#[isa(all)]` baselines they share.
+  # The sharded job above measures simulated instruction counts on one x86-64 build. That
+  # says nothing about code whose machine code depends on the instruction set it was compiled
+  # for, and nothing at all about Arm. A benchmark opts in with `#[isa]` and is then built
+  # and measured once per leg here. VORTEX_BENCH_VARIANT takes those benchmarks out of the
+  # sharded job and VORTEX_BENCH_PREFIX qualifies their names, so each leg reports its own
+  # series rather than the legs fighting over a shared one.
   #
-  # Each `isa` here must match a tag in `vortex_bench_support`'s ISA table, and each `family`
-  # must name a machine that actually implements the instruction set: the build enables it
-  # globally, so surrounding code may use it and will fault on a machine that lacks it. These
-  # are metal instances, as the other walltime benchmark jobs use, so measurements are not
-  # taken through a hypervisor.
+  # This matrix is the only place the legs are named — `#[isa]` carries no leg list, so
+  # adding one is a change here alone. Each `family` must implement its instruction set: the
+  # build enables it globally, so surrounding code may use it and will fault on a machine
+  # that lacks it. These are metal instances, as the other walltime benchmark jobs use, so
+  # measurements are not taken through a hypervisor.
   bench-codspeed-isa:
     if: github.repository == 'vortex-data/vortex'
     strategy:
@@ -133,7 +133,7 @@ jobs:
     name: "Benchmark with Codspeed (${{ matrix.isa }})"
     timeout-minutes: 60
     runs-on: >-
-      runs-on=${{ github.run_id }}/runner=bench-dedicated/family=${{ matrix.family }}/image=${{ matrix.image }}/extras=s3-cache/tag=bench-codspeed-isa-${{ matrix.isa }}
+      runs-on=${{ github.run_id }}/runner=bench-dedicated/family=${{ matrix.family }}/image=${{ matrix.image }}/disk=large/extras=s3-cache/tag=bench-codspeed-isa-${{ matrix.isa }}
     steps:
       - uses: runs-on/action@v2
         with:
@@ -147,19 +147,37 @@ jobs:
         uses: taiki-e/cache-cargo-install-action@66c9585ef5ca780ee69399975a5e911f47905995
         with:
           tool: cargo-codspeed
+      # Which packages to build is derived from the source rather than listed here, so a
+      # crate that adds an `#[isa]` benchmark is picked up without editing this workflow.
+      # Building the whole workspace would do the same, but links every bench binary in it
+      # — with debuginfo, from the bench profile — to measure only the tagged ones.
+      - name: Select packages with tagged benchmarks
+        id: select
+        run: |
+          python3 - <<'EOF' >> "$GITHUB_OUTPUT"
+          import json, pathlib, subprocess
+
+          meta = json.loads(subprocess.check_output(
+              ["cargo", "metadata", "--no-deps", "--format-version", "1"]))
+          tagged = sorted(
+              package["name"]
+              for package in meta["packages"]
+              for target in package["targets"]
+              if "bench" in target["kind"]
+              and "#[isa]" in pathlib.Path(target["src_path"]).read_text()
+          )
+          if not tagged:
+              raise SystemExit("no benchmark carries `#[isa]`; this job has nothing to measure")
+          print("packages=" + " ".join(f"-p {name}" for name in dict.fromkeys(tagged)))
+          EOF
       - name: Build benchmarks
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
           VORTEX_BENCH_VARIANT: ${{ matrix.isa }}
           VORTEX_BENCH_PREFIX: "${{ matrix.isa }}::"
-        # Every benchmark in the workspace, so a crate that adds an `#[isa]` benchmark is
-        # picked up without editing this matrix. The filter on the run step is what keeps
-        # the leg to the tagged ones, so building more costs build time and nothing else.
-        # vortex-cuda needs a CUDA toolchain and vortex-duckdb a DuckDB build; neither is
-        # present here, and the sharded job leaves them out for the same reason.
         run: |
           cargo codspeed build --locked -m walltime --profile bench \
-            --workspace --exclude vortex-cuda --exclude vortex-duckdb
+            ${{ steps.select.outputs.packages }}
       # Pinning clocks and reserving CPUs only pays off for walltime measurements, so this
       # runs here but not in the simulation job. It must come after setup, which itself
       # spawns processes that would otherwise be pinned to the housekeeping CPUs.

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -120,10 +120,16 @@ jobs:
             family: c7i.metal-24xl
             image: ubuntu24-full-x64-pre-v2
             rustflags: "-C target-feature=+avx2"
+          # Every AVX-512 extension Sapphire Rapids implements, not just the two the current
+          # `cfg(target_feature)` gates test for. Those gates decide which kernel the code
+          # under test selects, but the rest of the build — anything the compiler
+          # auto-vectorizes, the scalar baselines included — sees the whole feature set, and
+          # a two-feature build is not what anything ships on.
           - isa: avx512
             family: c7i.metal-24xl
             image: ubuntu24-full-x64-pre-v2
-            rustflags: "-C target-feature=+avx512f,+avx512bw"
+            rustflags: >-
+              -C target-feature=+avx512f,+avx512bw,+avx512cd,+avx512dq,+avx512vl,+avx512ifma,+avx512vbmi,+avx512vbmi2,+avx512vnni,+avx512bitalg,+avx512vpopcntdq,+avx512bf16,+avx512fp16
           # Graviton3, the cheapest current-generation Arm metal. Graviton2 (c6g.metal) is
           # cheaper still but predates SVE, so it cannot host a future SVE leg.
           - isa: neon

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -177,10 +177,16 @@ jobs:
       # spawns processes that would otherwise be pinned to the housekeeping CPUs.
       - name: Setup benchmark environment
         run: sudo bash scripts/setup-benchmark.sh
+      # The trailing filter is what keeps a leg to its own benchmarks. Unlike a simulation
+      # build, a walltime one does not set `--cfg codspeed`, so benchmarks excluded from
+      # CodSpeed that way are compiled in here and divan would measure them — under bare
+      # names, which every leg would then upload to the same series. `#[isa]` puts the leg
+      # tag in the name of every benchmark it owns, so filtering on it selects exactly
+      # those; the per-leg `ignore` still applies on top.
       - name: Run benchmarks
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8  # v5
         with:
-          run: bash scripts/bench-taskset.sh cargo codspeed run
+          run: bash scripts/bench-taskset.sh cargo codspeed run -- '${{ matrix.isa }}::'
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: "walltime"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9741,6 +9741,11 @@ dependencies = [
 [[package]]
 name = "vortex-bench-support"
 version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "vortex-btrblocks"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9739,6 +9739,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "vortex-bench-support"
+version = "0.1.0"
+
+[[package]]
 name = "vortex-btrblocks"
 version = "0.1.0"
 dependencies = [
@@ -9789,6 +9793,7 @@ dependencies = [
  "serde",
  "simdutf8",
  "tracing",
+ "vortex-bench-support",
  "vortex-error",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
     "encodings/parquet-variant",
     "encodings/onpair",
     # Benchmarks
+    "benchmarks/bench-support",
     "benchmarks/lance-bench",
     "benchmarks/compress-bench",
     "benchmarks/datafusion-bench",
@@ -335,6 +336,7 @@ vortex-zstd = { version = "0.1.0", path = "./encodings/zstd", default-features =
 
 # No version constraints for unpublished crates.
 vortex-bench = { path = "./vortex-bench", default-features = false }
+vortex-bench-support = { path = "./benchmarks/bench-support" }
 vortex-cuda = { path = "./vortex-cuda", default-features = false }
 vortex-cuda-macros = { path = "./vortex-cuda/macros" }
 vortex-duckdb = { path = "./vortex-duckdb", default-features = false }

--- a/benchmarks/bench-support/Cargo.toml
+++ b/benchmarks/bench-support/Cargo.toml
@@ -1,20 +1,26 @@
 [package]
 name = "vortex-bench-support"
-description = "Shared support code for Vortex benchmark binaries"
-authors.workspace = true
-categories.workspace = true
-edition.workspace = true
-homepage.workspace = true
-include.workspace = true
-keywords.workspace = true
-license.workspace = true
-readme.workspace = true
-repository.workspace = true
-rust-version.workspace = true
-version.workspace = true
+description = "Proc macros for gating Vortex benchmarks by CPU architecture and instruction set"
+authors = { workspace = true }
+categories = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+include = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
 publish = false
-
-[dependencies]
 
 [lints]
 workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }

--- a/benchmarks/bench-support/Cargo.toml
+++ b/benchmarks/bench-support/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "vortex-bench-support"
+description = "Shared support code for Vortex benchmark binaries"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+include.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/benchmarks/bench-support/src/lib.rs
+++ b/benchmarks/bench-support/src/lib.rs
@@ -11,6 +11,9 @@
 //! One leg per instruction set, so what a leg measures is what its name says: an AVX-512
 //! benchmark is compiled `+avx512f,+avx512bw` and run on an AVX-512 machine, not compiled
 //! for AVX2 and steered into an AVX-512 kernel at runtime.
+//!
+//! Simulation stays the default. Only a benchmark that names an instruction set leaves the
+//! sharded job, so this costs nothing for the benchmarks that have no reason to care.
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
@@ -30,10 +33,6 @@ struct Isa {
 
 const ISAS: &[Isa] = &[
     Isa {
-        tag: "sse2",
-        target_arch: "x86_64",
-    },
-    Isa {
         tag: "avx2",
         target_arch: "x86_64",
     },
@@ -45,18 +44,14 @@ const ISAS: &[Isa] = &[
         tag: "neon",
         target_arch: "aarch64",
     },
-    Isa {
-        tag: "sve",
-        target_arch: "aarch64",
-    },
 ];
 
 /// Resolve the argument of `#[isa(..)]` to the legs that measure the benchmark.
 ///
-/// `any` is the arch-neutral case — a scalar baseline, or a shipped entry point — measured on
+/// `all` is the arch-neutral case — a scalar baseline, or a shipped entry point — measured on
 /// every leg, so each build has something of its own to compare its kernels against.
 fn legs_for(isa: &str) -> Option<Vec<&'static Isa>> {
-    if isa == "any" {
+    if isa == "all" {
         return Some(ISAS.iter().collect());
     }
     ISAS.iter().find(|leg| leg.tag == isa).map(|leg| vec![leg])
@@ -74,13 +69,14 @@ fn legs_for(isa: &str) -> Option<Vec<&'static Isa>> {
 /// fn words_gather_avx2(bencher: Bencher, len: usize) { /* ... */ }
 /// ```
 ///
-/// Accepts `sse2`, `avx2`, `avx512`, `neon`, `sve`, and `any` for benchmarks that are not
-/// tied to an instruction set. The `#[cfg(target_arch = ...)]` is implied — an `avx2`
-/// benchmark cannot compile for Arm, so writing that out would only create a chance for it
-/// to disagree with the tag.
+/// Accepts `avx2`, `avx512`, `neon`, and `all` for benchmarks that are not tied to an
+/// instruction set. The `#[cfg(target_arch = ...)]` is implied — an `avx2` benchmark cannot
+/// compile for Arm, so writing that out would only create a chance for it to disagree with
+/// the tag.
 ///
-/// An untagged benchmark is untouched: it keeps running on the simulation shards under its
-/// own name, which is the right home for anything that is not architecture-specific.
+/// Simulation is the default: an untagged benchmark is untouched and keeps running on the
+/// sharded CodSpeed job under its own name, which is the right home for anything that is
+/// not specific to an instruction set.
 #[proc_macro_attribute]
 pub fn isa(attr: TokenStream, item: TokenStream) -> TokenStream {
     let isa = parse_macro_input!(attr as Ident);
@@ -94,7 +90,7 @@ pub fn isa(attr: TokenStream, item: TokenStream) -> TokenStream {
             .join(", ");
         return syn::Error::new(
             isa.span(),
-            format!("unknown instruction set `{isa}`; expected one of {known}, any"),
+            format!("unknown instruction set `{isa}`; expected one of {known}, all"),
         )
         .to_compile_error()
         .into();

--- a/benchmarks/bench-support/src/lib.rs
+++ b/benchmarks/bench-support/src/lib.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Support for benchmarks measured once per CPU instruction set.
+//! Support for benchmarks measured once per CPU feature set.
 //!
-//! One attribute, [`isa`]. Which instruction sets exist, what each is built with, and where
-//! it runs are all in `.github/workflows/codspeed.yml`.
+//! One attribute, [`cpu_features`]. Which feature sets exist, what each is built with, and
+//! where it runs are all in `.github/workflows/codspeed.yml`.
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
@@ -12,7 +12,7 @@ use quote::quote;
 use syn::ItemFn;
 use syn::parse_macro_input;
 
-/// Measure this benchmark on every walltime instruction-set leg instead of in simulation.
+/// Measure this benchmark on every walltime CPU-feature leg instead of in simulation.
 ///
 /// Takes no argument: the benchmark runs on all of them. Write it *above* `#[divan::bench]`,
 /// whose arguments it fills in — the name is qualified with the leg that produced it, so the
@@ -21,23 +21,26 @@ use syn::parse_macro_input;
 /// under its bare name.
 ///
 /// ```ignore
-/// #[isa]
+/// #[vortex_bench_support::cpu_features]
 /// #[divan::bench(args = INPUT_SIZE)]
 /// fn words_gather_dispatch(bencher: Bencher, len: usize) { /* ... */ }
 /// ```
 ///
-/// This is for code that is written once and *compiled* differently per instruction set —
-/// a shipped entry point that selects its kernel through `cfg(target_feature)`, or a scalar
+/// Spell it out in full rather than importing it: benchmark files are read a function at a
+/// time, and the path says where the behaviour comes from.
+///
+/// This is for code that is written once and *compiled* differently per feature set — a
+/// shipped entry point that selects its kernel through `cfg(target_feature)`, or a scalar
 /// loop whose auto-vectorization depends on the build. A hand-written kernel for one
-/// instruction set is a different thing: it cannot run on the other legs, so it does not
-/// belong here. Keep those on `#[cfg(not(codspeed))]` for local A/B runs.
+/// instruction set extension is a different thing: it cannot run on the other legs, so it
+/// does not belong here. Keep those on `#[cfg(not(codspeed))]` for local A/B runs.
 #[proc_macro_attribute]
-pub fn isa(attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn cpu_features(attr: TokenStream, item: TokenStream) -> TokenStream {
     if !attr.is_empty() {
         let attr = TokenStream2::from(attr);
         return syn::Error::new_spanned(
             attr,
-            "`#[isa]` takes no argument; a tagged benchmark runs on every instruction-set leg",
+            "`#[cpu_features]` takes no argument; a tagged benchmark runs on every feature-set leg",
         )
         .to_compile_error()
         .into();
@@ -53,7 +56,7 @@ pub fn isa(attr: TokenStream, item: TokenStream) -> TokenStream {
     }) else {
         return syn::Error::new(
             proc_macro2::Span::call_site(),
-            "`#[isa]` must be written directly above the `#[divan::bench]` attribute it applies to",
+            "`#[cpu_features]` must be written directly above the `#[divan::bench]` it applies to",
         )
         .to_compile_error()
         .into();
@@ -80,7 +83,9 @@ pub fn isa(attr: TokenStream, item: TokenStream) -> TokenStream {
         {
             return syn::Error::new_spanned(
                 &existing,
-                format!("`{reserved}` is set by `#[isa]`; remove it from `#[divan::bench]`"),
+                format!(
+                    "`{reserved}` is set by `#[cpu_features]`; remove it from `#[divan::bench]`"
+                ),
             )
             .to_compile_error()
             .into();

--- a/benchmarks/bench-support/src/lib.rs
+++ b/benchmarks/bench-support/src/lib.rs
@@ -5,8 +5,12 @@
 //!
 //! CodSpeed's sharded job measures simulated instruction counts on x86-64. That says little
 //! about a hand-written SIMD kernel and nothing at all about Arm. [`isa`] marks a benchmark
-//! as belonging to one instruction set, which routes it to a walltime CI leg running on that
-//! architecture's silicon.
+//! as belonging to one instruction set, which routes it to the CI leg that builds with that
+//! instruction set enabled and measures walltime on silicon that has it.
+//!
+//! One leg per instruction set, so what a leg measures is what its name says: an AVX-512
+//! benchmark is compiled `+avx512f,+avx512bw` and run on an AVX-512 machine, not compiled
+//! for AVX2 and steered into an AVX-512 kernel at runtime.
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
@@ -15,38 +19,50 @@ use syn::Ident;
 use syn::ItemFn;
 use syn::parse_macro_input;
 
-/// The architecture leg an instruction set belongs to.
-struct Leg {
-    /// Variant tag, matched against `VORTEX_BENCH_VARIANT`.
-    variant: &'static str,
-    /// `target_arch` the instruction set exists on.
+/// An instruction set, and so a CI leg: one build, one walltime run.
+struct Isa {
+    /// Leg tag, matched against `VORTEX_BENCH_VARIANT` and used to qualify benchmark names.
+    /// Every tag here needs a matching entry in `.github/workflows/codspeed.yml`.
+    tag: &'static str,
+    /// The `target_arch` this instruction set exists on.
     target_arch: &'static str,
 }
 
-const X86: Leg = Leg {
-    variant: "x86",
-    target_arch: "x86_64",
-};
-const ARM: Leg = Leg {
-    variant: "arm",
-    target_arch: "aarch64",
-};
+const ISAS: &[Isa] = &[
+    Isa {
+        tag: "sse2",
+        target_arch: "x86_64",
+    },
+    Isa {
+        tag: "avx2",
+        target_arch: "x86_64",
+    },
+    Isa {
+        tag: "avx512",
+        target_arch: "x86_64",
+    },
+    Isa {
+        tag: "neon",
+        target_arch: "aarch64",
+    },
+    Isa {
+        tag: "sve",
+        target_arch: "aarch64",
+    },
+];
 
-/// Resolve an instruction set to the legs that measure it.
+/// Resolve the argument of `#[isa(..)]` to the legs that measure the benchmark.
 ///
-/// `any` is the arch-neutral case: a scalar baseline or a shipped entry point, measured on
-/// every leg so each architecture has something to compare its kernels against. Everything
-/// else names one instruction set and so implies exactly one architecture.
-fn legs_for(isa: &str) -> Option<Vec<Leg>> {
-    match isa {
-        "sse2" | "avx2" | "avx512" => Some(vec![X86]),
-        "neon" | "sve" => Some(vec![ARM]),
-        "any" => Some(vec![X86, ARM]),
-        _ => None,
+/// `any` is the arch-neutral case — a scalar baseline, or a shipped entry point — measured on
+/// every leg, so each build has something of its own to compare its kernels against.
+fn legs_for(isa: &str) -> Option<Vec<&'static Isa>> {
+    if isa == "any" {
+        return Some(ISAS.iter().collect());
     }
+    ISAS.iter().find(|leg| leg.tag == isa).map(|leg| vec![leg])
 }
 
-/// Measure this benchmark on the CI leg for the given instruction set.
+/// Measure this benchmark on the CI leg that builds for the given instruction set.
 ///
 /// Must sit *above* `#[divan::bench]`, whose arguments it fills in: the benchmark's name is
 /// qualified with the leg that produced it, and `ignore` is set so the benchmark is skipped
@@ -58,10 +74,10 @@ fn legs_for(isa: &str) -> Option<Vec<Leg>> {
 /// fn words_gather_avx2(bencher: Bencher, len: usize) { /* ... */ }
 /// ```
 ///
-/// Accepts `sse2`, `avx2`, `avx512`, `neon`, `sve`, and `any` for benchmarks that are not tied
-/// to an instruction set. The `#[cfg(target_arch = ...)]` is implied — an `avx2` benchmark cannot
-/// compile for Arm, so writing that out would only create a chance for it to disagree with
-/// the tag.
+/// Accepts `sse2`, `avx2`, `avx512`, `neon`, `sve`, and `any` for benchmarks that are not
+/// tied to an instruction set. The `#[cfg(target_arch = ...)]` is implied — an `avx2`
+/// benchmark cannot compile for Arm, so writing that out would only create a chance for it
+/// to disagree with the tag.
 ///
 /// An untagged benchmark is untouched: it keeps running on the simulation shards under its
 /// own name, which is the right home for anything that is not architecture-specific.
@@ -71,11 +87,14 @@ pub fn isa(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut function = parse_macro_input!(item as ItemFn);
 
     let Some(legs) = legs_for(&isa.to_string()) else {
+        let known = ISAS
+            .iter()
+            .map(|leg| leg.tag)
+            .collect::<Vec<_>>()
+            .join(", ");
         return syn::Error::new(
             isa.span(),
-            format!(
-                "unknown instruction set `{isa}`; expected one of sse2, avx2, avx512, neon, sve, any"
-            ),
+            format!("unknown instruction set `{isa}`; expected one of {known}, any"),
         )
         .to_compile_error()
         .into();
@@ -124,10 +143,12 @@ pub fn isa(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     // `env!` rather than reading the environment during expansion: rustc records it as a
-    // dependency of the crate, so changing the variant rebuilds the benchmark.
+    // dependency of the crate, so changing legs rebuilds the benchmarks.
     let name = function.sig.ident.to_string();
-    let variants = legs.iter().map(|leg| leg.variant);
-    let arches = legs.iter().map(|leg| leg.target_arch);
+    let tags = legs.iter().map(|leg| leg.tag);
+
+    let mut arches: Vec<&str> = legs.iter().map(|leg| leg.target_arch).collect();
+    arches.dedup();
 
     let separator = if existing.is_empty() {
         quote!()
@@ -140,8 +161,8 @@ pub fn isa(attr: TokenStream, item: TokenStream) -> TokenStream {
             #existing #separator
             name = concat!(env!("VORTEX_BENCH_PREFIX"), #name),
             ignore = {
-                let variant = env!("VORTEX_BENCH_VARIANT");
-                !(variant == "local" #(|| variant == #variants)*)
+                let leg = env!("VORTEX_BENCH_VARIANT");
+                !(leg == "local" #(|| leg == #tags)*)
             },
         )
     };

--- a/benchmarks/bench-support/src/lib.rs
+++ b/benchmarks/bench-support/src/lib.rs
@@ -1,21 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Instruction-set gating for Vortex benchmarks.
+//! Support for benchmarks measured once per CPU instruction set.
 //!
-//! CodSpeed's sharded job measures simulated instruction counts on one x86-64 build. That
-//! says little about code whose machine code depends on the instruction set it was compiled
-//! for, and nothing at all about Arm. [`isa`] moves a benchmark off that job and onto the
-//! walltime legs, which build the same source once per instruction set — `+avx2`, `+avx512`,
-//! `+neon` — and measure each on silicon that implements it.
-//!
-//! Simulation is the default. An untagged benchmark is untouched and keeps running on the
-//! sharded job under its own name, which is where anything not sensitive to the instruction
-//! set belongs.
-//!
-//! The legs themselves live in `.github/workflows/codspeed.yml` and nowhere else. A tagged
-//! benchmark runs on every leg in that matrix, so adding one is a workflow change with no
-//! counterpart here.
+//! One attribute, [`isa`]. Which instruction sets exist, what each is built with, and where
+//! it runs are all in `.github/workflows/codspeed.yml`.
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;

--- a/benchmarks/bench-support/src/lib.rs
+++ b/benchmarks/bench-support/src/lib.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Shared support code for Vortex benchmark binaries.
+//!
+//! # Benchmark variants
+//!
+//! A *variant* names the build a benchmark binary was produced for. A benchmark that only
+//! makes sense under one CPU architecture, or that is too noisy for one instrument but not
+//! another, declares the variants it should be measured under; everywhere else it is skipped
+//! rather than compiled out, so a single bench source covers every leg.
+//!
+//! | Variant | Where it runs | Instrument |
+//! |---|---|---|
+//! | `local` | a plain `cargo bench` on a developer machine | divan walltime |
+//! | `simulation` | the sharded `bench-codspeed` CI job | CodSpeed simulation |
+//! | `x86_64` | the `bench-codspeed-arch` x86-64 leg, built with `+avx2` | CodSpeed walltime |
+//! | `aarch64` | the `bench-codspeed-arch` aarch64 leg, built with `+neon` | CodSpeed walltime |
+//!
+//! Two compile-time environment variables carry the variant, both defaulted in
+//! `.cargo/config.toml` so a plain `cargo bench` needs no setup:
+//!
+//! * `VORTEX_BENCH_VARIANT` — the active variant tag, read by [`ignore_unless_variant!`].
+//!   Defaults to `local`, under which *every* benchmark runs, whatever it is tagged with.
+//! * `VORTEX_BENCH_PREFIX` — prepended to benchmark names by [`variant_name!`]. Empty by
+//!   default, so local and simulation runs keep bare names (and, for CodSpeed, their
+//!   existing measurement history); only the walltime legs set it, to `<variant>::`.
+//!
+//! The prefix is what makes it safe for one benchmark to run on more than one leg: an
+//! architecture-neutral baseline measured on both the x86-64 and aarch64 legs reports as
+//! `x86_64::words_gather_scalar` and `aarch64::words_gather_scalar`, instead of two
+//! different machines fighting over one name.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use vortex_bench_support::ignore_unless_variant;
+//! use vortex_bench_support::variant_name;
+//!
+//! // Runs locally, on the simulation shards, and on both walltime legs.
+//! #[divan::bench(
+//!     name = variant_name!("from_bool_slice"),
+//!     ignore = ignore_unless_variant!(simulation, x86_64, aarch64),
+//! )]
+//! fn from_bool_slice(bencher: divan::Bencher) { /* ... */ }
+//!
+//! // NEON only: compiled out elsewhere by `cfg`, and skipped on the aarch64 machine
+//! // whenever that machine is running some other leg.
+//! #[cfg(target_arch = "aarch64")]
+//! #[divan::bench(
+//!     name = variant_name!("words_gather_neon"),
+//!     ignore = ignore_unless_variant!(aarch64),
+//! )]
+//! fn words_gather_neon(bencher: divan::Bencher) { /* ... */ }
+//! ```
+//!
+//! # Adding a variant
+//!
+//! Add an arm to [`variant_tag!`] and a matching leg to `.github/workflows/codspeed.yml`.
+//! Benchmarks name variants by identifier, not by string, so a tag that does not exist
+//! fails to compile instead of silently never running.
+
+/// Map a benchmark variant identifier to its string tag.
+///
+/// This is the list of variants that exist. An unknown identifier is a compile error, so a
+/// typo in an [`ignore_unless_variant!`] tag cannot silently turn into a benchmark that
+/// never runs anywhere. A benchmark behind `#[cfg(target_arch = ...)]` is only checked when
+/// building for that architecture, which for a NEON-only benchmark means the aarch64 CI leg
+/// rather than a developer's x86-64 machine.
+#[macro_export]
+macro_rules! variant_tag {
+    (local) => {
+        "local"
+    };
+    (simulation) => {
+        "simulation"
+    };
+    (x86_64) => {
+        "x86_64"
+    };
+    (aarch64) => {
+        "aarch64"
+    };
+    ($unknown:ident) => {
+        compile_error!(concat!(
+            "unknown benchmark variant `",
+            stringify!($unknown),
+            "`; add it to `vortex_bench_support::variant_tag!` and give it a CI leg",
+        ))
+    };
+}
+
+/// Qualify a benchmark name with the active variant's prefix.
+///
+/// Expands to a string literal, so it is usable as `#[divan::bench(name = ...)]`. The prefix
+/// comes from the compile-time `VORTEX_BENCH_PREFIX` and is empty unless the build sets it,
+/// leaving local and CodSpeed simulation names untouched.
+#[macro_export]
+macro_rules! variant_name {
+    ($name:literal) => {
+        concat!(env!("VORTEX_BENCH_PREFIX"), $name)
+    };
+}
+
+/// Skip this benchmark unless the active variant is one of the listed ones.
+///
+/// Expands to a `bool` for `#[divan::bench(ignore = ...)]`. `local` — the default outside
+/// CI — always runs, so a developer never has to know which tags a benchmark carries.
+///
+/// The check is an OR-chain of `==` rather than a `matches!`, because [`variant_tag!`]
+/// expands to a string literal, which is not valid in pattern position.
+#[macro_export]
+macro_rules! ignore_unless_variant {
+    ($($variant:ident),+ $(,)?) => {{
+        let active = env!("VORTEX_BENCH_VARIANT");
+        !(active == $crate::variant_tag!(local) $(|| active == $crate::variant_tag!($variant))+)
+    }};
+}

--- a/benchmarks/bench-support/src/lib.rs
+++ b/benchmarks/bench-support/src/lib.rs
@@ -1,118 +1,154 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Shared support code for Vortex benchmark binaries.
+//! Instruction-set gating for Vortex benchmarks.
 //!
-//! # Benchmark variants
-//!
-//! A *variant* names the build a benchmark binary was produced for. A benchmark that only
-//! makes sense under one CPU architecture, or that is too noisy for one instrument but not
-//! another, declares the variants it should be measured under; everywhere else it is skipped
-//! rather than compiled out, so a single bench source covers every leg.
-//!
-//! | Variant | Where it runs | Instrument |
-//! |---|---|---|
-//! | `local` | a plain `cargo bench` on a developer machine | divan walltime |
-//! | `simulation` | the sharded `bench-codspeed` CI job | CodSpeed simulation |
-//! | `x86_64` | the `bench-codspeed-arch` x86-64 leg, built with `+avx2` | CodSpeed walltime |
-//! | `aarch64` | the `bench-codspeed-arch` aarch64 leg, built with `+neon` | CodSpeed walltime |
-//!
-//! Two compile-time environment variables carry the variant, both defaulted in
-//! `.cargo/config.toml` so a plain `cargo bench` needs no setup:
-//!
-//! * `VORTEX_BENCH_VARIANT` — the active variant tag, read by [`ignore_unless_variant!`].
-//!   Defaults to `local`, under which *every* benchmark runs, whatever it is tagged with.
-//! * `VORTEX_BENCH_PREFIX` — prepended to benchmark names by [`variant_name!`]. Empty by
-//!   default, so local and simulation runs keep bare names (and, for CodSpeed, their
-//!   existing measurement history); only the walltime legs set it, to `<variant>::`.
-//!
-//! The prefix is what makes it safe for one benchmark to run on more than one leg: an
-//! architecture-neutral baseline measured on both the x86-64 and aarch64 legs reports as
-//! `x86_64::words_gather_scalar` and `aarch64::words_gather_scalar`, instead of two
-//! different machines fighting over one name.
-//!
-//! # Example
-//!
-//! ```ignore
-//! use vortex_bench_support::ignore_unless_variant;
-//! use vortex_bench_support::variant_name;
-//!
-//! // Runs locally, on the simulation shards, and on both walltime legs.
-//! #[divan::bench(
-//!     name = variant_name!("from_bool_slice"),
-//!     ignore = ignore_unless_variant!(simulation, x86_64, aarch64),
-//! )]
-//! fn from_bool_slice(bencher: divan::Bencher) { /* ... */ }
-//!
-//! // NEON only: compiled out elsewhere by `cfg`, and skipped on the aarch64 machine
-//! // whenever that machine is running some other leg.
-//! #[cfg(target_arch = "aarch64")]
-//! #[divan::bench(
-//!     name = variant_name!("words_gather_neon"),
-//!     ignore = ignore_unless_variant!(aarch64),
-//! )]
-//! fn words_gather_neon(bencher: divan::Bencher) { /* ... */ }
-//! ```
-//!
-//! # Adding a variant
-//!
-//! Add an arm to [`variant_tag!`] and a matching leg to `.github/workflows/codspeed.yml`.
-//! Benchmarks name variants by identifier, not by string, so a tag that does not exist
-//! fails to compile instead of silently never running.
+//! CodSpeed's sharded job measures simulated instruction counts on x86-64. That says little
+//! about a hand-written SIMD kernel and nothing at all about Arm. [`isa`] marks a benchmark
+//! as belonging to one instruction set, which routes it to a walltime CI leg running on that
+//! architecture's silicon.
 
-/// Map a benchmark variant identifier to its string tag.
-///
-/// This is the list of variants that exist. An unknown identifier is a compile error, so a
-/// typo in an [`ignore_unless_variant!`] tag cannot silently turn into a benchmark that
-/// never runs anywhere. A benchmark behind `#[cfg(target_arch = ...)]` is only checked when
-/// building for that architecture, which for a NEON-only benchmark means the aarch64 CI leg
-/// rather than a developer's x86-64 machine.
-#[macro_export]
-macro_rules! variant_tag {
-    (local) => {
-        "local"
-    };
-    (simulation) => {
-        "simulation"
-    };
-    (x86_64) => {
-        "x86_64"
-    };
-    (aarch64) => {
-        "aarch64"
-    };
-    ($unknown:ident) => {
-        compile_error!(concat!(
-            "unknown benchmark variant `",
-            stringify!($unknown),
-            "`; add it to `vortex_bench_support::variant_tag!` and give it a CI leg",
-        ))
-    };
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::Ident;
+use syn::ItemFn;
+use syn::parse_macro_input;
+
+/// The architecture leg an instruction set belongs to.
+struct Leg {
+    /// Variant tag, matched against `VORTEX_BENCH_VARIANT`.
+    variant: &'static str,
+    /// `target_arch` the instruction set exists on.
+    target_arch: &'static str,
 }
 
-/// Qualify a benchmark name with the active variant's prefix.
+const X86: Leg = Leg {
+    variant: "x86",
+    target_arch: "x86_64",
+};
+const ARM: Leg = Leg {
+    variant: "arm",
+    target_arch: "aarch64",
+};
+
+/// Resolve an instruction set to the legs that measure it.
 ///
-/// Expands to a string literal, so it is usable as `#[divan::bench(name = ...)]`. The prefix
-/// comes from the compile-time `VORTEX_BENCH_PREFIX` and is empty unless the build sets it,
-/// leaving local and CodSpeed simulation names untouched.
-#[macro_export]
-macro_rules! variant_name {
-    ($name:literal) => {
-        concat!(env!("VORTEX_BENCH_PREFIX"), $name)
-    };
+/// `any` is the arch-neutral case: a scalar baseline or a shipped entry point, measured on
+/// every leg so each architecture has something to compare its kernels against. Everything
+/// else names one instruction set and so implies exactly one architecture.
+fn legs_for(isa: &str) -> Option<Vec<Leg>> {
+    match isa {
+        "sse2" | "avx2" | "avx512" => Some(vec![X86]),
+        "neon" | "sve" => Some(vec![ARM]),
+        "any" => Some(vec![X86, ARM]),
+        _ => None,
+    }
 }
 
-/// Skip this benchmark unless the active variant is one of the listed ones.
+/// Measure this benchmark on the CI leg for the given instruction set.
 ///
-/// Expands to a `bool` for `#[divan::bench(ignore = ...)]`. `local` — the default outside
-/// CI — always runs, so a developer never has to know which tags a benchmark carries.
+/// Must sit *above* `#[divan::bench]`, whose arguments it fills in: the benchmark's name is
+/// qualified with the leg that produced it, and `ignore` is set so the benchmark is skipped
+/// on every other leg. A plain `cargo bench` runs it regardless.
 ///
-/// The check is an OR-chain of `==` rather than a `matches!`, because [`variant_tag!`]
-/// expands to a string literal, which is not valid in pattern position.
-#[macro_export]
-macro_rules! ignore_unless_variant {
-    ($($variant:ident),+ $(,)?) => {{
-        let active = env!("VORTEX_BENCH_VARIANT");
-        !(active == $crate::variant_tag!(local) $(|| active == $crate::variant_tag!($variant))+)
-    }};
+/// ```ignore
+/// #[isa(avx2)]
+/// #[divan::bench(args = INPUT_SIZE)]
+/// fn words_gather_avx2(bencher: Bencher, len: usize) { /* ... */ }
+/// ```
+///
+/// Accepts `sse2`, `avx2`, `avx512`, `neon`, `sve`, and `any` for benchmarks that are not tied
+/// to an instruction set. The `#[cfg(target_arch = ...)]` is implied — an `avx2` benchmark cannot
+/// compile for Arm, so writing that out would only create a chance for it to disagree with
+/// the tag.
+///
+/// An untagged benchmark is untouched: it keeps running on the simulation shards under its
+/// own name, which is the right home for anything that is not architecture-specific.
+#[proc_macro_attribute]
+pub fn isa(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let isa = parse_macro_input!(attr as Ident);
+    let mut function = parse_macro_input!(item as ItemFn);
+
+    let Some(legs) = legs_for(&isa.to_string()) else {
+        return syn::Error::new(
+            isa.span(),
+            format!(
+                "unknown instruction set `{isa}`; expected one of sse2, avx2, avx512, neon, sve, any"
+            ),
+        )
+        .to_compile_error()
+        .into();
+    };
+
+    let Some(bench) = function.attrs.iter_mut().find(|attr| {
+        attr.path()
+            .segments
+            .last()
+            .is_some_and(|s| s.ident == "bench")
+    }) else {
+        return syn::Error::new(
+            isa.span(),
+            "`#[isa]` must be written directly above the `#[divan::bench]` attribute it applies to",
+        )
+        .to_compile_error()
+        .into();
+    };
+
+    let existing: TokenStream2 = match &bench.meta {
+        syn::Meta::Path(_) => TokenStream2::new(),
+        syn::Meta::List(list) => list.tokens.clone(),
+        syn::Meta::NameValue(value) => {
+            return syn::Error::new_spanned(
+                value,
+                "expected `#[divan::bench]` or `#[divan::bench(..)]`",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    for reserved in ["name", "ignore"] {
+        if existing
+            .clone()
+            .into_iter()
+            .any(|token| matches!(&token, proc_macro2::TokenTree::Ident(i) if i == reserved))
+        {
+            return syn::Error::new_spanned(
+                &existing,
+                format!("`{reserved}` is set by `#[isa]`; remove it from `#[divan::bench]`"),
+            )
+            .to_compile_error()
+            .into();
+        }
+    }
+
+    // `env!` rather than reading the environment during expansion: rustc records it as a
+    // dependency of the crate, so changing the variant rebuilds the benchmark.
+    let name = function.sig.ident.to_string();
+    let variants = legs.iter().map(|leg| leg.variant);
+    let arches = legs.iter().map(|leg| leg.target_arch);
+
+    let separator = if existing.is_empty() {
+        quote!()
+    } else {
+        quote!(,)
+    };
+    let bench_path = bench.path().clone();
+    bench.meta = syn::parse_quote! {
+        #bench_path(
+            #existing #separator
+            name = concat!(env!("VORTEX_BENCH_PREFIX"), #name),
+            ignore = {
+                let variant = env!("VORTEX_BENCH_VARIANT");
+                !(variant == "local" #(|| variant == #variants)*)
+            },
+        )
+    };
+
+    quote! {
+        #[cfg(any(#(target_arch = #arches),*))]
+        #function
+    }
+    .into()
 }

--- a/benchmarks/bench-support/src/lib.rs
+++ b/benchmarks/bench-support/src/lib.rs
@@ -3,98 +3,58 @@
 
 //! Instruction-set gating for Vortex benchmarks.
 //!
-//! CodSpeed's sharded job measures simulated instruction counts on x86-64. That says little
-//! about a hand-written SIMD kernel and nothing at all about Arm. [`isa`] marks a benchmark
-//! as belonging to one instruction set, which routes it to the CI leg that builds with that
-//! instruction set enabled and measures walltime on silicon that has it.
+//! CodSpeed's sharded job measures simulated instruction counts on one x86-64 build. That
+//! says little about code whose machine code depends on the instruction set it was compiled
+//! for, and nothing at all about Arm. [`isa`] moves a benchmark off that job and onto the
+//! walltime legs, which build the same source once per instruction set — `+avx2`, `+avx512`,
+//! `+neon` — and measure each on silicon that implements it.
 //!
-//! One leg per instruction set, so what a leg measures is what its name says: an AVX-512
-//! benchmark is compiled `+avx512f,+avx512bw` and run on an AVX-512 machine, not compiled
-//! for AVX2 and steered into an AVX-512 kernel at runtime.
+//! Simulation is the default. An untagged benchmark is untouched and keeps running on the
+//! sharded job under its own name, which is where anything not sensitive to the instruction
+//! set belongs.
 //!
-//! Simulation stays the default. Only a benchmark that names an instruction set leaves the
-//! sharded job, so this costs nothing for the benchmarks that have no reason to care.
+//! The legs themselves live in `.github/workflows/codspeed.yml` and nowhere else. A tagged
+//! benchmark runs on every leg in that matrix, so adding one is a workflow change with no
+//! counterpart here.
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::Ident;
 use syn::ItemFn;
 use syn::parse_macro_input;
 
-/// An instruction set, and so a CI leg: one build, one walltime run.
-struct Isa {
-    /// Leg tag, matched against `VORTEX_BENCH_VARIANT` and used to qualify benchmark names.
-    /// Every tag here needs a matching entry in `.github/workflows/codspeed.yml`.
-    tag: &'static str,
-    /// The `target_arch` this instruction set exists on.
-    target_arch: &'static str,
-}
-
-const ISAS: &[Isa] = &[
-    Isa {
-        tag: "avx2",
-        target_arch: "x86_64",
-    },
-    Isa {
-        tag: "avx512",
-        target_arch: "x86_64",
-    },
-    Isa {
-        tag: "neon",
-        target_arch: "aarch64",
-    },
-];
-
-/// Resolve the argument of `#[isa(..)]` to the legs that measure the benchmark.
+/// Measure this benchmark on every walltime instruction-set leg instead of in simulation.
 ///
-/// `all` is the arch-neutral case — a scalar baseline, or a shipped entry point — measured on
-/// every leg, so each build has something of its own to compare its kernels against.
-fn legs_for(isa: &str) -> Option<Vec<&'static Isa>> {
-    if isa == "all" {
-        return Some(ISAS.iter().collect());
-    }
-    ISAS.iter().find(|leg| leg.tag == isa).map(|leg| vec![leg])
-}
-
-/// Measure this benchmark on the CI leg that builds for the given instruction set.
-///
-/// Must sit *above* `#[divan::bench]`, whose arguments it fills in: the benchmark's name is
-/// qualified with the leg that produced it, and `ignore` is set so the benchmark is skipped
-/// on every other leg. A plain `cargo bench` runs it regardless.
+/// Takes no argument: the benchmark runs on all of them. Write it *above* `#[divan::bench]`,
+/// whose arguments it fills in — the name is qualified with the leg that produced it, so the
+/// legs report one series each rather than fighting over a shared name, and `ignore` takes
+/// the benchmark out of the sharded simulation job. A plain `cargo bench` runs it as before,
+/// under its bare name.
 ///
 /// ```ignore
-/// #[isa(avx2)]
+/// #[isa]
 /// #[divan::bench(args = INPUT_SIZE)]
-/// fn words_gather_avx2(bencher: Bencher, len: usize) { /* ... */ }
+/// fn words_gather_dispatch(bencher: Bencher, len: usize) { /* ... */ }
 /// ```
 ///
-/// Accepts `avx2`, `avx512`, `neon`, and `all` for benchmarks that are not tied to an
-/// instruction set. The `#[cfg(target_arch = ...)]` is implied — an `avx2` benchmark cannot
-/// compile for Arm, so writing that out would only create a chance for it to disagree with
-/// the tag.
-///
-/// Simulation is the default: an untagged benchmark is untouched and keeps running on the
-/// sharded CodSpeed job under its own name, which is the right home for anything that is
-/// not specific to an instruction set.
+/// This is for code that is written once and *compiled* differently per instruction set —
+/// a shipped entry point that selects its kernel through `cfg(target_feature)`, or a scalar
+/// loop whose auto-vectorization depends on the build. A hand-written kernel for one
+/// instruction set is a different thing: it cannot run on the other legs, so it does not
+/// belong here. Keep those on `#[cfg(not(codspeed))]` for local A/B runs.
 #[proc_macro_attribute]
 pub fn isa(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let isa = parse_macro_input!(attr as Ident);
-    let mut function = parse_macro_input!(item as ItemFn);
-
-    let Some(legs) = legs_for(&isa.to_string()) else {
-        let known = ISAS
-            .iter()
-            .map(|leg| leg.tag)
-            .collect::<Vec<_>>()
-            .join(", ");
-        return syn::Error::new(
-            isa.span(),
-            format!("unknown instruction set `{isa}`; expected one of {known}, all"),
+    if !attr.is_empty() {
+        let attr = TokenStream2::from(attr);
+        return syn::Error::new_spanned(
+            attr,
+            "`#[isa]` takes no argument; a tagged benchmark runs on every instruction-set leg",
         )
         .to_compile_error()
         .into();
-    };
+    }
+
+    let mut function = parse_macro_input!(item as ItemFn);
 
     let Some(bench) = function.attrs.iter_mut().find(|attr| {
         attr.path()
@@ -103,7 +63,7 @@ pub fn isa(attr: TokenStream, item: TokenStream) -> TokenStream {
             .is_some_and(|s| s.ident == "bench")
     }) else {
         return syn::Error::new(
-            isa.span(),
+            proc_macro2::Span::call_site(),
             "`#[isa]` must be written directly above the `#[divan::bench]` attribute it applies to",
         )
         .to_compile_error()
@@ -138,14 +98,10 @@ pub fn isa(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
-    // `env!` rather than reading the environment during expansion: rustc records it as a
-    // dependency of the crate, so changing legs rebuilds the benchmarks.
+    // Skipping simulation, rather than naming the legs to run on, is what keeps the leg list
+    // in the workflow alone. `env!` rather than reading the environment during expansion:
+    // rustc records it as a dependency of the crate, so changing legs rebuilds the benchmarks.
     let name = function.sig.ident.to_string();
-    let tags = legs.iter().map(|leg| leg.tag);
-
-    let mut arches: Vec<&str> = legs.iter().map(|leg| leg.target_arch).collect();
-    arches.dedup();
-
     let separator = if existing.is_empty() {
         quote!()
     } else {
@@ -156,16 +112,9 @@ pub fn isa(attr: TokenStream, item: TokenStream) -> TokenStream {
         #bench_path(
             #existing #separator
             name = concat!(env!("VORTEX_BENCH_PREFIX"), #name),
-            ignore = {
-                let leg = env!("VORTEX_BENCH_VARIANT");
-                !(leg == "local" #(|| leg == #tags)*)
-            },
+            ignore = env!("VORTEX_BENCH_VARIANT") == "simulation",
         )
     };
 
-    quote! {
-        #[cfg(any(#(target_arch = #arches),*))]
-        #function
-    }
-    .into()
+    quote!(#function).into()
 }

--- a/vortex-buffer/Cargo.toml
+++ b/vortex-buffer/Cargo.toml
@@ -40,6 +40,7 @@ workspace = true
 divan = { workspace = true }
 num-traits = { workspace = true }
 rstest = { workspace = true }
+vortex-bench-support = { workspace = true }
 
 [[bench]]
 name = "vortex_buffer"

--- a/vortex-buffer/benches/collect_bool.rs
+++ b/vortex-buffer/benches/collect_bool.rs
@@ -14,10 +14,10 @@
 //!   boolean-gather predicate and a `u32` comparison predicate.
 //!
 //! The `words_gather_*` benchmarks carry a `#[isa]` tag, which sends them to the walltime CI
-//! leg for that instruction set's architecture — the only place NEON is measured at all.
-//! Instruction counts say little about a SIMD kernel, so the simulation shards stick to the
-//! untagged shipped entry points. The historical bit-at-a-time baselines are for local A/B
-//! runs and compile out of every CodSpeed build.
+//! leg built for that instruction set — the only place NEON is measured at all. Instruction
+//! counts say little about a SIMD kernel, so the simulation shards stick to the untagged
+//! shipped entry points. The historical bit-at-a-time baselines are for local A/B runs and
+//! compile out of every CodSpeed build.
 //!
 //! A plain `cargo bench` ignores all of it and runs everything on the host.
 

--- a/vortex-buffer/benches/collect_bool.rs
+++ b/vortex-buffer/benches/collect_bool.rs
@@ -13,11 +13,15 @@
 //! - `collect_bool_*` / `from_bool_slice`: the public entry points end to end, with a
 //!   boolean-gather predicate and a `u32` comparison predicate.
 //!
-//! The `words_gather_*` benchmarks carry a `#[isa]` tag, which sends them to the walltime CI
-//! leg built for that instruction set — the only place NEON is measured at all. Instruction
-//! counts say little about a SIMD kernel, so the simulation shards stick to the untagged
-//! shipped entry points. The historical bit-at-a-time baselines are for local A/B runs and
-//! compile out of every CodSpeed build.
+//! `words_gather_dispatch` and `words_gather_scalar` carry `#[isa]`, so they are measured on
+//! every walltime instruction-set leg rather than in simulation. Both are written once and
+//! compiled differently per leg: the shipped entry point picks its pack kernel through
+//! `cfg(target_feature)`, and how well the scalar loop auto-vectorizes depends on the build.
+//! Comparing them across legs is the point.
+//!
+//! The hand-written per-kernel benchmarks are not tagged. Each one only exists for a single
+//! instruction set and cannot run on the other legs, so they stay out of CodSpeed entirely
+//! and remain local A/B tools, as do the historical bit-at-a-time baselines.
 //!
 //! A plain `cargo bench` ignores all of it and runs everything on the host.
 
@@ -103,7 +107,7 @@ fn bench_words_gather(
         .bench_refs(|words| collect(words, len, &bools));
 }
 
-#[isa(all)]
+#[isa]
 #[divan::bench(args = INPUT_SIZE)]
 fn words_gather_dispatch(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {
@@ -112,7 +116,7 @@ fn words_gather_dispatch(bencher: Bencher, len: usize) {
     });
 }
 
-#[isa(all)]
+#[isa]
 #[divan::bench(args = INPUT_SIZE)]
 fn words_gather_scalar(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {
@@ -131,7 +135,8 @@ fn words_gather_sse2(bencher: Bencher, len: usize) {
     });
 }
 
-#[isa(avx2)]
+#[cfg(target_arch = "x86_64")]
+#[cfg(not(codspeed))]
 #[divan::bench(args = INPUT_SIZE)]
 fn words_gather_avx2(bencher: Bencher, len: usize) {
     if !is_x86_feature_detected!("avx2") {
@@ -143,7 +148,8 @@ fn words_gather_avx2(bencher: Bencher, len: usize) {
     });
 }
 
-#[isa(avx512)]
+#[cfg(target_arch = "x86_64")]
+#[cfg(not(codspeed))]
 #[divan::bench(args = INPUT_SIZE)]
 fn words_gather_avx512(bencher: Bencher, len: usize) {
     if !(is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512bw")) {
@@ -155,7 +161,8 @@ fn words_gather_avx512(bencher: Bencher, len: usize) {
     });
 }
 
-#[isa(neon)]
+#[cfg(target_arch = "aarch64")]
+#[cfg(not(codspeed))]
 #[divan::bench(args = INPUT_SIZE)]
 fn words_gather_neon(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {

--- a/vortex-buffer/benches/collect_bool.rs
+++ b/vortex-buffer/benches/collect_bool.rs
@@ -103,7 +103,7 @@ fn bench_words_gather(
         .bench_refs(|words| collect(words, len, &bools));
 }
 
-#[isa(any)]
+#[isa(all)]
 #[divan::bench(args = INPUT_SIZE)]
 fn words_gather_dispatch(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {
@@ -112,7 +112,7 @@ fn words_gather_dispatch(bencher: Bencher, len: usize) {
     });
 }
 
-#[isa(any)]
+#[isa(all)]
 #[divan::bench(args = INPUT_SIZE)]
 fn words_gather_scalar(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {
@@ -121,7 +121,8 @@ fn words_gather_scalar(bencher: Bencher, len: usize) {
     });
 }
 
-#[isa(sse2)]
+#[cfg(target_arch = "x86_64")]
+#[cfg(not(codspeed))]
 #[divan::bench(args = INPUT_SIZE)]
 fn words_gather_sse2(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {

--- a/vortex-buffer/benches/collect_bool.rs
+++ b/vortex-buffer/benches/collect_bool.rs
@@ -13,20 +13,19 @@
 //! - `collect_bool_*` / `from_bool_slice`: the public entry points end to end, with a
 //!   boolean-gather predicate and a `u32` comparison predicate.
 //!
-//! `words_gather_dispatch` and `words_gather_scalar` carry `#[isa]`, so they are measured on
-//! every walltime instruction-set leg rather than in simulation. Both are written once and
-//! compiled differently per leg: the shipped entry point picks its pack kernel through
-//! `cfg(target_feature)`, and how well the scalar loop auto-vectorizes depends on the build.
-//! Comparing them across legs is the point.
+//! `words_gather_dispatch` and `words_gather_scalar` carry `#[cpu_features]`, so they are
+//! measured on every walltime CPU-feature leg rather than in simulation. Both are written
+//! once and compiled differently per leg: the shipped entry point picks its pack kernel
+//! through `cfg(target_feature)`, and how well the scalar loop auto-vectorizes depends on
+//! the build. Comparing them across legs is the point.
 //!
-//! The hand-written per-kernel benchmarks are not tagged. Each one only exists for a single
-//! instruction set and cannot run on the other legs, so they stay out of CodSpeed entirely
-//! and remain local A/B tools, as do the historical bit-at-a-time baselines.
+//! The hand-written per-kernel benchmarks are not tagged. Each one needs an instruction set
+//! extension the other legs do not build for, so they stay out of CodSpeed entirely and
+//! remain local A/B tools, as do the historical bit-at-a-time baselines.
 //!
 //! A plain `cargo bench` ignores all of it and runs everything on the host.
 
 use divan::Bencher;
-use vortex_bench_support::isa;
 use vortex_buffer::BitBuffer;
 use vortex_buffer::collect_bool_word_scalar;
 #[cfg(not(codspeed))]
@@ -107,7 +106,7 @@ fn bench_words_gather(
         .bench_refs(|words| collect(words, len, &bools));
 }
 
-#[isa]
+#[vortex_bench_support::cpu_features]
 #[divan::bench(args = INPUT_SIZE)]
 fn words_gather_dispatch(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {
@@ -116,7 +115,7 @@ fn words_gather_dispatch(bencher: Bencher, len: usize) {
     });
 }
 
-#[isa]
+#[vortex_bench_support::cpu_features]
 #[divan::bench(args = INPUT_SIZE)]
 fn words_gather_scalar(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {

--- a/vortex-buffer/benches/collect_bool.rs
+++ b/vortex-buffer/benches/collect_bool.rs
@@ -4,9 +4,7 @@
 //! Benchmarks for `collect_bool` bit packing.
 //!
 //! Three groups, each with a scalar baseline that replicates the previous bit-at-a-time
-//! implementation. Under CodSpeed only the shipped entry points are tracked
-//! (`from_bool_slice`, `collect_bool_u32_gt`); the baselines, the dispatch loop,
-//! per-SIMD-level loops, and the portable SWAR kernel compile out and are for local A/B runs:
+//! implementation:
 //!
 //! - `pack_words_*`: the portable SWAR kernel vs the scalar loop, word by word. The SIMD
 //!   kernels are covered by `words_gather_*` instead, where they can inline.
@@ -14,10 +12,20 @@
 //!   measuring the fused fill + pack pipeline per SIMD level.
 //! - `collect_bool_*` / `from_bool_slice`: the public entry points end to end, with a
 //!   boolean-gather predicate and a `u32` comparison predicate.
+//!
+//! What CI measures is set per benchmark with [`ignore_unless_variant!`], see
+//! `vortex_bench_support` for the variant list. The simulation shards track only the shipped
+//! entry points, because instruction counts for the SIMD kernels say little about how they
+//! perform on real silicon. The walltime `x86_64` and `aarch64` legs track the whole
+//! `words_gather_*` family, which is the only place NEON is measured at all. The historical
+//! bit-at-a-time baselines exist for local A/B runs and compile out of every CodSpeed build.
+//!
+//! A plain `cargo bench` ignores all of it and runs everything on the host.
 
 use divan::Bencher;
+use vortex_bench_support::ignore_unless_variant;
+use vortex_bench_support::variant_name;
 use vortex_buffer::BitBuffer;
-#[cfg(not(codspeed))]
 use vortex_buffer::collect_bool_word_scalar;
 #[cfg(not(codspeed))]
 use vortex_buffer::pack_bool_word_swar;
@@ -86,7 +94,6 @@ fn pack_words_swar(bencher: Bencher, len: usize) {
 
 /// Benchmark a full multiversioned word loop with a bounds-check-free bool gather, measuring
 /// the packing pipeline itself (fill + pack fully inlined) rather than predicate evaluation.
-#[cfg(not(codspeed))]
 fn bench_words_gather(
     bencher: Bencher,
     len: usize,
@@ -98,8 +105,11 @@ fn bench_words_gather(
         .bench_refs(|words| collect(words, len, &bools));
 }
 
-#[cfg(not(codspeed))]
-#[divan::bench(args = INPUT_SIZE)]
+#[divan::bench(
+    args = INPUT_SIZE,
+    name = variant_name!("words_gather_dispatch"),
+    ignore = ignore_unless_variant!(x86_64, aarch64),
+)]
 fn words_gather_dispatch(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {
         // SAFETY: `collect_bool_words` invokes the predicate with indices `0..len` only.
@@ -107,8 +117,11 @@ fn words_gather_dispatch(bencher: Bencher, len: usize) {
     });
 }
 
-#[cfg(not(codspeed))]
-#[divan::bench(args = INPUT_SIZE)]
+#[divan::bench(
+    args = INPUT_SIZE,
+    name = variant_name!("words_gather_scalar"),
+    ignore = ignore_unless_variant!(x86_64, aarch64),
+)]
 fn words_gather_scalar(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {
         // SAFETY: `collect_bool_words_old` invokes the predicate with indices `0..len` only.
@@ -117,8 +130,11 @@ fn words_gather_scalar(bencher: Bencher, len: usize) {
 }
 
 #[cfg(target_arch = "x86_64")]
-#[cfg(not(codspeed))]
-#[divan::bench(args = INPUT_SIZE)]
+#[divan::bench(
+    args = INPUT_SIZE,
+    name = variant_name!("words_gather_sse2"),
+    ignore = ignore_unless_variant!(x86_64),
+)]
 fn words_gather_sse2(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {
         // SAFETY: SSE2 is part of the x86-64 baseline; indices passed are `0..len`.
@@ -127,8 +143,11 @@ fn words_gather_sse2(bencher: Bencher, len: usize) {
 }
 
 #[cfg(target_arch = "x86_64")]
-#[cfg(not(codspeed))]
-#[divan::bench(args = INPUT_SIZE)]
+#[divan::bench(
+    args = INPUT_SIZE,
+    name = variant_name!("words_gather_avx2"),
+    ignore = ignore_unless_variant!(x86_64),
+)]
 fn words_gather_avx2(bencher: Bencher, len: usize) {
     if !is_x86_feature_detected!("avx2") {
         return;
@@ -140,8 +159,11 @@ fn words_gather_avx2(bencher: Bencher, len: usize) {
 }
 
 #[cfg(target_arch = "x86_64")]
-#[cfg(not(codspeed))]
-#[divan::bench(args = INPUT_SIZE)]
+#[divan::bench(
+    args = INPUT_SIZE,
+    name = variant_name!("words_gather_avx512"),
+    ignore = ignore_unless_variant!(x86_64),
+)]
 fn words_gather_avx512(bencher: Bencher, len: usize) {
     if !(is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512bw")) {
         return;
@@ -153,8 +175,11 @@ fn words_gather_avx512(bencher: Bencher, len: usize) {
 }
 
 #[cfg(target_arch = "aarch64")]
-#[cfg(not(codspeed))]
-#[divan::bench(args = INPUT_SIZE)]
+#[divan::bench(
+    args = INPUT_SIZE,
+    name = variant_name!("words_gather_neon"),
+    ignore = ignore_unless_variant!(aarch64),
+)]
 fn words_gather_neon(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {
         // SAFETY: NEON is part of the aarch64 baseline; indices passed are `0..len`.
@@ -164,7 +189,6 @@ fn words_gather_neon(bencher: Bencher, len: usize) {
 
 /// Faithful copy of the previous scalar-only `collect_bool_words` word loop, used as the
 /// baseline for the end-to-end comparison.
-#[cfg(not(codspeed))]
 fn collect_bool_words_old(words: &mut [u64], len: usize, mut f: impl FnMut(usize) -> bool) {
     let full = len / 64;
     let remainder = len % 64;
@@ -187,7 +211,11 @@ fn from_bool_slice_old_scalar(bencher: Bencher, len: usize) {
         .bench_refs(|words| collect_bool_words_old(words, len, |i| bools[i]));
 }
 
-#[divan::bench(args = INPUT_SIZE)]
+#[divan::bench(
+    args = INPUT_SIZE,
+    name = variant_name!("from_bool_slice"),
+    ignore = ignore_unless_variant!(simulation, x86_64, aarch64),
+)]
 fn from_bool_slice(bencher: Bencher, len: usize) {
     let bools = make_bools(len);
     bencher.bench(|| vortex_buffer::BitBufferMut::from(bools.as_slice()));
@@ -202,7 +230,11 @@ fn collect_bool_u32_gt_old_scalar(bencher: Bencher, len: usize) {
         .bench_refs(|words| collect_bool_words_old(words, len, |i| values[i] > u32::MAX / 2));
 }
 
-#[divan::bench(args = INPUT_SIZE)]
+#[divan::bench(
+    args = INPUT_SIZE,
+    name = variant_name!("collect_bool_u32_gt"),
+    ignore = ignore_unless_variant!(simulation, x86_64, aarch64),
+)]
 fn collect_bool_u32_gt(bencher: Bencher, len: usize) {
     let values = make_u32s(len);
     bencher.bench(|| BitBuffer::collect_bool(len, |i| values[i] > u32::MAX / 2));

--- a/vortex-buffer/benches/collect_bool.rs
+++ b/vortex-buffer/benches/collect_bool.rs
@@ -13,18 +13,16 @@
 //! - `collect_bool_*` / `from_bool_slice`: the public entry points end to end, with a
 //!   boolean-gather predicate and a `u32` comparison predicate.
 //!
-//! What CI measures is set per benchmark with [`ignore_unless_variant!`], see
-//! `vortex_bench_support` for the variant list. The simulation shards track only the shipped
-//! entry points, because instruction counts for the SIMD kernels say little about how they
-//! perform on real silicon. The walltime `x86_64` and `aarch64` legs track the whole
-//! `words_gather_*` family, which is the only place NEON is measured at all. The historical
-//! bit-at-a-time baselines exist for local A/B runs and compile out of every CodSpeed build.
+//! The `words_gather_*` benchmarks carry a `#[isa]` tag, which sends them to the walltime CI
+//! leg for that instruction set's architecture — the only place NEON is measured at all.
+//! Instruction counts say little about a SIMD kernel, so the simulation shards stick to the
+//! untagged shipped entry points. The historical bit-at-a-time baselines are for local A/B
+//! runs and compile out of every CodSpeed build.
 //!
 //! A plain `cargo bench` ignores all of it and runs everything on the host.
 
 use divan::Bencher;
-use vortex_bench_support::ignore_unless_variant;
-use vortex_bench_support::variant_name;
+use vortex_bench_support::isa;
 use vortex_buffer::BitBuffer;
 use vortex_buffer::collect_bool_word_scalar;
 #[cfg(not(codspeed))]
@@ -105,11 +103,8 @@ fn bench_words_gather(
         .bench_refs(|words| collect(words, len, &bools));
 }
 
-#[divan::bench(
-    args = INPUT_SIZE,
-    name = variant_name!("words_gather_dispatch"),
-    ignore = ignore_unless_variant!(x86_64, aarch64),
-)]
+#[isa(any)]
+#[divan::bench(args = INPUT_SIZE)]
 fn words_gather_dispatch(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {
         // SAFETY: `collect_bool_words` invokes the predicate with indices `0..len` only.
@@ -117,11 +112,8 @@ fn words_gather_dispatch(bencher: Bencher, len: usize) {
     });
 }
 
-#[divan::bench(
-    args = INPUT_SIZE,
-    name = variant_name!("words_gather_scalar"),
-    ignore = ignore_unless_variant!(x86_64, aarch64),
-)]
+#[isa(any)]
+#[divan::bench(args = INPUT_SIZE)]
 fn words_gather_scalar(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {
         // SAFETY: `collect_bool_words_old` invokes the predicate with indices `0..len` only.
@@ -129,12 +121,8 @@ fn words_gather_scalar(bencher: Bencher, len: usize) {
     });
 }
 
-#[cfg(target_arch = "x86_64")]
-#[divan::bench(
-    args = INPUT_SIZE,
-    name = variant_name!("words_gather_sse2"),
-    ignore = ignore_unless_variant!(x86_64),
-)]
+#[isa(sse2)]
+#[divan::bench(args = INPUT_SIZE)]
 fn words_gather_sse2(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {
         // SAFETY: SSE2 is part of the x86-64 baseline; indices passed are `0..len`.
@@ -142,12 +130,8 @@ fn words_gather_sse2(bencher: Bencher, len: usize) {
     });
 }
 
-#[cfg(target_arch = "x86_64")]
-#[divan::bench(
-    args = INPUT_SIZE,
-    name = variant_name!("words_gather_avx2"),
-    ignore = ignore_unless_variant!(x86_64),
-)]
+#[isa(avx2)]
+#[divan::bench(args = INPUT_SIZE)]
 fn words_gather_avx2(bencher: Bencher, len: usize) {
     if !is_x86_feature_detected!("avx2") {
         return;
@@ -158,12 +142,8 @@ fn words_gather_avx2(bencher: Bencher, len: usize) {
     });
 }
 
-#[cfg(target_arch = "x86_64")]
-#[divan::bench(
-    args = INPUT_SIZE,
-    name = variant_name!("words_gather_avx512"),
-    ignore = ignore_unless_variant!(x86_64),
-)]
+#[isa(avx512)]
+#[divan::bench(args = INPUT_SIZE)]
 fn words_gather_avx512(bencher: Bencher, len: usize) {
     if !(is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512bw")) {
         return;
@@ -174,12 +154,8 @@ fn words_gather_avx512(bencher: Bencher, len: usize) {
     });
 }
 
-#[cfg(target_arch = "aarch64")]
-#[divan::bench(
-    args = INPUT_SIZE,
-    name = variant_name!("words_gather_neon"),
-    ignore = ignore_unless_variant!(aarch64),
-)]
+#[isa(neon)]
+#[divan::bench(args = INPUT_SIZE)]
 fn words_gather_neon(bencher: Bencher, len: usize) {
     bench_words_gather(bencher, len, |words, len, bools| {
         // SAFETY: NEON is part of the aarch64 baseline; indices passed are `0..len`.
@@ -211,11 +187,7 @@ fn from_bool_slice_old_scalar(bencher: Bencher, len: usize) {
         .bench_refs(|words| collect_bool_words_old(words, len, |i| bools[i]));
 }
 
-#[divan::bench(
-    args = INPUT_SIZE,
-    name = variant_name!("from_bool_slice"),
-    ignore = ignore_unless_variant!(simulation, x86_64, aarch64),
-)]
+#[divan::bench(args = INPUT_SIZE)]
 fn from_bool_slice(bencher: Bencher, len: usize) {
     let bools = make_bools(len);
     bencher.bench(|| vortex_buffer::BitBufferMut::from(bools.as_slice()));
@@ -230,11 +202,7 @@ fn collect_bool_u32_gt_old_scalar(bencher: Bencher, len: usize) {
         .bench_refs(|words| collect_bool_words_old(words, len, |i| values[i] > u32::MAX / 2));
 }
 
-#[divan::bench(
-    args = INPUT_SIZE,
-    name = variant_name!("collect_bool_u32_gt"),
-    ignore = ignore_unless_variant!(simulation, x86_64, aarch64),
-)]
+#[divan::bench(args = INPUT_SIZE)]
 fn collect_bool_u32_gt(bencher: Bencher, len: usize) {
     let values = make_u32s(len);
     bencher.bench(|| BitBuffer::collect_bool(len, |i| values[i] > u32::MAX / 2));


### PR DESCRIPTION
## Rationale for this change

CodSpeed's only measures simulated runtime, this is not great for SIMD

## What changes are included in this PR?

**`#[isa(..)]`**, a proc macro in a new unpublished `vortex-bench-support` crate. It sits above an otherwise untouched `#[divan::bench]` and fills in its arguments:

```rust
#[isa(avx2)]
#[divan::bench(args = INPUT_SIZE)]
fn words_gather_avx2(bencher: Bencher, len: usize) { .. }
```
