### PR TITLE
Remove the unused `StrictComparison::to_compare_operator`

### DIFF
--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -32,7 +32,6 @@ use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
-use crate::scalar_fn::fns::operators::CompareOperator;
 use crate::scalar_fn::fns::operators::Operator;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -67,13 +66,6 @@ pub enum StrictComparison {
 }
 
 impl StrictComparison {
-    pub const fn to_compare_operator(&self) -> CompareOperator {
-        match self {
-            StrictComparison::Strict => CompareOperator::Lt,
-            StrictComparison::NonStrict => CompareOperator::Lte,
-        }
-    }
-
     pub const fn to_operator(&self) -> Operator {
         match self {
             StrictComparison::Strict => Operator::Lt,


### PR DESCRIPTION
## Rationale for this change

`to_compare_operator` lost its last caller in #9404, which rewrote the `between_canonical` fallback to build its operators with `to_operator`. Nothing else in the workspace calls it, and it is a `pub const fn`, so no dead-code lint will report it later.

If this is a bit contentious, feel free to close and delete the branch.

## What changes are included in this PR?

Deletes the method and the `CompareOperator` import it needed. Split out from #9404 because `StrictComparison` is public and eight crates use it, so removing a method from it is a separate decision from a semantics fix.

## What APIs are changed? Are there any user-facing changes?

`StrictComparison::to_compare_operator` is gone. No caller exists in the workspace, but it was reachable, so this is a public API removal. `to_operator` covers the same need and returns the `Operator` that the call sites take.