### PR TITLE
GPU: remove FSST scalar D2H waits

### DIFF
--- a/vortex-btrblocks/src/schemes/string/fsst.rs
+++ b/vortex-btrblocks/src/schemes/string/fsst.rs
@@ -16,6 +16,7 @@ use vortex_array::arrays::VarBin;
 use vortex_array::arrays::VarBinArray;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_array::arrays::varbin::VarBinArraySlotsExt;
+use vortex_array::expr::stats::Stat;
 use vortex_compressor::scheme::CompressionEstimate;
 use vortex_compressor::scheme::DeferredEstimate;
 use vortex_error::VortexResult;
@@ -84,6 +85,10 @@ impl Scheme for FSSTScheme {
             .clone()
             .execute::<PrimitiveArray>(exec_ctx)?
             .narrow(exec_ctx)?;
+        let length_stats = uncompressed_lengths_primitive
+            .as_ref()
+            .statistics()
+            .compute_all(&[Stat::Min, Stat::Sum], exec_ctx)?;
         let compressed_original_lengths = compressor.compress_child(
             &uncompressed_lengths_primitive.into_array(),
             &compress_ctx,
@@ -91,6 +96,9 @@ impl Scheme for FSSTScheme {
             0,
             exec_ctx,
         )?;
+        compressed_original_lengths
+            .statistics()
+            .set_iter(length_stats.into_iter());
 
         let codes_offsets_primitive = fsst
             .codes()

--- a/vortex-cuda/kernels/src/arrow_offsets.cu
+++ b/vortex-cuda/kernels/src/arrow_offsets.cu
@@ -61,3 +61,28 @@ GENERATE_FROM_LENGTHS_KERNEL(u8, uint8_t, false)
 GENERATE_FROM_LENGTHS_KERNEL(u16, uint16_t, false)
 GENERATE_FROM_LENGTHS_KERNEL(u32, uint32_t, false)
 GENERATE_FROM_LENGTHS_KERNEL(u64, uint64_t, false)
+
+// Convert lengths that have already been proven nonnegative with an i32-representable sum. This
+// avoids allocating and copying a status word when trusted exact Min/Sum statistics provide the
+// same proof on the host.
+#define GENERATE_FROM_KNOWN_LENGTHS_KERNEL(suffix, LengthT)                                                  \
+    extern "C" __global__ void arrow_offsets_from_known_lengths_##suffix(const LengthT *__restrict lengths,  \
+                                                                         int32_t *__restrict scan,           \
+                                                                         uint64_t len) {                     \
+        const uint64_t scan_len = len + 1;                                                                   \
+        const uint64_t elements_per_block = (uint64_t)blockDim.x * ELEMENTS_PER_THREAD;                      \
+        const uint64_t block_start = (uint64_t)blockIdx.x * elements_per_block;                              \
+        const uint64_t block_stop = min(block_start + elements_per_block, scan_len);                         \
+        for (uint64_t idx = block_start + threadIdx.x; idx < block_stop; idx += blockDim.x) {                \
+            scan[idx] = idx == len ? 0 : (int32_t)lengths[idx];                                              \
+        }                                                                                                    \
+    }
+
+GENERATE_FROM_KNOWN_LENGTHS_KERNEL(i8, int8_t)
+GENERATE_FROM_KNOWN_LENGTHS_KERNEL(i16, int16_t)
+GENERATE_FROM_KNOWN_LENGTHS_KERNEL(i32, int32_t)
+GENERATE_FROM_KNOWN_LENGTHS_KERNEL(i64, int64_t)
+GENERATE_FROM_KNOWN_LENGTHS_KERNEL(u8, uint8_t)
+GENERATE_FROM_KNOWN_LENGTHS_KERNEL(u16, uint16_t)
+GENERATE_FROM_KNOWN_LENGTHS_KERNEL(u32, uint32_t)
+GENERATE_FROM_KNOWN_LENGTHS_KERNEL(u64, uint64_t)

--- a/vortex-cuda/kernels/src/fsst.cu
+++ b/vortex-cuda/kernels/src/fsst.cu
@@ -295,6 +295,31 @@ __device__ inline void fsst_decode_string(const FSSTArgs<CodeOffsetT, OutputOffs
         FSST_GRID_STRIDE_LOOP(CodeOffsetT, int32_t, args)                                                    \
     }
 
+#define GENERATE_FSST_VARBINVIEW_KERNEL(suffix, CodeOffsetT)                                                 \
+    extern "C" __global__ void fsst_varbinview_##suffix(const uint8_t *__restrict codes_bytes,               \
+                                                        const CodeOffsetT *__restrict codes_offsets,         \
+                                                        const uint64_t *__restrict symbols,                  \
+                                                        const uint8_t *__restrict symbol_lengths,            \
+                                                        const int32_t *__restrict output_offsets,            \
+                                                        const uint8_t *__restrict validity_bits,             \
+                                                        uint64_t validity_bit_offset,                        \
+                                                        uint8_t *__restrict output_bytes,                    \
+                                                        uint4 *__restrict output_views,                      \
+                                                        uint64_t num_strings) {                              \
+        const FSSTArgs<CodeOffsetT, int32_t> args = {                                                        \
+            codes_bytes,                                                                                     \
+            codes_offsets,                                                                                   \
+            symbols,                                                                                         \
+            symbol_lengths,                                                                                  \
+            output_bytes,                                                                                    \
+            output_offsets,                                                                                  \
+            validity_bits,                                                                                   \
+            validity_bit_offset,                                                                             \
+            output_views,                                                                                    \
+        };                                                                                                   \
+        FSST_GRID_STRIDE_LOOP(CodeOffsetT, int32_t, args)                                                    \
+    }
+
 GENERATE_FSST_VIEW_KERNEL(u8, uint8_t)
 GENERATE_FSST_VIEW_KERNEL(u16, uint16_t)
 GENERATE_FSST_VIEW_KERNEL(u32, uint32_t)
