### PR TITLE
Add compression diff viewer to Vortex Web

### DIFF
--- a/vortex-web/README.md
+++ b/vortex-web/README.md
@@ -14,6 +14,44 @@ A web UI for exploring Vortex data files, built with React, TypeScript, Tailwind
 npm install
 ```
 
+## Comparing compression output
+
+Open the candidate `.vortex` file, select **Compare…** in the header, and choose the previous
+version of the same file. The Compare view shows whole-file, data, and metadata byte deltas and
+then aligns the layout and array-encoding trees to explain where those bytes changed.
+
+The tree comparison is semantic rather than a diff of rendered labels. Layout siblings are
+matched by field name, chunk row range, or named transparent/auxiliary role. Array children use
+their encoding-provided child names, with their stable child position as a fallback for serialized
+trees that do not carry names. This makes an inserted field an addition instead of making every
+following field look modified.
+
+To open a comparison directly, use the compare hash route with URL-encoded remote file URLs:
+
+```text
+https://explorer.example/#/compare?baseline=https%3A%2F%2Fdata.example%2Fbefore.vortex&candidate=https%3A%2F%2Fdata.example%2Fafter.vortex
+```
+
+An individual file can also be opened directly:
+
+```text
+https://explorer.example/#/file?url=https%3A%2F%2Fdata.example%2Foutput.vortex
+```
+
+URLs may be absolute HTTP(S) URLs or paths relative to the Explorer deployment. From the Compare
+view, either file can be opened in the regular Details and Swimlane views or replaced with another
+local file to recalculate the diff.
+
+The hash route does not require server-side routing, so the Explorer remains a static application:
+the browser fetches both files and opens them in the existing Web Workers. Each file host must
+permit browser access with CORS. Local files still need to be selected manually because browsers
+do not allow a page to read arbitrary local paths.
+
+Use `compress-bench --ingest-jsonl <path>` for repeatable encode/decode timing and file-size
+measurements. The Explorer comparison complements those aggregate measurements: it compares the
+actual output files and attributes size changes to layout and encoding nodes. Compare files made
+from identical logical input; the UI warns when row counts or schemas differ.
+
 ### Full App (requires Rust + wasm-pack)
 
 ```bash

--- a/vortex-web/crate/src/array_tree_json.rs
+++ b/vortex-web/crate/src/array_tree_json.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex::array::ArrayRef;
+use vortex::array::display::ArrayTreeEvent;
+use vortex::array::display::walk_array_tree;
+use vortex::array::session::ArraySessionExt;
+use vortex::session::VortexSession;
+
+trait TraversalObserver {
+    fn enter(&self, _array: &ArrayRef) {}
+    fn exit(&self, _array: &ArrayRef) {}
+}
+
+impl TraversalObserver for () {}
+
+/// Stream an array encoding tree directly to JSON in one depth-first traversal.
+///
+/// Each `ArrayTreeNode` is written before its children are visited. No recursive JSON model is
+/// constructed, and the array's child iterator is consumed exactly once per node.
+#[cfg(target_arch = "wasm32")]
+pub(super) fn write_array_encoding_tree_json(
+    array: &ArrayRef,
+    session: &VortexSession,
+) -> serde_json::Result<String> {
+    write_array_encoding_tree_json_with_observer(array, session, &())
+}
+
+fn write_array_encoding_tree_json_with_observer(
+    array: &ArrayRef,
+    session: &VortexSession,
+    observer: &impl TraversalObserver,
+) -> serde_json::Result<String> {
+    let mut output = Vec::new();
+
+    walk_array_tree(array, |event| -> serde_json::Result<()> {
+        match event {
+            ArrayTreeEvent::Enter {
+                name,
+                node,
+                depth,
+                is_first,
+                ..
+            } => {
+                let array = node.array();
+                observer.enter(array);
+                if depth > 0 && !is_first {
+                    output.extend_from_slice(b",");
+                }
+
+                let name = if depth == 0 { "array" } else { name };
+                let encoding = array.encoding_id().to_string();
+                let dtype = array.dtype().to_string();
+                let buffer_names = array.buffer_names();
+                let buffer_handles = array.buffer_handles();
+                let buffer_lengths: Vec<usize> =
+                    buffer_handles.iter().map(|buffer| buffer.len()).collect();
+                let metadata_bytes = session
+                    .array_serialize(array)
+                    .ok()
+                    .flatten()
+                    .map(|metadata| metadata.len())
+                    .unwrap_or(0);
+
+                output.extend_from_slice(b"{\"name\":");
+                serde_json::to_writer(&mut output, name)?;
+                output.extend_from_slice(b",\"encoding\":");
+                serde_json::to_writer(&mut output, &encoding)?;
+                output.extend_from_slice(b",\"dtype\":");
+                serde_json::to_writer(&mut output, &dtype)?;
+                output.extend_from_slice(b",\"metadataBytes\":");
+                serde_json::to_writer(&mut output, &metadata_bytes)?;
+                output.extend_from_slice(b",\"numBuffers\":");
+                serde_json::to_writer(&mut output, &buffer_lengths.len())?;
+                output.extend_from_slice(b",\"bufferLengths\":");
+                serde_json::to_writer(&mut output, &buffer_lengths)?;
+                output.extend_from_slice(b",\"bufferNames\":");
+                serde_json::to_writer(&mut output, &buffer_names)?;
+                output.extend_from_slice(b",\"children\":[");
+            }
+            ArrayTreeEvent::Exit { node, .. } => {
+                observer.exit(node.array());
+                output.extend_from_slice(b"]}");
+            }
+        }
+        Ok(())
+    })?;
+
+    // Every byte written above is either fixed UTF-8 syntax or emitted by serde_json.
+    String::from_utf8(output).map_err(<serde_json::Error as serde::ser::Error>::custom)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use serde_json::Value;
+    use vortex::VortexSessionDefault;
+    use vortex::array::IntoArray;
+    use vortex::array::arrays::StructArray;
+    use vortex::buffer::buffer;
+    use vortex::session::VortexSession;
+
+    use super::TraversalObserver;
+    use super::write_array_encoding_tree_json_with_observer;
+
+    #[derive(Default)]
+    struct CountingObserver {
+        enters: Cell<usize>,
+        exits: Cell<usize>,
+    }
+
+    impl TraversalObserver for CountingObserver {
+        fn enter(&self, _array: &vortex::array::ArrayRef) {
+            self.enters.set(self.enters.get() + 1);
+        }
+
+        fn exit(&self, _array: &vortex::array::ArrayRef) {
+            self.exits.set(self.exits.get() + 1);
+        }
+    }
+
+    #[test]
+    fn serializes_each_array_node_exactly_once() -> Result<(), Box<dyn std::error::Error>> {
+        let array = StructArray::from_fields(&[
+            ("x", buffer![1_i32, 2].into_array()),
+            ("y", buffer![3_i32, 4].into_array()),
+        ])?
+        .into_array();
+        let session = VortexSession::default();
+        let observer = CountingObserver::default();
+
+        let json = write_array_encoding_tree_json_with_observer(&array, &session, &observer)?;
+        let tree: Value = serde_json::from_str(&json)?;
+
+        assert_eq!(observer.enters.get(), 3);
+        assert_eq!(observer.exits.get(), 3);
+        assert_eq!(tree["name"], "array");
+        assert_eq!(tree["children"][0]["name"], "x");
+        assert_eq!(tree["children"][1]["name"], "y");
+        Ok(())
+    }
+}

--- a/vortex-web/crate/src/lib.rs
+++ b/vortex-web/crate/src/lib.rs
@@ -1,21 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-#![cfg(target_arch = "wasm32")]
-
 //! WASM bindings for the Vortex web explorer.
 //!
 //! Built with `wasm-pack build --target web` and consumed by the vortex-web frontend.
 
+#[cfg(any(target_arch = "wasm32", test))]
+mod array_tree_json;
+
+#[cfg(target_arch = "wasm32")]
 use std::sync::LazyLock;
 
+#[cfg(target_arch = "wasm32")]
 use vortex::VortexSessionDefault;
+#[cfg(target_arch = "wasm32")]
 use vortex::io::runtime::wasm::WasmRuntime;
+#[cfg(target_arch = "wasm32")]
 use vortex::io::session::RuntimeSessionExt;
+#[cfg(target_arch = "wasm32")]
 use vortex::session::VortexSession;
 
+#[cfg(target_arch = "wasm32")]
 mod wasm;
 
