### PR TITLE
Deduplicate BitBuffer set-index visitors

### DIFF
--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::convert::Infallible;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
@@ -462,21 +463,10 @@ impl BitBuffer {
     /// (whose per-`next` iterator state does not inline as well).
     #[inline]
     pub fn for_each_set_index<F: FnMut(usize)>(&self, mut f: F) {
-        let mut base = 0usize;
-        for word in self.chunks().iter_padded() {
-            if word == u64::MAX {
-                for k in 0..64 {
-                    f(base + k);
-                }
-            } else {
-                let mut w = word;
-                while w != 0 {
-                    f(base + w.trailing_zeros() as usize);
-                    w &= w - 1;
-                }
-            }
-            base += 64;
-        }
+        let Ok(()) = self.try_for_each_set_index(|index| {
+            f(index);
+            Ok::<_, Infallible>(())
+        });
     }
 
     /// Fallible variant of [`for_each_set_index`](Self::for_each_set_index).


### PR DESCRIPTION
## Rationale for this change

Keeps the infallible and fallible set-index visitors on one implementation. Optimized LLVM IR and assembly for the measured hot path were identical. Eight paired runtime comparisons on macOS with Apple M4 Max and rustc 1.97.1 showed no clear difference.

## What changes are included in this PR?

Routes `BitBuffer::for_each_set_index` through `try_for_each_set_index` with `Infallible`, removing the duplicate traversal. The `vortex-buffer` tests, all-target/all-feature Clippy, and doctests pass.

## What APIs are changed? Are there any user-facing changes?

No public API or behavior changes.