### PR TITLE
perf(fastlanes): borrow unpack inputs

### DIFF
--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -22,6 +22,7 @@ use vortex_error::VortexResult;
 
 use crate::BitPacked;
 use crate::BitPackedArrayExt;
+use crate::FL_CHUNK_SIZE;
 use crate::unpack_iter::BitPacked as BitPackedUnpack;
 use crate::unpack_iter::BitUnpackedChunks;
 
@@ -102,7 +103,7 @@ where
     F: BitPackedUnpack,
     T: NativePType,
     M: Fn(F) -> T,
-    D: FnOnce(&mut BitUnpackedChunks<F>, &mut [MaybeUninit<T>], &M),
+    D: FnOnce(&mut BitUnpackedChunks<'_, F>, &mut [MaybeUninit<T>], &M),
 {
     if array.is_empty() {
         return Ok(());
@@ -119,7 +120,8 @@ where
     // SAFETY: `decode` writes a value to every slot in this range.
     let uninit_slice = unsafe { uninit_range.slice_uninit_mut(0, len) };
 
-    let mut chunks = array.unpacked_chunks::<F>()?;
+    let mut scratch = [const { MaybeUninit::<F>::uninit() }; FL_CHUNK_SIZE];
+    let mut chunks = array.unpacked_chunks::<F>(&mut scratch)?;
     decode(&mut chunks, uninit_slice, &map);
 
     if let Some(patches) = array.patches() {

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -3,6 +3,7 @@
 
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::mem::MaybeUninit;
 
 use fastlanes::BitPacking;
 use vortex_array::ArrayRef;
@@ -29,6 +30,7 @@ pub mod bitpack_decompress;
 pub mod unpack_iter;
 
 use crate::BitPackedArray;
+use crate::FL_CHUNK_SIZE;
 use crate::bitpack_compress::bitpack_encode;
 use crate::unpack_iter::BitPacked as BitPackedIter;
 use crate::unpack_iter::BitUnpackedChunks;
@@ -223,17 +225,18 @@ impl BitPackedData {
     }
 
     /// Accessor for bit unpacked chunks
-    pub fn unpacked_chunks<T: BitPackedIter>(
-        &self,
+    pub fn unpacked_chunks<'a, T: BitPackedIter>(
+        &'a self,
         dtype: &DType,
         len: usize,
-    ) -> VortexResult<BitUnpackedChunks<T>> {
+        scratch: &'a mut [MaybeUninit<T>; FL_CHUNK_SIZE],
+    ) -> VortexResult<BitUnpackedChunks<'a, T>> {
         assert_eq!(
             T::PTYPE,
             self.ptype(dtype),
             "Requested type doesn't match the array ptype"
         );
-        BitUnpackedChunks::try_new(self, len)
+        BitUnpackedChunks::try_new(self, len, scratch)
     }
 
     /// Bit-width of the packed values
@@ -316,8 +319,16 @@ pub trait BitPackedArrayExt: BitPackedArraySlotsExt {
     }
 
     #[inline]
-    fn unpacked_chunks<T: BitPackedIter>(&self) -> VortexResult<BitUnpackedChunks<T>> {
-        BitPackedData::unpacked_chunks::<T>(self, self.as_ref().dtype(), self.as_ref().len())
+    fn unpacked_chunks<'a, T: BitPackedIter>(
+        &'a self,
+        scratch: &'a mut [MaybeUninit<T>; FL_CHUNK_SIZE],
+    ) -> VortexResult<BitUnpackedChunks<'a, T>> {
+        BitPackedData::unpacked_chunks::<T>(
+            self,
+            self.as_ref().dtype(),
+            self.as_ref().len(),
+            scratch,
+        )
     }
 }
 

--- a/encodings/fastlanes/src/bitpacking/array/unpack_iter.rs
+++ b/encodings/fastlanes/src/bitpacking/array/unpack_iter.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::marker::PhantomData;
 use std::mem;
 use std::mem::MaybeUninit;
 use std::ops::Range;
@@ -51,6 +52,8 @@ impl<T: PhysicalPType<Physical: BitPacking>> UnpackStrategy<T> for BitPackingStr
 ///
 /// The usual pattern of usage should follow
 /// ```
+/// use std::mem::MaybeUninit;
+///
 /// use lending_iterator::gat;
 /// use lending_iterator::prelude::Item;
 /// #[gat(Item)]
@@ -65,17 +68,20 @@ impl<T: PhysicalPType<Physical: BitPacking>> UnpackStrategy<T> for BitPackingStr
 /// let mut ctx = vortex_array::array_session().create_execution_ctx();
 /// let array = BitPackedData::encode(&buffer![2, 3, 4, 5].into_array(), 2, &mut ctx).unwrap();
 /// let mut unpacked_chunks: BitUnpackedChunks<i32> = array.unpacked_chunks().unwrap();
+/// let mut scratch = [const { MaybeUninit::<i32>::uninit() }; 1024];
 ///
-/// if let Some(header) = unpacked_chunks.initial() {
+/// if let Some(header) = unpacked_chunks.initial(&mut scratch) {
 ///    // handle partial initial chunk
 /// }
 ///
-/// let mut chunks_iter = unpacked_chunks.full_chunks();
-/// while let Some(chunk) = chunks_iter.next() {
-///     // handle full bitpacked chunks of 1024 elements
+/// {
+///     let mut chunks_iter = unpacked_chunks.full_chunks(&mut scratch);
+///     while let Some(chunk) = chunks_iter.next() {
+///         // handle full bitpacked chunks of 1024 elements
+///     }
 /// }
 ///
-/// if let Some(trailer) = unpacked_chunks.trailer() {
+/// if let Some(trailer) = unpacked_chunks.trailer(&mut scratch) {
 ///     // handle partial trailing chunk
 /// }
 /// ```
@@ -88,7 +94,7 @@ pub struct UnpackedChunks<T: PhysicalPType, S: UnpackStrategy<T>> {
     // 0 indicates full chunk of CHUNK_SIZE
     last_chunk_length: usize,
     packed: ByteBuffer,
-    buffer: [MaybeUninit<T>; CHUNK_SIZE],
+    _marker: PhantomData<T>,
 }
 
 pub type BitUnpackedChunks<T> = UnpackedChunks<T, BitPackingStrategy>;
@@ -104,13 +110,16 @@ impl<T: BitPacked> BitUnpackedChunks<T> {
         )
     }
 
