### PR TITLE
bench: track small u8 dictionary take

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9631,6 +9631,7 @@ dependencies = [
  "uuid",
  "vortex-array",
  "vortex-array-macros",
+ "vortex-bench-support",
  "vortex-buffer",
  "vortex-compute",
  "vortex-error",

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -97,6 +97,7 @@ vortex-array = { path = ".", features = [
     "table-display",
     "unstable_row_fns",
 ] }
+vortex-bench-support = { workspace = true }
 
 [[bench]]
 name = "aggregate_max"

--- a/vortex-array/benches/take_primitive.rs
+++ b/vortex-array/benches/take_primitive.rs
@@ -29,6 +29,9 @@ fn main() {
 /// Number of indices to take. The top tier is sized to keep CodSpeed simulation under 1ms.
 const NUM_INDICES: &[usize] = &[1_000, 10_000, 25_000];
 
+/// Large enough to measure both cache-resident and streaming dictionary decoding.
+const GT_NUM_INDICES: &[usize] = &[1_000_000, 16_000_000];
+
 /// Size of the source vector / dictionary values.
 const VECTOR_SIZE: &[usize] = &[16, 256, 2048, 8192];
 
@@ -87,6 +90,31 @@ fn dict_canonicalize_zipfian<const NUM_VALUES: usize>(bencher: Bencher, num_indi
     let dict = DictArray::try_new(codes.into_array(), values.into_array()).unwrap();
 
     bencher
+        .with_inputs(|| (&dict, SESSION.create_execution_ctx()))
+        .bench_refs(|(dict, ctx)| (*dict).clone().into_array().execute::<Canonical>(ctx));
+}
+
+/// StatPopGen GT distribution: 75.21% 0, 3.85% 1, 0.45% 2, and 20.49% null.
+#[vortex_bench_support::cpu_features]
+#[divan::bench(args = GT_NUM_INDICES)]
+fn dict_canonicalize_gt_u8(bencher: Bencher, num_indices: usize) {
+    let values = PrimitiveArray::from_option_iter([Some(0u8), Some(1), Some(2), None]);
+    let range = Uniform::new(0u16, 10_000).unwrap();
+    let codes = PrimitiveArray::from_iter(
+        StdRng::seed_from_u64(0)
+            .sample_iter(range)
+            .take(num_indices)
+            .map(|sample| match sample {
+                0..7521 => 0u8,
+                7521..7906 => 1,
+                7906..7951 => 2,
+                _ => 3,
+            }),
+    );
+    let dict = DictArray::try_new(codes.into_array(), values.into_array()).unwrap();
+
+    bencher
+        .counter(ItemsCount::new(num_indices))
         .with_inputs(|| (&dict, SESSION.create_execution_ctx()))
         .bench_refs(|(dict, ctx)| (*dict).clone().into_array().execute::<Canonical>(ctx));
 }


### PR DESCRIPTION
## Rationale

Establish a CodSpeed baseline for the low-cardinality dictionary case before adding the SIMD table kernel.

## Changes

- Add a deterministic StatPopGen GT-shaped dictionary with four entries: `0u8`, `1u8`, `2u8`, and fused null.
- Use `u8` dictionary codes at the observed GT frequencies.
- Measure 1M and 16M rows.
- Tag the case with `#[vortex_bench_support::cpu_features]`, routing it to the AVX2, AVX-512, and NEON wall-time legs instead of simulation.

This is the lower PR in a two-PR stack. The SIMD implementation is intentionally absent so this PR records the baseline.

## Checks

- `cargo check --locked -p vortex-array --bench take_primitive` in simulation routing
- `cargo check --locked -p vortex-array --bench take_primitive` with the NEON feature leg
- targeted Clippy with warnings denied
- `cargo +nightly fmt --all --check`
- `git diff --check`
