### PR TITLE
Fix build for wasm32-unknown-unknown without bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10348,6 +10348,7 @@ dependencies = [
  "termtree",
  "tokio",
  "tracing",
+ "uuid",
  "vortex-array",
  "vortex-arrow",
  "vortex-btrblocks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,7 @@ tracing = { version = "0.1.41", default-features = false }
 tracing-perfetto = "0.1.5"
 tracing-subscriber = "0.3"
 url = "2.5.7"
-uuid = { version = "1.23", features = ["js"] }
+uuid = "1.23"
 wasm-bindgen-futures = "0.4.58"
 wkb = "0.9.2"
 xshell = "0.2.6"
@@ -314,7 +314,7 @@ vortex-fsst = { version = "0.1.0", path = "./encodings/fsst", default-features =
 vortex-io = { version = "0.1.0", path = "./vortex-io", default-features = false }
 vortex-ipc = { version = "0.1.0", path = "./vortex-ipc", default-features = false }
 vortex-json = { version = "0.1.0", path = "./vortex-json", default-features = false }
-vortex-layout = { version = "0.1.0", path = "./vortex-layout", default-features = false }
+vortex-layout = { version = "0.1.0", path = "./vortex-layout" }
 vortex-mask = { version = "0.1.0", path = "./vortex-mask", default-features = false }
 vortex-metrics = { version = "0.1.0", path = "./vortex-metrics", default-features = false }
 vortex-onpair = { version = "0.1.0", path = "./encodings/onpair", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,7 +314,7 @@ vortex-fsst = { version = "0.1.0", path = "./encodings/fsst", default-features =
 vortex-io = { version = "0.1.0", path = "./vortex-io", default-features = false }
 vortex-ipc = { version = "0.1.0", path = "./vortex-ipc", default-features = false }
 vortex-json = { version = "0.1.0", path = "./vortex-json", default-features = false }
-vortex-layout = { version = "0.1.0", path = "./vortex-layout" }
+vortex-layout = { version = "0.1.0", path = "./vortex-layout", default-features = false }
 vortex-mask = { version = "0.1.0", path = "./vortex-mask", default-features = false }
 vortex-metrics = { version = "0.1.0", path = "./vortex-metrics", default-features = false }
 vortex-onpair = { version = "0.1.0", path = "./encodings/onpair", default-features = false }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -37,7 +37,7 @@ vortex-btrblocks = { workspace = true }
 vortex-buffer = { workspace = true }
 vortex-error = { workspace = true }
 vortex-fsst = { workspace = true, features = ["_test-harness"] }
-vortex-io = { workspace = true }
+vortex-io = { workspace = true, features = ["wasm-bindgen"] }
 vortex-mask = { workspace = true }
 vortex-row = { workspace = true }
 vortex-runend = { workspace = true, features = ["arbitrary"] }

--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -77,6 +77,7 @@ name = "split_collection"
 harness = false
 
 [features]
+default = ["wasm-bindgen"]
 object_store = ["dep:object_store", "vortex-io/object_store", "tokio"]
 tokio = [
     "dep:tokio",
@@ -84,6 +85,7 @@ tokio = [
     "vortex-io/tokio",
     "vortex-layout/tokio",
 ]
+wasm-bindgen = ["vortex-layout/wasm-bindgen"]
 zstd = ["dep:vortex-zstd", "vortex-btrblocks/zstd", "vortex-btrblocks/pco"]
 # This feature enables unstable encodings for which we don't guarantee stability.
 unstable_encodings = [

--- a/vortex-io/Cargo.toml
+++ b/vortex-io/Cargo.toml
@@ -51,7 +51,7 @@ smol = { workspace = true }
 # target_os = "unknown" matches wasm32-unknown-unknown (browser), excluding WASI targets
 # where wasm-bindgen's JS interop is not available.
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-wasm-bindgen-futures = { workspace = true }
+wasm-bindgen-futures = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -63,6 +63,7 @@ tokio = { workspace = true, features = ["full"] }
 [features]
 object_store = ["dep:object_store", "vortex-error/object_store"]
 tokio = ["tokio/fs", "tokio/rt-multi-thread"]
+wasm-bindgen = ["dep:wasm-bindgen-futures"]
 
 [lints]
 workspace = true

--- a/vortex-io/src/runtime/mod.rs
+++ b/vortex-io/src/runtime/mod.rs
@@ -11,6 +11,11 @@
 //! * Multi-threaded: work is driven on a pool of threads managed by Vortex.
 //! * Worker Pool: work is driven on a pool of threads provided by the caller.
 //! * Tokio: work is driven on a Tokio runtime provided by the caller.
+//! * WebAssembly: work is driven by `wasm_bindgen_futures`, behind the `wasm-bindgen` feature.
+//!
+//! Callers may also implement [`Executor`] themselves and install it with
+//! `RuntimeSessionExt::with_handle`, which is the only option on `wasm32-unknown-unknown`
+//! without the `wasm-bindgen` feature.
 
 use futures::future::BoxFuture;
 
@@ -33,7 +38,11 @@ mod smol;
 pub mod tokio;
 // target_os = "unknown" matches wasm32-unknown-unknown (browser), excluding WASI targets
 // where wasm-bindgen's JS interop is not available.
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "wasm-bindgen"
+))]
 pub mod wasm;
 
 #[cfg(test)]

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -64,12 +64,20 @@ vortex-array = { path = "../vortex-array", features = ["_test-harness"] }
 vortex-io = { path = "../vortex-io", features = ["tokio"] }
 
 [features]
+default = ["wasm-bindgen"]
 _test-harness = []
 tokio = ["dep:tokio", "vortex-error/tokio"]
+# `moka` enables uuid's `v4`, which needs a randomness source on wasm32-unknown-unknown.
+# Disable this to supply your own instead, by depending on uuid from your own manifest with
+# one of `js`, `rng-getrandom` (plus a getrandom backend), or `rng-rand` enabled.
+wasm-bindgen = ["dep:uuid"]
 
 [[bench]]
 name = "zone_map_prune"
 harness = false
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+uuid = { workspace = true, features = ["js"], optional = true }
 
 [lints]
 workspace = true

--- a/vortex-tui/Cargo.toml
+++ b/vortex-tui/Cargo.toml
@@ -55,6 +55,7 @@ serde_json = { workspace = true }
 taffy = { workspace = true }
 vortex = { version = "0.1.0", path = "../vortex", default-features = false, features = [
     "files",
+    "wasm-bindgen",
 ] }
 vortex-arrow = { workspace = true }
 

--- a/vortex-web/crate/Cargo.toml
+++ b/vortex-web/crate/Cargo.toml
@@ -18,6 +18,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 vortex = { path = "../../vortex", default-features = false, features = [
     "files",
+    "wasm-bindgen",
 ] }
 vortex-arrow = { workspace = true }
 

--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -88,6 +88,7 @@ tokio = [
     "vortex-layout/tokio",
 ]
 zstd = ["dep:vortex-zstd", "vortex-file?/zstd"]
+wasm-bindgen = ["vortex-io/wasm-bindgen"]
 pretty = ["vortex-array/table-display"]
 serde = ["vortex-array/serde", "vortex-buffer/serde", "vortex-mask/serde"]
 # Exposes experimental row-function APIs without compatibility guarantees.

--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -35,7 +35,7 @@ vortex-decimal-byte-parts = { workspace = true }
 vortex-edition = { workspace = true }
 vortex-error = { workspace = true }
 vortex-fastlanes = { workspace = true }
-vortex-file = { workspace = true, optional = true, default-features = true }
+vortex-file = { workspace = true, optional = true }
 vortex-flatbuffers = { workspace = true }
 vortex-fsst = { workspace = true }
 vortex-io = { workspace = true }
@@ -70,7 +70,7 @@ tracing-subscriber = { workspace = true }
 vortex = { path = ".", features = ["tokio"] }
 
 [features]
-default = ["files", "zstd"]
+default = ["files", "wasm-bindgen", "zstd"]
 files = ["dep:vortex-file"]
 memmap2 = ["vortex-buffer/memmap2"]
 object_store = ["vortex-file?/object_store", "vortex-io/object_store"]
@@ -88,7 +88,11 @@ tokio = [
     "vortex-layout/tokio",
 ]
 zstd = ["dep:vortex-zstd", "vortex-file?/zstd"]
-wasm-bindgen = ["vortex-io/wasm-bindgen"]
+wasm-bindgen = [
+    "vortex-file?/wasm-bindgen",
+    "vortex-io/wasm-bindgen",
+    "vortex-layout/wasm-bindgen",
+]
 pretty = ["vortex-array/table-display"]
 serde = ["vortex-array/serde", "vortex-buffer/serde", "vortex-mask/serde"]
 # Exposes experimental row-function APIs without compatibility guarantees.


### PR DESCRIPTION
We shouldn't unconditionally force people to use wasm-bindgen if they're not in
a js environment

fix #9475 