### PR TITLE
Avoid boxing already-resolved masks in MaskFuture

### DIFF
--- a/vortex-array/src/mask_future.rs
+++ b/vortex-array/src/mask_future.rs
@@ -16,10 +16,21 @@ use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 
 /// A future that resolves to a mask.
+///
+/// Masks that are known up-front (e.g. scans without a filter) are stored resolved, so awaiting,
+/// cloning, and slicing them never allocates a boxed future.
 #[derive(Clone)]
 pub struct MaskFuture {
-    inner: Shared<BoxFuture<'static, SharedVortexResult<Mask>>>,
+    inner: Inner,
     len: usize,
+}
+
+#[derive(Clone)]
+enum Inner {
+    /// The mask is already resolved.
+    Ready(Mask),
+    /// The mask is still being computed.
+    Pending(Shared<BoxFuture<'static, SharedVortexResult<Mask>>>),
 }
 
 impl MaskFuture {
@@ -29,8 +40,8 @@ impl MaskFuture {
         F: Future<Output = VortexResult<Mask>> + Send + 'static,
     {
         Self {
-            inner: fut
-                .inspect(move |r| {
+            inner: Inner::Pending(
+                fut.inspect(move |r| {
                     if let Ok(mask) = r
                         && mask.len() != len {
                             vortex_panic!("MaskFuture created with future that returned mask of incorrect length (expected {}, got {})", len, mask.len());
@@ -39,6 +50,7 @@ impl MaskFuture {
                 .map_err(Arc::new)
                 .boxed()
                 .shared(),
+            ),
             len,
         }
     }
@@ -55,7 +67,10 @@ impl MaskFuture {
 
     /// Create a MaskFuture from a ready mask.
     pub fn ready(mask: Mask) -> Self {
-        Self::new(mask.len(), async move { Ok(mask) })
+        Self {
+            len: mask.len(),
+            inner: Inner::Ready(mask),
+        }
     }
 
     /// Create a MaskFuture that resolves to a mask with all values set to true.
@@ -65,25 +80,42 @@ impl MaskFuture {
 
     /// Create a MaskFuture that resolves to a slice of the original mask.
     pub fn slice(&self, range: Range<usize>) -> Self {
-        // Slicing the whole mask is the identity. Cloning shares the existing future instead of
-        // allocating another boxed, shared one that would await it only to hand the mask back.
+        // Slicing the whole mask is the identity. Cloning shares the existing state instead of
+        // allocating another boxed, shared future that would await it only to hand the mask back.
         if range.start == 0 && range.end == self.len {
             return self.clone();
         }
 
-        let inner = self.inner.clone();
-        Self::new(range.len(), async move { Ok(inner.await?.slice(range)) })
+        match &self.inner {
+            Inner::Ready(mask) => Self::ready(mask.slice(range)),
+            Inner::Pending(inner) => {
+                let inner = inner.clone();
+                Self::new(range.len(), async move { Ok(inner.await?.slice(range)) })
+            }
+        }
     }
 
+    /// Observe the resolved mask.
+    ///
+    /// An already-resolved mask calls `f` immediately rather than deferring it to the first poll.
     pub fn inspect(
         self,
         f: impl FnOnce(&SharedVortexResult<Mask>) + 'static + Send + Sync,
     ) -> Self {
         let len = self.len;
 
-        Self {
-            inner: self.inner.inspect(f).boxed().shared(),
-            len,
+        match self.inner {
+            Inner::Ready(mask) => {
+                f(&Ok(mask.clone()));
+                Self {
+                    inner: Inner::Ready(mask),
+                    len,
+                }
+            }
+            Inner::Pending(inner) => Self {
+                inner: Inner::Pending(inner.inspect(f).boxed().shared()),
+                len,
+            },
         }
     }
 }
@@ -95,12 +127,18 @@ impl Future for MaskFuture {
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        self.inner.poll_unpin(cx).map_err(VortexError::from)
+        match &mut self.inner {
+            Inner::Ready(mask) => std::task::Poll::Ready(Ok(mask.clone())),
+            Inner::Pending(inner) => inner.poll_unpin(cx).map_err(VortexError::from),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+
     use vortex_buffer::BitBuffer;
 
     use super::*;
@@ -120,6 +158,43 @@ mod tests {
             let partial = fut.slice(0..mask.len() - 1);
             assert_eq!(partial.len(), mask.len() - 1);
             assert_eq!(partial.await?, mask.slice(0..mask.len() - 1));
+            Ok(())
+        })
+    }
+
+    /// Ready and pending variants must behave identically through slice and await.
+    #[test]
+    fn pending_slice_matches_ready_slice() -> VortexResult<()> {
+        futures::executor::block_on(async {
+            let mask = Mask::from_buffer(BitBuffer::from_iter([true, false, true, true, false]));
+            let ready = MaskFuture::ready(mask.clone());
+            let pending = {
+                let mask = mask.clone();
+                MaskFuture::new(mask.len(), async move { Ok(mask) })
+            };
+
+            assert_eq!(ready.slice(1..4).await?, pending.slice(1..4).await?);
+            assert_eq!(ready.clone().await?, pending.clone().await?);
+            Ok(())
+        })
+    }
+
+    /// Inspect fires for an already-resolved mask and preserves the resolved value.
+    #[test]
+    fn inspect_fires_on_ready_mask() -> VortexResult<()> {
+        futures::executor::block_on(async {
+            let mask = Mask::from_buffer(BitBuffer::from_iter([true, false]));
+            let fired = Arc::new(AtomicBool::new(false));
+            let fut = MaskFuture::ready(mask.clone()).inspect({
+                let fired = Arc::clone(&fired);
+                move |r| {
+                    assert!(r.is_ok());
+                    fired.store(true, Ordering::Relaxed);
+                }
+            });
+
+            assert!(fired.load(Ordering::Relaxed));
+            assert_eq!(fut.await?, mask);
             Ok(())
         })
     }


### PR DESCRIPTION
## Summary

Reduces per-split overhead on the sparse random-access path.

`MaskFuture` always stored its mask behind a `Shared<BoxFuture<..>>`, even when the mask was
already known. Random access hits this hardest: it runs without a filter, so `split_exec` builds
every split's mask up front via `MaskFuture::ready(..)`, and `StructReader::projection_evaluation`
then clones that mask once per leaf field. Each of those clones, slices, and awaits went through
boxed-future and waker machinery to hand back a value that was already sitting in memory.

## Changes

Splits the inner state into `Ready` and `Pending`. Ready masks resolve inline, slice eagerly, and
clone without allocating; pending masks keep the previous shared-future behaviour. `inspect` on an
already-resolved mask now fires immediately rather than deferring to the first poll, which is
documented on the method — it currently has no production callers.

Tests cover that ready and pending variants agree through `slice` and `await`, and that `inspect`
fires for a resolved mask.

### Local measurements

`nested-structs` (1M rows, 6 leaf fields, cached file handle), interleaved A/B of separately built
baseline and patched binaries, median of 5 runs x 300 takes:

| indices | build-futures stage | end-to-end take |
| --- | --- | --- |
| uniform 99 | 275.5us -> 237.5us (-14%) | 4958us -> 4886us (-1.5%) |
| correlated 100 | 150.2us -> 123.8us (-18%) | 3425us -> 3265us (-4.7%) |
| fixed 6 | 77.5us -> 71.2us (-8%) | 1238us -> 1161us (-6.2%) |

The saving is concentrated in future construction, which is only ~5% of a take, so the end-to-end
effect is small and may not clear benchmark noise in CI.

### Why the end-to-end win is small

Instrumenting bytes actually read per `take()` shows the dominant cost is read amplification rather
than scan machinery: a 99-row point lookup reads **33.97 MiB**, against 33.98 MiB of segments in the
whole file. 100 correlated rows read 26.66 MiB; even 6 rows read 11.72 MiB. The file has 54 segments
of roughly 904 KiB-1 MiB, because the default `data_block_target_bytes` of 1 MiB coalesces the
8192-row blocks into megabyte data blocks, so reading one row fetches its whole segment. Sampling
agrees: ~76% of CPU samples sit on the tokio blocking pool servicing those reads.

That is a write-side granularity question (`WriteStrategyBuilder::with_data_block_target_bytes`)
with a scan-throughput trade-off, so it is deliberately left out of this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5Uqxc31yWg4f2Pe513ogR)_