### PR TITLE
test(jni): characterize ScanOptions validation and write summary values

### DIFF
--- a/java/vortex-jni/src/test/java/dev/vortex/api/ScanOptionsTest.java
+++ b/java/vortex-jni/src/test/java/dev/vortex/api/ScanOptionsTest.java
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+package dev.vortex.api;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.vortex.api.ScanOptions.SelectionMode;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.util.OptionalLong;
+import org.junit.jupiter.api.Test;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+/**
+ * Unit tests for {@link ScanOptions#validateSelectionPayload()} and the factories that build a row selection.
+ *
+ * <p>Validation runs in an Immutables {@code @Value.Check}, so it fires at {@code build()} time on the driver rather
+ * than inside the native scan. That is the only place a mismatched mode and payload is reported with a message a caller
+ * can act on: {@code scan.rs} sees the mode as a bare byte alongside two possibly-empty arrays, so an absent payload
+ * reaches it as an empty selection instead of an error.
+ */
+public final class ScanOptionsTest {
+
+    @Test
+    public void defaultsReadEveryRowAndColumn() {
+        ScanOptions options = ScanOptions.of();
+
+        assertTrue(options.projection().isEmpty());
+        assertTrue(options.filter().isEmpty());
+        assertEquals(OptionalLong.empty(), options.rowRangeBegin());
+        assertEquals(OptionalLong.empty(), options.rowRangeEnd());
+        assertEquals(OptionalLong.empty(), options.limit());
+        assertTrue(options.selectionIndices().isEmpty());
+        assertTrue(options.selectionRoaringBitmap().isEmpty());
+        assertEquals(SelectionMode.INCLUDE_ALL, options.selectionMode());
+        assertFalse(options.ordered());
+    }
+
+    @Test
+    public void indexSelectionModesRequireIndices() {
+        for (SelectionMode mode : new SelectionMode[] {SelectionMode.INCLUDE, SelectionMode.EXCLUDE}) {
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> ScanOptions.builder().selectionMode(mode).build(),
+                    () -> "no exception for " + mode);
+            assertEquals("selection indices are required for index selection modes", exception.getMessage());
+        }
+    }
+
+    @Test
+    public void indexSelectionModesRejectARoaringPayload() {
+        // The payload is present but of the wrong kind, so the indices check is what rejects it.
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> ScanOptions.builder()
+                .selectionMode(SelectionMode.INCLUDE)
+                .selectionRoaringBitmap(new byte[] {1})
+                .build());
+        assertEquals("selection indices are required for index selection modes", exception.getMessage());
+    }
+
+    @Test
+    public void roaringSelectionModesRequireABitmap() {
+        for (SelectionMode mode : new SelectionMode[] {SelectionMode.INCLUDE_ROARING, SelectionMode.EXCLUDE_ROARING}) {
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> ScanOptions.builder().selectionMode(mode).build(),
+                    () -> "no exception for " + mode);
+            assertEquals("selection roaring bitmap is required for roaring selection modes", exception.getMessage());
+        }
+    }
+
+    @Test
+    public void roaringSelectionModesRejectAnIndexPayload() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> ScanOptions.builder()
+                .selectionMode(SelectionMode.INCLUDE_ROARING)
+                .selectionIndices(new long[] {0})
+                .build());
+        assertEquals("selection roaring bitmap is required for roaring selection modes", exception.getMessage());
+    }
+
+    @Test
+    public void roaringSelectionModesRejectAnEmptyBitmap() {
+        // `deserialize_roaring_selection` in scan.rs also rejects an empty buffer; catching it here keeps the
+        // failure on the driver, where the caller still has a stack that names the option.
+        for (SelectionMode mode : new SelectionMode[] {SelectionMode.INCLUDE_ROARING, SelectionMode.EXCLUDE_ROARING}) {
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> ScanOptions.builder()
+                            .selectionMode(mode)
+                            .selectionRoaringBitmap(new byte[0])
+                            .build(),
+                    () -> "no exception for " + mode);
+            assertEquals("selection roaring bitmap must not be empty", exception.getMessage());
+        }
+    }
+
+    @Test
+    public void anEmptyIndexArrayIsAcceptedForIndexModes() {
+        // Only the roaring payload has a non-empty requirement; an empty index array selects no rows.
+        ScanOptions options = ScanOptions.includeRows();
+
+        assertEquals(SelectionMode.INCLUDE, options.selectionMode());
+        assertArrayEquals(new long[0], options.selectionIndices().orElseThrow());
+    }
+
+    @Test
+    public void includeAllRejectsEitherPayload() {
+        IllegalArgumentException fromIndices = assertThrows(
+                IllegalArgumentException.class,
+                () -> ScanOptions.builder().selectionIndices(new long[] {0}).build());
+        assertEquals("row selection payload requires a selection mode", fromIndices.getMessage());
+
+        IllegalArgumentException fromBitmap = assertThrows(IllegalArgumentException.class, () -> ScanOptions.builder()
+                .selectionRoaringBitmap(new byte[] {1})
+                .build());
+        assertEquals("row selection payload requires a selection mode", fromBitmap.getMessage());
+    }
+
+    @Test
+    public void bothPayloadsTogetherAreRejectedBeforeTheModeIsConsidered() {
+        // Checked ahead of the mode switch, so it reports the same message for a roaring mode.
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> ScanOptions.builder()
+                .selectionMode(SelectionMode.INCLUDE_ROARING)
+                .selectionIndices(new long[] {0})
+                .selectionRoaringBitmap(new byte[] {1})
+                .build());
+        assertEquals("row selection must use either indices or roaring bitmap, not both", exception.getMessage());
+    }
+
+    @Test
+    public void indexFactoriesSetTheMatchingMode() {
+        assertEquals(SelectionMode.INCLUDE, ScanOptions.includeRows(0, 3, 9).selectionMode());
+        assertEquals(SelectionMode.EXCLUDE, ScanOptions.excludeRows(0, 9).selectionMode());
+    }
+
+    @Test
+    public void indexFactoriesCopyTheirArgument() {
+        long[] rowIndices = {0, 3, 9};
+        ScanOptions options = ScanOptions.includeRows(rowIndices);
+        rowIndices[0] = 7;
+
+        assertArrayEquals(new long[] {0, 3, 9}, options.selectionIndices().orElseThrow());
+    }
+
+    @Test
+    public void roaringFactoriesSetTheMatchingModeAndSerializeThePayload() throws Exception {
+        Roaring64NavigableMap rows = new Roaring64NavigableMap();
+        rows.addLong(0);
+        rows.addLong(3);
+        rows.addLong(9);
+
+        for (SelectionMode mode : new SelectionMode[] {SelectionMode.INCLUDE_ROARING, SelectionMode.EXCLUDE_ROARING}) {
+            ScanOptions options = mode == SelectionMode.INCLUDE_ROARING
+                    ? ScanOptions.includeRows(rows)
+                    : ScanOptions.excludeRows(rows);
+
+            assertEquals(mode, options.selectionMode());
+            // Written with `serializePortable`, so `deserializePortable` on the same bytes must round trip.
+            Roaring64NavigableMap parsed = new Roaring64NavigableMap();
+            parsed.deserializePortable(new DataInputStream(
+                    new ByteArrayInputStream(options.selectionRoaringBitmap().orElseThrow())));
+            assertEquals(3, parsed.getLongCardinality());
+            assertTrue(parsed.contains(9L));
+            assertFalse(parsed.contains(1L));
+        }
+    }
+
+    @Test
+    public void anEmptyRoaringBitmapStillSerializesToAHeader() {
+        // `serializePortable` writes a container count even for an empty map, so the non-empty check above
+        // guards a malformed buffer rather than an empty selection.
+        ScanOptions options = ScanOptions.includeRows(new Roaring64NavigableMap());
+
+        assertTrue(options.selectionRoaringBitmap().orElseThrow().length > 0);
+    }
+
+    @Test
+    public void selectionModeCodesMatchTheNativeSwitch() {
+        // scan.rs matches these bytes directly and bails on anything else.
+        assertEquals(0, SelectionMode.INCLUDE_ALL.code());
+        assertEquals(1, SelectionMode.INCLUDE.code());
+        assertEquals(2, SelectionMode.EXCLUDE.code());
+        assertEquals(3, SelectionMode.INCLUDE_ROARING.code());
+        assertEquals(4, SelectionMode.EXCLUDE_ROARING.code());
+        assertEquals(5, SelectionMode.values().length);
+    }
+
+    @Test
+    public void rowRangeAndLimitAreCarriedThrough() {
+        ScanOptions options = ScanOptions.builder()
+                .rowRangeBegin(10)
+                .rowRangeEnd(20)
+                .limit(5)
+                .ordered(true)
+                .build();
+
+        assertEquals(OptionalLong.of(10), options.rowRangeBegin());
+        assertEquals(OptionalLong.of(20), options.rowRangeEnd());
+        assertEquals(OptionalLong.of(5), options.limit());
+        assertTrue(options.ordered());
+    }
+}