@@ -304,3 +329,8 @@ GENERATE_FSST_VARBIN_KERNEL(u8, uint8_t)
 GENERATE_FSST_VARBIN_KERNEL(u16, uint16_t)
 GENERATE_FSST_VARBIN_KERNEL(u32, uint32_t)
 GENERATE_FSST_VARBIN_KERNEL(u64, uint64_t)
+
+GENERATE_FSST_VARBINVIEW_KERNEL(u8, uint8_t)
+GENERATE_FSST_VARBINVIEW_KERNEL(u16, uint16_t)
+GENERATE_FSST_VARBINVIEW_KERNEL(u32, uint32_t)
+GENERATE_FSST_VARBINVIEW_KERNEL(u64, uint64_t)

--- a/vortex-cuda/src/arrow/mod.rs
+++ b/vortex-cuda/src/arrow/mod.rs
@@ -33,6 +33,7 @@ use cudarc::driver::CudaStream;
 use cudarc::driver::DevicePtr;
 use cudarc::runtime::sys::cudaEvent_t;
 pub(crate) use offsets::I32Offsets;
+pub(crate) use offsets::i32_offsets_from_known_lengths;
 pub(crate) use offsets::i32_offsets_from_lengths;
 use vortex::array::ArrayRef;
 use vortex::array::arrays::Dict;

--- a/vortex-cuda/src/arrow/offsets.rs
+++ b/vortex-cuda/src/arrow/offsets.rs
@@ -46,6 +46,50 @@ pub(crate) async fn i32_offsets_from_lengths(
     })
 }
 
