### PR TITLE
Fix path WORK_DIR path normalization in SLT tests

### DIFF
--- a/.github/workflows/musl.yml
+++ b/.github/workflows/musl.yml
@@ -69,7 +69,7 @@ jobs:
             --exclude gpu-scan-cli --exclude vortex-test-e2e-cuda --exclude vortex-python-cuda \
             --exclude vortex-duckdb --exclude duckdb-bench --exclude vortex-sqllogictest \
             --exclude vortex-bench --exclude lance-bench --exclude datafusion-bench --exclude vortex-datafusion \
-            --exclude compress-bench --exclude random-access-bench --exclude vortex-bench-server
+            --exclude compress-bench --exclude random-access-bench
 
       - name: Alert incident.io
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/develop'

--- a/vortex-sqllogictest/slt/datafusion/list_length_pushdown.slt
+++ b/vortex-sqllogictest/slt/datafusion/list_length_pushdown.slt
@@ -30,7 +30,7 @@ EXPLAIN SELECT array_length(a) AS len FROM list_test;
 logical_plan
 01)Projection: array_length(list_test.a) AS len
 02)--TableScan: list_test projection=[a]
-physical_plan DataSourceExec: file_groups={<slt:ignore>}, projection=[array_length(a@1) as len], file_type=vortex
+physical_plan DataSourceExec: file_groups={1 group: [[${WORK_DIR}/list_test/<slt:ignore>_0.vortex]]}, projection=[array_length(a@1) as len], file_type=vortex
 
 query I
 SELECT array_length(a) FROM list_test ORDER BY id;
@@ -47,7 +47,7 @@ EXPLAIN SELECT array_length(a, 1) AS len FROM list_test;
 logical_plan
 01)Projection: array_length(list_test.a, Int64(1)) AS len
 02)--TableScan: list_test projection=[a]
-physical_plan DataSourceExec: file_groups={<slt:ignore>}, projection=[array_length(a@1, 1) as len], file_type=vortex
+physical_plan DataSourceExec: file_groups={1 group: [[${WORK_DIR}/list_test/<slt:ignore>_0.vortex]]}, projection=[array_length(a@1, 1) as len], file_type=vortex
 
 query I
 SELECT array_length(a, 1) FROM list_test ORDER BY id;
@@ -64,7 +64,7 @@ EXPLAIN SELECT list_length(a) AS len FROM list_test;
 logical_plan
 01)Projection: array_length(list_test.a) AS list_length(list_test.a) AS len
 02)--TableScan: list_test projection=[a]
-physical_plan DataSourceExec: file_groups={<slt:ignore>}, projection=[array_length(a@1) as len], file_type=vortex
+physical_plan DataSourceExec: file_groups={1 group: [[${WORK_DIR}/list_test/<slt:ignore>_0.vortex]]}, projection=[array_length(a@1) as len], file_type=vortex
 
 query I
 SELECT list_length(a) FROM list_test ORDER BY id;
@@ -83,7 +83,7 @@ EXPLAIN SELECT array_length(a) as len_a, array_length(b) AS len_b FROM list_test
 logical_plan
 01)Projection: array_length(list_test.a) AS len_a, array_length(list_test.b) AS len_b
 02)--TableScan: list_test projection=[a, b]
-physical_plan DataSourceExec: file_groups={<slt:ignore>}, projection=[array_length(a@1) as len_a, array_length(b@2) as len_b], file_type=vortex
+physical_plan DataSourceExec: file_groups={1 group: [[${WORK_DIR}/list_test/<slt:ignore>_0.vortex]]}, projection=[array_length(a@1) as len_a, array_length(b@2) as len_b], file_type=vortex
 
 query II
 SELECT array_length(a), array_length(b) FROM list_test ORDER BY id;
@@ -103,7 +103,7 @@ logical_plan
 01)Projection: list_test.id
 02)--Filter: array_length(list_test.a) >= UInt64(4)
 03)----TableScan: list_test projection=[id, a], partial_filters=[array_length(list_test.a) >= UInt64(4)]
