### PR TITLE
Use mimalloc for expression benchmarks

### DIFF
--- a/vortex-array/benches/expr/case_when_bench.rs
+++ b/vortex-array/benches/expr/case_when_bench.rs
@@ -7,6 +7,7 @@
 use std::sync::LazyLock;
 
 use divan::Bencher;
+use mimalloc::MiMalloc;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
@@ -25,6 +26,9 @@ use vortex_array::expr::nested_case_when;
 use vortex_array::expr::root;
 use vortex_buffer::Buffer;
 use vortex_session::VortexSession;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 

--- a/vortex-array/benches/expr/large_struct_pack.rs
+++ b/vortex-array/benches/expr/large_struct_pack.rs
@@ -4,6 +4,7 @@
 #![expect(clippy::unwrap_used)]
 
 use divan::Bencher;
+use mimalloc::MiMalloc;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldName;
 use vortex_array::dtype::Nullability;
@@ -12,6 +13,9 @@ use vortex_array::dtype::StructFields;
 use vortex_array::expr::get_item;
 use vortex_array::expr::pack;
 use vortex_array::expr::root;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 fn main() {
     divan::main();

--- a/vortex-array/benches/expr/optimize_bench.rs
+++ b/vortex-array/benches/expr/optimize_bench.rs
@@ -5,6 +5,7 @@
 #![expect(clippy::cast_possible_truncation)]
 
 use divan::Bencher;
+use mimalloc::MiMalloc;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
@@ -15,6 +16,9 @@ use vortex_array::expr::get_item;
 use vortex_array::expr::lit;
 use vortex_array::expr::or;
 use vortex_array::expr::root;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 fn main() {
     divan::main();

--- a/vortex-array/benches/expr/optimize_predicate.rs
+++ b/vortex-array/benches/expr/optimize_predicate.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use divan::Bencher;
 use divan::black_box;
+use mimalloc::MiMalloc;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
@@ -32,6 +33,9 @@ use vortex_array::expr::or_collect;
 use vortex_array::extension::datetime::TimeUnit;
 use vortex_array::extension::datetime::Timestamp;
 use vortex_array::scalar::Scalar;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 fn main() {
     divan::main();


### PR DESCRIPTION
Configure mimalloc as the global allocator for every vortex-array expression benchmark, aligning setup with other benchmark targets.