### PR TITLE
Carry partial RowFn validity with MaskValues

### DIFF
--- a/vortex-array/src/scalar_fn/unstable/row/batch/execute/dense.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/batch/execute/dense.rs
@@ -5,6 +5,7 @@ use vortex_error::VortexError;
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 use vortex_mask::Mask;
+use vortex_mask::MaskValuesRef;
 
 use super::super::RowFnExecutionArgs;
 use super::super::args::BorrowedRowFnArgs;
@@ -39,7 +40,7 @@ impl RowFnExecutionArgs {
         ) -> VortexResult<DenseAttempt>,
         try_valid_rows: impl FnOnce(
             BorrowedRowFnArgs<'_>,
-            &Mask,
+            MaskValuesRef,
             &mut ExecutionCtx,
         ) -> VortexResult<Option<ArrayRef>>,
         ctx: &mut ExecutionCtx,
@@ -60,30 +61,26 @@ impl RowFnExecutionArgs {
         deferred_error: VortexError,
         try_valid_rows: impl FnOnce(
             BorrowedRowFnArgs<'_>,
-            &Mask,
+            MaskValuesRef,
             &mut ExecutionCtx,
         ) -> VortexResult<Option<ArrayRef>>,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let valid_rows = self.validity.execute_mask(self.row_count, ctx)?;
-
-        // An array-backed validity can materialize to all valid even though the cheap checks in
-        // `RowFnExecutionArgs::execute` could not prove that. The deferred error therefore came
-        // from an observable row and remains terminal. Check all-true before all-false because an
-        // empty mask is both.
-        if valid_rows.all_true() {
-            return Err(deferred_error);
-        }
-
-        if valid_rows.all_false() {
-            return Ok(self.all_null());
-        }
+        let valid_rows = match self.validity.execute_mask(self.row_count, ctx)? {
+            // An array-backed validity can materialize to all valid even though the cheap checks
+            // in `RowFnExecutionArgs::execute` could not prove that. The deferred error therefore
+            // came from an observable row and remains terminal. An empty mask is both all-valid
+            // and all-null, so preserve the all-valid behavior.
+            Mask::AllTrue(_) | Mask::AllFalse(0) => return Err(deferred_error),
+            Mask::AllFalse(_) => return Ok(self.all_null()),
+            Mask::Values(valid_rows) => valid_rows,
+        };
 
         // Reduced evidence does not identify which rows failed. Discard the dense error before
         // retrying only observable rows.
         drop(deferred_error);
 
-        if let Some(result) = self.try_execute_valid_rows(try_valid_rows, &valid_rows, ctx)? {
+        if let Some(result) = self.try_execute_valid_rows(try_valid_rows, valid_rows, ctx)? {
             return Ok(result);
         }
 

--- a/vortex-array/src/scalar_fn/unstable/row/batch/execute/dense.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/batch/execute/dense.rs
@@ -105,8 +105,9 @@ impl RowFnExecutionArgs {
                 self.finalize_output(values, self.row_count)
             }
             Validity::Array(valid) => self.finalize_output(values.mask(valid)?, self.row_count),
-            // Handled by the guard in `RowFnExecutionArgs::execute`, before the kernel ran.
-            Validity::AllInvalid => Ok(self.all_null()),
+            Validity::AllInvalid => {
+                unreachable!("all-invalid validity is handled before dense row execution")
+            }
         }
     }
 }

--- a/vortex-array/src/scalar_fn/unstable/row/batch/execute/mod.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/batch/execute/mod.rs
@@ -7,7 +7,7 @@
 //! valid-only execution.
 
 use vortex_error::VortexResult;
-use vortex_mask::MaskValues;
+use vortex_mask::MaskValuesRef;
 
 use super::RowFnExecutionArgs;
 use super::RowPolicy;
@@ -40,7 +40,7 @@ impl RowFnExecutionArgs {
         ) -> VortexResult<DenseAttempt>,
         try_valid_rows: impl FnOnce(
             BorrowedRowFnArgs<'_>,
-            &MaskValues,
+            MaskValuesRef,
             &mut ExecutionCtx,
         ) -> VortexResult<Option<ArrayRef>>,
         ctx: &mut ExecutionCtx,

