### PR TITLE
Optimize RunsOn CI and prebuilt fallbacks

### DIFF
--- a/.github/actions/setup-prebuild/action.yml
+++ b/.github/actions/setup-prebuild/action.yml
@@ -1,5 +1,5 @@
 name: "Setup Prebuild"
-description: "Prebuild AMIs — uses pre-installed tools, falls back to full setup-rust for forks"
+description: "Use pre-installed AMI tools and install any missing requirements"
 
 inputs:
   repo-token:
@@ -16,6 +16,10 @@ inputs:
   targets:
     description: "optional targets override (e.g. wasm32-unknown-unknown)"
     required: false
+  protoc-version:
+    description: "protoc version expected in the prebuilt image"
+    default: "29.3"
+    required: false
   enable-sccache:
     description: "Should sccache be enabled."
     required: false
@@ -24,7 +28,122 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Prebuild path: tools already installed, just configure sccache
+    - name: Resolve toolchain config
+      if: github.repository == 'vortex-data/vortex'
+      id: toolchain-config
+      shell: bash
+      run: |
+        DEFAULT_VERSION=$(grep channel rust-toolchain.toml | awk -F'"' '{print $2}')
+        TOOLCHAIN="${TOOLCHAIN_OVERRIDE:-$DEFAULT_VERSION}"
+        echo "toolchain=$TOOLCHAIN" >> "$GITHUB_OUTPUT"
+      env:
+        TOOLCHAIN_OVERRIDE: ${{ inputs.toolchain }}
+
+    - name: Check for rustup
+      if: github.repository == 'vortex-data/vortex'
+      id: check-rustup
+      shell: bash
+      run: echo "exists=$(command -v rustup &> /dev/null && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
+
+    - name: Install Rust
+      if: github.repository == 'vortex-data/vortex' && steps.check-rustup.outputs.exists != 'true'
+      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c  # stable
+      with:
+        toolchain: ${{ steps.toolchain-config.outputs.toolchain }}
+        targets: ${{ inputs.targets }}
+        components: ${{ inputs.components }}
+
+    - name: Reconcile prebuilt Rust installation
+      if: github.repository == 'vortex-data/vortex' && steps.check-rustup.outputs.exists == 'true'
+      shell: bash
+      run: |
+        TOOLCHAIN_FOUND=false
+        for INSTALLED in $(rustup toolchain list | awk '{print $1}'); do
+          case "$INSTALLED" in
+            "$TOOLCHAIN"|"$TOOLCHAIN"-*) TOOLCHAIN_FOUND=true ;;
+          esac
+        done
+        if [ "$TOOLCHAIN_FOUND" != true ]; then
+          rustup toolchain install "$TOOLCHAIN" --profile minimal
+        fi
+
+        TOOLCHAIN_HOST=$(rustc +"$TOOLCHAIN" --print host-tuple)
+        INSTALLED_COMPONENTS=$(rustup component list --toolchain "$TOOLCHAIN" --installed)
+        MISSING_COMPONENTS=()
+        IFS=',' read -ra REQUESTED_COMPONENTS <<< "$COMPONENTS"
+        for COMPONENT in "${REQUESTED_COMPONENTS[@]}"; do
+          COMPONENT=${COMPONENT// /}
+          [ -z "$COMPONENT" ] && continue
+          if [ "$COMPONENT" = llvm-tools ]; then
+            COMPONENT=llvm-tools-preview
+          fi
+          if ! grep -Fqx "$COMPONENT" <<< "$INSTALLED_COMPONENTS" && \
+             ! grep -Fqx "$COMPONENT-$TOOLCHAIN_HOST" <<< "$INSTALLED_COMPONENTS"; then
+            MISSING_COMPONENTS+=("$COMPONENT")
+          fi
+        done
+        if [ ${#MISSING_COMPONENTS[@]} -gt 0 ]; then
+          rustup component add --toolchain "$TOOLCHAIN" "${MISSING_COMPONENTS[@]}"
+        fi
+
+        INSTALLED_TARGETS=$(rustup target list --toolchain "$TOOLCHAIN" --installed)
+        MISSING_TARGETS=()
+        IFS=',' read -ra REQUESTED_TARGETS <<< "$TARGETS"
+        for TARGET in "${REQUESTED_TARGETS[@]}"; do
+          TARGET=${TARGET// /}
+          [ -z "$TARGET" ] && continue
+          if ! grep -Fqx "$TARGET" <<< "$INSTALLED_TARGETS"; then
+            MISSING_TARGETS+=("$TARGET")
+          fi
+        done
+        if [ ${#MISSING_TARGETS[@]} -gt 0 ]; then
+          rustup target add --toolchain "$TOOLCHAIN" "${MISSING_TARGETS[@]}"
+        fi
+      env:
+        TOOLCHAIN: ${{ steps.toolchain-config.outputs.toolchain }}
+        COMPONENTS: ${{ inputs.components }}
+        TARGETS: ${{ inputs.targets }}
+
+    - name: Reconcile mold installation
+      if: github.repository == 'vortex-data/vortex' && runner.os == 'Linux'
+      shell: bash
+      run: |
+        if ! command -v mold >/dev/null; then
+          sudo apt-get update
+          sudo apt-get install -y mold
+        fi
+
+    - name: Check protoc installation
+      if: github.repository == 'vortex-data/vortex' && runner.os == 'Linux'
+      id: check-protoc
+      shell: bash
+      run: |
+        EXPECTED="libprotoc $PROTOC_VERSION"
+        ACTUAL=$(protoc --version 2>/dev/null || true)
+        echo "install=$([ "$ACTUAL" = "$EXPECTED" ] && echo false || echo true)" >> "$GITHUB_OUTPUT"
+      env:
+        PROTOC_VERSION: ${{ inputs.protoc-version }}
+
+    - name: Install protoc
+      if: steps.check-protoc.outputs.install == 'true'
+      uses: ./.github/actions/setup-protoc
+      with:
+        protoc_version: ${{ inputs.protoc-version }}
+
+    - name: Check sccache installation
+      if: github.repository == 'vortex-data/vortex' && inputs.enable-sccache == 'true'
+      id: check-sccache
+      shell: bash
+      run: echo "installed=$(command -v sccache >/dev/null && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+    - name: Install sccache
+      if: >-
+        github.repository == 'vortex-data/vortex' &&
+        inputs.enable-sccache == 'true' &&
+        steps.check-sccache.outputs.installed != 'true'
+      uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+
+    # Prebuild path: configure the bundled (or fallback-installed) sccache.
     - name: Configure sccache timeout
       if: github.repository == 'vortex-data/vortex' && inputs.enable-sccache == 'true'
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     name: "Python (lint)"
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=python-lint', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=python-lint', github.run_id)
           || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
@@ -97,7 +97,7 @@ jobs:
     name: "Python (test)"
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-large/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=python-test', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-large/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=python-test', github.run_id)
           || 'ubuntu-latest' }}
     timeout-minutes: 30
     env:
@@ -215,7 +215,7 @@ jobs:
     timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-small/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=rust-docs', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-small/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=rust-docs', github.run_id)
           || 'ubuntu-latest' }}
     steps:
       - uses: runs-on/action@v2
