### PR TITLE
fix(vx): stop advertising --json on 'vx tree array'

### DIFF
--- a/vortex-tui/src/lib.rs
+++ b/vortex-tui/src/lib.rs
@@ -173,6 +173,41 @@ mod native_cli {
                 Some(clap::error::ErrorKind::DisplayHelp),
             );
         }
+
+        /// `vx tree array` advertised `--json` but bound it to `_json` and printed the
+        /// human-readable tree anyway, so a JSON consumer parsed prose and saw exit 0.
+        /// `docs/getting-started/query.md` documents `--json` as supported by `vx inspect`
+        /// and `vx tree layout` only.
+        #[tokio::test]
+        async fn tree_array_rejects_json_flag() {
+            let err = super::launch_from(
+                &VortexSession::default(),
+                ["vx", "tree", "array", "missing.vortex", "--json"],
+            )
+            .await
+            .expect_err("`tree array` does not support --json");
+            assert_eq!(
+                err.downcast_ref::<clap::Error>().map(clap::Error::kind),
+                Some(clap::error::ErrorKind::UnknownArgument),
+            );
+        }
+
+        /// The sibling subcommand does honour `--json`, so the flag must still parse there.
+        #[tokio::test]
+        async fn tree_layout_still_accepts_json_flag() {
+            let err = super::launch_from(
+                &VortexSession::default(),
+                ["vx", "tree", "layout", "missing.vortex", "--json"],
+            )
+            .await
+            .expect_err("opening a missing file must fail");
+            // Reaching the missing-file check means the flag parsed; `launch_from`
+            // reports that as a `clap::Error` of kind `Io`.
+            assert_eq!(
+                err.downcast_ref::<clap::Error>().map(clap::Error::kind),
+                Some(clap::error::ErrorKind::Io),
+            );
+        }
     }
 }
 

--- a/vortex-tui/src/tree.rs
+++ b/vortex-tui/src/tree.rs
@@ -29,9 +29,6 @@ pub enum TreeMode {
     Array {
         /// Path to the Vortex file
         file: PathBuf,
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
     },
     /// Display the layout tree structure (metadata only, no array loading)
     Layout {
@@ -80,7 +77,7 @@ pub struct LayoutTreeNodeWithName {
 /// Returns an error if the file cannot be opened or read.
 pub async fn exec_tree(session: &VortexSession, args: TreeArgs) -> VortexResult<()> {
     match args.mode {
-        TreeMode::Array { file, json } => exec_array_tree(session, &file, json).await?,
+        TreeMode::Array { file } => exec_array_tree(session, &file).await?,
         TreeMode::Layout {
             file,
             verbose,
@@ -91,7 +88,7 @@ pub async fn exec_tree(session: &VortexSession, args: TreeArgs) -> VortexResult<
     Ok(())
 }
 
-async fn exec_array_tree(session: &VortexSession, file: &Path, _json: bool) -> VortexResult<()> {
+async fn exec_array_tree(session: &VortexSession, file: &Path) -> VortexResult<()> {
     let full = session
         .open_options()
         .open_path(file)


### PR DESCRIPTION
`vx tree array` declares `--json` but binds it to `_json` and prints the human-readable tree
unconditionally, so a JSON consumer parses prose and sees exit 0. The flag has been dead since
#5642 introduced it; the sibling `vx tree layout` honours it.

`docs/getting-started/query.md` already documents `--json` as supported by `vx inspect` and
`vx tree layout` only, so this drops the flag rather than inventing a JSON schema for the array
tree.

Behaviour change: `vx tree array f.vortex --json` now fails with a clap usage error instead of
silently printing the human-readable tree.

## AI assistance

Agentic AI assistance; I checked the flag has been unwired since #5642 and that the new test fails
when it is restored.
