### PR TITLE
[EXPERIMENT] Pass buffer capacity and alignment to the allocator

### DIFF
--- a/vortex-buffer/src/allocation.rs
+++ b/vortex-buffer/src/allocation.rs
@@ -2,6 +2,9 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 //! Allocator-backed storage for Vortex buffers.
+//!
+//! Each allocation retains its base pointer and original layout through slicing and ownership
+//! transfers. Buffer data pointers and logical alignments do not change the layout used to free it.
 
 use std::alloc::Layout;
 use std::any::Any;
@@ -22,7 +25,7 @@ use crate::BufferMut;
 
 /// An allocator that can back a Vortex buffer.
 ///
-/// Vortex over-allocates raw storage and aligns the buffer within it.
+/// Buffer allocations pass their byte capacity and effective alignment through [`Layout`].
 pub trait BufferAllocator: Allocator + Debug + Send + Sync + 'static {}
 
 impl<A> BufferAllocator for A where A: Allocator + Debug + Send + Sync + 'static {}
@@ -235,7 +238,9 @@ unsafe impl Allocator for StaticBufferAllocator {
 static STATIC_ALLOCATOR: BufferAllocatorRef = BufferAllocatorRef(None);
 
 pub(crate) struct Allocation {
+    /// Allocation base, or an aligned dangling pointer when the layout has zero size.
     ptr: NonNull<u8>,
+    /// Layout used to allocate this block. Allocator excess is not exposed as buffer capacity.
     layout: Layout,
     allocator: BufferAllocatorRef,
 }
@@ -318,6 +323,7 @@ impl Allocation {
     }
 
     pub(crate) fn grow(&mut self, new_layout: Layout) {
+        debug_assert!(new_layout.size() >= self.layout.size());
         let allocation = if self.layout.size() == 0 {
             self.allocator.allocate(new_layout)
         } else {
@@ -361,177 +367,5 @@ impl BufferBacking {
             #[cfg(feature = "arrow")]
             Self::Arrow(_) => &STATIC_ALLOCATOR,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::alloc::Layout;
-    use std::ptr::NonNull;
-    use std::sync::Arc;
-    use std::sync::atomic::AtomicUsize;
-    use std::sync::atomic::Ordering;
-
-    use allocator_api2::alloc::AllocError;
-    use allocator_api2::alloc::Allocator;
-    use allocator_api2::alloc::Global;
-    use rstest::rstest;
-    use vortex_error::VortexResult;
-    use vortex_error::vortex_err;
-
-    use crate::Alignment;
-    use crate::BufferAllocatorRef;
-    use crate::BufferMut;
-
-    #[derive(Clone, Debug, Default)]
-    struct TrackingAllocator {
-        state: Arc<TrackingState>,
-    }
-
-    #[derive(Debug, Default)]
-    struct TrackingState {
-        allocations: AtomicUsize,
-        deallocations: AtomicUsize,
-        grows: AtomicUsize,
-        alignment: AtomicUsize,
-    }
-
-    // SAFETY: this forwards all memory operations to Global and only records call metadata.
-    unsafe impl Allocator for TrackingAllocator {
-        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-            self.state.allocations.fetch_add(1, Ordering::Relaxed);
-            self.state
-                .alignment
-                .store(layout.align(), Ordering::Relaxed);
-            Global.allocate(layout)
-        }
-
-        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-            self.state.deallocations.fetch_add(1, Ordering::Relaxed);
-            // SAFETY: the caller passes the pointer and layout returned by Global.
-            unsafe { Global.deallocate(ptr, layout) }
-        }
-
-        unsafe fn grow(
-            &self,
-            ptr: NonNull<u8>,
-            old_layout: Layout,
-            new_layout: Layout,
-        ) -> Result<NonNull<[u8]>, AllocError> {
-            self.state.grows.fetch_add(1, Ordering::Relaxed);
-            // SAFETY: the caller upholds the Allocator contract.
-            unsafe { Global.grow(ptr, old_layout, new_layout) }
-        }
-    }
-
-    #[test]
-    fn allocator_identity() {
-        let static_allocator = BufferAllocatorRef::statically_allocated();
-        assert!(static_allocator.ptr_eq(&BufferAllocatorRef::statically_allocated()));
-
-        let custom_allocator = BufferAllocatorRef::new(TrackingAllocator::default());
-        assert!(custom_allocator.ptr_eq(&custom_allocator.clone()));
-        assert!(!custom_allocator.ptr_eq(&static_allocator));
-        assert!(!custom_allocator.ptr_eq(&BufferAllocatorRef::new(TrackingAllocator::default())));
-    }
-
-    #[test]
-    fn allocation_lives_until_last_view() {
-        let allocator = TrackingAllocator::default();
-        let state = Arc::clone(&allocator.state);
-        let buffer = BufferAllocatorRef::new(allocator)
-            .copy_from([1u32, 2, 3, 4])
-            .freeze();
-        let view = buffer.slice(0..2);
-
-        assert_eq!(state.allocations.load(Ordering::Relaxed), 1);
-        assert_eq!(
-            state.alignment.load(Ordering::Relaxed),
-            Alignment::of::<u8>().as_usize()
-        );
-        drop(buffer);
-        assert_eq!(state.deallocations.load(Ordering::Relaxed), 0);
-        drop(view);
-        assert_eq!(state.deallocations.load(Ordering::Relaxed), 1);
-    }
-
-    #[rstest]
-    fn buffer_growth_uses_allocator_grow(#[values(4, 64, 4096)] alignment: usize) {
-        let allocator = TrackingAllocator::default();
-        let state = Arc::clone(&allocator.state);
-        let alignment = Alignment::new(alignment);
-        let mut buffer =
-            BufferAllocatorRef::new(allocator).with_capacity_aligned::<u32>(1, alignment);
-        let initial_capacity = buffer.capacity();
-        buffer.extend(std::iter::repeat_n(7, initial_capacity));
-
-        buffer.push(u32::MAX);
-        assert!(alignment.is_ptr_aligned(buffer.as_ptr()));
-
-        assert_eq!(&buffer[..initial_capacity], vec![7; initial_capacity]);
-        assert_eq!(buffer[initial_capacity], u32::MAX);
-        assert_eq!(state.allocations.load(Ordering::Relaxed), 1);
-        assert_eq!(state.deallocations.load(Ordering::Relaxed), 0);
-        assert_eq!(state.grows.load(Ordering::Relaxed), 1);
-
-        drop(buffer);
-        assert_eq!(state.deallocations.load(Ordering::Relaxed), 1);
-    }
-
-    #[test]
-    fn zero_capacity_does_not_allocate() {
-        let allocator = TrackingAllocator::default();
-        let state = Arc::clone(&allocator.state);
-        let mut buffer = BufferAllocatorRef::new(allocator).with_capacity::<u32>(0);
-
-        assert_eq!(buffer.capacity(), 0);
-        assert!(Alignment::DEFAULT_ALIGNMENT.is_offset_aligned(buffer.as_ptr().addr()));
-        assert_eq!(state.allocations.load(Ordering::Relaxed), 0);
-
-        buffer.push(42);
-
-        assert_eq!(buffer.as_slice(), [42]);
-        assert_eq!(state.allocations.load(Ordering::Relaxed), 1);
-        assert_eq!(state.grows.load(Ordering::Relaxed), 0);
-    }
-
-    #[test]
-    fn empty_buffers_preserve_allocator_without_allocating() -> VortexResult<()> {
-        let allocator = TrackingAllocator::default();
-        let state = Arc::clone(&allocator.state);
-        let allocator = BufferAllocatorRef::new(allocator);
-        let buffer = BufferMut::<u32>::zeroed_in(0, allocator.clone());
-        let buffer = buffer.freeze();
-        let copy = buffer.clone().into_mut();
-        assert!(copy.allocator().ptr_eq(&allocator));
-        let mut buffer = buffer
-            .try_into_mut()
-            .map_err(|_| vortex_err!("unique buffer"))?;
-        buffer.reserve(0);
-        assert!(buffer.is_empty());
-        assert!(buffer.allocator().ptr_eq(&allocator));
-        drop((copy, buffer));
-        assert_eq!(state.allocations.load(Ordering::Relaxed), 0);
-        assert_eq!(state.grows.load(Ordering::Relaxed), 0);
-        assert_eq!(state.deallocations.load(Ordering::Relaxed), 0);
-        Ok(())
-    }
-
-    #[test]
-    fn shared_into_mut_preserves_allocator() {
-        let allocator = TrackingAllocator::default();
-        let state = Arc::clone(&allocator.state);
-        let allocator = BufferAllocatorRef::new(allocator);
-        let original = allocator.copy_from([1u32, 2, 3]).freeze();
-        let mut copy = original.clone().into_mut();
-        assert!(copy.allocator().ptr_eq(&allocator));
-        copy[0] = 42;
-        assert_eq!(original.as_slice(), [1, 2, 3]);
-        assert_eq!(copy.as_slice(), [42, 2, 3]);
-        assert_eq!(state.allocations.load(Ordering::Relaxed), 2);
-        drop(copy);
-        assert_eq!(state.deallocations.load(Ordering::Relaxed), 1);
-        drop(original);
-        assert_eq!(state.deallocations.load(Ordering::Relaxed), 2);
     }
 }

--- a/vortex-buffer/src/buffer_mut.rs
+++ b/vortex-buffer/src/buffer_mut.rs
@@ -36,15 +36,15 @@ use crate::trusted_len::TrustedLen;
 /// let _ = BufferMut::<()>::zeroed(3);
 /// ```
 pub struct BufferMut<T> {
-    /// The owned allocation, including any bytes before `ptr` used for alignment.
+    /// Owns the allocation base and the layout used to allocate it.
     pub(crate) allocation: Allocation,
-    /// The first element, aligned to `alignment`; it may dangle for an empty buffer.
+    /// Aligned data pointer, possibly dangling for empty buffers or interior to a sliced allocation.
     pub(crate) ptr: std::ptr::NonNull<T>,
-    /// The number of initialized `T` values starting at `ptr`.
+    /// Number of initialized elements, at most `capacity`.
     pub(crate) length: usize,
-    /// The number of `T` values that fit from `ptr`.
+    /// Number of usable elements starting at `ptr`, excluding any allocation prefix.
     pub(crate) capacity: usize,
-    /// The minimum alignment maintained for `ptr` across reallocations.
+    /// Requested alignment. The backing allocation can have a stronger preferred alignment.
     pub(crate) alignment: Alignment,
     /// Marks the buffer as logically owning values of `T` despite storing an erased allocation.
     pub(crate) _marker: std::marker::PhantomData<T>,
@@ -135,22 +135,11 @@ impl<T> BufferMut<T> {
         let size = capacity
             .checked_mul(size_of::<T>())
             .vortex_expect("buffer capacity overflow");
-        let layout = if size == 0 {
-            Layout::from_size_align(0, actual.as_usize())
-                .unwrap_or_else(|_| vortex_panic!("invalid empty buffer alignment"))
-        } else {
-            let allocation_size = size
-                .checked_add(actual.as_usize())
-                .vortex_expect("buffer capacity overflow");
-            Layout::from_size_align(allocation_size, 1).unwrap_or_else(|_| {
-                vortex_panic!("buffer capacity exceeds maximum allocation size")
-            })
-        };
+        let layout = Layout::from_size_align(size, actual.as_usize())
+            .unwrap_or_else(|_| vortex_panic!("buffer capacity exceeds maximum allocation size"));
         let allocation = Allocation::allocate(layout, allocator);
-        let offset = allocation.ptr().as_ptr().align_offset(actual.as_usize());
-        // SAFETY: the allocation includes enough padding to reach this aligned pointer.
-        let ptr = unsafe { allocation.ptr().add(offset).cast() };
-        let capacity = (allocation.size() - offset) / size_of::<T>();
+        let ptr = allocation.ptr().cast();
+
         Self {
             allocation,
             ptr,
@@ -220,34 +209,30 @@ impl<T> BufferMut<T> {
         allocator: BufferAllocatorRef,
     ) -> Self {
         const { assert!(size_of::<T>() != 0, "ZSTs are not supported") };
+
+        if !alignment.is_aligned_to(Alignment::of::<T>()) {
+            vortex_panic!(
+                "Alignment {} must align to the scalar type's alignment {}",
+                alignment,
+                align_of::<T>()
+            );
+        }
+
         let preferred_alignment = preferred_alignment.unwrap_or(Alignment::of::<u8>());
         let actual_alignment = max(preferred_alignment, alignment);
         let size = len
             .checked_mul(size_of::<T>())
             .vortex_expect("buffer length overflow");
-        let layout = if size == 0 {
-            Layout::from_size_align(0, actual_alignment.as_usize())
-                .unwrap_or_else(|_| vortex_panic!("invalid empty buffer alignment"))
-        } else {
-            let allocation_size = size
-                .checked_add(actual_alignment.as_usize())
-                .vortex_expect("buffer length overflow");
-            Layout::from_size_align(allocation_size, 1)
-                .unwrap_or_else(|_| vortex_panic!("buffer length exceeds maximum allocation size"))
-        };
+        let layout = Layout::from_size_align(size, actual_alignment.as_usize())
+            .unwrap_or_else(|_| vortex_panic!("buffer length exceeds maximum allocation size"));
         let allocation = Allocation::allocate_zeroed(layout, allocator);
-        let offset = allocation
-            .ptr()
-            .as_ptr()
-            .align_offset(actual_alignment.as_usize());
-        // SAFETY: the allocation includes enough padding to reach this aligned pointer.
-        let ptr = unsafe { allocation.ptr().add(offset).cast() };
-        let capacity = (allocation.size() - offset) / size_of::<T>();
+        let ptr = allocation.ptr().cast();
+
         Self {
             allocation,
             ptr,
             length: len,
-            capacity,
+            capacity: len,
             alignment,
             _marker: Default::default(),
         }
@@ -477,7 +462,6 @@ impl<T> BufferMut<T> {
             return;
         }
 
-        // Otherwise, reserve additional + alignment bytes in case we need to realign the buffer.
         self.reserve_allocate(additional);
     }
 
@@ -490,7 +474,6 @@ impl<T> BufferMut<T> {
         let required_size = required
             .checked_mul(size_of::<T>())
             .vortex_expect("buffer capacity overflow");
-        let alignment = self.alignment;
         let current_size = self
             .capacity
             .checked_mul(size_of::<T>())
@@ -498,55 +481,43 @@ impl<T> BufferMut<T> {
         let logical_size = required_size
             .max(current_size.saturating_mul(2))
             .max(Alignment::DEFAULT_ALIGNMENT.as_usize());
-        let allocation_size = logical_size
-            .checked_add(alignment.as_usize())
-            .vortex_expect("buffer capacity overflow");
-        let allocation_alignment = if self.allocation.size() == 0 {
-            1
-        } else {
-            self.allocation.alignment()
-        };
-        let layout = Layout::from_size_align(allocation_size, allocation_alignment)
+        let alignment = self.alignment.as_usize().max(self.allocation.alignment());
+        let layout = Layout::from_size_align(logical_size, alignment)
             .unwrap_or_else(|_| vortex_panic!("buffer capacity exceeds maximum allocation size"));
 
         let old_offset = self.ptr.cast::<u8>().addr().get() - self.allocation.ptr().addr().get();
-        let new_offset = if self.allocation.allocator().is_statically_allocated() {
-            let allocation =
-                Allocation::allocate(layout, BufferAllocatorRef::statically_allocated());
-            let new_offset = allocation.ptr().as_ptr().align_offset(alignment.as_usize());
+        // A short slice can need more capacity while still needing fewer bytes than its backing
+        // allocation. Allocator::grow cannot shrink that backing layout. The static path also uses
+        // a fresh allocation so it copies only initialized data.
+        if self.allocation.allocator().is_statically_allocated()
+            || layout.size() < self.allocation.size()
+        {
+            let allocation = Allocation::allocate(layout, self.allocation.allocator().clone());
             // SAFETY: both allocations have room for the initialized elements and do not overlap.
             unsafe {
                 std::ptr::copy_nonoverlapping(
                     self.ptr.cast::<u8>().as_ptr(),
-                    allocation.ptr().as_ptr().add(new_offset),
+                    allocation.ptr().as_ptr(),
                     self.length * size_of::<T>(),
                 );
             }
             self.allocation = allocation;
-            new_offset
         } else {
             self.allocation.grow(layout);
-            let new_offset = self
-                .allocation
-                .ptr()
-                .as_ptr()
-                .align_offset(alignment.as_usize());
-            if new_offset != old_offset {
-                // SAFETY: grow preserved the initialized elements at old_offset. The new allocation
-                // has room for the requested elements plus alignment padding, and copy permits
-                // overlap.
+            if old_offset != 0 {
+                // SAFETY: grow preserves the old layout's bytes, including the initialized range
+                // at old_offset. The new base is aligned, has enough capacity, and copy permits
+                // overlap when moving the slice to the base.
                 unsafe {
                     std::ptr::copy(
                         self.allocation.ptr().as_ptr().add(old_offset),
-                        self.allocation.ptr().as_ptr().add(new_offset),
+                        self.allocation.ptr().as_ptr(),
                         self.length * size_of::<T>(),
                     );
                 }
             }
-            new_offset
-        };
-        // SAFETY: new_offset was computed within the allocation for alignment.
-        self.ptr = unsafe { self.allocation.ptr().add(new_offset).cast() };
+        }
+        self.ptr = self.allocation.ptr().cast();
         self.capacity = logical_size / size_of::<T>();
     }
 
@@ -557,9 +528,7 @@ impl<T> BufferMut<T> {
     /// reading from a file) before marking the data as initialized using the
     /// [`set_len`] method.
     ///
-    /// Note that the returned slice may be larger than the capacity requested at
-    /// construction, since the underlying allocation can be rounded up (e.g. to
-    /// satisfy alignment requirements).
+    /// Growth and ownership transfers can provide more capacity than originally requested.
     ///
     /// [`set_len`]: BufferMut::set_len
     /// [`Vec::spare_capacity_mut`]: Vec::spare_capacity_mut
@@ -994,7 +963,7 @@ impl<T> FromIterator<T> for BufferMut<T> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::Alignment;
     use crate::BufferMut;
     use crate::buffer_mut;

--- a/vortex-buffer/tests/allocation.rs
+++ b/vortex-buffer/tests/allocation.rs
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Check the allocator boundary through public buffer operations.
+//!
+//! The allocator records requested layouts, checks ownership, and always moves on growth. Its
+//! backing alignment is stronger than requested so metadata-only alignment changes are repeatable.
+
+#![cfg(test)]
+#![allow(clippy::expect_used)]
+#![allow(
+    clippy::disallowed_types,
+    reason = "the test recorder does not need parking_lot"
+)]
+
+use std::alloc::Layout;
+use std::ptr::NonNull;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use allocator_api2::alloc::AllocError;
+use allocator_api2::alloc::Allocator;
+use allocator_api2::alloc::Global;
+use rstest::rstest;
+use vortex_buffer::Alignment;
+use vortex_buffer::BufferAllocatorRef;
+use vortex_buffer::BufferMut;
+
+#[derive(Clone, Debug, Default)]
+struct TrackingAllocator {
+    state: Arc<Mutex<TrackingState>>,
+}
+
+#[derive(Debug, Default)]
+struct TrackingState {
+    requests: Vec<Request>,
+    live: Vec<(usize, Layout, Layout)>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Request {
+    Allocate { layout: Layout, zeroed: bool },
+    Grow { old: Layout, new: Layout },
+    Deallocate(Layout),
+}
+
+impl TrackingAllocator {
+    fn as_ref(&self) -> BufferAllocatorRef {
+        BufferAllocatorRef::new(self.clone())
+    }
+
+    fn allocate_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
+        let backing = Layout::from_size_align(layout.size(), layout.align().max(4096))
+            .map_err(|_| AllocError)?;
+        let allocation = if zeroed {
+            Global.allocate_zeroed(backing)?
+        } else {
+            Global.allocate(backing)?
+        };
+        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        state.requests.push(Request::Allocate { layout, zeroed });
+        state
+            .live
+            .push((allocation.cast::<u8>().addr().get(), layout, backing));
+
+        Ok(allocation)
+    }
+
+    fn requests(&self) -> Vec<Request> {
+        self.state
+            .lock()
+            .expect("tracking state is not poisoned")
+            .requests
+            .clone()
+    }
+
+    #[track_caller]
+    fn assert_all_freed(&self) {
+        assert!(
+            self.state
+                .lock()
+                .expect("tracking state is not poisoned")
+                .live
+                .is_empty()
+        );
+    }
+}
+
+// SAFETY: The shared state keeps each requested layout paired with its Global backing layout.
+// Growth allocates before freeing, and every free checks the pointer and the original layout.
+unsafe impl Allocator for TrackingAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        self.allocate_impl(layout, false)
+    }
+
+    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        self.allocate_impl(layout, true)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        let mut state = self.state.lock().expect("tracking state is not poisoned");
+        let index = state
+            .live
+            .iter()
+            .position(|(address, ..)| *address == ptr.addr().get())
+            .expect("the buffer must free a live allocation base");
+        let (_, requested, backing) = state.live.remove(index);
+        assert_eq!(layout, requested);
+        state.requests.push(Request::Deallocate(layout));
+
+        // SAFETY: The live entry identifies the original pointer and Global layout.
+        unsafe { Global.deallocate(ptr, backing) }
+    }
+
+    unsafe fn grow(
+        &self,
+        ptr: NonNull<u8>,
+        old: Layout,
+        new: Layout,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        {
+            let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+            assert!(state.live.iter().any(|(address, requested, _)| {
+                *address == ptr.addr().get() && *requested == old
+            }));
+            assert!(new.size() >= old.size());
+            state.requests.push(Request::Grow { old, new });
+        }
+        let allocation = self.allocate(new)?;
+
+        // SAFETY: The checked old layout fits the live block. The new block is large enough and
+        // cannot overlap it because allocation precedes deallocation.
+        unsafe {
+            std::ptr::copy_nonoverlapping(ptr.as_ptr(), allocation.cast().as_ptr(), old.size());
+            self.deallocate(ptr, old);
+        }
+
+        Ok(allocation)
+    }
+}
+
+#[test]
+fn allocator_identity() {
+    let static_allocator = BufferAllocatorRef::statically_allocated();
+    assert!(static_allocator.ptr_eq(&BufferAllocatorRef::statically_allocated()));
+
+    let custom_allocator = TrackingAllocator::default().as_ref();
+    assert!(custom_allocator.ptr_eq(&custom_allocator.clone()));
+    assert!(!custom_allocator.ptr_eq(&static_allocator));
+    assert!(!custom_allocator.ptr_eq(&TrackingAllocator::default().as_ref()));
+}
+
+#[rstest]
+#[case::page(4096, None, 4096)]
+#[case::preferred_page(4, Some(4096), 4096)]
+#[case::requested_wins(4096, Some(256), 4096)]
+#[case::default(4, Some(256), 256)]
+#[case::natural(4, None, 4)]
+fn requested_layout_reaches_allocator(
+    #[case] requested: usize,
+    #[case] preferred: Option<usize>,
+    #[case] effective: usize,
+    #[values(false, true)] zeroed: bool,
+) {
+    let allocator = TrackingAllocator::default();
+    let alignment = Alignment::new(requested);
+    let preferred = preferred.map(Alignment::new);
+    let buffer = if zeroed {
+        BufferMut::<u32>::zeroed_preferred_aligned_in(
+            1024,
+            alignment,
+            preferred,
+            allocator.as_ref(),
+        )
+    } else {
+        BufferMut::<u32>::with_capacity_preferred_aligned_in(
+            1024,
+            alignment,
+            preferred,
+            allocator.as_ref(),
+        )
+    };
+    let layout = Layout::from_size_align(4096, effective).expect("valid test layout");
+
+    assert_eq!(allocator.requests(), [Request::Allocate { layout, zeroed }]);
+    assert_eq!(buffer.alignment(), alignment);
+    assert!(Alignment::new(effective).is_ptr_aligned(buffer.as_ptr()));
+    assert!(buffer.capacity() >= 1024);
+    if zeroed {
+        assert_eq!(buffer.as_slice(), [0; 1024]);
+    } else {
+        assert!(buffer.is_empty());
+    }
+
+    drop(buffer);
+    assert_eq!(
+        allocator.requests().last(),
+        Some(&Request::Deallocate(layout))
+    );
+    allocator.assert_all_freed();
+}
+
+#[test]
+fn allocation_lives_until_last_view() {
+    let allocator = TrackingAllocator::default();
+    let buffer = allocator.as_ref().copy_from([1u32, 2, 3, 4]).freeze();
+    let view = buffer.slice(1..3).into_byte_buffer().into_bytes();
+    drop(buffer);
+
+    assert_eq!(allocator.requests().len(), 1);
+    assert_eq!(view.len(), 8);
+    drop(view);
+    allocator.assert_all_freed();
+}
+
+#[rstest]
+fn growth_moves_initialized_and_spare_contents(#[values(4, 64, 4096)] alignment: usize) {
+    let allocator = TrackingAllocator::default();
+    let alignment = Alignment::new(alignment);
+    let mut buffer = allocator
+        .as_ref()
+        .with_capacity_aligned::<u32>(17, alignment);
+    let capacity = buffer.capacity();
+    buffer.push(7);
+    buffer
+        .spare_capacity_mut()
+        .fill(std::mem::MaybeUninit::new(11));
+    // SAFETY: The first element and every element of the spare capacity are initialized.
+    unsafe { buffer.set_len(capacity) };
+    let expected = buffer.as_slice().to_vec();
+    let old_ptr = buffer.as_ptr();
+
+    buffer.push(u32::MAX);
+
+    assert_ne!(buffer.as_ptr(), old_ptr);
+    assert_eq!(&buffer[..capacity], expected);
+    assert_eq!(buffer[capacity], u32::MAX);
+    assert!(Alignment::DEFAULT_ALIGNMENT.is_ptr_aligned(buffer.as_ptr()));
+    assert!(alignment.is_ptr_aligned(buffer.as_ptr()));
+    assert!(matches!(allocator.requests()[1], Request::Grow { .. }));
+    drop(buffer);
+    allocator.assert_all_freed();
+}
+
+#[rstest]
+#[case::large_tail(32, true)]
+#[case::small_tail(1000, false)]
+fn sliced_growth_preserves_contents(#[case] begin: usize, #[case] grows: bool) {
+    let allocator = TrackingAllocator::default();
+    let mut original = allocator.as_ref().with_capacity::<u32>(1024);
+    original.extend(0..1024);
+    let original = original.freeze();
+    let sliced = original.slice(begin..begin + 8);
+    drop(original);
+    let mut sliced = sliced.try_into_mut().expect("the slice is uniquely owned");
+    let capacity = sliced.capacity();
+    sliced.push_n(777, capacity - sliced.len());
+    let expected = sliced.as_slice().to_vec();
+
+    sliced.push(u32::MAX);
+
+    assert_eq!(&sliced[..capacity], expected);
+    assert_eq!(sliced[capacity], u32::MAX);
+    assert!(Alignment::DEFAULT_ALIGNMENT.is_ptr_aligned(sliced.as_ptr()));
+    assert_eq!(
+        allocator
+            .requests()
+            .iter()
+            .any(|request| matches!(request, Request::Grow { .. })),
+        grows
+    );
+    drop(sliced.freeze());
+    allocator.assert_all_freed();
+}
+
+#[test]
+fn realigning_a_slice_copies_with_its_allocator() {
+    let allocator = TrackingAllocator::default();
+    let original = allocator.as_ref().copy_from([1u32, 2, 3, 4]).freeze();
+    let sliced = original.slice(1..3);
+    drop(original);
+    let buffer = sliced.try_into_mut().expect("the slice is uniquely owned");
+    let capacity = buffer.capacity();
+    let alignment = Alignment::new(4096);
+    assert!(!alignment.is_ptr_aligned(buffer.as_ptr()));
+
+    let mut buffer = buffer.aligned(alignment);
+
+    assert!(alignment.is_ptr_aligned(buffer.as_ptr()));
+    assert_eq!(buffer.capacity(), capacity);
+    buffer.push(7);
+    buffer.reserve(buffer.capacity());
+    assert_eq!(buffer.as_slice(), [2, 3, 7]);
+    drop(buffer);
+    allocator.assert_all_freed();
+}
+
+#[rstest]
+#[case::raise(4, 4096)]
+#[case::lower(4096, 4)]
+fn changing_alignment_uses_original_layout_for_growth(
+    #[case] original_alignment: usize,
+    #[case] new_alignment: usize,
+) {
+    let allocator = TrackingAllocator::default();
+    let mut buffer = BufferMut::<u32>::with_capacity_preferred_aligned_in(
+        4,
+        Alignment::new(original_alignment),
+        None,
+        allocator.as_ref(),
+    );
+    buffer.extend([1, 2, 3, 4]);
+    let ptr = buffer.as_ptr();
+    let mut buffer = buffer.aligned(Alignment::new(new_alignment));
+    assert_eq!(buffer.as_ptr(), ptr);
+
+    buffer.reserve(buffer.capacity());
+
+    assert_eq!(buffer.as_slice(), [1, 2, 3, 4]);
+    assert_eq!(buffer.alignment(), Alignment::new(new_alignment));
+    assert!(Alignment::new(4096).is_ptr_aligned(buffer.as_ptr()));
+    let Request::Grow { old, new } = allocator.requests()[1] else {
+        panic!("the allocator must grow the original block");
+    };
+    assert_eq!(old.align(), original_alignment);
+    assert_eq!(new.align(), 4096);
+    drop(buffer);
+    allocator.assert_all_freed();
+}
+
+#[rstest]
+fn zero_capacity_does_not_allocate(#[values(false, true)] zeroed: bool) {
+    let allocator = TrackingAllocator::default();
+    let alignment = Alignment::new(4096);
+    let mut buffer = if zeroed {
+        BufferMut::<u32>::zeroed_aligned_in(0, alignment, allocator.as_ref())
+    } else {
+        BufferMut::<u32>::with_capacity_aligned_in(0, alignment, allocator.as_ref())
+    };
+    assert_eq!(buffer.capacity(), 0);
+    assert!(alignment.is_ptr_aligned(buffer.as_ptr()));
+    assert!(allocator.requests().is_empty());
+
+    buffer.push(42);
+
+    assert_eq!(buffer.as_slice(), [42]);
+    assert!(alignment.is_ptr_aligned(buffer.as_ptr()));
+    assert_eq!(allocator.requests().len(), 1);
+    drop(buffer);
+    allocator.assert_all_freed();
+}
+
+#[test]
+fn empty_buffers_preserve_allocator_without_allocating() {
+    let allocator = TrackingAllocator::default();
+    let handle = allocator.as_ref();
+    let buffer = BufferMut::<u32>::zeroed_in(0, handle.clone()).freeze();
+    let copy = buffer.clone().into_mut();
+    assert!(copy.allocator().ptr_eq(&handle));
+    let mut buffer = buffer.try_into_mut().expect("the buffer is uniquely owned");
+
+    buffer.reserve(0);
+
+    assert!(buffer.is_empty());
+    assert!(buffer.allocator().ptr_eq(&handle));
+    drop((copy, buffer));
+    assert!(allocator.requests().is_empty());
+}
+
+#[test]
+fn shared_into_mut_preserves_allocator() {
+    let allocator = TrackingAllocator::default();
+    let handle = allocator.as_ref();
+    let original = handle.copy_from([1u32, 2, 3]).freeze();
+    let mut copy = original.clone().into_mut();
+    assert!(copy.allocator().ptr_eq(&handle));
+
+    copy[0] = 42;
+
+    assert_eq!(original.as_slice(), [1, 2, 3]);
+    assert_eq!(copy.as_slice(), [42, 2, 3]);
+    assert_eq!(allocator.requests().len(), 2);
+    drop(copy);
+    assert!(matches!(allocator.requests()[2], Request::Deallocate(_)));
+    drop(original);
+    assert!(matches!(allocator.requests()[3], Request::Deallocate(_)));
+    allocator.assert_all_freed();
+}
+
+#[test]
+fn empty_max_alignment() {
+    let buffer = BufferMut::<u8>::zeroed_aligned(0, Alignment::MAX);
+    assert!(Alignment::MAX.is_ptr_aligned(buffer.as_ptr()));
+    assert_eq!(buffer.capacity(), 0);
+    drop(buffer.freeze().into_mut());
+}
+
+#[test]
+#[should_panic(expected = "must align to the scalar type")]
+fn zeroed_rejects_alignment_below_element_alignment() {
+    drop(BufferMut::<u64>::zeroed_preferred_aligned(
+        1,
+        Alignment::none(),
+        None,
+    ));
+}


### PR DESCRIPTION
## Summary

Removes unconditional padding from `BufferMut` allocation requests while preserving requested versus preferred alignment. Local macOS measurements show System allocation/drop and growth regressions, while mimalloc results are mixed. Linux testing will follow.

## Changes

Keeps the allocation base and backing layout separate from the data pointer and usable capacity, so slicing and logical alignment changes preserve the layout used for growth and deallocation. Extends the allocator tests with recorded layouts and forced moving growth, covering zeroed allocation, initialized spare capacity, sliced ownership, realignment, and empty buffers.

<details>
<summary>Correctness and validation</summary>

- A 4096-byte request with effective alignment 4096 reaches the backend as `Layout { size: 4096, align: 4096 }`, including zeroed allocation.
- Constructors use the aligned allocation base. Acquired storage can still have an offset, and its usable capacity excludes the allocation prefix. Geometric growth and ownership transfers can provide more capacity than originally requested.
- Growth preserves the stronger of the backing and logical alignments. Custom allocator growth uses the saved old layout and the newly returned pointer, then moves the initialized slice to the aligned base if needed. A short slice gets a fresh allocation when its new usable capacity would require a backing layout smaller than the old one, since `Allocator::grow` cannot shrink.
- Freezing retains the backing allocation and offset. Deallocation uses the saved allocation base and layout. The allocator contract was checked against the installed `allocator-api2` 0.2.21 sources.
- Preserves the compile-time ZST rejection added in #9807. Existing compile-fail doctests cover it.

After rebasing onto `402fd1dfbd5c876ac7a4d24da3048bd69ac830d6`, 892 crate tests and 14 doctests pass. The 26 allocator integration cases include the 10 layout-routing cases that failed before the original fix. Crate and workspace Clippy pass with all targets and features.

```sh
cargo nextest run -p vortex-buffer --all-features
cargo test --doc -p vortex-buffer --all-features
cargo +nightly fmt --all
rustfmt +nightly --edition 2024 --check vortex-buffer/src/allocation.rs vortex-buffer/src/buffer_mut.rs vortex-buffer/tests/allocation.rs
cargo clippy -p vortex-buffer --all-targets --all-features
cargo clippy --all-targets --all-features -- -D warnings
git diff --check
```

The changed files pass formatting. The workspace formatting command also ran, but its edits to four unrelated FFI/DuckDB files were discarded. The local commit hook still flags those existing formatting differences and was bypassed for this commit.

</details>

<details>
<summary>Existing macOS benchmark results and methodology</summary>

Measured baseline: `5c8c397e2297c41b81ca4aa77b0ca02c5d73728b`. Measured candidate: the pre-rebase implementation, captured in local commit `5fa15ee368c56d43ed7556e9a5d23e0a37385cde` and the retained candidate patch. These measurements isolate this change at the original base. They were not rerun after rebasing onto the upstream ZST and ownership changes, so they do not measure the final rebased commit.

Both versions ran on the same Apple M4 Max with macOS 15.7.3, using Rust 1.98.0, LLVM 22.1.8, `aarch64-apple-darwin`, optimization level 3, 16 codegen units, no LTO, full debug information, and `RUSTFLAGS='-C force-frame-pointers=yes'`. The standalone harness used identical locked dependencies and explicitly registered either `std::alloc::System` or `mimalloc::MiMalloc` as the global allocator. The default buffer allocator forwards through `Global`, so the named backend is selected by the benchmark binary. Mimalloc used wrapper 0.1.52, `libmimalloc-sys` 0.1.49, and native mimalloc 3.3.2.

The matrix covered 64, 4096, and 65536 bytes at effective alignments 256 and 4096, with immediate reuse or batches of 64 live buffers. Alignment 256 used requested alignment 1 and preferred alignment 256, matching normal `u8` construction. Each operation includes drop:

- `allocate`: construct capacity N.
- `zeroed`: construct N zeroed bytes.
- `grow`: construct capacity N, initialize N bytes, then reserve an additional `4 * max(N, 4096)` bytes.
- `append`: construct capacity N, then append the same N-byte input eight times.

Inputs and the batch container were allocated outside timing. Runtime sizes, mutable buffer references, and initialized growth contents passed through `black_box`. Each case used adaptive warmup, then 11 samples of approximately 20 ms or longer, with three process runs alternating implementation order. Timings below are the median of the three process medians, in ns per complete buffer operation. No builds or correctness checks ran concurrently with these measurements.

Requested-byte totals and usable capacities came from separate instrumented runs. Totals sum requests over one buffer lifetime, not peak memory or RSS. Old capacity depends on the allocation address, so the recorded capacities can differ from the timing processes. Small percentage changes do not establish statistical significance.

**4096 bytes, requested alignment 4096**

| Backend | Work | Live | Old ns | New ns | Change | Total requested bytes, old to new | Usable bytes, old to new |
|---|---|---:|---:|---:|---:|---:|---:|
| system | allocate | 1 | 14.85 | 52.35 | +252.5% | 8192 to 4096 | 7168 to 4096 |
| system | allocate | 64 | 34.33 | 62.10 | +80.9% | 8192 to 4096 | 7680 to 4096 |
| system | zeroed | 1 | 88.67 | 84.64 | -4.6% | 8192 to 4096 | 7168 to 4096 |
| system | zeroed | 64 | 146.20 | 113.74 | -22.2% | 8192 to 4096 | 7680 to 4096 |
| system | grow | 1 | 129.79 | 200.27 | +54.3% | 32768 to 24576 | 20480 to 20480 |
| system | grow | 64 | 159.31 | 208.66 | +31.0% | 32768 to 24576 | 20480 to 20480 |
| system | append | 1 | 839.23 | 902.00 | +7.5% | 120832 to 61440 | 57344 to 32768 |
| system | append | 64 | 1512.69 | 1601.63 | +5.9% | 128000 to 61440 | 61440 to 32768 |
| mimalloc | allocate | 1 | 14.52 | 11.64 | -19.9% | 8192 to 4096 | 8192 to 4096 |
| mimalloc | allocate | 64 | 49.69 | 35.24 | -29.1% | 8192 to 4096 | 8192 to 4096 |
| mimalloc | zeroed | 1 | 85.52 | 47.74 | -44.2% | 8192 to 4096 | 8192 to 4096 |
| mimalloc | zeroed | 64 | 146.80 | 88.80 | -39.5% | 8192 to 4096 | 8192 to 4096 |
| mimalloc | grow | 1 | 117.85 | 111.85 | -5.1% | 32768 to 24576 | 20480 to 20480 |
| mimalloc | grow | 64 | 167.02 | 151.49 | -9.3% | 32768 to 24576 | 20480 to 20480 |
| mimalloc | append | 1 | 670.18 | 690.82 | +3.1% | 65536 to 61440 | 32768 to 32768 |
| mimalloc | append | 64 | 674.05 | 704.59 | +4.5% | 65536 to 61440 | 32768 to 32768 |

Initial allocation and zeroed requests change from `(8192, align 1)` to `(4096, align 4096)`. Forced growth ends with 20480 usable bytes in both versions, while the final backing request falls from 24576 to 20480 bytes.

**4096 bytes, normal preferred alignment 256**

| Backend | Work | Live | Old ns | New ns | Change | Total requested bytes, old to new | Usable bytes, old to new |
|---|---|---:|---:|---:|---:|---:|---:|
| system | allocate | 1 | 14.78 | 18.88 | +27.7% | 4352 to 4096 | 4352 to 4096 |
| system | allocate | 64 | 33.98 | 38.13 | +12.2% | 4352 to 4096 | 4352 to 4096 |
| system | zeroed | 1 | 52.33 | 48.98 | -6.4% | 4352 to 4096 | 4352 to 4096 |
| system | zeroed | 64 | 96.94 | 89.37 | -7.8% | 4352 to 4096 | 4352 to 4096 |
| system | grow | 1 | 127.07 | 128.02 | +0.7% | 24833 to 24576 | 20480 to 20480 |
| system | grow | 64 | 159.88 | 163.39 | +2.2% | 24833 to 24576 | 20480 to 20480 |
| system | append | 1 | 826.05 | 903.72 | +9.4% | 65283 to 61440 | 34816 to 32768 |
| system | append | 64 | 1538.15 | 792.17 | -48.5% | 65283 to 61440 | 34816 to 32768 |
| mimalloc | allocate | 1 | 14.55 | 11.27 | -22.5% | 4352 to 4096 | 4352 to 4096 |
| mimalloc | allocate | 64 | 39.99 | 35.26 | -11.8% | 4352 to 4096 | 4352 to 4096 |
| mimalloc | zeroed | 1 | 63.44 | 44.31 | -30.2% | 4352 to 4096 | 4352 to 4096 |
| mimalloc | zeroed | 64 | 106.45 | 86.63 | -18.6% | 4352 to 4096 | 4352 to 4096 |
| mimalloc | grow | 1 | 118.13 | 113.42 | -4.0% | 24833 to 24576 | 20480 to 20480 |
| mimalloc | grow | 64 | 159.79 | 160.77 | +0.6% | 24833 to 24576 | 20480 to 20480 |
| mimalloc | append | 1 | 730.71 | 750.80 | +2.7% | 65283 to 61440 | 34816 to 32768 |
| mimalloc | append | 64 | 729.68 | 720.97 | -1.2% | 65283 to 61440 | 34816 to 32768 |

Initial allocation and zeroed requests change from `(4352, align 1)` to `(4096, align 256)`. Growth retains the preferred backing alignment while continuing to report requested alignment 1.

**Other regressions and context sensitivity**

System immediate allocation/drop for 64 bytes at preferred alignment 256 increases from 27.60 to 70.15 ns, while the request falls from 320 to 64 bytes and recorded usable capacity falls from 160 to 64 bytes. Mimalloc increases from 8.36 to 10.56 ns for the same case, with recorded old capacity ranging from 128 to 320 bytes.

Mimalloc appending eight 64-byte chunks at alignment 4096 increases from 27.51 to 55.60 ns. The old implementation uses one 4160-byte request with 4160 usable bytes. The new implementation uses three requests totaling 832 bytes and ends at capacity 512. Losing incidental padding capacity can require more growth operations even when total requested bytes fall.

The 65536-byte, 4096-aligned System allocation/drop case is sensitive to benchmark context:

| Context | Live buffers | Old ns | New ns |
| --- | ---: | ---: | ---: |
| Full matrix | 1 | 16.99 | 13473.50 |
| Full matrix | 64 | 572.40 | 379.25 |
| Fresh process, only this workload | 1 | 16.57 | 53.72 |
| Fresh process, only this workload | 64 | 80.73 | 134.51 |

The request falls from 69632 to 65536 bytes, with the same recorded usable capacities. Immediate reuse regresses in both contexts, while the full-matrix batch improves. The large difference suggests allocator history matters, but its internal cause was not established. The checked Rust System implementation routes these aligned requests through `posix_memalign`.

A separate macOS System adapter experiment recovers much of the allocation/drop cost by retaining padding inside that specific allocator. For 4096 bytes at alignment 4096, it measures 17.68 ns versus 52.35 ns for the new native System path, but requests 8192 raw bytes while exposing only 4096 usable bytes. It also worsens zeroed batches from 113.74 to 151.49 ns and normal-preferred-alignment append batches from 792.17 to 1809.26 ns. The adapter is not included in this PR, and the System regressions remain.

These measurements do not establish Linux behavior, application throughput, or resident-memory savings. The harness, raw CSVs, and reproduction bundle are retained locally rather than attached to this PR.

</details>
