### PR TITLE
perf: vectorize small u8 table take with AVX2

### DIFF
--- a/vortex-array/src/arrays/fixed_width/take/mod.rs
+++ b/vortex-array/src/arrays/fixed_width/take/mod.rs
@@ -6,7 +6,11 @@ mod avx2;
 mod records;
 mod scalar;
 mod slices;
-#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+#[cfg(any(
+    all(target_arch = "aarch64", target_endian = "little"),
+    target_arch = "x86_64",
+    target_arch = "x86"
+))]
 mod small_table;
 #[cfg(test)]
 mod tests;
@@ -38,7 +42,11 @@ use crate::arrays::piecewise_sequence::constant_unsigned_usize;
 use crate::arrays::piecewise_sequence::maybe_contiguous_slices;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
-#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+#[cfg(any(
+    all(target_arch = "aarch64", target_endian = "little"),
+    target_arch = "x86_64",
+    target_arch = "x86"
+))]
 use crate::dtype::PType;
 use crate::dtype::UnsignedPType;
 use crate::dtype::half::f16;
@@ -86,6 +94,16 @@ pub(crate) fn take_values<T: FixedWidthTakeValue, I: UnsignedPType>(
 ) -> Buffer<T> {
     #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     if I::PTYPE == PType::U8 {
+        // SAFETY: the ptype dispatcher guarantees that `I::PTYPE == U8` is the concrete `u8`
+        // implementation, so these slices have identical layouts.
+        let indices = unsafe { std::slice::from_raw_parts(indices.as_ptr().cast(), indices.len()) };
+        if let Some(taken) = small_table::take(values, indices) {
+            return taken;
+        }
+    }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    if I::PTYPE == PType::U8 && *HAS_AVX2 {
         // SAFETY: the ptype dispatcher guarantees that `I::PTYPE == U8` is the concrete `u8`
         // implementation, so these slices have identical layouts.
         let indices = unsafe { std::slice::from_raw_parts(indices.as_ptr().cast(), indices.len()) };

--- a/vortex-array/src/arrays/fixed_width/take/small_table.rs
+++ b/vortex-array/src/arrays/fixed_width/take/small_table.rs
@@ -1,74 +1,159 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! NEON byte-table take for `u8` codes and at most 16 one-byte values.
+//! Byte-table take for `u8` codes and at most 16 one-byte values.
 
-use std::arch::aarch64::uint8x16_t;
-use std::arch::aarch64::vdupq_n_u8;
-use std::arch::aarch64::vld1q_u8;
-use std::arch::aarch64::vmaxq_u8;
-use std::arch::aarch64::vmaxvq_u8;
-use std::arch::aarch64::vqtbl1q_u8;
-use std::arch::aarch64::vst1q_u8;
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+mod arch {
+    use std::arch::aarch64::uint8x16_t;
+    use std::arch::aarch64::vdupq_n_u8;
+    use std::arch::aarch64::vld1q_u8;
+    use std::arch::aarch64::vmaxq_u8;
+    use std::arch::aarch64::vmaxvq_u8;
+    use std::arch::aarch64::vqtbl1q_u8;
+    use std::arch::aarch64::vst1q_u8;
 
-use vortex_buffer::Buffer;
-use vortex_buffer::BufferMut;
+    use vortex_buffer::Buffer;
+    use vortex_buffer::BufferMut;
 
-use super::FixedWidthTakeValue;
+    use super::super::FixedWidthTakeValue;
 
-pub(crate) fn take<T: FixedWidthTakeValue>(values: &[T], indices: &[u8]) -> Option<Buffer<T>> {
-    if values.is_empty() || values.len() > 16 || size_of::<T>() != 1 || indices.len() < 64 {
-        return None;
-    }
+    pub(crate) fn take<T: FixedWidthTakeValue>(values: &[T], indices: &[u8]) -> Option<Buffer<T>> {
+        if values.is_empty() || values.len() > 16 || size_of::<T>() != 1 || indices.len() < 64 {
+            return None;
+        }
 
-    let mut table = [0u8; 16];
-    // SAFETY: one-byte values have the same representation as bytes, and the length is <= 16.
-    unsafe {
-        std::ptr::copy_nonoverlapping(
-            values.as_ptr().cast::<u8>(),
-            table.as_mut_ptr(),
-            values.len(),
-        );
-    }
+        let mut table = [0u8; 16];
+        // SAFETY: one-byte values have the same representation as bytes, and the length is <= 16.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                values.as_ptr().cast::<u8>(),
+                table.as_mut_ptr(),
+                values.len(),
+            );
+        }
 
-    let mut output = BufferMut::<T>::with_capacity(indices.len());
-    let output_ptr = output.spare_capacity_mut().as_mut_ptr().cast::<u8>();
-    // SAFETY: AArch64 always provides NEON. Both pointers advance only by complete vectors.
-    let (offset, max_code) = unsafe { take_vectors(&table, indices, output_ptr) };
+        let mut output = BufferMut::<T>::with_capacity(indices.len());
+        let output_ptr = output.spare_capacity_mut().as_mut_ptr().cast::<u8>();
+        // SAFETY: AArch64 always provides NEON. Both pointers advance only by complete vectors.
+        let (offset, max_code) = unsafe { take_vectors(&table, indices, output_ptr) };
 
-    for offset in offset..indices.len() {
-        let code = usize::from(indices[offset]);
+        for offset in offset..indices.len() {
+            let code = usize::from(indices[offset]);
+            assert!(
+                code < values.len(),
+                "take index {code} out of bounds for length {}",
+                values.len()
+            );
+            // SAFETY: the code was checked and this reserved output position is uninitialized.
+            unsafe {
+                output_ptr
+                    .add(offset)
+                    .write(*values.as_ptr().add(code).cast::<u8>())
+            };
+        }
         assert!(
-            code < values.len(),
-            "take index {code} out of bounds for length {}",
+            usize::from(max_code) < values.len(),
+            "take index {max_code} out of bounds for length {}",
             values.len()
         );
-        // SAFETY: the code was checked and this reserved output position is uninitialized.
-        unsafe {
-            output_ptr
-                .add(offset)
-                .write(*values.as_ptr().add(code).cast::<u8>())
-        };
+        // SAFETY: the vector loop and scalar remainder initialized every output value.
+        unsafe { output.set_len(indices.len()) };
+        Some(output.freeze())
     }
-    assert!(
-        usize::from(max_code) < values.len(),
-        "take index {max_code} out of bounds for length {}",
-        values.len()
-    );
-    // SAFETY: the vector loop and scalar remainder initialized every output value.
-    unsafe { output.set_len(indices.len()) };
-    Some(output.freeze())
+
+    unsafe fn take_vectors(table: &[u8; 16], indices: &[u8], output: *mut u8) -> (usize, u8) {
+        let table = unsafe { vld1q_u8(table.as_ptr()) };
+        let mut max_codes: uint8x16_t = unsafe { vdupq_n_u8(0) };
+        let mut offset = 0;
+        while offset + 16 <= indices.len() {
+            let codes = unsafe { vld1q_u8(indices.as_ptr().add(offset)) };
+            max_codes = unsafe { vmaxq_u8(max_codes, codes) };
+            unsafe { vst1q_u8(output.add(offset), vqtbl1q_u8(table, codes)) };
+            offset += 16;
+        }
+        (offset, unsafe { vmaxvq_u8(max_codes) })
+    }
 }
 
-unsafe fn take_vectors(table: &[u8; 16], indices: &[u8], output: *mut u8) -> (usize, u8) {
-    let table = unsafe { vld1q_u8(table.as_ptr()) };
-    let mut max_codes: uint8x16_t = unsafe { vdupq_n_u8(0) };
-    let mut offset = 0;
-    while offset + 16 <= indices.len() {
-        let codes = unsafe { vld1q_u8(indices.as_ptr().add(offset)) };
-        max_codes = unsafe { vmaxq_u8(max_codes, codes) };
-        unsafe { vst1q_u8(output.add(offset), vqtbl1q_u8(table, codes)) };
-        offset += 16;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+mod arch {
+    use std::arch::x86_64::__m256i;
+    use std::arch::x86_64::_mm_loadu_si128;
+    use std::arch::x86_64::_mm256_broadcastsi128_si256;
+    use std::arch::x86_64::_mm256_loadu_si256;
+    use std::arch::x86_64::_mm256_or_si256;
+    use std::arch::x86_64::_mm256_set1_epi8;
+    use std::arch::x86_64::_mm256_setzero_si256;
+    use std::arch::x86_64::_mm256_shuffle_epi8;
+    use std::arch::x86_64::_mm256_storeu_si256;
+    use std::arch::x86_64::_mm256_subs_epu8;
+    use std::arch::x86_64::_mm256_testz_si256;
+
+    use vortex_buffer::Buffer;
+    use vortex_buffer::BufferMut;
+
+    use super::super::FixedWidthTakeValue;
+
+    pub(crate) fn take<T: FixedWidthTakeValue>(values: &[T], indices: &[u8]) -> Option<Buffer<T>> {
+        if values.is_empty() || values.len() > 16 || size_of::<T>() != 1 || indices.len() < 64 {
+            return None;
+        }
+        // SAFETY: the caller detects AVX2 before entering this architecture-specific module.
+        Some(unsafe { take_avx2(values, indices) })
     }
-    (offset, unsafe { vmaxvq_u8(max_codes) })
+
+    #[target_feature(enable = "avx2")]
+    unsafe fn take_avx2<T: FixedWidthTakeValue>(values: &[T], indices: &[u8]) -> Buffer<T> {
+        let mut table = [0u8; 16];
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                values.as_ptr().cast::<u8>(),
+                table.as_mut_ptr(),
+                values.len(),
+            );
+        }
+        let table = unsafe { _mm_loadu_si128(table.as_ptr().cast()) };
+        let table = _mm256_broadcastsi128_si256(table);
+        let limit = _mm256_set1_epi8((values.len() - 1) as i8);
+        let mut invalid = _mm256_setzero_si256();
+        let mut output = BufferMut::<T>::with_capacity(indices.len());
+        let output_ptr = output.spare_capacity_mut().as_mut_ptr().cast::<u8>();
+
+        let mut offset = 0;
+        while offset + 32 <= indices.len() {
+            let codes = unsafe { _mm256_loadu_si256(indices.as_ptr().add(offset).cast()) };
+            invalid = _mm256_or_si256(invalid, _mm256_subs_epu8(codes, limit));
+            unsafe {
+                _mm256_storeu_si256(
+                    output_ptr.add(offset).cast::<__m256i>(),
+                    _mm256_shuffle_epi8(table, codes),
+                )
+            };
+            offset += 32;
+        }
+        assert_eq!(
+            _mm256_testz_si256(invalid, invalid),
+            1,
+            "take index out of bounds"
+        );
+
+        for offset in offset..indices.len() {
+            let code = usize::from(indices[offset]);
+            assert!(
+                code < values.len(),
+                "take index {code} out of bounds for length {}",
+                values.len()
+            );
+            unsafe {
+                output_ptr
+                    .add(offset)
+                    .write(*values.as_ptr().add(code).cast::<u8>())
+            };
+        }
+        unsafe { output.set_len(indices.len()) };
+        output.freeze()
+    }
 }
+
+pub(super) use arch::take;


### PR DESCRIPTION
## Rationale

Add the x86 table-lookup implementation after the NEON implementation in #9571.

This is the upper PR in the stack: #9566 (benchmark) → #9571 (NEON) → this PR (AVX2).

## Changes

- Use AVX2 `VPSHUFB` on x86/x86-64.
- Apply the path to `u8` codes, at most 16 one-byte values, and at least 64 rows.
- Retain runtime AVX2 detection, bounds checks, and the existing general AVX2/scalar fallbacks.

## CodSpeed wall-time results

Medians over 1,000 samples on the same Sapphire Rapids metal family, compared with #9566:

| Build | Rows | Baseline | AVX2 table | Speedup | Time reduction |
|---|---:|---:|---:|---:|---:|
| AVX2 | 1M | 428.1 µs | 61.12 µs | **7.00×** | **85.7%** |
| AVX2 | 16M | 6.809 ms | 1.361 ms | **5.00×** | **80.0%** |
| AVX-512 | 1M | 426.5 µs | 59.28 µs | **7.19×** | **86.1%** |
| AVX-512 | 16M | 6.778 ms | 1.358 ms | **4.99×** | **80.0%** |

The AVX-512 leg is an AVX-512-enabled whole-crate build executing this AVX2 `VPSHUFB` kernel; there is no separate AVX-512 table kernel.

Runs: [baseline](https://github.com/vortex-data/vortex/actions/runs/32718822097), [optimized](https://github.com/vortex-data/vortex/actions/runs/32718838970).

## Validation

- 3,352 `vortex-array` tests passed; 1 skipped
- targeted Clippy passed
- x86-64 cross-check passed
- formatting and diff checks passed
