### PR TITLE
duckdb: propagate per-file "partition" stats

### DIFF
--- a/vortex-duckdb/cpp/include/multi_file_reader.hpp
+++ b/vortex-duckdb/cpp/include/multi_file_reader.hpp
@@ -16,7 +16,6 @@ struct VortexBindData final : TableFunctionData {
     bool Equals(const FunctionData &other) const override;
 
     unique_ptr<CData> ffi_bind_data;
-    bool no_footer_caches = false;
 };
 
 struct VortexBindResult {

--- a/vortex-duckdb/cpp/include/multi_file_reader.hpp
+++ b/vortex-duckdb/cpp/include/multi_file_reader.hpp
@@ -16,7 +16,7 @@ struct VortexBindData final : TableFunctionData {
     bool Equals(const FunctionData &other) const override;
 
     unique_ptr<CData> ffi_bind_data;
-    bool attempted_to_load_caches = false;
+    bool no_footer_caches = false;
 };
 
 struct VortexBindResult {

--- a/vortex-duckdb/cpp/include/multi_file_reader.hpp
+++ b/vortex-duckdb/cpp/include/multi_file_reader.hpp
@@ -3,9 +3,12 @@
 #pragma once
 
 #include "data.hpp"
+#include "table_function.h"
 #include "duckdb/common/multi_file/multi_file_function.hpp"
 
 using namespace duckdb;
+
+unique_ptr<BaseStatistics> to_duckdb_statistics(duckdb_column_statistics &statistics);
 
 struct VortexBindData final : TableFunctionData {
     VortexBindData() = default;
@@ -13,6 +16,7 @@ struct VortexBindData final : TableFunctionData {
     bool Equals(const FunctionData &other) const override;
 
     unique_ptr<CData> ffi_bind_data;
+    bool attempted_to_load_caches = false;
 };
 
 struct VortexBindResult {

--- a/vortex-duckdb/cpp/include/multi_file_reader.hpp
+++ b/vortex-duckdb/cpp/include/multi_file_reader.hpp
@@ -8,6 +8,7 @@
 
 using namespace duckdb;
 
+// Convert Vortex statistics to DuckDB statistics
 unique_ptr<BaseStatistics> to_duckdb_statistics(duckdb_column_statistics &statistics);
 
 struct VortexBindData final : TableFunctionData {

--- a/vortex-duckdb/cpp/include/table_function.hpp
+++ b/vortex-duckdb/cpp/include/table_function.hpp
@@ -33,9 +33,15 @@ struct TableFunctionUngroupedAggregateInput {
 bool aggregate_pushdown(ClientContext &context, const TableFunctionUngroupedAggregateInput &input);
 
 /*
- * DuckDB uses partition row groups to answer filter-less aggregation queries
- * from statistics. A Vortex "row group" is therefore a file since we have
- * file statistics and they're easiest to read.
+ * DuckDB uses partition row groups for two purposes:
+ *
+ * 1. If optimizer proves query (e.g. SELECT min(col)) can be answered from
+ *    metadata, it replaces a real scan with a call to GetColumnStatistics.
+ * 2. If optimizer proves a row group can be pruned because of statistics, it
+ *    removes row group's read. We don't use this as we implement own prunung.
+ *
+ * For (1) we care about providing statistics fast, so we report a file as
+ * a "row group".
  */
 struct VortexRowGroup final : PartitionRowGroup {
     explicit VortexRowGroup(unique_ptr<CData> ffi_footer) : ffi_footer(std::move(ffi_footer)) {

--- a/vortex-duckdb/cpp/include/table_function.hpp
+++ b/vortex-duckdb/cpp/include/table_function.hpp
@@ -41,6 +41,8 @@ struct VortexRowGroup final : PartitionRowGroup {
 
     unique_ptr<BaseStatistics> GetColumnStatistics(const StorageIndex &storage_index) override;
     bool MinMaxIsExact(const BaseStatistics &, const StorageIndex &) override {
+        // TODO(myrrc): in duckdb 2.0 we should report false for strings and
+        // also add TRUNCATED_STATS type for them
         return true;
     }
 };

--- a/vortex-duckdb/cpp/include/table_function.hpp
+++ b/vortex-duckdb/cpp/include/table_function.hpp
@@ -32,7 +32,11 @@ struct TableFunctionUngroupedAggregateInput {
 
 bool aggregate_pushdown(ClientContext &context, const TableFunctionUngroupedAggregateInput &input);
 
-// Vortex "row group" is a file
+/*
+ * DuckDB uses partition row groups to answer filter-less aggregation queries
+ * from statistics. A Vortex "row group" is therefore a file since we have
+ * file statistics and they're easiest to read.
+ */
 struct VortexRowGroup final : PartitionRowGroup {
     explicit VortexRowGroup(unique_ptr<CData> ffi_footer) : ffi_footer(std::move(ffi_footer)) {
     }

--- a/vortex-duckdb/cpp/include/table_function.hpp
+++ b/vortex-duckdb/cpp/include/table_function.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "data.hpp"
 #include "duckdb.h"
 #include "duckdb/function/function.hpp"
 #include "duckdb/function/table_function.hpp"
@@ -30,3 +31,16 @@ struct TableFunctionUngroupedAggregateInput {
 };
 
 bool aggregate_pushdown(ClientContext &context, const TableFunctionUngroupedAggregateInput &input);
+
+// Vortex "row group" is a file
+struct VortexRowGroup final : PartitionRowGroup {
+    explicit VortexRowGroup(unique_ptr<CData> ffi_footer) : ffi_footer(std::move(ffi_footer)) {
+    }
+
+    unique_ptr<CData> ffi_footer;
+
+    unique_ptr<BaseStatistics> GetColumnStatistics(const StorageIndex &storage_index) override;
+    bool MinMaxIsExact(const BaseStatistics &, const StorageIndex &) override {
+        return true;
+    }
+};

--- a/vortex-duckdb/cpp/multi_file_reader.cpp
+++ b/vortex-duckdb/cpp/multi_file_reader.cpp
@@ -344,17 +344,7 @@ static unique_ptr<BaseStatistics> base_stats(duckdb_column_statistics &stats, Lo
     return out.ToUnique();
 }
 
-unique_ptr<BaseStatistics> VortexBaseReader::GetStatistics(ClientContext &, const string &name) {
-    D_ASSERT(ffi_bind);
-    duckdb_column_statistics statistics = {};
-    if (!duckdb_reader_get_statistics(ffi_file->DataPtr(),
-                                      ffi_bind,
-                                      name.c_str(),
-                                      name.size(),
-                                      &statistics)) {
-        return {};
-    }
-
+unique_ptr<BaseStatistics> to_duckdb_statistics(duckdb_column_statistics &statistics) {
     using enum LogicalTypeId;
     const unique_ptr<LogicalType> type(reinterpret_cast<LogicalType *>(statistics.type));
     switch (type->id()) {
@@ -370,7 +360,15 @@ unique_ptr<BaseStatistics> VortexBaseReader::GetStatistics(ClientContext &, cons
     case UINTEGER:
     case UBIGINT:
     case UHUGEINT:
-    case HUGEINT: {
+    case HUGEINT:
+    case DATE:
+    case TIME:
+    case TIME_TZ:
+    case TIMESTAMP_SEC:
+    case TIMESTAMP_MS:
+    case TIMESTAMP:
+    case TIMESTAMP_NS:
+    case TIMESTAMP_TZ: {
         return numeric_stats(statistics, *type);
     }
     case VARCHAR:
@@ -393,6 +391,20 @@ unique_ptr<BaseStatistics> VortexBaseReader::GetStatistics(ClientContext &, cons
     default:
         return base_stats(statistics, *type);
     }
+}
+
+unique_ptr<BaseStatistics> VortexBaseReader::GetStatistics(ClientContext &, const string &name) {
+    D_ASSERT(ffi_bind);
+    duckdb_column_statistics statistics = {};
+    if (!duckdb_reader_get_statistics(ffi_file->DataPtr(),
+                                      ffi_bind,
+                                      name.c_str(),
+                                      name.size(),
+                                      &statistics)) {
+        return {};
+    }
+
+    return to_duckdb_statistics(statistics);
 }
 
 double VortexBaseReader::GetProgressInFile(ClientContext &) {

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -145,9 +145,14 @@ unique_ptr<BaseStatistics> VortexRowGroup::GetColumnStatistics(const StorageInde
 static vector<PartitionStatistics> get_partition_stats(ClientContext &, GetPartitionStatsInput &input) {
     const MultiFileBindData &bind_data = input.bind_data->Cast<MultiFileBindData>();
     VortexBindData &bind = bind_data.bind_data->Cast<VortexBindData>();
+    // Re-reading the footers on every request is costly so me mimic DuckDB's
+    // TryLoadCaches for Parquet and load them once per file.
     if (bind.no_footer_caches) {
         return {};
     }
+    // get_partition_stats is called during plan phase where we haven't read
+    // data yet. If there's a filter, we need to read the data to evaluate
+    // stats
     if (duckdb_table_function_has_pushed_filters(bind.ffi_bind_data->DataPtr())) {
         return {};
     }

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -145,7 +145,7 @@ unique_ptr<BaseStatistics> VortexRowGroup::GetColumnStatistics(const StorageInde
 static vector<PartitionStatistics> get_partition_stats(ClientContext &, GetPartitionStatsInput &input) {
     const MultiFileBindData &bind_data = input.bind_data->Cast<MultiFileBindData>();
     VortexBindData &bind = bind_data.bind_data->Cast<VortexBindData>();
-    if (bind.attempted_to_load_caches) {
+    if (bind.no_footer_caches) {
         return {};
     }
     if (duckdb_table_function_has_pushed_filters(bind.ffi_bind_data->DataPtr())) {
@@ -165,7 +165,7 @@ static vector<PartitionStatistics> get_partition_stats(ClientContext &, GetParti
             throw BinderException(IntoErrString(error));
         }
         if (!cdata) {
-            bind.attempted_to_load_caches = true;
+            bind.no_footer_caches = true;
             return {};
         }
 

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -145,32 +145,25 @@ unique_ptr<BaseStatistics> VortexRowGroup::GetColumnStatistics(const StorageInde
 static vector<PartitionStatistics> get_partition_stats(ClientContext &, GetPartitionStatsInput &input) {
     const MultiFileBindData &bind_data = input.bind_data->Cast<MultiFileBindData>();
     VortexBindData &bind = bind_data.bind_data->Cast<VortexBindData>();
-    // Re-reading the footers on every request is costly so me mimic DuckDB's
-    // TryLoadCaches for Parquet and load them once per file.
-    if (bind.no_footer_caches) {
-        return {};
-    }
-    // get_partition_stats is called during plan phase where we haven't read
-    // data yet. If there's a filter, we need to read the data to evaluate
-    // stats
-    if (duckdb_table_function_has_pushed_filters(bind.ffi_bind_data->DataPtr())) {
+    void *const ffi_bind = bind.ffi_bind_data->DataPtr();
+
+    if (!duckdb_table_function_can_get_partition_stats(ffi_bind)) {
         return {};
     }
 
     vector<OpenFileInfo> files = bind_data.file_list->GetAllFiles();
     vector<PartitionStatistics> result(files.size());
     idx_t row_start = 0;
+    uint64_t count = 0;
+    duckdb_vx_error error = nullptr;
     for (size_t i = 0; i < files.size(); ++i) {
         const std::string_view path = files[i].path;
-        duckdb_vx_error error = nullptr;
-        uint64_t count = 0;
-        duckdb_vx_data raw = duckdb_footer_open(path.data(), path.size(), &count, &error);
+        duckdb_vx_data raw = duckdb_footer_get_cached(ffi_bind, path.data(), path.size(), &count, &error);
         unique_ptr<CData> cdata(reinterpret_cast<CData *>(raw));
         if (error) {
             throw BinderException(IntoErrString(error));
         }
         if (!cdata) {
-            bind.no_footer_caches = true;
             return {};
         }
 

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -17,8 +17,10 @@
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/main/connection.hpp"
+#include "duckdb/function/partition_stats.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/storage/storage_index.hpp"
 
 using namespace std::string_literals;
 constexpr column_t COLUMN_IDENTIFIER_FILE_INDEX = MultiFileReader::COLUMN_IDENTIFIER_FILE_INDEX;
@@ -130,6 +132,53 @@ unique_ptr<MultiFileReader> get_multi_file_reader(const TableFunction &) {
     return make_uniq<VortexMultiFileReader>();
 }
 
+unique_ptr<BaseStatistics> VortexRowGroup::GetColumnStatistics(const StorageIndex &storage_index) {
+    duckdb_column_statistics statistics = {};
+    const idx_t idx = storage_index.GetPrimaryIndex();
+    const void *const ffi_footer_ptr = ffi_footer->DataPtr();
+    if (!duckdb_footer_get_statistics(ffi_footer_ptr, idx, &statistics)) {
+        return {};
+    }
+    return to_duckdb_statistics(statistics);
+}
+
+static vector<PartitionStatistics> get_partition_stats(ClientContext &, GetPartitionStatsInput &input) {
+    const MultiFileBindData &bind_data = input.bind_data->Cast<MultiFileBindData>();
+    VortexBindData &bind = bind_data.bind_data->Cast<VortexBindData>();
+    if (bind.attempted_to_load_caches) {
+        return {};
+    }
+    if (duckdb_table_function_has_pushed_filters(bind.ffi_bind_data->DataPtr())) {
+        return {};
+    }
+
+    vector<OpenFileInfo> files = bind_data.file_list->GetAllFiles();
+    vector<PartitionStatistics> result(files.size());
+    idx_t row_start = 0;
+    for (size_t i = 0; i < files.size(); ++i) {
+        const std::string_view path = files[i].path;
+        duckdb_vx_error error = nullptr;
+        uint64_t count = 0;
+        duckdb_vx_data raw = duckdb_footer_open(path.data(), path.size(), &count, &error);
+        unique_ptr<CData> cdata(reinterpret_cast<CData *>(raw));
+        if (error) {
+            throw BinderException(IntoErrString(error));
+        }
+        if (!cdata) {
+            bind.attempted_to_load_caches = true;
+            return {};
+        }
+
+        PartitionStatistics &stats = result[i];
+        stats.row_start = row_start;
+        stats.count = count;
+        stats.count_type = CountType::COUNT_EXACT;
+        row_start += count;
+        stats.partition_row_group = make_shared_ptr<VortexRowGroup>(std::move(cdata));
+    }
+    return result;
+}
+
 duckdb_state register_table_function(DatabaseInstance &db, LogicalType parameter, const std::string &name) {
     MultiFileFunction<VortexReaderInterface> fn(name);
     fn.arguments[0] = parameter;
@@ -156,6 +205,7 @@ duckdb_state register_table_function(DatabaseInstance &db, LogicalType parameter
     };
 
     fn.statistics = MultiFileFunction<VortexReaderInterface>::MultiFileScanStats;
+    fn.get_partition_stats = get_partition_stats;
     fn.get_multi_file_reader = get_multi_file_reader;
 
     try {

--- a/vortex-duckdb/include/vortex.h
+++ b/vortex-duckdb/include/vortex.h
@@ -65,6 +65,19 @@ bool duckdb_reader_get_statistics(const void *file,
                                   size_t column_name_len,
                                   duckdb_column_statistics *stats_out);
 
+extern bool duckdb_table_function_has_pushed_filters(const void *bind);
+
+extern
+duckdb_vx_data duckdb_footer_open(const char *path,
+                                  size_t len,
+                                  uint64_t *row_count_out,
+                                  duckdb_vx_error *error);
+
+extern
+bool duckdb_footer_get_statistics(const void *footer,
+                                  size_t column_index,
+                                  duckdb_column_statistics *stats_out);
+
 extern bool duckdb_reader_initialize(const void *global, void *file, duckdb_vx_error *error);
 
 extern duckdb_logical_type duckdb_reader_bind_column_type(const void *bind, size_t index);

--- a/vortex-duckdb/include/vortex.h
+++ b/vortex-duckdb/include/vortex.h
@@ -65,13 +65,14 @@ bool duckdb_reader_get_statistics(const void *file,
                                   size_t column_name_len,
                                   duckdb_column_statistics *stats_out);
 
-extern bool duckdb_table_function_has_pushed_filters(const void *bind);
+extern bool duckdb_table_function_can_get_partition_stats(const void *bind);
 
 extern
-duckdb_vx_data duckdb_footer_open(const char *path,
-                                  size_t len,
-                                  uint64_t *row_count_out,
-                                  duckdb_vx_error *error);
+duckdb_vx_data duckdb_footer_get_cached(void *bind,
+                                        const char *path,
+                                        size_t len,
+                                        uint64_t *row_count_out,
+                                        duckdb_vx_error *error);
 
 extern
 bool duckdb_footer_get_statistics(const void *footer,

--- a/vortex-duckdb/src/ffi.rs
+++ b/vortex-duckdb/src/ffi.rs
@@ -34,8 +34,9 @@ use crate::duckdb::TableInitInput;
 use crate::duckdb::try_or;
 use crate::duckdb::try_or_null;
 use crate::file_reader::OpenFileReader;
+use crate::file_reader::can_get_partition_stats;
+use crate::file_reader::footer_get_cached;
 use crate::file_reader::footer_get_statistics;
-use crate::file_reader::footer_open;
 use crate::file_reader::reader_bind;
 use crate::file_reader::reader_get_progress_in_file;
 use crate::file_reader::reader_get_statistics;
@@ -221,24 +222,26 @@ pub unsafe extern "C-unwind" fn duckdb_reader_get_statistics(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn duckdb_table_function_has_pushed_filters(
+pub unsafe extern "C-unwind" fn duckdb_table_function_can_get_partition_stats(
     bind: *const c_void,
 ) -> bool {
     let bind = unsafe { bind.cast::<BindState>().as_ref() }.vortex_expect("null pointer");
-    !bind.filters.is_empty()
+    can_get_partition_stats(bind)
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn duckdb_footer_open(
+pub unsafe extern "C-unwind" fn duckdb_footer_get_cached(
+    bind: *mut c_void,
     path: *const c_char,
     len: usize,
     row_count_out: *mut u64,
     error: *mut cpp::duckdb_vx_error,
 ) -> cpp::duckdb_vx_data {
+    let bind = unsafe { bind.cast::<BindState>().as_mut() }.vortex_expect("null pointer");
     let path = unsafe { std::slice::from_raw_parts(path.cast::<u8>(), len) };
     try_or_null(error, || {
         let path = str::from_utf8(path).map_err(|_| vortex_err!("invalid utf-8"))?;
-        Ok(match footer_open(path)? {
+        Ok(match footer_get_cached(bind, path)? {
             Some(footer) => {
                 unsafe { *row_count_out = footer.row_count() };
                 Data::from(Box::new(footer)).as_ptr()

--- a/vortex-duckdb/src/ffi.rs
+++ b/vortex-duckdb/src/ffi.rs
@@ -9,6 +9,7 @@ use std::ptr;
 use num_traits::AsPrimitive;
 use vortex::error::VortexExpect;
 use vortex::error::vortex_err;
+use vortex::file::Footer;
 
 use crate::convert::can_push_expression;
 use crate::copy::CopyFunctionBind;
@@ -33,6 +34,8 @@ use crate::duckdb::TableInitInput;
 use crate::duckdb::try_or;
 use crate::duckdb::try_or_null;
 use crate::file_reader::OpenFileReader;
+use crate::file_reader::footer_get_statistics;
+use crate::file_reader::footer_open;
 use crate::file_reader::reader_bind;
 use crate::file_reader::reader_get_progress_in_file;
 use crate::file_reader::reader_get_statistics;
@@ -206,6 +209,53 @@ pub unsafe extern "C-unwind" fn duckdb_reader_get_statistics(
     let name = String::from_utf8_lossy(name_bytes);
 
     let Some(stats) = reader_get_statistics(file, bind, &name) else {
+        return false;
+    };
+    let stats_out = unsafe { &mut *stats_out };
+    stats_out.min = stats.min.map_or(ptr::null_mut(), |v| v.into_ptr());
+    stats_out.max = stats.max.map_or(ptr::null_mut(), |v| v.into_ptr());
+    stats_out.max_string_length = stats.max_string_length;
+    stats_out.has_null = stats.has_null;
+    stats_out.type_ = stats.logical_type.into_ptr();
+    true
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn duckdb_table_function_has_pushed_filters(
+    bind: *const c_void,
+) -> bool {
+    let bind = unsafe { bind.cast::<BindState>().as_ref() }.vortex_expect("null pointer");
+    !bind.filters.is_empty()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn duckdb_footer_open(
+    path: *const c_char,
+    len: usize,
+    row_count_out: *mut u64,
+    error: *mut cpp::duckdb_vx_error,
+) -> cpp::duckdb_vx_data {
+    let path = unsafe { std::slice::from_raw_parts(path.cast::<u8>(), len) };
+    try_or_null(error, || {
+        let path = str::from_utf8(path).map_err(|_| vortex_err!("invalid utf-8"))?;
+        Ok(match footer_open(path)? {
+            Some(footer) => {
+                unsafe { *row_count_out = footer.row_count() };
+                Data::from(Box::new(footer)).as_ptr()
+            }
+            None => ptr::null_mut(),
+        })
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn duckdb_footer_get_statistics(
+    footer: *const c_void,
+    column_index: usize,
+    stats_out: *mut cpp::duckdb_column_statistics,
+) -> bool {
+    let footer = unsafe { footer.cast::<Footer>().as_ref() }.vortex_expect("null pointer");
+    let Some(stats) = footer_get_statistics(footer, column_index) else {
         return false;
     };
     let stats_out = unsafe { &mut *stats_out };

--- a/vortex-duckdb/src/file_reader.rs
+++ b/vortex-duckdb/src/file_reader.rs
@@ -66,7 +66,7 @@ use crate::table_function::convert_result;
 // After this, still in planning phase, one thread calls the following chain on
 // all files to try and replace scanning with metadata answer:
 //
-// `footer_open` -> `footer_get_statistics`.
+// `can_get_partition_stats` -> `footer_open` -> `footer_get_statistics`.
 //
 // Then there's query runtime phase, called for all files in scan:
 //
@@ -167,6 +167,7 @@ pub fn reader_bind(file: &OpenFileReader, result: &mut BindResultRef) -> VortexR
         columns,
         has_non_optional_filter: AtomicBool::new(false),
         aggregates: vec![],
+        no_footer_caches: false,
     })
 }
 
@@ -310,12 +311,27 @@ pub fn reader_get_progress_in_file(file: &OpenFileReader) -> f64 {
     100.0 * (total - left) as f64 / denom as f64
 }
 
-/// Called by one thread for every file to get metadata
-pub fn footer_open(path: &str) -> VortexResult<Option<Footer>> {
+/// Called by one thread in planning phase
+pub fn can_get_partition_stats(bind: &BindState) -> bool {
+    // Re-reading footers on every request is costly so me mimic DuckDB's
+    // TryLoadCaches for Parquet and load them once per file
+    !bind.no_footer_caches
+    // This function is called during planning where we haven't read data yet.
+    // If there's a filter, we need to read the data to evaluate stats
+        && bind.filters.is_empty()
+}
+
+/// Called by one thread for every file. When we open files, we cache footers
+/// in MultiFileSession so this function retrieves the cached data if present.
+/// If any footer is not present, it sets a flag in BindState so we won't try
+/// again.
+pub fn footer_get_cached(bind: &mut BindState, path: &str) -> VortexResult<Option<Footer>> {
     let url = parse_uri_or_path(path)?;
     let path = resolve_path(&url)?;
     let key = object_path_from_literal(&path).to_string();
-    Ok(SESSION.get::<MultiFileSession>().get_footer(&key))
+    let footer = SESSION.get::<MultiFileSession>().get_footer(&key);
+    bind.no_footer_caches |= footer.is_none();
+    Ok(footer)
 }
 
 /// Called by one thread for every footer in planning phase

--- a/vortex-duckdb/src/file_reader.rs
+++ b/vortex-duckdb/src/file_reader.rs
@@ -279,20 +279,17 @@ pub fn reader_get_statistics(
         return None;
     }
 
-    let DType::Struct(fields, _) = &file.reader.dtype() else {
-        return None;
-    };
-    let index = fields.find(column)?;
-
     let reader = file
         .reader
         .as_any()
         .downcast_ref::<FileStatsLayoutReader>()?;
-    let stats_sets = reader.file_stats().stats_sets();
 
     let DType::Struct(fields, _) = &file.reader.dtype() else {
         return None;
     };
+    let index = fields.find(column)?;
+    let stats_sets = reader.file_stats().stats_sets();
+
     let dtype = fields.field_by_index(index)?;
 
     let stats = ColumnStatisticsAggregate::new(stats_sets.get(index)?);

--- a/vortex-duckdb/src/file_reader.rs
+++ b/vortex-duckdb/src/file_reader.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::sync::Arc;
-use std::sync::LazyLock;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 
@@ -11,7 +10,6 @@ use object_store::registry::ObjectStoreRegistry;
 use url::Url;
 use vortex::array::VortexSessionExecute as _;
 use vortex::array::arrays::struct_::StructArrayExt as _;
-use vortex::cloud::Registry;
 use vortex::dtype::DType;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
@@ -31,6 +29,7 @@ use vortex::layout::scan::scan_builder::ScanBuilder;
 use vortex::mask::Mask;
 use vortex::session::SessionExt as _;
 
+use crate::REGISTRY;
 use crate::RUNTIME;
 use crate::SESSION;
 use crate::column_statistics::ColumnStatistics;
@@ -64,6 +63,11 @@ use crate::table_function::convert_result;
 //
 // `reader_open` -> `reader_bind` -> `reader_get_statistics`
 //
+// After this, still in planning phase, one thread calls the following chain on
+// all files to try and replace scanning with metadata answer:
+//
+// `footer_open` -> `footer_get_statistics`.
+//
 // Then there's query runtime phase, called for all files in scan:
 //
 // `reader_open` -> `reader_initialize` ->
@@ -71,8 +75,6 @@ use crate::table_function::convert_result;
 //
 // `reader_get_progress_in_file` is called during `reader_scan` calls from a
 // separate thread.
-
-static REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::new);
 
 fn resolve_filesystem(url: &Url) -> VortexResult<(FileSystemRef, String)> {
     // Compat makes us use tokio which is very bad for local reads on
@@ -95,7 +97,7 @@ fn resolve_filesystem(url: &Url) -> VortexResult<(FileSystemRef, String)> {
     ))
 }
 
-/// Same as resolve_filesystem, but doesn't create filesystem object
+/// Same as resolve_filesystem but doesn't create filesystem object
 fn resolve_path(url: &Url) -> VortexResult<String> {
     if url.scheme() == "file" {
         return Ok(url.path().to_string());
@@ -308,6 +310,7 @@ pub fn reader_get_progress_in_file(file: &OpenFileReader) -> f64 {
     100.0 * (total - left) as f64 / denom as f64
 }
 
+/// Called by one thread for every file to get metadata
 pub fn footer_open(path: &str) -> VortexResult<Option<Footer>> {
     let url = parse_uri_or_path(path)?;
     let path = resolve_path(&url)?;
@@ -315,6 +318,7 @@ pub fn footer_open(path: &str) -> VortexResult<Option<Footer>> {
     Ok(SESSION.get::<MultiFileSession>().get_footer(&key))
 }
 
+/// Called by one thread for every footer in planning phase
 pub fn footer_get_statistics(footer: &Footer, index: usize) -> Option<ColumnStatistics> {
     let DType::Struct(fields, _) = footer.dtype() else {
         return None;

--- a/vortex-duckdb/src/file_reader.rs
+++ b/vortex-duckdb/src/file_reader.rs
@@ -313,11 +313,13 @@ pub fn reader_get_progress_in_file(file: &OpenFileReader) -> f64 {
 
 /// Called by one thread in planning phase
 pub fn can_get_partition_stats(bind: &BindState) -> bool {
-    // Re-reading footers on every request is costly so me mimic DuckDB's
+    // Re-reading footers on every request is costly so we mimic DuckDB's
     // TryLoadCaches for Parquet and load them once per file
     !bind.no_footer_caches
     // This function is called during planning where we haven't read data yet.
-    // If there's a filter, we need to read the data to evaluate stats
+    // If there's a filter, we need to read the data to evaluate stats.
+    // Even if we could do this fast, we report some filters here as not pushed
+    // (see table_function.rs) and stats would be incorrect.
         && bind.filters.is_empty()
 }
 

--- a/vortex-duckdb/src/file_reader.rs
+++ b/vortex-duckdb/src/file_reader.rs
@@ -16,16 +16,20 @@ use vortex::dtype::DType;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_panic;
+use vortex::file::Footer;
+use vortex::file::multi::MultiFileSession;
 use vortex::file::multi::open_cached;
 use vortex::file::multi::parse_uri_or_path;
 use vortex::file::v2::FileStatsLayoutReader;
 use vortex::io::compat::Compat;
 use vortex::io::filesystem::FileSystemRef;
 use vortex::io::object_store::ObjectStoreFileSystem;
+use vortex::io::object_store::object_path_from_literal;
 use vortex::io::runtime::BlockingRuntime as _;
 use vortex::layout::LayoutReaderRef;
 use vortex::layout::scan::scan_builder::ScanBuilder;
 use vortex::mask::Mask;
+use vortex::session::SessionExt as _;
 
 use crate::RUNTIME;
 use crate::SESSION;
@@ -89,6 +93,14 @@ fn resolve_filesystem(url: &Url) -> VortexResult<(FileSystemRef, String)> {
         )),
         path.to_string(),
     ))
+}
+
+/// Same as resolve_filesystem, but doesn't create filesystem object
+fn resolve_path(url: &Url) -> VortexResult<String> {
+    if url.scheme() == "file" {
+        return Ok(url.path().to_string());
+    }
+    Ok(REGISTRY.resolve(url)?.1.to_string())
 }
 
 pub struct OpenFileReader {
@@ -267,6 +279,11 @@ pub fn reader_get_statistics(
         return None;
     }
 
+    let DType::Struct(fields, _) = &file.reader.dtype() else {
+        return None;
+    };
+    let index = fields.find(column)?;
+
     let reader = file
         .reader
         .as_any()
@@ -276,7 +293,6 @@ pub fn reader_get_statistics(
     let DType::Struct(fields, _) = &file.reader.dtype() else {
         return None;
     };
-    let index = fields.find(column)?;
     let dtype = fields.field_by_index(index)?;
 
     let stats = ColumnStatisticsAggregate::new(stats_sets.get(index)?);
@@ -293,4 +309,25 @@ pub fn reader_get_progress_in_file(file: &OpenFileReader) -> f64 {
     let left = file.splits.len();
     let denom = total + (total == 0) as usize;
     100.0 * (total - left) as f64 / denom as f64
+}
+
+pub fn footer_open(path: &str) -> VortexResult<Option<Footer>> {
+    let url = parse_uri_or_path(path)?;
+    let path = resolve_path(&url)?;
+    let key = object_path_from_literal(&path).to_string();
+    Ok(SESSION.get::<MultiFileSession>().get_footer(&key))
+}
+
+pub fn footer_get_statistics(footer: &Footer, index: usize) -> Option<ColumnStatistics> {
+    let DType::Struct(fields, _) = footer.dtype() else {
+        return None;
+    };
+    let stats = footer.statistics()?;
+    let dtype = fields.field_by_index(index)?;
+    let stats = stats.stats_sets().get(index)?;
+    let stats = ColumnStatisticsAggregate::new(stats);
+    match ColumnStatistics::try_from(&stats, dtype) {
+        Ok(stats) => Some(stats),
+        Err(e) => vortex_panic!(e),
+    }
 }

--- a/vortex-duckdb/src/table_function.rs
+++ b/vortex-duckdb/src/table_function.rs
@@ -89,6 +89,8 @@ pub(crate) struct BindState {
     pub has_non_optional_filter: AtomicBool,
     // Non-empty iff this scan is aggregate
     pub aggregates: Vec<ColumnAggregate>,
+    // Any of files present in scan lack a footer
+    pub no_footer_caches: bool,
 }
 assert_impl_all!(BindState: Send, Clone);
 
@@ -103,6 +105,7 @@ impl Clone for BindState {
                 self.has_non_optional_filter.load(Ordering::Relaxed),
             ),
             aggregates: self.aggregates.clone(),
+            no_footer_caches: false,
         }
     }
 }

--- a/vortex-file/src/multi/session.rs
+++ b/vortex-file/src/multi/session.rs
@@ -55,7 +55,7 @@ impl Debug for MultiFileSession {
 
 impl MultiFileSession {
     /// Retrieve a cached footer for the given file path.
-    pub(crate) fn get_footer(&self, path: &str) -> Option<Footer> {
+    pub fn get_footer(&self, path: &str) -> Option<Footer> {
         self.footer_cache.get(path)
     }
 

--- a/vortex-sqllogictest/slt/duckdb/agg_partition_stats.slt
+++ b/vortex-sqllogictest/slt/duckdb/agg_partition_stats.slt
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+include ../setup.slt.no
+
+statement ok
+COPY (
+    WITH cte AS (
+        SELECT generate_series AS i FROM generate_series(100000))
+    SELECT (CASE WHEN i > 0 THEN i::INTEGER ELSE NULL END) AS i FROM cte
+)
+TO '${WORK_DIR}/agg-ps.vortex';
+
+query TT
+EXPLAIN SELECT count(*) FROM '${WORK_DIR}/agg-ps.vortex';
+----
+<REGEX>:.*COLUMN_DATA_SCAN.*
+
+query TT
+EXPLAIN SELECT count(*) FROM '${WORK_DIR}/agg-ps.vortex';
+----
+<!REGEX>:.*(READ_VORTEX|AGGREGATE).*
+
+query I
+SELECT count(*) FROM '${WORK_DIR}/agg-ps.vortex';
+----
+100001
+
+query TT
+EXPLAIN SELECT min(i), max(i) FROM '${WORK_DIR}/agg-ps.vortex';
+----
+<REGEX>:.*COLUMN_DATA_SCAN.*
+
+query TT
+EXPLAIN SELECT min(i), max(i) FROM '${WORK_DIR}/agg-ps.vortex';
+----
+<!REGEX>:.*(READ_VORTEX|AGGREGATE).*
+
+query II
+SELECT min(i), max(i) FROM '${WORK_DIR}/agg-ps.vortex';
+----
+1 100000
+
+query III
+SELECT count(*), min(i), max(i) FROM '${WORK_DIR}/agg-ps.vortex';
+----
+100001 1 100000
+
+statement ok
+COPY (
+    SELECT DATE '2013-07-01' + ((i % 30)::INTEGER) AS d
+    FROM generate_series(1, 5000) t(i))
+TO '${WORK_DIR}/agg-ps-date.vortex';
+
+query TT
+EXPLAIN SELECT min(d), max(d) FROM '${WORK_DIR}/agg-ps-date.vortex';
+----
+<REGEX>:.*COLUMN_DATA_SCAN.*
+
+query DD
+SELECT min(d), max(d) FROM '${WORK_DIR}/agg-ps-date.vortex';
+----
+2013-07-01 2013-07-30
+
+query TT
+EXPLAIN SELECT count(*) FROM '${WORK_DIR}/agg-ps.vortex'
+WHERE i > 50000;
+----
+<REGEX>:.*READ_VORTEX.*
+
+query I
+SELECT count(*) FROM '${WORK_DIR}/agg-ps.vortex'
+WHERE i > 50000;
+----
+50000
+
+statement ok
+COPY (SELECT * FROM (VALUES (1::INTEGER), (2), (3)) t(i))
+TO '${WORK_DIR}/agg-ps-1.vortex';
+
+statement ok
+COPY (SELECT * FROM (VALUES (4::INTEGER), (5), (6)) t(i))
+TO '${WORK_DIR}/agg-ps-2.vortex';
+
+query I
+SELECT count(*) FROM '${WORK_DIR}/agg-ps-*.vortex';
+----
+6
+
+query TT
+EXPLAIN SELECT count(*) FROM '${WORK_DIR}/agg-ps-*.vortex';
+----
+<REGEX>:.*COLUMN_DATA_SCAN.*
+
+query TT
+EXPLAIN SELECT count(*) FROM '${WORK_DIR}/agg-ps-*.vortex';
+----
+<!REGEX>:.*(READ_VORTEX|AGGREGATE).*
+
+query III
+SELECT count(*), min(i), max(i) FROM '${WORK_DIR}/agg-ps-*.vortex';
+----
+6 1 6

--- a/vortex-sqllogictest/slt/duckdb/agg_partition_stats.slt
+++ b/vortex-sqllogictest/slt/duckdb/agg_partition_stats.slt
@@ -9,40 +9,46 @@ COPY (
         SELECT generate_series AS i FROM generate_series(100000))
     SELECT (CASE WHEN i > 0 THEN i::INTEGER ELSE NULL END) AS i FROM cte
 )
-TO '${WORK_DIR}/agg-ps.vortex';
+TO '${WORK_DIR}/agg_partition_stats.vortex';
 
 query TT
-EXPLAIN SELECT count(*) FROM '${WORK_DIR}/agg-ps.vortex';
+EXPLAIN SELECT count(*)
+FROM '${WORK_DIR}/agg_partition_stats.vortex';
 ----
 <REGEX>:.*COLUMN_DATA_SCAN.*
 
 query TT
-EXPLAIN SELECT count(*) FROM '${WORK_DIR}/agg-ps.vortex';
+EXPLAIN SELECT count(*)
+FROM '${WORK_DIR}/agg_partition_stats.vortex';
 ----
 <!REGEX>:.*(READ_VORTEX|AGGREGATE).*
 
 query I
-SELECT count(*) FROM '${WORK_DIR}/agg-ps.vortex';
+SELECT count(*)
+FROM '${WORK_DIR}/agg_partition_stats.vortex';
 ----
 100001
 
 query TT
-EXPLAIN SELECT min(i), max(i) FROM '${WORK_DIR}/agg-ps.vortex';
+EXPLAIN SELECT min(i), max(i)
+FROM '${WORK_DIR}/agg_partition_stats.vortex';
 ----
 <REGEX>:.*COLUMN_DATA_SCAN.*
 
 query TT
-EXPLAIN SELECT min(i), max(i) FROM '${WORK_DIR}/agg-ps.vortex';
+EXPLAIN SELECT min(i), max(i)
+FROM '${WORK_DIR}/agg_partition_stats.vortex';
 ----
 <!REGEX>:.*(READ_VORTEX|AGGREGATE).*
 
 query II
-SELECT min(i), max(i) FROM '${WORK_DIR}/agg-ps.vortex';
+SELECT min(i), max(i) FROM '${WORK_DIR}/agg_partition_stats.vortex';
 ----
 1 100000
 
 query III
-SELECT count(*), min(i), max(i) FROM '${WORK_DIR}/agg-ps.vortex';
+SELECT count(*), min(i), max(i)
+FROM '${WORK_DIR}/agg_partition_stats.vortex';
 ----
 100001 1 100000
 
@@ -50,54 +56,27 @@ statement ok
 COPY (
     SELECT DATE '2013-07-01' + ((i % 30)::INTEGER) AS d
     FROM generate_series(1, 5000) t(i))
-TO '${WORK_DIR}/agg-ps-date.vortex';
+TO '${WORK_DIR}/agg_partition_stats-date.vortex';
 
 query TT
-EXPLAIN SELECT min(d), max(d) FROM '${WORK_DIR}/agg-ps-date.vortex';
+EXPLAIN SELECT min(d), max(d)
+FROM '${WORK_DIR}/agg_partition_stats-date.vortex';
 ----
 <REGEX>:.*COLUMN_DATA_SCAN.*
 
 query DD
-SELECT min(d), max(d) FROM '${WORK_DIR}/agg-ps-date.vortex';
+SELECT min(d), max(d) FROM '${WORK_DIR}/agg_partition_stats-date.vortex';
 ----
 2013-07-01 2013-07-30
 
 query TT
-EXPLAIN SELECT count(*) FROM '${WORK_DIR}/agg-ps.vortex'
+EXPLAIN SELECT count(*) FROM '${WORK_DIR}/agg_partition_stats.vortex'
 WHERE i > 50000;
 ----
 <REGEX>:.*READ_VORTEX.*
 
 query I
-SELECT count(*) FROM '${WORK_DIR}/agg-ps.vortex'
+SELECT count(*) FROM '${WORK_DIR}/agg_partition_stats.vortex'
 WHERE i > 50000;
 ----
 50000
-
-statement ok
-COPY (SELECT * FROM (VALUES (1::INTEGER), (2), (3)) t(i))
-TO '${WORK_DIR}/agg-ps-1.vortex';
-
-statement ok
-COPY (SELECT * FROM (VALUES (4::INTEGER), (5), (6)) t(i))
-TO '${WORK_DIR}/agg-ps-2.vortex';
-
-query I
-SELECT count(*) FROM '${WORK_DIR}/agg-ps-*.vortex';
-----
-6
-
-query TT
-EXPLAIN SELECT count(*) FROM '${WORK_DIR}/agg-ps-*.vortex';
-----
-<REGEX>:.*COLUMN_DATA_SCAN.*
-
-query TT
-EXPLAIN SELECT count(*) FROM '${WORK_DIR}/agg-ps-*.vortex';
-----
-<!REGEX>:.*(READ_VORTEX|AGGREGATE).*
-
-query III
-SELECT count(*), min(i), max(i) FROM '${WORK_DIR}/agg-ps-*.vortex';
-----
-6 1 6

--- a/vortex-sqllogictest/slt/duckdb/agg_partition_stats_multi_file.slt
+++ b/vortex-sqllogictest/slt/duckdb/agg_partition_stats_multi_file.slt
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+include ../setup.slt.no
+
+statement ok
+COPY (SELECT * FROM (VALUES (1::INTEGER), (2), (3)) t(i))
+TO '${WORK_DIR}/agg_partition_stats_1.vortex';
+
+statement ok
+COPY (SELECT * FROM (VALUES (4::INTEGER), (5), (6)) t(i))
+TO '${WORK_DIR}/agg_partition_stats_2.vortex';
+
+query I
+SELECT count(*) FROM '${WORK_DIR}/agg_partition_stats_*.vortex';
+----
+6
+
+query TT
+EXPLAIN SELECT count(*) FROM '${WORK_DIR}/agg_partition_stats_*.vortex';
+----
+<REGEX>:.*COLUMN_DATA_SCAN.*
+
+query TT
+EXPLAIN SELECT count(*) FROM '${WORK_DIR}/agg_partition_stats_*.vortex';
+----
+<!REGEX>:.*(READ_VORTEX|AGGREGATE).*
+
+query III
+SELECT count(*), min(i), max(i)
+FROM '${WORK_DIR}/agg_partition_stats_*.vortex';
+----
+6 1 6

--- a/vortex-sqllogictest/slt/duckdb/aggregate_pushdown.slt
+++ b/vortex-sqllogictest/slt/duckdb/aggregate_pushdown.slt
@@ -4,6 +4,9 @@
 include ../setup.slt.no
 
 statement ok
+SET disabled_optimizers='statistics_propagation';
+
+statement ok
 COPY (
 WITH cte AS (SELECT generate_series AS i FROM generate_series(100000))
 SELECT (CASE WHEN i > 0 THEN i::INTEGER ELSE NULL END) AS i FROM cte

--- a/vortex-sqllogictest/slt/duckdb/nan_aggregates.slt
+++ b/vortex-sqllogictest/slt/duckdb/nan_aggregates.slt
@@ -7,6 +7,9 @@
 include ../setup.slt.no
 
 statement ok
+SET disabled_optimizers='statistics_propagation';
+
+statement ok
 COPY (
     SELECT * FROM (VALUES
         ('nan'::DOUBLE),


### PR DESCRIPTION
This couldn't be done previously since we didn't have ordering of files
for threads. Since migration to MultiFileReader, we now have well-defined
batch indices.

Propagate per-file partition stats to duckdb. MultiFileSession already caches
footers by file path, so we can use this information. This change makes
Clickbench Q0 and Q6 constant (supplied from metadata) from second iteration.

Use crate's REGISTRY instead of own one.

Resolves: #3393