-physical_plan DataSourceExec: file_groups={<slt:ignore>}, projection=[id], file_type=vortex, predicate: array_length(a@1) >= 4
+physical_plan DataSourceExec: file_groups={1 group: [[${WORK_DIR}/list_test/<slt:ignore>_0.vortex]]}, projection=[id], file_type=vortex, predicate: array_length(a@1) >= 4
 
 query I
 SELECT id FROM list_test WHERE array_length(a) >= 4 ORDER BY id;
@@ -120,7 +120,7 @@ logical_plan
 01)Projection: list_test.id
 02)--Filter: array_length(list_test.a) >= UInt64(4) AND array_length(list_test.b) >= UInt64(3)
 03)----TableScan: list_test projection=[id, a, b], partial_filters=[array_length(list_test.a) >= UInt64(4), array_length(list_test.b) >= UInt64(3)]
-physical_plan DataSourceExec: file_groups={<slt:ignore>}, projection=[id], file_type=vortex, predicate: array_length(a@1) >= 4 AND array_length(b@2) >= 3
+physical_plan DataSourceExec: file_groups={1 group: [[${WORK_DIR}/list_test/<slt:ignore>_0.vortex]]}, projection=[id], file_type=vortex, predicate: array_length(a@1) >= 4 AND array_length(b@2) >= 3
 
 query I
 SELECT id FROM list_test WHERE array_length(a) >= 4 AND array_length(b) >= 3 ORDER BY id;
@@ -139,7 +139,7 @@ logical_plan
 01)Projection: array_length(list_test.a) AS len
 02)--Filter: array_length(list_test.a) >= UInt64(4)
 03)----TableScan: list_test projection=[a], partial_filters=[array_length(list_test.a) >= UInt64(4)]
-physical_plan DataSourceExec: file_groups={<slt:ignore>}, projection=[array_length(a@1) as len], file_type=vortex, predicate: array_length(a@1) >= 4
+physical_plan DataSourceExec: file_groups={1 group: [[${WORK_DIR}/list_test/<slt:ignore>_0.vortex]]}, projection=[array_length(a@1) as len], file_type=vortex, predicate: array_length(a@1) >= 4
 
 query I
 SELECT array_length(a) FROM list_test WHERE array_length(a) >= 4 ORDER BY id;
@@ -156,7 +156,7 @@ logical_plan
 01)Projection: array_length(list_test.a) AS len
 02)--Filter: array_length(list_test.b) >= UInt64(3)
 03)----TableScan: list_test projection=[a, b], partial_filters=[array_length(list_test.b) >= UInt64(3)]
-physical_plan DataSourceExec: file_groups={<slt:ignore>}, projection=[array_length(a@1) as len], file_type=vortex, predicate: array_length(b@2) >= 3
+physical_plan DataSourceExec: file_groups={1 group: [[${WORK_DIR}/list_test/<slt:ignore>_0.vortex]]}, projection=[array_length(a@1) as len], file_type=vortex, predicate: array_length(b@2) >= 3
 
 query I
 SELECT array_length(a) FROM list_test WHERE array_length(b) >= 3 ORDER BY id;

--- a/vortex-sqllogictest/slt/datafusion/order_pushdown.slt
+++ b/vortex-sqllogictest/slt/datafusion/order_pushdown.slt
@@ -3,6 +3,10 @@
 
 include ../setup.slt.no
 
+# Keep each of the three inserted files in its own ordered scan partition.
+statement ok
+SET datafusion.execution.target_partitions = 3;
+
 statement ok
 CREATE EXTERNAL TABLE ordered_pushdown (
     c1 VARCHAR NOT NULL,
@@ -41,4 +45,4 @@ logical_plan
 02)--TableScan: ordered_pushdown projection=[c1, c2]
 physical_plan
 01)SortPreservingMergeExec: [c1@0 ASC NULLS LAST], fetch=3
