### PR TITLE
Streaming chunked decompression via a composable vtable method

### DIFF
--- a/encodings/fastlanes/Cargo.toml
+++ b/encodings/fastlanes/Cargo.toml
@@ -70,3 +70,7 @@ harness = false
 name = "cast_bitpacked"
 harness = false
 required-features = ["_test-harness"]
+
+[[bench]]
+name = "chunked_decompress"
+harness = false

--- a/encodings/fastlanes/benches/chunked_decompress.rs
+++ b/encodings/fastlanes/benches/chunked_decompress.rs
@@ -441,3 +441,77 @@ fn execute_fused_for_bp_streaming(bencher: Bencher) {
 fn execute_fused_for_bp_levelwise(bencher: Bencher) {
     bench_execute(bencher, make_for_bitpacked(), false);
 }
+
+// ---------------------------------------------------------------------------------------------
+// Filter(BitPacked): the dominant TPC-H scan tree (736x at 65,536 rows in the Q1/Q6 trace).
+// Compares the streaming path (unpack a block, compact it in L1, write survivors once) against
+// level-wise execution (materialize the full 64K child, then run the compaction kernel over it).
+// ---------------------------------------------------------------------------------------------
+
+const SPLIT_LEN: usize = 65_536;
+
+/// Filter over BitPacked keeping `keep` rows out of every 16 (i.e. selectivity `keep/16`),
+/// giving the mask realistic run structure rather than alternating single rows.
+fn make_filter_bitpacked(keep: usize) -> ArrayRef {
+    let mut ctx = SESSION.create_execution_ctx();
+    let values = PrimitiveArray::from_iter(
+        (0..SPLIT_LEN as u64).map(|i| u32::try_from((i * 7) % 1000).vortex_expect("fits")),
+    );
+    let bp = bitpack_encode(&values, 10, None, &mut ctx)
+        .vortex_expect("bench")
+        .into_array();
+    const PERIOD: usize = 16;
+    assert!(keep < PERIOD, "mask must filter some rows out");
+    let mask = vortex_mask::Mask::from_iter((0..SPLIT_LEN).map(|i| (i % PERIOD) < keep));
+    bp.filter(mask).vortex_expect("bench")
+}
+
+/// `keep` rows out of every 16.
+const FILTER_KEEP: &[usize] = &[1, 4, 8, 12];
+
+#[divan::bench(args = FILTER_KEEP)]
+fn execute_filter_bp_streaming(bencher: Bencher, keep: usize) {
+    bench_execute(bencher, make_filter_bitpacked(keep), true);
+}
+
+#[divan::bench(args = FILTER_KEEP)]
+fn execute_filter_bp_levelwise(bencher: Bencher, keep: usize) {
+    bench_execute(bencher, make_filter_bitpacked(keep), false);
+}
+
+/// Consumption (not materialization): sum a Filter(BitPacked) tree. Streaming compacts each
+/// block in L1 and folds it directly; the baseline canonicalizes the filtered array first and
+/// then reads it back.
+#[divan::bench(args = FILTER_KEEP)]
+fn filter_bp_sum_streaming(bencher: Bencher, keep: usize) {
+    let array = make_filter_bitpacked(keep);
+    bencher
+        .with_inputs(|| (array.clone(), SESSION.create_execution_ctx()))
+        .bench_values(|(array, mut ctx)| {
+            let mut sink = SumSink { total: 0 };
+            array
+                .decompress_chunks(&mut ctx, &mut sink)
+                .vortex_expect("bench");
+            black_box(sink.total)
+        });
+}
+
+#[divan::bench(args = FILTER_KEEP)]
+fn filter_bp_sum_execute_then_read(bencher: Bencher, keep: usize) {
+    let array = make_filter_bitpacked(keep);
+    bencher
+        .with_inputs(|| (array.clone(), SESSION.create_execution_ctx()))
+        .bench_values(|(array, mut ctx)| {
+            vortex_array::chunk_iter::set_chunked_execute_enabled(false);
+            let primitive = array
+                .execute::<PrimitiveArray>(&mut ctx)
+                .vortex_expect("bench");
+            vortex_array::chunk_iter::set_chunked_execute_enabled(true);
+            let total: u64 = primitive
+                .as_slice::<u32>()
+                .iter()
+                .map(|&v| v as u64)
+                .fold(0, u64::wrapping_add);
+            black_box(total)
+        });
+}

--- a/encodings/fastlanes/benches/chunked_decompress.rs
+++ b/encodings/fastlanes/benches/chunked_decompress.rs
@@ -399,16 +399,26 @@ fn make_patched_for_bitpacked() -> ArrayRef {
         .into_array()
 }
 
+/// Canonicalize `array`, either by streaming chunks into the builder or by level-wise execution.
+/// Driving `execute_via_chunks` directly measures the mechanism itself, independent of the
+/// executor's depth heuristic.
 fn bench_execute(bencher: Bencher, array: ArrayRef, streaming: bool) {
     bencher
         .with_inputs(|| (array.clone(), SESSION.create_execution_ctx()))
         .bench_values(|(array, mut ctx)| {
-            vortex_array::chunk_iter::set_chunked_execute_enabled(streaming);
-            let result = array
-                .execute::<PrimitiveArray>(&mut ctx)
-                .vortex_expect("bench");
-            vortex_array::chunk_iter::set_chunked_execute_enabled(true);
-            black_box(result.len())
+            let len = if streaming {
+                vortex_array::chunk_iter::execute_via_chunks(&array, &mut ctx)
+                    .vortex_expect("bench")
+                    .len()
+            } else {
+                vortex_array::chunk_iter::set_chunked_execute_enabled(false);
+                let result = array
+                    .execute::<PrimitiveArray>(&mut ctx)
+                    .vortex_expect("bench");
+                vortex_array::chunk_iter::set_chunked_execute_enabled(true);
+                result.len()
+            };
+            black_box(len)
         });
 }
 
@@ -514,4 +524,42 @@ fn filter_bp_sum_execute_then_read(bencher: Bencher, keep: usize) {
                 .fold(0, u64::wrapping_add);
             black_box(total)
         });
+}
+
+// ---------------------------------------------------------------------------------------------
+// Depth sweep: does the streaming win grow with stack depth?
+//
+// Each level above the innermost fused FoR+BitPacked pair is a generic composition step. For
+// level-wise execution that is one extra *full-buffer* read+write pass over every value; for
+// streaming it is one extra pass over an L1-resident block. If the model is right, the gap
+// should widen roughly linearly with depth.
+// ---------------------------------------------------------------------------------------------
+
+/// `depth` nested FoR levels over one BitPacked leaf.
+fn make_for_stack(depth: usize) -> ArrayRef {
+    let mut ctx = SESSION.create_execution_ctx();
+    let deltas = PrimitiveArray::from_iter(
+        (0..LEN as u64).map(|i| u32::try_from((i * 7) % 1000).vortex_expect("fits")),
+    );
+    let mut array = bitpack_encode(&deltas, 10, None, &mut ctx)
+        .vortex_expect("bench")
+        .into_array();
+    for _ in 0..depth {
+        array = FoR::try_new(array, Scalar::from(1_000u32))
+            .vortex_expect("bench")
+            .into_array();
+    }
+    array
+}
+
+const STACK_DEPTHS: &[usize] = &[1, 2, 4, 8];
+
+#[divan::bench(args = STACK_DEPTHS)]
+fn execute_for_stack_streaming(bencher: Bencher, depth: usize) {
+    bench_execute(bencher, make_for_stack(depth), true);
+}
+
+#[divan::bench(args = STACK_DEPTHS)]
+fn execute_for_stack_levelwise(bencher: Bencher, depth: usize) {
+    bench_execute(bencher, make_for_stack(depth), false);
 }

--- a/encodings/fastlanes/benches/chunked_decompress.rs
+++ b/encodings/fastlanes/benches/chunked_decompress.rs
@@ -356,3 +356,88 @@ fn chunked_decompress_into_patched_constant(bencher: Bencher) {
             black_box(out.len())
         });
 }
+
+// ---------------------------------------------------------------------------------------------
+// Executor integration: execute::<PrimitiveArray> with the stream-to-canonical shortcut
+// (execute_until step 2c) enabled vs disabled, on realistic multi-level trees.
+// ---------------------------------------------------------------------------------------------
+
+/// FoR(signed reference) over BitPacked: the common shape for signed integers. The level-wise
+/// executor unpacks the full buffer, then does a second full-buffer wrapping-add pass; the
+/// streaming shortcut does the add in L1 per block and writes the output once.
+fn make_signed_for_bitpacked() -> ArrayRef {
+    let mut ctx = SESSION.create_execution_ctx();
+    let deltas = PrimitiveArray::from_iter(
+        (0..LEN as u64).map(|i| i32::try_from((i * 7) % 1000).vortex_expect("fits")),
+    );
+    let bp = bitpack_encode(&deltas, 10, None, &mut ctx).vortex_expect("bench");
+    FoR::try_new(bp.into_array(), Scalar::from(-1_000_000i32))
+        .vortex_expect("bench")
+        .into_array()
+}
+
+/// Patched(FoR(BitPacked)): G-ALP-style tree — bitpacked base, frame-of-reference shift, and
+/// sparse exceptions patched at the top.
+fn make_patched_for_bitpacked() -> ArrayRef {
+    let mut ctx = SESSION.create_execution_ctx();
+    let inner = make_for_bitpacked();
+    let n_patches = LEN / 1000;
+    let patches = vortex_array::patches::Patches::new(
+        LEN,
+        0,
+        PrimitiveArray::from_iter((0..n_patches as u64).map(|i| i * 1000)).into_array(),
+        PrimitiveArray::from_iter(
+            (0..n_patches as u64)
+                .map(|i| u32::try_from(2_000_000 + i % 90_000).vortex_expect("fits")),
+        )
+        .into_array(),
+        None,
+    )
+    .vortex_expect("bench");
+    vortex_array::arrays::Patched::from_array_and_patches(inner, &patches, &mut ctx)
+        .vortex_expect("bench")
+        .into_array()
+}
+
+fn bench_execute(bencher: Bencher, array: ArrayRef, streaming: bool) {
+    bencher
+        .with_inputs(|| (array.clone(), SESSION.create_execution_ctx()))
+        .bench_values(|(array, mut ctx)| {
+            vortex_array::chunk_iter::set_chunked_execute_enabled(streaming);
+            let result = array
+                .execute::<PrimitiveArray>(&mut ctx)
+                .vortex_expect("bench");
+            vortex_array::chunk_iter::set_chunked_execute_enabled(true);
+            black_box(result.len())
+        });
+}
+
+#[divan::bench]
+fn execute_signed_for_bp_streaming(bencher: Bencher) {
+    bench_execute(bencher, make_signed_for_bitpacked(), true);
+}
+
+#[divan::bench]
+fn execute_signed_for_bp_levelwise(bencher: Bencher) {
+    bench_execute(bencher, make_signed_for_bitpacked(), false);
+}
+
+#[divan::bench]
+fn execute_patched_for_bp_streaming(bencher: Bencher) {
+    bench_execute(bencher, make_patched_for_bitpacked(), true);
+}
+
+#[divan::bench]
+fn execute_patched_for_bp_levelwise(bencher: Bencher) {
+    bench_execute(bencher, make_patched_for_bitpacked(), false);
+}
+
+#[divan::bench]
+fn execute_fused_for_bp_streaming(bencher: Bencher) {
+    bench_execute(bencher, make_for_bitpacked(), true);
+}
+
+#[divan::bench]
+fn execute_fused_for_bp_levelwise(bencher: Bencher) {
+    bench_execute(bencher, make_for_bitpacked(), false);
+}

--- a/encodings/fastlanes/benches/chunked_decompress.rs
+++ b/encodings/fastlanes/benches/chunked_decompress.rs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Measures the composable chunked-decompression vtable path (`decompress_chunks`) for
+//! FoR-over-BitPacked against:
+//!
+//! - `two_pass`: full fused decompression to a `PrimitiveArray` followed by a second pass over
+//!   the materialized buffer (the pattern `decompress_chunks` is designed to replace).
+//! - `hand_fused`: a monomorphized loop over `BitUnpackedChunks` with the reference folded in
+//!   algebraically — the no-dispatch upper bound, equivalent to the fused `unpack_map` kernels.
+//!
+//! The gap between `chunked_vtable` and `hand_fused` is the exact price of the generic
+//! mechanism: one virtual call per 1024-element chunk per encoding level plus one in-place
+//! add pass over the L1-resident chunk at the FoR level.
+
+// The `#[gat(Item)]` import expansion trips unused_imports even though the lending iterator
+// machinery requires it.
+#![allow(unused_imports)]
+
+use std::hint::black_box;
+use std::ops::Range;
+use std::sync::LazyLock;
+
+use divan::Bencher;
+use lending_iterator::gat;
+use lending_iterator::prelude::Item;
+#[gat(Item)]
+use lending_iterator::prelude::LendingIterator;
+use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
+use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::chunk_iter::ChunkMut;
+use vortex_array::chunk_iter::ChunkSink;
+use vortex_array::scalar::Scalar;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_fastlanes::BitPackedArrayExt;
+use vortex_fastlanes::FoR;
+use vortex_fastlanes::FoRArraySlotsExt;
+use vortex_fastlanes::bitpack_compress::bitpack_encode;
+use vortex_fastlanes::unpack_iter::BitUnpackedChunks;
+use vortex_session::VortexSession;
+
+fn main() {
+    divan::main();
+}
+
+static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
+    let session = vortex_array::array_session();
+    vortex_fastlanes::initialize(&session);
+    session
+});
+
+const LEN: usize = 4 * 1024 * 1024;
+const REFERENCE: u32 = 1_000_000;
+
+/// FoR(reference=1M) over BitPacked(bit_width=10), no patches.
+fn make_for_bitpacked() -> ArrayRef {
+    let mut ctx = SESSION.create_execution_ctx();
+    let deltas = PrimitiveArray::from_iter(
+        (0..LEN as u64).map(|i| u32::try_from((i * 7) % 1000).vortex_expect("fits")),
+    );
+    let bp = bitpack_encode(&deltas, 10, None, &mut ctx).vortex_expect("bench");
+    FoR::try_new(bp.into_array(), Scalar::from(REFERENCE))
+        .vortex_expect("bench")
+        .into_array()
+}
+
+struct SumSink {
+    total: u64,
+}
+
+impl ChunkSink for SumSink {
+    #[inline]
+    fn accept(&mut self, chunk: ChunkMut<'_>, _row_range: Range<usize>) -> VortexResult<()> {
+        self.total = self
+            .total
+            .wrapping_add(chunk.as_slice::<u32>().iter().map(|&v| v as u64).sum());
+        Ok(())
+    }
+}
+
+/// Sum through the composable vtable path: BitPacked streams unpacked blocks, FoR shifts each
+/// block in place, the sink folds it — one streaming pass, no materialization.
+#[divan::bench]
+fn chunked_vtable_sum(bencher: Bencher) {
+    let array = make_for_bitpacked();
+    bencher
+        .with_inputs(|| (array.clone(), SESSION.create_execution_ctx()))
+        .bench_values(|(array, mut ctx)| {
+            let mut sink = SumSink { total: 0 };
+            array
+                .decompress_chunks(&mut ctx, &mut sink)
+                .vortex_expect("bench");
+            black_box(sink.total)
+        });
+}
+
+/// Sum by fully decompressing (the fused FoR+BitPacked execute path) and then re-reading the
+/// materialized array: two passes over `LEN` values.
+#[divan::bench]
+fn two_pass_sum(bencher: Bencher) {
+    let array = make_for_bitpacked();
+    bencher
+        .with_inputs(|| (array.clone(), SESSION.create_execution_ctx()))
+        .bench_values(|(array, mut ctx)| {
+            let primitive = array
+                .execute::<PrimitiveArray>(&mut ctx)
+                .vortex_expect("bench");
+            let total: u64 = primitive
+                .as_slice::<u32>()
+                .iter()
+                .map(|&v| v as u64)
+                .fold(0, u64::wrapping_add);
+            black_box(total)
+        });
+}
+
+/// Monomorphized upper bound: iterate the BitPacked child's unpacked blocks directly and fold
+/// the FoR reference in algebraically — no dynamic dispatch, no extra in-place pass.
+#[divan::bench]
+fn hand_fused_sum(bencher: Bencher) {
+    let array = make_for_bitpacked();
+    bencher.with_inputs(|| array.clone()).bench_values(|array| {
+        let for_ = array.as_::<FoR>();
+        let bp = for_.encoded().as_::<vortex_fastlanes::BitPacked>();
+        let mut chunks: BitUnpackedChunks<u32> = bp.unpacked_chunks().vortex_expect("bench");
+        let mut total = 0u64;
+        let mut count = 0u64;
+        if let Some(initial) = chunks.initial() {
+            total = total.wrapping_add(initial.iter().map(|&v| v as u64).sum());
+            count += initial.len() as u64;
+        }
+        let mut iter = chunks.full_chunks();
+        while let Some(chunk) = iter.next() {
+            total = total.wrapping_add(chunk.iter().map(|&v| v as u64).sum());
+            count += chunk.len() as u64;
+        }
+        if let Some(trailer) = chunks.trailer() {
+            total = total.wrapping_add(trailer.iter().map(|&v| v as u64).sum());
+            count += trailer.len() as u64;
+        }
+        black_box(total.wrapping_add(count * REFERENCE as u64))
+    });
+}
+
+/// Monomorphized version of exactly what the vtable path does per chunk (unpack, in-place
+/// reference add, then fold) but with zero dynamic dispatch. The gap between this and
+/// `hand_fused_sum` is the cost of the extra in-place pass; the gap between this and
+/// `chunked_vtable_sum` is the pure dynamic-dispatch cost (two virtual calls per 1024 values).
+#[divan::bench]
+fn hand_chunked_add_pass_sum(bencher: Bencher) {
+    let array = make_for_bitpacked();
+    bencher.with_inputs(|| array.clone()).bench_values(|array| {
+        let for_ = array.as_::<FoR>();
+        let bp = for_.encoded().as_::<vortex_fastlanes::BitPacked>();
+        let mut chunks: BitUnpackedChunks<u32> = bp.unpacked_chunks().vortex_expect("bench");
+        let mut total = 0u64;
+        let mut fold = |chunk: &mut [u32]| {
+            for v in chunk.iter_mut() {
+                *v = v.wrapping_add(REFERENCE);
+            }
+            total = total.wrapping_add(chunk.iter().map(|&v| v as u64).sum());
+        };
+        if let Some(initial) = chunks.initial() {
+            fold(initial);
+        }
+        let mut iter = chunks.full_chunks();
+        while let Some(chunk) = iter.next() {
+            fold(chunk);
+        }
+        if let Some(trailer) = chunks.trailer() {
+            fold(trailer);
+        }
+        black_box(total)
+    });
+}
+
+struct WriteSink<'a> {
+    out: &'a mut Vec<u32>,
+}
+
+impl ChunkSink for WriteSink<'_> {
+    #[inline]
+    fn accept(&mut self, chunk: ChunkMut<'_>, _row_range: Range<usize>) -> VortexResult<()> {
+        self.out.extend_from_slice(chunk.as_slice::<u32>());
+        Ok(())
+    }
+}
+
+/// Materialize through the chunked path (unpack to scratch, add reference in place, copy out) —
+/// upper-bounds the cost of the non-fused composition when the consumer wants a full buffer.
+#[divan::bench]
+fn chunked_vtable_decompress_into(bencher: Bencher) {
+    let array = make_for_bitpacked();
+    bencher
+        .with_inputs(|| {
+            (
+                array.clone(),
+                SESSION.create_execution_ctx(),
+                Vec::<u32>::with_capacity(LEN),
+            )
+        })
+        .bench_values(|(array, mut ctx, mut out)| {
+            let mut sink = WriteSink { out: &mut out };
+            array
+                .decompress_chunks(&mut ctx, &mut sink)
+                .vortex_expect("bench");
+            black_box(out.len())
+        });
+}
+
+/// Materialize through the fused execute path (`decode_into` writes unpacked+shifted values
+/// straight into the output buffer) — the specialized baseline for full decompression.
+#[divan::bench]
+fn fused_decompress(bencher: Bencher) {
+    let array = make_for_bitpacked();
+    bencher
+        .with_inputs(|| (array.clone(), SESSION.create_execution_ctx()))
+        .bench_values(|(array, mut ctx)| {
+            let primitive = array
+                .execute::<PrimitiveArray>(&mut ctx)
+                .vortex_expect("bench");
+            black_box(primitive.len())
+        });
+}

