### PR TITLE
Conditionally slice elements to selected index bounds before filtering wide list arrays

### DIFF
--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -34,28 +34,43 @@ use crate::validity::Validity;
 /// Note that this is somewhat arbitrarily chosen...
 const MASK_EXPANSION_DENSITY_THRESHOLD: f64 = 0.05;
 
-/// Minimum average list length at which filtering trims unselected leading and trailing elements.
-const ELEMENT_RANGE_CROP_MIN_AVERAGE_LIST_LENGTH: usize = 1024;
+/// Minimum percentage of referenced-but-unselected prefix and suffix elements required before
+/// cropping.
+const PERCENTAGE_REFERENCED_UNSELECTED_ELEMENTS_THRESHOLD: usize = 20;
 
-/// Return the element range to filter.
+/// Crop when at least `1 / denominator` of referenced elements are unselected.
+const N_REFERENCED_UNSELECTED_ELEMENTS_THRESHOLD: usize = 1024;
+
+/// Return the element range to construct new mask over and to subsequently filter. In the general case this will be the range
+/// of elements referenced by a sublist.
+///
+/// If there are enough elements in head or tail that are referenced but not selected, it is more efficient
+/// to bound the element range to the first and last selected indices. We can then expand the
+/// mask only over this subset of elements, slice the elements array, and then filter. This avoids the
+/// overhead of potentially wasteful mask reconstruction.
+///
+/// Returns the range and a flag indicating whether the range is a subinterval of the referenced element range.
 fn element_range_from_offsets<O: IntegerPType>(
     offsets: &[O],
     selection: &MaskValuesRef,
-) -> Range<usize> {
-    let first_offset = offsets.first().map_or(0, |first_offset| first_offset.as_());
-    let last_offset = offsets.last().map_or(0, |last_offset| last_offset.as_());
-    let element_count = last_offset - first_offset;
-    let list_count = offsets.len() - 1;
-
-    if element_count <= list_count.saturating_mul(ELEMENT_RANGE_CROP_MIN_AVERAGE_LIST_LENGTH) {
-        return first_offset..last_offset;
-    }
+) -> (Range<usize>, bool) {
+    let referenced_elements_range = offsets[0].as_()..offsets[offsets.len() - 1].as_();
 
     let selected_indices = selection.indices();
-    let first_index = selected_indices[0];
-    let last_index = selected_indices[selected_indices.len() - 1];
+    let first_selected_sublist_index = selected_indices[0];
+    let last_selected_sublist_index = selected_indices[selected_indices.len() - 1];
+    let selected_elements_range =
+        offsets[first_selected_sublist_index].as_()..offsets[last_selected_sublist_index + 1].as_();
+    let trimmed_element_count = referenced_elements_range.len() - selected_elements_range.len();
 
-    offsets[first_index].as_()..offsets[last_index + 1].as_()
+    if trimmed_element_count >= N_REFERENCED_UNSELECTED_ELEMENTS_THRESHOLD
+        && trimmed_element_count.saturating_mul(PERCENTAGE_REFERENCED_UNSELECTED_ELEMENTS_THRESHOLD)
+            >= referenced_elements_range.len()
+    {
+        (selected_elements_range, true)
+    } else {
+        (referenced_elements_range, false)
+    }
 }
 
 /// Construct an element mask relative to `element_range` from contiguous list offsets and an
@@ -146,7 +161,7 @@ impl FilterKernel for List {
         // TODO(ngates): for ultra-sparse masks, we don't need to optimize the entire offsets.
         let offsets = array.offsets().clone();
 
-        let (new_offsets, element_range, element_mask) =
+        let (new_offsets, element_range, range_is_subinterval, element_mask) =
             match_each_integer_ptype!(offsets.dtype().as_ptype(), |O| {
                 let offsets_buffer = offsets.execute::<Buffer<O>>(ctx)?;
                 let offsets = offsets_buffer.as_slice();
@@ -159,23 +174,27 @@ impl FilterKernel for List {
                     unsafe { new_offsets.push_unchecked(offset) };
                 }
 
-                // TODO(ngates): for very dense masks, there may be no point in filtering the elements,
-                //  and instead we should construct a view against the unfiltered elements.
-                let element_range = element_range_from_offsets::<O>(offsets, selection);
+                let (element_range, range_is_subinterval) =
+                    element_range_from_offsets::<O>(offsets, selection);
                 let element_mask =
                     element_mask_from_offsets::<O>(offsets, selection, &element_range);
 
                 (
                     new_offsets.freeze().into_array(),
                     element_range,
+                    range_is_subinterval,
                     element_mask,
                 )
             });
 
-        let new_elements = array
-            .elements()
-            .slice(element_range)?
-            .filter(element_mask)?;
+        let new_elements = if range_is_subinterval {
+            array
+                .elements()
+                .slice(element_range)?
+                .filter(element_mask)?
+        } else {
+            array.sliced_elements()?.filter(element_mask)?
+        };
 
         // SAFETY: new_offsets are monotonically increasing starting from 0 with length
         // true_count + 1, and the elements have been filtered to match.
@@ -200,13 +219,14 @@ mod tests {
             vortex_bail!("a partially selective mask uses Mask::Values")
         };
 
-        let offsets = [10u32, 2010, 4010, 6010, 8010, 10010];
-        let range = element_range_from_offsets(&offsets, &selection);
+        let offsets = [10u32, 20010, 40010, 60010, 80010, 100010];
+        let (range, range_is_subinterval) = element_range_from_offsets(&offsets, &selection);
         let element_mask = element_mask_from_offsets(&offsets, &selection, &range);
 
-        assert_eq!(range, 4010..6010);
+        assert_eq!(range, 40010..60010);
+        assert!(range_is_subinterval);
         assert!(element_mask.all_true());
-        assert_eq!(element_mask.len(), 2000);
+        assert_eq!(element_mask.len(), 20000);
         Ok(())
     }
 
