### PR TITLE
Fix DuckDB scans over Vortex being merged or stalling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11555,6 +11555,7 @@ dependencies = [
  "datafusion 55.0.0",
  "datafusion-functions-nested 55.0.0",
  "datafusion-sqllogictest",
+ "futures",
  "indicatif",
  "regex",
  "rstest",

--- a/vortex-duckdb/src/file_reader.rs
+++ b/vortex-duckdb/src/file_reader.rs
@@ -76,8 +76,10 @@ use crate::table_function::convert_result;
 // separate thread.
 
 fn resolve_filesystem(url: &Url) -> VortexResult<(FileSystemRef, String)> {
-    // Compat makes us use tokio which is very bad for local reads on
-    // high-core machines because reads go into blocking pool
+    // Keep local files off `Compat`, which routes reads through Tokio. Beyond the cost of
+    // pushing every local read into a blocking pool on high-core machines, a Vortex runtime
+    // that awaits a Tokio task while its driving thread sits inside `Runtime::block_on` loses
+    // the completion wakeup and stalls forever (#9817).
     if url.scheme() == "file" {
         return Ok((
             Arc::new(ObjectStoreFileSystem::local(RUNTIME.handle())),

--- a/vortex-duckdb/src/file_reader.rs
+++ b/vortex-duckdb/src/file_reader.rs
@@ -76,10 +76,8 @@ use crate::table_function::convert_result;
 // separate thread.
 
 fn resolve_filesystem(url: &Url) -> VortexResult<(FileSystemRef, String)> {
-    // Keep local files off `Compat`, which routes reads through Tokio. Beyond the cost of
-    // pushing every local read into a blocking pool on high-core machines, a Vortex runtime
-    // that awaits a Tokio task while its driving thread sits inside `Runtime::block_on` loses
-    // the completion wakeup and stalls forever (#9817).
+    // Compat makes us use tokio which is very bad for local reads on
+    // high-core machines because reads go into blocking pool
     if url.scheme() == "file" {
         return Ok((
             Arc::new(ObjectStoreFileSystem::local(RUNTIME.handle())),

--- a/vortex-sqllogictest/Cargo.toml
+++ b/vortex-sqllogictest/Cargo.toml
@@ -29,6 +29,7 @@ vortex-duckdb = { workspace = true }
 [dev-dependencies]
 datafusion = { workspace = true, features = ["parquet"] }
 datafusion-functions-nested.workspace = true
+futures = { workspace = true }
 indicatif = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 vortex-datafusion = { workspace = true }

--- a/vortex-sqllogictest/bin/sqllogictests-runner.rs
+++ b/vortex-sqllogictest/bin/sqllogictests-runner.rs
@@ -48,11 +48,11 @@ enum Mode {
     Complete,
 }
 
-/// Builds a single-threaded Tokio runtime for one test file.
+/// Builds a single-threaded Tokio runtime for one DataFusion test file.
 ///
 /// `libtest-mimic` runs each trial on its own thread, so a current-thread
-/// runtime keeps blocking DuckDB calls and async DataFusion work isolated per
-/// file instead of contending for shared multi-threaded runtime workers.
+/// runtime keeps async DataFusion work isolated per file instead of contending
+/// for shared multi-threaded runtime workers.
 fn build_runtime() -> anyhow::Result<tokio::runtime::Runtime> {
     Ok(tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -111,8 +111,11 @@ fn drive_duckdb(path: &Path, work_dir: &Path, mode: Mode) -> anyhow::Result<()> 
     let _guard = WorkDirGuard::new(work_dir.to_path_buf());
     let work_dir = work_dir.to_string_lossy().into_owned();
 
-    let rt = build_runtime()?;
-    rt.block_on(async {
+    // Deliberately not a Tokio runtime. DuckDB scans drive Vortex's own runtime, and a Vortex
+    // runtime driven from a thread inside `tokio::runtime::Runtime::block_on` loses the wakeups
+    // that complete its I/O and stalls forever (#9817). `AsyncDB::run` for DuckDB is synchronous
+    // and no DuckDB `.slt` uses the `sleep` or `system` directives, so nothing here needs Tokio.
+    futures::executor::block_on(async {
         let mut runner = Runner::new(|| async {
             DuckDB::try_new().map(|db| PathNormalizing::new(db, work_dir.clone()))
         });


### PR DESCRIPTION
## Summary

Two bugs surfaced by running all 99 TPC-DS queries against Vortex through DuckDB in a single connection (the TPC-DS SLT suite is stacked on this PR). Both make DuckDB over Vortex either return wrong results or hang, so they are split out here for separate review.

