### PR TITLE
Add ExecutionCtx to VTable::validity

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -84,6 +84,7 @@ impl VTable for ALP {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let alp_slots = ALPSlotsView::from_slots(slots);
         let patches =

--- a/encodings/alp/src/alp/plugin.rs
+++ b/encodings/alp/src/alp/plugin.rs
@@ -57,15 +57,19 @@ impl ArrayPlugin for ALPPatchedPlugin {
             "ALP plugin does not recognize serialized ID {}",
             parts.serialized_id,
         );
-        let alp_array = Array::<ALP>::try_from_parts(ArrayVTable::deserialize(
-            &ALP,
-            parts.dtype,
-            parts.len,
-            parts.metadata,
-            parts.buffers,
-            parts.children,
-            session,
-        )?)
+        let mut ctx = session.create_execution_ctx();
+        let alp_array = Array::<ALP>::try_from_parts_in(
+            ArrayVTable::deserialize(
+                &ALP,
+                parts.dtype,
+                parts.len,
+                parts.metadata,
+                parts.buffers,
+                parts.children,
+                session,
+            )?,
+            &mut ctx,
+        )
         .map_err(|_| vortex_err!("ALP plugin should only deserialize vortex.alp"))?;
 
         // Check if there are interior patches to externalize.
@@ -78,11 +82,7 @@ impl ArrayPlugin for ALPPatchedPlugin {
 
         let alp_without_patches = ALP::try_new(encoded, exponents, None)?.into_array();
 
-        let patched = Patched::from_array_and_patches(
-            alp_without_patches,
-            &patches,
-            &mut session.create_execution_ctx(),
-        )?;
+        let patched = Patched::from_array_and_patches(alp_without_patches, &patches, &mut ctx)?;
 
         Ok(patched.into_array())
     }

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -105,6 +105,7 @@ impl VTable for ALPRD {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let alprd_slots = ALPRDSlotsView::from_slots(slots);
         validate_parts(

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -72,6 +72,7 @@ impl VTable for ByteBool {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let validity =
             child_to_validity(slots[ByteBoolSlots::VALIDITY].as_ref(), dtype.nullability());

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -105,6 +105,7 @@ impl VTable for DateTimeParts {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let slots = DateTimePartsSlotsView::from_slots(slots);
         DateTimePartsData::validate(dtype, slots.days, slots.seconds, slots.subseconds, len)

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -86,6 +86,7 @@ impl VTable for DecimalByteParts {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let Some(decimal_dtype) = dtype.as_decimal_opt() else {
             vortex_bail!("expected decimal dtype, got {}", dtype)
@@ -137,10 +138,6 @@ impl VTable for DecimalByteParts {
         _session: &VortexSession,
     ) -> VortexResult<ArrayParts<Self>> {
         let metadata = DecimalBytesPartsMetadata::decode(metadata)?;
-        let Some(decimal_dtype) = dtype.as_decimal_opt() else {
-            vortex_bail!("decoding decimal but given non decimal dtype {}", dtype)
-        };
-
         let encoded_dtype = DType::Primitive(metadata.zeroth_child_ptype(), dtype.nullability());
 
         let msp = children.get(0, &encoded_dtype, len)?;
@@ -150,8 +147,8 @@ impl VTable for DecimalByteParts {
             "lower_part_count > 0 not currently supported"
         );
 
-        let slots = smallvec![Some(msp.clone())];
-        let data = DecimalBytePartsData::try_new(msp.dtype(), msp.len(), *decimal_dtype)?;
+        let slots = smallvec![Some(msp)];
+        let data = DecimalBytePartsData::new();
         Ok(ArrayParts::new(self.clone(), dtype.clone(), len, data).with_slots(slots))
     }
 
@@ -222,21 +219,12 @@ impl DecimalBytePartsData {
         Ok(())
     }
 
-    pub(crate) fn try_new(
-        msp_dtype: &DType,
-        msp_len: usize,
-        decimal_dtype: DecimalDType,
-    ) -> VortexResult<Self> {
-        let expected_dtype = DType::Decimal(decimal_dtype, msp_dtype.nullability());
-        vortex_ensure!(
-            msp_dtype.is_signed_int(),
-            "decimal bytes parts, first part must be a signed array"
-        );
-        let _ = msp_len;
-        drop(expected_dtype);
-        Ok(Self {
+    /// Builds the payload. The MSP dtype and length are checked by
+    /// [`VTable::validate`](vortex_array::array::VTable::validate) on construction.
+    pub(crate) fn new() -> Self {
+        Self {
             _lower_parts: Vec::new(),
-        })
+        }
     }
 }
 
@@ -251,13 +239,10 @@ impl DecimalByteParts {
     ) -> VortexResult<DecimalBytePartsArray> {
         let len = msp.len();
         let dtype = DType::Decimal(decimal_dtype, msp.dtype().nullability());
-        let slots = smallvec![Some(msp.clone())];
-        let data = DecimalBytePartsData::try_new(msp.dtype(), msp.len(), decimal_dtype)?;
-        Ok(unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(DecimalByteParts, dtype, len, data).with_slots(slots),
-            )
-        })
+        let slots = smallvec![Some(msp)];
+        let data = DecimalBytePartsData::new();
+
+        Array::try_from_parts(ArrayParts::new(DecimalByteParts, dtype, len, data).with_slots(slots))
     }
 }
 

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -125,24 +125,15 @@ impl BitPackedData {
     ///   up to the next multiple of 1024.
     ///
     /// Any violation of these preconditions will result in an error.
-    pub fn try_new(
-        packed: BufferHandle,
-        patches: Option<Patches>,
-        bit_width: u8,
-        offset: u16,
-    ) -> VortexResult<Self> {
-        vortex_ensure!(bit_width <= 64, "Unsupported bit width {bit_width}");
-        vortex_ensure!(
-            offset < 1024,
-            "Offset must be less than the full block i.e., 1024, got {offset}"
-        );
-
-        Ok(Self {
+    /// Builds the payload. The bit width and offset bounds are checked by
+    /// [`VTable::validate`](vortex_array::array::VTable::validate) on construction.
+    pub fn new(packed: BufferHandle, patches: Option<Patches>, bit_width: u8, offset: u16) -> Self {
+        Self {
             offset,
             bit_width,
             packed,
             patches_data: patches.as_ref().map(PatchesData::from_patches),
-        })
+        }
     }
 
     pub(crate) fn validate(
@@ -156,6 +147,10 @@ impl BitPackedData {
     ) -> VortexResult<()> {
         vortex_ensure!(ptype.is_int(), MismatchedTypes: "integer", ptype);
         vortex_ensure!(bit_width <= 64, "Unsupported bit width {bit_width}");
+        vortex_ensure!(
+            offset < 1024,
+            "Offset must be less than the full block i.e., 1024, got {offset}"
+        );
 
         if let Some(validity_len) = validity.maybe_len() {
             vortex_ensure!(

--- a/encodings/fastlanes/src/bitpacking/plugin.rs
+++ b/encodings/fastlanes/src/bitpacking/plugin.rs
@@ -56,15 +56,19 @@ impl ArrayPlugin for BitPackedPatchedPlugin {
             "BitPacked plugin does not recognize serialized ID {}",
             parts.serialized_id,
         );
-        let bitpacked = Array::<BitPacked>::try_from_parts(ArrayVTable::deserialize(
-            &BitPacked,
-            parts.dtype,
-            parts.len,
-            parts.metadata,
-            parts.buffers,
-            parts.children,
-            session,
-        )?)
+        let mut ctx = session.create_execution_ctx();
+        let bitpacked = Array::<BitPacked>::try_from_parts_in(
+            ArrayVTable::deserialize(
+                &BitPacked,
+                parts.dtype,
+                parts.len,
+                parts.metadata,
+                parts.buffers,
+                parts.children,
+                session,
+            )?,
+            &mut ctx,
+        )
         .map_err(|_| vortex_err!("BitPacked plugin should only deserialize fastlanes.bitpacked"))?;
 
         // Create a new BitPackedArray without the interior patches installed.
@@ -82,11 +86,8 @@ impl ArrayPlugin for BitPackedPatchedPlugin {
         let bitpacked_without_patches =
             BitPacked::try_new(packed, ptype, validity, None, bw, len, offset)?.into_array();
 
-        let patched = Patched::from_array_and_patches(
-            bitpacked_without_patches,
-            &patches,
-            &mut session.create_execution_ctx(),
-        )?;
+        let patched =
+            Patched::from_array_and_patches(bitpacked_without_patches, &patches, &mut ctx)?;
 
         Ok(patched.into_array())
     }

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -107,6 +107,7 @@ impl VTable for BitPacked {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let bp_slots = BitPackedSlotsView::from_slots(slots);
 
@@ -236,7 +237,7 @@ impl VTable for BitPacked {
             s.push(validity_to_child(&validity, len));
             s
         };
-        let data = BitPackedData::try_new(
+        let data = BitPackedData::new(
             packed,
             patches,
             u8::try_from(metadata.bit_width).map_err(|_| {
@@ -251,7 +252,7 @@ impl VTable for BitPacked {
                     metadata.offset
                 )
             })?,
-        )?;
+        );
         Ok(ArrayParts::new(self.clone(), dtype.clone(), len, data).with_slots(slots))
     }
 
@@ -319,7 +320,7 @@ impl BitPacked {
             s.push(validity_to_child(&validity, len));
             s
         };
-        let data = BitPackedData::try_new(packed, patches, bit_width, offset)?;
+        let data = BitPackedData::new(packed, patches, bit_width, offset);
         Array::try_from_parts(ArrayParts::new(BitPacked, dtype, len, data).with_slots(slots))
     }
 

--- a/encodings/fastlanes/src/delta/vtable/mod.rs
+++ b/encodings/fastlanes/src/delta/vtable/mod.rs
@@ -84,6 +84,7 @@ impl VTable for Delta {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let delta_slots = DeltaSlotsView::from_slots(slots);
         validate_parts(

--- a/encodings/fastlanes/src/for/vtable/mod.rs
+++ b/encodings/fastlanes/src/for/vtable/mod.rs
@@ -81,6 +81,7 @@ impl VTable for FoR {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let encoded = FoRSlotsView::from_slots(slots).encoded;
         validate_parts(encoded.dtype(), encoded.len(), &data.reference, dtype, len)

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -89,6 +89,7 @@ impl VTable for RLE {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let rle_slots = RLESlotsView::from_slots(slots);
         validate_parts(

--- a/encodings/fastlanes/src/transposed_bool.rs
+++ b/encodings/fastlanes/src/transposed_bool.rs
@@ -144,6 +144,7 @@ impl VTable for TransposedBool {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             dtype == &DType::Bool(Nullability::NonNullable),

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -26,7 +26,6 @@ use vortex_array::EqMode;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::TypedArrayRef;
-use vortex_array::VortexSessionExecute;
 use vortex_array::array_slots;
 use vortex_array::arrays::VarBin;
 use vortex_array::arrays::VarBinArray;
@@ -39,7 +38,6 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::OffsetBuilderPType;
 use vortex_array::dtype::PType;
-use vortex_array::legacy_session;
 use vortex_array::match_each_integer_ptype;
 use vortex_array::match_each_varbin_builder;
 use vortex_array::serde::ArrayChildren;
@@ -124,17 +122,15 @@ impl VTable for FSST {
         *ID
     }
 
-    #[allow(clippy::disallowed_methods)]
     fn validate(
         &self,
         data: &Self::TypedArrayData,
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
-        // TODO(ctx): trait fixes - VTable::validate has a fixed signature.
-        let mut ctx = legacy_session().create_execution_ctx();
-        data.validate(dtype, len, slots, &mut ctx)
+        data.validate(dtype, len, slots, ctx)
     }
 
     fn nbuffers(_array: ArrayView<'_, Self>) -> usize {
@@ -233,13 +229,12 @@ impl VTable for FSST {
         metadata: &[u8],
         buffers: &[BufferHandle],
         children: &dyn ArrayChildren,
-        session: &VortexSession,
+        _session: &VortexSession,
     ) -> VortexResult<ArrayParts<Self>> {
         let metadata = FSSTMetadata::decode(metadata)?;
         let symbols = Buffer::<Symbol>::from_byte_buffer(buffers[0].clone().try_to_host_sync()?);
         let symbol_lengths = Buffer::<u8>::from_byte_buffer(buffers[1].clone().try_to_host_sync()?);
 
-        let mut ctx = session.create_execution_ctx();
         if buffers.len() == 2 {
             return Self::deserialize_legacy(
                 self,
@@ -249,7 +244,6 @@ impl VTable for FSST {
                 &symbols,
                 &symbol_lengths,
                 children,
-                &mut ctx,
             );
         }
 
@@ -283,17 +277,6 @@ impl VTable for FSST {
                 vortex_bail!("Expected 2 or 3 children, got {}", children.len());
             };
 
-            FSSTData::validate_parts(
-                symbols.as_slice(),
-                symbol_lengths.as_slice(),
-                &codes_bytes,
-                &codes_offsets,
-                dtype.nullability(),
-                &uncompressed_lengths,
-                dtype,
-                len,
-                &mut ctx,
-            )?;
             let slots = FSSTSlots {
                 uncompressed_lengths,
                 codes_offsets,
@@ -597,21 +580,14 @@ impl FSST {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<FSSTArray> {
         let len = codes.len();
-        FSSTData::validate_parts_from_codes(
-            symbols.as_slice(),
-            symbol_lengths.as_slice(),
-            &codes,
-            &uncompressed_lengths,
-            &dtype,
-            len,
-            ctx,
-        )?;
         let slots = FSSTData::make_slots(&codes, &uncompressed_lengths);
         let codes_bytes = codes.bytes_handle().clone();
         let data = FSSTData::try_new(symbols, symbol_lengths, codes_bytes, len)?;
-        Ok(unsafe {
-            Array::from_parts_unchecked(ArrayParts::new(FSST, dtype, len, data).with_slots(slots))
-        })
+
+        Array::try_from_parts_in(
+            ArrayParts::new(FSST, dtype, len, data).with_slots(slots),
+            ctx,
+        )
     }
 
     pub fn try_new_with_symbol_table(
@@ -622,22 +598,16 @@ impl FSST {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<FSSTArray> {
         let len = codes.len();
-        FSSTData::validate_parts_from_codes(
-            symbol_table.symbols(),
-            symbol_table.symbol_lengths(),
-            &codes,
-            &uncompressed_lengths,
-            &dtype,
-            len,
-            ctx,
-        )?;
         let slots = FSSTData::make_slots(&codes, &uncompressed_lengths);
         let codes_bytes = codes.bytes_handle().clone();
+        // SAFETY: `try_from_parts_in` validates the symbol table shape before publishing.
         let data =
             unsafe { FSSTData::new_unchecked_with_symbol_table(symbol_table, codes_bytes, len) };
-        Ok(unsafe {
-            Array::from_parts_unchecked(ArrayParts::new(FSST, dtype, len, data).with_slots(slots))
-        })
+
+        Array::try_from_parts_in(
+            ArrayParts::new(FSST, dtype, len, data).with_slots(slots),
+            ctx,
+        )
     }
 
     /// Legacy deserialization path (2 buffers): the codes were stored as a full
@@ -652,7 +622,6 @@ impl FSST {
         symbols: &Buffer<Symbol>,
         symbol_lengths: &Buffer<u8>,
         children: &dyn ArrayChildren,
-        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayParts<Self>> {
         if children.len() != 2 {
             vortex_bail!(InvalidArgument: "Expected 2 children, got {}", children.len());
@@ -676,15 +645,6 @@ impl FSST {
             len,
         )?;
 
-        FSSTData::validate_parts_from_codes(
-            symbols.as_slice(),
-            symbol_lengths.as_slice(),
-            &codes,
-            &uncompressed_lengths,
-            dtype,
-            len,
-            ctx,
-        )?;
         let slots = FSSTData::make_slots(&codes, &uncompressed_lengths);
         let codes_bytes = codes.bytes_handle().clone();
         let data = FSSTData::try_new(symbols.clone(), symbol_lengths.clone(), codes_bytes, len)?;
@@ -885,28 +845,6 @@ impl FSSTData {
     }
 
     /// Validate using a VarBinArray for the codes (convenience for construction paths).
-    fn validate_parts_from_codes(
-        symbols: &[Symbol],
-        symbol_lengths: &[u8],
-        codes: &VarBinArray,
-        uncompressed_lengths: &ArrayRef,
-        dtype: &DType,
-        len: usize,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<()> {
-        Self::validate_parts(
-            symbols,
-            symbol_lengths,
-            codes.bytes_handle(),
-            codes.offsets(),
-            codes.dtype().nullability(),
-            uncompressed_lengths,
-            dtype,
-            len,
-            ctx,
-        )
-    }
-
     pub(crate) unsafe fn new_unchecked_with_symbol_table(
         symbol_table: Arc<FSSTSymbolTable>,
         codes_bytes: BufferHandle,

--- a/encodings/onpair/src/array.rs
+++ b/encodings/onpair/src/array.rs
@@ -452,6 +452,7 @@ impl VTable for OnPair {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let s = OnPairSlotsView::from_slots(slots);
         validate_parts(

--- a/encodings/parquet-variant/src/vtable.rs
+++ b/encodings/parquet-variant/src/vtable.rs
@@ -95,6 +95,7 @@ impl VTable for ParquetVariant {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             slots.len() == ParquetVariantSlots::COUNT,

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -138,6 +138,7 @@ impl VTable for Pco {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let validity = child_to_validity(
             PcoSlotsView::from_slots(slots).validity,

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -20,7 +20,6 @@ use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
 use vortex_array::TypedArrayRef;
-use vortex_array::VortexSessionExecute;
 use vortex_array::array_slots;
 use vortex_array::arrays::DecimalArray;
 use vortex_array::arrays::Primitive;
@@ -29,7 +28,6 @@ use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
-use vortex_array::legacy_session;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
 use vortex_array::vtable::VTable;
@@ -87,20 +85,18 @@ impl VTable for RunEnd {
         *ID
     }
 
-    #[allow(clippy::disallowed_methods)]
     fn validate(
         &self,
         data: &Self::TypedArrayData,
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let run_end_slots = RunEndSlotsView::from_slots(slots);
         let ends = run_end_slots.ends;
         let values = run_end_slots.values;
-        // TODO(ctx): trait fixes - VTable::validate has a fixed signature.
-        let mut ctx = legacy_session().create_execution_ctx();
-        RunEndData::validate_parts(ends, values, data.offset, len, &mut ctx)?;
+        RunEndData::validate_parts(ends, values, data.offset, len, ctx)?;
         vortex_ensure!(
             values.dtype() == dtype,
             "expected dtype {}, got {}",
@@ -261,11 +257,13 @@ impl RunEnd {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<RunEndArray> {
         let len = RunEndData::logical_len_from_ends(&ends, ctx)?;
-        RunEndData::validate_parts(&ends, &values, 0, len, ctx)?;
         let dtype = values.dtype().clone();
         let slots = RunEndSlots { ends, values }.into_slots();
         let data = RunEndData::new(0);
-        Array::try_from_parts(ArrayParts::new(RunEnd, dtype, len, data).with_slots(slots))
+        Array::try_from_parts_in(
+            ArrayParts::new(RunEnd, dtype, len, data).with_slots(slots),
+            ctx,
+        )
     }
 
     /// Build a new [`RunEndArray`] from ends, values, offset, and length.
@@ -276,11 +274,13 @@ impl RunEnd {
         length: usize,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<RunEndArray> {
-        RunEndData::validate_parts(&ends, &values, offset, length, ctx)?;
         let dtype = values.dtype().clone();
         let slots = RunEndSlots { ends, values }.into_slots();
         let data = RunEndData::new(offset);
-        Array::try_from_parts(ArrayParts::new(RunEnd, dtype, length, data).with_slots(slots))
+        Array::try_from_parts_in(
+            ArrayParts::new(RunEnd, dtype, length, data).with_slots(slots),
+            ctx,
+        )
     }
 
     /// Build a new [`RunEndArray`] from ends and values (panics on invalid input).
@@ -297,7 +297,10 @@ impl RunEnd {
             let dtype = values.dtype().clone();
             let slots = RunEndSlots { ends, values }.into_slots();
             let data = unsafe { RunEndData::new_unchecked(0) };
-            Array::try_from_parts(ArrayParts::new(RunEnd, dtype, len, data).with_slots(slots))
+            Array::try_from_parts_in(
+                ArrayParts::new(RunEnd, dtype, len, data).with_slots(slots),
+                ctx,
+            )
         } else {
             vortex_bail!("REE can only encode primitive arrays")
         }

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -103,16 +103,18 @@ impl SequenceData {
         )
     }
 
-    /// Constructs a sequence array using two integer values, validated against output `ptype`.
+    /// Constructs a sequence array using two integer values, normalized to output `ptype`.
+    ///
+    /// The sequence invariants are checked by
+    /// [`VTable::validate`](vortex_array::array::VTable::validate) on construction; normalizing
+    /// already rejects a `base` that does not fit `ptype`.
     pub(crate) fn try_new(
         base: PValue,
         multiplier: PValue,
         ptype: PType,
-        nullability: Nullability,
-        length: usize,
+        _nullability: Nullability,
+        _length: usize,
     ) -> VortexResult<Self> {
-        let dtype = DType::Primitive(ptype, nullability);
-        Self::validate(base, multiplier, &dtype, length)?;
         let (base, multiplier) = Self::normalize(base, multiplier, ptype)?;
 
         Ok(unsafe { Self::new_unchecked(base, multiplier) })
@@ -310,6 +312,7 @@ impl VTable for Sequence {
         dtype: &DType,
         len: usize,
         _slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         SequenceData::validate(data.base, data.multiplier, dtype, len)
     }
@@ -504,8 +507,9 @@ impl Sequence {
         let dtype = DType::Primitive(ptype, nullability);
         let data = SequenceData::try_new(base, multiplier, ptype, nullability, length)?;
         let stats = Self::stats(data.multiplier());
+
         Ok(
-            unsafe { Array::from_parts_unchecked(ArrayParts::new(Sequence, dtype, length, data)) }
+            Array::try_from_parts(ArrayParts::new(Sequence, dtype, length, data))?
                 .with_stats_set(stats),
         )
     }
@@ -521,8 +525,9 @@ impl Sequence {
         let dtype = DType::Primitive(ptype, nullability);
         let data = SequenceData::try_new_typed(base, multiplier, nullability, length)?;
         let stats = Self::stats(data.multiplier());
+
         Ok(
-            unsafe { Array::from_parts_unchecked(ArrayParts::new(Sequence, dtype, length, data)) }
+            Array::try_from_parts(ArrayParts::new(Sequence, dtype, length, data))?
                 .with_stats_set(stats),
         )
     }

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -203,6 +203,7 @@ impl VTable for Sparse {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let patches = SparseData::patches_from_slots(data, len, slots);
         SparseData::validate(&patches, data.fill_scalar(), dtype, len)

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -62,6 +62,7 @@ impl VTable for ZigZag {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let encoded = ZigZagSlotsView::from_slots(slots).encoded;
         let expected_dtype = ZigZagData::dtype_from_encoded_dtype(encoded.dtype())?;

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -153,6 +153,7 @@ impl VTable for Zstd {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let validity = child_to_validity(slots[ZstdSlots::VALIDITY].as_ref(), dtype.nullability());
         data.validate(dtype, len, &validity)

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -412,6 +412,7 @@ impl VTable for ZstdBuffers {
         _dtype: &DType,
         _len: usize,
         _slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         data.validate()
     }
@@ -504,7 +505,6 @@ impl VTable for ZstdBuffers {
             buffer_alignments: metadata.buffer_alignments.clone(),
         };
 
-        data.validate()?;
         Ok(ArrayParts::new(self.clone(), dtype.clone(), len, data).with_slots(slots))
     }
 

--- a/vortex-array/src/array/foreign.rs
+++ b/vortex-array/src/array/foreign.rs
@@ -104,6 +104,7 @@ impl VTable for ForeignArray {
         _dtype: &DType,
         _len: usize,
         _slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         Ok(())
     }

--- a/vortex-array/src/array/plugin.rs
+++ b/vortex-array/src/array/plugin.rs
@@ -13,6 +13,7 @@ use vortex_session::VortexSession;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::VTable;
@@ -193,7 +194,7 @@ impl<V: VTable> ArrayPlugin for V {
             self.id(),
             parts.serialized_id,
         );
-        Ok(Array::<V>::try_from_parts(V::deserialize(
+        let parts = V::deserialize(
             self,
             parts.dtype,
             parts.len,
@@ -201,7 +202,9 @@ impl<V: VTable> ArrayPlugin for V {
             parts.buffers,
             parts.children,
             session,
-        )?)?
-        .into_array())
+        )?;
+        let mut ctx = session.create_execution_ctx();
+
+        Ok(Array::<V>::try_from_parts_in(parts, &mut ctx)?.into_array())
     }
 }

--- a/vortex-array/src/array/typed.rs
+++ b/vortex-array/src/array/typed.rs
@@ -117,9 +117,9 @@ pub(crate) struct ArrayData<V: VTable> {
 impl<V: VTable> ArrayInner<ArrayData<V>> {
     /// Create a new validated [`ArrayInner`] from construction parameters.
     #[doc(hidden)]
-    pub fn try_new(new: ArrayParts<V>) -> VortexResult<Self> {
+    pub fn try_new(new: ArrayParts<V>, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
         new.vtable
-            .validate(&new.data, &new.dtype, new.len, &new.slots)?;
+            .validate(&new.data, &new.dtype, new.len, &new.slots, ctx)?;
         Ok(ArrayInner {
             len: new.len,
             encoding_id: new.vtable.id(),
@@ -214,8 +214,17 @@ impl<V: VTable> Array<V> {
     ///
     /// This is the safe construction path for encoding implementors. It calls
     /// [`VTable::validate`] before publishing the array as an [`ArrayRef`].
+    ///
+    /// Prefer [`Array::try_from_parts_in`] when the caller already holds an [`ExecutionCtx`];
+    /// this variant falls back to the legacy global session.
+    #[allow(clippy::disallowed_methods)]
     pub fn try_from_parts(new: ArrayParts<V>) -> VortexResult<Self> {
-        let store = ArrayInner::<ArrayData<V>>::try_new(new)?;
+        Self::try_from_parts_in(new, &mut legacy_session().create_execution_ctx())
+    }
+
+    /// Create a typed array from explicit construction parameters, validating against `ctx`.
+    pub fn try_from_parts_in(new: ArrayParts<V>, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+        let store = ArrayInner::<ArrayData<V>>::try_new(new, ctx)?;
         let inner = ArrayRef::from_inner(Arc::new(store));
         Ok(Self {
             inner,

--- a/vortex-array/src/array/vtable/mod.rs
+++ b/vortex-array/src/array/vtable/mod.rs
@@ -83,12 +83,16 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
     /// This is called by [`Array::try_from_parts`](crate::Array::try_from_parts) before the array
     /// is published. Implementations should check dtype, length, slot count, child dtypes/lengths,
     /// metadata bounds, and any buffer shape invariants that unsafe accessors depend on.
+    ///
+    /// `ctx` lets implementations execute child arrays when an invariant cannot be checked from
+    /// metadata alone. Use it sparingly: validation runs on every checked construction.
     fn validate(
         &self,
         data: &Self::TypedArrayData,
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()>;
 
     /// Returns the number of top-level buffers in the array.
@@ -127,7 +131,12 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
 
     /// Deserialize an array from serialized metadata, buffers, and children.
     ///
-    /// The returned [`ArrayParts`] are still validated by the generic adapter.
+    /// The returned [`ArrayParts`] are passed to checked construction by the generic adapter,
+    /// which runs [`validate`](Self::validate). Implementations should therefore do only the
+    /// bare minimum needed to assemble the parts — decode metadata, check buffer and child
+    /// counts, resolve child dtypes — and leave every semantic invariant to `validate`.
+    /// Repeating those checks here validates the array twice.
+    ///
     /// Deserializers should use the provided `session` to resolve plugin-owned metadata instead of
     /// relying on global state.
     fn deserialize(

--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -203,10 +203,9 @@ impl Array<Bool> {
     ) -> VortexResult<Self> {
         let dtype = DType::Bool(validity.nullability());
         let slots = BoolData::make_slots(&validity, len);
-        let data = BoolData::try_new_from_handle(bits, offset, len, validity)?;
-        Ok(unsafe {
-            Array::from_parts_unchecked(ArrayParts::new(Bool, dtype, len, data).with_slots(slots))
-        })
+        let data = BoolData::new_from_handle(bits, offset, len);
+
+        Array::try_from_parts(ArrayParts::new(Bool, dtype, len, data).with_slots(slots))
     }
 
     /// Creates a new [`BoolArray`] without validation.
@@ -266,31 +265,13 @@ impl BoolData {
         })
     }
 
-    pub(super) fn try_new_from_handle(
-        bits: BufferHandle,
-        offset: usize,
-        len: usize,
-        validity: Validity,
-    ) -> VortexResult<Self> {
-        vortex_ensure!(offset < 8, "BitBuffer offset must be <8, got {}", offset);
-        if let Some(validity_len) = validity.maybe_len() {
-            vortex_ensure!(
-                validity_len == len,
-                "BoolArray of size {} cannot be built with validity of size {validity_len}",
-                len,
-            );
-        }
-
-        vortex_ensure!(
-            bits.len() * 8 >= (len + offset),
-            "provided BufferHandle with offset {offset} len {len} had size {} bits",
-            bits.len() * 8,
-        );
-
-        Ok(Self {
+    /// Wraps a bit buffer handle. The offset, length, and validity agreement are checked by
+    /// [`VTable::validate`](crate::array::VTable::validate) on construction.
+    pub(super) fn new_from_handle(bits: BufferHandle, offset: usize, len: usize) -> Self {
+        Self {
             bits,
             meta: BitBufferMeta::new(offset, len),
-        })
+        }
     }
 
     pub(super) unsafe fn new_unchecked(bits: BitBuffer, validity: Validity) -> Self {

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -134,10 +134,16 @@ impl VTable for Bool {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let DType::Bool(nullability) = dtype else {
             vortex_bail!("Expected bool dtype, got {dtype:?}");
         };
+        vortex_ensure!(
+            data.meta.offset() < 8,
+            "BoolArray bit offset must be <8, got {}",
+            data.meta.offset()
+        );
         vortex_ensure!(
             data.bits.len() * 8 >= data.meta.offset() + len,
             "BoolArray buffer with offset {} cannot back outer length {} (buffer bits = {})",
@@ -184,7 +190,7 @@ impl VTable for Bool {
 
         let buffer = buffers[0].clone();
         let slots = BoolData::make_slots(&validity, len);
-        let data = BoolData::try_new_from_handle(buffer, metadata.offset as usize, len, validity)?;
+        let data = BoolData::new_from_handle(buffer, metadata.offset as usize, len);
         Ok(ArrayParts::new(self.clone(), dtype.clone(), len, data).with_slots(slots))
     }
 

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -82,6 +82,7 @@ impl VTable for Chunked {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             !slots.is_empty(),

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -91,6 +91,7 @@ impl VTable for Constant {
         dtype: &DType,
         _len: usize,
         _slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             data.scalar.dtype() == dtype,

--- a/vortex-array/src/arrays/decimal/vtable/mod.rs
+++ b/vortex-array/src/arrays/decimal/vtable/mod.rs
@@ -122,6 +122,7 @@ impl VTable for Decimal {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let DType::Decimal(_, nullability) = dtype else {
             vortex_bail!("Expected decimal dtype, got {dtype:?}");

--- a/vortex-array/src/arrays/dict/vtable/mod.rs
+++ b/vortex-array/src/arrays/dict/vtable/mod.rs
@@ -100,6 +100,7 @@ impl VTable for Dict {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let view = DictSlotsView::from_slots(slots);
         let codes = view.codes;

--- a/vortex-array/src/arrays/extension/vtable/mod.rs
+++ b/vortex-array/src/arrays/extension/vtable/mod.rs
@@ -99,6 +99,7 @@ impl VTable for Extension {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let storage = slots[ExtensionSlots::STORAGE]
             .as_ref()

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -78,6 +78,7 @@ impl VTable for Filter {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             slots[FilterSlots::CHILD].is_some(),

--- a/vortex-array/src/arrays/fixed_size_list/array.rs
+++ b/vortex-array/src/arrays/fixed_size_list/array.rs
@@ -120,37 +120,6 @@ impl FixedSizeListData {
         .into_slots()
     }
 
-    /// Creates a new `FixedSizeListArray`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the provided components do not satisfy the invariants documented
-    /// in `FixedSizeListArray::new_unchecked`.
-    pub fn build(elements: ArrayRef, list_size: u32, validity: Validity, len: usize) -> Self {
-        Self::try_build(elements, list_size, validity, len)
-            .vortex_expect("FixedSizeListArray construction failed")
-    }
-
-    /// Constructs a new `FixedSizeListArray`.
-    ///
-    /// See `FixedSizeListArray::new_unchecked` for more information.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the provided components do not satisfy the invariants documented
-    /// in `FixedSizeListArray::new_unchecked`.
-    pub(crate) fn try_build(
-        elements: ArrayRef,
-        list_size: u32,
-        validity: Validity,
-        len: usize,
-    ) -> VortexResult<Self> {
-        Self::validate(&elements, len, list_size, &validity)?;
-
-        // SAFETY: we validate that the inputs are valid above.
-        Ok(unsafe { Self::new_unchecked(list_size, len) })
-    }
-
     /// Creates a new `FixedSizeListArray` without validation from these components:
     ///
     /// * `elements` is the data array where each fixed-size list is a slice.
@@ -258,12 +227,11 @@ impl Array<FixedSizeList> {
             validity.nullability(),
         );
         let slots = FixedSizeListData::make_slots(&elements, &validity, len);
-        let data = FixedSizeListData::build(elements, list_size, validity, len);
-        unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(FixedSizeList, dtype, len, data).with_slots(slots),
-            )
-        }
+        // SAFETY: `try_from_parts` validates the components before publishing the array.
+        let data = unsafe { FixedSizeListData::new_unchecked(list_size, len) };
+
+        Array::try_from_parts(ArrayParts::new(FixedSizeList, dtype, len, data).with_slots(slots))
+            .vortex_expect("FixedSizeListArray construction failed")
     }
 
     /// Constructs a new `FixedSizeListArray`.
@@ -279,12 +247,10 @@ impl Array<FixedSizeList> {
             validity.nullability(),
         );
         let slots = FixedSizeListData::make_slots(&elements, &validity, len);
-        let data = FixedSizeListData::try_build(elements, list_size, validity, len)?;
-        Ok(unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(FixedSizeList, dtype, len, data).with_slots(slots),
-            )
-        })
+        // SAFETY: `try_from_parts` validates the components before publishing the array.
+        let data = unsafe { FixedSizeListData::new_unchecked(list_size, len) };
+
+        Array::try_from_parts(ArrayParts::new(FixedSizeList, dtype, len, data).with_slots(slots))
     }
 
     /// Creates a new `FixedSizeListArray` without validation.

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -24,6 +24,7 @@ use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
 use crate::array::VTable;
+use crate::array::child_to_validity;
 use crate::array::with_empty_buffers;
 use crate::arrays::fixed_size_list::FixedSizeListData;
 use crate::arrays::fixed_size_list::FixedSizeListSlots;
@@ -111,6 +112,7 @@ impl VTable for FixedSizeList {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             slots.len() == FixedSizeListSlots::COUNT,
@@ -125,15 +127,14 @@ impl VTable for FixedSizeList {
             .as_ref()
             .vortex_expect("FixedSizeListArray elements slot");
         vortex_ensure!(
-            if *list_size == 0 {
-                data.degenerate_len == len
-            } else {
-                elements.len() / *list_size as usize == len
-            },
-            "FixedSizeListArray length {} does not match outer length {}",
-            len,
-            len
+            *list_size != 0 || data.degenerate_len == len,
+            "FixedSizeListArray degenerate length {} does not match outer length {len}",
+            data.degenerate_len
         );
+
+        let validity =
+            child_to_validity(slots[FixedSizeListSlots::VALIDITY].as_ref(), *nullability);
+        FixedSizeListData::validate(elements, len, *list_size, &validity)?;
 
         let actual_dtype =
             DType::FixedSizeList(Arc::new(elements.dtype().clone()), *list_size, *nullability);
@@ -189,8 +190,8 @@ impl VTable for FixedSizeList {
         let num_elements = len * (*list_size as usize);
         let elements = children.get(0, element_dtype.as_ref(), num_elements)?;
 
-        let data =
-            FixedSizeListData::try_build(elements.clone(), *list_size, validity.clone(), len)?;
+        // SAFETY: `try_from_parts` validates the components before publishing the array.
+        let data = unsafe { FixedSizeListData::new_unchecked(*list_size, len) };
         let slots = FixedSizeListData::make_slots(&elements, &validity, len);
         Ok(ArrayParts::new(self.clone(), dtype.clone(), len, data).with_slots(slots))
     }

--- a/vortex-array/src/arrays/interleave/mod.rs
+++ b/vortex-array/src/arrays/interleave/mod.rs
@@ -297,6 +297,7 @@ impl VTable for Interleave {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             slots.len() == data.num_values + 2,

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -136,16 +136,6 @@ impl ListData {
         .into_slots()
     }
 
-    /// Creates a new `ListArray`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the provided components do not satisfy the invariants documented
-    /// in `ListArray::new_unchecked`.
-    pub fn build(elements: ArrayRef, offsets: ArrayRef, validity: Validity) -> Self {
-        Self::try_build(elements, offsets, validity).vortex_expect("ListArray new")
-    }
-
     /// Constructs a new `ListArray`.
     ///
     /// See `ListArray::new_unchecked` for more information.
@@ -154,17 +144,6 @@ impl ListData {
     ///
     /// Returns an error if the provided components do not satisfy the invariants documented in
     /// `ListArray::new_unchecked`.
-    pub(crate) fn try_build(
-        elements: ArrayRef,
-        offsets: ArrayRef,
-        validity: Validity,
-    ) -> VortexResult<Self> {
-        Self::validate(&elements, &offsets, &validity)?;
-
-        // SAFETY: validate ensures all invariants are met.
-        Ok(unsafe { Self::new_unchecked() })
-    }
-
     /// Creates a new `ListArray` without validation from these components:
     ///
     /// * `elements` is a flat array containing all list elements concatenated.
@@ -188,11 +167,11 @@ impl ListData {
     /// Validates the components that would be used to create a `ListArray`.
     ///
     /// This function checks all the invariants required by `ListArray::new_unchecked`.
-    #[allow(clippy::disallowed_methods)]
     pub fn validate(
         elements: &ArrayRef,
         offsets: &ArrayRef,
         validity: &Validity,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         // Offsets must have at least one element
         vortex_ensure!(
@@ -209,10 +188,9 @@ impl ListData {
 
         // We can safely unwrap the DType as primitive now
         let offsets_ptype = offsets.dtype().as_ptype();
-        let mut ctx = legacy_session().create_execution_ctx();
 
         // Offsets must be sorted (but not strictly sorted, zero-length lists are allowed)
-        if let Some(is_sorted) = offsets.statistics().compute_is_sorted(&mut ctx) {
+        if let Some(is_sorted) = offsets.statistics().compute_is_sorted(ctx) {
             vortex_ensure!(is_sorted, InvalidArgument: "offsets must be sorted");
         } else {
             vortex_bail!(InvalidArgument: "offsets must report is_sorted statistic");
@@ -220,7 +198,7 @@ impl ListData {
 
         // Validate that offsets min is non-negative, and max does not exceed the length of
         // the elements array.
-        if let Some(min_max) = min_max(offsets, &mut ctx, NumericalAggregateOpts::default())? {
+        if let Some(min_max) = min_max(offsets, ctx, NumericalAggregateOpts::default())? {
             match_each_integer_ptype!(offsets_ptype, |P| {
                 #[allow(clippy::absurd_extreme_comparisons, unused_comparisons)]
                 {
@@ -362,10 +340,11 @@ impl Array<List> {
         let dtype = DType::List(Arc::new(elements.dtype().clone()), validity.nullability());
         let len = offsets.len().saturating_sub(1);
         let slots = ListData::make_slots(&elements, &offsets, &validity, len);
-        let data = ListData::build(elements, offsets, validity);
-        unsafe {
-            Array::from_parts_unchecked(ArrayParts::new(List, dtype, len, data).with_slots(slots))
-        }
+        // SAFETY: `try_from_parts` validates the components before publishing the array.
+        let data = unsafe { ListData::new_unchecked() };
+
+        Array::try_from_parts(ArrayParts::new(List, dtype, len, data).with_slots(slots))
+            .vortex_expect("ListArray new")
     }
 
     /// Constructs a new `ListArray`.
@@ -377,10 +356,10 @@ impl Array<List> {
         let dtype = DType::List(Arc::new(elements.dtype().clone()), validity.nullability());
         let len = offsets.len().saturating_sub(1);
         let slots = ListData::make_slots(&elements, &offsets, &validity, len);
-        let data = ListData::try_build(elements, offsets, validity)?;
-        Ok(unsafe {
-            Array::from_parts_unchecked(ArrayParts::new(List, dtype, len, data).with_slots(slots))
-        })
+        // SAFETY: `try_from_parts` validates the components before publishing the array.
+        let data = unsafe { ListData::new_unchecked() };
+
+        Array::try_from_parts(ArrayParts::new(List, dtype, len, data).with_slots(slots))
     }
 
     /// Creates a new `ListArray` without validation.

--- a/vortex-array/src/arrays/list/vtable/mod.rs
+++ b/vortex-array/src/arrays/list/vtable/mod.rs
@@ -25,6 +25,7 @@ use crate::array::ArrayId;
 use crate::array::ArrayParts;
 use crate::array::ArrayView;
 use crate::array::VTable;
+use crate::array::child_to_validity;
 use crate::array::with_empty_buffers;
 use crate::arrays::list::ListArraySlotsExt;
 use crate::arrays::list::ListData;
@@ -119,6 +120,7 @@ impl VTable for List {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             slots.len() == ListSlots::COUNT,
@@ -132,6 +134,11 @@ impl VTable for List {
         let offsets = slots[ListSlots::OFFSETS]
             .as_ref()
             .vortex_expect("ListArray offsets slot");
+        // Check the children against each other first: those errors name the offending child,
+        // which is more useful than the outer length/dtype mismatch they also produce.
+        let validity = child_to_validity(slots[ListSlots::VALIDITY].as_ref(), dtype.nullability());
+        ListData::validate(elements, offsets, &validity, ctx)?;
+
         vortex_ensure!(
             offsets.len().saturating_sub(1) == len,
             "ListArray length {} does not match outer length {}",
@@ -185,7 +192,8 @@ impl VTable for List {
             len + 1,
         )?;
 
-        let data = ListData::try_build(elements.clone(), offsets.clone(), validity.clone())?;
+        // SAFETY: `try_from_parts` validates the components before publishing the array.
+        let data = unsafe { ListData::new_unchecked() };
         let slots = ListData::make_slots(&elements, &offsets, &validity, len);
         Ok(ArrayParts::new(self.clone(), dtype.clone(), len, data).with_slots(slots))
     }

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -231,6 +231,7 @@ impl ListViewData {
         offsets: &ArrayRef,
         sizes: &ArrayRef,
         validity: &Validity,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         // Check that offsets and sizes are integer arrays and non-nullable.
         vortex_ensure!(
@@ -263,10 +264,8 @@ impl ListViewData {
 
         // Skip host-only validation when offsets/sizes are not host-resident.
         if offsets.is_host() && sizes.is_host() {
-            #[allow(clippy::disallowed_methods)]
-            let mut ctx = legacy_session().create_execution_ctx();
-            let offsets_primitive = offsets.clone().execute::<PrimitiveArray>(&mut ctx)?;
-            let sizes_primitive = sizes.clone().execute::<PrimitiveArray>(&mut ctx)?;
+            let offsets_primitive = offsets.clone().execute::<PrimitiveArray>(ctx)?;
+            let sizes_primitive = sizes.clone().execute::<PrimitiveArray>(ctx)?;
             // Offsets and sizes are non-negative; reinterpret to unsigned to dispatch over 4 widths
             // each (4x4 instead of 8x8). This is a read-only validation, so result types are moot.
             let offsets_primitive =
@@ -570,14 +569,10 @@ impl Array<ListView> {
         let dtype = DType::List(Arc::new(elements.dtype().clone()), validity.nullability());
         let len = offsets.len();
         let slots = ListViewData::make_slots(&elements, &offsets, &sizes, &validity, len);
-        ListViewData::validate(&elements, &offsets, &sizes, &validity)
-            .vortex_expect("`ListViewArray` construction failed");
         let data = ListViewData::new();
-        unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(ListView, dtype, len, data).with_slots(slots),
-            )
-        }
+
+        Array::try_from_parts(ArrayParts::new(ListView, dtype, len, data).with_slots(slots))
+            .vortex_expect("`ListViewArray` construction failed")
     }
 
     /// Constructs a new `ListViewArray`.
@@ -590,13 +585,9 @@ impl Array<ListView> {
         let dtype = DType::List(Arc::new(elements.dtype().clone()), validity.nullability());
         let len = offsets.len();
         let slots = ListViewData::make_slots(&elements, &offsets, &sizes, &validity, len);
-        ListViewData::validate(&elements, &offsets, &sizes, &validity)?;
         let data = ListViewData::try_new()?;
-        Ok(unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(ListView, dtype, len, data).with_slots(slots),
-            )
-        })
+
+        Array::try_from_parts(ArrayParts::new(ListView, dtype, len, data).with_slots(slots))
     }
 
     /// Creates a new `ListViewArray` without validation.

--- a/vortex-array/src/arrays/listview/vtable/mod.rs
+++ b/vortex-array/src/arrays/listview/vtable/mod.rs
@@ -25,6 +25,7 @@ use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
 use crate::array::VTable;
+use crate::array::child_to_validity;
 use crate::array::with_empty_buffers;
 use crate::arrays::listview::ListViewArraySlotsExt;
 use crate::arrays::listview::ListViewData;
@@ -123,6 +124,7 @@ impl VTable for ListView {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             slots.len() == ListViewSlots::COUNT,
@@ -139,9 +141,15 @@ impl VTable for ListView {
         let sizes = slots[ListViewSlots::SIZES]
             .as_ref()
             .vortex_expect("ListViewArray sizes slot");
+        // Check the children against each other first: those errors name the offending child,
+        // which is more useful than the outer length/dtype mismatch they also produce.
+        let validity =
+            child_to_validity(slots[ListViewSlots::VALIDITY].as_ref(), dtype.nullability());
+        ListViewData::validate(elements, offsets, sizes, &validity, ctx)?;
+
         vortex_ensure!(
-            offsets.len() == len && sizes.len() == len,
-            "ListViewArray length {} does not match outer length {}",
+            offsets.len() == len,
+            "ListViewArray offsets length {} does not match outer length {}",
             offsets.len(),
             len
         );
@@ -210,7 +218,6 @@ impl VTable for ListView {
             len,
         )?;
 
-        ListViewData::validate(&elements, &offsets, &sizes, &validity)?;
         let data = ListViewData::try_new()?;
         let slots = ListViewData::make_slots(&elements, &offsets, &sizes, &validity, len);
         Ok(ArrayParts::new(self.clone(), dtype.clone(), len, data).with_slots(slots))

--- a/vortex-array/src/arrays/map/vtable/mod.rs
+++ b/vortex-array/src/arrays/map/vtable/mod.rs
@@ -65,6 +65,7 @@ impl VTable for Map {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             slots.len() == MapSlots::COUNT,

--- a/vortex-array/src/arrays/masked/array.rs
+++ b/vortex-array/src/arrays/masked/array.rs
@@ -9,7 +9,6 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 
 use crate::ArrayRef;
-use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayParts;
 use crate::array::TypedArrayRef;
@@ -17,7 +16,6 @@ use crate::array::child_to_validity;
 use crate::array::validity_to_child;
 use crate::array_slots;
 use crate::arrays::Masked;
-use crate::legacy_session;
 use crate::validity::Validity;
 
 #[array_slots(Masked)]
@@ -50,17 +48,9 @@ pub trait MaskedArrayExt: TypedArrayRef<Masked> + MaskedArraySlotsExt {
 impl<T: TypedArrayRef<Masked>> MaskedArrayExt for T {}
 
 impl MaskedData {
-    pub(crate) fn try_new(
-        child_len: usize,
-        child_all_valid: bool,
-        validity: Validity,
-    ) -> VortexResult<Self> {
+    pub(crate) fn try_new(child_len: usize, validity: Validity) -> VortexResult<Self> {
         if matches!(validity, Validity::NonNullable) {
             vortex_bail!("MaskedArray must have nullable validity, got {validity:?}")
-        }
-
-        if !child_all_valid {
-            vortex_bail!("MaskedArray children must not have nulls");
         }
 
         if let Some(validity_len) = validity.maybe_len()
@@ -77,21 +67,15 @@ impl MaskedData {
 
 impl Array<Masked> {
     /// Constructs a new `MaskedArray`.
-    #[allow(clippy::disallowed_methods)]
     pub fn try_new(child: ArrayRef, validity: Validity) -> VortexResult<Self> {
         let dtype = child.dtype().as_nullable();
         let len = child.len();
         let validity_slot = validity_to_child(&validity, len);
-        let data = MaskedData::try_new(
-            len,
-            child.all_valid(&mut legacy_session().create_execution_ctx())?,
-            validity,
-        )?;
-        Ok(unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(Masked, dtype, len, data)
-                    .with_slots(smallvec![Some(child), validity_slot]),
-            )
-        })
+        let data = MaskedData::try_new(len, validity)?;
+
+        Array::try_from_parts(
+            ArrayParts::new(Masked, dtype, len, data)
+                .with_slots(smallvec![Some(child), validity_slot]),
+        )
     }
 }

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -23,7 +23,6 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::EqMode;
 use crate::IntoArray;
-use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
@@ -41,7 +40,6 @@ use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::executor::ExecutionCtx;
 use crate::executor::ExecutionResult;
-use crate::legacy_session;
 use crate::require_child;
 use crate::scalar::Scalar;
 use crate::serde::ArrayChildren;
@@ -73,13 +71,13 @@ impl VTable for Masked {
         *ID
     }
 
-    #[expect(clippy::disallowed_methods)]
     fn validate(
         &self,
         _data: &MaskedData,
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             slots[MaskedSlots::CHILD].is_some(),
@@ -94,7 +92,7 @@ impl VTable for Masked {
             "MaskedArray dtype does not match child and validity"
         );
         vortex_ensure!(
-            child.all_valid(&mut legacy_session().create_execution_ctx())?,
+            child.all_valid(ctx)?,
             "MaskedArray children must not have nulls",
         );
         Ok(())
@@ -164,11 +162,7 @@ impl VTable for Masked {
         };
 
         let validity_slot = validity_to_child(&validity, len);
-        let data = MaskedData::try_new(
-            len,
-            child.all_valid(&mut legacy_session().create_execution_ctx())?,
-            validity,
-        )?;
+        let data = MaskedData::try_new(len, validity)?;
         Ok(ArrayParts::new(self.clone(), dtype.clone(), len, data)
             .with_slots(smallvec![Some(child), validity_slot]))
     }

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -51,6 +51,7 @@ impl VTable for Null {
         dtype: &DType,
         _len: usize,
         _slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(*dtype == DType::Null, "NullArray dtype must be DType::Null");
         Ok(())

--- a/vortex-array/src/arrays/patched/vtable/mod.rs
+++ b/vortex-array/src/arrays/patched/vtable/mod.rs
@@ -114,6 +114,7 @@ impl VTable for Patched {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         data.validate(dtype, len, &PatchedSlotsView::from_slots(slots))
     }

--- a/vortex-array/src/arrays/piecewise_sequence/vtable.rs
+++ b/vortex-array/src/arrays/piecewise_sequence/vtable.rs
@@ -60,6 +60,7 @@ impl VTable for PiecewiseSequence {
         dtype: &DType,
         _len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             dtype == &DType::from(PType::U64),

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -106,6 +106,7 @@ impl VTable for Primitive {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let DType::Primitive(_, nullability) = dtype else {
             vortex_bail!("Expected primitive dtype, got {dtype:?}");

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -82,6 +82,7 @@ impl VTable for ScalarFn {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let scalar_fn = data.scalar_fn();
         vortex_ensure!(

--- a/vortex-array/src/arrays/shared/vtable.rs
+++ b/vortex-array/src/arrays/shared/vtable.rs
@@ -65,6 +65,7 @@ impl VTable for Shared {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let source = slots[SharedSlots::SOURCE]
             .as_ref()

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -75,6 +75,7 @@ impl VTable for Slice {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             slots[SliceSlots::CHILD].is_some(),

--- a/vortex-array/src/arrays/struct_/vtable/mod.rs
+++ b/vortex-array/src/arrays/struct_/vtable/mod.rs
@@ -61,6 +61,7 @@ impl VTable for Struct {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let DType::Struct(struct_dtype, nullability) = dtype else {
             vortex_bail!("Expected struct dtype, found {:?}", dtype)

--- a/vortex-array/src/arrays/union/vtable/mod.rs
+++ b/vortex-array/src/arrays/union/vtable/mod.rs
@@ -61,6 +61,7 @@ impl VTable for Union {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let type_ids = slots
             .get(UnionSlots::TYPE_IDS)

--- a/vortex-array/src/arrays/varbin/array.rs
+++ b/vortex-array/src/arrays/varbin/array.rs
@@ -27,6 +27,7 @@ use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::OffsetBuilderPType;
+use crate::executor::ExecutionCtx;
 use crate::legacy_session;
 use crate::match_each_integer_ptype;
 use crate::validity::Validity;
@@ -60,79 +61,12 @@ pub struct VarBinDataParts {
 }
 
 impl VarBinData {
-    /// Creates a new `VarBinArray`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the provided components do not satisfy the invariants documented
-    /// in `VarBinArray::new_unchecked`.
-    pub fn build(offsets: ArrayRef, bytes: ByteBuffer, dtype: DType, validity: Validity) -> Self {
-        Self::try_build(offsets, bytes, dtype, validity).vortex_expect("VarBinArray new")
-    }
-
-    /// Creates a new `VarBinArray`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the provided components do not satisfy the invariants documented
-    /// in `VarBinArray::new_unchecked`.
-    pub fn build_from_handle(
-        offset: ArrayRef,
-        bytes: BufferHandle,
-        dtype: DType,
-        validity: Validity,
-    ) -> Self {
-        Self::try_build_from_handle(offset, bytes, dtype, validity).vortex_expect("VarBinArray new")
-    }
-
     pub(crate) fn make_slots(offsets: ArrayRef, validity: &Validity, len: usize) -> ArraySlots {
         VarBinSlots {
             offsets,
             validity: validity_to_child(validity, len),
         }
         .into_slots()
-    }
-
-    /// Constructs a new `VarBinArray`.
-    ///
-    /// See `VarBinArray::new_unchecked` for more information.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the provided components do not satisfy the invariants documented in
-    /// `VarBinArray::new_unchecked`.
-    pub fn try_build(
-        offsets: ArrayRef,
-        bytes: ByteBuffer,
-        dtype: DType,
-        validity: Validity,
-    ) -> VortexResult<Self> {
-        let bytes = BufferHandle::new_host(bytes);
-        Self::validate(&offsets, &bytes, &dtype, &validity)?;
-
-        // SAFETY: validate ensures all invariants are met.
-        Ok(unsafe { Self::new_unchecked_from_handle(bytes) })
-    }
-
-    /// Constructs a new `VarBinArray` from a `BufferHandle` of memory that may exist
-    /// on the CPU or GPU.
-    ///
-    /// See `VarBinArray::new_unchecked` for more information.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the provided components do not satisfy the invariants documented in
-    /// `VarBinArray::new_unchecked`.
-    pub fn try_build_from_handle(
-        offsets: ArrayRef,
-        bytes: BufferHandle,
-        dtype: DType,
-        validity: Validity,
-    ) -> VortexResult<Self> {
-        Self::validate(&offsets, &bytes, &dtype, &validity)?;
-
-        // SAFETY: validate ensures all invariants are met.
-        Ok(unsafe { Self::new_unchecked_from_handle(bytes) })
     }
 
     /// Creates a new `VarBinArray` without validation from these components:
@@ -187,6 +121,7 @@ impl VarBinData {
         bytes: &BufferHandle,
         dtype: &DType,
         validity: &Validity,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         // Check offsets are non-nullable integer
         vortex_ensure!(
@@ -230,15 +165,19 @@ impl VarBinData {
             && matches!(dtype, DType::Utf8(_))
             && let Some(bytes) = bytes.as_host_opt()
         {
-            Self::validate_utf8(offsets, bytes.as_ref(), validity)?;
+            Self::validate_utf8(offsets, bytes.as_ref(), validity, ctx)?;
         }
 
         Ok(())
     }
 
     /// Validates that every non-null value is valid UTF-8.
-    #[allow(clippy::disallowed_methods)]
-    fn validate_utf8(offsets: &ArrayRef, bytes: &[u8], validity: &Validity) -> VortexResult<()> {
+    fn validate_utf8(
+        offsets: &ArrayRef,
+        bytes: &[u8],
+        validity: &Validity,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<()> {
         let validate_at = |i: usize, start: usize, end: usize| -> VortexResult<()> {
             let string_bytes = &bytes[start..end];
             simdutf8::basic::from_utf8(string_bytes).map_err(|_| {
@@ -250,16 +189,15 @@ impl VarBinData {
             Ok(())
         };
 
-        let mut ctx = legacy_session().create_execution_ctx();
         // TODO(joe): update the created VarBin with this decompressed Array.
-        let primitive_offsets = offsets.clone().execute::<PrimitiveArray>(&mut ctx)?;
+        let primitive_offsets = offsets.clone().execute::<PrimitiveArray>(ctx)?;
 
         // Array-backed validity is the only variant that needs an execution context: execute it into
         // a mask once. The constant variants resolve null-ness without one. Resolving this before
         // the per-type dispatch keeps the dtype loop simple.
         let mask = match validity {
             Validity::Array(_) => {
-                Some(validity.execute_mask(primitive_offsets.len().saturating_sub(1), &mut ctx)?)
+                Some(validity.execute_mask(primitive_offsets.len().saturating_sub(1), ctx)?)
             }
             _ => None,
         };
@@ -453,18 +391,11 @@ impl Array<VarBin> {
     pub fn new(offsets: ArrayRef, bytes: ByteBuffer, dtype: DType, validity: Validity) -> Self {
         let len = offsets.len().saturating_sub(1);
         let slots = VarBinData::make_slots(offsets, &validity, len);
-        let data = VarBinData::build(
-            slots[VarBinSlots::OFFSETS]
-                .as_ref()
-                .vortex_expect("VarBinArray offsets slot")
-                .clone(),
-            bytes,
-            dtype.clone(),
-            validity,
-        );
-        unsafe {
-            Array::from_parts_unchecked(ArrayParts::new(VarBin, dtype, len, data).with_slots(slots))
-        }
+        // SAFETY: `try_from_parts` validates the components before publishing the array.
+        let data = unsafe { VarBinData::new_unchecked(bytes) };
+
+        Array::try_from_parts(ArrayParts::new(VarBin, dtype, len, data).with_slots(slots))
+            .vortex_expect("VarBinArray new")
     }
 
     /// Creates a new `VarBinArray` without validation.
@@ -514,13 +445,11 @@ impl Array<VarBin> {
     ) -> VortexResult<Self> {
         let len = offsets.len() - 1;
         let bytes = BufferHandle::new_host(bytes);
-        VarBinData::validate(&offsets, &bytes, &dtype, &validity)?;
         let slots = VarBinData::make_slots(offsets, &validity, len);
-        // SAFETY: validate ensures all invariants are met.
+        // SAFETY: `try_from_parts` validates the components before publishing the array.
         let data = unsafe { VarBinData::new_unchecked_from_handle(bytes) };
-        Ok(unsafe {
-            Array::from_parts_unchecked(ArrayParts::new(VarBin, dtype, len, data).with_slots(slots))
-        })
+
+        Array::try_from_parts(ArrayParts::new(VarBin, dtype, len, data).with_slots(slots))
     }
 }
 

--- a/vortex-array/src/arrays/varbin/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbin/vtable/mod.rs
@@ -20,6 +20,7 @@ use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayView;
 use crate::array::VTable;
+use crate::array::child_to_validity;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::varbin::VarBinArrayExt;
 use crate::arrays::varbin::VarBinArraySlotsExt;
@@ -89,10 +90,11 @@ impl VTable for VarBin {
 
     fn validate(
         &self,
-        _data: &VarBinData,
+        data: &VarBinData,
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             slots.len() == VarBinSlots::COUNT,
@@ -109,11 +111,11 @@ impl VTable for VarBin {
             offsets.len().saturating_sub(1),
             len
         );
-        vortex_ensure!(
-            matches!(dtype, DType::Binary(_) | DType::Utf8(_)),
-            "VarBinArray dtype must be binary or utf8, got {dtype}"
-        );
-        Ok(())
+
+        let validity =
+            child_to_validity(slots[VarBinSlots::VALIDITY].as_ref(), dtype.nullability());
+
+        VarBinData::validate(offsets, data.bytes_handle(), dtype, &validity, ctx)
     }
 
     fn buffer(array: ArrayView<'_, Self>, idx: usize) -> BufferHandle {
@@ -191,7 +193,8 @@ impl VTable for VarBin {
         }
         let bytes = buffers[0].clone().try_to_host_sync()?;
 
-        let data = VarBinData::try_build(offsets.clone(), bytes, dtype.clone(), validity.clone())?;
+        // SAFETY: `try_from_parts` validates the components before publishing the array.
+        let data = unsafe { VarBinData::new_unchecked(bytes) };
         let slots = VarBinData::make_slots(offsets, &validity, len);
         Ok(ArrayParts::new(self.clone(), dtype.clone(), len, data).with_slots(slots))
     }

--- a/vortex-array/src/arrays/varbinview/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/mod.rs
@@ -92,6 +92,7 @@ impl VTable for VarBinView {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             slots.len() == VarBinViewSlots::COUNT,

--- a/vortex-array/src/arrays/variant/vtable/mod.rs
+++ b/vortex-array/src/arrays/variant/vtable/mod.rs
@@ -71,6 +71,7 @@ impl VTable for Variant {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             slots.len() == VariantSlots::COUNT,

--- a/vortex-array/src/test_harness/trace/tests.rs
+++ b/vortex-array/src/test_harness/trace/tests.rs
@@ -152,6 +152,7 @@ impl VTable for StackParent {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(dtype == &test_dtype(), "unexpected stack parent dtype");
         vortex_ensure!(len == 3, "unexpected stack parent length");
@@ -266,6 +267,7 @@ impl VTable for StackChild {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(dtype == &test_dtype(), "unexpected stack child dtype");
         vortex_ensure!(len == 3, "unexpected stack child length");

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -65,6 +65,7 @@ impl VTable for PythonVTable {
         dtype: &DType,
         len: usize,
         _slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(data.vtable.id == self.id, "PythonArray vtable id mismatch");
         vortex_ensure!(&data.dtype == dtype, "PythonArray dtype mismatch");

--- a/vortex-tensor/src/encodings/normalized/array.rs
+++ b/vortex-tensor/src/encodings/normalized/array.rs
@@ -176,6 +176,7 @@ impl VTable for Normalized {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let slots = NormalizedSlotsView::from_slots(slots);
 


### PR DESCRIPTION
A lot of validation requires doing minimum amount of execution, instead of
removing this validtion or using legacy_session we plumb execution context to
the validate function