+#[cfg(target_arch = "wasm32")]
 static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
     let session = VortexSession::default().with_handle(WasmRuntime::handle());
     session.allow_unknown();

--- a/vortex-web/crate/src/wasm.rs
+++ b/vortex-web/crate/src/wasm.rs
@@ -18,12 +18,14 @@ use futures::FutureExt;
 use futures::TryStreamExt;
 use futures::future::BoxFuture;
 use serde::Serialize;
+use serde::Serializer;
+use serde::ser::SerializeSeq;
+use serde::ser::SerializeStruct;
 use vortex::array::ArrayRef;
 use vortex::array::VortexSessionExecute;
 use vortex::array::buffer::BufferHandle;
 use vortex::array::dtype::DType;
 use vortex::array::serde::SerializedArray;
-use vortex::array::session::ArraySessionExt;
 use vortex::array::stream::ArrayStream;
 use vortex::buffer::Alignment;
 use vortex::buffer::ByteBufferMut;
@@ -44,6 +46,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
 use crate::SESSION;
+use crate::array_tree_json::write_array_encoding_tree_json;
 
 /// Initialize the WASM module (sets up panic hook for better error messages).
 #[wasm_bindgen(start)]
@@ -370,8 +373,7 @@ impl VortexFileHandle {
             .decode(&dtype, row_count, ctx, &self.session)
             .map_err(|e| JsValue::from_str(&e.to_string()))?;
 
-        let tree = build_array_encoding_tree_from_array(&array, &self.session);
-        serde_json::to_string(&tree)
+        write_array_encoding_tree_json(&array, &self.session)
             .map_err(|e| JsValue::from_str(&format!("JSON serialization failed: {e}")))
     }
 
@@ -582,9 +584,11 @@ fn build_layout_tree(
     // For flat layouts, extract the array encoding tree if available.
     let array_encoding_tree = layout.as_opt::<Flat>().and_then(|flat| {
         let tree_buf = flat.array_tree()?;
-        let ctx = flat.array_ctx();
         let parts = SerializedArray::from_array_tree(tree_buf.as_ref().to_vec()).ok()?;
-        Some(build_array_encoding_tree(&parts, ctx))
+        Some(SerializedArrayEncodingTreeJson {
+            parts,
+            ctx: flat.array_ctx().clone(),
+        })
     });
 
     Ok(LayoutTreeNodeJson {
@@ -608,71 +612,6 @@ fn sum_metadata_bytes(layout: &LayoutRef) -> VortexResult<u64> {
         total += node?.metadata().len() as u64;
     }
     Ok(total)
-}
-
-/// Recursively build the array encoding tree from `ArrayParts` (used for inline trees
-/// where we don't have a fully decoded array).
-fn build_array_encoding_tree(parts: &SerializedArray, ctx: &ReadContext) -> ArrayEncodingNodeJson {
-    let encoding = ctx
-        .resolve(parts.encoding_id())
-        .map(|id| id.to_string())
-        .unwrap_or_else(|| format!("unknown({})", parts.encoding_id()));
-
-    let nchildren = parts.nchildren();
-    let children: Vec<ArrayEncodingNodeJson> = (0..nchildren)
-        .map(|i| build_array_encoding_tree(&parts.child(i), ctx))
-        .collect();
-
-    ArrayEncodingNodeJson {
-        encoding,
-        dtype: String::new(),
-        metadata_bytes: parts.metadata().len(),
-        num_buffers: parts.nbuffers(),
-        buffer_lengths: parts.buffer_lengths(),
-        buffer_names: Vec::new(),
-        children,
-        child_names: (0..nchildren).map(|i| format!("child {i}")).collect(),
-    }
-}
-
-/// Recursively build the array encoding tree from a fully decoded array,
-/// extracting dtype, child names, and buffer names from the encoding vtables.
-fn build_array_encoding_tree_from_array(
-    array: &ArrayRef,
-    session: &VortexSession,
-) -> ArrayEncodingNodeJson {
-    let encoding = array.encoding_id().to_string();
-    let dtype = array.dtype().to_string();
-    let buffer_names = array.buffer_names();
-    let buffer_handles = array.buffer_handles();
-    let buffer_lengths: Vec<usize> = buffer_handles.iter().map(|b| b.len()).collect();
-    let metadata_bytes = session
-        .array_serialize(array)
-        .ok()
-        .flatten()
-        .map(|m| m.len())
-        .unwrap_or(0);
-
-    let named_children = array.named_children();
-    let child_names: Vec<String> = named_children
-        .iter()
-        .map(|(name, _)| name.clone())
-        .collect();
-    let children: Vec<ArrayEncodingNodeJson> = named_children
-        .iter()
-        .map(|(_, child)| build_array_encoding_tree_from_array(child, session))
-        .collect();
-
-    ArrayEncodingNodeJson {
-        encoding,
-        dtype,
-        metadata_bytes,
-        num_buffers: buffer_lengths.len(),
-        buffer_lengths,
-        buffer_names,
-        children,
-        child_names,
-    }
 }
 
 /// Navigate the layout tree to find a node by its dot-separated ID path.
@@ -805,20 +744,90 @@ struct LayoutTreeNodeJson {
     child_type: ChildKindJson,
     children: Vec<LayoutTreeNodeJson>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    array_encoding_tree: Option<ArrayEncodingNodeJson>,
+    array_encoding_tree: Option<SerializedArrayEncodingTreeJson>,
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ArrayEncodingNodeJson {
-    encoding: String,
-    dtype: String,
-    metadata_bytes: usize,
-    num_buffers: usize,
-    buffer_lengths: Vec<usize>,
-    buffer_names: Vec<String>,
-    children: Vec<ArrayEncodingNodeJson>,
-    child_names: Vec<String>,
+/// A lazy JSON view over an inline serialized array tree.
+///
+/// `Serialize` recursively borrows one node at a time instead of constructing a second tree.
+struct SerializedArrayEncodingTreeJson {
+    parts: SerializedArray,
+    ctx: ReadContext,
+}
+
+impl Serialize for SerializedArrayEncodingTreeJson {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        SerializedArrayEncodingNodeJson {
+            name: "array",
+            parts: &self.parts,
+            ctx: &self.ctx,
+        }
+        .serialize(serializer)
+    }
+}
+
+struct SerializedArrayEncodingNodeJson<'a> {
+    name: &'a str,
+    parts: &'a SerializedArray,
+    ctx: &'a ReadContext,
+}
+
+impl Serialize for SerializedArrayEncodingNodeJson<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let encoding = self
+            .ctx
+            .resolve(self.parts.encoding_id())
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| format!("unknown({})", self.parts.encoding_id()));
+        let buffer_lengths = self.parts.buffer_lengths();
+        let mut state = serializer.serialize_struct("ArrayEncodingNode", 8)?;
+        state.serialize_field("name", self.name)?;
+        state.serialize_field("encoding", &encoding)?;
+        state.serialize_field("dtype", "")?;
+        state.serialize_field("metadataBytes", &self.parts.metadata().len())?;
+        state.serialize_field("numBuffers", &buffer_lengths.len())?;
+        state.serialize_field("bufferLengths", &buffer_lengths)?;
+        state.serialize_field("bufferNames", &[] as &[String])?;
+        state.serialize_field(
+            "children",
+            &SerializedArrayEncodingChildrenJson {
+                parts: self.parts,
+                ctx: self.ctx,
+            },
+        )?;
+        state.end()
+    }
+}
+
+struct SerializedArrayEncodingChildrenJson<'a> {
+    parts: &'a SerializedArray,
+    ctx: &'a ReadContext,
+}
+
+impl Serialize for SerializedArrayEncodingChildrenJson<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let child_count = self.parts.nchildren();
+        let mut children = serializer.serialize_seq(Some(child_count))?;
+        for index in 0..child_count {
+            let name = format!("child {index}");
+            let parts = self.parts.child(index);
+            children.serialize_element(&SerializedArrayEncodingNodeJson {
+                name: &name,
+                parts: &parts,
+                ctx: self.ctx,
+            })?;
+        }
+        children.end()
+    }
 }
 
 #[derive(Serialize, Clone)]

--- a/vortex-web/package-lock.json
+++ b/vortex-web/package-lock.json
@@ -13,7 +13,8 @@
         "apache-arrow": "^21.1.0",
         "d3-hierarchy": "^3.1.2",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^6.30.6"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -33,6 +34,7 @@
         "prettier": "^3.8.3",
         "storybook": "^10.3.5",
         "tailwindcss": "^4.2.4",
