### PR TITLE
GPU benchmark: add low-overhead Nsight ranges

### DIFF
--- a/benchmarks/compress-bench/Cargo.toml
+++ b/benchmarks/compress-bench/Cargo.toml
@@ -21,7 +21,7 @@ arrow-schema = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-cudarc = { workspace = true, optional = true }
+cudarc = { workspace = true, features = ["nvtx"], optional = true }
 futures = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }

--- a/benchmarks/compress-bench/README.md
+++ b/benchmarks/compress-bench/README.md
@@ -30,7 +30,9 @@ Set `VORTEX_GPU_PROFILE=wall` to emit one JSON record per decompression with fil
 decoded rows, batch and field-dispatch counts, host time for open, scan planning, reads, struct and
 field dispatch, and final synchronization, plus wall time grouped by full encoding tree. Set it to
 `gpu` to additionally bracket field dispatches with CUDA events and report each encoding group's
-device-stream time. Profiling perturbs the measurement; rerun without it for comparison numbers.
+device-stream time. `nsys` adds an NVTX range around each field while retaining encoding-tree
+metrics; `nsys-ranges` omits tree construction for a lower-overhead Nsight Systems capture.
+Profiling perturbs the measurement; rerun without it for comparison numbers.
 
 ```bash
 VORTEX_GPU_PROFILE=gpu cargo run -p compress-bench --profile release_debug \

--- a/benchmarks/compress-bench/src/gpu_vortex.rs
+++ b/benchmarks/compress-bench/src/gpu_vortex.rs
@@ -12,6 +12,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use cudarc::driver::CudaEvent;
 use cudarc::driver::sys::CUevent_flags::CU_EVENT_DEFAULT;
+use cudarc::nvtx::safe::scoped_range;
 use futures::StreamExt;
 use serde_json::json;
 use tempfile::NamedTempFile;
@@ -86,8 +87,8 @@ impl Compressor for GpuVortexCompressor {
         anyhow::ensure!(
             profile
                 .as_deref()
-                .is_none_or(|mode| matches!(mode, "wall" | "gpu")),
-            "VORTEX_GPU_PROFILE must be wall or gpu"
+                .is_none_or(|mode| matches!(mode, "wall" | "gpu" | "nsys" | "nsys-ranges")),
+            "VORTEX_GPU_PROFILE must be wall, gpu, nsys, or nsys-ranges"
         );
         if profile.is_none() {
             let start = Instant::now();
@@ -112,6 +113,8 @@ impl Compressor for GpuVortexCompressor {
         }
 
         let profile_gpu = profile.as_deref() == Some("gpu");
+        let profile_nsys = matches!(profile.as_deref(), Some("nsys" | "nsys-ranges"));
+        let profile_trees = profile.as_deref() != Some("nsys-ranges");
         let start = Instant::now();
         let open_start = Instant::now();
         let open_options = SESSION.open_options().with_cuda();
@@ -163,7 +166,7 @@ impl Compressor for GpuVortexCompressor {
             batch_count += 1;
             decoded_rows += record.len();
             for field in record.iter_unmasked_fields() {
-                let metadata = profile.as_ref().map(|_| {
+                let metadata = profile_trees.then(|| {
                     (
                         field.encoding_id().to_string(),
                         field
@@ -175,9 +178,13 @@ impl Compressor for GpuVortexCompressor {
                 let before = profile_gpu
                     .then(|| cuda_ctx.stream().record_event(Some(CU_EVENT_DEFAULT)))
                     .transpose()?;
+                let range = profile_nsys.then(|| {
+                    scoped_range(format!("vortex_field encoding={}", field.encoding_id()))
+                });
                 let field_start = Instant::now();
                 black_box(field.clone().execute_cuda(&mut cuda_ctx).await?);
                 let wall = field_start.elapsed();
+                drop(range);
                 field_time += wall;
                 let events = if let Some(before) = before {
                     Some((


### PR DESCRIPTION
Stacked only on #9432, whose root is current `develop`; it has no dependency on the Parquet benchmark PR.

## What

- Add `VORTEX_GPU_PROFILE=nsys` to wrap each field decode in an NVTX range while retaining encoding-tree metrics.
- Add `VORTEX_GPU_PROFILE=nsys-ranges` for lower-overhead captures that skip encoding-tree construction.

## Why this is needed

Nsight Systems shows CUDA API calls, copies, waits, allocations, and kernel gaps, but those events are hard to map back to Vortex fields. NVTX ranges provide that correlation. The ranges-only mode is separate because formatting every full array/encoding tree materially perturbs the host timeline we are trying to inspect.

## Validation

- `cargo +nightly fmt --all`
- `cargo check -p compress-bench --features cuda,unstable_encodings`
- `git diff --check`