### PR TITLE
Add HigherOrderFn infrastructure

### DIFF
--- a/vortex-array/src/higher_order_fn/erased.rs
+++ b/vortex-array/src/higher_order_fn/erased.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::any::type_name;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::sync::Arc;
+
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_error::vortex_err;
+use vortex_utils::debug_with::DebugWith;
+
+use crate::higher_order_fn::HigherOrderFnId;
+use crate::higher_order_fn::HigherOrderFnOptions;
+use crate::higher_order_fn::HigherOrderFnVTable;
+use crate::higher_order_fn::TypedHigherOrderFnInstance;
+use crate::higher_order_fn::typed::DynHigherOrderFn;
+use crate::scalar_fn::Arity;
+use crate::scalar_fn::ChildName;
+
+/// A type-erased higher-order function, pairing a vtable with per-call options.
+#[derive(Clone)]
+pub struct HigherOrderFnRef(pub(super) Arc<dyn DynHigherOrderFn>);
+
+impl HigherOrderFnRef {
+    /// Bind `vtable` with its per-call `options`.
+    pub fn new<V: HigherOrderFnVTable>(vtable: V, options: V::Options) -> Self {
+        TypedHigherOrderFnInstance::new(vtable, options).erased()
+    }
+
+    /// The function's global identifier.
+    pub fn id(&self) -> HigherOrderFnId {
+        self.0.id()
+    }
+
+    /// Whether this function uses vtable `V`.
+    pub fn is<V: HigherOrderFnVTable>(&self) -> bool {
+        self.0.as_any().is::<TypedHigherOrderFnInstance<V>>()
+    }
+
+    /// Return typed options when this function uses vtable `V`.
+    pub fn as_opt<V: HigherOrderFnVTable>(&self) -> Option<&V::Options> {
+        self.0
+            .as_any()
+            .downcast_ref::<TypedHigherOrderFnInstance<V>>()
+            .map(TypedHigherOrderFnInstance::options)
+    }
+
+    /// Return typed options for vtable `V`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this function does not use vtable `V`.
+    pub fn as_<V: HigherOrderFnVTable>(&self) -> &V::Options {
+        self.as_opt::<V>()
+            .vortex_expect("higher-order function options type mismatch")
+    }
+
+    /// Return these options behind an opaque type-erased handle.
+    pub fn options(&self) -> HigherOrderFnOptions<'_> {
+        HigherOrderFnOptions { inner: &*self.0 }
+    }
+
+    /// Return the arity of the ordinary arguments.
+    pub fn arity(&self) -> Arity {
+        self.0.arity()
+    }
+
+    /// Return the number of lambda arguments.
+    pub fn lambda_arity(&self) -> usize {
+        self.0.lambda_arity()
+    }
+
+    /// Return the name of an ordinary argument.
+    pub fn child_name(&self, child_idx: usize) -> ChildName {
+        self.0.child_name(child_idx)
+    }
+
+    /// Serialize the per-call options.
+    pub fn serialize(&self) -> VortexResult<Option<Vec<u8>>> {
+        self.0.options_serialize()
+    }
+
+    /// Downcast this function to its typed representation.
+    pub fn try_downcast<V: HigherOrderFnVTable>(
+        self,
+    ) -> Result<Arc<TypedHigherOrderFnInstance<V>>, Self> {
+        if self.is::<V>() {
+            let ptr = Arc::into_raw(self.0) as *const TypedHigherOrderFnInstance<V>;
+            Ok(unsafe { Arc::from_raw(ptr) })
+        } else {
+            Err(self)
+        }
+    }
+
+    /// Downcast this function to its typed representation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this function does not use vtable `V`.
+    pub fn downcast<V: HigherOrderFnVTable>(self) -> Arc<TypedHigherOrderFnInstance<V>> {
+        self.try_downcast::<V>()
+            .map_err(|function| {
+                vortex_err!(
+                    "failed to downcast higher-order function {} to {}",
+                    function.id(),
+                    type_name::<V>(),
+                )
+            })
+            .vortex_expect("failed to downcast higher-order function")
+    }
+}
+
+impl Debug for HigherOrderFnRef {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HigherOrderFnRef")
+            .field("vtable", &self.id())
+            .field("options", &DebugWith(|fmt| self.0.options_debug(fmt)))
+            .finish()
+    }
+}
+
+impl Display for HigherOrderFnRef {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}(", self.id())?;
+        self.0.options_display(f)?;
+        write!(f, ")")
+    }
+}
+
+impl PartialEq for HigherOrderFnRef {
+    fn eq(&self, other: &Self) -> bool {
+        self.id() == other.id() && self.0.options_eq(other.0.options_any())
+    }
+}
+
+impl Eq for HigherOrderFnRef {}
+
+impl Hash for HigherOrderFnRef {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id().hash(state);
+        self.0.options_hash(state);
+    }
+}

