### PR TITLE
feat(duckdb): overlap IO across two splits per scan thread

### DIFF
--- a/vortex-duckdb/include/vortex.h
+++ b/vortex-duckdb/include/vortex.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#define SPLITS_PER_SCAN 2
+
 #define COUNT_STAR_PROJ_IDX UINT64_MAX
 
 #ifdef __cplusplus

--- a/vortex-duckdb/src/file_reader.rs
+++ b/vortex-duckdb/src/file_reader.rs
@@ -205,10 +205,18 @@ pub const SPLITS_PER_SCAN: usize = 2;
 /// Takes up to [`SPLITS_PER_SCAN`] splits at once; reader_scan runs them
 /// concurrently so IO for the second split overlaps work on the first.
 pub fn reader_try_initialize_scan(file: &mut OpenFileReader, local: &mut LocalState) -> bool {
-    let take = SPLITS_PER_SCAN.min(file.splits.len());
-    if take == 0 {
+    if file.splits.is_empty() {
         return false;
     }
+    // Only take multiple splits while there are enough left to keep every
+    // scan thread busy; near the tail of a file grabbing two splits per
+    // thread halves effective parallelism on compute-bound scans.
+    let threads = vortex_utils::parallelism::get_available_parallelism().unwrap_or(1);
+    let take = if file.splits.len() >= SPLITS_PER_SCAN * threads {
+        SPLITS_PER_SCAN.min(file.splits.len())
+    } else {
+        1
+    };
     let splits = file.splits.split_off(file.splits.len() - take);
     // file.splits is stored in inverse order, so restore scan order
     let splits = stream::iter(splits.into_iter().rev());

--- a/vortex-duckdb/src/file_reader.rs
+++ b/vortex-duckdb/src/file_reader.rs
@@ -7,8 +7,11 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 
 use futures::FutureExt;
+use futures::StreamExt as _;
+use futures::stream;
 use object_store::registry::ObjectStoreRegistry;
 use url::Url;
+use vortex::array::ArrayRef;
 use vortex::array::VortexSessionExecute as _;
 use vortex::array::arrays::struct_::StructArrayExt as _;
 use vortex::cloud::Registry;
@@ -97,6 +100,8 @@ pub struct OpenFileReader {
     pub splits: Vec<Split>,
     pub cache: ConversionCache,
     total_splits: usize,
+    /// Whether split results must be emitted in file order.
+    ordered: bool,
 }
 
 impl OpenFileReader {
@@ -110,6 +115,7 @@ impl OpenFileReader {
             cache: ConversionCache::default(),
             splits: vec![],
             total_splits: 0,
+            ordered: false,
         })
     }
 
@@ -183,19 +189,52 @@ pub fn reader_initialize(file: &mut OpenFileReader, global: &GlobalState) -> Vor
     splits.reverse();
     file.total_splits = splits.len();
     file.splits = splits;
+    file.ordered = ordered;
     Ok(false)
 }
+
+/// Number of splits a single thread drives concurrently, overlapping the IO
+/// of the next split with the decode/export of the current one.
+pub const SPLITS_PER_SCAN: usize = 2;
 
 /// Called by all threads under global lock. If this function returns true,
 /// thread calls reader_scan on this file. If this function returns false,
 /// duckdb thinks file is exhausted, closes the file, and the first thread to
 /// get "false" switches to next file.
