### PR TITLE
docs(vortex-layout): mark the bloom filter aggregate as unstable

### DIFF
--- a/vortex-layout/src/layouts/zoned/aggregates/bloom_filter/mod.rs
+++ b/vortex-layout/src/layouts/zoned/aggregates/bloom_filter/mod.rs
@@ -258,6 +258,12 @@ impl Display for BloomOptions {
 /// ### Notice
 ///
 /// Only valid (non-null) scalar values are stored in the filter.
+///
+/// ### Stability
+///
+/// This aggregate is unstable. The hash function, the block layout, and the salt order can still
+/// change without a file format version bump. Do not persist `vortex.bloom_filter.sbbf` partials
+/// in a Vortex file.
 #[derive(Clone, Debug)]
 pub struct BloomFilter;
 


### PR DESCRIPTION
## Summary

- Tracking Issue: #8901

The bloom filter aggregate from #9398 does not have a settled wire format. The hash function, the block layout, and the salt order can all still change, and no edition declares `vortex.bloom_filter.sbbf`, so nothing must write bloom partials into a file yet.

## Changes

Adds a `Stability` section to the `BloomFilter` doc comment saying that the aggregate is unstable and that `vortex.bloom_filter.sbbf` partials must not be persisted. Comment only, no behavior change.