--- a/vortex-array/src/higher_order_fn/mod.rs
+++ b/vortex-array/src/higher_order_fn/mod.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Higher-order function vtable machinery.
+//!
+//! Higher-order functions accept ordinary arguments and lambda arguments. This module provides
+//! their identity, type erasure, per-call options, and session registry.
+
+use vortex_session::registry::Id;
+
+mod erased;
+pub use erased::HigherOrderFnRef;
+
+mod options;
+pub use options::HigherOrderFnOptions;
+
+mod typed;
+pub use typed::TypedHigherOrderFnInstance;
+
+mod plugin;
+pub use plugin::*;
+
+pub mod session;
+
+mod vtable;
+pub use vtable::*;
+
+/// A globally unique identifier for a higher-order function.
+pub type HigherOrderFnId = Id;

--- a/vortex-array/src/higher_order_fn/options.rs
+++ b/vortex-array/src/higher_order_fn/options.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::any::Any;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::hash::Hash;
+use std::hash::Hasher;
+
+use vortex_error::VortexResult;
+
+use crate::higher_order_fn::typed::DynHigherOrderFn;
+
+/// An opaque handle to the options of a higher-order function.
+pub struct HigherOrderFnOptions<'a> {
+    pub(super) inner: &'a dyn DynHigherOrderFn,
+}
+
+impl Display for HigherOrderFnOptions<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.options_display(f)
+    }
+}
+
+impl Debug for HigherOrderFnOptions<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.options_debug(f)
+    }
+}
+
+impl PartialEq for HigherOrderFnOptions<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.id() == other.inner.id() && self.inner.options_eq(other.inner.options_any())
+    }
+}
+
+impl Eq for HigherOrderFnOptions<'_> {}
+
+impl Hash for HigherOrderFnOptions<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inner.id().hash(state);
+        self.inner.options_hash(state);
+    }
+}
+
+impl HigherOrderFnOptions<'_> {
+    /// Serialize these options to a byte vector.
+    pub fn serialize(&self) -> VortexResult<Option<Vec<u8>>> {
+        self.inner.options_serialize()
+    }
+
+    /// Return the underlying typed options as [`Any`].
+    pub fn as_any(&self) -> &dyn Any {
+        self.inner.options_any()
+    }
+}

--- a/vortex-array/src/higher_order_fn/plugin.rs
+++ b/vortex-array/src/higher_order_fn/plugin.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::sync::Arc;
+
+use vortex_error::VortexResult;
+use vortex_session::VortexSession;
+
+use crate::higher_order_fn::HigherOrderFnId;
+use crate::higher_order_fn::HigherOrderFnRef;
+use crate::higher_order_fn::HigherOrderFnVTable;
+use crate::higher_order_fn::TypedHigherOrderFnInstance;
+
+/// Reference-counted pointer to a higher-order function plugin.
+pub type HigherOrderFnPluginRef = Arc<dyn HigherOrderFnPlugin>;
+
+/// Registry trait for ID-based deserialization of higher-order functions.
+pub trait HigherOrderFnPlugin: 'static + Send + Sync {
+    /// Return the ID for this higher-order function.
+    fn id(&self) -> HigherOrderFnId;
+
+    /// Deserialize a higher-order function from serialized metadata.
+    fn deserialize(
+        &self,
+        metadata: &[u8],
+        session: &VortexSession,
+    ) -> VortexResult<HigherOrderFnRef>;
+}
+
+impl std::fmt::Debug for dyn HigherOrderFnPlugin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("HigherOrderFnPlugin")
+            .field(&self.id())
+            .finish()
+    }
+}
+
+impl<V: HigherOrderFnVTable> HigherOrderFnPlugin for V {
+    fn id(&self) -> HigherOrderFnId {
+        V::id(self)
+    }
+
+    fn deserialize(
+        &self,
+        metadata: &[u8],
+        session: &VortexSession,
+    ) -> VortexResult<HigherOrderFnRef> {
+        let options = HigherOrderFnVTable::deserialize(self, metadata, session)?;
+        Ok(TypedHigherOrderFnInstance::new(self.clone(), options).erased())
+    }
+}

