### PR TITLE
refactor: extract scalar function OptimizeVTable

### DIFF
--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -271,6 +271,7 @@ impl Display for FakeEq<ArrayRef> {
 
 impl scalar_fn::ScalarFnVTable for ArrayExpr {
     type Options = FakeEq<ArrayRef>;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.array");

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -204,6 +204,7 @@ impl Between {
 
 impl ScalarFnVTable for Between {
     type Options = BetweenOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.between");

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -27,6 +27,7 @@ use crate::expr::lit;
 use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::OptimizeVTable;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
 use crate::scalar_fn::ScalarFnVTableExt;
@@ -70,6 +71,7 @@ impl Binary {
 
 impl ScalarFnVTable for Binary {
     type Options = Operator;
+    type OptimizeVTable = Self;
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.binary");
@@ -180,8 +182,50 @@ impl ScalarFnVTable for Binary {
         }
     }
 
-    fn simplify_untyped(
+    fn validity(
         &self,
+        operator: &Operator,
+        expression: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        let lhs = expression.child(0).validity()?;
+        let rhs = expression.child(1).validity()?;
+
+        Ok(match operator {
+            // AND and OR are kleene logic.
+            Operator::And => None,
+            Operator::Or => None,
+            _ => {
+                // All other binary operators are null if either side is null.
+                Some(and(lhs, rhs))
+            }
+        })
+    }
+
+    fn is_strict(&self, operator: &Operator) -> bool {
+        // Kleene AND/OR is not strict (`false AND null = false`, `true OR null = true`), which is
+        // consistent with `validity` returning `None` for these operators above.
+        !matches!(operator, Operator::And | Operator::Or)
+    }
+
+    fn is_infallible(&self, operator: &Operator) -> bool {
+        // Arithmetic operations could be better modelled here.
+        matches!(
+            operator,
+            Operator::Eq
+                | Operator::NotEq
+                | Operator::Gt
+                | Operator::Gte
+                | Operator::Lt
+                | Operator::Lte
+                | Operator::And
+                | Operator::Or
+        )
+    }
+}
+
+impl OptimizeVTable<Binary> for Binary {
+    fn simplify_untyped(
+        _vtable: &Self,
         operator: &Operator,
         expr: &Expression,
     ) -> VortexResult<Option<Expression>> {
@@ -229,7 +273,7 @@ impl ScalarFnVTable for Binary {
     }
 
     fn simplify(
-        &self,
+        _vtable: &Self,
         operator: &Operator,
         expr: &Expression,
         ctx: &dyn SimplifyCtx,
@@ -247,46 +291,6 @@ impl ScalarFnVTable for Binary {
         }
 
         Ok(None)
-    }
-
-    fn validity(
-        &self,
-        operator: &Operator,
-        expression: &Expression,
-    ) -> VortexResult<Option<Expression>> {
-        let lhs = expression.child(0).validity()?;
-        let rhs = expression.child(1).validity()?;
-
-        Ok(match operator {
-            // AND and OR are kleene logic.
-            Operator::And => None,
-            Operator::Or => None,
-            _ => {
-                // All other binary operators are null if either side is null.
-                Some(and(lhs, rhs))
-            }
-        })
-    }
-
-    fn is_strict(&self, operator: &Operator) -> bool {
-        // Kleene AND/OR is not strict (`false AND null = false`, `true OR null = true`), which is
-        // consistent with `validity` returning `None` for these operators above.
-        !matches!(operator, Operator::And | Operator::Or)
-    }
-
-    fn is_infallible(&self, operator: &Operator) -> bool {
-        // Arithmetic operations could be better modelled here.
-        matches!(
-            operator,
-            Operator::Eq
-                | Operator::NotEq
-                | Operator::Gt
-                | Operator::Gte
-                | Operator::Lt
-                | Operator::Lte
-                | Operator::And
-                | Operator::Or
-        )
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/byte_length.rs
+++ b/vortex-array/src/scalar_fn/fns/byte_length.rs
@@ -65,6 +65,7 @@ pub struct ByteLength;
 
 impl ScalarFnVTable for ByteLength {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.byte_length");

--- a/vortex-array/src/scalar_fn/fns/case_when.rs
+++ b/vortex-array/src/scalar_fn/fns/case_when.rs
@@ -40,6 +40,7 @@ use crate::scalar::Scalar;
 use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::OptimizeVTable;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
 use crate::scalar_fn::SimplifyCtx;
@@ -83,6 +84,7 @@ pub struct CaseWhen;
 
 impl ScalarFnVTable for CaseWhen {
     type Options = CaseWhenOptions;
+    type OptimizeVTable = Self;
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.case_when");
@@ -256,9 +258,20 @@ impl ScalarFnVTable for CaseWhen {
         merge_case_branches(branches, else_value, ctx)
     }
 
+    fn is_strict(&self, _options: &Self::Options) -> bool {
+        // A null in an unselected branch does not force a null output.
+        false
+    }
+
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
+    }
+}
+
+impl OptimizeVTable<CaseWhen> for CaseWhen {
     fn simplify(
-        &self,
-        options: &Self::Options,
+        _vtable: &Self,
+        options: &CaseWhenOptions,
         expr: &Expression,
         _ctx: &dyn SimplifyCtx,
     ) -> VortexResult<Option<Expression>> {
@@ -299,15 +312,6 @@ impl ScalarFnVTable for CaseWhen {
         }
 
         Ok(Some(crate::expr::fill_null(x.clone(), fill.clone())))
-    }
-
-    fn is_strict(&self, _options: &Self::Options) -> bool {
-        // A null in an unselected branch does not force a null output.
-        false
-    }
-
-    fn is_infallible(&self, _options: &Self::Options) -> bool {
-        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/cast/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/cast/mod.rs
@@ -42,6 +42,7 @@ use crate::expr::lit;
 use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::OptimizeVTable;
 use crate::scalar_fn::ReduceNode;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
@@ -63,6 +64,7 @@ impl Cast {
 
 impl ScalarFnVTable for Cast {
     type Options = DType;
+    type OptimizeVTable = Self;
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.cast");
@@ -154,28 +156,6 @@ impl ScalarFnVTable for Cast {
         }
     }
 
-    fn reduce<T: ReduceNode>(&self, target_dtype: &DType, node: &T) -> VortexResult<Option<T>> {
-        // Collapse node if child is already the target type
-        let child = node.child(0);
-        if &child.node_dtype()? == target_dtype {
-            return Ok(Some(child));
-        }
-        Ok(None)
-    }
-
-    fn simplify_untyped(
-        &self,
-        target_dtype: &DType,
-        expr: &Expression,
-    ) -> VortexResult<Option<Expression>> {
-        let Some(scalar) = expr.child(0).as_opt::<Literal>() else {
-            return Ok(None);
-        };
-        // A failing cast (e.g. null to a non-nullable dtype) is left in place so the error
-        // surfaces at execution time rather than during optimization.
-        Ok(scalar.cast(target_dtype).ok().map(lit))
-    }
-
     fn validity(&self, dtype: &DType, expression: &Expression) -> VortexResult<Option<Expression>> {
         Ok(Some(if dtype.is_nullable() {
             expression.child(0).validity()?
@@ -187,6 +167,34 @@ impl ScalarFnVTable for Cast {
     fn is_strict(&self, _instance: &DType) -> bool {
         // Cast options can pin a non-nullable output dtype instead of propagating nullability.
         false
+    }
+}
+
+impl OptimizeVTable<Cast> for Cast {
+    fn reduce<T: ReduceNode>(
+        _vtable: &Self,
+        target_dtype: &DType,
+        node: &T,
+    ) -> VortexResult<Option<T>> {
+        // Collapse node if child is already the target type
+        let child = node.child(0);
+        if &child.node_dtype()? == target_dtype {
+            return Ok(Some(child));
+        }
+        Ok(None)
+    }
+
+    fn simplify_untyped(
+        _vtable: &Self,
+        target_dtype: &DType,
+        expr: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        let Some(scalar) = expr.child(0).as_opt::<Literal>() else {
+            return Ok(None);
+        };
+        // A failing cast (e.g. null to a non-nullable dtype) is left in place so the error
+        // surfaces at execution time rather than during optimization.
+        Ok(scalar.cast(target_dtype).ok().map(lit))
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/dynamic.rs
+++ b/vortex-array/src/scalar_fn/fns/dynamic.rs
@@ -45,6 +45,7 @@ pub struct DynamicComparison;
 
 impl ScalarFnVTable for DynamicComparison {
     type Options = DynamicComparisonExpr;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.dynamic");

--- a/vortex-array/src/scalar_fn/fns/ext_storage.rs
+++ b/vortex-array/src/scalar_fn/fns/ext_storage.rs
@@ -27,6 +27,7 @@ pub struct ExtStorage;
 
 impl ScalarFnVTable for ExtStorage {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.ext.storage");

--- a/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
@@ -28,6 +28,7 @@ use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::OptimizeVTable;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
 use crate::scalar_fn::ScalarFnVTableExt;
@@ -49,6 +50,7 @@ impl FillNull {
 
 impl ScalarFnVTable for FillNull {
     type Options = EmptyOptions;
+    type OptimizeVTable = Self;
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.fill_null");
@@ -120,21 +122,6 @@ impl ScalarFnVTable for FillNull {
         }
     }
 
-    fn simplify(
-        &self,
-        _options: &Self::Options,
-        expr: &Expression,
-        ctx: &dyn crate::scalar_fn::SimplifyCtx,
-    ) -> VortexResult<Option<Expression>> {
-        let input_dtype = ctx.return_dtype(expr.child(0))?;
-
-        if !input_dtype.is_nullable() {
-            return Ok(Some(expr.child(0).clone()));
-        }
-
-        Ok(None)
-    }
-
     fn validity(
         &self,
         _options: &Self::Options,
@@ -152,6 +139,23 @@ impl ScalarFnVTable for FillNull {
 
     fn is_infallible(&self, _options: &Self::Options) -> bool {
         true
+    }
+}
+
+impl OptimizeVTable<FillNull> for FillNull {
+    fn simplify(
+        _vtable: &Self,
+        _options: &EmptyOptions,
+        expr: &Expression,
+        ctx: &dyn crate::scalar_fn::SimplifyCtx,
+    ) -> VortexResult<Option<Expression>> {
+        let input_dtype = ctx.return_dtype(expr.child(0))?;
+
+        if !input_dtype.is_nullable() {
+            return Ok(Some(expr.child(0).clone()));
+        }
+
+        Ok(None)
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/get_item.rs
+++ b/vortex-array/src/scalar_fn/fns/get_item.rs
@@ -32,6 +32,7 @@ use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::OptimizeVTable;
 use crate::scalar_fn::ReduceNode;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
@@ -59,6 +60,7 @@ impl GetItem {
 
 impl ScalarFnVTable for GetItem {
     type Options = FieldName;
+    type OptimizeVTable = Self;
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.get_item");
@@ -162,7 +164,22 @@ impl ScalarFnVTable for GetItem {
         }
     }
 
-    fn reduce<T: ReduceNode>(&self, field_name: &FieldName, node: &T) -> VortexResult<Option<T>> {
+    fn is_strict(&self, _field_name: &FieldName) -> bool {
+        true
+    }
+
+    fn is_infallible(&self, _field_name: &FieldName) -> bool {
+        // If this type-checks, it is infallible.
+        true
+    }
+}
+
+impl OptimizeVTable<GetItem> for GetItem {
+    fn reduce<T: ReduceNode>(
+        _vtable: &Self,
+        field_name: &FieldName,
+        node: &T,
+    ) -> VortexResult<Option<T>> {
         let child = node.child(0);
         if let Some(child_fn) = child.scalar_fn()
             && let Some(pack) = child_fn.as_opt::<Pack>()
@@ -185,7 +202,7 @@ impl ScalarFnVTable for GetItem {
     }
 
     fn simplify_untyped(
-        &self,
+        _vtable: &Self,
         field_name: &FieldName,
         expr: &Expression,
     ) -> VortexResult<Option<Expression>> {
@@ -220,15 +237,6 @@ impl ScalarFnVTable for GetItem {
         }
 
         Ok(None)
-    }
-
-    fn is_strict(&self, _field_name: &FieldName) -> bool {
-        true
-    }
-
-    fn is_infallible(&self, _field_name: &FieldName) -> bool {
-        // If this type-checks, it is infallible.
-        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/is_not_null.rs
+++ b/vortex-array/src/scalar_fn/fns/is_not_null.rs
@@ -41,6 +41,7 @@ impl IsNotNull {
 
 impl ScalarFnVTable for IsNotNull {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.is_not_null");

--- a/vortex-array/src/scalar_fn/fns/is_null.rs
+++ b/vortex-array/src/scalar_fn/fns/is_null.rs
@@ -38,6 +38,7 @@ impl IsNull {
 
 impl ScalarFnVTable for IsNull {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.is_null");

--- a/vortex-array/src/scalar_fn/fns/like/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/like/mod.rs
@@ -82,6 +82,7 @@ impl Like {
 
 impl ScalarFnVTable for Like {
     type Options = LikeOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.like");

--- a/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
@@ -64,6 +64,7 @@ impl ListContains {
 
 impl ScalarFnVTable for ListContains {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.list.contains");

--- a/vortex-array/src/scalar_fn/fns/list_length.rs
+++ b/vortex-array/src/scalar_fn/fns/list_length.rs
@@ -45,6 +45,7 @@ pub struct ListLength;
 
 impl ScalarFnVTable for ListLength {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.list.length");

--- a/vortex-array/src/scalar_fn/fns/list_sum.rs
+++ b/vortex-array/src/scalar_fn/fns/list_sum.rs
@@ -40,6 +40,7 @@ pub struct ListSum;
 
 impl ScalarFnVTable for ListSum {
     type Options = NumericalAggregateOpts;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.list.sum");

--- a/vortex-array/src/scalar_fn/fns/literal.rs
+++ b/vortex-array/src/scalar_fn/fns/literal.rs
@@ -35,6 +35,7 @@ pub struct Literal;
 
 impl ScalarFnVTable for Literal {
     type Options = Scalar;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.literal");

--- a/vortex-array/src/scalar_fn/fns/mask/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/mask/mod.rs
@@ -30,6 +30,7 @@ use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::OptimizeVTable;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
 use crate::scalar_fn::ScalarFnVTableExt;
@@ -57,6 +58,7 @@ impl Mask {
 
 impl ScalarFnVTable for Mask {
     type Options = EmptyOptions;
+    type OptimizeVTable = Self;
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.mask");
@@ -112,9 +114,26 @@ impl ScalarFnVTable for Mask {
         execute_canonical(input, mask_array, ctx)
     }
 
-    fn simplify(
+    fn validity(
         &self,
         _options: &Self::Options,
+        expression: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        Ok(Some(and(
+            expression.child(0).validity()?,
+            expression.child(1).clone(),
+        )))
+    }
+
+    fn is_strict(&self, _options: &Self::Options) -> bool {
+        true
+    }
+}
+
+impl OptimizeVTable<Mask> for Mask {
+    fn simplify(
+        _vtable: &Self,
+        _options: &EmptyOptions,
         expr: &Expression,
         ctx: &dyn SimplifyCtx,
     ) -> VortexResult<Option<Expression>> {
@@ -135,21 +154,6 @@ impl ScalarFnVTable for Mask {
             let input_dtype = ctx.return_dtype(expr.child(0))?;
             Ok(Some(lit(Scalar::null(input_dtype.as_nullable()))))
         }
-    }
-
-    fn validity(
-        &self,
-        _options: &Self::Options,
-        expression: &Expression,
-    ) -> VortexResult<Option<Expression>> {
-        Ok(Some(and(
-            expression.child(0).validity()?,
-            expression.child(1).clone(),
-        )))
-    }
-
-    fn is_strict(&self, _options: &Self::Options) -> bool {
-        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/merge.rs
+++ b/vortex-array/src/scalar_fn/fns/merge.rs
@@ -28,6 +28,7 @@ use crate::expr::lit;
 use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::OptimizeVTable;
 use crate::scalar_fn::ReduceNode;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
@@ -48,6 +49,7 @@ pub struct Merge;
 
 impl ScalarFnVTable for Merge {
     type Options = DuplicateHandling;
+    type OptimizeVTable = Self;
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.merge");
@@ -173,7 +175,29 @@ impl ScalarFnVTable for Merge {
         )
     }
 
-    fn reduce<T: ReduceNode>(&self, options: &Self::Options, node: &T) -> VortexResult<Option<T>> {
+    fn validity(
+        &self,
+        _options: &Self::Options,
+        _expression: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        Ok(Some(lit(true)))
+    }
+
+    fn is_strict(&self, _options: &Self::Options) -> bool {
+        true
+    }
+
+    fn is_infallible(&self, instance: &Self::Options) -> bool {
+        !matches!(instance, DuplicateHandling::Error)
+    }
+}
+
+impl OptimizeVTable<Merge> for Merge {
+    fn reduce<T: ReduceNode>(
+        _vtable: &Self,
+        options: &DuplicateHandling,
+        node: &T,
+    ) -> VortexResult<Option<T>> {
         let mut names = Vec::with_capacity(node.child_count() * 2);
         let mut children = Vec::with_capacity(node.child_count() * 2);
         let mut duplicate_names = HashSet::<_>::new();
@@ -224,22 +248,6 @@ impl ScalarFnVTable for Merge {
         )?;
 
         Ok(Some(pack_expr))
-    }
-
-    fn validity(
-        &self,
-        _options: &Self::Options,
-        _expression: &Expression,
-    ) -> VortexResult<Option<Expression>> {
-        Ok(Some(lit(true)))
-    }
-
-    fn is_strict(&self, _options: &Self::Options) -> bool {
-        true
-    }
-
-    fn is_infallible(&self, instance: &Self::Options) -> bool {
-        !matches!(instance, DuplicateHandling::Error)
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/not/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/not/mod.rs
@@ -45,6 +45,7 @@ impl Not {
 
 impl ScalarFnVTable for Not {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.not");

--- a/vortex-array/src/scalar_fn/fns/pack.rs
+++ b/vortex-array/src/scalar_fn/fns/pack.rs
@@ -55,6 +55,7 @@ impl Display for PackOptions {
 
 impl ScalarFnVTable for Pack {
     type Options = PackOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.pack");

--- a/vortex-array/src/scalar_fn/fns/select.rs
+++ b/vortex-array/src/scalar_fn/fns/select.rs
@@ -34,6 +34,7 @@ use crate::expr::pack;
 use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::OptimizeVTable;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
 use crate::scalar_fn::SimplifyCtx;
@@ -50,6 +51,7 @@ pub struct Select;
 
 impl ScalarFnVTable for Select {
     type Options = FieldSelection;
+    type OptimizeVTable = Self;
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.select");
@@ -181,8 +183,19 @@ impl ScalarFnVTable for Select {
         result.into_array().execute(ctx)
     }
 
+    fn is_strict(&self, _options: &FieldSelection) -> bool {
+        true
+    }
+
+    fn is_infallible(&self, _instance: &FieldSelection) -> bool {
+        // If this type-checks, it is infallible.
+        true
+    }
+}
+
+impl OptimizeVTable<Select> for Select {
     fn simplify(
-        &self,
+        _vtable: &Self,
         selection: &FieldSelection,
         expr: &Expression,
         ctx: &dyn SimplifyCtx,
@@ -245,15 +258,6 @@ impl ScalarFnVTable for Select {
         }
 
         Ok(None)
-    }
-
-    fn is_strict(&self, _options: &FieldSelection) -> bool {
-        true
-    }
-
-    fn is_infallible(&self, _instance: &FieldSelection) -> bool {
-        // If this type-checks, it is infallible.
-        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/fns/stat.rs
+++ b/vortex-array/src/scalar_fn/fns/stat.rs
@@ -81,6 +81,7 @@ pub struct StatFn;
 
 impl ScalarFnVTable for StatFn {
     type Options = StatOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.stat");

--- a/vortex-array/src/scalar_fn/fns/variant_get/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/variant_get/mod.rs
@@ -57,6 +57,7 @@ impl VariantGet {
 
 impl ScalarFnVTable for VariantGet {
     type Options = VariantGetOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.variant_get");

--- a/vortex-array/src/scalar_fn/fns/zip/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/zip/mod.rs
@@ -33,6 +33,7 @@ use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::OptimizeVTable;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
 use crate::scalar_fn::ScalarFnVTableExt;
@@ -68,6 +69,7 @@ impl Zip {
 
 impl ScalarFnVTable for Zip {
     type Options = EmptyOptions;
+    type OptimizeVTable = Self;
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.zip");
@@ -156,9 +158,20 @@ impl ScalarFnVTable for Zip {
         zip_impl(&if_true, &if_false, &mask, ctx)
     }
 
+    fn is_strict(&self, _options: &Self::Options) -> bool {
+        // A null in an unselected branch does not force a null output.
+        false
+    }
+
+    fn is_infallible(&self, _options: &Self::Options) -> bool {
+        true
+    }
+}
+
+impl OptimizeVTable<Zip> for Zip {
     fn simplify(
-        &self,
-        _options: &Self::Options,
+        _vtable: &Self,
+        _options: &EmptyOptions,
         expr: &Expression,
         _ctx: &dyn SimplifyCtx,
     ) -> VortexResult<Option<Expression>> {
@@ -175,15 +188,6 @@ impl ScalarFnVTable for Zip {
         }
 
         Ok(None)
-    }
-
-    fn is_strict(&self, _options: &Self::Options) -> bool {
-        // A null in an unselected branch does not force a null output.
-        false
-    }
-
-    fn is_infallible(&self, _options: &Self::Options) -> bool {
-        true
     }
 }
 

--- a/vortex-array/src/scalar_fn/foreign.rs
+++ b/vortex-array/src/scalar_fn/foreign.rs
@@ -65,6 +65,7 @@ impl ForeignScalarFnVTable {
 
 impl ScalarFnVTable for ForeignScalarFnVTable {
     type Options = ForeignScalarFnOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         self.id

--- a/vortex-array/src/scalar_fn/internal/row_count.rs
+++ b/vortex-array/src/scalar_fn/internal/row_count.rs
@@ -47,6 +47,7 @@ pub struct RowCount;
 
 impl ScalarFnVTable for RowCount {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.row_count");

--- a/vortex-array/src/scalar_fn/mod.rs
+++ b/vortex-array/src/scalar_fn/mod.rs
@@ -20,6 +20,9 @@ use crate::scalar_fn::fns::ext_storage::ExtStorage;
 use crate::scalar_fn::fns::get_item::GetItem;
 use crate::scalar_fn::fns::literal::Literal;
 
+mod optimize;
+pub use optimize::*;
+
 mod vtable;
 pub use vtable::*;
 

--- a/vortex-array/src/scalar_fn/optimize.rs
+++ b/vortex-array/src/scalar_fn/optimize.rs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Scalar function optimization hooks and tree reduction adapters.
+
+use std::borrow::Cow;
+
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+
+use crate::ArrayRef;
+use crate::IntoArray;
+use crate::arrays::ScalarFn;
+use crate::arrays::ScalarFnArray;
+use crate::dtype::DType;
+use crate::expr::Expression;
+use crate::scalar_fn::ScalarFnRef;
+use crate::scalar_fn::ScalarFnVTable;
+
+/// Rewrite rules for a scalar function's expression and array nodes.
+///
+/// Selected by [`ScalarFnVTable::OptimizeVTable`]. Hooks receive the function's vtable and
+/// bound options, and return `Ok(None)` when no rule applies. The optimizer controls rule
+/// ordering and iteration; implementations only rewrite the supplied node.
+///
+/// Use `()` for scalar functions without optimization rules. The generic [`Self::reduce`]
+/// hook is dispatched separately for expression and array trees by the scalar function's
+/// existing type-erased wrapper.
+pub trait OptimizeVTable<V: ScalarFnVTable> {
+    /// Implement an abstract reduction rule over a tree of scalar functions.
+    ///
+    /// The [`ReduceNode`] can be used to traverse children, inspect their types, and
+    /// construct the result via [`ReduceNode::new_node`]. The rule is generic over the node
+    /// type and is instantiated once per reducible tree kind (expressions and arrays).
+    ///
+    /// Return `Ok(None)` if no reduction is possible.
+    fn reduce<T: ReduceNode>(
+        _vtable: &V,
+        _options: &V::Options,
+        _node: &T,
+    ) -> VortexResult<Option<T>> {
+        Ok(None)
+    }
+
+    /// Simplify the expression using type information from the context.
+    fn simplify(
+        _vtable: &V,
+        _options: &V::Options,
+        _expr: &Expression,
+        _ctx: &dyn SimplifyCtx,
+    ) -> VortexResult<Option<Expression>> {
+        Ok(None)
+    }
+
+    /// Simplify the expression without type information.
+    fn simplify_untyped(
+        _vtable: &V,
+        _options: &V::Options,
+        _expr: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        Ok(None)
+    }
+}
+
+impl<V: ScalarFnVTable> OptimizeVTable<V> for () {}
+
+/// A node used for implementing abstract reduction rules over a tree of scalar functions.
+///
+/// Reduction rules are generic over the node type, so a rule is written once and monomorphized
+/// per reducible tree kind: [`ExpressionReduceNode`] for expression trees and
+/// [`ArrayReduceNode`] for array trees. Nodes borrow from the tree being reduced, making
+/// traversal allocation-free, while nodes produced by [`ReduceNode::new_node`] own their
+/// freshly-built subtrees.
+pub trait ReduceNode: Clone {
+    /// Return the data type of this node.
+    fn node_dtype(&self) -> VortexResult<DType>;
+
+    /// Return this node's scalar function if it is indeed a scalar fn.
+    fn scalar_fn(&self) -> Option<&ScalarFnRef>;
+
+    /// Descend to the child of this node.
+    fn child(&self, idx: usize) -> Self;
+
+    /// Returns the number of children of this node.
+    fn child_count(&self) -> usize;
+
+    /// Create a new node from the given scalar function and children, inheriting this node's
+    /// reduction context (e.g. the expression scope, or the array row count).
+    fn new_node(&self, scalar_fn: ScalarFnRef, children: &[Self]) -> VortexResult<Self>;
+}
+
+/// A [`ReduceNode`] over an expression tree, typed within a scope.
+#[derive(Clone)]
+pub struct ExpressionReduceNode<'a> {
+    expression: Cow<'a, Expression>,
+    scope: &'a DType,
+}
+
+impl<'a> ExpressionReduceNode<'a> {
+    /// Creates a node borrowing the given expression and scope.
+    pub fn new(expression: &'a Expression, scope: &'a DType) -> Self {
+        Self {
+            expression: Cow::Borrowed(expression),
+            scope,
+        }
+    }
+
+    /// Returns the expression backing this node.
+    pub fn expression(&self) -> &Expression {
+        &self.expression
+    }
+
+    /// Consumes this node and returns the backing expression.
+    pub fn into_expression(self) -> Expression {
+        self.expression.into_owned()
+    }
+}
+
+impl ReduceNode for ExpressionReduceNode<'_> {
+    fn node_dtype(&self) -> VortexResult<DType> {
+        self.expression.return_dtype(self.scope)
+    }
+
+    fn scalar_fn(&self) -> Option<&ScalarFnRef> {
+        self.expression.as_scalar()
+    }
+
+    fn child(&self, idx: usize) -> Self {
+        let expression = match &self.expression {
+            Cow::Borrowed(expression) => Cow::Borrowed(expression.child(idx)),
+            Cow::Owned(expression) => Cow::Owned(expression.child(idx).clone()),
+        };
+        Self {
+            expression,
+            scope: self.scope,
+        }
+    }
+
+    fn child_count(&self) -> usize {
+        self.expression.children().len()
+    }
+
+    fn new_node(&self, scalar_fn: ScalarFnRef, children: &[Self]) -> VortexResult<Self> {
+        let expression = Expression::try_new(
+            scalar_fn,
+            children
+                .iter()
+                .map(|c| c.expression.as_ref().clone())
+                .collect::<Vec<_>>(),
+        )?;
+        Ok(Self {
+            expression: Cow::Owned(expression),
+            scope: self.scope,
+        })
+    }
+}
+
+/// A [`ReduceNode`] over an array tree.
+#[derive(Clone)]
+pub struct ArrayReduceNode<'a> {
+    array: Cow<'a, ArrayRef>,
+}
+
+impl<'a> ArrayReduceNode<'a> {
+    /// Creates a node borrowing the given array.
+    pub fn new(array: &'a ArrayRef) -> Self {
+        Self {
+            array: Cow::Borrowed(array),
+        }
+    }
+
+    /// Returns the array backing this node.
+    pub fn array(&self) -> &ArrayRef {
+        &self.array
+    }
+
+    /// Consumes this node and returns the backing array.
+    pub fn into_array(self) -> ArrayRef {
+        self.array.into_owned()
+    }
+}
+
+impl ReduceNode for ArrayReduceNode<'_> {
+    fn node_dtype(&self) -> VortexResult<DType> {
+        Ok(self.array.dtype().clone())
+    }
+
+    fn scalar_fn(&self) -> Option<&ScalarFnRef> {
+        self.array
+            .as_opt::<ScalarFn>()
+            .map(|a| a.data().scalar_fn())
+    }
+
+    fn child(&self, idx: usize) -> Self {
+        let array = match &self.array {
+            Cow::Borrowed(array) => Cow::Borrowed(
+                array
+                    .children_iter()
+                    .nth(idx)
+                    .vortex_expect("child idx out of bounds"),
+            ),
+            Cow::Owned(array) => Cow::Owned(
+                array
+                    .nth_child(idx)
+                    .vortex_expect("child idx out of bounds"),
+            ),
+        };
+        Self { array }
+    }
+
+    fn child_count(&self) -> usize {
+        self.array.nchildren()
+    }
+
+    fn new_node(&self, scalar_fn: ScalarFnRef, children: &[Self]) -> VortexResult<Self> {
+        let array = ScalarFnArray::try_new_with_len(
+            scalar_fn,
+            children.iter().map(|c| c.array.as_ref().clone()).collect(),
+            self.array.len(),
+        )?;
+        Ok(Self {
+            array: Cow::Owned(array.into_array()),
+        })
+    }
+}
+
+/// Context for simplification.
+///
+/// Used to lazily compute input data types where simplification requires them.
+pub trait SimplifyCtx {
+    /// Get the data type of the given expression.
+    fn return_dtype(&self, expr: &Expression) -> VortexResult<DType>;
+}

--- a/vortex-array/src/scalar_fn/typed.rs
+++ b/vortex-array/src/scalar_fn/typed.rs
@@ -30,6 +30,7 @@ use crate::scalar_fn::ArrayReduceNode;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ExpressionReduceNode;
+use crate::scalar_fn::OptimizeVTable;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnRef;
 use crate::scalar_fn::ScalarFnVTable;
@@ -172,14 +173,14 @@ impl<V: ScalarFnVTable> DynScalarFn for TypedScalarFnInstance<V> {
         &self,
         node: &ExpressionReduceNode<'a>,
     ) -> VortexResult<Option<ExpressionReduceNode<'a>>> {
-        V::reduce(&self.vtable, &self.options, node)
+        V::OptimizeVTable::reduce(&self.vtable, &self.options, node)
     }
 
     fn reduce_array<'a>(
         &self,
         node: &ArrayReduceNode<'a>,
     ) -> VortexResult<Option<ArrayReduceNode<'a>>> {
-        V::reduce(&self.vtable, &self.options, node)
+        V::OptimizeVTable::reduce(&self.vtable, &self.options, node)
     }
 
     fn arity(&self) -> Arity {
@@ -207,11 +208,11 @@ impl<V: ScalarFnVTable> DynScalarFn for TypedScalarFnInstance<V> {
         expression: &Expression,
         ctx: &dyn SimplifyCtx,
     ) -> VortexResult<Option<Expression>> {
-        V::simplify(&self.vtable, &self.options, expression, ctx)
+        V::OptimizeVTable::simplify(&self.vtable, &self.options, expression, ctx)
     }
 
     fn simplify_untyped(&self, expression: &Expression) -> VortexResult<Option<Expression>> {
-        V::simplify_untyped(&self.vtable, &self.options, expression)
+        V::OptimizeVTable::simplify_untyped(&self.vtable, &self.options, expression)
     }
 
     fn validity(&self, expression: &Expression) -> VortexResult<Option<Expression>> {

--- a/vortex-array/src/scalar_fn/unstable/row/vtable.rs
+++ b/vortex-array/src/scalar_fn/unstable/row/vtable.rs
@@ -35,6 +35,7 @@ use crate::scalar_fn::unstable::row::execute::DenseAttempt;
 
 impl<F: RowFn> ScalarFnVTable for F {
     type Options = F::Options;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         RowFn::id(self)

--- a/vortex-array/src/scalar_fn/vtable.rs
+++ b/vortex-array/src/scalar_fn/vtable.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Display;
@@ -17,13 +16,11 @@ use vortex_session::VortexSession;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
-use crate::IntoArray;
-use crate::arrays::ScalarFn;
-use crate::arrays::ScalarFnArray;
 use crate::dtype::DType;
 use crate::expr::BoundExpression;
 use crate::expr::Expression;
 use crate::expr::display::ExprDisplay;
+use crate::scalar_fn::OptimizeVTable;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnRef;
 use crate::scalar_fn::TypedScalarFnInstance;
@@ -42,6 +39,11 @@ use crate::scalar_fn::TypedScalarFnInstance;
 pub trait ScalarFnVTable: 'static + Sized + Clone + Send + Sync {
     /// Options for this expression.
     type Options: 'static + Send + Sync + Clone + Debug + Display + PartialEq + Eq + Hash;
+
+    /// Optimization rules for this scalar function.
+    ///
+    /// Use `Self` to implement custom rules, or `()` when no rules are needed.
+    type OptimizeVTable: OptimizeVTable<Self>;
 
     /// Returns the ID of the scalar function vtable.
     fn id(&self) -> ScalarFnId;
@@ -125,43 +127,6 @@ pub trait ScalarFnVTable: 'static + Sized + Clone + Send + Sync {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef>;
 
-    /// Implement an abstract reduction rule over a tree of scalar functions.
-    ///
-    /// The [`ReduceNode`] can be used to traverse children, inspect their types, and
-    /// construct the result via [`ReduceNode::new_node`]. The rule is generic over the node
-    /// type and is instantiated once per reducible tree kind (expressions and arrays).
-    ///
-    /// Return `Ok(None)` if no reduction is possible.
-    fn reduce<T: ReduceNode>(&self, options: &Self::Options, node: &T) -> VortexResult<Option<T>> {
-        _ = options;
-        _ = node;
-        Ok(None)
-    }
-
-    /// Simplify the expression if possible.
-    fn simplify(
-        &self,
-        options: &Self::Options,
-        expr: &Expression,
-        ctx: &dyn SimplifyCtx,
-    ) -> VortexResult<Option<Expression>> {
-        _ = options;
-        _ = expr;
-        _ = ctx;
-        Ok(None)
-    }
-
-    /// Simplify the expression if possible, without type information.
-    fn simplify_untyped(
-        &self,
-        options: &Self::Options,
-        expr: &Expression,
-    ) -> VortexResult<Option<Expression>> {
-        _ = options;
-        _ = expr;
-        Ok(None)
-    }
-
     /// Returns an expression that evaluates to the validity of the result of this expression.
     ///
     /// If a validity expression cannot be constructed, returns `None` and the expression will
@@ -222,166 +187,6 @@ pub trait ScalarFnVTable: 'static + Sized + Clone + Send + Sync {
     }
 }
 
-/// A node used for implementing abstract reduction rules over a tree of scalar functions.
-///
-/// Reduction rules are generic over the node type, so a rule is written once and monomorphized
-/// per reducible tree kind: [`ExpressionReduceNode`] for expression trees and
-/// [`ArrayReduceNode`] for array trees. Nodes borrow from the tree being reduced, making
-/// traversal allocation-free, while nodes produced by [`ReduceNode::new_node`] own their
-/// freshly-built subtrees.
-pub trait ReduceNode: Clone {
-    /// Return the data type of this node.
-    fn node_dtype(&self) -> VortexResult<DType>;
-
-    /// Return this node's scalar function if it is indeed a scalar fn.
-    fn scalar_fn(&self) -> Option<&ScalarFnRef>;
-
-    /// Descend to the child of this node.
-    fn child(&self, idx: usize) -> Self;
-
-    /// Returns the number of children of this node.
-    fn child_count(&self) -> usize;
-
-    /// Create a new node from the given scalar function and children, inheriting this node's
-    /// reduction context (e.g. the expression scope, or the array row count).
-    fn new_node(&self, scalar_fn: ScalarFnRef, children: &[Self]) -> VortexResult<Self>;
-}
-
-/// A [`ReduceNode`] over an expression tree, typed within a scope.
-#[derive(Clone)]
-pub struct ExpressionReduceNode<'a> {
-    expression: Cow<'a, Expression>,
-    scope: &'a DType,
-}
-
-impl<'a> ExpressionReduceNode<'a> {
-    /// Creates a node borrowing the given expression and scope.
-    pub fn new(expression: &'a Expression, scope: &'a DType) -> Self {
-        Self {
-            expression: Cow::Borrowed(expression),
-            scope,
-        }
-    }
-
-    /// Returns the expression backing this node.
-    pub fn expression(&self) -> &Expression {
-        &self.expression
-    }
-
-    /// Consumes this node and returns the backing expression.
-    pub fn into_expression(self) -> Expression {
-        self.expression.into_owned()
-    }
-}
-
-impl ReduceNode for ExpressionReduceNode<'_> {
-    fn node_dtype(&self) -> VortexResult<DType> {
-        self.expression.return_dtype(self.scope)
-    }
-
-    fn scalar_fn(&self) -> Option<&ScalarFnRef> {
-        self.expression.as_scalar()
-    }
-
-    fn child(&self, idx: usize) -> Self {
-        let expression = match &self.expression {
-            Cow::Borrowed(expression) => Cow::Borrowed(expression.child(idx)),
-            Cow::Owned(expression) => Cow::Owned(expression.child(idx).clone()),
-        };
-        Self {
-            expression,
-            scope: self.scope,
-        }
-    }
-
-    fn child_count(&self) -> usize {
-        self.expression.children().len()
-    }
-
-    fn new_node(&self, scalar_fn: ScalarFnRef, children: &[Self]) -> VortexResult<Self> {
-        let expression = Expression::try_new(
-            scalar_fn,
-            children
-                .iter()
-                .map(|c| c.expression.as_ref().clone())
-                .collect::<Vec<_>>(),
-        )?;
-        Ok(Self {
-            expression: Cow::Owned(expression),
-            scope: self.scope,
-        })
-    }
-}
-
-/// A [`ReduceNode`] over an array tree.
-#[derive(Clone)]
-pub struct ArrayReduceNode<'a> {
-    array: Cow<'a, ArrayRef>,
-}
-
-impl<'a> ArrayReduceNode<'a> {
-    /// Creates a node borrowing the given array.
-    pub fn new(array: &'a ArrayRef) -> Self {
-        Self {
-            array: Cow::Borrowed(array),
-        }
-    }
-
-    /// Returns the array backing this node.
-    pub fn array(&self) -> &ArrayRef {
-        &self.array
-    }
-
-    /// Consumes this node and returns the backing array.
-    pub fn into_array(self) -> ArrayRef {
-        self.array.into_owned()
-    }
-}
-
-impl ReduceNode for ArrayReduceNode<'_> {
-    fn node_dtype(&self) -> VortexResult<DType> {
-        Ok(self.array.dtype().clone())
-    }
-
-    fn scalar_fn(&self) -> Option<&ScalarFnRef> {
-        self.array
-            .as_opt::<ScalarFn>()
-            .map(|a| a.data().scalar_fn())
-    }
-
-    fn child(&self, idx: usize) -> Self {
-        let array = match &self.array {
-            Cow::Borrowed(array) => Cow::Borrowed(
-                array
-                    .children_iter()
-                    .nth(idx)
-                    .vortex_expect("child idx out of bounds"),
-            ),
-            Cow::Owned(array) => Cow::Owned(
-                array
-                    .nth_child(idx)
-                    .vortex_expect("child idx out of bounds"),
-            ),
-        };
-        Self { array }
-    }
-
-    fn child_count(&self) -> usize {
-        self.array.nchildren()
-    }
-
-    fn new_node(&self, scalar_fn: ScalarFnRef, children: &[Self]) -> VortexResult<Self> {
-        let array = ScalarFnArray::try_new_with_len(
-            scalar_fn,
-            children.iter().map(|c| c.array.as_ref().clone()).collect(),
-            self.array.len(),
-        )?;
-        Ok(Self {
-            array: Cow::Owned(array.into_array()),
-        })
-    }
-}
-
 /// The arity (number of arguments) of a function.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Arity {
@@ -420,14 +225,6 @@ impl Arity {
             }
         }
     }
-}
-
-/// Context for simplification.
-///
-/// Used to lazily compute input data types where simplification requires them.
-pub trait SimplifyCtx {
-    /// Get the data type of the given expression.
-    fn return_dtype(&self, expr: &Expression) -> VortexResult<DType>;
 }
 
 /// Arguments for expression execution.

--- a/vortex-json/src/json_to_variant.rs
+++ b/vortex-json/src/json_to_variant.rs
@@ -81,6 +81,7 @@ impl JsonToVariant {
 
 impl ScalarFnVTable for JsonToVariant {
     type Options = JsonToVariantOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.json_to_variant");

--- a/vortex-layout/src/layouts/row_idx/expr.rs
+++ b/vortex-layout/src/layouts/row_idx/expr.rs
@@ -25,6 +25,7 @@ pub struct RowIdx;
 
 impl ScalarFnVTable for RowIdx {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.row_idx");

--- a/vortex-layout/src/layouts/zoned/aggregates/bloom_filter/scalar_fn.rs
+++ b/vortex-layout/src/layouts/zoned/aggregates/bloom_filter/scalar_fn.rs
@@ -58,6 +58,7 @@ struct BloomContains;
 
 impl ScalarFnVTable for BloomContains {
     type Options = BloomOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.bloom_filter.sbbf.contains");

--- a/vortex-row/src/encode.rs
+++ b/vortex-row/src/encode.rs
@@ -49,6 +49,7 @@ pub struct RowEncode;
 
 impl ScalarFnVTable for RowEncode {
     type Options = RowEncodingOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         ScalarFnId::from("vortex.row_encode")

--- a/vortex-row/src/size.rs
+++ b/vortex-row/src/size.rs
@@ -189,6 +189,7 @@ pub(crate) fn row_size_struct_dtype() -> DType {
 
 impl ScalarFnVTable for RowSize {
     type Options = RowEncodingOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         ScalarFnId::from("vortex.row_size")

--- a/vortex-spatial/src/scalar_fn/collect.rs
+++ b/vortex-spatial/src/scalar_fn/collect.rs
@@ -260,6 +260,7 @@ impl SpatialCollect {
 
 impl ScalarFnVTable for SpatialCollect {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.st.collect");

--- a/vortex-spatial/src/scalar_fn/envelope.rs
+++ b/vortex-spatial/src/scalar_fn/envelope.rs
@@ -205,6 +205,7 @@ fn execute_envelope(
 
 impl ScalarFnVTable for SpatialEnvelope {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.st.envelope");

--- a/vortex-spatial/src/scalar_fn/length.rs
+++ b/vortex-spatial/src/scalar_fn/length.rs
@@ -160,6 +160,7 @@ impl SpatialLength {
 
 impl ScalarFnVTable for SpatialLength {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.st.length");

--- a/vortex-spatial/src/scalar_fn/make_line.rs
+++ b/vortex-spatial/src/scalar_fn/make_line.rs
@@ -175,6 +175,7 @@ impl SpatialMakeLine {
 
 impl ScalarFnVTable for SpatialMakeLine {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.st.make_line");

--- a/vortex-tensor/src/scalar_fns/cosine_similarity.rs
+++ b/vortex-tensor/src/scalar_fns/cosine_similarity.rs
@@ -73,6 +73,7 @@ impl CosineSimilarity {
 
 impl ScalarFnVTable for CosineSimilarity {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.tensor.cosine_similarity");

--- a/vortex-tensor/src/scalar_fns/inner_product.rs
+++ b/vortex-tensor/src/scalar_fns/inner_product.rs
@@ -70,6 +70,7 @@ impl InnerProduct {
 
 impl ScalarFnVTable for InnerProduct {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.tensor.inner_product");

--- a/vortex-tensor/src/scalar_fns/l2_norm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_norm.rs
@@ -80,6 +80,7 @@ impl L2Norm {
 
 impl ScalarFnVTable for L2Norm {
     type Options = EmptyOptions;
+    type OptimizeVTable = ();
 
     fn id(&self) -> ScalarFnId {
         static ID: CachedId = CachedId::new("vortex.tensor.l2_norm");


### PR DESCRIPTION
## Summary

Separate scalar function rewrite rules from the core function interface into an associated `OptimizeVTable`. Existing simplification and reduction behavior, shared expression/array reduction rules, and optimizer ordering are preserved.

## Changes

- Move `simplify`, `simplify_untyped`, and generic `reduce` into `OptimizeVTable<V>`, with no-op defaults.
- Forward the existing erased dispatch through `V::OptimizeVTable`, passing the function vtable and bound options.
- Move reduction adapters and `SimplifyCtx` alongside the new trait, preserving their public re-exports.
- Migrate all scalar functions in the workspace.

## API Changes

`ScalarFnVTable` implementations must specify `type OptimizeVTable`. Custom rewrite hooks move to `impl OptimizeVTable<F> for F` and receive `&F` as their first argument in place of `&self`.
