### PR TITLE
perf(buffer): store alignment exponents

### DIFF
--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -1144,7 +1144,7 @@ impl ZstdData {
 
         let value_bytes = values.buffer_handle().try_to_host_sync()?;
         // Align frames to buffer alignment. This is necessary for overaligned buffers.
-        let alignment = *value_bytes.alignment();
+        let alignment = value_bytes.alignment().as_usize();
         let step_width = (values_per_frame * byte_width).div_ceil(alignment) * alignment;
 
         let frame_byte_starts = (0..n_values * byte_width)

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -356,7 +356,7 @@ fn compute_output_layout(
     let mut total_size = 0usize;
 
     for (&size, &alignment) in output_sizes.iter().zip(output_alignments.iter()) {
-        total_size = total_size.next_multiple_of(*alignment);
+        total_size = total_size.next_multiple_of(alignment.as_usize());
         offsets.push(total_size);
         total_size += size;
     }

--- a/vortex-array/src/serde.rs
+++ b/vortex-array/src/serde.rs
@@ -84,7 +84,7 @@ impl ArrayRef {
             .unwrap_or_else(FlatBuffer::alignment);
 
         // Create a shared buffer of zeros we can use for padding
-        let zeros = ByteBuffer::zeroed(*max_alignment);
+        let zeros = ByteBuffer::zeroed(max_alignment.as_usize());
 
         // We push an empty buffer with the maximum alignment, so then subsequent buffers
         // will be aligned. For subsequent buffers, we always push a 1-byte alignment.
@@ -96,7 +96,7 @@ impl ArrayRef {
         // Push all the array buffers with padding as necessary.
         for buffer in array_buffers {
             let padding = if options.include_padding {
-                let padding = pos.next_multiple_of(*buffer.alignment()) - pos;
+                let padding = pos.next_multiple_of(buffer.alignment().as_usize()) - pos;
                 if padding > 0 {
                     pos += padding;
                     buffers.push(zeros.slice(0..padding));
@@ -138,7 +138,7 @@ impl ArrayRef {
         let fb_length = fb_buffer.len();
 
         if options.include_padding {
-            let padding = pos.next_multiple_of(*FlatBuffer::alignment()) - pos;
+            let padding = pos.next_multiple_of(FlatBuffer::alignment().as_usize()) - pos;
             if padding > 0 {
                 buffers.push(zeros.slice(0..padding));
             }

--- a/vortex-buffer/src/alignment.rs
+++ b/vortex-buffer/src/alignment.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::fmt::Display;
-use std::ops::Deref;
 
 use vortex_error::VortexError;
 use vortex_error::VortexExpect;
@@ -12,9 +11,9 @@ use vortex_error::vortex_err;
 
 /// The alignment of a buffer.
 ///
-/// This type is a wrapper around `usize` that ensures the alignment is a non-zero power of 2.
+/// This type stores the base-2 exponent of a non-zero power-of-two alignment.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Alignment(usize);
+pub struct Alignment(u8);
 
 impl Alignment {
     /// Largest alignment accepted from untrusted serialized input.
@@ -41,10 +40,11 @@ impl Alignment {
     ///
     /// Panics if `align` is zero or is not a power of 2.
     #[inline]
+    #[expect(clippy::cast_possible_truncation, reason = "usize has at most 64 bits")]
     pub const fn new(align: usize) -> Self {
         assert!(align > 0, "Alignment must be greater than 0");
         assert!(align.is_power_of_two(), "Alignment must be a power of 2");
-        Self(align)
+        Self(align.trailing_zeros() as u8)
     }
 
     /// Create a new 1-byte alignment.
@@ -67,12 +67,6 @@ impl Alignment {
     #[inline]
     pub const fn of<T>() -> Self {
         Self::new(align_of::<T>())
-    }
-
-    /// Return the alignment in bytes.
-    #[inline]
-    pub const fn as_usize(self) -> usize {
-        self.0
     }
 
     /// The largest valid alignment: the greatest power of 2 representable in a `usize`.
@@ -110,7 +104,7 @@ impl Alignment {
     #[inline]
     pub const fn is_offset_aligned(&self, offset: usize) -> bool {
         // Alignment is always a power of 2, so a mask test is equivalent to `offset % self == 0`.
-        offset & (self.0 - 1) == 0
+        offset & (self.as_usize() - 1) == 0
     }
 
     /// Check if the given pointer is aligned to this alignment.
@@ -121,8 +115,7 @@ impl Alignment {
 
     /// Returns the log2 of the alignment.
     pub fn exponent(&self) -> u8 {
-        u8::try_from(self.0.trailing_zeros())
-            .vortex_expect("alignment is a power of 2 within usize, so its exponent fits in u8")
+        self.0
     }
 
     /// Create from the log2 exponent of the alignment.
@@ -137,7 +130,7 @@ impl Alignment {
             (exponent as u32) < usize::BITS,
             "Alignment exponent must fit in usize"
         );
-        Self::new(1 << exponent)
+        Self(exponent)
     }
 
     /// Create from the log2 exponent of the alignment, returning an error rather than panicking if
@@ -172,20 +165,17 @@ impl Alignment {
         }
         Ok(alignment)
     }
+
+    /// Return the alignment in bytes.
+    #[inline]
+    pub const fn as_usize(self) -> usize {
+        1 << self.0
+    }
 }
 
 impl Display for Alignment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl Deref for Alignment {
-    type Target = usize;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.0
+        write!(f, "{}", self.as_usize())
     }
 }
 
@@ -206,14 +196,14 @@ impl From<u16> for Alignment {
 impl From<Alignment> for usize {
     #[inline]
     fn from(value: Alignment) -> Self {
-        value.0
+        value.as_usize()
     }
 }
 
 impl From<Alignment> for u32 {
     #[inline]
     fn from(value: Alignment) -> Self {
-        u32::try_from(value.0).vortex_expect("Alignment must fit into u32")
+        u32::try_from(value.as_usize()).vortex_expect("Alignment must fit into u32")
     }
 }
 
@@ -231,7 +221,7 @@ impl TryFrom<u32> for Alignment {
             return Err(vortex_err!("Alignment must be a power of 2, got {value}"));
         }
 
-        Ok(Self(value))
+        Ok(Self::new(value))
     }
 }
 
@@ -249,7 +239,7 @@ mod test {
     fn alignment_above_u16() {
         // 64KiB alignment (one past `u16::MAX`) is valid — common on ARM with 64K pages.
         let alignment = Alignment::new(u16::MAX as usize + 1);
-        assert_eq!(*alignment, 1 << 16);
+        assert_eq!(alignment.as_usize(), 1 << 16);
         assert_eq!(alignment, Alignment::from_exponent(16));
     }
 

--- a/vortex-buffer/src/arrow.rs
+++ b/vortex-buffer/src/arrow.rs
@@ -28,7 +28,7 @@ impl<T: ArrowNativeType> Buffer<T> {
         let bytes = Bytes::from_owner(ArrowWrapper(arrow.into_inner()));
 
         let alignment = Alignment::of::<T>();
-        if bytes.as_ptr().align_offset(*alignment) != 0 {
+        if bytes.as_ptr().align_offset(alignment.as_usize()) != 0 {
             vortex_panic!(
                 "Arrow buffer is not aligned to the requested alignment: {}",
                 alignment
@@ -67,7 +67,7 @@ impl ByteBuffer {
         let length = arrow.len();
 
         let bytes = Bytes::from_owner(ArrowWrapper(arrow));
-        if bytes.as_ptr().align_offset(*alignment) != 0 {
+        if bytes.as_ptr().align_offset(alignment.as_usize()) != 0 {
             vortex_panic!(
                 "Arrow buffer is not aligned to the requested alignment: {}",
                 alignment

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -75,7 +75,7 @@ impl<T> BufferMut<T> {
             );
         }
 
-        let mut bytes = BytesMut::with_capacity((capacity * size_of::<T>()) + *actual);
+        let mut bytes = BytesMut::with_capacity((capacity * size_of::<T>()) + actual.as_usize());
         bytes.align_empty(actual);
 
         Self {
@@ -112,8 +112,8 @@ impl<T> BufferMut<T> {
     ) -> Self {
         let preferred_alignment = preferred_alignment.unwrap_or(Alignment::of::<u8>());
         let actual_alignment = max(preferred_alignment, alignment);
-        let mut bytes = BytesMut::zeroed((len * size_of::<T>()) + *actual_alignment);
-        bytes.advance(bytes.as_ptr().align_offset(*actual_alignment));
+        let mut bytes = BytesMut::zeroed((len * size_of::<T>()) + actual_alignment.as_usize());
+        bytes.advance(bytes.as_ptr().align_offset(actual_alignment.as_usize()));
         unsafe { bytes.set_len(len * size_of::<T>()) };
         let actual_len = bytes.len().checked_div(size_of::<T>()).unwrap_or(0);
         Self {
@@ -282,7 +282,8 @@ impl<T> BufferMut<T> {
     /// A separate function so we can inline the reserve call's fast path. According to `BytesMut`
     /// this has significant performance implications.
     fn reserve_allocate(&mut self, additional: usize) {
-        let new_capacity: usize = ((self.length + additional) * size_of::<T>()) + *self.alignment;
+        let new_capacity: usize =
+            ((self.length + additional) * size_of::<T>()) + self.alignment.as_usize();
         // Make sure we at least double in size each time we re-allocate to amortize the cost
         let new_capacity = new_capacity.max(self.bytes.capacity() * 2);
 
@@ -532,7 +533,7 @@ impl<T> BufferMut<T> {
     ///
     /// If the data is not aligned, we copy it into a new allocation.
     pub fn aligned(self, alignment: Alignment) -> Self {
-        if self.as_ptr().align_offset(*alignment) == 0 {
+        if self.as_ptr().align_offset(alignment.as_usize()) == 0 {
             Self {
                 bytes: self.bytes,
                 length: self.length,
@@ -866,7 +867,7 @@ impl AlignedBytesMut for BytesMut {
             vortex_panic!("ByteBufferMut must be empty");
         }
 
-        let padding = self.as_ptr().align_offset(*alignment);
+        let padding = self.as_ptr().align_offset(alignment.as_usize());
         self.capacity()
             .checked_sub(padding)
             .vortex_expect("Not enough capacity to align buffer");
@@ -1017,7 +1018,10 @@ mod test {
 
         let mut buf = BufferMut::<u32>::zeroed(LEN);
 
-        assert_eq!(buf.as_ptr().align_offset(*Alignment::of::<u32>()), 0);
+        assert_eq!(
+            buf.as_ptr().align_offset(Alignment::of::<u32>().as_usize()),
+            0
+        );
         assert_eq!(buf.as_slice(), &[0; LEN]);
 
         buf[3] = 7;
@@ -1031,7 +1035,7 @@ mod test {
 
         let mut buf = BufferMut::<u32>::zeroed_aligned(LEN, alignment);
 
-        assert_eq!(buf.as_ptr().align_offset(*alignment), 0);
+        assert_eq!(buf.as_ptr().align_offset(alignment.as_usize()), 0);
         assert_eq!(buf.as_slice(), &[0; LEN]);
 
         buf[3] = 7;

--- a/vortex-cuda/src/device_buffer.rs
+++ b/vortex-cuda/src/device_buffer.rs
@@ -474,7 +474,7 @@ impl DeviceBuffer for CudaDeviceBuffer {
 
     fn aligned(self: Arc<Self>, alignment: Alignment) -> VortexResult<Arc<dyn DeviceBuffer>> {
         let effective_ptr = self.device_ptr + self.offset as u64;
-        if effective_ptr.is_multiple_of(*alignment as u64) {
+        if effective_ptr.is_multiple_of(alignment.as_usize() as u64) {
             Ok(Arc::new(CudaDeviceBuffer {
                 allocation: Arc::clone(&self.allocation),
                 offset: self.offset,

--- a/vortex-file/src/footer/serializer.rs
+++ b/vortex-file/src/footer/serializer.rs
@@ -246,7 +246,7 @@ fn write_buffer(
         .map_err(|_| vortex_err!("metadata segment length exceeds maximum u32"))?;
     let alignment = buffer.alignment();
 
-    let padding = offset.next_multiple_of(*alignment as u64) - *offset;
+    let padding = offset.next_multiple_of(alignment.as_usize() as u64) - *offset;
     let segment_offset = *offset + padding;
 
     let segment = PostscriptSegment {

--- a/vortex-file/src/read/driver.rs
+++ b/vortex-file/src/read/driver.rs
@@ -228,7 +228,7 @@ impl State {
         let mut requests = vec![first_req];
         let mut current_start = requests[0].offset;
         let mut current_end = requests[0].offset + requests[0].length as u64;
-        let align = *self.coalesced_buffer_alignment as u64;
+        let align = self.coalesced_buffer_alignment.as_usize() as u64;
 
         // Track requests that we've already decided to remove (or that were cancelled) so that
         // we don't repeatedly process them during range scans.
@@ -593,7 +593,7 @@ mod tests {
                 assert_eq!(coalesced.alignment(), Alignment::new(4));
                 for req in coalesced.requests() {
                     let rel = req.offset - coalesced.range().start;
-                    assert_eq!(rel % *req.alignment as u64, 0);
+                    assert_eq!(rel % req.alignment.as_usize() as u64, 0);
                 }
             }
             _ => panic!("Expected coalesced request"),

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -309,7 +309,7 @@ impl FileSegmentSource {
         let coalesce_config = reader.coalesce_config().map(|mut config| {
             // Aligning the coalesced start down can add up to (alignment - 1) bytes.
             // Increase max_size to keep the effective payload window consistent.
-            let extra = (*max_alignment as u64).saturating_sub(1);
+            let extra = (max_alignment.as_usize() as u64).saturating_sub(1);
             config.max_size = config.max_size.saturating_add(extra);
             config
         });

--- a/vortex-file/src/segments/writer.rs
+++ b/vortex-file/src/segments/writer.rs
@@ -70,7 +70,7 @@ impl SegmentSink for BufferedSegmentSink {
 
             // Add any padding required to align the segment.
             let byte_offset = self.byte_offset.load(Ordering::Relaxed);
-            let padding = byte_offset.next_multiple_of(*alignment as u64) - byte_offset;
+            let padding = byte_offset.next_multiple_of(alignment.as_usize() as u64) - byte_offset;
             let offset = byte_offset + padding;
             specs.push(SegmentSpec {
                 offset,

--- a/vortex-tui/src/inspect.rs
+++ b/vortex-tui/src/inspect.rs
@@ -185,22 +185,22 @@ async fn exec_inspect_json(
                     dtype: ps.dtype.map(|s| SegmentInfoJson {
                         offset: s.offset,
                         length: s.length,
-                        alignment: *s.alignment,
+                        alignment: s.alignment.as_usize(),
                     }),
                     layout: SegmentInfoJson {
                         offset: ps.layout.offset,
                         length: ps.layout.length,
-                        alignment: *ps.layout.alignment,
+                        alignment: ps.layout.alignment.as_usize(),
                     },
                     statistics: ps.statistics.map(|s| SegmentInfoJson {
                         offset: s.offset,
                         length: s.length,
-                        alignment: *s.alignment,
+                        alignment: s.alignment.as_usize(),
                     }),
                     footer: SegmentInfoJson {
                         offset: ps.footer.offset,
                         length: ps.footer.length,
-                        alignment: *ps.footer.alignment,
+                        alignment: ps.footer.alignment.as_usize(),
                     },
                 })
         } else {
@@ -239,7 +239,7 @@ async fn exec_inspect_json(
                         offset: segment.offset,
                         end_offset: segment.offset + segment.length as u64,
                         length: segment.length,
-                        alignment: *segment.alignment,
+                        alignment: segment.alignment.as_usize(),
                         path: segment_paths[i]
                             .as_ref()
                             .map(|p| p.iter().map(|s| s.as_ref()).collect::<Vec<_>>().join(".")),
@@ -611,7 +611,7 @@ impl FooterSegments {
             print!(
                 "{:>length_w$}  {:>align_w$}  ",
                 segment.length,
-                *segment.alignment,
+                segment.alignment.as_usize(),
                 length_w = length_width,
                 align_w = alignment_width,
             );

--- a/vortex-tui/src/segments.rs
+++ b/vortex-tui/src/segments.rs
@@ -90,7 +90,7 @@ pub async fn exec_segments(session: &VortexSession, args: SegmentsArgs) -> Vorte
                         row_count: seg.row_count,
                         byte_offset: seg.spec.offset,
                         byte_length: seg.spec.length,
-                        alignment: *seg.spec.alignment,
+                        alignment: seg.spec.alignment.as_usize(),
                         byte_gap,
                     }
                 })

--- a/vortex-web/crate/src/wasm.rs
+++ b/vortex-web/crate/src/wasm.rs
@@ -244,7 +244,7 @@ impl VortexFileHandle {
                     index: i,
                     byte_offset: spec.offset,
                     byte_length: spec.length,
-                    alignment: *spec.alignment,
+                    alignment: spec.alignment.as_usize(),
                     column,
                     layout_path,
                 }


### PR DESCRIPTION
## Summary

Store `Alignment` as its base-2 exponent instead of a `usize`.

## Changes

- Shrink `Alignment` from 8 bytes to 1 byte.
- Remove `Deref` and convert to bytes explicitly with `as_usize()`.
- Keep the accepted alignments and serialized exponent unchanged.