--- a/vortex-array/src/higher_order_fn/session.rs
+++ b/vortex-array/src/higher_order_fn/session.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::any::Any;
+use std::sync::Arc;
+
+use vortex_session::ArcSwapMap;
+use vortex_session::SessionExt;
+use vortex_session::SessionGuard;
+use vortex_session::SessionVar;
+
+use crate::higher_order_fn::HigherOrderFnId;
+use crate::higher_order_fn::HigherOrderFnPluginRef;
+use crate::higher_order_fn::HigherOrderFnVTable;
+
+/// Registry of higher-order function vtables.
+pub type HigherOrderFnRegistry = ArcSwapMap<HigherOrderFnId, HigherOrderFnPluginRef>;
+
+/// Session state for higher-order function vtables.
+#[derive(Clone, Debug, Default)]
+pub struct HigherOrderFnSession {
+    registry: HigherOrderFnRegistry,
+}
+
+impl HigherOrderFnSession {
+    pub fn registry(&self) -> &HigherOrderFnRegistry {
+        &self.registry
+    }
+
+    /// Register a vtable, replacing any existing vtable with the same ID.
+    pub fn register<V: HigherOrderFnVTable>(&self, vtable: V) {
+        self.registry
+            .insert(vtable.id(), Arc::new(vtable) as HigherOrderFnPluginRef);
+    }
+}
+
+impl SessionVar for HigherOrderFnSession {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// Extension trait for accessing higher-order-function session state.
+pub trait HigherOrderFnSessionExt: SessionExt {
+    /// Return the higher-order function vtable registry.
+    fn higher_order_fns(&self) -> SessionGuard<'_, HigherOrderFnSession> {
+        self.get::<HigherOrderFnSession>()
+    }
+}
+
+impl<S: SessionExt> HigherOrderFnSessionExt for S {}

--- a/vortex-array/src/higher_order_fn/typed.rs
+++ b/vortex-array/src/higher_order_fn/typed.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::any::Any;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::hash::Hasher;
+use std::sync::Arc;
+
+use vortex_error::VortexResult;
+
+use crate::higher_order_fn::HigherOrderFnId;
+use crate::higher_order_fn::HigherOrderFnRef;
+use crate::higher_order_fn::HigherOrderFnVTable;
+use crate::scalar_fn::Arity;
+use crate::scalar_fn::ChildName;
+
+/// A typed higher-order-function instance, pairing a vtable with per-call options.
+pub struct TypedHigherOrderFnInstance<V: HigherOrderFnVTable> {
+    vtable: V,
+    options: V::Options,
+}
+
+impl<V: HigherOrderFnVTable> TypedHigherOrderFnInstance<V> {
+    /// Create a typed higher-order-function instance.
+    pub fn new(vtable: V, options: V::Options) -> Self {
+        Self { vtable, options }
+    }
+
+    /// Return the vtable.
+    pub fn vtable(&self) -> &V {
+        &self.vtable
+    }
+
+    /// Return the typed options.
+    pub fn options(&self) -> &V::Options {
+        &self.options
+    }
+
+    /// Erase the concrete type information.
+    pub fn erased(self) -> HigherOrderFnRef {
+        HigherOrderFnRef(Arc::new(self))
+    }
+}
+
+pub(super) trait DynHigherOrderFn: 'static + Send + Sync {
+    fn as_any(&self) -> &dyn Any;
+    fn id(&self) -> HigherOrderFnId;
+    fn options_any(&self) -> &dyn Any;
+    fn arity(&self) -> Arity;
+    fn lambda_arity(&self) -> usize;
+    fn child_name(&self, child_idx: usize) -> ChildName;
+    fn options_serialize(&self) -> VortexResult<Option<Vec<u8>>>;
+    fn options_eq(&self, other_options: &dyn Any) -> bool;
+    fn options_hash(&self, hasher: &mut dyn Hasher);
+    fn options_display(&self, f: &mut Formatter<'_>) -> std::fmt::Result;
+    fn options_debug(&self, f: &mut Formatter<'_>) -> std::fmt::Result;
+}
+
+impl<V: HigherOrderFnVTable> DynHigherOrderFn for TypedHigherOrderFnInstance<V> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn id(&self) -> HigherOrderFnId {
+        V::id(&self.vtable)
+    }
+
+    fn options_any(&self) -> &dyn Any {
+        &self.options
+    }
+
+    fn arity(&self) -> Arity {
+        V::arity(&self.vtable, &self.options)
+    }
+
+    fn lambda_arity(&self) -> usize {
+        V::lambda_arity(&self.vtable, &self.options)
+    }
+
+    fn child_name(&self, child_idx: usize) -> ChildName {
+        V::child_name(&self.vtable, &self.options, child_idx)
+    }
+
+    fn options_serialize(&self) -> VortexResult<Option<Vec<u8>>> {
+        V::serialize(&self.vtable, &self.options)
+    }
+
+    fn options_eq(&self, other_options: &dyn Any) -> bool {
+        other_options
+            .downcast_ref::<V::Options>()
+            .is_some_and(|options| self.options == *options)
+    }
+
+    fn options_hash(&self, mut hasher: &mut dyn Hasher) {
+        std::hash::Hash::hash(&self.options, &mut hasher);
+    }
+
+    fn options_display(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.options, f)
+    }
+
+    fn options_debug(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.options, f)
+    }
+}

