### PR TITLE
GPU: keep FSST decompression output on device

### DIFF
--- a/vortex-cuda/kernels/src/fsst.cu
+++ b/vortex-cuda/kernels/src/fsst.cu
@@ -295,6 +295,31 @@ __device__ inline void fsst_decode_string(const FSSTArgs<CodeOffsetT, OutputOffs
         FSST_GRID_STRIDE_LOOP(CodeOffsetT, int32_t, args)                                                    \
     }
 
+#define GENERATE_FSST_VARBINVIEW_KERNEL(suffix, CodeOffsetT)                                                 \
+    extern "C" __global__ void fsst_varbinview_##suffix(const uint8_t *__restrict codes_bytes,               \
+                                                        const CodeOffsetT *__restrict codes_offsets,         \
+                                                        const uint64_t *__restrict symbols,                  \
+                                                        const uint8_t *__restrict symbol_lengths,            \
+                                                        const int32_t *__restrict output_offsets,            \
+                                                        const uint8_t *__restrict validity_bits,             \
+                                                        uint64_t validity_bit_offset,                        \
+                                                        uint8_t *__restrict output_bytes,                    \
+                                                        uint4 *__restrict output_views,                      \
+                                                        uint64_t num_strings) {                              \
+        const FSSTArgs<CodeOffsetT, int32_t> args = {                                                        \
+            codes_bytes,                                                                                     \
+            codes_offsets,                                                                                   \
+            symbols,                                                                                         \
+            symbol_lengths,                                                                                  \
+            output_bytes,                                                                                    \
+            output_offsets,                                                                                  \
+            validity_bits,                                                                                   \
+            validity_bit_offset,                                                                             \
+            output_views,                                                                                    \
+        };                                                                                                   \
+        FSST_GRID_STRIDE_LOOP(CodeOffsetT, int32_t, args)                                                    \
+    }
+
 GENERATE_FSST_VIEW_KERNEL(u8, uint8_t)
 GENERATE_FSST_VIEW_KERNEL(u16, uint16_t)
 GENERATE_FSST_VIEW_KERNEL(u32, uint32_t)
@@ -304,3 +329,8 @@ GENERATE_FSST_VARBIN_KERNEL(u8, uint8_t)
 GENERATE_FSST_VARBIN_KERNEL(u16, uint16_t)
 GENERATE_FSST_VARBIN_KERNEL(u32, uint32_t)
 GENERATE_FSST_VARBIN_KERNEL(u64, uint64_t)
+
+GENERATE_FSST_VARBINVIEW_KERNEL(u8, uint8_t)
+GENERATE_FSST_VARBINVIEW_KERNEL(u16, uint16_t)
+GENERATE_FSST_VARBINVIEW_KERNEL(u32, uint32_t)
+GENERATE_FSST_VARBINVIEW_KERNEL(u64, uint64_t)

--- a/vortex-cuda/src/kernel/encodings/fsst.rs
+++ b/vortex-cuda/src/kernel/encodings/fsst.rs
@@ -30,6 +30,7 @@ use vortex::buffer::Alignment;
 use vortex::buffer::Buffer;
 use vortex::dtype::DType;
 use vortex::dtype::NativePType;
+use vortex::dtype::PType;
 use vortex::encodings::fsst::FSST;
 use vortex::encodings::fsst::FSSTArray;
 use vortex::encodings::fsst::FSSTArrayExt;
@@ -121,42 +122,117 @@ impl CudaExecute for FSSTExecutor {
             }));
         }
 