+        "tsx": "^4.21.0",
         "typescript": "~6.0.0",
         "typescript-eslint": "^8.59.0",
         "vite": "^8.0.10"
@@ -1779,6 +1781,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
+      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.2.4",
@@ -5194,6 +5205,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-router": {
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
+      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
+      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.4",
+        "react-router": "6.30.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/recast": {
       "version": "0.23.21",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.21.tgz",
@@ -5581,6 +5624,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/vortex-web/package.json
+++ b/vortex-web/package.json
@@ -8,12 +8,13 @@
     "wasm:release": "wasm-pack build crate --release --target web --out-dir ../src/wasm/pkg",
     "dev": "npm run wasm && vite",
     "build": "npm run wasm:release && tsc -b && vite build",
-    "check": "npm run wasm && npm run lint && npm run typecheck",
+    "check": "npm run wasm && npm run lint && npm run typecheck && npm test",
     "preview": "vite preview",
     "format": "prettier --write 'src/**/*.{ts,tsx,css}' '.storybook/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.{ts,tsx,css}' '.storybook/**/*.ts'",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test": "node --import tsx --test src/routes.test.ts src/components/compare/diff.test.ts",
     "typecheck": "tsc -b --noEmit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
@@ -24,7 +25,8 @@
     "apache-arrow": "^21.1.0",
     "d3-hierarchy": "^3.1.2",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.30.6"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -46,6 +48,7 @@
     "tailwindcss": "^4.2.4",
     "typescript": "~6.0.0",
     "typescript-eslint": "^8.59.0",
+    "tsx": "^4.21.0",
     "vite": "^8.0.10"
   }
 }

--- a/vortex-web/src/App.tsx
+++ b/vortex-web/src/App.tsx
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent } from 'react';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import type { VortexFileState, VortexFileContextValue } from './contexts/VortexFileContext';
 import { VortexFileProvider } from './contexts/VortexFileContext';
 import { SelectionProvider } from './contexts/SelectionContext';
@@ -12,52 +13,189 @@ import { FileHeader } from './components/explorer/FileHeader';
 import { MainArea, type MainView } from './components/explorer/MainArea';
 import { StatusBar } from './components/explorer/StatusBar';
 import { VortexWorker } from './workers/VortexWorker';
+import { fetchRemoteFile } from './remoteFile';
+import { resolveDeepLink, viewForPathname } from './routes';
 
 function App() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [fileState, setFileState] = useState<VortexFileState | null>(null);
+  const [baselineState, setBaselineState] = useState<VortexFileState | null>(null);
+  const [activeSide, setActiveSide] = useState<'baseline' | 'candidate'>('candidate');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
-  const [view, setView] = useState<MainView>('details');
   const dragCounter = useRef(0);
   const workerRef = useRef<VortexWorker | null>(null);
+  const baselineWorkerRef = useRef<VortexWorker | null>(null);
+  const view: MainView = viewForPathname(location.pathname);
 
   useEffect(() => {
     workerRef.current = new VortexWorker();
-    return () => workerRef.current?.terminate();
+    baselineWorkerRef.current = new VortexWorker();
+    return () => {
+      workerRef.current?.terminate();
+      baselineWorkerRef.current?.terminate();
+    };
   }, []);
 