+/// Build offsets without status validation when the caller has already proven that every length
+/// is nonnegative and their exact sum fits in an Arrow `i32` offset.
+pub(crate) async fn i32_offsets_from_known_lengths(
+    lengths: PrimitiveArray,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<BufferHandle> {
+    let len = lengths.len();
+    let ptype = lengths.ptype();
+    let PrimitiveDataParts { buffer, .. } = lengths.into_data_parts();
+    let lengths = ctx.ensure_on_device(buffer).await?;
+
+    match_each_integer_ptype!(ptype, |L| {
+        i32_offsets_from_known_lengths_typed::<L>(&lengths, len, ctx)
+    })
+}
+
+fn i32_offsets_from_known_lengths_typed<L>(
+    lengths: &BufferHandle,
+    len: usize,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<BufferHandle>
+where
+    L: NativePType + DeviceRepr + Send + Sync + 'static,
+{
+    let scan_len = len
+        .checked_add(1)
+        .ok_or_else(|| vortex_err!("Arrow offset count overflow"))?;
+    let lengths_view = lengths.cuda_view::<L>()?;
+    let mut scan_input = ctx.device_alloc::<i32>(scan_len)?;
+    let ptype = L::PTYPE.to_string();
+    let scan_kernel =
+        ctx.load_function_with_suffixes("arrow_offsets", &["from", "known", "lengths", &ptype])?;
+    let len_u64 = u64::try_from(len)?;
+
+    ctx.launch_kernel(&scan_kernel, scan_len, |args| {
+        args.arg(&lengths_view).arg(&mut scan_input).arg(&len_u64);
+    })?;
+
+    let offsets = exclusive_sum_i32(&scan_input, scan_len, ctx)?;
+    Ok(BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(
+        offsets,
+    ))))
+}
+
 async fn i32_offsets_from_lengths_typed<L>(
     lengths: &BufferHandle,
     len: usize,

--- a/vortex-cuda/src/kernel/encodings/fsst.rs
+++ b/vortex-cuda/src/kernel/encodings/fsst.rs
@@ -23,6 +23,9 @@ use vortex::array::arrays::varbinview::build_views::MAX_BUFFER_LEN;
 use vortex::array::arrays::varbinview::build_views::build_views;
 use vortex::array::buffer::BufferHandle;
 use vortex::array::buffer::DeviceBuffer;
+use vortex::array::expr::stats::Precision;
+use vortex::array::expr::stats::Stat;
+use vortex::array::expr::stats::StatsProvider;
 use vortex::array::match_each_integer_ptype;
 use vortex::array::match_each_unsigned_integer_ptype;
 use vortex::array::validity::Validity;
@@ -43,6 +46,7 @@ use crate::CanonicalCudaExt;
 use crate::CudaBufferExt;
 use crate::CudaDeviceBuffer;
 use crate::arrow::I32Offsets;
+use crate::arrow::i32_offsets_from_known_lengths;
 use crate::arrow::i32_offsets_from_lengths;
 use crate::executor::CudaArrayExt;
 use crate::executor::CudaExecute;
@@ -122,7 +126,7 @@ impl CudaExecute for FSSTExecutor {
             }));
         }
 
-        if can_build_i32_offsets(&fsst) {
+        if exact_nonnegative_length_sum(&fsst).is_some() || can_build_i32_offsets(&fsst) {
             decode_fsst_varbinview(fsst, ctx).await
         } else {
             decode_fsst_host_varbinview(fsst, ctx).await
@@ -154,7 +158,7 @@ async fn decode_fsst_varbinview(
     let I32Offsets {
         buffer: output_offsets,
         total: total_size,
-    } = i32_offsets_from_lengths(lens, ctx).await?;
+    } = fsst_i32_offsets(&fsst, lens, ctx).await?;
 
     if total_size == 0 {
         let views = ctx.copy_to_device(vec![0i128; len])?.await?;
@@ -259,7 +263,7 @@ pub(crate) async fn decode_fsst_varbin(
     let I32Offsets {
         buffer: output_offsets,
         total: total_size,
-    } = i32_offsets_from_lengths(lens, ctx).await?;
+    } = fsst_i32_offsets(&fsst, lens, ctx).await?;
 
     if total_size == 0 {
         let allocation = CudaDeviceBuffer::new(ctx.device_alloc::<u8>(1)?);
@@ -351,6 +355,34 @@ where
         values: BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(output))),
         validity,
     })
+}
+
+async fn fsst_i32_offsets(
+    fsst: &FSSTArray,
+    lengths: PrimitiveArray,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<I32Offsets> {
+    if let Some(total) = exact_nonnegative_length_sum(fsst) {
+        return Ok(I32Offsets {
+            buffer: i32_offsets_from_known_lengths(lengths, ctx).await?,
+            total,
+        });
+    }
+
+    i32_offsets_from_lengths(lengths, ctx).await
+}
+
+fn exact_nonnegative_length_sum(fsst: &FSSTArray) -> Option<usize> {
+    let stats = fsst.uncompressed_lengths().statistics();
+    let Precision::Exact(min) = stats.get(Stat::Min) else {
+        return None;
+    };
+    let Precision::Exact(sum) = stats.get(Stat::Sum) else {
+        return None;
+    };
+    let min = i64::try_from(&min).ok()?;
+    let total = usize::try_from(&sum).ok()?;
+    (min >= 0 && total <= i32::MAX as usize).then_some(total)
 }
 
 fn can_build_i32_offsets(fsst: &FSSTArray) -> bool {

--- a/vortex-cuda/src/kernel/encodings/fsst.rs
+++ b/vortex-cuda/src/kernel/encodings/fsst.rs
@@ -30,6 +30,7 @@ use vortex::buffer::Alignment;
 use vortex::buffer::Buffer;
 use vortex::dtype::DType;
 use vortex::dtype::NativePType;
+use vortex::dtype::PType;
 use vortex::encodings::fsst::FSST;
 use vortex::encodings::fsst::FSSTArray;
 use vortex::encodings::fsst::FSSTArrayExt;
@@ -121,42 +122,117 @@ impl CudaExecute for FSSTExecutor {
             }));
         }
 
