### PR TITLE
docs(vx): state which inspection commands support --json

### DIFF
--- a/docs/getting-started/query.md
+++ b/docs/getting-started/query.md
@@ -51,7 +51,8 @@ vx segments yellow_tripdata_2024-01.vortex
 vx inspect yellow_tripdata_2024-01.vortex
 ```
 
-All inspection commands support `--json` for machine-readable output.
+`vx inspect` and `vx tree layout` take `--json` for machine-readable output; `vx segments` always
+emits JSON.
 
 ## Standalone SQL
 

--- a/vortex-tui/README.md
+++ b/vortex-tui/README.md
@@ -6,6 +6,8 @@ A small, helpful CLI tool for exploring and analyzing Vortex files.
 * `tree`: Print the encoding tree of a Vortex file
 * `inspect`: Inspect Vortex file footer and metadata
 * `convert`: Convert a Parquet file to a Vortex file
+* `query`: Run a SQL query against a Vortex file and print JSON
+* `segments`: Print the segment layout of a Vortex file as JSON
 
 ## Examples
 


### PR DESCRIPTION
`query.md` said all inspection commands support `--json`. `vx segments` has no such flag (it always
prints JSON) and `vx tree array` accepts it then prints a human tree, so a script trusting it breaks
either way. Wiring `vx tree array` changes CLI output, so that is left for an issue.

Also adds `query` and `segments` to the `vx` README, which listed four of six subcommands.

## Tests

`make -C docs html` succeeds under `--fail-on-warning`, same warning count as develop.

## AI assistance

Written with agentic AI assistance; I read each command's argument struct first.