--- a/encodings/fastlanes/benches/chunked_decompress.rs
+++ b/encodings/fastlanes/benches/chunked_decompress.rs
@@ -81,8 +81,9 @@ impl ChunkSink for SumSink {
     }
 }
 
-/// Sum through the composable vtable path: BitPacked streams unpacked blocks, FoR shifts each
-/// block in place, the sink folds it — one streaming pass, no materialization.
+/// Sum through the composable vtable path. With an unsigned reference over BitPacked, FoR takes
+/// its fused streaming path: each block is unpacked with the reference folded into the kernel
+/// and handed straight to the sink — one streaming pass, no materialization, no extra add pass.
 #[divan::bench]
 fn chunked_vtable_sum(bencher: Bencher) {
     let array = make_for_bitpacked();
@@ -90,6 +91,44 @@ fn chunked_vtable_sum(bencher: Bencher) {
         .with_inputs(|| (array.clone(), SESSION.create_execution_ctx()))
         .bench_values(|(array, mut ctx)| {
             let mut sink = SumSink { total: 0 };
+            array
+                .decompress_chunks(&mut ctx, &mut sink)
+                .vortex_expect("bench");
+            black_box(sink.total)
+        });
+}
+
+/// Same as `chunked_vtable_sum` but with a signed FoR reference, which skips the fused
+/// FoR+BitPacked dispatch and exercises the generic composition: BitPacked streams plain
+/// unpacked blocks and FoR's sink adapter adds the reference in place per chunk.
+#[divan::bench]
+fn chunked_vtable_sum_generic_compose(bencher: Bencher) {
+    let mut ctx = SESSION.create_execution_ctx();
+    let deltas = PrimitiveArray::from_iter(
+        (0..LEN as u64).map(|i| i32::try_from((i * 7) % 1000).vortex_expect("fits")),
+    );
+    let bp = bitpack_encode(&deltas, 10, None, &mut ctx).vortex_expect("bench");
+    let array = FoR::try_new(bp.into_array(), Scalar::from(-1_000_000i32))
+        .vortex_expect("bench")
+        .into_array();
+
+    struct SumSinkI32 {
+        total: i64,
+    }
+    impl ChunkSink for SumSinkI32 {
+        #[inline]
+        fn accept(&mut self, chunk: ChunkMut<'_>, _row_range: Range<usize>) -> VortexResult<()> {
+            self.total = self
+                .total
+                .wrapping_add(chunk.as_slice::<i32>().iter().map(|&v| v as i64).sum());
+            Ok(())
+        }
+    }
+
+    bencher
+        .with_inputs(|| (array.clone(), SESSION.create_execution_ctx()))
+        .bench_values(|(array, mut ctx)| {
+            let mut sink = SumSinkI32 { total: 0 };
             array
                 .decompress_chunks(&mut ctx, &mut sink)
                 .vortex_expect("bench");

--- a/encodings/fastlanes/benches/chunked_decompress.rs
+++ b/encodings/fastlanes/benches/chunked_decompress.rs
@@ -264,3 +264,57 @@ fn fused_decompress(bencher: Bencher) {
             black_box(primitive.len())
         });
 }
+
+/// Patched(Constant): the base never materializes — Constant re-emits one L1-resident scratch
+/// chunk and Patched's sink adapter overwrites the sparse patch rows per chunk.
+fn make_patched_constant() -> ArrayRef {
+    let mut ctx = SESSION.create_execution_ctx();
+    let inner = vortex_array::arrays::ConstantArray::new(42u32, LEN).into_array();
+    let n_patches = LEN / 1000;
+    let patches = vortex_array::patches::Patches::new(
+        LEN,
+        0,
+        PrimitiveArray::from_iter((0..n_patches as u64).map(|i| i * 1000)).into_array(),
+        PrimitiveArray::from_iter(
+            (0..n_patches as u64).map(|i| u32::try_from(i % 90_000).vortex_expect("fits")),
+        )
+        .into_array(),
+        None,
+    )
+    .vortex_expect("bench");
+    vortex_array::arrays::Patched::from_array_and_patches(inner, &patches, &mut ctx)
+        .vortex_expect("bench")
+        .into_array()
+}
+
+#[divan::bench]
+fn chunked_vtable_sum_patched_constant(bencher: Bencher) {
+    let array = make_patched_constant();
+    bencher
+        .with_inputs(|| (array.clone(), SESSION.create_execution_ctx()))
+        .bench_values(|(array, mut ctx)| {
+            let mut sink = SumSink { total: 0 };
+            array
+                .decompress_chunks(&mut ctx, &mut sink)
+                .vortex_expect("bench");
+            black_box(sink.total)
+        });
+}
+
+#[divan::bench]
+fn two_pass_sum_patched_constant(bencher: Bencher) {
+    let array = make_patched_constant();
+    bencher
+        .with_inputs(|| (array.clone(), SESSION.create_execution_ctx()))
+        .bench_values(|(array, mut ctx)| {
+            let primitive = array
+                .execute::<PrimitiveArray>(&mut ctx)
+                .vortex_expect("bench");
+            let total: u64 = primitive
+                .as_slice::<u32>()
+                .iter()
+                .map(|&v| v as u64)
+                .fold(0, u64::wrapping_add);
+            black_box(total)
+        });
+}

--- a/encodings/fastlanes/benches/chunked_decompress.rs
+++ b/encodings/fastlanes/benches/chunked_decompress.rs
@@ -318,3 +318,41 @@ fn two_pass_sum_patched_constant(bencher: Bencher) {
             black_box(total)
         });
 }
+
+/// Sparse decompression baseline: `execute` on Patched(Constant) canonicalizes the constant into
+/// a full-length buffer, then scatters the sparse patches over it — one full-buffer write pass
+/// plus sparse writes, materializing the array.
+#[divan::bench]
+fn sparse_decompress_patched_constant(bencher: Bencher) {
+    let array = make_patched_constant();
+    bencher
+        .with_inputs(|| (array.clone(), SESSION.create_execution_ctx()))
+        .bench_values(|(array, mut ctx)| {
+            let primitive = array
+                .execute::<PrimitiveArray>(&mut ctx)
+                .vortex_expect("bench");
+            black_box(primitive.len())
+        });
+}
+
+/// Materialize Patched(Constant) through the chunked path: splat the constant into an 8KB
+/// scratch, patch it, and copy each chunk out to the destination buffer.
+#[divan::bench]
+fn chunked_decompress_into_patched_constant(bencher: Bencher) {
+    let array = make_patched_constant();
+    bencher
+        .with_inputs(|| {
+            (
+                array.clone(),
+                SESSION.create_execution_ctx(),
+                Vec::<u32>::with_capacity(LEN),
+            )
+        })
+        .bench_values(|(array, mut ctx, mut out)| {
+            let mut sink = WriteSink { out: &mut out };
+            array
+                .decompress_chunks(&mut ctx, &mut sink)
+                .vortex_expect("bench");
+            black_box(out.len())
+        });
+}

