### PR TITLE
CastExecute for constant always uses regular scalar cast and propagates error

### DIFF
--- a/vortex-array/src/arrays/constant/compute/cast.rs
+++ b/vortex-array/src/arrays/constant/compute/cast.rs
@@ -23,7 +23,9 @@ impl CastReduce for Constant {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_error::VortexResult;
 
+    use crate::ArrayRef;
     use crate::IntoArray;
     use crate::VortexSessionExecute;
     use crate::array_session;
@@ -33,6 +35,7 @@ mod tests {
     use crate::dtype::DType;
     use crate::dtype::DecimalDType;
     use crate::dtype::Nullability;
+    use crate::dtype::PType;
     use crate::scalar::DecimalValue;
     use crate::scalar::Scalar;
 
@@ -43,8 +46,29 @@ mod tests {
     #[case(ConstantArray::new(Scalar::from(true), 7).into_array())]
     #[case(ConstantArray::new(Scalar::null_native::<i32>(), 4).into_array())]
     #[case(ConstantArray::new(Scalar::from(255u8), 1).into_array())]
-    fn test_cast_constant_conformance(#[case] array: crate::ArrayRef) {
+    fn test_cast_constant_conformance(#[case] array: ArrayRef) {
         test_cast_conformance(&array, &mut array_session().create_execution_ctx());
+    }
+
+    #[test]
+    fn cast_constant_out_of_range_reports_scalar_error() -> VortexResult<()> {
+        let err = ConstantArray::new(Scalar::from(-1i32), 5)
+            .into_array()
+            .cast(DType::Primitive(PType::U32, Nullability::Nullable))?
+            .execute::<ArrayRef>(&mut array_session().create_execution_ctx())
+            .expect_err("casting a negative constant to u32 must fail");
+
+        // The scalar cast failure must surface, not a missing-rule error.
+        let message = err.to_string();
+        assert!(
+            message.contains("Cannot cast"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            !message.contains("No CastReduce"),
+            "unexpected error: {message}"
+        );
+        Ok(())
     }
 
     #[test]

--- a/vortex-array/src/scalar_fn/fns/cast/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/cast/mod.rs
@@ -22,8 +22,10 @@ use crate::ArrayView;
 use crate::CanonicalView;
 use crate::ColumnarView;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::arrays::Bool;
 use crate::arrays::Constant;
+use crate::arrays::ConstantArray;
 use crate::arrays::Decimal;
 use crate::arrays::Extension;
 use crate::arrays::FixedSizeList;
@@ -143,14 +145,7 @@ impl ScalarFnVTable for Cast {
                     ),
                 }
             }
-            ColumnarView::Constant(constant) => match cast_constant(constant, target_dtype)? {
-                Some(result) => Ok(result),
-                None => vortex_bail!(
-                    "No CastReduce to cast constant array from {} to {}",
-                    constant.dtype(),
-                    target_dtype,
-                ),
-            },
+            ColumnarView::Constant(constant) => cast_constant(constant, target_dtype),
         }
     }
 
@@ -226,9 +221,14 @@ fn cast_canonical(
     }
 }
 
-/// Cast a constant array by dispatching to its [`CastReduce`] implementation.
-fn cast_constant(array: ArrayView<Constant>, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
-    <Constant as CastReduce>::cast(array, dtype)
+/// Cast a constant array by casting its scalar.
+///
+/// Unlike [`Constant`]'s [`CastReduce`] rule, which returns `None` on a failing scalar cast so
+/// the optimizer leaves the cast in place, execution is the last stop: a failing scalar cast
+/// (e.g. an out-of-range value) is the error the caller should see.
+fn cast_constant(array: ArrayView<Constant>, dtype: &DType) -> VortexResult<ArrayRef> {
+    let scalar = array.scalar().cast(dtype)?;
+    Ok(ConstantArray::new(scalar, array.len()).into_array())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
CastExecute for constant doesn't produce CastReduce error and instead shows the
actual cast error

