### PR TITLE
ci(bench): drop Clickbench Sorted from the "pr" SQL benchmark preset

### DIFF
--- a/bench-orchestrator/bench_orchestrator/ci_matrix/catalog.py
+++ b/bench-orchestrator/bench_orchestrator/ci_matrix/catalog.py
@@ -93,14 +93,14 @@ BENCHMARKS = (
             "develop": FULL_LOCAL,
         },
     ),
+    # Not in the "pr" preset: the sorted variant is excluded from the default PR benchmark run.
     BenchmarkCase(
         id="clickbench-sorted-nvme",
         benchmark=Benchmark.CLICKBENCH_SORTED,
         name="Clickbench Sorted on NVME",
         runs={
-            "pr": DEFAULT,
             "pr-compact": COMPACT,
-            "pr-all": STANDARD,
+            "pr-all": COMPACT,
             "pr-full": DEFAULT_WITH_DUCKDB_PR_FULL,
             "develop": FULL_LOCAL,
         },

--- a/bench-orchestrator/tests/test_matrix.py
+++ b/bench-orchestrator/tests/test_matrix.py
@@ -42,7 +42,7 @@ EXPECTED_IDS = {
     "pr": tuple(
         benchmark_id
         for benchmark_id in REGULAR_IDS
-        if benchmark_id not in {"tpch-s3-10", "appian-nvme", "vortex-queries"}
+        if benchmark_id not in {"clickbench-sorted-nvme", "tpch-s3-10", "appian-nvme", "vortex-queries"}
     ),
     "pr-compact": COMPACT_IDS,
     "pr-all": PR_ALL_IDS,


### PR DESCRIPTION
## Summary

Stop running the `Clickbench Sorted on NVME` benchmark as part of the default pull-request SQL benchmark matrix (the `pr` preset, triggered by the `action/bench-sql` label).

## Changes

- `bench-orchestrator/bench_orchestrator/ci_matrix/catalog.py`: remove the `pr` entry from the `clickbench-sorted-nvme` case. It still runs under `pr-compact`, `pr-all`, `pr-full`, and `develop`. Because `pr-all` is defined as the union of `pr` and `pr-compact`, its coverage for this case narrows from `STANDARD` to `COMPACT` (the same pattern `tpch-s3-10` and `appian-nvme` already use).
- `bench-orchestrator/tests/test_matrix.py`: update the expected `pr` preset IDs.

Resolved `pr` matrix after this change:
`clickbench-nvme, tpch-nvme, tpch-s3, tpch-nvme-10, tpcds-nvme, statpopgen, fineweb, fineweb-s3, polarsignals`

Checks run locally:
- `uv run --project bench-orchestrator --with pytest python -m pytest tests/test_matrix.py` (12 passed)
- `ruff check` and `ruff format --check` on the two changed files
- `vx-bench matrix pr` / `vx-bench matrix pr-all` to confirm the rendered output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9e8MM2rjbnH4qN4jtzMKm

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9e8MM2rjbnH4qN4jtzMKm)_