@@ -252,17 +252,17 @@ jobs:
       matrix:
         config:
           - name: "all-features"
-            runner: amd64-large
+            runner: amd64-ci-large
             args: "--all-features --all-targets"
           - name: "default features"
-            runner: amd64-large
+            runner: amd64-ci-large
             args: "--all-targets"
           - name: "with tokio dispatcher"
-            runner: amd64-small
+            runner: amd64-ci-small
             # Only build the crates that have the tokio features, not re-building other crates with no-default-features
             args: "--no-default-features --features tokio --all-targets -p vortex -p vortex-io -p vortex-file -p vortex-layout"
           - name: "wasm32 with default features"
-            runner: amd64-medium
+            runner: amd64-ci-medium
             target: wasm32-unknown-unknown
             env:
               rustflags: "RUSTFLAGS='-A warnings --cfg getrandom_backend=\"unsupported\"'"
@@ -276,9 +276,7 @@ jobs:
       - uses: ./.github/actions/setup-prebuild
         with:
           enable-sccache: "true"
-      - name: Install wasm32 target
-        if: matrix.config.target == 'wasm32-unknown-unknown'
-        run: rustup target add wasm32-unknown-unknown
+          targets: ${{ matrix.config.target }}
       - uses: ./.github/actions/check-rebuild
         with:
           command: "${{matrix.config.env.rustflags}} cargo hack build --profile ci --locked ${{matrix.config.args}} --ignore-private"