-        let lens = fsst
-            .uncompressed_lengths()
-            .clone()
-            .execute_cuda(ctx)
-            .await?
-            .into_host()
-            .await?
-            .into_primitive();
-        let codes_offsets = fsst
-            .codes()
-            .offsets()
-            .clone()
-            .execute_cuda(ctx)
-            .await?
-            .into_primitive();
-
-        // Prefix-sum lens to per-string u64 output offsets so the kernel
-        // knows where to write each decoded string.
-        let output_offsets: Vec<u64> = match_each_integer_ptype!(lens.ptype(), |P| {
-            let mut out = Vec::with_capacity(lens.len() + 1);
-            let mut acc: u64 = 0;
-            out.push(0u64);
-            #[allow(clippy::unnecessary_cast)]
-            for &l in lens.as_slice::<P>() {
-                acc += l as u64;
-                out.push(acc);
-            }
-            out
-        });
-
-        // Dispatch on the unsigned width; signed and unsigned offsets of the
-        // same width share an identical byte representation.
-        match_each_unsigned_integer_ptype!(codes_offsets.ptype().to_unsigned(), |U| {
-            decode_fsst::<U>(fsst, codes_offsets, lens, output_offsets, ctx).await
-        })
+        if can_build_i32_offsets(&fsst) {
+            decode_fsst_varbinview(fsst, ctx).await
+        } else {
+            decode_fsst_host_varbinview(fsst, ctx).await
+        }
     }
+}
+
+/// Decode FSST directly into a device-resident canonical `VarBinView` array.
+async fn decode_fsst_varbinview(
+    fsst: FSSTArray,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<Canonical> {
+    let dtype = fsst.dtype().clone();
+    let validity = fsst.codes().validity()?;
+    let len = fsst.len();
+    let lens = fsst
+        .uncompressed_lengths()
+        .clone()
+        .execute_cuda(ctx)
+        .await?
+        .into_primitive();
+    let codes_offsets = fsst
+        .codes()
+        .offsets()
+        .clone()
+        .execute_cuda(ctx)
+        .await?
+        .into_primitive();
+    let I32Offsets {
+        buffer: output_offsets,
+        total: total_size,
+    } = i32_offsets_from_lengths(lens, ctx).await?;
+
+    if total_size == 0 {
+        let views = ctx.copy_to_device(vec![0i128; len])?.await?;
+        return Ok(Canonical::VarBinView(unsafe {
+            VarBinViewArray::new_handle_unchecked(views, Arc::from([]), dtype, validity)
+        }));
+    }
+
+    match_each_unsigned_integer_ptype!(codes_offsets.ptype().to_unsigned(), |U| {
+        decode_fsst_varbinview_typed::<U>(fsst, codes_offsets, output_offsets, total_size, ctx)
+            .await
+    })
+}
+
+async fn decode_fsst_varbinview_typed<U>(
+    fsst: FSSTArray,
+    codes_offsets: PrimitiveArray,
+    output_offsets: BufferHandle,
+    total_size: usize,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<Canonical>
+where
+    U: NativePType + DeviceRepr + Send + Sync + 'static,
+{
+    let dtype = fsst.dtype().clone();
+    let validity = fsst.codes().validity()?;
+    let num_strings = fsst.len();
+    let num_strings_u64 = u64::try_from(num_strings)?;
+    let symbols_u64 = fsst
+        .symbols()
+        .iter()
+        .map(|symbol| symbol.to_u64())
+        .collect::<Vec<_>>();
+    let symbol_lengths = fsst.padded_symbol_lengths().slice(0..fsst.n_symbols());
+    let codes_bytes_handle = fsst.codes_bytes_handle().clone();
+    let PrimitiveDataParts {
+        buffer: codes_offsets_buffer,
+        ..
+    } = codes_offsets.into_data_parts();
+    let (validity_bit_offset, validity_bits) = cuda_validity(&validity, num_strings, ctx).await?;
+
+    let (symbols, symbol_lengths, validity_device, codes_bytes, codes_offsets) = futures::try_join!(
+        ctx.copy_to_device(symbols_u64)?,
+        ctx.copy_to_device(symbol_lengths)?,
+        ctx.ensure_on_device(validity_bits),
+        ctx.ensure_on_device(codes_bytes_handle),
+        ctx.ensure_on_device(codes_offsets_buffer),
+    )?;
+
+    let mut output = ctx.device_alloc::<u8>(total_size)?;
+    let mut views = ctx.device_alloc::<i128>(num_strings)?;
+    let codes_bytes_view = codes_bytes.cuda_view::<u8>()?;
+    let codes_offsets_view = codes_offsets.cuda_view::<U>()?;
+    let symbols_view = symbols.cuda_view::<u64>()?;
+    let symbol_lengths_view = symbol_lengths.cuda_view::<u8>()?;
+    let output_offsets_view = output_offsets.cuda_view::<i32>()?;
+    let validity_view = validity_device.cuda_view::<u8>()?;
+    let ptype = U::PTYPE.to_string();
+    let cuda_function = ctx.load_function_with_suffixes("fsst", &["varbinview", &ptype])?;
+
+    ctx.launch_kernel(&cuda_function, num_strings, |args| {
+        args.arg(&codes_bytes_view)
+            .arg(&codes_offsets_view)
+            .arg(&symbols_view)
+            .arg(&symbol_lengths_view)
+            .arg(&output_offsets_view)
+            .arg(&validity_view)
+            .arg(&validity_bit_offset)
+            .arg(&mut output)
+            .arg(&mut views)
+            .arg(&num_strings_u64);
+    })?;
+
+    let views = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(views)));
+    let values = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(output)));
+    Ok(Canonical::VarBinView(unsafe {
+        VarBinViewArray::new_handle_unchecked(views, Arc::from([values]), dtype, validity)
+    }))
 }
 
 /// Decode FSST directly into Arrow-compatible i32 offsets and contiguous values on device.