-        let lens = fsst
-            .uncompressed_lengths()
-            .clone()
-            .execute_cuda(ctx)
-            .await?
-            .into_host()
-            .await?
-            .into_primitive();
-        let codes_offsets = fsst
-            .codes()
-            .offsets()
-            .clone()
-            .execute_cuda(ctx)
-            .await?
-            .into_primitive();
-
-        // Prefix-sum lens to per-string u64 output offsets so the kernel
-        // knows where to write each decoded string.
-        let output_offsets: Vec<u64> = match_each_integer_ptype!(lens.ptype(), |P| {
-            let mut out = Vec::with_capacity(lens.len() + 1);
-            let mut acc: u64 = 0;
-            out.push(0u64);
-            #[allow(clippy::unnecessary_cast)]
-            for &l in lens.as_slice::<P>() {
-                acc += l as u64;
-                out.push(acc);
-            }
-            out
-        });
-
-        // Dispatch on the unsigned width; signed and unsigned offsets of the
-        // same width share an identical byte representation.
-        match_each_unsigned_integer_ptype!(codes_offsets.ptype().to_unsigned(), |U| {
-            decode_fsst::<U>(fsst, codes_offsets, lens, output_offsets, ctx).await
-        })
+        if can_build_i32_offsets(&fsst) {
+            decode_fsst_varbinview(fsst, ctx).await
+        } else {
+            decode_fsst_host_varbinview(fsst, ctx).await
+        }
     }
+}
+
+/// Decode FSST directly into a device-resident canonical `VarBinView` array.
+async fn decode_fsst_varbinview(
+    fsst: FSSTArray,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<Canonical> {
+    let dtype = fsst.dtype().clone();
+    let validity = fsst.codes().validity()?;
+    let len = fsst.len();
+    let lens = fsst
+        .uncompressed_lengths()
+        .clone()
+        .execute_cuda(ctx)
+        .await?
+        .into_primitive();
+    let codes_offsets = fsst
+        .codes()
+        .offsets()
+        .clone()
+        .execute_cuda(ctx)
+        .await?
+        .into_primitive();
+    let I32Offsets {
+        buffer: output_offsets,
+        total: total_size,
+    } = i32_offsets_from_lengths(lens, ctx).await?;
+
+    if total_size == 0 {
+        let views = ctx.copy_to_device(vec![0i128; len])?.await?;
+        return Ok(Canonical::VarBinView(unsafe {
+            VarBinViewArray::new_handle_unchecked(views, Arc::from([]), dtype, validity)
+        }));
+    }
+
+    match_each_unsigned_integer_ptype!(codes_offsets.ptype().to_unsigned(), |U| {
+        decode_fsst_varbinview_typed::<U>(fsst, codes_offsets, output_offsets, total_size, ctx)
+            .await
+    })
+}
+
+async fn decode_fsst_varbinview_typed<U>(
+    fsst: FSSTArray,
+    codes_offsets: PrimitiveArray,
+    output_offsets: BufferHandle,
+    total_size: usize,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<Canonical>
+where
+    U: NativePType + DeviceRepr + Send + Sync + 'static,
+{
+    let dtype = fsst.dtype().clone();
+    let validity = fsst.codes().validity()?;
+    let num_strings = fsst.len();
+    let num_strings_u64 = u64::try_from(num_strings)?;
+    let symbols_u64 = fsst
+        .symbols()
+        .iter()
+        .map(|symbol| symbol.to_u64())
+        .collect::<Vec<_>>();
+    let symbol_lengths = fsst.padded_symbol_lengths().slice(0..fsst.n_symbols());
+    let codes_bytes_handle = fsst.codes_bytes_handle().clone();
+    let PrimitiveDataParts {
+        buffer: codes_offsets_buffer,
+        ..
+    } = codes_offsets.into_data_parts();
+    let (validity_bit_offset, validity_bits) = cuda_validity(&validity, num_strings, ctx).await?;
+
+    let (symbols, symbol_lengths, validity_device, codes_bytes, codes_offsets) = futures::try_join!(
+        ctx.copy_to_device(symbols_u64)?,
+        ctx.copy_to_device(symbol_lengths)?,
+        ctx.ensure_on_device(validity_bits),
+        ctx.ensure_on_device(codes_bytes_handle),
+        ctx.ensure_on_device(codes_offsets_buffer),
+    )?;
+
+    let mut output = ctx.device_alloc::<u8>(total_size)?;
+    let mut views = ctx.device_alloc::<i128>(num_strings)?;
+    let codes_bytes_view = codes_bytes.cuda_view::<u8>()?;
+    let codes_offsets_view = codes_offsets.cuda_view::<U>()?;
+    let symbols_view = symbols.cuda_view::<u64>()?;
+    let symbol_lengths_view = symbol_lengths.cuda_view::<u8>()?;
+    let output_offsets_view = output_offsets.cuda_view::<i32>()?;
+    let validity_view = validity_device.cuda_view::<u8>()?;
+    let ptype = U::PTYPE.to_string();
+    let cuda_function = ctx.load_function_with_suffixes("fsst", &["varbinview", &ptype])?;
+
+    ctx.launch_kernel(&cuda_function, num_strings, |args| {
+        args.arg(&codes_bytes_view)
+            .arg(&codes_offsets_view)
+            .arg(&symbols_view)
+            .arg(&symbol_lengths_view)
+            .arg(&output_offsets_view)
+            .arg(&validity_view)
+            .arg(&validity_bit_offset)
+            .arg(&mut output)
+            .arg(&mut views)
+            .arg(&num_strings_u64);
+    })?;
+
+    let views = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(views)));
+    let values = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(output)));
+    Ok(Canonical::VarBinView(unsafe {
+        VarBinViewArray::new_handle_unchecked(views, Arc::from([values]), dtype, validity)
+    }))
 }
 
 /// Decode FSST directly into Arrow-compatible i32 offsets and contiguous values on device.