@@ -216,29 +236,73 @@ mod tests {
             vortex_bail!("a partially selective mask uses Mask::Values")
         };
 
-        let offsets = [10u32, 2010, 4010, 6010, 8010, 10010];
-        let range = element_range_from_offsets(&offsets, &selection);
+        let offsets = [10u32, 20010, 40010, 60010, 80010, 100010];
+        let (range, range_is_subinterval) = element_range_from_offsets(&offsets, &selection);
         let element_mask = element_mask_from_offsets(&offsets, &selection, &range);
 
-        assert_eq!(range, 2010..8010);
-        assert_eq!(element_mask.len(), 6000);
-        assert_eq!(element_mask.true_count(), 4000);
+        assert_eq!(range, 20010..80010);
+        assert!(range_is_subinterval);
+        assert_eq!(element_mask.len(), 60000);
+        assert_eq!(element_mask.true_count(), 40000);
         Ok(())
     }
 
     #[test]
-    fn element_mask_preserves_complete_range_for_short_lists() -> VortexResult<()> {
+    fn element_range_preserves_complete_range_for_short_lists() -> VortexResult<()> {
         let Mask::Values(selection) = Mask::from_indices(5, [2]) else {
             vortex_bail!("a partially selective mask uses Mask::Values")
         };
 
         let offsets = [10u32, 20, 30, 40, 50, 60];
-        let range = element_range_from_offsets(&offsets, &selection);
+        let (range, range_is_subinterval) = element_range_from_offsets(&offsets, &selection);
         let element_mask = element_mask_from_offsets(&offsets, &selection, &range);
 
         assert_eq!(range, 10..60);
+        assert!(!range_is_subinterval);
         assert_eq!(element_mask.len(), 50);
         assert_eq!(element_mask.true_count(), 10);
+        Ok(())
+    }
+
+    #[test]
+    fn element_range_requires_minimum_savings() -> VortexResult<()> {
+        let Mask::Values(selection) = Mask::from_indices(2, [0]) else {
+            vortex_bail!("a partially selective mask uses Mask::Values")
+        };
+
+        let offsets = [0u32, 512, 1024];
+        assert_eq!(
+            element_range_from_offsets(&offsets, &selection),
+            (0..1024, false)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn element_range_requires_sufficient_savings_ratio() -> VortexResult<()> {
+        let Mask::Values(selection) = Mask::from_slices(100, vec![(0, 96)]) else {
+            vortex_bail!("a partially selective mask uses Mask::Values")
+        };
+        let offsets = (0..=100).map(|index| index * 1000).collect::<Vec<u32>>();
+
+        assert_eq!(
+            element_range_from_offsets(&offsets, &selection),
+            (0..100_000, false)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn element_range_crops_at_sufficient_savings_ratio() -> VortexResult<()> {
+        let Mask::Values(selection) = Mask::from_slices(100, vec![(0, 95)]) else {
+            vortex_bail!("a partially selective mask uses Mask::Values")
+        };
+        let offsets = (0..=100).map(|index| index * 1000).collect::<Vec<u32>>();
+
+        assert_eq!(
+            element_range_from_offsets(&offsets, &selection),
+            (0..95_000, true)
+        );
         Ok(())
     }
 
@@ -248,13 +312,14 @@ mod tests {
             vortex_bail!("a partially selective mask uses Mask::Values")
         };
 
-        let offsets = [10u32, 2010, 4010, 6010, 8010, 10010];
-        let range = element_range_from_offsets(&offsets, &selection);
+        let offsets = [10u32, 20010, 40010, 60010, 80010, 100010];
+        let (range, range_is_subinterval) = element_range_from_offsets(&offsets, &selection);
         let element_mask = element_mask_from_offsets(&offsets, &selection, &range);
 
-        assert_eq!(range, 10..10010);
-        assert_eq!(element_mask.len(), 10000);
-        assert_eq!(element_mask.true_count(), 4000);
+        assert_eq!(range, 10..100010);
+        assert!(!range_is_subinterval);
+        assert_eq!(element_mask.len(), 100000);
+        assert_eq!(element_mask.true_count(), 40000);
         Ok(())
     }
 }

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -34,11 +34,11 @@ use crate::validity::Validity;
 /// Note that this is somewhat arbitrarily chosen...
 const MASK_EXPANSION_DENSITY_THRESHOLD: f64 = 0.05;
 
-/// Minimum percentage of referenced-but-unselected prefix and suffix elements required before
-/// cropping.
+/// Crop when at least `1 / threshold` of referenced elements are unselected.
 const PERCENTAGE_REFERENCED_UNSELECTED_ELEMENTS_THRESHOLD: usize = 20;
 
-/// Crop when at least `1 / denominator` of referenced elements are unselected.
+/// Minimum percentage of referenced-but-unselected prefix and suffix elements required before
+/// cropping.
 const N_REFERENCED_UNSELECTED_ELEMENTS_THRESHOLD: usize = 1024;
 
 /// Return the element range to construct new mask over and to subsequently filter. In the general case this will be the range

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Range;
+
 use num_traits::Zero;
 use vortex_buffer::BitBufferMut;
 use vortex_buffer::Buffer;
@@ -32,13 +34,29 @@ use crate::validity::Validity;
 /// Note that this is somewhat arbitrarily chosen...
 const MASK_EXPANSION_DENSITY_THRESHOLD: f64 = 0.05;
 
-/// Construct an element mask from contiguous list offsets and a selection mask.
-pub fn element_mask_from_offsets<O: IntegerPType>(
+/// Minimum average list length at which filtering trims unselected leading and trailing elements.
+const ELEMENT_RANGE_CROP_MIN_AVERAGE_LIST_LENGTH: usize = 1024;
+
+/// Construct the element range to filter and a mask relative to that range.
+fn element_range_and_mask_from_offsets<O: IntegerPType>(
     offsets: &[O],
     selection: &MaskValuesRef,
-) -> Mask {
-    let first_offset = offsets.first().map_or(0, |first_offset| first_offset.as_());
-    let last_offset = offsets.last().map_or(0, |last_offset| last_offset.as_());
+) -> (Range<usize>, Mask) {
+    let full_first_offset = offsets[0].as_();
+    let full_last_offset = offsets[offsets.len() - 1].as_();
+    let element_count = full_last_offset - full_first_offset;
+    let list_count = offsets.len() - 1;
+
+    let selected_indices = selection.indices();
+    let first_index = selected_indices[0];
+    let last_index = selected_indices[selected_indices.len() - 1];
+    let crop_element_range =
+        element_count > list_count.saturating_mul(ELEMENT_RANGE_CROP_MIN_AVERAGE_LIST_LENGTH);
+    let (first_offset, last_offset) = if crop_element_range {
+        (offsets[first_index].as_(), offsets[last_index + 1].as_())
+    } else {
+        (full_first_offset, full_last_offset)
+    };
     let len = last_offset - first_offset;
 
     let mut mask_builder = BitBufferMut::with_capacity(len);
@@ -70,7 +88,10 @@ pub fn element_mask_from_offsets<O: IntegerPType>(
     // Pad to full length if necessary.
     mask_builder.append_n(false, len - mask_builder.len());
 
-    Mask::from_buffer(mask_builder.freeze())
+    (
+        first_offset..last_offset,
+        Mask::from_buffer(mask_builder.freeze()),
+    )
 }
 
 /// Process a range of elements for filtering.
@@ -119,7 +140,7 @@ impl FilterKernel for List {
         // TODO(ngates): for ultra-sparse masks, we don't need to optimize the entire offsets.
         let offsets = array.offsets().clone();
 
-        let (new_offsets, element_mask) =
+        let (new_offsets, element_range, element_mask) =
             match_each_integer_ptype!(offsets.dtype().as_ptype(), |O| {
                 let offsets_buffer = offsets.execute::<Buffer<O>>(ctx)?;
                 let offsets = offsets_buffer.as_slice();
@@ -135,17 +156,83 @@ impl FilterKernel for List {
 
                 // TODO(ngates): for very dense masks, there may be no point in filtering the elements,
                 //  and instead we should construct a view against the unfiltered elements.
-                let element_mask = element_mask_from_offsets::<O>(offsets, selection);
+                let (element_range, element_mask) =
+                    element_range_and_mask_from_offsets::<O>(offsets, selection);
 
-                (new_offsets.freeze().into_array(), element_mask)
+                (
+                    new_offsets.freeze().into_array(),
+                    element_range,
+                    element_mask,
+                )
             });
 
-        let new_elements = array.sliced_elements()?.filter(element_mask)?;
+        let new_elements = array
+            .elements()
+            .slice(element_range)?
+            .filter(element_mask)?;
 
         // SAFETY: new_offsets are monotonically increasing starting from 0 with length
         // true_count + 1, and the elements have been filtered to match.
         Ok(Some(unsafe {
             ListArray::new_unchecked(new_elements, new_offsets, new_validity).into_array()
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_error::VortexResult;
+    use vortex_error::vortex_bail;
+    use vortex_mask::Mask;
+
+    use super::element_range_and_mask_from_offsets;
+
+    #[test]
+    fn element_mask_excludes_unselected_prefix_and_suffix() -> VortexResult<()> {
+        let Mask::Values(selection) = Mask::from_indices(5, [2]) else {
+            vortex_bail!("a partially selective mask uses Mask::Values")
+        };
+
+        let (range, element_mask) = element_range_and_mask_from_offsets(
+            &[10u32, 2010, 4010, 6010, 8010, 10010],
+            &selection,
+        );
+
+        assert_eq!(range, 4010..6010);
+        assert!(element_mask.all_true());
+        assert_eq!(element_mask.len(), 2000);
+        Ok(())
+    }
+
+    #[test]
+    fn element_mask_retains_gaps_between_selected_lists() -> VortexResult<()> {
+        let Mask::Values(selection) = Mask::from_indices(5, [1, 3]) else {
+            vortex_bail!("a partially selective mask uses Mask::Values")
+        };
+
+        let (range, element_mask) = element_range_and_mask_from_offsets(
+            &[10u32, 2010, 4010, 6010, 8010, 10010],
+            &selection,
+        );
+
+        assert_eq!(range, 2010..8010);
+        assert_eq!(element_mask.len(), 6000);
+        assert_eq!(element_mask.true_count(), 4000);
+        Ok(())
+    }
+
+    #[test]
+    fn element_mask_preserves_complete_range_for_short_lists() -> VortexResult<()> {
+        let Mask::Values(selection) = Mask::from_indices(5, [2]) else {
+            vortex_bail!("a partially selective mask uses Mask::Values")
+        };
+
+        let (range, element_mask) =
+            element_range_and_mask_from_offsets(&[10u32, 20, 30, 40, 50, 60], &selection);
+
+        assert_eq!(range, 10..60);
+        assert_eq!(element_mask.len(), 50);
+        assert_eq!(element_mask.true_count(), 10);
+        Ok(())
     }
 }

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -37,11 +37,11 @@ const MASK_EXPANSION_DENSITY_THRESHOLD: f64 = 0.05;
 /// Minimum average list length at which filtering trims unselected leading and trailing elements.
 const ELEMENT_RANGE_CROP_MIN_AVERAGE_LIST_LENGTH: usize = 1024;
 
-/// Construct the element range to filter and a mask relative to that range.
-fn element_range_and_mask_from_offsets<O: IntegerPType>(
+/// Construct the element range to filter.
+fn element_range_from_offsets<O: IntegerPType>(
     offsets: &[O],
     selection: &MaskValuesRef,
-) -> (Range<usize>, Mask) {
+) -> Range<usize> {
     let full_first_offset = offsets[0].as_();
     let full_last_offset = offsets[offsets.len() - 1].as_();
     let element_count = full_last_offset - full_first_offset;
@@ -57,7 +57,18 @@ fn element_range_and_mask_from_offsets<O: IntegerPType>(
     } else {
         (full_first_offset, full_last_offset)
     };
-    let len = last_offset - first_offset;
+    first_offset..last_offset
+}
+
+/// Construct an element mask relative to `element_range` from contiguous list offsets and an
+/// outer-row selection mask.
+pub fn element_mask_from_offsets<O: IntegerPType>(
+    offsets: &[O],
+    selection: &MaskValuesRef,
+    element_range: &Range<usize>,
+) -> Mask {
+    let first_offset = element_range.start;
+    let len = element_range.end - first_offset;
 
     let mut mask_builder = BitBufferMut::with_capacity(len);
 
@@ -88,10 +99,7 @@ fn element_range_and_mask_from_offsets<O: IntegerPType>(
     // Pad to full length if necessary.
     mask_builder.append_n(false, len - mask_builder.len());
 
-    (
-        first_offset..last_offset,
-        Mask::from_buffer(mask_builder.freeze()),
-    )
+    Mask::from_buffer(mask_builder.freeze())
 }
 
 /// Process a range of elements for filtering.
@@ -156,8 +164,9 @@ impl FilterKernel for List {
 
                 // TODO(ngates): for very dense masks, there may be no point in filtering the elements,
                 //  and instead we should construct a view against the unfiltered elements.
-                let (element_range, element_mask) =
-                    element_range_and_mask_from_offsets::<O>(offsets, selection);
+                let element_range = element_range_from_offsets::<O>(offsets, selection);
+                let element_mask =
+                    element_mask_from_offsets::<O>(offsets, selection, &element_range);
 
                 (
                     new_offsets.freeze().into_array(),
@@ -185,7 +194,8 @@ mod tests {
     use vortex_error::vortex_bail;
     use vortex_mask::Mask;
 
-    use super::element_range_and_mask_from_offsets;
+    use super::element_mask_from_offsets;
+    use super::element_range_from_offsets;
 
     #[test]
     fn element_mask_excludes_unselected_prefix_and_suffix() -> VortexResult<()> {
@@ -193,10 +203,9 @@ mod tests {
             vortex_bail!("a partially selective mask uses Mask::Values")
         };
 
-        let (range, element_mask) = element_range_and_mask_from_offsets(
-            &[10u32, 2010, 4010, 6010, 8010, 10010],
-            &selection,
-        );
+        let offsets = [10u32, 2010, 4010, 6010, 8010, 10010];
+        let range = element_range_from_offsets(&offsets, &selection);
+        let element_mask = element_mask_from_offsets(&offsets, &selection, &range);
 
         assert_eq!(range, 4010..6010);
         assert!(element_mask.all_true());
@@ -210,10 +219,9 @@ mod tests {
             vortex_bail!("a partially selective mask uses Mask::Values")
         };
 
-        let (range, element_mask) = element_range_and_mask_from_offsets(
-            &[10u32, 2010, 4010, 6010, 8010, 10010],
-            &selection,
-        );
+        let offsets = [10u32, 2010, 4010, 6010, 8010, 10010];
+        let range = element_range_from_offsets(&offsets, &selection);
+        let element_mask = element_mask_from_offsets(&offsets, &selection, &range);
 
         assert_eq!(range, 2010..8010);
         assert_eq!(element_mask.len(), 6000);
@@ -227,8 +235,9 @@ mod tests {
             vortex_bail!("a partially selective mask uses Mask::Values")
         };
 
-        let (range, element_mask) =
-            element_range_and_mask_from_offsets(&[10u32, 20, 30, 40, 50, 60], &selection);
+        let offsets = [10u32, 20, 30, 40, 50, 60];
+        let range = element_range_from_offsets(&offsets, &selection);
+        let element_mask = element_mask_from_offsets(&offsets, &selection, &range);
 
         assert_eq!(range, 10..60);
         assert_eq!(element_mask.len(), 50);

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -3,12 +3,14 @@
 
 use std::ops::Range;
 
+use num_traits::Zero;
 use vortex_buffer::BitBufferMut;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 use vortex_mask::MaskIter;
+use vortex_mask::MaskValuesRef;
 
 use crate::ArrayRef;
 use crate::Canonical;
@@ -35,53 +37,40 @@ const MASK_EXPANSION_DENSITY_THRESHOLD: f64 = 0.05;
 /// Minimum average list length at which filtering trims unselected leading and trailing elements.
 const ELEMENT_RANGE_CROP_MIN_AVERAGE_LIST_LENGTH: usize = 1024;
 
-/// Return the element range to slice before filtering, if doing so removes a sufficiently large
-/// unselected prefix or suffix.
-fn slice_elements_before_filter<O: IntegerPType>(
+/// Return the element range to filter.
+fn element_range_from_offsets<O: IntegerPType>(
     offsets: &[O],
-    selection: &MaskIter<'_>,
-) -> Option<Range<usize>> {
+    selection: &MaskValuesRef,
+) -> Range<usize> {
     let first_offset = offsets.first().map_or(0, |first_offset| first_offset.as_());
     let last_offset = offsets.last().map_or(0, |last_offset| last_offset.as_());
     let element_count = last_offset - first_offset;
     let list_count = offsets.len() - 1;
 
     if element_count <= list_count.saturating_mul(ELEMENT_RANGE_CROP_MIN_AVERAGE_LIST_LENGTH) {
-        return None;
+        return first_offset..last_offset;
     }
 
-    let (first_index, last_index) = match selection {
-        MaskIter::Indices(indices) => (indices[0], indices[indices.len() - 1]),
-        MaskIter::Slices(slices) => (slices[0].0, slices[slices.len() - 1].1 - 1),
-    };
-    let element_range = offsets[first_index].as_()..offsets[last_index + 1].as_();
-    let full_element_range = first_offset..last_offset;
+    let selected_indices = selection.indices();
+    let first_index = selected_indices[0];
+    let last_index = selected_indices[selected_indices.len() - 1];
 
-    (element_range != full_element_range).then_some(element_range)
+    offsets[first_index].as_()..offsets[last_index + 1].as_()
 }
 
-/// Construct an element mask from contiguous list offsets and an outer-row selection mask. If
-/// `element_slice` is present, construct the mask relative to that slice instead of the complete
-/// logical element range.
+/// Construct an element mask relative to `element_range` from contiguous list offsets and an
+/// outer-row selection mask.
 pub fn element_mask_from_offsets<O: IntegerPType>(
     offsets: &[O],
-    selection: MaskIter<'_>,
-    element_slice: Option<&Range<usize>>,
+    selection: &MaskValuesRef,
+    element_range: &Range<usize>,
 ) -> Mask {
-    let (first_offset, last_offset) = element_slice.map_or_else(
-        || {
-            (
-                offsets.first().map_or(0, |offset| offset.as_()),
-                offsets.last().map_or(0, |offset| offset.as_()),
-            )
-        },
-        |range| (range.start, range.end),
-    );
-    let len = last_offset - first_offset;
+    let first_offset = element_range.start;
+    let len = element_range.end - first_offset;
 
     let mut mask_builder = BitBufferMut::with_capacity(len);
 
-    match selection {
+    match selection.threshold_iter(MASK_EXPANSION_DENSITY_THRESHOLD) {
         MaskIter::Slices(slices) => {
             // Dense iteration: process ranges of consecutive selected lists.
             for &(start, end) in slices {
@@ -109,43 +98,6 @@ pub fn element_mask_from_offsets<O: IntegerPType>(
     mask_builder.append_n(false, len - mask_builder.len());
 
     Mask::from_buffer(mask_builder.freeze())
-}
-
-fn append_selected_list_offset<O: IntegerPType>(
-    offsets: &[O],
-    index: usize,
-    offset: &mut O,
-    new_offsets: &mut BufferMut<O>,
-) {
-    *offset += offsets[index + 1] - offsets[index];
-    unsafe { new_offsets.push_unchecked(*offset) };
-}
-
-fn filtered_offsets<O: IntegerPType>(
-    offsets: &[O],
-    selection: &MaskIter<'_>,
-    selected_count: usize,
-) -> Buffer<O> {
-    let mut new_offsets = BufferMut::<O>::with_capacity(selected_count + 1);
-    let mut offset = O::zero();
-    unsafe { new_offsets.push_unchecked(offset) };
-
-    match selection {
-        MaskIter::Indices(indices) => {
-            for &index in *indices {
-                append_selected_list_offset(offsets, index, &mut offset, &mut new_offsets);
-            }
-        }
-        MaskIter::Slices(slices) => {
-            for &(start, end) in *slices {
-                for index in start..end {
-                    append_selected_list_offset(offsets, index, &mut offset, &mut new_offsets);
-                }
-            }
-        }
-    }
-
-    new_offsets.freeze()
 }
 
 /// Process a range of elements for filtering.
@@ -194,28 +146,36 @@ impl FilterKernel for List {
         // TODO(ngates): for ultra-sparse masks, we don't need to optimize the entire offsets.
         let offsets = array.offsets().clone();
 
-        let (new_offsets, element_slice, element_mask) =
+        let (new_offsets, element_range, element_mask) =
             match_each_integer_ptype!(offsets.dtype().as_ptype(), |O| {
                 let offsets_buffer = offsets.execute::<Buffer<O>>(ctx)?;
                 let offsets = offsets_buffer.as_slice();
-                let selected_lists = selection.threshold_iter(MASK_EXPANSION_DENSITY_THRESHOLD);
-                let new_offsets =
-                    filtered_offsets(offsets, &selected_lists, selection.true_count());
+                let mut new_offsets = BufferMut::<O>::with_capacity(selection.true_count() + 1);
+
+                let mut offset = O::zero();
+                unsafe { new_offsets.push_unchecked(offset) };
+                for &index in selection.indices() {
+                    offset += offsets[index + 1] - offsets[index];
+                    unsafe { new_offsets.push_unchecked(offset) };
+                }
 
                 // TODO(ngates): for very dense masks, there may be no point in filtering the elements,
                 //  and instead we should construct a view against the unfiltered elements.
-                let element_slice = slice_elements_before_filter::<O>(offsets, &selected_lists);
+                let element_range = element_range_from_offsets::<O>(offsets, selection);
                 let element_mask =
-                    element_mask_from_offsets::<O>(offsets, selected_lists, element_slice.as_ref());
+                    element_mask_from_offsets::<O>(offsets, selection, &element_range);
 
-                (new_offsets.into_array(), element_slice, element_mask)
+                (
+                    new_offsets.freeze().into_array(),
+                    element_range,
+                    element_mask,
+                )
             });
 
-        let elements = match element_slice {
-            Some(range) => array.elements().slice(range)?,
-            None => array.sliced_elements()?,
-        };
-        let new_elements = elements.filter(element_mask)?;
+        let new_elements = array
+            .elements()
+            .slice(element_range)?
+            .filter(element_mask)?;
 
         // SAFETY: new_offsets are monotonically increasing starting from 0 with length
         // true_count + 1, and the elements have been filtered to match.
@@ -231,9 +191,8 @@ mod tests {
     use vortex_error::vortex_bail;
     use vortex_mask::Mask;
 
-    use super::MASK_EXPANSION_DENSITY_THRESHOLD;
     use super::element_mask_from_offsets;
-    use super::slice_elements_before_filter;
+    use super::element_range_from_offsets;
 
     #[test]
     fn element_mask_excludes_unselected_prefix_and_suffix() -> VortexResult<()> {
@@ -242,11 +201,10 @@ mod tests {
         };
 
         let offsets = [10u32, 2010, 4010, 6010, 8010, 10010];
-        let selected_lists = selection.threshold_iter(MASK_EXPANSION_DENSITY_THRESHOLD);
-        let range = slice_elements_before_filter(&offsets, &selected_lists);
-        let element_mask = element_mask_from_offsets(&offsets, selected_lists, range.as_ref());
+        let range = element_range_from_offsets(&offsets, &selection);
+        let element_mask = element_mask_from_offsets(&offsets, &selection, &range);
 
-        assert_eq!(range, Some(4010..6010));
+        assert_eq!(range, 4010..6010);
         assert!(element_mask.all_true());
         assert_eq!(element_mask.len(), 2000);
         Ok(())
@@ -259,11 +217,10 @@ mod tests {
         };
 
         let offsets = [10u32, 2010, 4010, 6010, 8010, 10010];
-        let selected_lists = selection.threshold_iter(MASK_EXPANSION_DENSITY_THRESHOLD);
-        let range = slice_elements_before_filter(&offsets, &selected_lists);
-        let element_mask = element_mask_from_offsets(&offsets, selected_lists, range.as_ref());
+        let range = element_range_from_offsets(&offsets, &selection);
+        let element_mask = element_mask_from_offsets(&offsets, &selection, &range);
 
-        assert_eq!(range, Some(2010..8010));
+        assert_eq!(range, 2010..8010);
         assert_eq!(element_mask.len(), 6000);
         assert_eq!(element_mask.true_count(), 4000);
         Ok(())
@@ -276,11 +233,10 @@ mod tests {
         };
 
         let offsets = [10u32, 20, 30, 40, 50, 60];
-        let selected_lists = selection.threshold_iter(MASK_EXPANSION_DENSITY_THRESHOLD);
-        let range = slice_elements_before_filter(&offsets, &selected_lists);
-        let element_mask = element_mask_from_offsets(&offsets, selected_lists, range.as_ref());
+        let range = element_range_from_offsets(&offsets, &selection);
+        let element_mask = element_mask_from_offsets(&offsets, &selection, &range);
 
-        assert_eq!(range, None);
+        assert_eq!(range, 10..60);
         assert_eq!(element_mask.len(), 50);
         assert_eq!(element_mask.true_count(), 10);
         Ok(())
@@ -293,11 +249,10 @@ mod tests {
         };
 
         let offsets = [10u32, 2010, 4010, 6010, 8010, 10010];
-        let selected_lists = selection.threshold_iter(MASK_EXPANSION_DENSITY_THRESHOLD);
-        let range = slice_elements_before_filter(&offsets, &selected_lists);
-        let element_mask = element_mask_from_offsets(&offsets, selected_lists, range.as_ref());
+        let range = element_range_from_offsets(&offsets, &selection);
+        let element_mask = element_mask_from_offsets(&offsets, &selection, &range);
 
-        assert_eq!(range, None);
+        assert_eq!(range, 10..10010);
         assert_eq!(element_mask.len(), 10000);
         assert_eq!(element_mask.true_count(), 4000);
         Ok(())

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -169,8 +169,9 @@ impl FilterKernel for List {
 
                 let mut offset = O::zero();
                 unsafe { new_offsets.push_unchecked(offset) };
-                for &index in selection.indices() {
-                    offset += offsets[index + 1] - offsets[index];
+                for idx in selection.indices() {
+                    let size = offsets[idx + 1] - offsets[*idx];
+                    offset += size;
                     unsafe { new_offsets.push_unchecked(offset) };
                 }
 

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -3,14 +3,12 @@
 
 use std::ops::Range;
 
-use num_traits::Zero;
 use vortex_buffer::BitBufferMut;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 use vortex_mask::MaskIter;
-use vortex_mask::MaskValuesRef;
 
 use crate::ArrayRef;
 use crate::Canonical;
@@ -37,42 +35,53 @@ const MASK_EXPANSION_DENSITY_THRESHOLD: f64 = 0.05;
 /// Minimum average list length at which filtering trims unselected leading and trailing elements.
 const ELEMENT_RANGE_CROP_MIN_AVERAGE_LIST_LENGTH: usize = 1024;
 
-/// Construct the element range to filter.
-fn element_range_from_offsets<O: IntegerPType>(
+/// Return the element range to slice before filtering, if doing so removes a sufficiently large
+/// unselected prefix or suffix.
+fn slice_elements_before_filter<O: IntegerPType>(
     offsets: &[O],
-    selection: &MaskValuesRef,
-) -> Range<usize> {
-    let full_first_offset = offsets[0].as_();
-    let full_last_offset = offsets[offsets.len() - 1].as_();
-    let element_count = full_last_offset - full_first_offset;
+    selection: &MaskIter<'_>,
+) -> Option<Range<usize>> {
+    let first_offset = offsets.first().map_or(0, |first_offset| first_offset.as_());
+    let last_offset = offsets.last().map_or(0, |last_offset| last_offset.as_());
+    let element_count = last_offset - first_offset;
     let list_count = offsets.len() - 1;
 
-    let selected_indices = selection.indices();
-    let first_index = selected_indices[0];
-    let last_index = selected_indices[selected_indices.len() - 1];
-    let crop_element_range =
-        element_count > list_count.saturating_mul(ELEMENT_RANGE_CROP_MIN_AVERAGE_LIST_LENGTH);
-    let (first_offset, last_offset) = if crop_element_range {
-        (offsets[first_index].as_(), offsets[last_index + 1].as_())
-    } else {
-        (full_first_offset, full_last_offset)
+    if element_count <= list_count.saturating_mul(ELEMENT_RANGE_CROP_MIN_AVERAGE_LIST_LENGTH) {
+        return None;
+    }
+
+    let (first_index, last_index) = match selection {
+        MaskIter::Indices(indices) => (indices[0], indices[indices.len() - 1]),
+        MaskIter::Slices(slices) => (slices[0].0, slices[slices.len() - 1].1 - 1),
     };
-    first_offset..last_offset
+    let element_range = offsets[first_index].as_()..offsets[last_index + 1].as_();
+    let full_element_range = first_offset..last_offset;
+
+    (element_range != full_element_range).then_some(element_range)
 }
 
-/// Construct an element mask relative to `element_range` from contiguous list offsets and an
-/// outer-row selection mask.
+/// Construct an element mask from contiguous list offsets and an outer-row selection mask. If
+/// `element_slice` is present, construct the mask relative to that slice instead of the complete
+/// logical element range.
 pub fn element_mask_from_offsets<O: IntegerPType>(
     offsets: &[O],
-    selection: &MaskValuesRef,
-    element_range: &Range<usize>,
+    selection: MaskIter<'_>,
+    element_slice: Option<&Range<usize>>,
 ) -> Mask {
-    let first_offset = element_range.start;
-    let len = element_range.end - first_offset;
+    let (first_offset, last_offset) = element_slice.map_or_else(
+        || {
+            (
+                offsets.first().map_or(0, |offset| offset.as_()),
+                offsets.last().map_or(0, |offset| offset.as_()),
+            )
+        },
+        |range| (range.start, range.end),
+    );
+    let len = last_offset - first_offset;
 
     let mut mask_builder = BitBufferMut::with_capacity(len);
 
-    match selection.threshold_iter(MASK_EXPANSION_DENSITY_THRESHOLD) {
+    match selection {
         MaskIter::Slices(slices) => {
             // Dense iteration: process ranges of consecutive selected lists.
             for &(start, end) in slices {
@@ -100,6 +109,43 @@ pub fn element_mask_from_offsets<O: IntegerPType>(
     mask_builder.append_n(false, len - mask_builder.len());
 
     Mask::from_buffer(mask_builder.freeze())
+}
+
+fn append_selected_list_offset<O: IntegerPType>(
+    offsets: &[O],
+    index: usize,
+    offset: &mut O,
+    new_offsets: &mut BufferMut<O>,
+) {
+    *offset += offsets[index + 1] - offsets[index];
+    unsafe { new_offsets.push_unchecked(*offset) };
+}
+
+fn filtered_offsets<O: IntegerPType>(
+    offsets: &[O],
+    selection: &MaskIter<'_>,
+    selected_count: usize,
+) -> Buffer<O> {
+    let mut new_offsets = BufferMut::<O>::with_capacity(selected_count + 1);
+    let mut offset = O::zero();
+    unsafe { new_offsets.push_unchecked(offset) };
+
+    match selection {
+        MaskIter::Indices(indices) => {
+            for &index in *indices {
+                append_selected_list_offset(offsets, index, &mut offset, &mut new_offsets);
+            }
+        }
+        MaskIter::Slices(slices) => {
+            for &(start, end) in *slices {
+                for index in start..end {
+                    append_selected_list_offset(offsets, index, &mut offset, &mut new_offsets);
+                }
+            }
+        }
+    }
+
+    new_offsets.freeze()
 }
 
 /// Process a range of elements for filtering.
@@ -148,37 +194,28 @@ impl FilterKernel for List {
         // TODO(ngates): for ultra-sparse masks, we don't need to optimize the entire offsets.
         let offsets = array.offsets().clone();
 
-        let (new_offsets, element_range, element_mask) =
+        let (new_offsets, element_slice, element_mask) =
             match_each_integer_ptype!(offsets.dtype().as_ptype(), |O| {
                 let offsets_buffer = offsets.execute::<Buffer<O>>(ctx)?;
                 let offsets = offsets_buffer.as_slice();
-                let mut new_offsets = BufferMut::<O>::with_capacity(selection.true_count() + 1);
-
-                let mut offset = O::zero();
-                unsafe { new_offsets.push_unchecked(offset) };
-                for idx in selection.indices() {
-                    let size = offsets[idx + 1] - offsets[*idx];
-                    offset += size;
-                    unsafe { new_offsets.push_unchecked(offset) };
-                }
+                let selected_lists = selection.threshold_iter(MASK_EXPANSION_DENSITY_THRESHOLD);
+                let new_offsets =
+                    filtered_offsets(offsets, &selected_lists, selection.true_count());
 
                 // TODO(ngates): for very dense masks, there may be no point in filtering the elements,
                 //  and instead we should construct a view against the unfiltered elements.
-                let element_range = element_range_from_offsets::<O>(offsets, selection);
+                let element_slice = slice_elements_before_filter::<O>(offsets, &selected_lists);
                 let element_mask =
-                    element_mask_from_offsets::<O>(offsets, selection, &element_range);
+                    element_mask_from_offsets::<O>(offsets, selected_lists, element_slice.as_ref());
 
-                (
-                    new_offsets.freeze().into_array(),
-                    element_range,
-                    element_mask,
-                )
+                (new_offsets.into_array(), element_slice, element_mask)
             });
 
-        let new_elements = array
-            .elements()
-            .slice(element_range)?
-            .filter(element_mask)?;
+        let elements = match element_slice {
+            Some(range) => array.elements().slice(range)?,
+            None => array.sliced_elements()?,
+        };
+        let new_elements = elements.filter(element_mask)?;
 
         // SAFETY: new_offsets are monotonically increasing starting from 0 with length
         // true_count + 1, and the elements have been filtered to match.
@@ -194,8 +231,9 @@ mod tests {
     use vortex_error::vortex_bail;
     use vortex_mask::Mask;
 
+    use super::MASK_EXPANSION_DENSITY_THRESHOLD;
     use super::element_mask_from_offsets;
-    use super::element_range_from_offsets;
+    use super::slice_elements_before_filter;
 
     #[test]
     fn element_mask_excludes_unselected_prefix_and_suffix() -> VortexResult<()> {
@@ -204,10 +242,11 @@ mod tests {
         };
 
         let offsets = [10u32, 2010, 4010, 6010, 8010, 10010];
-        let range = element_range_from_offsets(&offsets, &selection);
-        let element_mask = element_mask_from_offsets(&offsets, &selection, &range);
+        let selected_lists = selection.threshold_iter(MASK_EXPANSION_DENSITY_THRESHOLD);
+        let range = slice_elements_before_filter(&offsets, &selected_lists);
+        let element_mask = element_mask_from_offsets(&offsets, selected_lists, range.as_ref());
 
-        assert_eq!(range, 4010..6010);
+        assert_eq!(range, Some(4010..6010));
         assert!(element_mask.all_true());
         assert_eq!(element_mask.len(), 2000);
         Ok(())
@@ -220,10 +259,11 @@ mod tests {
         };
 
         let offsets = [10u32, 2010, 4010, 6010, 8010, 10010];
-        let range = element_range_from_offsets(&offsets, &selection);
-        let element_mask = element_mask_from_offsets(&offsets, &selection, &range);
+        let selected_lists = selection.threshold_iter(MASK_EXPANSION_DENSITY_THRESHOLD);
+        let range = slice_elements_before_filter(&offsets, &selected_lists);
+        let element_mask = element_mask_from_offsets(&offsets, selected_lists, range.as_ref());
 
-        assert_eq!(range, 2010..8010);
+        assert_eq!(range, Some(2010..8010));
         assert_eq!(element_mask.len(), 6000);
         assert_eq!(element_mask.true_count(), 4000);
         Ok(())
@@ -236,12 +276,30 @@ mod tests {
         };
 
         let offsets = [10u32, 20, 30, 40, 50, 60];
-        let range = element_range_from_offsets(&offsets, &selection);
-        let element_mask = element_mask_from_offsets(&offsets, &selection, &range);
+        let selected_lists = selection.threshold_iter(MASK_EXPANSION_DENSITY_THRESHOLD);
+        let range = slice_elements_before_filter(&offsets, &selected_lists);
+        let element_mask = element_mask_from_offsets(&offsets, selected_lists, range.as_ref());
 
-        assert_eq!(range, 10..60);
+        assert_eq!(range, None);
         assert_eq!(element_mask.len(), 50);
         assert_eq!(element_mask.true_count(), 10);
+        Ok(())
+    }
+
+    #[test]
+    fn element_mask_preserves_complete_range_for_edge_spanning_selection() -> VortexResult<()> {
+        let Mask::Values(selection) = Mask::from_indices(5, [0, 4]) else {
+            vortex_bail!("a partially selective mask uses Mask::Values")
+        };
+
+        let offsets = [10u32, 2010, 4010, 6010, 8010, 10010];
+        let selected_lists = selection.threshold_iter(MASK_EXPANSION_DENSITY_THRESHOLD);
+        let range = slice_elements_before_filter(&offsets, &selected_lists);
+        let element_mask = element_mask_from_offsets(&offsets, selected_lists, range.as_ref());
+
+        assert_eq!(range, None);
+        assert_eq!(element_mask.len(), 10000);
+        assert_eq!(element_mask.true_count(), 4000);
         Ok(())
     }
 }

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -174,6 +174,8 @@ impl FilterKernel for List {
                     unsafe { new_offsets.push_unchecked(offset) };
                 }
 
+                // TODO(ngates): for very dense masks, there may be no point in filtering the elements,
+                //  and instead we should construct a view against the unfiltered elements.
                 let (element_range, range_is_subinterval) =
                     element_range_from_offsets::<O>(offsets, selection);
                 let element_mask =


### PR DESCRIPTION
## Summary

Avoid expanding ListArray element masks over large unselected prefixes and suffixes. For lists averaging more than 1,024 elements per sublist, filter the child slice spanning the first through last selected list instead of the complete element range.

## Example

Suppose a ListArray contains eight sublists with 2,000 elements each, and the outer filter selects rows 3 and 4. The existing path expands the mask across all 16,000 child elements. This change slices elements 6,000..10,000 and expands the mask across only those 4,000 elements.

If the selected rows span the complete element range, the optimization keeps the existing full-range path.