@@ -292,7 +290,7 @@ jobs:
     timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=rust-min-deps', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=rust-min-deps', github.run_id)
           || 'ubuntu-latest' }}
     steps:
       - uses: runs-on/action@v2
@@ -310,7 +308,7 @@ jobs:
     timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=rust-msrv', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=rust-msrv', github.run_id)
           || 'ubuntu-latest' }}
     env:
       RUSTFLAGS: "-A warnings"
@@ -332,7 +330,7 @@ jobs:
     timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-large/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=rust-lint', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-large/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=rust-lint', github.run_id)
           || 'ubuntu-latest' }}
     steps:
       - uses: runs-on/action@v2
@@ -412,7 +410,7 @@ jobs:
     timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=rust-lint-no-default', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=rust-lint-no-default', github.run_id)
           || 'ubuntu-latest' }}
     steps:
       - uses: runs-on/action@v2
@@ -506,7 +504,7 @@ jobs:
     timeout-minutes: 10
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=btrblocks-golden', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=btrblocks-golden', github.run_id)
           || 'ubuntu-latest' }}
     steps:
       - uses: runs-on/action@v2
@@ -537,7 +535,7 @@ jobs:
     name: "Java"
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/pool=amd64-medium-pre-v2/extras=s3-cache/tag=java', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=java', github.run_id)
           || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
@@ -576,7 +574,7 @@ jobs:
     timeout-minutes: 5
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=cxx-build', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=cxx-build', github.run_id)
           || 'ubuntu-latest' }}
     steps:
       - uses: runs-on/action@v2
@@ -624,7 +622,7 @@ jobs:
     needs: duckdb-ready
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=sql-logic-test', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=sql-logic-test', github.run_id)
           || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
@@ -650,7 +648,7 @@ jobs:
     needs: duckdb-ready
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=duckdb-s3-test', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=duckdb-s3-test', github.run_id)
           || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
@@ -692,7 +690,7 @@ jobs:
     timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=wasm-integration', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=wasm-integration', github.run_id)
           || 'ubuntu-latest' }}
     steps:
       - uses: runs-on/action@v2
@@ -704,8 +702,6 @@ jobs:
         with:
           enable-sccache: "true"
           targets: "wasm32-wasip1"
-      - name: Install wasm32-wasip1 target
-        run: rustup target add wasm32-wasip1
       - name: Setup Wasmer
         shell: bash
         run: |
@@ -720,7 +716,7 @@ jobs:
     name: "Check generated source files are up to date"
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=generated-files', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=generated-files', github.run_id)
           || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
@@ -775,7 +771,7 @@ jobs:
     timeout-minutes: 10
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=cxx-build', github.run_id)
+          && format('runs-on={0}/runner=amd64-ci-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=cxx-build', github.run_id)
           || 'ubuntu-latest' }}
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/close-fixed-fuzzer-issues.yml
+++ b/.github/workflows/close-fixed-fuzzer-issues.yml
@@ -38,13 +38,24 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: ./.github/actions/setup-rust
+      - uses: ./.github/actions/setup-prebuild
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           enable-sccache: ${{ github.repository == 'vortex-data/vortex' && 'true' || 'false' }}
 
+      - name: Check LLVM toolchain
+        id: llvm-toolchain
+        shell: bash
+        run: |
+          if command -v clang >/dev/null && command -v llvm-symbolizer >/dev/null; then
+            echo "installed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "installed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install llvm
+        if: steps.llvm-toolchain.outputs.installed != 'true'
         uses: aminya/setup-cpp@v1
         with:
           compiler: llvm

--- a/.github/workflows/fuzz-coverage.yml
+++ b/.github/workflows/fuzz-coverage.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: ./.github/actions/setup-rust
+      - uses: ./.github/actions/setup-prebuild
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -149,7 +149,7 @@ jobs:
     uses: ./.github/workflows/run-fuzzer.yml
     with:
       fuzz_target: fsst_like
