### PR TITLE
Benchmark OnPair Arrow GPU export

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -55,7 +55,7 @@ jobs:
           - { shard: 4, name: "Encodings 1", packages: "vortex-alp vortex-bytebool vortex-datetime-parts" }
           - { shard: 5, name: "Encodings 2", packages: "vortex-decimal-byte-parts vortex-fastlanes vortex-fsst", features: "--features _test-harness" }
           - { shard: 6, name: "Encodings 3", packages: "vortex-pco vortex-runend vortex-sequence" }
-          - { shard: 7, name: "Encodings 4", packages: "vortex-sparse vortex-zigzag vortex-zstd" }
+          - { shard: 7, name: "Encodings 4 & layout", packages: "vortex-sparse vortex-zigzag vortex-zstd vortex-layout" }
           - { shard: 8, name: "Storage formats & row encoding", packages: "vortex-flatbuffers vortex-proto vortex-btrblocks vortex-row" }
           - { shard: 9, name: "Tensor & spatial", packages: "vortex-tensor vortex-spatial" }
     name: "Benchmark with Codspeed (Shard #${{ matrix.shard }})"

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -55,7 +55,7 @@ jobs:
           - { shard: 4, name: "Encodings 1", packages: "vortex-alp vortex-bytebool vortex-datetime-parts" }
           - { shard: 5, name: "Encodings 2", packages: "vortex-decimal-byte-parts vortex-fastlanes vortex-fsst", features: "--features _test-harness" }
           - { shard: 6, name: "Encodings 3", packages: "vortex-pco vortex-runend vortex-sequence" }
-          - { shard: 7, name: "Encodings 4 & layout", packages: "vortex-sparse vortex-zigzag vortex-zstd vortex-layout" }
+          - { shard: 7, name: "Encodings 4", packages: "vortex-sparse vortex-zigzag vortex-zstd" }
           - { shard: 8, name: "Storage formats & row encoding", packages: "vortex-flatbuffers vortex-proto vortex-btrblocks vortex-row" }
           - { shard: 9, name: "Tensor & spatial", packages: "vortex-tensor vortex-spatial" }
     name: "Benchmark with Codspeed (Shard #${{ matrix.shard }})"
@@ -232,6 +232,7 @@ jobs:
             --bench date_time_parts_cuda \
             --bench dict_cuda \
             --bench fsst_cuda \
+            --bench onpair_cuda \
             --bench runend_cuda \
             --profile bench
       - name: Package CUB shared library
@@ -255,7 +256,7 @@ jobs:
         include:
           - { shard: 1, name: "Bitpacked", benches: "bitpacked_cuda" }
           - { shard: 2, name: "Dynamic dispatch", benches: "dynamic_dispatch_cuda" }
-          - { shard: 3, name: "Standalone kernels", benches: "alp_cuda date_time_parts_cuda dict_cuda fsst_cuda runend_cuda" }
+          - { shard: 3, name: "Standalone kernels", benches: "alp_cuda date_time_parts_cuda dict_cuda fsst_cuda onpair_cuda runend_cuda" }
     name: "Benchmark with Codspeed (CUDA Shard #${{ matrix.shard }} - ${{ matrix.name }})"
     timeout-minutes: 30
     runs-on: >-

--- a/vortex-cuda/benches/onpair_cuda.rs
+++ b/vortex-cuda/benches/onpair_cuda.rs
@@ -24,6 +24,9 @@ use vortex::dtype::Nullability;
 use vortex::error::VortexExpect;
 use vortex_cuda::CudaDispatchMode;
 use vortex_cuda::CudaSession;
+use vortex_cuda::VarBinExportLayout;
+use vortex_cuda::arrow::DeviceArrayExt;
+use vortex_cuda::arrow::release_device_array;
 use vortex_cuda::executor::CudaArrayExt;
 use vortex_cuda_macros::cuda_available;
 use vortex_cuda_macros::cuda_not_available;
@@ -36,6 +39,14 @@ use crate::timed_launch_strategy::TimedLaunchStrategy;
 // URL-shaped string, much heavier per-element than the fixed-width primitives
 // other kernels benchmark.
 const BENCH_SIZES: &[(usize, &str)] = &[(10_000_000, "10M")];
+
+fn session_with_varbin_layout(layout: VarBinExportLayout) -> vortex::session::VortexSession {
+    vortex::array::array_session().with_some(
+        CudaSession::try_default()
+            .vortex_expect("failed to create CUDA session")
+            .with_varbin_export_layout(layout),
+    )
+}
 
 struct OnPairBenchFixture {
     array: ArrayRef,
@@ -87,6 +98,30 @@ fn benchmark_onpair_cuda_decompress(c: &mut Criterion) {
 
                     for _ in 0..iters {
                         block_on(onpair_array.clone().execute_cuda(&mut cuda_ctx)).unwrap();
+                    }
+                    Duration::from_nanos(timer.load(Ordering::Relaxed))
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("cuda/onpair/decompress_to_varbin", len_str),
+            &fixture.array,
+            |b, onpair_array| {
+                b.iter_custom(|iters| {
+                    let timed = TimedLaunchStrategy::default();
+                    let timer = timed.timer();
+                    let session = session_with_varbin_layout(VarBinExportLayout::VarBin);
+                    let mut cuda_ctx = CudaSession::create_execution_ctx(&session)
+                        .vortex_expect("failed to create execution context")
+                        .with_dispatch_mode(CudaDispatchMode::StandaloneOnly)
+                        .with_launch_strategy(Arc::new(timed));
+
+                    for _ in 0..iters {
+                        let mut exported =
+                            block_on(onpair_array.clone().export_device_array(&mut cuda_ctx))
+                                .vortex_expect("export OnPair device array");
+                        release_device_array(&mut exported);
                     }
                     Duration::from_nanos(timer.load(Ordering::Relaxed))
                 });


### PR DESCRIPTION
## Summary

- benchmark OnPair decompression directly to Arrow Device VarBin output
- retain the VarBinView benchmark as a comparison
- build and run the OnPair CUDA benchmark in the CodSpeed standalone-kernel shard

The Arrow Device path bypasses BinaryView materialization and exports device-resident validity, i32 offsets, and contiguous values buffers directly.

## Local results

10 million URL-shaped strings on the local GPU:

| Output | Median | Throughput |
| --- | ---: | ---: |
| VarBinView | 945.55 µs | 480.52 GiB/s (516.0 GB/s) |
| Arrow Device VarBin | 722.54 µs | 628.83 GiB/s (675.2 GB/s) |

Direct VarBin reduced latency by 23.6% and increased useful throughput by 30.9%.

## Validation

- `cargo bench -p vortex-cuda --bench onpair_cuda`
- `cargo test -p vortex-cuda onpair --lib` (19 passed)
- `cargo check -p vortex-cuda --bench onpair_cuda`
- `cargo +nightly fmt --all`
- `git diff --check`

`yamllint` was unavailable locally.