### PR TITLE
feat(list): push element projections through ListLayout via `list_get_item`

### DIFF
--- a/vortex-array/src/expr/exprs.rs
+++ b/vortex-array/src/expr/exprs.rs
@@ -39,6 +39,7 @@ use crate::scalar_fn::fns::is_null::IsNull;
 use crate::scalar_fn::fns::like::Like;
 use crate::scalar_fn::fns::like::LikeOptions;
 use crate::scalar_fn::fns::list_contains::ListContains;
+use crate::scalar_fn::fns::list_get_item::ListGetItem;
 use crate::scalar_fn::fns::list_length::ListLength;
 use crate::scalar_fn::fns::list_sum::ListSum;
 use crate::scalar_fn::fns::literal::Literal;
@@ -1155,6 +1156,26 @@ pub fn bound_ext_storage(input: BoundExpression) -> BoundExpression {
         .vortex_expect("extension-storage expressions require an extension child")
 }
 
+// ---- ListGetItem ----
+
+/// Creates an expression that projects a named field out of every list element, turning a
+/// `List<Struct{..., f, ...}>` input into `List<f>` while keeping the list shape and validity.
+///
+/// ```rust
+/// # use vortex_array::expr::{list_get_item, root};
+/// let expr = list_get_item("name", root());
+/// ```
+pub fn list_get_item(field: impl Into<FieldName>, input: Expression) -> Expression {
+    ListGetItem.new_expr(field.into(), [input])
+}
+
+/// Creates a bound expression that projects a named field out of every list element.
+pub fn bound_list_get_item(field: impl Into<FieldName>, input: BoundExpression) -> BoundExpression {
+    ListGetItem
+        .try_new_bound_expr(field.into(), [input])
+        .vortex_expect("list-get-item expressions require a list-of-struct child")
+}
+
 // ---- ListLength ----
 
 /// Creates an expression that computes the number of elements in each list
