### PR TITLE
Benchmark primitive comparison across CPU features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9631,6 +9631,7 @@ dependencies = [
  "uuid",
  "vortex-array",
  "vortex-array-macros",
+ "vortex-bench-support",
  "vortex-buffer",
  "vortex-compute",
  "vortex-error",

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -97,6 +97,7 @@ vortex-array = { path = ".", features = [
     "table-display",
     "unstable_row_fns",
 ] }
+vortex-bench-support = { workspace = true }
 
 [[bench]]
 name = "aggregate_max"

--- a/vortex-array/benches/compare.rs
+++ b/vortex-array/benches/compare.rs
@@ -1,9 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+//! Benchmarks for the binary comparison path, over every array kind it accepts.
+//!
+//! `compare_int_constant_left`, `compare_u8`, `compare_u64`, and `compare_f32` carry
+//! `#[cpu_features]`, so they are measured on every walltime CPU-feature leg rather than in
+//! simulation. Each is written once and compiled differently per leg: today the primitive
+//! comparison path is a portable lane kernel, and how well it auto-vectorizes is decided by
+//! the build. That is the baseline a hand-written kernel selected through
+//! `cfg(target_feature)` has to beat, measured on the silicon it would run on.
+
 #![expect(clippy::unwrap_used)]
 
 use divan::Bencher;
+use divan::counter::ItemsCount;
 use mimalloc::MiMalloc;
 use rand::RngExt;
 use rand::SeedableRng;
@@ -38,7 +48,10 @@ const ARRAY_SIZE: usize = 8_192;
 
 fn bench_compare(bencher: Bencher, lhs: ArrayRef, rhs: ArrayRef, op: Operator) {
     let session = vortex_array::array_session();
+    let len = lhs.len();
+
     bencher
+        .counter(ItemsCount::new(len))
         .with_inputs(|| (&lhs, &rhs, session.create_execution_ctx()))
         .bench_refs(|input| {
             input
@@ -84,6 +97,27 @@ fn int_array_nullable(rng: &mut StdRng) -> ArrayRef {
 fn float_array(rng: &mut StdRng) -> ArrayRef {
     (0..ARRAY_SIZE)
         .map(|_| rng.random_range(0.0f64..1.0))
+        .collect::<Buffer<_>>()
+        .into_array()
+}
+
+fn u8_array(rng: &mut StdRng) -> ArrayRef {
+    (0..ARRAY_SIZE)
+        .map(|_| rng.random::<u8>())
+        .collect::<Buffer<_>>()
+        .into_array()
+}
+
+fn u64_array(rng: &mut StdRng) -> ArrayRef {
+    (0..ARRAY_SIZE)
+        .map(|_| rng.random::<u64>())
+        .collect::<Buffer<_>>()
+        .into_array()
+}
+
+fn f32_array(rng: &mut StdRng) -> ArrayRef {
+    (0..ARRAY_SIZE)
+        .map(|_| rng.random_range(0.0f32..1.0))
         .collect::<Buffer<_>>()
         .into_array()
 }
@@ -152,6 +186,42 @@ fn compare_int_constant(bencher: Bencher) {
     let arr = int_array(&mut rng);
     let constant = ConstantArray::new(50_000_000i64, ARRAY_SIZE).into_array();
     bench_compare(bencher, arr, constant, Operator::Gte);
+}
+
+#[vortex_bench_support::cpu_features]
+#[divan::bench]
+fn compare_int_constant_left(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(0);
+    let constant = ConstantArray::new(50_000_000i64, ARRAY_SIZE).into_array();
+    let arr = int_array(&mut rng);
+    bench_compare(bencher, constant, arr, Operator::Lte);
+}
+
+#[vortex_bench_support::cpu_features]
+#[divan::bench]
+fn compare_u8(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(0);
+    let arr1 = u8_array(&mut rng);
+    let arr2 = u8_array(&mut rng);
+    bench_compare(bencher, arr1, arr2, Operator::Gte);
+}
+
+#[vortex_bench_support::cpu_features]
+#[divan::bench]
+fn compare_u64(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(0);
+    let arr1 = u64_array(&mut rng);
+    let arr2 = u64_array(&mut rng);
+    bench_compare(bencher, arr1, arr2, Operator::Gte);
+}
+
+#[vortex_bench_support::cpu_features]
+#[divan::bench]
+fn compare_f32(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(0);
+    let arr1 = f32_array(&mut rng);
+    let arr2 = f32_array(&mut rng);
+    bench_compare(bencher, arr1, arr2, Operator::Gte);
 }
 
 #[divan::bench]


### PR DESCRIPTION
## Summary

The measurement half of #9587, split out so the numbers land before the kernels do.

Bottom of a three-PR stack: this PR, then #9599, then #9587. Tagging these with `#[cpu_features]` first means the walltime legs record the portable lane kernel's throughput on `avx2`, `avx512`, and `neon` metal as a baseline series. The kernel PR then reports against it rather than introducing both the benchmark and the thing it measures in one diff.

## Changes

- Adds the primitive comparison cases a hand-written SIMD kernel would have to beat: constant on the left, `u8`, `u64`, and `f32`.
- Tags those four with `#[cpu_features]`, so each walltime leg measures them under its own build flags instead of in simulation. The existing cases are untouched and keep their simulation series.
- `bench_compare` now carries an `ItemsCount`, so the report reads as throughput rather than a time that only means something next to another run over the same array length.
- Adds module docs recording why these four are tagged and the rest are not.