### PR TITLE
duckdb: UUID export support

### DIFF
--- a/vortex-duckdb/src/convert/dtype.rs
+++ b/vortex-duckdb/src/convert/dtype.rs
@@ -57,6 +57,8 @@ use vortex::extension::datetime::TemporalMetadata;
 use vortex::extension::datetime::Time;
 use vortex::extension::datetime::TimeUnit;
 use vortex::extension::datetime::Timestamp;
+use vortex::extension::uuid::Uuid;
+use vortex::extension::uuid::UuidMetadata;
 use vortex_spatial::extension::LineString;
 use vortex_spatial::extension::MultiLineString;
 use vortex_spatial::extension::MultiPoint;
@@ -180,11 +182,18 @@ impl FromLogicalType for DType {
                 )
             }
             DUCKDB_TYPE::DUCKDB_TYPE_VARIANT => DType::Variant(nullability),
+            DUCKDB_TYPE::DUCKDB_TYPE_UUID => DType::Extension(
+                ExtDType::<Uuid>::try_with_vtable(
+                    Uuid,
+                    UuidMetadata::default(),
+                    uuid_storage_dtype(nullability),
+                )?
+                .erased(),
+            ),
             other @ (DUCKDB_TYPE::DUCKDB_TYPE_TIME_TZ
             | DUCKDB_TYPE::DUCKDB_TYPE_INTERVAL
             | DUCKDB_TYPE::DUCKDB_TYPE_ENUM
             | DUCKDB_TYPE::DUCKDB_TYPE_MAP
-            | DUCKDB_TYPE::DUCKDB_TYPE_UUID
             | DUCKDB_TYPE::DUCKDB_TYPE_UNION
             | DUCKDB_TYPE::DUCKDB_TYPE_BIT
             | DUCKDB_TYPE::DUCKDB_TYPE_ANY
@@ -254,6 +263,10 @@ impl TryFrom<&DType> for LogicalType {
                     return temporal_to_duckdb(temporal);
                 }
 
+                if ext_dtype.is::<Uuid>() {
+                    return Ok(LogicalType::new(DUCKDB_TYPE::DUCKDB_TYPE_UUID));
+                }
+
                 // Native geometry types and WKB all surface to DuckDB as GEOMETRY so `ST_*` bind.
                 if let Some(spatial_metadata) = ext_dtype
                     .metadata_opt::<Point>()
@@ -273,6 +286,14 @@ impl TryFrom<&DType> for LogicalType {
 
         Ok(LogicalType::new(duckdb_type))
     }
+}
+
+fn uuid_storage_dtype(nullability: Nullability) -> DType {
+    DType::FixedSizeList(
+        Arc::new(DType::Primitive(U8, Nullability::NonNullable)),
+        16,
+        nullability,
+    )
 }
 
 fn temporal_to_duckdb(temporal: TemporalMetadata) -> VortexResult<LogicalType> {
@@ -633,6 +654,31 @@ mod tests {
 
         let original = DType::from_logical_type(&duckdb_geometry, Nullability::NonNullable)?;
         assert_eq!(original, vortex_geometry);
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[case(Nullability::NonNullable)]
+    #[case(Nullability::Nullable)]
+    fn test_uuid_roundtrip(#[case] nullability: Nullability) -> VortexResult<()> {
+        use vortex::extension::uuid::Uuid;
+        use vortex::extension::uuid::UuidMetadata;
+
+        let storage = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::U8, Nullability::NonNullable)),
+            16,
+            nullability,
+        );
+        let vortex_uuid = DType::Extension(
+            ExtDType::<Uuid>::try_with_vtable(Uuid, UuidMetadata::default(), storage)?.erased(),
+        );
+
+        let duckdb_uuid = LogicalType::try_from(&vortex_uuid)?;
+        assert_eq!(duckdb_uuid.as_type_id(), cpp::DUCKDB_TYPE::DUCKDB_TYPE_UUID);
+
+        let original = DType::from_logical_type(&duckdb_uuid, nullability)?;
+        assert_eq!(original, vortex_uuid);
 
         Ok(())
     }

--- a/vortex-duckdb/src/convert/scalar.rs
+++ b/vortex-duckdb/src/convert/scalar.rs
@@ -22,6 +22,7 @@
 use vortex::array::match_each_native_simd_ptype;
 use vortex::dtype::DType;
 use vortex::dtype::DecimalDType;