-    pub fn full_chunks(&mut self) -> BitUnpackIterator<'_, T> {
+    pub fn full_chunks<'a>(
+        &'a self,
+        scratch: &'a mut [MaybeUninit<T>; CHUNK_SIZE],
+    ) -> BitUnpackIterator<'a, T> {
         let elems_per_chunk = self.elems_per_chunk();
         let last_chunk_is_sliced = self.last_chunk_is_sliced() as usize;
         let first_chunk_is_sliced = self.first_chunk_is_sliced();
         BitUnpackIterator::new(
             buffer_as_slice(&self.packed),
-            &mut self.buffer,
+            scratch,
             self.bit_width,
             elems_per_chunk,
             self.num_chunks - last_chunk_is_sliced,
@@ -148,9 +157,9 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
             offset,
             len,
             packed,
-            buffer: [const { MaybeUninit::<T>::uninit() }; CHUNK_SIZE],
             num_chunks,
             last_chunk_length,
+            _marker: PhantomData,
         })
     }
 
@@ -160,10 +169,13 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
     }
 
     /// Access first chunk of the array if the last chunk has fewer than 1024 due to slicing
-    pub fn initial(&mut self) -> Option<&mut [T]> {
+    pub fn initial<'a>(
+        &self,
+        scratch: &'a mut [MaybeUninit<T>; CHUNK_SIZE],
+    ) -> Option<&'a mut [T]> {
         (self.first_chunk_is_sliced() || self.num_chunks == 1).then(|| {
             let chunk: &[T::Physical] = &buffer_as_slice(&self.packed)[..self.elems_per_chunk()];
-            let dst: &mut [MaybeUninit<T>] = &mut self.buffer;
+            let dst: &mut [MaybeUninit<T>] = scratch;
             let dst: &mut [T::Physical] = unsafe { mem::transmute(dst) };
 
             let header_end_slice = if self.num_chunks == 1 {
@@ -176,7 +188,7 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
             // 2. buffer is exactly CHUNK_SIZE.
             unsafe {
                 self.strategy.unpack_chunk(self.bit_width, chunk, dst);
-                mem::transmute(&mut self.buffer[self.offset..][..header_end_slice])
+                mem::transmute(&mut scratch[self.offset..][..header_end_slice])
             }
         })
     }
