### PR TITLE
perf(datafusion): Only wrap stream in prunable stream when predicate can still change

### DIFF
--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -483,7 +483,9 @@ impl FileOpener for VortexOpener {
                 })
                 .boxed();
 
-            if let Some(file_pruner) = file_pruner {
+            if let Some(file_pruner) = file_pruner
+                && file_pruner.is_watching()
+            {
                 Ok(PrunableStream::new(file_pruner, stream).boxed())
             } else {
                 Ok(stream)


### PR DESCRIPTION
## Summary

If we know the file pruner won't change anymore, we don't need to wrap the returned stream in a `PrunableStream` that keeps checking the predicate on every poll. 