### PR TITLE
fix: stop percent-encoding object keys on the way to the request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9826,8 +9826,14 @@ dependencies = [
  "percent-encoding",
  "rstest",
  "tempfile",
+ "tokio",
  "tracing",
  "url",
+ "vortex-array",
+ "vortex-error",
+ "vortex-file",
+ "vortex-io",
+ "vortex-layout",
  "vortex-utils",
 ]
 
@@ -10476,6 +10482,7 @@ dependencies = [
  "pyo3-bytes",
  "pyo3-log",
  "pyo3-object_store",
+ "rstest",
  "tokio",
  "url",
  "vortex",

--- a/vortex-cloud/Cargo.toml
+++ b/vortex-cloud/Cargo.toml
@@ -30,6 +30,14 @@ vortex-utils = { workspace = true }
 [dev-dependencies]
 rstest = { workspace = true }
 tempfile = { workspace = true }
+# So the registry's key resolution can be tested end to end against a real file open, which is
+# where the key reaches the store.
+tokio = { workspace = true, features = ["rt", "macros"] }
+vortex-array = { workspace = true }
+vortex-error = { workspace = true, features = ["object_store"] }
+vortex-file = { workspace = true, features = ["object_store", "tokio"] }
+vortex-io = { workspace = true, features = ["object_store", "tokio"] }
+vortex-layout = { workspace = true }
 
 [features]
 default = []

--- a/vortex-cloud/src/registry/tests.rs
+++ b/vortex-cloud/src/registry/tests.rs
@@ -290,11 +290,7 @@ async fn test_resolved_key_reaches_the_object(
         "the registry must report the literal key"
     );
 
-    let Err(err) = session
-        .open_options()
-        .open_object_store(&store, path)
-        .await
-    else {
+    let Err(err) = session.open_options().open_object_store(&store, path).await else {
         panic!("the payload is not a Vortex file, so opening it must fail")
     };
     assert!(

--- a/vortex-cloud/src/registry/tests.rs
+++ b/vortex-cloud/src/registry/tests.rs
@@ -292,7 +292,7 @@ async fn test_resolved_key_reaches_the_object(
 
     let Err(err) = session
         .open_options()
-        .open_object_store(&store, path.as_ref())
+        .open_object_store(&store, path)
         .await
     else {
         panic!("the payload is not a Vortex file, so opening it must fail")

--- a/vortex-cloud/src/registry/tests.rs
+++ b/vortex-cloud/src/registry/tests.rs
@@ -218,3 +218,91 @@ fn test_opendal_schemes_reach_the_opendal_builder() -> Result<(), Box<dyn std::e
     }
     Ok(())
 }
+
+/// The key the registry reports must be the object's *literal* key.
+///
+/// `~` is unreserved, so it travels through a URL verbatim; characters a URL has to escape decode
+/// back to their literal form.
+#[rstest::rstest]
+#[case("repro~tilde~key/data.vortex", "repro~tilde~key/data.vortex")]
+#[case("tablets/~~all~0/data.vortex", "tablets/~~all~0/data.vortex")]
+#[case("dir/a[1].vortex", "dir/a[1].vortex")]
+#[case("dir/a%23b.vortex", "dir/a#b.vortex")]
+#[case("dir/a%20b.vortex", "dir/a b.vortex")]
+#[case("dir/a%2520b.vortex", "dir/a%20b.vortex")]
+fn test_resolve_reports_literal_key(
+    #[case] url_path: &str,
+    #[case] expected: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let registry = registry();
+    registry.register(
+        Url::parse("memory://bucket/")?,
+        Arc::new(object_store::memory::InMemory::new()),
+    );
+
+    // Both the registered-store branch and the recomputed cached branch must agree.
+    let url = Url::parse(&format!("memory://bucket/{url_path}"))?;
+    let (_store, path) = registry.resolve(&url)?;
+    assert_eq!(path.as_ref(), expected);
+    let (_store, path) = registry.resolve(&url)?;
+    assert_eq!(path.as_ref(), expected);
+    Ok(())
+}
+
+#[rstest::rstest]
+#[case::tilde("repro~tilde~key/data.vortex")]
+#[case::double_tilde("tablets/~~all~0/data.vortex")]
+#[case::brackets("dir/a[1].vortex")]
+#[case::braces("dir/a{x}.vortex")]
+#[case::caret("dir/a^b.vortex")]
+#[case::pipe("dir/a|b.vortex")]
+#[case::star("dir/a*b.vortex")]
+#[case::space("dir/a b.vortex")]
+#[case::plain("plain/data.vortex")]
+#[tokio::test]
+async fn test_resolved_key_reaches_the_object(
+    #[case] key: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use object_store::ObjectStoreExt;
+    use vortex_error::VortexError;
+    use vortex_file::OpenOptionsSessionExt;
+
+    let session = vortex_array::array_session()
+        .with::<vortex_layout::session::LayoutSession>()
+        .with::<vortex_io::session::RuntimeSession>();
+
+    // Seed the store with the literal key, the way any other client would.
+    let store: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
+    let location = Path::parse(key)?;
+    assert_eq!(
+        location.as_ref(),
+        key,
+        "the store must hold the literal key"
+    );
+    store.put(&location, vec![0u8; 1024].into()).await?;
+
+    let registry = registry();
+    registry.register(Url::parse("memory://bucket/")?, Arc::clone(&store));
+    let (store, path) = registry.resolve(&Url::parse(&format!("memory://bucket/{key}"))?)?;
+    assert_eq!(
+        path.as_ref(),
+        key,
+        "the registry must report the literal key"
+    );
+
+    let Err(err) = session
+        .open_options()
+        .open_object_store(&store, path.as_ref())
+        .await
+    else {
+        panic!("the payload is not a Vortex file, so opening it must fail")
+    };
+    assert!(
+        !matches!(
+            err,
+            VortexError::ObjectStore(object_store::Error::NotFound { .. }, _)
+        ),
+        "opening {key:?} requested a key the store does not have: {err}"
+    );
+    Ok(())
+}

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -482,16 +482,15 @@ impl VortexOpenOptions {
     pub async fn open_object_store(
         self,
         object_store: &Arc<dyn object_store::ObjectStore>,
-        path: &str,
+        path: object_store::path::Path,
     ) -> VortexResult<VortexFile> {
         use vortex_io::object_store::ObjectStoreReadAt;
-        use vortex_io::object_store::object_path_from_literal;
 
         let handle = self.session.handle();
         let allocator = self.session.allocator();
         let source = Arc::new(ObjectStoreReadAt::new_with_allocator(
             Arc::clone(object_store),
-            object_path_from_literal(path),
+            path,
             handle,
             allocator,
         ));

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -477,18 +477,21 @@ async fn resolve_metadata(
 #[cfg(feature = "object_store")]
 impl VortexOpenOptions {
     /// Open a Vortex file from an `object_store` backend and path.
+    ///
+    /// `path` is the object's *literal* key, exactly as the store holds it.
     pub async fn open_object_store(
         self,
         object_store: &Arc<dyn object_store::ObjectStore>,
         path: &str,
     ) -> VortexResult<VortexFile> {
         use vortex_io::object_store::ObjectStoreReadAt;
+        use vortex_io::object_store::object_path_from_literal;
 
         let handle = self.session.handle();
         let allocator = self.session.allocator();
         let source = Arc::new(ObjectStoreReadAt::new_with_allocator(
             Arc::clone(object_store),
-            path.into(),
+            object_path_from_literal(path),
             handle,
             allocator,
         ));

--- a/vortex-io/src/object_store/filesystem.rs
+++ b/vortex-io/src/object_store/filesystem.rs
@@ -14,12 +14,12 @@ use object_store::ObjectStore;
 use object_store::ObjectStoreExt;
 use object_store::path::Path;
 use vortex_error::VortexResult;
-use vortex_error::vortex_err;
 
 use crate::VortexReadAt;
 use crate::filesystem::FileListing;
 use crate::filesystem::FileSystem;
 use crate::object_store::ObjectStoreReadAt;
+use crate::object_store::object_path_from_literal;
 use crate::runtime::Handle;
 
 /// A [`FileSystem`] backed by an [`ObjectStore`].
@@ -54,21 +54,6 @@ impl ObjectStoreFileSystem {
     }
 }
 
-/// Convert a literal filesystem path into an object-store [`Path`] (key).
-///
-/// Object stores key their objects *literally*: a file named `a~b.vortex` has the key
-/// `a~b.vortex`, and `LocalFileSystem` likewise surfaces real filenames verbatim. [`Path::parse`]
-/// preserves those characters, whereas [`Path::from`] percent-encodes `~`, `%`, `[`, `]`, `#`,
-/// etc. — turning `a~b.vortex` into the key `a%7Eb.vortex`, which no real object has. Using
-/// `parse` keeps inputs and the keys returned by [`list`](FileSystem::list) on the same literal
-/// representation, so a path from `list`/`head` round-trips back through `open_read` unchanged.
-///
-/// `parse` rejects empty, `.`, and `..` segments; for those we fall back to [`Path::from`], which
-/// normalizes them (this never applies to a key `list` produced, so it cannot break a round-trip).
-fn to_object_path(path: &str) -> Path {
-    Path::parse(path).unwrap_or_else(|_| Path::from(path))
-}
-
 fn listing_from_meta(location: &Path, size: u64) -> FileListing {
     FileListing {
         path: location.to_string(),
@@ -82,7 +67,7 @@ impl FileSystem for ObjectStoreFileSystem {
         let path = if prefix.is_empty() {
             None
         } else {
-            Some(to_object_path(prefix))
+            Some(object_path_from_literal(prefix))
         };
         self.store
             .list(path.as_ref())
@@ -97,7 +82,7 @@ impl FileSystem for ObjectStoreFileSystem {
     async fn head(&self, path: &str) -> VortexResult<Option<FileListing>> {
         // `head` issues a single metadata lookup (e.g. an S3 HEAD) for the exact key, unlike
         // `list`, which enumerates by path-segment prefix and never returns the key itself.
-        match self.store.head(&to_object_path(path)).await {
+        match self.store.head(&object_path_from_literal(path)).await {
             Ok(meta) => Ok(Some(listing_from_meta(&meta.location, meta.size))),
             Err(object_store::Error::NotFound { .. }) => Ok(None),
             Err(e) => Err(e.into()),
@@ -107,18 +92,13 @@ impl FileSystem for ObjectStoreFileSystem {
     async fn open_read(&self, path: &str) -> VortexResult<Arc<dyn VortexReadAt>> {
         Ok(Arc::new(ObjectStoreReadAt::new(
             Arc::clone(&self.store),
-            to_object_path(path),
+            object_path_from_literal(path),
             self.handle.clone(),
         )))
     }
 
     async fn delete(&self, path: &str) -> VortexResult<()> {
-        self.store
-            .delete(
-                &Path::from_url_path(path)
-                    .map_err(|_| vortex_err!("invalid path for url {path}"))?,
-            )
-            .await?;
+        self.store.delete(&object_path_from_literal(path)).await?;
         Ok(())
     }
 }
@@ -140,13 +120,13 @@ mod tests {
 
     /// Build an [`ObjectStoreFileSystem`] over an in-memory store seeded with `(path, size)` files.
     ///
-    /// Keys are written with [`to_object_path`] so the store holds the same literal keys a real
-    /// backend would (e.g. `a~b.vortex`, not the percent-encoded `a%7Eb.vortex`).
+    /// Keys are written with [`object_path_from_literal`] so the store holds the same literal keys
+    /// a real backend would (e.g. `a~b.vortex`, not the percent-encoded `a%7Eb.vortex`).
     async fn memory_fs(files: &[(&str, usize)]) -> VortexResult<ObjectStoreFileSystem> {
         let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
         for &(path, size) in files {
             store
-                .put(&to_object_path(path), vec![0u8; size].into())
+                .put(&object_path_from_literal(path), vec![0u8; size].into())
                 .await?;
         }
         let handle = Handle::find().expect("tokio runtime available within #[tokio::test]");
@@ -276,6 +256,43 @@ mod tests {
         assert_eq!(exact, vec![expected]);
 
         assert_eq!(fs.open_read("a~b.vortex").await?.size().await?, 5);
+        Ok(())
+    }
+
+    /// `delete` must address the same literal key as the rest of the trait. It used
+    /// `from_url_path`, which percent-*decodes*: given the real object `a%20b.vortex` it resolved
+    /// to `a b.vortex` and deleted a *different* object that happened to exist.
+    #[tokio::test]
+    async fn test_delete_addresses_the_literal_key() -> VortexResult<()> {
+        let fs = memory_fs(&[("dir/a%20b.vortex", 1), ("dir/a b.vortex", 2)]).await?;
+
+        fs.delete("dir/a%20b.vortex").await?;
+
+        assert_eq!(fs.head("dir/a%20b.vortex").await?, None);
+        assert_eq!(
+            fs.head("dir/a b.vortex").await?,
+            Some(FileListing {
+                path: "dir/a b.vortex".to_string(),
+                size: Some(2),
+            }),
+            "deleting the percent-literal key must not touch its decoded neighbour"
+        );
+        Ok(())
+    }
+
+    /// The keys `head`/`open_read` accept must also be the keys `delete` accepts.
+    #[tokio::test]
+    #[rstest]
+    #[case::tilde("dir/a~b.vortex")]
+    #[case::brackets("dir/a[1].vortex")]
+    #[case::hash("dir/a#b.vortex")]
+    #[case::space("dir/a b.vortex")]
+    #[case::plain("dir/plain.vortex")]
+    async fn test_delete_round_trip_special_chars(#[case] path: &str) -> VortexResult<()> {
+        let fs = memory_fs(&[(path, 5)]).await?;
+        assert!(fs.head(path).await?.is_some());
+        fs.delete(path).await?;
+        assert_eq!(fs.head(path).await?, None);
         Ok(())
     }
 

--- a/vortex-io/src/object_store/mod.rs
+++ b/vortex-io/src/object_store/mod.rs
@@ -2,9 +2,11 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 mod filesystem;
+mod path;
 mod read_at;
 mod write;
 
 pub use filesystem::*;
+pub use path::*;
 pub use read_at::*;
 pub use write::*;

--- a/vortex-io/src/object_store/path.rs
+++ b/vortex-io/src/object_store/path.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Conversion from a literal object key to an `object_store` [`Path`].
+
+use object_store::path::Path;
+
+/// Convert a literal object key (or filesystem path) into an object-store [`Path`].
+///
+/// Object stores key their objects *literally*: an object named `a~b.vortex` has the key
+/// `a~b.vortex`, and `LocalFileSystem` likewise surfaces real filenames verbatim. [`Path::parse`]
+/// preserves those characters, whereas [`Path::from`] percent-encodes `~`, `%`, `[`, `]`, `#`,
+/// `{`, `}`, `^`, `|`, `*`, `?`, `<`, `>`, `"`, `` ` `` and `\` — turning `a~b.vortex` into the
+/// key `a%7Eb.vortex`, which no real object has. Worse, the request layer then percent-encodes
+/// that `%` again (`%7E` → `%257E`), so the object is doubly encoded and the store 404s.
+///
+/// Using `parse` keeps caller inputs, the keys returned by listings, and the keys sent on the wire
+/// on a single literal representation, so a key from `list`/`head` round-trips back through a read
+/// unchanged.
+///
+/// `parse` rejects empty, `.`, and `..` segments; for those we fall back to [`Path::from`], which
+/// normalizes them (this never applies to a key a listing produced, so it cannot break a
+/// round-trip).
+pub fn object_path_from_literal(path: &str) -> Path {
+    Path::parse(path).unwrap_or_else(|_| Path::from(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    /// Characters `Path::from` percent-encodes must survive verbatim (regression for #9420).
+    /// `Path::from` would turn `~` into the key `%7E`, which the request layer then encodes again.
+    #[rstest]
+    #[case::tilde("dir/a~b.vortex")]
+    #[case::double_tilde("dir/~~all~0.vortex")]
+    #[case::percent_literal("dir/a%20b.vortex")]
+    #[case::brackets("dir/a[1].vortex")]
+    #[case::hash("dir/a#b.vortex")]
+    #[case::braces("dir/a{x}.vortex")]
+    #[case::caret("dir/a^b.vortex")]
+    #[case::pipe("dir/a|b.vortex")]
+    #[case::star("dir/a*b.vortex")]
+    #[case::question("dir/a?b.vortex")]
+    #[case::backslash("dir/a\\b.vortex")]
+    #[case::angles("dir/a<b>.vortex")]
+    #[case::backtick("dir/a`b.vortex")]
+    #[case::quote("dir/a\"b.vortex")]
+    #[case::space("dir/a b.vortex")]
+    #[case::unicode("dir/é~ü.vortex")]
+    #[case::plain("dir/plain.vortex")]
+    fn test_literal_round_trip(#[case] key: &str) {
+        assert_eq!(object_path_from_literal(key).as_ref(), key);
+    }
+
+    /// Relative and empty segments cannot be represented literally, so they fall back to the
+    /// normalizing conversion rather than erroring.
+    #[rstest]
+    #[case::dot("a/./b", "a/%2E/b")]
+    #[case::dotdot("a/../b", "a/%2E%2E/b")]
+    #[case::empty_segment("a//b", "a/b")]
+    fn test_normalizing_fallback(#[case] key: &str, #[case] expected: &str) {
+        assert_eq!(object_path_from_literal(key).as_ref(), expected);
+    }
+
+    /// A leading slash is not a segment; both conversions drop it.
+    #[test]
+    fn test_leading_slash_stripped() {
+        assert_eq!(
+            object_path_from_literal("/a~b.vortex").as_ref(),
+            "a~b.vortex"
+        );
+    }
+}

--- a/vortex-python/Cargo.toml
+++ b/vortex-python/Cargo.toml
@@ -63,4 +63,5 @@ vortex-python-abi = { path = "../vortex-python-abi" }
 vortex-tui = { workspace = true, optional = true }
 
 [dev-dependencies]
+rstest = { workspace = true }
 vortex-array = { path = "../vortex-array", features = ["_test-harness"] }

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -137,7 +137,7 @@ impl PyVortexDataset {
             ResolvedStore::ObjectStore(store, path) => {
                 session
                     .open_options()
-                    .open_object_store(&store, path.as_ref())
+                    .open_object_store(&store, path)
                     .await?
             }
             ResolvedStore::Path(path) => session.open_options().open_path(path).await?,

--- a/vortex-python/src/file.rs
+++ b/vortex-python/src/file.rs
@@ -89,7 +89,7 @@ pub fn open(
 
             match resolve_store(path, store.map(|x| x.into_inner()))? {
                 ResolvedStore::ObjectStore(store, path) => {
-                    options.open_object_store(&store, path.as_ref()).await
+                    options.open_object_store(&store, path).await
                 }
                 ResolvedStore::Path(path) => options.open_path(path).await,
             }

--- a/vortex-python/src/object_store/resolve.rs
+++ b/vortex-python/src/object_store/resolve.rs
@@ -13,6 +13,7 @@ use vortex::cloud::Registry;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
 use vortex::io::compat::Compat;
+use vortex::io::object_store::object_path_from_literal;
 
 static REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::default);
 
@@ -28,8 +29,11 @@ pub(crate) fn resolve_store(
     store: Option<Arc<dyn ObjectStore>>,
 ) -> VortexResult<ResolvedStore> {
     match store {
-        // If explicit store is provided use that
-        Some(store) => Ok(ResolvedStore::object_store(store, Path::from(url_or_path))),
+        // If explicit store is provided use that.
+        Some(store) => Ok(ResolvedStore::object_store(
+            store,
+            object_path_from_literal(url_or_path),
+        )),
         None => {
             // If the URL does not parse
             match Url::parse(url_or_path) {
@@ -92,7 +96,9 @@ mod test {
     use std::sync::Arc;
 
     use object_store::local::LocalFileSystem;
+    use object_store::memory::InMemory;
     use object_store::path::Path;
+    use rstest::rstest;
 
     use crate::object_store::resolve::resolve_store;
 
@@ -124,5 +130,36 @@ mod test {
             .unwrap_store();
 
         assert_eq!(path, Path::from("root/test"));
+    }
+
+    #[rstest]
+    #[case::tilde("repro~tilde~key/data.vortex", "repro~tilde~key/data.vortex")]
+    #[case::double_tilde("tablets/~~all~0/data.vortex", "tablets/~~all~0/data.vortex")]
+    #[case::brackets("dir/a[1].vortex", "dir/a[1].vortex")]
+    #[case::caret("dir/a^b.vortex", "dir/a^b.vortex")]
+    #[case::escaped_hash("dir/a%23b.vortex", "dir/a#b.vortex")]
+    #[case::escaped_space("dir/a%20b.vortex", "dir/a b.vortex")]
+    #[case::escaped_percent("dir/a%2520b.vortex", "dir/a%20b.vortex")]
+    fn test_resolve_url_yields_literal_key(#[case] url_path: &str, #[case] expected_key: &str) {
+        let (_store, path) = resolve_store(&format!("s3://my-bucket/{url_path}"), None)
+            .unwrap()
+            .unwrap_store();
+        assert_eq!(path.as_ref(), expected_key);
+    }
+
+    #[rstest]
+    #[case::tilde("repro~tilde~key/data.vortex")]
+    #[case::double_tilde("tablets/~~all~0/data.vortex")]
+    #[case::hash("dir/a#b.vortex")]
+    #[case::brackets("dir/a[1].vortex")]
+    #[case::braces("dir/a{x}.vortex")]
+    #[case::caret("dir/a^b.vortex")]
+    #[case::percent_literal("dir/a%20b.vortex")]
+    #[case::plain("dir/plain.vortex")]
+    fn test_resolve_explicit_store_preserves_literal_key(#[case] key: &str) {
+        let (_store, path) = resolve_store(key, Some(Arc::new(InMemory::new())))
+            .unwrap()
+            .unwrap_store();
+        assert_eq!(path.as_ref(), key);
     }
 }


### PR DESCRIPTION
Take user provided paths without additional encoding/decoding

Fixes #9420

Signed-off-by: Robert Kruszewski <github@robertk.io>