@@ -1246,6 +1267,7 @@ pub mod bound {
     pub use super::bound_is_null as is_null;
     pub use super::bound_like as like;
     pub use super::bound_list_contains as list_contains;
+    pub use super::bound_list_get_item as list_get_item;
     pub use super::bound_list_length as list_length;
     pub use super::bound_list_sum as list_sum;
     pub use super::bound_list_sum_opts as list_sum_opts;

--- a/vortex-array/src/expr/mod.rs
+++ b/vortex-array/src/expr/mod.rs
@@ -97,6 +97,7 @@ pub use exprs::is_null;
 pub use exprs::is_root;
 pub use exprs::like;
 pub use exprs::list_contains;
+pub use exprs::list_get_item;
 pub use exprs::list_length;
 pub use exprs::list_sum;
 pub use exprs::list_sum_opts;

--- a/vortex-array/src/scalar_fn/fns/list_get_item.rs
+++ b/vortex-array/src/scalar_fn/fns/list_get_item.rs
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use prost::Message;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
+use vortex_proto::expr as pb;
+use vortex_session::VortexSession;
+use vortex_session::registry::CachedId;
+
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::IntoArray;
+use crate::arrays::FixedSizeList;
+use crate::arrays::FixedSizeListArray;
+use crate::arrays::List;
+use crate::arrays::ListArray;
+use crate::arrays::ListView;
+use crate::arrays::ListViewArray;
+use crate::arrays::fixed_size_list::FixedSizeListArrayExt;
+use crate::arrays::fixed_size_list::FixedSizeListArraySlotsExt;
+use crate::arrays::list::ListArrayExt;
+use crate::arrays::list::ListArraySlotsExt;
+use crate::arrays::listview::ListViewArrayExt;
+use crate::arrays::listview::ListViewArraySlotsExt;
+use crate::dtype::DType;
+use crate::dtype::FieldName;
+use crate::dtype::Nullability;
+use crate::expr::Expression;
+use crate::expr::display::ExprDisplay;
+use crate::scalar_fn::Arity;
+use crate::scalar_fn::ChildName;
+use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::ScalarFnId;
+use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::fns::get_item::GetItem;
+use crate::scalar_fn::fns::list_length::AnyList;
+
+/// Element-wise field projection through a list: `List<Struct{..., f, ...}>` -> `List<f>`.
+///
+/// The list shape (offsets/sizes and validity) is carried over unchanged; only the elements
+/// child is narrowed to the requested struct field. Struct-level element nullability is folded
+/// into the projected field, mirroring [`GetItem`].
+#[derive(Clone)]
+pub struct ListGetItem;
+
+impl ScalarFnVTable for ListGetItem {
+    type Options = FieldName;
+
+    fn id(&self) -> ScalarFnId {
+        static ID: CachedId = CachedId::new("vortex.list.get_item");
+        *ID
+    }
+
+    fn serialize(&self, instance: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
+        Ok(Some(
+            pb::GetItemOpts {
+                path: instance.to_string(),
+            }
+            .encode_to_vec(),
+        ))
+    }
+
+    fn deserialize(
+        &self,
+        metadata: &[u8],
+        _session: &VortexSession,
+    ) -> VortexResult<Self::Options> {
+        let opts = pb::GetItemOpts::decode(metadata)?;
+        Ok(FieldName::from(opts.path))
+    }
+
+    fn arity(&self, _field_name: &FieldName) -> Arity {
+        Arity::Exact(1)
+    }
+
+    fn child_name(&self, _instance: &Self::Options, child_idx: usize) -> ChildName {
+        match child_idx {
+            0 => ChildName::from("input"),
+            _ => unreachable!("Invalid child index {child_idx} for list_get_item()"),
+        }
+    }
+
+    fn fmt_sql(
+        &self,
+        field_name: &FieldName,
+        expr: &dyn ExprDisplay,
+        f: &mut Formatter<'_>,
+    ) -> std::fmt::Result {
+        Display::fmt(expr.display_child(0), f)?;
+        write!(f, "[].{}", field_name)
+    }
+
+    fn return_dtype(&self, field_name: &FieldName, arg_dtypes: &[DType]) -> VortexResult<DType> {
+        let (element_dtype, rebuild): (&DType, &dyn Fn(DType) -> DType) = match &arg_dtypes[0] {
+            DType::List(element, nullability) => (element.as_ref(), &move |f| {
+                DType::List(f.into(), *nullability)
+            }),
+            DType::FixedSizeList(element, size, nullability) => (element.as_ref(), &move |f| {
+                DType::FixedSizeList(f.into(), *size, *nullability)
+            }),
+            other => vortex_bail!("list_get_item() requires a list input, got {other}"),
+        };
+
+        let field_dtype = element_dtype
+            .as_struct_fields_opt()
+            .and_then(|st| st.field(field_name))
+            .ok_or_else(|| {
+                vortex_err!(
+                    "list_get_item() couldn't find field {} in list element {}",
+                    field_name,
+                    element_dtype
+                )
+            })?;
+
+        // A nullable struct element makes the projected field nullable, mirroring GetItem.
+        let field_dtype = if matches!(
+            (element_dtype.nullability(), field_dtype.nullability()),
+            (Nullability::Nullable, Nullability::NonNullable)
+        ) {
+            field_dtype.with_nullability(Nullability::Nullable)
+        } else {
+            field_dtype
+        };
+
+        Ok(rebuild(field_dtype))
+    }
+
+    fn execute(
+        &self,
+        field_name: &FieldName,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let input = args.get(0)?;
+        let any_list = input.execute_until::<AnyList>(ctx)?;
+
+        if let Some(l) = any_list.as_opt::<List>() {
+            let projected = GetItem::try_new(l.elements().clone(), field_name.clone())?;
+            Ok(ListArray::try_new(
+                projected.into_array(),
+                l.offsets().clone(),
+                l.list_validity(),
+            )?
+            .into_array())
+        } else if let Some(lv) = any_list.as_opt::<ListView>() {
+            let projected = GetItem::try_new(lv.elements().clone(), field_name.clone())?;
+            Ok(ListViewArray::try_new(
+                projected.into_array(),
+                lv.offsets().clone(),
+                lv.sizes().clone(),
+                lv.listview_validity(),
+            )?
+            .into_array())
+        } else if let Some(fsl) = any_list.as_opt::<FixedSizeList>() {
+            let projected = GetItem::try_new(fsl.elements().clone(), field_name.clone())?;
+            let len = fsl.as_ref().len();
+            Ok(FixedSizeListArray::new(
+                projected.into_array(),
+                fsl.list_size(),
+                fsl.validity()?,
+                len,
+            )
+            .into_array())
+        } else {
+            let dtype = any_list.dtype();
+            vortex_bail!("list_get_item() requires List, ListView, or FixedSizeList, got {dtype}")
+        }
+    }
+
+    fn validity(
+        &self,
+        _field_name: &FieldName,
+        expression: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        // Row validity is the list validity, carried over from the input unchanged.
+        Ok(Some(expression.child(0).validity()?))
+    }
+
+    fn is_strict(&self, _field_name: &FieldName) -> bool {
+        true
+    }
+
+    fn is_infallible(&self, _field_name: &FieldName) -> bool {
+        // If this type-checks, it is infallible.
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
+
+    use crate::ArrayRef;
+    use crate::IntoArray;
+    use crate::VortexSessionExecute;
+    use crate::array_session;
+    use crate::arrays::BoolArray;
+    use crate::arrays::ListArray;
+    use crate::arrays::ListViewArray;
+    use crate::arrays::StructArray;
+    use crate::assert_arrays_eq;
+    use crate::dtype::DType;
+    use crate::dtype::Nullability;
+    use crate::dtype::PType;
+    use crate::expr::list_get_item;
+    use crate::expr::root;
+    use crate::validity::Validity;
+
+    /// 4 struct elements {a: i32, b: i64} in 3 lists of lengths [2, 1, 1].
+    fn create_list_of_structs(validity: Validity) -> ArrayRef {
+        let elements = StructArray::from_fields(&[
+            ("a", buffer![10i32, 11, 20, 30].into_array()),
+            ("b", buffer![-1i64, -2, -3, -4].into_array()),
+        ])
+        .unwrap()
+        .into_array();
+        ListArray::try_new(elements, buffer![0u32, 2, 3, 4].into_array(), validity)
+            .unwrap()
+            .into_array()
+    }
+
+    #[test]
+    fn projects_field_and_keeps_shape() -> VortexResult<()> {
+        let list = create_list_of_structs(Validity::NonNullable);
+        let result = list.apply(&list_get_item("a", root()))?;
+
+        assert_eq!(
+            result.dtype(),
+            &DType::List(
+                DType::Primitive(PType::I32, Nullability::NonNullable).into(),
+                Nullability::NonNullable
+            )
+        );
+
+        let expected = ListArray::try_new(
+            buffer![10i32, 11, 20, 30].into_array(),
+            buffer![0u32, 2, 3, 4].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn carries_list_validity() -> VortexResult<()> {
+        let validity = Validity::Array(BoolArray::from_iter([true, false, true]).into_array());
+        let list = create_list_of_structs(validity.clone());
+        let result = list.apply(&list_get_item("b", root()))?;
+
+        let expected = ListArray::try_new(
+            buffer![-1i64, -2, -3, -4].into_array(),
+            buffer![0u32, 2, 3, 4].into_array(),
+            validity,
+        )?
+        .into_array();
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn projects_through_listview() -> VortexResult<()> {
+        let elements = StructArray::from_fields(&[
+            ("a", buffer![10i32, 11, 20, 30].into_array()),
+            ("b", buffer![-1i64, -2, -3, -4].into_array()),
+        ])?
+        .into_array();
+        let lv = ListViewArray::try_new(
+            elements,
+            buffer![0u32, 2, 3].into_array(),
+            buffer![2u32, 1, 1].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let result = lv.apply(&list_get_item("a", root()))?;
+
+        let expected = ListArray::try_new(
+            buffer![10i32, 11, 20, 30].into_array(),
+            buffer![0u32, 2, 3, 4].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_field_fails_to_bind() {
+        let list = create_list_of_structs(Validity::NonNullable);
+        assert!(list.apply(&list_get_item("missing", root())).is_err());
+    }
+
+    #[test]
+    fn test_display() {
+        let expr = list_get_item("a", root());
+        assert_eq!(expr.to_string(), "$[].a");
+    }
+}

--- a/vortex-array/src/scalar_fn/fns/list_get_item.rs
+++ b/vortex-array/src/scalar_fn/fns/list_get_item.rs
@@ -21,6 +21,7 @@ use crate::arrays::List;
 use crate::arrays::ListArray;
 use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
+use crate::arrays::ScalarFnArray;
 use crate::arrays::fixed_size_list::FixedSizeListArrayExt;
 use crate::arrays::fixed_size_list::FixedSizeListArraySlotsExt;
 use crate::arrays::list::ListArrayExt;
@@ -37,6 +38,7 @@ use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
 use crate::scalar_fn::fns::get_item::GetItem;
 use crate::scalar_fn::fns::list_length::AnyList;
 
@@ -44,9 +46,74 @@ use crate::scalar_fn::fns::list_length::AnyList;
 ///
 /// The list shape (offsets/sizes and validity) is carried over unchanged; only the elements
 /// child is narrowed to the requested struct field. Struct-level element nullability is folded
-/// into the projected field, mirroring [`GetItem`].
+/// into the projected field, mirroring [`GetItem`]. Nested lists project recursively:
+/// `List<List<Struct{..., f, ...}>>` -> `List<List<f>>`, so a chain of `list_get_item`
+/// descends a struct/list tree the way a Parquet leaf path does.
 #[derive(Clone)]
 pub struct ListGetItem;
+
+impl ListGetItem {
+    /// Creates a lazy element-wise projection of `field_name` through the lists of `input`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `input` is not list-typed or its (transitively) innermost element
+    /// is not a struct containing `field_name`.
+    pub fn try_new(
+        input: ArrayRef,
+        field_name: impl Into<FieldName>,
+    ) -> VortexResult<ScalarFnArray> {
+        ScalarFnArray::try_new(ListGetItem.bind(field_name.into()), vec![input])
+    }
+}
+
+/// Project `field_name` out of a list's element dtype, descending nested lists.
+fn project_element_dtype(element_dtype: &DType, field_name: &FieldName) -> VortexResult<DType> {
+    match element_dtype {
+        DType::List(inner, nullability) => Ok(DType::List(
+            project_element_dtype(inner, field_name)?.into(),
+            *nullability,
+        )),
+        DType::FixedSizeList(inner, size, nullability) => Ok(DType::FixedSizeList(
+            project_element_dtype(inner, field_name)?.into(),
+            *size,
+            *nullability,
+        )),
+        _ => {
+            let field_dtype = element_dtype
+                .as_struct_fields_opt()
+                .and_then(|st| st.field(field_name))
+                .ok_or_else(|| {
+                    vortex_err!(
+                        "list_get_item() couldn't find field {} in list element {}",
+                        field_name,
+                        element_dtype
+                    )
+                })?;
+
+            // A nullable struct element makes the projected field nullable, mirroring GetItem.
+            if matches!(
+                (element_dtype.nullability(), field_dtype.nullability()),
+                (Nullability::Nullable, Nullability::NonNullable)
+            ) {
+                Ok(field_dtype.with_nullability(Nullability::Nullable))
+            } else {
+                Ok(field_dtype)
+            }
+        }
+    }
+}
+
+/// Lazily project `field_name` from a list's elements child: through a `GetItem` for struct
+/// elements, or a recursive `ListGetItem` for nested-list elements.
+fn project_elements(elements: &ArrayRef, field_name: &FieldName) -> VortexResult<ArrayRef> {
+    match elements.dtype() {
+        DType::List(..) | DType::FixedSizeList(..) => {
+            Ok(ListGetItem::try_new(elements.clone(), field_name.clone())?.into_array())
+        }
+        _ => Ok(GetItem::try_new(elements.clone(), field_name.clone())?.into_array()),
+    }
+}
 
 impl ScalarFnVTable for ListGetItem {
     type Options = FieldName;
@@ -96,38 +163,18 @@ impl ScalarFnVTable for ListGetItem {
     }
 
     fn return_dtype(&self, field_name: &FieldName, arg_dtypes: &[DType]) -> VortexResult<DType> {
-        let (element_dtype, rebuild): (&DType, &dyn Fn(DType) -> DType) = match &arg_dtypes[0] {
-            DType::List(element, nullability) => (element.as_ref(), &move |f| {
-                DType::List(f.into(), *nullability)
-            }),
-            DType::FixedSizeList(element, size, nullability) => (element.as_ref(), &move |f| {
-                DType::FixedSizeList(f.into(), *size, *nullability)
-            }),
+        match &arg_dtypes[0] {
+            DType::List(element, nullability) => Ok(DType::List(
+                project_element_dtype(element, field_name)?.into(),
+                *nullability,
+            )),
+            DType::FixedSizeList(element, size, nullability) => Ok(DType::FixedSizeList(
+                project_element_dtype(element, field_name)?.into(),
+                *size,
+                *nullability,
+            )),
             other => vortex_bail!("list_get_item() requires a list input, got {other}"),
-        };
-
-        let field_dtype = element_dtype
-            .as_struct_fields_opt()
-            .and_then(|st| st.field(field_name))
-            .ok_or_else(|| {
-                vortex_err!(
-                    "list_get_item() couldn't find field {} in list element {}",
-                    field_name,
-                    element_dtype
-                )
-            })?;
-
-        // A nullable struct element makes the projected field nullable, mirroring GetItem.
-        let field_dtype = if matches!(
-            (element_dtype.nullability(), field_dtype.nullability()),
-            (Nullability::Nullable, Nullability::NonNullable)
-        ) {
-            field_dtype.with_nullability(Nullability::Nullable)
-        } else {
-            field_dtype
-        };
-
-        Ok(rebuild(field_dtype))
+        }
     }
 
     fn execute(
@@ -140,32 +187,24 @@ impl ScalarFnVTable for ListGetItem {
         let any_list = input.execute_until::<AnyList>(ctx)?;
 
         if let Some(l) = any_list.as_opt::<List>() {
-            let projected = GetItem::try_new(l.elements().clone(), field_name.clone())?;
-            Ok(ListArray::try_new(
-                projected.into_array(),
-                l.offsets().clone(),
-                l.list_validity(),
-            )?
-            .into_array())
+            let projected = project_elements(l.elements(), field_name)?;
+            Ok(ListArray::try_new(projected, l.offsets().clone(), l.list_validity())?.into_array())
         } else if let Some(lv) = any_list.as_opt::<ListView>() {
-            let projected = GetItem::try_new(lv.elements().clone(), field_name.clone())?;
+            let projected = project_elements(lv.elements(), field_name)?;
             Ok(ListViewArray::try_new(
-                projected.into_array(),
+                projected,
                 lv.offsets().clone(),
                 lv.sizes().clone(),
                 lv.listview_validity(),
             )?
             .into_array())
         } else if let Some(fsl) = any_list.as_opt::<FixedSizeList>() {
-            let projected = GetItem::try_new(fsl.elements().clone(), field_name.clone())?;
+            let projected = project_elements(fsl.elements(), field_name)?;
             let len = fsl.as_ref().len();
-            Ok(FixedSizeListArray::new(
-                projected.into_array(),
-                fsl.list_size(),
-                fsl.validity()?,
-                len,
+            Ok(
+                FixedSizeListArray::new(projected, fsl.list_size(), fsl.validity()?, len)
+                    .into_array(),
             )
-            .into_array())
         } else {
             let dtype = any_list.dtype();
             vortex_bail!("list_get_item() requires List, ListView, or FixedSizeList, got {dtype}")
@@ -288,6 +327,36 @@ mod tests {
             Validity::NonNullable,
         )?
         .into_array();
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn projects_through_nested_lists() -> VortexResult<()> {
+        // List<List<Struct{a, b}>>: outer offsets [0, 2, 3] over inner lists [0, 2, 3, 4].
+        let inner = create_list_of_structs(Validity::NonNullable);
+        let outer = ListArray::try_new(
+            inner,
+            buffer![0u32, 2, 3].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let result = outer.apply(&list_get_item("a", root()))?;
+
+        let expected_inner = ListArray::try_new(
+            buffer![10i32, 11, 20, 30].into_array(),
+            buffer![0u32, 2, 3, 4].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        let expected = ListArray::try_new(
+            expected_inner,
+            buffer![0u32, 2, 3].into_array(),
+            Validity::NonNullable,
+        )?
+        .into_array();
+        assert_eq!(result.dtype(), expected.dtype());
         let mut ctx = array_session().create_execution_ctx();
         assert_arrays_eq!(result, expected, &mut ctx);
         Ok(())

--- a/vortex-array/src/scalar_fn/fns/list_get_item.rs
+++ b/vortex-array/src/scalar_fn/fns/list_get_item.rs
@@ -124,6 +124,8 @@ impl ScalarFnVTable for ListGetItem {
     }
 
     fn serialize(&self, instance: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
+        // The options are a single field name, identical to `GetItem`'s, so the same proto
+        // message is reused; the fn id keeps the two distinct on the wire.
         Ok(Some(
             pb::GetItemOpts {
                 path: instance.to_string(),
@@ -232,14 +234,17 @@ impl ScalarFnVTable for ListGetItem {
 
 #[cfg(test)]
 mod tests {
+    use prost::Message;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
+    use vortex_proto::expr as pb;
 
     use crate::ArrayRef;
     use crate::IntoArray;
     use crate::VortexSessionExecute;
     use crate::array_session;
     use crate::arrays::BoolArray;
+    use crate::arrays::FixedSizeListArray;
     use crate::arrays::ListArray;
     use crate::arrays::ListViewArray;
     use crate::arrays::StructArray;
@@ -247,26 +252,33 @@ mod tests {
     use crate::dtype::DType;
     use crate::dtype::Nullability;
     use crate::dtype::PType;
+    use crate::expr::Expression;
     use crate::expr::list_get_item;
+    use crate::expr::proto::ExprSerializeProtoExt;
     use crate::expr::root;
     use crate::validity::Validity;
 
     /// 4 struct elements {a: i32, b: i64} in 3 lists of lengths [2, 1, 1].
-    fn create_list_of_structs(validity: Validity) -> ArrayRef {
-        let elements = StructArray::from_fields(&[
+    fn create_list_of_structs(validity: Validity) -> VortexResult<ArrayRef> {
+        let elements = create_struct_elements()?;
+        Ok(
+            ListArray::try_new(elements, buffer![0u32, 2, 3, 4].into_array(), validity)?
+                .into_array(),
+        )
+    }
+
+    /// 4 struct elements {a: i32, b: i64}.
+    fn create_struct_elements() -> VortexResult<ArrayRef> {
+        Ok(StructArray::from_fields(&[
             ("a", buffer![10i32, 11, 20, 30].into_array()),
             ("b", buffer![-1i64, -2, -3, -4].into_array()),
-        ])
-        .unwrap()
-        .into_array();
-        ListArray::try_new(elements, buffer![0u32, 2, 3, 4].into_array(), validity)
-            .unwrap()
-            .into_array()
+        ])?
+        .into_array())
     }
 
     #[test]
     fn projects_field_and_keeps_shape() -> VortexResult<()> {
-        let list = create_list_of_structs(Validity::NonNullable);
+        let list = create_list_of_structs(Validity::NonNullable)?;
         let result = list.apply(&list_get_item("a", root()))?;
 
         assert_eq!(
@@ -291,7 +303,7 @@ mod tests {
     #[test]
     fn carries_list_validity() -> VortexResult<()> {
         let validity = Validity::Array(BoolArray::from_iter([true, false, true]).into_array());
-        let list = create_list_of_structs(validity.clone());
+        let list = create_list_of_structs(validity.clone())?;
         let result = list.apply(&list_get_item("b", root()))?;
 
         let expected = ListArray::try_new(
@@ -307,13 +319,8 @@ mod tests {
 
     #[test]
     fn projects_through_listview() -> VortexResult<()> {
-        let elements = StructArray::from_fields(&[
-            ("a", buffer![10i32, 11, 20, 30].into_array()),
-            ("b", buffer![-1i64, -2, -3, -4].into_array()),
-        ])?
-        .into_array();
         let lv = ListViewArray::try_new(
-            elements,
+            create_struct_elements()?,
             buffer![0u32, 2, 3].into_array(),
             buffer![2u32, 1, 1].into_array(),
             Validity::NonNullable,
@@ -335,7 +342,7 @@ mod tests {
     #[test]
     fn projects_through_nested_lists() -> VortexResult<()> {
         // List<List<Struct{a, b}>>: outer offsets [0, 2, 3] over inner lists [0, 2, 3, 4].
-        let inner = create_list_of_structs(Validity::NonNullable);
+        let inner = create_list_of_structs(Validity::NonNullable)?;
         let outer = ListArray::try_new(
             inner,
             buffer![0u32, 2, 3].into_array(),
@@ -363,9 +370,39 @@ mod tests {
     }
 
     #[test]
-    fn unknown_field_fails_to_bind() {
-        let list = create_list_of_structs(Validity::NonNullable);
+    fn projects_through_fixed_size_list() -> VortexResult<()> {
+        // 2 lists of size 2 over the 4 struct elements.
+        let fsl = FixedSizeListArray::new(create_struct_elements()?, 2, Validity::NonNullable, 2)
+            .into_array();
+        let result = fsl.apply(&list_get_item("b", root()))?;
+
+        let expected = FixedSizeListArray::new(
+            buffer![-1i64, -2, -3, -4].into_array(),
+            2,
+            Validity::NonNullable,
+            2,
+        )
+        .into_array();
+        assert_eq!(result.dtype(), expected.dtype());
+        let mut ctx = array_session().create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut ctx);
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_field_fails_to_bind() -> VortexResult<()> {
+        let list = create_list_of_structs(Validity::NonNullable)?;
         assert!(list.apply(&list_get_item("missing", root())).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_proto_round_trip() -> VortexResult<()> {
+        let expr = list_get_item("a", list_get_item("inner", root()));
+        let buf = expr.serialize_proto()?.encode_to_vec();
+        let decoded = pb::Expr::decode(buf.as_slice())?;
+        assert_eq!(expr, Expression::from_proto(&decoded, &array_session())?);
+        Ok(())
     }
 
     #[test]

--- a/vortex-array/src/scalar_fn/fns/list_length.rs
+++ b/vortex-array/src/scalar_fn/fns/list_length.rs
@@ -177,7 +177,7 @@ fn list_length_from_offsets(list: ArrayView<'_, List>) -> VortexResult<ArrayRef>
 }
 
 /// Matches an `Array<List>`, `Array<ListView>`, or `Array<FixedSizeList>`
-struct AnyList;
+pub(crate) struct AnyList;
 
 impl Matcher for AnyList {
     type Match<'a> = ();

--- a/vortex-array/src/scalar_fn/fns/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/mod.rs
@@ -14,6 +14,7 @@ pub mod is_not_null;
 pub mod is_null;
 pub mod like;
 pub mod list_contains;
+pub mod list_get_item;
 pub mod list_length;
 pub mod list_sum;
 pub mod literal;

--- a/vortex-array/src/scalar_fn/session.rs
+++ b/vortex-array/src/scalar_fn/session.rs
@@ -23,6 +23,7 @@ use crate::scalar_fn::fns::is_not_null::IsNotNull;
 use crate::scalar_fn::fns::is_null::IsNull;
 use crate::scalar_fn::fns::like::Like;
 use crate::scalar_fn::fns::list_contains::ListContains;
+use crate::scalar_fn::fns::list_get_item::ListGetItem;
 use crate::scalar_fn::fns::list_length::ListLength;
 use crate::scalar_fn::fns::list_sum::ListSum;
 use crate::scalar_fn::fns::literal::Literal;
@@ -74,6 +75,7 @@ impl Default for ScalarFnSession {
         this.register(IsNull);
         this.register(Like);
         this.register(ListContains);
+        this.register(ListGetItem);
         this.register(ListLength);
         this.register(ListSum);
         this.register(Literal);

--- a/vortex-layout/src/layouts/list/expr.rs
+++ b/vortex-layout/src/layouts/list/expr.rs
@@ -98,32 +98,34 @@ fn rewrite_validity_expr_with_root(
     expr.clone().with_children(children)
 }
 
-/// How an expression uses the list root, while scanning for a single-field element projection.
+/// How an expression uses the list root, while scanning for an element-projection chain.
 enum ElementFieldUse {
     /// No reference to the root anywhere in the (sub)expression.
     NoRoot,
-    /// Every root reference is `list_get_item(field, root())` with this one field.
-    Field(FieldName),
-    /// The root is used some other way (bare root, another field, `is_null`, `list_length`, …).
+    /// Every root reference is the same `list_get_item(fk, … list_get_item(f1, root()) …)`
+    /// tower; the path is innermost-first (`[f1, …, fk]`).
+    Path(Vec<FieldName>),
+    /// The root is used some other way (bare root, differing chains, `is_null`, `list_length`, …).
     Mixed,
 }
 
-/// Returns the single struct field projected out of the list elements, iff *every* root
-/// reference in `expr` has the shape `list_get_item(field, root())` with the same field.
+/// Returns the field path projected out of the list elements, iff *every* root reference in
+/// `expr` is the same tower of `list_get_item` calls over `root()`. The path is returned
+/// innermost-first, i.e. `list_get_item("b", list_get_item("a", root()))` yields `[a, b]`.
 ///
-/// Such an expression only needs that one field of the elements child: the caller can push
-/// `get_item(field, ·)` into the elements read and rewrite this expression with
+/// Such an expression only needs that leaf path of the elements child: the caller can push the
+/// equivalent element-wise projection into the elements read and rewrite this expression with
 /// [`rewrite_element_projection_expr`] to run against the narrowed list.
-pub(super) fn extract_element_projection(expr: &BoundExpression) -> Option<FieldName> {
+pub(super) fn extract_element_projection(expr: &BoundExpression) -> Option<Vec<FieldName>> {
     match element_field_use(expr) {
-        ElementFieldUse::Field(field) => Some(field),
+        ElementFieldUse::Path(path) => Some(path),
         ElementFieldUse::NoRoot | ElementFieldUse::Mixed => None,
     }
 }
 
 fn element_field_use(expr: &BoundExpression) -> ElementFieldUse {
-    if is_bound_element_projection(expr) {
-        return ElementFieldUse::Field(expr.as_::<ListGetItem>().clone());
+    if let Some(path) = chain_path(expr) {
+        return ElementFieldUse::Path(path);
     }
     if expr.is_root() {
         return ElementFieldUse::Mixed;
@@ -134,8 +136,8 @@ fn element_field_use(expr: &BoundExpression) -> ElementFieldUse {
         acc = match (acc, element_field_use(child)) {
             (ElementFieldUse::NoRoot, child_use) => child_use,
             (acc, ElementFieldUse::NoRoot) => acc,
-            (ElementFieldUse::Field(a), ElementFieldUse::Field(b)) if a == b => {
-                ElementFieldUse::Field(a)
+            (ElementFieldUse::Path(a), ElementFieldUse::Path(b)) if a == b => {
+                ElementFieldUse::Path(a)
             }
             _ => return ElementFieldUse::Mixed,
         };
@@ -143,24 +145,36 @@ fn element_field_use(expr: &BoundExpression) -> ElementFieldUse {
     acc
 }
 
-fn is_bound_element_projection(expr: &BoundExpression) -> bool {
-    expr.as_opt::<ListGetItem>().is_some()
-        && expr.children().len() == 1
-        && expr.children()[0].is_root()
+/// If `expr` is a tower of `list_get_item` nodes whose innermost child is `root()`, return the
+/// projected field path innermost-first; otherwise `None`.
+fn chain_path(expr: &BoundExpression) -> Option<Vec<FieldName>> {
+    let field = expr.as_opt::<ListGetItem>()?;
+    if expr.children().len() != 1 {
+        return None;
+    }
+    let child = &expr.children()[0];
+    if child.is_root() {
+        return Some(vec![field.clone()]);
+    }
+    let mut path = chain_path(child)?;
+    path.push(field.clone());
+    Some(path)
 }
 
 /// Rewrite an element-projection expression so it can be evaluated against the narrowed list
-/// (whose elements are already the projected field): `list_get_item(field, root())` becomes
-/// `root()` bound to `new_root_dtype`. All other nodes are rebuilt with rewritten children.
+/// (whose elements are already the projected leaf path): every `list_get_item` tower matching
+/// `path` becomes `root()` bound to `new_root_dtype`. All other nodes are rebuilt with
+/// rewritten children.
 pub(super) fn rewrite_element_projection_expr(
     expr: &BoundExpression,
+    path: &[FieldName],
     new_root_dtype: &DType,
 ) -> VortexResult<BoundExpression> {
-    if is_bound_element_projection(expr) {
+    if chain_path(expr).is_some_and(|p| p == path) {
         debug_assert_eq!(
             expr.dtype(),
             new_root_dtype,
-            "narrowed list dtype must match the list_get_item node it replaces"
+            "narrowed list dtype must match the list_get_item tower it replaces"
         );
         return Ok(BoundExpression::new_root(new_root_dtype.clone()));
     }
@@ -168,7 +182,7 @@ pub(super) fn rewrite_element_projection_expr(
     let children = expr
         .children()
         .iter()
-        .map(|child| rewrite_element_projection_expr(child, new_root_dtype))
+        .map(|child| rewrite_element_projection_expr(child, path, new_root_dtype))
         .collect::<VortexResult<Vec<_>>>()?;
     expr.clone().with_children(children)
 }

--- a/vortex-layout/src/layouts/list/expr.rs
+++ b/vortex-layout/src/layouts/list/expr.rs
@@ -2,11 +2,13 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::dtype::DType;
+use vortex_array::dtype::FieldName;
 use vortex_array::dtype::Nullability;
 use vortex_array::expr::BoundExpression;
 use vortex_array::expr::bound::not;
 use vortex_array::scalar_fn::fns::is_not_null::IsNotNull;
 use vortex_array::scalar_fn::fns::is_null::IsNull;
+use vortex_array::scalar_fn::fns::list_get_item::ListGetItem;
 use vortex_array::scalar_fn::fns::list_length::ListLength;
 use vortex_error::VortexResult;
 
@@ -92,6 +94,81 @@ fn rewrite_validity_expr_with_root(
         .children()
         .iter()
         .map(|child| rewrite_validity_expr_with_root(child, root_dtype))
+        .collect::<VortexResult<Vec<_>>>()?;
+    expr.clone().with_children(children)
+}
+
+/// How an expression uses the list root, while scanning for a single-field element projection.
+enum ElementFieldUse {
+    /// No reference to the root anywhere in the (sub)expression.
+    NoRoot,
+    /// Every root reference is `list_get_item(field, root())` with this one field.
+    Field(FieldName),
+    /// The root is used some other way (bare root, another field, `is_null`, `list_length`, …).
+    Mixed,
+}
+
+/// Returns the single struct field projected out of the list elements, iff *every* root
+/// reference in `expr` has the shape `list_get_item(field, root())` with the same field.
+///
+/// Such an expression only needs that one field of the elements child: the caller can push
+/// `get_item(field, ·)` into the elements read and rewrite this expression with
+/// [`rewrite_element_projection_expr`] to run against the narrowed list.
+pub(super) fn extract_element_projection(expr: &BoundExpression) -> Option<FieldName> {
+    match element_field_use(expr) {
+        ElementFieldUse::Field(field) => Some(field),
+        ElementFieldUse::NoRoot | ElementFieldUse::Mixed => None,
+    }
+}
+
+fn element_field_use(expr: &BoundExpression) -> ElementFieldUse {
+    if is_bound_element_projection(expr) {
+        return ElementFieldUse::Field(expr.as_::<ListGetItem>().clone());
+    }
+    if expr.is_root() {
+        return ElementFieldUse::Mixed;
+    }
+
+    let mut acc = ElementFieldUse::NoRoot;
+    for child in expr.children() {
+        acc = match (acc, element_field_use(child)) {
+            (ElementFieldUse::NoRoot, child_use) => child_use,
+            (acc, ElementFieldUse::NoRoot) => acc,
+            (ElementFieldUse::Field(a), ElementFieldUse::Field(b)) if a == b => {
+                ElementFieldUse::Field(a)
+            }
+            _ => return ElementFieldUse::Mixed,
+        };
+    }
+    acc
+}
+
+fn is_bound_element_projection(expr: &BoundExpression) -> bool {
+    expr.as_opt::<ListGetItem>().is_some()
+        && expr.children().len() == 1
+        && expr.children()[0].is_root()
+}
+
+/// Rewrite an element-projection expression so it can be evaluated against the narrowed list
+/// (whose elements are already the projected field): `list_get_item(field, root())` becomes
+/// `root()` bound to `new_root_dtype`. All other nodes are rebuilt with rewritten children.
+pub(super) fn rewrite_element_projection_expr(
+    expr: &BoundExpression,
+    new_root_dtype: &DType,
+) -> VortexResult<BoundExpression> {
+    if is_bound_element_projection(expr) {
+        debug_assert_eq!(
+            expr.dtype(),
+            new_root_dtype,
+            "narrowed list dtype must match the list_get_item node it replaces"
+        );
+        return Ok(BoundExpression::new_root(new_root_dtype.clone()));
+    }
+
+    let children = expr
+        .children()
+        .iter()
+        .map(|child| rewrite_element_projection_expr(child, new_root_dtype))
         .collect::<VortexResult<Vec<_>>>()?;
     expr.clone().with_children(children)
 }

--- a/vortex-layout/src/layouts/list/reader.rs
+++ b/vortex-layout/src/layouts/list/reader.rs
@@ -17,9 +17,11 @@ use vortex_array::arrays::ListArray;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldMask;
+use vortex_array::dtype::FieldName;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::expr::BoundExpression;
+use vortex_array::expr::bound;
 use vortex_array::expr::root;
 use vortex_array::scalar_fn::fns::operators::Operator;
 use vortex_array::validity::Validity;
@@ -36,7 +38,9 @@ use crate::RowSplits;
 use crate::SplitRange;
 use crate::layouts::list::ListLayout;
 use crate::layouts::list::expr::ListChildrenNeeded;
+use crate::layouts::list::expr::extract_element_projection;
 use crate::layouts::list::expr::get_necessary_bound_list_children;
+use crate::layouts::list::expr::rewrite_element_projection_expr;
 use crate::layouts::list::expr::rewrite_offsets_expr;
 use crate::layouts::list::expr::rewrite_validity_expr;
 use crate::segments::SegmentSource;
@@ -144,40 +148,51 @@ impl ListReader {
         .boxed())
     }
 
-    /// Projection for [`ListChildrenNeeded::All`] expressions.
+    /// Projection for [`ListChildrenNeeded::All`] expressions, and for element-projection
+    /// expressions with `elements_expr` narrowing what is read from the elements child.
     ///
-    /// An all-true mask over the full local range reads every child concurrently. Otherwise, the
-    /// read is bounded to the first and last selected list.
+    /// `elements_expr` is pushed into the elements child read (bare `root()` for a plain read),
+    /// and `expr` is evaluated against the list rebuilt from the returned elements. An all-true
+    /// mask over the full local range reads every child concurrently. Otherwise, the read is
+    /// bounded to the first and last selected list.
     fn project_all(
         &self,
         row_range: &Range<u64>,
         expr: &BoundExpression,
+        elements_expr: &BoundExpression,
         mask: MaskFuture,
     ) -> VortexResult<ArrayFuture> {
         let is_full_range = row_range.start == 0 && row_range.end == self.layout.row_count();
         let reader = self.clone();
         let row_range = row_range.clone();
         let expr = expr.clone();
+        let elements_expr = elements_expr.clone();
         Ok(async move {
             let mask = mask.await?;
             if is_full_range && mask.all_true() {
-                reader.project_all_full(&expr)?.await
+                reader.project_all_full(&expr, &elements_expr)?.await
             } else {
-                reader.project_all_bounded(&row_range, &expr, mask)?.await
+                reader
+                    .project_all_bounded(&row_range, &expr, &elements_expr, mask)?
+                    .await
             }
         }
         .boxed())
     }
 
     /// Fetch the complete `elements`, `offsets`, and `validity` children concurrently.
-    fn project_all_full(&self, expr: &BoundExpression) -> VortexResult<ArrayFuture> {
+    fn project_all_full(
+        &self,
+        expr: &BoundExpression,
+        elements_expr: &BoundExpression,
+    ) -> VortexResult<ArrayFuture> {
         let row_count = self.layout.row_count();
         let elements_row_count = self.elements.row_count();
         let nullability = self.layout.dtype().nullability();
         let expr = expr.clone();
 
         let offsets_fut = self.fetch_raw_offsets(&(0..row_count))?;
-        let elements_fut = self.fetch_raw_elements(&(0..elements_row_count))?;
+        let elements_fut = self.fetch_elements(&(0..elements_row_count), elements_expr)?;
         let validity_fut = fetch_validity(
             self.validity.as_ref(),
             &(0..row_count),
@@ -186,8 +201,9 @@ impl ListReader {
 
         Ok(async move {
             let (offsets, elements, validity) = try_join!(offsets_fut, elements_fut, validity_fut)?;
-            // SAFETY: ListLayout is constructed from a valid ListArray and reading its children
-            // without transformation preserves the list invariants.
+            // SAFETY: ListLayout is constructed from a valid ListArray, reading its children
+            // preserves the list invariants, and an element-wise `elements_expr` preserves the
+            // element row count the offsets index into.
             let list = unsafe {
                 ListArray::new_unchecked(elements, offsets, create_validity(validity, nullability))
             }
@@ -206,6 +222,7 @@ impl ListReader {
         &self,
         row_range: &Range<u64>,
         expr: &BoundExpression,
+        elements_expr: &BoundExpression,
         mask: Mask,
     ) -> VortexResult<ArrayFuture> {
         // Crop to the smallest contiguous row range containing every selected list.
@@ -220,6 +237,7 @@ impl ListReader {
 
         let nullability = self.layout.dtype().nullability();
         let expr = expr.clone();
+        let elements_expr = elements_expr.clone();
         let reader = self.clone();
         let offsets_fut = self.fetch_raw_offsets(&selected_row_range)?;
 
@@ -227,7 +245,7 @@ impl ListReader {
             let offsets = offsets_fut.await?;
 
             let elements_range = elements_range_from_offsets(&offsets, &reader.session)?;
-            let elements_fut = reader.fetch_raw_elements(&elements_range)?;
+            let elements_fut = reader.fetch_elements(&elements_range, &elements_expr)?;
             let validity_fut = fetch_validity(
                 reader.validity.as_ref(),
                 &selected_row_range,
@@ -308,14 +326,39 @@ impl ListReader {
         )
     }
 
-    /// Fire the elements read for `row_range` in element space.
+    /// Fire the elements read for `row_range` in element space, pushing `expr` down into the
+    /// elements child (a shredded elements layout can then skip unprojected sub-children).
     ///
-    /// No mask or expression is applied.
-    fn fetch_raw_elements(&self, row_range: &Range<u64>) -> VortexResult<ArrayFuture> {
+    /// No mask is applied.
+    fn fetch_elements(
+        &self,
+        row_range: &Range<u64>,
+        expr: &BoundExpression,
+    ) -> VortexResult<ArrayFuture> {
         let row_count = usize::try_from(row_range.end - row_range.start)?;
-        let root = root().bind(self.elements.dtype())?;
         self.elements
-            .projection_evaluation(row_range, &root, MaskFuture::new_true(row_count))
+            .projection_evaluation(row_range, expr, MaskFuture::new_true(row_count))
+    }
+
+    /// Projection for expressions whose only use of the list is `list_get_item(field, root())`:
+    /// push `get_item(field, ·)` into the elements read and evaluate the rewritten expression
+    /// against the narrowed list. Offsets and validity are read as usual — the list shape is
+    /// unchanged, only the elements are narrowed to one struct field.
+    fn project_element_field(
+        &self,
+        row_range: &Range<u64>,
+        expr: &BoundExpression,
+        field: FieldName,
+        mask: MaskFuture,
+    ) -> VortexResult<ArrayFuture> {
+        let elements_root = root().bind(self.elements.dtype())?;
+        let elements_expr = bound::get_item(field, elements_root);
+        let narrowed_dtype = DType::List(
+            elements_expr.dtype().clone().into(),
+            self.layout.dtype().nullability(),
+        );
+        let outer_expr = rewrite_element_projection_expr(expr, &narrowed_dtype)?;
+        self.project_all(row_range, &outer_expr, &elements_expr, mask)
     }
 }
 
@@ -464,12 +507,19 @@ impl LayoutReader for ListReader {
         mask: MaskFuture,
     ) -> VortexResult<ArrayFuture> {
         // Read as little as possible based on which list children the expression needs.
+        // A single-field element projection narrows the elements read to that field.
+        if let Some(field) = extract_element_projection(expr) {
+            return self.project_element_field(row_range, expr, field, mask);
+        }
         match get_necessary_bound_list_children(expr) {
             ListChildrenNeeded::Validity => self.project_validity(row_range, expr, mask),
             ListChildrenNeeded::OffsetsAndValidity => {
                 self.project_offsets_validity(row_range, expr, mask)
             }
-            ListChildrenNeeded::All => self.project_all(row_range, expr, mask),
+            ListChildrenNeeded::All => {
+                let elements_root = root().bind(self.elements.dtype())?;
+                self.project_all(row_range, expr, &elements_root, mask)
+            }
         }
     }
 }
@@ -615,12 +665,15 @@ mod tests {
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::ListArray;
     use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::arrays::StructArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::expr::Expression;
     use vortex_array::expr::cast;
     use vortex_array::expr::gt;
     use vortex_array::expr::is_not_null;
     use vortex_array::expr::is_null;
+    use vortex_array::expr::list_contains;
+    use vortex_array::expr::list_get_item;
     use vortex_array::expr::list_length;
     use vortex_array::expr::lit;
     use vortex_buffer::buffer;
@@ -635,6 +688,7 @@ mod tests {
     use crate::layouts::list::writer::ListLayoutStrategy;
     use crate::layouts::repartition::RepartitionStrategy;
     use crate::layouts::repartition::RepartitionWriterOptions;
+    use crate::layouts::struct_::writer::StructStrategy;
     use crate::scan::split_by::SplitBy;
     use crate::segments::SegmentFuture;
     use crate::segments::SegmentSource;
@@ -1038,6 +1092,129 @@ mod tests {
         let expected = list.slice(1..4)?;
         let mut exec_ctx = session.create_execution_ctx();
         assert_arrays_eq!(result, expected, &mut exec_ctx);
+        Ok(())
+    }
+
+    /// 3 lists over 5 struct elements `{a: i32, b: i64}`, offsets [0, 2, 4, 5].
+    fn create_list_of_structs(nullable: bool) -> ArrayRef {
+        let validity = if nullable {
+            Validity::Array(BoolArray::from_iter([true, false, true]).into_array())
+        } else {
+            Validity::NonNullable
+        };
+        let elements = StructArray::from_fields(&[
+            ("a", buffer![10i32, 11, 20, 21, 30].into_array()),
+            ("b", buffer![-1i64, -2, -3, -4, -5].into_array()),
+        ])
+        .expect("fields are valid")
+        .into_array();
+        ListArray::try_new(elements, buffer![0u32, 2, 4, 5].into_array(), validity)
+            .expect("array is valid")
+            .into_array()
+    }
+
+    /// List strategy whose elements child is shredded into a struct layout with per-field
+    /// children, so element projections can skip unprojected fields at IO time.
+    fn struct_elements_list_strategy() -> ListLayoutStrategy {
+        let flat: Arc<dyn LayoutStrategy> = Arc::new(FlatLayoutStrategy::default());
+        ListLayoutStrategy::default()
+            .with_elements(Arc::new(StructStrategy::new(Arc::clone(&flat), flat)))
+    }
+
+    /// `list_get_item` projections round-trip against the in-memory result for shredded and
+    /// flat elements, across ranges, masks, and list nullability.
+    #[rstest]
+    #[case::full(0..3, Mask::new_true(3), false, true)]
+    #[case::subrange(1..3, Mask::new_true(2), false, true)]
+    #[case::sparse(0..3, Mask::from_iter([true, false, true]), false, true)]
+    #[case::nullable(0..3, Mask::new_true(3), true, true)]
+    #[case::all_false(0..3, Mask::new_false(3), false, true)]
+    #[case::flat_elements(0..3, Mask::new_true(3), false, false)]
+    #[case::flat_elements_sparse(1..3, Mask::from_iter([false, true]), true, false)]
+    #[tokio::test]
+    async fn element_projection_round_trips(
+        #[case] row_range: Range<u64>,
+        #[case] mask: Mask,
+        #[case] nullable: bool,
+        #[case] shredded: bool,
+    ) -> VortexResult<()> {
+        let list = create_list_of_structs(nullable);
+        let ctx = LayoutReaderContext::new();
+        let strategy = if shredded {
+            struct_elements_list_strategy()
+        } else {
+            flat_list_strategy()
+        };
+        let (segments, layout, session) = write_layout(&strategy, list.clone()).await?;
+        let reader = layout.new_reader("".into(), segments, &session, &ctx)?;
+
+        let projection = list_get_item("a", root());
+        let expr = projection.bind(reader.dtype())?;
+        let result = reader
+            .projection_evaluation(&row_range, &expr, MaskFuture::ready(mask.clone()))?
+            .await?;
+
+        let expected = list
+            .slice(usize::try_from(row_range.start)?..usize::try_from(row_range.end)?)?
+            .filter(mask)?
+            .apply(&projection)?;
+        let mut exec_ctx = session.create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut exec_ctx);
+        Ok(())
+    }
+
+    /// With struct-shredded elements, projecting one field must not request the segments of the
+    /// other field: offsets + `a` are two segments, while a bare-root read touches `b` too.
+    #[tokio::test]
+    async fn element_projection_skips_unprojected_field_segments() -> VortexResult<()> {
+        let list = create_list_of_structs(false);
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout, session) =
+            write_layout(&struct_elements_list_strategy(), list).await?;
+
+        let counted_requests = |expr: Expression| {
+            let request_count = Arc::new(AtomicUsize::new(0));
+            let source = Arc::new(CountingSegmentSource {
+                inner: Arc::clone(&segments),
+                request_count: Arc::clone(&request_count),
+            });
+            let reader = layout.new_reader("".into(), source, &session, &ctx)?;
+            let bound = expr.bind(reader.dtype())?;
+            let fut = reader.projection_evaluation(&(0..3), &bound, MaskFuture::new_true(3))?;
+            Ok::<_, vortex_error::VortexError>((fut, request_count))
+        };
+
+        let (fut, projected_count) = counted_requests(list_get_item("a", root()))?;
+        fut.await?;
+        let (fut, root_count) = counted_requests(root())?;
+        fut.await?;
+
+        assert!(
+            projected_count.load(Ordering::Relaxed) < root_count.load(Ordering::Relaxed),
+            "projected read must touch fewer segments: projected={}, root={}",
+            projected_count.load(Ordering::Relaxed),
+            root_count.load(Ordering::Relaxed)
+        );
+        Ok(())
+    }
+
+    /// A predicate over a projected element field (`list_contains(list_get_item(a, $), 20)`)
+    /// takes the element-projection path inside filter evaluation and yields the right mask.
+    #[tokio::test]
+    async fn filter_evaluation_over_projected_field() -> VortexResult<()> {
+        let list = create_list_of_structs(false);
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout, session) =
+            write_layout(&struct_elements_list_strategy(), list).await?;
+        let reader = layout.new_reader("".into(), segments, &session, &ctx)?;
+
+        let expr = list_contains(list_get_item("a", root()), lit(20i32)).bind(reader.dtype())?;
+        let result = reader
+            .filter_evaluation(&(0..3), &expr, MaskFuture::new_true(3))?
+            .await?;
+
+        // `a` lists are [10, 11], [20, 21], [30] — only the second contains 20.
+        assert_eq!(result, Mask::from_iter([false, true, false]));
         Ok(())
     }
 

--- a/vortex-layout/src/layouts/list/reader.rs
+++ b/vortex-layout/src/layouts/list/reader.rs
@@ -340,24 +340,35 @@ impl ListReader {
             .projection_evaluation(row_range, expr, MaskFuture::new_true(row_count))
     }
 
-    /// Projection for expressions whose only use of the list is `list_get_item(field, root())`:
-    /// push `get_item(field, ·)` into the elements read and evaluate the rewritten expression
-    /// against the narrowed list. Offsets and validity are read as usual — the list shape is
-    /// unchanged, only the elements are narrowed to one struct field.
+    /// Projection for expressions whose only use of the list is a `list_get_item` tower over
+    /// `root()`: push the equivalent element-wise projection into the elements read and
+    /// evaluate the rewritten expression against the narrowed list. Offsets and validity are
+    /// read as usual — the list shape is unchanged, only the elements are narrowed to the
+    /// projected leaf path. The pushdown recurses naturally: a struct elements child routes
+    /// the projection to one field, and a nested list elements child peels the next level.
     fn project_element_field(
         &self,
         row_range: &Range<u64>,
         expr: &BoundExpression,
-        field: FieldName,
+        path: &[FieldName],
         mask: MaskFuture,
     ) -> VortexResult<ArrayFuture> {
-        let elements_root = root().bind(self.elements.dtype())?;
-        let elements_expr = bound::get_item(field, elements_root);
+        // Descend the path in element space: struct level → get_item, list level →
+        // list_get_item (which itself recurses through deeper list nesting).
+        let mut elements_expr = root().bind(self.elements.dtype())?;
+        for field in path {
+            elements_expr = match elements_expr.dtype() {
+                DType::List(..) | DType::FixedSizeList(..) => {
+                    bound::list_get_item(field.clone(), elements_expr)
+                }
+                _ => bound::get_item(field.clone(), elements_expr),
+            };
+        }
         let narrowed_dtype = DType::List(
             elements_expr.dtype().clone().into(),
             self.layout.dtype().nullability(),
         );
-        let outer_expr = rewrite_element_projection_expr(expr, &narrowed_dtype)?;
+        let outer_expr = rewrite_element_projection_expr(expr, path, &narrowed_dtype)?;
         self.project_all(row_range, &outer_expr, &elements_expr, mask)
     }
 }
@@ -507,9 +518,9 @@ impl LayoutReader for ListReader {
         mask: MaskFuture,
     ) -> VortexResult<ArrayFuture> {
         // Read as little as possible based on which list children the expression needs.
-        // A single-field element projection narrows the elements read to that field.
-        if let Some(field) = extract_element_projection(expr) {
-            return self.project_element_field(row_range, expr, field, mask);
+        // An element-projection chain narrows the elements read to its leaf path.
+        if let Some(path) = extract_element_projection(expr) {
+            return self.project_element_field(row_range, expr, &path, mask);
         }
         match get_necessary_bound_list_children(expr) {
             ListChildrenNeeded::Validity => self.project_validity(row_range, expr, mask),
@@ -1195,6 +1206,91 @@ mod tests {
             projected_count.load(Ordering::Relaxed),
             root_count.load(Ordering::Relaxed)
         );
+        Ok(())
+    }
+
+    /// Two-level nesting shaped like a trace block: `List<Struct{x, inner: List<Struct{name,
+    /// dur}>}>`, shredded at every level.
+    fn create_nested_trace_shape() -> ArrayRef {
+        let spans = StructArray::from_fields(&[
+            (
+                "name",
+                vortex_array::arrays::VarBinViewArray::from_iter_str(["a", "b", "c", "d", "e"])
+                    .into_array(),
+            ),
+            ("dur", buffer![1u64, 2, 3, 4, 5].into_array()),
+        ])
+        .expect("fields are valid")
+        .into_array();
+        let inner = ListArray::try_new(
+            spans,
+            buffer![0u32, 2, 4, 5].into_array(),
+            Validity::NonNullable,
+        )
+        .expect("array is valid")
+        .into_array();
+        let outer_elements = StructArray::from_fields(&[
+            ("x", buffer![100i64, 200, 300].into_array()),
+            ("inner", inner),
+        ])
+        .expect("fields are valid")
+        .into_array();
+        ListArray::try_new(
+            outer_elements,
+            buffer![0u32, 2, 3].into_array(),
+            Validity::NonNullable,
+        )
+        .expect("array is valid")
+        .into_array()
+    }
+
+    /// Strategy shredding both levels: outer elements struct routes `inner` through another
+    /// shredded list strategy, mirroring what `TableStrategy::with_list_layout` produces.
+    fn nested_shredded_strategy() -> ListLayoutStrategy {
+        let flat: Arc<dyn LayoutStrategy> = Arc::new(FlatLayoutStrategy::default());
+        let inner_list = struct_elements_list_strategy();
+        let outer_struct = StructStrategy::new(Arc::clone(&flat), flat)
+            .with_field_writer("inner", Arc::new(inner_list));
+        ListLayoutStrategy::default().with_elements(Arc::new(outer_struct))
+    }
+
+    /// A `list_get_item` chain descends every nesting level: correctness against the in-memory
+    /// result, and the read must skip both unprojected leaves (`x` at the outer struct, `dur`
+    /// at the span struct).
+    #[tokio::test]
+    async fn element_projection_chain_descends_nesting() -> VortexResult<()> {
+        let list = create_nested_trace_shape();
+        let ctx = LayoutReaderContext::new();
+        let (segments, layout, session) =
+            write_layout(&nested_shredded_strategy(), list.clone()).await?;
+
+        let chain = list_get_item("name", list_get_item("inner", root()));
+
+        let counted = |expr: Expression| {
+            let request_count = Arc::new(AtomicUsize::new(0));
+            let source = Arc::new(CountingSegmentSource {
+                inner: Arc::clone(&segments),
+                request_count: Arc::clone(&request_count),
+            });
+            let reader = layout.new_reader("".into(), source, &session, &ctx)?;
+            let bound = expr.bind(reader.dtype())?;
+            let fut = reader.projection_evaluation(&(0..2), &bound, MaskFuture::new_true(2))?;
+            Ok::<_, vortex_error::VortexError>((fut, request_count))
+        };
+
+        let (fut, chain_count) = counted(chain.clone())?;
+        let result = fut.await?;
+        let (fut, root_count) = counted(root())?;
+        fut.await?;
+
+        let expected = list.apply(&chain)?;
+        let mut exec_ctx = session.create_execution_ctx();
+        assert_arrays_eq!(result, expected, &mut exec_ctx);
+
+        // Chain: outer offsets + inner offsets + name = 3 segments.
+        // Root: those plus `x` and `dur` = 5 segments.
+        assert_eq!(chain_count.load(Ordering::Relaxed), 3);
+        assert_eq!(root_count.load(Ordering::Relaxed), 5);
         Ok(())
     }
 


### PR DESCRIPTION
Closes #9724.

- Adds `ListGetItem` (`vortex.list.get_item`): projects one struct field out of every list
  element, over List/ListView/FixedSizeList and nested lists.
- `ListLayout` reader detects a `list_get_item` chain over `root()`, pushes the equivalent
  element projection into the elements child, and rewrites the outer expression against the
  narrowed list. Other expression shapes keep the existing read. `filter_evaluation` shares the path.

Tests: segment-count tests prove unprojected fields are never requested at one and two
nesting levels; results round-trip against in-memory evaluation across ranges, masks, nullability.

Scope: one leaf path per expression (two different fields in one expression fall back to the
full read); IO skipping needs files written with `ListLayoutStrategy::with_elements(StructStrategy)`,
the default writer is unchanged.

Follow-ups: multi-field projection, Python/FFI/DuckDB/DataFusion exposure.

AI assistance: implemented with Claude Code; design, review and testing by me.