--- a/encodings/fastlanes/src/bitpacking/array/chunked_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/chunked_decompress.rs
@@ -235,11 +235,12 @@ mod tests {
 
 #[cfg(test)]
 mod executor_tests {
+    use vortex_array::ArrayRef;
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
-    use vortex_array::chunk_iter::set_chunked_execute_enabled;
+    use vortex_array::chunk_iter::execute_via_chunks;
     use vortex_array::scalar::Scalar;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
@@ -249,25 +250,61 @@ mod executor_tests {
     use crate::FoR;
     use crate::bitpack_compress::bitpack_encode;
 
-    /// The executor's stream-to-canonical shortcut must produce the same canonical array as
-    /// level-wise execution, including validity, on a nullable multi-level tree.
-    #[test]
-    fn execute_via_chunks_matches_levelwise() -> VortexResult<()> {
-        let mut ctx = SESSION.create_execution_ctx();
+    /// `depth` nested FoR levels over a nullable BitPacked leaf.
+    fn for_stack(depth: usize, ctx: &mut vortex_array::ExecutionCtx) -> VortexResult<ArrayRef> {
         let values = Buffer::from_iter((0..5000i32).map(|i| i % 900));
         let validity = Validity::from_iter((0..5000).map(|i| i % 7 != 0));
-        let deltas = PrimitiveArray::new(values, validity);
-        let bp = bitpack_encode(&deltas, 10, None, &mut ctx)?;
-        // Signed reference so the generic streaming composition (not the fused path) is used.
-        let array = FoR::try_new(bp.into_array(), Scalar::from(-1_000_000i32))?.into_array();
+        let mut array =
+            bitpack_encode(&PrimitiveArray::new(values, validity), 10, None, ctx)?.into_array();
+        for _ in 0..depth {
+            // A signed reference keeps every level on the generic streaming composition rather
+            // than the fused FoR+BitPacked kernel.
+            array = FoR::try_new(array, Scalar::from(-1_000i32))?.into_array();
+        }
+        Ok(array)
+    }
 
-        set_chunked_execute_enabled(false);
-        let levelwise = array.clone().execute::<PrimitiveArray>(&mut ctx);
-        set_chunked_execute_enabled(true);
-        let levelwise = levelwise?;
-        let streaming = array.execute::<PrimitiveArray>(&mut ctx)?;
+    /// Streaming a tree to canonical must match level-wise execution exactly, including
+    /// validity, at every stack depth.
+    #[rstest::rstest]
+    #[case::single(1)]
+    #[case::pair(2)]
+    #[case::deep(5)]
+    fn execute_via_chunks_matches_levelwise(#[case] depth: usize) -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let array = for_stack(depth, &mut ctx)?;
+        assert!(array.supports_decompress_chunks());
+
+        let streaming = execute_via_chunks(&array, &mut ctx)?;
+        let levelwise = array.execute::<PrimitiveArray>(&mut ctx)?;
 
         assert_arrays_eq!(streaming, levelwise, &mut ctx);
+        Ok(())
+    }
+
+    /// The executor only takes the streaming shortcut once a tree is deep enough for it to pay
+    /// off, and never for cardinality-changing roots.
+    #[test]
+    fn executor_depth_rule() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+
+        assert!(!for_stack(1, &mut ctx)?.should_execute_via_chunks());
+        assert!(!for_stack(2, &mut ctx)?.should_execute_via_chunks());
+        assert!(for_stack(3, &mut ctx)?.should_execute_via_chunks());
+        assert!(for_stack(8, &mut ctx)?.should_execute_via_chunks());
+
+        // A Filter root streams, but never through the executor: its level-wise kernel already
+        // decodes into the output and compacts in place, so there is no intermediate to remove.
+        let filtered = for_stack(0, &mut ctx)?
+            .filter(vortex_mask::Mask::from_iter((0..5000).map(|i| i % 3 == 0)))?;
+        assert!(filtered.supports_decompress_chunks());
+        assert!(!filtered.should_execute_via_chunks());
+
+        // Filter push-down can sink a filter beneath a deep stack; the levels above it still
+        // stream, because each of them would otherwise materialize a full intermediate.
+        let deep_filtered = for_stack(8, &mut ctx)?
+            .filter(vortex_mask::Mask::from_iter((0..5000).map(|i| i % 3 == 0)))?;
+        assert!(deep_filtered.should_execute_via_chunks());
         Ok(())
     }
 }
@@ -279,7 +316,7 @@ mod filter_tests {
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
-    use vortex_array::chunk_iter::set_chunked_execute_enabled;
+    use vortex_array::chunk_iter::execute_via_chunks;
     use vortex_error::VortexResult;
     use vortex_mask::Mask;
 
@@ -305,11 +342,8 @@ mod filter_tests {
         let filtered = bp.filter(mask)?;
         assert!(filtered.supports_decompress_chunks());
 
-        set_chunked_execute_enabled(false);
-        let levelwise = filtered.clone().execute::<PrimitiveArray>(&mut ctx);
-        set_chunked_execute_enabled(true);
-        let levelwise = levelwise?;
-        let streaming = filtered.execute::<PrimitiveArray>(&mut ctx)?;
+        let streaming = execute_via_chunks(&filtered, &mut ctx)?;
+        let levelwise = filtered.execute::<PrimitiveArray>(&mut ctx)?;
 
         assert_eq!(streaming.len(), levelwise.len());
         assert_arrays_eq!(streaming, levelwise, &mut ctx);

--- a/encodings/fastlanes/src/bitpacking/array/chunked_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/chunked_decompress.rs
@@ -271,3 +271,63 @@ mod executor_tests {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod filter_tests {
+    use rstest::rstest;
+    use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::assert_arrays_eq;
+    use vortex_array::chunk_iter::set_chunked_execute_enabled;
+    use vortex_error::VortexResult;
+    use vortex_mask::Mask;
+
+    use super::tests::SESSION;
+    use crate::bitpack_compress::bitpack_encode;
+
+    /// Filter over BitPacked must stream to the same canonical result as level-wise execution,
+    /// across selectivities and mask shapes that straddle the 1024-element block boundary.
+    #[rstest]
+    #[case::sparse(97)]
+    #[case::medium(7)]
+    #[case::dense(2)]
+    #[case::every_row(1)]
+    fn filter_over_bitpacked_streams_like_execute(#[case] keep_every: usize) -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let len = 5000;
+        let values = PrimitiveArray::from_iter((0..len as u32).map(|i| i % 900));
+        let bp = bitpack_encode(&values, 10, None, &mut ctx)?.into_array();
+
+        // A run-structured mask: keeps a 3-wide run every `keep_every` rows, so runs cross
+        // block boundaries at 1024/2048/... for several of these cases.
+        let mask = Mask::from_iter((0..len).map(|i| (i % keep_every) < 3));
+        let filtered = bp.filter(mask)?;
+        assert!(filtered.supports_decompress_chunks());
+
+        set_chunked_execute_enabled(false);
+        let levelwise = filtered.clone().execute::<PrimitiveArray>(&mut ctx);
+        set_chunked_execute_enabled(true);
+        let levelwise = levelwise?;
+        let streaming = filtered.execute::<PrimitiveArray>(&mut ctx)?;
+
+        assert_eq!(streaming.len(), levelwise.len());
+        assert_arrays_eq!(streaming, levelwise, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn filter_all_false_and_all_true_over_bitpacked() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let values = PrimitiveArray::from_iter((0..3000u32).map(|i| i % 900));
+        let bp = bitpack_encode(&values, 10, None, &mut ctx)?.into_array();
+
+        let none = bp.filter(Mask::new_false(3000))?;
+        assert_eq!(none.execute::<PrimitiveArray>(&mut ctx)?.len(), 0);
+
+        let all = bp.filter(Mask::new_true(3000))?;
+        let all = all.execute::<PrimitiveArray>(&mut ctx)?;
+        assert_arrays_eq!(all, values, &mut ctx);
+        Ok(())
+    }
+}

--- a/encodings/fastlanes/src/bitpacking/array/chunked_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/chunked_decompress.rs
@@ -119,7 +119,7 @@ mod tests {
     use crate::FoRData;
     use crate::bitpack_compress::bitpack_encode;
 
-    static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
+    pub(super) static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
         let session = vortex_array::array_session();
         crate::initialize(&session);
         session
@@ -229,6 +229,45 @@ mod tests {
         let bp = bitpack_encode(&values, 0, None, &mut ctx)?;
         let chunked = collect_chunks::<u32>(&bp.into_array())?;
         assert!(chunked.is_empty());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod executor_tests {
+    use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::assert_arrays_eq;
+    use vortex_array::chunk_iter::set_chunked_execute_enabled;
+    use vortex_array::scalar::Scalar;
+    use vortex_array::validity::Validity;
+    use vortex_buffer::Buffer;
+    use vortex_error::VortexResult;
+
+    use super::tests::SESSION;
+    use crate::FoR;
+    use crate::bitpack_compress::bitpack_encode;
+
+    /// The executor's stream-to-canonical shortcut must produce the same canonical array as
+    /// level-wise execution, including validity, on a nullable multi-level tree.
+    #[test]
+    fn execute_via_chunks_matches_levelwise() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let values = Buffer::from_iter((0..5000i32).map(|i| i % 900));
+        let validity = Validity::from_iter((0..5000).map(|i| i % 7 != 0));
+        let deltas = PrimitiveArray::new(values, validity);
+        let bp = bitpack_encode(&deltas, 10, None, &mut ctx)?;
+        // Signed reference so the generic streaming composition (not the fused path) is used.
+        let array = FoR::try_new(bp.into_array(), Scalar::from(-1_000_000i32))?.into_array();
+
+        set_chunked_execute_enabled(false);
+        let levelwise = array.clone().execute::<PrimitiveArray>(&mut ctx);
+        set_chunked_execute_enabled(true);
+        let levelwise = levelwise?;
+        let streaming = array.execute::<PrimitiveArray>(&mut ctx)?;
+
+        assert_arrays_eq!(streaming, levelwise, &mut ctx);
         Ok(())
     }
 }

--- a/encodings/fastlanes/src/bitpacking/array/chunked_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/chunked_decompress.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Streaming chunked decompression for bit-packed arrays.
+//!
+//! This backs [`VTable::decompress_chunks`](vortex_array::vtable::VTable::decompress_chunks) for
+//! [`BitPacked`]: each FastLanes block is unpacked into the decompressor's cache-resident scratch
+//! buffer, patches falling in that block are applied in place, and the block is handed to the
+//! sink — the array is never materialized in full.
+
+use num_traits::AsPrimitive;
+use vortex_array::ArrayView;
+use vortex_array::ExecutionCtx;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::chunk_iter::ChunkMut;
+use vortex_array::chunk_iter::ChunkSink;
+use vortex_array::match_each_integer_ptype;
+use vortex_array::match_each_unsigned_integer_ptype;
+use vortex_error::VortexResult;
+
+use crate::BitPacked;
+use crate::BitPackedArrayExt;
+use crate::unpack_iter::BitPacked as BitPackedUnpack;
+
+pub(crate) fn decompress_chunks(
+    array: ArrayView<'_, BitPacked>,
+    ctx: &mut ExecutionCtx,
+    sink: &mut dyn ChunkSink,
+) -> VortexResult<()> {
+    match_each_integer_ptype!(array.as_ref().dtype().as_ptype(), |T| {
+        decompress_chunks_typed::<T>(array, ctx, sink)
+    })
+}
+
+fn decompress_chunks_typed<T: BitPackedUnpack>(
+    array: ArrayView<'_, BitPacked>,
+    ctx: &mut ExecutionCtx,
+    sink: &mut dyn ChunkSink,
+) -> VortexResult<()> {
+    if array.as_ref().is_empty() {
+        return Ok(());
+    }
+
+    // Patches are sparse: materialize them once as (local row, value) pairs so the per-chunk
+    // loop only advances a cursor. This is the only heap state the streaming path allocates,
+    // and it is proportional to the patch count, not the array length.
+    let patch_list: Vec<(usize, T)> = match array.patches() {
+        None => Vec::new(),
+        Some(patches) => {
+            let indices = patches.indices().clone().execute::<PrimitiveArray>(ctx)?;
+            let values = patches.values().clone().execute::<PrimitiveArray>(ctx)?;
+            let values = values.as_slice::<T>();
+            let offset = patches.offset();
+            match_each_unsigned_integer_ptype!(indices.ptype(), |P| {
+                indices
+                    .as_slice::<P>()
+                    .iter()
+                    .zip(values)
+                    .map(|(&idx, &v)| (<P as AsPrimitive<usize>>::as_(idx) - offset, v))
+                    .collect()
+            })
+        }
+    };
+
+    let mut chunks = array.unpacked_chunks::<T>()?;
+    let mut patch_cursor = 0usize;
+    let mut result = Ok(());
+    chunks.for_each_unpacked_chunk(|chunk, range| {
+        if result.is_err() {
+            return;
+        }
+        while let Some(&(row, value)) = patch_list.get(patch_cursor)
+            && row < range.end
+        {
+            chunk[row - range.start] = value;
+            patch_cursor += 1;
+        }
+        result = sink.accept(ChunkMut::new(chunk), range);
+    });
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::LazyLock;
+
+    use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::chunk_iter::ChunkMut;
+    use vortex_array::dtype::NativePType;
+    use vortex_error::VortexResult;
+    use vortex_session::VortexSession;
+
+    use crate::BitPackedArrayExt;
+    use crate::FoRArraySlotsExt;
+    use crate::FoRData;
+    use crate::bitpack_compress::bitpack_encode;
+
+    static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
+        let session = vortex_array::array_session();
+        crate::initialize(&session);
+        session
+    });
+
+    fn collect_chunks<T: NativePType>(array: &vortex_array::ArrayRef) -> VortexResult<Vec<T>> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let mut out = Vec::with_capacity(array.len());
+        array.decompress_chunks(&mut ctx, &mut |chunk: ChunkMut<'_>,
+                                                 _range: std::ops::Range<usize>|
+         -> VortexResult<()> {
+            out.extend_from_slice(chunk.as_slice::<T>());
+            Ok(())
+        })?;
+        Ok(out)
+    }
+
+    fn assert_chunks_match_execute<T: NativePType>(
+        array: vortex_array::ArrayRef,
+    ) -> VortexResult<()> {
+        let chunked = collect_chunks::<T>(&array)?;
+        let mut ctx = SESSION.create_execution_ctx();
+        let expected = array.execute::<PrimitiveArray>(&mut ctx)?;
+        assert_eq!(chunked.as_slice(), expected.as_slice::<T>());
+        Ok(())
+    }
+
+    #[test]
+    fn bitpacked_chunks_match_execute() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let values = PrimitiveArray::from_iter((0..5000u32).map(|i| i % 900));
+        let bp = bitpack_encode(&values, 10, None, &mut ctx)?;
+        assert_chunks_match_execute::<u32>(bp.into_array())
+    }
+
+    #[test]
+    fn bitpacked_chunks_with_patches() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let values = PrimitiveArray::from_iter(
+            (0..5000u32).map(|i| if i % 700 == 0 { 100_000 + i } else { i % 900 }),
+        );
+        let bp = bitpack_encode(&values, 10, None, &mut ctx)?;
+        assert!(bp.patches().is_some());
+        assert_chunks_match_execute::<u32>(bp.into_array())
+    }
+
+    #[test]
+    fn bitpacked_chunks_sliced() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let values = PrimitiveArray::from_iter(
+            (0..5000u32).map(|i| if i % 700 == 0 { 100_000 + i } else { i % 900 }),
+        );
+        let bp = bitpack_encode(&values, 10, None, &mut ctx)?.into_array();
+        // Slice crossing chunk boundaries with a non-zero offset.
+        let sliced = bp.slice(517..4013)?;
+        // The slice may no longer be a BitPacked array head, but chunked iteration must still
+        // stream correct values via whatever encodings the slice resolves to.
+        assert_chunks_match_execute::<u32>(sliced)
+    }
+
+    #[test]
+    fn for_over_bitpacked_chunks() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let values = PrimitiveArray::from_iter((0..5000i64).map(|i| 1_000_000 + (i * 7) % 800));
+        let for_array = FoRData::encode(values, &mut ctx)?;
+        assert!(
+            for_array.encoded().as_opt::<crate::BitPacked>().is_some()
+                || for_array
+                    .encoded()
+                    .as_opt::<vortex_array::arrays::Primitive>()
+                    .is_some()
+        );
+        assert_chunks_match_execute::<i64>(for_array.into_array())
+    }
+
+    #[test]
+    fn fallback_primitive_chunks() -> VortexResult<()> {
+        let values = PrimitiveArray::from_iter(0..3000i32).into_array();
+        assert_chunks_match_execute::<i32>(values)
+    }
+
+    #[test]
+    fn empty_array_chunks() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let values = PrimitiveArray::from_iter(Vec::<u32>::new());
+        let bp = bitpack_encode(&values, 0, None, &mut ctx)?;
+        let chunked = collect_chunks::<u32>(&bp.into_array())?;
+        assert!(chunked.is_empty());
+        Ok(())
+    }
+}

