### PR TITLE
Replace `ScalarFnVTable::is_fallible` with `is_infallible`

### DIFF
--- a/vortex-array/src/arrays/dict/compute/rules.rs
+++ b/vortex-array/src/arrays/dict/compute/rules.rs
@@ -130,7 +130,7 @@ impl ArrayParentReduceRule<Dict> for DictionaryScalarFnValuesPushDownRule {
 
         // If the scalar function is fallible, we cannot push it down since it may fail over a
         // value that isn't referenced by any code.
-        if !array.all_values_referenced && sig.is_fallible() {
+        if !array.all_values_referenced && !sig.is_infallible() {
             tracing::trace!(
                 "Not pushing down fallible scalar function {} over dictionary with sparse codes {}",
                 parent.scalar_fn(),

--- a/vortex-array/src/expr/analysis/infallible.rs
+++ b/vortex-array/src/expr/analysis/infallible.rs
@@ -5,7 +5,12 @@ use crate::expr::Expression;
 use crate::expr::analysis::BooleanLabels;
 use crate::expr::label_tree;
 
-pub fn label_is_infallible(expr: &Expression) -> BooleanLabels<'_> {
+/// Label each expression with whether its entire subtree is infallible.
+///
+/// A subtree is infallible only when the node's scalar function and every child subtree are
+/// infallible. See [`crate::scalar_fn::ScalarFnVTable::is_infallible`] for the scalar-function
+/// contract.
+pub fn label_infallible(expr: &Expression) -> BooleanLabels<'_> {
     label_tree(
         expr,
         |expr| match expr {
@@ -32,35 +37,35 @@ mod tests {
     #[test]
     fn not_is_infallible() {
         let expr = not(col("x"));
-        let labels = label_is_infallible(&expr);
+        let labels = label_infallible(&expr);
         assert_eq!(labels.get(&expr), Some(&true));
     }
 
     #[test]
     fn checked_add_defaults_to_fallible() {
         let expr = checked_add(col("a"), col("b"));
-        let labels = label_is_infallible(&expr);
+        let labels = label_infallible(&expr);
         assert_eq!(labels.get(&expr), Some(&false));
     }
 
     #[test]
     fn eq_is_infallible() {
         let expr = eq(col("a"), lit(5));
-        let labels = label_is_infallible(&expr);
+        let labels = label_infallible(&expr);
         assert_eq!(labels.get(&expr), Some(&true));
     }
 
     #[test]
     fn merge_with_error_handling_is_fallible() {
         let expr = merge_opts([col("a"), col("b")], DuplicateHandling::Error);
-        let labels = label_is_infallible(&expr);
+        let labels = label_infallible(&expr);
         assert_eq!(labels.get(&expr), Some(&false));
     }
 
     #[test]
     fn merge_with_rightmost_handling_is_infallible() {
         let expr = merge_opts([col("a"), col("b")], DuplicateHandling::RightMost);
-        let labels = label_is_infallible(&expr);
+        let labels = label_infallible(&expr);
         assert_eq!(labels.get(&expr), Some(&true));
     }
 
@@ -68,7 +73,7 @@ mod tests {
     fn nested_with_fallible_child() {
         let child = checked_add(col("a"), col("b"));
         let expr = not(child.clone());
-        let labels = label_is_infallible(&expr);
+        let labels = label_infallible(&expr);
         assert_eq!(labels.get(&child), Some(&false));
         assert_eq!(labels.get(&expr), Some(&false));
     }
@@ -77,7 +82,7 @@ mod tests {
     fn nested_without_fallible_child() {
         let child = is_null(col("x"));
         let expr = not(child.clone());
-        let labels = label_is_infallible(&expr);
+        let labels = label_infallible(&expr);
         assert_eq!(labels.get(&child), Some(&true));
         assert_eq!(labels.get(&expr), Some(&true));
     }

--- a/vortex-array/src/expr/analysis/infallible.rs
+++ b/vortex-array/src/expr/analysis/infallible.rs
@@ -5,15 +5,15 @@ use crate::expr::Expression;
 use crate::expr::analysis::BooleanLabels;
 use crate::expr::label_tree;
 
-pub fn label_is_fallible(expr: &Expression) -> BooleanLabels<'_> {
+pub fn label_is_infallible(expr: &Expression) -> BooleanLabels<'_> {
     label_tree(
         expr,
         |expr| match expr {
-            Expression::Scalar { scalar_fn, .. } => scalar_fn.signature().is_fallible(),
+            Expression::Scalar { scalar_fn, .. } => scalar_fn.signature().is_infallible(),
             // The scope itself cannot fail.
-            Expression::Root => false,
+            Expression::Root => true,
         },
-        |acc, &child| acc | child,
+        |acc, &child| acc & child,
     )
 }
 
@@ -30,55 +30,55 @@ mod tests {
     use crate::scalar_fn::fns::merge::DuplicateHandling;
 
     #[test]
-    fn not_is_not_fallible() {
+    fn not_is_infallible() {
         let expr = not(col("x"));
-        let labels = label_is_fallible(&expr);
-        assert_eq!(labels.get(&expr), Some(&false));
+        let labels = label_is_infallible(&expr);
+        assert_eq!(labels.get(&expr), Some(&true));
     }
 
     #[test]
     fn checked_add_defaults_to_fallible() {
         let expr = checked_add(col("a"), col("b"));
-        let labels = label_is_fallible(&expr);
-        assert_eq!(labels.get(&expr), Some(&true));
+        let labels = label_is_infallible(&expr);
+        assert_eq!(labels.get(&expr), Some(&false));
     }
 
     #[test]
-    fn eq_not_fallible() {
+    fn eq_is_infallible() {
         let expr = eq(col("a"), lit(5));
-        let labels = label_is_fallible(&expr);
-        assert_eq!(labels.get(&expr), Some(&false));
+        let labels = label_is_infallible(&expr);
+        assert_eq!(labels.get(&expr), Some(&true));
     }
 
     #[test]
     fn merge_with_error_handling_is_fallible() {
         let expr = merge_opts([col("a"), col("b")], DuplicateHandling::Error);
-        let labels = label_is_fallible(&expr);
-        assert_eq!(labels.get(&expr), Some(&true));
+        let labels = label_is_infallible(&expr);
+        assert_eq!(labels.get(&expr), Some(&false));
     }
 
     #[test]
-    fn merge_with_rightmost_handling_is_not_fallible() {
+    fn merge_with_rightmost_handling_is_infallible() {
         let expr = merge_opts([col("a"), col("b")], DuplicateHandling::RightMost);
-        let labels = label_is_fallible(&expr);
-        assert_eq!(labels.get(&expr), Some(&false));
+        let labels = label_is_infallible(&expr);
+        assert_eq!(labels.get(&expr), Some(&true));
     }
 
     #[test]
     fn nested_with_fallible_child() {
         let child = checked_add(col("a"), col("b"));
         let expr = not(child.clone());
-        let labels = label_is_fallible(&expr);
-        assert_eq!(labels.get(&child), Some(&true));
-        assert_eq!(labels.get(&expr), Some(&true));
+        let labels = label_is_infallible(&expr);
+        assert_eq!(labels.get(&child), Some(&false));
+        assert_eq!(labels.get(&expr), Some(&false));
     }
 
     #[test]
     fn nested_without_fallible_child() {
         let child = is_null(col("x"));
         let expr = not(child.clone());
-        let labels = label_is_fallible(&expr);
-        assert_eq!(labels.get(&child), Some(&false));
-        assert_eq!(labels.get(&expr), Some(&false));
+        let labels = label_is_infallible(&expr);
+        assert_eq!(labels.get(&child), Some(&true));
+        assert_eq!(labels.get(&expr), Some(&true));
     }
 }

--- a/vortex-array/src/expr/analysis/mod.rs
+++ b/vortex-array/src/expr/analysis/mod.rs
@@ -10,7 +10,7 @@ mod strict;
 
 pub use annotation::*;
 pub use immediate_access::*;
-pub use infallible::label_is_infallible;
+pub use infallible::label_infallible;
 pub use labeling::*;
 pub use referenced_field_paths::referenced_field_paths;
 pub use strict::label_strict;

--- a/vortex-array/src/expr/analysis/mod.rs
+++ b/vortex-array/src/expr/analysis/mod.rs
@@ -2,15 +2,15 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 pub mod annotation;
-mod fallible;
 pub mod immediate_access;
+mod infallible;
 mod labeling;
 mod referenced_field_paths;
 mod strict;
 
 pub use annotation::*;
-pub use fallible::label_is_fallible;
 pub use immediate_access::*;
+pub use infallible::label_is_infallible;
 pub use labeling::*;
 pub use referenced_field_paths::referenced_field_paths;
 pub use strict::label_strict;

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -344,8 +344,8 @@ impl ScalarFnVTable for Between {
         false
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -274,10 +274,9 @@ impl ScalarFnVTable for Binary {
         !matches!(operator, Operator::And | Operator::Or)
     }
 
-    fn is_fallible(&self, operator: &Operator) -> bool {
-        // Opt-in not out for fallibility.
+    fn is_infallible(&self, operator: &Operator) -> bool {
         // Arithmetic operations could be better modelled here.
-        let infallible = matches!(
+        matches!(
             operator,
             Operator::Eq
                 | Operator::NotEq
@@ -287,9 +286,7 @@ impl ScalarFnVTable for Binary {
                 | Operator::Lte
                 | Operator::And
                 | Operator::Or
-        );
-
-        !infallible
+        )
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/byte_length.rs
+++ b/vortex-array/src/scalar_fn/fns/byte_length.rs
@@ -135,8 +135,8 @@ impl ScalarFnVTable for ByteLength {
         true
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/case_when.rs
+++ b/vortex-array/src/scalar_fn/fns/case_when.rs
@@ -306,8 +306,8 @@ impl ScalarFnVTable for CaseWhen {
         false
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/ext_storage.rs
+++ b/vortex-array/src/scalar_fn/fns/ext_storage.rs
@@ -97,8 +97,8 @@ impl ScalarFnVTable for ExtStorage {
         true
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
@@ -150,8 +150,8 @@ impl ScalarFnVTable for FillNull {
         false
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/get_item.rs
+++ b/vortex-array/src/scalar_fn/fns/get_item.rs
@@ -200,7 +200,7 @@ impl ScalarFnVTable for GetItem {
     }
 
     fn is_infallible(&self, _field_name: &FieldName) -> bool {
-        // If this type-checks its infallible.
+        // If this type-checks, it is infallible.
         true
     }
 }

--- a/vortex-array/src/scalar_fn/fns/get_item.rs
+++ b/vortex-array/src/scalar_fn/fns/get_item.rs
@@ -199,9 +199,9 @@ impl ScalarFnVTable for GetItem {
         true
     }
 
-    fn is_fallible(&self, _field_name: &FieldName) -> bool {
+    fn is_infallible(&self, _field_name: &FieldName) -> bool {
         // If this type-checks its infallible.
-        false
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/is_not_null.rs
+++ b/vortex-array/src/scalar_fn/fns/is_not_null.rs
@@ -106,8 +106,8 @@ impl ScalarFnVTable for IsNotNull {
         false
     }
 
-    fn is_fallible(&self, _instance: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _instance: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/is_null.rs
+++ b/vortex-array/src/scalar_fn/fns/is_null.rs
@@ -96,8 +96,8 @@ impl ScalarFnVTable for IsNull {
         false
     }
 
-    fn is_fallible(&self, _instance: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _instance: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/like/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/like/mod.rs
@@ -186,8 +186,8 @@ impl ScalarFnVTable for Like {
         true
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 
@@ -745,9 +745,9 @@ mod tests {
                 .is_some_and(|f| f.signature().is_strict())
         );
         assert!(
-            !like_expr
+            like_expr
                 .as_scalar()
-                .is_some_and(|f| f.signature().is_fallible())
+                .is_some_and(|f| f.signature().is_infallible())
         );
     }
 

--- a/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
@@ -138,8 +138,8 @@ impl ScalarFnVTable for ListContains {
         false
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/list_length.rs
+++ b/vortex-array/src/scalar_fn/fns/list_length.rs
@@ -114,8 +114,8 @@ impl ScalarFnVTable for ListLength {
         true
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/list_sum.rs
+++ b/vortex-array/src/scalar_fn/fns/list_sum.rs
@@ -127,8 +127,8 @@ impl ScalarFnVTable for ListSum {
         true
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/literal.rs
+++ b/vortex-array/src/scalar_fn/fns/literal.rs
@@ -106,8 +106,8 @@ impl ScalarFnVTable for Literal {
         true
     }
 
-    fn is_fallible(&self, _instance: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _instance: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/merge.rs
+++ b/vortex-array/src/scalar_fn/fns/merge.rs
@@ -238,8 +238,8 @@ impl ScalarFnVTable for Merge {
         true
     }
 
-    fn is_fallible(&self, instance: &Self::Options) -> bool {
-        matches!(instance, DuplicateHandling::Error)
+    fn is_infallible(&self, instance: &Self::Options) -> bool {
+        !matches!(instance, DuplicateHandling::Error)
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/not/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/not/mod.rs
@@ -115,8 +115,8 @@ impl ScalarFnVTable for Not {
         true
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/pack.rs
+++ b/vortex-array/src/scalar_fn/fns/pack.rs
@@ -156,8 +156,8 @@ impl ScalarFnVTable for Pack {
         false
     }
 
-    fn is_fallible(&self, _instance: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _instance: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/select.rs
+++ b/vortex-array/src/scalar_fn/fns/select.rs
@@ -238,7 +238,7 @@ impl ScalarFnVTable for Select {
     }
 
     fn is_infallible(&self, _instance: &FieldSelection) -> bool {
-        // If this type-checks its infallible.
+        // If this type-checks, it is infallible.
         true
     }
 }

--- a/vortex-array/src/scalar_fn/fns/select.rs
+++ b/vortex-array/src/scalar_fn/fns/select.rs
@@ -237,9 +237,9 @@ impl ScalarFnVTable for Select {
         true
     }
 
-    fn is_fallible(&self, _instance: &FieldSelection) -> bool {
+    fn is_infallible(&self, _instance: &FieldSelection) -> bool {
         // If this type-checks its infallible.
-        false
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/zip/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/zip/mod.rs
@@ -183,8 +183,8 @@ impl ScalarFnVTable for Zip {
         false
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/internal/row_count.rs
+++ b/vortex-array/src/scalar_fn/internal/row_count.rs
@@ -87,8 +87,8 @@ impl ScalarFnVTable for RowCount {
         true
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/signature.rs
+++ b/vortex-array/src/scalar_fn/signature.rs
@@ -27,9 +27,9 @@ impl ScalarFnSignature<'_> {
         self.inner.is_strict()
     }
 
-    /// Returns whether this expression itself is fallible.
-    /// See [`crate::scalar_fn::ScalarFnVTable::is_fallible`].
-    pub fn is_fallible(&self) -> bool {
-        self.inner.is_fallible()
+    /// Returns whether this expression itself is infallible.
+    /// See [`crate::scalar_fn::ScalarFnVTable::is_infallible`].
+    pub fn is_infallible(&self) -> bool {
+        self.inner.is_infallible()
     }
 }

--- a/vortex-array/src/scalar_fn/typed.rs
+++ b/vortex-array/src/scalar_fn/typed.rs
@@ -92,7 +92,7 @@ pub(super) trait DynScalarFn: 'static + Send + Sync + super::sealed::Sealed {
     fn arity(&self) -> Arity;
     fn child_name(&self, child_idx: usize) -> ChildName;
     fn is_strict(&self) -> bool;
-    fn is_fallible(&self) -> bool;
+    fn is_infallible(&self) -> bool;
 
     // Expression methods — take expressions for tree traversal
     fn fmt_sql(&self, expression: &dyn ExprDisplay, f: &mut Formatter<'_>) -> fmt::Result;
@@ -192,8 +192,8 @@ impl<V: ScalarFnVTable> DynScalarFn for TypedScalarFnInstance<V> {
         V::is_strict(&self.vtable, &self.options)
     }
 
-    fn is_fallible(&self) -> bool {
-        V::is_fallible(&self.vtable, &self.options)
+    fn is_infallible(&self) -> bool {
+        V::is_infallible(&self.vtable, &self.options)
     }
 
     fn fmt_sql(&self, expression: &dyn ExprDisplay, f: &mut Formatter<'_>) -> fmt::Result {

--- a/vortex-array/src/scalar_fn/unstable/row/row_fn.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/row_fn.rs
@@ -49,8 +49,8 @@ pub trait RowFn: 'static + Sized + Clone + Send + Sync {
 
     /// Whether every dispatch is infallible.
     ///
-    /// See [`ScalarFnVTable::is_fallible`](crate::scalar_fn::ScalarFnVTable::is_fallible) for a
-    /// more detailed explanation of semantic errors.
+    /// See [`ScalarFnVTable::is_infallible`](crate::scalar_fn::ScalarFnVTable::is_infallible) for
+    /// a more detailed explanation of semantic errors.
     ///
     /// The framework checks dispatched element and result types. A conservative `false` is allowed.
     const INFALLIBLE: bool;

--- a/vortex-array/src/scalar_fn/unstable/row/vtable.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/vtable.rs
@@ -81,8 +81,8 @@ impl<F: RowFn> ScalarFnVTable for F {
         true
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        !F::INFALLIBLE
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        F::INFALLIBLE
     }
 }
 

--- a/vortex-array/src/scalar_fn/vtable.rs
+++ b/vortex-array/src/scalar_fn/vtable.rs
@@ -201,24 +201,24 @@ pub trait ScalarFnVTable: 'static + Sized + Clone + Send + Sync {
         false
     }
 
-    /// Returns whether this scalar function can raise a semantic error.
+    /// Returns whether this scalar function can never raise a semantic error.
     ///
-    /// Return `true` if a well-typed call can error because of its values. `checked_add` is
-    /// fallible on integer overflow, and integer division is fallible when its divisor is zero.
+    /// Return `true` only when a well-typed call cannot error because of its values. `checked_add`
+    /// is fallible on integer overflow, and integer division is fallible when its divisor is zero.
     /// A null result is not an error: [`crate::expr::list_sum`] is infallible for an empty list.
     ///
-    /// Exclude incidental execution errors, such as canonicalization failures, allocation errors,
+    /// Ignore incidental execution errors, such as canonicalization failures, allocation errors,
     /// and encoding mismatches. They are not part of the function's semantics.
     ///
-    /// Returning `false` permits optimizations that evaluate the function over values that no input
+    /// Returning `true` permits optimizations that evaluate the function over values that no input
     /// row references. Dictionary push-down, for example, evaluates every dictionary value, so a
     /// fallible function could error on a value that row-wise evaluation would never reach.
     ///
     /// This applies only to the scalar function, not its child expressions, and only to inputs
-    /// accepted by [`ScalarFnVTable::return_dtype`]. The default is conservatively `true`.
-    fn is_fallible(&self, options: &Self::Options) -> bool {
+    /// accepted by [`ScalarFnVTable::return_dtype`]. The default is conservatively `false`.
+    fn is_infallible(&self, options: &Self::Options) -> bool {
         _ = options;
-        true
+        false
     }
 }
 

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -195,7 +195,7 @@ fn split_expression_for_pushdown(
             return vec![];
         };
         let signature = scalar_fn.signature();
-        if !signature.is_fallible()
+        if signature.is_infallible()
             && signature.is_strict()
             && is_negative_cost(scalar_fn.id())
             && references_root

--- a/vortex-layout/src/plan/plans/take.rs
+++ b/vortex-layout/src/plan/plans/take.rs
@@ -144,17 +144,17 @@ impl PlanParentReduceRule<Take> for ExpressionTakeRule {
                 Some(scalar_fn) => (
                     false,
                     scalar_fn.signature().is_strict(),
-                    scalar_fn.signature().is_fallible(),
+                    scalar_fn.signature().is_infallible(),
                 ),
-                None => (true, true, false),
+                None => (true, true, true),
             },
-            |acc, &child| (acc.0 | child.0, acc.1 & child.1, acc.2 | child.2),
+            |acc, &child| (acc.0 | child.0, acc.1 & child.1, acc.2 & child.2),
         );
-        let (references_root, is_strict, is_fallible) = labels
+        let (references_root, is_strict, is_infallible) = labels
             .get(&ExactBoundExpr(expression.clone()))
             .copied()
-            .unwrap_or((false, false, true));
-        if !references_root || !is_strict || is_fallible {
+            .unwrap_or((false, false, false));
+        if !references_root || !is_strict || !is_infallible {
             return Ok(None);
         }
 

--- a/vortex-row/src/encode.rs
+++ b/vortex-row/src/encode.rs
@@ -94,8 +94,8 @@ impl ScalarFnVTable for RowEncode {
         false
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-row/src/size.rs
+++ b/vortex-row/src/size.rs
@@ -246,7 +246,7 @@ impl ScalarFnVTable for RowSize {
         false
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }

--- a/vortex-spatial/src/scalar_fn/area.rs
+++ b/vortex-spatial/src/scalar_fn/area.rs
@@ -112,8 +112,8 @@ impl ScalarFnVTable for SpatialArea {
         true
     }
 
-    fn is_fallible(&self, _: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-spatial/src/scalar_fn/collect.rs
+++ b/vortex-spatial/src/scalar_fn/collect.rs
@@ -317,8 +317,8 @@ impl ScalarFnVTable for SpatialCollect {
         true
     }
 
-    fn is_fallible(&self, _: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-spatial/src/scalar_fn/contains.rs
+++ b/vortex-spatial/src/scalar_fn/contains.rs
@@ -125,8 +125,8 @@ impl ScalarFnVTable for SpatialContains {
         true
     }
 
-    fn is_fallible(&self, _: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-spatial/src/scalar_fn/convex_hull.rs
+++ b/vortex-spatial/src/scalar_fn/convex_hull.rs
@@ -194,8 +194,8 @@ impl ScalarFnVTable for SpatialConvexHull {
         true
     }
 
-    fn is_fallible(&self, _: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-spatial/src/scalar_fn/distance.rs
+++ b/vortex-spatial/src/scalar_fn/distance.rs
@@ -118,8 +118,8 @@ impl ScalarFnVTable for SpatialDistance {
         true
     }
 
-    fn is_fallible(&self, _: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-spatial/src/scalar_fn/envelope.rs
+++ b/vortex-spatial/src/scalar_fn/envelope.rs
@@ -266,8 +266,8 @@ impl ScalarFnVTable for SpatialEnvelope {
         true
     }
 
-    fn is_fallible(&self, _: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-spatial/src/scalar_fn/intersects.rs
+++ b/vortex-spatial/src/scalar_fn/intersects.rs
@@ -123,8 +123,8 @@ impl ScalarFnVTable for SpatialIntersects {
         true
     }
 
-    fn is_fallible(&self, _: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-spatial/src/scalar_fn/length.rs
+++ b/vortex-spatial/src/scalar_fn/length.rs
@@ -166,8 +166,8 @@ impl ScalarFnVTable for SpatialLength {
         true
     }
 
-    fn is_fallible(&self, _: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-spatial/src/scalar_fn/make_line.rs
+++ b/vortex-spatial/src/scalar_fn/make_line.rs
@@ -235,8 +235,8 @@ impl ScalarFnVTable for SpatialMakeLine {
         true
     }
 
-    fn is_fallible(&self, _: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-tensor/src/scalar_fns/cosine_similarity.rs
+++ b/vortex-tensor/src/scalar_fns/cosine_similarity.rs
@@ -183,8 +183,8 @@ impl ScalarFnVTable for CosineSimilarity {
         true
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-tensor/src/scalar_fns/inner_product.rs
+++ b/vortex-tensor/src/scalar_fns/inner_product.rs
@@ -169,8 +169,8 @@ impl ScalarFnVTable for InnerProduct {
         true
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 

--- a/vortex-tensor/src/scalar_fns/l2_norm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_norm.rs
@@ -189,8 +189,8 @@ impl ScalarFnVTable for L2Norm {
         true
     }
 
-    fn is_fallible(&self, _options: &Self::Options) -> bool {
-        false
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
## Summary

- Tracking issue: #9130

Flips the polarity of the fallibility hook so the conservative answer is the default. A scalar function now opts in to being infallible by overriding `is_infallible` to return `true`, instead of opting out of the fallible default.

## What changes are included in this PR?

Renames `ScalarFnVTable::is_fallible` to `is_infallible` along with the `DynScalarFn` and `ScalarFnSignature` mirrors, and inverts every implementation and call site (dictionary push-down, the dict layout pushdown split, and `ExpressionTakeRule`). Also renames the `label_is_fallible` expression analysis to `label_infallible` so it matches `label_strict`, and inverts its tests in place.

## What APIs are changed? Are there any user-facing changes?

`ScalarFnSignature::is_fallible` becomes `is_infallible` and `label_is_fallible` becomes `label_infallible`, both with flipped return values. Out-of-tree `ScalarFnVTable` implementations must rename their `is_fallible` override and invert the result, and an override that returned `true` can now rely on the default.

---
_Generated by [Claude Code](https://claude.ai/code/session_011DaVCc8ZmJ13JtPGQYMM3o)_