### PR TITLE
Make the default session include default encodings on wasm32

### DIFF
--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -320,13 +320,15 @@ impl VortexSessionDefault for VortexSession {
         editions::register_default_editions(&session);
         editions::enable_default_editions(&session);
 
-        // `MultiFileSession` holds a `moka` cache whose clock reads `std::time::Instant::now()`
-        // when constructed. `Instant` is unsupported on `wasm32` and panics with "time not
-        // implemented on this platform". Multi-file scanning is not available on wasm anyway, so
-        // only register this session variable on non-wasm targets.
-        #[cfg(all(feature = "files", not(target_arch = "wasm32")))]
+        #[cfg(feature = "files")]
         let session = {
+            // `MultiFileSession` holds a `moka` cache whose clock reads `std::time::Instant::now()`
+            // when constructed. `Instant` is unsupported on `wasm32` and panics with "time not
+            // implemented on this platform". Multi-file scanning is not available on wasm anyway, so
+            // only register this session variable on non-wasm targets.
+            #[cfg(not(target_arch = "wasm32"))]
             let session = session.with::<file::multi::MultiFileSession>();
+            // Default encodings are registered everywhere (if the `files` feature is enabled).
             file::register_default_encodings(&session);
             session
         };


### PR DESCRIPTION
## Rationale for this change

The configuration of a default `VortexSession` has a `cfg` gate for including multi-file scanning only on non-wasm32 targets. However, the line that registers all default encodings is also behind that gate, but it doesn't has to. This causes any open command with the default session fail on wasm32, because no encodings are known.

- Realted: #9475

## What changes are included in this PR?

The change simply calls `vortex::file::register_default_encodings` regardless of the target.

## What APIs are changed? Are there any user-facing changes?

If anyone was using a `VortexSession::default()` on `wasm32` with `files` enabled they'll have all the default encodings included now, but I argue that's the expected behaviour (matches other platforms).