--- a/encodings/fastlanes/src/bitpacking/array/chunked_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/chunked_decompress.rs
@@ -128,8 +128,10 @@ mod tests {
     fn collect_chunks<T: NativePType>(array: &vortex_array::ArrayRef) -> VortexResult<Vec<T>> {
         let mut ctx = SESSION.create_execution_ctx();
         let mut out = Vec::with_capacity(array.len());
-        array.decompress_chunks(&mut ctx, &mut |chunk: ChunkMut<'_>,
-                                                 _range: std::ops::Range<usize>|
+        array.decompress_chunks_or_materialize(&mut ctx, &mut |chunk: ChunkMut<'_>,
+                                                                _range: std::ops::Range<
+            usize,
+        >|
          -> VortexResult<()> {
             out.extend_from_slice(chunk.as_slice::<T>());
             Ok(())
@@ -152,7 +154,9 @@ mod tests {
         let mut ctx = SESSION.create_execution_ctx();
         let values = PrimitiveArray::from_iter((0..5000u32).map(|i| i % 900));
         let bp = bitpack_encode(&values, 10, None, &mut ctx)?;
-        assert_chunks_match_execute::<u32>(bp.into_array())
+        let array = bp.into_array();
+        assert!(array.supports_decompress_chunks());
+        assert_chunks_match_execute::<u32>(array)
     }
 
     #[test]

--- a/encodings/fastlanes/src/bitpacking/array/chunked_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/chunked_decompress.rs
@@ -14,13 +14,18 @@ use vortex_array::ExecutionCtx;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::chunk_iter::ChunkMut;
 use vortex_array::chunk_iter::ChunkSink;
+use vortex_array::dtype::NativePType;
+use vortex_array::dtype::PhysicalPType;
 use vortex_array::match_each_integer_ptype;
 use vortex_array::match_each_unsigned_integer_ptype;
+use vortex_array::patches::Patches;
 use vortex_error::VortexResult;
 
 use crate::BitPacked;
 use crate::BitPackedArrayExt;
 use crate::unpack_iter::BitPacked as BitPackedUnpack;
+use crate::unpack_iter::UnpackStrategy;
+use crate::unpack_iter::UnpackedChunks;
 
 pub(crate) fn decompress_chunks(
     array: ArrayView<'_, BitPacked>,
@@ -41,28 +46,45 @@ fn decompress_chunks_typed<T: BitPackedUnpack>(
         return Ok(());
     }
 
-    // Patches are sparse: materialize them once as (local row, value) pairs so the per-chunk
-    // loop only advances a cursor. This is the only heap state the streaming path allocates,
-    // and it is proportional to the patch count, not the array length.
-    let patch_list: Vec<(usize, T)> = match array.patches() {
+    let patch_list = match array.patches() {
         None => Vec::new(),
-        Some(patches) => {
-            let indices = patches.indices().clone().execute::<PrimitiveArray>(ctx)?;
-            let values = patches.values().clone().execute::<PrimitiveArray>(ctx)?;
-            let values = values.as_slice::<T>();
-            let offset = patches.offset();
-            match_each_unsigned_integer_ptype!(indices.ptype(), |P| {
-                indices
-                    .as_slice::<P>()
-                    .iter()
-                    .zip(values)
-                    .map(|(&idx, &v)| (<P as AsPrimitive<usize>>::as_(idx) - offset, v))
-                    .collect()
-            })
-        }
+        Some(patches) => build_patch_list(&patches, ctx, |v: T| v)?,
     };
 
     let mut chunks = array.unpacked_chunks::<T>()?;
+    stream_unpacked_chunks(&mut chunks, &patch_list, sink)
+}
+
+/// Materialize sparse patches once as sorted (local row, value) pairs so the per-chunk loop only
+/// advances a cursor, applying `map` to each patch value. This is the only heap state the
+/// streaming path allocates, and it is proportional to the patch count, not the array length.
+pub(crate) fn build_patch_list<T: NativePType>(
+    patches: &Patches,
+    ctx: &mut ExecutionCtx,
+    map: impl Fn(T) -> T,
+) -> VortexResult<Vec<(usize, T)>> {
+    let indices = patches.indices().clone().execute::<PrimitiveArray>(ctx)?;
+    let values = patches.values().clone().execute::<PrimitiveArray>(ctx)?;
+    let values = values.as_slice::<T>();
+    let offset = patches.offset();
+    Ok(match_each_unsigned_integer_ptype!(indices.ptype(), |P| {
+        indices
+            .as_slice::<P>()
+            .iter()
+            .zip(values)
+            .map(|(&idx, &v)| (<P as AsPrimitive<usize>>::as_(idx) - offset, map(v)))
+            .collect()
+    }))
+}
+
+/// Walk every unpacked FastLanes block in order, patch it in place from the pre-built cursor
+/// list, and hand it to the sink. Generic over the [`UnpackStrategy`] so fused strategies (e.g.
+/// FoR's reference-add unpack) stream through the same loop with zero extra passes.
+pub(crate) fn stream_unpacked_chunks<T: PhysicalPType, S: UnpackStrategy<T>>(
+    chunks: &mut UnpackedChunks<T, S>,
+    patch_list: &[(usize, T)],
+    sink: &mut dyn ChunkSink,
+) -> VortexResult<()> {
     let mut patch_cursor = 0usize;
     let mut result = Ok(());
     chunks.for_each_unpacked_chunk(|chunk, range| {
@@ -171,6 +193,23 @@ mod tests {
                     .is_some()
         );
         assert_chunks_match_execute::<i64>(for_array.into_array())
+    }
+
+    /// An unsigned reference over a BitPacked child takes the fused `FoRStrategy` streaming
+    /// path (reference folded into the unpack kernel), including patch handling.
+    #[test]
+    fn for_over_bitpacked_fused_chunks_with_patches() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
+        let deltas = PrimitiveArray::from_iter(
+            (0..5000u32).map(|i| if i % 700 == 0 { 100_000 + i } else { i % 900 }),
+        );
+        let bp = bitpack_encode(&deltas, 10, None, &mut ctx)?;
+        assert!(bp.patches().is_some());
+        let for_array = crate::FoR::try_new(
+            bp.into_array(),
+            vortex_array::scalar::Scalar::from(1_000_000u32),
+        )?;
+        assert_chunks_match_execute::<u32>(for_array.into_array())
     }
 
     #[test]

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -26,6 +26,7 @@ use vortex_error::vortex_err;
 
 pub mod bitpack_compress;
 pub mod bitpack_decompress;
+pub(crate) mod chunked_decompress;
 pub mod unpack_iter;
 
 use crate::BitPackedArray;

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -9,6 +9,7 @@ pub use array::BitPackedDataParts;
 pub use array::BitPackedSlots;
 pub use array::bitpack_compress;
 pub use array::bitpack_decompress;
+pub(crate) use array::chunked_decompress;
 pub use array::unpack_iter;
 
 pub(crate) mod compute;

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -50,7 +50,7 @@ use crate::bitpack_decompress::unpack_into_primitive_builder;
 use crate::bitpacking::array::BitPackedSlots;
 use crate::bitpacking::array::BitPackedSlotsView;
 use crate::bitpacking::array::PATCH_SLOTS;
-use crate::bitpacking::array::chunked_decompress;
+use crate::bitpacking::chunked_decompress;
 use crate::bitpacking::vtable::rules::RULES;
 mod kernels;
 mod operations;

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -19,6 +19,7 @@ use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::builders::ArrayBuilder;
+use vortex_array::chunk_iter::ChunkSink;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::PType;
 use vortex_array::match_each_integer_ptype;
@@ -49,6 +50,7 @@ use crate::bitpack_decompress::unpack_into_primitive_builder;
 use crate::bitpacking::array::BitPackedSlots;
 use crate::bitpacking::array::BitPackedSlotsView;
 use crate::bitpacking::array::PATCH_SLOTS;
+use crate::bitpacking::array::chunked_decompress;
 use crate::bitpacking::vtable::rules::RULES;
 mod kernels;
 mod operations;
@@ -296,6 +298,14 @@ impl VTable for BitPacked {
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         RULES.evaluate(array, parent, child_idx)
+    }
+
+    fn decompress_chunks(
+        array: ArrayView<'_, Self>,
+        ctx: &mut ExecutionCtx,
+        sink: &mut dyn ChunkSink,
+    ) -> VortexResult<()> {
+        chunked_decompress::decompress_chunks(array, ctx, sink)
     }
 }
 

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -300,6 +300,10 @@ impl VTable for BitPacked {
         RULES.evaluate(array, parent, child_idx)
     }
 
+    fn supports_decompress_chunks(_array: ArrayView<'_, Self>) -> bool {
+        true
+    }
+
     fn decompress_chunks(
         array: ArrayView<'_, Self>,
         ctx: &mut ExecutionCtx,

--- a/encodings/fastlanes/src/for/array/for_decompress.rs
+++ b/encodings/fastlanes/src/for/array/for_decompress.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use fastlanes::FoR;
 use num_traits::PrimInt;
 use num_traits::WrappingAdd;
@@ -8,6 +10,8 @@ use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::builders::PrimitiveBuilder;
+use vortex_array::chunk_iter::ChunkMut;
+use vortex_array::chunk_iter::ChunkSink;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::PhysicalPType;
 use vortex_array::dtype::UnsignedPType;
@@ -135,6 +139,49 @@ pub(crate) fn fused_decompress<
     }
 
     Ok(builder.finish_into_primitive())
+}
+
+/// Streaming chunked decompression for FoR arrays.
+///
+/// FoR composes over any encoded child: each chunk the child streams up is shifted by the
+/// reference value in place (one pass over an L1-resident chunk) and forwarded to the downstream
+/// sink. The adapter lives on this stack frame — no heap state is added on the way down.
+pub(crate) fn decompress_chunks(
+    array: ArrayView<'_, crate::FoR>,
+    ctx: &mut ExecutionCtx,
+    sink: &mut dyn ChunkSink,
+) -> VortexResult<()> {
+    match_each_integer_ptype!(array.ptype(), |T| {
+        let reference = array
+            .reference_scalar()
+            .as_primitive()
+            .typed_value::<T>()
+            .vortex_expect("reference must be non-null");
+        if reference == 0 {
+            array.encoded().decompress_chunks(ctx, sink)
+        } else {
+            let mut adapter = AddReferenceSink {
+                reference,
+                inner: sink,
+            };
+            array.encoded().decompress_chunks(ctx, &mut adapter)
+        }
+    })
+}
+
+struct AddReferenceSink<'a, T> {
+    reference: T,
+    inner: &'a mut dyn ChunkSink,
+}
+
+impl<T: NativePType + WrappingAdd> ChunkSink for AddReferenceSink<'_, T> {
+    #[inline]
+    fn accept(&mut self, mut chunk: ChunkMut<'_>, row_range: Range<usize>) -> VortexResult<()> {
+        for v in chunk.as_slice_mut::<T>() {
+            *v = v.wrapping_add(&self.reference);
+        }
+        self.inner.accept(chunk, row_range)
+    }
 }
 
 fn decompress_primitive<T: NativePType + WrappingAdd + PrimInt>(

--- a/encodings/fastlanes/src/for/array/for_decompress.rs
+++ b/encodings/fastlanes/src/for/array/for_decompress.rs
@@ -25,6 +25,7 @@ use crate::BitPacked;
 use crate::BitPackedArrayExt;
 use crate::FoRArray;
 use crate::bitpack_decompress;
+use crate::bitpacking::chunked_decompress;
 use crate::r#for::array::FoRArrayExt;
 use crate::r#for::array::FoRArraySlotsExt;
 use crate::unpack_iter::UnpackStrategy;
@@ -143,14 +144,28 @@ pub(crate) fn fused_decompress<
 
 /// Streaming chunked decompression for FoR arrays.
 ///
-/// FoR composes over any encoded child: each chunk the child streams up is shifted by the
-/// reference value in place (one pass over an L1-resident chunk) and forwarded to the downstream
-/// sink. The adapter lives on this stack frame — no heap state is added on the way down.
+/// When the child is a [`BitPacked`] array (the common layout), this streams through the fused
+/// [`FoRStrategy`] unpack kernel — the reference is folded into `unchecked_unfor_pack` itself,
+/// exactly like [`fused_decompress`], so there is no extra add pass at all.
+///
+/// Otherwise FoR composes generically over any encoded child: each chunk the child streams up is
+/// shifted by the reference value in place (one pass over an L1-resident chunk) and forwarded to
+/// the downstream sink. The adapter lives on this stack frame — no heap state is added on the
+/// way down.
 pub(crate) fn decompress_chunks(
     array: ArrayView<'_, crate::FoR>,
     ctx: &mut ExecutionCtx,
     sink: &mut dyn ChunkSink,
 ) -> VortexResult<()> {
+    // Fused fast path, mirroring the dispatch in `decompress`.
+    if array.reference_scalar().dtype().is_unsigned_int()
+        && let Some(bp) = array.encoded().as_opt::<BitPacked>()
+    {
+        return match_each_unsigned_integer_ptype!(array.ptype(), |T| {
+            fused_decompress_chunks::<T>(array, bp, ctx, sink)
+        });
+    }
+
     match_each_integer_ptype!(array.ptype(), |T| {
         let reference = array
             .reference_scalar()
@@ -167,6 +182,43 @@ pub(crate) fn decompress_chunks(
             array.encoded().decompress_chunks(ctx, &mut adapter)
         }
     })
+}
+
+/// Stream FoR-over-BitPacked chunks through the fused unpack kernel: each FastLanes block is
+/// unpacked with the reference added by `unchecked_unfor_pack`, patched in place (patch values
+/// get the reference applied up front), and handed to the sink.
+fn fused_decompress_chunks<T: PhysicalPType<Physical = T> + UnsignedPType + FoR + WrappingAdd>(
+    for_: ArrayView<'_, crate::FoR>,
+    bp: ArrayView<'_, BitPacked>,
+    ctx: &mut ExecutionCtx,
+    sink: &mut dyn ChunkSink,
+) -> VortexResult<()> {
+    if bp.as_ref().is_empty() {
+        return Ok(());
+    }
+
+    let ref_ = for_
+        .reference_scalar()
+        .as_primitive()
+        .as_::<T>()
+        .vortex_expect("cannot be null");
+
+    let mut unpacked = UnpackedChunks::try_new_with_strategy(
+        FoRStrategy { reference: ref_ },
+        bp.packed().as_host().clone(),
+        bp.bit_width() as usize,
+        bp.offset() as usize,
+        bp.len(),
+    )?;
+
+    let patch_list = match bp.patches() {
+        None => Vec::new(),
+        Some(patches) => {
+            chunked_decompress::build_patch_list(&patches, ctx, |v: T| v.wrapping_add(&ref_))?
+        }
+    };
+
+    chunked_decompress::stream_unpacked_chunks(&mut unpacked, &patch_list, sink)
 }
 
 struct AddReferenceSink<'a, T> {

--- a/encodings/fastlanes/src/for/array/for_decompress.rs
+++ b/encodings/fastlanes/src/for/array/for_decompress.rs
@@ -142,6 +142,13 @@ pub(crate) fn fused_decompress<
     Ok(builder.finish_into_primitive())
 }
 
+/// Whether [`decompress_chunks`] can stream: either the fused FoR+BitPacked path applies, or the
+/// encoded child itself supports streaming (generic composition).
+pub(crate) fn supports_decompress_chunks(array: ArrayView<'_, crate::FoR>) -> bool {
+    (array.reference_scalar().dtype().is_unsigned_int() && array.encoded().is::<BitPacked>())
+        || array.encoded().supports_decompress_chunks()
+}
+
 /// Streaming chunked decompression for FoR arrays.
 ///
 /// When the child is a [`BitPacked`] array (the common layout), this streams through the fused

--- a/encodings/fastlanes/src/for/vtable/mod.rs
+++ b/encodings/fastlanes/src/for/vtable/mod.rs
@@ -164,6 +164,10 @@ impl VTable for FoR {
         Ok(ExecutionResult::done(decompress(&array, ctx)?.into_array()))
     }
 
+    fn supports_decompress_chunks(array: ArrayView<'_, Self>) -> bool {
+        for_decompress::supports_decompress_chunks(array)
+    }
+
     fn decompress_chunks(
         array: ArrayView<'_, Self>,
         ctx: &mut ExecutionCtx,

--- a/encodings/fastlanes/src/for/vtable/mod.rs
+++ b/encodings/fastlanes/src/for/vtable/mod.rs
@@ -18,6 +18,7 @@ use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
+use vortex_array::chunk_iter::ChunkSink;
 use vortex_array::dtype::DType;
 use vortex_array::scalar::Scalar;
 use vortex_array::scalar::ScalarValue;
@@ -36,6 +37,7 @@ use crate::FoRData;
 use crate::r#for::array::FoRArrayExt;
 use crate::r#for::array::FoRSlots;
 use crate::r#for::array::FoRSlotsView;
+use crate::r#for::array::for_decompress;
 use crate::r#for::array::for_decompress::decompress;
 use crate::r#for::vtable::rules::PARENT_RULES;
 
@@ -160,6 +162,14 @@ impl VTable for FoR {
 
     fn execute(array: Array<Self>, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionResult> {
         Ok(ExecutionResult::done(decompress(&array, ctx)?.into_array()))
+    }
+
+    fn decompress_chunks(
+        array: ArrayView<'_, Self>,
+        ctx: &mut ExecutionCtx,
+        sink: &mut dyn ChunkSink,
+    ) -> VortexResult<()> {
+        for_decompress::decompress_chunks(array, ctx, sink)
     }
 }
 

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -220,6 +220,9 @@ pub(crate) trait DynArrayData: 'static + private::Sealed + Send + Sync + Debug {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ExecutionResult>;
 
+    /// Returns whether this encoding (recursively) supports streaming chunked decompression.
+    fn supports_decompress_chunks(&self, this: &ArrayRef) -> bool;
+
     /// Stream the array's decompressed values through `sink` in cache-resident chunks.
     fn decompress_chunks(
         &self,
@@ -496,6 +499,11 @@ impl<V: VTable> DynArrayData for ArrayData<V> {
             .map_err(|_| vortex_err!("Failed to downcast array for execute"))
             .vortex_expect("Failed to downcast array for execute");
         V::execute(typed, ctx)
+    }
+
+    fn supports_decompress_chunks(&self, this: &ArrayRef) -> bool {
+        let view = unsafe { ArrayView::new_unchecked(this, &self.data) };
+        V::supports_decompress_chunks(view)
     }
 
     fn decompress_chunks(

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -220,6 +220,14 @@ pub(crate) trait DynArrayData: 'static + private::Sealed + Send + Sync + Debug {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ExecutionResult>;
 
+    /// Stream the array's decompressed values through `sink` in cache-resident chunks.
+    fn decompress_chunks(
+        &self,
+        this: &ArrayRef,
+        ctx: &mut ExecutionCtx,
+        sink: &mut dyn crate::chunk_iter::ChunkSink,
+    ) -> VortexResult<()>;
+
     /// Execute the scalar at the given index.
     ///
     /// This method panics if the index is out of bounds for the array.
@@ -488,6 +496,16 @@ impl<V: VTable> DynArrayData for ArrayData<V> {
             .map_err(|_| vortex_err!("Failed to downcast array for execute"))
             .vortex_expect("Failed to downcast array for execute");
         V::execute(typed, ctx)
+    }
+
+    fn decompress_chunks(
+        &self,
+        this: &ArrayRef,
+        ctx: &mut ExecutionCtx,
+        sink: &mut dyn crate::chunk_iter::ChunkSink,
+    ) -> VortexResult<()> {
+        let view = unsafe { ArrayView::new_unchecked(this, &self.data) };
+        V::decompress_chunks(view, ctx, sink)
     }
 
     fn execute_scalar(

--- a/vortex-array/src/array/vtable/mod.rs
+++ b/vortex-array/src/array/vtable/mod.rs
@@ -187,6 +187,26 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
     /// incorrectly contains null values.
     fn execute(array: Array<Self>, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionResult>;
 
+    /// Stream the array's decompressed values through `sink` in cache-resident chunks.
+    ///
+    /// See [`chunk_iter`](crate::chunk_iter) for the contract and cost model. The default
+    /// implementation executes the array to canonical and streams the result (the two-pass
+    /// baseline), so this is always possible; encodings should override it to stream chunks
+    /// directly out of their decompression kernel, and wrapper encodings should compose by
+    /// interposing a stack-allocated [`ChunkSink`](crate::chunk_iter::ChunkSink) adapter and
+    /// recursing into their child via
+    /// [`ArrayRef::decompress_chunks`](crate::ArrayRef::decompress_chunks).
+    ///
+    /// The caller guarantees the array is primitive-typed. Implementations must emit contiguous,
+    /// in-order chunks covering exactly `0..len` (checked in debug builds).
+    fn decompress_chunks(
+        array: ArrayView<'_, Self>,
+        ctx: &mut ExecutionCtx,
+        sink: &mut dyn crate::chunk_iter::ChunkSink,
+    ) -> VortexResult<()> {
+        crate::chunk_iter::decompress_chunks_via_canonical(array.array(), ctx, sink)
+    }
+
     /// Attempt to reduce the array to a simpler representation without changing logical values.
     ///
     /// Reductions are opportunistic and may return `Ok(None)` when no cheaper representation is

--- a/vortex-array/src/array/vtable/mod.rs
+++ b/vortex-array/src/array/vtable/mod.rs
@@ -187,24 +187,44 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
     /// incorrectly contains null values.
     fn execute(array: Array<Self>, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionResult>;
 
+    /// Returns whether this encoding can stream decompressed chunks via
+    /// [`decompress_chunks`](Self::decompress_chunks) without materializing anything.
+    ///
+    /// Defaults to `false`: streaming is an explicit capability, never a silent fallback. Leaf
+    /// encodings that override `decompress_chunks` return `true`; wrapper encodings must
+    /// propagate the check into the children their implementation streams from (e.g. via
+    /// [`ArrayRef::supports_decompress_chunks`](crate::ArrayRef::supports_decompress_chunks)),
+    /// so support of the whole tree is decided before any chunk is emitted.
+    fn supports_decompress_chunks(array: ArrayView<'_, Self>) -> bool {
+        _ = array;
+        false
+    }
+
     /// Stream the array's decompressed values through `sink` in cache-resident chunks.
     ///
-    /// See [`chunk_iter`](crate::chunk_iter) for the contract and cost model. The default
-    /// implementation executes the array to canonical and streams the result (the two-pass
-    /// baseline), so this is always possible; encodings should override it to stream chunks
-    /// directly out of their decompression kernel, and wrapper encodings should compose by
-    /// interposing a stack-allocated [`ChunkSink`](crate::chunk_iter::ChunkSink) adapter and
-    /// recursing into their child via
-    /// [`ArrayRef::decompress_chunks`](crate::ArrayRef::decompress_chunks).
+    /// See [`chunk_iter`](crate::chunk_iter) for the contract and cost model. The whole point of
+    /// this method is to decompress and transform block-by-block while the block is L1-resident;
+    /// implementations must therefore stream directly out of their decompression kernel (leaf
+    /// encodings) or interpose a stack-allocated [`ChunkSink`](crate::chunk_iter::ChunkSink)
+    /// adapter and recurse into their child via
+    /// [`ArrayRef::decompress_chunks`](crate::ArrayRef::decompress_chunks) (wrappers) — never
+    /// materialize the array. Encodings that cannot do this leave the default, which reports
+    /// unsupported; callers wanting a materializing fallback opt in by name via
+    /// [`ArrayRef::decompress_chunks_or_materialize`](crate::ArrayRef::decompress_chunks_or_materialize).
     ///
-    /// The caller guarantees the array is primitive-typed. Implementations must emit contiguous,
-    /// in-order chunks covering exactly `0..len` (checked in debug builds).
+    /// Only called when [`supports_decompress_chunks`](Self::supports_decompress_chunks) returned
+    /// `true`; the caller guarantees the array is primitive-typed. Implementations must emit
+    /// contiguous, in-order chunks covering exactly `0..len` (checked in debug builds).
     fn decompress_chunks(
         array: ArrayView<'_, Self>,
         ctx: &mut ExecutionCtx,
         sink: &mut dyn crate::chunk_iter::ChunkSink,
     ) -> VortexResult<()> {
-        crate::chunk_iter::decompress_chunks_via_canonical(array.array(), ctx, sink)
+        _ = (ctx, sink);
+        vortex_bail!(
+            "decompress_chunks is not supported by encoding {}",
+            array.encoding_id()
+        )
     }
 
     /// Attempt to reduce the array to a simpler representation without changing logical values.

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -42,6 +42,9 @@ use crate::builders::PrimitiveBuilder;
 use crate::builders::VarBinViewBuilder;
 use crate::builders::builder_with_capacity;
 use crate::canonical::Canonical;
+use crate::chunk_iter::ChunkMut;
+use crate::chunk_iter::ChunkSink;
+use crate::chunk_iter::DECOMPRESS_CHUNK_LEN;
 use crate::dtype::DType;
 use crate::dtype::OffsetBuilderPType;
 use crate::match_each_decimal_value;
@@ -184,6 +187,34 @@ impl VTable for Constant {
             array.as_view(),
             ctx,
         )?))
+    }
+
+    fn decompress_chunks(
+        array: ArrayView<'_, Self>,
+        _ctx: &mut ExecutionCtx,
+        sink: &mut dyn ChunkSink,
+    ) -> VortexResult<()> {
+        let len = array.as_ref().len();
+        // The entry point guarantees a primitive dtype. A null constant streams unspecified (but
+        // initialized) values, matching the not-streamed-validity contract.
+        match_each_native_ptype!(array.as_ref().dtype().as_ptype(), |T| {
+            let value: T = array
+                .scalar()
+                .as_primitive()
+                .typed_value::<T>()
+                .unwrap_or_default();
+            let mut scratch = [value; DECOMPRESS_CHUNK_LEN];
+            let mut start = 0;
+            while start < len {
+                let n = (len - start).min(DECOMPRESS_CHUNK_LEN);
+                // Sinks may mutate the chunk in place (e.g. Patched patching over it), so the
+                // scratch is refilled before every emission.
+                scratch[..n].fill(value);
+                sink.accept(ChunkMut::new(&mut scratch[..n]), start..start + n)?;
+                start += n;
+            }
+            Ok(())
+        })
     }
 
     fn append_to_builder(

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -189,6 +189,10 @@ impl VTable for Constant {
         )?))
     }
 
+    fn supports_decompress_chunks(_array: ArrayView<'_, Self>) -> bool {
+        true
+    }
+
     fn decompress_chunks(
         array: ArrayView<'_, Self>,
         _ctx: &mut ExecutionCtx,

--- a/vortex-array/src/arrays/filter/chunked_decompress.rs
+++ b/vortex-array/src/arrays/filter/chunked_decompress.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Streaming chunked decompression for filtered arrays.
+//!
+//! The child streams its decompressed blocks; each block is compacted **in place** against the
+//! slice of the filter mask covering that block's rows, and the surviving prefix is forwarded
+//! downstream. Compaction in place is sound because within a block the output index is always
+//! `<=` the input index.
+//!
+//! The mask's run-slice representation is computed once up front and walked with a cursor, so no
+//! per-chunk mask slicing or allocation happens on the hot path. This mirrors the kernel used by
+//! the non-streaming path ([`filter_slice_mut_by_slices`](super::execute::slice)), but avoids
+//! materializing the child's full decompressed buffer first.
+
+use std::ops::Range;
+
+use vortex_error::VortexResult;
+use vortex_mask::Mask;
+use vortex_mask::MaskIter;
+
+use crate::ExecutionCtx;
+use crate::array::ArrayView;
+use crate::arrays::Filter;
+use crate::arrays::filter::FilterArraySlotsExt;
+use crate::chunk_iter::ChunkMut;
+use crate::chunk_iter::ChunkSink;
+use crate::dtype::NativePType;
+use crate::match_each_native_ptype;
+
+/// Below this mean run length, per-index gathering beats copying runs during in-place
+/// compaction. Measured on `Filter(BitPacked)` at 64K rows: runs of 1 favor gathering by ~2x,
+/// runs of 8 favor run-copying by ~1.7x.
+const MIN_RUN_LEN_FOR_RUN_COPY: f64 = 4.0;
+
+pub(crate) fn supports_decompress_chunks(array: ArrayView<'_, Filter>) -> bool {
+    array.child().supports_decompress_chunks()
+}
+
+pub(crate) fn decompress_chunks(
+    array: ArrayView<'_, Filter>,
+    ctx: &mut ExecutionCtx,
+    sink: &mut dyn ChunkSink,
+) -> VortexResult<()> {
+    // A zero-length mask is both all-true and all-false, so check the empty case first.
+    match array.filter_mask() {
+        Mask::AllFalse(_) | Mask::AllTrue(0) => Ok(()),
+        // Nothing is filtered out: forward the child's chunks untouched.
+        Mask::AllTrue(_) => array.child().decompress_chunks(ctx, sink),
+        Mask::Values(values) => {
+            // Compaction here is in-place, so runs are preferred (fewer loop iterations and
+            // branches than per-index gathers, as in `filter_slice_mut_by_mask_values`) — except
+            // when runs are so short that run-copying degenerates into one-element `copy_within`
+            // calls, where gathering indices measures faster.
+            let runs = values.slices();
+            let mean_run_len = values.true_count() as f64 / (runs.len().max(1) as f64);
+            let selection = if mean_run_len < MIN_RUN_LEN_FOR_RUN_COPY {
+                MaskIter::Indices(values.indices())
+            } else {
+                MaskIter::Slices(runs)
+            };
+            let mut adapter = FilterChunkSink {
+                selection,
+                cursor: 0,
+                out_row: 0,
+                inner: sink,
+            };
+            array.child().decompress_chunks(ctx, &mut adapter)
+        }
+    }
+}
+
+/// Sink adapter that compacts each child chunk down to its surviving rows.
+struct FilterChunkSink<'a> {
+    /// The mask's selected rows in child coordinates, as indices (sparse) or runs (dense).
+    selection: MaskIter<'a>,
+    /// Index of the first index/run that may still fall in a future chunk.
+    cursor: usize,
+    /// Number of rows already emitted downstream (i.e. the parent row cursor).
+    out_row: usize,
+    inner: &'a mut dyn ChunkSink,
+}
+
+impl ChunkSink for FilterChunkSink<'_> {
+    fn accept(&mut self, mut chunk: ChunkMut<'_>, child_rows: Range<usize>) -> VortexResult<()> {
+        match_each_native_ptype!(chunk.ptype(), |T| {
+            compact_and_forward::<T>(
+                &mut chunk,
+                child_rows,
+                &self.selection,
+                &mut self.cursor,
+                &mut self.out_row,
+                self.inner,
+            )
+        })
+    }
+}
+
+fn compact_and_forward<T: NativePType>(
+    chunk: &mut ChunkMut<'_>,
+    child_rows: Range<usize>,
+    selection: &MaskIter<'_>,
+    cursor: &mut usize,
+    out_row: &mut usize,
+    inner: &mut dyn ChunkSink,
+) -> VortexResult<()> {
+    let values = chunk.as_slice_mut::<T>();
+    let out = match selection {
+        MaskIter::Indices(indices) => compact_by_indices(values, &child_rows, indices, cursor),
+        MaskIter::Slices(runs) => compact_by_runs(values, &child_rows, runs, cursor),
+    };
+
+    if out == 0 {
+        // Nothing survived in this block: emit nothing rather than a zero-length chunk.
+        return Ok(());
+    }
+
+    let start = *out_row;
+    *out_row += out;
+    inner.accept(ChunkMut::new(&mut values[..out]), start..*out_row)
+}
+
+/// Gather selected rows for sparse masks. In-place is sound because `out <= idx - start`.
+fn compact_by_indices<T: Copy>(
+    values: &mut [T],
+    child_rows: &Range<usize>,
+    indices: &[usize],
+    cursor: &mut usize,
+) -> usize {
+    let mut out = 0usize;
+    while let Some(&idx) = indices.get(*cursor) {
+        if idx < child_rows.start {
+            *cursor += 1;
+            continue;
+        }
+        if idx >= child_rows.end {
+            break;
+        }
+        values[out] = values[idx - child_rows.start];
+        out += 1;
+        *cursor += 1;
+    }
+    out
+}
+
+/// Copy selected runs for dense masks, clipping each run to the chunk.
+fn compact_by_runs<T: Copy>(
+    values: &mut [T],
+    child_rows: &Range<usize>,
+    runs: &[(usize, usize)],
+    run_cursor: &mut usize,
+) -> usize {
+    let mut out = 0usize;
+
+    while let Some(&(run_start, run_end)) = runs.get(*run_cursor) {
+        if run_end <= child_rows.start {
+            // Fully behind this chunk (only reachable if a chunk was empty).
+            *run_cursor += 1;
+            continue;
+        }
+        if run_start >= child_rows.end {
+            break;
+        }
+
+        let from = run_start.max(child_rows.start) - child_rows.start;
+        let to = run_end.min(child_rows.end) - child_rows.start;
+        // In-place left-compaction: `out <= from` always holds because runs are ordered and
+        // disjoint, so this never overwrites a value it has not yet copied.
+        values.copy_within(from..to, out);
+        out += to - from;
+
+        if run_end <= child_rows.end {
+            *run_cursor += 1;
+        } else {
+            // This run continues into the next chunk; keep the cursor on it.
+            break;
+        }
+    }
+
+    out
+}

--- a/vortex-array/src/arrays/filter/mod.rs
+++ b/vortex-array/src/arrays/filter/mod.rs
@@ -9,6 +9,7 @@ pub use array::FilterSlots;
 pub use array::FilterSlotsView;
 pub use vtable::FilterArray;
 
+mod chunked_decompress;
 mod execute;
 pub(crate) use execute::buffer::filter_buffer;
 pub(crate) use execute::filter_validity;

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -31,12 +31,14 @@ use crate::array::with_empty_buffers;
 use crate::arrays::filter::FilterArraySlotsExt;
 use crate::arrays::filter::array::FilterData;
 use crate::arrays::filter::array::FilterSlots;
+use crate::arrays::filter::chunked_decompress;
 use crate::arrays::filter::execute::contiguous_filter_range;
 use crate::arrays::filter::execute::execute_all_null_filter_fast_path;
 use crate::arrays::filter::execute::execute_filter;
 use crate::arrays::filter::rules::PARENT_RULES;
 use crate::arrays::filter::rules::RULES;
 use crate::buffer::BufferHandle;
+use crate::chunk_iter::ChunkSink;
 use crate::dtype::DType;
 use crate::executor::ExecutionCtx;
 use crate::executor::ExecutionResult;
@@ -185,6 +187,18 @@ impl VTable for Filter {
         Ok(ExecutionResult::done(
             execute_filter(child, &mask_values).into_array(),
         ))
+    }
+
+    fn supports_decompress_chunks(array: ArrayView<'_, Self>) -> bool {
+        chunked_decompress::supports_decompress_chunks(array)
+    }
+
+    fn decompress_chunks(
+        array: ArrayView<'_, Self>,
+        ctx: &mut ExecutionCtx,
+        sink: &mut dyn ChunkSink,
+    ) -> VortexResult<()> {
+        chunked_decompress::decompress_chunks(array, ctx, sink)
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/patched/vtable/mod.rs
+++ b/vortex-array/src/arrays/patched/vtable/mod.rs
@@ -312,6 +312,10 @@ impl VTable for Patched {
         PARENT_RULES.evaluate(array, parent, child_idx)
     }
 
+    fn supports_decompress_chunks(array: ArrayView<'_, Self>) -> bool {
+        array.inner().supports_decompress_chunks()
+    }
+
     fn decompress_chunks(
         array: ArrayView<'_, Self>,
         ctx: &mut ExecutionCtx,

--- a/vortex-array/src/arrays/patched/vtable/mod.rs
+++ b/vortex-array/src/arrays/patched/vtable/mod.rs
@@ -45,6 +45,8 @@ use crate::arrays::primitive::PrimitiveDataParts;
 use crate::buffer::BufferHandle;
 use crate::builders::ArrayBuilder;
 use crate::builders::PrimitiveBuilder;
+use crate::chunk_iter::ChunkMut;
+use crate::chunk_iter::ChunkSink;
 use crate::dtype::DType;
 use crate::dtype::NativePType;
 use crate::dtype::PType;
@@ -308,6 +310,107 @@ impl VTable for Patched {
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)
+    }
+
+    fn decompress_chunks(
+        array: ArrayView<'_, Self>,
+        ctx: &mut ExecutionCtx,
+        sink: &mut dyn ChunkSink,
+    ) -> VortexResult<()> {
+        if array.as_ref().is_empty() {
+            return Ok(());
+        }
+
+        let len = array.as_ref().len();
+        let offset = array.offset();
+        let n_lanes = array.n_lanes();
+
+        // The patch children are tiny relative to the array; materialize them once up front and
+        // flatten the lane-transposed layout into row-sorted (row, value) pairs so the per-chunk
+        // wrapper below only advances a cursor.
+        let lane_offsets = array
+            .lane_offsets()
+            .clone()
+            .execute::<PrimitiveArray>(ctx)?;
+        let indices = array
+            .patch_indices()
+            .clone()
+            .execute::<PrimitiveArray>(ctx)?;
+        let values = array
+            .patch_values()
+            .clone()
+            .execute::<PrimitiveArray>(ctx)?;
+
+        match_each_native_ptype!(values.ptype(), |V| {
+            let mut adapter = PatchChunkSink {
+                patch_list: build_row_sorted_patches::<V>(
+                    lane_offsets.as_slice::<u32>(),
+                    indices.as_slice::<u16>(),
+                    values.as_slice::<V>(),
+                    offset,
+                    len,
+                    n_lanes,
+                ),
+                cursor: 0,
+                inner: sink,
+            };
+            array.inner().decompress_chunks(ctx, &mut adapter)
+        })
+    }
+}
+
+/// Flatten the lane-transposed patch layout into row-sorted (row, value) pairs so the streaming
+/// chunk wrapper only advances a cursor.
+fn build_row_sorted_patches<V: NativePType>(
+    lane_offsets: &[u32],
+    indices: &[u16],
+    values: &[V],
+    offset: usize,
+    len: usize,
+    n_lanes: usize,
+) -> Vec<(usize, V)> {
+    let mut patch_list: Vec<(usize, V)> = Vec::with_capacity(values.len());
+    let n_chunks = (offset + len).div_ceil(1024);
+    for chunk in 0..n_chunks {
+        let start = lane_offsets[chunk * n_lanes] as usize;
+        let stop = lane_offsets[chunk * n_lanes + n_lanes] as usize;
+        for idx in start..stop {
+            // The indices slice is measured as an offset into the 1024-value chunk.
+            let index = chunk * 1024 + indices[idx] as usize;
+            if index < offset || index >= offset + len {
+                continue;
+            }
+            patch_list.push((index - offset, values[idx]));
+        }
+    }
+    // Patches are sorted by (chunk, lane), not by row; the stable sort preserves the original
+    // application order for any duplicate rows.
+    patch_list.sort_by_key(|&(row, _)| row);
+    patch_list
+}
+
+/// Sink adapter that overwrites patched rows in each streamed chunk before forwarding it.
+struct PatchChunkSink<'a, V> {
+    patch_list: Vec<(usize, V)>,
+    cursor: usize,
+    inner: &'a mut dyn ChunkSink,
+}
+
+impl<V: NativePType> ChunkSink for PatchChunkSink<'_, V> {
+    #[inline]
+    fn accept(
+        &mut self,
+        mut chunk: ChunkMut<'_>,
+        row_range: std::ops::Range<usize>,
+    ) -> VortexResult<()> {
+        let out = chunk.as_slice_mut::<V>();
+        while let Some(&(row, value)) = self.patch_list.get(self.cursor)
+            && row < row_range.end
+        {
+            out[row - row_range.start] = value;
+            self.cursor += 1;
+        }
+        self.inner.accept(chunk, row_range)
     }
 }
 

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -17,6 +17,9 @@ use crate::arrays::primitive::PrimitiveData;
 use crate::buffer::BufferHandle;
 use crate::builders::ArrayBuilder;
 use crate::builders::PrimitiveBuilder;
+use crate::chunk_iter::ChunkMut;
+use crate::chunk_iter::ChunkSink;
+use crate::chunk_iter::DECOMPRESS_CHUNK_LEN;
 use crate::dtype::DType;
 use crate::dtype::PType;
 use crate::match_each_native_ptype;
@@ -179,6 +182,30 @@ impl VTable for Primitive {
 
     fn execute(array: Array<Self>, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionResult> {
         Ok(ExecutionResult::done(array))
+    }
+
+    fn supports_decompress_chunks(_array: ArrayView<'_, Self>) -> bool {
+        true
+    }
+
+    fn decompress_chunks(
+        array: ArrayView<'_, Self>,
+        _ctx: &mut ExecutionCtx,
+        sink: &mut dyn ChunkSink,
+    ) -> VortexResult<()> {
+        // Already decompressed: stream the buffer through one reusable L1-resident scratch chunk
+        // (chunks are handed out mutably, so the shared buffer cannot be exposed directly).
+        match_each_native_ptype!(array.ptype(), |P| {
+            let values = array.as_slice::<P>();
+            let mut scratch = vec![P::default(); values.len().min(DECOMPRESS_CHUNK_LEN)];
+            for (i, chunk) in values.chunks(DECOMPRESS_CHUNK_LEN).enumerate() {
+                let start = i * DECOMPRESS_CHUNK_LEN;
+                let scratch = &mut scratch[..chunk.len()];
+                scratch.copy_from_slice(chunk);
+                sink.accept(ChunkMut::new(scratch), start..start + chunk.len())?;
+            }
+            Ok(())
+        })
     }
 
     fn append_to_builder(

--- a/vortex-array/src/chunk_iter.rs
+++ b/vortex-array/src/chunk_iter.rs
@@ -226,9 +226,13 @@ impl ArrayRef {
 }
 
 /// Global toggle for the executor's stream-to-canonical shortcut (see
-/// [`execute_via_chunks`]). Enabled by default; exposed only so benchmarks and tests can compare
-/// the executor with and without the shortcut inside one process.
-static CHUNKED_EXECUTE_ENABLED: AtomicBool = AtomicBool::new(true);
+/// [`execute_via_chunks`]). Enabled by default; `VORTEX_CHUNKED_EXECUTE=0` disables it at process
+/// start, and [`set_chunked_execute_enabled`] overrides it at runtime — both exist only so
+/// benchmarks and tests can compare the executor with and without the shortcut.
+static CHUNKED_EXECUTE_ENABLED: std::sync::LazyLock<AtomicBool> =
+    std::sync::LazyLock::new(|| {
+        AtomicBool::new(!std::env::var("VORTEX_CHUNKED_EXECUTE").is_ok_and(|v| v == "0"))
+    });
 
 #[doc(hidden)]
 pub fn set_chunked_execute_enabled(enabled: bool) {

--- a/vortex-array/src/chunk_iter.rs
+++ b/vortex-array/src/chunk_iter.rs
@@ -230,3 +230,72 @@ fn stream_slice_chunks<T: NativePType>(values: &[T], sink: &mut dyn ChunkSink) -
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::buffer;
+
+    use super::*;
+    use crate::IntoArray;
+    use crate::VortexSessionExecute;
+    use crate::array_session;
+    use crate::arrays::ConstantArray;
+    use crate::arrays::Patched;
+    use crate::dtype::DType;
+    use crate::dtype::Nullability;
+    use crate::patches::Patches;
+    use crate::scalar::Scalar;
+
+    fn collect_chunks<T: NativePType>(array: &ArrayRef) -> VortexResult<Vec<T>> {
+        let mut ctx = array_session().create_execution_ctx();
+        let mut out = Vec::with_capacity(array.len());
+        array.decompress_chunks(&mut ctx, &mut |chunk: ChunkMut<'_>,
+                                                 _range: Range<usize>|
+         -> VortexResult<()> {
+            out.extend_from_slice(chunk.as_slice::<T>());
+            Ok(())
+        })?;
+        Ok(out)
+    }
+
+    #[test]
+    fn constant_chunks() -> VortexResult<()> {
+        // Length deliberately not a multiple of the chunk size.
+        let array = ConstantArray::new(7i32, 2500).into_array();
+        let chunked = collect_chunks::<i32>(&array)?;
+        assert_eq!(chunked, vec![7i32; 2500]);
+        Ok(())
+    }
+
+    #[test]
+    fn null_constant_chunks_cover_length() -> VortexResult<()> {
+        let array = ConstantArray::new(
+            Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable)),
+            100,
+        )
+        .into_array();
+        // Values are unspecified for nulls; only coverage matters (checked in debug builds too).
+        let chunked = collect_chunks::<i32>(&array)?;
+        assert_eq!(chunked.len(), 100);
+        Ok(())
+    }
+
+    #[test]
+    fn patched_over_constant_chunks() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        let inner = ConstantArray::new(0u16, 2500).into_array();
+        let patches = Patches::new(
+            2500,
+            0,
+            buffer![1u32, 1023, 1024, 2047, 2499].into_array(),
+            buffer![11u16, 22, 33, 44, 55].into_array(),
+            None,
+        )?;
+        let array = Patched::from_array_and_patches(inner, &patches, &mut ctx)?.into_array();
+
+        let chunked = collect_chunks::<u16>(&array)?;
+        let expected = array.execute::<PrimitiveArray>(&mut ctx)?;
+        assert_eq!(chunked.as_slice(), expected.as_slice::<u16>());
+        Ok(())
+    }
+}

--- a/vortex-array/src/chunk_iter.rs
+++ b/vortex-array/src/chunk_iter.rs
@@ -37,7 +37,10 @@
 //! - Currently only primitive-typed arrays are supported.
 
 use std::marker::PhantomData;
+use std::mem::MaybeUninit;
 use std::ops::Range;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
@@ -45,6 +48,7 @@ use vortex_error::vortex_ensure;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::arrays::PrimitiveArray;
+use crate::builders::PrimitiveBuilder;
 use crate::dtype::NativePType;
 use crate::dtype::PType;
 use crate::match_each_native_ptype;
@@ -218,6 +222,80 @@ impl ArrayRef {
         }
         #[cfg(not(debug_assertions))]
         self.dyn_array().decompress_chunks(self, ctx, sink)
+    }
+}
+
+/// Global toggle for the executor's stream-to-canonical shortcut (see
+/// [`execute_via_chunks`]). Enabled by default; exposed only so benchmarks and tests can compare
+/// the executor with and without the shortcut inside one process.
+static CHUNKED_EXECUTE_ENABLED: AtomicBool = AtomicBool::new(true);
+
+#[doc(hidden)]
+pub fn set_chunked_execute_enabled(enabled: bool) {
+    CHUNKED_EXECUTE_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+/// Returns whether the executor should shortcut this array's canonicalization through
+/// [`execute_via_chunks`].
+///
+/// True when the shortcut is enabled, the whole tree streams
+/// ([`ArrayRef::supports_decompress_chunks`], which cascades: an encoding only advertises
+/// support when the children it streams from do), and the tree is at least two streaming levels
+/// deep. A lone streaming leaf (e.g. BitPacked with canonical patch children) decodes directly
+/// into the builder on its normal execute path, so streaming it would only add a scratch copy;
+/// the shortcut pays off when the normal path would materialize a full intermediate per level.
+pub(crate) fn should_execute_via_chunks(array: &ArrayRef) -> bool {
+    CHUNKED_EXECUTE_ENABLED.load(Ordering::Relaxed)
+        && array.supports_decompress_chunks()
+        && array
+            .children_iter()
+            .any(|child| !child.is_canonical() && child.supports_decompress_chunks())
+}
+
+/// Execute a streaming-capable primitive array tree to a canonical [`PrimitiveArray`] by
+/// decompressing chunks straight into the output buffer: each block is decoded and transformed
+/// while L1-resident, and the only full-length write is the final copy into the builder.
+///
+/// The caller must have checked [`ArrayRef::supports_decompress_chunks`].
+pub fn execute_via_chunks(
+    array: &ArrayRef,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<PrimitiveArray> {
+    let len = array.len();
+    let validity_mask = array.validity()?.execute_mask(len, ctx)?;
+    match_each_native_ptype!(array.dtype().as_ptype(), |T| {
+        let mut builder = PrimitiveBuilder::<T>::with_capacity(array.dtype().nullability(), len);
+        let mut uninit_range = builder.uninit_range(len);
+        // SAFETY: every value slot is initialized by the chunk stream below, which covers
+        // exactly 0..len (checked in debug builds).
+        unsafe {
+            uninit_range.append_mask(&validity_mask);
+        }
+        {
+            // SAFETY: the chunk stream covers 0..len contiguously.
+            let dst = unsafe { uninit_range.slice_uninit_mut(0, len) };
+            let mut sink = BuilderSink::<T> { dst };
+            array.decompress_chunks(ctx, &mut sink)?;
+        }
+        // SAFETY: mask appended for len rows and all len values initialized above.
+        unsafe {
+            uninit_range.finish();
+        }
+        Ok(builder.finish_into_primitive())
+    })
+}
+
+struct BuilderSink<'a, T> {
+    dst: &'a mut [MaybeUninit<T>],
+}
+
+impl<T: NativePType> ChunkSink for BuilderSink<'_, T> {
+    #[inline]
+    fn accept(&mut self, chunk: ChunkMut<'_>, row_range: Range<usize>) -> VortexResult<()> {
+        // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout.
+        let src: &[MaybeUninit<T>] = unsafe { std::mem::transmute(chunk.as_slice::<T>()) };
+        self.dst[row_range].copy_from_slice(src);
+        Ok(())
     }
 }
 

