### PR TITLE
Suffix CPU-feature benchmarks with the leg that ran them

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,14 +20,17 @@ timeout = 3600
 PYO3_ENVIRONMENT_SIGNATURE = { value = "cpython-3.11-64bit", force = true }
 # Read by benchmarks marked `#[cpu_features]` (see the `vortex-bench-support` crate), which
 # expands to code reading both with `env!`. VORTEX_BENCH_VARIANT names the run: the benchmark
-# is skipped when it is "simulation", and runs otherwise. VORTEX_BENCH_PREFIX is prepended to
-# the benchmark's name, so a CI leg can label the numbers it produced.
+# is skipped when it is "simulation", and runs otherwise. VORTEX_BENCH_PREFIX and
+# VORTEX_BENCH_SUFFIX wrap the benchmark's name, so a CI leg can label the numbers it produced:
+# the prefix is the `::` component the leg's benchmark filter selects on, and the suffix is on
+# the leaf name, which is the part CodSpeed reports under.
 #
 # The values below are what a plain `cargo bench` wants: nothing skipped, names left bare. The
-# per-feature-set jobs in `.github/workflows/codspeed.yml` set their own. Neither is `force`d,
+# per-feature-set jobs in `.github/workflows/codspeed.yml` set their own. None of them is `force`d,
 # so the value those jobs export wins over the one here.
 VORTEX_BENCH_VARIANT = "local"
 VORTEX_BENCH_PREFIX = ""
+VORTEX_BENCH_SUFFIX = ""
 
 [cache.global-clean]
 # Anything older than this duration will be deleted in the source cache.

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -168,6 +168,7 @@ jobs:
           RUSTFLAGS: ${{ matrix.rustflags }}
           VORTEX_BENCH_VARIANT: ${{ matrix.features }}
           VORTEX_BENCH_PREFIX: "${{ matrix.features }}::"
+          VORTEX_BENCH_SUFFIX: "_${{ matrix.features }}"
         run: |
           cargo codspeed build --locked -m walltime --profile bench \
             ${{ steps.select.outputs.packages }}

--- a/benchmarks/bench-support/src/lib.rs
+++ b/benchmarks/bench-support/src/lib.rs
@@ -15,10 +15,11 @@ use syn::parse_macro_input;
 /// Measure this benchmark on every walltime CPU-feature leg instead of in simulation.
 ///
 /// Takes no argument: the benchmark runs on all of them. Write it *above* `#[divan::bench]`,
-/// whose arguments it fills in — the name is qualified with the leg that produced it, so the
-/// legs report one series each rather than fighting over a shared name, and `ignore` takes
-/// the benchmark out of the sharded simulation job. A plain `cargo bench` runs it as before,
-/// under its bare name.
+/// whose arguments it fills in — the name is qualified with the leg that produced it, both as
+/// a `::` component the CI filter selects on and as a suffix on the leaf name CodSpeed
+/// reports under, so the legs report one series each rather than fighting over a shared name.
+/// `ignore` takes the benchmark out of the sharded simulation job. A plain `cargo bench` runs
+/// it as before, under its bare name.
 ///
 /// ```ignore
 /// #[vortex_bench_support::cpu_features]
@@ -95,6 +96,12 @@ pub fn cpu_features(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Skipping simulation, rather than naming the legs to run on, is what keeps the leg list
     // in the workflow alone. `env!` rather than reading the environment during expansion:
     // rustc records it as a dependency of the crate, so changing legs rebuilds the benchmarks.
+    //
+    // The leg lands in the name twice, and each copy earns its place. The prefix is a `::`
+    // component, which is what the workflow's filter selects on. The suffix is part of the
+    // leaf name, which is the only part CodSpeed keeps: its walltime reports identify a
+    // benchmark by leaf name and arguments, so without the suffix every leg would report
+    // into one `words_gather_dispatch[65536]` series instead of one series each.
     let name = function.sig.ident.to_string();
     let separator = if existing.is_empty() {
         quote!()
@@ -105,7 +112,11 @@ pub fn cpu_features(attr: TokenStream, item: TokenStream) -> TokenStream {
     bench.meta = syn::parse_quote! {
         #bench_path(
             #existing #separator
-            name = concat!(env!("VORTEX_BENCH_PREFIX"), #name),
+            name = concat!(
+                env!("VORTEX_BENCH_PREFIX"),
+                #name,
+                env!("VORTEX_BENCH_SUFFIX"),
+            ),
             ignore = env!("VORTEX_BENCH_VARIANT") == "simulation",
         )
     };


### PR DESCRIPTION
This means that codspeed will show each version of a benchmark with the cpu features set suffexed