### PR TITLE
perf: cache lowered stats rewrites in StatsSession

### DIFF
--- a/vortex-array/src/stats/rewrite.rs
+++ b/vortex-array/src/stats/rewrite.rs
@@ -17,6 +17,7 @@ use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTableExt;
 use crate::scalar_fn::fns::binary::Binary;
 use crate::scalar_fn::fns::operators::Operator;
+use crate::stats::session::StatsRewriteKind;
 use crate::stats::session::StatsSessionExt;
 
 mod builtins;
@@ -107,15 +108,39 @@ impl<'a> StatsRewriteCtx<'a> {
     }
 
     /// Rewrite `expr` into a stats-backed falsifier.
+    ///
+    /// Results are cached in the session, so readers that share the same bound expression share
+    /// one lowered falsifier.
     pub fn falsify(&self, expr: &BoundExpression) -> VortexResult<Option<BoundExpression>> {
-        self.ensure_predicate(expr)?;
-        rewrite(expr, self, StatsRewriteRule::falsify)
+        self.cached_rewrite(StatsRewriteKind::Falsify, expr, StatsRewriteRule::falsify)
     }
 
     /// Rewrite `expr` into a stats-backed satisfier.
+    ///
+    /// Results are cached in the session, so readers that share the same bound expression share
+    /// one lowered satisfier.
     pub fn satisfy(&self, expr: &BoundExpression) -> VortexResult<Option<BoundExpression>> {
+        self.cached_rewrite(StatsRewriteKind::Satisfy, expr, StatsRewriteRule::satisfy)
+    }
+
+    fn cached_rewrite(
+        &self,
+        kind: StatsRewriteKind,
+        expr: &BoundExpression,
+        apply: RewriteFn,
+    ) -> VortexResult<Option<BoundExpression>> {
         self.ensure_predicate(expr)?;
-        rewrite(expr, self, StatsRewriteRule::satisfy)
+
+        let stats = self.session.stats();
+        if let Some(cached) = stats.cached_rewrite(kind, expr) {
+            return Ok(cached);
+        }
+
+        // Rules recurse through this context, so the rewrite must run without holding the cache
+        // lock. Errors are not cached: they are rare and the caller decides how to report them.
+        let rewritten = rewrite(expr, self, apply)?;
+
+        Ok(stats.cache_rewrite(kind, expr, rewritten))
     }
 
     fn ensure_predicate(&self, expr: &BoundExpression) -> VortexResult<()> {
@@ -128,14 +153,16 @@ impl<'a> StatsRewriteCtx<'a> {
     }
 }
 
