### PR TITLE
Improve compact compression choices

### DIFF
--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::mem::size_of;
+
 use ::alp::ENCODE_CHUNK_SIZE;
 use itertools::Itertools;
+use num_traits::CheckedSub;
+use num_traits::ToPrimitive;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
@@ -23,6 +27,93 @@ use crate::ALP;
 use crate::Exponents;
 use crate::alp::ALPArray;
 use crate::alp::ALPFloat;
+
+// The upstream selector assumes every patch index costs two bytes and samples only 32 values.
+// Score against the original array length so exponent selection reflects the index type that
+// Vortex can materialize after encoding.
+const EXPONENT_SAMPLE_SIZE: usize = 4096;
+
+fn patch_index_nbytes(array_len: usize) -> usize {
+    let max_index = array_len.saturating_sub(1);
+    if max_index <= u16::MAX as usize {
+        size_of::<u16>()
+    } else if max_index <= u32::MAX as usize {
+        size_of::<u32>()
+    } else {
+        size_of::<u64>()
+    }
+}
+
+fn update_bounds<I: Ord + Copy>(bounds: &mut Option<(I, I)>, value: I) {
+    *bounds = Some(bounds.map_or((value, value), |(min, max)| {
+        (min.min(value), max.max(value))
+    }));
+}
+
+fn estimate_encoded_size<T: ALPFloat>(
+    values: &[T],
+    array_len: usize,
+    exponents: Exponents,
+) -> usize {
+    let mut kept = None;
+    let mut all = None;
+    let mut patch_count = 0usize;
+
+    for &value in values {
+        let encoded = T::encode_single_unchecked(value, exponents);
+        update_bounds(&mut all, encoded);
+        if T::decode_single(encoded, exponents).is_eq(value) {
+            update_bounds(&mut kept, encoded);
+        } else {
+            patch_count += 1;
+        }
+    }
+
+    let range = if patch_count == values.len() {
+        all
+    } else {
+        kept
+    };
+    let bits_per_encoded = range
+        .and_then(|(min, max)| max.checked_sub(&min))
+        .and_then(|range_size| range_size.to_u64())
+        .and_then(|range_size| {
+            range_size
+                .checked_ilog2()
+                .map(|bits| (bits + 1) as usize)
+                .or(Some(0))
+        })
+        .unwrap_or(size_of::<T::ALPInt>() * 8);
+
+    let encoded_bytes = (values.len() * bits_per_encoded).div_ceil(8);
+    let patch_bytes = patch_count * (size_of::<T>() + patch_index_nbytes(array_len));
+    encoded_bytes + patch_bytes
+}
+
+fn find_best_exponents<T: ALPFloat>(values: &[T]) -> Exponents {
+    let sample = (values.len() > EXPONENT_SAMPLE_SIZE).then(|| {
+        values
+            .iter()
+            .step_by(values.len() / EXPONENT_SAMPLE_SIZE)
+            .copied()
+            .collect_vec()
+    });
+    let sample = sample.as_deref().unwrap_or(values);
+    let mut best = Exponents { e: 0, f: 0 };
+    let mut best_nbytes = usize::MAX;
+
+    for e in (0..T::MAX_EXPONENT).rev() {
+        for f in 0..e {
+            let candidate = Exponents { e, f };
+            let nbytes = estimate_encoded_size(sample, values.len(), candidate);
+            if nbytes < best_nbytes || (nbytes == best_nbytes && e - f < best.e - best.f) {
+                best = candidate;
+                best_nbytes = nbytes;
+            }
+        }
+    }
+    best
+}
 
 #[macro_export]
 macro_rules! match_each_alp_float_ptype {
@@ -73,6 +164,7 @@ where
     T::ALPInt: NativePType,
 {
     let values_slice = values.as_slice::<T>();
+    let exponents = exponents.unwrap_or_else(|| find_best_exponents(values_slice));
 
     // Encode straight into a Vortex buffer, so that the encoded array owns its values rather than
     // adopting a `Vec` allocated by the encoder.
@@ -86,7 +178,7 @@ where
     let mut chunk_offsets = Vec::with_capacity(values_slice.len().div_ceil(ENCODE_CHUNK_SIZE));
     let exponents = ::alp::encode_into(
         values_slice,
-        exponents,
+        Some(exponents),
         &mut encoded.spare_capacity_mut()[..values_slice.len()],
         &mut exceptional_positions,
         &mut exceptional_values,
@@ -174,6 +266,19 @@ mod tests {
         crate::initialize(&session);
         session
     });
+
+    #[test]
+    fn patch_index_width_tracks_array_length() {
+        assert_eq!(patch_index_nbytes(1 << 16), 2);
+        assert_eq!(patch_index_nbytes((1 << 16) + 1), 4);
+
+        let values = [1.0f64 / 3.0];
+        let exponents = Exponents { e: 1, f: 0 };
+        assert_eq!(
+            estimate_encoded_size(&values, (1 << 16) + 1, exponents),
+            estimate_encoded_size(&values, 1 << 16, exponents) + 2
+        );
+    }
 
     #[test]
     fn test_compress() {

--- a/vortex-btrblocks/src/builder.rs
+++ b/vortex-btrblocks/src/builder.rs
@@ -150,6 +150,10 @@ impl BtrBlocksCompressorBuilder {
             .with_new_scheme(&integer::PcoScheme)
             .with_new_scheme(&float::PcoScheme);
 
+        let builder = builder
+            .with_new_scheme(&integer::ZstdScheme)
+            .with_new_scheme(&float::ZstdScheme);
+
         builder
     }
 

--- a/vortex-btrblocks/src/schemes/binary/zstd.rs
+++ b/vortex-btrblocks/src/schemes/binary/zstd.rs
@@ -56,7 +56,7 @@ impl Scheme for ZstdScheme {
             .into_owned()
             .compact_buffers(exec_ctx)?;
         Ok(
-            vortex_zstd::Zstd::from_var_bin_view_without_dict(&compacted, 3, 8192, exec_ctx)?
+            vortex_zstd::Zstd::from_var_bin_view_without_dict(&compacted, 3, 65536, exec_ctx)?
                 .into_array(),
         )
     }

--- a/vortex-btrblocks/src/schemes/float/alp.rs
+++ b/vortex-btrblocks/src/schemes/float/alp.rs
@@ -28,6 +28,7 @@ use crate::CompressorContext;
 use crate::Scheme;
 use crate::SchemeExt;
 use crate::compress_patches;
+use crate::schemes::patches::compress_patched_children;
 
 /// ALP (Adaptive Lossless floating-Point) encoding.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -50,9 +51,9 @@ impl Scheme for ALPScheme {
         encodings
     }
 
-    /// Children: encoded_ints=0.
+    /// Children: encoded_ints=0, lane_offsets=1, patch_indices=2, patch_values=3.
     fn num_children(&self) -> usize {
-        1
+        4
     }
 
     fn expected_compression_ratio(
@@ -104,9 +105,17 @@ impl Scheme for ALPScheme {
 
             match patches {
                 None => Ok(alp_array),
-                Some(p) => Ok(Patched::from_array_and_patches(alp_array, &p, exec_ctx)?
-                    .with_stats_set(alp_stats)
-                    .into_array()),
+                Some(p) => {
+                    let patched = Patched::from_array_and_patches(alp_array, &p, exec_ctx)?
+                        .with_stats_set(alp_stats);
+                    compress_patched_children(
+                        compressor,
+                        patched,
+                        &compress_ctx,
+                        self.id(),
+                        exec_ctx,
+                    )
+                }
             }
         } else {
             let patches = alp_encoded

--- a/vortex-btrblocks/src/schemes/float/mod.rs
+++ b/vortex-btrblocks/src/schemes/float/mod.rs
@@ -10,6 +10,8 @@ mod sparse;
 
 #[cfg(feature = "pco")]
 mod pco;
+#[cfg(feature = "zstd")]
+mod zstd;
 
 pub use alp::ALPScheme;
 pub use alprd::ALPRDScheme;
@@ -20,6 +22,8 @@ pub use sparse::NullDominatedSparseScheme;
 // Re-export builtin schemes from vortex-compressor.
 pub use vortex_compressor::builtins::FloatDictScheme;
 pub use vortex_compressor::stats::FloatStats;
+#[cfg(feature = "zstd")]
+pub use zstd::ZstdScheme;
 
 #[cfg(test)]
 mod scheme_selection_tests;

--- a/vortex-btrblocks/src/schemes/float/zstd.rs
+++ b/vortex-btrblocks/src/schemes/float/zstd.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Zstd string compression without dictionaries (nvCOMP compatible).
+//! Zstd floating-point compression.
 
 use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
@@ -18,17 +18,17 @@ use crate::CascadingCompressor;
 use crate::CompressorContext;
 use crate::Scheme;
 
-/// Zstd compression without dictionaries (nvCOMP compatible).
+/// Zstd compression for floating-point arrays.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ZstdScheme;
 
 impl Scheme for ZstdScheme {
     fn scheme_name(&self) -> &'static str {
-        "vortex.string.zstd"
+        "vortex.float.zstd"
     }
 
     fn matches(&self, canonical: &Canonical) -> bool {
-        canonical.dtype().is_utf8()
+        canonical.dtype().is_float()
     }
 
     fn produced_encodings(&self) -> Vec<ArrayId> {
@@ -51,13 +51,7 @@ impl Scheme for ZstdScheme {
         _compress_ctx: CompressorContext,
         exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let compacted = data
-            .array_as_varbinview()
-            .into_owned()
-            .compact_buffers(exec_ctx)?;
-        Ok(
-            vortex_zstd::Zstd::from_var_bin_view_without_dict(&compacted, 3, 65536, exec_ctx)?
-                .into_array(),
-        )
+        let primitive = data.array_as_primitive().into_owned();
+        Ok(vortex_zstd::Zstd::from_primitive(&primitive, 3, 65536, exec_ctx)?.into_array())
     }
 }

--- a/vortex-btrblocks/src/schemes/integer/bitpacking.rs
+++ b/vortex-btrblocks/src/schemes/integer/bitpacking.rs
@@ -25,7 +25,9 @@ use crate::ArrayAndStats;
 use crate::CascadingCompressor;
 use crate::CompressorContext;
 use crate::Scheme;
+use crate::SchemeExt;
 use crate::compress_patches;
+use crate::schemes::patches::compress_patched_children;
 
 /// BitPacking encoding for non-negative integers.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -46,6 +48,11 @@ impl Scheme for BitPackingScheme {
             encodings.push(Patched.id());
         }
         encodings
+    }
+
+    /// Children: packed=0, lane_offsets=1, patch_indices=2, patch_values=3.
+    fn num_children(&self) -> usize {
+        4
     }
 
     fn expected_compression_ratio(
@@ -105,9 +112,17 @@ impl Scheme for BitPackingScheme {
 
             match patches {
                 None => array,
-                Some(p) => Patched::from_array_and_patches(array, &p, exec_ctx)?
-                    .with_stats_set(packed_stats)
-                    .into_array(),
+                Some(p) => {
+                    let patched = Patched::from_array_and_patches(array, &p, exec_ctx)?
+                        .with_stats_set(packed_stats);
+                    return compress_patched_children(
+                        _compressor,
+                        patched,
+                        &_compress_ctx,
+                        self.id(),
+                        exec_ctx,
+                    );
+                }
             }
         } else {
             // Compress patches and place back into BitPackedArray.

--- a/vortex-btrblocks/src/schemes/integer/mod.rs
+++ b/vortex-btrblocks/src/schemes/integer/mod.rs
@@ -15,6 +15,8 @@ mod zigzag;
 
 #[cfg(feature = "pco")]
 mod pco;
+#[cfg(feature = "zstd")]
+mod zstd;
 
 pub use bitpacking::BitPackingScheme;
 #[cfg(feature = "unstable_encodings")]
@@ -33,6 +35,8 @@ pub use sparse::SparseScheme;
 pub use vortex_compressor::builtins::IntDictScheme;
 pub use vortex_compressor::stats::IntegerStats;
 pub use zigzag::ZigZagScheme;
+#[cfg(feature = "zstd")]
+pub use zstd::ZstdScheme;
 
 /// Threshold for the average run length in an array before we consider run-length encoding.
 pub(crate) const RUN_LENGTH_THRESHOLD: u32 = 4;

--- a/vortex-btrblocks/src/schemes/integer/zstd.rs
+++ b/vortex-btrblocks/src/schemes/integer/zstd.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Zstd string compression without dictionaries (nvCOMP compatible).
+//! Zstd integer compression.
 
 use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
@@ -18,17 +18,17 @@ use crate::CascadingCompressor;
 use crate::CompressorContext;
 use crate::Scheme;
 
-/// Zstd compression without dictionaries (nvCOMP compatible).
+/// Zstd compression for integer arrays.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ZstdScheme;
 
 impl Scheme for ZstdScheme {
     fn scheme_name(&self) -> &'static str {
-        "vortex.string.zstd"
+        "vortex.int.zstd"
     }
 
     fn matches(&self, canonical: &Canonical) -> bool {
-        canonical.dtype().is_utf8()
+        canonical.dtype().is_int()
     }
 
     fn produced_encodings(&self) -> Vec<ArrayId> {
@@ -51,13 +51,7 @@ impl Scheme for ZstdScheme {
         _compress_ctx: CompressorContext,
         exec_ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let compacted = data
-            .array_as_varbinview()
-            .into_owned()
-            .compact_buffers(exec_ctx)?;
-        Ok(
-            vortex_zstd::Zstd::from_var_bin_view_without_dict(&compacted, 3, 65536, exec_ctx)?
-                .into_array(),
-        )
+        let primitive = data.array_as_primitive().into_owned();
+        Ok(vortex_zstd::Zstd::from_primitive(&primitive, 3, 65536, exec_ctx)?.into_array())
     }
 }

--- a/vortex-btrblocks/src/schemes/patches.rs
+++ b/vortex-btrblocks/src/schemes/patches.rs
@@ -1,15 +1,42 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::Array;
 use vortex_array::ArrayRef;
+use vortex_array::ArraySlots;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::ConstantArray;
+use vortex_array::arrays::Patched;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::patched::PatchedArraySlotsExt;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_array::patches::Patches;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
+
+use crate::CascadingCompressor;
+use crate::CompressorContext;
+use crate::SchemeId;
+
+/// Compresses the physical patch-location and patch-value children of a patched array.
+pub fn compress_patched_children(
+    compressor: &CascadingCompressor,
+    array: Array<Patched>,
+    compress_ctx: &CompressorContext,
+    parent_id: SchemeId,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let slots = ArraySlots::from([
+        Some(array.inner().clone()),
+        Some(compressor.compress_child(array.lane_offsets(), compress_ctx, parent_id, 1, ctx)?),
+        Some(compressor.compress_child(array.patch_indices(), compress_ctx, parent_id, 2, ctx)?),
+        Some(compressor.compress_child(array.patch_values(), compress_ctx, parent_id, 3, ctx)?),
+    ]);
+
+    // SAFETY: each compressed child preserves the original logical dtype and values.
+    unsafe { array.into_array().with_slots(slots) }
+}
 
 /// Compresses the given patches by downscaling integers and checking for constant values.
 pub fn compress_patches(patches: Patches, ctx: &mut ExecutionCtx) -> VortexResult<Patches> {


### PR DESCRIPTION
## Summary

Improve the compact BtrBlocks compression model and scheme set used to produce the files explored by the follow-up Vortex Web compression diff viewer.

## Changes

- Account for ALP exception patch structure and index width when estimating encoded size.
- Add integer and float Zstd schemes to the compact compressor.
- Refine bitpacking and ALP patch-selection costs.
- Share patch-size calculations across schemes.
- Increase the value framing used by compact Zstd string and binary compression.
- Add focused tests for the updated estimates and scheme choices.

## Stack

1. This PR: compression/array-layer choices.
2. Follow-up: Vortex Web compression diff viewer (#9603).