### PR TITLE
GPU: skip events for default kernel launches

### DIFF
--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -167,8 +167,15 @@ impl CudaExecutionCtx {
         let mut launcher = self.launch_builder(function);
         build_args(&mut launcher);
 
-        let events = launch_cuda_kernel_impl(&mut launcher, self.strategy.event_flags(), len)?;
-        self.strategy.on_complete(&events, len)?;
+        if let Some(events) = launch_cuda_kernel_impl(
+            &mut launcher,
+            self.strategy
+                .records_events()
+                .then(|| self.strategy.event_flags()),
+            len,
+        )? {
+            self.strategy.on_complete(&events, len)?;
+        }
         Ok(())
     }
 
@@ -187,9 +194,15 @@ impl CudaExecutionCtx {
         let mut launcher = self.launch_builder(function);
         build_args(&mut launcher);
 
-        let events =
-            launch_cuda_kernel_with_config(&mut launcher, cfg, self.strategy.event_flags())?;
-        self.strategy.on_complete(&events, len)?;
+        if let Some(events) = launch_cuda_kernel_with_config(
+            &mut launcher,
+            cfg,
+            self.strategy
+                .records_events()
+                .then(|| self.strategy.event_flags()),
+        )? {
+            self.strategy.on_complete(&events, len)?;
+        }
         Ok(())
     }
 

--- a/vortex-cuda/src/kernel/mod.rs
+++ b/vortex-cuda/src/kernel/mod.rs
@@ -49,6 +49,11 @@ pub trait LaunchStrategy: Debug + Send + Sync + 'static {
     /// Returns the event flags to use for this launch.
     fn event_flags(&self) -> CUevent_flags;
 
+    /// Whether this strategy records events around launches.
+    fn records_events(&self) -> bool {
+        true
+    }
+
     /// Called after the kernel launch completes with the recorded events.
     fn on_complete(&self, events: &CudaKernelEvents, len: usize) -> VortexResult<()>;
 }
@@ -66,6 +71,9 @@ impl<S: ?Sized + LaunchStrategy> LaunchStrategyExt for S {
     where
         F: FnMut() -> VortexResult<()>,
     {
+        if !self.records_events() {
+            return func();
+        }
         let flags = self.event_flags();
 
         let before = stream
@@ -97,6 +105,10 @@ pub struct DefaultLaunchStrategy;
 impl LaunchStrategy for DefaultLaunchStrategy {
     fn event_flags(&self) -> CUevent_flags {
         CUevent_flags::CU_EVENT_DISABLE_TIMING
+    }
+
+    fn records_events(&self) -> bool {
+        false
     }
 
     fn on_complete(&self, _events: &CudaKernelEvents, _len: usize) -> VortexResult<()> {
@@ -132,15 +144,15 @@ impl LaunchStrategy for TracingLaunchStrategy {
 ///
 /// # Returns
 ///
-/// A pair of CUDA events submitted before and after the kernel.
-/// Depending on `CUevent_flags` these events can contain timestamps. Use
+/// An optional pair of CUDA events submitted before and after the kernel.
+/// Events are omitted when `event_flags` is `None`; otherwise they can contain timestamps. Use
 /// `CU_EVENT_DISABLE_TIMING` for minimal overhead and `CU_EVENT_DEFAULT` to
 /// enable timestamps.
 pub(crate) fn launch_cuda_kernel_impl(
     launch_builder: &mut LaunchArgs,
-    event_flags: CUevent_flags,
+    event_flags: Option<CUevent_flags>,
     array_len: usize,
-) -> VortexResult<CudaKernelEvents> {
+) -> VortexResult<Option<CudaKernelEvents>> {
     // Kernel launch configuration constants.
     // Must match ELEMENTS_PER_THREAD in CUDA kernels (kernels/*.cu).
     const THREADS_PER_BLOCK: u32 = 64; // 2 warps
@@ -167,28 +179,28 @@ pub(crate) fn launch_cuda_kernel_impl(
 ///
 /// # Returns
 ///
-/// A pair of CUDA events submitted before and after the kernel.
-/// Depending on `CUevent_flags` these events can contain timestamps. Use
+/// An optional pair of CUDA events submitted before and after the kernel.
+/// Events are omitted when `event_flags` is `None`; otherwise they can contain timestamps. Use
 /// `CU_EVENT_DISABLE_TIMING` for minimal overhead and `CU_EVENT_DEFAULT` to
 /// enable timestamps.
 pub(crate) fn launch_cuda_kernel_with_config(
     launch_builder: &mut LaunchArgs,
     config: LaunchConfig,
-    event_flags: CUevent_flags,
-) -> VortexResult<CudaKernelEvents> {
-    launch_builder.record_kernel_launch(event_flags);
+    event_flags: Option<CUevent_flags>,
+) -> VortexResult<Option<CudaKernelEvents>> {
+    if let Some(event_flags) = event_flags {
+        launch_builder.record_kernel_launch(event_flags);
+    }
 
     unsafe {
         launch_builder
             .launch(config)
             .map_err(|e| vortex_err!("Failed to launch kernel: {}", e))
-            .and_then(|events| {
-                events
-                    .ok_or_else(|| vortex_err!("CUDA events not recorded"))
-                    .map(|(before_launch, after_launch)| CudaKernelEvents {
-                        before_launch,
-                        after_launch,
-                    })
+            .map(|events| {
+                events.map(|(before_launch, after_launch)| CudaKernelEvents {
+                    before_launch,
+                    after_launch,
+                })
             })
     }
 }


### PR DESCRIPTION
Independent of the other follow-up PRs; based directly on #9147. This draft contains one reviewable GPU correctness or performance concern.

## What

- Make kernel event recording conditional on the launch strategy.
- Record no before/after events for normal execution.
- Preserve timed events for tracing and profiling strategies.

## Why this is needed

The default launch strategy records before/after CUDA events around every kernel even though its completion hook is a no-op. Those events therefore cannot affect correctness or produce a metric. The profile observed 1,865 event records across the benchmark. This change skips them only for the default strategy and preserves event timing for tracing/profiling strategies, removing two unnecessary driver operations per normal launch.

## Validation

Checked independently against this PR's current base:

- `cargo check -p vortex-cuda --all-features`

The combined implementation also passed Rust/CUDA formatting, 164 focused dynamic-dispatch tests, and 28 focused constant-array tests.