--- a/vortex-array/src/chunk_iter.rs
+++ b/vortex-array/src/chunk_iter.rs
@@ -249,11 +249,25 @@ pub fn set_chunked_execute_enabled(enabled: bool) {
 /// into the builder on its normal execute path, so streaming it would only add a scratch copy;
 /// the shortcut pays off when the normal path would materialize a full intermediate per level.
 pub(crate) fn should_execute_via_chunks(array: &ArrayRef) -> bool {
-    CHUNKED_EXECUTE_ENABLED.load(Ordering::Relaxed)
+    let fires = CHUNKED_EXECUTE_ENABLED.load(Ordering::Relaxed)
         && array.supports_decompress_chunks()
         && array
             .children_iter()
-            .any(|child| !child.is_canonical() && child.supports_decompress_chunks())
+            .any(|child| !child.is_canonical() && child.supports_decompress_chunks());
+    // TEMPORARY diagnostics, not for merge.
+    if std::env::var("VORTEX_CHUNKED_EXECUTE_TRACE").is_ok() && !array.is_canonical() {
+        eprintln!(
+            "CHUNKED_EXEC fires={} len={} root={} children={:?}",
+            fires,
+            array.len(),
+            array.encoding_id(),
+            array
+                .children_iter()
+                .map(|c| c.encoding_id().to_string())
+                .collect::<Vec<_>>()
+        );
+    }
+    fires
 }
 
 /// Execute a streaming-capable primitive array tree to a canonical [`PrimitiveArray`] by

--- a/vortex-array/src/chunk_iter.rs
+++ b/vortex-array/src/chunk_iter.rs
@@ -3,38 +3,55 @@
 
 //! Streaming chunked decompression.
 //!
-//! [`ArrayRef::decompress_chunks`] walks an array's decompressed values in cache-resident chunks
-//! (~1024 elements) without materializing the full array. Each encoding can override
-//! [`VTable::decompress_chunks`](crate::vtable::VTable::decompress_chunks) to stream chunks
-//! straight out of its decompression kernel; wrapper encodings (e.g. FoR) compose by interposing
-//! a stack-allocated [`ChunkSink`] adapter around the downstream sink and recursing into their
-//! child through the erased [`ArrayRef`] entry point.
+//! [`ArrayRef::decompress_chunks`] walks an encoding tree's decompressed values in cache-resident
+//! chunks of [`DECOMPRESS_CHUNK_LEN`] without materializing the array. Leaf encodings stream
+//! blocks straight out of their decompression kernel; wrapper encodings compose by interposing a
+//! stack-allocated [`ChunkSink`] adapter and recursing into their child through the erased
+//! [`ArrayRef`] entry point, so a whole tree decompresses and transforms one L1-resident block at
+//! a time.
 //!
-//! # Cost model
+//! # The vtable API
 //!
-//! The composition cost is one virtual call per chunk per encoding level (amortized over ~1024
-//! elements, i.e. fractions of a nanosecond per element) plus, for each wrapper level, one
-//! in-place pass over an L1-resident chunk. There is no per-element dynamic dispatch and no
-//! heap-allocated state introduced on the way down: the sink chain lives in the caller's stack
-//! frames, one frame per encoding level. Leaf producers reuse whatever scratch buffer their
-//! decompressor already maintains (e.g. the FastLanes 1024-element unpack buffer).
+//! Encodings implement two methods (see [`VTable`](crate::vtable::VTable)):
 //!
-//! Streaming is an explicit capability, not a silent guarantee: encodings advertise it via
-//! [`VTable::supports_decompress_chunks`](crate::vtable::VTable::supports_decompress_chunks)
-//! (wrappers propagate the check through their children), and
-//! [`ArrayRef::decompress_chunks`] errors on an unsupported tree instead of quietly
-//! materializing it. Callers that want a works-everywhere path opt into the two-pass fallback
-//! by name with [`ArrayRef::decompress_chunks_or_materialize`].
+//! ```ignore
+//! fn supports_decompress_chunks(array: ArrayView<'_, Self>) -> bool;      // default: false
+//! fn decompress_chunks(
+//!     array: ArrayView<'_, Self>,
+//!     ctx: &mut ExecutionCtx,
+//!     sink: &mut dyn ChunkSink,
+//! ) -> VortexResult<()>;                                                  // default: unsupported
+//! ```
+//!
+//! They are separate because support must be answerable *before* any work happens, and because it
+//! **cascades**: a wrapper only advertises support when the children it streams from do, so the
+//! whole tree is validated up front and [`ArrayRef::decompress_chunks`] can reject an unsupported
+//! tree without emitting a partial stream. There is no silent fallback — callers that want one
+//! ask for it by name via [`ArrayRef::decompress_chunks_or_materialize`].
 //!
 //! # Contract
 //!
-//! - Chunks arrive in order, are contiguous, and cover `0..array.len()` exactly.
-//! - Chunks are producer-owned scratch: the sink may mutate them freely (wrappers rely on this to
-//!   transform values in place), and their contents are invalid once `accept` returns.
-//! - Validity is *not* streamed: positions that are logically null contain unspecified (but
-//!   initialized) values, matching `execute`'s decompression behavior. Callers that need null
-//!   information should fetch `array.validity()` separately.
-//! - Currently only primitive-typed arrays are supported.
+//! - Chunks arrive in order, are contiguous, and cover `0..array.len()` exactly (debug-checked).
+//! - Chunks may be shorter than [`DECOMPRESS_CHUNK_LEN`] (sliced blocks, filtered blocks).
+//! - Chunks are producer-owned scratch: a sink may mutate one freely — wrappers rely on this to
+//!   transform values in place — and its contents are invalid once `accept` returns.
+//! - Validity is *not* streamed. Positions that are logically null hold unspecified but
+//!   initialized values, matching what `execute` produces; read `array.validity()` separately.
+//! - Primitive-typed arrays only.
+//!
+//! # Cost model
+//!
+//! Dispatch is per chunk, never per value: one virtual call per ~1024 values per encoding level
+//! (~0.06 ns/element), with all per-element work monomorphized behind a real typed slice. No heap
+//! state is introduced descending the tree — the sink chain is one stack frame per level — and
+//! leaf producers reuse the scratch buffer their decompressor already owns.
+//!
+//! What streaming trades: one full-length intermediate buffer per encoding level becomes one pass
+//! over an L1-resident block, at the cost of a final scratch-to-output copy when the consumer
+//! wants a buffer. So it wins outright for consumers that never materialize (folding values
+//! directly), and for materialization it wins once a tree is deep enough that the eliminated
+//! intermediates outweigh that copy — see [`MIN_STREAMING_CHAIN`] for the measured threshold the
+//! executor uses.
 
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
@@ -158,6 +175,13 @@ impl ArrayRef {
         self.dtype().is_primitive() && self.dyn_array().supports_decompress_chunks(self)
     }
 
+    /// Returns whether the executor will canonicalize this array by streaming chunks (see
+    /// [`should_execute_via_chunks`]). Exposed for diagnostics and tests.
+    #[doc(hidden)]
+    pub fn should_execute_via_chunks(&self) -> bool {
+        should_execute_via_chunks(self)
+    }
+
     /// Stream the array's decompressed values through `sink` in cache-resident chunks.
     ///
     /// See the [module docs](self) for the contract and cost model. This errors — without
@@ -225,21 +249,13 @@ impl ArrayRef {
     }
 }
 