--- a/vortex-array/src/scalar_fn/unstable/row/batch/execute/mod.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/batch/execute/mod.rs
@@ -7,7 +7,7 @@
 //! valid-only execution.
 
 use vortex_error::VortexResult;
-use vortex_mask::Mask;
+use vortex_mask::MaskValues;
 
 use super::RowFnExecutionArgs;
 use super::RowPolicy;
@@ -40,7 +40,7 @@ impl RowFnExecutionArgs {
         ) -> VortexResult<DenseAttempt>,
         try_valid_rows: impl FnOnce(
             BorrowedRowFnArgs<'_>,
-            &Mask,
+            &MaskValues,
             &mut ExecutionCtx,
         ) -> VortexResult<Option<ArrayRef>>,
         ctx: &mut ExecutionCtx,
@@ -67,8 +67,8 @@ impl RowFnExecutionArgs {
             return self.execute_all_constant(kernel, ctx);
         }
 
-        // A known all-valid batch does not need to materialize validity, even when its row policy
-        // only permits valid rows.
+        // Do not resolve array-backed validity for the uncommon all-valid or all-null cases here.
+        // That can execute and scan the full mask; each policy resolves it only when necessary.
         if self.validity.definitely_no_nulls() {
             return self.execute_dense(kernel, ctx);
         }

--- a/vortex-array/src/scalar_fn/unstable/row/batch/execute/valid_only.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/batch/execute/valid_only.rs
@@ -4,7 +4,7 @@
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 use vortex_mask::Mask;
-use vortex_mask::MaskValues;
+use vortex_mask::MaskValuesRef;
 
 use super::super::RowFnExecutionArgs;
 use super::super::args::BorrowedRowFnArgs;