--- a/java/vortex-jni/src/test/java/dev/vortex/api/VortexWriteSummaryTest.java
+++ b/java/vortex-jni/src/test/java/dev/vortex/api/VortexWriteSummaryTest.java
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+package dev.vortex.api;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.OptionalLong;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the value semantics of {@link VortexWriteSummary} and {@link VortexColumnStatistics}.
+ *
+ * <p>Both constructors are public only so {@code writer.rs} can call them through JNI, which means the boundary is
+ * untyped: counts arrive as bare {@code jlong}s and bounds as {@code Object}. {@code exact_count_jlong} sends
+ * {@code -1} when Vortex has no exact statistic, and the accessors turn that into an empty {@link OptionalLong} — a
+ * caller reading the field directly would see a negative count instead. These tests pin that translation and the
+ * defensive copy that keeps the statistics list immutable.
+ */
+public final class VortexWriteSummaryTest {
+
+    @Test
+    public void summaryReportsTheSizeAndRowCountItWasGiven() {
+        VortexWriteSummary summary = new VortexWriteSummary(4096L, 10L, new VortexColumnStatistics[0]);
+
+        assertEquals(4096L, summary.fileSize());
+        assertEquals(10L, summary.rowCount());
+        assertTrue(summary.columnStatistics().isEmpty());
+    }
+
+    @Test
+    public void summaryCopiesTheStatisticsArray() {
+        VortexColumnStatistics first = statistics(0, 1L, 0L);
+        VortexColumnStatistics[] columns = {first};
+        VortexWriteSummary summary = new VortexWriteSummary(1L, 1L, columns);
+        columns[0] = statistics(1, 2L, 0L);
+
+        assertEquals(1, summary.columnStatistics().size());
+        assertSame(first, summary.columnStatistics().get(0));
+    }
+
+    @Test
+    public void statisticsListRejectsModification() {
+        VortexWriteSummary summary =
+                new VortexWriteSummary(1L, 1L, new VortexColumnStatistics[] {statistics(0, 1L, 0L)});
+        List<VortexColumnStatistics> columns = summary.columnStatistics();
+
+        assertThrows(UnsupportedOperationException.class, columns::clear);
+        assertThrows(UnsupportedOperationException.class, () -> columns.add(statistics(1, 1L, 0L)));
+    }
+
+    @Test
+    public void statisticsListIsStableAcrossCalls() {
+        VortexWriteSummary summary = new VortexWriteSummary(1L, 1L, new VortexColumnStatistics[0]);
+
+        assertSame(summary.columnStatistics(), summary.columnStatistics());
+    }
+
+    @Test
+    public void aNegativeCountMeansVortexComputedNone() {
+        // `exact_count_jlong` returns -1 when the statistic is absent or inexact.
+        VortexColumnStatistics absent = statistics(0, 5L, 5L, -1L, -1L, null, null);
+
+        assertEquals(OptionalLong.empty(), absent.nullValueCount());
+        assertEquals(OptionalLong.empty(), absent.nanValueCount());
+    }
+
+    @Test
+    public void zeroIsAnExactCountAndNotASentinel() {
+        VortexColumnStatistics none = statistics(0, 5L, 5L, 0L, 0L, null, null);
+
+        assertEquals(OptionalLong.of(0L), none.nullValueCount());
+        assertEquals(OptionalLong.of(0L), none.nanValueCount());
+    }
+
+    @Test
+    public void exactCountsAreReportedAsGiven() {
+        VortexColumnStatistics counted = statistics(2, 128L, 10L, 3L, 1L, null, null);
+
+        assertEquals(2, counted.columnIndex());
+        assertEquals(128L, counted.compressedSize());
+        assertEquals(10L, counted.valueCount());
+        assertEquals(OptionalLong.of(3L), counted.nullValueCount());
+        assertEquals(OptionalLong.of(1L), counted.nanValueCount());
+    }
+
+    @Test
+    public void oneCountCanBeExactWhileTheOtherIsAbsent() {
+        // A non-floating-point column has a null count but no NaN count.
+        VortexColumnStatistics integral = statistics(0, 64L, 10L, 2L, -1L, null, null);
+
+        assertEquals(OptionalLong.of(2L), integral.nullValueCount());
+        assertEquals(OptionalLong.empty(), integral.nanValueCount());
+    }
+
+    @Test
+    public void absentBoundsAreEmpty() {
+        VortexColumnStatistics unbounded = statistics(0, 1L, 1L, 0L, -1L, null, null);
+
+        assertTrue(unbounded.lowerBound().isEmpty());
+        assertTrue(unbounded.upperBound().isEmpty());
+    }
+
+    @Test
+    public void boundsAreReturnedWithoutConversion() {
+        // `scalar_to_java` picks the Java type per Arrow scalar; the accessor must not narrow or box further.
+        for (Object[] pair : new Object[][] {
+            {Integer.valueOf(1), Integer.valueOf(9)},
+            {Long.valueOf(1L), Long.valueOf(9L)},
+            {BigInteger.ONE, BigInteger.TEN},
+            {Float.valueOf(1.5f), Float.valueOf(9.5f)},
+            {Double.valueOf(1.5d), Double.valueOf(9.5d)},
+            {new BigDecimal("1.50"), new BigDecimal("9.50")},
+            {"a", "z"}
+        }) {
+            VortexColumnStatistics bounded = statistics(0, 1L, 1L, 0L, -1L, pair[0], pair[1]);
+
+            assertSame(pair[0], bounded.lowerBound().orElseThrow());
+            assertSame(pair[1], bounded.upperBound().orElseThrow());
+        }
+    }
+
+    @Test
+    public void binaryBoundsAreSharedNotCopied() {
+        // Documented as `byte[]` and handed straight back, so a reader that mutates the array changes what
+        // every later reader sees. Callers must copy before writing.
+        VortexColumnStatistics bounded = statistics(0, 1L, 1L, 0L, -1L, new byte[] {1, 2}, new byte[] {3, 4});
+
+        byte[] lower = (byte[]) bounded.lowerBound().orElseThrow();
+        assertArrayEquals(new byte[] {1, 2}, lower);
+        lower[0] = 9;
+
+        assertSame(lower, bounded.lowerBound().orElseThrow());
+        assertArrayEquals(new byte[] {9, 2}, (byte[]) bounded.lowerBound().orElseThrow());
+    }
+
+    private static VortexColumnStatistics statistics(int columnIndex, long compressedSize, long valueCount) {
+        return statistics(columnIndex, compressedSize, valueCount, 0L, -1L, null, null);
+    }
+
+    private static VortexColumnStatistics statistics(
+            int columnIndex,
+            long compressedSize,
+            long valueCount,
+            long nullValueCount,
+            long nanValueCount,
+            Object lowerBound,
+            Object upperBound) {
+        return new VortexColumnStatistics(
+                columnIndex, compressedSize, valueCount, nullValueCount, nanValueCount, lowerBound, upperBound);
+    }
+}


