### PR TITLE
chore(deps): raise the pco floor to 1.0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,7 +209,7 @@ parquet = "58.3"
 parquet-variant = "58.3"
 parquet-variant-compute = "58.3"
 paste = "1.0.15"
-pco = "1.0.1"
+pco = "1.0.3"
 percent-encoding = "2.3.2"
 pin-project-lite = "0.2.15"
 primitive-types = { version = "0.14.0" }


### PR DESCRIPTION
## Summary

The workspace declares `pco = "1.0.1"`, but the caret requirement means `Cargo.lock` has resolved 1.0.3 since it was published — every build and CI run already compiles against 1.0.3. This raises the declared floor to match what is actually built and tested, so the manifest stops advertising support for a version nothing exercises.

1.0.2 and 1.0.3 harden the decoder against corrupt and hostile input: upstream added a mutation-based test suite (`src/tests/corruption.rs`) covering single-bit flips and headers whose declared sizes are not backed by any data, with the contract that the decoder returns a `PcoError` rather than panicking or allocating on an unearned length. Vortex decodes Pco blocks straight out of files it does not control, so that floor is worth stating rather than leaving to lockfile resolution.

Split out of #9582 so the dependency change lands on its own; #9582 is now stacked on this branch and carries the 8-bit ptype support.

## Changes

- `Cargo.toml`: `pco = "1.0.1"` → `pco = "1.0.3"`.

`Cargo.lock` is unchanged — it already points at 1.0.3, so this is a no-op for the resolved dependency graph and cannot change compressed output.

Checks: `cargo check -p vortex-pco --all-features`, and `cargo test -p vortex-pco -p vortex-btrblocks --all-features` (all pass) on the stacked branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiRWxgc6LRj1Zds26bQSds)_