### PR TITLE
ci: measure duckdb query latency using duckdb profiler

### DIFF
--- a/benchmarks/duckdb-bench/src/lib.rs
+++ b/benchmarks/duckdb-bench/src/lib.rs
@@ -11,6 +11,7 @@ use std::time::Instant;
 use anyhow::Result;
 use tracing::trace;
 use vortex::error::VortexExpect;
+use vortex::error::vortex_err;
 use vortex_bench::Benchmark;
 use vortex_bench::Format;
 use vortex_bench::IdempotentPath;
@@ -130,6 +131,8 @@ impl DuckClient {
         // extension is loaded after the connection is established.
         connection.query("SET parquet_metadata_cache = true")?;
 
+        connection.query("PRAGMA enable_profiling = 'no_output'")?;
+
         Ok((db, connection))
     }
 
@@ -179,21 +182,6 @@ impl DuckClient {
         })
     }
 
-    /// Execute DuckDB queries for benchmarks using the internal connection.
-    /// Returns `(row_count, optional_timing)` where `optional_timing` is the query's
-    /// internal execution time if available.
-    pub fn execute_query(&self, query: &str) -> Result<(usize, Option<Duration>)> {
-        trace!("execute duckdb query: {query}");
-        let time_instant = Instant::now();
-        let result = self.connection().query(query)?;
-        let query_time = time_instant.elapsed();
-
-        let row_count = usize::try_from(result.row_count()).vortex_expect("row count overflow");
-
-        // TODO: Extract DuckDB's internal timing from profiling info if available
-        Ok((row_count, Some(query_time)))
-    }
-
     /// Register tables for benchmarks using the internal connection.
     pub fn register_tables<B: Benchmark + ?Sized>(
         &self,
@@ -239,13 +227,22 @@ impl DuckClient {
         Ok(())
     }
 
-    /// Execute a query and return a `DuckQueryResult` wrapper.
+    /// Execute a query
+    pub fn execute_query(&self, query: &str) -> Result<()> {
+        trace!("execute duckdb query: {query}");
+        self.connection().query(query)?;
+        Ok(())
+    }
+
+    /// Execute a query and return its result with query duration
     pub fn execute_query_result(&self, query: &str) -> Result<(Option<Duration>, DuckQueryResult)> {
         trace!("execute duckdb query: {query}");
-        let time_instant = Instant::now();
         let result = self.connection().query(query)?;
-        let query_time = time_instant.elapsed();
-        Ok((Some(query_time), DuckQueryResult(result)))
+        let time = self
+            .connection()
+            .last_query_latency()
+            .ok_or_else(|| anyhow::anyhow!("no query latency"))?;
+        Ok((Some(time), DuckQueryResult(result)))
     }
 }
 

--- a/benchmarks/duckdb-bench/src/lib.rs
+++ b/benchmarks/duckdb-bench/src/lib.rs
@@ -6,12 +6,10 @@
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::time::Duration;
-use std::time::Instant;
 
 use anyhow::Result;
 use tracing::trace;
 use vortex::error::VortexExpect;
-use vortex::error::vortex_err;
 use vortex_bench::Benchmark;
 use vortex_bench::Format;
 use vortex_bench::IdempotentPath;

--- a/benchmarks/duckdb-bench/src/lib.rs
+++ b/benchmarks/duckdb-bench/src/lib.rs
@@ -131,7 +131,10 @@ impl DuckClient {
         // extension is loaded after the connection is established.
         connection.query("SET parquet_metadata_cache = true")?;
 
+        // this allows collecting LATENCY metric after query
         connection.query("PRAGMA enable_profiling = 'no_output'")?;
+        // this allows collecting metrics specifically for Vortex
+        connection.query("PRAGMA profiling_coverage = 'all'")?;
 
         Ok((db, connection))
     }

--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -47,7 +47,7 @@ const SOURCE_FILES: [&str; 12] = [
 
 // Duckdb C API function we use.
 // This lowers codegen'd src/cpp.rs by four times.
-const DUCKDB_C_API_FUNCTIONS: [&str; 135] = [
+const DUCKDB_C_API_FUNCTIONS: [&str; 137] = [
     "duckdb_array_type_array_size",
     "duckdb_array_type_child_type",
     "duckdb_array_vector_get_child",
@@ -129,6 +129,7 @@ const DUCKDB_C_API_FUNCTIONS: [&str; 135] = [
     "duckdb_get_int8",
     "duckdb_get_list_child",
     "duckdb_get_list_size",
+    "duckdb_get_profiling_info",
     "duckdb_get_struct_child",
     "duckdb_get_time",
     "duckdb_get_time_ns",
@@ -157,6 +158,7 @@ const DUCKDB_C_API_FUNCTIONS: [&str; 135] = [
     "duckdb_map_type_value_type",
     "duckdb_open",
     "duckdb_open_ext",
+    "duckdb_profiling_info_get_value",
     "duckdb_query",
     "duckdb_result_error",
     "duckdb_row_count",

--- a/vortex-duckdb/src/duckdb/connection.rs
+++ b/vortex-duckdb/src/duckdb/connection.rs
@@ -3,13 +3,16 @@
 
 use std::ffi::CStr;
 use std::ptr;
+use std::time::Duration;
 
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
 
 use crate::cpp;
 use crate::duckdb::DatabaseRef;
+use crate::duckdb::ExtractedValue;
 use crate::duckdb::QueryResult;
+use crate::duckdb::Value;
 use crate::duckdb_try;
 use crate::lifetime_wrapper;
 
@@ -57,6 +60,28 @@ impl ConnectionRef {
 
         Ok(unsafe { QueryResult::new(result) })
     }
+
+    /// Last query's wall clock time or None if profiling was disabled.
+    pub fn last_query_latency(&self) -> Option<Duration> {
+        let info = unsafe { cpp::duckdb_get_profiling_info(self.as_ptr()) };
+        if info.is_null() {
+            return None;
+        }
+        let value = unsafe { cpp::duckdb_profiling_info_get_value(info, c"LATENCY".as_ptr()) };
+        if value.is_null() {
+            return None;
+        }
+        let value = unsafe { Value::own(value) };
+
+        let ExtractedValue::Varchar(seconds) = value.extract() else {
+            return None;
+        };
+        seconds
+            .parse::<f64>()
+            .ok()
+            .filter(|s| s.is_finite() && *s >= 0.0)
+            .map(Duration::from_secs_f64)
+    }
 }
 
 #[cfg(test)]
@@ -83,6 +108,23 @@ mod tests {
         let conn = test_connection().unwrap();
         let result = conn.query("SELECT 1");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_last_query_latency() {
+        let conn = test_connection().unwrap();
+        assert!(
+            conn.last_query_latency().is_none(),
+            "no latency before profiling is enabled"
+        );
+
+        conn.query("PRAGMA enable_profiling = 'no_output'").unwrap();
+        conn.query("SELECT count(*) FROM range(1000000)").unwrap();
+
+        let latency = conn
+            .last_query_latency()
+            .expect("LATENCY metric available once profiling is on");
+        assert!(latency > Duration::ZERO);
     }
 
     #[test]


### PR DESCRIPTION
Before we measured query latency inside duckdb-bench.
Move it to duckdb's own query profiler.