-02)--DataSourceExec: file_groups={<slt:ignore>}, projection=[c1, c2], limit=3, output_ordering=[c1@0 ASC NULLS LAST], file_type=vortex
+02)--DataSourceExec: file_groups={3 groups: [[${WORK_DIR}/ordered_pushdown/<slt:ignore>_0.vortex], [${WORK_DIR}/ordered_pushdown/<slt:ignore>_0.vortex], [${WORK_DIR}/ordered_pushdown/<slt:ignore>_0.vortex]]}, projection=[c1, c2], limit=3, output_ordering=[c1@0 ASC NULLS LAST], file_type=vortex

--- a/vortex-sqllogictest/slt/datafusion/table_options.slt
+++ b/vortex-sqllogictest/slt/datafusion/table_options.slt
@@ -37,7 +37,7 @@ logical_plan
 physical_plan
 01)SortExec: expr=[y@0 ASC NULLS LAST], preserve_partitioning=[false]
 02)--FilterExec: x@0 > 1, projection=[y@1]
-03)----DataSourceExec: file_groups={<slt:ignore>}, projection=[x, y], file_type=vortex
+03)----DataSourceExec: file_groups={1 group: [[${WORK_DIR}/session_disabled_pushdown/<slt:ignore>_0.vortex]]}, projection=[x, y], file_type=vortex
 
 statement ok
 CREATE EXTERNAL TABLE table_enabled_pushdown (
@@ -64,7 +64,7 @@ logical_plan
 04)------TableScan: table_enabled_pushdown projection=[x, y], partial_filters=[table_enabled_pushdown.x > Int64(1)]
 physical_plan
 01)SortExec: expr=[y@0 ASC NULLS LAST], preserve_partitioning=[false]
-02)--DataSourceExec: file_groups={<slt:ignore>}, projection=[y], file_type=vortex, predicate: x@0 > 1
+02)--DataSourceExec: file_groups={1 group: [[${WORK_DIR}/table_enabled_pushdown/<slt:ignore>_0.vortex]]}, projection=[y], file_type=vortex, predicate: x@0 > 1
 
 query I
 SELECT y FROM table_enabled_pushdown WHERE x > 1 ORDER BY y;

--- a/vortex-sqllogictest/slt/datafusion/utf8_min_max_stats.slt
+++ b/vortex-sqllogictest/slt/datafusion/utf8_min_max_stats.slt
@@ -13,8 +13,39 @@ COPY (
 ----
 2
 
-query TT
-SELECT MIN(value), MAX(value)
+query T
+SELECT MIN(value)
 FROM '${WORK_DIR}/utf8_min_max_stats.vortex';
 ----
-Another string that is meant to be smaller than the previous value, with extra padding Long value used to verify that UTF-8 statistics do not replace the actual maximum value
+Another string that is meant to be smaller than the previous value, with extra padding
+
+
+query TT
+EXPLAIN SELECT MIN(value)
+FROM '${WORK_DIR}/utf8_min_max_stats.vortex';
+----
+logical_plan
+01)Aggregate: groupBy=[[]], aggr=[[min(${WORK_DIR}/utf8_min_max_stats.vortex.value)]]
+02)--TableScan: ${WORK_DIR}/utf8_min_max_stats.vortex projection=[value]
+physical_plan
+01)AggregateExec: mode=Single, gby=[], aggr=[min(${WORK_DIR}/utf8_min_max_stats.vortex.value)]
+02)--DataSourceExec: file_groups={1 group: [[${WORK_DIR}/utf8_min_max_stats.vortex]]}, projection=[value], file_type=vortex
+
+
+query T
+SELECT MAX(value)
+FROM '${WORK_DIR}/utf8_min_max_stats.vortex';
+----
+Long value used to verify that UTF-8 statistics do not replace the actual maximum value
+
+
+query TT
+EXPLAIN SELECT MAX(value)
+FROM '${WORK_DIR}/utf8_min_max_stats.vortex';
+----
+logical_plan
+01)Aggregate: groupBy=[[]], aggr=[[max(${WORK_DIR}/utf8_min_max_stats.vortex.value)]]
+02)--TableScan: ${WORK_DIR}/utf8_min_max_stats.vortex projection=[value]
+physical_plan
+01)AggregateExec: mode=Single, gby=[], aggr=[max(${WORK_DIR}/utf8_min_max_stats.vortex.value)]
+02)--DataSourceExec: file_groups={1 group: [[${WORK_DIR}/utf8_min_max_stats.vortex]]}, projection=[value], file_type=vortex