### PR DESCRIPTION
## Rationale for this change

Both classes sit on the untyped JNI boundary. `ScanOptions` validates its selection payload in a `@Value.Check` because `scan.rs` receives the mode as a bare byte next to two possibly-empty arrays — an absent payload arrives there as an empty selection, not an error. Three of the five checks had no test. On the write side, `exact_count_jlong` sends `-1` when Vortex has no exact statistic and the accessors turn that into an empty `OptionalLong`, also untested.

## What changes are included in this PR?

Test only, two new files.

`ScanOptionsTest` covers the defaults, each mode against a missing, wrong-kind, empty and doubly-supplied payload, the array copy in `includeRows`, the roaring round trip, and that `SelectionMode.code()` matches the bytes `scan.rs` switches on.

`VortexWriteSummaryTest` covers the `-1` sentinel against an exact zero, one count exact while the other is absent, the bound types `scalar_to_java` produces, the immutable statistics list, and that a `byte[]` bound is shared, not copied.

Verified non-vacuous: seven mutations, one per behaviour, each fail a targeted test. `:vortex-jni:test` goes from 32 to 58, no failures.

## What APIs are changed? Are there any user-facing changes?

None.

## AI assistance

Prepared with agentic AI assistance. I read both classes and their callers in `writer.rs` and `scan.rs`, and confirmed the mutations fail.
