### PR TITLE
duckdb: batch processing in copy function

### DIFF
--- a/vortex-duckdb/cpp/copy_function.cpp
+++ b/vortex-duckdb/cpp/copy_function.cpp
@@ -1,64 +1,51 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+#include "copy_function.hpp"
 #include "data.hpp"
 #include "error.hpp"
 #include "vortex_duckdb.h"
 #include "table_function.h"
 #include "vortex.h"
-#include "duckdb/function/copy_function.hpp"
+#include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/parser/parsed_data/create_copy_function_info.hpp"
 
-using namespace duckdb;
-
-struct CopyBindData final : TableFunctionData {
-    CopyBindData(unique_ptr<CData> ffi_data) : ffi_data(std::move(ffi_data)) {
-    }
-    unique_ptr<CData> ffi_data;
-};
-
-struct CopyGlobalData final : GlobalFunctionData {
-    CopyGlobalData(unique_ptr<CData> ffi_data) : ffi_data(std::move(ffi_data)) {
-    }
-
-    unique_ptr<CData> ffi_data;
-};
-
 unique_ptr<FunctionData> copy_to_bind(ClientContext &,
                                       CopyFunctionBindInput &,
-                                      const vector<string> &column_names,
-                                      const vector<LogicalType> &column_types) {
-    vector<const char *> ffi_column_names(column_names.size());
-    for (size_t i = 0; i < column_names.size(); ++i) {
-        ffi_column_names[i] = column_names[i].c_str();
+                                      const vector<string> &names,
+                                      const vector<LogicalType> &types) {
+    vector<const char *> ffi_names(names.size());
+    for (size_t i = 0; i < names.size(); ++i) {
+        ffi_names[i] = names[i].c_str();
     }
 
-    vector<duckdb_logical_type> ffi_column_types(column_types.size());
-    for (size_t i = 0; i < column_types.size(); ++i) {
+    vector<duckdb_logical_type> ffi_types(types.size());
+    for (size_t i = 0; i < types.size(); ++i) {
         // duckdb C api doesn't allow passing const LogicalTypes. We never
         // modify input in copy function.
-        ffi_column_types[i] =
-            reinterpret_cast<duckdb_logical_type>(const_cast<LogicalType *>(&column_types[i]));
+        ffi_types[i] = reinterpret_cast<duckdb_logical_type>(const_cast<LogicalType *>(&types[i]));
     }
 
     duckdb_vx_error error_out = nullptr;
-    const duckdb_vx_data ffi_bind_data = duckdb_copy_function_copy_to_bind(ffi_column_names.data(),
-                                                                           ffi_column_names.size(),
-                                                                           ffi_column_types.data(),
-                                                                           ffi_column_types.size(),
+    const duckdb_vx_data ffi_bind_data = duckdb_copy_function_copy_to_bind(ffi_names.data(),
+                                                                           ffi_names.size(),
+                                                                           ffi_types.data(),
+                                                                           ffi_types.size(),
                                                                            &error_out);
     if (error_out) {
         throw BinderException(IntoErrString(error_out));
     }
     auto cdata = unique_ptr<CData>(reinterpret_cast<CData *>(ffi_bind_data));
-    return make_uniq<CopyBindData>(std::move(cdata));
+    return make_uniq<VortexCopyBindData>(std::move(cdata));
 }
 
 unique_ptr<GlobalFunctionData>
 copy_to_initialize_global(ClientContext &, FunctionData &bind_data, const string &file_path) {
-    void *const ffi_bind = bind_data.Cast<CopyBindData>().ffi_data->DataPtr();
+    const VortexCopyBindData &bind = bind_data.Cast<VortexCopyBindData>();
+    const void *const ffi_bind = bind.ffi_bind->DataPtr();
 
     duckdb_vx_error error_out = nullptr;
     const duckdb_vx_data ffi_global =
@@ -68,7 +55,7 @@ copy_to_initialize_global(ClientContext &, FunctionData &bind_data, const string
     }
 
     auto cdata = unique_ptr<CData>(reinterpret_cast<CData *>(ffi_global));
-    return make_uniq<CopyGlobalData>(std::move(cdata));
+    return make_uniq<VortexCopyGlobalState>(std::move(cdata));
 }
 
 void copy_to_sink(ExecutionContext &,
@@ -76,9 +63,13 @@ void copy_to_sink(ExecutionContext &,
                   GlobalFunctionData &gstate,
                   LocalFunctionData &,
                   DataChunk &input) {
-    void *const ffi_bind = bind_data.Cast<CopyBindData>().ffi_data->DataPtr();
-    void *const ffi_global = gstate.Cast<CopyGlobalData>().ffi_data->DataPtr();
-    auto ffi_chunk = reinterpret_cast<duckdb_data_chunk>(&input);
+    const VortexCopyBindData &bind = bind_data.Cast<VortexCopyBindData>();
+    const VortexCopyGlobalState &global = gstate.Cast<VortexCopyGlobalState>();
+
+    const void *const ffi_bind = bind.ffi_bind->DataPtr();
+    const void *const ffi_global = global.ffi_global->DataPtr();
+
+    duckdb_data_chunk ffi_chunk = reinterpret_cast<duckdb_data_chunk>(&input);
     duckdb_vx_error error_out = nullptr;
     duckdb_copy_function_copy_to_sink(ffi_bind, ffi_global, ffi_chunk, &error_out);
     if (error_out) {
@@ -87,9 +78,47 @@ void copy_to_sink(ExecutionContext &,
 }
 
 void copy_to_finalize(ClientContext &, FunctionData &, GlobalFunctionData &gstate) {
-    void *const ffi_global = gstate.Cast<CopyGlobalData>().ffi_data->DataPtr();
+    const VortexCopyGlobalState &global = gstate.Cast<VortexCopyGlobalState>();
+
+    void *const ffi_global = global.ffi_global->DataPtr();
     duckdb_vx_error error_out = nullptr;
     duckdb_copy_function_copy_to_finalize(ffi_global, &error_out);
+    if (error_out) {
+        throw ExecutorException(IntoErrString(error_out));
+    }
+}
+
+unique_ptr<PreparedBatchData> copy_to_prepare_batch(ClientContext &,
+                                                    FunctionData &bind_data,
+                                                    GlobalFunctionData &,
+                                                    unique_ptr<ColumnDataCollection> collection) {
+    const VortexCopyBindData &bind = bind_data.Cast<VortexCopyBindData>();
+
+    const void *const ffi_bind = bind.ffi_bind->DataPtr();
+    auto ffi_batch = unique_ptr<CData>(reinterpret_cast<CData *>(duckdb_copy_function_prepare_batch_new()));
+    duckdb_vx_error error_out = nullptr;
+
+    for (DataChunk &chunk : collection->Chunks()) {
+        duckdb_data_chunk ffi_chunk = reinterpret_cast<duckdb_data_chunk>(&chunk);
+        duckdb_copy_function_prepare_batch_push(ffi_bind, ffi_batch->DataPtr(), ffi_chunk, &error_out);
+        if (error_out) {
+            throw ExecutorException(IntoErrString(error_out));
+        }
+    }
+    return make_uniq<VortexCopyPreparedBatchData>(std::move(ffi_batch));
+}
+
+void copy_to_flush_batch(ClientContext &,
+                         FunctionData &,
+                         GlobalFunctionData &gstate,
+                         PreparedBatchData &batch_data) {
+    const VortexCopyGlobalState &global = gstate.Cast<VortexCopyGlobalState>();
+    const VortexCopyPreparedBatchData &batch = batch_data.Cast<VortexCopyPreparedBatchData>();
+
+    const void *const ffi_global = global.ffi_global->DataPtr();
+    const void *const ffi_batch = batch.ffi_copy_prepared->DataPtr();
+    duckdb_vx_error error_out = nullptr;
+    duckdb_copy_function_flush_batch(ffi_global, ffi_batch, &error_out);
     if (error_out) {
         throw ExecutorException(IntoErrString(error_out));
     }
@@ -103,18 +132,29 @@ extern "C" duckdb_state duckdb_vx_register_copy_function(duckdb_database ffi_db)
     CopyFunction fn("vortex");
     fn.copy_to_bind = copy_to_bind;
     fn.copy_to_initialize_global = copy_to_initialize_global;
+    // required by duckdb
     fn.copy_to_initialize_local = [](auto &, auto &) {
         return make_uniq<LocalFunctionData>();
     };
     fn.copy_to_sink = copy_to_sink;
+    // required by duckdb for PARTITION_BY
+    fn.copy_to_combine = [](ExecutionContext &, FunctionData &, GlobalFunctionData &, LocalFunctionData &) {
+    };
     fn.copy_to_finalize = copy_to_finalize;
+    fn.prepare_batch = copy_to_prepare_batch;
+    fn.flush_batch = copy_to_flush_batch;
     fn.extension = "vortex";
 
-    // TODO(joe): expose this via c our api
-    fn.execution_mode = [](bool, bool) {
-        return CopyFunctionExecutionMode::REGULAR_COPY_TO_FILE;
+    fn.execution_mode = [](bool preserve_insertion_order, bool supports_batch_index) {
+        using enum CopyFunctionExecutionMode;
+        if (!preserve_insertion_order) {
+            return PARALLEL_COPY_TO_FILE;
+        }
+        if (supports_batch_index) {
+            return BATCH_COPY_TO_FILE;
+        }
+        return REGULAR_COPY_TO_FILE;
     };
-    // TODO(joe): handle parameters as in table_function
 
     try {
         Catalog &system_catalog = Catalog::GetSystemCatalog(db);

--- a/vortex-duckdb/cpp/include/copy_function.hpp
+++ b/vortex-duckdb/cpp/include/copy_function.hpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+#pragma once
+#include "data.hpp"
+#include "duckdb/function/copy_function.hpp"
+
+using namespace duckdb;
+
+struct VortexCopyBindData final : TableFunctionData {
+    VortexCopyBindData(unique_ptr<CData> ffi_bind) : ffi_bind(std::move(ffi_bind)) {
+    }
+    unique_ptr<CData> ffi_bind;
+};
+
+struct VortexCopyGlobalState final : GlobalFunctionData {
+    VortexCopyGlobalState(unique_ptr<CData> ffi_global) : ffi_global(std::move(ffi_global)) {
+    }
+    unique_ptr<CData> ffi_global;
+};
+
+struct VortexCopyPreparedBatchData final : PreparedBatchData {
+    VortexCopyPreparedBatchData(unique_ptr<CData> ffi_copy_prepared)
+        : ffi_copy_prepared(std::move(ffi_copy_prepared)) {
+    }
+    unique_ptr<CData> ffi_copy_prepared;
+};

--- a/vortex-duckdb/include/vortex.h
+++ b/vortex-duckdb/include/vortex.h
@@ -88,11 +88,24 @@ duckdb_vx_data duckdb_copy_function_copy_to_initialize_global(const void *bind_d
 
 extern
 void duckdb_copy_function_copy_to_sink(const void *bind_data,
-                                       void *global_data,
+                                       const void *global_data,
                                        duckdb_data_chunk data_chunk,
                                        duckdb_vx_error *error_out);
 
 extern void duckdb_copy_function_copy_to_finalize(void *global_data, duckdb_vx_error *error_out);
+
+extern duckdb_vx_data duckdb_copy_function_prepare_batch_new(void);
+
+extern
+void duckdb_copy_function_prepare_batch_push(const void *bind,
+                                             void *batch,
+                                             duckdb_data_chunk chunk,
+                                             duckdb_vx_error *error);
+
+extern
+void duckdb_copy_function_flush_batch(const void *global,
+                                      const void *batch,
+                                      duckdb_vx_error *error);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/vortex-duckdb/src/convert/vector.rs
+++ b/vortex-duckdb/src/convert/vector.rs
@@ -82,6 +82,13 @@ fn vector_as_slice<T: NativePType>(vector: &VectorRef, len: usize) -> ArrayRef {
     .into_array()
 }
 
+fn vector_i128_values(vector: &VectorRef, len: usize) -> impl Iterator<Item = i128> {
+    let base = unsafe { crate::cpp::duckdb_vector_get_data(vector.as_ptr()) }.cast::<i128>();
+    // In batch copy, columns are 8 byte aligned, so reading vector's values
+    // as &[i128] is UB. Read data unaligned specifically
+    (0..len).map(move |i| unsafe { base.add(i).read_unaligned() })
+}
+
 fn vector_mapped<T, P: NativePType, F: Fn(&T) -> P>(
     vector: &VectorRef,
     len: usize,
@@ -311,18 +318,17 @@ pub fn flat_vector_to_vortex(vector: &VectorRef, len: usize) -> VortexResult<Arr
                     DecimalArray::try_new(Buffer::copy_from(data), decimal_dtype, validity)
                 }
                 DecimalType::I128 => {
-                    let data = vector.as_slice_with_len::<i128>(len);
-                    DecimalArray::try_new(Buffer::copy_from(data), decimal_dtype, validity)
+                    let data = Buffer::from_iter(vector_i128_values(vector, len));
+                    DecimalArray::try_new(data, decimal_dtype, validity)
                 }
                 _ => vortex_bail!("Unsupported decimal precision: {precision}"),
             }
             .map(|a| a.into_array())
         }
         DUCKDB_TYPE::DUCKDB_TYPE_UUID => {
-            let data = vector.as_slice_with_len::<i128>(len);
             let mut bytes = BufferMut::<u8>::with_capacity(len * 16);
-            for v in data {
-                let be = (*v as u128) ^ (1u128 << 127);
+            for v in vector_i128_values(vector, len) {
+                let be = (v as u128) ^ (1u128 << 127);
                 bytes.extend_from_slice(&be.to_be_bytes());
             }
 

--- a/vortex-duckdb/src/copy.rs
+++ b/vortex-duckdb/src/copy.rs
@@ -31,7 +31,6 @@ use vortex::io::compat::Compat;
 use vortex::io::object_store::ObjectStoreWrite;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::io::runtime::Task;
-use vortex::io::runtime::current::CurrentThreadWorkerPool;
 use vortex::io::session::RuntimeSessionExt;
 
 use crate::REGISTRY;
@@ -57,12 +56,6 @@ assert_impl_all!(CopyFunctionBind: Send, Clone);
 pub struct CopyFunctionGlobal {
     write_task: Mutex<Option<Task<VortexResult<WriteSummary>>>>,
     sink: Option<Sender<VortexResult<ArrayRef>>>,
-    // Pool of background workers helping to drive the write task.
-    // Note that this is optional and without it, we would only drive the task when DuckDB calls
-    // into us, and we call `RUNTIME.block_on`.
-    // TODO(myrrc): we should rely only on host threads, remove this
-    #[expect(dead_code)]
-    worker_pool: CurrentThreadWorkerPool,
 }
 assert_impl_all!(CopyFunctionGlobal: Send, Sync);
 
@@ -87,33 +80,58 @@ pub fn copy_to_bind(
     })
 }
 
-pub fn copy_to_sink(
-    bind_data: &CopyFunctionBind,
-    init_global: &CopyFunctionGlobal,
-    chunk: &mut DataChunkRef,
-) -> VortexResult<()> {
-    let chunk = data_chunk_to_vortex(bind_data.fields.names(), chunk);
-    let mut sink = init_global
+fn push_to_writer(global: &CopyFunctionGlobal, array: ArrayRef) -> VortexResult<()> {
+    let mut sink = global
         .sink
         .as_ref()
         .ok_or_else(|| vortex_err!("sink closed early"))?
         .clone();
     RUNTIME.block_on(async {
-        // sink.send may error with "receiver is gone" which isn't the
-        // real error
-        if sink.send(chunk).await.is_ok() {
+        // send may error with "receiver is gone" which isn't the real error
+        if sink.send(Ok(array)).await.is_ok() {
             return Ok(());
         }
-        let task;
-        {
-            task = init_global.write_task.lock().take();
-        }
+        let task = global.write_task.lock().take();
         if let Some(task) = task {
             // we can get the real error (i.e invalid path) from here
             task.await?;
         }
         vortex_bail!("Writer stopped before all data was written")
     })
+}
+
+pub fn copy_to_sink(
+    bind_data: &CopyFunctionBind,
+    init_global: &CopyFunctionGlobal,
+    chunk: &mut DataChunkRef,
+) -> VortexResult<()> {
+    push_to_writer(
+        init_global,
+        data_chunk_to_vortex(bind_data.fields.names(), chunk)?,
+    )
+}
+
+#[derive(Default)]
+pub struct CopyPreparedBatch {
+    arrays: Vec<ArrayRef>,
+}
+
+pub fn prepare_batch_push(
+    bind: &CopyFunctionBind,
+    batch: &mut CopyPreparedBatch,
+    chunk: &DataChunkRef,
+) -> VortexResult<()> {
+    batch
+        .arrays
+        .push(data_chunk_to_vortex(bind.fields.names(), chunk)?);
+    Ok(())
+}
+
+pub fn flush_batch(global: &CopyFunctionGlobal, batch: &CopyPreparedBatch) -> VortexResult<()> {
+    for array in &batch.arrays {
+        push_to_writer(global, array.clone())?;
+    }
+    Ok(())
 }
 
 pub fn copy_to_finalize(init_global: &mut CopyFunctionGlobal) -> VortexResult<()> {
@@ -171,10 +189,7 @@ pub fn copy_to_initialize_global(
         })
     };
 
-    let worker_pool = RUNTIME.new_pool();
-    worker_pool.set_workers_to_available_parallelism();
     Ok(CopyFunctionGlobal {
-        worker_pool,
         write_task: Mutex::new(Some(write_task)),
         sink: Some(sink),
     })

--- a/vortex-duckdb/src/ffi.rs
+++ b/vortex-duckdb/src/ffi.rs
@@ -12,10 +12,13 @@ use vortex::error::VortexExpect;
 use crate::convert::can_push_expression;
 use crate::copy::CopyFunctionBind;
 use crate::copy::CopyFunctionGlobal;
+use crate::copy::CopyPreparedBatch;
 use crate::copy::copy_to_bind;
 use crate::copy::copy_to_finalize;
 use crate::copy::copy_to_initialize_global;
 use crate::copy::copy_to_sink;
+use crate::copy::flush_batch;
+use crate::copy::prepare_batch_push;
 use crate::cpp;
 use crate::duckdb::AggregatePushdownInput;
 use crate::duckdb::BindInput;
@@ -310,7 +313,7 @@ pub unsafe extern "C-unwind" fn duckdb_copy_function_copy_to_initialize_global(
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn duckdb_copy_function_copy_to_sink(
     bind_data: *const c_void,
-    global_data: *mut c_void,
+    global_data: *const c_void,
     data_chunk: cpp::duckdb_data_chunk,
     error_out: *mut cpp::duckdb_vx_error,
 ) {
@@ -332,4 +335,34 @@ pub unsafe extern "C-unwind" fn duckdb_copy_function_copy_to_finalize(
     let global_data = unsafe { global_data.cast::<CopyFunctionGlobal>().as_mut() }
         .vortex_expect("bind_data null pointer");
     try_or(error_out, || copy_to_finalize(global_data))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn duckdb_copy_function_prepare_batch_new() -> cpp::duckdb_vx_data {
+    Data::from(Box::new(CopyPreparedBatch::default())).as_ptr()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn duckdb_copy_function_prepare_batch_push(
+    bind: *const c_void,
+    batch: *mut c_void,
+    chunk: cpp::duckdb_data_chunk,
+    error: *mut cpp::duckdb_vx_error,
+) {
+    let bind = unsafe { bind.cast::<CopyFunctionBind>().as_ref() }.vortex_expect("null pointer");
+    let batch = unsafe { batch.cast::<CopyPreparedBatch>().as_mut() }.vortex_expect("null pointer");
+    let chunk = unsafe { DataChunk::borrow_mut(chunk) };
+    try_or(error, || prepare_batch_push(bind, batch, chunk))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn duckdb_copy_function_flush_batch(
+    global: *const c_void,
+    batch: *const c_void,
+    error: *mut cpp::duckdb_vx_error,
+) {
+    let global =
+        unsafe { global.cast::<CopyFunctionGlobal>().as_ref() }.vortex_expect("null pointer");
+    let batch = unsafe { batch.cast::<CopyPreparedBatch>().as_ref() }.vortex_expect("null pointer");
+    try_or(error, || flush_batch(global, batch))
 }

--- a/vortex-sqllogictest/slt/duckdb/copy_ordered.slt
+++ b/vortex-sqllogictest/slt/duckdb/copy_ordered.slt
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+include ../setup.slt.no
+
+statement ok
+COPY (SELECT range AS j FROM range(100000))
+TO '${WORK_DIR}/copy_ordered.vortex';
+
+query III
+SELECT count(*), sum(j), count(*) FILTER (WHERE j <= prev)
+FROM (SELECT j, lag(j) OVER () AS prev
+FROM '${WORK_DIR}/copy_ordered.vortex');
+----
+100000 4999950000 0

--- a/vortex-sqllogictest/slt/duckdb/copy_parallel.slt
+++ b/vortex-sqllogictest/slt/duckdb/copy_parallel.slt
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+include ../setup.slt.no
+
+SET preserve_insertion_order = false;
+
+statement ok
+COPY (SELECT range AS j FROM range(100000))
+TO '${WORK_DIR}/copy_parallel.vortex';
+
+query II
+SELECT count(*), sum(j) FROM '${WORK_DIR}/copy_parallel.vortex';
+----
+100000 4999950000
+
+statement ok
+SET preserve_insertion_order = true;

--- a/vortex-sqllogictest/slt/duckdb/copy_parallel.slt
+++ b/vortex-sqllogictest/slt/duckdb/copy_parallel.slt
@@ -3,6 +3,7 @@
 
 include ../setup.slt.no
 
+statement ok
 SET preserve_insertion_order = false;
 
 statement ok

--- a/vortex-sqllogictest/slt/duckdb/copy_partition.slt
+++ b/vortex-sqllogictest/slt/duckdb/copy_partition.slt
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+include ../setup.slt.no
+
+statement ok
+CREATE TABLE partitioned AS SELECT range % 3 AS i, range AS j FROM range(30);
+
+statement ok
+COPY partitioned TO '${WORK_DIR}/partitioned-writes' (FORMAT vortex, PARTITION_BY (i));
+
+query II
+SELECT count(*), sum(j) FROM read_vortex('${WORK_DIR}/partitioned-writes/**/*.vortex');
+----
+30 435
+
+query II
+SELECT count(*), count(*) FILTER (WHERE j % 3 = 0)
+FROM read_vortex('${WORK_DIR}/partitioned-writes/i=0/*.vortex');
+----
+10 10

--- a/vortex-sqllogictest/slt/duckdb/uuid.slt
+++ b/vortex-sqllogictest/slt/duckdb/uuid.slt
@@ -75,6 +75,7 @@ SELECT count(id) FROM '${WORK_DIR}/uuid.vortex';
 
 # batch processing of UUID aligns columns at 8 bytes but reading uuid's
 # buffer as i128 requires 16 byte alighnemnt. Check this doesn't abort.
+statement ok
 COPY (SELECT range::DECIMAL(38, 2) AS d, gen_random_uuid() AS u FROM range(5000))
 TO '${WORK_DIR}/copy_uuid.vortex' (FORMAT vortex);
 

--- a/vortex-sqllogictest/slt/duckdb/uuid.slt
+++ b/vortex-sqllogictest/slt/duckdb/uuid.slt
@@ -72,3 +72,13 @@ query I
 SELECT count(id) FROM '${WORK_DIR}/uuid.vortex';
 ----
 3
+
+# batch processing of UUID aligns columns at 8 bytes but reading uuid's
+# buffer as i128 requires 16 byte alighnemnt. Check this doesn't abort.
+COPY (SELECT range::DECIMAL(38, 2) AS d, gen_random_uuid() AS u FROM range(5000))
+TO '${WORK_DIR}/copy_uuid.vortex' (FORMAT vortex);
+
+query IR
+SELECT count(DISTINCT u), sum(d) FROM '${WORK_DIR}/copy_uuid.vortex';
+----
+5000 12497500


### PR DESCRIPTION
- Support parallel and batched writes in COPY TO function.
- Fix PARTITION_BY segfault in copy function.
- Fix aligned loads crash while exporting 128-bit width types like
  UUID.

Resolves: #9484
