### PR TITLE
Fix empty array validity predicates

### DIFF
--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -301,6 +301,10 @@ impl ArrayRef {
 
     /// Returns whether all items in the array are valid.
     pub fn all_valid(&self, ctx: &mut ExecutionCtx) -> VortexResult<bool> {
+        if self.is_empty() {
+            return Ok(true);
+        }
+
         match self.validity()? {
             Validity::NonNullable | Validity::AllValid => Ok(true),
             Validity::AllInvalid => Ok(false),
@@ -310,6 +314,10 @@ impl ArrayRef {
 
     /// Returns whether the array is all invalid.
     pub fn all_invalid(&self, ctx: &mut ExecutionCtx) -> VortexResult<bool> {
+        if self.is_empty() {
+            return Ok(true);
+        }
+
         match self.validity()? {
             Validity::NonNullable | Validity::AllValid => Ok(false),
             Validity::AllInvalid => Ok(true),

--- a/vortex-array/src/arrays/masked/tests.rs
+++ b/vortex-array/src/arrays/masked/tests.rs
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use rstest::rstest;
+use vortex_buffer::BitBuffer;
+use vortex_buffer::Buffer;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
@@ -10,6 +12,7 @@ use crate::Canonical;
 use crate::IntoArray;
 use crate::VortexSessionExecute;
 use crate::array_session;
+use crate::arrays::BoolArray;
 use crate::arrays::ListViewArray;
 use crate::arrays::PrimitiveArray;
 use crate::assert_arrays_eq;
@@ -39,6 +42,24 @@ fn test_dtype_nullability_with_nullable_child() {
 
     // Child has nullable dtype.
     assert!(child.dtype().is_nullable());
+}
+
+#[test]
+fn test_empty_child_with_array_validity() -> VortexResult<()> {
+    let child_validity =
+        Validity::Array(BoolArray::new(BitBuffer::new_set(0), Validity::NonNullable).into_array());
+    let child = PrimitiveArray::new(Buffer::<i32>::empty(), child_validity).into_array();
+    let validity =
+        Validity::Array(BoolArray::new(BitBuffer::new_set(0), Validity::NonNullable).into_array());
+
+    let mut ctx = array_session().create_execution_ctx();
+    assert!(child.all_valid(&mut ctx)?);
+    assert!(child.all_invalid(&mut ctx)?);
+
+    let array = MaskedArray::try_new(child, validity)?;
+
+    assert!(array.is_empty());
+    Ok(())
 }
 
 #[test]

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -73,6 +73,7 @@ impl VTable for Masked {
         *ID
     }
 
+    #[expect(clippy::disallowed_methods)]
     fn validate(
         &self,
         _data: &MaskedData,
@@ -91,6 +92,10 @@ impl VTable for Masked {
         vortex_ensure!(
             child.dtype().as_nullable() == *dtype,
             "MaskedArray dtype does not match child and validity"
+        );
+        vortex_ensure!(
+            child.all_valid(&mut legacy_session().create_execution_ctx())?,
+            "MaskedArray children must not have nulls",
         );
         Ok(())
     }


### PR DESCRIPTION
## Rationale for this change

- Closes #9403

`ArrayRef::all_valid` treated an empty bitmap's missing `Min` statistic as evidence of a null, so `MaskedArray` rejected an empty child based on its validity representation.

## What changes are included in this PR?

Empty arrays are now vacuously both all-valid and all-invalid. `Masked` validation now enforces the all-valid child invariant, and a regression covers the empty bitmap case.