@@ -274,6 +350,56 @@ where
         offsets: output_offsets,
         values: BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(output))),
         validity,
+    })
+}
+
+fn can_build_i32_offsets(fsst: &FSSTArray) -> bool {
+    let max_length = match fsst.uncompressed_lengths().dtype().as_ptype() {
+        PType::U8 => u8::MAX as usize,
+        PType::U16 => u16::MAX as usize,
+        PType::U32 => u32::MAX as usize,
+        PType::U64 => usize::MAX,
+        _ => return false,
+    };
+    fsst.len()
+        .checked_mul(max_length)
+        .is_some_and(|max_total| max_total <= i32::MAX as usize)
+}
+
+async fn decode_fsst_host_varbinview(
+    fsst: FSSTArray,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<Canonical> {
+    let lens = fsst
+        .uncompressed_lengths()
+        .clone()
+        .execute_cuda(ctx)
+        .await?
+        .into_host()
+        .await?
+        .into_primitive();
+    let codes_offsets = fsst
+        .codes()
+        .offsets()
+        .clone()
+        .execute_cuda(ctx)
+        .await?
+        .into_primitive();
+
+    let output_offsets: Vec<u64> = match_each_integer_ptype!(lens.ptype(), |P| {
+        let mut out = Vec::with_capacity(lens.len() + 1);
+        let mut acc: u64 = 0;
+        out.push(0u64);
+        #[allow(clippy::unnecessary_cast)]
+        for &length in lens.as_slice::<P>() {
+            acc += length as u64;
+            out.push(acc);
+        }
+        out
+    });
+
+    match_each_unsigned_integer_ptype!(codes_offsets.ptype().to_unsigned(), |U| {
+        decode_fsst::<U>(fsst, codes_offsets, lens, output_offsets, ctx).await
     })
 }
 


### PR DESCRIPTION
Stacked on #9147. This draft contains one reviewable GPU correctness or performance concern.

## What

- Materialize FSST offsets, bytes, and VarBinView outputs directly in CUDA memory.
- Warm CUDA modules and allocators with a fresh untimed file scan, then time a separately opened scan.
- Keep verification available as an explicit, untimed host comparison.

## Why this is needed

This is required for the benchmark to mean “GPU Vortex decompression” on FSST columns. Before this change, FSST output sizing and canonical materialization crossed through host arrays, so the timed path mixed CPU decoding/materialization and host-to-device transfer into the Vortex number. It is also the minimum foundation for the later FSST-only optimizations.

## Validation

Validated at the stack tip:

- `cargo +nightly fmt --all -- --check`
- `clang-format --dry-run --Werror --style=file` on changed CUDA sources
- `cargo check -p vortex-cuda --all-features`
- `cargo check -p compress-bench --features cuda,unstable_encodings`
- 164 focused dynamic-dispatch tests
- 28 focused constant-array tests