### PR TITLE
feat(vortex-spatial): add native geometry computation core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5806,7 +5821,7 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6832254d731cb022d46927ce64403221b280b17140516cafa21e43ee4140d633"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.9.1",
  "bstr",
  "futures",
  "indexmap 2.14.0",
@@ -6827,6 +6842,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec 0.8.0",
+ "bitflags 2.13.1",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7048,6 +7082,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7266,6 +7306,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -7946,6 +7995,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -9376,6 +9437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10323,7 +10390,7 @@ dependencies = [
  "arrow-schema 58.4.0",
  "async-stream",
  "async-trait",
- "bit-vec",
+ "bit-vec 0.9.1",
  "flatbuffers",
  "futures",
  "insta",
@@ -10611,6 +10678,7 @@ dependencies = [
  "geoarrow",
  "geoarrow-cast",
  "mimalloc",
+ "proptest",
  "prost 0.14.4",
  "rstest",
  "vortex-array",
@@ -10767,6 +10835,15 @@ dependencies = [
  "vortex-mask",
  "vortex-session",
  "zstd",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,7 @@ percent-encoding = "2.3.2"
 pin-project-lite = "0.2.15"
 primitive-types = { version = "0.14.0" }
 proc-macro2 = "1.0.95"
+proptest = "1.11.0"
 prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"

--- a/vortex-spatial/Cargo.toml
+++ b/vortex-spatial/Cargo.toml
@@ -37,6 +37,7 @@ _test-harness = []
 [dev-dependencies]
 divan = { workspace = true }
 mimalloc = { workspace = true }
+proptest = { workspace = true }
 rstest = { workspace = true }
 vortex-array = { workspace = true, features = ["_test-harness"] }
 vortex-layout = { workspace = true }

--- a/vortex-spatial/src/aggregate_fn/aabb.rs
+++ b/vortex-spatial/src/aggregate_fn/aabb.rs
@@ -3,7 +3,6 @@
 
 //! The 2D axis-aligned bounding-box (AABB) aggregate for native geometry columns.
 
-use geo::Rect as SpatialRect;
 use vortex_array::ArrayRef;
 use vortex_array::Columnar;
 use vortex_array::ExecutionCtx;
@@ -23,11 +22,12 @@ use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::algorithms::Aabb;
+use crate::algorithms::coords_aabb;
 use crate::extension::Rect;
 use crate::extension::SpatialMetadata;
 use crate::extension::box_storage_dtype;
 use crate::extension::coordinate::Dimension;
-use crate::extension::coordinate::box_corners;
 use crate::extension::coordinate::ordinates;
 use crate::extension::flatten_coordinates;
 use crate::extension::is_native_geometry;
@@ -39,26 +39,15 @@ use crate::extension::is_native_geometry;
 pub struct GeometryAabb;
 
 /// Running union of geometry AABBs, or `None` until the first row. A transient
-/// `geo::Rect` value - the persisted stat is the native box (see `to_scalar`).
+/// [`Aabb`] value - the persisted stat is the native box (see `to_scalar`).
 pub struct AabbPartial {
-    rect: Option<SpatialRect<f64>>,
+    rect: Option<Aabb>,
 }
 
 impl AabbPartial {
     /// Grow the accumulated box to also cover `other`.
-    fn merge(&mut self, other: SpatialRect<f64>) {
-        self.rect = Some(self.rect.map_or(other, |cur| {
-            SpatialRect::new(
-                (
-                    cur.min().x.min(other.min().x),
-                    cur.min().y.min(other.min().y),
-                ),
-                (
-                    cur.max().x.max(other.max().x),
-                    cur.max().y.max(other.max().y),
-                ),
-            )
-        }));
+    fn merge(&mut self, other: Aabb) {
+        self.rect = Some(self.rect.map_or(other, |cur| cur.union(other)));
     }
 }
 
@@ -76,17 +65,9 @@ fn aabb_storage_dtype() -> DType {
     box_storage_dtype(Dimension::Xy, Nullability::Nullable)
 }
 
-/// The AABB of the raw `x`/`y` slices, or `None` when empty.
-fn aabb_of(xs: &[f64], ys: &[f64]) -> Option<SpatialRect<f64>> {
-    (!xs.is_empty()).then(|| {
-        let [xmin, ymin, xmax, ymax] = box_corners(xs, ys);
-        SpatialRect::new((xmin, ymin), (xmax, ymax))
-    })
-}
-
-/// Read an AABB stat scalar (a nullable native `geoarrow.box`) into a [`SpatialRect`], or `None` when
+/// Read an AABB stat scalar (a nullable native `geoarrow.box`) into an [`Aabb`], or `None` when
 /// the scalar is null (an empty group).
-fn rect_from_storage(scalar: &Scalar) -> VortexResult<Option<SpatialRect<f64>>> {
+fn rect_from_storage(scalar: &Scalar) -> VortexResult<Option<Aabb>> {
     if scalar.is_null() {
         return Ok(None);
     }
@@ -99,21 +80,23 @@ fn rect_from_storage(scalar: &Scalar) -> VortexResult<Option<SpatialRect<f64>>> 
                 .ok_or_else(|| vortex_err!("AABB missing {name}"))?,
         )
     };
-    Ok(Some(SpatialRect::new(
-        (read("xmin")?, read("ymin")?),
-        (read("xmax")?, read("ymax")?),
+    Ok(Some(Aabb::new(
+        read("xmin")?,
+        read("ymin")?,
+        read("xmax")?,
+        read("ymax")?,
     )))
 }
 
-/// Serialize a [`SpatialRect`] as a native `geoarrow.box` stat scalar (inverse of [`rect_from_storage`]).
-fn rect_to_storage(rect: SpatialRect<f64>) -> Scalar {
+/// Serialize an [`Aabb`] as a native `geoarrow.box` stat scalar (inverse of [`rect_from_storage`]).
+fn rect_to_storage(rect: Aabb) -> Scalar {
     let storage = Scalar::struct_(
         aabb_storage_dtype(),
         vec![
-            Scalar::primitive(rect.min().x, Nullability::NonNullable),
-            Scalar::primitive(rect.min().y, Nullability::NonNullable),
-            Scalar::primitive(rect.max().x, Nullability::NonNullable),
-            Scalar::primitive(rect.max().y, Nullability::NonNullable),
+            Scalar::primitive(rect.min_x, Nullability::NonNullable),
+            Scalar::primitive(rect.min_y, Nullability::NonNullable),
+            Scalar::primitive(rect.max_x, Nullability::NonNullable),
+            Scalar::primitive(rect.max_y, Nullability::NonNullable),
         ],
     );
     Scalar::extension::<Rect>(SpatialMetadata::default(), storage)
@@ -211,7 +194,7 @@ impl AggregateFnVTable for GeometryAabb {
         let coords = flatten_coordinates(&array, ctx)?;
         let xs = ordinates(&coords, "x", ctx)?;
         let ys = ordinates(&coords, "y", ctx)?;
-        if let Some(rect) = aabb_of(&xs, &ys) {
+        if let Some(rect) = coords_aabb(&xs, &ys) {
             partial.merge(rect);
         }
         Ok(())
@@ -229,7 +212,6 @@ impl AggregateFnVTable for GeometryAabb {
 
 #[cfg(test)]
 mod tests {
-    use geo::Rect as SpatialRect;
     use vortex_array::ArrayRef;
     use vortex_array::VortexSessionExecute;
     use vortex_array::aggregate_fn::Accumulator;
@@ -247,6 +229,7 @@ mod tests {
     use super::GeometryAabb;
     use super::aabb_dtype;
     use super::rect_from_storage;
+    use crate::algorithms::Aabb;
     use crate::test_harness::linestring_column;
     use crate::test_harness::multilinestring_column;
     use crate::test_harness::multipoint_column;
@@ -284,7 +267,7 @@ mod tests {
     /// The AABB result's corners as `(xmin, ymin, xmax, ymax)`.
     fn aabb(result: &Scalar) -> VortexResult<(f64, f64, f64, f64)> {
         let rect = rect_from_storage(result)?.expect("non-null AABB");
-        Ok((rect.min().x, rect.min().y, rect.max().x, rect.max().y))
+        Ok((rect.min_x, rect.min_y, rect.max_x, rect.max_y))
     }
 
     /// The AABB of a Point column is the min/max of its coordinates, accumulated across batches.
@@ -393,7 +376,7 @@ mod tests {
     #[test]
     fn combine_partials_unions_boxes() -> VortexResult<()> {
         let bbox = |xmin, ymin, xmax, ymax| AabbPartial {
-            rect: Some(SpatialRect::new((xmin, ymin), (xmax, ymax))),
+            rect: Some(Aabb::new(xmin, ymin, xmax, ymax)),
         };
         let mut partial = AabbPartial { rect: None };
         GeometryAabb.combine_partials(
@@ -415,7 +398,7 @@ mod tests {
     #[test]
     fn combine_partials_ignores_null() -> VortexResult<()> {
         let mut partial = AabbPartial {
-            rect: Some(SpatialRect::new((0.0, 0.0), (1.0, 1.0))),
+            rect: Some(Aabb::new(0.0, 0.0, 1.0, 1.0)),
         };
         GeometryAabb.combine_partials(&mut partial, Scalar::null(aabb_dtype()))?;
         assert_eq!(

--- a/vortex-spatial/src/algorithms/area.rs
+++ b/vortex-spatial/src/algorithms/area.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Unsigned planar area.
+
+use super::Coords;
+use super::GeometryRef;
+use super::PolygonRef;
+
+/// Twice the signed shoelace area of `ring`, with every vertex shifted by the first to condition
+/// the determinant sum (as `geo` does). The ring is implicitly closed: native storage does not
+/// guarantee a closing vertex, and `geo_types::Polygon` - which the kernels previously decoded
+/// through - closes rings on construction. A stored closing vertex contributes a zero term, so
+/// closed rings compute the identical sum.
+fn twice_signed_ring_area(ring: Coords<'_>) -> f64 {
+    if ring.len() < 3 {
+        return 0.0;
+    }
+    let first = ring.coord(0);
+    let mut sum = 0.0;
+    for index in 0..ring.len() {
+        let a = ring.coord(index);
+        let b = ring.coord(if index + 1 == ring.len() {
+            0
+        } else {
+            index + 1
+        });
+        sum += (a.x - first.x) * (b.y - first.y) - (a.y - first.y) * (b.x - first.x);
+    }
+    sum
+}
+
+/// The signed area of a polygon: the exterior ring's magnitude minus each hole's magnitude,
+/// carrying the exterior ring's winding sign. This is the exact shape of `geo`'s implementation,
+/// including its treatment of mis-oriented holes.
+fn polygon_signed_area(polygon: PolygonRef<'_>) -> f64 {
+    if polygon.ring_count() == 0 {
+        return 0.0;
+    }
+    let exterior = twice_signed_ring_area(polygon.ring(0)) / 2.0;
+    let mut magnitude = exterior.abs();
+    for index in 1..polygon.ring_count() {
+        magnitude -= (twice_signed_ring_area(polygon.ring(index)) / 2.0).abs();
+    }
+    if exterior < 0.0 {
+        -magnitude
+    } else {
+        magnitude
+    }
+}
+
+/// The unsigned planar area of `geometry`, matching `geo::Area::unsigned_area` for every native
+/// type: zero- and one-dimensional geometries measure zero, a multi-polygon sums its members'
+/// unsigned areas, and a rectangle measures width times height.
+pub(crate) fn unsigned_area(geometry: GeometryRef<'_>) -> f64 {
+    match geometry {
+        GeometryRef::Point(_)
+        | GeometryRef::LineString(_)
+        | GeometryRef::MultiPoint(_)
+        | GeometryRef::MultiLineString(_) => 0.0,
+        GeometryRef::Polygon(polygon) => polygon_signed_area(polygon).abs(),
+        GeometryRef::MultiPolygon(multipolygon) => (0..multipolygon.polygon_count())
+            .map(|index| polygon_signed_area(multipolygon.polygon(index)).abs())
+            .sum(),
+        GeometryRef::Rect(aabb) => aabb.width() * aabb.height(),
+    }
+}

--- a/vortex-spatial/src/algorithms/bounds.rs
+++ b/vortex-spatial/src/algorithms/bounds.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Axis-aligned bounding boxes.
+
+use super::Aabb;
+use super::GeometryRef;
+use super::PolygonRef;
+
+/// The corners of the box containing the `(xs, ys)` coordinates, in
+/// `[xmin, ymin, xmax, ymax]` order. Inverted (infinite) corners when the slices are empty,
+/// since `f64::min`/`max` also skip any NaN ordinates.
+pub(crate) fn box_corners(xs: &[f64], ys: &[f64]) -> [f64; 4] {
+    let (mut xmin, mut ymin) = (f64::INFINITY, f64::INFINITY);
+    let (mut xmax, mut ymax) = (f64::NEG_INFINITY, f64::NEG_INFINITY);
+    for (&x, &y) in xs.iter().zip(ys) {
+        xmin = xmin.min(x);
+        ymin = ymin.min(y);
+        xmax = xmax.max(x);
+        ymax = ymax.max(y);
+    }
+    [xmin, ymin, xmax, ymax]
+}
+
+/// The [`Aabb`] of the raw ordinate slices, or `None` when they are empty. All-NaN coordinates
+/// normalize to the whole plane via [`Aabb::new`], so such rows are never pruned.
+pub(crate) fn coords_aabb(xs: &[f64], ys: &[f64]) -> Option<Aabb> {
+    (!xs.is_empty()).then(|| {
+        let [xmin, ymin, xmax, ymax] = box_corners(xs, ys);
+        Aabb::new(xmin, ymin, xmax, ymax)
+    })
+}
+
+/// The 2-D bounding box of `geometry`, or `None` for one without an extent (an empty geometry).
+/// Matches `geo::BoundingRect` for every native type; in particular a polygon's box is its
+/// exterior ring's box alone, since the holes of a valid polygon lie inside it.
+pub(crate) fn bounding_rect(geometry: GeometryRef<'_>) -> Option<Aabb> {
+    match geometry {
+        GeometryRef::Point(coord) => Some(Aabb::new(coord.x, coord.y, coord.x, coord.y)),
+        GeometryRef::Rect(aabb) => Some(aabb),
+        GeometryRef::LineString(coords) | GeometryRef::MultiPoint(coords) => {
+            coords_aabb(coords.xs(), coords.ys())
+        }
+        GeometryRef::Polygon(polygon) => polygon_bounding_rect(polygon),
+        GeometryRef::MultiLineString(multiline) => {
+            let coords = multiline.coords();
+            coords_aabb(coords.xs(), coords.ys())
+        }
+        GeometryRef::MultiPolygon(multipolygon) => (0..multipolygon.polygon_count())
+            .filter_map(|index| polygon_bounding_rect(multipolygon.polygon(index)))
+            .reduce(Aabb::union),
+    }
+}
+
+/// A polygon's bounding box: its exterior ring's box, `None` when the polygon or its exterior is
+/// empty.
+fn polygon_bounding_rect(polygon: PolygonRef<'_>) -> Option<Aabb> {
+    if polygon.ring_count() == 0 {
+        return None;
+    }
+    let exterior = polygon.ring(0);
+    coords_aabb(exterior.xs(), exterior.ys())
+}

--- a/vortex-spatial/src/algorithms/mod.rs
+++ b/vortex-spatial/src/algorithms/mod.rs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! The planar geometry computation core behind the spatial functions.
+//!
+//! Algorithms here are pure functions over [`GeometryRef`] views: borrowed slices of the
+//! canonical separated ordinate buffers plus list offsets, exactly as
+//! [`GeometryBatch`](crate::extension::GeometryBatch) lays them out. Keeping the math over plain
+//! slices keeps it free of per-row allocation, testable without an execution context, and
+//! directly comparable against the `geo` crate, which the differential tests use as an oracle.
+//!
+//! All computation is planar and two-dimensional: `z`/`m` ordinates never participate.
+//! Coordinates are assumed finite; non-finite values yield unspecified (but never panicking)
+//! results, matching the ingest-time validation policy of the native geometry types.
+
+mod area;
+mod bounds;
+#[cfg(test)]
+mod tests;
+
+pub(crate) use area::unsigned_area;
+pub(crate) use bounds::bounding_rect;
+pub(crate) use bounds::box_corners;
+pub(crate) use bounds::coords_aabb;
+
+/// A 2-D coordinate, the vertex unit of every computation. Unlike
+/// [`Coordinate`](crate::extension::coordinate::Coordinate), which decodes full `z`/`m`-aware
+/// storage values, this is the planar projection the algorithms operate on.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct Coord {
+    /// The x (longitude/easting) ordinate.
+    pub(crate) x: f64,
+    /// The y (latitude/northing) ordinate.
+    pub(crate) y: f64,
+}
+
+/// A 2-D axis-aligned bounding box with `min <= max` on both axes by construction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct Aabb {
+    /// The minimum x ordinate.
+    pub(crate) min_x: f64,
+    /// The minimum y ordinate.
+    pub(crate) min_y: f64,
+    /// The maximum x ordinate.
+    pub(crate) max_x: f64,
+    /// The maximum y ordinate.
+    pub(crate) max_y: f64,
+}
+
+impl Aabb {
+    /// A box over two corners given in any order, normalized so `min <= max` per axis. The
+    /// comparison matches `geo::Rect::new`, which also sends the inverted infinities of an
+    /// all-NaN corner fold to the whole plane.
+    pub(crate) fn new(x1: f64, y1: f64, x2: f64, y2: f64) -> Self {
+        let (min_x, max_x) = if x1 < x2 { (x1, x2) } else { (x2, x1) };
+        let (min_y, max_y) = if y1 < y2 { (y1, y2) } else { (y2, y1) };
+        Aabb {
+            min_x,
+            min_y,
+            max_x,
+            max_y,
+        }
+    }
+
+    /// The smallest box covering both `self` and `other`.
+    pub(crate) fn union(self, other: Self) -> Self {
+        Aabb {
+            min_x: self.min_x.min(other.min_x),
+            min_y: self.min_y.min(other.min_y),
+            max_x: self.max_x.max(other.max_x),
+            max_y: self.max_y.max(other.max_y),
+        }
+    }
+
+    /// The box's extent along the x axis.
+    pub(crate) fn width(&self) -> f64 {
+        self.max_x - self.min_x
+    }
+
+    /// The box's extent along the y axis.
+    pub(crate) fn height(&self) -> f64 {
+        self.max_y - self.min_y
+    }
+}
+
+/// A borrowed coordinate sequence: parallel x/y ordinate slices of equal length. The semantics
+/// depend on context: a line string's path, a multi-point's members, or one polygon ring.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Coords<'a> {
+    xs: &'a [f64],
+    ys: &'a [f64],
+}
+
+impl<'a> Coords<'a> {
+    /// A sequence over parallel ordinate slices, which must have equal lengths.
+    pub(crate) fn new(xs: &'a [f64], ys: &'a [f64]) -> Self {
+        debug_assert_eq!(xs.len(), ys.len());
+        Coords { xs, ys }
+    }
+
+    /// The number of coordinates.
+    pub(crate) fn len(&self) -> usize {
+        self.xs.len()
+    }
+
+    /// The coordinate at `index`.
+    pub(crate) fn coord(&self, index: usize) -> Coord {
+        Coord {
+            x: self.xs[index],
+            y: self.ys[index],
+        }
+    }
+
+    /// The raw x ordinate slice, for bulk folds.
+    pub(crate) fn xs(&self) -> &'a [f64] {
+        self.xs
+    }
+
+    /// The raw y ordinate slice, for bulk folds.
+    pub(crate) fn ys(&self) -> &'a [f64] {
+        self.ys
+    }
+}
+
+/// A borrowed polygon: full ordinate buffers plus `ring_count + 1` absolute vertex offsets.
+/// Ring 0 is the exterior; any further rings are holes.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PolygonRef<'a> {
+    xs: &'a [f64],
+    ys: &'a [f64],
+    rings: &'a [usize],
+}
+
+impl<'a> PolygonRef<'a> {
+    /// A polygon over `ring_count + 1` monotonic vertex offsets into the ordinate buffers.
+    pub(crate) fn new(xs: &'a [f64], ys: &'a [f64], rings: &'a [usize]) -> Self {
+        debug_assert!(!rings.is_empty());
+        PolygonRef { xs, ys, rings }
+    }
+
+    /// The number of rings, counting the exterior.
+    pub(crate) fn ring_count(&self) -> usize {
+        self.rings.len() - 1
+    }
+
+    /// The ring at `index`; ring 0 is the exterior.
+    pub(crate) fn ring(&self, index: usize) -> Coords<'a> {
+        let (start, end) = (self.rings[index], self.rings[index + 1]);
+        Coords::new(&self.xs[start..end], &self.ys[start..end])
+    }
+}
+
+/// A borrowed multi-line-string: full ordinate buffers plus `line_count + 1` absolute vertex
+/// offsets.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MultiLineStringRef<'a> {
+    xs: &'a [f64],
+    ys: &'a [f64],
+    lines: &'a [usize],
+}
+
+impl<'a> MultiLineStringRef<'a> {
+    /// A multi-line-string over `line_count + 1` monotonic vertex offsets into the ordinate
+    /// buffers.
+    pub(crate) fn new(xs: &'a [f64], ys: &'a [f64], lines: &'a [usize]) -> Self {
+        debug_assert!(!lines.is_empty());
+        MultiLineStringRef { xs, ys, lines }
+    }
+
+    /// Every vertex of every member as one contiguous sequence (members partition the span).
+    pub(crate) fn coords(&self) -> Coords<'a> {
+        let (start, end) = (self.lines[0], self.lines[self.lines.len() - 1]);
+        Coords::new(&self.xs[start..end], &self.ys[start..end])
+    }
+}
+
+/// A borrowed multi-polygon: full ordinate buffers, `polygon_count + 1` absolute ring offsets,
+/// and the full ring-to-vertex offset level shared by its polygons.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MultiPolygonRef<'a> {
+    xs: &'a [f64],
+    ys: &'a [f64],
+    polygons: &'a [usize],
+    rings: &'a [usize],
+}
+
+impl<'a> MultiPolygonRef<'a> {
+    /// A multi-polygon over `polygon_count + 1` monotonic offsets into `rings`, itself the full
+    /// monotonic ring-to-vertex offset level.
+    pub(crate) fn new(
+        xs: &'a [f64],
+        ys: &'a [f64],
+        polygons: &'a [usize],
+        rings: &'a [usize],
+    ) -> Self {
+        debug_assert!(!polygons.is_empty());
+        MultiPolygonRef {
+            xs,
+            ys,
+            polygons,
+            rings,
+        }
+    }
+
+    /// The number of member polygons.
+    pub(crate) fn polygon_count(&self) -> usize {
+        self.polygons.len() - 1
+    }
+
+    /// The member polygon at `index`.
+    pub(crate) fn polygon(&self, index: usize) -> PolygonRef<'a> {
+        let (start, end) = (self.polygons[index], self.polygons[index + 1]);
+        PolygonRef::new(self.xs, self.ys, &self.rings[start..=end])
+    }
+}
+
+/// One row of any native geometry type, borrowed from its canonicalized storage. Row validity is
+/// not part of the view; callers mask computed results separately.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum GeometryRef<'a> {
+    /// A single coordinate.
+    Point(Coord),
+    /// An open path of coordinates.
+    LineString(Coords<'a>),
+    /// An unordered set of coordinates.
+    MultiPoint(Coords<'a>),
+    /// An exterior ring plus optional holes.
+    Polygon(PolygonRef<'a>),
+    /// A set of open paths.
+    MultiLineString(MultiLineStringRef<'a>),
+    /// A set of polygons.
+    MultiPolygon(MultiPolygonRef<'a>),
+    /// An axis-aligned box.
+    Rect(Aabb),
+}

--- a/vortex-spatial/src/algorithms/tests.rs
+++ b/vortex-spatial/src/algorithms/tests.rs
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Differential tests of the computation core against its `geo` oracle, over fixed cases and
+//! property-based sweeps: failures shrink to a minimal counterexample and persist to
+//! `proptest-regressions/`. Inputs are finite by construction, matching the core's coordinate
+//! policy; the non-finite edge cases live with their kernels.
+
+use geo::Area;
+use geo::BoundingRect;
+use proptest::prelude::*;
+use rstest::rstest;
+
+use super::Aabb;
+use super::Coord;
+use super::Coords;
+use super::GeometryRef;
+use super::MultiLineStringRef;
+use super::MultiPolygonRef;
+use super::PolygonRef;
+use super::bounding_rect;
+use super::coords_aabb;
+use super::unsigned_area;
+
+type Ring = Vec<(f64, f64)>;
+
+/// An owned geometry that presents itself both as a core view (via [`Fixture::flat`]) and as its
+/// `geo_types` oracle form (via [`Fixture::geo`]).
+#[derive(Debug, Clone)]
+enum Fixture {
+    Point(f64, f64),
+    LineString(Ring),
+    MultiPoint(Ring),
+    Polygon(Vec<Ring>),
+    MultiLineString(Vec<Ring>),
+    MultiPolygon(Vec<Vec<Ring>>),
+    Rect(f64, f64, f64, f64),
+}
+
+/// Owned flattened storage mirroring `GeometryBatch`'s single-row layout, backing the borrowed
+/// view under test.
+enum Flat {
+    Point(f64, f64),
+    LineString(Vec<f64>, Vec<f64>),
+    MultiPoint(Vec<f64>, Vec<f64>),
+    Polygon(Vec<f64>, Vec<f64>, Vec<usize>),
+    MultiLineString(Vec<f64>, Vec<f64>, Vec<usize>),
+    MultiPolygon(Vec<f64>, Vec<f64>, Vec<usize>, Vec<usize>),
+    Rect(f64, f64, f64, f64),
+}
+
+/// Flatten coordinate sequences into parallel ordinate vectors plus their vertex offsets.
+fn flatten_seqs(seqs: &[Ring]) -> (Vec<f64>, Vec<f64>, Vec<usize>) {
+    let (mut xs, mut ys) = (Vec::new(), Vec::new());
+    let mut offsets = vec![0];
+    for seq in seqs {
+        for &(x, y) in seq {
+            xs.push(x);
+            ys.push(y);
+        }
+        offsets.push(xs.len());
+    }
+    (xs, ys, offsets)
+}
+
+impl Fixture {
+    fn flat(&self) -> Flat {
+        match self {
+            Fixture::Point(x, y) => Flat::Point(*x, *y),
+            Fixture::LineString(line) => {
+                let (xs, ys, _) = flatten_seqs(std::slice::from_ref(line));
+                Flat::LineString(xs, ys)
+            }
+            Fixture::MultiPoint(points) => {
+                let (xs, ys, _) = flatten_seqs(std::slice::from_ref(points));
+                Flat::MultiPoint(xs, ys)
+            }
+            Fixture::Polygon(rings) => {
+                let (xs, ys, offsets) = flatten_seqs(rings);
+                Flat::Polygon(xs, ys, offsets)
+            }
+            Fixture::MultiLineString(lines) => {
+                let (xs, ys, offsets) = flatten_seqs(lines);
+                Flat::MultiLineString(xs, ys, offsets)
+            }
+            Fixture::MultiPolygon(polygons) => {
+                let all_rings = polygons.iter().flatten().cloned().collect::<Vec<_>>();
+                let (xs, ys, rings) = flatten_seqs(&all_rings);
+                let mut offsets = vec![0];
+                for polygon in polygons {
+                    offsets.push(offsets.last().copied().unwrap_or(0) + polygon.len());
+                }
+                Flat::MultiPolygon(xs, ys, offsets, rings)
+            }
+            Fixture::Rect(x1, y1, x2, y2) => Flat::Rect(*x1, *y1, *x2, *y2),
+        }
+    }
+
+    fn geo(&self) -> geo_types::Geometry<f64> {
+        match self {
+            Fixture::Point(x, y) => geo_types::Point::new(*x, *y).into(),
+            Fixture::LineString(line) => geo_line(line).into(),
+            Fixture::MultiPoint(points) => geo_types::MultiPoint::from(points.clone()).into(),
+            Fixture::Polygon(rings) => geo_polygon(rings).into(),
+            Fixture::MultiLineString(lines) => {
+                geo_types::MultiLineString::new(lines.iter().map(geo_line).collect()).into()
+            }
+            Fixture::MultiPolygon(polygons) => {
+                geo_types::MultiPolygon::new(polygons.iter().map(|p| geo_polygon(p)).collect())
+                    .into()
+            }
+            Fixture::Rect(x1, y1, x2, y2) => geo_types::Rect::new((*x1, *y1), (*x2, *y2)).into(),
+        }
+    }
+}
+
+impl Flat {
+    fn view(&self) -> GeometryRef<'_> {
+        match self {
+            Flat::Point(x, y) => GeometryRef::Point(Coord { x: *x, y: *y }),
+            Flat::LineString(xs, ys) => GeometryRef::LineString(Coords::new(xs, ys)),
+            Flat::MultiPoint(xs, ys) => GeometryRef::MultiPoint(Coords::new(xs, ys)),
+            Flat::Polygon(xs, ys, rings) => GeometryRef::Polygon(PolygonRef::new(xs, ys, rings)),
+            Flat::MultiLineString(xs, ys, lines) => {
+                GeometryRef::MultiLineString(MultiLineStringRef::new(xs, ys, lines))
+            }
+            Flat::MultiPolygon(xs, ys, polygons, rings) => {
+                GeometryRef::MultiPolygon(MultiPolygonRef::new(xs, ys, polygons, rings))
+            }
+            Flat::Rect(x1, y1, x2, y2) => GeometryRef::Rect(Aabb::new(*x1, *y1, *x2, *y2)),
+        }
+    }
+}
+
+fn geo_line(ring: &Ring) -> geo_types::LineString<f64> {
+    geo_types::LineString::from(ring.clone())
+}
+
+fn geo_polygon(rings: &[Ring]) -> geo_types::Polygon<f64> {
+    let exterior = rings
+        .first()
+        .map(geo_line)
+        .unwrap_or_else(|| geo_types::LineString::new(Vec::new()));
+    geo_types::Polygon::new(exterior, rings.iter().skip(1).map(geo_line).collect())
+}
+
+/// Both algorithms agree with their `geo` oracle on `fixture`. Equality is exact: on finite
+/// inputs each implementation performs the same floating-point operations.
+fn assert_matches_geo(fixture: &Fixture) {
+    let flat = fixture.flat();
+    let oracle = fixture.geo();
+    assert_eq!(
+        unsigned_area(flat.view()),
+        oracle.unsigned_area(),
+        "area mismatch for {fixture:?}"
+    );
+    let expected = oracle
+        .bounding_rect()
+        .map(|rect| Aabb::new(rect.min().x, rect.min().y, rect.max().x, rect.max().y));
+    assert_eq!(
+        bounding_rect(flat.view()),
+        expected,
+        "bounding rect mismatch for {fixture:?}"
+    );
+}
+
+#[rstest]
+#[case::point(Fixture::Point(1.5, -2.0))]
+#[case::empty_linestring(Fixture::LineString(vec![]))]
+#[case::linestring(Fixture::LineString(vec![(0.0, 0.0), (3.0, 4.0), (-1.0, 2.0)]))]
+#[case::multipoint(Fixture::MultiPoint(vec![(2.0, 1.0), (-5.0, 3.0)]))]
+#[case::square_with_hole(Fixture::Polygon(vec![
+    vec![(0.0, 0.0), (4.0, 0.0), (4.0, 3.0), (0.0, 3.0), (0.0, 0.0)],
+    vec![(1.0, 1.0), (2.0, 1.0), (2.0, 2.0), (1.0, 2.0), (1.0, 1.0)],
+]))]
+#[case::clockwise_exterior(Fixture::Polygon(vec![
+    vec![(0.0, 0.0), (0.0, 3.0), (4.0, 3.0), (4.0, 0.0), (0.0, 0.0)],
+]))]
+#[case::unclosed_ring_is_implicitly_closed(Fixture::Polygon(vec![
+    vec![(0.0, 0.0), (4.0, 0.0), (4.0, 3.0)],
+]))]
+#[case::hole_larger_than_exterior(Fixture::Polygon(vec![
+    vec![(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0), (0.0, 0.0)],
+    vec![(-5.0, -5.0), (5.0, -5.0), (5.0, 5.0), (-5.0, 5.0), (-5.0, -5.0)],
+]))]
+#[case::empty_polygon(Fixture::Polygon(vec![]))]
+#[case::multilinestring(Fixture::MultiLineString(vec![
+    vec![(0.0, 0.0), (1.0, 1.0)],
+    vec![(2.0, 2.0), (3.0, 3.0)],
+]))]
+#[case::multipolygon_mixed_winding(Fixture::MultiPolygon(vec![
+    vec![vec![(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0), (0.0, 0.0)]],
+    vec![vec![(3.0, 0.0), (3.0, 3.0), (6.0, 3.0), (6.0, 0.0), (3.0, 0.0)]],
+]))]
+#[case::empty_multipolygon(Fixture::MultiPolygon(vec![]))]
+#[case::rect(Fixture::Rect(0.0, 0.0, 5.0, 3.0))]
+#[case::inverted_rect_corners(Fixture::Rect(5.0, 3.0, 0.0, 0.0))]
+fn matches_geo_on_fixed_cases(#[case] fixture: Fixture) {
+    assert_matches_geo(&fixture);
+}
+
+/// A finite ordinate; the bounded range never produces NaN, matching the core's coordinate
+/// policy.
+fn ordinate() -> impl Strategy<Value = f64> {
+    -100.0..100.0f64
+}
+
+/// An open path of up to eight vertices, possibly empty.
+fn path() -> impl Strategy<Value = Ring> {
+    prop::collection::vec((ordinate(), ordinate()), 0..=8)
+}
+
+/// A ring of at least three vertices, mostly closed but occasionally left unclosed to exercise
+/// implicit ring closure (the oracle's `geo_types::Polygon` closes rings on construction).
+fn ring() -> impl Strategy<Value = Ring> {
+    (
+        prop::collection::vec((ordinate(), ordinate()), 3..=8),
+        0u8..8,
+    )
+        .prop_map(|(mut ring, unclosed)| {
+            if unclosed != 0 {
+                ring.push(ring[0]);
+            }
+            ring
+        })
+}
+
+/// One to three rings: an exterior plus up to two holes.
+fn rings() -> impl Strategy<Value = Vec<Ring>> {
+    prop::collection::vec(ring(), 1..=3)
+}
+
+proptest! {
+    #[test]
+    fn matches_geo_on_points(x in ordinate(), y in ordinate()) {
+        assert_matches_geo(&Fixture::Point(x, y));
+    }
+
+    #[test]
+    fn matches_geo_on_linestrings(line in path()) {
+        assert_matches_geo(&Fixture::LineString(line));
+    }
+
+    #[test]
+    fn matches_geo_on_multipoints(points in path()) {
+        assert_matches_geo(&Fixture::MultiPoint(points));
+    }
+
+    #[test]
+    fn matches_geo_on_polygons(polygon in rings()) {
+        assert_matches_geo(&Fixture::Polygon(polygon));
+    }
+
+    #[test]
+    fn matches_geo_on_multilinestrings(lines in prop::collection::vec(path(), 0..=3)) {
+        assert_matches_geo(&Fixture::MultiLineString(lines));
+    }
+
+    #[test]
+    fn matches_geo_on_multipolygons(polygons in prop::collection::vec(rings(), 0..=3)) {
+        assert_matches_geo(&Fixture::MultiPolygon(polygons));
+    }
+
+    #[test]
+    fn matches_geo_on_rects(
+        x1 in ordinate(),
+        y1 in ordinate(),
+        x2 in ordinate(),
+        y2 in ordinate(),
+    ) {
+        assert_matches_geo(&Fixture::Rect(x1, y1, x2, y2));
+    }
+}
+
+/// `Aabb::new` accepts corners in any order.
+#[test]
+fn aabb_normalizes_inverted_corners() {
+    assert_eq!(Aabb::new(5.0, 3.0, 0.0, 1.0), Aabb::new(0.0, 1.0, 5.0, 3.0));
+}
+
+/// The inverted infinite corners of an all-NaN fold normalize to the whole plane, so such rows
+/// are kept by every box proof (they can never be proven absent).
+#[test]
+fn all_nan_coords_aabb_is_whole_plane() {
+    let nans = [f64::NAN, f64::NAN];
+    let aabb = coords_aabb(&nans, &nans).expect("non-empty slices have a box");
+    assert_eq!(
+        aabb,
+        Aabb::new(
+            f64::NEG_INFINITY,
+            f64::NEG_INFINITY,
+            f64::INFINITY,
+            f64::INFINITY
+        )
+    );
+}
+
+/// `union` covers both boxes.
+#[test]
+fn aabb_union_covers_both() {
+    let union = Aabb::new(0.0, 0.0, 1.0, 1.0).union(Aabb::new(5.0, -2.0, 7.0, 3.0));
+    assert_eq!(union, Aabb::new(0.0, -2.0, 7.0, 3.0));
+}

