### PR TITLE
docs: filter pushdown is connected, not future work

### DIFF
--- a/docs/developer-guide/integrations/spark.md
+++ b/docs/developer-guide/integrations/spark.md
@@ -39,8 +39,9 @@ Projection pushdown is supported through Spark's `SupportsPushDownRequiredColumn
 The scan builder prunes the column list to only those referenced by the query, and the pruned
 column set is passed to the native scan via `ScanOptions`.
 
-Filter pushdown infrastructure exists in the `ScanOptions` type but is not yet connected to
-Spark's `SupportsPushDownFilters` interface. This is planned future work.
+Filter pushdown is supported through `SupportsPushDownV2Filters`. The scan builder converts each
+predicate it recognizes into a Vortex expression and keeps the rest for Spark to evaluate after the
+scan; the converted expression reaches native code as the `ScanOptions` filter.
 
 ## Data Export
 
@@ -53,5 +54,4 @@ through direct byte buffers.
 
 The current integration builds directly on the native file and scan APIs via JNI. Future work
 will migrate it to use the [Scan API](/concepts/scanning) `Source` trait, which will provide a
-standard interface for file discovery, partitioning, and pushdown. This will also enable
-connecting Spark's filter pushdown to Vortex's expression-based filtering.
+standard interface for file discovery, partitioning, and pushdown.


### PR DESCRIPTION
The guide called filter pushdown unconnected and "planned future work". It was connected in #7785:
`VortexScanBuilder` implements `SupportsPushDownV2Filters` and the converted expression reaches
native code as the `ScanOptions` filter, so a developer reading this plans around a limitation that
no longer exists.

The Future Work section keeps the `Source` trait migration, which is still outstanding.

## Tests

`make -C docs html` succeeds under the repo's `--fail-on-warning`, same warning count as develop.

## AI assistance

Written with agentic AI assistance; I traced the pushdown path end to end before editing.