+type RewriteFn = fn(
+    &dyn StatsRewriteRule,
+    &BoundExpression,
+    &StatsRewriteCtx<'_>,
+) -> VortexResult<Option<BoundExpression>>;
+
 fn rewrite(
     expr: &BoundExpression,
     ctx: &StatsRewriteCtx<'_>,
-    apply: fn(
-        &dyn StatsRewriteRule,
-        &BoundExpression,
-        &StatsRewriteCtx<'_>,
-    ) -> VortexResult<Option<BoundExpression>>,
+    apply: RewriteFn,
 ) -> VortexResult<Option<BoundExpression>> {
     // The scope alone proves nothing about the rows it contains.
     let Some(scalar_fn) = expr.as_scalar() else {
@@ -160,6 +187,10 @@ fn rewrite(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
     use vortex_error::VortexResult;
 
     use super::StatsRewriteCtx;
@@ -168,6 +199,7 @@ mod tests {
     use crate::dtype::Nullability;
     use crate::dtype::PType;
     use crate::expr::BoundExpression;
+    use crate::expr::ExactBoundExpr;
     use crate::expr::lit;
     use crate::expr::or;
     use crate::scalar_fn::ScalarFnId;
@@ -200,6 +232,26 @@ mod tests {
             _ctx: &StatsRewriteCtx<'_>,
         ) -> VortexResult<Option<BoundExpression>> {
             Ok(self.satisfier.clone())
+        }
+    }
+
+    #[derive(Debug)]
+    struct CountingRule {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl StatsRewriteRule for CountingRule {
+        fn scalar_fn_id(&self) -> ScalarFnId {
+            Literal.id()
+        }
+
+        fn falsify(
+            &self,
+            expr: &BoundExpression,
+            _ctx: &StatsRewriteCtx<'_>,
+        ) -> VortexResult<Option<BoundExpression>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(lit(false).bind(expr.dtype())?))
         }
     }
 
@@ -251,6 +303,52 @@ mod tests {
         let expr = lit(true).bind(&dtype)?;
         assert_eq!(expr.falsify(&session)?, None);
         assert_eq!(expr.satisfy(&session)?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn readers_sharing_an_expression_share_the_cached_falsifier() -> VortexResult<()> {
+        let session = crate::array_session();
+        let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
+        let calls = Arc::new(AtomicUsize::new(0));
+        session.stats().register_rewrite(CountingRule {
+            calls: Arc::clone(&calls),
+        });
+
+        // Two readers in one scan hold clones of the same bound predicate.
+        let expr = lit(true).bind(&dtype)?;
+        let reader_a = expr.clone();
+        let first_reader = reader_a.falsify(&session)?;
+        let second_reader = expr.falsify(&session)?;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(first_reader.is_some());
+        assert_eq!(
+            first_reader.clone().map(ExactBoundExpr),
+            second_reader.map(ExactBoundExpr),
+        );
+
+        // A structurally equal predicate bound independently is a different tree and misses.
+        let rebound = lit(true).bind(&dtype)?;
+        assert_eq!(rebound.falsify(&session)?, first_reader);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn registering_a_rule_invalidates_cached_rewrites() -> VortexResult<()> {
+        let session = crate::array_session();
+        let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
+
+        let expr = lit(true).bind(&dtype)?;
+        assert_eq!(expr.falsify(&session)?, None);
+
+        session.stats().register_rewrite(StaticLiteralRule {
+            falsifier: Some(lit(false).bind(&dtype)?),
+            satisfier: None,
+        });
+
+        assert_eq!(expr.falsify(&session)?, Some(lit(false).bind(&dtype)?));
         Ok(())
     }
 

--- a/vortex-array/src/stats/session.rs
+++ b/vortex-array/src/stats/session.rs
@@ -12,6 +12,8 @@ use vortex_session::SessionGuard;
 use vortex_session::SessionVar;
 use vortex_utils::aliases::hash_map::HashMap;
 
+use crate::expr::BoundExpression;
+use crate::expr::ExactBoundExpr;
 use crate::scalar_fn::ScalarFnId;
 use crate::stats::rewrite::StatsRewriteRule;
 use crate::stats::rewrite::StatsRewriteRuleRef;
@@ -19,16 +21,41 @@ use crate::stats::rewrite::register_builtins;
 
 type StatsRewriteRuleSet = Arc<[StatsRewriteRuleRef]>;
 
+/// Upper bound on cached rewrites per kind before the cache is reset.
+///
+/// Keys are identity-based, so a long-lived session that binds many distinct predicates would
+/// otherwise grow without bound. A full reset is simpler than LRU bookkeeping and the cache is
+/// only an accelerator: a miss recomputes the rewrite.
+const REWRITE_CACHE_CAPACITY: usize = 4096;
+
+/// The kind of stats proof a rewrite produces.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum StatsRewriteKind {
+    /// A proof that the predicate is false for every row in scope.
+    Falsify,
+    /// A proof that the predicate is true for every row in scope.
+    Satisfy,
+}
+
+/// Session-scoped cache of lowered stats proofs.
+///
+/// Keys compare shared-tree identity rather than structure. Every entry holds a clone of the
+/// keyed expression, which keeps its allocation alive so the pointer cannot be reused by an
+/// unrelated expression while the entry exists.
+type StatsRewriteCache = HashMap<(StatsRewriteKind, ExactBoundExpr), Option<BoundExpression>>;
+
 /// Session state for stats APIs.
 #[derive(Clone, Debug)]
 pub struct StatsSession {
     rewrite_rules: Arc<RwLock<HashMap<ScalarFnId, StatsRewriteRuleSet>>>,
+    rewrite_cache: Arc<RwLock<StatsRewriteCache>>,
 }
 
 impl Default for StatsSession {
     fn default() -> Self {
         let this = Self {
             rewrite_rules: Arc::new(RwLock::new(HashMap::default())),
+            rewrite_cache: Arc::new(RwLock::new(HashMap::default())),
         };
         register_builtins(&this);
         this
@@ -42,6 +69,9 @@ impl StatsSession {
     }
 
     /// Register a shared stats rewrite rule.
+    ///
+    /// Registering a rule invalidates every cached rewrite, since a new rule can strengthen the
+    /// proof produced for expressions that were already lowered.
     pub fn register_rewrite_ref(&self, rule: StatsRewriteRuleRef) {
         let mut rules = self.rewrite_rules.write();
         let rule_id = rule.scalar_fn_id();
@@ -51,6 +81,45 @@ impl StatsSession {
             .unwrap_or_default();
         updated_rules.push(rule);
         rules.insert(rule_id, updated_rules.into());
+
+        self.rewrite_cache.write().clear();
+    }
+
+    /// Return the cached rewrite of `expr`, if one exists.
+    ///
+    /// `Some(None)` records that no rule could prove anything for `expr`, which is just as
+    /// valuable to remember as a successful proof.
+    pub(crate) fn cached_rewrite(
+        &self,
+        kind: StatsRewriteKind,
+        expr: &BoundExpression,
+    ) -> Option<Option<BoundExpression>> {
+        self.rewrite_cache
+            .read()
+            .get(&(kind, ExactBoundExpr(expr.clone())))
+            .cloned()
+    }
+
+    /// Cache the rewrite of `expr` and return the entry that is now shared by the session.
+    ///
+    /// If another thread cached the same expression first, its result wins so that every caller
+    /// observes one shared proof tree.
+    pub(crate) fn cache_rewrite(
+        &self,
+        kind: StatsRewriteKind,
+        expr: &BoundExpression,
+        rewrite: Option<BoundExpression>,
+    ) -> Option<BoundExpression> {
+        let mut cache = self.rewrite_cache.write();
+
+        if cache.len() >= REWRITE_CACHE_CAPACITY {
+            cache.clear();
+        }
+
+        cache
+            .entry((kind, ExactBoundExpr(expr.clone())))
+            .or_insert(rewrite)
+            .clone()
     }
 
     /// Return the rewrite rules registered for `scalar_fn_id`.

--- a/vortex-layout/src/layouts/zoned/pruning.rs
+++ b/vortex-layout/src/layouts/zoned/pruning.rs
@@ -38,7 +38,6 @@ use crate::layouts::zoned::zone_map::ZoneMap;
 type SharedZoneMap = Shared<BoxFuture<'static, SharedVortexResult<ZoneMap>>>;
 pub(super) type SharedPruningResult =
     Shared<BoxFuture<'static, SharedVortexResult<Arc<PruningResult>>>>;
-type PredicateCache = Arc<OnceLock<Option<BoundExpression>>>;
 
 pub(super) struct PruningState {
     zone_count: usize,
@@ -50,7 +49,6 @@ pub(super) struct PruningState {
     session: VortexSession,
     pruning_result: LazyLock<DashMap<ExactBoundExpr, Option<SharedPruningResult>>>,
     zone_map: OnceLock<SharedZoneMap>,
-    pruning_predicates: LazyLock<Arc<DashMap<ExactBoundExpr, PredicateCache>>>,
 }
 
 impl PruningState {
@@ -74,7 +72,6 @@ impl PruningState {
             session,
             pruning_result: Default::default(),
             zone_map: Default::default(),
-            pruning_predicates: Default::default(),
         }
     }
 
@@ -126,20 +123,19 @@ impl PruningState {
             .clone()
     }
 
+    /// Lower `expr` into a pruning predicate.
+    ///
+    /// The session caches lowered predicates, so every reader and zone that shares `expr` reuses
+    /// one falsifier. The per-expression `pruning_result` entry already keeps this reader from
+    /// asking twice.
     fn pruning_predicate(&self, expr: BoundExpression) -> Option<BoundExpression> {
-        let key = ExactBoundExpr(expr.clone());
-
-        self.pruning_predicates
-            .entry(key)
-            .or_default()
-            .get_or_init(move || match expr.falsify(&self.session) {
-                Ok(predicate) => predicate,
-                Err(error) => {
-                    trace!(%expr, %error, "failed to construct stats rewrite predicate");
-                    None
-                }
-            })
-            .clone()
+        match expr.falsify(&self.session) {
+            Ok(predicate) => predicate,
+            Err(error) => {
+                trace!(%expr, %error, "failed to construct stats rewrite predicate");
+                None
+            }
+        }
     }
 
     fn zone_map(&self) -> SharedZoneMap {


### PR DESCRIPTION
## Summary

Zoned readers lowered pruning predicates into falsifiers themselves and cached them per reader, while `StatsSession` held only the rewrite registry. Every reader and every zoned layout in a scan repeated the same lowering for the same predicate.

This PR adds a session-scoped cache of falsifiers and satisfiers to `StatsSession` and routes `StatsRewriteCtx::falsify` / `satisfy` through it. Rules recurse through the context, so shared subtrees are cached too. The zoned reader drops its private predicate cache and relies on the session.

## Design

- **Key identity:** `ExactBoundExpr` (shared-tree identity, same key the zoned reader already used). Scan readers hold clones of one bound predicate so identity hits across readers, and it avoids hashing deep trees with lazy dtypes. Each entry keeps a clone of its key alive, so a pointer cannot be reused by an unrelated expression while the entry exists.
- **Invalidation / lifetime:** session-scoped. `register_rewrite_ref` clears the cache since new rules can change the proof. A fixed entry cap (4096) resets the cache rather than LRU bookkeeping; a miss only recomputes.
- **Thread safety:** `parking_lot::RwLock<HashMap>`, matching the rule registry. Rewrites run outside the lock; the first writer wins so all callers see one shared proof tree. Errors are not cached.

## Tests

- `readers_sharing_an_expression_share_the_cached_falsifier`: two clones of one bound predicate trigger one rule invocation and receive an identity-equal falsifier; an independently bound copy is a miss.
- `registering_a_rule_invalidates_cached_rewrites`.

## Checks

- `cargo nextest run -p vortex-array -p vortex-layout -p vortex-file` — 3798 passed
- `cargo clippy -p vortex-array -p vortex-layout -p vortex-file --all-targets --all-features` — clean
- `cargo +nightly fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)