### PR TITLE
feat(vortex-spatial): support GeoArrow Geometry unions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10605,6 +10605,7 @@ name = "vortex-spatial"
 version = "0.1.0"
 dependencies = [
  "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
  "arrow-schema 58.4.0",
  "codspeed-divan-compat",
  "geo",

--- a/vortex-spatial/Cargo.toml
+++ b/vortex-spatial/Cargo.toml
@@ -15,6 +15,7 @@ version.workspace = true
 
 [dependencies]
 arrow-array = { workspace = true }
+arrow-buffer = { workspace = true }
 arrow-schema = { workspace = true }
 geo = { workspace = true }
 geo-traits = { workspace = true }

--- a/vortex-spatial/src/aggregate_fn/aabb.rs
+++ b/vortex-spatial/src/aggregate_fn/aabb.rs
@@ -3,6 +3,7 @@
 
 //! The 2D axis-aligned bounding-box (AABB) aggregate for native geometry columns.
 
+use geo::BoundingRect;
 use geo::Rect as SpatialRect;
 use vortex_array::ArrayRef;
 use vortex_array::Columnar;
@@ -23,12 +24,14 @@ use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::extension::Geometry;
 use crate::extension::Rect;
 use crate::extension::SpatialMetadata;
 use crate::extension::box_storage_dtype;
 use crate::extension::coordinate::Dimension;
 use crate::extension::coordinate::box_corners;
 use crate::extension::coordinate::ordinates;
+use crate::extension::decode_mixed_geometries;
 use crate::extension::flatten_coordinates;
 use crate::extension::is_native_geometry;
 
@@ -205,6 +208,18 @@ impl AggregateFnVTable for GeometryAabb {
         // non-nullable case already costs nothing (the all-true mask makes `filter` a no-op).
         let valid = array.validity()?.execute_mask(array.len(), ctx)?;
         let array = array.filter(valid)?;
+        if array
+            .dtype()
+            .as_extension_opt()
+            .is_some_and(|ext| ext.is::<Geometry>())
+        {
+            for geometry in decode_mixed_geometries(&array, ctx)? {
+                if let Some(rect) = geometry.bounding_rect() {
+                    partial.merge(rect);
+                }
+            }
+            return Ok(());
+        }
         // Null rows are gone, so every coordinate below belongs to a present geometry — the
         // `unmasked_field_by_name` reads are therefore safe. Min/max the raw x/y buffers directly:
         // cheap, and avoids `to_geometry`'s panic on empty points (which decoding would hit).

--- a/vortex-spatial/src/aggregate_fn/aabb.rs
+++ b/vortex-spatial/src/aggregate_fn/aabb.rs
@@ -24,7 +24,6 @@ use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::extension::Geometry;
 use crate::extension::Rect;
 use crate::extension::SpatialMetadata;
 use crate::extension::box_storage_dtype;
@@ -33,6 +32,7 @@ use crate::extension::coordinate::box_corners;
 use crate::extension::coordinate::ordinates;
 use crate::extension::decode_mixed_geometries;
 use crate::extension::flatten_coordinates;
+use crate::extension::is_mixed_geometry;
 use crate::extension::is_native_geometry;
 
 /// Aggregates a native geometry column's 2D axis-aligned bounding box (AABB) as a native
@@ -208,11 +208,7 @@ impl AggregateFnVTable for GeometryAabb {
         // non-nullable case already costs nothing (the all-true mask makes `filter` a no-op).
         let valid = array.validity()?.execute_mask(array.len(), ctx)?;
         let array = array.filter(valid)?;
-        if array
-            .dtype()
-            .as_extension_opt()
-            .is_some_and(|ext| ext.is::<Geometry>())
-        {
+        if is_mixed_geometry(array.dtype()) {
             for geometry in decode_mixed_geometries(&array, ctx)? {
                 if let Some(rect) = geometry.bounding_rect() {
                     partial.merge(rect);

--- a/vortex-spatial/src/dense_union/canonical.rs
+++ b/vortex-spatial/src/dense_union/canonical.rs
@@ -16,18 +16,17 @@ use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
-use vortex_mask::AllOr;
 
 use super::array::DenseUnion;
 use super::array::DenseUnionArrayExt;
 use super::array::DenseUnionArraySlotsExt;
+use super::tag_lookup;
 
 /// Converts a dense union to its canonical sparse representation.
 ///
-/// Each child is a dictionary over the original compact child, so values are not copied. Codes for
-/// other variants stay zero because their type IDs make them unreachable. Unused variants use a
-/// constant zero code array, and empty children use a one-value constant because dictionaries
-/// require non-empty values.
+/// A selected variant becomes a dictionary over the original compact child, so values are not
+/// copied. Codes for rows that select another variant stay zero, which their type IDs make
+/// unreachable. A variant no row selects becomes a constant of its default value.
 ///
 /// # Errors
 ///
@@ -45,62 +44,44 @@ pub(crate) fn canonicalize(
     let valid_rows = type_ids.validity()?.execute_mask(len, ctx)?;
     let child_lengths = array.iter_children().map(ArrayRef::len).collect::<Vec<_>>();
 
-    let mut child_indices = [None; 256];
-    for (child_index, type_id) in variants.type_ids().iter().copied().enumerate() {
-        child_indices[usize::from(type_id)] = Some(child_index);
-    }
+    let child_indices = tag_lookup(&variants);
     let mut codes_by_child: Vec<Option<BufferMut<u32>>> = vec![None; variants.len()];
 
-    let mut assign_row = |row: usize| -> VortexResult<()> {
-        let type_id = type_id_values[row];
-        let child_index = child_indices[usize::from(type_id)]
+    for (row, ((type_id, offset), valid)) in type_id_values
+        .iter()
+        .zip(offset_values)
+        .zip(valid_rows.iter())
+        .enumerate()
+    {
+        if !valid {
+            continue;
+        }
+        let child_index = child_indices[usize::from(*type_id)]
             .ok_or_else(|| vortex_err!("DenseUnion contains unknown type ID {type_id}"))?;
-        let offset = u32::try_from(offset_values[row]).map_err(|_| {
-            vortex_err!(
-                "DenseUnion contains negative offset {} at row {row}",
-                offset_values[row]
-            )
+        let offset = u32::try_from(*offset).map_err(|_| {
+            vortex_err!("DenseUnion contains negative offset {offset} at row {row}")
         })?;
         let child_len = child_lengths[child_index];
         vortex_ensure!(
             (offset as usize) < child_len,
             "DenseUnion offset {offset} is out of bounds for child {child_index} of length {child_len}"
         );
-        let codes = codes_by_child[child_index].get_or_insert_with(|| BufferMut::zeroed(len));
-        codes[row] = offset;
-        Ok(())
-    };
-
-    match valid_rows.indices() {
-        AllOr::All => {
-            for row in 0..len {
-                assign_row(row)?;
-            }
-        }
-        AllOr::None => {}
-        AllOr::Some(rows) => {
-            for &row in rows {
-                assign_row(row)?;
-            }
-        }
+        codes_by_child[child_index].get_or_insert_with(|| BufferMut::zeroed(len))[row] = offset;
     }
 
     let sparse_children = array
         .iter_children()
         .zip(codes_by_child)
         .map(|(child, codes)| {
-            let codes = match codes {
-                Some(codes) => {
-                    PrimitiveArray::new(codes.freeze(), Validity::NonNullable).into_array()
-                }
-                None => ConstantArray::new(0u32, len).into_array(),
+            // Codes are only recorded for a variant some valid row selects at an in-bounds
+            // offset, so a variant without them is unreachable and needs no values at all.
+            let Some(codes) = codes else {
+                return Ok(
+                    ConstantArray::new(Scalar::default_value(child.dtype()), len).into_array(),
+                );
             };
-            let values = if child.is_empty() {
-                ConstantArray::new(Scalar::default_value(child.dtype()), 1).into_array()
-            } else {
-                child.clone()
-            };
-            DictArray::try_new(codes, values).map(IntoArray::into_array)
+            let codes = PrimitiveArray::new(codes.freeze(), Validity::NonNullable).into_array();
+            DictArray::try_new(codes, child.clone()).map(IntoArray::into_array)
         })
         .collect::<VortexResult<Vec<_>>>()?;
 

--- a/vortex-spatial/src/dense_union/compact.rs
+++ b/vortex-spatial/src/dense_union/compact.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::dtype::UnionVariants;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
+use vortex_mask::Mask;
+
+use super::tag_lookup;
+
+/// A dense union compacted into a directly Arrow-exportable layout.
+pub(crate) struct CompactUnion {
+    variants: UnionVariants,
+    /// The row-aligned Arrow type IDs.
+    pub type_ids: Vec<i8>,
+    /// The row-aligned offsets into [`Self::children`], increasing within each child.
+    pub offsets: Vec<i32>,
+    /// The compacted children in variant order, each holding exactly the rows that select it.
+    children: Vec<ArrayRef>,
+    /// The row validity, which Arrow instead expresses through the selected child.
+    pub validity: Mask,
+}
+
+impl CompactUnion {
+    /// Return the compacted child selected by a data-level type tag.
+    pub(crate) fn child(&self, tag: u8) -> Option<&ArrayRef> {
+        self.variants
+            .tag_to_child_index(tag)
+            .and_then(|child_index| self.children.get(child_index))
+    }
+}
+
+/// Compact a dense union so that its offsets increase within each child.
+///
+/// Vortex's selector-only operations reorder and repeat per-child offsets and retain unselected
+/// child rows, so the compact children are not an Arrow dense-union layout as they stand. This
+/// gathers each child down to exactly the rows that select it, in row order, and rebases the
+/// offsets onto the result.
+///
+/// A row's nullity moves from the union onto the selected child, matching Arrow's dense union,
+/// which has no validity of its own.
+///
+/// # Errors
+///
+/// Returns an error for unknown type IDs on valid rows, for offsets that exceed `i32`, or when
+/// gathering a child fails.
+pub(crate) fn compact_for_arrow(
+    variants: UnionVariants,
+    type_ids: &PrimitiveArray,
+    offsets: &PrimitiveArray,
+    children: Vec<ArrayRef>,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<CompactUnion> {
+    let validity = type_ids.validity()?.execute_mask(type_ids.len(), ctx)?;
+    let all_valid = validity.all_true();
+    let type_id_values = type_ids.as_slice::<u8>();
+    let offset_values = offsets.as_slice::<i32>();
+
+    let child_indices = tag_lookup(&variants);
+    // A null row is free to carry a type ID no variant declares: canonicalization and `scalar_at`
+    // both skip a null row's selectors without reading them. Arrow has no such slack, so park
+    // those rows on the first variant, where the null index below makes the value null.
+    let fallback_child = variants
+        .type_ids()
+        .first()
+        .and_then(|tag| child_indices[usize::from(*tag)])
+        .ok_or_else(|| vortex_err!("DenseUnion has no variants"))?;
+
+    let mut selections = vec![Vec::<Option<i32>>::new(); children.len()];
+    let mut arrow_type_ids = Vec::with_capacity(type_id_values.len());
+    let mut arrow_offsets = Vec::with_capacity(offset_values.len());
+    for (row, ((type_id, offset), valid)) in type_id_values
+        .iter()
+        .zip(offset_values)
+        .zip(validity.iter())
+        .enumerate()
+    {
+        let child_index = match (child_indices[usize::from(*type_id)], valid) {
+            (Some(child_index), _) => child_index,
+            (None, false) => fallback_child,
+            (None, true) => vortex_bail!("DenseUnion row has unknown type ID {type_id}"),
+        };
+        let arrow_type_id = variants.child_index_to_tag(child_index);
+        arrow_type_ids.push(
+            i8::try_from(arrow_type_id)
+                .map_err(|_| vortex_err!("DenseUnion type ID {arrow_type_id} exceeds i8"))?,
+        );
+        arrow_offsets.push(
+            i32::try_from(selections[child_index].len())
+                .map_err(|_| vortex_err!("DenseUnion child offset exceeds i32 at row {row}"))?,
+        );
+        selections[child_index].push(valid.then_some(*offset));
+    }
+
+    let children = children
+        .into_iter()
+        .zip(selections)
+        .map(|(child, selection)| {
+            // A null index gathers to a null value, which is how the row's nullity reaches the
+            // child. Keeping the child non-nullable when nothing selected it while null lets the
+            // Arrow export match a non-nullable child field.
+            let indices = if all_valid || selection.iter().all(Option::is_some) {
+                PrimitiveArray::from_iter(selection.into_iter().flatten()).into_array()
+            } else {
+                PrimitiveArray::from_option_iter(selection).into_array()
+            };
+            child.take(indices)
+        })
+        .collect::<VortexResult<Vec<_>>>()?;
+
+    Ok(CompactUnion {
+        variants,
+        type_ids: arrow_type_ids,
+        offsets: arrow_offsets,
+        children,
+        validity,
+    })
+}

--- a/vortex-spatial/src/dense_union/compute/filter.rs
+++ b/vortex-spatial/src/dense_union/compute/filter.rs
@@ -3,23 +3,20 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
-use vortex_array::IntoArray;
 use vortex_array::arrays::filter::FilterReduce;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use super::with_selectors;
 use crate::dense_union::DenseUnion;
-use crate::dense_union::DenseUnionArrayExt;
 use crate::dense_union::DenseUnionArraySlotsExt;
 
 impl FilterReduce for DenseUnion {
     fn filter(array: ArrayView<'_, Self>, mask: &Mask) -> VortexResult<Option<ArrayRef>> {
-        DenseUnion::try_new(
+        with_selectors(
+            array,
             array.type_ids().filter(mask.clone())?,
             array.offsets().filter(mask.clone())?,
-            array.variants().clone(),
-            array.iter_children().cloned(),
         )
-        .map(|array| Some(array.into_array()))
     }
 }

--- a/vortex-spatial/src/dense_union/compute/mask.rs
+++ b/vortex-spatial/src/dense_union/compute/mask.rs
@@ -3,23 +3,20 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
-use vortex_array::IntoArray;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::scalar_fn::fns::mask::MaskReduce;
 use vortex_error::VortexResult;
 
+use super::with_selectors;
 use crate::dense_union::DenseUnion;
-use crate::dense_union::DenseUnionArrayExt;
 use crate::dense_union::DenseUnionArraySlotsExt;
 
 impl MaskReduce for DenseUnion {
     fn mask(array: ArrayView<'_, Self>, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
-        DenseUnion::try_new(
+        with_selectors(
+            array,
             array.type_ids().clone().mask(mask.clone())?,
             array.offsets().clone(),
-            array.variants().clone(),
-            array.iter_children().cloned(),
         )
-        .map(|array| Some(array.into_array()))
     }
 }

--- a/vortex-spatial/src/dense_union/compute/mod.rs
+++ b/vortex-spatial/src/dense_union/compute/mod.rs
@@ -2,8 +2,35 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 //! Compute kernels for dense unions.
+//!
+//! Every kernel here is selector-only: it transforms the type IDs and offsets and retains each
+//! compact child in full. That is O(selected rows) rather than O(child values), at the cost of
+//! leaving unselected values behind and reordering per-child offsets.
 
 mod filter;
 mod mask;
 mod slice;
 mod take;
+
+use vortex_array::ArrayRef;
+use vortex_array::ArrayView;
+use vortex_array::IntoArray;
+use vortex_error::VortexResult;
+
+use super::DenseUnion;
+use super::DenseUnionArrayExt;
+
+/// Rebuild a dense union around transformed row selectors, retaining its compact children.
+fn with_selectors(
+    array: ArrayView<'_, DenseUnion>,
+    type_ids: ArrayRef,
+    offsets: ArrayRef,
+) -> VortexResult<Option<ArrayRef>> {
+    DenseUnion::try_new(
+        type_ids,
+        offsets,
+        array.variants().clone(),
+        array.iter_children().cloned(),
+    )
+    .map(|array| Some(array.into_array()))
+}

--- a/vortex-spatial/src/dense_union/compute/slice.rs
+++ b/vortex-spatial/src/dense_union/compute/slice.rs
@@ -5,22 +5,19 @@ use std::ops::Range;
 
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
-use vortex_array::IntoArray;
 use vortex_array::arrays::slice::SliceReduce;
 use vortex_error::VortexResult;
 
+use super::with_selectors;
 use crate::dense_union::DenseUnion;
-use crate::dense_union::DenseUnionArrayExt;
 use crate::dense_union::DenseUnionArraySlotsExt;
 
 impl SliceReduce for DenseUnion {
     fn slice(array: ArrayView<'_, Self>, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
-        DenseUnion::try_new(
+        with_selectors(
+            array,
             array.type_ids().slice(range.clone())?,
             array.offsets().slice(range)?,
-            array.variants().clone(),
-            array.iter_children().cloned(),
         )
-        .map(|array| Some(array.into_array()))
     }
 }

--- a/vortex-spatial/src/dense_union/compute/take.rs
+++ b/vortex-spatial/src/dense_union/compute/take.rs
@@ -1,37 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Selector-only take for dense unions.
-//!
-//! For performance, take gathers only the row selectors and retains every compact child in full.
-//! This is O(selected rows) but may reorder per-child offsets; Arrow dense unions instead require
-//! those offsets to increase.
-
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
-use vortex_array::IntoArray;
 use vortex_array::arrays::dict::TakeReduce;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::scalar::Scalar;
 use vortex_error::VortexResult;
 
+use super::with_selectors;
 use crate::dense_union::DenseUnion;
-use crate::dense_union::DenseUnionArrayExt;
 use crate::dense_union::DenseUnionArraySlotsExt;
 
 impl TakeReduce for DenseUnion {
     fn take(array: ArrayView<'_, Self>, indices: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
-        let type_ids = array.type_ids().take(indices.clone())?;
+        // A null index makes the row null through the type IDs, so the offset it gathers is never
+        // read; gather offset zero rather than propagating the null into a non-nullable array.
         let fill_scalar = Scalar::zero_value(&indices.dtype().as_nonnullable());
         let offset_indices = indices.clone().fill_null(fill_scalar)?;
-        let offsets = array.offsets().take(offset_indices)?;
 
-        DenseUnion::try_new(
-            type_ids,
-            offsets,
-            array.variants().clone(),
-            array.iter_children().cloned(),
+        with_selectors(
+            array,
+            array.type_ids().take(indices.clone())?,
+            array.offsets().take(offset_indices)?,
         )
-        .map(|array| Some(array.into_array()))
     }
 }

--- a/vortex-spatial/src/dense_union/mod.rs
+++ b/vortex-spatial/src/dense_union/mod.rs
@@ -10,20 +10,48 @@
 //!
 //! Vortex does not require offsets for each child to increase. Selector-only operations can retain
 //! the original compact children and reorder their offsets, so this encoding is not necessarily a
-//! directly exportable Arrow dense-union layout without compaction and offset rebasing.
+//! directly exportable Arrow dense-union layout; [`compact_for_arrow`] gathers the children and
+//! rebases the offsets when one is needed.
 
 mod array;
 mod canonical;
+mod compact;
 mod compute;
 mod rules;
 mod vtable;
 
 pub use array::*;
+pub(crate) use compact::compact_for_arrow;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::Nullability;
+use vortex_array::dtype::UnionVariants;
 use vortex_array::session::ArraySessionExt;
+use vortex_error::VortexResult;
+use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 
 pub(crate) fn initialize(session: &VortexSession) {
     session.arrays().register(DenseUnion);
+}
+
+/// Destructure a union dtype into its variants and nullability.
+pub(crate) fn union_variants(dtype: &DType) -> VortexResult<(&UnionVariants, Nullability)> {
+    let variants = dtype
+        .as_union_variants_opt()
+        .ok_or_else(|| vortex_err!("DenseUnion requires a union dtype, got {dtype}"))?;
+    Ok((variants, dtype.nullability()))
+}
+
+/// Map every data-level type tag to its child index.
+///
+/// [`UnionVariants::tag_to_child_index`] linear-scans the variants, which is the right trade-off
+/// for a one-off lookup but not for one resolved per row.
+pub(crate) fn tag_lookup(variants: &UnionVariants) -> [Option<usize>; 256] {
+    let mut lookup = [None; 256];
+    for (child_index, tag) in variants.type_ids().iter().copied().enumerate() {
+        lookup[usize::from(tag)] = Some(child_index);
+    }
+    lookup
 }
 
 #[cfg(test)]

--- a/vortex-spatial/src/dense_union/tests.rs
+++ b/vortex-spatial/src/dense_union/tests.rs
@@ -20,6 +20,8 @@ use vortex_array::arrays::UnionArray;
 use vortex_array::arrays::union::UnionArraySlotsExt;
 use vortex_array::assert_arrays_eq;
 use vortex_array::builtins::ArrayBuiltins;
+use vortex_array::compute::conformance::mask::test_mask_conformance;
+use vortex_array::compute::conformance::take::test_take_conformance;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
@@ -37,6 +39,7 @@ use vortex_session::registry::ReadContext;
 use super::DenseUnion;
 use super::DenseUnionArray;
 use super::DenseUnionArraySlotsExt;
+use crate::test_harness::spatial_session;
 
 fn variants() -> VortexResult<UnionVariants> {
     UnionVariants::try_new(
@@ -84,12 +87,6 @@ fn nullable_dense_union() -> VortexResult<DenseUnionArray> {
     )
 }
 
-fn session() -> VortexSession {
-    let session = vortex_array::array_session();
-    crate::initialize(&session);
-    session
-}
-
 #[track_caller]
 fn assert_rows(
     array: &ArrayRef,
@@ -123,7 +120,7 @@ fn assert_same_rows(
 
 #[test]
 fn scalar_at_uses_type_id_and_offset() -> VortexResult<()> {
-    let session = session();
+    let session = spatial_session();
     let array = dense_union()?.into_array();
     assert_rows(
         &array,
@@ -138,7 +135,7 @@ fn scalar_at_uses_type_id_and_offset() -> VortexResult<()> {
 
 #[test]
 fn outer_and_selected_child_nulls_are_distinct() -> VortexResult<()> {
-    let session = session();
+    let session = spatial_session();
     let variants = nullable_variants()?;
     let array = nullable_dense_union()?.into_array();
     assert_rows(
@@ -163,64 +160,84 @@ fn outer_and_selected_child_nulls_are_distinct() -> VortexResult<()> {
     )
 }
 
-#[test]
-fn slice_filter_take_and_mask_preserve_dense_encoding() -> VortexResult<()> {
-    let session = session();
+/// The selector-only kernels, each applied to [`dense_union`].
+#[derive(Clone, Copy)]
+enum SelectorOp {
+    Slice,
+    Filter,
+    Take,
+    Mask,
+}
+
+impl SelectorOp {
+    fn apply(self, array: &ArrayRef) -> VortexResult<ArrayRef> {
+        match self {
+            Self::Slice => array.slice(1..3),
+            Self::Filter => array.filter(Mask::from_iter([true, false, true])),
+            Self::Take => array.take(PrimitiveArray::from_iter([2u32, 0, 1]).into_array()),
+            Self::Mask => array
+                .clone()
+                .mask(BoolArray::from_iter([true, false, true]).into_array()),
+        }
+    }
+}
+
+#[rstest]
+#[case::slice(SelectorOp::Slice)]
+#[case::filter(SelectorOp::Filter)]
+#[case::take(SelectorOp::Take)]
+#[case::mask(SelectorOp::Mask)]
+fn selector_ops_preserve_dense_encoding(#[case] op: SelectorOp) -> VortexResult<()> {
+    let session = spatial_session();
+    let variants = variants()?;
     let array = dense_union()?.into_array();
+    let selected = op.apply(&array)?;
 
-    let sliced = array.slice(1..3)?;
-    let filtered = array.filter(Mask::from_iter([true, false, true]))?;
-    let taken = array.take(PrimitiveArray::from_iter([2u32, 0, 1]).into_array())?;
-    let masked = array.mask(BoolArray::from_iter([true, false, true]).into_array())?;
+    // Selector-only means the compact children survive untouched, at their original length.
+    assert!(selected.is::<DenseUnion>());
+    assert_eq!(selected.as_::<DenseUnion>().children()[0].len(), 2);
 
-    assert!(sliced.is::<DenseUnion>());
-    assert!(filtered.is::<DenseUnion>());
-    assert!(taken.is::<DenseUnion>());
-    assert!(masked.is::<DenseUnion>());
-    assert_eq!(sliced.as_::<DenseUnion>().children()[0].len(), 2);
-    assert_eq!(filtered.as_::<DenseUnion>().children()[0].len(), 2);
-    assert_eq!(taken.as_::<DenseUnion>().children()[0].len(), 2);
-    assert_eq!(masked.as_::<DenseUnion>().children()[0].len(), 2);
+    let number =
+        |value: i32, nullability| Scalar::union(variants.clone(), 5, value.into(), nullability);
+    let flag =
+        |value: bool, nullability| Scalar::union(variants.clone(), 9, value.into(), nullability);
+    let expected = match op {
+        SelectorOp::Slice => vec![
+            flag(true, Nullability::NonNullable)?,
+            number(30, Nullability::NonNullable)?,
+        ],
+        SelectorOp::Filter => vec![
+            number(10, Nullability::NonNullable)?,
+            number(30, Nullability::NonNullable)?,
+        ],
+        SelectorOp::Take => vec![
+            number(30, Nullability::NonNullable)?,
+            number(10, Nullability::NonNullable)?,
+            flag(true, Nullability::NonNullable)?,
+        ],
+        SelectorOp::Mask => vec![
+            number(10, Nullability::Nullable)?,
+            Scalar::null(DType::Union(variants.clone(), Nullability::Nullable)),
+            number(30, Nullability::Nullable)?,
+        ],
+    };
+    assert_rows(&selected, expected, &session)
+}
 
-    assert_rows(
-        &sliced,
-        vec![
-            Scalar::union(variants()?, 9, true.into(), Nullability::NonNullable)?,
-            Scalar::union(variants()?, 5, 30i32.into(), Nullability::NonNullable)?,
-        ],
-        &session,
-    )?;
-    assert_rows(
-        &filtered,
-        vec![
-            Scalar::union(variants()?, 5, 10i32.into(), Nullability::NonNullable)?,
-            Scalar::union(variants()?, 5, 30i32.into(), Nullability::NonNullable)?,
-        ],
-        &session,
-    )?;
-    assert_rows(
-        &taken,
-        vec![
-            Scalar::union(variants()?, 5, 30i32.into(), Nullability::NonNullable)?,
-            Scalar::union(variants()?, 5, 10i32.into(), Nullability::NonNullable)?,
-            Scalar::union(variants()?, 9, true.into(), Nullability::NonNullable)?,
-        ],
-        &session,
-    )?;
-    assert_rows(
-        &masked,
-        vec![
-            Scalar::union(variants()?, 5, 10i32.into(), Nullability::Nullable)?,
-            Scalar::null(DType::Union(variants()?, Nullability::Nullable)),
-            Scalar::union(variants()?, 5, 30i32.into(), Nullability::Nullable)?,
-        ],
-        &session,
-    )
+#[rstest]
+#[case::non_nullable(dense_union())]
+#[case::nullable(nullable_dense_union())]
+fn take_and_mask_conformance(#[case] array: VortexResult<DenseUnionArray>) -> VortexResult<()> {
+    let array = array?.into_array();
+    let mut ctx = spatial_session().create_execution_ctx();
+    test_take_conformance(&array, &mut ctx);
+    test_mask_conformance(&array, &mut ctx);
+    Ok(())
 }
 
 #[test]
 fn nullable_take_indices_become_outer_nulls() -> VortexResult<()> {
-    let session = session();
+    let session = spatial_session();
     let taken = dense_union()?
         .into_array()
         .take(PrimitiveArray::from_option_iter([Some(2u32), None, Some(0)]).into_array())?;
@@ -238,7 +255,7 @@ fn nullable_take_indices_become_outer_nulls() -> VortexResult<()> {
 
 #[test]
 fn canonicalization_uses_sparse_dictionary_children() -> VortexResult<()> {
-    let session = session();
+    let session = spatial_session();
     let array = dense_union()?.into_array();
     let mut ctx = session.create_execution_ctx();
     let canonical = array.clone().execute::<UnionArray>(&mut ctx)?;
@@ -250,7 +267,7 @@ fn canonicalization_uses_sparse_dictionary_children() -> VortexResult<()> {
 
 #[test]
 fn canonicalization_handles_unselected_empty_child() -> VortexResult<()> {
-    let session = session();
+    let session = spatial_session();
     let array = DenseUnion::try_new(
         PrimitiveArray::from_iter([5u8, 5]).into_array(),
         PrimitiveArray::from_iter([0i32, 1]).into_array(),
@@ -276,7 +293,7 @@ fn invalid_type_id_and_offsets_return_errors(
     #[case] offset: i32,
     #[case] expected: &str,
 ) -> VortexResult<()> {
-    let session = session();
+    let session = spatial_session();
     let mut ctx = session.create_execution_ctx();
     let array = DenseUnion::try_new(
         PrimitiveArray::from_iter([type_id]).into_array(),
@@ -340,7 +357,7 @@ fn validates_structural_components(
 
 #[test]
 fn canonicalization_handles_zero_length_array() -> VortexResult<()> {
-    let session = session();
+    let session = spatial_session();
     let array = DenseUnion::try_new(
         PrimitiveArray::from_iter(Vec::<u8>::new()).into_array(),
         PrimitiveArray::from_iter(Vec::<i32>::new()).into_array(),
@@ -359,7 +376,7 @@ fn canonicalization_handles_zero_length_array() -> VortexResult<()> {
 
 #[test]
 fn serde_roundtrip() -> VortexResult<()> {
-    let session = session();
+    let session = spatial_session();
     let array = nullable_dense_union()?.into_array();
     let dtype = array.dtype().clone();
     let len = array.len();

--- a/vortex-spatial/src/dense_union/vtable.rs
+++ b/vortex-spatial/src/dense_union/vtable.rs
@@ -18,14 +18,12 @@ use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
-use vortex_array::dtype::UnionVariants;
 use vortex_array::require_child;
 use vortex_array::scalar::Scalar;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
 use vortex_array::with_empty_buffers;
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_ensure_eq;
 use vortex_error::vortex_err;
@@ -40,6 +38,7 @@ use super::array::DenseUnionSlots;
 use super::array::make_parts;
 use super::canonical::canonicalize;
 use super::rules::PARENT_RULES;
+use super::union_variants;
 
 const OFFSETS_DTYPE: DType = DType::Primitive(PType::I32, Nullability::NonNullable);
 
@@ -50,13 +49,6 @@ struct DenseUnionMetadata {
     child_lengths: Vec<u64>,
 }
 
-fn union_dtype(dtype: &DType) -> VortexResult<(&UnionVariants, Nullability)> {
-    let DType::Union(variants, nullability) = dtype else {
-        vortex_bail!("DenseUnion requires a union dtype, got {dtype}");
-    };
-    Ok((variants, *nullability))
-}
-
 fn validate_components(
     type_ids: &ArrayRef,
     offsets: &ArrayRef,
@@ -64,7 +56,7 @@ fn validate_components(
     dtype: &DType,
     len: usize,
 ) -> VortexResult<()> {
-    let (variants, nullability) = union_dtype(dtype)?;
+    let (variants, nullability) = union_variants(dtype)?;
     vortex_ensure_eq!(
         children.len(),
         variants.len(),
@@ -128,7 +120,7 @@ impl VTable for DenseUnion {
         len: usize,
         slots: &[Option<ArrayRef>],
     ) -> VortexResult<()> {
-        let (variants, _) = union_dtype(dtype)?;
+        let (variants, _) = union_variants(dtype)?;
         let expected_slots = DenseUnionSlots::CHILDREN_OFFSET + variants.len();
         vortex_ensure_eq!(
             slots.len(),
@@ -199,7 +191,7 @@ impl VTable for DenseUnion {
         _session: &VortexSession,
     ) -> VortexResult<ArrayParts<Self>> {
         vortex_ensure!(buffers.is_empty(), "DenseUnion expects no buffers");
-        let (variants, nullability) = union_dtype(dtype)?;
+        let (variants, nullability) = union_variants(dtype)?;
         let metadata = DenseUnionMetadata::decode(metadata)?;
         vortex_ensure_eq!(
             metadata.child_lengths.len(),

--- a/vortex-spatial/src/extension/geometry.rs
+++ b/vortex-spatial/src/extension/geometry.rs
@@ -1,0 +1,636 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! The [`Geometry`] extension type (`vortex.st.geometry`), represented logically as a union
+//! of native geometry extension arrays and mapped to `geoarrow.geometry`. Arrow imports retain
+//! the compact layout through the private DenseUnion physical encoding.
+
+use std::sync::Arc;
+
+use arrow_array::Array as _;
+use arrow_array::ArrayRef as ArrowArrayRef;
+use arrow_array::UnionArray as ArrowUnionArray;
+use arrow_array::new_empty_array;
+use arrow_buffer::ScalarBuffer;
+use arrow_schema::DataType;
+use arrow_schema::Field;
+use arrow_schema::UnionMode;
+use arrow_schema::extension::ExtensionType;
+use geo_traits::to_geo::ToGeoGeometry;
+use geo_types::Geometry as GeoGeometry;
+use geoarrow::array::GeoArrowArrayAccessor;
+use geoarrow::array::GeometryArray as GeoArrowGeometryArray;
+use geoarrow::datatypes::CoordType;
+use geoarrow::datatypes::GeometryType as GeoArrowGeometryType;
+use prost::Message;
+use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::arrays::ExtensionArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::UnionArray;
+use vortex_array::arrays::extension::ExtensionArrayExt;
+use vortex_array::arrays::union::UnionArrayExt;
+use vortex_array::arrays::union::UnionArraySlotsExt;
+use vortex_array::builtins::ArrayBuiltins;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::FieldNames;
+use vortex_array::dtype::Nullability;
+use vortex_array::dtype::UnionVariants;
+use vortex_array::dtype::extension::ExtDType;
+use vortex_array::dtype::extension::ExtId;
+use vortex_array::dtype::extension::ExtVTable;
+use vortex_array::scalar::Scalar;
+use vortex_array::scalar::ScalarValue;
+use vortex_array::validity::Validity;
+use vortex_arrow::ArrowExport;
+use vortex_arrow::ArrowExportVTable;
+use vortex_arrow::ArrowImport;
+use vortex_arrow::ArrowImportVTable;
+use vortex_arrow::ArrowSession;
+use vortex_arrow::ArrowSessionExt;
+use vortex_error::VortexError;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_ensure;
+use vortex_error::vortex_err;
+use vortex_session::registry::CachedId;
+use vortex_session::registry::Id;
+
+use super::LineString;
+use super::MultiLineString;
+use super::MultiPoint;
+use super::MultiPolygon;
+use super::Point;
+use super::Polygon;
+use super::SpatialMetadata;
+use super::coordinate::Dimension;
+use super::coordinate::coordinate_dimension;
+use super::geoarrow_metadata;
+use super::geoarrow_to_wkb;
+use super::linestring_dimension;
+use super::multilinestring_dimension;
+use super::multipoint_dimension;
+use super::multipolygon_dimension;
+use super::polygon_dimension;
+use super::spatial_metadata_from_arrow;
+use crate::dense_union::DenseUnion;
+use crate::dense_union::DenseUnionArrayExt;
+use crate::dense_union::DenseUnionArraySlotsExt;
+
+/// A mixed native geometry column whose logical union variants are Point, LineString, Polygon,
+/// MultiPoint, MultiLineString, and MultiPolygon extension arrays. GeoArrow GeometryCollection
+/// fields may be present in the Arrow schema, but selected GeometryCollection values are not yet
+/// supported.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct Geometry;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GeoArrowGeometryKind {
+    Point,
+    LineString,
+    Polygon,
+    MultiPoint,
+    MultiLineString,
+    MultiPolygon,
+    GeometryCollection,
+}
+
+fn geoarrow_type_id_parts(type_id: u8) -> VortexResult<(GeoArrowGeometryKind, Dimension)> {
+    // GeoArrow assigns the ones digit to geometry kind and the tens digit to coordinate dimension.
+    let dimension = match type_id / 10 {
+        0 => Dimension::Xy,
+        1 => Dimension::Xyz,
+        2 => Dimension::Xym,
+        3 => Dimension::Xyzm,
+        _ => vortex_bail!("unsupported GeoArrow geometry type ID {type_id}"),
+    };
+    let kind = match type_id % 10 {
+        1 => GeoArrowGeometryKind::Point,
+        2 => GeoArrowGeometryKind::LineString,
+        3 => GeoArrowGeometryKind::Polygon,
+        4 => GeoArrowGeometryKind::MultiPoint,
+        5 => GeoArrowGeometryKind::MultiLineString,
+        6 => GeoArrowGeometryKind::MultiPolygon,
+        7 => GeoArrowGeometryKind::GeometryCollection,
+        _ => vortex_bail!("unsupported GeoArrow geometry type ID {type_id}"),
+    };
+    Ok((kind, dimension))
+}
+
+fn validate_variant_dtype(type_id: u8, dtype: &DType) -> VortexResult<()> {
+    let (kind, expected_dimension) = geoarrow_type_id_parts(type_id)?;
+    let ext = dtype
+        .as_extension_opt()
+        .ok_or_else(|| vortex_err!("GeoArrow geometry variant {type_id} must be an extension"))?;
+    let actual_dimension = match kind {
+        GeoArrowGeometryKind::Point => {
+            vortex_ensure!(
+                ext.is::<Point>(),
+                "type ID {type_id} must contain Point values"
+            );
+            coordinate_dimension(ext.storage_dtype())?
+        }
+        GeoArrowGeometryKind::LineString => {
+            vortex_ensure!(
+                ext.is::<LineString>(),
+                "type ID {type_id} must contain LineString values"
+            );
+            linestring_dimension(ext.storage_dtype())?
+        }
+        GeoArrowGeometryKind::Polygon => {
+            vortex_ensure!(
+                ext.is::<Polygon>(),
+                "type ID {type_id} must contain Polygon values"
+            );
+            polygon_dimension(ext.storage_dtype())?
+        }
+        GeoArrowGeometryKind::MultiPoint => {
+            vortex_ensure!(
+                ext.is::<MultiPoint>(),
+                "type ID {type_id} must contain MultiPoint values"
+            );
+            multipoint_dimension(ext.storage_dtype())?
+        }
+        GeoArrowGeometryKind::MultiLineString => {
+            vortex_ensure!(
+                ext.is::<MultiLineString>(),
+                "type ID {type_id} must contain MultiLineString values"
+            );
+            multilinestring_dimension(ext.storage_dtype())?
+        }
+        GeoArrowGeometryKind::MultiPolygon => {
+            vortex_ensure!(
+                ext.is::<MultiPolygon>(),
+                "type ID {type_id} must contain MultiPolygon values"
+            );
+            multipolygon_dimension(ext.storage_dtype())?
+        }
+        GeoArrowGeometryKind::GeometryCollection => {
+            vortex_bail!("GeoArrow GeometryCollection values are not supported yet")
+        }
+    };
+    vortex_ensure!(
+        actual_dimension == expected_dimension,
+        "GeoArrow geometry type ID {type_id} requires {expected_dimension:?} storage, got {actual_dimension:?}"
+    );
+    Ok(())
+}
+
+fn native_child_dtype(
+    type_id: u8,
+    metadata: &SpatialMetadata,
+    storage_dtype: DType,
+) -> VortexResult<DType> {
+    let (kind, _) = geoarrow_type_id_parts(type_id)?;
+    let dtype = match kind {
+        GeoArrowGeometryKind::Point => {
+            DType::Extension(ExtDType::<Point>::try_new(metadata.clone(), storage_dtype)?.erased())
+        }
+        GeoArrowGeometryKind::LineString => DType::Extension(
+            ExtDType::<LineString>::try_new(metadata.clone(), storage_dtype)?.erased(),
+        ),
+        GeoArrowGeometryKind::Polygon => DType::Extension(
+            ExtDType::<Polygon>::try_new(metadata.clone(), storage_dtype)?.erased(),
+        ),
+        GeoArrowGeometryKind::MultiPoint => DType::Extension(
+            ExtDType::<MultiPoint>::try_new(metadata.clone(), storage_dtype)?.erased(),
+        ),
+        GeoArrowGeometryKind::MultiLineString => DType::Extension(
+            ExtDType::<MultiLineString>::try_new(metadata.clone(), storage_dtype)?.erased(),
+        ),
+        GeoArrowGeometryKind::MultiPolygon => DType::Extension(
+            ExtDType::<MultiPolygon>::try_new(metadata.clone(), storage_dtype)?.erased(),
+        ),
+        GeoArrowGeometryKind::GeometryCollection => {
+            vortex_bail!("GeoArrow GeometryCollection values are not supported yet")
+        }
+    };
+    validate_variant_dtype(type_id, &dtype)?;
+    Ok(dtype)
+}
+
+fn geometry_variants(dtype: &DType) -> VortexResult<(&UnionVariants, Nullability)> {
+    let DType::Union(variants, nullability) = dtype else {
+        vortex_bail!("Geometry storage must be a union, got {dtype}");
+    };
+    Ok((variants, *nullability))
+}
+
+struct GeometryUnionParts {
+    variants: UnionVariants,
+    type_ids: PrimitiveArray,
+    offsets: PrimitiveArray,
+    children: Vec<ArrayRef>,
+}
+
+impl GeometryUnionParts {
+    fn child(&self, type_id: u8) -> Option<&ArrayRef> {
+        self.variants
+            .tag_to_child_index(type_id)
+            .and_then(|child_index| self.children.get(child_index))
+    }
+}
+
+fn geometry_union_parts(
+    storage: ArrayRef,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<GeometryUnionParts> {
+    if let Some(dense) = storage.as_opt::<DenseUnion>() {
+        return Ok(GeometryUnionParts {
+            variants: dense.variants().clone(),
+            type_ids: dense.type_ids().clone().execute::<PrimitiveArray>(ctx)?,
+            offsets: dense.offsets().clone().execute::<PrimitiveArray>(ctx)?,
+            children: dense.iter_children().cloned().collect(),
+        });
+    }
+
+    // Other physical encodings execute to the canonical sparse union. Its row-aligned children
+    // can use row indices as dense-union offsets, so export does not need to compact them.
+    let sparse = storage.execute::<UnionArray>(ctx)?;
+    let offsets = (0..sparse.len())
+        .map(|offset| {
+            i32::try_from(offset)
+                .map_err(|_| vortex_err!("Geometry row offset {offset} exceeds i32"))
+        })
+        .collect::<VortexResult<Vec<_>>>()?;
+    let type_ids = sparse.type_ids().clone().execute::<PrimitiveArray>(ctx)?;
+    let outer_validity = type_ids
+        .validity()?
+        .execute_mask(type_ids.len(), ctx)?
+        .into_array();
+    let children = sparse
+        .iter_children()
+        .cloned()
+        .map(|child| child.mask(outer_validity.clone()))
+        .collect::<VortexResult<Vec<_>>>()?;
+    Ok(GeometryUnionParts {
+        variants: sparse.variants().clone(),
+        type_ids,
+        offsets: PrimitiveArray::from_iter(offsets),
+        children,
+    })
+}
+
+impl ExtVTable for Geometry {
+    type Metadata = SpatialMetadata;
+    type NativeValue<'a> = Scalar;
+
+    fn id(&self) -> ExtId {
+        static ID: CachedId = CachedId::new("vortex.st.geometry");
+        *ID
+    }
+
+    fn serialize_metadata(&self, metadata: &Self::Metadata) -> VortexResult<Vec<u8>> {
+        Ok(metadata.encode_to_vec())
+    }
+
+    fn deserialize_metadata(&self, metadata: &[u8]) -> VortexResult<Self::Metadata> {
+        Ok(SpatialMetadata::decode(metadata)?)
+    }
+
+    fn validate_dtype(ext_dtype: &ExtDType<Self>) -> VortexResult<()> {
+        let (variants, _) = geometry_variants(ext_dtype.storage_dtype())?;
+        for (type_id, dtype) in variants.type_ids().iter().zip(variants.variants()) {
+            validate_variant_dtype(*type_id, &dtype)?;
+        }
+        Ok(())
+    }
+
+    fn unpack_native<'a>(
+        ext_dtype: &'a ExtDType<Self>,
+        storage_value: &'a ScalarValue,
+    ) -> VortexResult<Self::NativeValue<'a>> {
+        Scalar::try_new(
+            ext_dtype.storage_dtype().clone(),
+            Some(storage_value.clone()),
+        )
+    }
+}
+
+static GEOARROW_GEOMETRY: CachedId = CachedId::new(GeoArrowGeometryType::NAME);
+
+fn geoarrow_geometry_type(metadata: &SpatialMetadata) -> GeoArrowGeometryType {
+    GeoArrowGeometryType::new(geoarrow_metadata(metadata)).with_coord_type(CoordType::Separated)
+}
+
+/// A materialized mixed geometry extension array.
+pub struct GeometryData(ExtensionArray);
+
+impl TryFrom<ExtensionArray> for GeometryData {
+    type Error = VortexError;
+
+    fn try_from(ext: ExtensionArray) -> Result<Self, Self::Error> {
+        vortex_ensure!(
+            ext.ext_dtype().is::<Geometry>(),
+            "expected a Geometry extension array"
+        );
+        Ok(Self(ext))
+    }
+}
+
+impl GeometryData {
+    /// Serialize mixed geometries to WKB.
+    pub fn to_wkb(&self, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+        geoarrow_to_wkb(
+            &geoarrow_geometry_array(&self.0.clone().into_array(), ctx)?,
+            &ctx.session().arrow(),
+        )
+    }
+}
+
+fn geoarrow_geometry_array(
+    array: &ArrayRef,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<GeoArrowGeometryArray> {
+    let session = ctx.session().clone();
+    let field = session.arrow().to_arrow_field("", array.dtype())?;
+    let geometry_type = field
+        .try_extension_type::<GeoArrowGeometryType>()
+        .map_err(|e| vortex_err!("failed to construct GeoArrow GeometryType: {e}"))?;
+    let arrow = session
+        .arrow()
+        .execute_arrow(array.clone(), Some(&field), ctx)?;
+    GeoArrowGeometryArray::try_from((arrow.as_ref(), geometry_type))
+        .map_err(|e| vortex_err!("failed to construct GeoArrow GeometryArray: {e}"))
+}
+
+pub(crate) fn decode_mixed_geometries(
+    array: &ArrayRef,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Vec<GeoGeometry<f64>>> {
+    geoarrow_geometry_array(array, ctx)?
+        .iter()
+        .map(|geometry| -> VortexResult<GeoGeometry<f64>> {
+            Ok(geometry
+                .ok_or_else(|| vortex_err!("spatial: null geometry is not supported"))?
+                .map_err(|e| vortex_err!("spatial: geometry access failed: {e}"))?
+                .to_geometry())
+        })
+        .collect()
+}
+
+impl ArrowExportVTable for Geometry {
+    fn arrow_ext_id(&self) -> Id {
+        *GEOARROW_GEOMETRY
+    }
+
+    fn vortex_id(&self) -> Id {
+        self.id()
+    }
+
+    fn to_arrow_field(
+        &self,
+        name: &str,
+        dtype: &DType,
+        _session: &ArrowSession,
+    ) -> VortexResult<Option<Field>> {
+        let ext_dtype = dtype.as_extension();
+        let metadata = ext_dtype.metadata::<Geometry>();
+        let (_, nullability) = geometry_variants(ext_dtype.storage_dtype())?;
+        Ok(Some(
+            geoarrow_geometry_type(metadata).to_field(name, nullability.is_nullable()),
+        ))
+    }
+
+    fn execute_arrow(
+        &self,
+        array: ArrayRef,
+        target: &Field,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrowExport> {
+        let Some(ext_dtype) = array.dtype().as_extension_opt() else {
+            return Ok(ArrowExport::Unsupported(array));
+        };
+        if !ext_dtype.is::<Geometry>() {
+            return Ok(ArrowExport::Unsupported(array));
+        }
+        let Ok(target_type) = target.try_extension_type::<GeoArrowGeometryType>() else {
+            return Ok(ArrowExport::Unsupported(array));
+        };
+        if target_type.coord_type() != CoordType::Separated {
+            return Ok(ArrowExport::Unsupported(array));
+        }
+        let DataType::Union(target_fields, UnionMode::Dense) = target.data_type() else {
+            return Ok(ArrowExport::Unsupported(array));
+        };
+
+        let extension = array.execute::<ExtensionArray>(ctx)?;
+        let parts = geometry_union_parts(extension.storage_array().clone(), ctx)?;
+        let mut known_type_ids = [false; 256];
+        for source_id in parts.variants.type_ids() {
+            known_type_ids[usize::from(*source_id)] = true;
+            let source_id = i8::try_from(*source_id)
+                .map_err(|_| vortex_err!("GeoArrow geometry type ID {source_id} exceeds i8"))?;
+            vortex_ensure!(
+                target_fields
+                    .iter()
+                    .any(|(target_id, _)| target_id == source_id),
+                "target GeoArrow geometry union is missing type ID {source_id}"
+            );
+        }
+
+        let validity = parts
+            .type_ids
+            .validity()?
+            .execute_mask(parts.type_ids.len(), ctx)?;
+        let fallback_type_id = parts
+            .variants
+            .type_ids()
+            .first()
+            .copied()
+            .ok_or_else(|| vortex_err!("Geometry union has no variants"))?;
+        let arrow_type_ids = parts
+            .type_ids
+            .as_slice::<u8>()
+            .iter()
+            .zip(validity.iter())
+            .map(|(type_id, valid)| {
+                let type_id = match (known_type_ids[usize::from(*type_id)], valid) {
+                    (true, _) => *type_id,
+                    (false, false) => fallback_type_id,
+                    (false, true) => {
+                        vortex_bail!("Geometry row has unknown type ID {type_id}")
+                    }
+                };
+                i8::try_from(type_id)
+                    .map_err(|_| vortex_err!("GeoArrow geometry type ID {type_id} exceeds i8"))
+            })
+            .collect::<VortexResult<Vec<_>>>()?;
+        let arrow_offsets = parts.offsets.as_slice::<i32>().to_vec();
+
+        let session = ctx.session().clone();
+        let mut arrow_children = Vec::with_capacity(target_fields.len());
+        for (type_id, child_field) in target_fields.iter() {
+            let source_id = u8::try_from(type_id)
+                .map_err(|_| vortex_err!("GeoArrow geometry type ID {type_id} is negative"))?;
+            let Some(child) = parts.child(source_id) else {
+                arrow_children.push(new_empty_array(child_field.data_type()));
+                continue;
+            };
+            let child = child.clone().execute::<ExtensionArray>(ctx)?;
+            arrow_children.push(session.arrow().execute_arrow(
+                child.storage_array().clone(),
+                Some(child_field.as_ref()),
+                ctx,
+            )?);
+        }
+
+        let union = ArrowUnionArray::try_new(
+            target_fields.clone(),
+            ScalarBuffer::from(arrow_type_ids),
+            Some(ScalarBuffer::from(arrow_offsets)),
+            arrow_children,
+        )
+        .map_err(|e| vortex_err!("failed to construct Arrow dense union: {e}"))?;
+
+        if !target.is_nullable() {
+            vortex_ensure!(
+                validity.all_true(),
+                "cannot export nullable Geometry values to a non-nullable Arrow field"
+            );
+        }
+        for (row, _) in validity.iter().enumerate().filter(|(_, valid)| !valid) {
+            let type_id = union.type_id(row);
+            let offset = union.value_offset(row);
+            vortex_ensure!(
+                union.child(type_id).is_null(offset),
+                "GeoArrow Geometry null at row {row} is not represented by a null selected child"
+            );
+        }
+
+        Ok(ArrowExport::Exported(Arc::new(union)))
+    }
+}
+
+impl ArrowImportVTable for Geometry {
+    fn arrow_ext_id(&self) -> Id {
+        *GEOARROW_GEOMETRY
+    }
+
+    fn from_arrow_field(
+        &self,
+        field: &Field,
+        session: &ArrowSession,
+    ) -> VortexResult<Option<DType>> {
+        let Ok(geometry_type) = field.try_extension_type::<GeoArrowGeometryType>() else {
+            return Ok(None);
+        };
+        vortex_ensure!(
+            geometry_type.coord_type() == CoordType::Separated,
+            "geoarrow.geometry with interleaved coordinates is not supported; re-encode with separated coordinates"
+        );
+        let DataType::Union(fields, UnionMode::Dense) = field.data_type() else {
+            vortex_bail!("geoarrow.geometry requires dense union storage");
+        };
+        let metadata = spatial_metadata_from_arrow(geometry_type.metadata());
+        let mut names = Vec::new();
+        let mut dtypes = Vec::new();
+        let mut type_ids = Vec::new();
+        for (type_id, child_field) in fields.iter() {
+            let type_id = u8::try_from(type_id)
+                .map_err(|_| vortex_err!("GeoArrow geometry type ID {type_id} is negative"))?;
+            let (kind, _) = geoarrow_type_id_parts(type_id)?;
+            if kind == GeoArrowGeometryKind::GeometryCollection {
+                continue;
+            }
+            let storage_dtype = session
+                .from_arrow_datatype(child_field.data_type(), child_field.is_nullable().into())?;
+            names.push(child_field.name().as_str());
+            dtypes.push(native_child_dtype(type_id, &metadata, storage_dtype)?);
+            type_ids.push(type_id);
+        }
+        let variants = UnionVariants::try_new(FieldNames::from(names), dtypes, type_ids)?;
+        let storage_dtype = DType::Union(variants, field.is_nullable().into());
+        Ok(Some(DType::Extension(
+            ExtDType::<Geometry>::try_new(metadata, storage_dtype)?.erased(),
+        )))
+    }
+
+    fn from_arrow_array(
+        &self,
+        array: ArrowArrayRef,
+        field: &Field,
+        dtype: &DType,
+        session: &ArrowSession,
+    ) -> VortexResult<ArrowImport> {
+        let Some(ext_dtype) = dtype.as_extension_opt() else {
+            return Ok(ArrowImport::Unsupported(array));
+        };
+        if !ext_dtype.is::<Geometry>() {
+            return Ok(ArrowImport::Unsupported(array));
+        }
+        let Some(union) = array.as_any().downcast_ref::<ArrowUnionArray>() else {
+            return Ok(ArrowImport::Unsupported(array));
+        };
+        let DataType::Union(fields, UnionMode::Dense) = union.data_type() else {
+            return Ok(ArrowImport::Unsupported(array));
+        };
+        let offsets = union
+            .offsets()
+            .ok_or_else(|| vortex_err!("geoarrow.geometry requires dense union offsets"))?;
+        let type_ids = union
+            .type_ids()
+            .iter()
+            .map(|type_id| {
+                let type_id = u8::try_from(*type_id)
+                    .map_err(|_| vortex_err!("GeoArrow geometry type ID {type_id} is negative"))?;
+                let (kind, _) = geoarrow_type_id_parts(type_id)?;
+                vortex_ensure!(
+                    kind != GeoArrowGeometryKind::GeometryCollection,
+                    "GeoArrow GeometryCollection values are not supported yet"
+                );
+                Ok(type_id)
+            })
+            .collect::<VortexResult<Vec<_>>>()?;
+
+        let (variants, nullability) = geometry_variants(ext_dtype.storage_dtype())?;
+        let mut children = Vec::with_capacity(variants.len());
+        for (type_id, child_dtype) in variants.type_ids().iter().zip(variants.variants()) {
+            let arrow_id = i8::try_from(*type_id)
+                .map_err(|_| vortex_err!("GeoArrow geometry type ID {type_id} exceeds i8"))?;
+            let child_field = fields
+                .iter()
+                .find_map(|(candidate, field)| (candidate == arrow_id).then_some(field))
+                .ok_or_else(|| vortex_err!("missing GeoArrow geometry child {type_id}"))?;
+            let storage = session
+                .from_arrow_array(Arc::clone(union.child(arrow_id)), child_field.is_nullable())?;
+            let child_ext = child_dtype.as_extension();
+            children.push(ExtensionArray::try_new(child_ext.clone(), storage)?.into_array());
+        }
+
+        let row_validity = union
+            .type_ids()
+            .iter()
+            .zip(offsets.iter())
+            .enumerate()
+            .map(|(row, (type_id, offset))| {
+                let offset = usize::try_from(*offset)
+                    .map_err(|_| vortex_err!("negative GeoArrow union offset at row {row}"))?;
+                let child = union.child(*type_id);
+                vortex_ensure!(
+                    offset < child.len(),
+                    "GeoArrow union offset {offset} is out of bounds at row {row}"
+                );
+                Ok(child.is_valid(offset))
+            })
+            .collect::<VortexResult<Vec<_>>>()?;
+        if !field.is_nullable() {
+            vortex_ensure!(
+                row_validity.iter().all(|valid| *valid),
+                "non-nullable geoarrow.geometry field contains null values"
+            );
+        }
+        let validity = match nullability {
+            Nullability::NonNullable => Validity::NonNullable,
+            Nullability::Nullable => row_validity.into_iter().collect(),
+        };
+        let type_ids = PrimitiveArray::new(type_ids, validity).into_array();
+        let offsets = PrimitiveArray::from_iter(offsets.iter().copied()).into_array();
+        let dense =
+            DenseUnion::try_new(type_ids, offsets, variants.clone(), children)?.into_array();
+        Ok(ArrowImport::Imported(
+            ExtensionArray::try_new(ext_dtype.clone(), dense)?.into_array(),
+        ))
+    }
+}

--- a/vortex-spatial/src/extension/geometry.rs
+++ b/vortex-spatial/src/extension/geometry.rs
@@ -11,6 +11,7 @@ use arrow_array::Array as _;
 use arrow_array::ArrayRef as ArrowArrayRef;
 use arrow_array::UnionArray as ArrowUnionArray;
 use arrow_array::new_empty_array;
+use arrow_buffer::NullBuffer;
 use arrow_buffer::ScalarBuffer;
 use arrow_schema::DataType;
 use arrow_schema::Field;
@@ -32,7 +33,6 @@ use vortex_array::arrays::UnionArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::union::UnionArrayExt;
 use vortex_array::arrays::union::UnionArraySlotsExt;
-use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldNames;
 use vortex_array::dtype::Nullability;
@@ -77,6 +77,8 @@ use super::spatial_metadata_from_arrow;
 use crate::dense_union::DenseUnion;
 use crate::dense_union::DenseUnionArrayExt;
 use crate::dense_union::DenseUnionArraySlotsExt;
+use crate::dense_union::compact_for_arrow;
+use crate::dense_union::union_variants;
 
 /// A mixed native geometry column whose logical union variants are Point, LineString, Polygon,
 /// MultiPoint, MultiLineString, and MultiPolygon extension arrays. GeoArrow GeometryCollection
@@ -206,15 +208,7 @@ fn native_child_dtype(
             vortex_bail!("GeoArrow GeometryCollection values are not supported yet")
         }
     };
-    validate_variant_dtype(type_id, &dtype)?;
     Ok(dtype)
-}
-
-fn geometry_variants(dtype: &DType) -> VortexResult<(&UnionVariants, Nullability)> {
-    let DType::Union(variants, nullability) = dtype else {
-        vortex_bail!("Geometry storage must be a union, got {dtype}");
-    };
-    Ok((variants, *nullability))
 }
 
 struct GeometryUnionParts {
@@ -222,14 +216,6 @@ struct GeometryUnionParts {
     type_ids: PrimitiveArray,
     offsets: PrimitiveArray,
     children: Vec<ArrayRef>,
-}
-
-impl GeometryUnionParts {
-    fn child(&self, type_id: u8) -> Option<&ArrayRef> {
-        self.variants
-            .tag_to_child_index(type_id)
-            .and_then(|child_index| self.children.get(child_index))
-    }
 }
 
 fn geometry_union_parts(
@@ -245,30 +231,17 @@ fn geometry_union_parts(
         });
     }
 
-    // Other physical encodings execute to the canonical sparse union. Its row-aligned children
-    // can use row indices as dense-union offsets, so export does not need to compact them.
+    // Other physical encodings execute to the canonical sparse union, whose children are
+    // row-aligned. Row indices are therefore valid dense-union offsets, and compaction gathers
+    // each child down to the rows that select it.
     let sparse = storage.execute::<UnionArray>(ctx)?;
-    let offsets = (0..sparse.len())
-        .map(|offset| {
-            i32::try_from(offset)
-                .map_err(|_| vortex_err!("Geometry row offset {offset} exceeds i32"))
-        })
-        .collect::<VortexResult<Vec<_>>>()?;
-    let type_ids = sparse.type_ids().clone().execute::<PrimitiveArray>(ctx)?;
-    let outer_validity = type_ids
-        .validity()?
-        .execute_mask(type_ids.len(), ctx)?
-        .into_array();
-    let children = sparse
-        .iter_children()
-        .cloned()
-        .map(|child| child.mask(outer_validity.clone()))
-        .collect::<VortexResult<Vec<_>>>()?;
+    let len = i32::try_from(sparse.len())
+        .map_err(|_| vortex_err!("Geometry column of {} rows exceeds i32", sparse.len()))?;
     Ok(GeometryUnionParts {
         variants: sparse.variants().clone(),
-        type_ids,
-        offsets: PrimitiveArray::from_iter(offsets),
-        children,
+        type_ids: sparse.type_ids().clone().execute::<PrimitiveArray>(ctx)?,
+        offsets: PrimitiveArray::from_iter(0..len),
+        children: sparse.iter_children().cloned().collect(),
     })
 }
 
@@ -290,7 +263,7 @@ impl ExtVTable for Geometry {
     }
 
     fn validate_dtype(ext_dtype: &ExtDType<Self>) -> VortexResult<()> {
-        let (variants, _) = geometry_variants(ext_dtype.storage_dtype())?;
+        let (variants, _) = union_variants(ext_dtype.storage_dtype())?;
         for (type_id, dtype) in variants.type_ids().iter().zip(variants.variants()) {
             validate_variant_dtype(*type_id, &dtype)?;
         }
@@ -387,7 +360,7 @@ impl ArrowExportVTable for Geometry {
     ) -> VortexResult<Option<Field>> {
         let ext_dtype = dtype.as_extension();
         let metadata = ext_dtype.metadata::<Geometry>();
-        let (_, nullability) = geometry_variants(ext_dtype.storage_dtype())?;
+        let (_, nullability) = union_variants(ext_dtype.storage_dtype())?;
         Ok(Some(
             geoarrow_geometry_type(metadata).to_field(name, nullability.is_nullable()),
         ))
@@ -417,9 +390,7 @@ impl ArrowExportVTable for Geometry {
 
         let extension = array.execute::<ExtensionArray>(ctx)?;
         let parts = geometry_union_parts(extension.storage_array().clone(), ctx)?;
-        let mut known_type_ids = [false; 256];
         for source_id in parts.variants.type_ids() {
-            known_type_ids[usize::from(*source_id)] = true;
             let source_id = i8::try_from(*source_id)
                 .map_err(|_| vortex_err!("GeoArrow geometry type ID {source_id} exceeds i8"))?;
             vortex_ensure!(
@@ -429,42 +400,22 @@ impl ArrowExportVTable for Geometry {
                 "target GeoArrow geometry union is missing type ID {source_id}"
             );
         }
-
-        let validity = parts
-            .type_ids
-            .validity()?
-            .execute_mask(parts.type_ids.len(), ctx)?;
-        let fallback_type_id = parts
-            .variants
-            .type_ids()
-            .first()
-            .copied()
-            .ok_or_else(|| vortex_err!("Geometry union has no variants"))?;
-        let arrow_type_ids = parts
-            .type_ids
-            .as_slice::<u8>()
-            .iter()
-            .zip(validity.iter())
-            .map(|(type_id, valid)| {
-                let type_id = match (known_type_ids[usize::from(*type_id)], valid) {
-                    (true, _) => *type_id,
-                    (false, false) => fallback_type_id,
-                    (false, true) => {
-                        vortex_bail!("Geometry row has unknown type ID {type_id}")
-                    }
-                };
-                i8::try_from(type_id)
-                    .map_err(|_| vortex_err!("GeoArrow geometry type ID {type_id} exceeds i8"))
-            })
-            .collect::<VortexResult<Vec<_>>>()?;
-        let arrow_offsets = parts.offsets.as_slice::<i32>().to_vec();
+        let parts = compact_for_arrow(
+            parts.variants,
+            &parts.type_ids,
+            &parts.offsets,
+            parts.children,
+            ctx,
+        )?;
 
         let session = ctx.session().clone();
         let mut arrow_children = Vec::with_capacity(target_fields.len());
         for (type_id, child_field) in target_fields.iter() {
             let source_id = u8::try_from(type_id)
                 .map_err(|_| vortex_err!("GeoArrow geometry type ID {type_id} is negative"))?;
-            let Some(child) = parts.child(source_id) else {
+            // A mixed column rarely holds every one of the 24 declared variants, and exporting a
+            // zero-row nested coordinate child costs the same dispatch as a populated one.
+            let Some(child) = parts.child(source_id).filter(|child| !child.is_empty()) else {
                 arrow_children.push(new_empty_array(child_field.data_type()));
                 continue;
             };
@@ -478,24 +429,16 @@ impl ArrowExportVTable for Geometry {
 
         let union = ArrowUnionArray::try_new(
             target_fields.clone(),
-            ScalarBuffer::from(arrow_type_ids),
-            Some(ScalarBuffer::from(arrow_offsets)),
+            ScalarBuffer::from(parts.type_ids),
+            Some(ScalarBuffer::from(parts.offsets)),
             arrow_children,
         )
         .map_err(|e| vortex_err!("failed to construct Arrow dense union: {e}"))?;
 
         if !target.is_nullable() {
             vortex_ensure!(
-                validity.all_true(),
+                parts.validity.all_true(),
                 "cannot export nullable Geometry values to a non-nullable Arrow field"
-            );
-        }
-        for (row, _) in validity.iter().enumerate().filter(|(_, valid)| !valid) {
-            let type_id = union.type_id(row);
-            let offset = union.value_offset(row);
-            vortex_ensure!(
-                union.child(type_id).is_null(offset),
-                "GeoArrow Geometry null at row {row} is not represented by a null selected child"
             );
         }
 
@@ -584,7 +527,7 @@ impl ArrowImportVTable for Geometry {
             })
             .collect::<VortexResult<Vec<_>>>()?;
 
-        let (variants, nullability) = geometry_variants(ext_dtype.storage_dtype())?;
+        let (variants, nullability) = union_variants(ext_dtype.storage_dtype())?;
         let mut children = Vec::with_capacity(variants.len());
         for (type_id, child_dtype) in variants.type_ids().iter().zip(variants.variants()) {
             let arrow_id = i8::try_from(*type_id)
@@ -599,20 +542,32 @@ impl ArrowImportVTable for Geometry {
             children.push(ExtensionArray::try_new(child_ext.clone(), storage)?.into_array());
         }
 
-        let row_validity = union
-            .type_ids()
+        // Arrow expresses a union row's nullity through the child it selects, so row validity is a
+        // gather. Materialize each child's length and null buffer once: `UnionArray::child` and
+        // `Array::is_valid` are both dynamically dispatched, and this runs once per imported row.
+        let mut child_nulls: [Option<&NullBuffer>; 256] = [None; 256];
+        let mut child_lens = [0usize; 256];
+        for (arrow_id, _) in fields.iter() {
+            let Ok(tag) = u8::try_from(arrow_id) else {
+                continue;
+            };
+            let child = union.child(arrow_id);
+            child_lens[usize::from(tag)] = child.len();
+            child_nulls[usize::from(tag)] = child.nulls();
+        }
+        let row_validity = type_ids
             .iter()
             .zip(offsets.iter())
             .enumerate()
             .map(|(row, (type_id, offset))| {
                 let offset = usize::try_from(*offset)
                     .map_err(|_| vortex_err!("negative GeoArrow union offset at row {row}"))?;
-                let child = union.child(*type_id);
+                let tag = usize::from(*type_id);
                 vortex_ensure!(
-                    offset < child.len(),
+                    offset < child_lens[tag],
                     "GeoArrow union offset {offset} is out of bounds at row {row}"
                 );
-                Ok(child.is_valid(offset))
+                Ok(child_nulls[tag].is_none_or(|nulls| nulls.is_valid(offset)))
             })
             .collect::<VortexResult<Vec<_>>>()?;
         if !field.is_nullable() {

--- a/vortex-spatial/src/extension/mod.rs
+++ b/vortex-spatial/src/extension/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 pub(crate) mod coordinate;
+mod geometry;
 mod linestring;
 mod multilinestring;
 mod multipoint;
@@ -16,7 +17,7 @@ use std::sync::Arc;
 
 use ::wkb::reader::GeometryType;
 use arrow_array::BinaryArray;
-use geo_types::Geometry;
+use geo_types::Geometry as GeoGeometry;
 use geoarrow::array::GenericWkbArray;
 use geoarrow::array::GeoArrowArray;
 use geoarrow::datatypes::CoordType;
@@ -32,6 +33,7 @@ use geoarrow::datatypes::PointType;
 use geoarrow::datatypes::PolygonType;
 use geoarrow::datatypes::WkbType;
 use geoarrow_cast::cast::cast;
+pub use geometry::*;
 pub use linestring::*;
 pub use multilinestring::*;
 pub use multipoint::*;
@@ -73,6 +75,7 @@ pub(crate) fn is_native_geometry(dtype: &DType) -> bool {
             || ext.is::<Polygon>()
             || ext.is::<MultiLineString>()
             || ext.is::<MultiPolygon>()
+            || ext.is::<Geometry>()
             || ext.is::<Rect>()
     })
 }
@@ -143,17 +146,20 @@ pub(crate) fn flatten_row_offsets(
     Ok((row_offsets, level.execute::<StructArray>(ctx)?))
 }
 
-/// Decode a native geometry column to `geo_types`. A non-geometry operand is an error.
-pub(crate) fn geometries(
+/// Decode a native geometry column to the row-oriented `geo_types` representation.
+pub(crate) fn decode_geometries(
     array: &ArrayRef,
     ctx: &mut ExecutionCtx,
-) -> VortexResult<Vec<Geometry<f64>>> {
+) -> VortexResult<Vec<GeoGeometry<f64>>> {
     let Some(ext) = array.dtype().as_extension_opt() else {
         vortex_bail!(
             "spatial: operand is not a geometry extension type, was {}",
             array.dtype()
         );
     };
+    if ext.is::<Geometry>() {
+        return decode_mixed_geometries(array, ctx);
+    }
     let storage = array
         .clone()
         .execute::<ExtensionArray>(ctx)?
@@ -180,12 +186,12 @@ pub(crate) fn geometries(
 
 /// Decode a constant operand scalar to one geometry, a constant of any
 /// supported geometry type is decoded exactly like a column.
-pub(crate) fn single_geometry(
+pub(crate) fn decode_geometry_scalar(
     scalar: &Scalar,
     ctx: &mut ExecutionCtx,
-) -> VortexResult<Geometry<f64>> {
+) -> VortexResult<GeoGeometry<f64>> {
     let array = ConstantArray::new(scalar.clone(), 1).into_array();
-    geometries(&array, ctx)?
+    decode_geometries(&array, ctx)?
         .pop()
         .ok_or_else(|| vortex_err!("spatial: constant operand decoded to no geometry"))
 }

--- a/vortex-spatial/src/extension/mod.rs
+++ b/vortex-spatial/src/extension/mod.rs
@@ -80,6 +80,16 @@ pub(crate) fn is_native_geometry(dtype: &DType) -> bool {
     })
 }
 
+/// Whether `dtype` is the mixed [`Geometry`] union rather than a homogeneous geometry type.
+///
+/// The mixed column has union storage, so the kernels that read coordinates straight out of a
+/// homogeneous layout have to take a different path for it.
+pub(crate) fn is_mixed_geometry(dtype: &DType) -> bool {
+    dtype
+        .as_extension_opt()
+        .is_some_and(|ext| ext.is::<Geometry>())
+}
+
 /// Flatten a native geometry column into a single coordinate `Struct<x, y, ...>` containing
 /// every vertex of every geometry.
 pub(crate) fn flatten_coordinates(
@@ -157,7 +167,7 @@ pub(crate) fn decode_geometries(
             array.dtype()
         );
     };
-    if ext.is::<Geometry>() {
+    if is_mixed_geometry(array.dtype()) {
         return decode_mixed_geometries(array, ctx);
     }
     let storage = array

--- a/vortex-spatial/src/lib.rs
+++ b/vortex-spatial/src/lib.rs
@@ -14,6 +14,7 @@ use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 
 use crate::aggregate_fn::GeometryAabb;
+use crate::extension::Geometry;
 use crate::extension::LineString;
 use crate::extension::MultiLineString;
 use crate::extension::MultiPoint;
@@ -74,6 +75,9 @@ pub fn initialize(session: &VortexSession) {
     session.dtypes().register(Rect);
     session.arrow().register_exporter(Arc::new(Rect));
     session.arrow().register_importer(Arc::new(Rect));
+    session.dtypes().register(Geometry);
+    session.arrow().register_exporter(Arc::new(Geometry));
+    session.arrow().register_importer(Arc::new(Geometry));
 
     // Register the geometry scalar functions.
     session.scalar_fns().register(SpatialArea);

--- a/vortex-spatial/src/prune/mod.rs
+++ b/vortex-spatial/src/prune/mod.rs
@@ -41,8 +41,8 @@ use vortex_array::stats::rewrite::StatsRewriteCtx;
 use vortex_error::VortexResult;
 
 use crate::aggregate_fn::GeometryAabb;
+use crate::extension::decode_geometry_scalar;
 use crate::extension::is_native_geometry;
-use crate::extension::single_geometry;
 
 /// Splits a symmetric two-operand spatial predicate into the scope-rooted geometry column and the
 /// constant operand's scalar.
@@ -91,7 +91,7 @@ fn query_aabb(
     // Decoding the constant into a concrete geometry runs through the compute stack, which needs
     // an execution context.
     let mut exec = ctx.session().create_execution_ctx();
-    Ok(single_geometry(constant, &mut exec)?.bounding_rect())
+    Ok(decode_geometry_scalar(constant, &mut exec)?.bounding_rect())
 }
 
 /// The chunk's AABB statistic, as the storage struct with `xmin`/`ymin`/`xmax`/`ymax` fields.

--- a/vortex-spatial/src/scalar_fn/convex_hull.rs
+++ b/vortex-spatial/src/scalar_fn/convex_hull.rs
@@ -35,9 +35,9 @@ use crate::extension::MultiPoint;
 use crate::extension::Polygon;
 use crate::extension::build_polygon_array;
 use crate::extension::coordinate::Dimension;
-use crate::extension::geometries;
+use crate::extension::decode_geometries;
+use crate::extension::decode_geometry_scalar;
 use crate::extension::polygon_storage_dtype;
-use crate::extension::single_geometry;
 use crate::scalar_fn::execute::Execution;
 use crate::scalar_fn::execute::Operand;
 use crate::scalar_fn::execute::dispatch_unary;
@@ -75,7 +75,7 @@ fn convex_hull_array(
     output_dtype: &ExtDTypeRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    let decoded = geometries(&array.filter(valid.clone())?, ctx)?;
+    let decoded = decode_geometries(&array.filter(valid.clone())?, ctx)?;
     let hulls = decoded.iter().map(ConvexHull::convex_hull);
     let polygons = match valid.indices() {
         AllOr::All => hulls.map(Some).collect(),
@@ -104,7 +104,7 @@ fn execute_convex_hull(
 ) -> VortexResult<ArrayRef> {
     match execution.operands {
         [Operand::Constant(scalar)] => {
-            let hull = single_geometry(&scalar, ctx)?.convex_hull();
+            let hull = decode_geometry_scalar(&scalar, ctx)?.convex_hull();
             let output = build_polygon_array(
                 &[Some(hull)],
                 output_dtype.metadata::<Polygon>().clone(),

--- a/vortex-spatial/src/scalar_fn/envelope.rs
+++ b/vortex-spatial/src/scalar_fn/envelope.rs
@@ -6,6 +6,7 @@
 //! A row-oriented consumer (e.g. bulk-loading an in-memory R-tree in a spatial-join operator)
 //! reads the resulting box column back row by row.
 
+use geo::BoundingRect;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
@@ -37,6 +38,7 @@ use vortex_mask::Mask;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::extension::Geometry;
 use crate::extension::Rect;
 use crate::extension::SpatialMetadata;
 use crate::extension::box_field_names;
@@ -45,6 +47,7 @@ use crate::extension::build_rect_array;
 use crate::extension::coordinate::Dimension;
 use crate::extension::coordinate::box_corners;
 use crate::extension::coordinate::ordinates;
+use crate::extension::decode_mixed_geometries;
 use crate::extension::flatten_row_offsets;
 use crate::extension::is_native_geometry;
 use crate::scalar_fn::execute::Execution;
@@ -138,6 +141,55 @@ fn row_boxes(
     ))
 }
 
+fn mixed_geometry_boxes(
+    array: ArrayRef,
+    valid: Mask,
+    output_dtype: &ExtDType<Rect>,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let len = array.len();
+    let decoded = decode_mixed_geometries(&array.filter(valid.clone())?, ctx)?;
+    let mut decoded = decoded.into_iter();
+    let mut xmins = BufferMut::zeroed(len);
+    let mut ymins = BufferMut::zeroed(len);
+    let mut xmaxs = BufferMut::zeroed(len);
+    let mut ymaxs = BufferMut::zeroed(len);
+    let mut output_validity = vec![false; len];
+
+    for (row, valid) in valid.iter().enumerate() {
+        if !valid {
+            continue;
+        }
+        let geometry = decoded
+            .next()
+            .ok_or_else(|| vortex_err!("Geometry decode returned too few rows"))?;
+        let Some(rect) = geometry.bounding_rect() else {
+            continue;
+        };
+        xmins[row] = rect.min().x;
+        ymins[row] = rect.min().y;
+        xmaxs[row] = rect.max().x;
+        ymaxs[row] = rect.max().y;
+        output_validity[row] = true;
+    }
+    vortex_ensure!(
+        decoded.next().is_none(),
+        "Geometry decode returned too many rows"
+    );
+
+    build_rect_array(
+        output_dtype,
+        vec![
+            xmins.freeze().into_array(),
+            ymins.freeze().into_array(),
+            xmaxs.freeze().into_array(),
+            ymaxs.freeze().into_array(),
+        ],
+        len,
+        Validity::from_iter(output_validity),
+    )
+}
+
 /// Compute boxes directly over a non-constant native geometry column.
 fn envelope_array(
     array: ArrayRef,
@@ -146,11 +198,15 @@ fn envelope_array(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let len = array.len();
-    let is_rect = array
+    let ext_dtype = array
         .dtype()
         .as_extension_opt()
-        .ok_or_else(|| vortex_err!("spatial: envelope operand is not a geometry extension type"))?
-        .is::<Rect>();
+        .ok_or_else(|| vortex_err!("spatial: envelope operand is not a geometry extension type"))?;
+    if ext_dtype.is::<Geometry>() {
+        let valid = validity.execute_mask(len, ctx)?;
+        return mixed_geometry_boxes(array, valid, output_dtype, ctx);
+    }
+    let is_rect = ext_dtype.is::<Rect>();
     let storage = array
         .execute::<ExtensionArray>(ctx)?
         .storage_array()
@@ -237,9 +293,9 @@ impl ScalarFnVTable for SpatialEnvelope {
         Ok(DType::Extension(output_box_dtype()?.erased()))
     }
 
-    /// Compute each row's box directly over the native coordinate storage — no decode to
-    /// `geo_types`, no Arrow round-trip. A null row, or a valid row that owns no coordinate (an
-    /// empty geometry), yields a null box.
+    /// Compute each row's box directly over homogeneous native coordinate storage. Geometry
+    /// unions use the row-oriented fallback. A null row, or a valid row that owns no coordinate
+    /// (an empty geometry), yields a null box.
     fn execute(
         &self,
         _: &Self::Options,

--- a/vortex-spatial/src/scalar_fn/envelope.rs
+++ b/vortex-spatial/src/scalar_fn/envelope.rs
@@ -7,6 +7,7 @@
 //! reads the resulting box column back row by row.
 
 use geo::BoundingRect;
+use geo::Rect as SpatialRect;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
@@ -34,11 +35,11 @@ use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
+use vortex_mask::AllOr;
 use vortex_mask::Mask;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
-use crate::extension::Geometry;
 use crate::extension::Rect;
 use crate::extension::SpatialMetadata;
 use crate::extension::box_field_names;
@@ -49,6 +50,7 @@ use crate::extension::coordinate::box_corners;
 use crate::extension::coordinate::ordinates;
 use crate::extension::decode_mixed_geometries;
 use crate::extension::flatten_row_offsets;
+use crate::extension::is_mixed_geometry;
 use crate::extension::is_native_geometry;
 use crate::scalar_fn::execute::Execution;
 use crate::scalar_fn::execute::Operand;
@@ -141,53 +143,60 @@ fn row_boxes(
     ))
 }
 
+/// Compute each valid row's box over a mixed geometry column and scatter the results back into
+/// full-length corner columns.
+///
+/// Union storage has no single coordinate layout to read straight through, so this decodes to
+/// `geo_types` per row rather than folding raw ordinate slices like [`row_boxes`].
 fn mixed_geometry_boxes(
     array: ArrayRef,
-    valid: Mask,
-    output_dtype: &ExtDType<Rect>,
+    valid: &Mask,
     ctx: &mut ExecutionCtx,
-) -> VortexResult<ArrayRef> {
+) -> VortexResult<(Vec<ArrayRef>, Validity)> {
     let len = array.len();
     let decoded = decode_mixed_geometries(&array.filter(valid.clone())?, ctx)?;
-    let mut decoded = decoded.into_iter();
+    let rects = decoded.iter().map(BoundingRect::bounding_rect);
+
     let mut xmins = BufferMut::zeroed(len);
     let mut ymins = BufferMut::zeroed(len);
     let mut xmaxs = BufferMut::zeroed(len);
     let mut ymaxs = BufferMut::zeroed(len);
-    let mut output_validity = vec![false; len];
-
-    for (row, valid) in valid.iter().enumerate() {
-        if !valid {
-            continue;
+    // A row has a box iff it is valid and owns at least one coordinate (an empty geometry has
+    // no box).
+    let mut has_box = vec![false; len];
+    let mut scatter = |row: usize, rect: Option<SpatialRect<f64>>| {
+        if let Some(rect) = rect {
+            xmins[row] = rect.min().x;
+            ymins[row] = rect.min().y;
+            xmaxs[row] = rect.max().x;
+            ymaxs[row] = rect.max().y;
+            has_box[row] = true;
         }
-        let geometry = decoded
-            .next()
-            .ok_or_else(|| vortex_err!("Geometry decode returned too few rows"))?;
-        let Some(rect) = geometry.bounding_rect() else {
-            continue;
-        };
-        xmins[row] = rect.min().x;
-        ymins[row] = rect.min().y;
-        xmaxs[row] = rect.max().x;
-        ymaxs[row] = rect.max().y;
-        output_validity[row] = true;
-    }
-    vortex_ensure!(
-        decoded.next().is_none(),
-        "Geometry decode returned too many rows"
-    );
+    };
 
-    build_rect_array(
-        output_dtype,
+    match valid.indices() {
+        AllOr::All => {
+            for (row, rect) in rects.enumerate() {
+                scatter(row, rect);
+            }
+        }
+        AllOr::None => {}
+        AllOr::Some(rows) => {
+            for (&row, rect) in rows.iter().zip(rects) {
+                scatter(row, rect);
+            }
+        }
+    }
+
+    Ok((
         vec![
             xmins.freeze().into_array(),
             ymins.freeze().into_array(),
             xmaxs.freeze().into_array(),
             ymaxs.freeze().into_array(),
         ],
-        len,
-        Validity::from_iter(output_validity),
-    )
+        Validity::from_iter(has_box),
+    ))
 }
 
 /// Compute boxes directly over a non-constant native geometry column.
@@ -198,15 +207,16 @@ fn envelope_array(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let len = array.len();
-    let ext_dtype = array
+    if is_mixed_geometry(array.dtype()) {
+        let valid = validity.execute_mask(len, ctx)?;
+        let (corners, output_validity) = mixed_geometry_boxes(array, &valid, ctx)?;
+        return build_rect_array(output_dtype, corners, len, output_validity);
+    }
+    let is_rect = array
         .dtype()
         .as_extension_opt()
-        .ok_or_else(|| vortex_err!("spatial: envelope operand is not a geometry extension type"))?;
-    if ext_dtype.is::<Geometry>() {
-        let valid = validity.execute_mask(len, ctx)?;
-        return mixed_geometry_boxes(array, valid, output_dtype, ctx);
-    }
-    let is_rect = ext_dtype.is::<Rect>();
+        .ok_or_else(|| vortex_err!("spatial: envelope operand is not a geometry extension type"))?
+        .is::<Rect>();
     let storage = array
         .execute::<ExtensionArray>(ctx)?
         .storage_array()

--- a/vortex-spatial/src/scalar_fn/execute/binary.rs
+++ b/vortex-spatial/src/scalar_fn/execute/binary.rs
@@ -4,7 +4,7 @@
 //! Binary pairwise dispatch, plus an adapter for row-oriented `geo_types` kernels.
 
 use geo::BoundingRect;
-use geo_types::Geometry;
+use geo_types::Geometry as GeoGeometry;
 use geo_types::Rect;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
@@ -22,7 +22,7 @@ use super::Operand;
 use super::geo_types::GeoTypesOutput;
 use super::geo_types::eval_column;
 use super::geo_types::eval_column_pair;
-use crate::extension::single_geometry;
+use crate::extension::decode_geometry_scalar;
 
 /// Dispatch a binary strict geometry kernel over constants and columns.
 ///
@@ -112,7 +112,7 @@ pub(crate) fn execute_binary_geo_types<T, F>(
 ) -> VortexResult<ArrayRef>
 where
     T: GeoTypesOutput,
-    F: Fn(&Geometry<f64>, &Geometry<f64>) -> T + Copy,
+    F: Fn(&GeoGeometry<f64>, &GeoGeometry<f64>) -> T + Copy,
 {
     let nullability = Nullability::from(left.dtype().is_nullable() || right.dtype().is_nullable());
     dispatch_binary(
@@ -121,8 +121,8 @@ where
         T::dtype(nullability),
         |execution, ctx| match execution.operands {
             [Operand::Constant(left), Operand::Constant(right)] => {
-                let left = single_geometry(&left, ctx)?;
-                let right = single_geometry(&right, ctx)?;
+                let left = decode_geometry_scalar(&left, ctx)?;
+                let right = decode_geometry_scalar(&right, ctx)?;
                 Ok(ConstantArray::new(
                     compute(&left, &right).into_scalar(execution.nullability),
                     execution.len,
@@ -130,7 +130,7 @@ where
                 .into_array())
             }
             [Operand::Constant(left), Operand::Column(right)] => {
-                let left = single_geometry(&left, ctx)?;
+                let left = decode_geometry_scalar(&left, ctx)?;
                 let prescreen = bbox_precheck.zip(left.bounding_rect());
                 eval_column(
                     &right,
@@ -145,7 +145,7 @@ where
                 )
             }
             [Operand::Column(left), Operand::Constant(right)] => {
-                let right = single_geometry(&right, ctx)?;
+                let right = decode_geometry_scalar(&right, ctx)?;
                 let prescreen = bbox_precheck.zip(right.bounding_rect());
                 eval_column(
                     &left,

--- a/vortex-spatial/src/scalar_fn/execute/geo_types.rs
+++ b/vortex-spatial/src/scalar_fn/execute/geo_types.rs
@@ -6,7 +6,7 @@
 //! `geo_types` is the row representation consumed by the kernel. These helpers always construct
 //! and return Vortex arrays; they do not expose `geo_types` values as scalar-function outputs.
 
-use geo_types::Geometry;
+use geo_types::Geometry as GeoGeometry;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
@@ -22,7 +22,7 @@ use vortex_error::VortexResult;
 use vortex_mask::AllOr;
 use vortex_mask::Mask;
 
-use crate::extension::geometries;
+use crate::extension::decode_geometries;
 
 /// A primitive result produced after kernel inputs are decoded to `geo_types`.
 pub(crate) trait GeoTypesOutput: Copy {
@@ -111,10 +111,10 @@ pub(super) fn eval_column<T, F>(
 ) -> VortexResult<ArrayRef>
 where
     T: GeoTypesOutput,
-    F: Fn(&Geometry<f64>) -> T,
+    F: Fn(&GeoGeometry<f64>) -> T,
 {
     let len = column.len();
-    let decoded = geometries(&column.filter(valid.clone())?, ctx)?;
+    let decoded = decode_geometries(&column.filter(valid.clone())?, ctx)?;
     let values = decoded.iter().map(compute).collect();
     Ok(T::build_array(len, valid, values, nullability))
 }
@@ -130,11 +130,11 @@ pub(super) fn eval_column_pair<T, F>(
 ) -> VortexResult<ArrayRef>
 where
     T: GeoTypesOutput,
-    F: Fn(&Geometry<f64>, &Geometry<f64>) -> T,
+    F: Fn(&GeoGeometry<f64>, &GeoGeometry<f64>) -> T,
 {
     let len = left.len();
-    let left = geometries(&left.filter(valid.clone())?, ctx)?;
-    let right = geometries(&right.filter(valid.clone())?, ctx)?;
+    let left = decode_geometries(&left.filter(valid.clone())?, ctx)?;
+    let right = decode_geometries(&right.filter(valid.clone())?, ctx)?;
     let values = left
         .iter()
         .zip(&right)

--- a/vortex-spatial/src/scalar_fn/execute/unary.rs
+++ b/vortex-spatial/src/scalar_fn/execute/unary.rs
@@ -3,7 +3,7 @@
 
 //! Unary operand dispatch, plus an adapter for row-oriented `geo_types` kernels.
 
-use geo_types::Geometry;
+use geo_types::Geometry as GeoGeometry;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
@@ -18,7 +18,7 @@ use super::Execution;
 use super::Operand;
 use super::geo_types::GeoTypesOutput;
 use super::geo_types::eval_column;
-use crate::extension::single_geometry;
+use crate::extension::decode_geometry_scalar;
 
 /// Dispatch a unary strict geometry kernel over a constant or column.
 ///
@@ -77,7 +77,7 @@ pub(crate) fn execute_unary_geo_types<T, F>(
 ) -> VortexResult<ArrayRef>
 where
     T: GeoTypesOutput,
-    F: Fn(&Geometry<f64>) -> T,
+    F: Fn(&GeoGeometry<f64>) -> T,
 {
     let nullability = array.dtype().nullability();
     dispatch_unary(
@@ -85,7 +85,7 @@ where
         T::dtype(nullability),
         |execution, ctx| match execution.operands {
             [Operand::Constant(scalar)] => {
-                let geometry = single_geometry(&scalar, ctx)?;
+                let geometry = decode_geometry_scalar(&scalar, ctx)?;
                 Ok(ConstantArray::new(
                     compute(&geometry).into_scalar(execution.nullability),
                     execution.len,

--- a/vortex-spatial/src/scalar_fn/make_line.rs
+++ b/vortex-spatial/src/scalar_fn/make_line.rs
@@ -270,8 +270,8 @@ mod tests {
     use crate::extension::coordinate::Dimension;
     use crate::extension::coordinate::coordinate_dimension;
     use crate::extension::coordinate::ordinates;
+    use crate::extension::decode_geometries;
     use crate::extension::flatten_coordinates;
-    use crate::extension::geometries;
     use crate::test_harness::point_column;
 
     fn dimensional_point(
@@ -319,7 +319,7 @@ mod tests {
         let lines = SpatialMakeLine::try_new_array(starts, ends)?.into_array();
         assert!(lines.dtype().as_extension().is::<LineString>());
         assert_eq!(
-            geometries(&lines, &mut ctx)?,
+            decode_geometries(&lines, &mut ctx)?,
             vec![
                 Geometry::LineString(GeoLineString::new(vec![
                     Coord { x: 0.0, y: 0.0 },
@@ -351,7 +351,7 @@ mod tests {
         };
         assert_eq!(lines.len(), 3);
         assert_eq!(
-            geometries(&lines.into_array(), &mut ctx)?,
+            decode_geometries(&lines.into_array(), &mut ctx)?,
             vec![
                 Geometry::LineString(GeoLineString::new(vec![
                     Coord { x: 0.0, y: 0.0 },
@@ -391,7 +391,7 @@ mod tests {
                 }))
             })
             .collect::<Vec<_>>();
-        assert_eq!(geometries(&lines, &mut ctx)?, expected);
+        assert_eq!(decode_geometries(&lines, &mut ctx)?, expected);
         Ok(())
     }
 

--- a/vortex-spatial/src/tests/geometry.rs
+++ b/vortex-spatial/src/tests/geometry.rs
@@ -25,6 +25,7 @@ use geoarrow::datatypes::CoordType;
 use geoarrow::datatypes::Crs;
 use geoarrow::datatypes::GeometryType as GeoArrowGeometryType;
 use geoarrow::datatypes::Metadata;
+use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::aggregate_fn::Accumulator;
@@ -32,6 +33,7 @@ use vortex_array::aggregate_fn::DynAccumulator;
 use vortex_array::aggregate_fn::EmptyOptions;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::ExtensionArray;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::UnionArray as SparseUnionArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::assert_arrays_eq;
@@ -103,6 +105,25 @@ fn decode_arrow(
         .collect()
 }
 
+/// The [`supported_geometries`] fixture imported as a `vortex.st.geometry` column, alongside the
+/// GeoArrow field it came from and the geometries it should read back as.
+struct Fixture {
+    imported: ArrayRef,
+    field: Field,
+    expected: Vec<Option<GeoGeometry<f64>>>,
+}
+
+fn imported_fixture() -> VortexResult<Fixture> {
+    let expected = supported_geometries();
+    let (arrow, field) = arrow_fixture(&expected)?;
+    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    Ok(Fixture {
+        imported,
+        field,
+        expected,
+    })
+}
+
 fn aabb(result: &Scalar) -> VortexResult<(f64, f64, f64, f64)> {
     let storage = result.as_extension().to_storage_scalar();
     let fields = storage.as_struct();
@@ -161,9 +182,11 @@ fn infers_canonical_geoarrow_field() -> VortexResult<()> {
 
 #[test]
 fn roundtrips_supported_kinds_and_nulls() -> VortexResult<()> {
-    let expected = supported_geometries();
-    let (arrow, field) = arrow_fixture(&expected)?;
-    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    let Fixture {
+        imported,
+        field,
+        expected,
+    } = imported_fixture()?;
 
     let mut ctx = SESSION.create_execution_ctx();
     let extension = imported.clone().execute::<ExtensionArray>(&mut ctx)?;
@@ -216,9 +239,11 @@ fn preserves_non_first_type_id_for_nulls() -> VortexResult<()> {
 
 #[test]
 fn slice_preserves_dense_union_storage() -> VortexResult<()> {
-    let expected = supported_geometries();
-    let (arrow, field) = arrow_fixture(&expected)?;
-    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    let Fixture {
+        imported,
+        field,
+        expected,
+    } = imported_fixture()?;
     let sliced = imported.slice(1..5)?;
 
     let mut ctx = SESSION.create_execution_ctx();
@@ -233,10 +258,45 @@ fn slice_preserves_dense_union_storage() -> VortexResult<()> {
 }
 
 #[test]
-fn exports_canonical_sparse_union() -> VortexResult<()> {
-    let expected = supported_geometries();
-    let (arrow, field) = arrow_fixture(&expected)?;
+fn take_compacts_dense_union_for_arrow() -> VortexResult<()> {
+    let geometries = vec![
+        Some(GeoGeometry::Point(Point::new(1.0, 2.0))),
+        Some(GeoGeometry::Point(Point::new(3.0, 4.0))),
+        Some(GeoGeometry::Point(Point::new(5.0, 6.0))),
+    ];
+    let (arrow, field) = arrow_fixture(&geometries)?;
     let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    let taken = imported.take(PrimitiveArray::from_iter([2u32, 0, 2]).into_array())?;
+
+    let mut ctx = SESSION.create_execution_ctx();
+    let exported = SESSION
+        .arrow()
+        .execute_arrow(taken, Some(&field), &mut ctx)?;
+    let union = exported
+        .as_any()
+        .downcast_ref::<ArrowUnionArray>()
+        .ok_or_else(|| vortex_err!("exported GeoArrow Geometry must use a UnionArray"))?;
+
+    assert_eq!(union.offsets().unwrap().as_ref(), &[0, 1, 2]);
+    assert_eq!(union.child(1).len(), 3);
+    assert_eq!(
+        decode_arrow(&exported, &field)?,
+        vec![
+            geometries[2].clone(),
+            geometries[0].clone(),
+            geometries[2].clone()
+        ]
+    );
+    Ok(())
+}
+
+#[test]
+fn exports_canonical_sparse_union() -> VortexResult<()> {
+    let Fixture {
+        imported,
+        field,
+        expected,
+    } = imported_fixture()?;
     let mut ctx = SESSION.create_execution_ctx();
 
     let extension = imported.execute::<ExtensionArray>(&mut ctx)?;
@@ -255,9 +315,9 @@ fn exports_canonical_sparse_union() -> VortexResult<()> {
 
 #[test]
 fn exports_constant_nulls() -> VortexResult<()> {
-    let expected = supported_geometries();
-    let (arrow, field) = arrow_fixture(&expected)?;
-    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    let Fixture {
+        imported, field, ..
+    } = imported_fixture()?;
     let mut ctx = SESSION.create_execution_ctx();
     let nulls = ConstantArray::new(Scalar::null(imported.dtype().clone()), 2).into_array();
     let exported = SESSION
@@ -269,9 +329,9 @@ fn exports_constant_nulls() -> VortexResult<()> {
 
 #[test]
 fn decodes_supported_variants() -> VortexResult<()> {
-    let expected = supported_geometries();
-    let (arrow, field) = arrow_fixture(&expected)?;
-    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    let Fixture {
+        imported, expected, ..
+    } = imported_fixture()?;
     let mut ctx = SESSION.create_execution_ctx();
 
     let non_null = imported.slice(0..6)?;
@@ -285,9 +345,7 @@ fn decodes_supported_variants() -> VortexResult<()> {
 
 #[test]
 fn computes_aabb_across_variants() -> VortexResult<()> {
-    let expected = supported_geometries();
-    let (arrow, field) = arrow_fixture(&expected)?;
-    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    let Fixture { imported, .. } = imported_fixture()?;
     let mut ctx = SESSION.create_execution_ctx();
     let mut accumulator =
         Accumulator::try_new(GeometryAabb, EmptyOptions, imported.dtype().clone())?;
@@ -298,9 +356,7 @@ fn computes_aabb_across_variants() -> VortexResult<()> {
 
 #[test]
 fn computes_envelopes_across_variants() -> VortexResult<()> {
-    let expected = supported_geometries();
-    let (arrow, field) = arrow_fixture(&expected)?;
-    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    let Fixture { imported, .. } = imported_fixture()?;
     let mut ctx = SESSION.create_execution_ctx();
     let envelopes = SpatialEnvelope::try_new_array(imported)?
         .into_array()

--- a/vortex-spatial/src/tests/geometry.rs
+++ b/vortex-spatial/src/tests/geometry.rs
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Arrow interop for the mixed `vortex.st.geometry` extension (`geoarrow.geometry`).
+
+use std::sync::Arc;
+
+use arrow_array::ArrayRef as ArrowArrayRef;
+use arrow_array::UnionArray as ArrowUnionArray;
+use arrow_schema::Field;
+use geo_traits::to_geo::ToGeoGeometry;
+use geo_types::Geometry as GeoGeometry;
+use geo_types::GeometryCollection;
+use geo_types::LineString;
+use geo_types::MultiLineString;
+use geo_types::MultiPoint;
+use geo_types::MultiPolygon;
+use geo_types::Point;
+use geo_types::Polygon;
+use geoarrow::array::GeoArrowArrayAccessor;
+use geoarrow::array::GeometryArray as GeoArrowGeometryArray;
+use geoarrow::array::GeometryBuilder;
+use geoarrow::array::IntoArrow;
+use geoarrow::datatypes::CoordType;
+use geoarrow::datatypes::Crs;
+use geoarrow::datatypes::GeometryType as GeoArrowGeometryType;
+use geoarrow::datatypes::Metadata;
+use vortex_array::IntoArray;
+use vortex_array::VortexSessionExecute;
+use vortex_array::aggregate_fn::Accumulator;
+use vortex_array::aggregate_fn::DynAccumulator;
+use vortex_array::aggregate_fn::EmptyOptions;
+use vortex_array::arrays::ConstantArray;
+use vortex_array::arrays::ExtensionArray;
+use vortex_array::arrays::UnionArray as SparseUnionArray;
+use vortex_array::arrays::extension::ExtensionArrayExt;
+use vortex_array::assert_arrays_eq;
+use vortex_array::dtype::DType;
+use vortex_array::scalar::Scalar;
+use vortex_arrow::ArrowSessionExt;
+use vortex_error::VortexResult;
+use vortex_error::vortex_err;
+
+use super::SESSION;
+use crate::aggregate_fn::GeometryAabb;
+use crate::dense_union::DenseUnion;
+use crate::extension::Geometry;
+use crate::extension::decode_geometries;
+use crate::scalar_fn::envelope::SpatialEnvelope;
+use crate::test_harness::nullable_rect_column;
+
+fn polygon(points: &[(f64, f64)]) -> Polygon<f64> {
+    Polygon::new(LineString::from(points.to_vec()), vec![])
+}
+
+fn supported_geometries() -> Vec<Option<GeoGeometry<f64>>> {
+    let line = LineString::from(vec![(3.0, -4.0), (8.0, 7.0)]);
+    let polygon = polygon(&[(0.0, 0.0), (4.0, 0.0), (4.0, 3.0), (0.0, 0.0)]);
+    vec![
+        Some(GeoGeometry::Point(Point::new(1.0, 2.0))),
+        Some(GeoGeometry::LineString(line.clone())),
+        Some(GeoGeometry::Polygon(polygon.clone())),
+        Some(GeoGeometry::MultiPoint(MultiPoint::new(vec![
+            Point::new(-2.0, 5.0),
+            Point::new(4.0, 9.0),
+        ]))),
+        Some(GeoGeometry::MultiLineString(MultiLineString::new(vec![
+            line,
+        ]))),
+        Some(GeoGeometry::MultiPolygon(MultiPolygon::new(vec![polygon]))),
+        None,
+    ]
+}
+
+fn geoarrow_geometry_type() -> GeoArrowGeometryType {
+    let crs = Crs::from_unknown_crs_type("EPSG:4326".to_string());
+    GeoArrowGeometryType::new(Arc::new(Metadata::new(crs, None)))
+        .with_coord_type(CoordType::Separated)
+}
+
+fn arrow_fixture(geometries: &[Option<GeoGeometry<f64>>]) -> VortexResult<(ArrowArrayRef, Field)> {
+    let geometry_type = geoarrow_geometry_type();
+    let array = GeometryBuilder::from_nullable_geometries(geometries, geometry_type.clone())
+        .map_err(|e| vortex_err!("failed to build GeoArrow geometry array: {e}"))?
+        .finish();
+    let field = geometry_type.to_field("geom", true);
+    Ok((Arc::new(array.into_arrow()), field))
+}
+
+fn decode_arrow(
+    array: &ArrowArrayRef,
+    field: &Field,
+) -> VortexResult<Vec<Option<GeoGeometry<f64>>>> {
+    let geometries = GeoArrowGeometryArray::try_from((array.as_ref(), field))
+        .map_err(|e| vortex_err!("failed to decode exported GeoArrow geometry array: {e}"))?;
+    geometries
+        .iter()
+        .map(|geometry| match geometry {
+            None => Ok(None),
+            Some(Ok(geometry)) => Ok(Some(geometry.to_geometry())),
+            Some(Err(e)) => Err(vortex_err!("failed to access GeoArrow geometry: {e}")),
+        })
+        .collect()
+}
+
+fn aabb(result: &Scalar) -> VortexResult<(f64, f64, f64, f64)> {
+    let storage = result.as_extension().to_storage_scalar();
+    let fields = storage.as_struct();
+    let read = |name: &str| -> VortexResult<f64> {
+        f64::try_from(
+            &fields
+                .field(name)
+                .ok_or_else(|| vortex_err!("AABB result is missing {name}"))?,
+        )
+    };
+    Ok((read("xmin")?, read("ymin")?, read("xmax")?, read("ymax")?))
+}
+
+#[test]
+fn imports_as_geometry_over_logical_union() -> VortexResult<()> {
+    let field = geoarrow_geometry_type().to_field("geom", true);
+    let dtype = SESSION.arrow().from_arrow_field(&field)?;
+
+    let DType::Extension(ext) = &dtype else {
+        return Err(vortex_err!(
+            "expected Geometry extension dtype, got {dtype}"
+        ));
+    };
+    assert!(ext.is::<Geometry>());
+    assert_eq!(ext.metadata::<Geometry>().crs.as_deref(), Some("EPSG:4326"));
+
+    let DType::Union(variants, nullability) = ext.storage_dtype() else {
+        return Err(vortex_err!(
+            "expected logical Union storage, got {}",
+            ext.storage_dtype()
+        ));
+    };
+    assert!(nullability.is_nullable());
+    assert_eq!(variants.len(), 24);
+    assert!(variants.type_ids().iter().all(|type_id| type_id % 10 != 7));
+    Ok(())
+}
+
+#[test]
+fn infers_canonical_geoarrow_field() -> VortexResult<()> {
+    let expected_type = geoarrow_geometry_type();
+    let dtype = SESSION
+        .arrow()
+        .from_arrow_field(&expected_type.to_field("input", true))?;
+    let field = SESSION.arrow().to_arrow_field("geom", &dtype)?;
+
+    assert_eq!(field.name(), "geom");
+    assert!(field.is_nullable());
+    assert_eq!(field.data_type(), &expected_type.data_type());
+    let actual_type = field
+        .try_extension_type::<GeoArrowGeometryType>()
+        .map_err(|e| vortex_err!("failed to read inferred GeoArrow GeometryType: {e}"))?;
+    assert_eq!(actual_type, expected_type);
+    Ok(())
+}
+
+#[test]
+fn roundtrips_supported_kinds_and_nulls() -> VortexResult<()> {
+    let expected = supported_geometries();
+    let (arrow, field) = arrow_fixture(&expected)?;
+    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+
+    let mut ctx = SESSION.create_execution_ctx();
+    let extension = imported.clone().execute::<ExtensionArray>(&mut ctx)?;
+    assert!(extension.storage_array().is::<DenseUnion>());
+    assert_eq!(
+        imported
+            .validity()?
+            .execute_mask(imported.len(), &mut ctx)?
+            .iter()
+            .collect::<Vec<_>>(),
+        vec![true, true, true, true, true, true, false]
+    );
+
+    let exported = SESSION
+        .arrow()
+        .execute_arrow(imported, Some(&field), &mut ctx)?;
+    assert_eq!(decode_arrow(&exported, &field)?, expected);
+    Ok(())
+}
+
+#[test]
+fn preserves_non_first_type_id_for_nulls() -> VortexResult<()> {
+    let expected = vec![
+        Some(GeoGeometry::LineString(LineString::from(vec![
+            (0.0, 1.0),
+            (2.0, 3.0),
+        ]))),
+        None,
+    ];
+    let (arrow, field) = arrow_fixture(&expected)?;
+    let input = arrow
+        .as_any()
+        .downcast_ref::<ArrowUnionArray>()
+        .ok_or_else(|| vortex_err!("GeoArrow fixture must use a UnionArray"))?;
+    assert_eq!(input.type_ids().as_ref(), &[2, 2]);
+
+    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    let mut ctx = SESSION.create_execution_ctx();
+    let exported = SESSION
+        .arrow()
+        .execute_arrow(imported, Some(&field), &mut ctx)?;
+    let output = exported
+        .as_any()
+        .downcast_ref::<ArrowUnionArray>()
+        .ok_or_else(|| vortex_err!("exported GeoArrow Geometry must use a UnionArray"))?;
+    assert_eq!(output.type_ids().as_ref(), &[2, 2]);
+    assert_eq!(decode_arrow(&exported, &field)?, expected);
+    Ok(())
+}
+
+#[test]
+fn slice_preserves_dense_union_storage() -> VortexResult<()> {
+    let expected = supported_geometries();
+    let (arrow, field) = arrow_fixture(&expected)?;
+    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    let sliced = imported.slice(1..5)?;
+
+    let mut ctx = SESSION.create_execution_ctx();
+    let extension = sliced.clone().execute::<ExtensionArray>(&mut ctx)?;
+    assert!(extension.storage_array().is::<DenseUnion>());
+
+    let exported = SESSION
+        .arrow()
+        .execute_arrow(sliced, Some(&field), &mut ctx)?;
+    assert_eq!(decode_arrow(&exported, &field)?, expected[1..5]);
+    Ok(())
+}
+
+#[test]
+fn exports_canonical_sparse_union() -> VortexResult<()> {
+    let expected = supported_geometries();
+    let (arrow, field) = arrow_fixture(&expected)?;
+    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    let mut ctx = SESSION.create_execution_ctx();
+
+    let extension = imported.execute::<ExtensionArray>(&mut ctx)?;
+    let sparse = extension
+        .storage_array()
+        .clone()
+        .execute::<SparseUnionArray>(&mut ctx)?;
+    let sparse_geometry =
+        ExtensionArray::try_new(extension.ext_dtype().clone(), sparse.into_array())?.into_array();
+    let exported = SESSION
+        .arrow()
+        .execute_arrow(sparse_geometry, Some(&field), &mut ctx)?;
+    assert_eq!(decode_arrow(&exported, &field)?, expected);
+    Ok(())
+}
+
+#[test]
+fn exports_constant_nulls() -> VortexResult<()> {
+    let expected = supported_geometries();
+    let (arrow, field) = arrow_fixture(&expected)?;
+    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    let mut ctx = SESSION.create_execution_ctx();
+    let nulls = ConstantArray::new(Scalar::null(imported.dtype().clone()), 2).into_array();
+    let exported = SESSION
+        .arrow()
+        .execute_arrow(nulls, Some(&field), &mut ctx)?;
+    assert_eq!(decode_arrow(&exported, &field)?, vec![None, None]);
+    Ok(())
+}
+
+#[test]
+fn decodes_supported_variants() -> VortexResult<()> {
+    let expected = supported_geometries();
+    let (arrow, field) = arrow_fixture(&expected)?;
+    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    let mut ctx = SESSION.create_execution_ctx();
+
+    let non_null = imported.slice(0..6)?;
+    let expected_non_null = expected[..6]
+        .iter()
+        .filter_map(Clone::clone)
+        .collect::<Vec<_>>();
+    assert_eq!(decode_geometries(&non_null, &mut ctx)?, expected_non_null);
+    Ok(())
+}
+
+#[test]
+fn computes_aabb_across_variants() -> VortexResult<()> {
+    let expected = supported_geometries();
+    let (arrow, field) = arrow_fixture(&expected)?;
+    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    let mut ctx = SESSION.create_execution_ctx();
+    let mut accumulator =
+        Accumulator::try_new(GeometryAabb, EmptyOptions, imported.dtype().clone())?;
+    accumulator.accumulate(&imported, &mut ctx)?;
+    assert_eq!(aabb(&accumulator.finish()?)?, (-2.0, -4.0, 8.0, 9.0));
+    Ok(())
+}
+
+#[test]
+fn computes_envelopes_across_variants() -> VortexResult<()> {
+    let expected = supported_geometries();
+    let (arrow, field) = arrow_fixture(&expected)?;
+    let imported = SESSION.arrow().from_arrow_array(arrow, &field)?;
+    let mut ctx = SESSION.create_execution_ctx();
+    let envelopes = SpatialEnvelope::try_new_array(imported)?
+        .into_array()
+        .execute::<ExtensionArray>(&mut ctx)?;
+    let expected_envelopes = nullable_rect_column(vec![
+        Some((1.0, 2.0, 1.0, 2.0)),
+        Some((3.0, -4.0, 8.0, 7.0)),
+        Some((0.0, 0.0, 4.0, 3.0)),
+        Some((-2.0, 5.0, 4.0, 9.0)),
+        Some((3.0, -4.0, 8.0, 7.0)),
+        Some((0.0, 0.0, 4.0, 3.0)),
+        None,
+    ])?;
+    assert_arrays_eq!(envelopes, expected_envelopes, &mut ctx);
+    Ok(())
+}
+
+#[test]
+fn rejects_selected_geometry_collection() -> VortexResult<()> {
+    let geometries = vec![Some(GeoGeometry::GeometryCollection(
+        GeometryCollection::new_from(vec![
+            GeoGeometry::Point(Point::new(1.0, 2.0)),
+            GeoGeometry::Point(Point::new(3.0, 4.0)),
+        ]),
+    ))];
+    let (arrow, field) = arrow_fixture(&geometries)?;
+    let Err(error) = SESSION.arrow().from_arrow_array(arrow, &field) else {
+        return Err(vortex_err!("selected GeometryCollection must be rejected"));
+    };
+    assert!(error.to_string().contains("GeometryCollection"));
+    Ok(())
+}

--- a/vortex-spatial/src/tests/mod.rs
+++ b/vortex-spatial/src/tests/mod.rs
@@ -4,6 +4,7 @@
 //! Arrow interop tests for the spatial extension types, exercising the session wiring set up
 //! by [`crate::initialize`].
 
+mod geometry;
 mod linestring;
 mod multilinestring;
 mod multipoint;

--- a/vortex-spatial/src/tests/rect.rs
+++ b/vortex-spatial/src/tests/rect.rs
@@ -110,7 +110,8 @@ fn roundtrips_through_arrow() -> VortexResult<()> {
     Ok(())
 }
 
-/// The existing spatial scalar functions run on a `Rect` operand via the shared `geometries()` decode,
+/// The existing spatial scalar functions run on a `Rect` operand via the shared
+/// `decode_geometries()` path,
 /// producing the same results as the equivalent polygon: a box `(0,0)-(10,10)` against interior
 /// point `(5,5)` and exterior point `(20,20)`.
 #[test]


### PR DESCRIPTION
## Rationale for this change

GeoArrow Geometry columns use dense unions to mix geometry kinds and dimensions. Vortex needs a logical Geometry extension over its canonical Union dtype while retaining Arrow compact children through the external DenseUnion physical encoding.

## What changes are included in this PR?

- Add the vortex.st.geometry extension mapped to geoarrow.geometry.
- Validate the standardized GeoArrow kind and dimension type IDs.
- Import Arrow dense unions as DenseUnion and export both DenseUnion and canonical sparse Union storage.
- Preserve null rows through the selected Arrow child.
- Decode Geometry values for existing spatial execution, AABB aggregation, and envelope computation.
- Cover all six supported geometry kinds, slicing, nulls, canonical sparse export, and GeometryCollection rejection.

## What APIs are changed? Are there any user-facing changes?

Adds the public Geometry and GeometryData spatial extension types and registers GeoArrow Geometry import/export in vortex_spatial::initialize. GeometryCollection fields are accepted as part of the standard schema, but selected GeometryCollection values remain unsupported.