+///
+/// Takes up to [`SPLITS_PER_SCAN`] splits at once; reader_scan runs them
+/// concurrently so IO for the second split overlaps work on the first.
 pub fn reader_try_initialize_scan(file: &mut OpenFileReader, local: &mut LocalState) -> bool {
-    let Some(split) = file.splits.pop() else {
+    let take = SPLITS_PER_SCAN.min(file.splits.len());
+    if take == 0 {
         return false;
-    };
-    local.split = Some(split);
+    }
+    let splits = file.splits.split_off(file.splits.len() - take);
+    // file.splits is stored in inverse order, so restore scan order
+    let splits = stream::iter(splits.into_iter().rev());
+    // With a file_row_number column output order matters, so preserve split
+    // order; otherwise emit whichever split finishes first.
+    local.splits = Some(if file.ordered {
+        splits.buffered(SPLITS_PER_SCAN).boxed()
+    } else {
+        splits.buffer_unordered(SPLITS_PER_SCAN).boxed()
+    });
     true
+}
+
+/// Pull the next completed split result from the local split stream. Returns
+/// `None` when all splits taken by this thread are exhausted.
+fn next_split_array(local: &mut LocalState) -> VortexResult<Option<Option<ArrayRef>>> {
+    let Some(splits) = local.splits.as_mut() else {
+        return Ok(None);
+    };
+    match RUNTIME.block_on(splits.next()) {
+        Some(result) => Ok(Some(result?)),
+        None => {
+            local.splits = None;
+            Ok(None)
+        }
+    }
 }
 
 /// Called by all threads operating on a file without locks. If this function
@@ -212,10 +251,10 @@ pub fn reader_scan(
     }
 
     if local.exporter.is_none() {
-        let Some(split) = local.split.take() else {
+        let Some(array) = next_split_array(local)? else {
             return Ok(false);
         };
-        let Some(array) = RUNTIME.block_on(split)? else {
+        let Some(array) = array else {
             // split is filtered
             return Ok(true);
         };
@@ -233,10 +272,10 @@ pub fn reader_scan(
 }
 
 fn reader_scan_aggregate(global: &GlobalState, local: &mut LocalState) -> VortexResult<bool> {
-    let Some(split) = local.split.take() else {
+    let Some(array) = next_split_array(local)? else {
         return Ok(false);
     };
-    let Some(array) = RUNTIME.block_on(split)? else {
+    let Some(array) = array else {
         // split is filtered
         return Ok(true);
     };

--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::Ordering;
 
 use custom_labels::CURRENT_LABELSET;
 use futures::future::BoxFuture;
+use futures::stream::BoxStream;
 use itertools::Itertools;
 use num_traits::AsPrimitive;
 use parking_lot::Mutex;
@@ -160,13 +161,17 @@ assert_impl_all!(GlobalState: Send, Sync);
 
 pub type Split = BoxFuture<'static, VortexResult<Option<ArrayRef>>>;
 
+/// Stream of split results, driving up to [`crate::file_reader::SPLITS_PER_SCAN`]
+/// splits concurrently so IO for later splits overlaps decoding of earlier ones.
+pub type SplitStream = BoxStream<'static, VortexResult<Option<ArrayRef>>>;
+
 /// field position, accumulator
 pub type Partials = Vec<(usize, Box<dyn DynAccumulator>)>;
 
 /// Per-thread scan state
 pub struct LocalState {
     pub exporter: Option<ArrayExporter>,
-    pub split: Option<Split>,
+    pub splits: Option<SplitStream>,
 
     /// Empty for non-aggregate scan
     pub partials: Partials,
@@ -365,7 +370,7 @@ pub fn init_local(bind_data: &BindState, global: &GlobalState) -> LocalState {
     LocalState {
         exporter: None,
         partials,
-        split: None,
+        splits: None,
         finished: false,
     }
 }


### PR DESCRIPTION
## Summary

Each DuckDB scan thread previously took a single split at a time and blocked on its future before exporting, so the IO for the next split only started after the current one was fully consumed. This PR lets each thread take two splits at once and drive them concurrently, overlapping the second split's IO with decode/export of the first.

## Changes

- `reader_try_initialize_scan` now pops up to `SPLITS_PER_SCAN` (2) splits from the file instead of one and wraps them in a `futures` stream stored on `LocalState`.
- The stream uses `buffered` when the scan must preserve file order (a `file_row_number` column is projected) and `buffer_unordered` otherwise, so both split futures are polled concurrently while the thread awaits the next result.
- `reader_scan` and `reader_scan_aggregate` pull completed arrays from the stream via a shared `next_split_array` helper; when the stream drains, the thread returns to `reader_try_initialize_scan` for more splits.
- The `ordered` flag is computed once in `reader_initialize` and stored on `OpenFileReader`, since the FFI signature of `reader_try_initialize_scan` doesn't carry the global state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ch9tafX3sEQgvzCvzHnNHk)_