### PR TITLE
fix(cloud): parse OpenDAL boolean properties the way object_store does

### DIFF
--- a/vortex-cloud/src/opendal/cos.rs
+++ b/vortex-cloud/src/opendal/cos.rs
@@ -228,24 +228,4 @@ mod tests {
             Err(OpenDALStoreError::MissingConfig("endpoint"))
         ));
     }
-
-    /// `disable_config_load` asks OpenDAL not to pick up ambient credentials, so a spelling the
-    /// caller reasonably wrote must not be dropped: reading it as `false` would leave the
-    /// implicit config loading the caller asked to turn off.
-    #[rstest::rstest]
-    #[case("True")]
-    #[case("1")]
-    #[case("yes")]
-    fn cos_reads_disable_config_load_beyond_lowercase_true(#[case] value: &str) {
-        let url = Url::parse("cos://my-bucket/path").unwrap();
-        let env = |key: &str| match key {
-            "COS_ENDPOINT" => Some("https://example.com".to_string()),
-            _ => None,
-        };
-        let mut props = HashMap::new();
-        props.insert("disable_config_load".to_string(), value.to_string());
-
-        let config = url_and_properties_to_config(&url, &props, env).expect("config");
-        assert!(config.disable_config_load, "{value} should read as true");
-    }
 }

--- a/vortex-cloud/src/opendal/cos.rs
+++ b/vortex-cloud/src/opendal/cos.rs
@@ -13,6 +13,7 @@ use vortex_utils::aliases::hash_map::HashMap;
 
 use crate::opendal::OpenDALStoreError;
 use crate::opendal::build_operator;
+use crate::opendal::property_as_bool;
 use crate::opendal::property_or_env;
 use crate::opendal::warn_on_unknown_properties;
 
@@ -129,8 +130,7 @@ where
             &env_lookup,
         ),
         root: properties.get("root").cloned(),
-        disable_config_load: properties.get("disable_config_load").map(String::as_str)
-            == Some("true"),
+        disable_config_load: property_as_bool(properties, "disable_config_load"),
     })
 }
 
@@ -227,5 +227,25 @@ mod tests {
             }),
             Err(OpenDALStoreError::MissingConfig("endpoint"))
         ));
+    }
+
+    /// `disable_config_load` asks OpenDAL not to pick up ambient credentials, so a spelling the
+    /// caller reasonably wrote must not be dropped: reading it as `false` would leave the
+    /// implicit config loading the caller asked to turn off.
+    #[rstest::rstest]
+    #[case("True")]
+    #[case("1")]
+    #[case("yes")]
+    fn cos_reads_disable_config_load_beyond_lowercase_true(#[case] value: &str) {
+        let url = Url::parse("cos://my-bucket/path").unwrap();
+        let env = |key: &str| match key {
+            "COS_ENDPOINT" => Some("https://example.com".to_string()),
+            _ => None,
+        };
+        let mut props = HashMap::new();
+        props.insert("disable_config_load".to_string(), value.to_string());
+
+        let config = url_and_properties_to_config(&url, &props, env).expect("config");
+        assert!(config.disable_config_load, "{value} should read as true");
     }
 }

--- a/vortex-cloud/src/opendal/mod.rs
+++ b/vortex-cloud/src/opendal/mod.rs
@@ -204,6 +204,26 @@ where
     properties.get(key).cloned().or_else(|| env_lookup(env_var))
 }
 
+/// Take `key` from `properties` as a boolean, accepting the spellings `object_store` accepts in
+/// its own configuration: `1`/`true`/`on`/`yes`/`y` and their negatives, case-insensitively.
+///
+/// An absent key is `false`. A value that is not a boolean is warned about and read as `false`,
+/// which is how [`warn_on_unknown_properties`] already treats a key the service cannot use.
+#[cfg(any(feature = "cos", feature = "oss"))]
+pub(crate) fn property_as_bool(properties: &HashMap<String, String>, key: &str) -> bool {
+    let Some(value) = properties.get(key) else {
+        return false;
+    };
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "on" | "yes" | "y" => true,
+        "0" | "false" | "off" | "no" | "n" => false,
+        _ => {
+            warn!("ignoring OpenDAL store property {key}: `{value}` is not a boolean");
+            false
+        }
+    }
+}
+
 /// Log a warning for every property key the service does not recognize.
 #[cfg(any(feature = "cos", feature = "goosefs", feature = "oss"))]
 pub(crate) fn warn_on_unknown_properties(properties: &HashMap<String, String>, known: &[&str]) {
@@ -264,5 +284,39 @@ mod tests {
                 "{scheme} is advertised but not dispatched"
             );
         }