@@ -274,6 +350,56 @@ where
         offsets: output_offsets,
         values: BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(output))),
         validity,
+    })
+}
+
+fn can_build_i32_offsets(fsst: &FSSTArray) -> bool {
+    let max_length = match fsst.uncompressed_lengths().dtype().as_ptype() {
+        PType::U8 => u8::MAX as usize,
+        PType::U16 => u16::MAX as usize,
+        PType::U32 => u32::MAX as usize,
+        PType::U64 => usize::MAX,
+        _ => return false,
+    };
+    fsst.len()
+        .checked_mul(max_length)
+        .is_some_and(|max_total| max_total <= i32::MAX as usize)
+}
+
+async fn decode_fsst_host_varbinview(
+    fsst: FSSTArray,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<Canonical> {
+    let lens = fsst
+        .uncompressed_lengths()
+        .clone()
+        .execute_cuda(ctx)
+        .await?
+        .into_host()
+        .await?
+        .into_primitive();
+    let codes_offsets = fsst
+        .codes()
+        .offsets()
+        .clone()
+        .execute_cuda(ctx)
+        .await?
+        .into_primitive();
+
+    let output_offsets: Vec<u64> = match_each_integer_ptype!(lens.ptype(), |P| {
+        let mut out = Vec::with_capacity(lens.len() + 1);
+        let mut acc: u64 = 0;
+        out.push(0u64);
+        #[allow(clippy::unnecessary_cast)]
+        for &length in lens.as_slice::<P>() {
+            acc += length as u64;
+            out.push(acc);
+        }
+        out
+    });
+
+    match_each_unsigned_integer_ptype!(codes_offsets.ptype().to_unsigned(), |U| {
+        decode_fsst::<U>(fsst, codes_offsets, lens, output_offsets, ctx).await
     })
 }
 


### PR DESCRIPTION
Stacked only on #9426. This draft contains one reviewable GPU correctness or performance concern.

## What

- Carry exact compressed-length min/sum statistics into the CUDA decoder.
- Build Arrow offsets from known lengths on device.
- Remove the two four-byte device-to-host scalar reads from each FSST decode.

## Why this is needed

This is required to remove a measured serialization point in every FSST decode. The old output-offset path copied two four-byte reduction scalars back to the host before launching the decoder. Small transfers are not the issue; each read forces the CPU to wait for preceding stream work. Exact compressed-length statistics let the same offsets be built on device without either wait.

## Validation

Checked independently against this PR's current base:

- `cargo check -p vortex-cuda --all-features`

The combined implementation also passed Rust/CUDA formatting, 164 focused dynamic-dispatch tests, and 28 focused constant-array tests.