-  const openFile = useCallback(async (file: File) => {
-    setError(null);
-    setLoading(true);
-    try {
-      const result = await workerRef.current!.openFile(file);
-      setFileState({
-        fileName: file.name,
-        fileSize: file.size,
-        rowCount: result.rowCount,
-        version: result.fileStructure.version,
-        dtype: result.dtype,
-        layoutTree: result.layoutTree,
-        segments: result.segments,
-        fileStructure: result.fileStructure,
-      });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-      setFileState(null);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  const fetchEncodingTree = useCallback(
-    (nodeId: string) => workerRef.current!.fetchEncodingTree(nodeId),
+  const stateFromResult = useCallback(
+    (file: File, result: Awaited<ReturnType<VortexWorker['openFile']>>): VortexFileState => ({
+      fileName: file.name,
+      fileSize: file.size,
+      rowCount: result.rowCount,
+      version: result.fileStructure.version,
+      dtype: result.dtype,
+      layoutTree: result.layoutTree,
+      segments: result.segments,
+      fileStructure: result.fileStructure,
+    }),
     [],
   );
 
+  const openFile = useCallback(
+    async (file: File) => {
+      setError(null);
+      setLoading(true);
+      try {
+        const result = await workerRef.current!.openFile(file);
+        setFileState(stateFromResult(file, result));
+        setBaselineState(null);
+        setActiveSide('candidate');
+        navigate('/');
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        setFileState(null);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [navigate, stateFromResult],
+  );
+
+  const openBaseline = useCallback(
+    async (file: File) => {
+      setError(null);
+      setLoading(true);
+      try {
+        const result = await baselineWorkerRef.current!.openFile(file);
+        setBaselineState(stateFromResult(file, result));
+        setActiveSide('candidate');
+        navigate('/compare');
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        setBaselineState(null);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [navigate, stateFromResult],
+  );
+
+  const openCandidate = useCallback(
+    async (file: File) => {
+      setError(null);
+      setLoading(true);
+      try {
+        const result = await workerRef.current!.openFile(file);
+        setFileState(stateFromResult(file, result));
+        setActiveSide('candidate');
+        navigate('/compare');
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [navigate, stateFromResult],
+  );
+
+  useEffect(() => {
+    const deepLink = resolveDeepLink(location.pathname, searchParams);
+    if (!deepLink) return;
+    if (deepLink.kind === 'error') {
+      setError(deepLink.message);
+      return;
+    }
+
+    if (deepLink.kind === 'file') {
+      const controller = new AbortController();
+      let active = true;
+      async function openDeepLinkedFile(fileSource: string) {
+        setError(null);
+        setLoading(true);
+        try {
+          const file = await fetchRemoteFile(fileSource, controller.signal);
+          if (!active) return;
+          const result = await workerRef.current!.openFile(file);
+          if (!active) return;
+          setFileState(stateFromResult(file, result));
+          setBaselineState(null);
+          setActiveSide('candidate');
+        } catch (e) {
+          if (!active || (e instanceof DOMException && e.name === 'AbortError')) return;
+          setError(e instanceof Error ? e.message : String(e));
+          setFileState(null);
+        } finally {
+          if (active) setLoading(false);
+        }
+      }
+      void openDeepLinkedFile(deepLink.source);
+      return () => {
+        active = false;
+        controller.abort();
+      };
+    }
+
+    const controller = new AbortController();
+    let active = true;
+    async function openDeepLink(baselineSource: string, candidateSource: string) {
+      setError(null);
+      setLoading(true);
+      try {
+        const [baselineFile, candidateFile] = await Promise.all([
+          fetchRemoteFile(baselineSource, controller.signal),
+          fetchRemoteFile(candidateSource, controller.signal),
+        ]);
+        if (!active) return;
+        const [baselineResult, candidateResult] = await Promise.all([
+          baselineWorkerRef.current!.openFile(baselineFile),
+          workerRef.current!.openFile(candidateFile),
+        ]);
+        if (!active) return;
+        setBaselineState(stateFromResult(baselineFile, baselineResult));
+        setFileState(stateFromResult(candidateFile, candidateResult));
+        setActiveSide('candidate');
+      } catch (e) {
+        if (!active || (e instanceof DOMException && e.name === 'AbortError')) return;
+        setError(e instanceof Error ? e.message : String(e));
+        setBaselineState(null);
+        setFileState(null);
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+    void openDeepLink(deepLink.baselineSource, deepLink.candidateSource);
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [location.pathname, searchParams, stateFromResult]);
+
+  const activeState =
+    activeSide === 'baseline' && baselineState !== null ? baselineState : fileState;
+  const activeWorkerRef = activeSide === 'baseline' ? baselineWorkerRef : workerRef;
+  const setActiveState = activeSide === 'baseline' ? setBaselineState : setFileState;
+
+  const fetchEncodingTree = useCallback(
+    (nodeId: string) => activeWorkerRef.current!.fetchEncodingTree(nodeId),
+    [activeWorkerRef],
+  );
+
   const previewData = useCallback(
-    (nodeId: string, rowLimit: number) => workerRef.current!.previewData(nodeId, rowLimit),
-    [],
+    (nodeId: string, rowLimit: number) => activeWorkerRef.current!.previewData(nodeId, rowLimit),
+    [activeWorkerRef],
   );
 
   /** Clone a tree, replacing the node at targetId with a modified version. */
@@ -80,10 +218,10 @@ function App() {
   const expandArrayTree = useCallback(
     async (nodeId: string) => {
       // Fetch the encoding tree (may be async).
-      const arrayTree = await workerRef.current!.fetchEncodingTree(nodeId);
+      const arrayTree = await activeWorkerRef.current!.fetchEncodingTree(nodeId);
       if (!arrayTree) return;
 
-      setFileState((prev) => {
+      setActiveState((prev) => {
         if (!prev) return prev;
         const node = findNodeById(prev.layoutTree, nodeId);
         if (!node || node.encoding !== 'vortex.flat') return prev;
@@ -98,26 +236,26 @@ function App() {
         return { ...prev, layoutTree: newTree };
       });
     },
-    [cloneTreeWithUpdate],
+    [activeWorkerRef, cloneTreeWithUpdate, setActiveState],
   );
 
   const fetchArrayBuffer = useCallback(
     (layoutNodeId: string, arrayPath: string[], bufferIndex: number) =>
-      workerRef.current!.fetchArrayBuffer(layoutNodeId, arrayPath, bufferIndex),
-    [],
+      activeWorkerRef.current!.fetchArrayBuffer(layoutNodeId, arrayPath, bufferIndex),
+    [activeWorkerRef],
   );
 
   const previewArrayData = useCallback(
     (layoutNodeId: string, arrayPath: string[], rowLimit: number) =>
-      workerRef.current!.previewArrayData(layoutNodeId, arrayPath, rowLimit),
-    [],
+      activeWorkerRef.current!.previewArrayData(layoutNodeId, arrayPath, rowLimit),
+    [activeWorkerRef],
   );
 
   const fileContextValue = useMemo<VortexFileContextValue | null>(
     () =>
-      fileState
+      activeState
         ? {
-            ...fileState,
+            ...activeState,
             fetchEncodingTree,
             previewData,
             expandArrayTree,
@@ -126,7 +264,7 @@ function App() {
           }
         : null,
     [
-      fileState,
+      activeState,
       fetchEncodingTree,
       previewData,
       expandArrayTree,
@@ -135,7 +273,26 @@ function App() {
     ],
   );
 
-  const closeFile = useCallback(() => setFileState(null), []);
+  const closeFile = useCallback(() => {
+    setFileState(null);
+    setBaselineState(null);
+    navigate('/');
+  }, [navigate]);
+
+  const changeView = useCallback(
+    (nextView: MainView) => {
+      navigate(nextView === 'details' ? '/' : `/${nextView}`);
+    },
+    [navigate],
+  );
+
+  const viewComparisonFile = useCallback(
+    (side: 'baseline' | 'candidate') => {
+      setActiveSide(side);
+      navigate('/');
+    },
+    [navigate],
+  );
 
   const handleDragEnter = useCallback((e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -178,8 +335,23 @@ function App() {
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
         >
-          <FileHeader onClose={closeFile} view={view} onViewChange={setView} />
-          <MainArea view={view} />
+          <FileHeader
+            onClose={closeFile}
+            view={view}
+            onViewChange={changeView}
+            onCompareFile={activeSide === 'baseline' ? openCandidate : openBaseline}
+            comparisonName={
+              activeSide === 'baseline' ? fileState?.fileName : baselineState?.fileName
+            }
+          />
+          <MainArea
+            view={view}
+            baseline={baselineState ?? undefined}
+            candidate={fileState ?? undefined}
+            onViewComparisonFile={viewComparisonFile}
+            onReplaceBaseline={openBaseline}
+            onReplaceCandidate={openCandidate}
+          />
           <StatusBar />
           {isDragging && (
             <div className="absolute inset-0 z-50 flex items-center justify-center bg-vortex-black/50 dark:bg-black/50 backdrop-blur-sm pointer-events-none">

--- a/vortex-web/src/components/compare/CompareView.tsx
+++ b/vortex-web/src/components/compare/CompareView.tsx
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+import { useMemo, useState } from 'react';
+import type { VortexFileState } from '../../contexts/VortexFileContext';
+import { diffLayoutTrees, flattenDiff, type DiffStatus } from './diff';
+
+function bytes(value: number): string {
+  if (Math.abs(value) < 1024) return `${value} B`;
+  if (Math.abs(value) < 1024 ** 2) return `${(value / 1024).toFixed(1)} KiB`;
+  return `${(value / 1024 ** 2).toFixed(2)} MiB`;
+}
+
+function delta(before: number, after: number): string {
+  const difference = after - before;
+  const percent = before === 0 ? null : (difference / before) * 100;
+  return `${difference > 0 ? '+' : ''}${bytes(difference)}${percent === null ? '' : ` (${percent > 0 ? '+' : ''}${percent.toFixed(1)}%)`}`;
+}
+
+const STATUS_CLASS: Record<DiffStatus, string> = {
+  unchanged: 'text-vortex-grey-dark',
+  changed: 'text-vortex-orange',
+  added: 'text-vortex-green',
+  removed: 'text-vortex-red',
+};
+
+function Metric({ label, before, after }: { label: string; before: number; after: number }) {
+  const improved = after <= before;
+  return (
+    <div className="rounded-md border border-vortex-grey-light/50 dark:border-white/[0.08] p-3">
+      <div className="text-[10px] uppercase tracking-wide text-vortex-grey-dark">{label}</div>
+      <div className="mt-1 font-mono text-lg text-vortex-fg-light dark:text-vortex-fg">
+        {bytes(after)}
+      </div>
+      <div
+        className={`mt-0.5 font-mono text-xs ${improved ? 'text-vortex-green' : 'text-vortex-red'}`}
+      >
+        {delta(before, after)}
+      </div>
+      <div className="mt-1 text-[10px] text-vortex-grey-dark">was {bytes(before)}</div>
+    </div>
+  );
+}
+
+export function CompareView({
+  baseline,
+  candidate,
+  onViewBaseline,
+  onViewCandidate,
+  onReplaceBaseline,
+  onReplaceCandidate,
+}: {
+  baseline: VortexFileState;
+  candidate: VortexFileState;
+  onViewBaseline?: () => void;
+  onViewCandidate?: () => void;
+  onReplaceBaseline?: (file: File) => void;
+  onReplaceCandidate?: (file: File) => void;
+}) {
+  const [changesOnly, setChangesOnly] = useState(true);
+  const root = useMemo(
+    () => diffLayoutTrees(baseline.layoutTree, candidate.layoutTree),
+    [baseline.layoutTree, candidate.layoutTree],
+  );
+  const rows = useMemo(() => flattenDiff(root, changesOnly), [root, changesOnly]);
+
+  return (
+    <div className="flex-1 min-h-0 overflow-auto p-4 text-vortex-fg-light dark:text-vortex-fg">
+      <div className="flex items-end justify-between gap-4">
+        <div>
+          <h2 className="font-funnel text-xl">Compression comparison</h2>
+          <p className="mt-1 font-mono text-xs text-vortex-grey-dark">
+            {baseline.fileName} → {candidate.fileName}
+          </p>
+        </div>
+        <label className="flex items-center gap-2 text-xs text-vortex-grey-dark">
+          <input
+            type="checkbox"
+            checked={changesOnly}
+            onChange={(event) => setChangesOnly(event.target.checked)}
+          />
+          Changes only
+        </label>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <FileControls
+          label="Previous"
+          fileName={baseline.fileName}
+          onView={onViewBaseline}
+          onReplace={onReplaceBaseline}
+        />
+        <FileControls
+          label="New"
+          fileName={candidate.fileName}
+          onView={onViewCandidate}
+          onReplace={onReplaceCandidate}
+        />
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <Metric label="File size" before={baseline.fileSize} after={candidate.fileSize} />
+        <Metric
+          label="Data bytes"
+          before={baseline.fileStructure.totalDataBytes}
+          after={candidate.fileStructure.totalDataBytes}
+        />
+        <Metric
+          label="Metadata bytes"
+          before={baseline.fileStructure.totalMetadataBytes}
+          after={candidate.fileStructure.totalMetadataBytes}
+        />
+      </div>
+
+      {baseline.rowCount !== candidate.rowCount || baseline.dtype !== candidate.dtype ? (
+        <div className="mt-4 rounded-md border border-vortex-red/40 bg-vortex-red/5 p-3 text-xs text-vortex-red">
+          Inputs differ: baseline has {baseline.rowCount.toLocaleString()} rows and candidate has{' '}
+          {candidate.rowCount.toLocaleString()} rows
+          {baseline.dtype !== candidate.dtype ? '; their schemas also differ' : ''}. Size deltas may
+          not isolate a compression change.
+        </div>
+      ) : null}
+
+      <div className="mt-5 overflow-hidden rounded-md border border-vortex-grey-light/50 dark:border-white/[0.08]">
+        <div className="grid grid-cols-[minmax(180px,1.2fr)_minmax(150px,1fr)_minmax(150px,1fr)_110px_110px] gap-3 border-b border-vortex-grey-light/50 dark:border-white/[0.08] bg-vortex-grey-lightest/60 dark:bg-white/[0.03] px-3 py-2 text-[10px] uppercase tracking-wide text-vortex-grey-dark">
+          <span>Node</span>
+          <span>Previous</span>
+          <span>New</span>
+          <span>Metadata Δ</span>
+          <span>Buffers Δ</span>
+        </div>
+        {rows.map((row) => (
+          <div
+            key={row.key}
+            className="grid grid-cols-[minmax(180px,1.2fr)_minmax(150px,1fr)_minmax(150px,1fr)_110px_110px] gap-3 border-b last:border-b-0 border-vortex-grey-light/30 dark:border-white/[0.05] px-3 py-1.5 font-mono text-xs"
+          >
+            <span className={STATUS_CLASS[row.status]} style={{ paddingLeft: row.depth * 14 }}>
+              <span className="mr-2 inline-block w-14 text-[9px] uppercase">{row.status}</span>
+              {row.label}
+            </span>
+            <span className="truncate text-vortex-grey-dark" title={row.beforeEncoding}>
+              {row.beforeEncoding ?? '—'}
+            </span>
+            <span className="truncate" title={row.afterEncoding}>
+              {row.afterEncoding ?? '—'}
+            </span>
+            <span
+              className={
+                row.beforeMetadataBytes === row.afterMetadataBytes ? 'text-vortex-grey-dark' : ''
+              }
+            >
+              {delta(row.beforeMetadataBytes, row.afterMetadataBytes)}
+            </span>
+            <span
+              className={
+                row.beforeBufferBytes === row.afterBufferBytes ? 'text-vortex-grey-dark' : ''
+              }
+            >
+              {delta(row.beforeBufferBytes, row.afterBufferBytes)}
+            </span>
+          </div>
+        ))}
+        {rows.length === 0 ? (
+          <div className="p-6 text-center text-sm text-vortex-grey-dark">No changes</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function FileControls({
+  label,
+  fileName,
+  onView,
+  onReplace,
+}: {
+  label: string;
+  fileName: string;
+  onView?: () => void;
+  onReplace?: (file: File) => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-md border border-vortex-grey-light/50 dark:border-white/[0.08] p-3">
+      <div className="min-w-0 flex-1">
+        <div className="text-[10px] uppercase tracking-wide text-vortex-grey-dark">{label}</div>
+        <div className="truncate font-mono text-xs" title={fileName}>
+          {fileName}
+        </div>
+      </div>
+      <button
+        type="button"
+        className="rounded px-2 py-1 text-xs text-vortex-blue hover:bg-vortex-grey-lightest dark:hover:bg-white/[0.06]"
+        onClick={onView}
+      >
+        View
+      </button>
+      <label className="cursor-pointer rounded px-2 py-1 text-xs text-vortex-grey-dark hover:bg-vortex-grey-lightest dark:hover:bg-white/[0.06]">
+        Replace…
+        <input
+          className="hidden"
+          type="file"
+          accept=".vortex,.vtx"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            if (file) onReplace?.(file);
+            event.target.value = '';
+          }}
+        />
+      </label>
+    </div>
+  );
+}

--- a/vortex-web/src/components/compare/diff.test.ts
+++ b/vortex-web/src/components/compare/diff.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { LayoutChildKind, LayoutTreeNode } from '../swimlane/types';
+import { diffLayoutTrees, flattenDiff } from './diff';
+
+function node({
+  id,
+  childType,
+  children = [],
+  encoding = 'vortex.flat',
+  metadataBytes = 0,
+  isArrayNode,
+}: {
+  id: string;
+  childType: LayoutChildKind;
+  children?: LayoutTreeNode[];
+  encoding?: string;
+  metadataBytes?: number;
+  isArrayNode?: boolean;
+}): LayoutTreeNode {
+  return {
+    id,
+    encoding,
+    dtype: 'utf8',
+    rowCount: 100,
+    rowOffset: 0,
+    metadataBytes,
+    segmentIds: [],
+    childType,
+    children,
+    isArrayNode,
+  };
+}
+
+function field(name: string, options: Partial<Parameters<typeof node>[0]> = {}): LayoutTreeNode {
+  return node({
+    id: `root.${name}`,
+    childType: { kind: 'field', fieldName: name },
+    ...options,
+  });
+}
+
+function root(children: LayoutTreeNode[]): LayoutTreeNode {
+  return node({ id: 'root', childType: { kind: 'root' }, children, encoding: 'vortex.struct' });
+}
+
+describe('semantic layout diff', () => {
+  it('matches fields by name when a field is inserted', () => {
+    const result = diffLayoutTrees(
+      root([field('a'), field('b')]),
+      root([field('a'), field('x'), field('b')]),
+    );
+
+    assert.deepEqual(
+      result.children.map(({ label, status }) => [label, status]),
+      [
+        ['a', 'unchanged'],
+        ['b', 'unchanged'],
+        ['x', 'added'],
+      ],
+    );
+    assert.deepEqual(
+      flattenDiff(result, true).map(({ label, status }) => [label, status]),
+      [
+        ['root', 'changed'],
+        ['x', 'added'],
+      ],
+    );
+  });
+
+  it('reports encoding and metadata changes on the matching field', () => {
+    const before = root([field('value', { encoding: 'vortex.dict', metadataBytes: 12 })]);
+    const after = root([field('value', { encoding: 'vortex.on_pair', metadataBytes: 20 })]);
+    const changed = diffLayoutTrees(before, after).children[0];
+
+    assert.deepEqual(
+      {
+        label: changed?.label,
+        status: changed?.status,
+        beforeEncoding: changed?.beforeEncoding,
+        afterEncoding: changed?.afterEncoding,
+        beforeMetadataBytes: changed?.beforeMetadataBytes,
+        afterMetadataBytes: changed?.afterMetadataBytes,
+      },
+      {
+        label: 'value',
+        status: 'changed',
+        beforeEncoding: 'vortex.dict',
+        afterEncoding: 'vortex.on_pair',
+        beforeMetadataBytes: 12,
+        afterMetadataBytes: 20,
+      },
+    );
+  });
+
+  it('ignores expanded array nodes that exist only in the rendered tree', () => {
+    const expandedArrayNode = field('array child', { isArrayNode: true });
+    const before = root([field('value')]);
+    const after = root([field('value'), expandedArrayNode]);
+
+    assert.equal(diffLayoutTrees(before, after).status, 'unchanged');
+  });
+});

--- a/vortex-web/src/components/compare/diff.test.ts
+++ b/vortex-web/src/components/compare/diff.test.ts
@@ -3,7 +3,7 @@
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import type { LayoutChildKind, LayoutTreeNode } from '../swimlane/types';
+import type { ArrayEncodingNode, LayoutChildKind, LayoutTreeNode } from '../swimlane/types';
 import { diffLayoutTrees, flattenDiff } from './diff';
 
 function node({
@@ -45,6 +45,23 @@ function field(name: string, options: Partial<Parameters<typeof node>[0]> = {}):
 
 function root(children: LayoutTreeNode[]): LayoutTreeNode {
   return node({ id: 'root', childType: { kind: 'root' }, children, encoding: 'vortex.struct' });
+}
+
+function arrayNode(
+  name: string,
+  encoding = 'vortex.primitive',
+  children: ArrayEncodingNode[] = [],
+): ArrayEncodingNode {
+  return {
+    name,
+    encoding,
+    dtype: 'i32',
+    metadataBytes: 0,
+    numBuffers: 0,
+    bufferLengths: [],
+    bufferNames: [],
+    children,
+  };
 }
 
 describe('semantic layout diff', () => {
@@ -102,5 +119,29 @@ describe('semantic layout diff', () => {
     const after = root([field('value'), expandedArrayNode]);
 
     assert.equal(diffLayoutTrees(before, after).status, 'unchanged');
+  });
+
+  it('matches streamed array children by the name carried on each node', () => {
+    const before = field('value');
+    before.arrayEncodingTree = arrayNode('array', 'vortex.struct', [
+      arrayNode('a'),
+      arrayNode('b'),
+    ]);
+    const after = field('value');
+    after.arrayEncodingTree = arrayNode('array', 'vortex.struct', [
+      arrayNode('a'),
+      arrayNode('inserted', 'vortex.constant'),
+      arrayNode('b'),
+    ]);
+
+    const arrayDiff = diffLayoutTrees(root([before]), root([after])).children[0]?.children[0];
+    assert.deepEqual(
+      arrayDiff?.children.map(({ label, status }) => [label, status]),
+      [
+        ['a', 'unchanged'],
+        ['b', 'unchanged'],
+        ['inserted', 'added'],
+      ],
+    );
   });
 });

--- a/vortex-web/src/components/compare/diff.ts
+++ b/vortex-web/src/components/compare/diff.ts
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+import type { ArrayEncodingNode, LayoutTreeNode } from '../swimlane/types';
+
+export type DiffStatus = 'unchanged' | 'changed' | 'added' | 'removed';
+
+export interface TreeDiffNode {
+  key: string;
+  label: string;
+  depth: number;
+  status: DiffStatus;
+  beforeEncoding?: string;
+  afterEncoding?: string;
+  beforeMetadataBytes: number;
+  afterMetadataBytes: number;
+  beforeBufferBytes: number;
+  afterBufferBytes: number;
+  children: TreeDiffNode[];
+}
+
+function layoutChildKey(node: LayoutTreeNode): string {
+  const child = node.childType;
+  switch (child.kind) {
+    case 'root':
+      return 'root';
+    case 'field':
+      return `field:${child.fieldName}`;
+    case 'chunk':
+      return `chunk:${child.rowOffset}:${node.rowCount}`;
+    case 'transparent':
+      return `transparent:${child.name}`;
+    case 'auxiliary':
+      return `auxiliary:${child.name}`;
+  }
+}
+
+function layoutLabel(node: LayoutTreeNode): string {
+  const child = node.childType;
+  switch (child.kind) {
+    case 'root':
+      return 'root';
+    case 'field':
+      return child.fieldName;
+    case 'chunk':
+      return `chunk ${child.chunkIndex}`;
+    case 'transparent':
+    case 'auxiliary':
+      return child.name;
+  }
+}
+
+function arrayBufferBytes(node: ArrayEncodingNode | undefined): number {
+  return node?.bufferLengths.reduce((sum, bytes) => sum + bytes, 0) ?? 0;
+}
+
+function statusFor(
+  beforeEncoding: string | undefined,
+  afterEncoding: string | undefined,
+  beforeMetadataBytes: number,
+  afterMetadataBytes: number,
+  beforeBufferBytes: number,
+  afterBufferBytes: number,
+  children: TreeDiffNode[],
+): DiffStatus {
+  if (!beforeEncoding) return 'added';
+  if (!afterEncoding) return 'removed';
+  if (
+    beforeEncoding !== afterEncoding ||
+    beforeMetadataBytes !== afterMetadataBytes ||
+    beforeBufferBytes !== afterBufferBytes ||
+    children.some((child) => child.status !== 'unchanged')
+  ) {
+    return 'changed';
+  }
+  return 'unchanged';
+}
+
+/**
+ * Match sibling nodes by a domain key while retaining duplicate keys in source order.
+ * This is deliberately not positional: inserting a field must not make every later field
+ * appear changed.
+ */
+function matchChildren<T>(
+  before: T[],
+  after: T[],
+  keyOf: (node: T, index: number) => string,
+): Array<{ key: string; before?: T; after?: T }> {
+  const afterByKey = new Map<string, T[]>();
+  after.forEach((node, index) => {
+    const key = keyOf(node, index);
+    const matches = afterByKey.get(key) ?? [];
+    matches.push(node);
+    afterByKey.set(key, matches);
+  });
+
+  const pairs: Array<{ key: string; before?: T; after?: T }> = [];
+  before.forEach((node, index) => {
+    const key = keyOf(node, index);
+    const matches = afterByKey.get(key);
+    const matched = matches?.shift();
+    pairs.push({ key, before: node, after: matched });
+    if (matches?.length === 0) afterByKey.delete(key);
+  });
+  after.forEach((node, index) => {
+    const key = keyOf(node, index);
+    const matches = afterByKey.get(key);
+    if (matches?.[0] === node) {
+      matches.shift();
+      pairs.push({ key, after: node });
+      if (matches.length === 0) afterByKey.delete(key);
+    }
+  });
+  return pairs;
+}
+
+function diffArrayNode(
+  before: ArrayEncodingNode | undefined,
+  after: ArrayEncodingNode | undefined,
+  key: string,
+  label: string,
+  depth: number,
+): TreeDiffNode {
+  type NamedChild = { key: string; node: ArrayEncodingNode };
+  const beforeChildren: NamedChild[] =
+    before?.children.map((node, index) => ({
+      key: before.childNames[index] || `child:${index}`,
+      node,
+    })) ?? [];
+  const afterChildren: NamedChild[] =
+    after?.children.map((node, index) => ({
+      key: after.childNames[index] || `child:${index}`,
+      node,
+    })) ?? [];
+  const pairs = matchChildren(beforeChildren, afterChildren, (child) => child.key);
+  const children = pairs.map((pair, index) => {
+    const childLabel = pair.key || `child ${index}`;
+    return diffArrayNode(
+      pair.before?.node,
+      pair.after?.node,
+      `${key}/array:${childLabel}`,
+      childLabel,
+      depth + 1,
+    );
+  });
+  const beforeMetadataBytes = before?.metadataBytes ?? 0;
+  const afterMetadataBytes = after?.metadataBytes ?? 0;
+  const beforeBufferBytes = arrayBufferBytes(before);
+  const afterBufferBytes = arrayBufferBytes(after);
+  const beforeEncoding = before?.encoding;
+  const afterEncoding = after?.encoding;
+  return {
+    key,
+    label,
+    depth,
+    status: statusFor(
+      beforeEncoding,
+      afterEncoding,
+      beforeMetadataBytes,
+      afterMetadataBytes,
+      beforeBufferBytes,
+      afterBufferBytes,
+      children,
+    ),
+    beforeEncoding,
+    afterEncoding,
+    beforeMetadataBytes,
+    afterMetadataBytes,
+    beforeBufferBytes,
+    afterBufferBytes,
+    children,
+  };
+}
+
+function diffLayoutNode(
+  before: LayoutTreeNode | undefined,
+  after: LayoutTreeNode | undefined,
+  key: string,
+  depth: number,
+): TreeDiffNode {
+  // Expanded array nodes are a UI projection of `arrayEncodingTree`, not layout children.
+  // Excluding them prevents a file explored before comparison from appearing structurally
+  // different from an otherwise identical freshly opened file.
+  const beforeChildren = before?.children.filter((node) => !node.isArrayNode) ?? [];
+  const afterChildren = after?.children.filter((node) => !node.isArrayNode) ?? [];
+  const pairs = matchChildren(beforeChildren, afterChildren, (node) => layoutChildKey(node));
+  const children = pairs.map((pair) =>
+    diffLayoutNode(pair.before, pair.after, `${key}/${pair.key}`, depth + 1),
+  );
+
+  const beforeArray = before?.arrayEncodingTree;
+  const afterArray = after?.arrayEncodingTree;
+  if (beforeArray || afterArray) {
+    children.push(diffArrayNode(beforeArray, afterArray, `${key}/array`, 'array', depth + 1));
+  }
+
+  const beforeMetadataBytes = before?.metadataBytes ?? 0;
+  const afterMetadataBytes = after?.metadataBytes ?? 0;
+  const beforeEncoding = before?.encoding;
+  const afterEncoding = after?.encoding;
+  return {
+    key,
+    label: after ? layoutLabel(after) : before ? layoutLabel(before) : key,
+    depth,
+    status: statusFor(
+      beforeEncoding,
+      afterEncoding,
+      beforeMetadataBytes,
+      afterMetadataBytes,
+      0,
+      0,
+      children,
+    ),
+    beforeEncoding,
+    afterEncoding,
+    beforeMetadataBytes,
+    afterMetadataBytes,
+    beforeBufferBytes: 0,
+    afterBufferBytes: 0,
+    children,
+  };
+}
+
+export function diffLayoutTrees(before: LayoutTreeNode, after: LayoutTreeNode): TreeDiffNode {
+  return diffLayoutNode(before, after, 'root', 0);
+}
+
+export function flattenDiff(root: TreeDiffNode, changesOnly: boolean): TreeDiffNode[] {
+  const rows: TreeDiffNode[] = [];
+  function visit(node: TreeDiffNode) {
+    if (!changesOnly || node.status !== 'unchanged') rows.push(node);
+    node.children.forEach(visit);
+  }
+  visit(root);
+  return rows;
+}

--- a/vortex-web/src/components/compare/diff.ts
+++ b/vortex-web/src/components/compare/diff.ts
@@ -124,12 +124,12 @@ function diffArrayNode(
   type NamedChild = { key: string; node: ArrayEncodingNode };
   const beforeChildren: NamedChild[] =
     before?.children.map((node, index) => ({
-      key: before.childNames[index] || `child:${index}`,
+      key: node.name || `child:${index}`,
       node,
     })) ?? [];
   const afterChildren: NamedChild[] =
     after?.children.map((node, index) => ({
-      key: after.childNames[index] || `child:${index}`,
+      key: node.name || `child:${index}`,
       node,
     })) ?? [];
   const pairs = matchChildren(beforeChildren, afterChildren, (child) => child.key);

--- a/vortex-web/src/components/explorer/FileDropScreen.tsx
+++ b/vortex-web/src/components/explorer/FileDropScreen.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useCallback, type DragEvent, type FormEvent } from 'react';
 import { ThemePicker } from '../ThemePicker';
+import { fetchRemoteFile } from '../../remoteFile';
 
 interface FileDropScreenProps {
   onFileLoaded: (file: File) => void;
@@ -56,12 +57,7 @@ export function FileDropScreen({ onFileLoaded, loading, error }: FileDropScreenP
       setFetchingUrl(true);
       setUrlError(null);
       try {
-        const resp = await fetch(trimmed);
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
-        const blob = await resp.blob();
-        const name = trimmed.split('/').pop() ?? 'remote.vortex';
-        const file = new File([blob], name, { type: blob.type });
-        onFileLoaded(file);
+        onFileLoaded(await fetchRemoteFile(trimmed));
       } catch (err) {
         setUrlError(err instanceof Error ? err.message : String(err));
       } finally {

--- a/vortex-web/src/components/explorer/FileHeader.tsx
+++ b/vortex-web/src/components/explorer/FileHeader.tsx
@@ -9,10 +9,21 @@ interface FileHeaderProps {
   onClose: () => void;
   view: MainView;
   onViewChange: (view: MainView) => void;
+  onCompareFile?: (file: File) => void;
+  comparisonName?: string;
 }
 
-export function FileHeader({ onClose, view, onViewChange }: FileHeaderProps) {
+export function FileHeader({
+  onClose,
+  view,
+  onViewChange,
+  onCompareFile,
+  comparisonName,
+}: FileHeaderProps) {
   const file = useVortexFile();
+  const views: MainView[] = comparisonName
+    ? ['details', 'swimlane', 'compare']
+    : ['details', 'swimlane'];
 
   return (
     <div className="flex items-center gap-3 px-3 py-1.5 border-b border-vortex-grey-light/60 dark:border-white/[0.08] bg-vortex-white dark:bg-vortex-black flex-shrink-0">
@@ -28,7 +39,7 @@ export function FileHeader({ onClose, view, onViewChange }: FileHeaderProps) {
       <div className="ml-auto flex items-center gap-2">
         {/* Primary view switch — sits with the global controls in the header. */}
         <div className="flex rounded-md bg-vortex-grey-lightest dark:bg-white/[0.06] p-0.5">
-          {(['details', 'swimlane'] as const).map((v) => (
+          {views.map((v) => (
             <button
               key={v}
               className={`px-3 py-0.5 text-[11px] rounded-[3px] transition-colors ${
@@ -38,10 +49,24 @@ export function FileHeader({ onClose, view, onViewChange }: FileHeaderProps) {
               }`}
               onClick={() => onViewChange(v)}
             >
-              {v === 'details' ? 'Details' : 'Swimlane'}
+              {v === 'details' ? 'Details' : v === 'swimlane' ? 'Swimlane' : 'Compare'}
             </button>
           ))}
         </div>
+
+        <label className="cursor-pointer rounded-md px-2 py-1 text-[11px] text-vortex-grey-dark hover:bg-vortex-grey-lightest dark:hover:bg-white/[0.06]">
+          {comparisonName ? `Compare with: ${comparisonName}` : 'Compare…'}
+          <input
+            className="hidden"
+            type="file"
+            accept=".vortex,.vtx"
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              if (file) onCompareFile?.(file);
+              event.target.value = '';
+            }}
+          />
+        </label>
 
         <div className="flex items-center gap-1">
           <ThemePicker />

--- a/vortex-web/src/components/explorer/MainArea.tsx
+++ b/vortex-web/src/components/explorer/MainArea.tsx
@@ -7,11 +7,13 @@ import { SwimlaneOverview } from '../swimlane/SwimlaneOverview';
 import { DataPreview } from './DataPreview';
 import { DetailPanel } from '../detail/DetailPanel';
 import { SummarySidebar } from '../detail/SummarySidebar';
+import { CompareView } from '../compare/CompareView';
+import type { VortexFileState } from '../../contexts/VortexFileContext';
 
 const MIN_PANEL_HEIGHT = 120;
 const DEFAULT_PREVIEW_HEIGHT = 200;
 
-export type MainView = 'details' | 'swimlane';
+export type MainView = 'details' | 'swimlane' | 'compare';
 
 /**
  * Main explorer area: tree panel (left) | the active main view (details or
@@ -20,7 +22,21 @@ export type MainView = 'details' | 'swimlane';
  *
  * The preview panel at the bottom is vertically resizable via a drag handle.
  */
-export function MainArea({ view }: { view: MainView }) {
+export function MainArea({
+  view,
+  baseline,
+  candidate,
+  onViewComparisonFile,
+  onReplaceBaseline,
+  onReplaceCandidate,
+}: {
+  view: MainView;
+  baseline?: VortexFileState;
+  candidate?: VortexFileState;
+  onViewComparisonFile?: (side: 'baseline' | 'candidate') => void;
+  onReplaceBaseline?: (file: File) => void;
+  onReplaceCandidate?: (file: File) => void;
+}) {
   const [previewHeight, setPreviewHeight] = useState(DEFAULT_PREVIEW_HEIGHT);
   const dragging = useRef(false);
   const startY = useRef(0);
@@ -62,35 +78,46 @@ export function MainArea({ view }: { view: MainView }) {
       )}
 
       {/* Right: active main view over the resizable data preview */}
-      <div ref={containerRef} className="flex-1 flex flex-col min-w-0 h-full overflow-hidden">
-        {/* Active view — fills available vertical space, scrolls internally. The
-            swimlane keeps the summary sidebar alongside it, like the details view. */}
-        <div className="flex-1 min-h-0 flex overflow-hidden">
-          {view === 'details' ? (
-            <DetailPanel />
-          ) : (
-            <>
-              <div className="flex-1 min-w-0 flex flex-col">
-                <SwimlaneOverview />
-              </div>
-              <SummarySidebar />
-            </>
-          )}
-        </div>
-
-        {/* Resize handle */}
-        <div
-          className="flex-shrink-0 h-1 cursor-row-resize border-t border-vortex-grey-light/40 dark:border-white/[0.06] hover:bg-vortex-light-blue/20 active:bg-vortex-light-blue/30 transition-colors"
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
+      {view === 'compare' && baseline && candidate ? (
+        <CompareView
+          baseline={baseline}
+          candidate={candidate}
+          onViewBaseline={() => onViewComparisonFile?.('baseline')}
+          onViewCandidate={() => onViewComparisonFile?.('candidate')}
+          onReplaceBaseline={onReplaceBaseline}
+          onReplaceCandidate={onReplaceCandidate}
         />
+      ) : (
+        <div ref={containerRef} className="flex-1 flex flex-col min-w-0 h-full overflow-hidden">
+          {/* Active view — fills available vertical space, scrolls internally. The
+            swimlane keeps the summary sidebar alongside it, like the details view. */}
+          <div className="flex-1 min-h-0 flex overflow-hidden">
+            {view === 'details' ? (
+              <DetailPanel />
+            ) : (
+              <>
+                <div className="flex-1 min-w-0 flex flex-col">
+                  <SwimlaneOverview />
+                </div>
+                <SummarySidebar />
+              </>
+            )}
+          </div>
 
-        {/* Data preview — resizable bottom section */}
-        <div className="flex-shrink-0 overflow-hidden" style={{ height: previewHeight }}>
-          <DataPreview />
+          {/* Resize handle */}
+          <div
+            className="flex-shrink-0 h-1 cursor-row-resize border-t border-vortex-grey-light/40 dark:border-white/[0.06] hover:bg-vortex-light-blue/20 active:bg-vortex-light-blue/30 transition-colors"
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+          />
+
+          {/* Data preview — resizable bottom section */}
+          <div className="flex-shrink-0 overflow-hidden" style={{ height: previewHeight }}>
+            <DataPreview />
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/vortex-web/src/components/swimlane/types.ts
+++ b/vortex-web/src/components/swimlane/types.ts
@@ -34,6 +34,7 @@ export interface LayoutTreeNode {
 }
 
 export interface ArrayEncodingNode {
+  name: string;
   encoding: string;
   dtype: string;
   metadataBytes: number;
@@ -41,7 +42,6 @@ export interface ArrayEncodingNode {
   bufferLengths: number[];
   bufferNames: string[];
   children: ArrayEncodingNode[];
-  childNames: string[];
 }
 
 export type LayoutChildKind =

--- a/vortex-web/src/components/swimlane/utils.ts
+++ b/vortex-web/src/components/swimlane/utils.ts
@@ -584,7 +584,7 @@ export function arrayTreeToLayoutChildren(
     const id = `${parentId}.$${name}`;
 
     const children = node.children.map((child, i) => {
-      const childName = node.childNames[i] ?? `child ${i}`;
+      const childName = child.name || `child ${i}`;
       return convert(child, id, childName);
     });
 

--- a/vortex-web/src/main.tsx
+++ b/vortex-web/src/main.tsx
@@ -3,14 +3,17 @@
 
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { HashRouter } from 'react-router-dom';
 import './index.css';
 import App from './App.tsx';
 import { ThemeProvider } from './contexts/ThemeContext.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ThemeProvider>
-      <App />
-    </ThemeProvider>
+    <HashRouter>
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
+    </HashRouter>
   </StrictMode>,
 );

--- a/vortex-web/src/remoteFile.ts
+++ b/vortex-web/src/remoteFile.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+/** Fetch a remote Vortex file using only browser APIs. Relative URLs resolve against the page. */
+export async function fetchRemoteFile(source: string, signal?: AbortSignal): Promise<File> {
+  const url = new URL(source, window.location.href);
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`Unsupported file URL protocol: ${url.protocol}`);
+  }
+
+  const response = await fetch(url, { signal });
+  if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+
+  const blob = await response.blob();
+  const pathName = url.pathname.split('/').filter(Boolean).pop();
+  const fileName = pathName ? decodeURIComponent(pathName) : 'remote.vortex';
+  return new File([blob], fileName, { type: blob.type });
+}

--- a/vortex-web/src/routes.test.ts
+++ b/vortex-web/src/routes.test.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { resolveDeepLink, viewForPathname } from './routes';
+
+describe('Vortex Web routes', () => {
+  const routes = [
+    ['/', 'details'],
+    ['/file', 'details'],
+    ['/swimlane', 'swimlane'],
+    ['/compare', 'compare'],
+    ['/unknown', 'details'],
+  ] as const;
+  routes.forEach(([pathname, expected]) => {
+    it(`maps ${pathname} to the ${expected} view`, () => {
+      assert.equal(viewForPathname(pathname), expected);
+    });
+  });
+
+  it('resolves an individual remote file deep link', () => {
+    const source = 'https://objects.example/file.vortex?signature=a+b';
+    const params = new URLSearchParams({ url: source });
+
+    assert.deepEqual(resolveDeepLink('/file', params), { kind: 'file', source });
+  });
+
+  it('resolves both files in a comparison deep link', () => {
+    const baselineSource = 'https://objects.example/previous.vortex?signature=old';
+    const candidateSource = 'https://objects.example/new.vortex?signature=new';
+    const params = new URLSearchParams({ baseline: baselineSource, candidate: candidateSource });
+
+    assert.deepEqual(resolveDeepLink('/compare', params), {
+      kind: 'compare',
+      baselineSource,
+      candidateSource,
+    });
+  });
+
+  it('rejects incomplete deep links', () => {
+    assert.deepEqual(resolveDeepLink('/file', new URLSearchParams()), {
+      kind: 'error',
+      message: 'A file link requires a URL.',
+    });
+    assert.deepEqual(
+      resolveDeepLink(
+        '/compare',
+        new URLSearchParams({ baseline: 'https://objects.example/previous.vortex' }),
+      ),
+      {
+        kind: 'error',
+        message: 'A comparison link requires both baseline and candidate URLs.',
+      },
+    );
+  });
+});

--- a/vortex-web/src/routes.ts
+++ b/vortex-web/src/routes.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+import type { MainView } from './components/explorer/MainArea';
+
+export type DeepLink =
+  | { kind: 'file'; source: string }
+  | { kind: 'compare'; baselineSource: string; candidateSource: string }
+  | { kind: 'error'; message: string };
+
+export function viewForPathname(pathname: string): MainView {
+  if (pathname === '/compare') return 'compare';
+  if (pathname === '/swimlane') return 'swimlane';
+  return 'details';
+}
+
+export function resolveDeepLink(pathname: string, searchParams: URLSearchParams): DeepLink | null {
+  if (pathname === '/file') {
+    const source = searchParams.get('url');
+    return source
+      ? { kind: 'file', source }
+      : { kind: 'error', message: 'A file link requires a URL.' };
+  }
+
+  if (pathname !== '/compare') return null;
+
+  const baselineSource = searchParams.get('baseline');
+  const candidateSource = searchParams.get('candidate');
+  if (!baselineSource && !candidateSource) return null;
+  if (!baselineSource || !candidateSource) {
+    return {
+      kind: 'error',
+      message: 'A comparison link requires both baseline and candidate URLs.',
+    };
+  }
+  return { kind: 'compare', baselineSource, candidateSource };
+}


### PR DESCRIPTION
## Summary

Add an interactive compression-output comparison to Vortex Web. The viewer compares whole-file, data, and metadata sizes, then semantically aligns layout and array-encoding trees so an inserted field does not make every following field appear changed.

The Explorer remains a static application. Hash routes provide shareable links for an individual HTTP(S) Vortex file or a baseline/candidate pair, and either comparison side can be opened in the normal explorer or replaced with another local file.

Array encoding trees are streamed from the decoded array into JSON one node at a time through the traversal introduced by #9612. The WASM bridge no longer constructs a recursive Rust JSON tree before serialization.

## Stack

1. #9612 — streaming array-tree traversal shared by display backends.
2. This PR — Vortex Web JSON backend, compression diff viewer, and deep links.

## Changes

- Add semantic layout and array-encoding tree diffing with changed, added, removed, and unchanged states.
- Add the comparison UI with byte deltas, schema/row-count warnings, changes-only filtering, and controls to view or replace either file.
- Add hash-based routes for Details, Swimlane, Compare, individual remote files, and remote comparison pairs.
- Load comparison files in separate Web Workers so tree expansion and previews target the selected file.
- Stream decoded array trees directly to JSON without a recursively allocated Rust intermediate tree.
- Carry each array child's name on the child node so traversal does not collect parallel child-name and child arrays.
- Add focused unit coverage for route/deep-link resolution, semantic tree matching, and one-pass JSON serialization.

## Checks

- `npm run wasm`
- `npm test`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `cargo test -p vortex-web-wasm`
- `cargo check -p vortex-web-wasm --target wasm32-unknown-unknown`
- `cargo clippy -p vortex-utils -p vortex-array -p vortex-web-wasm --all-targets --all-features`
- `git diff --check`

Workspace-wide Clippy was also attempted, but the unrelated `vortex-nvcomp` build script could not download NVIDIA nvCOMP.