### PR TITLE
refactor(decimal): dispatch numeric kernels on one storage width

### DIFF
--- a/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric/decimal.rs
@@ -15,6 +15,11 @@
 //! declared precision, so an out-of-precision value can reach a kernel and must not be able to
 //! overflow it. An operation that overflows the result precision on a valid lane is an error;
 //! invalid lanes never error.
+//!
+//! Storage width is independent of precision, so two arrays sharing a dtype may still be stored
+//! at different widths. A mismatched pair is widened to the wider of the two before the lane
+//! loop, zero-copy when they already match, so each working width and operator monomorphizes
+//! one array kernel per storage width rather than one per pair of storage widths.
 
 use std::ops::Mul;
 
@@ -38,6 +43,7 @@ use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrays::DecimalArray;
 use crate::arrays::decimal::DecimalArrayExt;
+use crate::arrays::decimal::widened_buffer;
 use crate::dtype::BigCast;
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;
@@ -421,22 +427,23 @@ where
     Op: CheckedDecimalOp,
 {
     debug_assert_eq!(lhs.len(), rhs.len());
-    match_each_decimal_value_type!(lhs.values_type(), |L| {
-        let lhs = lhs.buffer::<L>();
-        match_each_decimal_value_type!(rhs.values_type(), |R| {
-            let rhs = rhs.buffer::<R>();
-            checked_lanes(
-                LaneZip::new(lhs.as_slice(), rhs.as_slice()),
-                valid_rows,
-                |(lhs, rhs)| {
-                    Op::apply(
-                        <W as BigCast>::from(lhs)?,
-                        <W as BigCast>::from(rhs)?,
-                        constants,
-                    )
-                },
-            )
-        })
+    // Dispatch on one storage width, not a pair: a mismatched pair is widened to the wider side
+    // first, which is a copy only in that rare case.
+    let storage = lhs.values_type().max(rhs.values_type());
+    match_each_decimal_value_type!(storage, |L| {
+        let lhs = widened_buffer::<L>(lhs);
+        let rhs = widened_buffer::<L>(rhs);
+        checked_lanes(
+            LaneZip::new(lhs.as_slice(), rhs.as_slice()),
+            valid_rows,
+            |(lhs, rhs)| {
+                Op::apply(
+                    <W as BigCast>::from(lhs)?,
+                    <W as BigCast>::from(rhs)?,
+                    constants,
+                )
+            },
+        )
     })
 }
 


### PR DESCRIPTION
`checked_decimal_arrays` is generic over the working width (6 types) and the operator (4), so there are 24 copies of the outer function. Inside each copy, a `match_each_decimal_value_type!` on the lhs storage type nests another on the rhs storage type, so every copy contains 36 `checked_lanes` closures. The 24 outer functions plus their 24 × 36= 864 closures make instantiations.

The nesting exists because a `DecimalArray`'s storage width is independent of its precision, so two operands sharing a `DecimalDType` may still be stored at different widths. 

Instead, this PR dispatches on a single storage width. A mismatched pair is first widened to the wider of the two with the existing `widened_buffer` (zero-copy when they already match), and the lane loop then runs once per (working width, operator, storage width) with the same inline checked cast as before.

Mono items in `vortex-array` (`cargo +nightly rustc -p vortex-array --lib -- -Zprint-mono-items`):

| | before | after |
|---|---:|---:|
| `checked_decimal_arrays` | 888 | 168 |
| `numeric::decimal::*` module total | 1,372 | 652 |
| `lane_kernels::*` total | 15,544 | 9,694 |
| whole crate | 100,083 | 93,513 |

Matched-storage inputs take the code path they did before, so the `binary_ops` decimal benchmarks are unchanged within noise.
