### PR TITLE
perf: avoid rebuilding untouched nodes during expression rewrites

### DIFF
--- a/vortex-array/src/expr/bound_expression.rs
+++ b/vortex-array/src/expr/bound_expression.rs
@@ -143,7 +143,12 @@ impl BoundExpression {
         children: impl IntoIterator<Item = BoundExpression>,
     ) -> VortexResult<Self> {
         let children = Vec::from_iter(children);
-        let BoundExpression::Scalar { scalar_fn, .. } = &self else {
+        let BoundExpression::Scalar {
+            dtype,
+            scalar_fn,
+            children: old_children,
+        } = &self
+        else {
             vortex_ensure!(
                 children.is_empty(),
                 "Root expression cannot have {} children",
@@ -151,6 +156,20 @@ impl BoundExpression {
             );
             return Ok(self);
         };
+
+        // cheaply check dtype equality before rebuilding the scalar
+        if children.len() == old_children.len()
+            && children
+                .iter()
+                .zip(old_children.iter())
+                .all(|(new, old)| new.dtype() == old.dtype())
+        {
+            return Ok(Self::Scalar {
+                dtype: dtype.clone(),
+                scalar_fn: scalar_fn.clone(),
+                children: children.into(),
+            });
+        }
 
         Self::try_new(scalar_fn.clone(), children)
     }

--- a/vortex-array/src/expr/traversal/mod.rs
+++ b/vortex-array/src/expr/traversal/mod.rs
@@ -556,28 +556,37 @@ impl Node for BoundExpression {
         };
 
         let mut order = TraversalOrder::Continue;
-        let mut changed = false;
-        let children = children
-            .iter()
-            .cloned()
-            .map(|child| match order {
-                TraversalOrder::Continue | TraversalOrder::Skip => f(child).map(|result| {
-                    order = result.order;
-                    changed |= result.changed;
-                    result.value
-                }),
-                TraversalOrder::Stop => Ok(child),
-            })
-            .collect::<VortexResult<Vec<_>>>()?;
+        // Stays `None` until a child actually changes. Most nodes of a rewritten tree are
+        // untouched.
+        let mut rewritten: Option<Vec<Self>> = None;
 
-        if changed {
-            Ok(Transformed {
-                value: self.with_children(children)?,
+        for (index, child) in children.iter().enumerate() {
+            let value = match order {
+                TraversalOrder::Continue | TraversalOrder::Skip => {
+                    let result = f(child.clone())?;
+                    order = result.order;
+                    if result.changed && rewritten.is_none() {
+                        let mut prefix = Vec::with_capacity(children.len());
+                        prefix.extend_from_slice(&children[..index]);
+                        rewritten = Some(prefix);
+                    }
+                    result.value
+                }
+                TraversalOrder::Stop => child.clone(),
+            };
+
+            if let Some(rewritten) = &mut rewritten {
+                rewritten.push(value);
+            }
+        }
+
+        match rewritten {
+            Some(rewritten) => Ok(Transformed {
+                value: self.with_children(rewritten)?,
                 order,
                 changed: true,
-            })
-        } else {
-            Ok(Transformed::no(self))
+            }),
+            None => Ok(Transformed::no(self)),
         }
     }
 


### PR DESCRIPTION
Defer cloning children until one of them actually changes

Signed-off-by: Robert Kruszewski <robert@spiraldb.com>