--- a/vortex-spatial/src/extension/coordinate.rs
+++ b/vortex-spatial/src/extension/coordinate.rs
@@ -221,20 +221,6 @@ pub(crate) fn ordinates(
         .execute::<Buffer<f64>>(ctx)
 }
 
-/// The corners of the box containing the `(xs, ys)` coordinates, in
-/// `[xmin, ymin, xmax, ymax]` order.
-pub(crate) fn box_corners(xs: &[f64], ys: &[f64]) -> [f64; 4] {
-    let (mut xmin, mut ymin) = (f64::INFINITY, f64::INFINITY);
-    let (mut xmax, mut ymax) = (f64::NEG_INFINITY, f64::NEG_INFINITY);
-    for (&x, &y) in xs.iter().zip(ys) {
-        xmin = xmin.min(x);
-        ymin = ymin.min(y);
-        xmax = xmax.max(x);
-        ymax = ymax.max(y);
-    }
-    [xmin, ymin, xmax, ymax]
-}
-
 #[cfg(test)]
 mod tests {
     use rstest::rstest;

--- a/vortex-spatial/src/extension/mod.rs
+++ b/vortex-spatial/src/extension/mod.rs
@@ -64,6 +64,15 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 pub use wkb::*;
 
+use crate::algorithms::Aabb;
+use crate::algorithms::Coord;
+use crate::algorithms::Coords;
+use crate::algorithms::GeometryRef;
+use crate::algorithms::MultiLineStringRef;
+use crate::algorithms::MultiPolygonRef;
+use crate::algorithms::PolygonRef;
+use crate::extension::coordinate::ordinates;
+
 /// Whether `dtype` is one of the native geometry extension types the spatial kernels operate on.
 pub(crate) fn is_native_geometry(dtype: &DType) -> bool {
     dtype.as_extension_opt().is_some_and(|ext| {
@@ -141,6 +150,241 @@ pub(crate) fn flatten_row_offsets(
         level = list.elements().clone();
     }
     Ok((row_offsets, level.execute::<StructArray>(ctx)?))
+}
+
+/// A native geometry column canonicalized for row-view access: the leaf ordinate buffers plus
+/// every list level's offsets, outer to inner, each absolute into the next level. [`Self::row`]
+/// borrows a [`GeometryRef`] without copying coordinates.
+///
+/// Row validity is not represented here: a null row's storage holds structurally valid
+/// placeholder data, so callers compute over every row and mask the results separately (see
+/// `ST_Length` for the pattern).
+pub(crate) enum GeometryBatch {
+    /// `Point` storage: one coordinate per row.
+    Point { xs: Buffer<f64>, ys: Buffer<f64> },
+    /// `LineString` storage: `rows` maps each row to its vertex run.
+    LineString {
+        rows: Vec<usize>,
+        xs: Buffer<f64>,
+        ys: Buffer<f64>,
+    },
+    /// `MultiPoint` storage: `rows` maps each row to its vertex run.
+    MultiPoint {
+        rows: Vec<usize>,
+        xs: Buffer<f64>,
+        ys: Buffer<f64>,
+    },
+    /// `Polygon` storage: `rows` maps each row to its rings, `rings` each ring to its vertices.
+    Polygon {
+        rows: Vec<usize>,
+        rings: Vec<usize>,
+        xs: Buffer<f64>,
+        ys: Buffer<f64>,
+    },
+    /// `MultiLineString` storage: `rows` maps each row to its lines, `lines` each line to its
+    /// vertices.
+    MultiLineString {
+        rows: Vec<usize>,
+        lines: Vec<usize>,
+        xs: Buffer<f64>,
+        ys: Buffer<f64>,
+    },
+    /// `MultiPolygon` storage: `rows` maps each row to its polygons, `polygons` each polygon to
+    /// its rings, and `rings` each ring to its vertices.
+    MultiPolygon {
+        rows: Vec<usize>,
+        polygons: Vec<usize>,
+        rings: Vec<usize>,
+        xs: Buffer<f64>,
+        ys: Buffer<f64>,
+    },
+    /// `Rect` storage: the four corner ordinates per row.
+    Rect {
+        xmin: Buffer<f64>,
+        ymin: Buffer<f64>,
+        xmax: Buffer<f64>,
+        ymax: Buffer<f64>,
+    },
+}
+
+impl GeometryBatch {
+    /// Canonicalize a native geometry column for view access. A non-geometry operand is an
+    /// error.
+    pub(crate) fn try_from_array(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+        let Some(ext) = array.dtype().as_extension_opt() else {
+            vortex_bail!(
+                "spatial: operand is not a geometry extension type, was {}",
+                array.dtype()
+            );
+        };
+        let storage = array
+            .clone()
+            .execute::<ExtensionArray>(ctx)?
+            .storage_array()
+            .clone();
+        if ext.is::<Point>() {
+            let (xs, ys) = leaf_ordinates(storage, ctx)?;
+            Ok(GeometryBatch::Point { xs, ys })
+        } else if ext.is::<LineString>() {
+            let (rows, coords) = list_level(storage, ctx)?;
+            let (xs, ys) = leaf_ordinates(coords, ctx)?;
+            Ok(GeometryBatch::LineString { rows, xs, ys })
+        } else if ext.is::<MultiPoint>() {
+            let (rows, coords) = list_level(storage, ctx)?;
+            let (xs, ys) = leaf_ordinates(coords, ctx)?;
+            Ok(GeometryBatch::MultiPoint { rows, xs, ys })
+        } else if ext.is::<Polygon>() {
+            let (rows, ring_lists) = list_level(storage, ctx)?;
+            let (rings, coords) = list_level(ring_lists, ctx)?;
+            let (xs, ys) = leaf_ordinates(coords, ctx)?;
+            Ok(GeometryBatch::Polygon {
+                rows,
+                rings,
+                xs,
+                ys,
+            })
+        } else if ext.is::<MultiLineString>() {
+            let (rows, line_lists) = list_level(storage, ctx)?;
+            let (lines, coords) = list_level(line_lists, ctx)?;
+            let (xs, ys) = leaf_ordinates(coords, ctx)?;
+            Ok(GeometryBatch::MultiLineString {
+                rows,
+                lines,
+                xs,
+                ys,
+            })
+        } else if ext.is::<MultiPolygon>() {
+            let (rows, polygon_lists) = list_level(storage, ctx)?;
+            let (polygons, ring_lists) = list_level(polygon_lists, ctx)?;
+            let (rings, coords) = list_level(ring_lists, ctx)?;
+            let (xs, ys) = leaf_ordinates(coords, ctx)?;
+            Ok(GeometryBatch::MultiPolygon {
+                rows,
+                polygons,
+                rings,
+                xs,
+                ys,
+            })
+        } else if ext.is::<Rect>() {
+            let corners = storage.execute::<StructArray>(ctx)?;
+            Ok(GeometryBatch::Rect {
+                xmin: ordinates(&corners, "xmin", ctx)?,
+                ymin: ordinates(&corners, "ymin", ctx)?,
+                xmax: ordinates(&corners, "xmax", ctx)?,
+                ymax: ordinates(&corners, "ymax", ctx)?,
+            })
+        } else {
+            vortex_bail!("spatial: unsupported geometry extension {}", array.dtype())
+        }
+    }
+
+    /// Canonicalize one non-null geometry scalar as a single-row batch (the constant-operand
+    /// path).
+    pub(crate) fn try_from_scalar(scalar: &Scalar, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+        Self::try_from_array(&ConstantArray::new(scalar.clone(), 1).into_array(), ctx)
+    }
+
+    /// The number of rows.
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            GeometryBatch::Point { xs, .. } => xs.len(),
+            GeometryBatch::LineString { rows, .. }
+            | GeometryBatch::MultiPoint { rows, .. }
+            | GeometryBatch::Polygon { rows, .. }
+            | GeometryBatch::MultiLineString { rows, .. }
+            | GeometryBatch::MultiPolygon { rows, .. } => rows.len() - 1,
+            GeometryBatch::Rect { xmin, .. } => xmin.len(),
+        }
+    }
+
+    /// Borrow row `index` as a [`GeometryRef`] view.
+    pub(crate) fn row(&self, index: usize) -> GeometryRef<'_> {
+        match self {
+            GeometryBatch::Point { xs, ys } => GeometryRef::Point(Coord {
+                x: xs[index],
+                y: ys[index],
+            }),
+            GeometryBatch::LineString { rows, xs, ys } => {
+                let (start, end) = (rows[index], rows[index + 1]);
+                GeometryRef::LineString(Coords::new(&xs[start..end], &ys[start..end]))
+            }
+            GeometryBatch::MultiPoint { rows, xs, ys } => {
+                let (start, end) = (rows[index], rows[index + 1]);
+                GeometryRef::MultiPoint(Coords::new(&xs[start..end], &ys[start..end]))
+            }
+            GeometryBatch::Polygon {
+                rows,
+                rings,
+                xs,
+                ys,
+            } => GeometryRef::Polygon(PolygonRef::new(
+                xs,
+                ys,
+                &rings[rows[index]..=rows[index + 1]],
+            )),
+            GeometryBatch::MultiLineString {
+                rows,
+                lines,
+                xs,
+                ys,
+            } => GeometryRef::MultiLineString(MultiLineStringRef::new(
+                xs,
+                ys,
+                &lines[rows[index]..=rows[index + 1]],
+            )),
+            GeometryBatch::MultiPolygon {
+                rows,
+                polygons,
+                rings,
+                xs,
+                ys,
+            } => GeometryRef::MultiPolygon(MultiPolygonRef::new(
+                xs,
+                ys,
+                &polygons[rows[index]..=rows[index + 1]],
+                rings,
+            )),
+            GeometryBatch::Rect {
+                xmin,
+                ymin,
+                xmax,
+                ymax,
+            } => GeometryRef::Rect(Aabb::new(
+                xmin[index],
+                ymin[index],
+                xmax[index],
+                ymax[index],
+            )),
+        }
+    }
+}
+
+/// Convert one list level to canonical offsets, returning them with the elements underneath.
+/// The offsets are position-aligned with the level's rows and absolute into the elements.
+fn list_level(level: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<(Vec<usize>, ArrayRef)> {
+    let list = list_from_list_view(level.execute::<ListViewArray>(ctx)?, ctx)?;
+    let offsets = list
+        .offsets()
+        .clone()
+        .cast(DType::Primitive(PType::U64, Nullability::NonNullable))?
+        .execute::<Buffer<u64>>(ctx)?;
+    debug_assert_eq!(offsets.len(), list.len() + 1);
+    let offsets = offsets
+        .iter()
+        .map(|&offset| {
+            usize::try_from(offset).map_err(|_| vortex_err!("spatial: list offset exceeds usize"))
+        })
+        .collect::<VortexResult<Vec<usize>>>()?;
+    Ok((offsets, list.elements().clone()))
+}
+
+/// The `x`/`y` ordinate buffers of a coordinate leaf.
+fn leaf_ordinates(
+    leaf: ArrayRef,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<(Buffer<f64>, Buffer<f64>)> {
+    let coords = leaf.execute::<StructArray>(ctx)?;
+    Ok((ordinates(&coords, "x", ctx)?, ordinates(&coords, "y", ctx)?))
 }
 
 /// Decode a native geometry column to `geo_types`. A non-geometry operand is an error.

--- a/vortex-spatial/src/lib.rs
+++ b/vortex-spatial/src/lib.rs
@@ -32,6 +32,7 @@ use crate::scalar_fn::length::SpatialLength;
 use crate::scalar_fn::make_line::SpatialMakeLine;
 
 pub mod aggregate_fn;
+mod algorithms;
 pub mod extension;
 pub mod prune;
 pub mod scalar_fn;

--- a/vortex-spatial/src/prune/distance.rs
+++ b/vortex-spatial/src/prune/distance.rs
@@ -3,7 +3,6 @@
 
 //! `ST_Distance(geom, const) <op> radius` pruning.
 
-use geo::Rect as SpatialRect;
 use vortex_array::expr::BoundExpression;
 use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
@@ -24,6 +23,7 @@ use super::lt_eq;
 use super::max_dist_sq;
 use super::min_dist_sq;
 use super::query_aabb;
+use crate::algorithms::Aabb;
 use crate::scalar_fn::distance::SpatialDistance;
 
 /// Prunes chunks for `ST_Distance(geom, const) <op> r` filters.
@@ -95,7 +95,7 @@ impl StatsRewriteRule for SpatialDistancePrune {
 /// A distance is always `>= 0`, which decides the degenerate radii up front.
 fn distance_prune_proof(
     geom: &BoundExpression,
-    query: SpatialRect<f64>,
+    query: Aabb,
     op: Operator,
     radius: f64,
 ) -> Option<BoundExpression> {

--- a/vortex-spatial/src/prune/mod.rs
+++ b/vortex-spatial/src/prune/mod.rs
@@ -16,8 +16,6 @@ mod intersects;
 mod test_harness;
 
 pub use distance::SpatialDistancePrune;
-use geo::BoundingRect;
-use geo::Rect as SpatialRect;
 pub use intersects::SpatialIntersectsPrune;
 use vortex_array::VortexSessionExecute;
 use vortex_array::aggregate_fn::AggregateFnVTableExt;
@@ -41,8 +39,10 @@ use vortex_array::stats::rewrite::StatsRewriteCtx;
 use vortex_error::VortexResult;
 
 use crate::aggregate_fn::GeometryAabb;
+use crate::algorithms::Aabb;
+use crate::algorithms::bounding_rect;
+use crate::extension::GeometryBatch;
 use crate::extension::is_native_geometry;
-use crate::extension::single_geometry;
 
 /// Splits a symmetric two-operand spatial predicate into the scope-rooted geometry column and the
 /// constant operand's scalar.
@@ -80,18 +80,17 @@ fn geometry_and_constant<'a>(
 ///
 /// Prove claims against this box rather than the constant itself: the constant lies inside it,
 /// so whatever holds for the box holds for the geometry.
-fn query_aabb(
-    constant: &Scalar,
-    ctx: &StatsRewriteCtx<'_>,
-) -> VortexResult<Option<SpatialRect<f64>>> {
+fn query_aabb(constant: &Scalar, ctx: &StatsRewriteCtx<'_>) -> VortexResult<Option<Aabb>> {
     // A null geometry literal has no extent to prove against, so it can never prune.
     if constant.is_null() {
         return Ok(None);
     }
-    // Decoding the constant into a concrete geometry runs through the compute stack, which needs
-    // an execution context.
+    // Canonicalizing the constant's storage runs through the compute stack, which needs an
+    // execution context.
     let mut exec = ctx.session().create_execution_ctx();
-    Ok(single_geometry(constant, &mut exec)?.bounding_rect())
+    Ok(bounding_rect(
+        GeometryBatch::try_from_scalar(constant, &mut exec)?.row(0),
+    ))
 }
 
 /// The chunk's AABB statistic, as the storage struct with `xmin`/`ymin`/`xmax`/`ymax` fields.
@@ -108,7 +107,7 @@ fn aabb_stat(geom: &BoundExpression) -> BoundExpression {
 /// touch, positive iff they are strictly separated.
 ///
 /// Prunes "near" predicates: `min_dist_sq > r^2` proves every row is farther than `r`.
-fn min_dist_sq(aabb: &BoundExpression, query: SpatialRect<f64>) -> BoundExpression {
+fn min_dist_sq(aabb: &BoundExpression, query: Aabb) -> BoundExpression {
     let field = |name: &str| get_item(name, aabb.clone());
     // Per axis: gap = max(0, q_lo - aabb_hi, aabb_lo - q_hi), positive only when the intervals
     // are separated. The nearest two points of the boxes are one axis-gap apart per axis, so the
@@ -122,15 +121,15 @@ fn min_dist_sq(aabb: &BoundExpression, query: SpatialRect<f64>) -> BoundExpressi
             ),
         )
     };
-    let dx = gap(query.min().x, query.max().x, field("xmin"), field("xmax"));
-    let dy = gap(query.min().y, query.max().y, field("ymin"), field("ymax"));
+    let dx = gap(query.min_x, query.max_x, field("xmin"), field("xmax"));
+    let dy = gap(query.min_y, query.max_y, field("ymin"), field("ymax"));
     checked_add(square(dx), square(dy))
 }
 
 /// Upper bound on every row's squared distance to the query AABB.
 ///
 /// Prunes "far" predicates: `max_dist_sq < r^2` proves every row is within `r`.
-fn max_dist_sq(aabb: &BoundExpression, query: SpatialRect<f64>) -> BoundExpression {
+fn max_dist_sq(aabb: &BoundExpression, query: Aabb) -> BoundExpression {
     let field = |name: &str| get_item(name, aabb.clone());
     // Per axis: span = max(q_hi, aabb_hi) - min(q_lo, aabb_lo), the farthest two points of the
     // boxes can be apart. The nullable AABB field is the second `maximum`/`minimum` argument so
@@ -142,8 +141,8 @@ fn max_dist_sq(aabb: &BoundExpression, query: SpatialRect<f64>) -> BoundExpressi
             minimum(lit(q_lo), lo),
         )
     };
-    let dx = span(query.min().x, query.max().x, field("xmin"), field("xmax"));
-    let dy = span(query.min().y, query.max().y, field("ymin"), field("ymax"));
+    let dx = span(query.min_x, query.max_x, field("xmin"), field("xmax"));
+    let dy = span(query.min_y, query.max_y, field("ymin"), field("ymax"));
     checked_add(square(dx), square(dy))
 }
 

--- a/vortex-spatial/src/scalar_fn/area.rs
+++ b/vortex-spatial/src/scalar_fn/area.rs
@@ -3,9 +3,11 @@
 
 //! `ST_Area`: unsigned planar area of native geometries.
 
-use geo::Area;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::arrays::ConstantArray;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::ScalarFnArray;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::PType;
@@ -18,13 +20,19 @@ use vortex_array::scalar_fn::ExecutionArgs;
 use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_array::scalar_fn::TypedScalarFnInstance;
+use vortex_array::validity::Validity;
+use vortex_buffer::Buffer;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::algorithms::unsigned_area;
+use crate::extension::GeometryBatch;
 use crate::extension::is_native_geometry;
-use crate::scalar_fn::execute::execute_unary_geo_types;
+use crate::scalar_fn::execute::Execution;
+use crate::scalar_fn::execute::Operand;
+use crate::scalar_fn::execute::dispatch_unary;
 
 /// Validate the native geometry operand accepted by `ST_Area`.
 fn validate_area_operand(dtypes: &[DType]) -> VortexResult<()> {
@@ -39,6 +47,32 @@ fn validate_area_operand(dtypes: &[DType]) -> VortexResult<()> {
         dtypes[0]
     );
     Ok(())
+}
+
+/// Compute unsigned areas directly over the canonicalized geometry batch.
+fn area_array(
+    array: ArrayRef,
+    validity: Validity,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let batch = GeometryBatch::try_from_array(&array, ctx)?;
+    let areas = Buffer::from_iter((0..batch.len()).map(|index| unsigned_area(batch.row(index))));
+    Ok(PrimitiveArray::new(areas, validity).into_array())
+}
+
+/// Execute area after shared constant/column and null dispatch.
+fn execute_area(
+    execution: Execution<1, Validity>,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    match execution.operands {
+        [Operand::Constant(geometry)] => {
+            let validity = Validity::from(execution.nullability);
+            let one = area_array(ConstantArray::new(geometry, 1).into_array(), validity, ctx)?;
+            Ok(ConstantArray::new(one.execute_scalar(0, ctx)?, execution.len).into_array())
+        }
+        [Operand::Column(geometries)] => area_array(geometries, execution.valid, ctx),
+    }
 }
 
 /// Unsigned planar `ST_Area` of native geometries.
@@ -97,7 +131,12 @@ impl ScalarFnVTable for SpatialArea {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         let array = args.get(0)?;
-        execute_unary_geo_types(&array, Area::unsigned_area, ctx)
+        dispatch_unary(
+            &array,
+            DType::Primitive(PType::F64, array.dtype().nullability()),
+            execute_area,
+            ctx,
+        )
     }
 
     fn validity(
@@ -220,6 +259,43 @@ mod tests {
         let expected =
             PrimitiveArray::new(vec![4.0f64, 0.0], Validity::from_iter([true, false])).into_array();
 
+        assert_arrays_eq!(areas, expected, &mut ctx);
+        Ok(())
+    }
+
+    /// A sliced column measures only its rows - the canonicalized offsets stay row-aligned even
+    /// when they do not start at zero.
+    #[test]
+    fn sliced_column_measures_sliced_rows() -> VortexResult<()> {
+        let session = vortex_array::array_session();
+        let mut ctx = session.create_execution_ctx();
+        let polygons = polygon_column(vec![
+            vec![vec![
+                (0.0, 0.0),
+                (1.0, 0.0),
+                (1.0, 1.0),
+                (0.0, 1.0),
+                (0.0, 0.0),
+            ]],
+            vec![vec![
+                (0.0, 0.0),
+                (2.0, 0.0),
+                (2.0, 2.0),
+                (0.0, 2.0),
+                (0.0, 0.0),
+            ]],
+            vec![vec![
+                (0.0, 0.0),
+                (3.0, 0.0),
+                (3.0, 3.0),
+                (0.0, 3.0),
+                (0.0, 0.0),
+            ]],
+        ])?
+        .slice(1..3)?;
+
+        let areas = SpatialArea::try_new_array(polygons)?.into_array();
+        let expected = PrimitiveArray::from_iter([4.0f64, 9.0]).into_array();
         assert_arrays_eq!(areas, expected, &mut ctx);
         Ok(())
     }

--- a/vortex-spatial/src/scalar_fn/envelope.rs
+++ b/vortex-spatial/src/scalar_fn/envelope.rs
@@ -37,13 +37,13 @@ use vortex_mask::Mask;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
 
+use crate::algorithms::box_corners;
 use crate::extension::Rect;
 use crate::extension::SpatialMetadata;
 use crate::extension::box_field_names;
 use crate::extension::box_storage_dtype;
 use crate::extension::build_rect_array;
 use crate::extension::coordinate::Dimension;
-use crate::extension::coordinate::box_corners;
 use crate::extension::coordinate::ordinates;
 use crate::extension::flatten_row_offsets;
 use crate::extension::is_native_geometry;

--- a/vortex-spatial/src/scalar_fn/execute.rs
+++ b/vortex-spatial/src/scalar_fn/execute.rs
@@ -7,10 +7,9 @@
 //! propagation without prescribing how a kernel represents geometries or builds its output.
 //! Native columnar kernels such as `ST_MakeLine` use these dispatchers directly.
 //!
-//! [`execute_unary_geo_types`] and [`execute_binary_geo_types`] are convenience adapters for
-//! row-oriented algorithms from the `geo` ecosystem. They decode valid inputs into
-//! `geo_types::Geometry`; the final output is still a Vortex [`ArrayRef`], such as an `f64` or
-//! boolean array.
+//! [`execute_binary_geo_types`] is a convenience adapter for row-oriented algorithms from the
+//! `geo` ecosystem. It decodes valid inputs into `geo_types::Geometry`; the final output is
+//! still a Vortex [`ArrayRef`], such as an `f64` or boolean array.
 
 mod binary;
 mod geo_types;
@@ -19,7 +18,6 @@ mod unary;
 pub(crate) use binary::dispatch_binary;
 pub(crate) use binary::execute_binary_geo_types;
 pub(crate) use unary::dispatch_unary;
-pub(crate) use unary::execute_unary_geo_types;
 use vortex_array::ArrayRef;
 use vortex_array::dtype::Nullability;
 use vortex_array::scalar::Scalar;

--- a/vortex-spatial/src/scalar_fn/execute/unary.rs
+++ b/vortex-spatial/src/scalar_fn/execute/unary.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Unary operand dispatch, plus an adapter for row-oriented `geo_types` kernels.
+//! Unary operand dispatch.
 
-use geo_types::Geometry;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
@@ -16,9 +15,6 @@ use vortex_error::VortexResult;
 
 use super::Execution;
 use super::Operand;
-use super::geo_types::GeoTypesOutput;
-use super::geo_types::eval_column;
-use crate::extension::single_geometry;
 
 /// Dispatch a unary strict geometry kernel over a constant or column.
 ///
@@ -60,42 +56,6 @@ where
             valid,
             len,
             nullability: output_dtype.nullability(),
-        },
-        ctx,
-    )
-}
-
-/// Run a unary row-oriented kernel whose input is decoded to `geo_types::Geometry`.
-///
-/// The `geo_types` name describes the value passed to `compute`, not the output. `T` is converted
-/// into a Vortex array before this function returns. A constant is decoded and computed once
-/// before broadcast; a column is decoded only for its valid rows.
-pub(crate) fn execute_unary_geo_types<T, F>(
-    array: &ArrayRef,
-    compute: F,
-    ctx: &mut ExecutionCtx,
-) -> VortexResult<ArrayRef>
-where
-    T: GeoTypesOutput,
-    F: Fn(&Geometry<f64>) -> T,
-{
-    let nullability = array.dtype().nullability();
-    dispatch_unary(
-        array,
-        T::dtype(nullability),
-        |execution, ctx| match execution.operands {
-            [Operand::Constant(scalar)] => {
-                let geometry = single_geometry(&scalar, ctx)?;
-                Ok(ConstantArray::new(
-                    compute(&geometry).into_scalar(execution.nullability),
-                    execution.len,
-                )
-                .into_array())
-            }
-            [Operand::Column(array)] => {
-                let valid = execution.valid.execute_mask(execution.len, ctx)?;
-                eval_column(&array, &valid, compute, execution.nullability, ctx)
-            }
         },
         ctx,
     )


### PR DESCRIPTION
First phase of #9388: an in-house planar geometry core that runs directly over the native columnar layout, replacing `geo` for `ST_Area`, the `GeometryAabb` aggregate, and the prune rules.

## What

* `vortex-spatial/src/algorithms/`: pure 2-D functions over borrowed slice views (`GeometryRef`, `Coords`, `PolygonRef`, ..., `Aabb`) — no vortex-array types inside, no per-row allocation. First algorithms: `unsigned_area`, `bounding_rect`.
* `GeometryBatch` (in `extension/`): canonicalizes a native geometry column once into ordinate buffers plus per-level list offsets; `row(i)` borrows a zero-copy view. A constant operand is a one-row batch.
* Swaps: `ST_Area` (same `dispatch_unary` shape as `ST_Length`), `GeometryAabb`, and both prune rules now use the core; `geo::Area`/`BoundingRect`/`Rect` imports are gone from them. The unary `geo_types` adapter lost its last consumer and is deleted; the binary one remains for the not-yet-swapped kernels.

## Semantics

Behavior-preserving, pinned by differential tests against `geo` (curated fixed cases plus per-family `proptest` properties; exact equality, since the core mirrors geo's float operation order). Two traps the suite caught and now encodes:

* Rings are implicitly closed — `geo_types::Polygon::new` closes rings on construction, so geo's raw "unclosed ring measures zero" rule never fired in the old decode path.
* A polygon's bounding box is its exterior ring's box alone, matching `geo::BoundingRect`.

## Verification

* `cargo nextest run -p vortex-spatial`: 269 passed (differential suite + all pre-existing kernel tests unchanged, plus a new sliced-column regression test).
* `cargo +nightly fmt --all`, workspace `cargo clippy --all-targets --all-features`, doctests, `taplo fmt --check` on changed TOML.
* `cargo bench -p vortex-spatial --bench area`, median vs `develop`: simple polygons 24.0 → 8.7 µs, with holes 55.6 → 14.1 µs, multipolygons 68.4 → 19.5 µs, nullable 29.4 → 9.3 µs.
