### PR TITLE
Trim constant-operand cases from scalar function benchmarks

### DIFF
--- a/vortex-array/benches/binary_ops.rs
+++ b/vortex-array/benches/binary_ops.rs
@@ -61,12 +61,19 @@ const I16_LEN: usize = primitive_len::<i16>();
 const I32_LEN: usize = primitive_len::<i32>();
 const I64_LEN: usize = primitive_len::<i64>();
 
+/// Per-row against per-row, short and long. This is the shape the operators are tuned for, so it
+/// is the one every operator is measured on.
 const BINARY_SHAPE_CASES: &[(usize, BinaryShape)] = &[
     (128, BinaryShape::PerRowPerRow),
-    (128, BinaryShape::PerRowConstant),
-    (128, BinaryShape::ConstantPerRow),
-    (128, BinaryShape::PerRowNullableConstant),
     (I64_LEN, BinaryShape::PerRowPerRow),
+];
+
+/// Constant operands are measured on `Add` alone, at the long length.
+///
+/// Decoding a constant operand, orienting it, and carrying its validity are shared by every
+/// operator, so repeating all three shapes under `Sub` and `Mul` costs three walltime legs apiece
+/// and measures the same code again. These cases stay as the regression guard on that path.
+const CONSTANT_SHAPE_CASES: &[(usize, BinaryShape)] = &[
     (I64_LEN, BinaryShape::PerRowConstant),
     (I64_LEN, BinaryShape::ConstantPerRow),
     (I64_LEN, BinaryShape::PerRowNullableConstant),
@@ -87,6 +94,12 @@ const DECIMAL_MUL_DIV_LEN: usize = 1_024;
 #[vortex_bench_support::cpu_features]
 #[divan::bench(args = BINARY_SHAPE_CASES)]
 fn add_shapes(bencher: Bencher, &(len, shape): &(usize, BinaryShape)) {
+    bench_binary_shape(bencher, len, shape, Operator::Add);
+}
+
+#[vortex_bench_support::cpu_features]
+#[divan::bench(args = CONSTANT_SHAPE_CASES)]
+fn add_constant_shapes(bencher: Bencher, &(len, shape): &(usize, BinaryShape)) {
     bench_binary_shape(bencher, len, shape, Operator::Add);
 }
 
@@ -132,15 +145,6 @@ fn add_i64_nonnull(bencher: Bencher) {
 fn add_i64_nullable(bencher: Bencher) {
     let lhs = primitive_nullable(0, 7, I64_LEN).into_array();
     let rhs = primitive_nullable(1_000_000, 5, I64_LEN).into_array();
-
-    bench_primitive(bencher, lhs, rhs, Operator::Add);
-}
-
-#[vortex_bench_support::cpu_features]
-#[divan::bench]
-fn add_i64_constant(bencher: Bencher) {
-    let lhs = primitive_nonnull(0, I64_LEN).into_array();
-    let rhs = ConstantArray::new(1_000_000i64, I64_LEN).into_array();
 
     bench_primitive(bencher, lhs, rhs, Operator::Add);
 }
@@ -246,15 +250,6 @@ fn mul_i32_nullable(bencher: Bencher) {
 
 #[vortex_bench_support::cpu_features]
 #[divan::bench]
-fn mul_i32_constant(bencher: Bencher) {
-    let lhs = primitive_i32_small_nonnull(1, I32_LEN).into_array();
-    let rhs = ConstantArray::new(31i32, I32_LEN).into_array();
-
-    bench_primitive(bencher, lhs, rhs, Operator::Mul);
-}
-
-#[vortex_bench_support::cpu_features]
-#[divan::bench]
 fn div_i64_nonnull(bencher: Bencher) {
     let lhs = primitive_nonnull(1_000_000, I64_LEN).into_array();
     let rhs = primitive_nonzero(I64_LEN).into_array();
@@ -269,15 +264,6 @@ fn div_i64_nullable(bencher: Bencher) {
     let rhs = primitive_nullable(17, 5, I64_LEN).into_array();
 
     bench_primitive(bencher, lhs, rhs, Operator::Div);
-}
-
-#[vortex_bench_support::cpu_features]
-#[divan::bench]
-fn sub_i64_constant(bencher: Bencher) {
-    let lhs = primitive_nonnull(0, I64_LEN).into_array();
-    let rhs = ConstantArray::new(37i64, I64_LEN).into_array();
-
-    bench_primitive(bencher, lhs, rhs, Operator::Sub);
 }
 
 #[divan::bench]
@@ -330,15 +316,6 @@ fn div_decimal_i128_nullable(bencher: Bencher) {
 
 #[vortex_bench_support::cpu_features]
 #[divan::bench]
-fn eq_i64_constant(bencher: Bencher) {
-    let lhs = primitive_nonnull(0, LEN).into_array();
-    let rhs = ConstantArray::new(1024i64, LEN).into_array();
-
-    bench_bool(bencher, lhs, rhs, Operator::Eq);
-}
-
-#[vortex_bench_support::cpu_features]
-#[divan::bench]
 fn lt_i64_nullable(bencher: Bencher) {
     let lhs = primitive_nullable(0, 7, LEN).into_array();
     let rhs = primitive_nullable(1_000_000, 5, LEN).into_array();
@@ -352,14 +329,6 @@ fn and_bool_nullable(bencher: Bencher) {
     let rhs = bool_nullable(3, 5).into_array();
 
     bench_bool(bencher, lhs, rhs, Operator::And);
-}
-
-#[divan::bench]
-fn or_bool_constant(bencher: Bencher) {
-    let lhs = bool_nullable(2, 7).into_array();
-    let rhs = ConstantArray::new(true, LEN).into_array();
-
-    bench_bool(bencher, lhs, rhs, Operator::Or);
 }
 
 fn bench_primitive(bencher: Bencher, lhs: ArrayRef, rhs: ArrayRef, operator: Operator) {

--- a/vortex-array/benches/compare.rs
+++ b/vortex-array/benches/compare.rs
@@ -10,6 +10,11 @@
 //! selected through `cfg(target_feature)` has to beat, measured on the silicon it would run
 //! on.
 //!
+//! Every case here compares one array against another, which is the shape the path is tuned for.
+//! The three constant cases that remain — boolean, integer, and string — are a regression guard on
+//! constant handling rather than coverage of it: a constant operand is decoded the same way
+//! whatever it holds. Constant orientation is measured once, in `binary_ops.rs`.
+//!
 //! The boolean, decimal, string, and struct cases are not tagged. A wider vector register is
 //! not what decides them: booleans are already word-at-a-time over a bitmap, decimals are
 //! `i128`, and the string and struct cases are dominated by view chasing and per-field
@@ -194,15 +199,6 @@ fn compare_int_constant(bencher: Bencher) {
     let arr = int_array(&mut rng);
     let constant = ConstantArray::new(50_000_000i64, ARRAY_SIZE).into_array();
     bench_compare(bencher, arr, constant, Operator::Gte);
-}
-
-#[vortex_bench_support::cpu_features]
-#[divan::bench]
-fn compare_int_constant_left(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(0);
-    let constant = ConstantArray::new(50_000_000i64, ARRAY_SIZE).into_array();
-    let arr = int_array(&mut rng);
-    bench_compare(bencher, constant, arr, Operator::Lte);
 }
 
 #[vortex_bench_support::cpu_features]

--- a/vortex-array/benches/row_fn_output.rs
+++ b/vortex-array/benches/row_fn_output.rs
@@ -44,11 +44,17 @@ static SESSION: LazyLock<VortexSession> = LazyLock::new(array_session);
 
 const ROWS: usize = 1 << 14;
 
-const INPUT_SHAPES: &[InputShape] = &[
-    InputShape::PerRowPerRow,
-    InputShape::PerRowConstant,
-    InputShape::ConstantPerRow,
-];
+/// The shape every row function is measured on: one per-row operand against another.
+const INPUT_SHAPES: &[InputShape] = &[InputShape::PerRowPerRow];
+
+/// Constant operands are measured on `i64` alone, by the `*_constant` benchmarks below.
+///
+/// The row executor decodes and orients a constant operand the same way whatever the row kernel
+/// does with the value, so running both constant orientations under every element type and every
+/// output mode measures one path repeatedly, three walltime legs at a time. One infallible pair and
+/// one deferred pair keep it covered: those two differ in how a constant row reaches the kernel,
+/// and that is the difference worth watching.
+const CONSTANT_SHAPES: &[InputShape] = &[InputShape::PerRowConstant, InputShape::ConstantPerRow];
 
 #[derive(Clone, Copy, Debug)]
 enum InputShape {
@@ -183,10 +189,24 @@ fn infallible_bool<T: BenchPrimitive>(bencher: Bencher, &shape: &InputShape) {
 }
 
 #[vortex_bench_support::cpu_features]
+#[divan::bench(args = CONSTANT_SHAPES)]
+fn infallible_bool_constant(bencher: Bencher, &shape: &InputShape) {
+    let function = InfallibleBool::<i64>(PhantomData);
+    bench_row_fn(bencher, &function, make_args::<i64>(shape));
+}
+
+#[vortex_bench_support::cpu_features]
 #[divan::bench(types = [i32, i64], args = INPUT_SHAPES)]
 fn deferred_bool<T: BenchPrimitive>(bencher: Bencher, &shape: &InputShape) {
     let function = DeferredBool::<T>(PhantomData);
     bench_row_fn(bencher, &function, make_args::<T>(shape));
+}
+
+#[vortex_bench_support::cpu_features]
+#[divan::bench(args = CONSTANT_SHAPES)]
+fn deferred_bool_constant(bencher: Bencher, &shape: &InputShape) {
+    let function = DeferredBool::<i64>(PhantomData);
+    bench_row_fn(bencher, &function, make_args::<i64>(shape));
 }
 
 #[vortex_bench_support::cpu_features]


### PR DESCRIPTION
## Summary

- Tracking issue: #9128

The scalar function benchmarks carried 37 cases with a constant operand, 34 of them tagged `#[cpu_features]` and so measured on three walltime legs each. Decoding a constant operand, orienting it, and carrying its validity are shared across operators, element types, and output modes, so most of those cases measure the same path again and crowd out the per-row against per-row shape the kernels are tuned for.

Or in other words, just reduces the # of constant benchmarks we have. Ideally we would keep this, but because they are so noisy we might as well just remove them.

## Changes

Keeps 10 constant cases as a regression guard on that path, 8 of them tagged, and makes per-row against per-row the default shape everywhere else.