### PR TITLE
Deduplicate trusted-length buffer construction

### DIFF
--- a/vortex-buffer/src/buffer.rs
+++ b/vortex-buffer/src/buffer.rs
@@ -236,12 +236,7 @@ impl<T> Buffer<T> {
     /// Create a buffer with values from the TrustedLen iterator.
     /// Should be preferred over `from_iter` when the iterator is known to be `TrustedLen`.
     pub fn from_trusted_len_iter<I: TrustedLen<Item = T>>(iter: I) -> Self {
-        let (_, upper_bound) = iter.size_hint();
-        let mut buffer = BufferMut::with_capacity(
-            upper_bound.vortex_expect("TrustedLen iterator has no upper bound"),
-        );
-        buffer.extend_trusted(iter);
-        buffer.freeze()
+        BufferMut::from_trusted_len_iter(iter).freeze()
     }
 
     /// Map each element of the buffer with a closure.

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -4,6 +4,7 @@
 use core::mem::MaybeUninit;
 use std::any::type_name;
 use std::cmp::max;
+use std::convert::Infallible;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::io::Write;
@@ -683,53 +684,16 @@ impl<T> BufferMut<T> {
     /// The caller guarantees that the iterator will have a trusted upper bound, which allows the
     /// implementation to reserve all of the memory needed up front.
     pub fn extend_trusted<I: TrustedLen<Item = T>>(&mut self, iter: I) {
-        // Since we know the exact upper bound (from `TrustedLen`), we can reserve all of the memory
-        // for this operation up front.
-        let (_, upper_bound) = iter.size_hint();
-        self.reserve(
-            upper_bound
-                .vortex_expect("`TrustedLen` iterator somehow didn't have valid upper bound"),
-        );
-
-        // We store `begin` in the case that the upper bound hint is incorrect.
-        let begin: *const T = self.bytes.spare_capacity_mut().as_mut_ptr().cast();
-        let mut dst: *mut T = begin.cast_mut();
-
-        iter.for_each(|item| {
-            // SAFETY: We have reserved enough capacity to hold this item, and `dst` is a pointer
-            // derived from a valid reference to byte data.
-            unsafe { dst.write(item) };
-
-            // Note: We used to have `dst.add(iteration).write(item)`, here. However this was much
-            // slower than just incrementing `dst`.
-            // SAFETY: The offsets fits in `isize`, and because we were able to reserve the memory
-            // we know that `add` will not overflow.
-            unsafe { dst = dst.add(1) };
-        });
-
-        // SAFETY: `dst` was derived from `begin`, which were both valid references to byte data,
-        // and since the only operation that `dst` has is `add`, we know that `dst >= begin`.
-        let items_written = unsafe { dst.offset_from_unsigned(begin) };
-        let length = self.len() + items_written;
-
-        // SAFETY: We have written valid items between the old length and the new length.
-        unsafe { self.set_len(length) };
+        let Ok(()) = self.try_extend_trusted(iter.map(Ok::<_, Infallible>));
     }
 
     /// Creates a `BufferMut` from an iterator with a trusted length.
-    ///
-    /// Internally, this calls [`extend_trusted()`](Self::extend_trusted).
     pub fn from_trusted_len_iter<I>(iter: I) -> Self
     where
         I: TrustedLen<Item = T>,
     {
-        let (_, upper_bound) = iter.size_hint();
-        let mut buffer = Self::with_capacity(
-            upper_bound
-                .vortex_expect("`TrustedLen` iterator somehow didn't have valid upper bound"),
-        );
+        let Ok(buffer) = Self::try_from_trusted_len_iter(iter.map(Ok::<_, Infallible>));
 
-        buffer.extend_trusted(iter);
         buffer
     }
 


### PR DESCRIPTION
## Rationale for this change

Keeps trusted-length buffer construction and extension on the fallible implementations. Optimized LLVM IR and assembly for the measured hot paths were unchanged. Eight paired runtime comparisons on macOS with Apple M4 Max and rustc 1.97.1 showed no clear difference.

## What changes are included in this PR?

Routes `BufferMut::extend_trusted` and `BufferMut::from_trusted_len_iter` through their `try_` counterparts with `Infallible`. `Buffer::from_trusted_len_iter` now delegates to `BufferMut`, and the `vortex-buffer` tests, all-target/all-feature Clippy, and doctests pass.

## What APIs are changed? Are there any user-facing changes?

No public API or behavior changes.