### PR TITLE
GPU: support unsigned datetime parts

### DIFF
--- a/vortex-cuda/kernels/src/date_time_parts.cu
+++ b/vortex-cuda/kernels/src/date_time_parts.cu
@@ -46,19 +46,31 @@ __device__ void date_time_parts(const DaysT *__restrict days,
     X(i8, int8_t)                                                                                            \
     X(i16, int16_t)                                                                                          \
     X(i32, int32_t)                                                                                          \
-    X(i64, int64_t)
+    X(i64, int64_t)                                                                                          \
+    X(u8, uint8_t)                                                                                           \
+    X(u16, uint16_t)                                                                                         \
+    X(u32, uint32_t)                                                                                         \
+    X(u64, uint64_t)
 
 #define EXPAND_SUBSECONDS(d, DT, s, ST)                                                                      \
     GENERATE_DATE_TIME_PARTS_KERNEL(d, DT, s, ST, i8, int8_t)                                                \
     GENERATE_DATE_TIME_PARTS_KERNEL(d, DT, s, ST, i16, int16_t)                                              \
     GENERATE_DATE_TIME_PARTS_KERNEL(d, DT, s, ST, i32, int32_t)                                              \
-    GENERATE_DATE_TIME_PARTS_KERNEL(d, DT, s, ST, i64, int64_t)
+    GENERATE_DATE_TIME_PARTS_KERNEL(d, DT, s, ST, i64, int64_t)                                              \
+    GENERATE_DATE_TIME_PARTS_KERNEL(d, DT, s, ST, u8, uint8_t)                                               \
+    GENERATE_DATE_TIME_PARTS_KERNEL(d, DT, s, ST, u16, uint16_t)                                             \
+    GENERATE_DATE_TIME_PARTS_KERNEL(d, DT, s, ST, u32, uint32_t)                                             \
+    GENERATE_DATE_TIME_PARTS_KERNEL(d, DT, s, ST, u64, uint64_t)
 
 #define EXPAND_SECONDS(d, DT)                                                                                \
     EXPAND_SUBSECONDS(d, DT, i8, int8_t)                                                                     \
     EXPAND_SUBSECONDS(d, DT, i16, int16_t)                                                                   \
     EXPAND_SUBSECONDS(d, DT, i32, int32_t)                                                                   \
-    EXPAND_SUBSECONDS(d, DT, i64, int64_t)
+    EXPAND_SUBSECONDS(d, DT, i64, int64_t)                                                                   \
+    EXPAND_SUBSECONDS(d, DT, u8, uint8_t)                                                                    \
+    EXPAND_SUBSECONDS(d, DT, u16, uint16_t)                                                                  \
+    EXPAND_SUBSECONDS(d, DT, u32, uint32_t)                                                                  \
+    EXPAND_SUBSECONDS(d, DT, u64, uint64_t)
 
-// Generate all 64 kernels (4³)
+// Components are narrowed independently, so generate every signed/unsigned integer combination.
 EXPAND_DAYS(EXPAND_SECONDS)

--- a/vortex-cuda/src/kernel/encodings/date_time_parts.rs
+++ b/vortex-cuda/src/kernel/encodings/date_time_parts.rs
@@ -15,7 +15,7 @@ use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::TemporalArray;
 use vortex::array::arrays::primitive::PrimitiveDataParts;
 use vortex::array::buffer::BufferHandle;
-use vortex::array::match_each_signed_integer_ptype;
+use vortex::array::match_each_integer_ptype;
 use vortex::array::validity::Validity;
 use vortex::dtype::DType;
 use vortex::dtype::NativePType;
@@ -110,9 +110,9 @@ impl CudaExecute for DateTimePartsExecutor {
         let seconds_ptype = seconds_prim.ptype();
         let subseconds_ptype = subseconds_prim.ptype();
 
-        match_each_signed_integer_ptype!(days_ptype, |DaysT| {
-            match_each_signed_integer_ptype!(seconds_ptype, |SecondsT| {
-                match_each_signed_integer_ptype!(subseconds_ptype, |SubsecondsT| {
+        match_each_integer_ptype!(days_ptype, |DaysT| {
+            match_each_integer_ptype!(seconds_ptype, |SecondsT| {
+                match_each_integer_ptype!(subseconds_ptype, |SubsecondsT| {
                     decode_datetimeparts_typed::<DaysT, SecondsT, SubsecondsT>(
                         days_prim,
                         seconds_prim,
@@ -294,6 +294,42 @@ mod tests {
 
         assert_arrays_eq!(dtp_array, gpu_result, &mut ctx);
 
+        Ok(())
+    }
+
+    #[crate::test]
+    async fn test_cuda_datetimeparts_unsigned_components() -> VortexResult<()> {
+        let mut ctx = vortex_array::array_session().create_execution_ctx();
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&crate::cuda_session())
+            .vortex_expect("failed to create execution context");
+
+        let len = 3;
+        let temporal = TemporalArray::new_timestamp(
+            PrimitiveArray::new(buffer![0i64; len], Validity::NonNullable).into_array(),
+            TimeUnit::Nanoseconds,
+            None,
+        );
+        let dtp_array = DateTimeParts::try_new(
+            temporal.dtype().clone(),
+            PrimitiveArray::new(buffer![20_000u16, 20_001, 20_002], Validity::NonNullable)
+                .into_array(),
+            PrimitiveArray::new(buffer![80_000u32, 80_001, 80_002], Validity::NonNullable)
+                .into_array(),
+            PrimitiveArray::new(
+                buffer![900_000_000u32, 900_000_001, 900_000_002],
+                Validity::NonNullable,
+            )
+            .into_array(),
+        )?;
+
+        let gpu_result = DateTimePartsExecutor
+            .execute(dtp_array.clone().into_array(), &mut cuda_ctx)
+            .await?
+            .into_host()
+            .await?
+            .into_array();
+
+        assert_arrays_eq!(dtp_array, gpu_result, &mut ctx);
         Ok(())
     }
 


### PR DESCRIPTION
Independent of the other follow-up PRs; based directly on #9147. This draft contains one reviewable GPU correctness or performance concern.

## What

- Generate datetime-parts CUDA kernels for unsigned primitive storage.
- Dispatch the matching signed or unsigned kernel from Rust.
- Cover the previously rejected unsigned layouts.

## Why this is needed

This is reachable in normal compressor output, not just a synthetic compatibility case. `split_temporal` first creates signed `i64` days/seconds/subseconds, then `TemporalScheme::compress` calls `PrimitiveArray::narrow` on every child. That narrowing deliberately chooses `u8/u16/u32` whenever a range is nonnegative. Seconds and subseconds are normally nonnegative, and post-epoch days are too, so ordinary compressed timestamps can have unsigned children and the signed-only CUDA executor rejects them.

Review concern: the implementation expands kernel combinations from 4³ = 64 to 8³ = 512. Before merging, add a regression that goes through the real temporal split+narrow/compression path and check the CUDA module-size/load-time cost; the need is real even if the implementation may be tightened.

## Validation

Checked independently against this PR's current base:

- `cargo check -p vortex-cuda --all-features`

The combined implementation also passed Rust/CUDA formatting, 164 focused dynamic-dispatch tests, and 28 focused constant-array tests.