### PR TITLE
duckdb: add release docs

### DIFF
--- a/docs/user-guide/duckdb.md
+++ b/docs/user-guide/duckdb.md
@@ -1,39 +1,36 @@
 # DuckDB
 
 Vortex [extension](https://duckdb.org/docs/stable/core_extensions/vortex) is
-available from DuckDB 1.4.2+ on Linux and macOS (amd64, arm64).
+available from DuckDB 1.4.2+ on Linux and macOS (amd64, arm64). Windows support
+[is planned](https://github.com/vortex-data/vortex/issues/9569).
 
 ## Setup
 
 ```sql
-INSTALL vortex;
-LOAD vortex;
+INSTALL vortex; LOAD vortex;
 ```
 
 ## Reading files
 
 ```sql
 SELECT * FROM 'data.vortex';
-```
-
-Filters and projections are pushed down into Vortex, so only the columns and rows needed by the
-query are read and decompressed.
-
-```sql
-SELECT name, age FROM 'data.vortex' WHERE age > 30;
+# this syntax supports arguments like hive_partitioning=true
+SELECT * FROM read_vortex('data.vortex');
 ```
 
 ## Writing files
-
-Export data to Vortex using the `COPY` statement.
 
 ```sql
 COPY (SELECT * FROM my_table) TO 'output.vortex';
 ```
 
-## Python
+Make sure to call `LOAD vortex` before writing any files. Duckdb writes CSV
+files by default, so if Vortex extension wasn't loaded prior to `COPY`,
+`output.vortex` will be a CSV file. If you want to prevent this from happening,
+you can use `COPY ... TO 'output.vortex' (FORMAT vortex)` syntax instead which
+will fail if Vortex is not loaded.
 
-The DuckDB Python client works the same way:
+## Python client
 
 ```python
 import duckdb
@@ -43,4 +40,34 @@ duckdb.sql("LOAD vortex")
 
 result = duckdb.sql("SELECT * FROM 'data.vortex' WHERE age > 30")
 result.show()
+```
+
+## Object storage secrets
+
+Vortex does not use DuckDB's secret storage. It uses environment variables via
+[`object_store`](https://docs.rs/object_store/latest/object_store) instead.
+
+If you want to read or write from an [S3
+bucket](https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html),
+set the following variables:
+
+```sh
+export AWS_ACCESS_KEY_ID="your_access_key"
+export AWS_SECRET_ACCESS_KEY="your_secret_key"
+export AWS_REGION="your_bucket_region"
+```
+
+For [Google Cloud Storage](https://docs.rs/object_store/latest/object_store/gcp/struct.GoogleCloudStorageBuilder.html),
+use a key file variable:
+
+```sh
+export GOOGLE_APPLICATION_CREDENTIALS="my service account JSON key file"
+```
+
+For [Azure Blob Storage](https://docs.rs/object_store/latest/object_store/azure/struct.MicrosoftAzureBuilder.html),
+use
+
+```sh
+export AZURE_STORAGE_ACCOUNT="my account"
+export AZURE_STORAGE_KEY="my key"
 ```

--- a/vortex-duckdb/README.md
+++ b/vortex-duckdb/README.md
@@ -1,80 +1,74 @@
-# Vortex DuckDB
+# DuckDB extension for Vortex
 
-Rust bindings for DuckDB. Supports DuckDB precompiled libraries for fast builds and from source builds for debugging.
+User documentation is on the [docs website](https://docs.vortex.dev/user-guide/duckdb).
 
-## Prerequisites
+## Build
 
-- **Ninja**: `brew install ninja` (macOS) | `apt-get install ninja-build` (Ubuntu)
-- **CMake**: `brew install cmake` (macOS) | `apt-get install cmake` (Ubuntu)
-- **C++20 compatible compiler**: GCC or Clang
+Install `ninja`, `cmake`, and a C++20 compiler.
 
-## Build Modes
+- For debug builds, launch `VX_DUCKDB_DEBUG=1 cargo build -p vortex-duckdb`.
+- For ASAN/TSAN builds, launch `VX_DUCKDB_DEBUG=1 VX_DUCKDB_SAN=1 cargo build -p
+  vortex-duckdb`.
+- For builds against a custom DuckDB tag or commit, change `build.rs`'s
+  `DEFAULT_DUCKDB_VERSION`.
 
-### Default (Release)
+## Test
 
-Link against the precompiled DuckDB release build.
+Our sqllogic tests use a build which links against `libduckdb.so`. This means
+you don't get an extension file to load in DuckDB. If you want to test just
+sqllogic, run `cargo test -p vortex-sqllogictest --test sqllogictests`. If you
+want to test a full setup,
 
-```bash
-cargo build -p vortex-duckdb
-```
+1. Clone [duckdb-vortex](https://github.com/vortex-data/duckdb-vortex).
+2. Update duckdb-vortex's submodules. Update vortex reference in duckdb-vortex's
+   `vortex-extension/Cargo.toml` with this Vortex checkout.
+4. Inside duckdb-vortex, run `make reldebug -j`.
 
-### Debug Build
+`./build/reldebug/duckdb` will be a DuckDB shell with Vortex linked statically.
 
-Opt into DuckDB debug build: `VX_DUCKDB_DEBUG=1`.
+## Update extension with same DuckDB version
 
-```bash
-VX_DUCKDB_DEBUG=1 cargo build -p vortex-duckdb
-```
+1. Merge the PR with your changes, if any.
+2. Make a new Vortex release.
+3. Get the commit of the release, i.e.
+   `afb005379dd9a1b7dc7ae2cb49f4f465d91cc2b3` is the commit for
+   [0.85](https://github.com/vortex-data/vortex/releases/tag/0.85.0).
+4. In duckdb-vortex, update vortex reference in `vortex-extension/Cargo.toml` to
+   the release commit hash.
+5. Open a PR in duckdb-vortex, check the tests and merge it.
+6. Ensure the PR has been backported to the current release branch, i.e. for
+   duckdb 1.5.* the release branch is
+   [v1.5-variegata](https://github.com/vortex-data/duckdb-vortex/tree/v1.5-variegata).
+   This should happen automatically.
+7. Notify DuckDB maintainers in the Discord `#spiraldb` channel of the new
+   commit and ask to update the extension version. This will likely take some
+   days since they need to bump the extension version, trigger a deploy job and
+   update the artifacts on their website. Provide the commit in duckdb-vortex's
+   release branch, i.e.
+   [`5390e62`](https://github.com/vortex-data/duckdb-vortex/commit/5390e6270da964f04afbd6df4a5c9bc83a2e7880).
+8. Check `UPDATE EXTENSIONS; INSTALL vortex; LOAD vortex` in your local duckdb
+   loads the latest version.
 
-### AddressSanitizer & ThreadSanitizer
+## Update duckdb version
 
-Enable both ASAN & TSAN: `VX_DUCKDB_SAN=1`.
+- Update the version in `build.rs`'s `DEFAULT_DUCKDB_VERSION`.
+- Create a PR with your changes and ensure it builds. Merge the PR. If your PR
+  is for a pre-release build, CI will build DuckDB from source and upload the
+  artifacts to R2 so you can reuse them locally.
+- Create a new Vortex release.
+- In duckdb-vortex, change all occurrences of old version to the new version. See
+  [1.5.5](https://github.com/vortex-data/duckdb-vortex/pull/105/changes) upgrade
+  as an example.
+- In duckdb-vortex, upgrade submodules to the new version.
+- Follow from step (3) in extension update plan.
 
-```bash
-VX_DUCKDB_DEBUG=1 VX_DUCKDB_SAN=1 cargo build -p vortex-duckdb
-```
+## Build artifacts storage
 
-## Environment Variables
+CI uses duckdb prebuilt (`.so/.a/.dylib`) artifacts from Github releases.
+However, release downloads from Github are very unstable, and we're observed a
+~25% build rate failure when doing so. Thus we mirror release archives to R2.
 
-| Variable          | Effect                          |
-| ----------------- | ------------------------------- |
-| `VX_DUCKDB_DEBUG` | Build from source in debug mode |
-| `VX_DUCKDB_ASAN`  | Enable AddressSanitizer         |
-
-## Running Tests
-
-```bash
-# By default, link against the precompiled DuckDB release build.
-cargo test -p vortex-duckdb
-
-# Link against the DuckDB debug build from source.
-VX_DUCKDB_DEBUG=1 cargo test -p vortex-duckdb
-
-# Link against the DuckDB debug build from source with ASAN & TSAN.
-ASAN_OPTIONS=detect_container_overflow=0 VX_DUCKDB_DEBUG=1 VX_DUCKDB_SAN=1 cargo test -p vortex-duckdb
-```
-
-## Testing the extension with DuckDB
-
-By default, our tests use a precompiled build which means you don't get an
-.extension which you can load in DuckDB. If you want to test a full setup,
-
-1. Clone [duckdb-vortex](https://github.com/vortex-data/duckdb-vortex)
-   repository.
-
-2. If there is an api difference between duckdb-vortex's duckdb submodule and
-   vortex's vortex-duckdb/duckdb submodule, checkout duckdb-vortex to previous
-   commit. For example, if duckdb-vortex's HEAD uses 1.6 API but vortex's HEAD
-   uses 1.5.2, checkout duckdb-vortex at 8a41ee6ebd9.
-
-3. Update duckdb-vortex's submodules. Replace vortex/ submodule by a softlink to
-   your local vortex repository.
-4. Inside duckdb-vortex, run make -j.
-
-./target/release/duckdb will be a duckdb instance with vortex-duckdb already
-loaded.
-
-## Testing a custom DuckDB tag
-
-Change `DUCKDB_VERSION` environment variable value to a preferred hash or commit
-(local build), or change build.rs (for testing in CI).
+A job is triggered on every PR which checks artifacts are present in R2, and if
+they aren't, tries to mirror them from DuckDB Github releases via a deployment
+request. If `DEFAULT_DUCKDB_VERSION` is a hash and files weren't present, the
+job builds DuckDB from source and uploads the artifacts to R2 as well.


### PR DESCRIPTION
- Add release and upgrade docs for maintainers.
- Add object store auth section in user docs.

Resolves: #9487