--- a/vortex-array/src/higher_order_fn/vtable.rs
+++ b/vortex-array/src/higher_order_fn/vtable.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::hash::Hash;
+
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_session::VortexSession;
+
+use crate::higher_order_fn::HigherOrderFnId;
+use crate::higher_order_fn::HigherOrderFnRef;
+use crate::scalar_fn::Arity;
+use crate::scalar_fn::ChildName;
+
+/// The identity and options contract for a higher-order function.
+///
+/// A higher-order function accepts ordinary arguments and lambda arguments. This core vtable
+/// describes their arities and provides type-erased option storage and serialization. Expression
+/// binding and execution are layered on top separately.
+pub trait HigherOrderFnVTable: 'static + Sized + Clone + Send + Sync {
+    /// Per-call options for this higher-order function.
+    type Options: 'static + Send + Sync + Clone + Debug + Display + PartialEq + Eq + Hash;
+
+    /// The globally unique identifier for this higher-order function.
+    fn id(&self) -> HigherOrderFnId;
+
+    /// Serialize the per-call options.
+    fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
+        _ = options;
+        Ok(None)
+    }
+
+    /// Deserialize per-call options.
+    fn deserialize(
+        &self,
+        _metadata: &[u8],
+        _session: &VortexSession,
+    ) -> VortexResult<Self::Options> {
+        vortex_bail!("higher-order function {} is not deserializable", self.id());
+    }
+
+    /// The arity of the ordinary arguments.
+    fn arity(&self, options: &Self::Options) -> Arity;
+
+    /// The number of lambda arguments.
+    fn lambda_arity(&self, options: &Self::Options) -> usize;
+
+    /// The name of an ordinary argument.
+    fn child_name(&self, options: &Self::Options, child_idx: usize) -> ChildName;
+}
+
+/// Empty higher-order-function options.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct EmptyOptions;
+
+impl Display for EmptyOptions {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("")
+    }
+}
+
+/// Factory methods for higher-order function vtables.
+pub trait HigherOrderFnVTableExt: HigherOrderFnVTable {
+    /// Bind this vtable with the given options into a [`HigherOrderFnRef`].
+    fn bind(&self, options: Self::Options) -> HigherOrderFnRef {
+        HigherOrderFnRef::new(self.clone(), options)
+    }
+}
+
+impl<V: HigherOrderFnVTable> HigherOrderFnVTableExt for V {}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Display;
+    use std::fmt::Formatter;
+
+    use vortex_error::VortexExpect;
+    use vortex_error::VortexResult;
+    use vortex_error::vortex_bail;
+    use vortex_session::registry::CachedId;
+
+    use super::*;
+    use crate::array_session;
+    use crate::higher_order_fn::session::HigherOrderFnSessionExt;
+
+    #[derive(Clone, Debug)]
+    struct TestHigherOrderFn;
+
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    struct TestOptions(&'static str);
+
+    impl Display for TestOptions {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            f.write_str(self.0)
+        }
+    }
+
+    impl HigherOrderFnVTable for TestHigherOrderFn {
+        type Options = TestOptions;
+
+        fn id(&self) -> HigherOrderFnId {
+            static ID: CachedId = CachedId::new("vortex.test.higher_order");
+            *ID
+        }
+
+        fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
+            Ok(Some(options.0.as_bytes().to_vec()))
+        }
+
+        fn deserialize(
+            &self,
+            metadata: &[u8],
+            _session: &VortexSession,
+        ) -> VortexResult<Self::Options> {
+            match metadata {
+                b"strategy=checked" => Ok(TestOptions("strategy=checked")),
+                _ => vortex_bail!("unknown test higher-order function options"),
+            }
+        }
+
+        fn arity(&self, _options: &Self::Options) -> Arity {
+            Arity::Exact(1)
+        }
+
+        fn lambda_arity(&self, _options: &Self::Options) -> usize {
+            1
+        }
+
+        fn child_name(&self, _options: &Self::Options, _child_idx: usize) -> ChildName {
+            ChildName::from("input")
+        }
+    }
+
+    #[test]
+    fn bound_function_exposes_vtable_metadata_and_options() -> VortexResult<()> {
+        let function = TestHigherOrderFn.bind(TestOptions("strategy=checked"));
+
+        assert!(function.is::<TestHigherOrderFn>());
+        assert_eq!(
+            function.as_::<TestHigherOrderFn>(),
+            &TestOptions("strategy=checked")
+        );
+        assert_eq!(function.arity(), Arity::Exact(1));
+        assert_eq!(function.lambda_arity(), 1);
+        assert_eq!(function.child_name(0), ChildName::from("input"));
+        assert_eq!(function.serialize()?, Some(b"strategy=checked".to_vec()));
+        assert_eq!(
+            function.to_string(),
+            "vortex.test.higher_order(strategy=checked)"
+        );
+        assert_ne!(
+            function,
+            TestHigherOrderFn.bind(TestOptions("strategy=unchecked"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn session_plugin_deserializes_bound_options() -> VortexResult<()> {
+        let session = array_session();
+        session.higher_order_fns().register(TestHigherOrderFn);
+        let plugin = session
+            .higher_order_fns()
+            .registry()
+            .get(&HigherOrderFnVTable::id(&TestHigherOrderFn))
+            .vortex_expect("test higher-order function is registered");
+
+        let function = plugin.deserialize(b"strategy=checked", &session)?;
+        assert_eq!(
+            function.as_::<TestHigherOrderFn>(),
+            &TestOptions("strategy=checked")
+        );
+        Ok(())
+    }
+}

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -96,6 +96,7 @@ use vortex_session::registry::Interner;
 
 use crate::aggregate_fn::session::AggregateFnSession;
 use crate::dtype::session::DTypeSession;
+use crate::higher_order_fn::session::HigherOrderFnSession;
 use crate::memory::MemorySession;
 use crate::optimizer::kernels::KernelSession;
 use crate::scalar_fn::session::ScalarFnSession;
@@ -122,6 +123,7 @@ pub mod expr;
 mod expression;
 pub mod extension;
 mod hash;
+pub mod higher_order_fn;
 pub mod iter;
 pub mod kernel;
 pub mod mask;
@@ -175,6 +177,7 @@ pub fn array_session() -> VortexSession {
         .with::<KernelSession>()
         .with::<DTypeSession>()
         .with::<ScalarFnSession>()
+        .with::<HigherOrderFnSession>()
         .with::<StatsSession>()
         .with::<AggregateFnSession>()
         .with::<MemorySession>()


### PR DESCRIPTION
## Summary

- introduce the HigherOrderFn vtable, typed instance, erased reference, and per-call options
- add plugin and session registries for ID-based option deserialization
- register higher-order function state in the array session
- leave expression representation, binding, serialization, and execution to follow-up PRs

## Testing

- `cargo nextest run -p vortex-array` (3,462 passed; 1 skipped)
- `cargo clippy -p vortex-array --all-targets --all-features`
- `cargo test --doc -p vortex-array`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`