### PR TITLE
Clarify `RowFn` infallibility documentation

### DIFF
--- a/vortex-array/src/scalar_fn/unstable/row/row_fn.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/row_fn.rs
@@ -47,15 +47,17 @@ pub trait RowFn: 'static + Sized + Clone + Send + Sync {
     /// The arguments in display order. Its length is the function's exact arity.
     const ARG_NAMES: &'static [&'static str];
 
-    /// Whether the row operation selected by every dispatch is infallible.
+    /// Whether every row operation selected by [`dispatch`](Self::dispatch) is semantically
+    /// infallible.
     ///
-    /// See [`ScalarFnVTable::is_infallible`](crate::scalar_fn::ScalarFnVTable::is_infallible) for
-    /// a more detailed explanation of semantic errors.
+    /// Input decoding declares its fallibility independently through
+    /// [`InputElement::DECODE_INFALLIBLE`] and does not affect this flag. The framework checks
+    /// row-result fallibility. A conservative `false` is allowed.
     ///
-    /// Input decoding fallibility is declared separately by
-    /// [`InputElement::DECODE_INFALLIBLE`](crate::scalar_fn::unstable::row::InputElement::DECODE_INFALLIBLE)
-    /// and does not affect this flag. The framework checks dispatched result types. A conservative
-    /// `false` is allowed.
+    /// See [`ScalarFnVTable::is_infallible`] for the definition of semantic errors.
+    ///
+    /// [`InputElement::DECODE_INFALLIBLE`]: crate::scalar_fn::unstable::row::InputElement::DECODE_INFALLIBLE
+    /// [`ScalarFnVTable::is_infallible`]: crate::scalar_fn::ScalarFnVTable::is_infallible
     const INFALLIBLE: bool;
 
     /// Returns the ID of the scalar function.


### PR DESCRIPTION
## Summary

- Tracking issue: #9129

Clarifies that `RowFn::INFALLIBLE` covers every supported call, including selected decoders that can reject legal input data.

## Changes

Updates the visitor documentation and assertion message to use the same contract.