### PR TITLE
docs(java): replace the Java API example that no longer compiles

### DIFF
--- a/docs/api/java/index.rst
+++ b/docs/api/java/index.rst
@@ -46,14 +46,31 @@ Here's a basic example of using the Vortex Java API to read a Vortex file:
 
 .. code-block:: java
 
-    import dev.vortex.api.File;
-    import dev.vortex.api.Array;
+    import dev.vortex.api.DataSource;
+    import dev.vortex.api.Partition;
+    import dev.vortex.api.Scan;
+    import dev.vortex.api.ScanOptions;
+    import dev.vortex.api.Session;
+    import dev.vortex.arrow.ArrowAllocation;
+    import org.apache.arrow.memory.BufferAllocator;
+    import org.apache.arrow.vector.VectorSchemaRoot;
+    import org.apache.arrow.vector.ipc.ArrowReader;
 
-    // Open a Vortex file
-    File vortexFile = File.open("path/to/file.vortex");
+    BufferAllocator allocator = ArrowAllocation.rootAllocator();
+    Session session = Session.create();
+    DataSource source = DataSource.open(session, "path/to/file.vortex");
 
-    // Read arrays from the file
-    Array array = vortexFile.readArray();
+    // A scan yields one partition per chunk of the file.
+    Scan scan = source.scan(ScanOptions.of());
+    while (scan.hasNext()) {
+        Partition partition = scan.next();
+        try (ArrowReader reader = partition.scanArrow(allocator)) {
+            while (reader.loadNextBatch()) {
+                VectorSchemaRoot batch = reader.getVectorSchemaRoot();
+                System.out.println("read " + batch.getRowCount() + " rows");
+            }
+        }
+    }
 
-    // Work with the array data
-    System.out.println("Array length: " + array.getLength());
+Data crosses the JNI boundary as Arrow record batches, so the buffers stay in native memory and
+are read from Java through the Arrow C Data Interface.


### PR DESCRIPTION
The only Java example on the docs site cannot compile: `dev.vortex.api.File` and
`dev.vortex.api.Array` were removed in #7527, and the page has not been touched since. Nothing in
it points at the API that replaced them.

Replaced with the read path that exists today — `Session` → `DataSource.open` → `scan` →
`Partition.scanArrow` — following the same loop the JNI tests use.

## Tests

Compiled both snippets as a scratch class under `vortex-jni/src/test`: the published one fails with
five `cannot find symbol` errors for `File` and `Array`, the new one compiles. `make -C docs html`
succeeds under the repo's `--fail-on-warning`.

## AI assistance

Written with agentic AI assistance; I compiled the replacement snippet before publishing it.
