### PR TITLE
duckdb: support TIMESTAMP_TZ and TIME_NS

### DIFF
--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -46,7 +46,7 @@ const SOURCE_FILES: [&str; 11] = [
 
 // Duckdb C API function we use.
 // This lowers codegen'd src/cpp.rs by four times.
-const DUCKDB_C_API_FUNCTIONS: [&str; 134] = [
+const DUCKDB_C_API_FUNCTIONS: [&str; 135] = [
     "duckdb_array_type_array_size",
     "duckdb_array_type_child_type",
     "duckdb_array_vector_get_child",
@@ -80,6 +80,7 @@ const DUCKDB_C_API_FUNCTIONS: [&str; 134] = [
     "duckdb_create_selection_vector",
     "duckdb_create_struct_type",
     "duckdb_create_time",
+    "duckdb_create_time_ns",
     "duckdb_create_timestamp",
     "duckdb_create_timestamp_ms",
     "duckdb_create_timestamp_ns",

--- a/vortex-duckdb/src/convert/dtype.rs
+++ b/vortex-duckdb/src/convert/dtype.rs
@@ -284,10 +284,9 @@ fn temporal_to_duckdb(temporal: TemporalMetadata) -> VortexResult<LogicalType> {
             TimeUnit::Seconds => DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_S,
             _ => vortex_bail!("Invalid TimeUnit {} for timestamp", unit),
         },
-        TemporalMetadata::Timestamp(unit, Some(tz)) => {
-            if tz.as_ref() != "UTC" {
-                vortex_bail!("Invalid timezone for timestamp_tz {tz}, must be UTC");
-            }
+        // TIMESTAMP_TZ's timezone is a display unit, time is stored in UTC
+        // microseconds
+        TemporalMetadata::Timestamp(unit, Some(_)) => {
             if unit != &TimeUnit::Microseconds {
                 vortex_bail!(
                     "Invalid TimeUnit {} for timestamp_tz, must be Microseconds",

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -178,8 +178,6 @@ impl ToDuckDBScalar for ExtScalar<'_> {
     /// Converts an extension scalar (temporal types or `WellKnownBinary` geometries) to a DuckDB
     /// value.
     fn try_to_duckdb_scalar(&self) -> VortexResult<Value> {
-        let logical_type = LogicalType::try_from(&DType::Extension(self.ext_dtype().clone()))?;
-
         if let Some(wkb) = self.ext_dtype().metadata_opt::<WellKnownBinary>() {
             let storage = self.to_storage_scalar();
             let binary = storage
@@ -187,7 +185,7 @@ impl ToDuckDBScalar for ExtScalar<'_> {
                 .ok_or_else(|| vortex_err!("WellKnownBinary storage must be a binary scalar"))?;
             return Ok(match binary.value() {
                 Some(bytes) => Value::new_geometry(bytes.as_slice(), wkb.crs.as_deref())?,
-                None => Value::null(&logical_type),
+                None => Value::null(&*ext_logical_type(self)?),
             });
         }
 
@@ -207,15 +205,10 @@ impl ToDuckDBScalar for ExtScalar<'_> {
 
         Ok(match temporal {
             TemporalMetadata::Timestamp(unit, tz) => {
-                if let Some(tz) = tz.as_ref() {
-                    if tz.as_ref() != "UTC" {
-                        // TODO(ngates): we should convert into UTC as DuckDB does internally.
-                        //  I'm sure we can expose their timezone conversion functions to do this.
-                        vortex_bail!(
-                            "Currently only UTC timezone is supported for duckdb timestamp(tz) conversion"
-                        );
-                    }
-                    return Ok(Value::new_timestamp_tz(value()?));
+                if tz.is_some() {
+                    // TIMESTAMP_TZ stores time in UTC microseconds, tz is
+                    // a display sign
+                    return Ok(Value::new_timestamp_tz(timestamp_tz_micros(*unit, value()?)?));
                 }
                 match unit {
                     TimeUnit::Nanoseconds => Value::new_timestamp_ns(value()?),
@@ -228,26 +221,46 @@ impl ToDuckDBScalar for ExtScalar<'_> {
                 }
             }
             TemporalMetadata::Date(unit) => match unit {
-                TimeUnit::Days => self
-                    .to_storage_scalar()
-                    .as_primitive_opt()
-                    .ok_or_else(|| {
-                        vortex_err!("temporal types must be backed by primitive scalars")
-                    })?
-                    .as_::<i32>()
-                    .map(Value::new_date)
-                    .unwrap_or_else(|| Value::null(&logical_type)),
+                TimeUnit::Days => {
+                    let days = self
+                        .to_storage_scalar()
+                        .as_primitive_opt()
+                        .ok_or_else(|| {
+                            vortex_err!("temporal types must be backed by primitive scalars")
+                        })?
+                        .as_::<i32>();
+                    match days {
+                        Some(days) => Value::new_date(days),
+                        None => Value::null(&*ext_logical_type(self)?),
+                    }
+                }
                 _ => vortex_bail!("cannot have TimeUnit {unit}, so represent a day"),
             },
             TemporalMetadata::Time(unit) => match unit {
                 TimeUnit::Microseconds => Value::new_time(value()?),
                 TimeUnit::Milliseconds => Value::new_time(value()? * 1000),
                 TimeUnit::Seconds => Value::new_time(value()? * 1000 * 1000),
-                TimeUnit::Nanoseconds | TimeUnit::Days => {
-                    vortex_bail!("cannot convert timeunit {unit} to a duckdb MS time")
+                TimeUnit::Nanoseconds => Value::new_time_ns(value()?),
+                TimeUnit::Days => {
+                    vortex_bail!("cannot convert timeunit {unit} to a duckdb time")
                 }
             },
         })
+    }
+}
+
+fn ext_logical_type(scalar: &ExtScalar<'_>) -> VortexResult<LogicalType> {
+    LogicalType::try_from(&DType::Extension(scalar.ext_dtype().clone()))
+}
+
+fn timestamp_tz_micros(unit: TimeUnit, raw: i64) -> VortexResult<i64> {
+    let overflow = || vortex_err!("timestamp_tz overflow rescaling {raw}{unit} to micros");
+    match unit {
+        TimeUnit::Seconds => raw.checked_mul(1_000_000).ok_or_else(overflow),
+        TimeUnit::Milliseconds => raw.checked_mul(1_000).ok_or_else(overflow),
+        TimeUnit::Microseconds => Ok(raw),
+        TimeUnit::Nanoseconds => Ok(raw / 1_000),
+        TimeUnit::Days => vortex_bail!("timestamp_tz cannot have a day time unit"),
     }
 }
 
@@ -313,6 +326,13 @@ impl<'a> TryFrom<&'a ValueRef> for Scalar {
                 Scalar::try_new(
                     DType::Primitive(I64, Nullable),
                     Some(ScalarValue::from(micros)),
+                )?,
+            )),
+            ExtractedValue::TimeNs(nanos) => Ok(Scalar::extension::<Time>(
+                TimeUnit::Nanoseconds,
+                Scalar::try_new(
+                    DType::Primitive(I64, Nullable),
+                    Some(ScalarValue::from(nanos)),
                 )?,
             )),
             ExtractedValue::TimestampNs(nanos) => Ok(Scalar::extension::<Timestamp>(
@@ -590,6 +610,63 @@ mod tests {
             other => panic!("unexpected extracted value: {other:?}"),
         };
         assert_eq!(extracted, raw);
+    }
+
+    fn timestamp_tz_scalar(unit: TimeUnit, tz: &str, v: i64) -> Scalar {
+        Scalar::extension::<Timestamp>(
+            TimestampOptions {
+                unit,
+                tz: Some(tz.into()),
+            },
+            Scalar::try_new(
+                DType::Primitive(PType::I64, Nullability::NonNullable),
+                Some(ScalarValue::from(v)),
+            )
+            .unwrap(),
+        )
+    }
+
+    #[rstest]
+    #[case::seconds_utc(TimeUnit::Seconds, "UTC", 1_704_088_800, 1_704_088_800_000_000)]
+    #[case::millis_utc(
+        TimeUnit::Milliseconds,
+        "UTC",
+        1_704_088_800_123,
+        1_704_088_800_123_000
+    )]
+    #[case::micros_utc(
+        TimeUnit::Microseconds,
+        "UTC",
+        1_704_088_800_000_000,
+        1_704_088_800_000_000
+    )]
+    #[case::nanos_utc(
+        TimeUnit::Nanoseconds,
+        "UTC",
+        1_704_088_800_123_456_789,
+        1_704_088_800_123_456
+    )]
+    #[case::seconds_non_utc(
+        TimeUnit::Seconds,
+        "America/New_York",
+        1_704_088_800,
+        1_704_088_800_000_000
+    )]
+    fn try_from_timestamp_tz_scalar(
+        #[case] unit: TimeUnit,
+        #[case] tz: &str,
+        #[case] raw: i64,
+        #[case] expected_micros: i64,
+    ) {
+        let value = Value::try_from(timestamp_tz_scalar(unit, tz, raw)).unwrap();
+        assert_eq!(
+            value.logical_type().as_type_id(),
+            DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_TZ
+        );
+        let ExtractedValue::TimestampTz(micros) = value.extract() else {
+            panic!("expected timestamp_tz");
+        };
+        assert_eq!(micros, expected_micros);
     }
 
     #[test]

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -208,7 +208,10 @@ impl ToDuckDBScalar for ExtScalar<'_> {
                 if tz.is_some() {
                     // TIMESTAMP_TZ stores time in UTC microseconds, tz is
                     // a display sign
-                    return Ok(Value::new_timestamp_tz(timestamp_tz_micros(*unit, value()?)?));
+                    return Ok(Value::new_timestamp_tz(timestamp_tz_micros(
+                        *unit,
+                        value()?,
+                    )?));
                 }
                 match unit {
                     TimeUnit::Nanoseconds => Value::new_timestamp_ns(value()?),

--- a/vortex-duckdb/src/copy.rs
+++ b/vortex-duckdb/src/copy.rs
@@ -17,6 +17,7 @@ use vortex::dtype::Nullability::Nullable;
 use vortex::dtype::StructFields;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
+use vortex::error::vortex_bail;
 use vortex::error::vortex_err;
 use vortex::file::WriteOptionsSessionExt;
 use vortex::file::WriteSummary;
@@ -88,10 +89,22 @@ pub fn copy_to_sink(
         .as_ref()
         .ok_or_else(|| vortex_err!("sink closed early"))?
         .clone();
-    RUNTIME
-        .block_on(sink.send(chunk))
-        .map_err(|e| vortex_err!("send error {e}"))?;
-    Ok(())
+    RUNTIME.block_on(async {
+        // sink.send may error with "receiver is gone" which isn't the
+        // real error
+        if sink.send(chunk).await.is_ok() {
+            return Ok(());
+        }
+        let task;
+        {
+            task = init_global.write_task.lock().take();
+        }
+        if let Some(task) = task {
+            // we can get the real error (i.e invalid path) from here
+            task.await?;
+        }
+        vortex_bail!("Writer stopped before all data was written")
+    })
 }
 
 pub fn copy_to_finalize(init_global: &mut CopyFunctionGlobal) -> VortexResult<()> {

--- a/vortex-duckdb/src/duckdb/value.rs
+++ b/vortex-duckdb/src/duckdb/value.rs
@@ -117,7 +117,7 @@ impl ValueRef {
                 ExtractedValue::Time(unsafe { cpp::duckdb_get_time(self.as_ptr()).micros })
             }
             DUCKDB_TYPE::DUCKDB_TYPE_TIME_NS => {
-                ExtractedValue::Time(unsafe { cpp::duckdb_get_time_ns(self.as_ptr()).nanos })
+                ExtractedValue::TimeNs(unsafe { cpp::duckdb_get_time_ns(self.as_ptr()).nanos })
             }
             DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_NS => ExtractedValue::TimestampNs(unsafe {
                 cpp::duckdb_get_timestamp_ns(self.as_ptr()).nanos
@@ -258,6 +258,10 @@ impl Value {
                 seconds,
             }))
         }
+    }
+
+    pub fn new_time_ns(nanos: i64) -> Self {
+        unsafe { Self::own(cpp::duckdb_create_time_ns(cpp::duckdb_time_ns { nanos })) }
     }
 
     pub fn new_time(micros: i64) -> Self {
@@ -454,7 +458,10 @@ pub enum ExtractedValue {
     Varchar(BufferString),
     Blob(ByteBuffer),
     Date(i32),
+    /// Microseconds since midnight
     Time(i64),
+    /// Nanoseconds since midnight
+    TimeNs(i64),
     TimestampNs(i64),
     Timestamp(i64),
     TimestampMs(i64),

--- a/vortex-sqllogictest/slt/duckdb/copy_errors.slt
+++ b/vortex-sqllogictest/slt/duckdb/copy_errors.slt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+include ../setup.slt.no
+
+statement error No such file or directory
+COPY (SELECT list_value(1, generate_series) AS a FROM generate_series(10))
+TO '${WORK_DIR}/does-not-exist/probe.vortex';

--- a/vortex-sqllogictest/slt/duckdb/timestamptz_time_unit.slt
+++ b/vortex-sqllogictest/slt/duckdb/timestamptz_time_unit.slt
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+include ../setup.slt.no
+
+statement ok
+SET TimeZone = 'UTC';
+
+statement ok
+COPY (
+    SELECT TIMESTAMPTZ '2024-01-01' + to_seconds(range) AS ts
+    FROM range(100000)
+) TO '${WORK_DIR}/tz-unit.vortex' (FORMAT vortex);
+
+query I
+SELECT count(*) FROM '${WORK_DIR}/tz-unit.vortex'
+WHERE ts >= TIMESTAMPTZ '2024-01-01 06:00:00';
+----
+78400

--- a/vortex-sqllogictest/src/duckdb.rs
+++ b/vortex-sqllogictest/src/duckdb.rs
@@ -288,6 +288,7 @@ impl std::fmt::Display for ValueDisplayAdapter {
             ExtractedValue::Blob(_)
             | ExtractedValue::Date(_)
             | ExtractedValue::Time(_)
+            | ExtractedValue::TimeNs(_)
             | ExtractedValue::TimestampNs(_)
             | ExtractedValue::Timestamp(_)
             | ExtractedValue::TimestampMs(_)


### PR DESCRIPTION
- Support TIMESTAMP_TZ with any time zone (before we supported only UTC).
- Support TIME_NS (nanosecond timestamp resolution).
- Fix a display bug where a COPY error (e.g. to an invalid file) was
  swallowed and a generic error was displayed instead.
- Fix a potential bug of TIMESTAMP_TZ filter incorrectly converted
  to a Vortex filter due to time resolution mismatch.

This specific bug has been already fixed, but this change fixes a
class of bugs.
Resolves: #9396
