### PR TITLE
fix(jni): rebase array offsets before handing batches to Java

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10281,6 +10281,7 @@ name = "vortex-jni"
 version = "0.1.0"
 dependencies = [
  "arrow-array 58.4.0",
+ "arrow-data 58.4.0",
  "arrow-schema 58.4.0",
  "async-fs",
  "async-lock",

--- a/vortex-jni/Cargo.toml
+++ b/vortex-jni/Cargo.toml
@@ -20,7 +20,6 @@ categories = { workspace = true }
 arrow-array = { workspace = true, features = ["ffi"] }
 arrow-data = { workspace = true }
 arrow-schema = { workspace = true }
-
 async-fs = { workspace = true }
 async-lock = { workspace = true }
 async-trait = { workspace = true }

--- a/vortex-jni/Cargo.toml
+++ b/vortex-jni/Cargo.toml
@@ -18,7 +18,9 @@ categories = { workspace = true }
 
 [dependencies]
 arrow-array = { workspace = true, features = ["ffi"] }
+arrow-data = { workspace = true }
 arrow-schema = { workspace = true }
+
 async-fs = { workspace = true }
 async-lock = { workspace = true }
 async-trait = { workspace = true }

--- a/vortex-jni/src/scan.rs
+++ b/vortex-jni/src/scan.rs
@@ -15,10 +15,14 @@ use std::ops::Range;
 use std::ptr;
 use std::sync::Arc;
 
+use arrow_array::Array;
 use arrow_array::RecordBatch;
+use arrow_array::array::make_array;
 use arrow_array::cast::AsArray;
 use arrow_array::ffi::FFI_ArrowSchema;
 use arrow_array::ffi_stream::FFI_ArrowArrayStream;
+use arrow_data::ArrayData;
+use arrow_data::transform::MutableArrayData;
 use arrow_schema::ArrowError;
 use arrow_schema::Field;
 use futures::StreamExt;
@@ -371,7 +375,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativePartition_scanArrow(
                                 Some(target.as_ref()),
                                 &mut ctx,
                             )?;
-                            Ok(RecordBatch::from(arrow.as_struct().clone()))
+                            rebase_offsets(RecordBatch::from(arrow.as_struct().clone()))
                         })
                     })
                     .buffered(POOL.worker_count().max(1))
@@ -387,4 +391,43 @@ pub extern "system" fn Java_dev_vortex_jni_NativePartition_scanArrow(
         }
         Ok(())
     });
+}
+
+/// Copy any column carrying a non-zero array offset into an offset-0 equivalent.
+///
+/// arrow-rs exports `ArrayData::offset` over the C Data Interface without rebasing the
+/// buffer pointers, and arrow-java's importer ignores that field (through 19.0.0), so such
+/// a column lands shifted by `offset` on the Java side. Only bit-packed columns get here
+/// with one: slicing a byte-addressed buffer rebases the pointer, but a boolean slice
+/// starting mid-byte carries `start % 8`.
+fn rebase_offsets(batch: RecordBatch) -> VortexResult<RecordBatch> {
+    let mut rebased = false;
+    let columns = batch
+        .columns()
+        .iter()
+        .map(|column| {
+            let data = column.to_data();
+            if carries_offset(&data) {
+                rebased = true;
+                // `concat` of a single array will not do this: it short-circuits to
+                // `slice(0, len)`, which keeps the offset.
+                let len = data.len();
+                let mut copy = MutableArrayData::new(vec![&data], false, len);
+                copy.extend(0, 0, len);
+                make_array(copy.freeze())
+            } else {
+                Arc::clone(column)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if !rebased {
+        return Ok(batch);
+    }
+    Ok(RecordBatch::try_new(batch.schema(), columns)?)
+}
+
+/// Whether `data` or any of its descendants carries a non-zero offset.
+fn carries_offset(data: &ArrayData) -> bool {
+    data.offset() != 0 || data.child_data().iter().any(carries_offset)
 }

--- a/vortex-jni/src/scan.rs
+++ b/vortex-jni/src/scan.rs
@@ -393,13 +393,8 @@ pub extern "system" fn Java_dev_vortex_jni_NativePartition_scanArrow(
     });
 }
 
-/// Copy any column carrying a non-zero array offset into an offset-0 equivalent.
-///
-/// arrow-rs exports `ArrayData::offset` over the C Data Interface without rebasing the
-/// buffer pointers, and arrow-java's importer ignores that field (through 19.0.0), so such
-/// a column lands shifted by `offset` on the Java side. Only bit-packed columns get here
-/// with one: slicing a byte-addressed buffer rebases the pointer, but a boolean slice
-/// starting mid-byte carries `start % 8`.
+/// Copy any column carrying a non-zero array offset into an offset-0 equivalent because
+/// arrow-java's C Data importer ignores `offset` (as of 19.0.0).
 fn rebase_offsets(batch: RecordBatch) -> VortexResult<RecordBatch> {
     let mut rebased = false;
     let columns = batch


### PR DESCRIPTION
A boolean column read across a chunk boundary that is not a multiple of 8 arrives in Java with every subsequent value shifted by `start % 8`. arrow-rs exports `ArrayData::offset` over the C Data Interface without rebasing the buffer pointers, and arrow-java's importer does not honor that field, so the Java side reads from the start of the byte holding the offset. Normalize the offset at the JNI export boundary, rather than in the shared arrow conversion, so arrow-rs consumers keep the zero-copy slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