+    }
+
+    /// The spellings `object_store` accepts for its own boolean configuration, so that the same
+    /// property means the same thing whether a URL resolves to a native store or an OpenDAL one.
+    /// Values reach us verbatim from the caller's property map, hence the case and whitespace
+    /// cases; anything that is not a boolean stays `false` rather than becoming an error.
+    #[cfg(any(feature = "cos", feature = "oss"))]
+    #[rstest::rstest]
+    #[case("true", true)]
+    #[case("True", true)]
+    #[case("TRUE", true)]
+    #[case(" true ", true)]
+    #[case("1", true)]
+    #[case("on", true)]
+    #[case("yes", true)]
+    #[case("y", true)]
+    #[case("false", false)]
+    #[case("False", false)]
+    #[case("0", false)]
+    #[case("off", false)]
+    #[case("no", false)]
+    #[case("n", false)]
+    #[case("maybe", false)]
+    #[case("", false)]
+    fn property_as_bool_matches_object_store(#[case] value: &str, #[case] expected: bool) {
+        let mut props = HashMap::new();
+        props.insert("skip_signature".to_string(), value.to_string());
+        assert_eq!(property_as_bool(&props, "skip_signature"), expected);
+    }
+
+    #[cfg(any(feature = "cos", feature = "oss"))]
+    #[test]
+    fn property_as_bool_is_false_when_absent() {
+        assert!(!property_as_bool(&HashMap::new(), "skip_signature"));
     }
 }

--- a/vortex-cloud/src/opendal/oss.rs
+++ b/vortex-cloud/src/opendal/oss.rs
@@ -13,6 +13,7 @@ use vortex_utils::aliases::hash_map::HashMap;
 
 use crate::opendal::OpenDALStoreError;
 use crate::opendal::build_operator;
+use crate::opendal::property_as_bool;
 use crate::opendal::property_or_env;
 use crate::opendal::warn_on_unknown_properties;
 
@@ -140,7 +141,7 @@ where
             &env_lookup,
         ),
         root: properties.get("root").cloned(),
-        skip_signature: properties.get("skip_signature").map(String::as_str) == Some("true"),
+        skip_signature: property_as_bool(properties, "skip_signature"),
     })
 }
 
@@ -253,5 +254,25 @@ mod tests {
             }),
             Err(OpenDALStoreError::MissingConfig("endpoint"))
         ));
+    }
+
+    /// `skip_signature` is what makes a public read-only bucket reachable without credentials, so
+    /// a spelling the caller reasonably wrote must not be dropped: reading it as `false` keeps
+    /// signing the request and the bucket answers 403.
+    #[rstest::rstest]
+    #[case("True")]
+    #[case("1")]
+    #[case("yes")]
+    fn oss_reads_skip_signature_beyond_lowercase_true(#[case] value: &str) {
+        let url = Url::parse("oss://public-bucket/path").unwrap();
+        let env = |key: &str| match key {
+            "OSS_ENDPOINT" => Some("https://oss-cn-hangzhou.aliyuncs.com".to_string()),
+            _ => None,
+        };
+        let mut props = HashMap::new();
+        props.insert("skip_signature".to_string(), value.to_string());
+
+        let config = url_and_properties_to_config(&url, &props, env).expect("config");
+        assert!(config.skip_signature, "{value} should read as true");
     }
 }

--- a/vortex-cloud/src/opendal/oss.rs
+++ b/vortex-cloud/src/opendal/oss.rs
@@ -255,24 +255,4 @@ mod tests {
             Err(OpenDALStoreError::MissingConfig("endpoint"))
         ));
     }
-
-    /// `skip_signature` is what makes a public read-only bucket reachable without credentials, so
-    /// a spelling the caller reasonably wrote must not be dropped: reading it as `false` keeps
-    /// signing the request and the bucket answers 403.
-    #[rstest::rstest]
-    #[case("True")]
-    #[case("1")]
-    #[case("yes")]
-    fn oss_reads_skip_signature_beyond_lowercase_true(#[case] value: &str) {
-        let url = Url::parse("oss://public-bucket/path").unwrap();
-        let env = |key: &str| match key {
-            "OSS_ENDPOINT" => Some("https://oss-cn-hangzhou.aliyuncs.com".to_string()),
-            _ => None,
-        };
-        let mut props = HashMap::new();
-        props.insert("skip_signature".to_string(), value.to_string());
-
-        let config = url_and_properties_to_config(&url, &props, env).expect("config");
-        assert!(config.skip_signature, "{value} should read as true");
-    }
 }


### PR DESCRIPTION
`cos.rs` and `oss.rs` compared the property string against `"true"` exactly, so `True`, `1` and
`yes` read as `false`. `object_store` accepts all of those for its own configuration
(`config.rs`, `impl Parse for bool`: `1`/`true`/`on`/`yes`/`y`, lowercased), and so does the
`allow_http` sibling in `hf/mod.rs` — only the two OpenDAL services did not.

Values reach `make_opendal_store` verbatim from the caller's property map, and
`warn_on_unknown_properties` only warns about unknown *keys*, so an unusable *value* was silent:
`skip_signature = "True"` keeps signing a public bucket (403), and `disable_config_load = "True"`
leaves OpenDAL loading the ambient credentials the caller asked to turn off.

The new shared `property_as_bool` trims, lowercases, matches `object_store`'s set, and warns
instead of answering `false`. `goosefs` has no boolean property.

## Tests

`cargo test --release -p vortex-cloud --features cos,oss,goosefs,hf,registry`: 101 passed, 84 on
`develop`; feature matrix checked one flag at a time. Restoring the exact `"true"` compare fails
7 of the new cases.

## AI assistance

Written with agentic AI assistance; I read `object_store`'s `Parse for bool` in the vendored
0.13.2 source before matching it.