-/// Global toggle for the executor's stream-to-canonical shortcut (see [`execute_via_chunks`]).
-///
-/// **Disabled by default.** Streaming only beats level-wise execution for *materialization* when
-/// the level-wise path performs an extra full-buffer pass over an intermediate; when it already
-/// decodes straight into the destination (`decode_into` for fused FoR, Patched, and the Filter
-/// compaction kernel), streaming just adds a scratch-to-output copy. Measured over three rounds
-/// on 4Mi-row trees: signed `FoR(BitPacked)` (which does a separate wrapping-add pass) is
-/// 10-25% faster streaming, while fused `FoR(BitPacked)` and `Patched(FoR(BitPacked))` are
-/// ~5-10% slower. Since the outcome depends on the child's decode path rather than on anything
-/// the executor can see, the shortcut stays opt-in until sinks can offer a destination slice
-/// (which would remove the extra copy).
-///
-/// Set `VORTEX_CHUNKED_EXECUTE=1` to enable it, or use [`set_chunked_execute_enabled`].
+/// Global kill switch for the executor's stream-to-canonical shortcut (see
+/// [`execute_via_chunks`]). Enabled by default, subject to the depth rule in
+/// [`should_execute_via_chunks`]; set `VORTEX_CHUNKED_EXECUTE=0` to disable it entirely, or use
+/// [`set_chunked_execute_enabled`] at runtime (benchmarks and tests use this to compare both
+/// executor paths in one process).
 static CHUNKED_EXECUTE_ENABLED: std::sync::LazyLock<AtomicBool> = std::sync::LazyLock::new(|| {
-    AtomicBool::new(std::env::var("VORTEX_CHUNKED_EXECUTE").is_ok_and(|v| v == "1"))
+    AtomicBool::new(!std::env::var("VORTEX_CHUNKED_EXECUTE").is_ok_and(|v| v == "0"))
 });
 
 #[doc(hidden)]
@@ -247,30 +263,49 @@ pub fn set_chunked_execute_enabled(enabled: bool) {
     CHUNKED_EXECUTE_ENABLED.store(enabled, Ordering::Relaxed);
 }
 
