### PR TITLE
perf(vortex-layout): lower pruning predicates once

### DIFF
--- a/vortex-layout/benches/zone_map_prune.rs
+++ b/vortex-layout/benches/zone_map_prune.rs
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Microbenchmarks for [`ZoneMap::prune`].
+//! Microbenchmarks for zoned pruning.
 //!
-//! Each case pre-falsifies its predicate so the timed region covers exactly what `prune` does:
-//! lowering the stats placeholders against the zone map, then evaluating the result per zone.
+//! Each case pre-falsifies its predicate, then runs it two ways over the same zone map:
+//!
+//! - `prune`: lower the stats placeholders against the zone map, then evaluate per zone.
+//! - `prepared`: lower once up front, then time only the per-zone evaluation.
+//!
+//! The gap between the two groups is the repeated lowering cost that readers pay when they
+//! re-prune, such as when a dynamic predicate tightens.
 
 #![expect(clippy::unwrap_used)]
 
@@ -256,6 +261,7 @@ fn falsify(expr: Expression, column_dtype: &DType) -> BoundExpression {
         .unwrap()
 }
 
+/// Time `prune`, which lowers the predicate against the zone map on every call.
 fn run(bencher: Bencher, zone_map: ZoneMap, predicate: BoundExpression) {
     bencher.bench(|| {
         divan::black_box(
@@ -266,69 +272,130 @@ fn run(bencher: Bencher, zone_map: ZoneMap, predicate: BoundExpression) {
     });
 }
 
-/// Integer range predicate: binds to `max` only, no row count, no NaN guard.
-#[divan::bench(args = ZONE_COUNTS)]
-fn int_gt(bencher: Bencher, num_zones: usize) {
-    static PREDICATE: LazyLock<BoundExpression> =
-        LazyLock::new(|| falsify(gt(root(), lit(5_000i32)), &i32_dtype()));
-    run(
-        bencher,
-        numeric_zone_map(i32_dtype(), num_zones),
-        PREDICATE.clone(),
-    );
+/// Time evaluation alone, with the predicate lowered once outside the timed region.
+fn run_prepared(bencher: Bencher, zone_map: ZoneMap, predicate: BoundExpression) {
+    let prepared = zone_map.prepare(&predicate).unwrap();
+    bencher.bench(|| divan::black_box(prepared.evaluate(&SESSION).unwrap()));
 }
+
+/// Integer range predicate: binds to `max` only, no row count, no NaN guard.
+static INT_GT: LazyLock<BoundExpression> =
+    LazyLock::new(|| falsify(gt(root(), lit(5_000i32)), &i32_dtype()));
 
 /// Float range predicate: the NaN-guarded and unguarded rules both fire, and on a zone map that
 /// stores `nan_count` they lower to the same expression.
-#[divan::bench(args = ZONE_COUNTS)]
-fn float_gt(bencher: Bencher, num_zones: usize) {
-    static PREDICATE: LazyLock<BoundExpression> =
-        LazyLock::new(|| falsify(gt(root(), lit(5_000f64)), &f64_dtype()));
-    run(
-        bencher,
-        numeric_zone_map(f64_dtype(), num_zones),
-        PREDICATE.clone(),
-    );
-}
+static FLOAT_GT: LazyLock<BoundExpression> =
+    LazyLock::new(|| falsify(gt(root(), lit(5_000f64)), &f64_dtype()));
 
 /// Null predicate: lowers to `null_count == row_count`, exercising the row-count path.
-#[divan::bench(args = ZONE_COUNTS)]
-fn is_not_null_pred(bencher: Bencher, num_zones: usize) {
-    static PREDICATE: LazyLock<BoundExpression> =
-        LazyLock::new(|| falsify(is_not_null(root()), &i32_dtype()));
-    run(
-        bencher,
-        numeric_zone_map(i32_dtype(), num_zones),
-        PREDICATE.clone(),
-    );
-}
+static IS_NOT_NULL: LazyLock<BoundExpression> =
+    LazyLock::new(|| falsify(is_not_null(root()), &i32_dtype()));
 
 /// A 16-term `OR` chain, which is where lowering cost grows relative to evaluation cost.
-#[divan::bench(args = ZONE_COUNTS)]
-fn or_chain(bencher: Bencher, num_zones: usize) {
-    static PREDICATE: LazyLock<BoundExpression> = LazyLock::new(|| {
-        let expr = (0..16i32)
-            .map(|i| eq(root(), lit(i * 500)))
-            .reduce(or)
-            .unwrap();
-        falsify(expr, &i32_dtype())
-    });
-    run(
-        bencher,
-        numeric_zone_map(i32_dtype(), num_zones),
-        PREDICATE.clone(),
-    );
+static OR_CHAIN: LazyLock<BoundExpression> = LazyLock::new(|| {
+    let expr = (0..16i32)
+        .map(|i| eq(root(), lit(i * 500)))
+        .reduce(or)
+        .unwrap();
+    falsify(expr, &i32_dtype())
+});
+
+mod prune {
+    use super::*;
+
+    #[divan::bench(args = ZONE_COUNTS)]
+    fn int_gt(bencher: Bencher, num_zones: usize) {
+        run(
+            bencher,
+            numeric_zone_map(i32_dtype(), num_zones),
+            INT_GT.clone(),
+        );
+    }
+
+    #[divan::bench(args = ZONE_COUNTS)]
+    fn float_gt(bencher: Bencher, num_zones: usize) {
+        run(
+            bencher,
+            numeric_zone_map(f64_dtype(), num_zones),
+            FLOAT_GT.clone(),
+        );
+    }
+
+    #[divan::bench(args = ZONE_COUNTS)]
+    fn is_not_null_pred(bencher: Bencher, num_zones: usize) {
+        run(
+            bencher,
+            numeric_zone_map(i32_dtype(), num_zones),
+            IS_NOT_NULL.clone(),
+        );
+    }
+
+    #[divan::bench(args = ZONE_COUNTS)]
+    fn or_chain(bencher: Bencher, num_zones: usize) {
+        run(
+            bencher,
+            numeric_zone_map(i32_dtype(), num_zones),
+            OR_CHAIN.clone(),
+        );
+    }
+
+    /// The zone map lacks min/max, so every proof binds to a null literal and the lowered
+    /// predicate is constant.
+    #[divan::bench(args = ZONE_COUNTS)]
+    fn missing_stats(bencher: Bencher, num_zones: usize) {
+        run(
+            bencher,
+            counts_only_zone_map(i32_dtype(), num_zones),
+            INT_GT.clone(),
+        );
+    }
 }
 
-/// The zone map lacks min/max, so every proof binds to a null literal and the lowered predicate is
-/// constant.
-#[divan::bench(args = ZONE_COUNTS)]
-fn missing_stats(bencher: Bencher, num_zones: usize) {
-    static PREDICATE: LazyLock<BoundExpression> =
-        LazyLock::new(|| falsify(gt(root(), lit(5_000i32)), &i32_dtype()));
-    run(
-        bencher,
-        counts_only_zone_map(i32_dtype(), num_zones),
-        PREDICATE.clone(),
-    );
+mod prepared {
+    use super::*;
+
+    #[divan::bench(args = ZONE_COUNTS)]
+    fn int_gt(bencher: Bencher, num_zones: usize) {
+        run_prepared(
+            bencher,
+            numeric_zone_map(i32_dtype(), num_zones),
+            INT_GT.clone(),
+        );
+    }
+
+    #[divan::bench(args = ZONE_COUNTS)]
+    fn float_gt(bencher: Bencher, num_zones: usize) {
+        run_prepared(
+            bencher,
+            numeric_zone_map(f64_dtype(), num_zones),
+            FLOAT_GT.clone(),
+        );
+    }
+
+    #[divan::bench(args = ZONE_COUNTS)]
+    fn is_not_null_pred(bencher: Bencher, num_zones: usize) {
+        run_prepared(
+            bencher,
+            numeric_zone_map(i32_dtype(), num_zones),
+            IS_NOT_NULL.clone(),
+        );
+    }
+
+    #[divan::bench(args = ZONE_COUNTS)]
+    fn or_chain(bencher: Bencher, num_zones: usize) {
+        run_prepared(
+            bencher,
+            numeric_zone_map(i32_dtype(), num_zones),
+            OR_CHAIN.clone(),
+        );
+    }
+
+    #[divan::bench(args = ZONE_COUNTS)]
+    fn missing_stats(bencher: Bencher, num_zones: usize) {
+        run_prepared(
+            bencher,
+            counts_only_zone_map(i32_dtype(), num_zones),
+            INT_GT.clone(),
+        );
+    }
 }

--- a/vortex-layout/src/layouts/zoned/pruning.rs
+++ b/vortex-layout/src/layouts/zoned/pruning.rs
@@ -33,6 +33,7 @@ use crate::Layout;
 use crate::LazyReaderChildren;
 use crate::VTable;
 use crate::layouts::zoned::ZonedData;
+use crate::layouts::zoned::zone_map::PreparedPruning;
 use crate::layouts::zoned::zone_map::ZoneMap;
 
 type SharedZoneMap = Shared<BoxFuture<'static, SharedVortexResult<ZoneMap>>>;
@@ -102,16 +103,22 @@ impl PruningState {
                         Some(
                             async move {
                                 let zone_map = zone_map.await?;
-                                let initial_mask =
-                                    zone_map.prune(&predicate, &session).map_err(|err| {
-                                        err.with_context(format!(
+                                let context = || {
+                                    format!(
                                         "While evaluating pruning predicate {} (derived from {})",
                                         predicate, expr
-                                    ))
-                                    })?;
+                                    )
+                                };
+
+                                let prepared = zone_map
+                                    .prepare(&predicate)
+                                    .map_err(|err| err.with_context(context()))?;
+                                let initial_mask = prepared
+                                    .evaluate(&session)
+                                    .map_err(|err| err.with_context(context()))?;
+
                                 Ok(Arc::new(PruningResult {
-                                    zone_map,
-                                    predicate,
+                                    prepared,
                                     dynamic_updates,
                                     latest_result: RwLock::new((0, initial_mask)),
                                     session,
@@ -190,8 +197,8 @@ impl PruningState {
 }
 
 pub(super) struct PruningResult {
-    zone_map: ZoneMap,
-    predicate: BoundExpression,
+    // The pruning predicate, lowered once against the zone map.
+    prepared: PreparedPruning,
     dynamic_updates: Option<DynamicExprUpdates>,
     latest_result: RwLock<(u64, Mask)>,
     session: VortexSession,
@@ -219,19 +226,16 @@ impl PruningResult {
 
         trace!(
             version,
-            predicate = %self.predicate,
+            predicate = %self.prepared.predicate(),
             "recomputing pruning mask"
         );
 
-        let next_mask = self
-            .zone_map
-            .prune(&self.predicate, &self.session)
-            .map_err(|err| {
-                err.with_context(format!(
-                    "While evaluating pruning predicate {}",
-                    self.predicate
-                ))
-            })?;
+        let next_mask = self.prepared.evaluate(&self.session).map_err(|err| {
+            err.with_context(format!(
+                "While evaluating pruning predicate {}",
+                self.prepared.predicate()
+            ))
+        })?;
         *guard = (version, next_mask.clone());
 
         Ok(next_mask)

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -31,7 +31,6 @@ use vortex_array::expr::stats::Stat;
 use vortex_array::scalar_fn::EmptyOptions;
 use vortex_array::scalar_fn::ScalarFnVTableExt;
 use vortex_array::scalar_fn::internal::row_count::RowCount;
-use vortex_array::scalar_fn::internal::row_count::contains_row_count;
 use vortex_array::scalar_fn::internal::row_count::substitute_row_count;
 use vortex_array::stats::bind::StatBinder;
 use vortex_array::stats::bind::bind_stats;
@@ -131,37 +130,79 @@ impl ZoneMap {
     /// [`BoundExpression::falsify`]. The returned mask has one value per zone, where
     /// `true` means the zone cannot contain matching rows and can be skipped.
     ///
-    /// If the predicate contains [`row_count`][vortex_array::scalar_fn::internal::row_count]
-    /// placeholders, they are replaced after [`ArrayRef::apply_bound`] with per-zone
-    /// counts derived from `zone_len` and `row_count`. Uniform zones use a
-    /// [`ConstantArray`]; a short final zone uses a run-end encoded array.
-    /// `row_count` is a layout property rather than a stored stats field, and the
-    /// final zone may be shorter than the nominal zone length, so it is materialized
-    /// only after the predicate has been lowered to the zone-map table.
+    /// This lowers the predicate on every call. Callers that evaluate the same predicate
+    /// more than once, such as readers that re-prune when a dynamic predicate tightens,
+    /// should call [`ZoneMap::prepare`] once and reuse the result.
     pub fn prune(
         &self,
         predicate: &BoundExpression,
         session: &VortexSession,
     ) -> VortexResult<Mask> {
-        let mut ctx = session.create_execution_ctx();
-        let num_zones = self.array.len();
+        self.prepare(predicate)?.evaluate(session)
+    }
+
+    /// Lower a pruning predicate against this zone map, ready for repeated evaluation.
+    ///
+    /// Lowering rewrites the stats placeholders of `predicate` into accesses of the zone-map
+    /// stats table. It depends only on the zone-map schema, never on the values a dynamic
+    /// predicate compares against, so the result stays valid for the life of the zone map.
+    ///
+    /// If the predicate contains [`row_count`][vortex_array::scalar_fn::internal::row_count]
+    /// placeholders, the per-zone counts derived from `zone_len` and `row_count` are
+    /// materialized here as well. Uniform zones use a [`ConstantArray`]; a short final zone
+    /// uses a run-end encoded array. `row_count` is a layout property rather than a stored
+    /// stats field, so the placeholders are substituted only after
+    /// [`ArrayRef::apply_bound`] has lowered the predicate to the zone-map table.
+    pub fn prepare(&self, predicate: &BoundExpression) -> VortexResult<PreparedPruning> {
         let predicate = self.lower_stats(predicate.clone())?;
+        let row_counts = predicate
+            .contains::<RowCount>()?
+            .then(|| row_count_array(self.zone_len, self.row_count, self.array.len()))
+            .transpose()?;
 
-        let array = self.array.clone().into_array();
-        let applied = array.apply_bound(&predicate)?;
-
-        if !contains_row_count(&applied) {
-            return applied.null_as_false().execute(&mut ctx);
-        }
-
-        let row_count_array = row_count_array(self.zone_len, self.row_count, num_zones)?;
-        let substituted = substitute_row_count(applied, &row_count_array)?;
-        substituted.null_as_false().execute(&mut ctx)
+        Ok(PreparedPruning {
+            zones: self.array.clone().into_array(),
+            predicate,
+            row_counts,
+        })
     }
 
     fn lower_stats(&self, predicate: BoundExpression) -> VortexResult<BoundExpression> {
         let binder = ZoneMapStatsBinder { zone_map: self };
         bind_stats(predicate, &binder)
+    }
+}
+
+/// A pruning predicate lowered against one [`ZoneMap`], as built by [`ZoneMap::prepare`].
+pub struct PreparedPruning {
+    // The stats table of the zone map this predicate was lowered against.
+    zones: ArrayRef,
+    // The lowered predicate, bound to the stats table dtype.
+    predicate: BoundExpression,
+    // Per-zone row counts, present only when the lowered predicate needs them.
+    row_counts: Option<ArrayRef>,
+}
+
+impl PreparedPruning {
+    /// Evaluate the predicate over the zone map.
+    ///
+    /// The returned mask has one value per zone, where `true` means the zone cannot contain
+    /// matching rows and can be skipped.
+    pub fn evaluate(&self, session: &VortexSession) -> VortexResult<Mask> {
+        let mut ctx = session.create_execution_ctx();
+        let applied = self.zones.clone().apply_bound(&self.predicate)?;
+
+        let applied = match &self.row_counts {
+            None => applied,
+            Some(row_counts) => substitute_row_count(applied, row_counts)?,
+        };
+
+        applied.null_as_false().execute(&mut ctx)
+    }
+
+    /// The lowered predicate.
+    pub fn predicate(&self) -> &BoundExpression {
+        &self.predicate
     }
 }
 
@@ -338,6 +379,8 @@ fn row_count_array(zone_len: u64, row_count: u64, num_zones: usize) -> VortexRes
 mod tests {
     use std::num::NonZeroUsize;
     use std::sync::Arc;
+    use std::sync::atomic::AtomicI32;
+    use std::sync::atomic::Ordering;
 
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
@@ -368,6 +411,7 @@ mod tests {
     use vortex_array::expr::BoundExpression;
     use vortex_array::expr::Expression;
     use vortex_array::expr::cast;
+    use vortex_array::expr::dynamic;
     use vortex_array::expr::gt;
     use vortex_array::expr::gt_eq;
     use vortex_array::expr::is_not_null;
@@ -377,6 +421,7 @@ mod tests {
     use vortex_array::expr::not_eq;
     use vortex_array::expr::root;
     use vortex_array::expr::stats::Stat;
+    use vortex_array::scalar_fn::fns::operators::CompareOperator;
     use vortex_array::stats::all_nan;
     use vortex_array::stats::all_non_nan;
     use vortex_array::stats::all_non_null;
@@ -991,5 +1036,88 @@ mod tests {
             BoolArray::from_iter([true, false, false]),
             &mut SESSION.create_execution_ctx()
         );
+    }
+
+    /// A prepared predicate is lowered once, so it must still observe the current value of a
+    /// dynamic comparison on every evaluation.
+    #[test]
+    fn prepared_predicate_tracks_dynamic_updates() -> VortexResult<()> {
+        let max = Max.bind(NumericalAggregateOpts::skip_nans());
+        let min = Min.bind(NumericalAggregateOpts::skip_nans());
+        let zone_map = ZoneMap::try_new(
+            PType::I32.into(),
+            StructArray::from_fields(&[
+                (
+                    max.to_string(),
+                    PrimitiveArray::new(buffer![5i32, 6, 7], Validity::AllValid).into_array(),
+                ),
+                (
+                    min.to_string(),
+                    PrimitiveArray::new(buffer![1i32, 2, 3], Validity::AllValid).into_array(),
+                ),
+            ])?,
+            Arc::new([max, min]),
+            4,
+            12,
+        )?;
+
+        let threshold = Arc::new(AtomicI32::new(2));
+        let bound = Arc::clone(&threshold);
+
+        // A < threshold => prune every zone whose min is at least the threshold.
+        let expr = dynamic(
+            CompareOperator::Lt,
+            move || Some(bound.load(Ordering::SeqCst).into()),
+            DType::Primitive(PType::I32, Nullability::NonNullable),
+            true,
+            root(),
+        );
+        let prepared = zone_map.prepare(&falsify(&expr, PType::I32.into()))?;
+
+        let ctx = &mut SESSION.create_execution_ctx();
+        assert_arrays_eq!(
+            prepared.evaluate(&SESSION)?.into_array(),
+            BoolArray::from_iter([false, true, true]),
+            ctx
+        );
+
+        threshold.store(8, Ordering::SeqCst);
+        assert_arrays_eq!(
+            prepared.evaluate(&SESSION)?.into_array(),
+            BoolArray::from_iter([false, false, false]),
+            ctx
+        );
+
+        Ok(())
+    }
+
+    /// The per-zone row counts are materialized once, so they must survive repeated
+    /// substitution into the lowered predicate.
+    #[test]
+    fn prepared_row_count_predicate_reevaluates() -> VortexResult<()> {
+        let zone_map = ZoneMap::try_new_legacy(
+            PType::U64.into(),
+            StructArray::from_fields(&[(
+                "null_count",
+                PrimitiveArray::new(buffer![0u64, 0, 2], Validity::AllValid).into_array(),
+            )])?,
+            Arc::new([Stat::NullCount]),
+            4,
+            10,
+        )?;
+
+        let prepared = zone_map.prepare(&falsify(&is_not_null(root()), PType::U64.into()))?;
+
+        let ctx = &mut SESSION.create_execution_ctx();
+        for _ in 0..2 {
+            // The trailing zone holds only two rows, both of which are null.
+            assert_arrays_eq!(
+                prepared.evaluate(&SESSION)?.into_array(),
+                BoolArray::from_iter([false, false, true]),
+                ctx
+            );
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Overview

`ZoneMap::prune` rewrote the falsified predicate against the zone-map stats table
(`bind_stats`) on every call, and rebuilt the per-zone row-count array with it. Zoned readers
cache the falsifier and the resulting mask, but they call `prune` again whenever a dynamic
predicate tightens, so the whole rewrite ran once per re-evaluation.

The rewrite depends only on the zone-map schema. A dynamic comparison keeps a shared handle to
its value function (`Arc<Rhs>`, preserved by `falsify`) and reads it during execution, so
lowering never captures the current bound.

## Changes

- Add `ZoneMap::prepare`, which lowers the predicate once and returns a `PreparedPruning`
  holding the lowered predicate, the stats table, and the per-zone row counts when the lowered
  predicate needs them. Presence of the `row_count` placeholder is now decided on the
  expression instead of on each applied array.
- `PreparedPruning::evaluate` does the per-evaluation work only: apply, substitute row counts,
  execute.
- The zoned reader's `PruningResult` stores the prepared predicate instead of the zone map plus
  the falsified predicate, so re-pruning after a dynamic update only evaluates.
- `ZoneMap::prune` stays as a one-shot wrapper for single-evaluation callers.

The trace and error context in the dynamic re-evaluation path now print the lowered predicate
rather than the falsified one.

## Benchmarks

`cargo bench -p vortex-layout --bench zone_map_prune`, medians. The `prune` group is the old
behavior (lower + evaluate), the `prepared` group is what a re-pruning reader now pays.

| case | zones | `prune` | `prepared` | change |
| --- | --- | --- | --- | --- |
| `int_gt` | 16 | 1.437 µs | 916.7 ns | -36% |
| `int_gt` | 8192 | 2.520 µs | 1.906 µs | -24% |
| `float_gt` | 16 | 8.124 µs | 4.999 µs | -38% |
| `float_gt` | 8192 | 14.95 µs | 11.66 µs | -22% |
| `is_not_null_pred` | 16 | 5.041 µs | 2.957 µs | -41% |
| `is_not_null_pred` | 8192 | 10.58 µs | 8.166 µs | -23% |
| `or_chain` (16 terms) | 16 | 59.99 µs | 42.18 µs | -30% |
| `or_chain` (16 terms) | 8192 | 108.2 µs | 89.27 µs | -17% |
| `missing_stats` | 8192 | 1.229 µs | 551.8 ns | -55% |

## Tests

- `prepared_predicate_tracks_dynamic_updates`: prepares a falsified dynamic comparison once,
  then asserts the mask follows the threshold across evaluations.
- `prepared_row_count_predicate_reevaluates`: evaluates a prepared `row_count` predicate twice
  over a short trailing zone.

## Validation

- `cargo nextest run -p vortex-layout -p vortex-file`: 391 passed.
- `cargo test --doc -p vortex-layout`.
- `cargo clippy -p vortex-layout --all-targets --all-features`.
- `cargo +nightly fmt --all -- --check`.

I did not run workspace-wide clippy or tests; the change is confined to `vortex-layout` and
keeps the existing public `prune` signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
