### PR TITLE
Remove explicit runner volumes in favor of newly updated global configs

### DIFF
--- a/.github/workflows/musl.yml
+++ b/.github/workflows/musl.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 90
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-large/image=ubuntu24-full-x64-pre-v2/tag=rust-build-musl', github.run_id)
+          && format('runs-on={0}/runner=amd64-large/volume=200gb/image=ubuntu24-full-x64-pre-v2/tag=rust-build-musl', github.run_id)
           || 'ubuntu-latest' }}
     container:
       image: ghcr.io/rust-lang/rust:1-alpine3.21

--- a/.github/workflows/musl.yml
+++ b/.github/workflows/musl.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 90
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-large/volume=200gb/image=ubuntu24-full-x64-pre-v2/tag=rust-build-musl', github.run_id)
+          && format('runs-on={0}/runner=amd64-large/image=ubuntu24-full-x64-pre-v2/tag=rust-build-musl', github.run_id)
           || 'ubuntu-latest' }}
     container:
       image: ghcr.io/rust-lang/rust:1-alpine3.21

--- a/.github/workflows/rust-instrumented.yml
+++ b/.github/workflows/rust-instrumented.yml
@@ -53,7 +53,7 @@ jobs:
           - suite: tests
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-large/volume=200gb/image=ubuntu24-full-x64-pre-v2/tag=rust-coverage-suite-{1}', github.run_id, matrix.suite)
+          && format('runs-on={0}/runner=amd64-large/image=ubuntu24-full-x64-pre-v2/tag=rust-coverage-suite-{1}', github.run_id, matrix.suite)
           || 'ubuntu-latest' }}
     env:
       RUSTFLAGS: "-Cinstrument-coverage -A warnings"


### PR DESCRIPTION
## Summary

I've updated the default config for the arm64-large runner, and it should now have an EBS volume attached