-/// Returns whether the executor should shortcut this array's canonicalization through
-/// [`execute_via_chunks`].
+/// Minimum streaming chain length for the executor to canonicalize via chunk streaming.
 ///
-/// True when the shortcut is enabled, the whole tree streams
-/// ([`ArrayRef::supports_decompress_chunks`], which cascades: an encoding only advertises
-/// support when the children it streams from do), and the tree is at least two streaming levels
-/// deep. A lone streaming leaf (e.g. BitPacked with canonical patch children) decodes directly
-/// into the builder on its normal execute path, so streaming it would only add a scratch copy;
-/// the shortcut pays off when the normal path would materialize a full intermediate per level.
+/// Streaming trades one full-length intermediate buffer per encoding level for one pass over an
+/// L1-resident block, but pays a scratch-to-output copy at the end. That trade only pays off once
+/// a tree is deep enough. Measured on 4Mi-row `FoR`-over-`BitPacked` stacks (three rounds,
+/// medians): the marginal cost of an added level is ~0.83ms level-wise versus ~0.53ms streaming,
+/// so chains of 5 and 9 nodes run 1.24x and 1.46x faster streaming, while chains of 2-3 are
+/// within noise or slightly slower (their level-wise paths decode straight into the destination
+/// via `decode_into`, leaving no intermediate to eliminate). Streaming also has far tighter tail
+/// latency: p100/median ~1.2x versus 2.5-5x for level-wise, which repeatedly allocates
+/// full-length intermediates.
+const MIN_STREAMING_CHAIN: usize = 4;
+
+/// Length of the streaming chain rooted at `array`: the number of consecutive
+/// streaming-capable nodes from the root down to and including the deepest leaf producer.
+///
+/// Only children that a streaming parent actually decodes *through* extend the chain: a child
+/// must itself stream, must not already be canonical (canonical children are read directly, with
+/// no decode to eliminate), and must preserve row count. The cardinality rule is what keeps
+/// selection encodings such as `Filter` out of the executor path: their level-wise kernels decode
+/// the child straight into the output buffer and compact in place, so streaming would only add a
+/// copy. Streaming them is still available to consumers that never materialize, via
+/// [`ArrayRef::decompress_chunks`].
+fn streaming_chain_len(array: &ArrayRef) -> usize {
+    if !array.supports_decompress_chunks() {
+        return 0;
+    }
+    1 + array
+        .children_iter()
+        .filter(|child| !child.is_canonical() && child.len() == array.len())
+        .map(streaming_chain_len)
+        .max()
+        .unwrap_or(0)
+}
+
+/// Returns whether the executor should canonicalize this array by streaming chunks rather than
+/// materializing an intermediate per encoding level.
+///
+/// True when streaming is enabled and the tree's streaming chain reaches
+/// [`MIN_STREAMING_CHAIN`] nodes — the depth at which streaming is measured to win.
 pub(crate) fn should_execute_via_chunks(array: &ArrayRef) -> bool {
     CHUNKED_EXECUTE_ENABLED.load(Ordering::Relaxed)
-        && array.supports_decompress_chunks()
-        && array.children_iter().any(|child| {
-            !child.is_canonical()
-                    && child.supports_decompress_chunks()
-                    // Cardinality-preserving only. When a level changes row count (e.g. Filter),
-                    // its level-wise path decodes the child straight into the output buffer and
-                    // compacts in place, so there is no intermediate for streaming to eliminate —
-                    // streaming only adds a scratch-to-output copy. Measured on Filter(BitPacked)
-                    // at 64K rows: streaming is 1.2-2.6x slower than level-wise for
-                    // materialization. Streaming such trees is still available to consumers that
-                    // never materialize, via `decompress_chunks`.
-                    && child.len() == array.len()
-        })
+        && streaming_chain_len(array) >= MIN_STREAMING_CHAIN
 }
 
 /// Execute a streaming-capable primitive array tree to a canonical [`PrimitiveArray`] by

