### PR TITLE
Remove scalar function factory

### DIFF
--- a/encodings/alp/src/alp_rd/compute/mask.rs
+++ b/encodings/alp/src/alp_rd/compute/mask.rs
@@ -4,8 +4,6 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::IntoArray;
-use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
-use vortex_array::scalar_fn::EmptyOptions;
 use vortex_array::scalar_fn::fns::mask::Mask as MaskExpr;
 use vortex_array::scalar_fn::fns::mask::MaskReduce;
 use vortex_error::VortexResult;
@@ -17,11 +15,8 @@ use crate::ALPRDArraySlotsExt;
 impl MaskReduce for ALPRD {
     #[allow(clippy::disallowed_methods)]
     fn mask(array: ArrayView<'_, Self>, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
-        let masked_left_parts = MaskExpr.try_new_array(
-            array.left_parts().len(),
-            EmptyOptions,
-            [array.left_parts().clone(), mask.clone()],
-        )?;
+        let masked_left_parts =
+            MaskExpr::try_new(array.left_parts().clone(), mask.clone())?.into_array();
         Ok(Some(
             ALPRD::try_new(
                 array.dtype().as_nullable(),

--- a/encodings/datetime-parts/src/compute/rules.rs
+++ b/encodings/datetime-parts/src/compute/rules.rs
@@ -185,7 +185,6 @@ mod tests {
     use vortex_array::array_session;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::TemporalArray;
-    use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
     use vortex_array::extension::datetime::TimeUnit;
     use vortex_array::extension::datetime::TimestampOptions;
     use vortex_array::optimizer::ArrayOptimizer;
@@ -282,9 +281,9 @@ mod tests {
 
         // Compare: dtp <= day 1 (midnight)
         let constant = midnight_constant(1, TimeUnit::Seconds, len);
-        let comparison = Binary
-            .try_new_array(len, Operator::Lte, [dtp.into_array(), constant])
-            .unwrap();
+        let comparison = Binary::try_new(dtp.into_array(), constant, Operator::Lte)
+            .unwrap()
+            .into_array();
 
         // Optimize should push down to days
         let optimized = comparison.optimize().unwrap();
@@ -310,16 +309,17 @@ mod tests {
         let lower = midnight_constant(1, TimeUnit::Seconds, len);
         let upper = midnight_constant(3, TimeUnit::Seconds, len);
 
-        let between = Between
-            .try_new_array(
-                len,
-                BetweenOptions {
-                    lower_strict: StrictComparison::NonStrict,
-                    upper_strict: StrictComparison::NonStrict,
-                },
-                [dtp.into_array(), lower, upper],
-            )
-            .unwrap();
+        let between = Between::try_new(
+            dtp.into_array(),
+            lower,
+            upper,
+            BetweenOptions {
+                lower_strict: StrictComparison::NonStrict,
+                upper_strict: StrictComparison::NonStrict,
+            },
+        )
+        .unwrap()
+        .into_array();
 
         // Optimize should push down to days
         let optimized = between.optimize().unwrap();
@@ -337,9 +337,9 @@ mod tests {
 
         // Compare against non-midnight constant (day 1 at noon)
         let constant = non_midnight_constant(1, 43200, TimeUnit::Seconds, len);
-        let comparison = Binary
-            .try_new_array(len, Operator::Lte, [dtp.into_array(), constant])
-            .unwrap();
+        let comparison = Binary::try_new(dtp.into_array(), constant, Operator::Lte)
+            .unwrap()
+            .into_array();
 
         // Optimize should NOT push down (constant has non-zero seconds)
         let optimized = comparison.optimize().unwrap();
@@ -372,9 +372,9 @@ mod tests {
 
         // Compare against midnight constant
         let constant = midnight_constant(1, TimeUnit::Seconds, len);
-        let comparison = Binary
-            .try_new_array(len, Operator::Lte, [dtp.into_array(), constant])
-            .unwrap();
+        let comparison = Binary::try_new(dtp.into_array(), constant, Operator::Lte)
+            .unwrap()
+            .into_array();
 
         // Should still compute correctly (just not optimized via pushdown)
         let optimized = comparison.optimize().unwrap();

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/mask.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/mask.rs
@@ -4,8 +4,6 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::IntoArray;
-use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
-use vortex_array::scalar_fn::EmptyOptions;
 use vortex_array::scalar_fn::fns::mask::Mask as MaskExpr;
 use vortex_array::scalar_fn::fns::mask::MaskReduce;
 use vortex_error::VortexExpect;
@@ -16,11 +14,7 @@ use crate::decimal_byte_parts::DecimalBytePartsArraySlotsExt;
 
 impl MaskReduce for DecimalByteParts {
     fn mask(array: ArrayView<'_, Self>, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
-        let masked_msp = MaskExpr.try_new_array(
-            array.msp().len(),
-            EmptyOptions,
-            [array.msp().clone(), mask.clone()],
-        )?;
+        let masked_msp = MaskExpr::try_new(array.msp().clone(), mask.clone())?.into_array();
         Ok(Some(
             DecimalByteParts::try_new(
                 masked_msp,

--- a/encodings/fsst/benches/fsst_like.rs
+++ b/encodings/fsst/benches/fsst_like.rs
@@ -11,7 +11,6 @@ use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ConstantArray;
-use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
 use vortex_array::scalar_fn::fns::like::Like;
 use vortex_array::scalar_fn::fns::like::LikeOptions;
 use vortex_fsst::FSSTArray;
@@ -121,7 +120,7 @@ fn bench_like(bencher: Bencher, fsst: &FSSTArray, pattern: &str) {
     bencher
         .with_inputs(|| SESSION.create_execution_ctx())
         .bench_refs(|ctx| {
-            Like.try_new_array(len, LikeOptions::default(), [arr.clone(), pattern.clone()])
+            Like::try_new(arr.clone(), pattern.clone(), LikeOptions::default())
                 .unwrap()
                 .into_array()
                 .execute::<Canonical>(ctx)

--- a/encodings/fsst/src/compute/like.rs
+++ b/encodings/fsst/src/compute/like.rs
@@ -86,7 +86,6 @@ mod tests {
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::ConstantArray;
     use vortex_array::arrays::VarBinArray;
-    use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
     use vortex_array::assert_arrays_eq;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
@@ -119,8 +118,7 @@ mod tests {
         let len = array.len();
         let arr = array.into_array();
         let pattern = ConstantArray::new(pattern, len).into_array();
-        let result = Like
-            .try_new_array(len, opts, [arr, pattern])?
+        let result = Like::try_new(arr, pattern, opts)?
             .into_array()
             .execute::<Canonical>(&mut SESSION.create_execution_ctx())?;
         Ok(result.into_bool())

--- a/encodings/fsst/src/dfa/tests.rs
+++ b/encodings/fsst/src/dfa/tests.rs
@@ -14,7 +14,6 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::VarBinArray;
-use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
 use vortex_array::assert_arrays_eq;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
@@ -279,10 +278,8 @@ fn make_fsst_str(strings: &[Option<&str>]) -> FSSTArray {
 }
 
 fn run_like(array: FSSTArray, pattern_arr: ArrayRef) -> VortexResult<BoolArray> {
-    let len = array.len();
     let arr: ArrayRef = array.into_array();
-    let result = Like
-        .try_new_array(len, LikeOptions::default(), [arr, pattern_arr])?
+    let result = Like::try_new(arr, pattern_arr, LikeOptions::default())?
         .into_array()
         .execute::<Canonical>(&mut SESSION.create_execution_ctx())?;
     Ok(result.into_bool())

--- a/encodings/runend/src/trace_tests.rs
+++ b/encodings/runend/src/trace_tests.rs
@@ -12,7 +12,6 @@ use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::FilterArray;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
 use vortex_array::assert_arrays_eq;
 use vortex_array::optimizer::ArrayOptimizer;
 use vortex_array::scalar::Scalar;
@@ -47,7 +46,7 @@ fn runend_array() -> VortexResult<ArrayRef> {
 fn trace_compare_on_runend() -> VortexResult<()> {
     let runend = runend_array()?;
     let rhs = ConstantArray::new(Scalar::from(2i32), runend.len()).into_array();
-    let compared = Binary.try_new_array(runend.len(), Operator::Eq, [runend, rhs])?;
+    let compared = Binary::try_new(runend, rhs, Operator::Eq)?.into_array();
 
     let traced = trace_op(|| compared.optimize())?;
     insta::assert_snapshot!(traced.trace.to_string(), @"

--- a/encodings/zigzag/src/compute/mod.rs
+++ b/encodings/zigzag/src/compute/mod.rs
@@ -9,8 +9,6 @@ use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::dict::TakeExecute;
 use vortex_array::arrays::filter::FilterReduce;
-use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
-use vortex_array::scalar_fn::EmptyOptions;
 use vortex_array::scalar_fn::fns::mask::Mask as MaskExpr;
 use vortex_array::scalar_fn::fns::mask::MaskReduce;
 use vortex_error::VortexResult;
@@ -39,11 +37,7 @@ impl TakeExecute for ZigZag {
 
 impl MaskReduce for ZigZag {
     fn mask(array: ArrayView<'_, Self>, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
-        let masked_encoded = MaskExpr.try_new_array(
-            array.encoded().len(),
-            EmptyOptions,
-            [array.encoded().clone(), mask.clone()],
-        )?;
+        let masked_encoded = MaskExpr::try_new(array.encoded().clone(), mask.clone())?.into_array();
         Ok(Some(ZigZag::try_new(masked_encoded)?.into_array()))
     }
 }

--- a/fuzz/src/fsst_like.rs
+++ b/fuzz/src/fsst_like.rs
@@ -160,11 +160,8 @@ fn run_like_on_array(
     len: usize,
     opts: LikeOptions,
 ) -> VortexResult<BoolArray> {
-    use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
-
     let pattern_arr = ConstantArray::new(pattern, len).into_array();
-    let result = Like
-        .try_new_array(len, opts, [array.clone(), pattern_arr])?
+    let result = Like::try_new(array.clone(), pattern_arr, opts)?
         .into_array()
         .execute::<Canonical>(&mut SESSION.create_execution_ctx())?;
     Ok(result.into_bool())

--- a/vortex-array/benches/like.rs
+++ b/vortex-array/benches/like.rs
@@ -14,7 +14,6 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::VarBinViewArray;
-use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
 use vortex_array::scalar_fn::fns::like::Like;
 use vortex_array::scalar_fn::fns::like::LikeOptions;
 
@@ -48,15 +47,13 @@ fn bench_like(bencher: Bencher, pattern: &str, options: LikeOptions) {
     bencher
         .with_inputs(|| {
             (
-                Like.try_new_array(
-                    ARRAY_SIZE,
+                Like::try_new(
+                    array.clone(),
+                    ConstantArray::new(pattern, ARRAY_SIZE).into_array(),
                     options,
-                    [
-                        array.clone(),
-                        ConstantArray::new(pattern, ARRAY_SIZE).into_array(),
-                    ],
                 )
-                .unwrap(),
+                .unwrap()
+                .into_array(),
                 session.create_execution_ctx(),
             )
         })
@@ -98,12 +95,9 @@ fn like_per_row_patterns(bencher: Bencher) {
     bencher
         .with_inputs(|| {
             (
-                Like.try_new_array(
-                    ARRAY_SIZE,
-                    LikeOptions::default(),
-                    [array.clone(), patterns.clone()],
-                )
-                .unwrap(),
+                Like::try_new(array.clone(), patterns.clone(), LikeOptions::default())
+                    .unwrap()
+                    .into_array(),
                 session.create_execution_ctx(),
             )
         })

--- a/vortex-array/src/arrays/chunked/compute/mask.rs
+++ b/vortex-array/src/arrays/chunked/compute/mask.rs
@@ -10,8 +10,6 @@ use crate::array::ArrayView;
 use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
 use crate::arrays::chunked::ChunkedArrayExt;
-use crate::arrays::scalar_fn::ScalarFnFactoryExt;
-use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::fns::mask::Mask as MaskExpr;
 use crate::scalar_fn::fns::mask::MaskKernel;
 
@@ -29,7 +27,7 @@ impl MaskKernel for Chunked {
                 let start = chunk_offsets[i];
                 let end = chunk_offsets[i + 1];
                 let chunk_mask = mask.slice(start..end)?;
-                MaskExpr.try_new_array(chunk.len(), EmptyOptions, [chunk.clone(), chunk_mask])
+                MaskExpr::try_new(chunk.clone(), chunk_mask).map(IntoArray::into_array)
             })
             .collect::<VortexResult<_>>()?;
 

--- a/vortex-array/src/arrays/dict/compute/like.rs
+++ b/vortex-array/src/arrays/dict/compute/like.rs
@@ -11,7 +11,6 @@ use crate::array::ArrayView;
 use crate::arrays::ConstantArray;
 use crate::arrays::dict::DictArrayExt;
 use crate::arrays::dict::DictArraySlotsExt;
-use crate::arrays::scalar_fn::ScalarFnFactoryExt;
 use crate::optimizer::ArrayOptimizer;
 use crate::scalar_fn::fns::like::Like;
 use crate::scalar_fn::fns::like::LikeOptions;
@@ -30,8 +29,8 @@ impl LikeReduce for Dict {
         if let Some(pattern) = pattern.as_constant() {
             let pattern = ConstantArray::new(pattern, array.values().len()).into_array();
 
-            let values = Like
-                .try_new_array(pattern.len(), options, [array.values().clone(), pattern])?
+            let values = Like::try_new(array.values().clone(), pattern, options)?
+                .into_array()
                 .optimize()?;
 
             // SAFETY: LIKE preserves the len of the values, so codes are still pointing at
@@ -62,7 +61,6 @@ mod tests {
     use crate::arrays::DictArray;
     use crate::arrays::VarBinArray;
     use crate::arrays::dict::compute::like::ConstantArray;
-    use crate::arrays::scalar_fn::ScalarFnFactoryExt;
     use crate::assert_arrays_eq;
     use crate::optimizer::ArrayOptimizer;
     use crate::scalar_fn::fns::like::Like;
@@ -78,8 +76,8 @@ mod tests {
         .into_array();
 
         let pattern = ConstantArray::new("hello%", 4).into_array();
-        let result = Like
-            .try_new_array(4, LikeOptions::default(), [dict, pattern])?
+        let result = Like::try_new(dict, pattern, LikeOptions::default())?
+            .into_array()
             .optimize()?;
 
         assert_arrays_eq!(

--- a/vortex-array/src/arrays/dict/compute/mask.rs
+++ b/vortex-array/src/arrays/dict/compute/mask.rs
@@ -9,18 +9,12 @@ use crate::array::ArrayView;
 use crate::arrays::Dict;
 use crate::arrays::DictArray;
 use crate::arrays::dict::DictArraySlotsExt;
-use crate::arrays::scalar_fn::ScalarFnFactoryExt;
-use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::fns::mask::Mask as MaskExpr;
 use crate::scalar_fn::fns::mask::MaskReduce;
 
 impl MaskReduce for Dict {
     fn mask(array: ArrayView<'_, Dict>, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
-        let masked_codes = MaskExpr.try_new_array(
-            array.codes().len(),
-            EmptyOptions,
-            [array.codes().clone(), mask.clone()],
-        )?;
+        let masked_codes = MaskExpr::try_new(array.codes().clone(), mask.clone())?.into_array();
         // SAFETY: masking codes doesn't change dict invariants
         Ok(Some(unsafe {
             DictArray::new_unchecked(masked_codes, array.values().clone()).into_array()

--- a/vortex-array/src/arrays/dict/compute/rules.rs
+++ b/vortex-array/src/arrays/dict/compute/rules.rs
@@ -278,13 +278,11 @@ mod tests {
     use crate::arrays::chunked::ChunkedArrayExt;
     use crate::arrays::dict::DictArrayExt;
     use crate::arrays::dict::DictArraySlotsExt;
-    use crate::arrays::scalar_fn::ScalarFnFactoryExt;
     use crate::assert_arrays_eq;
     use crate::dtype::Nullability;
     use crate::executor::VortexSessionExecute;
     use crate::optimizer::ArrayOptimizer;
     use crate::scalar::Scalar;
-    use crate::scalar_fn::EmptyOptions;
     use crate::scalar_fn::fns::binary::Binary;
     use crate::scalar_fn::fns::not::Not;
     use crate::scalar_fn::fns::operators::Operator;
@@ -350,9 +348,7 @@ mod tests {
         }
         .into_array();
 
-        let result = Not
-            .try_new_array(dict.len(), EmptyOptions, [dict])?
-            .optimize()?;
+        let result = Not::try_new(dict)?.into_array().optimize()?;
         let result = result.as_::<Dict>();
 
         assert!(result.has_all_values_referenced());
@@ -367,7 +363,7 @@ mod tests {
         let dict = DictArray::try_new(codes, values)?.into_array();
         let const_false =
             ConstantArray::new(Scalar::bool(false, Nullability::NonNullable), 3).into_array();
-        let expr = Binary.try_new_array(3, Operator::And, vec![dict, const_false])?;
+        let expr = Binary::try_new(dict, const_false, Operator::And)?.into_array();
 
         let mut ctx = array_session().create_execution_ctx();
         // Kleene AND: null AND false == false, so all three rows must be valid `false`.
@@ -384,7 +380,7 @@ mod tests {
         let dict = DictArray::try_new(codes, values)?.into_array();
         let const_true =
             ConstantArray::new(Scalar::bool(true, Nullability::NonNullable), 3).into_array();
-        let expr = Binary.try_new_array(3, Operator::Or, vec![dict, const_true])?;
+        let expr = Binary::try_new(dict, const_true, Operator::Or)?.into_array();
 
         let mut ctx = array_session().create_execution_ctx();
         // Kleene OR: null OR true == true, so all three rows must be valid `true`.

--- a/vortex-array/src/arrays/extension/compute/mask.rs
+++ b/vortex-array/src/arrays/extension/compute/mask.rs
@@ -9,18 +9,13 @@ use crate::array::ArrayView;
 use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
 use crate::arrays::extension::ExtensionArrayExt;
-use crate::arrays::scalar_fn::ScalarFnFactoryExt;
-use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::fns::mask::Mask as MaskExpr;
 use crate::scalar_fn::fns::mask::MaskReduce;
 
 impl MaskReduce for Extension {
     fn mask(array: ArrayView<'_, Extension>, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
-        let masked_storage = MaskExpr.try_new_array(
-            array.storage_array().len(),
-            EmptyOptions,
-            [array.storage_array().clone(), mask.clone()],
-        )?;
+        let masked_storage =
+            MaskExpr::try_new(array.storage_array().clone(), mask.clone())?.into_array();
         Ok(Some(
             ExtensionArray::new(
                 array

--- a/vortex-array/src/arrays/extension/compute/rules.rs
+++ b/vortex-array/src/arrays/extension/compute/rules.rs
@@ -99,7 +99,6 @@ mod tests {
     use crate::arrays::ScalarFn;
     use crate::arrays::extension::ExtensionArrayExt;
     use crate::arrays::scalar_fn::ScalarFnArrayExt;
-    use crate::arrays::scalar_fn::ScalarFnFactoryExt;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
     use crate::dtype::PType;
@@ -229,9 +228,9 @@ mod tests {
         let storage = buffer![15i64, 25, 35].into_array();
         let ext_array = ExtensionArray::new(ext_dtype, storage).into_array();
 
-        let scalar_fn_array = Binary
-            .try_new_array(3, Operator::Lt, [constant_ext, ext_array])
-            .unwrap();
+        let scalar_fn_array = Binary::try_new(constant_ext, ext_array, Operator::Lt)
+            .unwrap()
+            .into_array();
 
         let optimized = scalar_fn_array.optimize_recursive(&SESSION).unwrap();
         let scalar_fn = optimized.as_opt::<ScalarFn>().unwrap();
@@ -291,9 +290,9 @@ mod tests {
         let const_scalar = Scalar::extension::<TestExt2>(EmptyMetadata, Scalar::from(25i64));
         let const_array = ConstantArray::new(const_scalar, 3).into_array();
 
-        let scalar_fn_array = Binary
-            .try_new_array(3, Operator::Lt, [ext_array, const_array])
-            .unwrap();
+        let scalar_fn_array = Binary::try_new(ext_array, const_array, Operator::Lt)
+            .unwrap()
+            .into_array();
 
         let optimized = scalar_fn_array.optimize().unwrap();
 
@@ -316,9 +315,9 @@ mod tests {
         let ext_array2 = ExtensionArray::new(ext_dtype, storage2).into_array();
 
         // Both children are extension arrays (not constants)
-        let scalar_fn_array = Binary
-            .try_new_array(3, Operator::Lt, [ext_array1, ext_array2])
-            .unwrap();
+        let scalar_fn_array = Binary::try_new(ext_array1, ext_array2, Operator::Lt)
+            .unwrap()
+            .into_array();
 
         let optimized = scalar_fn_array.optimize().unwrap();
 
@@ -339,9 +338,9 @@ mod tests {
         // Create a non-extension constant (plain primitive)
         let const_array = ConstantArray::new(Scalar::from(25i64), 3).into_array();
 
-        let scalar_fn_array = Binary
-            .try_new_array(3, Operator::Lt, [ext_array, const_array])
-            .unwrap();
+        let scalar_fn_array = Binary::try_new(ext_array, const_array, Operator::Lt)
+            .unwrap()
+            .into_array();
 
         let optimized = scalar_fn_array.optimize().unwrap();
 

--- a/vortex-array/src/arrays/masked/compute/mask.rs
+++ b/vortex-array/src/arrays/masked/compute/mask.rs
@@ -4,11 +4,10 @@
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::IntoArray;
 use crate::array::ArrayView;
 use crate::arrays::Masked;
 use crate::arrays::masked::MaskedArraySlotsExt;
-use crate::arrays::scalar_fn::ScalarFnFactoryExt;
-use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::fns::mask::Mask as MaskExpr;
 use crate::scalar_fn::fns::mask::MaskReduce;
 use crate::validity::Validity;
@@ -20,11 +19,7 @@ impl MaskReduce for Masked {
             .validity()?
             .and(Validity::Array(mask.clone()))?
             .to_array(array.len());
-        let masked_child = MaskExpr.try_new_array(
-            array.child().len(),
-            EmptyOptions,
-            [array.child().clone(), combined_mask],
-        )?;
+        let masked_child = MaskExpr::try_new(array.child().clone(), combined_mask)?.into_array();
         Ok(Some(masked_child))
     }
 }

--- a/vortex-array/src/arrays/scalar_fn/array.rs
+++ b/vortex-array/src/arrays/scalar_fn/array.rs
@@ -87,13 +87,16 @@ impl Array<ScalarFn> {
         children: Vec<ArrayRef>,
         len: usize,
     ) -> VortexResult<Self> {
+        Self::validate_arity(&scalar_fn, children.len())?;
         Self::validate_children_len(&children, len)?;
+
         let arg_dtypes: Vec<_> = children.iter().map(|c| c.dtype().clone()).collect();
         let dtype = scalar_fn.return_dtype(&arg_dtypes)?;
         let data = ScalarFnData {
             scalar_fn: scalar_fn.clone(),
         };
         let vtable = ScalarFn { id: scalar_fn.id() };
+
         Ok(unsafe {
             Array::from_parts_unchecked(
                 ArrayParts::new(vtable, dtype, len, data)
@@ -107,6 +110,15 @@ impl Array<ScalarFn> {
             vortex_bail!("ScalarFnArray length cannot be inferred without children");
         };
         Ok(child.len())
+    }
+
+    fn validate_arity(scalar_fn: &ScalarFnRef, child_count: usize) -> VortexResult<()> {
+        let arity = scalar_fn.signature().arity();
+        vortex_ensure!(
+            arity.matches(child_count),
+            "ScalarFnArray requires {arity} children, got {child_count}"
+        );
+        Ok(())
     }
 
     fn validate_children_len(children: &[ArrayRef], len: usize) -> VortexResult<()> {

--- a/vortex-array/src/arrays/scalar_fn/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/mod.rs
@@ -7,5 +7,4 @@ mod rules;
 mod vtable;
 
 pub use array::ScalarFnArrayExt;
-pub use vtable::ScalarFnFactoryExt;
 pub use vtable::*;

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -20,9 +20,7 @@ use vortex_session::registry::CachedId;
 use crate::ArrayEq;
 use crate::ArrayHash;
 use crate::ArrayRef;
-use crate::ArraySlots;
 use crate::EqMode;
-use crate::IntoArray;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;
@@ -85,9 +83,23 @@ impl VTable for ScalarFn {
         len: usize,
         slots: &[Option<ArrayRef>],
     ) -> VortexResult<()> {
+        let scalar_fn = data.scalar_fn();
         vortex_ensure!(
-            data.scalar_fn.id() == self.id,
+            scalar_fn.id() == self.id,
             "ScalarFnArray data scalar_fn does not match vtable"
+        );
+
+        let missing_children = slots.iter().filter(|slot| slot.is_none()).count();
+        vortex_ensure!(
+            missing_children == 0,
+            "ScalarFnArray requires every child slot to be present, got {missing_children} missing"
+        );
+
+        let arity = scalar_fn.signature().arity();
+        vortex_ensure!(
+            arity.matches(slots.len()),
+            "ScalarFnArray requires {arity} children, got {}",
+            slots.len()
         );
         vortex_ensure!(
             slots.iter().flatten().all(|c| c.len() == len),
@@ -100,7 +112,7 @@ impl VTable for ScalarFn {
             .map(|c| c.dtype().clone())
             .collect_vec();
         vortex_ensure!(
-            data.scalar_fn.return_dtype(&child_dtypes)? == *dtype,
+            scalar_fn.return_dtype(&child_dtypes)? == *dtype,
             "ScalarFnArray dtype does not match scalar function return dtype"
         );
         Ok(())
@@ -175,40 +187,6 @@ impl VTable for ScalarFn {
         PARENT_RULES.evaluate(array, parent, child_idx)
     }
 }
-
-/// Array factory functions for scalar functions.
-pub trait ScalarFnFactoryExt: scalar_fn::ScalarFnVTable {
-    fn try_new_array(
-        &self,
-        len: usize,
-        options: Self::Options,
-        children: impl Into<Vec<ArrayRef>>,
-    ) -> VortexResult<ArrayRef> {
-        let scalar_fn = scalar_fn::TypedScalarFnInstance::new(self.clone(), options).erased();
-
-        let children = children.into();
-        vortex_ensure!(
-            children.iter().all(|c| c.len() == len),
-            "All child arrays must have the same length as the scalar function array"
-        );
-
-        let child_dtypes = children.iter().map(|c| c.dtype().clone()).collect_vec();
-        let dtype = scalar_fn.return_dtype(&child_dtypes)?;
-
-        let data = ScalarFnData {
-            scalar_fn: scalar_fn.clone(),
-        };
-        let vtable = ScalarFn { id: scalar_fn.id() };
-        Ok(unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(vtable, dtype, len, data)
-                    .with_slots(children.into_iter().map(Some).collect::<ArraySlots>()),
-            )
-        }
-        .into_array())
-    }
-}
-impl<V: scalar_fn::ScalarFnVTable> ScalarFnFactoryExt for V {}
 
 /// A matcher that matches any scalar function expression.
 #[derive(Debug)]

--- a/vortex-array/src/arrays/scalar_fn/vtable/operations.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/operations.rs
@@ -58,14 +58,19 @@ mod tests {
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
 
+    use crate::ArraySlots;
     use crate::Canonical;
     use crate::IntoArray;
     use crate::VortexSessionExecute;
+    use crate::array::Array;
+    use crate::array::ArrayParts;
     use crate::array_session;
     use crate::arrays::BoolArray;
     use crate::arrays::PrimitiveArray;
     use crate::arrays::ScalarFnArray;
     use crate::arrays::scalar_fn::ScalarFnArrayExt;
+    use crate::arrays::scalar_fn::array::ScalarFnData;
+    use crate::arrays::scalar_fn::vtable::ScalarFn;
     use crate::assert_arrays_eq;
     use crate::scalar::Scalar;
     use crate::scalar_fn::TypedScalarFnInstance;
@@ -107,6 +112,50 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("ScalarFnArray must have children equal to the array length")
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_arity() {
+        let child = buffer![1i32, 2, 3].into_array();
+        let scalar_fn = TypedScalarFnInstance::new(Binary, Operator::Add).erased();
+
+        let Err(err) = ScalarFnArray::try_new(scalar_fn.clone(), vec![child.clone()]) else {
+            panic!("Binary must reject one child");
+        };
+        assert!(
+            err.to_string()
+                .contains("ScalarFnArray requires 2 children, got 1")
+        );
+
+        let Err(err) = ScalarFnArray::try_new(scalar_fn, vec![child.clone(), child.clone(), child])
+        else {
+            panic!("Binary must reject three children");
+        };
+        assert!(
+            err.to_string()
+                .contains("ScalarFnArray requires 2 children, got 3")
+        );
+    }
+
+    #[test]
+    fn rejects_missing_child_slot() {
+        let lhs = buffer![1i32, 2, 3].into_array();
+        let dtype = lhs.dtype().clone();
+        let scalar_fn = TypedScalarFnInstance::new(Binary, Operator::Add).erased();
+        let vtable = ScalarFn { id: scalar_fn.id() };
+        let data = ScalarFnData { scalar_fn };
+        let slots = [Some(lhs), None].into_iter().collect::<ArraySlots>();
+
+        let Err(err) = Array::<ScalarFn>::try_from_parts(
+            ArrayParts::new(vtable, dtype, 3, data).with_slots(slots),
+        ) else {
+            panic!("ScalarFnArray must reject missing child slots");
+        };
+
+        assert!(
+            err.to_string()
+                .contains("ScalarFnArray requires every child slot to be present, got 1 missing")
         );
     }
 

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -139,7 +139,6 @@ mod tests {
     use crate::arrays::PrimitiveArray;
     use crate::arrays::StructArray;
     use crate::arrays::VarBinArray;
-    use crate::arrays::scalar_fn::ScalarFnFactoryExt;
     use crate::arrays::struct_::StructArrayExt;
     use crate::assert_arrays_eq;
     use crate::builtins::ArrayBuiltins;
@@ -209,9 +208,7 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let cast = Cast
-            .try_new_array(source.len(), target.clone(), [source])
-            .unwrap();
+        let cast = Cast::new(source, target.clone()).into_array();
         let parent_id = cast.encoding_id();
         let session = VortexSession::empty().with_some(KernelSession::empty());
         let kernels = session.kernels();

--- a/vortex-array/src/arrays/variant/vtable/kernel.rs
+++ b/vortex-array/src/arrays/variant/vtable/kernel.rs
@@ -18,7 +18,6 @@ use crate::arrays::Variant;
 use crate::arrays::VariantArray;
 use crate::arrays::scalar_fn::ExactScalarFn;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
-use crate::arrays::scalar_fn::ScalarFnFactoryExt;
 use crate::arrays::struct_::StructArrayExt;
 use crate::arrays::variant::VariantArraySlotsExt;
 use crate::builtins::ArrayBuiltins;
@@ -60,12 +59,7 @@ impl ExecuteParentKernel<Variant> for VariantGetKernel {
         // perfectly represented by the canonical shredded tree.
         let core_validity = array.core_storage().validity()?;
         let make_fallback = |ctx: &mut ExecutionCtx| {
-            execute_fallback_variant_get(
-                array.len(),
-                parent.options.clone(),
-                array.core_storage().clone(),
-                ctx,
-            )
+            execute_fallback_variant_get(parent.options.clone(), array.core_storage().clone(), ctx)
         };
 
         // Canonical shredded storage is a logical typed tree. We can only walk object
@@ -95,7 +89,6 @@ impl ExecuteParentKernel<Variant> for VariantGetKernel {
                 .is_some_and(|dtype| !dtype.is_variant())
         {
             return execute_fallback_variant_get(
-                array.len(),
                 VariantGetOptions::new(VariantPath::root(), parent.options.dtype().cloned()),
                 typed,
                 ctx,
@@ -202,12 +195,11 @@ fn merge_typed_as_variant(
 }
 
 fn execute_fallback_variant_get(
-    len: usize,
     options: VariantGetOptions,
     core_storage: ArrayRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    VariantGet
-        .try_new_array(len, options, [core_storage])?
+    VariantGet::try_new(core_storage, options)?
+        .into_array()
         .execute::<ArrayRef>(ctx)
 }

--- a/vortex-array/src/builtins.rs
+++ b/vortex-array/src/builtins.rs
@@ -15,7 +15,6 @@ use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::InterleaveArray;
-use crate::arrays::scalar_fn::ScalarFnFactoryExt;
 use crate::dtype::DType;
 use crate::dtype::FieldName;
 use crate::expr::Expression;
@@ -173,8 +172,7 @@ impl ArrayBuiltins for ArrayRef {
         if self.dtype() == &dtype {
             return Ok(self.clone());
         }
-        Cast.try_new_array(self.len(), dtype, [self.clone()])?
-            .optimize()
+        Cast::new(self.clone(), dtype).into_array().optimize()
     }
 
     fn fill_null(&self, fill_value: impl Into<Scalar>) -> VortexResult<ArrayRef> {
@@ -182,48 +180,38 @@ impl ArrayBuiltins for ArrayRef {
         if !self.dtype().is_nullable() {
             return self.cast(fill_value.dtype().clone());
         }
-        FillNull
-            .try_new_array(
-                self.len(),
-                EmptyOptions,
-                [
-                    self.clone(),
-                    ConstantArray::new(fill_value, self.len()).into_array(),
-                ],
-            )?
-            .optimize()
+        FillNull::try_new(
+            self.clone(),
+            ConstantArray::new(fill_value, self.len()).into_array(),
+        )?
+        .into_array()
+        .optimize()
     }
 
     fn get_item(&self, field_name: impl Into<FieldName>) -> VortexResult<ArrayRef> {
-        GetItem
-            .try_new_array(self.len(), field_name.into(), [self.clone()])?
+        GetItem::try_new(self.clone(), field_name)?
+            .into_array()
             .optimize()
     }
 
     fn is_null(&self) -> VortexResult<ArrayRef> {
-        IsNull
-            .try_new_array(self.len(), EmptyOptions, [self.clone()])?
-            .optimize()
+        IsNull::new(self.clone()).into_array().optimize()
     }
 
     fn is_not_null(&self) -> VortexResult<ArrayRef> {
-        IsNotNull
-            .try_new_array(self.len(), EmptyOptions, [self.clone()])?
-            .optimize()
+        IsNotNull::new(self.clone()).into_array().optimize()
     }
 
     fn mask(self, mask: ArrayRef) -> VortexResult<ArrayRef> {
-        Mask.try_new_array(self.len(), EmptyOptions, [self, mask])?
-            .optimize()
+        Mask::try_new(self, mask)?.into_array().optimize()
     }
 
     fn not(&self) -> VortexResult<ArrayRef> {
-        Not.try_new_array(self.len(), EmptyOptions, [self.clone()])?
-            .optimize()
+        Not::try_new(self.clone())?.into_array().optimize()
     }
 
     fn zip(&self, if_true: ArrayRef, if_false: ArrayRef) -> VortexResult<ArrayRef> {
-        Zip.try_new_array(self.len(), EmptyOptions, [if_true, if_false, self.clone()])
+        Ok(Zip::try_new(if_true, if_false, self.clone())?.into_array())
     }
 
     fn interleave(
@@ -238,14 +226,14 @@ impl ArrayBuiltins for ArrayRef {
     }
 
     fn list_contains(&self, value: ArrayRef) -> VortexResult<ArrayRef> {
-        ListContains
-            .try_new_array(self.len(), EmptyOptions, [self.clone(), value])?
+        ListContains::try_new(self.clone(), value)?
+            .into_array()
             .optimize()
     }
 
     fn binary(&self, rhs: ArrayRef, op: Operator) -> VortexResult<ArrayRef> {
-        Binary
-            .try_new_array(self.len(), op, [self.clone(), rhs])?
+        Binary::try_new(self.clone(), rhs, op)?
+            .into_array()
             .optimize()
     }
 
@@ -255,8 +243,8 @@ impl ArrayBuiltins for ArrayRef {
         upper: ArrayRef,
         options: BetweenOptions,
     ) -> VortexResult<ArrayRef> {
-        Between
-            .try_new_array(self.len(), options, [self, lower, upper])?
+        Between::try_new(self, lower, upper, options)?
+            .into_array()
             .optimize()
     }
 }

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -21,6 +21,7 @@ use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::Decimal;
 use crate::arrays::Primitive;
+use crate::arrays::ScalarFnArray;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::DType::Bool;
@@ -32,6 +33,7 @@ use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
 use crate::scalar_fn::fns::operators::Operator;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -183,6 +185,22 @@ fn between_canonical(
 /// separate comparisons combined with a logical AND.
 #[derive(Clone)]
 pub struct Between;
+
+impl Between {
+    /// Creates a lazy between operation over an array and its bounds.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the children have different lengths or incompatible dtypes.
+    pub fn try_new(
+        array: ArrayRef,
+        lower: ArrayRef,
+        upper: ArrayRef,
+        options: BetweenOptions,
+    ) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(Between.bind(options), vec![array, lower, upper])
+    }
+}
 
 impl ScalarFnVTable for Between {
     type Options = BetweenOptions;

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -17,6 +17,7 @@ use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::arrays::ScalarFnArray;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::expr::and;
@@ -28,6 +29,7 @@ use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
 use crate::scalar_fn::SimplifyCtx;
 use crate::scalar_fn::fns::literal::Literal;
 use crate::scalar_fn::fns::operators::CompareOperator;
@@ -50,6 +52,21 @@ use crate::scalar::Scalar;
 
 #[derive(Clone)]
 pub struct Binary;
+
+impl Binary {
+    /// Creates a lazy binary operation over `lhs` and `rhs`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the children have different lengths or incompatible dtypes.
+    pub fn try_new(
+        lhs: ArrayRef,
+        rhs: ArrayRef,
+        operator: Operator,
+    ) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(Binary.bind(operator), vec![lhs, rhs])
+    }
+}
 
 impl ScalarFnVTable for Binary {
     type Options = Operator;

--- a/vortex-array/src/scalar_fn/fns/cast/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/cast/mod.rs
@@ -8,6 +8,7 @@ use std::fmt::Formatter;
 
 pub use kernel::*;
 use prost::Message;
+use vortex_error::VortexExpect as _;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
@@ -30,6 +31,7 @@ use crate::arrays::ListView;
 use crate::arrays::Map;
 use crate::arrays::Null;
 use crate::arrays::Primitive;
+use crate::arrays::ScalarFnArray;
 use crate::arrays::VarBinView;
 use crate::arrays::struct_::compute::cast::struct_cast;
 use crate::builtins::ArrayBuiltins;
@@ -43,11 +45,21 @@ use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ReduceNode;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
 use crate::scalar_fn::fns::literal::Literal;
 
 /// A cast expression that converts values to a target data type.
 #[derive(Clone)]
 pub struct Cast;
+
+impl Cast {
+    /// Creates a lazy cast of `input` to `target_dtype`.
+    #[expect(clippy::new_ret_no_self, reason = "constructs the lazy result array")]
+    pub fn new(input: ArrayRef, target_dtype: DType) -> ScalarFnArray {
+        ScalarFnArray::try_new(Cast.bind(target_dtype), vec![input])
+            .vortex_expect("Cast has one child and an infallible return dtype")
+    }
+}
 
 impl ScalarFnVTable for Cast {
     type Options = DType;

--- a/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
@@ -19,6 +19,7 @@ use crate::ExecutionCtx;
 use crate::arrays::Bool;
 use crate::arrays::Decimal;
 use crate::arrays::Primitive;
+use crate::arrays::ScalarFnArray;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::expr::Expression;
@@ -29,10 +30,22 @@ use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
 
 /// An expression that replaces null values in the input with a fill value.
 #[derive(Clone)]
 pub struct FillNull;
+
+impl FillNull {
+    /// Creates a lazy operation that replaces null input values with `fill_value`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the children have different lengths or incompatible dtypes.
+    pub fn try_new(input: ArrayRef, fill_value: ArrayRef) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(FillNull.bind(EmptyOptions), vec![input, fill_value])
+    }
+}
 
 impl ScalarFnVTable for FillNull {
     type Options = EmptyOptions;

--- a/vortex-array/src/scalar_fn/fns/get_item.rs
+++ b/vortex-array/src/scalar_fn/fns/get_item.rs
@@ -13,6 +13,7 @@ use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::arrays::ScalarFnArray;
 use crate::arrays::StructArray;
 use crate::arrays::struct_::StructArrayExt;
 use crate::builtins::ArrayBuiltins;
@@ -37,6 +38,20 @@ use crate::scalar_fn::fns::pack::Pack;
 
 #[derive(Clone)]
 pub struct GetItem;
+
+impl GetItem {
+    /// Creates a lazy projection of `field_name` from `input`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `input` is not a struct or does not contain `field_name`.
+    pub fn try_new(
+        input: ArrayRef,
+        field_name: impl Into<FieldName>,
+    ) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(GetItem.bind(field_name.into()), vec![input])
+    }
+}
 
 impl ScalarFnVTable for GetItem {
     type Options = FieldName;

--- a/vortex-array/src/scalar_fn/fns/is_not_null.rs
+++ b/vortex-array/src/scalar_fn/fns/is_not_null.rs
@@ -4,6 +4,7 @@
 use std::fmt::Display;
 use std::fmt::Formatter;
 
+use vortex_error::VortexExpect as _;
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
@@ -12,6 +13,7 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
+use crate::arrays::ScalarFnArray;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::expr::display::ExprDisplay;
@@ -21,11 +23,21 @@ use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
 use crate::validity::Validity;
 
 /// Expression that checks for non-null values.
 #[derive(Clone)]
 pub struct IsNotNull;
+
+impl IsNotNull {
+    /// Creates a lazy non-null check over `input`.
+    #[expect(clippy::new_ret_no_self, reason = "constructs the lazy result array")]
+    pub fn new(input: ArrayRef) -> ScalarFnArray {
+        ScalarFnArray::try_new(IsNotNull.bind(EmptyOptions), vec![input])
+            .vortex_expect("IsNotNull has one child and an infallible return dtype")
+    }
+}
 
 impl ScalarFnVTable for IsNotNull {
     type Options = EmptyOptions;

--- a/vortex-array/src/scalar_fn/fns/is_null.rs
+++ b/vortex-array/src/scalar_fn/fns/is_null.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexExpect as _;
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
 use vortex_session::registry::CachedId;
@@ -9,6 +10,7 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
+use crate::arrays::ScalarFnArray;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -18,11 +20,21 @@ use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
 use crate::validity::Validity;
 
 /// Expression that checks for null values.
 #[derive(Clone)]
 pub struct IsNull;
+
+impl IsNull {
+    /// Creates a lazy null check over `input`.
+    #[expect(clippy::new_ret_no_self, reason = "constructs the lazy result array")]
+    pub fn new(input: ArrayRef) -> ScalarFnArray {
+        ScalarFnArray::try_new(IsNull.bind(EmptyOptions), vec![input])
+            .vortex_expect("IsNull has one child and an infallible return dtype")
+    }
+}
 
 impl ScalarFnVTable for IsNull {
     type Options = EmptyOptions;

--- a/vortex-array/src/scalar_fn/fns/like/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/like/mod.rs
@@ -25,6 +25,7 @@ use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
 use crate::arrays::ConstantArray;
+use crate::arrays::ScalarFnArray;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::varbinview::BinaryView;
 use crate::dtype::DType;
@@ -38,6 +39,7 @@ use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
 
 /// Options for SQL LIKE function
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -62,6 +64,21 @@ impl Display for LikeOptions {
 /// Expression that performs SQL LIKE pattern matching.
 #[derive(Clone)]
 pub struct Like;
+
+impl Like {
+    /// Creates a lazy SQL `LIKE` operation over `input` and `pattern`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the children have different lengths or are not UTF-8 arrays.
+    pub fn try_new(
+        input: ArrayRef,
+        pattern: ArrayRef,
+        options: LikeOptions,
+    ) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(Like.bind(options), vec![input, pattern])
+    }
+}
 
 impl ScalarFnVTable for Like {
     type Options = LikeOptions;
@@ -490,7 +507,6 @@ mod tests {
     use crate::arrays::ConstantArray;
     use crate::arrays::VarBinArray;
     use crate::arrays::VarBinViewArray;
-    use crate::arrays::scalar_fn::ScalarFnFactoryExt;
     use crate::assert_arrays_eq;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
@@ -510,8 +526,7 @@ mod tests {
         pattern: crate::ArrayRef,
         options: LikeOptions,
     ) -> crate::ArrayRef {
-        let len = array.len();
-        Like.try_new_array(len, options, [array, pattern]).unwrap()
+        Like::try_new(array, pattern, options).unwrap().into_array()
     }
 
     #[rstest]

--- a/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
@@ -25,10 +25,10 @@ use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrays::ListViewArray;
 use crate::arrays::PrimitiveArray;
+use crate::arrays::ScalarFnArray;
 use crate::arrays::bool::BoolArrayExt;
 use crate::arrays::listview::ListViewArraySlotsExt;
 use crate::arrays::primitive::PrimitiveArrayExt;
-use crate::arrays::scalar_fn::ScalarFnFactoryExt;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
@@ -43,12 +43,24 @@ use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
 use crate::scalar_fn::fns::binary::Binary;
 use crate::scalar_fn::fns::operators::Operator;
 use crate::validity::Validity;
 
 #[derive(Clone)]
 pub struct ListContains;
+
+impl ListContains {
+    /// Creates a lazy list membership check for `needle` in `list`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the children have different lengths or `list` is not a list array.
+    pub fn try_new(list: ArrayRef, needle: ArrayRef) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(ListContains.bind(EmptyOptions), vec![list, needle])
+    }
+}
 
 impl ScalarFnVTable for ListContains {
     type Options = EmptyOptions;
@@ -197,16 +209,13 @@ fn constant_list_scalar_contains(
     let result = elements
         .iter()
         .map(|element| {
-            Binary
-                .try_new_array(
-                    len,
-                    Operator::Eq,
-                    [
-                        ConstantArray::new(element.clone(), len).into_array(),
-                        values.clone(),
-                    ],
-                )?
-                .fill_null(false_scalar.clone())
+            Binary::try_new(
+                ConstantArray::new(element.clone(), len).into_array(),
+                values.clone(),
+                Operator::Eq,
+            )?
+            .into_array()
+            .fill_null(false_scalar.clone())
         })
         .collect::<VortexResult<Vec<_>>>()?
         .into_iter()
@@ -237,11 +246,8 @@ fn list_contains_scalar(
     }
 
     let rhs = ConstantArray::new(value.clone(), elems.len());
-    let matching_elements = Binary.try_new_array(
-        elems.len(),
-        Operator::Eq,
-        &[elems.clone(), rhs.clone().into_array()],
-    )?;
+    let matching_elements =
+        Binary::try_new(elems.clone(), rhs.clone().into_array(), Operator::Eq)?.into_array();
 
     // TODO(ngates): we should execute this into a Columnar and check for constant.
     let matches = matching_elements.execute::<BoolArray>(ctx)?;

--- a/vortex-array/src/scalar_fn/fns/mask/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/mask/kernel.rs
@@ -125,13 +125,11 @@ mod tests {
     use crate::arrays::Primitive;
     use crate::arrays::PrimitiveArray;
     use crate::arrays::ScalarFn;
-    use crate::arrays::scalar_fn::ScalarFnFactoryExt;
     use crate::assert_arrays_eq;
     use crate::dtype::Nullability;
     use crate::executor::VortexSessionExecute;
     use crate::optimizer::ArrayOptimizer;
     use crate::scalar::Scalar;
-    use crate::scalar_fn::EmptyOptions;
     use crate::scalar_fn::fns::mask::Mask as MaskExpr;
 
     /// A constant Boolean mask child must take the metadata-only reduction path (pushing into the
@@ -149,7 +147,7 @@ mod tests {
         )
         .into_array();
 
-        let masked = MaskExpr.try_new_array(input.len(), EmptyOptions, [input, mask])?;
+        let masked = MaskExpr::try_new(input, mask)?.into_array();
         assert!(
             masked.is::<ScalarFn>(),
             "expected an un-optimized ScalarFn wrapper before optimization"

--- a/vortex-array/src/scalar_fn/fns/mask/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/mask/mod.rs
@@ -16,6 +16,7 @@ use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
+use crate::arrays::ScalarFnArray;
 use crate::arrays::masked::mask_validity_canonical;
 use crate::builtins::ArrayBuiltins;
 use crate::child_to_validity;
@@ -31,6 +32,7 @@ use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
 use crate::scalar_fn::SimplifyCtx;
 use crate::scalar_fn::fns::literal::Literal;
 
@@ -40,6 +42,18 @@ use crate::scalar_fn::fns::literal::Literal;
 /// null. In other words, this performs an intersection of the input's validity with the mask.
 #[derive(Clone)]
 pub struct Mask;
+
+impl Mask {
+    /// Creates a lazy mask operation over `input`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the children have different lengths or `mask` is not non-nullable
+    /// boolean data.
+    pub fn try_new(input: ArrayRef, mask: ArrayRef) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(Mask.bind(EmptyOptions), vec![input, mask])
+    }
+}
 
 impl ScalarFnVTable for Mask {
     type Options = EmptyOptions;

--- a/vortex-array/src/scalar_fn/fns/not/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/not/mod.rs
@@ -15,6 +15,7 @@ use crate::IntoArray;
 use crate::arrays::Bool;
 use crate::arrays::BoolArray;
 use crate::arrays::ConstantArray;
+use crate::arrays::ScalarFnArray;
 use crate::arrays::bool::BoolArrayExt;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
@@ -25,10 +26,22 @@ use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
 
 /// Expression that logically inverts boolean values.
 #[derive(Clone)]
 pub struct Not;
+
+impl Not {
+    /// Creates a lazy boolean inversion of `input`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `input` is not boolean data.
+    pub fn try_new(input: ArrayRef) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(Not.bind(EmptyOptions), vec![input])
+    }
+}
 
 impl ScalarFnVTable for Not {
     type Options = EmptyOptions;

--- a/vortex-array/src/scalar_fn/fns/variant_get/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/variant_get/mod.rs
@@ -20,6 +20,7 @@ use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::ChunkedArray;
 use crate::arrays::ConstantArray;
+use crate::arrays::ScalarFnArray;
 use crate::arrays::VariantArray;
 use crate::builders::builder_with_capacity_in;
 use crate::dtype::DType;
@@ -32,6 +33,7 @@ use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
 
 /// Extracts a field/index path from Variant values.
 ///
@@ -41,6 +43,17 @@ use crate::scalar_fn::ScalarFnVTable;
 /// but must fall back to the core Variant value for paths not represented by shredded storage.
 #[derive(Clone)]
 pub struct VariantGet;
+
+impl VariantGet {
+    /// Creates a lazy extraction from Variant `input`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `input` is not Variant data.
+    pub fn try_new(input: ArrayRef, options: VariantGetOptions) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(VariantGet.bind(options), vec![input])
+    }
+}
 
 impl ScalarFnVTable for VariantGet {
     type Options = VariantGetOptions;

--- a/vortex-array/src/scalar_fn/fns/zip/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/zip/mod.rs
@@ -21,6 +21,7 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
+use crate::arrays::ScalarFnArray;
 use crate::arrays::bool::BoolArrayExt;
 use crate::builders::ArrayBuilder;
 use crate::builders::builder_with_capacity;
@@ -35,6 +36,7 @@ use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
 use crate::scalar_fn::SimplifyCtx;
 use crate::scalar_fn::fns::literal::Literal;
 use crate::validity::Validity;
@@ -48,6 +50,22 @@ use crate::validity::Validity;
 /// rather than Arrow's `if_else` which propagates null conditions to the output.
 #[derive(Clone)]
 pub struct Zip;
+
+impl Zip {
+    /// Creates a lazy conditional selection between `if_true` and `if_false`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the children have different lengths, the values have incompatible
+    /// dtypes, or `mask` is not boolean data.
+    pub fn try_new(
+        if_true: ArrayRef,
+        if_false: ArrayRef,
+        mask: ArrayRef,
+    ) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(Zip.bind(EmptyOptions), vec![if_true, if_false, mask])
+    }
+}
 
 impl ScalarFnVTable for Zip {
     type Options = EmptyOptions;

--- a/vortex-array/src/test_harness/trace/tests.rs
+++ b/vortex-array/src/test_harness/trace/tests.rs
@@ -43,7 +43,6 @@ use crate::arrays::PrimitiveArray;
 use crate::arrays::StructArray;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::filter::FilterArraySlotsExt;
-use crate::arrays::scalar_fn::ScalarFnFactoryExt;
 use crate::assert_arrays_eq;
 use crate::buffer::BufferHandle;
 use crate::dtype::DType;
@@ -659,7 +658,7 @@ fn trace_compare_on_dict() -> VortexResult<()> {
     .into_array();
     let rhs = ConstantArray::new(Scalar::from(20i32), dict.len()).into_array();
 
-    let compared = Binary.try_new_array(dict.len(), Operator::Eq, [dict, rhs])?;
+    let compared = Binary::try_new(dict, rhs, Operator::Eq)?.into_array();
 
     let traced = trace_op(|| compared.optimize())?;
     insta::assert_snapshot!(traced.trace.to_string(), @"
@@ -702,14 +701,15 @@ fn trace_like_on_dict() -> VortexResult<()> {
     let strings = dict_of_strings()?;
     let pattern = ConstantArray::new(Scalar::from("b%"), strings.len()).into_array();
 
-    let like = Like.try_new_array(
-        strings.len(),
+    let like = Like::try_new(
+        strings,
+        pattern,
         LikeOptions {
             negated: false,
             case_insensitive: false,
         },
-        [strings, pattern],
-    )?;
+    )?
+    .into_array();
 
     let traced = trace_op(|| like.optimize())?;
     insta::assert_snapshot!(traced.trace.to_string(), @"

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -28,7 +28,6 @@ use crate::VortexSessionExecute;
 use crate::arrays::BoolArray;
 use crate::arrays::ChunkedArray;
 use crate::arrays::ConstantArray;
-use crate::arrays::scalar_fn::ScalarFnFactoryExt;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -322,8 +321,8 @@ impl Validity {
             | (Validity::AllValid, Validity::AllValid) => Validity::AllValid,
             // Here we actually have to do some work
             (Validity::Array(lhs), Validity::Array(rhs)) => Validity::Array(
-                Binary
-                    .try_new_array(lhs.len(), Operator::And, [lhs, rhs])?
+                Binary::try_new(lhs, rhs, Operator::And)?
+                    .into_array()
                     .optimize()?,
             ),
         })

--- a/vortex-arrow/src/executor/byte.rs
+++ b/vortex-arrow/src/executor/byte.rs
@@ -196,10 +196,8 @@ mod tests {
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::VarBinArray;
     use vortex_array::arrays::VarBinViewArray;
-    use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
-    use vortex_array::scalar_fn::EmptyOptions;
     use vortex_array::scalar_fn::fns::mask::Mask as MaskFn;
     use vortex_array::validity::Validity;
     use vortex_buffer::ByteBuffer;
@@ -219,8 +217,7 @@ mod tests {
             DType::Utf8(Nullability::NonNullable),
         );
         let mask = BoolArray::from_iter([true, false, true]);
-        let masked =
-            MaskFn.try_new_array(3, EmptyOptions, [varbin.into_array(), mask.into_array()])?;
+        let masked = MaskFn::try_new(varbin.into_array(), mask.into_array())?.into_array();
 
         let field = Field::new("s", DataType::Utf8, true);
         let arrow = session

--- a/vortex-arrow/src/executor/dictionary.rs
+++ b/vortex-arrow/src/executor/dictionary.rs
@@ -166,11 +166,9 @@ mod tests {
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::VarBinViewArray;
-    use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability::Nullable;
     use vortex_array::scalar::Scalar;
-    use vortex_array::scalar_fn::EmptyOptions;
     use vortex_array::scalar_fn::fns::mask::Mask;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
@@ -253,7 +251,7 @@ mod tests {
             VarBinViewArray::from_iter_str(["a", "b"]).into_array(),
         )?;
         let mask = BoolArray::from_iter([true, false, true]);
-        let masked = Mask.try_new_array(3, EmptyOptions, [dict.into_array(), mask.into_array()])?;
+        let masked = Mask::try_new(dict.into_array(), mask.into_array())?.into_array();
 
         let actual = execute(masked, &dict_type(DataType::UInt8, DataType::Utf8))?;
         let flat = arrow_cast::cast(&actual, &DataType::Utf8)?;

--- a/vortex-arrow/src/executor/list.rs
+++ b/vortex-arrow/src/executor/list.rs
@@ -227,10 +227,8 @@ mod tests {
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::SliceArray;
-    use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability::NonNullable;
-    use vortex_array::scalar_fn::EmptyOptions;
     use vortex_array::scalar_fn::fns::mask::Mask;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
@@ -436,7 +434,7 @@ mod tests {
             Validity::NonNullable,
         )?;
         let mask = BoolArray::from_iter([true, false, true]);
-        let masked = Mask.try_new_array(3, EmptyOptions, [list.into_array(), mask.into_array()])?;
+        let masked = Mask::try_new(list.into_array(), mask.into_array())?.into_array();
 
         let field = Field::new("item", DataType::Int32, false);
         let arrow_dt = DataType::List(field.into());

--- a/vortex-arrow/src/executor/struct_.rs
+++ b/vortex-arrow/src/executor/struct_.rs
@@ -231,9 +231,7 @@ mod tests {
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::StructArray;
-    use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
     use vortex_array::dtype::FieldNames;
-    use vortex_array::scalar_fn::EmptyOptions;
     use vortex_array::scalar_fn::fns::mask::Mask;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
@@ -375,11 +373,7 @@ mod tests {
             Validity::NonNullable,
         )?;
         let mask = BoolArray::from_iter([true, false, true]);
-        let masked = Mask.try_new_array(
-            3,
-            EmptyOptions,
-            [struct_array.into_array(), mask.into_array()],
-        )?;
+        let masked = Mask::try_new(struct_array.into_array(), mask.into_array())?.into_array();
 
         let arrow = masked.execute_arrow(None, &mut ctx)?;
 

--- a/vortex-btrblocks/src/trace_tests.rs
+++ b/vortex-btrblocks/src/trace_tests.rs
@@ -30,7 +30,6 @@ use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::Struct;
 use vortex_array::arrays::StructArray;
 use vortex_array::arrays::patched::use_experimental_patches;
-use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
 use vortex_array::arrays::struct_::StructArrayExt;
 use vortex_array::assert_arrays_eq;
 use vortex_array::dtype::DType;
@@ -175,11 +174,12 @@ fn shipdate_predicate(column: ArrayRef, len: usize) -> VortexResult<ArrayRef> {
         ext,
         Scalar::primitive_value(PValue::I32(8766), PType::I32, Nullability::NonNullable),
     );
-    Binary.try_new_array(
-        len,
+    Binary::try_new(
+        column,
+        ConstantArray::new(cutoff, len).into_array(),
         Operator::Gte,
-        [column, ConstantArray::new(cutoff, len).into_array()],
     )
+    .map(IntoArray::into_array)
 }
 
 #[test]
@@ -226,11 +226,12 @@ fn quantity_predicate(column: ArrayRef, len: usize) -> VortexResult<ArrayRef> {
         DecimalDType::new(15, 2),
         Nullability::NonNullable,
     );
-    Binary.try_new_array(
-        len,
+    Binary::try_new(
+        column,
+        ConstantArray::new(cutoff, len).into_array(),
         Operator::Lt,
-        [column, ConstantArray::new(cutoff, len).into_array()],
     )
+    .map(IntoArray::into_array)
 }
 
 #[test]
@@ -283,14 +284,12 @@ fn trace_scan_compare_on_compressed_quantity() -> VortexResult<()> {
 ///
 /// The column compresses to `dict -> {bitpacked codes, fsst values}`.
 fn shipmode_predicate(column: ArrayRef, len: usize) -> VortexResult<ArrayRef> {
-    Binary.try_new_array(
-        len,
+    Binary::try_new(
+        column,
+        ConstantArray::new(Scalar::from("AIR"), len).into_array(),
         Operator::Eq,
-        [
-            column,
-            ConstantArray::new(Scalar::from("AIR"), len).into_array(),
-        ],
     )
+    .map(IntoArray::into_array)
 }
 
 #[test]
@@ -336,17 +335,15 @@ fn trace_scan_compare_on_compressed_shipmode() -> VortexResult<()> {
 ///
 /// The column compresses to `fsst -> bitpacked lengths/offsets`.
 fn comment_predicate(column: ArrayRef, len: usize) -> VortexResult<ArrayRef> {
-    Like.try_new_array(
-        len,
+    Like::try_new(
+        column,
+        ConstantArray::new(Scalar::from("%special%"), len).into_array(),
         LikeOptions {
             negated: false,
             case_insensitive: false,
         },
-        [
-            column,
-            ConstantArray::new(Scalar::from("%special%"), len).into_array(),
-        ],
     )
+    .map(IntoArray::into_array)
 }
 
 #[test]

--- a/vortex-json/src/json_to_variant.rs
+++ b/vortex-json/src/json_to_variant.rs
@@ -13,7 +13,7 @@ use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::Extension;
 use vortex_array::arrays::ExtensionArray;
-use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
+use vortex_array::arrays::ScalarFnArray;
 use vortex_array::dtype::DType;
 use vortex_array::expr::Expression;
 use vortex_array::scalar_fn::Arity;
@@ -67,6 +67,17 @@ use crate::Json;
 /// [Parquet Variant shredding]: https://github.com/apache/parquet-format/blob/master/VariantShredding.md
 #[derive(Clone)]
 pub struct JsonToVariant;
+
+impl JsonToVariant {
+    /// Creates a lazy conversion from JSON `input` to Variant data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `input` is not a JSON extension array.
+    pub fn try_new(input: ArrayRef, options: JsonToVariantOptions) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(JsonToVariant.bind(options), vec![input])
+    }
+}
 
 impl ScalarFnVTable for JsonToVariant {
     type Options = JsonToVariantOptions;
@@ -179,7 +190,8 @@ impl ScalarFnVTable for JsonToVariant {
             );
         };
 
-        self.try_new_array(canonical.len(), options.clone(), [canonical])?
+        Self::try_new(canonical, options.clone())?
+            .into_array()
             .execute::<ArrayRef>(ctx)
     }
 
@@ -354,9 +366,7 @@ mod tests {
     #[test]
     fn utf8_input_is_rejected() {
         let input = VarBinViewArray::from_iter_str(["1", "2"]).into_array();
-        let err = JsonToVariant
-            .try_new_array(input.len(), JsonToVariantOptions::unshredded(), [input])
-            .unwrap_err();
+        let err = JsonToVariant::try_new(input, JsonToVariantOptions::unshredded()).unwrap_err();
 
         assert!(
             err.to_string().contains("Json extension"),
@@ -376,11 +386,7 @@ mod tests {
         .into_array();
 
         let dtype = input.dtype().clone();
-        let array = JsonToVariant.try_new_array(
-            input.len(),
-            JsonToVariantOptions::unshredded(),
-            [input],
-        )?;
+        let array = JsonToVariant::try_new(input, JsonToVariantOptions::unshredded())?.into_array();
 
         let err = array
             .execute::<ArrayRef>(&mut session().create_execution_ctx())

--- a/vortex-spatial/benches/area.rs
+++ b/vortex-spatial/benches/area.rs
@@ -96,7 +96,7 @@ fn multipolygons() -> ArrayRef {
 }
 
 fn areas(geometry: &ArrayRef, ctx: &mut ExecutionCtx) -> ArrayRef {
-    SpatialArea::try_new_array(geometry.clone())
+    SpatialArea::try_new(geometry.clone())
         .unwrap()
         .into_array()
         .execute::<Canonical>(ctx)

--- a/vortex-spatial/benches/binary_predicates.rs
+++ b/vortex-spatial/benches/binary_predicates.rs
@@ -176,7 +176,7 @@ mod contains {
         let points = points(ROWS);
         bencher.counter(ItemsCount::new(ROWS)).bench_local(|| {
             execute(
-                SpatialContains::try_new_array(polygons.clone(), points.clone()),
+                SpatialContains::try_new(polygons.clone(), points.clone()),
                 &mut ctx,
             )
         });
@@ -188,12 +188,9 @@ mod contains {
         let mut ctx = SESSION.create_execution_ctx();
         let a = squares_mostly_overlapping(ROWS);
         let b = squares_mostly_disjoint(ROWS);
-        bencher.counter(ItemsCount::new(ROWS)).bench_local(|| {
-            execute(
-                SpatialContains::try_new_array(a.clone(), b.clone()),
-                &mut ctx,
-            )
-        });
+        bencher
+            .counter(ItemsCount::new(ROWS))
+            .bench_local(|| execute(SpatialContains::try_new(a.clone(), b.clone()), &mut ctx));
     }
 
     /// Constant container against a point column: the `geo` crate's direct point-in-polygon pairing.
@@ -204,7 +201,7 @@ mod contains {
         let points = points(ROWS);
         bencher.counter(ItemsCount::new(ROWS)).bench_local(|| {
             execute(
-                SpatialContains::try_new_array(query.clone(), points.clone()),
+                SpatialContains::try_new(query.clone(), points.clone()),
                 &mut ctx,
             )
         });
@@ -219,7 +216,7 @@ mod contains {
         let polygons = squares_mostly_disjoint(ROWS);
         bencher.counter(ItemsCount::new(ROWS)).bench_local(|| {
             execute(
-                SpatialContains::try_new_array(query.clone(), polygons.clone()),
+                SpatialContains::try_new(query.clone(), polygons.clone()),
                 &mut ctx,
             )
         });
@@ -233,7 +230,7 @@ mod contains {
         let points = nullable_every(points(ROWS), 8);
         bencher.counter(ItemsCount::new(ROWS)).bench_local(|| {
             execute(
-                SpatialContains::try_new_array(query.clone(), points.clone()),
+                SpatialContains::try_new(query.clone(), points.clone()),
                 &mut ctx,
             )
         });
@@ -247,7 +244,7 @@ mod contains {
         let polygons = nullable_every(squares_mostly_disjoint(ROWS), 8);
         bencher.counter(ItemsCount::new(ROWS)).bench_local(|| {
             execute(
-                SpatialContains::try_new_array(query.clone(), polygons.clone()),
+                SpatialContains::try_new(query.clone(), polygons.clone()),
                 &mut ctx,
             )
         });
@@ -262,7 +259,7 @@ mod contains {
         let point = point_constant(&mut ctx, ROWS);
         bencher.counter(ItemsCount::new(ROWS)).bench_local(|| {
             execute(
-                SpatialContains::try_new_array(polygons.clone(), point.clone()),
+                SpatialContains::try_new(polygons.clone(), point.clone()),
                 &mut ctx,
             )
         });
@@ -276,7 +273,7 @@ mod contains {
         let point = point_constant(&mut ctx, ROWS);
         bencher.counter(ItemsCount::new(ROWS)).bench_local(|| {
             execute(
-                SpatialContains::try_new_array(polygons.clone(), point.clone()),
+                SpatialContains::try_new(polygons.clone(), point.clone()),
                 &mut ctx,
             )
         });
@@ -291,7 +288,7 @@ mod contains {
         let points = half_valid(points(ROWS), 1);
         bencher.counter(ItemsCount::new(ROWS)).bench_local(|| {
             execute(
-                SpatialContains::try_new_array(polygons.clone(), points.clone()),
+                SpatialContains::try_new(polygons.clone(), points.clone()),
                 &mut ctx,
             )
         });
@@ -307,12 +304,9 @@ mod intersects {
         let mut ctx = SESSION.create_execution_ctx();
         let a = squares_mostly_overlapping(ROWS);
         let b = squares_mostly_disjoint(ROWS);
-        bencher.counter(ItemsCount::new(ROWS)).bench_local(|| {
-            execute(
-                SpatialIntersects::try_new_array(a.clone(), b.clone()),
-                &mut ctx,
-            )
-        });
+        bencher
+            .counter(ItemsCount::new(ROWS))
+            .bench_local(|| execute(SpatialIntersects::try_new(a.clone(), b.clone()), &mut ctx));
     }
 
     /// Point column against the constant query: the `geo` crate answers point-x-polygon directly, with no
@@ -324,7 +318,7 @@ mod intersects {
         let query = query_constant(&mut ctx, ROWS);
         bencher.counter(ItemsCount::new(ROWS)).bench_local(|| {
             execute(
-                SpatialIntersects::try_new_array(points.clone(), query.clone()),
+                SpatialIntersects::try_new(points.clone(), query.clone()),
                 &mut ctx,
             )
         });
@@ -339,7 +333,7 @@ mod intersects {
         let query = query_constant(&mut ctx, ROWS);
         bencher.counter(ItemsCount::new(ROWS)).bench_local(|| {
             execute(
-                SpatialIntersects::try_new_array(polygons.clone(), query.clone()),
+                SpatialIntersects::try_new(polygons.clone(), query.clone()),
                 &mut ctx,
             )
         });
@@ -357,7 +351,7 @@ mod intersects {
             .counter(ItemsCount::new(OVERLAPPING_POLYGON_ROWS))
             .bench_local(|| {
                 execute(
-                    SpatialIntersects::try_new_array(polygons.clone(), query.clone()),
+                    SpatialIntersects::try_new(polygons.clone(), query.clone()),
                     &mut ctx,
                 )
             });
@@ -371,7 +365,7 @@ mod intersects {
         let query = query_constant(&mut ctx, ROWS);
         bencher.counter(ItemsCount::new(ROWS)).bench_local(|| {
             execute(
-                SpatialIntersects::try_new_array(points.clone(), query.clone()),
+                SpatialIntersects::try_new(points.clone(), query.clone()),
                 &mut ctx,
             )
         });
@@ -385,7 +379,7 @@ mod intersects {
         let query = query_constant(&mut ctx, ROWS);
         bencher.counter(ItemsCount::new(ROWS)).bench_local(|| {
             execute(
-                SpatialIntersects::try_new_array(polygons.clone(), query.clone()),
+                SpatialIntersects::try_new(polygons.clone(), query.clone()),
                 &mut ctx,
             )
         });

--- a/vortex-spatial/benches/collect.rs
+++ b/vortex-spatial/benches/collect.rs
@@ -115,7 +115,7 @@ fn polygon_lists() -> ArrayRef {
 }
 
 fn collect_list_rows(geometry_lists: &ArrayRef, ctx: &mut ExecutionCtx) -> ArrayRef {
-    SpatialCollect::try_new_array(geometry_lists.clone())
+    SpatialCollect::try_new(geometry_lists.clone())
         .unwrap()
         .into_array()
         .execute::<Canonical>(ctx)
@@ -156,10 +156,8 @@ fn nullable_points(bencher: Bencher) {
 /// whether the output still reports itself zero-copy to a list. `ST_Envelope` reaches that path via
 /// `flatten_row_offsets` and re-gathers the whole payload when the flag is missing.
 fn envelope_of_collect(input: &ArrayRef, ctx: &mut ExecutionCtx) -> ArrayRef {
-    let collected = SpatialCollect::try_new_array(input.clone())
-        .unwrap()
-        .into_array();
-    SpatialEnvelope::try_new_array(collected)
+    let collected = SpatialCollect::try_new(input.clone()).unwrap().into_array();
+    SpatialEnvelope::try_new(collected)
         .unwrap()
         .into_array()
         .execute::<Canonical>(ctx)

--- a/vortex-spatial/benches/convex_hull.rs
+++ b/vortex-spatial/benches/convex_hull.rs
@@ -65,7 +65,7 @@ fn multipoints(rows: usize, points_per_row: usize) -> ArrayRef {
 }
 
 fn hulls(input: &ArrayRef, ctx: &mut ExecutionCtx) -> ArrayRef {
-    SpatialConvexHull::try_new_array(input.clone())
+    SpatialConvexHull::try_new(input.clone())
         .unwrap()
         .into_array()
         .execute::<Canonical>(ctx)

--- a/vortex-spatial/benches/distance.rs
+++ b/vortex-spatial/benches/distance.rs
@@ -105,12 +105,9 @@ fn execute(distance: VortexResult<impl IntoArray>, ctx: &mut ExecutionCtx) -> Ar
 fn bench_distance(bencher: Bencher, lhs: ArrayRef, rhs: ArrayRef) {
     let rows = lhs.len();
     let mut ctx = SESSION.create_execution_ctx();
-    bencher.counter(ItemsCount::new(rows)).bench_local(|| {
-        execute(
-            SpatialDistance::try_new_array(lhs.clone(), rhs.clone()),
-            &mut ctx,
-        )
-    });
+    bencher
+        .counter(ItemsCount::new(rows))
+        .bench_local(|| execute(SpatialDistance::try_new(lhs.clone(), rhs.clone()), &mut ctx));
 }
 
 #[divan::bench]

--- a/vortex-spatial/benches/envelope.rs
+++ b/vortex-spatial/benches/envelope.rs
@@ -64,7 +64,7 @@ fn coin(i: usize) -> bool {
 
 /// Execute the envelope of `column` to completion.
 fn envelope(column: &ArrayRef, ctx: &mut ExecutionCtx) -> ArrayRef {
-    SpatialEnvelope::try_new_array(column.clone())
+    SpatialEnvelope::try_new(column.clone())
         .unwrap()
         .into_array()
         .execute::<Canonical>(ctx)

--- a/vortex-spatial/benches/length.rs
+++ b/vortex-spatial/benches/length.rs
@@ -61,7 +61,7 @@ fn linestrings(vertices: usize) -> ArrayRef {
 }
 
 fn lengths(lines: &ArrayRef, ctx: &mut ExecutionCtx) -> ArrayRef {
-    SpatialLength::try_new_array(lines.clone())
+    SpatialLength::try_new(lines.clone())
         .unwrap()
         .into_array()
         .execute::<Canonical>(ctx)

--- a/vortex-spatial/benches/make_line.rs
+++ b/vortex-spatial/benches/make_line.rs
@@ -83,7 +83,7 @@ fn point_constant(ctx: &mut ExecutionCtx) -> ArrayRef {
 }
 
 fn make_lines(starts: &ArrayRef, ends: &ArrayRef, ctx: &mut ExecutionCtx) -> ArrayRef {
-    SpatialMakeLine::try_new_array(starts.clone(), ends.clone())
+    SpatialMakeLine::try_new(starts.clone(), ends.clone())
         .unwrap()
         .into_array()
         .execute::<Canonical>(ctx)

--- a/vortex-spatial/src/scalar_fn/area.rs
+++ b/vortex-spatial/src/scalar_fn/area.rs
@@ -50,7 +50,7 @@ pub struct SpatialArea;
 
 impl SpatialArea {
     /// A lazy `ScalarFnArray` computing the per-row area of a native geometry operand.
-    pub fn try_new_array(array: ArrayRef) -> VortexResult<ScalarFnArray> {
+    pub fn try_new(array: ArrayRef) -> VortexResult<ScalarFnArray> {
         ScalarFnArray::try_new(
             TypedScalarFnInstance::new(SpatialArea, EmptyOptions).erased(),
             vec![array],
@@ -196,7 +196,7 @@ mod tests {
     ) -> VortexResult<()> {
         let session = vortex_array::array_session();
         let mut ctx = session.create_execution_ctx();
-        let areas = SpatialArea::try_new_array(geometry?)?.into_array();
+        let areas = SpatialArea::try_new(geometry?)?.into_array();
         let expected = PrimitiveArray::from_iter(expected.iter().copied()).into_array();
         assert_arrays_eq!(areas, expected, &mut ctx);
         Ok(())
@@ -216,7 +216,7 @@ mod tests {
             ]]]),
             None,
         ])?;
-        let areas = SpatialArea::try_new_array(multipolygons)?.into_array();
+        let areas = SpatialArea::try_new(multipolygons)?.into_array();
         let expected =
             PrimitiveArray::new(vec![4.0f64, 0.0], Validity::from_iter([true, false])).into_array();
 

--- a/vortex-spatial/src/scalar_fn/collect.rs
+++ b/vortex-spatial/src/scalar_fn/collect.rs
@@ -250,7 +250,7 @@ pub struct SpatialCollect;
 
 impl SpatialCollect {
     /// Create a lazy scalar array that converts each geometry-list row to one multi-geometry row.
-    pub fn try_new_array(geometry_lists: ArrayRef) -> VortexResult<ScalarFnArray> {
+    pub fn try_new(geometry_lists: ArrayRef) -> VortexResult<ScalarFnArray> {
         ScalarFnArray::try_new(
             TypedScalarFnInstance::new(SpatialCollect, EmptyOptions).erased(),
             vec![geometry_lists],
@@ -376,7 +376,7 @@ mod tests {
     /// Assert that `ST_Collect` of `input` equals `expected`.
     fn assert_collects(input: ArrayRef, expected: ArrayRef) -> VortexResult<()> {
         let mut ctx = vortex_array::array_session().create_execution_ctx();
-        let result = SpatialCollect::try_new_array(input)?.into_array();
+        let result = SpatialCollect::try_new(input)?.into_array();
 
         assert_arrays_eq!(result, expected, &mut ctx);
         Ok(())
@@ -427,7 +427,7 @@ mod tests {
             .clone();
         let input = list(points, &[0, 2, 3])?;
 
-        let result = SpatialCollect::try_new_array(input)?
+        let result = SpatialCollect::try_new(input)?
             .into_array()
             .execute::<ExtensionArray>(&mut ctx)?;
         let result_storage = result
@@ -460,7 +460,7 @@ mod tests {
             "a list column reaches collect as an exact list view"
         );
 
-        let storage = SpatialCollect::try_new_array(input)?
+        let storage = SpatialCollect::try_new(input)?
             .into_array()
             .execute::<ExtensionArray>(&mut ctx)?
             .storage_array()
@@ -513,7 +513,7 @@ mod tests {
         let scalar = input.execute_scalar(0, &mut ctx)?;
         let input = ConstantArray::new(scalar, 3).into_array();
 
-        let result = SpatialCollect::try_new_array(input)?.into_array();
+        let result = SpatialCollect::try_new(input)?.into_array();
         let Columnar::Constant(constant) = result.clone().execute::<Columnar>(&mut ctx)? else {
             return Err(vortex_err!(
                 "collect of a constant list should remain constant"
@@ -565,10 +565,10 @@ mod tests {
     #[test]
     fn rejects_unsupported_inputs() -> VortexResult<()> {
         let point = point_column(vec![0.0], vec![0.0])?;
-        assert!(SpatialCollect::try_new_array(point).is_err());
+        assert!(SpatialCollect::try_new(point).is_err());
 
         let multipoints = multipoint_column(vec![vec![(0.0, 0.0)]])?;
-        assert!(SpatialCollect::try_new_array(list(multipoints, &[0, 1])?).is_err());
+        assert!(SpatialCollect::try_new(list(multipoints, &[0, 1])?).is_err());
 
         let primitive = DType::Primitive(PType::F64, Nullability::NonNullable);
         assert!(

--- a/vortex-spatial/src/scalar_fn/contains.rs
+++ b/vortex-spatial/src/scalar_fn/contains.rs
@@ -51,7 +51,7 @@ pub struct SpatialContains;
 impl SpatialContains {
     /// A lazy `ScalarFnArray` computing per-row whether operand `a` contains operand `b`;
     /// either may be constant. The output length is taken from `a`.
-    pub fn try_new_array(a: ArrayRef, b: ArrayRef) -> VortexResult<ScalarFnArray> {
+    pub fn try_new(a: ArrayRef, b: ArrayRef) -> VortexResult<ScalarFnArray> {
         ScalarFnArray::try_new(
             TypedScalarFnInstance::new(SpatialContains, EmptyOptions).erased(),
             vec![a, b],
@@ -196,7 +196,7 @@ mod tests {
     ) -> VortexResult<()> {
         let session = vortex_array::array_session();
         let mut ctx = session.create_execution_ctx();
-        let contains = SpatialContains::try_new_array(a, b)?.into_array();
+        let contains = SpatialContains::try_new(a, b)?.into_array();
         assert_arrays_eq!(contains, BoolArray::from_iter(expected), &mut ctx);
         Ok(())
     }
@@ -318,7 +318,7 @@ mod tests {
 
         let container = geometry_constant(&Geometry::Polygon(rect_polygon(0.0, 0.0, 4.0, 4.0)), 3)?;
         let points = nullable_point_column(vec![Some((2.0, 2.0)), None, Some((10.0, 10.0))])?;
-        let contains = SpatialContains::try_new_array(container, points)?.into_array();
+        let contains = SpatialContains::try_new(container, points)?.into_array();
 
         let expected = BoolArray::new(
             BitBuffer::from_iter([true, false, false]),
@@ -338,7 +338,7 @@ mod tests {
         let point_dtype = point_column(vec![0.0], vec![0.0])?.dtype().as_nullable();
         let null_const = ConstantArray::new(Scalar::null(point_dtype), 2).into_array();
         let points = point_column(vec![2.0, 10.0], vec![2.0, 10.0])?;
-        let contains = SpatialContains::try_new_array(null_const, points)?.into_array();
+        let contains = SpatialContains::try_new(null_const, points)?.into_array();
 
         let expected =
             BoolArray::new(BitBuffer::from_iter([false, false]), Validity::AllInvalid).into_array();
@@ -366,7 +366,7 @@ mod tests {
             None,
             Some((4.0, 4.0)),
         ])?;
-        let contains = SpatialContains::try_new_array(container, contained)?.into_array();
+        let contains = SpatialContains::try_new(container, contained)?.into_array();
 
         let expected = BoolArray::new(
             BitBuffer::from_iter([true, false, false, false]),
@@ -385,7 +385,7 @@ mod tests {
 
         let container = geometry_constant(&Geometry::Polygon(rect_polygon(0.0, 0.0, 4.0, 4.0)), 2)?;
         let points = nullable_point_column(vec![None, None])?;
-        let contains = SpatialContains::try_new_array(container, points)?.into_array();
+        let contains = SpatialContains::try_new(container, points)?.into_array();
 
         let expected =
             BoolArray::new(BitBuffer::from_iter([false, false]), Validity::AllInvalid).into_array();
@@ -402,7 +402,7 @@ mod tests {
 
         let container = nullable_point_column(vec![Some((1.0, 1.0)), None])?;
         let contained = nullable_point_column(vec![None, Some((2.0, 2.0))])?;
-        let contains = SpatialContains::try_new_array(container, contained)?.into_array();
+        let contains = SpatialContains::try_new(container, contained)?.into_array();
 
         let expected =
             BoolArray::new(BitBuffer::from_iter([false, false]), Validity::AllInvalid).into_array();

--- a/vortex-spatial/src/scalar_fn/convex_hull.rs
+++ b/vortex-spatial/src/scalar_fn/convex_hull.rs
@@ -127,7 +127,7 @@ pub struct SpatialConvexHull;
 
 impl SpatialConvexHull {
     /// A lazy `ScalarFnArray` computing a polygon hull for each native `MultiPoint` row.
-    pub fn try_new_array(array: ArrayRef) -> VortexResult<ScalarFnArray> {
+    pub fn try_new(array: ArrayRef) -> VortexResult<ScalarFnArray> {
         ScalarFnArray::try_new(
             TypedScalarFnInstance::new(SpatialConvexHull, EmptyOptions).erased(),
             vec![array],
@@ -240,7 +240,7 @@ mod tests {
             (0.0, 0.0),
             (2.0, 0.0),
         ]]])?;
-        let result = SpatialConvexHull::try_new_array(input)?.into_array();
+        let result = SpatialConvexHull::try_new(input)?.into_array();
         let mut ctx = vortex_array::array_session().create_execution_ctx();
 
         assert_arrays_eq!(result, expected, &mut ctx);
@@ -263,7 +263,7 @@ mod tests {
     ) -> VortexResult<()> {
         let input = multipoint_column(vec![points])?;
         let expected = polygon_column(vec![expected_rings])?;
-        let result = SpatialConvexHull::try_new_array(input)?.into_array();
+        let result = SpatialConvexHull::try_new(input)?.into_array();
         let mut ctx = vortex_array::array_session().create_execution_ctx();
 
         assert_arrays_eq!(result, expected, &mut ctx);
@@ -288,7 +288,7 @@ mod tests {
             Validity::from_iter([true, false]),
         )?
         .into_array();
-        let result = SpatialConvexHull::try_new_array(input)?.into_array();
+        let result = SpatialConvexHull::try_new(input)?.into_array();
         let mut ctx = vortex_array::array_session().create_execution_ctx();
 
         assert_arrays_eq!(result, expected, &mut ctx);
@@ -302,7 +302,7 @@ mod tests {
             .execute_scalar(0, &mut ctx)?;
         let input = ConstantArray::new(scalar, 3).into_array();
 
-        let result = SpatialConvexHull::try_new_array(input)?.into_array();
+        let result = SpatialConvexHull::try_new(input)?.into_array();
         let Columnar::Constant(constant) = result.clone().execute::<Columnar>(&mut ctx)? else {
             return Err(vortex_err!(
                 "convex_hull of a constant should remain constant"
@@ -328,9 +328,9 @@ mod tests {
         )?
         .into_array();
 
-        let collected = SpatialCollect::try_new_array(point_lists)?.into_array();
-        let hulls = SpatialConvexHull::try_new_array(collected)?.into_array();
-        let areas = SpatialArea::try_new_array(hulls)?.into_array();
+        let collected = SpatialCollect::try_new(point_lists)?.into_array();
+        let hulls = SpatialConvexHull::try_new(collected)?.into_array();
+        let areas = SpatialArea::try_new(hulls)?.into_array();
         let expected = PrimitiveArray::from_iter([4.0_f64, 0.0]).into_array();
         let mut ctx = vortex_array::array_session().create_execution_ctx();
 
@@ -354,7 +354,7 @@ mod tests {
     #[test]
     fn rejects_non_multipoint_input() -> VortexResult<()> {
         let input: ArrayRef = point_column(vec![0.0], vec![0.0])?;
-        assert!(SpatialConvexHull::try_new_array(input).is_err());
+        assert!(SpatialConvexHull::try_new(input).is_err());
         Ok(())
     }
 }

--- a/vortex-spatial/src/scalar_fn/distance.rs
+++ b/vortex-spatial/src/scalar_fn/distance.rs
@@ -52,7 +52,7 @@ pub struct SpatialDistance;
 impl SpatialDistance {
     /// A lazy `ScalarFnArray` computing the per-row distance between operands `a` and `b`; either may
     /// be constant. The output length is taken from `a`.
-    pub fn try_new_array(a: ArrayRef, b: ArrayRef) -> VortexResult<ScalarFnArray> {
+    pub fn try_new(a: ArrayRef, b: ArrayRef) -> VortexResult<ScalarFnArray> {
         ScalarFnArray::try_new(
             TypedScalarFnInstance::new(SpatialDistance, EmptyOptions).erased(),
             vec![a, b],
@@ -176,7 +176,7 @@ mod tests {
 
         let a = point_column(vec![0.0, 3.0, 0.0, 3.0], vec![0.0, 0.0, 4.0, 4.0])?;
         let b = point_constant(0.0, 0.0, 4, &mut ctx)?;
-        let distance = SpatialDistance::try_new_array(a, b)?.into_array();
+        let distance = SpatialDistance::try_new(a, b)?.into_array();
 
         assert_eq!(distances(distance, &mut ctx)?, vec![0.0, 3.0, 4.0, 5.0]);
         Ok(())
@@ -190,7 +190,7 @@ mod tests {
 
         let a = point_column(vec![0.0, 1.0], vec![0.0, 1.0])?;
         let b = point_column(vec![3.0, 1.0], vec![4.0, 1.0])?;
-        let distance = SpatialDistance::try_new_array(a, b)?.into_array();
+        let distance = SpatialDistance::try_new(a, b)?.into_array();
 
         assert_eq!(distances(distance, &mut ctx)?, vec![5.0, 0.0]);
         Ok(())
@@ -207,7 +207,7 @@ mod tests {
         let single = polygon_column(vec![vec![ring]])?.execute_scalar(0, &mut ctx)?;
         let square = ConstantArray::new(single, 2).into_array();
         let points = point_column(vec![7.0, 2.0], vec![2.0, 2.0])?;
-        let distance = SpatialDistance::try_new_array(points, square)?.into_array();
+        let distance = SpatialDistance::try_new(points, square)?.into_array();
 
         assert_eq!(distances(distance, &mut ctx)?, vec![3.0, 0.0]);
         Ok(())
@@ -221,7 +221,7 @@ mod tests {
 
         let a = point_constant(0.0, 0.0, 4, &mut ctx)?;
         let b = point_column(vec![0.0, 3.0, 0.0, 3.0], vec![0.0, 0.0, 4.0, 4.0])?;
-        let distance = SpatialDistance::try_new_array(a, b)?.into_array();
+        let distance = SpatialDistance::try_new(a, b)?.into_array();
 
         assert_eq!(distances(distance, &mut ctx)?, vec![0.0, 3.0, 4.0, 5.0]);
         Ok(())
@@ -235,7 +235,7 @@ mod tests {
 
         let a = point_constant(0.0, 0.0, 3, &mut ctx)?;
         let b = point_constant(3.0, 4.0, 3, &mut ctx)?;
-        let distance = SpatialDistance::try_new_array(a, b)?.into_array();
+        let distance = SpatialDistance::try_new(a, b)?.into_array();
 
         assert_eq!(distances(distance, &mut ctx)?, vec![5.0, 5.0, 5.0]);
         Ok(())
@@ -263,7 +263,7 @@ mod tests {
 
         let a = nullable_point_column(vec![Some((0.0, 0.0)), None, Some((3.0, 4.0))])?;
         let b = point_constant(0.0, 0.0, 3, &mut ctx)?;
-        let distance = SpatialDistance::try_new_array(a, b)?.into_array();
+        let distance = SpatialDistance::try_new(a, b)?.into_array();
 
         let expected = PrimitiveArray::new(
             vec![0.0f64, 0.0, 5.0],
@@ -282,7 +282,7 @@ mod tests {
 
         let a = nullable_point_column(vec![Some((0.0, 0.0)), None, Some((0.0, 0.0))])?;
         let b = nullable_point_column(vec![Some((3.0, 4.0)), Some((1.0, 1.0)), None])?;
-        let distance = SpatialDistance::try_new_array(a, b)?.into_array();
+        let distance = SpatialDistance::try_new(a, b)?.into_array();
 
         let expected = PrimitiveArray::new(
             vec![5.0f64, 0.0, 0.0],
@@ -302,7 +302,7 @@ mod tests {
         let point_dtype = point_column(vec![0.0], vec![0.0])?.dtype().as_nullable();
         let null_const = ConstantArray::new(Scalar::null(point_dtype), 3).into_array();
         let b = point_column(vec![0.0, 3.0, 0.0], vec![0.0, 0.0, 4.0])?;
-        let distance = SpatialDistance::try_new_array(null_const, b)?.into_array();
+        let distance = SpatialDistance::try_new(null_const, b)?.into_array();
 
         let expected = PrimitiveArray::new(vec![0.0f64; 3], Validity::AllInvalid).into_array();
         assert_arrays_eq!(distance, expected, &mut ctx);
@@ -317,7 +317,7 @@ mod tests {
 
         let a = nullable_point_column(vec![None, None])?;
         let b = point_constant(0.0, 0.0, 2, &mut ctx)?;
-        let distance = SpatialDistance::try_new_array(a, b)?.into_array();
+        let distance = SpatialDistance::try_new(a, b)?.into_array();
 
         let expected = PrimitiveArray::new(vec![0.0f64; 2], Validity::AllInvalid).into_array();
         assert_arrays_eq!(distance, expected, &mut ctx);
@@ -333,7 +333,7 @@ mod tests {
 
         let a = nullable_point_column(vec![Some((0.0, 0.0)), None])?;
         let b = nullable_point_column(vec![None, Some((1.0, 1.0))])?;
-        let distance = SpatialDistance::try_new_array(a, b)?.into_array();
+        let distance = SpatialDistance::try_new(a, b)?.into_array();
 
         let expected = PrimitiveArray::new(vec![0.0f64; 2], Validity::AllInvalid).into_array();
         assert_arrays_eq!(distance, expected, &mut ctx);
@@ -350,7 +350,7 @@ mod tests {
 
         let a = point_column(vec![], vec![])?;
         let b = point_column(vec![], vec![])?;
-        let result = SpatialDistance::try_new_array(a, b)?
+        let result = SpatialDistance::try_new(a, b)?
             .into_array()
             .execute::<Canonical>(&mut ctx)?
             .into_array();

--- a/vortex-spatial/src/scalar_fn/envelope.rs
+++ b/vortex-spatial/src/scalar_fn/envelope.rs
@@ -77,7 +77,7 @@ pub struct SpatialEnvelope;
 impl SpatialEnvelope {
     /// A lazy `ScalarFnArray` computing the per-row bounding box of geometry operand `a`, which may
     /// be constant. The output length is taken from `a`.
-    pub fn try_new_array(a: ArrayRef) -> VortexResult<ScalarFnArray> {
+    pub fn try_new(a: ArrayRef) -> VortexResult<ScalarFnArray> {
         ScalarFnArray::try_new(
             TypedScalarFnInstance::new(SpatialEnvelope, EmptyOptions).erased(),
             vec![a],
@@ -310,7 +310,7 @@ mod tests {
 
     /// Execute a `SpatialEnvelope` over `array`, returning the lazy box column.
     fn boxes(array: ArrayRef) -> VortexResult<ArrayRef> {
-        Ok(SpatialEnvelope::try_new_array(array)?.into_array())
+        Ok(SpatialEnvelope::try_new(array)?.into_array())
     }
 
     /// A point's box is degenerate: both corners are the point itself.

--- a/vortex-spatial/src/scalar_fn/intersects.rs
+++ b/vortex-spatial/src/scalar_fn/intersects.rs
@@ -50,7 +50,7 @@ pub struct SpatialIntersects;
 impl SpatialIntersects {
     /// A lazy `ScalarFnArray` computing per-row whether operands `a` and `b` intersect; either may
     /// be constant. The output length is taken from `a`.
-    pub fn try_new_array(a: ArrayRef, b: ArrayRef) -> VortexResult<ScalarFnArray> {
+    pub fn try_new(a: ArrayRef, b: ArrayRef) -> VortexResult<ScalarFnArray> {
         ScalarFnArray::try_new(
             TypedScalarFnInstance::new(SpatialIntersects, EmptyOptions).erased(),
             vec![a, b],
@@ -216,7 +216,7 @@ mod tests {
     ) -> VortexResult<()> {
         let session = vortex_array::array_session();
         let mut ctx = session.create_execution_ctx();
-        let intersects = SpatialIntersects::try_new_array(a, b)?.into_array();
+        let intersects = SpatialIntersects::try_new(a, b)?.into_array();
         assert_arrays_eq!(intersects, BoolArray::from_iter(expected), &mut ctx);
         Ok(())
     }
@@ -302,9 +302,8 @@ mod tests {
         let constant = geometry_constant(&donut(), 4)?;
         let column = materialize(constant.clone(), &mut ctx)?;
 
-        let against_constant =
-            SpatialIntersects::try_new_array(donut_probes()?, constant)?.into_array();
-        let pairwise = SpatialIntersects::try_new_array(donut_probes()?, column)?.into_array();
+        let against_constant = SpatialIntersects::try_new(donut_probes()?, constant)?.into_array();
+        let pairwise = SpatialIntersects::try_new(donut_probes()?, column)?.into_array();
 
         assert_arrays_eq!(against_constant, pairwise, &mut ctx);
         Ok(())
@@ -341,7 +340,7 @@ mod tests {
 
         let points = nullable_point_column(vec![Some((2.0, 2.0)), None, Some((20.0, 20.0))])?;
         let query = geometry_constant(&donut(), 3)?;
-        let intersects = SpatialIntersects::try_new_array(points, query)?.into_array();
+        let intersects = SpatialIntersects::try_new(points, query)?.into_array();
 
         let expected = BoolArray::new(
             BitBuffer::from_iter([true, false, false]),
@@ -361,7 +360,7 @@ mod tests {
         let point_dtype = point_column(vec![0.0], vec![0.0])?.dtype().as_nullable();
         let null_const = ConstantArray::new(Scalar::null(point_dtype), 2).into_array();
         let points = point_column(vec![2.0, 20.0], vec![2.0, 20.0])?;
-        let intersects = SpatialIntersects::try_new_array(null_const, points)?.into_array();
+        let intersects = SpatialIntersects::try_new(null_const, points)?.into_array();
 
         let expected =
             BoolArray::new(BitBuffer::from_iter([false, false]), Validity::AllInvalid).into_array();
@@ -388,7 +387,7 @@ mod tests {
             None,
             Some((9.0, 9.0)),
         ])?;
-        let intersects = SpatialIntersects::try_new_array(a, b)?.into_array();
+        let intersects = SpatialIntersects::try_new(a, b)?.into_array();
 
         let expected = BoolArray::new(
             BitBuffer::from_iter([true, false, false, false]),
@@ -407,7 +406,7 @@ mod tests {
 
         let points = nullable_point_column(vec![None, None])?;
         let query = geometry_constant(&donut(), 2)?;
-        let intersects = SpatialIntersects::try_new_array(points, query)?.into_array();
+        let intersects = SpatialIntersects::try_new(points, query)?.into_array();
 
         let expected =
             BoolArray::new(BitBuffer::from_iter([false, false]), Validity::AllInvalid).into_array();
@@ -424,7 +423,7 @@ mod tests {
 
         let a = nullable_point_column(vec![Some((0.0, 0.0)), None])?;
         let b = nullable_point_column(vec![None, Some((1.0, 1.0))])?;
-        let intersects = SpatialIntersects::try_new_array(a, b)?.into_array();
+        let intersects = SpatialIntersects::try_new(a, b)?.into_array();
 
         let expected =
             BoolArray::new(BitBuffer::from_iter([false, false]), Validity::AllInvalid).into_array();

--- a/vortex-spatial/src/scalar_fn/length.rs
+++ b/vortex-spatial/src/scalar_fn/length.rs
@@ -99,7 +99,7 @@ pub struct SpatialLength;
 
 impl SpatialLength {
     /// A lazy `ScalarFnArray` computing the per-row length of a line string operand.
-    pub fn try_new_array(array: ArrayRef) -> VortexResult<ScalarFnArray> {
+    pub fn try_new(array: ArrayRef) -> VortexResult<ScalarFnArray> {
         ScalarFnArray::try_new(
             TypedScalarFnInstance::new(SpatialLength, EmptyOptions).erased(),
             vec![array],
@@ -216,7 +216,7 @@ mod tests {
             vec![],
         ])?;
 
-        let lengths = SpatialLength::try_new_array(lines)?.into_array();
+        let lengths = SpatialLength::try_new(lines)?.into_array();
         let expected = PrimitiveArray::from_iter([5.0f64, 9.0, 0.0, 0.0]).into_array();
 
         assert_arrays_eq!(lengths, expected, &mut ctx);
@@ -229,7 +229,7 @@ mod tests {
         let mut ctx = session.create_execution_ctx();
         let lines = line_constant(vec![(0.0, 0.0), (3.0, 4.0), (3.0, 8.0)], 3, &mut ctx)?;
 
-        let result = SpatialLength::try_new_array(lines)?
+        let result = SpatialLength::try_new(lines)?
             .into_array()
             .execute::<Columnar>(&mut ctx)?;
         let Columnar::Constant(lengths) = result else {
@@ -247,7 +247,7 @@ mod tests {
         let dtype = linestring_column(vec![vec![]])?.dtype().as_nullable();
         let lines = ConstantArray::new(Scalar::null(dtype), 2).into_array();
 
-        let result = SpatialLength::try_new_array(lines)?
+        let result = SpatialLength::try_new(lines)?
             .into_array()
             .execute::<Columnar>(&mut ctx)?;
         let Columnar::Constant(lengths) = result else {
@@ -279,7 +279,7 @@ mod tests {
             Validity::from_iter([true, false, true]),
         )
         .into_array();
-        let lengths = SpatialLength::try_new_array(lines)?.into_array();
+        let lengths = SpatialLength::try_new(lines)?.into_array();
         assert_arrays_eq!(lengths, expected, &mut ctx);
         Ok(())
     }
@@ -299,7 +299,7 @@ mod tests {
         let expected =
             PrimitiveArray::new(vec![0.0, 0.0], Validity::from_iter([false, false])).into_array();
 
-        let lengths = SpatialLength::try_new_array(lines)?.into_array();
+        let lengths = SpatialLength::try_new(lines)?.into_array();
 
         assert_arrays_eq!(lengths, expected, &mut ctx);
         Ok(())

--- a/vortex-spatial/src/scalar_fn/make_line.rs
+++ b/vortex-spatial/src/scalar_fn/make_line.rs
@@ -165,7 +165,7 @@ pub struct SpatialMakeLine;
 
 impl SpatialMakeLine {
     /// A lazy `ScalarFnArray` constructing one two-vertex line string per pair of point operands.
-    pub fn try_new_array(a: ArrayRef, b: ArrayRef) -> VortexResult<ScalarFnArray> {
+    pub fn try_new(a: ArrayRef, b: ArrayRef) -> VortexResult<ScalarFnArray> {
         ScalarFnArray::try_new(
             TypedScalarFnInstance::new(SpatialMakeLine, EmptyOptions).erased(),
             vec![a, b],
@@ -316,7 +316,7 @@ mod tests {
         let starts = point_column(vec![0.0, 3.0], vec![0.0, 4.0])?;
         let ends = point_column(vec![3.0, 0.0], vec![4.0, 0.0])?;
 
-        let lines = SpatialMakeLine::try_new_array(starts, ends)?.into_array();
+        let lines = SpatialMakeLine::try_new(starts, ends)?.into_array();
         assert!(lines.dtype().as_extension().is::<LineString>());
         assert_eq!(
             geometries(&lines, &mut ctx)?,
@@ -341,7 +341,7 @@ mod tests {
         let starts = point_constant(0.0, 0.0, 3, &mut ctx)?;
         let ends = point_constant(3.0, 4.0, 3, &mut ctx)?;
 
-        let result = SpatialMakeLine::try_new_array(starts, ends)?
+        let result = SpatialMakeLine::try_new(starts, ends)?
             .into_array()
             .execute::<Columnar>(&mut ctx)?;
         let Columnar::Constant(lines) = result else {
@@ -377,7 +377,7 @@ mod tests {
             (column, constant)
         };
 
-        let lines = SpatialMakeLine::try_new_array(starts, ends)?.into_array();
+        let lines = SpatialMakeLine::try_new(starts, ends)?.into_array();
         let endpoints = [(3.0, 4.0), (6.0, 8.0)];
         let expected = endpoints
             .into_iter()
@@ -403,7 +403,7 @@ mod tests {
         let starts = ConstantArray::new(Scalar::null(point_dtype), 2).into_array();
         let ends = point_column(vec![3.0, 6.0], vec![4.0, 8.0])?;
 
-        let result = SpatialMakeLine::try_new_array(starts, ends)?
+        let result = SpatialMakeLine::try_new(starts, ends)?
             .into_array()
             .execute::<Columnar>(&mut ctx)?;
         let Columnar::Constant(lines) = result else {
@@ -470,7 +470,7 @@ mod tests {
         let start = dimensional_point(start_dimension, start, None)?;
         let end = dimensional_point(end_dimension, end, None)?;
 
-        let lines = SpatialMakeLine::try_new_array(start, end)?.into_array();
+        let lines = SpatialMakeLine::try_new(start, end)?.into_array();
         let vertices = flatten_coordinates(&lines, &mut ctx)?;
         assert_eq!(coordinate_dimension(vertices.dtype())?, expected_dimension);
         for (name, expected) in [("x", expected_x), ("y", expected_y)] {

--- a/vortex-spatial/src/tests/rect.rs
+++ b/vortex-spatial/src/tests/rect.rs
@@ -130,17 +130,17 @@ fn scalar_functions_run_on_rect() -> VortexResult<()> {
     let points = point_column(vec![5.0, 20.0], vec![5.0, 20.0])?;
 
     // Distance: 0 to the interior point, >0 to the exterior point.
-    let distance = SpatialDistance::try_new_array(bbox.clone(), points.clone())?.into_array();
+    let distance = SpatialDistance::try_new(bbox.clone(), points.clone())?.into_array();
     let distance = distance.execute::<Canonical>(&mut ctx)?.into_primitive();
     let distances = distance.as_slice::<f64>();
     assert_eq!(distances[0], 0.0);
     assert!(distances[1] > 0.0);
 
     // Intersects / Contains: true for the interior point, false for the exterior one.
-    let intersects = SpatialIntersects::try_new_array(bbox.clone(), points.clone())?.into_array();
+    let intersects = SpatialIntersects::try_new(bbox.clone(), points.clone())?.into_array();
     assert_arrays_eq!(intersects, BoolArray::from_iter([true, false]), &mut ctx);
 
-    let contains = SpatialContains::try_new_array(bbox, points)?.into_array();
+    let contains = SpatialContains::try_new(bbox, points)?.into_array();
     assert_arrays_eq!(contains, BoolArray::from_iter([true, false]), &mut ctx);
     Ok(())
 }

--- a/vortex-tensor/benches/cosine_similarity.rs
+++ b/vortex-tensor/benches/cosine_similarity.rs
@@ -85,7 +85,7 @@ fn bench_cosine(bencher: Bencher, lhs: ArrayRef, rhs: ArrayRef) {
     bencher
         .with_inputs(|| {
             (
-                CosineSimilarity::try_new_array(lhs.clone(), rhs.clone())
+                CosineSimilarity::try_new(lhs.clone(), rhs.clone())
                     .unwrap()
                     .into_array(),
                 session.create_execution_ctx(),

--- a/vortex-tensor/benches/inner_product.rs
+++ b/vortex-tensor/benches/inner_product.rs
@@ -62,7 +62,7 @@ fn bench_inner_product(bencher: Bencher, lhs: ArrayRef, rhs: ArrayRef) {
         .counter(ItemsCount::new(lhs.len()))
         .with_inputs(|| {
             (
-                InnerProduct::try_new_array(lhs.clone(), rhs.clone())
+                InnerProduct::try_new(lhs.clone(), rhs.clone())
                     .unwrap()
                     .into_array(),
                 session.create_execution_ctx(),

--- a/vortex-tensor/benches/l2_norm.rs
+++ b/vortex-tensor/benches/l2_norm.rs
@@ -60,7 +60,7 @@ fn bench_l2_norm(bencher: Bencher, input: ArrayRef) {
         .counter(ItemsCount::new(input.len()))
         .with_inputs(|| {
             (
-                L2Norm::try_new_array(input.clone()).unwrap().into_array(),
+                L2Norm::try_new(input.clone()).unwrap().into_array(),
                 session.create_execution_ctx(),
             )
         })

--- a/vortex-tensor/src/encodings/normalized/compress.rs
+++ b/vortex-tensor/src/encodings/normalized/compress.rs
@@ -16,14 +16,12 @@ use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
-use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
 use vortex_array::match_each_float_ptype;
 use vortex_array::scalar::Scalar;
-use vortex_array::scalar_fn::EmptyOptions;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
@@ -139,9 +137,7 @@ pub fn normalize(input: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Normal
         return Ok(wrapped);
     }
 
-    let norms_array: ArrayRef = L2Norm
-        .try_new_array(row_count, EmptyOptions, [input.clone()])?
-        .execute(ctx)?;
+    let norms_array: ArrayRef = L2Norm::try_new(input.clone())?.into_array().execute(ctx)?;
 
     // Execute before reading validity. Reading validity from the lazy array would run `L2Norm`
     // again when the values are requested.

--- a/vortex-tensor/src/scalar_fns/cosine_similarity.rs
+++ b/vortex-tensor/src/scalar_fns/cosine_similarity.rs
@@ -23,7 +23,7 @@ use vortex_array::scalar_fn::EmptyOptions;
 use vortex_array::scalar_fn::ExecutionArgs;
 use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
-use vortex_array::scalar_fn::TypedScalarFnInstance;
+use vortex_array::scalar_fn::ScalarFnVTableExt;
 use vortex_array::serde::ArrayChildren;
 use vortex_buffer::Buffer;
 use vortex_error::VortexResult;
@@ -59,11 +59,6 @@ use crate::utils::validate_binary_tensor_float_inputs;
 pub struct CosineSimilarity;
 
 impl CosineSimilarity {
-    /// Creates a new [`TypedScalarFnInstance`] wrapping the cosine similarity operation.
-    pub fn new() -> TypedScalarFnInstance<CosineSimilarity> {
-        TypedScalarFnInstance::new(CosineSimilarity, EmptyOptions)
-    }
-
     /// Constructs a [`ScalarFnArray`] that lazily computes the cosine similarity between `lhs` and
     /// `rhs`.
     ///
@@ -71,8 +66,8 @@ impl CosineSimilarity {
     ///
     /// Returns an error if the [`ScalarFnArray`] cannot be constructed (e.g. due to dtype
     /// mismatches).
-    pub fn try_new_array(lhs: ArrayRef, rhs: ArrayRef) -> VortexResult<ScalarFnArray> {
-        ScalarFnArray::try_new(CosineSimilarity::new().erased(), vec![lhs, rhs])
+    pub fn try_new(lhs: ArrayRef, rhs: ArrayRef) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(CosineSimilarity.bind(EmptyOptions), vec![lhs, rhs])
     }
 }
 
@@ -142,9 +137,9 @@ impl ScalarFnVTable for CosineSimilarity {
         let validity = lhs_ref.validity()?.and(rhs_ref.validity()?)?;
 
         // Compute inner product and norms as columnar operations, and propagate the options.
-        let norm_lhs_arr = L2Norm::try_new_array(lhs_ref.clone())?;
-        let norm_rhs_arr = L2Norm::try_new_array(rhs_ref.clone())?;
-        let dot_arr = InnerProduct::try_new_array(lhs_ref, rhs_ref)?;
+        let norm_lhs_arr = L2Norm::try_new(lhs_ref.clone())?;
+        let norm_rhs_arr = L2Norm::try_new(rhs_ref.clone())?;
+        let dot_arr = InnerProduct::try_new(lhs_ref, rhs_ref)?;
 
         // Execute to get the inner product and norms of the arrays. We only fully decompress
         // because we need to perform special logic (guard against 0) during division.
@@ -239,7 +234,7 @@ impl CosineSimilarity {
         // `Normalized` makes the normalized children authoritative, so their dot product is the
         // cosine similarity even for lossy storage wrappers, except that a zero stored norm still
         // represents a zero vector.
-        let dot: PrimitiveArray = InnerProduct::try_new_array(normalized_l, normalized_r)?
+        let dot: PrimitiveArray = InnerProduct::try_new(normalized_l, normalized_r)?
             .into_array()
             .execute(ctx)?;
         let norms_l: PrimitiveArray = norms_l.execute(ctx)?;
@@ -281,12 +276,12 @@ impl CosineSimilarity {
 
         let (normalized, normalized_norms) = extract_normalized_children(normalized_ref);
 
-        let dot_arr = InnerProduct::try_new_array(normalized, plain_ref.clone())?;
+        let dot_arr = InnerProduct::try_new(normalized, plain_ref.clone())?;
         let dot: PrimitiveArray = dot_arr.into_array().execute(ctx)?;
 
         let normalized_norms: PrimitiveArray = normalized_norms.execute(ctx)?;
 
-        let norm_arr = L2Norm::try_new_array(plain_ref.clone())?;
+        let norm_arr = L2Norm::try_new(plain_ref.clone())?;
         let plain_norm: PrimitiveArray = norm_arr.into_array().execute(ctx)?;
 
         // TODO(connor): Ideally we would have a `SafeDiv` binary numeric operation.
@@ -321,7 +316,6 @@ mod tests {
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::MaskedArray;
     use vortex_array::arrays::PrimitiveArray;
-    use vortex_array::arrays::ScalarFnArray;
     use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayPlugin;
     use vortex_array::validity::Validity;
     use vortex_error::VortexResult;
@@ -338,8 +332,7 @@ mod tests {
 
     /// Evaluates cosine similarity between two tensor arrays and returns the result as `Vec<f64>`.
     fn eval_cosine_similarity(lhs: ArrayRef, rhs: ArrayRef) -> VortexResult<Vec<f64>> {
-        let scalar_fn = CosineSimilarity::new().erased();
-        let result = ScalarFnArray::try_new(scalar_fn, vec![lhs, rhs])?;
+        let result = CosineSimilarity::try_new(lhs, rhs)?;
         let mut ctx = SESSION.create_execution_ctx();
         let prim: PrimitiveArray = result.into_array().execute(&mut ctx)?;
         Ok(prim.as_slice::<f64>().to_vec())
@@ -503,8 +496,7 @@ mod tests {
         let rhs = tensor_array(&[2], &[3.0, 4.0, 0.0, 1.0])?;
         let rhs = MaskedArray::try_new(rhs, Validity::from_iter([true, false]))?.into_array();
 
-        let scalar_fn = CosineSimilarity::new().erased();
-        let result = ScalarFnArray::try_new(scalar_fn, vec![lhs, rhs])?;
+        let result = CosineSimilarity::try_new(lhs, rhs)?;
         let mut ctx = SESSION.create_execution_ctx();
         let prim: PrimitiveArray = result.into_array().execute(&mut ctx)?;
 
@@ -587,8 +579,7 @@ mod tests {
         let validity = Validity::from_iter([true, false]);
         let rhs = Normalized::try_new(normalized_r, norms_r, validity, &mut ctx)?.into_array();
 
-        let scalar_fn = CosineSimilarity::new().erased();
-        let result = ScalarFnArray::try_new(scalar_fn, vec![lhs, rhs])?;
+        let result = CosineSimilarity::try_new(lhs, rhs)?;
         let prim: PrimitiveArray = result.into_array().execute(&mut ctx)?;
 
         assert!(prim.is_valid(0, &mut ctx)?);
@@ -761,7 +752,7 @@ mod tests {
     #[case::vector(cosine_vector_lhs(), cosine_vector_rhs())]
     #[case::fixed_shape_tensor(cosine_tensor_lhs(), cosine_tensor_rhs())]
     fn serde_round_trip(#[case] lhs: ArrayRef, #[case] rhs: ArrayRef) -> VortexResult<()> {
-        let original = CosineSimilarity::try_new_array(lhs.clone(), rhs.clone())?.into_array();
+        let original = CosineSimilarity::try_new(lhs.clone(), rhs.clone())?.into_array();
 
         let plugin = ScalarFnArrayPlugin::new(CosineSimilarity);
         let metadata = plugin

--- a/vortex-tensor/src/scalar_fns/inner_product.rs
+++ b/vortex-tensor/src/scalar_fns/inner_product.rs
@@ -26,7 +26,7 @@ use vortex_array::scalar_fn::EmptyOptions;
 use vortex_array::scalar_fn::ExecutionArgs;
 use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
-use vortex_array::scalar_fn::TypedScalarFnInstance;
+use vortex_array::scalar_fn::ScalarFnVTableExt;
 use vortex_array::serde::ArrayChildren;
 use vortex_buffer::Buffer;
 use vortex_error::VortexExpect;
@@ -56,11 +56,6 @@ use crate::utils::validate_binary_tensor_float_inputs;
 pub struct InnerProduct;
 
 impl InnerProduct {
-    /// Creates a new [`TypedScalarFnInstance`] wrapping the inner product operation.
-    pub fn new() -> TypedScalarFnInstance<InnerProduct> {
-        TypedScalarFnInstance::new(InnerProduct, EmptyOptions)
-    }
-
     /// Constructs a [`ScalarFnArray`] that lazily computes the inner product between `lhs` and
     /// `rhs`.
     ///
@@ -68,8 +63,8 @@ impl InnerProduct {
     ///
     /// Returns an error if the [`ScalarFnArray`] cannot be constructed (e.g. due to dtype
     /// mismatches).
-    pub fn try_new_array(lhs: ArrayRef, rhs: ArrayRef) -> VortexResult<ScalarFnArray> {
-        ScalarFnArray::try_new(InnerProduct::new().erased(), vec![lhs, rhs])
+    pub fn try_new(lhs: ArrayRef, rhs: ArrayRef) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(InnerProduct.bind(EmptyOptions), vec![lhs, rhs])
     }
 }
 
@@ -224,7 +219,7 @@ impl InnerProduct {
         let norms_l: PrimitiveArray = norms_l.execute(ctx)?;
         let norms_r: PrimitiveArray = norms_r.execute(ctx)?;
 
-        let dot: PrimitiveArray = InnerProduct::try_new_array(normalized_l, normalized_r)?
+        let dot: PrimitiveArray = InnerProduct::try_new(normalized_l, normalized_r)?
             .into_array()
             .execute(ctx)?;
 
@@ -256,7 +251,7 @@ impl InnerProduct {
         let (normalized, norms) = extract_normalized_children(normalized_ref);
         let normalized_norms: PrimitiveArray = norms.execute(ctx)?;
 
-        let dot: PrimitiveArray = InnerProduct::try_new_array(normalized, plain_ref.clone())?
+        let dot: PrimitiveArray = InnerProduct::try_new(normalized, plain_ref.clone())?
             .into_array()
             .execute(ctx)?;
 
@@ -291,7 +286,6 @@ mod tests {
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::MaskedArray;
     use vortex_array::arrays::PrimitiveArray;
-    use vortex_array::arrays::ScalarFnArray;
     use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayPlugin;
     use vortex_array::validity::Validity;
     use vortex_error::VortexResult;
@@ -306,8 +300,7 @@ mod tests {
 
     /// Evaluates inner product between two tensor arrays and returns the result as `Vec<f64>`.
     fn eval_inner_product(lhs: ArrayRef, rhs: ArrayRef) -> VortexResult<Vec<f64>> {
-        let scalar_fn = InnerProduct::new().erased();
-        let result = ScalarFnArray::try_new(scalar_fn, vec![lhs, rhs])?;
+        let result = InnerProduct::try_new(lhs, rhs)?;
         let mut ctx = SESSION.create_execution_ctx();
         let prim: PrimitiveArray = result.into_array().execute(&mut ctx)?;
         Ok(prim.as_slice::<f64>().to_vec())
@@ -384,8 +377,7 @@ mod tests {
         let rhs = tensor_array(&[2], &[7.0, 8.0, 9.0, 10.0, 11.0, 12.0])?;
         let lhs = MaskedArray::try_new(lhs, Validity::from_iter([true, false, true]))?.into_array();
 
-        let scalar_fn = InnerProduct::new().erased();
-        let result = ScalarFnArray::try_new(scalar_fn, vec![lhs, rhs])?;
+        let result = InnerProduct::try_new(lhs, rhs)?;
         let mut ctx = SESSION.create_execution_ctx();
         let prim: PrimitiveArray = result.into_array().execute(&mut ctx)?;
 
@@ -402,7 +394,7 @@ mod tests {
     fn rejects_non_extension_dtype() {
         let lhs = PrimitiveArray::from_iter([1.0_f64, 2.0]).into_array();
         let rhs = PrimitiveArray::from_iter([3.0_f64, 4.0]).into_array();
-        let result = InnerProduct::try_new_array(lhs, rhs);
+        let result = InnerProduct::try_new(lhs, rhs);
         assert!(result.is_err());
     }
 
@@ -410,7 +402,7 @@ mod tests {
     fn rejects_mismatched_dtypes() -> VortexResult<()> {
         let lhs = tensor_array(&[2], &[1.0_f64, 2.0])?;
         let rhs = vector_array(2, &[3.0_f64, 4.0])?;
-        let result = InnerProduct::try_new_array(lhs, rhs);
+        let result = InnerProduct::try_new(lhs, rhs);
         assert!(result.is_err());
         Ok(())
     }
@@ -477,8 +469,7 @@ mod tests {
         let lhs = Normalized::try_new(normalized_l, norms_l, validity, &mut ctx)?.into_array();
         let rhs = normalized_array(&[2], &[0.6, 0.8, 1.0, 0.0], &[5.0, 1.0], &mut ctx)?;
 
-        let scalar_fn = InnerProduct::new().erased();
-        let result = ScalarFnArray::try_new(scalar_fn, vec![lhs, rhs])?;
+        let result = InnerProduct::try_new(lhs, rhs)?;
         let prim: PrimitiveArray = result.into_array().execute(&mut ctx)?;
 
         // Row 0: 5.0 * 5.0 * dot([0.6, 0.8], [0.6, 0.8]) = 25.0, row 1: null.
@@ -492,7 +483,7 @@ mod tests {
     #[case::vector(inner_product_vector_lhs(), inner_product_vector_rhs())]
     #[case::fixed_shape_tensor(inner_product_tensor_lhs(), inner_product_tensor_rhs())]
     fn serde_round_trip(#[case] lhs: ArrayRef, #[case] rhs: ArrayRef) -> VortexResult<()> {
-        let original = InnerProduct::try_new_array(lhs.clone(), rhs.clone())?.into_array();
+        let original = InnerProduct::try_new(lhs.clone(), rhs.clone())?.into_array();
 
         let plugin = ScalarFnArrayPlugin::new(InnerProduct);
         let metadata = plugin

--- a/vortex-tensor/src/scalar_fns/l2_norm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_norm.rs
@@ -33,7 +33,7 @@ use vortex_array::scalar_fn::EmptyOptions;
 use vortex_array::scalar_fn::ExecutionArgs;
 use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
-use vortex_array::scalar_fn::TypedScalarFnInstance;
+use vortex_array::scalar_fn::ScalarFnVTableExt;
 use vortex_array::serde::ArrayChildren;
 use vortex_buffer::Buffer;
 use vortex_error::VortexExpect;
@@ -67,19 +67,14 @@ use crate::utils::validate_tensor_float_input;
 pub struct L2Norm;
 
 impl L2Norm {
-    /// Creates a new [`TypedScalarFnInstance`] wrapping the L2 norm operation.
-    pub fn new() -> TypedScalarFnInstance<L2Norm> {
-        TypedScalarFnInstance::new(L2Norm, EmptyOptions)
-    }
-
     /// Constructs a [`ScalarFnArray`] that lazily computes the L2 norm over `child`.
     ///
     /// # Errors
     ///
     /// Returns an error if the [`ScalarFnArray`] cannot be constructed (e.g. due to dtype
     /// mismatches).
-    pub fn try_new_array(child: ArrayRef) -> VortexResult<ScalarFnArray> {
-        ScalarFnArray::try_new(L2Norm::new().erased(), vec![child])
+    pub fn try_new(child: ArrayRef) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(L2Norm.bind(EmptyOptions), vec![child])
     }
 }
 
@@ -266,7 +261,6 @@ mod tests {
     use vortex_array::arrays::ConstantArray;
     use vortex_array::arrays::MaskedArray;
     use vortex_array::arrays::PrimitiveArray;
-    use vortex_array::arrays::ScalarFnArray;
     use vortex_array::arrays::scalar_fn::plugin::ScalarFnArrayPlugin;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
@@ -287,8 +281,7 @@ mod tests {
 
     /// Evaluates L2 norm on a tensor/vector array and returns the result as `Vec<f64>`.
     fn eval_l2_norm(input: ArrayRef) -> VortexResult<Vec<f64>> {
-        let scalar_fn = L2Norm::new().erased();
-        let result = ScalarFnArray::try_new(scalar_fn, vec![input])?;
+        let result = L2Norm::try_new(input)?;
         let mut ctx = SESSION.create_execution_ctx();
         let prim: PrimitiveArray = result.into_array().execute(&mut ctx)?;
         Ok(prim.as_slice::<f64>().to_vec())
@@ -342,8 +335,7 @@ mod tests {
         let arr = tensor_array(&[2], &[3.0, 4.0, 0.0, 0.0])?;
         let arr = MaskedArray::try_new(arr, Validity::from_iter([true, false]))?.into_array();
 
-        let scalar_fn = L2Norm::new().erased();
-        let result = ScalarFnArray::try_new(scalar_fn, vec![arr])?;
+        let result = L2Norm::try_new(arr)?;
         let mut ctx = SESSION.create_execution_ctx();
         let prim: PrimitiveArray = result.into_array().execute(&mut ctx)?;
 
@@ -362,8 +354,7 @@ mod tests {
     fn constant_non_null_input_yields_constant_output() -> VortexResult<()> {
         let input = literal_vector_array(&[3.0f64, 4.0], 4);
 
-        let scalar_fn = L2Norm::new().erased();
-        let result = ScalarFnArray::try_new(scalar_fn, vec![input])?.into_array();
+        let result = L2Norm::try_new(input)?.into_array();
         let mut ctx = SESSION.create_execution_ctx();
         let output = result.execute_until::<Constant>(&mut ctx)?;
 
@@ -393,8 +384,7 @@ mod tests {
         let null_scalar = Scalar::null(DType::Extension(ext_dtype));
         let input = ConstantArray::new(null_scalar, 3).into_array();
 
-        let scalar_fn = L2Norm::new().erased();
-        let result = ScalarFnArray::try_new(scalar_fn, vec![input])?.into_array();
+        let result = L2Norm::try_new(input)?.into_array();
         let mut ctx = SESSION.create_execution_ctx();
         let output = result.execute_until::<Constant>(&mut ctx)?;
 
@@ -419,7 +409,7 @@ mod tests {
         let validity = Validity::from_iter([true, false]);
         let input = Normalized::try_new(normalized, norms, validity, &mut ctx)?.into_array();
 
-        let result = ScalarFnArray::try_new(L2Norm::new().erased(), vec![input])?.into_array();
+        let result = L2Norm::try_new(input)?.into_array();
         let prim: PrimitiveArray = result.execute(&mut ctx)?;
 
         assert_eq!(
@@ -437,7 +427,7 @@ mod tests {
     #[case::fixed_shape_tensor(l2_norm_tensor_child())]
     #[case::vector(l2_norm_vector_child())]
     fn serde_round_trip(#[case] child: ArrayRef) -> VortexResult<()> {
-        let original = L2Norm::try_new_array(child.clone())?.into_array();
+        let original = L2Norm::try_new(child.clone())?.into_array();
 
         let plugin = ScalarFnArrayPlugin::new(L2Norm);
         let metadata = plugin

--- a/vortex-tensor/src/vector_search.rs
+++ b/vortex-tensor/src/vector_search.rs
@@ -79,7 +79,7 @@ pub fn build_similarity_search_tree<T: NativePType + Into<PValue>>(
     let num_rows = data.len();
     let query_vec = Vector::constant_array(query, num_rows)?;
 
-    let cosine = CosineSimilarity::try_new_array(data, query_vec)?.into_array();
+    let cosine = CosineSimilarity::try_new(data, query_vec)?.into_array();
 
     let threshold_scalar = Scalar::primitive(threshold, Nullability::NonNullable);
     let threshold_array = ConstantArray::new(threshold_scalar, num_rows).into_array();


### PR DESCRIPTION
## Rationale for this change

Closes https://github.com/vortex-data/vortex/issues/9213

Scalar functions have distinct construction contracts, so the shared factory exposes caller-supplied lengths and defers basic validation.

This is a purely cosmetic change.

## What changes are included in this PR?

Removes `ScalarFnFactoryExt`, restores hand-written constructors, and migrates callers. `ScalarFnArray` now rejects the wrong arity and missing child slots before dispatching to `return_dtype`.

## What APIs are changed? Are there any user-facing changes?

Renames `try_new_array` to `try_new` for tensor and spatial scalar functions, while infallible functions expose `new`. `Normalized::{try_new, new_unchecked}` and the unrelated Arrow datum constructor are unchanged.