-      jobs: 16
+      jobs: 4
     secrets:
       R2_FUZZ_ACCESS_KEY_ID: ${{ secrets.R2_FUZZ_ACCESS_KEY_ID }}
       R2_FUZZ_SECRET_ACCESS_KEY: ${{ secrets.R2_FUZZ_SECRET_ACCESS_KEY }}

--- a/.github/workflows/minimize_fuzz_corpus_workflow.yml
+++ b/.github/workflows/minimize_fuzz_corpus_workflow.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: ./.github/actions/setup-rust
+      - uses: ./.github/actions/setup-prebuild
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}

--- a/.github/workflows/run-fuzzer.yml
+++ b/.github/workflows/run-fuzzer.yml
@@ -18,10 +18,10 @@ on:
         type: number
         default: 18000
       runner:
-        description: "Runner name from .github-private runs-on.yml (e.g., arm64-medium, gpu)"
+        description: "Runner name from .github-private runs-on.yml (e.g., arm64-fuzz, gpu)"
         required: false
         type: string
-        default: "arm64-medium"
+        default: "arm64-fuzz"
       extra_features:
         description: "Extra cargo features to enable (e.g., cuda)"
         required: false
@@ -33,7 +33,7 @@ on:
         type: string
         default: ""
       jobs:
-        description: "Number of parallel fuzzing jobs (libfuzzer -fork=N). Set to match available vCPUs."
+        description: "Number of parallel fuzzing jobs (libfuzzer -fork=N)."
         required: false
         type: number
         default: 1
@@ -78,13 +78,36 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
+      - uses: ./.github/actions/setup-prebuild
+        if: >-
+          github.repository == 'vortex-data/vortex' &&
+          contains(fromJSON('["arm64-fuzz", "arm64-medium"]'), inputs.runner)
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+          enable-sccache: "true"
+
       - uses: ./.github/actions/setup-rust
+        if: >-
+          github.repository != 'vortex-data/vortex' ||
+          !contains(fromJSON('["arm64-fuzz", "arm64-medium"]'), inputs.runner)
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           enable-sccache: ${{ github.repository == 'vortex-data/vortex' && 'true' || 'false' }}
 
+      - name: Check LLVM toolchain
+        id: llvm-toolchain
+        shell: bash
+        run: |
+          if command -v clang >/dev/null && command -v llvm-symbolizer >/dev/null; then
+            echo "installed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "installed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install llvm
+        if: steps.llvm-toolchain.outputs.installed != 'true'
         uses: aminya/setup-cpp@v1
         with:
           compiler: llvm

--- a/.github/workflows/rust-instrumented.yml
+++ b/.github/workflows/rust-instrumented.yml
@@ -136,8 +136,10 @@ jobs:
           enable-sccache: "true"
       - name: Install lcov
         run: |
-          sudo apt-get update
-          sudo apt-get install -y lcov libjson-xs-perl
+          if ! command -v lcov >/dev/null || ! dpkg-query -W libjson-xs-perl >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y lcov libjson-xs-perl
+          fi
       - name: Build FFI library
         run: cargo build -p vortex-ffi
       - name: Build and test C++ API with coverage
@@ -166,7 +168,7 @@ jobs:
     name: "Rust tests (${{ matrix.sanitizer }})"
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/pool=amd64-medium-pre-v2/tag=rust-test-sanitizer', github.run_id)
+          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/extras=s3-cache/tag=rust-test-sanitizer', github.run_id)
           || 'ubuntu-latest' }}
     timeout-minutes: 30
     env:


### PR DESCRIPTION
## Summary

- right-size general RunsOn CI jobs and broaden use of the new spot runner classes
- run CPU fuzzers on an 8-vCPU Graviton runner with four libFuzzer processes
- use prebuilt Rust and LLVM for ARM fuzzing while retaining conditional installation fallbacks
- reconcile Rust toolchains, components, targets, mold, protoc, and sccache against the AMI
- avoid redundant WASM target and coverage-package installation

Requires vortex-data/.github-private#29 to land first so the new runner aliases exist.

## Validation

- strict `yamllint` on all changed workflow/action files
- reconciliation fast-path and missing-toolchain shell tests
- `git diff --check`