+use vortex::dtype::Nullability::NonNullable;
 use vortex::dtype::Nullability::Nullable;
 use vortex::dtype::PType;
 use vortex::dtype::PType::I32;
@@ -30,6 +31,7 @@ use vortex::dtype::half::f16;
 use vortex::error::VortexError;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
+use vortex::error::vortex_ensure;
 use vortex::error::vortex_err;
 use vortex::extension::datetime::AnyTemporal;
 use vortex::extension::datetime::Date;
@@ -38,6 +40,7 @@ use vortex::extension::datetime::Time;
 use vortex::extension::datetime::TimeUnit;
 use vortex::extension::datetime::Timestamp;
 use vortex::extension::datetime::TimestampOptions;
+use vortex::extension::uuid::Uuid;
 use vortex::scalar::BinaryScalar;
 use vortex::scalar::BoolScalar;
 use vortex::scalar::DecimalScalar;
@@ -315,6 +318,19 @@ impl<'a> TryFrom<&'a ValueRef> for Scalar {
                     ext.clone(),
                     Scalar::binary(b, Nullable),
                 )),
+                DType::Extension(ext) if ext.is::<Uuid>() => {
+                    vortex_ensure!(b.len() == 16, "UUID blob must be 16 bytes, got {}", b.len());
+                    let children = b
+                        .iter()
+                        .map(|&byte| Scalar::primitive(byte, NonNullable))
+                        .collect();
+                    let storage = Scalar::fixed_size_list(
+                        DType::Primitive(PType::U8, NonNullable),
+                        children,
+                        Nullable,
+                    );
+                    Ok(Scalar::extension_ref(ext.clone(), storage))
+                }
                 _ => vortex_bail!("Cannot convert DuckDB blob to Vortex scalar of dtype {dtype}"),
             },
             ExtractedValue::Date(days) => Ok(Scalar::extension::<Date>(

--- a/vortex-duckdb/src/convert/vector.rs
+++ b/vortex-duckdb/src/convert/vector.rs
@@ -29,6 +29,8 @@ use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
 use vortex::extension::datetime::TimeUnit;
+use vortex::extension::uuid::Uuid;
+use vortex::extension::uuid::UuidMetadata;
 use vortex::mask::Mask;
 use vortex_spatial::extension::SpatialMetadata;
 use vortex_spatial::extension::WellKnownBinary;
@@ -315,6 +317,29 @@ pub fn flat_vector_to_vortex(vector: &VectorRef, len: usize) -> VortexResult<Arr
                 _ => vortex_bail!("Unsupported decimal precision: {precision}"),
             }
             .map(|a| a.into_array())
+        }
+        DUCKDB_TYPE::DUCKDB_TYPE_UUID => {
+            let data = vector.as_slice_with_len::<i128>(len);
+            let mut bytes = BufferMut::<u8>::with_capacity(len * 16);
+            for v in data {
+                let be = (*v as u128) ^ (1u128 << 127);
+                bytes.extend_from_slice(&be.to_be_bytes());
+            }
+
+            let storage = FixedSizeListArray::try_new(
+                PrimitiveArray::new(bytes.freeze(), Validity::NonNullable).into_array(),
+                16,
+                vector.validity_ref(len).to_validity(),
+                len,
+            )?;
+            let ext_dtype = ExtDType::<Uuid>::try_with_vtable(
+                Uuid,
+                UuidMetadata::default(),
+                storage.dtype().clone(),
+            )?
+            .erased();
+
+            Ok(ExtensionArray::try_new(ext_dtype, storage.into_array())?.into_array())
         }
         DUCKDB_TYPE::DUCKDB_TYPE_ARRAY => {
             let array_elem_size = vector.logical_type().array_type_array_size();

--- a/vortex-duckdb/src/duckdb/value.rs
+++ b/vortex-duckdb/src/duckdb/value.rs
@@ -99,7 +99,7 @@ impl ValueRef {
                 unsafe { cpp::duckdb_free(ptr.cast()) };
                 ExtractedValue::Varchar(string)
             }
-            DUCKDB_TYPE::DUCKDB_TYPE_BLOB => {
+            DUCKDB_TYPE::DUCKDB_TYPE_BLOB | DUCKDB_TYPE::DUCKDB_TYPE_UUID => {
                 ExtractedValue::Blob(unsafe { take_blob(cpp::duckdb_get_blob(self.as_ptr())) })
             }
             DUCKDB_TYPE::DUCKDB_TYPE_GEOMETRY => {

--- a/vortex-duckdb/src/exporter/extension.rs
+++ b/vortex-duckdb/src/exporter/extension.rs
@@ -8,6 +8,7 @@ use vortex::array::arrays::extension::ExtensionArrayExt;
 use vortex::array::extension::datetime::AnyTemporal;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
+use vortex::extension::uuid::Uuid;
 use vortex_spatial::extension::LineString;
 use vortex_spatial::extension::LineStringData;
 use vortex_spatial::extension::MultiLineString;
@@ -26,6 +27,7 @@ use vortex_spatial::extension::WellKnownBinaryData;
 use crate::exporter::ColumnExporter;
 use crate::exporter::spatial;
 use crate::exporter::temporal;
+use crate::exporter::uuid;
 
 pub(crate) fn new_exporter(
     ext: ExtensionArray,
@@ -33,6 +35,10 @@ pub(crate) fn new_exporter(
 ) -> VortexResult<Box<dyn ColumnExporter>> {
     if ext.ext_dtype().is::<AnyTemporal>() {
         return temporal::new_exporter(TemporalArray::try_from(ext)?, ctx);
+    }
+
+    if ext.ext_dtype().is::<Uuid>() {
+        return uuid::new_exporter(ext, ctx);
     }
 
     if ext.ext_dtype().is::<WellKnownBinary>() {

--- a/vortex-duckdb/src/exporter/mod.rs
+++ b/vortex-duckdb/src/exporter/mod.rs
@@ -20,6 +20,7 @@ mod sequence;
 mod spatial;
 mod struct_;
 mod temporal;
+mod uuid;
 mod validity;
 mod varbinview;
 mod vector;

--- a/vortex-duckdb/src/exporter/uuid.rs
+++ b/vortex-duckdb/src/exporter/uuid.rs
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex::array::Canonical;
+use vortex::array::ExecutionCtx;
+use vortex::array::arrays::ExtensionArray;
+use vortex::array::arrays::extension::ExtensionArrayExt;
+use vortex::buffer::Buffer;
+use vortex::error::VortexResult;
+use vortex::error::vortex_ensure;
+use vortex::mask::Mask;
+
+use crate::duckdb::VectorRef;
+use crate::exporter::ColumnExporter;
+use crate::exporter::all_invalid;
+use crate::exporter::validity;
+
+const UUID_BYTE_LEN: usize = 16;
+
+struct UuidExporter {
+    /// UUID_BYTE_LEN big-engian bytes
+    bytes: Buffer<u8>,
+}
+
+pub(crate) fn new_exporter(
+    ext: ExtensionArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Box<dyn ColumnExporter>> {
+    let len = ext.len();
+    let storage = ext
+        .storage_array()
+        .clone()
+        .execute::<Canonical>(ctx)?
+        .into_fixed_size_list();
+    let parts = storage.into_data_parts();
+
+    if parts.validity.definitely_all_null() {
+        return Ok(all_invalid::new_exporter());
+    }
+    let mask = parts.validity.to_array(len).execute::<Mask>(ctx)?;
+
+    let bytes = parts
+        .elements
+        .execute::<Canonical>(ctx)?
+        .into_primitive()
+        .to_buffer::<u8>();
+    vortex_ensure!(
+        bytes.len() == len * UUID_BYTE_LEN,
+        "UUID storage has {} bytes, expected {}",
+        bytes.len(),
+        len * UUID_BYTE_LEN
+    );
+
+    Ok(validity::new_exporter(
+        mask,
+        Box::new(UuidExporter { bytes }),
+    ))
+}
+
+impl ColumnExporter for UuidExporter {
+    fn export(
+        &self,
+        offset: usize,
+        len: usize,
+        vector: &mut VectorRef,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<()> {
+        let src = &self.bytes[offset * UUID_BYTE_LEN..(offset + len) * UUID_BYTE_LEN];
+        let dest = unsafe { vector.as_slice_mut::<i128>(len) };
+
+        for (chunk, out) in src.chunks_exact(UUID_BYTE_LEN).zip(dest) {
+            let mut be_bytes = [0u8; UUID_BYTE_LEN];
+            be_bytes.copy_from_slice(chunk);
+            let be = u128::from_be_bytes(be_bytes);
+            *out = (be ^ (1u128 << 127)) as i128;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::cast_possible_truncation, reason = "test-only hex parsing")]
+mod tests {
+    use vortex::array::IntoArray as _;
+    use vortex::array::VortexSessionExecute as _;
+    use vortex::array::arrays::ExtensionArray;
+    use vortex::array::arrays::FixedSizeListArray;
+    use vortex::array::arrays::PrimitiveArray;
+    use vortex::array::validity::Validity;
+    use vortex::dtype::extension::ExtDType;
+    use vortex::extension::uuid::Uuid;
+    use vortex::extension::uuid::UuidMetadata;
+
+    use super::*;
+    use crate::SESSION;
+    use crate::cpp;
+    use crate::duckdb::DataChunk;
+    use crate::duckdb::LogicalType;
+
+    fn parse_uuid(uuid: &str) -> [u8; UUID_BYTE_LEN] {
+        let hex: Vec<u8> = uuid
+            .chars()
+            .filter(|c| *c != '-')
+            .map(|c| c.to_digit(16).expect("hex digit") as u8)
+            .collect();
+        assert_eq!(hex.len(), UUID_BYTE_LEN * 2);
+        let mut bytes = [0u8; UUID_BYTE_LEN];
+        for (i, byte) in bytes.iter_mut().enumerate() {
+            *byte = (hex[2 * i] << 4) | hex[2 * i + 1];
+        }
+        bytes
+    }
+
+    fn uuid_array(uuids: &[Option<&str>]) -> ExtensionArray {
+        let mut bytes = Vec::with_capacity(uuids.len() * UUID_BYTE_LEN);
+        for uuid in uuids {
+            bytes.extend_from_slice(&parse_uuid(
+                uuid.unwrap_or("00000000-0000-0000-0000-000000000000"),
+            ));
+        }
+        let validity = Validity::from_iter(uuids.iter().map(Option::is_some));
+        let storage = FixedSizeListArray::new(
+            PrimitiveArray::from_iter(bytes).into_array(),
+            UUID_BYTE_LEN as u32,
+            validity,
+            uuids.len(),
+        )
+        .into_array();
+        let ext_dtype =
+            ExtDType::try_with_vtable(Uuid, UuidMetadata::default(), storage.dtype().clone())
+                .expect("valid uuid storage")
+                .erased();
+        ExtensionArray::new(ext_dtype, storage)
+    }
+
+    #[test]
+    fn test_uuid_exporter() {
+        let arr = uuid_array(&[
+            Some("550e8400-e29b-41d4-a716-446655440000"),
+            Some("00000000-0000-0000-0000-000000000000"),
+            Some("ffffffff-ffff-ffff-ffff-ffffffffffff"),
+        ]);
+
+        let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_UUID)]);
+        let mut ctx = SESSION.create_execution_ctx();
+
+        new_exporter(arr, &mut ctx)
+            .unwrap()
+            .export(0, 3, chunk.get_vector_mut(0), &mut ctx)
+            .unwrap();
+        chunk.set_len(3);
+
+        assert_eq!(
+            format!("{}", String::try_from(&*chunk).unwrap()),
+            r#"Chunk - [1 Columns]
+- FLAT UUID: 3 = [ 550e8400-e29b-41d4-a716-446655440000, 00000000-0000-0000-0000-000000000000, ffffffff-ffff-ffff-ffff-ffffffffffff]
+"#
+        );
+    }
+
+    #[test]
+    fn test_uuid_exporter_with_nulls() {
+        let arr = uuid_array(&[
+            Some("550e8400-e29b-41d4-a716-446655440000"),
+            None,
+            Some("ffffffff-ffff-ffff-ffff-ffffffffffff"),
+        ]);
+
+        let mut chunk = DataChunk::new([LogicalType::new(cpp::duckdb_type::DUCKDB_TYPE_UUID)]);
+        let mut ctx = SESSION.create_execution_ctx();
+
+        new_exporter(arr, &mut ctx)
+            .unwrap()
+            .export(0, 3, chunk.get_vector_mut(0), &mut ctx)
+            .unwrap();
+        chunk.set_len(3);
+
+        assert_eq!(
+            format!("{}", String::try_from(&*chunk).unwrap()),
+            r#"Chunk - [1 Columns]
+- FLAT UUID: 3 = [ 550e8400-e29b-41d4-a716-446655440000, NULL, ffffffff-ffff-ffff-ffff-ffffffffffff]
+"#
+        );
+    }
+}

--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -40,6 +40,7 @@ use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
 use vortex::expr::Expression;
 use vortex::expr::stats::Precision;
+use vortex::extension::uuid::Uuid;
 use vortex::file::v2::FileStatsLayoutReader;
 use vortex::io::kanal_ext::KanalExt as _;
 use vortex::io::runtime::BlockingRuntime as _;
@@ -745,6 +746,13 @@ fn can_push_projection_aggregate(
     // vortex doesn't have list comparison
     if matches!(aggregate, PushedAggregate::Min | PushedAggregate::Max)
         && matches!(dtype, DType::List(..) | DType::FixedSizeList(..))
+    {
+        return false;
+    }
+
+    // UUID is backed by FixedSizeList which aggregations can't compute over
+    if dtype.as_extension_opt().is_some_and(|ext| ext.is::<Uuid>())
+        && !matches!(aggregate, PushedAggregate::Count)
     {
         return false;
     }

--- a/vortex-sqllogictest/slt/duckdb/uuid.slt
+++ b/vortex-sqllogictest/slt/duckdb/uuid.slt
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+include ../setup.slt.no
+
+statement ok
+CREATE TABLE u(id UUID, name VARCHAR);
+
+statement ok
+INSERT INTO u VALUES
+  ('550e8400-e29b-41d4-a716-446655440000', 'a'),
+  ('00000000-0000-0000-0000-000000000000', 'zero'),
+  ('ffffffff-ffff-ffff-ffff-ffffffffffff', 'max'),
+  (NULL, 'null');
+
+statement ok
+COPY u TO '${WORK_DIR}/uuid.vortex';
+
+query ?T
+SELECT id, name FROM '${WORK_DIR}/uuid.vortex' ORDER BY name;
+----
+550e8400-e29b-41d4-a716-446655440000 a
+ffffffff-ffff-ffff-ffff-ffffffffffff max
+NULL null
+00000000-0000-0000-0000-000000000000 zero
+
+query T
+SELECT name FROM '${WORK_DIR}/uuid.vortex'
+WHERE id = UUID '550e8400-e29b-41d4-a716-446655440000';
+----
+a
+
+query I
+SELECT count(*) FROM '${WORK_DIR}/uuid.vortex'
+WHERE id > UUID '550e8400-e29b-41d4-a716-446655440000';
+----
+1
+
+query T
+SELECT name FROM '${WORK_DIR}/uuid.vortex'
+WHERE id < UUID '550e8400-e29b-41d4-a716-446655440000';
+----
+zero
+
+query T
+SELECT name FROM '${WORK_DIR}/uuid.vortex'
+WHERE id IN (
+  UUID '00000000-0000-0000-0000-000000000000',
+  UUID 'ffffffff-ffff-ffff-ffff-ffffffffffff'
+)
+ORDER BY name;
+----
+max
+zero
+
+query I
+SELECT count(*) FROM '${WORK_DIR}/uuid.vortex' WHERE id IS NULL;
+----
+1
+
+query I
+SELECT count(*) FROM '${WORK_DIR}/uuid.vortex' WHERE id IS NOT NULL;
+----
+3
+
+query ??
+SELECT min(id), max(id) FROM '${WORK_DIR}/uuid.vortex';
+----
+00000000-0000-0000-0000-000000000000 ffffffff-ffff-ffff-ffff-ffffffffffff
+
+query I
+SELECT count(id) FROM '${WORK_DIR}/uuid.vortex';
+----
+3


### PR DESCRIPTION
Support export of UUID in duckdb and UUID as a scalar in filter
pushdown.
Resolves: #9488