@@ -184,9 +196,10 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
     /// Decode all chunks (initial, full, and trailer) directly into the output range.
     pub fn decode_into(&mut self, output: &mut [MaybeUninit<T>]) {
         debug_assert_eq!(output.len(), self.len);
+        let mut scratch = [const { MaybeUninit::<T>::uninit() }; CHUNK_SIZE];
         let mut local_idx = 0;
 
-        if let Some(initial) = self.initial() {
+        if let Some(initial) = self.initial(&mut scratch) {
             local_idx = initial.len();
 
             // TODO(connor): use maybe_uninit_write_slice when it gets stabilized.
@@ -197,7 +210,7 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
 
         local_idx = self.decode_full_chunks_into_at(output, local_idx);
 
-        if let Some(trailer) = self.trailer() {
+        if let Some(trailer) = self.trailer(&mut scratch) {
             // TODO(connor): use maybe_uninit_write_slice when it gets stabilized.
             // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout.
             let init_trailer: &[MaybeUninit<T>] = unsafe { mem::transmute(trailer) };
@@ -226,9 +239,10 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
     where
         F: FnMut(&mut [T], Range<usize>),
     {
+        let mut scratch = [const { MaybeUninit::<T>::uninit() }; CHUNK_SIZE];
         let mut local_idx = 0;
 
-        if let Some(initial) = self.initial() {
+        if let Some(initial) = self.initial(&mut scratch) {
             let chunk_len = initial.len();
             f(initial, local_idx..local_idx + chunk_len);
             local_idx += chunk_len;
@@ -240,16 +254,16 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
             for i in self.full_chunks_range() {
                 let chunk = &packed_slice[i * elems_per_chunk..][..elems_per_chunk];
                 unsafe {
-                    let dst: &mut [T::Physical] = mem::transmute(&mut self.buffer[..]);
+                    let dst: &mut [T::Physical] = mem::transmute(&mut scratch[..]);
                     self.strategy.unpack_chunk(self.bit_width, chunk, dst);
-                    let unpacked: &mut [T] = mem::transmute(&mut self.buffer[..]);
+                    let unpacked: &mut [T] = mem::transmute(&mut scratch[..]);
                     f(unpacked, local_idx..local_idx + CHUNK_SIZE);
                 }
                 local_idx += CHUNK_SIZE;
             }
         }
 
-        if let Some(trailer) = self.trailer() {
+        if let Some(trailer) = self.trailer(&mut scratch) {
             let chunk_len = trailer.len();
             f(trailer, local_idx..local_idx + chunk_len);
             local_idx += chunk_len;
@@ -320,18 +334,21 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
     }
 
     /// Access last chunk of the array if the last chunk has fewer than 1024 due to slicing
-    pub fn trailer(&mut self) -> Option<&mut [T]> {
+    pub fn trailer<'a>(
+        &self,
+        scratch: &'a mut [MaybeUninit<T>; CHUNK_SIZE],
+    ) -> Option<&'a mut [T]> {
         (self.last_chunk_is_sliced() && self.num_chunks > 1).then(|| {
             let chunk: &[T::Physical] = &buffer_as_slice(&self.packed)
                 [(self.num_chunks - 1) * self.elems_per_chunk()..][..self.elems_per_chunk()];
-            let dst: &mut [MaybeUninit<T>] = &mut self.buffer;
+            let dst: &mut [MaybeUninit<T>] = scratch;
             let dst: &mut [T::Physical] = unsafe { mem::transmute(dst) };
             // SAFETY:
             // 1. chunk is elems_per_chunk.
             // 2. buffer is exactly CHUNK_SIZE.
             unsafe {
                 self.strategy.unpack_chunk(self.bit_width, chunk, dst);
-                mem::transmute(&mut self.buffer[..self.last_chunk_length])
+                mem::transmute(&mut scratch[..self.last_chunk_length])
             }
         })
     }

--- a/encodings/fastlanes/src/bitpacking/array/unpack_iter.rs
+++ b/encodings/fastlanes/src/bitpacking/array/unpack_iter.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::marker::PhantomData;
 use std::mem;
 use std::mem::MaybeUninit;
 use std::ops::Range;
@@ -12,13 +11,13 @@ use lending_iterator::prelude::Item;
 #[gat(Item)]
 use lending_iterator::prelude::LendingIterator;
 use vortex_array::dtype::PhysicalPType;
-use vortex_buffer::ByteBuffer;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 
 use crate::BitPackedData;
+use crate::FL_CHUNK_SIZE;
 
-const CHUNK_SIZE: usize = 1024;
+const CHUNK_SIZE: usize = FL_CHUNK_SIZE;
 
 /// Strategy trait for fastlanes unpacking operations
 pub trait UnpackStrategy<T: PhysicalPType> {
@@ -67,25 +66,26 @@ impl<T: PhysicalPType<Physical: BitPacking>> UnpackStrategy<T> for BitPackingStr
 ///
 /// let mut ctx = vortex_array::array_session().create_execution_ctx();
 /// let array = BitPackedData::encode(&buffer![2, 3, 4, 5].into_array(), 2, &mut ctx).unwrap();
-/// let mut unpacked_chunks: BitUnpackedChunks<i32> = array.unpacked_chunks().unwrap();
 /// let mut scratch = [const { MaybeUninit::<i32>::uninit() }; 1024];
+/// let mut unpacked_chunks: BitUnpackedChunks<i32> =
+///     array.unpacked_chunks(&mut scratch).unwrap();
 ///
-/// if let Some(header) = unpacked_chunks.initial(&mut scratch) {
+/// if let Some(header) = unpacked_chunks.initial() {
 ///    // handle partial initial chunk
 /// }
 ///
 /// {
-///     let mut chunks_iter = unpacked_chunks.full_chunks(&mut scratch);
+///     let mut chunks_iter = unpacked_chunks.full_chunks();
 ///     while let Some(chunk) = chunks_iter.next() {
 ///         // handle full bitpacked chunks of 1024 elements
 ///     }
 /// }
 ///
-/// if let Some(trailer) = unpacked_chunks.trailer(&mut scratch) {
+/// if let Some(trailer) = unpacked_chunks.trailer() {
 ///     // handle partial trailing chunk
 /// }
 /// ```
-pub struct UnpackedChunks<T: PhysicalPType, S: UnpackStrategy<T>> {
+pub struct UnpackedChunks<'a, T: PhysicalPType, S: UnpackStrategy<T>> {
     strategy: S,
     bit_width: usize,
     offset: usize,
@@ -93,33 +93,35 @@ pub struct UnpackedChunks<T: PhysicalPType, S: UnpackStrategy<T>> {
     num_chunks: usize,
     // 0 indicates full chunk of CHUNK_SIZE
     last_chunk_length: usize,
-    packed: ByteBuffer,
-    _marker: PhantomData<T>,
+    packed: &'a [T::Physical],
+    scratch: &'a mut [MaybeUninit<T>; CHUNK_SIZE],
 }
 
-pub type BitUnpackedChunks<T> = UnpackedChunks<T, BitPackingStrategy>;
+pub type BitUnpackedChunks<'a, T> = UnpackedChunks<'a, T, BitPackingStrategy>;
 
-impl<T: BitPacked> BitUnpackedChunks<T> {
-    pub fn try_new(array: &BitPackedData, len: usize) -> VortexResult<Self> {
+impl<'a, T: BitPacked> BitUnpackedChunks<'a, T> {
+    pub fn try_new(
+        array: &'a BitPackedData,
+        len: usize,
+        scratch: &'a mut [MaybeUninit<T>; CHUNK_SIZE],
+    ) -> VortexResult<Self> {
         Self::try_new_with_strategy(
             BitPackingStrategy,
-            array.packed().clone().unwrap_host(),
+            array.packed_slice::<T::Physical>(),
             array.bit_width() as usize,
             array.offset() as usize,
             len,
+            scratch,
         )
     }
 
-    pub fn full_chunks<'a>(
-        &'a self,
-        scratch: &'a mut [MaybeUninit<T>; CHUNK_SIZE],
-    ) -> BitUnpackIterator<'a, T> {
+    pub fn full_chunks(&mut self) -> BitUnpackIterator<'_, T> {
         let elems_per_chunk = self.elems_per_chunk();
         let last_chunk_is_sliced = self.last_chunk_is_sliced() as usize;
         let first_chunk_is_sliced = self.first_chunk_is_sliced();
         BitUnpackIterator::new(
-            buffer_as_slice(&self.packed),
-            scratch,
+            self.packed,
+            self.scratch,
             self.bit_width,
             elems_per_chunk,
             self.num_chunks - last_chunk_is_sliced,
@@ -128,38 +130,26 @@ impl<T: BitPacked> BitUnpackedChunks<T> {
     }
 }
 
-impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
+impl<'a, T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<'a, T, S> {
     pub fn try_new_with_strategy(
         strategy: S,
-        packed: ByteBuffer,
+        packed: &'a [T::Physical],
         bit_width: usize,
         offset: usize,
         len: usize,
+        scratch: &'a mut [MaybeUninit<T>; CHUNK_SIZE],
     ) -> VortexResult<Self> {
-        vortex_ensure!(
-            offset < CHUNK_SIZE,
-            "Invalid bit-packed offset {offset}, expected < {CHUNK_SIZE}"
-        );
-        let elems_per_chunk = 128 * bit_width / size_of::<T>();
-        let num_chunks = (offset + len).div_ceil(CHUNK_SIZE);
-
-        vortex_ensure!(
-            packed.len() / size_of::<T>() == num_chunks * elems_per_chunk,
-            "Invalid packed length: got {}, expected {}",
-            packed.len() / size_of::<T>(),
-            num_chunks * elems_per_chunk
-        );
-
-        let last_chunk_length = (offset + len) % CHUNK_SIZE;
+        let (num_chunks, last_chunk_length) =
+            validate_packed::<T>(packed.len(), bit_width, offset, len)?;
         Ok(Self {
             strategy,
             bit_width,
             offset,
             len,
-            packed,
             num_chunks,
             last_chunk_length,
-            _marker: PhantomData,
+            packed,
+            scratch,
         })
     }
 
@@ -169,13 +159,10 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
     }
 
     /// Access first chunk of the array if the last chunk has fewer than 1024 due to slicing
-    pub fn initial<'a>(
-        &self,
-        scratch: &'a mut [MaybeUninit<T>; CHUNK_SIZE],
-    ) -> Option<&'a mut [T]> {
+    pub fn initial(&mut self) -> Option<&mut [T]> {
         (self.first_chunk_is_sliced() || self.num_chunks == 1).then(|| {
-            let chunk: &[T::Physical] = &buffer_as_slice(&self.packed)[..self.elems_per_chunk()];
-            let dst: &mut [MaybeUninit<T>] = scratch;
+            let chunk: &[T::Physical] = &self.packed[..self.elems_per_chunk()];
+            let dst: &mut [MaybeUninit<T>] = self.scratch;
             let dst: &mut [T::Physical] = unsafe { mem::transmute(dst) };
 
             let header_end_slice = if self.num_chunks == 1 {
@@ -188,7 +175,7 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
             // 2. buffer is exactly CHUNK_SIZE.
             unsafe {
                 self.strategy.unpack_chunk(self.bit_width, chunk, dst);
-                mem::transmute(&mut scratch[self.offset..][..header_end_slice])
+                mem::transmute(&mut self.scratch[self.offset..][..header_end_slice])
             }
         })
     }
@@ -196,10 +183,9 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
     /// Decode all chunks (initial, full, and trailer) directly into the output range.
     pub fn decode_into(&mut self, output: &mut [MaybeUninit<T>]) {
         debug_assert_eq!(output.len(), self.len);
-        let mut scratch = [const { MaybeUninit::<T>::uninit() }; CHUNK_SIZE];
         let mut local_idx = 0;
 
-        if let Some(initial) = self.initial(&mut scratch) {
+        if let Some(initial) = self.initial() {
             local_idx = initial.len();
 
             // TODO(connor): use maybe_uninit_write_slice when it gets stabilized.
@@ -210,7 +196,7 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
 
         local_idx = self.decode_full_chunks_into_at(output, local_idx);
 
-        if let Some(trailer) = self.trailer(&mut scratch) {
+        if let Some(trailer) = self.trailer() {
             // TODO(connor): use maybe_uninit_write_slice when it gets stabilized.
             // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout.
             let init_trailer: &[MaybeUninit<T>] = unsafe { mem::transmute(trailer) };
@@ -239,65 +225,36 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
     where
         F: FnMut(&mut [T], Range<usize>),
     {
-        let mut scratch = [const { MaybeUninit::<T>::uninit() }; CHUNK_SIZE];
         let mut local_idx = 0;
 
-        if let Some(initial) = self.initial(&mut scratch) {
+        if let Some(initial) = self.initial() {
             let chunk_len = initial.len();
             f(initial, local_idx..local_idx + chunk_len);
             local_idx += chunk_len;
         }
 
         if self.num_chunks > 1 {
-            let packed_slice: &[T::Physical] = buffer_as_slice(&self.packed);
+            let packed_slice = self.packed;
             let elems_per_chunk = self.elems_per_chunk();
             for i in self.full_chunks_range() {
                 let chunk = &packed_slice[i * elems_per_chunk..][..elems_per_chunk];
                 unsafe {
-                    let dst: &mut [T::Physical] = mem::transmute(&mut scratch[..]);
+                    let dst: &mut [T::Physical] = mem::transmute(&mut self.scratch[..]);
                     self.strategy.unpack_chunk(self.bit_width, chunk, dst);
-                    let unpacked: &mut [T] = mem::transmute(&mut scratch[..]);
+                    let unpacked: &mut [T] = mem::transmute(&mut self.scratch[..]);
                     f(unpacked, local_idx..local_idx + CHUNK_SIZE);
                 }
                 local_idx += CHUNK_SIZE;
             }
         }
 
-        if let Some(trailer) = self.trailer(&mut scratch) {
+        if let Some(trailer) = self.trailer() {
             let chunk_len = trailer.len();
             f(trailer, local_idx..local_idx + chunk_len);
             local_idx += chunk_len;
         }
 
         debug_assert_eq!(local_idx, self.len);
-    }
-
-    /// Walk every *packed* chunk in array order, yielding the raw packed FastLanes block and the
-    /// padded bit range it covers, without unpacking it.
-    ///
-    /// Unlike [`Self::for_each_unpacked_chunk`], this does not fill the scratch buffer: it hands
-    /// the still-packed block to the callback so fused kernels (e.g. compare) can unpack and
-    /// consume it in a single pass. Each yielded block holds exactly `elems_per_chunk` packed
-    /// values (the buffer is zero-padded out to a whole final chunk).
-    ///
-    /// The yielded range is in *padded* coordinates: block `c` covers
-    /// `[c * 1024, min((c + 1) * 1024, offset + len))`, so it includes the leading `offset` rows
-    /// that slicing skips. Block starts are therefore always 1024-aligned regardless of `offset`.
-    /// Callers must account for the array's `offset` when mapping a block's rows back to logical
-    /// output positions (e.g. by viewing the output buffer at a bit offset of `offset`).
-    pub(crate) fn for_each_packed_chunk<F>(&self, mut f: F)
-    where
-        F: FnMut(&[T::Physical], Range<usize>),
-    {
-        let packed_slice: &[T::Physical] = buffer_as_slice(&self.packed);
-        let elems_per_chunk = self.elems_per_chunk();
-        let padded_len = self.offset + self.len;
-        for chunk in 0..self.num_chunks {
-            let packed_chunk = &packed_slice[chunk * elems_per_chunk..][..elems_per_chunk];
-            let start = chunk * CHUNK_SIZE;
-            let end = (start + CHUNK_SIZE).min(padded_len);
-            f(packed_chunk, start..end);
-        }
     }
 
     /// Unpack full chunks into output range starting at the given index.
@@ -312,7 +269,7 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
 
         let mut local_idx = start_idx;
 
-        let packed_slice: &[T::Physical] = buffer_as_slice(&self.packed);
+        let packed_slice = self.packed;
         let elems_per_chunk = self.elems_per_chunk();
         for i in self.full_chunks_range() {
             let chunk = &packed_slice[i * elems_per_chunk..][..elems_per_chunk];
@@ -334,21 +291,18 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
     }
 
     /// Access last chunk of the array if the last chunk has fewer than 1024 due to slicing
-    pub fn trailer<'a>(
-        &self,
-        scratch: &'a mut [MaybeUninit<T>; CHUNK_SIZE],
-    ) -> Option<&'a mut [T]> {
+    pub fn trailer(&mut self) -> Option<&mut [T]> {
         (self.last_chunk_is_sliced() && self.num_chunks > 1).then(|| {
-            let chunk: &[T::Physical] = &buffer_as_slice(&self.packed)
+            let chunk: &[T::Physical] = &self.packed
                 [(self.num_chunks - 1) * self.elems_per_chunk()..][..self.elems_per_chunk()];
-            let dst: &mut [MaybeUninit<T>] = scratch;
+            let dst: &mut [MaybeUninit<T>] = self.scratch;
             let dst: &mut [T::Physical] = unsafe { mem::transmute(dst) };
             // SAFETY:
             // 1. chunk is elems_per_chunk.
             // 2. buffer is exactly CHUNK_SIZE.
             unsafe {
                 self.strategy.unpack_chunk(self.bit_width, chunk, dst);
-                mem::transmute(&mut scratch[..self.last_chunk_length])
+                mem::transmute(&mut self.scratch[..self.last_chunk_length])
             }
         })
     }
@@ -360,6 +314,50 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
     fn first_chunk_is_sliced(&self) -> bool {
         self.offset != 0
     }
+}
+
+/// Walk every packed chunk in array order without allocating an unpack scratch buffer.
+pub(crate) fn for_each_packed_chunk<T, F>(
+    packed: &[T::Physical],
+    bit_width: usize,
+    offset: usize,
+    len: usize,
+    mut f: F,
+) -> VortexResult<()>
+where
+    T: PhysicalPType,
+    F: FnMut(&[T::Physical], Range<usize>),
+{
+    let (num_chunks, _) = validate_packed::<T>(packed.len(), bit_width, offset, len)?;
+    let elems_per_chunk = 128 * bit_width / size_of::<T>();
+    let padded_len = offset + len;
+    for chunk in 0..num_chunks {
+        let packed_chunk = &packed[chunk * elems_per_chunk..][..elems_per_chunk];
+        let start = chunk * CHUNK_SIZE;
+        let end = (start + CHUNK_SIZE).min(padded_len);
+        f(packed_chunk, start..end);
+    }
+    Ok(())
+}
+
+fn validate_packed<T: PhysicalPType>(
+    packed_len: usize,
+    bit_width: usize,
+    offset: usize,
+    len: usize,
+) -> VortexResult<(usize, usize)> {
+    vortex_ensure!(
+        offset < CHUNK_SIZE,
+        "Invalid bit-packed offset {offset}, expected < {CHUNK_SIZE}"
+    );
+    let elems_per_chunk = 128 * bit_width / size_of::<T>();
+    let num_chunks = (offset + len).div_ceil(CHUNK_SIZE);
+    vortex_ensure!(
+        packed_len == num_chunks * elems_per_chunk,
+        "Invalid packed length: got {packed_len}, expected {}",
+        num_chunks * elems_per_chunk
+    );
+    Ok((num_chunks, (offset + len) % CHUNK_SIZE))
 }
 
 /// Iterator over full chunks of bitpacked array that yields unpacked chunks one at a time
@@ -416,17 +414,6 @@ impl<'a, T: BitPacked + 'a> LendingIterator for BitUnpackIterator<'a, T> {
         // SAFETY: The buffer has the appropriate lifetime, the iterator signature doesn't account for it
         Some(unsafe { mem::transmute::<&mut [MaybeUninit<T>; 1024], &mut [T; 1024]>(self.buffer) })
     }
-}
-
-fn buffer_as_slice<T>(buffer: &ByteBuffer) -> &[T] {
-    let packed_ptr: *const T = buffer.as_ptr().cast();
-    // Return number of elements of type `T` packed in the buffer
-    let packed_len = buffer.len() / size_of::<T>();
-
-    // SAFETY: as_slice points to buffer memory that outlives the lifetime of `self`.
-    //  Unfortunately Rust cannot understand this, so we reconstruct the slice from raw parts
-    //  to get it to reinterpret the lifetime.
-    unsafe { std::slice::from_raw_parts(packed_ptr, packed_len) }
 }
 
 fn write_map<T: Copy, U>(src: &[T], dst: &mut [MaybeUninit<U>], f: &mut impl FnMut(T) -> U) {

--- a/encodings/fastlanes/src/bitpacking/compute/compare_fused.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/compare_fused.rs
@@ -11,9 +11,8 @@
 //! `[bool; 1024]` or `[T; 1024]` scratch. A single SIMD [`transpose_bits`] per block then rotates
 //! that mask into logical row order.
 //!
-//! The packed blocks are walked through the regular [`crate::unpack_iter::BitUnpackedChunks`]
-//! iterator (via [`crate::unpack_iter::BitUnpackedChunks::for_each_packed_chunk`]) rather than a
-//! bespoke chunk loop, so chunk sizing and bounds live in one place.
+//! The packed blocks are walked through [`crate::unpack_iter::for_each_packed_chunk`], so chunk
+//! sizing and bounds live in one place without allocating an unpack scratch buffer.
 //!
 //! Slicing is handled by working in *padded* coordinates: bit `offset + i` holds element `i`. The
 //! output buffer is over-allocated to whole 1024-bit blocks, so every block - the sliced first
@@ -50,6 +49,7 @@ use super::stream_predicate::stream_predicate;
 use crate::BitPacked;
 use crate::BitPackedArrayExt;
 use crate::unpack_iter::BitPacked as BitPackedIter;
+use crate::unpack_iter::for_each_packed_chunk;
 
 const CHUNK_SIZE: usize = 1024;
 const U64_BITS: usize = u64::BITS as usize;
@@ -92,29 +92,31 @@ where
     let num_chunks = (offset + len).div_ceil(CHUNK_SIZE);
     let mut words: BufferMut<u64> = BufferMut::zeroed(num_chunks * WORDS_PER_CHUNK);
 
-    let chunks = array.unpacked_chunks::<T>()?;
     {
         let words = words.as_mut_slice();
         let mut lane_major = [0u64; WORDS_PER_CHUNK];
-        chunks.for_each_packed_chunk(|packed_chunk, range| {
-            // Block starts are always 1024-aligned (padded coords), so the slot is a full block.
-            let out = words[range.start / U64_BITS..]
-                .first_chunk_mut::<WORDS_PER_CHUNK>()
-                .vortex_expect("over-allocated buffer holds a full block per chunk");
-            // SAFETY: `packed_chunk` holds exactly `128 * bit_width / size_of::<U>()` packed
-            // elements and `bit_width <= U::T`, satisfying `unchecked_unpack_cmp`'s contract. The
-            // kernel assigns every word in `transposed`, so its previous contents are irrelevant.
-            unsafe {
-                <<T as PhysicalPType>::Physical as BitPackingCompare>::unchecked_unpack_cmp::<T, _>(
-                    bit_width,
-                    packed_chunk,
-                    &mut lane_major,
-                    cmp,
-                    rhs,
-                );
-            }
-            transpose_bits::<<T as PhysicalPType>::Physical>(&lane_major, out);
-        });
+        for_each_packed_chunk::<T, _>(
+            array.packed_slice::<<T as PhysicalPType>::Physical>(),
+            bit_width,
+            offset,
+            len,
+            |packed_chunk, range| {
+                // Block starts are always 1024-aligned (padded coords), so the slot is a full block.
+                let out = words[range.start / U64_BITS..]
+                    .first_chunk_mut::<WORDS_PER_CHUNK>()
+                    .vortex_expect("over-allocated buffer holds a full block per chunk");
+                // SAFETY: `packed_chunk` holds exactly `128 * bit_width / size_of::<U>()` packed
+                // elements and `bit_width <= U::T`, satisfying `unchecked_unpack_cmp`'s contract. The
+                // kernel assigns every word in `transposed`, so its previous contents are irrelevant.
+                unsafe {
+                    <<T as PhysicalPType>::Physical as BitPackingCompare>::unchecked_unpack_cmp::<
+                        T,
+                        _,
+                    >(bit_width, packed_chunk, &mut lane_major, cmp, rhs);
+                }
+                transpose_bits::<<T as PhysicalPType>::Physical>(&lane_major, out);
+            },
+        )?;
     }
 
     let mut bits = BitBufferMut::from_buffer(words.into_byte_buffer(), offset, len);

--- a/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
@@ -56,8 +56,8 @@ fn bitpacked_is_constant<T: BitPackedUnpack, const WIDTH: usize>(
     array: ArrayView<'_, BitPacked>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<bool> {
-    let bit_unpack_iterator = array.unpacked_chunks::<T>()?;
     let mut scratch = [const { MaybeUninit::<T>::uninit() }; 1024];
+    let mut bit_unpack_iterator = array.unpacked_chunks::<T>(&mut scratch)?;
     let patches = array
         .patches()
         .map(|p| -> VortexResult<_> {
@@ -70,7 +70,7 @@ fn bitpacked_is_constant<T: BitPackedUnpack, const WIDTH: usize>(
 
     let mut header_constant_value = None;
     let mut current_idx = 0;
-    if let Some(header) = bit_unpack_iterator.initial(&mut scratch) {
+    if let Some(header) = bit_unpack_iterator.initial() {
         if let Some((indices, patches, offset)) = &patches {
             apply_patches(
                 header,
@@ -90,7 +90,7 @@ fn bitpacked_is_constant<T: BitPackedUnpack, const WIDTH: usize>(
 
     let mut first_chunk_value = None;
     {
-        let mut chunks_iter = bit_unpack_iterator.full_chunks(&mut scratch);
+        let mut chunks_iter = bit_unpack_iterator.full_chunks();
         while let Some(chunk) = chunks_iter.next() {
             if let Some((indices, patches, offset)) = &patches {
                 let chunk_len = chunk.len();
@@ -124,7 +124,7 @@ fn bitpacked_is_constant<T: BitPackedUnpack, const WIDTH: usize>(
         }
     }
 
-    if let Some(trailer) = bit_unpack_iterator.trailer(&mut scratch) {
+    if let Some(trailer) = bit_unpack_iterator.trailer() {
         if let Some((indices, patches, offset)) = &patches {
             let chunk_len = trailer.len();
             apply_patches(

--- a/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::mem::MaybeUninit;
 use std::ops::Range;
 
 use itertools::Itertools;
@@ -55,7 +56,8 @@ fn bitpacked_is_constant<T: BitPackedUnpack, const WIDTH: usize>(
     array: ArrayView<'_, BitPacked>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<bool> {
-    let mut bit_unpack_iterator = array.unpacked_chunks::<T>()?;
+    let bit_unpack_iterator = array.unpacked_chunks::<T>()?;
+    let mut scratch = [const { MaybeUninit::<T>::uninit() }; 1024];
     let patches = array
         .patches()
         .map(|p| -> VortexResult<_> {
@@ -68,7 +70,7 @@ fn bitpacked_is_constant<T: BitPackedUnpack, const WIDTH: usize>(
 
     let mut header_constant_value = None;
     let mut current_idx = 0;
-    if let Some(header) = bit_unpack_iterator.initial() {
+    if let Some(header) = bit_unpack_iterator.initial(&mut scratch) {
         if let Some((indices, patches, offset)) = &patches {
             apply_patches(
                 header,
@@ -87,40 +89,42 @@ fn bitpacked_is_constant<T: BitPackedUnpack, const WIDTH: usize>(
     }
 
     let mut first_chunk_value = None;
-    let mut chunks_iter = bit_unpack_iterator.full_chunks();
-    while let Some(chunk) = chunks_iter.next() {
-        if let Some((indices, patches, offset)) = &patches {
-            let chunk_len = chunk.len();
-            apply_patches(
-                chunk,
-                current_idx..current_idx + chunk_len,
-                indices,
-                patches.as_slice::<T>(),
-                *offset,
-            )
-        }
+    {
+        let mut chunks_iter = bit_unpack_iterator.full_chunks(&mut scratch);
+        while let Some(chunk) = chunks_iter.next() {
+            if let Some((indices, patches, offset)) = &patches {
+                let chunk_len = chunk.len();
+                apply_patches(
+                    chunk,
+                    current_idx..current_idx + chunk_len,
+                    indices,
+                    patches.as_slice::<T>(),
+                    *offset,
+                )
+            }
 
-        if !compute_is_constant::<_, WIDTH>(chunk) {
-            return Ok(false);
-        }
-
-        if let Some(chunk_value) = first_chunk_value {
-            if chunk_value != chunk[0] {
+            if !compute_is_constant::<_, WIDTH>(chunk) {
                 return Ok(false);
             }
-        } else {
-            if let Some(header_value) = header_constant_value
-                && header_value != chunk[0]
-            {
-                return Ok(false);
-            }
-            first_chunk_value = Some(chunk[0]);
-        }
 
-        current_idx += chunk.len();
+            if let Some(chunk_value) = first_chunk_value {
+                if chunk_value != chunk[0] {
+                    return Ok(false);
+                }
+            } else {
+                if let Some(header_value) = header_constant_value
+                    && header_value != chunk[0]
+                {
+                    return Ok(false);
+                }
+                first_chunk_value = Some(chunk[0]);
+            }
+
+            current_idx += chunk.len();
+        }
     }
 
-    if let Some(trailer) = bit_unpack_iterator.trailer() {
+    if let Some(trailer) = bit_unpack_iterator.trailer(&mut scratch) {
         if let Some((indices, patches, offset)) = &patches {
             let chunk_len = trailer.len();
             apply_patches(

--- a/encodings/fastlanes/src/bitpacking/compute/stream_predicate.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/stream_predicate.rs
@@ -15,6 +15,8 @@
 //! [`BitBuffer::collect_bool`]: vortex_buffer::BitBuffer::collect_bool
 //! [`Patches`]: vortex_array::patches::Patches
 
+use std::mem::MaybeUninit;
+
 use num_traits::AsPrimitive;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
@@ -32,6 +34,7 @@ use vortex_error::VortexResult;
 
 use crate::BitPacked;
 use crate::BitPackedArrayExt;
+use crate::FL_CHUNK_SIZE;
 use crate::unpack_iter::BitPacked as BitPackedIter;
 
 /// Stream `predicate` over the unpacked values of a [`BitPackedArray`](crate::BitPackedArray), one FastLanes
@@ -50,7 +53,8 @@ where
     let mut words: BufferMut<u64> = BufferMut::zeroed(len.div_ceil(u64::BITS as usize));
 
     if len > 0 {
-        let mut chunks = array.unpacked_chunks::<T>()?;
+        let mut scratch = [const { MaybeUninit::<T>::uninit() }; FL_CHUNK_SIZE];
+        let mut chunks = array.unpacked_chunks::<T>(&mut scratch)?;
         let words = words.as_mut_slice();
 
         if let Some(p) = array.patches() {

--- a/encodings/fastlanes/src/for/array/for_decompress.rs
+++ b/encodings/fastlanes/src/for/array/for_decompress.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::mem::MaybeUninit;
+
 use fastlanes::FoR;
 use num_traits::PrimInt;
 use num_traits::WrappingAdd;
@@ -19,6 +21,7 @@ use vortex_error::VortexResult;
 
 use crate::BitPacked;
 use crate::BitPackedArrayExt;
+use crate::FL_CHUNK_SIZE;
 use crate::FoRArray;
 use crate::bitpack_decompress;
 use crate::r#for::array::FoRArrayExt;
@@ -93,14 +96,16 @@ pub(crate) fn fused_decompress<
         .vortex_expect("cannot be null");
 
     let strategy = FoRStrategy { reference: ref_ };
+    let mut scratch = [const { MaybeUninit::<T>::uninit() }; FL_CHUNK_SIZE];
 
     // Create [`UnpackedChunks`] with FoR strategy.
     let mut unpacked = UnpackedChunks::try_new_with_strategy(
         strategy,
-        bp.packed().as_host().clone(),
+        bp.packed_slice::<T>(),
         bp.bit_width() as usize,
         bp.offset() as usize,
         bp.len(),
+        &mut scratch,
     )?;
 
     let mut builder = PrimitiveBuilder::<T>::with_capacity(


### PR DESCRIPTION
## Summary

Reduce FastLanes bit-packed decode overhead independently of buffer allocation changes.

## Changes

- Borrow packed slices and caller-owned unpack scratch.
- Keep scratch out of the iterator struct and reuse it across chunks.
- Walk fused compare blocks without an unused unpack buffer.