@@ -25,7 +25,7 @@ impl RowFnExecutionArgs {
         kernel: impl Fn(BorrowedRowFnArgs<'_>, &mut ExecutionCtx) -> VortexResult<ArrayRef>,
         try_valid_rows: impl FnOnce(
             BorrowedRowFnArgs<'_>,
-            &MaskValues,
+            MaskValuesRef,
             &mut ExecutionCtx,
         ) -> VortexResult<Option<ArrayRef>>,
         ctx: &mut ExecutionCtx,
@@ -44,9 +44,7 @@ impl RowFnExecutionArgs {
             Mask::Values(valid_rows) => valid_rows,
         };
 
-        if let Some(result) =
-            self.try_execute_valid_rows(try_valid_rows, valid_rows.as_ref(), ctx)?
-        {
+        if let Some(result) = self.try_execute_valid_rows(try_valid_rows, valid_rows, ctx)? {
             return Ok(result);
         }
 
@@ -61,15 +59,15 @@ impl RowFnExecutionArgs {
         &self,
         try_valid_rows: impl FnOnce(
             BorrowedRowFnArgs<'_>,
-            &MaskValues,
+            MaskValuesRef,
             &mut ExecutionCtx,
         ) -> VortexResult<Option<ArrayRef>>,
-        valid: &MaskValues,
+        valid: MaskValuesRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let Some(values) = try_valid_rows(
             self.execution_args(&self.inputs, self.row_count),
-            valid,
+            MaskValuesRef::clone(&valid),
             ctx,
         )?
         else {
@@ -77,7 +75,7 @@ impl RowFnExecutionArgs {
         };
         let values = self.validate_kernel_output(values, valid.len(), ctx)?;
 
-        let mask = valid.into_array();
+        let mask = valid.as_ref().into_array();
         self.finalize_output(values.mask(mask)?, valid.len())
             .map(Some)
     }

--- a/vortex-array/src/scalar_fn/unstable/row/batch/execute/valid_only.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/batch/execute/valid_only.rs
@@ -4,24 +4,14 @@
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 use vortex_mask::Mask;
+use vortex_mask::MaskValues;
 
 use super::super::RowFnExecutionArgs;
 use super::super::args::BorrowedRowFnArgs;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::arrays::BoolArray;
 use crate::builtins::ArrayBuiltins;
-use crate::validity::Validity;
-
-/// The result of resolving batch validity.
-enum ResolvedValidity {
-    /// The output for an all-valid or all-null batch.
-    Output(ArrayRef),
-
-    /// A mask with both valid and invalid rows.
-    PartiallyValid(Mask),
-}
 
 impl RowFnExecutionArgs {
     /// Resolve validity, then execute valid rows over the original inputs.
@@ -35,17 +25,28 @@ impl RowFnExecutionArgs {
         kernel: impl Fn(BorrowedRowFnArgs<'_>, &mut ExecutionCtx) -> VortexResult<ArrayRef>,
         try_valid_rows: impl FnOnce(
             BorrowedRowFnArgs<'_>,
-            &Mask,
+            &MaskValues,
             &mut ExecutionCtx,
         ) -> VortexResult<Option<ArrayRef>>,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let valid = match self.resolve_validity(&kernel, ctx)? {
-            ResolvedValidity::Output(output) => return Ok(output),
-            ResolvedValidity::PartiallyValid(valid) => valid,
+        let validity = self.validity.clone().execute_mask(self.row_count, ctx)?;
+
+        let valid_rows = match validity {
+            // An empty mask is both all-valid and all-null. Preserve the all-valid behavior.
+            Mask::AllTrue(_) | Mask::AllFalse(0) => {
+                let values = kernel(self.execution_args(&self.inputs, self.row_count), ctx)?;
+                let values = self.validate_kernel_output(values, self.row_count, ctx)?;
+
+                return self.finalize_output(values, self.row_count);
+            }
+            Mask::AllFalse(_) => return Ok(self.all_null()),
+            Mask::Values(valid_rows) => valid_rows,
         };
 
-        if let Some(result) = self.try_execute_valid_rows(try_valid_rows, &valid, ctx)? {
+        if let Some(result) =
+            self.try_execute_valid_rows(try_valid_rows, valid_rows.as_ref(), ctx)?
+        {
             return Ok(result);
         }
 
@@ -55,41 +56,15 @@ impl RowFnExecutionArgs {
         )
     }
 
-    /// Materialize validity and handle all-valid or all-null batches.
-    fn resolve_validity(
-        &self,
-        kernel: &impl Fn(BorrowedRowFnArgs<'_>, &mut ExecutionCtx) -> VortexResult<ArrayRef>,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<ResolvedValidity> {
-        let valid = self.validity.clone().execute_mask(self.row_count, ctx)?;
-
-        // An array-backed validity can materialize to all valid even though the cheap checks in
-        // `RowFnExecutionArgs::execute` could not prove that. Run the full-row kernel in that
-        // case. Check all-true before all-false because an empty mask is both.
-        if valid.all_true() {
-            let values = kernel(self.execution_args(&self.inputs, self.row_count), ctx)?;
-            let values = self.validate_kernel_output(values, self.row_count, ctx)?;
-            let values = self.finalize_output(values, self.row_count)?;
-
-            return Ok(ResolvedValidity::Output(values));
-        }
-
-        if valid.all_false() {
-            return Ok(ResolvedValidity::Output(self.all_null()));
-        }
-
-        Ok(ResolvedValidity::PartiallyValid(valid))
-    }
-
     /// Try execution against the original inputs, then mask a returned full-length result.
     pub(super) fn try_execute_valid_rows(
         &self,
         try_valid_rows: impl FnOnce(
             BorrowedRowFnArgs<'_>,
-            &Mask,
+            &MaskValues,
             &mut ExecutionCtx,
         ) -> VortexResult<Option<ArrayRef>>,
-        valid: &Mask,
+        valid: &MaskValues,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let Some(values) = try_valid_rows(
@@ -102,7 +77,7 @@ impl RowFnExecutionArgs {
         };
         let values = self.validate_kernel_output(values, valid.len(), ctx)?;
 
-        let mask = BoolArray::new(valid.to_bit_buffer(), Validity::NonNullable).into_array();
+        let mask = valid.into_array();
         self.finalize_output(values.mask(mask)?, valid.len())
             .map(Some)
     }

--- a/vortex-array/src/scalar_fn/unstable/row/execute/owned.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/execute/owned.rs
@@ -11,11 +11,9 @@ use std::ops::BitOrAssign;
 
 use vortex_compute::lane_kernels::IndexedSourceExt;
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_ensure_eq;
-use vortex_mask::AllOr;
-use vortex_mask::Mask;
+use vortex_mask::MaskValues;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
@@ -56,7 +54,7 @@ where
 /// Decode nullable inputs, then store one output for each valid row from an infallible kernel.
 pub(crate) fn execute_owned_infallible_valid_rows<Args, Out, Prepared>(
     args: &dyn ExecutionArgs,
-    valid: &Mask,
+    valid: &MaskValues,
     ctx: &mut ExecutionCtx,
     prepare: impl FnOnce(Args::ConstElems<'_>) -> Prepared,
     apply: impl Fn(&Prepared, Args::Elems<'_>) -> Out,
@@ -78,7 +76,7 @@ where
 /// Decode nullable inputs, then store outputs and combine failure evidence for valid rows.
 pub(crate) fn execute_owned_valid_rows<Args, Out, Prepared, Fail>(
     args: &dyn ExecutionArgs,
-    valid: &Mask,
+    valid: &MaskValues,
     ctx: &mut ExecutionCtx,
     prepare: impl FnOnce(Args::ConstElems<'_>) -> Prepared,
     apply: impl Fn(&Prepared, Args::Elems<'_>) -> (Out, Fail),
@@ -96,11 +94,7 @@ where
     };
 
     let row_count = args.row_count();
-    let AllOr::Some(valid_rows) = valid.bit_buffer() else {
-        vortex_bail!(
-            "execute_owned_valid_rows requires valid and invalid rows, got an all-valid or all-invalid mask"
-        );
-    };
+    let valid_rows = valid.bit_buffer();
     vortex_ensure_eq!(
         valid_rows.len(),
         row_count,

--- a/vortex-array/src/scalar_fn/unstable/row/execute/owned.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/execute/owned.rs
@@ -13,7 +13,7 @@ use vortex_compute::lane_kernels::IndexedSourceExt;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_ensure_eq;
-use vortex_mask::MaskValues;
+use vortex_mask::MaskValuesRef;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
@@ -54,7 +54,7 @@ where
 /// Decode nullable inputs, then store one output for each valid row from an infallible kernel.
 pub(crate) fn execute_owned_infallible_valid_rows<Args, Out, Prepared>(
     args: &dyn ExecutionArgs,
-    valid: &MaskValues,
+    valid: &MaskValuesRef,
     ctx: &mut ExecutionCtx,
     prepare: impl FnOnce(Args::ConstElems<'_>) -> Prepared,
     apply: impl Fn(&Prepared, Args::Elems<'_>) -> Out,
@@ -76,7 +76,7 @@ where
 /// Decode nullable inputs, then store outputs and combine failure evidence for valid rows.
 pub(crate) fn execute_owned_valid_rows<Args, Out, Prepared, Fail>(
     args: &dyn ExecutionArgs,
-    valid: &MaskValues,
+    valid: &MaskValuesRef,
     ctx: &mut ExecutionCtx,
     prepare: impl FnOnce(Args::ConstElems<'_>) -> Prepared,
     apply: impl Fn(&Prepared, Args::Elems<'_>) -> (Out, Fail),

--- a/vortex-array/src/scalar_fn/unstable/row/execute/sink.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/execute/sink.rs
@@ -11,8 +11,7 @@ use vortex_buffer::BitBuffer;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure_eq;
-use vortex_mask::AllOr;
-use vortex_mask::Mask;
+use vortex_mask::MaskValues;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
@@ -102,7 +101,7 @@ where
 /// how to handle the decline.
 pub(crate) fn execute_sink_valid_rows<Args, Prepared, Sink, ApplyResult, Options>(
     args: &dyn ExecutionArgs,
-    valid: &Mask,
+    valid: &MaskValues,
     ctx: &mut ExecutionCtx,
     prepare: impl FnOnce(Args::ConstElems<'_>) -> Prepared,
     apply: impl Fn(&Prepared, Args::Elems<'_>, <Sink as OutputSink<Options>>::Row<'_>) -> ApplyResult,
@@ -209,7 +208,7 @@ where
 /// Resolve the capabilities, inputs, sink, and validity mask for skip-invalid execution.
 fn setup_sink_valid_rows<'valid, Args, Sink, Options>(
     args: &dyn ExecutionArgs,
-    valid: &'valid Mask,
+    valid: &'valid MaskValues,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ValidRowsSetup<'valid, Args, Sink, Options>>>
 where
@@ -235,12 +234,7 @@ where
     // checks.
     let sink = <Sink as OutputSink<Options>>::with_capacity(row_count)?;
 
-    // Batch execution resolves all-valid and all-null inputs before selecting this path.
-    let AllOr::Some(valid_rows) = valid.bit_buffer() else {
-        vortex_bail!(
-            "execute_sink_valid_rows requires valid and invalid rows, got an all-valid or all-invalid mask"
-        );
-    };
+    let valid_rows = valid.bit_buffer();
     vortex_ensure_eq!(
         valid_rows.len(),
         row_count,
@@ -347,12 +341,15 @@ mod tests {
     fn test_non_skipping_sink_declines_before_allocation() -> VortexResult<()> {
         let input = PrimitiveArray::new(vec![1_i64, 2], Validity::NonNullable).into_array();
         let args = VecExecutionArgs::new(vec![input], 2);
-        let valid = Mask::from_iter([true, false]);
+        let valid_mask = Mask::from_iter([true, false]);
+        let Some(valid) = valid_mask.values() else {
+            vortex_bail!("the test validity must be partially valid");
+        };
         let mut ctx = array_session().create_execution_ctx();
 
         let execution = execute_sink_valid_rows::<(i64,), (), NonSkippingSink, (), EmptyOptions>(
             &args,
-            &valid,
+            valid,
             &mut ctx,
             |_| (),
             |_, _, _| (),
@@ -367,12 +364,15 @@ mod tests {
     fn test_skip_invalid_sink_rechecks_rows_after_initialization() -> VortexResult<()> {
         let input = PrimitiveArray::from_iter([10_i64, 20]).into_array();
         let args = VecExecutionArgs::new(vec![input], 2);
-        let valid = Mask::from_iter([false, true]);
+        let valid_mask = Mask::from_iter([false, true]);
+        let Some(valid) = valid_mask.values() else {
+            vortex_bail!("the test validity must be partially valid");
+        };
         let mut ctx = array_session().create_execution_ctx();
 
         let result = execute_sink_valid_rows::<(i64,), (), ShrinkingSink, (), EmptyOptions>(
             &args,
-            &valid,
+            valid,
             &mut ctx,
             |_| (),
             |_, (value,), output| {

--- a/vortex-array/src/scalar_fn/unstable/row/execute/sink.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/execute/sink.rs
@@ -11,7 +11,7 @@ use vortex_buffer::BitBuffer;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure_eq;
-use vortex_mask::MaskValues;
+use vortex_mask::MaskValuesRef;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
@@ -101,7 +101,7 @@ where
 /// how to handle the decline.
 pub(crate) fn execute_sink_valid_rows<Args, Prepared, Sink, ApplyResult, Options>(
     args: &dyn ExecutionArgs,
-    valid: &MaskValues,
+    valid: &MaskValuesRef,
     ctx: &mut ExecutionCtx,
     prepare: impl FnOnce(Args::ConstElems<'_>) -> Prepared,
     apply: impl Fn(&Prepared, Args::Elems<'_>, <Sink as OutputSink<Options>>::Row<'_>) -> ApplyResult,
@@ -208,7 +208,7 @@ where
 /// Resolve the capabilities, inputs, sink, and validity mask for skip-invalid execution.
 fn setup_sink_valid_rows<'valid, Args, Sink, Options>(
     args: &dyn ExecutionArgs,
-    valid: &'valid MaskValues,
+    valid: &'valid MaskValuesRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ValidRowsSetup<'valid, Args, Sink, Options>>>
 where
@@ -341,15 +341,14 @@ mod tests {
     fn test_non_skipping_sink_declines_before_allocation() -> VortexResult<()> {
         let input = PrimitiveArray::new(vec![1_i64, 2], Validity::NonNullable).into_array();
         let args = VecExecutionArgs::new(vec![input], 2);
-        let valid_mask = Mask::from_iter([true, false]);
-        let Some(valid) = valid_mask.values() else {
+        let Mask::Values(valid) = Mask::from_iter([true, false]) else {
             vortex_bail!("the test validity must be partially valid");
         };
         let mut ctx = array_session().create_execution_ctx();
 
         let execution = execute_sink_valid_rows::<(i64,), (), NonSkippingSink, (), EmptyOptions>(
             &args,
-            valid,
+            &valid,
             &mut ctx,
             |_| (),
             |_, _, _| (),
@@ -364,15 +363,14 @@ mod tests {
     fn test_skip_invalid_sink_rechecks_rows_after_initialization() -> VortexResult<()> {
         let input = PrimitiveArray::from_iter([10_i64, 20]).into_array();
         let args = VecExecutionArgs::new(vec![input], 2);
-        let valid_mask = Mask::from_iter([false, true]);
-        let Some(valid) = valid_mask.values() else {
+        let Mask::Values(valid) = Mask::from_iter([false, true]) else {
             vortex_bail!("the test validity must be partially valid");
         };
         let mut ctx = array_session().create_execution_ctx();
 
         let result = execute_sink_valid_rows::<(i64,), (), ShrinkingSink, (), EmptyOptions>(
             &args,
-            valid,
+            &valid,
             &mut ctx,
             |_| (),
             |_, (value,), output| {

--- a/vortex-array/src/scalar_fn/unstable/row/visitor/execute.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/visitor/execute.rs
@@ -8,7 +8,7 @@
 //! signature cannot execute over the original inputs.
 
 use vortex_error::VortexResult;
-use vortex_mask::Mask;
+use vortex_mask::MaskValues;
 
 use super::RowPolicy;
 use super::RowVisitor;
@@ -180,7 +180,7 @@ pub(crate) struct ExecuteValidRows<'args, 'ctx, F: RowFn> {
     policy: RowPolicy,
 
     /// The conjoined validity, containing both valid and invalid rows.
-    valid: &'args Mask,
+    valid: &'args MaskValues,
 
     /// The execution context used to decode the input columns.
     ctx: &'ctx mut ExecutionCtx,
@@ -193,7 +193,7 @@ impl<'args, 'ctx, F: RowFn> ExecuteValidRows<'args, 'ctx, F> {
         options: &'args F::Options,
         output_dtype: &'args DType,
         policy: RowPolicy,
-        valid: &'args Mask,
+        valid: &'args MaskValues,
         ctx: &'ctx mut ExecutionCtx,
     ) -> Self {
         Self {

--- a/vortex-array/src/scalar_fn/unstable/row/visitor/execute.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/visitor/execute.rs
@@ -8,7 +8,7 @@
 //! signature cannot execute over the original inputs.
 
 use vortex_error::VortexResult;
-use vortex_mask::MaskValues;
+use vortex_mask::MaskValuesRef;
 
 use super::RowPolicy;
 use super::RowVisitor;
@@ -180,7 +180,7 @@ pub(crate) struct ExecuteValidRows<'args, 'ctx, F: RowFn> {
     policy: RowPolicy,
 
     /// The conjoined validity, containing both valid and invalid rows.
-    valid: &'args MaskValues,
+    valid: MaskValuesRef,
 
     /// The execution context used to decode the input columns.
     ctx: &'ctx mut ExecutionCtx,
@@ -193,7 +193,7 @@ impl<'args, 'ctx, F: RowFn> ExecuteValidRows<'args, 'ctx, F> {
         options: &'args F::Options,
         output_dtype: &'args DType,
         policy: RowPolicy,
-        valid: &'args MaskValues,
+        valid: MaskValuesRef,
         ctx: &'ctx mut ExecutionCtx,
     ) -> Self {
         Self {
@@ -231,7 +231,11 @@ impl<F: RowFn> RowVisitor<F::Options> for ExecuteValidRows<'_, '_, F> {
         )?;
 
         execute_owned_infallible_valid_rows::<Args, Out, Prepared>(
-            self.args, self.valid, self.ctx, prepare, apply,
+            self.args,
+            &self.valid,
+            self.ctx,
+            prepare,
+            apply,
         )
     }
 
@@ -258,7 +262,11 @@ impl<F: RowFn> RowVisitor<F::Options> for ExecuteValidRows<'_, '_, F> {
         )?;
 
         execute_sink_valid_rows::<Args, Prepared, Sink, ApplyResult, F::Options>(
-            self.args, self.valid, self.ctx, prepare, apply,
+            self.args,
+            &self.valid,
+            self.ctx,
+            prepare,
+            apply,
         )
     }
 
@@ -283,7 +291,7 @@ impl<F: RowFn> RowVisitor<F::Options> for ExecuteValidRows<'_, '_, F> {
 
         execute_owned_valid_rows::<Args, Out, Prepared, Fail>(
             self.args,
-            self.valid,
+            &self.valid,
             self.ctx,
             prepare,
             apply,

--- a/vortex-array/src/scalar_fn/unstable/row/vtable.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/vtable.rs
@@ -10,7 +10,7 @@
 
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure_eq;
-use vortex_mask::Mask;
+use vortex_mask::MaskValues;
 use vortex_session::VortexSession;
 
 use super::batch::BorrowedRowFnArgs;
@@ -195,7 +195,7 @@ fn try_execute_valid_rows<F: RowFn>(
     function: &F,
     options: &F::Options,
     args: BorrowedRowFnArgs<'_>,
-    valid: &Mask,
+    valid: &MaskValues,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ArrayRef>> {
     function.dispatch(

--- a/vortex-array/src/scalar_fn/unstable/row/vtable.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/vtable.rs
@@ -10,7 +10,7 @@
 
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure_eq;
-use vortex_mask::MaskValues;
+use vortex_mask::MaskValuesRef;
 use vortex_session::VortexSession;
 
 use super::batch::BorrowedRowFnArgs;
@@ -195,7 +195,7 @@ fn try_execute_valid_rows<F: RowFn>(
     function: &F,
     options: &F::Options,
     args: BorrowedRowFnArgs<'_>,
-    valid: &MaskValues,
+    valid: MaskValuesRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ArrayRef>> {
     function.dispatch(

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -263,6 +263,11 @@ impl Validity {
         }
     }
 
+    /// Execute this validity into a [`Mask`] of the given length.
+    ///
+    /// Resolving [`Validity::Array`] can execute and scan up to `length` values. Optimistic fast
+    /// paths that do not need the exact mask should use [`Self::definitely_no_nulls`] or
+    /// [`Self::definitely_all_null`] and delay this work until necessary.
     #[inline]
     pub fn execute_mask(&self, length: usize, ctx: &mut ExecutionCtx) -> VortexResult<Mask> {
         match self {

--- a/vortex-mask/src/lib.rs
+++ b/vortex-mask/src/lib.rs
@@ -109,7 +109,7 @@ pub enum Mask {
     /// No values are included.
     AllFalse(usize),
     /// Some values are included, represented as a [`BitBuffer`].
-    Values(Arc<MaskValues>),
+    Values(MaskValuesRef),
 }
 
 impl Debug for Mask {
@@ -145,6 +145,9 @@ pub struct MaskValues {
     // i.e., the fraction of values that are true
     density: f64,
 }
+
+/// A shared reference to [`MaskValues`].
+pub type MaskValuesRef = Arc<MaskValues>;
 
 impl Debug for MaskValues {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
## Summary

- Tracking issue: #9128

Row batch execution resolves validity once, but the valid-row executors repeat the check that the materialized mask is partial. Array-backed validity stays lazy on optimistic paths because resolving it can execute and linearly scan the full mask for the uncommon all-valid and all-null cases.

## Changes

Matches the materialized `Mask` once and passes `MaskValues` through valid-row visitors, owned execution, and sink execution. Marks the all-null dense path as unreachable and documents the cost boundary on `Validity::execute_mask`.
