### PR TITLE
Rename the `precondition` helpers to `short_circuit`

### DIFF
--- a/encodings/fastlanes/src/bitpacking/compute/between.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/between.rs
@@ -55,10 +55,10 @@ impl BetweenKernel for BitPacked {
         let result = match_each_integer_ptype!(arr_ptype, |T| {
             let lo: T = lower_prim
                 .typed_value::<T>()
-                .vortex_expect("between precondition strips null lower");
+                .vortex_expect("the between short circuit strips a null lower bound");
             let up: T = upper_prim
                 .typed_value::<T>()
-                .vortex_expect("between precondition strips null upper");
+                .vortex_expect("the between short circuit strips a null upper bound");
             between_constant_typed::<T>(array, lo, up, options, nullability, ctx)?
         });
         Ok(Some(result))

--- a/vortex-array/src/arrays/dict/take.rs
+++ b/vortex-array/src/arrays/dict/take.rs
@@ -53,11 +53,11 @@ pub trait TakeExecute: VTable {
     ) -> VortexResult<Option<ArrayRef>>;
 }
 
-/// Common preconditions for take operations that apply to all arrays.
+/// Short-circuits take for the inputs that need no encoding-specific work.
 ///
-/// Returns `Some(result)` if the precondition short-circuits the take operation,
-/// or `None` if the take should proceed normally.
-fn precondition<V: VTable>(array: ArrayView<'_, V>, indices: &ArrayRef) -> Option<ArrayRef> {
+/// Returns `Some(result)` when the answer is already known, or `None` when take must proceed
+/// normally.
+fn short_circuit<V: VTable>(array: ArrayView<'_, V>, indices: &ArrayRef) -> Option<ArrayRef> {
     // Fast-path for empty indices.
     if indices.is_empty() {
         let result_dtype = array
@@ -97,7 +97,7 @@ where
         if child_idx != 1 {
             return Ok(None);
         }
-        if let Some(result) = precondition::<V>(array, parent.codes()) {
+        if let Some(result) = short_circuit::<V>(array, parent.codes()) {
             return Ok(Some(result));
         }
         let result = <V as TakeReduce>::take(array, parent.codes())?;
@@ -128,7 +128,7 @@ where
         if child_idx != 1 {
             return Ok(None);
         }
-        if let Some(result) = precondition::<V>(array, parent.codes()) {
+        if let Some(result) = short_circuit::<V>(array, parent.codes()) {
             return Ok(Some(result));
         }
         let result = <V as TakeExecute>::take(array, parent.codes(), ctx)?;

--- a/vortex-array/src/arrays/filter/execute/take/fixed_width.rs
+++ b/vortex-array/src/arrays/filter/execute/take/fixed_width.rs
@@ -175,7 +175,7 @@ where
                 take_values_by_rank(values, ranks, filtered_len, |idx| idx)
             }
         }
-        AllOr::None => unreachable!("empty filters are handled by take preconditions"),
+        AllOr::None => unreachable!("empty filters are handled by the filter short circuit"),
         AllOr::Some(indices) => {
             if let Some(indices_validity) = indices_validity {
                 take_values_by_rank_nullable(

--- a/vortex-array/src/arrays/filter/execute/take/rank.rs
+++ b/vortex-array/src/arrays/filter/execute/take/rank.rs
@@ -82,7 +82,7 @@ pub(in crate::arrays::filter) fn translate_ranks<P: IntegerPType>(
 
     match filter.indices() {
         AllOr::All => translate_ranks_with(ranks, ranks_validity, filtered_len, |rank| rank),
-        AllOr::None => unreachable!("empty filters are handled by take preconditions"),
+        AllOr::None => unreachable!("empty filters are handled by the filter short circuit"),
         AllOr::Some(filter_indices) => {
             translate_ranks_with(ranks, ranks_validity, filtered_len, |rank| unsafe {
                 *filter_indices.get_unchecked(rank)

--- a/vortex-array/src/arrays/filter/kernel.rs
+++ b/vortex-array/src/arrays/filter/kernel.rs
@@ -67,11 +67,11 @@ pub trait FilterKernel: VTable {
     ) -> VortexResult<Option<ArrayRef>>;
 }
 
-/// Common preconditions for filter operations that apply to all arrays.
+/// Short-circuits filter for the inputs that need no encoding-specific work.
 ///
-/// Returns `Some(result)` if the precondition short-circuits the filter operation,
-/// or `None` if the filter should proceed normally.
-fn precondition<V: VTable>(array: ArrayView<'_, V>, mask: &Mask) -> Option<ArrayRef> {
+/// Returns `Some(result)` when the answer is already known, or `None` when the filter must proceed
+/// normally.
+fn short_circuit<V: VTable>(array: ArrayView<'_, V>, mask: &Mask) -> Option<ArrayRef> {
     let true_count = mask.true_count();
 
     // Fast-path for empty mask (all false).
@@ -104,7 +104,7 @@ where
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         assert_eq!(child_idx, 0);
-        if let Some(result) = precondition::<V>(array, parent.filter_mask()) {
+        if let Some(result) = short_circuit::<V>(array, parent.filter_mask()) {
             return Ok(Some(result));
         }
         <V as FilterReduce>::filter(array, parent.filter_mask())
@@ -129,7 +129,7 @@ where
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         assert_eq!(child_idx, 0);
-        if let Some(result) = precondition::<V>(array, parent.filter_mask()) {
+        if let Some(result) = short_circuit::<V>(array, parent.filter_mask()) {
             return Ok(Some(result));
         }
         <V as FilterKernel>::filter(array, parent.filter_mask(), ctx)

--- a/vortex-array/src/arrays/slice/mod.rs
+++ b/vortex-array/src/arrays/slice/mod.rs
@@ -66,10 +66,14 @@ pub trait SliceKernel: VTable {
     ) -> VortexResult<Option<ArrayRef>>;
 }
 
-fn precondition<V: VTable>(array: ArrayView<'_, V>, range: &Range<usize>) -> Option<ArrayRef> {
+/// Short-circuits slice for the ranges that need no encoding-specific work.
+///
+/// Returns `Some(result)` when the answer is already known, or `None` when the slice must proceed
+/// normally.
+fn short_circuit<V: VTable>(array: ArrayView<'_, V>, range: &Range<usize>) -> Option<ArrayRef> {
     if range.start == 0 && range.end == array.len() {
         return Some(array.array().clone());
-    };
+    }
     if range.start == range.end {
         return Some(Canonical::empty(array.dtype()).into_array());
     }
@@ -93,7 +97,7 @@ where
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         assert_eq!(child_idx, 0);
-        if let Some(result) = precondition::<V>(array, &parent.range) {
+        if let Some(result) = short_circuit::<V>(array, &parent.range) {
             return Ok(Some(result));
         }
         <V as SliceReduce>::slice(array, parent.range.clone())
@@ -118,7 +122,7 @@ where
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         assert_eq!(child_idx, 0);
-        if let Some(result) = precondition::<V>(array, &parent.range) {
+        if let Some(result) = short_circuit::<V>(array, &parent.range) {
             return Ok(Some(result));
         }
         <V as SliceKernel>::slice(array, parent.range.clone(), ctx)

--- a/vortex-array/src/scalar_fn/fns/between/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/between/kernel.rs
@@ -6,7 +6,7 @@ use vortex_error::VortexResult;
 
 use super::Between;
 use super::BetweenOptions;
-use super::precondition;
+use super::short_circuit;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::array::ArrayView;
@@ -70,7 +70,7 @@ where
         let lower = &children[1];
         let upper = &children[2];
         let arr = array.array().clone();
-        if let Some(result) = precondition(&arr, lower, upper, parent.options)? {
+        if let Some(result) = short_circuit(&arr, lower, upper, parent.options)? {
             return Ok(Some(result));
         }
         <V as BetweenReduce>::between(array, lower, upper, parent.options)
@@ -105,7 +105,7 @@ where
         let lower = &children[1];
         let upper = &children[2];
         let arr = array.array().clone();
-        if let Some(result) = precondition(&arr, lower, upper, parent.options)? {
+        if let Some(result) = short_circuit(&arr, lower, upper, parent.options)? {
             // TODO(joe): return the lazy array directly, blocked on the same executor support as
             // the fallback in `between_canonical`. The reduce adaptor above already passes it
             // through unexecuted, since a reduce rule can return a lazy array.

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -86,18 +86,17 @@ impl StrictComparison {
     }
 }
 
-/// Common preconditions for between operations that apply to all arrays.
+/// Short-circuits between for the inputs that need no encoding-specific work.
 ///
-/// Returns `Some(result)` if the precondition short-circuits the between operation
-/// (empty array, null bounds), or `None` if between must proceed with the
-/// encoding-specific implementation. Kernels can therefore rely on both bounds being
-/// non-null.
+/// Returns `Some(result)` when the answer is already known (empty array, null bounds), or `None`
+/// when between must proceed with the encoding-specific implementation. Kernels can therefore rely
+/// on both bounds being non-null.
 ///
 /// The result can be a lazy [`ScalarFn`] array, so a caller that needs a computed array
 /// **must** execute it.
 ///
 /// [`ScalarFn`]: crate::arrays::ScalarFn
-pub(super) fn precondition(
+pub(super) fn short_circuit(
     arr: &ArrayRef,
     lower: &ArrayRef,
     upper: &ArrayRef,
@@ -155,7 +154,7 @@ fn between_canonical(
     options: &BetweenOptions,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    if let Some(result) = precondition(arr, lower, upper, options)? {
+    if let Some(result) = short_circuit(arr, lower, upper, options)? {
         // TODO(joe): return the lazy array directly, blocked on the same executor support as the
         // fallback below. Only the single-null-bound case is lazy, so this forces it for now.
         return result.execute::<ArrayRef>(ctx);

--- a/vortex-array/src/scalar_fn/fns/fill_null/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/fill_null/kernel.rs
@@ -55,11 +55,16 @@ pub trait FillNullKernel: VTable {
     ) -> VortexResult<Option<ArrayRef>>;
 }
 
-/// Common preconditions for fill_null operations that apply to all arrays.
+/// Short-circuits fill_null for the inputs that need no encoding-specific work.
 ///
-/// Returns `Some(result)` if the precondition short-circuits the fill_null operation,
-/// or `None` if fill_null should proceed with the encoding-specific implementation.
-pub(super) fn precondition(
+/// Returns `Some(result)` when the answer is already known, or `None` when fill_null must proceed
+/// with the encoding-specific implementation. Kernels can therefore rely on a non-null fill value.
+///
+/// The result can be a lazy [`ScalarFn`] array, so a caller that needs a computed array
+/// **must** execute it.
+///
+/// [`ScalarFn`]: crate::arrays::ScalarFn
+pub(super) fn short_circuit(
     array: &ArrayRef,
     fill_value: &Scalar,
 ) -> VortexResult<Option<ArrayRef>> {
@@ -130,7 +135,7 @@ where
             .as_constant()
             .vortex_expect("fill_null fill_value must be constant");
         let arr = array.array().clone();
-        if let Some(result) = precondition(&arr, &fill_value)? {
+        if let Some(result) = short_circuit(&arr, &fill_value)? {
             return Ok(Some(result));
         }
         <V as FillNullReduce>::fill_null(array, &fill_value)
@@ -166,7 +171,7 @@ where
             .as_constant()
             .vortex_expect("fill_null fill_value must be constant");
         let arr = array.array().clone();
-        if let Some(result) = precondition(&arr, &fill_value)? {
+        if let Some(result) = short_circuit(&arr, &fill_value)? {
             return Ok(Some(result));
         }
         <V as FillNullKernel>::fill_null(array, &fill_value, ctx)

--- a/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
@@ -151,9 +151,8 @@ fn fill_null_canonical(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let arr = canonical.to_array_ref();
-    if let Some(result) = precondition(&arr, fill_value)? {
-        // The result of precondition may return another ScalarFn, in which case we should
-        // apply it immediately.
+    if let Some(result) = short_circuit(&arr, fill_value)? {
+        // The short circuit can return a lazy `ScalarFn`, so this forces it for now.
         // TODO(aduffy): Remove this once we have better driver check. We're also implicitly
         //  relying on the fact that Cast execution will do an optimize on its result.
         return result.execute::<ArrayRef>(ctx);


### PR DESCRIPTION
## Rationale for this change

`precondition` was just kind of confusing. These helpers do not check a precondition, they check for some specific conditions and return early.

This is a purely cosmetic change.