### PR TITLE
Avoid materializing constant structs for get_item

### DIFF
--- a/vortex-array/src/scalar_fn/fns/get_item.rs
+++ b/vortex-array/src/scalar_fn/fns/get_item.rs
@@ -13,6 +13,9 @@ use vortex_session::registry::CachedId;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::IntoArray;
+use crate::arrays::Constant;
+use crate::arrays::ConstantArray;
 use crate::arrays::ScalarFnArray;
 use crate::arrays::StructArray;
 use crate::arrays::struct_::StructArrayExt;
@@ -24,6 +27,7 @@ use crate::dtype::Nullability;
 use crate::expr::Expression;
 use crate::expr::display::ExprDisplay;
 use crate::expr::lit;
+use crate::scalar::Scalar;
 use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::EmptyOptions;
@@ -126,7 +130,30 @@ impl ScalarFnVTable for GetItem {
         args: &dyn ExecutionArgs,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let input = args.get(0)?.execute::<StructArray>(ctx)?;
+        let input = args.get(0)?;
+        if let Some(constant) = input.as_opt::<Constant>() {
+            let dtype = self.return_dtype(field_name, &[input.dtype().clone()])?;
+            let scalar = if constant.scalar().is_null() {
+                Scalar::null(dtype)
+            } else {
+                constant
+                    .scalar()
+                    .as_struct()
+                    .field(field_name)
+                    .ok_or_else(|| {
+                        vortex_err!(
+                            "Field '{}' missing from constant struct array {}",
+                            field_name,
+                            input.dtype()
+                        )
+                    })?
+                    .cast(&dtype)?
+            };
+
+            return Ok(ConstantArray::new(scalar, input.len()).into_array());
+        }
+
+        let input = input.execute::<StructArray>(ctx)?;
         let field = input.unmasked_field_by_name(field_name).cloned()?;
 
         match input.dtype().nullability() {
@@ -210,8 +237,14 @@ mod tests {
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
 
+    use super::GetItem;
+    use crate::ArrayRef;
     use crate::IntoArray;
+    use crate::VortexSessionExecute;
+    use crate::arrays::Constant;
+    use crate::arrays::ConstantArray;
     use crate::dtype::DType;
+    use crate::dtype::FieldName;
     use crate::dtype::FieldNames;
     use crate::dtype::Nullability;
     use crate::dtype::Nullability::NonNullable;
@@ -222,6 +255,7 @@ mod tests {
     use crate::expr::lit;
     use crate::expr::pack;
     use crate::expr::root;
+    use crate::scalar::Scalar;
     use crate::scalar_fn::fns::get_item::StructArray;
     use crate::validity::Validity;
 
@@ -287,6 +321,35 @@ mod tests {
         assert_eq!(
             item.dtype(),
             &DType::Primitive(PType::I32, Nullability::Nullable)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn execute_constant_struct_stays_constant() -> VortexResult<()> {
+        let field_count = 128usize;
+        let selected_idx = 97i32;
+        let names = (0..field_count)
+            .map(|idx| FieldName::from(format!("f{idx}")))
+            .collect::<Vec<_>>();
+        let dtypes = vec![DType::Primitive(PType::I32, NonNullable); field_count];
+        let fields = StructFields::new(FieldNames::from(names), dtypes);
+        let scalar = Scalar::struct_(
+            DType::Struct(fields, NonNullable),
+            (0..128).map(|idx| Scalar::primitive(idx, NonNullable)),
+        );
+        let array = ConstantArray::new(scalar, 1_000_000).into_array();
+        let mut ctx = crate::array_session().create_execution_ctx();
+
+        let item: ArrayRef = GetItem::try_new(array, "f97")?
+            .into_array()
+            .execute(&mut ctx)?;
+
+        let constant = item.as_::<Constant>();
+        assert_eq!(constant.len(), 1_000_000);
+        assert_eq!(
+            constant.scalar(),
+            &Scalar::primitive(selected_idx, NonNullable)
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- add a Constant/GetItem reduce-parent rule that extracts only the requested struct field scalar
- preserve GetItem output dtype/nullability by casting the selected scalar to the parent dtype
- add a regression test for selecting from a wide, million-row constant struct while keeping the result constant-encoded

## Tests
- cargo +nightly fmt --all
- cargo test -p vortex-array test_get_item_constant_struct_stays_constant
- cargo test -p vortex-array arrays::constant
- cargo clippy --all-targets --all-features