--- a/vortex-array/src/chunk_iter.rs
+++ b/vortex-array/src/chunk_iter.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Streaming chunked decompression.
+//!
+//! [`ArrayRef::decompress_chunks`] walks an array's decompressed values in cache-resident chunks
+//! (~1024 elements) without materializing the full array. Each encoding can override
+//! [`VTable::decompress_chunks`](crate::vtable::VTable::decompress_chunks) to stream chunks
+//! straight out of its decompression kernel; wrapper encodings (e.g. FoR) compose by interposing
+//! a stack-allocated [`ChunkSink`] adapter around the downstream sink and recursing into their
+//! child through the erased [`ArrayRef`] entry point.
+//!
+//! # Cost model
+//!
+//! The composition cost is one virtual call per chunk per encoding level (amortized over ~1024
+//! elements, i.e. fractions of a nanosecond per element) plus, for each wrapper level, one
+//! in-place pass over an L1-resident chunk. There is no per-element dynamic dispatch and no
+//! heap-allocated state introduced on the way down: the sink chain lives in the caller's stack
+//! frames, one frame per encoding level. Leaf producers reuse whatever scratch buffer their
+//! decompressor already maintains (e.g. the FastLanes 1024-element unpack buffer).
+//!
+//! The default implementation executes the array to canonical and then streams the result, which
+//! is exactly the two-pass behavior this API exists to avoid — so `decompress_chunks` is always
+//! possible on any encoding, and monotonically improves as encodings add overrides.
+//!
+//! # Contract
+//!
+//! - Chunks arrive in order, are contiguous, and cover `0..array.len()` exactly.
+//! - Chunks are producer-owned scratch: the sink may mutate them freely (wrappers rely on this to
+//!   transform values in place), and their contents are invalid once `accept` returns.
+//! - Validity is *not* streamed: positions that are logically null contain unspecified (but
+//!   initialized) values, matching `execute`'s decompression behavior. Callers that need null
+//!   information should fetch `array.validity()` separately.
+//! - Currently only primitive-typed arrays are supported.
+
+use std::marker::PhantomData;
+use std::ops::Range;
+
+use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
+
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::arrays::PrimitiveArray;
+use crate::dtype::NativePType;
+use crate::dtype::PType;
+use crate::match_each_native_ptype;
+
+/// The target number of elements per streamed chunk.
+///
+/// This matches the FastLanes block size so leaf decompressors can hand their unpack scratch
+/// buffer to the sink without copying. Producers may emit shorter chunks (e.g. a sliced first or
+/// last block).
+pub const DECOMPRESS_CHUNK_LEN: usize = 1024;
+
+/// A type-erased, mutable view over one chunk of decompressed primitive values.
+///
+/// This is a `(PType, *mut, len)` triple rather than a generic slice so it can cross the
+/// `dyn ChunkSink` boundary; sinks recover the typed slice with [`Self::as_slice_mut`]. The
+/// erasure cost is paid once per chunk, not per element.
+pub struct ChunkMut<'a> {
+    ptype: PType,
+    data: *mut u8,
+    len: usize,
+    _marker: PhantomData<&'a mut u8>,
+}
+
+impl<'a> ChunkMut<'a> {
+    /// Wrap a typed slice of decompressed values.
+    pub fn new<T: NativePType>(values: &'a mut [T]) -> Self {
+        Self {
+            ptype: T::PTYPE,
+            data: values.as_mut_ptr().cast(),
+            len: values.len(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// The primitive type of the values in this chunk.
+    #[inline]
+    pub fn ptype(&self) -> PType {
+        self.ptype
+    }
+
+    /// The number of values in this chunk.
+    #[inline]
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// View the chunk as a typed slice.
+    ///
+    /// # Panics
+    /// Panics if `T::PTYPE` does not match the chunk's ptype.
+    #[inline]
+    pub fn as_slice<T: NativePType>(&self) -> &[T] {
+        assert_eq!(T::PTYPE, self.ptype, "ChunkMut ptype mismatch");
+        // SAFETY: constructed from a valid `&mut [T]` with matching ptype; the lifetime is tied
+        // to the original borrow via `_marker`.
+        unsafe { std::slice::from_raw_parts(self.data.cast(), self.len) }
+    }
+
+    /// View the chunk as a mutable typed slice.
+    ///
+    /// # Panics
+    /// Panics if `T::PTYPE` does not match the chunk's ptype.
+    #[inline]
+    pub fn as_slice_mut<T: NativePType>(&mut self) -> &mut [T] {
+        assert_eq!(T::PTYPE, self.ptype, "ChunkMut ptype mismatch");
+        // SAFETY: constructed from a valid, exclusively borrowed `&mut [T]` with matching ptype.
+        unsafe { std::slice::from_raw_parts_mut(self.data.cast(), self.len) }
+    }
+
+    /// Reborrow this chunk with a shorter lifetime, e.g. to forward it to a downstream sink.
+    #[inline]
+    pub fn reborrow(&mut self) -> ChunkMut<'_> {
+        ChunkMut {
+            ptype: self.ptype,
+            data: self.data,
+            len: self.len,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Consumer side of [`ArrayRef::decompress_chunks`].
+///
+/// Implementations receive each decompressed chunk exactly once, in array order. `row_range` is
+/// the range of logical rows (relative to the array being iterated) that `chunk` covers; its
+/// length always equals `chunk.len()`.
+pub trait ChunkSink {
+    /// Accept the next chunk of decompressed values.
+    fn accept(&mut self, chunk: ChunkMut<'_>, row_range: Range<usize>) -> VortexResult<()>;
+}
+
+impl<F> ChunkSink for F
+where
+    F: FnMut(ChunkMut<'_>, Range<usize>) -> VortexResult<()>,
+{
+    #[inline]
+    fn accept(&mut self, chunk: ChunkMut<'_>, row_range: Range<usize>) -> VortexResult<()> {
+        self(chunk, row_range)
+    }
+}
+
+impl ArrayRef {
+    /// Stream the array's decompressed values through `sink` in cache-resident chunks.
+    ///
+    /// See the [module docs](self) for the contract and cost model. Encodings without a
+    /// specialized implementation fall back to full decompression followed by chunked iteration
+    /// of the result.
+    pub fn decompress_chunks(
+        &self,
+        ctx: &mut ExecutionCtx,
+        sink: &mut dyn ChunkSink,
+    ) -> VortexResult<()> {
+        vortex_ensure!(
+            self.dtype().is_primitive(),
+            "decompress_chunks requires a primitive-typed array, got {}",
+            self.dtype()
+        );
+
+        #[cfg(debug_assertions)]
+        {
+            let mut checked = CoverageCheckSink {
+                inner: sink,
+                next_row: 0,
+                ptype: self.dtype().as_ptype(),
+            };
+            self.dyn_array()
+                .decompress_chunks(self, ctx, &mut checked)?;
+            debug_assert_eq!(
+                checked.next_row,
+                self.len(),
+                "decompress_chunks did not cover the full array"
+            );
+            Ok(())
+        }
+        #[cfg(not(debug_assertions))]
+        self.dyn_array().decompress_chunks(self, ctx, sink)
+    }
+}
+
+#[cfg(debug_assertions)]
+struct CoverageCheckSink<'a> {
+    inner: &'a mut dyn ChunkSink,
+    next_row: usize,
+    ptype: PType,
+}
+
+#[cfg(debug_assertions)]
+impl ChunkSink for CoverageCheckSink<'_> {
+    fn accept(&mut self, chunk: ChunkMut<'_>, row_range: Range<usize>) -> VortexResult<()> {
+        debug_assert_eq!(row_range.start, self.next_row, "non-contiguous chunk");
+        debug_assert_eq!(
+            row_range.len(),
+            chunk.len(),
+            "chunk/row_range length mismatch"
+        );
+        debug_assert_eq!(chunk.ptype(), self.ptype, "chunk ptype mismatch");
+        self.next_row = row_range.end;
+        self.inner.accept(chunk, row_range)
+    }
+}
+
+/// Fallback chunked decompression: execute the array to a canonical [`PrimitiveArray`], then
+/// stream copies of its values in [`DECOMPRESS_CHUNK_LEN`]-sized chunks.
+///
+/// This is the two-pass baseline. It copies each chunk into a single reusable scratch buffer
+/// (allocated once) because sinks receive exclusive, mutable chunks.
+pub fn decompress_chunks_via_canonical(
+    array: &ArrayRef,
+    ctx: &mut ExecutionCtx,
+    sink: &mut dyn ChunkSink,
+) -> VortexResult<()> {
+    let primitive = array.clone().execute::<PrimitiveArray>(ctx)?;
+    match_each_native_ptype!(primitive.ptype(), |T| {
+        stream_slice_chunks::<T>(primitive.as_slice::<T>(), sink)
+    })
+}
+
+fn stream_slice_chunks<T: NativePType>(values: &[T], sink: &mut dyn ChunkSink) -> VortexResult<()> {
+    let mut scratch = vec![T::default(); values.len().min(DECOMPRESS_CHUNK_LEN)];
+    for (chunk_idx, chunk) in values.chunks(DECOMPRESS_CHUNK_LEN).enumerate() {
+        let start = chunk_idx * DECOMPRESS_CHUNK_LEN;
+        let scratch = &mut scratch[..chunk.len()];
+        scratch.copy_from_slice(chunk);
+        sink.accept(ChunkMut::new(scratch), start..start + chunk.len())?;
+    }
+    Ok(())
+}

--- a/vortex-array/src/chunk_iter.rs
+++ b/vortex-array/src/chunk_iter.rs
@@ -19,9 +19,12 @@
 //! frames, one frame per encoding level. Leaf producers reuse whatever scratch buffer their
 //! decompressor already maintains (e.g. the FastLanes 1024-element unpack buffer).
 //!
-//! The default implementation executes the array to canonical and then streams the result, which
-//! is exactly the two-pass behavior this API exists to avoid — so `decompress_chunks` is always
-//! possible on any encoding, and monotonically improves as encodings add overrides.
+//! Streaming is an explicit capability, not a silent guarantee: encodings advertise it via
+//! [`VTable::supports_decompress_chunks`](crate::vtable::VTable::supports_decompress_chunks)
+//! (wrappers propagate the check through their children), and
+//! [`ArrayRef::decompress_chunks`] errors on an unsupported tree instead of quietly
+//! materializing it. Callers that want a works-everywhere path opt into the two-pass fallback
+//! by name with [`ArrayRef::decompress_chunks_or_materialize`].
 //!
 //! # Contract
 //!
@@ -145,12 +148,37 @@ where
 }
 
 impl ArrayRef {
+    /// Returns whether this array (recursively, through wrapper encodings) can stream its
+    /// decompressed values via [`Self::decompress_chunks`] without materializing anything.
+    pub fn supports_decompress_chunks(&self) -> bool {
+        self.dtype().is_primitive() && self.dyn_array().supports_decompress_chunks(self)
+    }
+
     /// Stream the array's decompressed values through `sink` in cache-resident chunks.
     ///
-    /// See the [module docs](self) for the contract and cost model. Encodings without a
-    /// specialized implementation fall back to full decompression followed by chunked iteration
-    /// of the result.
+    /// See the [module docs](self) for the contract and cost model. This errors — without
+    /// emitting any chunks — if the encoding tree does not support streaming (check with
+    /// [`Self::supports_decompress_chunks`]); it never silently falls back to full
+    /// materialization. Use [`Self::decompress_chunks_or_materialize`] to opt into that
+    /// fallback explicitly.
     pub fn decompress_chunks(
+        &self,
+        ctx: &mut ExecutionCtx,
+        sink: &mut dyn ChunkSink,
+    ) -> VortexResult<()> {
+        vortex_ensure!(
+            self.supports_decompress_chunks(),
+            "decompress_chunks is not supported by this array tree (root encoding {}, dtype {}); \
+             use decompress_chunks_or_materialize for an explicit two-pass fallback",
+            self.encoding_id(),
+            self.dtype()
+        );
+        self.decompress_chunks_unchecked(ctx, sink)
+    }
+
+    /// Stream chunks if the tree supports it, otherwise fall back to executing the array to
+    /// canonical and streaming the materialized result — the two-pass behavior, chosen by name.
+    pub fn decompress_chunks_or_materialize(
         &self,
         ctx: &mut ExecutionCtx,
         sink: &mut dyn ChunkSink,
@@ -160,7 +188,18 @@ impl ArrayRef {
             "decompress_chunks requires a primitive-typed array, got {}",
             self.dtype()
         );
+        if self.supports_decompress_chunks() {
+            self.decompress_chunks_unchecked(ctx, sink)
+        } else {
+            decompress_chunks_via_canonical(self, ctx, sink)
+        }
+    }
 
+    fn decompress_chunks_unchecked(
+        &self,
+        ctx: &mut ExecutionCtx,
+        sink: &mut dyn ChunkSink,
+    ) -> VortexResult<()> {
         #[cfg(debug_assertions)]
         {
             let mut checked = CoverageCheckSink {
@@ -262,6 +301,7 @@ mod tests {
     fn constant_chunks() -> VortexResult<()> {
         // Length deliberately not a multiple of the chunk size.
         let array = ConstantArray::new(7i32, 2500).into_array();
+        assert!(array.supports_decompress_chunks());
         let chunked = collect_chunks::<i32>(&array)?;
         assert_eq!(chunked, vec![7i32; 2500]);
         Ok(())
@@ -293,9 +333,43 @@ mod tests {
         )?;
         let array = Patched::from_array_and_patches(inner, &patches, &mut ctx)?.into_array();
 
+        assert!(array.supports_decompress_chunks());
         let chunked = collect_chunks::<u16>(&array)?;
         let expected = array.execute::<PrimitiveArray>(&mut ctx)?;
         assert_eq!(chunked.as_slice(), expected.as_slice::<u16>());
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_encoding_errors_without_emitting() -> VortexResult<()> {
+        let mut ctx = array_session().create_execution_ctx();
+        // A primitive-typed encoding tree with no streaming support: Dict over primitives.
+        let array = crate::arrays::DictArray::try_new(
+            buffer![0u32, 1, 0, 1].into_array(),
+            buffer![10i32, 20].into_array(),
+        )?
+        .into_array();
+        assert!(!array.supports_decompress_chunks());
+
+        let mut emitted = 0usize;
+        let result = array.decompress_chunks(&mut ctx, &mut |chunk: ChunkMut<'_>,
+                                                             _range: Range<usize>|
+         -> VortexResult<()> {
+            emitted += chunk.len();
+            Ok(())
+        });
+        assert!(result.is_err());
+        assert_eq!(emitted, 0, "no chunks may be emitted on unsupported trees");
+
+        // The explicit fallback still works and covers the array.
+        let mut out = Vec::new();
+        array.decompress_chunks_or_materialize(&mut ctx, &mut |chunk: ChunkMut<'_>,
+                                                                _range: Range<usize>|
+         -> VortexResult<()> {
+            out.extend_from_slice(chunk.as_slice::<i32>());
+            Ok(())
+        })?;
+        assert_eq!(out, vec![10i32, 20, 10, 20]);
         Ok(())
     }
 }

--- a/vortex-array/src/chunk_iter.rs
+++ b/vortex-array/src/chunk_iter.rs
@@ -225,12 +225,21 @@ impl ArrayRef {
     }
 }
 
-/// Global toggle for the executor's stream-to-canonical shortcut (see
-/// [`execute_via_chunks`]). Enabled by default; `VORTEX_CHUNKED_EXECUTE=0` disables it at process
-/// start, and [`set_chunked_execute_enabled`] overrides it at runtime — both exist only so
-/// benchmarks and tests can compare the executor with and without the shortcut.
+/// Global toggle for the executor's stream-to-canonical shortcut (see [`execute_via_chunks`]).
+///
+/// **Disabled by default.** Streaming only beats level-wise execution for *materialization* when
+/// the level-wise path performs an extra full-buffer pass over an intermediate; when it already
+/// decodes straight into the destination (`decode_into` for fused FoR, Patched, and the Filter
+/// compaction kernel), streaming just adds a scratch-to-output copy. Measured over three rounds
+/// on 4Mi-row trees: signed `FoR(BitPacked)` (which does a separate wrapping-add pass) is
+/// 10-25% faster streaming, while fused `FoR(BitPacked)` and `Patched(FoR(BitPacked))` are
+/// ~5-10% slower. Since the outcome depends on the child's decode path rather than on anything
+/// the executor can see, the shortcut stays opt-in until sinks can offer a destination slice
+/// (which would remove the extra copy).
+///
+/// Set `VORTEX_CHUNKED_EXECUTE=1` to enable it, or use [`set_chunked_execute_enabled`].
 static CHUNKED_EXECUTE_ENABLED: std::sync::LazyLock<AtomicBool> = std::sync::LazyLock::new(|| {
-    AtomicBool::new(!std::env::var("VORTEX_CHUNKED_EXECUTE").is_ok_and(|v| v == "0"))
+    AtomicBool::new(std::env::var("VORTEX_CHUNKED_EXECUTE").is_ok_and(|v| v == "1"))
 });
 
 #[doc(hidden)]
@@ -250,9 +259,18 @@ pub fn set_chunked_execute_enabled(enabled: bool) {
 pub(crate) fn should_execute_via_chunks(array: &ArrayRef) -> bool {
     CHUNKED_EXECUTE_ENABLED.load(Ordering::Relaxed)
         && array.supports_decompress_chunks()
-        && array
-            .children_iter()
-            .any(|child| !child.is_canonical() && child.supports_decompress_chunks())
+        && array.children_iter().any(|child| {
+            !child.is_canonical()
+                    && child.supports_decompress_chunks()
+                    // Cardinality-preserving only. When a level changes row count (e.g. Filter),
+                    // its level-wise path decodes the child straight into the output buffer and
+                    // compacts in place, so there is no intermediate for streaming to eliminate —
+                    // streaming only adds a scratch-to-output copy. Measured on Filter(BitPacked)
+                    // at 64K rows: streaming is 1.2-2.6x slower than level-wise for
+                    // materialization. Streaming such trees is still available to consumers that
+                    // never materialize, via `decompress_chunks`.
+                    && child.len() == array.len()
+        })
 }
 
 /// Execute a streaming-capable primitive array tree to a canonical [`PrimitiveArray`] by

--- a/vortex-array/src/chunk_iter.rs
+++ b/vortex-array/src/chunk_iter.rs
@@ -229,10 +229,9 @@ impl ArrayRef {
 /// [`execute_via_chunks`]). Enabled by default; `VORTEX_CHUNKED_EXECUTE=0` disables it at process
 /// start, and [`set_chunked_execute_enabled`] overrides it at runtime — both exist only so
 /// benchmarks and tests can compare the executor with and without the shortcut.
-static CHUNKED_EXECUTE_ENABLED: std::sync::LazyLock<AtomicBool> =
-    std::sync::LazyLock::new(|| {
-        AtomicBool::new(!std::env::var("VORTEX_CHUNKED_EXECUTE").is_ok_and(|v| v == "0"))
-    });
+static CHUNKED_EXECUTE_ENABLED: std::sync::LazyLock<AtomicBool> = std::sync::LazyLock::new(|| {
+    AtomicBool::new(!std::env::var("VORTEX_CHUNKED_EXECUTE").is_ok_and(|v| v == "0"))
+});
 
 #[doc(hidden)]
 pub fn set_chunked_execute_enabled(enabled: bool) {
@@ -249,25 +248,11 @@ pub fn set_chunked_execute_enabled(enabled: bool) {
 /// into the builder on its normal execute path, so streaming it would only add a scratch copy;
 /// the shortcut pays off when the normal path would materialize a full intermediate per level.
 pub(crate) fn should_execute_via_chunks(array: &ArrayRef) -> bool {
-    let fires = CHUNKED_EXECUTE_ENABLED.load(Ordering::Relaxed)
+    CHUNKED_EXECUTE_ENABLED.load(Ordering::Relaxed)
         && array.supports_decompress_chunks()
         && array
             .children_iter()
-            .any(|child| !child.is_canonical() && child.supports_decompress_chunks());
-    // TEMPORARY diagnostics, not for merge.
-    if std::env::var("VORTEX_CHUNKED_EXECUTE_TRACE").is_ok() && !array.is_canonical() {
-        eprintln!(
-            "CHUNKED_EXEC fires={} len={} root={} children={:?}",
-            fires,
-            array.len(),
-            array.encoding_id(),
-            array
-                .children_iter()
-                .map(|c| c.encoding_id().to_string())
-                .collect::<Vec<_>>()
-        );
-    }
-    fires
+            .any(|child| !child.is_canonical() && child.supports_decompress_chunks())
 }
 
 /// Execute a streaming-capable primitive array tree to a canonical [`PrimitiveArray`] by

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -265,6 +265,25 @@ impl ArrayRef {
                 ));
             }
 
+            // Step 2c: stream-to-canonical shortcut. When the whole encoding tree supports
+            // chunked decompression (the capability cascades: each encoding only advertises
+            // support when the children it streams from do) and is at least two streaming
+            // levels deep, decompress blocks straight into the canonical builder while each
+            // block is L1-resident, instead of materializing a full intermediate per level.
+            if current_builder.is_none()
+                && crate::chunk_iter::should_execute_via_chunks(&current_array)
+            {
+                let stats = current_array.statistics().to_array_stats();
+                let result = crate::chunk_iter::execute_via_chunks(&current_array, ctx)?;
+                trace_op!(record_execute_done(&result.as_ref()));
+                let result = result.into_array();
+                result
+                    .statistics()
+                    .set_iter(StatsSet::from(stats).into_iter());
+                current_array = result;
+                continue;
+            }
+
             let expected_len = current_array.len();
             let expected_dtype = current_array.dtype().clone();
             let stats = current_array.statistics().to_array_stats();

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -113,6 +113,7 @@ pub mod buffer;
 pub mod builders;
 pub mod builtins;
 mod canonical;
+pub mod chunk_iter;
 mod columnar;
 pub mod compute;
 pub mod display;


### PR DESCRIPTION
## Summary

Adds `decompress_chunks`, a vtable method that streams an encoding tree's decompressed values through a `ChunkSink` in cache-resident ~1024-element chunks. Leaf encodings stream blocks straight out of their decompression kernel; wrapper encodings compose by interposing a stack-allocated sink adapter and recursing into their child, so a whole tree decompresses and transforms one L1-resident block at a time instead of materializing a full-length buffer per level.

Two things this buys:

1. **Consumers that never materialize** fold values directly out of L1 — a sum over `FoR(BitPacked)` runs 1.29 ms vs 3.36 ms for decompress-then-iterate, matching a hand-written monomorphized loop within noise.
2. **Deep encoding stacks canonicalize faster**, because each level costs level-wise execution a whole intermediate buffer but costs streaming only one more L1 pass. Marginal cost per added level: **0.93 ms level-wise vs 0.51 ms streaming**.

The executor uses it where that second effect pays, decided by measuring the tree rather than by a blanket default.

## The vtable API

```rust
pub trait VTable {
    /// Can this encoding (recursively) stream without materializing? Default: false.
    fn supports_decompress_chunks(array: ArrayView<'_, Self>) -> bool { false }

    /// Stream decompressed values through `sink` in cache-resident chunks.
    /// Default: reports unsupported — never a silent materializing fallback.
    fn decompress_chunks(
        array: ArrayView<'_, Self>,
        ctx: &mut ExecutionCtx,
        sink: &mut dyn ChunkSink,
    ) -> VortexResult<()>;
}

pub trait ChunkSink {
    fn accept(&mut self, chunk: ChunkMut<'_>, row_range: Range<usize>) -> VortexResult<()>;
}
```

Design points:

- **Two methods, not one.** Support must be answerable *before* any work happens, and it **cascades**: a wrapper only advertises support when the children it streams from do. So the whole tree is validated up front and `ArrayRef::decompress_chunks` rejects an unsupported tree without emitting a partial stream.
- **No silent fallback.** Callers who want one ask by name: `ArrayRef::decompress_chunks_or_materialize`.
- **Dispatch is per chunk, never per value.** `ChunkMut` is a type-erased `&mut [T]`; sinks recover the typed slice once per chunk and all per-element work stays monomorphized (~0.06 ns/element of dispatch).
- **Chunks are mutable producer scratch**, which is what lets wrappers transform in place (FoR adds its reference, Patched overwrites patched rows, Filter compacts) with no extra buffer.
- **No heap state descending the tree** — the sink chain is one stack frame per level.
- Contract: chunks are in-order, contiguous, cover `0..len` exactly (debug-checked), may be short; validity is not streamed; primitive dtypes only.

## Changes

- `vortex-array/src/chunk_iter.rs` (new): `ChunkSink`, `ChunkMut`, `DECOMPRESS_CHUNK_LEN`, the `ArrayRef` entry points, `execute_via_chunks`, a debug-build coverage checker, and the explicit materializing fallback.
- `VTable::{supports_decompress_chunks, decompress_chunks}`, wired through `DynArrayData`.
- `execute_until` step 2c: canonicalize by streaming when `streaming_chain_len(array) >= MIN_STREAMING_CHAIN` (4). The chain counts consecutive streaming-capable nodes from the root, following only children that stream, are not already canonical, and **preserve row count** — that last rule keeps selection encodings such as `Filter` out of the executor path without a special case. `VORTEX_CHUNKED_EXECUTE=0` is a kill switch.
- Implementations: **BitPacked** (streams FastLanes blocks from its unpack scratch, patches applied per block via a cursor), **FoR** (fused `FoRStrategy` kernel when the child is BitPacked with an unsigned reference, otherwise generic in-place add composition), **Patched** (patches each streamed block in place; lane-transposed layout flattened once), **Filter** (compacts each block in place against the mask, with a mean-run-length heuristic choosing run-copy vs gather), **Constant** (re-emits one scratch chunk), **Primitive** (streams its buffer through one L1 scratch chunk).
- Tests: patches, slicing/offset, fused and generic FoR, Patched-over-Constant, Filter-over-BitPacked across selectivities plus all-true/all-false, non-chunk-aligned lengths, null constants, empty arrays, the error-without-emitting contract, streaming-vs-levelwise equivalence at three stack depths on nullable trees, and the executor depth rule (including that filter push-down beneath a deep stack still streams the levels above it).
- New divan bench `encodings/fastlanes/benches/chunked_decompress.rs` with hand-written monomorphized baselines to isolate each overhead.

## Benchmarks

Divan on a 4-core cloud VM, 4Mi rows unless noted. **Methodology note:** an earlier revision of this PR reported executor wins that did not reproduce — they were measured while other builds were running. Everything below is from repeated rounds on a quiet machine, and results that were not stable across rounds are called out as such.

**Depth sweep — nested FoR over BitPacked, canonicalize:**

| streaming chain | level-wise | streaming | speedup | level-wise p100 | streaming p100 |
|---|---|---|---|---|---|
| 2 | 2.57 ms | 2.58 ms | parity | 10.9 ms | 3.1 ms |
| 3 | 3.14 ms | 2.74 ms | 1.15× | 13.6 ms | 3.8 ms |
| 5 | 5.26 ms | 4.00 ms | 1.32× | 17.0 ms | 4.6 ms |
| 9 | 9.07 ms | 6.16 ms | **1.47×** | 23.4 ms | 6.5 ms |

Marginal cost per added level: **0.93 ms level-wise vs 0.51 ms streaming**. Tail latency is the other story: p100/median is ~1.2× streaming versus 2.5–5× level-wise, which repeatedly allocates full-length intermediates. This is what `MIN_STREAMING_CHAIN = 4` is calibrated against; chain 3 is borderline (1.08–1.15× across rounds) and excluded conservatively.

**Streaming consumption — sum without materializing, FoR(ref=1M) over BitPacked(bw=10):**

| bench | median |
|---|---|
| `hand_fused_sum` (monomorphized upper bound) | 1.014 ms |
| `chunked_vtable_sum` (**this API**, fused FoR+BitPacked) | 1.291 ms |
| `hand_chunked_add_pass_sum` (monomorphized, extra in-place pass) | 1.411 ms |
| `chunked_vtable_sum_generic_compose` (signed ref, generic composition) | 1.886 ms |
| `two_pass_sum` (decompress then re-read) | 3.360 ms |

Patched(Constant), 1 patch per 1000 — the 16 MB base buffer is never written: streaming sum 0.955 ms vs 1.953 ms decompress-then-read.

**Where streaming does *not* win, and why.** When an encoding's level-wise path already decodes straight into the destination (`decode_into` for fused FoR/Patched; the in-place compaction kernel for Filter), there is no intermediate to eliminate and streaming only adds a scratch→output copy. `Filter(BitPacked)` at 65,536 rows (the dominant TPC-H scan tree) measures at parity for materialization and 10–35% slower for consumption except at high selectivity. Hence the cardinality rule in the executor: `Filter` streams for consumers, never through the executor.

**SQL (TPC-H SF-1, DataFusion, Q1 + Q6).** Neutral within noise. A trace showed why: streaming-capable trees are ~6% of non-canonical executor invocations there, and the trees that dominate (`Filter`, `decimal_byte_parts`) are shallow — chains of 2–3, below the depth where streaming pays. The mechanism is confirmed non-regressing on the real scan path; SQL-level wins need `ChunkSink` consumers in the aggregate kernels, where the consumption win above would reach query time.

**Next step.** The remaining structural overhead is destination-blindness: a producer cannot see the consumer's output buffer, so it always decodes into scratch. Letting a sink offer a destination slice per chunk would remove that copy, which should turn the parity/loss cases into wins and lower `MIN_STREAMING_CHAIN`.

Checks run: `cargo nextest run` on vortex-array (3439), vortex-fastlanes (327), vortex-file (144), vortex-alp, vortex-btrblocks — all passing; `cargo test --doc -p vortex-array`; `cargo clippy --all-targets` on vortex-array/vortex-fastlanes (clean); `cargo +nightly fmt --all`; TPC-H SF-1 Q1/Q6 A/B via `datafusion-bench`. Not run: workspace-wide `--all-features` clippy (CUDA feature stack untouched).

## API Changes

New public API in `vortex-array`: the `chunk_iter` module (`ChunkSink`, `ChunkMut`, `DECOMPRESS_CHUNK_LEN`, `execute_via_chunks`), `ArrayRef::{supports_decompress_chunks, decompress_chunks, decompress_chunks_or_materialize}`, and two defaulted `VTable` methods. Behavior change: `execute_until` canonicalizes streaming-capable primitive trees of chain length ≥ 4 via chunk streaming (same logical results, covered by equivalence tests; disable with `VORTEX_CHUNKED_EXECUTE=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNgQat1UYMr3pjJrdhPJuh