--- a/vortex-sqllogictest/src/normalize.rs
+++ b/vortex-sqllogictest/src/normalize.rs
@@ -25,8 +25,16 @@ pub const WORK_DIR_VAR: &str = "WORK_DIR";
 pub const WORK_DIR_TOKEN: &str = "${WORK_DIR}";
 
 /// Replaces every occurrence of `work_dir` in `cell` with [`WORK_DIR_TOKEN`].
+/// Also handles object-store paths, which omit the leading `/`.
 pub fn normalize_work_dir(cell: &str, work_dir: &str) -> String {
-    cell.replace(work_dir, WORK_DIR_TOKEN)
+    // Replace absolute paths first so their leading slash does not survive.
+    let normalized = cell.replace(work_dir, WORK_DIR_TOKEN);
+    if let Some(object_store_path) = work_dir.strip_prefix('/')
+        && !object_store_path.is_empty()
+    {
+        return normalized.replace(object_store_path, WORK_DIR_TOKEN);
+    }
+    normalized
 }
 
 /// Wraps an [`AsyncDB`] and rewrites this test's scratch path in query output back
@@ -96,12 +104,12 @@ impl<D: AsyncDB + Send> AsyncDB for PathNormalizing<D> {
 mod tests {
     use rstest::rstest;
 
-    use super::WORK_DIR_TOKEN;
     use super::normalize_work_dir;
 
     #[rstest]
     #[case("no paths here", "no paths here")]
     #[case("plain 42", "plain 42")]
+    #[case("${WORK_DIR}/data.vortex", "${WORK_DIR}/data.vortex")]
     fn leaves_unrelated_text_untouched(#[case] input: &str, #[case] expected: &str) {
         assert_eq!(
             normalize_work_dir(input, "/repo/scratch/123/df_create.slt"),
@@ -109,13 +117,27 @@ mod tests {
         );
     }
 
-    #[test]
-    fn rewrites_work_dir_to_token() {
-        let work_dir = "/repo/scratch/123/df_create.slt";
-        let cell = format!("output_url={work_dir}/sink/data1.vortex foo");
+    #[rstest]
+    #[case::filesystem(
+        "output_url=/repo/scratch/123/df_create.slt/sink/data1.vortex foo",
+        "output_url=${WORK_DIR}/sink/data1.vortex foo"
+    )]
+    #[case::object_store(
+        "file_groups={1 group: [[repo/scratch/123/df_create.slt/data.vortex]]}",
+        "file_groups={1 group: [[${WORK_DIR}/data.vortex]]}"
+    )]
+    #[case::mixed(
+        "TableScan: /repo/scratch/123/df_create.slt/data.vortex\nfile_groups={1 group: [[repo/scratch/123/df_create.slt/data.vortex]]}",
+        "TableScan: ${WORK_DIR}/data.vortex\nfile_groups={1 group: [[${WORK_DIR}/data.vortex]]}"
+    )]
+    #[case::file_url(
+        "file:///repo/scratch/123/df_create.slt/data.vortex",
+        "file://${WORK_DIR}/data.vortex"
+    )]
+    fn rewrites_work_dir_to_token(#[case] input: &str, #[case] expected: &str) {
         assert_eq!(
-            normalize_work_dir(&cell, work_dir),
-            format!("output_url={WORK_DIR_TOKEN}/sink/data1.vortex foo")
+            normalize_work_dir(input, "/repo/scratch/123/df_create.slt"),
+            expected
         );
     }
 }


### PR DESCRIPTION
## Summary

DF shows file paths sometimes with a leading `/` and sometimes without it, so path normalization was slightly broken. This PR fixes it and changes some of the code paths that use `<slt:ignore>` to use the expanded variable.
